### PR TITLE
렌더 캐시 style signature 계산에 glyph run의 advance와 baseline 포함함

### DIFF
--- a/crates/editor/src/layout/elements/line.rs
+++ b/crates/editor/src/layout/elements/line.rs
@@ -208,7 +208,10 @@ impl LineElement {
                     style.brush.hash(state);
                     style.underline.is_some().hash(state);
                     style.strikethrough.is_some().hash(state);
+
                     glyph_run.offset().to_bits().hash(state);
+                    glyph_run.advance().to_bits().hash(state);
+                    glyph_run.baseline().to_bits().hash(state);
 
                     let run = glyph_run.run();
                     run.font_size().to_bits().hash(state);


### PR DESCRIPTION
라인 전체가 단일 glyph run일 때 자간 변화가 렌더 캐시를 무효화하지 않는 문제 해결
