### PR TITLE
TR-137 벡터 페이지 출력을 위한 함수 구현

### DIFF
--- a/crates/editor-core/src/editor.rs
+++ b/crates/editor-core/src/editor.rs
@@ -599,6 +599,15 @@ impl Editor {
         );
     }
 
+    pub fn export_page_vector(&mut self, page_idx: u32, scale_factor: f32) -> Vec<u8> {
+        self.renderer.export_page_vector(
+            &self.state.doc,
+            &self.view,
+            page_idx as usize,
+            scale_factor,
+        )
+    }
+
     fn process_message(&mut self, msg: Message) -> Result<(), EditorError> {
         match msg {
             Message::Key { event } => handle::handle_key_event(self, event)?,

--- a/crates/editor-ffi/src/editor.rs
+++ b/crates/editor-ffi/src/editor.rs
@@ -361,6 +361,10 @@ impl Editor {
         })
     }
 
+    pub fn export_page_vector(&self, page: u32, scale_factor: f64) -> EditorResult<Vec<u8>> {
+        self.with_inner(|inner| Ok(inner.editor.export_page_vector(page, scale_factor as f32)))
+    }
+
     pub fn tracked_ranges_at(
         &self,
         page: u32,
@@ -964,6 +968,101 @@ mod tests {
         assert_eq!(
             hits[0].rects[0].page_idx, endpoints.from.page_idx,
             "rects must be page-local"
+        );
+    }
+
+    #[test]
+    fn ffi_export_page_vector_returns_nonempty_bytes() {
+        // export 결과가 비어있지 않은 바이너리여야 호스트가 파일로 저장할 수 있다.
+        let (initial, ..) = state! {
+            doc { root { paragraph { t: text("hello") } } }
+            selection: (t, 0)
+        };
+        let editor = make_ffi_editor(initial);
+        let bytes = editor
+            .export_page_vector(0, 1.0)
+            .expect("export_page_vector must return Ok");
+        assert!(!bytes.is_empty());
+    }
+
+    #[test]
+    fn ffi_export_page_vector_starts_with_magic() {
+        // TVE1(0x3156_4554) magic으로 시작해야 외부 변환기가 포맷을 식별할 수 있다.
+        let (initial, ..) = state! {
+            doc { root { paragraph { t: text("hello") } } }
+            selection: (t, 0)
+        };
+        let editor = make_ffi_editor(initial);
+        let bytes = editor
+            .export_page_vector(0, 1.0)
+            .expect("export_page_vector must return Ok");
+        let magic = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
+        assert_eq!(magic, 0x3156_4554u32);
+    }
+
+    fn op_count(bytes: &[u8]) -> u32 {
+        u32::from_le_bytes(bytes[12..16].try_into().unwrap())
+    }
+
+    #[test]
+    fn ffi_export_page_vector_has_valid_dimensions() {
+        // width/height가 양수여야 외부 변환기가 페이지 크기를 올바르게 재현할 수 있다.
+        let (initial, ..) = state! {
+            doc { root { paragraph { t: text("hello") } } }
+            selection: (t, 0)
+        };
+        let editor = make_ffi_editor(initial);
+        let bytes = editor.export_page_vector(0, 1.0).expect("must return Ok");
+        let width = f32::from_le_bytes(bytes[4..8].try_into().unwrap());
+        let height = f32::from_le_bytes(bytes[8..12].try_into().unwrap());
+        assert!(width > 0.0 && height > 0.0);
+    }
+
+    #[test]
+    fn ffi_export_page_vector_shape_produces_ops() {
+        // horizontal_rule이 FillPath/StrokePath op으로 수집되어야 외부 변환기가 재현 가능하다.
+        let (initial, _t) = state! {
+            doc { root { paragraph { t: text("a") } horizontal_rule } }
+            selection: (t, 0)
+        };
+        let editor = make_ffi_editor(initial);
+        let bytes = editor.export_page_vector(0, 1.0).expect("must return Ok");
+        assert!(
+            op_count(&bytes) > 0,
+            "horizontal_rule must produce at least one op"
+        );
+    }
+
+    #[test]
+    fn ffi_export_page_vector_table_border_produces_ops() {
+        // table border가 벡터 op으로 수집되어야 외부 변환기가 재현 가능하다.
+        let (initial, _t) = state! {
+            doc { root {
+                paragraph { t: text("a") }
+                table { table_row { table_cell { paragraph } table_cell { paragraph } } }
+            } }
+            selection: (t, 0)
+        };
+        let editor = make_ffi_editor(initial);
+        let bytes = editor.export_page_vector(0, 1.0).expect("must return Ok");
+        assert!(
+            op_count(&bytes) > 0,
+            "table border must produce at least one op"
+        );
+    }
+
+    #[test]
+    fn ffi_export_page_vector_text_page_produces_valid_binary() {
+        // 텍스트 페이지도 글리프 outline 기반 벡터 op와 유효한 헤더를 포함한 바이너리를 반환해야 한다.
+        let (initial, ..) = state! {
+            doc { root { paragraph { t: text("hello") } } }
+            selection: (t, 0)
+        };
+        let editor = make_ffi_editor(initial);
+        let bytes = editor.export_page_vector(0, 1.0).expect("must return Ok");
+        assert!(
+            bytes.len() >= 16,
+            "must produce at least magic+dimensions+op_count"
         );
     }
 }

--- a/crates/editor-renderer/Cargo.toml
+++ b/crates/editor-renderer/Cargo.toml
@@ -51,3 +51,4 @@ toml.workspace = true
 [dev-dependencies]
 editor-model = { path = "../editor-model", features = ["test-utils"] }
 editor-resource = { path = "../editor-resource", features = ["test-utils"] }
+editor-view = { path = "../editor-view", features = ["test-utils"] }

--- a/crates/editor-renderer/src/lib.rs
+++ b/crates/editor-renderer/src/lib.rs
@@ -7,6 +7,7 @@ pub mod icons;
 pub mod renderer;
 pub mod sink;
 pub mod types;
+pub mod vector;
 
 pub use backend::RenderBackend;
 pub use renderer::{Mark, MarkData, MarkRect, Renderer};

--- a/crates/editor-renderer/src/renderer.rs
+++ b/crates/editor-renderer/src/renderer.rs
@@ -13,6 +13,8 @@ use crate::types::{
     Color, CornerRadii, IconData, IconElement, Image, Path, PathElement, Stroke, StrokeCap,
     StrokeJoin, Transform,
 };
+use crate::vector::codec::encode_vector_page;
+use crate::vector::export::VectorSink;
 
 fn bake_mask_to_premul_rgba(mask: &[u8], width: u32, height: u32, color: Color) -> Image {
     let color_r = color.r as u32;
@@ -364,6 +366,15 @@ pub struct Mark {
     pub rects: Vec<MarkRect>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TextRenderMode {
+    Raster,
+    VectorExport,
+}
+
+struct MarkStyle {
+    color: Color,
+}
 const SELECTION_FOCUSED_ALPHA: u8 = 77;
 const SELECTION_UNFOCUSED_ALPHA: u8 = 48;
 
@@ -552,12 +563,76 @@ impl Renderer {
         );
     }
 
-    pub fn page_visitor<'a>(
+    pub fn export_page_vector(
+        &mut self,
+        doc: &Doc,
+        view: &editor_view::View,
+        page_idx: usize,
+        scale_factor: f32,
+    ) -> Vec<u8> {
+        let (width, height) = view
+            .pages()
+            .get(page_idx)
+            .map(|p| (p.size.width, p.size.height))
+            .unwrap_or((0.0, 0.0));
+
+        let mut sink = VectorSink::new();
+        view.visit_page(
+            page_idx,
+            &mut self.vector_page_visitor(
+                &mut sink,
+                doc,
+                scale_factor,
+                LayerSet::of(&[RenderLayer::Background]),
+            ),
+        );
+        view.visit_page(
+            page_idx,
+            &mut self.vector_page_visitor(
+                &mut sink,
+                doc,
+                scale_factor,
+                LayerSet::of(&[RenderLayer::Content, RenderLayer::Border]),
+            ),
+        );
+
+        let page = sink.into_page(width, height);
+        encode_vector_page(&page)
+    }
+
+    fn page_visitor<'a>(
         &'a mut self,
         sink: &'a mut dyn RenderSink,
         doc: &'a Doc,
         scale_factor: f32,
         active: LayerSet,
+    ) -> RenderVisitor<'a> {
+        self.make_page_visitor(sink, doc, scale_factor, active, TextRenderMode::Raster)
+    }
+
+    fn vector_page_visitor<'a>(
+        &'a mut self,
+        sink: &'a mut dyn RenderSink,
+        doc: &'a Doc,
+        scale_factor: f32,
+        active: LayerSet,
+    ) -> RenderVisitor<'a> {
+        self.make_page_visitor(
+            sink,
+            doc,
+            scale_factor,
+            active,
+            TextRenderMode::VectorExport,
+        )
+    }
+
+    fn make_page_visitor<'a>(
+        &'a mut self,
+        sink: &'a mut dyn RenderSink,
+        doc: &'a Doc,
+        scale_factor: f32,
+        active: LayerSet,
+        text_mode: TextRenderMode,
     ) -> RenderVisitor<'a> {
         let theme = self.resource.lock().unwrap().theme;
         RenderVisitor {
@@ -568,6 +643,7 @@ impl Renderer {
             root_transform: Transform::scale(scale_factor),
             box_stack: Vec::new(),
             active,
+            text_mode,
             theme,
         }
     }
@@ -589,6 +665,7 @@ pub struct RenderVisitor<'a> {
     root_transform: Transform,
     box_stack: Vec<BoxFrame>,
     active: LayerSet,
+    text_mode: TextRenderMode,
     theme: Theme,
 }
 
@@ -646,6 +723,14 @@ impl<'a> RenderVisitor<'a> {
         base_transform: Transform,
     ) {
         for run in glyph_runs {
+            if self.text_mode == TextRenderMode::VectorExport {
+                let resource = Arc::clone(&self.renderer.resource);
+                let fonts = resource.lock().unwrap();
+                self.sink
+                    .draw_glyph_run(run, color, base_transform, &fonts.font_registry);
+                continue;
+            }
+
             let resource = Arc::clone(&self.renderer.resource);
             let resource_guard = resource.lock().unwrap();
             let positioned = crate::glyph::rasterize(
@@ -1345,6 +1430,8 @@ impl<'a> PageVisitor for RenderVisitor<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vector::export::VectorSink;
+    use crate::vector::types::{VectorOp, VectorPage};
     use editor_resource::ThemeVariant;
 
     #[test]
@@ -1587,6 +1674,94 @@ mod tests {
         assert!((r.height - 1.0).abs() < 0.01);
     }
 
+    fn export_page_to_vector_page(doc: &Doc) -> VectorPage {
+        let resource = Arc::new(Mutex::new(Resource::new_test()));
+        let mut view = editor_view::View::new_test();
+        view.layout(doc);
+
+        let (width, height) = view
+            .pages()
+            .first()
+            .map(|p| (p.size.width, p.size.height))
+            .expect("test document must layout to at least one page");
+
+        let mut renderer = Renderer::new(resource);
+        let mut sink = VectorSink::new();
+
+        view.visit_page(
+            0,
+            &mut renderer.vector_page_visitor(
+                &mut sink,
+                doc,
+                1.0,
+                LayerSet::of(&[RenderLayer::Background]),
+            ),
+        );
+        view.visit_page(
+            0,
+            &mut renderer.vector_page_visitor(
+                &mut sink,
+                doc,
+                1.0,
+                LayerSet::of(&[RenderLayer::Content, RenderLayer::Border]),
+            ),
+        );
+
+        sink.into_page(width, height)
+    }
+
+    #[test]
+    fn table_border_page_is_vectorized() {
+        // 테이블 보더가 페이지 export 결과에서 벡터 path op로 나타나는지 확인한다.
+        use editor_macros::doc;
+
+        let (doc,) = doc! {
+            root {
+                table {
+                    table_row {
+                        table_cell { paragraph }
+                        table_cell { paragraph }
+                    }
+                }
+            }
+        };
+
+        let page = export_page_to_vector_page(&doc);
+
+        assert!(page.width > 0.0);
+        assert!(page.height > 0.0);
+        assert!(
+            page.ops
+                .iter()
+                .any(|op| matches!(op, VectorOp::FillPath { .. } | VectorOp::StrokePath { .. })),
+            "table border page must contain vector path ops"
+        );
+    }
+
+    #[test]
+    fn horizontal_rule_pattern_page_is_vectorized() {
+        // horizontal rule 패턴이 페이지 export 결과에서 벡터 path op로 나타나는지 확인한다.
+        use editor_macros::doc;
+
+        let (doc,) = doc! {
+            root {
+                paragraph { text("a") }
+                horizontal_rule
+            }
+        };
+
+        let page = export_page_to_vector_page(&doc);
+
+        assert!(page.width > 0.0);
+        assert!(page.height > 0.0);
+        assert!(
+            page.ops
+                .iter()
+                .any(|op| matches!(op, VectorOp::FillPath { .. } | VectorOp::StrokePath { .. })),
+            "horizontal rule page must contain vector path ops"
+        );
+    }
+
     #[test]
     fn line_with_ruby_annotation_invokes_ruby_raster_path() {
         use editor_view::glyph_run::{Glyph, RubyAnnotation, Synthesis};
@@ -1605,6 +1780,14 @@ mod tests {
             fn fill_rect(&mut self, _r: Rect, _c: Color, _t: Transform) {}
             fn fill_path(&mut self, _p: &Path, _c: Color, _t: Transform) {}
             fn stroke_path(&mut self, _p: &Path, _c: Color, _s: &Stroke, _t: Transform) {}
+            fn draw_glyph_run(
+                &mut self,
+                _r: &editor_view::glyph_run::GlyphRun,
+                _c: Color,
+                _t: Transform,
+                _f: &editor_resource::FontRegistry,
+            ) {
+            }
             fn draw_image(&mut self, _i: &Image, _r: Rect, _t: Transform) {
                 self.image_draws += 1;
             }
@@ -1684,6 +1867,14 @@ mod tests {
                 self.fills.push(c);
             }
             fn stroke_path(&mut self, _p: &Path, _c: Color, _s: &Stroke, _t: Transform) {}
+            fn draw_glyph_run(
+                &mut self,
+                _r: &editor_view::glyph_run::GlyphRun,
+                _c: Color,
+                _t: Transform,
+                _f: &editor_resource::FontRegistry,
+            ) {
+            }
             fn draw_image(&mut self, _i: &Image, _r: Rect, _t: Transform) {}
         }
 
@@ -1786,6 +1977,14 @@ mod tests {
                 self.count += 1;
             }
             fn stroke_path(&mut self, _p: &Path, _c: Color, _s: &Stroke, _t: Transform) {}
+            fn draw_glyph_run(
+                &mut self,
+                _r: &editor_view::glyph_run::GlyphRun,
+                _c: Color,
+                _t: Transform,
+                _f: &editor_resource::FontRegistry,
+            ) {
+            }
             fn draw_image(&mut self, _i: &Image, _r: Rect, _t: Transform) {}
         }
 
@@ -1865,6 +2064,14 @@ mod tests {
                 self.count += 1;
             }
             fn stroke_path(&mut self, _p: &Path, _c: Color, _s: &Stroke, _t: Transform) {}
+            fn draw_glyph_run(
+                &mut self,
+                _r: &editor_view::glyph_run::GlyphRun,
+                _c: Color,
+                _t: Transform,
+                _f: &editor_resource::FontRegistry,
+            ) {
+            }
             fn draw_image(&mut self, _i: &Image, _r: Rect, _t: Transform) {}
         }
 
@@ -1932,6 +2139,14 @@ mod tests {
                 self.count += 1;
             }
             fn stroke_path(&mut self, _p: &Path, _c: Color, _s: &Stroke, _t: Transform) {}
+            fn draw_glyph_run(
+                &mut self,
+                _r: &editor_view::glyph_run::GlyphRun,
+                _c: Color,
+                _t: Transform,
+                _f: &editor_resource::FontRegistry,
+            ) {
+            }
             fn draw_image(&mut self, _i: &Image, _r: Rect, _t: Transform) {}
         }
 
@@ -2033,6 +2248,14 @@ mod tests {
                 self.count += 1;
             }
             fn stroke_path(&mut self, _p: &Path, _c: Color, _s: &Stroke, _t: Transform) {}
+            fn draw_glyph_run(
+                &mut self,
+                _r: &editor_view::glyph_run::GlyphRun,
+                _c: Color,
+                _t: Transform,
+                _f: &editor_resource::FontRegistry,
+            ) {
+            }
             fn draw_image(&mut self, _i: &Image, _r: Rect, _t: Transform) {}
         }
 

--- a/crates/editor-renderer/src/sink.rs
+++ b/crates/editor-renderer/src/sink.rs
@@ -1,4 +1,6 @@
 use editor_common::Rect;
+use editor_resource::FontRegistry;
+use editor_view::glyph_run::GlyphRun;
 
 use crate::types::Color;
 use crate::types::{Image, Path, Stroke, Transform};
@@ -9,4 +11,12 @@ pub trait RenderSink {
     fn fill_path(&mut self, path: &Path, color: Color, transform: Transform);
     fn stroke_path(&mut self, path: &Path, color: Color, stroke: &Stroke, transform: Transform);
     fn draw_image(&mut self, image: &Image, rect: Rect, transform: Transform);
+    fn draw_glyph_run(
+        &mut self,
+        _run: &GlyphRun,
+        _color: Color,
+        _transform: Transform,
+        _fonts: &FontRegistry,
+    ) {
+    }
 }

--- a/crates/editor-renderer/src/vector/codec.rs
+++ b/crates/editor-renderer/src/vector/codec.rs
@@ -1,0 +1,215 @@
+use crate::vector::types::{
+    VectorFillRule, VectorLineCap, VectorLineJoin, VectorOp, VectorPage, VectorPathCommand,
+};
+
+const MAGIC: u32 = 0x3156_4554;
+const OP_FILL_PATH: u8 = 0;
+const OP_STROKE_PATH: u8 = 1;
+const OP_IMAGE: u8 = 2;
+const FILL_RULE_WINDING: u8 = 0;
+const FILL_RULE_EVEN_ODD: u8 = 1;
+const LINE_CAP_BUTT: u8 = 0;
+const LINE_CAP_ROUND: u8 = 1;
+const LINE_CAP_SQUARE: u8 = 2;
+const LINE_JOIN_MITER: u8 = 0;
+const LINE_JOIN_ROUND: u8 = 1;
+const LINE_JOIN_BEVEL: u8 = 2;
+const CMD_MOVE_TO: u8 = 0;
+const CMD_LINE_TO: u8 = 1;
+const CMD_QUAD_TO: u8 = 2;
+const CMD_CUBIC_TO: u8 = 3;
+const CMD_CLOSE_PATH: u8 = 4;
+
+pub fn encode_vector_page(page: &VectorPage) -> Vec<u8> {
+    let mut out = Vec::with_capacity(page.ops.len() * 128 + 32);
+    write_u32(&mut out, MAGIC);
+    write_f32(&mut out, page.width);
+    write_f32(&mut out, page.height);
+    write_u32(&mut out, page.ops.len() as u32);
+
+    for op in &page.ops {
+        match op {
+            VectorOp::FillPath {
+                path,
+                color,
+                fill_rule,
+            } => {
+                write_u8(&mut out, OP_FILL_PATH);
+                write_u32(&mut out, path.len() as u32);
+                write_path_commands(&mut out, path);
+                out.extend_from_slice(color);
+                write_u8(
+                    &mut out,
+                    match fill_rule {
+                        VectorFillRule::Winding => FILL_RULE_WINDING,
+                        VectorFillRule::EvenOdd => FILL_RULE_EVEN_ODD,
+                    },
+                );
+            }
+            VectorOp::StrokePath {
+                path,
+                color,
+                width,
+                line_cap,
+                line_join,
+            } => {
+                write_u8(&mut out, OP_STROKE_PATH);
+                write_u32(&mut out, path.len() as u32);
+                write_path_commands(&mut out, path);
+                out.extend_from_slice(color);
+                write_f32(&mut out, *width);
+                write_u8(
+                    &mut out,
+                    match line_cap {
+                        VectorLineCap::Butt => LINE_CAP_BUTT,
+                        VectorLineCap::Round => LINE_CAP_ROUND,
+                        VectorLineCap::Square => LINE_CAP_SQUARE,
+                    },
+                );
+                write_u8(
+                    &mut out,
+                    match line_join {
+                        VectorLineJoin::Miter => LINE_JOIN_MITER,
+                        VectorLineJoin::Round => LINE_JOIN_ROUND,
+                        VectorLineJoin::Bevel => LINE_JOIN_BEVEL,
+                    },
+                );
+            }
+            VectorOp::Image {
+                data,
+                width,
+                height,
+                x,
+                y,
+                render_width,
+                render_height,
+            } => {
+                write_u8(&mut out, OP_IMAGE);
+                write_u32(&mut out, *width);
+                write_u32(&mut out, *height);
+                write_f32(&mut out, *x);
+                write_f32(&mut out, *y);
+                write_f32(&mut out, *render_width);
+                write_f32(&mut out, *render_height);
+                write_u32(&mut out, data.len() as u32);
+                out.extend_from_slice(data);
+            }
+        }
+    }
+
+    out
+}
+
+fn write_u8(out: &mut Vec<u8>, v: u8) {
+    out.push(v);
+}
+fn write_u32(out: &mut Vec<u8>, v: u32) {
+    out.extend_from_slice(&v.to_le_bytes());
+}
+fn write_f32(out: &mut Vec<u8>, v: f32) {
+    out.extend_from_slice(&v.to_le_bytes());
+}
+
+fn write_path_commands(out: &mut Vec<u8>, path: &[VectorPathCommand]) {
+    for cmd in path {
+        match cmd {
+            VectorPathCommand::MoveTo { x, y } => {
+                write_u8(out, CMD_MOVE_TO);
+                write_f32(out, *x);
+                write_f32(out, *y);
+            }
+            VectorPathCommand::LineTo { x, y } => {
+                write_u8(out, CMD_LINE_TO);
+                write_f32(out, *x);
+                write_f32(out, *y);
+            }
+            VectorPathCommand::QuadTo { cx, cy, x, y } => {
+                write_u8(out, CMD_QUAD_TO);
+                write_f32(out, *cx);
+                write_f32(out, *cy);
+                write_f32(out, *x);
+                write_f32(out, *y);
+            }
+            VectorPathCommand::CubicTo {
+                c1x,
+                c1y,
+                c2x,
+                c2y,
+                x,
+                y,
+            } => {
+                write_u8(out, CMD_CUBIC_TO);
+                write_f32(out, *c1x);
+                write_f32(out, *c1y);
+                write_f32(out, *c2x);
+                write_f32(out, *c2y);
+                write_f32(out, *x);
+                write_f32(out, *y);
+            }
+            VectorPathCommand::ClosePath => {
+                write_u8(out, CMD_CLOSE_PATH);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vector::types::VectorPage;
+
+    #[test]
+    fn encode_starts_with_magic() {
+        // 인코딩 결과가 TVE1 매직으로 시작해 외부 파서가 포맷을 식별할 수 있는지 확인한다.
+        let page = VectorPage {
+            width: 100.0,
+            height: 200.0,
+            ops: vec![],
+        };
+        let bytes = encode_vector_page(&page);
+        let magic = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
+        assert_eq!(magic, MAGIC);
+    }
+
+    #[test]
+    fn encode_records_dimensions() {
+        // 페이지 크기가 바이너리 헤더에 그대로 기록되는지 확인한다.
+        let page = VectorPage {
+            width: 123.0,
+            height: 456.0,
+            ops: vec![],
+        };
+        let bytes = encode_vector_page(&page);
+        let w = f32::from_le_bytes(bytes[4..8].try_into().unwrap());
+        let h = f32::from_le_bytes(bytes[8..12].try_into().unwrap());
+        assert!((w - 123.0).abs() < 0.001);
+        assert!((h - 456.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn encode_vector_page_produces_converter_ready_binary() {
+        // PDF/SVG 변환기가 바로 읽을 수 있도록
+        // 인코딩 결과가 TVE1 헤더와 최소한의 op 정보를 포함하는지 확인한다.
+        let page = VectorPage {
+            width: 210.0,
+            height: 297.0,
+            ops: vec![VectorOp::FillPath {
+                path: vec![
+                    VectorPathCommand::MoveTo { x: 0.0, y: 0.0 },
+                    VectorPathCommand::LineTo { x: 10.0, y: 0.0 },
+                    VectorPathCommand::ClosePath,
+                ],
+                color: [255, 0, 0, 255],
+                fill_rule: VectorFillRule::Winding,
+            }],
+        };
+
+        let bytes = encode_vector_page(&page);
+
+        assert_eq!(u32::from_le_bytes(bytes[0..4].try_into().unwrap()), MAGIC);
+        assert!((f32::from_le_bytes(bytes[4..8].try_into().unwrap()) - 210.0).abs() < 0.001);
+        assert!((f32::from_le_bytes(bytes[8..12].try_into().unwrap()) - 297.0).abs() < 0.001);
+        assert_eq!(u32::from_le_bytes(bytes[12..16].try_into().unwrap()), 1);
+        assert_eq!(bytes[16], OP_FILL_PATH);
+    }
+}

--- a/crates/editor-renderer/src/vector/export.rs
+++ b/crates/editor-renderer/src/vector/export.rs
@@ -1,0 +1,524 @@
+use editor_common::Rect;
+use skrifa::instance::{LocationRef, NormalizedCoord, Size};
+use skrifa::outline::{DrawSettings, OutlinePen};
+use skrifa::{FontRef, GlyphId, MetadataProvider};
+
+use crate::sink::RenderSink;
+use crate::types::{Color, Image, Path, PathElement, Stroke, StrokeCap, StrokeJoin, Transform};
+use crate::vector::types::{
+    VectorFillRule, VectorLineCap, VectorLineJoin, VectorOp, VectorPage, VectorPathCommand,
+};
+
+pub struct VectorSink {
+    ops: Vec<VectorOp>,
+}
+
+impl VectorSink {
+    pub fn new() -> Self {
+        Self { ops: Vec::new() }
+    }
+
+    pub fn into_page(self, width: f32, height: f32) -> VectorPage {
+        VectorPage {
+            width,
+            height,
+            ops: self.ops,
+        }
+    }
+}
+
+impl RenderSink for VectorSink {
+    fn pixel_size(&self) -> (u32, u32) {
+        (0, 0)
+    }
+
+    fn fill_rect(&mut self, rect: Rect, color: Color, transform: Transform) {
+        self.fill_path(&Path::rect(rect), color, transform);
+    }
+
+    fn fill_path(&mut self, path: &Path, color: Color, transform: Transform) {
+        let cmds = path_to_commands(path, transform);
+        if cmds.is_empty() {
+            return;
+        }
+        self.ops.push(VectorOp::FillPath {
+            path: cmds,
+            color: color_to_rgba(color),
+            fill_rule: VectorFillRule::Winding,
+        });
+    }
+
+    fn stroke_path(&mut self, path: &Path, color: Color, stroke: &Stroke, transform: Transform) {
+        let cmds = path_to_commands(path, transform);
+        if cmds.is_empty() {
+            return;
+        }
+        self.ops.push(VectorOp::StrokePath {
+            path: cmds,
+            color: color_to_rgba(color),
+            width: stroke.width,
+            line_cap: match stroke.cap {
+                StrokeCap::Butt => VectorLineCap::Butt,
+                StrokeCap::Round => VectorLineCap::Round,
+                StrokeCap::Square => VectorLineCap::Square,
+            },
+            line_join: match stroke.join {
+                StrokeJoin::Miter => VectorLineJoin::Miter,
+                StrokeJoin::Round => VectorLineJoin::Round,
+                StrokeJoin::Bevel => VectorLineJoin::Bevel,
+            },
+        });
+    }
+
+    fn draw_image(&mut self, image: &Image, rect: Rect, transform: Transform) {
+        let (x, y, render_width, render_height) = map_rect_bounds(transform, rect);
+        self.ops.push(VectorOp::Image {
+            data: image.data.clone(),
+            width: image.width,
+            height: image.height,
+            x,
+            y,
+            render_width,
+            render_height,
+        });
+    }
+
+    fn draw_glyph_run(
+        &mut self,
+        run: &editor_view::glyph_run::GlyphRun,
+        color: Color,
+        base_transform: Transform,
+        fonts: &editor_resource::FontRegistry,
+    ) {
+        let Some(font_data) = fonts.font_data(run.family_id, run.weight) else {
+            return;
+        };
+        let Ok(font) = FontRef::from_index(font_data, 0) else {
+            return;
+        };
+        let outlines = font.outline_glyphs();
+        let coords: &[NormalizedCoord] = &[];
+        let size = Size::new(run.font_size);
+        let rgba = color_to_rgba(color);
+
+        for g in &run.glyphs {
+            if g.id == 0 {
+                continue;
+            }
+            let Some(og) = outlines.get(GlyphId::new(g.id)) else {
+                continue;
+            };
+            let glyph_t = base_transform.translate(g.x, g.y);
+            let mut writer = GlyphOutlineWriter {
+                cmds: Vec::new(),
+                transform: glyph_t,
+            };
+            let settings = DrawSettings::unhinted(size, LocationRef::new(coords));
+            if og.draw(settings, &mut writer).is_err() || writer.cmds.is_empty() {
+                continue;
+            }
+            self.ops.push(VectorOp::FillPath {
+                path: writer.cmds,
+                color: rgba,
+                fill_rule: VectorFillRule::Winding,
+            });
+        }
+    }
+}
+
+struct GlyphOutlineWriter {
+    cmds: Vec<VectorPathCommand>,
+    transform: Transform,
+}
+
+impl OutlinePen for GlyphOutlineWriter {
+    fn move_to(&mut self, x: f32, y: f32) {
+        let (x, y) = map_glyph_point(self.transform, x, y);
+        self.cmds.push(VectorPathCommand::MoveTo { x, y });
+    }
+    fn line_to(&mut self, x: f32, y: f32) {
+        let (x, y) = map_glyph_point(self.transform, x, y);
+        self.cmds.push(VectorPathCommand::LineTo { x, y });
+    }
+    fn quad_to(&mut self, cx0: f32, cy0: f32, x: f32, y: f32) {
+        let (cx, cy) = map_glyph_point(self.transform, cx0, cy0);
+        let (x, y) = map_glyph_point(self.transform, x, y);
+        self.cmds.push(VectorPathCommand::QuadTo { cx, cy, x, y });
+    }
+    fn curve_to(&mut self, cx0: f32, cy0: f32, cx1: f32, cy1: f32, x: f32, y: f32) {
+        let (c1x, c1y) = map_glyph_point(self.transform, cx0, cy0);
+        let (c2x, c2y) = map_glyph_point(self.transform, cx1, cy1);
+        let (x, y) = map_glyph_point(self.transform, x, y);
+        self.cmds.push(VectorPathCommand::CubicTo {
+            c1x,
+            c1y,
+            c2x,
+            c2y,
+            x,
+            y,
+        });
+    }
+    fn close(&mut self) {
+        self.cmds.push(VectorPathCommand::ClosePath);
+    }
+}
+
+fn map_point(t: Transform, x: f32, y: f32) -> (f32, f32) {
+    let [a, b, c, d, e, f] = t.m;
+    (a * x + c * y + e, b * x + d * y + f)
+}
+
+fn map_rect_bounds(t: Transform, rect: Rect) -> (f32, f32, f32, f32) {
+    let corners = [
+        map_point(t, rect.x, rect.y),
+        map_point(t, rect.x + rect.width, rect.y),
+        map_point(t, rect.x, rect.y + rect.height),
+        map_point(t, rect.x + rect.width, rect.y + rect.height),
+    ];
+
+    let min_x = corners
+        .iter()
+        .map(|(x, _)| *x)
+        .fold(f32::INFINITY, f32::min);
+    let max_x = corners
+        .iter()
+        .map(|(x, _)| *x)
+        .fold(f32::NEG_INFINITY, f32::max);
+    let min_y = corners
+        .iter()
+        .map(|(_, y)| *y)
+        .fold(f32::INFINITY, f32::min);
+    let max_y = corners
+        .iter()
+        .map(|(_, y)| *y)
+        .fold(f32::NEG_INFINITY, f32::max);
+
+    (min_x, min_y, max_x - min_x, max_y - min_y)
+}
+
+fn map_glyph_point(t: Transform, x: f32, y: f32) -> (f32, f32) {
+    map_point(t, x, -y)
+}
+
+fn path_to_commands(path: &Path, transform: Transform) -> Vec<VectorPathCommand> {
+    let mut cmds = Vec::new();
+    for el in &path.elements {
+        match *el {
+            PathElement::MoveTo { x, y } => {
+                let (x, y) = map_point(transform, x, y);
+                cmds.push(VectorPathCommand::MoveTo { x, y });
+            }
+            PathElement::LineTo { x, y } => {
+                let (x, y) = map_point(transform, x, y);
+                cmds.push(VectorPathCommand::LineTo { x, y });
+            }
+            PathElement::QuadTo { x1, y1, x, y } => {
+                let (cx, cy) = map_point(transform, x1, y1);
+                let (x, y) = map_point(transform, x, y);
+                cmds.push(VectorPathCommand::QuadTo { cx, cy, x, y });
+            }
+            PathElement::CurveTo {
+                x1,
+                y1,
+                x2,
+                y2,
+                x,
+                y,
+            } => {
+                let (c1x, c1y) = map_point(transform, x1, y1);
+                let (c2x, c2y) = map_point(transform, x2, y2);
+                let (x, y) = map_point(transform, x, y);
+                cmds.push(VectorPathCommand::CubicTo {
+                    c1x,
+                    c1y,
+                    c2x,
+                    c2y,
+                    x,
+                    y,
+                });
+            }
+            PathElement::Close => {
+                cmds.push(VectorPathCommand::ClosePath);
+            }
+        }
+    }
+    cmds
+}
+
+fn color_to_rgba(c: Color) -> [u8; 4] {
+    [c.r, c.g, c.b, c.a]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::Stroke;
+    use crate::vector::types::VectorOp;
+    use editor_common::Rect;
+
+    fn red() -> Color {
+        Color {
+            r: 255,
+            g: 0,
+            b: 0,
+            a: 255,
+        }
+    }
+
+    #[test]
+    fn fill_rect_produces_fill_path_op() {
+        // 사각형 채우기 명령이 VectorPage에서 FillPath op로 기록되는지 확인한다.
+        let mut sink = VectorSink::new();
+        sink.fill_rect(
+            Rect::from_xywh(0.0, 0.0, 10.0, 10.0),
+            red(),
+            Transform::IDENTITY,
+        );
+        let page = sink.into_page(100.0, 100.0);
+        assert!(matches!(page.ops[0], VectorOp::FillPath { .. }));
+    }
+
+    #[test]
+    fn fill_path_produces_fill_path_op() {
+        // 일반 path 채우기 명령이 FillPath op로 보존되는지 확인한다.
+        let mut sink = VectorSink::new();
+        sink.fill_path(
+            &Path::rect(Rect::from_xywh(0.0, 0.0, 10.0, 10.0)),
+            red(),
+            Transform::IDENTITY,
+        );
+        let page = sink.into_page(100.0, 100.0);
+        assert!(matches!(page.ops[0], VectorOp::FillPath { .. }));
+    }
+
+    #[test]
+    fn stroke_path_produces_stroke_path_op() {
+        // stroke 정보가 포함된 path가 StrokePath op로 기록되는지 확인한다.
+        let mut sink = VectorSink::new();
+        sink.stroke_path(
+            &Path::rect(Rect::from_xywh(0.0, 0.0, 10.0, 10.0)),
+            red(),
+            &Stroke::new(1.0),
+            Transform::IDENTITY,
+        );
+        let page = sink.into_page(100.0, 100.0);
+        assert!(matches!(page.ops[0], VectorOp::StrokePath { .. }));
+    }
+
+    #[test]
+    fn draw_image_produces_image_op() {
+        // 이미지 그리기 명령이 VectorPage에서 Image op로 바뀌는지 확인한다.
+        let image = crate::types::Image {
+            data: vec![0u8; 4],
+            width: 1,
+            height: 1,
+        };
+        let mut sink = VectorSink::new();
+        sink.draw_image(
+            &image,
+            Rect::from_xywh(5.0, 10.0, 1.0, 1.0),
+            Transform::IDENTITY,
+        );
+        let page = sink.into_page(100.0, 100.0);
+        assert!(matches!(page.ops[0], VectorOp::Image { .. }));
+    }
+
+    #[test]
+    fn image_is_vectorized_as_image_op() {
+        // 이미지 리소스가 표시 위치와 표시 크기를 포함한 Image op로 보존되는지 확인한다.
+        let image = crate::types::Image {
+            data: vec![1, 2, 3, 4],
+            width: 1,
+            height: 1,
+        };
+        let mut sink = VectorSink::new();
+        sink.draw_image(
+            &image,
+            Rect::from_xywh(5.0, 10.0, 3.0, 4.0),
+            Transform::scale(2.0),
+        );
+
+        let page = sink.into_page(100.0, 100.0);
+        match &page.ops[0] {
+            VectorOp::Image {
+                data,
+                width,
+                height,
+                x,
+                y,
+                render_width,
+                render_height,
+            } => {
+                assert_eq!(data, &vec![1, 2, 3, 4]);
+                assert_eq!(*width, 1);
+                assert_eq!(*height, 1);
+                assert!((*x - 10.0).abs() < 0.001);
+                assert!((*y - 20.0).abs() < 0.001);
+                assert!((*render_width - 6.0).abs() < 0.001);
+                assert!((*render_height - 8.0).abs() < 0.001);
+            }
+            other => panic!("expected Image op, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn into_page_sets_dimensions() {
+        // sink가 수집한 op를 페이지로 바꿀 때 width/height가 그대로 보존되는지 확인한다.
+        let sink = VectorSink::new();
+        let page = sink.into_page(123.0, 456.0);
+        assert_eq!(page.width, 123.0);
+        assert_eq!(page.height, 456.0);
+    }
+
+    #[test]
+    fn draw_glyph_run_produces_fill_path_ops() {
+        // 글리프 run을 그리면 텍스트가 래스터가 아니라 FillPath op들로 수집되는지 확인한다.
+        use editor_view::glyph_run::{Glyph, GlyphRun, Synthesis, TextDecoration};
+
+        const TEST_FONT: &[u8] = include_bytes!("../../../../assets/Pretendard-Regular.ttf");
+        let mut resource = editor_resource::Resource::new_test();
+        let compressed = editor_resource::compress_zstd(TEST_FONT);
+        resource.add_font_base("test", 400, &compressed).unwrap();
+        let family_id = resource.font_registry.intern_id("test").unwrap();
+
+        let run = GlyphRun {
+            family_id,
+            weight: 400,
+            font_size: 16.0,
+            synthesis: Synthesis::default(),
+            color: "text.black".to_string(),
+            background_color: None,
+            glyphs: vec![Glyph {
+                id: 3,
+                x: 0.0,
+                y: 0.0,
+            }],
+            decoration: TextDecoration::default(),
+            node_id: editor_model::NodeId::ROOT,
+            offset: 0,
+            text: "A".to_string(),
+            x: 0.0,
+            width: 10.0,
+            graphemes: vec![],
+        };
+
+        let mut sink = VectorSink::new();
+        sink.draw_glyph_run(&run, red(), Transform::IDENTITY, &resource.font_registry);
+        let page = sink.into_page(100.0, 100.0);
+        assert!(!page.ops.is_empty());
+        assert!(
+            page.ops
+                .iter()
+                .all(|op| matches!(op, VectorOp::FillPath { .. }))
+        );
+    }
+
+    #[test]
+    fn text_glyph_outline_is_vectorized_as_fill_paths() {
+        // 텍스트는 래스터 이미지가 아니라 글리프 outline 기반 FillPath들로 수집되어야 한다.
+        use editor_view::glyph_run::{Glyph, GlyphRun, Synthesis, TextDecoration};
+
+        const TEST_FONT: &[u8] = include_bytes!("../../../../assets/Pretendard-Regular.ttf");
+        let mut resource = editor_resource::Resource::new_test();
+        let compressed = editor_resource::compress_zstd(TEST_FONT);
+        resource.add_font_base("test", 400, &compressed).unwrap();
+        let family_id = resource.font_registry.intern_id("test").unwrap();
+
+        let run = GlyphRun {
+            family_id,
+            weight: 400,
+            font_size: 16.0,
+            synthesis: Synthesis::default(),
+            color: "text.black".to_string(),
+            background_color: None,
+            glyphs: vec![Glyph {
+                id: 3,
+                x: 0.0,
+                y: 0.0,
+            }],
+            decoration: TextDecoration::default(),
+            node_id: editor_model::NodeId::ROOT,
+            offset: 0,
+            text: "A".to_string(),
+            x: 0.0,
+            width: 10.0,
+            graphemes: vec![],
+        };
+
+        let mut sink = VectorSink::new();
+        sink.draw_glyph_run(&run, red(), Transform::IDENTITY, &resource.font_registry);
+        let page = sink.into_page(100.0, 100.0);
+
+        assert!(!page.ops.is_empty());
+        assert!(page.width > 0.0);
+        assert!(page.height > 0.0);
+        assert!(
+            page.ops
+                .iter()
+                .all(|op| matches!(op, VectorOp::FillPath { .. }))
+        );
+    }
+
+    #[test]
+    fn glyph_outline_y_coordinates_are_flipped_into_screen_space() {
+        // 글리프 outline은 폰트 좌표계(y-up)를 화면 좌표계(y-down)로 뒤집어 baseline 위쪽에 배치해야 한다.
+        use editor_view::glyph_run::{Glyph, GlyphRun, Synthesis, TextDecoration};
+
+        const TEST_FONT: &[u8] = include_bytes!("../../../../assets/Pretendard-Regular.ttf");
+        let mut resource = editor_resource::Resource::new_test();
+        let compressed = editor_resource::compress_zstd(TEST_FONT);
+        resource.add_font_base("test", 400, &compressed).unwrap();
+        let family_id = resource.font_registry.intern_id("test").unwrap();
+        let baseline_y = 20.0;
+
+        let run = GlyphRun {
+            family_id,
+            weight: 400,
+            font_size: 16.0,
+            synthesis: Synthesis::default(),
+            color: "text.black".to_string(),
+            background_color: None,
+            glyphs: vec![Glyph {
+                id: 3,
+                x: 0.0,
+                y: baseline_y,
+            }],
+            decoration: TextDecoration::default(),
+            node_id: editor_model::NodeId::ROOT,
+            offset: 0,
+            text: "A".to_string(),
+            x: 0.0,
+            width: 10.0,
+            graphemes: vec![],
+        };
+
+        let mut sink = VectorSink::new();
+        sink.draw_glyph_run(&run, red(), Transform::IDENTITY, &resource.font_registry);
+        let page = sink.into_page(100.0, 100.0);
+
+        let mut ys = Vec::new();
+        for op in &page.ops {
+            if let VectorOp::FillPath { path, .. } = op {
+                for cmd in path {
+                    match cmd {
+                        VectorPathCommand::MoveTo { y, .. }
+                        | VectorPathCommand::LineTo { y, .. }
+                        | VectorPathCommand::QuadTo { y, .. }
+                        | VectorPathCommand::CubicTo { y, .. } => ys.push(*y),
+                        VectorPathCommand::ClosePath => {}
+                    }
+                }
+            }
+        }
+
+        assert!(!ys.is_empty());
+        assert!(
+            ys.iter().all(|y| *y <= baseline_y + 0.01),
+            "glyph outline points must stay at or above the baseline in screen space"
+        );
+        assert!(
+            ys.iter().any(|y| *y < baseline_y - 1.0),
+            "glyph outline should extend upward from the baseline"
+        );
+    }
+}

--- a/crates/editor-renderer/src/vector/mod.rs
+++ b/crates/editor-renderer/src/vector/mod.rs
@@ -1,0 +1,3 @@
+pub mod codec;
+pub mod export;
+pub mod types;

--- a/crates/editor-renderer/src/vector/types.rs
+++ b/crates/editor-renderer/src/vector/types.rs
@@ -1,0 +1,78 @@
+#[derive(Debug, Clone)]
+pub enum VectorPathCommand {
+    MoveTo {
+        x: f32,
+        y: f32,
+    },
+    LineTo {
+        x: f32,
+        y: f32,
+    },
+    QuadTo {
+        cx: f32,
+        cy: f32,
+        x: f32,
+        y: f32,
+    },
+    CubicTo {
+        c1x: f32,
+        c1y: f32,
+        c2x: f32,
+        c2y: f32,
+        x: f32,
+        y: f32,
+    },
+    ClosePath,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum VectorFillRule {
+    Winding,
+    EvenOdd,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum VectorLineCap {
+    Butt,
+    Round,
+    Square,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum VectorLineJoin {
+    Miter,
+    Round,
+    Bevel,
+}
+
+#[derive(Debug, Clone)]
+pub enum VectorOp {
+    FillPath {
+        path: Vec<VectorPathCommand>,
+        color: [u8; 4],
+        fill_rule: VectorFillRule,
+    },
+    StrokePath {
+        path: Vec<VectorPathCommand>,
+        color: [u8; 4],
+        width: f32,
+        line_cap: VectorLineCap,
+        line_join: VectorLineJoin,
+    },
+    Image {
+        data: Vec<u8>,
+        width: u32,
+        height: u32,
+        x: f32,
+        y: f32,
+        render_width: f32,
+        render_height: f32,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct VectorPage {
+    pub width: f32,
+    pub height: f32,
+    pub ops: Vec<VectorOp>,
+}


### PR DESCRIPTION
레거시 에디터의 `VectorPage` 변환 경로를 참고해, 신규 editor-renderer에 페이지 벡터 명령 시퀀스 표현과 이를 바이너리로 직렬화하는 codec을 구현했습니다. 또한 페이지 단위 vector export API를 editor-renderer에 추가하고, 호스트가 사용할 수 있도록 FFI `export_page_vector()` 경로를 연결했습니다. 