### PR TITLE
TR-199 테이블 마지막 행 어느 열에서나 down키로 나갈 때, gap cursor 문단으로 이동하도록 수정

### DIFF
--- a/crates/editor-core/src/handle/navigation.rs
+++ b/crates/editor-core/src/handle/navigation.rs
@@ -2413,4 +2413,181 @@ mod tests {
             "backward from callout#2 inner-first returns to the same gap (round-trip)"
         );
     }
+
+    // TR-199: 테이블 뒤에 폴드가 오면 그 경계는 두 monolithic 사이의 유효한
+    // 갭이다. 마지막 행에서 아래로 이동하면 마지막 열뿐 아니라 어느 열에서든
+    // 이 갭으로 진입해야 한다. 버그는 테이블의 유일한 "마지막 navigable 라인"이
+    // 마지막 셀에 있어 마지막 열에서만 테이블을 벗어나게 했다.
+    #[test]
+    fn arrow_down_from_non_last_column_of_table_last_row_enters_between_gap() {
+        let (state, r, ..) = state! {
+            doc {
+                r: root {
+                    table {
+                        table_row {
+                            table_cell { paragraph { text("a") } }
+                            table_cell { paragraph { text("b") } }
+                            table_cell { paragraph { text("c") } }
+                        }
+                        table_row {
+                            table_cell { paragraph { t: text("d") } }
+                            table_cell { paragraph { text("e") } }
+                            table_cell { paragraph { text("f") } }
+                        }
+                    }
+                    fold { fold_title { text("T") } fold_content { paragraph { text("x") } } }
+                    paragraph {}
+                }
+            }
+            selection: (t, 1)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.view.layout(&editor.state.doc);
+        let expected = gap_cursor_selection_between(&editor.state.doc, r, 1)
+            .expect("table↔fold between gap is valid");
+        arrow(
+            &mut editor,
+            Movement::Line {
+                direction: Direction::Forward,
+                axis: Axis::Vertical,
+            },
+        );
+        let s = editor.state().selection.expect("selection exists in test");
+        assert_eq!(
+            (s.anchor, s.head),
+            (expected.anchor, expected.head),
+            "down from the first column of the last row must enter the table↔fold gap"
+        );
+    }
+
+    // 회귀 방지: 마지막 열은 원래 동작했으므로 수정 후에도 유지되어야 한다.
+    #[test]
+    fn arrow_down_from_last_column_of_table_last_row_enters_between_gap() {
+        let (state, r, ..) = state! {
+            doc {
+                r: root {
+                    table {
+                        table_row {
+                            table_cell { paragraph { text("a") } }
+                            table_cell { paragraph { text("b") } }
+                            table_cell { paragraph { text("c") } }
+                        }
+                        table_row {
+                            table_cell { paragraph { text("d") } }
+                            table_cell { paragraph { text("e") } }
+                            table_cell { paragraph { t: text("f") } }
+                        }
+                    }
+                    fold { fold_title { text("T") } fold_content { paragraph { text("x") } } }
+                    paragraph {}
+                }
+            }
+            selection: (t, 1)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.view.layout(&editor.state.doc);
+        let expected = gap_cursor_selection_between(&editor.state.doc, r, 1)
+            .expect("table↔fold between gap is valid");
+        arrow(
+            &mut editor,
+            Movement::Line {
+                direction: Direction::Forward,
+                axis: Axis::Vertical,
+            },
+        );
+        let s = editor.state().selection.expect("selection exists in test");
+        assert_eq!(
+            (s.anchor, s.head),
+            (expected.anchor, expected.head),
+            "down from the last column of the last row must enter the table↔fold gap"
+        );
+    }
+
+    // 테이블의 이웃이 일반 문단(monolithic 아님)이면 그 경계는 갭이 아니다.
+    // 이때 마지막 행에서 아래로 이동하면 갭에 멈추지 않고 일반 기하학적 이동으로
+    // 넘어가, 테이블 아래 문단에 도착해야 한다. 버그가 가두던 비-마지막 열에서도
+    // 마찬가지여야 한다.
+    #[test]
+    fn arrow_down_from_non_last_column_of_table_last_row_with_paragraph_neighbor_moves_out() {
+        let (state, _t, below) = state! {
+            doc {
+                root {
+                    table {
+                        table_row {
+                            table_cell { paragraph { text("a") } }
+                            table_cell { paragraph { text("b") } }
+                            table_cell { paragraph { text("c") } }
+                        }
+                        table_row {
+                            table_cell { paragraph { t: text("d") } }
+                            table_cell { paragraph { text("e") } }
+                            table_cell { paragraph { text("f") } }
+                        }
+                    }
+                    paragraph { below: text("below") }
+                }
+            }
+            selection: (t, 1)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.view.layout(&editor.state.doc);
+        arrow(
+            &mut editor,
+            Movement::Line {
+                direction: Direction::Forward,
+                axis: Axis::Vertical,
+            },
+        );
+        let s = editor.state().selection.expect("selection exists in test");
+        assert!(
+            s.resolve(&editor.state().doc)
+                .and_then(|rs| rs.as_gap_cursor())
+                .is_none(),
+            "paragraph neighbor is not a between-gap; must not enter a gap cursor"
+        );
+        assert!(s.is_collapsed());
+        assert_eq!(
+            s.head.node_id, below,
+            "down must move into the paragraph below the table, not stay in the cell"
+        );
+    }
+
+    // TR-199 회귀 방지: 가장자리 행 판정이 "마지막 직계 자식 서브트리"로 넓어지면서,
+    // 자식이 단락 하나뿐이고 그 단락이 여러 줄로 접히는 monolithic(콜아웃 등)에서
+    // 첫 줄에 있어도 가장자리로 오인될 수 있다. 첫 줄에서 down은 갭으로 나가지 말고
+    // 같은 단락의 둘째 줄로 가야 한다.
+    #[test]
+    fn arrow_down_within_multiline_paragraph_in_callout_does_not_exit() {
+        let (state, t_a, t_b) = state! {
+            doc {
+                root {
+                    callout { paragraph { t_a: text("a") hard_break t_b: text("b") } }
+                    callout { paragraph {} }
+                    paragraph {}
+                }
+            }
+            selection: (t_a, 0)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.view.layout(&editor.state.doc);
+        arrow(
+            &mut editor,
+            Movement::Line {
+                direction: Direction::Forward,
+                axis: Axis::Vertical,
+            },
+        );
+        let s = editor.state().selection.expect("selection exists in test");
+        assert!(
+            s.resolve(&editor.state().doc)
+                .and_then(|rs| rs.as_gap_cursor())
+                .is_none(),
+            "down from the first wrapped line must not exit the callout into the gap"
+        );
+        assert!(s.is_collapsed());
+        assert_eq!(
+            s.head.node_id, t_b,
+            "down must move to the second line within the same paragraph"
+        );
+    }
 }

--- a/crates/editor-view/src/query/navigation.rs
+++ b/crates/editor-view/src/query/navigation.rs
@@ -579,11 +579,15 @@ pub(crate) fn position_at_preferred_x_in(
     }
 }
 
-/// True when `head`'s containing Line is itself the first (`at_end=false`)
-/// or last (`at_end=true`) navigable Line inside `node_id`'s subtree.
-/// Used for vertical (Line) gap entry, where a caret on the edge Line
-/// must leave the monolithic regardless of column offset — the
-/// position-equality variant misses any column past offset 0/end.
+/// `head`가 속한 Line이 `node_id`의 첫(`at_end=false`) 또는 마지막
+/// (`at_end=true`) 시각적 행에 있으면 true. 세로(Line) 갭 진입에 쓰인다.
+///
+/// 기본은 박스 서브트리의 유일한 첫/마지막 navigable 라인과의 포인터 비교다
+/// (콜아웃·폴드처럼 가장자리 자식이 여러 줄로 접히는 단락 하나일 때, 그
+/// 마지막 줄에서만 벗어나야 하므로). 단, 테이블처럼 가장자리 행이 가로로
+/// 나열된 여러 셀(각자 navigable을 가진 별도 자식 박스)로 이루어진 경우엔
+/// 그 행 안의 어느 셀이든 가장자리로 본다 — 그래야 마지막 행이 마지막 열뿐
+/// 아니라 어느 열에서도 갭으로 진입한다.
 pub(crate) fn is_at_edge_line_of(
     tree: &LayoutTree,
     node_id: NodeId,
@@ -599,15 +603,63 @@ pub(crate) fn is_at_edge_line_of(
     let LayoutContent::Box(b) = &boxed.content else {
         return false;
     };
-    let edge = if at_end {
+    let edge_child = if at_end {
         b.children
             .iter()
             .rev()
-            .find_map(search::find_last_navigable)
+            .find(|c| search::find_last_navigable(c).is_some())
     } else {
-        b.children.iter().find_map(search::find_first_navigable)
+        b.children
+            .iter()
+            .find(|c| search::find_first_navigable(c).is_some())
     };
-    edge.is_some_and(|n| std::ptr::eq(n, cursor_line))
+    let Some(edge_child) = edge_child else {
+        return false;
+    };
+
+    // 가장자리 자식이 가로로 나열된 여러 navigable 열(테이블 행의 셀들)을
+    // 직접 품으면, 그 열들은 같은 시각적 행이므로 어느 셀이든 가장자리다.
+    // 그렇지 않으면(단일 흐름이 여러 줄로 접히는 단락 등) 마지막/첫 줄만
+    // 가장자리이므로 그 단일 navigable 라인과 비교한다.
+    if has_multiple_navigable_columns(edge_child) {
+        subtree_contains(edge_child, cursor_line)
+    } else {
+        let leaf = if at_end {
+            search::find_last_navigable(edge_child)
+        } else {
+            search::find_first_navigable(edge_child)
+        };
+        leaf.is_some_and(|n| std::ptr::eq(n, cursor_line))
+    }
+}
+
+/// `node`의 직계 자식 중 navigable을 서브트리에 품은 "박스"가 둘 이상이면
+/// true. 테이블 행은 셀(navigable을 품은 Box)이 가로로 여럿이고, 단락은
+/// 직계 자식이 Line(navigable 그 자체, 세로로 접힌 줄들)이므로 false다 —
+/// 이 차이로 둘을 구분한다.
+fn has_multiple_navigable_columns(node: &LayoutNode) -> bool {
+    let LayoutContent::Box(b) = &node.content else {
+        return false;
+    };
+    b.children
+        .iter()
+        .filter(|c| {
+            matches!(c.content, LayoutContent::Box(_)) && search::find_first_navigable(c).is_some()
+        })
+        .nth(1)
+        .is_some()
+}
+
+/// `target`(navigable Line/Atom 노드)이 `node` 자신이거나 그 서브트리
+/// 어딘가에 있는지를 포인터 동일성으로 판정한다.
+fn subtree_contains(node: &LayoutNode, target: &LayoutNode) -> bool {
+    if std::ptr::eq(node, target) {
+        return true;
+    }
+    match &node.content {
+        LayoutContent::Box(b) => b.children.iter().any(|c| subtree_contains(c, target)),
+        _ => false,
+    }
 }
 
 /// A navigable unit's `(parent, index)` bracket. An atom carries it directly;
@@ -2425,5 +2477,80 @@ mod tests {
         view.layout(&state.doc);
         let image_id = state.doc.node(r).unwrap().children().next().unwrap().id();
         assert!(view.editable_position_inside(image_id, false).is_none());
+    }
+
+    // TR-199: 테이블 마지막 행의 어느 셀에 있는 커서든 테이블의 아래쪽
+    // 가장자리 행에 있으므로 세로 갭 진입에서 가장자리로 봐야 한다 — 라인이
+    // 테이블 서브트리의 유일한 마지막 navigable인 마지막 열만이 아니라.
+    #[test]
+    fn is_at_edge_line_of_table_last_row_any_column() {
+        let (state, table, t_first, t_last) = state! {
+            doc {
+                root {
+                    table: table {
+                        table_row {
+                            table_cell { paragraph { text("a") } }
+                            table_cell { paragraph { text("b") } }
+                        }
+                        table_row {
+                            table_cell { paragraph { t_first: text("c") } }
+                            table_cell { paragraph { t_last: text("d") } }
+                        }
+                    }
+                    paragraph {}
+                }
+            }
+            selection: (t_first, 0)
+        };
+        let mut view = View::new_test();
+        view.layout(&state.doc);
+
+        let first_col = Position::new(t_first, 1);
+        let last_col = Position::new(t_last, 1);
+
+        assert!(
+            view.is_at_edge_line_of(table, &last_col, true),
+            "last column of last row is on the bottom edge"
+        );
+        assert!(
+            view.is_at_edge_line_of(table, &first_col, true),
+            "first column of last row must also be on the bottom edge"
+        );
+    }
+
+    // 반대 경우: 첫 행의 커서는 아래쪽 가장자리로 보면 안 되고(그러면 첫 행에서
+    // 아래로 새어 나간다) 위쪽 가장자리로 봐야 한다(첫 행에서 위로 벗어남).
+    #[test]
+    fn is_at_edge_line_of_table_first_row_is_top_edge_not_bottom() {
+        let (state, table, t_top, _t_bottom) = state! {
+            doc {
+                root {
+                    table: table {
+                        table_row {
+                            table_cell { paragraph { t_top: text("a") } }
+                            table_cell { paragraph { text("b") } }
+                        }
+                        table_row {
+                            table_cell { paragraph { text("c") } }
+                            table_cell { paragraph { t_bottom: text("d") } }
+                        }
+                    }
+                    paragraph {}
+                }
+            }
+            selection: (t_top, 0)
+        };
+        let mut view = View::new_test();
+        view.layout(&state.doc);
+
+        let top = Position::new(t_top, 1);
+        assert!(
+            !view.is_at_edge_line_of(table, &top, true),
+            "first row is not the table's bottom edge"
+        );
+        assert!(
+            view.is_at_edge_line_of(table, &top, false),
+            "first row IS the table's top edge"
+        );
     }
 }


### PR DESCRIPTION
테이블의 마지막 열이 아닌 열의 마지막 행에서 down 키를 눌러도 gap cursor가 생기지 않는 문제를 수정했습니다.
이전엔 박스 전체에서 단 하나의 마지막 navigable 라인을 찾았습니다.
그러면 테이블에선 마지막 행 × 마지막 열 셀의 라인 하나만 잡혀서, 다른 열은 가장자리로 처리되지 않아 버그가 재현되고 있었습니다.
지금은 마지막 행(자식 박스)을 통째로 고르고 커서가 그 가장자리 행 안에 있는지 확인하도록 수정해, 그 행 안의 어느 셀이든 포함되도록 했습니다.
