### PR TITLE
findScroller 제거

### DIFF
--- a/apps/website/src/lib/components/editor/Editor.svelte
+++ b/apps/website/src/lib/components/editor/Editor.svelte
@@ -64,6 +64,10 @@
   let initialized = $state(false);
 
   $effect(() => {
+    editor.scrollContainerEl = scrollContainerEl;
+  });
+
+  $effect(() => {
     untrack(() => {
       editor.initialize({ theme: getEditorTheme(theme.effectiveTheme), snapshot, readOnly, onDocChanged, onExitedDocumentStart });
     });

--- a/apps/website/src/lib/components/editor/core/Cursor.svelte
+++ b/apps/website/src/lib/components/editor/core/Cursor.svelte
@@ -2,7 +2,6 @@
   import { css } from '@typie/styled-system/css';
   import { cubicOut } from 'svelte/easing';
   import { getEditor } from '$lib/editor/context';
-  import { findScroller } from '$lib/editor/utils';
 
   const editor = getEditor();
 
@@ -25,7 +24,9 @@
     if (!element) return;
     if (!animate && !editor.isPointerModeIdle) return;
 
-    const scroller = findScroller(element);
+    const scroller = editor.scrollContainerEl;
+    if (!scroller) return;
+
     const scrollerRect = scroller.getBoundingClientRect();
     const cursorRect = element.getBoundingClientRect();
 

--- a/apps/website/src/lib/editor/editor.svelte.ts
+++ b/apps/website/src/lib/editor/editor.svelte.ts
@@ -161,6 +161,8 @@ export class Editor {
     pageElements: [] as HTMLElement[],
   });
 
+  scrollContainerEl = $state<HTMLElement | null>(null);
+
   pageContainerEls = $state<HTMLDivElement[]>([]);
 
   #lastClickTime = 0;

--- a/apps/website/src/lib/editor/typewriter.svelte.ts
+++ b/apps/website/src/lib/editor/typewriter.svelte.ts
@@ -1,7 +1,6 @@
 import { getAppContext } from '@typie/ui/context';
 import { CONTINUOUS_PAGE_MARGIN, PAGE_GAP } from './constants';
 import { getEditor } from './context';
-import { findScroller } from './utils';
 
 export function typewriterPadding(node: HTMLElement, defaultPadding: number) {
   const editor = getEditor();
@@ -11,9 +10,13 @@ export function typewriterPadding(node: HTMLElement, defaultPadding: number) {
     return;
   }
 
+  const scroller = editor.scrollContainerEl;
+  if (!scroller) {
+    return;
+  }
+
   const app = getAppContext();
 
-  const scroller = findScroller(node);
   let scrollContainerHeight = 0;
 
   const resizeObserver = new ResizeObserver((entries) => {

--- a/apps/website/src/lib/editor/utils.ts
+++ b/apps/website/src/lib/editor/utils.ts
@@ -26,24 +26,6 @@ export const calculateRelativePosition = (element: HTMLElement, e: MouseEvent | 
   };
 };
 
-export const findScroller = (element: HTMLElement): HTMLElement => {
-  let currentElement = element;
-  while (true) {
-    const style = getComputedStyle(currentElement);
-    const overflowY = style.overflowY;
-    const isScrollable = overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'overlay';
-
-    if (isScrollable && currentElement.scrollHeight > currentElement.clientHeight) {
-      return currentElement;
-    }
-    if (!currentElement.parentElement || !(currentElement.parentElement instanceof HTMLElement)) {
-      break;
-    }
-    currentElement = currentElement.parentElement;
-  }
-  return currentElement;
-};
-
 export const idleCallback = (callback: () => void): void => {
   if (typeof requestIdleCallback === 'undefined') {
     setTimeout(callback);

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@document-panel/DocumentPanelTimeline.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@document-panel/DocumentPanelTimeline.svelte
@@ -16,7 +16,7 @@
   import MinusIcon from '~icons/lucide/minus';
   import PlusIcon from '~icons/lucide/plus';
   import { fragment, graphql } from '$graphql';
-  import { findScroller, idleCallback } from '$lib/editor/utils';
+  import { idleCallback } from '$lib/editor/utils';
   import { getViewContext } from '../@split-view/context.svelte';
   import type { Action } from 'svelte/action';
   import type { PointerEventHandler } from 'svelte/elements';
@@ -61,14 +61,7 @@
   const app = getAppContext();
   const view = getViewContext();
 
-  let editorContainer = $state<HTMLElement | null>(null);
-
-  $effect(() => {
-    const containerEl = editor.extensionArea.containerEl;
-    if (containerEl) {
-      editorContainer = findScroller(containerEl).parentElement;
-    }
-  });
+  let editorContainer = $derived.by(() => editor.scrollContainerEl);
 
   let selectedVersionId = $state<string | null>(null);
   let isLoading = $state(true);

--- a/apps/website/src/routes/website/(dashboard)/[slug]/SpellcheckPopover.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/SpellcheckPopover.svelte
@@ -5,7 +5,6 @@
   import { Icon } from '@typie/ui/components';
   import ArrowRightIcon from '~icons/lucide/arrow-right';
   import XIcon from '~icons/lucide/x';
-  import { findScroller } from '$lib/editor/utils';
   import type { Editor } from '$lib/editor/editor.svelte';
 
   type Props = {
@@ -21,7 +20,7 @@
     editor.activeSpellcheckErrorId ? editor.fullSpellcheckErrors.find((e) => e.id === editor.activeSpellcheckErrorId) : null,
   );
 
-  let scroller = $state<HTMLElement | null>(null);
+  const scroller = $derived.by(() => editor.scrollContainerEl);
 
   const { anchor, floating } = createFloatingActions({
     placement: 'top',
@@ -58,11 +57,6 @@
   $effect(() => {
     if (activeOverlay?.bounds?.[0]) {
       const pageIdx = activeOverlay.pageIdx;
-      const pageEl = editor.pageContainerEls[pageIdx];
-
-      if (pageEl) {
-        scroller = findScroller(pageEl) as HTMLElement;
-      }
 
       const virtualEl = {
         getBoundingClientRect: () => {


### PR DESCRIPTION
에디터에서 overflow가 안 일어날 때 더 상위의 dom을 찾는 동작이 이런저런 버그를 발생시킴
항상 동일한 dom을 `editor.scrollContainerEl`로서 저장해서 사용하도록 함