### PR TITLE
에디터 템플릿 로드 placeholder가 에디터 내용이 비어있을 때도 표시하도록 수정

### DIFF
--- a/apps/website/src/lib/tiptap/extensions/placeholder.ts
+++ b/apps/website/src/lib/tiptap/extensions/placeholder.ts
@@ -3,6 +3,7 @@ import { Plugin } from '@tiptap/pm/state';
 import { Decoration, DecorationSet } from '@tiptap/pm/view';
 import { match } from 'ts-pattern';
 import { css } from '$styled-system/css';
+import { isBodyEmpty } from '../lib';
 
 export const Placeholder = Extension.create({
   name: 'placeholder',
@@ -21,14 +22,6 @@ export const Placeholder = Extension.create({
             const { doc, selection } = state;
             const { $anchor, empty } = selection;
 
-            const body = doc.child(0);
-            const currentBodyEmpty =
-              empty &&
-              body.childCount === 1 &&
-              body.child(0).type.name === 'paragraph' &&
-              (body.child(0).attrs.textAlign === 'left' || body.child(0).attrs.textAlign === 'justify') &&
-              body.child(0).childCount === 0;
-
             const currentParagraphEmpty =
               this.editor.isFocused &&
               empty &&
@@ -37,7 +30,7 @@ export const Placeholder = Extension.create({
               ($anchor.parent.attrs.textAlign === 'left' || $anchor.parent.attrs.textAlign === 'justify') &&
               $anchor.parent.childCount === 0;
 
-            if (!currentBodyEmpty && currentParagraphEmpty) {
+            if (!isBodyEmpty(state) && currentParagraphEmpty) {
               decorations.push(
                 createDecoration(
                   $anchor.pos <= 2 ? 1 : $anchor.before(),

--- a/apps/website/src/lib/tiptap/lib/utils.ts
+++ b/apps/website/src/lib/tiptap/lib/utils.ts
@@ -1,4 +1,5 @@
 import { findChildren } from '@tiptap/core';
+import type { Node } from '@tiptap/pm/model';
 import type { EditorState } from '@tiptap/pm/state';
 import type { EditorView } from '@tiptap/pm/view';
 
@@ -55,4 +56,30 @@ export const isCodeActive = (state: EditorState) => {
   });
 
   return isInCodeBlock;
+};
+
+export const isBodyEmpty = (state: EditorState) => {
+  const { doc, selection } = state;
+  const { anchor, empty } = selection;
+
+  if (!empty || anchor !== 2) {
+    return false;
+  }
+
+  const body = doc.child(0);
+
+  const isEmptyParagraph = (node: Node) => {
+    return (
+      node.type.name === 'paragraph' && (node.attrs.textAlign === 'left' || node.attrs.textAlign === 'justify') && node.childCount === 0
+    );
+  };
+
+  for (let i = 0; i < body.childCount; i++) {
+    const node = body.child(i);
+    if (!isEmptyParagraph(node)) {
+      return false;
+    }
+  }
+
+  return true;
 };

--- a/apps/website/src/routes/website/(dashboard)/[slug]/Placeholder.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/Placeholder.svelte
@@ -5,6 +5,7 @@
   import ShapesIcon from '~icons/lucide/shapes';
   import { fragment, graphql } from '$graphql';
   import { HorizontalDivider, Icon, Modal } from '$lib/components';
+  import { isBodyEmpty } from '$lib/tiptap';
   import { css, cx } from '$styled-system/css';
   import { center, flex } from '$styled-system/patterns';
   import { YState } from './state.svelte';
@@ -54,20 +55,7 @@
 
   const maxWidth = new YState<number>(doc, 'maxWidth', 800);
 
-  const isBodyEmpty = $derived.by(() => {
-    const { doc, selection } = editor.current.state;
-    const { empty } = selection;
-
-    const body = doc.child(0);
-
-    return (
-      empty &&
-      body.childCount === 1 &&
-      body.child(0).type.name === 'paragraph' &&
-      (body.child(0).attrs.textAlign === 'left' || body.child(0).attrs.textAlign === 'justify') &&
-      body.child(0).childCount === 0
-    );
-  });
+  const emptyBody = $derived(isBodyEmpty(editor.current.state));
 
   const paragraphIndent = $derived.by(() => {
     const { doc } = editor.current.state;
@@ -95,7 +83,7 @@
   };
 </script>
 
-{#if isBodyEmpty}
+{#if emptyBody}
   <div class={center({ position: 'absolute', top: '0', insetX: '0', flexGrow: '1', pointerEvents: 'none' })}>
     <div
       style:padding-left={`${paragraphIndent}em`}

--- a/apps/website/src/routes/website/_webview/editor/Placeholder.svelte
+++ b/apps/website/src/routes/website/_webview/editor/Placeholder.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import ShapesIcon from '~icons/lucide/shapes';
   import { Icon } from '$lib/components';
+  import { isBodyEmpty } from '$lib/tiptap';
   import { css } from '$styled-system/css';
   import { center, flex } from '$styled-system/patterns';
   import type { Editor } from '@tiptap/core';
@@ -13,20 +14,7 @@
 
   let { editor, isTemplateActive }: Props = $props();
 
-  const isBodyEmpty = $derived.by(() => {
-    const { doc, selection } = editor.current.state;
-    const { empty } = selection;
-
-    const body = doc.child(0);
-
-    return (
-      empty &&
-      body.childCount === 1 &&
-      body.child(0).type.name === 'paragraph' &&
-      (body.child(0).attrs.textAlign === 'left' || body.child(0).attrs.textAlign === 'justify') &&
-      body.child(0).childCount === 0
-    );
-  });
+  const emptyBody = $derived(isBodyEmpty(editor.current.state));
 
   const paragraphIndent = $derived.by(() => {
     const { doc } = editor.current.state;
@@ -35,7 +23,7 @@
   });
 </script>
 
-{#if isBodyEmpty}
+{#if emptyBody}
   <div class={center({ position: 'absolute', top: '0', insetX: '0', flexGrow: '1', pointerEvents: 'none' })}>
     <div
       style:padding-left={`${paragraphIndent}em`}


### PR DESCRIPTION
trailing node랑 상성이 잘 안 맞아서 그냥 에디터 전체가 빈 paragraph로 구성되어 있을 때 표시하도록 수정함
