### PR TITLE
v2 문서 생성 시 route 오류 수정 - v2 리다이렉션

### DIFF
--- a/apps/website/src/routes/website/(dashboard)/[slug]/+page.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/+page.ts
@@ -1,3 +1,4 @@
+import { redirect } from '@sveltejs/kit';
 import { loadQuery } from '$lib/graphql';
 import { graphql } from '$mearie';
 import type { PageLoad } from './$types';
@@ -20,6 +21,17 @@ export const load: PageLoad = async (event) => {
           site {
             id
           }
+
+          node {
+            __typename
+
+            ... on Document {
+              id
+              state {
+                __typename
+              }
+            }
+          }
         }
 
         ...WidgetGroup_query
@@ -27,6 +39,10 @@ export const load: PageLoad = async (event) => {
     `),
     { slug, isHome },
   );
+
+  if (!isHome && query.data.entity?.node.__typename === 'Document' && query.data.entity.node.state) {
+    redirect(307, `/${slug}/v2`);
+  }
 
   return { query };
 };


### PR DESCRIPTION
v2 문서를 만든 직후 /{slug}/v2 URL이 잠깐 보였다가 /{slug} 로 바뀌면서 레거시 에디터로 전환되는 현상.
다른 페이지로 이탈했다가 사이드바/검색에서 v2 문서를 다시 클릭하면 항상 레거시 에디터가 열리고 있었습니다.


* 레거시 라우트([slug]/+page.ts) 의 load 함수에서 v2 문서 감지 시 /{slug}/v2 로 서버사이드 리다이렉트.

