### PR TITLE
앱 에디터 데드존 없애고 typewriter bottom padding 수정

### DIFF
--- a/apps/mobile/ios/Runner/Keyboard/KeyboardPlugin.swift
+++ b/apps/mobile/ios/Runner/Keyboard/KeyboardPlugin.swift
@@ -68,10 +68,6 @@ class KeyboardPlugin: NSObject, FlutterStreamHandler {
     }
 
     let height = keyboardVisibleHeight(from: keyboardFrame)
-    guard height > 0 else {
-      return
-    }
-
     sendKeyboardHeight(height)
   }
   

--- a/apps/mobile/lib/screens/native_editor/view/editor.dart
+++ b/apps/mobile/lib/screens/native_editor/view/editor.dart
@@ -542,16 +542,17 @@ class EditorView extends HookWidget {
 
     useEffect(() {
       final subscription = keyboard.onHeightChange.listen((double height) {
+        final nextHeight = height < 0 ? 0.0 : height;
         final wasVisible = isKeyboardVisible.value;
-        if (height > 0) {
-          keyboardHeight.value = height;
+        keyboardHeight.value = nextHeight;
+        if (nextHeight > 0) {
           if (!wasVisible) {
             bottomToolbarMode.value = BottomToolbarMode.hidden;
           }
         }
-        isKeyboardVisible.value = height > 0;
+        isKeyboardVisible.value = nextHeight > 0;
 
-        if (!wasVisible && height > 0) {
+        if (!wasVisible && nextHeight > 0) {
           WidgetsBinding.instance.addPostFrameCallback((_) {
             final verticalPosition = resolveScrollPosition(verticalScrollController);
             if (verticalPosition == null || !verticalPosition.hasContentDimensions) {

--- a/apps/mobile/lib/screens/native_editor/view/geometry.dart
+++ b/apps/mobile/lib/screens/native_editor/view/geometry.dart
@@ -19,7 +19,8 @@ class ContentGeometry {
 
   static const pageGap = 24.0;
   static const pagePadding = 40.0;
-  static const continuousPageMargin = 20.0;
+  static const typewriterMinBottomPadding = 48.0;
+  static const typewriterPaddingSafety = 1.0;
 
   double get effectiveZoom => isPaginated ? zoom : 1.0;
 
@@ -32,8 +33,6 @@ class ContentGeometry {
   double get horizontalPadding => 0;
   double get contentWidth => pageWidthAt(0) + horizontalPadding * 2;
   double get defaultBottomPadding => isPaginated ? toDisplayY(pagePadding) : 200.0;
-  double get trailingBottomMargin =>
-      layout is PaginatedLayout ? toDisplayY((layout as PaginatedLayout).pageMarginBottom) : continuousPageMargin;
 
   double _logicalPageWidthAt(int index) {
     if (layout case PaginatedLayout(:final pageWidth)) {
@@ -85,17 +84,6 @@ class ContentGeometry {
 
   double cursorTopInContent(CursorInfo cursor) => cursorTopInPages(cursor) + titleAreaHeight;
 
-  double? get collapsedSelectionHandleHeight {
-    if (!(selection?.collapsed ?? false)) {
-      return null;
-    }
-    final h = selection?.headBounds?.height ?? selection?.anchorBounds?.height;
-    if (h == null) {
-      return null;
-    }
-    return toDisplayY(h);
-  }
-
   List<double> computeCumulativePageOffsets() {
     final offsets = <double>[0];
     for (var i = 0; i < pages.length; i++) {
@@ -111,18 +99,22 @@ class ContentGeometry {
     bool typewriterEnabled = false,
     double typewriterPosition = 0.5,
   }) {
+    final minimumBottomPadding = typewriterEnabled ? typewriterMinBottomPadding : defaultBottomPadding;
+
     if (!typewriterEnabled || cursor == null) {
-      return defaultBottomPadding;
+      return minimumBottomPadding;
     }
 
     final cursorHeight = toDisplayY(cursor.height);
-    final handleHeight = collapsedSelectionHandleHeight ?? cursorHeight;
-    final cursorLeading = math.max(0, handleHeight - cursorHeight);
     final spaceNeededBelowCursorTop = (1 - typewriterPosition) * (viewportHeight - cursorHeight) + cursorHeight;
-    final intrinsicSpaceBelowLastLine = trailingBottomMargin + cursorHeight + cursorLeading;
-    final requiredPadding = spaceNeededBelowCursorTop - intrinsicSpaceBelowLastLine;
+    final spaceAvailableBelowCursorTop = (titleAreaHeight + pagesContentHeight - cursorTopInContent(cursor)).clamp(
+      0.0,
+      double.infinity,
+    );
 
-    return math.max(defaultBottomPadding, requiredPadding);
+    final requiredPadding = spaceNeededBelowCursorTop - spaceAvailableBelowCursorTop + typewriterPaddingSafety;
+
+    return math.max(minimumBottomPadding, requiredPadding);
   }
 
   double totalContentHeight({

--- a/apps/mobile/lib/screens/native_editor/view/pages.dart
+++ b/apps/mobile/lib/screens/native_editor/view/pages.dart
@@ -616,7 +616,7 @@ class PageList extends HookWidget {
             : const _NonGestureBouncingScrollPhysics();
 
         final contentBottomPadding = geo.bottomPadding(
-          viewportHeight: resolveScrollPosition(verticalScrollController)?.viewportDimension ?? viewHeight,
+          viewportHeight: viewHeight,
           cursor: cursor,
           typewriterEnabled: pref.typewriterEnabled,
           typewriterPosition: pref.typewriterPosition,
@@ -1346,6 +1346,7 @@ class PageList extends HookWidget {
               endTextHandleDrag();
             },
             child: Stack(
+              fit: StackFit.expand,
               clipBehavior: Clip.none,
               children: [
                 NotificationListener<ScrollMetricsNotification>(


### PR DESCRIPTION
- 에디터가 항상 화면 전체를 차지하도록 해서 특히 키보드 닫았을 때 뷰포트 아래 부분의 데드존을 없앰
- typewriter bottom padding 정확하게 수정
- keyboard height 0도 전달