### PR TITLE
문서 시작 또는 끝에 DnD drop 가능

### DIFF
--- a/crates/editor-view/src/query/dnd.rs
+++ b/crates/editor-view/src/query/dnd.rs
@@ -30,8 +30,10 @@ fn dnd_position(hit: &HitTester<'_>, doc: &Doc, source: Option<&Selection>) -> O
     let position = if let Some(position) = hit.block_gap_position(doc) {
         promote_block_container_edge_position(doc, position).unwrap_or(position)
     } else {
-        hit.hit_extending_selection()
-            .map(|selection| selection.head)?
+        let target_x = hit.target_x();
+        hit.exact_target()
+            .or_else(|| hit.closest_target())
+            .map(|target| target.selection(target_x).head)?
     };
 
     if let Some(source) = source
@@ -288,6 +290,48 @@ mod tests {
             }
             other => panic!("expected inline indicator, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn dnd_hit_test_page_top_margin_returns_root_start_block_position() {
+        let (doc,) = doc! {
+            root { paragraph { text("hello") } }
+        };
+        let mut view = View::new_test();
+        view.layout(&doc);
+
+        let target = view
+            .drop_target_at(&doc, 0, 40.0, 0.0, None)
+            .expect("page top margin should be a root start drop target");
+
+        assert_eq!(target.position, Position::new(NodeId::ROOT, 0));
+        match target.indicator {
+            crate::DropIndicator::Block { page_idx, y, .. } => {
+                assert_eq!(page_idx, 0);
+                assert_eq!(y, 20.0);
+            }
+            other => panic!("expected block indicator, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dnd_hit_test_page_bottom_margin_returns_root_end_block_position() {
+        let (doc,) = doc! {
+            root { paragraph { text("hello") } }
+        };
+        let mut view = View::new_test();
+        view.layout(&doc);
+        let page_bottom = view.pages()[0].size.height;
+
+        let target = view
+            .drop_target_at(&doc, 0, 40.0, page_bottom, None)
+            .expect("page bottom margin should be a root end drop target");
+
+        assert_eq!(target.position, Position::new(NodeId::ROOT, 1));
+        assert!(matches!(
+            target.indicator,
+            crate::DropIndicator::Block { page_idx: 0, .. }
+        ));
     }
 
     #[test]

--- a/crates/editor-view/src/query/hit_test/hit.rs
+++ b/crates/editor-view/src/query/hit_test/hit.rs
@@ -56,45 +56,17 @@ impl<'a> HitTester<'a> {
         }
     }
 
-    /// Exact target classification used by click/pointer policies before each
-    /// caller maps the target to a selection or cursor style.
+    /// Exact target classification used by click/pointer policies.
     pub(crate) fn exact_target(&self) -> Option<HitTarget<'a>> {
         let (root, x) = self.target_root_and_x();
         exact_hit_target(root, x, self.y)
     }
 
-    /// Exact hit: returns a selection only at a precise coordinate on a navigable node.
-    pub(crate) fn exact_selection(&self) -> Option<Selection> {
-        let (root, x) = self.target_root_and_x();
-        exact_hit_target(root, x, self.y).map(|target| target.selection(x))
-    }
-
-    /// Closest hit: returns the nearest navigable by euclidean edge distance,
-    /// restricted to navigables owned by the current page by `rect.y` range.
-    pub(crate) fn closest_selection(&self) -> Option<Selection> {
+    /// Closest navigable target by euclidean edge distance, restricted to
+    /// navigables owned by the current page by `rect.y` range.
+    pub(crate) fn closest_target(&self) -> Option<HitTarget<'a>> {
         let (root, x) = self.target_root_and_x();
         closest_target(root, x, self.y, self.page.y_start, self.page.y_end)
-            .map(|target| target.selection(x))
-    }
-
-    /// Extending variant: when the click fully escapes a monolithic ancestor's
-    /// vertical range, promote the head to that container's slot boundary so the
-    /// drag/shift-extend can select the container as a unit. Plain
-    /// non-extending hit testing must use the exact/closest path instead.
-    pub(crate) fn closest_extending_selection(&self) -> Option<Selection> {
-        let (root, x) = self.target_root_and_x();
-        let target = closest_target(root, x, self.y, self.page.y_start, self.page.y_end)?;
-        if let Some(promoted) = promote_outside_y(&self.tree.root, target.node(), self.y) {
-            return Some(Selection::collapsed(promoted));
-        }
-        Some(target.selection(x))
-    }
-
-    /// Exact hit first, then the extending closest fallback used by drag-style
-    /// hit tests.
-    pub(crate) fn hit_extending_selection(&self) -> Option<Selection> {
-        self.exact_selection()
-            .or_else(|| self.closest_extending_selection())
     }
 
     /// Returns a block insertion position only when the point falls in a
@@ -105,6 +77,14 @@ impl<'a> HitTester<'a> {
             BlockGapSearch::Hit(position) => Some(position),
             BlockGapSearch::Blocked | BlockGapSearch::Miss => None,
         }
+    }
+
+    pub(crate) fn document_y(&self) -> f32 {
+        self.y
+    }
+
+    pub(crate) fn target_x(&self) -> f32 {
+        self.target_root_and_x().1
     }
 
     /// Confine row-like scopes, such as table cells, before hit policy runs.
@@ -280,16 +260,21 @@ fn collect_box_path_at<'a>(
     true
 }
 
-/// Search for a block gap inside the containing branch. Text and atom hits
-/// block gap placement; scope boxes confine the search.
+/// Search for a block gap in the active branch. Points above or below the
+/// branch still resolve to its first/last structural slot, matching DnD's page
+/// margin behavior; text and atom hits block gap placement.
 fn block_gap_in_node(node: &LayoutNode, doc: &Doc, x: f32, y: f32) -> BlockGapSearch {
-    if !node.rect.contains(x, y) {
-        return BlockGapSearch::Miss;
-    }
-
     let LayoutContent::Box(b) = &node.content else {
         return BlockGapSearch::Blocked;
     };
+
+    if !node.rect.contains(x, y) {
+        if y < node.rect.y || y > node.rect.bottom() {
+            return block_gap_between_direct_children(b, doc, y)
+                .map_or(BlockGapSearch::Miss, BlockGapSearch::Hit);
+        }
+        return BlockGapSearch::Miss;
+    }
 
     for child in &b.children {
         if !child.rect.contains(x, y) {
@@ -441,109 +426,6 @@ fn nearest_scope_in_row<'a>(node: &'a LayoutNode, x: f32, y: f32) -> Option<&'a 
 
 fn rect_area(rect: &Rect) -> f32 {
     rect.width * rect.height
-}
-
-/// When the click sits outside the vertical range of `leaf`'s monolithic
-/// ancestor boxes, snap the head up the structural ancestry to the slot
-/// boundary of the outermost monolithic box the click fully escaped. Above
-/// the box -> its Front slot `(parent, idx)`; below -> its Back slot
-/// `(parent, idx + 1)`. Without this, dragging the selection past a
-/// monolithic container stalls at the container's innermost text position,
-/// making it impossible to select the container as a unit.
-///
-/// The returned affinity points at the box the user is interacting with:
-/// `above` returns Downstream (the slot points forward at the box being
-/// approached); `below` returns Upstream (the slot points back at the box just
-/// crossed). When surrounding normalize/unit logic resolves the slot to an
-/// adjacent child via affinity, this consistently picks the box involved in
-/// the gesture instead of the unrelated next sibling.
-///
-/// Only a true escape into the gutter promotes when escaping above the box.
-/// The inter-block gap directly above the box belongs to the approach toward
-/// the box, not an escape past it: `closest_target` can pick the box's own
-/// leading text there, and that text caret, not a unit promotion, is the
-/// intended drag-extend target. So above promotion requires the click to be
-/// past the previous sibling too, or there to be no previous sibling at all.
-/// The below direction needs no such guard: once the click is past the box's
-/// bottom, `closest_target` resolves to the next sibling's text rather than
-/// back into the box.
-fn promote_outside_y(root: &LayoutNode, leaf: &LayoutNode, click_y: f32) -> Option<Position> {
-    let mut path: Vec<(&LayoutNode, usize)> = Vec::new();
-    if !build_path(root, leaf, &mut path) {
-        return None;
-    }
-    for k in 1..path.len() {
-        let ancestor = path[k].0;
-        let LayoutContent::Box(ancestor_box) = &ancestor.content else {
-            continue;
-        };
-        if !ancestor_box.style.monolithic {
-            continue;
-        }
-        let above = click_y < ancestor.rect.y;
-        let below = click_y >= ancestor.rect.y + ancestor.rect.height;
-        if above || below {
-            let (parent_box_node, idx) = path[k - 1];
-            if above
-                && idx > 0
-                && let Some(prev) = nth_content_child(parent_box_node, idx - 1)
-                && click_y >= prev.rect.y + prev.rect.height
-            {
-                continue;
-            }
-            if let LayoutContent::Box(parent_box) = &parent_box_node.content {
-                let (slot, affinity) = if below {
-                    (idx + 1, Affinity::Upstream)
-                } else {
-                    (idx, Affinity::Downstream)
-                };
-                return Some(Position {
-                    node_id: parent_box.node_id,
-                    offset: slot,
-                    affinity,
-                });
-            }
-        }
-    }
-    None
-}
-
-/// The `n`-th non-spacing child of `parent`, matching the content indexing
-/// that `build_path` uses (`Spacing` children are skipped there too).
-fn nth_content_child(parent: &LayoutNode, n: usize) -> Option<&LayoutNode> {
-    let LayoutContent::Box(b) = &parent.content else {
-        return None;
-    };
-    b.children
-        .iter()
-        .filter(|c| !matches!(c.content, LayoutContent::Spacing(_)))
-        .nth(n)
-}
-
-fn build_path<'a>(
-    node: &'a LayoutNode,
-    target: &LayoutNode,
-    path: &mut Vec<(&'a LayoutNode, usize)>,
-) -> bool {
-    if std::ptr::eq(node, target) {
-        return true;
-    }
-    let LayoutContent::Box(b) = &node.content else {
-        return false;
-    };
-    let mut content_idx = 0usize;
-    for child in &b.children {
-        if matches!(child.content, LayoutContent::Spacing(_)) {
-            continue;
-        }
-        path.push((node, content_idx));
-        if build_path(child, target, path) {
-            return true;
-        }
-        path.pop();
-        content_idx += 1;
-    }
-    false
 }
 
 fn navigate_to_line(line: &LayoutLine, rect: &Rect, x: f32) -> Selection {

--- a/crates/editor-view/src/query/hit_test/tests.rs
+++ b/crates/editor-view/src/query/hit_test/tests.rs
@@ -1,36 +1,12 @@
 use super::*;
 
 use editor_common::Rect;
-use editor_state::Selection;
 
 use crate::page::LayoutPage;
 use crate::paginate::*;
 
-fn exact_hit_test(tree: &LayoutTree, page: &LayoutPage, x: f32, page_y: f32) -> Option<Selection> {
-    HitTester::for_page(tree, page, x, page_y).exact_selection()
-}
-
-fn closest_hit_test(
-    tree: &LayoutTree,
-    page: &LayoutPage,
-    x: f32,
-    page_y: f32,
-) -> Option<Selection> {
-    HitTester::for_page(tree, page, x, page_y).closest_selection()
-}
-
-fn closest_hit_test_extending(
-    tree: &LayoutTree,
-    page: &LayoutPage,
-    x: f32,
-    page_y: f32,
-) -> Option<Selection> {
-    HitTester::for_page(tree, page, x, page_y).closest_extending_selection()
-}
-
 use crate::glyph_run::{GlyphRun, GraphemeSpan};
 use crate::style::*;
-use crate::view::View;
 use editor_common::EdgeInsets;
 use editor_macros::doc;
 use editor_model::NodeId;
@@ -147,7 +123,8 @@ fn exact_hit_on_line() {
     };
     let page = make_page(0.0, 100.0);
 
-    let sel = exact_hit_test(&tree, &page, 25.0, 5.0).unwrap();
+    let hit = HitTester::for_page(&tree, &page, 25.0, 5.0);
+    let sel = hit.exact_target().unwrap().selection(hit.target_x());
     assert!(sel.is_collapsed());
     assert_eq!(sel.head.node_id, id);
 }
@@ -174,7 +151,8 @@ fn exact_hit_on_spacing_returns_none() {
     let page = make_page(0.0, 100.0);
 
     // Click in the spacing area (y=25)
-    assert!(exact_hit_test(&tree, &page, 5.0, 25.0).is_none());
+    let hit = HitTester::for_page(&tree, &page, 5.0, 25.0);
+    assert!(hit.exact_target().is_none());
 }
 
 #[test]
@@ -201,7 +179,8 @@ fn closest_hit_on_spacing_returns_nearest_line() {
     let page = make_page(0.0, 100.0);
 
     // Click in spacing (y=25) -- should find closest line
-    let sel = closest_hit_test(&tree, &page, 5.0, 25.0).unwrap();
+    let hit = HitTester::for_page(&tree, &page, 5.0, 25.0);
+    let sel = hit.closest_target().unwrap().selection(hit.target_x());
     assert!(sel.is_collapsed());
     // Should be id1 (closer: line1 bottom at 20, dist=5; line2 top at 36, dist=11)
     assert_eq!(sel.head.node_id, id1);
@@ -223,8 +202,71 @@ fn closest_hit_in_margin_returns_nearest() {
     let page = make_page(0.0, 200.0);
 
     // Click in margin area (x=5, y=5) -- outside all boxes
-    let sel = closest_hit_test(&tree, &page, 5.0, 5.0).unwrap();
+    let hit = HitTester::for_page(&tree, &page, 5.0, 5.0);
+    let sel = hit.closest_target().unwrap().selection(hit.target_x());
     assert_eq!(sel.head.node_id, id);
+}
+
+#[test]
+fn block_gap_above_root_content_returns_root_start() {
+    let (doc, p1, p2) = doc! {
+        root {
+            p1: paragraph {}
+            p2: paragraph {}
+        }
+    };
+    let tree = LayoutTree {
+        root: make_box_node(
+            NodeId::ROOT,
+            0.0,
+            20.0,
+            200.0,
+            80.0,
+            vec![
+                make_box_node(p1, 0.0, 20.0, 200.0, 20.0, vec![]),
+                make_box_node(p2, 0.0, 60.0, 200.0, 20.0, vec![]),
+            ],
+        ),
+    };
+    let page = make_page(0.0, 120.0);
+
+    let hit = HitTester::for_page(&tree, &page, 10.0, 0.0);
+
+    assert_eq!(
+        hit.block_gap_position(&doc),
+        Some(Position::new(NodeId::ROOT, 0))
+    );
+}
+
+#[test]
+fn block_gap_below_root_content_returns_root_end() {
+    let (doc, p1, p2) = doc! {
+        root {
+            p1: paragraph {}
+            p2: paragraph {}
+        }
+    };
+    let tree = LayoutTree {
+        root: make_box_node(
+            NodeId::ROOT,
+            0.0,
+            20.0,
+            200.0,
+            80.0,
+            vec![
+                make_box_node(p1, 0.0, 20.0, 200.0, 20.0, vec![]),
+                make_box_node(p2, 0.0, 60.0, 200.0, 20.0, vec![]),
+            ],
+        ),
+    };
+    let page = make_page(0.0, 120.0);
+
+    let hit = HitTester::for_page(&tree, &page, 10.0, 120.0);
+
+    assert_eq!(
+        hit.block_gap_position(&doc),
+        Some(Position::new(NodeId::ROOT, 2))
+    );
 }
 
 #[test]
@@ -253,7 +295,8 @@ fn closest_hit_below_paragraph_returns_last_line() {
     let page = make_page(0.0, 200.0);
 
     // Click at y=100, well below paragraph (ends at y=60).
-    let sel = closest_hit_test(&tree, &page, 5.0, 100.0).unwrap();
+    let hit = HitTester::for_page(&tree, &page, 5.0, 100.0);
+    let sel = hit.closest_target().unwrap().selection(hit.target_x());
     assert_eq!(sel.head.node_id, line3);
 }
 
@@ -297,32 +340,13 @@ fn closest_hit_stays_within_page() {
     };
     let page_0 = make_page(0.0, 1123.0);
 
-    let sel = closest_hit_test(&tree, &page_0, 5.0, 1000.0).unwrap();
+    let hit = HitTester::for_page(&tree, &page_0, 5.0, 1000.0);
+    let sel = hit.closest_target().unwrap().selection(hit.target_x());
     assert_eq!(sel.head.node_id, id_p0);
 }
 
 #[test]
-fn extending_drag_above_top_promotes_to_front_slot() {
-    let (doc,) = doc! {
-        root {
-            fold {
-                fold_title { text("title") }
-                fold_content { paragraph { text("content") } }
-            }
-            paragraph {}
-        }
-    };
-    let mut view = View::new_test();
-    view.layout(&doc);
-
-    let sel = view.hit_test_extending(0, 20.0, -100.0).unwrap();
-    assert!(sel.is_collapsed());
-    assert_eq!(sel.head.node_id, NodeId::ROOT);
-    assert_eq!(sel.head.offset, 0, "above-top escape → Front slot (idx)");
-}
-
-#[test]
-fn exact_hit_in_monolithic_box_returns_leaf_while_closest_above_promotes() {
+fn exact_hit_in_monolithic_box_returns_leaf() {
     let line_id = NodeId::new();
     let line = make_line_node(line_id, 0.0, 100.0, "hello", 10.0);
     let mono = LayoutNode {
@@ -349,83 +373,12 @@ fn exact_hit_in_monolithic_box_returns_leaf_while_closest_above_promotes() {
     };
     let page = make_page(0.0, 200.0);
 
-    let exact = exact_hit_test(&tree, &page, 25.0, 110.0).unwrap();
+    let hit = HitTester::for_page(&tree, &page, 25.0, 110.0);
+    let exact = hit.exact_target().unwrap().selection(hit.target_x());
     assert!(exact.is_collapsed());
     assert_eq!(
         exact.head.node_id, line_id,
         "exact hit inside a monolithic box must return the text leaf"
-    );
-
-    let promoted = closest_hit_test_extending(&tree, &page, 25.0, -50.0).unwrap();
-    assert!(promoted.is_collapsed());
-    assert_eq!(
-        promoted.head.node_id,
-        NodeId::ROOT,
-        "above the monolithic box, the extending closest path must promote"
-    );
-    assert_eq!(promoted.head.offset, 0);
-}
-
-#[test]
-fn extending_drag_below_bottom_promotes_to_back_slot() {
-    let (doc,) = doc! {
-        root {
-            paragraph {}
-            fold {
-                fold_title { text("title") }
-                fold_content { paragraph { text("content") } }
-            }
-        }
-    };
-    let mut view = View::new_test();
-    view.layout(&doc);
-
-    let sel = view.hit_test_extending(0, 20.0, 99999.0).unwrap();
-    assert!(sel.is_collapsed());
-    assert_eq!(sel.head.node_id, NodeId::ROOT);
-    assert_eq!(
-        sel.head.offset, 2,
-        "below-bottom escape → Back slot (idx+1)"
-    );
-}
-
-#[test]
-fn plain_hit_test_in_gutter_does_not_promote() {
-    let (doc,) = doc! {
-        root {
-            fold {
-                fold_title { text("title") }
-                fold_content { paragraph { text("content") } }
-            }
-            paragraph {}
-        }
-    };
-    let mut view = View::new_test();
-    view.layout(&doc);
-
-    let sel = view.hit_test(0, 20.0, -100.0).unwrap();
-    assert!(sel.is_collapsed());
-    assert_ne!(
-        sel.head.node_id,
-        NodeId::ROOT,
-        "plain Down must not promote; head stays on nearest text leaf"
-    );
-    let ft_text = doc
-        .node(NodeId::ROOT)
-        .unwrap()
-        .children()
-        .next()
-        .unwrap() // fold
-        .children()
-        .next()
-        .unwrap() // fold_title
-        .children()
-        .next()
-        .unwrap() // text("title")
-        .id();
-    assert_eq!(
-        sel.head.node_id, ft_text,
-        "plain Down must land on the nearest text leaf (fold_title text), not promote"
     );
 }
 
@@ -502,7 +455,8 @@ fn hit_test_in_empty_trailing_line_returns_paragraph_offset() {
         y_end: 800.0,
         size: Size::new(200.0, 800.0),
     };
-    let sel = closest_hit_test(&tree, &page, 50.0, 30.0).unwrap();
+    let hit = HitTester::for_page(&tree, &page, 50.0, 30.0);
+    let sel = hit.closest_target().unwrap().selection(hit.target_x());
     assert_eq!(sel.head.node_id, p1);
     assert_eq!(sel.head.offset, 2);
 }
@@ -524,11 +478,13 @@ fn click_left_of_line_goes_to_start() {
     let page = make_page(0.0, 100.0);
 
     // Click at x=5 (left margin, before line x=20)
-    let sel = exact_hit_test(&tree, &page, 5.0, 5.0);
+    let hit = HitTester::for_page(&tree, &page, 5.0, 5.0);
+    let sel = hit.exact_target();
     // exact misses (x=5 is outside line rect at x=20)
     assert!(sel.is_none());
     // closest finds the line, cursor should be at offset 0 (start)
-    let sel = closest_hit_test(&tree, &page, 5.0, 5.0).unwrap();
+    let hit = HitTester::for_page(&tree, &page, 5.0, 5.0);
+    let sel = hit.closest_target().unwrap().selection(hit.target_x());
     assert_eq!(sel.head.node_id, id);
     assert_eq!(sel.head.offset, 0);
 }
@@ -550,7 +506,8 @@ fn exact_hit_on_atom_node_selects_atom() {
     };
     let page = make_page(0.0, 100.0);
     // page-local (50,20) → abs (50,20) ∈ atom rect (10..110, 0..40).
-    let sel = exact_hit_test(&tree, &page, 50.0, 20.0).unwrap();
+    let hit = HitTester::for_page(&tree, &page, 50.0, 20.0);
+    let sel = hit.exact_target().unwrap().selection(hit.target_x());
     assert!(
         !sel.is_collapsed(),
         "click on atom must node-select, got {:?}",
@@ -630,7 +587,10 @@ fn closest_hit_in_table_row_side_margin_stays_in_nearest_cell_scope() {
     };
     let page = make_page(0.0, 100.0);
 
-    let sel = closest_hit_test(&tree, &page, 290.0, 20.0)
+    let hit = HitTester::for_page(&tree, &page, 290.0, 20.0);
+    let sel = hit
+        .closest_target()
+        .map(|target| target.selection(hit.target_x()))
         .expect("same-row side margin should resolve into a table cell scope");
 
     assert_eq!(sel.head.node_id, right_p);

--- a/crates/editor-view/src/query/mod.rs
+++ b/crates/editor-view/src/query/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod pointer_style;
 pub(crate) mod search;
 pub(crate) mod segmentation;
 pub(crate) mod selection;
+pub(crate) mod selection_drag;
 mod visit;
 
 pub use composition::CompositionRect;

--- a/crates/editor-view/src/query/selection_drag.rs
+++ b/crates/editor-view/src/query/selection_drag.rs
@@ -1,0 +1,123 @@
+use editor_state::{Affinity, Position, Selection};
+
+use crate::paginate::{LayoutContent, LayoutNode};
+
+use super::hit_test::HitTarget;
+
+pub(crate) fn selection_from_closest_target(
+    root: &LayoutNode,
+    target: HitTarget<'_>,
+    x: f32,
+    y: f32,
+) -> Selection {
+    if let Some(promoted) = promote_outside_monolithic_y(root, target.node(), y) {
+        return Selection::collapsed(promoted);
+    }
+    target.selection(x)
+}
+
+/// When the click sits outside the vertical range of `leaf`'s monolithic
+/// ancestor boxes, snap the head up the structural ancestry to the slot
+/// boundary of the outermost monolithic box the click fully escaped. Above
+/// the box -> its Front slot `(parent, idx)`; below -> its Back slot
+/// `(parent, idx + 1)`. Without this, dragging the selection past a
+/// monolithic container stalls at the container's innermost text position,
+/// making it impossible to select the container as a unit.
+///
+/// The returned affinity points at the box the user is interacting with:
+/// `above` returns Downstream (the slot points forward at the box being
+/// approached); `below` returns Upstream (the slot points back at the box just
+/// crossed). When surrounding normalize/unit logic resolves the slot to an
+/// adjacent child via affinity, this consistently picks the box involved in
+/// the gesture instead of the unrelated next sibling.
+///
+/// Only a true escape into the gutter promotes when escaping above the box.
+/// The inter-block gap directly above the box belongs to the approach toward
+/// the box, not an escape past it: closest hit can pick the box's own leading
+/// text there, and that text caret, not a unit promotion, is the intended
+/// drag-extend target. So above promotion requires the click to be past the
+/// previous sibling too, or there to be no previous sibling at all. The below
+/// direction needs no such guard: once the click is past the box's bottom,
+/// closest hit resolves to the next sibling's text rather than back into the box.
+fn promote_outside_monolithic_y(
+    root: &LayoutNode,
+    leaf: &LayoutNode,
+    click_y: f32,
+) -> Option<Position> {
+    let mut path: Vec<(&LayoutNode, usize)> = Vec::new();
+    if !build_path(root, leaf, &mut path) {
+        return None;
+    }
+    for k in 1..path.len() {
+        let ancestor = path[k].0;
+        let LayoutContent::Box(ancestor_box) = &ancestor.content else {
+            continue;
+        };
+        if !ancestor_box.style.monolithic {
+            continue;
+        }
+        let above = click_y < ancestor.rect.y;
+        let below = click_y >= ancestor.rect.y + ancestor.rect.height;
+        if above || below {
+            let (parent_box_node, idx) = path[k - 1];
+            if above
+                && idx > 0
+                && let Some(prev) = nth_content_child(parent_box_node, idx - 1)
+                && click_y >= prev.rect.y + prev.rect.height
+            {
+                continue;
+            }
+            if let LayoutContent::Box(parent_box) = &parent_box_node.content {
+                let (slot, affinity) = if below {
+                    (idx + 1, Affinity::Upstream)
+                } else {
+                    (idx, Affinity::Downstream)
+                };
+                return Some(Position {
+                    node_id: parent_box.node_id,
+                    offset: slot,
+                    affinity,
+                });
+            }
+        }
+    }
+    None
+}
+
+/// The `n`-th non-spacing child of `parent`, matching the content indexing
+/// that `build_path` uses (`Spacing` children are skipped there too).
+fn nth_content_child(parent: &LayoutNode, n: usize) -> Option<&LayoutNode> {
+    let LayoutContent::Box(b) = &parent.content else {
+        return None;
+    };
+    b.children
+        .iter()
+        .filter(|c| !matches!(c.content, LayoutContent::Spacing(_)))
+        .nth(n)
+}
+
+fn build_path<'a>(
+    node: &'a LayoutNode,
+    target: &LayoutNode,
+    path: &mut Vec<(&'a LayoutNode, usize)>,
+) -> bool {
+    if std::ptr::eq(node, target) {
+        return true;
+    }
+    let LayoutContent::Box(b) = &node.content else {
+        return false;
+    };
+    let mut content_idx = 0usize;
+    for child in &b.children {
+        if matches!(child.content, LayoutContent::Spacing(_)) {
+            continue;
+        }
+        path.push((node, content_idx));
+        if build_path(child, target, path) {
+            return true;
+        }
+        path.pop();
+        content_idx += 1;
+    }
+    false
+}

--- a/crates/editor-view/src/view.rs
+++ b/crates/editor-view/src/view.rs
@@ -212,13 +212,28 @@ impl View {
         let result = self.layout.as_ref()?;
         let page = result.pages.get(page_idx)?;
         let hit = query::HitTester::for_page(&result.tree, page, x, y);
-        hit.exact_selection().or_else(|| hit.closest_selection())
+        let target_x = hit.target_x();
+        hit.exact_target()
+            .or_else(|| hit.closest_target())
+            .map(|target| target.selection(target_x))
     }
 
     pub fn hit_test_extending(&self, page_idx: usize, x: f32, y: f32) -> Option<Selection> {
         let result = self.layout.as_ref()?;
         let page = result.pages.get(page_idx)?;
-        query::HitTester::for_page(&result.tree, page, x, y).hit_extending_selection()
+        let hit = query::HitTester::for_page(&result.tree, page, x, y);
+        let target_x = hit.target_x();
+        hit.exact_target()
+            .map(|target| target.selection(target_x))
+            .or_else(|| {
+                let target = hit.closest_target()?;
+                Some(query::selection_drag::selection_from_closest_target(
+                    &result.tree.root,
+                    target,
+                    target_x,
+                    hit.document_y(),
+                ))
+            })
     }
 
     pub fn drop_target_at(
@@ -637,6 +652,89 @@ mod tests {
         let mut view = View::new_test();
         view.layout(&doc);
         assert!(!view.pages().is_empty());
+    }
+
+    #[test]
+    fn hit_test_extending_above_top_promotes_to_front_slot() {
+        let (doc,) = doc! {
+            root {
+                fold {
+                    fold_title { text("title") }
+                    fold_content { paragraph { text("content") } }
+                }
+                paragraph {}
+            }
+        };
+        let mut view = View::new_test();
+        view.layout(&doc);
+
+        let sel = view.hit_test_extending(0, 20.0, -100.0).unwrap();
+        assert!(sel.is_collapsed());
+        assert_eq!(sel.head.node_id, NodeId::ROOT);
+        assert_eq!(sel.head.offset, 0, "above-top escape -> Front slot (idx)");
+    }
+
+    #[test]
+    fn hit_test_extending_below_bottom_promotes_to_back_slot() {
+        let (doc,) = doc! {
+            root {
+                paragraph {}
+                fold {
+                    fold_title { text("title") }
+                    fold_content { paragraph { text("content") } }
+                }
+            }
+        };
+        let mut view = View::new_test();
+        view.layout(&doc);
+
+        let sel = view.hit_test_extending(0, 20.0, 99999.0).unwrap();
+        assert!(sel.is_collapsed());
+        assert_eq!(sel.head.node_id, NodeId::ROOT);
+        assert_eq!(
+            sel.head.offset, 2,
+            "below-bottom escape -> Back slot (idx+1)"
+        );
+    }
+
+    #[test]
+    fn hit_test_in_gutter_does_not_promote() {
+        let (doc,) = doc! {
+            root {
+                fold {
+                    fold_title { text("title") }
+                    fold_content { paragraph { text("content") } }
+                }
+                paragraph {}
+            }
+        };
+        let mut view = View::new_test();
+        view.layout(&doc);
+
+        let sel = view.hit_test(0, 20.0, -100.0).unwrap();
+        assert!(sel.is_collapsed());
+        assert_ne!(
+            sel.head.node_id,
+            NodeId::ROOT,
+            "plain hit test must not promote; head stays on nearest text leaf"
+        );
+        let ft_text = doc
+            .node(NodeId::ROOT)
+            .unwrap()
+            .children()
+            .next()
+            .unwrap()
+            .children()
+            .next()
+            .unwrap()
+            .children()
+            .next()
+            .unwrap()
+            .id();
+        assert_eq!(
+            sel.head.node_id, ft_text,
+            "plain hit test must land on the nearest text leaf"
+        );
     }
 
     #[test]


### PR DESCRIPTION
- 문서 시작 또는 끝에 DnD drop 가능
- HitTester는 primitive query만 제공하고 selection drag 등 로직은 분리