### PR TITLE
insertion message 타입에서 commitPreedit 제외

### DIFF
--- a/apps/mobile/lib/screens/native_editor/state/controller.dart
+++ b/apps/mobile/lib/screens/native_editor/state/controller.dart
@@ -138,7 +138,6 @@ class EditorController extends ChangeNotifier {
     'repasteAsText',
     'compositionStart',
     'compositionUpdate',
-    'commitPreedit',
     'drop',
   };
 

--- a/apps/website/src/lib/editor/editor.svelte.ts
+++ b/apps/website/src/lib/editor/editor.svelte.ts
@@ -102,6 +102,7 @@ const NON_EDIT_MESSAGE_TYPES = new Set<Message['type']>([
   'addRemark',
   'updateRemark',
   'removeRemark',
+  'commitPreedit',
 ]);
 
 /** 텍스트를 삽입하는 메시지 타입 (restricted 모드에서 차단) */
@@ -114,7 +115,6 @@ const INSERTION_MESSAGE_TYPES = new Set<Message['type']>([
   'repasteAsText',
   'compositionStart',
   'compositionUpdate',
-  'commitPreedit',
   'drop',
 ]);
 


### PR DESCRIPTION
에디터에서 조합 완료하려고 commitPreedit 호출하는 경우에 (예: 화면 터치) 플랜 초과 모달 안 뜨도록 함
어차피 compositionStart와 compositionUpdate에서 텍스트 입력은 막힌다.
