### PR TITLE
fifo 규칙에 맞게 업데이트 실패 큐 뒤집음

### DIFF
--- a/apps/api/src/mq/tasks/canvas.ts
+++ b/apps/api/src/mq/tasks/canvas.ts
@@ -139,7 +139,7 @@ export const CanvasSyncCollectJob = defineJob('canvas:sync:collect', async (canv
     Sentry.captureException(err);
 
     if (updates.length > 0) {
-      await redis.rpush(`canvas:sync:updates:${canvasId}`, ...updates);
+      await redis.rpush(`canvas:sync:updates:${canvasId}`, ...updates.toReversed());
     }
   } finally {
     await lock.release();

--- a/apps/api/src/mq/tasks/post.ts
+++ b/apps/api/src/mq/tasks/post.ts
@@ -218,7 +218,7 @@ export const PostSyncCollectJob = defineJob('post:sync:collect', async (postId: 
     Sentry.captureException(err);
 
     if (updates.length > 0) {
-      await redis.rpush(`post:sync:updates:${postId}`, ...updates);
+      await redis.rpush(`post:sync:updates:${postId}`, ...updates.toReversed());
     }
   } finally {
     await lock.release();


### PR DESCRIPTION
실패시 재삽입할 때 올바른 fifo 순서 유지되도록 함
