### PR TITLE
앱 DND 및 제스처 디버그

### DIFF
--- a/apps/mobile/lib/native/editor_native.dart
+++ b/apps/mobile/lib/native/editor_native.dart
@@ -289,6 +289,7 @@ final class NativeEditor {
 
   final Pointer<EditorHandle> _handle;
   final _NativeEditorTestConfig? _testConfig;
+  final List<Map<String, dynamic>> _testDispatchedMessages = [];
   bool _disposed = false;
   bool _awake = false;
 
@@ -297,6 +298,14 @@ final class NativeEditor {
   bool get isDisposed => _disposed;
   bool get awake => _awake;
   bool get isTest => _testConfig != null;
+
+  @visibleForTesting
+  List<Map<String, dynamic>> get testDispatchedMessages => List.unmodifiable(_testDispatchedMessages);
+
+  @visibleForTesting
+  void clearTestDispatchedMessages() {
+    _testDispatchedMessages.clear();
+  }
 
   void _wakeUp() {
     if (!_awake) {
@@ -312,6 +321,7 @@ final class NativeEditor {
   void dispatch(Map<String, dynamic> message) {
     _checkDisposed();
     if (isTest) {
+      _testDispatchedMessages.add(Map<String, dynamic>.from(message));
       _wakeUp();
       return;
     }

--- a/apps/mobile/lib/screens/native_editor/controller/dnd_controller.dart
+++ b/apps/mobile/lib/screens/native_editor/controller/dnd_controller.dart
@@ -8,6 +8,8 @@ import 'package:super_drag_and_drop/super_drag_and_drop.dart';
 import 'package:typie/native/editor_native.dart';
 import 'package:typie/screens/native_editor/state/controller.dart';
 
+enum DndDropResult { handled, needsDragEnd }
+
 class DndController {
   DndController({required this.editor, required this.controller});
 
@@ -188,7 +190,7 @@ class DndController {
     controller.dispatch({'type': 'dragOver', 'pageIdx': pageIdx, 'x': x, 'y': y});
   }
 
-  Future<void> handleDrop({
+  Future<DndDropResult> handleDrop({
     required int pageIdx,
     required double x,
     required double y,
@@ -196,8 +198,7 @@ class DndController {
   }) async {
     final item = session.items.firstOrNull;
     if (item == null) {
-      _handleDragEnd();
-      return;
+      return DndDropResult.needsDragEnd;
     }
 
     // 내부 드래그인 경우
@@ -215,14 +216,13 @@ class DndController {
           'modifier': {'shift': false, 'ctrl': false, 'alt': false, 'meta': false},
         })
         ..scrollIntoView();
-      return;
+      return DndDropResult.handled;
     }
 
     // 외부 드래그인 경우
     final reader = item.dataReader;
     if (reader == null) {
-      _handleDragEnd();
-      return;
+      return DndDropResult.needsDragEnd;
     }
 
     if (reader.canProvide(Formats.plainText)) {
@@ -249,11 +249,11 @@ class DndController {
             'modifier': {'shift': false, 'ctrl': false, 'alt': false, 'meta': false},
           })
           ..scrollIntoView();
-        return;
+        return DndDropResult.handled;
       }
     }
 
-    _handleDragEnd();
+    return DndDropResult.needsDragEnd;
   }
 
   void handleDragEnd() {

--- a/apps/mobile/lib/screens/native_editor/view/editor_draggable.dart
+++ b/apps/mobile/lib/screens/native_editor/view/editor_draggable.dart
@@ -44,11 +44,12 @@ class EditorDraggable extends StatelessWidget {
         }
 
         onSessionCompleted = () {
-          if (request.session.dragCompleted.value == null) {
+          final op = request.session.dragCompleted.value;
+          if (op == null) {
             return;
           }
           clearSessionCompletedListener();
-          interactionController.endDndSession();
+          interactionController.onLocalDragCompleted(op);
         };
         request.session.dragCompleted.addListener(onSessionCompleted);
         isSessionListenerAttached = true;

--- a/apps/mobile/lib/screens/native_editor/view/interaction/controller.dart
+++ b/apps/mobile/lib/screens/native_editor/view/interaction/controller.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:super_drag_and_drop/super_drag_and_drop.dart';
+import 'package:typie/screens/native_editor/controller/dnd_controller.dart';
 import 'package:typie/screens/native_editor/state/state.dart';
 import 'package:typie/screens/native_editor/view/geometry.dart';
 import 'package:typie/screens/native_editor/view/interaction/controller_state.dart';
@@ -120,6 +121,7 @@ class EditorInteractionController {
 
   final _gestureState = ControllerSelectionGestureState();
   final _resumedPanState = ControllerResumedPanState();
+  final _dndSession = _DndSessionState();
 
   bool get interactionActive => _gestureState.active;
   bool get hasTextHandleDrag => gesture.hasTextHandleDrag;
@@ -158,7 +160,7 @@ class EditorInteractionController {
   }
 
   ResolvedDragLocation? resolveSelectionDrag(Offset globalPosition) {
-    if (interactionActive || hasTextHandleDrag || pinch.isPinching) {
+    if (interactionActive || _gestureState.longPressing || hasTextHandleDrag || pinch.isPinching) {
       return null;
     }
 
@@ -241,9 +243,19 @@ class EditorInteractionController {
   }
 
   void _recoverDndLockIfStale() {
-    if (!_hasActiveDndLock()) {
+    final snapshot = scope.interactionState.snapshot();
+    if (!snapshot.isDndActive) {
       return;
     }
+
+    if (snapshot.mode == InteractionMode.dndLocal && _dndSession.isNativeLocalDragActive) {
+      return;
+    }
+
+    if (snapshot.mode == InteractionMode.dndExternal) {
+      return;
+    }
+
     endDndSession();
   }
 
@@ -263,5 +275,40 @@ class EditorInteractionController {
 
   void _clearResumedPanState() {
     _resumedPanState.clear();
+  }
+}
+
+class _DndSessionState {
+  bool _active = false;
+  bool _local = false;
+  bool _nativeLocalDragActive = false;
+
+  bool get isActive => _active;
+  bool get isLocal => _local;
+  bool get isNativeLocalDragActive => _nativeLocalDragActive;
+
+  void startLocal() {
+    _active = true;
+    _local = true;
+    _nativeLocalDragActive = true;
+  }
+
+  void startExternalIfIdle() {
+    if (_active) {
+      return;
+    }
+    _active = true;
+    _local = false;
+    _nativeLocalDragActive = false;
+  }
+
+  void endNativeLocalDrag() {
+    _nativeLocalDragActive = false;
+  }
+
+  void clear() {
+    _active = false;
+    _local = false;
+    _nativeLocalDragActive = false;
   }
 }

--- a/apps/mobile/lib/screens/native_editor/view/interaction/controller_dnd.dart
+++ b/apps/mobile/lib/screens/native_editor/view/interaction/controller_dnd.dart
@@ -1,7 +1,28 @@
 part of 'controller.dart';
 
 extension ControllerDndMethods on EditorInteractionController {
+  void _endNativeLocalDragIfNeeded() {
+    if (!_dndSession.isNativeLocalDragActive) {
+      return;
+    }
+    scope.dndController.handleDragEnd();
+    _dndSession.endNativeLocalDrag();
+  }
+
+  void onLocalDragCompleted(DropOperation operation) {
+    if (!_dndSession.isActive || !_dndSession.isLocal) {
+      return;
+    }
+
+    if (operation == DropOperation.none ||
+        operation == DropOperation.userCancelled ||
+        operation == DropOperation.forbidden) {
+      endDndSession();
+    }
+  }
+
   void startLocalDndSession(ResolvedDragLocation location) {
+    _dndSession.startLocal();
     _handleInteractionInput(const DndStartInput(local: true));
     scope.dndController.handleDragStart(
       location.pageIdx,
@@ -15,7 +36,8 @@ extension ControllerDndMethods on EditorInteractionController {
     _handleInteractionInput(const DndSessionEndInput());
     dropPosition.value = null;
     gesture.stopAutoScroll();
-    scope.dndController.handleDragEnd();
+    _endNativeLocalDragIfNeeded();
+    _dndSession.clear();
   }
 
   void beginTableCellHandleDragDown() {
@@ -105,6 +127,7 @@ extension ControllerDndMethods on EditorInteractionController {
     if (pinch.isPinching) {
       return;
     }
+    _dndSession.startExternalIfIdle();
     _handleInteractionInput(const DndEnterInput());
     scope.dndController.handleDragEnter();
   }
@@ -114,6 +137,18 @@ extension ControllerDndMethods on EditorInteractionController {
     dropPosition.value = null;
     gesture.stopAutoScroll();
     scope.dndController.handleDragLeave();
+    if (!_dndSession.isNativeLocalDragActive) {
+      _dndSession.clear();
+    }
+  }
+
+  void onDropEnded(dynamic event) {
+    if (_hasActiveDndLock()) {
+      endDndSession();
+      return;
+    }
+    _endNativeLocalDragIfNeeded();
+    _dndSession.clear();
   }
 
   Future<void> onPerformDrop(PerformDropEvent event) async {
@@ -135,6 +170,17 @@ extension ControllerDndMethods on EditorInteractionController {
 
     final pointerX = gesture.getPointerX(position.dx);
     unawaited(HapticFeedback.lightImpact());
-    await scope.dndController.handleDrop(pageIdx: pageIdx, x: pointerX, y: localY, session: event.session);
+    final result = await scope.dndController.handleDrop(
+      pageIdx: pageIdx,
+      x: pointerX,
+      y: localY,
+      session: event.session,
+    );
+    if (result == DndDropResult.needsDragEnd) {
+      scope.dndController.handleDragEnd();
+      _dndSession.endNativeLocalDrag();
+    }
+    _endNativeLocalDragIfNeeded();
+    _dndSession.clear();
   }
 }

--- a/apps/mobile/lib/screens/native_editor/view/interaction/controller_pointer.dart
+++ b/apps/mobile/lib/screens/native_editor/view/interaction/controller_pointer.dart
@@ -426,7 +426,14 @@ extension ControllerPointerMethods on EditorInteractionController {
       return;
     }
 
+    final hadPendingDoubleTap = _gestureState.pending;
     _gestureState.clearPending();
+    if (!canceled && hadPendingDoubleTap) {
+      final hasRangeSelection = !(scope.controller.state.selection?.collapsed ?? true);
+      if (hasRangeSelection) {
+        showContextMenu.value = true;
+      }
+    }
     endLongPress();
     _endTextHandleDrag();
   }

--- a/apps/mobile/lib/screens/native_editor/view/interaction/state.dart
+++ b/apps/mobile/lib/screens/native_editor/view/interaction/state.dart
@@ -1,38 +1,23 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/scheduler.dart';
-import 'package:flutter/widgets.dart';
 import 'package:typie/screens/native_editor/view/interaction/input.dart';
 import 'package:typie/screens/native_editor/view/interaction/mode.dart';
 
 class EditorInteractionState {
   final ValueNotifier<InteractionSnapshot> _snapshotNotifier = ValueNotifier(const InteractionSnapshot());
-  bool _disposed = false;
-  final List<InteractionInput> _deferredInputs = [];
-  bool _deferredFlushScheduled = false;
 
   ValueListenable<InteractionSnapshot> get listenable => _snapshotNotifier;
 
   InteractionSnapshot snapshot() => _snapshotNotifier.value;
 
   void reset() {
-    _deferredInputs.clear();
-    _deferredFlushScheduled = false;
     _snapshotNotifier.value = const InteractionSnapshot();
   }
 
   void dispose() {
-    _disposed = true;
-    _deferredInputs.clear();
-    _deferredFlushScheduled = false;
     _snapshotNotifier.dispose();
   }
 
   void handle(InteractionInput input) {
-    if (_shouldDeferMutation()) {
-      _deferredInputs.add(input);
-      _scheduleDeferredFlush();
-      return;
-    }
     _applyInput(input);
   }
 
@@ -86,42 +71,6 @@ class EditorInteractionState {
     if (!_equalsSnapshot(previous, nextSnapshot)) {
       _snapshotNotifier.value = nextSnapshot;
     }
-  }
-
-  bool _shouldDeferMutation() {
-    if (_disposed) {
-      return false;
-    }
-    SchedulerPhase? phase;
-    try {
-      phase = SchedulerBinding.instance.schedulerPhase;
-    } catch (_) {
-      return false;
-    }
-    return phase == SchedulerPhase.persistentCallbacks;
-  }
-
-  void _scheduleDeferredFlush() {
-    if (_deferredFlushScheduled || _disposed) {
-      return;
-    }
-    _deferredFlushScheduled = true;
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      _deferredFlushScheduled = false;
-      if (_disposed || _deferredInputs.isEmpty) {
-        _deferredInputs.clear();
-        return;
-      }
-
-      final pending = List<InteractionInput>.from(_deferredInputs);
-      _deferredInputs.clear();
-      for (final input in pending) {
-        if (_disposed) {
-          break;
-        }
-        _applyInput(input);
-      }
-    });
   }
 
   bool _equalsSnapshot(InteractionSnapshot a, InteractionSnapshot b) {
@@ -229,6 +178,12 @@ class EditorInteractionState {
 
   InteractionMode _handleDndMode({required InteractionMode currentMode, required InteractionInput input}) {
     if (input is DndStartInput) {
+      if (currentMode == InteractionMode.textHandleDragging ||
+          currentMode == InteractionMode.tableCellHandleDragging ||
+          currentMode == InteractionMode.longPressSelecting ||
+          currentMode == InteractionMode.doubleTapSelecting) {
+        return currentMode;
+      }
       return input.local ? InteractionMode.dndLocal : InteractionMode.dndExternal;
     }
 

--- a/apps/mobile/lib/screens/native_editor/view/pages.dart
+++ b/apps/mobile/lib/screens/native_editor/view/pages.dart
@@ -119,7 +119,21 @@ class PageList extends HookWidget {
         readViewHeight: () => viewportSize.value.height,
         readGeometry: () => scope.geometry,
       ),
-      [scope, gesture, pinch, wheelZoomSession],
+      [
+        scope.controller,
+        scope.inputController,
+        scope.interactionState,
+        scope.verticalScrollController,
+        scope.horizontalScrollController,
+        scope.longPressPosition,
+        scope.handleDragPosition,
+        scope.titleAreaHeight,
+        scope.displayZoom,
+        scope.renderZoom,
+        gesture,
+        pinch,
+        wheelZoomSession,
+      ],
     );
     final interactionController = useMemoized(() => EditorInteractionController(deps: interactionControllerDeps), [
       interactionControllerDeps,
@@ -384,6 +398,7 @@ class PageList extends HookWidget {
             onDropOver: interactionController.onDropOver,
             onDropEnter: interactionController.onDropEnter,
             onDropLeave: interactionController.onDropLeave,
+            onDropEnded: interactionController.onDropEnded,
             onPerformDrop: interactionController.onPerformDrop,
             child: Listener(
               key: interactionRegionKey,

--- a/apps/mobile/test/screens/native_editor/view/page_list_interaction_test.dart
+++ b/apps/mobile/test/screens/native_editor/view/page_list_interaction_test.dart
@@ -9,12 +9,14 @@ import 'package:typie/screens/native_editor/external/models.dart';
 import 'package:typie/screens/native_editor/state/controller.dart';
 import 'package:typie/screens/native_editor/state/state.dart';
 import 'package:typie/screens/native_editor/toolbar/scope.dart';
+import 'package:typie/screens/native_editor/view/context_menu.dart';
 import 'package:typie/screens/native_editor/view/input.dart';
-import 'package:typie/screens/native_editor/view/interaction/input.dart';
+import 'package:typie/screens/native_editor/view/interaction/controller.dart';
 import 'package:typie/screens/native_editor/view/interaction/mode.dart';
 import 'package:typie/screens/native_editor/view/interaction/state.dart';
 import 'package:typie/screens/native_editor/view/pages.dart';
 import 'package:typie/screens/native_editor/view/scope.dart';
+import 'package:typie/screens/native_editor/view/selection.dart';
 import 'package:typie/service.dart';
 import 'package:typie/services/keyboard.dart';
 import 'package:typie/services/preference.dart';
@@ -54,6 +56,21 @@ class _TestPref implements Pref {
 
 BottomToolbarMode _hiddenBottomToolbarMode() => BottomToolbarMode.hidden;
 
+class _ImmediateEditorTicker extends EditorTicker {
+  _ImmediateEditorTicker({required super.getController}) : super(tickerProvider: const TestVSync());
+
+  @override
+  Future<void> settled() {
+    return Future.value();
+  }
+
+  @override
+  void start() {}
+
+  @override
+  void stop() {}
+}
+
 class _PageListHarnessDeps {
   _PageListHarnessDeps._({
     required this.editor,
@@ -88,8 +105,17 @@ class _PageListHarnessDeps {
     required this.subtitleFocusNode,
   });
 
-  factory _PageListHarnessDeps.create() {
-    final editor = NativeEditor.test();
+  factory _PageListHarnessDeps.create({
+    bool selectionHit = false,
+    bool interactiveHit = false,
+    Map<String, dynamic>? clipboardData,
+    bool immediateSettledTicker = false,
+  }) {
+    final editor = NativeEditor.test(
+      selectionHit: selectionHit,
+      interactiveHit: interactiveHit,
+      clipboardData: clipboardData,
+    );
     final controller = EditorController(editor: editor, fontManager: null)
       ..updateState(
         (_) => const EditorState(
@@ -125,7 +151,9 @@ class _PageListHarnessDeps {
     EditorController readController() => controller;
 
     final dndController = DndController(editor: editor, controller: controller);
-    final ticker = EditorTicker(getController: readController, tickerProvider: const TestVSync());
+    final ticker = immediateSettledTicker
+        ? _ImmediateEditorTicker(getController: readController)
+        : EditorTicker(getController: readController, tickerProvider: const TestVSync());
 
     return _PageListHarnessDeps._(
       editor: editor,
@@ -193,7 +221,43 @@ class _PageListHarnessDeps {
   final FocusNode titleFocusNode;
   final FocusNode subtitleFocusNode;
 
-  Widget build() {
+  Widget build({bool rebuildContentScopeOnControllerChange = false}) {
+    Widget buildContentScope() {
+      return ContentScope(
+        controller: controller,
+        ticker: ticker,
+        verticalScrollController: verticalScrollController,
+        horizontalScrollController: horizontalScrollController,
+        inputController: inputController,
+        longPressPosition: longPressPosition,
+        handleDragPosition: handleDragPosition,
+        titleAreaHeight: titleAreaHeight,
+        title: title,
+        subtitle: subtitle,
+        onTitleChanged: (_) {},
+        onSubtitleChanged: (_) {},
+        titleFocusNode: titleFocusNode,
+        subtitleFocusNode: subtitleFocusNode,
+        pendingScroll: pendingScroll,
+        pendingScrollPageIdx: pendingScrollPageIdx,
+        presentedViewport: presentedViewport,
+        dndController: dndController,
+        interactionState: interactionState,
+        interactionSnapshot: interactionState.listenable,
+        displayZoom: displayZoom,
+        renderZoom: renderZoom,
+        setZoom: (zoom, {bool commitRender = false}) {
+          displayZoom.value = zoom;
+          renderZoom.value = zoom;
+        },
+        child: const PageList(),
+      );
+    }
+
+    final content = rebuildContentScopeOnControllerChange
+        ? AnimatedBuilder(animation: controller, builder: (_, __) => buildContentScope())
+        : buildContentScope();
+
     return MaterialApp(
       theme: lightTheme,
       home: Scaffold(
@@ -216,35 +280,7 @@ class _PageListHarnessDeps {
           clearFocus: inputController.clearFocus,
           dismissKeyboard: inputController.dismissKeyboard,
           commitComposing: inputController.commitComposing,
-          child: ContentScope(
-            controller: controller,
-            ticker: ticker,
-            verticalScrollController: verticalScrollController,
-            horizontalScrollController: horizontalScrollController,
-            inputController: inputController,
-            longPressPosition: longPressPosition,
-            handleDragPosition: handleDragPosition,
-            titleAreaHeight: titleAreaHeight,
-            title: title,
-            subtitle: subtitle,
-            onTitleChanged: (_) {},
-            onSubtitleChanged: (_) {},
-            titleFocusNode: titleFocusNode,
-            subtitleFocusNode: subtitleFocusNode,
-            pendingScroll: pendingScroll,
-            pendingScrollPageIdx: pendingScrollPageIdx,
-            presentedViewport: presentedViewport,
-            dndController: dndController,
-            interactionState: interactionState,
-            interactionSnapshot: interactionState.listenable,
-            displayZoom: displayZoom,
-            renderZoom: renderZoom,
-            setZoom: (zoom, {bool commitRender = false}) {
-              displayZoom.value = zoom;
-              renderZoom.value = zoom;
-            },
-            child: const PageList(),
-          ),
+          child: content,
         ),
       ),
     );
@@ -278,7 +314,9 @@ class _PageListHarnessDeps {
     titleFocusNode.dispose();
     subtitleFocusNode.dispose();
     controller.dispose();
-    editor.dispose();
+    if (!editor.isTest) {
+      editor.dispose();
+    }
   }
 }
 
@@ -289,8 +327,53 @@ void main() {
     return deps.verticalScrollController.offset;
   }
 
-  void expectScrollLocked(double before, double after) {
-    expect((after - before).abs(), lessThan(0.1));
+  EditorSelection seededRangeSelectionWithoutAnchorBounds() {
+    return const EditorSelection(
+      collapsed: false,
+      cmp: 1,
+      headBounds: SelectionEndpointBounds(pageIdx: 0, x: 180, y: 320, width: 1, height: 20),
+      range: {
+        'anchor': {'nodeId': 'n1', 'offset': 3, 'affinity': 'forward'},
+        'head': {'nodeId': 'n1', 'offset': 8, 'affinity': 'forward'},
+      },
+    );
+  }
+
+  EditorSelection seededRangeSelection() {
+    return const EditorSelection(
+      collapsed: false,
+      cmp: 1,
+      anchorBounds: SelectionEndpointBounds(pageIdx: 0, x: 120, y: 320, width: 1, height: 20),
+      headBounds: SelectionEndpointBounds(pageIdx: 0, x: 180, y: 320, width: 1, height: 20),
+      range: {
+        'anchor': {'nodeId': 'n1', 'offset': 3, 'affinity': 'forward'},
+        'head': {'nodeId': 'n1', 'offset': 8, 'affinity': 'forward'},
+      },
+    );
+  }
+
+  CursorInfo seededCursor() {
+    return const CursorInfo(pageIdx: 0, x: 160, y: 360, height: 20, visible: true, precedingCharWidths: []);
+  }
+
+  Future<void> quickTap(WidgetTester tester, Offset position) async {
+    final gesture = await tester.startGesture(position);
+    await tester.pump(const Duration(milliseconds: 10));
+    await gesture.up();
+    await tester.pump(const Duration(milliseconds: 10));
+  }
+
+  Offset interactionPoint(WidgetTester tester, _PageListHarnessDeps deps) {
+    final target = find.byType(PageList);
+    final topLeft = tester.getTopLeft(target);
+    final size = tester.getSize(target);
+    final localX = (size.width / 2).clamp(40.0, size.width - 40.0);
+    final localY = (deps.titleAreaHeight.value + 120).clamp(40.0, size.height - 40.0);
+    return topLeft + Offset(localX, localY);
+  }
+
+  EditorInteractionController interactionControllerOf(WidgetTester tester) {
+    return tester.widget<EditorInteractionControllerScope>(find.byType(EditorInteractionControllerScope)).controller;
   }
 
   setUp(() async {
@@ -307,140 +390,574 @@ void main() {
   });
 
   group('PageList interaction regression', () {
-    testWidgets('stale dnd lock recovers on pan attempt (image-drag failure regression)', (tester) async {
+    testWidgets('interaction controller instance stays stable across content-scope rebuilds', (tester) async {
+      final deps = _PageListHarnessDeps.create();
+      addTearDown(deps.dispose);
+      await tester.pumpWidget(deps.build(rebuildContentScopeOnControllerChange: true));
+      await tester.pumpAndSettle();
+
+      final before = interactionControllerOf(tester);
+      deps.controller.updateState((state) => state.copyWith(selection: seededRangeSelection()));
+      await tester.pump();
+      final afterSelection = interactionControllerOf(tester);
+
+      deps.controller.updateState((state) => state.copyWith(selection: null));
+      await tester.pump();
+      final afterClear = interactionControllerOf(tester);
+
+      expect(identical(before, afterSelection), isTrue);
+      expect(identical(before, afterClear), isTrue);
+    });
+
+    testWidgets('double-tap hold-drag extends selection repeatedly', (tester) async {
       final deps = _PageListHarnessDeps.create();
       addTearDown(deps.dispose);
       await tester.pumpWidget(deps.build());
       await tester.pumpAndSettle();
 
-      final beforeStaleLock = await dragPageList(tester, deps, dy: -280);
-      expect(beforeStaleLock, greaterThan(0));
+      final point = interactionPoint(tester, deps);
 
-      deps.interactionState.handle(const DndStartInput(local: true));
+      await quickTap(tester, point);
+      deps.editor.clearTestDispatchedMessages();
+
+      final drag = await tester.startGesture(point);
+      await tester.pump(const Duration(milliseconds: 120));
+      deps.controller.updateState((state) => state.copyWith(selection: seededRangeSelection()));
       await tester.pump();
-      expect(deps.interactionState.snapshot().isDndActive, isTrue);
+      await drag.moveBy(const Offset(0, -80));
+      await tester.pump();
+      await drag.moveBy(const Offset(0, -80));
+      await tester.pump();
+      await drag.up();
+      await tester.pump();
 
-      final afterRecovery = await dragPageList(tester, deps, dy: -280);
-      expect(afterRecovery, greaterThan(beforeStaleLock + 1));
-      expect(deps.interactionState.snapshot().isDndActive, isFalse);
+      final hasDoubleTapDispatch = deps.editor.testDispatchedMessages.any(
+        (message) => message['type'] == 'pointerDown' && message['clickCount'] == 2,
+      );
+      final extendEvents = deps.editor.testDispatchedMessages
+          .where((message) => message['type'] == 'extendSelectionTo')
+          .toList();
+
+      expect(hasDoubleTapDispatch, isTrue);
+      expect(extendEvents.length, greaterThanOrEqualTo(2));
     });
 
-    testWidgets('pinch end resumes single-pointer pan', (tester) async {
+    testWidgets('double-tap hold-drag still extends after content-scope rebuild', (tester) async {
+      final deps = _PageListHarnessDeps.create();
+      addTearDown(deps.dispose);
+      await tester.pumpWidget(deps.build(rebuildContentScopeOnControllerChange: true));
+      await tester.pumpAndSettle();
+
+      final point = interactionPoint(tester, deps);
+
+      await quickTap(tester, point);
+      deps.editor.clearTestDispatchedMessages();
+
+      final beforePan = deps.verticalScrollController.offset;
+      final drag = await tester.startGesture(point);
+      await tester.pump(const Duration(milliseconds: 120));
+      deps.controller.updateState((state) => state.copyWith(selection: seededRangeSelection()));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 550));
+      await drag.moveBy(const Offset(0, -80));
+      await tester.pump();
+      await drag.moveBy(const Offset(0, -80));
+      await tester.pump();
+      await drag.up();
+      await tester.pump();
+      final afterPan = deps.verticalScrollController.offset;
+
+      final extendEvents = deps.editor.testDispatchedMessages
+          .where((message) => message['type'] == 'extendSelectionTo')
+          .toList();
+      expect(extendEvents.length, greaterThanOrEqualTo(2));
+      expect((afterPan - beforePan).abs(), lessThan(0.1));
+    });
+
+    testWidgets('double-tap quick drag extends selection and does not pan-scroll', (tester) async {
+      final deps = _PageListHarnessDeps.create();
+      addTearDown(deps.dispose);
+      await tester.pumpWidget(deps.build());
+      await tester.pumpAndSettle();
+
+      final point = interactionPoint(tester, deps) + const Offset(0, 180);
+
+      await quickTap(tester, point);
+      deps.editor.clearTestDispatchedMessages();
+
+      final beforePan = deps.verticalScrollController.offset;
+      final drag = await tester.startGesture(point);
+      await tester.pump(const Duration(milliseconds: 120));
+      deps.controller.updateState((state) => state.copyWith(selection: seededRangeSelection()));
+      await tester.pump();
+      await drag.moveBy(const Offset(0, -60));
+      await tester.pump();
+      await drag.moveBy(const Offset(0, -60));
+      await tester.pump();
+      await drag.up();
+      await tester.pump();
+      final afterPan = deps.verticalScrollController.offset;
+
+      final extendEvents = deps.editor.testDispatchedMessages
+          .where((message) => message['type'] == 'extendSelectionTo')
+          .toList();
+      expect(extendEvents.isNotEmpty, isTrue);
+      expect((afterPan - beforePan).abs(), lessThan(0.1));
+    });
+
+    testWidgets('pan works after double-tap selection', (tester) async {
+      final deps = _PageListHarnessDeps.create();
+      addTearDown(deps.dispose);
+      await tester.pumpWidget(deps.build());
+      await tester.pumpAndSettle();
+
+      final point = interactionPoint(tester, deps);
+
+      await quickTap(tester, point);
+      await quickTap(tester, point);
+      await tester.pump();
+
+      final beforePan = deps.verticalScrollController.offset;
+      final pan = await tester.startGesture(point + const Offset(80, 80));
+      await tester.pump();
+      await pan.moveBy(const Offset(0, -260));
+      await tester.pump();
+      await pan.up();
+      await tester.pump();
+      final afterPan = deps.verticalScrollController.offset;
+
+      expect(afterPan, greaterThan(beforePan + 1));
+    });
+
+    testWidgets('pan works after double-tap drag completes', (tester) async {
+      final deps = _PageListHarnessDeps.create();
+      addTearDown(deps.dispose);
+      await tester.pumpWidget(deps.build());
+      await tester.pumpAndSettle();
+
+      final point = interactionPoint(tester, deps) + const Offset(0, 140);
+      await quickTap(tester, point);
+
+      final drag = await tester.startGesture(point);
+      await tester.pump(const Duration(milliseconds: 20));
+      await drag.moveBy(const Offset(0, -80));
+      await tester.pump();
+      await drag.up();
+      await tester.pump();
+      expect(deps.interactionState.snapshot().mode, InteractionMode.idle);
+
+      final beforePan = deps.verticalScrollController.offset;
+      final pan = await tester.startGesture(point + const Offset(80, 80));
+      await tester.pump();
+      await pan.moveBy(const Offset(0, -260));
+      await tester.pump();
+      await pan.up();
+      await tester.pump();
+      final afterPan = deps.verticalScrollController.offset;
+      expect(afterPan, greaterThan(beforePan + 1));
+    });
+
+    testWidgets('double-tap drag auto-scrolls at viewport edge', (tester) async {
       final deps = _PageListHarnessDeps.create();
       addTearDown(deps.dispose);
       await tester.pumpWidget(deps.build());
       await tester.pumpAndSettle();
 
       final target = find.byType(PageList);
-      final center = tester.getCenter(target);
-      final g1 = await tester.startGesture(center + const Offset(-40, 0), pointer: 1);
-      final g2 = await tester.startGesture(center + const Offset(40, 0), pointer: 2);
+      final topLeft = tester.getTopLeft(target);
+      final size = tester.getSize(target);
+      final start = topLeft + Offset(size.width / 2, size.height - 12);
+      await quickTap(tester, start);
+      deps.editor.clearTestDispatchedMessages();
+
+      final before = deps.verticalScrollController.offset;
+      final drag = await tester.startGesture(start);
+      await tester.pump(const Duration(milliseconds: 120));
+      deps.controller.updateState((state) => state.copyWith(selection: seededRangeSelection()));
+      await tester.pump();
+      await drag.moveBy(const Offset(0, 10));
+      await tester.pump(const Duration(milliseconds: 250));
+      await drag.up();
+      await tester.pump();
+      final after = deps.verticalScrollController.offset;
+
+      final extendEvents = deps.editor.testDispatchedMessages
+          .where((message) => message['type'] == 'extendSelectionTo')
+          .toList();
+      expect(extendEvents.isNotEmpty, isTrue);
+      expect(after, greaterThan(before));
+    });
+
+    testWidgets('double-tap does not emit trailing single click', (tester) async {
+      final deps = _PageListHarnessDeps.create();
+      addTearDown(deps.dispose);
+      await tester.pumpWidget(deps.build());
+      await tester.pumpAndSettle();
+
+      final point = interactionPoint(tester, deps);
+
+      await quickTap(tester, point);
+      deps.editor.clearTestDispatchedMessages();
+      await quickTap(tester, point);
       await tester.pump();
 
-      await g1.moveTo(center + const Offset(-90, 0));
-      await g2.moveTo(center + const Offset(90, 0));
-      await tester.pump();
-      expect(deps.interactionState.snapshot().isPinching, isTrue);
+      final pointerDowns = deps.editor.testDispatchedMessages.where((message) => message['type'] == 'pointerDown');
+      final click2 = pointerDowns.where((message) => message['clickCount'] == 2).length;
+      final click1 = pointerDowns.where((message) => message['clickCount'] == 1).length;
+      expect(click2, 1);
+      expect(click1, 0);
+    });
 
-      await g2.up();
+    testWidgets('double-tap drag does not extend until selection bounds are materialized', (tester) async {
+      final deps = _PageListHarnessDeps.create();
+      addTearDown(deps.dispose);
+      await tester.pumpWidget(deps.build());
+      await tester.pumpAndSettle();
+
+      final point = interactionPoint(tester, deps);
+
+      await quickTap(tester, point);
+      deps.controller.updateState((state) => state.copyWith(selection: seededRangeSelectionWithoutAnchorBounds()));
       await tester.pump();
-      expect(deps.interactionState.snapshot().isPinching, isFalse);
+
+      deps.editor.clearTestDispatchedMessages();
+      final drag = await tester.startGesture(point);
+      await tester.pump(const Duration(milliseconds: 120));
+      await drag.moveBy(const Offset(0, -90));
+      await tester.pump();
+      await drag.up();
+      await tester.pump();
+
+      final extendEvent = deps.editor.testDispatchedMessages.firstWhere(
+        (message) => message['type'] == 'extendSelectionTo',
+        orElse: () => <String, dynamic>{},
+      );
+      expect(extendEvent.isEmpty, isTrue);
+    });
+
+    testWidgets('double-tap selection then handle drag extends selection', (tester) async {
+      final deps = _PageListHarnessDeps.create();
+      addTearDown(deps.dispose);
+      await tester.pumpWidget(deps.build());
+      await tester.pumpAndSettle();
+
+      final point = interactionPoint(tester, deps);
+      await quickTap(tester, point);
+      await quickTap(tester, point);
+      deps.controller.updateState((state) => state.copyWith(selection: seededRangeSelection()));
+      await tester.pump();
+
+      deps.editor.clearTestDispatchedMessages();
+      final handles = find.byType(SelectionHandle);
+      expect(handles, findsWidgets);
+      await tester.drag(handles.last, const Offset(0, -80), warnIfMissed: false);
+      await tester.pump();
+
+      final extendEvent = deps.editor.testDispatchedMessages.firstWhere(
+        (message) => message['type'] == 'extendSelectionTo',
+        orElse: () => <String, dynamic>{},
+      );
+      expect(extendEvent.isNotEmpty, isTrue);
+    });
+
+    testWidgets('long-press move keeps updating cursor and clears magnifier on release', (tester) async {
+      final deps = _PageListHarnessDeps.create();
+      addTearDown(deps.dispose);
+      await tester.pumpWidget(deps.build());
+      await tester.pumpAndSettle();
+
+      final start = interactionPoint(tester, deps);
+
+      deps.editor.clearTestDispatchedMessages();
+      final gesture = await tester.startGesture(start);
+      await tester.pump(const Duration(milliseconds: 600));
+
+      await gesture.moveBy(const Offset(16, -6));
+      await tester.pump();
+      await gesture.moveBy(const Offset(18, -8));
+      await tester.pump();
+
+      final movePointerDownCount = deps.editor.testDispatchedMessages
+          .where((message) => message['type'] == 'pointerDown' && message['clickCount'] == 1)
+          .length;
+      expect(movePointerDownCount, greaterThanOrEqualTo(2));
+      expect(deps.longPressPosition.value, isNotNull);
+
+      await gesture.up();
+      await tester.pump();
+      expect(deps.longPressPosition.value, isNull);
+      expect(deps.interactionState.snapshot().mode, InteractionMode.idle);
+    });
+
+    testWidgets('long-press drag keeps dispatching cursor moves after first update', (tester) async {
+      final deps = _PageListHarnessDeps.create();
+      addTearDown(deps.dispose);
+      await tester.pumpWidget(deps.build());
+      await tester.pumpAndSettle();
+
+      final start = interactionPoint(tester, deps) + const Offset(0, 120);
+
+      deps.editor.clearTestDispatchedMessages();
+      final gesture = await tester.startGesture(start);
+      await tester.pump(const Duration(milliseconds: 600));
+
+      await gesture.moveBy(const Offset(0, -20));
+      await tester.pump();
+      await gesture.moveBy(const Offset(0, -20));
+      await tester.pump();
+      await gesture.moveBy(const Offset(0, -20));
+      await tester.pump();
+
+      final pointerDownEvents = deps.editor.testDispatchedMessages
+          .where((message) => message['type'] == 'pointerDown' && message['clickCount'] == 1)
+          .toList();
+      final uniqueY = pointerDownEvents.map((message) => message['y']).toSet();
+      expect(pointerDownEvents.length, greaterThanOrEqualTo(3));
+      expect(uniqueY.length, greaterThanOrEqualTo(2));
+
+      await gesture.up();
+      await tester.pump();
+      expect(deps.longPressPosition.value, isNull);
+    });
+
+    testWidgets('long-press drag keeps dispatching after content-scope rebuild', (tester) async {
+      final deps = _PageListHarnessDeps.create();
+      addTearDown(deps.dispose);
+      await tester.pumpWidget(deps.build(rebuildContentScopeOnControllerChange: true));
+      await tester.pumpAndSettle();
+
+      final start = interactionPoint(tester, deps) + const Offset(0, 120);
+
+      deps.editor.clearTestDispatchedMessages();
+      final gesture = await tester.startGesture(start);
+      await tester.pump(const Duration(milliseconds: 600));
+
+      await gesture.moveBy(const Offset(0, -20));
+      await tester.pump();
+      await gesture.moveBy(const Offset(0, -20));
+      await tester.pump();
+      await gesture.moveBy(const Offset(0, -20));
+      await tester.pump();
+
+      final pointerDownEvents = deps.editor.testDispatchedMessages
+          .where((message) => message['type'] == 'pointerDown' && message['clickCount'] == 1)
+          .toList();
+      final uniqueY = pointerDownEvents.map((message) => message['y']).toSet();
+      expect(pointerDownEvents.length, greaterThanOrEqualTo(3));
+      expect(uniqueY.length, greaterThanOrEqualTo(2));
+
+      await gesture.up();
+      await tester.pump();
+      expect(deps.longPressPosition.value, isNull);
+    });
+
+    testWidgets('pan works after long-press cursor move ends', (tester) async {
+      final deps = _PageListHarnessDeps.create();
+      addTearDown(deps.dispose);
+      await tester.pumpWidget(deps.build());
+      await tester.pumpAndSettle();
+
+      final start = interactionPoint(tester, deps) + const Offset(0, 120);
+      final longPress = await tester.startGesture(start);
+      await tester.pump(const Duration(milliseconds: 600));
+      await longPress.moveBy(const Offset(0, -30));
+      await tester.pump();
+      await longPress.up();
+      await tester.pump();
 
       final beforePan = deps.verticalScrollController.offset;
-      await g1.moveBy(const Offset(0, -180));
+      final pan = await tester.startGesture(start + const Offset(80, 80));
       await tester.pump();
-      await g1.up();
+      await pan.moveBy(const Offset(0, -240));
       await tester.pump();
-      expect(deps.verticalScrollController.offset, greaterThan(beforePan + 1));
+      await pan.up();
+      await tester.pump();
+      final afterPan = deps.verticalScrollController.offset;
+      expect(afterPan, greaterThan(beforePan + 1));
     });
 
-    testWidgets('long-press selecting mode blocks pan until end', (tester) async {
+    testWidgets('long-press outside selection moves cursor', (tester) async {
       final deps = _PageListHarnessDeps.create();
       addTearDown(deps.dispose);
       await tester.pumpWidget(deps.build());
       await tester.pumpAndSettle();
 
-      final beforeLock = await dragPageList(tester, deps);
-
-      deps.interactionState.handle(const LongPressStartInput());
+      final point = interactionPoint(tester, deps);
+      deps.editor.clearTestDispatchedMessages();
+      final longPress = await tester.startGesture(point);
+      await tester.pump(const Duration(milliseconds: 600));
+      await longPress.moveBy(const Offset(10, -10));
+      await tester.pump();
+      await longPress.up();
       await tester.pump();
 
-      final duringLock = await dragPageList(tester, deps);
-      expectScrollLocked(beforeLock, duringLock);
-
-      deps.interactionState.handle(const LongPressEndInput());
-      await tester.pump();
-
-      final afterUnlock = await dragPageList(tester, deps);
-      expect(afterUnlock, greaterThan(beforeLock + 1));
+      final pointerDowns = deps.editor.testDispatchedMessages
+          .where((message) => message['type'] == 'pointerDown' && message['clickCount'] == 1)
+          .toList();
+      expect(pointerDowns.isNotEmpty, isTrue);
     });
 
-    testWidgets('dnd leave clears external mode and pan remains available', (tester) async {
+    testWidgets('same-cursor tap toggles context menu open-close-open', (tester) async {
+      final deps = _PageListHarnessDeps.create(immediateSettledTicker: true);
+      addTearDown(deps.dispose);
+      await tester.pumpWidget(deps.build());
+      await tester.pumpAndSettle();
+
+      deps.controller.updateState((state) => state.copyWith(cursor: seededCursor(), selection: null));
+      await tester.pump();
+
+      final point = interactionPoint(tester, deps);
+
+      await quickTap(tester, point);
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(find.byType(SelectionContextMenu), findsOneWidget);
+
+      await tester.pump(const Duration(milliseconds: 350));
+      await quickTap(tester, point);
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(find.byType(SelectionContextMenu), findsNothing);
+
+      await tester.pump(const Duration(milliseconds: 350));
+      await quickTap(tester, point);
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(find.byType(SelectionContextMenu), findsOneWidget);
+    });
+
+    testWidgets('double-tap hold keeps double-tap selecting mode even outside selection', (tester) async {
       final deps = _PageListHarnessDeps.create();
       addTearDown(deps.dispose);
       await tester.pumpWidget(deps.build());
       await tester.pumpAndSettle();
 
-      deps.interactionState.handle(const DndEnterInput());
-      await tester.pump();
-      expect(deps.interactionState.snapshot().mode, InteractionMode.dndExternal);
+      final point = interactionPoint(tester, deps);
+      await quickTap(tester, point);
 
-      deps.interactionState.handle(const DndLeaveInput());
+      final hold = await tester.startGesture(point);
+      await tester.pump(const Duration(milliseconds: 120));
+      deps.controller.updateState((state) => state.copyWith(selection: seededRangeSelection()));
+      await tester.pump();
+      await hold.moveBy(const Offset(220, 0));
+      await tester.pump();
+      expect(deps.interactionState.snapshot().mode, InteractionMode.doubleTapSelecting);
+
+      await hold.moveBy(const Offset(0, -60));
+      await tester.pump();
+      expect(deps.interactionState.snapshot().mode, InteractionMode.doubleTapSelecting);
+
+      await hold.up();
+      await tester.pump();
+      expect(deps.interactionState.snapshot().mode, InteractionMode.idle);
+    });
+
+    testWidgets('double-tap near line end prefers word selection over context menu toggle', (tester) async {
+      final deps = _PageListHarnessDeps.create(immediateSettledTicker: true);
+      addTearDown(deps.dispose);
+      await tester.pumpWidget(deps.build());
+      await tester.pumpAndSettle();
+
+      deps.controller.updateState((state) => state.copyWith(cursor: seededCursor(), selection: null));
+      await tester.pump();
+
+      final point = interactionPoint(tester, deps);
+
+      await quickTap(tester, point);
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(find.byType(SelectionContextMenu), findsOneWidget);
+
+      deps.editor.clearTestDispatchedMessages();
+      final farRight = point + const Offset(18, 0);
+      await quickTap(tester, farRight);
+      await tester.pump(const Duration(milliseconds: 200));
+
+      final pointerDowns = deps.editor.testDispatchedMessages.where((message) => message['type'] == 'pointerDown');
+      final click2 = pointerDowns.where((message) => message['clickCount'] == 2).length;
+      expect(click2, 1);
+    });
+
+    testWidgets('double-tap hold without drag shows context menu on release', (tester) async {
+      final deps = _PageListHarnessDeps.create(immediateSettledTicker: true);
+      addTearDown(deps.dispose);
+      await tester.pumpWidget(deps.build());
+      await tester.pumpAndSettle();
+
+      final point = interactionPoint(tester, deps);
+
+      await quickTap(tester, point);
+      final hold = await tester.startGesture(point);
+      await tester.pump(const Duration(milliseconds: 120));
+      deps.controller.updateState((state) => state.copyWith(selection: seededRangeSelection()));
+      await tester.pump();
+
+      await hold.up();
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(find.byType(SelectionContextMenu), findsOneWidget);
+    });
+
+    testWidgets('double-tap drag selection shows context menu after release', (tester) async {
+      final deps = _PageListHarnessDeps.create(immediateSettledTicker: true);
+      addTearDown(deps.dispose);
+      await tester.pumpWidget(deps.build());
+      await tester.pumpAndSettle();
+
+      final point = interactionPoint(tester, deps) + const Offset(0, 140);
+
+      await quickTap(tester, point);
+      final drag = await tester.startGesture(point);
+      await tester.pump(const Duration(milliseconds: 120));
+      deps.controller.updateState((state) => state.copyWith(selection: seededRangeSelection()));
+      await tester.pump();
+      await drag.moveBy(const Offset(0, -90));
+      await tester.pump();
+      await drag.up();
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(find.byType(SelectionContextMenu), findsOneWidget);
+    });
+
+    testWidgets('double-tap word selection shows context menu when selection materializes', (tester) async {
+      final deps = _PageListHarnessDeps.create(immediateSettledTicker: true);
+      addTearDown(deps.dispose);
+      await tester.pumpWidget(deps.build());
+      await tester.pumpAndSettle();
+
+      final point = interactionPoint(tester, deps);
+      await quickTap(tester, point);
+      await quickTap(tester, point);
+      deps.controller.updateState((state) => state.copyWith(selection: seededRangeSelection()));
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(find.byType(SelectionContextMenu), findsOneWidget);
+    });
+
+    testWidgets('selection dnd locks pan and unlocks after session end', (tester) async {
+      final deps = _PageListHarnessDeps.create(selectionHit: true, clipboardData: {'text': 'hello'});
+      addTearDown(deps.dispose);
+      await tester.pumpWidget(deps.build());
+      await tester.pumpAndSettle();
+
+      final interaction = interactionControllerOf(tester);
+      final point = interactionPoint(tester, deps);
+      final resolved = interaction.resolveSelectionDrag(point);
+      expect(resolved, isNotNull);
+
+      interaction.startLocalDndSession(resolved!);
+      await tester.pump();
+      expect(deps.interactionState.snapshot().mode, InteractionMode.dndLocal);
+
+      final beforeLocked = deps.verticalScrollController.offset;
+      await dragPageList(tester, deps, dy: -260);
+      final duringLocked = deps.verticalScrollController.offset;
+      expect((duringLocked - beforeLocked).abs(), lessThan(0.1));
+
+      interaction.endDndSession();
       await tester.pump();
       expect(deps.interactionState.snapshot().mode, InteractionMode.idle);
 
       final beforePan = deps.verticalScrollController.offset;
-      final afterUnlock = await dragPageList(tester, deps, dy: -260);
-      expect(afterUnlock, greaterThan(beforePan + 1));
-    });
-
-    testWidgets('auxiliary mode stays locked through update and unlocks on end', (tester) async {
-      final deps = _PageListHarnessDeps.create();
-      addTearDown(deps.dispose);
-      await tester.pumpWidget(deps.build());
-      await tester.pumpAndSettle();
-
-      deps.interactionState.handle(const AuxiliaryGestureStartInput(kind: AuxiliaryGestureKind.tableColumnResize));
-      await tester.pump();
-      expect(deps.interactionState.snapshot().mode, InteractionMode.auxiliaryGesture);
-
-      final beforeLocked = deps.verticalScrollController.offset;
-      final duringStartLocked = await dragPageList(tester, deps);
-      expectScrollLocked(beforeLocked, duringStartLocked);
-
-      deps.interactionState.handle(const AuxiliaryGestureUpdateInput(kind: AuxiliaryGestureKind.tableColumnResize));
-      await tester.pump();
-      final duringUpdateLocked = await dragPageList(tester, deps);
-      expectScrollLocked(duringStartLocked, duringUpdateLocked);
-
-      deps.interactionState.handle(const AuxiliaryGestureEndInput());
-      await tester.pump();
-      expect(deps.interactionState.snapshot().mode, InteractionMode.idle);
-
-      final afterUnlock = await dragPageList(tester, deps);
-      expect(afterUnlock, greaterThan(duringUpdateLocked + 1));
-    });
-
-    testWidgets('pointer cancel releases text-handle selecting lock', (tester) async {
-      final deps = _PageListHarnessDeps.create();
-      addTearDown(deps.dispose);
-      await tester.pumpWidget(deps.build());
-      await tester.pumpAndSettle();
-
-      deps.interactionState.handle(const TextHandleDragStartInput());
-      await tester.pump();
-      expect(deps.interactionState.snapshot().mode, InteractionMode.textHandleDragging);
-
-      final beforeLocked = deps.verticalScrollController.offset;
-      final duringLocked = await dragPageList(tester, deps, dy: -240);
-      expectScrollLocked(beforeLocked, duringLocked);
-
-      deps.interactionState.handle(const PointerCancelInput(pointer: 42));
-      await tester.pump();
-      expect(deps.interactionState.snapshot().mode, InteractionMode.idle);
-
-      final afterUnlock = await dragPageList(tester, deps, dy: -240);
-      expect(afterUnlock, greaterThan(duringLocked + 1));
+      await dragPageList(tester, deps, dy: -260);
+      final afterPan = deps.verticalScrollController.offset;
+      expect(afterPan, greaterThan(beforePan + 1));
     });
   });
 }


### PR DESCRIPTION
- ContentScope 리빌드 시 InteractionController가 교체되지 않도록 함 - interaction 리팩토링 이후 깨진 제스처들이 모두 복구됨
- DND 버그를 해결함
- 불필요한 로직을 제거함
- 실제 시나리오를 검증하는 회귀 테스트 22개