### PR TITLE
TR-76 전부 비적용인 범위 modifier는 Err 대신 Ok(false) 반환 (TR-73 연장)

### DIFF
--- a/crates/editor-commands/src/commands/set_modifier.rs
+++ b/crates/editor-commands/src/commands/set_modifier.rs
@@ -91,7 +91,6 @@ fn set_modifier_range_text(tr: &mut Transaction, modifier: &Modifier) -> Command
     let applicable_node_ids = filter_applicable_node_ids(&tr.doc(), &node_ids, modifier.as_type());
 
     if applicable_node_ids.is_empty() {
-        compact_and_restore_selection(tr, &node_ids)?;
         return Ok(false);
     }
 
@@ -405,6 +404,37 @@ mod tests {
                 }
             }
             selection: (t1, 0) -> (t2, 4)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn range_set_font_size_on_fold_title_only_is_noop() {
+        let (initial, ..) = state! {
+            doc {
+                root [font_size(1600)] {
+                    fold {
+                        fold_title { t1: text("Title") }
+                        fold_content { paragraph { text("Body") } }
+                    }
+                }
+            }
+            selection: (t1, 0) -> (t1, 5)
+        };
+        let (actual, ..) = transact_fail!(initial, |tr| set_modifier(
+            &mut tr,
+            Modifier::FontSize { value: 2400 }
+        ));
+        let (expected, ..) = state! {
+            doc {
+                root [font_size(1600)] {
+                    fold {
+                        fold_title { t1: text("Title") }
+                        fold_content { paragraph { text("Body") } }
+                    }
+                }
+            }
+            selection: (t1, 0) -> (t1, 5)
         };
         assert_state_eq!(&actual, &expected);
     }

--- a/crates/editor-commands/src/commands/toggle_bold.rs
+++ b/crates/editor-commands/src/commands/toggle_bold.rs
@@ -27,7 +27,6 @@ pub fn toggle_bold(tr: &mut Transaction, resource: &Resource) -> CommandResult {
     let applicable_node_ids = filter_applicable_node_ids(&tr.doc(), &node_ids, ModifierType::Bold);
 
     if applicable_node_ids.is_empty() {
-        compact_and_restore_selection(tr, &node_ids)?;
         return Ok(false);
     }
 
@@ -712,6 +711,35 @@ mod tests {
                 }
             }
             selection: (t1, 0) -> (t1, 9)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn range_toggle_bold_on_fold_title_only_is_noop() {
+        let resource = make_resource([("Pretendard", vec![400, 700])]);
+        let (initial, ..) = state! {
+            doc {
+                root [font_weight(400), font_family("Pretendard".to_string())] {
+                    fold {
+                        fold_title { t1: text("Title") }
+                        fold_content { paragraph { text("Body") } }
+                    }
+                }
+            }
+            selection: (t1, 0) -> (t1, 5)
+        };
+        let (actual, ..) = transact_fail!(initial, |tr| toggle_bold(&mut tr, &resource));
+        let (expected, ..) = state! {
+            doc {
+                root [font_weight(400), font_family("Pretendard".to_string())] {
+                    fold {
+                        fold_title { t1: text("Title") }
+                        fold_content { paragraph { text("Body") } }
+                    }
+                }
+            }
+            selection: (t1, 0) -> (t1, 5)
         };
         assert_state_eq!(&actual, &expected);
     }

--- a/crates/editor-commands/src/commands/toggle_modifier.rs
+++ b/crates/editor-commands/src/commands/toggle_modifier.rs
@@ -38,7 +38,6 @@ pub fn toggle_modifier(tr: &mut Transaction, modifier_type: ModifierType) -> Com
     let applicable_node_ids = filter_applicable_node_ids(&tr.doc(), &node_ids, modifier_type);
 
     if applicable_node_ids.is_empty() {
-        compact_and_restore_selection(tr, &node_ids)?;
         return Ok(false);
     }
 


### PR DESCRIPTION
### TR-73 의 연장으로, 선택 범위가 전부 비적용일 때의 반환 규약(Err → Ok(false))을 닫는 티켓입니다.
핵심 fix(빈 분기 + Ok(false) 반환)는 TR-73 PR #4239 가 함께 가져간 것으로 보입니다.

**_변경사항_**
* 빈 분기 안 compact_and_restore_selection 호출 제거 (3 파일 × 1줄)
   * set_modifier_range_text, toggle_modifier, toggle_bold
   * 잠재적 step 생성 가능성을 호출 자체에서 차단해 "불변 보장"을 명시적으로 닫음
* 누락된 회귀 테스트 2개 추가
   * set_modifier::tests::range_set_font_size_on_fold_title_only_is_noop
   * toggle_bold::tests::range_toggle_bold_on_fold_title_only_is_noop
   * 기존 toggle_modifier::tests::range_toggle_italic_on_fold_title_only_is_noop 와 동일 패턴 (transact_fail! + assert_state_eq!)