### PR TITLE
인용구 메시지 내부 정렬

### DIFF
--- a/crates/editor/src/layout/elements/line.rs
+++ b/crates/editor/src/layout/elements/line.rs
@@ -1405,9 +1405,11 @@ pub fn build_metrics(
         top += line_metrics.line_height;
 
         let mut clusters = Vec::new();
-        let mut advance_x = 0.0;
+        let mut advance_x: f32 = 0.0;
         let mut inline_prefix = 0.0;
         let mut seen_glyph = false;
+        let mut min_cluster_x: Option<f32> = None;
+        let mut max_cluster_right: Option<f32> = None;
         let mut max_ascent_overflow = 0.0f32;
         let mut max_descent_overflow = 0.0f32;
 
@@ -1415,8 +1417,9 @@ pub fn build_metrics(
 
         for item in line.items() {
             match item {
-                parley::PositionedLayoutItem::GlyphRun(run) => {
-                    let run = run.run();
+                parley::PositionedLayoutItem::GlyphRun(glyph_run) => {
+                    let run = glyph_run.run();
+                    let run_offset = glyph_run.offset();
 
                     if !indices.insert(run.index()) {
                         continue;
@@ -1438,8 +1441,11 @@ pub fn build_metrics(
                         }
                     }
 
+                    let mut run_advance = 0.0;
                     for cluster in run.clusters() {
                         let text_range = cluster.text_range();
+                        let cluster_width = cluster.advance();
+                        let cluster_x = run_offset + run_advance;
 
                         clusters.push(ClusterMetric {
                             start_offset: byte_to_char_offset_with_map(
@@ -1447,13 +1453,26 @@ pub fn build_metrics(
                                 text_range.start,
                             ),
                             end_offset: byte_to_char_offset_with_map(&char_to_byte, text_range.end),
-                            x: snap_to_pixel(advance_x - inline_prefix, scale_factor),
-                            width: cluster.advance(),
+                            x: cluster_x,
+                            width: cluster_width,
                         });
 
-                        advance_x += cluster.advance();
+                        min_cluster_x = Some(
+                            min_cluster_x
+                                .map(|min_x| min_x.min(cluster_x))
+                                .unwrap_or(cluster_x),
+                        );
+                        max_cluster_right = Some(
+                            max_cluster_right
+                                .map(|max_x| max_x.max(cluster_x + cluster_width))
+                                .unwrap_or(cluster_x + cluster_width),
+                        );
+
+                        run_advance += cluster_width;
                         seen_glyph = true;
                     }
+
+                    advance_x = advance_x.max(run_offset + run_advance);
                 }
                 parley::PositionedLayoutItem::InlineBox(inline_box) => {
                     advance_x += inline_box.width;
@@ -1490,16 +1509,25 @@ pub fn build_metrics(
             grapheme_offsets.push(line_end_char);
         }
 
-        let content_width = advance_x - inline_prefix;
+        let left = min_cluster_x.unwrap_or(line_metrics.offset + inline_prefix);
+        let content_width = match (min_cluster_x, max_cluster_right) {
+            (Some(min_x), Some(max_x)) => (max_x - min_x).max(0.0),
+            _ => (advance_x - inline_prefix).max(0.0),
+        };
+        let cluster_origin = min_cluster_x.unwrap_or(0.0);
+        for cluster in &mut clusters {
+            cluster.x = snap_to_pixel(cluster.x - cluster_origin, scale_factor);
+        }
 
         lines.push(LineMetric {
             top: snap_to_pixel(line_top, scale_factor),
-            left: snap_to_pixel(line_metrics.offset + inline_prefix, scale_factor),
+            left: snap_to_pixel(left, scale_factor),
             height,
             leading,
             baseline: snap_to_pixel(line_metrics.baseline, scale_factor),
             ascent: snap_to_pixel(line_metrics.ascent, scale_factor),
-            content_width: snap_to_pixel(content_width, scale_factor),
+            // NOTE: width를 스냅하면 실제 glyph 폭보다 작아져 overflow가 생길 수 있어 원본값 유지
+            content_width,
             start_offset: line_start_char,
             end_offset: line_end_char,
             clusters,

--- a/crates/editor/src/model/nodes/blockquote.rs
+++ b/crates/editor/src/model/nodes/blockquote.rs
@@ -3,13 +3,15 @@ use crate::layout::elements::blockquote::{
     BlockquoteLineElement, BlockquoteMessageElement, BlockquoteQuoteElement,
 };
 use crate::layout::{
-    Element, Layout, LayoutContext, LayoutNode, PageBreakPolicy, PositionedNode, RenderHints,
+    Element, Layout, LayoutCache, LayoutContext, LayoutNode, PageBreakPolicy, PositionedNode,
+    RenderHints,
 };
-use crate::model::Node;
 use crate::model::html::{DomSpec, NodeHtmlCodec, NodeParseRule};
+use crate::model::{Node, NodeRef, TextAlign};
 use crate::types::{BoxConstraints, Point, Size};
 use macros::Codec;
 use serde::{Deserialize, Serialize};
+use std::cell::RefCell;
 use std::rc::Rc;
 
 const LINE_WIDTH: f32 = 4.0;
@@ -105,6 +107,136 @@ impl Layout for BlockquoteNode {
 }
 
 impl BlockquoteNode {
+    fn merge_x_bounds(acc: &mut Option<(f32, f32)>, left: f32, right: f32) {
+        if right < left {
+            return;
+        }
+
+        match acc {
+            Some((min_x, max_x)) => {
+                *min_x = min_x.min(left);
+                *max_x = max_x.max(right);
+            }
+            None => *acc = Some((left, right)),
+        }
+    }
+
+    fn line_visual_x_bounds(
+        line: &crate::layout::elements::LineElement,
+        x_offset: f32,
+    ) -> (f32, f32) {
+        let left = x_offset + line.metric.left;
+        let right = line
+            .metric
+            .clusters
+            .last()
+            .map(|cluster| left + cluster.x + cluster.width)
+            .unwrap_or(left + line.metric.content_width.max(0.0))
+            .max(left);
+        (left, right)
+    }
+
+    fn line_intrinsic_x_bounds(
+        line: &crate::layout::elements::LineElement,
+        x_offset: f32,
+    ) -> (f32, f32) {
+        let width = line
+            .metric
+            .clusters
+            .last()
+            .map(|cluster| cluster.x + cluster.width)
+            .unwrap_or(line.metric.content_width.max(0.0))
+            .max(0.0);
+        (x_offset, x_offset + width)
+    }
+
+    fn layout_visual_x_bounds(node: &LayoutNode, x_offset: f32) -> Option<(f32, f32)> {
+        let mut bounds = None;
+
+        if let Some(children) = node.children.as_ref() {
+            for child in children {
+                if let Some((left, right)) =
+                    Self::layout_visual_x_bounds(child.node.as_ref(), x_offset + child.position.x)
+                {
+                    Self::merge_x_bounds(&mut bounds, left, right);
+                }
+            }
+        }
+
+        if bounds.is_some() {
+            return bounds;
+        }
+
+        if let Some(Element::Line(line)) = node.element.as_ref() {
+            let (left, right) = Self::line_visual_x_bounds(line, x_offset);
+            return Some((left, right));
+        }
+
+        if node.size.width > 0.0 {
+            return Some((x_offset, x_offset + node.size.width));
+        }
+
+        None
+    }
+
+    fn layout_intrinsic_x_bounds(node: &LayoutNode, x_offset: f32) -> Option<(f32, f32)> {
+        let mut bounds = None;
+
+        if let Some(children) = node.children.as_ref() {
+            for child in children {
+                if let Some((left, right)) = Self::layout_intrinsic_x_bounds(
+                    child.node.as_ref(),
+                    x_offset + child.position.x,
+                ) {
+                    Self::merge_x_bounds(&mut bounds, left, right);
+                }
+            }
+        }
+
+        if bounds.is_some() {
+            return bounds;
+        }
+
+        if let Some(Element::Line(line)) = node.element.as_ref() {
+            let (left, right) = Self::line_intrinsic_x_bounds(line, x_offset);
+            return Some((left, right));
+        }
+
+        if node.size.width > 0.0 {
+            return Some((x_offset, x_offset + node.size.width));
+        }
+
+        None
+    }
+
+    fn node_intrinsic_width(node: &LayoutNode) -> f32 {
+        Self::layout_intrinsic_x_bounds(node, 0.0)
+            .map(|(left, right)| (right - left).max(0.0))
+            .unwrap_or(node.size.width.max(0.0))
+    }
+
+    fn node_visual_left_and_width(node: &LayoutNode) -> (f32, f32) {
+        let (left, right) = Self::layout_visual_x_bounds(node, 0.0)
+            .or_else(|| Self::layout_intrinsic_x_bounds(node, 0.0))
+            .unwrap_or((0.0, node.size.width.max(0.0)));
+        (left, (right - left).max(0.0))
+    }
+
+    fn message_child_align(child: &NodeRef<'_>) -> TextAlign {
+        match child.node() {
+            Some(Node::Paragraph(paragraph)) => paragraph.align,
+            _ => TextAlign::Left,
+        }
+    }
+
+    fn message_target_left(inner_width: f32, child_width: f32, align: TextAlign) -> f32 {
+        match align {
+            TextAlign::Center => MESSAGE_PADDING_X + (inner_width - child_width).max(0.0) / 2.0,
+            TextAlign::Right => MESSAGE_PADDING_X + (inner_width - child_width).max(0.0),
+            TextAlign::Left | TextAlign::Justify => MESSAGE_PADDING_X,
+        }
+    }
+
     fn layout_left_line(&self, ctx: &LayoutContext, constraints: BoxConstraints) -> LayoutNode {
         const CONTENT_OFFSET: f32 = LINE_WIDTH + CONTENT_PADDING;
 
@@ -248,42 +380,97 @@ impl BlockquoteNode {
     fn layout_message(&self, ctx: &LayoutContext, constraints: BoxConstraints) -> LayoutNode {
         let max_bubble_width = constraints.max_width * MESSAGE_MAX_WIDTH_RATIO;
         let max_content_width = (max_bubble_width - MESSAGE_PADDING_X * 2.0).max(0.0);
-
-        let child_constraints =
+        let min_content_width = (MESSAGE_MIN_WIDTH - MESSAGE_PADDING_X * 2.0).max(0.0);
+        let measure_constraints =
             BoxConstraints::new(0.0, max_content_width, 0.0, constraints.max_height);
-
         let children: Vec<_> = ctx.node.children().collect();
-        let child_count = children.len();
         let block_gap = ctx.settings.block_gap;
         let node_id = ctx.node.node_id();
 
-        let mut content_nodes = Vec::new();
-        let mut y_offset = MESSAGE_PADDING_Y;
-        let mut actual_content_width = 0.0f32;
+        let measured_content_width = {
+            let measure_cache = RefCell::new(LayoutCache::new());
+            let measure_ctx = LayoutContext::new(
+                ctx.node,
+                ctx.settings,
+                ctx.default_attrs,
+                ctx.decorations,
+                ctx.scale_factor,
+                ctx.view_states,
+                &measure_cache,
+            );
+            children.iter().fold(min_content_width, |acc, child| {
+                let child_layout = measure_ctx.layout(child, measure_constraints);
+                acc.max(Self::node_intrinsic_width(child_layout.as_ref()))
+            })
+        };
 
-        for (idx, child) in children.iter().enumerate() {
-            let child_layout = ctx.layout(child, child_constraints);
-            let is_last = idx == child_count - 1;
-            let child_height = child_layout.size.height;
-            let child_width = child_layout.size.width;
+        let final_constraints =
+            BoxConstraints::new(0.0, measured_content_width, 0.0, constraints.max_height);
+
+        struct PreparedChild {
+            layout: Rc<LayoutNode>,
+            height: f32,
+            visual_left: f32,
+            visual_width: f32,
+            align: TextAlign,
+        }
+
+        let (prepared, actual_content_width) = {
+            let final_cache = RefCell::new(LayoutCache::new());
+            let final_ctx = LayoutContext::new(
+                ctx.node,
+                ctx.settings,
+                ctx.default_attrs,
+                ctx.decorations,
+                ctx.scale_factor,
+                ctx.view_states,
+                &final_cache,
+            );
+            let mut prepared = Vec::with_capacity(children.len());
+            let mut actual_content_width = min_content_width;
+            for child in children.iter() {
+                let child_layout = final_ctx.layout(child, final_constraints);
+                let (visual_left, visual_width) =
+                    Self::node_visual_left_and_width(child_layout.as_ref());
+                let align = Self::message_child_align(child);
+                actual_content_width = actual_content_width.max(visual_width);
+
+                prepared.push(PreparedChild {
+                    height: child_layout.size.height,
+                    layout: child_layout,
+                    visual_left,
+                    visual_width,
+                    align,
+                });
+            }
+            (prepared, actual_content_width)
+        };
+
+        let mut content_nodes = Vec::with_capacity(prepared.len());
+        let mut y_offset = MESSAGE_PADDING_Y;
+
+        for (idx, child) in prepared.iter().enumerate() {
+            let target_left =
+                Self::message_target_left(actual_content_width, child.visual_width, child.align);
+            let child_x = target_left - child.visual_left;
+            let is_last = idx == prepared.len() - 1;
 
             content_nodes.push(PositionedNode {
-                position: Point::new(MESSAGE_PADDING_X, y_offset),
-                node: child_layout,
+                position: Point::new(child_x, y_offset),
+                node: child.layout.clone(),
             });
 
-            y_offset += child_height
+            y_offset += child.height
                 + (if is_last {
                     0.0
                 } else {
                     block_gap as f32 / 100.0 * 16.0
                 });
-            actual_content_width = actual_content_width.max(child_width);
         }
 
         y_offset += MESSAGE_PADDING_Y;
 
-        let bubble_width = (actual_content_width + MESSAGE_PADDING_X * 2.0).max(MESSAGE_MIN_WIDTH);
+        let bubble_width = actual_content_width + MESSAGE_PADDING_X * 2.0;
         let bubble_height = y_offset;
         let bubble_size = Size::new(bubble_width, bubble_height);
 
@@ -327,5 +514,478 @@ impl BlockquoteNode {
             render_hints: Default::default(),
             scope_id: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::layout::LayoutCache;
+    use crate::model::{Decorations, DefaultAttrs, TextAlign};
+    use crate::runtime::ViewStates;
+    use crate::state::build_selection_decorations;
+    use crate::types::Point;
+    use std::cell::RefCell;
+
+    fn get_message_sent_bubble(layout: &LayoutNode) -> &LayoutNode {
+        layout
+            .children
+            .as_ref()
+            .and_then(|children| children.first())
+            .map(|child| child.node.as_ref())
+            .expect("bubble child missing")
+    }
+
+    fn content_x_bounds_in_bubble(bubble: &LayoutNode) -> (f32, f32) {
+        let Some(content_nodes) = bubble.children.as_ref() else {
+            return (0.0, 0.0);
+        };
+
+        let mut bounds = None;
+        for content in content_nodes {
+            if let Some((left, right)) =
+                BlockquoteNode::layout_visual_x_bounds(content.node.as_ref(), content.position.x)
+            {
+                BlockquoteNode::merge_x_bounds(&mut bounds, left, right);
+            }
+        }
+
+        bounds.unwrap_or((0.0, 0.0))
+    }
+
+    fn content_node_x_bounds(content: &PositionedNode) -> Option<(f32, f32)> {
+        BlockquoteNode::layout_visual_x_bounds(content.node.as_ref(), content.position.x)
+    }
+
+    #[test]
+    fn message_sent_right_align_keeps_compact_width_without_overflow() {
+        let mut bq = id!();
+        let mut p = id!();
+
+        let state = state! {
+            doc {
+                @bq blockquote(variant: BlockquoteVariant::MessageSent,) {
+                    @p paragraph(align: TextAlign::Right,) {
+                        text { "hello" }
+                    }
+                }
+            }
+            selection { (p, 0) }
+        };
+
+        let doc = &state.doc;
+        let blockquote_ref = doc.node(bq).unwrap();
+        let settings = doc.settings();
+        let default_attrs = DefaultAttrs::default();
+        let decorations = Decorations::default();
+        let cache = RefCell::new(LayoutCache::new());
+        let view_states = ViewStates::default();
+        let ctx = LayoutContext::new(
+            &blockquote_ref,
+            &settings,
+            &default_attrs,
+            &decorations,
+            1.0,
+            &view_states,
+            &cache,
+        );
+
+        let constraints = BoxConstraints::new(0.0, 300.0, 0.0, f32::INFINITY);
+        let expected_max_bubble_width = constraints.max_width * MESSAGE_MAX_WIDTH_RATIO;
+
+        let Some(Node::Blockquote(blockquote)) = blockquote_ref.node() else {
+            panic!("blockquote node expected");
+        };
+
+        let layout = blockquote.layout(&ctx, constraints);
+        let bubble = get_message_sent_bubble(&layout);
+        let (content_min_x, content_max_x) = content_x_bounds_in_bubble(bubble);
+
+        assert!(bubble.size.width < expected_max_bubble_width - 0.01);
+        assert!(content_min_x >= MESSAGE_PADDING_X - 0.01);
+        assert!(content_max_x <= bubble.size.width - MESSAGE_PADDING_X + 0.01);
+    }
+
+    #[test]
+    fn message_sent_center_align_keeps_compact_width_without_overflow() {
+        let mut bq = id!();
+        let mut p = id!();
+
+        let state = state! {
+            doc {
+                @bq blockquote(variant: BlockquoteVariant::MessageSent,) {
+                    @p paragraph(align: TextAlign::Center,) {
+                        text { "hello" }
+                    }
+                }
+            }
+            selection { (p, 0) }
+        };
+
+        let doc = &state.doc;
+        let blockquote_ref = doc.node(bq).unwrap();
+        let settings = doc.settings();
+        let default_attrs = DefaultAttrs::default();
+        let decorations = Decorations::default();
+        let cache = RefCell::new(LayoutCache::new());
+        let view_states = ViewStates::default();
+        let ctx = LayoutContext::new(
+            &blockquote_ref,
+            &settings,
+            &default_attrs,
+            &decorations,
+            1.0,
+            &view_states,
+            &cache,
+        );
+
+        let constraints = BoxConstraints::new(0.0, 300.0, 0.0, f32::INFINITY);
+        let expected_max_bubble_width = constraints.max_width * MESSAGE_MAX_WIDTH_RATIO;
+
+        let Some(Node::Blockquote(blockquote)) = blockquote_ref.node() else {
+            panic!("blockquote node expected");
+        };
+
+        let layout = blockquote.layout(&ctx, constraints);
+        let bubble = get_message_sent_bubble(&layout);
+        let (content_min_x, content_max_x) = content_x_bounds_in_bubble(bubble);
+
+        assert!(bubble.size.width < expected_max_bubble_width - 0.01);
+        assert!(content_min_x >= MESSAGE_PADDING_X - 0.01);
+        assert!(content_max_x <= bubble.size.width - MESSAGE_PADDING_X + 0.01);
+    }
+
+    #[test]
+    fn message_sent_keeps_compact_width_when_paragraph_is_left_aligned() {
+        let mut bq = id!();
+        let mut p = id!();
+
+        let state = state! {
+            doc {
+                @bq blockquote(variant: BlockquoteVariant::MessageSent,) {
+                    @p paragraph(align: TextAlign::Left,) {
+                        text { "hello" }
+                    }
+                }
+            }
+            selection { (p, 0) }
+        };
+
+        let doc = &state.doc;
+        let blockquote_ref = doc.node(bq).unwrap();
+        let settings = doc.settings();
+        let default_attrs = DefaultAttrs::default();
+        let decorations = Decorations::default();
+        let cache = RefCell::new(LayoutCache::new());
+        let view_states = ViewStates::default();
+        let ctx = LayoutContext::new(
+            &blockquote_ref,
+            &settings,
+            &default_attrs,
+            &decorations,
+            1.0,
+            &view_states,
+            &cache,
+        );
+
+        let constraints = BoxConstraints::new(0.0, 300.0, 0.0, f32::INFINITY);
+        let expected_max_bubble_width = constraints.max_width * MESSAGE_MAX_WIDTH_RATIO;
+
+        let Some(Node::Blockquote(blockquote)) = blockquote_ref.node() else {
+            panic!("blockquote node expected");
+        };
+
+        let layout = blockquote.layout(&ctx, constraints);
+        let bubble = get_message_sent_bubble(&layout);
+
+        assert!(bubble.size.width < expected_max_bubble_width - 0.01);
+        assert!(bubble.size.width >= MESSAGE_MIN_WIDTH);
+    }
+
+    #[test]
+    fn message_sent_uses_max_item_width_and_aligns_each_paragraph_within_bubble() {
+        let mut bq = id!();
+        let mut p1 = id!();
+        let mut p2 = id!();
+        let mut p3 = id!();
+
+        let state = state! {
+            doc {
+                @bq blockquote(variant: BlockquoteVariant::MessageSent,) {
+                    @p1 paragraph(align: TextAlign::Left,) {
+                        text { "long long long message" }
+                    }
+                    @p2 paragraph(align: TextAlign::Center,) {
+                        text { "mid" }
+                    }
+                    @p3 paragraph(align: TextAlign::Right,) {
+                        text { "rt" }
+                    }
+                }
+            }
+            selection { (p1, 0) }
+        };
+
+        let doc = &state.doc;
+        let blockquote_ref = doc.node(bq).unwrap();
+        let settings = doc.settings();
+        let default_attrs = DefaultAttrs::default();
+        let decorations = Decorations::default();
+        let cache = RefCell::new(LayoutCache::new());
+        let view_states = ViewStates::default();
+        let ctx = LayoutContext::new(
+            &blockquote_ref,
+            &settings,
+            &default_attrs,
+            &decorations,
+            1.0,
+            &view_states,
+            &cache,
+        );
+
+        let constraints = BoxConstraints::new(0.0, 300.0, 0.0, f32::INFINITY);
+        let Some(Node::Blockquote(blockquote)) = blockquote_ref.node() else {
+            panic!("blockquote node expected");
+        };
+
+        let layout = blockquote.layout(&ctx, constraints);
+        let bubble = get_message_sent_bubble(&layout);
+        let Some(content_nodes) = bubble.children.as_ref() else {
+            panic!("bubble content missing");
+        };
+        assert_eq!(content_nodes.len(), 3);
+
+        let (l1, r1) = content_node_x_bounds(&content_nodes[0]).expect("p1 bounds");
+        let (l2, r2) = content_node_x_bounds(&content_nodes[1]).expect("p2 bounds");
+        let (l3, r3) = content_node_x_bounds(&content_nodes[2]).expect("p3 bounds");
+        let w1 = r1 - l1;
+        let w2 = r2 - l2;
+        let w3 = r3 - l3;
+
+        let inner_width = bubble.size.width - MESSAGE_PADDING_X * 2.0;
+        let max_width = w1.max(w2).max(w3);
+
+        assert!(
+            (inner_width - max_width).abs() < 0.51,
+            "inner/max mismatch: inner={}, max={}, w1={}, w2={}, w3={}, l1={}, r1={}, l2={}, r2={}, l3={}, r3={}",
+            inner_width,
+            max_width,
+            w1,
+            w2,
+            w3,
+            l1,
+            r1,
+            l2,
+            r2,
+            l3,
+            r3
+        );
+        assert!((l1 - MESSAGE_PADDING_X).abs() < 0.51);
+        assert!((l2 - (MESSAGE_PADDING_X + (inner_width - w2) / 2.0)).abs() < 0.51);
+        assert!(
+            (r3 - (MESSAGE_PADDING_X + inner_width)).abs() < 0.51,
+            "right align mismatch: r3={}, expected={}, inner_width={}, w3={}, l3={}",
+            r3,
+            MESSAGE_PADDING_X + inner_width,
+            inner_width,
+            w3,
+            l3
+        );
+    }
+
+    #[test]
+    fn message_sent_bullet_list_right_align_stays_inside_bubble() {
+        let mut bq = id!();
+        let mut p = id!();
+
+        let state = state! {
+            doc {
+                @bq blockquote(variant: BlockquoteVariant::MessageSent,) {
+                    bullet_list {
+                        list_item {
+                            @p paragraph(align: TextAlign::Right,) {
+                                text { "hello" }
+                            }
+                        }
+                    }
+                }
+            }
+            selection { (p, 0) }
+        };
+
+        let doc = &state.doc;
+        let blockquote_ref = doc.node(bq).unwrap();
+        let settings = doc.settings();
+        let default_attrs = DefaultAttrs::default();
+        let decorations = Decorations::default();
+        let cache = RefCell::new(LayoutCache::new());
+        let view_states = ViewStates::default();
+        let ctx = LayoutContext::new(
+            &blockquote_ref,
+            &settings,
+            &default_attrs,
+            &decorations,
+            1.0,
+            &view_states,
+            &cache,
+        );
+
+        let constraints = BoxConstraints::new(0.0, 300.0, 0.0, f32::INFINITY);
+        let Some(Node::Blockquote(blockquote)) = blockquote_ref.node() else {
+            panic!("blockquote node expected");
+        };
+
+        let layout = blockquote.layout(&ctx, constraints);
+        let bubble = get_message_sent_bubble(&layout);
+        let (content_min_x, content_max_x) = content_x_bounds_in_bubble(bubble);
+
+        assert!(content_min_x >= MESSAGE_PADDING_X - 0.01);
+        assert!(content_max_x <= bubble.size.width - MESSAGE_PADDING_X + 0.01);
+        assert!(
+            (content_max_x - (bubble.size.width - MESSAGE_PADDING_X)).abs() < 0.51,
+            "list right align mismatch: right={}, expected={}",
+            content_max_x,
+            bubble.size.width - MESSAGE_PADDING_X
+        );
+    }
+
+    #[test]
+    fn message_sent_ordered_list_right_align_stays_inside_bubble() {
+        let mut bq = id!();
+        let mut p = id!();
+
+        let state = state! {
+            doc {
+                @bq blockquote(variant: BlockquoteVariant::MessageSent,) {
+                    ordered_list {
+                        list_item {
+                            @p paragraph(align: TextAlign::Right,) {
+                                text { "hello" }
+                            }
+                        }
+                    }
+                }
+            }
+            selection { (p, 0) }
+        };
+
+        let doc = &state.doc;
+        let blockquote_ref = doc.node(bq).unwrap();
+        let settings = doc.settings();
+        let default_attrs = DefaultAttrs::default();
+        let decorations = Decorations::default();
+        let cache = RefCell::new(LayoutCache::new());
+        let view_states = ViewStates::default();
+        let ctx = LayoutContext::new(
+            &blockquote_ref,
+            &settings,
+            &default_attrs,
+            &decorations,
+            1.0,
+            &view_states,
+            &cache,
+        );
+
+        let constraints = BoxConstraints::new(0.0, 300.0, 0.0, f32::INFINITY);
+        let Some(Node::Blockquote(blockquote)) = blockquote_ref.node() else {
+            panic!("blockquote node expected");
+        };
+
+        let layout = blockquote.layout(&ctx, constraints);
+        let bubble = get_message_sent_bubble(&layout);
+        let (content_min_x, content_max_x) = content_x_bounds_in_bubble(bubble);
+
+        assert!(content_min_x >= MESSAGE_PADDING_X - 0.01);
+        assert!(content_max_x <= bubble.size.width - MESSAGE_PADDING_X + 0.01);
+        assert!(
+            (content_max_x - (bubble.size.width - MESSAGE_PADDING_X)).abs() < 0.51,
+            "list right align mismatch: right={}, expected={}",
+            content_max_x,
+            bubble.size.width - MESSAGE_PADDING_X
+        );
+    }
+
+    #[test]
+    fn message_sent_right_align_selection_rect_stays_inside_bubble() {
+        let mut bq = id!();
+        let mut p = id!();
+
+        let state = state! {
+            doc {
+                @bq blockquote(variant: BlockquoteVariant::MessageSent,) {
+                    @p paragraph(align: TextAlign::Right,) {
+                        text { "hello" }
+                    }
+                }
+            }
+            selection { (p, 0) -> (p, 5) }
+        };
+
+        let doc = &state.doc;
+        let blockquote_ref = doc.node(bq).unwrap();
+        let settings = doc.settings();
+        let default_attrs = DefaultAttrs::default();
+        let decorations = Decorations::default();
+        let cache = RefCell::new(LayoutCache::new());
+        let view_states = ViewStates::default();
+        let ctx = LayoutContext::new(
+            &blockquote_ref,
+            &settings,
+            &default_attrs,
+            &decorations,
+            1.0,
+            &view_states,
+            &cache,
+        );
+
+        let constraints = BoxConstraints::new(0.0, 300.0, 0.0, f32::INFINITY);
+        let selections = build_selection_decorations(&state.doc, &state.selection, None);
+
+        let Some(Node::Blockquote(blockquote)) = blockquote_ref.node() else {
+            panic!("blockquote node expected");
+        };
+
+        let layout = blockquote.layout(&ctx, constraints);
+        let bubble = get_message_sent_bubble(&layout);
+
+        let mut found_rect = false;
+
+        let Some(content_nodes) = bubble.children.as_ref() else {
+            panic!("bubble content missing");
+        };
+
+        for content in content_nodes {
+            let Some(lines) = content.node.children.as_ref() else {
+                continue;
+            };
+
+            for line in lines {
+                let Some(Element::Line(line_element)) = line.node.element.as_ref() else {
+                    continue;
+                };
+
+                let rects = line_element.compute_selection_rects(
+                    Point::new(
+                        content.position.x + line.position.x,
+                        content.position.y + line.position.y,
+                    ),
+                    &selections,
+                );
+
+                for rect in rects {
+                    found_rect = true;
+                    assert!(rect.x >= MESSAGE_PADDING_X - 0.01);
+                    assert!(
+                        rect.x + rect.width <= bubble.size.width - MESSAGE_PADDING_X + 0.01,
+                        "selection rect overflow: x={}, width={}, bubble_width={}",
+                        rect.x,
+                        rect.width,
+                        bubble.size.width
+                    );
+                }
+            }
+        }
+
+        assert!(found_rect, "selection rect should be generated");
     }
 }


### PR DESCRIPTION
line.rs
- cluster x를 누적 advance 대신 run_offset + run_advance로 계산
- 라인 메트릭이 실제 glyph 경계와 일치하도록 수정

blockquote.rs
- 자식 intrinsic 폭을 먼저 측정한 후 그것을 constraint로 다시 레이아웃