### PR TITLE
feat: tracked item reveal API

### DIFF
--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -22,6 +22,7 @@ import type {
   ModifierState,
   PlainRootNode,
   PointerStyle,
+  ScrollTarget,
   Selection,
   SelectionEndpoints,
   Size,
@@ -141,6 +142,7 @@ export class Editor {
 
     self.on('state_changed', self.#stateChangedHandler);
     self.on('font_data_missing', fontDataMissingHandler);
+    self.on('scroll', self.#scrollHandler);
 
     register(self);
 
@@ -646,6 +648,31 @@ export class Editor {
       this.refreshPointerStyle();
     }
   };
+
+  #scrollHandler: EditorEventListener<'scroll'> = (_, { rect: { page_idx, rect } }) => {
+    const pageEl = this.pageEls[page_idx];
+    const container = this.scrollContainerEl;
+    if (!pageEl || !container) return;
+
+    const top = pageEl.offsetTop + rect.y;
+    const bottom = top + rect.height;
+    const viewTop = container.scrollTop;
+    const viewBottom = viewTop + container.clientHeight;
+
+    let nextTop: number | null = null;
+    if (top < viewTop) {
+      nextTop = top;
+    } else if (bottom > viewBottom) {
+      nextTop = bottom - container.clientHeight;
+    }
+    if (nextTop !== null) {
+      container.scrollTo({ top: nextTop, behavior: 'smooth' });
+    }
+  };
+
+  scrollIntoView(target: ScrollTarget): void {
+    this.enqueue({ type: 'view', op: { type: 'scroll_into_view', target } });
+  }
 
   destroy(): void {
     this.#destroyed = true;

--- a/crates/editor-core/src/event.rs
+++ b/crates/editor-core/src/event.rs
@@ -1,4 +1,5 @@
 use editor_macros::ffi;
+use editor_view::PageRect;
 use serde::{Deserialize, Serialize};
 
 use crate::state_field::StateField;
@@ -26,4 +27,7 @@ pub enum EditorEvent {
         prefetch: Vec<FontData>,
     },
     CursorExitedDocumentStart,
+    Scroll {
+        rect: PageRect,
+    },
 }

--- a/crates/editor-core/src/handle/view.rs
+++ b/crates/editor-core/src/handle/view.rs
@@ -4,6 +4,7 @@ use editor_transaction::HistoryMeta;
 
 use crate::editor::Editor;
 use crate::error::EditorError;
+use crate::event::EditorEvent;
 use crate::message::*;
 
 pub fn handle_view_op(editor: &mut Editor, op: ViewOp) -> Result<(), EditorError> {
@@ -27,7 +28,52 @@ pub fn handle_view_op(editor: &mut Editor, op: ViewOp) -> Result<(), EditorError
             editor.toggle_fold(id);
             Ok(())
         }
+        ViewOp::ScrollIntoView { target } => handle_scroll_into_view(editor, target),
     }
+}
+
+fn handle_scroll_into_view(editor: &mut Editor, target: ScrollTarget) -> Result<(), EditorError> {
+    let selection = match target {
+        ScrollTarget::TrackedItem { id } => {
+            let Some(range) = editor.tracked_ranges().get(&id).cloned() else {
+                return Ok(());
+            };
+            if range.explicitly_invalid {
+                return Ok(());
+            }
+            let sel = range.selection.thaw(&editor.state.doc);
+            if sel.is_collapsed() {
+                return Ok(());
+            }
+            sel
+        }
+        ScrollTarget::Selection => {
+            let Some(sel) = editor.state.selection else {
+                return Ok(());
+            };
+            if sel.is_collapsed() {
+                return Ok(());
+            }
+            sel
+        }
+    };
+
+    let endpoints = selection
+        .resolve(&editor.state.doc)
+        .and_then(|resolved| editor.view.selection_endpoints(&resolved));
+    let Some(endpoints) = endpoints else {
+        return Ok(());
+    };
+
+    if editor.is_probing() {
+        editor.mark_probed_change(true);
+        return Ok(());
+    }
+
+    editor.push_event(EditorEvent::Scroll {
+        rect: endpoints.from,
+    });
+    Ok(())
 }
 
 // Legacy parity: collapse hides fold-content, so a caret/anchor inside it is

--- a/crates/editor-core/src/message.rs
+++ b/crates/editor-core/src/message.rs
@@ -255,8 +255,17 @@ pub enum NodeOp {
 #[ffi]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
+pub enum ScrollTarget {
+    TrackedItem { id: String },
+    Selection,
+}
+
+#[ffi]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
 pub enum ViewOp {
     ToggleFold { id: NodeId },
+    ScrollIntoView { target: ScrollTarget },
 }
 
 #[ffi]

--- a/crates/editor-core/src/tests/can_invariants.rs
+++ b/crates/editor-core/src/tests/can_invariants.rs
@@ -77,6 +77,18 @@ fn build_corpus() -> Vec<Message> {
                 id: editor_model::NodeId::ROOT,
             },
         },
+        Message::View {
+            op: ViewOp::ScrollIntoView {
+                target: ScrollTarget::TrackedItem {
+                    id: "missing".into(),
+                },
+            },
+        },
+        Message::View {
+            op: ViewOp::ScrollIntoView {
+                target: ScrollTarget::Selection,
+            },
+        },
         Message::Key {
             event: KeyEvent {
                 key: Key::Backspace,

--- a/crates/editor-core/src/tests/mod.rs
+++ b/crates/editor-core/src/tests/mod.rs
@@ -1,2 +1,3 @@
 mod can_invariants;
+mod scroll_into_view_integration;
 mod tracked_range_integration;

--- a/crates/editor-core/src/tests/scroll_into_view_integration.rs
+++ b/crates/editor-core/src/tests/scroll_into_view_integration.rs
@@ -1,0 +1,269 @@
+use editor_macros::state;
+use editor_state::{Position, Selection};
+
+use crate::editor::Editor;
+use crate::event::EditorEvent;
+use crate::message::*;
+
+fn add_message(id: &str, selection: Selection) -> Message {
+    Message::TrackedRange {
+        op: TrackedRangeOp::Add {
+            id: id.into(),
+            group: "g".into(),
+            selection,
+            metadata: String::new(),
+        },
+    }
+}
+
+fn scroll_to_tracked(id: &str) -> Message {
+    Message::View {
+        op: ViewOp::ScrollIntoView {
+            target: ScrollTarget::TrackedItem { id: id.into() },
+        },
+    }
+}
+
+fn scroll_to_selection() -> Message {
+    Message::View {
+        op: ViewOp::ScrollIntoView {
+            target: ScrollTarget::Selection,
+        },
+    }
+}
+
+#[test]
+fn tracked_item_does_not_change_selection() {
+    let (initial, t1) = state! {
+        doc { root { paragraph { t1: text("hello world") } } }
+        selection: (t1, 1) -> (t1, 4)
+    };
+    let sel = initial.selection.unwrap();
+    let mut editor = Editor::new_test(initial);
+    editor.apply(Message::System {
+        event: SystemEvent::Initialize,
+    });
+    editor.apply(add_message("r", sel));
+
+    let other = Selection::collapsed(Position::new(t1, 0));
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set { selection: other },
+    });
+
+    editor.apply(scroll_to_tracked("r"));
+
+    let now = editor.state().selection.expect("selection must remain set");
+    assert_eq!(
+        now, other,
+        "scroll_into_view is scroll-only and must not modify selection"
+    );
+}
+
+#[test]
+fn tracked_item_emits_scroll_event() {
+    let (initial, _t1) = state! {
+        doc { root { paragraph { t1: text("hello world") } } }
+        selection: (t1, 1) -> (t1, 4)
+    };
+    let sel = initial.selection.unwrap();
+    let mut editor = Editor::new_test(initial);
+    editor.apply(Message::System {
+        event: SystemEvent::Initialize,
+    });
+    editor.apply(add_message("r", sel));
+
+    let events = editor.apply(scroll_to_tracked("r"));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, EditorEvent::Scroll { .. })),
+        "tracked_item scroll must emit Scroll event"
+    );
+}
+
+#[test]
+fn tracked_item_unknown_id_is_noop() {
+    let (initial, ..) = state! {
+        doc { root { paragraph { t1: text("hello") } } }
+        selection: (t1, 0)
+    };
+    let mut editor = Editor::new_test(initial);
+    editor.apply(Message::System {
+        event: SystemEvent::Initialize,
+    });
+    let before = editor.state().selection;
+
+    let events = editor.apply(scroll_to_tracked("missing"));
+
+    assert_eq!(editor.state().selection, before);
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, EditorEvent::Scroll { .. })),
+        "missing id must not emit Scroll"
+    );
+}
+
+#[test]
+fn tracked_item_explicitly_invalid_is_noop() {
+    let (initial, _t1) = state! {
+        doc { root { paragraph { t1: text("hello") } } }
+        selection: (t1, 1) -> (t1, 4)
+    };
+    let sel = initial.selection.unwrap();
+    let mut editor = Editor::new_test(initial);
+    editor.apply(Message::System {
+        event: SystemEvent::Initialize,
+    });
+    editor.apply(add_message("r", sel));
+    editor.apply(Message::TrackedRange {
+        op: TrackedRangeOp::Invalidate { id: "r".into() },
+    });
+
+    let before = editor.state().selection;
+    let events = editor.apply(scroll_to_tracked("r"));
+    assert_eq!(editor.state().selection, before);
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, EditorEvent::Scroll { .. })),
+        "explicitly_invalid must not emit Scroll"
+    );
+}
+
+#[test]
+fn tracked_item_collapsed_on_thaw_is_noop() {
+    let (initial, t1) = state! {
+        doc { root { paragraph { t1: text("hello") } } }
+        selection: (t1, 1) -> (t1, 4)
+    };
+    let sel = initial.selection.unwrap();
+    let mut editor = Editor::new_test(initial);
+    editor.apply(Message::System {
+        event: SystemEvent::Initialize,
+    });
+    editor.apply(add_message("r", sel));
+
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::new(Position::new(t1, 1), Position::new(t1, 4)),
+        },
+    });
+    editor.apply(Message::Deletion {
+        op: DeletionOp::Selection,
+    });
+
+    let before = editor.state().selection;
+    let events = editor.apply(scroll_to_tracked("r"));
+    assert_eq!(editor.state().selection, before);
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, EditorEvent::Scroll { .. })),
+        "collapsed-on-thaw must not emit Scroll"
+    );
+}
+
+#[test]
+fn tracked_item_still_emits_after_document_edits() {
+    let (initial, t1) = state! {
+        doc { root { paragraph { t1: text("hello") } } }
+        selection: (t1, 1) -> (t1, 4)
+    };
+    let sel = initial.selection.unwrap();
+    let mut editor = Editor::new_test(initial);
+    editor.apply(Message::System {
+        event: SystemEvent::Initialize,
+    });
+    editor.apply(add_message("r", sel));
+
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::collapsed(Position::new(t1, 0)),
+        },
+    });
+    editor.apply(Message::Insertion {
+        op: InsertionOp::Text { text: "X".into() },
+    });
+
+    let events = editor.apply(scroll_to_tracked("r"));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, EditorEvent::Scroll { .. })),
+        "scroll must still emit Scroll after edits shift the tracked range"
+    );
+}
+
+#[test]
+fn selection_emits_scroll_event() {
+    let (initial, _t1) = state! {
+        doc { root { paragraph { t1: text("hello world") } } }
+        selection: (t1, 1) -> (t1, 4)
+    };
+    let mut editor = Editor::new_test(initial);
+    editor.apply(Message::System {
+        event: SystemEvent::Initialize,
+    });
+
+    let events = editor.apply(scroll_to_selection());
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, EditorEvent::Scroll { .. })),
+        "selection target must emit Scroll event when selection has rects"
+    );
+}
+
+#[test]
+fn selection_collapsed_is_noop() {
+    let (initial, t1) = state! {
+        doc { root { paragraph { t1: text("hello") } } }
+        selection: (t1, 0)
+    };
+    let mut editor = Editor::new_test(initial);
+    editor.apply(Message::System {
+        event: SystemEvent::Initialize,
+    });
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::collapsed(Position::new(t1, 2)),
+        },
+    });
+
+    let events = editor.apply(scroll_to_selection());
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, EditorEvent::Scroll { .. })),
+        "collapsed selection has no endpoints rect, so no Scroll event"
+    );
+}
+
+#[test]
+fn can_returns_false_for_missing_tracked_item() {
+    let (initial, ..) = state! {
+        doc { root { paragraph { t1: text("hello") } } }
+        selection: (t1, 0)
+    };
+    let mut editor = Editor::new_test(initial);
+    let probed = editor.can(scroll_to_tracked("missing")).unwrap();
+    assert!(!probed, "can() must report false for unknown id");
+}
+
+#[test]
+fn can_returns_true_for_revealable_tracked_item() {
+    let (initial, _t1) = state! {
+        doc { root { paragraph { t1: text("hello") } } }
+        selection: (t1, 1) -> (t1, 4)
+    };
+    let sel = initial.selection.unwrap();
+    let mut editor = Editor::new_test(initial);
+    editor.apply(Message::System {
+        event: SystemEvent::Initialize,
+    });
+    editor.apply(add_message("r", sel));
+
+    let probed = editor.can(scroll_to_tracked("r")).unwrap();
+    assert!(probed, "can() must report true for revealable tracked item");
+}

--- a/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
@@ -547,7 +547,7 @@ export type DndOp = { type: "start"; page: number; x: number; y: number } | { ty
 
 export type DndPayloadKind = "internal_selection" | "text" | "html" | "image_files" | "files" | "mixed_files";
 
-export type EditorEvent = { type: "state_changed"; fields: StateField[] } | { type: "render_invalidated" } | { type: "font_data_missing"; family: string; weight: number; required: FontData[]; prefetch: FontData[] } | { type: "cursor_exited_document_start" };
+export type EditorEvent = { type: "state_changed"; fields: StateField[] } | { type: "render_invalidated" } | { type: "font_data_missing"; family: string; weight: number; required: FontData[]; prefetch: FontData[] } | { type: "cursor_exited_document_start" } | { type: "scroll"; rect: PageRect };
 
 export type Effect = { load_font: { family: string; weight: number; codepoints: number[] } };
 
@@ -627,6 +627,8 @@ export type PointerStyle = "default" | "text" | "pointer";
 
 export type RootNodeAttr = { type: "layout_mode" } & LayoutMode;
 
+export type ScrollTarget = { type: "tracked_item"; id: string } | { type: "selection" };
+
 export type SelectionExpansionUnit = "word" | "sentence" | "paragraph" | "all";
 
 export type SelectionOp = { type: "set"; selection: Selection } | { type: "unset" } | { type: "set_flat"; start: number; end: number } | { type: "extend_to"; anchor_page: number; anchor_x: number; anchor_y: number; head_page: number; head_x: number; head_y: number; initial_selection: Selection | undefined } | { type: "expand"; unit: SelectionExpansionUnit };
@@ -653,7 +655,7 @@ export type TrackedRangeOp = { type: "add"; id: string; group: string; selection
 
 export type Tri<T> = { type: "absent" } | { type: "uniform"; value: T } | { type: "mixed" };
 
-export type ViewOp = { type: "toggle_fold"; id: NodeId };
+export type ViewOp = { type: "toggle_fold"; id: NodeId } | { type: "scroll_into_view"; target: ScrollTarget };
 
 
 declare class Editor {

--- a/crates/editor-ffi/pkg/server/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/server/editor_ffi.d.ts
@@ -574,7 +574,7 @@ export type DndOp = { type: "start"; page: number; x: number; y: number } | { ty
 
 export type DndPayloadKind = "internal_selection" | "text" | "html" | "image_files" | "files" | "mixed_files";
 
-export type EditorEvent = { type: "state_changed"; fields: StateField[] } | { type: "render_invalidated" } | { type: "font_data_missing"; family: string; weight: number; required: FontData[]; prefetch: FontData[] } | { type: "cursor_exited_document_start" };
+export type EditorEvent = { type: "state_changed"; fields: StateField[] } | { type: "render_invalidated" } | { type: "font_data_missing"; family: string; weight: number; required: FontData[]; prefetch: FontData[] } | { type: "cursor_exited_document_start" } | { type: "scroll"; rect: PageRect };
 
 export type Effect = { load_font: { family: string; weight: number; codepoints: number[] } };
 
@@ -654,6 +654,8 @@ export type PointerStyle = "default" | "text" | "pointer";
 
 export type RootNodeAttr = { type: "layout_mode" } & LayoutMode;
 
+export type ScrollTarget = { type: "tracked_item"; id: string } | { type: "selection" };
+
 export type SelectionExpansionUnit = "word" | "sentence" | "paragraph" | "all";
 
 export type SelectionOp = { type: "set"; selection: Selection } | { type: "unset" } | { type: "set_flat"; start: number; end: number } | { type: "extend_to"; anchor_page: number; anchor_x: number; anchor_y: number; head_page: number; head_x: number; head_y: number; initial_selection: Selection | undefined } | { type: "expand"; unit: SelectionExpansionUnit };
@@ -680,7 +682,7 @@ export type TrackedRangeOp = { type: "add"; id: string; group: string; selection
 
 export type Tri<T> = { type: "absent" } | { type: "uniform"; value: T } | { type: "mixed" };
 
-export type ViewOp = { type: "toggle_fold"; id: NodeId };
+export type ViewOp = { type: "toggle_fold"; id: NodeId } | { type: "scroll_into_view"; target: ScrollTarget };
 
 
 declare class Editor {


### PR DESCRIPTION
TrackedRangeRegistry에 등록된 range를 id 하나로 viewport 안으로 끌어오는 표준 API를 추가했습니다. TR-28(맞춤법 결과 → 위치 이동), TR-29(AI 피드백 결과 → 위치 이동)의 공통 전제 인프라.

| | 내용 |
|------|------|
| API 형태 | `ViewOp::ScrollIntoView { target: ScrollTarget }` — 미래 확장(Selection 등)을 위한 일반화. 기존 `ToggleFold`와 같은 view 상태 변경 카테고리 |
| ScrollTarget | `TrackedItem { id }` + `Selection` 두 variant로 시작. 추가 variant는 필요해질 때 |
| selection 분리 | reveal 핸들러는 `state.selection`을 읽기만 함. tracked item과 selection은 별개의 관심사이므로 호출만으로 selection이 바뀌면 안 됨 |
| 분업 | 엔진은 page-local rect 계산까지, scrollContainer 좌표 변환과 `scrollTo`는 JS 책임 |
| 이벤트 형태 | `EditorEvent::Scroll { rect: PageRect }` — page_idx와 rect를 별도 필드로 두지 않고 기존 `PageRect`로 통합 |
| scroll 방식 | `nearest` + `smooth` — 이미 보이면 no-scroll, 안 보이면 최소 이동 |
| invalid 처리 | `TrackedItem`: 미존재 id / `explicitly_invalid` / `thaw().is_collapsed()`, `Selection`: 부재 / collapsed — 모두 no-op (이벤트 미발행, `can()` = false) |
| probe 정확도 | endpoints 계산을 probe 분기보다 앞에 둬서 "이벤트 미발행" 케이스에서도 `can()` 결과가 일치 |
