### PR TITLE
kubelet image gc threshold 설정

### DIFF
--- a/infrastructure/machines/patches/base.yaml
+++ b/infrastructure/machines/patches/base.yaml
@@ -12,6 +12,11 @@ machine:
       - 1.1.1.1
       - 1.0.0.1
 
+  kubelet:
+    extraConfig:
+      imageGCHighThresholdPercent: 60
+      imageGCLowThresholdPercent: 50
+
   features:
     hostDNS:
       forwardKubeDNSToHost: false


### PR DESCRIPTION
서버 디스크가 이미지 캐시로 꽉 차기 시작함
