### PR TITLE
SearchableDropdown 스타일 수정

### DIFF
--- a/packages/ui/src/components/SearchableDropdown.svelte
+++ b/packages/ui/src/components/SearchableDropdown.svelte
@@ -160,7 +160,8 @@
       display: 'flex',
       alignItems: 'center',
       borderRadius: '4px',
-      paddingX: '4px',
+      paddingLeft: '4px',
+      paddingRight: '20px',
       height: '24px',
       _hover: {
         backgroundColor: 'surface.muted',
@@ -185,6 +186,7 @@
       backgroundColor: 'transparent',
       border: 'none',
       outline: 'none',
+      textOverflow: 'ellipsis',
     })}
     {disabled}
     onblur={handleBlur}


### PR DESCRIPTION
오른쪽 chevron icon과 텍스트가 겹치게 하지 않고 textOverflow: 'ellipsis' 적용