### PR TITLE
안드로이드 bottom toolbar 디버그

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorInput.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorInput.kt
@@ -333,7 +333,12 @@ internal class EditorInputNode(
   }
 
   override fun onFocusEvent(focusState: FocusState) {
-    focused = focusState.isFocused
+    val nextFocused = focusState.isFocused
+    if (focused == nextFocused) {
+      return
+    }
+
+    focused = nextFocused
     syncTextInputSession()
   }
 


### PR DESCRIPTION
- 바텀 툴바를 열었을 때 키보드가 닫혔다가 열렸다가 닫히는 문제
- 에뮬레이터에서 바텀 툴바를 열자마자 닫히는 문제

를 해결함