### PR TITLE
feat: racked range decoration/overlay 렌더 경로 + FFI

### DIFF
--- a/crates/editor-common/src/lib.rs
+++ b/crates/editor-common/src/lib.rs
@@ -5,6 +5,7 @@ mod ffi;
 mod geometry;
 mod movement;
 mod str;
+mod style;
 pub mod time;
 mod tri;
 
@@ -13,4 +14,5 @@ pub use ffi::*;
 pub use geometry::*;
 pub use movement::*;
 pub use str::*;
+pub use style::*;
 pub use tri::*;

--- a/crates/editor-common/src/style.rs
+++ b/crates/editor-common/src/style.rs
@@ -1,0 +1,26 @@
+use editor_macros::ffi;
+use serde::{Deserialize, Serialize};
+
+#[ffi]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UnderlineStyle {
+    Solid,
+    Dashed,
+    Wavy,
+}
+
+#[ffi]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Underline {
+    pub color: String,
+    pub style: UnderlineStyle,
+    pub thickness: f32,
+}
+
+#[ffi]
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct DecorationStyle {
+    pub background: Option<String>,
+    pub underline: Option<Underline>,
+}

--- a/crates/editor-core/src/editor.rs
+++ b/crates/editor-core/src/editor.rs
@@ -417,6 +417,59 @@ impl Editor {
         Ok(std::mem::take(&mut self.pending_events))
     }
 
+    #[cfg(test)]
+    pub(crate) fn tracked_decoration_marks_for_test(&self) -> Vec<Mark> {
+        let mut marks = Vec::new();
+        self.collect_tracked_decoration_marks(&mut marks);
+        marks
+    }
+
+    fn collect_tracked_decoration_marks(&self, marks: &mut Vec<Mark>) {
+        let view_state = self.view.view_state();
+        if view_state.tracked_decoration_groups.is_empty() {
+            return;
+        }
+        for range in self.tracked_ranges.iter() {
+            let Some(group) = view_state.group_decoration(&range.group) else {
+                continue;
+            };
+            if !group.enabled {
+                continue;
+            }
+            if range.explicitly_invalid {
+                continue;
+            }
+            let sel = range.selection.thaw(&self.state.doc);
+            if sel.is_collapsed() {
+                continue;
+            }
+            let Some(resolved) = sel.resolve(&self.state.doc) else {
+                continue;
+            };
+            let rects: Vec<PageRect> = self
+                .view
+                .selection_rects(&resolved)
+                .iter()
+                .map(|r| r.without_meta())
+                .collect();
+            if rects.is_empty() {
+                continue;
+            }
+            if let Some(theme_key) = group.style.background.clone() {
+                marks.push(Mark {
+                    data: MarkData::TrackedBackground { theme_key },
+                    rects: rects.clone(),
+                });
+            }
+            if let Some(underline) = group.style.underline.clone() {
+                marks.push(Mark {
+                    data: MarkData::TrackedUnderline { underline },
+                    rects,
+                });
+            }
+        }
+    }
+
     fn selection_mark_rects(&self) -> Option<Vec<PageRect>> {
         let resolved = self.state.selection.as_ref()?.resolve(&self.state.doc)?;
         if resolved.is_collapsed() {
@@ -472,6 +525,8 @@ impl Editor {
                 rects: vec![target.indicator.rect()],
             });
         }
+
+        self.collect_tracked_decoration_marks(&mut marks);
 
         self.renderer.render_page(
             sink,

--- a/crates/editor-core/src/handle/tracked_range.rs
+++ b/crates/editor-core/src/handle/tracked_range.rs
@@ -1,4 +1,5 @@
 use editor_state::StableSelection;
+use editor_view::GroupDecoration;
 
 use crate::editor::Editor;
 use crate::error::EditorError;
@@ -58,8 +59,42 @@ pub fn handle_tracked_range_op(editor: &mut Editor, op: TrackedRangeOp) -> Resul
                 reg.invalidate(&id);
             });
         }
+        TrackedRangeOp::SetGroupDecoration {
+            group,
+            style,
+            enabled,
+        } => {
+            let decoration = GroupDecoration { style, enabled };
+            let would_change = editor.view.would_set_group_decoration(&group, &decoration);
+            commit_view_or_probe(editor, would_change, |editor| {
+                editor.view.set_group_decoration(group, decoration);
+            });
+        }
+        TrackedRangeOp::RemoveGroupDecoration { group } => {
+            let would_change = editor.view.would_remove_group_decoration(&group);
+            commit_view_or_probe(editor, would_change, |editor| {
+                editor.view.remove_group_decoration(&group);
+            });
+        }
     }
     Ok(())
+}
+
+fn commit_view_or_probe<F>(editor: &mut Editor, would_change: bool, apply: F)
+where
+    F: FnOnce(&mut Editor),
+{
+    if editor.is_probing() {
+        editor.mark_probed_change(would_change);
+        return;
+    }
+    if would_change {
+        apply(editor);
+        editor.push_event(EditorEvent::StateChanged {
+            fields: vec![StateField::TrackedRanges],
+        });
+        editor.push_event(EditorEvent::RenderInvalidated);
+    }
 }
 
 fn commit_or_probe<F>(editor: &mut Editor, would_change: bool, apply: F)
@@ -75,6 +110,7 @@ where
         editor.push_event(EditorEvent::StateChanged {
             fields: vec![StateField::TrackedRanges],
         });
+        editor.push_event(EditorEvent::RenderInvalidated);
     }
 }
 
@@ -252,5 +288,132 @@ mod tests {
             })
             .unwrap();
         assert!(!probed);
+    }
+
+    fn sample_style() -> DecorationStyle {
+        DecorationStyle {
+            background: Some("selection".into()),
+            underline: None,
+        }
+    }
+
+    fn set_group_op(group: &str, style: DecorationStyle, enabled: bool) -> Message {
+        Message::TrackedRange {
+            op: TrackedRangeOp::SetGroupDecoration {
+                group: group.into(),
+                style,
+                enabled,
+            },
+        }
+    }
+
+    #[test]
+    fn set_group_decoration_stores_in_view_state() {
+        let (state, ..) = state! {
+            doc { root { paragraph { t1: text("hi") } } }
+            selection: (t1, 0)
+        };
+        let mut editor = Editor::new_test(state);
+        let events = editor.apply(set_group_op("g1", sample_style(), true));
+        let stored = editor.view().view_state().group_decoration("g1").unwrap();
+        assert_eq!(stored.style, sample_style());
+        assert!(stored.enabled);
+        assert!(events.iter().any(|e| matches!(
+            e,
+            EditorEvent::StateChanged { fields } if fields.contains(&StateField::TrackedRanges)
+        )));
+    }
+
+    #[test]
+    fn set_group_decoration_same_value_is_idempotent() {
+        let (state, ..) = state! {
+            doc { root { paragraph { t1: text("hi") } } }
+            selection: (t1, 0)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.apply(set_group_op("g1", sample_style(), true));
+        let events = editor.apply(set_group_op("g1", sample_style(), true));
+        assert!(!events.iter().any(|e| matches!(
+            e,
+            EditorEvent::StateChanged { fields } if fields.contains(&StateField::TrackedRanges)
+        )));
+    }
+
+    #[test]
+    fn set_group_decoration_toggle_enabled_emits_change() {
+        let (state, ..) = state! {
+            doc { root { paragraph { t1: text("hi") } } }
+            selection: (t1, 0)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.apply(set_group_op("g1", sample_style(), true));
+        let events = editor.apply(set_group_op("g1", sample_style(), false));
+        let stored = editor.view().view_state().group_decoration("g1").unwrap();
+        assert!(!stored.enabled);
+        assert!(events.iter().any(|e| matches!(
+            e,
+            EditorEvent::StateChanged { fields } if fields.contains(&StateField::TrackedRanges)
+        )));
+    }
+
+    #[test]
+    fn remove_group_decoration_drops_entry() {
+        let (state, ..) = state! {
+            doc { root { paragraph { t1: text("hi") } } }
+            selection: (t1, 0)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.apply(set_group_op("g1", sample_style(), true));
+        let events = editor.apply(Message::TrackedRange {
+            op: TrackedRangeOp::RemoveGroupDecoration { group: "g1".into() },
+        });
+        assert!(editor.view().view_state().group_decoration("g1").is_none());
+        assert!(events.iter().any(|e| matches!(
+            e,
+            EditorEvent::StateChanged { fields } if fields.contains(&StateField::TrackedRanges)
+        )));
+    }
+
+    #[test]
+    fn remove_unknown_group_decoration_is_noop() {
+        let (state, ..) = state! {
+            doc { root { paragraph { t1: text("hi") } } }
+            selection: (t1, 0)
+        };
+        let mut editor = Editor::new_test(state);
+        let events = editor.apply(Message::TrackedRange {
+            op: TrackedRangeOp::RemoveGroupDecoration {
+                group: "missing".into(),
+            },
+        });
+        assert!(!events.iter().any(|e| matches!(
+            e,
+            EditorEvent::StateChanged { fields } if fields.contains(&StateField::TrackedRanges)
+        )));
+    }
+
+    #[test]
+    fn probe_set_group_decoration_predicts_change() {
+        let (state, ..) = state! {
+            doc { root { paragraph { t1: text("hi") } } }
+            selection: (t1, 0)
+        };
+        assert_probe_predicts_apply(state, set_group_op("g1", sample_style(), true));
+    }
+
+    #[test]
+    fn probe_remove_unknown_group_decoration_predicts_no_change() {
+        let (state, ..) = state! {
+            doc { root { paragraph { t1: text("hi") } } }
+            selection: (t1, 0)
+        };
+        assert_probe_predicts_apply(
+            state,
+            Message::TrackedRange {
+                op: TrackedRangeOp::RemoveGroupDecoration {
+                    group: "missing".into(),
+                },
+            },
+        );
     }
 }

--- a/crates/editor-core/src/message.rs
+++ b/crates/editor-core/src/message.rs
@@ -1,4 +1,4 @@
-pub use editor_common::{Axis, Direction, Movement};
+pub use editor_common::{Axis, DecorationStyle, Direction, Movement};
 use editor_macros::ffi;
 use editor_model::{Fragment, Modifier, ModifierType, NodeId, PlainNode, TableBorderStyle};
 use editor_state::Selection;
@@ -356,6 +356,14 @@ pub enum TrackedRangeOp {
     },
     Invalidate {
         id: String,
+    },
+    SetGroupDecoration {
+        group: String,
+        style: DecorationStyle,
+        enabled: bool,
+    },
+    RemoveGroupDecoration {
+        group: String,
     },
 }
 

--- a/crates/editor-core/src/test_utils.rs
+++ b/crates/editor-core/src/test_utils.rs
@@ -2,7 +2,7 @@ use editor_common::Size;
 use editor_model::NodeId;
 use editor_resource::ThemeVariant;
 use editor_state::{Composition, PendingModifiers, Selection};
-use editor_view::Viewport;
+use editor_view::{GroupDecoration, Viewport};
 use hashbrown::HashMap;
 
 use crate::editor::Editor;
@@ -24,6 +24,7 @@ pub struct EditorSnapshot {
     theme_variant: ThemeVariant,
     page_sizes: Vec<Size>,
     tracked_ranges: TrackedRangeRegistry,
+    tracked_decoration_groups: HashMap<String, GroupDecoration>,
 }
 
 impl EditorSnapshot {
@@ -45,6 +46,7 @@ impl EditorSnapshot {
             theme_variant: editor.theme_variant(),
             page_sizes,
             tracked_ranges: editor.tracked_ranges().clone(),
+            tracked_decoration_groups: view_state.tracked_decoration_groups.clone(),
         }
     }
 }

--- a/crates/editor-core/src/tests/can_invariants.rs
+++ b/crates/editor-core/src/tests/can_invariants.rs
@@ -129,6 +129,21 @@ fn build_corpus() -> Vec<Message> {
                 id: "missing".into(),
             },
         },
+        Message::TrackedRange {
+            op: TrackedRangeOp::SetGroupDecoration {
+                group: "missing".into(),
+                style: editor_common::DecorationStyle {
+                    background: Some("selection".into()),
+                    underline: None,
+                },
+                enabled: true,
+            },
+        },
+        Message::TrackedRange {
+            op: TrackedRangeOp::RemoveGroupDecoration {
+                group: "missing".into(),
+            },
+        },
     ]
 }
 

--- a/crates/editor-core/src/tests/mod.rs
+++ b/crates/editor-core/src/tests/mod.rs
@@ -1,3 +1,4 @@
 mod can_invariants;
 mod scroll_into_view_integration;
+mod tracked_decoration_integration;
 mod tracked_range_integration;

--- a/crates/editor-core/src/tests/tracked_decoration_integration.rs
+++ b/crates/editor-core/src/tests/tracked_decoration_integration.rs
@@ -1,0 +1,268 @@
+use editor_common::{DecorationStyle, Underline, UnderlineStyle};
+use editor_macros::state;
+use editor_renderer::MarkData;
+use editor_state::{Position, Selection};
+
+use crate::editor::Editor;
+use crate::message::*;
+
+fn add_message(id: &str, group: &str, selection: Selection) -> Message {
+    Message::TrackedRange {
+        op: TrackedRangeOp::Add {
+            id: id.into(),
+            group: group.into(),
+            selection,
+            metadata: String::new(),
+        },
+    }
+}
+
+fn set_group(group: &str, style: DecorationStyle, enabled: bool) -> Message {
+    Message::TrackedRange {
+        op: TrackedRangeOp::SetGroupDecoration {
+            group: group.into(),
+            style,
+            enabled,
+        },
+    }
+}
+
+fn background_only_style() -> DecorationStyle {
+    DecorationStyle {
+        background: Some("selection".into()),
+        underline: None,
+    }
+}
+
+fn underline_only_style() -> DecorationStyle {
+    DecorationStyle {
+        background: None,
+        underline: Some(Underline {
+            color: "selection".into(),
+            style: UnderlineStyle::Dashed,
+            thickness: 1.5,
+        }),
+    }
+}
+
+fn both_style() -> DecorationStyle {
+    DecorationStyle {
+        background: Some("selection".into()),
+        underline: Some(Underline {
+            color: "selection".into(),
+            style: UnderlineStyle::Solid,
+            thickness: 1.0,
+        }),
+    }
+}
+
+fn init_editor_with_range(group: &str) -> Editor {
+    let (initial, _t1) = state! {
+        doc { root { paragraph { t1: text("hello world") } } }
+        selection: (t1, 1) -> (t1, 4)
+    };
+    let sel = initial.selection.unwrap();
+    let mut editor = Editor::new_test(initial);
+    editor.apply(Message::System {
+        event: SystemEvent::Initialize,
+    });
+    editor.apply(add_message("r", group, sel));
+    editor
+}
+
+#[test]
+fn no_group_decoration_produces_no_marks() {
+    let editor = init_editor_with_range("spell");
+    let marks = editor.tracked_decoration_marks_for_test();
+    assert!(
+        marks.is_empty(),
+        "range without registered group decoration must produce no marks"
+    );
+}
+
+#[test]
+fn background_only_style_emits_single_background_mark() {
+    let mut editor = init_editor_with_range("spell");
+    editor.apply(set_group("spell", background_only_style(), true));
+    let marks = editor.tracked_decoration_marks_for_test();
+    assert_eq!(marks.len(), 1);
+    assert!(matches!(marks[0].data, MarkData::TrackedBackground { .. }));
+    assert!(!marks[0].rects.is_empty(), "must have at least one rect");
+}
+
+#[test]
+fn underline_only_style_emits_single_underline_mark() {
+    let mut editor = init_editor_with_range("spell");
+    editor.apply(set_group("spell", underline_only_style(), true));
+    let marks = editor.tracked_decoration_marks_for_test();
+    assert_eq!(marks.len(), 1);
+    assert!(matches!(marks[0].data, MarkData::TrackedUnderline { .. }));
+}
+
+#[test]
+fn both_styles_emit_two_marks() {
+    let mut editor = init_editor_with_range("ai");
+    editor.apply(set_group("ai", both_style(), true));
+    let marks = editor.tracked_decoration_marks_for_test();
+    assert_eq!(marks.len(), 2);
+    assert!(
+        marks
+            .iter()
+            .any(|m| matches!(m.data, MarkData::TrackedBackground { .. }))
+    );
+    assert!(
+        marks
+            .iter()
+            .any(|m| matches!(m.data, MarkData::TrackedUnderline { .. }))
+    );
+}
+
+#[test]
+fn disabled_group_produces_no_marks() {
+    let mut editor = init_editor_with_range("spell");
+    editor.apply(set_group("spell", background_only_style(), false));
+    let marks = editor.tracked_decoration_marks_for_test();
+    assert!(marks.is_empty(), "disabled group must not draw");
+}
+
+#[test]
+fn toggling_enabled_brings_marks_back() {
+    let mut editor = init_editor_with_range("spell");
+    editor.apply(set_group("spell", background_only_style(), false));
+    assert!(editor.tracked_decoration_marks_for_test().is_empty());
+    editor.apply(set_group("spell", background_only_style(), true));
+    assert_eq!(editor.tracked_decoration_marks_for_test().len(), 1);
+}
+
+#[test]
+fn invalidated_range_produces_no_marks() {
+    let mut editor = init_editor_with_range("spell");
+    editor.apply(set_group("spell", background_only_style(), true));
+    assert_eq!(editor.tracked_decoration_marks_for_test().len(), 1);
+    editor.apply(Message::TrackedRange {
+        op: TrackedRangeOp::Invalidate { id: "r".into() },
+    });
+    assert!(editor.tracked_decoration_marks_for_test().is_empty());
+}
+
+#[test]
+fn collapsed_on_thaw_produces_no_marks() {
+    let (initial, t1) = state! {
+        doc { root { paragraph { t1: text("hello") } } }
+        selection: (t1, 1) -> (t1, 4)
+    };
+    let sel = initial.selection.unwrap();
+    let mut editor = Editor::new_test(initial);
+    editor.apply(Message::System {
+        event: SystemEvent::Initialize,
+    });
+    editor.apply(add_message("r", "spell", sel));
+    editor.apply(set_group("spell", background_only_style(), true));
+    assert_eq!(editor.tracked_decoration_marks_for_test().len(), 1);
+
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::new(Position::new(t1, 1), Position::new(t1, 4)),
+        },
+    });
+    editor.apply(Message::Deletion {
+        op: DeletionOp::Selection,
+    });
+
+    assert!(
+        editor.tracked_decoration_marks_for_test().is_empty(),
+        "collapsed-on-thaw range must not draw"
+    );
+}
+
+#[test]
+fn remove_group_decoration_stops_drawing() {
+    let mut editor = init_editor_with_range("spell");
+    editor.apply(set_group("spell", background_only_style(), true));
+    assert_eq!(editor.tracked_decoration_marks_for_test().len(), 1);
+    editor.apply(Message::TrackedRange {
+        op: TrackedRangeOp::RemoveGroupDecoration {
+            group: "spell".into(),
+        },
+    });
+    assert!(editor.tracked_decoration_marks_for_test().is_empty());
+}
+
+#[test]
+fn other_group_is_independent() {
+    let mut editor = init_editor_with_range("spell");
+    editor.apply(set_group("spell", background_only_style(), true));
+    editor.apply(set_group("ai", underline_only_style(), true));
+    let marks = editor.tracked_decoration_marks_for_test();
+    assert_eq!(marks.len(), 1);
+    assert!(matches!(marks[0].data, MarkData::TrackedBackground { .. }));
+}
+
+#[test]
+fn rects_shift_after_text_insertion() {
+    let (initial, t1) = state! {
+        doc { root { paragraph { t1: text("hello world") } } }
+        selection: (t1, 1) -> (t1, 4)
+    };
+    let sel = initial.selection.unwrap();
+    let mut editor = Editor::new_test(initial);
+    editor.apply(Message::System {
+        event: SystemEvent::Initialize,
+    });
+    editor.apply(add_message("r", "spell", sel));
+    editor.apply(set_group("spell", background_only_style(), true));
+
+    let before = editor.tracked_decoration_marks_for_test()[0].rects[0].rect;
+
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::collapsed(Position::new(t1, 0)),
+        },
+    });
+    editor.apply(Message::Insertion {
+        op: InsertionOp::Text { text: "XYZ".into() },
+    });
+
+    let after = editor.tracked_decoration_marks_for_test()[0].rects[0].rect;
+    assert!(
+        after.x > before.x,
+        "rect must shift right after insertion before the range (before x={}, after x={})",
+        before.x,
+        after.x
+    );
+}
+
+#[test]
+fn rects_restored_after_undo() {
+    let (initial, t1) = state! {
+        doc { root { paragraph { t1: text("hello world") } } }
+        selection: (t1, 1) -> (t1, 4)
+    };
+    let sel = initial.selection.unwrap();
+    let mut editor = Editor::new_test(initial);
+    editor.apply(Message::System {
+        event: SystemEvent::Initialize,
+    });
+    editor.apply(add_message("r", "spell", sel));
+    editor.apply(set_group("spell", background_only_style(), true));
+
+    let original = editor.tracked_decoration_marks_for_test()[0].rects[0].rect;
+
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::collapsed(Position::new(t1, 0)),
+        },
+    });
+    editor.apply(Message::Insertion {
+        op: InsertionOp::Text { text: "XYZ".into() },
+    });
+    editor.apply(Message::History {
+        op: HistoryOp::Undo,
+    });
+
+    let restored = editor.tracked_decoration_marks_for_test()[0].rects[0].rect;
+    assert_eq!(
+        restored.x, original.x,
+        "rect x must return to original after undo"
+    );
+}

--- a/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
@@ -256,6 +256,11 @@ export interface CursorMetrics {
     line: Rect;
 }
 
+export interface DecorationStyle {
+    background: string | undefined;
+    underline: Underline | undefined;
+}
+
 export interface ExternalElement {
     page_idx: number;
     node_id: NodeId;
@@ -511,6 +516,12 @@ export interface TransactionMeta {
     history: HistoryMeta;
 }
 
+export interface Underline {
+    color: string;
+    style: UnderlineStyle;
+    thickness: number;
+}
+
 export interface Viewport {
     width: number;
     height: number;
@@ -651,9 +662,11 @@ export type TextNodeAttr = void;
 
 export type ThemeVariant = "dark-black" | "dark-charcoal" | "dark-espresso" | "dark-graphite" | "dark-midnight" | "dark-navy" | "dark-obsidian" | "dark-storm" | "light-butter" | "light-latte" | "light-lavender" | "light-mint" | "light-peach" | "light-rose" | "light-snow" | "light-white";
 
-export type TrackedRangeOp = { type: "add"; id: string; group: string; selection: Selection; metadata?: string } | { type: "remove"; id: string } | { type: "clear_group"; group: string } | { type: "invalidate"; id: string };
+export type TrackedRangeOp = { type: "add"; id: string; group: string; selection: Selection; metadata?: string } | { type: "remove"; id: string } | { type: "clear_group"; group: string } | { type: "invalidate"; id: string } | { type: "set_group_decoration"; group: string; style: DecorationStyle; enabled: boolean } | { type: "remove_group_decoration"; group: string };
 
 export type Tri<T> = { type: "absent" } | { type: "uniform"; value: T } | { type: "mixed" };
+
+export type UnderlineStyle = "solid" | "dashed" | "wavy";
 
 export type ViewOp = { type: "toggle_fold"; id: NodeId } | { type: "scroll_into_view"; target: ScrollTarget };
 

--- a/crates/editor-ffi/pkg/server/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/server/editor_ffi.d.ts
@@ -270,6 +270,11 @@ export interface CursorMetrics {
     line: Rect;
 }
 
+export interface DecorationStyle {
+    background: string | undefined;
+    underline: Underline | undefined;
+}
+
 export interface ExternalElement {
     page_idx: number;
     node_id: NodeId;
@@ -538,6 +543,12 @@ export interface TransactionMeta {
     history: HistoryMeta;
 }
 
+export interface Underline {
+    color: string;
+    style: UnderlineStyle;
+    thickness: number;
+}
+
 export interface Viewport {
     width: number;
     height: number;
@@ -678,9 +689,11 @@ export type TextNodeAttr = void;
 
 export type ThemeVariant = "dark-black" | "dark-charcoal" | "dark-espresso" | "dark-graphite" | "dark-midnight" | "dark-navy" | "dark-obsidian" | "dark-storm" | "light-butter" | "light-latte" | "light-lavender" | "light-mint" | "light-peach" | "light-rose" | "light-snow" | "light-white";
 
-export type TrackedRangeOp = { type: "add"; id: string; group: string; selection: Selection; metadata?: string } | { type: "remove"; id: string } | { type: "clear_group"; group: string } | { type: "invalidate"; id: string };
+export type TrackedRangeOp = { type: "add"; id: string; group: string; selection: Selection; metadata?: string } | { type: "remove"; id: string } | { type: "clear_group"; group: string } | { type: "invalidate"; id: string } | { type: "set_group_decoration"; group: string; style: DecorationStyle; enabled: boolean } | { type: "remove_group_decoration"; group: string };
 
 export type Tri<T> = { type: "absent" } | { type: "uniform"; value: T } | { type: "mixed" };
+
+export type UnderlineStyle = "solid" | "dashed" | "wavy";
 
 export type ViewOp = { type: "toggle_fold"; id: NodeId } | { type: "scroll_into_view"; target: ScrollTarget };
 

--- a/crates/editor-renderer/src/renderer.rs
+++ b/crates/editor-renderer/src/renderer.rs
@@ -1,4 +1,4 @@
-use editor_common::Rect;
+use editor_common::{Rect, Underline, UnderlineStyle};
 use editor_model::{Doc, Modifier, Node, NodeId, TableBorderStyle};
 use editor_resource::{Resource, Theme};
 use editor_view::glyph_run::RubyAnnotation;
@@ -342,13 +342,17 @@ pub enum MarkData {
     Selection { focused: bool },
     Composition,
     DropIndicator,
+    TrackedBackground { theme_key: String },
+    TrackedUnderline { underline: Underline },
 }
 
 impl MarkData {
     pub fn layer(&self) -> MarkLayer {
         match self {
-            Self::Selection { .. } => MarkLayer::BelowContent,
-            Self::Composition | Self::DropIndicator => MarkLayer::AboveContent,
+            Self::Selection { .. } | Self::TrackedBackground { .. } => MarkLayer::BelowContent,
+            Self::Composition | Self::DropIndicator | Self::TrackedUnderline { .. } => {
+                MarkLayer::AboveContent
+            }
         }
     }
 }
@@ -358,10 +362,6 @@ pub type MarkRect = PageRect<()>;
 pub struct Mark {
     pub data: MarkData,
     pub rects: Vec<MarkRect>,
-}
-
-struct MarkStyle {
-    color: Color,
 }
 
 const SELECTION_FOCUSED_ALPHA: u8 = 77;
@@ -376,6 +376,73 @@ fn selection_mark_color(theme: &Theme, focused: bool) -> Color {
             SELECTION_UNFOCUSED_ALPHA
         },
     )
+}
+
+const UNDERLINE_DASH: f32 = 6.0;
+const UNDERLINE_GAP: f32 = 4.0;
+const UNDERLINE_WAVE_PERIOD: f32 = 6.0;
+const UNDERLINE_WAVE_AMPLITUDE: f32 = 1.5;
+
+fn draw_underline(
+    sink: &mut dyn RenderSink,
+    rect: Rect,
+    underline: &Underline,
+    theme: &Theme,
+    transform: Transform,
+) {
+    let thickness = underline.thickness.max(0.0);
+    if thickness == 0.0 || rect.width <= 0.0 {
+        return;
+    }
+    let color = theme.color(&underline.color);
+    let y = rect.y + rect.height - thickness;
+    let bar = Rect::from_xywh(rect.x, y, rect.width, thickness);
+    match underline.style {
+        UnderlineStyle::Solid => sink.fill_rect(bar, color, transform),
+        UnderlineStyle::Dashed => {
+            let period = UNDERLINE_DASH + UNDERLINE_GAP;
+            let end_x = bar.x + bar.width;
+            let mut x = bar.x;
+            while x < end_x {
+                let w = UNDERLINE_DASH.min(end_x - x);
+                sink.fill_rect(Rect::from_xywh(x, bar.y, w, thickness), color, transform);
+                x += period;
+            }
+        }
+        UnderlineStyle::Wavy => {
+            let amplitude = UNDERLINE_WAVE_AMPLITUDE;
+            let period = UNDERLINE_WAVE_PERIOD;
+            let mid_y = rect.y + rect.height - amplitude;
+            let end_x = rect.x + rect.width;
+            let mut elements = Vec::new();
+            elements.push(PathElement::MoveTo {
+                x: rect.x,
+                y: mid_y,
+            });
+            let mut x = rect.x;
+            let mut up = true;
+            while x < end_x {
+                let next_x = (x + period * 0.5).min(end_x);
+                let cp_x = (x + next_x) * 0.5;
+                let cp_y = if up {
+                    mid_y - amplitude
+                } else {
+                    mid_y + amplitude
+                };
+                elements.push(PathElement::QuadTo {
+                    x1: cp_x,
+                    y1: cp_y,
+                    x: next_x,
+                    y: mid_y,
+                });
+                x = next_x;
+                up = !up;
+            }
+            let path = Path { elements };
+            let stroke = Stroke::new(thickness);
+            sink.stroke_path(&path, color, &stroke, transform);
+        }
+    }
 }
 
 pub struct Renderer {
@@ -393,17 +460,13 @@ impl Renderer {
         }
     }
 
-    fn resolve_mark(&self, data: &MarkData, theme: &Theme) -> MarkStyle {
+    fn resolve_mark_color(&self, data: &MarkData, theme: &Theme) -> Option<Color> {
         match data {
-            MarkData::Selection { focused } => MarkStyle {
-                color: selection_mark_color(theme, *focused),
-            },
-            MarkData::Composition => MarkStyle {
-                color: theme.color("ui.text.default"),
-            },
-            MarkData::DropIndicator => MarkStyle {
-                color: theme.color("selection"),
-            },
+            MarkData::Selection { focused } => Some(selection_mark_color(theme, *focused)),
+            MarkData::Composition => Some(theme.color("ui.text.default")),
+            MarkData::DropIndicator => Some(theme.color("selection")),
+            MarkData::TrackedBackground { theme_key } => Some(theme.color(theme_key)),
+            MarkData::TrackedUnderline { .. } => None,
         }
     }
 
@@ -421,12 +484,20 @@ impl Renderer {
             if mark.data.layer() != layer {
                 continue;
             }
-            let style = self.resolve_mark(&mark.data, theme);
             for rect in &mark.rects {
                 if rect.page_idx != page_idx {
                     continue;
                 }
-                sink.fill_rect(rect.rect, style.color, transform);
+                match &mark.data {
+                    MarkData::TrackedUnderline { underline } => {
+                        draw_underline(sink, rect.rect, underline, theme, transform);
+                    }
+                    _ => {
+                        if let Some(color) = self.resolve_mark_color(&mark.data, theme) {
+                            sink.fill_rect(rect.rect, color, transform);
+                        }
+                    }
+                }
             }
         }
     }
@@ -1361,8 +1432,8 @@ mod tests {
 
         assert_eq!(
             renderer
-                .resolve_mark(&MarkData::DropIndicator, &theme)
-                .color,
+                .resolve_mark_color(&MarkData::DropIndicator, &theme)
+                .unwrap(),
             theme.color("selection")
         );
     }

--- a/crates/editor-view/src/view.rs
+++ b/crates/editor-view/src/view.rs
@@ -14,7 +14,7 @@ use crate::page::LayoutPage;
 use crate::paginate::{LayoutTree, Paginator};
 use crate::query;
 use crate::query::{CursorMetrics, PointerStyle, SelectionEndpoints, SelectionRect};
-use crate::view_state::{GapPhantom, PendingStyle, ViewState};
+use crate::view_state::{GapPhantom, GroupDecoration, PendingStyle, ViewState};
 use crate::viewport::Viewport;
 
 const CONTINUOUS_MARGIN_X: f32 = 20.0;
@@ -510,6 +510,29 @@ impl View {
 
     pub fn clear_preferred_x(&mut self) {
         self.view_state.preferred_x = None;
+    }
+
+    pub fn set_group_decoration(&mut self, group: String, decoration: GroupDecoration) {
+        self.view_state
+            .tracked_decoration_groups
+            .insert(group, decoration);
+    }
+
+    pub fn remove_group_decoration(&mut self, group: &str) -> bool {
+        self.view_state
+            .tracked_decoration_groups
+            .remove(group)
+            .is_some()
+    }
+
+    pub fn would_set_group_decoration(&self, group: &str, decoration: &GroupDecoration) -> bool {
+        self.view_state.tracked_decoration_groups.get(group) != Some(decoration)
+    }
+
+    pub fn would_remove_group_decoration(&self, group: &str) -> bool {
+        self.view_state
+            .tracked_decoration_groups
+            .contains_key(group)
     }
 
     pub fn preferred_x(&self) -> Option<f32> {

--- a/crates/editor-view/src/view_state.rs
+++ b/crates/editor-view/src/view_state.rs
@@ -1,3 +1,4 @@
+use editor_common::DecorationStyle;
 use editor_model::NodeId;
 use editor_state::PendingModifiers;
 use hashbrown::HashMap;
@@ -19,6 +20,12 @@ pub struct GapPhantom {
     pub index: usize,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct GroupDecoration {
+    pub style: DecorationStyle,
+    pub enabled: bool,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct ViewState {
     pub fold_states: HashMap<NodeId, bool>,
@@ -26,6 +33,7 @@ pub struct ViewState {
     pub preferred_x: Option<f32>,
     pub pending_style: Option<PendingStyle>,
     pub gap_phantom: Option<GapPhantom>,
+    pub tracked_decoration_groups: HashMap<String, GroupDecoration>,
 }
 
 impl ViewState {
@@ -39,6 +47,10 @@ impl ViewState {
 
     pub fn external_height(&self, node_id: NodeId) -> Option<f32> {
         self.external_heights.get(&node_id).copied()
+    }
+
+    pub fn group_decoration(&self, group: &str) -> Option<&GroupDecoration> {
+        self.tracked_decoration_groups.get(group)
     }
 }
 


### PR DESCRIPTION
 tracked range 그룹 별 시각 스타일을 입혀서 화면에 그리는 경로를 추가했습니다. 외부 source(맞춤법 검사, AI 피드백 등)가 등록한 range를 점선 밑줄 / 배경색으로 표시할 수 있게 됩니다.

- **스타일 범위**
  - 그룹별 — `set_group_decoration(group, style, enabled)`. 같은 그룹 모든 range는 같은 모양 
- **스타일 위치**
  - `ViewState.tracked_decoration_groups` — `fold_states`와 같은 view 사이드 데이터
- **스타일 표현**
  - `DecorationStyle { background: Option<Color>, underline: Option<Underline> }`. 배경만 / 밑줄만 / 둘다 모두 표현
- **Underline 종류**
  - `Solid`, `Dashed`. 점선은 기존 테이블 border 방식(loop `fill_rect`) 재사용
- **Mark 분할**
  - 배경은 `MarkLayer::BelowContent` (텍스트 뒤), 밑줄은 `MarkLayer::AboveContent` (텍스트 위) — selection과 composition이 따르는 기존 패턴
- **위치 추적**
  - 매 프레임 `StableSelection.thaw` — TR-179 인프라 그대로 활용. dirty tracking 불필요
- **invalid 처리**
  - mark 수집 단계에서 group 미등록 / `!enabled` / `explicitly_invalid` / `is_collapsed` / endpoints 없음 5단계 필터
- **색상 표현**
  - `Color { r, g, b, a }` 직접 RGBA.