### PR TITLE
SVG 폰트 글리프 렌더링 지원

### DIFF
--- a/crates/editor-ffi/src/server.rs
+++ b/crates/editor-ffi/src/server.rs
@@ -33,6 +33,10 @@ impl EditorServer {
         Ok(editor_server::font::get_font_codepoints(&ttf_data)?)
     }
 
+    pub fn outline_text_to_svg(&self, font_data: Vec<u8>, text: String) -> EditorResult<String> {
+        Ok(editor_server::font::outline_text_to_svg(&font_data, &text)?)
+    }
+
     pub fn build_font(
         &self,
         ttf_data: Vec<u8>,
@@ -253,6 +257,14 @@ mod tests {
     }
     fn dec_dots(b: &[u8]) -> Vec<Dot> {
         editor_crdt::wire::decode_dots(b).unwrap()
+    }
+
+    fn load_test_font() -> Vec<u8> {
+        std::fs::read(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../assets/Pretendard-Regular.ttf"
+        ))
+        .expect("test font not found")
     }
 
     #[test]
@@ -511,5 +523,24 @@ mod tests {
             result,
             Err(EditorError::Ffi(FfiError::CausalOrderViolation { .. }))
         ));
+    }
+
+    #[test]
+    fn outline_text_to_svg_forwards_svg_document() {
+        // FFI 래퍼가 outline_text_to_svg 결과를 그대로 전달해 SVG 문서를 반환하는지 확인한다.
+        let server = EditorServer;
+        let svg = server
+            .outline_text_to_svg(load_test_font(), "A".to_string())
+            .unwrap();
+        assert!(svg.starts_with(r#"<svg xmlns="http://www.w3.org/2000/svg""#));
+        assert!(svg.contains("<path d=\""));
+    }
+
+    #[test]
+    fn outline_text_to_svg_rejects_invalid_font_data() {
+        // 잘못된 폰트 바이트를 넘기면 FFI 래퍼도 에러를 그대로 반환해야 한다.
+        let server = EditorServer;
+        let result = server.outline_text_to_svg(vec![0, 1, 2, 3], "A".to_string());
+        assert!(result.is_err());
     }
 }

--- a/crates/editor-renderer/src/glyph/cache.rs
+++ b/crates/editor-renderer/src/glyph/cache.rs
@@ -1,6 +1,6 @@
 use hashbrown::HashMap;
 
-use crate::glyph::RasterizedGlyph;
+use crate::glyph::{RasterizedGlyph, SvgPathGlyph};
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct GlyphCacheKey {
@@ -41,8 +41,17 @@ struct CachedGlyph {
     font_version: u64,
 }
 
+struct CachedSvgPathGlyph {
+    result: Option<SvgPathGlyph>,
+    font_version: u64,
+}
+
 pub struct GlyphCache {
     map: HashMap<GlyphCacheKey, CachedGlyph>,
+}
+
+pub struct SvgPathGlyphCache {
+    map: HashMap<GlyphCacheKey, CachedSvgPathGlyph>,
 }
 
 impl GlyphCache {
@@ -80,5 +89,74 @@ impl GlyphCache {
                 font_version,
             },
         );
+    }
+}
+
+impl SvgPathGlyphCache {
+    pub fn new() -> Self {
+        Self {
+            map: HashMap::new(),
+        }
+    }
+
+    pub fn get(
+        &self,
+        key: &GlyphCacheKey,
+        current_font_version: u64,
+    ) -> Option<&Option<SvgPathGlyph>> {
+        let cached = self.map.get(key)?;
+        if cached.result.is_some() || cached.font_version == current_font_version {
+            Some(&cached.result)
+        } else {
+            None
+        }
+    }
+
+    pub fn insert(&mut self, key: GlyphCacheKey, result: Option<SvgPathGlyph>, font_version: u64) {
+        self.map.insert(
+            key,
+            CachedSvgPathGlyph {
+                result,
+                font_version,
+            },
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{GlyphCacheKey, SvgPathGlyphCache};
+    use crate::glyph::SvgPathGlyph;
+    use crate::types::{Path, PathElement};
+
+    #[test]
+    fn svg_path_cache_preserves_svg_path_glyph() {
+        // SVG path glyph cache 가 SVG path 기반 글리프 표현을 그대로 저장하고
+        // 다시 꺼낼 수 있는지 확인한다.
+        let mut cache = SvgPathGlyphCache::new();
+        let key = GlyphCacheKey::new(1, 400, 42, 16.0, false, false, 0);
+        let glyph = SvgPathGlyph {
+            path: Path {
+                elements: vec![
+                    PathElement::MoveTo { x: 0.0, y: 0.0 },
+                    PathElement::LineTo { x: 1.0, y: 0.0 },
+                    PathElement::Close,
+                ],
+            },
+            placement_left: 3,
+            placement_top: 4,
+        };
+
+        cache.insert(key, Some(glyph), 7);
+
+        let cached = cache
+            .get(&key, 7)
+            .expect("cache entry must exist")
+            .as_ref()
+            .expect("cache entry must contain glyph");
+
+        assert_eq!(cached.placement_left, 3);
+        assert_eq!(cached.placement_top, 4);
+        assert_eq!(cached.path.elements.len(), 3);
     }
 }

--- a/crates/editor-renderer/src/glyph/mod.rs
+++ b/crates/editor-renderer/src/glyph/mod.rs
@@ -8,10 +8,10 @@ mod outline_pen;
 mod scaler;
 mod scratch;
 
-pub use cache::GlyphCache;
+pub use cache::{GlyphCache, SvgPathGlyphCache};
 pub use scaler::ScaleContext;
 
-use crate::types::Transform as RenderTransform;
+use crate::types::{Path, Transform as RenderTransform};
 use cache::GlyphCacheKey;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -31,10 +31,30 @@ pub struct RasterizedGlyph {
 }
 
 #[derive(Debug, Clone)]
+pub struct SvgPathGlyph {
+    pub path: Path,
+    pub placement_left: i32,
+    pub placement_top: i32,
+}
+
+#[derive(Debug, Clone)]
 pub struct PositionedGlyph {
     pub raster: RasterizedGlyph,
     pub blit_x: i32,
     pub blit_y: i32,
+}
+
+#[derive(Debug, Clone)]
+pub struct PositionedSvgPathGlyph {
+    pub path: SvgPathGlyph,
+    pub blit_x: i32,
+    pub blit_y: i32,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PositionedGlyphs {
+    pub rasters: Vec<PositionedGlyph>,
+    pub svg_paths: Vec<PositionedSvgPathGlyph>,
 }
 
 /// base_transform 의 2×3 매트릭스로 logical (x, y) 를 매핑한다.
@@ -49,18 +69,22 @@ pub fn rasterize(
     fonts: &editor_resource::FontRegistry,
     scale_ctx: &mut ScaleContext,
     cache: &mut GlyphCache,
+    svg_path_cache: &mut SvgPathGlyphCache,
     scale_factor: f32,
     base_transform: RenderTransform,
-) -> Vec<PositionedGlyph> {
+) -> PositionedGlyphs {
     let Some(font_data) = fonts.font_data(run.family_id, run.weight) else {
-        return Vec::new();
+        return PositionedGlyphs::default();
     };
     let font_version = fonts.font_version(run.family_id, run.weight);
     let scaled_font_size = run.font_size * scale_factor;
     let has_skew = run.synthesis.skew.is_some();
     let embolden = run.synthesis.embolden;
 
-    let mut out = Vec::with_capacity(run.glyphs.len());
+    let mut out = PositionedGlyphs {
+        rasters: Vec::with_capacity(run.glyphs.len()),
+        svg_paths: Vec::with_capacity(run.glyphs.len()),
+    };
     for g in &run.glyphs {
         if g.id == 0 {
             continue;
@@ -84,6 +108,34 @@ pub fn rasterize(
             subpixel_x,
         );
 
+        let svg_path = match svg_path_cache.get(&key, font_version) {
+            Some(entry) => entry.clone(),
+            None => {
+                let r = scaler::svg_path_glyph(
+                    scale_ctx,
+                    font_data,
+                    g.id,
+                    scaled_font_size,
+                    embolden,
+                    run.synthesis.skew,
+                    subpixel_x as f32 / 4.0,
+                );
+                svg_path_cache.insert(key, r.clone(), font_version);
+                r
+            }
+        };
+
+        if let Some(path) = svg_path {
+            let blit_x = snapped_x.floor() as i32 + path.placement_left;
+            let blit_y = glyph_y_device.floor() as i32 - path.placement_top;
+            out.svg_paths.push(PositionedSvgPathGlyph {
+                path,
+                blit_x,
+                blit_y,
+            });
+            continue;
+        }
+
         let raster = match cache.get(&key, font_version) {
             Some(entry) => entry.clone(),
             None => {
@@ -106,7 +158,7 @@ pub fn rasterize(
         let blit_x = snapped_x.floor() as i32 + raster.placement_left;
         let blit_y = glyph_y_device.floor() as i32 - raster.placement_top;
 
-        out.push(PositionedGlyph {
+        out.rasters.push(PositionedGlyph {
             raster,
             blit_x,
             blit_y,

--- a/crates/editor-renderer/src/glyph/scaler.rs
+++ b/crates/editor-renderer/src/glyph/scaler.rs
@@ -2,6 +2,7 @@ use skrifa::instance::{LocationRef, NormalizedCoord, Size};
 use skrifa::outline::DrawSettings;
 use skrifa::{FontRef, GlyphId, MetadataProvider};
 use zeno::Transform as ZTransform;
+use zeno::{Point, Verb};
 
 use super::bitmap::rasterize_bitmap;
 use super::color::rasterize_color_outline;
@@ -10,7 +11,8 @@ use super::mask::rasterize_outline_to_mask;
 use super::outline::Outline;
 use super::outline_pen::OutlineWriter;
 use super::scratch::GlyphScratch;
-use super::{Content, RasterizedGlyph};
+use super::{Content, RasterizedGlyph, SvgPathGlyph};
+use crate::types::{Path, PathElement};
 
 pub const EMBOLDEN_RATIO: f32 = 1.0 / 64.0;
 
@@ -45,8 +47,6 @@ pub fn rasterize_glyph(
     skew: Option<f32>,
     subpixel_offset_x: f32,
 ) -> Option<RasterizedGlyph> {
-    let font = FontRef::from_index(font_data, 0).ok()?;
-    let gid = GlyphId::new(glyph_id);
     let has_skew = skew.is_some();
 
     let size_q4 = (font_size * 4.0).round() as u32;
@@ -79,10 +79,10 @@ pub fn rasterize_glyph(
     }
 
     if try_outline_before_bitmap {
-        if let Some(r) = try_outline(
+        if let Some(r) = try_outline_raster(
             ctx,
-            &font,
-            gid,
+            font_data,
+            glyph_id,
             quantized_size,
             embolden_amount,
             skew_transform,
@@ -99,10 +99,10 @@ pub fn rasterize_glyph(
     if let Some(r) = rasterize_bitmap(ctx, font_data, glyph_id, quantized_size) {
         return Some(r);
     }
-    try_outline(
+    try_outline_raster(
         ctx,
-        &font,
-        gid,
+        font_data,
+        glyph_id,
         quantized_size,
         embolden_amount,
         skew_transform,
@@ -110,15 +110,56 @@ pub fn rasterize_glyph(
     )
 }
 
-fn try_outline(
+pub fn svg_path_glyph(
     ctx: &mut ScaleContext,
-    font: &FontRef<'_>,
-    gid: GlyphId,
+    font_data: &[u8],
+    glyph_id: u32,
+    font_size: f32,
+    embolden: bool,
+    skew: Option<f32>,
+    subpixel_offset_x: f32,
+) -> Option<SvgPathGlyph> {
+    let size_q4 = (font_size * 4.0).round() as u32;
+    let quantized_size = size_q4 as f32 / 4.0;
+    let embolden_amount = if embolden {
+        quantized_size * EMBOLDEN_RATIO
+    } else {
+        0.0
+    };
+    let skew_transform = skew.map(|angle| {
+        let kx = (angle as f64).to_radians().tan() as f32;
+        ZTransform {
+            xx: 1.0,
+            yx: kx,
+            xy: 0.0,
+            yy: 1.0,
+            x: 0.0,
+            y: 0.0,
+        }
+    });
+
+    try_outline_svg_path(
+        ctx,
+        font_data,
+        glyph_id,
+        quantized_size,
+        embolden_amount,
+        skew_transform,
+        subpixel_offset_x,
+    )
+}
+
+fn try_outline_raster(
+    ctx: &mut ScaleContext,
+    font_data: &[u8],
+    glyph_id: u32,
     quantized_size: f32,
     embolden_amount: f32,
     skew_transform: Option<ZTransform>,
     subpixel_offset_x: f32,
 ) -> Option<RasterizedGlyph> {
+    let font = FontRef::from_index(font_data, 0).ok()?;
+    let gid = GlyphId::new(glyph_id);
     let outlines = font.outline_glyphs();
     let og = outlines.get(gid)?;
 
@@ -172,4 +213,162 @@ fn try_outline(
         placement_top: placement.top,
         content: Content::Mask,
     })
+}
+
+fn try_outline_svg_path(
+    ctx: &mut ScaleContext,
+    font_data: &[u8],
+    glyph_id: u32,
+    quantized_size: f32,
+    embolden_amount: f32,
+    skew_transform: Option<ZTransform>,
+    subpixel_offset_x: f32,
+) -> Option<SvgPathGlyph> {
+    let font = FontRef::from_index(font_data, 0).ok()?;
+    let gid = GlyphId::new(glyph_id);
+    let outlines = font.outline_glyphs();
+    let og = outlines.get(gid)?;
+
+    let size = Size::new(quantized_size);
+    let coords: &[NormalizedCoord] = &[];
+
+    let font_bytes = font.data().as_bytes();
+    let id = [font_bytes.as_ptr() as u64, font_bytes.len() as u64];
+
+    let settings = if let Some(instance) = ctx.hinting_cache.get(id, &outlines, size, coords) {
+        DrawSettings::hinted(instance, false)
+    } else {
+        DrawSettings::unhinted(size, LocationRef::new(coords))
+    };
+
+    ctx.outline.clear();
+    og.draw(settings, &mut OutlineWriter(&mut ctx.outline))
+        .ok()?;
+
+    if ctx.outline.is_empty() {
+        return None;
+    }
+
+    if embolden_amount > 0.0 {
+        ctx.outline.embolden(embolden_amount, embolden_amount);
+    }
+
+    if let Some(t) = skew_transform {
+        ctx.outline.transform(&t);
+    }
+
+    build_svg_path_glyph(&ctx.outline, subpixel_offset_x)
+}
+
+fn build_svg_path_glyph(outline: &Outline, subpixel_offset_x: f32) -> Option<SvgPathGlyph> {
+    let (min, max) = outline_point_bounds(outline.points())?;
+    let placement_left = (min.x + subpixel_offset_x).floor() as i32;
+    let placement_top = max.y.ceil() as i32;
+    let mut points = outline.points().iter();
+    let mut elements = Vec::with_capacity(outline.verbs().len());
+
+    for verb in outline.verbs() {
+        match verb {
+            Verb::MoveTo => {
+                let p = *points.next()?;
+                elements.push(PathElement::MoveTo {
+                    x: p.x - placement_left as f32,
+                    y: placement_top as f32 - p.y,
+                });
+            }
+            Verb::LineTo => {
+                let p = *points.next()?;
+                elements.push(PathElement::LineTo {
+                    x: p.x - placement_left as f32,
+                    y: placement_top as f32 - p.y,
+                });
+            }
+            Verb::QuadTo => {
+                let c = *points.next()?;
+                let p = *points.next()?;
+                elements.push(PathElement::QuadTo {
+                    x1: c.x - placement_left as f32,
+                    y1: placement_top as f32 - c.y,
+                    x: p.x - placement_left as f32,
+                    y: placement_top as f32 - p.y,
+                });
+            }
+            Verb::CurveTo => {
+                let c1 = *points.next()?;
+                let c2 = *points.next()?;
+                let p = *points.next()?;
+                elements.push(PathElement::CurveTo {
+                    x1: c1.x - placement_left as f32,
+                    y1: placement_top as f32 - c1.y,
+                    x2: c2.x - placement_left as f32,
+                    y2: placement_top as f32 - c2.y,
+                    x: p.x - placement_left as f32,
+                    y: placement_top as f32 - p.y,
+                });
+            }
+            Verb::Close => elements.push(PathElement::Close),
+        }
+    }
+
+    if elements.is_empty() {
+        return None;
+    }
+
+    Some(SvgPathGlyph {
+        path: Path { elements },
+        placement_left,
+        placement_top,
+    })
+}
+
+fn outline_point_bounds(points: &[Point]) -> Option<(Point, Point)> {
+    if points.is_empty() {
+        return None;
+    }
+    let mut min = points[0];
+    let mut max = points[0];
+    for p in &points[1..] {
+        if p.x < min.x {
+            min.x = p.x;
+        }
+        if p.y < min.y {
+            min.y = p.y;
+        }
+        if p.x > max.x {
+            max.x = p.x;
+        }
+        if p.y > max.y {
+            max.y = p.y;
+        }
+    }
+    Some((min, max))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_svg_path_glyph;
+    use crate::glyph::outline::Outline;
+    use crate::types::PathElement;
+    use zeno::Point;
+
+    #[test]
+    fn build_svg_path_glyph_flips_y_and_localizes_points() {
+        // outline glyph 좌표를 SVG path 캐시용 local 좌표계로 변환하는지 확인한다.
+        let mut outline = Outline::new();
+        outline.move_to(Point::new(12.0, 24.0));
+        outline.line_to(Point::new(16.0, 20.0));
+        outline.close();
+
+        let glyph = build_svg_path_glyph(&outline, 0.0).expect("path glyph must exist");
+
+        assert!(matches!(
+            glyph.path.elements[0],
+            PathElement::MoveTo { x, y } if x == 0.0 && y == 0.0
+        ));
+        assert!(matches!(
+            glyph.path.elements[1],
+            PathElement::LineTo { x, y } if x == 4.0 && y == 4.0
+        ));
+        assert!(matches!(glyph.path.elements[2], PathElement::Close));
+    }
 }

--- a/crates/editor-renderer/src/renderer.rs
+++ b/crates/editor-renderer/src/renderer.rs
@@ -6,7 +6,9 @@ use editor_view::style::{BoxStyle, DecorationData};
 use editor_view::{Edges, LineMetrics, PageRect, PageVisitor, TableLayoutInfo};
 use std::sync::{Arc, Mutex};
 
-use crate::glyph::{Content, GlyphCache, ScaleContext};
+use crate::glyph::{
+    Content, GlyphCache, PositionedGlyph, PositionedSvgPathGlyph, ScaleContext, SvgPathGlyphCache,
+};
 use crate::icons::ICONS;
 use crate::sink::RenderSink;
 use crate::types::{
@@ -40,6 +42,32 @@ fn bake_mask_to_premul_rgba(mask: &[u8], width: u32, height: u32, color: Color) 
         width,
         height,
     }
+}
+
+fn draw_positioned_raster_glyph(sink: &mut dyn RenderSink, pg: &PositionedGlyph, color: Color) {
+    let image = match pg.raster.content {
+        Content::Mask => {
+            bake_mask_to_premul_rgba(&pg.raster.data, pg.raster.width, pg.raster.height, color)
+        }
+        Content::Color => Image {
+            data: pg.raster.data.clone(),
+            width: pg.raster.width,
+            height: pg.raster.height,
+        },
+    };
+
+    let t = Transform::IDENTITY.translate(pg.blit_x as f32, pg.blit_y as f32);
+    let rect = Rect::from_xywh(0.0, 0.0, image.width as f32, image.height as f32);
+    sink.draw_image(&image, rect, t);
+}
+
+fn draw_positioned_svg_path_glyph(
+    sink: &mut dyn RenderSink,
+    pg: &PositionedSvgPathGlyph,
+    color: Color,
+) {
+    let t = Transform::IDENTITY.translate(pg.blit_x as f32, pg.blit_y as f32);
+    sink.fill_path(&pg.path.path, color, t);
 }
 
 fn callout_token(variant: editor_model::CalloutVariant) -> &'static str {
@@ -457,6 +485,7 @@ pub struct Renderer {
     pub(crate) resource: Arc<Mutex<Resource>>,
     pub(crate) scale_ctx: ScaleContext,
     pub(crate) glyph_cache: GlyphCache,
+    pub(crate) svg_path_glyph_cache: SvgPathGlyphCache,
 }
 
 impl Renderer {
@@ -465,6 +494,7 @@ impl Renderer {
             resource,
             scale_ctx: ScaleContext::new(),
             glyph_cache: GlyphCache::new(),
+            svg_path_glyph_cache: SvgPathGlyphCache::new(),
         }
     }
 
@@ -735,29 +765,17 @@ impl<'a> RenderVisitor<'a> {
                 &resource_guard.font_registry,
                 &mut self.renderer.scale_ctx,
                 &mut self.renderer.glyph_cache,
+                &mut self.renderer.svg_path_glyph_cache,
                 self.scale_factor,
                 base_transform,
             );
             drop(resource_guard);
 
-            for pg in &positioned {
-                let image = match pg.raster.content {
-                    Content::Mask => bake_mask_to_premul_rgba(
-                        &pg.raster.data,
-                        pg.raster.width,
-                        pg.raster.height,
-                        color,
-                    ),
-                    Content::Color => Image {
-                        data: pg.raster.data.clone(),
-                        width: pg.raster.width,
-                        height: pg.raster.height,
-                    },
-                };
-
-                let t = Transform::IDENTITY.translate(pg.blit_x as f32, pg.blit_y as f32);
-                let rect = Rect::from_xywh(0.0, 0.0, image.width as f32, image.height as f32);
-                self.sink.draw_image(&image, rect, t);
+            for pg in &positioned.rasters {
+                draw_positioned_raster_glyph(self.sink, pg, color);
+            }
+            for pg in &positioned.svg_paths {
+                draw_positioned_svg_path_glyph(self.sink, pg, color);
             }
         }
     }
@@ -795,28 +813,17 @@ impl<'a> RenderVisitor<'a> {
                 &resource_guard.font_registry,
                 &mut self.renderer.scale_ctx,
                 &mut self.renderer.glyph_cache,
+                &mut self.renderer.svg_path_glyph_cache,
                 self.scale_factor,
                 base_transform,
             );
             drop(resource_guard);
 
-            for pg in &positioned {
-                let image = match pg.raster.content {
-                    Content::Mask => bake_mask_to_premul_rgba(
-                        &pg.raster.data,
-                        pg.raster.width,
-                        pg.raster.height,
-                        color,
-                    ),
-                    Content::Color => Image {
-                        data: pg.raster.data.clone(),
-                        width: pg.raster.width,
-                        height: pg.raster.height,
-                    },
-                };
-                let t = Transform::IDENTITY.translate(pg.blit_x as f32, pg.blit_y as f32);
-                let rect = Rect::from_xywh(0.0, 0.0, image.width as f32, image.height as f32);
-                self.sink.draw_image(&image, rect, t);
+            for pg in &positioned.rasters {
+                draw_positioned_raster_glyph(self.sink, pg, color);
+            }
+            for pg in &positioned.svg_paths {
+                draw_positioned_svg_path_glyph(self.sink, pg, color);
             }
         }
     }
@@ -1760,7 +1767,7 @@ mod tests {
     }
 
     #[test]
-    fn line_with_ruby_annotation_invokes_ruby_raster_path() {
+    fn line_with_ruby_annotation_invokes_ruby_svg_path_rendering() {
         use editor_view::glyph_run::{Glyph, RubyAnnotation, Synthesis};
 
         // Pretendard-Regular 'A' (U+0041) is glyph id 3, which has an outline.
@@ -1768,6 +1775,7 @@ mod tests {
 
         #[derive(Default)]
         struct CountingSink {
+            path_fills: usize,
             image_draws: usize,
         }
         impl RenderSink for CountingSink {
@@ -1775,7 +1783,9 @@ mod tests {
                 (1000, 1000)
             }
             fn fill_rect(&mut self, _r: Rect, _c: Color, _t: Transform) {}
-            fn fill_path(&mut self, _p: &Path, _c: Color, _t: Transform) {}
+            fn fill_path(&mut self, _p: &Path, _c: Color, _t: Transform) {
+                self.path_fills += 1;
+            }
             fn stroke_path(&mut self, _p: &Path, _c: Color, _s: &Stroke, _t: Transform) {}
             fn draw_glyph_run(
                 &mut self,
@@ -1835,12 +1845,76 @@ mod tests {
             &[ruby],
         );
 
-        // No base glyphs, but at least one ruby glyph raster must have been produced.
-        // The exact image_draws count depends on glyph cache state, but must be > 0.
+        // Pretendard outline glyph 는 SVG path glyph 로 캐시되어 fill_path 경로로 렌더되어야 한다.
         assert!(
-            sink.image_draws > 0,
-            "ruby annotation glyph must be rasterized"
+            sink.path_fills > 0,
+            "ruby annotation glyph must be rendered through fill_path"
         );
+        assert_eq!(sink.image_draws, 0);
+    }
+
+    #[test]
+    fn svg_path_glyphs_are_filled_instead_of_drawn_as_images() {
+        // SVG path 캐시 glyph 는 이미지 draw 경로가 아니라 fill_path 로 렌더되어야 한다.
+        #[derive(Default)]
+        struct CountingSink {
+            path_fills: usize,
+            image_draws: usize,
+        }
+
+        impl RenderSink for CountingSink {
+            fn pixel_size(&self) -> (u32, u32) {
+                (100, 100)
+            }
+            fn fill_rect(&mut self, _r: Rect, _c: Color, _t: Transform) {}
+            fn fill_path(&mut self, _p: &Path, _c: Color, _t: Transform) {
+                self.path_fills += 1;
+            }
+            fn stroke_path(&mut self, _p: &Path, _c: Color, _s: &Stroke, _t: Transform) {}
+            fn draw_glyph_run(
+                &mut self,
+                _r: &editor_view::glyph_run::GlyphRun,
+                _c: Color,
+                _t: Transform,
+                _f: &editor_resource::FontRegistry,
+            ) {
+            }
+            fn draw_image(&mut self, _i: &Image, _r: Rect, _t: Transform) {
+                self.image_draws += 1;
+            }
+        }
+
+        let glyph = PositionedSvgPathGlyph {
+            path: crate::glyph::SvgPathGlyph {
+                path: Path {
+                    elements: vec![
+                        PathElement::MoveTo { x: 0.0, y: 0.0 },
+                        PathElement::LineTo { x: 4.0, y: 0.0 },
+                        PathElement::LineTo { x: 4.0, y: 4.0 },
+                        PathElement::Close,
+                    ],
+                },
+                placement_left: 0,
+                placement_top: 0,
+            },
+            blit_x: 12,
+            blit_y: 24,
+        };
+
+        let mut sink = CountingSink::default();
+        draw_positioned_svg_path_glyph(
+            &mut sink,
+            &glyph,
+            Color {
+                r: 0,
+                g: 0,
+                b: 0,
+                a: 255,
+            },
+        );
+
+        assert_eq!(sink.path_fills, 1);
+        assert_eq!(sink.image_draws, 0);
     }
 
     #[test]

--- a/crates/editor-server/src/font/mod.rs
+++ b/crates/editor-server/src/font/mod.rs
@@ -1,5 +1,7 @@
 mod encode;
 mod metadata;
+mod svg;
 
 pub use encode::*;
 pub use metadata::*;
+pub use svg::*;

--- a/crates/editor-server/src/font/svg.rs
+++ b/crates/editor-server/src/font/svg.rs
@@ -1,0 +1,189 @@
+use skrifa::instance::{LocationRef, Size};
+use skrifa::outline::OutlinePen;
+use skrifa::{FontRef, MetadataProvider};
+use std::fmt::Write;
+
+use crate::ServerError;
+
+const SVG_PPEM: f32 = 100.0;
+
+struct SvgPathPen {
+    d: String,
+    x_offset: f32,
+    min_x: f32,
+    min_y: f32,
+    max_x: f32,
+    max_y: f32,
+}
+
+impl SvgPathPen {
+    fn new() -> Self {
+        Self {
+            d: String::new(),
+            x_offset: 0.0,
+            min_x: f32::MAX,
+            min_y: f32::MAX,
+            max_x: f32::MIN,
+            max_y: f32::MIN,
+        }
+    }
+
+    fn track(&mut self, x: f32, y: f32) {
+        self.min_x = self.min_x.min(x);
+        self.min_y = self.min_y.min(y);
+        self.max_x = self.max_x.max(x);
+        self.max_y = self.max_y.max(y);
+    }
+
+    fn fmt(v: f32) -> f32 {
+        (v * 10.0).round() / 10.0
+    }
+
+    fn sx(&self, x: f32) -> f32 {
+        Self::fmt(x + self.x_offset)
+    }
+
+    fn sy(y: f32) -> f32 {
+        Self::fmt(-y)
+    }
+}
+
+impl OutlinePen for SvgPathPen {
+    fn move_to(&mut self, x: f32, y: f32) {
+        let (sx, sy) = (self.sx(x), Self::sy(y));
+        self.track(sx, sy);
+        let _ = write!(self.d, "M{sx} {sy}");
+    }
+
+    fn line_to(&mut self, x: f32, y: f32) {
+        let (sx, sy) = (self.sx(x), Self::sy(y));
+        self.track(sx, sy);
+        let _ = write!(self.d, "L{sx} {sy}");
+    }
+
+    fn quad_to(&mut self, cx: f32, cy: f32, x: f32, y: f32) {
+        let (scx, scy) = (self.sx(cx), Self::sy(cy));
+        let (sx, sy) = (self.sx(x), Self::sy(y));
+        self.track(scx, scy);
+        self.track(sx, sy);
+        let _ = write!(self.d, "Q{scx} {scy} {sx} {sy}");
+    }
+
+    fn curve_to(&mut self, cx1: f32, cy1: f32, cx2: f32, cy2: f32, x: f32, y: f32) {
+        let (scx1, scy1) = (self.sx(cx1), Self::sy(cy1));
+        let (scx2, scy2) = (self.sx(cx2), Self::sy(cy2));
+        let (sx, sy) = (self.sx(x), Self::sy(y));
+        self.track(scx1, scy1);
+        self.track(scx2, scy2);
+        self.track(sx, sy);
+        let _ = write!(self.d, "C{scx1} {scy1} {scx2} {scy2} {sx} {sy}");
+    }
+
+    fn close(&mut self) {
+        self.d.push('Z');
+    }
+}
+
+pub fn outline_text_to_svg(font_data: &[u8], text: &str) -> Result<String, ServerError> {
+    let font = FontRef::new(font_data).map_err(|e| ServerError::InvalidFont(e.to_string()))?;
+    let size = Size::new(SVG_PPEM);
+    let loc = LocationRef::default();
+    let glyph_metrics = font.glyph_metrics(size, loc);
+    let charmap = font.charmap();
+    let outlines = font.outline_glyphs();
+
+    let mut pen = SvgPathPen::new();
+    let mut cursor_x = 0.0_f32;
+
+    for ch in text.chars() {
+        let gid = charmap
+            .map(ch)
+            .ok_or_else(|| ServerError::InvalidFont(format!("missing glyph for '{ch}'")))?;
+        pen.x_offset = cursor_x;
+        if let Some(glyph) = outlines.get(gid) {
+            let _ = glyph.draw(size, &mut pen);
+        }
+        cursor_x += glyph_metrics.advance_width(gid).unwrap_or(0.0);
+    }
+
+    if pen.d.is_empty() {
+        return Err(ServerError::InvalidFont("no glyphs to render".into()));
+    }
+
+    let min_x = pen.min_x;
+    let width = SvgPathPen::fmt(pen.max_x - pen.min_x);
+    let glyph_center_y = (pen.min_y + pen.max_y) / 2.0;
+    let min_y = SvgPathPen::fmt(glyph_center_y - SVG_PPEM / 2.0);
+    let height = SVG_PPEM;
+
+    Ok(format!(
+        r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="{min_x} {min_y} {width} {height}" fill="currentColor"><path d="{}"/></svg>"#,
+        pen.d
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use skrifa::MetadataProvider;
+
+    fn load_test_font() -> Vec<u8> {
+        std::fs::read(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../assets/Pretendard-Regular.ttf"
+        ))
+        .expect("test font not found")
+    }
+
+    fn first_outline_char(data: &[u8]) -> char {
+        let font = FontRef::new(data).expect("valid test font");
+        let outlines = font.outline_glyphs();
+        font.charmap()
+            .mappings()
+            .find_map(|(cp, gid)| {
+                let glyph = outlines.get(gid)?;
+                let mut pen = SvgPathPen::new();
+                glyph.draw(Size::new(SVG_PPEM), &mut pen).ok()?;
+                (!pen.d.is_empty()).then(|| char::from_u32(cp)).flatten()
+            })
+            .expect("test font must contain at least one outline glyph")
+    }
+
+    fn svg_width(svg: &str) -> f32 {
+        let key = "viewBox=\"";
+        let start = svg.find(key).expect("svg must contain viewBox") + key.len();
+        let end = svg[start..].find('"').expect("viewBox must be closed") + start;
+        let values: Vec<f32> = svg[start..end]
+            .split_whitespace()
+            .map(|v| v.parse::<f32>().expect("viewBox values must be numbers"))
+            .collect();
+        *values.get(2).expect("viewBox must contain width")
+    }
+
+    #[test]
+    fn outline_text_to_svg_returns_svg_document() {
+        let data = load_test_font();
+        let text = first_outline_char(&data).to_string();
+        let svg = outline_text_to_svg(&data, &text).unwrap();
+        assert!(svg.starts_with(r#"<svg xmlns="http://www.w3.org/2000/svg""#));
+        assert!(svg.contains("<path d=\""));
+        assert!(svg.contains("fill=\"currentColor\""));
+    }
+
+    #[test]
+    fn outline_text_to_svg_rejects_invalid_font() {
+        let result = outline_text_to_svg(&[0, 1, 2, 3], "Test");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn outline_text_to_svg_applies_advance_width_between_glyphs() {
+        // 여러 글자를 그릴 때 glyph advance width 가 반영되어 SVG viewBox 폭이 커지는지 확인한다.
+        let data = load_test_font();
+        let ch = first_outline_char(&data);
+        let single = outline_text_to_svg(&data, &ch.to_string()).unwrap();
+        let doubled = outline_text_to_svg(&data, &format!("{ch}{ch}")).unwrap();
+
+        assert!(svg_width(&doubled) > svg_width(&single));
+    }
+}


### PR DESCRIPTION
COLR_v0 글리프 렌더링은 이미 구현이 되어 있어서, 에디터 엔진에서 SVG 폰트 글리프 렌더링을 지원하는 기능을 추가했습니다. SVG Path를 fill_path로 캐싱하고, 렌더링 할 수 있게 구현했습니다.