### PR TITLE
전체선택 시 commitPreedit 먼저 하기 / leaf_block_start/end 쓰기

### DIFF
--- a/crates/editor/src/runtime/handlers/drag.rs
+++ b/crates/editor/src/runtime/handlers/drag.rs
@@ -480,7 +480,7 @@ mod tests {
                 @p1 paragraph { text { "Hello" } }
                 @p2 paragraph { text { "World" } }
             }
-            selection { (p1, 0) -> (p1, 5) }
+            selection { (p1, 0) -> (p1, 5, Affinity::Upstream) }
         };
         rt.layout();
 
@@ -496,7 +496,7 @@ mod tests {
                 @p1 paragraph { text { "Hello" } }
                 @p2 paragraph { text { "World" } }
             }
-            selection { (p1, 0) -> (p1, 5) }
+            selection { (p1, 0) -> (p1, 5, Affinity::Upstream) }
         };
 
         assert_state_eq!(rt.state(), expected);
@@ -531,7 +531,7 @@ mod tests {
                 @p2 paragraph { text { "Wor" } }
                 paragraph { text { "Target" } }
             }
-            selection { (p1, 0) -> (p2, 3) }
+            selection { (p1, 0) -> (p2, 3, Affinity::Upstream) }
         };
 
         assert_state_eq!(rt.state(), expected);
@@ -920,7 +920,7 @@ mod tests {
                 image (id: Some("test-image-id".to_string()),) {}
                 @p paragraph { text { "He" } }
             }
-            selection { (NodeId::ROOT, 1) -> (p, 2) }
+            selection { (NodeId::ROOT, 1) -> (p, 2, Affinity::Upstream) }
         };
 
         assert_state_eq!(rt.state(), expected);
@@ -980,7 +980,7 @@ mod tests {
                 @img image (id: Some("test-image-id".to_string()),) {}
                 @p4 paragraph { text { "4" } }
             }
-            selection { (p3, 0) -> (p4, 1) }
+            selection { (p3, 0) -> (p4, 1, Affinity::Upstream) }
         };
         rt.layout();
 
@@ -999,7 +999,7 @@ mod tests {
                 @p2 paragraph { text { "2" } }
                 paragraph {}
             }
-            selection { (p3, 0) -> (p4, 1) }
+            selection { (p3, 0) -> (p4, 1, Affinity::Upstream) }
         };
         assert_state_eq!(rt.state(), expected);
     }
@@ -1021,7 +1021,7 @@ mod tests {
                 @p3 paragraph { text { "3" } }
                 @p4 paragraph { text { "4" } }
             }
-            selection { (p1, 0) -> (p2, 1) }
+            selection { (p1, 0) -> (p2, 1, Affinity::Upstream) }
         };
         rt.layout();
 
@@ -1039,7 +1039,7 @@ mod tests {
                 image (id: Some("test-image-id".to_string()),) {}
                 @p2 paragraph { text { "2" } }
             }
-            selection { (p1, 1) -> (p2, 1) }
+            selection { (p1, 1) -> (p2, 1, Affinity::Upstream) }
         };
         assert_state_eq!(rt.state(), expected);
     }
@@ -1062,7 +1062,7 @@ mod tests {
                 @p3 paragraph { text { "3" } }
                 @p4 paragraph { text { "4" } }
             }
-            selection { (p1, 0) -> (p2, 1) }
+            selection { (p1, 0) -> (p2, 1, Affinity::Upstream) }
         };
         rt.layout();
 
@@ -1082,7 +1082,7 @@ mod tests {
                 @p3 paragraph { text { "3" } }
                 @p4 paragraph { text { "4" } }
             }
-            selection { (p1, 0) -> (p2, 1) }
+            selection { (p1, 0) -> (p2, 1, Affinity::Upstream) }
         };
         assert_state_eq!(rt.state(), expected);
     }
@@ -1104,7 +1104,7 @@ mod tests {
                 @p3 paragraph { text { "3" } }
                 @p4 paragraph { text { "4" } }
             }
-            selection { (p1, 0) -> (p2, 1) }
+            selection { (p1, 0) -> (p2, 1, Affinity::Upstream) }
         };
         rt.layout();
 
@@ -1122,7 +1122,7 @@ mod tests {
                 @bq blockquote { paragraph { text { "bq" } } }
                 @p2 paragraph { text { "2" } }
             }
-            selection { (p1, 1) -> (p2, 1) }
+            selection { (p1, 1) -> (p2, 1, Affinity::Upstream) }
         };
         assert_state_eq!(rt.state(), expected);
     }
@@ -1155,7 +1155,7 @@ mod tests {
                 @n paragraph { text { "New" } }
                 paragraph { text { "2" } }
             }
-            selection { (n, 0) -> (n, 3) }
+            selection { (n, 0) -> (n, 3, Affinity::Upstream) }
         };
         assert_state_eq!(rt.state(), expected);
     }
@@ -1183,7 +1183,7 @@ mod tests {
                     text { "44" }
                 }
             }
-            selection { (p1, 1) -> (p2, 1) }
+            selection { (p1, 1) -> (p2, 1, Affinity::Upstream) }
         };
 
         rt.layout();
@@ -1211,7 +1211,7 @@ mod tests {
                     text { "34" }
                 }
             }
-            selection { (p1, 1) -> (p2, 1) }
+            selection { (p1, 1) -> (p2, 1, Affinity::Upstream) }
         };
         assert_state_eq!(rt.state(), expected);
     }
@@ -1229,7 +1229,7 @@ mod tests {
                     text { "2" }
                 }
             }
-            selection { (p, 0) -> (p, 3) }
+            selection { (p, 0) -> (p, 3, Affinity::Upstream) }
         };
         rt.layout();
 
@@ -1248,7 +1248,7 @@ mod tests {
                     text { "2" }
                 }
             }
-            selection { (p, 0) -> (p, 3) }
+            selection { (p, 0) -> (p, 3, Affinity::Upstream) }
         };
         assert_state_eq!(rt.state(), expected);
     }
@@ -1282,7 +1282,7 @@ mod tests {
                 image (id: Some("test-image-id".to_string()),) {}
                 paragraph { }
             }
-            selection { (p, 0) -> (NodeId::ROOT, 4) }
+            selection { (p, 0) -> (NodeId::ROOT, 4, Affinity::Upstream) }
         };
 
         assert_state_eq!(rt.state(), expected);
@@ -1440,7 +1440,7 @@ mod tests {
                 @pb_para paragraph { page_break {} }
                 paragraph { }
             }
-            selection { (pb_para, 0) -> (pb_para, 1) }
+            selection { (pb_para, 0) -> (pb_para, 1, Affinity::Upstream) }
         };
 
         assert_state_eq!(rt.state(), expected);
@@ -1526,7 +1526,7 @@ mod tests {
                     text { "23" }
                 }
             }
-            selection { (p1, 1) -> (p2, 1) }
+            selection { (p1, 1) -> (p2, 1, Affinity::Upstream) }
         };
         assert_state_eq!(rt.state(), expected);
     }
@@ -1562,7 +1562,7 @@ mod tests {
                 @p3 paragraph { text { "3" } }
                 paragraph { text { "23" } }
             }
-            selection { (p2, 0) -> (p3, 1) }
+            selection { (p2, 0) -> (p3, 1, Affinity::Upstream) }
         };
         assert_state_eq!(rt.state(), expected);
     }
@@ -1598,7 +1598,7 @@ mod tests {
                 @p2 paragraph { text { "2" } }
                 @p3 paragraph { text { "3" } }
             }
-            selection { (p2, 0) -> (p3, 1) }
+            selection { (p2, 0) -> (p3, 1, Affinity::Upstream) }
         };
         assert_state_eq!(rt.state(), expected);
     }
@@ -1632,7 +1632,7 @@ mod tests {
                 bullet_list { list_item { paragraph { text { "22" } } } }
                 @p2 paragraph { text { "33" } }
             }
-            selection { (p1, 3) -> (p2, 1) }
+            selection { (p1, 3) -> (p2, 1, Affinity::Upstream) }
         };
         assert_state_eq!(rt.state(), expected);
     }
@@ -1667,7 +1667,7 @@ mod tests {
                 }
                 paragraph { }
             }
-            selection { (p1, 0) -> (p2, 1) }
+            selection { (p1, 0) -> (p2, 1, Affinity::Upstream) }
         };
         assert_state_eq!(rt.state(), expected);
     }
@@ -1701,7 +1701,7 @@ mod tests {
                 blockquote { paragraph { text { "AB" } } }
                 paragraph { }
             }
-            selection { (p1, 0) -> (p2, 1) }
+            selection { (p1, 0) -> (p2, 1, Affinity::Upstream) }
         };
         assert_state_eq!(rt.state(), expected);
     }
@@ -1736,7 +1736,7 @@ mod tests {
                 paragraph { text { "AB" } }
                 paragraph {}
             }
-            selection { (p1, 0) -> (p2, 1) }
+            selection { (p1, 0) -> (p2, 1, Affinity::Upstream) }
         };
         assert_state_eq!(rt.state(), expected);
     }
@@ -1753,7 +1753,7 @@ mod tests {
                 blockquote { @p2 paragraph { text { "B" } } }
                 paragraph { text { "C" } }
             }
-            selection { (p1, 0) -> (p2, 1) }
+            selection { (p1, 0) -> (p2, 1, Affinity::Upstream) }
         };
 
         rt.layout();
@@ -1772,7 +1772,7 @@ mod tests {
                 blockquote { @p2 paragraph { text { "B" } } }
                 paragraph {}
             }
-            selection { (p1, 0) -> (p2, 1) }
+            selection { (p1, 0) -> (p2, 1, Affinity::Upstream) }
         };
         assert_state_eq!(rt.state(), expected);
     }
@@ -1794,7 +1794,7 @@ mod tests {
                 }
                 paragraph { text { "Tail" } }
             }
-            selection { (p1, 0) -> (p2, 1) }
+            selection { (p1, 0) -> (p2, 1, Affinity::Upstream) }
         };
 
         rt.layout();
@@ -1816,7 +1816,7 @@ mod tests {
                 }
                 paragraph { text { "Tail" } }
             }
-            selection { (p1, 0) -> (p2, 1) }
+            selection { (p1, 0) -> (p2, 1, Affinity::Upstream) }
         };
 
         assert_state_eq!(rt.state(), expected);
@@ -1962,7 +1962,7 @@ mod tests {
                 paragraph { text { "existing" } }
                 @n paragraph { text { "dropped" } }
             }
-            selection { (n, 0) -> (n, 7) }
+            selection { (n, 0) -> (n, 7, Affinity::Upstream) }
         };
 
         assert_state_eq!(rt.state(), expected);
@@ -1994,7 +1994,7 @@ mod tests {
                 paragraph { text { "existing" } }
                 @n paragraph { text { "hello" } }
             }
-            selection { (n, 0) -> (n, 5) }
+            selection { (n, 0) -> (n, 5, Affinity::Upstream) }
         };
 
         assert_state_eq!(rt.state(), expected);
@@ -2028,7 +2028,7 @@ mod tests {
                     text(styles: [bold()]) { "bold" }
                 }
             }
-            selection { (n, 0) -> (n, 4) }
+            selection { (n, 0) -> (n, 4, Affinity::Upstream) }
         };
 
         assert_state_eq!(rt.state(), expected);
@@ -2060,7 +2060,7 @@ mod tests {
                 paragraph { text { "existing" } }
                 @n paragraph { text { "fallback" } }
             }
-            selection { (n, 0) -> (n, 8) }
+            selection { (n, 0) -> (n, 8, Affinity::Upstream) }
         };
 
         assert_state_eq!(rt.state(), expected);

--- a/crates/editor/src/runtime/handlers/navigation.rs
+++ b/crates/editor/src/runtime/handlers/navigation.rs
@@ -94,41 +94,49 @@ impl Runtime {
     }
 
     pub(crate) fn handle_select_all(&mut self) -> Vec<Effect> {
+        let mut effects = if self.state.preedit.is_some() {
+            self.handle_commit_preedit()
+        } else {
+            vec![]
+        };
+
+        let current = self.state.selection.as_sorted(&self.state.doc).ok();
+
         if let Some(isolating_id) = self.common_isolating_ancestor_id(&self.state.selection) {
             if let Some(isolating) = self.state.doc.node(isolating_id) {
                 if let (Some(start), Some(end)) =
                     (leaf_block_start(&isolating), leaf_block_end(&isolating))
                 {
-                    if let Ok((from, to)) = self.state.selection.as_sorted(&self.state.doc) {
-                        if start != from || end != to {
-                            return self.transact(move |tr| {
-                                tr.set_selection(Selection::new(start, end));
-                                Ok(true)
-                            });
-                        }
+                    if current != Some((start, end)) {
+                        effects.extend(self.transact(move |tr| {
+                            tr.set_selection(Selection::new(start, end));
+                            Ok(true)
+                        }));
+                        return effects;
                     }
                 }
             }
         }
 
-        let ctx = NavigationContext::new(&self.state.doc);
-        let doc_start = Cursor::move_to_document_start(&ctx, self.pages());
-        let doc_end = Cursor::move_to_document_end(&ctx, self.pages());
+        let Some(root) = self.state.doc.node(NodeId::ROOT) else {
+            return effects;
+        };
+        let Some(start) = leaf_block_start(&root) else {
+            return effects;
+        };
+        let Some(end) = leaf_block_end(&root) else {
+            return effects;
+        };
 
-        if let (Some(start_sel), Some(end_sel)) = (doc_start, doc_end) {
-            let Ok((start, _)) = start_sel.as_sorted(&self.state.doc) else {
-                return vec![];
-            };
-            let Ok((_, end)) = end_sel.as_sorted(&self.state.doc) else {
-                return vec![];
-            };
-            self.transact(move |tr| {
-                tr.set_selection(Selection::new(start, end));
-                Ok(true)
-            })
-        } else {
-            vec![]
+        if current == Some((start, end)) {
+            return effects;
         }
+
+        effects.extend(self.transact(move |tr| {
+            tr.set_selection(Selection::new(start, end));
+            Ok(true)
+        }));
+        effects
     }
 
     pub(crate) fn handle_select_word(&mut self) -> Vec<Effect> {
@@ -678,6 +686,47 @@ mod tests {
     }
 
     #[test]
+    fn select_all_in_isolating_node_second_press_selects_whole_document() {
+        let mut before = id!();
+        let mut inside = id!();
+        let mut after = id!();
+
+        let mut rt = runtime! {
+            viewport { 800, 600, 1.0 }
+            doc {
+                @before paragraph {
+                    text { "before" }
+                }
+                fold {
+                    fold_title {
+                        text { "title" }
+                    }
+                    fold_content {
+                        @inside paragraph {
+                            text { "inside fold" }
+                        }
+                    }
+                }
+                @after paragraph {
+                    text { "after" }
+                }
+            }
+            selection { (inside, 3) }
+        };
+
+        rt.layout();
+        rt.update(Message::SelectAll);
+        rt.update(Message::SelectAll);
+
+        let selection = &rt.state().selection;
+        assert_eq!(selection.anchor.node_id, before);
+        assert_eq!(selection.anchor.offset, 0);
+        assert_eq!(selection.head.node_id, after);
+        assert_eq!(selection.head.offset, 5);
+        assert_eq!(selection.head.affinity, Affinity::Upstream);
+    }
+
+    #[test]
     fn select_all_in_fold_with_multiple_paragraphs() {
         let mut p1 = id!();
         let mut p2 = id!();
@@ -933,6 +982,37 @@ mod tests {
         assert_eq!(selection.anchor.offset, 0);
         assert_eq!(selection.head.node_id, p2);
         assert_eq!(selection.head.offset, 6);
+    }
+
+    #[test]
+    fn select_all_during_preedit_commits_text_before_expanding_selection() {
+        let mut p = id!();
+
+        let mut rt = runtime! {
+            viewport { 800, 600, 1.0 }
+            doc {
+                @p paragraph { text { "start " } }
+            }
+            selection { (p, 6) }
+        };
+
+        rt.layout();
+        rt.update(Message::CompositionUpdate {
+            text: "한".to_string(),
+            replace_length: None,
+        });
+
+        rt.update(Message::SelectAll);
+        rt.update(Message::CommitPreedit);
+
+        assert_eq!(rt.state().doc.to_plain_text(), "start 한");
+        assert!(rt.state().preedit.is_none());
+
+        let selection = &rt.state().selection;
+        assert_eq!(selection.anchor.node_id, p);
+        assert_eq!(selection.anchor.offset, 0);
+        assert_eq!(selection.head.node_id, p);
+        assert_eq!(selection.head.offset, 7);
     }
 
     #[test]

--- a/crates/editor/src/state/position_helpers.rs
+++ b/crates/editor/src/state/position_helpers.rs
@@ -218,15 +218,14 @@ pub fn leaf_block_end(node: &NodeRef<'_>) -> Option<Position> {
         return Some(Position::new(
             node.node_id(),
             block_content_len(node),
-            Affinity::Downstream,
+            Affinity::Upstream,
         ));
     }
 
     if node.spec().map_or(false, |s| s.content.is_leaf()) || node.last_child().is_none() {
         let parent_id = node.parent_id()?;
         let idx = node.index()?;
-        // TODO: Upstream으로 바꿔야 함
-        return Some(Position::new(parent_id, idx + 1, Affinity::Downstream));
+        return Some(Position::new(parent_id, idx + 1, Affinity::Upstream));
     }
 
     let child = node.last_child()?;
@@ -467,7 +466,7 @@ mod tests {
         assert_eq!(start_pos, Position::new(root_id, 0, Affinity::Downstream));
 
         let end_pos = leaf_block_end(&image).unwrap();
-        assert_eq!(end_pos, Position::new(root_id, 1, Affinity::Downstream));
+        assert_eq!(end_pos, Position::new(root_id, 1, Affinity::Upstream));
     }
 
     #[test]
@@ -484,7 +483,7 @@ mod tests {
         assert_eq!(start_pos, Position::new(root_id, 0, Affinity::Downstream));
 
         let end_pos = leaf_block_end(&blockquote).unwrap();
-        assert_eq!(end_pos, Position::new(root_id, 1, Affinity::Downstream));
+        assert_eq!(end_pos, Position::new(root_id, 1, Affinity::Upstream));
     }
 
     #[test]
@@ -503,7 +502,7 @@ mod tests {
         assert_eq!(start_pos, Position::new(p, 0, Affinity::Downstream));
 
         let end_pos = leaf_block_end(&blockquote).unwrap();
-        assert_eq!(end_pos, Position::new(p, 1, Affinity::Downstream));
+        assert_eq!(end_pos, Position::new(p, 1, Affinity::Upstream));
     }
 
     #[test]
@@ -519,7 +518,7 @@ mod tests {
         assert_eq!(start_pos, Position::new(p, 0, Affinity::Downstream));
 
         let end_pos = leaf_block_end(&paragraph).unwrap();
-        assert_eq!(end_pos, Position::new(p, 5, Affinity::Downstream));
+        assert_eq!(end_pos, Position::new(p, 5, Affinity::Upstream));
     }
 
     #[test]
@@ -545,7 +544,7 @@ mod tests {
         assert_eq!(start_pos, Position::new(p, 0, Affinity::Downstream));
 
         let end_pos = leaf_block_end(&blockquote).unwrap();
-        assert_eq!(end_pos, Position::new(p, 6, Affinity::Downstream));
+        assert_eq!(end_pos, Position::new(p, 6, Affinity::Upstream));
     }
 
     #[test]
@@ -565,7 +564,7 @@ mod tests {
         assert_eq!(start_pos, Position::new(bq, 0, Affinity::Downstream));
 
         let end_pos = leaf_block_end(&blockquote).unwrap();
-        assert_eq!(end_pos, Position::new(bq, 1, Affinity::Downstream));
+        assert_eq!(end_pos, Position::new(bq, 1, Affinity::Upstream));
     }
 
     #[test]


### PR DESCRIPTION
안드로이드에서 전체선택 시 조합중이던 글자가 사라지는 문제를 해결함
leaf_block_end가 upstream을 반환하게 함