### PR TITLE
앵커 위치 계산 시 inline node 제외

### DIFF
--- a/packages/ui/src/tiptap/nodes/hard-break.ts
+++ b/packages/ui/src/tiptap/nodes/hard-break.ts
@@ -23,7 +23,7 @@ export const HardBreak = Node.create({
   renderHTML({ HTMLAttributes }) {
     return [
       'span',
-      { style: 'display: inline;' },
+      {},
       ['br', HTMLAttributes],
       [
         'span',


### PR DESCRIPTION
- hard_break wrapper에서 불필요한 스타일 제거
- 마지막 노드가 hard_break면 getLastNodeOffsetTop이 0이 되고 앵커 포지션이 전부 0이 되는 문제가 있었음