### PR TITLE
툴바 이것저것 디버그

### DIFF
--- a/apps/mobile/lib/screens/native_editor/controller/input.dart
+++ b/apps/mobile/lib/screens/native_editor/controller/input.dart
@@ -15,6 +15,7 @@ class InputController {
     required this.onFocusChanged,
     required this.scrollIntoView,
     required ValueGetter<BottomToolbarMode> getBottomToolbarMode,
+    this.onInputAttempt,
   }) : _getBottomToolbarMode = getBottomToolbarMode;
 
   final GlobalKey<InputViewState> inputKey;
@@ -23,6 +24,7 @@ class InputController {
   final void Function(bool focused) onFocusChanged;
   final void Function({ScrollMode mode}) scrollIntoView;
   final ValueGetter<BottomToolbarMode> _getBottomToolbarMode;
+  final VoidCallback? onInputAttempt;
 
   bool _isActive = false;
   bool get isActive => _isActive;
@@ -88,12 +90,14 @@ class InputController {
   }
 
   void onInsertText(String text) {
+    onInputAttempt?.call();
     _deleteStartTime = null;
     dispatch({'type': 'input', 'text': text});
     scrollIntoView(mode: ScrollMode.typewriter);
   }
 
   void onDeleteBackward() {
+    onInputAttempt?.call();
     final now = DateTime.now();
     final lastSignal = _lastDeleteSignal;
     _lastDeleteSignal = now;
@@ -118,6 +122,7 @@ class InputController {
   }
 
   void onSetMarkedText(String text) {
+    onInputAttempt?.call();
     isComposing = true;
     dispatch({'type': 'compositionUpdate', 'text': text});
     scrollIntoView(mode: ScrollMode.typewriter);
@@ -137,6 +142,7 @@ class InputController {
   }
 
   void onPerformAction(String action) {
+    onInputAttempt?.call();
     if (action == 'newline') {
       dispatch({'type': 'insertNewline'});
       scrollIntoView(mode: ScrollMode.typewriter);
@@ -144,6 +150,7 @@ class InputController {
   }
 
   void onShortcut(String action) {
+    onInputAttempt?.call();
     final direction = switch (action) {
       'navigateLeft' => 'left',
       'navigateRight' => 'right',
@@ -230,6 +237,7 @@ class InputController {
   }
 
   void onReplaceBackward(int length, String text) {
+    onInputAttempt?.call();
     dispatch({'type': 'replaceBackward', 'length': length, 'text': text});
     scrollIntoView(mode: ScrollMode.typewriter);
   }

--- a/apps/mobile/lib/screens/native_editor/toolbar/bottom/bottom.dart
+++ b/apps/mobile/lib/screens/native_editor/toolbar/bottom/bottom.dart
@@ -16,16 +16,22 @@ class NativeEditorBottomToolbar extends HookWidget {
   Widget build(BuildContext context) {
     final scope = NativeEditorToolbarScope.of(context);
     final keyboardHeight = useValueListenable(scope.keyboardHeight);
+    final isKeyboardVisible = useValueListenable(scope.isKeyboardVisible);
     final keyboardType = useValueListenable(scope.keyboardType);
     final bottomToolbarMode = useValueListenable(scope.bottomToolbarMode);
 
     final mediaQuery = MediaQuery.of(context);
+    final expandedHeightFallback = mediaQuery.viewPadding.bottom + mediaQuery.size.height * 0.2;
+    final softwareExpandedHeight = keyboardHeight > 0 ? keyboardHeight : expandedHeightFallback;
 
     return AnimatedContainer(
       duration: const Duration(milliseconds: 300),
       curve: Curves.ease,
       height: switch (keyboardType) {
-        KeyboardType.software => keyboardHeight,
+        KeyboardType.software => switch (bottomToolbarMode) {
+          BottomToolbarMode.hidden => isKeyboardVisible ? keyboardHeight : mediaQuery.viewPadding.bottom,
+          _ => isKeyboardVisible ? keyboardHeight : softwareExpandedHeight,
+        },
         KeyboardType.hardware => switch (bottomToolbarMode) {
           BottomToolbarMode.hidden => mediaQuery.viewPadding.bottom,
           _ => mediaQuery.viewPadding.bottom + mediaQuery.size.height * 0.2,

--- a/apps/mobile/lib/screens/native_editor/toolbar/primary/primary.dart
+++ b/apps/mobile/lib/screens/native_editor/toolbar/primary/primary.dart
@@ -41,10 +41,12 @@ class NativeEditorPrimaryToolbar extends HookWidget {
                     isActive: bottomToolbarMode == BottomToolbarMode.insert,
                     onTap: () {
                       if (bottomToolbarMode == BottomToolbarMode.insert) {
-                        if (keyboardType == KeyboardType.software) {
-                          scope.requestFocus();
+                        switch (keyboardType) {
+                          case KeyboardType.software:
+                            scope.requestFocus();
+                          case KeyboardType.hardware:
+                            scope.bottomToolbarMode.value = BottomToolbarMode.hidden;
                         }
-                        scope.bottomToolbarMode.value = BottomToolbarMode.hidden;
                       } else {
                         scope.bottomToolbarMode.value = BottomToolbarMode.insert;
                         if (keyboardType == KeyboardType.software) {
@@ -124,10 +126,12 @@ class NativeEditorPrimaryToolbar extends HookWidget {
               IconToolbarButton(
                 icon: LucideLightIcons.circle_x,
                 onTap: () {
-                  if (keyboardType == KeyboardType.software) {
-                    scope.requestFocus();
+                  switch (keyboardType) {
+                    case KeyboardType.software:
+                      scope.requestFocus();
+                    case KeyboardType.hardware:
+                      scope.bottomToolbarMode.value = BottomToolbarMode.hidden;
                   }
-                  scope.bottomToolbarMode.value = BottomToolbarMode.hidden;
                   scope.secondaryToolbarMode.value = SecondaryToolbarMode.hidden;
                 },
               ),

--- a/apps/mobile/lib/screens/native_editor/toolbar/toolbar.dart
+++ b/apps/mobile/lib/screens/native_editor/toolbar/toolbar.dart
@@ -4,7 +4,6 @@ import 'package:typie/screens/native_editor/toolbar/bottom/bottom.dart';
 import 'package:typie/screens/native_editor/toolbar/primary/primary.dart';
 import 'package:typie/screens/native_editor/toolbar/scope.dart';
 import 'package:typie/screens/native_editor/toolbar/secondary/secondary.dart';
-import 'package:typie/services/keyboard.dart';
 
 class NativeEditorToolbar extends HookWidget {
   const NativeEditorToolbar({super.key});
@@ -14,18 +13,12 @@ class NativeEditorToolbar extends HookWidget {
     final scope = NativeEditorToolbarScope.of(context);
     final isKeyboardVisible = useValueListenable(scope.isKeyboardVisible);
     final keyboardHeight = useValueListenable(scope.keyboardHeight);
-    final keyboardType = useValueListenable(scope.keyboardType);
     final isEditorFocused = useValueListenable(scope.isEditorFocused);
-    final bottomToolbarMode = useValueListenable(scope.bottomToolbarMode);
 
     if (!isEditorFocused) {
       if (isKeyboardVisible) {
         return SizedBox(height: keyboardHeight);
       }
-      return const SizedBox.shrink();
-    }
-
-    if (keyboardType == KeyboardType.software && !isKeyboardVisible && bottomToolbarMode == BottomToolbarMode.hidden) {
       return const SizedBox.shrink();
     }
 

--- a/apps/mobile/lib/screens/native_editor/view/editor.dart
+++ b/apps/mobile/lib/screens/native_editor/view/editor.dart
@@ -144,6 +144,11 @@ class EditorView extends HookWidget {
         onFocusChanged: controller.setFocused,
         scrollIntoView: controller.scrollIntoView,
         getBottomToolbarMode: () => bottomToolbarMode.value,
+        onInputAttempt: () {
+          if (bottomToolbarMode.value != BottomToolbarMode.hidden) {
+            bottomToolbarMode.value = BottomToolbarMode.hidden;
+          }
+        },
       ),
       [controller],
     );

--- a/apps/mobile/lib/screens/native_editor/view/scrollbar.dart
+++ b/apps/mobile/lib/screens/native_editor/view/scrollbar.dart
@@ -8,7 +8,6 @@ import 'package:typie/screens/native_editor/state/state.dart';
 import 'package:typie/screens/native_editor/toolbar/scope.dart';
 import 'package:typie/screens/native_editor/view/scope.dart';
 import 'package:typie/screens/native_editor/view/scroll.dart';
-import 'package:typie/services/keyboard.dart';
 import 'package:typie/services/preference.dart';
 
 const _hideDelay = Duration(milliseconds: 1000);
@@ -39,10 +38,8 @@ class EditorScrollbar extends HookWidget {
 
     final verticalScrollController = scope.verticalScrollController;
     final horizontalScrollController = scope.horizontalScrollController;
-    final keyboardType = useValueListenable(toolbarScope.keyboardType);
     final isKeyboardVisible = useValueListenable(toolbarScope.isKeyboardVisible);
     final isEditorFocused = useValueListenable(toolbarScope.isEditorFocused);
-    final bottomToolbarMode = useValueListenable(toolbarScope.bottomToolbarMode);
     final layout = state.state.layout!;
     final pages = state.state.pages;
     final cursor = state.state.cursor;
@@ -168,9 +165,7 @@ class EditorScrollbar extends HookWidget {
         : viewWidth;
 
     final safeTop = safePadding.top;
-    final toolbarVisible =
-        isEditorFocused &&
-        !(keyboardType == KeyboardType.software && !isKeyboardVisible && bottomToolbarMode == BottomToolbarMode.hidden);
+    final toolbarVisible = isEditorFocused;
     final safeBottom = (!isKeyboardVisible && !toolbarVisible) ? safePadding.bottom : 0.0;
     final trackHeight =
         actualViewHeight - _trackPadding * 2 - safeTop - safeBottom - (hasHorizontalScroll ? _trackWidth : 0);


### PR DESCRIPTION
- 바텀 툴바 닫을 때 깜빡임 제거
- 시뮬레이터에서 host 키보드 사용 후 바텀 툴바를 닫을 수는 없게 되었지만 실기기에서는 문제 없음
- 시뮬레이터에서도 툴바가 항상 보임