### PR TITLE
Fragment::from_html 에서 styled whitespace node 무시하지 않음

### DIFF
--- a/crates/editor/src/model/html/mod.rs
+++ b/crates/editor/src/model/html/mod.rs
@@ -183,7 +183,10 @@ fn parse_children(
                     .map(|pt| schema.node_spec(pt).is_textblock(schema))
                     .unwrap_or(false);
                 let is_whitespace_only = s.chars().all(|c| c.is_ascii_whitespace());
-                let skip = is_whitespace_only && (!is_textblock_parent || s.contains('\n'));
+                let has_inline_styles = !styles.is_empty();
+                let skip = is_whitespace_only
+                    && !has_inline_styles
+                    && (!is_textblock_parent || s.contains('\n'));
                 if !s.is_empty() && !skip {
                     let id = pending_text_id.take();
                     add_text(

--- a/crates/editor/src/transaction/clipboard.rs
+++ b/crates/editor/src/transaction/clipboard.rs
@@ -2508,4 +2508,59 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn copy_paste_html_preserves_font_size_on_space() {
+        use crate::runtime::Message;
+
+        let mut p = id!();
+
+        // 1. Source document: ABCD[font_size 20pt space]EFG
+        let source_rt = runtime! {
+            viewport { 800, 600, 1.0 }
+            doc {
+                @p paragraph {
+                    text {
+                        "ABCD",
+                        " " => [font_size(2000)],
+                        "EFG"
+                    }
+                }
+            }
+            selection { (p, 0) -> (p, 8) }
+        };
+
+        // 2. Copy: extract_fragment → to_html (same as get_clipboard_data in web FFI)
+        let state = source_rt.state();
+        let fragment = state.selection.extract_fragment(&state.doc).unwrap();
+        let html = fragment.to_html();
+        let text = fragment.to_plain_text();
+
+        // 3. Paste into empty document via Message::PasteHtml handler
+        let mut paste_rt = runtime! {
+            viewport { 800, 600, 1.0 }
+            doc {
+                @p paragraph {}
+            }
+            selection { (p, 0) }
+        };
+
+        paste_rt.update(Message::PasteHtml { html, text });
+
+        // 4. Verify
+        let expected = state! {
+            doc {
+                @p paragraph {
+                    text {
+                        "ABCD",
+                        " " => [font_size(2000)],
+                        "EFG"
+                    }
+                }
+            }
+            selection { (p, 8) }
+        };
+
+        assert_state_eq!(paste_rt.state(), expected);
+    }
 }


### PR DESCRIPTION
일부 케이스에서 텍스트 사이에 삽입된 공백 복사 붙여넣기가 공백을 제거하는 문제 해결
