### PR TITLE
Popover 배치 디버그

### DIFF
--- a/apps/mobile2/compose/src/commonMain/kotlin/co/typie/ui/component/popover/Popover.kt
+++ b/apps/mobile2/compose/src/commonMain/kotlin/co/typie/ui/component/popover/Popover.kt
@@ -412,12 +412,24 @@ private fun PopoverPanePopup(
         paneWidth.coerceAtLeast(minWidthPx).coerceAtMost(finalPaneConstraints.maxWidth)
       }
     val paneSize = IntSize(resolvedPaneWidth, paneHeight)
-    val anchorSize = anchorBounds.size
-    val resolvedPlacement = resolvedPlacement(placement, showBelow)
+    val geometry =
+      resolvePopoverGeometry(
+        anchorBounds = anchorBounds,
+        windowSize = IntSize(constraints.maxWidth, constraints.maxHeight),
+        placement = placement,
+        popupContentSize = paneSize,
+        screenPadding = screenPadding,
+      )
     val transition =
       PopoverPaneTransition(
         progress = progress,
-        anchorContentRect = anchorContentRect(paneSize, anchorSize, resolvedPlacement),
+        anchorContentRect =
+          Rect(
+            left = geometry.anchorBoundsInPopup.left.toFloat(),
+            top = geometry.anchorBoundsInPopup.top.toFloat(),
+            right = geometry.anchorBoundsInPopup.right.toFloat(),
+            bottom = geometry.anchorBoundsInPopup.bottom.toFloat(),
+          ),
       )
 
     val surfacePlaceable =
@@ -427,8 +439,7 @@ private fun PopoverPanePopup(
               anchor = anchor,
               pane = { ShrinkWrappedPane(expandToMaxWidth = expandToMaxWidth, content = pane) },
               paneSize = paneSize,
-              anchorSize = anchorSize,
-              resolvedPlacement = resolvedPlacement,
+              anchorContentRect = geometry.anchorBoundsInPopup,
               progress = progress,
               interactive = interactive,
               collapsedCornerRadius = collapsedCornerRadius,
@@ -470,13 +481,13 @@ private fun PopoverPaneSurface(
   anchor: @Composable () -> Unit,
   pane: @Composable () -> Unit,
   paneSize: IntSize,
-  anchorSize: IntSize,
-  resolvedPlacement: PopoverPlacement,
+  anchorContentRect: IntRect,
   progress: Float,
   interactive: Boolean,
   collapsedCornerRadius: Dp,
 ) {
   val density = LocalDensity.current
+  val anchorSize = anchorContentRect.size
   val animatedWidth =
     sizeForProgress(anchorSize.width.toFloat(), paneSize.width.toFloat(), progress)
   val animatedHeight =
@@ -486,9 +497,9 @@ private fun PopoverPaneSurface(
       width = max(1, animatedWidth.roundToInt()),
       height = max(1, animatedHeight.roundToInt()),
     )
-  val surfaceOffset = alignedOffset(paneSize, animatedSurfaceSize, resolvedPlacement)
-  val paneOffset = alignedOffset(animatedSurfaceSize, paneSize, resolvedPlacement)
-  val anchorOffset = anchorContentOffset(paneSize, anchorSize, resolvedPlacement)
+  val surfaceOffset = surfaceOffsetForProgress(anchorContentRect, progress)
+  val paneOffset = IntOffset(x = -surfaceOffset.x, y = -surfaceOffset.y)
+  val anchorOffset = IntOffset(x = anchorContentRect.left, y = anchorContentRect.top)
   val cornerRadius =
     lerp(
       collapsedCornerRadius.toPx(density),
@@ -576,48 +587,6 @@ private fun sizeForProgress(start: Float, end: Float, progress: Float): Float {
   }
 }
 
-private fun anchorContentRect(
-  paneSize: IntSize,
-  anchorSize: IntSize,
-  placement: PopoverPlacement,
-): Rect {
-  val offset = anchorContentOffset(paneSize, anchorSize, placement)
-  return Rect(
-    left = offset.x.toFloat(),
-    top = offset.y.toFloat(),
-    right = offset.x + anchorSize.width.toFloat(),
-    bottom = offset.y + anchorSize.height.toFloat(),
-  )
-}
-
-private fun anchorContentOffset(
-  paneSize: IntSize,
-  anchorSize: IntSize,
-  placement: PopoverPlacement,
-): IntOffset {
-  return alignedOffset(paneSize, anchorSize, placement)
-}
-
-private fun alignedOffset(
-  containerSize: IntSize,
-  childSize: IntSize,
-  placement: PopoverPlacement,
-): IntOffset {
-  val x =
-    when (placement.align) {
-      PopoverAlign.Start -> 0
-      PopoverAlign.Center -> (containerSize.width - childSize.width) / 2
-      PopoverAlign.End -> containerSize.width - childSize.width
-    }
-  val y =
-    when (placement.side) {
-      PopoverSide.Below -> 0
-      PopoverSide.Above -> containerSize.height - childSize.height
-    }
-
-  return IntOffset(x, y)
-}
-
 private fun shrinkBounded(value: Int, inset: Int): Int {
   if (value == Constraints.Infinity) {
     return value
@@ -641,6 +610,13 @@ private fun availableHeightForPlacement(
   } else {
     max(0, anchorBounds.bottom - screenPadding.top)
   }
+}
+
+private fun surfaceOffsetForProgress(anchorContentRect: IntRect, progress: Float): IntOffset {
+  return IntOffset(
+    x = lerp(anchorContentRect.left.toFloat(), 0f, progress).roundToInt(),
+    y = lerp(anchorContentRect.top.toFloat(), 0f, progress).roundToInt(),
+  )
 }
 
 private fun availableWidthForPlacement(

--- a/apps/mobile2/compose/src/commonMain/kotlin/co/typie/ui/component/popover/PopoverPlacementProvider.kt
+++ b/apps/mobile2/compose/src/commonMain/kotlin/co/typie/ui/component/popover/PopoverPlacementProvider.kt
@@ -28,6 +28,12 @@ data class PopoverPlacement(val side: PopoverSide, val align: PopoverAlign) {
   }
 }
 
+internal data class ResolvedPopoverGeometry(
+  val popupOffset: IntOffset,
+  val placement: PopoverPlacement,
+  val anchorBoundsInPopup: IntRect,
+)
+
 internal class PopoverPlacementProvider(
   private val placement: PopoverPlacement,
   private val screenPadding: PopoverScreenPadding,
@@ -39,45 +45,51 @@ internal class PopoverPlacementProvider(
     layoutDirection: LayoutDirection,
     popupContentSize: IntSize,
   ): IntOffset {
-    val showBelow =
-      shouldShowBelow(
+    return resolvePopoverGeometry(
+        anchorBounds = anchorBounds,
+        windowSize = windowSize,
         placement = placement,
-        childHeight = popupContentSize.height,
-        windowHeight = windowSize.height,
-        anchorRect = anchorBounds,
+        popupContentSize = popupContentSize,
         screenPadding = screenPadding,
       )
-
-    val unclampedX =
-      when (placement.align) {
-        PopoverAlign.Start -> anchorBounds.left
-        PopoverAlign.Center -> anchorBounds.left + (anchorBounds.width - popupContentSize.width) / 2
-        PopoverAlign.End -> anchorBounds.right - popupContentSize.width
-      }
-
-    val unclampedY =
-      if (showBelow) anchorBounds.top else anchorBounds.bottom - popupContentSize.height
-
-    val minX =
-      when (placement.align) {
-        PopoverAlign.Start -> anchorBounds.left
-        else -> screenPadding.left
-      }
-    val maxX =
-      when (placement.align) {
-        PopoverAlign.End -> anchorBounds.right - popupContentSize.width
-        else -> windowSize.width - screenPadding.right - popupContentSize.width
-      }
-    val minY = if (showBelow) anchorBounds.top else screenPadding.top
-    val maxY =
-      if (showBelow) {
-        windowSize.height - screenPadding.bottom - popupContentSize.height
-      } else {
-        anchorBounds.bottom - popupContentSize.height
-      }
-
-    return IntOffset(x = clamp(unclampedX, minX, maxX), y = clamp(unclampedY, minY, maxY))
+      .popupOffset
   }
+}
+
+internal fun resolvePopoverGeometry(
+  anchorBounds: IntRect,
+  windowSize: IntSize,
+  placement: PopoverPlacement,
+  popupContentSize: IntSize,
+  screenPadding: PopoverScreenPadding,
+): ResolvedPopoverGeometry {
+  val showBelow =
+    shouldShowBelow(
+      placement = placement,
+      childHeight = popupContentSize.height,
+      windowHeight = windowSize.height,
+      anchorRect = anchorBounds,
+      screenPadding = screenPadding,
+    )
+  val popupOffset =
+    calculatePopoverOffset(
+      anchorBounds = anchorBounds,
+      windowSize = windowSize,
+      placement = placement,
+      popupContentSize = popupContentSize,
+      screenPadding = screenPadding,
+      showBelow = showBelow,
+    )
+
+  return ResolvedPopoverGeometry(
+    popupOffset = popupOffset,
+    placement = resolvedPlacement(placement, showBelow),
+    anchorBoundsInPopup =
+      IntRect(
+        IntOffset(x = anchorBounds.left - popupOffset.x, y = anchorBounds.top - popupOffset.y),
+        anchorBounds.size,
+      ),
+  )
 }
 
 internal fun shouldShowBelow(
@@ -104,6 +116,45 @@ internal fun shouldShowBelow(
 
 internal fun resolvedPlacement(placement: PopoverPlacement, showBelow: Boolean): PopoverPlacement {
   return placement.copy(side = if (showBelow) PopoverSide.Below else PopoverSide.Above)
+}
+
+private fun calculatePopoverOffset(
+  anchorBounds: IntRect,
+  windowSize: IntSize,
+  placement: PopoverPlacement,
+  popupContentSize: IntSize,
+  screenPadding: PopoverScreenPadding,
+  showBelow: Boolean,
+): IntOffset {
+  val unclampedX =
+    when (placement.align) {
+      PopoverAlign.Start -> anchorBounds.left
+      PopoverAlign.Center -> anchorBounds.left + (anchorBounds.width - popupContentSize.width) / 2
+      PopoverAlign.End -> anchorBounds.right - popupContentSize.width
+    }
+
+  val unclampedY =
+    if (showBelow) anchorBounds.top else anchorBounds.bottom - popupContentSize.height
+
+  val minX =
+    when (placement.align) {
+      PopoverAlign.Start -> anchorBounds.left
+      else -> screenPadding.left
+    }
+  val maxX =
+    when (placement.align) {
+      PopoverAlign.End -> anchorBounds.right - popupContentSize.width
+      else -> windowSize.width - screenPadding.right - popupContentSize.width
+    }
+  val minY = if (showBelow) anchorBounds.top else screenPadding.top
+  val maxY =
+    if (showBelow) {
+      windowSize.height - screenPadding.bottom - popupContentSize.height
+    } else {
+      anchorBounds.bottom - popupContentSize.height
+    }
+
+  return IntOffset(x = clamp(unclampedX, minX, maxX), y = clamp(unclampedY, minY, maxY))
 }
 
 private fun clamp(value: Int, min: Int, max: Int): Int {

--- a/apps/mobile2/compose/src/commonTest/kotlin/co/typie/ui/component/popover/PopoverPlacementProviderTest.kt
+++ b/apps/mobile2/compose/src/commonTest/kotlin/co/typie/ui/component/popover/PopoverPlacementProviderTest.kt
@@ -34,6 +34,20 @@ class PopoverPlacementProviderTest {
     )
   }
 
+  private fun resolveGeometry(
+    anchorBounds: IntRect,
+    placement: PopoverPlacement,
+    popupContentSize: IntSize = popupSize,
+  ): ResolvedPopoverGeometry {
+    return resolvePopoverGeometry(
+      anchorBounds = anchorBounds,
+      windowSize = windowSize,
+      placement = placement,
+      popupContentSize = popupContentSize,
+      screenPadding = screenPadding,
+    )
+  }
+
   @Test
   fun shouldShowBelow_prefersBottom_enoughSpace() {
     assertTrue(shouldShowBelow(PopoverPlacement.BelowEnd, 200, 844, topAnchor, screenPadding))
@@ -83,5 +97,16 @@ class PopoverPlacementProviderTest {
     val rightAnchor = IntRect(300, 100, 370, 144)
     val offset = calculate(rightAnchor, PopoverPlacement.BelowStart)
     assertEquals(300, offset.x)
+  }
+
+  @Test
+  fun resolvePopoverGeometry_tracksActualAnchorRect_whenCenteredPopupClampsToRightEdge() {
+    val rightAnchor = IntRect(320, 100, 360, 144)
+
+    val geometry = resolveGeometry(rightAnchor, PopoverPlacement.BelowCenter)
+
+    assertEquals(IntOffset(142, 100), geometry.popupOffset)
+    assertEquals(PopoverPlacement.BelowCenter, geometry.placement)
+    assertEquals(IntRect(178, 0, 218, 44), geometry.anchorBoundsInPopup)
   }
 }


### PR DESCRIPTION
화면 가장자리에서 팝오버가 flip될 때 배치 계산과 확장 애니메이션이 서로 다른 기준을 쓰는 문제를 수정