### PR TITLE
PDF export 마지막 페이지 짧게 렌더링되는 문제 해결 등

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -99,6 +99,7 @@
     "@typie/pulumi": "workspace:*",
     "@typie/rps": "workspace:*",
     "drizzle-kit": "^0.31.4",
+    "pdf-lib": "^1.17.1",
     "react-email": "^4.2.8",
     "tsup": "^8.5.0"
   }

--- a/apps/website/src/routes/website/_internal/export/pdf/[slug]/+page.svelte
+++ b/apps/website/src/routes/website/_internal/export/pdf/[slug]/+page.svelte
@@ -78,7 +78,7 @@
 
 {#if post}
   {#if pageLayout.width && pageLayout.height}
-    <div style:height={`${pageLayout.height}mm`} class={cx('page-export-viewport', css({ overflowY: 'scroll' }))}>
+    <div style:height={`${pageLayout.height}mm`} class={cx('page-export-viewport', css({ overflowY: 'hidden' }))}>
       <TiptapRenderer
         style={css.raw({ size: 'full' })}
         content={{

--- a/packages/ui/src/tiptap/extensions/page.ts
+++ b/packages/ui/src/tiptap/extensions/page.ts
@@ -268,18 +268,16 @@ function createDecoration(_state: EditorState, pageOptions: PageLayout, forPdf?:
 
         const pageBackground = document.createElement('div');
         pageBackground.className = 'page-background';
-        if (!forPdf) {
-          pageBackground.style.cssText = `
-            position: absolute;
-            top: ${i * (PAGE_HEIGHT_PX + GAP) - MARGIN_TOP_PX}px;
-            left: -${MARGIN_LEFT_PX}px;
-            z-index: -1;
-            width: ${PAGE_WIDTH_PX}px;
-            height: ${PAGE_HEIGHT_PX}px;
-            background-color: ${token('colors.surface.default')};
-            box-shadow: ${token('shadows.medium')};
-          `;
-        }
+        pageBackground.style.cssText = `
+          position: absolute;
+          top: ${i * (PAGE_HEIGHT_PX + GAP) - MARGIN_TOP_PX}px;
+          left: -${MARGIN_LEFT_PX}px;
+          z-index: -1;
+          width: ${PAGE_WIDTH_PX}px;
+          height: ${PAGE_HEIGHT_PX}px;
+          background-color: ${token('colors.surface.default')};
+          box-shadow: ${forPdf ? 'none' : token('shadows.medium')};
+        `;
 
         const breaker = document.createElement('div');
         breaker.className = 'breaker';
@@ -336,9 +334,7 @@ function createDecoration(_state: EditorState, pageOptions: PageLayout, forPdf?:
         }
         breaker.append(pageHeader);
 
-        if (!forPdf) {
-          pageBreak.append(pageBackground);
-        }
+        pageBreak.append(pageBackground);
         pageBreak.append(page);
         pageBreak.append(breaker);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,6 +300,9 @@ importers:
       drizzle-kit:
         specifier: ^0.31.4
         version: 0.31.4
+      pdf-lib:
+        specifier: ^1.17.1
+        version: 1.17.1
       react-email:
         specifier: ^4.2.8
         version: 4.2.8
@@ -3723,6 +3726,12 @@ packages:
 
   '@paralleldrive/cuid2@2.2.2':
     resolution: {integrity: sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==}
+
+  '@pdf-lib/standard-fonts@1.0.0':
+    resolution: {integrity: sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==}
+
+  '@pdf-lib/upng@1.0.1':
+    resolution: {integrity: sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==}
 
   '@phc/format@1.0.0':
     resolution: {integrity: sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==}
@@ -8604,6 +8613,9 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
+  pdf-lib@1.17.1:
+    resolution: {integrity: sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==}
+
   peberminta@0.9.0:
     resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
 
@@ -9887,6 +9899,9 @@ packages:
   tsconfig-paths@4.2.0:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
     engines: {node: '>=6'}
+
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -13634,6 +13649,14 @@ snapshots:
   '@paralleldrive/cuid2@2.2.2':
     dependencies:
       '@noble/hashes': 1.8.0
+
+  '@pdf-lib/standard-fonts@1.0.0':
+    dependencies:
+      pako: 1.0.11
+
+  '@pdf-lib/upng@1.0.1':
+    dependencies:
+      pako: 1.0.11
 
   '@phc/format@1.0.0': {}
 
@@ -19162,6 +19185,13 @@ snapshots:
 
   pathval@2.0.1: {}
 
+  pdf-lib@1.17.1:
+    dependencies:
+      '@pdf-lib/standard-fonts': 1.0.0
+      '@pdf-lib/upng': 1.0.1
+      pako: 1.0.11
+      tslib: 1.14.1
+
   peberminta@0.9.0: {}
 
   peek-readable@4.1.0: {}
@@ -20615,6 +20645,8 @@ snapshots:
       json5: 2.2.3
       minimist: 1.2.8
       strip-bom: 3.0.0
+
+  tslib@1.14.1: {}
 
   tslib@2.8.1: {}
 


### PR DESCRIPTION
- page extension에서 PDF용으로도 페이지 배경을 항상 그림. 그려주지 않으면 마지막 페이지가 짧게 렌더링되어 PDF에서 마지막 페이지에 마지막 직전 페이지의 아랫부분이 보임
- 로컬에서는 pdf-lib로 PDF를 병합함. 용량이 크다는 문제가 있지만 어째선지 로컬에서는 ghostscript로 병합하면 이미지가 날아감
- `.page-export-viewport` scroll 말고 hidden으로 함. 일부 상황에서 스크롤바가 PDF에 찍히는 문제가 있음