### PR TITLE
앱에서 redo 시 selection 복원 안 되는 문제 수정

### DIFF
--- a/apps/mobile/lib/screens/native_editor/toolbar/buttons/background_color.dart
+++ b/apps/mobile/lib/screens/native_editor/toolbar/buttons/background_color.dart
@@ -9,6 +9,8 @@ class BackgroundColorToolbarButton extends StatelessWidget {
     required this.onTap,
     required this.color,
     required this.value,
+    this.onTapDown,
+    this.prepareMutationOnTapDown = false,
     this.isActive = false,
     super.key,
   });
@@ -16,12 +18,16 @@ class BackgroundColorToolbarButton extends StatelessWidget {
   final Color? color;
   final String value;
   final bool isActive;
+  final void Function()? onTapDown;
+  final bool prepareMutationOnTapDown;
   final void Function() onTap;
 
   @override
   Widget build(BuildContext context) {
     return ToolbarButton(
       isActive: isActive,
+      onTapDown: onTapDown,
+      prepareMutationOnTapDown: prepareMutationOnTapDown,
       onTap: onTap,
       builder: (context, textColor, backgroundColor) {
         return Center(

--- a/apps/mobile/lib/screens/native_editor/toolbar/buttons/base.dart
+++ b/apps/mobile/lib/screens/native_editor/toolbar/buttons/base.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:typie/context/theme.dart';
+import 'package:typie/screens/native_editor/toolbar/scope.dart';
 
 enum _ButtonState { idle, pressed, active }
 
@@ -10,6 +11,8 @@ class ToolbarButton extends HookWidget {
   const ToolbarButton({
     required this.onTap,
     required this.builder,
+    this.onTapDown,
+    this.prepareMutationOnTapDown = false,
     this.isActive = false,
     this.isDisabled = false,
     this.isRepeatable = false,
@@ -20,6 +23,8 @@ class ToolbarButton extends HookWidget {
   final Widget Function(BuildContext context, Color color, Color? backgroundColor) builder;
 
   final Color? color;
+  final void Function()? onTapDown;
+  final bool prepareMutationOnTapDown;
   final bool isActive;
   final bool isDisabled;
   final bool isRepeatable;
@@ -102,7 +107,13 @@ class ToolbarButton extends HookWidget {
         repeatTimer.value?.cancel();
         state.value = _ButtonState.idle;
       },
-      onTapDown: (_) => state.value = _ButtonState.pressed,
+      onTapDown: (_) {
+        state.value = _ButtonState.pressed;
+        if (prepareMutationOnTapDown) {
+          NativeEditorToolbarScope.maybeOf(context)?.prepareMutation();
+        }
+        onTapDown?.call();
+      },
       onTapUp: (_) => state.value = _ButtonState.idle,
       onTapCancel: () => state.value = _ButtonState.idle,
       child: AnimatedBuilder(

--- a/apps/mobile/lib/screens/native_editor/toolbar/buttons/color.dart
+++ b/apps/mobile/lib/screens/native_editor/toolbar/buttons/color.dart
@@ -9,6 +9,8 @@ class ColorToolbarButton extends StatelessWidget {
     required this.onTap,
     required this.color,
     required this.value,
+    this.onTapDown,
+    this.prepareMutationOnTapDown = false,
     this.isActive = false,
     super.key,
   });
@@ -16,12 +18,16 @@ class ColorToolbarButton extends StatelessWidget {
   final Color color;
   final String value;
   final bool isActive;
+  final void Function()? onTapDown;
+  final bool prepareMutationOnTapDown;
   final void Function() onTap;
 
   @override
   Widget build(BuildContext context) {
     return ToolbarButton(
       isActive: isActive,
+      onTapDown: onTapDown,
+      prepareMutationOnTapDown: prepareMutationOnTapDown,
       onTap: onTap,
       builder: (context, textColor, backgroundColor) {
         return Center(

--- a/apps/mobile/lib/screens/native_editor/toolbar/buttons/icon.dart
+++ b/apps/mobile/lib/screens/native_editor/toolbar/buttons/icon.dart
@@ -6,6 +6,8 @@ class IconToolbarButton extends StatelessWidget {
   const IconToolbarButton({
     required this.onTap,
     required this.icon,
+    this.onTapDown,
+    this.prepareMutationOnTapDown = false,
     this.isActive = false,
     this.isDisabled = false,
     this.isRepeatable = false,
@@ -17,6 +19,8 @@ class IconToolbarButton extends StatelessWidget {
   final bool isActive;
   final bool isDisabled;
   final bool isRepeatable;
+  final void Function()? onTapDown;
+  final bool prepareMutationOnTapDown;
   final void Function() onTap;
 
   @override
@@ -25,6 +29,8 @@ class IconToolbarButton extends StatelessWidget {
       isActive: isActive,
       isDisabled: isDisabled,
       isRepeatable: isRepeatable,
+      onTapDown: onTapDown,
+      prepareMutationOnTapDown: prepareMutationOnTapDown,
       onTap: onTap,
       builder: (context, color, backgroundColor) {
         return Container(

--- a/apps/mobile/lib/screens/native_editor/toolbar/buttons/label.dart
+++ b/apps/mobile/lib/screens/native_editor/toolbar/buttons/label.dart
@@ -7,6 +7,8 @@ class LabelToolbarButton extends StatelessWidget {
   const LabelToolbarButton({
     required this.onTap,
     required this.text,
+    this.onTapDown,
+    this.prepareMutationOnTapDown = false,
     this.isActive = false,
     this.color,
     this.suffix,
@@ -16,6 +18,8 @@ class LabelToolbarButton extends StatelessWidget {
   final String text;
   final Color? color;
   final bool isActive;
+  final void Function()? onTapDown;
+  final bool prepareMutationOnTapDown;
   final void Function() onTap;
   final Widget? suffix;
 
@@ -23,6 +27,8 @@ class LabelToolbarButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return ToolbarButton(
       isActive: isActive,
+      onTapDown: onTapDown,
+      prepareMutationOnTapDown: prepareMutationOnTapDown,
       onTap: onTap,
       color: color ?? context.colors.textFaint,
       builder: (context, color, _) {

--- a/apps/mobile/lib/screens/native_editor/toolbar/primary/primary.dart
+++ b/apps/mobile/lib/screens/native_editor/toolbar/primary/primary.dart
@@ -85,6 +85,7 @@ class NativeEditorPrimaryToolbar extends HookWidget {
                       ),
                       IconToolbarButton(
                         icon: LucideLightIcons.undo,
+                        prepareMutationOnTapDown: true,
                         onTap: () {
                           scope.dispatch({'type': 'undo'});
                           scope.controller.scrollIntoView();
@@ -92,6 +93,7 @@ class NativeEditorPrimaryToolbar extends HookWidget {
                       ),
                       IconToolbarButton(
                         icon: LucideLightIcons.redo,
+                        prepareMutationOnTapDown: true,
                         onTap: () {
                           scope.dispatch({'type': 'redo'});
                           scope.controller.scrollIntoView();

--- a/apps/mobile/lib/screens/native_editor/toolbar/scope.dart
+++ b/apps/mobile/lib/screens/native_editor/toolbar/scope.dart
@@ -72,6 +72,15 @@ class NativeEditorToolbarScope extends InheritedWidget {
     return scope!;
   }
 
+  static NativeEditorToolbarScope? maybeOf(BuildContext context) {
+    return context.getInheritedWidgetOfExactType<NativeEditorToolbarScope>();
+  }
+
+  void prepareMutation() {
+    reconcileInput();
+    requestFocus();
+  }
+
   @override
   bool updateShouldNotify(covariant NativeEditorToolbarScope old) => false;
 }

--- a/apps/mobile/lib/screens/native_editor/toolbar/secondary/text.dart
+++ b/apps/mobile/lib/screens/native_editor/toolbar/secondary/text.dart
@@ -175,6 +175,7 @@ class NativeEditorTextToolbar extends HookWidget {
           IconToolbarButton(
             icon: LucideLightIcons.bold,
             isActive: isBold,
+            prepareMutationOnTapDown: true,
             onTap: () {
               scope.dispatch({'type': 'toggleBold'});
             },
@@ -182,6 +183,7 @@ class NativeEditorTextToolbar extends HookWidget {
           IconToolbarButton(
             icon: LucideLightIcons.italic,
             isActive: isItalic,
+            prepareMutationOnTapDown: true,
             onTap: () {
               scope.dispatch({
                 'type': 'toggleStyle',
@@ -192,6 +194,7 @@ class NativeEditorTextToolbar extends HookWidget {
           IconToolbarButton(
             icon: LucideLightIcons.underline,
             isActive: isUnderline,
+            prepareMutationOnTapDown: true,
             onTap: () {
               scope.dispatch({
                 'type': 'toggleStyle',
@@ -202,6 +205,7 @@ class NativeEditorTextToolbar extends HookWidget {
           IconToolbarButton(
             icon: LucideLightIcons.strikethrough,
             isActive: isStrikethrough,
+            prepareMutationOnTapDown: true,
             onTap: () {
               scope.dispatch({
                 'type': 'toggleStyle',
@@ -290,6 +294,7 @@ class NativeEditorTextToolbar extends HookWidget {
           AppVerticalDivider(color: context.colors.borderSubtle, height: 20),
           IconToolbarButton(
             icon: LucideLightIcons.remove_formatting,
+            prepareMutationOnTapDown: true,
             onTap: () {
               scope.dispatch({'type': 'clearFormatting'});
             },

--- a/apps/mobile/lib/screens/native_editor/toolbar/secondary/text_options/font_family.dart
+++ b/apps/mobile/lib/screens/native_editor/toolbar/secondary/text_options/font_family.dart
@@ -43,6 +43,7 @@ class NativeEditorFontFamilyTextOptionsToolbar extends HookWidget {
         return ToolbarButton(
           isActive: isActive,
           color: context.colors.textFaint,
+          prepareMutationOnTapDown: true,
           onTap: () {
             scope.dispatch({
               'type': 'toggleStyle',

--- a/apps/mobile/lib/screens/native_editor/toolbar/secondary/text_options/font_size.dart
+++ b/apps/mobile/lib/screens/native_editor/toolbar/secondary/text_options/font_size.dart
@@ -54,6 +54,7 @@ class NativeEditorFontSizeTextOptionsToolbar extends HookWidget {
           text: item['label'] as String,
           isActive: isActive,
           suffix: isActive ? const Icon(LucideLightIcons.pencil, size: 14) : null,
+          prepareMutationOnTapDown: true,
           onTap: () async {
             if (isActive) {
               await context.showModal(

--- a/apps/mobile/lib/screens/native_editor/toolbar/secondary/text_options/font_weight.dart
+++ b/apps/mobile/lib/screens/native_editor/toolbar/secondary/text_options/font_weight.dart
@@ -48,6 +48,7 @@ class NativeEditorFontWeightTextOptionsToolbar extends HookWidget {
         return LabelToolbarButton(
           text: item['label'] as String,
           isActive: isActive,
+          prepareMutationOnTapDown: true,
           onTap: () {
             scope.dispatch({
               'type': 'toggleStyle',

--- a/apps/mobile/lib/screens/native_editor/toolbar/secondary/text_options/letter_spacing.dart
+++ b/apps/mobile/lib/screens/native_editor/toolbar/secondary/text_options/letter_spacing.dart
@@ -25,6 +25,7 @@ class NativeEditorLetterSpacingTextOptionsToolbar extends HookWidget {
         return LabelToolbarButton(
           text: item['label'] as String,
           isActive: isActive,
+          prepareMutationOnTapDown: true,
           onTap: () {
             scope.dispatch({
               'type': 'toggleStyle',

--- a/apps/mobile/lib/screens/native_editor/toolbar/secondary/text_options/line_height.dart
+++ b/apps/mobile/lib/screens/native_editor/toolbar/secondary/text_options/line_height.dart
@@ -25,6 +25,7 @@ class NativeEditorLineHeightTextOptionsToolbar extends HookWidget {
         return LabelToolbarButton(
           text: item['label'] as String,
           isActive: isActive,
+          prepareMutationOnTapDown: true,
           onTap: () {
             scope.dispatch({'type': 'setLineHeight', 'height': item['value']});
           },

--- a/apps/mobile/lib/screens/native_editor/toolbar/secondary/text_options/text_align.dart
+++ b/apps/mobile/lib/screens/native_editor/toolbar/secondary/text_options/text_align.dart
@@ -23,6 +23,7 @@ class NativeEditorTextAlignTextOptionsToolbar extends HookWidget {
         return LabelToolbarButton(
           text: item['label'] as String,
           isActive: isActive,
+          prepareMutationOnTapDown: true,
           onTap: () {
             scope.dispatch({'type': 'setTextAlign', 'align': item['value']});
           },

--- a/apps/mobile/lib/screens/native_editor/toolbar/secondary/text_options/text_background_color.dart
+++ b/apps/mobile/lib/screens/native_editor/toolbar/secondary/text_options/text_background_color.dart
@@ -26,6 +26,7 @@ class NativeEditorTextBackgroundColorTextOptionsToolbar extends HookWidget {
           color: item['color'] != null ? (item['color'] as Color Function(BuildContext))(context) : null,
           value: item['value'] as String,
           isActive: isActive,
+          prepareMutationOnTapDown: true,
           onTap: () {
             final value = item['value'] as String;
             scope.dispatch({

--- a/apps/mobile/lib/screens/native_editor/toolbar/secondary/text_options/text_color.dart
+++ b/apps/mobile/lib/screens/native_editor/toolbar/secondary/text_options/text_color.dart
@@ -26,6 +26,7 @@ class NativeEditorTextColorTextOptionsToolbar extends HookWidget {
           color: (item['color'] as Color Function(BuildContext))(context),
           value: item['value'] as String,
           isActive: isActive,
+          prepareMutationOnTapDown: true,
           onTap: () {
             scope.dispatch({
               'type': 'toggleStyle',

--- a/apps/mobile/lib/screens/native_editor/view/editor.dart
+++ b/apps/mobile/lib/screens/native_editor/view/editor.dart
@@ -1105,78 +1105,78 @@ class EditorView extends HookWidget {
       return const SizedBox.shrink();
     }
 
-    return Listener(
-      onPointerDown: (_) {
-        inputController
-          ..commitPreedit(scroll: false)
-          ..invalidate();
-      },
-      child: NativeEditorToolbarScope(
+    return NativeEditorToolbarScope(
+      controller: controller,
+      keyboardHeight: keyboardHeight,
+      isKeyboardVisible: isKeyboardVisible,
+      keyboardType: keyboardType,
+      isEditorFocused: isEditorFocused,
+      bottomToolbarMode: bottomToolbarMode,
+      secondaryToolbarMode: secondaryToolbarMode,
+      selection: selection,
+      attrs: attrs,
+      floatingContext: controller.floatingContext,
+      floatingNodeId: controller.floatingNodeId,
+      externalElements: externalElements,
+      uploadManager: uploadManager,
+      dispatch: controller.dispatch,
+      requestFocus: inputController.requestFocus,
+      clearFocus: inputController.clearFocus,
+      dismissKeyboard: inputController.dismissKeyboard,
+      reconcileInput: inputController.invalidate,
+      child: ContentScope(
         controller: controller,
-        keyboardHeight: keyboardHeight,
-        isKeyboardVisible: isKeyboardVisible,
-        keyboardType: keyboardType,
-        isEditorFocused: isEditorFocused,
-        bottomToolbarMode: bottomToolbarMode,
-        secondaryToolbarMode: secondaryToolbarMode,
-        selection: selection,
-        attrs: attrs,
-        floatingContext: controller.floatingContext,
-        floatingNodeId: controller.floatingNodeId,
-        externalElements: externalElements,
-        uploadManager: uploadManager,
-        dispatch: controller.dispatch,
-        requestFocus: inputController.requestFocus,
-        clearFocus: inputController.clearFocus,
-        dismissKeyboard: inputController.dismissKeyboard,
-        reconcileInput: inputController.invalidate,
-        child: ContentScope(
-          controller: controller,
-          ticker: ticker,
-          dndController: dndController,
-          interactionState: interactionState,
-          interactionSnapshot: interactionState.listenable,
-          verticalScrollController: verticalScrollController,
-          horizontalScrollController: horizontalScrollController,
-          inputController: inputController,
-          longPressPosition: longPressPosition,
-          handleDragPosition: handleDragPosition,
-          titleAreaHeight: titleAreaHeight,
-          viewportTopInset: viewportTopInset,
-          title: titleNotifier,
-          subtitle: subtitleNotifier,
-          onTitleChanged: onTitleChanged,
-          onSubtitleChanged: onSubtitleChanged,
-          titleFocusNode: titleFocusNode,
-          subtitleFocusNode: subtitleFocusNode,
-          pendingScroll: pendingScroll,
-          pendingScrollPageIdx: pendingScrollPageIdx,
-          presentedViewport: presentedViewport,
-          displayZoom: displayZoom,
-          renderZoom: renderZoom,
-          setZoom: setZoom,
-          child: LayoutBuilder(
-            builder: (context, constraints) {
-              final width = constraints.maxWidth.floorToDouble();
-              final height = constraints.maxHeight;
-              if (zoomViewportWidth.value != constraints.maxWidth) {
-                final nextViewportWidth = constraints.maxWidth;
-                WidgetsBinding.instance.addPostFrameCallback((_) {
-                  if (zoomViewportWidth.value != nextViewportWidth) {
-                    zoomViewportWidth.value = nextViewportWidth;
-                  }
-                });
-              }
-              final zoomForRender = isPaginatedLayout ? currentRenderZoom : 1.0;
-              final scaleFactor = MediaQuery.devicePixelRatioOf(context) * zoomForRender;
-              final currentSize = (width, height, scaleFactor);
-              if (lastSize.value != currentSize) {
-                lastSize.value = currentSize;
-                controller.dispatch({'type': 'resize', 'width': width, 'height': height, 'scaleFactor': scaleFactor});
-              }
-              return Column(
-                children: [
-                  Expanded(
+        ticker: ticker,
+        dndController: dndController,
+        interactionState: interactionState,
+        interactionSnapshot: interactionState.listenable,
+        verticalScrollController: verticalScrollController,
+        horizontalScrollController: horizontalScrollController,
+        inputController: inputController,
+        longPressPosition: longPressPosition,
+        handleDragPosition: handleDragPosition,
+        titleAreaHeight: titleAreaHeight,
+        viewportTopInset: viewportTopInset,
+        title: titleNotifier,
+        subtitle: subtitleNotifier,
+        onTitleChanged: onTitleChanged,
+        onSubtitleChanged: onSubtitleChanged,
+        titleFocusNode: titleFocusNode,
+        subtitleFocusNode: subtitleFocusNode,
+        pendingScroll: pendingScroll,
+        pendingScrollPageIdx: pendingScrollPageIdx,
+        presentedViewport: presentedViewport,
+        displayZoom: displayZoom,
+        renderZoom: renderZoom,
+        setZoom: setZoom,
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final width = constraints.maxWidth.floorToDouble();
+            final height = constraints.maxHeight;
+            if (zoomViewportWidth.value != constraints.maxWidth) {
+              final nextViewportWidth = constraints.maxWidth;
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                if (zoomViewportWidth.value != nextViewportWidth) {
+                  zoomViewportWidth.value = nextViewportWidth;
+                }
+              });
+            }
+            final zoomForRender = isPaginatedLayout ? currentRenderZoom : 1.0;
+            final scaleFactor = MediaQuery.devicePixelRatioOf(context) * zoomForRender;
+            final currentSize = (width, height, scaleFactor);
+            if (lastSize.value != currentSize) {
+              lastSize.value = currentSize;
+              controller.dispatch({'type': 'resize', 'width': width, 'height': height, 'scaleFactor': scaleFactor});
+            }
+            return Column(
+              children: [
+                Expanded(
+                  child: Listener(
+                    onPointerDown: (_) {
+                      inputController
+                        ..commitPreedit(scroll: false)
+                        ..invalidate();
+                    },
                     child: Stack(
                       key: floatingContainerKey,
                       fit: StackFit.expand,
@@ -1246,11 +1246,11 @@ class EditorView extends HookWidget {
                       ],
                     ),
                   ),
-                  const NativeEditorToolbar(),
-                ],
-              );
-            },
-          ),
+                ),
+                const NativeEditorToolbar(),
+              ],
+            );
+          },
         ),
       ),
     );

--- a/apps/mobile/lib/screens/native_editor/view/input.dart
+++ b/apps/mobile/lib/screens/native_editor/view/input.dart
@@ -737,6 +737,7 @@ class EditorTextInputState extends State<EditorTextInput> with DeltaTextInputCli
       text: precedingText + followingText + marker,
       selection: TextSelection.collapsed(offset: precedingText.length),
     );
+    var shouldCommitPreedit = false;
 
     if (_currentValue != newValue) {
       var forceSync = false;
@@ -759,6 +760,7 @@ class EditorTextInputState extends State<EditorTextInput> with DeltaTextInputCli
           'currentValue': _serializeValue(_currentValue),
           'newValue': _serializeValue(newValue),
         });
+        shouldCommitPreedit = true;
         _currentValue = _currentValue.copyWith(composing: TextRange.empty);
         _extendedComposingStart = null;
         _connection = TextInput.attach(this, _configuration);
@@ -809,7 +811,7 @@ class EditorTextInputState extends State<EditorTextInput> with DeltaTextInputCli
       _addRecordingEntry({'type': 'reconcile', 'result': 'unchanged', 'currentValue': _serializeValue(_currentValue)});
     }
 
-    return true;
+    return shouldCommitPreedit;
   }
 
   void _setCurrentValue(TextEditingValue value, {bool allowSentinel = true}) {

--- a/apps/mobile/test/screens/native_editor/toolbar/primary_test.dart
+++ b/apps/mobile/test/screens/native_editor/toolbar/primary_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:typie/icons/lucide_light.dart';
+import 'package:typie/native/editor_native.dart';
+import 'package:typie/screens/native_editor/controller/upload.dart';
+import 'package:typie/screens/native_editor/state/controller.dart';
+import 'package:typie/screens/native_editor/toolbar/primary/primary.dart';
+import 'package:typie/screens/native_editor/toolbar/scope.dart';
+import 'package:typie/services/keyboard.dart';
+import 'package:typie/styles/semantic_colors.dart';
+
+void main() {
+  Future<void> pumpToolbar(
+    WidgetTester tester, {
+    required void Function(Map<String, dynamic> message) dispatch,
+    required VoidCallback requestFocus,
+    required VoidCallback reconcileInput,
+  }) async {
+    final controller = EditorController(editor: NativeEditor.test(), fontManager: null);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(extensions: const <ThemeExtension<dynamic>>[SemanticColors.light]),
+        home: NativeEditorToolbarScope(
+          controller: controller,
+          keyboardHeight: ValueNotifier(0),
+          isKeyboardVisible: ValueNotifier(true),
+          keyboardType: ValueNotifier(KeyboardType.software),
+          isEditorFocused: ValueNotifier(true),
+          bottomToolbarMode: ValueNotifier(BottomToolbarMode.hidden),
+          secondaryToolbarMode: ValueNotifier(SecondaryToolbarMode.hidden),
+          selection: ValueNotifier(null),
+          attrs: ValueNotifier(const []),
+          floatingContext: ValueNotifier(null),
+          floatingNodeId: ValueNotifier(null),
+          externalElements: ValueNotifier(const []),
+          uploadManager: UploadManager(),
+          dispatch: dispatch,
+          requestFocus: requestFocus,
+          clearFocus: () {},
+          dismissKeyboard: () {},
+          reconcileInput: reconcileInput,
+          child: const Scaffold(body: NativeEditorPrimaryToolbar()),
+        ),
+      ),
+    );
+    await tester.pump();
+  }
+
+  testWidgets('redo toolbar reconciles input and keeps focus before dispatch', (tester) async {
+    final events = <String>[];
+
+    await pumpToolbar(
+      tester,
+      dispatch: (message) => events.add('dispatch:${message['type']}'),
+      requestFocus: () => events.add('requestFocus'),
+      reconcileInput: () => events.add('reconcileInput'),
+    );
+
+    final gesture = await tester.startGesture(tester.getCenter(find.byIcon(LucideLightIcons.redo)));
+    await tester.pump(kPressTimeout);
+
+    expect(events, ['reconcileInput', 'requestFocus']);
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(events, ['reconcileInput', 'requestFocus', 'dispatch:redo']);
+  });
+
+  testWidgets('undo toolbar reconciles input and keeps focus before dispatch', (tester) async {
+    final events = <String>[];
+
+    await pumpToolbar(
+      tester,
+      dispatch: (message) => events.add('dispatch:${message['type']}'),
+      requestFocus: () => events.add('requestFocus'),
+      reconcileInput: () => events.add('reconcileInput'),
+    );
+
+    final gesture = await tester.startGesture(tester.getCenter(find.byIcon(LucideLightIcons.undo)));
+    await tester.pump(kPressTimeout);
+
+    expect(events, ['reconcileInput', 'requestFocus']);
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(events, ['reconcileInput', 'requestFocus', 'dispatch:undo']);
+  });
+}

--- a/apps/mobile/test/screens/native_editor/toolbar/secondary_text_test.dart
+++ b/apps/mobile/test/screens/native_editor/toolbar/secondary_text_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:typie/icons/lucide_light.dart';
+import 'package:typie/native/editor_native.dart';
+import 'package:typie/screens/native_editor/controller/upload.dart';
+import 'package:typie/screens/native_editor/state/controller.dart';
+import 'package:typie/screens/native_editor/state/state.dart';
+import 'package:typie/screens/native_editor/state/theme.dart';
+import 'package:typie/screens/native_editor/toolbar/scope.dart';
+import 'package:typie/screens/native_editor/toolbar/secondary/text.dart';
+import 'package:typie/screens/native_editor/toolbar/secondary/text_options/line_height.dart';
+import 'package:typie/services/keyboard.dart';
+import 'package:typie/styles/semantic_colors.dart';
+
+Future<void> _pumpToolbar(
+  WidgetTester tester, {
+  required Widget child,
+  required void Function(Map<String, dynamic> message) dispatch,
+  required VoidCallback requestFocus,
+  required VoidCallback reconcileInput,
+  ValueNotifier<EditorSelection?>? selection,
+  ValueNotifier<List<Map<String, dynamic>>>? attrs,
+}) async {
+  final controller = EditorController(editor: NativeEditor.test(), fontManager: null);
+
+  await tester.pumpWidget(
+    MaterialApp(
+      theme: ThemeData(extensions: const <ThemeExtension<dynamic>>[SemanticColors.light]),
+      home: NativeEditorToolbarScope(
+        controller: controller,
+        keyboardHeight: ValueNotifier(0),
+        isKeyboardVisible: ValueNotifier(true),
+        keyboardType: ValueNotifier(KeyboardType.software),
+        isEditorFocused: ValueNotifier(true),
+        bottomToolbarMode: ValueNotifier(BottomToolbarMode.hidden),
+        secondaryToolbarMode: ValueNotifier(SecondaryToolbarMode.text),
+        selection:
+            selection ??
+            ValueNotifier(
+              const EditorSelection(
+                range: {
+                  'anchor': {'nodeId': 'node-1', 'offset': 3, 'affinity': 'upstream'},
+                  'head': {'nodeId': 'node-1', 'offset': 3, 'affinity': 'upstream'},
+                },
+              ),
+            ),
+        attrs: attrs ?? ValueNotifier(const []),
+        floatingContext: ValueNotifier(null),
+        floatingNodeId: ValueNotifier(null),
+        externalElements: ValueNotifier(const []),
+        uploadManager: UploadManager(),
+        dispatch: dispatch,
+        requestFocus: requestFocus,
+        clearFocus: () {},
+        dismissKeyboard: () {},
+        reconcileInput: reconcileInput,
+        child: Scaffold(body: child),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  setUpAll(() async {
+    await initEditorTheme();
+  });
+
+  testWidgets('bold toolbar prepares input before toggling style', (tester) async {
+    final events = <String>[];
+
+    await _pumpToolbar(
+      tester,
+      child: const NativeEditorTextToolbar(),
+      dispatch: (message) => events.add('dispatch:${message['type']}'),
+      requestFocus: () => events.add('requestFocus'),
+      reconcileInput: () => events.add('reconcileInput'),
+    );
+
+    final gesture = await tester.startGesture(tester.getCenter(find.byIcon(LucideLightIcons.bold)));
+    await tester.pump(kPressTimeout);
+
+    expect(events, ['reconcileInput', 'requestFocus']);
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(events, ['reconcileInput', 'requestFocus', 'dispatch:toggleBold']);
+  });
+
+  testWidgets('line height option prepares input before dispatch', (tester) async {
+    final events = <String>[];
+
+    await _pumpToolbar(
+      tester,
+      child: const NativeEditorLineHeightTextOptionsToolbar(),
+      dispatch: (message) => events.add('dispatch:${message['type']}'),
+      requestFocus: () => events.add('requestFocus'),
+      reconcileInput: () => events.add('reconcileInput'),
+      attrs: ValueNotifier(const []),
+    );
+
+    final gesture = await tester.startGesture(tester.getCenter(find.text('80%')));
+    await tester.pump(kPressTimeout);
+
+    expect(events, ['reconcileInput', 'requestFocus']);
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(events, ['reconcileInput', 'requestFocus', 'dispatch:setLineHeight']);
+  });
+}

--- a/apps/mobile/test/screens/native_editor/view/input_delta_test.dart
+++ b/apps/mobile/test/screens/native_editor/view/input_delta_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:typie/native/editor_native.dart';
 import 'package:typie/screens/native_editor/controller/input.dart';
 import 'package:typie/screens/native_editor/state/scroll_mode.dart';
+import 'package:typie/screens/native_editor/state/state.dart';
 import 'package:typie/screens/native_editor/toolbar/scope.dart';
 import 'package:typie/screens/native_editor/view/input.dart';
 
@@ -178,4 +179,41 @@ void main() {
       }
     });
   }
+
+  testWidgets('input controller reconcile does not dispatch commitPreedit for ordinary selection sync', (tester) async {
+    EditorSelection? selection;
+    controller = InputController(
+      inputKey: inputKey,
+      dispatch: dispatched.add,
+      editor: NativeEditor.test(),
+      onFocusChanged: (_) {},
+      scrollIntoView: ({ScrollMode mode = ScrollMode.auto}) {},
+      getBottomToolbarMode: () => BottomToolbarMode.hidden,
+      getEditorSelection: () => selection,
+    );
+
+    await pumpAndActivate(tester);
+
+    selection = const EditorSelection(
+      range: {
+        'anchor': {'nodeId': 'node-1', 'offset': 3, 'affinity': 'upstream'},
+        'head': {'nodeId': 'node-1', 'offset': 3, 'affinity': 'upstream'},
+      },
+      precedingText: 'abc',
+      followingText: 'def',
+    );
+    controller.reconcile();
+    expect(dispatched, isEmpty);
+
+    selection = const EditorSelection(
+      range: {
+        'anchor': {'nodeId': 'node-1', 'offset': 4, 'affinity': 'upstream'},
+        'head': {'nodeId': 'node-1', 'offset': 4, 'affinity': 'upstream'},
+      },
+      precedingText: 'abcd',
+      followingText: 'ef',
+    );
+    controller.reconcile();
+    expect(dispatched, isEmpty);
+  });
 }


### PR DESCRIPTION
- redo 시 reconcile이 commitPreedit을 무조건 dispatch하지 않도록 함
- 툴바 탭시 commitPreedit + invalidate 하지 않도록 함. 대신 reconcileInput, requestFocus는 함. 다음 PR에서 formatting시 rust 쪽에서 commitPreedit 하게끔 할 예정