### PR TITLE
웹 드래그 이미지 디버그

### DIFF
--- a/apps/mobile/lib/screens/native_editor/view/editor_draggable.dart
+++ b/apps/mobile/lib/screens/native_editor/view/editor_draggable.dart
@@ -101,33 +101,12 @@ class EditorDraggable extends StatelessWidget {
     final geo = scope.geometry;
     final offsets = geo.computeCumulativePageOffsets();
 
-    final textRect = Rect.fromLTWH(
+    final unionRect = Rect.fromLTWH(
       imageRecord.offsetX,
       imageRecord.offsetY,
       imageRecord.image.width / imageRecord.scale,
       imageRecord.image.height / imageRecord.scale,
     );
-
-    var unionRect = textRect;
-    final elements = scope.controller.state.externalElements;
-
-    for (final element in elements) {
-      if (!element.isSelected || element.pageIdx != imageRecord.pageIdx) {
-        continue;
-      }
-
-      final widget = element.data.mapOrNull(
-        image: (imageData) {
-          final displayWidth = element.bounds.width * imageData.proportion;
-          final xOffset = (element.bounds.width - displayWidth) / 2;
-          return Rect.fromLTWH(element.bounds.x + xOffset, element.bounds.y, displayWidth, element.bounds.height);
-        },
-      );
-
-      if (widget != null) {
-        unionRect = unionRect.expandToInclude(widget);
-      }
-    }
 
     return SnapshotSettings(
       translation: (rect, point) {
@@ -147,10 +126,10 @@ class EditorDraggable extends StatelessWidget {
         clipBehavior: Clip.none,
         children: [
           Positioned(
-            left: textRect.left - unionRect.left,
-            top: textRect.top - unionRect.top,
-            width: textRect.width,
-            height: textRect.height,
+            left: 0,
+            top: 0,
+            width: unionRect.width,
+            height: unionRect.height,
             child: RawImage(image: imageRecord.image, scale: imageRecord.scale),
           ),
           ..._buildExternalElements(context, scope, imageRecord, unionRect),

--- a/apps/website/src/lib/editor/editor.svelte.ts
+++ b/apps/website/src/lib/editor/editor.svelte.ts
@@ -941,16 +941,10 @@ export class Editor {
     const buffer = new Uint8ClampedArray(wasmMemory.buffer, ptr, len);
     const imageData = new ImageData(new Uint8ClampedArray(buffer), width, height);
 
-    const tempCanvas = document.createElement('canvas');
-    tempCanvas.width = width;
-    tempCanvas.height = height;
-    const tempCtx = tempCanvas.getContext('2d');
-    if (!tempCtx) return null;
-    tempCtx.putImageData(imageData, 0, 0);
-
     const canvas = document.createElement('canvas');
     canvas.width = width;
     canvas.height = height;
+
     const cssWidth = Math.ceil(width / scaleFactor);
     const cssHeight = Math.ceil(height / scaleFactor);
     canvas.style.width = `${cssWidth}px`;
@@ -960,9 +954,29 @@ export class Editor {
     if (!ctx) return null;
 
     ctx.save();
-    ctx.globalAlpha = 0.7;
+    ctx.globalAlpha = 0.5;
 
-    ctx.drawImage(tempCanvas, 0, 0);
+    ctx.putImageData(imageData, 0, 0);
+
+    const selectedImages = this.#getSelectedDragImages(visiblePages, pageIdx);
+    for (const { image, rect } of selectedImages) {
+      const destX = (rect.x - offsetX) * scaleFactor;
+      const destY = (rect.y - offsetY) * scaleFactor;
+      const destW = rect.width * scaleFactor;
+      const destH = rect.height * scaleFactor;
+      ctx.drawImage(image, destX, destY, destW, destH);
+    }
+
+    ctx.restore();
+
+    return { element: canvas, offsetX, offsetY };
+  }
+
+  #getSelectedDragImages(
+    visiblePages: number[],
+    pageIdx: number,
+  ): { image: HTMLImageElement; rect: { x: number; y: number; width: number; height: number } }[] {
+    const selectedImages: { image: HTMLImageElement; rect: { x: number; y: number; width: number; height: number } }[] = [];
 
     for (const el of this.externalElements) {
       if (!el.isSelected || el.data.type !== 'image' || !visiblePages.includes(el.pageIdx)) {
@@ -980,8 +994,12 @@ export class Editor {
         relativePageY = el.pageIdx < pageIdx ? -dist : dist;
       }
 
-      const imgElement = document.querySelector(`div[data-node-id="${el.nodeId}"] img`);
-      if (imgElement instanceof HTMLImageElement && el.data.type === 'image') {
+      let imgElement = document.querySelector(`div[data-node-id="${el.nodeId}"] img:not([loading="lazy"])`);
+      if (!imgElement) {
+        imgElement = document.querySelector(`div[data-node-id="${el.nodeId}"] img`);
+      }
+
+      if (imgElement instanceof HTMLImageElement) {
         const imageId = el.data.id;
         const uploadId = el.data.uploadId;
         const asset = imageId ? this.imageAssets.get(imageId) : undefined;
@@ -991,20 +1009,19 @@ export class Editor {
         const { displayWidth, xOffset } = calculateImageDisplaySize(el.bounds, originalWidth, originalHeight);
 
         const globalX = el.bounds.x + xOffset;
-        const globalY = el.bounds.y;
+        const globalY = relativePageY + el.bounds.y;
 
-        const destX = (globalX - offsetX) * scaleFactor;
-        const destY = (relativePageY + globalY - offsetY) * scaleFactor;
-        const destW = displayWidth * scaleFactor;
-        const destH = el.bounds.height * scaleFactor;
+        const rect = {
+          x: globalX,
+          y: globalY,
+          width: displayWidth,
+          height: el.bounds.height,
+        };
 
-        ctx.drawImage(imgElement, destX, destY, destW, destH);
+        selectedImages.push({ image: imgElement, rect });
       }
     }
-
-    ctx.restore();
-
-    return { element: canvas, offsetX, offsetY };
+    return selectedImages;
   }
 
   handleDragOver(e: DragEvent): void {

--- a/crates/editor/src/layout/query.rs
+++ b/crates/editor/src/layout/query.rs
@@ -42,6 +42,16 @@ pub fn find_node_bounds_on_page(
     node_id: NodeId,
     page_idx: usize,
 ) -> Option<NodeBounds> {
+    find_node_rect_on_page(doc, page, node_id).map(|rect| NodeBounds {
+        page_idx,
+        x: rect.x,
+        y: rect.y,
+        width: rect.width,
+        height: rect.height,
+    })
+}
+
+pub fn find_node_rect_on_page(doc: &Doc, page: &Page, node_id: NodeId) -> Option<Rect> {
     let targets = collect_leaf_ids(doc, node_id);
     if targets.is_empty() {
         return None;
@@ -49,7 +59,17 @@ pub fn find_node_bounds_on_page(
 
     let mut acc = BoundsAccumulator::new();
     scan_layout_node(&page.root, &targets, Point::zero(), &mut acc);
-    acc.to_bounds(page_idx)
+
+    if acc.found {
+        Some(Rect::new(
+            acc.min_x,
+            acc.min_y,
+            acc.max_x - acc.min_x,
+            acc.max_y - acc.min_y,
+        ))
+    } else {
+        None
+    }
 }
 
 fn collect_leaf_ids(doc: &Doc, root_id: NodeId) -> HashSet<NodeId> {
@@ -172,11 +192,33 @@ pub fn find_drag_image_bounds(
     }
 
     let decorations = build_selection_decorations(doc, selection, None);
-    if decorations.is_empty() {
+    let non_text_blocks = collect_selected_non_text_blocks(doc, selection);
+
+    if decorations.is_empty() && non_text_blocks.is_empty() {
         return None;
     }
 
-    let drag_pages = collect_page_bounds_from_decorations(pages, &decorations);
+    let mut drag_pages = Vec::new();
+
+    for (page_idx, page) in pages.iter().enumerate() {
+        let rects =
+            collect_page_selection_bounds(doc, page, selection, &decorations, &non_text_blocks);
+
+        if !rects.is_empty() {
+            let mut acc = BoundsAccumulator::new();
+            for rect in &rects {
+                acc.add_rect(rect.x, rect.y, rect.width, rect.height);
+            }
+
+            if let Some(overall_bounds) = acc.to_bounds(page_idx) {
+                drag_pages.push(DragImagePageBounds {
+                    page_idx,
+                    bounds: overall_bounds.to_rect(),
+                    clip_rects: rects,
+                });
+            }
+        }
+    }
 
     if drag_pages.is_empty() {
         None
@@ -185,46 +227,43 @@ pub fn find_drag_image_bounds(
     }
 }
 
-fn collect_page_bounds_from_decorations(
-    pages: &[Page],
-    decorations: &[SelectionDecor],
-) -> Vec<DragImagePageBounds> {
-    let mut drag_pages = Vec::new();
-
-    for (page_idx, page) in pages.iter().enumerate() {
-        if let Some(page_bounds) = collect_single_page_selection_bounds(page, page_idx, decorations)
+fn collect_selected_non_text_blocks(doc: &Doc, selection: &crate::state::Selection) -> Vec<NodeId> {
+    if let Ok((from, to)) = selection.as_sorted(doc) {
+        if let Ok(blocks) = crate::state::selection_helpers::collect_blocks_in_range(doc, from, to)
         {
-            drag_pages.push(page_bounds);
+            return blocks
+                .into_iter()
+                .filter(|&id| {
+                    doc.node(id)
+                        .map(|n| !n.spec().is_textblock(doc.schema()))
+                        .unwrap_or(false)
+                })
+                .collect();
+        }
+    }
+    Vec::new()
+}
+
+fn collect_page_selection_bounds(
+    doc: &Doc,
+    page: &Page,
+    _selection: &crate::state::Selection,
+    decorations: &[SelectionDecor],
+    non_text_blocks: &[NodeId],
+) -> Vec<Rect> {
+    let mut rects = Vec::new();
+
+    if !decorations.is_empty() {
+        scan_for_selection_bounds(&page.root, Point::zero(), decorations, &mut rects);
+    }
+
+    for &block_id in non_text_blocks {
+        if let Some(rect) = find_node_rect_on_page(doc, page, block_id) {
+            rects.push(rect);
         }
     }
 
-    drag_pages
-}
-
-fn collect_single_page_selection_bounds(
-    page: &Page,
-    page_idx: usize,
-    decorations: &[SelectionDecor],
-) -> Option<DragImagePageBounds> {
-    let mut clip_rects = Vec::new();
-    scan_for_selection_bounds(&page.root, Point::zero(), decorations, &mut clip_rects);
-
-    if clip_rects.is_empty() {
-        return None;
-    }
-
-    let mut acc = BoundsAccumulator::new();
-    for rect in &clip_rects {
-        acc.add_rect(rect.x, rect.y, rect.width, rect.height);
-    }
-
-    let overall_bounds = acc.to_bounds(page_idx)?;
-
-    Some(DragImagePageBounds {
-        page_idx,
-        bounds: overall_bounds.to_rect(),
-        clip_rects,
-    })
+    rects
 }
 
 fn scan_for_selection_bounds(
@@ -263,7 +302,6 @@ fn scan_for_selection_bounds(
     }
 }
 
-// TODO: selection decoration 뿐만 아니라 selected external element도 고려해야 함
 pub fn is_point_in_selection_bounds(
     doc: &Doc,
     page: &Page,
@@ -275,14 +313,15 @@ pub fn is_point_in_selection_bounds(
     }
 
     let decorations = build_selection_decorations(doc, selection, None);
-    if decorations.is_empty() {
+    let non_text_blocks = collect_selected_non_text_blocks(doc, selection);
+
+    if decorations.is_empty() && non_text_blocks.is_empty() {
         return false;
     }
 
-    let mut clip_rects = Vec::new();
-    scan_for_selection_bounds(&page.root, Point::zero(), &decorations, &mut clip_rects);
+    let rects = collect_page_selection_bounds(doc, page, selection, &decorations, &non_text_blocks);
 
-    for rect in clip_rects {
+    for rect in rects {
         if point.x >= rect.x
             && point.x <= rect.x + rect.width
             && point.y >= rect.y


### PR DESCRIPTION
- opacity 0.7 -> 0.5
- crop하는 bounds에 image bounds를 union하도록 하며 그것을 rust backend에서 수행
- 원본 이미지를 먼저 사용하고 fallback으로 placeholder 이미지 사용
- 이미지 단독으로 드래그 이미지 안 만들어지는 버그 수정