### PR TITLE
editor mount 전에 dom에 접근하지 않도록 함

### DIFF
--- a/packages/ui/src/tiptap/extensions/page.ts
+++ b/packages/ui/src/tiptap/extensions/page.ts
@@ -89,7 +89,7 @@ export const Page = Extension.create<unknown, PageStorage>({
               return { decorations: DecorationSet.empty, pages: 0 };
             }
 
-            if (!editor.view?.dom?.isConnected) {
+            if (!editor.view || !('dom' in editor.view)) {
               return {
                 decorations: value.decorations.map(tr.mapping, tr.doc),
                 pages: value.pages,


### PR DESCRIPTION
기존 조건식에서는 view.dom에 접근할 때
`Uncaught (in promise) Error: [tiptap error]: The editor view is not available. Cannot access view['dom']. The editor may not be mounted yet.`
에러가 발생

`editor.isInitialized`를 쓸 수도 있지만 `'dom' in view`가 true가 되는 시점이 더 빠르면서도 충분히 안전