### PR TITLE
feat: blockquote, callout, fold unwrap 구현

### DIFF
--- a/crates/editor-commands/src/commands/mod.rs
+++ b/crates/editor-commands/src/commands/mod.rs
@@ -60,6 +60,9 @@ mod surround_selection;
 mod toggle_bold;
 mod toggle_modifier;
 mod try_text_replacement;
+mod unwrap_blockquote;
+mod unwrap_callout;
+mod unwrap_fold;
 
 pub use auto_surround::auto_surround;
 pub use clear_all_modifiers::clear_all_modifiers;
@@ -123,3 +126,6 @@ pub use surround_selection::surround_selection;
 pub use toggle_bold::toggle_bold;
 pub use toggle_modifier::toggle_modifier;
 pub use try_text_replacement::try_text_replacement;
+pub use unwrap_blockquote::unwrap_blockquote;
+pub use unwrap_callout::unwrap_callout;
+pub use unwrap_fold::unwrap_fold;

--- a/crates/editor-commands/src/commands/unwrap_blockquote.rs
+++ b/crates/editor-commands/src/commands/unwrap_blockquote.rs
@@ -1,0 +1,157 @@
+use editor_model::{Node, NodeId};
+use editor_transaction::Transaction;
+
+use crate::helpers::unwrap_block_wrapper;
+use crate::{CommandError, CommandResult};
+
+pub fn unwrap_blockquote(tr: &mut Transaction, node_id: NodeId) -> CommandResult {
+    let doc = tr.doc();
+    let node = doc
+        .node(node_id)
+        .ok_or(CommandError::NodeNotFound(node_id))?;
+    if !matches!(node.node(), Node::Blockquote(_)) {
+        return Ok(false);
+    }
+    unwrap_block_wrapper(tr, node_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use editor_macros::state;
+
+    use super::*;
+    use crate::test_utils::*;
+
+    #[test]
+    fn unwrap_blockquote_with_single_paragraph() {
+        let (initial, bq, ..) = state! {
+            doc {
+                root {
+                    bq: blockquote {
+                        paragraph { t: text("hello") }
+                    }
+                    paragraph {}
+                }
+            }
+            selection: (bq, 0)
+        };
+        let (actual, ..) = transact!(initial, |tr| unwrap_blockquote(&mut tr, bq));
+        let (expected, ..) = state! {
+            doc {
+                root {
+                    paragraph { t: text("hello") }
+                    paragraph {}
+                }
+            }
+            selection: (t, 0)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn unwrap_blockquote_with_multiple_children() {
+        let (initial, bq, ..) = state! {
+            doc {
+                root {
+                    bq: blockquote {
+                        paragraph { t1: text("a") }
+                        paragraph { text("b") }
+                    }
+                    paragraph {}
+                }
+            }
+            selection: (bq, 0)
+        };
+        let (actual, ..) = transact!(initial, |tr| unwrap_blockquote(&mut tr, bq));
+        let (expected, ..) = state! {
+            doc {
+                root {
+                    paragraph { t1: text("a") }
+                    paragraph { text("b") }
+                    paragraph {}
+                }
+            }
+            selection: (t1, 0)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn unwrap_blockquote_preserves_nested_list() {
+        let (initial, bq, ..) = state! {
+            doc {
+                root {
+                    bq: blockquote {
+                        paragraph { t1: text("a") }
+                        bullet_list {
+                            list_item { paragraph { text("b") } }
+                        }
+                    }
+                    paragraph {}
+                }
+            }
+            selection: (bq, 0)
+        };
+        let (actual, ..) = transact!(initial, |tr| unwrap_blockquote(&mut tr, bq));
+        let (expected, ..) = state! {
+            doc {
+                root {
+                    paragraph { t1: text("a") }
+                    bullet_list {
+                        list_item { paragraph { text("b") } }
+                    }
+                    paragraph {}
+                }
+            }
+            selection: (t1, 0)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn unwrap_non_blockquote_returns_false() {
+        let (initial, p, ..) = state! {
+            doc {
+                root {
+                    p: paragraph { text("hi") }
+                }
+            }
+            selection: (p, 0)
+        };
+        transact_fail!(initial, |tr| unwrap_blockquote(&mut tr, p));
+    }
+
+    #[test]
+    fn unwrap_blockquote_inside_fold_content() {
+        let (initial, bq, ..) = state! {
+            doc {
+                root {
+                    fold {
+                        fold_title { text("title") }
+                        fold_content {
+                            bq: blockquote {
+                                paragraph { t: text("body") }
+                            }
+                        }
+                    }
+                }
+            }
+            selection: (bq, 0)
+        };
+        let (actual, ..) = transact!(initial, |tr| unwrap_blockquote(&mut tr, bq));
+        let (expected, ..) = state! {
+            doc {
+                root {
+                    fold {
+                        fold_title { text("title") }
+                        fold_content {
+                            paragraph { t: text("body") }
+                        }
+                    }
+                }
+            }
+            selection: (t, 0)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+}

--- a/crates/editor-commands/src/commands/unwrap_callout.rs
+++ b/crates/editor-commands/src/commands/unwrap_callout.rs
@@ -1,0 +1,98 @@
+use editor_model::{Node, NodeId};
+use editor_transaction::Transaction;
+
+use crate::helpers::unwrap_block_wrapper;
+use crate::{CommandError, CommandResult};
+
+pub fn unwrap_callout(tr: &mut Transaction, node_id: NodeId) -> CommandResult {
+    let doc = tr.doc();
+    let node = doc
+        .node(node_id)
+        .ok_or(CommandError::NodeNotFound(node_id))?;
+    if !matches!(node.node(), Node::Callout(_)) {
+        return Ok(false);
+    }
+    unwrap_block_wrapper(tr, node_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use editor_macros::state;
+
+    use super::*;
+    use crate::test_utils::*;
+
+    #[test]
+    fn unwrap_callout_with_single_paragraph() {
+        let (initial, co, ..) = state! {
+            doc {
+                root {
+                    co: callout {
+                        paragraph { t: text("hello") }
+                    }
+                    paragraph {}
+                }
+            }
+            selection: (co, 0)
+        };
+        let (actual, ..) = transact!(initial, |tr| unwrap_callout(&mut tr, co));
+        let (expected, ..) = state! {
+            doc {
+                root {
+                    paragraph { t: text("hello") }
+                    paragraph {}
+                }
+            }
+            selection: (t, 0)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn unwrap_callout_with_multiple_children() {
+        let (initial, co, ..) = state! {
+            doc {
+                root {
+                    co: callout {
+                        paragraph { t1: text("a") }
+                        paragraph { text("b") }
+                        ordered_list {
+                            list_item { paragraph { text("c") } }
+                        }
+                    }
+                    paragraph {}
+                }
+            }
+            selection: (co, 0)
+        };
+        let (actual, ..) = transact!(initial, |tr| unwrap_callout(&mut tr, co));
+        let (expected, ..) = state! {
+            doc {
+                root {
+                    paragraph { t1: text("a") }
+                    paragraph { text("b") }
+                    ordered_list {
+                        list_item { paragraph { text("c") } }
+                    }
+                    paragraph {}
+                }
+            }
+            selection: (t1, 0)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn unwrap_non_callout_returns_false() {
+        let (initial, bq, ..) = state! {
+            doc {
+                root {
+                    bq: blockquote { paragraph { text("hi") } }
+                    paragraph {}
+                }
+            }
+            selection: (bq, 0)
+        };
+        transact_fail!(initial, |tr| unwrap_callout(&mut tr, bq));
+    }
+}

--- a/crates/editor-commands/src/commands/unwrap_fold.rs
+++ b/crates/editor-commands/src/commands/unwrap_fold.rs
@@ -1,0 +1,235 @@
+use editor_model::{Node, NodeId, NodeType, PlainNode, PlainParagraphNode, Subtree};
+use editor_transaction::Transaction;
+
+use crate::helpers::place_caret_at_block_start;
+use crate::{CommandError, CommandResult};
+
+pub fn unwrap_fold(tr: &mut Transaction, node_id: NodeId) -> CommandResult {
+    let doc = tr.doc();
+    let fold = doc
+        .node(node_id)
+        .ok_or(CommandError::NodeNotFound(node_id))?;
+    if !matches!(fold.node(), Node::Fold(_)) {
+        return Ok(false);
+    }
+    let parent = fold.parent().ok_or(CommandError::NoParent(node_id))?;
+    let parent_id = parent.id();
+    let parent_spec = parent.spec();
+    let fold_index = fold
+        .index()
+        .ok_or(CommandError::Corrupted("fold has no index".into()))?;
+
+    let title = fold
+        .first_child()
+        .ok_or(CommandError::Corrupted("fold missing FoldTitle".into()))?;
+    let content = fold
+        .last_child()
+        .ok_or(CommandError::Corrupted("fold missing FoldContent".into()))?;
+
+    let title_text_ids: Vec<NodeId> = title.children().map(|c| c.id()).collect();
+    let content_block_ids: Vec<(NodeId, NodeType)> =
+        content.children().map(|c| (c.id(), c.as_type())).collect();
+
+    let has_title_text = !title_text_ids.is_empty();
+
+    let mut new_seq: Vec<NodeType> = parent.children().map(|c| c.as_type()).collect();
+    new_seq.remove(fold_index);
+    let mut insert_at = fold_index;
+    if has_title_text {
+        new_seq.insert(insert_at, NodeType::Paragraph);
+        insert_at += 1;
+    }
+    for (i, (_, t)) in content_block_ids.iter().enumerate() {
+        new_seq.insert(insert_at + i, *t);
+    }
+    if !parent_spec.content.matches_sequence(&new_seq) {
+        return Ok(false);
+    }
+
+    let new_para_id = if has_title_text {
+        Some(NodeId::new())
+    } else {
+        None
+    };
+
+    tr.batch::<_, CommandError>(|tr| {
+        let mut next_index = fold_index + 1;
+        if let Some(para_id) = new_para_id {
+            tr.insert_subtree(
+                parent_id,
+                next_index,
+                Subtree::leaf(para_id, PlainNode::Paragraph(PlainParagraphNode::default())),
+            )?;
+            next_index += 1;
+            for (i, text_id) in title_text_ids.iter().enumerate() {
+                tr.move_node(*text_id, para_id, i)?;
+            }
+        }
+        for (i, (child_id, _)) in content_block_ids.iter().enumerate() {
+            tr.move_node(*child_id, parent_id, next_index + i)?;
+        }
+        tr.remove_subtree(node_id)?;
+        Ok(())
+    })?;
+
+    let first_lifted_id = new_para_id.unwrap_or(content_block_ids[0].0);
+    place_caret_at_block_start(tr, first_lifted_id)?;
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use editor_macros::state;
+
+    use super::*;
+    use crate::test_utils::*;
+
+    #[test]
+    fn unwrap_fold_with_title_and_content() {
+        let (initial, f, ..) = state! {
+            doc {
+                root {
+                    f: fold {
+                        fold_title { text("title") }
+                        fold_content {
+                            paragraph { text("body") }
+                        }
+                    }
+                    paragraph {}
+                }
+            }
+            selection: (f, 0)
+        };
+        let (actual, ..) = transact!(initial, |tr| unwrap_fold(&mut tr, f));
+        let (expected, ..) = state! {
+            doc {
+                root {
+                    paragraph { tt: text("title") }
+                    paragraph { text("body") }
+                    paragraph {}
+                }
+            }
+            selection: (tt, 0)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn unwrap_fold_with_empty_title() {
+        let (initial, f, ..) = state! {
+            doc {
+                root {
+                    f: fold {
+                        fold_title {}
+                        fold_content {
+                            paragraph { tb: text("body") }
+                        }
+                    }
+                    paragraph {}
+                }
+            }
+            selection: (f, 0)
+        };
+        let (actual, ..) = transact!(initial, |tr| unwrap_fold(&mut tr, f));
+        let (expected, ..) = state! {
+            doc {
+                root {
+                    paragraph { tb: text("body") }
+                    paragraph {}
+                }
+            }
+            selection: (tb, 0)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn unwrap_fold_with_multiple_content_blocks() {
+        let (initial, f, ..) = state! {
+            doc {
+                root {
+                    f: fold {
+                        fold_title { text("t") }
+                        fold_content {
+                            paragraph { text("a") }
+                            bullet_list {
+                                list_item { paragraph { text("b") } }
+                            }
+                            paragraph { text("c") }
+                        }
+                    }
+                    paragraph {}
+                }
+            }
+            selection: (f, 0)
+        };
+        let (actual, ..) = transact!(initial, |tr| unwrap_fold(&mut tr, f));
+        let (expected, ..) = state! {
+            doc {
+                root {
+                    paragraph { tt: text("t") }
+                    paragraph { text("a") }
+                    bullet_list {
+                        list_item { paragraph { text("b") } }
+                    }
+                    paragraph { text("c") }
+                    paragraph {}
+                }
+            }
+            selection: (tt, 0)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn unwrap_fold_nested_inside_fold_content() {
+        let (initial, inner, ..) = state! {
+            doc {
+                root {
+                    fold {
+                        fold_title { text("outer") }
+                        fold_content {
+                            inner: fold {
+                                fold_title { text("inner") }
+                                fold_content {
+                                    paragraph { text("body") }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            selection: (inner, 0)
+        };
+        let (actual, ..) = transact!(initial, |tr| unwrap_fold(&mut tr, inner));
+        let (expected, ..) = state! {
+            doc {
+                root {
+                    fold {
+                        fold_title { text("outer") }
+                        fold_content {
+                            paragraph { tt: text("inner") }
+                            paragraph { text("body") }
+                        }
+                    }
+                }
+            }
+            selection: (tt, 0)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn unwrap_non_fold_returns_false() {
+        let (initial, bq, ..) = state! {
+            doc {
+                root {
+                    bq: blockquote { paragraph { text("hi") } }
+                    paragraph {}
+                }
+            }
+            selection: (bq, 0)
+        };
+        transact_fail!(initial, |tr| unwrap_fold(&mut tr, bq));
+    }
+}

--- a/crates/editor-commands/src/helpers/mod.rs
+++ b/crates/editor-commands/src/helpers/mod.rs
@@ -9,6 +9,7 @@ mod range;
 mod selection;
 mod table;
 mod tree;
+mod unwrap;
 
 pub(crate) use deletion::*;
 pub(crate) use insertion::*;
@@ -21,3 +22,4 @@ pub(crate) use range::*;
 pub(crate) use selection::*;
 pub(crate) use table::*;
 pub(crate) use tree::*;
+pub(crate) use unwrap::*;

--- a/crates/editor-commands/src/helpers/unwrap.rs
+++ b/crates/editor-commands/src/helpers/unwrap.rs
@@ -1,0 +1,70 @@
+use editor_model::{Node, NodeId, NodeType};
+use editor_state::{Affinity, Position, Selection};
+use editor_transaction::Transaction;
+
+use crate::{CommandError, CommandResult};
+
+pub(crate) fn unwrap_block_wrapper(tr: &mut Transaction, node_id: NodeId) -> CommandResult {
+    let doc = tr.doc();
+    let node = doc
+        .node(node_id)
+        .ok_or(CommandError::NodeNotFound(node_id))?;
+    let parent = node.parent().ok_or(CommandError::NoParent(node_id))?;
+    let parent_id = parent.id();
+    let parent_spec = parent.spec();
+    let node_index = node
+        .index()
+        .ok_or(CommandError::Corrupted("wrapper has no index".into()))?;
+
+    let children: Vec<(NodeId, NodeType)> =
+        node.children().map(|c| (c.id(), c.as_type())).collect();
+    if children.is_empty() {
+        return Ok(false);
+    }
+
+    let mut new_seq: Vec<NodeType> = parent.children().map(|c| c.as_type()).collect();
+    new_seq.remove(node_index);
+    for (i, (_, t)) in children.iter().enumerate() {
+        new_seq.insert(node_index + i, *t);
+    }
+    if !parent_spec.content.matches_sequence(&new_seq) {
+        return Ok(false);
+    }
+
+    let first_child_id = children[0].0;
+
+    tr.batch::<_, CommandError>(|tr| {
+        for (i, (child_id, _)) in children.iter().enumerate() {
+            tr.move_node(*child_id, parent_id, node_index + 1 + i)?;
+        }
+        tr.remove_subtree(node_id)?;
+        Ok(())
+    })?;
+
+    place_caret_at_block_start(tr, first_child_id)?;
+    Ok(true)
+}
+
+pub(crate) fn place_caret_at_block_start(
+    tr: &mut Transaction,
+    block_id: NodeId,
+) -> Result<(), CommandError> {
+    let doc = tr.doc();
+    let Some(block) = doc.node(block_id) else {
+        return Ok(());
+    };
+    let pos = match block.first_child() {
+        Some(child) if matches!(child.node(), Node::Text(_)) => Position {
+            node_id: child.id(),
+            offset: 0,
+            affinity: Affinity::Downstream,
+        },
+        _ => Position {
+            node_id: block_id,
+            offset: 0,
+            affinity: Affinity::Downstream,
+        },
+    };
+    tr.set_selection(Some(Selection::collapsed(pos)))?;
+    Ok(())
+}


### PR DESCRIPTION
  - 인용구/강조/접기 블록을 일반 텍스트(부모로 lift)로 변환하는 커맨드 3개 추가
  - 내부 텍스트·블록 보존 (Fold 의 title 텍스트는 새 Paragraph 로 감싸 보존)    
  - Transaction 기반이라 undo/redo 자동, 스키마 위반/타입 불일치는 Ok(false)  
  no-op     