### PR TITLE
fix: match 하이라이트 오프셋 수정

### DIFF
--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -760,13 +760,15 @@ export class Editor {
     if (idx === undefined) return;
     const match = this.#searchMatches[idx];
     if (!match) return;
+    const live = this.#wasm.tracked_ranges('search-match').find((r) => r.id === match.id);
+    const selection = live && !live.invalid ? { anchor: live.anchor, head: live.head } : match.selection;
     this.enqueue({
       type: 'tracked_range',
       op: {
         type: 'add',
         id: `search-match-active:${match.id}`,
         group: 'search-match-active',
-        selection: match.selection,
+        selection,
         metadata: '',
       },
     });


### PR DESCRIPTION
`#applyActiveMark`에서  this.#wasm.tracked_ranges('search-match')로 현재 anchoring된 위치를 직접 조회해 active 하이라이트의 selection으로 사용. 
초기 search() 호출 시점(아직 tick 전이라 tracked range 미생성)에는 fresh한 match.selection으로 fallback.                