### PR TITLE
인용구/콜아웃 노드 텍스트 정렬 버그 수정

### DIFF
--- a/apps/website/src/lib/tiptap/node-views/blockquote/Component.svelte
+++ b/apps/website/src/lib/tiptap/node-views/blockquote/Component.svelte
@@ -16,5 +16,5 @@
 <NodeView style={flex.raw({ gap: '16px' })}>
   <Component />
 
-  <NodeViewContentEditable style={css.raw({ flexGrow: '1' })} />
+  <NodeViewContentEditable style={css.raw({ flexGrow: '1', '& > *': { textAlign: '[left!]', textIndent: '0!' } })} />
 </NodeView>

--- a/apps/website/src/lib/tiptap/node-views/callout/Component.svelte
+++ b/apps/website/src/lib/tiptap/node-views/callout/Component.svelte
@@ -70,8 +70,6 @@
       <Icon {icon} size={20} />
     </svelte:element>
 
-    <div class={css({ flexGrow: 1, paddingTop: '2px' })}>
-      <NodeViewContentEditable />
-    </div>
+    <NodeViewContentEditable style={css.raw({ flexGrow: '1', paddingTop: '2px', '& > *': { textAlign: '[left!]', textIndent: '0!' } })} />
   </div>
 </NodeView>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **스타일**
  - 콘텐츠 편집 영역의 자식 요소에 대해 왼쪽 정렬 및 들여쓰기 속성이 명확하게 적용되었습니다.
  - 불필요한 구조 요소를 제거하여 컴포넌트의 구조를 단순화하였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->