### PR TITLE
무료 플랜 글자수 및 파일 업로드 용량 제한 증가

### DIFF
--- a/apps/api/src/const.ts
+++ b/apps/api/src/const.ts
@@ -16,8 +16,8 @@ export const PlanPair = {
 } as const;
 
 export const defaultPlanRules: PlanRules = {
-  maxTotalCharacterCount: 16_000,
-  maxTotalBlobSize: 20 * 1000 * 1000,
+  maxTotalCharacterCount: 200_000,
+  maxTotalBlobSize: 100 * 1000 * 1000,
 };
 
 export const SUBSCRIPTION_GRACE_DAYS = 7;

--- a/apps/mobile/lib/constants/plan_features.dart
+++ b/apps/mobile/lib/constants/plan_features.dart
@@ -9,8 +9,8 @@ class PlanFeature {
 }
 
 const basicPlanFeatures = <PlanFeature>[
-  PlanFeature(icon: LucideLightIcons.book_open_text, label: '16,000자까지 작성 가능'),
-  PlanFeature(icon: LucideLightIcons.images, label: '20MB까지 파일 업로드 가능'),
+  PlanFeature(icon: LucideLightIcons.book_open_text, label: '200,000자까지 작성 가능'),
+  PlanFeature(icon: LucideLightIcons.images, label: '100MB까지 파일 업로드 가능'),
 ];
 
 const fullPlanFeatures = <PlanFeature>[

--- a/packages/ui/src/constants/plan-features.ts
+++ b/packages/ui/src/constants/plan-features.ts
@@ -16,8 +16,8 @@ export type PlanFeature = {
 
 export const PLAN_FEATURES: Record<'basic' | 'full', PlanFeature[]> = {
   basic: [
-    { icon: TypeIcon, label: '총 16,000자의 글자 작성' },
-    { icon: ImagesIcon, label: '총 20MB의 파일 업로드' },
+    { icon: TypeIcon, label: '총 200,000자의 글자 작성' },
+    { icon: ImagesIcon, label: '총 100MB의 파일 업로드' },
   ],
   full: [
     { icon: TypeIcon, label: '무제한 글자 수' },


### PR DESCRIPTION
글자수: 16,000자 -> 200,000자
파일 업로드 용량: 20MB -> 100MB
