### PR TITLE
문단 지울 때 문단 속성 및 마크 강제로 유지함

### DIFF
--- a/packages/ui/src/tiptap/extensions/selection.ts
+++ b/packages/ui/src/tiptap/extensions/selection.ts
@@ -138,10 +138,10 @@ export const Selection = Extension.create({
             const decorations: Decoration[] = [];
 
             if (this.editor.isEditable && (selection instanceof NodeSelection || selection instanceof MultiNodeSelection)) {
-              const startPos = Math.max(1, from - 1);
-              const endPos = Math.min(body.content.size + 1, to + 1);
+              const startPos = Math.max(0, from - 1);
+              const endPos = Math.min(body.content.size, to - 1);
 
-              body.nodesBetween(startPos - 1, endPos - 1, (node, offset) => {
+              body.nodesBetween(startPos, endPos, (node, offset) => {
                 if (!node.isBlock) {
                   return true;
                 }
@@ -152,7 +152,6 @@ export const Selection = Extension.create({
 
                 const pos = offset + 1;
                 const selected = from <= pos && to >= pos + node.nodeSize;
-
                 if (!selected) {
                   return true;
                 }


### PR DESCRIPTION
문서 전체 선택하고 지우기, 다시 작성, 혹은 문단 선택하고 지우기, 다시 작성시 기존 문단의 속성 및 마크 계속 유지되도록 함
폰트나 글자 크기, 색상 등 바꾸었을 때 훨씬 편리할 것