### PR TITLE
하드 브레이크 선택 및 시각화 (shift+arrow 선택 확장 오작동 수정)

### DIFF
--- a/crates/editor-core/src/handle/navigation.rs
+++ b/crates/editor-core/src/handle/navigation.rs
@@ -722,6 +722,133 @@ mod tests {
     }
 
     #[test]
+    fn shift_right_through_consecutive_hard_breaks_visits_each_offset() {
+        let (state, _p1, _t_a, _t_b) = state! {
+            doc {
+                root {
+                    p1: paragraph { t_a: text("a") hard_break hard_break t_b: text("b") }
+                }
+            }
+            selection: (t_a, 0)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.view.layout(&editor.state.doc);
+        let doc = editor.state.doc.clone();
+
+        let h0 = editor.state().selection.head;
+        shift_right(&mut editor);
+        let h1 = editor.state().selection.head;
+        shift_right(&mut editor);
+        let h2 = editor.state().selection.head;
+        shift_right(&mut editor);
+        let h3 = editor.state().selection.head;
+        shift_right(&mut editor);
+        let h4 = editor.state().selection.head;
+
+        let r = |p: Position| p.resolve(&doc).expect("resolves");
+        assert!(r(h1) > r(h0), "1st Shift+Right selects 'a'");
+        assert!(r(h2) > r(h1), "2nd Shift+Right passes first hard_break");
+        assert!(
+            r(h3) > r(h2),
+            "3rd Shift+Right passes second hard_break (not stuck/skipped)"
+        );
+        assert!(r(h4) > r(h3), "4th Shift+Right enters text 'b'");
+    }
+
+    #[test]
+    fn shift_left_through_consecutive_hard_breaks_visits_each_offset() {
+        let (state, _p1, _t_a, _t_b) = state! {
+            doc {
+                root {
+                    p1: paragraph { t_a: text("a") hard_break hard_break t_b: text("b") }
+                }
+            }
+            selection: (t_b, 1)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.view.layout(&editor.state.doc);
+        let doc = editor.state.doc.clone();
+
+        let h0 = editor.state().selection.head;
+        shift_left(&mut editor);
+        let h1 = editor.state().selection.head;
+        shift_left(&mut editor);
+        let h2 = editor.state().selection.head;
+        shift_left(&mut editor);
+        let h3 = editor.state().selection.head;
+        shift_left(&mut editor);
+        let h4 = editor.state().selection.head;
+
+        let r = |p: Position| p.resolve(&doc).expect("resolves");
+        assert!(r(h1) < r(h0), "1st Shift+Left selects 'b'");
+        assert!(r(h2) < r(h1), "2nd Shift+Left passes second hard_break");
+        assert!(r(h3) < r(h2), "3rd Shift+Left passes first hard_break");
+        assert!(r(h4) < r(h3), "4th Shift+Left enters text 'a'");
+    }
+
+    #[test]
+    fn shift_down_through_consecutive_hard_breaks_visits_each_line() {
+        let (state, _p1, _t_a, _t_b) = state! {
+            doc {
+                root {
+                    p1: paragraph { t_a: text("a") hard_break hard_break t_b: text("b") }
+                }
+            }
+            selection: (t_a, 0)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.view.layout(&editor.state.doc);
+        let doc = editor.state.doc.clone();
+
+        let h0 = editor.state().selection.head;
+        shift_down(&mut editor);
+        let h1 = editor.state().selection.head;
+        shift_down(&mut editor);
+        let h2 = editor.state().selection.head;
+
+        let r = |p: Position| p.resolve(&doc).expect("resolves");
+        assert!(
+            r(h1) > r(h0),
+            "1st Shift+Down lands on the empty hard_break line"
+        );
+        assert!(
+            r(h2) > r(h1),
+            "2nd Shift+Down reaches the 'b' line (not stuck)"
+        );
+    }
+
+    #[test]
+    fn shift_up_through_consecutive_hard_breaks_visits_each_line() {
+        let (state, _p1, _t_a, _t_b) = state! {
+            doc {
+                root {
+                    p1: paragraph { t_a: text("a") hard_break hard_break t_b: text("b") }
+                }
+            }
+            selection: (t_b, 1)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.view.layout(&editor.state.doc);
+        let doc = editor.state.doc.clone();
+
+        let h0 = editor.state().selection.head;
+        shift_up(&mut editor);
+        let h1 = editor.state().selection.head;
+        shift_up(&mut editor);
+        let h2 = editor.state().selection.head;
+
+        let r = |p: Position| p.resolve(&doc).expect("resolves");
+        assert!(
+            r(h1) < r(h0),
+            "1st Shift+Up lands on the empty hard_break line"
+        );
+        assert!(
+            r(h2) < r(h1),
+            "2nd Shift+Up reaches the 'a' line (not stuck)"
+        );
+    }
+
+    #[test]
     fn replace_over_extended_consecutive_atoms_removes_both() {
         let (state, _, i1, i2) = state! {
             doc {

--- a/crates/editor-view/src/query/navigation.rs
+++ b/crates/editor-view/src/query/navigation.rs
@@ -88,6 +88,22 @@ fn move_grapheme_forward(tree: &LayoutTree, pos: &Position) -> Option<Selection>
 
     match &line_node.content {
         LayoutContent::Line(line) => {
+            // An empty hard_break line owns paragraph offsets via child_range
+            // but has no glyph runs to step through; the new affinity keeps
+            // the result on this line so normalize doesn't bounce to the
+            // upper line.
+            if line.glyph_runs.is_empty()
+                && let Some(range) = &line.child_range
+                && pos.node_id == line.node_id
+                && pos.offset >= range.start
+                && pos.offset < range.end
+            {
+                return Some(Selection::collapsed(Position {
+                    node_id: line.node_id,
+                    offset: pos.offset + 1,
+                    affinity: Affinity::Upstream,
+                }));
+            }
             for (i, run) in line.glyph_runs.iter().enumerate() {
                 if run.node_id != pos.node_id {
                     continue;
@@ -129,6 +145,22 @@ fn move_grapheme_forward(tree: &LayoutTree, pos: &Position) -> Option<Selection>
                     pos.offset + g.codepoints as usize,
                 )));
             }
+            // Landing at the empty line's start would re-stage the same
+            // caret; normalize then locks head Upstream and the next press
+            // loops on the upper line.
+            if let LayoutContent::Line(next_line) = &next.content
+                && next_line.glyph_runs.is_empty()
+                && let Some(range) = &next_line.child_range
+                && pos.node_id == next_line.node_id
+                && pos.offset == range.start
+                && range.start < range.end
+            {
+                return Some(Selection::collapsed(Position {
+                    node_id: next_line.node_id,
+                    offset: range.start + 1,
+                    affinity: Affinity::Upstream,
+                }));
+            }
             Some(landed(next, false, true))
         }
         _ => {
@@ -150,6 +182,19 @@ fn move_grapheme_backward(tree: &LayoutTree, pos: &Position) -> Option<Selection
 
     match &line_node.content {
         LayoutContent::Line(line) => {
+            // Symmetric to forward; Downstream keeps the result on this line.
+            if line.glyph_runs.is_empty()
+                && let Some(range) = &line.child_range
+                && pos.node_id == line.node_id
+                && pos.offset > range.start
+                && pos.offset <= range.end
+            {
+                return Some(Selection::collapsed(Position {
+                    node_id: line.node_id,
+                    offset: pos.offset - 1,
+                    affinity: Affinity::Downstream,
+                }));
+            }
             for (i, run) in line.glyph_runs.iter().enumerate() {
                 if run.node_id != pos.node_id {
                     continue;
@@ -196,6 +241,28 @@ fn move_grapheme_backward(tree: &LayoutTree, pos: &Position) -> Option<Selection
                     pos.offset - g.codepoints as usize,
                 )));
             }
+            // Mirror of forward. `normalize_position` may have descended a
+            // paragraph-level pos into the adjacent text node's start, so
+            // accept both shapes.
+            if let LayoutContent::Line(prev_line) = &prev.content
+                && prev_line.glyph_runs.is_empty()
+                && let Some(prev_range) = &prev_line.child_range
+                && prev_range.start < prev_range.end
+            {
+                let at_para_boundary =
+                    pos.node_id == prev_line.node_id && pos.offset == prev_range.end;
+                let at_line_start = line
+                    .glyph_runs
+                    .first()
+                    .is_some_and(|r| r.node_id == pos.node_id && r.offset == pos.offset);
+                if at_para_boundary || at_line_start {
+                    return Some(Selection::collapsed(Position {
+                        node_id: prev_line.node_id,
+                        offset: prev_range.end - 1,
+                        affinity: Affinity::Downstream,
+                    }));
+                }
+            }
             Some(landed(prev, true, false))
         }
         _ => {
@@ -236,7 +303,13 @@ fn move_line_vertical_forward(
     let x = preferred_x.unwrap_or_else(|| compute_preferred_x(line_node, pos));
     let y = line_node.rect.bottom();
     let target = search::find_navigable_below_at_x(&tree.root, y, x);
-    (target.map(|t| navigate_to(t, x)), Some(x))
+    let sel = if let Some(t) = target {
+        let s = escape_empty_line_trap(navigate_to(t, x), Some(t), pos, true);
+        Some(skip_over_when_stuck(tree, s, t, pos, x, true))
+    } else {
+        line_end_fallback(line_node, true)
+    };
+    (sel, Some(x))
 }
 
 fn move_line_vertical_backward(
@@ -250,7 +323,98 @@ fn move_line_vertical_backward(
     let x = preferred_x.unwrap_or_else(|| compute_preferred_x(line_node, pos));
     let y = line_node.rect.y;
     let target = search::find_navigable_above_at_x(&tree.root, y, x);
-    (target.map(|t| navigate_to(t, x)), Some(x))
+    let sel = if let Some(t) = target {
+        let s = escape_empty_line_trap(navigate_to(t, x), Some(t), pos, false);
+        Some(skip_over_when_stuck(tree, s, t, pos, x, false))
+    } else {
+        line_end_fallback(line_node, false)
+    };
+    (sel, Some(x))
+}
+
+/// A trailing empty line owns no children (zero-width `child_range`), so
+/// `escape_empty_line_trap` can't push off it.
+fn skip_over_when_stuck(
+    tree: &LayoutTree,
+    sel: Selection,
+    target: &LayoutNode,
+    pos: &Position,
+    x: f32,
+    forward: bool,
+) -> Selection {
+    let LayoutContent::Line(line) = &target.content else {
+        return sel;
+    };
+    if !line.glyph_runs.is_empty() {
+        return sel;
+    }
+    let Some(range) = &line.child_range else {
+        return sel;
+    };
+    if range.start != range.end {
+        return sel;
+    }
+    if sel.head.node_id != pos.node_id || sel.head.offset != pos.offset {
+        return sel;
+    }
+    let next = if forward {
+        search::find_navigable_below_at_x(&tree.root, target.rect.bottom(), x)
+    } else {
+        search::find_navigable_above_at_x(&tree.root, target.rect.y, x)
+    };
+    next.map(|n| navigate_to(n, x)).unwrap_or(sel)
+}
+
+/// At the document edge return the current line's end instead of `None`, so
+/// the navigation handler doesn't silently swallow the keypress.
+fn line_end_fallback(line_node: &LayoutNode, forward: bool) -> Option<Selection> {
+    let LayoutContent::Line(line) = &line_node.content else {
+        return None;
+    };
+    let pos = if forward {
+        last_position_in_line(line)
+    } else {
+        first_position_in_line(line)
+    };
+    Some(Selection::collapsed(pos))
+}
+
+/// `position_at_x` on an empty line collapses to its `child_range.start`,
+/// which can equal the input position when crossing an empty hard_break line
+/// — making the press a visible no-op. Push to the far end of the range so
+/// the next press exits in the same direction.
+fn escape_empty_line_trap(
+    sel: Selection,
+    target: Option<&LayoutNode>,
+    pos: &Position,
+    forward: bool,
+) -> Selection {
+    let Some(t) = target else { return sel };
+    let LayoutContent::Line(line) = &t.content else {
+        return sel;
+    };
+    if !line.glyph_runs.is_empty() {
+        return sel;
+    }
+    if sel.head.node_id != pos.node_id || sel.head.offset != pos.offset {
+        return sel;
+    }
+    let Some(range) = &line.child_range else {
+        return sel;
+    };
+    if range.end == range.start {
+        return sel;
+    }
+    let (offset, affinity) = if forward {
+        (range.end, Affinity::Upstream)
+    } else {
+        (range.start, Affinity::Downstream)
+    };
+    Selection::collapsed(Position {
+        node_id: line.node_id,
+        offset,
+        affinity,
+    })
 }
 
 fn move_block_forward(tree: &LayoutTree, pos: &Position) -> Option<Selection> {
@@ -854,19 +1018,20 @@ mod tests {
     }
 
     #[test]
-    fn line_vertical_forward_at_last_returns_none() {
+    fn line_vertical_forward_at_last_extends_to_line_end() {
         let f = fixture();
-        assert!(
-            mov(
-                &f.tree,
-                Position::new(f.lines[4], 0),
-                Movement::Line {
-                    direction: Direction::Forward,
-                    axis: Axis::Vertical
-                },
-            )
-            .is_none()
-        );
+        let sel = mov(
+            &f.tree,
+            Position::new(f.lines[4], 0),
+            Movement::Line {
+                direction: Direction::Forward,
+                axis: Axis::Vertical,
+            },
+        )
+        .expect("falls back to end of current line at document edge");
+        assert_eq!(sel.head, sel.anchor);
+        // Stays on the same line, head pushed to its end position.
+        assert_eq!(sel.head.node_id, f.lines[4]);
     }
 
     #[test]

--- a/crates/editor-view/src/query/segmentation.rs
+++ b/crates/editor-view/src/query/segmentation.rs
@@ -148,11 +148,13 @@ pub fn select_word_at(
 
     if line.glyph_runs.is_empty() {
         let para = pos.doc().node(line.node_id)?;
-        let paragraph_has_no_text = para.children().all(|c| match c.node() {
+        // hard_break is selectable content, so it disqualifies the
+        // unit-select fallback in favor of the adjacent-hard_break branch.
+        let paragraph_truly_empty = para.children().all(|c| match c.node() {
             editor_model::Node::Text(t) => t.text.is_empty(),
-            _ => true,
+            _ => false,
         });
-        if paragraph_has_no_text {
+        if paragraph_truly_empty {
             let parent_id = para.parent()?.id();
             let index = para.index()?;
             return Some(Selection::new(
@@ -164,6 +166,26 @@ pub fn select_word_at(
                 Position {
                     node_id: parent_id,
                     offset: index + 1,
+                    affinity: Affinity::Upstream,
+                },
+            ));
+        }
+        // Trailing empty line (`start == end`) owns no hard_break — fall
+        // through to collapsed so the double-click is a visual no-op.
+        if let Some(range) = &line.child_range
+            && range.start < range.end
+            && let Some(child) = para.children().nth(range.start)
+            && matches!(child.node(), editor_model::Node::HardBreak(_))
+        {
+            return Some(Selection::new(
+                Position {
+                    node_id: line.node_id,
+                    offset: range.start,
+                    affinity: Affinity::Downstream,
+                },
+                Position {
+                    node_id: line.node_id,
+                    offset: range.end,
                     affinity: Affinity::Upstream,
                 },
             ));
@@ -694,7 +716,7 @@ mod tests {
     }
 
     #[test]
-    fn select_word_at_on_empty_hard_break_line_collapses() {
+    fn select_word_at_on_trailing_empty_hard_break_line_collapses() {
         use editor_macros::doc;
         let (doc_, p1) = doc! { root { p1: paragraph { text("a") hard_break } } };
         let t1 = doc_.node(p1).unwrap().children().next().unwrap().id();
@@ -729,13 +751,57 @@ mod tests {
         };
         let resolved = pos.resolve(&doc_).unwrap();
         let sel = select_word_at(&tree, &resolved, &resource.segmenters).unwrap();
-        assert!(
-            sel.is_collapsed(),
-            "expected collapsed selection, got: {:?}",
-            sel
-        );
+        assert!(sel.is_collapsed());
         assert_eq!(sel.head.node_id, p1);
         assert_eq!(sel.head.offset, 2);
+    }
+
+    #[test]
+    fn select_word_at_between_consecutive_hard_breaks_selects_the_hard_break() {
+        use editor_macros::doc;
+        let (doc_, p1) = doc! {
+            root { p1: paragraph { text("a") hard_break hard_break text("b") } }
+        };
+        let children: Vec<_> = doc_.node(p1).unwrap().children().collect();
+        let t_a = children[0].id();
+        let t_b = children[3].id();
+        let tree = LayoutTree {
+            root: LayoutNode {
+                rect: Rect::from_xywh(0.0, 0.0, 200.0, 60.0),
+                content: LayoutContent::Box(LayoutBox {
+                    node_id: NodeId::new(),
+                    style: BoxStyle {
+                        direction: LayoutDirection::Vertical,
+                        padding: editor_common::EdgeInsets::ZERO,
+                        border: editor_common::EdgeInsets::ZERO,
+                        border_mode: BorderMode::Separate,
+                        alignment: Alignment::Start,
+                        scope: false,
+                        decorations: vec![],
+                        monolithic: false,
+                    },
+                    children: vec![
+                        make_text_line_node(p1, t_a, 0.0, "a", 0..2),
+                        make_empty_line_node(p1, 20.0, 2..3),
+                        make_text_line_node(p1, t_b, 40.0, "b", 3..4),
+                    ],
+                    nav: None,
+                }),
+            },
+        };
+        let resource = editor_resource::Resource::new_test();
+        let pos = editor_state::Position {
+            node_id: p1,
+            offset: 2,
+            affinity: editor_state::Affinity::Downstream,
+        };
+        let resolved = pos.resolve(&doc_).unwrap();
+        let sel = select_word_at(&tree, &resolved, &resource.segmenters).unwrap();
+        assert!(!sel.is_collapsed());
+        assert_eq!(sel.anchor.node_id, p1);
+        assert_eq!(sel.anchor.offset, 2);
+        assert_eq!(sel.head.node_id, p1);
+        assert_eq!(sel.head.offset, 3);
     }
 
     #[test]

--- a/crates/editor-view/src/query/selection.rs
+++ b/crates/editor-view/src/query/selection.rs
@@ -162,6 +162,27 @@ fn attached(node: &LayoutNode, pos: &Position) -> bool {
     }
 }
 
+/// True when `child_range` owns more slots than the number of distinct text
+/// children — the surplus is non-text content (in practice, a trailing
+/// `hard_break`).
+fn line_has_trailing_non_text(line: &LayoutLine) -> bool {
+    let Some(range) = &line.child_range else {
+        return false;
+    };
+    if line.glyph_runs.is_empty() {
+        return false;
+    }
+    let mut text_child_count = 1usize;
+    let mut prev = line.glyph_runs[0].node_id;
+    for run in line.glyph_runs.iter().skip(1) {
+        if run.node_id != prev {
+            text_child_count += 1;
+            prev = run.node_id;
+        }
+    }
+    range.end.saturating_sub(range.start) > text_child_count
+}
+
 fn visit_node(
     node: &LayoutNode,
     from: &Position,
@@ -198,34 +219,65 @@ fn visit_line(
     let contains_from = from_owner.map(|n| std::ptr::eq(n, node)).unwrap_or(false);
     let contains_to = to_owner.map(|n| std::ptr::eq(n, node)).unwrap_or(false);
 
+    let hb_placeholder = node.rect.height * 0.15;
+    // Without an explicit extension, a trailing hard_break enveloped by the
+    // selection reads as zero width because `x_at_offset` pins to the last
+    // run's right edge.
+    let trailing_hb = line_has_trailing_non_text(line);
+    let at_line_trailing = |pos: &Position| -> bool {
+        line.child_range
+            .as_ref()
+            .is_some_and(|r| pos.node_id == line.node_id && pos.offset == r.end && r.end > r.start)
+    };
+
     let (x_start, x_end) = match (*phase, contains_from, contains_to) {
         (Phase::Before, true, true) => {
             let x0 = super::grapheme::x_at_offset(line, from);
-            let x1 = super::grapheme::x_at_offset(line, to);
+            let mut x1 = super::grapheme::x_at_offset(line, to);
+            if trailing_hb && at_line_trailing(to) {
+                x1 += hb_placeholder;
+            }
             *phase = Phase::After;
             (x0, x1)
         }
         (Phase::Before, true, false) => {
             let x0 = super::grapheme::x_at_offset(line, from);
-            let x1 = line_end_x(line);
+            let mut x1 = line_end_x(line);
+            if trailing_hb {
+                x1 += hb_placeholder;
+            }
             *phase = Phase::Inside;
             (x0, x1)
         }
-        (Phase::Inside, false, false) => (line_start_x(line), line_end_x(line)),
+        (Phase::Inside, false, false) => {
+            let x0 = line_start_x(line);
+            let mut x1 = line_end_x(line);
+            if trailing_hb {
+                x1 += hb_placeholder;
+            }
+            (x0, x1)
+        }
         (Phase::Inside, false, true) => {
             let x0 = line_start_x(line);
-            let x1 = super::grapheme::x_at_offset(line, to);
+            let mut x1 = super::grapheme::x_at_offset(line, to);
+            if trailing_hb && at_line_trailing(to) {
+                x1 += hb_placeholder;
+            }
             *phase = Phase::After;
             (x0, x1)
         }
         _ => return,
     };
 
+    // Both endpoints at paragraph-level offsets in the same line collapse
+    // onto the same x via `x_at_offset` — show a placeholder so the
+    // hard_break still reads as selected.
+    let spans_hard_break =
+        from.node_id == line.node_id && to.node_id == line.node_id && from.offset != to.offset;
     let width = if x_end > x_start {
         x_end - x_start
-    } else if line.glyph_runs.is_empty() {
-        // empty line — show a small placeholder like a virtual space
-        node.rect.height * 0.3
+    } else if line.glyph_runs.is_empty() || spans_hard_break {
+        hb_placeholder
     } else {
         return;
     };


### PR DESCRIPTION
연속된 hard_break로 만들어진 빈 라인 주변에서 다음 동작들이 깨져있었습니다. 

- Shift+Arrow 선택 확장이 정체 — 두 hard_break 사이의 빈 라인에서 선택이 멈추거나 hard_break를 건너뜀
- 빈 라인 더블클릭이 무동작 — 빈 라인의 hard_break 자체를 선택할 수 없음
- 시각화 누락 — 선택이 hard_break를 가로질러도 visual feedback이 없어 사용자가 "아무 변화 없다"고 느낌

빈 라인에서의 offset 진행을 처리하지 못했고, selection normalize가 head에 Upstream 친화도를 강제하면서 find_line_at이 항상 위쪽 라인을 골라 다음 step에서 같은 자리에 떨어지는 정체 루프 발생. 

1. Grapheme 네비게이션 — 빈 라인 step
- In-line step: 빈 라인 위에서 paragraph offset ±1. forward는 Upstream, backward는 Downstream으로 affinity 고정 → 다음 press가 같은 라인에 머묾.
- Cross-line step: 텍스트 라인 끝 → 다음 빈 라인의 시작이 현재 offset과 같으면, landed 대신 한 칸 진입한 위치로 land. backward는 라인 첫 run 시작과도 매칭 (normalize_position descend 케이스 커버).

2. Line 네비게이션 (Shift+Up/Down)
- escape_empty_line_trap: vertical landing이 입력 pos와 일치(stuck)하면 빈 라인의 반대편 끝으로 head 이동. target이 빈 라인일 때만 작동 → atom navigation 영향 없음.
- line_end_fallback: 위/아래 라인 없을 때 None 대신 현재 라인의 끝/시작 반환. document-edge에서 표준 에디터 동작과 일치.

3. select_word_at — 빈 hard_break 라인 더블클릭
빈 hard_break 라인 더블클릭이 collapsed가 아니라 인접 hard_break를 선택하도록:
- paragraph_truly_empty 판정에서 hard_break 제외
- child_range shape으로 인접 hard_break offset 결정
start < end: (p, start) → (p, end)
start == end (trailing): (p, start-1) → (p, start)
실제 HardBreak 노드 검증 (PageBreak 등과 혼동 방지)

4. Selection rect 시각화
hard_break 포함했는데 폭 0이라 안 보이는 케이스 보강:
- spans_hard_break: 양 끝이 같은 라인의 paragraph-level offset일 때 placeholder 처리
- trailing_hb 확장: trailing hard_break를 envelope하면 x_end에 placeholder 폭(height * 0.15) 추가. 4개 phase 케이스 모두
- line_has_trailing_non_text: child_range 슬롯 수 > distinct text 자식 수 → trailing 비-text(hard_break) 있음
레거시처럼 hard_break 영역이 "공백 씌워진 듯" 보임.
