### PR TITLE
태블릿에서 양쪽 여백 영역에서 스크롤 가능

### DIFF
--- a/apps/mobile/lib/widgets/responsive_container.dart
+++ b/apps/mobile/lib/widgets/responsive_container.dart
@@ -1,4 +1,6 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 
 class ResponsiveContainer extends StatelessWidget {
   const ResponsiveContainer({required this.child, super.key, this.maxWidth, this.alignment = Alignment.topCenter});
@@ -17,11 +19,143 @@ class ResponsiveContainer extends StatelessWidget {
       return child;
     }
 
-    return Align(
-      alignment: alignment,
-      child: ConstrainedBox(
-        constraints: BoxConstraints(maxWidth: effectiveMaxWidth),
-        child: child,
+    final gutterWidth = (screenWidth - effectiveMaxWidth) / 2;
+
+    return Stack(
+      children: [
+        Align(
+          alignment: alignment,
+          child: ConstrainedBox(
+            constraints: BoxConstraints(maxWidth: effectiveMaxWidth),
+            child: child,
+          ),
+        ),
+        if (gutterWidth > 0)
+          Positioned.fill(
+            child: Row(
+              children: [
+                _ScrollForwardingGutter(width: gutterWidth, scopeContext: context),
+                const Spacer(),
+                _ScrollForwardingGutter(width: gutterWidth, scopeContext: context),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _ScrollForwardingGutter extends HookWidget {
+  const _ScrollForwardingGutter({required this.width, required this.scopeContext});
+
+  final double width;
+  final BuildContext scopeContext;
+
+  @override
+  Widget build(BuildContext context) {
+    final drag = useRef<Drag?>(null);
+
+    ScrollPosition? resolveFromDescendantScrollables() {
+      final rootElement = scopeContext as Element;
+      final candidates = <ScrollPosition>[];
+
+      void visit(Element element) {
+        if (element is StatefulElement && element.state is ScrollableState) {
+          final state = element.state as ScrollableState;
+          final position = state.position;
+          if (position.axis == Axis.vertical) {
+            candidates.add(position);
+          }
+        }
+        element.visitChildren(visit);
+      }
+
+      rootElement.visitChildren(visit);
+      if (candidates.isEmpty) {
+        return null;
+      }
+
+      ScrollPosition? active;
+      var maxViewportDimension = -1.0;
+      for (final position in candidates) {
+        if (position.viewportDimension > maxViewportDimension) {
+          maxViewportDimension = position.viewportDimension;
+          active = position;
+        }
+      }
+
+      return active;
+    }
+
+    ScrollPosition? resolveFromPrimaryScrollController() {
+      final controller = PrimaryScrollController.maybeOf(context);
+      if (controller == null || !controller.hasClients) {
+        return null;
+      }
+
+      ScrollPosition? active;
+      var maxViewportDimension = -1.0;
+      for (final position in controller.positions) {
+        if (position.axis != Axis.vertical) {
+          continue;
+        }
+        if (position.viewportDimension > maxViewportDimension) {
+          maxViewportDimension = position.viewportDimension;
+          active = position;
+        }
+      }
+
+      return active;
+    }
+
+    ScrollPosition? resolveScrollPosition() {
+      return resolveFromDescendantScrollables() ?? resolveFromPrimaryScrollController();
+    }
+
+    void disposeDrag() {
+      drag.value = null;
+    }
+
+    void handleDragStart(DragStartDetails details) {
+      drag.value?.cancel();
+
+      final position = resolveScrollPosition();
+      if (position == null) {
+        disposeDrag();
+        return;
+      }
+
+      drag.value = position.drag(details, disposeDrag);
+    }
+
+    void handleDragUpdate(DragUpdateDetails details) {
+      drag.value?.update(details);
+    }
+
+    void handleDragEnd(DragEndDetails details) {
+      drag.value?.end(details);
+      disposeDrag();
+    }
+
+    void handleDragCancel() {
+      drag.value?.cancel();
+      disposeDrag();
+    }
+
+    useEffect(() {
+      return () {
+        drag.value?.cancel();
+      };
+    }, const []);
+
+    return SizedBox(
+      width: width,
+      child: GestureDetector(
+        behavior: HitTestBehavior.translucent,
+        onVerticalDragStart: handleDragStart,
+        onVerticalDragUpdate: handleDragUpdate,
+        onVerticalDragEnd: handleDragEnd,
+        onVerticalDragCancel: handleDragCancel,
       ),
     );
   }

--- a/apps/mobile/test/widgets/responsive_container_test.dart
+++ b/apps/mobile/test/widgets/responsive_container_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:typie/widgets/responsive_container.dart';
+
+void main() {
+  testWidgets('side gutter drags scroll the primary scroll view', (tester) async {
+    final controller = ScrollController();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: PrimaryScrollController(
+            controller: controller,
+            child: ResponsiveContainer(
+              maxWidth: 600,
+              child: SingleChildScrollView(
+                controller: controller,
+                physics: const AlwaysScrollableScrollPhysics(),
+                child: const SizedBox(height: 2000),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(controller.offset, 0);
+
+    final origin = tester.getTopLeft(find.byType(ResponsiveContainer));
+
+    await tester.dragFrom(origin + const Offset(12, 300), const Offset(0, -240));
+    await tester.pumpAndSettle();
+
+    expect(controller.offset, greaterThan(0));
+  });
+
+  testWidgets('side gutter drags do not throw when primary controller has multiple positions', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: ResponsiveContainer(
+            maxWidth: 600,
+            child: Column(
+              children: [
+                Expanded(
+                  child: SingleChildScrollView(
+                    primary: true,
+                    physics: AlwaysScrollableScrollPhysics(),
+                    child: SizedBox(height: 1600),
+                  ),
+                ),
+                Expanded(
+                  child: SingleChildScrollView(
+                    primary: true,
+                    physics: AlwaysScrollableScrollPhysics(),
+                    child: SizedBox(height: 1600),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final origin = tester.getTopLeft(find.byType(ResponsiveContainer));
+
+    await tester.dragFrom(origin + const Offset(12, 300), const Offset(0, -240));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('side gutter drags scroll an explicit controller even when primary is unused', (tester) async {
+    final controller = ScrollController();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ResponsiveContainer(
+            maxWidth: 600,
+            child: SingleChildScrollView(
+              controller: controller,
+              primary: false,
+              physics: const AlwaysScrollableScrollPhysics(),
+              child: const SizedBox(height: 2000),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(controller.offset, 0);
+
+    final origin = tester.getTopLeft(find.byType(ResponsiveContainer));
+
+    await tester.dragFrom(origin + const Offset(12, 300), const Offset(0, -240));
+    await tester.pumpAndSettle();
+
+    expect(controller.offset, greaterThan(0));
+  });
+}


### PR DESCRIPTION
typ-532

ResponsiveContainer의 양쪽 여백이 스크롤 제스처를 내부에 전달