### PR TITLE
윈도/리눅스 일부 단축키 조합에 shift 포함 안 하던 문제 수정

### DIFF
--- a/apps/website/src/lib/editor/keyboard.ts
+++ b/apps/website/src/lib/editor/keyboard.ts
@@ -152,7 +152,7 @@ export const handleKeyEvent = (editor: Editor, e: KeyboardEvent): boolean => {
     }
     case 's':
     case 'S': {
-      if ((e.shiftKey && IS_MAC && e.metaKey) || (!IS_MAC && e.ctrlKey)) {
+      if ((e.shiftKey && IS_MAC && e.metaKey) || (e.shiftKey && !IS_MAC && e.ctrlKey)) {
         editor.dispatch({ type: 'toggleStyle', style: { type: 'strikethrough' } }).scrollIntoView();
         return true;
       }
@@ -160,7 +160,7 @@ export const handleKeyEvent = (editor: Editor, e: KeyboardEvent): boolean => {
     }
     case 'v':
     case 'V': {
-      if (e.shiftKey && ((IS_MAC && e.metaKey) || (!IS_MAC && e.ctrlKey))) {
+      if (e.shiftKey && ((IS_MAC && e.metaKey) || (e.shiftKey && !IS_MAC && e.ctrlKey))) {
         editor.handlePasteTextOnly();
         return true;
       }


### PR DESCRIPTION
취소선 및 서식 없이 붙여넣기 조합 트리거에 shift 체크 빠져있던 문제 수정 