### PR TITLE
cursor_hit_test, iOS 스칼라 반환 브리지 정리

### DIFF
--- a/crates/editor-bindgen/src/kotlin_ios.rs
+++ b/crates/editor-bindgen/src/kotlin_ios.rs
@@ -249,6 +249,15 @@ fn generate_method(
             }
         },
         FfiReturnType::Option(inner) => match inner {
+            FfiScalarReturn::Primitive(p) if is_objc_scalar_primitive(p, custom_types) => {
+                emit_pre_call_conversions(w, &method.params);
+                w.line(&format!("val result = {}", native_call));
+                w.line("error.value?.let { throw EditorException(it.localizedDescription) }");
+                w.line(&format!(
+                    "result?.{}",
+                    objc_number_value_property(p, custom_types)
+                ));
+            }
             FfiScalarReturn::Primitive(_) => {
                 emit_pre_call_conversions(w, &method.params);
                 w.line(&format!("val result = {}", native_call));
@@ -284,7 +293,12 @@ fn generate_method(
             emit_pre_call_conversions(w, &method.params);
             w.line(&format!("val result = {}", native_call));
             w.line("error.value?.let { throw EditorException(it.localizedDescription) }");
-            w.line("result!!");
+            if matches!(&method.return_type, FfiReturnType::Primitive(p) if is_objc_scalar_primitive(p, custom_types))
+            {
+                w.line("result");
+            } else {
+                w.line("result!!");
+            }
         }
     }
 
@@ -348,6 +362,34 @@ fn convert_param_value(param: &FfiParam, _custom_types: &HashMap<String, String>
 
 fn is_byte_array(ty: &FfiParamType) -> bool {
     matches!(ty, FfiParamType::Vec(FfiScalarParam::Primitive(p)) if p == "u8")
+}
+
+fn is_objc_scalar_primitive(name: &str, custom_types: &HashMap<String, String>) -> bool {
+    matches!(
+        custom_types.get(name).map(|s| s.as_str()).unwrap_or(name),
+        "bool"
+            | "u8"
+            | "u16"
+            | "u32"
+            | "usize"
+            | "i8"
+            | "i16"
+            | "i32"
+            | "u64"
+            | "i64"
+            | "f32"
+            | "f64"
+    )
+}
+
+fn objc_number_value_property(name: &str, custom_types: &HashMap<String, String>) -> &'static str {
+    match custom_types.get(name).map(|s| s.as_str()).unwrap_or(name) {
+        "bool" => "boolValue",
+        "u64" | "i64" => "longLongValue",
+        "f32" => "floatValue",
+        "f64" => "doubleValue",
+        _ => "intValue",
+    }
 }
 
 fn format_call_args_multiline(args: &[(usize, String, String)]) -> String {
@@ -760,5 +802,36 @@ mod tests {
         };
         let output = generate_ios_wrapper(&iface, &[iface.clone()], &empty_ct());
         assert!(output.contains("result?.let { json.decodeFromString(it) }"));
+    }
+
+    #[test]
+    fn scalar_primitive_return_uses_non_optional_cinterop_result() {
+        let iface = FfiInterface {
+            name: "Editor".into(),
+            methods: vec![make_method(
+                "cursor_hit_test",
+                vec![],
+                FfiReturnType::Primitive("bool".into()),
+            )],
+        };
+        let output = generate_ios_wrapper(&iface, &[iface.clone()], &empty_ct());
+        assert!(output.contains("val result = native.cursorHitTestWithError(error = error.ptr)"));
+        assert!(output.contains("error.value?.let { throw EditorException(it.localizedDescription) }\n            result"));
+        assert!(!output.contains("boolValue"));
+        assert!(!output.contains("result!!"));
+    }
+
+    #[test]
+    fn optional_scalar_primitive_return_unboxes_nsnumber() {
+        let iface = FfiInterface {
+            name: "Editor".into(),
+            methods: vec![make_method(
+                "maybe_hit",
+                vec![],
+                FfiReturnType::Option(FfiScalarReturn::Primitive("bool".into())),
+            )],
+        };
+        let output = generate_ios_wrapper(&iface, &[iface.clone()], &empty_ct());
+        assert!(output.contains("result?.boolValue"));
     }
 }

--- a/crates/editor-bindgen/src/swift.rs
+++ b/crates/editor-bindgen/src/swift.rs
@@ -139,16 +139,11 @@ fn generate_regular_method(
         format!("{}, {}", user_params, error_param)
     };
 
-    let ret_swift = swift_return_type(&method.return_type, custom_types);
-    let ret_part = if ret_swift.is_empty() {
+    let objc_ret_swift = objc_return_type(&method.return_type, custom_types);
+    let ret_part = if objc_ret_swift.is_empty() {
         String::new()
     } else {
-        let opt = if ret_swift.ends_with('?') {
-            ret_swift.clone()
-        } else {
-            format!("{}?", ret_swift)
-        };
-        format!(" -> {}", opt)
+        format!(" -> {}", objc_ret_swift)
     };
 
     let sig = format!(
@@ -163,8 +158,8 @@ fn generate_regular_method(
         format!("inner.{}({})", swift_name, call_args)
     };
 
-    let has_return = !ret_swift.is_empty();
     let return_expr = build_return_expr(&method.return_type, &call_expr, custom_types);
+    let error_return = build_error_return(&method.return_type, custom_types);
 
     let mut out = String::new();
     out.push_str(&format!("{} {{\n", sig));
@@ -175,11 +170,7 @@ fn generate_regular_method(
         out.push_str(
             "                userInfo: [NSLocalizedDescriptionKey: \"EditorHost not initialized\"])\n",
         );
-        if has_return {
-            out.push_str("            return nil\n");
-        } else {
-            out.push_str("            return\n");
-        }
+        out.push_str(&format!("            {}\n", error_return));
         out.push_str("        }\n");
     }
 
@@ -187,9 +178,7 @@ fn generate_regular_method(
     out.push_str(&format!("            {}\n", return_expr));
     out.push_str("        } catch let e {\n");
     out.push_str("            error.pointee = e as NSError\n");
-    if has_return {
-        out.push_str("            return nil\n");
-    }
+    out.push_str(&format!("            {}\n", error_return));
     out.push_str("        }\n");
 
     out.push_str("    }\n");
@@ -199,15 +188,52 @@ fn generate_regular_method(
 fn build_return_expr(
     ret: &FfiReturnType,
     call_expr: &str,
-    _custom_types: &HashMap<String, String>,
+    custom_types: &HashMap<String, String>,
 ) -> String {
     match ret {
         FfiReturnType::Unit => format!("try {}", call_expr),
+        FfiReturnType::Primitive(p) => build_primitive_return_expr(p, call_expr, custom_types),
         FfiReturnType::Owned(name) => {
             let native_name = format!("Native{}", name);
             format!("return {}(inner: try {})", native_name, call_expr)
         }
+        FfiReturnType::Option(FfiScalarReturn::Primitive(p))
+            if is_objc_scalar_primitive(p, custom_types) =>
+        {
+            format!(
+                "let result = try {}\n            return result.map {{ NSNumber(value: $0) }}",
+                call_expr
+            )
+        }
         _ => format!("return try {}", call_expr),
+    }
+}
+
+fn build_primitive_return_expr(
+    primitive: &str,
+    call_expr: &str,
+    custom_types: &HashMap<String, String>,
+) -> String {
+    match custom_types
+        .get(primitive)
+        .map(|s| s.as_str())
+        .unwrap_or(primitive)
+    {
+        "u8" | "u16" | "u32" | "usize" | "i8" | "i16" | "i32" => {
+            format!("return Int32(try {})", call_expr)
+        }
+        "u64" | "i64" => format!("return Int64(try {})", call_expr),
+        _ => format!("return try {}", call_expr),
+    }
+}
+
+fn build_error_return(ret: &FfiReturnType, custom_types: &HashMap<String, String>) -> String {
+    match ret {
+        FfiReturnType::Unit => "return".into(),
+        FfiReturnType::Primitive(p) if is_objc_scalar_primitive(p, custom_types) => {
+            format!("return {}", objc_scalar_default_value(p, custom_types))
+        }
+        _ => "return nil".into(),
     }
 }
 
@@ -232,27 +258,61 @@ fn swift_param_type(ty: &FfiParamType, custom_types: &HashMap<String, String>) -
     }
 }
 
-fn swift_return_type(ret: &FfiReturnType, custom_types: &HashMap<String, String>) -> String {
+fn objc_return_type(ret: &FfiReturnType, custom_types: &HashMap<String, String>) -> String {
     match ret {
         FfiReturnType::Unit => String::new(),
-        FfiReturnType::Primitive(p) => resolve_swift_primitive(p, custom_types),
-        FfiReturnType::Complex(_) => "String".into(),
-        FfiReturnType::Owned(name) => format!("Native{}", name),
-        FfiReturnType::Vec(inner) => match inner {
-            FfiScalarReturn::Primitive(p) if p == "u8" => "Data".into(),
-            FfiScalarReturn::Complex(_) | FfiScalarReturn::Owned(_) => "[String]".into(),
-            FfiScalarReturn::Primitive(p) => {
-                format!("[{}]", resolve_swift_primitive(p, custom_types))
-            }
-        },
+        FfiReturnType::Primitive(p) if is_objc_scalar_primitive(p, custom_types) => {
+            resolve_swift_primitive(p, custom_types)
+        }
+        FfiReturnType::Primitive(p) => format!("{}?", resolve_swift_primitive(p, custom_types)),
+        FfiReturnType::Complex(_) => "String?".into(),
+        FfiReturnType::Owned(name) => format!("Native{}?", name),
+        FfiReturnType::Vec(inner) => {
+            let base = match inner {
+                FfiScalarReturn::Primitive(p) if p == "u8" => "Data".into(),
+                FfiScalarReturn::Complex(_) | FfiScalarReturn::Owned(_) => "[String]".into(),
+                FfiScalarReturn::Primitive(p) => {
+                    format!("[{}]", resolve_swift_primitive(p, custom_types))
+                }
+            };
+            format!("{}?", base)
+        }
         FfiReturnType::Option(inner) => {
             let base = match inner {
+                FfiScalarReturn::Primitive(p) if is_objc_scalar_primitive(p, custom_types) => {
+                    "NSNumber".into()
+                }
                 FfiScalarReturn::Primitive(p) => resolve_swift_primitive(p, custom_types),
                 FfiScalarReturn::Complex(_) => "String".into(),
                 FfiScalarReturn::Owned(name) => format!("Native{}", name),
             };
             format!("{}?", base)
         }
+    }
+}
+
+fn is_objc_scalar_primitive(name: &str, custom_types: &HashMap<String, String>) -> bool {
+    matches!(
+        custom_types.get(name).map(|s| s.as_str()).unwrap_or(name),
+        "bool"
+            | "u8"
+            | "u16"
+            | "u32"
+            | "usize"
+            | "i8"
+            | "i16"
+            | "i32"
+            | "u64"
+            | "i64"
+            | "f32"
+            | "f64"
+    )
+}
+
+fn objc_scalar_default_value(name: &str, custom_types: &HashMap<String, String>) -> &'static str {
+    match custom_types.get(name).map(|s| s.as_str()).unwrap_or(name) {
+        "bool" => "false",
+        _ => "0",
     }
 }
 
@@ -279,7 +339,7 @@ fn resolve_swift_primitive(name: &str, custom_types: &HashMap<String, String>) -
     let resolved = custom_types.get(name).map(|s| s.as_str()).unwrap_or(name);
     match resolved {
         "bool" => "Bool".into(),
-        "u16" | "i16" | "u32" | "i32" | "usize" => "Int32".into(),
+        "u8" | "u16" | "i8" | "i16" | "u32" | "i32" | "usize" => "Int32".into(),
         "u64" | "i64" => "Int64".into(),
         "f32" => "Float".into(),
         "f64" => "Double".into(),
@@ -428,6 +488,83 @@ mod tests {
         let iface = editor_host_iface();
         let output = generate_class(&iface, &empty_ct());
         assert!(output.contains("-> NativeEditor?"));
+    }
+
+    #[test]
+    fn scalar_primitive_return_is_non_optional_for_objc_export() {
+        let iface = FfiInterface {
+            name: "Editor".into(),
+            methods: vec![FfiMethod {
+                name: "cursor_hit_test".into(),
+                is_async: false,
+                is_constructor: false,
+                params: vec![],
+                return_type: FfiReturnType::Primitive("bool".into()),
+            }],
+        };
+
+        let output = generate_class(&iface, &empty_ct());
+
+        assert!(output.contains(
+            "func cursorHitTest(error: AutoreleasingUnsafeMutablePointer<NSError?>) -> Bool"
+        ));
+        assert!(output.contains("return try inner.cursorHitTest()"));
+        assert!(output.contains("return false"));
+        assert!(!output.contains("-> Bool?"));
+        assert!(!output.contains("NSNumber"));
+    }
+
+    #[test]
+    fn host_scalar_primitive_return_uses_dummy_value_on_uninitialized_or_error() {
+        let iface = FfiInterface {
+            name: "EditorHost".into(),
+            methods: vec![
+                FfiMethod {
+                    name: "create".into(),
+                    is_async: false,
+                    is_constructor: true,
+                    params: vec![],
+                    return_type: FfiReturnType::Owned("EditorHost".into()),
+                },
+                FfiMethod {
+                    name: "revision".into(),
+                    is_async: false,
+                    is_constructor: false,
+                    params: vec![],
+                    return_type: FfiReturnType::Primitive("u32".into()),
+                },
+            ],
+        };
+
+        let output = generate_class(&iface, &empty_ct());
+
+        assert!(output.contains(
+            "func revision(error: AutoreleasingUnsafeMutablePointer<NSError?>) -> Int32"
+        ));
+        assert!(output.contains("return Int32(try inner.revision())"));
+        assert!(output.contains("EditorHost not initialized\"])\n            return 0"));
+        assert!(output.contains("error.pointee = e as NSError\n            return 0"));
+    }
+
+    #[test]
+    fn optional_scalar_primitive_return_stays_boxed_for_objc_export() {
+        let iface = FfiInterface {
+            name: "Editor".into(),
+            methods: vec![FfiMethod {
+                name: "maybe_hit".into(),
+                is_async: false,
+                is_constructor: false,
+                params: vec![],
+                return_type: FfiReturnType::Option(FfiScalarReturn::Primitive("bool".into())),
+            }],
+        };
+
+        let output = generate_class(&iface, &empty_ct());
+
+        assert!(output.contains(
+            "func maybeHit(error: AutoreleasingUnsafeMutablePointer<NSError?>) -> NSNumber?"
+        ));
+        assert!(output.contains("return result.map { NSNumber(value: $0) }"));
     }
 
     #[test]

--- a/crates/editor-core/src/editor.rs
+++ b/crates/editor-core/src/editor.rs
@@ -142,6 +142,28 @@ impl Editor {
         self.view.selection_hit_test(&resolved, page_idx, x, y)
     }
 
+    pub fn cursor_hit_test(&self, page_idx: usize, x: f32, y: f32) -> bool {
+        let selection = self.state.selection;
+        if !selection.is_collapsed() {
+            return false;
+        }
+
+        let Some(hit_selection) = self.view.hit_test(page_idx, x, y) else {
+            return false;
+        };
+        if !hit_selection.is_collapsed() {
+            return false;
+        }
+
+        let Some(current_head) = selection.head.resolve(&self.state.doc) else {
+            return false;
+        };
+        let Some(hit_head) = hit_selection.head.resolve(&self.state.doc) else {
+            return false;
+        };
+        current_head == hit_head
+    }
+
     pub fn pointer_style(
         &self,
         page_idx: usize,
@@ -1572,6 +1594,62 @@ mod tests {
             event: crate::message::SystemEvent::Initialize,
         });
         assert!(!editor.selection_hit_test(0, 10.0, 10.0));
+    }
+
+    #[test]
+    fn editor_cursor_hit_test_matches_current_collapsed_position() {
+        let (initial, ..) = state! {
+            doc { root { paragraph { t: text("hello") } } }
+            selection: (t, 2)
+        };
+        let mut editor = Editor::new_test(initial);
+        editor.apply(Message::System {
+            event: crate::message::SystemEvent::Initialize,
+        });
+
+        let cursor = editor
+            .view()
+            .cursor_metrics(&editor.state.doc, &editor.state.selection.head)
+            .expect("collapsed cursor has metrics");
+        let probe_x = cursor.caret.x;
+        let probe_y = cursor.line.y + cursor.line.height * 0.5;
+
+        assert!(editor.cursor_hit_test(0, probe_x, probe_y));
+    }
+
+    #[test]
+    fn editor_cursor_hit_test_rejects_different_position() {
+        let (initial, ..) = state! {
+            doc { root { paragraph { t: text("hello") } } }
+            selection: (t, 0)
+        };
+        let mut editor = Editor::new_test(initial);
+        editor.apply(Message::System {
+            event: crate::message::SystemEvent::Initialize,
+        });
+
+        let cursor = editor
+            .view()
+            .cursor_metrics(&editor.state.doc, &editor.state.selection.head)
+            .expect("collapsed cursor has metrics");
+        let probe_x = cursor.caret.x + 100.0;
+        let probe_y = cursor.line.y + cursor.line.height * 0.5;
+
+        assert!(!editor.cursor_hit_test(0, probe_x, probe_y));
+    }
+
+    #[test]
+    fn editor_cursor_hit_test_rejects_range_selection() {
+        let (initial, ..) = state! {
+            doc { root { paragraph { t: text("hello") } } }
+            selection: (t, 0) -> (t, 2)
+        };
+        let mut editor = Editor::new_test(initial);
+        editor.apply(Message::System {
+            event: crate::message::SystemEvent::Initialize,
+        });
+
+        assert!(!editor.cursor_hit_test(0, 10.0, 10.0));
     }
 
     #[test]

--- a/crates/editor-ffi/src/editor.rs
+++ b/crates/editor-ffi/src/editor.rs
@@ -108,6 +108,10 @@ impl Editor {
         self.with_inner(|inner| Ok(inner.editor.selection_hit_test(page as usize, x, y)))
     }
 
+    pub fn cursor_hit_test(&self, page: u32, x: f32, y: f32) -> EditorResult<bool> {
+        self.with_inner(|inner| Ok(inner.editor.cursor_hit_test(page as usize, x, y)))
+    }
+
     pub fn pointer_style(
         &self,
         page: u32,
@@ -368,6 +372,31 @@ mod tests {
         assert!(
             hit,
             "probe inside selection rect must register as hit through FFI"
+        );
+    }
+
+    #[test]
+    fn ffi_cursor_hit_test_resolves_and_forwards() {
+        let (initial, ..) = state! {
+            doc { root { paragraph { t: text("hello") } } }
+            selection: (t, 2)
+        };
+        let editor = make_ffi_editor(initial);
+        let cursor = editor
+            .cursor()
+            .expect("ffi call returns Ok")
+            .expect("collapsed cursor has metrics")
+            .from_ffi()
+            .expect("cursor metrics decode");
+        let probe_x = cursor.caret.x;
+        let probe_y = cursor.line.y + cursor.line.height * 0.5;
+        let hit = editor
+            .cursor_hit_test(0, probe_x, probe_y)
+            .expect("ffi call returns Ok");
+
+        assert!(
+            hit,
+            "probe resolving to current cursor must register as hit through FFI"
         );
     }
 }


### PR DESCRIPTION
- cursor_hit_test 추가: 안드로이드에서는 cursor 위치일 때만 롱프레스 후 이동으로 커서 이동이 가능해야 함. (그 외에는 롱프레스 후 이동이 iOS의 더블탭 드래그처럼 동작해야 함)
- non-optional scalar는 ObjC scalar로 유지하고 optional scalar만 NSNumber?로 감싸도록 함: selection_hit_test / cursor_hit_test처럼 non-optional bool을 반환하는 경우 generated Kotlin의 `Boolean`과 일치하게끔