### PR TITLE
에디터 전역 오버레이 디버그

### DIFF
--- a/apps/website/src/lib/editor-ffi/components/CaretPositioned.svelte
+++ b/apps/website/src/lib/editor-ffi/components/CaretPositioned.svelte
@@ -11,23 +11,30 @@
 
   const { editor } = getEditorContext();
 
-  const pageContainer = $derived(editor?.cursor ? editor.pageEls[editor.cursor.page_idx] : undefined);
-  let element = $state<HTMLDivElement>();
-
-  const point = $derived.by(() => {
-    if (editor?.cursor) {
-      const local = editor.cursor.caret;
-      return { x: local.x, y: local.y };
-    }
-  });
+  let point = $state<{ x: number; y: number } | null>(null);
 
   $effect(() => {
-    if (pageContainer && element && element.parentElement !== pageContainer) {
-      pageContainer.append(element);
+    const cursor = editor?.cursor;
+    if (!editor || !cursor) {
+      point = null;
+      return;
     }
+
+    const { page_idx, caret } = cursor;
+    point = editor.localToOffset(page_idx, caret.x, caret.y);
+  });
+
+  const transform = $derived.by(() => {
+    const scale = editor?.safeDisplayZoom() ?? 1;
+    return scale === 1 ? undefined : `scale(${scale})`;
   });
 </script>
 
-<div bind:this={element} style:top={`${point?.y ?? -9999}px`} style:left={`${point?.x ?? -9999}px`} class={css({ position: 'absolute' })}>
+<div
+  style:left={`${point?.x ?? -9999}px`}
+  style:top={`${point?.y ?? -9999}px`}
+  style:transform
+  class={css({ position: 'absolute', transformOrigin: 'top left' })}
+>
   {@render children()}
 </div>

--- a/apps/website/src/lib/editor-ffi/components/RepasteAsText.svelte
+++ b/apps/website/src/lib/editor-ffi/components/RepasteAsText.svelte
@@ -7,12 +7,17 @@
   const ctx = getEditorContext();
 
   let show = $derived(ctx.editor !== undefined && !ctx.editor.readOnly && ctx.editor.lastHistoryTag?.type === 'paste_html');
-  const point = $derived.by(() => {
+  let point = $state<{ x: number; y: number } | null>(null);
+
+  $effect(() => {
     const editor = ctx.editor;
-    if (!show || !editor?.cursor) return null;
+    if (!show || !editor?.cursor) {
+      point = null;
+      return;
+    }
 
     const { page_idx, caret } = editor.cursor;
-    return editor.localToOffset(page_idx, caret.x, caret.y + caret.height + 4);
+    point = editor.localToOffset(page_idx, caret.x, caret.y + caret.height + 4);
   });
 
   $effect(() => {

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-comments/CommentPopover.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-comments/CommentPopover.svelte
@@ -48,9 +48,15 @@
   const thread = $derived(threadFragment.data);
   const anchor = $derived(comments.activeAnchor);
 
-  const point = $derived.by(() => {
-    if (!editor || !anchor) return;
-    return editor.localToOffset(anchor.page, anchor.x, anchor.y + anchor.height);
+  let point = $state<{ x: number; y: number } | null>(null);
+
+  $effect(() => {
+    if (!open || !editor || !anchor) {
+      point = null;
+      return;
+    }
+
+    point = editor.localToOffset(anchor.page, anchor.x, anchor.y + anchor.height);
   });
 
   let composerDirty = $state(false);


### PR DESCRIPTION
- CaretPositioned를 page에 append하지 않고 scroll container에 배치함: page를 넘어갈 때 input이 다른 페이지에 append되면서 에디터에서 blur되는 버그를 해결함
- scroll container에 배치되는 오버레이들(CaretPositioned, RepasteAsText, CommentPopover) 디버그: point를 derived가 아닌 effect를 통해 업데이트함. DOM layout 이후에 localToOffset을 호출해서 제대로 계산되도록 함. 줌 할 때 위치가 흔들리지 않게 됨.