### PR TITLE
에디터 이미지 업로드 및 편집 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,10 @@ vite.config.ts.timestamp-*
 
 .claude/worktrees/
 .superpowers/
+.openchrome/
 docs/superpowers/
+docs/tasks/
+docs/file-based-planning-workflow/
 
 *.tsx.js
 *.tsx.d.ts

--- a/apps/api/src/graphql/resolvers/changeset.ts
+++ b/apps/api/src/graphql/resolvers/changeset.ts
@@ -64,10 +64,20 @@ builder.mutationFields((t) => ({
       await assertSitePermission({ userId: ctx.session.userId, siteId: docEntity.siteId });
 
       let opsCount: number;
+      let graph: Uint8Array;
       try {
-        opsCount = await wasm.use((host) => host.peek_changeset_ops_count(input.changesets));
+        graph = await readMergedGraph(input.documentId);
+        opsCount = await wasm.use((host) => {
+          const count = host.peek_changeset_ops_count(input.changesets);
+          if (count > 0) {
+            const candidate = host.apply(graph, input.changesets);
+            host.verify_plain(host.to_plain(candidate));
+          }
+          return count;
+        });
       } catch {
-        throw new TypieError({ code: 'invalid_changeset_payload' });
+        await enqueueJob('document:changesets:collect', input.documentId);
+        throw new TypieError({ code: 'invalid_changeset_payload', status: 400 });
       }
 
       if (opsCount > 0) {
@@ -83,7 +93,7 @@ builder.mutationFields((t) => ({
 
       // Compute heads after lpush so the merged graph reflects this push.
       // Receivers of the broadcast see heads that include the just-pushed bundle.
-      const graph = await readMergedGraph(input.documentId);
+      graph = await readMergedGraph(input.documentId);
       const heads = await wasm.use((host) => host.heads(graph));
 
       if (opsCount > 0) {

--- a/apps/api/src/graphql/resolvers/changeset.ts
+++ b/apps/api/src/graphql/resolvers/changeset.ts
@@ -63,10 +63,10 @@ builder.mutationFields((t) => ({
 
       await assertSitePermission({ userId: ctx.session.userId, siteId: docEntity.siteId });
 
+      let graph = await readMergedGraph(input.documentId);
+
       let opsCount: number;
-      let graph: Uint8Array;
       try {
-        graph = await readMergedGraph(input.documentId);
         opsCount = await wasm.use((host) => {
           const count = host.peek_changeset_ops_count(input.changesets);
           if (count > 0) {

--- a/apps/website/src/lib/editor-ffi/components/Editor.svelte
+++ b/apps/website/src/lib/editor-ffi/components/Editor.svelte
@@ -117,6 +117,19 @@
       if (ctx.editor) ctx.editor.scrollContainerEl = undefined;
     };
   }}
+  ondragover={(e) => {
+    if (e.dataTransfer?.types.includes('Files')) {
+      e.preventDefault();
+    }
+  }}
+  ondrop={(e) => {
+    const files = e.dataTransfer?.files;
+    if (!files || files.length === 0) return;
+    const imageFiles = [...files].filter((file) => file.type.startsWith('image/'));
+    if (imageFiles.length === 0) return;
+    e.preventDefault();
+    ctx.editor?.insertImagesFromFiles(imageFiles);
+  }}
   onfocusin={() => ctx.editor?.focus()}
   onfocusout={() => {
     if (!window.document.hasFocus()) return;

--- a/apps/website/src/lib/editor-ffi/components/Editor.svelte
+++ b/apps/website/src/lib/editor-ffi/components/Editor.svelte
@@ -125,9 +125,9 @@
   ondrop={(e) => {
     const files = e.dataTransfer?.files;
     if (!files || files.length === 0) return;
+    e.preventDefault();
     const imageFiles = [...files].filter((file) => file.type.startsWith('image/'));
     if (imageFiles.length === 0) return;
-    e.preventDefault();
     ctx.editor?.insertImagesFromFiles(imageFiles);
   }}
   onfocusin={() => ctx.editor?.focus()}

--- a/apps/website/src/lib/editor-ffi/components/ExternalElement.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ExternalElement.svelte
@@ -9,6 +9,7 @@
   import ImageIcon from '~icons/lucide/image';
   import { THEME_COLORS } from '$lib/editor/theme';
   import { getEditorContext } from '../editor.svelte';
+  import ExternalImage from './ExternalImage.svelte';
   import type { ExternalElement } from '@typie/editor-ffi/browser';
   import type { Component } from 'svelte';
 
@@ -79,58 +80,62 @@
   });
 </script>
 
-<div
-  style:left={`${element.bounds.x}px`}
-  style:top={`${element.bounds.y}px`}
-  style:width={`${element.bounds.width}px`}
-  class={css({
-    position: 'absolute',
-    userSelect: 'none',
-    display: 'flex',
-    justifyContent: 'center',
-    visibility: reportedHeight === undefined ? 'hidden' : 'visible',
-  })}
-  data-external-element
-  data-node-id={element.node_id}
->
-  <div bind:this={containerEl} class={css({ width: 'full', minHeight: '48px' })}>
-    <div
-      class={flex({
-        align: 'center',
-        gap: '12px',
-        width: 'full',
-        minHeight: '48px',
-        paddingX: '14px',
-        paddingY: '12px',
-        borderRadius: '4px',
-        backgroundColor: 'surface.muted',
-        color: 'text.disabled',
-        fontSize: '14px',
-      })}
-    >
-      <Icon class={css({ flexShrink: '0' })} icon={meta.icon} size={20} />
-      <span
-        class={css({
-          minWidth: '0',
-          overflow: 'hidden',
-          whiteSpace: 'nowrap',
-          textOverflow: 'ellipsis',
+{#if element.data.type === 'image'}
+  <ExternalImage {element} />
+{:else}
+  <div
+    style:left={`${element.bounds.x}px`}
+    style:top={`${element.bounds.y}px`}
+    style:width={`${element.bounds.width}px`}
+    class={css({
+      position: 'absolute',
+      userSelect: 'none',
+      display: 'flex',
+      justifyContent: 'center',
+      visibility: reportedHeight === undefined ? 'hidden' : 'visible',
+    })}
+    data-external-element
+    data-node-id={element.node_id}
+  >
+    <div bind:this={containerEl} class={css({ width: 'full', minHeight: '48px' })}>
+      <div
+        class={flex({
+          align: 'center',
+          gap: '12px',
+          width: 'full',
+          minHeight: '48px',
+          paddingX: '14px',
+          paddingY: '12px',
+          borderRadius: '4px',
+          backgroundColor: 'surface.muted',
+          color: 'text.disabled',
+          fontSize: '14px',
         })}
       >
-        {meta.label}
-      </span>
+        <Icon class={css({ flexShrink: '0' })} icon={meta.icon} size={20} />
+        <span
+          class={css({
+            minWidth: '0',
+            overflow: 'hidden',
+            whiteSpace: 'nowrap',
+            textOverflow: 'ellipsis',
+          })}
+        >
+          {meta.label}
+        </span>
+      </div>
     </div>
-  </div>
 
-  {#if element.is_selected}
-    <div
-      style:background-color={selectionColor}
-      style:opacity={selectionOpacity}
-      class={css({
-        position: 'absolute',
-        inset: '0',
-        pointerEvents: 'none',
-      })}
-    ></div>
-  {/if}
-</div>
+    {#if element.is_selected}
+      <div
+        style:background-color={selectionColor}
+        style:opacity={selectionOpacity}
+        class={css({
+          position: 'absolute',
+          inset: '0',
+          pointerEvents: 'none',
+        })}
+      ></div>
+    {/if}
+  </div>
+{/if}

--- a/apps/website/src/lib/editor-ffi/components/ExternalImage.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ExternalImage.svelte
@@ -1,0 +1,586 @@
+<script lang="ts">
+  import { flip, hide } from '@floating-ui/dom';
+  import { createQuery } from '@mearie/svelte';
+  import { css, cx } from '@typie/styled-system/css';
+  import { center, flex } from '@typie/styled-system/patterns';
+  import { createFloatingActions } from '@typie/ui/actions';
+  import { Icon, Img, Menu, MenuItem, RingSpinner } from '@typie/ui/components';
+  import { getThemeContext } from '@typie/ui/context';
+  import { Toast } from '@typie/ui/notification';
+  import { nanoid } from 'nanoid';
+  import EllipsisIcon from '~icons/lucide/ellipsis';
+  import ImageIcon from '~icons/lucide/image';
+  import Trash2Icon from '~icons/lucide/trash-2';
+  import ExternalImageEnlarge from '$lib/components/editor/external/ExternalImageEnlarge.svelte';
+  import { THEME_COLORS } from '$lib/editor/theme';
+  import { uploadBlobAsImage } from '$lib/utils/blob.svelte';
+  import { graphql } from '$mearie';
+  import { getEditorContext } from '../editor.svelte';
+  import type { ExternalElement } from '@typie/editor-ffi/browser';
+
+  type Props = {
+    element: ExternalElement;
+  };
+
+  let { element }: Props = $props();
+
+  const SELECTION_FOCUSED_ALPHA = 77 / 255;
+  const SELECTION_UNFOCUSED_ALPHA = 48 / 255;
+
+  const ctx = getEditorContext();
+  const theme = getThemeContext();
+
+  const themeVariant = $derived(theme.currentThemeVariant);
+  const selectionColor = $derived(THEME_COLORS[themeVariant].selection);
+  const selectionOpacity = $derived(ctx.editor?.focused ? SELECTION_FOCUSED_ALPHA : SELECTION_UNFOCUSED_ALPHA);
+
+  let containerEl: HTMLDivElement | null = $state(null);
+  let reportedHeight = $state<number>();
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  let pickerOpened = $state(false);
+  let localUploadId = $state<string>();
+  let processedUploadId = $state<string>();
+  let proportion = $state(100);
+  let isResizing = $state(false);
+  let initialResizeData: { x: number; width: number; proportion: number; reverse: boolean } | null = null;
+  let enlarged = $state(false);
+  let objectUrl: string | undefined;
+
+  const imageData = $derived(element.data.type === 'image' ? element.data : undefined);
+  const asset = $derived(imageData?.id ? ctx.editor?.imageAssets.get(imageData.id) : undefined);
+  const imageAssetQuery = createQuery(
+    graphql(`
+      query EditorFfiExternalImage_Query($imageId: ID!) {
+        image(imageId: $imageId) {
+          id
+          url
+          originalUrl
+          width
+          height
+          placeholder
+        }
+      }
+    `),
+    () => ({ imageId: imageData?.id ?? '' }),
+    () => ({ skip: !imageData?.id || !!asset }),
+  );
+  const currentUploadId = $derived(imageData?.upload_id ?? localUploadId);
+  const inflight = $derived(currentUploadId && ctx.editor ? ctx.editor.inflightImages.get(currentUploadId) : undefined);
+  const imageSrc = $derived(asset?.url ?? inflight?.url);
+  const hasImage = $derived(!!imageSrc);
+  const isUploading = $derived(!!inflight && !asset);
+  const isResolvingAsset = $derived(!!imageData?.id && !asset && !inflight);
+  const originalWidth = $derived(asset?.width ?? inflight?.width ?? 0);
+  const originalHeight = $derived(asset?.height ?? inflight?.height ?? 0);
+  const aspectRatio = $derived(originalWidth > 0 ? originalHeight / originalWidth : 0);
+  const liveWidth = $derived(
+    originalWidth <= 0 ? element.bounds.width * (proportion / 100) : Math.min(originalWidth, element.bounds.width * (proportion / 100)),
+  );
+  const liveHeight = $derived(aspectRatio <= 0 ? 0 : liveWidth * aspectRatio);
+
+  const { anchor, floating } = createFloatingActions({
+    placement: 'bottom',
+    offset: 4,
+    middleware: [flip(), hide()],
+  });
+
+  $effect(() => {
+    pickerOpened = element.is_selected;
+  });
+
+  const getWidthBounds = (boundsWidth: number) => {
+    const maxWidth = Math.min(originalWidth || boundsWidth, boundsWidth);
+    const minWidth = Math.min(maxWidth, Math.max(boundsWidth * 0.1, 100));
+    return { minWidth, maxWidth };
+  };
+
+  const clampWidth = (width: number, boundsWidth: number) => {
+    const { minWidth, maxWidth } = getWidthBounds(boundsWidth);
+    return Math.max(minWidth, Math.min(maxWidth, width));
+  };
+
+  const clampProportion = (value: number) => Math.max(10, Math.min(100, Math.round(value)));
+
+  const getImageDimensions = (src: string): Promise<{ width: number; height: number }> => {
+    return new Promise((resolve, reject) => {
+      const img = new Image();
+      img.addEventListener('load', () => resolve({ width: img.naturalWidth, height: img.naturalHeight }));
+      img.addEventListener('error', () => reject(new Error('Failed to load image')));
+      img.src = src;
+    });
+  };
+
+  const deleteNode = () => {
+    const editor = ctx.editor;
+    if (!editor) return;
+    editor.enqueue({ type: 'node', op: { type: 'delete', id: element.node_id } });
+    editor.focus();
+  };
+
+  const stopPointerPropagation = (event: PointerEvent) => {
+    event.stopPropagation();
+  };
+
+  const processFile = async (file: File, uploadId: string) => {
+    const editor = ctx.editor;
+    if (!editor) return;
+
+    objectUrl = URL.createObjectURL(file);
+
+    try {
+      const { width, height } = await getImageDimensions(objectUrl);
+      editor.inflightImages.set(uploadId, { url: objectUrl, width, height });
+
+      const uploadedImage = await uploadBlobAsImage(file);
+      editor.imageAssets.set(uploadedImage.id, {
+        id: uploadedImage.id,
+        url: uploadedImage.url,
+        originalUrl: uploadedImage.originalUrl,
+        width: uploadedImage.width,
+        height: uploadedImage.height,
+        placeholder: uploadedImage.placeholder,
+      });
+
+      if (!editor.hasExternalElement(element.node_id)) {
+        return;
+      }
+
+      editor.enqueue({
+        type: 'node',
+        op: {
+          type: 'set_image_id',
+          id: element.node_id,
+          image_id: uploadedImage.id,
+        },
+      });
+      editor.focus();
+    } catch (err) {
+      console.error('Image upload failed:', err);
+      Toast.error(`${file.name} 이미지 업로드에 실패했습니다.`);
+      if (!imageData?.id && editor.hasExternalElement(element.node_id)) {
+        deleteNode();
+      }
+    } finally {
+      editor.clearImageUpload(uploadId);
+      localUploadId = undefined;
+      if (objectUrl) {
+        URL.revokeObjectURL(objectUrl);
+        objectUrl = undefined;
+      }
+    }
+  };
+
+  const handleUpload = async () => {
+    const editor = ctx.editor;
+    if (!editor || editor.blockBlobEdit()) {
+      return;
+    }
+
+    const picker = document.createElement('input');
+    picker.type = 'file';
+    picker.accept = 'image/*';
+    picker.multiple = true;
+
+    picker.addEventListener(
+      'change',
+      () => {
+        pickerOpened = false;
+
+        const files = picker.files ? [...picker.files].filter((file) => file.type.startsWith('image/')) : [];
+        if (files.length === 0) {
+          return;
+        }
+
+        const [firstFile, ...restFiles] = files;
+        const uploadId = nanoid();
+        editor.queueUpload(uploadId, firstFile);
+        const queuedFile = editor.popUpload(uploadId) ?? firstFile;
+        processedUploadId = uploadId;
+        localUploadId = uploadId;
+        void processFile(queuedFile, uploadId);
+
+        if (restFiles.length > 0) {
+          editor.insertImagesFromFiles(restFiles);
+        }
+      },
+      { once: true },
+    );
+
+    picker.click();
+  };
+
+  const handleResizeStart = (event: PointerEvent, reverse: boolean) => {
+    const target = event.currentTarget as HTMLElement;
+    target.setPointerCapture(event.pointerId);
+    event.stopPropagation();
+    event.preventDefault();
+
+    isResizing = true;
+    initialResizeData = {
+      x: event.clientX,
+      width: liveWidth,
+      proportion,
+      reverse,
+    };
+  };
+
+  const handleResize = (event: PointerEvent) => {
+    const target = event.currentTarget as HTMLElement;
+    if (!target.hasPointerCapture(event.pointerId) || !initialResizeData) {
+      return;
+    }
+
+    const boundsWidth = element.bounds.width;
+    if (boundsWidth <= 0) return;
+
+    const dx = (event.clientX - initialResizeData.x) * (initialResizeData.reverse ? -1 : 1);
+    const newWidth = clampWidth(initialResizeData.width + dx * 2, boundsWidth);
+    proportion = Math.round((newWidth / boundsWidth) * 100);
+  };
+
+  const handleResizeEnd = (event: PointerEvent) => {
+    const editor = ctx.editor;
+    const target = event.currentTarget as HTMLElement;
+    target.releasePointerCapture(event.pointerId);
+    isResizing = false;
+
+    if (!editor || !imageData) return;
+    editor.enqueue({
+      type: 'node',
+      op: {
+        type: 'set_image_proportion',
+        id: element.node_id,
+        proportion: clampProportion(proportion),
+      },
+    });
+    editor.focus();
+  };
+
+  $effect(() => {
+    if (!imageData || isResizing) return;
+    proportion = imageData.proportion ?? 100;
+  });
+
+  $effect(() => {
+    const editor = ctx.editor;
+    const image = imageAssetQuery.data?.image;
+    if (!editor || !imageData?.id || !image || image.id !== imageData.id) return;
+
+    editor.imageAssets.set(image.id, {
+      id: image.id,
+      url: image.url,
+      originalUrl: image.originalUrl,
+      width: image.width,
+      height: image.height,
+      placeholder: image.placeholder,
+    });
+  });
+
+  $effect(() => {
+    const editor = ctx.editor;
+    const boundsWidth = element.bounds.width;
+    if (!editor || !imageData || isResizing || boundsWidth <= 0 || originalWidth <= 0) return;
+
+    const currentWidth = Math.min(originalWidth, boundsWidth * (proportion / 100));
+    const clampedWidth = clampWidth(currentWidth, boundsWidth);
+
+    if (currentWidth !== clampedWidth) {
+      const newProportion = Math.round((clampedWidth / boundsWidth) * 100);
+      proportion = newProportion;
+      editor.enqueue({
+        type: 'node',
+        op: {
+          type: 'set_image_proportion',
+          id: element.node_id,
+          proportion: clampProportion(newProportion),
+        },
+      });
+    }
+  });
+
+  $effect(() => {
+    if (!ctx.editor || !imageData || imageData.id || processedUploadId || !imageData.upload_id) return;
+
+    const file = ctx.editor.popUpload(imageData.upload_id);
+    if (file) {
+      processedUploadId = imageData.upload_id;
+      void processFile(file, imageData.upload_id);
+    } else {
+      console.warn('Upload file not found for uploadId:', imageData.upload_id);
+    }
+  });
+
+  $effect(() => {
+    if (!hasImage) {
+      enlarged = false;
+    }
+  });
+
+  $effect(() => {
+    const editor = ctx.editor;
+    const node = containerEl;
+    if (!editor || !node) return;
+
+    const observer = new ResizeObserver((entries) => {
+      const height = entries[0]?.contentRect.height ?? 0;
+      if (height <= 0 || height === reportedHeight) return;
+
+      if (debounceTimer) {
+        clearTimeout(debounceTimer);
+      }
+
+      debounceTimer = setTimeout(() => {
+        reportedHeight = height;
+        editor.setExternalElementHeight(element.node_id, height);
+        debounceTimer = null;
+      }, 100);
+    });
+
+    observer.observe(node);
+    return () => {
+      observer.disconnect();
+      if (debounceTimer) {
+        clearTimeout(debounceTimer);
+      }
+    };
+  });
+
+  $effect(() => {
+    return () => {
+      if (localUploadId) {
+        ctx.editor?.clearImageUpload(localUploadId);
+      }
+      if (objectUrl) {
+        URL.revokeObjectURL(objectUrl);
+        objectUrl = undefined;
+      }
+    };
+  });
+</script>
+
+<div
+  style:left={`${element.bounds.x}px`}
+  style:top={`${element.bounds.y}px`}
+  style:width={`${element.bounds.width}px`}
+  class={css({
+    position: 'absolute',
+    userSelect: 'none',
+    display: 'flex',
+    justifyContent: 'center',
+    visibility: reportedHeight === undefined ? 'hidden' : 'visible',
+  })}
+  data-external-element
+  data-node-id={element.node_id}
+>
+  <div
+    bind:this={containerEl}
+    style:width={hasImage ? `${liveWidth}px` : '100%'}
+    style:height={hasImage ? `${liveHeight}px` : undefined}
+    class={cx('group', css({ position: 'relative', minHeight: '48px', margin: '[0 auto]' }))}
+  >
+    {#if hasImage && imageSrc}
+      <Img
+        style={css.raw({ width: 'full', borderRadius: '4px' })}
+        alt="본문 이미지"
+        aria-label="이미지 확대 보기"
+        onclick={() => {
+          enlarged = true;
+        }}
+        onkeydown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            enlarged = true;
+          }
+        }}
+        onpointerdown={(event) => event.stopPropagation()}
+        placeholder={asset?.placeholder}
+        progressive
+        ratio={originalHeight > 0 ? originalWidth / originalHeight : undefined}
+        role="button"
+        size="full"
+        tabindex={0}
+        url={imageSrc}
+      />
+
+      {#if isUploading}
+        <div class={center({ position: 'absolute', inset: '0', backgroundColor: 'white/50' })}>
+          <RingSpinner style={css.raw({ size: '24px', color: 'text.disabled' })} />
+        </div>
+      {/if}
+
+      <button
+        class={css({
+          position: 'absolute',
+          top: '10px',
+          right: '10px',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          borderRadius: '4px',
+          size: '28px',
+          color: 'text.bright',
+          backgroundColor: '[#363839/70]',
+          opacity: '0',
+          transition: 'opacity',
+          zIndex: '10',
+          _hover: { backgroundColor: '[#363839/40]' },
+          _groupHover: { opacity: '100' },
+        })}
+        aria-label="이미지 삭제"
+        onclick={deleteNode}
+        onpointerdown={(event) => event.stopPropagation()}
+        type="button"
+      >
+        <Icon icon={Trash2Icon} size={16} />
+      </button>
+
+      {#each [true, false] as reverse (reverse)}
+        <div
+          class={flex({
+            position: 'absolute',
+            top: '0',
+            bottom: '0',
+            left: reverse ? '10px' : undefined,
+            right: reverse ? undefined : '10px',
+            alignItems: 'center',
+            pointerEvents: 'none',
+          })}
+        >
+          <button
+            class={css({
+              borderRadius: '4px',
+              backgroundColor: 'white/50',
+              mixBlendMode: 'difference',
+              width: '8px',
+              height: '1/3',
+              maxHeight: '72px',
+              cursor: 'col-resize',
+              opacity: '0',
+              transition: 'opacity',
+              zIndex: '10',
+              pointerEvents: 'auto',
+              _hover: { backgroundColor: 'white/40' },
+              _groupHover: { opacity: '100' },
+            })}
+            aria-label="이미지 크기 조절"
+            onpointerdown={(event) => handleResizeStart(event, reverse)}
+            onpointermove={handleResize}
+            onpointerup={handleResizeEnd}
+            type="button"
+          ></button>
+        </div>
+      {/each}
+    {:else}
+      <div
+        class={flex({
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          borderRadius: '4px',
+          backgroundColor: 'surface.muted',
+          width: 'full',
+          height: '48px',
+        })}
+        use:anchor
+      >
+        <div
+          class={flex({
+            align: 'center',
+            gap: '12px',
+            paddingX: '14px',
+            paddingY: '12px',
+            fontSize: '14px',
+            color: 'text.disabled',
+          })}
+        >
+          <Icon icon={ImageIcon} size={20} />
+          {isResolvingAsset ? '이미지를 불러오는 중...' : '이미지'}
+        </div>
+
+        {#if isResolvingAsset}
+          <div class={css({ marginRight: '14px' })}>
+            <RingSpinner style={css.raw({ size: '16px', color: 'text.disabled' })} />
+          </div>
+        {/if}
+
+        <div onpointerdown={stopPointerPropagation} role="presentation">
+          <Menu>
+            {#snippet button({ open }: { open: boolean })}
+              <div
+                class={css(
+                  {
+                    marginRight: '12px',
+                    borderRadius: '4px',
+                    padding: '2px',
+                    color: 'text.disabled',
+                    opacity: '0',
+                    transition: 'common',
+                    _hover: { backgroundColor: 'interactive.hover' },
+                    _groupHover: { opacity: '100' },
+                  },
+                  open && { opacity: '100' },
+                )}
+              >
+                <Icon icon={EllipsisIcon} size={20} />
+              </div>
+            {/snippet}
+
+            <MenuItem onclick={deleteNode} variant="danger">
+              <Icon icon={Trash2Icon} size={12} />
+              <span>삭제</span>
+            </MenuItem>
+          </Menu>
+        </div>
+      </div>
+    {/if}
+  </div>
+
+  {#if element.is_selected}
+    <div
+      style:background-color={selectionColor}
+      style:opacity={selectionOpacity}
+      class={css({
+        position: 'absolute',
+        inset: '0',
+        borderRadius: '4px',
+        pointerEvents: 'none',
+      })}
+    ></div>
+  {/if}
+</div>
+
+{#if pickerOpened && !hasImage && !isResolvingAsset}
+  <button
+    class={flex({
+      alignItems: 'center',
+      gap: '6px',
+      borderWidth: '1px',
+      borderRadius: '8px',
+      paddingX: '12px',
+      paddingY: '6px',
+      fontSize: '13px',
+      color: 'text.muted',
+      backgroundColor: 'surface.default',
+      boxShadow: 'small',
+      transition: 'common',
+      zIndex: 'editor',
+      _hover: { backgroundColor: 'interactive.hover' },
+    })}
+    onclick={handleUpload}
+    onpointerdown={(event) => event.stopPropagation()}
+    type="button"
+    use:floating
+  >
+    <Icon icon={ImageIcon} size={14} />
+    이미지 선택
+  </button>
+{/if}
+
+{#if enlarged && hasImage && imageSrc && containerEl}
+  <ExternalImageEnlarge
+    onclose={() => (enlarged = false)}
+    placeholder={asset?.placeholder}
+    ratio={originalHeight > 0 ? originalWidth / originalHeight : undefined}
+    referenceEl={containerEl}
+    url={imageSrc}
+  />
+{/if}

--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -1,4 +1,6 @@
+import { nanoid } from 'nanoid';
 import { createContext, tick, untrack } from 'svelte';
+import { SvelteMap } from 'svelte/reactivity';
 import { match } from 'ts-pattern';
 import { initWasm, wasm } from '$lib/wasm-ffi.svelte';
 import { fontDataMissingHandler } from './fonts';
@@ -21,6 +23,21 @@ import type {
   Viewport,
 } from '@typie/editor-ffi/browser';
 import type { EditorEventListener } from './types';
+
+export type ImageAsset = {
+  id: string;
+  url: string;
+  originalUrl: string;
+  width: number;
+  height: number;
+  placeholder: string;
+};
+
+export type InflightImage = {
+  url: string;
+  width: number;
+  height: number;
+};
 
 let wasmInitPromise: Promise<void> | null = null;
 
@@ -53,6 +70,11 @@ export class Editor {
   scrollContainerEl = $state<HTMLDivElement>();
 
   readOnly = false;
+  restrictedBlob = $state(false);
+  imageAssets = $state(new SvelteMap<string, ImageAsset>());
+  inflightImages = $state(new SvelteMap<string, InflightImage>());
+  uploadQueue = new SvelteMap<string, File>();
+  #onEditBlocked?: (reason: 'restrictedBlob') => void;
 
   // eslint-disable-next-line svelte/prefer-svelte-reactivity
   #listeners = new Map<EditorEvent['type'], Set<EditorEventListener<EditorEvent['type']>>>();
@@ -171,6 +193,73 @@ export class Editor {
 
   get focused() {
     return this.#focused;
+  }
+
+  setEditBlockedHandler(handler: (reason: 'restrictedBlob') => void): void {
+    this.#onEditBlocked = handler;
+  }
+
+  queueUpload(uploadId: string, file: File): void {
+    this.uploadQueue.set(uploadId, file);
+    setTimeout(() => {
+      if (this.uploadQueue.has(uploadId)) {
+        this.uploadQueue.delete(uploadId);
+        console.warn('Upload timed out for', uploadId);
+      }
+    }, 30_000);
+  }
+
+  popUpload(uploadId: string): File | undefined {
+    const file = this.uploadQueue.get(uploadId);
+    if (file) {
+      this.uploadQueue.delete(uploadId);
+    }
+    return file;
+  }
+
+  clearImageUpload(uploadId?: string): void {
+    if (uploadId) {
+      this.uploadQueue.delete(uploadId);
+      this.inflightImages.delete(uploadId);
+    }
+  }
+
+  hasExternalElement(nodeId: string): boolean {
+    return this.#externalElements.some((element) => element.node_id === nodeId);
+  }
+
+  blockBlobEdit(): boolean {
+    if (!this.restrictedBlob) {
+      return false;
+    }
+    this.#onEditBlocked?.('restrictedBlob');
+    return true;
+  }
+
+  insertImagesFromFiles(files: Iterable<File>): boolean {
+    if (this.blockBlobEdit()) {
+      return false;
+    }
+
+    let handled = false;
+    for (const file of files) {
+      if (!file.type.startsWith('image/')) {
+        continue;
+      }
+
+      const uploadId = nanoid();
+      this.queueUpload(uploadId, file);
+      this.enqueue({
+        type: 'insertion',
+        op: { type: 'fragment', fragment: { node: { type: 'image', id: undefined, upload_id: uploadId } } },
+      });
+      handled = true;
+    }
+
+    if (handled) {
+      this.focus();
+    }
+    return handled;
   }
 
   #setFocused(focused: boolean): void {

--- a/apps/website/src/lib/editor-ffi/handlers/clipboard.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/clipboard.ts
@@ -1,6 +1,13 @@
 import type { EditorEventHandler } from '../types';
 
 export const handlePaste: EditorEventHandler<HTMLInputElement, ClipboardEvent> = (editor, e) => {
+  const imageFiles = [...(e.clipboardData?.files ?? [])].filter((file) => file.type.startsWith('image/'));
+  if (imageFiles.length > 0) {
+    e.preventDefault();
+    editor.insertImagesFromFiles(imageFiles);
+    return;
+  }
+
   const text = e.clipboardData?.getData('text/plain') || undefined;
   const html = e.clipboardData?.getData('text/html') || undefined;
 

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@debug/TimelineSection.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@debug/TimelineSection.svelte
@@ -38,6 +38,9 @@
       case 'poll.applied': {
         return `poll.applied (${entry.bytes}B)`;
       }
+      case 'poll.error': {
+        return `poll.error: ${entry.message}`;
+      }
     }
   }
 

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@debug/types.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@debug/types.ts
@@ -12,7 +12,8 @@ export type DebugEvent =
   | { kind: 'push.success'; durationMs: number }
   | { kind: 'push.error'; message: string }
   | { kind: 'subscription.received'; bytes: number }
-  | { kind: 'poll.applied'; bytes: number };
+  | { kind: 'poll.applied'; bytes: number }
+  | { kind: 'poll.error'; message: string };
 
 export type TimelineEntry = { id: number; ts: number } & DebugEvent;
 
@@ -29,6 +30,9 @@ export const eventCategory = (kind: DebugEvent['kind']): DebugEventCategory => {
       return 'subscription';
     }
     case 'poll.applied': {
+      return 'poll';
+    }
+    case 'poll.error': {
       return 'poll';
     }
   }

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditorV2.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditorV2.svelte
@@ -1,14 +1,17 @@
 <script lang="ts">
   import { createFragment, createMutation, createSubscription } from '@mearie/svelte';
   import { css } from '@typie/styled-system/css';
+  import { getAppContext } from '@typie/ui/context';
   import { onDestroy, untrack } from 'svelte';
   import EditorComponent from '$lib/editor-ffi/components/Editor.svelte';
   import { setupEditorContext } from '$lib/editor-ffi/editor.svelte';
   import { graphql } from '$mearie';
+  import { PlanUpgradeDialog } from '../../plan-upgrade-dialog.svelte';
   import { DebugBus } from './@debug/debug-bus.svelte';
   import DebugPanel from './@debug/DebugPanel.svelte';
   import BottomToolbar from './BottomToolbar.svelte';
   import SettingsPanel from './SettingsPanel.svelte';
+  import { describeSyncError } from './sync/errors';
   import { Pusher } from './sync/pusher.svelte';
   import TopToolbar from './TopToolbar.svelte';
   import type { DocumentEditorV2_document$key } from '$mearie';
@@ -25,6 +28,18 @@
       fragment DocumentEditorV2_document on Document {
         id
         title
+        assets {
+          __typename
+
+          ... on Image {
+            id
+            url
+            originalUrl
+            width
+            height
+            placeholder
+          }
+        }
         state {
           graph
           updatedAt
@@ -38,6 +53,7 @@
   );
 
   const ctx = setupEditorContext();
+  const app = getAppContext();
   const bus = new DebugBus();
   const clientId = crypto.randomUUID();
   let pusher = $state<Pusher | null>(null);
@@ -166,15 +182,21 @@
       const ed = ctx.editor;
       const heads = lastConfirmedHeads;
       if (!ed || heads === null) return;
-      const result = await pullDocumentChangesets({
-        input: { documentId: document.data.id, heads: heads.toBase64() },
-      });
-      const missing = Uint8Array.fromBase64(result.pullDocumentChangesets.changesets);
-      if (missing.length > 0) {
-        ed.receiveRemoteChangeset(missing);
-        bus.emit({ kind: 'poll.applied', bytes: missing.length });
+      try {
+        const result = await pullDocumentChangesets({
+          input: { documentId: document.data.id, heads: heads.toBase64() },
+        });
+        const missing = Uint8Array.fromBase64(result.pullDocumentChangesets.changesets);
+        if (missing.length > 0) {
+          ed.receiveRemoteChangeset(missing);
+          bus.emit({ kind: 'poll.applied', bytes: missing.length });
+        }
+        lastConfirmedHeads = Uint8Array.fromBase64(result.pullDocumentChangesets.heads);
+      } catch (err) {
+        const message = describeSyncError(err);
+        bus.emit({ kind: 'poll.error', message });
+        console.warn('DocumentEditorV2: poll failed', message, err);
       }
-      lastConfirmedHeads = Uint8Array.fromBase64(result.pullDocumentChangesets.heads);
     }, 10_000);
 
     return () => {
@@ -183,6 +205,37 @@
       ps.stop();
       pusher = null;
     };
+  });
+
+  $effect(() => {
+    const editor = ctx.editor;
+    if (!editor) return;
+
+    for (const asset of document.data.assets) {
+      if (asset.__typename !== 'Image') continue;
+      editor.imageAssets.set(asset.id, {
+        id: asset.id,
+        url: asset.url,
+        originalUrl: asset.originalUrl,
+        width: asset.width,
+        height: asset.height,
+        placeholder: asset.placeholder,
+      });
+    }
+  });
+
+  $effect(() => {
+    const editor = ctx.editor;
+    if (!editor) return;
+
+    editor.restrictedBlob =
+      Number(app.state.usage.limit.totalBlobSize) !== -1 &&
+      Number(app.state.usage.current.totalBlobSize) >= Number(app.state.usage.limit.totalBlobSize);
+    editor.setEditBlockedHandler(() => {
+      PlanUpgradeDialog.show({
+        message: '현재 플랜의 최대 업로드 가능 용량을 초과했어요.\nFULL ACCESS로 업그레이드하고 이어서 업로드하세요.',
+      });
+    });
   });
 
   onDestroy(() => {

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/TopToolbar.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/TopToolbar.svelte
@@ -73,7 +73,11 @@
   })}
   role="toolbar"
 >
-  <ToolbarButton icon={ImageIcon} label="이미지" onclick={() => enqueue(insertFragment({ node: { type: 'image', id: undefined } }))} />
+  <ToolbarButton
+    icon={ImageIcon}
+    label="이미지"
+    onclick={() => enqueue(insertFragment({ node: { type: 'image', id: undefined, upload_id: undefined } }))}
+  />
   <ToolbarButton icon={PaperclipIcon} label="파일" onclick={() => enqueue(insertFragment({ node: { type: 'file', id: undefined } }))} />
   <ToolbarButton icon={FileUpIcon} label="임베드" onclick={() => enqueue(insertFragment({ node: { type: 'embed', id: undefined } }))} />
 

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/sync/errors.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/sync/errors.test.ts
@@ -1,0 +1,29 @@
+import { TypieError } from '@typie/lib/errors';
+import { describe, expect, it } from 'vitest';
+import { describeSyncError, isPermanentSyncError } from './errors';
+
+describe('sync errors', () => {
+  it('classifies invalid changeset payload as permanent', () => {
+    const error = new TypieError({ code: 'invalid_changeset_payload', message: 'invalid_changeset_payload', status: 400 });
+
+    expect(isPermanentSyncError(error)).toBe(true);
+  });
+
+  it('does not classify unknown typie errors as permanent', () => {
+    const error = new TypieError({ code: 'unexpected_error_dev', message: 'Unexpected error' });
+
+    expect(isPermanentSyncError(error)).toBe(false);
+  });
+
+  it('describes typie errors with code and message', () => {
+    const error = new TypieError({ code: 'invalid_changeset_payload', message: 'invalid_changeset_payload', status: 400 });
+
+    expect(describeSyncError(error)).toBe('invalid_changeset_payload: invalid_changeset_payload');
+  });
+
+  it('describes regular errors with message', () => {
+    const error = new Error('Network error');
+
+    expect(describeSyncError(error)).toBe('Network error');
+  });
+});

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/sync/errors.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/sync/errors.ts
@@ -1,0 +1,43 @@
+import { isAggregatedError, isExchangeError, isGraphQLError } from '@mearie/svelte';
+import { TypieError } from '@typie/lib/errors';
+
+const PERMANENT_CODES = new Set(['invalid_changeset_payload']);
+
+export function isPermanentSyncError(err: unknown): boolean {
+  if (err instanceof TypieError) {
+    return PERMANENT_CODES.has(err.code);
+  }
+  if (!isAggregatedError(err)) return false;
+  for (const e of err.errors) {
+    if (e instanceof TypieError) {
+      if (PERMANENT_CODES.has(e.code)) return true;
+    } else if (isGraphQLError(e)) {
+      const code = e.extensions?.code;
+      if (typeof code === 'string' && PERMANENT_CODES.has(code)) return true;
+    } else if (isExchangeError(e, 'http')) {
+      const status = e.extensions?.statusCode;
+      if (typeof status === 'number' && status >= 400 && status < 500) return true;
+    }
+  }
+  return false;
+}
+
+export function describeSyncError(err: unknown): string {
+  if (err instanceof TypieError) {
+    return `${err.code}: ${err.message}`;
+  }
+  if (isGraphQLError(err)) {
+    const code = typeof err.extensions?.code === 'string' ? `${err.extensions.code}: ` : '';
+    return `${code}${err.message}`;
+  }
+  if (isExchangeError(err, 'http')) {
+    return `http ${err.extensions?.statusCode ?? 'error'}: ${err.message}`;
+  }
+  if (isAggregatedError(err)) {
+    return err.errors.map(describeSyncError).join('; ');
+  }
+  if (err instanceof Error) {
+    return err.message;
+  }
+  return String(err);
+}

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/sync/pusher.svelte.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/sync/pusher.svelte.ts
@@ -1,4 +1,4 @@
-import { isAggregatedError, isExchangeError, isGraphQLError } from '@mearie/svelte';
+import { describeSyncError, isPermanentSyncError } from './errors';
 import type { Editor } from '$lib/editor-ffi/editor.svelte';
 import type { PusherEvent, PushStatus } from './types';
 
@@ -6,22 +6,6 @@ const IDLE_MS = 500;
 const MAX_WAIT_MS = 3000;
 const BACKOFF_BASE_MS = 2000;
 const BACKOFF_CAP_MS = 30_000;
-
-const PERMANENT_CODES = new Set(['invalid_changeset_payload']);
-
-function isPermanent(err: unknown): boolean {
-  if (!isAggregatedError(err)) return false;
-  for (const e of err.errors) {
-    if (isGraphQLError(e)) {
-      const code = e.extensions?.code;
-      if (typeof code === 'string' && PERMANENT_CODES.has(code)) return true;
-    } else if (isExchangeError(e, 'http')) {
-      const status = e.extensions?.statusCode;
-      if (typeof status === 'number' && status >= 400 && status < 500) return true;
-    }
-  }
-  return false;
-}
 
 type PusherOpts = {
   editor: Editor;
@@ -108,7 +92,7 @@ export class Pusher {
       await this.opts.pushFn(bundle);
     } catch (err) {
       this.inflight = false;
-      this.opts.onEvent?.({ kind: 'push.error', message: String(err) });
+      this.opts.onEvent?.({ kind: 'push.error', message: describeSyncError(err) });
       this.handleFailure(err);
       return;
     }
@@ -124,9 +108,9 @@ export class Pusher {
   }
 
   private handleFailure(err: unknown): void {
-    if (isPermanent(err)) {
+    if (isPermanentSyncError(err)) {
       this.status = 'error';
-      console.error('Pusher: permanent failure', err);
+      console.error('Pusher: permanent failure', describeSyncError(err), err);
       return;
     }
     this.status = 'retrying';

--- a/crates/editor-core/src/handle/node.rs
+++ b/crates/editor-core/src/handle/node.rs
@@ -1,4 +1,5 @@
 use editor_commands as commands;
+use editor_model::{Node, PlainImageNode, PlainNode};
 
 use crate::editor::Editor;
 use crate::error::EditorError;
@@ -8,6 +9,53 @@ pub fn handle_node_op(editor: &mut Editor, op: NodeOp) -> Result<(), EditorError
     editor.transact(|tr| match op {
         NodeOp::SetAttrs { id, attrs } => {
             tr.set_node(id, attrs)?;
+            Ok(())
+        }
+        NodeOp::SetImageId { id, image_id } => {
+            let doc = tr.doc();
+            let Some(node_ref) = doc.node(id) else {
+                return Err(EditorError::General {
+                    msg: format!("node {id} not found"),
+                });
+            };
+            let Node::Image(image) = node_ref.node() else {
+                return Err(EditorError::General {
+                    msg: format!("node {id} is not an image"),
+                });
+            };
+            let proportion = *image.proportion.get();
+            tr.set_node(
+                id,
+                PlainNode::Image(PlainImageNode {
+                    id: Some(image_id),
+                    upload_id: None,
+                    proportion,
+                }),
+            )?;
+            Ok(())
+        }
+        NodeOp::SetImageProportion { id, proportion } => {
+            let doc = tr.doc();
+            let Some(node_ref) = doc.node(id) else {
+                return Err(EditorError::General {
+                    msg: format!("node {id} not found"),
+                });
+            };
+            let Node::Image(image) = node_ref.node() else {
+                return Err(EditorError::General {
+                    msg: format!("node {id} is not an image"),
+                });
+            };
+            let image_id = image.id.get().clone();
+            let upload_id = image.upload_id.get().clone();
+            tr.set_node(
+                id,
+                PlainNode::Image(PlainImageNode {
+                    id: image_id,
+                    upload_id,
+                    proportion,
+                }),
+            )?;
             Ok(())
         }
         NodeOp::Delete { id } => {
@@ -21,6 +69,7 @@ pub fn handle_node_op(editor: &mut Editor, op: NodeOp) -> Result<(), EditorError
 #[cfg(test)]
 mod tests {
     use editor_macros::state;
+    use editor_model::Node;
     use editor_state::assert_state_eq;
 
     use super::*;
@@ -60,5 +109,56 @@ mod tests {
             op: HistoryOp::Redo,
         });
         assert_state_eq!(editor.state(), &deleted);
+    }
+
+    #[test]
+    fn set_image_proportion_preserves_image_id() {
+        let (initial, img) = state! {
+            doc { root {
+                img: image(id: Some("asset-1".to_string()), proportion: 100)
+            } }
+            selection: (img, 0)
+        };
+        let mut editor = Editor::new_test(initial);
+
+        editor.apply(Message::Node {
+            op: NodeOp::SetImageProportion {
+                id: img,
+                proportion: 40,
+            },
+        });
+
+        let node_ref = editor.state().doc.node(img).expect("image node exists");
+        let Node::Image(image) = node_ref.node() else {
+            panic!("expected image node");
+        };
+        assert_eq!(image.id.get().as_deref(), Some("asset-1"));
+        assert_eq!(*image.proportion.get(), 40);
+    }
+
+    #[test]
+    fn set_image_id_clears_upload_id_and_preserves_proportion() {
+        let (initial, img) = state! {
+            doc { root {
+                img: image(upload_id: Some("upload-1".to_string()), proportion: 55)
+            } }
+            selection: (img, 0)
+        };
+        let mut editor = Editor::new_test(initial);
+
+        editor.apply(Message::Node {
+            op: NodeOp::SetImageId {
+                id: img,
+                image_id: "asset-1".to_string(),
+            },
+        });
+
+        let node_ref = editor.state().doc.node(img).expect("image node exists");
+        let Node::Image(image) = node_ref.node() else {
+            panic!("expected image node");
+        };
+        assert_eq!(image.id.get().as_deref(), Some("asset-1"));
+        assert_eq!(image.upload_id.get(), &None);
+        assert_eq!(*image.proportion.get(), 55);
     }
 }

--- a/crates/editor-core/src/message.rs
+++ b/crates/editor-core/src/message.rs
@@ -139,6 +139,8 @@ pub enum TableOp {
 pub enum NodeOp {
     Delete { id: NodeId },
     SetAttrs { id: NodeId, attrs: PlainNode },
+    SetImageId { id: NodeId, image_id: String },
+    SetImageProportion { id: NodeId, proportion: u32 },
     Table { id: NodeId, op: TableOp },
 }
 

--- a/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
@@ -383,6 +383,7 @@ export interface PlainHorizontalRuleNode {
 export interface PlainImageNode {
     id: string | undefined;
     proportion?: number;
+    upload_id?: string | undefined;
 }
 
 export interface PlainListItemNode {}
@@ -481,7 +482,7 @@ export type Effect = { load_font: { family: string; weight: number; codepoints: 
 
 export type EmbedNodeAttr = { type: "id" } & string | undefined;
 
-export type ExternalElementData = { type: "image"; id: string | undefined; proportion: number } | { type: "file"; id: string | undefined } | { type: "embed"; id: string | undefined } | { type: "archived"; id: string | undefined };
+export type ExternalElementData = { type: "image"; id: string | undefined; upload_id: string | undefined; proportion: number } | { type: "file"; id: string | undefined } | { type: "embed"; id: string | undefined } | { type: "archived"; id: string | undefined };
 
 export type FileNodeAttr = { type: "id" } & string | undefined;
 
@@ -509,7 +510,7 @@ export type HorizontalRuleNodeAttr = { type: "variant" } & HorizontalRuleVariant
 
 export type HorizontalRuleVariant = "line" | "dashed_line" | "circle_line" | "diamond_line" | "circle" | "diamond" | "three_circles" | "three_diamonds" | "zigzag";
 
-export type ImageNodeAttr = ({ type: "id" } & string | undefined) | ({ type: "proportion" } & number);
+export type ImageNodeAttr = ({ type: "id" } & string | undefined) | ({ type: "proportion" } & number) | ({ type: "upload_id" } & string | undefined);
 
 export type InsertionOp = { type: "text"; text: string } | { type: "break"; kind: Break } | { type: "fragment"; fragment: Fragment };
 
@@ -535,7 +536,7 @@ export type NodeAttr = { type: "root"; attr: RootNodeAttr } | { type: "paragraph
 
 export type NodeId = string;
 
-export type NodeOp = { type: "delete"; id: NodeId } | { type: "set_attrs"; id: NodeId; attrs: PlainNode } | { type: "table"; id: NodeId; op: TableOp };
+export type NodeOp = { type: "delete"; id: NodeId } | { type: "set_attrs"; id: NodeId; attrs: PlainNode } | { type: "set_image_id"; id: NodeId; image_id: string } | { type: "set_image_proportion"; id: NodeId; proportion: number } | { type: "table"; id: NodeId; op: TableOp };
 
 export type OrderedListNodeAttr = void;
 

--- a/crates/editor-ffi/pkg/server/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/server/editor_ffi.d.ts
@@ -410,6 +410,7 @@ export interface PlainHorizontalRuleNode {
 export interface PlainImageNode {
     id: string | undefined;
     proportion?: number;
+    upload_id?: string | undefined;
 }
 
 export interface PlainListItemNode {}
@@ -508,7 +509,7 @@ export type Effect = { load_font: { family: string; weight: number; codepoints: 
 
 export type EmbedNodeAttr = { type: "id" } & string | undefined;
 
-export type ExternalElementData = { type: "image"; id: string | undefined; proportion: number } | { type: "file"; id: string | undefined } | { type: "embed"; id: string | undefined } | { type: "archived"; id: string | undefined };
+export type ExternalElementData = { type: "image"; id: string | undefined; upload_id: string | undefined; proportion: number } | { type: "file"; id: string | undefined } | { type: "embed"; id: string | undefined } | { type: "archived"; id: string | undefined };
 
 export type FileNodeAttr = { type: "id" } & string | undefined;
 
@@ -536,7 +537,7 @@ export type HorizontalRuleNodeAttr = { type: "variant" } & HorizontalRuleVariant
 
 export type HorizontalRuleVariant = "line" | "dashed_line" | "circle_line" | "diamond_line" | "circle" | "diamond" | "three_circles" | "three_diamonds" | "zigzag";
 
-export type ImageNodeAttr = ({ type: "id" } & string | undefined) | ({ type: "proportion" } & number);
+export type ImageNodeAttr = ({ type: "id" } & string | undefined) | ({ type: "proportion" } & number) | ({ type: "upload_id" } & string | undefined);
 
 export type InsertionOp = { type: "text"; text: string } | { type: "break"; kind: Break } | { type: "fragment"; fragment: Fragment };
 
@@ -562,7 +563,7 @@ export type NodeAttr = { type: "root"; attr: RootNodeAttr } | { type: "paragraph
 
 export type NodeId = string;
 
-export type NodeOp = { type: "delete"; id: NodeId } | { type: "set_attrs"; id: NodeId; attrs: PlainNode } | { type: "table"; id: NodeId; op: TableOp };
+export type NodeOp = { type: "delete"; id: NodeId } | { type: "set_attrs"; id: NodeId; attrs: PlainNode } | { type: "set_image_id"; id: NodeId; image_id: string } | { type: "set_image_proportion"; id: NodeId; proportion: number } | { type: "table"; id: NodeId; op: TableOp };
 
 export type OrderedListNodeAttr = void;
 

--- a/crates/editor-model/src/nodes/image.rs
+++ b/crates/editor-model/src/nodes/image.rs
@@ -7,6 +7,8 @@ pub struct ImageNode {
     #[node_attr(default = "100u32")]
     #[plain(ffi(default = "100"), serde(default = "default_proportion"))]
     pub proportion: LwwReg<u32>,
+    #[plain(serde(default))]
+    pub upload_id: LwwReg<Option<String>>,
 }
 
 fn default_proportion() -> u32 {

--- a/crates/editor-model/src/plain.rs
+++ b/crates/editor-model/src/plain.rs
@@ -410,6 +410,7 @@ mod tests {
                 modifiers: BTreeMap::new(),
                 node: PlainNode::Image(PlainImageNode {
                     id: Some("img-001".to_string()),
+                    upload_id: None,
                     proportion: 50,
                 }),
             },

--- a/crates/editor-transaction/tests/transaction_acceptance.rs
+++ b/crates/editor-transaction/tests/transaction_acceptance.rs
@@ -341,6 +341,7 @@ mod tests {
         let plain_before = state.doc.to_plain();
         let new_node = editor_model::PlainNode::Image(editor_model::PlainImageNode {
             id: Some("new-image-id".to_string()),
+            upload_id: None,
             proportion: 50,
         });
         let old_node = state.doc.get_entry(im1).unwrap().node.to_plain();

--- a/crates/editor-view/src/external.rs
+++ b/crates/editor-view/src/external.rs
@@ -11,10 +11,20 @@ use crate::paginate::{LayoutContent, LayoutNode, LayoutTree};
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ExternalElementData {
-    Image { id: Option<String>, proportion: u32 },
-    File { id: Option<String> },
-    Embed { id: Option<String> },
-    Archived { id: Option<String> },
+    Image {
+        id: Option<String>,
+        upload_id: Option<String>,
+        proportion: u32,
+    },
+    File {
+        id: Option<String>,
+    },
+    Embed {
+        id: Option<String>,
+    },
+    Archived {
+        id: Option<String>,
+    },
 }
 
 #[ffi]
@@ -107,6 +117,7 @@ fn external_element_data(doc: &Doc, node_id: NodeId) -> Option<ExternalElementDa
     match doc.node(node_id)?.node() {
         Node::Image(img) => Some(ExternalElementData::Image {
             id: img.id.get().clone(),
+            upload_id: img.upload_id.get().clone(),
             proportion: *img.proportion.get(),
         }),
         Node::File(file) => Some(ExternalElementData::File {


### PR DESCRIPTION
새 에디터의 이미지 노드가 자리만 잡혀 있고 실제 업로드와 표시는 동작하지 않아, 이를 동작하도록 구현했습니다.  
업로드 중에도 노드와 파일이 안정적으로 연결되도록 모델에 upload_id를 도입했고,  
UI는 기존 레거시 에디터의 이미지 구현을 참고했습니다.  
또한 이미지 업로드 같은 무거운 변경이 늘어나면 서버 측 changeset 검증 실패가 일어날 가능성이 커지고   
그 실패가 사용자에게 그대로 드러날 수 있어서 잘못된 변경 사항은 서버가 미리 검증해 거절하도록 했습니다.