### PR TITLE
fix desktop/iOS input

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorImeTextFieldValue.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorImeTextFieldValue.kt
@@ -1,0 +1,54 @@
+// cspell:ignore DBFF DFFF
+
+package co.typie.editor.input
+
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+import co.typie.editor.ffi.Ime
+
+internal fun Ime.toTextFieldValue(): TextFieldValue =
+  TextFieldValue(
+    text = text,
+    selection =
+      resolveImeTextRange(
+        text = text,
+        windowStart = windowStart,
+        start = selection.start,
+        end = selection.end,
+      ),
+    composition =
+      composing?.let {
+        resolveImeTextRange(text = text, windowStart = windowStart, start = it.start, end = it.end)
+      },
+  )
+
+private fun resolveImeTextRange(text: String, windowStart: Int, start: Int, end: Int): TextRange {
+  val textStart = resolveImeTextIndex(text = text, windowStart = windowStart, offset = start)
+  val textEnd = resolveImeTextIndex(text = text, windowStart = windowStart, offset = end)
+  return TextRange(start = textStart, end = textEnd)
+}
+
+private fun resolveImeTextIndex(text: String, windowStart: Int, offset: Int): Int {
+  val relativeOffset =
+    (offset.toLong() - windowStart.toLong()).coerceIn(0, Int.MAX_VALUE.toLong()).toInt()
+  return text.utf16IndexAtCodePointOffset(relativeOffset)
+}
+
+private fun String.utf16IndexAtCodePointOffset(offset: Int): Int {
+  var utf16Index = 0
+  var remaining = offset
+  while (utf16Index < length && remaining > 0) {
+    utf16Index += codePointUtf16LengthAt(utf16Index)
+    remaining--
+  }
+  return utf16Index.coerceAtMost(length)
+}
+
+private fun String.codePointUtf16LengthAt(index: Int): Int =
+  if (
+    this[index] in '\uD800'..'\uDBFF' && index + 1 < length && this[index + 1] in '\uDC00'..'\uDFFF'
+  ) {
+    2
+  } else {
+    1
+  }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/input/EditorImeTextFieldValueTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/input/EditorImeTextFieldValueTest.kt
@@ -1,0 +1,33 @@
+package co.typie.editor.input
+
+import androidx.compose.ui.text.TextRange
+import co.typie.editor.ffi.Ime
+import co.typie.editor.ffi.ImeRange
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class EditorImeTextFieldValueTest {
+  @Test
+  fun ime_context_selection_is_clamped_to_text_length() {
+    val value =
+      Ime(text = "abc", windowStart = 0, selection = ImeRange(start = 4, end = 4), composing = null)
+        .toTextFieldValue()
+
+    assertEquals(TextRange(3), value.selection)
+  }
+
+  @Test
+  fun ime_context_flat_offsets_are_mapped_to_utf16_indices() {
+    val value =
+      Ime(
+          text = "a\uD83D\uDE00b",
+          windowStart = 0,
+          selection = ImeRange(start = 2, end = 3),
+          composing = ImeRange(start = 1, end = 3),
+        )
+        .toTextFieldValue()
+
+    assertEquals(TextRange(start = 3, end = 4), value.selection)
+    assertEquals(TextRange(start = 1, end = 4), value.composition)
+  }
+}

--- a/apps/mobile/compose/src/desktopMain/kotlin/co/typie/editor/input/EditorInput.desktop.kt
+++ b/apps/mobile/compose/src/desktopMain/kotlin/co/typie/editor/input/EditorInput.desktop.kt
@@ -28,15 +28,7 @@ internal actual suspend fun PlatformTextInputSessionScope.createEditorInputReque
 ): PlatformTextInputMethodRequest {
   return object : PlatformTextInputMethodRequest {
     override val value: () -> TextFieldValue = {
-      val ctx = editor.ime(Int.MAX_VALUE, Int.MAX_VALUE)
-      val selectionStart = ctx.selection.start - ctx.windowStart
-      val selectionEnd = ctx.selection.end - ctx.windowStart
-      TextFieldValue(
-        text = ctx.text,
-        selection = TextRange(selectionStart, selectionEnd),
-        composition =
-          ctx.composing?.let { TextRange(it.start - ctx.windowStart, it.end - ctx.windowStart) },
-      )
+      editor.ime?.toTextFieldValue() ?: TextFieldValue()
     }
 
     override val imeOptions: ImeOptions =

--- a/apps/mobile/compose/src/iosMain/kotlin/co/typie/editor/input/EditorInput.ios.kt
+++ b/apps/mobile/compose/src/iosMain/kotlin/co/typie/editor/input/EditorInput.ios.kt
@@ -22,19 +22,10 @@ import kotlinx.cinterop.ExperimentalForeignApi
 
 internal actual suspend fun PlatformTextInputSessionScope.createEditorInputRequest(
   editor: Editor
-): PlatformTextInputMethodRequest =
-  object : PlatformTextInputMethodRequest {
-    override val value: () -> TextFieldValue = value@{
-      val ctx = editor.ime ?: return@value TextFieldValue()
-      val selectionStart = ctx.selection.start - ctx.windowStart
-      val selectionEnd = ctx.selection.end - ctx.windowStart
-
-      TextFieldValue(
-        text = ctx.text,
-        selection = TextRange(selectionStart, selectionEnd),
-        composition =
-          ctx.composing?.let { TextRange(it.start - ctx.windowStart, it.end - ctx.windowStart) },
-      )
+): PlatformTextInputMethodRequest {
+  return object : PlatformTextInputMethodRequest {
+    override val value: () -> TextFieldValue = {
+      editor.ime?.toTextFieldValue() ?: TextFieldValue()
     }
 
     override val imeOptions: ImeOptions =
@@ -80,6 +71,7 @@ internal actual suspend fun PlatformTextInputSessionScope.createEditorInputReque
 
     override val editText: (block: TextEditingScope.() -> Unit) -> Unit = { _ -> }
   }
+}
 
 internal actual fun PlatformTextInputSessionScope.notifyImeSelectionChanged(editor: Editor) {
   // iOS: pull-based via request.value — no explicit notification needed


### PR DESCRIPTION
- backspace 꾹 누르는 중 `Caused by: java.lang.StringIndexOutOfBoundsException: Range [331, 331) out of bounds for length 330` 같은 에러를 방지함
- Desktop/iOS IME 상태 조회를 커밋된 editor.ime 스냅샷 기준으로 통일
- 선택 범위를 안전하게 clamp