### PR TITLE
KMP 14

### DIFF
--- a/apps/mobile2/compose/src/commonMain/kotlin/co/typie/navigation/NavigationStack.kt
+++ b/apps/mobile2/compose/src/commonMain/kotlin/co/typie/navigation/NavigationStack.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -33,6 +32,8 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import co.typie.route.Route
+import co.typie.route.RouteTransitionStyle
+import co.typie.route.transitionStyleTo
 import co.typie.ui.component.topbar.LocalTopBarState
 import co.typie.ui.component.topbar.NavDirection
 import co.typie.ui.component.topbar.TopBarState
@@ -74,6 +75,7 @@ fun NavigationStack(
   var visibleRoute by remember { mutableStateOf(navigator.current) }
   // behindRoute: 애니메이션/제스처 중 뒤에 깔리는 화면. Idle에서는 null.
   var behindRoute by remember { mutableStateOf<Route?>(null) }
+  var transitionStyle by remember { mutableStateOf(RouteTransitionStyle.Slide) }
 
   val progress = remember { Animatable(0f) }
 
@@ -83,6 +85,7 @@ fun NavigationStack(
       .collect { requested ->
         if (requested && animState == AnimState.Idle) {
           behindRoute = navigator.previous
+          behindRoute?.let { transitionStyle = visibleRoute.transitionStyleTo(it) }
           animState = AnimState.Pop
           progress.snapTo(0f)
           progress.animateTo(1f, tween(350, easing = FastOutSlowInEasing))
@@ -105,6 +108,7 @@ fun NavigationStack(
       when (navigator.lastOperation) {
         NavOperation.Push -> {
           // Push: visibleRoute(이전 화면)가 뒤로, navigator.current(새 화면)가 앞으로
+          transitionStyle = visibleRoute.transitionStyleTo(navigator.current)
           behindRoute = visibleRoute
           animState = AnimState.Push
           progress.snapTo(0f)
@@ -116,6 +120,7 @@ fun NavigationStack(
         else -> {
           // Pop: visibleRoute(현재 화면)가 앞에서 나가고, navigator.current(이전 화면)가 뒤에서 나타남
           val poppedRoute = visibleRoute
+          transitionStyle = poppedRoute.transitionStyleTo(navigator.current)
           behindRoute = navigator.current
           animState = AnimState.Pop
           progress.snapTo(0f)
@@ -140,14 +145,18 @@ fun NavigationStack(
         .fillMaxSize()
         .onSizeChanged { containerWidth = it.width.toFloat() }
     ) {
+      val useFadeTransition = transitionStyle == RouteTransitionStyle.Fade
+
       // 전환 progress에 연동: 0→1f, 0.5→0f, 1→1f
-      topBarState.blurFactor = if (animState == AnimState.Idle) 1f else abs(progress.value * 2f - 1f)
+      topBarState.blurFactor = if (animState == AnimState.Idle || useFadeTransition) 1f else abs(progress.value * 2f - 1f)
 
       when (animState) {
         AnimState.Idle -> topBarState.navDirection = NavDirection.Switch
-        AnimState.Push -> topBarState.navDirection = NavDirection.Push
-        AnimState.Pop -> topBarState.navDirection = NavDirection.Pop
-        AnimState.Dragging -> if (navigator.popRequested) topBarState.navDirection = NavDirection.Pop
+        AnimState.Push -> topBarState.navDirection = if (useFadeTransition) NavDirection.Switch else NavDirection.Push
+        AnimState.Pop -> topBarState.navDirection = if (useFadeTransition) NavDirection.Switch else NavDirection.Pop
+        AnimState.Dragging -> if (navigator.popRequested) {
+          topBarState.navDirection = if (useFadeTransition) NavDirection.Switch else NavDirection.Pop
+        }
       }
 
       val p = progress.value
@@ -171,17 +180,32 @@ fun NavigationStack(
           else -> topBarState
         }
 
-        Box(Modifier.fillMaxSize().graphicsLayer { translationX = behindOffset }) {
-          CompositionLocalProvider(LocalTopBarState provides behindTopBar) {
-            RouteContent(behindRoute!!)
+        if (useFadeTransition) {
+          val behindAlpha = when (animState) {
+            AnimState.Push -> 1f - p
+            AnimState.Pop -> p
+            AnimState.Dragging -> if (navigator.popRequested) p else 0f
+            AnimState.Idle -> 1f
           }
+
+          Box(Modifier.fillMaxSize().graphicsLayer { alpha = behindAlpha }) {
+            CompositionLocalProvider(LocalTopBarState provides behindTopBar) {
+              RouteContent(behindRoute!!)
+            }
+          }
+        } else {
+          Box(Modifier.fillMaxSize().graphicsLayer { translationX = behindOffset }) {
+            CompositionLocalProvider(LocalTopBarState provides behindTopBar) {
+              RouteContent(behindRoute!!)
+            }
+          }
+          // Dim overlay — 전환 중 behind 화면 터치 차단
+          Box(
+            Modifier.fillMaxSize().graphicsLayer { translationX = behindOffset }
+              .background(AppTheme.colors.shadow.copy(alpha = dimAlpha))
+              .pointerIgnore()
+          )
         }
-        // Dim overlay — 전환 중 behind 화면 터치 차단
-        Box(
-          Modifier.fillMaxSize().graphicsLayer { translationX = behindOffset }
-            .background(AppTheme.colors.shadow.copy(alpha = dimAlpha))
-            .pointerIgnore()
-        )
       }
 
       // Main layer (현재 화면 — 항상 같은 composition slot을 유지하여
@@ -201,22 +225,31 @@ fun NavigationStack(
 
       Box(Modifier.fillMaxSize().graphicsLayer {
         if (animState != AnimState.Idle) {
-          translationX = when (animState) {
-            // Push: 오른쪽에서 왼쪽으로 슬라이드 in
-            AnimState.Push -> containerWidth * (1f - p)
-            // Pop/Dragging: 오른쪽으로 슬라이드 out
-            else -> containerWidth * p
-          }
-          shadowElevation = 12.dp.toPx()
-          shape = RoundedCornerShape(
-            cornerRadius(
-              when (animState) {
-                AnimState.Push -> p
-                else -> 1f - p
-              }
+          if (useFadeTransition) {
+            alpha = when (animState) {
+              AnimState.Push -> p
+              AnimState.Pop -> 1f - p
+              AnimState.Dragging -> if (navigator.popRequested) 1f - p else 1f
+              AnimState.Idle -> 1f
+            }
+          } else {
+            translationX = when (animState) {
+              // Push: 오른쪽에서 왼쪽으로 슬라이드 in
+              AnimState.Push -> containerWidth * (1f - p)
+              // Pop/Dragging: 오른쪽으로 슬라이드 out
+              else -> containerWidth * p
+            }
+            shadowElevation = 12.dp.toPx()
+            shape = RoundedCornerShape(
+              cornerRadius(
+                when (animState) {
+                  AnimState.Push -> p
+                  else -> 1f - p
+                }
+              )
             )
-          )
-          clip = true
+            clip = true
+          }
         }
       }) {
         CompositionLocalProvider(LocalTopBarState provides mainTopBar) {
@@ -235,9 +268,12 @@ fun NavigationStack(
             .pointerInput(Unit) {
               detectHorizontalDragGestures(
                 onDragStart = {
-                  behindRoute = navigator.previous
-                  animState = AnimState.Dragging
-                  scope.launch { progress.snapTo(0f) }
+                  navigator.previous?.let {
+                    transitionStyle = visibleRoute.transitionStyleTo(it)
+                    behindRoute = it
+                    animState = AnimState.Dragging
+                    scope.launch { progress.snapTo(0f) }
+                  }
                 },
                 onDragEnd = {
                   val velocity = lastDragAmount * 1000f / 16f

--- a/apps/mobile2/compose/src/commonMain/kotlin/co/typie/route/Route.kt
+++ b/apps/mobile2/compose/src/commonMain/kotlin/co/typie/route/Route.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.unit.dp
 
 sealed interface Route {
   data object Home : Route
+  data object HomeSearch : Route
   data object Space : Route
   data object Notes : Route
   data object More : Route
@@ -34,6 +35,15 @@ sealed interface Route {
   data class Folder(val entityId: String) : Route
   data class Editor(val slug: String) : Route
   data object Login : Route
+}
+
+enum class RouteTransitionStyle { Slide, Fade }
+
+fun Route.transitionStyleTo(route: Route): RouteTransitionStyle = when {
+  (this is Route.Home && route is Route.HomeSearch) ||
+    (this is Route.HomeSearch && route is Route.Home) -> RouteTransitionStyle.Fade
+
+  else -> RouteTransitionStyle.Slide
 }
 
 val Route.toastBottomInset: Dp

--- a/apps/mobile2/compose/src/commonMain/kotlin/co/typie/route/Routes.kt
+++ b/apps/mobile2/compose/src/commonMain/kotlin/co/typie/route/Routes.kt
@@ -8,6 +8,7 @@ import co.typie.screen.editor.EditorScreen
 import co.typie.screen.editor_settings.EditorSettingsScreen
 import co.typie.screen.font_settings.FontSettingsScreen
 import co.typie.screen.folder.FolderScreen
+import co.typie.screen.home.HomeSearchScreen
 import co.typie.screen.home.HomeScreen
 import co.typie.screen.login.LoginScreen
 import co.typie.screen.more.MoreScreen
@@ -36,6 +37,7 @@ import co.typie.screen.text_replacements.TextReplacementsScreen
 fun MainRoutes(route: Route) {
   when (route) {
     is Route.Home -> HomeScreen()
+    is Route.HomeSearch -> HomeSearchScreen()
     is Route.Space -> SpaceScreen()
     is Route.Notes -> NotesScreen()
     is Route.More -> MoreScreen()

--- a/apps/mobile2/compose/src/commonMain/kotlin/co/typie/screen/home/HomeScreen.kt
+++ b/apps/mobile2/compose/src/commonMain/kotlin/co/typie/screen/home/HomeScreen.kt
@@ -1,19 +1,17 @@
 package co.typie.screen.home
 
-import androidx.compose.animation.Crossfade
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -46,7 +44,6 @@ import co.typie.graphql.QueryState
 import co.typie.graphql.type.DocumentType
 import co.typie.icons.Lucide
 import co.typie.navigation.Nav
-import co.typie.navigation.PlatformBackHandler
 import co.typie.route.Route
 import co.typie.shell.LocalBottomBarState
 import co.typie.ui.component.DocumentThumbnailPreview
@@ -60,7 +57,6 @@ import co.typie.ui.component.SpacePopoverLeadingKey
 import co.typie.ui.component.Text
 import co.typie.ui.component.resolveResponsiveContainerMetrics
 import co.typie.ui.component.topbar.ProvideTopBar
-import co.typie.ui.component.topbar.TopBarBackButton
 import co.typie.ui.component.topbar.topBarScrollOffset
 import co.typie.ui.icon.Icon
 import co.typie.ui.skeleton.Skeleton
@@ -71,104 +67,64 @@ import org.koin.compose.viewmodel.koinViewModel
 @Composable
 fun HomeScreen() {
   val model = koinViewModel<HomeViewModel>()
-  val searchModel = koinViewModel<SearchViewModel>()
+  val nav = Nav.current
   val scrollState = rememberScrollState()
-  val searchScrollState = rememberScrollState("home-search")
   val bottomBarState = LocalBottomBarState.current
 
-  LaunchedEffect(model.searching) {
-    bottomBarState.visible = !model.searching
+  LaunchedEffect(Unit) {
+    bottomBarState.visible = true
   }
 
   ProvideTopBar(
-    leadingKey = if (model.searching) SearchTopBarKey else SpacePopoverLeadingKey,
-    leading = if (model.searching) {
-      { TopBarBackButton(onClick = { model.exitSearch() }) }
-    } else {
-      { SpacePopover() }
-    },
-    center = if (model.searching) null else { { Text("홈", style = AppTheme.typography.title) } },
-    scrollOffset = if (model.searching) null else scrollState.topBarScrollOffset(),
+    leadingKey = SpacePopoverLeadingKey,
+    leading = { SpacePopover() },
+    center = { Text("홈", style = AppTheme.typography.title) },
+    scrollOffset = scrollState.topBarScrollOffset(),
   )
-
-  PlatformBackHandler(enabled = model.searching) {
-    model.exitSearch()
-  }
 
   if (model.query.state is QueryState.Error) {
     ErrorDialog { model.query.refetch() }
   }
 
-  Crossfade(
-    targetState = model.searching,
-    animationSpec = tween(200),
-    modifier = Modifier.fillMaxSize(),
-  ) { isSearching ->
-    Screen(
-      loading = model.query.state !is QueryState.Success,
-      background = AppTheme.colors.surfaceBase,
-      responsive = isSearching,
-      contentPadding = PaddingValues(0.dp),
-      primaryScrollableState = if (isSearching) searchScrollState else scrollState,
-      body = { contentPadding ->
-        if (isSearching) {
-          Column(
-            Modifier
-              .fillMaxSize()
-              .padding(contentPadding)
-          ) {
-            SearchHeader(
-              animateOnEnter = model.shouldAnimateSearchHeader,
-              query = searchModel.query,
-              onQueryChange = { searchModel.updateQuery(it) },
-              onSubmit = { searchModel.submitQuery() },
-              onEnterAnimationConsumed = { model.onSearchHeaderAnimationConsumed() },
+  Screen(
+    loading = model.query.state !is QueryState.Success,
+    background = AppTheme.colors.surfaceBase,
+    contentPadding = PaddingValues(0.dp),
+    primaryScrollableState = scrollState,
+    body = { contentPadding ->
+      Column(
+        Modifier
+          .fillMaxSize()
+          .verticalScroll(scrollState)
+          .padding(contentPadding)
+          .navigationBarsPadding()
+      ) {
+        HomeFramedSection {
+          Skeleton.Keep {
+            Text(
+              "홈",
+              style = AppTheme.typography.display,
+              modifier = Modifier.padding(horizontal = 16.dp)
             )
 
-            SearchContent(
-              modifier = Modifier.weight(1f),
-              searchViewModel = searchModel,
-              contentPadding = PaddingValues(0.dp),
-              scrollState = searchScrollState,
-            )
-          }
-        } else {
-          Column(
-            Modifier
-              .fillMaxSize()
-              .verticalScroll(scrollState)
-              .padding(contentPadding)
-              .navigationBarsPadding()
-          ) {
-            HomeFramedSection {
-              Skeleton.Keep {
-                Text(
-                  "홈",
-                  style = AppTheme.typography.display,
-                  modifier = Modifier.padding(horizontal = 16.dp)
-                )
-
-                SearchBar(onClick = {
-                  searchModel.reset()
-                  model.enterSearch()
-                })
-              }
-            }
-
-            RecentDocuments(data = model.query.data)
-
-            RecentFolders(data = model.query.data)
-
-            HomeFramedSection {
-              MoreDocuments(data = model.query.data)
-            }
-
-            Spacer(Modifier.height(140.dp))
+            SearchBar(onClick = {
+              nav.navigate(Route.HomeSearch)
+            })
           }
         }
-      },
-    )
-  }
+
+        RecentDocuments(data = model.query.data)
+
+        RecentFolders(data = model.query.data)
+
+        HomeFramedSection {
+          MoreDocuments(data = model.query.data)
+        }
+
+        Spacer(Modifier.height(140.dp))
+      }
+    },
+  )
 }
 
 @Composable
@@ -206,7 +162,7 @@ private fun HomeFullBleedRail(
 }
 
 @Composable
-private fun SearchBar(onClick: () -> Unit) {
+private fun SearchBar(onClick: suspend () -> Unit) {
   HomeSearchFieldFrame(
     modifier = Modifier
       .padding(horizontal = 16.dp)

--- a/apps/mobile2/compose/src/commonMain/kotlin/co/typie/screen/home/HomeSearchField.kt
+++ b/apps/mobile2/compose/src/commonMain/kotlin/co/typie/screen/home/HomeSearchField.kt
@@ -39,7 +39,7 @@ fun HomeSearchFieldFrame(
   modifier: Modifier = Modifier,
   focused: Boolean = false,
   enabled: Boolean = true,
-  onClick: (() -> Unit)? = null,
+  onClick: (suspend () -> Unit)? = null,
   content: @Composable RowScope.() -> Unit,
 ) {
   val colorSpec = tween<Color>(220)

--- a/apps/mobile2/compose/src/commonMain/kotlin/co/typie/screen/home/HomeSearchScreen.kt
+++ b/apps/mobile2/compose/src/commonMain/kotlin/co/typie/screen/home/HomeSearchScreen.kt
@@ -1,0 +1,65 @@
+package co.typie.screen.home
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import co.typie.navigation.Nav
+import co.typie.shell.LocalBottomBarState
+import co.typie.ui.component.Screen
+import co.typie.ui.component.topbar.ProvideTopBar
+import co.typie.ui.component.topbar.TopBarBackButton
+import co.typie.ui.state.rememberScrollState
+import co.typie.ui.theme.AppTheme
+import org.koin.compose.viewmodel.koinViewModel
+
+@Composable
+fun HomeSearchScreen() {
+  val nav = Nav.current
+  val model = koinViewModel<SearchViewModel>()
+  val scrollState = rememberScrollState("home-search")
+  val bottomBarState = LocalBottomBarState.current
+
+  LaunchedEffect(Unit) {
+    bottomBarState.visible = false
+  }
+
+  ProvideTopBar(
+    leadingKey = SearchTopBarKey,
+    leading = { TopBarBackButton(onClick = { nav.pop() }) },
+  )
+
+  Screen(
+    background = AppTheme.colors.surfaceBase,
+    responsive = true,
+    imeAware = true,
+    contentPadding = PaddingValues(0.dp),
+    primaryScrollableState = scrollState,
+    body = { contentPadding ->
+      Column(
+        Modifier
+          .fillMaxSize()
+          .padding(contentPadding)
+      ) {
+        SearchHeader(
+          animateOnEnter = model.shouldAnimateHeaderOnEnter,
+          query = model.query,
+          onQueryChange = { model.updateQuery(it) },
+          onSubmit = { model.submitQuery() },
+          onEnterAnimationConsumed = { model.onHeaderEnterAnimationConsumed() },
+        )
+
+        SearchContent(
+          modifier = Modifier.weight(1f),
+          searchViewModel = model,
+          contentPadding = PaddingValues(0.dp),
+          scrollState = scrollState,
+        )
+      }
+    },
+  )
+}

--- a/apps/mobile2/compose/src/commonMain/kotlin/co/typie/screen/home/HomeViewModel.kt
+++ b/apps/mobile2/compose/src/commonMain/kotlin/co/typie/screen/home/HomeViewModel.kt
@@ -1,8 +1,5 @@
 package co.typie.screen.home
 
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import co.typie.graphql.GraphQLViewModel
 import co.typie.graphql.HomeScreen_Query
 import co.typie.graphql.PlaceholderResolver
@@ -20,23 +17,6 @@ class HomeViewModel(
 ) : GraphQLViewModel() {
   val query =
     watchQuery(placeholderData()) { HomeScreen_Query(siteId = siteService.siteId) }
-
-  var searching by mutableStateOf(false)
-  var shouldAnimateSearchHeader by mutableStateOf(false)
-
-  fun enterSearch() {
-    shouldAnimateSearchHeader = true
-    searching = true
-  }
-
-  fun onSearchHeaderAnimationConsumed() {
-    shouldAnimateSearchHeader = false
-  }
-
-  fun exitSearch() {
-    shouldAnimateSearchHeader = false
-    searching = false
-  }
 }
 
 private fun placeholderData() = HomeScreen_Query.Data(PlaceholderResolver) {

--- a/apps/mobile2/compose/src/commonMain/kotlin/co/typie/screen/home/SearchContent.kt
+++ b/apps/mobile2/compose/src/commonMain/kotlin/co/typie/screen/home/SearchContent.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import co.typie.ext.InteractionScope
 import co.typie.ext.clickable
-import co.typie.ext.navigationBarsPadding
 import co.typie.ext.pressScale
 import co.typie.ext.verticalScroll
 import co.typie.graphql.HomeScreen_Search_Query
@@ -67,8 +66,7 @@ fun SearchContent(
       modifier = Modifier
         .fillMaxWidth()
         .verticalScroll(scrollState)
-        .padding(contentPadding)
-        .navigationBarsPadding(),
+        .padding(contentPadding),
     ) {
       if (searchViewModel.activeQuery.isBlank()) {
         RecentSearchesList(

--- a/apps/mobile2/compose/src/commonMain/kotlin/co/typie/screen/home/SearchViewModel.kt
+++ b/apps/mobile2/compose/src/commonMain/kotlin/co/typie/screen/home/SearchViewModel.kt
@@ -18,6 +18,8 @@ class SearchViewModel(
   private val siteService: SiteService,
   prefs: Prefs,
 ) : GraphQLViewModel() {
+  var shouldAnimateHeaderOnEnter by mutableStateOf(true)
+    private set
 
   var query by mutableStateOf("")
     private set
@@ -77,9 +79,7 @@ class SearchViewModel(
     storedRecentSearches = updated
   }
 
-  fun reset() {
-    query = ""
-    activeQuery = ""
-    debounceJob?.cancel()
+  fun onHeaderEnterAnimationConsumed() {
+    shouldAnimateHeaderOnEnter = false
   }
 }

--- a/apps/mobile2/compose/src/commonMain/kotlin/co/typie/screen/subscription/CurrentPlanViewModel.kt
+++ b/apps/mobile2/compose/src/commonMain/kotlin/co/typie/screen/subscription/CurrentPlanViewModel.kt
@@ -1,19 +1,31 @@
 package co.typie.screen.subscription
 
+import androidx.lifecycle.viewModelScope
 import co.typie.graphql.CurrentPlanScreen_Query
 import co.typie.graphql.GraphQLViewModel
 import co.typie.graphql.PlaceholderResolver
 import co.typie.graphql.type.buildUser
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
 import org.koin.core.annotation.KoinViewModel
 
 @KoinViewModel
 class CurrentPlanViewModel(
   subscriptionService: SubscriptionService,
+  private val subscriptionSync: SubscriptionSync,
 ) : GraphQLViewModel() {
   val query = watchQuery(
     placeholderData(),
     skip = { subscriptionService.usesSandbox },
   ) { CurrentPlanScreen_Query() }
+
+  init {
+    viewModelScope.launch {
+      subscriptionSync.events.collect {
+        query.refetch()
+      }
+    }
+  }
 }
 
 private fun placeholderData() = CurrentPlanScreen_Query.Data(PlaceholderResolver) {

--- a/apps/mobile2/compose/src/commonMain/kotlin/co/typie/screen/subscription/ReferralScreen.kt
+++ b/apps/mobile2/compose/src/commonMain/kotlin/co/typie/screen/subscription/ReferralScreen.kt
@@ -236,6 +236,8 @@ fun ReferralScreen() {
             ReferralBulletPoint("초대 횟수에는 제한이 없어요.")
           }
         }
+
+        Spacer(Modifier.height(72.dp))
   }
 }
 

--- a/apps/mobile2/compose/src/commonTest/kotlin/co/typie/route/RouteTransitionStyleTest.kt
+++ b/apps/mobile2/compose/src/commonTest/kotlin/co/typie/route/RouteTransitionStyleTest.kt
@@ -1,0 +1,17 @@
+package co.typie.route
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RouteTransitionStyleTest {
+
+  @Test
+  fun `home search fades in from home`() {
+    assertEquals(RouteTransitionStyle.Fade, Route.Home.transitionStyleTo(Route.HomeSearch))
+  }
+
+  @Test
+  fun `non search routes keep slide transition`() {
+    assertEquals(RouteTransitionStyle.Slide, Route.HomeSearch.transitionStyleTo(Route.Editor("doc-1")))
+  }
+}

--- a/apps/mobile2/compose/src/commonTest/kotlin/co/typie/screen/subscription/CurrentPlanViewModelTest.kt
+++ b/apps/mobile2/compose/src/commonTest/kotlin/co/typie/screen/subscription/CurrentPlanViewModelTest.kt
@@ -1,0 +1,124 @@
+package co.typie.screen.subscription
+
+import co.typie.di.Platform
+import co.typie.graphql.CurrentPlanScreen_Query
+import co.typie.graphql.PlaceholderResolver
+import co.typie.graphql.type.buildUser
+import com.apollographql.apollo.ApolloClient
+import com.apollographql.apollo.api.ApolloRequest
+import com.apollographql.apollo.api.ApolloResponse
+import com.apollographql.apollo.api.Operation
+import com.apollographql.apollo.network.NetworkTransport
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CurrentPlanViewModelTest {
+  private val dispatcher = StandardTestDispatcher()
+
+  @BeforeTest
+  fun setUp() {
+    Dispatchers.setMain(dispatcher)
+    stopKoin()
+  }
+
+  @AfterTest
+  fun tearDown() {
+    stopKoin()
+    Dispatchers.resetMain()
+  }
+
+  @Test
+  fun `subscription change refetches current plan query`() = runTest(dispatcher) {
+    val networkTransport = CountingNetworkTransport()
+    startKoin {
+      modules(
+        module {
+          single<ApolloClient> {
+            ApolloClient.Builder()
+              .networkTransport(networkTransport)
+              .build()
+          }
+        },
+      )
+    }
+
+    val subscriptionSync = SubscriptionSync()
+    CurrentPlanViewModel(
+      subscriptionService = SubscriptionService(
+        platform = Platform.iOS,
+        purchaseService = CurrentPlanTestPurchaseService(),
+        subscriptionDevSandbox = SubscriptionDevSandbox(Platform.iOS),
+        subscriptionSync = subscriptionSync,
+      ),
+      subscriptionSync = subscriptionSync,
+    )
+
+    advanceUntilIdle()
+    assertEquals(1, networkTransport.requestCount)
+
+    subscriptionSync.notifyChanged()
+    advanceUntilIdle()
+
+    assertEquals(2, networkTransport.requestCount)
+  }
+}
+
+private class CountingNetworkTransport : NetworkTransport {
+  var requestCount = 0
+    private set
+
+  override fun <D : Operation.Data> execute(request: ApolloRequest<D>): Flow<ApolloResponse<D>> {
+    requestCount += 1
+
+    @Suppress("UNCHECKED_CAST")
+    val data = currentPlanQueryData() as D
+
+    return flowOf(
+      ApolloResponse.Builder(
+        operation = request.operation,
+        requestUuid = request.requestUuid,
+        data = data,
+      )
+        .isLast(true)
+        .build(),
+    )
+  }
+
+  override fun dispose() = Unit
+}
+
+private fun currentPlanQueryData() = CurrentPlanScreen_Query.Data(PlaceholderResolver) {
+  me = buildUser {
+    credit = 0
+    subscription = null
+  }
+}
+
+private class CurrentPlanTestPurchaseService : co.typie.platform.PurchaseService {
+  override val events = MutableSharedFlow<co.typie.platform.PurchaseEvent>()
+
+  override suspend fun queryProducts(): Map<co.typie.platform.PurchasePlanInterval, co.typie.platform.PurchaseProduct> = emptyMap()
+
+  override suspend fun purchase(
+    product: co.typie.platform.PurchaseProduct,
+    accountId: String,
+  ): Boolean = false
+
+  override suspend fun openSubscriptionManagement(): Boolean = false
+}


### PR DESCRIPTION
- 초대 페이지 하단 패딩 추가해서 CTA에 가려지지 않도록 함
- 검색 페이지 결과 키보드에 가려지지 않도록 함 (imeAware)
- 검색 페이지 라우트 분리, 뒤로가기 제스처 및 crossfade 트랜지션 지원
- 플랜 업그레이드 후 뒤로 가기 해서 이용권 정보 스크린으로 갔을 때 리프레시하도록 함