### PR TITLE
페이지뷰에서 플로팅이 제대로 뜨도록 함

### DIFF
--- a/packages/ui/src/tiptap/extensions/page.ts
+++ b/packages/ui/src/tiptap/extensions/page.ts
@@ -102,35 +102,39 @@ export const Page = Extension.create<unknown, PageStorage>({
             const decorations: Decoration[] = [];
 
             for (const [i, { pos, height }] of pages.entries()) {
-              const widget = Decoration.widget(pos, () => {
-                const element = document.createElement('div');
+              const widget = Decoration.widget(
+                pos,
+                () => {
+                  const element = document.createElement('div');
 
-                element.className = css({
-                  position: 'relative',
-                  height: '40px',
-                  backgroundColor: 'surface.muted',
-                });
+                  element.className = css({
+                    position: 'relative',
+                    height: '40px',
+                    backgroundColor: 'surface.muted',
+                  });
 
-                element.style.cssText = `margin: ${MARGIN_PX + (PAGE_HEIGHT_PX - MARGIN_PX * 2 - height)}px -${MARGIN_PX}px ${i === pages.length - 1 ? 0 : MARGIN_PX}px -${MARGIN_PX}px`;
+                  element.style.cssText = `margin: ${MARGIN_PX + (PAGE_HEIGHT_PX - MARGIN_PX * 2 - height)}px -${MARGIN_PX}px ${i === pages.length - 1 ? 0 : MARGIN_PX}px -${MARGIN_PX}px`;
 
-                const label = document.createElement('span');
-                label.textContent = `페이지 ${i + 1} / ${pages.length}`;
-                label.className = css({
-                  position: 'absolute',
-                  top: '-32px',
-                  right: '20px',
-                  fontSize: '12px',
-                  color: 'text.faint',
-                  userSelect: 'none',
-                });
-                element.append(label);
+                  const label = document.createElement('span');
+                  label.textContent = `페이지 ${i + 1} / ${pages.length}`;
+                  label.className = css({
+                    position: 'absolute',
+                    top: '-32px',
+                    right: '20px',
+                    fontSize: '12px',
+                    color: 'text.faint',
+                    userSelect: 'none',
+                  });
+                  element.append(label);
 
-                const fill = document.createElement('div');
-                fill.className = css({ position: 'absolute', inset: '0' });
-                element.append(fill);
+                  const fill = document.createElement('div');
+                  fill.className = css({ position: 'absolute', inset: '0' });
+                  element.append(fill);
 
-                return element;
-              });
+                  return element;
+                },
+                { side: -1 },
+              );
 
               decorations.push(widget);
             }

--- a/packages/ui/src/tiptap/menus/floating/extension.svelte.ts
+++ b/packages/ui/src/tiptap/menus/floating/extension.svelte.ts
@@ -284,7 +284,7 @@ export const FloatingMenu = Extension.create({
               const width = body.getBoundingClientRect().width;
 
               const posAtCoords = view.posAtCoords({ left: left + width / 2, top: event.clientY });
-              if (!posAtCoords) {
+              if (!posAtCoords || posAtCoords.inside <= 0) {
                 const updateFn = (view as ViewWithUpdate).__updateFloatingMenu;
                 if (updateFn) {
                   updateFn(view, null);
@@ -292,7 +292,8 @@ export const FloatingMenu = Extension.create({
                 return false;
               }
 
-              const pos = posAtCoords.inside <= 0 ? posAtCoords.pos : posAtCoords.inside;
+              const pos = posAtCoords.inside;
+
               const resolvedPos = view.state.doc.resolve(pos);
 
               let newPos: number | null = null;


### PR DESCRIPTION
- 페이지 위아래 여백에서 floating 안 뜨도록 함
- 페이지 break 위젯? 다음에 나오는 노드의 floating이 이상한 곳에 뜨는 문제 해결. `{side: -1}`