### PR TITLE
text segment 삭제시 삭제된 스타일로 pending_styles 재지정

### DIFF
--- a/crates/editor/src/transaction/mod.rs
+++ b/crates/editor/src/transaction/mod.rs
@@ -17,7 +17,7 @@ mod table;
 mod text;
 
 pub use selection::{paragraph_range_at, sentence_range_at, word_range_at};
-pub(crate) use style::compute_styles_at_cursor;
+pub(crate) use style::{compute_styles_at_char_position, compute_styles_at_cursor};
 pub use text::DeleteResult;
 
 use crate::model::*;

--- a/crates/editor/src/transaction/style.rs
+++ b/crates/editor/src/transaction/style.rs
@@ -40,6 +40,40 @@ pub(crate) fn compute_styles_at_cursor(doc: &Doc, position: &Position) -> Vec<St
     cascade
 }
 
+/// Character-at semantics: returns the styles of the segment containing the character
+/// at the given offset (>= start, < end), unlike `compute_styles_at_cursor` which
+/// uses cursor semantics (> start, <= end).
+pub(crate) fn compute_styles_at_char_position(doc: &Doc, position: &Position) -> Vec<Style> {
+    let cascade = resolve_style_cascade(doc, position.node_id);
+
+    let Some(node) = doc.node(position.node_id) else {
+        return cascade;
+    };
+
+    let Some((child_id, local_offset)) = find_child_at_offset(&node, position.offset) else {
+        return cascade;
+    };
+
+    let Some(child) = doc.node(child_id) else {
+        return cascade;
+    };
+
+    if let Node::Text(text_node) = child.node() {
+        let segments = text_node.text.get_segments();
+        let mut current_offset = 0;
+
+        for segment in segments {
+            let segment_len = segment.text.chars().count();
+            if local_offset >= current_offset && local_offset < current_offset + segment_len {
+                return fill_missing_styles(segment.styles, &cascade);
+            }
+            current_offset += segment_len;
+        }
+    }
+
+    cascade
+}
+
 pub(crate) fn resolve_style_cascade(doc: &Doc, node_id: NodeId) -> Vec<Style> {
     let mut attrs: Vec<Attr> = Vec::new();
     let Some(node) = doc.node(node_id) else {

--- a/crates/editor/src/transaction/text.rs
+++ b/crates/editor/src/transaction/text.rs
@@ -8,7 +8,7 @@ use crate::state::selection_helpers::{
     StructureSelectionInfo, block_content_len, compute_structure_selection,
 };
 use crate::state::{Position, Selection};
-use crate::transaction::Transaction;
+use crate::transaction::{Transaction, compute_styles_at_char_position, compute_styles_at_cursor};
 use crate::types::Affinity;
 use crate::utils::{
     collect_codepoints, find_next_grapheme_boundary, find_prev_grapheme_boundary,
@@ -368,7 +368,6 @@ impl Transaction {
         }
 
         let head = selection.head;
-        let pre_styles = self.state.pending_styles.clone();
 
         let paragraph = self.node(head.node_id).context("Paragraph not found")?;
 
@@ -415,13 +414,18 @@ impl Transaction {
             }
         };
 
+        let deleted_styles = compute_styles_at_char_position(
+            self.doc(),
+            &Position::new(head.node_id, from_global_offset, head.affinity),
+        );
+
         let from = Position::new(head.node_id, from_global_offset, head.affinity);
         let to = Position::new(head.node_id, to_global_offset, head.affinity);
 
         self.delete_range(from, to)?;
 
         if !self.cursor_has_text_segment(head.node_id, from_global_offset) {
-            let _ = self.set_cascade_attrs(head.node_id, &Attr::from_styles(&pre_styles));
+            let _ = self.set_cascade_attrs(head.node_id, &Attr::from_styles(&deleted_styles));
         }
 
         let new_affinity =
@@ -432,6 +436,11 @@ impl Transaction {
             from_global_offset,
             new_affinity,
         )));
+
+        if self.state.pending_styles != deleted_styles {
+            self.state.pending_styles = deleted_styles;
+            self.push_effect(Effect::PendingStylesChanged);
+        }
 
         self.push_effect(Effect::NodeChanged {
             node_id: head.node_id,
@@ -446,7 +455,6 @@ impl Transaction {
         }
 
         let head = selection.head;
-        let pre_styles = self.state.pending_styles.clone();
 
         let paragraph = self.node(head.node_id).context("Paragraph not found")?;
 
@@ -497,13 +505,18 @@ impl Transaction {
             }
         };
 
+        let deleted_styles = compute_styles_at_char_position(
+            self.doc(),
+            &Position::new(head.node_id, from_global_offset, head.affinity),
+        );
+
         let from = Position::new(head.node_id, from_global_offset, head.affinity);
         let to = Position::new(head.node_id, to_global_offset, head.affinity);
 
         self.delete_range(from, to)?;
 
         if !self.cursor_has_text_segment(head.node_id, from_global_offset) {
-            let _ = self.set_cascade_attrs(head.node_id, &Attr::from_styles(&pre_styles));
+            let _ = self.set_cascade_attrs(head.node_id, &Attr::from_styles(&deleted_styles));
         }
 
         let new_affinity =
@@ -514,6 +527,11 @@ impl Transaction {
             from_global_offset,
             new_affinity,
         )));
+
+        if self.state.pending_styles != deleted_styles {
+            self.state.pending_styles = deleted_styles;
+            self.push_effect(Effect::PendingStylesChanged);
+        }
 
         self.push_effect(Effect::NodeChanged {
             node_id: head.node_id,
@@ -528,7 +546,11 @@ impl Transaction {
             return self.delete_structure_selection(&structure_selection);
         }
 
-        let pre_delete_styles = self.state.pending_styles.clone();
+        let deleted_styles = self
+            .selection()
+            .as_sorted(self.doc())
+            .map(|(from, _)| compute_styles_at_char_position(self.doc(), &from))
+            .unwrap_or_else(|_| compute_styles_at_cursor(self.doc(), &self.selection().head));
 
         if let StructureSelectionInfo::Structural(block_ids) = structure_selection {
             let (mut from, mut to) = self.selection().as_sorted(self.doc())?;
@@ -569,12 +591,11 @@ impl Transaction {
 
             let head = self.state.selection.head;
             if !self.cursor_has_text_segment(head.node_id, head.offset) {
-                let _ =
-                    self.set_cascade_attrs(head.node_id, &Attr::from_styles(&pre_delete_styles));
-                if self.state.pending_styles != pre_delete_styles {
-                    self.state.pending_styles = pre_delete_styles;
-                    self.push_effect(Effect::PendingStylesChanged);
-                }
+                let _ = self.set_cascade_attrs(head.node_id, &Attr::from_styles(&deleted_styles));
+            }
+            if self.state.pending_styles != deleted_styles {
+                self.state.pending_styles = deleted_styles;
+                self.push_effect(Effect::PendingStylesChanged);
             }
         }
 
@@ -3685,6 +3706,164 @@ mod tests {
                 .iter()
                 .any(|m| matches!(m, Style::Italic(_))),
             "pending_styles should pick up italic from adjacent segment, got: {:?}",
+            view.pending_styles
+        );
+    }
+
+    #[test]
+    fn delete_text_backward_uses_deleted_segment_styles_over_remaining() {
+        let mut p = id!();
+
+        let state = state! {
+            doc {
+                @p paragraph {
+                    text(styles: [font_weight(700)]) { "a" }
+                    text(styles: [italic()]) { "b" }
+                }
+            }
+            selection { (p, 1) }
+        };
+
+        let mut tr = Transaction::new(&state);
+        tr.delete_text_backward().unwrap();
+        let (view, _) = tr.commit().unwrap();
+
+        // "a" [bold] deleted, "b" [italic] remains → pending_styles = deleted segment's [bold]
+        assert!(
+            view.pending_styles
+                .iter()
+                .any(|m| matches!(m, Style::FontWeight(fw) if fw.weight == 700)),
+            "pending_styles should use deleted segment's bold, got: {:?}",
+            view.pending_styles
+        );
+    }
+
+    #[test]
+    fn delete_text_backward_ignores_style_override_uses_segment_styles() {
+        let mut p = id!();
+
+        let state = state! {
+            doc {
+                @p paragraph {
+                    text(styles: [font_weight(700)]) { "a" }
+                }
+            }
+            selection { (p, 1) }
+        };
+
+        let mut tr = Transaction::new(&state);
+        // toggle italic → pending_styles = [bold, italic]
+        tr.set_style(Style::Italic(ItalicStyle {})).unwrap();
+        tr.delete_text_backward().unwrap();
+        let (view, _) = tr.commit().unwrap();
+
+        // segment was [bold] only → italic override should be discarded
+        assert!(
+            view.pending_styles
+                .iter()
+                .any(|m| matches!(m, Style::FontWeight(fw) if fw.weight == 700)),
+            "pending_styles should contain bold from segment, got: {:?}",
+            view.pending_styles
+        );
+        assert!(
+            !view
+                .pending_styles
+                .iter()
+                .any(|m| matches!(m, Style::Italic(_))),
+            "pending_styles should NOT contain manually toggled italic, got: {:?}",
+            view.pending_styles
+        );
+    }
+
+    #[test]
+    fn delete_text_forward_uses_deleted_segment_styles_over_remaining() {
+        let mut p = id!();
+
+        let state = state! {
+            doc {
+                @p paragraph {
+                    text(styles: [italic()]) { "a" }
+                    text(styles: [font_weight(700)]) { "b" }
+                }
+            }
+            selection { (p, 1) }
+        };
+
+        let mut tr = Transaction::new(&state);
+        tr.delete_text_forward().unwrap();
+        let (view, _) = tr.commit().unwrap();
+
+        // "b" [bold] deleted, "a" [italic] remains → pending_styles = deleted segment's [bold]
+        assert!(
+            view.pending_styles
+                .iter()
+                .any(|m| matches!(m, Style::FontWeight(fw) if fw.weight == 700)),
+            "pending_styles should use deleted segment's bold, got: {:?}",
+            view.pending_styles
+        );
+    }
+
+    #[test]
+    fn delete_text_forward_ignores_style_override_uses_segment_styles() {
+        let mut p = id!();
+
+        let state = state! {
+            doc {
+                @p paragraph {
+                    text(styles: [font_weight(700)]) { "a" }
+                }
+            }
+            selection { (p, 0) }
+        };
+
+        let mut tr = Transaction::new(&state);
+        // toggle italic → pending_styles includes italic
+        tr.set_style(Style::Italic(ItalicStyle {})).unwrap();
+        tr.delete_text_forward().unwrap();
+        let (view, _) = tr.commit().unwrap();
+
+        // segment was [bold] only → italic override should be discarded
+        assert!(
+            view.pending_styles
+                .iter()
+                .any(|m| matches!(m, Style::FontWeight(fw) if fw.weight == 700)),
+            "pending_styles should contain bold from segment, got: {:?}",
+            view.pending_styles
+        );
+        assert!(
+            !view
+                .pending_styles
+                .iter()
+                .any(|m| matches!(m, Style::Italic(_))),
+            "pending_styles should NOT contain manually toggled italic, got: {:?}",
+            view.pending_styles
+        );
+    }
+
+    #[test]
+    fn delete_selection_uses_deleted_segment_styles_over_remaining() {
+        let mut p = id!();
+
+        let state = state! {
+            doc {
+                @p paragraph {
+                    text(styles: [font_weight(700)]) { "ab" }
+                    text(styles: [italic()]) { "cd" }
+                }
+            }
+            selection { (p, 0) -> (p, 2) }
+        };
+
+        let mut tr = Transaction::new(&state);
+        tr.delete_selection().unwrap();
+        let (view, _) = tr.commit().unwrap();
+
+        // "ab" [bold] deleted, "cd" [italic] remains → pending_styles = deleted segment's [bold]
+        assert!(
+            view.pending_styles
+                .iter()
+                .any(|m| matches!(m, Style::FontWeight(fw) if fw.weight == 700)),
+            "pending_styles should use deleted segment's bold, got: {:?}",
             view.pending_styles
         );
     }


### PR DESCRIPTION
iOS의 delete-then-insert 케이스에서 스타일 유지되도록 커버함
