### PR TITLE
fix: fold, table 내부에서 외부에 걸친 선택이 그 자체를 선택하지 않는 오류 수정

### DIFF
--- a/crates/editor-core/src/handle/selection.rs
+++ b/crates/editor-core/src/handle/selection.rs
@@ -4,7 +4,7 @@ use editor_state::{
     PendingModifiers, Position, ResolvedPosition, ResolvedPositionFlatExt, Selection,
     cell_rect_selection, enclosing_table, enclosing_table_cell, farther_endpoint,
     resolve_paragraph_selection_expansion, resolve_sentence_selection_expansion,
-    resolve_word_selection_expansion, table_cell_ids, table_parent_boundary,
+    resolve_word_selection_expansion, table_cell_ids,
 };
 use editor_transaction::HistoryMeta;
 
@@ -179,7 +179,6 @@ fn resolve_extend_to_selection(
             let head_inside_table = editor
                 .view
                 .node_box_contains(head_page, head_x, head_y, table_id);
-
             if head_inside_table {
                 let cells = table_cell_ids(doc, anchor_cell);
                 if let Some(head_cell) = editor
@@ -198,19 +197,8 @@ fn resolve_extend_to_selection(
                         return Some(selection);
                     }
                 }
-            } else {
-                let head_hit = editor.view.hit_test_extending(head_page, head_x, head_y)?;
-                let head_is_below = editor
-                    .view
-                    .is_below_node_box(head_page, head_x, head_y, table_id);
-                if let Some(boundary) = table_parent_boundary(doc, anchor_cell, head_is_below) {
-                    let head_pos = farther_endpoint(doc, anchor, head_hit.anchor, head_hit.head);
-                    let selection = Selection::new(boundary, head_pos);
-                    if !selection.is_collapsed() {
-                        return Some(selection);
-                    }
-                }
             }
+            // head outside table: fall through; normalize promotes anchor to table boundary
         }
     }
 

--- a/crates/editor-state/src/cell_selection.rs
+++ b/crates/editor-state/src/cell_selection.rs
@@ -254,21 +254,6 @@ pub fn enclosing_table(doc: &Doc, cell_id: NodeId) -> Option<NodeId> {
         .map(|n| n.id())
 }
 
-pub fn table_parent_boundary(doc: &Doc, cell_id: NodeId, head_is_below: bool) -> Option<Position> {
-    let cell = doc.node(cell_id)?;
-    let table = cell
-        .ancestors()
-        .find(|n| matches!(n.node(), Node::Table(_)))?;
-    let parent = table.parent()?;
-    let table_index = table.index()?;
-    let offset = if head_is_below {
-        table_index
-    } else {
-        table_index + 1
-    };
-    Some(Position::new(parent.id(), offset))
-}
-
 pub fn table_cell_ids(doc: &Doc, cell_id: NodeId) -> Vec<NodeId> {
     let Some(node) = doc.node(cell_id) else {
         return Vec::new();

--- a/crates/editor-state/src/normalize.rs
+++ b/crates/editor-state/src/normalize.rs
@@ -1,6 +1,7 @@
 use std::cmp::Ordering;
+use std::collections::HashSet;
 
-use editor_model::{Doc, Node, NodeRef, Schema};
+use editor_model::{Doc, Node, NodeId, NodeRef, Schema};
 
 use crate::affinity::Affinity;
 use crate::gap_cursor::between_monolithic_at;
@@ -199,6 +200,62 @@ fn unit_or_collapsed(doc: &Doc, pos: Position) -> Selection {
     Selection::collapsed(pos)
 }
 
+fn is_isolating_container(node: &NodeRef<'_>) -> bool {
+    let spec = Schema::node_spec(node.as_type());
+    spec.isolating && spec.monolithic
+}
+
+fn outermost_crossing_unit(doc: &Doc, inside: Position, outside: Position) -> Option<NodeId> {
+    let inside_node = doc.node(inside.node_id)?;
+    let outside_ancestors: HashSet<NodeId> = doc
+        .node(outside.node_id)?
+        .ancestors()
+        .map(|n| n.id())
+        .chain([outside.node_id])
+        .collect();
+
+    let mut result = None;
+    for ancestor in inside_node.ancestors() {
+        if outside_ancestors.contains(&ancestor.id()) {
+            break;
+        }
+        if is_isolating_container(&ancestor) {
+            result = Some(ancestor.id());
+        }
+    }
+    result
+}
+
+fn promote_cross_isolating(doc: &Doc, a: Position, h: Position) -> Option<Selection> {
+    if let Some(unit_id) = outermost_crossing_unit(doc, a, h) {
+        let unit = doc.node(unit_id)?;
+        let parent = unit.parent()?;
+        let unit_idx = unit.index()?;
+        let a_res = a.resolve(doc)?;
+        let h_res = h.resolve(doc)?;
+        let offset = if h_res > a_res {
+            unit_idx
+        } else {
+            unit_idx + 1
+        };
+        return Some(Selection::new(Position::new(parent.id(), offset), h));
+    }
+    if let Some(unit_id) = outermost_crossing_unit(doc, h, a) {
+        let unit = doc.node(unit_id)?;
+        let parent = unit.parent()?;
+        let unit_idx = unit.index()?;
+        let a_res = a.resolve(doc)?;
+        let h_res = h.resolve(doc)?;
+        let offset = if h_res > a_res {
+            unit_idx + 1
+        } else {
+            unit_idx
+        };
+        return Some(Selection::new(a, Position::new(parent.id(), offset)));
+    }
+    None
+}
+
 pub(crate) fn enclosing_unit_at_subtree_overlap(
     doc: &Doc,
     a_in: Position,
@@ -272,6 +329,10 @@ impl<'a> ResolvedSelection<'a> {
                 return sel;
             }
             return unit_or_collapsed(doc, normalize_position(doc, h_in));
+        }
+
+        if let Some(promoted) = promote_cross_isolating(doc, a_in, h_in) {
+            return promoted.normalize(doc).unwrap_or(promoted);
         }
 
         Selection { anchor: a, head: h }
@@ -1809,6 +1870,123 @@ mod tests {
                 "subtree_violation fallback must not produce a gap cursor at affinity {aff:?}, got {s:?}"
             );
         }
+    }
+
+    #[test]
+    fn promote_anchor_inside_fold_head_outside() {
+        let (d, tc, ta) = doc! {
+            root {
+                fold {
+                    fold_title { text("t") }
+                    fold_content { paragraph { tc: text("content") } }
+                }
+                paragraph { ta: text("after") }
+            }
+        };
+        let root_id = NodeId::ROOT;
+        let raw = Selection::new(Position::new(tc, 4), Position::new(ta, 2));
+        let out = raw.normalize(&d).unwrap();
+        assert_eq!(
+            out.anchor,
+            Position {
+                node_id: root_id,
+                offset: 0,
+                affinity: Affinity::Downstream
+            },
+            "anchor must be promoted to fold's front boundary"
+        );
+        assert_eq!(out.head.node_id, ta);
+    }
+
+    #[test]
+    fn promote_head_inside_fold_anchor_outside() {
+        let (d, ta, tc) = doc! {
+            root {
+                paragraph { ta: text("before") }
+                fold {
+                    fold_title { text("t") }
+                    fold_content { paragraph { tc: text("content") } }
+                }
+            }
+        };
+        let root_id = NodeId::ROOT;
+        let raw = Selection::new(Position::new(ta, 2), Position::new(tc, 3));
+        let out = raw.normalize(&d).unwrap();
+        assert_eq!(out.anchor.node_id, ta);
+        assert_eq!(
+            out.head,
+            Position {
+                node_id: root_id,
+                offset: 2,
+                affinity: Affinity::Upstream
+            },
+            "head must be promoted to fold's back boundary"
+        );
+    }
+
+    #[test]
+    fn promote_skips_when_both_inside_same_fold() {
+        let (d, ta, tb) = doc! {
+            root {
+                fold {
+                    fold_title { ta: text("title") }
+                    fold_content { paragraph { tb: text("body") } }
+                }
+            }
+        };
+        let raw = Selection::new(Position::new(ta, 1), Position::new(tb, 2));
+        let out = raw.normalize(&d).unwrap();
+        assert!(
+            !out.is_collapsed(),
+            "selection inside fold must not collapse"
+        );
+        assert_eq!(out.anchor.node_id, ta);
+        assert_eq!(out.head.node_id, tb);
+    }
+
+    #[test]
+    fn promote_anchor_inside_table_head_outside() {
+        let (d, tc, ta) = doc! {
+            root {
+                table {
+                    table_row { table_cell { paragraph { tc: text("cell") } } }
+                }
+                paragraph { ta: text("after") }
+            }
+        };
+        let root_id = NodeId::ROOT;
+        let raw = Selection::new(Position::new(tc, 2), Position::new(ta, 1));
+        let out = raw.normalize(&d).unwrap();
+        assert_eq!(
+            out.anchor,
+            Position {
+                node_id: root_id,
+                offset: 0,
+                affinity: Affinity::Downstream
+            },
+            "anchor must be promoted to table's front boundary"
+        );
+        assert_eq!(out.head.node_id, ta);
+    }
+
+    #[test]
+    fn promote_cross_isolating_idempotent() {
+        let (d, tc, ta) = doc! {
+            root {
+                fold {
+                    fold_title { text("t") }
+                    fold_content { paragraph { tc: text("content") } }
+                }
+                paragraph { ta: text("after") }
+            }
+        };
+        let raw = Selection::new(Position::new(tc, 4), Position::new(ta, 2));
+        let once = raw.normalize(&d).unwrap();
+        let twice = once.normalize(&d).unwrap();
+        assert_eq!(
+            once, twice,
+            "promote_cross_isolating normalize must be idempotent"
+        );
     }
 
     #[test]

--- a/crates/editor-view/src/view.rs
+++ b/crates/editor-view/src/view.rs
@@ -444,20 +444,6 @@ impl View {
         query::hit_test::rect_distance_sq(&node.rect, x, abs_y) == 0.0
     }
 
-    pub fn is_below_node_box(&self, page_idx: usize, _x: f32, y: f32, id: NodeId) -> bool {
-        let Some(ref result) = self.layout else {
-            return false;
-        };
-        let Some(page) = result.pages.get(page_idx) else {
-            return false;
-        };
-        let Some(node) = query::search::find_box_by_node_id(&result.tree.root, id) else {
-            return false;
-        };
-        let abs_y = y + page.y_start;
-        abs_y > node.rect.y + node.rect.height
-    }
-
     pub fn composition_rects(
         &self,
         from: &Position,


### PR DESCRIPTION
- Selection::normalize() 내에 promote_cross_isolating 단계 추가 
- 모든 selection 업데이트(drag, shift+arrow)는
  Transaction::set_selection() → normalize()를 거치므로, 이 단계에서 일괄 처리.