### PR TITLE
앱 frame sync 회귀 수정

### DIFF
--- a/apps/mobile/lib/screens/native_editor/view/editor.dart
+++ b/apps/mobile/lib/screens/native_editor/view/editor.dart
@@ -544,7 +544,24 @@ class EditorView extends HookWidget {
       };
     }
 
-    void applyCursorScrollAndVisual(CursorInfo nextCursor, {required bool typewriter}) {
+    void applyCursorScrollAndVisual(
+      CursorInfo nextCursor, {
+      required bool typewriter,
+      bool synchronizeWithRender = true,
+    }) {
+      final shouldSynchronizeWithRender =
+          synchronizeWithRender &&
+          typewriter &&
+          !identical(presentedViewport.value.renderVersion, controller.state.renderVersion);
+      if (shouldSynchronizeWithRender) {
+        queueRenderSynchronizedCursorUpdate(
+          nextCursor: nextCursor,
+          typewriter: true,
+          targetPageIdx: nextCursor.pageIdx,
+        );
+        return;
+      }
+
       if (canApplyCursorScrollNow()) {
         pendingScroll.value = null;
         pendingScrollPageIdx.value = null;
@@ -654,9 +671,14 @@ class EditorView extends HookWidget {
 
         if (pendingMode != null) {
           final useTypewriter = pref.typewriterEnabled && pendingMode == ScrollMode.typewriter;
+          final waitForCursorUpdate = controller.pendingScrollWaitForCursorUpdate;
           typewriterRecoveryPending.value = useTypewriter;
           controller.clearPendingScroll();
-          applyCursorScrollAndVisual(nextCursor, typewriter: useTypewriter);
+          applyCursorScrollAndVisual(
+            nextCursor,
+            typewriter: useTypewriter,
+            synchronizeWithRender: !waitForCursorUpdate,
+          );
           return;
         }
 


### PR DESCRIPTION
- 초기 로드 시 커서 스크롤 복원 기능을 유지하면서
- cursor, scroll, line highlight, render의 frame sync 유지