### PR TITLE
코멘트 기능 UX 개선, 앱 바텀시트 개선

### DIFF
--- a/apps/mobile/lib/context/bottom_sheet.dart
+++ b/apps/mobile/lib/context/bottom_sheet.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:assorted_layout_widgets/assorted_layout_widgets.dart';
 import 'package:auto_route/auto_route.dart';
@@ -19,13 +20,14 @@ extension BottomSheetExtension on BuildContext {
     required Widget child,
     bool intercept = false,
     double overlayOpacity = 0.5,
-    bool resizeToAvoidBottomInset = false,
     bool dismissKeyboardOnTap = true,
     void Function(double)? onHeightCalculated,
+    ValueNotifier<double>? heightNotifier,
   }) {
     unawaited(HapticFeedback.lightImpact());
+    var isClosed = false;
 
-    return router.root.pushWidget(
+    final result = router.root.pushWidget<T>(
       child,
       opaque: false,
       transitionBuilder: (context, animation, secondaryAnimation, child) {
@@ -63,9 +65,7 @@ extension BottomSheetExtension on BuildContext {
               child: AnimatedPadding(
                 duration: const Duration(milliseconds: 100),
                 curve: Curves.easeOut,
-                padding: EdgeInsets.only(
-                  bottom: resizeToAvoidBottomInset ? MediaQuery.viewInsetsOf(context).bottom : 0,
-                ),
+                padding: EdgeInsets.only(bottom: MediaQuery.viewInsetsOf(context).bottom),
                 child: Align(
                   alignment: Alignment.bottomCenter,
                   child: ResponsiveContainer(
@@ -73,7 +73,15 @@ extension BottomSheetExtension on BuildContext {
                     child: SlideTransition(
                       position: tweenedSlide,
                       child: _BottomSheet(
-                        onHeightCalculated: onHeightCalculated,
+                        onHeightCalculated: (height) {
+                          if (isClosed) {
+                            return;
+                          }
+                          if (heightNotifier != null) {
+                            _setNotifierValueSafely(heightNotifier, height);
+                          }
+                          onHeightCalculated?.call(height);
+                        },
                         dismissKeyboardOnTap: dismissKeyboardOnTap,
                         child: child,
                       ),
@@ -86,7 +94,20 @@ extension BottomSheetExtension on BuildContext {
         );
       },
     );
+
+    return result.whenComplete(() {
+      isClosed = true;
+      if (heightNotifier != null) {
+        _setNotifierValueSafely(heightNotifier, 0);
+      }
+    });
   }
+}
+
+void _setNotifierValueSafely(ValueNotifier<double> notifier, double value) {
+  try {
+    notifier.value = value;
+  } catch (_) {}
 }
 
 class _BottomSheet extends HookWidget {
@@ -100,16 +121,59 @@ class _BottomSheet extends HookWidget {
   Widget build(BuildContext context) {
     final sheetKey = useMemoized(GlobalKey.new);
     final controller = useAnimationController(upperBound: double.infinity, duration: const Duration(milliseconds: 300));
+    final reportedHeight = useRef<double?>(null);
+
+    void reportHeightIfChanged() {
+      if (onHeightCalculated == null) {
+        return;
+      }
+      final height = sheetKey.currentContext?.size?.height;
+      if (height == null) {
+        return;
+      }
+      if (reportedHeight.value != null && (reportedHeight.value! - height).abs() <= 0.5) {
+        return;
+      }
+      reportedHeight.value = height;
+      onHeightCalculated!(height);
+    }
+
+    Widget sheet = Material(
+      color: AppColors.transparent,
+      child: Container(
+        key: sheetKey,
+        width: double.infinity,
+        decoration: BoxDecoration(
+          border: Border(
+            top: BorderSide(color: context.colors.borderStrong),
+            left: BorderSide(color: context.colors.borderStrong),
+            right: BorderSide(color: context.colors.borderStrong),
+          ),
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
+        ),
+        child: ClipRRect(
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
+          child: child,
+        ),
+      ),
+    );
 
     useEffect(() {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        final renderBox = sheetKey.currentContext?.findRenderObject() as RenderBox?;
-        if (renderBox != null && onHeightCalculated != null) {
-          onHeightCalculated!(renderBox.size.height);
-        }
-      });
+      if (onHeightCalculated != null) {
+        WidgetsBinding.instance.addPostFrameCallback((_) => reportHeightIfChanged());
+      }
       return null;
-    }, []);
+    }, [onHeightCalculated]);
+
+    if (onHeightCalculated != null) {
+      sheet = NotificationListener<SizeChangedLayoutNotification>(
+        onNotification: (_) {
+          WidgetsBinding.instance.addPostFrameCallback((_) => reportHeightIfChanged());
+          return false;
+        },
+        child: SizeChangedLayoutNotifier(child: sheet),
+      );
+    }
 
     return GestureDetector(
       onVerticalDragStart: (details) {
@@ -142,28 +206,7 @@ class _BottomSheet extends HookWidget {
         builder: (context, child) {
           return Transform.translate(offset: Offset(0, controller.value), child: child);
         },
-        child: _maybeDismissKeyboard(
-          dismissKeyboardOnTap: dismissKeyboardOnTap,
-          child: Material(
-            color: AppColors.transparent,
-            child: Container(
-              key: sheetKey,
-              width: double.infinity,
-              decoration: BoxDecoration(
-                border: Border(
-                  top: BorderSide(color: context.colors.borderStrong),
-                  left: BorderSide(color: context.colors.borderStrong),
-                  right: BorderSide(color: context.colors.borderStrong),
-                ),
-                borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
-              ),
-              child: ClipRRect(
-                borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
-                child: child,
-              ),
-            ),
-          ),
-        ),
+        child: _maybeDismissKeyboard(dismissKeyboardOnTap: dismissKeyboardOnTap, child: sheet),
       ),
     );
   }
@@ -183,14 +226,19 @@ class AppBottomSheet extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final mediaQuery = MediaQuery.of(context);
-    final maxHeight = (mediaQuery.size.height - mediaQuery.padding.top) * 0.9;
+    final keyboardInset = mediaQuery.viewInsets.bottom;
+    final availableWithoutKeyboard = mediaQuery.size.height - mediaQuery.padding.top;
+    final maxHeight = math.max<double>(0, availableWithoutKeyboard * 0.9 - keyboardInset);
     final bottomPadding = mediaQuery.padding.bottom;
+    final containerBottomPadding = includeBottomPadding ? (bottomPadding + 12) : 0.0;
+    final content = padding == null ? child : Padding(padding: padding!, child: child);
+    final contentMaxHeight = math.max<double>(0, maxHeight - 8 - containerBottomPadding - 4 - 16);
 
     return Container(
       constraints: BoxConstraints(maxHeight: maxHeight),
       decoration: BoxDecoration(color: context.colors.surfaceSubtle),
       child: Padding(
-        padding: Pad(top: 8, bottom: includeBottomPadding ? (bottomPadding + 12) : 0),
+        padding: Pad(top: 8, bottom: containerBottomPadding),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           spacing: 16,
@@ -205,7 +253,10 @@ class AppBottomSheet extends StatelessWidget {
                 ),
               ),
             ),
-            if (padding == null) child else Padding(padding: padding!, child: child),
+            ConstrainedBox(
+              constraints: BoxConstraints(maxHeight: contentMaxHeight),
+              child: SingleChildScrollView(primary: false, child: content),
+            ),
           ],
         ),
       ),

--- a/apps/mobile/lib/native/slate_reader.dart
+++ b/apps/mobile/lib/native/slate_reader.dart
@@ -627,6 +627,13 @@ class SlateReader {
       final boundsHeight = _slabF32(pos + 12);
       pos += 16;
 
+      final nodeType = readStr(pos);
+      pos += _strByteLen(pos);
+      final isTextblock = _slabU32(pos) != 0;
+      pos += 4;
+      final nodeText = readStr(pos);
+      pos += _strByteLen(pos);
+
       result.add(
         _RemarkOverlayRaw(
           pageIdx: pageIdx,
@@ -639,6 +646,9 @@ class SlateReader {
           boundsY: boundsY,
           boundsWidth: boundsWidth,
           boundsHeight: boundsHeight,
+          nodeType: nodeType,
+          isTextblock: isTextblock,
+          nodeText: nodeText,
         ),
       );
     }
@@ -954,6 +964,9 @@ class _RemarkOverlayRaw {
     required this.boundsY,
     required this.boundsWidth,
     required this.boundsHeight,
+    required this.nodeType,
+    required this.isTextblock,
+    required this.nodeText,
   });
 
   final int pageIdx;
@@ -966,4 +979,7 @@ class _RemarkOverlayRaw {
   final double boundsY;
   final double boundsWidth;
   final double boundsHeight;
+  final String nodeType;
+  final bool isTextblock;
+  final String nodeText;
 }

--- a/apps/mobile/lib/screens/native_editor/handler/command.dart
+++ b/apps/mobile/lib/screens/native_editor/handler/command.dart
@@ -252,6 +252,25 @@ class CommandHandler {
     final currentBlockNodeId = reader.readCurrentBlockNodeId();
     final isZero = currentBlockNodeId.replaceAll('0', '').isEmpty;
     controller.updateState((state) => state.copyWith(currentBlockNodeId: isZero ? null : currentBlockNodeId));
+    if (isZero) {
+      controller.currentBlockOverlay.value = null;
+    } else {
+      final pageIdx = reader.getI32('current_block_page_idx');
+      if (pageIdx < 0) {
+        controller.currentBlockOverlay.value = null;
+      } else {
+        final width = reader.getF32('current_block_width');
+        final height = reader.getF32('current_block_height');
+        controller.currentBlockOverlay.value = CurrentBlockOverlay(
+          nodeId: currentBlockNodeId,
+          pageIdx: pageIdx,
+          x: reader.getF32('current_block_x'),
+          y: reader.getF32('current_block_y'),
+          width: width <= 0 ? 1 : width,
+          height: height <= 0 ? 1 : height,
+        );
+      }
+    }
 
     controller.onSelectionChanged?.call(anchor, head);
   }
@@ -527,6 +546,16 @@ class CommandHandler {
 
   static void _handleRemarksChanged(EditorController controller, SlateReader reader) {
     final rawRemarks = reader.readRemarks();
+    final nodeContexts = <String, RemarkNodeContext>{};
+    for (final remark in rawRemarks) {
+      nodeContexts[remark.nodeId] = RemarkNodeContext(
+        nodeType: remark.nodeType,
+        isTextblock: remark.isTextblock,
+        nodeText: remark.nodeText,
+      );
+    }
+    controller.remarkNodeContexts.value = nodeContexts;
+
     final remarks = rawRemarks
         .map(
           (r) => RemarkOverlayInfo(

--- a/apps/mobile/lib/screens/native_editor/screen.dart
+++ b/apps/mobile/lib/screens/native_editor/screen.dart
@@ -225,6 +225,7 @@ class _Content extends HookWidget {
                                   intercept: true,
                                   overlayOpacity: 0.05,
                                   dismissKeyboardOnTap: false,
+                                  heightNotifier: controller.sheetBottomInset,
                                   child: FindReplaceSheet(controller: controller),
                                 );
                               },
@@ -233,12 +234,22 @@ class _Content extends HookWidget {
                                 if (controller == null) {
                                   return;
                                 }
-                                await context.showBottomSheet(
-                                  intercept: true,
-                                  overlayOpacity: 0.05,
-                                  resizeToAvoidBottomInset: true,
-                                  child: RemarkBottomSheet(controller: controller, client: client, userId: data.me!.id),
-                                );
+                                try {
+                                  await context.showBottomSheet(
+                                    intercept: true,
+                                    overlayOpacity: 0.05,
+                                    heightNotifier: controller.sheetBottomInset,
+                                    child: RemarkBottomSheet(
+                                      controller: controller,
+                                      client: client,
+                                      userId: data.me!.id,
+                                    ),
+                                  );
+                                } finally {
+                                  if (!controller.isDisposed) {
+                                    controller.remarkHighlightTarget.value = null;
+                                  }
+                                }
                               },
                               onOpenSpellcheck: () async {
                                 final controller = editorContext.controller;
@@ -263,6 +274,7 @@ class _Content extends HookWidget {
                                 await context.showBottomSheet(
                                   intercept: true,
                                   overlayOpacity: 0.05,
+                                  heightNotifier: controller.sheetBottomInset,
                                   child: SpellcheckSheet(
                                     controller: controller,
                                     editor: currentEditor,
@@ -296,6 +308,7 @@ class _Content extends HookWidget {
                                 await context.showBottomSheet(
                                   intercept: true,
                                   overlayOpacity: 0.05,
+                                  heightNotifier: controller.sheetBottomInset,
                                   child: AiFeedbackSheet(
                                     controller: controller,
                                     editor: currentEditor,

--- a/apps/mobile/lib/screens/native_editor/sheet/find_replace.dart
+++ b/apps/mobile/lib/screens/native_editor/sheet/find_replace.dart
@@ -6,11 +6,9 @@ import 'package:flutter/services.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:typie/context/bottom_sheet.dart';
 import 'package:typie/context/theme.dart';
-import 'package:typie/hooks/service.dart';
 import 'package:typie/icons/lucide_light.dart';
 import 'package:typie/screens/native_editor/state/controller.dart';
 import 'package:typie/screens/native_editor/state/state.dart';
-import 'package:typie/services/keyboard.dart';
 import 'package:typie/widgets/tappable.dart';
 
 class FindReplaceSheet extends HookWidget {
@@ -20,7 +18,7 @@ class FindReplaceSheet extends HookWidget {
 
   @override
   Widget build(BuildContext context) {
-    final keyboard = useService<Keyboard>();
+    final bottomPadding = MediaQuery.paddingOf(context).bottom;
 
     final findTextController = useTextEditingController();
     final replaceTextController = useTextEditingController();
@@ -38,27 +36,6 @@ class FindReplaceSheet extends HookWidget {
     final searchMatches = useRef<List<Map<String, dynamic>>>([]);
     final activeIndex = useState(0);
     final matchCount = useState(0);
-
-    final keyboardHeight = useState<double>(0);
-    useEffect(() {
-      Timer? heightDebounce;
-      final sub = keyboard.onHeightChange.listen((value) {
-        if (value >= keyboardHeight.value) {
-          heightDebounce?.cancel();
-          keyboardHeight.value = value;
-        } else {
-          heightDebounce?.cancel();
-          heightDebounce = Timer(const Duration(milliseconds: 150), () {
-            keyboardHeight.value = value;
-          });
-        }
-      });
-
-      return () {
-        heightDebounce?.cancel();
-        unawaited(sub.cancel());
-      };
-    }, []);
 
     useEffect(() {
       void ensureKeyboardVisible() {
@@ -234,121 +211,114 @@ class FindReplaceSheet extends HookWidget {
     final currentIndex = activeIndex.value;
 
     return AppBottomSheet(
-      padding: const Pad(horizontal: 20, vertical: 16),
       includeBottomPadding: false,
-      child: Padding(
-        padding: Pad(bottom: keyboardHeight.value),
-        child: Row(
-          spacing: 12,
-          children: [
-            Expanded(
-              child: Column(
-                spacing: 12,
-                children: [
-                  Container(
-                    height: 44,
-                    decoration: BoxDecoration(
-                      border: Border.all(
-                        color: findHasFocus ? context.colors.borderStrong : context.colors.borderDefault,
-                      ),
-                      borderRadius: BorderRadius.circular(8),
-                    ),
-                    child: Padding(
-                      padding: const Pad(horizontal: 16),
-                      child: Row(
-                        children: [
-                          Expanded(
-                            child: TextField(
-                              controller: findTextController,
-                              focusNode: findFocusNode,
-                              decoration: InputDecoration.collapsed(
-                                hintText: '찾기',
-                                hintStyle: TextStyle(
-                                  fontSize: 16,
-                                  fontWeight: FontWeight.w500,
-                                  color: context.colors.textDisabled,
-                                ),
-                              ),
-                              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
-                              cursorColor: context.colors.textDefault,
-                              autofocus: true,
-                              textInputAction: TextInputAction.search,
-                              onEditingComplete: findNext,
-                            ),
-                          ),
-                          if (findText.isNotEmpty)
-                            Text(
-                              totalCount > 0 ? '${currentIndex + 1} / $totalCount' : '결과 없음',
-                              style: TextStyle(fontSize: 14, color: context.colors.textSubtle),
-                            ),
-                        ],
-                      ),
-                    ),
-                  ),
-                  Container(
-                    height: 44,
-                    decoration: BoxDecoration(
-                      border: Border.all(
-                        color: replaceHasFocus ? context.colors.borderStrong : context.colors.borderDefault,
-                      ),
-                      borderRadius: BorderRadius.circular(8),
-                    ),
-                    child: Center(
-                      child: Padding(
-                        padding: const Pad(horizontal: 16),
-                        child: TextField(
-                          controller: replaceTextController,
-                          focusNode: replaceFocusNode,
-                          decoration: InputDecoration.collapsed(
-                            hintText: '바꾸기',
-                            hintStyle: TextStyle(
-                              fontSize: 16,
-                              fontWeight: FontWeight.w500,
-                              color: context.colors.textDisabled,
-                            ),
-                          ),
-                          style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
-                          cursorColor: context.colors.textDefault,
-                          textInputAction: TextInputAction.search,
-                          onEditingComplete: replace,
-                        ),
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            Column(
+      padding: Pad(left: 20, top: 16, right: 20, bottom: bottomPadding + 12),
+      child: Row(
+        spacing: 12,
+        children: [
+          Expanded(
+            child: Column(
               spacing: 12,
               children: [
-                SizedBox(
+                Container(
                   height: 44,
-                  child: Row(
-                    spacing: 8,
-                    children: [
-                      _ActionButton(icon: LucideLightIcons.arrow_up, enabled: findText.isNotEmpty, onTap: findPrevious),
-                      _ActionButton(icon: LucideLightIcons.arrow_down, enabled: findText.isNotEmpty, onTap: findNext),
-                    ],
+                  decoration: BoxDecoration(
+                    border: Border.all(
+                      color: findHasFocus ? context.colors.borderStrong : context.colors.borderDefault,
+                    ),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Padding(
+                    padding: const Pad(horizontal: 16),
+                    child: Row(
+                      children: [
+                        Expanded(
+                          child: TextField(
+                            controller: findTextController,
+                            focusNode: findFocusNode,
+                            decoration: InputDecoration.collapsed(
+                              hintText: '찾기',
+                              hintStyle: TextStyle(
+                                fontSize: 16,
+                                fontWeight: FontWeight.w500,
+                                color: context.colors.textDisabled,
+                              ),
+                            ),
+                            style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                            cursorColor: context.colors.textDefault,
+                            autofocus: true,
+                            textInputAction: TextInputAction.search,
+                            onEditingComplete: findNext,
+                          ),
+                        ),
+                        if (findText.isNotEmpty)
+                          Text(
+                            totalCount > 0 ? '${currentIndex + 1} / $totalCount' : '결과 없음',
+                            style: TextStyle(fontSize: 14, color: context.colors.textSubtle),
+                          ),
+                      ],
+                    ),
                   ),
                 ),
-                SizedBox(
+                Container(
                   height: 44,
-                  child: Row(
-                    spacing: 8,
-                    children: [
-                      _ActionButton(icon: LucideLightIcons.replace, enabled: findText.isNotEmpty, onTap: replace),
-                      _ActionButton(
-                        icon: LucideLightIcons.replace_all,
-                        enabled: findText.isNotEmpty,
-                        onTap: replaceAll,
+                  decoration: BoxDecoration(
+                    border: Border.all(
+                      color: replaceHasFocus ? context.colors.borderStrong : context.colors.borderDefault,
+                    ),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Center(
+                    child: Padding(
+                      padding: const Pad(horizontal: 16),
+                      child: TextField(
+                        controller: replaceTextController,
+                        focusNode: replaceFocusNode,
+                        decoration: InputDecoration.collapsed(
+                          hintText: '바꾸기',
+                          hintStyle: TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.w500,
+                            color: context.colors.textDisabled,
+                          ),
+                        ),
+                        style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                        cursorColor: context.colors.textDefault,
+                        textInputAction: TextInputAction.search,
+                        onEditingComplete: replace,
                       ),
-                    ],
+                    ),
                   ),
                 ),
               ],
             ),
-          ],
-        ),
+          ),
+          Column(
+            spacing: 12,
+            children: [
+              SizedBox(
+                height: 44,
+                child: Row(
+                  spacing: 8,
+                  children: [
+                    _ActionButton(icon: LucideLightIcons.arrow_up, enabled: findText.isNotEmpty, onTap: findPrevious),
+                    _ActionButton(icon: LucideLightIcons.arrow_down, enabled: findText.isNotEmpty, onTap: findNext),
+                  ],
+                ),
+              ),
+              SizedBox(
+                height: 44,
+                child: Row(
+                  spacing: 8,
+                  children: [
+                    _ActionButton(icon: LucideLightIcons.replace, enabled: findText.isNotEmpty, onTap: replace),
+                    _ActionButton(icon: LucideLightIcons.replace_all, enabled: findText.isNotEmpty, onTap: replaceAll),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ],
       ),
     );
   }

--- a/apps/mobile/lib/screens/native_editor/sheet/remark.dart
+++ b/apps/mobile/lib/screens/native_editor/sheet/remark.dart
@@ -18,6 +18,37 @@ import 'package:typie/screens/native_editor/state/controller.dart';
 import 'package:typie/screens/native_editor/state/state.dart';
 import 'package:typie/widgets/tappable.dart';
 
+const _remarkNodeLabels = {
+  'image': '이미지',
+  'file': '파일',
+  'embed': '임베드',
+  'archived': '보관된 블록',
+  'horizontal_rule': '구분선',
+  'blockquote': '인용구',
+  'callout': '강조',
+  'bullet_list': '순서 없는 목록',
+  'ordered_list': '순서 있는 목록',
+  'fold': '접기',
+  'table': '표',
+};
+
+String _resolveRemarkNodeInfoText({
+  required RemarkOverlayInfo remark,
+  required Map<String, RemarkNodeContext> nodeContexts,
+}) {
+  final context = nodeContexts[remark.nodeId];
+  if (context == null) {
+    return '';
+  }
+
+  if (context.isTextblock) {
+    final normalized = context.nodeText.replaceAll(RegExp(r'\s+'), ' ').trim();
+    return normalized.isNotEmpty ? normalized : '빈 텍스트';
+  }
+
+  return _remarkNodeLabels[context.nodeType] ?? context.nodeType;
+}
+
 class RemarkBottomSheet extends HookWidget {
   const RemarkBottomSheet({required this.controller, required this.client, required this.userId, super.key});
 
@@ -32,6 +63,10 @@ class RemarkBottomSheet extends HookWidget {
     final editingRemarkId = useState<String?>(null);
     final editController = useTextEditingController();
     final inputController = useTextEditingController();
+    final inputFocusNode = useFocusNode();
+    final listScrollController = useScrollController();
+    final pendingScrollToBottomAfterAdd = useState(false);
+    final pendingScrollToCurrentBlock = useState(false);
     final inputText = useState('');
 
     useEffect(() {
@@ -46,8 +81,10 @@ class RemarkBottomSheet extends HookWidget {
     final users = useState<Map<String, GNativeEditor_RemarkUser_QueryData_userView>>({});
 
     final state = useListenableSelector(controller, () => controller.state);
+    final currentBlockOverlay = useValueListenable(controller.currentBlockOverlay);
     final remarks = state.remarks;
     final currentBlockNodeId = state.currentBlockNodeId;
+    final remarkNodeContexts = useValueListenable(controller.remarkNodeContexts);
 
     useEffect(() {
       final uniqueUserIds = remarks.map((r) => r.userId).toSet();
@@ -106,6 +143,8 @@ class RemarkBottomSheet extends HookWidget {
         'createdAt': DateTime.now().millisecondsSinceEpoch,
       });
       inputController.clear();
+      inputFocusNode.requestFocus();
+      pendingScrollToBottomAfterAdd.value = true;
     }
 
     void deleteRemark(RemarkOverlayInfo remark) {
@@ -132,6 +171,104 @@ class RemarkBottomSheet extends HookWidget {
 
     final currentRemarks = isBlockTab.value ? blockRemarks : allRemarks;
     final bottomPadding = MediaQuery.paddingOf(context).bottom;
+
+    RemarkOverlayInfo? currentBlockHighlightTarget() {
+      final nodeId = currentBlockNodeId;
+      if (nodeId == null) {
+        return null;
+      }
+      for (final remark in allRemarks) {
+        if (remark.nodeId == nodeId) {
+          return remark;
+        }
+      }
+      final overlay = controller.currentBlockOverlay.value;
+      if (overlay == null || overlay.nodeId != nodeId || overlay.pageIdx < 0) {
+        return null;
+      }
+      return RemarkOverlayInfo(
+        pageIdx: overlay.pageIdx,
+        nodeId: nodeId,
+        remarkId: '__current_block_$nodeId',
+        userId: userId,
+        text: '',
+        createdAt: 0,
+        boundsX: overlay.x,
+        boundsY: overlay.y,
+        boundsWidth: overlay.width,
+        boundsHeight: overlay.height,
+      );
+    }
+
+    useEffect(() {
+      if (!pendingScrollToBottomAfterAdd.value || !isBlockTab.value) {
+        return null;
+      }
+
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!listScrollController.hasClients) {
+          return;
+        }
+        unawaited(
+          listScrollController.animateTo(
+            listScrollController.position.maxScrollExtent,
+            duration: const Duration(milliseconds: 180),
+            curve: Curves.easeOut,
+          ),
+        );
+      });
+      pendingScrollToBottomAfterAdd.value = false;
+      return null;
+    }, [pendingScrollToBottomAfterAdd.value, blockRemarks.length, isBlockTab.value]);
+
+    useEffect(() {
+      pendingScrollToCurrentBlock.value = true;
+      return null;
+    }, const []);
+
+    useEffect(
+      () {
+        if (!pendingScrollToCurrentBlock.value) {
+          return null;
+        }
+        if (!isBlockTab.value) {
+          pendingScrollToCurrentBlock.value = false;
+          return null;
+        }
+
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!context.mounted || !isBlockTab.value) {
+            pendingScrollToCurrentBlock.value = false;
+            return;
+          }
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (!context.mounted || !isBlockTab.value) {
+              pendingScrollToCurrentBlock.value = false;
+              return;
+            }
+            final target = currentBlockHighlightTarget();
+            if (target == null) {
+              if (currentBlockNodeId == null) {
+                controller.remarkHighlightTarget.value = null;
+                controller.scrollIntoView();
+                pendingScrollToCurrentBlock.value = false;
+              }
+              return;
+            }
+            controller.scrollToRemark(target);
+            pendingScrollToCurrentBlock.value = false;
+          });
+        });
+        return null;
+      },
+      [
+        pendingScrollToCurrentBlock.value,
+        isBlockTab.value,
+        currentBlockNodeId,
+        blockRemarks.length,
+        currentBlockOverlay,
+      ],
+    );
 
     return AppBottomSheet(
       includeBottomPadding: false,
@@ -163,8 +300,24 @@ class RemarkBottomSheet extends HookWidget {
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    _TabPill(label: '전체', isActive: !isBlockTab.value, onTap: () => isBlockTab.value = false),
-                    _TabPill(label: '현재 위치', isActive: isBlockTab.value, onTap: () => isBlockTab.value = true),
+                    _TabPill(
+                      label: '전체',
+                      isActive: !isBlockTab.value,
+                      onTap: () {
+                        isBlockTab.value = false;
+                        pendingScrollToCurrentBlock.value = false;
+                        activeRemarkId.value = null;
+                        controller.remarkHighlightTarget.value = null;
+                      },
+                    ),
+                    _TabPill(
+                      label: '현재 위치',
+                      isActive: isBlockTab.value,
+                      onTap: () {
+                        isBlockTab.value = true;
+                        pendingScrollToCurrentBlock.value = true;
+                      },
+                    ),
                   ],
                 ),
               ),
@@ -189,6 +342,7 @@ class RemarkBottomSheet extends HookWidget {
             ConstrainedBox(
               constraints: BoxConstraints(maxHeight: MediaQuery.sizeOf(context).height * 0.4),
               child: SingleChildScrollView(
+                controller: listScrollController,
                 padding: Pad(bottom: isBlockTab.value ? 0 : bottomPadding + 12),
                 child: Column(
                   children: currentRemarks
@@ -201,6 +355,9 @@ class RemarkBottomSheet extends HookWidget {
                           isEditing: editingRemarkId.value == remark.remarkId,
                           isOwnRemark: remark.userId == userId,
                           editController: editController,
+                          nodeInfoText: isBlockTab.value
+                              ? null
+                              : _resolveRemarkNodeInfoText(remark: remark, nodeContexts: remarkNodeContexts),
                           onTap: () {
                             activeRemarkId.value = remark.remarkId;
                             controller.scrollToRemark(remark);
@@ -233,7 +390,12 @@ class RemarkBottomSheet extends HookWidget {
           if (isBlockTab.value && currentBlockNodeId != null) ...[
             Container(height: 1, color: context.colors.borderSubtle),
             const Gap(12),
-            _RemarkInput(controller: inputController, hasText: inputText.value.trim().isNotEmpty, onSubmit: addRemark),
+            _RemarkInput(
+              controller: inputController,
+              focusNode: inputFocusNode,
+              hasText: inputText.value.trim().isNotEmpty,
+              onSubmit: addRemark,
+            ),
             Gap(bottomPadding + 12),
           ],
         ],
@@ -280,6 +442,7 @@ class _RemarkItem extends StatelessWidget {
     required this.isEditing,
     required this.isOwnRemark,
     required this.editController,
+    this.nodeInfoText,
     required this.onTap,
     required this.onStartEdit,
     required this.onSaveEdit,
@@ -294,6 +457,7 @@ class _RemarkItem extends StatelessWidget {
   final bool isEditing;
   final bool isOwnRemark;
   final TextEditingController editController;
+  final String? nodeInfoText;
   final VoidCallback onTap;
   final VoidCallback onStartEdit;
   final VoidCallback onSaveEdit;
@@ -305,6 +469,7 @@ class _RemarkItem extends StatelessWidget {
     final timeText = Jiffy.parseFromMillisecondsSinceEpoch(remark.createdAt).ago;
     final dpr = MediaQuery.devicePixelRatioOf(context);
     final imageSize = pow(2, (log(28 * dpr) / log(2)).ceil()).toInt();
+    final hasNodeInfoText = nodeInfoText != null && nodeInfoText!.isNotEmpty;
 
     return Tappable(
       onTap: onTap,
@@ -339,22 +504,46 @@ class _RemarkItem extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      if (user != null)
-                        Flexible(
+                      Expanded(
+                        child: Row(
+                          children: [
+                            if (user != null)
+                              Flexible(
+                                child: Text(
+                                  user!.name,
+                                  style: TextStyle(
+                                    fontSize: 13,
+                                    fontWeight: FontWeight.w600,
+                                    color: context.colors.textDefault,
+                                  ),
+                                  overflow: TextOverflow.ellipsis,
+                                  maxLines: 1,
+                                ),
+                              ),
+                            if (user != null) const Gap(6),
+                            Text(timeText, style: TextStyle(fontSize: 12, color: context.colors.textFaint)),
+                          ],
+                        ),
+                      ),
+                      if (hasNodeInfoText) ...[
+                        const Gap(8),
+                        ConstrainedBox(
+                          constraints: const BoxConstraints(maxWidth: 150),
                           child: Text(
-                            user!.name,
+                            nodeInfoText!,
+                            textAlign: TextAlign.right,
                             style: TextStyle(
-                              fontSize: 13,
-                              fontWeight: FontWeight.w600,
-                              color: context.colors.textDefault,
+                              fontSize: 11,
+                              fontWeight: FontWeight.w500,
+                              color: context.colors.textFaint,
                             ),
-                            overflow: TextOverflow.ellipsis,
                             maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
                           ),
                         ),
-                      const Gap(6),
-                      Text(timeText, style: TextStyle(fontSize: 12, color: context.colors.textFaint)),
+                      ],
                     ],
                   ),
                   const Gap(4),
@@ -486,9 +675,15 @@ class _RemarkItem extends StatelessWidget {
 }
 
 class _RemarkInput extends StatelessWidget {
-  const _RemarkInput({required this.controller, required this.hasText, required this.onSubmit});
+  const _RemarkInput({
+    required this.controller,
+    required this.focusNode,
+    required this.hasText,
+    required this.onSubmit,
+  });
 
   final TextEditingController controller;
+  final FocusNode focusNode;
   final bool hasText;
   final VoidCallback onSubmit;
 
@@ -496,6 +691,7 @@ class _RemarkInput extends StatelessWidget {
   Widget build(BuildContext context) {
     return TextField(
       controller: controller,
+      focusNode: focusNode,
       style: TextStyle(fontSize: 14, color: context.colors.textDefault),
       decoration: InputDecoration(
         hintText: '코멘트 입력...',

--- a/apps/mobile/lib/screens/native_editor/state/controller.dart
+++ b/apps/mobile/lib/screens/native_editor/state/controller.dart
@@ -14,6 +14,32 @@ class TrackedItemRange {
   final int endOffset;
 }
 
+class CurrentBlockOverlay {
+  const CurrentBlockOverlay({
+    required this.nodeId,
+    required this.pageIdx,
+    required this.x,
+    required this.y,
+    required this.width,
+    required this.height,
+  });
+
+  final String nodeId;
+  final int pageIdx;
+  final double x;
+  final double y;
+  final double width;
+  final double height;
+}
+
+class RemarkNodeContext {
+  const RemarkNodeContext({required this.nodeType, required this.isTextblock, required this.nodeText});
+
+  final String nodeType;
+  final bool isTextblock;
+  final String nodeText;
+}
+
 class EditorController extends ChangeNotifier {
   EditorController({
     required this.editor,
@@ -154,6 +180,9 @@ class EditorController extends ChangeNotifier {
 
   final ValueNotifier<RemarkOverlayInfo?> remarkScrollTarget = ValueNotifier(null);
   final ValueNotifier<RemarkOverlayInfo?> remarkHighlightTarget = ValueNotifier(null);
+  final ValueNotifier<Map<String, RemarkNodeContext>> remarkNodeContexts = ValueNotifier({});
+  final ValueNotifier<double> sheetBottomInset = ValueNotifier(0);
+  final ValueNotifier<CurrentBlockOverlay?> currentBlockOverlay = ValueNotifier(null);
 
   void scrollToRemark(RemarkOverlayInfo remark) {
     remarkScrollTarget.value = null;
@@ -211,6 +240,9 @@ class EditorController extends ChangeNotifier {
     tableOverlays.dispose();
     remarkScrollTarget.dispose();
     remarkHighlightTarget.dispose();
+    remarkNodeContexts.dispose();
+    sheetBottomInset.dispose();
+    currentBlockOverlay.dispose();
     super.dispose();
   }
 }

--- a/apps/mobile/lib/screens/native_editor/view/editor.dart
+++ b/apps/mobile/lib/screens/native_editor/view/editor.dart
@@ -110,6 +110,7 @@ class EditorView extends HookWidget {
     final currentZoomViewportWidth = useValueListenable(zoomViewportWidth);
     final currentDisplayZoom = useValueListenable(displayZoom);
     final currentRenderZoom = useValueListenable(renderZoom);
+    final sheetBottomInset = useValueListenable(controller.sheetBottomInset);
     final cursorFollowScrollActive = useRef(false);
     final cursorFollowScrollMode = useRef(ScrollMode.auto);
     final typewriterRecoveryPending = useRef(false);
@@ -738,7 +739,13 @@ class EditorView extends HookWidget {
       return null;
     }, [renderedCursorValue, state.state.renderVersion, currentDisplayZoom]);
 
-    void scrollToOverlay({required int pageIdx, required double x, required double y, required double width}) {
+    void scrollToOverlay({
+      required int pageIdx,
+      required double x,
+      required double y,
+      required double width,
+      required double height,
+    }) {
       if (currentLayout == null) {
         return;
       }
@@ -755,13 +762,36 @@ class EditorView extends HookWidget {
         targetX: x,
         targetY: y,
         targetWidth: width,
+        targetHeight: height,
       );
     }
 
     useEffect(() {
+      if (sheetBottomInset <= 0) {
+        return null;
+      }
+
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        final target = controller.remarkHighlightTarget.value;
+        if (target == null) {
+          return;
+        }
+        scrollToOverlay(
+          pageIdx: target.pageIdx,
+          x: target.boundsX,
+          y: target.boundsY,
+          width: target.boundsWidth,
+          height: target.boundsHeight,
+        );
+      });
+
+      return null;
+    }, [sheetBottomInset]);
+
+    useEffect(() {
       final target = state.state.search.scrollTarget;
       if (target != null) {
-        scrollToOverlay(pageIdx: target.pageIdx, x: target.x, y: target.y, width: target.width);
+        scrollToOverlay(pageIdx: target.pageIdx, x: target.x, y: target.y, width: target.width, height: target.height);
       }
       return null;
     }, [state.state.search.scrollTarget]);
@@ -770,7 +800,7 @@ class EditorView extends HookWidget {
       final target = state.state.spellcheck.scrollTarget;
       final pageIdx = state.state.spellcheck.scrollTargetPageIdx;
       if (target != null && pageIdx != null) {
-        scrollToOverlay(pageIdx: pageIdx, x: target.x, y: target.y, width: target.width);
+        scrollToOverlay(pageIdx: pageIdx, x: target.x, y: target.y, width: target.width, height: target.height);
       }
       return null;
     }, [state.state.spellcheck.scrollTarget, state.state.spellcheck.scrollTargetPageIdx]);
@@ -779,7 +809,7 @@ class EditorView extends HookWidget {
       final target = state.state.aiFeedback.scrollTarget;
       final pageIdx = state.state.aiFeedback.scrollTargetPageIdx;
       if (target != null && pageIdx != null) {
-        scrollToOverlay(pageIdx: pageIdx, x: target.x, y: target.y, width: target.width);
+        scrollToOverlay(pageIdx: pageIdx, x: target.x, y: target.y, width: target.width, height: target.height);
       }
       return null;
     }, [state.state.aiFeedback.scrollTarget, state.state.aiFeedback.scrollTargetPageIdx]);
@@ -803,6 +833,7 @@ class EditorView extends HookWidget {
               targetX: target.boundsX,
               targetY: target.boundsY,
               targetWidth: target.boundsWidth,
+              targetHeight: target.boundsHeight,
             );
           }
           controller.remarkScrollTarget.value = null;

--- a/apps/mobile/lib/screens/native_editor/view/page.dart
+++ b/apps/mobile/lib/screens/native_editor/view/page.dart
@@ -493,17 +493,14 @@ class _RemarkHighlightOverlay extends StatefulWidget {
 
 class _RemarkHighlightOverlayState extends State<_RemarkHighlightOverlay> with SingleTickerProviderStateMixin {
   late final AnimationController _animation;
+  late final Animation<double> _opacity;
   RemarkOverlayInfo? _target;
 
   @override
   void initState() {
     super.initState();
-    _animation = AnimationController(vsync: this, duration: const Duration(milliseconds: 1500))
-      ..addStatusListener((status) {
-        if (status == AnimationStatus.completed) {
-          setState(() => _target = null);
-        }
-      });
+    _animation = AnimationController(vsync: this, duration: const Duration(milliseconds: 220));
+    _opacity = CurvedAnimation(parent: _animation, curve: Curves.easeOut);
     widget.controller.remarkHighlightTarget.addListener(_onHighlight);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) {
@@ -522,10 +519,14 @@ class _RemarkHighlightOverlayState extends State<_RemarkHighlightOverlay> with S
 
   void _onHighlight() {
     final target = widget.controller.remarkHighlightTarget.value;
-    if (target != null && target.pageIdx == widget.pageIndex) {
-      setState(() => _target = target);
-      unawaited(_animation.forward(from: 0));
+    if (target == null || target.pageIdx != widget.pageIndex) {
+      if (_target != null) {
+        setState(() => _target = null);
+      }
+      return;
     }
+    setState(() => _target = target);
+    unawaited(_animation.forward(from: 0));
   }
 
   @override
@@ -537,19 +538,8 @@ class _RemarkHighlightOverlayState extends State<_RemarkHighlightOverlay> with S
 
     return IgnorePointer(
       child: AnimatedBuilder(
-        animation: _animation,
+        animation: _opacity,
         builder: (context, _) {
-          final t = _animation.value;
-          // fast fade-in (0~0.15), hold (0.15~0.4), fade-out (0.4~1.0)
-          final double opacity;
-          if (t < 0.15) {
-            opacity = t / 0.15;
-          } else if (t < 0.4) {
-            opacity = 1.0;
-          } else {
-            opacity = 1.0 - (t - 0.4) / 0.6;
-          }
-
           return Stack(
             children: [
               Positioned(
@@ -559,7 +549,7 @@ class _RemarkHighlightOverlayState extends State<_RemarkHighlightOverlay> with S
                 height: target.boundsHeight + 8,
                 child: DecoratedBox(
                   decoration: BoxDecoration(
-                    color: context.colors.accentBrand.withValues(alpha: 0.12 * opacity),
+                    color: context.colors.accentBrand.withValues(alpha: 0.12 * _opacity.value),
                     borderRadius: BorderRadius.circular(4),
                   ),
                 ),

--- a/apps/mobile/lib/screens/native_editor/view/pages.dart
+++ b/apps/mobile/lib/screens/native_editor/view/pages.dart
@@ -28,6 +28,7 @@ class PageList extends HookWidget {
     final scope = ContentScope.of(context);
     final pref = useService<Pref>();
     final state = useListenable(scope.controller);
+    final sheetBottomInset = useValueListenable(scope.controller.sheetBottomInset);
 
     final pages = state.state.pages;
     final cursor = state.state.cursor;
@@ -229,74 +230,77 @@ class PageList extends HookWidget {
             typewriterPosition: pref.typewriterPosition,
           );
 
-          final listView = ScrollConfiguration(
-            behavior: ScrollConfiguration.of(
-              context,
-            ).copyWith(scrollbars: false, dragDevices: scrollLocked ? {} : null),
-            child: SingleChildScrollView(
-              controller: verticalScrollController,
-              physics: scrollLocked ? const NeverScrollableScrollPhysics() : const NonGestureBouncingScrollPhysics(),
-              child: Builder(
-                builder: (_) {
-                  final content = RawGestureDetector(
-                    gestures: {
-                      ConditionalLongPressGestureRecognizer:
-                          GestureRecognizerFactoryWithHandlers<ConditionalLongPressGestureRecognizer>(
-                            () => ConditionalLongPressGestureRecognizer(
-                              condition: interactionController.shouldRejectLongPress,
-                              duration: const Duration(milliseconds: 500),
+          final listView = Padding(
+            padding: EdgeInsets.only(bottom: sheetBottomInset),
+            child: ScrollConfiguration(
+              behavior: ScrollConfiguration.of(
+                context,
+              ).copyWith(scrollbars: false, dragDevices: scrollLocked ? {} : null),
+              child: SingleChildScrollView(
+                controller: verticalScrollController,
+                physics: scrollLocked ? const NeverScrollableScrollPhysics() : const NonGestureBouncingScrollPhysics(),
+                child: Builder(
+                  builder: (_) {
+                    final content = RawGestureDetector(
+                      gestures: {
+                        ConditionalLongPressGestureRecognizer:
+                            GestureRecognizerFactoryWithHandlers<ConditionalLongPressGestureRecognizer>(
+                              () => ConditionalLongPressGestureRecognizer(
+                                condition: interactionController.shouldRejectLongPress,
+                                duration: const Duration(milliseconds: 500),
+                              ),
+                              (ConditionalLongPressGestureRecognizer instance) {
+                                instance
+                                  ..onLongPressStart = (details) {
+                                    interactionController.startLongPress(details.globalPosition);
+                                  }
+                                  ..onLongPressEnd = (details) {
+                                    interactionController.endLongPress();
+                                  };
+                              },
                             ),
-                            (ConditionalLongPressGestureRecognizer instance) {
-                              instance
-                                ..onLongPressStart = (details) {
-                                  interactionController.startLongPress(details.globalPosition);
-                                }
-                                ..onLongPressEnd = (details) {
-                                  interactionController.endLongPress();
-                                };
-                            },
-                          ),
-                    },
-                    child: Column(
-                      children: [
-                        MeasuredTitleFields(scope: scope),
-                        TrackedHorizontalScrollView(
-                          controller: horizontalScrollController,
-                          physics: horizontalPhysics,
-                          child: SizedBox(
-                            width: math.max(contentWidth, viewWidth),
-                            child: Align(
-                              alignment: Alignment.topCenter,
-                              child: Container(
-                                width: contentWidth,
-                                padding: EdgeInsets.only(
-                                  left: geo.horizontalPadding,
-                                  right: geo.horizontalPadding,
-                                  bottom: contentBottomPadding,
-                                ),
-                                child: Column(
-                                  children: [
-                                    for (var i = 0; i < pages.length; i++) ...[
-                                      PageSlot(
-                                        key: ValueKey(i),
-                                        pageIndex: i,
-                                        pageTop: geo.titleAreaHeight + offsets[i],
-                                        pageBottom: geo.titleAreaHeight + offsets[i] + geo.pageHeightAt(i),
-                                        activeCursorPageIdx: renderedCursor?.pageIdx,
-                                      ),
+                      },
+                      child: Column(
+                        children: [
+                          MeasuredTitleFields(scope: scope),
+                          TrackedHorizontalScrollView(
+                            controller: horizontalScrollController,
+                            physics: horizontalPhysics,
+                            child: SizedBox(
+                              width: math.max(contentWidth, viewWidth),
+                              child: Align(
+                                alignment: Alignment.topCenter,
+                                child: Container(
+                                  width: contentWidth,
+                                  padding: EdgeInsets.only(
+                                    left: geo.horizontalPadding,
+                                    right: geo.horizontalPadding,
+                                    bottom: contentBottomPadding,
+                                  ),
+                                  child: Column(
+                                    children: [
+                                      for (var i = 0; i < pages.length; i++) ...[
+                                        PageSlot(
+                                          key: ValueKey(i),
+                                          pageIndex: i,
+                                          pageTop: geo.titleAreaHeight + offsets[i],
+                                          pageBottom: geo.titleAreaHeight + offsets[i] + geo.pageHeightAt(i),
+                                          activeCursorPageIdx: renderedCursor?.pageIdx,
+                                        ),
+                                      ],
                                     ],
-                                  ],
+                                  ),
                                 ),
                               ),
                             ),
                           ),
-                        ),
-                      ],
-                    ),
-                  );
+                        ],
+                      ),
+                    );
 
-                  return EditorDraggable(interactionController: interactionController, child: content);
-                },
+                    return EditorDraggable(interactionController: interactionController, child: content);
+                  },
+                ),
               ),
             ),
           );

--- a/apps/mobile/lib/screens/native_editor/view/scroll.dart
+++ b/apps/mobile/lib/screens/native_editor/view/scroll.dart
@@ -165,17 +165,29 @@ void scrollToOverlayTarget({
   required double targetX,
   required double targetY,
   required double targetWidth,
+  double targetHeight = 0,
+  double targetAnchor = 0.5,
+  double viewportAnchor = 0.5,
 }) {
   final offsets = geometry.computeCumulativePageOffsets();
   final absoluteY = geometry.titleAreaHeight + offsets[pageIdx] + geometry.toDisplayY(targetY);
 
   final verticalPosition = resolveScrollPosition(verticalScrollController);
   if (verticalPosition != null && verticalPosition.hasContentDimensions) {
+    final clampedTargetAnchor = targetAnchor.clamp(0.0, 1.0);
+    final clampedViewportAnchor = viewportAnchor.clamp(0.0, 1.0);
     final viewportHeight = verticalPosition.viewportDimension;
-    final targetOffset = (absoluteY - viewportHeight / 3).clamp(0.0, verticalPosition.maxScrollExtent);
-    unawaited(
-      verticalPosition.animateTo(targetOffset, duration: const Duration(milliseconds: 200), curve: Curves.easeOut),
+    final absoluteAnchorY = absoluteY + geometry.toDisplayY(targetHeight) * clampedTargetAnchor;
+    final targetOffset = (absoluteAnchorY - viewportHeight * clampedViewportAnchor).clamp(
+      0.0,
+      verticalPosition.maxScrollExtent,
     );
+    final currentOffset = verticalPosition.pixels;
+    if ((targetOffset - currentOffset).abs() > 1) {
+      unawaited(
+        verticalPosition.animateTo(targetOffset, duration: const Duration(milliseconds: 200), curve: Curves.easeOut),
+      );
+    }
   }
 
   final horizontalMetrics = resolveHorizontalScrollMetrics(
@@ -195,20 +207,18 @@ void scrollToOverlayTarget({
   final viewportWidth = horizontalMetrics.viewportDimension;
 
   if (matchRight > scrollOffset + viewportWidth - scrollMargin) {
-    unawaited(
-      horizontalPosition.animateTo(
-        (matchRight - viewportWidth + scrollMargin).clamp(0.0, horizontalPosition.maxScrollExtent),
-        duration: const Duration(milliseconds: 200),
-        curve: Curves.easeOut,
-      ),
-    );
+    final target = (matchRight - viewportWidth + scrollMargin).clamp(0.0, horizontalPosition.maxScrollExtent);
+    if ((target - scrollOffset).abs() > 1) {
+      unawaited(
+        horizontalPosition.animateTo(target, duration: const Duration(milliseconds: 200), curve: Curves.easeOut),
+      );
+    }
   } else if (matchX < scrollOffset + scrollMargin) {
-    unawaited(
-      horizontalPosition.animateTo(
-        (matchX - scrollMargin).clamp(0.0, horizontalPosition.maxScrollExtent),
-        duration: const Duration(milliseconds: 200),
-        curve: Curves.easeOut,
-      ),
-    );
+    final target = (matchX - scrollMargin).clamp(0.0, horizontalPosition.maxScrollExtent);
+    if ((target - scrollOffset).abs() > 1) {
+      unawaited(
+        horizontalPosition.animateTo(target, duration: const Duration(milliseconds: 200), curve: Curves.easeOut),
+      );
+    }
   }
 }

--- a/apps/mobile/lib/screens/text_replacements/screen.dart
+++ b/apps/mobile/lib/screens/text_replacements/screen.dart
@@ -113,7 +113,6 @@ class TextReplacementsScreen extends HookWidget {
             icon: LucideLightIcons.plus,
             onTap: () async {
               await context.showBottomSheet(
-                resizeToAvoidBottomInset: true,
                 child: _FormBottomSheet(
                   client: client,
                   refreshNotifier: refreshNotifier,
@@ -613,7 +612,6 @@ class _CustomItemsList extends HookWidget {
                   Tappable(
                     onTap: () async {
                       await context.showBottomSheet(
-                        resizeToAvoidBottomInset: true,
                         child: _FormBottomSheet(
                           client: client,
                           refreshNotifier: refreshNotifier,

--- a/apps/website/src/lib/components/editor/core/Page.svelte
+++ b/apps/website/src/lib/components/editor/core/Page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { css } from '@typie/styled-system/css';
+  import { fade } from 'svelte/transition';
   import { CROP_MARKER_SIZE } from '$lib/editor/constants';
   import { getEditorContext } from '$lib/editor/context.svelte';
   import ExternalArchived from '../external/ExternalArchived.svelte';
@@ -28,6 +29,7 @@
   const displayZoom = $derived(isPaginated ? editor.displayZoom : 1);
   const slotWidth = $derived(pageWidth * displayZoom);
   const slotHeight = $derived(pageHeight * displayZoom);
+  const remarkHighlightTarget = $derived(editor.remarkHighlightTarget?.pageIdx === page ? editor.remarkHighlightTarget : null);
 
   // NOTE: iOS에서 캔버스 롱프레스 시 텍스트 인식해서 선택되는 동작을 막음
   const disableCanvasPointer = $derived(editor.readOnly); // TODO: 항상 disable 해도 안전한지 확인하기
@@ -226,6 +228,23 @@
           ></div>
         {/each}
       {/each}
+
+      {#if remarkHighlightTarget}
+        <div
+          style:left={`${remarkHighlightTarget.bounds.x - 4}px`}
+          style:top={`${remarkHighlightTarget.bounds.y - 4}px`}
+          style:width={`${remarkHighlightTarget.bounds.width + 8}px`}
+          style:height={`${remarkHighlightTarget.bounds.height + 8}px`}
+          class={css({
+            position: 'absolute',
+            pointerEvents: 'none',
+            borderRadius: '4px',
+            backgroundColor: 'accent.brand.subtle',
+            mixBlendMode: { base: 'multiply', _dark: 'screen' },
+          })}
+          transition:fade={{ duration: 150 }}
+        ></div>
+      {/if}
 
       {#if isPaginated && !editor.isReadOnly()}
         <svg

--- a/apps/website/src/lib/components/editor/core/RemarkOverlayLayer.svelte
+++ b/apps/website/src/lib/components/editor/core/RemarkOverlayLayer.svelte
@@ -73,6 +73,31 @@
     }
   });
 
+  $effect(() => {
+    const nodeId = openGroupNodeId;
+    if (!nodeId) {
+      editor.remarkHighlightTarget = null;
+      return;
+    }
+
+    const group = remarkGroups.find((item) => item.nodeId === nodeId);
+    const target =
+      group?.remarks[0] ??
+      (editor.currentBlock?.nodeId === nodeId
+        ? {
+            pageIdx: editor.currentBlock.pageIdx,
+            bounds: editor.currentBlock.bounds,
+          }
+        : null);
+
+    if (target) {
+      editor.highlightRemark(target);
+      return;
+    }
+
+    editor.remarkHighlightTarget = null;
+  });
+
   const displayZoom = $derived(editor.layout?.layoutMode.type === 'paginated' ? editor.displayZoom : 1);
   const pageGap = $derived(editor.layout?.layoutMode.type === 'paginated' ? PAGE_GAP * displayZoom : 0);
   const currentBlockHasRemarks = $derived(editor.currentBlock ? remarkGroups.some((g) => g.nodeId === editor.currentBlock?.nodeId) : false);

--- a/apps/website/src/lib/components/editor/core/RemarkPopover.svelte
+++ b/apps/website/src/lib/components/editor/core/RemarkPopover.svelte
@@ -54,6 +54,9 @@
   let textareaEl = $state<HTMLTextAreaElement>();
   let listEl = $state<HTMLDivElement>();
   let headerMenuOpen = $state(false);
+  let activeRemarkId = $state<string | null>(null);
+  let wasOpen = false;
+  let shouldJumpToActiveOnOpen = false;
   const hasText = $derived($state.eager(newRemarkText).trim().length > 0);
   const hasContent = $derived($state.eager(newRemarkText).length > 0);
 
@@ -65,13 +68,23 @@
       tick()
         .then(tick)
         .then(() => {
-          if (listEl) {
+          if (listEl && !activeRemarkId) {
             listEl.scrollTop = listEl.scrollHeight;
           }
           textareaEl?.focus();
         });
     }
   });
+
+  function scrollToActiveRemark(remarkId: string, behavior: ScrollBehavior) {
+    const el = listEl?.querySelector(`[data-remark-id="${remarkId}"]`);
+    if (!(el instanceof HTMLElement) || !listEl) return;
+
+    const listRect = listEl.getBoundingClientRect();
+    const elRect = el.getBoundingClientRect();
+    const scrollTarget = el.offsetTop - listRect.height / 2 + elRect.height / 2;
+    listEl.scrollTo({ top: Math.max(0, scrollTarget), behavior });
+  }
 
   const { anchor, floating } = createFloatingActions({
     placement: 'bottom-start',
@@ -130,6 +143,7 @@
     if (!open) {
       newRemarkText = '';
       dirtyRemarkIds.clear();
+      activeRemarkId = null;
     }
   });
 
@@ -163,51 +177,46 @@
       });
   }
 
-  let wasOpenBeforeFocus = $state(false);
-  $effect.pre(() => {
-    if (!editor.remarkFocus) {
-      wasOpenBeforeFocus = open;
+  $effect(() => {
+    if (open && !wasOpen) {
+      shouldJumpToActiveOnOpen = true;
+    } else if (!open && wasOpen) {
+      shouldJumpToActiveOnOpen = false;
     }
+    wasOpen = open;
   });
 
   $effect(() => {
     const focus = editor.remarkFocus;
     if (focus && open && focus.nodeId === nodeId) {
-      tick().then(() => {
-        const el = listEl?.querySelector(`[data-remark-id="${focus.remarkId}"]`);
-        if (el instanceof HTMLElement && listEl) {
-          const listRect = listEl.getBoundingClientRect();
-          const elRect = el.getBoundingClientRect();
-          const scrollTarget = el.offsetTop - listRect.height / 2 + elRect.height / 2;
-          listEl.scrollTo({ top: Math.max(0, scrollTarget), behavior: 'smooth' });
-
-          const shake = () => {
-            for (const animation of el.getAnimations()) {
-              animation.cancel();
-            }
-
-            el.animate(
-              [
-                { transform: 'translateX(0)' },
-                { transform: 'translateX(-3px)' },
-                { transform: 'translateX(3px)' },
-                { transform: 'translateX(-2px)' },
-                { transform: 'translateX(2px)' },
-                { transform: 'translateX(0)' },
-              ],
-              { duration: 520, iterations: 1, easing: 'linear' },
-            );
-          };
-
-          if (wasOpenBeforeFocus) {
-            shake();
-          } else {
-            setTimeout(shake, 300);
-          }
-        }
+      if (focus.source === 'panel-group' && !focus.remarkId) {
+        activeRemarkId = null;
+        shouldJumpToActiveOnOpen = false;
         editor.remarkFocus = null;
-      });
+        return;
+      }
+
+      if (focus.source !== 'panel-group' && focus.remarkId && activeRemarkId === focus.remarkId) {
+        editor.remarkFocus = null;
+        tryClose();
+        return;
+      }
+
+      activeRemarkId = focus.remarkId ?? null;
+      editor.remarkFocus = null;
     }
+  });
+
+  $effect(() => {
+    const remarkId = activeRemarkId;
+    if (!open || !remarkId) return;
+
+    tick().then(() => {
+      if (!open || activeRemarkId !== remarkId) return;
+      scrollToActiveRemark(remarkId, shouldJumpToActiveOnOpen ? 'auto' : 'smooth');
+      shouldJumpToActiveOnOpen = false;
+      textareaEl?.focus();
+    });
   });
 </script>
 
@@ -369,17 +378,25 @@
         class={css({
           display: 'flex',
           flexDirection: 'column',
-          gap: '8px',
-          paddingY: '8px',
-          paddingLeft: '10px',
-          paddingRight: '10px',
+          gap: '2px',
           maxHeight: '300px',
           overflowX: 'hidden',
           overflowY: 'auto',
         })}
       >
         {#each remarks as remark (remark.remarkId)}
-          <div class={css({ marginX: '-10px', marginY: '-6px', paddingX: '10px', paddingY: '6px' })} data-remark-id={remark.remarkId}>
+          <div
+            class={css(
+              {
+                paddingX: '10px',
+                paddingY: '8px',
+                borderRadius: '8px',
+                transition: 'colors',
+              },
+              activeRemarkId === remark.remarkId && { backgroundColor: 'surface.muted' },
+            )}
+            data-remark-id={remark.remarkId}
+          >
             <RemarkCard
               createdAt={remark.createdAt}
               {editor}

--- a/apps/website/src/lib/editor/editor.svelte.ts
+++ b/apps/website/src/lib/editor/editor.svelte.ts
@@ -273,7 +273,8 @@ export class Editor {
   interactiveOverlays: InteractiveOverlay[] = [];
 
   remarkOverlays = $state<RemarkOverlay[]>([]);
-  remarkFocus = $state<{ nodeId: string; remarkId: string } | null>(null);
+  remarkFocus = $state<{ nodeId: string; remarkId?: string; source?: 'panel-item' | 'panel-group' } | null>(null);
+  remarkHighlightTarget = $state<{ pageIdx: number; bounds: Rect } | null>(null);
   currentBlock = $state<{ nodeId: string; pageIdx: number; bounds: Rect } | null>(null);
 
   repasteAsTextEnabled = $state(false);
@@ -702,6 +703,13 @@ export class Editor {
         scroller.scrollTo({ top: Math.max(0, targetScroll), behavior: 'smooth' });
       }
     }
+  }
+
+  highlightRemark(remark: Pick<RemarkOverlay, 'pageIdx' | 'bounds'>): void {
+    this.remarkHighlightTarget = {
+      pageIdx: remark.pageIdx,
+      bounds: { ...remark.bounds },
+    };
   }
 
   handleRepasteAsText(): void {

--- a/apps/website/src/lib/editor/slate.ts
+++ b/apps/website/src/lib/editor/slate.ts
@@ -40,6 +40,9 @@ export type RemarkOverlay = {
   createdAt: number;
   pageIdx: number;
   bounds: Rect;
+  nodeType: string;
+  isTextblock: boolean;
+  nodeText: string;
 };
 
 export type InteractiveOverlay = {
@@ -883,7 +886,16 @@ function readRemarkOverlays(view: DataView, offset: number, count: number): Rema
     };
     pos += 16;
 
-    overlays.push({ nodeId, remarkId, userId, text, createdAt, pageIdx, bounds });
+    const { value: nodeType, end: afterNodeType } = readStr(view, pos);
+    pos = afterNodeType;
+
+    const isTextblock = view.getUint32(pos, true) !== 0;
+    pos += 4;
+
+    const { value: nodeText, end: afterNodeText } = readStr(view, pos);
+    pos = afterNodeText;
+
+    overlays.push({ nodeId, remarkId, userId, text, createdAt, pageIdx, bounds, nodeType, isTextblock, nodeText });
   }
   return overlays;
 }

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@document-panel/DocumentPanelRemark.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@document-panel/DocumentPanelRemark.svelte
@@ -2,6 +2,8 @@
   import { css } from '@typie/styled-system/css';
   import { center, flex } from '@typie/styled-system/patterns';
   import { Icon } from '@typie/ui/components';
+  import { SvelteMap } from 'svelte/reactivity';
+  import ChevronDownIcon from '~icons/lucide/chevron-down';
   import MessageSquareTextIcon from '~icons/lucide/message-square-text';
   import DocumentPanelRemarkItem from './DocumentPanelRemarkItem.svelte';
   import type { Editor } from '$lib/editor/editor.svelte';
@@ -12,6 +14,7 @@
   };
 
   let { editor }: Props = $props();
+  let collapsedGroupsByNodeId = $state<Record<string, boolean>>({});
 
   const sortedRemarks = $derived(
     editor.remarkOverlays.toSorted((a, b) => {
@@ -21,7 +24,64 @@
     }),
   );
 
-  function focusRemark(remark: RemarkOverlay) {
+  type RemarkGroup = {
+    nodeId: string;
+    remarks: RemarkOverlay[];
+  };
+
+  const REMARK_NODE_LABELS: Record<string, string> = {
+    image: '이미지',
+    file: '파일',
+    embed: '임베드',
+    archived: '보관된 블록',
+    horizontal_rule: '구분선',
+    blockquote: '인용구',
+    callout: '강조',
+    bullet_list: '순서 없는 목록',
+    ordered_list: '순서 있는 목록',
+    fold: '접기',
+    table: '표',
+  };
+
+  const remarkGroups = $derived.by(() => {
+    const groups = new SvelteMap<string, RemarkGroup>();
+    const orderedGroups: RemarkGroup[] = [];
+
+    for (const remark of sortedRemarks) {
+      const existing = groups.get(remark.nodeId);
+      if (existing) {
+        existing.remarks.push(remark);
+        continue;
+      }
+
+      const group: RemarkGroup = {
+        nodeId: remark.nodeId,
+        remarks: [remark],
+      };
+      groups.set(remark.nodeId, group);
+      orderedGroups.push(group);
+    }
+
+    return orderedGroups;
+  });
+
+  const allGroupsCollapsed = $derived(
+    remarkGroups.length > 0 && remarkGroups.every((group) => collapsedGroupsByNodeId[group.nodeId] === true),
+  );
+
+  function getGroupTitle(group: RemarkGroup): string {
+    const primary = group.remarks[0];
+    if (!primary) return '';
+
+    if (primary.isTextblock) {
+      const normalized = primary.nodeText.replaceAll(/\s+/g, ' ').trim();
+      return normalized.length > 0 ? normalized : '빈 텍스트';
+    }
+
+    return REMARK_NODE_LABELS[primary.nodeType] ?? '';
+  }
+
+  function scrollToRemark(remark: RemarkOverlay) {
     const pageEl = editor.pageContainerEls[remark.pageIdx];
     const scroller = editor.scrollContainerEl;
     if (pageEl && scroller) {
@@ -30,7 +90,34 @@
       const targetY = pageRect.top + remark.bounds.y - scrollerRect.top + scroller.scrollTop;
       scroller.scrollTo({ top: Math.max(0, targetY - scroller.clientHeight / 3), behavior: 'smooth' });
     }
-    editor.remarkFocus = { nodeId: remark.nodeId, remarkId: remark.remarkId };
+  }
+
+  function focusRemark(remark: RemarkOverlay, source: 'panel-item' | 'panel-group' = 'panel-item') {
+    scrollToRemark(remark);
+    editor.remarkFocus = { nodeId: remark.nodeId, remarkId: remark.remarkId, source };
+  }
+
+  function focusRemarkGroup(group: RemarkGroup) {
+    const primary = group.remarks[0];
+    if (!primary) return;
+    scrollToRemark(primary);
+    editor.remarkFocus = { nodeId: primary.nodeId, source: 'panel-group' };
+  }
+
+  function toggleGroup(nodeId: string) {
+    collapsedGroupsByNodeId = {
+      ...collapsedGroupsByNodeId,
+      [nodeId]: !collapsedGroupsByNodeId[nodeId],
+    };
+  }
+
+  function toggleAllGroups() {
+    const nextCollapsed = !allGroupsCollapsed;
+    const next = { ...collapsedGroupsByNodeId };
+    for (const group of remarkGroups) {
+      next[group.nodeId] = nextCollapsed;
+    }
+    collapsedGroupsByNodeId = next;
   }
 </script>
 
@@ -63,6 +150,22 @@
         </div>
       {/if}
     </div>
+
+    {#if remarkGroups.length >= 2}
+      <button
+        class={css({
+          fontSize: '13px',
+          fontWeight: 'medium',
+          color: 'text.faint',
+          transition: 'common',
+          _hover: { color: 'text.subtle' },
+        })}
+        onclick={toggleAllGroups}
+        type="button"
+      >
+        {allGroupsCollapsed ? '모두 열기' : '모두 닫기'}
+      </button>
+    {/if}
   </div>
 
   <div
@@ -96,8 +199,95 @@
         <p class={css({ fontSize: '13px', color: 'text.faint', textAlign: 'center' })}>아직 코멘트가 없어요</p>
       </div>
     {:else}
-      {#each sortedRemarks as remark (remark.remarkId)}
-        <DocumentPanelRemarkItem onclick={() => focusRemark(remark)} {remark} />
+      {#each remarkGroups as group (group.nodeId)}
+        {@const collapsed = collapsedGroupsByNodeId[group.nodeId] === true}
+        <div class={flex({ flexDirection: 'column' })}>
+          <div
+            class={css({
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: '8px',
+              width: 'full',
+              height: '36px',
+              backgroundColor: 'surface.subtle',
+              paddingX: '20px',
+              borderBottomWidth: '1px',
+              borderColor: 'surface.muted',
+            })}
+          >
+            <button
+              class={css({
+                display: 'flex',
+                alignItems: 'center',
+                flexGrow: '1',
+                minWidth: '0',
+                fontSize: '12px',
+                fontWeight: 'semibold',
+                color: 'text.subtle',
+                borderWidth: '0',
+                backgroundColor: 'transparent',
+                textAlign: 'left',
+                padding: '0',
+                cursor: 'pointer',
+                transition: 'common',
+                _hover: { color: 'text.default' },
+              })}
+              onclick={() => focusRemarkGroup(group)}
+              title={getGroupTitle(group)}
+              type="button"
+            >
+              <span
+                class={css({
+                  display: 'block',
+                  width: 'full',
+                  overflow: 'hidden',
+                  whiteSpace: 'nowrap',
+                  textOverflow: 'ellipsis',
+                })}
+              >
+                {getGroupTitle(group)}
+              </span>
+            </button>
+            <button
+              class={css({
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                height: '28px',
+                minWidth: '28px',
+                paddingX: '12px',
+                gap: '2px',
+                borderRadius: '8px',
+                borderWidth: '0',
+                backgroundColor: 'transparent',
+                color: 'text.subtle',
+                cursor: 'pointer',
+                transition: 'common',
+                _hover: { backgroundColor: 'surface.muted', color: 'text.default' },
+              })}
+              aria-label={collapsed ? '그룹 펼치기' : '그룹 접기'}
+              onclick={() => toggleGroup(group.nodeId)}
+              type="button"
+            >
+              {#if group.remarks.length >= 2}
+                <span class={css({ fontSize: '11px', fontWeight: 'semibold', lineHeight: 'none' })}>{group.remarks.length}</span>
+              {/if}
+              <span
+                style:transform={collapsed ? 'rotate(-90deg)' : 'rotate(0deg)'}
+                class={css({ display: 'flex', transition: 'transform' })}
+              >
+                <Icon icon={ChevronDownIcon} size={14} />
+              </span>
+            </button>
+          </div>
+
+          {#if !collapsed}
+            {#each group.remarks as remark (remark.remarkId)}
+              <DocumentPanelRemarkItem onclick={() => focusRemark(remark, 'panel-item')} {remark} />
+            {/each}
+          {/if}
+        </div>
       {/each}
     {/if}
   </div>

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@document-panel/DocumentPanelRemarkItem.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@document-panel/DocumentPanelRemarkItem.svelte
@@ -33,6 +33,7 @@
 <button
   class={css({
     display: 'flex',
+    width: 'full',
     gap: '8px',
     paddingX: '16px',
     paddingY: '10px',
@@ -110,7 +111,6 @@
         whiteSpace: 'pre-wrap',
         wordBreak: 'break-word',
         lineClamp: 2,
-        minHeight: '[2lh]',
       })}
     >
       {remark.text}

--- a/crates/editor/src/runtime/cmd.rs
+++ b/crates/editor/src/runtime/cmd.rs
@@ -64,4 +64,7 @@ pub struct RemarkOverlay {
     pub text: String,
     pub created_at: i64,
     pub bounds: Rect,
+    pub node_type: String,
+    pub is_textblock: bool,
+    pub node_text: String,
 }

--- a/crates/editor/src/runtime/mod.rs
+++ b/crates/editor/src/runtime/mod.rs
@@ -1580,6 +1580,21 @@ impl Runtime {
         let mut overlays = Vec::new();
         for (node_id, remark) in self.doc().all_remarks() {
             if let Some(nb) = find_node_bounds(self.doc(), self.pages(), node_id) {
+                let (node_type, is_textblock, node_text) = self
+                    .doc()
+                    .node(node_id)
+                    .and_then(|node| {
+                        let spec = node.spec()?;
+                        let is_textblock = spec.is_textblock(self.doc().schema());
+                        let node_text = if is_textblock {
+                            self.doc().get_block_text(node_id)
+                        } else {
+                            String::new()
+                        };
+                        Some((spec.name.to_string(), is_textblock, node_text))
+                    })
+                    .unwrap_or_else(|| ("unknown".to_string(), false, String::new()));
+
                 overlays.push(cmd::RemarkOverlay {
                     page_idx: nb.page_idx,
                     node_id,
@@ -1593,6 +1608,9 @@ impl Runtime {
                         width: nb.width,
                         height: nb.height,
                     },
+                    node_type,
+                    is_textblock,
+                    node_text,
                 });
             }
         }

--- a/crates/editor/src/runtime/slate.rs
+++ b/crates/editor/src/runtime/slate.rs
@@ -921,6 +921,9 @@ impl Slab {
             ]);
             self.write_u32_slice(&[o.page_idx as u32]);
             self.write_f32_slice(&[o.bounds.x, o.bounds.y, o.bounds.width, o.bounds.height]);
+            self.write_str(&o.node_type);
+            self.write_u32_slice(&[o.is_textblock as u32]);
+            self.write_str(&o.node_text);
         }
         slate.remarks_offset = start;
         slate.remarks_count = overlays.len() as u32;

--- a/crates/editor/src/schema/mod.rs
+++ b/crates/editor/src/schema/mod.rs
@@ -27,6 +27,12 @@ impl Schema {
     }
 
     pub fn add_node(&mut self, node_type: NodeType, spec: NodeSpec) {
+        assert!(
+            !spec.name.is_empty(),
+            "Node {:?} must define NodeSpec.name",
+            node_type
+        );
+
         if let Some(item_type) = spec.promote_item_type_on_delete {
             assert!(
                 spec.content.repeated_single_type() == Some(item_type),
@@ -73,6 +79,7 @@ impl Default for Schema {
         schema.add_node(
             NodeType::Root,
             NodeSpec {
+                name: "root",
                 content: content_expr!([((Paragraph | Image | File | Embed | Archived | Blockquote | Callout | BulletList | OrderedList | HorizontalRule | Fold | Table)*), (Paragraph)]),
                 ..Default::default()
             },
@@ -81,6 +88,7 @@ impl Default for Schema {
         schema.add_node(
             NodeType::Blockquote,
             NodeSpec {
+                name: "blockquote",
                 content: content_expr!((Paragraph | BulletList | OrderedList)+),
                 block_selection_boundary_mode: Some(BlockSelectionBoundaryMode::FrontOnly),
                 ..Default::default()
@@ -90,6 +98,7 @@ impl Default for Schema {
         schema.add_node(
             NodeType::Paragraph,
             NodeSpec {
+                name: "paragraph",
                 content: content_expr!([((Text | HardBreak)*), (PageBreak?)]),
                 styles: Some(&[
                     StyleType::BackgroundColor,
@@ -111,6 +120,7 @@ impl Default for Schema {
         schema.add_node(
             NodeType::Text,
             NodeSpec {
+                name: "text",
                 inline: true,
                 ..Default::default()
             },
@@ -119,6 +129,7 @@ impl Default for Schema {
         schema.add_node(
             NodeType::Image,
             NodeSpec {
+                name: "image",
                 selectable: true,
                 external: true,
                 ..Default::default()
@@ -128,6 +139,7 @@ impl Default for Schema {
         schema.add_node(
             NodeType::File,
             NodeSpec {
+                name: "file",
                 selectable: true,
                 external: true,
                 ..Default::default()
@@ -137,6 +149,7 @@ impl Default for Schema {
         schema.add_node(
             NodeType::Embed,
             NodeSpec {
+                name: "embed",
                 selectable: true,
                 external: true,
                 ..Default::default()
@@ -146,6 +159,7 @@ impl Default for Schema {
         schema.add_node(
             NodeType::Archived,
             NodeSpec {
+                name: "archived",
                 selectable: true,
                 external: true,
                 ..Default::default()
@@ -155,6 +169,7 @@ impl Default for Schema {
         schema.add_node(
             NodeType::HardBreak,
             NodeSpec {
+                name: "hard_break",
                 inline: true,
                 ..Default::default()
             },
@@ -163,6 +178,7 @@ impl Default for Schema {
         schema.add_node(
             NodeType::PageBreak,
             NodeSpec {
+                name: "page_break",
                 inline: true,
                 grandparent_must_be: Some(NodeType::Root),
                 ..Default::default()
@@ -172,6 +188,7 @@ impl Default for Schema {
         schema.add_node(
             NodeType::HorizontalRule,
             NodeSpec {
+                name: "horizontal_rule",
                 selectable: true,
                 block_selection_boundary_mode: Some(BlockSelectionBoundaryMode::Both),
                 ..Default::default()
@@ -181,6 +198,7 @@ impl Default for Schema {
         schema.add_node(
             NodeType::BulletList,
             NodeSpec {
+                name: "bullet_list",
                 content: content_expr!(ListItem+),
                 promote_item_type_on_delete: Some(NodeType::ListItem),
                 ..Default::default()
@@ -190,6 +208,7 @@ impl Default for Schema {
         schema.add_node(
             NodeType::OrderedList,
             NodeSpec {
+                name: "ordered_list",
                 content: content_expr!(ListItem+),
                 promote_item_type_on_delete: Some(NodeType::ListItem),
                 ..Default::default()
@@ -199,6 +218,7 @@ impl Default for Schema {
         schema.add_node(
             NodeType::ListItem,
             NodeSpec {
+                name: "list_item",
                 content: content_expr!([(Paragraph), ((BulletList | OrderedList) *)]),
                 structural: true,
                 block_selection_boundary_mode: Some(BlockSelectionBoundaryMode::FrontOnly),
@@ -209,6 +229,7 @@ impl Default for Schema {
         schema.add_node(
             NodeType::Fold,
             NodeSpec {
+                name: "fold",
                 content: content_expr!([(FoldTitle), (FoldContent)]),
                 isolating: true,
                 block_selection_boundary_mode: Some(BlockSelectionBoundaryMode::FrontOrBack),
@@ -219,6 +240,7 @@ impl Default for Schema {
         schema.add_node(
             NodeType::FoldTitle,
             NodeSpec {
+                name: "fold_title",
                 content: content_expr!(Text*),
                 isolating: true,
                 structural: true,
@@ -229,6 +251,7 @@ impl Default for Schema {
         schema.add_node(
             NodeType::FoldContent,
             NodeSpec {
+                name: "fold_content",
                 content: content_expr!((Paragraph | Image | File | Embed | Archived | Blockquote | Callout | BulletList | OrderedList | HorizontalRule | Fold | Table)+),
                 isolating: true,
                 structural: true,
@@ -239,6 +262,7 @@ impl Default for Schema {
         schema.add_node(
             NodeType::Callout,
             NodeSpec {
+                name: "callout",
                 content: content_expr!((Paragraph | BulletList | OrderedList)+),
                 block_selection_boundary_mode: Some(BlockSelectionBoundaryMode::FrontOnly),
                 ..Default::default()
@@ -248,6 +272,7 @@ impl Default for Schema {
         schema.add_node(
             NodeType::Table,
             NodeSpec {
+                name: "table",
                 content: content_expr!(TableRow+),
                 isolating: true,
                 block_selection_boundary_mode: Some(BlockSelectionBoundaryMode::FrontOrBack),
@@ -259,6 +284,7 @@ impl Default for Schema {
         schema.add_node(
             NodeType::TableRow,
             NodeSpec {
+                name: "table_row",
                 content: content_expr!(TableCell+),
                 structural: true,
                 ..Default::default()
@@ -268,6 +294,7 @@ impl Default for Schema {
         schema.add_node(
             NodeType::TableCell,
             NodeSpec {
+                name: "table_cell",
                 content: content_expr!((Paragraph | Image | File | Embed | Archived | Blockquote | Callout | BulletList | OrderedList | HorizontalRule | Fold)+),
                 isolating: true,
                 structural: true,

--- a/crates/editor/src/schema/spec.rs
+++ b/crates/editor/src/schema/spec.rs
@@ -11,6 +11,7 @@ pub enum BlockSelectionBoundaryMode {
 
 #[derive(Debug, Clone)]
 pub struct NodeSpec {
+    pub name: &'static str,
     pub content: ContentExpr,
     pub styles: Option<&'static [StyleType]>,
     pub annotations: Option<&'static [AnnotationType]>,
@@ -52,6 +53,7 @@ impl NodeSpec {
 impl Default for NodeSpec {
     fn default() -> Self {
         Self {
+            name: "",
             content: ContentExpr::Empty,
             styles: None,
             annotations: None,


### PR DESCRIPTION
웹
- 코멘트 붙은 노드별 그룹으로 표시
- 그룹 헤더에 블록 타입 또는 텍스트 발췌 표시
- 그룹을 열고 닫을 수 있음
- 그룹이 2개 이상일 때 '모두 열기' / '모두 닫기' 버튼
- 액티브 코멘트 shake 애니메이션 대신 앱처럼 옅은 회색 하이라이트
- 코멘트 팝오버가 열릴 때 액티브 코멘트로 스크롤 jump
- 코멘트 팝오버가 열릴 때부터 닫힐 때까지 본문에서 해당 블록에 하이라이트

앱
- 본문 하이라이트는 액티브 코멘트가 해제될 때까지 사라지지 않게 함
- '현재 위치' 탭으로 전환 시 현재 위치 블록에 본문 하이라이트 (현재 위치에 코멘트가 없어도)
- '전체' 탭으로 전환 시 액티브 코멘트 해제
- '전체' 탭에서 코멘트 오른쪽에 블록 타입 또는 텍스트 발췌 표시

앱 바텀 시트
- 기본적으로 소프트웨어 키보드 높이를 포함해서 최대 높이를 제한하도록 함
- resizeToAvoidBottomInset를 옵션에서 제외하고 무조건 함
- 찾기/코멘트/맞춤법/AI피드백 바텀 시트에서 키보드 높이 + 바텀 시트를 제외한 에디터 가시 영역 내에서 오버레이가 가운데 오도록 스크롤
