### PR TITLE
cleanOrphanAnchors를 더욱 안전하게 함

### DIFF
--- a/packages/ui/src/anchor/utils.ts
+++ b/packages/ui/src/anchor/utils.ts
@@ -91,11 +91,13 @@ export const cleanOrphanAnchors = (editor: Editor, doc: Y.Doc): number => {
     return 0;
   }
 
-  const existingNodeIds = new Set(
-    [...editor.view.dom.querySelectorAll('[data-node-id]')]
-      .map((el) => (el as HTMLElement).dataset.nodeId)
-      .filter((id): id is string => id !== undefined),
-  );
+  const existingNodeIds = new Set<string>();
+
+  editor.state.doc.descendants((node) => {
+    if (node.attrs.nodeId) {
+      existingNodeIds.add(node.attrs.nodeId);
+    }
+  });
 
   const orphanNodeIds: string[] = [];
   const cleanedAnchors: Record<string, string | null> = {};


### PR DESCRIPTION
혹시나 DOM이 준비가 안 됐을 때 existingNodeIds를 얻어서 앵커가 날아가는 걸지도..