### PR TITLE
feat: text auto surround 기능 구현

### DIFF
--- a/crates/editor-commands/src/commands/auto_surround.rs
+++ b/crates/editor-commands/src/commands/auto_surround.rs
@@ -1,0 +1,110 @@
+use editor_transaction::Transaction;
+
+use crate::CommandResult;
+use crate::commands::surround_selection;
+
+const AUTO_SURROUND_PAIRS: &[(&str, &str, &str)] = &[
+    ("(", "(", ")"),
+    ("[", "[", "]"),
+    ("{", "{", "}"),
+    ("\"", "\u{201C}", "\u{201D}"),
+    ("'", "\u{2018}", "\u{2019}"),
+    ("\u{201C}", "\u{201C}", "\u{201D}"),
+    ("\u{2018}", "\u{2018}", "\u{2019}"),
+    ("`", "`", "`"),
+    ("<", "<", ">"),
+    ("\u{300C}", "\u{300C}", "\u{300D}"), // 「」
+    ("\u{300E}", "\u{300E}", "\u{300F}"), // 『』
+    ("\u{300A}", "\u{300A}", "\u{300B}"), // 《》
+    ("\u{3008}", "\u{3008}", "\u{3009}"), // 〈〉
+    ("\u{3010}", "\u{3010}", "\u{3011}"), // 【】
+    ("\u{3014}", "\u{3014}", "\u{3015}"), // 〔〕
+    ("*", "*", "*"),
+    ("_", "_", "_"),
+    ("=", "=", "="),
+    ("+", "+", "+"),
+    ("-", "-", "-"),
+    ("~", "~", "~"),
+    ("|", "|", "|"),
+    ("^", "^", "^"),
+];
+
+pub fn auto_surround(tr: &mut Transaction, text: &str) -> CommandResult {
+    let Some((_, left, right)) = AUTO_SURROUND_PAIRS
+        .iter()
+        .find(|(trigger, _, _)| *trigger == text)
+    else {
+        return Ok(false);
+    };
+
+    surround_selection(tr, left, right)
+}
+
+#[cfg(test)]
+mod tests {
+    use editor_macros::state;
+    use editor_state::assert_state_eq;
+
+    use super::*;
+    use crate::test_utils::*;
+
+    #[test]
+    fn parenthesis_surrounds_selection() {
+        let (initial, ..) = state! {
+            doc { root { paragraph { t1: text("hello world") } } }
+            selection: (t1, 0) -> (t1, 11)
+        };
+        let (actual, ..) = transact!(initial, |tr| auto_surround(&mut tr, "("));
+        let (expected, ..) = state! {
+            doc { root { paragraph { t1: text("(hello world)") } } }
+            selection: (t1, 0) -> (t1, 13)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn ascii_quote_produces_curly_quotes() {
+        let (initial, ..) = state! {
+            doc { root { paragraph { t1: text("hello") } } }
+            selection: (t1, 0) -> (t1, 5)
+        };
+        let (actual, ..) = transact!(initial, |tr| auto_surround(&mut tr, "\""));
+        let (expected, ..) = state! {
+            doc { root { paragraph { t1: text("\u{201C}hello\u{201D}") } } }
+            selection: (t1, 0) -> (t1, 7)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn no_match_returns_false() {
+        let (initial, ..) = state! {
+            doc { root { paragraph { t1: text("hello") } } }
+            selection: (t1, 0) -> (t1, 5)
+        };
+        transact_fail!(initial, |tr| auto_surround(&mut tr, "x"));
+    }
+
+    #[test]
+    fn collapsed_selection_returns_false() {
+        let (initial, ..) = state! {
+            doc { root { paragraph { t1: text("hello") } } }
+            selection: (t1, 2)
+        };
+        transact_fail!(initial, |tr| auto_surround(&mut tr, "("));
+    }
+
+    #[test]
+    fn cjk_bracket_surrounds_selection() {
+        let (initial, ..) = state! {
+            doc { root { paragraph { t1: text("일이삼") } } }
+            selection: (t1, 0) -> (t1, 3)
+        };
+        let (actual, ..) = transact!(initial, |tr| auto_surround(&mut tr, "\u{300C}"));
+        let (expected, ..) = state! {
+            doc { root { paragraph { t1: text("\u{300C}일이삼\u{300D}") } } }
+            selection: (t1, 0) -> (t1, 5)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+}

--- a/crates/editor-commands/src/commands/mod.rs
+++ b/crates/editor-commands/src/commands/mod.rs
@@ -1,3 +1,4 @@
+mod auto_surround;
 mod clear_all_modifiers;
 mod delete_empty_paragraph_backward;
 mod delete_empty_paragraph_forward;
@@ -47,10 +48,12 @@ mod sink_list_item;
 mod sink_paragraph_backward;
 mod split_list_item;
 mod split_paragraph;
+mod surround_selection;
 mod toggle_bold;
 mod toggle_modifier;
 mod try_text_replacement;
 
+pub use auto_surround::auto_surround;
 pub use clear_all_modifiers::clear_all_modifiers;
 pub use delete_empty_paragraph_backward::delete_empty_paragraph_backward;
 pub use delete_empty_paragraph_forward::delete_empty_paragraph_forward;
@@ -100,6 +103,7 @@ pub use sink_list_item::sink_list_item;
 pub use sink_paragraph_backward::sink_paragraph_backward;
 pub use split_list_item::split_list_item;
 pub use split_paragraph::split_paragraph;
+pub use surround_selection::surround_selection;
 pub use toggle_bold::toggle_bold;
 pub use toggle_modifier::toggle_modifier;
 pub use try_text_replacement::try_text_replacement;

--- a/crates/editor-commands/src/commands/surround_selection.rs
+++ b/crates/editor-commands/src/commands/surround_selection.rs
@@ -1,0 +1,196 @@
+use editor_model::Node;
+use editor_state::{NodeRefCursorExt, Position, Selection};
+use editor_transaction::Transaction;
+
+use crate::{CommandError, CommandResult};
+
+pub fn surround_selection(tr: &mut Transaction, left: &str, right: &str) -> CommandResult {
+    let selection = tr.selection();
+    if selection.is_collapsed() {
+        return Ok(false);
+    }
+
+    let doc = tr.doc();
+    let resolved = selection
+        .resolve(&doc)
+        .ok_or_else(|| CommandError::Corrupted("cannot resolve selection".into()))?;
+
+    let raw_from_id = resolved.from().node_id();
+    let raw_from_offset = resolved.from().offset();
+    let raw_to_id = resolved.to().node_id();
+    let raw_to_offset = resolved.to().offset();
+
+    let from_pos = {
+        let doc = tr.doc();
+        let node = doc
+            .node(raw_from_id)
+            .ok_or(CommandError::NodeNotFound(raw_from_id))?;
+        if matches!(node.node(), Node::Text(_)) {
+            Position {
+                node_id: raw_from_id,
+                offset: raw_from_offset,
+                affinity: resolved.from().affinity(),
+            }
+        } else {
+            let child = node
+                .children()
+                .nth(raw_from_offset)
+                .and_then(|c| c.first_cursor_position());
+            match child {
+                Some(pos)
+                    if doc
+                        .node(pos.node_id)
+                        .is_some_and(|n| matches!(n.node(), Node::Text(_))) =>
+                {
+                    pos
+                }
+                _ => return Ok(false),
+            }
+        }
+    };
+
+    let to_pos = {
+        let doc = tr.doc();
+        let node = doc
+            .node(raw_to_id)
+            .ok_or(CommandError::NodeNotFound(raw_to_id))?;
+        if matches!(node.node(), Node::Text(_)) {
+            Position {
+                node_id: raw_to_id,
+                offset: raw_to_offset,
+                affinity: resolved.to().affinity(),
+            }
+        } else {
+            let child = raw_to_offset
+                .checked_sub(1)
+                .and_then(|idx| node.children().nth(idx))
+                .and_then(|c| c.last_cursor_position());
+            match child {
+                Some(pos)
+                    if doc
+                        .node(pos.node_id)
+                        .is_some_and(|n| matches!(n.node(), Node::Text(_))) =>
+                {
+                    pos
+                }
+                _ => return Ok(false),
+            }
+        }
+    };
+
+    let from_id = from_pos.node_id;
+    let to_id = to_pos.node_id;
+    let from_offset = from_pos.offset;
+    let to_offset = to_pos.offset;
+
+    let left_char_count = left.chars().count();
+    let right_char_count = right.chars().count();
+
+    // Insert right first so the from position is not shifted.
+    tr.insert_text(to_id, to_offset, right)?;
+    tr.insert_text(from_id, from_offset, left)?;
+
+    let new_to_offset = if from_id == to_id {
+        to_offset + left_char_count + right_char_count
+    } else {
+        to_offset + right_char_count
+    };
+
+    let new_from = Position {
+        node_id: from_id,
+        offset: from_offset,
+        affinity: from_pos.affinity,
+    };
+    let new_to = Position {
+        node_id: to_id,
+        offset: new_to_offset,
+        affinity: to_pos.affinity,
+    };
+    tr.set_selection(Selection::new(new_from, new_to))?;
+
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use editor_macros::state;
+    use editor_state::assert_state_eq;
+
+    use super::*;
+    use crate::test_utils::*;
+
+    #[test]
+    fn collapsed_selection_returns_false() {
+        let (initial, ..) = state! {
+            doc { root { paragraph { t1: text("hello") } } }
+            selection: (t1, 2)
+        };
+        transact_fail!(initial, |tr| surround_selection(&mut tr, "(", ")"));
+    }
+
+    #[test]
+    fn surrounds_within_single_text_node() {
+        let (initial, ..) = state! {
+            doc { root { paragraph { t1: text("hello world") } } }
+            selection: (t1, 6) -> (t1, 11)
+        };
+        let (actual, ..) = transact!(initial, |tr| surround_selection(&mut tr, "(", ")"));
+        let (expected, ..) = state! {
+            doc { root { paragraph { t1: text("hello (world)") } } }
+            selection: (t1, 6) -> (t1, 13)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn surrounds_across_two_paragraphs() {
+        let (initial, ..) = state! {
+            doc { root {
+                paragraph { t1: text("hello") }
+                paragraph { t2: text("world") }
+            } }
+            selection: (t1, 2) -> (t2, 3)
+        };
+        let (actual, ..) = transact!(initial, |tr| surround_selection(&mut tr, "[", "]"));
+        let (expected, ..) = state! {
+            doc { root {
+                paragraph { t1: text("he[llo") }
+                paragraph { t2: text("wor]ld") }
+            } }
+            selection: (t1, 2) -> (t2, 4)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn surrounds_block_unit_selection() {
+        // Unit selection: the whole paragraph is selected at the root container level.
+        // auto_surround must descend into the block and find the text endpoints.
+        let (initial, _r1, ..) = state! {
+            doc { r1: root { paragraph { t1: text("A") } } }
+            selection: (r1, 0, >) -> (r1, 1, <)
+        };
+        let (actual, ..) = transact!(initial, |tr| surround_selection(&mut tr, "(", ")"));
+        let (expected, ..) = state! {
+            doc { root { paragraph { t1: text("(A)") } } }
+            selection: (t1, 0) -> (t1, 3)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn ascii_quote_maps_to_curly_pair() {
+        let (initial, ..) = state! {
+            doc { root { paragraph { t1: text("hello") } } }
+            selection: (t1, 0) -> (t1, 5)
+        };
+        let (actual, ..) = transact!(initial, |tr| surround_selection(
+            &mut tr, "\u{201C}", "\u{201D}"
+        ));
+        let (expected, ..) = state! {
+            doc { root { paragraph { t1: text("\u{201C}hello\u{201D}") } } }
+            selection: (t1, 0) -> (t1, 7)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+}

--- a/crates/editor-core/src/handle/insertion.rs
+++ b/crates/editor-core/src/handle/insertion.rs
@@ -5,6 +5,23 @@ use crate::error::EditorError;
 use crate::message::*;
 
 pub fn handle_insertion_op(editor: &mut Editor, op: InsertionOp) -> Result<(), EditorError> {
+    // Auto surround: when the user types a bracket/quote over a non-collapsed selection
+    // and IME is not active, wrap the selection instead of replacing it.
+    if let InsertionOp::Text { text } = &op {
+        let enabled = editor.resource.lock().unwrap().auto_surround_enabled;
+        if enabled && editor.state.composition.is_none() {
+            let text = text.clone();
+            let mut surround_applied = false;
+            editor.transact(|tr| {
+                surround_applied = commands::auto_surround(tr, &text)?;
+                Ok(())
+            })?;
+            if surround_applied {
+                return Ok(());
+            }
+        }
+    }
+
     editor.transact(|tr| {
         match &op {
             InsertionOp::Text { text } => {
@@ -456,6 +473,63 @@ mod tests {
         let (expected, ..) = state! {
             doc { root { paragraph { t1: text("hello w") } } }
             selection: (t1, 7)
+        };
+        assert_state_eq!(editor.state(), &expected);
+    }
+
+    #[test]
+    fn auto_surround_wraps_selection_with_parens() {
+        let (state, ..) = state! {
+            doc { root { paragraph { t1: text("hello world") } } }
+            selection: (t1, 6) -> (t1, 11)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.apply(Message::Insertion {
+            op: InsertionOp::Text { text: "(".into() },
+        });
+        let (expected, ..) = state! {
+            doc { root { paragraph { t1: text("hello (world)") } } }
+            selection: (t1, 6) -> (t1, 13)
+        };
+        assert_state_eq!(editor.state(), &expected);
+        assert!(editor.history.can_undo());
+    }
+
+    #[test]
+    fn auto_surround_disabled_replaces_selection_normally() {
+        let (state, ..) = state! {
+            doc { root { paragraph { t1: text("hello world") } } }
+            selection: (t1, 6) -> (t1, 11)
+        };
+        let mut editor = Editor::new_test(state);
+        editor
+            .resource
+            .lock()
+            .unwrap()
+            .set_auto_surround_enabled(false);
+        editor.apply(Message::Insertion {
+            op: InsertionOp::Text { text: "(".into() },
+        });
+        let (expected, ..) = state! {
+            doc { root { paragraph { t1: text("hello (") } } }
+            selection: (t1, 7)
+        };
+        assert_state_eq!(editor.state(), &expected);
+    }
+
+    #[test]
+    fn auto_surround_collapsed_selection_inserts_normally() {
+        let (state, ..) = state! {
+            doc { root { paragraph { t1: text("hello") } } }
+            selection: (t1, 5)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.apply(Message::Insertion {
+            op: InsertionOp::Text { text: "(".into() },
+        });
+        let (expected, ..) = state! {
+            doc { root { paragraph { t1: text("hello(") } } }
+            selection: (t1, 6)
         };
         assert_state_eq!(editor.state(), &expected);
     }

--- a/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
@@ -600,6 +600,7 @@ declare class Editor {
     block_state(): BlockState;
     current_heads(): Uint8Array;
     cursor(): CursorMetrics | undefined;
+    cursor_hit_test(page: number, x: number, y: number): boolean;
     detach_surface(page: number): void;
     enqueue(message: Message): void;
     external_elements(): ExternalElement[];
@@ -634,6 +635,7 @@ declare class EditorHost {
     extract_text_from_graph(changesets: Uint8Array): string;
     root_attrs_from_graph(changesets: Uint8Array): PlainRootNode;
     root_modifiers_from_graph(changesets: Uint8Array): Modifier[];
+    set_auto_surround_enabled(enabled: boolean): void;
     set_fonts(families: FontFamily[]): void;
     set_text_replacement_rules(rules: RawTextReplacementRule[]): void;
 }

--- a/crates/editor-ffi/pkg/server/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/server/editor_ffi.d.ts
@@ -660,6 +660,7 @@ declare class EditorHost {
     root_modifiers_from_graph(changesets: Uint8Array): Modifier[];
     set_fonts(families: FontFamily[]): void;
     set_text_replacement_rules(rules: RawTextReplacementRule[]): void;
+    set_auto_surround_enabled(enabled: boolean): void;
 }
 
 declare class EditorServer {

--- a/crates/editor-ffi/src/host.rs
+++ b/crates/editor-ffi/src/host.rs
@@ -151,6 +151,13 @@ impl EditorHost {
             Ok(())
         })
     }
+
+    pub fn set_auto_surround_enabled(&self, enabled: bool) -> EditorResult<()> {
+        self.with_resource(|resource| {
+            resource.set_auto_surround_enabled(enabled);
+            Ok(())
+        })
+    }
 }
 
 impl EditorHost {

--- a/crates/editor-resource/src/resource.rs
+++ b/crates/editor-resource/src/resource.rs
@@ -15,6 +15,7 @@ pub struct Resource {
     pub layout_context: LayoutContext<TextBrush>,
     pub segmenters: Arc<TextSegmenters>,
     pub text_replacement_rules: Vec<TextReplacementRule>,
+    pub auto_surround_enabled: bool,
 }
 
 impl Resource {
@@ -25,6 +26,7 @@ impl Resource {
             layout_context: LayoutContext::new(),
             segmenters,
             text_replacement_rules: Vec::new(),
+            auto_surround_enabled: true,
         };
         resource.register_placeholder();
         resource
@@ -32,6 +34,10 @@ impl Resource {
 
     pub fn set_text_replacement_rules(&mut self, raw_rules: Vec<RawTextReplacementRule>) {
         self.text_replacement_rules = compile_rules(raw_rules);
+    }
+
+    pub fn set_auto_surround_enabled(&mut self, enabled: bool) {
+        self.auto_surround_enabled = enabled;
     }
 
     pub fn clear_text_replacement_rules(&mut self) {


### PR DESCRIPTION
 선택 영역이 있을 때 괄호/따옴표 등을 입력하면 선택 텍스트를 대체하지 않고 양쪽에 감싸는 auto surround 기능 구현.

- 삽입 순서 — right를 먼저 삽입하고 left를 나중에 삽입. 반대 순서면 to
  offset이 밀려 위치 계산이 틀어진다.
- container position 처리 — (root, 0) → (root, 1) 같은 블록 단위 선택의 경우,
   from은 해당 자식의 first_cursor_position(), to는
  last_cursor_position()으로 해소 후 처리.
- selection 복원 — 삽입 후 선택 영역을 (left_bracket 위치) → (right_bracket
  끝) 으로 재설정. 같은 노드면 to + left_len + right_len, 다른 노드면 to +
  right_len.
- undo — 단일 transaction으로 감싸므로 undo 한 번으로 전체 되돌아간다.