### PR TITLE
scroll bottom padding이 커서/타겟 위치 상관 없이 항상 존재하도록 함

### DIFF
--- a/apps/website/src/lib/editor-ffi/scroll.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/scroll.svelte.ts
@@ -1,8 +1,7 @@
 import { getAppContext } from '@typie/ui/context';
 import { tick, untrack } from 'svelte';
-import { PAGE_GAP } from './constants';
+import { CONTINUOUS_VIEW_PADDING } from './constants';
 import {
-  resolveDistanceToPagesBottom,
   resolveKeepVisibleBottomPadding,
   resolveNearestScrollTop,
   resolveTypewriterBottomPadding,
@@ -232,16 +231,6 @@ export class EditorScrollScope {
     return { targetTop, targetBottom };
   }
 
-  #distanceToPagesBottom({ page_idx }: PageRect, targetY: number): number | null {
-    return resolveDistanceToPagesBottom({
-      pageSizes: this.#editor.pageSizes,
-      pageIdx: page_idx,
-      targetY,
-      displayZoom: this.#editor.safeDisplayZoom(),
-      pageGap: this.#editor.rootAttrs?.layout_mode.type === 'paginated' ? PAGE_GAP : 0,
-    });
-  }
-
   #keepVisibleBottomPadding(): number {
     const target = this.#keepVisibleTarget;
     if (!target) {
@@ -249,31 +238,30 @@ export class EditorScrollScope {
     }
 
     const rect = this.#resolveTargetRect(target);
-    const distanceToPagesBottom = rect ? this.#distanceToPagesBottom(rect, rect.rect.y + rect.rect.height) : null;
-    if (distanceToPagesBottom === null) {
+    if (!rect) {
       return 0;
     }
 
     return resolveKeepVisibleBottomPadding({
-      distanceToContentBottom: distanceToPagesBottom,
       visibleArea: this.visibleArea,
     });
   }
 
   #typewriterBottomPaddingForRect(rect: PageRect): number {
     const container = this.#editor.scrollContainerEl;
-    const distanceToPagesBottom = this.#distanceToPagesBottom(rect, rect.rect.y);
-    if (!container || distanceToPagesBottom === null) {
+    if (!container) {
       return 0;
     }
 
     const zoom = this.#editor.safeDisplayZoom();
+    const layoutMode = this.#editor.rootAttrs?.layout_mode;
+    const trailingBottomMargin = layoutMode?.type === 'paginated' ? layoutMode.page_margin_bottom * zoom : CONTINUOUS_VIEW_PADDING;
     return resolveTypewriterBottomPadding({
       clientHeight: container.clientHeight,
       targetHeight: rect.rect.height * zoom,
-      distanceToContentBottom: distanceToPagesBottom,
       visibleArea: this.visibleArea,
       position: sanitizeTypewriterPosition(this.#typewriterPreferences().position),
+      trailingBottomMargin,
     });
   }
 }

--- a/apps/website/src/lib/editor-ffi/scroll.test.ts
+++ b/apps/website/src/lib/editor-ffi/scroll.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { resolveNearestScrollTop, resolveTypewriterBottomPadding, resolveTypewriterScrollTop } from './scroll';
+import {
+  resolveKeepVisibleBottomPadding,
+  resolveNearestScrollTop,
+  resolveTypewriterBottomPadding,
+  resolveTypewriterScrollTop,
+} from './scroll';
 
 describe('resolveNearestScrollTop', () => {
   it('keeps the target inside the guarded visible area with insets', () => {
@@ -68,26 +73,36 @@ describe('resolveTypewriterScrollTop', () => {
   });
 });
 
+describe('resolveKeepVisibleBottomPadding', () => {
+  it('uses stable bottom padding for the cursor guard range', () => {
+    expect(
+      resolveKeepVisibleBottomPadding({
+        visibleArea: { topInset: 0, bottomInset: 40 },
+      }),
+    ).toBe(100);
+  });
+});
+
 describe('resolveTypewriterBottomPadding', () => {
-  it('grows when content bottom is too close to the cursor line', () => {
+  it('uses typewriter padding from viewport position and trailing margin', () => {
     expect(
       resolveTypewriterBottomPadding({
         clientHeight: 500,
         targetHeight: 20,
-        distanceToContentBottom: 80,
         visibleArea: { topInset: 0, bottomInset: 40 },
         position: 0.5,
+        trailingBottomMargin: 20,
       }),
-    ).toBe(200);
+    ).toBe(240);
   });
 
-  it('keeps the minimum bottom padding when existing content space is enough', () => {
+  it('keeps the minimum bottom padding when typewriter space fits in the trailing margin', () => {
     expect(
       resolveTypewriterBottomPadding({
         clientHeight: 500,
         targetHeight: 20,
-        distanceToContentBottom: 500,
-        position: 0.5,
+        position: 1,
+        trailingBottomMargin: 20,
       }),
     ).toBe(48);
   });

--- a/apps/website/src/lib/editor-ffi/scroll.ts
+++ b/apps/website/src/lib/editor-ffi/scroll.ts
@@ -1,6 +1,5 @@
 import { clamp } from '@typie/ui/utils';
 import { CURSOR_VISIBLE_MARGIN, TYPEWRITER_MIN_BOTTOM_PADDING } from './constants';
-import type { Size } from '@typie/editor-ffi/browser';
 
 export type EditorVisibleArea = {
   topInset: number;
@@ -108,66 +107,33 @@ export function resolveTypewriterScrollTop({
   return nearlySameScroll(clamped, safeScrollTop) ? null : clamped;
 }
 
-export function resolveDistanceToPagesBottom({
-  pageSizes,
-  pageIdx,
-  targetY,
-  displayZoom = 1,
-  pageGap = 0,
-}: {
-  pageSizes: readonly Size[];
-  pageIdx: number;
-  targetY: number;
-  displayZoom?: number;
-  pageGap?: number;
-}): number | null {
-  if (!Number.isInteger(pageIdx) || pageIdx < 0 || pageIdx >= pageSizes.length) {
-    return null;
-  }
-
-  const zoom = finiteOrZero(displayZoom) > 0 ? finiteOrZero(displayZoom) : 1;
-  const gap = Math.max(0, finiteOrZero(pageGap));
-  const page = pageSizes[pageIdx];
-  const currentPageDistance = Math.max(0, finiteOrZero(page.height) - Math.max(0, finiteOrZero(targetY)));
-  let distance = currentPageDistance;
-
-  for (let i = pageIdx + 1; i < pageSizes.length; i++) {
-    distance += gap + Math.max(0, finiteOrZero(pageSizes[i].height));
-  }
-
-  return distance * zoom;
-}
-
 export function resolveKeepVisibleBottomPadding({
-  distanceToContentBottom,
   visibleArea,
   margin = CURSOR_VISIBLE_MARGIN,
   minPadding = 0,
 }: {
-  distanceToContentBottom: number;
   visibleArea?: EditorVisibleArea;
   margin?: number;
   minPadding?: number;
 }): number {
   const area = normalizeVisibleArea(visibleArea);
-  const safeDistanceToContentBottom = Math.max(0, finiteOrZero(distanceToContentBottom));
-  const requiredPadding = area.bottomInset + Math.max(0, finiteOrZero(margin)) - safeDistanceToContentBottom;
+  const requiredPadding = area.bottomInset + Math.max(0, finiteOrZero(margin));
   return Math.max(Math.max(0, finiteOrZero(minPadding)), requiredPadding);
 }
 
 export function resolveTypewriterBottomPadding({
   clientHeight,
   targetHeight,
-  distanceToContentBottom,
   visibleArea,
   position,
+  trailingBottomMargin = 0,
   minPadding = TYPEWRITER_MIN_BOTTOM_PADDING,
 }: {
   clientHeight: number;
   targetHeight: number;
-  distanceToContentBottom: number;
   visibleArea?: EditorVisibleArea;
   position: number;
+  trailingBottomMargin?: number;
   minPadding?: number;
 }): number {
   const area = normalizeVisibleArea(visibleArea);
@@ -176,7 +142,8 @@ export function resolveTypewriterBottomPadding({
   const availableRange = Math.max(0, usableHeight - safeTargetHeight);
   const clampedPosition = clamp(finiteOrZero(position), 0, 1);
   const spaceNeededBelowTargetTop = area.bottomInset + (1 - clampedPosition) * availableRange + safeTargetHeight;
-  const requiredPadding = spaceNeededBelowTargetTop - Math.max(0, finiteOrZero(distanceToContentBottom));
+  const intrinsicSpaceBelowTargetTop = Math.max(0, finiteOrZero(trailingBottomMargin)) + safeTargetHeight;
+  const requiredPadding = spaceNeededBelowTargetTop - intrinsicSpaceBelowTargetTop;
 
   return Math.max(Math.max(0, finiteOrZero(minPadding)), requiredPadding);
 }


### PR DESCRIPTION
문서 끝에서 위로 드래그 선택할 때 스크롤 extent가 줄어들면서 몇 줄씩 점프하는 현상이 일어나지 않도록 함