### PR TITLE
maxDepth 체크 로직 개선

### DIFF
--- a/apps/website/src/routes/website/(dashboard)/@tree/EntityTree.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@tree/EntityTree.svelte
@@ -181,23 +181,24 @@
     }
 
     if (parentElement) {
-      const parentDepth = Number(parentElement.dataset.depth ?? 0);
-      const draggingDepth = Number(dragging.element.dataset.depth ?? 0);
-      const draggingMaxDepth = Math.max(
-        draggingDepth,
-        ...[...dragging.element.querySelectorAll<HTMLElement>('[data-id]')].map((element) => Number(element.dataset.depth ?? 0)),
-      );
-
-      const depthDelta =
-        draggingMaxDepth - draggingDepth + (dragging.element.dataset.type === 'folder' ? 1 : 0) + (parentDepth === 0 ? 0 : 1);
-
-      if (parentDepth + depthDelta > maxDepth) {
-        dragging.indicator = {};
-        dragging.drop = undefined;
-        return;
-      }
-
       dragging.drop.parentId = parentElement.dataset.id;
+
+      if (dragging.element.dataset.type === 'folder') {
+        const newPathDepth = Number(parentElement.dataset.pathDepth ?? 0) + 1;
+        const folderDepth = 1;
+        const draggingDepth = Math.max(
+          folderDepth,
+          ...[...dragging.element.querySelectorAll<HTMLElement>('[data-type="folder"]')].map(
+            (element) => Number(element.dataset.pathDepth ?? 0) - Number(dragging?.element.dataset.pathDepth ?? 0) + folderDepth,
+          ),
+        );
+
+        if (newPathDepth + draggingDepth > maxDepth) {
+          dragging.indicator = {};
+          dragging.drop = undefined;
+          return;
+        }
+      }
     }
   };
 

--- a/apps/website/src/routes/website/(dashboard)/@tree/Folder.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@tree/Folder.svelte
@@ -134,7 +134,7 @@
   });
 </script>
 
-<details data-depth={$folder.entity.depth} data-id={$folder.entity.id} data-order={$folder.entity.order} data-type="folder" bind:open>
+<details data-id={$folder.entity.id} data-order={$folder.entity.order} data-path-depth={$folder.entity.depth} data-type="folder" bind:open>
   <summary
     class={cx(
       'group',

--- a/apps/website/src/routes/website/(dashboard)/@tree/Post.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@tree/Post.svelte
@@ -101,9 +101,9 @@
     ),
   )}
   aria-selected="false"
-  data-depth={$post.entity.depth}
   data-id={$post.entity.id}
   data-order={$post.entity.order}
+  data-path-depth={$post.entity.depth}
   data-type="post"
   draggable="false"
   href="/{$post.entity.slug}"


### PR DESCRIPTION
**path-depth, depth 구분**

기존에는 depth라는 명칭을

- 루트에서부터 깊이가 어떻게 되는지
- dragging하는 요소 안의 깊이가 어떻게 되는지

를 혼동해서 쓰고 있었음
따라서 루트에서부터의 깊이를 path-depth라는 이름으로 변경, depth는 상대적인 깊이를 나타내도록 함

**max depth 체크 로직 변경**

- max depth 체크 로직은 dragging type이 folder일 때만 체크하면 되기 때문에, parentId 지정하는 로직을 앞으로 빼고, max depth 체크 로직은 그 아래에서 진행하도록 수정
- newPathDepth(드롭하게 될 경우 dragging이 가지게 될 path-depth)
- folderDepth: 기본적인 폴더의 depth
- draggingDepth: 폴더 내의 하위 폴더들(`[data-type="folder"]`)을 돌면서 `하위 폴더의 pathDepth - dragging 요소의 pathDepth`를 계산해 dragging 요소 하위에 폴더가 얼마나 있는지 체크한 후, folderDepth를 더해줌