### PR TITLE
typewriter extra padding 디버그

### DIFF
--- a/apps/mobile/lib/screens/native_editor/handler/command.dart
+++ b/apps/mobile/lib/screens/native_editor/handler/command.dart
@@ -171,32 +171,27 @@ class CommandHandler {
     final cmp = reader.getI32('selection_cmp');
     final collapsed = cmp == 0;
 
-    SelectionEndpointBounds? anchorBounds;
-    SelectionEndpointBounds? headBounds;
+    final anchorPageIdx = reader.getI32('selection_anchor_page_idx');
+    final anchorBounds = anchorPageIdx < 0
+        ? null
+        : SelectionEndpointBounds(
+            pageIdx: anchorPageIdx,
+            x: reader.getF32('selection_anchor_x'),
+            y: reader.getF32('selection_anchor_y'),
+            width: reader.getF32('selection_anchor_width'),
+            height: reader.getF32('selection_anchor_height'),
+          );
 
-    if (!collapsed) {
-      final anchorPageIdx = reader.getI32('selection_anchor_page_idx');
-      anchorBounds = anchorPageIdx < 0
-          ? null
-          : SelectionEndpointBounds(
-              pageIdx: anchorPageIdx,
-              x: reader.getF32('selection_anchor_x'),
-              y: reader.getF32('selection_anchor_y'),
-              width: reader.getF32('selection_anchor_width'),
-              height: reader.getF32('selection_anchor_height'),
-            );
-
-      final headPageIdx = reader.getI32('selection_head_page_idx');
-      headBounds = headPageIdx < 0
-          ? null
-          : SelectionEndpointBounds(
-              pageIdx: headPageIdx,
-              x: reader.getF32('selection_head_x'),
-              y: reader.getF32('selection_head_y'),
-              width: reader.getF32('selection_head_width'),
-              height: reader.getF32('selection_head_height'),
-            );
-    }
+    final headPageIdx = reader.getI32('selection_head_page_idx');
+    final headBounds = headPageIdx < 0
+        ? null
+        : SelectionEndpointBounds(
+            pageIdx: headPageIdx,
+            x: reader.getF32('selection_head_x'),
+            y: reader.getF32('selection_head_y'),
+            width: reader.getF32('selection_head_width'),
+            height: reader.getF32('selection_head_height'),
+          );
 
     final expandable = reader.getU32('selection_expandable');
 

--- a/apps/mobile/lib/screens/native_editor/state/state.dart
+++ b/apps/mobile/lib/screens/native_editor/state/state.dart
@@ -58,8 +58,8 @@ abstract class EditorSelection with _$EditorSelection {
 
   const EditorSelection._();
 
-  SelectionEndpointBounds? get fromBounds => cmp < 0 ? headBounds : anchorBounds;
-  SelectionEndpointBounds? get toBounds => cmp < 0 ? anchorBounds : headBounds;
+  SelectionEndpointBounds? get fromBounds => collapsed ? null : (cmp < 0 ? headBounds : anchorBounds);
+  SelectionEndpointBounds? get toBounds => collapsed ? null : (cmp < 0 ? anchorBounds : headBounds);
 
   bool get canExpandWord => expandable & 1 != 0;
   bool get canExpandSentence => expandable & 2 != 0;

--- a/apps/mobile/lib/screens/native_editor/view/editor.dart
+++ b/apps/mobile/lib/screens/native_editor/view/editor.dart
@@ -311,6 +311,7 @@ class EditorView extends HookWidget {
           titleAreaHeight: titleAreaHeight.value,
           layout: controller.state.layout!,
           pages: controller.state.pages,
+          selection: controller.state.selection,
         ),
         cursor: c,
         typewriterEnabled: typewriter,

--- a/apps/mobile/lib/screens/native_editor/view/geometry.dart
+++ b/apps/mobile/lib/screens/native_editor/view/geometry.dart
@@ -3,18 +3,22 @@ import 'dart:math' as math;
 import 'package:typie/screens/native_editor/state/state.dart';
 
 class ContentGeometry {
-  const ContentGeometry({required this.layout, required this.pages, required this.titleAreaHeight});
+  const ContentGeometry({required this.layout, required this.pages, required this.titleAreaHeight, this.selection});
 
   final Layout layout;
   final List<PageSize> pages;
   final double titleAreaHeight;
+  final EditorSelection? selection;
 
   static const pageGap = 24.0;
   static const pagePadding = 40.0;
+  static const continuousPageMargin = 20.0;
 
   bool get isPaginated => layout is PaginatedLayout;
   double get horizontalPadding => isPaginated ? pagePadding : 0.0;
   double get defaultBottomPadding => isPaginated ? pagePadding : 200.0;
+  double get trailingBottomMargin =>
+      layout is PaginatedLayout ? (layout as PaginatedLayout).pageMarginBottom : continuousPageMargin;
 
   double gapAfterPage(int index) => isPaginated && index < pages.length - 1 ? pageGap : 0.0;
 
@@ -38,6 +42,13 @@ class ContentGeometry {
 
   double cursorTopInContent(CursorInfo cursor) => cursorTopInPages(cursor) + titleAreaHeight;
 
+  double? get collapsedSelectionHandleHeight {
+    if (!(selection?.collapsed ?? false)) {
+      return null;
+    }
+    return selection?.headBounds?.height ?? selection?.anchorBounds?.height;
+  }
+
   List<double> computeCumulativePageOffsets() {
     final offsets = <double>[0];
     for (var i = 0; i < pages.length; i++) {
@@ -57,12 +68,14 @@ class ContentGeometry {
       return defaultBottomPadding;
     }
 
-    final cursorTopInDoc = cursorTopInPages(cursor);
-    final spaceNeededBelow = (1 - typewriterPosition) * (viewportHeight - cursor.height) + 2 * cursor.height;
-    final contentBelow = pagesContentHeight - cursorTopInDoc;
-    final extraPadding = spaceNeededBelow - contentBelow;
+    final cursorHeight = cursor.height;
+    final handleHeight = collapsedSelectionHandleHeight ?? cursorHeight;
+    final cursorLeading = math.max(0, handleHeight - cursorHeight);
+    final spaceNeededBelowCursorTop = (1 - typewriterPosition) * (viewportHeight - cursorHeight) + cursorHeight;
+    final intrinsicSpaceBelowLastLine = trailingBottomMargin + cursorHeight + cursorLeading;
+    final requiredPadding = spaceNeededBelowCursorTop - intrinsicSpaceBelowLastLine;
 
-    return math.max(defaultBottomPadding, extraPadding);
+    return math.max(defaultBottomPadding, requiredPadding);
   }
 
   double totalContentHeight({

--- a/apps/mobile/lib/screens/native_editor/view/scope.dart
+++ b/apps/mobile/lib/screens/native_editor/view/scope.dart
@@ -52,6 +52,7 @@ class ContentScope extends InheritedWidget {
       layout: controller.state.layout!,
       pages: controller.state.pages,
       titleAreaHeight: titleAreaHeight.value,
+      selection: controller.state.selection,
     );
   }
 

--- a/apps/website/src/lib/editor/typewriter.svelte.ts
+++ b/apps/website/src/lib/editor/typewriter.svelte.ts
@@ -1,5 +1,5 @@
 import { getAppContext } from '@typie/ui/context';
-import { PAGE_GAP } from './constants';
+import { CONTINUOUS_PAGE_MARGIN } from './constants';
 import { getEditorContext } from './context.svelte';
 
 export function setupTypewriter(getTargetEl: () => HTMLElement | undefined, defaultPadding: number) {
@@ -83,40 +83,25 @@ export function setupTypewriter(getTargetEl: () => HTMLElement | undefined, defa
       return defaultPadding;
     }
 
-    const isPaginated = editor.layout.layoutMode.type === 'paginated';
+    const layoutMode = editor.layout.layoutMode;
+    const trailingBottomMargin = layoutMode.type === 'paginated' ? layoutMode.pageMarginBottom : CONTINUOUS_PAGE_MARGIN;
     const cursorHeight = editor.cursor.bounds?.height ?? 0;
-
-    const totalContentHeight =
-      editor.layout.pages.reduce((sum, p) => sum + p.height, 0) + (isPaginated ? (editor.layout.pages.length - 1) * PAGE_GAP : 0);
-
-    const bounds = editor.cursor.bounds;
-    const pageIdx = editor.cursor.pageIdx;
-    let cursorTopInDocument = 0;
-    if (bounds && pageIdx !== undefined) {
-      for (let i = 0; i < pageIdx; i++) {
-        cursorTopInDocument += editor.layout.pages[i]?.height ?? 0;
-        if (isPaginated) cursorTopInDocument += PAGE_GAP;
-      }
-      cursorTopInDocument += bounds.y;
-      if (!isPaginated) cursorTopInDocument += defaultPadding;
-    }
-
-    const totalScrollableContentHeight = totalContentHeight + (isPaginated ? 0 : defaultPadding);
-
-    const position = app.preference.current.typewriterPosition;
+    const collapsedSelectionHeight = editor.selection?.collapsed
+      ? (editor.selection.headBounds?.bounds.height ?? cursorHeight)
+      : cursorHeight;
+    const cursorLeading = Math.max(0, collapsedSelectionHeight - cursorHeight);
+    const position = app.preference.current.typewriterPosition ?? 0.5;
     const availableRange = scrollContainerHeight - cursorHeight;
-
     const spaceNeededBelowCursorTop = (1 - position) * availableRange + cursorHeight;
-    const contentBelowCursorTop = totalScrollableContentHeight - cursorTopInDocument;
+    const intrinsicSpaceBelowLastLine = trailingBottomMargin + cursorHeight + cursorLeading;
+    const requiredPadding = spaceNeededBelowCursorTop - intrinsicSpaceBelowLastLine;
 
-    const extraPaddingNeeded = spaceNeededBelowCursorTop - contentBelowCursorTop;
-    return Math.max(defaultPadding, extraPaddingNeeded);
+    return Math.max(defaultPadding, requiredPadding);
   }
 
   $effect(() => {
     void editor.cursor.bounds;
-    void editor.cursor.pageIdx;
-    void editor.layout.pages;
+    void editor.selection;
     void editor.layout.layoutMode;
     void app.preference.current.typewriterEnabled;
     void app.preference.current.typewriterPosition;

--- a/crates/editor/src/model/nodes/root.rs
+++ b/crates/editor/src/model/nodes/root.rs
@@ -30,7 +30,8 @@ impl Layout for RootNode {
 
         let block_gap = ctx.settings.block_gap;
 
-        for child in &children {
+        let child_count = children.len();
+        for (idx, child) in children.iter().enumerate() {
             let child_layout = ctx.layout(child, constraints);
 
             let positioned = PositionedNode {
@@ -38,7 +39,11 @@ impl Layout for RootNode {
                 node: child_layout,
             };
 
-            y_offset += positioned.node.size.height + (block_gap * 16.0);
+            y_offset += positioned.node.size.height;
+            let is_last = idx == child_count - 1;
+            if !is_last {
+                y_offset += block_gap * 16.0;
+            }
             max_width = max_width.max(positioned.node.size.width);
 
             child_nodes.push(positioned);


### PR DESCRIPTION
- root node에서 trailing block gap 제거
- 커서 위치에 의존하지 않고 항상 typewriter position에 맞는 최대 패딩을 계산해서 사용
- 문서 끝에 커서 옮기면 스크롤 100%