### PR TITLE
TR-69 웹 v2 이미지 업로드와 편집 기능 구현

### DIFF
--- a/apps/website/src/lib/editor-ffi/components/Editor.svelte
+++ b/apps/website/src/lib/editor-ffi/components/Editor.svelte
@@ -10,6 +10,7 @@
   import { loadFonts } from '../fonts';
   import { handle } from '../handlers';
   import { handlePointerCancel, handlePointerDown, handlePointerMove, handlePointerUp } from '../handlers/pointer';
+  import { getDataTransferImageFiles } from '../handlers/upload';
   import Caret from './Caret.svelte';
   import CaretPositioned from './CaretPositioned.svelte';
   import Input from './Input.svelte';
@@ -88,6 +89,22 @@
     ctx.editor?.destroy();
     ctx.editor = undefined;
   });
+
+  const handleDrop = (event: DragEvent) => {
+    event.preventDefault();
+
+    const editor = ctx.editor;
+    if (!editor) {
+      return;
+    }
+
+    const files = getDataTransferImageFiles(event.dataTransfer);
+    if (files.length === 0) {
+      return;
+    }
+
+    editor.insertImagesFromDrop(files, event.clientX, event.clientY);
+  };
 </script>
 
 <div
@@ -117,6 +134,8 @@
       if (ctx.editor) ctx.editor.scrollContainerEl = undefined;
     };
   }}
+  ondragover={(event) => event.preventDefault()}
+  ondrop={handleDrop}
   onfocusin={() => ctx.editor?.focus()}
   onfocusout={() => {
     if (!window.document.hasFocus()) return;

--- a/apps/website/src/lib/editor-ffi/components/ExternalElement.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ExternalElement.svelte
@@ -6,9 +6,10 @@
   import ArchiveIcon from '~icons/lucide/archive';
   import FileIcon from '~icons/lucide/file';
   import FileUpIcon from '~icons/lucide/file-up';
-  import ImageIcon from '~icons/lucide/image';
   import { THEME_COLORS } from '$lib/editor/theme';
+  import { getExternalElementPlaceholderLabel } from '$lib/editor-ffi/image';
   import { getEditorContext } from '../editor.svelte';
+  import ExternalImage from './ExternalImage.svelte';
   import type { ExternalElement } from '@typie/editor-ffi/browser';
   import type { Component } from 'svelte';
 
@@ -32,19 +33,24 @@
   const selectionColor = $derived(THEME_COLORS[themeVariant].selection);
   const selectionOpacity = $derived(ctx.editor?.focused ? SELECTION_FOCUSED_ALPHA : SELECTION_UNFOCUSED_ALPHA);
 
-  const meta = $derived.by<{ icon: Component; label: string }>(() => {
+  const meta = $derived.by<{ icon: Component; label: string } | null>(() => {
+    const label = getExternalElementPlaceholderLabel(element.data);
+    if (!label) {
+      return null;
+    }
+
     switch (element.data.type) {
       case 'image': {
-        return { icon: ImageIcon, label: '이미지' };
+        return null;
       }
       case 'file': {
-        return { icon: FileIcon, label: '파일' };
+        return { icon: FileIcon, label };
       }
       case 'embed': {
-        return { icon: FileUpIcon, label: '임베드' };
+        return { icon: FileUpIcon, label };
       }
       case 'archived': {
-        return { icon: ArchiveIcon, label: '보관된 블록' };
+        return { icon: ArchiveIcon, label };
       }
     }
   });
@@ -93,33 +99,37 @@
   data-external-element
   data-node-id={element.node_id}
 >
-  <div bind:this={containerEl} class={css({ width: 'full', minHeight: '48px' })}>
-    <div
-      class={flex({
-        align: 'center',
-        gap: '12px',
-        width: 'full',
-        minHeight: '48px',
-        paddingX: '14px',
-        paddingY: '12px',
-        borderRadius: '4px',
-        backgroundColor: 'surface.muted',
-        color: 'text.disabled',
-        fontSize: '14px',
-      })}
-    >
-      <Icon class={css({ flexShrink: '0' })} icon={meta.icon} size={20} />
-      <span
-        class={css({
-          minWidth: '0',
-          overflow: 'hidden',
-          whiteSpace: 'nowrap',
-          textOverflow: 'ellipsis',
+  <div bind:this={containerEl} class={css({ width: 'full' })}>
+    {#if element.data.type === 'image'}
+      <ExternalImage {element} />
+    {:else if meta}
+      <div
+        class={flex({
+          align: 'center',
+          gap: '12px',
+          width: 'full',
+          minHeight: '48px',
+          paddingX: '14px',
+          paddingY: '12px',
+          borderRadius: '4px',
+          backgroundColor: 'surface.muted',
+          color: 'text.disabled',
+          fontSize: '14px',
         })}
       >
-        {meta.label}
-      </span>
-    </div>
+        <Icon class={css({ flexShrink: '0' })} icon={meta.icon} size={20} />
+        <span
+          class={css({
+            minWidth: '0',
+            overflow: 'hidden',
+            whiteSpace: 'nowrap',
+            textOverflow: 'ellipsis',
+          })}
+        >
+          {meta.label}
+        </span>
+      </div>
+    {/if}
   </div>
 
   {#if element.is_selected}

--- a/apps/website/src/lib/editor-ffi/components/ExternalImage.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ExternalImage.svelte
@@ -1,0 +1,422 @@
+<script lang="ts">
+  import { flip, hide } from '@floating-ui/dom';
+  import { createQuery } from '@mearie/svelte';
+  import { css } from '@typie/styled-system/css';
+  import { center, flex } from '@typie/styled-system/patterns';
+  import { createFloatingActions } from '@typie/ui/actions';
+  import { Icon, Img, Menu, MenuItem, RingSpinner } from '@typie/ui/components';
+  import { Toast } from '@typie/ui/notification';
+  import EllipsisIcon from '~icons/lucide/ellipsis';
+  import ImageIcon from '~icons/lucide/image';
+  import Trash2Icon from '~icons/lucide/trash-2';
+  import ZoomInIcon from '~icons/lucide/zoom-in';
+  import ExternalImageEnlarge from '$lib/components/editor/external/ExternalImageEnlarge.svelte';
+  import { uploadBlobAsImage } from '$lib/utils/blob.svelte';
+  import { graphql } from '$mearie';
+  import { getEditorContext } from '../editor.svelte';
+  import {
+    computeImagePresentation,
+    createDeleteImageMessage,
+    createSetImageAttrsMessage,
+    processImageUpload,
+    resolveResizedImageProportion,
+  } from '../image';
+  import type { ExternalElement, ExternalElementData } from '@typie/editor-ffi/browser';
+
+  type ImageData = Extract<ExternalElementData, { type: 'image' }>;
+
+  type Props = {
+    element: ExternalElement;
+  };
+
+  let { element }: Props = $props();
+
+  const ctx = getEditorContext();
+  const editor = $derived(ctx.editor);
+
+  let isResizing = $state(false);
+  let liveProportion = $state<number | null>(null);
+  let initialResizeData: { x: number; width: number; reverse: boolean } | null = null;
+  let enlarged = $state(false);
+  let containerEl = $state<HTMLDivElement>();
+
+  const imageData = $derived(element.data as ImageData);
+
+  const imageQuery = createQuery(
+    graphql(`
+      query FfiExternalImage_Query($imageId: ID!) {
+        image(imageId: $imageId) {
+          id
+          url
+          originalUrl
+          width
+          height
+          ratio
+          placeholder
+        }
+      }
+    `),
+    () => ({ imageId: imageData.id ?? '' }),
+    () => ({ skip: !imageData.id }),
+  );
+
+  const asset = $derived(imageData.id ? (editor?.imageAssets.get(imageData.id) ?? imageQuery.data?.image ?? undefined) : undefined);
+  const inflight = $derived(editor?.inflightImages.get(element.node_id));
+
+  const activeProportion = $derived(liveProportion ?? imageData.proportion ?? 100);
+
+  const presentation = $derived(
+    computeImagePresentation({
+      proportion: activeProportion,
+      boundsWidth: element.bounds.width,
+      imageId: imageData.id,
+      asset: asset ?? undefined,
+      inflight: inflight ?? undefined,
+    }),
+  );
+
+  const { anchor, floating } = createFloatingActions({
+    placement: 'bottom',
+    offset: 4,
+    middleware: [flip(), hide()],
+  });
+
+  $effect(() => {
+    if (!presentation.hasImage) {
+      enlarged = false;
+    }
+  });
+
+  const dispatchProportion = (nextProportion: number) => {
+    if (!editor) return;
+    editor.enqueue(
+      createSetImageAttrsMessage({
+        nodeId: element.node_id,
+        currentId: imageData.id,
+        currentProportion: imageData.proportion || 100,
+        nextProportion,
+      }),
+    );
+  };
+
+  const handleDelete = () => {
+    if (!editor) return;
+    editor.pendingImageFilesByNode.delete(element.node_id);
+    editor.inflightImages.delete(element.node_id);
+    editor.enqueue(createDeleteImageMessage(element.node_id));
+    editor.focus();
+  };
+
+  const handleResizeStart = (event: PointerEvent, reverse: boolean) => {
+    const target = event.currentTarget as HTMLElement;
+    target.setPointerCapture(event.pointerId);
+    event.stopPropagation();
+    event.preventDefault();
+
+    isResizing = true;
+    initialResizeData = {
+      x: event.clientX,
+      width: presentation.width,
+      reverse,
+    };
+  };
+
+  const handleResize = (event: PointerEvent) => {
+    const target = event.currentTarget as HTMLElement;
+    if (!target.hasPointerCapture(event.pointerId) || !initialResizeData) {
+      return;
+    }
+
+    const boundsWidth = element.bounds.width;
+    if (boundsWidth <= 0) return;
+
+    const resized = resolveResizedImageProportion({
+      boundsWidth,
+      originalWidth: presentation.originalWidth,
+      initialWidth: initialResizeData.width,
+      initialClientX: initialResizeData.x,
+      nextClientX: event.clientX,
+      reverse: initialResizeData.reverse,
+    });
+    liveProportion = resized.proportion;
+  };
+
+  const handleResizeEnd = (event: PointerEvent) => {
+    const target = event.currentTarget as HTMLElement;
+    target.releasePointerCapture(event.pointerId);
+
+    const finalProportion = liveProportion;
+    isResizing = false;
+    liveProportion = null;
+
+    if (finalProportion != null) {
+      dispatchProportion(finalProportion);
+    }
+    editor?.focus();
+  };
+
+  $effect(() => {
+    if (!isResizing) {
+      liveProportion = null;
+    }
+  });
+
+  const getImageDimensions = (src: string): Promise<{ width: number; height: number }> =>
+    new Promise((resolve, reject) => {
+      const img = new Image();
+      img.addEventListener('load', () => resolve({ width: img.naturalWidth, height: img.naturalHeight }));
+      img.addEventListener('error', () => reject(new Error('Failed to load image')));
+      img.src = src;
+    });
+
+  const runUpload = async (file: File) => {
+    const currentEditor = editor;
+    if (!currentEditor) {
+      return;
+    }
+
+    await processImageUpload({
+      file,
+      nodeId: element.node_id,
+      currentId: imageData.id,
+      currentProportion: imageData.proportion || 100,
+      editor: currentEditor,
+      getImageDimensions,
+      uploadImage: uploadBlobAsImage,
+      createObjectUrl: URL.createObjectURL,
+      revokeObjectUrl: URL.revokeObjectURL,
+      onFailure: (err) => {
+        console.error('Image upload failed:', err);
+        Toast.error(`${file.name} 이미지 업로드에 실패했습니다.`);
+      },
+    });
+  };
+
+  $effect(() => {
+    const currentEditor = editor;
+    if (!currentEditor || imageData.id) {
+      return;
+    }
+
+    const file = currentEditor.dequeuePendingImageFile(element.node_id);
+    if (file) {
+      void runUpload(file);
+    }
+  });
+
+  const handlePickImage = () => {
+    const picker = document.createElement('input');
+    picker.type = 'file';
+    picker.accept = 'image/*';
+
+    picker.addEventListener('change', () => {
+      const file = picker.files?.[0];
+      if (!file) return;
+      void runUpload(file);
+    });
+
+    picker.click();
+  };
+</script>
+
+{#if presentation.hasImage}
+  <div
+    bind:this={containerEl}
+    style:width={`${presentation.width}px`}
+    style:height={`${presentation.height}px`}
+    class={css({ position: 'relative', margin: '[0 auto]' })}
+  >
+    <Img
+      style={css.raw({ width: 'full', borderRadius: '4px' })}
+      alt="본문 이미지"
+      placeholder={presentation.placeholder ?? undefined}
+      progressive
+      ratio={presentation.originalHeight > 0 ? presentation.originalWidth / presentation.originalHeight : undefined}
+      size="full"
+      url={presentation.url ?? ''}
+    />
+
+    {#if presentation.isUploading}
+      <div class={center({ position: 'absolute', inset: '0', backgroundColor: 'white/50' })}>
+        <RingSpinner style={css.raw({ size: '24px', color: 'text.disabled' })} />
+      </div>
+    {/if}
+
+    {#if element.is_selected}
+      <div class={css({ position: 'absolute', top: '10px', right: '10px', display: 'flex', gap: '8px', zIndex: '10' })}>
+        <button
+          class={css({
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            borderRadius: '4px',
+            size: '28px',
+            color: 'text.bright',
+            backgroundColor: '[#363839/70]',
+          })}
+          aria-label="이미지 확대"
+          onclick={() => (enlarged = true)}
+          onpointerdown={(event) => event.stopPropagation()}
+          type="button"
+        >
+          <Icon icon={ZoomInIcon} size={16} />
+        </button>
+
+        <button
+          class={css({
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            borderRadius: '4px',
+            size: '28px',
+            color: 'text.bright',
+            backgroundColor: '[#363839/70]',
+          })}
+          aria-label="이미지 삭제"
+          onclick={handleDelete}
+          onpointerdown={(event) => event.stopPropagation()}
+          type="button"
+        >
+          <Icon icon={Trash2Icon} size={16} />
+        </button>
+      </div>
+
+      <div class={flex({ position: 'absolute', top: '0', bottom: '0', left: '10px', alignItems: 'center', pointerEvents: 'none' })}>
+        <button
+          class={css({
+            borderRadius: '4px',
+            backgroundColor: 'white/50',
+            mixBlendMode: 'difference',
+            width: '8px',
+            height: '1/3',
+            maxHeight: '72px',
+            cursor: 'col-resize',
+            zIndex: '10',
+            pointerEvents: 'auto',
+          })}
+          aria-label="이미지 크기 조절"
+          onpointerdown={(event) => handleResizeStart(event, true)}
+          onpointermove={handleResize}
+          onpointerup={handleResizeEnd}
+          type="button"
+        ></button>
+      </div>
+
+      <div class={flex({ position: 'absolute', top: '0', bottom: '0', right: '10px', alignItems: 'center', pointerEvents: 'none' })}>
+        <button
+          class={css({
+            borderRadius: '4px',
+            backgroundColor: 'white/50',
+            mixBlendMode: 'difference',
+            width: '8px',
+            height: '1/3',
+            maxHeight: '72px',
+            cursor: 'col-resize',
+            zIndex: '10',
+            pointerEvents: 'auto',
+          })}
+          aria-label="이미지 크기 조절"
+          onpointerdown={(event) => handleResizeStart(event, false)}
+          onpointermove={handleResize}
+          onpointerup={handleResizeEnd}
+          type="button"
+        ></button>
+      </div>
+    {/if}
+  </div>
+{:else}
+  <div
+    class={flex({
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      borderRadius: '4px',
+      backgroundColor: 'surface.muted',
+      width: 'full',
+      height: '48px',
+    })}
+    use:anchor
+  >
+    <div
+      class={flex({
+        align: 'center',
+        gap: '12px',
+        paddingX: '14px',
+        paddingY: '12px',
+        fontSize: '14px',
+        color: 'text.disabled',
+      })}
+    >
+      <Icon icon={ImageIcon} size={20} />
+      {presentation.isResolvingAsset ? '이미지를 불러오는 중...' : '이미지'}
+    </div>
+
+    {#if presentation.isResolvingAsset}
+      <div class={css({ marginRight: '14px' })}>
+        <RingSpinner style={css.raw({ size: '16px', color: 'text.disabled' })} />
+      </div>
+    {:else}
+      <div onpointerdown={(event) => event.stopPropagation()} role="none">
+        <Menu>
+          {#snippet button({ open }: { open: boolean })}
+            <div
+              class={css(
+                {
+                  marginRight: '12px',
+                  borderRadius: '4px',
+                  padding: '2px',
+                  color: 'text.disabled',
+                  _hover: { backgroundColor: 'interactive.hover' },
+                },
+                open && { backgroundColor: 'interactive.hover' },
+              )}
+            >
+              <Icon icon={EllipsisIcon} size={20} />
+            </div>
+          {/snippet}
+
+          <MenuItem onclick={handleDelete} variant="danger">
+            <Icon icon={Trash2Icon} size={12} />
+            <span>삭제</span>
+          </MenuItem>
+        </Menu>
+      </div>
+    {/if}
+  </div>
+{/if}
+
+{#if element.is_selected && !presentation.hasImage && !presentation.isResolvingAsset}
+  <button
+    class={flex({
+      alignItems: 'center',
+      gap: '6px',
+      borderWidth: '1px',
+      borderRadius: '8px',
+      paddingX: '12px',
+      paddingY: '6px',
+      fontSize: '13px',
+      color: 'text.muted',
+      backgroundColor: 'surface.default',
+      boxShadow: 'small',
+      transition: 'common',
+      zIndex: 'editor',
+      _hover: { backgroundColor: 'interactive.hover' },
+    })}
+    onclick={handlePickImage}
+    onpointerdown={(event) => event.stopPropagation()}
+    type="button"
+    use:floating
+  >
+    <Icon icon={ImageIcon} size={14} />
+    이미지 선택
+  </button>
+{/if}
+
+{#if enlarged && presentation.hasImage && presentation.url && containerEl}
+  <ExternalImageEnlarge
+    onclose={() => (enlarged = false)}
+    placeholder={presentation.placeholder ?? undefined}
+    ratio={presentation.originalHeight > 0 ? presentation.originalWidth / presentation.originalHeight : undefined}
+    referenceEl={containerEl}
+    url={presentation.url}
+  />
+{/if}

--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -1,7 +1,10 @@
 import { createContext, tick, untrack } from 'svelte';
+import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 import { match } from 'ts-pattern';
 import { initWasm, wasm } from '$lib/wasm-ffi.svelte';
 import { fontDataMissingHandler } from './fonts';
+import { assignPendingImageFiles } from './handlers/upload';
+import { createDropImageSelectionMessages } from './image';
 import { register, unregister } from './registry';
 import type {
   BlockState,
@@ -21,6 +24,21 @@ import type {
   Viewport,
 } from '@typie/editor-ffi/browser';
 import type { EditorEventListener } from './types';
+
+export type ImageAsset = {
+  id: string;
+  url: string;
+  originalUrl: string;
+  width: number;
+  height: number;
+  placeholder?: string | null;
+};
+
+export type InflightImage = {
+  url: string;
+  width: number;
+  height: number;
+};
 
 let wasmInitPromise: Promise<void> | null = null;
 
@@ -71,6 +89,11 @@ export class Editor {
   #pointerStyle = $state<PointerStyle>('default');
   #lastPointerClient: { x: number; y: number } | null = null;
   #pointerStyleDomRefreshQueued = false;
+
+  #pendingImageFiles: File[] = [];
+  imageAssets = new SvelteMap<string, ImageAsset>();
+  inflightImages = new SvelteMap<string, InflightImage>();
+  pendingImageFilesByNode = new SvelteMap<string, File>();
 
   private constructor() {
     // no-op
@@ -291,6 +314,80 @@ export class Editor {
     this.#scheduleTick();
   }
 
+  insertImagesFromFiles(files: Iterable<File>): boolean {
+    let handled = false;
+
+    for (const file of files) {
+      if (!file.type.startsWith('image/')) {
+        continue;
+      }
+
+      this.#pendingImageFiles.push(file);
+      this.enqueue({
+        type: 'insertion',
+        op: { type: 'fragment', fragment: { node: { type: 'image', id: undefined } } },
+      });
+      handled = true;
+    }
+
+    if (handled) {
+      this.focus();
+    }
+
+    return handled;
+  }
+
+  insertImagesFromDrop(files: Iterable<File>, clientX: number, clientY: number): boolean {
+    const local = this.clientToLocal(clientX, clientY);
+    for (const message of createDropImageSelectionMessages(local)) {
+      this.enqueue(message);
+    }
+    return this.insertImagesFromFiles(files);
+  }
+
+  dequeuePendingImageFile(nodeId: string): File | undefined {
+    const file = this.pendingImageFilesByNode.get(nodeId);
+    if (file) {
+      this.pendingImageFilesByNode.delete(nodeId);
+    }
+    return file;
+  }
+
+  #reconcilePendingImageFiles(): void {
+    const imageElements = this.#externalElements.filter((element) => element.data.type === 'image');
+
+    const validNodeIds = new SvelteSet<string>();
+    for (const element of imageElements) {
+      if (element.data.type === 'image' && !element.data.id) {
+        validNodeIds.add(element.node_id);
+      }
+    }
+    // snapshot keys before mutating the map below
+    // eslint-disable-next-line unicorn/no-useless-spread
+    for (const nodeId of [...this.pendingImageFilesByNode.keys()]) {
+      if (!validNodeIds.has(nodeId)) {
+        this.pendingImageFilesByNode.delete(nodeId);
+      }
+    }
+
+    if (this.#pendingImageFiles.length === 0) {
+      return;
+    }
+
+    const candidates = imageElements.map((element) => ({
+      nodeId: element.node_id,
+      imageId: element.data.type === 'image' ? element.data.id : undefined,
+      assigned: this.pendingImageFilesByNode.has(element.node_id),
+      inflight: this.inflightImages.has(element.node_id),
+    }));
+
+    const { assignments, remainingFiles } = assignPendingImageFiles(candidates, this.#pendingImageFiles);
+    this.#pendingImageFiles = remainingFiles;
+    for (const { nodeId, file } of assignments) {
+      this.pendingImageFilesByNode.set(nodeId, file);
+    }
+  }
+
   #scheduleTick(): void {
     if (!this.#queued) {
       this.#queued = true;
@@ -385,6 +482,7 @@ export class Editor {
 
     if (fields.includes('external_elements')) {
       this.#externalElements = this.#wasm.external_elements();
+      this.#reconcilePendingImageFiles();
     }
 
     if (fields.includes('root_attrs')) {

--- a/apps/website/src/lib/editor-ffi/handlers/clipboard.test.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/clipboard.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest';
+import { handlePaste } from './clipboard';
+import type { Editor } from '../editor.svelte';
+
+const imageFile = (name = 'image.png') => new File(['x'], name, { type: 'image/png' });
+
+const makeEditor = (overrides: Partial<Editor> = {}) =>
+  ({
+    insertImagesFromFiles: vi.fn().mockReturnValue(false),
+    enqueue: vi.fn(),
+    ...overrides,
+  }) as unknown as Editor;
+
+type FakePasteEvent = ClipboardEvent & { currentTarget: HTMLInputElement; preventDefault: ReturnType<typeof vi.fn> };
+
+const makeEvent = (clipboardData: Partial<DataTransfer>): FakePasteEvent => {
+  const event = {
+    clipboardData: {
+      files: [] as File[],
+      items: [] as DataTransferItem[],
+      getData: () => '',
+      ...clipboardData,
+    },
+    currentTarget: null,
+    preventDefault: vi.fn(),
+  };
+  return event as unknown as FakePasteEvent;
+};
+
+describe('handlePaste', () => {
+  it('routes clipboard image files to insertImagesFromFiles and skips text paste', () => {
+    const file = imageFile();
+    const insertImagesFromFiles = vi.fn().mockReturnValue(true);
+    const enqueue = vi.fn();
+    const editor = makeEditor({ insertImagesFromFiles, enqueue });
+
+    const event = makeEvent({
+      files: [file] as unknown as FileList,
+      getData: ((kind: string) => (kind === 'text/plain' ? 'fallback text' : '')) as DataTransfer['getData'],
+    });
+
+    handlePaste(editor, event);
+
+    expect(insertImagesFromFiles).toHaveBeenCalledWith([file]);
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it('falls back to FFI clipboard paste when no image is present', () => {
+    const insertImagesFromFiles = vi.fn().mockReturnValue(false);
+    const enqueue = vi.fn();
+    const editor = makeEditor({ insertImagesFromFiles, enqueue });
+
+    const event = makeEvent({
+      getData: ((kind: string) => (kind === 'text/plain' ? 'hello' : '<p>hello</p>')) as DataTransfer['getData'],
+    });
+
+    handlePaste(editor, event);
+
+    expect(insertImagesFromFiles).toHaveBeenCalledWith([]);
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(enqueue).toHaveBeenCalledWith({
+      type: 'clipboard',
+      op: { type: 'paste', text: 'hello', html: '<p>hello</p>' },
+    });
+  });
+
+  it('lets the default paste behavior run when both image and plain text are missing', () => {
+    const insertImagesFromFiles = vi.fn().mockReturnValue(false);
+    const enqueue = vi.fn();
+    const editor = makeEditor({ insertImagesFromFiles, enqueue });
+
+    const event = makeEvent({});
+
+    handlePaste(editor, event);
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+});

--- a/apps/website/src/lib/editor-ffi/handlers/clipboard.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/clipboard.ts
@@ -1,6 +1,13 @@
+import { getClipboardImageFiles } from './upload';
 import type { EditorEventHandler } from '../types';
 
 export const handlePaste: EditorEventHandler<HTMLInputElement, ClipboardEvent> = (editor, e) => {
+  const imageFiles = getClipboardImageFiles(e.clipboardData);
+  if (editor.insertImagesFromFiles(imageFiles)) {
+    e.preventDefault();
+    return;
+  }
+
   const text = e.clipboardData?.getData('text/plain') || undefined;
   const html = e.clipboardData?.getData('text/html') || undefined;
 

--- a/apps/website/src/lib/editor-ffi/handlers/upload.test.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/upload.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { assignPendingImageFiles, getClipboardImageFiles, getDataTransferImageFiles } from './upload';
+
+const imageFile = (name: string, type = 'image/png') => new File(['x'], name, { type });
+
+describe('getClipboardImageFiles', () => {
+  it('prefers files attached directly to the clipboard payload', () => {
+    const image = imageFile('image.png');
+    const text = new File(['hello'], 'note.txt', { type: 'text/plain' });
+
+    const clipboardData = {
+      files: [image, text],
+      items: [],
+    } as unknown as DataTransfer;
+
+    expect(getClipboardImageFiles(clipboardData)).toEqual([image]);
+  });
+
+  it('falls back to dataTransfer items when files are absent', () => {
+    const image = imageFile('clipboard.png');
+    const clipboardData = {
+      files: [],
+      items: [
+        { type: 'image/png', getAsFile: () => image },
+        { type: 'text/plain', getAsFile: () => null },
+      ],
+    } as unknown as DataTransfer;
+
+    expect(getClipboardImageFiles(clipboardData)).toEqual([image]);
+  });
+
+  it('returns an empty list when the clipboard payload is missing', () => {
+    expect(getClipboardImageFiles(null)).toEqual([]);
+  });
+});
+
+describe('getDataTransferImageFiles', () => {
+  it('returns only image files from drag-and-drop payloads', () => {
+    const image = imageFile('image.png');
+    const text = new File(['hello'], 'note.txt', { type: 'text/plain' });
+
+    const dataTransfer = { files: [image, text] } as unknown as DataTransfer;
+
+    expect(getDataTransferImageFiles(dataTransfer)).toEqual([image]);
+  });
+
+  it('returns an empty list when the drop payload is missing', () => {
+    expect(getDataTransferImageFiles(null)).toEqual([]);
+  });
+});
+
+describe('assignPendingImageFiles', () => {
+  it('assigns pending files to empty image nodes in document order', () => {
+    const first = imageFile('first.png');
+    const second = imageFile('second.png');
+
+    const result = assignPendingImageFiles(
+      [
+        { nodeId: 'a', assigned: false, inflight: false },
+        { nodeId: 'b', assigned: false, inflight: false },
+      ],
+      [first, second],
+    );
+
+    expect(result.assignments).toEqual([
+      { nodeId: 'a', file: first },
+      { nodeId: 'b', file: second },
+    ]);
+    expect(result.remainingFiles).toEqual([]);
+  });
+
+  it('skips nodes that already have an image, an assignment, or an inflight upload', () => {
+    const first = imageFile('first.png');
+    const second = imageFile('second.png');
+
+    const result = assignPendingImageFiles(
+      [
+        { nodeId: 'done', imageId: 'image-1', assigned: false, inflight: false },
+        { nodeId: 'assigned', assigned: true, inflight: false },
+        { nodeId: 'uploading', assigned: false, inflight: true },
+        { nodeId: 'target', assigned: false, inflight: false },
+      ],
+      [first, second],
+    );
+
+    expect(result.assignments).toEqual([{ nodeId: 'target', file: first }]);
+    expect(result.remainingFiles).toEqual([second]);
+  });
+
+  it('leaves remaining files untouched when no candidates are available', () => {
+    const file = imageFile('orphan.png');
+
+    const result = assignPendingImageFiles([{ nodeId: 'done', imageId: 'image-1', assigned: false, inflight: false }], [file]);
+
+    expect(result.assignments).toEqual([]);
+    expect(result.remainingFiles).toEqual([file]);
+  });
+});

--- a/apps/website/src/lib/editor-ffi/handlers/upload.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/upload.ts
@@ -1,0 +1,59 @@
+export const getClipboardImageFiles = (clipboardData: DataTransfer | null): File[] => {
+  if (!clipboardData) {
+    return [];
+  }
+
+  const fromFiles = [...clipboardData.files].filter((file) => file.type.startsWith('image/'));
+  if (fromFiles.length > 0) {
+    return fromFiles;
+  }
+
+  const fromItems: File[] = [];
+  for (const item of clipboardData.items) {
+    if (!item.type.startsWith('image/')) continue;
+    const file = item.getAsFile();
+    if (file) {
+      fromItems.push(file);
+    }
+  }
+  return fromItems;
+};
+
+export const getDataTransferImageFiles = (dataTransfer: DataTransfer | null): File[] => {
+  if (!dataTransfer) {
+    return [];
+  }
+  return [...dataTransfer.files].filter((file) => file.type.startsWith('image/'));
+};
+
+type PendingImageCandidate = {
+  nodeId: string;
+  imageId?: string;
+  assigned: boolean;
+  inflight: boolean;
+};
+
+export const assignPendingImageFiles = (
+  candidates: PendingImageCandidate[],
+  pendingFiles: File[],
+): { assignments: { nodeId: string; file: File }[]; remainingFiles: File[] } => {
+  const remainingFiles = [...pendingFiles];
+  const assignments: { nodeId: string; file: File }[] = [];
+
+  for (const candidate of candidates) {
+    if (remainingFiles.length === 0) {
+      break;
+    }
+    if (candidate.imageId || candidate.assigned || candidate.inflight) {
+      continue;
+    }
+
+    const file = remainingFiles.shift();
+    if (!file) {
+      break;
+    }
+    assignments.push({ nodeId: candidate.nodeId, file });
+  }
+
+  return { assignments, remainingFiles };
+};

--- a/apps/website/src/lib/editor-ffi/image.test.ts
+++ b/apps/website/src/lib/editor-ffi/image.test.ts
@@ -1,0 +1,371 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  clampImageWidth,
+  computeImagePresentation,
+  createDeleteImageMessage,
+  createDropImageSelectionMessages,
+  createSetImageAttrsMessage,
+  getExternalElementPlaceholderLabel,
+  IMAGE_PROPORTION_MAX,
+  processImageUpload,
+  proportionToScale,
+  resolveResizedImageProportion,
+} from './image';
+
+describe('getExternalElementPlaceholderLabel', () => {
+  it('returns null for image and labels for non-image placeholders', () => {
+    expect(getExternalElementPlaceholderLabel({ type: 'image', id: undefined, proportion: 100 })).toBeNull();
+    expect(getExternalElementPlaceholderLabel({ type: 'file', id: undefined })).toBe('파일');
+    expect(getExternalElementPlaceholderLabel({ type: 'embed', id: undefined })).toBe('임베드');
+    expect(getExternalElementPlaceholderLabel({ type: 'archived', id: undefined })).toBe('보관된 블록');
+  });
+});
+
+describe('proportionToScale', () => {
+  it('converts FFI percentage proportion (1-100) to a 0-1 scale', () => {
+    expect(proportionToScale(100)).toBe(1);
+    expect(proportionToScale(50)).toBe(0.5);
+  });
+
+  it('treats invalid proportion as full width', () => {
+    expect(proportionToScale(0)).toBe(1);
+    expect(proportionToScale(-10)).toBe(1);
+    expect(proportionToScale(Number.NaN)).toBe(1);
+  });
+
+  it('clamps proportion above max to 1', () => {
+    expect(proportionToScale(IMAGE_PROPORTION_MAX + 50)).toBe(1);
+  });
+});
+
+describe('createDropImageSelectionMessages', () => {
+  it('creates pointer down/up messages so the drop position becomes the insertion point', () => {
+    expect(createDropImageSelectionMessages({ page: 2, x: 10, y: 20 })).toEqual([
+      { type: 'pointer', event: { type: 'down', page: 2, x: 10, y: 20, count: 1 } },
+      { type: 'pointer', event: { type: 'up' } },
+    ]);
+  });
+
+  it('returns no messages when drop coordinates are unavailable', () => {
+    expect(createDropImageSelectionMessages(null)).toEqual([]);
+  });
+});
+
+describe('createSetImageAttrsMessage', () => {
+  it('emits a node set_attrs message carrying the new image id while preserving proportion', () => {
+    expect(
+      createSetImageAttrsMessage({
+        nodeId: 'node-1',
+        currentId: undefined,
+        currentProportion: 100,
+        nextId: 'image-1',
+      }),
+    ).toEqual({
+      type: 'node',
+      op: {
+        type: 'set_attrs',
+        id: 'node-1',
+        attrs: { type: 'image', id: 'image-1', proportion: 100 },
+      },
+    });
+  });
+
+  it('rounds fractional proportion to the FFI u32 percent unit', () => {
+    expect(
+      createSetImageAttrsMessage({
+        nodeId: 'node-1',
+        currentId: 'image-1',
+        currentProportion: 100,
+        nextProportion: 62.4,
+      }),
+    ).toMatchObject({
+      type: 'node',
+      op: {
+        attrs: { type: 'image', id: 'image-1', proportion: 62 },
+      },
+    });
+  });
+
+  it('clamps proportion to the 1..100 range', () => {
+    expect(
+      createSetImageAttrsMessage({
+        nodeId: 'node-1',
+        currentId: 'image-1',
+        currentProportion: 100,
+        nextProportion: 250,
+      }),
+    ).toMatchObject({
+      type: 'node',
+      op: { attrs: { proportion: 100 } },
+    });
+
+    expect(
+      createSetImageAttrsMessage({
+        nodeId: 'node-1',
+        currentId: 'image-1',
+        currentProportion: 100,
+        nextProportion: 0,
+      }),
+    ).toMatchObject({
+      type: 'node',
+      op: { attrs: { proportion: 1 } },
+    });
+  });
+});
+
+describe('createDeleteImageMessage', () => {
+  it('creates a delete node message for empty or failed image nodes', () => {
+    expect(createDeleteImageMessage('node-1')).toEqual({
+      type: 'node',
+      op: { type: 'delete', id: 'node-1' },
+    });
+  });
+});
+
+describe('clampImageWidth', () => {
+  it('enforces both the minimum (max(10%, 100px)) and maximum (originalWidth or bounds)', () => {
+    expect(clampImageWidth(30, 1200, 800)).toBe(100);
+    expect(clampImageWidth(2000, 1200, 800)).toBe(800);
+    expect(clampImageWidth(2000, 500, 800)).toBe(500);
+  });
+});
+
+describe('computeImagePresentation', () => {
+  it('reports inflight preview when only an inflight image is present', () => {
+    const result = computeImagePresentation({
+      proportion: 100,
+      boundsWidth: 800,
+      imageId: undefined,
+      asset: undefined,
+      inflight: { url: 'blob:preview', width: 1600, height: 1200 },
+    });
+    expect(result).toMatchObject({
+      hasImage: true,
+      isUploading: true,
+      isResolvingAsset: false,
+      url: 'blob:preview',
+      width: 800,
+      height: 600,
+    });
+  });
+
+  it('reports the uploaded asset once it becomes available, even if inflight still lingers', () => {
+    const result = computeImagePresentation({
+      proportion: 100,
+      boundsWidth: 800,
+      imageId: 'image-1',
+      asset: { id: 'image-1', url: 'https://cdn/asset.webp', originalUrl: 'https://cdn/raw.png', width: 1600, height: 1200 },
+      inflight: { url: 'blob:preview', width: 1600, height: 1200 },
+    });
+    expect(result).toMatchObject({
+      hasImage: true,
+      isUploading: false,
+      isResolvingAsset: false,
+      url: 'https://cdn/asset.webp',
+    });
+  });
+
+  it('reports resolving state when an image id exists but neither asset nor inflight is loaded yet', () => {
+    const result = computeImagePresentation({
+      proportion: 100,
+      boundsWidth: 800,
+      imageId: 'image-1',
+      asset: undefined,
+      inflight: undefined,
+    });
+    expect(result).toMatchObject({
+      hasImage: false,
+      isUploading: false,
+      isResolvingAsset: true,
+    });
+  });
+
+  it('uses the proportion scale to compute width and preserves aspect ratio', () => {
+    const result = computeImagePresentation({
+      proportion: 50,
+      boundsWidth: 800,
+      imageId: 'image-1',
+      asset: { id: 'image-1', url: 'https://cdn/asset.webp', originalUrl: 'https://cdn/raw.png', width: 1000, height: 500 },
+      inflight: undefined,
+    });
+    expect(result.width).toBe(400);
+    expect(result.height).toBe(200);
+  });
+
+  it('reports empty state when no image id and no inflight exist', () => {
+    const result = computeImagePresentation({
+      proportion: 100,
+      boundsWidth: 800,
+      imageId: undefined,
+      asset: undefined,
+      inflight: undefined,
+    });
+    expect(result).toMatchObject({ hasImage: false, isUploading: false, isResolvingAsset: false });
+  });
+});
+
+describe('processImageUpload', () => {
+  const makeEditor = () => ({
+    inflightImages: new Map<string, { url: string; width: number; height: number }>(),
+    imageAssets: new Map<
+      string,
+      { id: string; url: string; originalUrl: string; width: number; height: number; placeholder?: string | null }
+    >(),
+    enqueue: vi.fn(),
+    focus: vi.fn(),
+  });
+
+  const file = new File(['x'], 'image.png', { type: 'image/png' });
+
+  it('stores the uploaded asset and dispatches set_attrs with the new id', async () => {
+    const editor = makeEditor();
+
+    const result = await processImageUpload({
+      file,
+      nodeId: 'node-1',
+      currentProportion: 100,
+      editor,
+      getImageDimensions: async () => ({ width: 640, height: 480 }),
+      uploadImage: async () => ({
+        id: 'image-1',
+        url: 'https://cdn/asset.webp',
+        originalUrl: 'https://cdn/raw.png',
+        width: 640,
+        height: 480,
+        placeholder: 'placeholder',
+      }),
+      createObjectUrl: () => 'blob:preview',
+      revokeObjectUrl: vi.fn(),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(editor.imageAssets.get('image-1')).toMatchObject({ id: 'image-1', url: 'https://cdn/asset.webp' });
+    expect(editor.enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'node',
+        op: expect.objectContaining({
+          type: 'set_attrs',
+          id: 'node-1',
+          attrs: expect.objectContaining({ type: 'image', id: 'image-1', proportion: 100 }),
+        }),
+      }),
+    );
+    expect(editor.inflightImages.size).toBe(0);
+  });
+
+  it('sets an inflight preview before the upload resolves and clears it after success', async () => {
+    const editor = makeEditor();
+    const revokeObjectUrl = vi.fn();
+
+    let resolveUpload!: (value: {
+      id: string;
+      url: string;
+      originalUrl: string;
+      width: number;
+      height: number;
+      placeholder?: string | null;
+    }) => void;
+    const uploadPromise = new Promise<{
+      id: string;
+      url: string;
+      originalUrl: string;
+      width: number;
+      height: number;
+      placeholder?: string | null;
+    }>((resolve) => {
+      resolveUpload = resolve;
+    });
+
+    const runner = processImageUpload({
+      file,
+      nodeId: 'node-1',
+      currentProportion: 100,
+      editor,
+      getImageDimensions: async () => ({ width: 200, height: 100 }),
+      uploadImage: () => uploadPromise,
+      createObjectUrl: () => 'blob:preview',
+      revokeObjectUrl,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(editor.inflightImages.get('node-1')).toEqual({ url: 'blob:preview', width: 200, height: 100 });
+
+    resolveUpload({
+      id: 'image-1',
+      url: 'https://cdn/a.webp',
+      originalUrl: 'https://cdn/raw.png',
+      width: 200,
+      height: 100,
+      placeholder: null,
+    });
+    await runner;
+
+    expect(editor.inflightImages.size).toBe(0);
+    expect(revokeObjectUrl).toHaveBeenCalledWith('blob:preview');
+  });
+
+  it('deletes the placeholder node and reports failure on upload error', async () => {
+    const editor = makeEditor();
+    const onFailure = vi.fn();
+
+    const result = await processImageUpload({
+      file,
+      nodeId: 'node-1',
+      currentProportion: 100,
+      editor,
+      getImageDimensions: async () => ({ width: 640, height: 480 }),
+      uploadImage: async () => {
+        throw new Error('upload failed');
+      },
+      createObjectUrl: () => 'blob:preview',
+      revokeObjectUrl: vi.fn(),
+      onFailure,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(editor.enqueue).toHaveBeenCalledWith({ type: 'node', op: { type: 'delete', id: 'node-1' } });
+    expect(onFailure).toHaveBeenCalledTimes(1);
+    expect(editor.inflightImages.size).toBe(0);
+  });
+});
+
+describe('resolveResizedImageProportion', () => {
+  it('returns the new width as an integer percent of bounds', () => {
+    expect(
+      resolveResizedImageProportion({
+        boundsWidth: 800,
+        originalWidth: 1200,
+        initialWidth: 400,
+        initialClientX: 100,
+        nextClientX: 150,
+        reverse: false,
+      }),
+    ).toEqual({ width: 500, proportion: 62.5 });
+  });
+
+  it('handles reverse handle by inverting the delta direction', () => {
+    expect(
+      resolveResizedImageProportion({
+        boundsWidth: 800,
+        originalWidth: 1200,
+        initialWidth: 400,
+        initialClientX: 100,
+        nextClientX: 50,
+        reverse: true,
+      }),
+    ).toEqual({ width: 500, proportion: 62.5 });
+  });
+
+  it('returns proportion 0 when bounds collapse', () => {
+    expect(
+      resolveResizedImageProportion({
+        boundsWidth: 0,
+        originalWidth: 1200,
+        initialWidth: 400,
+        initialClientX: 100,
+        nextClientX: 200,
+        reverse: false,
+      }),
+    ).toEqual({ width: 400, proportion: 0 });
+  });
+});

--- a/apps/website/src/lib/editor-ffi/image.ts
+++ b/apps/website/src/lib/editor-ffi/image.ts
@@ -206,6 +206,9 @@ export const processImageUpload = async ({
     editor.inflightImages.set(nodeId, { url: objectUrl, width, height });
 
     const uploadedImage = await uploadImage(file);
+    if (!editor.inflightImages.has(nodeId)) {
+      return { ok: false, error: new Error('Upload cancelled') };
+    }
     editor.imageAssets.set(uploadedImage.id, uploadedImage);
     editor.enqueue(
       createSetImageAttrsMessage({

--- a/apps/website/src/lib/editor-ffi/image.ts
+++ b/apps/website/src/lib/editor-ffi/image.ts
@@ -1,0 +1,246 @@
+import type { ExternalElementData, Message } from '@typie/editor-ffi/browser';
+
+export const IMAGE_PROPORTION_MAX = 100;
+export const IMAGE_PROPORTION_MIN = 1;
+
+export const getExternalElementPlaceholderLabel = (data: ExternalElementData): string | null => {
+  switch (data.type) {
+    case 'image': {
+      return null;
+    }
+    case 'file': {
+      return '파일';
+    }
+    case 'embed': {
+      return '임베드';
+    }
+    case 'archived': {
+      return '보관된 블록';
+    }
+  }
+};
+
+export const proportionToScale = (proportion: number): number => {
+  if (!Number.isFinite(proportion) || proportion <= 0) {
+    return 1;
+  }
+  if (proportion >= IMAGE_PROPORTION_MAX) {
+    return 1;
+  }
+  return proportion / IMAGE_PROPORTION_MAX;
+};
+
+const clampProportion = (proportion: number): number => {
+  if (!Number.isFinite(proportion)) {
+    return IMAGE_PROPORTION_MAX;
+  }
+  const rounded = Math.round(proportion);
+  return Math.max(IMAGE_PROPORTION_MIN, Math.min(IMAGE_PROPORTION_MAX, rounded));
+};
+
+type SetImageAttrsArgs = {
+  nodeId: string;
+  currentId?: string;
+  currentProportion: number;
+  nextId?: string;
+  nextProportion?: number;
+};
+
+export const createSetImageAttrsMessage = ({
+  nodeId,
+  currentId,
+  currentProportion,
+  nextId,
+  nextProportion,
+}: SetImageAttrsArgs): Message => ({
+  type: 'node',
+  op: {
+    type: 'set_attrs',
+    id: nodeId,
+    attrs: {
+      type: 'image',
+      id: nextId ?? currentId,
+      proportion: clampProportion(nextProportion ?? currentProportion),
+    },
+  },
+});
+
+export const createDeleteImageMessage = (nodeId: string): Message => ({
+  type: 'node',
+  op: { type: 'delete', id: nodeId },
+});
+
+export const createDropImageSelectionMessages = (local: { page: number; x: number; y: number } | null): Message[] => {
+  if (!local) {
+    return [];
+  }
+
+  return [
+    { type: 'pointer', event: { type: 'down', page: local.page, x: local.x, y: local.y, count: 1 } },
+    { type: 'pointer', event: { type: 'up' } },
+  ];
+};
+
+const getImageWidthBounds = (originalWidth: number, boundsWidth: number) => {
+  const maxWidth = Math.min(originalWidth > 0 ? originalWidth : boundsWidth, boundsWidth);
+  const minWidth = Math.max(boundsWidth * 0.1, 100);
+  return { minWidth, maxWidth };
+};
+
+export const clampImageWidth = (width: number, originalWidth: number, boundsWidth: number): number => {
+  const { minWidth, maxWidth } = getImageWidthBounds(originalWidth, boundsWidth);
+  return Math.max(minWidth, Math.min(maxWidth, width));
+};
+
+type ImagePresentationInput = {
+  proportion: number;
+  boundsWidth: number;
+  imageId: string | undefined;
+  asset: { id?: string; url: string; originalUrl?: string; width: number; height: number; placeholder?: string | null } | undefined;
+  inflight: { url: string; width: number; height: number } | undefined;
+};
+
+export type ImagePresentation = {
+  hasImage: boolean;
+  isUploading: boolean;
+  isResolvingAsset: boolean;
+  url: string | undefined;
+  placeholder: string | null | undefined;
+  width: number;
+  height: number;
+  originalWidth: number;
+  originalHeight: number;
+};
+
+export const computeImagePresentation = ({
+  proportion,
+  boundsWidth,
+  imageId,
+  asset,
+  inflight,
+}: ImagePresentationInput): ImagePresentation => {
+  const url = asset?.url ?? inflight?.url;
+  const hasImage = !!url;
+  const isUploading = !!inflight && !asset;
+  const isResolvingAsset = !!imageId && !asset && !inflight;
+
+  const originalWidth = asset?.width ?? inflight?.width ?? 0;
+  const originalHeight = asset?.height ?? inflight?.height ?? 0;
+  const scale = proportionToScale(proportion);
+
+  let width = 0;
+  let height = 0;
+  if (hasImage && boundsWidth > 0) {
+    const targetWidth = boundsWidth * scale;
+    width = originalWidth > 0 ? Math.min(originalWidth, targetWidth) : targetWidth;
+    height = originalWidth > 0 ? (width * originalHeight) / originalWidth : 0;
+  }
+
+  return {
+    hasImage,
+    isUploading,
+    isResolvingAsset,
+    url,
+    placeholder: asset && 'placeholder' in asset ? (asset.placeholder ?? null) : undefined,
+    width,
+    height,
+    originalWidth,
+    originalHeight,
+  };
+};
+
+type ResolveResizeArgs = {
+  boundsWidth: number;
+  originalWidth: number;
+  initialWidth: number;
+  initialClientX: number;
+  nextClientX: number;
+  reverse: boolean;
+};
+
+type UploadImageResult = {
+  id: string;
+  url: string;
+  originalUrl: string;
+  width: number;
+  height: number;
+  placeholder?: string | null;
+};
+
+type ProcessImageUploadEditor = {
+  inflightImages: Map<string, { url: string; width: number; height: number }>;
+  imageAssets: Map<string, UploadImageResult>;
+  enqueue: (message: Message) => void;
+  focus: () => void;
+};
+
+type ProcessImageUploadArgs = {
+  file: File;
+  nodeId: string;
+  currentId?: string;
+  currentProportion: number;
+  editor: ProcessImageUploadEditor;
+  getImageDimensions: (src: string) => Promise<{ width: number; height: number }>;
+  uploadImage: (file: File) => Promise<UploadImageResult>;
+  createObjectUrl: (file: File) => string;
+  revokeObjectUrl: (url: string) => void;
+  onFailure?: (error: unknown) => void;
+};
+
+export const processImageUpload = async ({
+  file,
+  nodeId,
+  currentId,
+  currentProportion,
+  editor,
+  getImageDimensions,
+  uploadImage,
+  createObjectUrl,
+  revokeObjectUrl,
+  onFailure,
+}: ProcessImageUploadArgs): Promise<{ ok: true; uploadedImage: UploadImageResult } | { ok: false; error: unknown }> => {
+  const objectUrl = createObjectUrl(file);
+
+  try {
+    const { width, height } = await getImageDimensions(objectUrl);
+    editor.inflightImages.set(nodeId, { url: objectUrl, width, height });
+
+    const uploadedImage = await uploadImage(file);
+    editor.imageAssets.set(uploadedImage.id, uploadedImage);
+    editor.enqueue(
+      createSetImageAttrsMessage({
+        nodeId,
+        currentId,
+        currentProportion,
+        nextId: uploadedImage.id,
+      }),
+    );
+    editor.focus();
+
+    return { ok: true, uploadedImage };
+  } catch (err) {
+    editor.enqueue(createDeleteImageMessage(nodeId));
+    onFailure?.(err);
+    return { ok: false, error: err };
+  } finally {
+    editor.inflightImages.delete(nodeId);
+    revokeObjectUrl(objectUrl);
+  }
+};
+
+export const resolveResizedImageProportion = ({
+  boundsWidth,
+  originalWidth,
+  initialWidth,
+  initialClientX,
+  nextClientX,
+  reverse,
+}: ResolveResizeArgs): { width: number; proportion: number } => {
+  if (boundsWidth <= 0) {
+    return { width: initialWidth, proportion: 0 };
+  }
+
+  const dx = (nextClientX - initialClientX) * (reverse ? -1 : 1);
+  const width = clampImageWidth(initialWidth + dx * 2, originalWidth, boundsWidth);
+  return { width, proportion: (width / boundsWidth) * IMAGE_PROPORTION_MAX };
+};


### PR DESCRIPTION
Web v2 에디터에 이미지 업로드와 편집 기능을 구현했습니다.   
기존 에디터의 동작을 그대로 가져왔고, 드래그 앤 드롭으로 사용자가 편리하게 이미지를 업로드 할 수 있도록 개선했습니다.  
  
주요 변경

- **삽입 진입점 통합**: 툴바 이미지 버튼 / 클립보드 paste / 드래그 앤 드롭이 모두 단일 업로드 경로로 모입니다.
- **업로드 수명주기 처리**: placeholder → inflight preview → 업로드 완료 asset URL로 자연스럽게 전환됩니다.
- **편집 기능**: 선택 상태에서 좌우 리사이즈 핸들, 확대 보기, 삭제가 동작합니다.
- **비율 저장**: FFI 모델에 맞춘 정수 백분율로 저장되어 새로고침 후에도 비율이 유지됩니다.
- **실패 복구**: 업로드 실패 시 toast를 띄우고 빈 이미지 노드를 자동으로 정리해 문서가 깨지지 않도록 합니다.