### PR TITLE
TR-70 파일 첨부와 다운로드 구현

### DIFF
--- a/apps/api/src/graphql/resolvers/document.ts
+++ b/apps/api/src/graphql/resolvers/document.ts
@@ -223,18 +223,12 @@ Document.implement({
           .where(eq(DocumentStates.documentId, self.id))
           .then(first);
 
-        let imageIds: string[];
-        let fileIds: string[];
-        let embedIds: string[];
-        let archivedIds: string[];
+        const assetTypes = new Set(['image', 'file', 'embed', 'archived']);
 
         if (state) {
           const plain = state.json as { nodes: Record<string, { node: { type: string; id?: string | null } }> };
           const nodes = Object.values(plain.nodes);
-          imageIds = [...new Set(nodes.flatMap((e) => (e.node.type === 'image' && e.node.id != null ? [e.node.id] : [])))];
-          fileIds = [...new Set(nodes.flatMap((e) => (e.node.type === 'file' && e.node.id != null ? [e.node.id] : [])))];
-          embedIds = [...new Set(nodes.flatMap((e) => (e.node.type === 'embed' && e.node.id != null ? [e.node.id] : [])))];
-          archivedIds = [...new Set(nodes.flatMap((e) => (e.node.type === 'archived' && e.node.id != null ? [e.node.id] : [])))];
+          return [...new Set(nodes.flatMap((e) => (assetTypes.has(e.node.type) && e.node.id ? [e.node.id] : [])))];
         } else {
           const content = await db
             .select({ snapshot: DocumentContents.snapshot })
@@ -243,41 +237,9 @@ Document.implement({
             .then(firstOrThrow);
           const doc = new LoroDoc();
           doc.import(content.snapshot);
-          ({ imageIds, fileIds, embedIds, archivedIds } = extractAssetIdsFromLoroDoc(doc));
+          const { imageIds, fileIds, embedIds, archivedIds } = extractAssetIdsFromLoroDoc(doc);
+          return [...new Set([...imageIds, ...fileIds, ...embedIds, ...archivedIds])];
         }
-
-        const [existingImageIds, existingFileIds, existingEmbedIds, existingArchivedIds] = await Promise.all([
-          imageIds.length > 0
-            ? db
-                .select({ id: Images.id })
-                .from(Images)
-                .where(inArray(Images.id, imageIds))
-                .then((r) => r.map((x) => x.id))
-            : [],
-          fileIds.length > 0
-            ? db
-                .select({ id: Files.id })
-                .from(Files)
-                .where(inArray(Files.id, fileIds))
-                .then((r) => r.map((x) => x.id))
-            : [],
-          embedIds.length > 0
-            ? db
-                .select({ id: Embeds.id })
-                .from(Embeds)
-                .where(inArray(Embeds.id, embedIds))
-                .then((r) => r.map((x) => x.id))
-            : [],
-          archivedIds.length > 0
-            ? db
-                .select({ id: DocumentArchivedNodes.id })
-                .from(DocumentArchivedNodes)
-                .where(inArray(DocumentArchivedNodes.id, archivedIds))
-                .then((r) => r.map((x) => x.id))
-            : [],
-        ]);
-
-        return [...existingImageIds, ...existingFileIds, ...existingEmbedIds, ...existingArchivedIds];
       },
     }),
 

--- a/apps/website/src/lib/editor-ffi/components/ExternalElement.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ExternalElement.svelte
@@ -7,6 +7,7 @@
   import FileUpIcon from '~icons/lucide/file-up';
   import ImageIcon from '~icons/lucide/image';
   import ExternalElementWrapper from './ExternalElementWrapper.svelte';
+  import ExternalFile from './ExternalFile.svelte';
   import ExternalImage from './ExternalImage.svelte';
   import type { ExternalElement } from '@typie/editor-ffi/browser';
   import type { Component } from 'svelte';
@@ -37,6 +38,8 @@
 
 {#if element.data.type === 'image'}
   <ExternalImage {element} />
+{:else if element.data.type === 'file'}
+  <ExternalFile {element} />
 {:else}
   <ExternalElementWrapper {element}>
     <div class={css({ width: 'full', minHeight: '48px' })}>

--- a/apps/website/src/lib/editor-ffi/components/ExternalFile.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ExternalFile.svelte
@@ -1,0 +1,203 @@
+<script lang="ts">
+  import { css } from '@typie/styled-system/css';
+  import { flex } from '@typie/styled-system/patterns';
+  import { Icon, RingSpinner } from '@typie/ui/components';
+  import { Toast } from '@typie/ui/notification';
+  import DownloadIcon from '~icons/lucide/download';
+  import FileIcon from '~icons/lucide/file';
+  import PaperclipIcon from '~icons/lucide/paperclip';
+  import Trash2Icon from '~icons/lucide/trash-2';
+  import { getEditorContext } from '../editor.svelte';
+  import { createDeleteNodeMessage, deriveFileStage, processFileUpload } from '../handlers/file-flow';
+  import { uploadFileAsFile } from '../handlers/upload';
+  import ExternalElementWrapper from './ExternalElementWrapper.svelte';
+  import type { ExternalElement } from '@typie/editor-ffi/browser';
+
+  type Props = {
+    element: ExternalElement;
+  };
+
+  let { element }: Props = $props();
+
+  const ctx = getEditorContext();
+
+  const fileData = $derived(element.data.type === 'file' ? element.data : undefined);
+  const fileId = $derived(fileData?.id || undefined);
+  const asset = $derived(fileId ? ctx.fileAssets.get(fileId) : undefined);
+  const inflight = $derived(ctx.editor?.inflightFiles.get(element.node_id));
+  const stage = $derived(deriveFileStage({ fileId, inflight, asset }));
+
+  const canEdit = $derived(!ctx.editor?.readOnly);
+
+  const deleteNode = () => {
+    ctx.editor?.enqueue(createDeleteNodeMessage(element.node_id));
+    ctx.editor?.focus();
+  };
+
+  const handleUpload = () => {
+    if (!canEdit) return;
+
+    const picker = document.createElement('input');
+    picker.type = 'file';
+
+    picker.addEventListener('change', () => {
+      const file = picker.files?.[0];
+      if (!file) return;
+
+      void processFile(file);
+    });
+
+    picker.click();
+  };
+
+  const processFile = async (file: File) => {
+    const editor = ctx.editor;
+    if (!editor) return;
+
+    const result = await processFileUpload({
+      file,
+      nodeId: element.node_id,
+      setInflightFile: (nodeId, data) => editor.inflightFiles.set(nodeId, data),
+      deleteInflightFile: (nodeId) => editor.inflightFiles.delete(nodeId),
+      setFileAsset: (a) => ctx.fileAssets.set(a.id, a),
+      enqueue: (message) => editor.enqueue(message),
+      focus: () => editor.focus(),
+      uploadFileAsFile,
+    });
+
+    if (result === 'failed') {
+      Toast.error(`${file.name} 파일 업로드에 실패했습니다.`);
+    }
+  };
+
+  const handleDownload = () => {
+    if (!asset) return;
+    const a = document.createElement('a');
+    a.href = asset.url;
+    a.download = asset.name;
+    a.click();
+  };
+
+  const formatBytes = (bytes: string): string => {
+    const n = Number(bytes);
+    if (n < 1024) return `${n} B`;
+    if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+    return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+  };
+</script>
+
+<ExternalElementWrapper {element}>
+  <div
+    class={flex({
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      borderRadius: '4px',
+      backgroundColor: 'surface.muted',
+      width: 'full',
+      minHeight: '48px',
+      paddingX: '14px',
+      paddingY: '12px',
+    })}
+  >
+    <div class={flex({ align: 'center', gap: '12px', minWidth: '0' })}>
+      <Icon class={css({ flexShrink: '0', color: 'text.disabled' })} icon={FileIcon} size={20} />
+
+      <div class={flex({ direction: 'column', gap: '2px', minWidth: '0' })}>
+        {#if asset}
+          <span
+            class={css({
+              fontSize: '14px',
+              overflow: 'hidden',
+              whiteSpace: 'nowrap',
+              textOverflow: 'ellipsis',
+            })}
+          >
+            {asset.name}
+          </span>
+          <span class={css({ fontSize: '12px', color: 'text.disabled' })}>
+            {formatBytes(asset.size)}
+          </span>
+        {:else}
+          <span class={css({ fontSize: '14px', color: 'text.disabled' })}>
+            {#if stage === 'uploading'}
+              {inflight?.name}
+            {:else if stage === 'resolving'}
+              파일을 불러오는 중...
+            {:else}
+              파일
+            {/if}
+          </span>
+        {/if}
+      </div>
+    </div>
+
+    <div class={flex({ align: 'center', gap: '4px', flexShrink: '0' })}>
+      {#if stage === 'resolving' || stage === 'uploading'}
+        <RingSpinner style={css.raw({ size: '16px', color: 'text.disabled' })} />
+      {:else if asset}
+        <button
+          class={flex({
+            align: 'center',
+            gap: '4px',
+            borderRadius: '4px',
+            paddingX: '8px',
+            paddingY: '4px',
+            fontSize: '12px',
+            color: 'text.muted',
+            _hover: { backgroundColor: 'interactive.hover' },
+          })}
+          aria-label="파일 다운로드"
+          onclick={handleDownload}
+          onpointerdown={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+          type="button"
+        >
+          <Icon icon={DownloadIcon} size={14} />
+          다운로드
+        </button>
+      {:else if canEdit}
+        <button
+          class={flex({
+            align: 'center',
+            borderRadius: '4px',
+            padding: '4px',
+            color: 'text.disabled',
+            _hover: { backgroundColor: 'interactive.hover' },
+          })}
+          aria-label="파일 선택"
+          onclick={handleUpload}
+          onpointerdown={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+          type="button"
+        >
+          <Icon icon={PaperclipIcon} size={16} />
+        </button>
+      {/if}
+
+      {#if canEdit}
+        <button
+          class={flex({
+            align: 'center',
+            borderRadius: '4px',
+            padding: '4px',
+            color: 'text.disabled',
+            _hover: { backgroundColor: 'interactive.hover', color: 'text.danger' },
+          })}
+          aria-label="파일 삭제"
+          onclick={deleteNode}
+          onpointerdown={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+          type="button"
+        >
+          <Icon icon={Trash2Icon} size={16} />
+        </button>
+      {/if}
+    </div>
+  </div>
+</ExternalElementWrapper>

--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -22,7 +22,7 @@ import type {
   ThemeVariant,
   Viewport,
 } from '@typie/editor-ffi/browser';
-import type { EditorEventListener, ImageAsset } from './types';
+import type { EditorEventListener, FileAsset, ImageAsset } from './types';
 
 let wasmInitPromise: Promise<void> | null = null;
 
@@ -34,6 +34,7 @@ function ensureWasmInitialized(): Promise<void> {
 
 class EditorContext {
   editor = $state<Editor>();
+  fileAssets = $state(new SvelteMap<string, FileAsset>());
 }
 
 const [getEditorContext, setEditorContext] = createContext<EditorContext>();
@@ -76,6 +77,8 @@ export class Editor {
 
   imageAssets = $state(new SvelteMap<string, ImageAsset>());
   inflightImages = $state(new SvelteMap<string, { url: string; width: number; height: number }>());
+
+  inflightFiles = $state(new SvelteMap<string, { name: string; size: number }>());
 
   private constructor() {
     // no-op

--- a/apps/website/src/lib/editor-ffi/handlers/file-flow.test.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/file-flow.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createDeleteNodeMessage, createSetFileAttrsMessage, processFileUpload } from './file-flow';
+import type { Message } from '@typie/editor-ffi/browser';
+import type { FileAsset } from '../types';
+
+const createFile = (name: string, type: string, size = 1024) => new File([new ArrayBuffer(size)], name, { type });
+
+const createAsset = (id = 'file-1'): FileAsset => ({
+  id,
+  name: 'document.pdf',
+  size: '204800',
+  url: 'https://example.com/document.pdf',
+});
+
+const createDeps = () => {
+  const messages: Message[] = [];
+  const inflight = new Map<string, { name: string; size: number }>();
+  const assets = new Map<string, FileAsset>();
+  const focus = vi.fn();
+
+  return {
+    deps: {
+      setInflightFile: (nodeId: string, data: { name: string; size: number }) => inflight.set(nodeId, data),
+      deleteInflightFile: (nodeId: string) => inflight.delete(nodeId),
+      setFileAsset: (asset: FileAsset) => assets.set(asset.id, asset),
+      enqueue: (message: Message) => messages.push(message),
+      focus,
+    },
+    messages,
+    inflight,
+    assets,
+    focus,
+  };
+};
+
+describe('v2 file flow messages', () => {
+  it('creates a set_attrs message with file type and id', () => {
+    expect(createSetFileAttrsMessage('node-1', 'file-1')).toEqual({
+      type: 'node',
+      op: {
+        type: 'set_attrs',
+        id: 'node-1',
+        attrs: {
+          type: 'file',
+          id: 'file-1',
+        },
+      },
+    });
+  });
+
+  it('creates a delete message for node cleanup', () => {
+    expect(createDeleteNodeMessage('node-1')).toEqual({
+      type: 'node',
+      op: {
+        type: 'delete',
+        id: 'node-1',
+      },
+    });
+  });
+});
+
+describe('v2 file upload processing', () => {
+  it('stores inflight state, persists uploaded file id, and calls focus', async () => {
+    const { deps, messages, inflight, assets, focus } = createDeps();
+    const file = createFile('document.pdf', 'application/pdf', 204_800);
+    const asset = createAsset('file-1');
+
+    const result = await processFileUpload({
+      file,
+      nodeId: 'node-1',
+      ...deps,
+      uploadFileAsFile: async () => asset,
+    });
+
+    expect(result).toBe('uploaded');
+    expect(inflight.has('node-1')).toBe(false);
+    expect(assets.get('file-1')).toEqual(asset);
+    expect(messages).toEqual([createSetFileAttrsMessage('node-1', 'file-1')]);
+    expect(focus).toHaveBeenCalledOnce();
+  });
+
+  it('stores inflight with original file name and size before upload resolves', async () => {
+    const { deps, inflight } = createDeps();
+    let resolveUpload!: (asset: FileAsset) => void;
+
+    const uploadPromise = processFileUpload({
+      file: createFile('report.xlsx', 'application/octet-stream', 51_200),
+      nodeId: 'node-2',
+      ...deps,
+      uploadFileAsFile: () =>
+        new Promise((resolve) => {
+          resolveUpload = resolve;
+        }),
+    });
+
+    expect(inflight.get('node-2')).toEqual({ name: 'report.xlsx', size: 51_200 });
+
+    resolveUpload(createAsset('file-2'));
+    await uploadPromise;
+  });
+
+  it('deletes the empty file node and removes inflight state when upload fails', async () => {
+    const { deps, messages, inflight, focus } = createDeps();
+    const file = createFile('document.pdf', 'application/pdf');
+
+    const result = await processFileUpload({
+      file,
+      nodeId: 'node-1',
+      ...deps,
+      uploadFileAsFile: async () => {
+        throw new Error('upload failed');
+      },
+    });
+
+    expect(result).toBe('failed');
+    expect(inflight.has('node-1')).toBe(false);
+    expect(messages).toEqual([createDeleteNodeMessage('node-1')]);
+    expect(focus).toHaveBeenCalledOnce();
+  });
+
+  it('does not set file asset when upload fails', async () => {
+    const { deps, assets } = createDeps();
+
+    await processFileUpload({
+      file: createFile('document.pdf', 'application/pdf'),
+      nodeId: 'node-1',
+      ...deps,
+      uploadFileAsFile: async () => {
+        throw new Error('network error');
+      },
+    });
+
+    expect(assets.size).toBe(0);
+  });
+
+  it('handles multiple concurrent uploads independently', async () => {
+    const { deps, messages, inflight, assets } = createDeps();
+
+    const [result1, result2] = await Promise.all([
+      processFileUpload({
+        file: createFile('a.pdf', 'application/pdf'),
+        nodeId: 'node-a',
+        ...deps,
+        uploadFileAsFile: async () => ({ id: 'file-a', name: 'a.pdf', size: '1024', url: 'https://example.com/a.pdf' }),
+      }),
+      processFileUpload({
+        file: createFile('b.pdf', 'application/pdf'),
+        nodeId: 'node-b',
+        ...deps,
+        uploadFileAsFile: async () => ({ id: 'file-b', name: 'b.pdf', size: '2048', url: 'https://example.com/b.pdf' }),
+      }),
+    ]);
+
+    expect(result1).toBe('uploaded');
+    expect(result2).toBe('uploaded');
+    expect(assets.has('file-a')).toBe(true);
+    expect(assets.has('file-b')).toBe(true);
+    expect(inflight.has('node-a')).toBe(false);
+    expect(inflight.has('node-b')).toBe(false);
+    expect(messages).toHaveLength(2);
+  });
+
+  it('first upload success does not affect second upload failure', async () => {
+    const { deps, messages } = createDeps();
+
+    const [result1, result2] = await Promise.all([
+      processFileUpload({
+        file: createFile('a.pdf', 'application/pdf'),
+        nodeId: 'node-a',
+        ...deps,
+        uploadFileAsFile: async () => createAsset('file-a'),
+      }),
+      processFileUpload({
+        file: createFile('b.pdf', 'application/pdf'),
+        nodeId: 'node-b',
+        ...deps,
+        uploadFileAsFile: async () => {
+          throw new Error('failed');
+        },
+      }),
+    ]);
+
+    expect(result1).toBe('uploaded');
+    expect(result2).toBe('failed');
+    expect(messages).toContainEqual(createSetFileAttrsMessage('node-a', 'file-a'));
+    expect(messages).toContainEqual(createDeleteNodeMessage('node-b'));
+  });
+});

--- a/apps/website/src/lib/editor-ffi/handlers/file-flow.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/file-flow.ts
@@ -1,0 +1,75 @@
+import type { Message } from '@typie/editor-ffi/browser';
+import type { FileAsset, FileStage } from '../types';
+
+export const deriveFileStage = ({
+  fileId,
+  inflight,
+  asset,
+}: {
+  fileId: string | undefined;
+  inflight: { name: string; size: number } | undefined;
+  asset: FileAsset | undefined;
+}): FileStage => {
+  if (asset) return 'ready';
+  if (inflight) return 'uploading';
+  if (fileId != null && fileId !== '') return 'resolving';
+  return 'empty';
+};
+
+type UploadFileAsFile = (file: File) => Promise<FileAsset>;
+
+export const createSetFileAttrsMessage = (nodeId: string, fileId: string): Message => ({
+  type: 'node',
+  op: {
+    type: 'set_attrs',
+    id: nodeId,
+    attrs: {
+      type: 'file',
+      id: fileId,
+    },
+  },
+});
+
+export const createDeleteNodeMessage = (nodeId: string): Message => ({
+  type: 'node',
+  op: {
+    type: 'delete',
+    id: nodeId,
+  },
+});
+
+export const processFileUpload = async ({
+  file,
+  nodeId,
+  setInflightFile,
+  deleteInflightFile,
+  setFileAsset,
+  enqueue,
+  focus,
+  uploadFileAsFile,
+}: {
+  file: File;
+  nodeId: string;
+  setInflightFile: (nodeId: string, inflight: { name: string; size: number }) => void;
+  deleteInflightFile: (nodeId: string) => void;
+  setFileAsset: (asset: FileAsset) => void;
+  enqueue: (message: Message) => void;
+  focus: () => void;
+  uploadFileAsFile: UploadFileAsFile;
+}): Promise<'uploaded' | 'failed'> => {
+  setInflightFile(nodeId, { name: file.name, size: file.size });
+
+  try {
+    const uploaded = await uploadFileAsFile(file);
+    deleteInflightFile(nodeId);
+    setFileAsset(uploaded);
+    enqueue(createSetFileAttrsMessage(nodeId, uploaded.id));
+    focus();
+    return 'uploaded';
+  } catch {
+    deleteInflightFile(nodeId);
+    enqueue(createDeleteNodeMessage(nodeId));
+    focus();
+    return 'failed';
+  }
+};

--- a/apps/website/src/lib/editor-ffi/handlers/upload.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/upload.ts
@@ -1,5 +1,5 @@
-import { uploadBlobAsImage } from '$lib/utils/blob.svelte';
-import type { ImageAsset } from '../types';
+import { uploadBlobAsFile, uploadBlobAsImage } from '$lib/utils/blob.svelte';
+import type { FileAsset, ImageAsset } from '../types';
 
 export const getImageDimensions = (src: string): Promise<{ width: number; height: number }> => {
   return new Promise((resolve, reject) => {
@@ -8,6 +8,16 @@ export const getImageDimensions = (src: string): Promise<{ width: number; height
     img.addEventListener('error', () => reject(new Error('Failed to load image')));
     img.src = src;
   });
+};
+
+export const uploadFileAsFile = async (file: File): Promise<FileAsset> => {
+  const uploaded = await uploadBlobAsFile(file);
+  return {
+    id: uploaded.id,
+    name: uploaded.name,
+    size: uploaded.size,
+    url: uploaded.url,
+  };
 };
 
 export const uploadImageFile = async (file: File): Promise<ImageAsset> => {

--- a/apps/website/src/lib/editor-ffi/types.ts
+++ b/apps/website/src/lib/editor-ffi/types.ts
@@ -2,6 +2,7 @@ import type { EditorEvent } from '@typie/editor-ffi/browser';
 import type { Editor } from './editor.svelte';
 
 export type ImageStage = 'empty' | 'uploading' | 'resolving' | 'ready';
+export type FileStage = 'empty' | 'uploading' | 'resolving' | 'ready';
 
 export type EditorEventListener<K extends EditorEvent['type']> = (editor: Editor, event: Extract<EditorEvent, { type: K }>) => void;
 
@@ -14,4 +15,11 @@ export type ImageAsset = {
   width: number;
   height: number;
   placeholder: string;
+};
+
+export type FileAsset = {
+  id: string;
+  name: string;
+  size: string;
+  url: string;
 };

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditorV2.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditorV2.svelte
@@ -40,6 +40,13 @@
             height
             placeholder
           }
+
+          ... on File {
+            id
+            name
+            size
+            url
+          }
         }
         ...Editor_document
         ...BottomToolbar_document
@@ -210,6 +217,16 @@
         width: asset.width,
         height: asset.height,
         placeholder: asset.placeholder,
+      });
+    }
+
+    for (const asset of document.data.assets) {
+      if (asset.__typename !== 'File') continue;
+      ctx.fileAssets.set(asset.id, {
+        id: asset.id,
+        name: asset.name,
+        size: asset.size,
+        url: asset.url,
       });
     }
   });


### PR DESCRIPTION
웹 v2 에서 파일 첨부와 다운로드 기능을 구현했습니다.
새로고침을 해도 문서 내부에서 첨부된 파일이 그대로 유지 되도록 적용했습니다.
더불어 첨부된 파일을 삭제할 수 있는 기능도 추가했습니다.