### PR TITLE
insert_slice_at이 삽입 범위를 반환하도록 함

### DIFF
--- a/crates/editor-commands/src/commands/insert_slice_at.rs
+++ b/crates/editor-commands/src/commands/insert_slice_at.rs
@@ -17,7 +17,10 @@ pub fn insert_slice_at(
 mod tests {
     use editor_clipboard::Slice;
     use editor_macros::state;
-    use editor_model::{Fragment, Node, NodeId, PlainImageNode, PlainNode, PlainRootNode};
+    use editor_model::{
+        Fragment, Node, NodeId, PlainImageNode, PlainNode, PlainParagraphNode, PlainRootNode,
+        PlainTextNode,
+    };
     use editor_state::{Affinity, Position, Selection};
     use editor_transaction::Transaction;
 
@@ -33,6 +36,23 @@ mod tests {
             open_start: 0,
             open_end: 0,
         }
+    }
+
+    fn paragraph_fragment(text: &str) -> Fragment {
+        Fragment {
+            node: PlainNode::Paragraph(PlainParagraphNode::default()),
+            modifiers: vec![],
+            children: vec![Fragment::leaf(PlainNode::Text(PlainTextNode {
+                text: text.into(),
+            }))],
+        }
+    }
+
+    fn text_of_first_child(node: editor_model::NodeRef<'_>) -> Option<String> {
+        node.first_child().and_then(|child| match child.node() {
+            Node::Text(text) => Some(text.text.to_string()),
+            _ => None,
+        })
     }
 
     #[test]
@@ -99,8 +119,10 @@ mod tests {
         };
 
         let mut tr = Transaction::new(&initial);
-        let result = insert_slice_at(&mut tr, Position::new(NodeId::ROOT, 1), image_slice());
-        assert!(result.expect("insert succeeds").is_some());
+        let inserted_selection =
+            insert_slice_at(&mut tr, Position::new(NodeId::ROOT, 1), image_slice())
+                .expect("insert succeeds")
+                .expect("slice inserted");
         let (actual, ..) = tr.commit();
 
         let root = actual.doc.node(NodeId::ROOT).expect("root exists");
@@ -109,5 +131,195 @@ mod tests {
             children.as_slice(),
             [Node::Paragraph(_), Node::Image(_), Node::Paragraph(_)]
         ));
+        assert_eq!(
+            inserted_selection,
+            Selection::new(
+                Position {
+                    node_id: NodeId::ROOT,
+                    offset: 1,
+                    affinity: Affinity::Downstream,
+                },
+                Position {
+                    node_id: NodeId::ROOT,
+                    offset: 2,
+                    affinity: Affinity::Upstream,
+                },
+            )
+        );
+    }
+
+    #[test]
+    fn insert_slice_at_image_in_text_middle_returns_inserted_range() {
+        let (initial, t) = state! {
+            doc { root { paragraph { t: text("hello") } } }
+            selection: (t, 0)
+        };
+
+        let mut tr = Transaction::new(&initial);
+        let inserted_selection = insert_slice_at(&mut tr, Position::new(t, 3), image_slice())
+            .expect("insert succeeds")
+            .expect("slice inserted");
+        let (actual, ..) = tr.commit();
+
+        let root = actual.doc.node(NodeId::ROOT).expect("root exists");
+        let children: Vec<_> = root.children().map(|c| c.node()).collect();
+        assert!(matches!(
+            children.as_slice(),
+            [Node::Paragraph(_), Node::Image(_), Node::Paragraph(_)]
+        ));
+        assert_eq!(
+            inserted_selection,
+            Selection::new(
+                Position {
+                    node_id: NodeId::ROOT,
+                    offset: 1,
+                    affinity: Affinity::Downstream,
+                },
+                Position {
+                    node_id: NodeId::ROOT,
+                    offset: 2,
+                    affinity: Affinity::Upstream,
+                },
+            )
+        );
+    }
+
+    #[test]
+    fn insert_slice_at_closed_paragraphs_in_text_middle_returns_inserted_range() {
+        let (initial, t) = state! {
+            doc { root { paragraph { t: text("hello") } } }
+            selection: (t, 0)
+        };
+        let slice = Slice {
+            fragment: Fragment {
+                node: PlainNode::Root(PlainRootNode::default()),
+                modifiers: vec![],
+                children: vec![paragraph_fragment("A"), paragraph_fragment("B")],
+            },
+            open_start: 0,
+            open_end: 0,
+        };
+
+        let mut tr = Transaction::new(&initial);
+        let inserted_selection = insert_slice_at(&mut tr, Position::new(t, 3), slice)
+            .expect("insert succeeds")
+            .expect("slice inserted");
+        let (actual, ..) = tr.commit();
+
+        let root = actual.doc.node(NodeId::ROOT).expect("root exists");
+        let children: Vec<_> = root.children().collect();
+        assert_eq!(
+            children
+                .iter()
+                .map(|child| text_of_first_child(*child))
+                .collect::<Vec<_>>(),
+            vec![
+                Some("hel".into()),
+                Some("A".into()),
+                Some("B".into()),
+                Some("lo".into()),
+            ]
+        );
+        assert_eq!(
+            inserted_selection,
+            Selection::new(
+                Position {
+                    node_id: NodeId::ROOT,
+                    offset: 1,
+                    affinity: Affinity::Downstream,
+                },
+                Position {
+                    node_id: NodeId::ROOT,
+                    offset: 3,
+                    affinity: Affinity::Upstream,
+                },
+            )
+        );
+    }
+
+    #[test]
+    fn insert_slice_at_open_paragraphs_in_text_middle_returns_inserted_range() {
+        let (initial, t) = state! {
+            doc { root { paragraph { t: text("Hello World") } } }
+            selection: (t, 0)
+        };
+        let slice = Slice {
+            fragment: Fragment {
+                node: PlainNode::Root(PlainRootNode::default()),
+                modifiers: vec![],
+                children: vec![paragraph_fragment("first"), paragraph_fragment("second")],
+            },
+            open_start: 2,
+            open_end: 2,
+        };
+
+        let mut tr = Transaction::new(&initial);
+        let inserted_selection = insert_slice_at(&mut tr, Position::new(t, 5), slice)
+            .expect("insert succeeds")
+            .expect("slice inserted");
+        let (actual, ..) = tr.commit();
+
+        let root = actual.doc.node(NodeId::ROOT).expect("root exists");
+        let children: Vec<_> = root.children().collect();
+        assert_eq!(
+            children
+                .iter()
+                .map(|child| text_of_first_child(*child))
+                .collect::<Vec<_>>(),
+            vec![Some("Hellofirst".into()), Some("second World".into())]
+        );
+        let first_text = children[0].first_child().expect("first text");
+        let second_text = children[1].first_child().expect("second text");
+        assert_eq!(
+            inserted_selection,
+            Selection::new(
+                Position {
+                    node_id: first_text.id(),
+                    offset: 5,
+                    affinity: Affinity::Downstream,
+                },
+                Position {
+                    node_id: second_text.id(),
+                    offset: 6,
+                    affinity: Affinity::Upstream,
+                },
+            )
+        );
+    }
+
+    #[test]
+    fn insert_slice_at_image_into_empty_paragraph_returns_inserted_range() {
+        let (initial, p) = state! {
+            doc { root { p: paragraph {} } }
+            selection: (p, 0)
+        };
+
+        let mut tr = Transaction::new(&initial);
+        let inserted_selection = insert_slice_at(&mut tr, Position::new(p, 0), image_slice())
+            .expect("insert succeeds")
+            .expect("slice inserted");
+        let (actual, ..) = tr.commit();
+
+        let root = actual.doc.node(NodeId::ROOT).expect("root exists");
+        let children: Vec<_> = root.children().map(|c| c.node()).collect();
+        assert!(matches!(
+            children.as_slice(),
+            [Node::Image(_), Node::Paragraph(_)]
+        ));
+        assert_eq!(
+            inserted_selection,
+            Selection::new(
+                Position {
+                    node_id: NodeId::ROOT,
+                    offset: 0,
+                    affinity: Affinity::Downstream,
+                },
+                Position {
+                    node_id: NodeId::ROOT,
+                    offset: 1,
+                    affinity: Affinity::Upstream,
+                },
+            )
+        );
     }
 }

--- a/crates/editor-commands/src/helpers/slice.rs
+++ b/crates/editor-commands/src/helpers/slice.rs
@@ -211,7 +211,7 @@ fn insert_inline_at_position(
     let Some(end) = tr.selection().map(|s| s.head) else {
         return Ok(None);
     };
-    Ok(Some(Selection::new(start, end)))
+    Ok(Some(normalized_selection(tr, start, end)))
 }
 
 fn insert_blocks_in_textblock_at_position(
@@ -220,15 +220,7 @@ fn insert_blocks_in_textblock_at_position(
     slice: &Slice,
 ) -> Result<Option<Selection>, CommandError> {
     tr.set_selection(Some(Selection::collapsed(position)))?;
-    let start = tr.selection().map(|s| s.head).unwrap_or(position);
-    let inserted = insert_blocks_in_textblock(tr, slice)?;
-    if !inserted {
-        return Ok(None);
-    }
-    let Some(end) = tr.selection().map(|s| s.head) else {
-        return Ok(None);
-    };
-    Ok(Some(Selection::new(start, end)))
+    insert_blocks_in_textblock(tr, slice)
 }
 
 fn insert_inline_fragments(tr: &mut Transaction, fragments: Vec<Fragment>) -> CommandResult {
@@ -309,7 +301,20 @@ fn textblock_insert_point(
     }
 }
 
-fn insert_blocks_in_textblock(tr: &mut Transaction, slice: &Slice) -> CommandResult {
+#[derive(Clone, Copy)]
+enum InsertedRangeEndpoint {
+    // Open slice edges merge into split textblocks and are represented by
+    // inline positions. Closed middle blocks are resolved after cleanup because
+    // removing empty split halves can shift their parent indices.
+    Position(Position),
+    BeforeBlock(NodeId),
+    AfterBlock(NodeId),
+}
+
+fn insert_blocks_in_textblock(
+    tr: &mut Transaction,
+    slice: &Slice,
+) -> Result<Option<Selection>, CommandError> {
     let head = tr
         .selection()
         .expect("entry caller guaranteed selection")
@@ -389,17 +394,27 @@ fn insert_blocks_in_textblock(tr: &mut Transaction, slice: &Slice) -> CommandRes
     let merge_end = merge_end && middle_end >= middle_start;
 
     let mut last_caret: Option<Position> = None;
+    let mut inserted_start: Option<InsertedRangeEndpoint> = None;
+    let mut inserted_end: Option<InsertedRangeEndpoint> = None;
 
     if merge_start {
         let first = blocks[0];
         let inline = first.children.to_vec();
         position_caret_at_textblock_end(tr, textblock_id)?;
-        insert_inline_fragments(tr, inline)?;
-        last_caret = Some(
-            tr.selection()
-                .expect("selection preserved through mutations")
-                .head,
-        );
+        let start = tr
+            .selection()
+            .expect("selection preserved through mutations")
+            .head;
+        let inserted = insert_inline_fragments(tr, inline)?;
+        let end = tr
+            .selection()
+            .expect("selection preserved through mutations")
+            .head;
+        if inserted {
+            inserted_start.get_or_insert(InsertedRangeEndpoint::Position(start));
+            inserted_end = Some(InsertedRangeEndpoint::Position(end));
+        }
+        last_caret = Some(end);
     }
 
     for (insert_at, block) in
@@ -408,6 +423,8 @@ fn insert_blocks_in_textblock(tr: &mut Transaction, slice: &Slice) -> CommandRes
         let subtree = (*block).clone().into_subtree();
         let inserted_id = subtree.id;
         tr.insert_subtree(container_id, insert_at, subtree)?;
+        inserted_start.get_or_insert(InsertedRangeEndpoint::BeforeBlock(inserted_id));
+        inserted_end = Some(InsertedRangeEndpoint::AfterBlock(inserted_id));
         last_caret = Some(position_at_end_of_block(tr, inserted_id));
     }
 
@@ -415,14 +432,22 @@ fn insert_blocks_in_textblock(tr: &mut Transaction, slice: &Slice) -> CommandRes
         let last = blocks.last().unwrap();
         let inline = last.children.to_vec();
         position_caret_at_textblock_start(tr, p2_id)?;
-        insert_inline_fragments(tr, inline)?;
+        let start = tr
+            .selection()
+            .expect("selection preserved through mutations")
+            .head;
+        let inserted = insert_inline_fragments(tr, inline)?;
         // After inserting at the start of p2, the caret naturally lands between
         // the merged-in inline and p2's original inline content.
-        last_caret = Some(
-            tr.selection()
-                .expect("selection preserved through mutations")
-                .head,
-        );
+        let end = tr
+            .selection()
+            .expect("selection preserved through mutations")
+            .head;
+        if inserted {
+            inserted_start.get_or_insert(InsertedRangeEndpoint::Position(start));
+            inserted_end = Some(InsertedRangeEndpoint::Position(end));
+        }
+        last_caret = Some(end);
     }
 
     // Drop the split halves when they're empty AND the container's schema
@@ -469,9 +494,19 @@ fn insert_blocks_in_textblock(tr: &mut Transaction, slice: &Slice) -> CommandRes
             affinity: Affinity::Upstream,
         },
     };
+    let inserted_selection = inserted_start.zip(inserted_end).and_then(|(start, end)| {
+        let start = resolve_inserted_range_endpoint(tr, start)?;
+        let end = resolve_inserted_range_endpoint(tr, end)?;
+        Some(normalized_selection(tr, start, end))
+    });
     tr.set_selection(Some(Selection::collapsed(final_pos)))?;
 
-    Ok(true)
+    Ok(inserted_selection)
+}
+
+fn normalized_selection(tr: &Transaction, anchor: Position, head: Position) -> Selection {
+    let selection = Selection::new(anchor, head);
+    selection.normalize(&tr.doc()).unwrap_or(selection)
 }
 
 fn position_caret_at_textblock_end(
@@ -660,6 +695,31 @@ fn selection_over_inserted_blocks(
             affinity: Affinity::Upstream,
         },
     )
+}
+
+fn resolve_inserted_range_endpoint(
+    tr: &Transaction,
+    endpoint: InsertedRangeEndpoint,
+) -> Option<Position> {
+    match endpoint {
+        InsertedRangeEndpoint::Position(position) => Some(position),
+        InsertedRangeEndpoint::BeforeBlock(id) | InsertedRangeEndpoint::AfterBlock(id) => {
+            let doc = tr.doc();
+            let node = doc.node(id)?;
+            let parent = node.parent()?;
+            let index = node.index()?;
+            let (offset, affinity) = match endpoint {
+                InsertedRangeEndpoint::BeforeBlock(_) => (index, Affinity::Downstream),
+                InsertedRangeEndpoint::AfterBlock(_) => (index + 1, Affinity::Upstream),
+                InsertedRangeEndpoint::Position(_) => unreachable!(),
+            };
+            Some(Position {
+                node_id: parent.id(),
+                offset,
+                affinity,
+            })
+        }
+    }
 }
 
 fn same_textblock_type(slice_node: &PlainNode, doc_node_id: NodeId, tr: &Transaction) -> bool {

--- a/crates/editor-core/src/editor.rs
+++ b/crates/editor-core/src/editor.rs
@@ -1097,7 +1097,7 @@ mod tests {
         Doc, DocOp, Modifier, ModifierType, Node, NodeId, PlainDoc, PlainNode, PlainNodeEntry,
         PlainParagraphNode, PlainRootNode, PlainTextNode,
     };
-    use editor_state::{PendingModifier, PendingModifiers, Position, Selection, State};
+    use editor_state::{Affinity, PendingModifier, PendingModifiers, Position, Selection, State};
     use hashbrown::HashSet;
     use std::collections::BTreeMap;
 
@@ -2629,6 +2629,84 @@ mod tests {
         });
 
         editor_state::assert_state_eq!(editor.state(), &initial);
+    }
+
+    #[test]
+    fn drop_internal_image_into_text_middle_selects_inserted_range() {
+        let (initial, root, t) = state! {
+            doc { root: root {
+                image
+                paragraph { t: text("hello") }
+            } }
+            selection: (root, 0, >) -> (root, 1, <)
+        };
+        let mut editor = Editor::new_test(initial);
+
+        editor.apply(Message::Dnd {
+            op: DndOp::StartInternalSelection,
+        });
+        let InteractionState::InternalDnd { drop_target, .. } = &mut editor.interaction else {
+            panic!("internal dnd should start from selected image");
+        };
+        *drop_target = Some(editor_view::DropTarget {
+            position: Position::new(t, 3),
+            indicator: editor_view::DropIndicator::Inline {
+                page_idx: 0,
+                x: 0.0,
+                y: 0.0,
+                height: 1.0,
+            },
+        });
+
+        editor.apply(Message::Dnd {
+            op: DndOp::Drop {
+                page: 0,
+                x: 0.0,
+                y: 0.0,
+                payload: DndDropPayload::InternalSelection,
+                modifiers: InputModifiers::default(),
+            },
+        });
+
+        let root_node = editor.state().doc.node(root).expect("root exists");
+        let children: Vec<_> = root_node.children().map(|c| c.node()).collect();
+        assert!(matches!(
+            children.as_slice(),
+            [Node::Paragraph(_), Node::Image(_), Node::Paragraph(_)]
+        ));
+        let first_text = root_node
+            .children()
+            .next()
+            .and_then(|p| p.first_child())
+            .and_then(|n| match n.node() {
+                Node::Text(t) => Some(t.text.to_string()),
+                _ => None,
+            });
+        let last_text = root_node
+            .children()
+            .nth(2)
+            .and_then(|p| p.first_child())
+            .and_then(|n| match n.node() {
+                Node::Text(t) => Some(t.text.to_string()),
+                _ => None,
+            });
+        assert_eq!(first_text.as_deref(), Some("hel"));
+        assert_eq!(last_text.as_deref(), Some("lo"));
+        assert_eq!(
+            editor.state().selection,
+            Some(Selection::new(
+                Position {
+                    node_id: root,
+                    offset: 1,
+                    affinity: Affinity::Downstream,
+                },
+                Position {
+                    node_id: root,
+                    offset: 2,
+                    affinity: Affinity::Upstream,
+                },
+            ))
+        );
     }
 
     #[test]


### PR DESCRIPTION
- inline position에 block 드랍 후 block부터 문서 끝까지 선택되어 보이는 버그를 해결