### PR TITLE
앱 액티비티 그리드 툴팁 위치 조정 2

### DIFF
--- a/apps/mobile/lib/screens/profile/activity_grid.dart
+++ b/apps/mobile/lib/screens/profile/activity_grid.dart
@@ -570,7 +570,7 @@ class _TooltipPositionDelegate extends SingleChildLayoutDelegate {
   Offset getPositionForChild(Size size, Size childSize) {
     const minX = 8.0;
     var tooltipX = cellPosition.dx - childSize.width - 2;
-    final tooltipY = cellPosition.dy - childSize.height - 2;
+    final tooltipY = cellPosition.dy - childSize.height + cellSize.height - 2;
 
     if (tooltipX < minX) {
       tooltipX = minX;


### PR DESCRIPTION
셀의 0, 0에서 -2, -2에 떨어진 곳에 표시