### PR TITLE
타자기 모드에 따른 에디터 bottom padding 조절

### DIFF
--- a/apps/website/src/routes/website/(dashboard)/[slug]/Editor.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/Editor.svelte
@@ -932,6 +932,7 @@
                   top: 20,
                   x: effectiveLayoutMode.current === PostLayoutMode.PAGE && effectivePageLayout.current ? 0 : 40,
                 }}
+                {editor}
                 layoutMode={effectiveLayoutMode.current}
                 maxWidth={effectiveMaxWidth.current}
                 pageLayout={effectivePageLayout.current}

--- a/apps/website/src/routes/website/_webview/editor/+page.svelte
+++ b/apps/website/src/routes/website/_webview/editor/+page.svelte
@@ -966,10 +966,12 @@
       top: 40,
       x: layoutMode.current === PostLayoutMode.PAGE && pageLayout.current ? 0 : 20,
     }}
+    {editor}
     layoutMode={layoutMode.current}
     maxWidth={maxWidth.current}
-    mobile={true}
     pageLayout={pageLayout.current}
+    typewriterEnabled={settings.typewriterEnabled}
+    typewriterPosition={settings.typewriterPosition}
   >
     <div
       style:width={editorZoomed && layoutMode.current === PostLayoutMode.PAGE

--- a/packages/ui/src/tiptap/nodes/body.ts
+++ b/packages/ui/src/tiptap/nodes/body.ts
@@ -54,11 +54,12 @@ export const Body = Node.create({
             paddingTop: 'var(--prosemirror-padding-top)',
             paddingLeft: 'var(--prosemirror-padding-x)',
             paddingRight: 'var(--prosemirror-padding-x)',
+            paddingBottom: 'var(--prosemirror-padding-bottom)',
             '[data-layout="page"] &': {
               minWidth: 'var(--prosemirror-max-width)',
               paddingTop: '[calc(var(--prosemirror-page-margin-top) + var(--prosemirror-padding-top))]',
               paddingLeft: '[calc(var(--prosemirror-page-margin-left) + var(--prosemirror-padding-x))]',
-              paddingBottom: 'var(--prosemirror-page-margin-bottom)',
+              paddingBottom: '[calc(var(--prosemirror-page-margin-bottom) + var(--prosemirror-padding-bottom))]',
               paddingRight: '[calc(var(--prosemirror-page-margin-right) + var(--prosemirror-padding-x))]',
             },
             '& > .paragraph-indent, & > .selected-node > .paragraph-indent': {

--- a/packages/ui/styles/prose.css
+++ b/packages/ui/styles/prose.css
@@ -58,8 +58,6 @@
 }
 
 .ProseMirror-editable {
-  padding-bottom: var(--prosemirror-padding-bottom);
-
   & [data-drag-handle] {
     cursor: grab;
   }


### PR DESCRIPTION
- 페이지 모드에서도 타자기 모드일 때 타자기 모드 설정에 따라 bottom padding 추가함. 추가하되, 마지막 페이지의 빈 부분을 고려해서 패딩이 너무 많이 추가되지 않도록 함
- 모바일에서 bottom padding 80vh 고정하지 않고 PC와 똑같이 처리함