### PR TITLE
IME 조합 디버그

### DIFF
--- a/apps/website/src/lib/editor-ffi/input/ime-input-adapter.test.ts
+++ b/apps/website/src/lib/editor-ffi/input/ime-input-adapter.test.ts
@@ -4,10 +4,52 @@ import { describe, expect, it } from 'vitest';
 import { ImeInputAdapter } from './ime-input-adapter';
 import { beforeInputEvent, compositionEvent, context, inputEvent } from './ime-test-fixtures';
 import type { Message } from '@typie/editor-ffi/browser';
+import type { ImeContext } from './ime-context';
+
+const createInput = () => document.createElement('input');
+
+const createImeHarness = (initialContext: ImeContext) => {
+  const input = createInput();
+  const messages: Message[] = [];
+  let editorContext = initialContext;
+  const adapter = new ImeInputAdapter({
+    readContext: () => editorContext,
+    enqueue: (next) => messages.push(...next),
+  });
+
+  return {
+    input,
+    messages,
+    adapter,
+    setContext: (context: ImeContext) => {
+      editorContext = context;
+    },
+    syncFromEditor: () => adapter.syncFromEditor(input),
+    compositionStart: (data = '') => adapter.handleCompositionStart(compositionEvent(input, data)),
+    compositionUpdate: (data: string) => adapter.handleCompositionUpdate(compositionEvent(input, data)),
+    compositionEnd: () => adapter.handleCompositionEnd(),
+    beforeCompositionInput: (text: string) => adapter.handleBeforeInput(beforeInputEvent(input, 'insertCompositionText', text)),
+    beforeTextInput: (text: string) => {
+      const event = beforeInputEvent(input, 'insertText', text);
+      adapter.handleBeforeInput(event);
+      return event;
+    },
+    applyNativeInput: (value: string, selectionStart: number, selectionEnd = selectionStart) => {
+      input.value = value;
+      input.setSelectionRange(selectionStart, selectionEnd);
+      adapter.handleInput(inputEvent(input));
+    },
+    expectInput: (value: string, selectionStart: number, selectionEnd = selectionStart) => {
+      expect(input.value).toBe(value);
+      expect(input.selectionStart).toBe(selectionStart);
+      expect(input.selectionEnd).toBe(selectionEnd);
+    },
+  };
+};
 
 describe('ImeInputAdapter', () => {
   it('captures context during beforeinput and diffs the following native input mutation', () => {
-    const input = document.createElement('input');
+    const input = createInput();
     const messages: Message[] = [];
     const adapter = new ImeInputAdapter({
       readContext: () => context(''),
@@ -35,7 +77,7 @@ describe('ImeInputAdapter', () => {
   });
 
   it('anchors repeated-character insertions to the beforeinput collapsed selection', () => {
-    const input = document.createElement('input');
+    const input = createInput();
     const messages: Message[] = [];
     const adapter = new ImeInputAdapter({
       readContext: () => ({
@@ -69,7 +111,7 @@ describe('ImeInputAdapter', () => {
   });
 
   it('does not rewrite the native input when editor sync only rebases the same local IME window', () => {
-    const input = document.createElement('input');
+    const input = createInput();
     const messages: Message[] = [];
     let syncCount = 0;
     const adapter = new ImeInputAdapter({
@@ -117,7 +159,7 @@ describe('ImeInputAdapter', () => {
   });
 
   it('uses the native DOM diff when the following native input appended', () => {
-    const input = document.createElement('input');
+    const input = createInput();
     const messages: Message[] = [];
     const adapter = new ImeInputAdapter({
       readContext: () => ({
@@ -156,7 +198,7 @@ describe('ImeInputAdapter', () => {
   });
 
   it('emits a replacement when the entire flat text is replaced with the same typed text', () => {
-    const input = document.createElement('input');
+    const input = createInput();
     const messages: Message[] = [];
     const adapter = new ImeInputAdapter({
       readContext: () => ({
@@ -192,7 +234,7 @@ describe('ImeInputAdapter', () => {
   });
 
   it('emits a replacement when selected text is replaced with the same typed text', () => {
-    const input = document.createElement('input');
+    const input = createInput();
     const messages: Message[] = [];
     const adapter = new ImeInputAdapter({
       readContext: () => ({
@@ -228,7 +270,7 @@ describe('ImeInputAdapter', () => {
   });
 
   it('prefers the native replacement diff when beforeinput selection points at the next character', () => {
-    const input = document.createElement('input');
+    const input = createInput();
     const messages: Message[] = [];
     const adapter = new ImeInputAdapter({
       readContext: () => ({
@@ -262,7 +304,7 @@ describe('ImeInputAdapter', () => {
   });
 
   it('keeps a collapsed native append as an insertion after many spaces', () => {
-    const input = document.createElement('input');
+    const input = createInput();
     const messages: Message[] = [];
     const spaces = ' '.repeat(79);
     const text = `\u2028${spaces}e\u2029`;
@@ -300,7 +342,7 @@ describe('ImeInputAdapter', () => {
   });
 
   it('does not turn a native collapsed insert into a synthetic previous-character replacement', () => {
-    const input = document.createElement('input');
+    const input = createInput();
     const messages: Message[] = [];
     const adapter = new ImeInputAdapter({
       readContext: () => ({
@@ -332,7 +374,7 @@ describe('ImeInputAdapter', () => {
   });
 
   it('maps input in an empty paragraph after previous text to the empty paragraph flat offset', () => {
-    const input = document.createElement('input');
+    const input = createInput();
     const messages: Message[] = [];
     const adapter = new ImeInputAdapter({
       readContext: () => ({
@@ -366,7 +408,7 @@ describe('ImeInputAdapter', () => {
   });
 
   it('does not suppress the next real input after a prevented line-break beforeinput', () => {
-    const input = document.createElement('input');
+    const input = createInput();
     const messages: Message[] = [];
     const adapter = new ImeInputAdapter({
       readContext: () => context(''),
@@ -394,7 +436,7 @@ describe('ImeInputAdapter', () => {
   });
 
   it('lets browser composition mutate the DOM and converts repeated updates to flat compose diffs', () => {
-    const input = document.createElement('input');
+    const input = createInput();
     const messages: Message[] = [];
     const adapter = new ImeInputAdapter({
       readContext: () => context(''),
@@ -446,7 +488,7 @@ describe('ImeInputAdapter', () => {
   });
 
   it('uses insertCompositionText data instead of duplicated native DOM preedit text', () => {
-    const input = document.createElement('input');
+    const input = createInput();
     const messages: Message[] = [];
     const adapter = new ImeInputAdapter({
       readContext: () => ({
@@ -491,7 +533,7 @@ describe('ImeInputAdapter', () => {
   });
 
   it('keeps repeated Korean preedit text growing after replacing selected text', () => {
-    const input = document.createElement('input');
+    const input = createInput();
     const messages: Message[] = [];
     const adapter = new ImeInputAdapter({
       readContext: () => ({
@@ -548,35 +590,297 @@ describe('ImeInputAdapter', () => {
   });
 
   it('starts composition when selected text is replaced with the same Korean preedit', () => {
-    const input = document.createElement('input');
-    const messages: Message[] = [];
-    const adapter = new ImeInputAdapter({
-      readContext: () => ({
-        text: '\u2028ㅁ\u2029',
-        windowStart: 0,
-        selection: { start: 1, end: 2 },
-        composing: null,
-      }),
-      enqueue: (next) => messages.push(...next),
+    const ime = createImeHarness({
+      text: '\u2028ㅁ\u2029',
+      windowStart: 0,
+      selection: { start: 1, end: 2 },
+      composing: null,
     });
 
-    adapter.syncFromEditor(input);
-    adapter.handleCompositionStart(compositionEvent(input));
+    ime.syncFromEditor();
+    ime.compositionStart();
+    ime.beforeCompositionInput('ㅁ');
+    ime.applyNativeInput('\u2028ㅁ\u2029', 2);
 
-    adapter.handleBeforeInput(beforeInputEvent(input, 'insertCompositionText', 'ㅁ'));
-    input.value = '\u2028ㅁ\u2029';
-    input.setSelectionRange(2, 2);
-    adapter.handleInput(inputEvent(input));
-
-    expect(input.value).toBe('\u2028ㅁ\u2029');
-    expect(input.selectionStart).toBe(2);
-    expect(input.selectionEnd).toBe(2);
-    expect(messages).toEqual([
+    ime.expectInput('\u2028ㅁ\u2029', 2);
+    expect(ime.messages).toEqual([
       {
         type: 'text_input',
         ops: [
           { type: 'set_composition', start: 1, end: 2 },
           { type: 'compose', text: 'ㅁ' },
+        ],
+      },
+    ]);
+  });
+
+  it('keeps appended Korean preedit text in composition after replacing the full IME buffer', () => {
+    const ime = createImeHarness({
+      text: '\u2028ㅁㄴ\u2029',
+      windowStart: 0,
+      selection: { start: 0, end: 4 },
+      composing: null,
+    });
+
+    ime.syncFromEditor();
+    ime.compositionStart();
+    ime.beforeCompositionInput('ㅁ');
+    ime.applyNativeInput('ㅁ', 1);
+
+    ime.setContext({
+      text: '\u2028ㅁ\u2029',
+      windowStart: 0,
+      selection: { start: 2, end: 2 },
+      composing: { start: 1, end: 2 },
+    });
+    ime.syncFromEditor();
+
+    ime.expectInput('\u2028ㅁ\u2029', 2);
+
+    const duplicateCommittedPreedit = ime.beforeTextInput('ㅁ');
+    expect(duplicateCommittedPreedit.preventDefault).toHaveBeenCalledOnce();
+    expect(ime.messages).toHaveLength(1);
+
+    ime.beforeCompositionInput('ㄴ');
+    ime.applyNativeInput('\u2028ㅁㄴ\u2029', 3);
+
+    ime.expectInput('\u2028ㅁㄴ\u2029', 3);
+
+    ime.setContext({
+      text: '\u2028ㅁㄴ\u2029',
+      windowStart: 0,
+      selection: { start: 3, end: 3 },
+      composing: { start: 2, end: 3 },
+    });
+    ime.syncFromEditor();
+
+    ime.compositionStart();
+    ime.beforeCompositionInput('ㅇ');
+    ime.applyNativeInput('\u2028ㅁㄴㅇ\u2029', 4);
+
+    ime.expectInput('\u2028ㅁㄴㅇ\u2029', 4);
+    expect(ime.messages).toEqual([
+      {
+        type: 'text_input',
+        ops: [
+          { type: 'set_composition', start: 0, end: 4 },
+          { type: 'compose', text: 'ㅁ' },
+        ],
+      },
+      {
+        type: 'text_input',
+        ops: [
+          { type: 'set_composition', start: 2, end: 2 },
+          { type: 'compose', text: 'ㄴ' },
+        ],
+      },
+      {
+        type: 'text_input',
+        ops: [
+          { type: 'set_composition', start: 3, end: 3 },
+          { type: 'compose', text: 'ㅇ' },
+        ],
+      },
+    ]);
+  });
+
+  it('syncs editor-restored structure while composing after replacing a structural selection', () => {
+    const ime = createImeHarness({
+      text: '\u2028\u2028\u2029\u2029',
+      windowStart: 0,
+      selection: { start: 0, end: 4 },
+      composing: null,
+    });
+
+    ime.syncFromEditor();
+    ime.compositionStart();
+    ime.beforeCompositionInput('ㅁ');
+    ime.applyNativeInput('ㅁ', 1);
+
+    ime.setContext({
+      text: '\u2028\u2028\u2029\u2029\u2028ㅁ\u2029',
+      windowStart: 0,
+      selection: { start: 6, end: 6 },
+      composing: { start: 5, end: 6 },
+    });
+    ime.syncFromEditor();
+
+    ime.expectInput('\u2028\u2028\u2029\u2029\u2028ㅁ\u2029', 6);
+
+    ime.compositionStart();
+    ime.beforeCompositionInput('ㄴ');
+    ime.applyNativeInput('\u2028\u2028\u2029\u2029\u2028ㅁㄴ\u2029', 7);
+
+    expect(ime.messages).toEqual([
+      {
+        type: 'text_input',
+        ops: [
+          { type: 'set_composition', start: 0, end: 4 },
+          { type: 'compose', text: 'ㅁ' },
+        ],
+      },
+      {
+        type: 'text_input',
+        ops: [
+          { type: 'set_composition', start: 6, end: 6 },
+          { type: 'compose', text: 'ㄴ' },
+        ],
+      },
+    ]);
+  });
+
+  it('infers composition when editor-restored structure omits it during a full-buffer replacement', () => {
+    const ime = createImeHarness({
+      text: '\u2028ㅁㄴㅇ\u2029',
+      windowStart: 0,
+      selection: { start: 0, end: 5 },
+      composing: null,
+    });
+
+    ime.syncFromEditor();
+    ime.compositionStart('\u2028ㅁㄴㅇ\u2029');
+    ime.compositionUpdate('ㅁ');
+    ime.beforeCompositionInput('ㅁ');
+    ime.applyNativeInput('ㅁ', 1);
+
+    ime.setContext({
+      text: '\u2028ㅁ\u2029',
+      windowStart: 0,
+      selection: { start: 2, end: 2 },
+      composing: null,
+    });
+    ime.syncFromEditor();
+
+    ime.expectInput('\u2028ㅁ\u2029', 2);
+
+    ime.compositionUpdate('ㅁ');
+    ime.beforeCompositionInput('ㅁ');
+    ime.applyNativeInput('\u2028ㅁ\u2029', 2);
+    ime.compositionEnd();
+
+    ime.compositionStart();
+    ime.compositionUpdate('ㄴ');
+    ime.beforeCompositionInput('ㄴ');
+    ime.applyNativeInput('\u2028ㅁㄴ\u2029', 3);
+
+    ime.expectInput('\u2028ㅁㄴ\u2029', 3);
+
+    ime.setContext({
+      text: '\u2028ㅁㄴ\u2029',
+      windowStart: 0,
+      selection: { start: 3, end: 3 },
+      composing: null,
+    });
+    ime.syncFromEditor();
+
+    const duplicateSecondPreedit = ime.beforeTextInput('ㄴ');
+    expect(duplicateSecondPreedit.preventDefault).toHaveBeenCalledOnce();
+
+    ime.compositionStart();
+    ime.compositionUpdate('ㅇ');
+    ime.beforeCompositionInput('ㅇ');
+    ime.applyNativeInput('\u2028ㅁㄴㅇ\u2029', 4);
+
+    ime.expectInput('\u2028ㅁㄴㅇ\u2029', 4);
+    expect(ime.messages).toEqual([
+      {
+        type: 'text_input',
+        ops: [
+          { type: 'set_composition', start: 0, end: 5 },
+          { type: 'compose', text: 'ㅁ' },
+        ],
+      },
+      {
+        type: 'text_input',
+        ops: [
+          { type: 'set_composition', start: 1, end: 2 },
+          { type: 'compose', text: 'ㅁ' },
+        ],
+      },
+      { type: 'text_input', ops: [{ type: 'commit_as_is' }] },
+      {
+        type: 'text_input',
+        ops: [
+          { type: 'set_composition', start: 2, end: 2 },
+          { type: 'compose', text: 'ㄴ' },
+        ],
+      },
+      {
+        type: 'text_input',
+        ops: [
+          { type: 'set_composition', start: 3, end: 3 },
+          { type: 'compose', text: 'ㅇ' },
+        ],
+      },
+    ]);
+  });
+
+  it('ignores duplicate committed preedit after replacing a selected empty paragraph', () => {
+    const ime = createImeHarness({
+      text: '\u2028\u2029',
+      windowStart: 0,
+      selection: { start: 0, end: 2 },
+      composing: null,
+    });
+
+    ime.syncFromEditor();
+    ime.compositionStart('\u2028\u2029');
+    ime.compositionUpdate('ㅁ');
+    ime.beforeCompositionInput('ㅁ');
+    ime.applyNativeInput('ㅁ', 1);
+
+    ime.setContext({
+      text: '\u2028ㅁ\u2029',
+      windowStart: 0,
+      selection: { start: 2, end: 2 },
+      composing: { start: 1, end: 2 },
+    });
+    ime.syncFromEditor();
+
+    const duplicateCommittedPreedit = ime.beforeTextInput('ㅁ');
+    expect(duplicateCommittedPreedit.preventDefault).toHaveBeenCalledOnce();
+
+    ime.compositionStart();
+    ime.compositionUpdate('ㄴ');
+    ime.beforeCompositionInput('ㄴ');
+    ime.applyNativeInput('\u2028ㅁㄴ\u2029', 3);
+
+    ime.setContext({
+      text: '\u2028ㅁㄴ\u2029',
+      windowStart: 0,
+      selection: { start: 3, end: 3 },
+      composing: { start: 2, end: 3 },
+    });
+    ime.syncFromEditor();
+
+    ime.compositionEnd();
+    ime.compositionStart();
+    ime.compositionUpdate('ㅇ');
+    ime.beforeCompositionInput('ㅇ');
+    ime.applyNativeInput('\u2028ㅁㄴㅇ\u2029', 4);
+
+    ime.expectInput('\u2028ㅁㄴㅇ\u2029', 4);
+    expect(ime.messages).toEqual([
+      {
+        type: 'text_input',
+        ops: [
+          { type: 'set_composition', start: 0, end: 2 },
+          { type: 'compose', text: 'ㅁ' },
+        ],
+      },
+      {
+        type: 'text_input',
+        ops: [
+          { type: 'set_composition', start: 2, end: 2 },
+          { type: 'compose', text: 'ㄴ' },
+        ],
+      },
+      { type: 'text_input', ops: [{ type: 'commit_as_is' }] },
+      {
+        type: 'text_input',
+        ops: [
+          { type: 'set_composition', start: 3, end: 3 },
+          { type: 'compose', text: 'ㅇ' },
         ],
       },
     ]);

--- a/apps/website/src/lib/editor-ffi/input/ime-input-adapter.ts
+++ b/apps/website/src/lib/editor-ffi/input/ime-input-adapter.ts
@@ -12,6 +12,7 @@ import {
 import { normalizeLineBreakBeforeInput, readDomComposingReplacement, readDomInputDiff, textInputMessage } from './ime-normalizer';
 import type { Message } from '@typie/editor-ffi/browser';
 import type { ImeContext, ImeRange } from './ime-context';
+import type { DomInputDiff } from './ime-normalizer';
 
 type ImeInputAdapterDeps = {
   readContext: () => ImeContext | null;
@@ -24,7 +25,71 @@ type ImeEditIntent = {
   replacementCandidate: ImeRange;
 };
 
+type ImeCompositionEdit = {
+  target: ImeRange;
+  text: string;
+};
+
 const isCollapsedRange = (range: ImeRange): boolean => range.start === range.end;
+
+const readContextCompositionText = (context: ImeContext): string | null => {
+  if (!context.composing) {
+    return null;
+  }
+
+  return codePointSlice(context.text, context.composing.start - context.windowStart, context.composing.end - context.windowStart);
+};
+
+const resolveActiveCompositionSyncContext = (local: ImeContext, incoming: ImeContext): ImeContext | null => {
+  const localText = readContextCompositionText(local);
+  if (localText == null) {
+    return null;
+  }
+
+  if (localText === readContextCompositionText(incoming)) {
+    return incoming;
+  }
+
+  if (incoming.composing || incoming.selection.start !== incoming.selection.end || local.selection.start !== local.selection.end) {
+    return null;
+  }
+
+  const textLength = codePointLength(localText);
+  if (textLength === 0) {
+    return null;
+  }
+
+  const end = incoming.selection.end;
+  const start = end - textLength;
+  if (start < incoming.windowStart) {
+    return null;
+  }
+
+  const incomingText = codePointSlice(incoming.text, start - incoming.windowStart, end - incoming.windowStart);
+  if (incomingText !== localText) {
+    return null;
+  }
+
+  return {
+    ...incoming,
+    composing: { start, end },
+  };
+};
+
+const readDuplicateCommittedPreeditTarget = (context: ImeContext, input: HTMLInputElement, text: string | null): ImeRange | null => {
+  if (!context.composing || text == null || readContextCompositionText(context) !== text) {
+    return null;
+  }
+
+  const selection = utf16SelectionToFlatRange(context.text, context.windowStart, readInputUtf16Selection(input));
+  return selection.start === selection.end && selection.start === context.composing.end ? selection : null;
+};
+
+const isDuplicateCommittedPreeditDiff = (context: ImeContext, diff: { start: number; end: number; insertedText: string }): boolean =>
+  !!context.composing &&
+  diff.start === context.composing.end &&
+  diff.end === context.composing.end &&
+  readContextCompositionText(context) === diff.insertedText;
 
 export class ImeInputAdapter {
   readonly #deps: ImeInputAdapterDeps;
@@ -40,12 +105,27 @@ export class ImeInputAdapter {
   }
 
   syncFromEditor(input: HTMLInputElement): void {
-    if (this.#compositionActive) {
+    const context = this.#deps.readContext();
+    if (!context) {
       return;
     }
 
-    const context = this.#deps.readContext();
-    if (!context) {
+    if (this.#compositionActive) {
+      if (!this.#context) {
+        this.#context = context;
+        syncInputElementToContext(input, context);
+        return;
+      }
+
+      if (canPreserveNativeInputOnEditorSync(this.#context, context)) {
+        return;
+      }
+
+      const syncContext = resolveActiveCompositionSyncContext(this.#context, context);
+      if (syncContext) {
+        this.#context = syncContext;
+        syncInputElementToContext(input, syncContext);
+      }
       return;
     }
 
@@ -77,9 +157,20 @@ export class ImeInputAdapter {
       return;
     }
 
+    const duplicateCommittedPreeditTarget =
+      this.#compositionActive && this.#pendingCompositionText == null && e.inputType === 'insertText' && context
+        ? readDuplicateCommittedPreeditTarget(context, e.currentTarget, e.data)
+        : null;
+    if (duplicateCommittedPreeditTarget) {
+      this.#pendingEditIntent = null;
+      this.#pendingCompositionTarget = duplicateCommittedPreeditTarget;
+      e.preventDefault();
+      return;
+    }
+
     if (this.#compositionActive && e.inputType === 'insertCompositionText') {
       this.#pendingCompositionText = e.data;
-      this.#pendingCompositionTarget =
+      this.#pendingCompositionTarget ??=
         context && !context.composing
           ? utf16SelectionToFlatRange(context.text, context.windowStart, readInputUtf16Selection(e.currentTarget))
           : null;
@@ -106,70 +197,68 @@ export class ImeInputAdapter {
 
     const diff = readDomInputDiff(context, e.currentTarget.value);
     if (!diff) {
-      const intent = this.#pendingEditIntent;
-      this.#pendingEditIntent = null;
-      if (this.#compositionActive) {
-        const pendingTarget = this.#pendingCompositionTarget;
-        this.#pendingCompositionTarget = null;
-        const text = this.#pendingCompositionText;
-        this.#pendingCompositionText = null;
-        const target = pendingTarget ?? context.composing;
-        if (target && text != null) {
-          const composing = { start: target.start, end: target.start + codePointLength(text) };
-          const messages = textInputMessage([
-            { type: 'set_composition', start: target.start, end: target.end },
-            { type: 'compose', text },
-          ]);
-          this.#deps.enqueue(messages);
-
-          const nextText = replaceContextRange(context, target, text);
-          if (e.currentTarget.value !== nextText) {
-            e.currentTarget.value = nextText;
-          }
-          const selection = flatOffsetToUtf16Index(nextText, context.windowStart, composing.end);
-          e.currentTarget.setSelectionRange(selection, selection);
-          this.#context = updateContextFromInputElement(context, e.currentTarget, composing);
-          return;
-        }
-      }
-      if (intent && !isCollapsedRange(intent.replacementCandidate)) {
-        const messages = textInputMessage([
-          { type: 'set_selection', start: intent.replacementCandidate.start, end: intent.replacementCandidate.end },
-          { type: 'replace_selection', text: intent.text },
-        ]);
-        this.#deps.enqueue(messages);
-      }
-      this.#context = updateContextFromInputElement(context, e.currentTarget, context.composing);
+      this.#handleInputWithoutDiff(context, e.currentTarget);
       return;
     }
 
     if (this.#compositionActive) {
-      const pendingTarget = this.#pendingCompositionTarget;
-      this.#pendingCompositionTarget = null;
-      const replacement = readDomComposingReplacement(context, e.currentTarget.value, diff);
-      if (pendingTarget && !context.composing) {
-        replacement.targetStart = pendingTarget.start;
-        replacement.targetEnd = pendingTarget.end;
-      }
-      const text = this.#compositionText(context, replacement);
-      this.#pendingCompositionText = null;
-      const composing = { start: replacement.targetStart, end: replacement.targetStart + codePointLength(text) };
-      const messages = textInputMessage([
-        { type: 'set_composition', start: replacement.targetStart, end: replacement.targetEnd },
-        { type: 'compose', text },
-      ]);
-      this.#deps.enqueue(messages);
-
-      const nextText = replaceContextRange(context, { start: replacement.targetStart, end: replacement.targetEnd }, text);
-      if (e.currentTarget.value !== nextText) {
-        e.currentTarget.value = nextText;
-      }
-      const selection = flatOffsetToUtf16Index(nextText, context.windowStart, composing.end);
-      e.currentTarget.setSelectionRange(selection, selection);
-      this.#context = updateContextFromInputElement(context, e.currentTarget, composing);
+      this.#handleCompositionInputWithDiff(context, e.currentTarget, diff);
       return;
     }
 
+    this.#handleTextInputWithDiff(context, e.currentTarget, diff);
+  }
+
+  #handleInputWithoutDiff(context: ImeContext, input: HTMLInputElement): void {
+    const intent = this.#pendingEditIntent;
+    this.#pendingEditIntent = null;
+
+    if (this.#compositionActive) {
+      const pendingTarget = this.#pendingCompositionTarget;
+      this.#pendingCompositionTarget = null;
+      const text = this.#pendingCompositionText;
+      this.#pendingCompositionText = null;
+      const target = pendingTarget ?? context.composing;
+      if (target && text != null) {
+        this.#applyCompositionEdit(context, input, { target, text });
+        return;
+      }
+    }
+
+    if (intent && !isCollapsedRange(intent.replacementCandidate)) {
+      const messages = textInputMessage([
+        { type: 'set_selection', start: intent.replacementCandidate.start, end: intent.replacementCandidate.end },
+        { type: 'replace_selection', text: intent.text },
+      ]);
+      this.#deps.enqueue(messages);
+    }
+    this.#context = updateContextFromInputElement(context, input, context.composing);
+  }
+
+  #handleCompositionInputWithDiff(context: ImeContext, input: HTMLInputElement, diff: DomInputDiff): void {
+    if (this.#pendingCompositionText == null && isDuplicateCommittedPreeditDiff(context, diff)) {
+      if (input.value !== context.text) {
+        input.value = context.text;
+      }
+      const selection = flatOffsetToUtf16Index(context.text, context.windowStart, context.selection.end);
+      input.setSelectionRange(selection, selection);
+      this.#context = context;
+      return;
+    }
+
+    const pendingTarget = this.#pendingCompositionTarget;
+    this.#pendingCompositionTarget = null;
+    const replacement = readDomComposingReplacement(context, input.value, diff);
+    if (pendingTarget) {
+      replacement.targetStart = pendingTarget.start;
+      replacement.targetEnd = pendingTarget.end;
+    }
+    const edit = this.#compositionEdit(context, replacement);
+    this.#pendingCompositionText = null;
+    this.#applyCompositionEdit(context, input, edit);
+  }
+
+  #handleTextInputWithDiff(context: ImeContext, input: HTMLInputElement, diff: DomInputDiff): void {
     const intent = this.#pendingEditIntent;
     this.#pendingEditIntent = null;
     this.#pendingCompositionTarget = null;
@@ -186,7 +275,24 @@ export class ImeInputAdapter {
       { type: 'replace_selection', text: diff.insertedText },
     ]);
     this.#deps.enqueue(messages);
-    this.#context = updateContextFromInputElement(context, e.currentTarget, null);
+    this.#context = updateContextFromInputElement(context, input, null);
+  }
+
+  #applyCompositionEdit(context: ImeContext, input: HTMLInputElement, edit: ImeCompositionEdit): void {
+    const composing = { start: edit.target.start, end: edit.target.start + codePointLength(edit.text) };
+    const messages = textInputMessage([
+      { type: 'set_composition', start: edit.target.start, end: edit.target.end },
+      { type: 'compose', text: edit.text },
+    ]);
+    this.#deps.enqueue(messages);
+
+    const nextText = replaceContextRange(context, edit.target, edit.text);
+    if (input.value !== nextText) {
+      input.value = nextText;
+    }
+    const selection = flatOffsetToUtf16Index(nextText, context.windowStart, composing.end);
+    input.setSelectionRange(selection, selection);
+    this.#context = updateContextFromInputElement(context, input, composing);
   }
 
   handleCompositionStart(e: CompositionEvent & { currentTarget: HTMLInputElement }): void {
@@ -194,7 +300,8 @@ export class ImeInputAdapter {
     this.#pendingCompositionText = null;
     this.#pendingCompositionTarget = null;
     this.#compositionActive = true;
-    this.#currentContext(e.currentTarget);
+    const context = this.#currentContext(e.currentTarget);
+    this.#pendingCompositionTarget = context?.composing ? { start: context.composing.end, end: context.composing.end } : null;
   }
 
   handleCompositionUpdate(e: CompositionEvent): void {
@@ -247,21 +354,20 @@ export class ImeInputAdapter {
     setTimeout(() => this.#clearCommitPending(), 0);
   }
 
-  #compositionText(context: ImeContext, replacement: { text: string }): string {
+  #compositionEdit(context: ImeContext, replacement: { targetStart: number; targetEnd: number; text: string }): ImeCompositionEdit {
+    const target = { start: replacement.targetStart, end: replacement.targetEnd };
     const pending = this.#pendingCompositionText;
     if (!pending || !context.composing) {
-      return pending ?? replacement.text;
+      const edit = { target, text: pending ?? replacement.text };
+      return edit;
     }
 
-    const current = codePointSlice(
-      context.text,
-      context.composing.start - context.windowStart,
-      context.composing.end - context.windowStart,
-    );
-    if (replacement.text === `${current}${pending}` && current.endsWith(pending)) {
-      return replacement.text;
+    const current = readContextCompositionText(context) ?? '';
+    const targetsCurrentComposition = target.start === context.composing.start && target.end === context.composing.end;
+    if (replacement.text === `${current}${pending}` && current.endsWith(pending) && targetsCurrentComposition) {
+      return { target, text: replacement.text };
     }
 
-    return pending;
+    return { target, text: pending };
   }
 }


### PR DESCRIPTION
## 문제

전체 선택 또는 구조 선택 후 한글 IME 입력을 시작하면 hidden input과 에디터의 IME context가 어긋날 수 있었습니다.

특히 첫 조합 입력 후 에디터는 paragraph/sentinel 구조를 복구했지만 hidden input에는 브라우저가 만든 짧은 preedit 값만 남아, 이후 입력이 잘못된 위치에 들어가거나 이미 입력된 preedit가 다시 처리되었습니다.

## 변경

- composition active 상태에서도 에디터 context가 바뀌면 필요한 경우 hidden input을 에디터 context로 다시 동기화합니다.
- 에디터가 composing range를 돌려주지 않는 경우에도, 현재 local preedit와 collapsed selection으로 composing range를 추론합니다.
- 브라우저가 이미 커밋된 preedit를 `insertText`로 한 번 더 내보내는 경우 중복 입력으로 보고 무시합니다.
- `handleInput`의 diff 없음 / composition diff / 일반 text diff 처리를 분리했습니다.

## 고쳐지는 시나리오

- `ㅁ`을 선택한 뒤 다시 `ㅁ`을 입력하면 새 `ㅁ` 뒤로 커서가 collapse되고, 그 `ㅁ`이 composition 상태로 유지됩니다.
- `ㅁㄴ` 전체 선택 후 다시 `ㅁㄴ`을 입력할 때 `ㄴㅁ`처럼 순서가 뒤집히지 않습니다.
- 전체 선택 후 첫 `ㅁ` 입력으로 에디터가 paragraph/sentinel 구조를 복구해도 hidden input이 그 구조와 다시 동기화되어, 이후 `ㄴ`, `ㅇ`이 올바른 위치에 들어갑니다.
- 전체 선택 후 `ㅁㄴㅇ` 입력 중 `ㅁㄴ` 전체가 composition처럼 보이거나, 다음 입력에서 앞 글자가 사라지는 흐름을 막습니다.
- 빈 paragraph 전체 선택 후 `ㅁㄴㅇ`을 입력할 때 첫 preedit가 중복 처리되지 않고 후속 조합이 제 위치에 이어집니다.
- 에디터가 복구한 context에서 composing range가 비어 있어도 active IME preedit를 기준으로 composition 위치를 복원합니다.