### PR TITLE
TR-229 설정 화면에서 페이지 크기 단위가 잘못 표기 된 문제 수정

### DIFF
--- a/apps/website/src/lib/editor/utils.test.ts
+++ b/apps/website/src/lib/editor/utils.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { createPaginatedLayout, getMaxMargin, mmToPx, resizePageUnit } from '$lib/editor/utils';
+import type { PageLayout } from '$lib/editor/utils';
+
+const toV2Layout = (layout: PageLayout) => ({
+  type: 'paginated' as const,
+  page_width: layout.pageWidth,
+  page_height: layout.pageHeight,
+  page_margin_top: layout.pageMarginTop,
+  page_margin_bottom: layout.pageMarginBottom,
+  page_margin_left: layout.pageMarginLeft,
+  page_margin_right: layout.pageMarginRight,
+});
+
+const fromV2Layout = (layout: ReturnType<typeof toV2Layout>): PageLayout => ({
+  pageWidth: layout.page_width,
+  pageHeight: layout.page_height,
+  pageMarginTop: layout.page_margin_top,
+  pageMarginBottom: layout.page_margin_bottom,
+  pageMarginLeft: layout.page_margin_left,
+  pageMarginRight: layout.page_margin_right,
+});
+
+describe('paginated layout helpers', () => {
+  it('clamps left/right margins after a width change and stays equivalent through v2 shape conversion', () => {
+    const layout: PageLayout = {
+      ...createPaginatedLayout('a4'),
+      pageMarginLeft: mmToPx(90),
+      pageMarginRight: mmToPx(70),
+    };
+
+    const actual = resizePageUnit(layout, 'width', 100);
+    const expectedBase = { ...layout, pageWidth: mmToPx(100) };
+    const expected = {
+      ...expectedBase,
+      pageMarginLeft: Math.min(expectedBase.pageMarginLeft, getMaxMargin('left', expectedBase)),
+      pageMarginRight: Math.min(expectedBase.pageMarginRight, getMaxMargin('right', expectedBase)),
+    };
+
+    expect(actual).toEqual(expected);
+    expect(fromV2Layout(toV2Layout(actual))).toEqual(expected);
+  });
+
+  it('clamps top/bottom margins after a height change and stays equivalent through v2 shape conversion', () => {
+    const layout: PageLayout = {
+      ...createPaginatedLayout('a4'),
+      pageMarginTop: mmToPx(120),
+      pageMarginBottom: mmToPx(90),
+    };
+
+    const actual = resizePageUnit(layout, 'height', 120);
+    const expectedBase = { ...layout, pageHeight: mmToPx(120) };
+    const expected = {
+      ...expectedBase,
+      pageMarginTop: Math.min(expectedBase.pageMarginTop, getMaxMargin('top', expectedBase)),
+      pageMarginBottom: Math.min(expectedBase.pageMarginBottom, getMaxMargin('bottom', expectedBase)),
+    };
+
+    expect(actual).toEqual(expected);
+    expect(fromV2Layout(toV2Layout(actual))).toEqual(expected);
+  });
+
+  it('clamps margins to the 0..maxMargin range for oversized and negative inputs', () => {
+    const layout = createPaginatedLayout('a4');
+
+    const oversized = resizePageUnit(layout, 'left', 500);
+    expect(oversized.pageMarginLeft).toBe(getMaxMargin('left', layout));
+
+    const negative = resizePageUnit(layout, 'top', -10);
+    expect(negative.pageMarginTop).toBe(0);
+  });
+});

--- a/apps/website/src/lib/editor/utils.ts
+++ b/apps/website/src/lib/editor/utils.ts
@@ -13,23 +13,69 @@ export type PageLayout = {
   pageMarginRight: number;
 };
 
+export type PageMarginSide = 'top' | 'bottom' | 'left' | 'right';
+
 export const createPaginatedLayout = (preset: PageLayoutPreset = 'a4'): PageLayout => {
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   return { ...values.pageLayout.find((p) => p.value === preset)!.layout };
 };
 
 const MIN_CONTENT_SIZE_PX = mmToPx(50);
+export const MIN_PAGE_SIZE_MM = 100;
 
-export const getMaxMargin = (side: 'top' | 'bottom' | 'left' | 'right', layout: PageLayout): number => {
-  if (side === 'left') {
-    return Math.max(0, layout.pageWidth - layout.pageMarginRight - MIN_CONTENT_SIZE_PX);
-  } else if (side === 'right') {
-    return Math.max(0, layout.pageWidth - layout.pageMarginLeft - MIN_CONTENT_SIZE_PX);
-  } else if (side === 'top') {
-    return Math.max(0, layout.pageHeight - layout.pageMarginBottom - MIN_CONTENT_SIZE_PX);
-  } else {
-    return Math.max(0, layout.pageHeight - layout.pageMarginTop - MIN_CONTENT_SIZE_PX);
+const clampNumber = (value: number, min: number, max: number): number => Math.min(max, Math.max(min, value));
+
+const PAGE_MARGIN_KEYS = {
+  top: 'pageMarginTop',
+  bottom: 'pageMarginBottom',
+  left: 'pageMarginLeft',
+  right: 'pageMarginRight',
+} as const satisfies Record<PageMarginSide, keyof PageLayout>;
+
+const OPPOSITE_PAGE_MARGIN_KEYS = {
+  top: 'pageMarginBottom',
+  bottom: 'pageMarginTop',
+  left: 'pageMarginRight',
+  right: 'pageMarginLeft',
+} as const satisfies Record<PageMarginSide, keyof PageLayout>;
+
+const PAGE_SIZE_KEYS = {
+  width: 'pageWidth',
+  height: 'pageHeight',
+} as const;
+
+const CONTENT_AXIS_SIZE_KEYS = {
+  top: 'pageHeight',
+  bottom: 'pageHeight',
+  left: 'pageWidth',
+  right: 'pageWidth',
+} as const satisfies Record<PageMarginSide, keyof PageLayout>;
+
+export const getMaxMargin = (side: PageMarginSide, layout: PageLayout): number => {
+  const axisSize = layout[CONTENT_AXIS_SIZE_KEYS[side]];
+  const oppositeMargin = layout[OPPOSITE_PAGE_MARGIN_KEYS[side]];
+  return Math.max(0, axisSize - oppositeMargin - MIN_CONTENT_SIZE_PX);
+};
+
+export const getPageMargin = (side: PageMarginSide, layout: PageLayout): number => layout[PAGE_MARGIN_KEYS[side]];
+
+export type PageUnit = 'width' | 'height' | PageMarginSide;
+
+// width/height: 페이지 크기를 바꾼 뒤 줄어든 축에 맞춰 인접 여백을 다시 clamp
+// margin: 0 ~ getMaxMargin 범위로 clamp
+export const resizePageUnit = (layout: PageLayout, unit: PageUnit, valueMm: number): PageLayout => {
+  if (unit === 'width' || unit === 'height') {
+    const nextLayout = { ...layout, [PAGE_SIZE_KEYS[unit]]: mmToPx(Math.max(MIN_PAGE_SIZE_MM, valueMm)) };
+    const sides = unit === 'width' ? (['left', 'right'] as const) : (['top', 'bottom'] as const);
+    return {
+      ...nextLayout,
+      [PAGE_MARGIN_KEYS[sides[0]]]: Math.min(nextLayout[PAGE_MARGIN_KEYS[sides[0]]], getMaxMargin(sides[0], nextLayout)),
+      [PAGE_MARGIN_KEYS[sides[1]]]: Math.min(nextLayout[PAGE_MARGIN_KEYS[sides[1]]], getMaxMargin(sides[1], nextLayout)),
+    };
   }
+
+  const marginPx = clampNumber(mmToPx(valueMm), 0, getMaxMargin(unit, layout));
+  return { ...layout, [PAGE_MARGIN_KEYS[unit]]: marginPx };
 };
 
 export const getPageElement = (element: HTMLElement): HTMLElement | null => {

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanelSettings.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanelSettings.svelte
@@ -31,6 +31,7 @@
   import TypeIcon from '~icons/lucide/type';
   import LetterSpacingIcon from '~icons/typie/letter-spacing';
   import LineHeightIcon from '~icons/typie/line-height';
+  import { getMaxMargin, getPageMargin, MIN_PAGE_SIZE_MM, pxToMm, resizePageUnit } from '$lib/editor/utils';
   import { ToolbarColorGrid } from '$lib/editor-ffi/components/toolbar';
   import { getEditorContext } from '$lib/editor-ffi/editor.svelte';
   import { defaultContinuousLayout, defaultPaginatedLayout, setRootLayoutMode, setRootModifier } from '$lib/editor-ffi/root-attrs';
@@ -38,6 +39,7 @@
   import { values } from '$lib/editor-ffi/values';
   import DocumentPanelStyleSelect from './DocumentPanelStyleSelect.svelte';
   import type { LayoutMode, Modifier, ModifierType } from '@typie/editor-ffi/browser';
+  import type { PageLayout, PageMarginSide } from '$lib/editor/utils';
   import type { Editor } from '$lib/editor-ffi/editor.svelte';
   import type { ThemeVariant } from '$lib/editor-ffi/theme';
 
@@ -70,10 +72,27 @@
     setRootLayoutMode(ctx.editor, layout_mode);
   };
 
-  const patchPaginated = (patch: Partial<Extract<LayoutMode, { type: 'paginated' }>>) => {
-    if (layoutMode?.type !== 'paginated') return;
-    setLayout({ ...layoutMode, ...patch });
-  };
+  const fromLayoutMode = (mode: Extract<LayoutMode, { type: 'paginated' }>): PageLayout => ({
+    pageWidth: mode.page_width,
+    pageHeight: mode.page_height,
+    pageMarginTop: mode.page_margin_top,
+    pageMarginBottom: mode.page_margin_bottom,
+    pageMarginLeft: mode.page_margin_left,
+    pageMarginRight: mode.page_margin_right,
+  });
+
+  const toLayoutMode = (
+    mode: Extract<LayoutMode, { type: 'paginated' }>,
+    layout: PageLayout,
+  ): Extract<LayoutMode, { type: 'paginated' }> => ({
+    ...mode,
+    page_width: layout.pageWidth,
+    page_height: layout.pageHeight,
+    page_margin_top: layout.pageMarginTop,
+    page_margin_bottom: layout.pageMarginBottom,
+    page_margin_left: layout.pageMarginLeft,
+    page_margin_right: layout.pageMarginRight,
+  });
 
   const textColorItems = $derived(values.textColor.map((c) => ({ label: c.label, value: c.value, color: tc[c.themeKey] })));
 
@@ -214,18 +233,38 @@
     if (value === 'custom') return;
     const preset = values.pageLayout.find((p) => p.value === value);
     if (preset && layoutMode?.type === 'paginated') {
-      setLayout({
-        ...layoutMode,
-        type: 'paginated',
-        page_width: preset.layout.pageWidth,
-        page_height: preset.layout.pageHeight,
-        page_margin_top: preset.layout.pageMarginTop,
-        page_margin_bottom: preset.layout.pageMarginBottom,
-        page_margin_left: preset.layout.pageMarginLeft,
-        page_margin_right: preset.layout.pageMarginRight,
-      });
+      setLayout(toLayoutMode(layoutMode, preset.layout));
       mixpanel.track('change_document_page_size', { preset: value });
     }
+  };
+
+  const handleWidthChange = (e: Event) => {
+    if (layoutMode?.type !== 'paginated') return;
+    const target = e.target as HTMLInputElement;
+    const value = Math.max(MIN_PAGE_SIZE_MM, Number(target.value));
+    target.value = String(value);
+
+    const nextLayout = resizePageUnit(fromLayoutMode(layoutMode), 'width', value);
+    setLayout(toLayoutMode(layoutMode, nextLayout));
+  };
+
+  const handleHeightChange = (e: Event) => {
+    if (layoutMode?.type !== 'paginated') return;
+    const target = e.target as HTMLInputElement;
+    const value = Math.max(MIN_PAGE_SIZE_MM, Number(target.value));
+    target.value = String(value);
+
+    const nextLayout = resizePageUnit(fromLayoutMode(layoutMode), 'height', value);
+    setLayout(toLayoutMode(layoutMode, nextLayout));
+  };
+
+  const handleMarginChange = (side: PageMarginSide, e: Event) => {
+    if (layoutMode?.type !== 'paginated') return;
+    const target = e.target as HTMLInputElement;
+    const nextLayout = resizePageUnit(fromLayoutMode(layoutMode), side, Number(target.value));
+    target.value = String(pxToMm(getPageMargin(side, nextLayout)));
+
+    setLayout(toLayoutMode(layoutMode, nextLayout));
   };
 </script>
 
@@ -566,14 +605,10 @@
                 <TextInput
                   style={css.raw({ width: '80px' })}
                   min="100"
-                  onchange={(e) => {
-                    const value = Math.max(100, Number((e.target as HTMLInputElement).value));
-                    (e.target as HTMLInputElement).value = String(value);
-                    patchPaginated({ page_width: value });
-                  }}
+                  onchange={handleWidthChange}
                   size="sm"
                   type="number"
-                  value={layoutMode.page_width}
+                  value={pxToMm(layoutMode.page_width)}
                 />
               </div>
               <div class={flex({ flexDirection: 'column', alignItems: 'center', gap: '4px' })}>
@@ -581,14 +616,10 @@
                 <TextInput
                   style={css.raw({ width: '80px' })}
                   min="100"
-                  onchange={(e) => {
-                    const value = Math.max(100, Number((e.target as HTMLInputElement).value));
-                    (e.target as HTMLInputElement).value = String(value);
-                    patchPaginated({ page_height: value });
-                  }}
+                  onchange={handleHeightChange}
                   size="sm"
                   type="number"
-                  value={layoutMode.page_height}
+                  value={pxToMm(layoutMode.page_height)}
                 />
               </div>
             </div>
@@ -605,44 +636,48 @@
               <div class={css({ fontSize: '12px', color: 'text.subtle' })}>상단</div>
               <TextInput
                 style={css.raw({ width: '80px' })}
+                max={String(pxToMm(getMaxMargin('top', fromLayoutMode(layoutMode))))}
                 min="0"
-                onchange={(e) => patchPaginated({ page_margin_top: Math.max(0, Number((e.target as HTMLInputElement).value)) })}
+                onchange={(e) => handleMarginChange('top', e)}
                 size="sm"
                 type="number"
-                value={layoutMode.page_margin_top}
+                value={pxToMm(layoutMode.page_margin_top)}
               />
             </div>
             <div class={flex({ flexDirection: 'column', alignItems: 'center', gap: '4px' })}>
               <div class={css({ fontSize: '12px', color: 'text.subtle' })}>하단</div>
               <TextInput
                 style={css.raw({ width: '80px' })}
+                max={String(pxToMm(getMaxMargin('bottom', fromLayoutMode(layoutMode))))}
                 min="0"
-                onchange={(e) => patchPaginated({ page_margin_bottom: Math.max(0, Number((e.target as HTMLInputElement).value)) })}
+                onchange={(e) => handleMarginChange('bottom', e)}
                 size="sm"
                 type="number"
-                value={layoutMode.page_margin_bottom}
+                value={pxToMm(layoutMode.page_margin_bottom)}
               />
             </div>
             <div class={flex({ flexDirection: 'column', alignItems: 'center', gap: '4px' })}>
               <div class={css({ fontSize: '12px', color: 'text.subtle' })}>왼쪽</div>
               <TextInput
                 style={css.raw({ width: '80px' })}
+                max={String(pxToMm(getMaxMargin('left', fromLayoutMode(layoutMode))))}
                 min="0"
-                onchange={(e) => patchPaginated({ page_margin_left: Math.max(0, Number((e.target as HTMLInputElement).value)) })}
+                onchange={(e) => handleMarginChange('left', e)}
                 size="sm"
                 type="number"
-                value={layoutMode.page_margin_left}
+                value={pxToMm(layoutMode.page_margin_left)}
               />
             </div>
             <div class={flex({ flexDirection: 'column', alignItems: 'center', gap: '4px' })}>
               <div class={css({ fontSize: '12px', color: 'text.subtle' })}>오른쪽</div>
               <TextInput
                 style={css.raw({ width: '80px' })}
+                max={String(pxToMm(getMaxMargin('right', fromLayoutMode(layoutMode))))}
                 min="0"
-                onchange={(e) => patchPaginated({ page_margin_right: Math.max(0, Number((e.target as HTMLInputElement).value)) })}
+                onchange={(e) => handleMarginChange('right', e)}
                 size="sm"
                 type="number"
-                value={layoutMode.page_margin_right}
+                value={pxToMm(layoutMode.page_margin_right)}
               />
             </div>
           </div>


### PR DESCRIPTION
v1의 페이지 크기 및 여백 clamp 변환 방식을 기준으로, v2 문서 패널의 페이지 크기 및 여백 입력이 올바르게 보이도록 수정했습니다.

관련 로직은 resizePageUnit 공통 유틸로 모으고 검증 테스트를 추가했습니다.