### PR TITLE
mailchimp 도메인 설정

### DIFF
--- a/apps/infrastructure/pulumi/aws/route53.ts
+++ b/apps/infrastructure/pulumi/aws/route53.ts
@@ -21,7 +21,6 @@ new aws.route53.Record('typie.co|txt', {
   records: [
     'google-site-verification=Q-1ETLmF6p7XkzQM0wpDyF0wCBQREsjK1aZdxR-4ggQ',
     'google-site-verification=hZdtWP44my1tA-wUAvYlOKAAPSp2vHT6M5omQXCRt6o',
-    'v=spf1 include:mail.stibee.com ~all',
   ],
   ttl: 300,
 });
@@ -43,10 +42,20 @@ new aws.route53.Record('help.typie.co', {
   ttl: 300,
 });
 
-new aws.route53.Record('stb._domainkey.typie.co', {
+new aws.route53.Record('k2._domainkey.typie.co', {
   zoneId: zones.typie_co.zoneId,
   type: 'CNAME',
-  name: 'stb._domainkey.typie.co',
-  records: ['dkim.stibee.com'],
+  name: 'k2._domainkey.typie.co',
+  // spell-checker:disable-next-line
+  records: ['dkim2.mcsv.net'],
+  ttl: 300,
+});
+
+new aws.route53.Record('k3._domainkey.typie.co', {
+  zoneId: zones.typie_co.zoneId,
+  type: 'CNAME',
+  name: 'k3._domainkey.typie.co',
+  // spell-checker:disable-next-line
+  records: ['dkim3.mcsv.net'],
   ttl: 300,
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - DNS 레코드 구성이 업데이트되었습니다.
    - SPF 관련 TXT 레코드가 제거되었습니다.
    - 기존 도메인 키 레코드가 새로운 항목으로 갱신되었으며, 새 도메인 키 레코드가 추가되어 유효 시간(TTL)이 300초로 설정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->