### PR TITLE
unit node 셀렉션 버그 수정

### DIFF
--- a/crates/editor-core/src/editor.rs
+++ b/crates/editor-core/src/editor.rs
@@ -3,7 +3,9 @@ use editor_crdt::{Changeset, CrdtError, Dot, Op};
 use editor_model::{DocOp, ModifierState, Node, NodeId};
 use editor_renderer::{Mark, MarkData, RenderSink, Renderer, ThemeVariant};
 use editor_resource::Resource;
-use editor_state::{DocFlatExt, Position, ResolvedPosition, ResolvedPositionFlatExt, State};
+use editor_state::{
+    DocFlatExt, Position, ResolvedPosition, ResolvedPositionFlatExt, Selection, State,
+};
 use editor_transaction::{Effect, HistoryMeta, Transaction};
 use editor_view::{PageRect, PendingStyle, View, Viewport};
 use hashbrown::{HashMap, HashSet};
@@ -45,7 +47,7 @@ pub struct Editor {
     pub(crate) history: History,
     pub(crate) renderer: Renderer,
     pub(crate) resource: Arc<Mutex<Resource>>,
-    pub(crate) drag_anchor: Option<Position>,
+    pub(crate) drag_anchor: Option<Selection>,
     pub(crate) focused: bool,
     message_queue: Vec<Message>,
     pending_events: Vec<EditorEvent>,

--- a/crates/editor-core/src/handle/navigation.rs
+++ b/crates/editor-core/src/handle/navigation.rs
@@ -1,45 +1,8 @@
-use std::cmp::Ordering;
-
-use editor_model::Doc;
-use editor_state::{Position, Selection};
+use editor_state::{Selection, farther_endpoint};
 
 use crate::editor::Editor;
 use crate::error::EditorError;
 use crate::message::*;
-
-/// Returns whichever of `e1`/`e2` lies farther from `reference` in document
-/// order (`ResolvedPosition` Ord is `(path, affinity)`, `Upstream < Downstream`).
-/// A collapsed target has `e1 == e2`, so the unchanged endpoint is returned and
-/// ordinary non-atom navigation behaves exactly as before.
-fn farther_endpoint(doc: &Doc, reference: Position, e1: Position, e2: Position) -> Position {
-    if e1 == e2 {
-        return e2;
-    }
-    let (Some(r), Some(r1), Some(r2)) = (reference.resolve(doc), e1.resolve(doc), e2.resolve(doc))
-    else {
-        return e2;
-    };
-    match (r1.cmp(&r), r2.cmp(&r)) {
-        (Ordering::Less | Ordering::Equal, Ordering::Less | Ordering::Equal) => {
-            if r1 <= r2 {
-                e1
-            } else {
-                e2
-            }
-        }
-        (Ordering::Greater | Ordering::Equal, Ordering::Greater | Ordering::Equal) => {
-            if r1 >= r2 {
-                e1
-            } else {
-                e2
-            }
-        }
-        // Real callers only pass adjacent atom-bracket pairs or equal endpoints,
-        // so a reference strictly between the two never occurs; this arm is a
-        // defensive fallback, not a meaningful answer.
-        _ => e2,
-    }
-}
 
 pub fn handle_navigation_op(editor: &mut Editor, op: NavigationOp) -> Result<(), EditorError> {
     match op {
@@ -97,7 +60,6 @@ pub fn handle_navigation_op(editor: &mut Editor, op: NavigationOp) -> Result<(),
 #[cfg(test)]
 mod tests {
     use editor_macros::state;
-    use editor_state::Affinity;
     use editor_state::Position;
     use editor_state::assert_state_eq;
 
@@ -301,88 +263,6 @@ mod tests {
             editor.state().selection.is_collapsed(),
             "replace must collapse the selection, not leave a stale node-selection"
         );
-    }
-
-    #[test]
-    fn farther_endpoint_picks_correct_edge() {
-        let (state, ..) = state! {
-            doc {
-                root {
-                    image
-                    image
-                    paragraph { t1: text("x") }
-                }
-            }
-            selection: (t1, 0)
-        };
-        let doc = &state.doc;
-        let text = state.selection.head.node_id;
-        let root = state
-            .doc
-            .node(text)
-            .unwrap()
-            .parent()
-            .unwrap()
-            .parent()
-            .unwrap()
-            .id();
-        // The second atom sits at root child index 1, so its node selection is
-        // front=(root,1,Down), back=(root,2,Up).
-        let front = Position {
-            node_id: root,
-            offset: 1,
-            affinity: Affinity::Downstream,
-        };
-        let back = Position {
-            node_id: root,
-            offset: 2,
-            affinity: Affinity::Upstream,
-        };
-
-        let ref_below = Position {
-            node_id: text,
-            offset: 0,
-            affinity: Affinity::Downstream,
-        };
-        assert_eq!(super::farther_endpoint(doc, ref_below, front, back), front);
-
-        let ref_above = Position {
-            node_id: root,
-            offset: 0,
-            affinity: Affinity::Downstream,
-        };
-        assert_eq!(super::farther_endpoint(doc, ref_above, front, back), back);
-
-        let collapsed = Position {
-            node_id: text,
-            offset: 1,
-            affinity: Affinity::Downstream,
-        };
-        assert_eq!(
-            super::farther_endpoint(doc, ref_below, collapsed, collapsed),
-            collapsed
-        );
-    }
-
-    /// The fallback arm is unreachable for real navigation callers (adjacent
-    /// atom-bracket endpoints leave no addressable position between them), so
-    /// it is exercised here only as a pure-function contract check.
-    #[test]
-    fn farther_endpoint_reference_between_returns_e2() {
-        let (state, t1, t2) = state! {
-            doc {
-                root {
-                    paragraph { t1: text("ab") }
-                    paragraph { t2: text("cd") }
-                }
-            }
-            selection: (t1, 0)
-        };
-        let doc = &state.doc;
-        let e1 = Position::new(t1, 0);
-        let e2 = Position::new(t2, 2);
-        let between = Position::new(t1, 1);
-        assert_eq!(super::farther_endpoint(doc, between, e1, e2), e2);
     }
 
     fn arrow(editor: &mut Editor, movement: Movement) {

--- a/crates/editor-core/src/handle/pointer.rs
+++ b/crates/editor-core/src/handle/pointer.rs
@@ -1,4 +1,6 @@
-use editor_state::{Selection, cell_rect_selection, enclosing_table_cell, table_cell_ids};
+use editor_state::{
+    Selection, cell_rect_selection, enclosing_table_cell, farther_endpoint, table_cell_ids,
+};
 
 use crate::editor::Editor;
 use crate::error::EditorError;
@@ -6,19 +8,15 @@ use crate::message::*;
 
 /// The anchor cell for the current drag: the live cell-rect's anchor cell if
 /// the selection is already a cell-rect (the latch's source of truth — also
-/// correct after Shift-click, where `drag_anchor` is a `(TableRow, _)`
-/// position with no `TableCell` ancestor), else the cell enclosing the drag
-/// anchor position.
-fn drag_anchor_cell(
-    editor: &Editor,
-    drag_anchor: &editor_state::Position,
-) -> Option<editor_model::NodeId> {
+/// correct after Shift-click, where `pos` is a `(TableRow, _)` position with
+/// no `TableCell` ancestor), else the cell enclosing `pos`.
+fn drag_anchor_cell(editor: &Editor, pos: &editor_state::Position) -> Option<editor_model::NodeId> {
     if let Some(resolved) = editor.state.selection.resolve(&editor.state.doc)
         && let Some(cr) = resolved.as_cell_rect()
     {
         return Some(cr.anchor_cell.id());
     }
-    enclosing_table_cell(&editor.state.doc, drag_anchor.node_id)
+    enclosing_table_cell(&editor.state.doc, pos.node_id)
 }
 
 pub fn handle_pointer_event(editor: &mut Editor, event: PointerEvent) -> Result<(), EditorError> {
@@ -76,30 +74,26 @@ pub fn handle_pointer_event(editor: &mut Editor, event: PointerEvent) -> Result<
                 })?;
             }
 
-            // Drag anchor is promotion-aware: a drag started in the gutter near
-            // a monolithic block must anchor at the block boundary, not at the
-            // nearest leaf inside it — otherwise the promoted Move forms an
-            // adjacent slot/descendant range that normalize collapses. Plain
-            // (non-promoting) positions make ext_hit == raw_hit, so the anchor
-            // is unchanged where promotion does not apply.
+            // Arm the whole selection, not a point: a unit (image/monolithic)
+            // click yields a two-position bracket, so Move can re-anchor to the
+            // edge that keeps the unit enveloped whichever way the drag goes. A
+            // text caret or promoted gutter slot is collapsed, so a single point
+            // is preserved as before. Non-shift keeps ext_hit's gutter promotion.
             editor.drag_anchor = (count == 1).then(|| {
                 if modifiers.shift {
-                    editor.state.selection.anchor
+                    Selection::collapsed(editor.state.selection.anchor)
                 } else {
-                    ext_hit
-                        .as_ref()
-                        .map(|h| h.head)
-                        .unwrap_or(editor.state.selection.anchor)
+                    ext_hit.unwrap_or_else(|| Selection::collapsed(editor.state.selection.anchor))
                 }
             });
         }
 
         PointerEvent::Move { page, x, y } => {
-            let Some(anchor) = editor.drag_anchor else {
+            let Some(armed) = editor.drag_anchor else {
                 return Ok(());
             };
 
-            if let Some(a) = drag_anchor_cell(editor, &anchor) {
+            if let Some(a) = drag_anchor_cell(editor, &armed.head) {
                 let cells = table_cell_ids(&editor.state.doc, a);
                 if let Some(h) = editor.view.nearest_node_box(page, x, y, &cells) {
                     let is_cell_mode = editor
@@ -121,7 +115,16 @@ pub fn handle_pointer_event(editor: &mut Editor, event: PointerEvent) -> Result<
             }
 
             if let Some(hit) = editor.view.hit_test_extending(page, x, y) {
-                let new_selection = Selection::new(anchor, hit.head);
+                // Re-anchor to the armed edge farther from the pointer, then take
+                // the hit edge farther from that anchor. A unit (image/monolithic)
+                // armed click or a unit under the pointer stays fully enveloped
+                // whichever way the drag goes; a collapsed text caret or promoted
+                // slot has equal endpoints, so both steps degenerate to the plain
+                // anchor→hit selection.
+                let doc = &editor.state.doc;
+                let fixed = farther_endpoint(doc, hit.head, armed.anchor, armed.head);
+                let head = farther_endpoint(doc, fixed, hit.anchor, hit.head);
+                let new_selection = Selection::new(fixed, head);
                 editor.view.clear_preferred_x();
                 editor.transact(|tr| {
                     tr.set_selection(new_selection)?;
@@ -323,6 +326,239 @@ mod tests {
             "drag anchor must survive an intermediate collapse"
         );
         assert_ne!(sel.anchor, sel.head);
+    }
+
+    #[test]
+    fn drag_down_from_first_image_keeps_it_selected() {
+        use editor_state::{Affinity, Position};
+
+        let (state, r1, i0, i1, i2) = state! {
+            doc { r1: root { i0: image i1: image i2: image paragraph {} } }
+            selection: (r1, 0, >) -> (r1, 1, <)
+        };
+        let mut editor = Editor::new_test(state);
+        for id in [i0, i1, i2] {
+            editor
+                .view
+                .set_external_height(&editor.state.doc, id, 100.0);
+        }
+        editor.view.layout(&editor.state.doc);
+
+        let atom_center = |editor: &Editor, idx: usize| {
+            let sel = Selection::new(
+                Position {
+                    node_id: r1,
+                    offset: idx,
+                    affinity: Affinity::Downstream,
+                },
+                Position {
+                    node_id: r1,
+                    offset: idx + 1,
+                    affinity: Affinity::Upstream,
+                },
+            );
+            let resolved = sel.resolve(&editor.state.doc).unwrap();
+            let rects = editor.view.selection_rects(&resolved);
+            let pr = &rects[0];
+            (
+                pr.page_idx,
+                pr.rect.x + pr.rect.width / 2.0,
+                pr.rect.y + pr.rect.height / 2.0,
+            )
+        };
+
+        let (p0, x0, y0) = atom_center(&editor, 0);
+        editor.apply(Message::Pointer {
+            event: PointerEvent::Down {
+                page: p0,
+                x: x0,
+                y: y0,
+                count: 1,
+                modifiers: InputModifiers::default(),
+            },
+        });
+        assert_eq!(
+            editor.state().selection,
+            Selection::new(
+                Position {
+                    node_id: r1,
+                    offset: 0,
+                    affinity: Affinity::Downstream,
+                },
+                Position {
+                    node_id: r1,
+                    offset: 1,
+                    affinity: Affinity::Upstream,
+                },
+            ),
+            "Down on the first image must node-select it"
+        );
+
+        let (p2, x2, y2) = atom_center(&editor, 2);
+        editor.apply(Message::Pointer {
+            event: PointerEvent::Move {
+                page: p2,
+                x: x2,
+                y: y2,
+            },
+        });
+
+        assert_eq!(
+            editor.state().selection,
+            Selection::new(
+                Position {
+                    node_id: r1,
+                    offset: 0,
+                    affinity: Affinity::Downstream,
+                },
+                Position {
+                    node_id: r1,
+                    offset: 3,
+                    affinity: Affinity::Upstream,
+                },
+            ),
+            "dragging down from the first image must keep it selected: \
+             anchor stays at the image's leading edge (r1,0), not its trailing edge (r1,1)"
+        );
+    }
+
+    #[test]
+    fn drag_up_from_trailing_paragraph_to_top_selects_all() {
+        use editor_state::{Affinity, Position};
+
+        let (state, r1, i0, i1, i2, p1) = state! {
+            doc { r1: root { i0: image i1: image i2: image p1: paragraph {} } }
+            selection: (p1, 0)
+        };
+        let mut editor = Editor::new_test(state);
+        for id in [i0, i1, i2] {
+            editor
+                .view
+                .set_external_height(&editor.state.doc, id, 100.0);
+        }
+        editor.view.layout(&editor.state.doc);
+
+        editor.apply(Message::Pointer {
+            event: PointerEvent::Down {
+                page: 0,
+                x: 5.0,
+                y: 9999.0,
+                count: 1,
+                modifiers: InputModifiers::default(),
+            },
+        });
+        let sel = editor.state().selection;
+        assert!(
+            sel.is_collapsed(),
+            "Down on the trailing paragraph collapses"
+        );
+        assert_eq!(sel.head.node_id, p1);
+        assert_eq!(sel.head.offset, 0);
+        assert!(editor.drag_anchor.is_some());
+
+        editor.apply(Message::Pointer {
+            event: PointerEvent::Move {
+                page: 0,
+                x: 5.0,
+                y: -9999.0,
+            },
+        });
+
+        assert_eq!(
+            editor.state().selection,
+            Selection::new(
+                Position {
+                    node_id: p1,
+                    offset: 0,
+                    affinity: Affinity::Upstream,
+                },
+                Position {
+                    node_id: r1,
+                    offset: 0,
+                    affinity: Affinity::Downstream,
+                },
+            ),
+            "dragging up to the top must envelope the first image: \
+             head reaches the doc start (r1,0), not the gap after image0 (r1,1)"
+        );
+    }
+
+    #[test]
+    fn drag_up_from_last_image_keeps_it_selected() {
+        use editor_state::{Affinity, Position};
+
+        let (state, r1, i0, i1, i2) = state! {
+            doc { r1: root { i0: image i1: image i2: image paragraph {} } }
+            selection: (r1, 2, >) -> (r1, 3, <)
+        };
+        let mut editor = Editor::new_test(state);
+        for id in [i0, i1, i2] {
+            editor
+                .view
+                .set_external_height(&editor.state.doc, id, 100.0);
+        }
+        editor.view.layout(&editor.state.doc);
+
+        let atom_center = |editor: &Editor, idx: usize| {
+            let sel = Selection::new(
+                Position {
+                    node_id: r1,
+                    offset: idx,
+                    affinity: Affinity::Downstream,
+                },
+                Position {
+                    node_id: r1,
+                    offset: idx + 1,
+                    affinity: Affinity::Upstream,
+                },
+            );
+            let resolved = sel.resolve(&editor.state.doc).unwrap();
+            let rects = editor.view.selection_rects(&resolved);
+            let pr = &rects[0];
+            (
+                pr.page_idx,
+                pr.rect.x + pr.rect.width / 2.0,
+                pr.rect.y + pr.rect.height / 2.0,
+            )
+        };
+
+        let (p2, x2, y2) = atom_center(&editor, 2);
+        editor.apply(Message::Pointer {
+            event: PointerEvent::Down {
+                page: p2,
+                x: x2,
+                y: y2,
+                count: 1,
+                modifiers: InputModifiers::default(),
+            },
+        });
+
+        let (p0, x0, y0) = atom_center(&editor, 0);
+        editor.apply(Message::Pointer {
+            event: PointerEvent::Move {
+                page: p0,
+                x: x0,
+                y: y0,
+            },
+        });
+
+        assert_eq!(
+            editor.state().selection,
+            Selection::new(
+                Position {
+                    node_id: r1,
+                    offset: 3,
+                    affinity: Affinity::Upstream,
+                },
+                Position {
+                    node_id: r1,
+                    offset: 0,
+                    affinity: Affinity::Downstream,
+                },
+            ),
+            "dragging up from the last image must keep it selected: \
+             anchor stays at the image's trailing edge (r1,3), not its leading edge (r1,2)"
+        );
     }
 
     #[test]

--- a/crates/editor-state/src/lib.rs
+++ b/crates/editor-state/src/lib.rs
@@ -28,6 +28,7 @@ pub use cursor_position::*;
 pub use error::*;
 pub use flat::*;
 pub use modifier_resolution::*;
+pub use normalize::farther_endpoint;
 pub use pending_modifier::*;
 pub use position::*;
 pub use resolved_position::*;

--- a/crates/editor-state/src/normalize.rs
+++ b/crates/editor-state/src/normalize.rs
@@ -1,3 +1,5 @@
+use std::cmp::Ordering;
+
 use editor_model::{Doc, Node, NodeRef, Schema};
 
 use crate::affinity::Affinity;
@@ -256,6 +258,42 @@ impl Selection {
         node.children()
             .nth(lo)
             .is_some_and(|child| is_unit_node(&child))
+    }
+}
+
+/// Returns whichever of `e1`/`e2` lies farther from `reference` in document
+/// order (`ResolvedPosition` Ord is `(path, affinity)`, `Upstream < Downstream`).
+/// A collapsed target has `e1 == e2`, so the unchanged endpoint is returned and
+/// ordinary non-unit navigation behaves exactly as before. Pairs naturally with
+/// [`Selection::is_unit_node_selection`]: re-anchor an extend to the unit edge
+/// farther from the moving end so a bracketed unit stays selected as it grows.
+pub fn farther_endpoint(doc: &Doc, reference: Position, e1: Position, e2: Position) -> Position {
+    if e1 == e2 {
+        return e2;
+    }
+    let (Some(r), Some(r1), Some(r2)) = (reference.resolve(doc), e1.resolve(doc), e2.resolve(doc))
+    else {
+        return e2;
+    };
+    match (r1.cmp(&r), r2.cmp(&r)) {
+        (Ordering::Less | Ordering::Equal, Ordering::Less | Ordering::Equal) => {
+            if r1 <= r2 {
+                e1
+            } else {
+                e2
+            }
+        }
+        (Ordering::Greater | Ordering::Equal, Ordering::Greater | Ordering::Equal) => {
+            if r1 >= r2 {
+                e1
+            } else {
+                e2
+            }
+        }
+        // Real callers only pass adjacent unit-bracket pairs or equal endpoints,
+        // so a reference strictly between the two never occurs; this arm is a
+        // defensive fallback, not a meaningful answer.
+        _ => e2,
     }
 }
 
@@ -1346,6 +1384,88 @@ mod tests {
             )
             .is_unit_node_selection(&d)
         );
+    }
+
+    #[test]
+    fn farther_endpoint_picks_correct_edge() {
+        let (state, ..) = state! {
+            doc {
+                root {
+                    image
+                    image
+                    paragraph { t1: text("x") }
+                }
+            }
+            selection: (t1, 0)
+        };
+        let doc = &state.doc;
+        let text = state.selection.head.node_id;
+        let root = state
+            .doc
+            .node(text)
+            .unwrap()
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .id();
+        // The second atom sits at root child index 1, so its node selection is
+        // front=(root,1,Down), back=(root,2,Up).
+        let front = Position {
+            node_id: root,
+            offset: 1,
+            affinity: Affinity::Downstream,
+        };
+        let back = Position {
+            node_id: root,
+            offset: 2,
+            affinity: Affinity::Upstream,
+        };
+
+        let ref_below = Position {
+            node_id: text,
+            offset: 0,
+            affinity: Affinity::Downstream,
+        };
+        assert_eq!(farther_endpoint(doc, ref_below, front, back), front);
+
+        let ref_above = Position {
+            node_id: root,
+            offset: 0,
+            affinity: Affinity::Downstream,
+        };
+        assert_eq!(farther_endpoint(doc, ref_above, front, back), back);
+
+        let collapsed = Position {
+            node_id: text,
+            offset: 1,
+            affinity: Affinity::Downstream,
+        };
+        assert_eq!(
+            farther_endpoint(doc, ref_below, collapsed, collapsed),
+            collapsed
+        );
+    }
+
+    /// The fallback arm is unreachable for real callers (adjacent unit-bracket
+    /// endpoints leave no addressable position between them), so it is
+    /// exercised here only as a pure-function contract check.
+    #[test]
+    fn farther_endpoint_reference_between_returns_e2() {
+        let (state, t1, t2) = state! {
+            doc {
+                root {
+                    paragraph { t1: text("ab") }
+                    paragraph { t2: text("cd") }
+                }
+            }
+            selection: (t1, 0)
+        };
+        let doc = &state.doc;
+        let e1 = Position::new(t1, 0);
+        let e2 = Position::new(t2, 2);
+        let between = Position::new(t1, 1);
+        assert_eq!(farther_endpoint(doc, between, e1, e2), e2);
     }
 
     #[test]


### PR DESCRIPTION
unit node에서 시작되거나 unit node를 거치는 selection이 시작점 혹은 끝점 anchor node 를 포함하지 않던 문제 해결
