### PR TITLE
is_collapsed_block_selection 등

### DIFF
--- a/crates/editor/src/runtime/handlers/deletion.rs
+++ b/crates/editor/src/runtime/handlers/deletion.rs
@@ -152,7 +152,7 @@ impl Runtime {
         let is_external = self
             .doc()
             .node(node_id)
-            .map(|n| matches!(n.node(), Node::Image(_) | Node::File(_)))
+            .map(|n| matches!(n.node(), Node::Image(_) | Node::File(_) | Node::Embed(_)))
             .unwrap_or(false);
 
         self.transact(move |tr| {

--- a/crates/editor/src/state/position_helpers.rs
+++ b/crates/editor/src/state/position_helpers.rs
@@ -108,6 +108,10 @@ pub fn calculate_offset_before_child(block: &NodeRef, target_child_id: NodeId) -
     offset
 }
 
+pub fn eq_positions_ignoring_affinity(a: Position, b: Position) -> bool {
+    a.node_id == b.node_id && a.offset == b.offset
+}
+
 pub fn compare_positions(doc: &Doc, a: Position, b: Position) -> Result<Ordering> {
     if a == b {
         return Ok(Ordering::Equal);
@@ -172,9 +176,7 @@ pub fn leaf_block_start(node: &NodeRef<'_>) -> Position {
 }
 
 pub fn leaf_block_end(node: &NodeRef<'_>) -> Position {
-    if node.spec().is_textblock(node.schema())
-        || node.node_type() == crate::model::NodeType::FoldTitle
-    {
+    if node.spec().is_textblock(node.schema()) {
         return Position::new(
             node.node_id(),
             block_content_len(node),
@@ -191,6 +193,7 @@ pub fn leaf_block_end(node: &NodeRef<'_>) -> Position {
             .index()
             .context("leaf_block_end: node has no index")
             .unwrap();
+        // TODO: Upstream으로 바꿔야 함
         return Position::new(parent_id, idx + 1, Affinity::Downstream);
     }
 
@@ -206,9 +209,7 @@ pub fn move_from_block_position(doc: &Doc, position: Position, go_forward: bool)
         return position;
     };
 
-    if node.spec().is_textblock(node.schema())
-        || node.node_type() == crate::model::NodeType::FoldTitle
-    {
+    if node.spec().is_textblock(node.schema()) {
         return position;
     }
 

--- a/crates/editor/src/state/selection.rs
+++ b/crates/editor/src/state/selection.rs
@@ -1,7 +1,7 @@
 use crate::model::{Doc, Fragment, Node, NodeId};
-use crate::state::BlockTraverser;
 use crate::state::position::Position;
 use crate::state::position_helpers::{compare_positions, is_block_position};
+use crate::state::{BlockTraverser, eq_positions_ignoring_affinity};
 use anyhow::{Context, Result};
 use std::cmp::Ordering;
 
@@ -25,6 +25,11 @@ impl Selection {
 
     pub fn is_collapsed(&self) -> bool {
         self.anchor == self.head
+    }
+
+    pub fn is_collapsed_block_selection(&self, doc: &Doc) -> bool {
+        eq_positions_ignoring_affinity(self.anchor, self.head)
+            && is_block_position(doc, self.anchor)
     }
 
     pub fn as_sorted(&self, doc: &Doc) -> Result<(Position, Position)> {

--- a/crates/editor/src/transaction/document.rs
+++ b/crates/editor/src/transaction/document.rs
@@ -1210,7 +1210,7 @@ impl Transaction {
 
         self.delete_node_recursive(node_id)?;
 
-        // TODO: 삭제되는 노드 내부에 selection이 있는 경우 삭제되는 노드 start position으로 selection을 이동시키기
+        // TODO: 삭제되는 노드 내부에 selection이 있는 경우 삭제되는 노드 start position으로 selection을 이동시키기. 지금은 이 함수를 쓰는 경우가 external element 삭제 케이스밖에 없어서 노드 내부에 selection이 있을 수 없음.
         if let (Some(parent_id), Some(node_index)) = (parent_id, node_index) {
             let mut selection = *self.selection();
             let mut changed = false;

--- a/crates/editor/src/transaction/mod.rs
+++ b/crates/editor/src/transaction/mod.rs
@@ -162,7 +162,7 @@ impl Transaction {
     fn normalize_selection(&mut self) {
         let selection = &self.state.selection;
 
-        if !selection.is_collapsed() {
+        if !(selection.is_collapsed() || selection.is_collapsed_block_selection(self.doc())) {
             return;
         }
 


### PR DESCRIPTION
- handle_delete_node에서 Embed도 external element 취급
- normalize_selection 할 때 엄격하게 collapsed가 아니어도 block position selection이면 is_collapsed_block_selection로 검사해서 affinity 무시