### PR TITLE
이미지, 파일 assets를 아직 얻을 수 없을 때 로딩 중으로 보여주기

### DIFF
--- a/apps/mobile/lib/screens/native_editor/external/file.dart
+++ b/apps/mobile/lib/screens/native_editor/external/file.dart
@@ -38,6 +38,7 @@ class FileWidget extends HookWidget {
 
     final hasFile = asset != null || inflight != null;
     final isUploading = inflight != null && asset == null;
+    final isResolvingAsset = fileData.id != null && asset == null && inflight == null;
 
     final displayName = asset?.name ?? inflight?.name ?? '파일';
     final displaySize = _formatFileSize(asset?.size ?? inflight?.size);
@@ -53,7 +54,7 @@ class FileWidget extends HookWidget {
     }, [currentUploadId, inflight, asset]);
 
     if (!hasFile) {
-      return _buildPlaceholder(context);
+      return _buildPlaceholder(context, isResolvingAsset: isResolvingAsset);
     }
 
     return Center(
@@ -115,7 +116,7 @@ class FileWidget extends HookWidget {
     );
   }
 
-  Widget _buildPlaceholder(BuildContext context) {
+  Widget _buildPlaceholder(BuildContext context, {required bool isResolvingAsset}) {
     return Container(
       height: 48,
       decoration: BoxDecoration(color: context.colors.surfaceMuted, borderRadius: BorderRadius.circular(4)),
@@ -127,12 +128,18 @@ class FileWidget extends HookWidget {
             const SizedBox(width: 12),
             Expanded(
               child: Text(
-                '파일',
+                isResolvingAsset ? '파일을 불러오는 중...' : '파일',
                 style: TextStyle(fontSize: 14, color: context.colors.textDisabled),
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
               ),
             ),
+            if (isResolvingAsset)
+              SizedBox(
+                width: 16,
+                height: 16,
+                child: CircularProgressIndicator(strokeWidth: 2, color: context.colors.textDisabled),
+              ),
           ],
         ),
       ),

--- a/apps/mobile/lib/screens/native_editor/external/image.dart
+++ b/apps/mobile/lib/screens/native_editor/external/image.dart
@@ -55,6 +55,7 @@ class ImageWidget extends HookWidget {
 
     final hasImage = asset != null || inflight != null;
     final isUploading = inflight != null && asset == null;
+    final isResolvingAsset = imageData.id != null && asset == null && inflight == null;
 
     final proportion = imageData.proportion;
     final boundsWidth = element.bounds.width;
@@ -108,7 +109,7 @@ class ImageWidget extends HookWidget {
     }, const []);
 
     if (!hasImage) {
-      return _buildPlaceholder(context);
+      return _buildPlaceholder(context, isResolvingAsset: isResolvingAsset);
     }
 
     final imageHeight = _calculateHeight(asset, inflight, imageWidth);
@@ -353,7 +354,7 @@ class ImageWidget extends HookWidget {
     return const SizedBox.shrink();
   }
 
-  Widget _buildPlaceholder(BuildContext context) {
+  Widget _buildPlaceholder(BuildContext context, {required bool isResolvingAsset}) {
     return Container(
       height: 48,
       decoration: BoxDecoration(color: context.colors.surfaceMuted, borderRadius: BorderRadius.circular(4)),
@@ -365,12 +366,18 @@ class ImageWidget extends HookWidget {
             const SizedBox(width: 12),
             Expanded(
               child: Text(
-                '이미지',
+                isResolvingAsset ? '이미지를 불러오는 중...' : '이미지',
                 style: TextStyle(fontSize: 14, color: context.colors.textDisabled),
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
               ),
             ),
+            if (isResolvingAsset)
+              SizedBox(
+                width: 16,
+                height: 16,
+                child: CircularProgressIndicator(strokeWidth: 2, color: context.colors.textDisabled),
+              ),
           ],
         ),
       ),

--- a/apps/website/src/lib/components/editor/external/ExternalFile.svelte
+++ b/apps/website/src/lib/components/editor/external/ExternalFile.svelte
@@ -39,6 +39,7 @@
   const inflight = $derived(currentUploadId ? editor.inflightFiles.get(currentUploadId) : undefined);
   const hasFile = $derived(!!asset || !!inflight);
   const isUploading = $derived(!!inflight && !asset);
+  const isResolvingAsset = $derived(!!fileData.id && !asset && !inflight);
   const displayName = $derived(asset?.name ?? inflight?.name ?? '파일');
   const displaySize = $derived.by(() => {
     const size = Number(asset?.size ?? inflight?.size);
@@ -268,8 +269,14 @@
           })}
         >
           <Icon icon={FileIcon} size={20} />
-          파일
+          {isResolvingAsset ? '파일을 불러오는 중...' : '파일'}
         </div>
+
+        {#if isResolvingAsset}
+          <div class={css({ marginRight: '14px' })}>
+            <RingSpinner style={css.raw({ size: '16px', color: 'text.disabled' })} />
+          </div>
+        {/if}
 
         {#if isEditable}
           <Menu>
@@ -304,7 +311,7 @@
   </div>
 </ExternalElementWrapper>
 
-{#if pickerOpened && !hasFile && isEditable}
+{#if pickerOpened && !hasFile && !isResolvingAsset && isEditable}
   <div
     class={center({
       flexDirection: 'column',

--- a/apps/website/src/lib/components/editor/external/ExternalImage.svelte
+++ b/apps/website/src/lib/components/editor/external/ExternalImage.svelte
@@ -46,6 +46,7 @@
   const imageSrc = $derived(asset?.url ?? inflight?.url);
   const hasImage = $derived(!!imageSrc);
   const isUploading = $derived(!!inflight && !asset);
+  const isResolvingAsset = $derived(!!imageData.id && !asset && !inflight);
   const originalWidth = $derived(asset?.width ?? inflight?.width ?? 0);
   const originalHeight = $derived(asset?.height ?? inflight?.height ?? 0);
   const aspectRatio = $derived(originalWidth > 0 ? originalHeight / originalWidth : 0);
@@ -488,8 +489,14 @@
           })}
         >
           <Icon icon={ImageIcon} size={20} />
-          이미지
+          {isResolvingAsset ? '이미지를 불러오는 중...' : '이미지'}
         </div>
+
+        {#if isResolvingAsset}
+          <div class={css({ marginRight: '14px' })}>
+            <RingSpinner style={css.raw({ size: '16px', color: 'text.disabled' })} />
+          </div>
+        {/if}
 
         {#if isEditable}
           <Menu>
@@ -524,7 +531,7 @@
   </div>
 </ExternalElementWrapper>
 
-{#if pickerOpened && !hasImage && isEditable}
+{#if pickerOpened && !hasImage && !isResolvingAsset && isEditable}
   <div
     class={center({
       flexDirection: 'column',


### PR DESCRIPTION
이미지, 파일 업로드 후 에디터 리로드하면 document assets를 아직 얻을 수 없는 경우가 있는데 이 때 마치 업로드 안 된 것처럼 placeholder를 보여주는 대신 불러오는 중이라는 문구와 스피너를 보여줌