### PR TITLE
모달과 Menu 단축키 충돌 해결 등

### DIFF
--- a/apps/website/src/routes/website/(dashboard)/@context-menu/PdfExportModal.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@context-menu/PdfExportModal.svelte
@@ -91,6 +91,7 @@
         <div class={flex({ justifyContent: 'space-between', alignItems: 'center', gap: '32px' })}>
           <div class={css({ fontSize: '14px', color: 'text.subtle' })}>페이지 크기</div>
           <Select
+            disabled={useCurrentSettings}
             items={PAGE_LAYOUT_OPTIONS}
             onselect={(value: PageLayoutSize) => {
               pageSize = value;
@@ -108,6 +109,7 @@
               <TextInput
                 id="margin-top"
                 style={css.raw({ width: 'full' })}
+                disabled={useCurrentSettings}
                 max={String(getMaxMargin('top', pageSize, margins))}
                 min="0"
                 oninput={(e) => {
@@ -126,6 +128,7 @@
               <TextInput
                 id="margin-bottom"
                 style={css.raw({ width: 'full' })}
+                disabled={useCurrentSettings}
                 max={String(getMaxMargin('bottom', pageSize, margins))}
                 min="0"
                 oninput={(e) => {
@@ -144,6 +147,7 @@
               <TextInput
                 id="margin-left"
                 style={css.raw({ width: 'full' })}
+                disabled={useCurrentSettings}
                 max={String(getMaxMargin('left', pageSize, margins))}
                 min="0"
                 oninput={(e) => {
@@ -162,6 +166,7 @@
               <TextInput
                 id="margin-right"
                 style={css.raw({ width: 'full' })}
+                disabled={useCurrentSettings}
                 max={String(getMaxMargin('right', pageSize, margins))}
                 min="0"
                 oninput={(e) => {

--- a/packages/ui/src/components/Modal.svelte
+++ b/packages/ui/src/components/Modal.svelte
@@ -39,7 +39,7 @@
     use:focusTrap={{
       fallbackFocus: '[role="none"]',
       escapeDeactivates: false,
-      returnFocusOnDeactivate: false,
+      returnFocusOnDeactivate: true,
       allowOutsideClick: true, // NOTE: downloadFromBase64 등 외부 클릭 허용
     }}
     use:portal

--- a/packages/ui/src/components/Select.svelte
+++ b/packages/ui/src/components/Select.svelte
@@ -19,11 +19,12 @@
       description?: string;
       value: T;
     }[];
+    disabled?: boolean;
     onselect?: (value: T) => void;
     chevron?: boolean;
   };
 
-  let { style, value = $bindable(), values, items = [], onselect, chevron = true }: Props = $props();
+  let { style, value = $bindable(), values, items = [], disabled, onselect, chevron = true }: Props = $props();
 
   const selectedValues = $derived(values ?? [value]);
   const isIndeterminate = $derived(selectedValues.some((v) => selectedValues[0] !== v));
@@ -42,7 +43,7 @@
   );
 </script>
 
-<Menu disableAutoUpdate listStyle={css.raw({ minWidth: '[initial]', maxWidth: '240px' })} offset={4} placement="bottom-end">
+<Menu disableAutoUpdate {disabled} listStyle={css.raw({ minWidth: '[initial]', maxWidth: '240px' })} offset={4} placement="bottom-end">
   {#snippet button({ open }: { open: boolean })}
     <button
       class={cx(
@@ -58,11 +59,22 @@
             transition: 'common',
             _hover: { backgroundColor: 'surface.muted' },
             _expanded: { backgroundColor: 'surface.muted' },
+            _disabled: {
+              opacity: '70',
+            },
           },
           style,
         ),
       )}
+      aria-disabled={disabled}
       aria-expanded={open}
+      {disabled}
+      onclick={() => {
+        if (disabled) {
+          return;
+        }
+      }}
+      tabindex={disabled ? -1 : 0}
       type="button"
     >
       {#if displayItem}


### PR DESCRIPTION
- Menu 단축키는 메뉴 또는 메뉴 트리거 버튼에 포커스가 있을 때만 동작하게 함
- Modal focus trap `returnFocusOnDeactivate: true`
- PDF export 모달에서 disabled 필드에 포커스할 수 없도록 함
- Menu와 Select가 disabled prop을 받아 쓰도록 함