### PR TITLE
sentry node-specific integration 비활성화

### DIFF
--- a/apps/website/src/hooks.server.ts
+++ b/apps/website/src/hooks.server.ts
@@ -11,6 +11,7 @@ import type { Handle, HandleServerError } from '@sveltejs/kit';
 Sentry.init({
   dsn: env.PUBLIC_SENTRY_DSN,
   sendDefaultPii: true,
+  integrations: (defaults) => defaults.filter((i) => i.name !== 'NodeSystemError'),
 });
 
 const log = logger.getChild('http');


### PR DESCRIPTION
`util.getSystemErrorMap is not a function. (In 'util.getSystemErrorMap()', 'util.getSystemErrorMap' is undefined)` 오류 방지함
