### PR TITLE
fix: 문단 스타일 복사붙여넣기 버그 수정

### DIFF
--- a/crates/editor-clipboard/src/html/parse/mod.rs
+++ b/crates/editor-clipboard/src/html/parse/mod.rs
@@ -70,6 +70,7 @@ fn fallback_body_parse(doc: &Html, resource: &Resource) -> Slice {
         fragment: Fragment {
             node: PlainNode::Root(PlainRootNode::default()),
             modifiers: vec![],
+            style: None,
             children: crate::html::parse::schema_normalize::normalize(children),
         },
         open_start: 0,
@@ -348,9 +349,11 @@ mod tests {
             fragment: Fragment {
                 node: PlainNode::Root(PlainRootNode::default()),
                 modifiers: vec![],
+                style: None,
                 children: vec![Fragment {
                     node: PlainNode::Paragraph(PlainParagraphNode::default()),
                     modifiers: vec![],
+                    style: None,
                     children: vec![
                         Fragment::leaf(PlainNode::Text(PlainTextNode { text: "x".into() }))
                             .with_modifiers(vec![

--- a/crates/editor-clipboard/src/html/parse/schema_normalize.rs
+++ b/crates/editor-clipboard/src/html/parse/schema_normalize.rs
@@ -10,6 +10,7 @@ pub fn normalize(children: Vec<Fragment>) -> Vec<Fragment> {
             result.push(Fragment {
                 node: PlainNode::Paragraph(PlainParagraphNode::default()),
                 modifiers: vec![],
+                style: None,
                 children: std::mem::take(inline_run),
             });
         }
@@ -22,6 +23,7 @@ pub fn normalize(children: Vec<Fragment>) -> Vec<Fragment> {
                 result.push(Fragment {
                     node: PlainNode::BulletList(PlainBulletListNode::default()),
                     modifiers: vec![],
+                    style: None,
                     children: vec![child],
                 });
             }
@@ -30,6 +32,7 @@ pub fn normalize(children: Vec<Fragment>) -> Vec<Fragment> {
                 result.push(Fragment {
                     node: PlainNode::Table(PlainTableNode::default()),
                     modifiers: vec![],
+                    style: None,
                     children: vec![child],
                 });
             }
@@ -38,9 +41,11 @@ pub fn normalize(children: Vec<Fragment>) -> Vec<Fragment> {
                 result.push(Fragment {
                     node: PlainNode::Table(PlainTableNode::default()),
                     modifiers: vec![],
+                    style: None,
                     children: vec![Fragment {
                         node: PlainNode::TableRow(PlainTableRowNode::default()),
                         modifiers: vec![],
+                        style: None,
                         children: vec![child],
                     }],
                 });

--- a/crates/editor-clipboard/src/html/parse/walker.rs
+++ b/crates/editor-clipboard/src/html/parse/walker.rs
@@ -86,6 +86,7 @@ pub fn walk<'a>(
                         out.push(Fragment {
                             node: plain_node,
                             modifiers: new_pending,
+                            style: None,
                             children: kids,
                         });
                     }

--- a/crates/editor-clipboard/src/html/serialize.rs
+++ b/crates/editor-clipboard/src/html/serialize.rs
@@ -240,9 +240,11 @@ mod tests {
             fragment: Fragment {
                 node: PlainNode::Root(PlainRootNode::default()),
                 modifiers: vec![],
+                style: None,
                 children: vec![Fragment {
                     node: PlainNode::Paragraph(PlainParagraphNode::default()),
                     modifiers: vec![],
+                    style: None,
                     children: vec![
                         Fragment::leaf(PlainNode::Text(PlainTextNode {
                             text: "bold italic".into(),
@@ -264,9 +266,11 @@ mod tests {
             fragment: Fragment {
                 node: PlainNode::Root(PlainRootNode::default()),
                 modifiers: vec![],
+                style: None,
                 children: vec![Fragment {
                     node: PlainNode::Paragraph(PlainParagraphNode::default()),
                     modifiers: vec![],
+                    style: None,
                     children: vec![
                         Fragment::leaf(PlainNode::Text(PlainTextNode {
                             text: "styled".into(),
@@ -296,9 +300,11 @@ mod tests {
             fragment: Fragment {
                 node: PlainNode::Root(PlainRootNode::default()),
                 modifiers: vec![],
+                style: None,
                 children: vec![Fragment {
                     node: PlainNode::Paragraph(PlainParagraphNode::default()),
                     modifiers: vec![],
+                    style: None,
                     children: vec![
                         Fragment::leaf(PlainNode::Text(PlainTextNode {
                             text: "click".into(),

--- a/crates/editor-clipboard/src/slice.rs
+++ b/crates/editor-clipboard/src/slice.rs
@@ -1,4 +1,6 @@
-use editor_model::{Fragment, Node, NodeRef, PlainNode, PlainRootNode, PlainTextNode};
+use editor_model::{
+    Fragment, Node, NodeRef, PlainNode, PlainParagraphNode, PlainRootNode, PlainTextNode,
+};
 use editor_resource::Resource;
 use editor_state::{CellRect, ResolvedSelection, State, is_prefix_of};
 use serde::{Deserialize, Serialize};
@@ -43,6 +45,14 @@ impl Slice {
             .saturating_sub(common_depth)) as u32;
 
         let fragment = build_fragment(&rs, common);
+        // When the selection is contained within a single inline node, the
+        // common ancestor is that inline node, so build_fragment returns a bare
+        // inline leaf with no way to carry the source paragraph's style. Wrap
+        // it in a synthesized Paragraph that carries the enclosing textblock's
+        // style; bump open_start/open_end so paste paths still see the slice as
+        // inline content to merge.
+        let (fragment, open_start, open_end) =
+            wrap_bare_inline_in_textblock(fragment, common, open_start, open_end);
         Some(Slice {
             fragment,
             open_start,
@@ -87,6 +97,50 @@ impl Slice {
             text: self.to_text(),
         }
     }
+}
+
+fn nearest_enclosing_textblock<'a>(node: NodeRef<'a>) -> Option<NodeRef<'a>> {
+    let mut current = Some(node);
+    while let Some(n) = current {
+        if n.spec().is_textblock() {
+            return Some(n);
+        }
+        current = n.parent();
+    }
+    None
+}
+
+// Only wraps when the source textblock actually has a named style — otherwise
+// returns the bare inline fragment unchanged, preserving the existing slice
+// shape (and open_start/open_end semantics) for unstyled paragraphs. The wrap
+// is the only carrier for style in the single-inline-node case because Text
+// itself has no style slot on its NodeEntry.
+fn wrap_bare_inline_in_textblock(
+    fragment: Fragment,
+    common: NodeRef<'_>,
+    open_start: u32,
+    open_end: u32,
+) -> (Fragment, u32, u32) {
+    let is_bare_inline = matches!(
+        fragment.node,
+        PlainNode::Text(_) | PlainNode::HardBreak(_) | PlainNode::Tab(_)
+    );
+    if !is_bare_inline {
+        return (fragment, open_start, open_end);
+    }
+    let Some(textblock) = nearest_enclosing_textblock(common) else {
+        return (fragment, open_start, open_end);
+    };
+    let Some(style_id) = textblock.entry().style.get().clone() else {
+        return (fragment, open_start, open_end);
+    };
+    let wrapped = Fragment {
+        node: PlainNode::Paragraph(PlainParagraphNode::default()),
+        modifiers: vec![],
+        style: Some(style_id),
+        children: vec![fragment],
+    };
+    (wrapped, open_start + 1, open_end + 1)
 }
 
 fn build_fragment<'a>(rs: &ResolvedSelection<'a>, node: NodeRef<'a>) -> Fragment {
@@ -138,6 +192,7 @@ fn build_fragment<'a>(rs: &ResolvedSelection<'a>, node: NodeRef<'a>) -> Fragment
             Fragment {
                 node: node.node().to_plain(),
                 modifiers: node.explicit_modifiers().cloned().collect(),
+                style: node.entry().style.get().clone(),
                 children: kids,
             }
         }
@@ -148,6 +203,7 @@ fn node_to_fragment(node: NodeRef<'_>) -> Fragment {
     Fragment {
         node: node.node().to_plain(),
         modifiers: node.explicit_modifiers().cloned().collect(),
+        style: node.entry().style.get().clone(),
         children: node.children().map(node_to_fragment).collect(),
     }
 }
@@ -171,18 +227,21 @@ fn extract_cell_rect(rect: &CellRect<'_>) -> Slice {
         rows.push(Fragment {
             node: row.node().to_plain(),
             modifiers: row.explicit_modifiers().cloned().collect(),
+            style: row.entry().style.get().clone(),
             children: cells,
         });
     }
     let table_frag = Fragment {
         node: table.node().to_plain(),
         modifiers: table.explicit_modifiers().cloned().collect(),
+        style: table.entry().style.get().clone(),
         children: rows,
     };
     Slice {
         fragment: Fragment {
             node: PlainNode::Root(PlainRootNode::default()),
             modifiers: vec![],
+            style: None,
             children: vec![table_frag],
         },
         open_start: 0,

--- a/crates/editor-clipboard/src/text/parse.rs
+++ b/crates/editor-clipboard/src/text/parse.rs
@@ -14,6 +14,7 @@ pub fn from_text(text: &str) -> Slice {
         fragment: Fragment {
             node: PlainNode::Root(PlainRootNode::default()),
             modifiers: vec![],
+            style: None,
             children: blocks,
         },
         open_start: 0,
@@ -51,6 +52,7 @@ fn paragraph_from_block(block: &str) -> Fragment {
     Fragment {
         node: PlainNode::Paragraph(PlainParagraphNode::default()),
         modifiers: vec![],
+        style: None,
         children: inline,
     }
 }

--- a/crates/editor-commands/src/commands/fill_cell_rect_with_slice.rs
+++ b/crates/editor-commands/src/commands/fill_cell_rect_with_slice.rs
@@ -59,6 +59,7 @@ fn slice_to_cell_blocks(slice: &Slice) -> Vec<Fragment> {
             out.push(Fragment {
                 node: PlainNode::Paragraph(PlainParagraphNode::default()),
                 modifiers: vec![],
+                style: None,
                 children: std::mem::take(run),
             });
         }

--- a/crates/editor-commands/src/commands/insert_slice.rs
+++ b/crates/editor-commands/src/commands/insert_slice.rs
@@ -38,9 +38,11 @@ mod tests {
             fragment: Fragment {
                 node: PlainNode::Root(PlainRootNode::default()),
                 modifiers: vec![],
+                style: None,
                 children: vec![Fragment {
                     node: PlainNode::Paragraph(PlainParagraphNode::default()),
                     modifiers: vec![],
+                    style: None,
                     children: vec![Fragment::leaf(PlainNode::Text(PlainTextNode {
                         text: text.into(),
                     }))],
@@ -55,6 +57,7 @@ mod tests {
         Fragment {
             node: PlainNode::Paragraph(PlainParagraphNode::default()),
             modifiers: vec![],
+            style: None,
             children: vec![Fragment::leaf(PlainNode::Text(PlainTextNode {
                 text: text.into(),
             }))],
@@ -104,6 +107,7 @@ mod tests {
             fragment: Fragment {
                 node: PlainNode::Root(PlainRootNode::default()),
                 modifiers: vec![],
+                style: None,
                 children: vec![Fragment::leaf(PlainNode::Text(PlainTextNode {
                     text: "X".into(),
                 }))],
@@ -134,12 +138,15 @@ mod tests {
             fragment: Fragment {
                 node: PlainNode::Root(PlainRootNode::default()),
                 modifiers: vec![],
+                style: None,
                 children: vec![Fragment {
                     node: PlainNode::BulletList(PlainBulletListNode::default()),
                     modifiers: vec![],
+                    style: None,
                     children: vec![Fragment {
                         node: PlainNode::ListItem(PlainListItemNode::default()),
                         modifiers: vec![],
+                        style: None,
                         children: vec![paragraph_fragment("X")],
                     }],
                 }],
@@ -205,6 +212,7 @@ mod tests {
             fragment: Fragment {
                 node: PlainNode::Root(PlainRootNode::default()),
                 modifiers: vec![],
+                style: None,
                 children: vec![paragraph_fragment("X"), paragraph_fragment("Y")],
             },
             open_start: 0,
@@ -234,15 +242,18 @@ mod tests {
             fragment: Fragment {
                 node: PlainNode::Root(PlainRootNode::default()),
                 modifiers: vec![],
+                style: None,
                 children: vec![
                     Fragment {
                         node: PlainNode::Callout(PlainCalloutNode::default()),
                         modifiers: vec![],
+                        style: None,
                         children: vec![paragraph_fragment("1")],
                     },
                     Fragment {
                         node: PlainNode::Paragraph(PlainParagraphNode::default()),
                         modifiers: vec![],
+                        style: None,
                         children: vec![],
                     },
                 ],
@@ -271,6 +282,7 @@ mod tests {
             fragment: Fragment {
                 node: PlainNode::Root(PlainRootNode::default()),
                 modifiers: vec![],
+                style: None,
                 children: vec![paragraph_fragment("first"), paragraph_fragment("second")],
             },
             open_start: 2,
@@ -298,6 +310,7 @@ mod tests {
             fragment: Fragment {
                 node: PlainNode::Root(PlainRootNode::default()),
                 modifiers: vec![],
+                style: None,
                 children: vec![Fragment::leaf(PlainNode::Image(PlainImageNode::default()))],
             },
             open_start: 0,
@@ -326,6 +339,7 @@ mod tests {
             fragment: Fragment {
                 node: PlainNode::Root(PlainRootNode::default()),
                 modifiers: vec![],
+                style: None,
                 children: vec![Fragment::leaf(PlainNode::Image(PlainImageNode::default()))],
             },
             open_start: 0,
@@ -340,5 +354,134 @@ mod tests {
             selection: (r, 0, >) -> (r, 1, <)
         };
         assert_state_eq!(&actual, &expected);
+    }
+
+    fn paragraph_slice_with_style(text: &str, style_id: &str) -> Slice {
+        Slice {
+            fragment: Fragment {
+                node: PlainNode::Root(PlainRootNode::default()),
+                modifiers: vec![],
+                style: None,
+                children: vec![Fragment {
+                    node: PlainNode::Paragraph(PlainParagraphNode::default()),
+                    modifiers: vec![],
+                    style: Some(style_id.into()),
+                    children: vec![Fragment::leaf(PlainNode::Text(PlainTextNode {
+                        text: text.into(),
+                    }))],
+                }],
+            },
+            open_start: 2,
+            open_end: 2,
+        }
+    }
+
+    #[test]
+    fn paste_block_boundary_applies_source_paragraph_style() {
+        use editor_model::Modifier;
+
+        use crate::commands::define_style;
+
+        let (initial, ..) = state! {
+            doc { r: root {
+                paragraph { text("a") }
+                paragraph { text("b") }
+            } }
+            selection: (r, 1, >)
+        };
+        let (with_style, ..) = transact!(initial, |tr| define_style(
+            &mut tr,
+            "h1".into(),
+            "H1".into(),
+            vec![Modifier::FontSize { value: 2400 }],
+        ));
+
+        let slice = paragraph_slice_with_style("XY", "h1");
+        let (actual, ..) = transact!(with_style, |tr| insert_slice(&mut tr, slice));
+
+        let root = actual.doc.root().unwrap();
+        let inserted = root.children().nth(1).unwrap();
+        assert_eq!(inserted.entry().style.get().as_deref(), Some("h1"));
+    }
+
+    #[test]
+    fn paste_into_empty_paragraph_inherits_source_style() {
+        use editor_model::Modifier;
+
+        use crate::commands::define_style;
+
+        let (initial, p_empty) = state! {
+            doc { root { p_empty: paragraph {} } }
+            selection: (p_empty, 0)
+        };
+        let (with_style, ..) = transact!(initial, |tr| define_style(
+            &mut tr,
+            "h1".into(),
+            "H1".into(),
+            vec![Modifier::FontSize { value: 2400 }],
+        ));
+
+        let slice = paragraph_slice_with_style("XY", "h1");
+        let (actual, ..) = transact!(with_style, |tr| insert_slice(&mut tr, slice));
+
+        let entry = actual.doc.get_entry(p_empty).unwrap();
+        assert_eq!(entry.style.get().as_deref(), Some("h1"));
+    }
+
+    #[test]
+    fn extract_preserves_paragraph_style() {
+        use editor_model::Modifier;
+
+        use crate::commands::{apply_style, define_style};
+
+        let (initial, p1, ..) = state! {
+            doc { root { p1: paragraph { t1: text("Hello") } } }
+            selection: (t1, 0) -> (t1, 5)
+        };
+        let (s1, ..) = transact!(initial, |tr| define_style(
+            &mut tr,
+            "h1".into(),
+            "H1".into(),
+            vec![Modifier::FontSize { value: 2400 }]
+        ));
+        let (with_style, ..) = transact!(s1, |tr| apply_style(&mut tr, p1, "h1".into()));
+
+        let slice = Slice::extract(&with_style).expect("non-collapsed");
+        // Single-text-node selection from a styled paragraph: extract
+        // synthesizes a Paragraph wrapper carrying the enclosing textblock's
+        // style so the slice can transport it to the paste site.
+        assert!(matches!(slice.fragment.node, PlainNode::Paragraph(_)));
+        assert_eq!(slice.fragment.style.as_deref(), Some("h1"));
+    }
+
+    #[test]
+    fn paste_into_non_empty_paragraph_keeps_destination_style() {
+        use editor_model::Modifier;
+
+        use crate::commands::{apply_style, define_style};
+
+        let (initial, p1, t1) = state! {
+            doc { root { p1: paragraph { t1: text("Hello") } } }
+            selection: (t1, 2)
+        };
+        let (s1, ..) = transact!(initial, |tr| define_style(
+            &mut tr,
+            "h1".into(),
+            "H1".into(),
+            vec![Modifier::FontSize { value: 2400 }]
+        ));
+        let (s2, ..) = transact!(s1, |tr| define_style(
+            &mut tr,
+            "body".into(),
+            "Body".into(),
+            vec![Modifier::FontSize { value: 1600 }]
+        ));
+        let (with_styles, ..) = transact!(s2, |tr| apply_style(&mut tr, p1, "body".into()));
+
+        let slice = paragraph_slice_with_style("XY", "h1");
+        let (actual, ..) = transact!(with_styles, |tr| insert_slice(&mut tr, slice));
+
+        let entry = actual.doc.get_entry(p1).unwrap();
+        assert_eq!(entry.style.get().as_deref(), Some("body"));
     }
 }

--- a/crates/editor-commands/src/commands/insert_slice_at.rs
+++ b/crates/editor-commands/src/commands/insert_slice_at.rs
@@ -31,6 +31,7 @@ mod tests {
             fragment: Fragment {
                 node: PlainNode::Root(PlainRootNode::default()),
                 modifiers: vec![],
+                style: None,
                 children: vec![Fragment::leaf(PlainNode::Image(PlainImageNode::default()))],
             },
             open_start: 0,
@@ -42,6 +43,7 @@ mod tests {
         Fragment {
             node: PlainNode::Paragraph(PlainParagraphNode::default()),
             modifiers: vec![],
+            style: None,
             children: vec![Fragment::leaf(PlainNode::Text(PlainTextNode {
                 text: text.into(),
             }))],
@@ -194,6 +196,7 @@ mod tests {
             fragment: Fragment {
                 node: PlainNode::Root(PlainRootNode::default()),
                 modifiers: vec![],
+                style: None,
                 children: vec![paragraph_fragment("A"), paragraph_fragment("B")],
             },
             open_start: 0,
@@ -247,6 +250,7 @@ mod tests {
             fragment: Fragment {
                 node: PlainNode::Root(PlainRootNode::default()),
                 modifiers: vec![],
+                style: None,
                 children: vec![paragraph_fragment("first"), paragraph_fragment("second")],
             },
             open_start: 2,

--- a/crates/editor-commands/src/helpers/slice.rs
+++ b/crates/editor-commands/src/helpers/slice.rs
@@ -59,6 +59,7 @@ fn coerce_slice_for_position(tr: &Transaction, position: Position, slice: Slice)
                 fragment: Fragment {
                     node: fragment.node,
                     modifiers: fragment.modifiers,
+                    style: fragment.style,
                     children: coerced,
                 },
                 open_start,
@@ -70,6 +71,7 @@ fn coerce_slice_for_position(tr: &Transaction, position: Position, slice: Slice)
                 Fragment {
                     node: fragment.node,
                     modifiers: fragment.modifiers,
+                    style: fragment.style,
                     children: fragment.children,
                 },
                 container_type,
@@ -77,6 +79,7 @@ fn coerce_slice_for_position(tr: &Transaction, position: Position, slice: Slice)
             let wrapped = Fragment {
                 node: PlainNode::Root(PlainRootNode::default()),
                 modifiers: vec![],
+                style: None,
                 children: coerced,
             };
             Slice {
@@ -176,6 +179,52 @@ fn position_in_textblock(tr: &Transaction, position: Position) -> bool {
         .is_some_and(|resolved| resolved.is_inline_position())
 }
 
+fn enclosing_textblock_id(tr: &Transaction, position: Position) -> Option<NodeId> {
+    let doc = tr.doc();
+    let node = doc.node(position.node_id)?;
+    if matches!(node.node(), Node::Text(_)) {
+        return node.parent().map(|p| p.id());
+    }
+    if node.spec().is_textblock() {
+        return Some(node.id());
+    }
+    None
+}
+
+fn paragraph_is_empty(tr: &Transaction, para_id: NodeId) -> bool {
+    let doc = tr.doc();
+    let Some(node) = doc.node(para_id) else {
+        return false;
+    };
+    if !node.spec().is_textblock() {
+        return false;
+    }
+    node.children().all(|c| match c.node() {
+        Node::Text(t) => t.text.is_empty(),
+        _ => false,
+    })
+}
+
+fn source_paragraph_wrapper_style(slice: &Slice) -> Option<String> {
+    match &slice.fragment.node {
+        PlainNode::Paragraph(_) => slice.fragment.style.clone(),
+        PlainNode::Root(_) => {
+            let paras: Vec<&Fragment> = slice
+                .fragment
+                .children
+                .iter()
+                .filter(|c| matches!(c.node, PlainNode::Paragraph(_)))
+                .collect();
+            if paras.len() == 1 {
+                paras[0].style.clone()
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
 fn collect_inline(f: &Fragment) -> Vec<&Fragment> {
     fn walk<'a>(f: &'a Fragment, out: &mut Vec<&'a Fragment>) {
         match &f.node {
@@ -205,11 +254,19 @@ fn insert_inline_at_position(
     position: Position,
     slice: &Slice,
 ) -> Result<Option<Selection>, CommandError> {
+    let dest_para = enclosing_textblock_id(tr, position);
+    let dest_was_empty = dest_para.is_some_and(|id| paragraph_is_empty(tr, id));
+
     tr.set_selection(Some(Selection::collapsed(position)))?;
     let start = tr.selection().map(|s| s.head).unwrap_or(position);
     let inserted = insert_inline_at_caret(tr, slice)?;
     if !inserted {
         return Ok(None);
+    }
+    if dest_was_empty
+        && let (Some(para_id), Some(style)) = (dest_para, source_paragraph_wrapper_style(slice))
+    {
+        tr.set_node_style(para_id, Some(style))?;
     }
     let Some(end) = tr.selection().map(|s| s.head) else {
         return Ok(None);
@@ -627,7 +684,8 @@ fn insert_inline_at_block_boundary(
     let para_subtree = Subtree::leaf(
         new_para_id,
         PlainNode::Paragraph(PlainParagraphNode::default()),
-    );
+    )
+    .with_style(source_paragraph_wrapper_style(slice));
     tr.insert_subtree(position.node_id, position.offset, para_subtree)?;
 
     position_caret_at_textblock_start(tr, new_para_id)?;
@@ -752,9 +810,11 @@ mod tests {
             fragment: Fragment {
                 node: PlainNode::Root(PlainRootNode::default()),
                 modifiers: vec![],
+                style: None,
                 children: vec![Fragment {
                     node: PlainNode::Paragraph(PlainParagraphNode::default()),
                     modifiers: vec![],
+                    style: None,
                     children: vec![Fragment::leaf(PlainNode::Text(PlainTextNode {
                         text: text.into(),
                     }))],
@@ -769,6 +829,7 @@ mod tests {
         Fragment {
             node: PlainNode::Paragraph(PlainParagraphNode::default()),
             modifiers: vec![],
+            style: None,
             children: vec![Fragment::leaf(PlainNode::Text(PlainTextNode {
                 text: text.into(),
             }))],
@@ -797,6 +858,7 @@ mod tests {
             fragment: Fragment {
                 node: PlainNode::Root(PlainRootNode::default()),
                 modifiers: vec![],
+                style: None,
                 children: vec![paragraph_fragment("a"), paragraph_fragment("b")],
             },
             open_start: 2,

--- a/crates/editor-core/src/handle/dnd.rs
+++ b/crates/editor-core/src/handle/dnd.rs
@@ -390,6 +390,7 @@ fn files_slice(image_count: u32, file_count: u32) -> Slice {
         fragment: Fragment {
             node: PlainNode::Root(PlainRootNode::default()),
             modifiers: vec![],
+            style: None,
             children,
         },
         open_start: 0,

--- a/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
@@ -295,6 +295,7 @@ export interface FontWeightValue {
 export interface Fragment {
     node: PlainNode;
     modifiers?: Modifier[];
+    style?: string;
     children?: Fragment[];
 }
 

--- a/crates/editor-ffi/pkg/server/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/server/editor_ffi.d.ts
@@ -322,6 +322,7 @@ export interface FontWeightValue {
 export interface Fragment {
     node: PlainNode;
     modifiers?: Modifier[];
+    style?: string;
     children?: Fragment[];
 }
 

--- a/crates/editor-model/src/fragment.rs
+++ b/crates/editor-model/src/fragment.rs
@@ -11,6 +11,8 @@ pub struct Fragment {
     pub node: PlainNode,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub modifiers: Vec<Modifier>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub style: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub children: Vec<Fragment>,
 }
@@ -20,6 +22,7 @@ impl Fragment {
         Self {
             node,
             modifiers: vec![],
+            style: None,
             children: vec![],
         }
     }
@@ -34,11 +37,17 @@ impl Fragment {
         self
     }
 
+    pub fn with_style(mut self, style: Option<String>) -> Self {
+        self.style = style;
+        self
+    }
+
     pub fn into_subtree(self) -> Subtree {
         Subtree {
             id: NodeId::new(),
             node: self.node,
             modifiers: self.modifiers,
+            style: self.style,
             children: self
                 .children
                 .into_iter()

--- a/crates/editor-model/src/subtree.rs
+++ b/crates/editor-model/src/subtree.rs
@@ -8,6 +8,7 @@ pub struct Subtree {
     pub id: NodeId,
     pub node: PlainNode,
     pub modifiers: Vec<Modifier>,
+    pub style: Option<String>,
     pub children: Vec<Subtree>,
 }
 
@@ -17,6 +18,7 @@ impl Subtree {
             id,
             node,
             modifiers: vec![],
+            style: None,
             children: vec![],
         }
     }
@@ -31,6 +33,11 @@ impl Subtree {
         self
     }
 
+    pub fn with_style(mut self, style: Option<String>) -> Self {
+        self.style = style;
+        self
+    }
+
     pub fn capture(doc: &Doc, node_id: NodeId) -> Option<Self> {
         let entry = doc.get_entry(node_id)?;
         let children = entry
@@ -40,10 +47,12 @@ impl Subtree {
             .filter_map(|child_id| Self::capture(doc, child_id))
             .collect();
         let modifiers: Vec<Modifier> = entry.modifiers.iter().map(|(_, v)| v.clone()).collect();
+        let style = entry.style.get().clone();
         Some(Self {
             id: node_id,
             node: entry.node.to_plain(),
             modifiers,
+            style,
             children,
         })
     }

--- a/crates/editor-transaction/src/compact.rs
+++ b/crates/editor-transaction/src/compact.rs
@@ -21,6 +21,7 @@ pub fn compact(node: &NodeRef) -> Vec<Step> {
                     id: children[i].id(),
                     node: children[i].node().to_plain(),
                     modifiers: children[i].modifiers().cloned().collect(),
+                    style: children[i].entry().style.get().clone(),
                     children: vec![],
                 },
             });

--- a/crates/editor-transaction/src/dissolve.rs
+++ b/crates/editor-transaction/src/dissolve.rs
@@ -50,6 +50,7 @@ fn dissolve_into(
             id: node.id(),
             node: node.node().to_plain(),
             modifiers: node.explicit_modifiers().cloned().collect(),
+            style: node.entry().style.get().clone(),
             children: vec![],
         },
     });

--- a/crates/editor-transaction/src/fulfill.rs
+++ b/crates/editor-transaction/src/fulfill.rs
@@ -121,6 +121,7 @@ fn scaffold(node_type: NodeType) -> Subtree {
         id,
         node,
         modifiers: vec![],
+        style: None,
         children,
     }
 }

--- a/crates/editor-transaction/src/prune.rs
+++ b/crates/editor-transaction/src/prune.rs
@@ -41,6 +41,7 @@ fn prune_empty(node: &NodeRef) -> Vec<Step> {
             id: node.id(),
             node: node.node().to_plain(),
             modifiers: node.explicit_modifiers().cloned().collect(),
+            style: node.entry().style.get().clone(),
             children: vec![],
         },
     }];

--- a/crates/editor-transaction/src/steps/insert_subtree.rs
+++ b/crates/editor-transaction/src/steps/insert_subtree.rs
@@ -69,6 +69,14 @@ fn emit_pass1(batched: &mut BatchedState, subtree: &Subtree) -> Result<(), StepE
             },
         })?;
     }
+    if let Some(style_id) = &subtree.style {
+        batched.apply(DocOp::NodeStyle {
+            node_id: subtree.id,
+            op: LwwRegOp::Set {
+                value: Some(style_id.clone()),
+            },
+        })?;
+    }
     for attr in subtree.node.to_attrs() {
         batched.apply(DocOp::Attr {
             node_id: subtree.id,


### PR DESCRIPTION
`style: Option<String>` 필드를 추가하고, extract 시 source 노드의 style을 캡처, paste 시 새로 생성되거나 비어있는 destination paragraph에 적용하도록 수정.                   


  - `Fragment`/`Subtree`에 `style` 필드 추가 (직렬화는 `None`이면 생략)       
  - `insert_subtree` step이 `subtree.style`을 `DocOp::NodeStyle`로 emit
  - `Slice::extract`이 각 노드의 `entry().style`을 Fragment에 캡처            
    - 단일 text 노드 부분 선택은 fragment.node가 Text라 style을 담을 곳이 없음
   → enclosing textblock에 style이 있을 때만 Paragraph wrapper로 합성 (style  
  없으면 기존 모양 그대로 유지 → 회귀 없음)                                   
  - Paste 경로:                                                               
    - 새 문단 생성 경로: source style 적용                                    
    - 빈 문단에 inline merge: source style 적용                             
    - 비어있지 않은 문단에 inline merge: destination style 유지 (워드프로세서 
  관례)    
                                   