### PR TITLE
segment button value를 bindable로 하지 않음

### DIFF
--- a/packages/ui/src/components/SegmentButtons.svelte
+++ b/packages/ui/src/components/SegmentButtons.svelte
@@ -11,7 +11,7 @@
     onselect?: (value: T) => void;
   };
 
-  let { style, value = $bindable(), items = [], size = 'md', onselect }: Props = $props();
+  let { style, value, items = [], size = 'md', onselect }: Props = $props();
 
   type Variants = RecipeVariant<typeof recipe>;
   const recipe = sva({
@@ -90,8 +90,7 @@
       class={css(classes.button)}
       aria-selected={value === item.value}
       onclick={() => {
-        value = item.value;
-        onselect?.(value);
+        onselect?.(item.value);
       }}
       role="tab"
       type="button"


### PR DESCRIPTION
segment button을 건드려도 value를 바꾸지 않고 onselect만 호출함. 실제로 value가 변경될 때 변경되도록 함. (예: 페이지 모드 전환 시, 모달에서 컨펌 해야지만 segment button에서도 페이지로 바뀜)