### PR TITLE
에디터 포커스 트랩 경험 개선

### DIFF
--- a/apps/website/src/lib/components/editor/core/Input.svelte
+++ b/apps/website/src/lib/components/editor/core/Input.svelte
@@ -239,9 +239,27 @@
     }
   };
 
+  let pointerDownOutsideEditor = false;
+
+  $effect(() => {
+    const paneEl = editor.scrollContainerEl?.closest('[data-pane-id]') as HTMLElement | null;
+    if (!paneEl) return;
+
+    const handlePointerDown = (e: PointerEvent) => {
+      if (editor.extensionArea.containerEl?.contains(e.target as Node)) return;
+      pointerDownOutsideEditor = true;
+      requestAnimationFrame(() => {
+        pointerDownOutsideEditor = false;
+      });
+    };
+
+    paneEl.addEventListener('pointerdown', handlePointerDown, true);
+    return () => paneEl.removeEventListener('pointerdown', handlePointerDown, true);
+  });
+
   $effect(() => {
     if (ctx.paneFocused) {
-      if (editor.scrollContainerEl?.contains(document.activeElement)) return;
+      if (pointerDownOutsideEditor) return;
       inputEl?.focus({ preventScroll: true });
     }
   });


### PR DESCRIPTION
포커스 안 된 pane의 패널등을(예: 노트) 눌렀을 때 해당 요소가 아닌 에디터 본문이 포커스 뺏어가는 문제 해결함
