### PR TITLE
selection collapse 버그 수정

### DIFF
--- a/crates/editor-core/src/handle/navigation.rs
+++ b/crates/editor-core/src/handle/navigation.rs
@@ -816,6 +816,97 @@ mod tests {
         assert_eq!(s.head.offset, 6);
     }
 
+    // Backward selection (head at sorted start) across two paragraphs;
+    // arrow-right must collapse to the sorted end, not step one grapheme
+    // from head.
+    #[test]
+    fn arrow_right_from_backward_multi_paragraph_text_range_collapses_to_sorted_end() {
+        let (state, _, p2) = state! {
+            doc {
+                root {
+                    paragraph { p1: text("hello") }
+                    paragraph { p2: text("world") }
+                }
+            }
+            selection: (p2, 3) -> (p1, 2)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.view.layout(&editor.state.doc);
+
+        arrow(
+            &mut editor,
+            Movement::Grapheme {
+                direction: Direction::Forward,
+            },
+        );
+
+        let s = editor.state().selection;
+        assert!(s.is_collapsed());
+        assert_eq!(s.head.node_id, p2);
+        assert_eq!(s.head.offset, 3);
+    }
+
+    // Multi-node range at root level (not a unit selection): arrow-left
+    // lands at the caret position before the sorted-start block boundary,
+    // i.e. the end of the previous leaf.
+    #[test]
+    fn arrow_left_from_multi_node_container_selection_lands_before_block_boundary() {
+        let (state, _, before) = state! {
+            doc {
+                r: root {
+                    paragraph { before: text("before") }
+                    paragraph { text("a") }
+                    paragraph { text("b") }
+                    paragraph { text("after") }
+                }
+            }
+            selection: (r, 1) -> (r, 3)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.view.layout(&editor.state.doc);
+
+        arrow(
+            &mut editor,
+            Movement::Grapheme {
+                direction: Direction::Backward,
+            },
+        );
+
+        let s = editor.state().selection;
+        assert!(s.is_collapsed());
+        assert_eq!(s.head.node_id, before);
+        assert_eq!(s.head.offset, 6);
+    }
+
+    // Word Left across two paragraphs: stepping movement runs from the
+    // sorted start, not from head, and actually advances by a word.
+    #[test]
+    fn word_left_from_multi_paragraph_text_range_moves_word_from_sorted_start() {
+        let (state, p1, _) = state! {
+            doc {
+                root {
+                    paragraph { p1: text("hello world") }
+                    paragraph { p2: text("foo bar") }
+                }
+            }
+            selection: (p1, 8) -> (p2, 3)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.view.layout(&editor.state.doc);
+
+        arrow(
+            &mut editor,
+            Movement::Word {
+                direction: Direction::Backward,
+            },
+        );
+
+        let s = editor.state().selection;
+        assert!(s.is_collapsed());
+        assert_eq!(s.head.node_id, p1);
+        assert_eq!(s.head.offset, 6);
+    }
+
     #[test]
     fn arrow_left_from_block_boundary_selection_lands_at_previous_leaf_end() {
         let (state, _, prev) = state! {

--- a/crates/editor-core/src/handle/navigation.rs
+++ b/crates/editor-core/src/handle/navigation.rs
@@ -143,42 +143,36 @@ pub fn handle_navigation_op(editor: &mut Editor, op: NavigationOp) -> Result<(),
                         resolved.to()
                     };
                     let left_or_right = matches!(movement, Movement::Grapheme { .. });
-                    let base_position = Position::from(base);
 
-                    let target = if left_or_right && base.is_inline_position() {
-                        // Left/Right from inline content only collapses the range.
-                        Selection::collapsed(base_position)
-                    } else if !left_or_right
-                        && can_stop_at_gap
-                        && let Some(sel) =
-                            gap_cursor_from_inner_edge(editor, base_position, backward)
-                    {
-                        // Vertical/word/block movement can stop at an adjacent
-                        // gap before asking the view for geometric movement.
-                        sel
+                    let target = if base.is_inline_position() {
+                        let base_position = Position::from(base);
+                        if left_or_right {
+                            Selection::collapsed(base_position)
+                        } else if can_stop_at_gap
+                            && let Some(sel) =
+                                gap_cursor_from_inner_edge(editor, base_position, backward)
+                        {
+                            // Monolithic inner-edge endpoint behaves like a
+                            // collapsed caret at that edge: gap cursor entry.
+                            sel
+                        } else {
+                            view_movement_or_collapse(editor, &base_position, &movement)
+                        }
                     } else {
-                        let view_target = {
-                            let resource_guard = editor.resource.lock().unwrap();
-                            editor
-                                .view
-                                .resolve_movement(&base_position, &movement, &resource_guard)
-                        };
-
-                        match view_target {
-                            Some(sel) => sel,
-                            None if base.is_block_position() => {
-                                // Block positions are container boundaries, so
-                                // the view has no caret rect to move from.
-                                Selection::collapsed(move_from_block_position(
-                                    editor, base, !backward,
-                                ))
-                            }
-                            None => {
-                                // Inline positions have a caret base. If the
-                                // view has no destination, the range simply
-                                // collapses to that base.
-                                Selection::collapsed(base_position)
-                            }
+                        // A block boundary is an abstract position with no
+                        // drawable caret, so the view cannot resolve movement
+                        // from it. Descend into the real caret inside the
+                        // adjacent text block first, then either stop there
+                        // (Left/Right) or run the stepping movement from it.
+                        let landed = move_from_block_position(editor, base, !backward);
+                        if left_or_right {
+                            Selection::collapsed(landed)
+                        } else if can_stop_at_gap
+                            && let Some(sel) = gap_cursor_from_inner_edge(editor, landed, backward)
+                        {
+                            sel
+                        } else {
+                            view_movement_or_collapse(editor, &landed, &movement)
                         }
                     };
 
@@ -295,6 +289,23 @@ fn gap_cursor_from_inner_edge(
         };
     }
     None
+}
+
+/// Ask the view to resolve `movement` from `base`. If the view has no
+/// destination, the range simply collapses to `base` — a no-op step from
+/// a caret-capable position is still a valid collapse.
+fn view_movement_or_collapse(
+    editor: &mut Editor,
+    base: &Position,
+    movement: &Movement,
+) -> Selection {
+    let view_target = {
+        let resource_guard = editor.resource.lock().unwrap();
+        editor
+            .view
+            .resolve_movement(base, movement, &resource_guard)
+    };
+    view_target.unwrap_or_else(|| Selection::collapsed(*base))
 }
 
 fn move_from_block_position(


### PR DESCRIPTION
선택 영역(non-collapsed selection)에서 화살표 키를 눌렀을 때 동작이 레거시 에디터와 동작이 달랐던 문제 해결 PR입니다.

- 기존 V2: 드래그 방향에 따라 한 글자씩 더 이동 (head 위치 기준으로 동작)

### 변경사항
* `handle_navigation_op` 안의 non-collapsed 분기를 두 갈래로 정리:

1. **기준점(base)을 잡는 규칙**: 왼쪽으로 가는 키면 선택의 시각적 시작(`from`), 오른쪽이면 끝(`to`). 드래그 방향(anchor/head 위치)과 무관.
2. **base에서 뭘 할지**:
   - base가 텍스트 안이고 화살표면 → 그 자리에 collapse, 추가 이동 없음
   - base가 블록 경계면 → 옆의 caret 가능한 위치로 먼저 내려간 다음 그 자리에 collapse
   - Word/Up/Down 같은 단위 이동은 base(또는 내려간 caret)에서 정상적으로 한 단위 이동

기존 동작(gap cursor 진입, Shift+화살표 확장 등)은 모두 보존됩니다.