### PR TITLE
feat: v2 esc to collapse or blur

### DIFF
--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -517,6 +517,10 @@ export class Editor {
 
     if (fields.includes('selection')) {
       this.#selection = this.#wasm.selection();
+      // null selection is the unfocused state; release DOM focus so OS caret and IME follow.
+      if (this.#selection === undefined) {
+        this.inputEl?.blur();
+      }
     }
 
     if (fields.includes('page_sizes')) {

--- a/crates/editor-core/src/handle/key.rs
+++ b/crates/editor-core/src/handle/key.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use editor_commands::{self as commands};
+use editor_state::Selection;
 use editor_transaction::HistoryMeta;
 
 use crate::editor::Editor;
@@ -94,7 +95,21 @@ pub fn handle_key_event(editor: &mut Editor, event: KeyEvent) -> Result<(), Edit
             (Key::Tab, _) => {
                 commands::sink_list_item(tr)?;
             }
-            (Key::Escape, _) => {}
+            (Key::Escape, _) => {
+                if let Some(current) = tr.selection() {
+                    let collapsed = Selection::collapsed(current.head);
+                    let normalized = collapsed.normalize(&tr.state().doc).unwrap_or(collapsed);
+                    // Unit selections re-normalize to the direction-flipped form;
+                    // an anchor/head swap brackets the same content.
+                    let unchanged = normalized == current
+                        || (normalized.anchor == current.head && normalized.head == current.anchor);
+                    if unchanged {
+                        tr.set_selection(None)?;
+                    } else {
+                        tr.set_selection(Some(collapsed))?;
+                    }
+                }
+            }
         }
         Ok(())
     })
@@ -1142,5 +1157,58 @@ mod tests {
             selection: (t, 0)
         };
         assert_doc_eq!(editor.state().doc, expected.doc);
+    }
+
+    #[test]
+    fn escape_collapses_text_range_to_head() {
+        let (state, ..) = state! {
+            doc { root { paragraph { t: text("hello") } } }
+            selection: (t, 1) -> (t, 4)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.apply(key(Key::Escape));
+        let (expected, ..) = state! {
+            doc { root { paragraph { t: text("hello") } } }
+            selection: (t, 4)
+        };
+        assert_state_eq!(editor.state(), &expected);
+    }
+
+    #[test]
+    fn escape_on_collapsed_caret_clears_selection() {
+        let (state, ..) = state! {
+            doc { root { paragraph { t: text("hello") } } }
+            selection: (t, 3)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.apply(key(Key::Escape));
+        assert!(editor.state().selection.is_none());
+    }
+
+    #[test]
+    fn escape_on_unit_node_selection_clears_selection() {
+        let (state, ..) = state! {
+            doc { r: root {
+                paragraph { text("a") }
+                image
+                paragraph { text("b") }
+            } }
+            selection: (r, 1, >) -> (r, 2, <)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.apply(key(Key::Escape));
+        assert!(editor.state().selection.is_none());
+    }
+
+    #[test]
+    fn escape_when_selection_is_none_is_noop() {
+        let (state, ..) = state! {
+            doc { root { paragraph { text("hello") } } }
+            selection: none
+        };
+        let initial = state.clone();
+        let mut editor = Editor::new_test(state);
+        editor.apply(key(Key::Escape));
+        assert_state_eq!(editor.state(), &initial);
     }
 }

--- a/crates/editor-ffi/src/editor.rs
+++ b/crates/editor-ffi/src/editor.rs
@@ -572,6 +572,17 @@ mod tests {
     }
 
     #[test]
+    fn ffi_external_elements_lists_image_when_selection_is_none() {
+        let (initial, ..) = state! {
+            doc { root { image paragraph { text("hi") } } }
+            selection: none
+        };
+        let editor = make_ffi_editor(initial);
+        let result = editor.external_elements().expect("ffi call returns Ok");
+        assert_eq!(result.len(), 1);
+    }
+
+    #[test]
     fn ffi_selection_hit_test_returns_false_for_no_selection_state() {
         let (initial, ..) = state! {
             doc { root { paragraph { t1: text("hello") } } }

--- a/crates/editor-view/src/external.rs
+++ b/crates/editor-view/src/external.rs
@@ -32,9 +32,9 @@ pub(crate) fn external_elements(
     tree: &LayoutTree,
     pages: &[LayoutPage],
     doc: &Doc,
-    selection: &Selection,
+    selection: Option<&Selection>,
 ) -> Vec<ExternalElement> {
-    let selection = selection.resolve(doc);
+    let selection = selection.and_then(|s| s.resolve(doc));
     let mut elements = Vec::new();
     for (page_idx, page) in pages.iter().enumerate() {
         collect_from_node(

--- a/crates/editor-view/src/view.rs
+++ b/crates/editor-view/src/view.rs
@@ -382,9 +382,6 @@ impl View {
         doc: &Doc,
         selection: Option<&Selection>,
     ) -> Vec<ExternalElement> {
-        let Some(selection) = selection else {
-            return Vec::new();
-        };
         let Some(ref result) = self.layout else {
             return Vec::new();
         };


### PR DESCRIPTION
                                                                               
  ## 동작                                                             
                                                                              
  | 상태 | Esc 결과 |                                                           
  |---|---|                                                                     
  | 텍스트 range | head 위치 caret으로 접힘, focus 유지 |                       
  | collapsed caret | blur + selection null |                                   
  | unit selection (이미지 등) | blur + selection null |                        
  | selection null | no-op |                                                    
                                                                                
  `selection == null`을 "에디터가 unfocus된 상태"로 본다.                       
  collapse 결과를 normalize했을 때 기존 selection과 같으면 (방향 뒤집힘 포함) 
  blur + clear, 다르면 새 selection 적용.                                       
                                                                              
  ## 구현                                                                       
                                                                              
  ### `Key::Escape` 핸들러                                                      
  `editor-core/src/handle/key.rs`의 비어있던 arm 구현. head로 collapse →      
  normalize → 동등 비교 → `set_selection(None)` 또는 collapsed 적용.            
                                                                                                                   
  ### JS focus 동기화                                                         
  selection이 undefined가 되면 `inputEl.blur()` 호출. DOM blur → 기존
  `setFocused` 경로로 Rust focused 상태도 따라옴.                               
   
  ### 부수 수정 — external_elements                                             
  `editor-view::external_elements`가 selection이 None일 때 빈 Vec을 리턴하던
  short-circuit 제거. 이전엔 selection이 항상 non-null이라 죽은 코드였는데, Esc로 null이 정상 상태가 되면서
   이미지/파일/embed가 화면에서 사라지는 버그로 노출됨. selection은             
  `is_selected` 표시에만 쓰이지 요소 collect와는 무관하므로 
  `Option<&Selection>`을 그대로 통과시키도록 변경.
                                                                              
  ## Selection 모델
  optional 확장은 이미 구현된 상태.  (`State::selection: Option<Selection>`,                                       
  `Transaction::set_selection(Option<Selection>)`, FFI/JS 모두 optional). 본
  PR은 Esc 동작 배선과 잠재 버그 수정에 한정.                                   
                                                 
  ## Test plan                                                                  
                                                                              
  - [x] `editor-core` 단위 테스트 4개 추가 (4가지 케이스 모두 커버)             
  - [x] `editor-ffi` 회귀 테스트                 
  (`ffi_external_elements_lists_image_when_selection_is_none`)                  
  - [x] `cargo test`: editor-core 446 / editor-view 408 모두 통과             
  - [x] 브라우저 수동 확인: text range → caret, caret → blur, image → blur, IME 
  조합 중 Esc 안전성    