### PR TITLE
fix:  paginated 모드 스크롤 fling 중 pinch 줌 시  브라우저 페이지 전체가 줌되는 문제 수정

### DIFF
--- a/apps/website/src/lib/components/editor/editor-zoom.svelte.ts
+++ b/apps/website/src/lib/components/editor/editor-zoom.svelte.ts
@@ -160,14 +160,20 @@ export class EditorZoomController {
       return;
     }
 
+    const zoomDelta = Math.abs(event.deltaY) >= Math.abs(event.deltaX) ? event.deltaY : event.deltaX;
+    const deltaMagnitude = Math.abs(zoomDelta);
+
     const hasZoomModifier = event.metaKey || event.ctrlKey;
+
+    if (hasZoomModifier && this.#wheelSessionMode === 'scroll' && deltaMagnitude >= EditorZoomController.WHEEL_MODE_SWITCH_MIN_DELTA_PX) {
+      this.#clearWheelSessionModeState();
+    }
+
     const shouldPreventBrowserZoom = hasZoomModifier && this.#wheelSessionMode !== 'scroll';
     if (shouldPreventBrowserZoom && event.cancelable) {
       event.preventDefault();
     }
 
-    const zoomDelta = Math.abs(event.deltaY) >= Math.abs(event.deltaX) ? event.deltaY : event.deltaX;
-    const deltaMagnitude = Math.abs(zoomDelta);
     if (deltaMagnitude === 0) {
       return;
     }

--- a/apps/website/src/lib/editor-ffi/components/editor-zoom.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/components/editor-zoom.svelte.ts
@@ -166,14 +166,20 @@ export class EditorZoomController {
       return;
     }
 
+    const zoomDelta = Math.abs(event.deltaY) >= Math.abs(event.deltaX) ? event.deltaY : event.deltaX;
+    const deltaMagnitude = Math.abs(zoomDelta);
+
     const hasZoomModifier = event.metaKey || event.ctrlKey;
+
+    if (hasZoomModifier && this.#wheelSessionMode === 'scroll' && deltaMagnitude >= EditorZoomController.WHEEL_MODE_SWITCH_MIN_DELTA_PX) {
+      this.#clearWheelSessionModeState();
+    }
+
     const shouldPreventBrowserZoom = hasZoomModifier && this.#wheelSessionMode !== 'scroll';
     if (shouldPreventBrowserZoom && event.cancelable) {
       event.preventDefault();
     }
 
-    const zoomDelta = Math.abs(event.deltaY) >= Math.abs(event.deltaX) ? event.deltaY : event.deltaX;
-    const deltaMagnitude = Math.abs(zoomDelta);
     if (deltaMagnitude === 0) {
       return;
     }


### PR DESCRIPTION
### handleWheel 수정 
1. zoomDelta / deltaMagnitude 계산을 modifier 체크 앞으로 이동                      
2. fling tail은 delta가 매우 작다(WHEEL_TAIL_DELTA_PX = 0.8)는 점을 이용해 fling과 pinch 시작을 구분. 다음 조건이 모두 참이면 'scroll' 세션을 즉시 해제:               
    - hasZoomModifier (metaKey/ctrlKey)         
    - #wheelSessionMode === 'scroll'                                                  
    - deltaMagnitude >= WHEEL_MODE_SWITCH_MIN_DELTA_PX (1.5px)                        
  3. 세션 해제 후 기존 shouldPreventBrowserZoom 분기에서 정상적으로 preventDefault()가
   호출되고, 아래쪽 !this.#wheelSessionMode 분기에서 새 세션이 'zoom'으로 설정됨