### PR TITLE
selectable 노드 + 선택 확장 버그 (shift+click, shift+left)

### DIFF
--- a/crates/editor-core/src/handle/navigation.rs
+++ b/crates/editor-core/src/handle/navigation.rs
@@ -220,22 +220,7 @@ pub fn handle_navigation_op(editor: &mut Editor, op: NavigationOp) -> Result<(),
             if let Some(new_selection) = new_selection {
                 let final_selection = if extend {
                     let doc = &editor.state.doc;
-                    // Re-anchoring is sound only when the current selection
-                    // already brackets a unit (atom or monolithic block) and the
-                    // move is a vertical line step; otherwise the gesture anchor
-                    // must stay put so ordinary Shift selection (shrink/reverse,
-                    // horizontal, word) is unaffected.
-                    let vertical_line = matches!(
-                        movement,
-                        Movement::Line {
-                            axis: Axis::Vertical,
-                            ..
-                        }
-                    );
-                    let fixed = if vertical_line && selection.is_unit_node_selection(doc) {
-                        // Re-anchor to the unit edge opposite the travel
-                        // direction so the already-selected unit stays in the
-                        // range as it grows.
+                    let fixed = if selection.is_unit_node_selection(doc) {
                         farther_endpoint(doc, new_selection.head, selection.anchor, selection.head)
                     } else {
                         selection.anchor
@@ -512,6 +497,92 @@ mod tests {
                 extend: true,
             },
         });
+    }
+
+    fn shift_left(editor: &mut Editor) {
+        editor.apply(Message::Navigation {
+            op: NavigationOp::Move {
+                movement: Movement::Grapheme {
+                    direction: Direction::Backward,
+                },
+                extend: true,
+            },
+        });
+    }
+
+    fn shift_right(editor: &mut Editor) {
+        editor.apply(Message::Navigation {
+            op: NavigationOp::Move {
+                movement: Movement::Grapheme {
+                    direction: Direction::Forward,
+                },
+                extend: true,
+            },
+        });
+    }
+
+    #[test]
+    fn shift_left_from_selected_lower_atom_includes_both() {
+        let (state, r) = state! {
+            doc {
+                r: root {
+                    image
+                    image
+                    paragraph { text("bottom") }
+                }
+            }
+            selection: (r, 1, >) -> (r, 2, <)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.view.layout(&editor.state.doc);
+
+        shift_left(&mut editor);
+
+        let s = editor.state().selection;
+        let (lo, hi) = if s.anchor.offset <= s.head.offset {
+            (s.anchor.offset, s.head.offset)
+        } else {
+            (s.head.offset, s.anchor.offset)
+        };
+        assert_eq!(s.anchor.node_id, r);
+        assert_eq!(s.head.node_id, r);
+        assert_eq!(
+            (lo, hi),
+            (0, 2),
+            "shift+left from image#1 node-selection must envelop both images"
+        );
+    }
+
+    #[test]
+    fn shift_right_from_selected_upper_atom_includes_both() {
+        let (state, r) = state! {
+            doc {
+                r: root {
+                    paragraph { text("top") }
+                    image
+                    image
+                }
+            }
+            selection: (r, 1, >) -> (r, 2, <)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.view.layout(&editor.state.doc);
+
+        shift_right(&mut editor);
+
+        let s = editor.state().selection;
+        let (lo, hi) = if s.anchor.offset <= s.head.offset {
+            (s.anchor.offset, s.head.offset)
+        } else {
+            (s.head.offset, s.anchor.offset)
+        };
+        assert_eq!(s.anchor.node_id, r);
+        assert_eq!(s.head.node_id, r);
+        assert_eq!(
+            (lo, hi),
+            (1, 3),
+            "shift+right from image#1 node-selection must envelop both images"
+        );
     }
 
     #[test]

--- a/crates/editor-core/src/handle/pointer.rs
+++ b/crates/editor-core/src/handle/pointer.rs
@@ -44,8 +44,15 @@ pub fn handle_pointer_event(editor: &mut Editor, event: PointerEvent) -> Result<
                                 .filter(|&h| h != a)
                                 .and_then(|h| cell_rect_selection(&editor.state.doc, a, h))
                         });
-                        cell_sel
-                            .or_else(|| ext_hit.as_ref().map(|h| Selection::new(anchor, h.head)))
+                        cell_sel.or_else(|| {
+                            ext_hit.as_ref().map(|h| {
+                                let doc = &editor.state.doc;
+                                let cur = editor.state.selection;
+                                let fixed = farther_endpoint(doc, h.head, cur.anchor, cur.head);
+                                let head = farther_endpoint(doc, fixed, h.anchor, h.head);
+                                Selection::new(fixed, head)
+                            })
+                        })
                     } else {
                         raw_hit
                     }
@@ -326,6 +333,75 @@ mod tests {
             "drag anchor must survive an intermediate collapse"
         );
         assert_ne!(sel.anchor, sel.head);
+    }
+
+    #[test]
+    fn shift_click_first_image_from_selected_second_image_envelops_both() {
+        use editor_state::{Affinity, Position};
+
+        let (state, r1, i0, i1) = state! {
+            doc { r1: root { i0: image i1: image paragraph {} } }
+            selection: (r1, 1, >) -> (r1, 2, <)
+        };
+        let mut editor = Editor::new_test(state);
+        for id in [i0, i1] {
+            editor
+                .view
+                .set_external_height(&editor.state.doc, id, 100.0);
+        }
+        editor.view.layout(&editor.state.doc);
+
+        let atom_center = |editor: &Editor, idx: usize| {
+            let sel = Selection::new(
+                Position {
+                    node_id: r1,
+                    offset: idx,
+                    affinity: Affinity::Downstream,
+                },
+                Position {
+                    node_id: r1,
+                    offset: idx + 1,
+                    affinity: Affinity::Upstream,
+                },
+            );
+            let resolved = sel.resolve(&editor.state.doc).unwrap();
+            let rects = editor.view.selection_rects(&resolved);
+            let pr = &rects[0];
+            (
+                pr.page_idx,
+                pr.rect.x + pr.rect.width / 2.0,
+                pr.rect.y + pr.rect.height / 2.0,
+            )
+        };
+
+        let (p0, x0, y0) = atom_center(&editor, 0);
+        editor.apply(Message::Pointer {
+            event: PointerEvent::Down {
+                page: p0,
+                x: x0,
+                y: y0,
+                count: 1,
+                modifiers: InputModifiers {
+                    shift: true,
+                    ..Default::default()
+                },
+            },
+        });
+
+        let s = editor.state().selection;
+        let (lo, hi) = if s.anchor.offset <= s.head.offset {
+            (s.anchor.offset, s.head.offset)
+        } else {
+            (s.head.offset, s.anchor.offset)
+        };
+        assert_eq!(s.anchor.node_id, r1);
+        assert_eq!(s.head.node_id, r1);
+        assert_eq!(
+            (lo, hi),
+            (0, 2),
+            "shift+click image#0 from image#1 node-selection must envelop both images: \
+             anchor must re-anchor to the unit's trailing edge (r1,2), not stay at (r1,1)"
+        );
     }
 
     #[test]


### PR DESCRIPTION
* 확장(extend) 시 "선택된 unit을 envelope한 채로 늘리기" 로직이 기존엔 세로(shift+up/down)에만 적용됐는데, 가로(shift+left/right)와 단어(shift+ctrl+left/right) 등 모든 extend movement에 적용되도록 수정하였습니다. 

* shift+click도 드래그 extend 경로(pointer.rs)와 완전히 동일한 farther_endpoint 2단을 거치도록 수정하였습니다.

```
state! {
    doc {
        r1: root {
            image
            image
            paragraph {}
        }
    }
    selection: (r1, 1, >) -> (r1, 2, <)
}
케이스1: 위 상태에서 첫번째 이미지를 shift click하면 selection은 (r1, 0, >) -> (r1, 2, <) 이 되어야 하는데 지금은 (r1, 0, >) -> (r1, 1, <)

케이스2: 위 상태에서 shift + left 하면 이미지 둘 다 선택되어야 하는데 첫 이미지만 선택됨 (케이스 1과 같음)

```
**회귀 테스트 3개 추가**
shift_left_from_selected_lower_atom_includes_both — 케이스 2 직접 검증
shift_right_from_selected_upper_atom_includes_both — 대칭 케이스 (앞 이미지 선택 → 오른쪽으로 확장)
shift_click_first_image_from_selected_second_image_envelops_both — 케이스 1 직접 검증