### PR TITLE
iOS paralell rendering 비활성화

### DIFF
--- a/apps/mobile2/compose/src/iosMain/kotlin/co/typie/MainViewController.kt
+++ b/apps/mobile2/compose/src/iosMain/kotlin/co/typie/MainViewController.kt
@@ -1,14 +1,10 @@
-@file:OptIn(ExperimentalComposeUiApi::class)
-
 package co.typie
 
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.uikit.OnFocusBehavior
 import androidx.compose.ui.window.ComposeUIViewController
 
 fun MainViewController() = ComposeUIViewController(
   configure = {
     onFocusBehavior = OnFocusBehavior.DoNothing
-    parallelRendering = true
   },
 ) { App() }


### PR DESCRIPTION
composition thread 와 render thread 간 race condition으로 앱 크래시 발생함
