### PR TITLE
TR-71 임베드 삽입과 미리보기 구현

### DIFF
--- a/apps/website/src/lib/editor-ffi/components/ExternalElement.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ExternalElement.svelte
@@ -7,6 +7,7 @@
   import FileUpIcon from '~icons/lucide/file-up';
   import ImageIcon from '~icons/lucide/image';
   import ExternalElementWrapper from './ExternalElementWrapper.svelte';
+  import ExternalEmbed from './ExternalEmbed.svelte';
   import ExternalFile from './ExternalFile.svelte';
   import ExternalImage from './ExternalImage.svelte';
   import type { ExternalElement } from '@typie/editor-ffi/browser';
@@ -40,6 +41,8 @@
   <ExternalImage {element} />
 {:else if element.data.type === 'file'}
   <ExternalFile {element} />
+{:else if element.data.type === 'embed'}
+  <ExternalEmbed {element} />
 {:else}
   <ExternalElementWrapper {element}>
     <div class={css({ width: 'full', minHeight: '48px' })}>

--- a/apps/website/src/lib/editor-ffi/components/ExternalEmbed.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ExternalEmbed.svelte
@@ -1,0 +1,270 @@
+<script lang="ts">
+  import { flip, hide } from '@floating-ui/dom';
+  import { createMutation } from '@mearie/svelte';
+  import { css } from '@typie/styled-system/css';
+  import { flex } from '@typie/styled-system/patterns';
+  import { createFloatingActions } from '@typie/ui/actions';
+  import { Button, Icon, RingSpinner, TextInput } from '@typie/ui/components';
+  import { Toast } from '@typie/ui/notification';
+  import ExternalLinkIcon from '~icons/lucide/external-link';
+  import FileUpIcon from '~icons/lucide/file-up';
+  import Trash2Icon from '~icons/lucide/trash-2';
+  import { graphql } from '$mearie';
+  import { getEditorContext } from '../editor.svelte';
+  import ExternalElementWrapper from './ExternalElementWrapper.svelte';
+  import type { ExternalElement } from '@typie/editor-ffi/browser';
+
+  type Props = {
+    element: ExternalElement;
+  };
+
+  let { element }: Props = $props();
+
+  const ctx = getEditorContext();
+
+  const embedData = $derived(element.data.type === 'embed' ? element.data : undefined);
+  const embedId = $derived(embedData?.id || undefined);
+  const asset = $derived(embedId ? ctx.editor?.embedAssets.get(embedId) : undefined);
+  const canEdit = $derived(!ctx.editor?.readOnly);
+
+  let inflightUrl = $state('');
+  let inflight = $state(false);
+  let error = $state(false);
+
+  const showUrlInput = $derived(element.is_selected && !embedId && !inflight && canEdit);
+
+  const { anchor, floating } = createFloatingActions({
+    placement: 'bottom',
+    offset: 4,
+    middleware: [flip(), hide()],
+  });
+
+  const [unfurlEmbed] = createMutation(
+    graphql(`
+      mutation ExternalEmbed_UnfurlEmbed($input: UnfurlEmbedInput!) {
+        unfurlEmbed(input: $input) {
+          id
+          url
+          title
+          description
+          thumbnailUrl
+          html
+        }
+      }
+    `),
+  );
+
+  const handleSubmit = async () => {
+    if (!inflightUrl || !ctx.editor) return;
+
+    error = false;
+    inflight = true;
+
+    try {
+      const url = /^[^:]+:\/\//.test(inflightUrl) ? inflightUrl : `https://${inflightUrl}`;
+      const result = await unfurlEmbed({ input: { url } });
+
+      ctx.editor.embedAssets.set(result.unfurlEmbed.id, {
+        id: result.unfurlEmbed.id,
+        url: result.unfurlEmbed.url,
+        title: result.unfurlEmbed.title ?? null,
+        description: result.unfurlEmbed.description ?? null,
+        thumbnailUrl: result.unfurlEmbed.thumbnailUrl ?? null,
+        html: result.unfurlEmbed.html ?? null,
+      });
+
+      ctx.editor.enqueue({
+        type: 'node',
+        op: { type: 'set_attrs', id: element.node_id, attrs: { type: 'embed', id: result.unfurlEmbed.id } },
+      });
+
+      ctx.editor.focus();
+    } catch {
+      error = true;
+      Toast.error('링크를 임베드할 수 없습니다.');
+    } finally {
+      inflight = false;
+      inflightUrl = '';
+    }
+  };
+
+  const deleteNode = () => {
+    ctx.editor?.enqueue({ type: 'node', op: { type: 'delete', id: element.node_id } });
+    ctx.editor?.focus();
+  };
+</script>
+
+<ExternalElementWrapper {element} minHeight={asset ? undefined : '48px'}>
+  <div class={css({ position: 'relative', width: 'full' })}>
+    {#if asset}
+      {#if asset.html}
+        <div class={css({ display: 'contents' }, canEdit && { pointerEvents: 'none' })}>
+          <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+          {@html asset.html}
+        </div>
+      {:else}
+        <div class={flex({ borderWidth: '1px', borderColor: 'border.subtle', borderRadius: '6px' })}>
+          <div class={flex({ direction: 'column', grow: '1', paddingX: '16px', paddingY: '15px', gap: '4px', minWidth: '0' })}>
+            <p class={css({ fontSize: '14px', fontWeight: 'medium', overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' })}>
+              {asset.title ?? '(제목 없음)'}
+            </p>
+            {#if asset.description}
+              <p class={css({ fontSize: '12px', color: 'text.faint', overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' })}>
+                {asset.description}
+              </p>
+            {/if}
+            <p
+              class={css({
+                fontSize: '12px',
+                color: 'text.muted',
+                marginTop: 'auto',
+                overflow: 'hidden',
+                whiteSpace: 'nowrap',
+                textOverflow: 'ellipsis',
+              })}
+            >
+              {new URL(asset.url).origin}
+            </p>
+          </div>
+          {#if asset.thumbnailUrl}
+            <img
+              class={css({
+                flexShrink: '0',
+                borderTopRightRadius: '5px',
+                borderBottomRightRadius: '5px',
+                size: '118px',
+                objectFit: 'cover',
+              })}
+              alt={asset.title ?? '(제목 없음)'}
+              src={asset.thumbnailUrl}
+            />
+          {/if}
+        </div>
+      {/if}
+
+      <div class={flex({ position: 'absolute', top: '8px', right: '8px', gap: '4px' })}>
+        <button
+          class={css({
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            borderRadius: '4px',
+            color: 'text.bright',
+            backgroundColor: '[#363839/70]',
+            size: '28px',
+            _hover: { backgroundColor: '[#363839/40]' },
+          })}
+          aria-label="링크 열기"
+          onclick={() => window.open(asset.url, '_blank', 'noopener,noreferrer')}
+          onpointerdown={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+          type="button"
+        >
+          <Icon icon={ExternalLinkIcon} size={16} />
+        </button>
+
+        {#if canEdit}
+          <button
+            class={css({
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              borderRadius: '4px',
+              color: 'text.bright',
+              backgroundColor: '[#363839/70]',
+              size: '28px',
+              _hover: { backgroundColor: '[#363839/40]' },
+            })}
+            aria-label="임베드 삭제"
+            onclick={deleteNode}
+            onpointerdown={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+            }}
+            type="button"
+          >
+            <Icon icon={Trash2Icon} size={16} />
+          </button>
+        {/if}
+      </div>
+    {:else}
+      <div
+        class={flex({
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          borderRadius: '4px',
+          backgroundColor: 'surface.muted',
+          width: 'full',
+          height: '48px',
+          paddingX: '14px',
+          paddingY: '12px',
+        })}
+        use:anchor
+      >
+        <div
+          class={flex({ align: 'center', gap: '12px', fontSize: '14px', color: error ? 'text.danger' : 'text.disabled', minWidth: '0' })}
+        >
+          {#if inflight}
+            <RingSpinner style={css.raw({ size: '20px', flexShrink: '0' })} />
+            <span class={css({ overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' })}>링크 임베드 중...</span>
+          {:else}
+            <Icon class={css({ flexShrink: '0' })} icon={FileUpIcon} size={20} />
+            <span class={css({ overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' })}>
+              {#if error}
+                링크를 임베드할 수 없습니다
+              {:else if canEdit}
+                링크 임베드 (Youtube, Google Drive, 일반 링크 등)
+              {:else}
+                링크 임베드 없음
+              {/if}
+            </span>
+          {/if}
+        </div>
+
+        {#if canEdit && !inflight}
+          <button
+            class={flex({
+              align: 'center',
+              borderRadius: '4px',
+              padding: '4px',
+              color: 'text.disabled',
+              _hover: { backgroundColor: 'interactive.hover', color: 'text.danger' },
+            })}
+            aria-label="임베드 삭제"
+            onclick={deleteNode}
+            onpointerdown={(e) => e.stopPropagation()}
+            type="button"
+          >
+            <Icon icon={Trash2Icon} size={16} />
+          </button>
+        {/if}
+      </div>
+    {/if}
+  </div>
+</ExternalElementWrapper>
+
+{#if showUrlInput}
+  <form
+    class={flex({
+      alignItems: 'center',
+      gap: '6px',
+      borderWidth: '1px',
+      borderRadius: '8px',
+      paddingX: '6px',
+      paddingY: '4px',
+      backgroundColor: 'surface.default',
+      boxShadow: 'small',
+      zIndex: 'editor',
+    })}
+    onsubmit={(e) => {
+      e.preventDefault();
+      void handleSubmit();
+    }}
+    use:floating
+  >
+    <TextInput name="url" style={css.raw({ flex: '1', minWidth: '200px' })} placeholder="https://..." size="sm" bind:value={inflightUrl} />
+    <Button size="sm" type="submit">확인</Button>
+  </form>
+{/if}

--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -32,6 +32,7 @@ import type {
   ContextMenuPlacement,
   ContextMenuSource,
   EditorEventListener,
+  EmbedAsset,
   FileAsset,
   ImageAsset,
 } from './types';
@@ -109,6 +110,8 @@ export class Editor {
   }
 
   inflightFiles = $state(new SvelteMap<string, { name: string; size: number }>());
+
+  embedAssets = $state(new SvelteMap<string, EmbedAsset>());
 
   private constructor() {
     // no-op

--- a/apps/website/src/lib/editor-ffi/handlers/embed-flow.test.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/embed-flow.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import type { Message } from '@typie/editor-ffi/browser';
+
+const createSetEmbedAttrsMessage = (nodeId: string, embedId: string): Message => ({
+  type: 'node',
+  op: {
+    type: 'set_attrs',
+    id: nodeId,
+    attrs: {
+      type: 'embed',
+      id: embedId,
+    },
+  },
+});
+
+const createDeleteNodeMessage = (nodeId: string): Message => ({
+  type: 'node',
+  op: {
+    type: 'delete',
+    id: nodeId,
+  },
+});
+
+const normalizeUrl = (raw: string): string => (/^[^:]+:\/\//.test(raw) ? raw : `https://${raw}`);
+
+describe('embed flow messages', () => {
+  it('creates a set_attrs message with embed type and id', () => {
+    expect(createSetEmbedAttrsMessage('node-1', 'embed-1')).toEqual({
+      type: 'node',
+      op: {
+        type: 'set_attrs',
+        id: 'node-1',
+        attrs: { type: 'embed', id: 'embed-1' },
+      },
+    });
+  });
+
+  it('creates a delete message for a node', () => {
+    expect(createDeleteNodeMessage('node-1')).toEqual({
+      type: 'node',
+      op: {
+        type: 'delete',
+        id: 'node-1',
+      },
+    });
+  });
+});
+
+describe('URL normalization', () => {
+  it('adds https:// prefix when scheme is missing', () => {
+    expect(normalizeUrl('example.com')).toBe('https://example.com');
+  });
+
+  it('preserves https:// URLs as-is', () => {
+    expect(normalizeUrl('https://example.com')).toBe('https://example.com');
+  });
+
+  it('preserves http:// URLs as-is', () => {
+    expect(normalizeUrl('http://example.com')).toBe('http://example.com');
+  });
+
+  it('preserves URLs with other schemes as-is', () => {
+    expect(normalizeUrl('ftp://example.com')).toBe('ftp://example.com');
+  });
+});

--- a/apps/website/src/lib/editor-ffi/types.ts
+++ b/apps/website/src/lib/editor-ffi/types.ts
@@ -18,6 +18,15 @@ export type ImageAsset = {
   placeholder: string;
 };
 
+export type EmbedAsset = {
+  id: string;
+  url: string;
+  title: string | null;
+  description: string | null;
+  thumbnailUrl: string | null;
+  html: string | null;
+};
+
 export type ContextMenuItem = {
   label: string;
   icon?: Component;

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditorV2.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditorV2.svelte
@@ -47,6 +47,15 @@
             size
             url
           }
+
+          ... on Embed {
+            id
+            url
+            title
+            description
+            thumbnailUrl
+            html
+          }
         }
         ...Editor_document
         ...BottomToolbar_document
@@ -209,25 +218,36 @@
     if (!editor) return;
 
     for (const asset of document.data.assets) {
-      if (asset.__typename !== 'Image') continue;
-      editor.imageAssets.set(asset.id, {
-        id: asset.id,
-        url: asset.url,
-        originalUrl: asset.originalUrl,
-        width: asset.width,
-        height: asset.height,
-        placeholder: asset.placeholder,
-      });
-    }
+      if (asset.__typename === 'Image') {
+        editor.imageAssets.set(asset.id, {
+          id: asset.id,
+          url: asset.url,
+          originalUrl: asset.originalUrl,
+          width: asset.width,
+          height: asset.height,
+          placeholder: asset.placeholder,
+        });
+      }
 
-    for (const asset of document.data.assets) {
-      if (asset.__typename !== 'File') continue;
-      ctx.fileAssets.set(asset.id, {
-        id: asset.id,
-        name: asset.name,
-        size: asset.size,
-        url: asset.url,
-      });
+      if (asset.__typename === 'File') {
+        ctx.fileAssets.set(asset.id, {
+          id: asset.id,
+          name: asset.name,
+          size: asset.size,
+          url: asset.url,
+        });
+      }
+
+      if (asset.__typename === 'Embed') {
+        editor.embedAssets.set(asset.id, {
+          id: asset.id,
+          url: asset.url,
+          title: asset.title ?? null,
+          description: asset.description ?? null,
+          thumbnailUrl: asset.thumbnailUrl ?? null,
+          html: asset.html ?? null,
+        });
+      }
     }
   });
 


### PR DESCRIPTION
사용자가 문서를 편집 하면서 손 쉽게 외부 링크를 삽입하고, 썸네일이 올바르게 보이도록 구현했습니다.
임베드 블록에 달린 버튼을 각각 클릭 했을 때 해당하는 경로로 브라우저를 열어주거나   
잘못 삽입한 링크를 삭제할 수 있도록 구현했습니다.