### PR TITLE
local storage 안전하게 파싱하고 set

### DIFF
--- a/packages/ui/src/notification/tip/index.ts
+++ b/packages/ui/src/notification/tip/index.ts
@@ -1,4 +1,5 @@
 import { toast as sonner } from 'svelte-sonner';
+import { safeJsonParse } from '../../utils';
 import Item from './Item.svelte';
 
 export type TipOptions = {
@@ -10,7 +11,7 @@ const append = (key: string, message: string, options?: TipOptions) => {
     throw new TypeError('tip can only be used in browser');
   }
 
-  const saved = JSON.parse(localStorage.getItem('typie:tips') ?? '[]') as string[];
+  const saved = safeJsonParse<string[]>(localStorage.getItem('typie:tips'), []);
   if (saved.includes(key)) {
     return;
   }

--- a/packages/ui/src/state/local-store.svelte.ts
+++ b/packages/ui/src/state/local-store.svelte.ts
@@ -1,4 +1,5 @@
 import { browser } from '$app/environment';
+import { safeJsonParse } from '../utils';
 
 export class LocalStore<T> {
   #key: string;
@@ -11,13 +12,15 @@ export class LocalStore<T> {
     if (browser) {
       const item = localStorage.getItem(this.#key);
       if (item) {
-        const value = JSON.parse(item);
+        const value = safeJsonParse<T>(item, defaultValue);
         this.current = { ...defaultValue, ...value };
       }
     }
 
     $effect(() => {
-      localStorage.setItem(this.#key, JSON.stringify(this.current));
+      if (this.current !== undefined) {
+        localStorage.setItem(this.#key, JSON.stringify(this.current));
+      }
     });
   }
 }

--- a/packages/ui/src/state/session-store.svelte.ts
+++ b/packages/ui/src/state/session-store.svelte.ts
@@ -1,4 +1,5 @@
 import { browser } from '$app/environment';
+import { safeJsonParse } from '../utils';
 
 export class SessionStore<T> {
   #key: string;
@@ -11,12 +12,14 @@ export class SessionStore<T> {
     if (browser) {
       const item = sessionStorage.getItem(this.#key);
       if (item) {
-        this.current = JSON.parse(item);
+        this.current = safeJsonParse<T>(item, value);
       }
     }
 
     $effect(() => {
-      sessionStorage.setItem(this.#key, JSON.stringify(this.current));
+      if (this.current !== undefined) {
+        sessionStorage.setItem(this.#key, JSON.stringify(this.current));
+      }
     });
   }
 }

--- a/packages/ui/src/utils/index.ts
+++ b/packages/ui/src/utils/index.ts
@@ -1,6 +1,7 @@
 export * from './auth';
 export * from './device';
 export * from './download';
+export * from './json';
 export * from './note-colors';
 export * from './number';
 export * from './page-layout';

--- a/packages/ui/src/utils/json.ts
+++ b/packages/ui/src/utils/json.ts
@@ -1,0 +1,11 @@
+export const safeJsonParse = <T>(jsonString: string | null | undefined, defaultValue: T): T => {
+  if (!jsonString) {
+    return defaultValue;
+  }
+
+  try {
+    return JSON.parse(jsonString);
+  } catch {
+    return defaultValue;
+  }
+};


### PR DESCRIPTION
- utils에 safeJsonParse 추가
- localStorage 파싱할 때 safeJsonParse 사용해서 파싱 실패 시 폴백으로 defaultValue 반환
- localStorage.setItem 전에 undefined인지 여부로 가드
- Editor selection 저장할 때 localStore 사용하도록 리팩토링