### PR TITLE
TR-80 보관된 블록의 내용 보기 구현

### DIFF
--- a/apps/website/src/lib/editor-ffi/components/ExternalArchived.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ExternalArchived.svelte
@@ -1,0 +1,188 @@
+<script lang="ts">
+  import { css } from '@typie/styled-system/css';
+  import { flex } from '@typie/styled-system/patterns';
+  import { Button, Icon, Modal } from '@typie/ui/components';
+  import ArchiveIcon from '~icons/lucide/archive';
+  import { getEditorContext } from '../editor.svelte';
+  import ExternalElementWrapper from './ExternalElementWrapper.svelte';
+  import type { ExternalElement } from '@typie/editor-ffi/browser';
+
+  type Props = {
+    element: ExternalElement;
+  };
+
+  let { element }: Props = $props();
+
+  const ctx = getEditorContext();
+
+  const archivedData = $derived(element.data.type === 'archived' ? element.data : undefined);
+  const archivedId = $derived(archivedData?.id || undefined);
+  const asset = $derived(archivedId ? ctx.editor?.archivedAssets.get(archivedId) : undefined);
+  const canEdit = $derived(!ctx.editor?.readOnly);
+  const hasPreviewButton = $derived(canEdit && !!asset?.content);
+
+  let open = $state(false);
+</script>
+
+<ExternalElementWrapper {element}>
+  <div class={css({ width: 'full' })}>
+    <div
+      class={flex({
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        borderRadius: '4px',
+        backgroundColor: 'surface.muted',
+        width: 'full',
+        height: '48px',
+      })}
+    >
+      <div
+        class={flex({
+          align: 'center',
+          gap: '12px',
+          paddingX: '14px',
+          paddingY: '12px',
+          fontSize: '14px',
+          color: 'text.disabled',
+          flex: '[1 999 0px]',
+          minWidth: '0',
+        })}
+      >
+        <Icon class={css({ flexShrink: '0' })} icon={ArchiveIcon} size={20} />
+        <span
+          class={css({
+            flex: '1',
+            minWidth: '0',
+            display: 'block',
+            overflow: 'hidden',
+            whiteSpace: 'nowrap',
+            textOverflow: 'ellipsis',
+          })}
+        >
+          보관된 블록
+        </span>
+      </div>
+
+      {#if hasPreviewButton}
+        <div
+          class={css({
+            marginRight: '12px',
+            display: 'flex',
+            justifyContent: 'flex-end',
+            flex: '[0 1 96px]',
+            minWidth: '0',
+            overflow: 'hidden',
+          })}
+        >
+          <Button
+            style={css.raw({ width: 'full', maxWidth: 'full', minWidth: '0', overflow: 'hidden' })}
+            onclick={() => {
+              open = true;
+            }}
+            onpointerdown={(event: PointerEvent) => {
+              event.stopPropagation();
+            }}
+            size="sm"
+            variant="secondary"
+          >
+            <span
+              class={css({
+                display: 'block',
+                overflow: 'hidden',
+                whiteSpace: 'nowrap',
+                textOverflow: 'ellipsis',
+              })}
+            >
+              내용 보기
+            </span>
+          </Button>
+        </div>
+      {/if}
+    </div>
+  </div>
+</ExternalElementWrapper>
+
+{#if asset?.content}
+  <Modal style={css.raw({ maxWidth: '560px' })} bind:open>
+    <div class={css({ padding: '24px' })}>
+      <div class={flex({ justifyContent: 'space-between', alignItems: 'center', marginBottom: '16px' })}>
+        <h2
+          class={css({
+            fontSize: '16px',
+            fontWeight: 'semibold',
+            color: 'text.default',
+          })}
+        >
+          보관된 블록
+        </h2>
+        <Button
+          onclick={async () => {
+            await navigator.clipboard.writeText(asset.content ?? '');
+          }}
+          size="sm"
+          variant="secondary"
+        >
+          복사
+        </Button>
+      </div>
+
+      <div
+        class={css({
+          maxHeight: '400px',
+          overflowY: 'auto',
+          padding: '12px',
+          borderRadius: '6px',
+          backgroundColor: 'surface.subtle',
+          '& pre': {
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-all',
+            padding: '12px',
+            borderRadius: '6px',
+            backgroundColor: 'surface.muted',
+            fontSize: '13px',
+            fontFamily: 'mono',
+            color: 'text.subtle',
+          },
+          '& pre code': {
+            fontFamily: '[inherit]',
+            fontSize: '[inherit]',
+          },
+          '& p': {
+            marginY: '0',
+          },
+          '& table': {
+            width: 'full',
+            borderCollapse: 'collapse',
+          },
+          '& td': {
+            border: '1px solid',
+            borderColor: 'border.default',
+            padding: '8px',
+          },
+          '& img': {
+            maxWidth: 'full',
+          },
+          '& a': {
+            color: 'accent.brand.default',
+            textDecoration: 'underline',
+          },
+        })}
+      >
+        <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+        {@html asset.content}
+      </div>
+
+      <div class={flex({ justifyContent: 'flex-end', marginTop: '16px' })}>
+        <Button
+          onclick={() => {
+            open = false;
+          }}
+          size="sm"
+          variant="secondary"
+        >
+          닫기
+        </Button>
+      </div>
+    </div>
+  </Modal>
+{/if}

--- a/apps/website/src/lib/editor-ffi/components/ExternalElement.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ExternalElement.svelte
@@ -1,40 +1,15 @@
 <script lang="ts">
-  import { css } from '@typie/styled-system/css';
-  import { flex } from '@typie/styled-system/patterns';
-  import { Icon } from '@typie/ui/components';
-  import ArchiveIcon from '~icons/lucide/archive';
-  import FileIcon from '~icons/lucide/file';
-  import FileUpIcon from '~icons/lucide/file-up';
-  import ImageIcon from '~icons/lucide/image';
-  import ExternalElementWrapper from './ExternalElementWrapper.svelte';
+  import ExternalArchived from './ExternalArchived.svelte';
   import ExternalEmbed from './ExternalEmbed.svelte';
   import ExternalFile from './ExternalFile.svelte';
   import ExternalImage from './ExternalImage.svelte';
   import type { ExternalElement } from '@typie/editor-ffi/browser';
-  import type { Component } from 'svelte';
 
   type Props = {
     element: ExternalElement;
   };
 
   let { element }: Props = $props();
-
-  const meta = $derived.by<{ icon: Component; label: string }>(() => {
-    switch (element.data.type) {
-      case 'image': {
-        return { icon: ImageIcon, label: '이미지' };
-      }
-      case 'file': {
-        return { icon: FileIcon, label: '파일' };
-      }
-      case 'embed': {
-        return { icon: FileUpIcon, label: '임베드' };
-      }
-      case 'archived': {
-        return { icon: ArchiveIcon, label: '보관된 블록' };
-      }
-    }
-  });
 </script>
 
 {#if element.data.type === 'image'}
@@ -43,35 +18,6 @@
   <ExternalFile {element} />
 {:else if element.data.type === 'embed'}
   <ExternalEmbed {element} />
-{:else}
-  <ExternalElementWrapper {element}>
-    <div class={css({ width: 'full', minHeight: '48px' })}>
-      <div
-        class={flex({
-          align: 'center',
-          gap: '12px',
-          width: 'full',
-          minHeight: '48px',
-          paddingX: '14px',
-          paddingY: '12px',
-          borderRadius: '4px',
-          backgroundColor: 'surface.muted',
-          color: 'text.disabled',
-          fontSize: '14px',
-        })}
-      >
-        <Icon class={css({ flexShrink: '0' })} icon={meta.icon} size={20} />
-        <span
-          class={css({
-            minWidth: '0',
-            overflow: 'hidden',
-            whiteSpace: 'nowrap',
-            textOverflow: 'ellipsis',
-          })}
-        >
-          {meta.label}
-        </span>
-      </div>
-    </div>
-  </ExternalElementWrapper>
+{:else if element.data.type === 'archived'}
+  <ExternalArchived {element} />
 {/if}

--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -27,6 +27,7 @@ import type {
   Viewport,
 } from '@typie/editor-ffi/browser';
 import type {
+  ArchivedAsset,
   ContextMenuContributor,
   ContextMenuContributorContext,
   ContextMenuItem,
@@ -114,6 +115,7 @@ export class Editor {
   inflightFiles = $state(new SvelteMap<string, { name: string; size: number }>());
 
   embedAssets = $state(new SvelteMap<string, EmbedAsset>());
+  archivedAssets = $state(new SvelteMap<string, ArchivedAsset>());
 
   private constructor() {
     // no-op

--- a/apps/website/src/lib/editor-ffi/types.ts
+++ b/apps/website/src/lib/editor-ffi/types.ts
@@ -27,6 +27,11 @@ export type EmbedAsset = {
   html: string | null;
 };
 
+export type ArchivedAsset = {
+  id: string;
+  content: string | null;
+};
+
 export type ContextMenuItem = {
   label: string;
   icon?: Component;

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditorV2.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditorV2.svelte
@@ -56,6 +56,11 @@
             thumbnailUrl
             html
           }
+
+          ... on DocumentArchivedNode {
+            id
+            content
+          }
         }
         ...Editor_document
         ...BottomToolbar_document
@@ -246,6 +251,13 @@
           description: asset.description ?? null,
           thumbnailUrl: asset.thumbnailUrl ?? null,
           html: asset.html ?? null,
+        });
+      }
+
+      if (asset.__typename === 'DocumentArchivedNode') {
+        editor.archivedAssets.set(asset.id, {
+          id: asset.id,
+          content: asset.content,
         });
       }
     }


### PR DESCRIPTION
사용자가 문서 안에서 보관된 블록의 내용을 손 쉽게 읽고, 복사해서 바로 사용할 수 있도록 기능을 구현했습니다.    
기존 웹 v1에는 보관된 블록을 표시하고 내용 보기 모달을 제공하는 로직이 이미 존재했습니다.    
이번 작업에서는 v1의 동작을 기준으로 삼아 Web v2 구조에 맞게 새로 구현했으며,   
v1에 없던 복사 버튼을 추가해 서식이 적용된 텍스트나 코드 블록을 바로 가져다 쓸 수 있도록 했습니다.