### PR TITLE
fix: trailing space overflow로 생기는 phantom 줄 제거

### DIFF
--- a/crates/editor-view/src/measure/text/extract.rs
+++ b/crates/editor-view/src/measure/text/extract.rs
@@ -332,6 +332,16 @@ pub fn extract_lines(
         });
     }
 
+    // Parley emits a zero-content trailing line as a hanging-space artifact;
+    // keeping it would break ArrowDown navigation across the paragraph.
+    if lines.len() > 1
+        && lines
+            .last()
+            .is_some_and(|l| l.glyph_runs.is_empty() && l.tab_gaps_raw.is_empty())
+    {
+        lines.pop();
+    }
+
     lines
 }
 #[cfg(test)]

--- a/crates/editor-view/src/measure/text/measure.rs
+++ b/crates/editor-view/src/measure/text/measure.rs
@@ -1351,4 +1351,23 @@ mod tests {
             "centered line must not collapse to left (x={glyph_x})"
         );
     }
+
+    #[test]
+    fn trailing_space_wrap_does_not_emit_phantom_line() {
+        let (doc, p1) = doc! { root { p1: paragraph { text("aaaaaaaaaa ") } } };
+        let mut measurer = Measurer::new_test();
+        let m = measurer.measure(&doc, p1, 30.0, &ViewState::new());
+        let MeasuredContent::Box(b) = &m.content else {
+            panic!("expected box")
+        };
+        for (i, c) in b.children.iter().enumerate() {
+            let MeasuredContent::Line(l) = &c.content else {
+                continue;
+            };
+            assert!(
+                !l.glyph_runs.is_empty() || !l.tab_gaps.is_empty(),
+                "line {i} must not be a phantom (empty trailing line)"
+            );
+        }
+    }
 }


### PR DESCRIPTION
- Segment::Text 경로에서 extract_lines 후 마지막 줄이 glyph run도 tab gap도 없으면 제거
- Segment::Empty에서 오는 의도적인 빈 줄은 별도 코드 경로(build_strut_only_line)를 거치므로 영향 없음