### PR TITLE
iPad 에디터 좌표 보정

### DIFF
--- a/apps/mobile/lib/screens/native_editor/view/context_menu.dart
+++ b/apps/mobile/lib/screens/native_editor/view/context_menu.dart
@@ -21,7 +21,7 @@ class SelectionContextMenu extends StatelessWidget {
     return ListenableBuilder(
       listenable: Listenable.merge([scope.verticalScrollController, scope.horizontalScrollController]),
       builder: (context, _) {
-        final anchor = _computeMenuAnchor(scope);
+        final anchor = _computeMenuAnchor(scope, viewportWidth: MediaQuery.sizeOf(context).width);
         if (anchor == null) {
           return const SizedBox.shrink();
         }
@@ -47,7 +47,10 @@ class SelectionContextMenu extends StatelessWidget {
     );
   }
 
-  ({double centerX, double above, double below})? _computeMenuAnchor(ContentScope scope) {
+  ({double centerX, double above, double below})? _computeMenuAnchor(
+    ContentScope scope, {
+    required double viewportWidth,
+  }) {
     final geo = scope.geometry;
     final offsets = geo.computeCumulativePageOffsets();
     final vController = scope.verticalScrollController;
@@ -59,6 +62,7 @@ class SelectionContextMenu extends StatelessWidget {
 
     final scrollOffset = vController.offset;
     final hScrollOffset = hController.hasSingleClient ? hController.offset : 0.0;
+    final contentStartX = geo.contentStartX(viewportWidth: viewportWidth, horizontalScrollOffset: hScrollOffset);
 
     final state = scope.controller.state;
     final fromHandle = state.selection?.fromBounds;
@@ -72,11 +76,11 @@ class SelectionContextMenu extends StatelessWidget {
     if (fromHandle != null && toHandle != null) {
       final fromPageTop = geo.titleAreaHeight + offsets[fromHandle.pageIdx];
       final fromScreenY = fromPageTop + fromHandle.y - scrollOffset;
-      final fromScreenX = geo.horizontalPadding + fromHandle.x - hScrollOffset;
+      final fromScreenX = contentStartX + fromHandle.x;
 
       final toPageTop = geo.titleAreaHeight + offsets[toHandle.pageIdx];
       final toScreenY = toPageTop + toHandle.y + toHandle.height - scrollOffset;
-      final toScreenX = geo.horizontalPadding + toHandle.x - hScrollOffset;
+      final toScreenX = contentStartX + toHandle.x;
 
       topY = fromScreenY;
       bottomY = toScreenY;
@@ -84,7 +88,7 @@ class SelectionContextMenu extends StatelessWidget {
     } else if (cursor != null) {
       final cursorPageTop = geo.titleAreaHeight + offsets[cursor.pageIdx];
       final cursorScreenY = cursorPageTop + cursor.y - scrollOffset;
-      final cursorScreenX = geo.horizontalPadding + cursor.x - hScrollOffset;
+      final cursorScreenX = contentStartX + cursor.x;
 
       topY = cursorScreenY;
       bottomY = cursorScreenY + cursor.height;

--- a/apps/mobile/lib/screens/native_editor/view/geometry.dart
+++ b/apps/mobile/lib/screens/native_editor/view/geometry.dart
@@ -16,9 +16,21 @@ class ContentGeometry {
 
   bool get isPaginated => layout is PaginatedLayout;
   double get horizontalPadding => isPaginated ? pagePadding : 0.0;
+  double get contentWidth => (pages.firstOrNull?.width ?? 0) + horizontalPadding * 2;
   double get defaultBottomPadding => isPaginated ? pagePadding : 200.0;
   double get trailingBottomMargin =>
       layout is PaginatedLayout ? (layout as PaginatedLayout).pageMarginBottom : continuousPageMargin;
+
+  double contentLeftInset(double viewportWidth) {
+    if (viewportWidth <= 0) {
+      return 0;
+    }
+    return ((viewportWidth - contentWidth) / 2).clamp(0.0, double.infinity);
+  }
+
+  double contentStartX({required double viewportWidth, required double horizontalScrollOffset}) {
+    return contentLeftInset(viewportWidth) + horizontalPadding - horizontalScrollOffset;
+  }
 
   double gapAfterPage(int index) => isPaginated && index < pages.length - 1 ? pageGap : 0.0;
 

--- a/apps/mobile/lib/screens/native_editor/view/gesture.dart
+++ b/apps/mobile/lib/screens/native_editor/view/gesture.dart
@@ -16,7 +16,7 @@ class GestureController {
     required this.controller,
     required this.getPageAtPosition,
     required this.getPointerX,
-    required this.getHorizontalPadding,
+    required this.getViewportWidth,
   });
 
   final ScrollController verticalScrollController;
@@ -25,7 +25,7 @@ class GestureController {
   final EditorController controller;
   final (int, double) Function(double y) getPageAtPosition;
   final double Function(double localX) getPointerX;
-  final double Function() getHorizontalPadding;
+  final double Function() getViewportWidth;
 
   static const _edgeThreshold = 60.0;
   static const _minScrollSpeed = 4.0;
@@ -129,8 +129,7 @@ class GestureController {
           return;
         }
 
-        final hOffset = horizontalScrollController.hasSingleClient ? horizontalScrollController.offset : 0.0;
-        final pointerX = scrolledX + hOffset - getHorizontalPadding();
+        final pointerX = getPointerX(scrolledX);
 
         final currentPosition = (pageIdx, pointerX, localY);
         if (_lastDispatchedPosition == currentPosition) {
@@ -230,7 +229,7 @@ class GestureController {
     final hScrollOffset = horizontalScrollController.hasSingleClient ? horizontalScrollController.offset : 0.0;
     final pageTopOffset = geo.titleAreaHeight + offsets[handle.pageIdx];
     final y = pageTopOffset + handle.y - scrollOffset;
-    final x = geo.horizontalPadding + handle.x - hScrollOffset;
+    final x = geo.contentStartX(viewportWidth: getViewportWidth(), horizontalScrollOffset: hScrollOffset) + handle.x;
     return Offset(x, y);
   }
 

--- a/apps/mobile/lib/screens/native_editor/view/line_highlight.dart
+++ b/apps/mobile/lib/screens/native_editor/view/line_highlight.dart
@@ -10,6 +10,7 @@ class LineHighlight extends StatelessWidget {
   final bool enabled;
 
   static const double _padding = 4;
+  static const double _horizontalOverflow = 100000;
 
   @override
   Widget build(BuildContext context) {
@@ -19,8 +20,8 @@ class LineHighlight extends StatelessWidget {
     }
 
     return Positioned(
-      left: 0,
-      right: 0,
+      left: -_horizontalOverflow,
+      width: _horizontalOverflow * 2,
       top: cursor.y - _padding,
       height: cursor.height + _padding * 2,
       child: Container(color: context.colors.surfaceMuted),

--- a/apps/mobile/lib/screens/native_editor/view/pages.dart
+++ b/apps/mobile/lib/screens/native_editor/view/pages.dart
@@ -74,6 +74,7 @@ class PageList extends HookWidget {
     final showContextMenu = useState(false);
     final wasContextMenuOpen = useRef(false);
     final clipboard = useMemoized(EditorClipboard.new);
+    final viewportWidth = useValueNotifier<double>(0);
 
     final longPressPosition = scope.longPressPosition;
     final handleDragPosition = scope.handleDragPosition;
@@ -87,10 +88,12 @@ class PageList extends HookWidget {
         controller: scope.controller,
         getPageAtPosition: getPageAtPosition,
         getPointerX: (localX) {
-          final offset = horizontalScrollController.hasSingleClient ? horizontalScrollController.offset : 0.0;
-          return localX + offset - scope.geometry.horizontalPadding;
+          final geo = scope.geometry;
+          final hScrollOffset = horizontalScrollController.hasSingleClient ? horizontalScrollController.offset : 0.0;
+          final viewport = viewportWidth.value;
+          return localX - geo.contentStartX(viewportWidth: viewport, horizontalScrollOffset: hScrollOffset);
         },
-        getHorizontalPadding: () => scope.geometry.horizontalPadding,
+        getViewportWidth: () => viewportWidth.value,
       ),
     );
 
@@ -153,6 +156,9 @@ class PageList extends HookWidget {
       builder: (context, constraints) {
         final viewWidth = constraints.maxWidth;
         final viewHeight = constraints.maxHeight;
+        if (viewportWidth.value != viewWidth) {
+          viewportWidth.value = viewWidth;
+        }
 
         Offset? viewportPositionFromGlobal(Offset globalPosition) {
           final renderBox = context.findRenderObject() as RenderBox?;
@@ -250,7 +256,7 @@ class PageList extends HookWidget {
 
         final geo = scope.geometry;
         final offsets = geo.computeCumulativePageOffsets();
-        final contentWidth = (pages.firstOrNull?.width ?? 0) + geo.horizontalPadding * 2;
+        final contentWidth = geo.contentWidth;
         final needsHorizontalScroll = contentWidth > viewWidth;
         final horizontalPhysics = isSelecting || !needsHorizontalScroll
             ? const NeverScrollableScrollPhysics()


### PR DESCRIPTION
- selection handle, context menu, 터치 좌표 등이 에디터 좌우 여백을 고려함
- line highlight가 화면 전체 폭을 차지함