### PR TITLE
line signature에 font version 추가

### DIFF
--- a/crates/editor/src/layout/elements/line.rs
+++ b/crates/editor/src/layout/elements/line.rs
@@ -1,3 +1,4 @@
+use crate::global::font_version;
 use crate::layout::cursor::{CursorNavigable, CursorNavigation, NavigationContext};
 use crate::model::{NodeId, PreeditDecor, SelectionDecor};
 use crate::state::{Position, Selection};
@@ -227,6 +228,7 @@ impl LineElement {
                     let font = run.font();
                     font.index.hash(state);
                     font.data.id().hash(state);
+                    font_version(font.data.as_ref().as_ptr()).hash(state);
 
                     let coords = run.normalized_coords();
                     coords.len().hash(state);


### PR DESCRIPTION
fallback 폰트에 embolden 적용해도 바로 렌더링되지 않는 문제를 해결함