### PR TITLE
sso 이메일 동일할 경우 존재하는 유저와 자동 병합

### DIFF
--- a/apps/api/src/graphql/resolvers/auth.ts
+++ b/apps/api/src/graphql/resolvers/auth.ts
@@ -193,7 +193,17 @@ builder.mutationFields((t) => ({
         .then(first);
 
       if (existingUser) {
-        throw new GlitterError({ code: 'user_email_exists' });
+        await db.insert(UserSingleSignOns).values({
+          userId: existingUser.id,
+          provider: externalUser.provider,
+          principal: externalUser.principal,
+          email: externalUser.email,
+        });
+
+        return {
+          user: existingUser.id,
+          accessToken: await createSessionAndReturnAccessToken(existingUser.id),
+        };
       }
 
       const user = await db.transaction(async (tx) => {


### PR DESCRIPTION
새로 시도된 sso 계정의 이메일이 기존 users에 존재할 경우 같은 인물로 취급하고 자동으로 링크 및 로그인함