### PR TITLE
앱 에디터 플로팅 툴바가 협업에 영향받지 않도록 함

### DIFF
--- a/apps/mobile/lib/screens/editor/editor.dart
+++ b/apps/mobile/lib/screens/editor/editor.dart
@@ -126,6 +126,8 @@ class Editor extends HookWidget {
             isReady.value = true;
           case 'setProseMirrorState':
             scope.proseMirrorState.value = ProseMirrorState.fromJson(event.data as Map<String, dynamic>);
+          case 'setLocalProseMirrorState':
+            scope.localProseMirrorState.value = ProseMirrorState.fromJson(event.data as Map<String, dynamic>);
           case 'setCharacterCountState':
             scope.characterCountState.value = CharacterCountState.fromJson(event.data as Map<String, dynamic>);
           case 'setYJSState':

--- a/apps/mobile/lib/screens/editor/scope.dart
+++ b/apps/mobile/lib/screens/editor/scope.dart
@@ -26,6 +26,7 @@ class EditorStateScope extends InheritedWidget {
     required this.data,
     required this.webViewController,
     required this.proseMirrorState,
+    required this.localProseMirrorState,
     required this.characterCountState,
     required this.yjsState,
     required this.keyboardHeight,
@@ -40,6 +41,7 @@ class EditorStateScope extends InheritedWidget {
   final ValueNotifier<GEditorScreen_QueryData?> data;
   final ValueNotifier<WebViewController?> webViewController;
   final ValueNotifier<ProseMirrorState?> proseMirrorState;
+  final ValueNotifier<ProseMirrorState?> localProseMirrorState;
   final ValueNotifier<CharacterCountState?> characterCountState;
   final ValueNotifier<YJSState?> yjsState;
   final ValueNotifier<double> keyboardHeight;

--- a/apps/mobile/lib/screens/editor/screen.dart
+++ b/apps/mobile/lib/screens/editor/screen.dart
@@ -23,6 +23,7 @@ class EditorScreen extends HookWidget {
     final data = useValueNotifier<GEditorScreen_QueryData?>(null);
     final webViewController = useValueNotifier<WebViewController?>(null);
     final proseMirrorState = useValueNotifier<ProseMirrorState?>(null);
+    final localProseMirrorState = useValueNotifier<ProseMirrorState?>(null);
     final characterCountState = useValueNotifier<CharacterCountState?>(null);
     final yjsState = useValueNotifier<YJSState?>(null);
     final keyboardHeight = useValueNotifier<double>(0);
@@ -45,6 +46,7 @@ class EditorScreen extends HookWidget {
       data: data,
       webViewController: webViewController,
       proseMirrorState: proseMirrorState,
+      localProseMirrorState: localProseMirrorState,
       characterCountState: characterCountState,
       yjsState: yjsState,
       keyboardHeight: keyboardHeight,

--- a/apps/mobile/lib/screens/editor/toolbar/floating/blockquote.dart
+++ b/apps/mobile/lib/screens/editor/toolbar/floating/blockquote.dart
@@ -13,7 +13,7 @@ class BlockquoteFloatingToolbar extends HookWidget {
     final scope = EditorStateScope.of(context);
     final webViewController = useValueListenable(scope.webViewController);
     final keyboardType = useValueListenable(scope.keyboardType);
-    final proseMirrorState = useValueListenable(scope.proseMirrorState);
+    final proseMirrorState = useValueListenable(scope.localProseMirrorState);
     final selected = proseMirrorState?.currentNode?.type == 'blockquote';
 
     return Row(

--- a/apps/mobile/lib/screens/editor/toolbar/floating/callout.dart
+++ b/apps/mobile/lib/screens/editor/toolbar/floating/callout.dart
@@ -18,7 +18,7 @@ class CalloutFloatingToolbar extends HookWidget {
   @override
   Widget build(BuildContext context) {
     final scope = EditorStateScope.of(context);
-    final proseMirrorState = useValueListenable(scope.proseMirrorState);
+    final proseMirrorState = useValueListenable(scope.localProseMirrorState);
     final selected = proseMirrorState?.currentNode?.type == 'callout';
 
     final currentType = proseMirrorState?.getNodeAttributes('callout')?['type'] as String? ?? 'info';

--- a/apps/mobile/lib/screens/editor/toolbar/floating/code.dart
+++ b/apps/mobile/lib/screens/editor/toolbar/floating/code.dart
@@ -10,7 +10,7 @@ class CodeFloatingToolbar extends HookWidget {
   @override
   Widget build(BuildContext context) {
     final scope = EditorStateScope.of(context);
-    final proseMirrorState = useValueListenable(scope.proseMirrorState);
+    final proseMirrorState = useValueListenable(scope.localProseMirrorState);
     final selected = proseMirrorState?.currentNode?.type == 'code_block';
 
     return Row(

--- a/apps/mobile/lib/screens/editor/toolbar/floating/embed.dart
+++ b/apps/mobile/lib/screens/editor/toolbar/floating/embed.dart
@@ -17,7 +17,7 @@ class EmbedFloatingToolbar extends HookWidget {
   Widget build(BuildContext context) {
     final client = useService<GraphQLClient>();
     final scope = EditorStateScope.of(context);
-    final proseMirrorState = useValueListenable(scope.proseMirrorState);
+    final proseMirrorState = useValueListenable(scope.localProseMirrorState);
 
     return Row(
       spacing: 8,

--- a/apps/mobile/lib/screens/editor/toolbar/floating/file.dart
+++ b/apps/mobile/lib/screens/editor/toolbar/floating/file.dart
@@ -21,7 +21,7 @@ class FileFloatingToolbar extends HookWidget {
     final client = useService<GraphQLClient>();
 
     final scope = EditorStateScope.of(context);
-    final proseMirrorState = useValueListenable(scope.proseMirrorState);
+    final proseMirrorState = useValueListenable(scope.localProseMirrorState);
 
     return Row(
       spacing: 8,

--- a/apps/mobile/lib/screens/editor/toolbar/floating/floating.dart
+++ b/apps/mobile/lib/screens/editor/toolbar/floating/floating.dart
@@ -19,7 +19,7 @@ class EditorFloatingToolbar extends HookWidget {
   @override
   Widget build(BuildContext context) {
     final scope = EditorStateScope.of(context);
-    final proseMirrorState = useValueListenable(scope.proseMirrorState);
+    final proseMirrorState = useValueListenable(scope.localProseMirrorState);
 
     if (proseMirrorState == null) {
       return const SizedBox.shrink();

--- a/apps/mobile/lib/screens/editor/toolbar/floating/fold.dart
+++ b/apps/mobile/lib/screens/editor/toolbar/floating/fold.dart
@@ -10,7 +10,7 @@ class FoldFloatingToolbar extends HookWidget {
   @override
   Widget build(BuildContext context) {
     final scope = EditorStateScope.of(context);
-    final proseMirrorState = useValueListenable(scope.proseMirrorState);
+    final proseMirrorState = useValueListenable(scope.localProseMirrorState);
     final selected = proseMirrorState?.currentNode?.type == 'fold';
 
     return Row(

--- a/apps/mobile/lib/screens/editor/toolbar/floating/html.dart
+++ b/apps/mobile/lib/screens/editor/toolbar/floating/html.dart
@@ -10,7 +10,7 @@ class HtmlFloatingToolbar extends HookWidget {
   @override
   Widget build(BuildContext context) {
     final scope = EditorStateScope.of(context);
-    final proseMirrorState = useValueListenable(scope.proseMirrorState);
+    final proseMirrorState = useValueListenable(scope.localProseMirrorState);
     final selected = proseMirrorState?.currentNode?.type == 'html_block';
 
     return Row(

--- a/apps/mobile/lib/screens/editor/toolbar/floating/image.dart
+++ b/apps/mobile/lib/screens/editor/toolbar/floating/image.dart
@@ -21,7 +21,7 @@ class ImageFloatingToolbar extends HookWidget {
     final client = useService<GraphQLClient>();
 
     final scope = EditorStateScope.of(context);
-    final proseMirrorState = useValueListenable(scope.proseMirrorState);
+    final proseMirrorState = useValueListenable(scope.localProseMirrorState);
 
     return Row(
       spacing: 8,

--- a/apps/mobile/lib/screens/editor/toolbar/floating/list.dart
+++ b/apps/mobile/lib/screens/editor/toolbar/floating/list.dart
@@ -10,7 +10,7 @@ class ListFloatingToolbar extends HookWidget {
   @override
   Widget build(BuildContext context) {
     final scope = EditorStateScope.of(context);
-    final proseMirrorState = useValueListenable(scope.proseMirrorState);
+    final proseMirrorState = useValueListenable(scope.localProseMirrorState);
 
     return Row(
       spacing: 8,

--- a/apps/mobile/lib/screens/editor/toolbar/floating/table.dart
+++ b/apps/mobile/lib/screens/editor/toolbar/floating/table.dart
@@ -10,7 +10,7 @@ class TableFloatingToolbar extends HookWidget {
   @override
   Widget build(BuildContext context) {
     final scope = EditorStateScope.of(context);
-    final proseMirrorState = useValueListenable(scope.proseMirrorState);
+    final proseMirrorState = useValueListenable(scope.localProseMirrorState);
     final selected = proseMirrorState?.currentNode?.type == 'table';
 
     return Row(

--- a/apps/website/src/lib/tiptap/extensions/node-id.ts
+++ b/apps/website/src/lib/tiptap/extensions/node-id.ts
@@ -2,6 +2,7 @@ import { combineTransactionSteps, Extension, findChildren, findChildrenInRange, 
 import { Fragment, Node as ProseMirrorNode, Slice } from '@tiptap/pm/model';
 import { Plugin, Transaction } from '@tiptap/pm/state';
 import { nanoid } from 'nanoid';
+import { ySyncPluginKey } from 'y-prosemirror';
 
 const generateId = () => nanoid(32);
 const types = [
@@ -79,7 +80,7 @@ export const NodeId = Extension.create({
       new Plugin({
         appendTransaction: (transactions, oldState, newState) => {
           const docChanged = transactions.some((tr) => tr.docChanged) && !oldState.doc.eq(newState.doc);
-          const ySync = transactions.find((tr) => tr.getMeta('y-sync$'));
+          const ySync = transactions.find((tr) => tr.getMeta(ySyncPluginKey));
 
           if (!docChanged || ySync) {
             return;

--- a/apps/website/src/lib/tiptap/menus/slash/extension.svelte.ts
+++ b/apps/website/src/lib/tiptap/menus/slash/extension.svelte.ts
@@ -5,6 +5,7 @@ import { disassemble } from 'es-hangul';
 import { matchSorter } from 'match-sorter';
 import { mount, unmount } from 'svelte';
 import { SvelteSet } from 'svelte/reactivity';
+import { ySyncPluginKey } from 'y-prosemirror';
 import { css } from '$styled-system/css';
 import { token } from '$styled-system/tokens';
 import Component from './Component.svelte';
@@ -49,7 +50,7 @@ export const SlashMenu = Extension.create({
               return prev;
             }
 
-            if (tr.getMeta('y-sync$') || tr.getMeta('y-origin')) {
+            if (tr.getMeta(ySyncPluginKey)) {
               return { active: false };
             }
 


### PR DESCRIPTION
- 원격에서 수정 또는 셀렉션 변화 일어나면 원격에서의 셀렉션을 포함해서 proseMirrorState가 갱신되고 앱으로 emit됨. 앱에선 그것을 기준으로 플로팅 툴바를 띄우고 있었음. 원격 트랜잭션 이외의 것만 localProseMirrorState로 emit하고 그걸 사용하도록 함.
- 모든 곳에서 `y-sync$` 문자열 대신 ySyncPluginKey 사용함. vite? svelte? 어딘가에서 $ 때문에 뭔가 깨짐