### PR TITLE
앱 키보드 숨김 동작 디버그

### DIFF
--- a/apps/mobile/lib/screens/native_editor/toolbar/primary/primary.dart
+++ b/apps/mobile/lib/screens/native_editor/toolbar/primary/primary.dart
@@ -59,7 +59,7 @@ class NativeEditorPrimaryToolbar extends HookWidget {
                             }
                           } else {
                             scope.bottomToolbarMode.value = BottomToolbarMode.insert;
-                            if (keyboardType == KeyboardType.software) {
+                            if (isKeyboardVisible) {
                               scope.dismissKeyboard();
                             }
                           }

--- a/apps/mobile/lib/screens/native_editor/view/editor.dart
+++ b/apps/mobile/lib/screens/native_editor/view/editor.dart
@@ -384,7 +384,9 @@ class EditorView extends HookWidget {
         final wasVisible = isKeyboardVisible.value;
         if (height > 0) {
           keyboardHeight.value = height;
-          bottomToolbarMode.value = BottomToolbarMode.hidden;
+          if (!wasVisible) {
+            bottomToolbarMode.value = BottomToolbarMode.hidden;
+          }
         }
         isKeyboardVisible.value = height > 0;
 


### PR DESCRIPTION
- 하드웨어 키보드 사용 중 소프트웨어 키보드를 강제로 연 상태에서 +버튼을 눌러도 아무 일도 안 일어나는 버그 수정: 키보드를 닫고 바텀 툴바를 적당한 크기로 열 수 있음
- 소프트웨어 키보드 사용 중 +버튼 눌러도 키보드 닫히거나 안 닫히고 바텀 툴바가 안 올라오는 버그 수정: 키보드 닫히고 바텀 툴바가 올라와서 툴바 높이가 그대로 유지됨