### PR TITLE
fix: table cell selection 버그 수정

### DIFF
--- a/crates/editor-core/src/handle/selection.rs
+++ b/crates/editor-core/src/handle/selection.rs
@@ -2,9 +2,9 @@ use editor_commands::{self as commands};
 use editor_model::NodeId;
 use editor_state::{
     PendingModifiers, Position, ResolvedPosition, ResolvedPositionFlatExt, Selection,
-    cell_rect_selection, enclosing_table_cell, farther_endpoint,
+    cell_rect_selection, enclosing_table, enclosing_table_cell, farther_endpoint,
     resolve_paragraph_selection_expansion, resolve_sentence_selection_expansion,
-    resolve_word_selection_expansion, table_cell_ids,
+    resolve_word_selection_expansion, table_cell_ids, table_parent_boundary,
 };
 use editor_transaction::HistoryMeta;
 
@@ -175,21 +175,41 @@ fn resolve_extend_to_selection(
 ) -> Option<Selection> {
     let doc = &editor.state().doc;
     if let Some(anchor_cell) = drag_anchor_cell(editor, &anchor) {
-        let cells = table_cell_ids(doc, anchor_cell);
-        if let Some(head_cell) = editor
-            .view
-            .nearest_node_box(head_page, head_x, head_y, &cells)
-        {
-            let is_cell_mode = editor
-                .state
-                .selection
-                .as_ref()
-                .and_then(|selection| selection.resolve(doc))
-                .is_some_and(|resolved| resolved.as_cell_rect().is_some());
-            if (head_cell != anchor_cell || is_cell_mode)
-                && let Some(selection) = cell_rect_selection(doc, anchor_cell, head_cell)
-            {
-                return Some(selection);
+        if let Some(table_id) = enclosing_table(doc, anchor_cell) {
+            let head_inside_table = editor
+                .view
+                .node_box_contains(head_page, head_x, head_y, table_id);
+
+            if head_inside_table {
+                let cells = table_cell_ids(doc, anchor_cell);
+                if let Some(head_cell) = editor
+                    .view
+                    .nearest_node_box(head_page, head_x, head_y, &cells)
+                {
+                    let is_cell_mode = editor
+                        .state
+                        .selection
+                        .as_ref()
+                        .and_then(|selection| selection.resolve(doc))
+                        .is_some_and(|resolved| resolved.as_cell_rect().is_some());
+                    if (head_cell != anchor_cell || is_cell_mode)
+                        && let Some(selection) = cell_rect_selection(doc, anchor_cell, head_cell)
+                    {
+                        return Some(selection);
+                    }
+                }
+            } else {
+                let head_hit = editor.view.hit_test_extending(head_page, head_x, head_y)?;
+                let head_is_below = editor
+                    .view
+                    .is_below_node_box(head_page, head_x, head_y, table_id);
+                if let Some(boundary) = table_parent_boundary(doc, anchor_cell, head_is_below) {
+                    let head_pos = farther_endpoint(doc, anchor, head_hit.anchor, head_hit.head);
+                    let selection = Selection::new(boundary, head_pos);
+                    if !selection.is_collapsed() {
+                        return Some(selection);
+                    }
+                }
             }
         }
     }

--- a/crates/editor-state/src/cell_selection.rs
+++ b/crates/editor-state/src/cell_selection.rs
@@ -247,6 +247,28 @@ pub fn enclosing_table_cell(doc: &Doc, node_id: NodeId) -> Option<NodeId> {
         .map(|n| n.id())
 }
 
+pub fn enclosing_table(doc: &Doc, cell_id: NodeId) -> Option<NodeId> {
+    doc.node(cell_id)?
+        .ancestors()
+        .find(|n| matches!(n.node(), Node::Table(_)))
+        .map(|n| n.id())
+}
+
+pub fn table_parent_boundary(doc: &Doc, cell_id: NodeId, head_is_below: bool) -> Option<Position> {
+    let cell = doc.node(cell_id)?;
+    let table = cell
+        .ancestors()
+        .find(|n| matches!(n.node(), Node::Table(_)))?;
+    let parent = table.parent()?;
+    let table_index = table.index()?;
+    let offset = if head_is_below {
+        table_index
+    } else {
+        table_index + 1
+    };
+    Some(Position::new(parent.id(), offset))
+}
+
 pub fn table_cell_ids(doc: &Doc, cell_id: NodeId) -> Vec<NodeId> {
     let Some(node) = doc.node(cell_id) else {
         return Vec::new();

--- a/crates/editor-view/src/table_overlay.rs
+++ b/crates/editor-view/src/table_overlay.rs
@@ -10,7 +10,7 @@ fn cell_background_color(doc: &Doc, cell_id: NodeId) -> Option<String> {
             _ => None,
         })
 }
-use editor_state::{ResolvedSelection, Selection};
+use editor_state::{Position, ResolvedSelection, Selection};
 use serde::{Deserialize, Serialize};
 
 use crate::page::LayoutPage;
@@ -224,7 +224,10 @@ fn build_overlay<'a>(
         (rect.table.id() == table_id).then_some(rect)
     });
 
-    let is_cell_selection = cell_rect.is_some();
+    let is_cross_boundary = cell_rect.is_none()
+        && selection.is_some_and(|sel| is_table_boundary_selection(sel, doc, table_id));
+
+    let is_cell_selection = cell_rect.is_some() || is_cross_boundary;
 
     let cell_selection_background_color = cell_rect.as_ref().and_then(|rect| {
         let mut common: Option<Option<String>> = None;
@@ -239,10 +242,40 @@ fn build_overlay<'a>(
         common.flatten()
     });
 
-    let cell_selection_row_start = cell_rect.as_ref().map(|r| *r.rows.start());
-    let cell_selection_row_end = cell_rect.as_ref().map(|r| *r.rows.end());
-    let cell_selection_col_start = cell_rect.as_ref().map(|r| *r.cols.start());
-    let cell_selection_col_end = cell_rect.as_ref().map(|r| *r.cols.end());
+    let (
+        cell_selection_row_start,
+        cell_selection_row_end,
+        cell_selection_col_start,
+        cell_selection_col_end,
+    ) = if is_cross_boundary {
+        let row_count = doc_node
+            .children()
+            .filter(|r| matches!(r.node(), Node::TableRow(_)))
+            .count();
+        let max_cols = doc_node
+            .children()
+            .filter(|r| matches!(r.node(), Node::TableRow(_)))
+            .map(|r| {
+                r.children()
+                    .filter(|c| matches!(c.node(), Node::TableCell(_)))
+                    .count()
+            })
+            .max()
+            .unwrap_or(0);
+        (
+            Some(0usize),
+            row_count.checked_sub(1),
+            Some(0usize),
+            max_cols.checked_sub(1),
+        )
+    } else {
+        (
+            cell_rect.as_ref().map(|r| *r.rows.start()),
+            cell_rect.as_ref().map(|r| *r.rows.end()),
+            cell_rect.as_ref().map(|r| *r.cols.start()),
+            cell_rect.as_ref().map(|r| *r.cols.end()),
+        )
+    };
 
     TableOverlay {
         table_id,
@@ -268,6 +301,23 @@ fn build_overlay<'a>(
         cell_selection_col_start,
         cell_selection_col_end,
     }
+}
+
+fn is_table_boundary_selection(sel: &ResolvedSelection<'_>, doc: &Doc, table_id: NodeId) -> bool {
+    let Some(table) = doc.node(table_id) else {
+        return false;
+    };
+    let Some(parent) = table.parent() else {
+        return false;
+    };
+    let Some(table_idx) = table.index() else {
+        return false;
+    };
+    let parent_id = parent.id();
+    let from = Position::from(sel.from());
+    let to = Position::from(sel.to());
+    (from.node_id == parent_id && from.offset == table_idx)
+        || (to.node_id == parent_id && to.offset == table_idx + 1)
 }
 
 fn is_inside_table(node_id: NodeId, doc: &Doc, table_id: NodeId) -> bool {

--- a/crates/editor-view/src/view.rs
+++ b/crates/editor-view/src/view.rs
@@ -427,6 +427,34 @@ impl View {
         query::search::nearest_node_box(&result.tree, page, x, y, ids)
     }
 
+    pub fn node_box_contains(&self, page_idx: usize, x: f32, y: f32, id: NodeId) -> bool {
+        let Some(ref result) = self.layout else {
+            return false;
+        };
+        let Some(page) = result.pages.get(page_idx) else {
+            return false;
+        };
+        let Some(node) = query::search::find_box_by_node_id(&result.tree.root, id) else {
+            return false;
+        };
+        let abs_y = y + page.y_start;
+        query::hit_test::rect_distance_sq(&node.rect, x, abs_y) == 0.0
+    }
+
+    pub fn is_below_node_box(&self, page_idx: usize, x: f32, y: f32, id: NodeId) -> bool {
+        let Some(ref result) = self.layout else {
+            return false;
+        };
+        let Some(page) = result.pages.get(page_idx) else {
+            return false;
+        };
+        let Some(node) = query::search::find_box_by_node_id(&result.tree.root, id) else {
+            return false;
+        };
+        let abs_y = y + page.y_start;
+        abs_y > node.rect.y + node.rect.height
+    }
+
     pub fn composition_rects(
         &self,
         from: &Position,


### PR DESCRIPTION
1. cell_selection.rs — table_parent_boundary 추가: 셀에서 테이블 → 부모 노드의 경계 position 계산     
  2. view.rs — is_below_node_box(page_idx, x, y, id) 추가: 드래그 위치가  
  테이블 box 아래인지 판정                     
  3. selection.rs — resolve_extend_to_selection 개선
   * 드래그가 테이블 안: 기존 cell-rect 선택                             
   * 드래그가 테이블 밖: anchor를 Position::new 
  (아래면 테이블 앞, 위면 테이블 뒤)로 승격하여 외부 head와 Selection 생성
  4. table_overlay.rs — is_table_boundary_selection 헬퍼 추가 + cross-boundary 감지
    - selection의 from 또는 to가 (parent, table_idx+1)이면 is_cross_boundary = true                               
    - → is_cell_selection = true, row/col 범위를 전체 테이블로 설정 