### PR TITLE
웹 에디터 뷰 레이아웃 수정

### DIFF
--- a/apps/website/src/lib/editor-ffi/components/View.svelte
+++ b/apps/website/src/lib/editor-ffi/components/View.svelte
@@ -5,7 +5,7 @@
   import { onDestroy, tick, untrack } from 'svelte';
   import { initWasm } from '$lib/wasm-ffi.svelte';
   import { graphql } from '$mearie';
-  import { PAGE_GAP } from '../constants';
+  import { CONTINUOUS_MIN_WIDTH, CONTINUOUS_VIEW_PADDING, PAGE_GAP } from '../constants';
   import { Editor, getEditorContext } from '../editor.svelte';
   import { loadFonts } from '../fonts';
   import { handle } from '../handlers';
@@ -68,6 +68,11 @@
 
   const layoutMode = $derived(ctx.editor?.rootAttrs?.layout_mode);
   const isPaginated = $derived(layoutMode?.type === 'paginated');
+  const framePadding = $derived(isPaginated ? 0 : CONTINUOUS_VIEW_PADDING);
+  const editorMinWidth = $derived(isPaginated ? 'max-content' : `${CONTINUOUS_MIN_WIDTH}px`);
+  const continuousMaxFrameWidth = $derived(
+    layoutMode?.type === 'continuous' ? `${layoutMode.max_width + CONTINUOUS_VIEW_PADDING * 2}px` : undefined,
+  );
 
   const cursor = $derived.by(() => {
     const editor = ctx.editor;
@@ -101,11 +106,14 @@
 
   $effect(() => {
     const editor = ctx.editor;
-    if (status !== 'initialized' || !editor || !clientWidth || !clientHeight) return;
+    const width = clientWidth;
+    const height = clientHeight;
+    const isContinuous = !isPaginated;
+    if (status !== 'initialized' || !editor || !width || !height) return;
+    const effectiveWidth = isContinuous ? Math.max(CONTINUOUS_MIN_WIDTH, width) : width;
 
     untrack(() => {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      editor.resizeViewport(clientWidth!, clientHeight!, window.devicePixelRatio);
+      editor.resizeViewport(effectiveWidth, height, window.devicePixelRatio);
     });
   });
 
@@ -126,7 +134,6 @@
       position: 'relative',
       display: 'flex',
       flexDirection: 'column',
-      alignItems: 'center',
       overflow: 'auto',
       scrollbar: 'hidden',
       ...(isPaginated && {
@@ -149,8 +156,10 @@
   {#if ctx.editor && header}
     <div
       style:width={layoutMode?.type === 'paginated' ? `${layoutMode.page_width}px` : '100%'}
-      style:max-width={layoutMode?.type === 'continuous' ? `${layoutMode.max_width}px` : undefined}
-      class={css({ flexShrink: '0' })}
+      style:min-width={isPaginated ? undefined : editorMinWidth}
+      style:max-width={continuousMaxFrameWidth}
+      style:padding-inline={`${framePadding}px`}
+      class={css({ flexShrink: '0', marginX: 'auto' })}
     >
       {@render header()}
     </div>
@@ -159,12 +168,15 @@
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <div
     style:cursor
+    style:min-width={editorMinWidth}
+    style:max-width={continuousMaxFrameWidth}
     class={css({
       display: 'flex',
       flexDirection: 'column',
       alignItems: 'center',
       flexGrow: '1',
       width: 'full',
+      marginX: 'auto',
       userSelect: 'none',
       ...(isPaginated && {
         rowGap: 'var(--page-gap)',
@@ -220,8 +232,10 @@
   {#if ctx.editor && footer}
     <div
       style:width={layoutMode?.type === 'paginated' ? `${layoutMode.page_width}px` : '100%'}
-      style:max-width={layoutMode?.type === 'continuous' ? `${layoutMode.max_width}px` : undefined}
-      class={css({ flexShrink: '0' })}
+      style:min-width={isPaginated ? undefined : editorMinWidth}
+      style:max-width={continuousMaxFrameWidth}
+      style:padding-inline={`${framePadding}px`}
+      class={css({ flexShrink: '0', marginX: 'auto' })}
     >
       {@render footer()}
     </div>

--- a/apps/website/src/lib/editor-ffi/constants.ts
+++ b/apps/website/src/lib/editor-ffi/constants.ts
@@ -1,5 +1,7 @@
 export const PAGE_GAP = 24;
 export const CROP_MARKER_SIZE = 32;
+export const CONTINUOUS_MIN_WIDTH = 300;
+export const CONTINUOUS_VIEW_PADDING = 20;
 
 export const IS_MAC = navigator.platform.toUpperCase().includes('MAC');
 

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/PaneSkeleton.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/PaneSkeleton.svelte
@@ -2,6 +2,7 @@
   import { css } from '@typie/styled-system/css';
   import { flex } from '@typie/styled-system/patterns';
   import { getAppContext } from '@typie/ui/context';
+  import { CONTINUOUS_MIN_WIDTH, CONTINUOUS_VIEW_PADDING } from '$lib/editor/constants';
   import type { LayoutMode } from '$lib/editor/types';
   import type { Pane } from './types';
 
@@ -48,7 +49,9 @@
   });
 
   const isPaginated = $derived(layoutMetrics.isPaginated);
-  const bodyMaxWidth = $derived(`${layoutMetrics.contentWidth}px`);
+  const bodyPaddingInline = $derived(isPaginated ? 0 : CONTINUOUS_VIEW_PADDING);
+  const bodyMinWidth = $derived(isPaginated ? undefined : `${CONTINUOUS_MIN_WIDTH}px`);
+  const bodyMaxWidth = $derived(`${layoutMetrics.contentWidth + bodyPaddingInline * 2}px`);
   const contentMaxWidth = $derived(`${layoutMetrics.contentWidth}px`);
   const paragraphPaddingTop = $derived(`${layoutMetrics.paragraphTopPadding}px`);
 
@@ -229,7 +232,9 @@
     <!-- Body: centered content with constrained width -->
     <div class={flex({ flexGrow: '1', overflow: 'hidden' })}>
       <div
+        style:min-width={bodyMinWidth}
         style:max-width={bodyMaxWidth}
+        style:padding-inline={`${bodyPaddingInline}px`}
         class={flex({
           flexDirection: 'column',
           width: 'full',


### PR DESCRIPTION
v1과 비슷하게 맞춤

다만 continuous 모드 좌우 패딩은 v1의 40px에서 20px로 줄임

- 에디터 헤더와 바디가 항상 정렬이 맞도록 함
- 최소 너비 지정