### PR TITLE
jvm desktop long press move 디버그

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionGestures.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionGestures.kt
@@ -216,6 +216,7 @@ internal class EditorInteractionGestures(
     selectionHandle.resetPointerOwnedState(context = context)
     doubleTapDrag.resetPointerOwnedState(context = context)
     longPress.reset()
+    context.effects.setScrollGestureLocked(false)
     context.semantics.magnifier.hide()
     context.semantics.edgeAutoScroll.stop()
     context.semantics.selectionExpansion.reset()

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/sessions/EditorLongPressSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/sessions/EditorLongPressSession.kt
@@ -57,6 +57,7 @@ internal class EditorLongPressSession {
     if (!begin(pointerId = pointerId, semanticIntent = semanticIntent)) {
       return false
     }
+    context.effects.setScrollGestureLocked(true)
 
     context.semantics.contextMenu.hide()
     context.semantics.magnifier.show(position)
@@ -69,6 +70,7 @@ internal class EditorLongPressSession {
     context.reduceMode(event)
     if (context.mode != expectedMode) {
       end()
+      context.effects.setScrollGestureLocked(false)
       context.semantics.magnifier.hide()
       context.semantics.selectionExpansion.reset()
       return false
@@ -126,6 +128,7 @@ internal class EditorLongPressSession {
     if (!context.mode.canApply(event)) {
       end()
       context.semantics.edgeAutoScroll.stop()
+      context.effects.setScrollGestureLocked(false)
       context.semantics.magnifier.hide()
       context.semantics.selectionExpansion.reset()
       return false
@@ -140,6 +143,7 @@ internal class EditorLongPressSession {
     context.reduceMode(event)
     end()
     context.semantics.edgeAutoScroll.stop()
+    context.effects.setScrollGestureLocked(false)
     context.semantics.magnifier.hide()
     context.semantics.selectionExpansion.reset()
     return true

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
@@ -836,10 +836,11 @@ class EditorInteractionControllerTest {
         controller.handleSelectionHandleDragDown(EditorSelectionHandleType.To, Offset(42f, 30f))
       )
       assertEquals(EditorInteractionMode.LongPressSelecting, controller.interactionMode)
-      assertFalse(host.scrollGestureLockActive)
+      assertTrue(host.scrollGestureLockActive)
 
       assertTrue(controller.onPointerUp(pointerId = 1L, position = start, nowMillis = 600L))
       assertEquals(EditorInteractionMode.Idle, controller.interactionMode)
+      assertFalse(host.scrollGestureLockActive)
     }
 
   private fun EditorInteractionController.handleSelectionHandleDragDown(
@@ -1256,6 +1257,64 @@ class EditorInteractionControllerTest {
       }
 
       assertEquals(6, fake.enqueued.size)
+    }
+
+  @Test
+  fun `long press cursor move locks desktop drag scroll until pointer up`() =
+    runTest(StandardTestDispatcher()) {
+      val fake = FakeFfiEditor()
+      val editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
+      val host = TestHost(this)
+      val controller =
+        EditorInteractionController(
+          editorProvider = { editor },
+          effects = host,
+          platformProvider = { Platform.Desktop },
+        )
+      controller.updateTapSlop(8f)
+      val start = Offset(10f, 20f)
+
+      controller.onPointerDown(pointerId = 1L, position = start, nowMillis = 0L)
+      assertTrue(controller.onLongPressTimer(pointerId = 1L, position = start, nowMillis = 500L))
+
+      assertTrue(host.scrollGestureLockActive)
+
+      assertTrue(
+        controller.onPointerMove(
+          pointerId = 1L,
+          position = start + Offset(12f, 0f),
+          nowMillis = 520L,
+        )
+      )
+      assertTrue(host.scrollGestureLockActive)
+
+      controller.onPointerUp(pointerId = 1L, position = start + Offset(12f, 0f), nowMillis = 540L)
+
+      assertFalse(host.scrollGestureLockActive)
+    }
+
+  @Test
+  fun `long press cancel clears desktop drag scroll lock`() =
+    runTest(StandardTestDispatcher()) {
+      val fake = FakeFfiEditor()
+      val editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
+      val host = TestHost(this)
+      val controller =
+        EditorInteractionController(
+          editorProvider = { editor },
+          effects = host,
+          platformProvider = { Platform.Desktop },
+        )
+      controller.updateTapSlop(8f)
+      val start = Offset(10f, 20f)
+
+      controller.onPointerDown(pointerId = 1L, position = start, nowMillis = 0L)
+      assertTrue(controller.onLongPressTimer(pointerId = 1L, position = start, nowMillis = 500L))
+      assertTrue(host.scrollGestureLockActive)
+
+      controller.cancel()
+
+      assertFalse(host.scrollGestureLockActive)
     }
 
   @Test


### PR DESCRIPTION
jvm desktop에서 long press move를 끝내면 스크롤이 되는 사소한 버그를 수정