### PR TITLE
안드로이드 렌더 안정화

### DIFF
--- a/apps/mobile/android/app/src/main/kotlin/co/typie/editortexture/EditorTexturePlugin.kt
+++ b/apps/mobile/android/app/src/main/kotlin/co/typie/editortexture/EditorTexturePlugin.kt
@@ -4,17 +4,24 @@ import android.graphics.PixelFormat
 import android.hardware.HardwareBuffer
 import android.media.ImageReader
 import android.media.ImageWriter
+import android.os.Handler
+import android.os.Looper
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.view.TextureRegistry
 import java.nio.ByteBuffer
+import java.util.concurrent.Executors
+import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.locks.ReentrantLock
 
 class EditorTexturePlugin : FlutterPlugin, MethodChannel.MethodCallHandler {
   private lateinit var channel: MethodChannel
   private lateinit var textureRegistry: TextureRegistry
   private val textures = mutableMapOf<Long, EditorTexture>()
+  private val texturesLock = Any()
+  private val mainHandler = Handler(Looper.getMainLooper())
+  private val renderExecutor = Executors.newSingleThreadExecutor()
 
   companion object {
     private const val MAX_TEXTURES = 10
@@ -28,8 +35,13 @@ class EditorTexturePlugin : FlutterPlugin, MethodChannel.MethodCallHandler {
 
   override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
     channel.setMethodCallHandler(null)
-    textures.values.forEach { it.dispose() }
-    textures.clear()
+    renderExecutor.shutdownNow()
+    val toDispose = synchronized(texturesLock) {
+      val values = textures.values.toList()
+      textures.clear()
+      values
+    }
+    toDispose.forEach { it.dispose() }
   }
 
   override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
@@ -43,86 +55,159 @@ class EditorTexturePlugin : FlutterPlugin, MethodChannel.MethodCallHandler {
 
   private fun handleCreate(call: MethodCall, result: MethodChannel.Result) {
     val width = call.argument<Int>("width") ?: run {
-      result.error("INVALID_ARGS", "Missing width", null)
+      replyError(result, "INVALID_ARGS", "Missing width")
       return
     }
     val height = call.argument<Int>("height") ?: run {
-      result.error("INVALID_ARGS", "Missing height", null)
+      replyError(result, "INVALID_ARGS", "Missing height")
       return
     }
 
-    while (textures.size >= MAX_TEXTURES) {
-      val oldestId = textures.keys.minOrNull() ?: break
-      textures.remove(oldestId)?.dispose()
+    postOnMainOrReplyError(result, "CREATE_FAILED") {
+      val toEvict = mutableListOf<EditorTexture>()
+      synchronized(texturesLock) {
+        while (textures.size >= MAX_TEXTURES) {
+          val oldestId = textures.keys.minOrNull() ?: break
+          val removed = textures.remove(oldestId)
+          if (removed != null) {
+            toEvict.add(removed)
+          }
+        }
+      }
+      toEvict.forEach { it.dispose() }
+
+      val entry = textureRegistry.createImageTexture()
+      val texture = EditorTexture(entry, width, height, mainHandler)
+      val textureId = entry.id()
+      synchronized(texturesLock) {
+        textures[textureId] = texture
+      }
+
+      result.success(textureId)
     }
-
-    val entry = textureRegistry.createImageTexture()
-    val texture = EditorTexture(entry, width, height)
-    val textureId = entry.id()
-    textures[textureId] = texture
-
-    result.success(textureId)
   }
 
   @Suppress("UNCHECKED_CAST")
   private fun handleRender(call: MethodCall, result: MethodChannel.Result) {
     val items = call.argument<List<Map<String, Any>>>("items") ?: run {
-      result.error("INVALID_ARGS", "Missing items", null)
+      replyError(result, "INVALID_ARGS", "Missing items")
       return
     }
 
-    val results = mutableListOf<Boolean>()
+    try {
+      renderExecutor.execute {
+        try {
+          val results = mutableListOf<Boolean>()
 
-    for (item in items) {
-      val textureId = (item["textureId"] as? Number)?.toLong()
-      val editorPtr = (item["editorPtr"] as? Number)?.toLong()
-      val pageIndex = item["pageIndex"] as? Int
-      val width = item["width"] as? Int
-      val height = item["height"] as? Int
+          for (item in items) {
+            val textureId = (item["textureId"] as? Number)?.toLong()
+            val editorPtr = (item["editorPtr"] as? Number)?.toLong()
+            val pageIndex = item["pageIndex"] as? Int
+            val width = item["width"] as? Int
+            val height = item["height"] as? Int
 
-      if (textureId == null || editorPtr == null || pageIndex == null || width == null || height == null) {
-        results.add(false)
-        continue
+            if (textureId == null || editorPtr == null || pageIndex == null || width == null || height == null) {
+              results.add(false)
+              continue
+            }
+
+            val texture = synchronized(texturesLock) {
+              textures[textureId]
+            }
+            val didRender = texture?.render(editorPtr, pageIndex, width, height) ?: false
+            results.add(didRender)
+          }
+
+          replySuccess(result, results)
+        } catch (t: Throwable) {
+          replyError(result, "RENDER_FAILED", t.message ?: "Render failed")
+        }
       }
-
-      val texture = textures[textureId]
-      val didRender = texture?.render(editorPtr, pageIndex, width, height) ?: false
-      results.add(didRender)
+    } catch (_: RejectedExecutionException) {
+      replySuccess(result, List(items.size) { false })
     }
-
-    result.success(results)
   }
 
   private fun handleDispose(call: MethodCall, result: MethodChannel.Result) {
     val textureId = call.argument<Number>("textureId")?.toLong() ?: run {
-      result.error("INVALID_ARGS", "Missing textureId", null)
+      replyError(result, "INVALID_ARGS", "Missing textureId")
       return
     }
 
-    textures.remove(textureId)?.dispose()
-    result.success(null)
+    postOnMainOrReplyError(result, "DISPOSE_FAILED") {
+      val texture = synchronized(texturesLock) {
+        textures.remove(textureId)
+      }
+      texture?.dispose()
+      result.success(null)
+    }
+  }
+
+  private fun replySuccess(result: MethodChannel.Result, value: Any?) {
+    if (Looper.myLooper() == Looper.getMainLooper()) {
+      result.success(value)
+      return
+    }
+    if (!mainHandler.post { result.success(value) }) {
+      result.success(value)
+    }
+  }
+
+  private fun replyError(result: MethodChannel.Result, code: String, message: String) {
+    if (Looper.myLooper() == Looper.getMainLooper()) {
+      result.error(code, message, null)
+      return
+    }
+    if (!mainHandler.post { result.error(code, message, null) }) {
+      result.error(code, message, null)
+    }
+  }
+
+  private inline fun postOnMainOrReplyError(
+    result: MethodChannel.Result,
+    errorCode: String,
+    crossinline block: () -> Unit
+  ) {
+    val task = Runnable {
+      try {
+        block()
+      } catch (t: Throwable) {
+        result.error(errorCode, t.message ?: errorCode, null)
+      }
+    }
+
+    if (Looper.myLooper() == Looper.getMainLooper()) {
+      task.run()
+      return
+    }
+    if (!mainHandler.post(task)) {
+      result.error(errorCode, "Failed to post work to main thread", null)
+    }
   }
 }
 
 class EditorTexture(
   private val entry: TextureRegistry.ImageTextureEntry,
   initialWidth: Int,
-  initialHeight: Int
+  initialHeight: Int,
+  private val mainHandler: Handler
 ) {
   private var imageReader: ImageReader? = null
   private var imageWriter: ImageWriter? = null
   private var currentWidth = initialWidth
   private var currentHeight = initialHeight
   private val bufferLock = ReentrantLock()
-  private var prevPrevImage: android.media.Image? = null
-  private var prevImage: android.media.Image? = null
+  @Volatile
+  private var disposed = false
 
   init {
-    createPipeline(initialWidth, initialHeight)
+    check(createPipeline(initialWidth, initialHeight)) { "Failed to create initial image pipeline" }
   }
 
-  private fun createPipeline(width: Int, height: Int) {
-    releasePipeline()
+  private fun createPipeline(width: Int, height: Int): Boolean {
+    if (!releasePipeline(clearTexture = true, waitForClear = true)) {
+      return false
+    }
 
     val reader = ImageReader.newInstance(
       width, height, PixelFormat.RGBA_8888, 4,
@@ -134,21 +219,22 @@ class EditorTexture(
     imageWriter = writer
     currentWidth = width
     currentHeight = height
+    return true
   }
 
-  private fun releasePipeline() {
-    entry.pushImage(null)
-    safeClose(prevPrevImage)
-    prevPrevImage = null
-    safeClose(prevImage)
-    prevImage = null
+  private fun releasePipeline(clearTexture: Boolean = true, waitForClear: Boolean = false): Boolean {
+    val hasPipeline = imageReader != null || imageWriter != null
+    if (clearTexture && hasPipeline && !pushImageOnMain(null, wait = waitForClear)) {
+      return false
+    }
     imageWriter?.close()
     imageWriter = null
     imageReader?.close()
     imageReader = null
+    return true
   }
 
-  private fun safeClose(image: android.media.Image?) {
+  private fun closeImageSafely(image: android.media.Image?) {
     if (image == null) {
       return
     }
@@ -159,20 +245,82 @@ class EditorTexture(
     }
   }
 
+  private fun pushImageOnMain(image: android.media.Image?, wait: Boolean): Boolean {
+    var pushed = false
+    val task = Runnable {
+      if (disposed) {
+        closeImageSafely(image)
+        return@Runnable
+      }
+      try {
+        entry.pushImage(image)
+        pushed = true
+      } catch (_: IllegalStateException) {
+        closeImageSafely(image)
+      }
+    }
+
+    if (Looper.myLooper() == Looper.getMainLooper()) {
+      task.run()
+      return pushed
+    }
+
+    if (!wait) {
+      if (!mainHandler.post(task)) {
+        closeImageSafely(image)
+      }
+      return false
+    }
+
+    val latch = java.util.concurrent.CountDownLatch(1)
+    val aborted = java.util.concurrent.atomic.AtomicBoolean(false)
+    if (!mainHandler.post({
+      try {
+        if (aborted.get()) {
+          closeImageSafely(image)
+          return@post
+        }
+        task.run()
+      } finally {
+        latch.countDown()
+      }
+    })) {
+      closeImageSafely(image)
+      return false
+    }
+    try {
+      if (!latch.await(MAIN_THREAD_PUSH_TIMEOUT_MS, java.util.concurrent.TimeUnit.MILLISECONDS)) {
+        aborted.set(true)
+        closeImageSafely(image)
+        return false
+      }
+    } catch (_: InterruptedException) {
+      aborted.set(true)
+      Thread.currentThread().interrupt()
+      closeImageSafely(image)
+      return false
+    }
+    return pushed
+  }
+
   fun render(editorPtr: Long, pageIndex: Int, width: Int, height: Int): Boolean {
+    var outputImage: android.media.Image? = null
+
     if (!bufferLock.tryLock()) return false
 
     try {
+      if (disposed) {
+        return false
+      }
+
       if (width != currentWidth || height != currentHeight) {
-        createPipeline(width, height)
+        if (!createPipeline(width, height)) {
+          return false
+        }
       }
 
       val writer = imageWriter ?: return false
       val reader = imageReader ?: return false
-
-      safeClose(prevPrevImage)
-      prevPrevImage = prevImage
-      prevImage = null
 
       val inputImage = try {
         writer.dequeueInputImage()
@@ -184,7 +332,7 @@ class EditorTexture(
       val buffer = plane.buffer
       val ptr = nativeGetDirectBufferAddress(buffer)
       if (ptr == 0L) {
-        inputImage.close()
+        closeImageSafely(inputImage)
         return false
       }
 
@@ -199,35 +347,38 @@ class EditorTexture(
       )
 
       if (result != 0L) {
-        inputImage.close()
+        closeImageSafely(inputImage)
         return false
       }
 
       try {
         writer.queueInputImage(inputImage)
       } catch (_: IllegalStateException) {
-        inputImage.close()
+        closeImageSafely(inputImage)
         return false
       }
 
-      val outputImage = try {
+      outputImage = try {
         reader.acquireLatestImage()
       } catch (_: IllegalStateException) {
         return false
       } ?: return false
-      entry.pushImage(outputImage)
-      prevImage = outputImage
-
-      return true
     } finally {
       bufferLock.unlock()
     }
+
+    return pushImageOnMain(outputImage, wait = true)
   }
 
   fun dispose() {
     bufferLock.lock()
     try {
-      releasePipeline()
+      if (disposed) {
+        return
+      }
+      pushImageOnMain(null, wait = true)
+      disposed = true
+      releasePipeline(clearTexture = false, waitForClear = false)
       entry.release()
     } finally {
       bufferLock.unlock()
@@ -247,6 +398,7 @@ class EditorTexture(
 
   companion object {
     private const val PIXEL_FORMAT_RGBA = 0L
+    private const val MAIN_THREAD_PUSH_TIMEOUT_MS = 250L
 
     init {
       System.loadLibrary("editor")

--- a/apps/mobile/lib/native/editor_native.dart
+++ b/apps/mobile/lib/native/editor_native.dart
@@ -6,6 +6,7 @@ import 'package:ffi/ffi.dart';
 import 'package:flutter/foundation.dart';
 
 import 'editor_bindings.dart';
+import 'editor_render_coordinator.dart';
 
 const _logLevelDebug = 0;
 const _logLevelInfo = 1;
@@ -716,10 +717,18 @@ final class NativeEditor {
     }
   }
 
-  void dispose() {
+  Future<void> dispose() async {
     if (!_disposed) {
-      _bindings.editor_handle_free(_handle);
       _disposed = true;
+
+      final editorPtr = _handle.address;
+      EditorRenderCoordinator.markEditorDisposing(editorPtr);
+      try {
+        await EditorRenderCoordinator.waitForEditorIdle(editorPtr);
+        _bindings.editor_handle_free(_handle);
+      } finally {
+        EditorRenderCoordinator.markEditorDisposed(editorPtr);
+      }
     }
   }
 

--- a/apps/mobile/lib/native/editor_render_coordinator.dart
+++ b/apps/mobile/lib/native/editor_render_coordinator.dart
@@ -1,0 +1,64 @@
+import 'dart:async';
+
+final class EditorRenderCoordinator {
+  EditorRenderCoordinator._();
+
+  static final _inFlightByEditor = <int, int>{};
+  static final _waitersByEditor = <int, List<Completer<void>>>{};
+  static final _disposingEditors = <int>{};
+
+  static bool isEditorDisposing(int editorPtr) {
+    return _disposingEditors.contains(editorPtr);
+  }
+
+  static void markEditorDisposing(int editorPtr) {
+    _disposingEditors.add(editorPtr);
+  }
+
+  static void markEditorDisposed(int editorPtr) {
+    _disposingEditors.remove(editorPtr);
+    _completeWaiters(editorPtr);
+  }
+
+  static void markBatchStarted(Iterable<int> editorPtrs) {
+    for (final editorPtr in editorPtrs.toSet()) {
+      _inFlightByEditor[editorPtr] = (_inFlightByEditor[editorPtr] ?? 0) + 1;
+    }
+  }
+
+  static void markBatchFinished(Iterable<int> editorPtrs) {
+    for (final editorPtr in editorPtrs.toSet()) {
+      final current = _inFlightByEditor[editorPtr];
+      if (current == null || current <= 1) {
+        _inFlightByEditor.remove(editorPtr);
+      } else {
+        _inFlightByEditor[editorPtr] = current - 1;
+      }
+      if ((_inFlightByEditor[editorPtr] ?? 0) == 0) {
+        _completeWaiters(editorPtr);
+      }
+    }
+  }
+
+  static Future<void> waitForEditorIdle(int editorPtr) {
+    if ((_inFlightByEditor[editorPtr] ?? 0) == 0) {
+      return Future<void>.value();
+    }
+
+    final completer = Completer<void>();
+    (_waitersByEditor[editorPtr] ??= []).add(completer);
+    return completer.future;
+  }
+
+  static void _completeWaiters(int editorPtr) {
+    final waiters = _waitersByEditor.remove(editorPtr);
+    if (waiters == null) {
+      return;
+    }
+    for (final waiter in waiters) {
+      if (!waiter.isCompleted) {
+        waiter.complete();
+      }
+    }
+  }
+}

--- a/apps/mobile/lib/native/editor_texture_renderer.dart
+++ b/apps/mobile/lib/native/editor_texture_renderer.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/services.dart';
 import 'package:typie/native/editor_native.dart';
+import 'package:typie/native/editor_render_coordinator.dart';
 
 class _BatchRenderItem {
   _BatchRenderItem({
@@ -64,7 +65,12 @@ class EditorTextureRenderer {
   }
 
   Future<bool> render(int pageIndex) async {
-    if (_textureId == null) {
+    if (_textureId == null || editor.isDisposed) {
+      return false;
+    }
+
+    final editorPtr = editor.handle.address;
+    if (EditorRenderCoordinator.isEditorDisposing(editorPtr)) {
       return false;
     }
 
@@ -86,7 +92,7 @@ class EditorTextureRenderer {
       _BatchRenderItem(
         textureId: _textureId!,
         editor: editor,
-        editorPtr: editor.handle.address,
+        editorPtr: editorPtr,
         pageIndex: pageIndex,
         width: info.width,
         height: info.height,
@@ -154,7 +160,18 @@ class EditorTextureRenderer {
         continue;
       }
 
-      final latestInfo = item.editor.getRenderInfo(item.pageIndex);
+      if (item.editor.isDisposed || EditorRenderCoordinator.isEditorDisposing(item.editorPtr)) {
+        item.completer.complete(false);
+        continue;
+      }
+
+      NativeEditorRenderInfo? latestInfo;
+      try {
+        latestInfo = item.editor.getRenderInfo(item.pageIndex);
+      } on EditorException {
+        item.completer.complete(false);
+        continue;
+      }
       final stableSize =
           latestInfo != null &&
           latestInfo.width > 0 &&
@@ -181,6 +198,8 @@ class EditorTextureRenderer {
       return;
     }
 
+    final editorPtrs = submitted.map((item) => item.editorPtr).toSet();
+    EditorRenderCoordinator.markBatchStarted(editorPtrs);
     try {
       final response = await _channel.invokeMethod<dynamic>('render', {'items': payloadItems});
 
@@ -205,6 +224,8 @@ class EditorTextureRenderer {
       for (final item in submitted) {
         item.completer.complete(false);
       }
+    } finally {
+      EditorRenderCoordinator.markBatchFinished(editorPtrs);
     }
   }
 

--- a/apps/mobile/lib/screens/native_editor/screen.dart
+++ b/apps/mobile/lib/screens/native_editor/screen.dart
@@ -521,7 +521,7 @@ class _EditorContent extends HookWidget {
         selectionSync.value?.dispose(titleFocusNode, subtitleFocusNode);
         syncManager.value?.dispose();
         syncManager.value = null;
-        editor.value?.dispose();
+        unawaited(editor.value?.dispose());
       };
     }, [document?.id]);
 

--- a/apps/mobile/lib/screens/native_editor/view/scrollbar.dart
+++ b/apps/mobile/lib/screens/native_editor/view/scrollbar.dart
@@ -450,6 +450,7 @@ class EditorScrollbar extends HookWidget {
                                     minHeight: thumbHeight,
                                     maxHeight: thumbHeight,
                                     child: AnimatedContainer(
+                                      key: const ValueKey('native-editor-scrollbar-thumb-vertical'),
                                       duration: const Duration(milliseconds: 250),
                                       curve: Curves.easeInOutBack,
                                       width: isDraggingV.value ? _activeThumbWidth : _thumbWidth,
@@ -572,6 +573,7 @@ class EditorScrollbar extends HookWidget {
                                     minHeight: 0,
                                     maxHeight: _activeThumbWidth * 2,
                                     child: AnimatedContainer(
+                                      key: const ValueKey('native-editor-scrollbar-thumb-horizontal'),
                                       duration: const Duration(milliseconds: 250),
                                       curve: Curves.easeInOutBack,
                                       width: double.infinity,

--- a/crates/editor/src/ffi/native.rs
+++ b/crates/editor/src/ffi/native.rs
@@ -20,6 +20,7 @@ use std::ffi::{CStr, CString, c_char};
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
+use std::sync::{Mutex, MutexGuard};
 
 #[cfg(target_os = "android")]
 use jni::EnvUnowned;
@@ -31,6 +32,7 @@ use jni::sys::jlong;
 use std::arch::aarch64::*;
 
 static PANIC_HOOK_INSTALLED: AtomicBool = AtomicBool::new(false);
+static EDITOR_FFI_LOCK: Mutex<()> = Mutex::new(());
 
 pub type LogCallback = extern "C" fn(level: i32, message: *const c_char);
 static LOG_CALLBACK: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());
@@ -78,6 +80,13 @@ fn install_panic_hook() {
 
 fn set_last_error(msg: impl Into<String>) {
     LAST_ERROR.with(|e| *e.borrow_mut() = Some(msg.into()));
+}
+
+fn lock_editor_ffi() -> MutexGuard<'static, ()> {
+    match EDITOR_FFI_LOCK.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
 }
 
 fn handle_panic(e: Box<dyn std::any::Any + Send>) {
@@ -161,6 +170,7 @@ impl IntoFfi for FfiResult<usize> {
 macro_rules! ffi {
     ($body:expr, $default:expr) => {{
         install_panic_hook();
+        let _guard = lock_editor_ffi();
         match catch_unwind(AssertUnwindSafe(|| $body)) {
             Ok(result) => result.into_ffi(),
             Err(e) => {
@@ -464,6 +474,7 @@ pub struct EditorHandle {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn editor_handle_free(editor: *mut EditorHandle) {
+    let _guard = lock_editor_ffi();
     if !editor.is_null() {
         unsafe { drop(Box::from_raw(editor as *mut EditorInner)) }
     }
@@ -507,6 +518,7 @@ pub extern "C" fn editor_tick(editor: *mut EditorHandle) -> i32 {
 #[unsafe(no_mangle)]
 pub extern "C" fn editor_get_slate_ptr(editor: *mut EditorHandle) -> *const u8 {
     install_panic_hook();
+    let _guard = lock_editor_ffi();
     if editor.is_null() {
         return std::ptr::null();
     }
@@ -522,6 +534,7 @@ pub extern "C" fn editor_get_slate_len(_editor: *mut EditorHandle) -> u32 {
 #[unsafe(no_mangle)]
 pub extern "C" fn editor_get_slab_ptr(editor: *mut EditorHandle) -> *const u8 {
     install_panic_hook();
+    let _guard = lock_editor_ffi();
     if editor.is_null() {
         return std::ptr::null();
     }
@@ -532,6 +545,7 @@ pub extern "C" fn editor_get_slab_ptr(editor: *mut EditorHandle) -> *const u8 {
 #[unsafe(no_mangle)]
 pub extern "C" fn editor_get_slab_len(editor: *mut EditorHandle) -> u32 {
     install_panic_hook();
+    let _guard = lock_editor_ffi();
     if editor.is_null() {
         return 0;
     }


### PR DESCRIPTION
느린 안드로이드 폰에서 줌을 빠르게 하다 보면 프리징이나 크래시

- texture create/dispose와 MethodChannel.Result를 메인 스레드로 강제
- 렌더를 위한 단일 executor와 lock
- 렌더 실패 시 오류 전파 최소화
- dispose vs render 경합 방지
- scrollbar thumb AnimatedContainer에 key 부여 (가끔 Infinity ~ Infinity를 interpolation하려고 하는 경우가 있었음)
- dispatch, tick, render 동시에 들어가지 않도록 lock (크래시 방지)