### PR TITLE
포커스 및 툴바 관련 디버그

### DIFF
--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.android.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.android.kt
@@ -3,16 +3,32 @@
 package co.typie.screen.editor.editor.toolbar
 
 import android.content.res.Configuration
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.imeAnimationSource
+import androidx.compose.foundation.layout.imeAnimationTarget
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 internal actual fun rememberEditorKeyboardState(): EditorKeyboardState {
   val configuration = LocalConfiguration.current
   val density = LocalDensity.current
+  val imeBottom = WindowInsets.ime.getBottom(density)
+  val imeAnimationSourceBottom = WindowInsets.imeAnimationSource.getBottom(density)
+  val imeAnimationTargetBottom = WindowInsets.imeAnimationTarget.getBottom(density)
+  val imeBottomDp = with(density) { imeBottom.toDp() }
+  val imeAnimationSourceBottomDp = with(density) { imeAnimationSourceBottom.toDp() }
+  val imeAnimationTargetBottomDp = with(density) { imeAnimationTargetBottom.toDp() }
+  val presentation =
+    resolveKeyboardPresentation(
+      imeBottom = imeBottomDp,
+      animationSourceBottom = imeAnimationSourceBottomDp,
+      animationTargetBottom = imeAnimationTargetBottomDp,
+    )
   val hardwareKeyboardVisible =
     configuration.keyboard != Configuration.KEYBOARD_NOKEYS &&
       configuration.hardKeyboardHidden != Configuration.HARDKEYBOARDHIDDEN_YES
@@ -23,6 +39,7 @@ internal actual fun rememberEditorKeyboardState(): EditorKeyboardState {
       } else {
         EditorKeyboardType.Software
       },
-    imeFrameVisible = WindowInsets.ime.getBottom(density) > 0,
+    imeFrameVisible = imeBottom > 0 || imeAnimationTargetBottom > 0,
+    presentation = presentation,
   )
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/viewport/EditorViewportScrollbarMetrics.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/viewport/EditorViewportScrollbarMetrics.kt
@@ -12,7 +12,18 @@ internal fun shouldShowEditorViewportScrollbarThumb(
   viewportLength: Float,
   contentLength: Float,
   trackLength: Float = resolveEditorViewportScrollbarTrackLength(viewportLength),
-): Boolean = viewportLength > 0f && contentLength > viewportLength && trackLength > 0f
+  minThumbSize: Float = 0f,
+): Boolean {
+  val effectiveMinThumbSize = minThumbSize.coerceAtLeast(0f)
+  val hasUsableTrack =
+    if (effectiveMinThumbSize > 0f) {
+      trackLength >= effectiveMinThumbSize
+    } else {
+      trackLength > 0f
+    }
+
+  return viewportLength > 0f && contentLength > viewportLength && hasUsableTrack
+}
 
 internal fun resolveEditorViewportScrollbarTrackLength(
   viewportLength: Float,
@@ -31,12 +42,18 @@ internal fun resolveEditorViewportScrollbarThumbSize(
   contentLength: Float,
   minThumbSize: Float,
 ): Float {
-  if (trackLength <= 0f || viewportLength <= 0f || contentLength <= viewportLength) {
+  val effectiveMinThumbSize = minThumbSize.coerceAtLeast(0f)
+  if (
+    trackLength <= 0f ||
+      viewportLength <= 0f ||
+      contentLength <= viewportLength ||
+      trackLength < effectiveMinThumbSize
+  ) {
     return 0f
   }
 
   val rawThumbSize = trackLength * viewportLength / contentLength
-  return rawThumbSize.coerceIn(minThumbSize.coerceAtLeast(0f), trackLength)
+  return rawThumbSize.coerceIn(effectiveMinThumbSize, trackLength)
 }
 
 internal fun resolveEditorViewportScrollbarThumbOffset(
@@ -92,7 +109,13 @@ internal fun resolveEditorViewportScrollbarMetrics(
       leadingPadding = leadingPadding,
       trailingPadding = trailingPadding,
     )
-  val isVisible = shouldShowEditorViewportScrollbarThumb(viewportLength, contentLength, trackLength)
+  val isVisible =
+    shouldShowEditorViewportScrollbarThumb(
+      viewportLength = viewportLength,
+      contentLength = contentLength,
+      trackLength = trackLength,
+      minThumbSize = minThumbSize,
+    )
   val thumbSize =
     if (isVisible) {
       resolveEditorViewportScrollbarThumbSize(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ext/Modifier.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ext/Modifier.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.platform.LocalFocusManager
 import kotlinx.coroutines.launch
 
 val LocalInteractionSource = compositionLocalOf<MutableInteractionSource?> { null }
@@ -60,16 +59,12 @@ fun Modifier.clickable(onClick: suspend () -> Unit): Modifier =
 fun Modifier.clickable(enabled: Boolean = true, onClick: suspend () -> Unit): Modifier {
   val scope = rememberCoroutineScope()
   val interactionSource = LocalInteractionSource.current ?: remember { MutableInteractionSource() }
-  val focusManager = LocalFocusManager.current
   return this.focusProperties { canFocus = false }
     .foundationClickable(
       enabled = enabled,
       interactionSource = interactionSource,
       indication = null,
-      onClick = {
-        focusManager.clearFocus()
-        scope.launch { onClick() }
-      },
+      onClick = { scope.launch { onClick() } },
     )
 }
 
@@ -82,7 +77,6 @@ fun Modifier.combinedClickable(
   val interactionSource = LocalInteractionSource.current ?: remember { MutableInteractionSource() }
   var handling by remember { mutableStateOf(false) }
   val scope = rememberCoroutineScope()
-  val focusManager = LocalFocusManager.current
   return this.focusProperties { canFocus = false }
     .foundationCombinedClickable(
       enabled = enabled,
@@ -91,7 +85,6 @@ fun Modifier.combinedClickable(
       onClick = {
         if (!handling) {
           handling = true
-          focusManager.clearFocus()
           scope.launch {
             try {
               onClick()
@@ -104,7 +97,6 @@ fun Modifier.combinedClickable(
       onLongClick = {
         if (!handling) {
           handling = true
-          focusManager.clearFocus()
           scope.launch {
             try {
               onLongClick()

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -69,7 +69,7 @@ import co.typie.screen.editor.editor.toolbar.ToolbarBottomPanelVisibilityExitMil
 import co.typie.screen.editor.editor.toolbar.ToolbarHeight
 import co.typie.screen.editor.editor.toolbar.ToolbarInputEnvironment
 import co.typie.screen.editor.editor.toolbar.effectiveImeInset
-import co.typie.screen.editor.editor.toolbar.isEditorToolbarVisible
+import co.typie.screen.editor.editor.toolbar.isEditorToolbarPresented
 import co.typie.screen.editor.editor.toolbar.isImeVisible
 import co.typie.screen.editor.editor.toolbar.rememberEditorKeyboardState
 import co.typie.screen.editor.editor.toolbar.rememberEditorToolbarInputState
@@ -219,14 +219,15 @@ fun EditorScreen(entityId: String) {
     val previousImeVisible = remember { mutableStateOf(imeVisible) }
     val imeAppearing = !previousImeVisible.value && imeVisible
     val toolbarRetainedKeyboardInset = toolbarInputState.retainedKeyboardInset()
-    val toolbarVisible =
-      isEditorToolbarVisible(
+    val toolbarRestoreInset = toolbarInputState.keyboardRestoreInset
+    val toolbarPresented =
+      isEditorToolbarPresented(
         environment = toolbarInputEnvironment,
         activeBottomPanel = toolbarPanel?.key,
-        retainedKeyboardInset = toolbarRetainedKeyboardInset,
+        restoringEditorInput = toolbarRestoreInset != null,
       )
     val toolbarControlsOcclusion =
-      if (toolbarVisible) {
+      if (toolbarPresented) {
         ToolbarHeight + ToolbarBottomPadding
       } else {
         0.dp
@@ -235,7 +236,8 @@ fun EditorScreen(entityId: String) {
       if (toolbarPanel != null) {
         bottomSafeInset + ToolbarBottomPanelGap + toolbarPanel.height
       } else {
-        maxOf(bottomSafeInset, toolbarEffectiveImeInset, toolbarRetainedKeyboardInset)
+        toolbarRestoreInset?.let { maxOf(bottomSafeInset, it) }
+          ?: maxOf(bottomSafeInset, toolbarEffectiveImeInset, toolbarRetainedKeyboardInset)
       }
     val toolbarBottomOcclusionTarget = toolbarControlsOcclusion + bottomPanelOrKeyboardOcclusion
     val inputSpaceOwnsOcclusion = !bottomPanelOpen && (imeVisible || !panelTransitionRunning)

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.kt
@@ -2,21 +2,57 @@ package co.typie.screen.editor.editor.toolbar
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 
 internal enum class EditorKeyboardType {
   Software,
   Hardware,
 }
 
+internal sealed interface EditorKeyboardPresentation {
+  data object Hidden : EditorKeyboardPresentation
+
+  data object Showing : EditorKeyboardPresentation
+
+  data class Shown(val settledImeBottom: Dp) : EditorKeyboardPresentation
+
+  data object Hiding : EditorKeyboardPresentation
+}
+
 internal data class EditorKeyboardState(
   val type: EditorKeyboardType,
   val imeFrameVisible: Boolean = false,
   val imeHideEventVersion: Int = 0,
+  val presentation: EditorKeyboardPresentation = EditorKeyboardPresentation.Hidden,
 ) {
   val usesImeInset: Boolean
     get() = type == EditorKeyboardType.Software || imeFrameVisible
+
+  val settledImeBottom: Dp?
+    get() =
+      when (val currentPresentation = presentation) {
+        is EditorKeyboardPresentation.Shown -> currentPresentation.settledImeBottom
+        EditorKeyboardPresentation.Hidden,
+        EditorKeyboardPresentation.Hiding,
+        EditorKeyboardPresentation.Showing -> null
+      }
 }
 
 @Composable internal expect fun rememberEditorKeyboardState(): EditorKeyboardState
 
 internal fun isImeVisible(imeBottom: Dp, safeBottomInset: Dp): Boolean = imeBottom > safeBottomInset
+
+internal fun resolveKeyboardPresentation(
+  imeBottom: Dp,
+  animationSourceBottom: Dp,
+  animationTargetBottom: Dp,
+): EditorKeyboardPresentation =
+  when {
+    imeBottom <= 0.dp && animationTargetBottom <= 0.dp -> EditorKeyboardPresentation.Hidden
+    animationTargetBottom > 0.dp && imeBottom < animationTargetBottom ->
+      EditorKeyboardPresentation.Showing
+    animationTargetBottom > 0.dp -> EditorKeyboardPresentation.Shown(animationTargetBottom)
+    animationSourceBottom > 0.dp -> EditorKeyboardPresentation.Hiding
+    imeBottom > 0.dp -> EditorKeyboardPresentation.Shown(imeBottom)
+    else -> EditorKeyboardPresentation.Hidden
+  }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarHost.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarHost.kt
@@ -57,9 +57,10 @@ internal fun EditorToolbarHost(
   val imeVisible =
     isImeVisible(imeBottom = effectiveImeInset, safeBottomInset = environment.safeBottomInset)
   val retainedKeyboardInset = inputState.retainedKeyboardInset()
-  val inputBottomInset =
-    maxOf(effectiveImeInset, retainedKeyboardInset, environment.safeBottomInset)
   val restoringKeyboard = inputState.keyboardRestoreInset != null
+  val inputBottomInset =
+    inputState.keyboardRestoreInset?.let { maxOf(it, environment.safeBottomInset) }
+      ?: maxOf(effectiveImeInset, retainedKeyboardInset, environment.safeBottomInset)
   val bottomPanelHeight = panel?.height ?: inputState.lastBottomPanelHeight
   val bottomPanelContainerHeight = panel?.let { ToolbarBottomPanelGap + it.height } ?: 0.dp
   val lastBottomPanelContainerHeight = ToolbarBottomPanelGap + inputState.lastBottomPanelHeight
@@ -77,11 +78,11 @@ internal fun EditorToolbarHost(
     } else {
       inputBottomInset
     }
-  val toolbarVisible =
-    isEditorToolbarVisible(
+  val toolbarPresented =
+    isEditorToolbarPresented(
       environment = environment,
       activeBottomPanel = activeBottomPanel,
-      retainedKeyboardInset = retainedKeyboardInset,
+      restoringEditorInput = restoringKeyboard,
     )
   val fixedAction =
     fixedActionFor(
@@ -162,7 +163,7 @@ internal fun EditorToolbarHost(
   SideEffect { previousImeVisible.value = imeVisible }
 
   AnimatedVisibility(
-    visible = toolbarVisible,
+    visible = toolbarPresented,
     enter = fadeIn(animationSpec = tween(ToolbarVisibilityEnterMillis)),
     exit = fadeOut(animationSpec = tween(ToolbarVisibilityExitMillis)),
     modifier =

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarInputState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarInputState.kt
@@ -50,15 +50,37 @@ internal enum class ToolbarFixedAction {
   DismissInput,
 }
 
-internal fun isEditorToolbarVisible(
+internal fun isEditorToolbarPresented(
   environment: ToolbarInputEnvironment,
   activeBottomPanel: EditorToolbarBottomPanelKey?,
-  retainedKeyboardInset: Dp,
-): Boolean =
-  environment.visible &&
-    (environment.focused ||
-      activeBottomPanel != null ||
-      retainedKeyboardInset > environment.safeBottomInset)
+  restoringEditorInput: Boolean = false,
+): Boolean {
+  val editorInputActive =
+    environment.visible &&
+      (environment.focused || activeBottomPanel != null || restoringEditorInput)
+  if (!editorInputActive) {
+    return false
+  }
+
+  if (activeBottomPanel != null || restoringEditorInput) {
+    return true
+  }
+
+  if (environment.keyboardType == EditorKeyboardType.Hardware) {
+    return true
+  }
+
+  return when (environment.keyboardState.presentation) {
+    EditorKeyboardPresentation.Hidden,
+    EditorKeyboardPresentation.Hiding -> false
+    EditorKeyboardPresentation.Showing ->
+      isImeVisible(
+        imeBottom = effectiveImeInset(environment),
+        safeBottomInset = environment.safeBottomInset,
+      )
+    is EditorKeyboardPresentation.Shown -> true
+  }
+}
 
 internal sealed interface PanelKeyboardSpace {
   val inset: Dp
@@ -135,8 +157,25 @@ internal class EditorToolbarInputState {
         visible = imeVisible,
         hideEventVersion = environment.keyboardState.imeHideEventVersion,
       )
+
+    panel
+      ?.takeIf { !environment.focused }
+      ?.let { currentPanel ->
+        lastPanelSnapshot = currentPanel.snapshot()
+        panel = null
+        keyboardRestoreInset = null
+        rememberedKeyboardInset =
+          visibleImeInsetOrZero(effectiveImeInset, environment.safeBottomInset)
+        previousIme = currentIme
+        return
+      }
+
+    val retainedKeyboardInset = retainedKeyboardInset()
     val editorInputActive =
-      environment.focused || panel != null || retainedKeyboardInset() > environment.safeBottomInset
+      environment.focused ||
+        panel != null ||
+        keyboardRestoreInset != null ||
+        (imeVisible && retainedKeyboardInset > environment.safeBottomInset)
     val imeHideEvent = currentIme.hideEventVersion != previousIme.hideEventVersion
 
     if (!editorInputActive) {
@@ -158,11 +197,20 @@ internal class EditorToolbarInputState {
     }
 
     if (currentPanel != null && !previousIme.visible && imeVisible) {
-      lastPanelSnapshot = currentPanel.snapshot()
-      keyboardRestoreInset = null
-      rememberedKeyboardInset =
-        visibleImeInsetOrZero(effectiveImeInset, environment.safeBottomInset)
-      panel = null
+      if (currentPanel.keyboardSpace is PanelKeyboardSpace.FollowIme) {
+        rememberKeyboardInset(
+          effectiveImeInset = effectiveImeInset,
+          safeBottomInset = environment.safeBottomInset,
+          preserveCurrentInset = true,
+        )
+        emit(ToolbarEffect.HideKeyboard)
+      } else {
+        lastPanelSnapshot = currentPanel.snapshot()
+        keyboardRestoreInset = null
+        rememberedKeyboardInset =
+          visibleImeInsetOrZero(effectiveImeInset, environment.safeBottomInset)
+        panel = null
+      }
       previousIme = currentIme
       return
     }
@@ -183,7 +231,7 @@ internal class EditorToolbarInputState {
       rememberKeyboardInset(
         effectiveImeInset = effectiveImeInset,
         safeBottomInset = environment.safeBottomInset,
-        preserveCurrentInset = panel != null || previousIme.visible,
+        preserveCurrentInset = panel != null,
       )
     }
 
@@ -320,7 +368,9 @@ internal class EditorToolbarInputState {
   ) {
     val restoreInset = keyboardRestoreInset ?: return
     when {
-      imeVisible && !environment.panelTransitionRunning && effectiveImeInset >= restoreInset -> {
+      imeVisible &&
+        !environment.panelTransitionRunning &&
+        effectiveImeInset == (environment.keyboardState.settledImeBottom ?: restoreInset) -> {
         keyboardRestoreInset = null
         rememberedKeyboardInset =
           visibleImeInsetOrZero(effectiveImeInset, environment.safeBottomInset)
@@ -355,8 +405,18 @@ internal class EditorToolbarInputState {
 internal fun visibleImeInsetOrZero(effectiveImeInset: Dp, safeBottomInset: Dp): Dp =
   if (effectiveImeInset > safeBottomInset) effectiveImeInset else 0.dp
 
-internal fun effectiveImeInset(environment: ToolbarInputEnvironment): Dp =
-  if (environment.keyboardState.usesImeInset) environment.imeBottom else 0.dp
+internal fun effectiveImeInset(environment: ToolbarInputEnvironment): Dp {
+  if (!environment.keyboardState.usesImeInset) {
+    return 0.dp
+  }
+
+  val settledImeInset = environment.keyboardState.settledImeBottom
+  return if (settledImeInset != null && environment.imeBottom > settledImeInset) {
+    settledImeInset
+  } else {
+    environment.imeBottom
+  }
+}
 
 private fun PanelKeyboardSpace.panelHeight(safeBottomInset: Dp): Dp =
   (maxOf(inset, safeBottomInset + ToolbarBottomPanelGap + ToolbarBottomPanelMinHeight) -

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/shell/RootShell.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/shell/RootShell.kt
@@ -2,7 +2,6 @@ package co.typie.shell
 
 import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
@@ -11,8 +10,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.FrameRateCategory
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.preferredFrameRate
 import co.typie.domain.auth.AuthService
 import co.typie.domain.auth.AuthState
@@ -67,8 +64,6 @@ fun RootShell() {
   val dialog = remember { Dialog() }
   val popover = remember { PopoverOverlayState() }
 
-  val focusManager = LocalFocusManager.current
-
   val screen =
     when {
       BootstrapService.state !is BootstrapState.Ready -> RootScreen.Splash
@@ -90,7 +85,6 @@ fun RootShell() {
         .safeDrawingHorizontalPadding()
         .preferredFrameRate(FrameRateCategory.High)
         .popoverOutsideTapHost(state = popover)
-        .pointerInput(Unit) { detectTapGestures { focusManager.clearFocus() } }
     ) {
       Crossfade(
         screen,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/Screen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/Screen.kt
@@ -1,6 +1,8 @@
 package co.typie.ui.component
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
@@ -17,9 +19,13 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
 import co.typie.contract.Loadable
 import co.typie.contract.LoadableState
@@ -51,6 +57,7 @@ fun Screen(
   refetchOnMount: Boolean = true,
   background: Color = AppTheme.colors.surfaceCanvas,
   contentPadding: PaddingValues = PaddingValues(horizontal = 16.dp),
+  dismissFocusOnTapOutsideInput: Boolean = true,
   overlay: (@Composable BoxScope.() -> Unit)? = null,
   content: @Composable BoxScope.(contentPadding: PaddingValues) -> Unit,
 ) {
@@ -61,6 +68,7 @@ fun Screen(
 
   val nav = Nav.current
   val dialog = LocalDialog.current
+  val focusManager = LocalFocusManager.current
 
   val contentPadding =
     if (hasTopBar) {
@@ -91,7 +99,14 @@ fun Screen(
     }
   }
 
-  Box(Modifier.fillMaxSize().background(background)) {
+  Box(
+    Modifier.fillMaxSize()
+      .background(background)
+      .clearFocusOnUnhandledTap(
+        enabled = dismissFocusOnTapOutsideInput,
+        focusManager = focusManager,
+      )
+  ) {
     Box(
       modifier = Modifier.fillMaxSize().hazeSource(hazeState).widthIn(max = MaxContentWidth),
       contentAlignment = Alignment.TopCenter,
@@ -170,6 +185,44 @@ fun Screen(
     overlay?.invoke(this)
   }
 }
+
+private fun Modifier.clearFocusOnUnhandledTap(
+  enabled: Boolean,
+  focusManager: FocusManager,
+): Modifier =
+  if (!enabled) {
+    this
+  } else {
+    pointerInput(focusManager) {
+      awaitEachGesture {
+        val down = awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Final)
+        if (down.isConsumed) {
+          return@awaitEachGesture
+        }
+
+        val origin = down.position
+        var isTapCandidate = true
+        var pressed = true
+        while (pressed) {
+          val event = awaitPointerEvent(pass = PointerEventPass.Final)
+          val change = event.changes.firstOrNull { it.id == down.id } ?: return@awaitEachGesture
+          if (change.isConsumed) {
+            return@awaitEachGesture
+          }
+          if ((change.position - origin).getDistance() > viewConfiguration.touchSlop) {
+            isTapCandidate = false
+          }
+          if (!change.pressed) {
+            pressed = false
+          }
+        }
+
+        if (isTapCandidate) {
+          focusManager.clearFocus()
+        }
+      }
+    }
+  }
 
 private fun overlayFadeBrush(color: Color, reverse: Boolean): Brush {
   val stops =

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/popover/Popover.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/popover/Popover.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntRect
@@ -60,6 +61,7 @@ fun Popover(
   collapsedCornerRadius: Dp? = null,
 ) {
   val density = LocalDensity.current
+  val focusManager = LocalFocusManager.current
   val layoutDirection = LocalLayoutDirection.current
   val safeDrawing = WindowInsets.safeDrawing
   val resolvedScreenPadding =
@@ -228,6 +230,7 @@ fun Popover(
             }
             is PopoverOpenTrigger.Tap -> {
               anchorInteractionSource.tryEmit(PressInteraction.Release(pressInteraction))
+              focusManager.clearFocus()
               openTrigger.upChange.consume()
               isExpanded = true
               return@awaitEachGesture
@@ -240,6 +243,7 @@ fun Popover(
 
           try {
             scrollLockHandle = scrollGestureLockState.acquire()
+            focusManager.clearFocus()
             isExpanded = true
             released =
               trackPressGestureSession(

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/viewport/EditorViewportScrollbarMetricsTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/viewport/EditorViewportScrollbarMetricsTest.kt
@@ -1,0 +1,26 @@
+package co.typie.editor.viewport
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class EditorViewportScrollbarMetricsTest {
+  @Test
+  fun `scrollbar is hidden when visible track cannot fit the minimum thumb`() {
+    val metrics =
+      resolveEditorViewportScrollbarMetrics(
+        viewportLength = 900f,
+        contentLength = 1800f,
+        scrollPosition = 240f,
+        minThumbSize = 30f,
+        leadingInset = 120f,
+        trailingInset = 755f,
+      )
+
+    assertFalse(metrics.isVisible)
+    assertEquals(25f, metrics.trackLength)
+    assertEquals(0f, metrics.thumbSize)
+    assertEquals(0f, metrics.thumbOffset)
+    assertEquals(25f, metrics.thumbTravel)
+  }
+}

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardTypeTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardTypeTest.kt
@@ -1,0 +1,112 @@
+package co.typie.screen.editor.editor.toolbar
+
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class EditorKeyboardTypeTest {
+  @Test
+  fun keyboard_state_defaults_to_hidden_presentation() {
+    assertEquals(
+      EditorKeyboardPresentation.Hidden,
+      EditorKeyboardState(EditorKeyboardType.Software).presentation,
+    )
+    assertNull(EditorKeyboardState(EditorKeyboardType.Software).settledImeBottom)
+  }
+
+  @Test
+  fun keyboard_presentation_tracks_show_animation() {
+    assertEquals(
+      EditorKeyboardPresentation.Showing,
+      resolveKeyboardPresentation(
+        imeBottom = 120.dp,
+        animationSourceBottom = 0.dp,
+        animationTargetBottom = 320.dp,
+      ),
+    )
+
+    assertEquals(
+      EditorKeyboardPresentation.Shown(settledImeBottom = 320.dp),
+      resolveKeyboardPresentation(
+        imeBottom = 320.dp,
+        animationSourceBottom = 0.dp,
+        animationTargetBottom = 320.dp,
+      ),
+    )
+  }
+
+  @Test
+  fun keyboard_presentation_tracks_hide_animation() {
+    assertEquals(
+      EditorKeyboardPresentation.Hiding,
+      resolveKeyboardPresentation(
+        imeBottom = 120.dp,
+        animationSourceBottom = 320.dp,
+        animationTargetBottom = 0.dp,
+      ),
+    )
+
+    assertEquals(
+      EditorKeyboardPresentation.Hidden,
+      resolveKeyboardPresentation(
+        imeBottom = 0.dp,
+        animationSourceBottom = 0.dp,
+        animationTargetBottom = 0.dp,
+      ),
+    )
+  }
+
+  @Test
+  fun keyboard_presentation_treats_stable_visible_ime_as_shown() {
+    assertEquals(
+      EditorKeyboardPresentation.Shown(settledImeBottom = 320.dp),
+      resolveKeyboardPresentation(
+        imeBottom = 320.dp,
+        animationSourceBottom = 0.dp,
+        animationTargetBottom = 0.dp,
+      ),
+    )
+  }
+
+  @Test
+  fun shown_keyboard_presentation_exposes_settled_ime_bottom() {
+    val keyboardState =
+      EditorKeyboardState(
+        type = EditorKeyboardType.Software,
+        presentation = EditorKeyboardPresentation.Shown(settledImeBottom = 280.dp),
+      )
+
+    assertEquals(280.dp, keyboardState.settledImeBottom)
+  }
+
+  @Test
+  fun unsettled_keyboard_presentation_has_no_settled_ime_bottom() {
+    assertNull(
+      EditorKeyboardState(
+          type = EditorKeyboardType.Software,
+          presentation = EditorKeyboardPresentation.Showing,
+        )
+        .settledImeBottom
+    )
+    assertNull(
+      EditorKeyboardState(
+          type = EditorKeyboardType.Software,
+          presentation = EditorKeyboardPresentation.Hiding,
+        )
+        .settledImeBottom
+    )
+  }
+
+  @Test
+  fun shown_keyboard_presentation_uses_animation_target_when_current_inset_overshoots() {
+    assertEquals(
+      EditorKeyboardPresentation.Shown(settledImeBottom = 350.dp),
+      resolveKeyboardPresentation(
+        imeBottom = 806.dp,
+        animationSourceBottom = 0.dp,
+        animationTargetBottom = 350.dp,
+      ),
+    )
+  }
+}

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarInputStateTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarInputStateTest.kt
@@ -100,6 +100,433 @@ class ToolbarInputStateTest {
   }
 
   @Test
+  fun focus_loss_tracks_keyboard_inset_down_instead_of_retaining_peak() {
+    val state = EditorToolbarInputState()
+    val keyboardVisible = toolbarInputEnvironment(imeBottom = 320.dp)
+
+    state.onEnvironmentChanged(keyboardVisible)
+
+    val partiallyHidden = toolbarInputEnvironment(focused = false, imeBottom = 180.dp)
+    state.onEnvironmentChanged(partiallyHidden)
+
+    assertEquals(180.dp, state.retainedKeyboardInset())
+
+    val keyboardHidden = toolbarInputEnvironment(focused = false, imeBottom = 0.dp)
+    state.onEnvironmentChanged(keyboardHidden)
+
+    assertEquals(0.dp, state.rememberedKeyboardInset)
+    assertEquals(0.dp, state.retainedKeyboardInset())
+  }
+
+  @Test
+  fun retained_keyboard_inset_does_not_present_toolbar_without_editor_focus() {
+    val environment = toolbarInputEnvironment(focused = false, imeBottom = 320.dp)
+
+    val presented = isEditorToolbarPresented(environment = environment, activeBottomPanel = null)
+
+    assertEquals(false, presented)
+  }
+
+  @Test
+  fun software_keyboard_toolbar_is_presented_when_keyboard_starts_visible_show_transition() {
+    val keyboardStarting =
+      toolbarInputEnvironment(
+        focused = true,
+        imeBottom = 0.dp,
+        safeBottomInset = 24.dp,
+        keyboardState =
+          EditorKeyboardState(
+            type = EditorKeyboardType.Software,
+            presentation = EditorKeyboardPresentation.Showing,
+          ),
+      )
+
+    assertEquals(
+      false,
+      isEditorToolbarPresented(environment = keyboardStarting, activeBottomPanel = null),
+    )
+
+    val keyboardMoving = keyboardStarting.copy(imeBottom = 64.dp)
+
+    assertEquals(
+      true,
+      isEditorToolbarPresented(environment = keyboardMoving, activeBottomPanel = null),
+    )
+  }
+
+  @Test
+  fun software_keyboard_toolbar_exits_while_keyboard_is_hiding() {
+    val environment =
+      toolbarInputEnvironment(
+        focused = false,
+        imeBottom = 160.dp,
+        keyboardState =
+          EditorKeyboardState(
+            type = EditorKeyboardType.Software,
+            presentation = EditorKeyboardPresentation.Hiding,
+          ),
+      )
+
+    assertEquals(
+      false,
+      isEditorToolbarPresented(environment = environment, activeBottomPanel = null),
+    )
+    assertEquals(160.dp, effectiveImeInset(environment))
+  }
+
+  @Test
+  fun panel_and_restore_present_toolbar_independent_of_keyboard_phase() {
+    val keyboardHidden =
+      toolbarInputEnvironment(
+        focused = true,
+        imeBottom = 0.dp,
+        keyboardState =
+          EditorKeyboardState(
+            type = EditorKeyboardType.Software,
+            presentation = EditorKeyboardPresentation.Hidden,
+          ),
+      )
+
+    assertEquals(
+      true,
+      isEditorToolbarPresented(
+        environment = keyboardHidden,
+        activeBottomPanel = EditorToolbarBottomPanelKey.Tools,
+      ),
+    )
+    assertEquals(
+      true,
+      isEditorToolbarPresented(
+        environment = keyboardHidden,
+        activeBottomPanel = null,
+        restoringEditorInput = true,
+      ),
+    )
+  }
+
+  @Test
+  fun hardware_keyboard_toolbar_is_presented_immediately_on_editor_focus() {
+    val environment =
+      toolbarInputEnvironment(
+        focused = true,
+        imeBottom = 0.dp,
+        keyboardState =
+          EditorKeyboardState(
+            type = EditorKeyboardType.Hardware,
+            presentation = EditorKeyboardPresentation.Hidden,
+          ),
+      )
+
+    assertEquals(
+      true,
+      isEditorToolbarPresented(environment = environment, activeBottomPanel = null),
+    )
+  }
+
+  @Test
+  fun panel_closes_when_external_keyboard_takes_focus() {
+    val state = EditorToolbarInputState()
+    val keyboardVisible = toolbarInputEnvironment(imeBottom = 320.dp)
+
+    state.onEnvironmentChanged(keyboardVisible)
+    state.dispatch(ToolbarIntent.OpenPanel(EditorToolbarBottomPanelKey.Insert), keyboardVisible)
+    state.takeEffects()
+    state.onEnvironmentChanged(toolbarInputEnvironment(imeBottom = 0.dp))
+
+    val editorFocusLost = toolbarInputEnvironment(focused = false, imeBottom = 260.dp)
+    state.onEnvironmentChanged(editorFocusLost)
+
+    assertEquals(null, state.panel)
+    assertEquals(null, state.activeBottomPanel)
+    assertEquals(EditorToolbarBottomPanelKey.Insert, state.lastBottomPanel)
+    assertEquals(260.dp, state.retainedKeyboardInset())
+    assertEquals(false, isEditorToolbarPresented(editorFocusLost, state.activeBottomPanel))
+    assertEquals(emptyList(), state.takeEffects())
+  }
+
+  @Test
+  fun panel_closes_when_editor_focus_is_cleared_without_keyboard() {
+    val state = EditorToolbarInputState()
+    val keyboardVisible = toolbarInputEnvironment(imeBottom = 320.dp)
+
+    state.onEnvironmentChanged(keyboardVisible)
+    state.dispatch(ToolbarIntent.OpenPanel(EditorToolbarBottomPanelKey.Insert), keyboardVisible)
+    state.takeEffects()
+    state.onEnvironmentChanged(toolbarInputEnvironment(imeBottom = 0.dp))
+
+    val editorFocusCleared = toolbarInputEnvironment(focused = false, imeBottom = 0.dp)
+    state.onEnvironmentChanged(editorFocusCleared)
+
+    assertEquals(null, state.activeBottomPanel)
+    assertEquals(null, state.keyboardRestoreInset)
+    assertEquals(0.dp, state.retainedKeyboardInset())
+    assertEquals(false, isEditorToolbarPresented(editorFocusCleared, state.activeBottomPanel))
+    assertEquals(emptyList(), state.takeEffects())
+  }
+
+  @Test
+  fun external_keyboard_after_editor_focus_loss_is_not_hidden_by_panel() {
+    val state = EditorToolbarInputState()
+    val keyboardVisible = toolbarInputEnvironment(imeBottom = 320.dp)
+
+    state.onEnvironmentChanged(keyboardVisible)
+    state.dispatch(ToolbarIntent.OpenPanel(EditorToolbarBottomPanelKey.Insert), keyboardVisible)
+    state.takeEffects()
+    state.onEnvironmentChanged(toolbarInputEnvironment(imeBottom = 0.dp))
+    state.onEnvironmentChanged(toolbarInputEnvironment(focused = false, imeBottom = 0.dp))
+
+    val externalKeyboardVisible = toolbarInputEnvironment(focused = false, imeBottom = 260.dp)
+    state.onEnvironmentChanged(externalKeyboardVisible)
+
+    assertEquals(null, state.panel)
+    assertEquals(null, state.activeBottomPanel)
+    assertEquals(false, isEditorToolbarPresented(externalKeyboardVisible, state.activeBottomPanel))
+    assertEquals(emptyList(), state.takeEffects())
+  }
+
+  @Test
+  fun editor_refocus_after_external_keyboard_can_open_and_restore_panel_input() {
+    val state = EditorToolbarInputState()
+    val keyboardVisible = toolbarInputEnvironment(imeBottom = 320.dp)
+
+    state.onEnvironmentChanged(keyboardVisible)
+    state.dispatch(ToolbarIntent.OpenPanel(EditorToolbarBottomPanelKey.Insert), keyboardVisible)
+    state.takeEffects()
+    state.onEnvironmentChanged(toolbarInputEnvironment(imeBottom = 0.dp))
+    state.onEnvironmentChanged(toolbarInputEnvironment(focused = false, imeBottom = 0.dp))
+    state.onEnvironmentChanged(toolbarInputEnvironment(focused = false, imeBottom = 320.dp))
+
+    val editorRefocused = toolbarInputEnvironment(imeBottom = 320.dp)
+    state.onEnvironmentChanged(editorRefocused)
+    state.dispatch(ToolbarIntent.OpenPanel(EditorToolbarBottomPanelKey.Insert), editorRefocused)
+
+    assertEquals(EditorToolbarBottomPanelKey.Insert, state.activeBottomPanel)
+    assertEquals(288.dp, state.panel?.height)
+    assertEquals(listOf(ToolbarEffect.HideKeyboard), state.takeEffects())
+
+    val keyboardHidden = toolbarInputEnvironment(imeBottom = 0.dp)
+    state.onEnvironmentChanged(keyboardHidden)
+    state.dispatch(ToolbarIntent.RestoreEditorInput, keyboardHidden)
+
+    assertEquals(null, state.activeBottomPanel)
+    assertEquals(320.dp, state.keyboardRestoreInset)
+    assertEquals(
+      true,
+      isEditorToolbarPresented(
+        environment = keyboardHidden,
+        activeBottomPanel = state.activeBottomPanel,
+        restoringEditorInput = state.keyboardRestoreInset != null,
+      ),
+    )
+    assertEquals(
+      listOf(ToolbarEffect.RequestFocus, ToolbarEffect.ShowKeyboard),
+      state.takeEffects(),
+    )
+  }
+
+  @Test
+  fun stale_keyboard_restore_after_reopening_panel_before_ime_moves_does_not_close_panel() {
+    val state = EditorToolbarInputState()
+    val keyboardVisible = toolbarInputEnvironment(imeBottom = 320.dp)
+
+    state.onEnvironmentChanged(keyboardVisible)
+    state.dispatch(ToolbarIntent.OpenPanel(EditorToolbarBottomPanelKey.Insert), keyboardVisible)
+    state.takeEffects()
+
+    val keyboardHidden = toolbarInputEnvironment(imeBottom = 0.dp)
+    state.onEnvironmentChanged(keyboardHidden)
+    state.dispatch(ToolbarIntent.RestoreEditorInput, keyboardHidden)
+    state.takeEffects()
+
+    val hiddenRestoring = toolbarInputEnvironment(imeBottom = 0.dp, panelTransitionRunning = true)
+    state.onEnvironmentChanged(hiddenRestoring)
+    state.dispatch(ToolbarIntent.OpenPanel(EditorToolbarBottomPanelKey.Tools), hiddenRestoring)
+    state.takeEffects()
+
+    val staleRestoredKeyboard = toolbarInputEnvironment(imeBottom = 320.dp)
+    state.onEnvironmentChanged(staleRestoredKeyboard)
+
+    assertEquals(EditorToolbarBottomPanelKey.Tools, state.activeBottomPanel)
+    assertEquals(288.dp, state.panel?.height)
+    assertEquals(320.dp, state.panel?.keyboardSpace?.inset)
+  }
+
+  @Test
+  fun keyboard_restore_owns_layout_until_live_ime_returns_to_restore_inset() {
+    val state = EditorToolbarInputState()
+    val keyboardVisible = toolbarInputEnvironment(imeBottom = 350.dp)
+
+    state.onEnvironmentChanged(keyboardVisible)
+    state.dispatch(ToolbarIntent.OpenPanel(EditorToolbarBottomPanelKey.Tools), keyboardVisible)
+    state.takeEffects()
+
+    val keyboardHidden = toolbarInputEnvironment(imeBottom = 0.dp)
+    state.onEnvironmentChanged(keyboardHidden)
+    state.dispatch(ToolbarIntent.RestoreEditorInput, keyboardHidden)
+    state.takeEffects()
+
+    state.onEnvironmentChanged(
+      toolbarInputEnvironment(imeBottom = 806.dp, panelTransitionRunning = true)
+    )
+
+    assertEquals(350.dp, state.keyboardRestoreInset)
+    assertEquals(350.dp, state.retainedKeyboardInset())
+
+    state.onEnvironmentChanged(toolbarInputEnvironment(imeBottom = 782.dp))
+
+    assertEquals(350.dp, state.keyboardRestoreInset)
+    assertEquals(350.dp, state.retainedKeyboardInset())
+
+    state.onEnvironmentChanged(toolbarInputEnvironment(imeBottom = 650.dp))
+
+    assertEquals(350.dp, state.keyboardRestoreInset)
+    assertEquals(350.dp, state.retainedKeyboardInset())
+
+    state.onEnvironmentChanged(toolbarInputEnvironment(imeBottom = 350.dp))
+
+    assertEquals(null, state.keyboardRestoreInset)
+    assertEquals(350.dp, state.rememberedKeyboardInset)
+    assertEquals(350.dp, state.retainedKeyboardInset())
+  }
+
+  @Test
+  fun keyboard_restore_keeps_panel_space_while_live_ime_is_still_replacing_it() {
+    val state = EditorToolbarInputState()
+    val keyboardVisible = toolbarInputEnvironment(imeBottom = 320.dp)
+
+    state.onEnvironmentChanged(keyboardVisible)
+    state.dispatch(ToolbarIntent.OpenPanel(EditorToolbarBottomPanelKey.Tools), keyboardVisible)
+    state.takeEffects()
+
+    val keyboardHidden = toolbarInputEnvironment(imeBottom = 0.dp)
+    state.onEnvironmentChanged(keyboardHidden)
+    state.dispatch(ToolbarIntent.RestoreEditorInput, keyboardHidden)
+    state.takeEffects()
+
+    state.onEnvironmentChanged(toolbarInputEnvironment(imeBottom = 95.dp))
+
+    assertEquals(320.dp, state.keyboardRestoreInset)
+    assertEquals(320.dp, state.retainedKeyboardInset())
+  }
+
+  @Test
+  fun keyboard_restore_releases_when_smaller_keyboard_reaches_settled_inset() {
+    val state = EditorToolbarInputState()
+    val keyboardVisible = toolbarInputEnvironment(imeBottom = 320.dp)
+
+    state.onEnvironmentChanged(keyboardVisible)
+    state.dispatch(ToolbarIntent.OpenPanel(EditorToolbarBottomPanelKey.Tools), keyboardVisible)
+    state.takeEffects()
+
+    val keyboardHidden = toolbarInputEnvironment(imeBottom = 0.dp)
+    state.onEnvironmentChanged(keyboardHidden)
+    state.dispatch(ToolbarIntent.RestoreEditorInput, keyboardHidden)
+    state.takeEffects()
+
+    val smallerKeyboardState =
+      EditorKeyboardState(
+        type = EditorKeyboardType.Software,
+        presentation = EditorKeyboardPresentation.Shown(settledImeBottom = 280.dp),
+      )
+    state.onEnvironmentChanged(
+      toolbarInputEnvironment(imeBottom = 160.dp, keyboardState = smallerKeyboardState)
+    )
+
+    assertEquals(320.dp, state.keyboardRestoreInset)
+    assertEquals(320.dp, state.retainedKeyboardInset())
+
+    state.onEnvironmentChanged(
+      toolbarInputEnvironment(imeBottom = 280.dp, keyboardState = smallerKeyboardState)
+    )
+
+    assertEquals(null, state.keyboardRestoreInset)
+    assertEquals(280.dp, state.retainedKeyboardInset())
+  }
+
+  @Test
+  fun settled_ime_inset_bounds_ios_refocus_overshoot() {
+    val environment =
+      toolbarInputEnvironment(
+        imeBottom = 806.dp,
+        keyboardState =
+          EditorKeyboardState(
+            type = EditorKeyboardType.Software,
+            presentation = EditorKeyboardPresentation.Shown(settledImeBottom = 350.dp),
+          ),
+      )
+
+    assertEquals(350.dp, effectiveImeInset(environment))
+  }
+
+  @Test
+  fun live_ime_inset_is_preserved_while_smaller_keyboard_is_still_appearing() {
+    val environment =
+      toolbarInputEnvironment(
+        imeBottom = 160.dp,
+        keyboardState =
+          EditorKeyboardState(
+            type = EditorKeyboardType.Software,
+            presentation = EditorKeyboardPresentation.Shown(settledImeBottom = 280.dp),
+          ),
+      )
+
+    assertEquals(160.dp, effectiveImeInset(environment))
+  }
+
+  @Test
+  fun keyboard_restore_releases_to_settled_inset_without_remembering_refocus_overshoot() {
+    val state = EditorToolbarInputState()
+    val keyboardVisible = toolbarInputEnvironment(imeBottom = 350.dp)
+
+    state.onEnvironmentChanged(keyboardVisible)
+    state.dispatch(ToolbarIntent.OpenPanel(EditorToolbarBottomPanelKey.Tools), keyboardVisible)
+    state.takeEffects()
+
+    val keyboardHidden = toolbarInputEnvironment(imeBottom = 0.dp)
+    state.onEnvironmentChanged(keyboardHidden)
+    state.dispatch(ToolbarIntent.RestoreEditorInput, keyboardHidden)
+    state.takeEffects()
+
+    state.onEnvironmentChanged(
+      toolbarInputEnvironment(
+        imeBottom = 806.dp,
+        keyboardState =
+          EditorKeyboardState(
+            type = EditorKeyboardType.Software,
+            presentation = EditorKeyboardPresentation.Shown(settledImeBottom = 350.dp),
+          ),
+      )
+    )
+
+    assertEquals(null, state.keyboardRestoreInset)
+    assertEquals(350.dp, state.retainedKeyboardInset())
+  }
+
+  @Test
+  fun restoring_editor_input_keeps_toolbar_visible_during_transient_focus_loss() {
+    val state = EditorToolbarInputState()
+    val keyboardVisible = toolbarInputEnvironment(imeBottom = 320.dp)
+
+    state.onEnvironmentChanged(keyboardVisible)
+    state.dispatch(ToolbarIntent.OpenPanel(EditorToolbarBottomPanelKey.Insert), keyboardVisible)
+    state.takeEffects()
+
+    val hiddenKeyboardDuringPanel = toolbarInputEnvironment(focused = false, imeBottom = 0.dp)
+    state.dispatch(ToolbarIntent.RestoreEditorInput, hiddenKeyboardDuringPanel)
+
+    assertEquals(null, state.activeBottomPanel)
+    assertEquals(320.dp, state.keyboardRestoreInset)
+    assertEquals(
+      true,
+      isEditorToolbarPresented(
+        environment = hiddenKeyboardDuringPanel,
+        activeBottomPanel = state.activeBottomPanel,
+        restoringEditorInput = state.keyboardRestoreInset != null,
+      ),
+    )
+  }
+
+  @Test
   fun hardware_keyboard_switch_uses_minimum_panel_height_and_filters_stale_ime() {
     val state = EditorToolbarInputState()
     val software = toolbarInputEnvironment(imeBottom = 320.dp)

--- a/apps/mobile/compose/src/desktopMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.desktop.kt
+++ b/apps/mobile/compose/src/desktopMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.desktop.kt
@@ -1,6 +1,7 @@
 package co.typie.screen.editor.editor.toolbar
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.dp
 import co.typie.dev.DesktopDebugKeyboard
 
 @Composable
@@ -11,5 +12,6 @@ internal actual fun rememberEditorKeyboardState(): EditorKeyboardState =
         EditorKeyboardType.Hardware
       } else {
         EditorKeyboardType.Software
-      }
+      },
+    presentation = EditorKeyboardPresentation.Shown(0.dp),
   )

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ext/ClickableFocusDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ext/ClickableFocusDesktopTest.kt
@@ -1,0 +1,80 @@
+package co.typie.ext
+
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class ClickableFocusDesktopTest {
+  @Test
+  fun clickableDoesNotClearExistingFocus() = runComposeUiTest {
+    var clicked = false
+
+    setContent {
+      val focusRequester = remember { FocusRequester() }
+
+      Column {
+        Box(Modifier.testTag(FocusTargetTag).size(48.dp).focusRequester(focusRequester).focusable())
+        Box(Modifier.testTag(ClickTargetTag).size(48.dp).clickable { clicked = true })
+      }
+
+      LaunchedEffect(Unit) { focusRequester.requestFocus() }
+    }
+
+    waitForIdle()
+
+    onNodeWithTag(ClickTargetTag).performClick()
+    waitForIdle()
+
+    assertTrue(clicked)
+    onNodeWithTag(FocusTargetTag).assertIsFocused()
+  }
+
+  @Test
+  fun combinedClickableDoesNotClearExistingFocus() = runComposeUiTest {
+    var clicked = false
+
+    setContent {
+      val focusRequester = remember { FocusRequester() }
+
+      Column {
+        Box(Modifier.testTag(FocusTargetTag).size(48.dp).focusRequester(focusRequester).focusable())
+        Box(
+          Modifier.testTag(ClickTargetTag)
+            .size(48.dp)
+            .combinedClickable(onClick = { clicked = true }, onLongClick = {})
+        )
+      }
+
+      LaunchedEffect(Unit) { focusRequester.requestFocus() }
+    }
+
+    waitForIdle()
+
+    onNodeWithTag(ClickTargetTag).performClick()
+    waitForIdle()
+
+    assertTrue(clicked)
+    onNodeWithTag(FocusTargetTag).assertIsFocused()
+  }
+
+  private companion object {
+    const val FocusTargetTag = "focus-target"
+    const val ClickTargetTag = "click-target"
+  }
+}

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/popover/PopoverFocusDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/popover/PopoverFocusDesktopTest.kt
@@ -1,0 +1,60 @@
+package co.typie.ui.component.popover
+
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsNotFocused
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class PopoverFocusDesktopTest {
+  @Test
+  fun openingPopoverClearsExistingFocus() = runComposeUiTest {
+    setContent {
+      val focusRequester = remember { FocusRequester() }
+      val overlayState = remember { PopoverOverlayState() }
+
+      CompositionLocalProvider(LocalPopoverOverlayState provides overlayState) {
+        Column {
+          Box(
+            Modifier.testTag(FocusTargetTag).size(48.dp).focusRequester(focusRequester).focusable()
+          )
+          Popover(
+            anchor = { Box(Modifier.testTag(PopoverAnchorTag).size(48.dp)) },
+            pane = { Box(Modifier.size(48.dp)) },
+          )
+        }
+      }
+
+      LaunchedEffect(Unit) { focusRequester.requestFocus() }
+    }
+
+    waitForIdle()
+
+    onNodeWithTag(PopoverAnchorTag).performTouchInput {
+      down(center)
+      up()
+    }
+    waitForIdle()
+
+    onNodeWithTag(FocusTargetTag).assertIsNotFocused()
+  }
+
+  private companion object {
+    const val FocusTargetTag = "focus-target"
+    const val PopoverAnchorTag = "popover-anchor"
+  }
+}

--- a/apps/mobile/compose/src/iosMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.ios.kt
+++ b/apps/mobile/compose/src/iosMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.ios.kt
@@ -9,10 +9,14 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.unit.dp
 import platform.Foundation.NSNotificationCenter
 import platform.Foundation.NSOperationQueue
 import platform.GameController.GCKeyboardDidConnectNotification
 import platform.GameController.GCKeyboardDidDisconnectNotification
+import platform.UIKit.UIKeyboardDidChangeFrameNotification
+import platform.UIKit.UIKeyboardDidHideNotification
+import platform.UIKit.UIKeyboardDidShowNotification
 import platform.UIKit.UIKeyboardWillChangeFrameNotification
 import platform.UIKit.UIKeyboardWillHideNotification
 import swiftPMImport.co.typie.compose.EditorKeyboardBridge
@@ -22,14 +26,46 @@ internal actual fun rememberEditorKeyboardState(): EditorKeyboardState {
   var hardwareKeyboardMode by remember { mutableStateOf(isEditorHardwareKeyboardConnected()) }
   var imeFrameVisible by remember { mutableStateOf(false) }
   var imeHideEventVersion by remember { mutableIntStateOf(0) }
+  var presentation by remember {
+    mutableStateOf<EditorKeyboardPresentation>(EditorKeyboardPresentation.Hidden)
+  }
 
   fun syncKeyboardState() {
     hardwareKeyboardMode = isEditorHardwareKeyboardConnected()
   }
 
-  fun syncKeyboardFrame(notification: platform.Foundation.NSNotification?) {
-    imeFrameVisible =
-      notification?.let(EditorKeyboardBridge::isImeFrameVisibleWithNotification) ?: false
+  fun syncKeyboardFrame(
+    notification: platform.Foundation.NSNotification?,
+    settlesImeBottom: Boolean,
+  ) {
+    val targetBottom =
+      notification?.let(EditorKeyboardBridge::imeVisibleHeightWithNotification)?.dp ?: 0.dp
+    if (settlesImeBottom) {
+      presentation =
+        if (targetBottom > 0.dp) {
+          EditorKeyboardPresentation.Shown(targetBottom)
+        } else {
+          EditorKeyboardPresentation.Hidden
+        }
+    } else {
+      presentation =
+        if (targetBottom > 0.dp) {
+          when (presentation) {
+            EditorKeyboardPresentation.Hidden,
+            EditorKeyboardPresentation.Hiding -> EditorKeyboardPresentation.Showing
+            EditorKeyboardPresentation.Showing,
+            is EditorKeyboardPresentation.Shown -> presentation
+          }
+        } else {
+          when (presentation) {
+            EditorKeyboardPresentation.Hidden -> EditorKeyboardPresentation.Hidden
+            EditorKeyboardPresentation.Showing,
+            is EditorKeyboardPresentation.Shown,
+            EditorKeyboardPresentation.Hiding -> EditorKeyboardPresentation.Hiding
+          }
+        }
+    }
+    imeFrameVisible = targetBottom > 0.dp
     syncKeyboardState()
   }
 
@@ -44,6 +80,7 @@ internal actual fun rememberEditorKeyboardState(): EditorKeyboardState {
         syncKeyboardState()
         if (hardwareKeyboardMode) {
           imeFrameVisible = false
+          presentation = EditorKeyboardPresentation.Hidden
         }
       }
     val disconnectObserver =
@@ -55,6 +92,7 @@ internal actual fun rememberEditorKeyboardState(): EditorKeyboardState {
         syncKeyboardState()
         if (hardwareKeyboardMode) {
           imeFrameVisible = false
+          presentation = EditorKeyboardPresentation.Hidden
         }
       }
     val frameObserver =
@@ -63,7 +101,23 @@ internal actual fun rememberEditorKeyboardState(): EditorKeyboardState {
         `object` = null,
         queue = NSOperationQueue.mainQueue,
       ) {
-        syncKeyboardFrame(it)
+        syncKeyboardFrame(it, settlesImeBottom = false)
+      }
+    val didChangeFrameObserver =
+      center.addObserverForName(
+        name = UIKeyboardDidChangeFrameNotification,
+        `object` = null,
+        queue = NSOperationQueue.mainQueue,
+      ) {
+        syncKeyboardFrame(it, settlesImeBottom = true)
+      }
+    val didShowObserver =
+      center.addObserverForName(
+        name = UIKeyboardDidShowNotification,
+        `object` = null,
+        queue = NSOperationQueue.mainQueue,
+      ) {
+        syncKeyboardFrame(it, settlesImeBottom = true)
       }
     val hideObserver =
       center.addObserverForName(
@@ -71,8 +125,19 @@ internal actual fun rememberEditorKeyboardState(): EditorKeyboardState {
         `object` = null,
         queue = NSOperationQueue.mainQueue,
       ) {
+        presentation = EditorKeyboardPresentation.Hiding
         imeFrameVisible = false
         imeHideEventVersion++
+        syncKeyboardState()
+      }
+    val didHideObserver =
+      center.addObserverForName(
+        name = UIKeyboardDidHideNotification,
+        `object` = null,
+        queue = NSOperationQueue.mainQueue,
+      ) {
+        presentation = EditorKeyboardPresentation.Hidden
+        imeFrameVisible = false
         syncKeyboardState()
       }
 
@@ -80,7 +145,10 @@ internal actual fun rememberEditorKeyboardState(): EditorKeyboardState {
       center.removeObserver(connectObserver)
       center.removeObserver(disconnectObserver)
       center.removeObserver(frameObserver)
+      center.removeObserver(didChangeFrameObserver)
+      center.removeObserver(didShowObserver)
       center.removeObserver(hideObserver)
+      center.removeObserver(didHideObserver)
     }
   }
 
@@ -93,6 +161,7 @@ internal actual fun rememberEditorKeyboardState(): EditorKeyboardState {
       },
     imeFrameVisible = imeFrameVisible,
     imeHideEventVersion = imeHideEventVersion,
+    presentation = presentation,
   )
 }
 

--- a/apps/mobile/ios/Bridge/Sources/Bridge/EditorKeyboardBridge.swift
+++ b/apps/mobile/ios/Bridge/Sources/Bridge/EditorKeyboardBridge.swift
@@ -22,6 +22,17 @@ import UIKit
     return keyboardVisibleHeight(from: keyboardFrame) > 0
   }
 
+  public static func imeVisibleHeight(notification: Notification) -> Double {
+    guard
+      let keyboardFrame =
+        notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect
+    else {
+      return 0
+    }
+
+    return keyboardVisibleHeight(from: keyboardFrame)
+  }
+
   private static func detectHardwareKeyboardModeFromUIKeyboardImpl() -> Bool? {
     guard
       let cls = NSClassFromString("UIKeyboardImpl") as? NSObject.Type,


### PR DESCRIPTION
- 전역 clearFocus 제거: 플러터와 비슷하게 고침
- 에디터 툴바/키보드 전환 상태 정리, 디버그