### PR TITLE
앱에서 appReady로 전달된 selection 사용할 수 없을 때 예외처리

### DIFF
--- a/apps/website/src/routes/website/_webview/editor/+page.svelte
+++ b/apps/website/src/routes/website/_webview/editor/+page.svelte
@@ -559,12 +559,16 @@
           }
         } else {
           if (editor) {
-            const selection = Selection.fromJSON(editor.current.state.doc, data.state.selection);
-            editor.current.commands.command(({ tr, dispatch }) => {
-              tr.setSelection(selection);
-              dispatch?.(tr);
-              return true;
-            });
+            try {
+              const selection = Selection.fromJSON(editor.current.state.doc, data.state.selection);
+              editor.current.commands.command(({ tr, dispatch }) => {
+                tr.setSelection(selection);
+                dispatch?.(tr);
+                return true;
+              });
+            } catch {
+              editor?.current.commands.setTextSelection(2);
+            }
 
             if (isFocusable) {
               editor.current.commands.focus(null, { scrollIntoView: false });


### PR DESCRIPTION
~state.getSerializedPostSelection(slug) 로 얻어온 셀렉션이 없을 때가 있는듯. 그러면 null이 전달됨. 하지만 null을 제대로 처리하고 있지 않음.~
뭔가 데이터가 더럽혀지는 경우가 있다..
이런 상황에서는 웹뷰가 응답을 멈추고 아무것도 되지 않음.