### PR TITLE
플러터 엔진에 pushImage한 이미지를 close하지 않도록 함

### DIFF
--- a/apps/mobile/android/app/src/main/kotlin/co/typie/editortexture/EditorTexturePlugin.kt
+++ b/apps/mobile/android/app/src/main/kotlin/co/typie/editortexture/EditorTexturePlugin.kt
@@ -122,15 +122,10 @@ class EditorTexture(
   }
 
   private fun createPipeline(width: Int, height: Int) {
-    prevPrevImage?.close()
-    prevPrevImage = null
-    prevImage?.close()
-    prevImage = null
-    imageWriter?.close()
-    imageReader?.close()
+    releasePipeline()
 
     val reader = ImageReader.newInstance(
-      width, height, PixelFormat.RGBA_8888, 3,
+      width, height, PixelFormat.RGBA_8888, 4,
       HardwareBuffer.USAGE_CPU_WRITE_OFTEN or HardwareBuffer.USAGE_GPU_SAMPLED_IMAGE
     )
     val writer = ImageWriter.newInstance(reader.surface, 2)
@@ -139,6 +134,29 @@ class EditorTexture(
     imageWriter = writer
     currentWidth = width
     currentHeight = height
+  }
+
+  private fun releasePipeline() {
+    entry.pushImage(null)
+    safeClose(prevPrevImage)
+    prevPrevImage = null
+    safeClose(prevImage)
+    prevImage = null
+    imageWriter?.close()
+    imageWriter = null
+    imageReader?.close()
+    imageReader = null
+  }
+
+  private fun safeClose(image: android.media.Image?) {
+    if (image == null) {
+      return
+    }
+    try {
+      image.close()
+    } catch (_: IllegalStateException) {
+      // May already be closed by Flutter internals.
+    }
   }
 
   fun render(editorPtr: Long, pageIndex: Int, width: Int, height: Int): Boolean {
@@ -152,7 +170,7 @@ class EditorTexture(
       val writer = imageWriter ?: return false
       val reader = imageReader ?: return false
 
-      prevPrevImage?.close()
+      safeClose(prevPrevImage)
       prevPrevImage = prevImage
       prevImage = null
 
@@ -185,9 +203,18 @@ class EditorTexture(
         return false
       }
 
-      writer.queueInputImage(inputImage)
+      try {
+        writer.queueInputImage(inputImage)
+      } catch (_: IllegalStateException) {
+        inputImage.close()
+        return false
+      }
 
-      val outputImage = reader.acquireLatestImage() ?: return false
+      val outputImage = try {
+        reader.acquireLatestImage()
+      } catch (_: IllegalStateException) {
+        return false
+      } ?: return false
       entry.pushImage(outputImage)
       prevImage = outputImage
 
@@ -200,15 +227,8 @@ class EditorTexture(
   fun dispose() {
     bufferLock.lock()
     try {
+      releasePipeline()
       entry.release()
-      prevPrevImage?.close()
-      prevPrevImage = null
-      prevImage?.close()
-      prevImage = null
-      imageWriter?.close()
-      imageWriter = null
-      imageReader?.close()
-      imageReader = null
     } finally {
       bufferLock.unlock()
     }

--- a/apps/mobile/lib/screens/native_editor/view/page.dart
+++ b/apps/mobile/lib/screens/native_editor/view/page.dart
@@ -17,7 +17,6 @@ import 'package:typie/services/preference.dart';
 const _cropMarkerSize = 32.0;
 const _renderRetryBaseDelayMs = 32;
 const _renderRetryMaxDelayMs = 512;
-const _renderRetryMaxAttempts = 6;
 
 class PageItem extends HookWidget {
   const PageItem({required this.pageIndex, super.key});
@@ -67,9 +66,6 @@ class PageItem extends HookWidget {
 
     void scheduleRetry(Future<void> Function() task) {
       if (!isMounted.value) {
-        return;
-      }
-      if (retryAttempts.value >= _renderRetryMaxAttempts) {
         return;
       }
 


### PR DESCRIPTION
- 핀치/리사이즈처럼 프레임 갱신이 급해질 때 종종 Image is already closed 뜨고 크래시가 남
- pushImage로 플러터 엔진에 전달한 이미지는 플러터에서 관리한다고 함
- 그것을 플러그인이 닫지 않도록 해야 한다고 함
- ~수동 close 제거~ -> safe close
- 파이프라인 정리 시 엔진 캐시 프레임을 먼저 비우기
- 예외가 크래시 대신 프레임 드롭/재시도가 되도록 함
- page.dart 에서 렌더 재시도 무제한으로 하도록 함