### PR TITLE
리팩토링: @context-menu/PostMenu, CanvasMenu

### DIFF
--- a/apps/website/src/routes/website/(dashboard)/@context-menu/CanvasMenu.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@context-menu/CanvasMenu.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+  import mixpanel from 'mixpanel-browser';
+  import CopyIcon from '~icons/lucide/copy';
+  import InfoIcon from '~icons/lucide/info';
+  import TrashIcon from '~icons/lucide/trash';
+  import { goto } from '$app/navigation';
+  import { graphql } from '$graphql';
+  import { HorizontalDivider, Icon, MenuItem } from '$lib/components';
+  import { Dialog } from '$lib/notification';
+  import { css } from '$styled-system/css';
+  import { flex } from '$styled-system/patterns';
+
+  type Props = {
+    canvas: {
+      id: string;
+      title: string;
+    };
+    via: 'tree' | 'editor';
+  };
+
+  let { canvas, via }: Props = $props();
+
+  const duplicateCanvas = graphql(`
+    mutation CanvasMenu_DuplicateCanvas_Mutation($input: DuplicateCanvasInput!) {
+      duplicateCanvas(input: $input) {
+        id
+
+        entity {
+          id
+          slug
+        }
+      }
+    }
+  `);
+
+  const deleteCanvas = graphql(`
+    mutation CanvasMenu_DeleteCanvas_Mutation($input: DeleteCanvasInput!) {
+      deleteCanvas(input: $input) {
+        id
+
+        entity {
+          id
+
+          site {
+            id
+            ...DashboardLayout_EntityTree_site
+            ...DashboardLayout_Trash_site
+            ...DashboardLayout_PlanUsageWidget_site
+          }
+        }
+      }
+    }
+  `);
+
+  const handleDuplicate = async () => {
+    const resp = await duplicateCanvas({ canvasId: canvas.id });
+    mixpanel.track('duplicate_canvas', { via });
+    await goto(`/${resp.entity.slug}`);
+  };
+
+  const handleDelete = () => {
+    Dialog.confirm({
+      title: '캔버스 삭제',
+      message: `정말 "${canvas.title}" 캔버스를 삭제하시겠어요?`,
+      children: deleteDetailsView,
+      action: 'danger',
+      actionLabel: '삭제',
+      actionHandler: async () => {
+        await deleteCanvas({ canvasId: canvas.id });
+        mixpanel.track('delete_canvas', { via });
+      },
+    });
+  };
+</script>
+
+{#snippet deleteDetailsView()}
+  <div
+    class={flex({
+      alignItems: 'center',
+      gap: '6px',
+      borderRadius: '8px',
+      paddingX: '12px',
+      paddingY: '8px',
+      backgroundColor: 'surface.subtle',
+    })}
+  >
+    <Icon style={css.raw({ color: 'text.muted' })} icon={InfoIcon} size={14} />
+    <span class={css({ fontSize: '13px', fontWeight: 'medium', color: 'text.muted' })}>삭제 후 30일 동안 휴지통에 보관돼요</span>
+  </div>
+{/snippet}
+
+<MenuItem icon={CopyIcon} onclick={handleDuplicate}>복제</MenuItem>
+
+<HorizontalDivider color="secondary" />
+
+<MenuItem icon={TrashIcon} onclick={handleDelete} variant="danger">삭제</MenuItem>

--- a/apps/website/src/routes/website/(dashboard)/@context-menu/PostMenu.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@context-menu/PostMenu.svelte
@@ -1,0 +1,217 @@
+<script lang="ts">
+  import mixpanel from 'mixpanel-browser';
+  import { EntityAvailability, EntityVisibility, PostType } from '@/enums';
+  import { TypieError } from '@/errors';
+  import BlendIcon from '~icons/lucide/blend';
+  import CopyIcon from '~icons/lucide/copy';
+  import ExternalLinkIcon from '~icons/lucide/external-link';
+  import InfoIcon from '~icons/lucide/info';
+  import ShapesIcon from '~icons/lucide/shapes';
+  import TrashIcon from '~icons/lucide/trash';
+  import { goto } from '$app/navigation';
+  import { graphql } from '$graphql';
+  import { HorizontalDivider, Icon, MenuItem } from '$lib/components';
+  import { getAppContext } from '$lib/context';
+  import { Dialog, Toast } from '$lib/notification';
+  import { comma } from '$lib/utils';
+  import { css } from '$styled-system/css';
+  import { flex } from '$styled-system/patterns';
+
+  type Props = {
+    post: {
+      id: string;
+      title: string;
+      type: PostType;
+      characterCount?: number;
+    };
+    entity: {
+      id: string;
+      url: string;
+      visibility: EntityVisibility;
+      availability: EntityAvailability;
+    };
+    via: 'tree' | 'editor';
+  };
+
+  let { post, entity, via }: Props = $props();
+
+  const duplicatePost = graphql(`
+    mutation PostMenu_DuplicatePost_Mutation($input: DuplicatePostInput!) {
+      duplicatePost(input: $input) {
+        id
+
+        entity {
+          id
+          slug
+        }
+      }
+    }
+  `);
+
+  const deletePost = graphql(`
+    mutation PostMenu_DeletePost_Mutation($input: DeletePostInput!) {
+      deletePost(input: $input) {
+        id
+
+        entity {
+          id
+
+          site {
+            id
+            ...DashboardLayout_EntityTree_site
+            ...DashboardLayout_Trash_site
+            ...DashboardLayout_PlanUsageWidget_site
+          }
+
+          user {
+            id
+
+            recentlyViewedEntities {
+              id
+            }
+          }
+        }
+      }
+    }
+  `);
+
+  const updatePostType = graphql(`
+    mutation PostMenu_UpdatePostType_Mutation($input: UpdatePostTypeInput!) {
+      updatePostType(input: $input) {
+        id
+        type
+
+        entity {
+          id
+
+          site {
+            id
+
+            templates {
+              id
+            }
+          }
+        }
+      }
+    }
+  `);
+
+  const app = getAppContext();
+
+  const handleDuplicate = async () => {
+    try {
+      const resp = await duplicatePost({ postId: post.id });
+      mixpanel.track('duplicate_post', { via });
+      await goto(`/${resp.entity.slug}`);
+    } catch (err) {
+      const errorMessages: Record<string, string> = {
+        character_count_limit_exceeded: '현재 플랜의 글자 수 제한을 초과했어요.',
+        blob_size_limit_exceeded: '현재 플랜의 파일 크기 제한을 초과했어요.',
+      };
+
+      if (err instanceof TypieError) {
+        const message = errorMessages[err.code] || err.code;
+        Toast.error(message);
+      }
+    }
+  };
+
+  const handleDelete = () => {
+    Dialog.confirm({
+      title: '포스트 삭제',
+      message: `정말 "${post.title}" 포스트를 삭제하시겠어요?`,
+      children: deleteDetailsView,
+      action: 'danger',
+      actionLabel: '삭제',
+      actionHandler: async () => {
+        await deletePost({ postId: post.id });
+        mixpanel.track('delete_post', { via });
+      },
+    });
+  };
+
+  const handleTypeChange = (newType: PostType) => {
+    const isToTemplate = newType === PostType.TEMPLATE;
+
+    Dialog.confirm({
+      title: isToTemplate ? '템플릿으로 전환' : '포스트로 전환',
+      message: isToTemplate
+        ? '이 포스트를 템플릿으로 전환하시겠어요?\n앞으로 새 포스트를 생성할 때 이 포스트의 서식을 쉽게 이용할 수 있어요.'
+        : '이 템플릿을 다시 일반 포스트로 전환하시겠어요?',
+      actionLabel: '전환',
+      actionHandler: async () => {
+        await updatePostType({ postId: post.id, type: newType });
+      },
+    });
+  };
+</script>
+
+{#snippet deleteDetailsView()}
+  <div
+    class={flex({
+      alignItems: 'center',
+      gap: '6px',
+      borderRadius: '8px',
+      paddingX: '12px',
+      paddingY: '8px',
+      backgroundColor: 'surface.subtle',
+    })}
+  >
+    <Icon style={css.raw({ color: 'text.muted' })} icon={InfoIcon} size={14} />
+    <span class={css({ fontSize: '13px', fontWeight: 'medium', color: 'text.muted' })}>삭제 후 30일 동안 휴지통에 보관돼요</span>
+  </div>
+{/snippet}
+
+<MenuItem external href={entity.url} icon={ExternalLinkIcon} type="link">사이트에서 열기</MenuItem>
+
+<HorizontalDivider color="secondary" />
+
+<MenuItem
+  icon={BlendIcon}
+  onclick={() => {
+    app.state.shareOpen = entity.id;
+    if (via === 'editor') {
+      mixpanel.track('open_post_share_modal', { via: 'editor' });
+    }
+  }}
+>
+  공유 및 게시
+</MenuItem>
+
+<MenuItem icon={CopyIcon} onclick={handleDuplicate}>복제</MenuItem>
+
+{#if post.type === PostType.NORMAL}
+  <MenuItem icon={ShapesIcon} onclick={() => handleTypeChange(PostType.TEMPLATE)}>템플릿으로 전환</MenuItem>
+{:else if post.type === PostType.TEMPLATE}
+  <MenuItem icon={ShapesIcon} onclick={() => handleTypeChange(PostType.NORMAL)}>포스트로 전환</MenuItem>
+{/if}
+
+<HorizontalDivider color="secondary" />
+
+<MenuItem icon={TrashIcon} onclick={handleDelete} variant="danger">삭제</MenuItem>
+
+{#if via === 'tree'}
+  <HorizontalDivider color="secondary" />
+
+  <div class={css({ paddingX: '10px', paddingY: '4px', fontSize: '12px', color: 'text.disabled', userSelect: 'none' })}>
+    <div class={css({ fontWeight: 'medium' })}>
+      {#if entity.visibility === EntityVisibility.UNLISTED || entity.availability === EntityAvailability.UNLISTED}
+        <span class={css({ color: 'accent.brand.default' })}>
+          {#if entity.visibility === EntityVisibility.UNLISTED && entity.availability === EntityAvailability.UNLISTED}
+            링크 조회/편집 가능 포스트
+          {:else if entity.visibility === EntityVisibility.UNLISTED}
+            링크 조회 가능 포스트
+          {:else if entity.availability === EntityAvailability.UNLISTED}
+            링크 편집 가능 포스트
+          {/if}
+        </span>
+      {:else}
+        <span>비공개 포스트</span>
+      {/if}
+    </div>
+
+    {#if post.characterCount !== undefined}
+      <span>총 {comma(post.characterCount)}자</span>
+    {/if}
+  </div>
+{/if}

--- a/apps/website/src/routes/website/(dashboard)/@tree/@selection/MultiEntitiesMenu.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@tree/@selection/MultiEntitiesMenu.svelte
@@ -9,14 +9,12 @@
   import TriangleAlertIcon from '~icons/lucide/triangle-alert';
   import { graphql } from '$graphql';
   import { HorizontalDivider, Icon, MenuItem } from '$lib/components';
-  import { getAppContext } from '$lib/context';
   import { Dialog, Toast } from '$lib/notification';
   import { css } from '$styled-system/css';
   import { center, flex } from '$styled-system/patterns';
   import { getTreeContext } from '../state.svelte';
   import type { TreeEntity } from './types';
 
-  const app = getAppContext();
   const treeState = getTreeContext();
 
   const deleteEntities = graphql(`
@@ -109,11 +107,6 @@
 
           treeState.selectedEntityIds.clear();
           treeState.lastSelectedEntityId = undefined;
-
-          if (app.state.current && entityIds.includes(app.state.current)) {
-            app.state.ancestors = [];
-            app.state.current = undefined;
-          }
 
           Toast.success(`${entityIds.length}개의 항목이 삭제되었어요`);
         } catch {

--- a/apps/website/src/routes/website/(dashboard)/@tree/EntityTree.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@tree/EntityTree.svelte
@@ -175,6 +175,26 @@
     }
   });
 
+  $effect(() => {
+    if (!treeState.entityMap) return;
+
+    const validEntityIds = new Set(treeState.entityMap.keys());
+
+    const invalidSelectedIds = treeState.selectedEntityIds.difference(validEntityIds);
+    for (const entityId of invalidSelectedIds) {
+      treeState.selectedEntityIds.delete(entityId);
+    }
+
+    if (treeState.lastSelectedEntityId && !validEntityIds.has(treeState.lastSelectedEntityId)) {
+      treeState.lastSelectedEntityId = undefined;
+    }
+
+    if (app.state.current && !validEntityIds.has(app.state.current)) {
+      app.state.ancestors = [];
+      app.state.current = undefined;
+    }
+  });
+
   // NOTE: 링크 관련 브라우저 기본 동작 방지
   const handleClick: MouseEventHandler<HTMLDivElement> = (e) => {
     const element = (e.target as HTMLElement).closest<HTMLElement>('[data-id]');
@@ -441,11 +461,6 @@
 
           treeState.selectedEntityIds.clear();
           treeState.lastSelectedEntityId = undefined;
-
-          if (app.state.current && selectedIds.includes(app.state.current)) {
-            app.state.ancestors = [];
-            app.state.current = undefined;
-          }
 
           Toast.success(`${selectedIds.length}개의 항목이 삭제되었어요`);
         } catch {

--- a/apps/website/src/routes/website/(dashboard)/@tree/Post.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@tree/Post.svelte
@@ -1,23 +1,14 @@
 <script lang="ts">
-  import mixpanel from 'mixpanel-browser';
-  import { EntityAvailability, EntityVisibility, PostType } from '@/enums';
-  import { TypieError } from '@/errors';
-  import BlendIcon from '~icons/lucide/blend';
-  import CopyIcon from '~icons/lucide/copy';
+  import { PostType } from '@/enums';
   import EllipsisIcon from '~icons/lucide/ellipsis';
-  import ExternalLinkIcon from '~icons/lucide/external-link';
   import FileIcon from '~icons/lucide/file';
-  import InfoIcon from '~icons/lucide/info';
   import ShapesIcon from '~icons/lucide/shapes';
-  import TrashIcon from '~icons/lucide/trash';
-  import { goto } from '$app/navigation';
   import { fragment, graphql } from '$graphql';
-  import { HorizontalDivider, Icon, Menu, MenuItem } from '$lib/components';
+  import { Icon, Menu } from '$lib/components';
   import { getAppContext } from '$lib/context';
-  import { Dialog, Toast } from '$lib/notification';
-  import { comma } from '$lib/utils';
   import { css, cx } from '$styled-system/css';
-  import { center, flex } from '$styled-system/patterns';
+  import { center } from '$styled-system/patterns';
+  import PostMenu from '../@context-menu/PostMenu.svelte';
   import EntitySelectionIndicator from './@selection/EntitySelectionIndicator.svelte';
   import MultiEntitiesMenu from './@selection/MultiEntitiesMenu.svelte';
   import { getTreeContext } from './state.svelte';
@@ -50,46 +41,6 @@
       }
     `),
   );
-
-  const duplicatePost = graphql(`
-    mutation DashboardLayout_EntityTree_Post_DuplicatePost_Mutation($input: DuplicatePostInput!) {
-      duplicatePost(input: $input) {
-        id
-
-        entity {
-          id
-          slug
-        }
-      }
-    }
-  `);
-
-  const deletePost = graphql(`
-    mutation DashboardLayout_EntityTree_Post_DeletePost_Mutation($input: DeletePostInput!) {
-      deletePost(input: $input) {
-        id
-
-        entity {
-          id
-
-          site {
-            id
-            ...DashboardLayout_EntityTree_site
-            ...DashboardLayout_Trash_site
-            ...DashboardLayout_PlanUsageWidget_site
-          }
-
-          user {
-            id
-
-            recentlyViewedEntities {
-              id
-            }
-          }
-        }
-      }
-    }
-  `);
 
   const app = getAppContext();
   const treeState = getTreeContext();
@@ -193,102 +144,7 @@
     {#if treeState.selectedEntityIds.size > 1 && treeState.selectedEntityIds.has($post.entity.id)}
       <MultiEntitiesMenu />
     {:else}
-      <MenuItem external href={$post.entity.url} icon={ExternalLinkIcon} type="link">사이트에서 열기</MenuItem>
-
-      <HorizontalDivider color="secondary" />
-
-      <MenuItem icon={BlendIcon} onclick={() => (app.state.shareOpen = $post.entity.id)}>공유 및 게시</MenuItem>
-
-      <MenuItem
-        icon={CopyIcon}
-        onclick={async () => {
-          try {
-            const resp = await duplicatePost({ postId: $post.id });
-            mixpanel.track('duplicate_post', { via: 'tree' });
-            await goto(`/${resp.entity.slug}`);
-          } catch (err) {
-            const errorMessages: Record<string, string> = {
-              character_count_limit_exceeded: '현재 플랜의 글자 수 제한을 초과했어요.',
-              blob_size_limit_exceeded: '현재 플랜의 파일 크기 제한을 초과했어요.',
-            };
-
-            if (err instanceof TypieError) {
-              const message = errorMessages[err.code] || err.code;
-              Toast.error(message);
-            }
-          }
-        }}
-      >
-        복제
-      </MenuItem>
-
-      <HorizontalDivider color="secondary" />
-
-      <MenuItem
-        icon={TrashIcon}
-        onclick={async () => {
-          Dialog.confirm({
-            title: '포스트 삭제',
-            message: `정말 "${$post.title}" 포스트를 삭제하시겠어요?`,
-            children: deleteDetailsView,
-            action: 'danger',
-            actionLabel: '삭제',
-            actionHandler: async () => {
-              await deletePost({ postId: $post.id });
-              mixpanel.track('delete_post', { via: 'tree' });
-              app.state.ancestors = [];
-              app.state.current = undefined;
-              if (treeState.selectedEntityIds.has($post.entity.id)) {
-                treeState.selectedEntityIds.delete($post.entity.id);
-              }
-              if (treeState.lastSelectedEntityId === $post.entity.id) {
-                treeState.lastSelectedEntityId = undefined;
-              }
-            },
-          });
-        }}
-        variant="danger"
-      >
-        삭제
-      </MenuItem>
-
-      {#snippet deleteDetailsView()}
-        <div
-          class={flex({
-            alignItems: 'center',
-            gap: '6px',
-            borderRadius: '8px',
-            paddingX: '12px',
-            paddingY: '8px',
-            backgroundColor: 'surface.subtle',
-          })}
-        >
-          <Icon style={css.raw({ color: 'text.muted' })} icon={InfoIcon} size={14} />
-          <span class={css({ fontSize: '13px', fontWeight: 'medium', color: 'text.muted' })}>삭제 후 30일 동안 휴지통에 보관돼요</span>
-        </div>
-      {/snippet}
-
-      <HorizontalDivider color="secondary" />
-
-      <div class={css({ paddingX: '10px', paddingY: '4px', fontSize: '12px', color: 'text.disabled', userSelect: 'none' })}>
-        <div class={css({ fontWeight: 'medium' })}>
-          {#if $post.entity.visibility === EntityVisibility.UNLISTED || $post.entity.availability === EntityAvailability.UNLISTED}
-            <span class={css({ color: 'accent.brand.default' })}>
-              {#if $post.entity.visibility === EntityVisibility.UNLISTED && $post.entity.availability === EntityAvailability.UNLISTED}
-                링크 조회/편집 가능 포스트
-              {:else if $post.entity.visibility === EntityVisibility.UNLISTED}
-                링크 조회 가능 포스트
-              {:else if $post.entity.availability === EntityAvailability.UNLISTED}
-                링크 편집 가능 포스트
-              {/if}
-            </span>
-          {:else}
-            <span>비공개 포스트</span>
-          {/if}
-        </div>
-
-        <span>총 {comma($post.characterCount)}자</span>
-      </div>
+      <PostMenu entity={$post.entity} post={$post} via="tree" />
     {/if}
   </Menu>
 </a>


### PR DESCRIPTION
- 두 곳에 따로 있던 Post 컨텍스트 메뉴와 Canvas 컨텍스트 메뉴를 통합
- entity 삭제할 때 삭제된 entity의 selection을 수동으로 정리하지 않고 EntityTree에서 $effect로 정리함
- app.state.ancestors, app.state.current 정리 로직도..