### PR TITLE
TR-73 접기 기능에서 타이틀과 본문을 함께 선택하면 텍스트 스타일 적용이 실패하는 문제 수정

### DIFF
--- a/crates/editor-commands/src/commands/set_modifier.rs
+++ b/crates/editor-commands/src/commands/set_modifier.rs
@@ -4,8 +4,8 @@ use editor_transaction::Transaction;
 
 use crate::helpers::{
     collect_applicable_targets_in_range, collect_text_nodes_in_range,
-    compact_and_restore_selection, is_text_applicable, resolve_applicable_target_collapsed,
-    resolve_inherited_modifiers,
+    compact_and_restore_selection, filter_applicable_node_ids, is_text_applicable,
+    resolve_applicable_target_collapsed, resolve_inherited_modifiers,
 };
 use crate::{CommandError, CommandResult};
 
@@ -88,12 +88,14 @@ fn set_modifier_range_text(tr: &mut Transaction, modifier: &Modifier) -> Command
     let to = Position::from(resolved.to());
 
     let node_ids = collect_text_nodes_in_range(tr, &from, &to)?;
+    let applicable_node_ids = filter_applicable_node_ids(&tr.doc(), &node_ids, modifier.as_type());
 
-    if node_ids.is_empty() {
+    if applicable_node_ids.is_empty() {
+        compact_and_restore_selection(tr, &node_ids)?;
         return Ok(false);
     }
 
-    for &node_id in &node_ids {
+    for &node_id in &applicable_node_ids {
         let doc = tr.doc();
         let node = doc
             .node(node_id)
@@ -372,6 +374,37 @@ mod tests {
                 }
             }
             selection: (t1, 0) -> (t1, 5)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn range_set_font_size_skips_fold_title_applies_to_paragraph() {
+        let (initial, ..) = state! {
+            doc {
+                root [font_size(1600)] {
+                    fold {
+                        fold_title { t1: text("Title") }
+                        fold_content { paragraph { t2: text("Body") } }
+                    }
+                }
+            }
+            selection: (t1, 0) -> (t2, 4)
+        };
+        let (actual, ..) = transact!(initial, |tr| set_modifier(
+            &mut tr,
+            Modifier::FontSize { value: 2400 }
+        ));
+        let (expected, ..) = state! {
+            doc {
+                root [font_size(1600)] {
+                    fold {
+                        fold_title { t1: text("Title") }
+                        fold_content { paragraph { t2: text("Body") [font_size(2400)] } }
+                    }
+                }
+            }
+            selection: (t1, 0) -> (t2, 4)
         };
         assert_state_eq!(&actual, &expected);
     }

--- a/crates/editor-commands/src/commands/toggle_bold.rs
+++ b/crates/editor-commands/src/commands/toggle_bold.rs
@@ -4,7 +4,8 @@ use editor_state::{PendingModifier, PendingModifiers, Position, resolve_effectiv
 use editor_transaction::Transaction;
 
 use crate::helpers::{
-    collect_text_nodes_in_range, compact_and_restore_selection, resolve_inherited_modifiers,
+    collect_text_nodes_in_range, compact_and_restore_selection, filter_applicable_node_ids,
+    resolve_inherited_modifiers,
 };
 use crate::{CommandError, CommandResult};
 
@@ -23,18 +24,24 @@ pub fn toggle_bold(tr: &mut Transaction, resource: &Resource) -> CommandResult {
     let to = Position::from(resolved.to());
 
     let node_ids = collect_text_nodes_in_range(tr, &from, &to)?;
+    let applicable_node_ids = filter_applicable_node_ids(&tr.doc(), &node_ids, ModifierType::Bold);
+
+    if applicable_node_ids.is_empty() {
+        compact_and_restore_selection(tr, &node_ids)?;
+        return Ok(false);
+    }
 
     let doc = tr.doc();
-    let nodes = node_ids
+    let nodes = applicable_node_ids
         .iter()
         .filter_map(|id| doc.node(*id))
         .collect::<Vec<_>>();
     let is_bold = check_range_is_bold(&nodes);
 
     if is_bold {
-        toggle_bold_off_range(tr, resource, &node_ids)?;
+        toggle_bold_off_range(tr, resource, &applicable_node_ids)?;
     } else {
-        toggle_bold_on_range(tr, resource, &node_ids)?;
+        toggle_bold_on_range(tr, resource, &applicable_node_ids)?;
     }
 
     compact_and_restore_selection(tr, &node_ids)?;
@@ -705,6 +712,35 @@ mod tests {
                 }
             }
             selection: (t1, 0) -> (t1, 9)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn range_toggle_bold_skips_fold_title_applies_to_paragraph() {
+        let resource = make_resource([("Pretendard", vec![400, 700])]);
+        let (initial, ..) = state! {
+            doc {
+                root [font_weight(400), font_family("Pretendard".to_string())] {
+                    fold {
+                        fold_title { t1: text("Title") }
+                        fold_content { paragraph { t2: text("Body") } }
+                    }
+                }
+            }
+            selection: (t1, 0) -> (t2, 4)
+        };
+        let (actual, ..) = transact!(initial, |tr| toggle_bold(&mut tr, &resource));
+        let (expected, ..) = state! {
+            doc {
+                root [font_weight(400), font_family("Pretendard".to_string())] {
+                    fold {
+                        fold_title { t1: text("Title") }
+                        fold_content { paragraph { t2: text("Body") [font_weight(700)] } }
+                    }
+                }
+            }
+            selection: (t1, 0) -> (t2, 4)
         };
         assert_state_eq!(&actual, &expected);
     }

--- a/crates/editor-commands/src/commands/toggle_modifier.rs
+++ b/crates/editor-commands/src/commands/toggle_modifier.rs
@@ -4,6 +4,7 @@ use editor_transaction::Transaction;
 
 use crate::helpers::{
     check_range_all_has_modifier, collect_text_nodes_in_range, compact_and_restore_selection,
+    filter_applicable_node_ids,
 };
 use crate::{CommandError, CommandResult};
 
@@ -34,17 +35,26 @@ pub fn toggle_modifier(tr: &mut Transaction, modifier_type: ModifierType) -> Com
     let to = Position::from(resolved.to());
 
     let node_ids = collect_text_nodes_in_range(tr, &from, &to)?;
+    let applicable_node_ids = filter_applicable_node_ids(&tr.doc(), &node_ids, modifier_type);
+
+    if applicable_node_ids.is_empty() {
+        compact_and_restore_selection(tr, &node_ids)?;
+        return Ok(false);
+    }
 
     let doc = tr.doc();
-    let nodes: Vec<_> = node_ids.iter().filter_map(|id| doc.node(*id)).collect();
+    let nodes: Vec<_> = applicable_node_ids
+        .iter()
+        .filter_map(|id| doc.node(*id))
+        .collect();
     let all_have = check_range_all_has_modifier(&nodes, modifier_type);
 
     if all_have {
-        for &node_id in &node_ids {
+        for &node_id in &applicable_node_ids {
             tr.remove_modifier(node_id, modifier.clone())?;
         }
     } else {
-        for &node_id in &node_ids {
+        for &node_id in &applicable_node_ids {
             let doc = tr.doc();
             let node = doc
                 .node(node_id)
@@ -246,6 +256,109 @@ mod tests {
                 t1: text("HelloWorld") [italic]
             } } }
             selection: (t1, 0) -> (t1, 10)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn range_toggle_italic_skips_fold_title_applies_to_paragraph() {
+        let (initial, ..) = state! {
+            doc { root {
+                fold {
+                    fold_title { t1: text("Title") }
+                    fold_content { paragraph { t2: text("Body") } }
+                }
+            } }
+            selection: (t1, 0) -> (t2, 4)
+        };
+        let (actual, ..) = transact!(initial, |tr| toggle_modifier(&mut tr, ModifierType::Italic));
+        let (expected, ..) = state! {
+            doc { root {
+                fold {
+                    fold_title { t1: text("Title") }
+                    fold_content { paragraph { t2: text("Body") [italic] } }
+                }
+            } }
+            selection: (t1, 0) -> (t2, 4)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn range_toggle_underline_skips_fold_title_applies_to_paragraph() {
+        let (initial, ..) = state! {
+            doc { root {
+                fold {
+                    fold_title { t1: text("Title") }
+                    fold_content { paragraph { t2: text("Body") } }
+                }
+            } }
+            selection: (t1, 0) -> (t2, 4)
+        };
+        let (actual, ..) = transact!(initial, |tr| toggle_modifier(
+            &mut tr,
+            ModifierType::Underline
+        ));
+        let (expected, ..) = state! {
+            doc { root {
+                fold {
+                    fold_title { t1: text("Title") }
+                    fold_content { paragraph { t2: text("Body") [underline] } }
+                }
+            } }
+            selection: (t1, 0) -> (t2, 4)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn range_toggle_strikethrough_skips_fold_title_applies_to_paragraph() {
+        let (initial, ..) = state! {
+            doc { root {
+                fold {
+                    fold_title { t1: text("Title") }
+                    fold_content { paragraph { t2: text("Body") } }
+                }
+            } }
+            selection: (t1, 0) -> (t2, 4)
+        };
+        let (actual, ..) = transact!(initial, |tr| toggle_modifier(
+            &mut tr,
+            ModifierType::Strikethrough
+        ));
+        let (expected, ..) = state! {
+            doc { root {
+                fold {
+                    fold_title { t1: text("Title") }
+                    fold_content { paragraph { t2: text("Body") [strikethrough] } }
+                }
+            } }
+            selection: (t1, 0) -> (t2, 4)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn range_toggle_italic_on_fold_title_only_is_noop() {
+        let (initial, ..) = state! {
+            doc { root {
+                fold {
+                    fold_title { t1: text("Title") }
+                    fold_content { paragraph { text("Body") } }
+                }
+            } }
+            selection: (t1, 0) -> (t1, 5)
+        };
+        let (actual, ..) =
+            transact_fail!(initial, |tr| toggle_modifier(&mut tr, ModifierType::Italic));
+        let (expected, ..) = state! {
+            doc { root {
+                fold {
+                    fold_title { t1: text("Title") }
+                    fold_content { paragraph { text("Body") } }
+                }
+            } }
+            selection: (t1, 0) -> (t1, 5)
         };
         assert_state_eq!(&actual, &expected);
     }

--- a/crates/editor-commands/src/helpers/modifiers.rs
+++ b/crates/editor-commands/src/helpers/modifiers.rs
@@ -82,6 +82,33 @@ pub(crate) fn is_text_applicable(modifier_type: ModifierType) -> bool {
         .contains(&NodeType::Text)
 }
 
+pub(crate) fn is_modifier_applicable_to_node(node: &NodeRef, modifier_type: ModifierType) -> bool {
+    let context = &Schema::modifier_spec(modifier_type).context;
+    let targets = context.rightmost_node_types();
+    if !targets.contains(&node.as_type()) {
+        return false;
+    }
+
+    let mut path: Vec<NodeType> = node.ancestors().map(|a| a.as_type()).collect();
+    path.reverse();
+    context.matches(&path)
+}
+
+pub(crate) fn filter_applicable_node_ids(
+    doc: &Doc,
+    node_ids: &[NodeId],
+    modifier_type: ModifierType,
+) -> Vec<NodeId> {
+    node_ids
+        .iter()
+        .copied()
+        .filter(|node_id| {
+            doc.node(*node_id)
+                .is_some_and(|node| is_modifier_applicable_to_node(&node, modifier_type))
+        })
+        .collect()
+}
+
 pub(crate) fn resolve_applicable_target_collapsed<'a>(
     doc: &'a Doc,
     cursor_node_id: NodeId,

--- a/crates/editor-core/src/handle/modifier.rs
+++ b/crates/editor-core/src/handle/modifier.rs
@@ -36,6 +36,7 @@ pub fn handle_modifier_op(editor: &mut Editor, op: ModifierOp) -> Result<(), Edi
 #[cfg(test)]
 mod tests {
     use editor_macros::state;
+    use editor_state::assert_state_eq;
 
     use super::*;
 
@@ -118,5 +119,36 @@ mod tests {
                 modifier: editor_model::Modifier::FontSize { value: 2400 }
             }]
         );
+    }
+
+    #[test]
+    fn toggle_italic_skips_fold_title_and_applies_to_paragraph_via_message() {
+        let (state, ..) = state! {
+            doc { root {
+                fold {
+                    fold_title { t1: text("Title") }
+                    fold_content { paragraph { t2: text("Body") } }
+                }
+            } }
+            selection: (t1, 0) -> (t2, 4)
+        };
+        let mut editor = Editor::new_test(state);
+
+        editor.apply(Message::Modifier {
+            op: ModifierOp::Toggle {
+                modifier_type: ModifierType::Italic,
+            },
+        });
+
+        let (expected, ..) = state! {
+            doc { root {
+                fold {
+                    fold_title { t1: text("Title") }
+                    fold_content { paragraph { t2: text("Body") [italic] } }
+                }
+            } }
+            selection: (t1, 0) -> (t2, 4)
+        };
+        assert_state_eq!(editor.state(), &expected);
     }
 }


### PR DESCRIPTION
접기 기능의 타이틀과 본문을 함께 선택한 상태에서 텍스트 스타일을 적용하면,
modifier를 받을 수 없는 타이틀 텍스트 때문에 트랜잭션 전체가 실패하고
본문에도 스타일이 적용되지 않던 문제를 수정했습니다.

실제 사용 경로에서 문제가 다시 발생하지 않도록 V2 Message::Modifier 경계에서
먼저 실패 테스트를 작성하는 Outside-in TDD 방식으로 동작을 고정한 뒤,
command layer로 내려가 원인을 해결했습니다.

범위 선택에서 수집한 전체 텍스트 노드와 실제 modifier를 적용할 수 있는
텍스트 노드를 분리하고, schema의 modifier context를 기준으로 적용 가능한 노드에만
modifier step을 생성하도록 변경했습니다.

이를 통해 transaction validation은 기존처럼 엄격하게 유지하면서도,
적용 불가능한 fold title은 건너뛰고 적용 가능한 본문 텍스트에는
bold, italic, underline, strikethrough 및 text modifier가 정상 적용되도록 했습니다.