### PR TITLE
TR-92 이미지 캐싱 및 렌더링 구현

### DIFF
--- a/apps/api/src/graphql/resolvers/document.ts
+++ b/apps/api/src/graphql/resolvers/document.ts
@@ -217,15 +217,34 @@ Document.implement({
     assets: t.field({
       type: [DocumentAsset],
       resolve: async (self) => {
-        const content = await db
-          .select({ snapshot: DocumentContents.snapshot })
-          .from(DocumentContents)
-          .where(eq(DocumentContents.documentId, self.id))
-          .then(firstOrThrow);
+        const state = await db
+          .select({ json: DocumentStates.json })
+          .from(DocumentStates)
+          .where(eq(DocumentStates.documentId, self.id))
+          .then(first);
 
-        const doc = new LoroDoc();
-        doc.import(content.snapshot);
-        const { imageIds, fileIds, embedIds, archivedIds } = extractAssetIdsFromLoroDoc(doc);
+        let imageIds: string[];
+        let fileIds: string[];
+        let embedIds: string[];
+        let archivedIds: string[];
+
+        if (state) {
+          const plain = state.json as { nodes: Record<string, { node: { type: string; id?: string | null } }> };
+          const nodes = Object.values(plain.nodes);
+          imageIds = [...new Set(nodes.flatMap((e) => (e.node.type === 'image' && e.node.id != null ? [e.node.id] : [])))];
+          fileIds = [...new Set(nodes.flatMap((e) => (e.node.type === 'file' && e.node.id != null ? [e.node.id] : [])))];
+          embedIds = [...new Set(nodes.flatMap((e) => (e.node.type === 'embed' && e.node.id != null ? [e.node.id] : [])))];
+          archivedIds = [...new Set(nodes.flatMap((e) => (e.node.type === 'archived' && e.node.id != null ? [e.node.id] : [])))];
+        } else {
+          const content = await db
+            .select({ snapshot: DocumentContents.snapshot })
+            .from(DocumentContents)
+            .where(eq(DocumentContents.documentId, self.id))
+            .then(firstOrThrow);
+          const doc = new LoroDoc();
+          doc.import(content.snapshot);
+          ({ imageIds, fileIds, embedIds, archivedIds } = extractAssetIdsFromLoroDoc(doc));
+        }
 
         const [existingImageIds, existingFileIds, existingEmbedIds, existingArchivedIds] = await Promise.all([
           imageIds.length > 0

--- a/apps/website/src/lib/editor-ffi/components/ExternalImage.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ExternalImage.svelte
@@ -14,6 +14,7 @@
     calculateImageWidth,
     createDeleteNodeMessage,
     createSetImageAttrsMessage,
+    deriveImageStage,
     getFirstImageFile,
     processImageUpload,
   } from '../handlers/image-flow';
@@ -30,22 +31,22 @@
 
   const ctx = getEditorContext();
 
-  let pickerOpened = $state(false);
   let proportion = $state(100);
   let isResizing = $state(false);
   let initialResizeData: { x: number; width: number; proportion: number; reverse: boolean; boundsWidth: number } | null = null;
   let enlarged = $state(false);
   let containerEl = $state<HTMLDivElement>();
+  let pickerOpened = $state(false);
 
   const imageData = $derived(element.data.type === 'image' ? element.data : undefined);
-  const asset = $derived(imageData?.id ? ctx.editor?.imageAssets.get(imageData.id) : undefined);
+  const imageId = $derived(imageData?.id || undefined);
+  const asset = $derived(imageId ? ctx.editor?.imageAssets.get(imageId) : undefined);
   const inflight = $derived(ctx.editor?.inflightImages.get(element.node_id));
+  const stage = $derived(deriveImageStage({ imageId, inflight, asset }));
+
   const imageSrc = $derived(asset?.url ?? inflight?.url);
   const originalWidth = $derived(asset?.width ?? inflight?.width ?? 0);
   const originalHeight = $derived(asset?.height ?? inflight?.height ?? 0);
-  const hasImage = $derived(!!imageSrc && originalWidth > 0);
-  const isUploading = $derived(!!inflight && !asset);
-  const isResolvingAsset = $derived(!!imageData?.id && !asset && !inflight);
   const liveWidth = $derived(calculateImageWidth(element.bounds.width, proportion, originalWidth));
   const liveHeight = $derived(calculateImageHeight(liveWidth, originalWidth, originalHeight));
   const canEdit = $derived(!ctx.editor?.readOnly);
@@ -63,11 +64,11 @@
   });
 
   $effect(() => {
-    pickerOpened = element.is_selected && !hasImage && !isResolvingAsset && !isUploading;
+    pickerOpened = element.is_selected && stage === 'empty';
   });
 
   $effect(() => {
-    if (!hasImage) {
+    if (stage !== 'ready') {
       enlarged = false;
     }
   });
@@ -75,22 +76,10 @@
   $effect(() => {
     if (asset && inflight) {
       const url = inflight.url;
-      deleteInflightImage(element.node_id);
-      revokeObjectUrl(url);
+      ctx.editor?.inflightImages.delete(element.node_id);
+      URL.revokeObjectURL(url);
     }
   });
-
-  const enqueueImageAttrs = (id: string | undefined, nextProportion: number) => {
-    ctx.editor?.enqueue(createSetImageAttrsMessage(element.node_id, id, nextProportion));
-  };
-
-  const deleteInflightImage = (nodeId: string) => {
-    ctx.editor?.inflightImages.delete(nodeId);
-  };
-
-  const revokeObjectUrl = (url: string) => {
-    URL.revokeObjectURL(url);
-  };
 
   const deleteNode = () => {
     ctx.editor?.enqueue(createDeleteNodeMessage(element.node_id));
@@ -106,12 +95,12 @@
       nodeId: element.node_id,
       getProportion: () => proportion,
       setInflightImage: (nodeId, image) => editor.inflightImages.set(nodeId, image),
-      deleteInflightImage,
+      deleteInflightImage: (nodeId) => editor.inflightImages.delete(nodeId),
       setImageAsset: (asset) => editor.imageAssets.set(asset.id, asset),
       enqueue: (message) => editor.enqueue(message),
       focus: () => editor.focus(),
       createObjectUrl: (file) => URL.createObjectURL(file),
-      revokeObjectUrl,
+      revokeObjectUrl: (url) => URL.revokeObjectURL(url),
       readImageDimensions: getImageDimensions,
       uploadImageFile,
     });
@@ -123,26 +112,21 @@
 
   const handleUpload = () => {
     if (!canEdit) return;
-    // TODO: restrictedBlob 용량 제한 처리.
 
     const picker = document.createElement('input');
     picker.type = 'file';
     picker.accept = 'image/*';
 
     picker.addEventListener('change', () => {
-      pickerOpened = false;
-
       const file = picker.files?.[0];
       if (!file) {
         deleteNode();
         return;
       }
-
       void processFile(file);
     });
 
     picker.addEventListener('cancel', () => {
-      pickerOpened = false;
       deleteNode();
     });
 
@@ -150,7 +134,7 @@
   };
 
   const handleDragOver = (event: DragEvent) => {
-    if (!canEdit || hasImage) return;
+    if (!canEdit || stage === 'ready') return;
 
     const items = [...(event.dataTransfer?.items ?? [])];
     if (items.length > 0 && !items.some((item) => item.kind === 'file' && item.type.startsWith('image/'))) return;
@@ -163,14 +147,13 @@
   };
 
   const handleDrop = (event: DragEvent) => {
-    if (!canEdit || hasImage) return;
+    if (!canEdit || stage === 'ready') return;
 
     event.preventDefault();
 
     const file = getFirstImageFile(event.dataTransfer?.files ?? []);
     if (!file) return;
 
-    pickerOpened = false;
     void processFile(file);
   };
 
@@ -221,32 +204,28 @@
 
     isResizing = false;
     initialResizeData = null;
-    enqueueImageAttrs(imageData?.id, proportion);
+    ctx.editor?.enqueue(createSetImageAttrsMessage(element.node_id, imageId, proportion));
     ctx.editor?.focus();
   };
 </script>
 
-<ExternalElementWrapper {element} minHeight={hasImage ? undefined : '48px'}>
+<ExternalElementWrapper {element} minHeight={stage === 'ready' ? undefined : '48px'}>
   <div
     bind:this={containerEl}
-    style:width={hasImage ? `${liveWidth}px` : '100%'}
-    style:height={hasImage ? `${liveHeight}px` : undefined}
+    style:width={stage === 'ready' ? `${liveWidth}px` : '100%'}
+    style:height={stage === 'ready' ? `${liveHeight}px` : undefined}
     class={cx('group', css({ position: 'relative', margin: '[0 auto]' }))}
     ondragovercapture={handleDragOver}
     ondropcapture={handleDrop}
     role="group"
   >
-    {#if hasImage}
+    {#if stage === 'ready' && imageSrc}
       <Img
         style={css.raw({ width: 'full', borderRadius: '4px' }, !canEdit && { cursor: 'zoom-in' })}
         alt="본문 이미지"
         aria-label={canEdit ? undefined : '이미지 확대 보기'}
         onclick={() => {
-          if (canEdit) {
-            return;
-          }
-
-          enlarged = true;
+          if (!canEdit) enlarged = true;
         }}
         onkeydown={(event) => {
           if (!canEdit && (event.key === 'Enter' || event.key === ' ')) {
@@ -263,14 +242,8 @@
         role={canEdit ? undefined : 'button'}
         size="full"
         tabindex={canEdit ? undefined : 0}
-        url={imageSrc ?? ''}
+        url={imageSrc}
       />
-
-      {#if isUploading}
-        <div class={center({ position: 'absolute', inset: '0', backgroundColor: 'white/50' })}>
-          <RingSpinner style={css.raw({ size: '24px', color: 'text.disabled' })} />
-        </div>
-      {/if}
 
       {#if canEdit}
         <div class={flex({ position: 'absolute', top: '10px', right: '10px', gap: '6px', zIndex: '10' })}>
@@ -381,10 +354,16 @@
       >
         <div class={flex({ align: 'center', gap: '12px', paddingX: '14px', paddingY: '12px', fontSize: '14px', color: 'text.disabled' })}>
           <Icon icon={ImageIcon} size={20} />
-          {isUploading ? '이미지를 업로드하는 중...' : isResolvingAsset ? '이미지를 불러오는 중...' : '이미지'}
+          {#if stage === 'uploading'}
+            이미지를 업로드하는 중...
+          {:else if stage === 'resolving'}
+            이미지를 불러오는 중...
+          {:else}
+            이미지
+          {/if}
         </div>
 
-        {#if isResolvingAsset || isUploading}
+        {#if stage === 'uploading' || stage === 'resolving'}
           <div class={css({ marginRight: '14px' })}>
             <RingSpinner style={css.raw({ size: '16px', color: 'text.disabled' })} />
           </div>
@@ -439,7 +418,7 @@
   </button>
 {/if}
 
-{#if enlarged && hasImage && imageSrc && containerEl}
+{#if enlarged && stage === 'ready' && imageSrc && containerEl}
   <ExternalImageEnlarge
     onclose={() => (enlarged = false)}
     placeholder={asset?.placeholder}

--- a/apps/website/src/lib/editor-ffi/handlers/image-flow.test.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/image-flow.test.ts
@@ -108,7 +108,7 @@ describe('v2 image upload processing', () => {
     expect(focus).toHaveBeenCalled();
   });
 
-  it('deletes the empty image node and cleans up preview when upload fails', async () => {
+  it('cleans up preview and leaves node as empty placeholder when upload fails', async () => {
     const { deps, messages, inflight, focus } = createDeps();
     const file = createFile('image.png', 'image/png');
     const revokeObjectUrl = vi.fn();
@@ -127,7 +127,7 @@ describe('v2 image upload processing', () => {
     });
 
     expect(result).toBe('failed');
-    expect(messages).toEqual([createDeleteNodeMessage('node-1')]);
+    expect(messages).toEqual([]);
     expect(inflight.has('node-1')).toBe(false);
     expect(revokeObjectUrl).toHaveBeenCalledWith('blob:image');
     expect(focus).toHaveBeenCalled();

--- a/apps/website/src/lib/editor-ffi/handlers/image-flow.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/image-flow.ts
@@ -1,5 +1,20 @@
 import type { Message } from '@typie/editor-ffi/browser';
-import type { ImageAsset } from '../types';
+import type { ImageAsset, ImageStage } from '../types';
+
+export const deriveImageStage = ({
+  imageId,
+  inflight,
+  asset,
+}: {
+  imageId: string | undefined;
+  inflight: { url: string; width: number; height: number } | undefined;
+  asset: ImageAsset | undefined;
+}): ImageStage => {
+  if (asset) return 'ready';
+  if (inflight) return 'uploading';
+  if (imageId != null && imageId !== '') return 'resolving';
+  return 'empty';
+};
 
 type UploadImageFile = (file: File) => Promise<ImageAsset>;
 type ReadImageDimensions = (src: string) => Promise<{ width: number; height: number }>;
@@ -82,7 +97,6 @@ export const processImageUpload = async ({
   } catch {
     deleteInflightImage(nodeId);
     revokeObjectUrl(objectUrl);
-    enqueue(createDeleteNodeMessage(nodeId));
     focus();
     return 'failed';
   }

--- a/apps/website/src/lib/editor-ffi/types.test.ts
+++ b/apps/website/src/lib/editor-ffi/types.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { deriveImageStage } from './handlers/image-flow';
+import type { ImageAsset } from './types';
+
+const asset: ImageAsset = {
+  id: 'image-1',
+  url: 'https://example.com/image.webp',
+  originalUrl: 'https://example.com/original.png',
+  width: 640,
+  height: 480,
+  placeholder: 'placeholder',
+};
+
+const inflight = { url: 'blob:preview', width: 640, height: 480 };
+
+describe('deriveImageStage', () => {
+  it('returns empty when there is no imageId and no inflight', () => {
+    expect(deriveImageStage({ imageId: undefined, inflight: undefined, asset: undefined })).toBe('empty');
+  });
+
+  it('returns empty when imageId is null (WASM may send null)', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(deriveImageStage({ imageId: null as any, inflight: undefined, asset: undefined })).toBe('empty');
+  });
+
+  it('returns empty when imageId is empty string', () => {
+    expect(deriveImageStage({ imageId: '', inflight: undefined, asset: undefined })).toBe('empty');
+  });
+
+  it('returns uploading when inflight exists and asset is not yet settled', () => {
+    expect(deriveImageStage({ imageId: undefined, inflight, asset: undefined })).toBe('uploading');
+  });
+
+  it('returns resolving when imageId is present but asset is not in cache', () => {
+    expect(deriveImageStage({ imageId: 'image-1', inflight: undefined, asset: undefined })).toBe('resolving');
+  });
+
+  it('returns ready when asset is in cache', () => {
+    expect(deriveImageStage({ imageId: 'image-1', inflight: undefined, asset })).toBe('ready');
+  });
+
+  it('returns ready when asset arrives after inflight', () => {
+    expect(deriveImageStage({ imageId: 'image-1', inflight, asset })).toBe('ready');
+  });
+
+  it('same imageId in multiple nodes shares resolving/ready — derived from imageId-keyed cache', () => {
+    const stageA = deriveImageStage({ imageId: 'shared-id', inflight: undefined, asset: undefined });
+    const stageB = deriveImageStage({ imageId: 'shared-id', inflight: undefined, asset: undefined });
+    expect(stageA).toBe('resolving');
+    expect(stageB).toBe('resolving');
+
+    const stageC = deriveImageStage({ imageId: 'shared-id', inflight: undefined, asset });
+    const stageD = deriveImageStage({ imageId: 'shared-id', inflight: undefined, asset });
+    expect(stageC).toBe('ready');
+    expect(stageD).toBe('ready');
+  });
+});

--- a/apps/website/src/lib/editor-ffi/types.ts
+++ b/apps/website/src/lib/editor-ffi/types.ts
@@ -1,6 +1,8 @@
 import type { EditorEvent } from '@typie/editor-ffi/browser';
 import type { Editor } from './editor.svelte';
 
+export type ImageStage = 'empty' | 'uploading' | 'resolving' | 'ready';
+
 export type EditorEventListener<K extends EditorEvent['type']> = (editor: Editor, event: Extract<EditorEvent, { type: K }>) => void;
 
 export type EditorEventHandler<E extends Element, T extends Event> = (editor: Editor, event: T & { currentTarget: E }) => void;


### PR DESCRIPTION
새로고침을 하거나 문서 재진입시에 업로드 된 이미지가 올바르게 보이도록 구현했습니다.

Document.assets 를 활용해서 올바르게 image id를 추출하도록 구현했습니다.  
V2 문서는 DocumentStates.json에 데이터가 저장되기 때문에, V2 문서에 대해 항상 빈 배열을 반환했습니다.

DocumentStates가 존재하면 json 컬럼의 node를 직접 순회해 asset id를 추출하고,
이미지 리사이즈에 따른 높이 변화도 문서 레이아웃에 반영되도록 보완했습니다.

후속 작업인 파일과 임베드 작업시에도 V2 Resolver가 올바르게 id를 추출할 수 있도록 이를 고려해서 수정했습니다.