### PR TITLE
TR-69 이미지 업로드 및 편집 기능 구현

### DIFF
--- a/apps/website/src/lib/editor-ffi/components/ExternalElement.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ExternalElement.svelte
@@ -2,13 +2,12 @@
   import { css } from '@typie/styled-system/css';
   import { flex } from '@typie/styled-system/patterns';
   import { Icon } from '@typie/ui/components';
-  import { getThemeContext } from '@typie/ui/context';
   import ArchiveIcon from '~icons/lucide/archive';
   import FileIcon from '~icons/lucide/file';
   import FileUpIcon from '~icons/lucide/file-up';
   import ImageIcon from '~icons/lucide/image';
-  import { THEME_COLORS } from '$lib/editor/theme';
-  import { getEditorContext } from '../editor.svelte';
+  import ExternalElementWrapper from './ExternalElementWrapper.svelte';
+  import ExternalImage from './ExternalImage.svelte';
   import type { ExternalElement } from '@typie/editor-ffi/browser';
   import type { Component } from 'svelte';
 
@@ -17,20 +16,6 @@
   };
 
   let { element }: Props = $props();
-
-  const SELECTION_FOCUSED_ALPHA = 77 / 255;
-  const SELECTION_UNFOCUSED_ALPHA = 48 / 255;
-
-  const ctx = getEditorContext();
-  const theme = getThemeContext();
-
-  let containerEl: HTMLDivElement | null = $state(null);
-  let reportedHeight = $state<number>();
-  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
-
-  const themeVariant = $derived(theme.currentThemeVariant);
-  const selectionColor = $derived(THEME_COLORS[themeVariant].selection);
-  const selectionOpacity = $derived(ctx.editor?.focused ? SELECTION_FOCUSED_ALPHA : SELECTION_UNFOCUSED_ALPHA);
 
   const meta = $derived.by<{ icon: Component; label: string }>(() => {
     switch (element.data.type) {
@@ -48,89 +33,39 @@
       }
     }
   });
-
-  $effect(() => {
-    const editor = ctx.editor;
-    const node = containerEl;
-    if (!editor || !node) return;
-
-    const observer = new ResizeObserver((entries) => {
-      const height = entries[0]?.contentRect.height ?? 0;
-      if (height <= 0 || height === reportedHeight) return;
-
-      if (debounceTimer) {
-        clearTimeout(debounceTimer);
-      }
-
-      debounceTimer = setTimeout(() => {
-        reportedHeight = height;
-        editor.setExternalElementHeight(element.node_id, height);
-        debounceTimer = null;
-      }, 100);
-    });
-
-    observer.observe(node);
-    return () => {
-      observer.disconnect();
-      if (debounceTimer) {
-        clearTimeout(debounceTimer);
-      }
-    };
-  });
 </script>
 
-<div
-  style:left={`${element.bounds.x}px`}
-  style:top={`${element.bounds.y}px`}
-  style:width={`${element.bounds.width}px`}
-  class={css({
-    position: 'absolute',
-    userSelect: 'none',
-    display: 'flex',
-    justifyContent: 'center',
-    visibility: reportedHeight === undefined ? 'hidden' : 'visible',
-  })}
-  data-external-element
-  data-node-id={element.node_id}
->
-  <div bind:this={containerEl} class={css({ width: 'full', minHeight: '48px' })}>
-    <div
-      class={flex({
-        align: 'center',
-        gap: '12px',
-        width: 'full',
-        minHeight: '48px',
-        paddingX: '14px',
-        paddingY: '12px',
-        borderRadius: '4px',
-        backgroundColor: 'surface.muted',
-        color: 'text.disabled',
-        fontSize: '14px',
-      })}
-    >
-      <Icon class={css({ flexShrink: '0' })} icon={meta.icon} size={20} />
-      <span
-        class={css({
-          minWidth: '0',
-          overflow: 'hidden',
-          whiteSpace: 'nowrap',
-          textOverflow: 'ellipsis',
+{#if element.data.type === 'image'}
+  <ExternalImage {element} />
+{:else}
+  <ExternalElementWrapper {element}>
+    <div class={css({ width: 'full', minHeight: '48px' })}>
+      <div
+        class={flex({
+          align: 'center',
+          gap: '12px',
+          width: 'full',
+          minHeight: '48px',
+          paddingX: '14px',
+          paddingY: '12px',
+          borderRadius: '4px',
+          backgroundColor: 'surface.muted',
+          color: 'text.disabled',
+          fontSize: '14px',
         })}
       >
-        {meta.label}
-      </span>
+        <Icon class={css({ flexShrink: '0' })} icon={meta.icon} size={20} />
+        <span
+          class={css({
+            minWidth: '0',
+            overflow: 'hidden',
+            whiteSpace: 'nowrap',
+            textOverflow: 'ellipsis',
+          })}
+        >
+          {meta.label}
+        </span>
+      </div>
     </div>
-  </div>
-
-  {#if element.is_selected}
-    <div
-      style:background-color={selectionColor}
-      style:opacity={selectionOpacity}
-      class={css({
-        position: 'absolute',
-        inset: '0',
-        pointerEvents: 'none',
-      })}
-    ></div>
-  {/if}
-</div>
+  </ExternalElementWrapper>
+{/if}

--- a/apps/website/src/lib/editor-ffi/components/ExternalElementWrapper.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ExternalElementWrapper.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+  import { css } from '@typie/styled-system/css';
+  import { getThemeContext } from '@typie/ui/context';
+  import { THEME_COLORS } from '$lib/editor/theme';
+  import { getEditorContext } from '../editor.svelte';
+  import type { ExternalElement } from '@typie/editor-ffi/browser';
+  import type { Snippet } from 'svelte';
+
+  type Props = {
+    element: ExternalElement;
+    minHeight?: string;
+    containerEl?: HTMLDivElement;
+    children: Snippet;
+  };
+
+  let { element, minHeight = '48px', containerEl = $bindable(), children }: Props = $props();
+
+  const SELECTION_FOCUSED_ALPHA = 77 / 255;
+  const SELECTION_UNFOCUSED_ALPHA = 48 / 255;
+
+  const ctx = getEditorContext();
+  const theme = getThemeContext();
+
+  let reportedHeight = $state<number>();
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const themeVariant = $derived(theme.currentThemeVariant);
+  const selectionColor = $derived(THEME_COLORS[themeVariant].selection);
+  const selectionOpacity = $derived(ctx.editor?.focused ? SELECTION_FOCUSED_ALPHA : SELECTION_UNFOCUSED_ALPHA);
+
+  $effect(() => {
+    const editor = ctx.editor;
+    const node = containerEl;
+    if (!editor || !node) return;
+
+    const observer = new ResizeObserver((entries) => {
+      const height = entries[0]?.contentRect.height ?? 0;
+      if (height <= 0 || height === reportedHeight) return;
+
+      if (debounceTimer) {
+        clearTimeout(debounceTimer);
+      }
+
+      debounceTimer = setTimeout(() => {
+        reportedHeight = height;
+        editor.setExternalElementHeight(element.node_id, height);
+        debounceTimer = null;
+      }, 100);
+    });
+
+    observer.observe(node);
+
+    return () => {
+      observer.disconnect();
+      if (debounceTimer) {
+        clearTimeout(debounceTimer);
+      }
+    };
+  });
+</script>
+
+<div
+  style:left={`${element.bounds.x}px`}
+  style:top={`${element.bounds.y}px`}
+  style:width={`${element.bounds.width}px`}
+  style:min-height={minHeight}
+  class={css({
+    position: 'absolute',
+    userSelect: 'none',
+    display: 'flex',
+    justifyContent: 'center',
+    visibility: reportedHeight === undefined ? 'hidden' : 'visible',
+  })}
+  data-external-element
+  data-node-id={element.node_id}
+>
+  <div bind:this={containerEl} class={css({ width: 'full' })}>
+    {@render children()}
+  </div>
+
+  {#if element.is_selected}
+    <div
+      style:background-color={selectionColor}
+      style:opacity={selectionOpacity}
+      class={css({ position: 'absolute', inset: '0', pointerEvents: 'none' })}
+    ></div>
+  {/if}
+</div>

--- a/apps/website/src/lib/editor-ffi/components/ExternalImage.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ExternalImage.svelte
@@ -1,0 +1,463 @@
+<script lang="ts">
+  import { flip, hide } from '@floating-ui/dom';
+  import { css, cx } from '@typie/styled-system/css';
+  import { center, flex } from '@typie/styled-system/patterns';
+  import { createFloatingActions } from '@typie/ui/actions';
+  import { Icon, Img, RingSpinner } from '@typie/ui/components';
+  import { Toast } from '@typie/ui/notification';
+  import ImageIcon from '~icons/lucide/image';
+  import Maximize2Icon from '~icons/lucide/maximize-2';
+  import Trash2Icon from '~icons/lucide/trash-2';
+  import { getEditorContext } from '../editor.svelte';
+  import {
+    calculateImageHeight,
+    calculateImageWidth,
+    createDeleteNodeMessage,
+    createSetImageAttrsMessage,
+    getFirstImageFile,
+    processImageUpload,
+  } from '../handlers/image-flow';
+  import { getImageDimensions, uploadImageFile } from '../handlers/upload';
+  import ExternalElementWrapper from './ExternalElementWrapper.svelte';
+  import ExternalImageEnlarge from './ExternalImageEnlarge.svelte';
+  import type { ExternalElement } from '@typie/editor-ffi/browser';
+
+  type Props = {
+    element: ExternalElement;
+  };
+
+  let { element }: Props = $props();
+
+  const ctx = getEditorContext();
+
+  let pickerOpened = $state(false);
+  let proportion = $state(100);
+  let isResizing = $state(false);
+  let initialResizeData: { x: number; width: number; proportion: number; reverse: boolean } | null = null;
+  let enlarged = $state(false);
+  let containerEl = $state<HTMLDivElement>();
+
+  const imageData = $derived(element.data.type === 'image' ? element.data : undefined);
+  const asset = $derived(imageData?.id ? ctx.editor?.imageAssets.get(imageData.id) : undefined);
+  const inflight = $derived(ctx.editor?.inflightImages.get(element.node_id));
+  const imageSrc = $derived(asset?.url ?? inflight?.url);
+  const hasImage = $derived(!!imageSrc);
+  const isUploading = $derived(!!inflight && !asset);
+  const isResolvingAsset = $derived(!!imageData?.id && !asset && !inflight);
+  const originalWidth = $derived(asset?.width ?? inflight?.width ?? 0);
+  const originalHeight = $derived(asset?.height ?? inflight?.height ?? 0);
+  const liveWidth = $derived(calculateImageWidth(element.bounds.width, proportion, originalWidth));
+  const liveHeight = $derived(calculateImageHeight(liveWidth, originalWidth, originalHeight));
+  const canEdit = $derived(!ctx.editor?.readOnly);
+
+  const { anchor, floating } = createFloatingActions({
+    placement: 'bottom',
+    offset: 4,
+    middleware: [flip(), hide()],
+  });
+
+  $effect(() => {
+    if (imageData && !isResizing) {
+      proportion = imageData.proportion;
+    }
+  });
+
+  $effect(() => {
+    pickerOpened = element.is_selected && !hasImage && !isResolvingAsset;
+  });
+
+  $effect(() => {
+    if (!hasImage) {
+      enlarged = false;
+    }
+  });
+
+  $effect(() => {
+    if (asset && inflight) {
+      deleteInflightImage(element.node_id);
+      revokeObjectUrl(inflight.url);
+    }
+  });
+
+  const enqueueImageAttrs = (id: string | undefined, nextProportion: number) => {
+    ctx.editor?.enqueue(createSetImageAttrsMessage(element.node_id, id, nextProportion));
+  };
+
+  const deleteInflightImage = (nodeId: string) => {
+    ctx.editor?.inflightImages.delete(nodeId);
+  };
+
+  const revokeObjectUrl = (url: string) => {
+    URL.revokeObjectURL(url);
+  };
+
+  const deleteNode = () => {
+    ctx.editor?.enqueue(createDeleteNodeMessage(element.node_id));
+    ctx.editor?.focus();
+  };
+
+  const processFile = async (file: File) => {
+    const editor = ctx.editor;
+    if (!editor || !imageData) return;
+
+    const result = await processImageUpload({
+      file,
+      nodeId: element.node_id,
+      getProportion: () => proportion,
+      setInflightImage: (nodeId, image) => editor.inflightImages.set(nodeId, image),
+      deleteInflightImage,
+      setImageAsset: (asset) => editor.imageAssets.set(asset.id, asset),
+      enqueue: (message) => editor.enqueue(message),
+      focus: () => editor.focus(),
+      createObjectUrl: (file) => URL.createObjectURL(file),
+      revokeObjectUrl,
+      readImageDimensions: getImageDimensions,
+      uploadImageFile,
+    });
+
+    if (result === 'failed') {
+      Toast.error(`${file.name} 이미지 업로드에 실패했습니다.`);
+    }
+  };
+
+  const handleUpload = () => {
+    if (!canEdit) return;
+    // TODO: restrictedBlob 용량 제한 처리.
+
+    const picker = document.createElement('input');
+    picker.type = 'file';
+    picker.accept = 'image/*';
+
+    picker.addEventListener('change', () => {
+      pickerOpened = false;
+
+      const file = picker.files?.[0];
+      if (!file) {
+        deleteNode();
+        return;
+      }
+
+      void processFile(file);
+    });
+
+    picker.addEventListener('cancel', () => {
+      pickerOpened = false;
+      deleteNode();
+    });
+
+    picker.click();
+  };
+
+  const handleDragOver = (event: DragEvent) => {
+    if (!canEdit || hasImage) return;
+
+    const items = [...(event.dataTransfer?.items ?? [])];
+    if (items.length > 0 && !items.some((item) => item.kind === 'file' && item.type.startsWith('image/'))) return;
+
+    event.preventDefault();
+
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = 'copy';
+    }
+  };
+
+  const handleDrop = (event: DragEvent) => {
+    if (!canEdit || hasImage) return;
+
+    event.preventDefault();
+
+    const file = getFirstImageFile(event.dataTransfer?.files ?? []);
+    if (!file) return;
+
+    pickerOpened = false;
+    void processFile(file);
+  };
+
+  const getWidthBounds = (boundsWidth: number) => {
+    const maxWidth = originalWidth > 0 ? Math.min(originalWidth, boundsWidth) : boundsWidth;
+    const minWidth = Math.min(maxWidth, Math.max(boundsWidth * 0.1, 100));
+    return { minWidth, maxWidth };
+  };
+
+  const clampWidth = (width: number, boundsWidth: number) => {
+    const { minWidth, maxWidth } = getWidthBounds(boundsWidth);
+    return Math.max(minWidth, Math.min(maxWidth, width));
+  };
+
+  const handleResizeStart = (event: PointerEvent, reverse: boolean) => {
+    const target = event.currentTarget as HTMLElement;
+    target.setPointerCapture(event.pointerId);
+    event.preventDefault();
+
+    isResizing = true;
+    initialResizeData = {
+      x: event.clientX,
+      width: liveWidth,
+      proportion,
+      reverse,
+    };
+  };
+
+  const handleResize = (event: PointerEvent) => {
+    const target = event.currentTarget as HTMLElement;
+    if (!target.hasPointerCapture(event.pointerId) || !initialResizeData) return;
+
+    const boundsWidth = element.bounds.width;
+    if (boundsWidth <= 0) return;
+
+    const dx = (event.clientX - initialResizeData.x) * (initialResizeData.reverse ? -1 : 1);
+    const newWidth = clampWidth(initialResizeData.width + dx * 2, boundsWidth);
+    proportion = (newWidth / boundsWidth) * 100;
+  };
+
+  const handleResizeEnd = (event: PointerEvent) => {
+    const target = event.currentTarget as HTMLElement;
+    if (target.hasPointerCapture(event.pointerId)) {
+      target.releasePointerCapture(event.pointerId);
+    }
+
+    // do NOT set isResizing = false here
+    enqueueImageAttrs(imageData?.id, proportion);
+    ctx.editor?.focus();
+  };
+
+  // Clear guard once editor state reflects the resize
+  $effect(() => {
+    if (isResizing && imageData && imageData.proportion === Math.round(proportion)) {
+      isResizing = false;
+    }
+  });
+</script>
+
+<ExternalElementWrapper {element} minHeight={hasImage ? undefined : '48px'}>
+  <div
+    bind:this={containerEl}
+    style:width={hasImage ? `${liveWidth}px` : '100%'}
+    style:height={hasImage ? `${liveHeight}px` : undefined}
+    class={cx('group', css({ position: 'relative', margin: '[0 auto]' }))}
+    ondragovercapture={handleDragOver}
+    ondropcapture={handleDrop}
+    role="group"
+  >
+    {#if hasImage}
+      <Img
+        style={css.raw({ width: 'full', borderRadius: '4px' }, !canEdit && { cursor: 'zoom-in' })}
+        alt="본문 이미지"
+        aria-label={canEdit ? undefined : '이미지 확대 보기'}
+        onclick={() => {
+          if (canEdit) {
+            return;
+          }
+
+          enlarged = true;
+        }}
+        onkeydown={(event) => {
+          if (!canEdit && (event.key === 'Enter' || event.key === ' ')) {
+            event.preventDefault();
+            enlarged = true;
+          }
+        }}
+        onpointerdown={(event) => {
+          if (canEdit) {
+            return;
+          }
+
+          event.stopPropagation();
+        }}
+        placeholder={asset?.placeholder}
+        progressive
+        ratio={originalHeight > 0 ? originalWidth / originalHeight : undefined}
+        role={canEdit ? undefined : 'button'}
+        size="full"
+        tabindex={canEdit ? undefined : 0}
+        url={imageSrc ?? ''}
+      />
+
+      {#if isUploading}
+        <div class={center({ position: 'absolute', inset: '0', backgroundColor: 'white/50' })}>
+          <RingSpinner style={css.raw({ size: '24px', color: 'text.disabled' })} />
+        </div>
+      {/if}
+
+      {#if canEdit}
+        <div class={flex({ position: 'absolute', top: '10px', right: '10px', gap: '6px', zIndex: '10' })}>
+          <button
+            class={center({
+              borderRadius: '4px',
+              size: '28px',
+              color: 'text.bright',
+              backgroundColor: '[#363839/70]',
+              opacity: '0',
+              transition: 'opacity',
+              _hover: { backgroundColor: '[#363839/40]' },
+              _groupHover: { opacity: '100' },
+            })}
+            aria-label="이미지 확대 보기"
+            onclick={() => (enlarged = true)}
+            onpointerdown={(event) => {
+              event.stopPropagation();
+            }}
+            type="button"
+          >
+            <Icon icon={Maximize2Icon} size={16} />
+          </button>
+
+          <button
+            class={center({
+              borderRadius: '4px',
+              size: '28px',
+              color: 'text.bright',
+              backgroundColor: '[#363839/70]',
+              opacity: '0',
+              transition: 'opacity',
+              _hover: { backgroundColor: '[#363839/40]' },
+              _groupHover: { opacity: '100' },
+            })}
+            aria-label="이미지 삭제"
+            onclick={deleteNode}
+            onpointerdown={(event) => {
+              event.stopPropagation();
+            }}
+            type="button"
+          >
+            <Icon icon={Trash2Icon} size={16} />
+          </button>
+        </div>
+
+        <div class={flex({ position: 'absolute', top: '0', bottom: '0', left: '10px', alignItems: 'center', pointerEvents: 'none' })}>
+          <button
+            class={css({
+              borderRadius: '4px',
+              backgroundColor: 'white/50',
+              mixBlendMode: 'difference',
+              width: '8px',
+              height: '1/3',
+              maxHeight: '72px',
+              cursor: 'col-resize',
+              opacity: '0',
+              transition: 'opacity',
+              zIndex: '10',
+              pointerEvents: 'auto',
+              _hover: { backgroundColor: 'white/40' },
+              _groupHover: { opacity: '100' },
+            })}
+            aria-label="이미지 크기 조절"
+            onpointerdown={(event) => {
+              event.preventDefault();
+              handleResizeStart(event, true);
+            }}
+            onpointermove={handleResize}
+            onpointerup={handleResizeEnd}
+            type="button"
+          ></button>
+        </div>
+
+        <div class={flex({ position: 'absolute', top: '0', bottom: '0', right: '10px', alignItems: 'center', pointerEvents: 'none' })}>
+          <button
+            class={css({
+              borderRadius: '4px',
+              backgroundColor: 'white/50',
+              mixBlendMode: 'difference',
+              width: '8px',
+              height: '1/3',
+              maxHeight: '72px',
+              cursor: 'col-resize',
+              opacity: '0',
+              transition: 'opacity',
+              zIndex: '10',
+              pointerEvents: 'auto',
+              _hover: { backgroundColor: 'white/40' },
+              _groupHover: { opacity: '100' },
+            })}
+            aria-label="이미지 크기 조절"
+            onpointerdown={(event) => {
+              event.stopPropagation();
+              handleResizeStart(event, false);
+            }}
+            onpointermove={handleResize}
+            onpointerup={handleResizeEnd}
+            type="button"
+          ></button>
+        </div>
+      {/if}
+    {:else}
+      <div
+        class={flex({
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          borderRadius: '4px',
+          backgroundColor: 'surface.muted',
+          width: 'full',
+          height: '48px',
+        })}
+        use:anchor
+      >
+        <div class={flex({ align: 'center', gap: '12px', paddingX: '14px', paddingY: '12px', fontSize: '14px', color: 'text.disabled' })}>
+          <Icon icon={ImageIcon} size={20} />
+          {isResolvingAsset ? '이미지를 불러오는 중...' : '이미지'}
+        </div>
+
+        {#if isResolvingAsset}
+          <div class={css({ marginRight: '14px' })}>
+            <RingSpinner style={css.raw({ size: '16px', color: 'text.disabled' })} />
+          </div>
+        {:else if canEdit}
+          <button
+            class={center({
+              marginRight: '12px',
+              borderRadius: '4px',
+              padding: '4px',
+              color: 'text.disabled',
+              _hover: { backgroundColor: 'interactive.hover', color: 'text.danger' },
+            })}
+            aria-label="이미지 삭제"
+            onclick={deleteNode}
+            onpointerdown={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+            }}
+            type="button"
+          >
+            <Icon icon={Trash2Icon} size={16} />
+          </button>
+        {/if}
+      </div>
+    {/if}
+  </div>
+</ExternalElementWrapper>
+
+{#if pickerOpened && canEdit}
+  <button
+    class={flex({
+      alignItems: 'center',
+      gap: '6px',
+      borderWidth: '1px',
+      borderRadius: '8px',
+      paddingX: '12px',
+      paddingY: '6px',
+      fontSize: '13px',
+      color: 'text.muted',
+      backgroundColor: 'surface.default',
+      boxShadow: 'small',
+      transition: 'common',
+      zIndex: 'editor',
+      _hover: { backgroundColor: 'interactive.hover' },
+    })}
+    onclick={handleUpload}
+    type="button"
+    use:floating
+  >
+    <Icon icon={ImageIcon} size={14} />
+    이미지 선택
+  </button>
+{/if}
+
+{#if enlarged && hasImage && imageSrc && containerEl}
+  <ExternalImageEnlarge
+    onclose={() => (enlarged = false)}
+    placeholder={asset?.placeholder}
+    ratio={originalHeight > 0 ? originalWidth / originalHeight : undefined}
+    referenceEl={containerEl}
+    url={imageSrc}
+  />
+{/if}

--- a/apps/website/src/lib/editor-ffi/components/ExternalImageEnlarge.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ExternalImageEnlarge.svelte
@@ -1,0 +1,132 @@
+<script lang="ts">
+  import { css } from '@typie/styled-system/css';
+  import { center } from '@typie/styled-system/patterns';
+  import { portal, scrollLock } from '@typie/ui/actions';
+  import { ContentProtect, Icon, Img } from '@typie/ui/components';
+  import { cubicOut } from 'svelte/easing';
+  import { Tween } from 'svelte/motion';
+  import XIcon from '~icons/lucide/x';
+
+  type Props = {
+    url: string;
+    referenceEl: HTMLDivElement;
+    placeholder?: string;
+    ratio?: number;
+    onclose: () => void;
+  };
+
+  let { url, referenceEl, placeholder, ratio, onclose }: Props = $props();
+
+  let targetEl = $state<HTMLDivElement>();
+
+  let referenceRect = $state<DOMRect>();
+  let targetRect = $state<DOMRect>();
+
+  const progress = new Tween(0, { duration: 300, easing: cubicOut });
+  const opacity = $derived(progress.current);
+
+  let transform = $derived.by(() => {
+    if (!referenceRect || !targetRect) {
+      return;
+    }
+
+    const { width, height, top, left } = referenceRect;
+
+    const scaleX = width + progress.current * (targetRect.width - width);
+    const scaleY = height + progress.current * (targetRect.height - height);
+    const scale = Math.min(scaleX / width, scaleY / height);
+
+    const centerX = left + width / 2;
+    const centerY = top + height / 2;
+
+    const targetCenterX = targetRect.left + targetRect.width / 2;
+    const targetCenterY = targetRect.top + targetRect.height / 2;
+
+    const translateX = centerX + progress.current * (targetCenterX - centerX) - centerX;
+    const translateY = centerY + progress.current * (targetCenterY - centerY) - centerY;
+
+    return {
+      scale,
+      translateX,
+      translateY,
+      width,
+      height,
+      top,
+      left,
+    };
+  });
+
+  $effect(() => {
+    if (referenceEl && targetEl) {
+      referenceRect = referenceEl.getBoundingClientRect();
+      targetRect = targetEl.getBoundingClientRect();
+
+      progress.target = 1;
+    }
+  });
+
+  const handleClose = async () => {
+    await progress.set(0);
+    onclose();
+  };
+</script>
+
+<svelte:window onclickcapture={handleClose} onkeydown={(event) => event.key === 'Escape' && handleClose()} />
+
+<div class={css({ position: 'fixed', inset: '0', size: 'full', zIndex: 'editor' })} use:portal use:scrollLock>
+  <ContentProtect>
+    <div class={css({ position: 'fixed', inset: '0', size: 'full', paddingX: '[5vw]', paddingY: '[5vh]' })}>
+      <div bind:this={targetEl} class={css({ size: 'full' })}></div>
+    </div>
+
+    <div style:opacity class={css({ position: 'fixed', inset: '0', size: 'full', backgroundColor: 'surface.default' })}>
+      <div class={css({ position: 'absolute', top: '20px', right: '20px' })}>
+        <button
+          class={center({
+            borderWidth: '[1.5px]',
+            borderColor: 'border.strong',
+            borderRadius: 'full',
+            marginBottom: '4px',
+            color: 'text.faint',
+            size: '40px',
+            backgroundColor: 'surface.default',
+            boxShadow: 'small',
+            _hover: {
+              borderColor: { base: 'gray.500', _dark: 'dark.gray.400' },
+              color: 'text.subtle',
+            },
+          })}
+          aria-label="닫기"
+          onclick={handleClose}
+          type="button"
+        >
+          <Icon icon={XIcon} />
+        </button>
+        <span class={css({ display: 'block', fontSize: '13px', fontWeight: 'semibold', color: 'text.disabled', textAlign: 'center' })}>
+          ESC
+        </span>
+      </div>
+    </div>
+
+    {#if transform}
+      <div
+        style:top={`${transform.top}px`}
+        style:left={`${transform.left}px`}
+        style:width={`${transform.width}px`}
+        style:height={`${transform.height}px`}
+        style:transform={`translate(${transform.translateX}px, ${transform.translateY}px) scale(${transform.scale})`}
+        class={center({ position: 'fixed', willChange: 'transform' })}
+      >
+        <Img
+          style={css.raw({ size: 'full', borderRadius: '4px', objectFit: 'contain', cursor: 'zoom-out' })}
+          alt="본문 이미지"
+          {placeholder}
+          progressive
+          {ratio}
+          size="full"
+          {url}
+        />
+      </div>
+    {/if}
+  </ContentProtect>
+</div>

--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -1,4 +1,5 @@
 import { createContext, tick, untrack } from 'svelte';
+import { SvelteMap } from 'svelte/reactivity';
 import { match } from 'ts-pattern';
 import { initWasm, wasm } from '$lib/wasm-ffi.svelte';
 import { fontDataMissingHandler } from './fonts';
@@ -20,7 +21,7 @@ import type {
   ThemeVariant,
   Viewport,
 } from '@typie/editor-ffi/browser';
-import type { EditorEventListener } from './types';
+import type { EditorEventListener, ImageAsset } from './types';
 
 let wasmInitPromise: Promise<void> | null = null;
 
@@ -71,6 +72,9 @@ export class Editor {
   #pointerStyle = $state<PointerStyle>('default');
   #lastPointerClient: { x: number; y: number } | null = null;
   #pointerStyleDomRefreshQueued = false;
+
+  imageAssets = $state(new SvelteMap<string, ImageAsset>());
+  inflightImages = $state(new SvelteMap<string, { url: string; width: number; height: number }>());
 
   private constructor() {
     // no-op

--- a/apps/website/src/lib/editor-ffi/handlers/image-flow.test.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/image-flow.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  calculateImageHeight,
+  calculateImageWidth,
+  createDeleteNodeMessage,
+  createSetImageAttrsMessage,
+  getFirstImageFile,
+  processImageUpload,
+} from './image-flow';
+import type { Message } from '@typie/editor-ffi/browser';
+import type { ImageAsset } from '../types';
+
+const createFile = (name: string, type: string) => new File(['content'], name, { type });
+
+const createAsset = (id = 'image-1'): ImageAsset => ({
+  id,
+  url: 'https://example.com/image.webp',
+  originalUrl: 'https://example.com/original.png',
+  width: 640,
+  height: 480,
+  placeholder: 'placeholder',
+});
+
+const createDeps = () => {
+  const messages: Message[] = [];
+  const inflight = new Map<string, { url: string; width: number; height: number }>();
+  const assets = new Map<string, ImageAsset>();
+  const focus = vi.fn();
+
+  return {
+    deps: {
+      setInflightImage: (nodeId: string, image: { url: string; width: number; height: number }) => inflight.set(nodeId, image),
+      deleteInflightImage: (nodeId: string) => inflight.delete(nodeId),
+      setImageAsset: (asset: ImageAsset) => assets.set(asset.id, asset),
+      enqueue: (message: Message) => messages.push(message),
+      focus,
+    },
+    messages,
+    inflight,
+    assets,
+    focus,
+  };
+};
+
+describe('v2 image flow messages', () => {
+  it('creates a v2 node attrs message for uploaded image id and rounded proportion', () => {
+    expect(createSetImageAttrsMessage('node-1', 'image-1', 74.6)).toEqual({
+      type: 'node',
+      op: {
+        type: 'set_attrs',
+        id: 'node-1',
+        attrs: {
+          type: 'image',
+          id: 'image-1',
+          proportion: 75,
+        },
+      },
+    });
+  });
+
+  it('creates a v2 node delete message for placeholder cleanup and deletion', () => {
+    expect(createDeleteNodeMessage('node-1')).toEqual({
+      type: 'node',
+      op: {
+        type: 'delete',
+        id: 'node-1',
+      },
+    });
+  });
+});
+
+describe('v2 image drop filtering', () => {
+  it('selects the first image file from dropped files', () => {
+    const text = createFile('memo.txt', 'text/plain');
+    const png = createFile('image.png', 'image/png');
+    const webp = createFile('image.webp', 'image/webp');
+
+    expect(getFirstImageFile([text, png, webp])).toBe(png);
+  });
+
+  it('ignores drops without image files', () => {
+    expect(getFirstImageFile([createFile('memo.txt', 'text/plain')])).toBeUndefined();
+  });
+});
+
+describe('v2 image upload processing', () => {
+  it('stores inflight preview, persists uploaded image id, and cleans up object url', async () => {
+    const { deps, messages, inflight, assets, focus } = createDeps();
+    const file = createFile('image.png', 'image/png');
+    const revokeObjectUrl = vi.fn();
+
+    const result = await processImageUpload({
+      file,
+      nodeId: 'node-1',
+      getProportion: () => 100,
+      ...deps,
+      createObjectUrl: () => 'blob:image',
+      revokeObjectUrl,
+      readImageDimensions: async () => ({ width: 320, height: 240 }),
+      uploadImageFile: async () => createAsset('image-1'),
+    });
+
+    expect(result).toBe('uploaded');
+    expect(assets.get('image-1')).toEqual(createAsset('image-1'));
+    expect(messages).toEqual([createSetImageAttrsMessage('node-1', 'image-1', 100)]);
+    expect(inflight.get('node-1')).toEqual({ url: 'blob:image', width: 320, height: 240 });
+    expect(revokeObjectUrl).not.toHaveBeenCalled();
+    expect(focus).toHaveBeenCalled();
+  });
+
+  it('deletes the empty image node and cleans up preview when upload fails', async () => {
+    const { deps, messages, inflight, focus } = createDeps();
+    const file = createFile('image.png', 'image/png');
+    const revokeObjectUrl = vi.fn();
+
+    const result = await processImageUpload({
+      file,
+      nodeId: 'node-1',
+      getProportion: () => 100,
+      ...deps,
+      createObjectUrl: () => 'blob:image',
+      revokeObjectUrl,
+      readImageDimensions: async () => ({ width: 320, height: 240 }),
+      uploadImageFile: async () => {
+        throw new Error('upload failed');
+      },
+    });
+
+    expect(result).toBe('failed');
+    expect(messages).toEqual([createDeleteNodeMessage('node-1')]);
+    expect(inflight.has('node-1')).toBe(false);
+    expect(revokeObjectUrl).toHaveBeenCalledWith('blob:image');
+    expect(focus).toHaveBeenCalled();
+  });
+});
+
+describe('v2 image resize calculations', () => {
+  it('calculates rendered image size from proportion and original ratio', () => {
+    const width = calculateImageWidth(800, 50, 1000);
+
+    expect(width).toBe(400);
+    expect(calculateImageHeight(width, 1000, 500)).toBe(200);
+  });
+
+  it('does not render wider than the original image', () => {
+    expect(calculateImageWidth(800, 100, 320)).toBe(320);
+  });
+});

--- a/apps/website/src/lib/editor-ffi/handlers/image-flow.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/image-flow.ts
@@ -1,0 +1,88 @@
+import type { Message } from '@typie/editor-ffi/browser';
+import type { ImageAsset } from '../types';
+
+type UploadImageFile = (file: File) => Promise<ImageAsset>;
+type ReadImageDimensions = (src: string) => Promise<{ width: number; height: number }>;
+
+export const createSetImageAttrsMessage = (nodeId: string, imageId: string | undefined, proportion: number): Message => ({
+  type: 'node',
+  op: {
+    type: 'set_attrs',
+    id: nodeId,
+    attrs: {
+      type: 'image',
+      id: imageId,
+      proportion: Math.round(proportion),
+    },
+  },
+});
+
+export const createDeleteNodeMessage = (nodeId: string): Message => ({
+  type: 'node',
+  op: {
+    type: 'delete',
+    id: nodeId,
+  },
+});
+
+export const getFirstImageFile = (files: Iterable<File>): File | undefined => {
+  return [...files].find((file) => file.type.startsWith('image/'));
+};
+
+export const calculateImageWidth = (boundsWidth: number, proportion: number, originalWidth: number): number => {
+  const proportionalWidth = (boundsWidth * proportion) / 100;
+  return originalWidth <= 0 ? proportionalWidth : Math.min(originalWidth, proportionalWidth);
+};
+
+export const calculateImageHeight = (width: number, originalWidth: number, originalHeight: number): number => {
+  if (originalWidth <= 0) return 0;
+  return width * (originalHeight / originalWidth);
+};
+
+export const processImageUpload = async ({
+  file,
+  nodeId,
+  getProportion,
+  setInflightImage,
+  deleteInflightImage,
+  setImageAsset,
+  enqueue,
+  focus,
+  createObjectUrl,
+  revokeObjectUrl,
+  readImageDimensions,
+  uploadImageFile,
+}: {
+  file: File;
+  nodeId: string;
+  getProportion: () => number;
+  setInflightImage: (nodeId: string, image: { url: string; width: number; height: number }) => void;
+  deleteInflightImage: (nodeId: string) => void;
+  setImageAsset: (asset: ImageAsset) => void;
+  enqueue: (message: Message) => void;
+  focus: () => void;
+  createObjectUrl: (file: File) => string;
+  revokeObjectUrl: (url: string) => void;
+  readImageDimensions: ReadImageDimensions;
+  uploadImageFile: UploadImageFile;
+}): Promise<'uploaded' | 'failed'> => {
+  const objectUrl = createObjectUrl(file);
+
+  try {
+    const { width, height } = await readImageDimensions(objectUrl);
+    setInflightImage(nodeId, { url: objectUrl, width, height });
+
+    const uploaded = await uploadImageFile(file);
+    setImageAsset(uploaded);
+    enqueue(createSetImageAttrsMessage(nodeId, uploaded.id, getProportion()));
+    focus();
+
+    return 'uploaded';
+  } catch {
+    deleteInflightImage(nodeId);
+    revokeObjectUrl(objectUrl);
+    enqueue(createDeleteNodeMessage(nodeId));
+    focus();
+    return 'failed';
+  }
+};

--- a/apps/website/src/lib/editor-ffi/handlers/upload.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/upload.ts
@@ -1,0 +1,23 @@
+import { uploadBlobAsImage } from '$lib/utils/blob.svelte';
+import type { ImageAsset } from '../types';
+
+export const getImageDimensions = (src: string): Promise<{ width: number; height: number }> => {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.addEventListener('load', () => resolve({ width: img.naturalWidth, height: img.naturalHeight }));
+    img.addEventListener('error', () => reject(new Error('Failed to load image')));
+    img.src = src;
+  });
+};
+
+export const uploadImageFile = async (file: File): Promise<ImageAsset> => {
+  const uploaded = await uploadBlobAsImage(file);
+  return {
+    id: uploaded.id,
+    url: uploaded.url,
+    originalUrl: uploaded.originalUrl,
+    width: uploaded.width,
+    height: uploaded.height,
+    placeholder: uploaded.placeholder,
+  };
+};

--- a/apps/website/src/lib/editor-ffi/types.ts
+++ b/apps/website/src/lib/editor-ffi/types.ts
@@ -4,3 +4,12 @@ import type { Editor } from './editor.svelte';
 export type EditorEventListener<K extends EditorEvent['type']> = (editor: Editor, event: Extract<EditorEvent, { type: K }>) => void;
 
 export type EditorEventHandler<E extends Element, T extends Event> = (editor: Editor, event: T & { currentTarget: E }) => void;
+
+export type ImageAsset = {
+  id: string;
+  url: string;
+  originalUrl: string;
+  width: number;
+  height: number;
+  placeholder: string;
+};

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditorV2.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditorV2.svelte
@@ -29,6 +29,18 @@
           graph
           updatedAt
         }
+        assets {
+          __typename
+
+          ... on Image {
+            id
+            url
+            originalUrl
+            width
+            height
+            placeholder
+          }
+        }
         ...Editor_document
         ...BottomToolbar_document
         ...SettingsPanel_document
@@ -183,6 +195,23 @@
       ps.stop();
       pusher = null;
     };
+  });
+
+  $effect(() => {
+    const editor = ctx.editor;
+    if (!editor) return;
+
+    for (const asset of document.data.assets) {
+      if (asset.__typename !== 'Image') continue;
+      editor.imageAssets.set(asset.id, {
+        id: asset.id,
+        url: asset.url,
+        originalUrl: asset.originalUrl,
+        width: asset.width,
+        height: asset.height,
+        placeholder: asset.placeholder,
+      });
+    }
   });
 
   onDestroy(() => {


### PR DESCRIPTION
v2 에디터에서 이미지 picker/drop 업로드, resize, 확대/축소, 삭제 기능을 구현했습니다.  
이 후에 파일 및 임베드 기능 구현을 이어감에 따라 관심사 분리가 필요해서 기존 레거시와 마찬가지로  
Wrapper, Image, Element로 관심사를 분리했습니다.

또한 이미지 관련 로직(메시지 생성, 크기 계산, 업로드 처리)은 컴포넌트에서 떼어
`editor-ffi/handlers/` 아래로 옮겼습니다. clipboard, input, keyboard, pointer가 이미 같은 위치에서
이벤트를 v2 메시지로 변환하는 역할을 하고 있어서 같은 위치에 두었습니다.  
  
이 작업에서는 단일 이미지 업로드를 목표로 구현되었습니다.

**변경 사항:**

- 문서 query의 기존 image asset을 editor 상태로 hydrate해 재진입 시에도
실제 이미지를 즉시 렌더링한다.
- 업로드 중에는 inflight preview(object URL)로 즉각 피드백을 주고,
성공 시 실제 image id를 v2 node message로 저장, 실패/취소 시 빈
image node를 제거합니다.
- 업로드/삭제/resize/drop 핵심 로직을 순수 함수로 분리하고 테스트로
회귀를 방지한다.