### PR TITLE
fallback 폰트 렌더링이 라인 전체 y위치를 흔들리지 않게 함

### DIFF
--- a/crates/editor/src/layout/elements/line.rs
+++ b/crates/editor/src/layout/elements/line.rs
@@ -1377,7 +1377,10 @@ pub fn build_metrics(
     layout: &parley::Layout<String>,
     text: &str,
     scale_factor: f64,
-    default_height: f32,
+    strut_ascent: f32,
+    strut_descent: f32,
+    strut_font_size: f32,
+    line_height_ratio: f32,
 ) -> Vec<LineMetric> {
     let mut lines = Vec::new();
 
@@ -1385,29 +1388,29 @@ pub fn build_metrics(
     let global_grapheme_offsets = compute_grapheme_boundaries(text);
 
     let mut top = 0.0;
+    let safe_strut_font_size = if strut_font_size > 0.0 {
+        strut_font_size
+    } else {
+        1.0
+    };
+    let ascent_ratio = (strut_ascent.max(0.0)) / safe_strut_font_size;
+    let descent_ratio = (strut_descent.max(0.0)) / safe_strut_font_size;
+    let fallback_ascent = strut_ascent.max(0.0);
+    let fallback_descent = strut_descent.max(0.0);
+    let safe_line_height_ratio = if line_height_ratio > 0.0 {
+        line_height_ratio
+    } else {
+        1.0
+    };
 
     for line in layout.lines() {
         let line_metrics = line.metrics();
-        let mut height = line_metrics.ascent + line_metrics.descent;
-        let line_top;
-
-        let mut leading = line_metrics.leading;
-
-        if height == 0.0 {
-            height = default_height;
-            let offset = (line_metrics.line_height - height) / 2.0;
-            line_top = offset;
-            leading = line_metrics.line_height - height;
-        } else {
-            line_top = line_metrics.baseline - line_metrics.ascent - top;
-        }
-
-        top += line_metrics.line_height;
 
         let mut clusters = Vec::new();
         let mut advance_x: f32 = 0.0;
         let mut inline_prefix = 0.0;
         let mut seen_glyph = false;
+        let mut max_run_font_size = 0.0f32;
         let mut min_cluster_x: Option<f32> = None;
         let mut max_cluster_right: Option<f32> = None;
         let mut max_ascent_overflow = 0.0f32;
@@ -1420,6 +1423,7 @@ pub fn build_metrics(
                 parley::PositionedLayoutItem::GlyphRun(glyph_run) => {
                     let run = glyph_run.run();
                     let run_offset = glyph_run.offset();
+                    max_run_font_size = max_run_font_size.max(run.font_size());
 
                     if !indices.insert(run.index()) {
                         continue;
@@ -1483,6 +1487,30 @@ pub fn build_metrics(
             }
         }
 
+        let line_font_size = if max_run_font_size > 0.0 {
+            max_run_font_size
+        } else {
+            safe_strut_font_size
+        };
+        let mut ascent = ascent_ratio * line_font_size;
+        let mut descent = descent_ratio * line_font_size;
+        if ascent <= 0.0 && descent <= 0.0 {
+            ascent = fallback_ascent;
+            descent = fallback_descent;
+        }
+        let mut height = (ascent + descent).max(0.0);
+        if height <= 0.0 {
+            height = (line_metrics.ascent + line_metrics.descent).max(0.0);
+        }
+        let mut line_box_height = (line_font_size * safe_line_height_ratio).max(height);
+        if !line_box_height.is_finite() || line_box_height <= 0.0 {
+            line_box_height = height;
+        }
+        let leading = (line_box_height - height).max(0.0);
+        let line_top = leading * 0.5;
+        let baseline = top + line_top + ascent;
+        top += line_box_height;
+
         let text_range = line.text_range();
         let line_start_char = byte_to_char_offset_with_map(&char_to_byte, text_range.start);
         let line_end_char = byte_to_char_offset_with_map(&char_to_byte, text_range.end);
@@ -1524,8 +1552,8 @@ pub fn build_metrics(
             left: snap_to_pixel(left, scale_factor),
             height,
             leading,
-            baseline: snap_to_pixel(line_metrics.baseline, scale_factor),
-            ascent: snap_to_pixel(line_metrics.ascent, scale_factor),
+            baseline: snap_to_pixel(baseline, scale_factor),
+            ascent: snap_to_pixel(ascent, scale_factor),
             // NOTE: width를 스냅하면 실제 glyph 폭보다 작아져 overflow가 생길 수 있어 원본값 유지
             content_width,
             start_offset: line_start_char,

--- a/crates/editor/src/model/nodes/fold_title.rs
+++ b/crates/editor/src/model/nodes/fold_title.rs
@@ -118,14 +118,35 @@ impl Layout for FoldTitleNode {
             dummy_layout.break_all_lines(None);
             let dummy_line = dummy_layout.lines().next().unwrap();
             let dummy_metrics = dummy_line.metrics();
-            let default_height = dummy_metrics.ascent + dummy_metrics.descent;
+            let strut_font_size = dummy_line
+                .items()
+                .find_map(|item| match item {
+                    parley::PositionedLayoutItem::GlyphRun(glyph_run) => {
+                        Some(glyph_run.run().font_size())
+                    }
+                    _ => None,
+                })
+                .unwrap_or(14.0);
 
-            (layout, default_height)
+            (
+                layout,
+                dummy_metrics.ascent,
+                dummy_metrics.descent,
+                strut_font_size,
+            )
         });
 
-        let (layout, default_height) = layout;
+        let (layout, strut_ascent, strut_descent, strut_font_size) = layout;
         let layout = Rc::new(layout);
-        let metrics = build_metrics(&layout, &text, ctx.scale_factor, default_height);
+        let metrics = build_metrics(
+            &layout,
+            &text,
+            ctx.scale_factor,
+            strut_ascent,
+            strut_descent,
+            strut_font_size,
+            line_height,
+        );
 
         let expanded = ctx
             .view_states

--- a/crates/editor/src/model/nodes/paragraph.rs
+++ b/crates/editor/src/model/nodes/paragraph.rs
@@ -638,7 +638,7 @@ impl Layout for ParagraphNode {
                 parley::AlignmentOptions::default(),
             );
 
-            let default_height = {
+            let (strut_ascent, strut_descent, strut_font_size) = {
                 let ps_styles = pending_styles.map(|ps| &ps.styles[..]);
 
                 let mut dummy_builder = lcx.ranged_builder(&mut fcx, "\u{200B}", 1.0, false);
@@ -681,15 +681,38 @@ impl Layout for ParagraphNode {
                 dummy_layout.break_all_lines(None);
                 let dummy_line = dummy_layout.lines().next().unwrap();
                 let dummy_metrics = dummy_line.metrics();
-                dummy_metrics.ascent + dummy_metrics.descent
+                let dummy_font_size = dummy_line
+                    .items()
+                    .find_map(|item| match item {
+                        parley::PositionedLayoutItem::GlyphRun(glyph_run) => {
+                            Some(glyph_run.run().font_size())
+                        }
+                        _ => None,
+                    })
+                    .unwrap_or_else(|| {
+                        convert_length(
+                            cascade_font_size as f32 / 100.0,
+                            LengthUnit::Pt,
+                            LengthUnit::Px,
+                        )
+                    });
+                (dummy_metrics.ascent, dummy_metrics.descent, dummy_font_size)
             };
 
-            (layout, default_height)
+            (layout, strut_ascent, strut_descent, strut_font_size)
         });
 
-        let (layout, default_height) = layout;
+        let (layout, strut_ascent, strut_descent, strut_font_size) = layout;
         let layout = Rc::new(layout);
-        let metrics = build_metrics(&layout, &text, ctx.scale_factor, default_height);
+        let metrics = build_metrics(
+            &layout,
+            &text,
+            ctx.scale_factor,
+            strut_ascent,
+            strut_descent,
+            strut_font_size,
+            line_height,
+        );
 
         let ruby_segments = extract_ruby_segments(ctx);
         let background_segments = extract_background_segments(ctx);

--- a/crates/editor/src/render/impls/line.rs
+++ b/crates/editor/src/render/impls/line.rs
@@ -213,14 +213,13 @@ impl LineElement {
         &self,
         sink: &mut dyn ElementSink,
         transform: Transform,
-        line_metrics: &parley::layout::LineMetrics,
         ctx: &RenderContext<'_>,
     ) {
         if self.background_segments.is_empty() {
             return;
         }
 
-        let line_height = line_metrics.ascent + line_metrics.descent;
+        let line_height = self.metric.height;
 
         for segment in &self.background_segments {
             let color = ctx.theme.color(&format!("bg.{}", segment.color_key));
@@ -256,7 +255,6 @@ impl LineElement {
         &self,
         sink: &mut dyn ElementSink,
         transform: Transform,
-        line_metrics: &parley::layout::LineMetrics,
         ctx: &RenderContext<'_>,
     ) {
         if self.ruby_segments.is_empty() {
@@ -264,7 +262,7 @@ impl LineElement {
         }
 
         let scale = ctx.scale_factor as f32;
-        let run_y = self.metric.top + line_metrics.ascent;
+        let run_y = self.metric.top + self.metric.ascent;
 
         GLOBALS.with(|globals| {
             use parley::style::*;
@@ -317,9 +315,8 @@ impl LineElement {
                     let ruby_x_offset = (base_x + (base_width - ruby_width) / 2.0)
                         .clamp(0.0, (self.size.width - ruby_width).max(0.0));
 
-                    let line_baseline = run_y + line_metrics.ascent;
                     let ruby_height = ruby_metrics.ascent + ruby_metrics.descent;
-                    let ruby_y_offset = line_baseline - line_metrics.ascent - ruby_height;
+                    let ruby_y_offset = run_y - ruby_height;
 
                     let color = ctx.theme.color("text.black");
                     let ruby_paint = create_solid_paint(color);
@@ -400,12 +397,11 @@ impl LineElement {
             return;
         };
 
-        let line_metrics = line.metrics();
         let point = Point::zero();
 
         match ctx.phase {
             RenderPhase::Background => {
-                self.render_background_segments(sink, transform, &line_metrics, ctx);
+                self.render_background_segments(sink, transform, ctx);
             }
             RenderPhase::Selection => {
                 self.render_line_selection(sink, transform, point, ctx);
@@ -413,7 +409,7 @@ impl LineElement {
             }
             RenderPhase::Content => {
                 let scale = ctx.scale_factor as f32;
-                let run_y = self.metric.top + line_metrics.ascent;
+                let run_y = self.metric.top + self.metric.ascent;
                 let mut last_text_run_idx = None;
 
                 for item in line.items() {
@@ -495,8 +491,8 @@ impl LineElement {
                             let run_width = glyph_run.advance();
 
                             if let Some(underline_style) = &style.underline {
-                                let metrics = line_metrics;
-                                let default_offset = metrics.descent * 0.5;
+                                let descent = (self.metric.height - self.metric.ascent).max(0.0);
+                                let default_offset = descent * 0.5;
                                 let offset = underline_style.offset.unwrap_or(default_offset);
                                 let size = underline_style.size.unwrap_or(1.0);
 
@@ -508,8 +504,7 @@ impl LineElement {
                             }
 
                             if let Some(strikethrough_style) = &style.strikethrough {
-                                let metrics = line_metrics;
-                                let default_offset = -metrics.ascent * 0.3;
+                                let default_offset = -self.metric.ascent * 0.3;
                                 let offset = strikethrough_style.offset.unwrap_or(default_offset);
                                 let size = strikethrough_style.size.unwrap_or(1.0);
 
@@ -524,7 +519,7 @@ impl LineElement {
                 }
 
                 self.render_preedit(sink, transform, point, ctx);
-                self.render_ruby_annotations(sink, transform, &line_metrics, ctx);
+                self.render_ruby_annotations(sink, transform, ctx);
             }
         }
     }
@@ -1024,6 +1019,135 @@ mod tests {
         assert!(
             page_break_rect.is_some(),
             "Page break indicator should be present"
+        );
+    }
+
+    #[test]
+    fn line_metrics_do_not_shift_with_box_drawing_char() {
+        let mut plain = id!();
+        let plain_state = state! {
+            doc {
+                @plain paragraph {
+                    text { "AAAA" }
+                }
+            }
+            selection { (plain, 0) }
+        };
+        let plain_layout = layout_for_paragraph(&plain_state, plain);
+        let plain_line = plain_layout
+            .children
+            .as_ref()
+            .and_then(|children| {
+                children
+                    .iter()
+                    .find_map(|child| match child.node.element.as_ref() {
+                        Some(Element::Line(line)) => Some(line),
+                        _ => None,
+                    })
+            })
+            .expect("plain line should exist");
+
+        let mut mixed = id!();
+        let mixed_state = state! {
+            doc {
+                @mixed paragraph {
+                    text { "AA─AA" }
+                }
+            }
+            selection { (mixed, 0) }
+        };
+        let mixed_layout = layout_for_paragraph(&mixed_state, mixed);
+        let mixed_line = mixed_layout
+            .children
+            .as_ref()
+            .and_then(|children| {
+                children
+                    .iter()
+                    .find_map(|child| match child.node.element.as_ref() {
+                        Some(Element::Line(line)) => Some(line),
+                        _ => None,
+                    })
+            })
+            .expect("mixed line should exist");
+
+        let eps = 0.01;
+        assert!(
+            (plain_line.metric.top - mixed_line.metric.top).abs() <= eps,
+            "line top should stay stable when box drawing char is present: plain={}, mixed={}",
+            plain_line.metric.top,
+            mixed_line.metric.top
+        );
+        assert!(
+            (plain_line.metric.ascent - mixed_line.metric.ascent).abs() <= eps,
+            "line ascent should stay stable when box drawing char is present: plain={}, mixed={}",
+            plain_line.metric.ascent,
+            mixed_line.metric.ascent
+        );
+        assert!(
+            ((plain_line.metric.height + plain_line.metric.leading)
+                - (mixed_line.metric.height + mixed_line.metric.leading))
+                .abs()
+                <= eps,
+            "line box height should stay stable when box drawing char is present"
+        );
+    }
+
+    #[test]
+    fn line_box_expands_when_mixed_with_larger_font_size() {
+        let mut small = id!();
+        let small_state = state! {
+            doc {
+                @small paragraph {
+                    text { "ab" }
+                }
+            }
+            selection { (small, 0) }
+        };
+        let small_layout = layout_for_paragraph(&small_state, small);
+        let small_line = small_layout
+            .children
+            .as_ref()
+            .and_then(|children| {
+                children
+                    .iter()
+                    .find_map(|child| match child.node.element.as_ref() {
+                        Some(Element::Line(line)) => Some(line),
+                        _ => None,
+                    })
+            })
+            .expect("small line should exist");
+
+        let mut mixed = id!();
+        let mixed_state = state! {
+            doc {
+                @mixed paragraph {
+                    text { "a" }
+                    text(styles: [font_size(2400)]) { "b" }
+                }
+            }
+            selection { (mixed, 0) }
+        };
+        let mixed_layout = layout_for_paragraph(&mixed_state, mixed);
+        let mixed_line = mixed_layout
+            .children
+            .as_ref()
+            .and_then(|children| {
+                children
+                    .iter()
+                    .find_map(|child| match child.node.element.as_ref() {
+                        Some(Element::Line(line)) => Some(line),
+                        _ => None,
+                    })
+            })
+            .expect("mixed line should exist");
+
+        let small_box_height = small_line.metric.height + small_line.metric.leading;
+        let mixed_box_height = mixed_line.metric.height + mixed_line.metric.leading;
+        assert!(
+            mixed_box_height > small_box_height,
+            "line box should expand for larger mixed font size: small={}, mixed={}",
+            small_box_height,
+            mixed_box_height
         );
     }
 


### PR DESCRIPTION
- parley line metrics(ascent/descent)를 그대로 쓰지 않고, 스타일 기준 strut_ascent/descent로 라인 기준선을 고정
- fallback glyph는 line metric에는 영향 주지 않고 overflow로만 처리
- 큰/작은 글자가 섞인 라인은 필요한 만큼 line box를 확장해 인접 라인 침범을 방지
- render anchor(run_y/background/ruby/decoration)를 고정 line metric 기준으로 통일해 y-shift 제거
- `─` 문자, mixed font-size 케이스 회귀 테스트 추가