### PR TITLE
TR-125 웹 서버 outbox 구현

### DIFF
--- a/apps/website/src/lib/editor-ffi/outbox.ts
+++ b/apps/website/src/lib/editor-ffi/outbox.ts
@@ -24,16 +24,10 @@ function openDatabase(): Promise<IDBDatabase> {
   });
 }
 
-function idbRequest<T>(request: IDBRequest<T>): Promise<T> {
-  return new Promise((resolve, reject) => {
-    request.addEventListener('error', () => reject(request.error));
-    request.addEventListener('success', () => resolve(request.result));
-  });
-}
-
 export class Outbox {
   #documentId: string;
   #db: IDBDatabase | null = null;
+  #destroyed = false;
 
   constructor(documentId: string) {
     this.#documentId = documentId;
@@ -43,27 +37,38 @@ export class Outbox {
     return (this.#db ??= await openDatabase());
   }
 
+  #request<T>(request: IDBRequest<T>): Promise<T> {
+    return new Promise((resolve, reject) => {
+      request.addEventListener('error', () => reject(request.error));
+      request.addEventListener('success', () => resolve(request.result));
+    });
+  }
+
   async save(id: string, bundle: Uint8Array): Promise<void> {
+    if (this.#destroyed) return;
     const db = await this.#ensureDb();
     const store = db.transaction(STORE_NAME, 'readwrite').objectStore(STORE_NAME);
-    await idbRequest(store.put({ id, documentId: this.#documentId, bundle, createdAt: Date.now() } satisfies StoredEntry));
+    await this.#request(store.put({ id, documentId: this.#documentId, bundle, createdAt: Date.now() } satisfies StoredEntry));
   }
 
   async delete(id: string): Promise<void> {
+    if (this.#destroyed) return;
     const db = await this.#ensureDb();
     const store = db.transaction(STORE_NAME, 'readwrite').objectStore(STORE_NAME);
-    await idbRequest(store.delete(id));
+    await this.#request(store.delete(id));
   }
 
   async loadAll(): Promise<{ id: string; bundle: Uint8Array }[]> {
+    if (this.#destroyed) return [];
     const db = await this.#ensureDb();
     const store = db.transaction(STORE_NAME, 'readonly').objectStore(STORE_NAME);
     const index = store.index('documentId');
-    const results = (await idbRequest(index.getAll(this.#documentId))) as StoredEntry[];
+    const results = (await this.#request(index.getAll(this.#documentId))) as StoredEntry[];
     return results.toSorted((a, b) => a.createdAt - b.createdAt).map(({ id, bundle }) => ({ id, bundle }));
   }
 
   destroy(): void {
+    this.#destroyed = true;
     this.#db?.close();
     this.#db = null;
   }

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditorV2.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditorV2.svelte
@@ -4,12 +4,12 @@
   import { onDestroy, untrack } from 'svelte';
   import EditorComponent from '$lib/editor-ffi/components/Editor.svelte';
   import { setupEditorContext } from '$lib/editor-ffi/editor.svelte';
+  import { Outbox } from '$lib/editor-ffi/outbox';
   import { graphql } from '$mearie';
   import { DebugBus } from './@debug/debug-bus.svelte';
   import DebugPanel from './@debug/DebugPanel.svelte';
   import BottomToolbar from './BottomToolbar.svelte';
   import SettingsPanel from './SettingsPanel.svelte';
-  import { Outbox } from './sync/outbox';
   import { Pusher } from './sync/pusher.svelte';
   import TopToolbar from './TopToolbar.svelte';
   import type { DocumentEditorV2_document$key } from '$mearie';
@@ -187,10 +187,22 @@
       lastConfirmedHeads = Uint8Array.fromBase64(result.pushDocumentChangesets.heads);
     };
 
-    // 재진입 시 outbox에 남은 bundle 재전송
+    // 재진입 시 outbox에 남은 bundle을 에디터에 적용 후 재전송
     void (async () => {
-      for (const { id, bundle } of await outbox.loadAll()) {
-        await pushFn(bundle);
+      const pending = await outbox.loadAll();
+      if (pending.length === 0) return;
+
+      for (const { bundle } of pending) {
+        editor.receiveRemoteChangeset(bundle);
+      }
+
+      const baseHeads = initialHeads;
+      const replayBundle = editor.localChangesetsSince(baseHeads);
+      if (replayBundle.length > 0) {
+        await pushFn(replayBundle);
+      }
+
+      for (const { id } of pending) {
         await outbox.delete(id);
       }
     })();

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditorV2.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditorV2.svelte
@@ -9,6 +9,7 @@
   import DebugPanel from './@debug/DebugPanel.svelte';
   import BottomToolbar from './BottomToolbar.svelte';
   import SettingsPanel from './SettingsPanel.svelte';
+  import { Outbox } from './sync/outbox';
   import { Pusher } from './sync/pusher.svelte';
   import TopToolbar from './TopToolbar.svelte';
   import type { DocumentEditorV2_document$key } from '$mearie';
@@ -74,6 +75,7 @@
   const bus = new DebugBus();
   const clientId = crypto.randomUUID();
   let pusher = $state<Pusher | null>(null);
+
   let debugOpen = $state(true);
   let settingsOpen = $state(false);
 
@@ -172,21 +174,34 @@
     const initialHeads = editor.currentHeads();
     lastConfirmedHeads = initialHeads;
 
+    const outbox = new Outbox(document.data.id);
+
+    const pushFn = async (changesets: Uint8Array) => {
+      const result = await pushDocumentChangesets({
+        input: {
+          documentId: document.data.id,
+          clientId,
+          changesets: changesets.toBase64(),
+        },
+      });
+      lastConfirmedHeads = Uint8Array.fromBase64(result.pushDocumentChangesets.heads);
+    };
+
+    // 재진입 시 outbox에 남은 bundle 재전송
+    void (async () => {
+      for (const { id, bundle } of await outbox.loadAll()) {
+        await pushFn(bundle);
+        await outbox.delete(id);
+      }
+    })();
+
     const ps = new Pusher({
       editor,
       documentId: document.data.id,
       clientId,
       initialServerHeads: initialHeads,
-      pushFn: async (changesets) => {
-        const result = await pushDocumentChangesets({
-          input: {
-            documentId: document.data.id,
-            clientId,
-            changesets: changesets.toBase64(),
-          },
-        });
-        lastConfirmedHeads = Uint8Array.fromBase64(result.pushDocumentChangesets.heads);
-      },
+      pushFn,
+      outbox,
       onEvent: (e) => bus.emit(e),
     });
     pusher = ps;
@@ -214,6 +229,7 @@
       clearInterval(pollIntervalId);
       offStateChanged();
       ps.stop();
+      outbox.destroy();
       pusher = null;
     };
   });

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/sync/outbox.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/sync/outbox.ts
@@ -1,0 +1,70 @@
+const DB_NAME = 'typie:outbox';
+const DB_VERSION = 1;
+const STORE_NAME = 'entries';
+
+type StoredEntry = {
+  id: string;
+  documentId: string;
+  bundle: Uint8Array;
+  createdAt: number;
+};
+
+function openDatabase(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.addEventListener('error', () => reject(request.error));
+    request.addEventListener('success', () => resolve(request.result));
+    request.addEventListener('upgradeneeded', () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        const store = db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+        store.createIndex('documentId', 'documentId');
+      }
+    });
+  });
+}
+
+function idbRequest<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.addEventListener('error', () => reject(request.error));
+    request.addEventListener('success', () => resolve(request.result));
+  });
+}
+
+export class Outbox {
+  #documentId: string;
+  #db: IDBDatabase | null = null;
+
+  constructor(documentId: string) {
+    this.#documentId = documentId;
+  }
+
+  async #ensureDb(): Promise<IDBDatabase> {
+    return (this.#db ??= await openDatabase());
+  }
+
+  async save(id: string, bundle: Uint8Array): Promise<void> {
+    const db = await this.#ensureDb();
+    const store = db.transaction(STORE_NAME, 'readwrite').objectStore(STORE_NAME);
+    await idbRequest(store.put({ id, documentId: this.#documentId, bundle, createdAt: Date.now() } satisfies StoredEntry));
+  }
+
+  async delete(id: string): Promise<void> {
+    const db = await this.#ensureDb();
+    const store = db.transaction(STORE_NAME, 'readwrite').objectStore(STORE_NAME);
+    await idbRequest(store.delete(id));
+  }
+
+  async loadAll(): Promise<{ id: string; bundle: Uint8Array }[]> {
+    const db = await this.#ensureDb();
+    const store = db.transaction(STORE_NAME, 'readonly').objectStore(STORE_NAME);
+    const index = store.index('documentId');
+    const results = (await idbRequest(index.getAll(this.#documentId))) as StoredEntry[];
+    return results.toSorted((a, b) => a.createdAt - b.createdAt).map(({ id, bundle }) => ({ id, bundle }));
+  }
+
+  destroy(): void {
+    this.#db?.close();
+    this.#db = null;
+  }
+}

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/sync/pusher.svelte.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/sync/pusher.svelte.ts
@@ -23,12 +23,18 @@ function isPermanent(err: unknown): boolean {
   return false;
 }
 
+type Outbox = {
+  save(id: string, bundle: Uint8Array): Promise<void>;
+  delete(id: string): Promise<void>;
+};
+
 type PusherOpts = {
   editor: Editor;
   documentId: string;
   clientId: string;
   initialServerHeads: Uint8Array;
   pushFn: (changesets: Uint8Array) => Promise<void>;
+  outbox: Outbox;
   onEvent?: (event: PusherEvent) => void;
 };
 
@@ -97,6 +103,9 @@ export class Pusher {
     const bundle = this.opts.editor.localChangesetsSince(before);
     if (bundle.length === 0) return;
 
+    const entryId = crypto.randomUUID();
+    await this.opts.outbox.save(entryId, bundle);
+
     const snapshot = this.opts.editor.currentHeads();
     this.clearTimers();
     this.inflight = true;
@@ -112,6 +121,8 @@ export class Pusher {
       this.handleFailure(err);
       return;
     }
+
+    await this.opts.outbox.delete(entryId);
 
     if (this.stopped) return;
 

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/sync/types.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/sync/types.ts
@@ -4,3 +4,14 @@ export type PusherEvent =
   | { kind: 'push.fired'; bytes: number }
   | { kind: 'push.success'; durationMs: number }
   | { kind: 'push.error'; message: string };
+
+export type OutboxEntry = {
+  id: string;
+  bundle: Uint8Array;
+};
+
+export type Outbox = {
+  save(entry: OutboxEntry): Promise<void>;
+  delete(id: string): Promise<void>;
+  loadAll(): Promise<OutboxEntry[]>;
+};


### PR DESCRIPTION
웹 에디터에서 생성된 changeset을 로컬 outbox를 구현하여 보존하고, 페이지 재진입 시 전송 되지 못한 changeset을 자동으로 재전송합니다.  
  
구현은 기존 에디터의 `persistence.ts` 를 참조하여 만들었습니다. 재 진입시 서버 최신 그래프로 에디터가 초기화 되므로 이를 고려하여 `DocumentEditorV2.svelte`에 재진입 복구 로직을 추가했습니다.