### PR TITLE
Menu, ContextMenu 디버그 및 개선

### DIFF
--- a/apps/website/src/lib/components/editor/core/Input.svelte
+++ b/apps/website/src/lib/components/editor/core/Input.svelte
@@ -87,9 +87,8 @@
   };
 
   const handleKeyDown = (e: KeyboardEvent) => {
-    if (e.key === 'Escape' && editor.contextMenu.isOpen) {
+    if (editor.contextMenu.isOpen) {
       e.preventDefault();
-      editor.closeContextMenu();
       return;
     }
 

--- a/packages/ui/src/components/Menu.svelte
+++ b/packages/ui/src/components/Menu.svelte
@@ -101,7 +101,7 @@
   });
 
   const getMenuItems = () => {
-    return menuEl?.querySelectorAll('[role="menuitem"], [role="menuitemradio"]');
+    return menuEl?.querySelectorAll('[role="menuitem"]:not(:disabled), [role="menuitemradio"]:not(:disabled)');
   };
 
   const onKeydown = (e: KeyboardEvent) => {
@@ -136,7 +136,7 @@
           const prev = (menuItems[pos - 1] || menuItems[menuItems.length - 1]) as HTMLElement;
           prev?.focus();
         }
-      } else if (focusInButton && ['ArrowDown', 'ArrowUp'].includes(e.key)) {
+      } else if (['ArrowDown', 'ArrowUp'].includes(e.key)) {
         e.preventDefault();
         (menuItems[0] as HTMLElement).focus();
       }

--- a/packages/ui/src/components/MenuItem.svelte
+++ b/packages/ui/src/components/MenuItem.svelte
@@ -75,6 +75,7 @@
         fontWeight: 'medium',
         textAlign: 'left',
         transition: 'common',
+        _focus: { backgroundColor: 'surface.muted' },
         _hover: { backgroundColor: 'surface.muted' },
         _disabled: {
           color: 'text.disabled!',


### PR DESCRIPTION
- context menu 닫는 것은 Menu가 알아서 처리하고 editor Input에서는 처리하지 않도록 함
- editor Input에서 contextMenu.isOpen일 때 입력 무시하도록 함
- Menu에서 키보드 내비게이션 가능한 MenuItem 목록 얻을 때 disabled는 제외하고 쿼리
- Menu 열려있고 리스트에 포커스 없을 때, 반드시 트리거 버튼에 포커스가 있지 않더라도 상하키 누르면 첫 아이템으로 포커스 가도록 함
- MenuItem 포커스 시 hover와 같은 스타일 적용

## 요약
- collapsed일 때 context menu 열려있어도 방향키로 이동 가능한 버그를 해- 결함
- Menu 키보드 탐색이 쉬워짐