### PR TITLE
popover 내부 scroll

### DIFF
--- a/apps/mobile2/compose/src/commonMain/kotlin/co/typie/ext/EdgeAutoScroll.kt
+++ b/apps/mobile2/compose/src/commonMain/kotlin/co/typie/ext/EdgeAutoScroll.kt
@@ -1,0 +1,255 @@
+package co.typie.ext
+
+import androidx.compose.foundation.gestures.ScrollableState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInWindow
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+object EdgeAutoScrollDefaults {
+  const val FrameDurationMs = 16L
+  val EdgeThreshold = 30.dp
+  val MinScrollSpeed = 4.dp
+  val MaxScrollSpeed = 16.dp
+}
+
+@Composable
+fun rememberEdgeAutoScrollState(
+  verticalScrollableState: ScrollableState? = null,
+  horizontalScrollableState: ScrollableState? = null,
+  edgeThreshold: Dp = EdgeAutoScrollDefaults.EdgeThreshold,
+  minScrollSpeed: Dp = EdgeAutoScrollDefaults.MinScrollSpeed,
+  maxScrollSpeed: Dp = EdgeAutoScrollDefaults.MaxScrollSpeed,
+  frameDurationMs: Long = EdgeAutoScrollDefaults.FrameDurationMs,
+): EdgeAutoScrollState {
+  val scope = rememberCoroutineScope()
+  val density = LocalDensity.current
+  val edgeThresholdPx = with(density) { edgeThreshold.toPx() }
+  val minScrollSpeedPx = with(density) { minScrollSpeed.toPx() }
+  val maxScrollSpeedPx = with(density) { maxScrollSpeed.toPx() }
+
+  return remember(scope, edgeThresholdPx, minScrollSpeedPx, maxScrollSpeedPx, frameDurationMs) {
+    EdgeAutoScrollState(
+      scope = scope,
+      edgeThresholdPx = edgeThresholdPx,
+      minScrollSpeedPx = minScrollSpeedPx,
+      maxScrollSpeedPx = maxScrollSpeedPx,
+      frameDurationMs = frameDurationMs,
+    )
+  }.also { state ->
+    state.verticalScrollableState = verticalScrollableState
+    state.horizontalScrollableState = horizontalScrollableState
+  }
+}
+
+fun Modifier.edgeAutoScroll(
+  state: EdgeAutoScrollState,
+  enabled: Boolean = true,
+): Modifier = composed {
+  SideEffect {
+    state.setEnabled(enabled)
+  }
+
+  DisposableEffect(state) {
+    onDispose {
+      state.detach()
+    }
+  }
+
+  onGloballyPositioned { coordinates ->
+    val position = coordinates.positionInWindow()
+    val size = coordinates.size
+    state.updateViewportRect(
+      Rect(
+        left = position.x,
+        top = position.y,
+        right = position.x + size.width,
+        bottom = position.y + size.height,
+      )
+    )
+  }
+}
+
+@Stable
+class EdgeAutoScrollState internal constructor(
+  private val scope: CoroutineScope,
+  private val edgeThresholdPx: Float,
+  private val minScrollSpeedPx: Float,
+  private val maxScrollSpeedPx: Float,
+  private val frameDurationMs: Long,
+) {
+  internal var verticalScrollableState: ScrollableState? = null
+  internal var horizontalScrollableState: ScrollableState? = null
+
+  private var autoScrollJob: Job? = null
+  private var viewportRect: Rect? = null
+  private var pointerPosition: Offset? = null
+  private var enabled = true
+  private var verticalDirection = 0f
+  private var horizontalDirection = 0f
+  private var verticalEdgeDistance = 0f
+  private var horizontalEdgeDistance = 0f
+  private var onAutoScroll: (() -> Unit)? = null
+
+  fun update(
+    pointerPosition: Offset,
+    onAutoScroll: (() -> Unit)? = null,
+  ) {
+    this.pointerPosition = pointerPosition
+    this.onAutoScroll = onAutoScroll
+    reevaluate()
+  }
+
+  fun stop() {
+    pointerPosition = null
+    onAutoScroll = null
+    stopAutoScroll()
+  }
+
+  internal fun setEnabled(enabled: Boolean) {
+    this.enabled = enabled
+    if (!enabled) {
+      stop()
+      return
+    }
+
+    reevaluate()
+  }
+
+  internal fun updateViewportRect(viewportRect: Rect?) {
+    this.viewportRect = viewportRect
+    reevaluate()
+  }
+
+  internal fun detach() {
+    viewportRect = null
+    stop()
+  }
+
+  private fun reevaluate() {
+    val viewportRect = viewportRect
+    val pointerPosition = pointerPosition
+    if (!enabled || viewportRect == null || pointerPosition == null) {
+      stopAutoScroll()
+      return
+    }
+
+    val localX = pointerPosition.x - viewportRect.left
+    val localY = pointerPosition.y - viewportRect.top
+    val bottomThreshold = viewportRect.height - edgeThresholdPx
+    val rightThreshold = viewportRect.width - edgeThresholdPx
+
+    if (localY < edgeThresholdPx) {
+      verticalEdgeDistance = localY.coerceIn(0f, edgeThresholdPx)
+      verticalDirection = -1f
+    } else if (localY > bottomThreshold) {
+      verticalEdgeDistance = (viewportRect.height - localY).coerceIn(0f, edgeThresholdPx)
+      verticalDirection = 1f
+    } else {
+      verticalDirection = 0f
+    }
+
+    if (localX < edgeThresholdPx) {
+      horizontalEdgeDistance = localX.coerceIn(0f, edgeThresholdPx)
+      horizontalDirection = -1f
+    } else if (localX > rightThreshold) {
+      horizontalEdgeDistance = (viewportRect.width - localX).coerceIn(0f, edgeThresholdPx)
+      horizontalDirection = 1f
+    } else {
+      horizontalDirection = 0f
+    }
+
+    val shouldAutoScroll =
+      (verticalDirection != 0f && verticalScrollableState != null) ||
+        (horizontalDirection != 0f && horizontalScrollableState != null)
+
+    if (shouldAutoScroll) {
+      startAutoScroll()
+    } else {
+      stopAutoScroll()
+    }
+  }
+
+  private fun startAutoScroll() {
+    if (autoScrollJob != null) {
+      return
+    }
+
+    autoScrollJob = scope.launch {
+      while (isActive) {
+        var didScroll = false
+
+        val verticalScrollableState = verticalScrollableState
+        if (verticalDirection != 0f && verticalScrollableState != null && canScroll(verticalScrollableState, verticalDirection)) {
+          didScroll = scrollAxis(
+            scrollableState = verticalScrollableState,
+            direction = verticalDirection,
+            edgeDistance = verticalEdgeDistance,
+          ) || didScroll
+        }
+
+        val horizontalScrollableState = horizontalScrollableState
+        if (horizontalDirection != 0f && horizontalScrollableState != null && canScroll(horizontalScrollableState, horizontalDirection)) {
+          didScroll = scrollAxis(
+            scrollableState = horizontalScrollableState,
+            direction = horizontalDirection,
+            edgeDistance = horizontalEdgeDistance,
+          ) || didScroll
+        }
+
+        if (didScroll) {
+          onAutoScroll?.invoke()
+        }
+
+        delay(frameDurationMs)
+      }
+    }
+  }
+
+  private fun stopAutoScroll() {
+    autoScrollJob?.cancel()
+    autoScrollJob = null
+    verticalDirection = 0f
+    horizontalDirection = 0f
+    verticalEdgeDistance = 0f
+    horizontalEdgeDistance = 0f
+  }
+
+  private fun scrollAxis(
+    scrollableState: ScrollableState,
+    direction: Float,
+    edgeDistance: Float,
+  ): Boolean {
+    val proximity = 1f - (edgeDistance / edgeThresholdPx).coerceIn(0f, 1f)
+    val scrollSpeed = minScrollSpeedPx + proximity * (maxScrollSpeedPx - minScrollSpeedPx)
+    val consumed = scrollableState.dispatchRawDelta(direction * scrollSpeed)
+    return consumed != 0f
+  }
+
+  private fun canScroll(
+    scrollableState: ScrollableState,
+    direction: Float,
+  ): Boolean {
+    return if (direction < 0f) {
+      scrollableState.canScrollBackward
+    } else {
+      scrollableState.canScrollForward
+    }
+  }
+}

--- a/apps/mobile2/compose/src/commonMain/kotlin/co/typie/ui/component/popover/Popover.kt
+++ b/apps/mobile2/compose/src/commonMain/kotlin/co/typie/ui/component/popover/Popover.kt
@@ -4,6 +4,8 @@ import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.fillMaxSize
@@ -33,6 +35,7 @@ import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
@@ -40,9 +43,15 @@ import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.round
+import co.typie.ext.EdgeAutoScrollState
+import co.typie.ext.edgeAutoScroll
+import co.typie.ext.safeDrawing
 import androidx.compose.ui.window.Popup
+import co.typie.ext.overscroll
+import co.typie.ext.rememberEdgeAutoScrollState
 import co.typie.ext.toDp
 import co.typie.ext.toPx
+import co.typie.ext.verticalScroll
 import co.typie.navigation.PlatformBackHandler
 import co.typie.ui.shape.SquircleShape
 import co.typie.ui.theme.AppTheme
@@ -57,6 +66,7 @@ data class PopoverPaneTransition(
 )
 
 val LocalPopoverPaneTransition = staticCompositionLocalOf<PopoverPaneTransition?> { null }
+val LocalPopoverPaneEdgeAutoScrollState = staticCompositionLocalOf<EdgeAutoScrollState?> { null }
 
 data class AnchorPointerState(
   val position: Offset,
@@ -77,9 +87,17 @@ class PopoverScope internal constructor(
 }
 
 private enum class PopoverSlot {
-  MeasurePane,
+  InitialMeasurePane,
+  FinalMeasurePane,
   Surface,
 }
+
+internal data class PopoverScreenPadding(
+  val left: Int,
+  val top: Int,
+  val right: Int,
+  val bottom: Int,
+)
 
 @Composable
 fun Popover(
@@ -90,7 +108,16 @@ fun Popover(
   collapsedCornerRadius: Dp = 0.dp,
 ) {
   val density = LocalDensity.current
+  val layoutDirection = LocalLayoutDirection.current
   val screenPaddingPx = PopoverDefaults.ScreenPadding.toPx(density).toInt()
+  val armDistancePx = PopoverDefaults.ArmDistance.toPx(density)
+  val safeDrawing = WindowInsets.safeDrawing
+  val screenPadding = PopoverScreenPadding(
+    left = screenPaddingPx + safeDrawing.getLeft(density, layoutDirection),
+    top = screenPaddingPx + safeDrawing.getTop(density),
+    right = screenPaddingPx + safeDrawing.getRight(density, layoutDirection),
+    bottom = screenPaddingPx + safeDrawing.getBottom(density),
+  )
 
   var isExpanded by remember { mutableStateOf(false) }
   var isOverlayVisible by remember { mutableStateOf(false) }
@@ -161,7 +188,7 @@ fun Popover(
                 val elapsed = armStartMark.elapsedNow().inWholeMilliseconds
                 val distance = (currentPos - origin).getDistance()
 
-                if (!isArmed && elapsed >= PopoverDefaults.ArmDelayMs && distance > PopoverDefaults.ArmDistance) {
+                if (!isArmed && elapsed >= PopoverDefaults.ArmDelayMs && distance > armDistancePx) {
                   isArmed = true
                 }
 
@@ -189,23 +216,22 @@ fun Popover(
     }
 
     if (isOverlayVisible) {
-      val positionProvider = remember(position, screenPaddingPx) {
-        PopoverPositionProvider(position, screenPaddingPx)
+      val positionProvider = remember(position, screenPadding) {
+        PopoverPositionProvider(position, screenPadding)
       }
 
       Popup(
         popupPositionProvider = positionProvider,
         onDismissRequest = { isExpanded = false },
       ) {
-        val effective = effectivePosition(position, positionProvider.lastShowBelow)
-
         PopoverPanePopup(
           anchor = anchor,
           pane = { scope.pane() },
-          anchorSize = anchorBounds.size,
-          effectivePosition = effective,
+          anchorBounds = anchorBounds,
+          position = position,
           progress = progress,
           collapsedCornerRadius = collapsedCornerRadius,
+          screenPadding = screenPadding,
           maxWidth = maxWidth,
         )
       }
@@ -217,22 +243,53 @@ fun Popover(
 private fun PopoverPanePopup(
   anchor: @Composable () -> Unit,
   pane: @Composable () -> Unit,
-  anchorSize: IntSize,
-  effectivePosition: PopoverPosition,
+  anchorBounds: IntRect,
+  position: PopoverPosition,
   progress: Float,
   collapsedCornerRadius: Dp,
+  screenPadding: PopoverScreenPadding,
   maxWidth: Dp?,
 ) {
   SubcomposeLayout(
     modifier = Modifier.then(if (maxWidth != null) Modifier.widthIn(max = maxWidth) else Modifier),
   ) { constraints ->
-    val panePlaceables = subcompose(PopoverSlot.MeasurePane) {
-      ShrinkWrappedPane(content = pane)
-    }.map { it.measure(constraints.copy(minWidth = 0, minHeight = 0)) }
+    val paneConstraints = constraints.copy(
+      minWidth = 0,
+      minHeight = 0,
+      maxWidth = shrinkBounded(constraints.maxWidth, screenPadding.left + screenPadding.right),
+      maxHeight = shrinkBounded(constraints.maxHeight, screenPadding.top + screenPadding.bottom),
+    )
 
-    val paneWidth = panePlaceables.maxOfOrNull { it.width } ?: anchorSize.width
-    val paneHeight = panePlaceables.maxOfOrNull { it.height } ?: anchorSize.height
+    val initialPanePlaceables = subcompose(PopoverSlot.InitialMeasurePane) {
+      ShrinkWrappedPane(content = pane)
+    }.map { it.measure(paneConstraints) }
+
+    val initiallyMeasuredWidth = initialPanePlaceables.maxOfOrNull { it.width } ?: anchorBounds.width
+    val initiallyMeasuredHeight = initialPanePlaceables.maxOfOrNull { it.height } ?: anchorBounds.height
+    val showBelow = shouldShowBelow(
+      position = position,
+      childHeight = initiallyMeasuredHeight,
+      windowHeight = constraints.maxHeight,
+      anchorRect = anchorBounds,
+      screenPadding = screenPadding,
+    )
+    val finalPaneConstraints = paneConstraints.copy(
+      maxHeight = availableHeightForPlacement(
+        windowHeight = constraints.maxHeight,
+        anchorBounds = anchorBounds,
+        screenPadding = screenPadding,
+        showBelow = showBelow,
+      ),
+    )
+    val finalPanePlaceables = subcompose(PopoverSlot.FinalMeasurePane) {
+      ShrinkWrappedPane(content = pane)
+    }.map { it.measure(finalPaneConstraints) }
+
+    val paneWidth = finalPanePlaceables.maxOfOrNull { it.width } ?: initiallyMeasuredWidth
+    val paneHeight = finalPanePlaceables.maxOfOrNull { it.height } ?: initiallyMeasuredHeight
     val paneSize = IntSize(paneWidth, paneHeight)
+    val anchorSize = anchorBounds.size
+    val effectivePosition = effectivePosition(position, showBelow)
     val transition = PopoverPaneTransition(
       progress = progress,
       anchorContentRect = anchorContentRect(paneSize, anchorSize, effectivePosition),
@@ -260,8 +317,21 @@ private fun PopoverPanePopup(
 
 @Composable
 private fun ShrinkWrappedPane(content: @Composable () -> Unit) {
-  Box(modifier = Modifier.width(IntrinsicSize.Max)) {
-    content()
+  val scrollState = rememberScrollState()
+  val edgeAutoScrollState = rememberEdgeAutoScrollState(verticalScrollableState = scrollState)
+
+  CompositionLocalProvider(
+    LocalPopoverPaneEdgeAutoScrollState provides edgeAutoScrollState,
+  ) {
+    Box(
+      modifier = Modifier
+        .width(IntrinsicSize.Max)
+        .edgeAutoScroll(edgeAutoScrollState)
+        .verticalScroll(scrollState)
+        .overscroll(),
+    ) {
+      content()
+    }
   }
 }
 
@@ -292,7 +362,7 @@ private fun PopoverPaneSurface(
     progress,
   )
   val shape = SquircleShape(cornerRadius.toDp(density))
-  val shadowElevation = (12f * progress).toDp(density)
+  val shadowElevation = (12f * progress).dp
 
   Box(
     modifier = Modifier.size(
@@ -411,4 +481,29 @@ private fun alignedOffset(
   }
 
   return IntOffset(x, y)
+}
+
+private fun shrinkBounded(value: Int, inset: Int): Int {
+  if (value == Constraints.Infinity) {
+    return value
+  }
+
+  return max(0, value - inset)
+}
+
+private fun availableHeightForPlacement(
+  windowHeight: Int,
+  anchorBounds: IntRect,
+  screenPadding: PopoverScreenPadding,
+  showBelow: Boolean,
+): Int {
+  if (windowHeight == Constraints.Infinity) {
+    return windowHeight
+  }
+
+  return if (showBelow) {
+    max(0, windowHeight - screenPadding.bottom - anchorBounds.top)
+  } else {
+    max(0, anchorBounds.bottom - screenPadding.top)
+  }
 }

--- a/apps/mobile2/compose/src/commonMain/kotlin/co/typie/ui/component/popover/PopoverDefaults.kt
+++ b/apps/mobile2/compose/src/commonMain/kotlin/co/typie/ui/component/popover/PopoverDefaults.kt
@@ -11,8 +11,8 @@ object PopoverDefaults {
   const val ForwardDuration = 320
   const val ReverseDuration = 240
   const val IndicatorDuration = 140
-  const val ArmDelayMs = 150L
-  const val ArmDistance = 9f // px threshold before selection arms
+  const val ArmDelayMs = 250L
+  val ArmDistance = 9.dp
 
   val PopoverEasing: Easing = EaseOutExpo
 }

--- a/apps/mobile2/compose/src/commonMain/kotlin/co/typie/ui/component/popover/PopoverList.kt
+++ b/apps/mobile2/compose/src/commonMain/kotlin/co/typie/ui/component/popover/PopoverList.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
@@ -47,6 +48,7 @@ fun PopoverScope.PopoverList(
   val haptic = LocalHapticFeedback.current
   val density = LocalDensity.current
   val gestureScope = rememberCoroutineScope()
+  val edgeAutoScrollState = LocalPopoverPaneEdgeAutoScrollState.current
   val itemRadius = PopoverDefaults.ExpandedRadius - PopoverDefaults.PanePadding
 
   var activeIndex by remember { mutableStateOf<Int?>(null) }
@@ -62,6 +64,27 @@ fun PopoverScope.PopoverList(
   var indicatorVisible by remember { mutableStateOf(false) }
 
   val animSpec = tween<Float>(PopoverDefaults.IndicatorDuration, easing = EaseOutCubic)
+
+  fun updateActiveIndex(windowPosition: Offset) {
+    val index = hitTestItems(windowPosition, itemBounds)
+    if (index != null && index != activeIndex) {
+      haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+    }
+    activeIndex = index
+  }
+
+  fun updateEdgeAutoScroll(windowPosition: Offset) {
+    edgeAutoScrollState?.update(
+      pointerPosition = windowPosition,
+      onAutoScroll = { updateActiveIndex(windowPosition) },
+    )
+  }
+
+  DisposableEffect(edgeAutoScrollState) {
+    onDispose {
+      edgeAutoScrollState?.stop()
+    }
+  }
 
   LaunchedEffect(activeIndex) {
     val index = activeIndex
@@ -94,22 +117,24 @@ fun PopoverScope.PopoverList(
     }
 
     val state = currentPointerState ?: run {
+      edgeAutoScrollState?.stop()
       activeIndex = null
       return@LaunchedEffect
     }
 
     if (!state.isSelectionArmed) {
+      edgeAutoScrollState?.stop()
       activeIndex = null
       return@LaunchedEffect
     }
 
-    val index = hitTestItems(state.position, itemBounds)
-    if (index != null && index != activeIndex) {
-      haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+    updateActiveIndex(state.position)
+    if (!state.isUp) {
+      updateEdgeAutoScroll(state.position)
     }
-    activeIndex = index
 
     if (state.isUp && state.isSelectionArmed) {
+      edgeAutoScrollState?.stop()
       val selectedIndex = activeIndex
       activeIndex = null
       if (selectedIndex != null) {
@@ -159,20 +184,24 @@ fun PopoverScope.PopoverList(
                     PointerEventType.Press -> {
                       val press = event.changes.firstOrNull() ?: continue
                       val pointerId = press.id
-                      var currentWindowPos =
+                      val originWindowPos =
                         press.position + (itemBounds[index]?.topLeft ?: Offset.Zero)
+                      val touchSlop = viewConfiguration.touchSlop
+                      var currentWindowPos =
+                        originWindowPos
                       var isSelectionArmed = false
+                      var isPanScroll = false
                       isLocalTracking = true
                       activeIndex = null
 
                       val armJob = gestureScope.launch {
                         delay(PopoverDefaults.ArmDelayMs)
-                        isSelectionArmed = true
-                        val hitIndex = hitTestItems(currentWindowPos, itemBounds)
-                        if (hitIndex != null && hitIndex != activeIndex) {
-                          haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                        if (isPanScroll) {
+                          return@launch
                         }
-                        activeIndex = hitIndex
+                        isSelectionArmed = true
+                        updateActiveIndex(currentWindowPos)
+                        updateEdgeAutoScroll(currentWindowPos)
                       }
 
                       while (true) {
@@ -181,17 +210,29 @@ fun PopoverScope.PopoverList(
 
                         currentWindowPos =
                           change.position + (itemBounds[index]?.topLeft ?: Offset.Zero)
-                        if (isSelectionArmed) {
-                          val hitIndex = hitTestItems(currentWindowPos, itemBounds)
-                          if (hitIndex != null && hitIndex != activeIndex) {
-                            haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                        if (!isSelectionArmed && !isPanScroll) {
+                          val distance = (currentWindowPos - originWindowPos).getDistance()
+                          if (distance > touchSlop) {
+                            isPanScroll = true
+                            armJob.cancel()
+                            edgeAutoScrollState?.stop()
+                            activeIndex = null
                           }
-                          activeIndex = hitIndex
+                        }
+                        if (isSelectionArmed) {
+                          change.consume()
+                          updateActiveIndex(currentWindowPos)
+                          updateEdgeAutoScroll(currentWindowPos)
                         }
 
                         if (!change.pressed) {
                           armJob.cancel()
-                          val selectedIndex = hitTestItems(currentWindowPos, itemBounds)
+                          edgeAutoScrollState?.stop()
+                          val selectedIndex = when {
+                            isPanScroll -> null
+                            isSelectionArmed -> hitTestItems(currentWindowPos, itemBounds)
+                            else -> hitTestItems(currentWindowPos, itemBounds)
+                          }
                           activeIndex = null
                           isLocalTracking = false
                           if (selectedIndex != null) {
@@ -202,6 +243,7 @@ fun PopoverScope.PopoverList(
                       }
 
                       armJob.cancel()
+                      edgeAutoScrollState?.stop()
                       activeIndex = null
                       isLocalTracking = false
                     }

--- a/apps/mobile2/compose/src/commonMain/kotlin/co/typie/ui/component/popover/PopoverPositionProvider.kt
+++ b/apps/mobile2/compose/src/commonMain/kotlin/co/typie/ui/component/popover/PopoverPositionProvider.kt
@@ -13,7 +13,7 @@ enum class PopoverPosition {
 
 internal class PopoverPositionProvider(
   private val position: PopoverPosition,
-  private val screenPaddingPx: Int,
+  private val screenPadding: PopoverScreenPadding,
 ) : PopupPositionProvider {
 
   var lastShowBelow: Boolean = true
@@ -30,7 +30,7 @@ internal class PopoverPositionProvider(
       childHeight = popupContentSize.height,
       windowHeight = windowSize.height,
       anchorRect = anchorBounds,
-      screenPadding = screenPaddingPx,
+      screenPadding = screenPadding,
     )
 
     val unclampedX = when (position) {
@@ -49,18 +49,18 @@ internal class PopoverPositionProvider(
 
     val minX = when (position) {
       PopoverPosition.BottomLeft, PopoverPosition.TopLeft -> 0
-      else -> screenPaddingPx
+      else -> screenPadding.left
     }
     val maxX = when (position) {
       PopoverPosition.BottomRight, PopoverPosition.TopRight ->
         windowSize.width - popupContentSize.width
 
       else ->
-        windowSize.width - screenPaddingPx - popupContentSize.width
+        windowSize.width - screenPadding.right - popupContentSize.width
     }
-    val minY = if (showBelow) 0 else screenPaddingPx
+    val minY = if (showBelow) 0 else screenPadding.top
     val maxY = if (showBelow) {
-      windowSize.height - screenPaddingPx - popupContentSize.height
+      windowSize.height - screenPadding.bottom - popupContentSize.height
     } else {
       windowSize.height - popupContentSize.height
     }
@@ -79,10 +79,10 @@ internal fun shouldShowBelow(
   childHeight: Int,
   windowHeight: Int,
   anchorRect: IntRect,
-  screenPadding: Int,
+  screenPadding: PopoverScreenPadding,
 ): Boolean {
-  val bottomSpace = windowHeight - screenPadding - anchorRect.top
-  val topSpace = anchorRect.bottom - screenPadding
+  val bottomSpace = windowHeight - screenPadding.bottom - anchorRect.top
+  val topSpace = anchorRect.bottom - screenPadding.top
   val prefersBottom = position == PopoverPosition.BottomLeft ||
     position == PopoverPosition.BottomCenter ||
     position == PopoverPosition.BottomRight


### PR DESCRIPTION
- edge auto scroll modifier 추가
- popover pane을 scroll container로 만듦
- 긴 popover의 포지셔닝을 개선
- scrub arm delay를 150 -> 250ms로 늘림
- (scroll + auto scroll)과 pan scroll은 상호배타적으로 동작
- 단위 해석 잘못된 부분 수정