### PR TITLE
업로드 직후 이미지 처음 PDF 익스포트할 때 페이지 잘리는 문제 디버그

### DIFF
--- a/packages/ui/src/components/Img.svelte
+++ b/packages/ui/src/components/Img.svelte
@@ -105,6 +105,19 @@
       {/if}
     </div>
   {:else}
-    <img class={css(style)} {alt} {sizes} {src} {srcset} {...rest} />
+    <img
+      class={css(style)}
+      {alt}
+      {sizes}
+      {src}
+      {srcset}
+      {...rest}
+      onload={() => {
+        loaded = true;
+      }}
+    />
+    {#if !loaded && placeholderUrl}
+      <img class={css(style, { size: 'full', objectFit: 'cover' })} src={placeholderUrl} {...rest} />
+    {/if}
   {/if}
 {/key}

--- a/packages/ui/src/tiptap/extensions/notify-idle.ts
+++ b/packages/ui/src/tiptap/extensions/notify-idle.ts
@@ -1,5 +1,6 @@
 import { Extension } from '@tiptap/core';
 import { Plugin } from '@tiptap/pm/state';
+import { tick } from 'svelte';
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -17,8 +18,10 @@ export const NotifyIdle = Extension.create({
         view() {
           return {
             update() {
-              requestIdleCallback(() => {
-                window.notifyIdle?.();
+              tick().then(() => {
+                requestIdleCallback(() => {
+                  window.notifyIdle?.();
+                });
               });
             },
           };


### PR DESCRIPTION
progressive=false일 때 img 가 아직 로드되지 않아서 size를 가지고있지 않을 때 page extension이 계산을 마쳐버림
그 뒤 이미지가 로드되어 크기를 차지하게 되어도 page extension이 재계산을 하지 않아서 PDF export 시 뒷부분이 조금 잘림
이 버그는 두번째 export부터는 발생하지 않음
load되지 않았을 때 placeholder가 있으면 띄워서 사이즈를 차지하게 함