### PR TITLE
expand and drag selection

### DIFF
--- a/packages/ui/src/tiptap/extensions/behavior.ts
+++ b/packages/ui/src/tiptap/extensions/behavior.ts
@@ -1,10 +1,10 @@
 import { Extension } from '@tiptap/core';
 import { Plugin } from '@tiptap/pm/state';
 import { Table } from '../node-views';
-import { TEXT_NODE_TYPES, WRAPPING_NODE_NAMES } from './node-commands';
+import { TEXT_NODE_TYPES, WRAPPING_NODE_TYPES } from './node-commands';
 
 const arrayOrNull = <T>(array: T[] | readonly T[] | null | undefined) => (array?.length ? array : null);
-const NODE_TYPES_TO_SELECT_ON_BACKSPACE = [...WRAPPING_NODE_NAMES, Table.name, ...TEXT_NODE_TYPES];
+const NODE_TYPES_TO_SELECT_ON_BACKSPACE = [...WRAPPING_NODE_TYPES, Table.name, ...TEXT_NODE_TYPES];
 
 export const Behavior = Extension.create({
   name: 'behavior',


### PR DESCRIPTION
- mod-a 로 선택 영역이 계속 확장됨. 중첩된 wrapping node에서 유용함
- selection이 있으면 Left는 그것에 대한 드래그 그립과 해제 버튼을 제공함. 중첩된 노드를 쉽게 옮기거나 해제할 수 있음
- 해제 버튼(unwrap) 디버그. 첫 문단만 해제되는 버그 있었음
- wrapping node의 내부 콘텐츠 셀렉션 드래그해서 옮길 때 unwrap한 콘텐츠만 옮김
- code, html 블록의 내부 텍스트 드래그해서 옮길 때 텍스트만 옮김

그런데 wrapping node 들 콘텐츠가 `paragraph+` 나 `block+`라서 내용 꺼내서 내용이 비면 wrapping node가 사라지는데 이게 굉장히 어색하게 보이는 문제가 있음