### PR TITLE
앱 액티비티 그리드 사용성 개선

### DIFF
--- a/apps/mobile/lib/screens/profile/screen.dart
+++ b/apps/mobile/lib/screens/profile/screen.dart
@@ -92,12 +92,15 @@ class ProfileScreen extends StatelessWidget {
                     borderRadius: BorderRadius.circular(8),
                     color: context.colors.surfaceDefault,
                   ),
-                  padding: const Pad(all: 16),
+                  padding: const Pad(vertical: 16),
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     spacing: 12,
                     children: [
-                      const Text('나의 글쓰기 활동', style: TextStyle(fontSize: 16, fontWeight: FontWeight.w500)),
+                      const Padding(
+                        padding: Pad(horizontal: 16),
+                        child: Text('나의 글쓰기 활동', style: TextStyle(fontSize: 16, fontWeight: FontWeight.w500)),
+                      ),
                       ActivityGrid(characterCountChanges: data.me?.characterCountChanges.toList() ?? []),
                     ],
                   ),


### PR DESCRIPTION
- '손으로 훑을' 수 있다
- 좌우 캐럿으로 2달씩 스크롤
- 월 레이블을 드래그해서 스크롤 가능
- 월 레이블을 탭하면 해당 월로 이동