### PR TITLE
pdf export시 vector export 후 slate refresh함

### DIFF
--- a/apps/api/src/export/document/index.ts
+++ b/apps/api/src/export/document/index.ts
@@ -144,6 +144,7 @@ export async function generateDocumentPdf(params: GenerateDocumentPdfParams): Pr
         return parseVectorPageBinary(bytes);
       });
 
+      slate.refresh(editor.getSlatePtr(), editor.getSlabPtr());
       const laidExternals = slate.readExternalElements();
       return await createPdfFromVectorPages(pages, title, author, laidExternals, assets);
     } finally {


### PR DESCRIPTION
`exportPageVector` 호출이 wasm memory를 grow할 수 있고, 그 뒤에 호출되는 slate read가 stale한 data view를 바라볼 수 있는 문제 수정
