### PR TITLE
promote_outside_y의 above 분기 조건 버그 수정

### DIFF
--- a/crates/editor-core/src/handle/pointer.rs
+++ b/crates/editor-core/src/handle/pointer.rs
@@ -1188,4 +1188,75 @@ mod tests {
             "head extends to the shift-clicked cell"
         );
     }
+
+    #[test]
+    fn drag_down_into_leading_gap_of_fold_keeps_text_selection() {
+        // Caret in the empty paragraph above a fold; drag straight down so the
+        // pointer lands in the inter-block gap directly above the fold, with x
+        // over the fold-title text. The gap is the *approach* to the fold, not
+        // an escape past it, so the head must stay a plain text caret in the
+        // fold-title text — not promote the whole fold to a ROOT-slot unit
+        // selection.
+        let (state, p1, f1, _, t1) = state! {
+            doc {
+                root {
+                    p1: paragraph {}
+                    f1: fold {
+                        ft1: fold_title {
+                            t1: text("1234")
+                        }
+                        fold_content {
+                            paragraph {
+                                text("12341234")
+                            }
+                        }
+                    }
+                    paragraph {}
+                }
+            }
+            selection: (p1, 0)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.view.layout(&editor.state.doc);
+
+        let p1_rect = editor.view.node_box_rects(&[p1])[0].rect;
+        editor.apply(Message::Pointer {
+            event: PointerEvent::Down {
+                page: 0,
+                x: p1_rect.x + 5.0,
+                y: p1_rect.y + p1_rect.height / 2.0,
+                count: 1,
+                modifiers: InputModifiers::default(),
+            },
+        });
+
+        let f1_rect = editor.view.node_box_rects(&[f1])[0].rect;
+        editor.apply(Message::Pointer {
+            event: PointerEvent::Move {
+                page: 0,
+                x: f1_rect.x + 50.0,
+                y: f1_rect.y - 2.0,
+            },
+        });
+
+        let sel = editor.state().selection;
+        assert_ne!(
+            sel.anchor.node_id,
+            editor_model::NodeId::ROOT,
+            "anchor must stay a text caret, not a ROOT slot, got {sel:?}"
+        );
+        assert_ne!(
+            sel.head.node_id,
+            editor_model::NodeId::ROOT,
+            "head must not promote the fold to a ROOT-slot unit selection, got {sel:?}"
+        );
+        assert_eq!(
+            sel.anchor.node_id, p1,
+            "anchor stays in the leading empty paragraph"
+        );
+        assert_eq!(
+            sel.head.node_id, t1,
+            "head lands in the fold-title text, not on the fold node"
+        );
+    }
 }

--- a/crates/editor-view/src/query/hit_test.rs
+++ b/crates/editor-view/src/query/hit_test.rs
@@ -85,6 +85,18 @@ pub fn closest_hit_test_extending(
 /// `(parent, idx + 1)`. Without this, dragging the selection past a
 /// monolithic container (e.g. fold) stalls at the container's innermost text
 /// position, making it impossible to select the container as a unit.
+///
+/// Only a true escape into the gutter promotes when escaping *above* the box.
+/// The inter-block gap directly above the box (between it and its previous
+/// sibling) belongs to the *approach* toward the box, not an escape past it:
+/// `closest_navigable` can pick the box's own leading text there, and that
+/// text caret — not a unit promotion — is the intended drag-extend target.
+/// So `above` promotion requires the click to be past the previous sibling
+/// too (or there to be no previous sibling at all). The `below` direction
+/// needs no such guard: once the click is past the box's bottom,
+/// `closest_navigable` resolves to the *next* sibling's text rather than back
+/// into the box, so this function is never even reached via the box for a
+/// gap directly below a box that has a following sibling.
 fn promote_outside_y(root: &LayoutNode, leaf: &LayoutNode, click_y: f32) -> Option<Position> {
     let mut path: Vec<(&LayoutNode, usize)> = Vec::new();
     if !build_path(root, leaf, &mut path) {
@@ -102,6 +114,13 @@ fn promote_outside_y(root: &LayoutNode, leaf: &LayoutNode, click_y: f32) -> Opti
         let below = click_y >= ancestor.rect.y + ancestor.rect.height;
         if above || below {
             let (parent_box_node, idx) = path[k - 1];
+            if above
+                && idx > 0
+                && let Some(prev) = nth_content_child(parent_box_node, idx - 1)
+                && click_y >= prev.rect.y + prev.rect.height
+            {
+                continue;
+            }
             if let LayoutContent::Box(parent_box) = &parent_box_node.content {
                 let slot = if below { idx + 1 } else { idx };
                 return Some(Position::new(parent_box.node_id, slot));
@@ -109,6 +128,18 @@ fn promote_outside_y(root: &LayoutNode, leaf: &LayoutNode, click_y: f32) -> Opti
         }
     }
     None
+}
+
+/// The `n`-th non-spacing child of `parent`, matching the content indexing
+/// that [`build_path`] uses (`Spacing` children are skipped there too).
+fn nth_content_child(parent: &LayoutNode, n: usize) -> Option<&LayoutNode> {
+    let LayoutContent::Box(b) = &parent.content else {
+        return None;
+    };
+    b.children
+        .iter()
+        .filter(|c| !matches!(c.content, LayoutContent::Spacing(_)))
+        .nth(n)
 }
 
 fn build_path<'a>(


### PR DESCRIPTION
조건 오류로 monolithic 노드 (fold 등) 에 진입하는 상황인데도 탈출하는 상황이라고 인지하고 잘못된 promotion을 하던 문제 수정
