### PR TITLE
앱 스크롤, 프레임 싱크 등 디버그

### DIFF
--- a/apps/mobile/lib/screens/native_editor/controller/keyboard.dart
+++ b/apps/mobile/lib/screens/native_editor/controller/keyboard.dart
@@ -71,7 +71,7 @@ class KeyboardHandler {
 
   final void Function(Map<String, dynamic> message) dispatch;
   final void Function() reconcileInput;
-  final void Function({ScrollMode mode}) scrollIntoView;
+  final void Function({ScrollMode mode, bool waitForCursorUpdate}) scrollIntoView;
   final void Function(String action) onShortcut;
 
   bool handleKeyEvent(KeyEvent event) {
@@ -95,7 +95,7 @@ class KeyboardHandler {
     dispatch(message);
 
     if (type == 'navigate') {
-      scrollIntoView(mode: ScrollMode.typewriter);
+      scrollIntoView(mode: ScrollMode.typewriter, waitForCursorUpdate: true);
     } else if (type == 'deleteForward' || type == 'deleteWordForward') {
       scrollIntoView(mode: ScrollMode.typewriter);
     } else {

--- a/apps/mobile/lib/screens/native_editor/view/editor.dart
+++ b/apps/mobile/lib/screens/native_editor/view/editor.dart
@@ -107,11 +107,9 @@ class EditorView extends HookWidget {
     final interactionState = useMemoized(EditorInteractionState.new);
     final pendingScroll = useValueNotifier<VoidCallback?>(null);
     final pendingScrollPageIdx = useValueNotifier<int?>(null);
+    final visualSyncPageIdx = useValueNotifier<int?>(null);
     final presentedViewport = useValueNotifier<PresentedViewport>(
-      PresentedViewport.base(
-        cursor: controller.state.cursor,
-        renderVersion: controller.state.cursor == null ? null : controller.state.renderVersion,
-      ),
+      PresentedViewport.base(cursor: controller.state.cursor, renderVersion: controller.state.renderVersion),
     );
     final zoomViewportWidth = useValueNotifier<double>(0);
     final displayZoom = useValueNotifier<double>(1);
@@ -462,6 +460,10 @@ class EditorView extends HookWidget {
       );
     }
 
+    void clearCursorFollowScroll() => cursorFollowScrollActive.value = false;
+
+    void clearTypewriterRecovery() => typewriterRecoveryPending.value = false;
+
     void registerCursorAutoScroll({required bool typewriter}) {
       cursorFollowScrollActive.value = true;
       cursorFollowScrollMode.value = typewriter ? ScrollMode.typewriter : ScrollMode.auto;
@@ -521,7 +523,7 @@ class EditorView extends HookWidget {
     }
 
     PresentedViewport buildPresentedViewportSnapshot({required CursorInfo? cursor, required bool projectTypewriter}) {
-      final renderVersion = cursor == null ? null : controller.state.renderVersion;
+      final renderVersion = controller.state.renderVersion;
       if (!projectTypewriter || cursor == null) {
         return PresentedViewport.base(cursor: cursor, renderVersion: renderVersion);
       }
@@ -576,12 +578,18 @@ class EditorView extends HookWidget {
       required CursorInfo nextCursor,
       required bool typewriter,
       required int? targetPageIdx,
+      int? visualTargetPageIdx,
+      bool scroll = true,
     }) {
       pendingScrollPageIdx.value = targetPageIdx;
+      visualSyncPageIdx.value = visualTargetPageIdx;
       pendingScroll.value = () {
         pendingScrollPageIdx.value = null;
+        visualSyncPageIdx.value = null;
         setRenderedCursorSnapshot(nextCursor, projectTypewriter: typewriter);
-        runCursorScroll(nextCursor, typewriter: typewriter);
+        if (scroll) {
+          runCursorScroll(nextCursor, typewriter: typewriter);
+        }
         syncInputCursorPosition(nextCursor);
       };
     }
@@ -605,12 +613,34 @@ class EditorView extends HookWidget {
       if (canApplyCursorScrollNow()) {
         pendingScroll.value = null;
         pendingScrollPageIdx.value = null;
+        visualSyncPageIdx.value = null;
         setRenderedCursorSnapshot(nextCursor, projectTypewriter: typewriter);
         runCursorScroll(nextCursor, typewriter: typewriter);
         syncInputCursorPosition(nextCursor);
       } else {
         queueRenderSynchronizedCursorUpdate(nextCursor: nextCursor, typewriter: typewriter, targetPageIdx: null);
       }
+    }
+
+    void applyCursorVisualOnly(CursorInfo nextCursor, {bool synchronizeWithRender = true}) {
+      final shouldSynchronizeWithRender =
+          synchronizeWithRender && !identical(presentedViewport.value.renderVersion, controller.state.renderVersion);
+      if (shouldSynchronizeWithRender) {
+        queueRenderSynchronizedCursorUpdate(
+          nextCursor: nextCursor,
+          typewriter: false,
+          targetPageIdx: nextCursor.pageIdx,
+          visualTargetPageIdx: nextCursor.pageIdx,
+          scroll: false,
+        );
+        return;
+      }
+
+      pendingScroll.value = null;
+      pendingScrollPageIdx.value = null;
+      visualSyncPageIdx.value = null;
+      setRenderedCursorSnapshot(nextCursor);
+      syncInputCursorPosition(nextCursor);
     }
 
     bool shouldUseTypewriterScrollForInteraction(InteractionSnapshot interaction, {ScrollMode? requestedMode}) {
@@ -869,13 +899,14 @@ class EditorView extends HookWidget {
           previousExternalElements.value = nextExternalElements;
 
           if (nextCursor == null && nextScrollTargetCursor == null) {
-            typewriterRecoveryPending.value = false;
-            cursorFollowScrollActive.value = false;
+            clearTypewriterRecovery();
+            clearCursorFollowScroll();
             if (pendingMode != null && !controller.pendingScrollWaitForCursorUpdate) {
               controller.clearPendingScroll();
             }
             pendingScroll.value = null;
             pendingScrollPageIdx.value = null;
+            visualSyncPageIdx.value = null;
             setRenderedCursorSnapshot(null);
             return;
           }
@@ -885,16 +916,17 @@ class EditorView extends HookWidget {
           final blockedByInteraction = interaction.isLongPressing || interaction.isDndActive || !focused;
           if (blockedByInteraction || nextLayout == null || nextScrollTargetCursor == null) {
             if (blockedByInteraction) {
-              typewriterRecoveryPending.value = false;
+              clearTypewriterRecovery();
             }
             if (!focused || nextScrollTargetCursor == null) {
-              cursorFollowScrollActive.value = false;
+              clearCursorFollowScroll();
             }
             if (pendingMode != null && !controller.pendingScrollWaitForCursorUpdate) {
               controller.clearPendingScroll();
             }
             pendingScroll.value = null;
             pendingScrollPageIdx.value = null;
+            visualSyncPageIdx.value = null;
             setRenderedCursorSnapshot(nextCursor);
             return;
           }
@@ -912,29 +944,36 @@ class EditorView extends HookWidget {
             return;
           }
 
+          if (nextSelection?.collapsed == false) {
+            clearTypewriterRecovery();
+            clearCursorFollowScroll();
+            final visualCursor = nextCursor ?? nextScrollTargetCursor;
+            applyCursorVisualOnly(visualCursor);
+            return;
+          }
+
           if (externalElementsChanged) {
             if (cursorFollowScrollActive.value) {
               final followTypewriter = shouldUseTypewriterScrollForInteraction(
                 interaction,
                 requestedMode: cursorFollowScrollMode.value,
               );
-              typewriterRecoveryPending.value = false;
+              clearTypewriterRecovery();
               applyCursorScrollAndVisual(nextScrollTargetCursor, typewriter: followTypewriter);
               return;
             }
 
             if (typewriterRecoveryPending.value &&
                 shouldUseTypewriterScrollForInteraction(interaction, requestedMode: ScrollMode.typewriter)) {
-              typewriterRecoveryPending.value = false;
+              clearTypewriterRecovery();
               applyCursorScrollAndVisual(nextScrollTargetCursor, typewriter: true);
               return;
             }
 
-            typewriterRecoveryPending.value = false;
+            clearTypewriterRecovery();
             setRenderedCursorSnapshot(nextCursor);
             return;
           }
-
           applyCursorScrollAndVisual(nextScrollTargetCursor, typewriter: false);
         }
 
@@ -1157,6 +1196,7 @@ class EditorView extends HookWidget {
         subtitleFocusNode: subtitleFocusNode,
         pendingScroll: pendingScroll,
         pendingScrollPageIdx: pendingScrollPageIdx,
+        visualSyncPageIdx: visualSyncPageIdx,
         presentedViewport: presentedViewport,
         displayZoom: displayZoom,
         renderZoom: renderZoom,
@@ -1197,8 +1237,8 @@ class EditorView extends HookWidget {
                         NotificationListener<UserScrollNotification>(
                           onNotification: (notification) {
                             if (notification.direction != ScrollDirection.idle) {
-                              cursorFollowScrollActive.value = false;
-                              typewriterRecoveryPending.value = false;
+                              clearCursorFollowScroll();
+                              clearTypewriterRecovery();
                             }
                             return false;
                           },

--- a/apps/mobile/lib/screens/native_editor/view/interaction/gestures/tap_gesture.dart
+++ b/apps/mobile/lib/screens/native_editor/view/interaction/gestures/tap_gesture.dart
@@ -113,7 +113,6 @@ extension TapGestureMethods on EditorInteractionController {
     );
 
     if (clickCount != 1) {
-      scope.controller.scrollIntoView();
       return;
     }
 

--- a/apps/mobile/lib/screens/native_editor/view/interaction/semantics/selection_expansion_semantic.dart
+++ b/apps/mobile/lib/screens/native_editor/view/interaction/semantics/selection_expansion_semantic.dart
@@ -111,7 +111,6 @@ extension SelectionExpansionSemanticActions on EditorInteractionController {
       clickCount: 2,
       isShiftPressed: false,
     );
-    scope.controller.scrollIntoView();
     return true;
   }
 

--- a/apps/mobile/lib/screens/native_editor/view/page.dart
+++ b/apps/mobile/lib/screens/native_editor/view/page.dart
@@ -29,6 +29,7 @@ class PageItem extends HookWidget {
     final pref = useService<Pref>();
     final editorState = scope.controller.state;
     final renderedCursor = useValueListenable(scope.presentedViewport).cursor;
+    final visualSyncPageIdx = useValueListenable(scope.visualSyncPageIdx);
 
     final layout = editorState.layout!;
     final pageCursor = renderedCursor?.pageIdx == pageIndex ? renderedCursor : null;
@@ -55,9 +56,11 @@ class PageItem extends HookWidget {
     final isMounted = useRef(true);
     final retryAttempts = useRef(0);
     final retryTimer = useRef<Timer?>(null);
+    final initialRenderTimer = useRef<Timer?>(null);
     final isRenderTaskRunning = useRef(false);
     final hasQueuedRender = useRef(false);
     final latestLogicalSize = useRef<Size>(Size.zero)..value = Size(logicalPageWidth, logicalPageHeight);
+    final shouldRenderImmediately = visualSyncPageIdx == pageIndex;
 
     void resetRetryState() {
       retryAttempts.value = 0;
@@ -150,17 +153,39 @@ class PageItem extends HookWidget {
     }
 
     useEffect(() {
-      final timer = Timer(const Duration(milliseconds: 150), () {
-        unawaited(render());
-      });
+      void kickInitialRender() {
+        initialRenderTimer.value?.cancel();
+        if (shouldRenderImmediately) {
+          unawaited(render());
+          return;
+        }
+
+        initialRenderTimer.value = Timer(const Duration(milliseconds: 150), () {
+          initialRenderTimer.value = null;
+          unawaited(render());
+        });
+      }
+
+      kickInitialRender();
       return () {
-        timer.cancel();
+        initialRenderTimer.value?.cancel();
+        initialRenderTimer.value = null;
         retryTimer.value?.cancel();
         retryTimer.value = null;
         isMounted.value = false;
         unawaited(renderer.value?.dispose());
       };
     }, const []);
+
+    useEffect(() {
+      if (!shouldRenderImmediately || renderer.value?.textureId != null) {
+        return null;
+      }
+      initialRenderTimer.value?.cancel();
+      initialRenderTimer.value = null;
+      unawaited(render());
+      return null;
+    }, [shouldRenderImmediately]);
 
     useEffect(() {
       resetRetryState();

--- a/apps/mobile/lib/screens/native_editor/view/pages.dart
+++ b/apps/mobile/lib/screens/native_editor/view/pages.dart
@@ -33,6 +33,7 @@ class PageList extends HookWidget {
     final pages = state.state.pages;
     final cursor = state.state.cursor;
     final presentedViewport = useValueListenable(scope.presentedViewport);
+    final visualSyncPageIdx = useValueListenable(scope.visualSyncPageIdx);
     final renderedCursor = presentedViewport.cursor;
     final isFocused = state.state.isFocused;
     final selection = state.state.selection;
@@ -311,7 +312,7 @@ class PageList extends HookWidget {
                                             pageIndex: i,
                                             pageTop: geo.titleAreaHeight + offsets[i],
                                             pageBottom: geo.titleAreaHeight + offsets[i] + geo.pageHeightAt(i),
-                                            activeCursorPageIdx: renderedCursor?.pageIdx,
+                                            activeCursorPageIdx: visualSyncPageIdx ?? renderedCursor?.pageIdx,
                                           ),
                                         ],
                                       ],

--- a/apps/mobile/lib/screens/native_editor/view/scope.dart
+++ b/apps/mobile/lib/screens/native_editor/view/scope.dart
@@ -57,6 +57,7 @@ class ContentScope extends InheritedWidget {
     required this.subtitleFocusNode,
     required this.pendingScroll,
     required this.pendingScrollPageIdx,
+    required this.visualSyncPageIdx,
     required this.presentedViewport,
     required this.dndController,
     required this.interactionState,
@@ -88,6 +89,7 @@ class ContentScope extends InheritedWidget {
   final FocusNode subtitleFocusNode;
   final ValueNotifier<VoidCallback?> pendingScroll;
   final ValueNotifier<int?> pendingScrollPageIdx;
+  final ValueNotifier<int?> visualSyncPageIdx;
   final ValueNotifier<PresentedViewport> presentedViewport;
   final ValueNotifier<double> displayZoom;
   final ValueNotifier<double> renderZoom;

--- a/apps/mobile/lib/screens/native_editor/view/zoom.dart
+++ b/apps/mobile/lib/screens/native_editor/view/zoom.dart
@@ -222,7 +222,7 @@ HorizontalScrollMetrics resolveHorizontalScrollMetrics({
   final positions = controller.positions.where((position) => position.hasContentDimensions).toList(growable: false);
   if (positions.isEmpty) {
     final fallbackPosition = resolveScrollPosition(controller);
-    if (fallbackPosition != null) {
+    if (fallbackPosition != null && fallbackPosition.hasContentDimensions) {
       _preferredHorizontalPositionByController[controller] = fallbackPosition;
       return _resolvedHorizontalMetrics(position: fallbackPosition, contentWidth: contentWidth);
     }

--- a/apps/mobile/test/screens/native_editor/controller/keyboard_test.dart
+++ b/apps/mobile/test/screens/native_editor/controller/keyboard_test.dart
@@ -1,3 +1,7 @@
+// Uses legacy synthetic key-data helpers because WidgetTester does not expose an
+// equivalent path for the IME-remapped physical-key fallback coverage below.
+// ignore_for_file: deprecated_member_use
+
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
@@ -72,7 +76,7 @@ void main() {
     final handler = KeyboardHandler(
       dispatch: (_) {},
       reconcileInput: () {},
-      scrollIntoView: ({ScrollMode mode = ScrollMode.auto}) {},
+      scrollIntoView: ({ScrollMode mode = ScrollMode.auto, bool waitForCursorUpdate = false}) {},
       onShortcut: shortcuts.add,
     );
 
@@ -87,7 +91,7 @@ void main() {
     final handler = KeyboardHandler(
       dispatch: (_) {},
       reconcileInput: () {},
-      scrollIntoView: ({ScrollMode mode = ScrollMode.auto}) {},
+      scrollIntoView: ({ScrollMode mode = ScrollMode.auto, bool waitForCursorUpdate = false}) {},
       onShortcut: shortcuts.add,
     );
 
@@ -102,7 +106,7 @@ void main() {
     final handler = KeyboardHandler(
       dispatch: dispatches.add,
       reconcileInput: () {},
-      scrollIntoView: ({ScrollMode mode = ScrollMode.auto}) {},
+      scrollIntoView: ({ScrollMode mode = ScrollMode.auto, bool waitForCursorUpdate = false}) {},
       onShortcut: (_) {},
     );
 
@@ -119,7 +123,7 @@ void main() {
     final handler = KeyboardHandler(
       dispatch: dispatches.add,
       reconcileInput: () {},
-      scrollIntoView: ({ScrollMode mode = ScrollMode.auto}) {},
+      scrollIntoView: ({ScrollMode mode = ScrollMode.auto, bool waitForCursorUpdate = false}) {},
       onShortcut: (_) {},
     );
 
@@ -136,7 +140,7 @@ void main() {
     final handler = KeyboardHandler(
       dispatch: (_) {},
       reconcileInput: () {},
-      scrollIntoView: ({ScrollMode mode = ScrollMode.auto}) {},
+      scrollIntoView: ({ScrollMode mode = ScrollMode.auto, bool waitForCursorUpdate = false}) {},
       onShortcut: shortcuts.add,
     );
 
@@ -151,7 +155,7 @@ void main() {
     final handler = KeyboardHandler(
       dispatch: (_) {},
       reconcileInput: () {},
-      scrollIntoView: ({ScrollMode mode = ScrollMode.auto}) {},
+      scrollIntoView: ({ScrollMode mode = ScrollMode.auto, bool waitForCursorUpdate = false}) {},
       onShortcut: shortcuts.add,
     );
 
@@ -166,7 +170,7 @@ void main() {
     final handler = KeyboardHandler(
       dispatch: (_) {},
       reconcileInput: () {},
-      scrollIntoView: ({ScrollMode mode = ScrollMode.auto}) {},
+      scrollIntoView: ({ScrollMode mode = ScrollMode.auto, bool waitForCursorUpdate = false}) {},
       onShortcut: shortcuts.add,
     );
 
@@ -195,7 +199,7 @@ void main() {
     final handler = KeyboardHandler(
       dispatch: (_) {},
       reconcileInput: () {},
-      scrollIntoView: ({ScrollMode mode = ScrollMode.auto}) {},
+      scrollIntoView: ({ScrollMode mode = ScrollMode.auto, bool waitForCursorUpdate = false}) {},
       onShortcut: shortcuts.add,
     );
 
@@ -209,5 +213,23 @@ void main() {
     );
 
     expect(shortcuts, isEmpty);
+  });
+
+  testWidgets('navigation waits for cursor update before consuming scroll intent', (tester) async {
+    final scrollCalls = <({ScrollMode mode, bool waitForCursorUpdate})>[];
+    final handler = KeyboardHandler(
+      dispatch: (_) {},
+      reconcileInput: () {},
+      scrollIntoView: ({ScrollMode mode = ScrollMode.auto, bool waitForCursorUpdate = false}) {
+        scrollCalls.add((mode: mode, waitForCursorUpdate: waitForCursorUpdate));
+      },
+      onShortcut: (_) {},
+    );
+
+    await _pumpHarness(tester, handler);
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.arrowUp);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.arrowUp);
+
+    expect(scrollCalls, [(mode: ScrollMode.typewriter, waitForCursorUpdate: true)]);
   });
 }

--- a/apps/mobile/test/screens/native_editor/view/page_list_interaction_test.dart
+++ b/apps/mobile/test/screens/native_editor/view/page_list_interaction_test.dart
@@ -85,6 +85,7 @@ class _PageListHarnessDeps {
     required this.subtitle,
     required this.pendingScroll,
     required this.pendingScrollPageIdx,
+    required this.visualSyncPageIdx,
     required this.presentedViewport,
     required this.displayZoom,
     required this.renderZoom,
@@ -164,6 +165,7 @@ class _PageListHarnessDeps {
       subtitle: ValueNotifier<String>(''),
       pendingScroll: ValueNotifier<VoidCallback?>(null),
       pendingScrollPageIdx: ValueNotifier<int?>(null),
+      visualSyncPageIdx: ValueNotifier<int?>(null),
       presentedViewport: ValueNotifier(const PresentedViewport.base(cursor: null, renderVersion: null)),
       displayZoom: displayZoom,
       renderZoom: renderZoom,
@@ -198,6 +200,7 @@ class _PageListHarnessDeps {
   final ValueNotifier<String> subtitle;
   final ValueNotifier<VoidCallback?> pendingScroll;
   final ValueNotifier<int?> pendingScrollPageIdx;
+  final ValueNotifier<int?> visualSyncPageIdx;
   final ValueNotifier<PresentedViewport> presentedViewport;
   final ValueNotifier<double> displayZoom;
   final ValueNotifier<double> renderZoom;
@@ -239,6 +242,7 @@ class _PageListHarnessDeps {
         subtitleFocusNode: subtitleFocusNode,
         pendingScroll: pendingScroll,
         pendingScrollPageIdx: pendingScrollPageIdx,
+        visualSyncPageIdx: visualSyncPageIdx,
         presentedViewport: presentedViewport,
         dndController: dndController,
         interactionState: interactionState,
@@ -299,6 +303,7 @@ class _PageListHarnessDeps {
     subtitle.dispose();
     pendingScroll.dispose();
     pendingScrollPageIdx.dispose();
+    visualSyncPageIdx.dispose();
     presentedViewport.dispose();
     displayZoom.dispose();
     renderZoom.dispose();
@@ -710,6 +715,38 @@ void main() {
       expect(click1, 0);
     });
 
+    testWidgets('double-tap on existing selection does not queue scroll intent', (tester) async {
+      final deps = _PageListHarnessDeps.create(selectionHit: true);
+      addTearDown(deps.dispose);
+      deps.controller.updateState(
+        (state) => state.copyWith(
+          selection: const EditorSelection(
+            collapsed: false,
+            cmp: 1,
+            range: {
+              'anchor': {'nodeId': 'n1', 'offset': 3, 'affinity': 'forward'},
+              'head': {'nodeId': 'n1', 'offset': 8, 'affinity': 'forward'},
+            },
+          ),
+        ),
+      );
+      await tester.pumpWidget(deps.build());
+      await tester.pumpAndSettle();
+
+      final point = interactionPoint(tester, deps);
+
+      await quickTap(tester, point);
+      deps.editor.clearTestDispatchedMessages();
+      await quickTap(tester, point);
+      await tester.pump();
+
+      expect(deps.controller.pendingScrollMode, isNull);
+      expect(deps.pendingScroll.value, isNull);
+
+      final pointerDowns = deps.editor.testDispatchedMessages.where((message) => message['type'] == 'pointerDown');
+      expect(pointerDowns.where((message) => message['clickCount'] == 2).length, 1);
+    });
+
     testWidgets('double-tap drag does not extend until selection bounds are materialized', (tester) async {
       final deps = _PageListHarnessDeps.create();
       addTearDown(deps.dispose);
@@ -760,6 +797,53 @@ void main() {
         orElse: () => <String, dynamic>{},
       );
       expect(extendEvent.isNotEmpty, isTrue);
+    });
+
+    testWidgets('selection handles resync after render completes without cursor', (tester) async {
+      final deps = _PageListHarnessDeps.create();
+      addTearDown(deps.dispose);
+
+      final initialRenderVersion = Object();
+      final updatedRenderVersion = Object();
+
+      deps.controller.updateState(
+        (state) => state.copyWith(selection: seededRangeSelection(), renderVersion: initialRenderVersion),
+      );
+      deps.presentedViewport.value = PresentedViewport.base(cursor: null, renderVersion: initialRenderVersion);
+
+      await tester.pumpWidget(deps.build());
+      await tester.pumpAndSettle();
+
+      final handles = find.byType(SelectionHandle);
+      expect(handles, findsWidgets);
+
+      final before = tester.getTopLeft(handles.last);
+
+      deps.controller.updateState(
+        (state) => state.copyWith(
+          selection: const EditorSelection(
+            collapsed: false,
+            cmp: 1,
+            anchorBounds: SelectionEndpointBounds(pageIdx: 0, x: 120, y: 320, width: 1, height: 20),
+            headBounds: SelectionEndpointBounds(pageIdx: 0, x: 180, y: 240, width: 1, height: 20),
+            range: {
+              'anchor': {'nodeId': 'n1', 'offset': 3, 'affinity': 'forward'},
+              'head': {'nodeId': 'n1', 'offset': 12, 'affinity': 'forward'},
+            },
+          ),
+          renderVersion: updatedRenderVersion,
+        ),
+      );
+      await tester.pump();
+
+      final held = tester.getTopLeft(handles.last);
+      expect((held.dy - before.dy).abs(), lessThan(1));
+
+      deps.presentedViewport.value = PresentedViewport.base(cursor: null, renderVersion: updatedRenderVersion);
+      await tester.pump();
+
+      final after = tester.getTopLeft(handles.last);
+      expect(after.dy, lessThan(before.dy - 40));
     });
 
     testWidgets('double-tap selection handle drag locks pan before first extension', (tester) async {


### PR DESCRIPTION
- 앱에서도 전체 선택 시 head로 스크롤되지 않도록 함
- 위 수정이 아래 동작들을 깨지 않도록 수정함
    - head가 보이지 않는 페이지에 있어서 렌더링되지 않아도 셀렉션 핸들과 커서가 업데이트되도록 함
    - 프레임 싱크가 깨지지 않도록 함