### PR TITLE
rename folder 디버그 등

### DIFF
--- a/apps/website/src/routes/website/(dashboard)/@context-menu/FolderMenu.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@context-menu/FolderMenu.svelte
@@ -125,10 +125,10 @@
 <MenuItem
   icon={PencilIcon}
   onclick={() => {
+    mixpanel.track('rename_folder_try', { via });
     if (onRename) {
       onRename();
     }
-    mixpanel.track('rename_folder', { via });
   }}
 >
   이름 변경

--- a/apps/website/src/routes/website/(dashboard)/@tree/Folder.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@tree/Folder.svelte
@@ -5,7 +5,6 @@
   import { Icon, Menu } from '@typie/ui/components';
   import { getAppContext } from '@typie/ui/context';
   import mixpanel from 'mixpanel-browser';
-  import { tick } from 'svelte';
   import ChevronDownIcon from '~icons/lucide/chevron-down';
   import ChevronRightIcon from '~icons/lucide/chevron-right';
   import EllipsisIcon from '~icons/lucide/ellipsis';
@@ -79,7 +78,8 @@
 
   $effect(() => {
     if (editing) {
-      tick().then(() => {
+      // NOTE: Menu 닫힐 때 포커스 트랩에 의해 select 하자마자 blur되지 않도록 setTimeout
+      setTimeout(() => {
         inputEl?.select();
       });
     }

--- a/packages/ui/src/components/Menu.svelte
+++ b/packages/ui/src/components/Menu.svelte
@@ -54,13 +54,13 @@
     offset,
     disableAutoUpdate,
     onClickOutside: () => {
-      open = false;
+      close();
     },
   });
 
   const close = () => {
     open = false;
-    buttonEl?.focus();
+    // NOTE: 닫으면 focusTrap에 의해 자동으로 포커스 돌아감
   };
 
   setContext('close', close);
@@ -77,7 +77,7 @@
   });
 
   afterNavigate(() => {
-    open = false;
+    close();
   });
 
   $effect(() => {
@@ -219,7 +219,13 @@
     )}
     role="menu"
     use:floating
-    use:focusTrap={{ fallbackFocus: menuEl, escapeDeactivates: false, allowOutsideClick: true }}
+    use:focusTrap={{
+      fallbackFocus: menuEl,
+      escapeDeactivates: false,
+      allowOutsideClick: true,
+      // NOTE: 우클릭으로 연 경우 buttonEl이 없으며 포커스 되돌리지 않음
+      returnFocusOnDeactivate: !!buttonEl,
+    }}
     transition:scale={{ start: 0.95, duration: 150 }}
   >
     {#if action}


### PR DESCRIPTION
## 현재 문제
- 우클릭으로 메뉴 열어서 폴더명 수정하면 무조건 바로 blur됨
- ... 메뉴로 열어서 폴더명 수정해도 가끔씩 바로 blur됨

## 수정사항
- Menu 닫힐 때 포커스 트랩에 의해 input.select 하자마자 blur되지 않도록, rename 시 input.select를  setTimeout함
- Menu focusTrap 옵션 수정: returnFocusOnDeactivate는 buttonEl 있을 때만. (우클릭으로 열 땐 없음) 우클릭으로 열고 나서 닫을 때는 포커스를 원래 위치로 돌리지 않음.
- 중복된 믹스패널 트래킹 수정: rename_folder를 시작, 종료 시 두 번 하고 있었음. rename_folder_try와 rename_folder로 나눔.