### PR TITLE
first visible font 기준으로 줄별 strut metric을 계산하도록 함

### DIFF
--- a/crates/editor/src/layout/elements/line.rs
+++ b/crates/editor/src/layout/elements/line.rs
@@ -1,4 +1,5 @@
 use crate::global::{TextBrush, font_version};
+use crate::layout::StrutMetrics;
 use crate::layout::cursor::{CursorNavigable, CursorNavigation, NavigationContext};
 use crate::model::{NodeId, PreeditDecor, SelectionDecor};
 use crate::state::{Position, Selection};
@@ -1339,9 +1340,8 @@ pub fn build_metrics(
     layout: &parley::Layout<TextBrush>,
     text: &str,
     scale_factor: f64,
-    strut_ascent: f32,
-    strut_descent: f32,
-    strut_font_size: f32,
+    default_strut: StrutMetrics,
+    per_line_struts: Option<&[StrutMetrics]>,
     line_height_ratio: f32,
 ) -> Vec<LineMetric> {
     let mut lines = Vec::new();
@@ -1350,22 +1350,16 @@ pub fn build_metrics(
     let global_grapheme_offsets = compute_grapheme_boundaries(text);
 
     let mut top = 0.0;
-    let safe_strut_font_size = if strut_font_size > 0.0 {
-        strut_font_size
-    } else {
-        1.0
-    };
-    let ascent_ratio = (strut_ascent.max(0.0)) / safe_strut_font_size;
-    let descent_ratio = (strut_descent.max(0.0)) / safe_strut_font_size;
-    let fallback_ascent = strut_ascent.max(0.0);
-    let fallback_descent = strut_descent.max(0.0);
     let safe_line_height_ratio = if line_height_ratio > 0.0 {
         line_height_ratio
     } else {
         1.0
     };
 
-    for line in layout.lines() {
+    for (line_idx, line) in layout.lines().enumerate() {
+        let line_strut = per_line_struts
+            .and_then(|metrics| metrics.get(line_idx).copied())
+            .unwrap_or(default_strut);
         let line_metrics = line.metrics();
 
         let mut clusters = Vec::new();
@@ -1448,6 +1442,16 @@ pub fn build_metrics(
                 }
             }
         }
+
+        let safe_strut_font_size = if line_strut.font_size > 0.0 {
+            line_strut.font_size
+        } else {
+            1.0
+        };
+        let ascent_ratio = (line_strut.ascent.max(0.0)) / safe_strut_font_size;
+        let descent_ratio = (line_strut.descent.max(0.0)) / safe_strut_font_size;
+        let fallback_ascent = line_strut.ascent.max(0.0);
+        let fallback_descent = line_strut.descent.max(0.0);
 
         let line_font_size = if max_run_font_size > 0.0 {
             max_run_font_size

--- a/crates/editor/src/layout/mod.rs
+++ b/crates/editor/src/layout/mod.rs
@@ -6,6 +6,7 @@ pub mod elements;
 mod page;
 mod paginator;
 pub mod query;
+pub mod strut;
 
 pub use cache::LayoutCache;
 pub use context::LayoutContext;
@@ -14,3 +15,4 @@ pub use element::{
 };
 pub use page::Page;
 pub use paginator::Paginator;
+pub use strut::{StrutMetrics, measure_strut, measure_strut_with_styles};

--- a/crates/editor/src/layout/strut.rs
+++ b/crates/editor/src/layout/strut.rs
@@ -1,0 +1,123 @@
+use crate::global::TextBrush;
+use crate::model::Style;
+use parley::style::*;
+use std::borrow::Cow;
+use std::ops::Range;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct StrutMetrics {
+    pub ascent: f32,
+    pub descent: f32,
+    pub font_size: f32,
+}
+
+pub fn measure_strut(
+    lcx: &mut parley::LayoutContext<TextBrush>,
+    fcx: &mut parley::FontContext,
+    family: &str,
+    weight: u16,
+    font_size_px: f32,
+    line_height: f32,
+) -> StrutMetrics {
+    measure_strut_inner(
+        lcx,
+        fcx,
+        family,
+        weight,
+        font_size_px,
+        line_height,
+        None,
+        0,
+        |_builder, _style, _range, _font_size| {},
+    )
+}
+
+pub fn measure_strut_with_styles<ApplyStyle>(
+    lcx: &mut parley::LayoutContext<TextBrush>,
+    fcx: &mut parley::FontContext,
+    family: &str,
+    weight: u16,
+    font_size_px: f32,
+    line_height: f32,
+    extra_styles: &[Style],
+    extra_style_default_font_size: u32,
+    apply_style: ApplyStyle,
+) -> StrutMetrics
+where
+    ApplyStyle: for<'a> FnMut(&mut parley::RangedBuilder<'a, TextBrush>, &Style, Range<usize>, u32),
+{
+    measure_strut_inner(
+        lcx,
+        fcx,
+        family,
+        weight,
+        font_size_px,
+        line_height,
+        Some(extra_styles),
+        extra_style_default_font_size,
+        apply_style,
+    )
+}
+
+fn measure_strut_inner<ApplyStyle>(
+    lcx: &mut parley::LayoutContext<TextBrush>,
+    fcx: &mut parley::FontContext,
+    family: &str,
+    weight: u16,
+    font_size_px: f32,
+    line_height: f32,
+    extra_styles: Option<&[Style]>,
+    extra_style_default_font_size: u32,
+    mut apply_style: ApplyStyle,
+) -> StrutMetrics
+where
+    ApplyStyle: for<'a> FnMut(&mut parley::RangedBuilder<'a, TextBrush>, &Style, Range<usize>, u32),
+{
+    let mut dummy_builder = lcx.ranged_builder(fcx, "\u{200B}", 1.0, false);
+    dummy_builder.push_default(StyleProperty::FontFamily(FontFamily::Single(
+        FontFamilyName::Named(family.to_string().into()),
+    )));
+    dummy_builder.push_default(StyleProperty::FontWeight(FontWeight::new(weight as f32)));
+    dummy_builder.push_default(StyleProperty::FontSize(font_size_px));
+    dummy_builder.push_default(StyleProperty::LineHeight(LineHeight::FontSizeRelative(
+        line_height,
+    )));
+    dummy_builder.push_default(StyleProperty::FontFeatures(FontFeatures::Source(
+        Cow::Owned("\"ss05\" 1, \"cv12\" 1, \"ss18\" 1".to_string()),
+    )));
+
+    if let Some(styles) = extra_styles {
+        let range = 0.."\u{200B}".len();
+        let font_size = styles
+            .iter()
+            .find_map(|style| {
+                if let Style::FontSize(font_size) = style {
+                    Some(font_size.size)
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(extra_style_default_font_size);
+        for style in styles {
+            apply_style(&mut dummy_builder, style, range.clone(), font_size);
+        }
+    }
+
+    let mut dummy_layout = dummy_builder.build("\u{200B}");
+    dummy_layout.break_all_lines(None);
+    let dummy_line = dummy_layout.lines().next().unwrap();
+    let dummy_metrics = dummy_line.metrics();
+    let dummy_font_size = dummy_line
+        .items()
+        .find_map(|item| match item {
+            parley::PositionedLayoutItem::GlyphRun(glyph_run) => Some(glyph_run.run().font_size()),
+            _ => None,
+        })
+        .unwrap_or(font_size_px);
+
+    StrutMetrics {
+        ascent: dummy_metrics.ascent,
+        descent: dummy_metrics.descent,
+        font_size: dummy_font_size,
+    }
+}

--- a/crates/editor/src/model/nodes/fold_title.rs
+++ b/crates/editor/src/model/nodes/fold_title.rs
@@ -1,6 +1,8 @@
 use crate::global::{GLOBALS, TextBrush};
 use crate::layout::elements::{FoldTitleIconElement, LineElement, build_metrics};
-use crate::layout::{Element, Layout, LayoutContext, LayoutNode, PageBreakPolicy, PositionedNode};
+use crate::layout::{
+    Element, Layout, LayoutContext, LayoutNode, PageBreakPolicy, PositionedNode, measure_strut,
+};
 use crate::model::html::{DomSpec, NodeHtmlCodec, NodeParseRule};
 use crate::model::{Node, PreeditDecor};
 use crate::types::{BoxConstraints, Point, Size};
@@ -177,40 +179,27 @@ impl Layout for FoldTitleNode {
                 parley::AlignmentOptions::default(),
             );
 
-            let mut dummy_builder = lcx.ranged_builder(&mut fcx, "\u{200B}", 1.0, false);
-            setup_defaults(&mut dummy_builder);
-
-            let mut dummy_layout = dummy_builder.build("\u{200B}");
-            dummy_layout.break_all_lines(None);
-            let dummy_line = dummy_layout.lines().next().unwrap();
-            let dummy_metrics = dummy_line.metrics();
-            let strut_font_size = dummy_line
-                .items()
-                .find_map(|item| match item {
-                    parley::PositionedLayoutItem::GlyphRun(glyph_run) => {
-                        Some(glyph_run.run().font_size())
-                    }
-                    _ => None,
-                })
-                .unwrap_or(14.0);
-
             (
                 layout,
-                dummy_metrics.ascent,
-                dummy_metrics.descent,
-                strut_font_size,
+                measure_strut(
+                    &mut lcx,
+                    &mut fcx,
+                    &cascade_family,
+                    FOLD_TITLE_FONT_WEIGHT,
+                    14.0,
+                    line_height,
+                ),
             )
         });
 
-        let (layout, strut_ascent, strut_descent, strut_font_size) = layout;
+        let (layout, strut_metrics) = layout;
         let layout = Rc::new(layout);
         let metrics = build_metrics(
             &layout,
             &text,
             ctx.scale_factor,
-            strut_ascent,
-            strut_descent,
-            strut_font_size,
+            strut_metrics,
+            None,
             line_height,
         );
 

--- a/crates/editor/src/model/nodes/paragraph.rs
+++ b/crates/editor/src/model/nodes/paragraph.rs
@@ -1,13 +1,16 @@
 use crate::global::{GLOBALS, TextBrush};
 use crate::layout::elements::{BackgroundSegment, LineElement, RubySegment, build_metrics};
-use crate::layout::{Element, Layout, LayoutContext, LayoutNode, PageBreakPolicy, PositionedNode};
+use crate::layout::{
+    Element, Layout, LayoutContext, LayoutNode, PageBreakPolicy, PositionedNode, StrutMetrics,
+    measure_strut, measure_strut_with_styles,
+};
 use crate::model::html::{DomSpec, NodeHtmlCodec, NodeParseRule, parse_styles};
 use crate::model::{Annotation, Node, PendingStylesDecor, PreeditDecor, Style};
 use crate::schema::Expand;
 use crate::types::{BoxConstraints, Point, Size};
 use crate::utils::{
-    LengthUnit, build_char_to_byte_offsets, char_to_byte_offset, char_to_byte_offset_with_map,
-    convert_length,
+    LengthUnit, build_char_to_byte_offsets, byte_to_char_offset_with_map, char_to_byte_offset,
+    char_to_byte_offset_with_map, convert_length,
 };
 use macros::Codec;
 use parley::style::*;
@@ -56,6 +59,119 @@ fn pending_styles_for_node<'a>(ctx: &'a LayoutContext<'a>) -> Option<&'a Pending
         Some(ps)
     } else {
         None
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct StrutFontDefaults {
+    family: String,
+    weight: u16,
+    font_size: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DeclaredStrutRun {
+    start_offset: usize,
+    end_offset: usize,
+    defaults: StrutFontDefaults,
+}
+
+fn resolve_strut_font_defaults(
+    ctx: &LayoutContext,
+    has_preedit: bool,
+    is_text_empty: bool,
+    cascade_family: &str,
+    cascade_weight: u16,
+    cascade_font_size: u32,
+) -> StrutFontDefaults {
+    let cascade_defaults = StrutFontDefaults {
+        family: cascade_family.to_string(),
+        weight: cascade_weight,
+        font_size: cascade_font_size,
+    };
+
+    if has_preedit || is_text_empty {
+        return cascade_defaults;
+    }
+
+    for child in ctx.node.children() {
+        match child.node() {
+            Some(Node::HardBreak(_)) => break,
+            Some(Node::Text(node)) => {
+                for segment in node.text.get_segments() {
+                    if segment.text.is_empty() {
+                        continue;
+                    }
+
+                    let family = segment
+                        .styles
+                        .iter()
+                        .find_map(|style| match style {
+                            Style::FontFamily(family) => Some(family.family.clone()),
+                            _ => None,
+                        })
+                        .unwrap_or_else(|| cascade_defaults.family.clone());
+                    let weight = segment
+                        .styles
+                        .iter()
+                        .find_map(|style| match style {
+                            Style::FontWeight(weight) => Some(weight.weight),
+                            _ => None,
+                        })
+                        .unwrap_or(cascade_defaults.weight);
+                    let font_size = segment
+                        .styles
+                        .iter()
+                        .find_map(|style| match style {
+                            Style::FontSize(size) => Some(size.size),
+                            _ => None,
+                        })
+                        .unwrap_or(cascade_defaults.font_size);
+
+                    return StrutFontDefaults {
+                        family,
+                        weight,
+                        font_size,
+                    };
+                }
+            }
+            _ => {}
+        }
+    }
+
+    cascade_defaults
+}
+
+fn resolve_declared_segment_strut_defaults(
+    styles: &[Style],
+    cascade_defaults: &StrutFontDefaults,
+) -> StrutFontDefaults {
+    let family = styles
+        .iter()
+        .find_map(|style| match style {
+            Style::FontFamily(family) => Some(family.family.clone()),
+            _ => None,
+        })
+        .unwrap_or_else(|| cascade_defaults.family.clone());
+    let weight = styles
+        .iter()
+        .find_map(|style| match style {
+            Style::FontWeight(weight) => Some(weight.weight),
+            _ => None,
+        })
+        .unwrap_or(cascade_defaults.weight);
+    let font_size = styles
+        .iter()
+        .find_map(|style| match style {
+            Style::FontSize(size) => Some(size.size),
+            _ => None,
+        })
+        .unwrap_or(cascade_defaults.font_size);
+
+    StrutFontDefaults {
+        family,
+        weight,
+        font_size,
     }
 }
 
@@ -502,6 +618,7 @@ impl Layout for ParagraphNode {
 
         let layout = GLOBALS.with(|globals| {
             use parley::style::*;
+            use rustc_hash::FxHashMap;
 
             let globals = globals.borrow();
 
@@ -533,6 +650,12 @@ impl Layout for ParagraphNode {
 
             let font_mappings = globals.font_mappings.borrow();
             let font_interner = globals.font_family_interner.borrow();
+            let mut declared_strut_runs = Vec::new();
+            let cascade_defaults = StrutFontDefaults {
+                family: cascade_family.clone(),
+                weight: cascade_weight,
+                font_size: cascade_font_size,
+            };
 
             let mut offset = 0;
             for child in ctx.node.children() {
@@ -545,18 +668,19 @@ impl Layout for ParagraphNode {
                             let segment_len = segment.text.chars().count();
                             let base_start = offset + segment_offset;
                             let base_end = base_start + segment_len;
+                            let segment_defaults = resolve_declared_segment_strut_defaults(
+                                &segment.styles,
+                                &cascade_defaults,
+                            );
+                            let segment_font_size = segment_defaults.font_size;
 
-                            let segment_font_size = segment
-                                .styles
-                                .iter()
-                                .find_map(|s| {
-                                    if let Style::FontSize(fs) = s {
-                                        Some(fs.size)
-                                    } else {
-                                        None
-                                    }
-                                })
-                                .unwrap_or(1200);
+                            if segment_len > 0 {
+                                declared_strut_runs.push(DeclaredStrutRun {
+                                    start_offset: base_start,
+                                    end_offset: base_end,
+                                    defaults: segment_defaults.clone(),
+                                });
+                            }
 
                             // Build TextBrush from segment styles (color + embolden)
                             let has_embolden =
@@ -609,23 +733,8 @@ impl Layout for ParagraphNode {
                             }
 
                             // Mapping-based font family resolution (single pass)
-                            let segment_family = segment
-                                .styles
-                                .iter()
-                                .find_map(|s| match s {
-                                    Style::FontFamily(m) => Some(m.family.as_str()),
-                                    _ => None,
-                                })
-                                .unwrap_or(&cascade_family);
-
-                            let segment_weight = segment
-                                .styles
-                                .iter()
-                                .find_map(|s| match s {
-                                    Style::FontWeight(w) => Some(w.weight),
-                                    _ => None,
-                                })
-                                .unwrap_or(cascade_weight);
+                            let segment_family = segment_defaults.family.as_str();
+                            let segment_weight = segment_defaults.weight;
 
                             let interned_primary = font_interner
                                 .get(segment_family)
@@ -776,75 +885,97 @@ impl Layout for ParagraphNode {
                 );
             }
 
-            let (strut_ascent, strut_descent, strut_font_size) = {
-                let ps_styles = if preedit.is_some() || is_text_empty {
-                    pending_styles.map(|ps| &ps.styles[..])
-                } else {
-                    None
-                };
-
-                let mut dummy_builder = lcx.ranged_builder(&mut fcx, "\u{200B}", 1.0, false);
-                dummy_builder.push_default(StyleProperty::FontFamily(FontFamily::Single(
-                    FontFamilyName::Named(cascade_family.clone().into()),
-                )));
-                dummy_builder.push_default(StyleProperty::FontWeight(FontWeight::new(
-                    cascade_weight as f32,
-                )));
-                dummy_builder.push_default(StyleProperty::FontSize(convert_length(
-                    cascade_font_size as f32 / 100.0,
+            let (default_strut, per_line_struts) = {
+                let ps_styles = pending_styles.map(|ps| &ps.styles[..]);
+                let strut_defaults = resolve_strut_font_defaults(
+                    ctx,
+                    preedit.is_some(),
+                    is_text_empty,
+                    &cascade_family,
+                    cascade_weight,
+                    cascade_font_size,
+                );
+                let default_font_size_px = convert_length(
+                    strut_defaults.font_size as f32 / 100.0,
                     LengthUnit::Pt,
                     LengthUnit::Px,
-                )));
-                dummy_builder.push_default(StyleProperty::LineHeight(
-                    LineHeight::FontSizeRelative(line_height),
-                ));
-                dummy_builder.push_default(StyleProperty::FontFeatures(FontFeatures::Source(
-                    Cow::Owned("\"ss05\" 1, \"cv12\" 1, \"ss18\" 1".to_string()),
-                )));
+                );
+                let default_strut = if let Some(styles) =
+                    ps_styles.filter(|_| preedit.is_some() || is_text_empty)
+                {
+                    measure_strut_with_styles(
+                        &mut lcx,
+                        &mut fcx,
+                        &strut_defaults.family,
+                        strut_defaults.weight,
+                        default_font_size_px,
+                        line_height,
+                        styles,
+                        strut_defaults.font_size,
+                        apply_style_to_builder,
+                    )
+                } else {
+                    measure_strut(
+                        &mut lcx,
+                        &mut fcx,
+                        &strut_defaults.family,
+                        strut_defaults.weight,
+                        default_font_size_px,
+                        line_height,
+                    )
+                };
 
-                if let Some(styles) = ps_styles {
-                    let range = 0.."\u{200B}".len();
-                    let font_size = styles
-                        .iter()
-                        .find_map(|s| {
-                            if let Style::FontSize(fs) = s {
-                                Some(fs.size)
-                            } else {
-                                None
-                            }
-                        })
-                        .unwrap_or(1200);
-                    for style in styles {
-                        apply_style_to_builder(&mut dummy_builder, style, range.clone(), font_size);
-                    }
-                }
+                let per_line_struts: Option<Vec<StrutMetrics>> =
+                    if preedit.is_some() || is_text_empty {
+                        None
+                    } else {
+                        let mut cache: FxHashMap<StrutFontDefaults, StrutMetrics> =
+                            FxHashMap::default();
+                        let metrics = layout
+                            .lines()
+                            .map(|line| {
+                                let text_range = line.text_range();
+                                let line_start =
+                                    byte_to_char_offset_with_map(&char_to_byte, text_range.start);
+                                let line_end =
+                                    byte_to_char_offset_with_map(&char_to_byte, text_range.end);
 
-                let mut dummy_layout = dummy_builder.build("\u{200B}");
-                dummy_layout.break_all_lines(None);
-                let dummy_line = dummy_layout.lines().next().unwrap();
-                let dummy_metrics = dummy_line.metrics();
-                let dummy_font_size = dummy_line
-                    .items()
-                    .find_map(|item| match item {
-                        parley::PositionedLayoutItem::GlyphRun(glyph_run) => {
-                            Some(glyph_run.run().font_size())
-                        }
-                        _ => None,
-                    })
-                    .unwrap_or_else(|| {
-                        convert_length(
-                            cascade_font_size as f32 / 100.0,
-                            LengthUnit::Pt,
-                            LengthUnit::Px,
-                        )
-                    });
-                (dummy_metrics.ascent, dummy_metrics.descent, dummy_font_size)
+                                let Some(run) = declared_strut_runs.iter().find(|run| {
+                                    run.start_offset < line_end && run.end_offset > line_start
+                                }) else {
+                                    return default_strut;
+                                };
+
+                                if let Some(metrics) = cache.get(&run.defaults) {
+                                    return *metrics;
+                                }
+
+                                let metrics = measure_strut(
+                                    &mut lcx,
+                                    &mut fcx,
+                                    &run.defaults.family,
+                                    run.defaults.weight,
+                                    convert_length(
+                                        run.defaults.font_size as f32 / 100.0,
+                                        LengthUnit::Pt,
+                                        LengthUnit::Px,
+                                    ),
+                                    line_height,
+                                );
+                                cache.insert(run.defaults.clone(), metrics);
+                                metrics
+                            })
+                            .collect::<Vec<_>>();
+                        Some(metrics)
+                    };
+
+                (default_strut, per_line_struts)
             };
 
-            (layout, strut_ascent, strut_descent, strut_font_size)
+            (layout, default_strut, per_line_struts)
         });
 
-        let (layout, strut_ascent, strut_descent, strut_font_size) = layout;
+        let (layout, default_strut, per_line_struts) = layout;
         let layout = Rc::new(layout);
         let metrics = {
             let _s = mark_span_as_active(TRACER.start("layout.paragraph.build_metrics"));
@@ -852,9 +983,8 @@ impl Layout for ParagraphNode {
                 &layout,
                 &text,
                 ctx.scale_factor,
-                strut_ascent,
-                strut_descent,
-                strut_font_size,
+                default_strut,
+                per_line_struts.as_deref(),
                 line_height,
             )
         };
@@ -937,8 +1067,8 @@ mod tests {
     use super::*;
     use crate::layout::{Element, LayoutCache, LayoutNode};
     use crate::model::{
-        BackgroundColorStyle, Decorations, DefaultAttrs, FontSizeStyle, FontWeightStyle,
-        PendingStylesDecor, PreeditDecor,
+        Attr, BackgroundColorStyle, Decorations, DefaultAttrs, FontFamilyStyle, FontSizeStyle,
+        FontWeightStyle, PendingStylesDecor, PreeditDecor,
     };
     use crate::runtime::ViewStates;
     use crate::types::BoxConstraints;
@@ -1102,6 +1232,113 @@ mod tests {
             baseline_first_line_height,
             pending_first_line_height
         );
+    }
+
+    #[test]
+    fn strut_defaults_prefer_visible_text_styles_over_hidden_cascade_font() {
+        let mut p = id!();
+        let state = state! {
+            doc {
+                @p paragraph {
+                    text(styles: [font_family("Pretendard")]) { "프리텐다드" }
+                }
+            }
+            selection { (p, 0) }
+        };
+        let state = transact!(state, |tr| {
+            tr.set_cascade_attrs(
+                p,
+                &Attr::from_styles(&[Style::FontFamily(FontFamilyStyle {
+                    family: "Paperlogy".to_string(),
+                })]),
+            )
+            .unwrap();
+        });
+
+        let doc = &state.doc;
+        let para = doc.node(p).unwrap();
+        let settings = doc.settings();
+        let default_attrs = doc.default_attrs();
+        let decorations = Decorations::default();
+        let cache = RefCell::new(LayoutCache::new());
+        let view_states = ViewStates::default();
+        let ctx = LayoutContext::new(
+            &para,
+            &settings,
+            &default_attrs,
+            &decorations,
+            1.0,
+            &view_states,
+            &cache,
+        );
+        let (cascade_family, cascade_weight, cascade_font_size) = ctx.resolve_cascade_font();
+
+        let strut_defaults = resolve_strut_font_defaults(
+            &ctx,
+            false,
+            false,
+            &cascade_family,
+            cascade_weight,
+            cascade_font_size,
+        );
+
+        assert_eq!(strut_defaults.family, "Pretendard");
+        assert_eq!(strut_defaults.weight, cascade_weight);
+        assert_eq!(strut_defaults.font_size, cascade_font_size);
+    }
+
+    #[test]
+    fn strut_defaults_ignore_later_text_after_leading_hard_break() {
+        let mut p = id!();
+        let state = state! {
+            doc {
+                @p paragraph {
+                    hard_break {}
+                    text(styles: [font_family("Pretendard"), font_size(1800)]) { "가나다" }
+                }
+            }
+            selection { (p, 0) }
+        };
+        let state = transact!(state, |tr| {
+            tr.set_cascade_attrs(
+                p,
+                &Attr::from_styles(&[Style::FontFamily(FontFamilyStyle {
+                    family: "Paperlogy".to_string(),
+                })]),
+            )
+            .unwrap();
+        });
+
+        let doc = &state.doc;
+        let para = doc.node(p).unwrap();
+        let settings = doc.settings();
+        let default_attrs = doc.default_attrs();
+        let decorations = Decorations::default();
+        let cache = RefCell::new(LayoutCache::new());
+        let view_states = ViewStates::default();
+        let ctx = LayoutContext::new(
+            &para,
+            &settings,
+            &default_attrs,
+            &decorations,
+            1.0,
+            &view_states,
+            &cache,
+        );
+        let (cascade_family, cascade_weight, cascade_font_size) = ctx.resolve_cascade_font();
+
+        let strut_defaults = resolve_strut_font_defaults(
+            &ctx,
+            false,
+            false,
+            &cascade_family,
+            cascade_weight,
+            cascade_font_size,
+        );
+
+        assert_eq!(strut_defaults.family, "Paperlogy");
+        assert_eq!(strut_defaults.weight, cascade_weight);
+        assert_eq!(strut_defaults.font_size, cascade_font_size);
     }
 
     #[test]

--- a/crates/editor/src/render/impls/line.rs
+++ b/crates/editor/src/render/impls/line.rs
@@ -526,7 +526,7 @@ mod tests {
     use super::*;
     use crate::layout::elements::{ClusterMetric, LineMetric};
     use crate::layout::{Element, Layout, LayoutCache, LayoutContext, LayoutNode};
-    use crate::model::{Decorations, NodeId, SelectionDecor};
+    use crate::model::{Attr, Decorations, FontFamilyStyle, NodeId, SelectionDecor, Style};
     use crate::runtime::{State, ViewStates};
     use crate::state::build_selection_decorations;
     use crate::state::selection_helpers::collect_blocks_in_range;
@@ -574,6 +574,36 @@ mod tests {
         let mut hasher = FxHasher::default();
         line.hash_render_cache_signature(&mut hasher);
         hasher.finish()
+    }
+
+    fn first_line(layout: &LayoutNode) -> &LineElement {
+        layout
+            .children
+            .as_ref()
+            .and_then(|children| {
+                children
+                    .iter()
+                    .find_map(|child| match child.node.element.as_ref() {
+                        Some(Element::Line(line)) => Some(line),
+                        _ => None,
+                    })
+            })
+            .expect("line should exist")
+    }
+
+    fn nth_line(layout: &LayoutNode, line_idx: usize) -> &LineElement {
+        layout
+            .children
+            .as_ref()
+            .and_then(|children| {
+                children
+                    .iter()
+                    .find_map(|child| match child.node.element.as_ref() {
+                        Some(Element::Line(line)) if line.line_idx == line_idx => Some(line),
+                        _ => None,
+                    })
+            })
+            .expect("line should exist")
     }
 
     #[test]
@@ -1085,6 +1115,172 @@ mod tests {
                 .abs()
                 <= eps,
             "line box height should stay stable when box drawing char is present"
+        );
+    }
+
+    #[test]
+    fn line_metrics_do_not_shift_with_cjk_ideograph_in_same_declared_font() {
+        let mut plain = id!();
+        let plain_state = state! {
+            doc {
+                @plain paragraph {
+                    text(styles: [font_family("Pretendard")]) { "가나다라" }
+                }
+            }
+            selection { (plain, 0) }
+        };
+        let plain_layout = layout_for_paragraph(&plain_state, plain);
+        let plain_line = first_line(&plain_layout);
+
+        let mut mixed = id!();
+        let mixed_state = state! {
+            doc {
+                @mixed paragraph {
+                    text(styles: [font_family("Pretendard")]) { "가나漢다라" }
+                }
+            }
+            selection { (mixed, 0) }
+        };
+        let mixed_layout = layout_for_paragraph(&mixed_state, mixed);
+        let mixed_line = first_line(&mixed_layout);
+
+        let eps = 0.01;
+        assert!(
+            (plain_line.metric.top - mixed_line.metric.top).abs() <= eps,
+            "line top should stay stable when a CJK ideograph is added in the same declared font: plain={}, mixed={}",
+            plain_line.metric.top,
+            mixed_line.metric.top
+        );
+        assert!(
+            (plain_line.metric.ascent - mixed_line.metric.ascent).abs() <= eps,
+            "line ascent should stay stable when a CJK ideograph is added in the same declared font: plain={}, mixed={}",
+            plain_line.metric.ascent,
+            mixed_line.metric.ascent
+        );
+        assert!(
+            ((plain_line.metric.height + plain_line.metric.leading)
+                - (mixed_line.metric.height + mixed_line.metric.leading))
+                .abs()
+                <= eps,
+            "line box height should stay stable when a CJK ideograph is added in the same declared font"
+        );
+    }
+
+    #[test]
+    fn hidden_paragraph_cascade_font_does_not_shift_visible_text_line_metrics() {
+        let mut plain = id!();
+        let plain_state = state! {
+            doc {
+                @plain paragraph {
+                    text(styles: [font_family("Pretendard")]) { "프리텐다드" }
+                }
+            }
+            selection { (plain, 0) }
+        };
+        let plain_layout = layout_for_paragraph(&plain_state, plain);
+        let plain_line = first_line(&plain_layout);
+
+        let mut hidden = id!();
+        let hidden_state = state! {
+            doc {
+                @hidden paragraph {
+                    text(styles: [font_family("Pretendard")]) { "프리텐다드" }
+                }
+            }
+            selection { (hidden, 0) }
+        };
+        let hidden_state = transact!(hidden_state, |tr| {
+            tr.set_cascade_attrs(
+                hidden,
+                &Attr::from_styles(&[Style::FontFamily(FontFamilyStyle {
+                    family: "Paperlogy".to_string(),
+                })]),
+            )
+            .unwrap();
+        });
+        let hidden_layout = layout_for_paragraph(&hidden_state, hidden);
+        let hidden_line = first_line(&hidden_layout);
+
+        let eps = 0.01;
+        assert!(
+            (plain_line.metric.top - hidden_line.metric.top).abs() <= eps,
+            "hidden paragraph cascade font should not shift visible text line top: plain={}, hidden={}",
+            plain_line.metric.top,
+            hidden_line.metric.top
+        );
+        assert!(
+            (plain_line.metric.ascent - hidden_line.metric.ascent).abs() <= eps,
+            "hidden paragraph cascade font should not shift visible text ascent: plain={}, hidden={}",
+            plain_line.metric.ascent,
+            hidden_line.metric.ascent
+        );
+        assert!(
+            ((plain_line.metric.height + plain_line.metric.leading)
+                - (hidden_line.metric.height + hidden_line.metric.leading))
+                .abs()
+                <= eps,
+            "hidden paragraph cascade font should not change visible text line box height"
+        );
+    }
+
+    #[test]
+    fn second_line_uses_its_own_declared_font_metrics_after_hard_break() {
+        let mut pretendard = id!();
+        let pretendard_state = state! {
+            doc {
+                @pretendard paragraph {
+                    text(styles: [font_family("Pretendard")]) { "프리텐다드" }
+                }
+            }
+            selection { (pretendard, 0) }
+        };
+        let pretendard_layout = layout_for_paragraph(&pretendard_state, pretendard);
+        let pretendard_line = first_line(&pretendard_layout);
+
+        let mut paperlogy = id!();
+        let paperlogy_state = state! {
+            doc {
+                @paperlogy paragraph {
+                    text(styles: [font_family("Paperlogy")]) { "페이퍼로지" }
+                }
+            }
+            selection { (paperlogy, 0) }
+        };
+        let paperlogy_layout = layout_for_paragraph(&paperlogy_state, paperlogy);
+        let paperlogy_line = first_line(&paperlogy_layout);
+
+        let mut mixed = id!();
+        let mixed_state = state! {
+            doc {
+                @mixed paragraph {
+                    text(styles: [font_family("Pretendard")]) { "프리텐다드" }
+                    hard_break {}
+                    text(styles: [font_family("Paperlogy")]) { "페이퍼로지" }
+                }
+            }
+            selection { (mixed, 0) }
+        };
+        let mixed_layout = layout_for_paragraph(&mixed_state, mixed);
+        let mixed_first_line = nth_line(&mixed_layout, 0);
+        let mixed_second_line = nth_line(&mixed_layout, 1);
+
+        let eps = 0.01;
+        assert!(
+            (pretendard_line.metric.ascent - mixed_first_line.metric.ascent).abs() <= eps,
+            "first line should keep Pretendard metrics in mixed paragraph"
+        );
+        assert!(
+            (paperlogy_line.metric.ascent - mixed_second_line.metric.ascent).abs() <= eps,
+            "second line should use Paperlogy metrics after hard break: standalone={}, mixed={}",
+            paperlogy_line.metric.ascent,
+            mixed_second_line.metric.ascent
+        );
+        assert!(
+            ((paperlogy_line.metric.height + paperlogy_line.metric.leading)
+                - (mixed_second_line.metric.height + mixed_second_line.metric.leading))
+                .abs()
+                <= eps,
+            "second line should use Paperlogy line box height after hard break"
         );
     }
 


### PR DESCRIPTION
기존에는..
- 문단의 cascade font가 visible text가 없는데도 strut metric으로 쓰이고 있었음
- layout / paint bounds는 숨겨진 cascade font 기준으로 하고 실제 glyph raster는 visible text font 기준이었음
- render cache는 paint bounds를 보고 dirty rect를 만드는데 glyph raster는 그 밖에 그려지는 문제 발생

이제는..
- first visible font 기준으로, 줄별로 strut metric을 계산함 (CSS와 비슷함)