### PR TITLE
앱 글자 수 위젯

### DIFF
--- a/apps/mobile/lib/screens/editor/editor.dart
+++ b/apps/mobile/lib/screens/editor/editor.dart
@@ -29,6 +29,7 @@ import 'package:typie/screens/editor/__generated__/editor_query.req.gql.dart';
 import 'package:typie/screens/editor/__generated__/update_post_type_mutation.req.gql.dart';
 import 'package:typie/screens/editor/anchor.dart';
 import 'package:typie/screens/editor/find_replace.dart';
+import 'package:typie/screens/editor/floating/widgets/character_count_floating.dart';
 import 'package:typie/screens/editor/limit.dart';
 import 'package:typie/screens/editor/schema.dart';
 import 'package:typie/screens/editor/scope.dart';
@@ -485,6 +486,7 @@ class Editor extends HookWidget {
                               scope.webViewController.value = controller;
                             },
                           ),
+                          if (pref.characterCountFloatingEnabled) const CharacterCountFloating(),
                           const Positioned(bottom: 20, right: 20, child: EditorFloatingToolbar()),
                         ],
                       ),

--- a/apps/mobile/lib/screens/editor/floating/editor_floating_widget.dart
+++ b/apps/mobile/lib/screens/editor/floating/editor_floating_widget.dart
@@ -1,0 +1,169 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+class EditorFloatingWidget extends HookWidget {
+  const EditorFloatingWidget({
+    required this.child,
+    required this.storageKey,
+    required this.onPositionChanged,
+    this.initialOffset,
+    this.isExpanded = false,
+    this.onExpansionChanged,
+    super.key,
+  });
+
+  final Widget child;
+  final String storageKey;
+  final void Function(Offset position) onPositionChanged;
+  final Offset? initialOffset;
+  final bool isExpanded;
+  final VoidCallback? onExpansionChanged;
+
+  Offset _adjustPositionWithinBounds({
+    required Offset currentPosition,
+    required Size widgetSize,
+    required Size containerSize,
+  }) {
+    var newX = currentPosition.dx;
+    var newY = currentPosition.dy;
+
+    if (newX < 0) {
+      newX = 0;
+    } else if (newX + widgetSize.width > containerSize.width) {
+      newX = containerSize.width - widgetSize.width;
+    }
+
+    if (newY < 0) {
+      newY = 0;
+    } else if (newY + widgetSize.height > containerSize.height) {
+      newY = containerSize.height - widgetSize.height;
+    }
+
+    return Offset(newX, newY);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // NOTE: 키보드 등 레이아웃 변화 감지
+    MediaQuery.of(context);
+
+    final widgetKey = useMemoized(GlobalKey.new);
+    final widgetSize = useState<Size?>(null);
+    final position = useState(initialOffset ?? const Offset(20, 20));
+    final previousEditorSize = useState<Size?>(null);
+    final isDragging = useState(false);
+
+    final originalPosition = useState<Offset?>(null);
+    final hasDragged = useState(false);
+    final wasExpanded = useState(false);
+
+    // NOTE: 확장 상태 변화 감지
+    useEffect(() {
+      if (isExpanded && !wasExpanded.value) {
+        originalPosition.value = position.value;
+        hasDragged.value = false;
+        wasExpanded.value = true;
+
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          final renderBox = widgetKey.currentContext?.findRenderObject() as RenderBox?;
+          final editorContainer = context.findAncestorRenderObjectOfType<RenderBox>();
+
+          if (renderBox != null && editorContainer != null && renderBox.hasSize && editorContainer.hasSize) {
+            final adjustedPosition = _adjustPositionWithinBounds(
+              currentPosition: position.value,
+              widgetSize: renderBox.size,
+              containerSize: editorContainer.size,
+            );
+
+            if (adjustedPosition != position.value) {
+              position.value = adjustedPosition;
+            }
+          }
+        });
+      } else if (!isExpanded && wasExpanded.value) {
+        if (!hasDragged.value && originalPosition.value != null) {
+          position.value = originalPosition.value!;
+        }
+        originalPosition.value = null;
+        hasDragged.value = false;
+        wasExpanded.value = false;
+      }
+      return null;
+    }, [isExpanded]);
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final renderBox = widgetKey.currentContext?.findRenderObject() as RenderBox?;
+      if (renderBox != null && renderBox.hasSize) {
+        widgetSize.value = renderBox.size;
+      }
+
+      final editorContainer = context.findAncestorRenderObjectOfType<RenderBox>();
+      if (editorContainer != null && editorContainer.hasSize) {
+        final currentEditorSize = editorContainer.size;
+        final currentWidgetSize = widgetSize.value ?? const Size(120, 40);
+
+        // NOTE: 부모 크기가 변경되었을 때 상대 위치 유지
+        if (previousEditorSize.value != null && previousEditorSize.value != currentEditorSize) {
+          final oldHeight = previousEditorSize.value!.height;
+          final newHeight = currentEditorSize.height;
+
+          if (oldHeight > 0 && newHeight > 0) {
+            final yPercentage = position.value.dy / oldHeight;
+            final newY = yPercentage * newHeight;
+
+            position.value = _adjustPositionWithinBounds(
+              currentPosition: Offset(position.value.dx, newY),
+              widgetSize: currentWidgetSize,
+              containerSize: currentEditorSize,
+            );
+          }
+        } else if (previousEditorSize.value == null) {
+          // NOTE: 초기 로드 시 위치 조정
+          position.value = _adjustPositionWithinBounds(
+            currentPosition: position.value,
+            widgetSize: currentWidgetSize,
+            containerSize: currentEditorSize,
+          );
+        }
+
+        previousEditorSize.value = currentEditorSize;
+      }
+    });
+
+    return AnimatedPositioned(
+      duration: isDragging.value ? Duration.zero : const Duration(milliseconds: 250),
+      curve: Curves.easeOutCubic,
+      left: position.value.dx,
+      top: position.value.dy,
+      child: GestureDetector(
+        onPanStart: (_) {
+          isDragging.value = true;
+        },
+        onPanUpdate: (details) {
+          hasDragged.value = true;
+
+          final editorContainer = context.findAncestorRenderObjectOfType<RenderBox>();
+
+          if (widgetSize.value == null || editorContainer == null || !editorContainer.hasSize) {
+            return;
+          }
+
+          final newPosition = Offset(position.value.dx + details.delta.dx, position.value.dy + details.delta.dy);
+
+          final adjustedPosition = _adjustPositionWithinBounds(
+            currentPosition: newPosition,
+            widgetSize: widgetSize.value!,
+            containerSize: editorContainer.size,
+          );
+
+          position.value = adjustedPosition;
+          onPositionChanged(adjustedPosition);
+        },
+        onPanEnd: (_) {
+          isDragging.value = false;
+        },
+        child: KeyedSubtree(key: widgetKey, child: child),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/screens/editor/floating/widgets/character_count_floating.dart
+++ b/apps/mobile/lib/screens/editor/floating/widgets/character_count_floating.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:typie/context/theme.dart';
+import 'package:typie/extensions/num.dart';
+import 'package:typie/hooks/service.dart';
+import 'package:typie/icons/lucide_light.dart';
+import 'package:typie/screens/editor/floating/editor_floating_widget.dart';
+import 'package:typie/screens/editor/scope.dart';
+import 'package:typie/services/preference.dart';
+
+class CharacterCountFloating extends HookWidget {
+  const CharacterCountFloating({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final scope = EditorStateScope.of(context);
+    final characterCountState = useValueListenable(scope.characterCountState);
+    final pref = useService<Pref>();
+
+    final isExpanded = useState(false);
+
+    if (characterCountState == null) {
+      return const SizedBox.shrink();
+    }
+
+    final savedPosition = pref.characterCountFloatingPosition;
+    final initialOffset = savedPosition != null
+        ? Offset(savedPosition['x'] ?? 20, savedPosition['y'] ?? 20)
+        : const Offset(20, 20);
+
+    return EditorFloatingWidget(
+      storageKey: 'character_count',
+      initialOffset: initialOffset,
+      isExpanded: isExpanded.value,
+      onPositionChanged: (position) {
+        pref.characterCountFloatingPosition = {'x': position.dx, 'y': position.dy};
+      },
+      child: GestureDetector(
+        onTap: () {
+          isExpanded.value = !isExpanded.value;
+        },
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+          decoration: BoxDecoration(
+            color: context.colors.surfaceSubtle.withValues(alpha: 0.95),
+            border: Border.all(color: context.colors.borderDefault),
+            borderRadius: BorderRadius.circular(16),
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(LucideLightIcons.type_, size: 14, color: context.colors.textSubtle),
+                  const SizedBox(width: 6),
+                  Text(
+                    '${characterCountState.countWithWhitespace.comma}자',
+                    style: TextStyle(fontSize: 15, fontWeight: FontWeight.w600, color: context.colors.textDefault),
+                  ),
+                  const SizedBox(width: 8),
+                  AnimatedRotation(
+                    turns: isExpanded.value ? 0.25 : 0,
+                    duration: const Duration(milliseconds: 200),
+                    child: Icon(LucideLightIcons.chevron_right, size: 14, color: context.colors.textSubtle),
+                  ),
+                ],
+              ),
+              if (isExpanded.value) ...[
+                const SizedBox(height: 8),
+                _buildCountRow(label: '공백 미포함', count: characterCountState.countWithoutWhitespace, context: context),
+                const SizedBox(height: 4),
+                _buildCountRow(
+                  label: '공백/부호 미포함',
+                  count: characterCountState.countWithoutWhitespaceAndPunctuation,
+                  context: context,
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCountRow({required String label, required int count, required BuildContext context}) {
+    return Text('$label: ${count.comma}자', style: TextStyle(fontSize: 13, color: context.colors.textSubtle));
+  }
+}

--- a/apps/mobile/lib/screens/editor_settings/screen.dart
+++ b/apps/mobile/lib/screens/editor_settings/screen.dart
@@ -133,6 +133,35 @@ class EditorSettingsScreen extends HookWidget {
                 ),
               ],
             ),
+            _Section(
+              title: '위젯 설정',
+              children: [
+                HookForm(
+                  submitMode: HookFormSubmitMode.onChange,
+                  onSubmit: (form) async {
+                    final characterCountFloatingEnabled = form.data['characterCountFloatingEnabled'] as bool;
+                    pref.characterCountFloatingEnabled = characterCountFloatingEnabled;
+
+                    unawaited(
+                      mixpanel.track(
+                        'toggle_character_count_floating',
+                        properties: {'enabled': characterCountFloatingEnabled},
+                      ),
+                    );
+                  },
+                  builder: (context, form) {
+                    return _Item(
+                      label: '글자 수 위젯',
+                      description: '에디터에서 글자 수를 표시합니다.',
+                      trailing: HookFormSwitch(
+                        name: 'characterCountFloatingEnabled',
+                        initialValue: pref.characterCountFloatingEnabled,
+                      ),
+                    );
+                  },
+                ),
+              ],
+            ),
           ],
         ),
       ),

--- a/apps/mobile/lib/services/preference.dart
+++ b/apps/mobile/lib/services/preference.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:hive_ce/hive.dart';
 import 'package:injectable/injectable.dart';
 import 'package:typie/services/kv.dart';
@@ -28,4 +30,24 @@ class Pref {
 
   bool get lineHighlightEnabled => _box.get('line_highlight_enabled', defaultValue: true) as bool;
   set lineHighlightEnabled(bool value) => _box.put('line_highlight_enabled', value);
+
+  Map<String, double>? get characterCountFloatingPosition {
+    final data = _box.get('character_count_floating_position');
+    if (data == null) {
+      return null;
+    }
+
+    return Map<String, double>.from(data as Map);
+  }
+
+  set characterCountFloatingPosition(Map<String, double>? value) {
+    if (value == null) {
+      unawaited(_box.delete('character_count_floating_position'));
+    } else {
+      unawaited(_box.put('character_count_floating_position', value));
+    }
+  }
+
+  bool get characterCountFloatingEnabled => _box.get('character_count_floating_enabled', defaultValue: false) as bool;
+  set characterCountFloatingEnabled(bool value) => _box.put('character_count_floating_enabled', value);
 }


### PR DESCRIPTION
- 에디터 설정에서 '글자 수 위젯' 켜기
- 위젯은 드래그해서 옮길 수 있고 마지막 위치는 저장됨
- 키보드 열리고 닫힐 때 위젯의 에디터 내 상대 높이가 유지됨
- 탭해서 확장하면 공백 미포함, 공백/부호 미포함 글자수도 볼 수 있음
- 확장 후 드래그하지 않았다면 축소 후 원래 위치로 돌아감 (오른쪽 끝에 붙였을 때 유용)

<img width="1179" height="2556" alt="simulator_screenshot_5981701E-7F9F-4770-80E9-1B896EE951FA" src="https://github.com/user-attachments/assets/f00d639b-8e25-4a59-afd6-e6e03bda1bbc" />
