### PR TITLE
찾기 바꾸기 단축키 등

### DIFF
--- a/apps/website/src/lib/context/app.svelte.ts
+++ b/apps/website/src/lib/context/app.svelte.ts
@@ -29,6 +29,7 @@ type AppState = {
   shareOpen: string | false;
   statsOpen: boolean;
   upgradeOpen: boolean;
+  findReplaceOpen: boolean;
 
   progress: {
     totalCharacterCount: number;
@@ -65,6 +66,7 @@ export const setupAppContext = (userId: string) => {
     shareOpen: false,
     statsOpen: false,
     upgradeOpen: false,
+    findReplaceOpen: false,
 
     progress: {
       totalCharacterCount: 0,

--- a/apps/website/src/routes/website/(dashboard)/@preference/ShortcutsTab.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@preference/ShortcutsTab.svelte
@@ -50,6 +50,7 @@
         { keys: [modKey, 'C'], description: '복사' },
         { keys: [modKey, 'V'], description: '붙여넣기' },
         { keys: [modKey, 'A'], description: '문단 선택 (반복시 전체 선택)' },
+        { keys: [modKey, 'F'], description: '찾기, 바꾸기 열기' },
       ],
     },
     {

--- a/apps/website/src/routes/website/(dashboard)/Shortcuts.svelte
+++ b/apps/website/src/routes/website/(dashboard)/Shortcuts.svelte
@@ -38,6 +38,8 @@
     }
 
     if ((event.ctrlKey || event.metaKey) && event.shiftKey && event.code === 'KeyP') {
+      if (!app.state.current) return;
+
       event.preventDefault();
 
       app.preference.current.panelExpanded = !app.preference.current.panelExpanded;
@@ -46,6 +48,8 @@
     }
 
     if ((event.ctrlKey || event.metaKey) && event.shiftKey && event.code === 'KeyM') {
+      if (!app.state.current) return;
+
       event.preventDefault();
 
       app.preference.current.zenModeEnabled = !app.preference.current.zenModeEnabled;
@@ -55,6 +59,15 @@
       } else {
         mixpanel.track('zen_mode_disabled', { via: 'shortcut' });
       }
+
+      return;
+    }
+
+    if ((event.ctrlKey || event.metaKey) && event.code === 'KeyF') {
+      if (!app.state.current) return;
+
+      event.preventDefault();
+      app.state.findReplaceOpen = true;
 
       return;
     }

--- a/apps/website/src/routes/website/(dashboard)/[slug]/Toolbar.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/Toolbar.svelte
@@ -31,6 +31,7 @@
   import LineHeightIcon from '~icons/typie/line-height';
   import RubyIcon from '~icons/typie/ruby';
   import { fragment, graphql } from '$graphql';
+  import { tooltip } from '$lib/actions';
   import { HorizontalDivider, Icon, SegmentButtons, Slider, Switch, Tooltip, VerticalDivider } from '$lib/components';
   import { getAppContext } from '$lib/context/app.svelte';
   import { defaultValues, values } from '$lib/tiptap/values';
@@ -277,18 +278,33 @@
     <div class={css({ flexGrow: '1' })}></div>
 
     {#if editor}
-      <ToolbarDropdownButton disabled={!editor.current} label="찾기" placement="bottom-end" size="large">
-        {#snippet anchor()}
-          <ToolbarIcon icon={SearchIcon} />
-        {/snippet}
+      <div
+        use:tooltip={{
+          message: '찾기, 바꾸기',
+          keys: ['Mod', 'F'],
+        }}
+      >
+        <ToolbarDropdownButton
+          disabled={!editor.current}
+          label="찾기"
+          onOpenChange={(opened) => {
+            app.state.findReplaceOpen = opened;
+          }}
+          opened={app.state.findReplaceOpen}
+          placement="bottom-end"
+          size="large"
+        >
+          {#snippet anchor()}
+            <ToolbarIcon icon={SearchIcon} />
+          {/snippet}
 
-        {#snippet floating({ close })}
-          {#if editor}
-            <ToolbarFloatingFindReplace {close} {editor} />
-          {/if}
-        {/snippet}
-      </ToolbarDropdownButton>
-
+          {#snippet floating({ close })}
+            {#if editor}
+              <ToolbarFloatingFindReplace {close} {editor} />
+            {/if}
+          {/snippet}
+        </ToolbarDropdownButton>
+      </div>
       <Spellcheck {editor} subscription={!!$site?.user.subscription} />
     {/if}
   </div>

--- a/apps/website/src/routes/website/(dashboard)/[slug]/ToolbarButton.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/ToolbarButton.svelte
@@ -15,7 +15,6 @@
     onclick?: () => void;
   };
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let { style, size, icon, label, active = false, disabled = false, onclick }: Props = $props();
 </script>
 
@@ -41,6 +40,7 @@
       style,
     )}
     aria-pressed={active}
+    {disabled}
     {onclick}
     type="button"
   >
@@ -67,6 +67,7 @@
         style,
       )}
       aria-pressed={active}
+      {disabled}
       {onclick}
       type="button"
     >

--- a/apps/website/src/routes/website/(dashboard)/[slug]/ToolbarDropdownButton.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/ToolbarDropdownButton.svelte
@@ -17,12 +17,25 @@
     disabled?: boolean;
     chevron?: boolean;
     placement?: Placement;
+    opened?: boolean;
+    onOpenChange?: (opened: boolean) => void;
     anchor: Snippet<[{ open: () => void; opened: boolean }]>;
     floating: Snippet<[{ close: () => void }]>;
   };
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  let { style, size, label, active = false, disabled = false, chevron = false, placement = 'bottom', anchor, floating }: Props = $props();
+  let {
+    style,
+    size,
+    label,
+    active = false,
+    disabled = false,
+    chevron = false,
+    placement = 'bottom',
+    opened: externalOpened,
+    onOpenChange,
+    anchor,
+    floating,
+  }: Props = $props();
 
   const { anchor: anchorAction, floating: floatingAction } = createFloatingActions({
     placement,
@@ -34,12 +47,24 @@
 
   let opened = $state(false);
 
+  $effect(() => {
+    if (externalOpened === undefined) return;
+
+    if (externalOpened && !opened) {
+      open();
+    } else if (!externalOpened && opened) {
+      close();
+    }
+  });
+
   const open = () => {
     opened = true;
+    onOpenChange?.(true);
   };
 
   const close = () => {
     opened = false;
+    onOpenChange?.(false);
   };
 </script>
 
@@ -65,6 +90,7 @@
       style,
     )}
     aria-pressed={opened}
+    {disabled}
     onclick={open}
     type="button"
     use:anchorAction
@@ -98,6 +124,7 @@
       )}
       aria-label={label}
       aria-pressed={opened}
+      {disabled}
       onclick={open}
       type="button"
       use:anchorAction


### PR DESCRIPTION
- ToolbarButton, ToolbarDropdownButton이 `disabled` 속성을 활용함
- ToolbarDropdownButton을 외부에서 여닫을 수 있도록 함
- Mod + F 로 찾기
- 우측 패널 여닫기, 집중 모드, 찾기 단축키는 app.state.current가 있을 때만 동작함