### PR TITLE
KMP surface size 동기화 이슈 수정

### DIFF
--- a/apps/mobile2/compose/src/commonMain/kotlin/co/typie/editor/compose/Page.kt
+++ b/apps/mobile2/compose/src/commonMain/kotlin/co/typie/editor/compose/Page.kt
@@ -6,7 +6,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
@@ -24,6 +25,8 @@ internal fun Page(
 ) {
   val density = LocalDensity.current
   val scaleFactor = density.density.toDouble()
+
+  val lastRendered = remember { floatArrayOf(width, height) }
 
   Box(modifier = Modifier.background(AppTheme.colors.surfaceDefault)) {
     Surface(
@@ -46,8 +49,12 @@ internal fun Page(
     onDispose { off() }
   }
 
-  LaunchedEffect(width, height) {
-    editor.resizeSurface(page, width.toInt(), height.toInt(), scaleFactor)
-    editor.renderSurface(page)
+  SideEffect {
+    if (lastRendered[0] != width || lastRendered[1] != height) {
+      editor.resizeSurface(page, width.toInt(), height.toInt(), scaleFactor)
+      editor.renderSurface(page)
+      lastRendered[0] = width
+      lastRendered[1] = height
+    }
   }
 }


### PR DESCRIPTION
render surface 크기 변경과 composable 사이즈 변경이 LaunchedEffect 코루틴 안에서 비동기로 이루어져 surface 버퍼 사이즈가 실제 뷰 사이즈와 어긋나는 문제 해결
