### PR TITLE
bullmq concurrency 50 -> 10

### DIFF
--- a/apps/api/src/mq/bullmq.ts
+++ b/apps/api/src/mq/bullmq.ts
@@ -43,7 +43,7 @@ export const worker = new Worker(
     }),
 
     autorun: false,
-    concurrency: 50,
+    concurrency: 10,
   },
 );
 


### PR DESCRIPTION
이벤트 루프 blocking되고 oom 발생이 너무 잦음
현재 페이로드로 봤을 때 concurrency 10도 충분함
