### PR TITLE
feat: 범용 tracked range 시스템 추가

### DIFF
--- a/crates/editor-core/src/editor.rs
+++ b/crates/editor-core/src/editor.rs
@@ -24,6 +24,7 @@ use crate::history::History;
 use crate::ime::{Ime, ImeRange};
 use crate::message::*;
 use crate::state_field::StateField;
+use crate::tracked_range::TrackedRangeRegistry;
 
 #[derive(Clone, Copy, Debug)]
 enum Mode {
@@ -74,6 +75,7 @@ pub struct Editor {
     pub(crate) history: History,
     pub(crate) renderer: Renderer,
     pub(crate) resource: Arc<Mutex<Resource>>,
+    pub(crate) tracked_ranges: TrackedRangeRegistry,
 
     // interaction state
     drag_anchor: Option<Selection>,
@@ -131,6 +133,7 @@ impl Editor {
             history: History::new(Duration::from_millis(300)),
             renderer: Renderer::new(Arc::clone(&resource)),
             resource,
+            tracked_ranges: TrackedRangeRegistry::new(),
             drag_anchor: None,
             dnd_drop_target: None,
             focused: false,
@@ -145,6 +148,24 @@ impl Editor {
 
     pub fn state(&self) -> &State {
         &self.state
+    }
+
+    pub fn tracked_ranges(&self) -> &TrackedRangeRegistry {
+        &self.tracked_ranges
+    }
+
+    pub(crate) fn tracked_ranges_mut(&mut self) -> &mut TrackedRangeRegistry {
+        &mut self.tracked_ranges
+    }
+
+    pub(crate) fn is_probing(&self) -> bool {
+        matches!(self.mode, Mode::Probe { .. })
+    }
+
+    pub(crate) fn mark_probed_change(&mut self, would_change: bool) {
+        if let Mode::Probe { ref mut changed } = self.mode {
+            *changed |= would_change;
+        }
     }
 
     pub fn receive_remote_changeset(&mut self, changeset: Changeset<DocOp>) {
@@ -478,6 +499,7 @@ impl Editor {
             Message::Navigation { op } => handle::handle_navigation_op(self, op)?,
             Message::History { op } => handle::handle_history_op(self, op)?,
             Message::System { event } => handle::handle_system_event(self, event)?,
+            Message::TrackedRange { op } => handle::handle_tracked_range_op(self, op)?,
             Message::Remote { changeset } => handle::handle_remote(self, changeset)?,
         }
         Ok(())
@@ -926,6 +948,7 @@ impl Editor {
             history: History::new(Duration::from_millis(300)),
             renderer: Renderer::new(Arc::clone(&resource)),
             resource,
+            tracked_ranges: TrackedRangeRegistry::new(),
             drag_anchor: None,
             dnd_drop_target: None,
             focused: false,

--- a/crates/editor-core/src/handle/mod.rs
+++ b/crates/editor-core/src/handle/mod.rs
@@ -12,6 +12,7 @@ mod remote;
 mod selection;
 mod system;
 mod text_input;
+mod tracked_range;
 mod view;
 
 pub use clipboard::handle_clipboard_op;
@@ -28,4 +29,5 @@ pub use remote::handle_remote;
 pub use selection::handle_selection_op;
 pub use system::handle_system_event;
 pub use text_input::handle_flat_ime_ops;
+pub use tracked_range::handle_tracked_range_op;
 pub use view::handle_view_op;

--- a/crates/editor-core/src/handle/tracked_range.rs
+++ b/crates/editor-core/src/handle/tracked_range.rs
@@ -1,0 +1,256 @@
+use editor_state::StableSelection;
+
+use crate::editor::Editor;
+use crate::error::EditorError;
+use crate::event::EditorEvent;
+use crate::message::*;
+use crate::state_field::StateField;
+use crate::tracked_range::TrackedRange;
+
+pub fn handle_tracked_range_op(editor: &mut Editor, op: TrackedRangeOp) -> Result<(), EditorError> {
+    match op {
+        TrackedRangeOp::Add {
+            id,
+            group,
+            selection,
+            metadata,
+        } => {
+            let doc = &editor.state().doc;
+            if selection.anchor.resolve(doc).is_none() || selection.head.resolve(doc).is_none() {
+                return Err(EditorError::General {
+                    msg: "TrackedRange::Add: selection must resolve against current doc".into(),
+                });
+            }
+            let new_range = TrackedRange {
+                id: id.clone(),
+                group,
+                selection: StableSelection::freeze(&selection, doc),
+                metadata,
+                explicitly_invalid: false,
+            };
+            let would_change = editor
+                .tracked_ranges()
+                .get(&id)
+                .map(|existing| existing != &new_range)
+                .unwrap_or(true);
+            commit_or_probe(editor, would_change, |reg| {
+                reg.add(new_range);
+            });
+        }
+        TrackedRangeOp::Remove { id } => {
+            let would_change = editor.tracked_ranges().contains(&id);
+            commit_or_probe(editor, would_change, |reg| {
+                reg.remove(&id);
+            });
+        }
+        TrackedRangeOp::ClearGroup { group } => {
+            let would_change = editor.tracked_ranges().group_size(&group) > 0;
+            commit_or_probe(editor, would_change, |reg| {
+                reg.clear_group(&group);
+            });
+        }
+        TrackedRangeOp::Invalidate { id } => {
+            let would_change = editor
+                .tracked_ranges()
+                .get(&id)
+                .is_some_and(|r| !r.explicitly_invalid);
+            commit_or_probe(editor, would_change, |reg| {
+                reg.invalidate(&id);
+            });
+        }
+    }
+    Ok(())
+}
+
+fn commit_or_probe<F>(editor: &mut Editor, would_change: bool, apply: F)
+where
+    F: FnOnce(&mut crate::tracked_range::TrackedRangeRegistry),
+{
+    if editor.is_probing() {
+        editor.mark_probed_change(would_change);
+        return;
+    }
+    if would_change {
+        apply(editor.tracked_ranges_mut());
+        editor.push_event(EditorEvent::StateChanged {
+            fields: vec![StateField::TrackedRanges],
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use editor_macros::state;
+
+    use crate::test_utils::assert_probe_predicts_apply;
+
+    fn add_op(id: &str, sel: editor_state::Selection) -> Message {
+        Message::TrackedRange {
+            op: TrackedRangeOp::Add {
+                id: id.into(),
+                group: "g1".into(),
+                selection: sel,
+                metadata: String::new(),
+            },
+        }
+    }
+
+    #[test]
+    fn add_inserts_range_and_emits_state_changed() {
+        let (state, ..) = state! {
+            doc { root { paragraph { t1: text("hello") } } }
+            selection: (t1, 1) -> (t1, 4)
+        };
+        let sel = state.selection.unwrap();
+        let mut editor = Editor::new_test(state);
+        let events = editor.apply(add_op("a", sel));
+        assert!(editor.tracked_ranges().contains("a"));
+        assert!(events.iter().any(|e| matches!(
+            e,
+            EditorEvent::StateChanged { fields } if fields.contains(&StateField::TrackedRanges)
+        )));
+    }
+
+    #[test]
+    fn add_same_range_twice_is_idempotent() {
+        let (state, ..) = state! {
+            doc { root { paragraph { t1: text("hello") } } }
+            selection: (t1, 1) -> (t1, 4)
+        };
+        let sel = state.selection.unwrap();
+        let mut editor = Editor::new_test(state);
+        editor.apply(add_op("a", sel));
+        let events = editor.apply(add_op("a", sel));
+        assert!(!events.iter().any(|e| matches!(
+            e,
+            EditorEvent::StateChanged { fields } if fields.contains(&StateField::TrackedRanges)
+        )));
+    }
+
+    #[test]
+    fn remove_drops_range_and_emits_state_changed() {
+        let (state, ..) = state! {
+            doc { root { paragraph { t1: text("hello") } } }
+            selection: (t1, 1) -> (t1, 4)
+        };
+        let sel = state.selection.unwrap();
+        let mut editor = Editor::new_test(state);
+        editor.apply(add_op("a", sel));
+        let events = editor.apply(Message::TrackedRange {
+            op: TrackedRangeOp::Remove { id: "a".into() },
+        });
+        assert!(!editor.tracked_ranges().contains("a"));
+        assert!(events.iter().any(|e| matches!(
+            e,
+            EditorEvent::StateChanged { fields } if fields.contains(&StateField::TrackedRanges)
+        )));
+    }
+
+    #[test]
+    fn remove_nonexistent_does_not_emit_event() {
+        let (state, ..) = state! {
+            doc { root { paragraph { t1: text("hello") } } }
+            selection: (t1, 1) -> (t1, 4)
+        };
+        let mut editor = Editor::new_test(state);
+        let events = editor.apply(Message::TrackedRange {
+            op: TrackedRangeOp::Remove { id: "x".into() },
+        });
+        assert!(!events.iter().any(|e| matches!(
+            e,
+            EditorEvent::StateChanged { fields } if fields.contains(&StateField::TrackedRanges)
+        )));
+    }
+
+    #[test]
+    fn invalidate_sets_flag() {
+        let (state, ..) = state! {
+            doc { root { paragraph { t1: text("hello") } } }
+            selection: (t1, 1) -> (t1, 4)
+        };
+        let sel = state.selection.unwrap();
+        let mut editor = Editor::new_test(state);
+        editor.apply(add_op("a", sel));
+        editor.apply(Message::TrackedRange {
+            op: TrackedRangeOp::Invalidate { id: "a".into() },
+        });
+        assert!(editor.tracked_ranges().get("a").unwrap().explicitly_invalid);
+    }
+
+    #[test]
+    fn clear_group_empties_group() {
+        let (state, ..) = state! {
+            doc { root { paragraph { t1: text("hello") } } }
+            selection: (t1, 1) -> (t1, 4)
+        };
+        let sel = state.selection.unwrap();
+        let mut editor = Editor::new_test(state);
+        editor.apply(add_op("a", sel));
+        editor.apply(add_op("b", sel));
+        editor.apply(Message::TrackedRange {
+            op: TrackedRangeOp::ClearGroup { group: "g1".into() },
+        });
+        assert_eq!(editor.tracked_ranges().len(), 0);
+    }
+
+    #[test]
+    fn probe_add_predicts_change() {
+        let (state, ..) = state! {
+            doc { root { paragraph { t1: text("hello") } } }
+            selection: (t1, 1) -> (t1, 4)
+        };
+        let sel = state.selection.unwrap();
+        assert_probe_predicts_apply(state, add_op("a", sel));
+    }
+
+    #[test]
+    fn probe_remove_nonexistent_predicts_no_change() {
+        let (state, ..) = state! {
+            doc { root { paragraph { t1: text("hello") } } }
+            selection: (t1, 1) -> (t1, 4)
+        };
+        assert_probe_predicts_apply(
+            state,
+            Message::TrackedRange {
+                op: TrackedRangeOp::Remove { id: "x".into() },
+            },
+        );
+    }
+
+    #[test]
+    fn probe_clear_empty_group_predicts_no_change() {
+        let (state, ..) = state! {
+            doc { root { paragraph { t1: text("hello") } } }
+            selection: (t1, 1) -> (t1, 4)
+        };
+        assert_probe_predicts_apply(
+            state,
+            Message::TrackedRange {
+                op: TrackedRangeOp::ClearGroup {
+                    group: "nothing".into(),
+                },
+            },
+        );
+    }
+
+    #[test]
+    fn probe_invalidate_already_invalid_predicts_no_change() {
+        let (state, ..) = state! {
+            doc { root { paragraph { t1: text("hello") } } }
+            selection: (t1, 1) -> (t1, 4)
+        };
+        let sel = state.selection.unwrap();
+        let mut editor = Editor::new_test(state);
+        editor.apply(add_op("a", sel));
+        editor.apply(Message::TrackedRange {
+            op: TrackedRangeOp::Invalidate { id: "a".into() },
+        });
+        let probed = editor
+            .can(Message::TrackedRange {
+                op: TrackedRangeOp::Invalidate { id: "a".into() },
+            })
+            .unwrap();
+        assert!(!probed);
+    }
+}

--- a/crates/editor-core/src/lib.rs
+++ b/crates/editor-core/src/lib.rs
@@ -10,6 +10,7 @@ mod history;
 mod ime;
 mod message;
 mod state_field;
+mod tracked_range;
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;
@@ -29,3 +30,4 @@ pub use history::*;
 pub use ime::*;
 pub use message::*;
 pub use state_field::*;
+pub use tracked_range::*;

--- a/crates/editor-core/src/message.rs
+++ b/crates/editor-core/src/message.rs
@@ -331,6 +331,28 @@ pub enum FlatImeOp {
 #[ffi]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
+pub enum TrackedRangeOp {
+    Add {
+        id: String,
+        group: String,
+        selection: Selection,
+        #[serde(default)]
+        metadata: String,
+    },
+    Remove {
+        id: String,
+    },
+    ClearGroup {
+        group: String,
+    },
+    Invalidate {
+        id: String,
+    },
+}
+
+#[ffi]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
 pub enum Message {
     Key {
         event: KeyEvent,
@@ -373,6 +395,9 @@ pub enum Message {
     },
     System {
         event: SystemEvent,
+    },
+    TrackedRange {
+        op: TrackedRangeOp,
     },
 
     #[ffi(skip)]

--- a/crates/editor-core/src/state_field.rs
+++ b/crates/editor-core/src/state_field.rs
@@ -19,4 +19,5 @@ pub enum StateField {
     Ime,
     Modifiers,
     Block,
+    TrackedRanges,
 }

--- a/crates/editor-core/src/test_utils.rs
+++ b/crates/editor-core/src/test_utils.rs
@@ -6,6 +6,7 @@ use editor_view::Viewport;
 use hashbrown::HashMap;
 
 use crate::editor::Editor;
+use crate::tracked_range::TrackedRangeRegistry;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct EditorSnapshot {
@@ -22,6 +23,7 @@ pub struct EditorSnapshot {
     focused: bool,
     theme_variant: ThemeVariant,
     page_sizes: Vec<Size>,
+    tracked_ranges: TrackedRangeRegistry,
 }
 
 impl EditorSnapshot {
@@ -42,6 +44,7 @@ impl EditorSnapshot {
             focused: editor.is_focused(),
             theme_variant: editor.theme_variant(),
             page_sizes,
+            tracked_ranges: editor.tracked_ranges().clone(),
         }
     }
 }

--- a/crates/editor-core/src/tests/can_invariants.rs
+++ b/crates/editor-core/src/tests/can_invariants.rs
@@ -102,6 +102,21 @@ fn build_corpus() -> Vec<Message> {
         Message::System {
             event: SystemEvent::FontsChanged,
         },
+        Message::TrackedRange {
+            op: TrackedRangeOp::Remove {
+                id: "missing".into(),
+            },
+        },
+        Message::TrackedRange {
+            op: TrackedRangeOp::ClearGroup {
+                group: "missing".into(),
+            },
+        },
+        Message::TrackedRange {
+            op: TrackedRangeOp::Invalidate {
+                id: "missing".into(),
+            },
+        },
     ]
 }
 
@@ -161,6 +176,7 @@ fn message_variants_are_enumerated() {
         | Message::Navigation { .. }
         | Message::History { .. }
         | Message::System { .. }
+        | Message::TrackedRange { .. }
         | Message::Remote { .. } => {}
     }
 }

--- a/crates/editor-core/src/tests/mod.rs
+++ b/crates/editor-core/src/tests/mod.rs
@@ -1,1 +1,2 @@
 mod can_invariants;
+mod tracked_range_integration;

--- a/crates/editor-core/src/tests/tracked_range_integration.rs
+++ b/crates/editor-core/src/tests/tracked_range_integration.rs
@@ -1,0 +1,163 @@
+use editor_macros::state;
+use editor_state::Selection;
+
+use crate::editor::Editor;
+use crate::message::*;
+
+fn add_message(id: &str, group: &str, selection: Selection) -> Message {
+    Message::TrackedRange {
+        op: TrackedRangeOp::Add {
+            id: id.into(),
+            group: group.into(),
+            selection,
+            metadata: String::new(),
+        },
+    }
+}
+
+fn thawed_offsets(editor: &Editor, id: &str) -> (usize, usize) {
+    let range = editor.tracked_ranges().get(id).expect("range present");
+    let sel = range.selection.thaw(&editor.state().doc);
+    (sel.anchor.offset, sel.head.offset)
+}
+
+fn is_collapsed_on_thaw(editor: &Editor, id: &str) -> bool {
+    let range = editor.tracked_ranges().get(id).expect("range present");
+    range.selection.thaw(&editor.state().doc).is_collapsed()
+}
+
+#[test]
+fn range_position_shifts_when_text_inserted_before_it() {
+    let (initial, t1) = state! {
+        doc { root { paragraph { t1: text("hello") } } }
+        selection: (t1, 1) -> (t1, 4)
+    };
+    let sel = initial.selection.unwrap();
+    let mut editor = Editor::new_test(initial);
+    editor.apply(add_message("r", "g", sel));
+
+    assert_eq!(thawed_offsets(&editor, "r"), (1, 4));
+
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::collapsed(editor_state::Position::new(t1, 0)),
+        },
+    });
+    editor.apply(Message::Insertion {
+        op: InsertionOp::Text { text: "X".into() },
+    });
+
+    let (a, h) = thawed_offsets(&editor, "r");
+    assert_eq!((a, h), (2, 5), "range must shift by inserted length");
+}
+
+#[test]
+fn range_marked_invalid_when_all_covered_text_deleted() {
+    let (initial, t1) = state! {
+        doc { root { paragraph { t1: text("hello") } } }
+        selection: (t1, 1) -> (t1, 4)
+    };
+    let sel = initial.selection.unwrap();
+    let mut editor = Editor::new_test(initial);
+    editor.apply(add_message("r", "g", sel));
+    assert!(!is_collapsed_on_thaw(&editor, "r"));
+
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::new(
+                editor_state::Position::new(t1, 1),
+                editor_state::Position::new(t1, 4),
+            ),
+        },
+    });
+    editor.apply(Message::Deletion {
+        op: DeletionOp::Selection,
+    });
+
+    assert!(
+        is_collapsed_on_thaw(&editor, "r"),
+        "deleting the covered text must collapse the range"
+    );
+}
+
+#[test]
+fn range_positions_revert_after_undo() {
+    let (initial, t1) = state! {
+        doc { root { paragraph { t1: text("hello") } } }
+        selection: (t1, 1) -> (t1, 4)
+    };
+    let sel = initial.selection.unwrap();
+    let mut editor = Editor::new_test(initial);
+    editor.apply(add_message("r", "g", sel));
+
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::collapsed(editor_state::Position::new(t1, 0)),
+        },
+    });
+    editor.apply(Message::Insertion {
+        op: InsertionOp::Text { text: "X".into() },
+    });
+    assert_eq!(thawed_offsets(&editor, "r"), (2, 5));
+
+    editor.apply(Message::History {
+        op: HistoryOp::Undo,
+    });
+
+    assert_eq!(
+        thawed_offsets(&editor, "r"),
+        (1, 4),
+        "undo must restore the original positions"
+    );
+}
+
+#[test]
+fn registry_membership_survives_undo() {
+    let (initial, t1) = state! {
+        doc { root { paragraph { t1: text("hello") } } }
+        selection: (t1, 1) -> (t1, 4)
+    };
+    let sel = initial.selection.unwrap();
+    let mut editor = Editor::new_test(initial);
+    editor.apply(add_message("r", "g", sel));
+
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::collapsed(editor_state::Position::new(t1, 0)),
+        },
+    });
+    editor.apply(Message::Insertion {
+        op: InsertionOp::Text { text: "X".into() },
+    });
+    editor.apply(Message::History {
+        op: HistoryOp::Undo,
+    });
+
+    assert!(
+        editor.tracked_ranges().contains("r"),
+        "registry membership is independent of doc history"
+    );
+}
+
+#[test]
+fn groups_are_independent() {
+    let (initial, ..) = state! {
+        doc { root { paragraph { t1: text("hello") } } }
+        selection: (t1, 1) -> (t1, 4)
+    };
+    let sel = initial.selection.unwrap();
+    let mut editor = Editor::new_test(initial);
+    editor.apply(add_message("a", "spellcheck", sel));
+    editor.apply(add_message("b", "ai", sel));
+
+    assert_eq!(editor.tracked_ranges().group_size("spellcheck"), 1);
+    assert_eq!(editor.tracked_ranges().group_size("ai"), 1);
+
+    editor.apply(Message::TrackedRange {
+        op: TrackedRangeOp::ClearGroup {
+            group: "spellcheck".into(),
+        },
+    });
+    assert_eq!(editor.tracked_ranges().group_size("spellcheck"), 0);
+    assert_eq!(editor.tracked_ranges().group_size("ai"), 1);
+}

--- a/crates/editor-core/src/tracked_range.rs
+++ b/crates/editor-core/src/tracked_range.rs
@@ -1,0 +1,228 @@
+use editor_state::StableSelection;
+use hashbrown::{HashMap, HashSet};
+
+pub type TrackedRangeId = String;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct TrackedRange {
+    pub id: TrackedRangeId,
+    pub group: String,
+    pub selection: StableSelection,
+    pub metadata: String,
+    pub explicitly_invalid: bool,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct TrackedRangeRegistry {
+    by_id: HashMap<TrackedRangeId, TrackedRange>,
+    by_group: HashMap<String, HashSet<TrackedRangeId>>,
+}
+
+impl TrackedRangeRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add(&mut self, range: TrackedRange) -> Option<TrackedRange> {
+        let id = range.id.clone();
+        let new_group = range.group.clone();
+        let prev = self.by_id.insert(id.clone(), range);
+        if let Some(prev_range) = &prev
+            && prev_range.group != new_group
+            && let Some(set) = self.by_group.get_mut(&prev_range.group)
+        {
+            set.remove(&id);
+            if set.is_empty() {
+                self.by_group.remove(&prev_range.group);
+            }
+        }
+        self.by_group.entry(new_group).or_default().insert(id);
+        prev
+    }
+
+    pub fn remove(&mut self, id: &str) -> Option<TrackedRange> {
+        let prev = self.by_id.remove(id)?;
+        if let Some(set) = self.by_group.get_mut(&prev.group) {
+            set.remove(id);
+            if set.is_empty() {
+                self.by_group.remove(&prev.group);
+            }
+        }
+        Some(prev)
+    }
+
+    pub fn clear_group(&mut self, group: &str) -> Vec<TrackedRange> {
+        let Some(ids) = self.by_group.remove(group) else {
+            return Vec::new();
+        };
+        ids.into_iter()
+            .filter_map(|id| self.by_id.remove(&id))
+            .collect()
+    }
+
+    pub fn invalidate(&mut self, id: &str) -> bool {
+        match self.by_id.get_mut(id) {
+            Some(range) if !range.explicitly_invalid => {
+                range.explicitly_invalid = true;
+                true
+            }
+            _ => false,
+        }
+    }
+
+    pub fn get(&self, id: &str) -> Option<&TrackedRange> {
+        self.by_id.get(id)
+    }
+
+    pub fn contains(&self, id: &str) -> bool {
+        self.by_id.contains_key(id)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &TrackedRange> {
+        self.by_id.values()
+    }
+
+    pub fn iter_group<'a>(&'a self, group: &'a str) -> impl Iterator<Item = &'a TrackedRange> + 'a {
+        self.by_group
+            .get(group)
+            .into_iter()
+            .flat_map(move |ids| ids.iter().filter_map(move |id| self.by_id.get(id)))
+    }
+
+    pub fn group_size(&self, group: &str) -> usize {
+        self.by_group.get(group).map(|s| s.len()).unwrap_or(0)
+    }
+
+    pub fn len(&self) -> usize {
+        self.by_id.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.by_id.is_empty()
+    }
+
+    pub fn sorted_ids(&self) -> Vec<TrackedRangeId> {
+        let mut ids: Vec<_> = self.by_id.keys().cloned().collect();
+        ids.sort();
+        ids
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use editor_macros::state;
+
+    fn make_range(id: &str, group: &str) -> TrackedRange {
+        let (s, ..) = state! {
+            doc { root { paragraph { t1: text("hello") } } }
+            selection: (t1, 0) -> (t1, 5)
+        };
+        let sel = s.selection.unwrap();
+        TrackedRange {
+            id: id.into(),
+            group: group.into(),
+            selection: StableSelection::freeze(&sel, &s.doc),
+            metadata: String::new(),
+            explicitly_invalid: false,
+        }
+    }
+
+    #[test]
+    fn add_inserts_into_both_indices() {
+        let mut reg = TrackedRangeRegistry::new();
+        reg.add(make_range("a", "g1"));
+        assert!(reg.contains("a"));
+        assert_eq!(reg.group_size("g1"), 1);
+        assert_eq!(reg.len(), 1);
+    }
+
+    #[test]
+    fn add_same_id_replaces() {
+        let mut reg = TrackedRangeRegistry::new();
+        reg.add(make_range("a", "g1"));
+        let prev = reg.add(make_range("a", "g1"));
+        assert!(prev.is_some());
+        assert_eq!(reg.len(), 1);
+    }
+
+    #[test]
+    fn add_same_id_different_group_migrates() {
+        let mut reg = TrackedRangeRegistry::new();
+        reg.add(make_range("a", "g1"));
+        reg.add(make_range("a", "g2"));
+        assert_eq!(reg.group_size("g1"), 0);
+        assert_eq!(reg.group_size("g2"), 1);
+    }
+
+    #[test]
+    fn remove_clears_from_both_indices() {
+        let mut reg = TrackedRangeRegistry::new();
+        reg.add(make_range("a", "g1"));
+        assert!(reg.remove("a").is_some());
+        assert!(!reg.contains("a"));
+        assert_eq!(reg.group_size("g1"), 0);
+    }
+
+    #[test]
+    fn remove_nonexistent_returns_none() {
+        let mut reg = TrackedRangeRegistry::new();
+        assert!(reg.remove("x").is_none());
+    }
+
+    #[test]
+    fn clear_group_removes_only_targeted_group() {
+        let mut reg = TrackedRangeRegistry::new();
+        reg.add(make_range("a", "g1"));
+        reg.add(make_range("b", "g1"));
+        reg.add(make_range("c", "g2"));
+        let cleared = reg.clear_group("g1");
+        assert_eq!(cleared.len(), 2);
+        assert_eq!(reg.len(), 1);
+        assert_eq!(reg.group_size("g2"), 1);
+    }
+
+    #[test]
+    fn clear_empty_group_returns_empty() {
+        let mut reg = TrackedRangeRegistry::new();
+        let cleared = reg.clear_group("nothing");
+        assert!(cleared.is_empty());
+    }
+
+    #[test]
+    fn invalidate_flips_flag_once() {
+        let mut reg = TrackedRangeRegistry::new();
+        reg.add(make_range("a", "g1"));
+        assert!(reg.invalidate("a"));
+        assert!(!reg.invalidate("a"));
+        assert!(reg.get("a").unwrap().explicitly_invalid);
+    }
+
+    #[test]
+    fn invalidate_unknown_id_returns_false() {
+        let mut reg = TrackedRangeRegistry::new();
+        assert!(!reg.invalidate("x"));
+    }
+
+    #[test]
+    fn iter_group_returns_only_members() {
+        let mut reg = TrackedRangeRegistry::new();
+        reg.add(make_range("a", "g1"));
+        reg.add(make_range("b", "g1"));
+        reg.add(make_range("c", "g2"));
+        let g1: Vec<_> = reg.iter_group("g1").map(|r| r.id.clone()).collect();
+        assert_eq!(g1.len(), 2);
+        assert!(g1.contains(&"a".to_string()));
+        assert!(g1.contains(&"b".to_string()));
+    }
+
+    #[test]
+    fn sorted_ids_returns_stable_order() {
+        let mut reg = TrackedRangeRegistry::new();
+        reg.add(make_range("c", "g"));
+        reg.add(make_range("a", "g"));
+        reg.add(make_range("b", "g"));
+        let ids = reg.sorted_ids();
+        assert_eq!(ids, vec!["a", "b", "c"]);
+    }
+}

--- a/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
@@ -498,6 +498,15 @@ export interface TextColorValue {
     value: string;
 }
 
+export interface TrackedRangePublic {
+    id: string;
+    group: string;
+    anchor: Position;
+    head: Position;
+    metadata: string;
+    invalid: boolean;
+}
+
 export interface TransactionMeta {
     history: HistoryMeta;
 }
@@ -584,7 +593,7 @@ export type LayoutMode = { type: "paginated"; page_width: number; page_height: n
 
 export type ListItemNodeAttr = void;
 
-export type Message = { type: "key"; event: KeyEvent } | { type: "pointer"; event: PointerEvent } | { type: "insertion"; op: InsertionOp } | { type: "deletion"; op: DeletionOp } | { type: "selection"; op: SelectionOp } | { type: "modifier"; op: ModifierOp } | { type: "node"; op: NodeOp } | { type: "view"; op: ViewOp } | { type: "clipboard"; op: ClipboardOp } | { type: "text_input"; ops: FlatImeOp[] } | { type: "dnd"; op: DndOp } | { type: "navigation"; op: NavigationOp } | { type: "history"; op: HistoryOp } | { type: "system"; event: SystemEvent };
+export type Message = { type: "key"; event: KeyEvent } | { type: "pointer"; event: PointerEvent } | { type: "insertion"; op: InsertionOp } | { type: "deletion"; op: DeletionOp } | { type: "selection"; op: SelectionOp } | { type: "modifier"; op: ModifierOp } | { type: "node"; op: NodeOp } | { type: "view"; op: ViewOp } | { type: "clipboard"; op: ClipboardOp } | { type: "text_input"; ops: FlatImeOp[] } | { type: "dnd"; op: DndOp } | { type: "navigation"; op: NavigationOp } | { type: "history"; op: HistoryOp } | { type: "system"; event: SystemEvent } | { type: "tracked_range"; op: TrackedRangeOp };
 
 export type Modifier = { type: "bold" } | { type: "italic" } | { type: "underline" } | { type: "strikethrough" } | { type: "font_size"; value: number } | { type: "font_family"; value: string } | { type: "font_weight"; value: number } | { type: "text_color"; value: string } | { type: "background_color"; value: string } | { type: "letter_spacing"; value: number } | { type: "link"; href: string } | { type: "ruby"; text: string } | { type: "line_height"; value: number } | { type: "block_gap"; value: number } | { type: "paragraph_indent"; value: number } | { type: "alignment"; value: Alignment };
 
@@ -622,7 +631,7 @@ export type SelectionExpansionUnit = "word" | "sentence" | "paragraph" | "all";
 
 export type SelectionOp = { type: "set"; selection: Selection } | { type: "unset" } | { type: "set_flat"; start: number; end: number } | { type: "extend_to"; anchor_page: number; anchor_x: number; anchor_y: number; head_page: number; head_x: number; head_y: number; initial_selection: Selection | undefined } | { type: "expand"; unit: SelectionExpansionUnit };
 
-export type StateField = "doc" | "root_attrs" | "selection" | "cursor" | "page_sizes" | "external_elements" | "table_overlays" | "link_rects" | "ime" | "modifiers" | "block";
+export type StateField = "doc" | "root_attrs" | "selection" | "cursor" | "page_sizes" | "external_elements" | "table_overlays" | "link_rects" | "ime" | "modifiers" | "block" | "tracked_ranges";
 
 export type SystemEvent = { type: "initialize" } | { type: "resize"; width: number; height: number; scale_factor: number } | { type: "set_focused"; focused: boolean } | { type: "theme_variant_changed" } | { type: "font_base_loaded"; family: string; weight: number } | { type: "font_chunk_loaded"; family: string; weight: number; chunk_id: number } | { type: "set_external_height"; node_id: NodeId; height: number } | { type: "fonts_changed" };
 
@@ -639,6 +648,8 @@ export type TableRowNodeAttr = void;
 export type TextNodeAttr = void;
 
 export type ThemeVariant = "dark-black" | "dark-charcoal" | "dark-espresso" | "dark-graphite" | "dark-midnight" | "dark-navy" | "dark-obsidian" | "dark-storm" | "light-butter" | "light-latte" | "light-lavender" | "light-mint" | "light-peach" | "light-rose" | "light-snow" | "light-white";
+
+export type TrackedRangeOp = { type: "add"; id: string; group: string; selection: Selection; metadata?: string } | { type: "remove"; id: string } | { type: "clear_group"; group: string } | { type: "invalidate"; id: string };
 
 export type Tri<T> = { type: "absent" } | { type: "uniform"; value: T } | { type: "mixed" };
 
@@ -681,6 +692,7 @@ declare class Editor {
     selection_hit_test(page: number, x: number, y: number): boolean;
     table_overlays(): TableOverlay[];
     tick(): EditorEvent[];
+    tracked_ranges(group?: string | null): TrackedRangePublic[];
 }
 
 declare class EditorHost {

--- a/crates/editor-ffi/pkg/server/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/server/editor_ffi.d.ts
@@ -525,6 +525,15 @@ export interface TextColorValue {
     value: string;
 }
 
+export interface TrackedRangePublic {
+    id: string;
+    group: string;
+    anchor: Position;
+    head: Position;
+    metadata: string;
+    invalid: boolean;
+}
+
 export interface TransactionMeta {
     history: HistoryMeta;
 }
@@ -611,7 +620,7 @@ export type LayoutMode = { type: "paginated"; page_width: number; page_height: n
 
 export type ListItemNodeAttr = void;
 
-export type Message = { type: "key"; event: KeyEvent } | { type: "pointer"; event: PointerEvent } | { type: "insertion"; op: InsertionOp } | { type: "deletion"; op: DeletionOp } | { type: "selection"; op: SelectionOp } | { type: "modifier"; op: ModifierOp } | { type: "node"; op: NodeOp } | { type: "view"; op: ViewOp } | { type: "clipboard"; op: ClipboardOp } | { type: "text_input"; ops: FlatImeOp[] } | { type: "dnd"; op: DndOp } | { type: "navigation"; op: NavigationOp } | { type: "history"; op: HistoryOp } | { type: "system"; event: SystemEvent };
+export type Message = { type: "key"; event: KeyEvent } | { type: "pointer"; event: PointerEvent } | { type: "insertion"; op: InsertionOp } | { type: "deletion"; op: DeletionOp } | { type: "selection"; op: SelectionOp } | { type: "modifier"; op: ModifierOp } | { type: "node"; op: NodeOp } | { type: "view"; op: ViewOp } | { type: "clipboard"; op: ClipboardOp } | { type: "text_input"; ops: FlatImeOp[] } | { type: "dnd"; op: DndOp } | { type: "navigation"; op: NavigationOp } | { type: "history"; op: HistoryOp } | { type: "system"; event: SystemEvent } | { type: "tracked_range"; op: TrackedRangeOp };
 
 export type Modifier = { type: "bold" } | { type: "italic" } | { type: "underline" } | { type: "strikethrough" } | { type: "font_size"; value: number } | { type: "font_family"; value: string } | { type: "font_weight"; value: number } | { type: "text_color"; value: string } | { type: "background_color"; value: string } | { type: "letter_spacing"; value: number } | { type: "link"; href: string } | { type: "ruby"; text: string } | { type: "line_height"; value: number } | { type: "block_gap"; value: number } | { type: "paragraph_indent"; value: number } | { type: "alignment"; value: Alignment };
 
@@ -649,7 +658,7 @@ export type SelectionExpansionUnit = "word" | "sentence" | "paragraph" | "all";
 
 export type SelectionOp = { type: "set"; selection: Selection } | { type: "unset" } | { type: "set_flat"; start: number; end: number } | { type: "extend_to"; anchor_page: number; anchor_x: number; anchor_y: number; head_page: number; head_x: number; head_y: number; initial_selection: Selection | undefined } | { type: "expand"; unit: SelectionExpansionUnit };
 
-export type StateField = "doc" | "root_attrs" | "selection" | "cursor" | "page_sizes" | "external_elements" | "table_overlays" | "link_rects" | "ime" | "modifiers" | "block";
+export type StateField = "doc" | "root_attrs" | "selection" | "cursor" | "page_sizes" | "external_elements" | "table_overlays" | "link_rects" | "ime" | "modifiers" | "block" | "tracked_ranges";
 
 export type SystemEvent = { type: "initialize" } | { type: "resize"; width: number; height: number; scale_factor: number } | { type: "set_focused"; focused: boolean } | { type: "theme_variant_changed" } | { type: "font_base_loaded"; family: string; weight: number } | { type: "font_chunk_loaded"; family: string; weight: number; chunk_id: number } | { type: "set_external_height"; node_id: NodeId; height: number } | { type: "fonts_changed" };
 
@@ -666,6 +675,8 @@ export type TableRowNodeAttr = void;
 export type TextNodeAttr = void;
 
 export type ThemeVariant = "dark-black" | "dark-charcoal" | "dark-espresso" | "dark-graphite" | "dark-midnight" | "dark-navy" | "dark-obsidian" | "dark-storm" | "light-butter" | "light-latte" | "light-lavender" | "light-mint" | "light-peach" | "light-rose" | "light-snow" | "light-white";
+
+export type TrackedRangeOp = { type: "add"; id: string; group: string; selection: Selection; metadata?: string } | { type: "remove"; id: string } | { type: "clear_group"; group: string } | { type: "invalidate"; id: string };
 
 export type Tri<T> = { type: "absent" } | { type: "uniform"; value: T } | { type: "mixed" };
 
@@ -705,6 +716,7 @@ declare class Editor {
     selection_hit_test(page: number, x: number, y: number): boolean;
     table_overlays(): TableOverlay[];
     tick(): EditorEvent[];
+    tracked_ranges(group?: string | null): TrackedRangePublic[];
 }
 
 declare class EditorHost {

--- a/crates/editor-ffi/src/editor.rs
+++ b/crates/editor-ffi/src/editor.rs
@@ -33,6 +33,18 @@ pub struct CharacterCounts {
     pub selection_without_whitespace_and_punctuation: u32,
 }
 
+#[ffi]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct TrackedRangePublic {
+    pub id: String,
+    pub group: String,
+    pub anchor: editor_state::Position,
+    pub head: editor_state::Position,
+    pub metadata: String,
+    pub invalid: bool,
+}
+
 #[cfg_attr(feature = "uniffi", editor_macros::ffi_export(uniffi))]
 #[cfg_attr(feature = "wasm", editor_macros::ffi_export(wasm))]
 impl Editor {
@@ -291,6 +303,34 @@ impl Editor {
             let bytes = editor_crdt::wire::encode_dots(&heads)
                 .map_err(|e| FfiError::Serialization(e.to_string()))?;
             Ok(bytes)
+        })
+    }
+
+    pub fn tracked_ranges(
+        &self,
+        group: Option<String>,
+    ) -> EditorResult<Vec<Complex<TrackedRangePublic>>> {
+        self.with_inner(|inner| {
+            let doc = &inner.editor.state().doc;
+            let registry = inner.editor.tracked_ranges();
+            let ranges: Box<dyn Iterator<Item = &editor_core::TrackedRange>> = match &group {
+                Some(g) => Box::new(registry.iter_group(g)),
+                None => Box::new(registry.iter()),
+            };
+            let result: Vec<TrackedRangePublic> = ranges
+                .map(|r| {
+                    let sel = r.selection.thaw(doc);
+                    TrackedRangePublic {
+                        id: r.id.clone(),
+                        group: r.group.clone(),
+                        anchor: sel.anchor,
+                        head: sel.head,
+                        metadata: r.metadata.clone(),
+                        invalid: r.explicitly_invalid || sel.is_collapsed(),
+                    }
+                })
+                .collect();
+            Ok(result.into_ffi()?)
         })
     }
 }


### PR DESCRIPTION
외부 소스(맞춤법 검사, AI 피드백 등)가 생성한 텍스트 범위를 문서에 부착하고, 사용자 편집 후에도 위치가 자동으로 추적되는 인프라를 editor-core에 구현했습니다. 



| | 내용 |
|------|------|
| Registry 위치 | `Editor` 필드 (State 바깥) — doc·history와 동급 사이드 데이터 |
| Range 표현 | `StableSelection` 재사용 — freeze/thaw로 undo/redo 자동 처리 |
| invalid 판정 | 조회 시 thaw 후 `is_collapsed()` — dirty tracking 불필요 |
| ID 타입 | `String` — 호출자가 발급, 엔진은 덮어쓰기만 허용 (계획서의 `u64` 자동 발급 대신) |
| 입력 채널 | `Message::TrackedRange { op }` — 기존 메시지 큐 패턴 통일 |
