### PR TITLE
sidebar peeking 개선

### DIFF
--- a/apps/website/src/routes/website/(dashboard)/Sidebar.svelte
+++ b/apps/website/src/routes/website/(dashboard)/Sidebar.svelte
@@ -111,7 +111,7 @@
         return 'translateX(-100%)';
       }
       case 'peeking': {
-        return 'translateX(-90%)';
+        return 'translateX(calc(-100% + 20px))';
       }
       case 'visible': {
         return 'translateX(0)';
@@ -172,23 +172,23 @@
   };
 </script>
 
-{#if app.preference.current.sidebarHidden && sidebarState !== 'visible'}
+{#if app.preference.current.sidebarTrigger === 'hover' && app.preference.current.sidebarHidden && sidebarState !== 'visible'}
   <div
     class={css({
       position: 'fixed',
       top: '128px',
       left: '0',
-      width: '60px',
+      width: '40px',
       height: '[calc(100vh - 256px)]',
       zIndex: 'sidebar',
     })}
     onmouseenter={() => {
-      if (app.preference.current.sidebarTrigger === 'hover' && sidebarState === 'hidden') {
+      if (sidebarState === 'hidden') {
         sidebarState = 'peeking';
       }
     }}
     onmouseleave={() => {
-      if (app.preference.current.sidebarTrigger === 'hover' && sidebarState !== 'visible') {
+      if (sidebarState !== 'visible') {
         sidebarState = 'hidden';
       }
     }}


### PR DESCRIPTION
- hover trigger의 width를 에디터 가로 패딩인 40px와 맞춤
- peeking 일 때 사이드바가 그 절반인 20px만 튀어나오게 함
- sidebarTrigger가 hover일 때만 hover trigger 렌더링하도록 함. 블록 셀렉터를 클릭할 수 있게 해줌.