### PR TITLE
autosize action이 height를 캐시함

### DIFF
--- a/apps/website/src/routes/website/(dashboard)/@widgets/widgets/PostRelatedNoteWidget.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@widgets/widgets/PostRelatedNoteWidget.svelte
@@ -480,7 +480,7 @@
             placeholder="기억할 내용이나 작성에 도움이 되는 내용을 자유롭게 적어보세요."
             rows={3}
             value={noteContents[note.id] || ''}
-            use:autosize
+            use:autosize={{ cacheKey: `note-${note.id}` }}
           ></textarea>
 
           {#if !palette}

--- a/packages/ui/src/actions/autosize.svelte.ts
+++ b/packages/ui/src/actions/autosize.svelte.ts
@@ -1,13 +1,36 @@
 import { on } from 'svelte/events';
+import { SvelteMap } from 'svelte/reactivity';
 import type { Action } from 'svelte/action';
 
-export const autosize: Action<HTMLTextAreaElement> = (element) => {
+// NOTE: animateFlip과의 호환성을 위해 캐시된 높이를 즉시 적용해서 항상 올바른 높이를 유지
+const heightCache = new SvelteMap<string, number>();
+
+type AutosizeParams = {
+  // NOTE: 높이 캐싱을 위한 stable key
+  cacheKey?: string;
+};
+
+export const autosize: Action<HTMLTextAreaElement, AutosizeParams | undefined> = (element, params = {}) => {
+  const cacheKey = params.cacheKey;
+
+  if (cacheKey) {
+    const cachedHeight = heightCache.get(cacheKey);
+    if (cachedHeight) {
+      element.style.height = `${cachedHeight}px`;
+    }
+  }
+
   $effect(() => {
     element.style.overflow = 'hidden';
 
     const handler = () => {
       element.style.height = 'auto';
-      element.style.height = `${element.scrollHeight}px`;
+      const height = element.scrollHeight;
+      element.style.height = `${height}px`;
+
+      if (cacheKey) {
+        heightCache.set(cacheKey, height);
+      }
     };
 
     const off = on(element, 'input', handler);
@@ -20,4 +43,12 @@ export const autosize: Action<HTMLTextAreaElement> = (element) => {
       off();
     };
   });
+
+  return {
+    destroy() {
+      if (cacheKey) {
+        heightCache.delete(cacheKey);
+      }
+    },
+  };
 };


### PR DESCRIPTION
- 강제 개행 없는 엄청 긴 노트를 가진 노트 위젯 위아래로 위젯을 드래그할 때 애니메이션이 버벅거리는 문제를 해결함.
- animateFlip이 초기 위치를 구하는 시점에는 아직 autosize가 textarea의 scrollHeight를 얻지 못한 상태라 내용이 많더라도 작은 크기 기준으로 위치가 구해짐 -> 애니메이션이 깨짐
- autosize action에 stable key를 넘겨주면 그 키로 height를 캐시하고, 리렌더링 시 곧바로 캐시된 height를 적용하도록 함 -> 애니메이션이 올바르게 동작함