### PR TITLE
TR-222 텍스트 배경색 및 선택 영역이 루비 문자를 포함하지 않도록 수정

### DIFF
--- a/crates/editor-renderer/src/renderer.rs
+++ b/crates/editor-renderer/src/renderer.rs
@@ -331,9 +331,16 @@ fn underline_rect(m: LineMetrics, run_x: f32, run_width: f32) -> Rect {
     )
 }
 
-fn text_background_rect(line_rect: Rect, m: LineMetrics, run_x: f32, run_width: f32) -> Rect {
-    let text_height = (m.ascent + m.descent).max(0.0);
-    let text_top = (line_rect.height - text_height).max(0.0) * 0.5;
+fn text_background_rect(
+    line_rect: Rect,
+    m: LineMetrics,
+    ruby_extra_top: f32,
+    run_x: f32,
+    run_width: f32,
+) -> Rect {
+    let text_height = (m.ascent + m.descent - ruby_extra_top).max(0.0);
+    let text_area = (line_rect.height - ruby_extra_top).max(0.0);
+    let text_top = ruby_extra_top + (text_area - text_height).max(0.0) * 0.5;
     Rect::from_xywh(run_x, text_top, run_width, text_height)
 }
 
@@ -1219,10 +1226,13 @@ impl<'a> PageVisitor for RenderVisitor<'a> {
         let t = self.root_transform.translate(local_rect.x, local_rect.y);
 
         if self.on(RenderLayer::Background) {
+            let ruby_extra_top =
+                editor_view::ruby_extra_top(metrics.baseline, metrics.ascent, ruby_annotations);
             for run in glyph_runs {
                 if let Some(ref bg_token) = run.background_color {
                     let bg_color = self.theme.color(bg_token);
-                    let run_rect = text_background_rect(local_rect, metrics, run.x, run.width);
+                    let run_rect =
+                        text_background_rect(local_rect, metrics, ruby_extra_top, run.x, run.width);
                     self.sink.fill_rect(run_rect, bg_color, t);
                 }
             }
@@ -1734,7 +1744,8 @@ mod tests {
             descent: 15.0,
         };
 
-        let r = text_background_rect(line_rect, m, 12.0, 34.0);
+        // No ruby (ruby_extra_top = 0): identical to the legacy centred formula.
+        let r = text_background_rect(line_rect, m, 0.0, 12.0, 34.0);
         let v1_text_height = m.ascent + m.descent;
         let selection_height = line_rect.height;
         let line_top = (selection_height - v1_text_height) * 0.5;
@@ -1745,6 +1756,103 @@ mod tests {
         assert!((r.height - v1_text_height).abs() < 0.01);
         assert!((selection_height - 100.0).abs() < 0.01);
         assert!(r.height < selection_height);
+    }
+
+    #[test]
+    fn text_background_rect_excludes_ruby_band() {
+        // Ruby inflates `ascent` and the line box top by `ruby_extra_top`. The
+        // fill must hug the base text only: height drops by the ruby band and
+        // the rect starts below it, never reaching into the ruby. (TR-222)
+        let line_rect = Rect::from_xywh(0.0, 0.0, 120.0, 100.0);
+        let m = LineMetrics {
+            baseline: 80.0,
+            ascent: 60.0, // base ascent 40 + ruby band 20
+            descent: 15.0,
+        };
+        let ruby_extra_top = 20.0;
+
+        let with_ruby = text_background_rect(line_rect, m, ruby_extra_top, 12.0, 34.0);
+        let without = text_background_rect(line_rect, m, 0.0, 12.0, 34.0);
+
+        // Height excludes the ruby band: (60-20)+15 = 55, vs 75 without.
+        assert!((with_ruby.height - 55.0).abs() < 0.01);
+        assert!(with_ruby.height < without.height);
+        // The rect starts below the ruby band reserved at the top.
+        assert!(with_ruby.y >= ruby_extra_top - 0.01);
+    }
+
+    /// Render the Background layer for a one-line doc and return the single
+    /// background-fill rect (page-local).
+    fn background_fill_rect(doc: &Doc) -> Rect {
+        #[derive(Default)]
+        struct RecordingSink {
+            rects: Vec<Rect>,
+        }
+        impl RenderSink for RecordingSink {
+            fn pixel_size(&self) -> (u32, u32) {
+                (1000, 1000)
+            }
+            fn fill_rect(&mut self, r: Rect, _c: Color, _t: Transform) {
+                self.rects.push(r);
+            }
+            fn fill_path(&mut self, _p: &Path, _c: Color, _t: Transform) {}
+            fn stroke_path(&mut self, _p: &Path, _c: Color, _s: &Stroke, _t: Transform) {}
+            fn draw_glyph_run(
+                &mut self,
+                _r: &editor_view::glyph_run::GlyphRun,
+                _c: Color,
+                _t: Transform,
+                _f: &editor_resource::FontRegistry,
+            ) {
+            }
+            fn draw_image(&mut self, _i: &Image, _r: Rect, _t: Transform) {}
+        }
+
+        let resource = Arc::new(Mutex::new(Resource::new_test()));
+        let mut view = editor_view::View::new_test();
+        view.layout(doc);
+        let mut renderer = Renderer::new(resource);
+        let mut sink = RecordingSink::default();
+        view.visit_page(
+            0,
+            &mut renderer.page_visitor(
+                &mut sink,
+                doc,
+                1.0,
+                LayerSet::of(&[RenderLayer::Background]),
+            ),
+        );
+        assert_eq!(sink.rects.len(), 1, "expected exactly one background fill");
+        sink.rects[0]
+    }
+
+    #[test]
+    fn text_background_height_matches_v1_and_excludes_ruby() {
+        use editor_macros::doc;
+
+        // V1 fills the background with `metric.height` (= ascent + descent),
+        // excluding ruby which it parks in paint-overflow above the line box.
+        // The new engine must match: the same text with and without ruby yields
+        // the same background height. (TR-222)
+        let (plain, _) = doc! { root { paragraph { t: text("ABCD") [background_color("yellow".to_string())] } } };
+        let (ruby, _) = doc! {
+            root {
+                paragraph {
+                    t: text("ABCD") [background_color("yellow".to_string()), ruby(text: "かな".to_string())]
+                }
+            }
+        };
+
+        let plain_rect = background_fill_rect(&plain);
+        let ruby_rect = background_fill_rect(&ruby);
+
+        // Ruby must not change the background height — it hugs the base text only.
+        assert!(
+            (ruby_rect.height - plain_rect.height).abs() < 0.5,
+            "ruby must not change background height: plain={}, ruby={}",
+            plain_rect.height,
+            ruby_rect.height,
+        );
     }
 
     #[test]

--- a/crates/editor-view/src/lib.rs
+++ b/crates/editor-view/src/lib.rs
@@ -23,6 +23,7 @@ pub struct TableLayoutInfo {
 
 pub use dnd::*;
 pub use external::*;
+pub use measure::text::ruby::ruby_extra_top;
 pub use page::*;
 pub use query::*;
 pub use table_overlay::*;

--- a/crates/editor-view/src/measure/text/ruby.rs
+++ b/crates/editor-view/src/measure/text/ruby.rs
@@ -15,6 +15,29 @@ pub(crate) const RUBY_FONT_SIZE_RATIO: f32 = 0.5;
 pub(crate) const RUBY_FONT_SIZE_MIN_PX: f32 = 12.0;
 pub(crate) const RUBY_GAP: f32 = 2.0;
 
+/// Space ruby reserves above the base text, inflating the line's `ascent` and
+/// `baseline` (see `measure_inline_text`); 0 without ruby. Subtract from
+/// `ascent` for the base-text ascent so backgrounds/selection skip the ruby.
+///
+/// Takes the already-inflated `baseline`/`ascent`: their difference is
+/// invariant under the inflation, so this recovers what the measure pass added.
+pub fn ruby_extra_top(baseline: f32, ascent: f32, ruby_annotations: &[RubyAnnotation]) -> f32 {
+    if ruby_annotations.is_empty() {
+        return 0.0;
+    }
+    let max_ruby_ascent = ruby_annotations
+        .iter()
+        .map(|r| r.ascent)
+        .fold(0.0, f32::max);
+    let max_ruby_descent = ruby_annotations
+        .iter()
+        .map(|r| r.descent)
+        .fold(0.0, f32::max);
+    let required_top = max_ruby_ascent + max_ruby_descent + RUBY_GAP;
+    let available_top = (baseline - ascent).max(0.0);
+    (required_top - available_top).max(0.0)
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct RubyGroup {
     pub text: String,

--- a/crates/editor-view/src/query/selection.rs
+++ b/crates/editor-view/src/query/selection.rs
@@ -294,8 +294,12 @@ fn line_has_trailing_non_text(line: &LayoutLine) -> bool {
     range.end.saturating_sub(range.start) > text_child_count
 }
 
+fn ruby_band(line: &LayoutLine) -> f32 {
+    crate::measure::text::ruby::ruby_extra_top(line.baseline, line.ascent, &line.ruby_annotations)
+}
+
 fn text_area_height(line: &LayoutLine) -> f32 {
-    let height = (line.ascent + line.descent).max(0.0);
+    let height = (line.ascent + line.descent - ruby_band(line)).max(0.0);
     if height > 0.0 {
         height
     } else if !line.glyph_runs.is_empty() {
@@ -406,27 +410,23 @@ fn visit_line(
     };
 
     if let Some(page_idx) = page_for_y(pages, node.rect.y) {
-        rects.line_box_rects.push(PageRect::with_meta(
-            page_idx,
-            Rect::from_xywh(
-                node.rect.x + x_start,
-                node.rect.y - pages[page_idx].y_start,
-                width,
-                node.rect.height,
-            ),
-            SelectionRectKind::Text,
-        ));
-        rects.text_rects.push(PageRect::with_meta(
-            page_idx,
-            Rect::from_xywh(
-                node.rect.x + x_start,
-                node.rect.y + ((node.rect.height - text_area_height(line)).max(0.0) * 0.5)
-                    - pages[page_idx].y_start,
-                width,
-                text_area_height(line),
-            ),
-            SelectionRectKind::Text,
-        ));
+        let band = ruby_band(line);
+        let box_height = (node.rect.height - band).max(0.0);
+        let x = node.rect.x + x_start;
+        let box_top = node.rect.y + band - pages[page_idx].y_start;
+        let push = |rects: &mut Vec<SelectionRect>, top: f32, height: f32| {
+            rects.push(PageRect::with_meta(
+                page_idx,
+                Rect::from_xywh(x, top, width, height),
+                SelectionRectKind::Text,
+            ));
+        };
+
+        push(&mut rects.line_box_rects, box_top, box_height);
+
+        let text_height = text_area_height(line);
+        let text_top = box_top + (box_height - text_height).max(0.0) * 0.5;
+        push(&mut rects.text_rects, text_top, text_height);
     }
 }
 
@@ -638,6 +638,73 @@ mod tests {
         assert!((text_rect.height - expected_height).abs() < 0.01);
         assert!((line_box_rect.x - text_rect.x).abs() < 0.01);
         assert!((line_box_rect.width - text_rect.width).abs() < 0.01);
+    }
+
+    #[test]
+    fn selection_highlight_excludes_ruby_band() {
+        // The rendered selection highlight uses `selection_rects` (line box).
+        // Ruby inflates the line box upward; that band must be excluded so the
+        // highlight never covers the ruby drawn above the text. (TR-222)
+        let (plain_doc, p) = doc! { root { paragraph { p: text("ABCD") } } };
+        let (ruby_doc, r) = doc! {
+            root { paragraph { r: text("ABCD") [ruby(text: "xy".to_string())] } }
+        };
+        let plain = layout(&plain_doc);
+        let ruby = layout(&ruby_doc);
+
+        let plain_box = {
+            let sel = Selection::new(Position::new(p, 0), Position::new(p, 4));
+            plain.selection_rects(&sel.resolve(&plain_doc).unwrap())[0].rect
+        };
+        let resolved = Selection::new(Position::new(r, 0), Position::new(r, 4))
+            .resolve(&ruby_doc)
+            .unwrap();
+        let ruby_box = ruby.selection_rects(&resolved)[0].rect;
+
+        let ruby_tree = ruby.layout_tree_for_test().unwrap();
+        let (ruby_node, ruby_line) = first_line(&ruby_tree.root).expect("line must exist");
+        let band = ruby_band(ruby_line);
+
+        // Ruby actually inflated this line (else the test is vacuous).
+        assert!(band > 0.0, "ruby must reserve space above the text");
+        // The rendered highlight excludes the ruby band: same height as the
+        // plain (ruby-free, v1-equivalent) line, not the inflated line box.
+        assert!(
+            (ruby_box.height - plain_box.height).abs() < 0.5,
+            "ruby must not enlarge the selection highlight: plain={}, ruby={}",
+            plain_box.height,
+            ruby_box.height,
+        );
+        assert!(
+            (ruby_box.height - (ruby_node.rect.height - band)).abs() < 0.01,
+            "highlight height must be line box minus the ruby band",
+        );
+        // ...and the highlight starts below the reserved ruby band, not at the
+        // inflated line-box top.
+        let page_start = ruby.pages()[0].y_start;
+        assert!(ruby_box.y >= ruby_node.rect.y + band - page_start - 0.01);
+    }
+
+    #[test]
+    fn selection_text_rect_matches_v1_metric_height_without_ruby() {
+        // Without ruby the text rect height equals the v1 formula `ascent +
+        // descent` (v1 `metric.height`).
+        let (doc, t) = doc! { root { paragraph { t: text("ABCD") } } };
+        let view = layout(&doc);
+        let resolved = Selection::new(Position::new(t, 0), Position::new(t, 4))
+            .resolve(&doc)
+            .unwrap();
+        let text_rect = view.selection_text_rects(&resolved)[0].rect;
+
+        let tree = view.layout_tree_for_test().unwrap();
+        let (_, line) = first_line(&tree.root).expect("line must exist");
+        let v1_height = line.ascent + line.descent;
+        assert!(
+            (text_rect.height - v1_height).abs() < 0.01,
+            "text rect height must equal v1 metric.height: rect={}, ascent+descent={}",
+            text_rect.height,
+            v1_height,
+        );
     }
 
     #[test]


### PR DESCRIPTION
루비 문자를 첨부했을 때, 텍스트 배경과 선택 영역이 루비 문자의 높이까지 포함시키는 문제를 해결했습니다.
루비를 제외한 본문 높이를 별도 필드로 저장하는 대신, 이미 line이 들고 있는 ruby_annotations에서 루비 공간(extra_top)을 역산하는 방식을 택했습니다.  
extra_top은 ascent와 baseline에 똑같이 더해져 그 차(baseline - ascent)가 부풀림 전후로 불변이므로, 부풀려진 값만으로 측정 때 더한 양을 정확히 복원할 수 있고, 본문 높이를 구할 수 있었습니다.