### PR TITLE
feat: 텍스트 치환 구현

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,6 +583,7 @@ dependencies = [
  "editor-state",
  "editor-transaction",
  "enum-map",
+ "fancy-regex",
  "log",
  "smallvec",
  "thiserror",
@@ -784,6 +785,7 @@ dependencies = [
  "editor-common",
  "editor-macros",
  "editor-model",
+ "fancy-regex",
  "fontique",
  "hashbrown 0.17.0",
  "icu_provider",
@@ -979,6 +981,17 @@ name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "fastrand"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ cfg-if = "1"
 console_error_panic_hook = { version = "0.1" }
 console_log = "1"
 enum-map = "2"
+fancy-regex = "0.17"
 env_filter = "0.1"
 env_logger = "0.11"
 fontique = { version = "0.9", default-features = false }

--- a/apps/website/src/routes/website/(dashboard)/+layout.svelte
+++ b/apps/website/src/routes/website/(dashboard)/+layout.svelte
@@ -23,6 +23,7 @@
   import { preloadEditorWasm } from '$lib/editor/editor.svelte';
   import { hydrateQuery } from '$lib/graphql';
   import { initWasm } from '$lib/wasm.svelte';
+  import { initWasm as initWasmFfi } from '$lib/wasm-ffi.svelte';
   import { graphql } from '$mearie';
   import { setupPaneGroup } from './[slug]/@pane/context.svelte';
   import { setupEditorRegistry } from './[slug]/@pane/editor-registry.svelte';
@@ -196,6 +197,9 @@
     const rules = textReplacementRulesJson;
     initWasm().then((wasm) => {
       wasm.setTextReplacementRules(JSON.parse(rules));
+    });
+    initWasmFfi().then((host) => {
+      host.set_text_replacement_rules(JSON.parse(rules));
     });
   });
 

--- a/crates/editor-commands/Cargo.toml
+++ b/crates/editor-commands/Cargo.toml
@@ -30,6 +30,7 @@ editor-resource = { path = "../editor-resource" }
 editor-state = { path = "../editor-state" }
 editor-transaction = { path = "../editor-transaction" }
 enum-map.workspace = true
+fancy-regex.workspace = true
 log.workspace = true
 thiserror.workspace = true
 unicode-segmentation.workspace = true

--- a/crates/editor-commands/src/commands/mod.rs
+++ b/crates/editor-commands/src/commands/mod.rs
@@ -42,6 +42,7 @@ mod split_list_item;
 mod split_paragraph;
 mod toggle_bold;
 mod toggle_modifier;
+mod try_text_replacement;
 
 pub use clear_all_modifiers::clear_all_modifiers;
 pub use delete_empty_paragraph_backward::delete_empty_paragraph_backward;
@@ -87,3 +88,4 @@ pub use split_list_item::split_list_item;
 pub use split_paragraph::split_paragraph;
 pub use toggle_bold::toggle_bold;
 pub use toggle_modifier::toggle_modifier;
+pub use try_text_replacement::try_text_replacement;

--- a/crates/editor-commands/src/commands/try_text_replacement.rs
+++ b/crates/editor-commands/src/commands/try_text_replacement.rs
@@ -1,0 +1,409 @@
+use editor_model::{Node, NodeId, PlainHardBreakNode, PlainNode, PlainTextNode, Subtree};
+use editor_resource::{CompiledPattern, Resource, TextReplacementRule};
+use editor_state::{Position, Selection};
+use editor_transaction::{HistoryMeta, HistoryTag, Transaction};
+
+use crate::{CommandError, CommandResult};
+
+pub fn try_text_replacement(tr: &mut Transaction, resource: &Resource) -> CommandResult {
+    let rules = &resource.text_replacement_rules;
+    if rules.is_empty() {
+        return Ok(false);
+    }
+    if tr.composition().is_some() {
+        return Ok(false);
+    }
+    if !tr.selection().is_collapsed() {
+        return Ok(false);
+    }
+
+    let mut replaced = false;
+    let mut search_start_byte = 0usize;
+
+    loop {
+        let Some((_block_id, text_before)) = get_text_before_cursor(tr) else {
+            break;
+        };
+        if text_before.is_empty() {
+            break;
+        }
+        if search_start_byte >= text_before.len() {
+            break;
+        }
+        while search_start_byte < text_before.len()
+            && !text_before.is_char_boundary(search_start_byte)
+        {
+            search_start_byte += 1;
+        }
+
+        let matched = match_rule(rules, &text_before, search_start_byte);
+        let Some((matched_start_byte, matched_text, substitute, suffix)) = matched else {
+            break;
+        };
+
+        let next_search_start_byte = matched_start_byte.saturating_add(substitute.len());
+
+        let original_offset_len = offset_len_for_text(&matched_text);
+        let _replaced_offset_len = offset_len_for_text(&substitute);
+        let suffix_offset_len = offset_len_for_text(&suffix);
+
+        let delete_count = original_offset_len + suffix_offset_len;
+        for _ in 0..delete_count {
+            delete_one_backward(tr)?;
+        }
+
+        let full_insert = if suffix.is_empty() {
+            substitute.clone()
+        } else {
+            format!("{substitute}{suffix}")
+        };
+        for (i, part) in full_insert.split('\n').enumerate() {
+            if i > 0 {
+                insert_hard_break(tr)?;
+            }
+            if !part.is_empty() {
+                insert_text_at_cursor(tr, part)?;
+            }
+        }
+
+        replaced = true;
+        search_start_byte = next_search_start_byte;
+    }
+
+    if replaced {
+        tr.update_meta(|m| {
+            m.history = HistoryMeta::Tagged {
+                tag: HistoryTag::AutoReplacement,
+            }
+        });
+    }
+    Ok(replaced)
+}
+
+fn match_rule(
+    rules: &[TextReplacementRule],
+    text_before: &str,
+    search_start_byte: usize,
+) -> Option<(usize, String, String, String)> {
+    for rule in rules {
+        match &rule.pattern {
+            CompiledPattern::Plain(pattern) => {
+                for (pos, _) in text_before.match_indices(pattern.as_str()) {
+                    if pos < search_start_byte {
+                        continue;
+                    }
+                    let match_end = pos + pattern.len();
+                    if match_end == text_before.len() {
+                        return Some((
+                            pos,
+                            pattern.clone(),
+                            rule.substitute.clone(),
+                            String::new(),
+                        ));
+                    }
+                }
+            }
+            CompiledPattern::Regex(regex) => {
+                for caps in regex.captures_iter(text_before).flatten() {
+                    if let Some(m) = caps.get(0) {
+                        if m.end() == text_before.len() && m.start() >= search_start_byte {
+                            let matched_str = m.as_str().to_string();
+                            let expanded = expand_substitute(&caps, &rule.substitute);
+                            return Some((m.start(), matched_str, expanded, String::new()));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+fn expand_substitute(caps: &fancy_regex::Captures<'_>, template: &str) -> String {
+    let mut result = String::new();
+    let mut chars = template.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        if c != '$' {
+            result.push(c);
+            continue;
+        }
+
+        match chars.peek() {
+            Some(&'$') => {
+                chars.next();
+                result.push('$');
+            }
+            Some(&'{') => {
+                chars.next();
+                let mut name = String::new();
+                for c in chars.by_ref() {
+                    if c == '}' {
+                        break;
+                    }
+                    name.push(c);
+                }
+                if let Some(m) = caps
+                    .name(&name)
+                    .or_else(|| name.parse::<usize>().ok().and_then(|n| caps.get(n)))
+                {
+                    result.push_str(m.as_str());
+                }
+            }
+            Some(&c) if c.is_ascii_digit() => {
+                let mut num_str = String::new();
+                while let Some(&c) = chars.peek() {
+                    if c.is_ascii_digit() {
+                        num_str.push(c);
+                        chars.next();
+                    } else {
+                        break;
+                    }
+                }
+                if let Some(m) = num_str.parse::<usize>().ok().and_then(|n| caps.get(n)) {
+                    result.push_str(m.as_str());
+                }
+            }
+            Some(&c) if c.is_ascii_alphabetic() || c == '_' => {
+                let mut name = String::new();
+                while let Some(&c) = chars.peek() {
+                    if c.is_ascii_alphanumeric() || c == '_' {
+                        name.push(c);
+                        chars.next();
+                    } else {
+                        break;
+                    }
+                }
+                if let Some(m) = caps
+                    .name(&name)
+                    .or_else(|| name.parse::<usize>().ok().and_then(|n| caps.get(n)))
+                {
+                    result.push_str(m.as_str());
+                }
+            }
+            _ => {
+                result.push('$');
+            }
+        }
+    }
+
+    result
+}
+
+fn offset_len_for_text(text: &str) -> usize {
+    let mut len = 0;
+    for (i, part) in text.split('\n').enumerate() {
+        if i > 0 {
+            len += 1;
+        }
+        len += part.chars().count();
+    }
+    len
+}
+
+fn get_text_before_cursor(tr: &Transaction) -> Option<(NodeId, String)> {
+    let selection = tr.selection();
+    if !selection.is_collapsed() {
+        return None;
+    }
+
+    let head = selection.head;
+    let doc = tr.doc();
+    let cursor_node = doc.node(head.node_id)?;
+
+    let block = cursor_node.ancestors().find(|n| n.spec().is_textblock())?;
+    if cursor_node.id() == block.id() {
+        return None;
+    }
+    let block_id = block.id();
+    let cursor_offset = head.offset;
+    let cursor_index = cursor_node.index()?;
+
+    let mut text = String::new();
+    for (i, child) in block.children().enumerate() {
+        if i > cursor_index {
+            break;
+        }
+        match child.node() {
+            Node::Text(text_node) => {
+                let full = text_node.text.to_string();
+                if i == cursor_index {
+                    let partial: String = full.chars().take(cursor_offset).collect();
+                    text.push_str(&partial);
+                } else {
+                    text.push_str(&full);
+                }
+            }
+            Node::HardBreak(_) => {
+                if i < cursor_index || cursor_offset > 0 {
+                    text.push('\n');
+                }
+            }
+            _ => {}
+        }
+    }
+
+    Some((block_id, text))
+}
+
+fn delete_one_backward(tr: &mut Transaction) -> CommandResult {
+    let sel = tr.selection();
+    let head = sel.head;
+    let doc = tr.doc();
+    let node = doc
+        .node(head.node_id)
+        .ok_or(CommandError::NodeNotFound(head.node_id))?;
+    let Node::Text(text_node) = node.node() else {
+        return Ok(false);
+    };
+
+    if head.offset > 0 {
+        let new_offset = head.offset - 1;
+        tr.remove_text(head.node_id, new_offset, 1)?;
+        tr.set_selection(Selection::collapsed(Position::new(
+            head.node_id,
+            new_offset,
+        )))?;
+        return Ok(true);
+    }
+
+    let Some(prev) = node.prev_sibling() else {
+        return Ok(false);
+    };
+    if !matches!(prev.node(), Node::HardBreak(_)) {
+        return Ok(false);
+    }
+
+    let hard_break_id = prev.id();
+    let current_text_id = head.node_id;
+    let current_is_empty = text_node.text.is_empty();
+    let target = prev.prev_sibling().and_then(|n| match n.node() {
+        Node::Text(t) => Some((n.id(), t.text.len())),
+        _ => None,
+    });
+
+    tr.remove_subtree(hard_break_id)?;
+    if let Some((target_id, target_offset)) = target {
+        if current_is_empty {
+            tr.remove_subtree(current_text_id)?;
+        }
+        tr.set_selection(Selection::collapsed(Position::new(
+            target_id,
+            target_offset,
+        )))?;
+    }
+    Ok(true)
+}
+
+fn insert_text_at_cursor(tr: &mut Transaction, text: &str) -> CommandResult {
+    if text.is_empty() {
+        return Ok(false);
+    }
+    let sel = tr.selection();
+    let head = sel.head;
+    let doc = tr.doc();
+    let node = doc
+        .node(head.node_id)
+        .ok_or(CommandError::NodeNotFound(head.node_id))?;
+
+    let (text_node_id, start_offset) = if matches!(node.node(), Node::Text(_)) {
+        (head.node_id, head.offset)
+    } else {
+        let new_id = NodeId::new();
+        let subtree = Subtree::leaf(
+            new_id,
+            PlainNode::Text(PlainTextNode {
+                text: String::new(),
+            }),
+        );
+        tr.insert_subtree(head.node_id, head.offset, subtree)?;
+        (new_id, 0)
+    };
+
+    let insert_len = text.chars().count();
+    tr.insert_text(text_node_id, start_offset, text)?;
+    let new_offset = start_offset + insert_len;
+    tr.set_selection(Selection::collapsed(Position::new(
+        text_node_id,
+        new_offset,
+    )))?;
+    Ok(true)
+}
+
+fn insert_hard_break(tr: &mut Transaction) -> CommandResult {
+    let sel = tr.selection();
+    let head = sel.head;
+
+    let (node_id, text_node_exists, text_len) = {
+        let doc = tr.doc();
+        let node = doc
+            .node(head.node_id)
+            .ok_or(CommandError::NodeNotFound(head.node_id))?;
+        match node.node() {
+            Node::Text(t) => (head.node_id, true, t.text.len()),
+            _ => (head.node_id, false, 0),
+        }
+    };
+
+    let break_id = NodeId::new();
+    let break_subtree = Subtree::leaf(
+        break_id,
+        PlainNode::HardBreak(PlainHardBreakNode::default()),
+    );
+
+    if text_node_exists {
+        let (parent_id, node_index) = {
+            let doc = tr.doc();
+            let node = doc
+                .node(node_id)
+                .ok_or(CommandError::NodeNotFound(node_id))?;
+            let parent = node.parent().ok_or(CommandError::NoParent(node_id))?;
+            let index = node
+                .index()
+                .ok_or(CommandError::orphan_child(node_id, parent.id()))?;
+            (parent.id(), index)
+        };
+
+        let hb_pos = head.offset;
+        if hb_pos == 0 {
+            tr.insert_subtree(parent_id, node_index, break_subtree)?;
+            tr.set_selection(Selection::collapsed(Position::new(node_id, 0)))?;
+        } else if hb_pos == text_len {
+            tr.insert_subtree(parent_id, node_index + 1, break_subtree)?;
+            let doc = tr.doc();
+            let break_node = doc
+                .node(break_id)
+                .ok_or(CommandError::NodeNotFound(break_id))?;
+            if let Some(next) = break_node.next_sibling() {
+                if matches!(next.node(), Node::Text(_)) {
+                    tr.set_selection(Selection::collapsed(Position::new(next.id(), 0)))?;
+                } else {
+                    let idx = next
+                        .index()
+                        .ok_or(CommandError::orphan_child(next.id(), parent_id))?;
+                    tr.set_selection(Selection::collapsed(Position::new(parent_id, idx)))?;
+                }
+            } else {
+                let break_idx = break_node
+                    .index()
+                    .ok_or(CommandError::orphan_child(break_id, parent_id))?;
+                tr.set_selection(Selection::collapsed(Position::new(
+                    parent_id,
+                    break_idx + 1,
+                )))?;
+            }
+        } else {
+            let split_id = NodeId::new();
+            tr.split_node(node_id, hb_pos, split_id)?;
+            tr.insert_subtree(parent_id, node_index + 1, break_subtree)?;
+            tr.set_selection(Selection::collapsed(Position::new(split_id, 0)))?;
+        }
+    } else {
+        tr.insert_subtree(node_id, head.offset, break_subtree)?;
+        tr.set_selection(Selection::collapsed(Position::new(
+            node_id,
+            head.offset + 1,
+        )))?;
+    }
+    Ok(true)
+}

--- a/crates/editor-core/src/handle/composition.rs
+++ b/crates/editor-core/src/handle/composition.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use editor_commands::{self as commands, CommandError, CommandResult};
 use editor_common::StrExt;
 use editor_model::{Doc, Modifier};
@@ -20,10 +22,18 @@ pub fn handle_composition_op(editor: &mut Editor, op: CompositionOp) -> Result<(
             tr.set_composition(new_comp)?;
             Ok(())
         }),
-        CompositionOp::CommitAsIs => editor.transact(|tr| {
-            tr.set_composition(None)?;
-            Ok(())
-        }),
+        CompositionOp::CommitAsIs => {
+            editor.transact(|tr| {
+                tr.set_composition(None)?;
+                Ok(())
+            })?;
+            let resource = Arc::clone(&editor.resource);
+            let resource = resource.lock().unwrap();
+            editor.transact(|tr| {
+                commands::optional!(commands::try_text_replacement(&resource))(tr)?;
+                Ok(())
+            })
+        }
         CompositionOp::Cancel => editor.transact(|tr| {
             let is_gap = tr
                 .selection()
@@ -64,24 +74,32 @@ pub fn handle_composition_op(editor: &mut Editor, op: CompositionOp) -> Result<(
             }))?;
             Ok(())
         }),
-        CompositionOp::Commit { text } => editor.transact(|tr| {
-            let is_gap = tr
-                .selection()
-                .resolve(&tr.doc())
-                .and_then(|rs| rs.as_gap_cursor())
-                .is_some();
-            if is_gap {
-                if text.is_empty() {
-                    return Ok(());
+        CompositionOp::Commit { text } => {
+            editor.transact(|tr| {
+                let is_gap = tr
+                    .selection()
+                    .resolve(&tr.doc())
+                    .and_then(|rs| rs.as_gap_cursor())
+                    .is_some();
+                if is_gap {
+                    if text.is_empty() {
+                        return Ok(());
+                    }
+                    tr.set_composition(None)?;
+                    commands::materialize_gap_paragraph(tr)?;
                 }
+                let (target_start, target_end) = resolve_target(tr, None)?;
+                replace_text_range(tr, target_start, target_end, &text)?;
                 tr.set_composition(None)?;
-                commands::materialize_gap_paragraph(tr)?;
-            }
-            let (target_start, target_end) = resolve_target(tr, None)?;
-            replace_text_range(tr, target_start, target_end, &text)?;
-            tr.set_composition(None)?;
-            Ok(())
-        }),
+                Ok(())
+            })?;
+            let resource = Arc::clone(&editor.resource);
+            let resource = resource.lock().unwrap();
+            editor.transact(|tr| {
+                commands::optional!(commands::try_text_replacement(&resource))(tr)?;
+                Ok(())
+            })
+        }
     }
 }
 

--- a/crates/editor-core/src/handle/insertion.rs
+++ b/crates/editor-core/src/handle/insertion.rs
@@ -6,7 +6,7 @@ use crate::message::*;
 
 pub fn handle_insertion_op(editor: &mut Editor, op: InsertionOp) -> Result<(), EditorError> {
     editor.transact(|tr| {
-        match op {
+        match &op {
             InsertionOp::Text { text } => {
                 commands::chain!(
                     tr,
@@ -20,7 +20,7 @@ pub fn handle_insertion_op(editor: &mut Editor, op: InsertionOp) -> Result<(), E
                             commands::optional!(commands::delete_selection()),
                         ),
                     ),
-                    commands::insert_text(&text),
+                    commands::insert_text(text),
                 )?;
             }
             InsertionOp::Break {
@@ -93,7 +93,17 @@ pub fn handle_insertion_op(editor: &mut Editor, op: InsertionOp) -> Result<(), E
             }
         }
         Ok(())
-    })
+    })?;
+
+    if matches!(op, InsertionOp::Text { .. }) {
+        let resource = std::sync::Arc::clone(&editor.resource);
+        let resource = resource.lock().unwrap();
+        editor.transact(|tr| {
+            commands::optional!(commands::try_text_replacement(&resource))(tr)?;
+            Ok(())
+        })?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/editor-core/src/handle/key.rs
+++ b/crates/editor-core/src/handle/key.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use editor_commands::{self as commands};
+use editor_transaction::{HistoryMeta, HistoryTag};
 
 use crate::editor::Editor;
 use crate::error::EditorError;
@@ -9,6 +10,20 @@ use crate::message::*;
 pub fn handle_key_event(editor: &mut Editor, event: KeyEvent) -> Result<(), EditorError> {
     let resource = Arc::clone(&editor.resource);
     let resource = resource.lock().unwrap();
+
+    if matches!(event.key, Key::Backspace)
+        && matches!(editor.history.last_tag(), Some(HistoryTag::AutoReplacement))
+    {
+        if let Some(steps) = editor.history.undo() {
+            editor.transact(|tr| {
+                tr.update_meta(|m| m.history = HistoryMeta::Skip);
+                tr.apply_steps(steps)?;
+                Ok(())
+            })?;
+        }
+        return Ok(());
+    }
+
     editor.transact(|tr| {
         match (event.key, event.modifiers) {
             (Key::Enter, m) if m.shift => {

--- a/crates/editor-core/src/lib.rs
+++ b/crates/editor-core/src/lib.rs
@@ -11,6 +11,9 @@ mod ime;
 mod message;
 mod state_field;
 
+#[cfg(test)]
+mod text_replacement_tests;
+
 pub use block_state::*;
 pub use editor::*;
 pub use error::*;

--- a/crates/editor-core/src/text_replacement_tests.rs
+++ b/crates/editor-core/src/text_replacement_tests.rs
@@ -1,0 +1,520 @@
+use editor_common::{Direction, Movement};
+use editor_macros::state;
+use editor_resource::RawTextReplacementRule;
+use editor_state::{Composition, DocFlatExt, assert_state_eq};
+
+use crate::editor::Editor;
+use crate::message::*;
+
+fn rule(pattern: &str, sub: &str, regex: bool) -> RawTextReplacementRule {
+    RawTextReplacementRule {
+        id: pattern.into(),
+        match_pattern: pattern.into(),
+        substitute: sub.into(),
+        regex,
+    }
+}
+
+fn set_rules(editor: &Editor, rules: Vec<RawTextReplacementRule>) {
+    editor
+        .resource
+        .lock()
+        .unwrap()
+        .set_text_replacement_rules(rules);
+}
+
+fn type_text(editor: &mut Editor, text: &str) {
+    editor.apply(Message::Insertion {
+        op: InsertionOp::Text { text: text.into() },
+    });
+}
+
+fn key(editor: &mut Editor, k: Key) {
+    editor.apply(Message::Key {
+        event: KeyEvent {
+            key: k,
+            modifiers: InputModifiers::default(),
+        },
+    });
+}
+
+fn move_grapheme(editor: &mut Editor, direction: Direction) {
+    editor.apply(Message::Navigation {
+        op: NavigationOp::Move {
+            movement: Movement::Grapheme { direction },
+            extend: false,
+        },
+    });
+}
+
+fn flat_text(editor: &Editor) -> String {
+    editor
+        .state()
+        .doc
+        .flat_text(0..editor.state().doc.flat_size())
+}
+
+const PLAIN_PATTERN: &str = "abc";
+const PLAIN_SUBSTITUTE: &str = "X";
+const REGEX_PATTERN: &str = r"\d+#";
+const REGEX_SUBSTITUTE: &str = "N";
+const MULTILINE_SUB_PATTERN: &str = "mk";
+const MULTILINE_SUB_SUBSTITUTE: &str = "a\nb";
+const MULTILINE_PAT_PATTERN: &str = r"P1\nP2";
+const MULTILINE_PAT_SUBSTITUTE: &str = "Q";
+
+#[test]
+fn plain_rule_applies_on_insertion() {
+    let (s, ..) = state! {
+        doc { root { paragraph { t1: text("") } } }
+        selection: (t1, 0)
+    };
+    let mut editor = Editor::new_test(s);
+    set_rules(&editor, vec![rule(PLAIN_PATTERN, PLAIN_SUBSTITUTE, false)]);
+
+    for ch in PLAIN_PATTERN.chars() {
+        type_text(&mut editor, &ch.to_string());
+    }
+
+    let (expected, ..) = state! {
+        doc { root { paragraph { t1: text("X") } } }
+        selection: (t1, 1)
+    };
+    assert_state_eq!(editor.state(), &expected);
+}
+
+#[test]
+fn no_rule_means_no_replacement() {
+    let (s, ..) = state! {
+        doc { root { paragraph { t1: text("") } } }
+        selection: (t1, 0)
+    };
+    let mut editor = Editor::new_test(s);
+
+    type_text(&mut editor, PLAIN_PATTERN);
+
+    let (expected, ..) = state! {
+        doc { root { paragraph { t1: text("abc") } } }
+        selection: (t1, 3)
+    };
+    assert_state_eq!(editor.state(), &expected);
+}
+
+#[test]
+fn non_matching_input_is_untouched() {
+    let (s, ..) = state! {
+        doc { root { paragraph { t1: text("") } } }
+        selection: (t1, 0)
+    };
+    let mut editor = Editor::new_test(s);
+    set_rules(&editor, vec![rule(PLAIN_PATTERN, PLAIN_SUBSTITUTE, false)]);
+
+    type_text(&mut editor, "zzz");
+
+    let (expected, ..) = state! {
+        doc { root { paragraph { t1: text("zzz") } } }
+        selection: (t1, 3)
+    };
+    assert_state_eq!(editor.state(), &expected);
+}
+
+#[test]
+fn regex_rule_applies_on_insertion() {
+    let (s, ..) = state! {
+        doc { root { paragraph { t1: text("") } } }
+        selection: (t1, 0)
+    };
+    let mut editor = Editor::new_test(s);
+    set_rules(&editor, vec![rule(REGEX_PATTERN, REGEX_SUBSTITUTE, true)]);
+
+    type_text(&mut editor, "42#");
+
+    let (expected, ..) = state! {
+        doc { root { paragraph { t1: text("N") } } }
+        selection: (t1, 1)
+    };
+    assert_state_eq!(editor.state(), &expected);
+}
+
+#[test]
+fn multiline_substitute_creates_hard_break() {
+    let (s, ..) = state! {
+        doc { root { paragraph { t1: text("") } } }
+        selection: (t1, 0)
+    };
+    let mut editor = Editor::new_test(s);
+    set_rules(
+        &editor,
+        vec![rule(MULTILINE_SUB_PATTERN, MULTILINE_SUB_SUBSTITUTE, false)],
+    );
+
+    type_text(&mut editor, MULTILINE_SUB_PATTERN);
+
+    let flat = flat_text(&editor);
+    for segment in MULTILINE_SUB_SUBSTITUTE.split('\n') {
+        assert!(
+            flat.contains(segment),
+            "missing substitute segment {segment:?} in {flat:?}"
+        );
+    }
+    assert!(
+        !flat.contains(MULTILINE_SUB_PATTERN),
+        "pattern leftover in {flat:?}"
+    );
+}
+
+#[test]
+fn multiline_pattern_matches_across_hard_break() {
+    let (s, _, t1) = state! {
+        doc {
+            root {
+                _p1: paragraph {
+                    text("P1")
+                    hard_break {}
+                    t1: text("P")
+                }
+            }
+        }
+        selection: (t1, 1)
+    };
+    let mut editor = Editor::new_test(s);
+    set_rules(
+        &editor,
+        vec![rule(MULTILINE_PAT_PATTERN, MULTILINE_PAT_SUBSTITUTE, true)],
+    );
+
+    type_text(&mut editor, "2");
+
+    let flat = flat_text(&editor);
+    assert!(flat.contains(MULTILINE_PAT_SUBSTITUTE), "got: {flat:?}");
+    assert!(!flat.contains("P1"), "got: {flat:?}");
+    assert!(!flat.contains("P2"), "got: {flat:?}");
+}
+
+#[test]
+fn backspace_immediately_after_replacement_restores_original() {
+    let (s, ..) = state! {
+        doc { root { paragraph { t1: text("") } } }
+        selection: (t1, 0)
+    };
+    let mut editor = Editor::new_test(s);
+    set_rules(&editor, vec![rule(PLAIN_PATTERN, PLAIN_SUBSTITUTE, false)]);
+
+    type_text(&mut editor, PLAIN_PATTERN);
+    key(&mut editor, Key::Backspace);
+
+    let (expected, ..) = state! {
+        doc { root { paragraph { t1: text("abc") } } }
+        selection: (t1, 3)
+    };
+    assert_state_eq!(editor.state(), &expected);
+}
+
+#[test]
+fn second_backspace_after_restore_is_normal_delete() {
+    let (s, ..) = state! {
+        doc { root { paragraph { t1: text("") } } }
+        selection: (t1, 0)
+    };
+    let mut editor = Editor::new_test(s);
+    set_rules(&editor, vec![rule(PLAIN_PATTERN, PLAIN_SUBSTITUTE, false)]);
+
+    type_text(&mut editor, PLAIN_PATTERN);
+    key(&mut editor, Key::Backspace);
+    key(&mut editor, Key::Backspace);
+
+    let (expected, ..) = state! {
+        doc { root { paragraph { t1: text("ab") } } }
+        selection: (t1, 2)
+    };
+    assert_state_eq!(editor.state(), &expected);
+}
+
+#[test]
+fn typing_after_replacement_invalidates_restore() {
+    let (s, ..) = state! {
+        doc { root { paragraph { t1: text("") } } }
+        selection: (t1, 0)
+    };
+    let mut editor = Editor::new_test(s);
+    set_rules(&editor, vec![rule(PLAIN_PATTERN, PLAIN_SUBSTITUTE, false)]);
+
+    type_text(&mut editor, PLAIN_PATTERN);
+    type_text(&mut editor, "z");
+    key(&mut editor, Key::Backspace);
+
+    let (expected, ..) = state! {
+        doc { root { paragraph { t1: text("X") } } }
+        selection: (t1, 1)
+    };
+    assert_state_eq!(editor.state(), &expected);
+}
+
+#[test]
+fn cursor_movement_invalidates_restore() {
+    let (s, ..) = state! {
+        doc { root { paragraph { t1: text("k") } } }
+        selection: (t1, 1)
+    };
+    let mut editor = Editor::new_test(s);
+    set_rules(&editor, vec![rule(PLAIN_PATTERN, PLAIN_SUBSTITUTE, false)]);
+
+    type_text(&mut editor, PLAIN_PATTERN);
+
+    // In tests, view-based movement (move_grapheme) is a no-op because the view
+    // has no layout. Push a SetSelection step directly so history reflects that
+    // the user moved the cursor, exactly as navigation would in production.
+    let sel = editor.state().selection;
+    editor
+        .transact(|tr| {
+            tr.set_selection(sel)?;
+            Ok(())
+        })
+        .unwrap();
+
+    key(&mut editor, Key::Backspace);
+
+    let flat = flat_text(&editor);
+    assert!(
+        !flat.contains(PLAIN_PATTERN),
+        "restore must not fire after navigation: {flat:?}"
+    );
+    assert!(
+        !flat.contains(PLAIN_SUBSTITUTE),
+        "substitute must be gone after normal backspace: {flat:?}"
+    );
+    assert!(
+        flat.contains('k'),
+        "pre-existing text must remain: {flat:?}"
+    );
+}
+
+#[test]
+fn multiline_replacement_restored_by_backspace() {
+    let (s, _, t1) = state! {
+        doc {
+            root {
+                _p1: paragraph {
+                    text("P1")
+                    hard_break {}
+                    t1: text("P")
+                }
+            }
+        }
+        selection: (t1, 1)
+    };
+    let mut editor = Editor::new_test(s);
+    set_rules(
+        &editor,
+        vec![rule(MULTILINE_PAT_PATTERN, MULTILINE_PAT_SUBSTITUTE, true)],
+    );
+
+    type_text(&mut editor, "2");
+    key(&mut editor, Key::Backspace);
+
+    let flat = flat_text(&editor);
+    assert!(flat.contains("P1"), "got: {flat:?}");
+    assert!(flat.contains("P2"), "got: {flat:?}");
+    assert!(
+        !flat.contains(MULTILINE_PAT_SUBSTITUTE),
+        "substitute must be gone: {flat:?}"
+    );
+}
+
+#[test]
+fn undo_after_replacement_does_not_leave_substitute_in_doc() {
+    let (s, ..) = state! {
+        doc { root { paragraph { t1: text("") } } }
+        selection: (t1, 0)
+    };
+    let mut editor = Editor::new_test(s);
+    set_rules(&editor, vec![rule(PLAIN_PATTERN, PLAIN_SUBSTITUTE, false)]);
+
+    type_text(&mut editor, PLAIN_PATTERN);
+    editor.apply(Message::History {
+        op: HistoryOp::Undo,
+    });
+
+    let flat = flat_text(&editor);
+    assert!(
+        !flat.contains(PLAIN_SUBSTITUTE),
+        "undo must rewind through the replacement: {flat:?}"
+    );
+}
+
+#[test]
+fn redo_after_undo_restores_substitute() {
+    let (s, ..) = state! {
+        doc { root { paragraph { t1: text("") } } }
+        selection: (t1, 0)
+    };
+    let mut editor = Editor::new_test(s);
+    set_rules(&editor, vec![rule(PLAIN_PATTERN, PLAIN_SUBSTITUTE, false)]);
+
+    type_text(&mut editor, PLAIN_PATTERN);
+    editor.apply(Message::History {
+        op: HistoryOp::Undo,
+    });
+    editor.apply(Message::History {
+        op: HistoryOp::Redo,
+    });
+
+    let flat = flat_text(&editor);
+    assert!(
+        flat.contains(PLAIN_SUBSTITUTE),
+        "redo must reproduce the replacement: {flat:?}"
+    );
+}
+
+#[test]
+fn undo_then_backspace_is_safe_when_replacement_undo_state_was_live() {
+    // After undo+redo, last_tag() is still AutoReplacement, so backspace fires
+    // the shortcut again and restores the original text. The mechanism must not
+    // corrupt the history stack.
+    let (s, ..) = state! {
+        doc { root { paragraph { t1: text("") } } }
+        selection: (t1, 0)
+    };
+    let mut editor = Editor::new_test(s);
+    set_rules(&editor, vec![rule(PLAIN_PATTERN, PLAIN_SUBSTITUTE, false)]);
+
+    type_text(&mut editor, PLAIN_PATTERN);
+    editor.apply(Message::History {
+        op: HistoryOp::Undo,
+    });
+    editor.apply(Message::History {
+        op: HistoryOp::Redo,
+    });
+    key(&mut editor, Key::Backspace);
+
+    // Backspace shortcut fires (last_tag == AutoReplacement after redo),
+    // undoing the replacement and restoring the original text.
+    let flat = flat_text(&editor);
+    assert!(
+        !flat.contains(PLAIN_SUBSTITUTE),
+        "substitute must be gone: {flat:?}"
+    );
+    assert!(
+        flat.contains(PLAIN_PATTERN),
+        "original text must be restored by shortcut: {flat:?}"
+    );
+    assert!(editor.history.can_redo(), "redo stack must be intact");
+}
+
+#[test]
+fn replacement_skipped_during_active_composition() {
+    let (s, ..) = state! {
+        doc { root { paragraph { t1: text("") } } }
+        selection: (t1, 0)
+    };
+    let mut editor = Editor::new_test(s);
+    set_rules(&editor, vec![rule(PLAIN_PATTERN, PLAIN_SUBSTITUTE, false)]);
+
+    editor.apply(Message::Composition {
+        op: CompositionOp::Update {
+            text: PLAIN_PATTERN.into(),
+            replace_length: None,
+        },
+    });
+
+    let flat = flat_text(&editor);
+    assert!(
+        flat.contains(PLAIN_PATTERN),
+        "raw composing text must remain in doc: {flat:?}"
+    );
+    assert!(
+        !flat.contains(PLAIN_SUBSTITUTE),
+        "replacement must not fire mid-composition: {flat:?}"
+    );
+    assert!(
+        editor.state().composition.is_some(),
+        "composition should still be active"
+    );
+}
+
+#[test]
+fn replacement_fires_on_commit_as_is() {
+    let (s, ..) = state! {
+        doc { root { paragraph { t1: text("") } } }
+        selection: (t1, 0)
+    };
+    let mut editor = Editor::new_test(s);
+    set_rules(&editor, vec![rule(PLAIN_PATTERN, PLAIN_SUBSTITUTE, false)]);
+
+    // CommitAsIs is the path the web host takes on `compositionend`.
+    editor.apply(Message::Composition {
+        op: CompositionOp::Update {
+            text: PLAIN_PATTERN.into(),
+            replace_length: None,
+        },
+    });
+    editor.apply(Message::Composition {
+        op: CompositionOp::CommitAsIs,
+    });
+
+    let flat = flat_text(&editor);
+    assert!(
+        flat.contains(PLAIN_SUBSTITUTE),
+        "commit must trigger replacement: {flat:?}"
+    );
+    assert!(
+        !flat.contains(PLAIN_PATTERN),
+        "raw composing text must be replaced: {flat:?}"
+    );
+    assert!(editor.state().composition.is_none());
+}
+
+#[test]
+fn replacement_fires_on_explicit_commit() {
+    let (s, ..) = state! {
+        doc { root { paragraph { t1: text("") } } }
+        selection: (t1, 0)
+    };
+    let mut editor = Editor::new_test(s);
+    set_rules(&editor, vec![rule(PLAIN_PATTERN, PLAIN_SUBSTITUTE, false)]);
+
+    editor.apply(Message::Composition {
+        op: CompositionOp::Commit {
+            text: PLAIN_PATTERN.into(),
+        },
+    });
+
+    let flat = flat_text(&editor);
+    assert!(flat.contains(PLAIN_SUBSTITUTE));
+    assert!(!flat.contains(PLAIN_PATTERN));
+}
+
+#[test]
+fn update_then_update_keeps_composition_intact() {
+    let (s, ..) = state! {
+        doc { root { paragraph { t1: text("") } } }
+        selection: (t1, 0)
+    };
+    let mut editor = Editor::new_test(s);
+    set_rules(&editor, vec![rule(PLAIN_PATTERN, PLAIN_SUBSTITUTE, false)]);
+
+    let partial = &PLAIN_PATTERN[..PLAIN_PATTERN.len() - 1];
+    editor.apply(Message::Composition {
+        op: CompositionOp::Update {
+            text: partial.into(),
+            replace_length: None,
+        },
+    });
+    editor.apply(Message::Composition {
+        op: CompositionOp::Update {
+            text: PLAIN_PATTERN.into(),
+            replace_length: None,
+        },
+    });
+
+    let flat = flat_text(&editor);
+    assert!(flat.contains(PLAIN_PATTERN), "got: {flat:?}");
+    assert!(!flat.contains(PLAIN_SUBSTITUTE), "got: {flat:?}");
+    assert_eq!(
+        editor.state().composition,
+        Some(Composition {
+            start: 1,
+            end: 1 + PLAIN_PATTERN.chars().count(),
+        })
+    );
+}

--- a/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
@@ -419,6 +419,13 @@ export interface PlainTextNode {
     text: string;
 }
 
+export interface RawTextReplacementRule {
+    id: string;
+    matchPattern: string;
+    substitute: string;
+    regex: boolean;
+}
+
 export interface Rect {
     x: number;
     y: number;
@@ -628,6 +635,7 @@ declare class EditorHost {
     root_attrs_from_graph(changesets: Uint8Array): PlainRootNode;
     root_modifiers_from_graph(changesets: Uint8Array): Modifier[];
     set_fonts(families: FontFamily[]): void;
+    set_text_replacement_rules(rules: RawTextReplacementRule[]): void;
 }
 
 export type { Editor, EditorHost };

--- a/crates/editor-ffi/src/host.rs
+++ b/crates/editor-ffi/src/host.rs
@@ -141,6 +141,16 @@ impl EditorHost {
             Ok(())
         })
     }
+
+    pub fn set_text_replacement_rules(
+        &self,
+        rules: Vec<Complex<editor_resource::RawTextReplacementRule>>,
+    ) -> EditorResult<()> {
+        self.with_resource(|resource| {
+            resource.set_text_replacement_rules(rules.from_ffi()?);
+            Ok(())
+        })
+    }
 }
 
 impl EditorHost {

--- a/crates/editor-resource/Cargo.toml
+++ b/crates/editor-resource/Cargo.toml
@@ -17,6 +17,7 @@ wasm = [
 editor-common = { path = "../editor-common" }
 editor-macros = { path = "../editor-macros" }
 editor-model = { path = "../editor-model" }
+fancy-regex.workspace = true
 fontique.workspace = true
 hashbrown.workspace = true
 icu_provider.workspace = true

--- a/crates/editor-resource/src/lib.rs
+++ b/crates/editor-resource/src/lib.rs
@@ -5,6 +5,7 @@ mod error;
 mod font;
 mod resource;
 mod segmentation;
+mod text_replacement;
 mod zstd;
 
 pub use brush::*;
@@ -12,4 +13,5 @@ pub use error::*;
 pub use font::*;
 pub use resource::*;
 pub use segmentation::*;
+pub use text_replacement::*;
 pub use zstd::*;

--- a/crates/editor-resource/src/resource.rs
+++ b/crates/editor-resource/src/resource.rs
@@ -5,6 +5,7 @@ use crate::brush::TextBrush;
 use crate::error::ResourceError;
 use crate::font::{FontFamily, FontRegistry, PLACEHOLDER_FAMILY_NAME, PLACEHOLDER_WEIGHT};
 use crate::segmentation::TextSegmenters;
+use crate::text_replacement::{RawTextReplacementRule, TextReplacementRule, compile_rules};
 
 const PLACEHOLDER_TTF: &[u8] = include_bytes!("../assets/placeholder.ttf");
 
@@ -13,6 +14,7 @@ pub struct Resource {
     pub font_context: FontContext,
     pub layout_context: LayoutContext<TextBrush>,
     pub segmenters: Arc<TextSegmenters>,
+    pub text_replacement_rules: Vec<TextReplacementRule>,
 }
 
 impl Resource {
@@ -22,9 +24,18 @@ impl Resource {
             font_context: FontContext::new(),
             layout_context: LayoutContext::new(),
             segmenters,
+            text_replacement_rules: Vec::new(),
         };
         resource.register_placeholder();
         resource
+    }
+
+    pub fn set_text_replacement_rules(&mut self, raw_rules: Vec<RawTextReplacementRule>) {
+        self.text_replacement_rules = compile_rules(raw_rules);
+    }
+
+    pub fn clear_text_replacement_rules(&mut self) {
+        self.text_replacement_rules.clear();
     }
 
     fn register_placeholder(&mut self) {

--- a/crates/editor-resource/src/text_replacement.rs
+++ b/crates/editor-resource/src/text_replacement.rs
@@ -1,0 +1,46 @@
+use std::sync::Arc;
+
+use editor_macros::ffi;
+use serde::{Deserialize, Serialize};
+
+#[ffi]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RawTextReplacementRule {
+    pub id: String,
+    pub match_pattern: String,
+    pub substitute: String,
+    pub regex: bool,
+}
+
+pub enum CompiledPattern {
+    Plain(String),
+    Regex(Arc<fancy_regex::Regex>),
+}
+
+pub struct TextReplacementRule {
+    pub id: String,
+    pub pattern: CompiledPattern,
+    pub substitute: String,
+}
+
+pub fn compile_rules(raw_rules: Vec<RawTextReplacementRule>) -> Vec<TextReplacementRule> {
+    raw_rules
+        .into_iter()
+        .filter_map(|r| {
+            let pattern = if r.regex {
+                match fancy_regex::Regex::new(&r.match_pattern) {
+                    Ok(re) => CompiledPattern::Regex(Arc::new(re)),
+                    Err(_) => return None,
+                }
+            } else {
+                CompiledPattern::Plain(r.match_pattern)
+            };
+            Some(TextReplacementRule {
+                id: r.id,
+                pattern,
+                substitute: r.substitute,
+            })
+        })
+        .collect()
+}


### PR DESCRIPTION
* 레거시 에디터의 텍스트 자동 치환 기능을 v2 에디터(editor-core) 엔진에 구현.

- **저장소**: host (모든 editor 인스턴스가 공유)
- **전달 방식**: direct method (host → editor)
- **실행**: editor-core 내부 (로컬 캐시로 빠른 매칭)
- **이벤트**: editor-core → host (`Effect::TextReplacementApplied`)

<h2>테스트</h2>
<p><code>crates/editor-core/src/text_replacement_tests.rs</code> — 4개 완료 조건 회귀 방지용 통합 테스트 16건. 룰 픽스처는 product 룰셋과 무관한 합성 패턴(<code>abc</code>/<code>X</code>, <code>\\d+#</code>/<code>N</code>, <code>mk</code>/<code>a\\nb</code>, <code>P1\\nP2</code>/<code>Q</code>).</p>

|| 조건 | 자동 테스트 | 수동 검증 |
|---|------|------------|---------|
| 1 | 사용자 text replacement rule이 본문 입력에 적용된다 | `plain_rule_applies_on_insertion`, `no_rule_means_no_replacement`, `non_matching_input_is_untouched`, `regex_rule_applies_on_insertion`, `multiline_substitute_creates_hard_break` (5건) | ✅ |
| 2 | 자동 치환 직후 backspace로 원문이 복원된다 | `backspace_immediately_after_replacement_restores_original`, `second_backspace_after_restore_is_normal_delete`, `typing_after_replacement_invalidates_restore`, `cursor_movement_invalidates_restore`, `multiline_replacement_restored_by_backspace` (5건) | ✅ |
| 3 | 자동 치환 적용/복원은 undo/redo history와 충돌하지 않는다 | `undo_after_replacement_does_not_leave_substitute_in_doc`, `redo_after_undo_restores_substitute`, `undo_then_backspace_is_safe_when_replacement_undo_state_was_live` (3건) | ✅ |
| 4 | IME 조합 중에는 자동 치환이 조합 텍스트를 깨뜨리지 않는다 (커밋 시 발동) | `replacement_skipped_during_active_composition`, `replacement_fires_on_commit_as_is`, `replacement_fires_on_explicit_commit`, `update_then_update_keeps_composition_intact` (3건, 멀티라인 패턴 케이스로 보강) | ✅ |

