### PR TITLE
첫 자식 선택 중 엔터로 앞에 문단 삽입

### DIFF
--- a/crates/editor/src/runtime/mod.rs
+++ b/crates/editor/src/runtime/mod.rs
@@ -4571,6 +4571,55 @@ mod tests {
     }
 
     #[test]
+    fn regression_insert_newline_on_first_selected_image_in_fold_content_inserts_paragraph_before()
+    {
+        let mut content = id!();
+        let mut inserted = id!();
+
+        let mut rt = runtime! {
+            viewport { 800, 600, 1.0 }
+            doc {
+                fold {
+                    fold_title {
+                        text { "title" }
+                    }
+                    @content fold_content {
+                        image(id: Some("image-in-fold".to_string()),)
+                        paragraph {
+                            text { "after image" }
+                        }
+                    }
+                }
+                paragraph { text { "tail" } }
+            }
+            selection { (content, 0) -> (content, 1, Affinity::Upstream) }
+        };
+
+        rt.update(Message::InsertNewline);
+
+        let expected = state! {
+            doc {
+                fold {
+                    fold_title {
+                        text { "title" }
+                    }
+                    @content fold_content {
+                        @inserted paragraph {}
+                        image(id: Some("image-in-fold".to_string()),)
+                        paragraph {
+                            text { "after image" }
+                        }
+                    }
+                }
+                paragraph { text { "tail" } }
+            }
+            selection { (inserted, 0) }
+        };
+
+        assert_state_eq!(rt.state(), expected);
+    }
+
+    #[test]
     fn regression_delete_backward_from_empty_paragraph_after_table_selects_table() {
         let mut empty = id!();
 

--- a/crates/editor/src/transaction/paragraph.rs
+++ b/crates/editor/src/transaction/paragraph.rs
@@ -315,8 +315,7 @@ impl Transaction {
             return Ok(false);
         }
 
-        let insert_before = matches!(parent.node(), Some(Node::Root(_)))
-            && parent.first_child().map(|child| child.node_id()) == Some(block_id);
+        let insert_before = parent.first_child().map(|child| child.node_id()) == Some(block_id);
         let prev = if insert_before {
             block.prev_sibling().map(|n| n.node_id())
         } else {


### PR DESCRIPTION
- 기존 조건: 루트의 첫번째 자식을 선택중일 때만 엔터 시 문단을 뒤가 아닌 앞에 삽입
- 새 조건: 루트가 아니어도 첫번째 자식 선택중이면 엔터 시 뒤가 아닌 앞에 문단 삽입