### PR TITLE
MenuItem close 후 onclick 호출

### DIFF
--- a/packages/ui/src/components/MenuItem.svelte
+++ b/packages/ui/src/components/MenuItem.svelte
@@ -113,10 +113,10 @@
   this={element}
   onblur={() => (focused = false)}
   onclick={() => {
-    onclick?.();
     if (!loading && !noCloseOnClick) {
       close?.();
     }
+    onclick?.();
   }}
   onfocus={() => (focused = true)}
   role="menuitem"


### PR DESCRIPTION
하위 폴더 생성 후 폴더명 변경 모드가 바로 풀림. Menu 닫힐 때 포커스를 버튼으로 이동시키는 것 때문에 폴더명 input에 blur가 호출되는 것 같음. (로컬에서는 발생하지 않음)

MenuItem 클릭 시 일단 Menu 닫기 먼저 하고 onclick을 호출하도록 함.