### PR TITLE
slice 생성과 삽입 수정

### DIFF
--- a/crates/editor-clipboard/src/slice.rs
+++ b/crates/editor-clipboard/src/slice.rs
@@ -1,6 +1,4 @@
-use editor_model::{
-    Fragment, Node, NodeRef, PlainNode, PlainParagraphNode, PlainRootNode, PlainTextNode,
-};
+use editor_model::{Fragment, Node, NodeRef, PlainNode, PlainRootNode, PlainTextNode};
 use editor_resource::Resource;
 use editor_state::{CellRect, ResolvedSelection, State, is_prefix_of};
 use serde::{Deserialize, Serialize};
@@ -47,12 +45,11 @@ impl Slice {
         let fragment = build_fragment(&rs, common);
         // When the selection is contained within a single inline node, the
         // common ancestor is that inline node, so build_fragment returns a bare
-        // inline leaf with no way to carry the source paragraph's style. Wrap
-        // it in a synthesized Paragraph that carries the enclosing textblock's
-        // style; bump open_start/open_end so paste paths still see the slice as
-        // inline content to merge.
+        // inline leaf. Wrap it in the enclosing textblock and bump
+        // open_start/open_end so all inline selections keep their source
+        // textblock shape as wider textblock selections.
         let (fragment, open_start, open_end) =
-            wrap_bare_inline_in_textblock(fragment, common, open_start, open_end);
+            wrap_bare_inline_in_enclosing_textblock(fragment, common, open_start, open_end);
         Some(Slice {
             fragment,
             open_start,
@@ -110,12 +107,7 @@ fn nearest_enclosing_textblock<'a>(node: NodeRef<'a>) -> Option<NodeRef<'a>> {
     None
 }
 
-// Only wraps when the source textblock actually has a named style — otherwise
-// returns the bare inline fragment unchanged, preserving the existing slice
-// shape (and open_start/open_end semantics) for unstyled paragraphs. The wrap
-// is the only carrier for style in the single-inline-node case because Text
-// itself has no style slot on its NodeEntry.
-fn wrap_bare_inline_in_textblock(
+fn wrap_bare_inline_in_enclosing_textblock(
     fragment: Fragment,
     common: NodeRef<'_>,
     open_start: u32,
@@ -131,13 +123,10 @@ fn wrap_bare_inline_in_textblock(
     let Some(textblock) = nearest_enclosing_textblock(common) else {
         return (fragment, open_start, open_end);
     };
-    let Some(style_id) = textblock.entry().style.get().clone() else {
-        return (fragment, open_start, open_end);
-    };
     let wrapped = Fragment {
-        node: PlainNode::Paragraph(PlainParagraphNode::default()),
-        modifiers: vec![],
-        style: Some(style_id),
+        node: textblock.node().to_plain(),
+        modifiers: textblock.explicit_modifiers().cloned().collect(),
+        style: textblock.entry().style.get().clone(),
         children: vec![fragment],
     };
     (wrapped, open_start + 1, open_end + 1)
@@ -285,7 +274,13 @@ mod tests {
 
     #[test]
     fn is_empty_keeps_text_leaf_non_empty() {
-        let slice = Slice::from_text("hello");
+        let slice = Slice {
+            fragment: Fragment::leaf(PlainNode::Text(PlainTextNode {
+                text: "hello".into(),
+            })),
+            open_start: 0,
+            open_end: 0,
+        };
         assert!(!slice.is_empty());
     }
 
@@ -306,9 +301,36 @@ mod tests {
             selection: (t1, 1) -> (t1, 4)
         };
         let slice = Slice::extract(&s).expect("non-collapsed");
-        assert_eq!(slice.open_start, 0);
-        assert_eq!(slice.open_end, 0);
-        if let editor_model::PlainNode::Text(t) = &slice.fragment.node {
+        assert_eq!(slice.open_start, 1);
+        assert_eq!(slice.open_end, 1);
+        assert!(matches!(
+            slice.fragment.node,
+            editor_model::PlainNode::Paragraph(_)
+        ));
+        if let editor_model::PlainNode::Text(t) = &slice.fragment.children[0].node {
+            assert_eq!(t.text, "ell");
+        } else {
+            panic!("expected text node");
+        }
+    }
+
+    #[test]
+    fn extract_inline_within_fold_title_keeps_fold_title_wrapper() {
+        let (s, ..) = state! {
+            doc { root { fold {
+                fold_title { t1: text("Hello World") }
+                fold_content { paragraph {} }
+            } } }
+            selection: (t1, 1) -> (t1, 4)
+        };
+        let slice = Slice::extract(&s).expect("non-collapsed");
+        assert_eq!(slice.open_start, 1);
+        assert_eq!(slice.open_end, 1);
+        assert!(matches!(
+            slice.fragment.node,
+            editor_model::PlainNode::FoldTitle(_)
+        ));
+        if let editor_model::PlainNode::Text(t) = &slice.fragment.children[0].node {
             assert_eq!(t.text, "ell");
         } else {
             panic!("expected text node");

--- a/crates/editor-clipboard/src/text/parse.rs
+++ b/crates/editor-clipboard/src/text/parse.rs
@@ -8,17 +8,22 @@ use crate::slice::Slice;
 pub fn from_text(text: &str) -> Slice {
     let stripped = text.trim_start_matches('\u{feff}');
     let normalized = stripped.replace("\r\n", "\n").replace('\r', "\n");
-    let blocks: Vec<Fragment> = normalized.split("\n\n").map(paragraph_from_block).collect();
+    let children: Vec<Fragment> = if normalized.is_empty() {
+        Vec::new()
+    } else {
+        normalized.split("\n\n").map(paragraph_from_block).collect()
+    };
+    let open_depth = u32::from(!children.is_empty());
 
     Slice {
         fragment: Fragment {
             node: PlainNode::Root(PlainRootNode::default()),
             modifiers: vec![],
             style: None,
-            children: blocks,
+            children,
         },
-        open_start: 0,
-        open_end: 0,
+        open_start: open_depth,
+        open_end: open_depth,
     }
 }
 
@@ -38,7 +43,16 @@ fn push_line_with_tabs(line: &str, inline: &mut Vec<Fragment>) {
 }
 
 fn paragraph_from_block(block: &str) -> Fragment {
-    let mut inline: Vec<Fragment> = Vec::new();
+    Fragment {
+        node: PlainNode::Paragraph(PlainParagraphNode::default()),
+        modifiers: vec![],
+        style: None,
+        children: inline_from_block(block),
+    }
+}
+
+fn inline_from_block(block: &str) -> Vec<Fragment> {
+    let mut inline = Vec::new();
     let mut first = true;
     for line in block.split('\n') {
         if !first {
@@ -49,56 +63,70 @@ fn paragraph_from_block(block: &str) -> Fragment {
         push_line_with_tabs(line, &mut inline);
         first = false;
     }
-    Fragment {
-        node: PlainNode::Paragraph(PlainParagraphNode::default()),
-        modifiers: vec![],
-        style: None,
-        children: inline,
-    }
+    inline
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn from_text_single_paragraph() {
-        let slice = from_text("Hello World");
+    fn only_paragraph(slice: &Slice) -> &Fragment {
         assert!(matches!(slice.fragment.node, PlainNode::Root(_)));
         assert_eq!(slice.fragment.children.len(), 1);
-        assert!(matches!(
-            slice.fragment.children[0].node,
-            PlainNode::Paragraph(_)
-        ));
-        let p = &slice.fragment.children[0];
-        assert_eq!(p.children.len(), 1);
-        if let PlainNode::Text(t) = &p.children[0].node {
+        let paragraph = &slice.fragment.children[0];
+        assert!(matches!(paragraph.node, PlainNode::Paragraph(_)));
+        paragraph
+    }
+
+    #[test]
+    fn from_text_empty_is_empty_slice() {
+        let slice = from_text("");
+        assert!(matches!(slice.fragment.node, PlainNode::Root(_)));
+        assert!(slice.fragment.children.is_empty());
+        assert_eq!(slice.open_start, 0);
+        assert_eq!(slice.open_end, 0);
+    }
+
+    #[test]
+    fn from_text_single_block_is_open_paragraph_slice() {
+        let slice = from_text("Hello World");
+        let paragraph = only_paragraph(&slice);
+        assert_eq!(paragraph.children.len(), 1);
+        if let PlainNode::Text(t) = &paragraph.children[0].node {
             assert_eq!(t.text, "Hello World");
         } else {
             panic!("expected text");
         }
-        assert_eq!(slice.open_start, 0);
-        assert_eq!(slice.open_end, 0);
+        assert_eq!(slice.open_start, 1);
+        assert_eq!(slice.open_end, 1);
     }
 
     #[test]
     fn from_text_double_newline_splits_paragraph() {
         let slice = Slice::from_text("first\n\nsecond");
         assert_eq!(slice.fragment.children.len(), 2);
+        assert_eq!(slice.open_start, 1);
+        assert_eq!(slice.open_end, 1);
     }
 
     #[test]
     fn from_text_single_newline_hardbreak() {
         let slice = Slice::from_text("line1\nline2");
-        assert_eq!(slice.fragment.children.len(), 1);
-        let p = &slice.fragment.children[0];
-        assert_eq!(p.children.len(), 3);
+        let paragraph = only_paragraph(&slice);
+        assert_eq!(paragraph.children.len(), 3);
+        assert!(matches!(
+            paragraph.children[1].node,
+            PlainNode::HardBreak(_)
+        ));
+        assert_eq!(slice.open_start, 1);
+        assert_eq!(slice.open_end, 1);
     }
 
     #[test]
     fn from_text_strips_bom() {
         let slice = Slice::from_text("\u{feff}hello");
-        if let PlainNode::Text(t) = &slice.fragment.children[0].children[0].node {
+        let paragraph = only_paragraph(&slice);
+        if let PlainNode::Text(t) = &paragraph.children[0].node {
             assert_eq!(t.text, "hello");
         } else {
             panic!("expected text");
@@ -108,16 +136,18 @@ mod tests {
     #[test]
     fn from_text_crlf_normalizes_to_lf() {
         let slice = Slice::from_text("a\r\nb");
-        assert_eq!(slice.fragment.children.len(), 1);
-        let p = &slice.fragment.children[0];
-        assert_eq!(p.children.len(), 3);
-        if let PlainNode::Text(t) = &p.children[0].node {
+        let paragraph = only_paragraph(&slice);
+        assert_eq!(paragraph.children.len(), 3);
+        if let PlainNode::Text(t) = &paragraph.children[0].node {
             assert_eq!(t.text, "a");
         } else {
             panic!("expected text");
         }
-        assert!(matches!(p.children[1].node, PlainNode::HardBreak(_)));
-        if let PlainNode::Text(t) = &p.children[2].node {
+        assert!(matches!(
+            paragraph.children[1].node,
+            PlainNode::HardBreak(_)
+        ));
+        if let PlainNode::Text(t) = &paragraph.children[2].node {
             assert_eq!(t.text, "b");
         } else {
             panic!("expected text");
@@ -133,24 +163,26 @@ mod tests {
     #[test]
     fn from_text_bare_cr_treated_as_lf() {
         let slice = Slice::from_text("a\rb");
-        assert_eq!(slice.fragment.children.len(), 1);
-        let p = &slice.fragment.children[0];
-        assert_eq!(p.children.len(), 3);
+        let paragraph = only_paragraph(&slice);
+        assert_eq!(paragraph.children.len(), 3);
+        assert!(matches!(
+            paragraph.children[1].node,
+            PlainNode::HardBreak(_)
+        ));
     }
 
     #[test]
     fn from_text_tab_becomes_tab_node() {
         let slice = Slice::from_text("a\tb");
-        assert_eq!(slice.fragment.children.len(), 1);
-        let p = &slice.fragment.children[0];
-        assert_eq!(p.children.len(), 3);
-        if let PlainNode::Text(t) = &p.children[0].node {
+        let paragraph = only_paragraph(&slice);
+        assert_eq!(paragraph.children.len(), 3);
+        if let PlainNode::Text(t) = &paragraph.children[0].node {
             assert_eq!(t.text, "a");
         } else {
             panic!("expected text");
         }
-        assert!(matches!(p.children[1].node, PlainNode::Tab(_)));
-        if let PlainNode::Text(t) = &p.children[2].node {
+        assert!(matches!(paragraph.children[1].node, PlainNode::Tab(_)));
+        if let PlainNode::Text(t) = &paragraph.children[2].node {
             assert_eq!(t.text, "b");
         } else {
             panic!("expected text");
@@ -160,7 +192,7 @@ mod tests {
     #[test]
     fn from_text_leading_tab_becomes_tab_node() {
         let slice = Slice::from_text("\tindented");
-        let p = &slice.fragment.children[0];
-        assert!(matches!(p.children[0].node, PlainNode::Tab(_)));
+        let paragraph = only_paragraph(&slice);
+        assert!(matches!(paragraph.children[0].node, PlainNode::Tab(_)));
     }
 }

--- a/crates/editor-commands/src/commands/insert_slice.rs
+++ b/crates/editor-commands/src/commands/insert_slice.rs
@@ -28,7 +28,9 @@ pub fn insert_slice(tr: &mut Transaction, slice: Slice) -> CommandResult {
 mod tests {
     use editor_clipboard::Slice;
     use editor_macros::state;
-    use editor_model::{Fragment, PlainNode, PlainParagraphNode, PlainRootNode, PlainTextNode};
+    use editor_model::{
+        Fragment, PlainFoldTitleNode, PlainNode, PlainParagraphNode, PlainRootNode, PlainTextNode,
+    };
 
     use super::*;
     use crate::test_utils::*;
@@ -64,6 +66,21 @@ mod tests {
         }
     }
 
+    fn open_fold_title_slice(text: &str) -> Slice {
+        Slice {
+            fragment: Fragment {
+                node: PlainNode::FoldTitle(PlainFoldTitleNode::default()),
+                modifiers: vec![],
+                style: None,
+                children: vec![Fragment::leaf(PlainNode::Text(PlainTextNode {
+                    text: text.into(),
+                }))],
+            },
+            open_start: 1,
+            open_end: 1,
+        }
+    }
+
     #[test]
     fn insert_empty_slice_no_op() {
         let (initial, ..) = state! {
@@ -80,7 +97,7 @@ mod tests {
     }
 
     #[test]
-    fn insert_inline_only_into_paragraph_middle() {
+    fn insert_open_single_paragraph_into_paragraph_middle_merges_both_edges() {
         let (initial, ..) = state! {
             doc { root { paragraph { t1: text("Hello") } } }
             selection: (t1, 2)
@@ -95,7 +112,7 @@ mod tests {
     }
 
     #[test]
-    fn insert_inline_at_block_boundary_wraps_paragraph() {
+    fn insert_open_paragraph_at_block_boundary_inserts_paragraph() {
         let (initial, ..) = state! {
             doc { r: root {
                 paragraph { text("a") }
@@ -103,18 +120,7 @@ mod tests {
             } }
             selection: (r, 1, >)
         };
-        let slice = Slice {
-            fragment: Fragment {
-                node: PlainNode::Root(PlainRootNode::default()),
-                modifiers: vec![],
-                style: None,
-                children: vec![Fragment::leaf(PlainNode::Text(PlainTextNode {
-                    text: "X".into(),
-                }))],
-            },
-            open_start: 1,
-            open_end: 1,
-        };
+        let slice = root_with_paragraph("X");
         let (actual, ..) = transact!(initial, |tr| insert_slice(&mut tr, slice));
         let (expected, ..) = state! {
             doc { root {
@@ -128,7 +134,50 @@ mod tests {
     }
 
     #[test]
-    fn insert_disallowed_block_unwraps_children() {
+    fn insert_open_paragraph_text_into_fold_title_uses_open_inline_content() {
+        let (source, ..) = state! {
+            doc { root { paragraph { t1: text("body") } } }
+            selection: (t1, 0) -> (t1, 4)
+        };
+        let slice = Slice::extract(&source).expect("non-collapsed");
+
+        let (initial, ..) = state! {
+            doc { root { fold {
+                ft: fold_title {}
+                fold_content { paragraph {} }
+            } } }
+            selection: (ft, 0)
+        };
+        let (actual, ..) = transact!(initial, |tr| insert_slice(&mut tr, slice));
+        let (expected, ..) = state! {
+            doc { root { fold {
+                fold_title { t: text("body") }
+                fold_content { paragraph {} }
+            } } }
+            selection: (t, 4)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn insert_open_fold_title_text_into_paragraph_uses_open_inline_content() {
+        let (initial, ..) = state! {
+            doc { root { p: paragraph {} } }
+            selection: (p, 0)
+        };
+        let (actual, ..) = transact!(initial, |tr| insert_slice(
+            &mut tr,
+            open_fold_title_slice("title")
+        ));
+        let (expected, ..) = state! {
+            doc { root { paragraph { t: text("title") } } }
+            selection: (t, 5)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn insert_block_slice_into_paragraph_preserves_block_structure() {
         use editor_model::{PlainBulletListNode, PlainListItemNode};
         let (initial, ..) = state! {
             doc { root { paragraph { t1: text("Hello") } } }
@@ -156,8 +205,12 @@ mod tests {
         };
         let (actual, ..) = transact!(initial, |tr| insert_slice(&mut tr, slice));
         let (expected, ..) = state! {
-            doc { root { paragraph { t: text("HelloX") } } }
-            selection: (t, 6)
+            doc { root {
+                paragraph { text("Hello") }
+                bl: bullet_list { list_item { paragraph { text("X") } } }
+                paragraph {}
+            } }
+            selection: (bl, 1)
         };
         assert_state_eq!(&actual, &expected);
     }
@@ -460,7 +513,7 @@ mod tests {
 
         use crate::commands::{apply_style, define_style};
 
-        let (initial, p1, t1) = state! {
+        let (initial, p1, _t1) = state! {
             doc { root { p1: paragraph { t1: text("Hello") } } }
             selection: (t1, 2)
         };

--- a/crates/editor-commands/src/helpers/slice.rs
+++ b/crates/editor-commands/src/helpers/slice.rs
@@ -1,12 +1,14 @@
 use editor_clipboard::Slice;
 use editor_model::{
-    Fragment, Modifier, Node, NodeId, NodeType, PlainNode, PlainParagraphNode, PlainRootNode,
-    PlainTextNode, Schema, Subtree,
+    Fragment, Modifier, Node, NodeId, NodeType, PlainNode, PlainTextNode, Schema, Subtree,
 };
 use editor_state::{Affinity, Position, Selection};
 use editor_transaction::{Transaction, fulfill};
 
-use super::{insert_hard_break_at_caret, insert_tab_at_caret, insert_text_at_caret};
+use super::{
+    compact_textblock_preserving_caret, find_ancestor_textblock, insert_hard_break_at_caret,
+    insert_tab_at_caret, insert_text_at_caret,
+};
 use crate::{CommandError, CommandResult};
 
 pub(crate) fn insert_slice_at_position(
@@ -18,157 +20,15 @@ pub(crate) fn insert_slice_at_position(
         return Ok(None);
     }
 
-    let slice = coerce_slice_for_position(tr, position, slice);
-    if slice.is_empty() {
-        return Ok(None);
-    }
-
-    let inline_only = is_inline_only(&slice);
     let in_textblock = position_in_textblock(tr, position);
-    match (inline_only, in_textblock) {
-        (true, true) => insert_inline_at_position(tr, position, &slice),
-        (false, true) => insert_blocks_in_textblock_at_position(tr, position, &slice),
-        (true, false) => insert_inline_at_block_boundary(tr, position, &slice),
-        (false, false) => insert_blocks_at_block_boundary(tr, position, &slice),
-    }
-}
-
-// Coerce slice's top-level block children to types the caret container allows.
-// Disallowed types are unwrapped recursively until either an allowed type or
-// an inline leaf is reached.
-fn coerce_slice_for_position(tr: &Transaction, position: Position, slice: Slice) -> Slice {
-    let container_type = match container_type_for_position(tr, position) {
-        Some(t) => t,
-        None => return slice,
-    };
-
-    let Slice {
-        fragment,
-        open_start,
-        open_end,
-    } = slice;
-
-    match fragment.node {
-        PlainNode::Root(_) => {
-            let coerced: Vec<Fragment> = fragment
-                .children
-                .into_iter()
-                .flat_map(|c| coerce_fragment_for_parent(c, container_type))
-                .collect();
-            Slice {
-                fragment: Fragment {
-                    node: fragment.node,
-                    modifiers: fragment.modifiers,
-                    style: fragment.style,
-                    children: coerced,
-                },
-                open_start,
-                open_end,
-            }
+    if in_textblock {
+        if should_insert_open_content_as_inline(tr, position, &slice) {
+            insert_open_content_as_inline_at_position(tr, position, &slice)
+        } else {
+            insert_blocks_in_textblock_at_position(tr, position, &slice)
         }
-        _ => {
-            let coerced = coerce_fragment_for_parent(
-                Fragment {
-                    node: fragment.node,
-                    modifiers: fragment.modifiers,
-                    style: fragment.style,
-                    children: fragment.children,
-                },
-                container_type,
-            );
-            let wrapped = Fragment {
-                node: PlainNode::Root(PlainRootNode::default()),
-                modifiers: vec![],
-                style: None,
-                children: coerced,
-            };
-            Slice {
-                fragment: wrapped,
-                open_start,
-                open_end,
-            }
-        }
-    }
-}
-
-fn container_type_for_position(tr: &Transaction, position: Position) -> Option<NodeType> {
-    let state = tr.state();
-    let node = state.doc.node(position.node_id)?;
-    // Coerce only against the textblock the caret sits inside — at block
-    // boundaries (Case C/D candidates) we want the slice's blocks to land
-    // as siblings of the existing blocks, not be unwrapped against the
-    // boundary container's schema.
-    match node.node() {
-        Node::Text(_) => node.parent().map(|p| p.as_type()),
-        _ => None,
-    }
-}
-
-fn coerce_fragment_for_parent(f: Fragment, parent_type: NodeType) -> Vec<Fragment> {
-    let f_type = f.node.as_type();
-    let f_spec = Schema::node_spec(f_type);
-    let parent_spec = Schema::node_spec(parent_type);
-
-    // Block content inside a textblock parent (nested textblock, or a block
-    // leaf like Image/HorizontalRule) keeps its boundary so the textblock
-    // gets split around it instead of being recursively unwrapped to nothing.
-    if parent_spec.is_textblock() && (f_spec.is_textblock() || f_spec.is_leaf()) && !f_spec.inline {
-        return vec![f];
-    }
-    // Inline content reaches the inline insertion path as-is.
-    if f_spec.inline {
-        return vec![f];
-    }
-    if child_allowed(parent_type, f_type) {
-        return vec![f];
-    }
-    let mut out = vec![];
-    for child in f.children {
-        out.extend(coerce_fragment_for_parent(child, parent_type));
-    }
-    out
-}
-
-fn child_allowed(parent_type: NodeType, child_type: NodeType) -> bool {
-    let spec = Schema::node_spec(parent_type);
-    spec.content.allowed_types().contains(&child_type)
-}
-
-// An inline-only slice represents pasteable content that fits inside a single
-// textblock — either bare inline (Text/HardBreak) or a single textblock wrapper
-// (Paragraph) around inline. A Root with multiple block children is a
-// block-sequence even if every block happens to be inline-compatible.
-fn is_inline_only(slice: &Slice) -> bool {
-    fn is_textblock_wrapper(n: &PlainNode) -> bool {
-        matches!(n, PlainNode::Paragraph(_))
-    }
-    fn is_inline_leaf(n: &PlainNode) -> bool {
-        matches!(
-            n,
-            PlainNode::Text(_) | PlainNode::HardBreak(_) | PlainNode::Tab(_)
-        )
-    }
-
-    let frag = &slice.fragment;
-    match &frag.node {
-        n if is_inline_leaf(n) => true,
-        n if is_textblock_wrapper(n) => frag.children.iter().all(|c| is_inline_leaf(&c.node)),
-        PlainNode::Root(_) => {
-            let block_kids: Vec<&Fragment> = frag
-                .children
-                .iter()
-                .filter(|c| !is_inline_leaf(&c.node))
-                .collect();
-            match block_kids.len() {
-                0 => true,
-                1 if is_textblock_wrapper(&block_kids[0].node) => block_kids[0]
-                    .children
-                    .iter()
-                    .all(|c| is_inline_leaf(&c.node)),
-                _ => false,
-            }
-        }
-        _ => false,
+    } else {
+        insert_blocks_at_block_boundary(tr, position, &slice)
     }
 }
 
@@ -179,21 +39,97 @@ fn position_in_textblock(tr: &Transaction, position: Position) -> bool {
         .is_some_and(|resolved| resolved.is_inline_position())
 }
 
-fn enclosing_textblock_id(tr: &Transaction, position: Position) -> Option<NodeId> {
-    let doc = tr.doc();
-    let node = doc.node(position.node_id)?;
-    if matches!(node.node(), Node::Text(_)) {
-        return node.parent().map(|p| p.id());
+fn top_level_fragments(slice: &Slice) -> Vec<&Fragment> {
+    match &slice.fragment.node {
+        PlainNode::Root(_) => slice.fragment.children.iter().collect(),
+        _ => vec![&slice.fragment],
     }
-    if node.spec().is_textblock() {
-        return Some(node.id());
-    }
-    None
 }
 
-fn paragraph_is_empty(tr: &Transaction, para_id: NodeId) -> bool {
+fn open_content_fragments(mut fragments: Vec<&Fragment>, open_depth: u32) -> Vec<&Fragment> {
+    for _ in 0..open_depth {
+        let mut next = Vec::new();
+        for fragment in fragments {
+            if Schema::node_spec(fragment.node.as_type()).is_leaf() || fragment.children.is_empty()
+            {
+                next.push(fragment);
+            } else {
+                next.extend(fragment.children.iter());
+            }
+        }
+        fragments = next;
+    }
+    fragments
+}
+
+fn fragments_fit_parent(parent_type: NodeType, fragments: &[&Fragment]) -> bool {
+    let content = &Schema::node_spec(parent_type).content;
+    fragments
+        .iter()
+        .all(|fragment| content.matches(fragment.node.as_type()))
+}
+
+fn fragments_are_inline(fragments: &[&Fragment]) -> bool {
+    !fragments.is_empty()
+        && fragments
+            .iter()
+            .all(|fragment| Schema::node_spec(fragment.node.as_type()).inline)
+}
+
+fn can_split_textblock_for_structural_insert(
+    doc: &editor_model::Doc,
+    textblock_id: NodeId,
+) -> bool {
+    let Some(textblock) = doc.node(textblock_id) else {
+        return false;
+    };
+    let Some(parent) = textblock.parent() else {
+        return false;
+    };
+    let Some(index) = textblock.index() else {
+        return false;
+    };
+
+    let mut child_types: Vec<NodeType> = parent.children().map(|child| child.as_type()).collect();
+    child_types.insert(index + 1, textblock.as_type());
+    parent.spec().content.validate(&child_types).is_ok()
+}
+
+fn should_insert_open_content_as_inline(
+    tr: &Transaction,
+    position: Position,
+    slice: &Slice,
+) -> bool {
+    if slice.open_start == 0 {
+        return false;
+    }
+
     let doc = tr.doc();
-    let Some(node) = doc.node(para_id) else {
+    let Some(textblock_id) = find_ancestor_textblock(&doc, position.node_id) else {
+        return false;
+    };
+    let Some(textblock) = doc.node(textblock_id) else {
+        return false;
+    };
+    let Some(parent) = textblock.parent() else {
+        return false;
+    };
+
+    let top_level = top_level_fragments(slice);
+    let open_content = open_content_fragments(top_level.clone(), slice.open_start);
+    if !fragments_are_inline(&open_content)
+        || !fragments_fit_parent(textblock.as_type(), &open_content)
+    {
+        return false;
+    }
+
+    !can_split_textblock_for_structural_insert(&doc, textblock_id)
+        || !fragments_fit_parent(parent.as_type(), &top_level)
+}
+
+fn textblock_is_empty(tr: &Transaction, textblock_id: NodeId) -> bool {
+    let doc = tr.doc();
+    let Some(node) = doc.node(textblock_id) else {
         return false;
     };
     if !node.spec().is_textblock() {
@@ -205,72 +141,33 @@ fn paragraph_is_empty(tr: &Transaction, para_id: NodeId) -> bool {
     })
 }
 
-fn source_paragraph_wrapper_style(slice: &Slice) -> Option<String> {
-    match &slice.fragment.node {
-        PlainNode::Paragraph(_) => slice.fragment.style.clone(),
-        PlainNode::Root(_) => {
-            let paras: Vec<&Fragment> = slice
-                .fragment
-                .children
-                .iter()
-                .filter(|c| matches!(c.node, PlainNode::Paragraph(_)))
-                .collect();
-            if paras.len() == 1 {
-                paras[0].style.clone()
-            } else {
-                None
-            }
-        }
-        _ => None,
-    }
-}
-
-fn collect_inline(f: &Fragment) -> Vec<&Fragment> {
-    fn walk<'a>(f: &'a Fragment, out: &mut Vec<&'a Fragment>) {
-        match &f.node {
-            PlainNode::Text(_) | PlainNode::HardBreak(_) | PlainNode::Tab(_) => out.push(f),
-            _ => {
-                for c in &f.children {
-                    walk(c, out);
-                }
-            }
-        }
-    }
-    let mut out = vec![];
-    walk(f, &mut out);
-    out
-}
-
-fn insert_inline_at_caret(tr: &mut Transaction, slice: &Slice) -> CommandResult {
-    let fragments: Vec<Fragment> = collect_inline(&slice.fragment)
-        .into_iter()
-        .cloned()
-        .collect();
-    insert_inline_fragments(tr, fragments)
-}
-
-fn insert_inline_at_position(
+fn insert_open_content_as_inline_at_position(
     tr: &mut Transaction,
     position: Position,
     slice: &Slice,
 ) -> Result<Option<Selection>, CommandError> {
-    let dest_para = enclosing_textblock_id(tr, position);
-    let dest_was_empty = dest_para.is_some_and(|id| paragraph_is_empty(tr, id));
+    let fragments: Vec<Fragment> =
+        open_content_fragments(top_level_fragments(slice), slice.open_start)
+            .into_iter()
+            .cloned()
+            .collect();
+    if fragments.is_empty() {
+        return Ok(None);
+    }
 
     tr.set_selection(Some(Selection::collapsed(position)))?;
-    let start = tr.selection().map(|s| s.head).unwrap_or(position);
-    let inserted = insert_inline_at_caret(tr, slice)?;
+    let start = tr
+        .selection()
+        .expect("selection preserved through mutations")
+        .head;
+    let inserted = insert_inline_fragments(tr, fragments)?;
     if !inserted {
         return Ok(None);
     }
-    if dest_was_empty
-        && let (Some(para_id), Some(style)) = (dest_para, source_paragraph_wrapper_style(slice))
-    {
-        tr.set_node_style(para_id, Some(style))?;
-    }
-    let Some(end) = tr.selection().map(|s| s.head) else {
-        return Ok(None);
-    };
+    let end = tr
+        .selection()
+        .expect("selection preserved through mutations")
+        .head;
     Ok(Some(normalized_selection(tr, start, end)))
 }
 
@@ -375,6 +272,32 @@ enum InsertedRangeEndpoint {
     AfterBlock(NodeId),
 }
 
+#[derive(Default)]
+struct InsertedRange {
+    start: Option<InsertedRangeEndpoint>,
+    end: Option<InsertedRangeEndpoint>,
+}
+
+impl InsertedRange {
+    fn include_position_range(&mut self, start: Position, end: Position) {
+        self.start
+            .get_or_insert(InsertedRangeEndpoint::Position(start));
+        self.end = Some(InsertedRangeEndpoint::Position(end));
+    }
+
+    fn include_block(&mut self, block_id: NodeId) {
+        self.start
+            .get_or_insert(InsertedRangeEndpoint::BeforeBlock(block_id));
+        self.end = Some(InsertedRangeEndpoint::AfterBlock(block_id));
+    }
+
+    fn selection(&self, tr: &Transaction) -> Option<Selection> {
+        let start = resolve_inserted_range_endpoint(tr, self.start?)?;
+        let end = resolve_inserted_range_endpoint(tr, self.end?)?;
+        Some(normalized_selection(tr, start, end))
+    }
+}
+
 fn insert_blocks_in_textblock(
     tr: &mut Transaction,
     slice: &Slice,
@@ -428,6 +351,8 @@ fn insert_blocks_in_textblock(
         (parent.id(), textblock_index)
     };
 
+    let textblock_was_empty = textblock_is_empty(tr, textblock_id);
+
     // Split the textblock at the resolved child index. p2_id becomes the right half.
     let p2_id = NodeId::new();
     tr.split_node(textblock_id, split_index_in_textblock, p2_id)?;
@@ -445,6 +370,9 @@ fn insert_blocks_in_textblock(
         && blocks
             .last()
             .is_some_and(|b| same_textblock_type(&b.node, p2_id, tr));
+    // If one open textblock is both the first and last block, it receives both
+    // split halves instead of being applied once to each side.
+    let merge_end_into_start = merge_start && merge_end && blocks.len() == 1;
 
     let middle_start = if merge_start { 1 } else { 0 };
     let middle_end = if merge_end {
@@ -452,19 +380,21 @@ fn insert_blocks_in_textblock(
     } else {
         blocks.len()
     };
-    // When the same block participates as both first and last (single-block slice with
-    // both ends open and matching textblocks), only merge into the start to avoid
-    // double-applying its inline content.
-    let merge_end = merge_end && middle_end >= middle_start;
+    let merge_end = merge_end && !merge_end_into_start && middle_end >= middle_start;
 
     let mut last_caret: Option<Position> = None;
-    let mut inserted_start: Option<InsertedRangeEndpoint> = None;
-    let mut inserted_end: Option<InsertedRangeEndpoint> = None;
+    let mut inserted_range = InsertedRange::default();
 
     if merge_start {
         let first = blocks[0];
+        if textblock_was_empty && let Some(style) = first.style.clone() {
+            tr.set_node_style(textblock_id, Some(style))?;
+        }
         let inline = first.children.to_vec();
-        position_caret_at_textblock_end(tr, textblock_id)?;
+        tr.set_selection(Some(Selection::collapsed(position_at_end_of_block(
+            tr,
+            textblock_id,
+        )?)))?;
         let start = tr
             .selection()
             .expect("selection preserved through mutations")
@@ -475,10 +405,16 @@ fn insert_blocks_in_textblock(
             .expect("selection preserved through mutations")
             .head;
         if inserted {
-            inserted_start.get_or_insert(InsertedRangeEndpoint::Position(start));
-            inserted_end = Some(InsertedRangeEndpoint::Position(end));
+            inserted_range.include_position_range(start, end);
+            last_caret = Some(end);
         }
-        last_caret = Some(end);
+    }
+
+    if merge_end_into_start {
+        tr.merge_node(p2_id, textblock_id)?;
+        let caret = last_caret.unwrap_or(head);
+        compact_textblock_preserving_caret(tr, caret)?;
+        last_caret = tr.selection().map(|s| s.head);
     }
 
     for (insert_at, block) in
@@ -487,15 +423,16 @@ fn insert_blocks_in_textblock(
         let subtree = (*block).clone().into_subtree();
         let inserted_id = subtree.id;
         tr.insert_subtree(container_id, insert_at, subtree)?;
-        inserted_start.get_or_insert(InsertedRangeEndpoint::BeforeBlock(inserted_id));
-        inserted_end = Some(InsertedRangeEndpoint::AfterBlock(inserted_id));
-        last_caret = Some(position_at_end_of_block(tr, inserted_id));
+        inserted_range.include_block(inserted_id);
+        last_caret = Some(position_at_end_of_block(tr, inserted_id)?);
     }
 
     if merge_end {
         let last = blocks.last().unwrap();
         let inline = last.children.to_vec();
-        position_caret_at_textblock_start(tr, p2_id)?;
+        tr.set_selection(Some(Selection::collapsed(position_at_start_of_block(
+            tr, p2_id,
+        )?)))?;
         let start = tr
             .selection()
             .expect("selection preserved through mutations")
@@ -508,8 +445,7 @@ fn insert_blocks_in_textblock(
             .expect("selection preserved through mutations")
             .head;
         if inserted {
-            inserted_start.get_or_insert(InsertedRangeEndpoint::Position(start));
-            inserted_end = Some(InsertedRangeEndpoint::Position(end));
+            inserted_range.include_position_range(start, end);
         }
         last_caret = Some(end);
     }
@@ -558,11 +494,20 @@ fn insert_blocks_in_textblock(
             affinity: Affinity::Upstream,
         },
     };
-    let inserted_selection = inserted_start.zip(inserted_end).and_then(|(start, end)| {
-        let start = resolve_inserted_range_endpoint(tr, start)?;
-        let end = resolve_inserted_range_endpoint(tr, end)?;
-        Some(normalized_selection(tr, start, end))
-    });
+    let explicit_inserted_selection = inserted_range.selection(tr);
+    let split_boundary_selection = if explicit_inserted_selection.is_none()
+        && tr.doc().node(textblock_id).is_some()
+        && tr.doc().node(p2_id).is_some()
+    {
+        Some(normalized_selection(
+            tr,
+            position_at_end_of_block(tr, textblock_id)?,
+            position_at_start_of_block(tr, p2_id)?,
+        ))
+    } else {
+        None
+    };
+    let inserted_selection = explicit_inserted_selection.or(split_boundary_selection);
     tr.set_selection(Some(Selection::collapsed(final_pos)))?;
 
     Ok(inserted_selection)
@@ -573,77 +518,12 @@ fn normalized_selection(tr: &Transaction, anchor: Position, head: Position) -> S
     selection.normalize(&tr.doc()).unwrap_or(selection)
 }
 
-fn position_caret_at_textblock_end(
-    tr: &mut Transaction,
-    textblock_id: NodeId,
-) -> Result<(), CommandError> {
+fn position_at_end_of_block(tr: &Transaction, block_id: NodeId) -> Result<Position, CommandError> {
     let doc = tr.doc();
-    let tb = doc
-        .node(textblock_id)
-        .ok_or(CommandError::NodeNotFound(textblock_id))?;
-    let pos = match tb.last_child() {
-        Some(c) => match c.node() {
-            Node::Text(t) => Position {
-                node_id: c.id(),
-                offset: t.text.len(),
-                affinity: Affinity::Upstream,
-            },
-            _ => {
-                let child_count = tb.children().count();
-                Position {
-                    node_id: textblock_id,
-                    offset: child_count,
-                    affinity: Affinity::Upstream,
-                }
-            }
-        },
-        None => Position {
-            node_id: textblock_id,
-            offset: 0,
-            affinity: Affinity::Upstream,
-        },
-    };
-    drop(doc);
-    tr.set_selection(Some(Selection::collapsed(pos)))?;
-    Ok(())
-}
-
-fn position_caret_at_textblock_start(
-    tr: &mut Transaction,
-    textblock_id: NodeId,
-) -> Result<(), CommandError> {
-    let doc = tr.doc();
-    let tb = doc
-        .node(textblock_id)
-        .ok_or(CommandError::NodeNotFound(textblock_id))?;
-    let pos = match tb.first_child() {
-        Some(c) => match c.node() {
-            Node::Text(_) => Position {
-                node_id: c.id(),
-                offset: 0,
-                affinity: Affinity::Downstream,
-            },
-            _ => Position {
-                node_id: textblock_id,
-                offset: 0,
-                affinity: Affinity::Downstream,
-            },
-        },
-        None => Position {
-            node_id: textblock_id,
-            offset: 0,
-            affinity: Affinity::Downstream,
-        },
-    };
-    drop(doc);
-    tr.set_selection(Some(Selection::collapsed(pos)))?;
-    Ok(())
-}
-
-fn position_at_end_of_block(tr: &Transaction, block_id: NodeId) -> Position {
-    let doc = tr.doc();
-    let block = doc.node(block_id).expect("inserted block exists");
-    match block.last_child() {
+    let block = doc
+        .node(block_id)
+        .ok_or(CommandError::NodeNotFound(block_id))?;
+    let position = match block.last_child() {
         Some(c) => match c.node() {
             Node::Text(t) => Position {
                 node_id: c.id(),
@@ -664,37 +544,38 @@ fn position_at_end_of_block(tr: &Transaction, block_id: NodeId) -> Position {
             offset: 0,
             affinity: Affinity::Upstream,
         },
-    }
+    };
+    Ok(position)
 }
 
-fn insert_inline_at_block_boundary(
-    tr: &mut Transaction,
-    position: Position,
-    slice: &Slice,
-) -> Result<Option<Selection>, CommandError> {
-    let inline_clones: Vec<Fragment> = collect_inline(&slice.fragment)
-        .into_iter()
-        .cloned()
-        .collect();
-    if inline_clones.is_empty() {
-        return Ok(None);
-    }
-
-    let new_para_id = NodeId::new();
-    let para_subtree = Subtree::leaf(
-        new_para_id,
-        PlainNode::Paragraph(PlainParagraphNode::default()),
-    )
-    .with_style(source_paragraph_wrapper_style(slice));
-    tr.insert_subtree(position.node_id, position.offset, para_subtree)?;
-
-    position_caret_at_textblock_start(tr, new_para_id)?;
-    insert_inline_fragments(tr, inline_clones)?;
-    Ok(Some(selection_over_inserted_blocks(
-        position.node_id,
-        position.offset,
-        1,
-    )))
+fn position_at_start_of_block(
+    tr: &Transaction,
+    block_id: NodeId,
+) -> Result<Position, CommandError> {
+    let doc = tr.doc();
+    let block = doc
+        .node(block_id)
+        .ok_or(CommandError::NodeNotFound(block_id))?;
+    let position = match block.first_child() {
+        Some(c) => match c.node() {
+            Node::Text(_) => Position {
+                node_id: c.id(),
+                offset: 0,
+                affinity: Affinity::Downstream,
+            },
+            _ => Position {
+                node_id: block_id,
+                offset: 0,
+                affinity: Affinity::Downstream,
+            },
+        },
+        None => Position {
+            node_id: block_id,
+            offset: 0,
+            affinity: Affinity::Downstream,
+        },
+    };
+    Ok(position)
 }
 
 fn insert_blocks_at_block_boundary(
@@ -732,7 +613,7 @@ fn insert_blocks_at_block_boundary(
     })?;
 
     if let Some(id) = last_inserted {
-        let final_pos = position_at_end_of_block(tr, id);
+        let final_pos = position_at_end_of_block(tr, id)?;
         tr.set_selection(Some(Selection::collapsed(final_pos)))?;
     }
 
@@ -792,49 +673,16 @@ fn same_textblock_type(slice_node: &PlainNode, doc_node_id: NodeId, tr: &Transac
     let Some(doc_node) = doc.node(doc_node_id) else {
         return false;
     };
-    matches!(
-        (slice_node, doc_node.node()),
-        (PlainNode::Paragraph(_), Node::Paragraph(_))
-    )
+    let slice_type = slice_node.as_type();
+    Schema::node_spec(slice_type).is_textblock()
+        && doc_node.spec().is_textblock()
+        && slice_type == doc_node.as_type()
 }
 
 #[cfg(test)]
 mod tests {
     use editor_clipboard::Slice;
-    use editor_model::{Fragment, PlainNode, PlainParagraphNode, PlainRootNode, PlainTextNode};
-
-    use super::*;
-
-    fn root_with_paragraph(text: &str) -> Slice {
-        Slice {
-            fragment: Fragment {
-                node: PlainNode::Root(PlainRootNode::default()),
-                modifiers: vec![],
-                style: None,
-                children: vec![Fragment {
-                    node: PlainNode::Paragraph(PlainParagraphNode::default()),
-                    modifiers: vec![],
-                    style: None,
-                    children: vec![Fragment::leaf(PlainNode::Text(PlainTextNode {
-                        text: text.into(),
-                    }))],
-                }],
-            },
-            open_start: 2,
-            open_end: 2,
-        }
-    }
-
-    fn paragraph_fragment(text: &str) -> Fragment {
-        Fragment {
-            node: PlainNode::Paragraph(PlainParagraphNode::default()),
-            modifiers: vec![],
-            style: None,
-            children: vec![Fragment::leaf(PlainNode::Text(PlainTextNode {
-                text: text.into(),
-            }))],
-        }
-    }
+    use editor_model::{Fragment, PlainNode, PlainRootNode};
 
     #[test]
     fn empty_slice_helper_recognises_bare_container() {
@@ -844,26 +692,5 @@ mod tests {
             open_end: 0,
         };
         assert!(empty.is_empty());
-    }
-
-    #[test]
-    fn is_inline_only_classifies_single_paragraph_slice() {
-        let slice = root_with_paragraph("XY");
-        assert!(is_inline_only(&slice));
-    }
-
-    #[test]
-    fn is_inline_only_classifies_multi_paragraph_slice() {
-        let slice = Slice {
-            fragment: Fragment {
-                node: PlainNode::Root(PlainRootNode::default()),
-                modifiers: vec![],
-                style: None,
-                children: vec![paragraph_fragment("a"), paragraph_fragment("b")],
-            },
-            open_start: 2,
-            open_end: 2,
-        };
-        assert!(!is_inline_only(&slice));
     }
 }

--- a/crates/editor-core/src/handle/clipboard.rs
+++ b/crates/editor-core/src/handle/clipboard.rs
@@ -299,6 +299,77 @@ mod tests {
     }
 
     #[test]
+    fn paste_empty_paragraph_copy_into_text_middle_inserts_block() {
+        let (source, ..) = state! {
+            doc { r: root { paragraph {} } }
+            selection: (r, 0, >) -> (r, 1, <)
+        };
+        let payload = Slice::extract(&source).expect("non-collapsed").to_payload();
+        let (target, _t1) = state! {
+            doc { root { paragraph { t1: text("asd") } } }
+            selection: (t1, 1)
+        };
+        let mut editor = Editor::new_test(target);
+
+        editor.apply(Message::Clipboard {
+            op: ClipboardOp::Paste {
+                html: Some(payload.html),
+                text: payload.text,
+            },
+        });
+
+        let (expected, ..) = state! {
+            doc { root {
+                paragraph { text("a") }
+                p: paragraph {}
+                paragraph { text("sd") }
+            } }
+            selection: (p, 0)
+        };
+        assert_state_eq!(editor.state(), &expected);
+    }
+
+    #[test]
+    fn paste_open_empty_paragraph_range_into_text_middle_inserts_boundary() {
+        let (source, _p1, _t1) = state! {
+            doc { root {
+                p1: paragraph {}
+                paragraph { t1: text("asd") }
+                paragraph {}
+            } }
+            selection: (p1, 0, >) -> (t1, 0, <)
+        };
+        let payload = Slice::extract(&source).expect("non-collapsed").to_payload();
+        let (target, _t2) = state! {
+            doc { root {
+                paragraph {}
+                paragraph { t2: text("asd") }
+                paragraph {}
+            } }
+            selection: (t2, 1)
+        };
+        let mut editor = Editor::new_test(target);
+
+        editor.apply(Message::Clipboard {
+            op: ClipboardOp::Paste {
+                html: Some(payload.html),
+                text: payload.text,
+            },
+        });
+
+        let (expected, ..) = state! {
+            doc { root {
+                paragraph {}
+                paragraph { text("a") }
+                paragraph { t3: text("sd") }
+                paragraph {}
+            } }
+            selection: (t3, 0)
+        };
+        assert_state_eq!(editor.state(), &expected);
+    }
+
+    #[test]
     fn paste_crlf_text_does_not_fail() {
         let (s, ..) = state! {
             doc { root { paragraph { t1: text("") } } }


### PR DESCRIPTION
- 레거시와 비슷한 로직
- 단일 노드 내 inline text range를 slice로 extract할 때 paragraph/fold_title로 감싸고 open_start/end: 1
- slice/fragment의 openness를 활용한 일반화된 로직으로 slice를 삽입함
- empty paragraph 또는 text 없이 paragraph 경계만 복사해서 붙여넣는 것이 더 이상 no-op이 아님