### PR TITLE
fix:   span 경계에서 커서 높이가 다음 글리프의 폰트로 그려지는 버그 수정

### DIFF
--- a/crates/editor-core/src/editor.rs
+++ b/crates/editor-core/src/editor.rs
@@ -2415,7 +2415,7 @@ mod tests {
         let sel = editor.state.selection.expect("selection exists in test");
         let cursor = editor
             .view()
-            .cursor_metrics(&editor.state.doc, &sel.head)
+            .cursor_metrics(&editor.state, &sel.head)
             .expect("collapsed cursor has metrics");
         let probe_x = cursor.caret.x;
         let probe_y = cursor.line.y + cursor.line.height * 0.5;
@@ -2437,7 +2437,7 @@ mod tests {
         let sel = editor.state.selection.expect("selection exists in test");
         let cursor = editor
             .view()
-            .cursor_metrics(&editor.state.doc, &sel.head)
+            .cursor_metrics(&editor.state, &sel.head)
             .expect("collapsed cursor has metrics");
         let probe_x = cursor.caret.x + 100.0;
         let probe_y = cursor.line.y + cursor.line.height * 0.5;
@@ -2460,6 +2460,35 @@ mod tests {
     }
 
     #[test]
+    fn cursor_metrics_at_span_boundary_uses_input_font_size() {
+        let (initial, _t0, t1) = state! {
+            doc { root { paragraph { t0: text("a") t1: text("a") [font_size(2400)] } } }
+            selection: (t1, 0)
+        };
+        let mut editor = Editor::new_test(initial);
+        editor.apply(Message::System {
+            event: crate::message::SystemEvent::Initialize,
+        });
+
+        let at_start = editor
+            .view()
+            .cursor_metrics(&editor.state, &Position::new(t1, 0))
+            .expect("cursor metrics at t1 start");
+        let at_end = editor
+            .view()
+            .cursor_metrics(&editor.state, &Position::new(t1, 1))
+            .expect("cursor metrics at t1 end");
+
+        assert!(
+            at_start.caret.height < at_end.caret.height,
+            "offset 0 (입력은 이전 span 폰트) caret이 offset 1 (24pt) caret보다 작아야 함: \
+             start={}, end={}",
+            at_start.caret.height,
+            at_end.caret.height,
+        );
+    }
+
+    #[test]
     fn dnd_over_text_sets_drop_indicator_and_invalidates_render() {
         let (initial, t) = state! {
             doc { root { paragraph { t: text("hello") } } }
@@ -2471,7 +2500,7 @@ mod tests {
         });
         let caret = editor
             .view()
-            .cursor_metrics(&editor.state.doc, &Position::new(t, 2))
+            .cursor_metrics(&editor.state, &Position::new(t, 2))
             .expect("cursor metrics")
             .caret;
 
@@ -2509,7 +2538,7 @@ mod tests {
         });
         let caret = editor
             .view()
-            .cursor_metrics(&editor.state.doc, &Position::new(t, 2))
+            .cursor_metrics(&editor.state, &Position::new(t, 2))
             .expect("cursor metrics")
             .caret;
 
@@ -2542,7 +2571,7 @@ mod tests {
         });
         let caret = editor
             .view()
-            .cursor_metrics(&editor.state.doc, &Position::new(t, 2))
+            .cursor_metrics(&editor.state, &Position::new(t, 2))
             .expect("cursor metrics")
             .caret;
         editor.apply(Message::Dnd {
@@ -2581,7 +2610,7 @@ mod tests {
         });
         let caret = editor
             .view()
-            .cursor_metrics(&editor.state.doc, &Position::new(t, 5))
+            .cursor_metrics(&editor.state, &Position::new(t, 5))
             .expect("cursor metrics")
             .caret;
         editor.apply(Message::Dnd {
@@ -2620,7 +2649,7 @@ mod tests {
         });
         let caret = editor
             .view()
-            .cursor_metrics(&editor.state.doc, &Position::new(t, 2))
+            .cursor_metrics(&editor.state, &Position::new(t, 2))
             .expect("cursor metrics")
             .caret;
 
@@ -2655,7 +2684,7 @@ mod tests {
         });
         let caret = editor
             .view()
-            .cursor_metrics(&editor.state.doc, &Position::new(t2, 2))
+            .cursor_metrics(&editor.state, &Position::new(t2, 2))
             .expect("cursor metrics")
             .caret;
 
@@ -2690,7 +2719,7 @@ mod tests {
         });
         let caret = editor
             .view()
-            .cursor_metrics(&editor.state.doc, &Position::new(t2, 2))
+            .cursor_metrics(&editor.state, &Position::new(t2, 2))
             .expect("cursor metrics")
             .caret;
 
@@ -2721,7 +2750,7 @@ mod tests {
         });
         let caret = editor
             .view()
-            .cursor_metrics(&editor.state.doc, &Position::new(t, 5))
+            .cursor_metrics(&editor.state, &Position::new(t, 5))
             .expect("cursor metrics")
             .caret;
 
@@ -2770,7 +2799,7 @@ mod tests {
         });
         let caret = editor
             .view()
-            .cursor_metrics(&editor.state.doc, &Position::new(t, 5))
+            .cursor_metrics(&editor.state, &Position::new(t, 5))
             .expect("cursor metrics")
             .caret;
 
@@ -2802,7 +2831,7 @@ mod tests {
         });
         let caret = editor
             .view()
-            .cursor_metrics(&editor.state.doc, &Position::new(t, 5))
+            .cursor_metrics(&editor.state, &Position::new(t, 5))
             .expect("cursor metrics")
             .caret;
 
@@ -2839,7 +2868,7 @@ mod tests {
         });
         let caret = editor
             .view()
-            .cursor_metrics(&editor.state.doc, &Position::new(t, 5))
+            .cursor_metrics(&editor.state, &Position::new(t, 5))
             .expect("cursor metrics")
             .caret;
 
@@ -2888,7 +2917,7 @@ mod tests {
         });
         let caret = editor
             .view()
-            .cursor_metrics(&editor.state.doc, &Position::new(t, 5))
+            .cursor_metrics(&editor.state, &Position::new(t, 5))
             .expect("cursor metrics")
             .caret;
 
@@ -2956,7 +2985,7 @@ mod tests {
         });
         let caret = editor
             .view()
-            .cursor_metrics(&editor.state.doc, &Position::new(t, 11))
+            .cursor_metrics(&editor.state, &Position::new(t, 11))
             .expect("cursor metrics")
             .caret;
 
@@ -3183,7 +3212,7 @@ mod tests {
         });
         let caret = editor
             .view()
-            .cursor_metrics(&editor.state.doc, &Position::new(t, 11))
+            .cursor_metrics(&editor.state, &Position::new(t, 11))
             .expect("cursor metrics")
             .caret;
 
@@ -3227,7 +3256,7 @@ mod tests {
         });
         let caret = editor
             .view()
-            .cursor_metrics(&editor.state.doc, &Position::new(t, 11))
+            .cursor_metrics(&editor.state, &Position::new(t, 11))
             .expect("cursor metrics")
             .caret;
 
@@ -3318,10 +3347,7 @@ mod tests {
         assert!(
             editor
                 .view()
-                .cursor_metrics(
-                    &st.doc,
-                    &st.selection.expect("selection exists in test").head
-                )
+                .cursor_metrics(st, &st.selection.expect("selection exists in test").head)
                 .is_some(),
             "gap cursor must produce a caret via the phantom line"
         );
@@ -3336,10 +3362,7 @@ mod tests {
         assert!(
             editor
                 .view()
-                .cursor_metrics(
-                    &st2.doc,
-                    &st2.selection.expect("selection exists in test").head
-                )
+                .cursor_metrics(st2, &st2.selection.expect("selection exists in test").head)
                 .is_some(),
             "normal caret still valid after leaving the gap (phantom space recovered)"
         );
@@ -3545,7 +3568,7 @@ mod tests {
         let page_bottom = editor.view().pages()[0].size.height;
         let caret = editor
             .view()
-            .cursor_metrics(&editor.state.doc, &Position::new(para_text, 5))
+            .cursor_metrics(&editor.state, &Position::new(para_text, 5))
             .expect("cursor metrics")
             .caret;
 
@@ -3750,7 +3773,7 @@ mod tests {
         });
         let caret = editor
             .view()
-            .cursor_metrics(&editor.state.doc, &Position::new(para_text, 5))
+            .cursor_metrics(&editor.state, &Position::new(para_text, 5))
             .expect("cursor metrics for paragraph after fold")
             .caret;
 
@@ -3794,7 +3817,7 @@ mod tests {
         });
         let caret = editor
             .view()
-            .cursor_metrics(&editor.state.doc, &Position::new(para_text, 5))
+            .cursor_metrics(&editor.state, &Position::new(para_text, 5))
             .expect("cursor metrics")
             .caret;
 

--- a/crates/editor-ffi/src/editor.rs
+++ b/crates/editor-ffi/src/editor.rs
@@ -90,7 +90,7 @@ impl Editor {
                 Ok(inner
                     .editor
                     .view()
-                    .cursor_metrics(&state.doc, &selection.head)
+                    .cursor_metrics(state, &selection.head)
                     .into_ffi()?)
             } else {
                 Ok(None)

--- a/crates/editor-view/src/measure/text/resolve.rs
+++ b/crates/editor-view/src/measure/text/resolve.rs
@@ -71,6 +71,49 @@ pub fn resolve_text_style(node: &NodeRef<'_>) -> ResolvedTextStyle {
     }
 }
 
+/// `resolve_text_style`와 달리 ancestor 순회·Expand 필터링을 하지 않는다 — 호출자가
+/// 미리 평탄화한 effective set을 넘긴다는 계약.
+pub fn style_from_effective_modifiers(modifiers: &[Modifier]) -> ResolvedTextStyle {
+    let mut font_family: Option<String> = None;
+    let mut font_weight: Option<u16> = None;
+    let mut font_size: Option<f32> = None;
+    let mut letter_spacing: Option<f32> = None;
+    let mut line_height: Option<f32> = None;
+
+    for m in modifiers {
+        match m {
+            Modifier::FontFamily { value } if font_family.is_none() => {
+                font_family = Some(value.clone());
+            }
+            Modifier::FontWeight { value } if font_weight.is_none() => {
+                font_weight = Some(*value);
+            }
+            Modifier::FontSize { value } if font_size.is_none() => {
+                let pt = *value as f32 / 100.0;
+                font_size = Some(pt * PT_TO_PX);
+            }
+            Modifier::LetterSpacing { value } if letter_spacing.is_none() => {
+                letter_spacing = Some(*value as f32 / 100.0);
+            }
+            Modifier::LineHeight { value } if line_height.is_none() => {
+                line_height = Some(*value as f32 / 100.0);
+            }
+            _ => {}
+        }
+    }
+
+    let final_font_size = font_size.unwrap_or(DEFAULT_FONT_SIZE_PX);
+    let ls_em = letter_spacing.unwrap_or(0.0);
+
+    ResolvedTextStyle {
+        font_family: font_family.unwrap_or_default(),
+        font_weight: font_weight.unwrap_or(DEFAULT_FONT_WEIGHT),
+        font_size: final_font_size,
+        letter_spacing: ls_em * final_font_size,
+        line_height: line_height.unwrap_or(DEFAULT_LINE_HEIGHT),
+    }
+}
+
 pub fn apply_pending_to_style(style: &mut ResolvedTextStyle, pending: &PendingModifiers) {
     for p in pending {
         if let PendingModifier::Set { modifier } = p {
@@ -222,6 +265,33 @@ mod tests {
         assert!((style.font_size - 16.0).abs() < 0.01);
         assert!((style.line_height - 1.6).abs() < 0.01);
         assert!((style.letter_spacing - 0.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn style_from_effective_modifiers_empty_uses_defaults() {
+        let style = style_from_effective_modifiers(&[]);
+        assert_eq!(style.font_weight, DEFAULT_FONT_WEIGHT);
+        assert!((style.font_size - DEFAULT_FONT_SIZE_PX).abs() < 0.01);
+        assert!((style.line_height - DEFAULT_LINE_HEIGHT).abs() < 0.01);
+        assert!((style.letter_spacing - 0.0).abs() < 0.01);
+        assert_eq!(style.font_family, "");
+    }
+
+    #[test]
+    fn style_from_effective_modifiers_applies_font_size() {
+        let style = style_from_effective_modifiers(&[Modifier::FontSize { value: 2400 }]);
+        // 24pt * (96/72) = 32px
+        assert!((style.font_size - 32.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn style_from_effective_modifiers_first_wins_per_type() {
+        let style = style_from_effective_modifiers(&[
+            Modifier::FontSize { value: 1200 },
+            Modifier::FontSize { value: 2400 },
+        ]);
+        // 12pt * (96/72) = 16px
+        assert!((style.font_size - 16.0).abs() < 0.01);
     }
 
     #[test]

--- a/crates/editor-view/src/query/dnd.rs
+++ b/crates/editor-view/src/query/dnd.rs
@@ -250,13 +250,14 @@ mod tests {
         };
         let mut view = View::new_test();
         view.layout(&doc);
+        let state = editor_state::State::new(doc, editor_crdt::OpGraph::new(), None);
         let caret = view
-            .cursor_metrics(&doc, &Position::new(t, 2))
+            .cursor_metrics(&state, &Position::new(t, 2))
             .expect("cursor metrics")
             .caret;
 
         let target = view
-            .drop_target_at(&doc, 0, caret.x, caret.y + caret.height * 0.5)
+            .drop_target_at(&state.doc, 0, caret.x, caret.y + caret.height * 0.5)
             .expect("valid dnd target");
 
         assert_eq!(target.position.node_id, t);
@@ -871,12 +872,13 @@ mod tests {
         };
         let mut view = View::new_test();
         view.layout(&doc);
+        let state = editor_state::State::new(doc, editor_crdt::OpGraph::new(), None);
         let caret = view
-            .cursor_metrics(&doc, &Position::new(t, 2))
+            .cursor_metrics(&state, &Position::new(t, 2))
             .expect("cursor metrics")
             .caret;
 
-        let target = view.drop_target_at(&doc, 0, caret.x, caret.y + caret.height * 0.5);
+        let target = view.drop_target_at(&state.doc, 0, caret.x, caret.y + caret.height * 0.5);
 
         assert!(target.is_some());
     }

--- a/crates/editor-view/src/view.rs
+++ b/crates/editor-view/src/view.rs
@@ -2,12 +2,12 @@ use editor_common::{EdgeInsets, Movement};
 use editor_crdt::Op;
 use editor_model::{Doc, DocOp, LayoutMode, Node, NodeId};
 use editor_resource::Resource;
-use editor_state::{Position, ResolvedSelection, Selection};
+use editor_state::{Position, ResolvedSelection, Selection, State, resolve_effective_modifiers_at};
 use std::sync::{Arc, Mutex};
 
 use crate::ExternalElement;
 use crate::TableOverlay;
-use crate::measure::text::resolve::resolve_text_style;
+use crate::measure::text::resolve::style_from_effective_modifiers;
 use crate::measure::text::strut::compute_strut;
 use crate::measure::{MeasuredTree, Measurer};
 use crate::page::LayoutPage;
@@ -362,9 +362,9 @@ impl View {
         query::navigation::position_at_preferred_x_in(&result.tree, node_id, at_end, x)
     }
 
-    pub fn cursor_metrics(&self, doc: &Doc, pos: &Position) -> Option<CursorMetrics> {
+    pub fn cursor_metrics(&self, state: &State, pos: &Position) -> Option<CursorMetrics> {
         let result = self.layout.as_ref()?;
-        let metrics_override = self.cursor_metrics_at(doc, pos);
+        let metrics_override = self.cursor_metrics_at(state, pos);
         query::cursor_metrics(&result.tree, &result.pages, pos, metrics_override)
     }
 
@@ -373,12 +373,15 @@ impl View {
         crate::query::placeholder_metrics(&result.tree, &result.pages, doc)
     }
 
-    fn cursor_metrics_at(&self, doc: &Doc, pos: &Position) -> Option<(f32, f32)> {
-        let node = doc.node(pos.node_id)?;
+    // 입력 경로(`resolve_effective_modifiers_at`)와 동일한 effective set을 써서
+    // span 경계의 Expand 규칙·pending_modifiers를 커서 높이에 반영한다.
+    fn cursor_metrics_at(&self, state: &State, pos: &Position) -> Option<(f32, f32)> {
+        let node = state.doc.node(pos.node_id)?;
         if !matches!(node.node(), Node::Text(_)) {
             return None;
         }
-        let style = resolve_text_style(&node);
+        let modifiers = resolve_effective_modifiers_at(state, pos);
+        let style = style_from_effective_modifiers(&modifiers);
         let mut resource = self.measurer.resource.lock().unwrap();
         let strut = compute_strut(&mut resource, &style)?;
         Some((strut.ascent, strut.descent))
@@ -673,6 +676,10 @@ mod tests {
         }
     }
 
+    fn mk_state(doc: Doc) -> State {
+        State::new(doc, editor_crdt::OpGraph::new(), None)
+    }
+
     #[test]
     fn layout_produces_pages() {
         let (doc,) = doc! { root { paragraph { text("hello") } } };
@@ -776,9 +783,10 @@ mod tests {
         let (doc, p1) = doc! { root { p1: paragraph } };
         let mut view = View::new_test();
         view.layout(&doc);
+        let state = mk_state(doc);
 
         let pos = Position::new(p1, 0);
-        let default_rect = view.cursor_metrics(&doc, &pos).unwrap();
+        let default_rect = view.cursor_metrics(&state, &pos).unwrap();
 
         // With no pending modifiers, cursor uses stored strut metrics.
         assert!(default_rect.caret.height > 0.0);
@@ -786,9 +794,6 @@ mod tests {
 
     #[test]
     fn cursor_rect_matches_adjacent_text_font_size() {
-        // Text node with its own FontSize modifier (24pt) alongside default text.
-        // Cursor inside the big-sized text should reflect that text's style, not
-        // the paragraph default.
         let (doc, t1, t2) = doc! {
             root {
                 paragraph {
@@ -799,9 +804,10 @@ mod tests {
         };
         let mut view = View::new_test();
         view.layout(&doc);
+        let state = mk_state(doc);
 
-        let r1 = view.cursor_metrics(&doc, &Position::new(t1, 0)).unwrap();
-        let r2 = view.cursor_metrics(&doc, &Position::new(t2, 0)).unwrap();
+        let r1 = view.cursor_metrics(&state, &Position::new(t1, 1)).unwrap();
+        let r2 = view.cursor_metrics(&state, &Position::new(t2, 1)).unwrap();
 
         assert!(
             r2.caret.height > r1.caret.height,
@@ -824,13 +830,16 @@ mod tests {
         };
         let mut view = View::new_test();
         view.layout(&doc);
+        let state = mk_state(doc);
 
+        // offset 1 = end of each single-char node so the Expand::After mark
+        // on `big` actually applies (Expand::After only kicks in at_end).
         let small_caret = view
-            .cursor_metrics(&doc, &Position::new(small, 0))
+            .cursor_metrics(&state, &Position::new(small, 1))
             .unwrap()
             .caret;
         let big_caret = view
-            .cursor_metrics(&doc, &Position::new(big, 0))
+            .cursor_metrics(&state, &Position::new(big, 1))
             .unwrap()
             .caret;
 
@@ -858,8 +867,9 @@ mod tests {
         let (doc, p1) = doc! { root { p1: paragraph } };
         let mut view = View::new_test();
         view.layout(&doc);
+        let state = mk_state(doc);
         let pos = Position::new(p1, 0);
-        let baseline = view.cursor_metrics(&doc, &pos).unwrap();
+        let baseline = view.cursor_metrics(&state, &pos).unwrap();
 
         let pending_style = Some(PendingStyle {
             node_id: p1,
@@ -867,8 +877,8 @@ mod tests {
                 modifier: Modifier::FontSize { value: 9600 },
             }],
         });
-        view.reconcile_with_ops(&doc, &doc, &[], pending_style, None);
-        let pending = view.cursor_metrics(&doc, &pos).unwrap();
+        view.reconcile_with_ops(&state.doc, &state.doc, &[], pending_style, None);
+        let pending = view.cursor_metrics(&state, &pos).unwrap();
 
         assert!(pending.caret.height > baseline.caret.height);
         assert!(pending.line.height > baseline.line.height);
@@ -880,9 +890,10 @@ mod tests {
         let (doc, p1) = doc! { root { p1: paragraph [alignment(Alignment::Right)] } };
         let mut view = View::new_test();
         view.layout(&doc);
+        let state = mk_state(doc);
 
         let pos = Position::new(p1, 0);
-        let m = view.cursor_metrics(&doc, &pos).unwrap();
+        let m = view.cursor_metrics(&state, &pos).unwrap();
 
         assert!(
             (m.caret.x - (m.line.x + m.line.width)).abs() < 1.0,
@@ -899,9 +910,10 @@ mod tests {
         let (doc, p1) = doc! { root { p1: paragraph [alignment(Alignment::Center)] } };
         let mut view = View::new_test();
         view.layout(&doc);
+        let state = mk_state(doc);
 
         let pos = Position::new(p1, 0);
-        let m = view.cursor_metrics(&doc, &pos).unwrap();
+        let m = view.cursor_metrics(&state, &pos).unwrap();
 
         let mid = m.line.x + m.line.width / 2.0;
         assert!(
@@ -922,8 +934,9 @@ mod tests {
         let (doc, p1, t1) = doc! { root { p1: paragraph { t1: text("hi") } } };
         let mut view = View::new_test();
         view.layout(&doc);
+        let state = mk_state(doc);
         let pos = Position::new(t1, 0);
-        let baseline = view.cursor_metrics(&doc, &pos).unwrap();
+        let baseline = view.cursor_metrics(&state, &pos).unwrap();
 
         let pending_style = Some(PendingStyle {
             node_id: p1,
@@ -931,8 +944,8 @@ mod tests {
                 modifier: Modifier::FontSize { value: 9600 },
             }],
         });
-        view.reconcile_with_ops(&doc, &doc, &[], pending_style, None);
-        let after = view.cursor_metrics(&doc, &pos).unwrap();
+        view.reconcile_with_ops(&state.doc, &state.doc, &[], pending_style, None);
+        let after = view.cursor_metrics(&state, &pos).unwrap();
 
         assert!((after.caret.height - baseline.caret.height).abs() < 0.01);
         assert!((after.line.height - baseline.line.height).abs() < 0.01);


### PR DESCRIPTION
 입력 경로와 커서 경로가 서로 다른 규칙으로 effective style을 계산함으로 생기는 버그. 

  - `cursor_metrics` 시그니처: `(&Doc, &Position)` → `(&State, &Position)`  
  - `cursor_metrics_at`이 `resolve_effective_modifiers_at`를 사용 → 입력      
  경로와 동일한 effective set으로 strut 계산                                  
  - 신규 helper `style_from_effective_modifiers(&[Modifier])` — 이미 평탄화된 
  effective list로부터 `ResolvedTextStyle` 생성       