### PR TITLE
조합 중에는 flat ime context를 textarea dom에 싱크하지 않음

### DIFF
--- a/apps/website/src/lib/editor-ffi/input/ime-input-adapter.test.ts
+++ b/apps/website/src/lib/editor-ffi/input/ime-input-adapter.test.ts
@@ -670,16 +670,16 @@ describe('ImeInputAdapter', () => {
     });
     ime.syncFromEditor();
 
-    ime.expectInput('\u2028ㅁ\u2029', 2);
+    ime.expectInput('ㅁ', 1);
 
     const duplicateCommittedPreedit = ime.beforeTextInput('ㅁ');
     expect(duplicateCommittedPreedit.preventDefault).toHaveBeenCalledOnce();
     expect(ime.messages).toHaveLength(1);
 
     ime.beforeCompositionInput('ㄴ');
-    ime.applyNativeInput('\u2028ㅁㄴ\u2029', 3);
+    ime.applyNativeInput('ㅁㄴ', 2);
 
-    ime.expectInput('\u2028ㅁㄴ\u2029', 3);
+    ime.expectInput('ㅁㄴ', 2);
 
     ime.setContext({
       text: '\u2028ㅁㄴ\u2029',
@@ -690,10 +690,11 @@ describe('ImeInputAdapter', () => {
     ime.syncFromEditor();
 
     ime.compositionStart();
-    ime.beforeCompositionInput('ㅇ');
-    ime.applyNativeInput('\u2028ㅁㄴㅇ\u2029', 4);
+    ime.compositionUpdate('ㄴㅇ');
+    ime.beforeCompositionInput('ㄴㅇ');
+    ime.applyNativeInput('ㅁㄴㅇ', 3);
 
-    ime.expectInput('\u2028ㅁㄴㅇ\u2029', 4);
+    ime.expectInput('ㅁㄴㅇ', 3);
     expect(ime.messages).toEqual([
       {
         type: 'text_input',
@@ -712,14 +713,14 @@ describe('ImeInputAdapter', () => {
       {
         type: 'text_input',
         ops: [
-          { type: 'set_composition', start: 3, end: 3 },
-          { type: 'compose', text: 'ㅇ' },
+          { type: 'set_composition', start: 2, end: 3 },
+          { type: 'compose', text: 'ㄴㅇ' },
         ],
       },
     ]);
   });
 
-  it('syncs editor-restored structure while composing after replacing a structural selection', () => {
+  it('preserves the native buffer while rebasing an editor-restored structure during composition', () => {
     const ime = createImeHarness({
       text: '\u2028\u2028\u2029\u2029',
       windowStart: 0,
@@ -740,11 +741,12 @@ describe('ImeInputAdapter', () => {
     });
     ime.syncFromEditor();
 
-    ime.expectInput('\u2028\u2028\u2029\u2029\u2028ㅁ\u2029', 6);
+    ime.expectInput('ㅁ', 1);
 
     ime.compositionStart();
-    ime.beforeCompositionInput('ㄴ');
-    ime.applyNativeInput('\u2028\u2028\u2029\u2029\u2028ㅁㄴ\u2029', 7);
+    ime.compositionUpdate('ㅁㄴ');
+    ime.beforeCompositionInput('ㅁㄴ');
+    ime.applyNativeInput('ㅁㄴ', 2);
 
     expect(ime.messages).toEqual([
       {
@@ -757,8 +759,8 @@ describe('ImeInputAdapter', () => {
       {
         type: 'text_input',
         ops: [
-          { type: 'set_composition', start: 6, end: 6 },
-          { type: 'compose', text: 'ㄴ' },
+          { type: 'set_composition', start: 5, end: 6 },
+          { type: 'compose', text: 'ㅁㄴ' },
         ],
       },
     ]);
@@ -786,19 +788,19 @@ describe('ImeInputAdapter', () => {
     });
     ime.syncFromEditor();
 
-    ime.expectInput('\u2028ㅁ\u2029', 2);
+    ime.expectInput('ㅁ', 1);
 
     ime.compositionUpdate('ㅁ');
     ime.beforeCompositionInput('ㅁ');
-    ime.applyNativeInput('\u2028ㅁ\u2029', 2);
+    ime.applyNativeInput('ㅁ', 1);
     ime.compositionEnd();
 
     ime.compositionStart();
     ime.compositionUpdate('ㄴ');
     ime.beforeCompositionInput('ㄴ');
-    ime.applyNativeInput('\u2028ㅁㄴ\u2029', 3);
+    ime.applyNativeInput('ㅁㄴ', 2);
 
-    ime.expectInput('\u2028ㅁㄴ\u2029', 3);
+    ime.expectInput('ㅁㄴ', 2);
 
     ime.setContext({
       text: '\u2028ㅁㄴ\u2029',
@@ -814,9 +816,9 @@ describe('ImeInputAdapter', () => {
     ime.compositionStart();
     ime.compositionUpdate('ㅇ');
     ime.beforeCompositionInput('ㅇ');
-    ime.applyNativeInput('\u2028ㅁㄴㅇ\u2029', 4);
+    ime.applyNativeInput('ㅁㄴㅇ', 3);
 
-    ime.expectInput('\u2028ㅁㄴㅇ\u2029', 4);
+    ime.expectInput('ㅁㄴㅇ', 3);
     expect(ime.messages).toEqual([
       {
         type: 'text_input',
@@ -878,7 +880,7 @@ describe('ImeInputAdapter', () => {
     ime.compositionStart();
     ime.compositionUpdate('ㄴ');
     ime.beforeCompositionInput('ㄴ');
-    ime.applyNativeInput('\u2028ㅁㄴ\u2029', 3);
+    ime.applyNativeInput('ㅁㄴ', 2);
 
     ime.setContext({
       text: '\u2028ㅁㄴ\u2029',
@@ -892,9 +894,9 @@ describe('ImeInputAdapter', () => {
     ime.compositionStart();
     ime.compositionUpdate('ㅇ');
     ime.beforeCompositionInput('ㅇ');
-    ime.applyNativeInput('\u2028ㅁㄴㅇ\u2029', 4);
+    ime.applyNativeInput('ㅁㄴㅇ', 3);
 
-    ime.expectInput('\u2028ㅁㄴㅇ\u2029', 4);
+    ime.expectInput('ㅁㄴㅇ', 3);
     expect(ime.messages).toEqual([
       {
         type: 'text_input',
@@ -916,6 +918,143 @@ describe('ImeInputAdapter', () => {
         ops: [
           { type: 'set_composition', start: 3, end: 3 },
           { type: 'compose', text: 'ㅇ' },
+        ],
+      },
+    ]);
+  });
+
+  it('preserves the native buffer while rebasing a selected empty paragraph during composition', () => {
+    const ime = createImeHarness({
+      text: '\u2028\u2029',
+      windowStart: 0,
+      selection: { start: 0, end: 2 },
+      composing: null,
+    });
+
+    ime.syncFromEditor();
+    ime.compositionStart('\u2028\u2029');
+    ime.compositionUpdate('n');
+    ime.beforeCompositionInput('n');
+    ime.applyNativeInput('n', 1);
+
+    ime.setContext({
+      text: '\u2028n\u2029',
+      windowStart: 0,
+      selection: { start: 2, end: 2 },
+      composing: { start: 1, end: 2 },
+    });
+    ime.syncFromEditor();
+
+    ime.expectInput('n', 1);
+
+    ime.compositionStart();
+    ime.compositionUpdate('に');
+    ime.beforeCompositionInput('に');
+    ime.applyNativeInput('に', 1);
+
+    ime.expectInput('に', 1);
+    expect(ime.messages).toEqual([
+      {
+        type: 'text_input',
+        ops: [
+          { type: 'set_composition', start: 0, end: 2 },
+          { type: 'compose', text: 'n' },
+        ],
+      },
+      {
+        type: 'text_input',
+        ops: [
+          { type: 'set_composition', start: 1, end: 2 },
+          { type: 'compose', text: 'に' },
+        ],
+      },
+    ]);
+  });
+
+  it('keeps a romanized IME composition in one native buffer after selected empty paragraph replacement', () => {
+    const ime = createImeHarness({
+      text: '\u2028\u2029',
+      windowStart: 0,
+      selection: { start: 0, end: 2 },
+      composing: null,
+    });
+
+    ime.syncFromEditor();
+    ime.compositionStart('\u2028\u2029');
+    ime.compositionUpdate('n');
+    ime.beforeCompositionInput('n');
+    ime.applyNativeInput('n', 1);
+
+    ime.setContext({
+      text: '\u2028n\u2029',
+      windowStart: 0,
+      selection: { start: 2, end: 2 },
+      composing: { start: 1, end: 2 },
+    });
+    ime.syncFromEditor();
+
+    for (const [text, cursor] of [
+      ['に', 1],
+      ['にh', 2],
+      ['にほ', 2],
+      ['にほn', 3],
+      ['にほんg', 4],
+      ['日本語', 3],
+    ] as const) {
+      ime.compositionUpdate(text);
+      ime.beforeCompositionInput(text);
+      ime.applyNativeInput(text, cursor);
+    }
+
+    ime.expectInput('日本語', 3);
+    expect(ime.messages).toEqual([
+      {
+        type: 'text_input',
+        ops: [
+          { type: 'set_composition', start: 0, end: 2 },
+          { type: 'compose', text: 'n' },
+        ],
+      },
+      {
+        type: 'text_input',
+        ops: [
+          { type: 'set_composition', start: 1, end: 2 },
+          { type: 'compose', text: 'に' },
+        ],
+      },
+      {
+        type: 'text_input',
+        ops: [
+          { type: 'set_composition', start: 1, end: 2 },
+          { type: 'compose', text: 'にh' },
+        ],
+      },
+      {
+        type: 'text_input',
+        ops: [
+          { type: 'set_composition', start: 1, end: 3 },
+          { type: 'compose', text: 'にほ' },
+        ],
+      },
+      {
+        type: 'text_input',
+        ops: [
+          { type: 'set_composition', start: 1, end: 3 },
+          { type: 'compose', text: 'にほn' },
+        ],
+      },
+      {
+        type: 'text_input',
+        ops: [
+          { type: 'set_composition', start: 1, end: 4 },
+          { type: 'compose', text: 'にほんg' },
+        ],
+      },
+      {
+        type: 'text_input',
+        ops: [
+          { type: 'set_composition', start: 1, end: 5 },
+          { type: 'compose', text: '日本語' },
         ],
       },
     ]);

--- a/apps/website/src/lib/editor-ffi/input/ime-input-adapter.ts
+++ b/apps/website/src/lib/editor-ffi/input/ime-input-adapter.ts
@@ -76,6 +76,45 @@ const resolveActiveCompositionSyncContext = (local: ImeContext, incoming: ImeCon
   };
 };
 
+const rebaseNativeCompositionContext = (local: ImeContext, incoming: ImeContext, input: ImeTextInput): ImeContext | null => {
+  if (!local.composing) {
+    return null;
+  }
+
+  const syncContext = resolveActiveCompositionSyncContext(local, incoming);
+  if (!syncContext?.composing) {
+    return null;
+  }
+
+  const compositionText = readContextCompositionText(local);
+  if (compositionText == null) {
+    return null;
+  }
+
+  const localStart = local.composing.start - local.windowStart;
+  const compositionLength = codePointLength(compositionText);
+  if (localStart < 0 || localStart + compositionLength > codePointLength(input.value)) {
+    return null;
+  }
+
+  if (codePointSlice(input.value, localStart, localStart + compositionLength) !== compositionText) {
+    return null;
+  }
+
+  const windowStart = syncContext.composing.start - localStart;
+  const composing = {
+    start: syncContext.composing.start,
+    end: syncContext.composing.start + compositionLength,
+  };
+
+  return {
+    text: input.value,
+    windowStart,
+    selection: utf16SelectionToFlatRange(input.value, windowStart, readInputUtf16Selection(input)),
+    composing,
+  };
+};
+
 const readDuplicateCommittedPreeditTarget = (context: ImeContext, input: ImeTextInput, text: string | null): ImeRange | null => {
   if (!context.composing || text == null || readContextCompositionText(context) !== text) {
     return null;
@@ -113,7 +152,6 @@ export class ImeInputAdapter {
     if (this.#compositionActive) {
       if (!this.#context) {
         this.#context = context;
-        syncInputElementToContext(input, context);
         return;
       }
 
@@ -121,10 +159,9 @@ export class ImeInputAdapter {
         return;
       }
 
-      const syncContext = resolveActiveCompositionSyncContext(this.#context, context);
-      if (syncContext) {
-        this.#context = syncContext;
-        syncInputElementToContext(input, syncContext);
+      const rebasedContext = rebaseNativeCompositionContext(this.#context, context, input);
+      if (rebasedContext) {
+        this.#context = rebasedContext;
       }
       return;
     }
@@ -205,7 +242,6 @@ export class ImeInputAdapter {
       this.#handleCompositionInputWithDiff(context, e.currentTarget, diff);
       return;
     }
-
     this.#handleTextInputWithDiff(context, e.currentTarget, diff);
   }
 
@@ -297,11 +333,13 @@ export class ImeInputAdapter {
 
   handleCompositionStart(e: CompositionEvent & { currentTarget: ImeTextInput }): void {
     this.#clearCommitPending();
+    const wasCompositionActive = this.#compositionActive;
+    const pendingTarget = this.#pendingCompositionTarget;
     this.#pendingCompositionText = null;
-    this.#pendingCompositionTarget = null;
     this.#compositionActive = true;
     const context = this.#currentContext(e.currentTarget);
-    this.#pendingCompositionTarget = context?.composing ? { start: context.composing.end, end: context.composing.end } : null;
+    this.#pendingCompositionTarget =
+      pendingTarget ?? (context?.composing && !wasCompositionActive ? { start: context.composing.end, end: context.composing.end } : null);
   }
 
   handleCompositionUpdate(e: CompositionEvent): void {
@@ -364,6 +402,7 @@ export class ImeInputAdapter {
 
     const current = readContextCompositionText(context) ?? '';
     const targetsCurrentComposition = target.start === context.composing.start && target.end === context.composing.end;
+
     if (replacement.text === `${current}${pending}` && current.endsWith(pending) && targetsCurrentComposition) {
       return { target, text: replacement.text };
     }


### PR DESCRIPTION
active composition 중 textarea DOM을 sync하지 않고 native buffer와 flat offset 매핑만 rebase
구조 토큰이 선택된 상태에서 바로 한글이나 일본어 입력 시작할 때 조합 상태를 잃지 않도록 해서 여러 버그를 해결함