### PR TITLE
단일 블록 셀렉션 중 엔터 -> 단일 비텍스트블록 셀렉션 중 엔터로 조건 좁힘

### DIFF
--- a/crates/editor/src/runtime/handlers/insertion.rs
+++ b/crates/editor/src/runtime/handlers/insertion.rs
@@ -3,7 +3,7 @@ use super::super::{Effect, Runtime};
 impl Runtime {
     pub(crate) fn handle_insert_newline(&mut self) -> Vec<Effect> {
         self.transact(|tr| {
-            if tr.insert_paragraph_on_block()? {
+            if tr.insert_paragraph_on_nontextblock_selection()? {
                 return Ok(true);
             }
             tr.delete_selection()?;
@@ -28,7 +28,7 @@ impl Runtime {
 
     pub(crate) fn handle_insert_page_break(&mut self) -> Vec<Effect> {
         self.transact(|tr| {
-            tr.insert_paragraph_on_block()?;
+            tr.insert_paragraph_on_nontextblock_selection()?;
             tr.delete_selection()?;
             tr.insert_page_break()
         })

--- a/crates/editor/src/transaction/paragraph.rs
+++ b/crates/editor/src/transaction/paragraph.rs
@@ -336,7 +336,7 @@ impl Transaction {
         }
     }
 
-    pub fn insert_paragraph_on_block(&mut self) -> Result<bool> {
+    pub fn insert_paragraph_on_nontextblock_selection(&mut self) -> Result<bool> {
         let selection = self.selection().clone();
         if selection.is_collapsed() {
             return Ok(false);
@@ -353,6 +353,10 @@ impl Transaction {
         }
 
         let block = self.node(block_id).context("Block not found")?;
+        if block.spec().is_textblock(self.doc().schema()) {
+            return Ok(false);
+        }
+
         let parent = block.parent().context("Parent not found")?;
         let parent_id = parent.node_id();
 
@@ -1083,7 +1087,9 @@ mod tests {
             selection { (NodeId::ROOT, 0) -> (NodeId::ROOT, 1) }
         };
 
-        let actual = transact!(initial, |tr| tr.insert_paragraph_on_block().unwrap());
+        let actual = transact!(initial, |tr| tr
+            .insert_paragraph_on_nontextblock_selection()
+            .unwrap());
 
         let expected = state! {
             doc {
@@ -1116,7 +1122,9 @@ mod tests {
             selection { (NodeId::ROOT, 1) -> (NodeId::ROOT, 2) }
         };
 
-        let actual = transact!(initial, |tr| tr.insert_paragraph_on_block().unwrap());
+        let actual = transact!(initial, |tr| tr
+            .insert_paragraph_on_nontextblock_selection()
+            .unwrap());
 
         let expected = state! {
             doc {


### PR DESCRIPTION
이미지 등 선택된 상태에서 엔터 누르면 위에 paragraph가 삽입되는 동작을 위한 것이었으나 문서에 paragraph 1개 있는 상태에서 전체 선택을 해도 block selection이 되어서, 엔터를 누르면 다 지워지고 엔터 쳐지는 게 아니라 paragraph 그대로 남고 위에 paragraph가 또 생기는 문제가 있어서 해결함