### PR TITLE
feat: 찾기와 바꾸기 구현

### DIFF
--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -65,6 +65,7 @@ export class EditorContext {
   resetKey = $state<number>(0);
   pendingImageDrops: File[] = [];
   pendingFileDrops: File[] = [];
+  findReplaceOpen = $state(false);
 }
 
 const [getEditorContext, setEditorContext] = createContext<EditorContext>();
@@ -111,6 +112,10 @@ export class Editor {
   #linkHover = $state<{ link: LinkRect; page: number; clientX: number; clientY: number } | undefined>();
   #modifierHeld = $state(false);
 
+  #searchQuery = $state('');
+  #searchMatches = $state<{ id: string; selection: Selection }[]>([]);
+  #searchActiveIdx = $state<number | undefined>();
+
   imageAssets = $state(new SvelteMap<string, ImageAsset>());
   inflightImages = $state(new SvelteMap<string, { url: string; width: number; height: number }>());
 
@@ -153,6 +158,9 @@ export class Editor {
     self.on('state_changed', self.#stateChangedHandler);
     self.on('font_data_missing', fontDataMissingHandler);
     self.on('scroll', self.#scrollHandler);
+    self.on('tracked_range_replace_result', (_, { id, outcome }) => {
+      self.#handleReplaceResult(id, outcome);
+    });
 
     register(self);
 
@@ -207,6 +215,37 @@ export class Editor {
     wasm.set_theme_variant(themeVariant);
     self.enqueue({ type: 'system', event: { type: 'theme_variant_changed' } });
     self.enqueue({ type: 'system', event: { type: 'initialize' } });
+
+    self.enqueue({
+      type: 'tracked_range',
+      op: {
+        type: 'set_group_decoration',
+        group: 'search-match',
+        style: {
+          background: 'ui.search-match',
+          background_radius: 2,
+          background_inset: 2,
+          underline: undefined,
+        },
+        enabled: true,
+        z_index: 0,
+      },
+    });
+    self.enqueue({
+      type: 'tracked_range',
+      op: {
+        type: 'set_group_decoration',
+        group: 'search-match-active',
+        style: {
+          background: 'ui.search-match-active',
+          background_radius: 2,
+          background_inset: 2,
+          underline: undefined,
+        },
+        enabled: true,
+        z_index: 1,
+      },
+    });
 
     return self;
   }
@@ -608,6 +647,143 @@ export class Editor {
     return this.#wasm.copy_selection();
   }
 
+  get searchMatches(): { active: boolean }[] {
+    const matches = this.#searchMatches;
+    const active = this.#searchActiveIdx;
+    return matches.map((_, i) => ({ active: i === active }));
+  }
+
+  search(query: string, options?: { matchWholeWord?: boolean }): void {
+    const matchWholeWord = options?.matchWholeWord ?? false;
+    this.#searchQuery = query;
+
+    this.enqueue({ type: 'tracked_range', op: { type: 'clear_group', group: 'search-match' } });
+    this.enqueue({ type: 'tracked_range', op: { type: 'clear_group', group: 'search-match-active' } });
+
+    if (query.length === 0) {
+      this.#searchMatches = [];
+      this.#searchActiveIdx = undefined;
+      return;
+    }
+
+    const selections = this.#wasm.find_matches(query, { match_whole_word: matchWholeWord });
+    const matches = selections.map((selection, i) => ({ id: `search-match:${i}`, selection }));
+
+    for (const m of matches) {
+      this.enqueue({
+        type: 'tracked_range',
+        op: { type: 'add', id: m.id, group: 'search-match', selection: m.selection, metadata: '' },
+      });
+    }
+
+    this.#searchMatches = matches;
+    this.#searchActiveIdx = matches.length === 0 ? undefined : 0;
+    if (this.#searchActiveIdx !== undefined) {
+      this.#applyActiveMark();
+      this.#scrollToActiveMatch();
+    }
+  }
+
+  clearSearch(): void {
+    this.#searchQuery = '';
+    this.#searchMatches = [];
+    this.#searchActiveIdx = undefined;
+    this.enqueue({ type: 'tracked_range', op: { type: 'clear_group', group: 'search-match' } });
+    this.enqueue({ type: 'tracked_range', op: { type: 'clear_group', group: 'search-match-active' } });
+  }
+
+  findNext(): void {
+    this.#moveActive(1);
+  }
+
+  findPrevious(): void {
+    this.#moveActive(-1);
+  }
+
+  replace(replacement: string): void {
+    if (replacement.includes('\n') || replacement.includes('\r')) return;
+    if (this.#searchActiveIdx === undefined) return;
+    const match = this.#searchMatches[this.#searchActiveIdx];
+    if (!match) return;
+    this.enqueue({
+      type: 'tracked_range',
+      op: { type: 'replace_text', id: match.id, expected_text: this.#searchQuery, replacement },
+    });
+  }
+
+  replaceAll(replacement: string): void {
+    if (replacement.includes('\n') || replacement.includes('\r')) return;
+    const query = this.#searchQuery;
+    if (query.length === 0) return;
+    for (const m of this.#searchMatches) {
+      this.enqueue({
+        type: 'tracked_range',
+        op: { type: 'replace_text', id: m.id, expected_text: query, replacement },
+      });
+    }
+    this.#searchMatches = [];
+    this.#searchActiveIdx = undefined;
+    this.enqueue({ type: 'tracked_range', op: { type: 'clear_group', group: 'search-match' } });
+    this.enqueue({ type: 'tracked_range', op: { type: 'clear_group', group: 'search-match-active' } });
+  }
+
+  #moveActive(delta: number): void {
+    const len = this.#searchMatches.length;
+    if (len === 0) return;
+    const current = this.#searchActiveIdx ?? 0;
+    const next = (((current + delta) % len) + len) % len;
+    this.#searchActiveIdx = next;
+    this.#applyActiveMark();
+    this.#scrollToActiveMatch();
+  }
+
+  #applyActiveMark(): void {
+    this.enqueue({ type: 'tracked_range', op: { type: 'clear_group', group: 'search-match-active' } });
+    const idx = this.#searchActiveIdx;
+    if (idx === undefined) return;
+    const match = this.#searchMatches[idx];
+    if (!match) return;
+    this.enqueue({
+      type: 'tracked_range',
+      op: {
+        type: 'add',
+        id: `search-match-active:${match.id}`,
+        group: 'search-match-active',
+        selection: match.selection,
+        metadata: '',
+      },
+    });
+  }
+
+  #scrollToActiveMatch(): void {
+    const idx = this.#searchActiveIdx;
+    if (idx === undefined) return;
+    const match = this.#searchMatches[idx];
+    if (!match) return;
+    this.enqueue({ type: 'view', op: { type: 'scroll_into_view', target: { type: 'tracked_item', id: match.id } } });
+  }
+
+  #handleReplaceResult(id: string, outcome: string): void {
+    if (!id.startsWith('search-match:')) return;
+    if (outcome !== 'replaced') return;
+    const idx = this.#searchMatches.findIndex((m) => m.id === id);
+    if (idx === -1) return;
+    this.#searchMatches = this.#searchMatches.filter((_, i) => i !== idx);
+    this.enqueue({ type: 'tracked_range', op: { type: 'remove', id } });
+    this.enqueue({
+      type: 'tracked_range',
+      op: { type: 'remove', id: `search-match-active:${id}` },
+    });
+    const len = this.#searchMatches.length;
+    if (len === 0) {
+      this.#searchActiveIdx = undefined;
+    } else {
+      this.#searchActiveIdx = Math.min(idx, len - 1);
+      this.#applyActiveMark();
+      this.#scrollToActiveMatch();
+    }
+  }
+
   inspect(mode: 'state' | 'state-with-node-id' | 'state-as-macro') {
     const output = match(mode)
       .with('state', () => this.#wasm.inspect_state())
@@ -695,7 +871,9 @@ export class Editor {
     const container = this.scrollContainerEl;
     if (!pageEl || !container) return;
 
-    const top = pageEl.offsetTop + rect.y;
+    const pageRect = pageEl.getBoundingClientRect();
+    const containerRect = container.getBoundingClientRect();
+    const top = pageRect.top - containerRect.top + container.scrollTop + rect.y;
     const bottom = top + rect.height;
     const viewTop = container.scrollTop;
     const viewBottom = viewTop + container.clientHeight;
@@ -707,7 +885,7 @@ export class Editor {
       nextTop = bottom - container.clientHeight;
     }
     if (nextTop !== null) {
-      container.scrollTo({ top: nextTop, behavior: 'smooth' });
+      container.scrollTo({ top: Math.max(0, nextTop), behavior: 'smooth' });
     }
   };
 

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentFindReplace.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentFindReplace.svelte
@@ -1,6 +1,274 @@
 <script lang="ts">
-  // v2 FFI: find/replace 미구현 — stub
-  let { close }: { close: () => void } = $props();
+  import { css } from '@typie/styled-system/css';
+  import { center, flex } from '@typie/styled-system/patterns';
+  import { tooltip } from '@typie/ui/actions';
+  import { Icon } from '@typie/ui/components';
+  import { onMount, tick, untrack } from 'svelte';
+  import ArrowDownIcon from '~icons/lucide/arrow-down';
+  import ArrowUpIcon from '~icons/lucide/arrow-up';
+  import ReplaceIcon from '~icons/lucide/replace';
+  import ReplaceAllIcon from '~icons/lucide/replace-all';
+  import WholeWordIcon from '~icons/lucide/whole-word';
+  import XIcon from '~icons/lucide/x';
+  import { IS_MAC } from '$lib/editor-ffi/constants';
+  import { getEditorContext } from '$lib/editor-ffi/editor.svelte';
+
+  type Props = {
+    close: () => void;
+  };
+
+  let { close }: Props = $props();
+
+  const ctx = getEditorContext();
+
+  let findInputEl: HTMLInputElement;
+
+  let findText = $state('');
+  let replaceText = $state('');
+  let matchWholeWord = $state(false);
+
+  $effect(() => {
+    void findText;
+    void matchWholeWord;
+    untrack(() => {
+      ctx.editor?.search(findText, { matchWholeWord });
+    });
+  });
+
+  const handleKeydown = (e: KeyboardEvent) => {
+    if ((IS_MAC ? e.metaKey : e.ctrlKey) && e.code === 'KeyF') {
+      e.preventDefault();
+      tick().then(() => {
+        findInputEl?.select();
+      });
+      return;
+    }
+
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
+      close();
+      ctx.editor?.focus();
+    }
+  };
+
+  const handleFindKeydown = (e: KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.isComposing) {
+      if (e.shiftKey) {
+        ctx.editor?.findPrevious();
+      } else {
+        ctx.editor?.findNext();
+      }
+    }
+  };
+
+  const handleReplaceKeydown = (e: KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.isComposing) {
+      if (IS_MAC ? e.metaKey : e.ctrlKey) {
+        ctx.editor?.replaceAll(replaceText);
+      } else {
+        ctx.editor?.replace(replaceText);
+      }
+    }
+  };
+
+  onMount(() => {
+    tick().then(() => {
+      findInputEl?.select();
+    });
+
+    return () => {
+      ctx.editor?.clearSearch();
+    };
+  });
 </script>
 
-<button hidden onclick={close} type="button">×</button>
+<svelte:window onkeydown={handleKeydown} />
+
+<div
+  class={flex({
+    gap: '4px',
+    padding: '8px',
+    position: 'absolute',
+    top: '0',
+    right: '52px',
+    zIndex: 'overEditor',
+    backgroundColor: 'surface.default',
+    borderRadius: '6px',
+    boxShadow: 'small',
+  })}
+  aria-label="찾기 및 바꾸기"
+  onkeydown={handleKeydown}
+  role="dialog"
+  tabindex="-1"
+>
+  <div class={flex({ flexDirection: 'column', gap: '4px' })}>
+    <div class={css({ position: 'relative', display: 'flex', alignItems: 'center' })}>
+      <input
+        bind:this={findInputEl}
+        class={css({
+          paddingLeft: '8px',
+          paddingRight: '32px',
+          paddingY: '4px',
+          width: '200px',
+          height: '30px',
+          borderWidth: '1px',
+          borderColor: 'border.default',
+          borderRadius: '6px',
+          fontSize: '14px',
+        })}
+        aria-label="찾을 텍스트"
+        autocomplete="off"
+        onkeydown={handleFindKeydown}
+        placeholder="찾기"
+        type="text"
+        bind:value={findText}
+      />
+      <button
+        class={css({
+          position: 'absolute',
+          right: '4px',
+          size: '22px',
+          padding: '3px',
+          borderRadius: '4px',
+          color: 'text.faint',
+          backgroundColor: 'transparent',
+          _hover: { backgroundColor: 'surface.muted' },
+          _pressed: { color: 'accent.brand.default', backgroundColor: 'accent.brand.subtle' },
+          _focus: { backgroundColor: 'surface.muted' },
+        })}
+        aria-pressed={matchWholeWord}
+        onclick={() => (matchWholeWord = !matchWholeWord)}
+        tabindex={-1}
+        type="button"
+        use:tooltip={{ message: '어절 단위로 찾기' }}
+      >
+        <Icon icon={WholeWordIcon} size={16} />
+      </button>
+    </div>
+    <input
+      class={css({
+        paddingX: '8px',
+        paddingY: '4px',
+        width: '200px',
+        height: '30px',
+        borderWidth: '1px',
+        borderColor: 'border.default',
+        borderRadius: '6px',
+        fontSize: '14px',
+      })}
+      aria-label="바꿀 텍스트"
+      autocomplete="off"
+      onkeydown={handleReplaceKeydown}
+      placeholder="바꾸기"
+      type="text"
+      bind:value={replaceText}
+    />
+  </div>
+
+  <div class={flex({ flex: '1', flexDirection: 'column', gap: '4px' })}>
+    <div class={flex({ alignItems: 'center', height: '30px' })}>
+      <div class={css({ flex: '1', paddingLeft: '4px', width: '60px', fontSize: '12px', fontWeight: 'medium', color: 'text.subtle' })}>
+        {#if ctx.editor && ctx.editor.searchMatches.length > 0}
+          {ctx.editor.searchMatches.findIndex((m) => m.active) + 1} / {ctx.editor.searchMatches.length}
+        {:else}
+          결과 없음
+        {/if}
+      </div>
+
+      <div class={flex({ gap: '4px' })}>
+        <button
+          class={css({
+            size: '24px',
+            padding: '4px',
+            borderRadius: '4px',
+            color: 'text.faint',
+            _hover: { backgroundColor: 'surface.muted' },
+            _disabled: { opacity: '[0.5]', _hover: { backgroundColor: 'transparent' } },
+            _focus: { backgroundColor: 'surface.muted' },
+          })}
+          disabled={!findText}
+          onclick={() => ctx.editor?.findPrevious()}
+          type="button"
+          use:tooltip={{ message: '이전 결과 찾기', keys: ['Shift', 'Enter'] }}
+        >
+          <Icon icon={ArrowUpIcon} size={16} />
+        </button>
+        <button
+          class={center({
+            size: '24px',
+            padding: '4px',
+            borderRadius: '4px',
+            color: 'text.faint',
+            _hover: { backgroundColor: 'surface.muted' },
+            _disabled: { opacity: '[0.5]', _hover: { backgroundColor: 'transparent' } },
+            _focus: { backgroundColor: 'surface.muted' },
+          })}
+          disabled={!findText}
+          onclick={() => ctx.editor?.findNext()}
+          type="button"
+          use:tooltip={{ message: '다음 결과 찾기', keys: ['Enter'] }}
+        >
+          <Icon icon={ArrowDownIcon} size={16} />
+        </button>
+      </div>
+    </div>
+
+    <div class={flex({ alignItems: 'center', gap: '4px', height: '30px', justifyContent: 'space-between' })}>
+      <div class={flex({ alignItems: 'center', gap: '4px' })}>
+        <button
+          class={center({
+            size: '24px',
+            padding: '4px',
+            borderRadius: '4px',
+            color: 'text.faint',
+            _hover: { backgroundColor: 'surface.muted' },
+            _disabled: { opacity: '[0.5]', _hover: { backgroundColor: 'transparent' } },
+            _focus: { backgroundColor: 'surface.muted' },
+          })}
+          disabled={!findText}
+          onclick={() => ctx.editor?.replace(replaceText)}
+          type="button"
+          use:tooltip={{ message: '바꾸기', keys: ['Enter'] }}
+        >
+          <Icon icon={ReplaceIcon} size={16} />
+        </button>
+        <button
+          class={center({
+            size: '24px',
+            padding: '4px',
+            borderRadius: '4px',
+            color: 'text.faint',
+            _hover: { backgroundColor: 'surface.muted' },
+            _disabled: { opacity: '[0.5]', _hover: { backgroundColor: 'transparent' } },
+            _focus: { backgroundColor: 'surface.muted' },
+          })}
+          disabled={!findText}
+          onclick={() => ctx.editor?.replaceAll(replaceText)}
+          type="button"
+          use:tooltip={{ message: '모두 바꾸기', keys: ['Mod', 'Enter'] }}
+        >
+          <Icon icon={ReplaceAllIcon} size={16} />
+        </button>
+      </div>
+      <button
+        class={center({
+          size: '24px',
+          padding: '4px',
+          borderRadius: '4px',
+          color: 'text.faint',
+          _hover: { backgroundColor: 'surface.muted' },
+          _focus: { backgroundColor: 'surface.muted' },
+        })}
+        onclick={() => {
+          close();
+          ctx.editor?.focus();
+        }}
+        type="button"
+        use:tooltip={{ message: '닫기', keys: ['Esc'] }}
+      >
+        <Icon icon={XIcon} size={16} />
+      </button>
+    </div>
+  </div>
+</div>

--- a/assets/theme.json
+++ b/assets/theme.json
@@ -34,7 +34,9 @@
     "bg.yellow": "#fef3c7",
     "bg.green": "#dff3e3",
     "bg.blue": "#e7f3f8",
-    "bg.purple": "#f0e7fe"
+    "bg.purple": "#f0e7fe",
+    "ui.search-match": "#ffff80",
+    "ui.search-match-active": "#ffd280"
   },
   "darkShared": {
     "ui.accent.brand.default": "#505ca4",
@@ -51,7 +53,9 @@
     "bg.yellow": "#4e3e1b",
     "bg.green": "#2c4331",
     "bg.blue": "#153b4f",
-    "bg.purple": "#3f2e50"
+    "bg.purple": "#3f2e50",
+    "ui.search-match": "#544a2e",
+    "ui.search-match-active": "#a06828"
   },
   "variants": {
     "light-white": {

--- a/crates/editor-common/src/style.rs
+++ b/crates/editor-common/src/style.rs
@@ -22,5 +22,9 @@ pub struct Underline {
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct DecorationStyle {
     pub background: Option<String>,
+    #[serde(default)]
+    pub background_radius: Option<f32>,
+    #[serde(default)]
+    pub background_inset: Option<f32>,
     pub underline: Option<Underline>,
 }

--- a/crates/editor-core/src/editor.rs
+++ b/crates/editor-core/src/editor.rs
@@ -162,6 +162,10 @@ impl Editor {
         &mut self.tracked_ranges
     }
 
+    pub fn find_matches(&self, query: &str, options: &SearchOptions) -> Vec<Selection> {
+        crate::search::find_matches(&self.state.doc, query, options)
+    }
+
     pub(crate) fn is_probing(&self) -> bool {
         matches!(self.mode, Mode::Probe { .. })
     }
@@ -494,6 +498,7 @@ impl Editor {
         if view_state.tracked_decoration_groups.is_empty() {
             return;
         }
+        let mut entries: Vec<(i32, &editor_view::GroupDecoration, Vec<PageRect>)> = Vec::new();
         for range in self.tracked_ranges.iter() {
             let Some(group) = view_state.group_decoration(&range.group) else {
                 continue;
@@ -520,9 +525,17 @@ impl Editor {
             if rects.is_empty() {
                 continue;
             }
+            entries.push((group.z_index, group, rects));
+        }
+        entries.sort_by_key(|(z, _, _)| *z);
+        for (_, group, rects) in entries {
             if let Some(theme_key) = group.style.background.clone() {
                 marks.push(Mark {
-                    data: MarkData::TrackedBackground { theme_key },
+                    data: MarkData::TrackedBackground {
+                        theme_key,
+                        border_radius: group.style.background_radius.unwrap_or(0.0),
+                        vertical_inset: group.style.background_inset.unwrap_or(0.0),
+                    },
                     rects: rects.clone(),
                 });
             }
@@ -551,6 +564,9 @@ impl Editor {
 
     pub fn render_page(&mut self, page_idx: u32, sink: &mut dyn RenderSink, scale_factor: f32) {
         let mut marks: Vec<Mark> = Vec::new();
+
+        // Push before selection so selection draws on top within BelowContent.
+        self.collect_tracked_decoration_marks(&mut marks);
 
         if let Some(rects) = self.selection_mark_rects() {
             marks.push(Mark {
@@ -585,8 +601,6 @@ impl Editor {
                 rects: vec![target.indicator.rect()],
             });
         }
-
-        self.collect_tracked_decoration_marks(&mut marks);
 
         self.renderer.render_page(
             sink,

--- a/crates/editor-core/src/handle/tracked_range.rs
+++ b/crates/editor-core/src/handle/tracked_range.rs
@@ -86,8 +86,13 @@ pub fn handle_tracked_range_op(editor: &mut Editor, op: TrackedRangeOp) -> Resul
             group,
             style,
             enabled,
+            z_index,
         } => {
-            let decoration = GroupDecoration { style, enabled };
+            let decoration = GroupDecoration {
+                style,
+                enabled,
+                z_index,
+            };
             let would_change = editor.view.would_set_group_decoration(&group, &decoration);
             commit_view_or_probe(editor, would_change, |editor| {
                 editor.view.set_group_decoration(group, decoration);
@@ -483,6 +488,7 @@ mod tests {
         DecorationStyle {
             background: Some("selection".into()),
             underline: None,
+            ..Default::default()
         }
     }
 
@@ -492,6 +498,7 @@ mod tests {
                 group: group.into(),
                 style,
                 enabled,
+                z_index: 0,
             },
         }
     }

--- a/crates/editor-core/src/lib.rs
+++ b/crates/editor-core/src/lib.rs
@@ -10,6 +10,7 @@ mod history;
 mod ime;
 mod interaction;
 mod message;
+mod search;
 mod state_field;
 mod tracked_range;
 
@@ -30,5 +31,6 @@ pub use handle::*;
 pub use history::*;
 pub use ime::*;
 pub use message::*;
+pub use search::find_matches;
 pub use state_field::*;
 pub use tracked_range::*;

--- a/crates/editor-core/src/message.rs
+++ b/crates/editor-core/src/message.rs
@@ -335,6 +335,14 @@ pub enum FlatImeOp {
 }
 
 #[ffi]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct SearchOptions {
+    #[serde(default)]
+    pub match_whole_word: bool,
+}
+
+#[ffi]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum TrackedRangeOp {
@@ -365,6 +373,8 @@ pub enum TrackedRangeOp {
         group: String,
         style: DecorationStyle,
         enabled: bool,
+        #[serde(default)]
+        z_index: i32,
     },
     RemoveGroupDecoration {
         group: String,

--- a/crates/editor-core/src/search.rs
+++ b/crates/editor-core/src/search.rs
@@ -1,0 +1,114 @@
+use editor_model::{Doc, Node};
+use editor_state::{Position, Selection};
+
+use crate::message::SearchOptions;
+
+pub fn find_matches(doc: &Doc, query: &str, options: &SearchOptions) -> Vec<Selection> {
+    let Some(root) = doc.root() else {
+        return Vec::new();
+    };
+    let query_chars: Vec<char> = query.chars().collect();
+    let m = query_chars.len();
+    if m == 0 {
+        return Vec::new();
+    }
+
+    let mut out = Vec::new();
+    for desc in root.descendants() {
+        let Node::Text(text_node) = desc.node() else {
+            continue;
+        };
+        let chars: Vec<char> = text_node.text.to_string().chars().collect();
+        let n = chars.len();
+        if m > n {
+            continue;
+        }
+        let mut i = 0;
+        while i + m <= n {
+            if chars[i..i + m] == query_chars[..] {
+                let passes_word = if options.match_whole_word {
+                    let before_ok = i == 0 || !is_word_char(chars[i - 1]);
+                    let after_ok = i + m == n || !is_word_char(chars[i + m]);
+                    before_ok && after_ok
+                } else {
+                    true
+                };
+                if passes_word {
+                    out.push(Selection::new(
+                        Position::new(desc.id(), i),
+                        Position::new(desc.id(), i + m),
+                    ));
+                    i += m;
+                    continue;
+                }
+            }
+            i += 1;
+        }
+    }
+    out
+}
+
+fn is_word_char(c: char) -> bool {
+    c.is_alphanumeric() || c == '_'
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use editor_macros::state;
+
+    fn matches_text(state: &editor_state::State, query: &str, whole_word: bool) -> Vec<String> {
+        let opts = SearchOptions {
+            match_whole_word: whole_word,
+        };
+        find_matches(&state.doc, query, &opts)
+            .into_iter()
+            .filter_map(|sel| sel.resolve(&state.doc).map(|r| r.collect_text()))
+            .collect()
+    }
+
+    #[test]
+    fn empty_query_returns_no_matches() {
+        let (state, ..) = state! {
+            doc { root { paragraph { t: text("hello world") } } }
+            selection: (t, 0)
+        };
+        assert!(matches_text(&state, "", false).is_empty());
+    }
+
+    #[test]
+    fn finds_multiple_occurrences_in_single_text_node() {
+        let (state, ..) = state! {
+            doc { root { paragraph { t: text("ab ab ab") } } }
+            selection: (t, 0)
+        };
+        assert_eq!(matches_text(&state, "ab", false), vec!["ab", "ab", "ab"]);
+    }
+
+    #[test]
+    fn does_not_cross_text_node_boundary() {
+        let (state, ..) = state! {
+            doc { root { paragraph { a: text("foo") b: text("bar") } } }
+            selection: (a, 0)
+        };
+        assert!(matches_text(&state, "oob", false).is_empty());
+    }
+
+    #[test]
+    fn whole_word_excludes_partial_matches() {
+        let (state, ..) = state! {
+            doc { root { paragraph { t: text("cat catalog cat") } } }
+            selection: (t, 0)
+        };
+        assert_eq!(matches_text(&state, "cat", true), vec!["cat", "cat"]);
+    }
+
+    #[test]
+    fn whole_word_includes_punctuation_boundary() {
+        let (state, ..) = state! {
+            doc { root { paragraph { t: text("cat. cat,") } } }
+            selection: (t, 0)
+        };
+        assert_eq!(matches_text(&state, "cat", true), vec!["cat", "cat"]);
+    }
+}

--- a/crates/editor-core/src/tests/can_invariants.rs
+++ b/crates/editor-core/src/tests/can_invariants.rs
@@ -135,8 +135,10 @@ fn build_corpus() -> Vec<Message> {
                 style: editor_common::DecorationStyle {
                     background: Some("selection".into()),
                     underline: None,
+                    ..Default::default()
                 },
                 enabled: true,
+                z_index: 0,
             },
         },
         Message::TrackedRange {

--- a/crates/editor-core/src/tests/tracked_decoration_integration.rs
+++ b/crates/editor-core/src/tests/tracked_decoration_integration.rs
@@ -23,6 +23,7 @@ fn set_group(group: &str, style: DecorationStyle, enabled: bool) -> Message {
             group: group.into(),
             style,
             enabled,
+            z_index: 0,
         },
     }
 }
@@ -31,6 +32,7 @@ fn background_only_style() -> DecorationStyle {
     DecorationStyle {
         background: Some("selection".into()),
         underline: None,
+        ..Default::default()
     }
 }
 
@@ -42,6 +44,7 @@ fn underline_only_style() -> DecorationStyle {
             style: UnderlineStyle::Dashed,
             thickness: 1.5,
         }),
+        ..Default::default()
     }
 }
 
@@ -53,6 +56,7 @@ fn both_style() -> DecorationStyle {
             style: UnderlineStyle::Solid,
             thickness: 1.0,
         }),
+        ..Default::default()
     }
 }
 

--- a/crates/editor-core/src/tests/tracked_range_hit_test.rs
+++ b/crates/editor-core/src/tests/tracked_range_hit_test.rs
@@ -168,8 +168,10 @@ fn hit_test_ignores_decoration_enabled_flag() {
             style: editor_common::DecorationStyle {
                 background: Some("selection".into()),
                 underline: None,
+                ..Default::default()
             },
             enabled: false,
+            z_index: 0,
         },
     });
 

--- a/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
@@ -261,6 +261,8 @@ export interface CursorMetrics {
 
 export interface DecorationStyle {
     background: string | undefined;
+    background_radius?: number | undefined;
+    background_inset?: number | undefined;
     underline: Underline | undefined;
 }
 
@@ -465,6 +467,10 @@ export interface Rect {
 
 export interface RubyValue {
     text: string;
+}
+
+export interface SearchOptions {
+    match_whole_word?: boolean;
 }
 
 export interface SelectionEndpoints {
@@ -678,7 +684,7 @@ export type TextNodeAttr = void;
 
 export type ThemeVariant = "dark-black" | "dark-charcoal" | "dark-espresso" | "dark-graphite" | "dark-midnight" | "dark-navy" | "dark-obsidian" | "dark-storm" | "light-butter" | "light-latte" | "light-lavender" | "light-mint" | "light-peach" | "light-rose" | "light-snow" | "light-white";
 
-export type TrackedRangeOp = { type: "add"; id: string; group: string; selection: Selection; metadata?: string } | { type: "add_frozen"; id: string; group: string; selection: StableSelection; metadata?: string } | { type: "remove"; id: string } | { type: "clear_group"; group: string } | { type: "invalidate"; id: string } | { type: "set_group_decoration"; group: string; style: DecorationStyle; enabled: boolean } | { type: "remove_group_decoration"; group: string } | { type: "replace_text"; id: string; expected_text?: string | undefined; replacement: string };
+export type TrackedRangeOp = { type: "add"; id: string; group: string; selection: Selection; metadata?: string } | { type: "add_frozen"; id: string; group: string; selection: StableSelection; metadata?: string } | { type: "remove"; id: string } | { type: "clear_group"; group: string } | { type: "invalidate"; id: string } | { type: "set_group_decoration"; group: string; style: DecorationStyle; enabled: boolean; z_index?: number } | { type: "remove_group_decoration"; group: string } | { type: "replace_text"; id: string; expected_text?: string | undefined; replacement: string };
 
 export type TrackedRangeReplaceOutcome = "replaced" | "unknown_id" | "invalid" | "text_mismatch" | "invalid_replacement";
 
@@ -705,6 +711,7 @@ declare class Editor {
     enqueue(message: Message): void;
     export_page_vector(page: number, scale_factor: number): Uint8Array;
     external_elements(): ExternalElement[];
+    find_matches(query: string, options?: SearchOptions | null): Selection[];
     freeze_selection(selection: Selection): StableSelection;
     ime(before_limit: number, after_limit: number): Ime;
     inspect_state(options?: InspectStateOptions | null): string;

--- a/crates/editor-ffi/pkg/server/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/server/editor_ffi.d.ts
@@ -275,6 +275,8 @@ export interface CursorMetrics {
 
 export interface DecorationStyle {
     background: string | undefined;
+    background_radius?: number | undefined;
+    background_inset?: number | undefined;
     underline: Underline | undefined;
 }
 
@@ -494,6 +496,10 @@ export interface RubyValue {
     text: string;
 }
 
+export interface SearchOptions {
+    match_whole_word?: boolean;
+}
+
 export interface SelectionEndpoints {
     from: PageRect;
     to: PageRect;
@@ -705,7 +711,7 @@ export type TextNodeAttr = void;
 
 export type ThemeVariant = "dark-black" | "dark-charcoal" | "dark-espresso" | "dark-graphite" | "dark-midnight" | "dark-navy" | "dark-obsidian" | "dark-storm" | "light-butter" | "light-latte" | "light-lavender" | "light-mint" | "light-peach" | "light-rose" | "light-snow" | "light-white";
 
-export type TrackedRangeOp = { type: "add"; id: string; group: string; selection: Selection; metadata?: string } | { type: "add_frozen"; id: string; group: string; selection: StableSelection; metadata?: string } | { type: "remove"; id: string } | { type: "clear_group"; group: string } | { type: "invalidate"; id: string } | { type: "set_group_decoration"; group: string; style: DecorationStyle; enabled: boolean } | { type: "remove_group_decoration"; group: string } | { type: "replace_text"; id: string; expected_text?: string | undefined; replacement: string };
+export type TrackedRangeOp = { type: "add"; id: string; group: string; selection: Selection; metadata?: string } | { type: "add_frozen"; id: string; group: string; selection: StableSelection; metadata?: string } | { type: "remove"; id: string } | { type: "clear_group"; group: string } | { type: "invalidate"; id: string } | { type: "set_group_decoration"; group: string; style: DecorationStyle; enabled: boolean; z_index?: number } | { type: "remove_group_decoration"; group: string } | { type: "replace_text"; id: string; expected_text?: string | undefined; replacement: string };
 
 export type TrackedRangeReplaceOutcome = "replaced" | "unknown_id" | "invalid" | "text_mismatch" | "invalid_replacement";
 
@@ -730,6 +736,7 @@ declare class Editor {
     enqueue(message: Message): void;
     export_page_vector(page: number, scale_factor: number): Uint8Array;
     external_elements(): ExternalElement[];
+    find_matches(query: string, options?: SearchOptions | null): Selection[];
     freeze_selection(selection: Selection): StableSelection;
     ime(before_limit: number, after_limit: number): Ime;
     inspect_state(options?: InspectStateOptions | null): string;

--- a/crates/editor-ffi/src/editor.rs
+++ b/crates/editor-ffi/src/editor.rs
@@ -333,6 +333,20 @@ impl Editor {
         })
     }
 
+    pub fn find_matches(
+        &self,
+        query: String,
+        options: Option<Complex<editor_core::SearchOptions>>,
+    ) -> EditorResult<Vec<Complex<editor_state::Selection>>> {
+        self.with_inner(|inner| {
+            let opts = match options {
+                Some(o) => o.from_ffi()?,
+                None => editor_core::SearchOptions::default(),
+            };
+            Ok(inner.editor.find_matches(&query, &opts).into_ffi()?)
+        })
+    }
+
     pub fn tracked_ranges(
         &self,
         group: Option<String>,

--- a/crates/editor-renderer/src/renderer.rs
+++ b/crates/editor-renderer/src/renderer.rs
@@ -369,11 +369,19 @@ pub enum MarkLayer {
 
 #[derive(Debug, Clone)]
 pub enum MarkData {
-    Selection { focused: bool },
+    Selection {
+        focused: bool,
+    },
     Composition,
     DropIndicator,
-    TrackedBackground { theme_key: String },
-    TrackedUnderline { underline: Underline },
+    TrackedBackground {
+        theme_key: String,
+        border_radius: f32,
+        vertical_inset: f32,
+    },
+    TrackedUnderline {
+        underline: Underline,
+    },
 }
 
 impl MarkData {
@@ -503,7 +511,7 @@ impl Renderer {
             MarkData::Selection { focused } => Some(selection_mark_color(theme, *focused)),
             MarkData::Composition => Some(theme.color("ui.text.default")),
             MarkData::DropIndicator => Some(theme.color("selection")),
-            MarkData::TrackedBackground { theme_key } => Some(theme.color(theme_key)),
+            MarkData::TrackedBackground { theme_key, .. } => Some(theme.color(theme_key)),
             MarkData::TrackedUnderline { .. } => None,
         }
     }
@@ -529,6 +537,37 @@ impl Renderer {
                 match &mark.data {
                     MarkData::TrackedUnderline { underline } => {
                         draw_underline(sink, rect.rect, underline, theme, transform);
+                    }
+                    MarkData::TrackedBackground {
+                        border_radius,
+                        vertical_inset,
+                        ..
+                    } => {
+                        if let Some(color) = self.resolve_mark_color(&mark.data, theme) {
+                            let inset = vertical_inset.max(0.0).min(rect.rect.height * 0.5);
+                            let r = Rect::from_xywh(
+                                rect.rect.x,
+                                rect.rect.y + inset,
+                                rect.rect.width,
+                                (rect.rect.height - inset * 2.0).max(0.0),
+                            );
+                            let radius = border_radius.max(0.0);
+                            if radius > 0.0 && r.height > 0.0 && r.width > 0.0 {
+                                let radius = radius.min(r.height * 0.5).min(r.width * 0.5);
+                                let path = Path::rrect(
+                                    r,
+                                    CornerRadii {
+                                        top_left: radius,
+                                        top_right: radius,
+                                        bottom_right: radius,
+                                        bottom_left: radius,
+                                    },
+                                );
+                                sink.fill_path(&path, color, transform);
+                            } else {
+                                sink.fill_rect(r, color, transform);
+                            }
+                        }
                     }
                     _ => {
                         if let Some(color) = self.resolve_mark_color(&mark.data, theme) {

--- a/crates/editor-view/src/view_state.rs
+++ b/crates/editor-view/src/view_state.rs
@@ -24,6 +24,7 @@ pub struct GapPhantom {
 pub struct GroupDecoration {
     pub style: DecorationStyle,
     pub enabled: bool,
+    pub z_index: i32,
 }
 
 #[derive(Debug, Clone, Default)]


### PR DESCRIPTION
  찾기·바꾸기 기능 구현. 엔진은 stateless find_matches 프리미티브만 노출하고, 검색
  세션 상태(query/matches/activeIndex)는 호스트가 보유. 매치는 기존 tracked range   
  시스템에 등록해 자동 anchoring.      
                                                                