### PR TITLE
TR-220 링크 및 루비 편집 중에 발생하는 버그 해결

### DIFF
--- a/apps/website/src/lib/editor-ffi/components/LinkTooltip.svelte
+++ b/apps/website/src/lib/editor-ffi/components/LinkTooltip.svelte
@@ -1,38 +1,227 @@
 <script lang="ts">
+  import { flip, hide, shift } from '@floating-ui/dom';
   import { css } from '@typie/styled-system/css';
-  import { IS_MAC } from '../constants';
+  import { createFloatingActions } from '@typie/ui/actions';
+  import { Icon } from '@typie/ui/components';
+  import CopyIcon from '~icons/lucide/copy';
+  import GlobeIcon from '~icons/lucide/globe';
   import { getEditorContext } from '../editor.svelte';
+  import { pageRectsToVirtualElement } from '../geometry';
+  import { openLinkEditorFromTooltip } from '../handlers/link';
+  import { pickLinkTooltipAnchorRect, resolveSelectionTarget } from './link-tooltip';
+  import type { NodeId } from '@typie/editor-ffi/browser';
 
-  const { editor } = getEditorContext();
+  const ctx = getEditorContext();
+  const { editor } = ctx;
 
   const hover = $derived(editor?.linkHover);
-  const followHint = $derived(editor?.readOnly ? '클릭하여 열기' : `${IS_MAC ? '⌘' : 'Ctrl'} + 클릭하여 열기`);
+
+  type TooltipTarget = import('./link-tooltip').LinkTooltipTarget;
+
+  let activeHover = $state<typeof hover>();
+  let isTooltipHovered = $state(false);
+  let hideTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const keyboardTarget = $derived.by<TooltipTarget | undefined>(() => {
+    const instance = editor;
+    if (!instance) return;
+    return resolveSelectionTarget({
+      linkRects: instance.linkRects,
+      modifierStateLink: instance.modifierState?.link,
+      selection: instance.selection,
+      selectionHeadRect: instance.selectionHeadRect(),
+    });
+  });
+
+  const tooltipTarget = $derived.by<TooltipTarget | undefined>(() => {
+    if (activeHover) {
+      // Anchor to the link's own first rect, independent of the pointer, so the
+      // tooltip stays fixed while the mouse moves within the link.
+      const anchorRect = pickLinkTooltipAnchorRect(activeHover.link.rects);
+      if (anchorRect) {
+        return {
+          link: activeHover.link,
+          page: activeHover.page,
+          anchorRect,
+        };
+      }
+    }
+
+    return keyboardTarget;
+  });
+
+  const { anchor, floating } = createFloatingActions({
+    placement: 'bottom-start',
+    offset: 8,
+    middleware: [flip(), shift({ padding: 8 }), hide()],
+  });
+
+  const clearHideTimer = () => {
+    if (hideTimer) {
+      clearTimeout(hideTimer);
+      hideTimer = null;
+    }
+  };
+
+  const copyHref = async () => {
+    const href = tooltipTarget?.link.href;
+    if (!href) return;
+    await navigator.clipboard.writeText(href);
+  };
+
+  const openToolbarLinkEditor = async (nodeId: NodeId) => {
+    await openLinkEditorFromTooltip({
+      closeTooltip: () => {
+        activeHover = undefined;
+        isTooltipHovered = false;
+      },
+      ctx,
+      editor,
+      nodeId,
+    });
+  };
+
+  $effect(() => {
+    clearHideTimer();
+
+    if (hover) {
+      const nodeChanged = activeHover?.link.node_id !== hover.link.node_id;
+      activeHover = hover;
+      if (nodeChanged) {
+        ctx.linkEditorOpen = false;
+      }
+      return;
+    }
+
+    if (isTooltipHovered) {
+      return;
+    }
+
+    hideTimer = setTimeout(() => {
+      activeHover = undefined;
+      hideTimer = null;
+    }, 120);
+
+    return () => clearHideTimer();
+  });
+
+  // Anchor the tooltip to the link rect via a floating-ui virtual element built
+  // from page-local rects. autoUpdate re-reads it on scroll/resize, keeping the
+  // tooltip pinned to the link. (Same pattern as the spellcheck/comment popovers.)
+  $effect(() => {
+    const target = tooltipTarget;
+    if (target && editor) {
+      anchor(pageRectsToVirtualElement(editor, [{ page_idx: target.page, rect: target.anchorRect }]));
+    }
+  });
 </script>
 
-{#if hover}
+{#if tooltipTarget}
   <div
-    style:left={`${hover.clientX + 12}px`}
-    style:top={`${hover.clientY + 18}px`}
     class={css({
-      position: 'fixed',
       zIndex: '50',
-      maxWidth: '320px',
-      paddingX: '8px',
-      paddingY: '4px',
-      borderRadius: '6px',
-      backgroundColor: 'surface.dark',
-      color: 'text.bright',
-      fontSize: '11px',
-      lineHeight: '[1.3]',
-      pointerEvents: 'none',
-      boxShadow: '[0_2px_8px_rgba(0,0,0,0.15)]',
+      width: '[fit-content]',
+      maxWidth: '[min(320px, calc(100vw - 24px))]',
+      pointerEvents: 'auto',
     })}
+    onpointerenter={() => {
+      clearHideTimer();
+      isTooltipHovered = true;
+    }}
+    onpointerleave={() => {
+      isTooltipHovered = false;
+      if (!hover) {
+        activeHover = undefined;
+      }
+    }}
+    role="presentation"
+    use:floating
   >
-    <div class={css({ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' })}>
-      {hover.link.href}
-    </div>
-    <div class={css({ opacity: '70', fontSize: '10px', marginTop: '2px' })}>
-      {followHint}
+    <div
+      class={css({
+        borderWidth: '1px',
+        borderColor: 'border.subtle',
+        borderRadius: '4px',
+        paddingX: '4px',
+        paddingY: '4px',
+        backgroundColor: 'surface.default',
+        boxShadow: 'small',
+        overflow: 'hidden',
+      })}
+    >
+      <div
+        class={css({
+          display: 'flex',
+          alignItems: 'center',
+          gap: '4px',
+          minWidth: '0',
+          borderRadius: '4px',
+          minHeight: '24px',
+          paddingLeft: '8px',
+          paddingRight: '4px',
+          paddingY: '2px',
+          backgroundColor: 'surface.default',
+          color: 'text.subtle',
+        })}
+      >
+        <Icon style={css.raw({ color: 'var(--colors-text-faint)' })} icon={GlobeIcon} size={12} />
+        <span
+          class={css({
+            display: 'block',
+            minWidth: '0',
+            flex: '1',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            fontSize: '12px',
+            lineHeight: '[1.2]',
+            color: 'text.subtle',
+          })}
+        >
+          {tooltipTarget.link.href}
+        </span>
+
+        <button
+          class={css({
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexShrink: '0',
+            width: '20px',
+            height: '20px',
+            borderRadius: '4px',
+            color: 'text.subtle',
+            transition: 'common',
+          })}
+          aria-label="링크 복사"
+          onclick={copyHref}
+          type="button"
+        >
+          <Icon icon={CopyIcon} size={12} />
+        </button>
+
+        {#if !(editor?.readOnly ?? false)}
+          <button
+            class={css({
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              flexShrink: '0',
+              height: '20px',
+              borderRadius: '4px',
+              paddingX: '6px',
+              fontSize: '11px',
+              fontWeight: 'medium',
+              color: 'text.subtle',
+              transition: 'common',
+            })}
+            onclick={() => openToolbarLinkEditor(tooltipTarget.link.node_id)}
+            type="button"
+          >
+            편집
+          </button>
+        {/if}
+      </div>
     </div>
   </div>
 {/if}

--- a/apps/website/src/lib/editor-ffi/components/link-tooltip.test.ts
+++ b/apps/website/src/lib/editor-ffi/components/link-tooltip.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { resolveSelectionTarget } from './link-tooltip';
+
+describe('resolveSelectionTarget', () => {
+  it('shows a tooltip for a range selection when the selected link href is uniform', () => {
+    const target = resolveSelectionTarget({
+      linkRects: [
+        {
+          node_id: 't1',
+          href: 'https://a.com',
+          page_idx: 0,
+          rects: [{ x: 10, y: 20, width: 30, height: 10 }],
+        },
+      ],
+      modifierStateLink: {
+        type: 'uniform',
+        value: { href: 'https://a.com' },
+      },
+      selection: {
+        anchor: { node_id: 't1', offset: 0 },
+        head: { node_id: 't1', offset: 5 },
+      },
+      selectionHeadRect: {
+        page_idx: 0,
+        rect: { x: 12, y: 20, width: 1, height: 10 },
+      },
+    });
+
+    expect(target?.link.node_id).toBe('t1');
+    expect(target?.link.href).toBe('https://a.com');
+  });
+
+  it('falls back to href matching when paragraph selection endpoints are container positions', () => {
+    const target = resolveSelectionTarget({
+      linkRects: [
+        {
+          node_id: 't1',
+          href: 'https://a.com',
+          page_idx: 0,
+          rects: [{ x: 10, y: 20, width: 30, height: 10 }],
+        },
+      ],
+      modifierStateLink: {
+        type: 'uniform',
+        value: { href: 'https://a.com' },
+      },
+      selection: {
+        anchor: { node_id: 'p1', offset: 0 },
+        head: { node_id: 'p1', offset: 2 },
+      },
+      selectionHeadRect: {
+        page_idx: 0,
+        rect: { x: 12, y: 20, width: 1, height: 10 },
+      },
+    });
+
+    expect(target?.link.node_id).toBe('t1');
+  });
+
+  it('anchors to the link first rect regardless of where the selection head landed', () => {
+    const target = resolveSelectionTarget({
+      linkRects: [
+        {
+          node_id: 't1',
+          href: 'https://a.com',
+          page_idx: 0,
+          rects: [
+            { x: 10, y: 20, width: 30, height: 10 },
+            { x: 0, y: 40, width: 50, height: 10 },
+          ],
+        },
+      ],
+      modifierStateLink: {
+        type: 'uniform',
+        value: { href: 'https://a.com' },
+      },
+      selection: {
+        anchor: { node_id: 't1', offset: 0 },
+        head: { node_id: 't1', offset: 8 },
+      },
+      // Head landed on the second visual line of the link.
+      selectionHeadRect: {
+        page_idx: 0,
+        rect: { x: 20, y: 40, width: 1, height: 10 },
+      },
+    });
+
+    expect(target?.anchorRect).toEqual({ x: 10, y: 20, width: 30, height: 10 });
+  });
+});

--- a/apps/website/src/lib/editor-ffi/components/link-tooltip.ts
+++ b/apps/website/src/lib/editor-ffi/components/link-tooltip.ts
@@ -1,0 +1,76 @@
+import type { LinkRect, ModifierState, PageRect, Selection } from '@typie/editor-ffi/browser';
+
+export type LinkTooltipTarget = {
+  link: LinkRect;
+  page: number;
+  anchorRect: { x: number; y: number; width: number; height: number };
+};
+
+type RectLike = LinkTooltipTarget['anchorRect'];
+
+// The tooltip anchors to the link's first rect, independent of pointer/selection.
+export const pickLinkTooltipAnchorRect = (rects: RectLike[]): RectLike | null => rects[0] ?? null;
+
+type SelectionTargetOptions = {
+  linkRects: LinkRect[];
+  modifierStateLink: ModifierState['link'] | undefined;
+  selection: Selection | undefined;
+  selectionHeadRect: PageRect | null;
+};
+
+export const resolveSelectionTarget = ({
+  linkRects,
+  modifierStateLink,
+  selection,
+  selectionHeadRect,
+}: SelectionTargetOptions): LinkTooltipTarget | undefined => {
+  if (!selection || modifierStateLink?.type !== 'uniform') return;
+
+  // The selection is a single uniform link, but the same href can appear several
+  // times in the document — pick the occurrence the selection actually points at,
+  // so the tooltip lands on the right one (not the first in the document).
+  const uniformHref = modifierStateLink.value.href;
+  const sameHrefRects = linkRects.filter((rect) => rect.href === uniformHref);
+  if (sameHrefRects.length === 0) return;
+
+  const link = pickSelectedLinkRect(sameHrefRects, selection, selectionHeadRect);
+
+  // Anchor to the link's own first rect, independent of the pointer/selection
+  // position, so the tooltip stays fixed — matching the hover path.
+  const anchorRect = pickLinkTooltipAnchorRect(link.rects);
+  if (!anchorRect) return;
+
+  return {
+    link,
+    page: link.page_idx,
+    anchorRect,
+  };
+};
+
+// Among link rects sharing the selected href, choose the one the selection refers
+// to, in priority order:
+//   1. a rect whose node is a selection endpoint (exact match),
+//   2. a rect on the same line as the selection head,
+//   3. the first occurrence in the document (fallback).
+const pickSelectedLinkRect = (sameHrefRects: LinkRect[], selection: Selection, selectionHeadRect: PageRect | null): LinkRect => {
+  // Prefer the head node over the anchor node (matches caret-led navigation).
+  const endpointNodeIds = [selection.head.node_id, selection.anchor.node_id];
+  const endpointMatch = endpointNodeIds
+    .map((nodeId) => sameHrefRects.find((rect) => rect.node_id === nodeId))
+    .find((rect) => rect !== undefined);
+  if (endpointMatch) return endpointMatch;
+
+  const lineMatch =
+    selectionHeadRect &&
+    sameHrefRects.find(
+      (rect) =>
+        rect.page_idx === selectionHeadRect.page_idx &&
+        rect.rects.some(
+          (candidate) =>
+            selectionHeadRect.rect.y < candidate.y + candidate.height &&
+            selectionHeadRect.rect.y + selectionHeadRect.rect.height > candidate.y,
+        ),
+    );
+
+  return lineMatch ?? sameHrefRects[0];
+};

--- a/apps/website/src/lib/editor-ffi/components/toolbar/BottomToolbar.svelte
+++ b/apps/website/src/lib/editor-ffi/components/toolbar/BottomToolbar.svelte
@@ -111,6 +111,26 @@
   const toggleModifier = (modifier_type: ModifierType) => {
     enqueue({ type: 'modifier', op: { type: 'toggle', modifier_type } });
   };
+
+  // When opening the link/ruby editor with a *collapsed* caret inside a mark,
+  // extend the selection over that whole mark span so editing applies to the
+  // entire mark and the range is visible. A range selection (partial or spanning
+  // several marks/plain text) is always preserved so editing applies to exactly
+  // what the user selected.
+  const extendSelectionToSpan = (modifier_type: 'link' | 'ruby') => {
+    const editor = ctx.editor;
+    if (editingDisabled || !editor) return;
+    const selection = editor.selection;
+    if (!selection || !editor.isSelectionCollapsed) return;
+
+    const span = editor.modifierSpanSelection(selection.head, modifier_type);
+    if (!span) return;
+
+    editor.enqueue({ type: 'selection', op: { type: 'set', selection: span } });
+    // Flush so the editor popover reads the extended selection synchronously
+    // instead of the pre-extend one on this same open.
+    editor.flush();
+  };
 </script>
 
 <div
@@ -284,6 +304,11 @@
       disabled={isLinkMixed || (isCollapsed && !isLinkActive)}
       label="링크"
       onEscape={() => ctx.editor?.focus()}
+      onOpenChange={(opened) => {
+        if (opened) extendSelectionToSpan('link');
+        ctx.linkEditorOpen = opened;
+      }}
+      opened={ctx.linkEditorOpen}
       size="small"
     >
       {#snippet anchor()}
@@ -300,6 +325,9 @@
       disabled={isRubyMixed || (isCollapsed && !isRubyActive)}
       label="루비"
       onEscape={() => ctx.editor?.focus()}
+      onOpenChange={(opened) => {
+        if (opened) extendSelectionToSpan('ruby');
+      }}
       size="small"
     >
       {#snippet anchor()}

--- a/apps/website/src/lib/editor-ffi/components/toolbar/LinkEditorForm.svelte
+++ b/apps/website/src/lib/editor-ffi/components/toolbar/LinkEditorForm.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  import { flex } from '@typie/styled-system/patterns';
+  import { Button, TextInput } from '@typie/ui/components';
+
+  type Props = {
+    close: () => void;
+    initialHref?: string;
+    submitLabel?: string;
+    onSubmit: (href: string) => void;
+    onRemove?: () => void;
+  };
+
+  let { close, initialHref, submitLabel = '삽입', onSubmit, onRemove }: Props = $props();
+
+  let url = $state(initialHref ?? '');
+
+  $effect(() => {
+    url = initialHref ?? '';
+  });
+</script>
+
+<form
+  class={flex({ alignItems: 'center', gap: '4px', padding: '4px' })}
+  onsubmit={(event) => {
+    event.preventDefault();
+    const trimmed = url.trim();
+    if (!trimmed) return;
+    onSubmit(trimmed);
+    close();
+  }}
+>
+  <TextInput autofocus placeholder="https://..." size="sm" bind:value={url} />
+
+  <Button disabled={url.trim() === ''} size="sm" type="submit">
+    {submitLabel}
+  </Button>
+
+  {#if onRemove}
+    <Button
+      onclick={() => {
+        onRemove();
+        close();
+      }}
+      size="sm"
+      variant="secondary"
+    >
+      제거
+    </Button>
+  {/if}
+</form>

--- a/apps/website/src/lib/editor-ffi/components/toolbar/ToolbarLink.svelte
+++ b/apps/website/src/lib/editor-ffi/components/toolbar/ToolbarLink.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
-  import { flex } from '@typie/styled-system/patterns';
-  import { Button, TextInput } from '@typie/ui/components';
-  import { createForm } from '@typie/ui/form';
-  import { z } from 'zod';
   import { getEditorContext } from '$lib/editor-ffi/editor.svelte';
+  import { normalizeUrl } from '../../handlers/link';
+  import LinkEditorForm from './LinkEditorForm.svelte';
   import type { Modifier } from '@typie/editor-ffi/browser';
 
   type Props = {
@@ -15,42 +13,20 @@
   const ctx = getEditorContext();
 
   const existingHref = $derived(ctx.editor?.modifierState?.link?.type === 'uniform' ? ctx.editor.modifierState.link.value.href : undefined);
-
-  const normalizeUrl = (input: string): string => (/^[a-z][a-z0-9+.-]*:/i.test(input) ? input : `https://${input}`);
-
-  const form = createForm({
-    schema: z.object({
-      url: z.string().min(1),
-    }),
-    onSubmit: (data) => {
-      const href = normalizeUrl(data.url.trim());
-      const modifier: Modifier = { type: 'link', href };
-      ctx.editor?.enqueue({ type: 'modifier', op: { type: 'edit', modifier_type: 'link', modifier } });
-      ctx.editor?.focus();
-      close();
-    },
-    defaultValues: {
-      url: existingHref ?? '',
-    },
-  });
 </script>
 
-<form class={flex({ alignItems: 'center', gap: '4px', padding: '4px' })} onsubmit={form.handleSubmit}>
-  <TextInput autofocus placeholder="https://..." size="sm" bind:value={form.fields.url} />
-
-  <Button size="sm" type="submit">삽입</Button>
-
-  {#if existingHref}
-    <Button
-      onclick={() => {
+<LinkEditorForm
+  {close}
+  initialHref={existingHref}
+  onRemove={existingHref
+    ? () => {
         ctx.editor?.enqueue({ type: 'modifier', op: { type: 'edit', modifier_type: 'link', modifier: undefined } });
         ctx.editor?.focus();
-        close();
-      }}
-      size="sm"
-      variant="secondary"
-    >
-      제거
-    </Button>
-  {/if}
-</form>
+      }
+    : undefined}
+  onSubmit={(href) => {
+    const modifier: Modifier = { type: 'link', href: normalizeUrl(href) };
+    ctx.editor?.enqueue({ type: 'modifier', op: { type: 'edit', modifier_type: 'link', modifier } });
+    ctx.editor?.focus();
+  }}
+/>

--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -23,6 +23,7 @@ import type {
   Message,
   Modifier,
   ModifierState,
+  ModifierType,
   PageRect,
   PlainDoc,
   PlainRootNode,
@@ -102,6 +103,7 @@ export class EditorContext {
   pendingImageDrops: File[] = [];
   pendingFileDrops: File[] = [];
   findReplaceOpen = $state(false);
+  linkEditorOpen = $state(false);
 }
 
 const [getEditorContext, setEditorContext] = createContext<EditorContext>();
@@ -743,6 +745,10 @@ export class Editor {
 
   selectionEndpoints(): SelectionEndpoints | undefined {
     return this.#wasm.selection_endpoints();
+  }
+
+  modifierSpanSelection(pos: Position, modifierType: ModifierType): Selection | undefined {
+    return this.#wasm.modifier_span_selection(pos, modifierType);
   }
 
   ime(beforeLimit: number, afterLimit: number): Ime {

--- a/apps/website/src/lib/editor-ffi/handlers/link.test.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/link.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+import { openLinkEditorFromTooltip } from './link';
+
+describe('openLinkEditorFromTooltip', () => {
+  it('extends the selection over the whole link span and opens the toolbar editor', async () => {
+    const span = {
+      anchor: { node_id: 't1', offset: 0 },
+      head: { node_id: 't2', offset: 5 },
+    };
+    const editor = {
+      enqueue: vi.fn(),
+      flush: vi.fn(),
+      focus: vi.fn(),
+      modifierSpanSelection: vi.fn(() => span),
+    };
+    const ctx = { linkEditorOpen: false };
+    const closeTooltip = vi.fn();
+
+    const opened = await openLinkEditorFromTooltip({ closeTooltip, ctx, editor, nodeId: 't1' });
+
+    expect(opened).toBe(true);
+    expect(editor.modifierSpanSelection).toHaveBeenCalledWith({ node_id: 't1', offset: 0 }, 'link');
+    expect(editor.enqueue).toHaveBeenCalledWith({ type: 'selection', op: { type: 'set', selection: span } });
+    expect(editor.flush).toHaveBeenCalled();
+    expect(closeTooltip).toHaveBeenCalled();
+    expect(ctx.linkEditorOpen).toBe(true);
+  });
+
+  it('falls back to a collapsed caret when the span cannot be resolved', async () => {
+    const editor = {
+      enqueue: vi.fn(),
+      flush: vi.fn(),
+      focus: vi.fn(),
+      modifierSpanSelection: vi.fn(),
+    };
+    const ctx = { linkEditorOpen: false };
+
+    await openLinkEditorFromTooltip({ closeTooltip: vi.fn(), ctx, editor, nodeId: 't1' });
+
+    const caret = { node_id: 't1', offset: 0 };
+    expect(editor.enqueue).toHaveBeenCalledWith({
+      type: 'selection',
+      op: { type: 'set', selection: { anchor: caret, head: caret } },
+    });
+  });
+
+  it('does nothing when the editor instance is unavailable', async () => {
+    const ctx = { linkEditorOpen: false };
+    const closeTooltip = vi.fn();
+
+    const opened = await openLinkEditorFromTooltip({ closeTooltip, ctx, editor: undefined, nodeId: 't1' });
+
+    expect(opened).toBe(false);
+    expect(closeTooltip).not.toHaveBeenCalled();
+    expect(ctx.linkEditorOpen).toBe(false);
+  });
+});

--- a/apps/website/src/lib/editor-ffi/handlers/link.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/link.ts
@@ -1,6 +1,7 @@
+import { tick } from 'svelte';
 import { goto } from '$app/navigation';
 import type { NodeId } from '@typie/editor-ffi/browser';
-import type { Editor } from '../editor.svelte';
+import type { Editor, EditorContext } from '../editor.svelte';
 import type { ContextMenuContributor, ContextMenuItem } from '../types';
 
 const SAFE_PROTOCOLS = new Set(['http:', 'https:', 'mailto:', 'tel:']);
@@ -23,6 +24,9 @@ export const openLink = (href: string): void => {
   window.open(url.href, '_blank', 'noopener,noreferrer');
 };
 
+export const normalizeUrl = (input: string): string =>
+  /^https?:/i.test(input) || /^mailto:/i.test(input) || /^tel:/i.test(input) ? input : `https://${input}`;
+
 export const registerLinkContextMenu = (editor: Editor): (() => void) => {
   const contributor: ContextMenuContributor = ({ clientX, clientY }) => {
     const hit = editor.linkHitTestAtClient(clientX, clientY);
@@ -44,7 +48,7 @@ export const registerLinkContextMenu = (editor: Editor): (() => void) => {
         {
           label: '링크 제거',
           variant: 'danger',
-          onclick: () => removeLink(editor, hit.link.node_id),
+          onclick: () => removeLinkAtNode(editor, hit.link.node_id),
         },
       );
     }
@@ -55,12 +59,24 @@ export const registerLinkContextMenu = (editor: Editor): (() => void) => {
   return editor.registerContextMenuContributor(contributor);
 };
 
-const normalizeUrl = (input: string): string =>
-  /^https?:/i.test(input) || /^mailto:/i.test(input) || /^tel:/i.test(input) ? input : `https://${input}`;
-
 const selectInsideNode = (editor: Editor, nodeId: NodeId): void => {
   const pos = { node_id: nodeId, offset: 0 };
   editor.enqueue({ type: 'selection', op: { type: 'set', selection: { anchor: pos, head: pos } } });
+};
+
+const editLinkAtNode = (editor: Editor, nodeId: NodeId, href: string): void => {
+  selectInsideNode(editor, nodeId);
+  editor.enqueue({
+    type: 'modifier',
+    op: { type: 'edit', modifier_type: 'link', modifier: { type: 'link', href: normalizeUrl(href.trim()) } },
+  });
+  editor.focus();
+};
+
+const removeLinkAtNode = (editor: Editor, nodeId: NodeId): void => {
+  selectInsideNode(editor, nodeId);
+  editor.enqueue({ type: 'modifier', op: { type: 'edit', modifier_type: 'link', modifier: undefined } });
+  editor.focus();
 };
 
 const editLinkPrompt = (editor: Editor, nodeId: NodeId, current: string): void => {
@@ -70,14 +86,49 @@ const editLinkPrompt = (editor: Editor, nodeId: NodeId, current: string): void =
     return;
   }
   const trimmed = result.trim();
-  const modifier = trimmed === '' ? undefined : ({ type: 'link', href: normalizeUrl(trimmed) } as const);
-  selectInsideNode(editor, nodeId);
-  editor.enqueue({ type: 'modifier', op: { type: 'edit', modifier_type: 'link', modifier } });
-  editor.focus();
+  if (trimmed === '') {
+    removeLinkAtNode(editor, nodeId);
+  } else {
+    editLinkAtNode(editor, nodeId, trimmed);
+  }
 };
 
-const removeLink = (editor: Editor, nodeId: NodeId): void => {
-  selectInsideNode(editor, nodeId);
-  editor.enqueue({ type: 'modifier', op: { type: 'edit', modifier_type: 'link', modifier: undefined } });
+type LinkEditorContextLike = Pick<EditorContext, 'linkEditorOpen'>;
+type LinkEditorTarget = Pick<Editor, 'enqueue' | 'flush' | 'focus' | 'modifierSpanSelection'>;
+
+type OpenLinkEditorFromTooltipOptions = {
+  closeTooltip: () => void;
+  ctx: LinkEditorContextLike;
+  editor: LinkEditorTarget | undefined;
+  nodeId: NodeId;
+};
+
+// Opens the toolbar link editor from the hover tooltip's "edit" action.
+export const openLinkEditorFromTooltip = async ({
+  closeTooltip,
+  ctx,
+  editor,
+  nodeId,
+}: OpenLinkEditorFromTooltipOptions): Promise<boolean> => {
+  if (!editor) return false;
+
+  // Extend the selection over the whole link span so editing/removal applies to
+  // the entire mark, not just the caret position. Fall back to a collapsed caret
+  // inside the node if the span cannot be resolved.
+  const caret = { node_id: nodeId, offset: 0 };
+  const selection = editor.modifierSpanSelection(caret, 'link') ?? { anchor: caret, head: caret };
+  editor.enqueue({ type: 'selection', op: { type: 'set', selection } });
+  editor.flush();
   editor.focus();
+
+  closeTooltip();
+
+  // If the editor is already open (e.g. switching links), force it to re-read
+  // the freshly extended selection by closing it for a tick before reopening.
+  if (ctx.linkEditorOpen) {
+    ctx.linkEditorOpen = false;
+    await tick();
+  }
+  ctx.linkEditorOpen = true;
+  return true;
 };

--- a/crates/editor-core/src/editor.rs
+++ b/crates/editor-core/src/editor.rs
@@ -1,7 +1,7 @@
 use editor_clipboard::Slice;
 use editor_common::{Movement, time::Duration};
 use editor_crdt::{Changeset, CrdtError, Dot, Op};
-use editor_model::{DocOp, ModifierState, Node, NodeId};
+use editor_model::{DocOp, ModifierState, ModifierType, Node, NodeId};
 use editor_renderer::{Mark, MarkData, RenderSink, Renderer};
 #[cfg(any(test, feature = "test-utils"))]
 use editor_resource::ThemeVariant;
@@ -197,6 +197,19 @@ impl Editor {
 
     pub fn modifier_state(&self) -> Option<ModifierState> {
         editor_state::resolve_modifier_state(&self.state)
+    }
+
+    /// Selection covering the whole link/ruby span containing `pos`.
+    ///
+    /// Used when entering edit mode (toolbar button, hover tooltip) to extend a
+    /// collapsed caret over the entire mark. Returns `None` when `pos` is not
+    /// inside such a span.
+    pub fn modifier_span_selection(
+        &self,
+        pos: &editor_state::Position,
+        modifier_type: ModifierType,
+    ) -> Option<editor_state::Selection> {
+        editor_state::resolve_modifier_span_selection(&self.state, pos, modifier_type)
     }
 
     pub fn block_state(&self) -> Option<BlockState> {
@@ -1792,6 +1805,41 @@ mod tests {
         let editor = Editor::new_test(state);
         let s = editor.modifier_state().unwrap();
         assert_eq!(s.bold, editor_common::Tri::Uniform { value: () });
+    }
+
+    #[test]
+    fn editor_exposes_uniform_link_for_paragraph_child_range_selection() {
+        let (state, _p1, ..) = state! {
+            doc { root { p1: paragraph {
+                t1: text("Hello") [link(href: "https://a.com".to_string())]
+                t2: text("World") [link(href: "https://a.com".to_string())]
+            } } }
+            selection: (p1, 0) -> (p1, 2)
+        };
+        let editor = Editor::new_test(state);
+        let s = editor.modifier_state().unwrap();
+        assert_eq!(
+            s.link,
+            editor_common::Tri::Uniform {
+                value: editor_model::LinkValue {
+                    href: "https://a.com".to_string(),
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn editor_exposes_mixed_link_for_paragraph_child_range_selection() {
+        let (state, _p1, ..) = state! {
+            doc { root { p1: paragraph {
+                t1: text("Hello") [link(href: "https://a.com".to_string())]
+                t2: text("World") [link(href: "https://b.com".to_string())]
+            } } }
+            selection: (p1, 0) -> (p1, 2)
+        };
+        let editor = Editor::new_test(state);
+        let s = editor.modifier_state().unwrap();
+        assert_eq!(s.link, editor_common::Tri::Mixed);
     }
 
     #[test]

--- a/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
@@ -751,6 +751,7 @@ declare class Editor {
     link_rects(): LinkRect[];
     local_changesets_since(remote_heads_payload: Uint8Array): Uint8Array;
     materialize_at(heads: Uint8Array): PlainDoc;
+    modifier_span_selection(pos: Position, modifier_type: ModifierType): Selection | undefined;
     modifier_state(): ModifierState | undefined;
     page_link_rects(page: number): LinkRect[];
     page_sizes(): Size[];

--- a/crates/editor-ffi/src/editor.rs
+++ b/crates/editor-ffi/src/editor.rs
@@ -140,6 +140,21 @@ impl Editor {
         self.with_inner(|inner| Ok(inner.editor.modifier_state().into_ffi()?))
     }
 
+    pub fn modifier_span_selection(
+        &self,
+        pos: Complex<editor_state::Position>,
+        modifier_type: Complex<editor_model::ModifierType>,
+    ) -> EditorResult<Option<Complex<editor_state::Selection>>> {
+        self.with_inner(|inner| {
+            let pos: editor_state::Position = pos.from_ffi()?;
+            let modifier_type: editor_model::ModifierType = modifier_type.from_ffi()?;
+            Ok(inner
+                .editor
+                .modifier_span_selection(&pos, modifier_type)
+                .into_ffi()?)
+        })
+    }
+
     pub fn block_state(&self) -> EditorResult<Option<Complex<editor_core::BlockState>>> {
         self.with_inner(|inner| Ok(inner.editor.block_state().into_ffi()?))
     }

--- a/crates/editor-state/src/modifier_resolution.rs
+++ b/crates/editor-state/src/modifier_resolution.rs
@@ -153,6 +153,10 @@ pub fn resolve_modifier_state_in_range(
         let mut canonical: Option<Modifier> = None;
         let mut absent_seen = false;
         let mut mixed = false;
+        // Links treat interleaved plain text as neutral so a single URL repeated
+        // across a paragraph stays editable as one. Ruby is per-glyph annotation,
+        // so any plain text / differing ruby in the selection makes it Mixed.
+        let sparse_absence_is_neutral = matches!(ty, ModifierType::Link);
 
         for node in &nodes {
             if !targets.contains(&node.as_type()) {
@@ -171,15 +175,17 @@ pub fn resolve_modifier_state_in_range(
                     break;
                 }
                 (Some(m), None) => {
-                    if absent_seen {
+                    if absent_seen && !sparse_absence_is_neutral {
                         mixed = true;
                         break;
                     }
                     canonical = Some(m);
                 }
                 (None, Some(_)) => {
-                    mixed = true;
-                    break;
+                    if !sparse_absence_is_neutral {
+                        mixed = true;
+                        break;
+                    }
                 }
                 (None, None) => {
                     absent_seen = true;
@@ -321,6 +327,37 @@ pub fn resolve_modifier_span_at(
     span.push(node.id());
     span.extend(right_chain);
     Some(span)
+}
+
+/// Selection that covers the whole modifier span containing `pos`.
+///
+/// Resolves the contiguous run of sibling text nodes sharing the same explicit
+/// modifier value (via [`resolve_modifier_span_at`]), then returns a selection
+/// from the start of the first node to the end of the last. Used when entering
+/// link/ruby editing so the visible selection extends over the entire mark,
+/// even if the caller only has a collapsed caret inside it.
+///
+/// Returns `None` when `pos` is not inside such a span.
+pub fn resolve_modifier_span_selection(
+    state: &State,
+    pos: &Position,
+    modifier_type: ModifierType,
+) -> Option<Selection> {
+    let span = resolve_modifier_span_at(state, pos, modifier_type)?;
+    let doc = &state.doc;
+
+    let first = *span.first()?;
+    let last = *span.last()?;
+
+    let last_len = match doc.node(last)?.node() {
+        Node::Text(t) => t.text.len(),
+        _ => return None,
+    };
+
+    Some(Selection::new(
+        Position::new(first, 0),
+        Position::new(last, last_len),
+    ))
 }
 
 fn collect_nodes_in_range<'a>(
@@ -840,6 +877,40 @@ mod tests {
     }
 
     #[test]
+    fn span_selection_covers_whole_link_from_collapsed_caret() {
+        let (state, t1, t2, ..) = state! {
+            doc { root { paragraph {
+                t1: text("Hello") [link(href: "https://a.com".to_string())]
+                t2: text("World") [link(href: "https://a.com".to_string())]
+            } } }
+            selection: (t1, 2)
+        };
+        let sel = resolve_modifier_span_selection(
+            &state,
+            &state.selection.as_ref().unwrap().head,
+            ModifierType::Link,
+        );
+        assert_eq!(
+            sel,
+            Some(Selection::new(Position::new(t1, 0), Position::new(t2, 5)))
+        );
+    }
+
+    #[test]
+    fn span_selection_is_none_outside_link() {
+        let (state, _t1, ..) = state! {
+            doc { root { paragraph { t1: text("plain") } } }
+            selection: (t1, 2)
+        };
+        let sel = resolve_modifier_span_selection(
+            &state,
+            &state.selection.as_ref().unwrap().head,
+            ModifierType::Link,
+        );
+        assert_eq!(sel, None);
+    }
+
+    #[test]
     fn resolve_span_stops_at_non_modifier_text() {
         let (state, _t0, t1, _t2, ..) = state! {
             doc { root { paragraph {
@@ -886,6 +957,94 @@ mod tests {
             ModifierType::Link,
         );
         assert_eq!(span, Some(vec![t1]));
+    }
+
+    #[test]
+    fn range_link_uniform_ignores_plain_text_inside_selection() {
+        let (state, _p1, ..) = state! {
+            doc { root { p1: paragraph {
+                t0: text("pre")
+                t1: text("Hello") [link(href: "https://a.com".to_string())]
+                t2: text("mid")
+                t3: text("World") [link(href: "https://a.com".to_string())]
+                t4: text("post")
+            } } }
+            selection: (p1, 0) -> (p1, 5)
+        };
+        let s = resolve_modifier_state(&state).unwrap();
+        assert_eq!(
+            s.link,
+            editor_common::Tri::Uniform {
+                value: editor_model::LinkValue {
+                    href: "https://a.com".to_string(),
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn range_link_mixed_when_selection_contains_different_hrefs_among_plain_text() {
+        let (state, _p1, ..) = state! {
+            doc { root { p1: paragraph {
+                t0: text("pre")
+                t1: text("Hello") [link(href: "https://a.com".to_string())]
+                t2: text("mid")
+                t3: text("World") [link(href: "https://b.com".to_string())]
+                t4: text("post")
+            } } }
+            selection: (p1, 0) -> (p1, 5)
+        };
+        let s = resolve_modifier_state(&state).unwrap();
+        assert_eq!(s.link, editor_common::Tri::Mixed);
+    }
+
+    #[test]
+    fn range_ruby_uniform_when_selection_is_a_single_ruby_run() {
+        let (state, _p1, ..) = state! {
+            doc { root { p1: paragraph {
+                t1: text("Hello") [ruby(text: "헬로".to_string())]
+                t2: text("World") [ruby(text: "헬로".to_string())]
+            } } }
+            selection: (p1, 0) -> (p1, 2)
+        };
+        let s = resolve_modifier_state(&state).unwrap();
+        assert_eq!(
+            s.ruby,
+            editor_common::Tri::Uniform {
+                value: editor_model::RubyValue {
+                    text: "헬로".to_string(),
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn range_ruby_mixed_when_plain_text_is_in_selection() {
+        // Unlike links, ruby does not treat interleaved plain text as neutral:
+        // mixing ruby with plain text is Mixed, which disables the ruby button.
+        let (state, _p1, ..) = state! {
+            doc { root { p1: paragraph {
+                t0: text("pre")
+                t1: text("Hello") [ruby(text: "헬로".to_string())]
+                t2: text("post")
+            } } }
+            selection: (p1, 0) -> (p1, 3)
+        };
+        let s = resolve_modifier_state(&state).unwrap();
+        assert_eq!(s.ruby, editor_common::Tri::Mixed);
+    }
+
+    #[test]
+    fn range_ruby_mixed_when_selection_contains_different_text() {
+        let (state, _p1, ..) = state! {
+            doc { root { p1: paragraph {
+                t1: text("Hello") [ruby(text: "헬로".to_string())]
+                t2: text("World") [ruby(text: "월드".to_string())]
+            } } }
+            selection: (p1, 0) -> (p1, 2)
+        };
+        let s = resolve_modifier_state(&state).unwrap();
+        assert_eq!(s.ruby, editor_common::Tri::Mixed);
     }
 
     #[test]


### PR DESCRIPTION
링크·루비 툴바 버튼을 눌러도 같은 mark 전체로 선택이 확장되지 않아 편집 진입이 번거로웠던 문제를 해결했습니다.  
커서만 있어도 그 mark 전체를 선택해 편집하도록 하고, 범위 선택은 그대로 보존합니다.

링크는 같은 URL이 반복되는 게 자연스러우니 일반 텍스트가 섞여도 한 번에 편집할 수 있게 하고,  
루비는 글자별 주석이라 다른 값이나 일반 텍스트가 섞이면 비활성화합니다.

링크 hover 툴팁은 노션처럼 카드형으로 교체하고, 키보드로 링크 안에 들어가도 뜨도록 했습니다.  
선택 범위에 여러가지 다른 링크나 루비가 여러 개 섞여 있으면 링크나 루비 버튼을 비활성화 처리하였습니다.