### PR TITLE
TR-225 코멘트 달린 텍스트 영역을 지웠을 때 유령 코멘트가 남는 버그 수정

### DIFF
--- a/crates/editor-core/src/editor.rs
+++ b/crates/editor-core/src/editor.rs
@@ -299,10 +299,9 @@ impl Editor {
             if range.explicitly_invalid {
                 continue;
             }
-            let sel = range.selection.thaw(&self.state.doc);
-            if sel.is_collapsed() {
+            let Some(sel) = range.locate(&self.state.doc) else {
                 continue;
-            }
+            };
             let Some(resolved) = sel.resolve(&self.state.doc) else {
                 continue;
             };
@@ -550,10 +549,9 @@ impl Editor {
             if range.explicitly_invalid {
                 continue;
             }
-            let sel = range.selection.thaw(&self.state.doc);
-            if sel.is_collapsed() {
+            let Some(sel) = range.locate(&self.state.doc) else {
                 continue;
-            }
+            };
             let Some(resolved) = sel.resolve(&self.state.doc) else {
                 continue;
             };

--- a/crates/editor-core/src/handle/tracked_range.rs
+++ b/crates/editor-core/src/handle/tracked_range.rs
@@ -23,13 +23,13 @@ pub fn handle_tracked_range_op(editor: &mut Editor, op: TrackedRangeOp) -> Resul
                     msg: "TrackedRange::Add: selection must resolve against current doc".into(),
                 });
             }
-            let new_range = TrackedRange {
-                id: id.clone(),
+            let new_range = TrackedRange::new(
+                id.clone(),
                 group,
-                selection: StableSelection::freeze(&selection, doc),
+                StableSelection::freeze(&selection, doc),
                 metadata,
-                explicitly_invalid: false,
-            };
+                doc,
+            );
             let would_change = editor
                 .tracked_ranges()
                 .get(&id)
@@ -45,13 +45,8 @@ pub fn handle_tracked_range_op(editor: &mut Editor, op: TrackedRangeOp) -> Resul
             selection,
             metadata,
         } => {
-            let new_range = TrackedRange {
-                id: id.clone(),
-                group,
-                selection,
-                metadata,
-                explicitly_invalid: false,
-            };
+            let doc = &editor.state().doc;
+            let new_range = TrackedRange::new(id.clone(), group, selection, metadata, doc);
             let would_change = editor
                 .tracked_ranges()
                 .get(&id)
@@ -157,10 +152,9 @@ fn classify_replace_text(
     if range.explicitly_invalid {
         return TrackedRangeReplaceOutcome::Invalid;
     }
-    let selection = range.selection.thaw(&editor.state.doc);
-    if selection.is_collapsed() {
+    let Some(selection) = range.locate(&editor.state.doc) else {
         return TrackedRangeReplaceOutcome::Invalid;
-    }
+    };
     if replacement.contains(['\n', '\r']) {
         return TrackedRangeReplaceOutcome::InvalidReplacement;
     }

--- a/crates/editor-core/src/tests/tracked_range_integration.rs
+++ b/crates/editor-core/src/tests/tracked_range_integration.rs
@@ -21,9 +21,12 @@ fn thawed_offsets(editor: &Editor, id: &str) -> (usize, usize) {
     (sel.anchor.offset, sel.head.offset)
 }
 
-fn is_collapsed_on_thaw(editor: &Editor, id: &str) -> bool {
+/// True when the range no longer maps back to its original covered content.
+/// This is the actual signal hit-test/render/FFI use to treat a comment as
+/// "no location".
+fn is_unlocatable(editor: &Editor, id: &str) -> bool {
     let range = editor.tracked_ranges().get(id).expect("range present");
-    range.selection.thaw(&editor.state().doc).is_collapsed()
+    range.locate(&editor.state().doc).is_none()
 }
 
 #[test]
@@ -60,7 +63,7 @@ fn range_marked_invalid_when_all_covered_text_deleted() {
     let sel = initial.selection.unwrap();
     let mut editor = Editor::new_test(initial);
     editor.apply(add_message("r", "g", sel));
-    assert!(!is_collapsed_on_thaw(&editor, "r"));
+    assert!(!is_unlocatable(&editor, "r"));
 
     editor.apply(Message::Selection {
         op: SelectionOp::Set {
@@ -75,8 +78,377 @@ fn range_marked_invalid_when_all_covered_text_deleted() {
     });
 
     assert!(
-        is_collapsed_on_thaw(&editor, "r"),
+        is_unlocatable(&editor, "r"),
         "deleting the covered text must collapse the range"
+    );
+}
+
+#[test]
+fn range_collapses_when_text_deleted_beyond_its_bounds() {
+    // Comment covers 'ell' (1..4) of "hello", but the user deletes the whole
+    // word (0..5). The range must still collapse — TR-225 repro.
+    let (initial, t1) = state! {
+        doc { root { paragraph { t1: text("hello") } } }
+        selection: (t1, 1) -> (t1, 4)
+    };
+    let sel = initial.selection.unwrap();
+    let mut editor = Editor::new_test(initial);
+    editor.apply(add_message("r", "g", sel));
+    assert!(!is_unlocatable(&editor, "r"));
+
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::new(
+                editor_state::Position::new(t1, 0),
+                editor_state::Position::new(t1, 5),
+            ),
+        },
+    });
+    editor.apply(Message::Deletion {
+        op: DeletionOp::Selection,
+    });
+
+    let (a, h) = thawed_offsets(&editor, "r");
+    assert!(
+        is_unlocatable(&editor, "r"),
+        "deleting text beyond the range bounds must collapse it, got anchor={a} head={h}"
+    );
+}
+
+#[test]
+fn range_across_two_paragraphs_collapses_when_wider_selection_deleted() {
+    // Comment spans from p1's 'llo' into p2's 'wor'. User deletes a WIDER
+    // selection covering all of both paragraphs' text, merging them.
+    // TR-225 repro: does the cross-node range collapse, or leave a ghost?
+    let (initial, _p1, t1, _p2, t2) = state! {
+        doc { root {
+            p1: paragraph { t1: text("hello") }
+            p2: paragraph { t2: text("world") }
+        } }
+        selection: (t1, 2) -> (t2, 3)
+    };
+    let sel = initial.selection.unwrap();
+    let mut editor = Editor::new_test(initial);
+    editor.apply(add_message("r", "g", sel));
+    assert!(!is_unlocatable(&editor, "r"));
+
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::new(
+                editor_state::Position::new(t1, 0),
+                editor_state::Position::new(t2, 5),
+            ),
+        },
+    });
+    editor.apply(Message::Deletion {
+        op: DeletionOp::Selection,
+    });
+
+    let (a, h) = thawed_offsets(&editor, "r");
+    assert!(
+        is_unlocatable(&editor, "r"),
+        "deleting both paragraphs must collapse the cross-node range, got anchor={a} head={h}"
+    );
+}
+
+#[test]
+fn range_across_two_paragraphs_collapses_when_tail_survives() {
+    // Real-app repro: comment spans p1 'llo' -> p2 'wor', but the deletion keeps
+    // the TAIL of p2 alive ('ld'). Paragraphs merge; t2 survives (not fully
+    // tombstoned). Does the comment still collapse, or leave a ghost on 'ld'?
+    let (initial, _p1, t1, _p2, t2) = state! {
+        doc { root {
+            p1: paragraph { t1: text("hello") }
+            p2: paragraph { t2: text("world") }
+        } }
+        selection: (t1, 2) -> (t2, 3)
+    };
+    let sel = initial.selection.unwrap();
+    let mut editor = Editor::new_test(initial);
+    editor.apply(add_message("r", "g", sel));
+    assert!(!is_unlocatable(&editor, "r"));
+
+    // Delete p1 'llo' .. p2 'wor' (covers the comment), leaving p2 'ld' alive.
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::new(
+                editor_state::Position::new(t1, 2),
+                editor_state::Position::new(t2, 3),
+            ),
+        },
+    });
+    editor.apply(Message::Deletion {
+        op: DeletionOp::Selection,
+    });
+
+    let (a, h) = thawed_offsets(&editor, "r");
+    assert!(
+        is_unlocatable(&editor, "r"),
+        "comment whose covered text was deleted (tail survives) must be unlocatable, got anchor={a} head={h}"
+    );
+}
+
+#[test]
+fn undo_restores_text_after_deleting_commented_cross_paragraph_range() {
+    // Repro attempt: comment spans two paragraphs, delete a wide range, then
+    // undo. Does the TEXT come back? (User reports it does NOT in the app.)
+    let (initial, _p1, t1, _p2, t2) = state! {
+        doc { root {
+            p1: paragraph { t1: text("hello") }
+            p2: paragraph { t2: text("world") }
+        } }
+        selection: (t1, 2) -> (t2, 3)
+    };
+    let sel = initial.selection.unwrap();
+    let mut editor = Editor::new_test(initial);
+    editor.apply(add_message("r", "g", sel));
+
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::new(
+                editor_state::Position::new(t1, 0),
+                editor_state::Position::new(t2, 5),
+            ),
+        },
+    });
+    editor.apply(Message::Deletion {
+        op: DeletionOp::Selection,
+    });
+
+    // After delete: t1/t2 text gone (merged). Confirm.
+    let text_after_delete: String = editor
+        .state()
+        .doc
+        .get_entry(t1)
+        .and_then(|e| match &e.node {
+            editor_model::Node::Text(t) => Some(t.text.to_string()),
+            _ => None,
+        })
+        .unwrap_or_default();
+
+    editor.apply(Message::History {
+        op: HistoryOp::Undo,
+    });
+
+    // After undo: t1 should read "hello" and t2 "world" again.
+    let t1_text = editor
+        .state()
+        .doc
+        .get_entry(t1)
+        .and_then(|e| match &e.node {
+            editor_model::Node::Text(t) => Some(t.text.to_string()),
+            _ => None,
+        });
+    let t2_text = editor
+        .state()
+        .doc
+        .get_entry(t2)
+        .and_then(|e| match &e.node {
+            editor_model::Node::Text(t) => Some(t.text.to_string()),
+            _ => None,
+        });
+    assert_eq!(
+        (t1_text.as_deref(), t2_text.as_deref()),
+        (Some("hello"), Some("world")),
+        "undo must restore both paragraphs' text (text_after_delete={text_after_delete:?})"
+    );
+}
+
+#[test]
+fn comment_in_second_paragraph_collapses_when_its_text_deleted_via_merge() {
+    // The real ghost: a comment fully inside p2 ('wor' of "world"). A wide
+    // delete spanning p1..into-p2 removes the commented text AND merges the
+    // paragraphs, leaving p2's tail ('ld') alive. The comment's endpoints both
+    // fall back onto the surviving tail -> must be unlocatable, not a ghost.
+    let (initial, _p1, _t1, _p2, t2) = state! {
+        doc { root {
+            p1: paragraph { t1: text("hello") }
+            p2: paragraph { t2: text("world") }
+        } }
+        selection: (t2, 0) -> (t2, 3)
+    };
+    let sel = initial.selection.unwrap();
+    let mut editor = Editor::new_test(initial);
+    editor.apply(add_message("r", "g", sel));
+    assert!(!is_unlocatable(&editor, "r"));
+
+    // Delete all of p1 + 'wor' of p2, merging paragraphs, leaving p2 'ld'.
+    let t1 = _t1;
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::new(
+                editor_state::Position::new(t1, 0),
+                editor_state::Position::new(t2, 3),
+            ),
+        },
+    });
+    editor.apply(Message::Deletion {
+        op: DeletionOp::Selection,
+    });
+
+    let (a, h) = thawed_offsets(&editor, "r");
+    assert!(
+        is_unlocatable(&editor, "r"),
+        "comment inside p2 whose text was deleted must be unlocatable, got anchor={a} head={h}"
+    );
+}
+
+#[test]
+fn range_stays_locatable_when_one_covered_char_survives() {
+    // Policy: a comment must survive as long as ANY of its original characters
+    // is still alive. Comment covers 'ell' (1..4) of "hello"; delete only 'el'
+    // (1..3), leaving 'l'. The range must remain locatable.
+    let (initial, t1) = state! {
+        doc { root { paragraph { t1: text("hello") } } }
+        selection: (t1, 1) -> (t1, 4)
+    };
+    let sel = initial.selection.unwrap();
+    let mut editor = Editor::new_test(initial);
+    editor.apply(add_message("r", "g", sel));
+
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::new(
+                editor_state::Position::new(t1, 1),
+                editor_state::Position::new(t1, 3),
+            ),
+        },
+    });
+    editor.apply(Message::Deletion {
+        op: DeletionOp::Selection,
+    });
+
+    assert!(
+        !is_unlocatable(&editor, "r"),
+        "range must survive while one covered char ('l') is still alive"
+    );
+}
+
+#[test]
+fn range_unaffected_by_deletion_elsewhere_stays_locatable() {
+    // Guard: deleting text OUTSIDE the comment must not invalidate it.
+    let (initial, t1) = state! {
+        doc { root { paragraph { t1: text("hello world") } } }
+        selection: (t1, 6) -> (t1, 11)
+    };
+    let sel = initial.selection.unwrap();
+    let mut editor = Editor::new_test(initial);
+    editor.apply(add_message("r", "g", sel));
+
+    // Delete 'hello ' (0..6), before the comment on 'world'.
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::new(
+                editor_state::Position::new(t1, 0),
+                editor_state::Position::new(t1, 6),
+            ),
+        },
+    });
+    editor.apply(Message::Deletion {
+        op: DeletionOp::Selection,
+    });
+
+    assert!(
+        !is_unlocatable(&editor, "r"),
+        "comment on 'world' must survive deletion of preceding 'hello '"
+    );
+}
+
+#[test]
+fn collapsed_range_on_live_text_is_handled_consistently() {
+    // Guard: a collapsed range (caret-position comment) on still-live text is
+    // still unlocatable by the is_collapsed() rule.
+    let (initial, t1) = state! {
+        doc { root { paragraph { t1: text("hello") } } }
+        selection: (t1, 2)
+    };
+    let sel = initial.selection.unwrap();
+    let mut editor = Editor::new_test(initial);
+    editor.apply(add_message("r", "g", sel));
+
+    // No deletion: locate must agree with is_collapsed().
+    let range = editor.tracked_ranges().get("r").unwrap();
+    let located = range.locate(&editor.state().doc);
+    let thawed_collapsed = range.selection.thaw(&editor.state().doc).is_collapsed();
+    assert_eq!(
+        located.is_none(),
+        thawed_collapsed,
+        "locate must agree with is_collapsed for a collapsed range on live text"
+    );
+}
+
+#[test]
+fn range_collapses_when_covered_text_deleted_but_following_char_survives() {
+    // The real app repro that still leaks: comment covers 'wor' (0..3) of
+    // "world". Delete exactly 'wor', leaving 'ld'. NO paragraph merge.
+    // head was frozen Bind::Right onto the char AT offset 3 ('l'), which is
+    // OUTSIDE the comment and survives -> head's anchor dot is alive even though
+    // every covered char ('w','o','r') is gone. Must still be unlocatable.
+    let (initial, t1) = state! {
+        doc { root { paragraph { t1: text("world") } } }
+        selection: (t1, 0) -> (t1, 3)
+    };
+    let sel = initial.selection.unwrap();
+    let mut editor = Editor::new_test(initial);
+    editor.apply(add_message("r", "g", sel));
+    assert!(!is_unlocatable(&editor, "r"));
+
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::new(
+                editor_state::Position::new(t1, 0),
+                editor_state::Position::new(t1, 3),
+            ),
+        },
+    });
+    editor.apply(Message::Deletion {
+        op: DeletionOp::Selection,
+    });
+
+    let (a, h) = thawed_offsets(&editor, "r");
+    assert!(
+        is_unlocatable(&editor, "r"),
+        "comment whose covered chars are all gone must be unlocatable even if the following char survives, got anchor={a} head={h}"
+    );
+}
+
+#[test]
+fn range_stays_locatable_when_endpoint_chars_die_but_middle_survives() {
+    let (initial, t1) = state! {
+        doc { root { paragraph { t1: text("abcdef") } } }
+        selection: (t1, 1) -> (t1, 5)
+    };
+    let sel = initial.selection.unwrap();
+    let mut editor = Editor::new_test(initial);
+    editor.apply(add_message("r", "g", sel));
+
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::new(
+                editor_state::Position::new(t1, 1),
+                editor_state::Position::new(t1, 2),
+            ),
+        },
+    });
+    editor.apply(Message::Deletion {
+        op: DeletionOp::Selection,
+    });
+
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::new(
+                editor_state::Position::new(t1, 3),
+                editor_state::Position::new(t1, 4),
+            ),
+        },
+    });
+    editor.apply(Message::Deletion {
+        op: DeletionOp::Selection,
+    });
+
+    assert!(
+        !is_unlocatable(&editor, "r"),
+        "range must survive while covered middle chars remain alive"
     );
 }
 
@@ -216,7 +588,7 @@ fn add_frozen_with_unresolvable_dots_marks_invalid_on_thaw() {
         },
     });
     assert!(b.tracked_ranges().contains("r"));
-    assert!(is_collapsed_on_thaw(&b, "r"));
+    assert!(is_unlocatable(&b, "r"));
 }
 
 #[test]
@@ -228,7 +600,7 @@ fn range_recovers_from_invalid_after_undo() {
     let sel = state.selection.unwrap();
     let mut editor = Editor::new_test(state);
     editor.apply(add_message("r", "g", sel));
-    assert!(!is_collapsed_on_thaw(&editor, "r"));
+    assert!(!is_unlocatable(&editor, "r"));
 
     editor.apply(Message::Selection {
         op: SelectionOp::Set {
@@ -242,7 +614,7 @@ fn range_recovers_from_invalid_after_undo() {
         op: DeletionOp::Selection,
     });
     assert!(
-        is_collapsed_on_thaw(&editor, "r"),
+        is_unlocatable(&editor, "r"),
         "deleting covered text must collapse the range"
     );
 
@@ -250,7 +622,7 @@ fn range_recovers_from_invalid_after_undo() {
         op: HistoryOp::Undo,
     });
     assert!(
-        !is_collapsed_on_thaw(&editor, "r"),
+        !is_unlocatable(&editor, "r"),
         "undo must restore range to valid"
     );
 }

--- a/crates/editor-core/src/tracked_range.rs
+++ b/crates/editor-core/src/tracked_range.rs
@@ -1,4 +1,6 @@
-use editor_state::StableSelection;
+use editor_crdt::Dot;
+use editor_model::{Doc, Node};
+use editor_state::{ResolvedSelection, Selection, StableSelection};
 use editor_view::PageRect;
 use hashbrown::{HashMap, HashSet};
 
@@ -11,6 +13,19 @@ pub struct TrackedRange {
     pub selection: StableSelection,
     pub metadata: String,
     pub explicitly_invalid: bool,
+    covered_text: Option<CoveredTextSnapshot>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct TrackedTextAnchor {
+    node_id: editor_model::NodeId,
+    dot: Dot,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct CoveredTextSnapshot {
+    anchors: Vec<TrackedTextAnchor>,
+    text: String,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -117,6 +132,105 @@ impl TrackedRangeRegistry {
     }
 }
 
+impl TrackedRange {
+    pub fn new(
+        id: TrackedRangeId,
+        group: String,
+        selection: StableSelection,
+        metadata: String,
+        doc: &Doc,
+    ) -> Self {
+        let covered_text = selection
+            .locate(doc)
+            .and_then(|sel| sel.resolve(doc))
+            .map(|resolved| CoveredTextSnapshot {
+                anchors: collect_covered_text_anchors(&resolved),
+                text: resolved.collect_text(),
+            });
+        Self {
+            id,
+            group,
+            selection,
+            metadata,
+            explicitly_invalid: false,
+            covered_text,
+        }
+    }
+
+    pub fn locate(&self, doc: &Doc) -> Option<Selection> {
+        let located = self.selection.locate(doc)?;
+        let Some(snapshot) = &self.covered_text else {
+            return Some(located);
+        };
+        if snapshot.anchors.iter().any(|anchor| anchor.is_alive(doc)) {
+            return Some(located);
+        }
+        let restored_text = located
+            .resolve(doc)
+            .is_some_and(|resolved| resolved.collect_text() == snapshot.text);
+        restored_text.then_some(located)
+    }
+}
+
+impl TrackedTextAnchor {
+    fn is_alive(&self, doc: &Doc) -> bool {
+        let Some(entry) = doc.get_entry(self.node_id) else {
+            return false;
+        };
+        match &entry.node {
+            Node::Text(text) => text.text.live_offset_of(self.dot).is_some(),
+            _ => false,
+        }
+    }
+}
+
+fn collect_covered_text_anchors(resolved: &ResolvedSelection<'_>) -> Vec<TrackedTextAnchor> {
+    let mut out = Vec::new();
+    if let Some(root) = resolved.doc().root() {
+        collect_text_anchors_walk(&root, resolved, &mut out);
+    }
+    out
+}
+
+fn collect_text_anchors_walk(
+    node: &editor_model::NodeRef<'_>,
+    resolved: &ResolvedSelection<'_>,
+    out: &mut Vec<TrackedTextAnchor>,
+) {
+    if !resolved.intersects_subtree(node) {
+        return;
+    }
+    if let Node::Text(text_node) = node.node() {
+        let from = resolved.from();
+        let to = resolved.to();
+        let total = text_node.text.len();
+        let start = if from.node_id() == node.id() {
+            from.offset().min(total)
+        } else {
+            0
+        };
+        let end = if to.node_id() == node.id() {
+            to.offset().min(total)
+        } else {
+            total
+        };
+        if end > start {
+            for idx in start + 1..=end {
+                if let Ok(Some(dot)) = text_node.text.dot_at(idx) {
+                    out.push(TrackedTextAnchor {
+                        node_id: node.id(),
+                        dot,
+                    });
+                }
+            }
+        }
+        return;
+    }
+    for child in node.children() {
+        collect_text_anchors_walk(&child, resolved, out);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -128,13 +242,13 @@ mod tests {
             selection: (t1, 0) -> (t1, 5)
         };
         let sel = s.selection.unwrap();
-        TrackedRange {
-            id: id.into(),
-            group: group.into(),
-            selection: StableSelection::freeze(&sel, &s.doc),
-            metadata: String::new(),
-            explicitly_invalid: false,
-        }
+        TrackedRange::new(
+            id.into(),
+            group.into(),
+            StableSelection::freeze(&sel, &s.doc),
+            String::new(),
+            &s.doc,
+        )
     }
 
     #[test]

--- a/crates/editor-ffi/src/editor.rs
+++ b/crates/editor-ffi/src/editor.rs
@@ -417,8 +417,13 @@ impl Editor {
             let result: Vec<TrackedRange> = ranges
                 .map(|r| {
                     let sel = r.selection.thaw(doc);
-                    let invalid = r.explicitly_invalid || sel.is_collapsed();
-                    let resolved = if invalid { None } else { sel.resolve(doc) };
+                    let located = if r.explicitly_invalid {
+                        None
+                    } else {
+                        r.locate(doc)
+                    };
+                    let invalid = located.is_none();
+                    let resolved = located.as_ref().and_then(|s| s.resolve(doc));
                     let rects = match &resolved {
                         Some(resolved) => view
                             .selection_rects(resolved)

--- a/crates/editor-state/src/stable_selection.rs
+++ b/crates/editor-state/src/stable_selection.rs
@@ -25,6 +25,15 @@ impl StableSelection {
         StableSelection { anchor, head }
     }
 
+    /// Thaws and normalizes, returning `Some` only when the range still locates
+    /// to a real (non-empty) span. Returns `None` when the covered text was
+    /// deleted.
+    pub fn locate(&self, doc: &Doc) -> Option<Selection> {
+        let sel = self.thaw(doc);
+        let sel = sel.normalize(doc).unwrap_or(sel);
+        (!sel.is_collapsed()).then_some(sel)
+    }
+
     pub fn thaw(&self, doc: &Doc) -> Selection {
         let was_collapsed = self.anchor == self.head;
         let a = thaw_position(&self.anchor, doc);


### PR DESCRIPTION
코멘트가 달린 텍스트를 더 넓게 삭제했을 때 유령 하이라이트가 남는 문제를 수정했습니다.

기존에는 코멘트 위치를 StableSelection으로 저장해 두고, 문서가 바뀐 뒤 그 저장된 위치를  
현재 문서에 되살린 결과만으로 코멘트 range의 유효성을 판단했습니다.
하지만 이 방식은 코멘트 끝점이 실제 마지막 글자가 아니라 경계 바깥의 다음 글자에 묶이는 경우를 구분하지 못해서  
코멘트 본문이 전부 삭제된 뒤에도 살아남은 주변 텍스트에 다시 붙는 문제가 있었습니다.

이 문제를 실제 StableSelection의 동작을 더 복잡하게 바꾸기보다, 좀 더 쉽게 풀기 위해   
tracked range로 관리되는 범위가 실제로 어떤 텍스트를 덮고 있었는지를 함께 기억하도록 했습니다.
tracked range를 등록할 때 원래 범위가 덮던 문자 dot들과 텍스트를 스냅샷으로 저장하고  
이 후엔 되살린 위치만 보지 않고 그 원래 텍스트가 실제로 남아 있는지를 기준으로 유효성을 판단합니다.

그 결과 코멘트 본문이 모두 사라진 경우에는 주변 텍스트로 재흡착하지 않도록 막으면서도  
일부 텍스트가 남아 있거나 undo로 내용이 복구되는 경우에는 기존처럼 range가 자연스럽게 유지됩니다.