### PR TITLE
entities site permission 디버그

### DIFF
--- a/apps/api/src/graphql/resolvers/entity.ts
+++ b/apps/api/src/graphql/resolvers/entity.ts
@@ -323,10 +323,14 @@ builder.queryFields((t) => ({
 
       const siteId = entities[0].siteId;
 
-      await assertSitePermission({
-        userId: ctx.session.userId,
-        siteId,
-      });
+      if (entities.some((entity) => entity.availability === EntityAvailability.PRIVATE)) {
+        await assertSitePermission({
+          userId: ctx.session.userId,
+          siteId,
+        }).catch(() => {
+          throw new NotFoundError();
+        });
+      }
 
       if (entities.some((entity) => entity.siteId !== siteId)) {
         throw new TypieError({ code: 'site_mismatch' });


### PR DESCRIPTION
- 스플릿뷰 이후로 발생한 편집 공유 링크 들어갔을 때 permission_denied 뜨는 버그를 해결함
- 여러 포스트를 스플릿뷰로 볼 때 하나라도 권한이 없으면 로딩이 안 되는 문제가 아직 있음. 이걸 해결하려면 스플릿뷰마다 각자 쿼리해야 하지만 지금 gql 클라이언트 구조상 모든 스플릿뷰의 entities를 모아서 쿼리하는 방법밖에 모르겠음..
