### PR TITLE
TR-185 이미지 업로드 중일 때, 완료 후가 같은 폭으로 렌더링 되도록 수정

### DIFF
--- a/apps/website/src/lib/editor-ffi/components/ExternalImage.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ExternalImage.svelte
@@ -12,7 +12,7 @@
   import Trash2Icon from '~icons/lucide/trash-2';
   import { getEditorContext } from '../editor.svelte';
   import {
-    calculateImageHeight,
+    calculateImageContainerSize,
     calculateImageWidth,
     createDeleteNodeMessage,
     createSetImageAttrsMessage,
@@ -51,7 +51,14 @@
   const originalWidth = $derived(asset?.width ?? inflight?.width ?? 0);
   const originalHeight = $derived(asset?.height ?? inflight?.height ?? 0);
   const liveWidth = $derived(calculateImageWidth(element.bounds.width, proportion, originalWidth));
-  const liveHeight = $derived(calculateImageHeight(liveWidth, originalWidth, originalHeight));
+  const containerSize = $derived(
+    calculateImageContainerSize({
+      boundsWidth: element.bounds.width,
+      proportion,
+      originalWidth,
+      originalHeight,
+    }),
+  );
   const canEdit = $derived(!ctx.editor?.readOnly);
 
   const { anchor, floating } = createFloatingActions({
@@ -278,8 +285,8 @@
 <ExternalElementWrapper {element} minHeight={stage === 'ready' ? undefined : '48px'}>
   <div
     bind:this={containerEl}
-    style:width={stage === 'ready' ? `${liveWidth}px` : '100%'}
-    style:height={stage === 'ready' ? `${liveHeight}px` : undefined}
+    style:width={containerSize.width}
+    style:height={containerSize.height}
     class={cx('group', css({ position: 'relative', margin: '[0 auto]' }))}
     ondragovercapture={handleDragOver}
     ondropcapture={handleDrop}

--- a/apps/website/src/lib/editor-ffi/handlers/image-flow.test.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/image-flow.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  calculateImageContainerSize,
   calculateImageHeight,
   calculateImageWidth,
   createDeleteNodeMessage,
@@ -160,5 +161,34 @@ describe('v2 image resize calculations', () => {
 
   it('does not render wider than the original image', () => {
     expect(calculateImageWidth(800, 100, 320)).toBe(320);
+  });
+
+  it('이미지 치수를 알게 된 뒤에는 업로드 중과 완료 후에 같은 폭 제한 정책을 사용한다', () => {
+    const uploading = calculateImageContainerSize({
+      boundsWidth: 800,
+      proportion: 100,
+      originalWidth: 320,
+      originalHeight: 240,
+    });
+    const ready = calculateImageContainerSize({
+      boundsWidth: 800,
+      proportion: 100,
+      originalWidth: 320,
+      originalHeight: 240,
+    });
+
+    expect(uploading).toEqual({ width: '320px', height: '240px' });
+    expect(ready).toEqual(uploading);
+  });
+
+  it('이미지 치수를 아직 모를 때만 전체 폭으로 폴백한다', () => {
+    expect(
+      calculateImageContainerSize({
+        boundsWidth: 800,
+        proportion: 100,
+        originalWidth: 0,
+        originalHeight: 0,
+      }),
+    ).toEqual({ width: '100%', height: undefined });
   });
 });

--- a/apps/website/src/lib/editor-ffi/handlers/image-flow.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/image-flow.ts
@@ -57,6 +57,26 @@ export const calculateImageHeight = (width: number, originalWidth: number, origi
   return width * (originalHeight / originalWidth);
 };
 
+export const calculateImageContainerSize = ({
+  boundsWidth,
+  proportion,
+  originalWidth,
+  originalHeight,
+}: {
+  boundsWidth: number;
+  proportion: number;
+  originalWidth: number;
+  originalHeight: number;
+}): { width: string; height: string | undefined } => {
+  if (originalWidth <= 0 || originalHeight <= 0) {
+    return { width: '100%', height: undefined };
+  }
+
+  const width = calculateImageWidth(boundsWidth, proportion, originalWidth);
+  const height = calculateImageHeight(width, originalWidth, originalHeight);
+  return { width: `${width}px`, height: `${height}px` };
+};
+
 export const processImageUpload = async ({
   file,
   nodeId,


### PR DESCRIPTION
이미지 컨테이너 크기 계산 규칙을 한 곳으로 정리했습니다.   
이제 이미지 크기를 알 수 있는 시점부터는 업로드 중과 업로드 완료 후가 같은 기준으로 폭과 높이를 계산합니다.   
크기를 아직 알 수 없는 아주 초기 상태에서만 기존처럼 전체 폭 기준 표시를 유지합니다.

테스트도 보강했습니다. 이미지 크기를 알 수 있을 때 업로드 중과 완료 후의 계산 결과가 같아지는지,   
그리고 크기를 아직 모를 때만 기존 표시 방식이 적용되는지를 검증하도록 추가했습니다.