### PR TITLE
fix: table 행/열 추가 cursor 버그 수정

### DIFF
--- a/crates/editor-commands/src/commands/insert_table_axis.rs
+++ b/crates/editor-commands/src/commands/insert_table_axis.rs
@@ -88,6 +88,10 @@ mod tests {
         let doc = actual.doc;
         let table = doc.node(tbl).unwrap();
         assert_eq!(table.children().count(), 2);
+        let new_row = table.children().next().unwrap();
+        for cell in new_row.children() {
+            assert_empty_cell(&cell);
+        }
     }
 
     #[test]
@@ -110,6 +114,10 @@ mod tests {
         let doc = actual.doc;
         let table = doc.node(tbl).unwrap();
         assert_eq!(table.children().count(), 2);
+        let new_row = table.children().nth(1).unwrap();
+        for cell in new_row.children() {
+            assert_empty_cell(&cell);
+        }
     }
 
     #[test]
@@ -136,6 +144,7 @@ mod tests {
         let table = doc.node(tbl).unwrap();
         let row = table.children().next().unwrap();
         assert_eq!(row.children().count(), 3);
+        assert_empty_cell(&row.children().next().unwrap());
     }
 
     #[test]
@@ -166,6 +175,14 @@ mod tests {
         let table = doc.node(tbl).unwrap();
         for row in table.children() {
             assert_eq!(row.children().count(), 3);
+            assert_empty_cell(&row.children().nth(2).unwrap());
         }
+    }
+
+    fn assert_empty_cell(cell: &editor_model::NodeRef<'_>) {
+        let kids: Vec<_> = cell.children().collect();
+        assert_eq!(kids.len(), 1, "cell should have one child");
+        assert!(matches!(kids[0].node(), editor_model::Node::Paragraph(_)));
+        assert_eq!(kids[0].children().count(), 0, "paragraph should be empty");
     }
 }

--- a/crates/editor-commands/src/helpers/table.rs
+++ b/crates/editor-commands/src/helpers/table.rs
@@ -1,6 +1,6 @@
 use editor_model::{
     Fragment, NodeId, NodeRef, PlainNode, PlainParagraphNode, PlainTableCellNode,
-    PlainTableRowNode, PlainTextNode, Subtree,
+    PlainTableRowNode, Subtree,
 };
 use editor_state::enclosing_table_cell;
 use editor_transaction::{Transaction, fulfill};
@@ -73,7 +73,6 @@ pub(crate) fn nth_table_cell(
 pub(crate) fn make_empty_table_cell() -> Subtree {
     let cell_id = NodeId::new();
     let para_id = NodeId::new();
-    let text_id = NodeId::new();
     Subtree::leaf(
         cell_id,
         PlainNode::TableCell(PlainTableCellNode {
@@ -81,16 +80,10 @@ pub(crate) fn make_empty_table_cell() -> Subtree {
             background_color: None,
         }),
     )
-    .with_children(vec![
-        Subtree::leaf(para_id, PlainNode::Paragraph(PlainParagraphNode {})).with_children(vec![
-            Subtree::leaf(
-                text_id,
-                PlainNode::Text(PlainTextNode {
-                    text: String::new(),
-                }),
-            ),
-        ]),
-    ])
+    .with_children(vec![Subtree::leaf(
+        para_id,
+        PlainNode::Paragraph(PlainParagraphNode {}),
+    )])
 }
 
 fn make_empty_table_row(n_cols: usize) -> Subtree {


### PR DESCRIPTION
                                                                                   
  - make_empty_table_cell()에서 빈 text 노드 제거
  - 셀 구조를 table_cell > paragraph(children 0)으로 통일.               
  - insert_table_axis 테스트 4개에 새 셀이 빈 paragraph만 갖는지 검증하는 assert_empty_cell 단언 추가. 