### PR TITLE
TR-221 텍스트 배경색과 선택 영역의 높이를 레거시와 동일하게 맞춤

### DIFF
--- a/crates/editor-core/src/editor.rs
+++ b/crates/editor-core/src/editor.rs
@@ -544,19 +544,19 @@ impl Editor {
             let Some(resolved) = sel.resolve(&self.state.doc) else {
                 continue;
             };
-            let rects: Vec<PageRect> = self
+            let selection_rects: Vec<PageRect> = self
                 .view
                 .selection_rects(&resolved)
                 .iter()
                 .map(|r| r.without_meta())
                 .collect();
-            if rects.is_empty() {
+            if selection_rects.is_empty() {
                 continue;
             }
-            entries.push((group.z_index, group, rects));
+            entries.push((group.z_index, group, selection_rects));
         }
         entries.sort_by_key(|(z, _, _)| *z);
-        for (_, group, rects) in entries {
+        for (_, group, selection_rects) in entries {
             if let Some(theme_key) = group.style.background.clone() {
                 marks.push(Mark {
                     data: MarkData::TrackedBackground {
@@ -564,13 +564,13 @@ impl Editor {
                         border_radius: group.style.background_radius.unwrap_or(0.0),
                         vertical_inset: group.style.background_inset.unwrap_or(0.0),
                     },
-                    rects: rects.clone(),
+                    rects: selection_rects.clone(),
                 });
             }
             if let Some(underline) = group.style.underline.clone() {
                 marks.push(Mark {
                     data: MarkData::TrackedUnderline { underline },
-                    rects,
+                    rects: selection_rects,
                 });
             }
         }

--- a/crates/editor-renderer/src/renderer.rs
+++ b/crates/editor-renderer/src/renderer.rs
@@ -331,6 +331,12 @@ fn underline_rect(m: LineMetrics, run_x: f32, run_width: f32) -> Rect {
     )
 }
 
+fn text_background_rect(line_rect: Rect, m: LineMetrics, run_x: f32, run_width: f32) -> Rect {
+    let text_height = (m.ascent + m.descent).max(0.0);
+    let text_top = (line_rect.height - text_height).max(0.0) * 0.5;
+    Rect::from_xywh(run_x, text_top, run_width, text_height)
+}
+
 fn strikethrough_rect(m: LineMetrics, run_x: f32, run_width: f32) -> Rect {
     Rect::from_xywh(
         run_x,
@@ -1216,7 +1222,7 @@ impl<'a> PageVisitor for RenderVisitor<'a> {
             for run in glyph_runs {
                 if let Some(ref bg_token) = run.background_color {
                     let bg_color = self.theme.color(bg_token);
-                    let run_rect = Rect::from_xywh(run.x, 0.0, run.width, local_rect.height);
+                    let run_rect = text_background_rect(local_rect, metrics, run.x, run.width);
                     self.sink.fill_rect(run_rect, bg_color, t);
                 }
             }
@@ -1717,6 +1723,104 @@ mod tests {
         assert!((r.y - 59.0).abs() < 0.01); // 80 - 70 * 0.3
         assert!((r.width - 50.0).abs() < 0.01);
         assert!((r.height - 1.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn text_background_rect_matches_v1_formula_and_differs_from_selection_height() {
+        let line_rect = Rect::from_xywh(0.0, 0.0, 120.0, 100.0);
+        let m = LineMetrics {
+            baseline: 65.0,
+            ascent: 45.0,
+            descent: 15.0,
+        };
+
+        let r = text_background_rect(line_rect, m, 12.0, 34.0);
+        let v1_text_height = m.ascent + m.descent;
+        let selection_height = line_rect.height;
+        let line_top = (selection_height - v1_text_height) * 0.5;
+
+        assert!((r.x - 12.0).abs() < 0.01);
+        assert!((r.y - line_top).abs() < 0.01);
+        assert!((r.width - 34.0).abs() < 0.01);
+        assert!((r.height - v1_text_height).abs() < 0.01);
+        assert!((selection_height - 100.0).abs() < 0.01);
+        assert!(r.height < selection_height);
+    }
+
+    #[test]
+    fn line_background_color_fill_uses_text_area_not_line_box_height() {
+        use editor_view::glyph_run::{GlyphRun, Synthesis, TextDecoration};
+
+        #[derive(Default)]
+        struct RecordingSink {
+            rects: Vec<Rect>,
+        }
+        impl RenderSink for RecordingSink {
+            fn pixel_size(&self) -> (u32, u32) {
+                (1000, 1000)
+            }
+            fn fill_rect(&mut self, r: Rect, _c: Color, _t: Transform) {
+                self.rects.push(r);
+            }
+            fn fill_path(&mut self, _p: &Path, _c: Color, _t: Transform) {}
+            fn stroke_path(&mut self, _p: &Path, _c: Color, _s: &Stroke, _t: Transform) {}
+            fn draw_glyph_run(
+                &mut self,
+                _r: &editor_view::glyph_run::GlyphRun,
+                _c: Color,
+                _t: Transform,
+                _f: &editor_resource::FontRegistry,
+            ) {
+            }
+            fn draw_image(&mut self, _i: &Image, _r: Rect, _t: Transform) {}
+        }
+
+        let resource = Arc::new(Mutex::new(Resource::new_test()));
+        let doc = Doc::empty();
+        let mut renderer = Renderer::new(resource);
+        let mut sink = RecordingSink::default();
+        let mut visitor = renderer.page_visitor(
+            &mut sink,
+            &doc,
+            1.0,
+            LayerSet::of(&[RenderLayer::Background]),
+        );
+
+        let run = GlyphRun {
+            family_id: 0,
+            weight: 400,
+            font_size: 16.0,
+            synthesis: Synthesis::default(),
+            color: "text.black".to_string(),
+            background_color: Some("bg.yellow".to_string()),
+            glyphs: vec![],
+            decoration: TextDecoration::default(),
+            node_id: NodeId::ROOT,
+            offset: 0,
+            text: "abc".to_string(),
+            x: 8.0,
+            width: 24.0,
+            graphemes: vec![],
+        };
+
+        visitor.line(
+            NodeId::ROOT,
+            Rect::from_xywh(0.0, 0.0, 120.0, 100.0),
+            LineMetrics {
+                baseline: 65.0,
+                ascent: 45.0,
+                descent: 15.0,
+            },
+            &[run],
+            &[],
+        );
+
+        assert_eq!(sink.rects.len(), 1);
+        let rect = sink.rects[0];
+        assert!((rect.x - 8.0).abs() < 0.01);
+        assert!((rect.y - 20.0).abs() < 0.01);
+        assert!((rect.width - 24.0).abs() < 0.01);
+        assert!((rect.height - 60.0).abs() < 0.01);
     }
 
     fn export_page_to_vector_page(doc: &Doc) -> VectorPage {

--- a/crates/editor-view/src/measure/text/extract.rs
+++ b/crates/editor-view/src/measure/text/extract.rs
@@ -23,6 +23,13 @@ pub struct LineHeightConfig {
     pub base_font_size: f32,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct LineTypographyMetrics {
+    ascent: f32,
+    descent: f32,
+    max_run_font_size: f32,
+}
+
 const ITALIC_SKEW_DEGREES: f32 = 14.0;
 
 fn resolve_synthesis(doc: &Doc, node_id: NodeId) -> Synthesis {
@@ -136,6 +143,45 @@ fn segment_graphemes(
     spans
 }
 
+fn max_run_font_size(line: &parley::layout::Line<TextBrush>, base_font_size: f32) -> f32 {
+    line.items()
+        .filter_map(|item| match item {
+            parley::PositionedLayoutItem::GlyphRun(gr) => Some(gr.run().font_size()),
+            _ => None,
+        })
+        .fold(base_font_size, f32::max)
+}
+
+fn resolve_line_typography_metrics(
+    metrics: parley::layout::LineMetrics,
+    strut: &StrutMetrics,
+    base_font_size: f32,
+    max_run_font_size: f32,
+) -> LineTypographyMetrics {
+    let safe_base_font_size = base_font_size.max(1.0);
+    let line_font_size = max_run_font_size.max(safe_base_font_size);
+
+    let mut ascent = (strut.ascent.max(0.0) / safe_base_font_size) * line_font_size;
+    let mut descent = (strut.descent.max(0.0) / safe_base_font_size) * line_font_size;
+
+    if ascent <= 0.0 && descent <= 0.0 {
+        ascent = strut.ascent.max(0.0);
+        descent = strut.descent.max(0.0);
+    }
+    if (!ascent.is_finite() || ascent <= 0.0) && metrics.ascent > 0.0 {
+        ascent = metrics.ascent;
+    }
+    if (!descent.is_finite() || descent <= 0.0) && metrics.descent > 0.0 {
+        descent = metrics.descent;
+    }
+
+    LineTypographyMetrics {
+        ascent,
+        descent,
+        max_run_font_size,
+    }
+}
+
 pub fn extract_lines(
     doc: &Doc,
     text: &str,
@@ -154,19 +200,17 @@ pub fn extract_lines(
 
     for line in layout.lines() {
         let metrics = line.metrics();
-
-        let ascent = metrics.ascent.max(strut.ascent);
-        let descent = metrics.descent.max(strut.descent);
-        let content_height = ascent + descent;
-
-        let max_run_font_size = line
-            .items()
-            .filter_map(|item| match item {
-                parley::PositionedLayoutItem::GlyphRun(gr) => Some(gr.run().font_size()),
-                _ => None,
-            })
-            .fold(base_font_size, f32::max);
-        let line_box_height = (max_run_font_size * line_height_ratio).max(content_height);
+        let typography = resolve_line_typography_metrics(
+            *metrics,
+            strut,
+            base_font_size,
+            max_run_font_size(&line, base_font_size),
+        );
+        let ascent = typography.ascent;
+        let descent = typography.descent;
+        let content_height = (ascent + descent).max(0.0);
+        let line_box_height =
+            (typography.max_run_font_size * line_height_ratio).max(content_height);
         let leading = (line_box_height - content_height).max(0.0);
         let baseline = leading / 2.0 + ascent;
 

--- a/crates/editor-view/src/query/selection.rs
+++ b/crates/editor-view/src/query/selection.rs
@@ -18,6 +18,12 @@ pub enum SelectionRectKind {
 
 pub type SelectionRect = PageRect<SelectionRectKind>;
 
+#[derive(Debug, Clone, PartialEq)]
+struct SelectionRectSets {
+    pub line_box_rects: Vec<SelectionRect>,
+    pub text_rects: Vec<SelectionRect>,
+}
+
 #[ffi]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -33,13 +39,36 @@ pub fn selection_rects(
     pages: &[LayoutPage],
     selection: &editor_state::ResolvedSelection<'_>,
 ) -> Vec<SelectionRect> {
+    selection_rect_sets(tree, pages, selection).line_box_rects
+}
+
+pub fn selection_text_rects(
+    tree: &LayoutTree,
+    pages: &[LayoutPage],
+    selection: &editor_state::ResolvedSelection<'_>,
+) -> Vec<SelectionRect> {
+    selection_rect_sets(tree, pages, selection).text_rects
+}
+
+fn selection_rect_sets(
+    tree: &LayoutTree,
+    pages: &[LayoutPage],
+    selection: &editor_state::ResolvedSelection<'_>,
+) -> SelectionRectSets {
     if selection.is_collapsed() {
-        return vec![];
+        return SelectionRectSets {
+            line_box_rects: vec![],
+            text_rects: vec![],
+        };
     }
 
     if let Some(cell_rect) = selection.as_cell_rect() {
         let ids: Vec<_> = cell_rect.cells().map(|cell| cell.id()).collect();
-        return super::search::node_box_rects(tree, pages, &ids);
+        let rects = super::search::node_box_rects(tree, pages, &ids);
+        return SelectionRectSets {
+            line_box_rects: rects.clone(),
+            text_rects: rects,
+        };
     }
 
     let from = Position::from(selection.from());
@@ -57,7 +86,10 @@ pub fn selection_rects(
     let from_owner = super::search::find_line_at(tree, &from).filter(|n| attached(n, &from));
     let to_owner = super::search::find_line_at(tree, &to).filter(|n| attached(n, &to));
     let mut phase = Phase::Before;
-    let mut rects = Vec::new();
+    let mut rects = SelectionRectSets {
+        line_box_rects: Vec::new(),
+        text_rects: Vec::new(),
+    };
 
     visit_node(
         &tree.root,
@@ -262,6 +294,17 @@ fn line_has_trailing_non_text(line: &LayoutLine) -> bool {
     range.end.saturating_sub(range.start) > text_child_count
 }
 
+fn text_area_height(line: &LayoutLine) -> f32 {
+    let height = (line.ascent + line.descent).max(0.0);
+    if height > 0.0 {
+        height
+    } else if !line.glyph_runs.is_empty() {
+        (line.cursor_ascent + line.cursor_descent).max(0.0)
+    } else {
+        0.0
+    }
+}
+
 fn visit_node(
     node: &LayoutNode,
     from: &Position,
@@ -269,7 +312,7 @@ fn visit_node(
     from_owner: Option<&LayoutNode>,
     to_owner: Option<&LayoutNode>,
     phase: &mut Phase,
-    rects: &mut Vec<SelectionRect>,
+    rects: &mut SelectionRectSets,
     pages: &[LayoutPage],
     doc: &Doc,
 ) {
@@ -293,7 +336,7 @@ fn visit_line(
     from_owner: Option<&LayoutNode>,
     to_owner: Option<&LayoutNode>,
     phase: &mut Phase,
-    rects: &mut Vec<SelectionRect>,
+    rects: &mut SelectionRectSets,
     pages: &[LayoutPage],
 ) {
     let contains_from = from_owner.map(|n| std::ptr::eq(n, node)).unwrap_or(false);
@@ -363,13 +406,24 @@ fn visit_line(
     };
 
     if let Some(page_idx) = page_for_y(pages, node.rect.y) {
-        rects.push(PageRect::with_meta(
+        rects.line_box_rects.push(PageRect::with_meta(
             page_idx,
             Rect::from_xywh(
                 node.rect.x + x_start,
                 node.rect.y - pages[page_idx].y_start,
                 width,
                 node.rect.height,
+            ),
+            SelectionRectKind::Text,
+        ));
+        rects.text_rects.push(PageRect::with_meta(
+            page_idx,
+            Rect::from_xywh(
+                node.rect.x + x_start,
+                node.rect.y + ((node.rect.height - text_area_height(line)).max(0.0) * 0.5)
+                    - pages[page_idx].y_start,
+                width,
+                text_area_height(line),
             ),
             SelectionRectKind::Text,
         ));
@@ -382,7 +436,7 @@ fn visit_atom(
     from: &Position,
     to: &Position,
     phase: &mut Phase,
-    rects: &mut Vec<SelectionRect>,
+    rects: &mut SelectionRectSets,
     pages: &[LayoutPage],
     doc: &Doc,
 ) {
@@ -401,7 +455,7 @@ fn visit_atom(
     // layer must not paint a rect over them.
     let is_external = doc.node(atom.node_id).is_some_and(|n| n.spec().external);
     if !is_external && let Some(page_idx) = page_for_y(pages, node.rect.y) {
-        rects.push(PageRect::with_meta(
+        let rect = PageRect::with_meta(
             page_idx,
             Rect::from_xywh(
                 node.rect.x,
@@ -410,7 +464,9 @@ fn visit_atom(
                 node.rect.height,
             ),
             SelectionRectKind::Atom,
-        ));
+        );
+        rects.line_box_rects.push(rect.clone());
+        rects.text_rects.push(rect);
     }
 
     if is_to {
@@ -426,7 +482,7 @@ fn visit_box(
     from_owner: Option<&LayoutNode>,
     to_owner: Option<&LayoutNode>,
     phase: &mut Phase,
-    rects: &mut Vec<SelectionRect>,
+    rects: &mut SelectionRectSets,
     pages: &[LayoutPage],
     doc: &Doc,
 ) {
@@ -446,7 +502,8 @@ fn visit_box(
     // envelopes the box from an ancestor's perspective rather than anchoring
     // inside it.
     let entry_phase = *phase;
-    let rects_before = rects.len();
+    let line_box_rects_before = rects.line_box_rects.len();
+    let text_rects_before = rects.text_rects.len();
     let mut has_content_child = false;
     let mut content_idx = 0usize;
 
@@ -481,7 +538,8 @@ fn visit_box(
     let fully = has_content_child && entry_phase == Phase::Inside && *phase == Phase::Inside;
 
     if fully && bx.style.monolithic {
-        rects.truncate(rects_before);
+        rects.line_box_rects.truncate(line_box_rects_before);
+        rects.text_rects.truncate(text_rects_before);
         let node_top = node.rect.y;
         let node_bottom = node_top + node.rect.height;
         for (page_idx, page) in pages.iter().enumerate() {
@@ -490,7 +548,7 @@ fn visit_box(
             }
             let top = node_top.max(page.y_start);
             let bottom = node_bottom.min(page.y_end);
-            rects.push(PageRect::with_meta(
+            let rect = PageRect::with_meta(
                 page_idx,
                 Rect::from_xywh(
                     node.rect.x,
@@ -499,7 +557,9 @@ fn visit_box(
                     bottom - top,
                 ),
                 SelectionRectKind::Block,
-            ));
+            );
+            rects.line_box_rects.push(rect.clone());
+            rects.text_rects.push(rect);
         }
     }
 }
@@ -517,6 +577,14 @@ mod tests {
         let mut view = View::new_test();
         view.layout(doc);
         view
+    }
+
+    fn first_line<'a>(node: &'a LayoutNode) -> Option<(&'a LayoutNode, &'a LayoutLine)> {
+        match &node.content {
+            LayoutContent::Line(line) => Some((node, line)),
+            LayoutContent::Box(bx) => bx.children.iter().find_map(first_line),
+            LayoutContent::Atom(_) | LayoutContent::Spacing(_) => None,
+        }
     }
 
     #[test]
@@ -542,6 +610,98 @@ mod tests {
         assert_eq!(rects[0].meta, SelectionRectKind::Text);
         assert!(rects[0].rect.width > 0.0);
         assert!(rects[0].rect.height > 0.0);
+    }
+
+    #[test]
+    fn selection_text_rect_uses_centered_text_area_height() {
+        let (doc, t) = doc! {
+            root {
+                paragraph [line_height(300)] { t: text("hello") }
+            }
+        };
+        let view = layout(&doc);
+
+        let sel = Selection::new(Position::new(t, 1), Position::new(t, 4));
+        let resolved = sel.resolve(&doc).unwrap();
+        let line_box_rect = view.selection_rects(&resolved)[0].rect;
+        let text_rect = view.selection_text_rects(&resolved)[0].rect;
+
+        let tree = view.layout_tree_for_test().unwrap();
+        let page_start = view.pages()[0].y_start;
+        let (line_node, line) = first_line(&tree.root).expect("line must exist");
+        let expected_height = text_area_height(line);
+        let expected_y =
+            line_node.rect.y + (line_node.rect.height - expected_height) * 0.5 - page_start;
+
+        assert!(line_box_rect.height > text_rect.height);
+        assert!((text_rect.y - expected_y).abs() < 0.01);
+        assert!((text_rect.height - expected_height).abs() < 0.01);
+        assert!((line_box_rect.x - text_rect.x).abs() < 0.01);
+        assert!((line_box_rect.width - text_rect.width).abs() < 0.01);
+    }
+
+    #[test]
+    fn selection_rects_match_v1_height_formulas_on_mixed_font_line() {
+        let (doc, small, big) = doc! {
+            root {
+                paragraph [line_height(200)] {
+                    small: text("a")
+                    big: text("A") [font_size(4800)]
+                }
+            }
+        };
+        let view = layout(&doc);
+
+        let sel = Selection::new(Position::new(small, 0), Position::new(big, 1));
+        let resolved = sel.resolve(&doc).unwrap();
+        let line_box_rect = view.selection_rects(&resolved)[0].rect;
+        let text_rect = view.selection_text_rects(&resolved)[0].rect;
+
+        let tree = view.layout_tree_for_test().unwrap();
+        let page_start = view.pages()[0].y_start;
+        let (line_node, line) = first_line(&tree.root).expect("line must exist");
+
+        let expected_text_height = text_area_height(line);
+        let expected_text_y =
+            line_node.rect.y + (line_node.rect.height - expected_text_height) * 0.5 - page_start;
+        let expected_line_box_height = line_node.rect.height;
+        let cursor_height = line.cursor_ascent + line.cursor_descent;
+
+        assert!(
+            text_rect.height > cursor_height,
+            "mixed-font line must follow v1-like line ascent/descent, not base cursor strut: text={}, cursor={}",
+            text_rect.height,
+            cursor_height,
+        );
+        assert!((text_rect.y - expected_text_y).abs() < 0.01);
+        assert!((text_rect.height - expected_text_height).abs() < 0.01);
+        assert!((line_box_rect.height - expected_line_box_height).abs() < 0.01);
+        assert!(line_box_rect.height > text_rect.height);
+    }
+
+    #[test]
+    fn selection_text_rects_preserve_line_box_rect_order_and_horizontal_span() {
+        let (doc, t1, t2) = doc! {
+            root {
+                paragraph [line_height(300)] { t1: text("hello") }
+                paragraph [line_height(300)] { t2: text("world") }
+            }
+        };
+        let view = layout(&doc);
+
+        let sel = Selection::new(Position::new(t1, 1), Position::new(t2, 4));
+        let resolved = sel.resolve(&doc).unwrap();
+        let line_box_rects = view.selection_rects(&resolved);
+        let text_rects = view.selection_text_rects(&resolved);
+
+        assert_eq!(line_box_rects.len(), text_rects.len());
+        for (line_box, text) in line_box_rects.iter().zip(text_rects.iter()) {
+            assert_eq!(line_box.page_idx, text.page_idx);
+            assert_eq!(line_box.meta, text.meta);
+            assert!((line_box.rect.x - text.rect.x).abs() < 0.01);
+            assert!((line_box.rect.width - text.rect.width).abs() < 0.01);
+            assert!(line_box.rect.height > text.rect.height);
+        }
     }
 
     #[test]

--- a/crates/editor-view/src/view.rs
+++ b/crates/editor-view/src/view.rs
@@ -383,6 +383,13 @@ impl View {
         query::selection::selection_rects(&result.tree, &result.pages, selection)
     }
 
+    pub fn selection_text_rects(&self, selection: &ResolvedSelection) -> Vec<SelectionRect> {
+        let Some(ref result) = self.layout else {
+            return vec![];
+        };
+        query::selection::selection_text_rects(&result.tree, &result.pages, selection)
+    }
+
     pub fn selection_endpoints(&self, selection: &ResolvedSelection) -> Option<SelectionEndpoints> {
         let result = self.layout.as_ref()?;
         query::selection::selection_endpoints(&result.tree, &result.pages, selection)


### PR DESCRIPTION
v1과 동일한 텍스트 배경 높이를 맞추기 위해, v2에서 selection 줄 박스를 그대로 재사용하던 배경 렌더링을  
텍스트 영역 높이와 centered leading 기준으로 분리했습니다.   
그 결과, mixed font와 큰 line-height에서도 배경 높이와 위치가 올바르게 보이도록 수정했습니다.