### PR TITLE
iOS 키보드 관련 픽스

### DIFF
--- a/apps/mobile/ios/Runner/Keyboard/KeyboardPlugin.swift
+++ b/apps/mobile/ios/Runner/Keyboard/KeyboardPlugin.swift
@@ -35,25 +35,21 @@ class KeyboardPlugin: NSObject, FlutterStreamHandler {
       object: nil
     )
     
-    #if targetEnvironment(simulator)
-      events(["type": "hardware", "hardware": false])
-    #else
-      NotificationCenter.default.addObserver(
-        self,
-        selector: #selector(hardwareKeyboardDidConnect),
-        name: .GCKeyboardDidConnect,
-        object: nil
-      )
-    
-      NotificationCenter.default.addObserver(
-        self,
-        selector: #selector(hardwareKeyboardDidDisconnect),
-        name: .GCKeyboardDidDisconnect,
-        object: nil
-      )
-    
-      events(["type": "hardware", "hardware": GCKeyboard.coalesced != nil])
-    #endif
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(hardwareKeyboardDidConnect),
+      name: .GCKeyboardDidConnect,
+      object: nil
+    )
+
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(hardwareKeyboardDidDisconnect),
+      name: .GCKeyboardDidDisconnect,
+      object: nil
+    )
+
+    sendHardwareState()
 
     return nil
   }
@@ -69,20 +65,56 @@ class KeyboardPlugin: NSObject, FlutterStreamHandler {
   @objc private func keyboardWillShow(_ notification: Notification) {
     if let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
       let keyboardHeight = keyboardFrame.height
-      events!(["type": "height", "height": Double(keyboardHeight)])
+      sendEvent(["type": "height", "height": Double(keyboardHeight)])
+      sendHardwareState()
     }
   }
   
   @objc private func keyboardWillHide(_ notification: Notification) {
-    events!(["type": "height", "height": 0.0])
+    sendEvent(["type": "height", "height": 0.0])
+    sendHardwareState()
   }
   
   @objc private func hardwareKeyboardDidConnect(_ notification: Notification) {
-    events!(["type": "hardware", "hardware": true])
+    sendHardwareState()
   }
 
   @objc private func hardwareKeyboardDidDisconnect(_ notification: Notification) {
-    events!(["type": "hardware", "hardware": false])
+    sendHardwareState()
+  }
+
+  private func sendHardwareState() {
+    let isHardwareKeyboard = resolveHardwareKeyboardState()
+    sendEvent(["type": "hardware", "hardware": isHardwareKeyboard])
+  }
+
+  private func resolveHardwareKeyboardState() -> Bool {
+    if let isInHardwareKeyboardMode = detectHardwareKeyboardModeFromUIKeyboardImpl() {
+      return isInHardwareKeyboardMode
+    }
+
+    return GCKeyboard.coalesced != nil
+  }
+
+  private func detectHardwareKeyboardModeFromUIKeyboardImpl() -> Bool? {
+    guard let cls = NSClassFromString("UIKeyboardImpl") as? NSObject.Type,
+          let instance = cls.perform(NSSelectorFromString("activeInstance"))?.takeUnretainedValue() as? NSObject else {
+      return nil
+    }
+
+    let selector = NSSelectorFromString("isInHardwareKeyboardMode")
+    guard instance.responds(to: selector) else {
+      return nil
+    }
+
+    typealias BoolMethod = @convention(c) (AnyObject, Selector) -> Bool
+    let methodImplementation = instance.method(for: selector)
+    let function = unsafeBitCast(methodImplementation, to: BoolMethod.self)
+    return function(instance, selector)
+  }
+
+  private func sendEvent(_ event: [String: Any]) {
+    events?(event)
   }
 }
   

--- a/apps/mobile/lib/screens/editor/toolbar/bottom/bottom.dart
+++ b/apps/mobile/lib/screens/editor/toolbar/bottom/bottom.dart
@@ -15,21 +15,32 @@ class BottomToolbar extends HookWidget {
   Widget build(BuildContext context) {
     final scope = EditorStateScope.of(context);
     final keyboardHeight = useValueListenable(scope.keyboardHeight);
+    final isKeyboardVisible = useValueListenable(scope.isKeyboardVisible);
     final keyboardType = useValueListenable(scope.keyboardType);
     final bottomToolbarMode = useValueListenable(scope.bottomToolbarMode);
 
     final mediaQuery = MediaQuery.of(context);
+    final expandedHeightFallback = mediaQuery.viewPadding.bottom + mediaQuery.size.height * 0.2;
+    final hardwareVisibleHeight = switch (bottomToolbarMode) {
+      BottomToolbarMode.hidden => keyboardHeight,
+      _ => keyboardHeight > expandedHeightFallback ? keyboardHeight : expandedHeightFallback,
+    };
 
     return AnimatedContainer(
       duration: const Duration(milliseconds: 300),
       curve: Curves.ease,
-      height: switch (keyboardType) {
-        KeyboardType.software => keyboardHeight,
-        KeyboardType.hardware => switch (bottomToolbarMode) {
-          BottomToolbarMode.hidden => mediaQuery.viewPadding.bottom,
-          _ => mediaQuery.viewPadding.bottom + mediaQuery.size.height * 0.2,
-        },
-      },
+      height: isKeyboardVisible
+          ? switch (keyboardType) {
+              KeyboardType.software => keyboardHeight,
+              KeyboardType.hardware => hardwareVisibleHeight,
+            }
+          : switch (keyboardType) {
+              KeyboardType.software => keyboardHeight,
+              KeyboardType.hardware => switch (bottomToolbarMode) {
+                BottomToolbarMode.hidden => mediaQuery.viewPadding.bottom,
+                _ => expandedHeightFallback,
+              },
+            },
       decoration: BoxDecoration(
         color: context.colors.surfaceDefault,
         border: Border(top: BorderSide(color: context.colors.borderSubtle)),

--- a/apps/mobile/lib/screens/native_editor/toolbar/bottom/bottom.dart
+++ b/apps/mobile/lib/screens/native_editor/toolbar/bottom/bottom.dart
@@ -23,20 +23,29 @@ class NativeEditorBottomToolbar extends HookWidget {
     final mediaQuery = MediaQuery.of(context);
     final expandedHeightFallback = mediaQuery.viewPadding.bottom + mediaQuery.size.height * 0.2;
     final softwareExpandedHeight = keyboardHeight > 0 ? keyboardHeight : expandedHeightFallback;
+    final hardwareVisibleHeight = switch (bottomToolbarMode) {
+      BottomToolbarMode.hidden => keyboardHeight,
+      _ => keyboardHeight > expandedHeightFallback ? keyboardHeight : expandedHeightFallback,
+    };
 
     return AnimatedContainer(
       duration: const Duration(milliseconds: 300),
       curve: Curves.ease,
-      height: switch (keyboardType) {
-        KeyboardType.software => switch (bottomToolbarMode) {
-          BottomToolbarMode.hidden => isKeyboardVisible ? keyboardHeight : mediaQuery.viewPadding.bottom,
-          _ => isKeyboardVisible ? keyboardHeight : softwareExpandedHeight,
-        },
-        KeyboardType.hardware => switch (bottomToolbarMode) {
-          BottomToolbarMode.hidden => mediaQuery.viewPadding.bottom,
-          _ => mediaQuery.viewPadding.bottom + mediaQuery.size.height * 0.2,
-        },
-      },
+      height: isKeyboardVisible
+          ? switch (keyboardType) {
+              KeyboardType.software => keyboardHeight,
+              KeyboardType.hardware => hardwareVisibleHeight,
+            }
+          : switch (keyboardType) {
+              KeyboardType.software => switch (bottomToolbarMode) {
+                BottomToolbarMode.hidden => mediaQuery.viewPadding.bottom,
+                _ => softwareExpandedHeight,
+              },
+              KeyboardType.hardware => switch (bottomToolbarMode) {
+                BottomToolbarMode.hidden => mediaQuery.viewPadding.bottom,
+                _ => mediaQuery.viewPadding.bottom + mediaQuery.size.height * 0.2,
+              },
+            },
       decoration: BoxDecoration(
         color: context.colors.surfaceDefault,
         border: Border(top: BorderSide(color: context.colors.borderSubtle)),


### PR DESCRIPTION
- 시뮬레이터에서도 hardware / software 키보드 타입 및 높이 보고
- 하드웨어 키보드 상태 판별 강화
- 하드웨어 키보드 연결 중 소프트웨어 키보드 띄워도 툴바를 소프트웨어 키보드 위에 표시
- iPad 하드웨어 키보드 연결 중 69.0px 보고되는 빈 키보드 공간 대응: bottom toolbar 열었을 때 그 안에 그대로 표시하지 않고 최소 높이 지정