### PR TITLE
페이지 크기 커스텀 가능, 페이지 모드 실험실에서 뺌

### DIFF
--- a/apps/website/src/routes/website/(dashboard)/@context-menu/PdfExportModal.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@context-menu/PdfExportModal.svelte
@@ -1,23 +1,25 @@
 <script lang="ts">
   import { css } from '@typie/styled-system/css';
-  import { center, flex, grid } from '@typie/styled-system/patterns';
+  import { flex, grid } from '@typie/styled-system/patterns';
   import { Button, Checkbox, HorizontalDivider, Icon, Modal, Select, TextInput } from '@typie/ui/components';
   import { getAppContext } from '@typie/ui/context';
-  import { clamp, DEFAULT_PAGE_MARGINS, getMaxMargin, PAGE_LAYOUT_OPTIONS } from '@typie/ui/utils';
+  import { clamp, createDefaultPageLayout, getMaxMargin, PAGE_LAYOUT_OPTIONS, PAGE_SIZE_MAP } from '@typie/ui/utils';
   import { ExportLayoutMode } from '@/enums';
   import FileIcon from '~icons/lucide/file';
+  import MoveHorizontalIcon from '~icons/lucide/move-horizontal';
+  import MoveVerticalIcon from '~icons/lucide/move-vertical';
   import PanelBottomDashedIcon from '~icons/lucide/panel-bottom-dashed';
   import PanelLeftDashedIcon from '~icons/lucide/panel-left-dashed';
   import PanelRightDashedIcon from '~icons/lucide/panel-right-dashed';
   import PanelTopDashedIcon from '~icons/lucide/panel-top-dashed';
   import RulerDimensionLineIcon from '~icons/lucide/ruler-dimension-line';
-  import type { PageLayoutSettings, PageLayoutSize } from '@typie/ui/utils';
+  import type { PageLayout, PageLayoutPreset } from '@typie/ui/utils';
 
   type Props = {
     open: boolean;
-    currentPageLayout?: PageLayoutSettings;
+    currentPageLayout?: PageLayout;
     currentPageEnabled?: boolean;
-    onConfirm: (layoutMode: ExportLayoutMode, pageLayout: PageLayoutSettings) => Promise<void>;
+    onConfirm: (layoutMode: ExportLayoutMode, pageLayout: PageLayout) => Promise<void>;
     onClose: () => void;
   };
 
@@ -27,27 +29,23 @@
 
   let isExporting = $state(false);
   let useCurrentSettings = $state(false);
-  let pageSize = $state<PageLayoutSize>(app.preference.current.lastPdfPageLayoutSettings.size);
-  let margins = $state(app.preference.current.lastPdfPageLayoutSettings.margins);
+  let pageLayout = $state<PageLayout>(app.preference.current.lastPdfPageLayout ?? createDefaultPageLayout('a4'));
 
   $effect(() => {
     if (open) {
       useCurrentSettings = !!currentPageEnabled && !!currentPageLayout;
 
       if (currentPageLayout && currentPageEnabled) {
-        pageSize = currentPageLayout.size;
-        margins = { ...currentPageLayout.margins };
+        pageLayout = currentPageLayout;
       } else {
-        pageSize = app.preference.current.lastPdfPageLayoutSettings.size;
-        margins = { ...app.preference.current.lastPdfPageLayoutSettings.margins };
+        pageLayout = app.preference.current.lastPdfPageLayout ?? createDefaultPageLayout('a4');
       }
     }
   });
 
   $effect(() => {
     if (useCurrentSettings && currentPageLayout) {
-      pageSize = currentPageLayout.size;
-      margins = { ...currentPageLayout.margins };
+      pageLayout = currentPageLayout;
     }
   });
 
@@ -57,11 +55,7 @@
     if (useCurrentSettings && currentPageLayout) {
       await onConfirm(layoutMode, currentPageLayout);
     } else {
-      const pageLayout: PageLayoutSettings = {
-        size: pageSize,
-        margins,
-      };
-      app.preference.current.lastPdfPageLayoutSettings = pageLayout;
+      app.preference.current.lastPdfPageLayout = pageLayout;
       await onConfirm(layoutMode, pageLayout);
     }
     isExporting = false;
@@ -94,20 +88,63 @@
           pointerEvents: useCurrentSettings ? 'none' : 'auto',
         })}
       >
-        <div class={flex({ justifyContent: 'space-between', alignItems: 'center', gap: '32px' })}>
-          <div class={flex({ alignItems: 'center', gap: '8px' })}>
-            <Icon style={css.raw({ color: 'text.faint' })} icon={FileIcon} />
-            <div class={css({ fontSize: '13px', color: 'text.subtle' })}>페이지 크기</div>
+        <div class={flex({ flexDirection: 'column', gap: '8px' })}>
+          <div class={flex({ justifyContent: 'space-between', alignItems: 'center', gap: '32px' })}>
+            <div class={flex({ alignItems: 'center', gap: '8px' })}>
+              <Icon style={css.raw({ color: 'text.faint' })} icon={FileIcon} />
+              <div class={css({ fontSize: '13px', color: 'text.subtle' })}>페이지 크기 (mm)</div>
+            </div>
+            <Select
+              disabled={useCurrentSettings}
+              items={PAGE_LAYOUT_OPTIONS}
+              onselect={(value: PageLayoutPreset | 'custom') => {
+                if (value === 'custom') return;
+                pageLayout = createDefaultPageLayout(value);
+              }}
+              value={(Object.entries(PAGE_SIZE_MAP).find(
+                ([, dimension]) => dimension.width === pageLayout.width && dimension.height === pageLayout.height,
+              )?.[0] as PageLayoutPreset) ?? ('custom' as const)}
+            />
           </div>
-          <Select
-            disabled={useCurrentSettings}
-            items={PAGE_LAYOUT_OPTIONS}
-            onselect={(value: PageLayoutSize) => {
-              pageSize = value;
-              margins = { ...DEFAULT_PAGE_MARGINS[value] };
-            }}
-            value={pageSize}
-          />
+
+          <div class={grid({ columns: 2, columnGap: '12px', rowGap: '8px', paddingLeft: '8px' })}>
+            <div class={flex({ alignItems: 'center', gap: '8px' })}>
+              <Icon style={css.raw({ size: '14px', color: 'text.subtle' })} icon={MoveHorizontalIcon} />
+              <div class={css({ fontSize: '12px', color: 'text.subtle', width: '32px' })}>너비</div>
+              <TextInput
+                style={css.raw({ width: '100px' })}
+                disabled={useCurrentSettings}
+                min="100"
+                onchange={(e) => {
+                  const target = e.target as HTMLInputElement;
+                  const value = Math.max(100, Number(target.value));
+                  target.value = String(value);
+                  pageLayout.width = value;
+                }}
+                size="sm"
+                type="number"
+                value={pageLayout.width}
+              />
+            </div>
+            <div class={flex({ alignItems: 'center', gap: '8px' })}>
+              <Icon style={css.raw({ size: '14px', color: 'text.subtle' })} icon={MoveVerticalIcon} />
+              <div class={css({ fontSize: '12px', color: 'text.subtle', width: '32px' })}>높이</div>
+              <TextInput
+                style={css.raw({ width: '100px' })}
+                disabled={useCurrentSettings}
+                min="100"
+                onchange={(e) => {
+                  const target = e.target as HTMLInputElement;
+                  const value = Math.max(100, Number(target.value));
+                  target.value = String(value);
+                  pageLayout.height = value;
+                }}
+                size="sm"
+                type="number"
+                value={pageLayout.height}
+              />
+            </div>
+          </div>
         </div>
 
         <div class={flex({ flexDirection: 'column', gap: '8px' })}>
@@ -116,88 +153,80 @@
             <div class={css({ fontSize: '13px', color: 'text.subtle' })}>여백 (mm)</div>
           </div>
           <div class={grid({ columns: 2, columnGap: '12px', rowGap: '8px', paddingLeft: '8px' })}>
-            <div class={center({ gap: '8px' })}>
-              <div class={center({ gap: '4px' })}>
-                <Icon style={css.raw({ width: '14px', height: '14px', color: 'text.subtle' })} icon={PanelTopDashedIcon} />
-                <div class={css({ fontSize: '12px', color: 'text.subtle' })}>상</div>
-              </div>
+            <div class={flex({ alignItems: 'center', gap: '8px' })}>
+              <Icon style={css.raw({ size: '14px', color: 'text.subtle' })} icon={PanelTopDashedIcon} />
+              <div class={css({ fontSize: '12px', color: 'text.subtle', width: '32px' })}>위</div>
               <TextInput
-                style={css.raw({ width: 'full' })}
+                style={css.raw({ width: '100px' })}
                 disabled={useCurrentSettings}
-                max={String(getMaxMargin('top', pageSize, margins))}
+                max={String(getMaxMargin('top', pageLayout))}
                 min="0"
                 oninput={(e) => {
                   const target = e.target as HTMLInputElement;
-                  const value = clamp(Number(target.value), 0, getMaxMargin('top', pageSize, margins));
+                  const value = clamp(Number(target.value), 0, getMaxMargin('top', pageLayout));
                   target.value = String(value);
-                  margins.top = value;
+                  pageLayout.marginTop = value;
                 }}
                 size="sm"
                 type="number"
-                value={margins.top}
+                value={pageLayout.marginTop}
               />
             </div>
-            <div class={center({ gap: '8px' })}>
-              <div class={center({ gap: '4px' })}>
-                <Icon style={css.raw({ width: '14px', height: '14px', color: 'text.subtle' })} icon={PanelBottomDashedIcon} />
-                <div class={css({ fontSize: '12px', color: 'text.subtle' })}>하</div>
-              </div>
+            <div class={flex({ alignItems: 'center', gap: '8px' })}>
+              <Icon style={css.raw({ size: '14px', color: 'text.subtle' })} icon={PanelBottomDashedIcon} />
+              <div class={css({ fontSize: '12px', color: 'text.subtle', width: '32px' })}>아래</div>
               <TextInput
-                style={css.raw({ width: 'full' })}
+                style={css.raw({ width: '100px' })}
                 disabled={useCurrentSettings}
-                max={String(getMaxMargin('bottom', pageSize, margins))}
+                max={String(getMaxMargin('bottom', pageLayout))}
                 min="0"
                 oninput={(e) => {
                   const target = e.target as HTMLInputElement;
-                  const value = clamp(Number(target.value), 0, getMaxMargin('bottom', pageSize, margins));
+                  const value = clamp(Number(target.value), 0, getMaxMargin('bottom', pageLayout));
                   target.value = String(value);
-                  margins.bottom = value;
+                  pageLayout.marginBottom = value;
                 }}
                 size="sm"
                 type="number"
-                value={margins.bottom}
+                value={pageLayout.marginBottom}
               />
             </div>
-            <div class={center({ gap: '8px' })}>
-              <div class={center({ gap: '4px' })}>
-                <Icon style={css.raw({ width: '14px', height: '14px', color: 'text.subtle' })} icon={PanelLeftDashedIcon} />
-                <div class={css({ fontSize: '12px', color: 'text.subtle' })}>좌</div>
-              </div>
+            <div class={flex({ alignItems: 'center', gap: '8px' })}>
+              <Icon style={css.raw({ size: '14px', color: 'text.subtle' })} icon={PanelLeftDashedIcon} />
+              <div class={css({ fontSize: '12px', color: 'text.subtle', width: '32px' })}>왼쪽</div>
               <TextInput
-                style={css.raw({ width: 'full' })}
+                style={css.raw({ width: '100px' })}
                 disabled={useCurrentSettings}
-                max={String(getMaxMargin('left', pageSize, margins))}
+                max={String(getMaxMargin('left', pageLayout))}
                 min="0"
                 oninput={(e) => {
                   const target = e.target as HTMLInputElement;
-                  const value = clamp(Number(target.value), 0, getMaxMargin('left', pageSize, margins));
+                  const value = clamp(Number(target.value), 0, getMaxMargin('left', pageLayout));
                   target.value = String(value);
-                  margins.left = value;
+                  pageLayout.marginLeft = value;
                 }}
                 size="sm"
                 type="number"
-                value={margins.left}
+                value={pageLayout.marginLeft}
               />
             </div>
-            <div class={center({ gap: '8px' })}>
-              <div class={center({ gap: '4px' })}>
-                <Icon style={css.raw({ width: '14px', height: '14px', color: 'text.subtle' })} icon={PanelRightDashedIcon} />
-                <div class={css({ fontSize: '12px', color: 'text.subtle' })}>우</div>
-              </div>
+            <div class={flex({ alignItems: 'center', gap: '8px' })}>
+              <Icon style={css.raw({ size: '14px', color: 'text.subtle' })} icon={PanelRightDashedIcon} />
+              <div class={css({ fontSize: '12px', color: 'text.subtle', width: '32px' })}>오른쪽</div>
               <TextInput
-                style={css.raw({ width: 'full' })}
+                style={css.raw({ width: '100px' })}
                 disabled={useCurrentSettings}
-                max={String(getMaxMargin('right', pageSize, margins))}
+                max={String(getMaxMargin('right', pageLayout))}
                 min="0"
                 oninput={(e) => {
                   const target = e.target as HTMLInputElement;
-                  const value = clamp(Number(target.value), 0, getMaxMargin('right', pageSize, margins));
+                  const value = clamp(Number(target.value), 0, getMaxMargin('right', pageLayout));
                   target.value = String(value);
-                  margins.right = value;
+                  pageLayout.marginRight = value;
                 }}
                 size="sm"
                 type="number"
-                value={margins.right}
+                value={pageLayout.marginRight}
               />
             </div>
           </div>

--- a/apps/website/src/routes/website/(dashboard)/@preference/LaboratoryTab.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@preference/LaboratoryTab.svelte
@@ -36,25 +36,6 @@
 
   <div class={flex({ align: 'center', justify: 'space-between', width: 'full', paddingY: '4px' })}>
     <div>
-      <h3 class={css({ fontSize: '14px', fontWeight: 'medium', color: 'text.default' })}>페이지 레이아웃</h3>
-      <p class={css({ marginTop: '4px', fontSize: '13px', color: 'text.faint' })}>
-        포스트별로 본문 설정에서 페이지 레이아웃 모드를 활성화할 수 있습니다.
-      </p>
-    </div>
-
-    <Switch
-      onchange={() => {
-        mixpanel.track('toggle_experimental_feature', {
-          feature: 'page_view',
-          enabled: app.preference.current.experimental_pageEnabled,
-        });
-      }}
-      bind:checked={app.preference.current.experimental_pageEnabled}
-    />
-  </div>
-
-  <div class={flex({ align: 'center', justify: 'space-between', width: 'full', paddingY: '4px' })}>
-    <div>
       <h3 class={css({ fontSize: '14px', fontWeight: 'medium', color: 'text.default' })}>PDF 내보내기</h3>
       <p class={css({ marginTop: '4px', fontSize: '13px', color: 'text.faint' })}>PDF 내보내기 기능을 활성화합니다.</p>
     </div>

--- a/apps/website/src/routes/website/(dashboard)/[slug]/ToolbarSettings.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/ToolbarSettings.svelte
@@ -1,17 +1,17 @@
 <script lang="ts">
   import { Fragment } from '@tiptap/pm/model';
   import { css } from '@typie/styled-system/css';
-  import { center, flex, grid } from '@typie/styled-system/patterns';
+  import { flex, grid } from '@typie/styled-system/patterns';
   import { HorizontalDivider, Icon, SegmentButtons, Select, Slider, Switch, TextInput, Tooltip } from '@typie/ui/components';
   import { getAppContext } from '@typie/ui/context';
   import { Dialog } from '@typie/ui/notification';
   import {
     clamp,
     createDefaultPageLayout,
-    DEFAULT_PAGE_MARGINS,
     getMaxMargin,
     INCOMPATIBLE_NODE_TYPES,
     PAGE_LAYOUT_OPTIONS,
+    PAGE_SIZE_MAP,
   } from '@typie/ui/utils';
   import mixpanel from 'mixpanel-browser';
   import AlignVerticalSpaceAroundIcon from '~icons/lucide/align-vertical-space-around';
@@ -24,6 +24,8 @@
   import GalleryVerticalEndIcon from '~icons/lucide/gallery-vertical-end';
   import HighlighterIcon from '~icons/lucide/highlighter';
   import InfoIcon from '~icons/lucide/info';
+  import MoveHorizontalIcon from '~icons/lucide/move-horizontal';
+  import MoveVerticalIcon from '~icons/lucide/move-vertical';
   import PanelBottomDashedIcon from '~icons/lucide/panel-bottom-dashed';
   import PanelLeftDashedIcon from '~icons/lucide/panel-left-dashed';
   import PanelRightDashedIcon from '~icons/lucide/panel-right-dashed';
@@ -38,7 +40,7 @@
   import ToolbarIcon from './ToolbarIcon.svelte';
   import type { Editor } from '@tiptap/core';
   import type { Node } from '@tiptap/pm/model';
-  import type { PageLayoutSettings, PageLayoutSize, Ref } from '@typie/ui/utils';
+  import type { PageLayout, PageLayoutPreset, Ref } from '@typie/ui/utils';
   import type * as Y from 'yjs';
 
   type Props = {
@@ -50,10 +52,10 @@
 
   const app = getAppContext();
   const maxWidth = new YState<number>(doc, 'maxWidth', 800);
-  const pageLayout = new YState<PageLayoutSettings | undefined>(doc, 'experimental_pageLayout', undefined);
-  const pageEnabled = new YState<boolean>(doc, 'experimental_pageEnabled', false);
+  const pageLayout = new YState<PageLayout | undefined>(doc, 'pageLayout', undefined);
+  const layoutMode = new YState<'scroll' | 'page'>(doc, 'layoutMode', 'scroll');
 
-  const isPageLayoutEnabled = $derived(app.preference.current.experimental_pageEnabled && pageEnabled.current);
+  const isPageLayoutEnabled = $derived(layoutMode.current === 'page');
 
   const getIncompatibleBlocks = () => {
     if (!editor?.current) return [];
@@ -177,11 +179,11 @@
 
   let capturedIncompatibleBlocks = $state<string[]>([]);
 
-  const handlePageLayoutToggle = (value: boolean) => {
+  const handlePageLayoutToggle = (value: 'scroll' | 'page') => {
     const incompatibleBlocks = getIncompatibleBlocks();
     capturedIncompatibleBlocks = incompatibleBlocks;
 
-    if (value && incompatibleBlocks.length > 0) {
+    if (value === 'page' && incompatibleBlocks.length > 0) {
       Dialog.confirm({
         title: '페이지 모드 전환',
         message: '페이지 모드에서는 일부 블록을 지원하지 않아요.',
@@ -191,8 +193,8 @@
         cancelLabel: '취소',
         actionHandler: () => {
           convertIncompatibleBlocks();
-          pageEnabled.current = value;
-          if (value && !pageLayout.current) {
+          layoutMode.current = value;
+          if (value === 'page' && !pageLayout.current) {
             pageLayout.current = createDefaultPageLayout('a4');
           }
           mixpanel.track('toggle_post_page_layout', {
@@ -201,8 +203,8 @@
         },
       });
     } else {
-      pageEnabled.current = value;
-      if (value && !pageLayout.current) {
+      layoutMode.current = value;
+      if (value === 'page' && !pageLayout.current) {
         pageLayout.current = createDefaultPageLayout('a4');
       }
       mixpanel.track('toggle_post_page_layout', {
@@ -249,45 +251,91 @@
         padding: '16px',
       })}
     >
-      {#if app.preference.current.experimental_pageEnabled}
-        <div class={flex({ justifyContent: 'space-between', alignItems: 'center', gap: '32px' })}>
-          <div class={flex({ alignItems: 'center', gap: '8px' })}>
-            <Icon style={css.raw({ color: 'text.faint' })} icon={FileTextIcon} />
-            <div class={css({ fontSize: '13px', color: 'text.subtle' })}>레이아웃 모드</div>
-          </div>
-          <div class={css({ width: '140px' })}>
-            <SegmentButtons
-              items={[
-                { label: '스크롤', value: false },
-                { label: '페이지', value: true },
-              ]}
-              onselect={handlePageLayoutToggle}
-              size="sm"
-              value={pageEnabled.current}
-            />
-          </div>
+      <div class={flex({ justifyContent: 'space-between', alignItems: 'center', gap: '32px' })}>
+        <div class={flex({ alignItems: 'center', gap: '8px' })}>
+          <Icon style={css.raw({ color: 'text.faint' })} icon={FileTextIcon} />
+          <div class={css({ fontSize: '13px', color: 'text.subtle' })}>레이아웃 모드</div>
         </div>
-      {/if}
+        <div class={css({ width: '140px' })}>
+          <SegmentButtons
+            items={[
+              { label: '스크롤', value: 'scroll' },
+              { label: '페이지', value: 'page' },
+            ]}
+            onselect={handlePageLayoutToggle}
+            size="sm"
+            value={layoutMode.current}
+          />
+        </div>
+      </div>
 
       {#if isPageLayoutEnabled && pageLayout.current}
-        <div class={flex({ flexDirection: 'column', gap: '12px', marginTop: '4px', marginBottom: '8px' })}>
-          <div class={flex({ justifyContent: 'space-between', alignItems: 'center', gap: '32px' })}>
-            <div class={flex({ alignItems: 'center', gap: '8px' })}>
-              <Icon style={css.raw({ color: 'text.faint' })} icon={FileIcon} />
-              <div class={css({ fontSize: '13px', color: 'text.subtle' })}>페이지 크기</div>
+        <div class={flex({ flexDirection: 'column', gap: '8px' })}>
+          <div class={flex({ flexDirection: 'column', gap: '8px' })}>
+            <div class={flex({ justifyContent: 'space-between', alignItems: 'center', gap: '32px' })}>
+              <div class={flex({ alignItems: 'center', gap: '8px' })}>
+                <Icon style={css.raw({ color: 'text.faint' })} icon={FileIcon} />
+                <div class={css({ fontSize: '13px', color: 'text.subtle' })}>페이지 크기 (mm)</div>
+              </div>
+              <Select
+                items={PAGE_LAYOUT_OPTIONS}
+                onselect={(value: PageLayoutPreset | 'custom') => {
+                  if (pageLayout.current && value !== 'custom') {
+                    pageLayout.current = createDefaultPageLayout(value);
+                  }
+                }}
+                value={(Object.entries(PAGE_SIZE_MAP).find(
+                  ([, dimension]) => dimension.width === pageLayout.current?.width && dimension.height === pageLayout.current?.height,
+                )?.[0] as PageLayoutPreset) ?? ('custom' as const)}
+              />
             </div>
-            <Select
-              items={PAGE_LAYOUT_OPTIONS}
-              onselect={(value: PageLayoutSize) => {
-                if (pageLayout.current && value) {
-                  pageLayout.current = {
-                    size: value,
-                    margins: DEFAULT_PAGE_MARGINS[value],
-                  };
-                }
-              }}
-              value={pageLayout.current?.size ?? 'a4'}
-            />
+
+            <div class={flex({ flexDirection: 'column', gap: '8px' })}>
+              <div class={grid({ columns: 2, columnGap: '12px', rowGap: '8px', paddingLeft: '8px' })}>
+                <div class={flex({ alignItems: 'center', gap: '8px' })}>
+                  <Icon style={css.raw({ size: '14px', color: 'text.subtle' })} icon={MoveHorizontalIcon} />
+                  <div class={css({ fontSize: '12px', color: 'text.subtle', width: '32px' })}>너비</div>
+                  <TextInput
+                    style={css.raw({ width: '100px' })}
+                    min="100"
+                    onchange={(e) => {
+                      if (!pageLayout.current) return;
+                      const target = e.target as HTMLInputElement;
+                      const value = Math.max(100, Number(target.value));
+                      target.value = String(value);
+                      pageLayout.current = {
+                        ...pageLayout.current,
+                        width: value,
+                      };
+                    }}
+                    size="sm"
+                    type="number"
+                    value={pageLayout.current.width}
+                  />
+                </div>
+                <div class={flex({ alignItems: 'center', gap: '8px' })}>
+                  <Icon style={css.raw({ size: '14px', color: 'text.subtle' })} icon={MoveVerticalIcon} />
+                  <div class={css({ fontSize: '12px', color: 'text.subtle', width: '32px' })}>높이</div>
+                  <TextInput
+                    style={css.raw({ width: '100px' })}
+                    min="100"
+                    onchange={(e) => {
+                      if (!pageLayout.current) return;
+                      const target = e.target as HTMLInputElement;
+                      const value = Math.max(100, Number(target.value));
+                      target.value = String(value);
+                      pageLayout.current = {
+                        ...pageLayout.current,
+                        height: value,
+                      };
+                    }}
+                    size="sm"
+                    type="number"
+                    value={pageLayout.current.height}
+                  />
+                </div>
+              </div>
+            </div>
           </div>
 
           <div class={flex({ flexDirection: 'column', gap: '8px' })}>
@@ -296,108 +344,92 @@
               <div class={css({ fontSize: '13px', color: 'text.subtle' })}>여백 (mm)</div>
             </div>
             <div class={grid({ columns: 2, columnGap: '12px', rowGap: '8px', paddingLeft: '8px' })}>
-              <div class={center({ gap: '8px' })}>
-                <div class={center({ gap: '4px' })}>
-                  <Icon style={css.raw({ width: '14px', height: '14px', color: 'text.subtle' })} icon={PanelTopDashedIcon} />
-                  <div class={css({ fontSize: '12px', color: 'text.subtle' })}>상</div>
-                </div>
+              <div class={flex({ alignItems: 'center', gap: '8px' })}>
+                <Icon style={css.raw({ size: '14px', color: 'text.subtle' })} icon={PanelTopDashedIcon} />
+                <div class={css({ fontSize: '12px', color: 'text.subtle', width: '32px' })}>위</div>
                 <TextInput
-                  style={css.raw({ width: 'full' })}
-                  max={pageLayout.current ? String(getMaxMargin('top', pageLayout.current.size, pageLayout.current.margins)) : undefined}
+                  style={css.raw({ width: '100px' })}
+                  max={pageLayout.current ? String(getMaxMargin('top', pageLayout.current)) : undefined}
                   min="0"
                   oninput={(e) => {
                     if (!pageLayout.current) return;
                     const target = e.target as HTMLInputElement;
-                    const value = clamp(Number(target.value), 0, getMaxMargin('top', pageLayout.current.size, pageLayout.current.margins));
+                    const value = clamp(Number(target.value), 0, getMaxMargin('top', pageLayout.current));
                     target.value = String(value);
                     pageLayout.current = {
                       ...pageLayout.current,
-                      margins: { ...pageLayout.current.margins, top: value },
+                      marginTop: value,
                     };
                   }}
                   size="sm"
                   type="number"
-                  value={pageLayout.current?.margins.top ?? 25}
+                  value={pageLayout.current?.marginTop ?? 25}
                 />
               </div>
-              <div class={center({ gap: '8px' })}>
-                <div class={center({ gap: '4px' })}>
-                  <Icon style={css.raw({ width: '14px', height: '14px', color: 'text.subtle' })} icon={PanelBottomDashedIcon} />
-                  <div class={css({ fontSize: '12px', color: 'text.subtle' })}>하</div>
-                </div>
+              <div class={flex({ alignItems: 'center', gap: '8px' })}>
+                <Icon style={css.raw({ size: '14px', color: 'text.subtle' })} icon={PanelBottomDashedIcon} />
+                <div class={css({ fontSize: '12px', color: 'text.subtle', width: '32px' })}>아래</div>
                 <TextInput
-                  style={css.raw({ width: 'full' })}
-                  max={pageLayout.current ? String(getMaxMargin('bottom', pageLayout.current.size, pageLayout.current.margins)) : undefined}
+                  style={css.raw({ width: '100px' })}
+                  max={pageLayout.current ? String(getMaxMargin('bottom', pageLayout.current)) : undefined}
                   min="0"
                   oninput={(e) => {
                     if (!pageLayout.current) return;
                     const target = e.target as HTMLInputElement;
-                    const value = clamp(
-                      Number(target.value),
-                      0,
-                      getMaxMargin('bottom', pageLayout.current.size, pageLayout.current.margins),
-                    );
+                    const value = clamp(Number(target.value), 0, getMaxMargin('bottom', pageLayout.current));
                     target.value = String(value);
                     pageLayout.current = {
                       ...pageLayout.current,
-                      margins: { ...pageLayout.current.margins, bottom: value },
+                      marginBottom: value,
                     };
                   }}
                   size="sm"
                   type="number"
-                  value={pageLayout.current?.margins.bottom ?? 25}
+                  value={pageLayout.current?.marginBottom ?? 25}
                 />
               </div>
-              <div class={center({ gap: '8px' })}>
-                <div class={center({ gap: '4px' })}>
-                  <Icon style={css.raw({ width: '14px', height: '14px', color: 'text.subtle' })} icon={PanelLeftDashedIcon} />
-                  <div class={css({ fontSize: '12px', color: 'text.subtle' })}>좌</div>
-                </div>
+              <div class={flex({ alignItems: 'center', gap: '8px' })}>
+                <Icon style={css.raw({ size: '14px', color: 'text.subtle' })} icon={PanelLeftDashedIcon} />
+                <div class={css({ fontSize: '12px', color: 'text.subtle', width: '32px' })}>왼쪽</div>
                 <TextInput
-                  style={css.raw({ width: 'full' })}
-                  max={pageLayout.current ? String(getMaxMargin('left', pageLayout.current.size, pageLayout.current.margins)) : undefined}
+                  style={css.raw({ width: '100px' })}
+                  max={pageLayout.current ? String(getMaxMargin('left', pageLayout.current)) : undefined}
                   min="0"
                   onchange={(e) => {
                     if (!pageLayout.current) return;
                     const target = e.target as HTMLInputElement;
-                    const value = clamp(Number(target.value), 0, getMaxMargin('left', pageLayout.current.size, pageLayout.current.margins));
+                    const value = clamp(Number(target.value), 0, getMaxMargin('left', pageLayout.current));
                     target.value = String(value);
                     pageLayout.current = {
                       ...pageLayout.current,
-                      margins: { ...pageLayout.current.margins, left: value },
+                      marginLeft: value,
                     };
                   }}
                   size="sm"
                   type="number"
-                  value={pageLayout.current?.margins.left ?? 25}
+                  value={pageLayout.current?.marginLeft ?? 25}
                 />
               </div>
-              <div class={center({ gap: '8px' })}>
-                <div class={center({ gap: '4px' })}>
-                  <Icon style={css.raw({ width: '14px', height: '14px', color: 'text.subtle' })} icon={PanelRightDashedIcon} />
-                  <div class={css({ fontSize: '12px', color: 'text.subtle' })}>우</div>
-                </div>
+              <div class={flex({ alignItems: 'center', gap: '8px' })}>
+                <Icon style={css.raw({ size: '14px', color: 'text.subtle' })} icon={PanelRightDashedIcon} />
+                <div class={css({ fontSize: '12px', color: 'text.subtle', width: '32px' })}>오른쪽</div>
                 <TextInput
-                  style={css.raw({ width: 'full' })}
-                  max={pageLayout.current ? String(getMaxMargin('right', pageLayout.current.size, pageLayout.current.margins)) : undefined}
+                  style={css.raw({ width: '100px' })}
+                  max={pageLayout.current ? String(getMaxMargin('right', pageLayout.current)) : undefined}
                   min="0"
                   oninput={(e) => {
                     if (!pageLayout.current) return;
                     const target = e.target as HTMLInputElement;
-                    const value = clamp(
-                      Number(target.value),
-                      0,
-                      getMaxMargin('right', pageLayout.current.size, pageLayout.current.margins),
-                    );
+                    const value = clamp(Number(target.value), 0, getMaxMargin('right', pageLayout.current));
                     target.value = String(value);
                     pageLayout.current = {
                       ...pageLayout.current,
-                      margins: { ...pageLayout.current.margins, right: value },
+                      marginRight: value,
                     };
                   }}
                   size="sm"
                   type="number"
-                  value={pageLayout.current?.margins.right ?? 25}
+                  value={pageLayout.current?.marginRight ?? 25}
                 />
               </div>
             </div>

--- a/packages/ui/src/components/InEditorBody.svelte
+++ b/packages/ui/src/components/InEditorBody.svelte
@@ -3,8 +3,7 @@
   import { tick, untrack } from 'svelte';
   import type { Editor } from '@tiptap/core';
   import type { Snippet } from 'svelte';
-  import type { PageLayout } from '../tiptap';
-  import type { Ref } from '../utils';
+  import type { PageLayout, Ref } from '../utils';
 
   type Props = {
     editor: Ref<Editor>;

--- a/packages/ui/src/context/app.svelte.ts
+++ b/packages/ui/src/context/app.svelte.ts
@@ -1,6 +1,6 @@
 import { getContext, setContext } from 'svelte';
 import { LocalStore, SessionStore } from '../state';
-import type { PageLayoutSettings } from '../utils';
+import type { PageLayout } from '../utils';
 
 type AppPreference = {
   postsExpanded: 'open' | 'closed' | false;
@@ -23,10 +23,9 @@ type AppPreference = {
 
   searchMatchWholeWord: boolean;
 
-  experimental_pageEnabled: boolean;
   experimental_pdfExportEnabled: boolean;
 
-  lastPdfPageLayoutSettings: PageLayoutSettings;
+  lastPdfPageLayout: PageLayout | null;
 
   referralWelcomeModalShown: boolean;
 
@@ -109,18 +108,9 @@ export const setupAppContext = (userId: string) => {
 
       searchMatchWholeWord: false,
 
-      experimental_pageEnabled: false,
       experimental_pdfExportEnabled: false,
 
-      lastPdfPageLayoutSettings: {
-        size: 'a4',
-        margins: {
-          top: 25,
-          bottom: 25,
-          left: 25,
-          right: 25,
-        },
-      },
+      lastPdfPageLayout: null,
 
       referralWelcomeModalShown: false,
 

--- a/packages/ui/src/tiptap/components/TiptapRenderer.svelte
+++ b/packages/ui/src/tiptap/components/TiptapRenderer.svelte
@@ -7,7 +7,7 @@
   import { baseExtensions } from '../schema';
   import type { JSONContent } from '@tiptap/core';
   import type { SystemStyleObject } from '@typie/styled-system/types';
-  import type { PageLayout } from '../extensions';
+  import type { PageLayout } from '../../utils';
 
   type Props = {
     style?: SystemStyleObject;

--- a/packages/ui/src/tiptap/extensions/page.ts
+++ b/packages/ui/src/tiptap/extensions/page.ts
@@ -5,17 +5,9 @@ import { css } from '@typie/styled-system/css';
 import { token } from '@typie/styled-system/tokens';
 import { tick } from 'svelte';
 import { mmToPx } from '../../utils';
+import type { PageLayout } from '../../utils';
 
 const GAP_HEIGHT_PX = 40;
-
-export type PageLayout = {
-  width: number;
-  height: number;
-  marginTop: number;
-  marginBottom: number;
-  marginLeft: number;
-  marginRight: number;
-};
 
 export type PageStorage = {
   layout?: PageLayout;

--- a/packages/ui/src/utils/page-layout.ts
+++ b/packages/ui/src/utils/page-layout.ts
@@ -2,17 +2,16 @@ export const MIN_CONTENT_SIZE_MM = 50;
 
 export const INCOMPATIBLE_NODE_TYPES = new Set(['blockquote', 'callout', 'fold', 'table', 'code_block', 'html_block']);
 
-export type PageLayoutSettings = {
-  size: 'a4' | 'a5' | 'b5' | 'b6';
-  margins: {
-    top: number;
-    bottom: number;
-    left: number;
-    right: number;
-  };
-};
+export type PageLayoutPreset = 'a4' | 'a5' | 'b5' | 'b6';
 
-export type PageLayoutSize = PageLayoutSettings['size'];
+export type PageLayout = {
+  width: number;
+  height: number;
+  marginTop: number;
+  marginBottom: number;
+  marginLeft: number;
+  marginRight: number;
+};
 
 export const PAGE_SIZE_MAP = {
   a4: { width: 210, height: 297 },
@@ -33,43 +32,27 @@ export const PAGE_LAYOUT_OPTIONS = [
   { label: 'A5 (148mm × 210mm)', value: 'a5' as const },
   { label: 'B5 (176mm × 250mm)', value: 'b5' as const },
   { label: 'B6 (125mm × 176mm)', value: 'b6' as const },
+  { label: '직접 지정', value: 'custom' as const },
 ];
 
-export function getPageLayoutDimensions(settings: PageLayoutSettings) {
-  const size = PAGE_SIZE_MAP[settings.size];
-  const margins = settings.margins;
-
+export function createDefaultPageLayout(preset: PageLayoutPreset = 'a4'): PageLayout {
   return {
-    width: size.width,
-    height: size.height,
-    marginTop: margins.top,
-    marginBottom: margins.bottom,
-    marginLeft: margins.left,
-    marginRight: margins.right,
+    ...PAGE_SIZE_MAP[preset],
+    marginTop: DEFAULT_PAGE_MARGINS[preset].top,
+    marginBottom: DEFAULT_PAGE_MARGINS[preset].bottom,
+    marginLeft: DEFAULT_PAGE_MARGINS[preset].left,
+    marginRight: DEFAULT_PAGE_MARGINS[preset].right,
   };
 }
 
-export function createDefaultPageLayout(size: PageLayoutSize = 'a4'): PageLayoutSettings {
-  return {
-    size,
-    margins: DEFAULT_PAGE_MARGINS[size],
-  };
-}
-
-export function getMaxMargin(
-  side: 'top' | 'bottom' | 'left' | 'right',
-  pageSize: PageLayoutSize,
-  margins: PageLayoutSettings['margins'],
-): number {
-  const pageDimensions = PAGE_SIZE_MAP[pageSize];
-
+export function getMaxMargin(side: 'top' | 'bottom' | 'left' | 'right', pageLayoutSettings: PageLayout): number {
   if (side === 'left') {
-    return pageDimensions.width - margins.right - MIN_CONTENT_SIZE_MM;
+    return pageLayoutSettings.width - pageLayoutSettings.marginRight - MIN_CONTENT_SIZE_MM;
   } else if (side === 'right') {
-    return pageDimensions.width - margins.left - MIN_CONTENT_SIZE_MM;
+    return pageLayoutSettings.width - pageLayoutSettings.marginLeft - MIN_CONTENT_SIZE_MM;
   } else if (side === 'top') {
-    return pageDimensions.height - margins.bottom - MIN_CONTENT_SIZE_MM;
+    return pageLayoutSettings.height - pageLayoutSettings.marginBottom - MIN_CONTENT_SIZE_MM;
   } else {
-    return pageDimensions.height - margins.top - MIN_CONTENT_SIZE_MM;
+    return pageLayoutSettings.height - pageLayoutSettings.marginTop - MIN_CONTENT_SIZE_MM;
   }
 }


### PR DESCRIPTION
- 기존 experimental flag 제거. 실험실에서 뺌
- `layoutMode`, `pageLayout` Yjs state 사용
- 페이지 크기 커스텀 가능
- PageLayoutSettings 타입 없애고 PageLayout 타입만 씀
- 데스크탑 쪽 코드 불가피하게 업데이트