### PR TITLE
MultiEntitiesMenu 분리

### DIFF
--- a/apps/mobile/lib/screens/entity/multi_entities_menu.dart
+++ b/apps/mobile/lib/screens/entity/multi_entities_menu.dart
@@ -1,0 +1,165 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:mixpanel_flutter/mixpanel_flutter.dart';
+import 'package:typie/context/bottom_sheet.dart';
+import 'package:typie/context/modal.dart';
+import 'package:typie/context/theme.dart';
+import 'package:typie/context/toast.dart';
+import 'package:typie/graphql/client.dart';
+import 'package:typie/hooks/service.dart';
+import 'package:typie/icons/lucide_light.dart';
+import 'package:typie/screens/entity/__generated__/delete_entities_mutation.req.gql.dart';
+import 'package:typie/screens/entity/__generated__/entity_fragment.data.gql.dart';
+import 'package:typie/screens/entity/move_entity_modal.dart';
+
+class MultiEntitiesMenu extends HookWidget {
+  const MultiEntitiesMenu({
+    super.key,
+    required this.selectedItems,
+    required this.entities,
+    required this.onExitSelectionMode,
+    required this.via,
+  });
+
+  final Set<String> selectedItems;
+  final List<GEntityScreen_Entity_entity> entities;
+  final VoidCallback onExitSelectionMode;
+  final String via;
+
+  @override
+  Widget build(BuildContext context) {
+    final client = useService<GraphQLClient>();
+    final mixpanel = useService<Mixpanel>();
+
+    final selectedEntities = entities.where((e) => selectedItems.contains(e.id)).toList();
+    final folderCount = selectedEntities.where((e) => e.node.G__typename == 'Folder').length;
+    final postCount = selectedEntities.where((e) => e.node.G__typename == 'Post').length;
+    final canvasCount = selectedEntities.where((e) => e.node.G__typename == 'Canvas').length;
+
+    return BottomMenu(
+      header: MultiEntitiesMenuHeader(
+        selectedCount: selectedItems.length,
+        folderCount: folderCount,
+        postCount: postCount,
+        canvasCount: canvasCount,
+      ),
+      items: [
+        BottomMenuItem(
+          icon: LucideLightIcons.folder_symlink,
+          label: '다른 폴더로 옮기기',
+          onTap: () async {
+            unawaited(
+              mixpanel.track('move_entities_try', properties: {'totalCount': selectedItems.length, 'via': via}),
+            );
+            await context.showBottomSheet(
+              intercept: true,
+              child: MoveEntityModal.multiple(entities: selectedEntities, via: via, onMoved: onExitSelectionMode),
+            );
+          },
+        ),
+        BottomMenuItem(
+          icon: LucideLightIcons.trash,
+          label: '삭제하기',
+          onTap: () async {
+            await context.showModal(
+              child: ConfirmModal(
+                title: '선택한 항목 삭제',
+                message: '선택한 ${selectedItems.length}개 항목을 삭제하시겠어요?',
+                confirmText: '삭제하기',
+                confirmTextColor: context.colors.textBright,
+                confirmBackgroundColor: context.colors.accentDanger,
+                onConfirm: () async {
+                  try {
+                    await client.request(
+                      GEntityScreen_DeleteEntities_MutationReq((b) => b..vars.input.entityIds.addAll(selectedItems)),
+                    );
+
+                    unawaited(
+                      mixpanel.track('delete_entities', properties: {'totalCount': selectedItems.length, 'via': via}),
+                    );
+
+                    if (context.mounted) {
+                      context.toast(ToastType.success, '${selectedItems.length}개의 항목이 삭제되었어요');
+                    }
+
+                    onExitSelectionMode();
+                  } catch (_) {
+                    if (context.mounted) {
+                      context.toast(ToastType.error, '삭제 중 오류가 발생했습니다');
+                    }
+                  }
+                },
+              ),
+            );
+          },
+        ),
+      ],
+    );
+  }
+}
+
+class MultiEntitiesMenuHeader extends StatelessWidget {
+  const MultiEntitiesMenuHeader({
+    super.key,
+    required this.selectedCount,
+    required this.folderCount,
+    required this.postCount,
+    required this.canvasCount,
+  });
+
+  final int selectedCount;
+  final int folderCount;
+  final int postCount;
+  final int canvasCount;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          spacing: 16,
+          children: [
+            const Icon(LucideLightIcons.square_check, size: 20),
+            Text('$selectedCount개 선택됨', style: const TextStyle(fontSize: 17, fontWeight: FontWeight.w600)),
+          ],
+        ),
+        if (folderCount > 0 || postCount > 0 || canvasCount > 0)
+          Padding(
+            padding: const EdgeInsets.only(left: 36, top: 4),
+            child: Row(
+              spacing: 12,
+              children: [
+                if (folderCount > 0)
+                  Row(
+                    spacing: 4,
+                    children: [
+                      Icon(LucideLightIcons.folder, size: 14, color: context.colors.textSubtle),
+                      Text('$folderCount개', style: TextStyle(fontSize: 14, color: context.colors.textSubtle)),
+                    ],
+                  ),
+                if (postCount > 0)
+                  Row(
+                    spacing: 4,
+                    children: [
+                      Icon(LucideLightIcons.file, size: 14, color: context.colors.textSubtle),
+                      Text('$postCount개', style: TextStyle(fontSize: 14, color: context.colors.textSubtle)),
+                    ],
+                  ),
+                if (canvasCount > 0)
+                  Row(
+                    spacing: 4,
+                    children: [
+                      Icon(LucideLightIcons.line_squiggle, size: 14, color: context.colors.textSubtle),
+                      Text('$canvasCount개', style: TextStyle(fontSize: 14, color: context.colors.textSubtle)),
+                    ],
+                  ),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/apps/mobile/lib/screens/entity/screen.dart
+++ b/apps/mobile/lib/screens/entity/screen.dart
@@ -36,6 +36,7 @@ import 'package:typie/screens/entity/__generated__/screen_with_entity_id_query.d
 import 'package:typie/screens/entity/__generated__/screen_with_entity_id_query.req.gql.dart';
 import 'package:typie/screens/entity/__generated__/screen_with_site_id_query.req.gql.dart';
 import 'package:typie/screens/entity/move_entity_modal.dart';
+import 'package:typie/screens/entity/multi_entities_menu.dart';
 import 'package:typie/screens/entity/selected_entities_bar.dart';
 import 'package:typie/services/preference.dart';
 import 'package:typie/widgets/forms/form.dart';
@@ -428,6 +429,21 @@ class _EntityList extends HookWidget {
                         },
                         onLongPress: () async {
                           if (isReordering.value) {
+                            return;
+                          }
+
+                          if (isSelecting.value && selectedItems.value.contains(entities[index].id)) {
+                            await context.showBottomSheet(
+                              child: MultiEntitiesMenu(
+                                selectedItems: selectedItems.value,
+                                entities: entities,
+                                onExitSelectionMode: () {
+                                  isSelecting.value = false;
+                                  selectedItems.value = {};
+                                },
+                                via: 'entity_long_press',
+                              ),
+                            );
                             return;
                           }
 

--- a/apps/mobile/lib/screens/entity/selected_entities_bar.dart
+++ b/apps/mobile/lib/screens/entity/selected_entities_bar.dart
@@ -1,20 +1,11 @@
-import 'dart:async';
-
 import 'package:assorted_layout_widgets/assorted_layout_widgets.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:mixpanel_flutter/mixpanel_flutter.dart';
 import 'package:typie/context/bottom_sheet.dart';
-import 'package:typie/context/modal.dart';
 import 'package:typie/context/theme.dart';
-import 'package:typie/context/toast.dart';
-import 'package:typie/graphql/client.dart';
-import 'package:typie/hooks/service.dart';
 import 'package:typie/icons/lucide_light.dart';
-import 'package:typie/icons/typie.dart';
-import 'package:typie/screens/entity/__generated__/delete_entities_mutation.req.gql.dart';
 import 'package:typie/screens/entity/__generated__/entity_fragment.data.gql.dart';
-import 'package:typie/screens/entity/move_entity_modal.dart';
+import 'package:typie/screens/entity/multi_entities_menu.dart';
 import 'package:typie/widgets/tappable.dart';
 
 class SelectedEntitiesBar extends HookWidget {
@@ -35,13 +26,6 @@ class SelectedEntitiesBar extends HookWidget {
 
   @override
   Widget build(BuildContext context) {
-    final client = useService<GraphQLClient>();
-    final mixpanel = useService<Mixpanel>();
-
-    final folderCount = entities.where((e) => selectedItems.contains(e.id) && e.node.G__typename == 'Folder').length;
-    final postCount = entities.where((e) => selectedItems.contains(e.id) && e.node.G__typename == 'Post').length;
-    final canvasCount = entities.where((e) => selectedItems.contains(e.id) && e.node.G__typename == 'Canvas').length;
-
     return AnimatedPositioned(
       duration: const Duration(milliseconds: 200),
       curve: Curves.easeInOut,
@@ -88,79 +72,11 @@ class SelectedEntitiesBar extends HookWidget {
                   Tappable(
                     onTap: () async {
                       await context.showBottomSheet(
-                        child: BottomMenu(
-                          header: _BottomMenuHeader(
-                            selectedCount: selectedItems.length,
-                            folderCount: folderCount,
-                            postCount: postCount,
-                            canvasCount: canvasCount,
-                          ),
-                          items: [
-                            BottomMenuItem(
-                              icon: LucideLightIcons.folder_symlink,
-                              label: '다른 폴더로 옮기기',
-                              onTap: () async {
-                                unawaited(
-                                  mixpanel.track(
-                                    'move_entities_try',
-                                    properties: {'totalCount': selectedItems.length, 'via': 'selected_entities_bar'},
-                                  ),
-                                );
-                                await context.showBottomSheet(
-                                  intercept: true,
-                                  child: MoveEntityModal.multiple(
-                                    entities: entities.where((e) => selectedItems.contains(e.id)).toList(),
-                                    via: 'selected_entities_bar',
-                                    onMoved: onExitSelectionMode,
-                                  ),
-                                );
-                              },
-                            ),
-                            BottomMenuItem(
-                              icon: LucideLightIcons.trash,
-                              label: '삭제하기',
-                              onTap: () async {
-                                await context.showModal(
-                                  child: ConfirmModal(
-                                    title: '선택한 항목 삭제',
-                                    message: '선택한 ${selectedItems.length}개 항목을 삭제하시겠어요?',
-                                    confirmText: '삭제하기',
-                                    confirmTextColor: context.colors.textBright,
-                                    confirmBackgroundColor: context.colors.accentDanger,
-                                    onConfirm: () async {
-                                      try {
-                                        await client.request(
-                                          GEntityScreen_DeleteEntities_MutationReq(
-                                            (b) => b..vars.input.entityIds.addAll(selectedItems),
-                                          ),
-                                        );
-
-                                        unawaited(
-                                          mixpanel.track(
-                                            'delete_entities',
-                                            properties: {
-                                              'totalCount': selectedItems.length,
-                                              'via': 'selected_entities_bar',
-                                            },
-                                          ),
-                                        );
-
-                                        if (context.mounted) {
-                                          context.toast(ToastType.success, '${selectedItems.length}개의 항목이 삭제되었어요');
-                                        }
-
-                                        onExitSelectionMode();
-                                      } catch (_) {
-                                        if (context.mounted) {
-                                          context.toast(ToastType.error, '삭제 중 오류가 발생했습니다');
-                                        }
-                                      }
-                                    },
-                                  ),
-                                );
-                              },
-                            ),
-                          ],
+                        child: MultiEntitiesMenu(
+                          selectedItems: selectedItems,
+                          entities: entities,
+                          onExitSelectionMode: onExitSelectionMode,
+                          via: 'selected_entities_bar',
                         ),
                       );
                     },
@@ -179,69 +95,6 @@ class SelectedEntitiesBar extends HookWidget {
           ),
         ),
       ),
-    );
-  }
-}
-
-class _BottomMenuHeader extends StatelessWidget {
-  const _BottomMenuHeader({
-    required this.selectedCount,
-    required this.folderCount,
-    required this.postCount,
-    required this.canvasCount,
-  });
-
-  final int selectedCount;
-  final int folderCount;
-  final int postCount;
-  final int canvasCount;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Row(
-          spacing: 16,
-          children: [
-            const Icon(LucideLightIcons.square_check, size: 20),
-            Text('$selectedCount개 선택됨', style: const TextStyle(fontSize: 17, fontWeight: FontWeight.w600)),
-          ],
-        ),
-        if (folderCount > 0 || postCount > 0 || canvasCount > 0)
-          Padding(
-            padding: const Pad(left: 36, top: 4),
-            child: Row(
-              spacing: 12,
-              children: [
-                if (folderCount > 0)
-                  Row(
-                    spacing: 4,
-                    children: [
-                      Icon(TypieIcons.folder_filled, size: 14, color: context.colors.textSubtle),
-                      Text('$folderCount개', style: TextStyle(fontSize: 14, color: context.colors.textSubtle)),
-                    ],
-                  ),
-                if (postCount > 0)
-                  Row(
-                    spacing: 4,
-                    children: [
-                      Icon(LucideLightIcons.file, size: 14, color: context.colors.textSubtle),
-                      Text('$postCount개', style: TextStyle(fontSize: 14, color: context.colors.textSubtle)),
-                    ],
-                  ),
-                if (canvasCount > 0)
-                  Row(
-                    spacing: 4,
-                    children: [
-                      Icon(LucideLightIcons.line_squiggle, size: 14, color: context.colors.textSubtle),
-                      Text('$canvasCount개', style: TextStyle(fontSize: 14, color: context.colors.textSubtle)),
-                    ],
-                  ),
-              ],
-            ),
-          ),
-      ],
     );
   }
 }


### PR DESCRIPTION
- 웹과 구조 동일하게 함
- 멀티셀렉트 중 체크된 항목 롱프레스하면 기존 단일 엔티티 컨텍스트 메뉴 대신 MultiEntitiesMenu 뜸