### PR TITLE
앱에 작성 노트 추가

### DIFF
--- a/apps/mobile/lib/screens/editor/editor.dart
+++ b/apps/mobile/lib/screens/editor/editor.dart
@@ -56,6 +56,7 @@ class Editor extends HookWidget {
 
     final scope = EditorStateScope.of(context);
     final webViewController = useValueListenable(scope.webViewController);
+    useAutomaticKeepAlive();
 
     useEffect(() {
       final subscription = keyboard.onHeightChange.listen((height) {

--- a/apps/mobile/lib/screens/editor/schema.dart
+++ b/apps/mobile/lib/screens/editor/schema.dart
@@ -149,7 +149,7 @@ abstract class CharacterCountState with _$CharacterCountState {
 
 @freezed
 abstract class YJSState with _$YJSState {
-  const factory YJSState({required int maxWidth}) = _YJSState;
+  const factory YJSState({required int maxWidth, required String note}) = _YJSState;
 
   factory YJSState.fromJson(Map<String, dynamic> json) => _$YJSStateFromJson(json);
 }

--- a/apps/mobile/lib/screens/editor/screen.dart
+++ b/apps/mobile/lib/screens/editor/screen.dart
@@ -1,11 +1,19 @@
+import 'dart:async';
+
+import 'package:assorted_layout_widgets/assorted_layout_widgets.dart';
 import 'package:auto_route/auto_route.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:typie/icons/lucide_light.dart';
 import 'package:typie/screens/editor/__generated__/editor_query.data.gql.dart';
 import 'package:typie/screens/editor/editor.dart';
 import 'package:typie/screens/editor/schema.dart';
 import 'package:typie/screens/editor/scope.dart';
 import 'package:typie/services/keyboard.dart';
+import 'package:typie/styles/colors.dart';
+import 'package:typie/widgets/heading.dart';
+import 'package:typie/widgets/screen.dart';
 import 'package:typie/widgets/webview.dart';
 
 @RoutePage()
@@ -27,6 +35,9 @@ class EditorScreen extends HookWidget {
     final bottomToolbarMode = useValueNotifier<BottomToolbarMode>(BottomToolbarMode.hidden);
     final secondaryToolbarMode = useValueNotifier<SecondaryToolbarMode>(SecondaryToolbarMode.hidden);
 
+    final textEditingController = useTextEditingController();
+    final pageController = usePageController();
+
     return EditorStateScope(
       data: data,
       webViewController: webViewController,
@@ -38,7 +49,110 @@ class EditorScreen extends HookWidget {
       keyboardType: keyboardType,
       bottomToolbarMode: bottomToolbarMode,
       secondaryToolbarMode: secondaryToolbarMode,
-      child: Editor(slug: slug),
+      child: Stack(
+        children: [
+          PageView(
+            controller: pageController,
+            physics: const NeverScrollableScrollPhysics(),
+            onPageChanged: (value) {
+              if (value == 1) {
+                if (yjsState.value?.note != null && textEditingController.text.isEmpty) {
+                  textEditingController.text = yjsState.value!.note;
+                }
+              }
+            },
+            children: [
+              Editor(slug: slug),
+              _PanelNote(controller: textEditingController),
+            ],
+          ),
+          Positioned(
+            top: 0,
+            left: 0,
+            right: 0,
+            height: kToolbarHeight + 52 + 16, // toolbar + heading + padding
+            child: RawGestureDetector(
+              gestures: {
+                HorizontalDragGestureRecognizer: GestureRecognizerFactoryWithHandlers<HorizontalDragGestureRecognizer>(
+                  HorizontalDragGestureRecognizer.new,
+                  (instance) {
+                    Offset? dragStart;
+
+                    instance
+                      ..onStart = (details) {
+                        dragStart = details.globalPosition;
+                      }
+                      ..onUpdate = (details) {
+                        if (dragStart == null) {
+                          return;
+                        }
+
+                        final delta = details.globalPosition.dx - dragStart!.dx;
+                        unawaited(pageController.position.moveTo(pageController.position.pixels - delta));
+
+                        dragStart = details.globalPosition;
+                      }
+                      ..onEnd = (details) {
+                        final velocity = details.velocity.pixelsPerSecond.dx;
+
+                        final page = pageController.page!;
+                        final nextPage = velocity < 0 ? page.ceil() : page.floor();
+
+                        unawaited(
+                          pageController.animateToPage(
+                            nextPage.clamp(0, 1),
+                            duration: const Duration(milliseconds: 300),
+                            curve: Curves.easeOut,
+                          ),
+                        );
+                      };
+                  },
+                ),
+              },
+              behavior: HitTestBehavior.translucent,
+              child: const SizedBox.expand(),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PanelNote extends StatelessWidget {
+  const _PanelNote({required this.controller});
+
+  final TextEditingController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final scope = EditorStateScope.of(context);
+
+    return Screen(
+      padding: const Pad(all: 20),
+      heading: const Heading(
+        titleIcon: LucideLightIcons.notebook_tabs,
+        title: '작성 노트',
+        backgroundColor: AppColors.white,
+      ),
+      backgroundColor: AppColors.white,
+      child: TextField(
+        controller: controller,
+        smartDashesType: SmartDashesType.disabled,
+        smartQuotesType: SmartQuotesType.disabled,
+        autocorrect: false,
+        keyboardType: TextInputType.multiline,
+        maxLines: null,
+        expands: true,
+        textAlignVertical: TextAlignVertical.top,
+        decoration: const InputDecoration(
+          hintText: '포스트에 대해 기억할 내용이나 작성에 도움이 되는 내용이 있다면 자유롭게 적어보세요',
+          hintStyle: TextStyle(fontSize: 16, fontWeight: FontWeight.w500, color: AppColors.gray_300),
+        ),
+        onChanged: (value) async {
+          await scope.command('note', attrs: {'note': value});
+        },
+      ),
     );
   }
 }

--- a/apps/website/src/routes/website/_webview/editor/+page.svelte
+++ b/apps/website/src/routes/website/_webview/editor/+page.svelte
@@ -136,6 +136,7 @@
   const subtitle = new YState<string>(doc, 'subtitle', '');
   const maxWidth = new YState<number>(doc, 'maxWidth', 800);
   const storedMarks = new YState<unknown[]>(doc, 'storedMarks', []);
+  const note = new YState(doc, 'note', '');
 
   const fontFaces = $derived(
     $query.post.entity.site.fonts
@@ -193,6 +194,7 @@
   const setYJSState = () => {
     window.__webview__?.emitEvent('setYJSState', {
       maxWidth: maxWidth.current,
+      note: note.current,
     });
   };
 
@@ -373,6 +375,8 @@
         if (attrs.blockGap !== undefined) {
           editor?.current.chain().focus().setBodyBlockGap(attrs.blockGap).run();
         }
+      } else if (name === 'note') {
+        note.current = attrs.note;
       }
     });
 


### PR DESCRIPTION
- 상단에서 heading 영역까지만 좌우로 스와이프해 에디터 <-> 작성노트 화면 전환하도록 함
- 화면 전환 시 에디터를 다시 로드하지 않도록 keep alive를 true로 설정함
