### PR TITLE
TR-22 웹 모바일 뷰어 선택 핸들과 컨텍스트 메뉴 구현

### DIFF
--- a/apps/website/src/lib/editor-ffi/components/ContextMenuDesktop.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ContextMenuDesktop.svelte
@@ -9,6 +9,7 @@
   import SquareDashedIcon from '~icons/lucide/square-dashed';
   import { IS_MAC } from '$lib/editor-ffi/constants';
   import { getEditorContext } from '$lib/editor-ffi/editor.svelte';
+  import { getContextMenuCapabilityState } from './context-menu-state';
 
   const ctx = getEditorContext();
 
@@ -39,13 +40,20 @@
   const shiftKey = IS_MAC ? '⇧' : 'Shift+';
 
   const extraItems = $derived(ctx.editor?.contextMenu.extraItems ?? []);
+  const capabilityState = $derived(
+    getContextMenuCapabilityState({
+      isSelectionCollapsed: ctx.editor?.isSelectionCollapsed ?? true,
+      readOnly: ctx.editor?.readOnly ?? false,
+      protectContent: ctx.editor?.protectContent ?? false,
+    }),
+  );
 </script>
 
 {#if ctx.editor}
   <Menu {contextMenuPosition} offset={6} placement={contextMenuPlacement} bind:open>
     {#snippet children({ close })}
       <MenuItem
-        disabled={(ctx.editor?.isSelectionCollapsed ?? true) || !!(ctx.editor?.readOnly && ctx.editor?.protectContent)}
+        disabled={capabilityState.copyDisabled}
         icon={CopyIcon}
         onclick={() => {
           void ctx.editor?.requestCopy();
@@ -60,56 +68,56 @@
         {/snippet}
         복사
       </MenuItem>
-      {#if !ctx.editor?.readOnly}
-        <MenuItem
-          disabled={ctx.editor?.isSelectionCollapsed ?? true}
-          icon={ScissorsIcon}
-          onclick={() => {
-            void ctx.editor?.requestCut();
-            close();
-          }}
-        >
-          {#snippet suffix()}
-            <span class={css(shortcutStyle)}>
-              <span class={css(modKeyStyle)}>{modKey}</span>
-              X
-            </span>
-          {/snippet}
-          잘라내기
-        </MenuItem>
-        <MenuItem
-          icon={ClipboardPasteIcon}
-          onclick={() => {
-            void ctx.editor?.requestPaste();
-            close();
-          }}
-        >
-          {#snippet suffix()}
-            <span class={css(shortcutStyle)}>
-              <span class={css(modKeyStyle)}>{modKey}</span>
-              V
-            </span>
-          {/snippet}
-          붙여넣기
-        </MenuItem>
-        <MenuItem
-          icon={ClipboardTypeIcon}
-          onclick={() => {
-            void ctx.editor?.requestPasteTextOnly();
-            close();
-          }}
-        >
-          {#snippet suffix()}
-            <span class={css(shortcutStyle)}>
-              <span class={css(modKeyStyle)}>{modKey}</span>
-              <span>{shiftKey}</span>
-              V
-            </span>
-          {/snippet}
-          서식 없이 붙여넣기
-        </MenuItem>
-        <HorizontalDivider color="secondary" />
-      {/if}
+      <MenuItem
+        disabled={capabilityState.cutDisabled}
+        icon={ScissorsIcon}
+        onclick={() => {
+          void ctx.editor?.requestCut();
+          close();
+        }}
+      >
+        {#snippet suffix()}
+          <span class={css(shortcutStyle)}>
+            <span class={css(modKeyStyle)}>{modKey}</span>
+            X
+          </span>
+        {/snippet}
+        잘라내기
+      </MenuItem>
+      <MenuItem
+        disabled={capabilityState.pasteDisabled}
+        icon={ClipboardPasteIcon}
+        onclick={() => {
+          void ctx.editor?.requestPaste();
+          close();
+        }}
+      >
+        {#snippet suffix()}
+          <span class={css(shortcutStyle)}>
+            <span class={css(modKeyStyle)}>{modKey}</span>
+            V
+          </span>
+        {/snippet}
+        붙여넣기
+      </MenuItem>
+      <MenuItem
+        disabled={capabilityState.pasteDisabled}
+        icon={ClipboardTypeIcon}
+        onclick={() => {
+          void ctx.editor?.requestPasteTextOnly();
+          close();
+        }}
+      >
+        {#snippet suffix()}
+          <span class={css(shortcutStyle)}>
+            <span class={css(modKeyStyle)}>{modKey}</span>
+            <span>{shiftKey}</span>
+            V
+          </span>
+        {/snippet}
+        서식 없이 붙여넣기
+      </MenuItem>
+      <HorizontalDivider color="secondary" />
       <MenuItem
         icon={SquareDashedIcon}
         onclick={() => {

--- a/apps/website/src/lib/editor-ffi/components/ContextMenuTouch.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ContextMenuTouch.svelte
@@ -5,16 +5,25 @@
   import { scale } from 'svelte/transition';
   import { TAP_FEEDBACK_MIN_MS, TOUCH_MENU_GAP, TOUCH_MENU_VIEWPORT_PADDING } from '$lib/editor-ffi/constants';
   import { getEditorContext } from '$lib/editor-ffi/editor.svelte';
+  import { getContextMenuCapabilityState } from './context-menu-state';
 
   const ctx = getEditorContext();
 
-  let pressedAction = $state<'copy' | 'selectAll' | null>(null);
+  let pressedAction = $state<string | null>(null);
 
   const isTouchContextMenuOpen = $derived(!!ctx.editor && ctx.editor.contextMenu.isOpen && ctx.editor.contextMenu.source === 'touch');
   const contextMenuPosition = $derived(
     isTouchContextMenuOpen && ctx.editor ? { x: ctx.editor.contextMenu.x, y: ctx.editor.contextMenu.y } : null,
   );
   const contextMenuPlacement = $derived(ctx.editor?.contextMenu.placement ?? 'bottom');
+  const extraItems = $derived(ctx.editor?.contextMenu.extraItems ?? []);
+  const capabilityState = $derived(
+    getContextMenuCapabilityState({
+      isSelectionCollapsed: ctx.editor?.isSelectionCollapsed ?? true,
+      readOnly: ctx.editor?.readOnly ?? false,
+      protectContent: ctx.editor?.protectContent ?? false,
+    }),
+  );
 
   const { anchor: topAnchorAction, floating: topFloatingAction } = createFloatingActions({
     placement: 'top',
@@ -40,7 +49,7 @@
 
   const waitForTapFeedback = () => new Promise((resolve) => setTimeout(resolve, TAP_FEEDBACK_MIN_MS));
 
-  const runTouchMenuAction = async (action: 'copy' | 'selectAll', fn: () => void | Promise<void>) => {
+  const runTouchMenuAction = async (action: string, fn: () => void | Promise<void>) => {
     pressedAction = action;
     try {
       await fn();
@@ -64,6 +73,31 @@
     clearPressedAction();
     ctx.editor?.closeContextMenu();
   };
+
+  const buttonStyle = (action: string) =>
+    css(
+      {
+        appearance: 'none',
+        border: 'none',
+        background: 'transparent',
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: '36px',
+        paddingX: '14px',
+        borderRadius: 'full',
+        fontSize: '16px',
+        fontWeight: 'medium',
+        color: 'text.default',
+        whiteSpace: 'nowrap',
+        WebkitTapHighlightColor: 'transparent',
+        _active: { backgroundColor: 'surface.muted' },
+        _disabled: { opacity: '40', cursor: 'default' },
+      },
+      pressedAction === action && { backgroundColor: 'surface.muted' },
+    );
+
+  const dividerStyle = css({ width: '1px', alignSelf: 'stretch', marginY: '4px', backgroundColor: 'border.default' });
 </script>
 
 <svelte:window onpointerdowncapture={handleOutsidePointerDown} />
@@ -87,28 +121,8 @@
     transition:scale={{ start: 0.94, duration: 120 }}
   >
     <button
-      class={css(
-        {
-          appearance: 'none',
-          border: 'none',
-          background: 'transparent',
-          display: 'inline-flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          height: '36px',
-          paddingX: '14px',
-          borderRadius: 'full',
-          fontSize: '16px',
-          fontWeight: 'medium',
-          color: 'text.default',
-          whiteSpace: 'nowrap',
-          WebkitTapHighlightColor: 'transparent',
-          _active: { backgroundColor: 'surface.muted' },
-          _disabled: { opacity: '40', cursor: 'default' },
-        },
-        pressedAction === 'copy' && { backgroundColor: 'surface.muted' },
-      )}
-      disabled={ctx.editor?.isSelectionCollapsed ?? true}
+      class={buttonStyle('copy')}
+      disabled={capabilityState.copyDisabled}
       onblur={clearPressedAction}
       onclick={(e) => {
         e.stopPropagation();
@@ -126,29 +140,52 @@
     >
       복사
     </button>
-    <div class={css({ width: '1px', alignSelf: 'stretch', marginY: '4px', backgroundColor: 'border.default' })}></div>
+    <div class={dividerStyle}></div>
     <button
-      class={css(
-        {
-          appearance: 'none',
-          border: 'none',
-          background: 'transparent',
-          display: 'inline-flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          height: '36px',
-          paddingX: '14px',
-          borderRadius: 'full',
-          fontSize: '16px',
-          fontWeight: 'medium',
-          color: 'text.default',
-          whiteSpace: 'nowrap',
-          WebkitTapHighlightColor: 'transparent',
-          _active: { backgroundColor: 'surface.muted' },
-          _disabled: { opacity: '40', cursor: 'default' },
-        },
-        pressedAction === 'selectAll' && { backgroundColor: 'surface.muted' },
-      )}
+      class={buttonStyle('cut')}
+      disabled={capabilityState.cutDisabled}
+      onblur={clearPressedAction}
+      onclick={(e) => {
+        e.stopPropagation();
+        void runTouchMenuAction('cut', async () => {
+          await ctx.editor?.requestCut();
+        });
+      }}
+      onpointercancel={clearPressedAction}
+      onpointerdown={(e) => {
+        e.stopPropagation();
+        pressedAction = 'cut';
+      }}
+      onpointerleave={clearPressedAction}
+      type="button"
+    >
+      잘라내기
+    </button>
+    <div class={dividerStyle}></div>
+    <button
+      class={buttonStyle('paste')}
+      disabled={capabilityState.pasteDisabled}
+      onblur={clearPressedAction}
+      onclick={(e) => {
+        e.stopPropagation();
+        void runTouchMenuAction('paste', async () => {
+          await ctx.editor?.requestPaste();
+        });
+      }}
+      onpointercancel={clearPressedAction}
+      onpointerdown={(e) => {
+        e.stopPropagation();
+        pressedAction = 'paste';
+      }}
+      onpointerleave={clearPressedAction}
+      type="button"
+    >
+      붙여넣기
+    </button>
+    <div class={dividerStyle}></div>
+    <button
+      class={buttonStyle('selectAll')}
+      disabled={capabilityState.selectAllDisabled}
       onblur={clearPressedAction}
       onclick={(e) => {
         e.stopPropagation();
@@ -166,6 +203,28 @@
     >
       전체 선택
     </button>
+    {#each extraItems as item, i (i)}
+      <div class={dividerStyle}></div>
+      <button
+        class={buttonStyle(`extra-${i}`)}
+        onblur={clearPressedAction}
+        onclick={(e) => {
+          e.stopPropagation();
+          void runTouchMenuAction(`extra-${i}`, async () => {
+            await item.onclick();
+          });
+        }}
+        onpointercancel={clearPressedAction}
+        onpointerdown={(e) => {
+          e.stopPropagation();
+          pressedAction = `extra-${i}`;
+        }}
+        onpointerleave={clearPressedAction}
+        type="button"
+      >
+        {item.label}
+      </button>
+    {/each}
   </div>
 {/snippet}
 

--- a/apps/website/src/lib/editor-ffi/components/LineHighlight.svelte
+++ b/apps/website/src/lib/editor-ffi/components/LineHighlight.svelte
@@ -7,6 +7,8 @@
   const app = getAppContext();
 
   const show = $derived(!!editor?.focused && !!editor?.cursor);
+  // app is absent in the public viewer (no AppContext provider); fall back to off.
+  const lineHighlightEnabled = $derived(app?.preference.current.lineHighlightEnabled ?? false);
 
   const isPaginated = $derived(editor?.rootAttrs?.layout_mode.type === 'paginated');
 
@@ -34,7 +36,7 @@
   });
 </script>
 
-{#if app.preference.current.lineHighlightEnabled}
+{#if lineHighlightEnabled}
   <div
     bind:this={element}
     style:display={show ? 'block' : 'none'}

--- a/apps/website/src/lib/editor-ffi/components/SelectionHandles.svelte
+++ b/apps/website/src/lib/editor-ffi/components/SelectionHandles.svelte
@@ -1,0 +1,193 @@
+<script lang="ts">
+  import { css } from '@typie/styled-system/css';
+  import { getEditorContext } from '$lib/editor-ffi/editor.svelte';
+  import {
+    computeSelectionHandleVisual,
+    SELECTION_HANDLE_RADIUS as HANDLE_RADIUS,
+    SELECTION_HANDLE_STEM_WIDTH as STEM_WIDTH,
+    SELECTION_HANDLE_TOUCH_TARGET_SIZE as TOUCH_TARGET_SIZE,
+  } from '$lib/editor-ffi/gesture.svelte';
+  import type { SelectionHandleKind, SelectionHandleVisual } from '$lib/editor-ffi/gesture.svelte';
+
+  const ctx = getEditorContext();
+
+  const fromHandle = $derived.by(() => getHandleVisual('from'));
+  const toHandle = $derived.by(() => getHandleVisual('to'));
+
+  function getHandleVisual(type: SelectionHandleKind): SelectionHandleVisual | null {
+    const editor = ctx.editor;
+    if (!editor) {
+      return null;
+    }
+
+    // Read every reactive dependency BEFORE any early return. A $derived only
+    // tracks the state it reads during evaluation; if we bailed at the readOnly/
+    // touch/selection gate before touching these, the first (mount-time) run
+    // would capture no deps and the derived would never recompute when the
+    // selection later appears — leaving the handles frozen as null.
+    const selection = editor.selection;
+    void editor.displayZoom;
+    const pageEls = editor.pageEls;
+    const surfaceEl = editor.surfaceEl;
+
+    if (!editor.readOnly || !isTouchCapable() || !selection || !surfaceEl) {
+      return null;
+    }
+
+    const endpoints = editor.selectionEndpoints();
+    if (!endpoints) {
+      return null;
+    }
+
+    const endpoint = type === 'from' ? endpoints.from : endpoints.to;
+    const pageEl = pageEls[endpoint.page_idx];
+    if (!pageEl) {
+      return null;
+    }
+
+    return computeSelectionHandleVisual({
+      kind: type,
+      endpoint,
+      pageRect: pageEl.getBoundingClientRect(),
+      surfaceRect: surfaceEl.getBoundingClientRect(),
+      zoom: editor.safeDisplayZoom(),
+    });
+  }
+
+  function isTouchLikePointer(event: PointerEvent): boolean {
+    return event.pointerType === 'touch';
+  }
+
+  function isTouchCapable(): boolean {
+    return typeof navigator !== 'undefined' && navigator.maxTouchPoints > 0;
+  }
+
+  const handleStyle = css({
+    position: 'absolute',
+    zIndex: 'menu',
+    pointerEvents: 'auto',
+    touchAction: 'none',
+    background: 'transparent',
+    border: 'none',
+    padding: '0',
+    margin: '0',
+    WebkitTapHighlightColor: 'transparent',
+  });
+
+  const paintStyle = css({
+    position: 'absolute',
+    width: `${HANDLE_RADIUS * 2}px`,
+  });
+
+  const stemStyle = css({
+    position: 'absolute',
+    left: `${HANDLE_RADIUS - STEM_WIDTH / 2}px`,
+    width: `${STEM_WIDTH}px`,
+    backgroundColor: 'text.default',
+    borderRadius: 'full',
+  });
+
+  const circleStyle = css({
+    position: 'absolute',
+    width: `${HANDLE_RADIUS * 2}px`,
+    height: `${HANDLE_RADIUS * 2}px`,
+    borderRadius: 'full',
+    backgroundColor: 'text.default',
+  });
+
+  function handlePointerDown(type: SelectionHandleKind, event: PointerEvent) {
+    if (!isTouchLikePointer(event)) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    const target = event.currentTarget as HTMLElement;
+    if (!target.hasPointerCapture(event.pointerId)) {
+      target.setPointerCapture(event.pointerId);
+    }
+
+    ctx.editor?.gesture.handleSelectionHandlePointerDown(type, event);
+  }
+
+  function handlePointerMove(event: PointerEvent) {
+    if (!isTouchLikePointer(event)) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    ctx.editor?.gesture.handleSelectionHandlePointerMove(event);
+  }
+
+  function handlePointerUp(event: PointerEvent) {
+    if (!isTouchLikePointer(event)) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    const target = event.currentTarget as HTMLElement;
+    if (target.hasPointerCapture(event.pointerId)) {
+      target.releasePointerCapture(event.pointerId);
+    }
+
+    ctx.editor?.gesture.handleSelectionHandlePointerUp(event);
+  }
+</script>
+
+{#if fromHandle}
+  <button
+    style:left={`${fromHandle.left}px`}
+    style:top={`${fromHandle.top}px`}
+    style:width={`${TOUCH_TARGET_SIZE}px`}
+    style:height={`${fromHandle.touchHeight}px`}
+    class={handleStyle}
+    aria-label="Selection start handle"
+    data-pointer-capture
+    onpointercancel={handlePointerUp}
+    onpointerdown={(event) => handlePointerDown('from', event)}
+    onpointermove={handlePointerMove}
+    onpointerup={handlePointerUp}
+    type="button"
+  >
+    <div
+      style:left={`${fromHandle.paintLeft}px`}
+      style:top={`${fromHandle.paintTop}px`}
+      style:height={`${HANDLE_RADIUS * 2 + fromHandle.stemHeight}px`}
+      class={paintStyle}
+    >
+      <div style:top="0" class={circleStyle}></div>
+      <div style:top={`${HANDLE_RADIUS * 2}px`} style:height={`${fromHandle.stemHeight}px`} class={stemStyle}></div>
+    </div>
+  </button>
+{/if}
+
+{#if toHandle}
+  <button
+    style:left={`${toHandle.left}px`}
+    style:top={`${toHandle.top}px`}
+    style:width={`${TOUCH_TARGET_SIZE}px`}
+    style:height={`${toHandle.touchHeight}px`}
+    class={handleStyle}
+    aria-label="Selection end handle"
+    data-pointer-capture
+    onpointercancel={handlePointerUp}
+    onpointerdown={(event) => handlePointerDown('to', event)}
+    onpointermove={handlePointerMove}
+    onpointerup={handlePointerUp}
+    type="button"
+  >
+    <div
+      style:left={`${toHandle.paintLeft}px`}
+      style:top={`${toHandle.paintTop}px`}
+      style:height={`${HANDLE_RADIUS * 2 + toHandle.stemHeight}px`}
+      class={paintStyle}
+    >
+      <div style:top="0" style:height={`${toHandle.stemHeight}px`} class={stemStyle}></div>
+      <div style:top={`${toHandle.stemHeight}px`} class={circleStyle}></div>
+    </div>
+  </button>
+{/if}

--- a/apps/website/src/lib/editor-ffi/components/View.svelte
+++ b/apps/website/src/lib/editor-ffi/components/View.svelte
@@ -28,6 +28,7 @@
   import PlaceholderOverlay from './PlaceholderOverlay.svelte';
   import RepasteAsText from './RepasteAsText.svelte';
   import Scrollbar from './Scrollbar.svelte';
+  import SelectionHandles from './SelectionHandles.svelte';
   import EditorZoom from './ui/EditorZoom.svelte';
   import type { SystemStyleObject } from '@typie/styled-system/types';
   import type { Snippet } from 'svelte';
@@ -200,11 +201,13 @@
       <EditorZoom {active} editor={ctx.editor} {isPaginated} {pageWidth} viewportWidth={clientWidth ?? 0}>
         <!-- svelte-ignore a11y_click_events_have_key_events -->
         <div
+          bind:this={ctx.editor.surfaceEl}
           style:cursor
           style:min-width={editorMinWidth}
           style:max-width={continuousMaxFrameWidth}
           style:padding-bottom={`${ctx.scroll?.bottomPadding ?? 0}px`}
           class={css({
+            position: 'relative',
             display: 'flex',
             flexDirection: 'column',
             alignItems: 'center',
@@ -253,6 +256,10 @@
           <PlaceholderOverlay />
 
           <RepasteAsText />
+
+          {#if ctx.editor.readOnly}
+            <SelectionHandles />
+          {/if}
 
           <ContextMenu />
 

--- a/apps/website/src/lib/editor-ffi/components/context-menu-state.test.ts
+++ b/apps/website/src/lib/editor-ffi/components/context-menu-state.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { getContextMenuCapabilityState } from './context-menu-state';
+
+describe('getContextMenuCapabilityState', () => {
+  it('enables copy and cut for editable range selections', () => {
+    expect(
+      getContextMenuCapabilityState({
+        isSelectionCollapsed: false,
+        readOnly: false,
+        protectContent: false,
+      }),
+    ).toEqual({
+      copyDisabled: false,
+      cutDisabled: false,
+      pasteDisabled: false,
+      selectAllDisabled: false,
+    });
+  });
+
+  it('disables copy and cut when selection is collapsed', () => {
+    expect(
+      getContextMenuCapabilityState({
+        isSelectionCollapsed: true,
+        readOnly: false,
+        protectContent: false,
+      }),
+    ).toEqual({
+      copyDisabled: true,
+      cutDisabled: true,
+      pasteDisabled: false,
+      selectAllDisabled: false,
+    });
+  });
+
+  it('disables cut and paste in read-only mode', () => {
+    expect(
+      getContextMenuCapabilityState({
+        isSelectionCollapsed: false,
+        readOnly: true,
+        protectContent: false,
+      }),
+    ).toEqual({
+      copyDisabled: false,
+      cutDisabled: true,
+      pasteDisabled: true,
+      selectAllDisabled: false,
+    });
+  });
+
+  it('disables copy for protected read-only content', () => {
+    expect(
+      getContextMenuCapabilityState({
+        isSelectionCollapsed: false,
+        readOnly: true,
+        protectContent: true,
+      }),
+    ).toEqual({
+      copyDisabled: true,
+      cutDisabled: true,
+      pasteDisabled: true,
+      selectAllDisabled: false,
+    });
+  });
+});

--- a/apps/website/src/lib/editor-ffi/components/context-menu-state.ts
+++ b/apps/website/src/lib/editor-ffi/components/context-menu-state.ts
@@ -1,0 +1,23 @@
+export type ContextMenuCapabilityInput = {
+  isSelectionCollapsed: boolean;
+  readOnly: boolean;
+  protectContent: boolean;
+};
+
+export type ContextMenuCapabilityState = {
+  copyDisabled: boolean;
+  cutDisabled: boolean;
+  pasteDisabled: boolean;
+  selectAllDisabled: boolean;
+};
+
+export const getContextMenuCapabilityState = ({
+  isSelectionCollapsed,
+  readOnly,
+  protectContent,
+}: ContextMenuCapabilityInput): ContextMenuCapabilityState => ({
+  copyDisabled: isSelectionCollapsed || (readOnly && protectContent),
+  cutDisabled: isSelectionCollapsed || readOnly,
+  pasteDisabled: readOnly,
+  selectAllDisabled: false,
+});

--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -139,6 +139,7 @@ export class Editor {
 
   inputEl = $state<HTMLTextAreaElement>();
   pageEls = $state<Record<number, HTMLDivElement | undefined>>({});
+  surfaceEl = $state<HTMLDivElement>();
   scrollContainerEl = $state<HTMLDivElement>();
   displayZoom = $state(1);
   renderZoom = $state(1);

--- a/apps/website/src/lib/editor-ffi/gesture.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/gesture.svelte.ts
@@ -7,8 +7,10 @@ import {
 } from './constants';
 import { EditorEdgeAutoScroll } from './edge-auto-scroll';
 import { tryHandleInteractiveHit } from './handlers/pointer';
-import type { InputModifiers, Position, Selection, SelectionEndpoints } from '@typie/editor-ffi/browser';
+import type { InputModifiers, PageRect, Position, Selection, SelectionEndpoints } from '@typie/editor-ffi/browser';
 import type { Editor } from './editor.svelte';
+
+export type SelectionHandleKind = 'from' | 'to';
 
 export type TouchMenuPosition = {
   x: number;
@@ -69,7 +71,66 @@ export const computeTouchContextMenuPosition = ({
   };
 };
 
-type Phase = 'idle' | 'pressing' | 'tapMoved' | 'longPressed';
+export const SELECTION_HANDLE_RADIUS = 8;
+export const SELECTION_HANDLE_STEM_WIDTH = 2;
+export const SELECTION_HANDLE_TOUCH_TARGET_SIZE = 44;
+
+export type SelectionHandleVisual = {
+  left: number;
+  top: number;
+  touchHeight: number;
+  paintLeft: number;
+  paintTop: number;
+  stemHeight: number;
+};
+
+export type SelectionHandleVisualInput = {
+  kind: SelectionHandleKind;
+  endpoint: PageRect;
+  pageRect: DOMRect;
+  surfaceRect: DOMRect;
+  zoom: number;
+};
+
+export const computeSelectionHandleVisual = ({
+  kind,
+  endpoint,
+  pageRect,
+  surfaceRect,
+  zoom,
+}: SelectionHandleVisualInput): SelectionHandleVisual => {
+  const radius = SELECTION_HANDLE_RADIUS;
+  const stemWidth = SELECTION_HANDLE_STEM_WIDTH;
+  const touchTargetSize = SELECTION_HANDLE_TOUCH_TARGET_SIZE;
+
+  const anchorLeft = pageRect.left - surfaceRect.left + endpoint.rect.x * zoom;
+  const anchorTop = pageRect.top - surfaceRect.top + endpoint.rect.y * zoom;
+
+  const stemHeight = endpoint.rect.height * zoom;
+  const totalHeight = radius * 2 + stemHeight;
+  const touchHeight = Math.max(totalHeight, touchTargetSize);
+
+  const customPaintTop = kind === 'from' ? -(radius * 2) : 0;
+  const handleCenterY = customPaintTop + totalHeight / 2;
+  const touchTargetTop = handleCenterY - touchHeight / 2;
+
+  const handleXOffset = kind === 'from' ? -stemWidth / 2 : stemWidth / 2;
+  const touchTargetLeft = handleXOffset - touchTargetSize / 2;
+
+  const paintTop = customPaintTop - touchTargetTop;
+  const paintLeft = (touchTargetSize - radius * 2) / 2;
+
+  return {
+    left: anchorLeft + touchTargetLeft,
+    top: anchorTop + touchTargetTop,
+    touchHeight,
+    paintLeft,
+    paintTop,
+    stemHeight,
+  };
+};
+
+type Phase = 'idle' | 'pressing' | 'tapMoved' | 'longPressed' | 'handleDragging';
 
 type ResolvedTouchPoint = {
   page: number;
@@ -189,6 +250,44 @@ export class TouchGestureController {
     this.#reset();
   }
 
+  handleSelectionHandlePointerDown(type: SelectionHandleKind, e: PointerEvent): void {
+    const endpoints = this.#editor.selectionEndpoints();
+    if (!endpoints) return;
+
+    this.#activePointerId = e.pointerId;
+    this.#phase = 'handleDragging';
+    this.#lastClientPoint = { x: e.clientX, y: e.clientY };
+    this.#dragAnchor = type === 'from' ? endpoints.to_position : endpoints.from_position;
+    this.#baseSelection = undefined;
+    this.#pendingDown = null;
+    this.#selectionHit = false;
+    this.#clearLongPressTimer();
+    this.#editor.closeContextMenu();
+    this.#routeMoveToClientPoint(e.clientX, e.clientY);
+    this.#editor.flush();
+  }
+
+  handleSelectionHandlePointerMove(e: PointerEvent): void {
+    if (this.#phase !== 'handleDragging' || this.#activePointerId !== e.pointerId) return;
+
+    this.#lastClientPoint = { x: e.clientX, y: e.clientY };
+    if (this.#routeMoveToClientPoint(e.clientX, e.clientY)) {
+      this.#editor.flush();
+    }
+    this.#updateEdgeAutoScroll();
+  }
+
+  handleSelectionHandlePointerUp(e: PointerEvent): void {
+    if (this.#phase !== 'handleDragging' || this.#activePointerId !== e.pointerId) return;
+
+    this.#lastClientPoint = { x: e.clientX, y: e.clientY };
+    if (this.#routeMoveToClientPoint(e.clientX, e.clientY)) {
+      this.#editor.flush();
+    }
+    this.#requestTouchMenuOpen(this.#pressGeneration, this.#lastClientPoint);
+    this.#reset();
+  }
+
   destroy(): void {
     this.#clearLongPressTimer();
     this.#reset();
@@ -227,9 +326,11 @@ export class TouchGestureController {
   #requestTouchMenuOpen(generation: number, fallbackPoint: { x: number; y: number } | null = this.#lastClientPoint): void {
     if (generation !== this.#pressGeneration) return;
 
+    const extraItems = this.#collectTouchContextMenuItems(fallbackPoint);
+
     const endpoints = this.#editor.selectionEndpoints();
     if (!endpoints) {
-      this.#openTouchMenuAtFallback(fallbackPoint);
+      this.#openTouchMenuAtFallback(fallbackPoint, extraItems);
       return;
     }
 
@@ -250,7 +351,7 @@ export class TouchGestureController {
 
     const position = computeTouchContextMenuPosition({ endpoints, pageRects, zoom: this.#editor.safeDisplayZoom(), viewport });
     if (!position) {
-      this.#openTouchMenuAtFallback(fallbackPoint);
+      this.#openTouchMenuAtFallback(fallbackPoint, extraItems);
       return;
     }
 
@@ -259,12 +360,28 @@ export class TouchGestureController {
       y: position.y,
       source: 'touch',
       placement: position.placement,
+      extraItems,
     });
   }
 
-  #openTouchMenuAtFallback(point: { x: number; y: number } | null): void {
+  #openTouchMenuAtFallback(
+    point: { x: number; y: number } | null,
+    extraItems: ReturnType<Editor['collectContextMenuContributions']>,
+  ): void {
     if (!point) return;
-    this.#editor.openContextMenu({ x: point.x, y: point.y, source: 'touch', placement: 'bottom' });
+    this.#editor.openContextMenu({ x: point.x, y: point.y, source: 'touch', placement: 'bottom', extraItems });
+  }
+
+  #collectTouchContextMenuItems(point: { x: number; y: number } | null): ReturnType<Editor['collectContextMenuContributions']> {
+    if (!point) return [];
+
+    const local = this.#editor.clientToLocal(point.x, point.y);
+    const hit = local ? this.#editor.interactiveHitTest(local.page, local.x, local.y) : undefined;
+    return this.#editor.collectContextMenuContributions({
+      hit,
+      clientX: point.x,
+      clientY: point.y,
+    });
   }
 
   #flushDeferredDown(): boolean {
@@ -309,7 +426,7 @@ export class TouchGestureController {
   }
 
   #updateEdgeAutoScroll(): void {
-    if (this.#phase !== 'tapMoved' || !this.#lastClientPoint) {
+    if ((this.#phase !== 'tapMoved' && this.#phase !== 'handleDragging') || !this.#lastClientPoint) {
       this.#edgeAutoScroll.stop();
       return;
     }
@@ -319,7 +436,7 @@ export class TouchGestureController {
       { clientX: this.#lastClientPoint.x, clientY: this.#lastClientPoint.y },
       (clientX, clientY) => {
         this.#lastClientPoint = { x: clientX, y: clientY };
-        if (this.#phase === 'tapMoved' && this.#routeMoveToClientPoint(clientX, clientY)) {
+        if ((this.#phase === 'tapMoved' || this.#phase === 'handleDragging') && this.#routeMoveToClientPoint(clientX, clientY)) {
           this.#editor.flush();
         }
       },

--- a/apps/website/src/lib/editor-ffi/scroll.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/scroll.svelte.ts
@@ -62,10 +62,14 @@ export function setupEditorScroll(ctx: EditorContext): void {
       return;
     }
 
-    const scope = new EditorScrollScope(editor, () => ({
-      enabled: app.preference.current.typewriterEnabled,
-      position: app.preference.current.typewriterPosition,
-    }));
+    // app is absent in the public viewer (no AppContext provider); fall back to typewriter off.
+    const scope = new EditorScrollScope(editor, () => {
+      const preference = app?.preference.current;
+      return {
+        enabled: preference?.typewriterEnabled ?? false,
+        position: preference?.typewriterPosition,
+      };
+    });
     ctx.scroll = scope;
     editor.registerScrollIntoView((options) => scope.scrollIntoView(options));
 

--- a/apps/website/src/lib/editor-ffi/touch-gesture.test.ts
+++ b/apps/website/src/lib/editor-ffi/touch-gesture.test.ts
@@ -1,9 +1,15 @@
-import { describe, expect, it } from 'vitest';
-import { computeTouchContextMenuPosition } from './gesture.svelte';
-import type { SelectionEndpoints } from '@typie/editor-ffi/browser';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LONG_PRESS_MS } from './constants';
+import { computeSelectionHandleVisual, computeTouchContextMenuPosition, TouchGestureController } from './gesture.svelte';
+import type { PageRect, SelectionEndpoints } from '@typie/editor-ffi/browser';
 
 const pageRect = (left: number, top: number, width: number, height: number): DOMRect =>
   ({ left, top, width, height, right: left + width, bottom: top + height, x: left, y: top, toJSON: () => ({}) }) as DOMRect;
+
+const endpoint = (page_idx: number, x: number, y: number, width: number, height: number): PageRect => ({
+  page_idx,
+  rect: { x, y, width, height },
+});
 
 const viewport = (left: number, top: number, width: number, height: number) => ({ left, top, width, height });
 
@@ -107,5 +113,149 @@ describe('computeTouchContextMenuPosition', () => {
     });
     expect(result).not.toBeNull();
     expect(result?.x).toBe(125);
+  });
+});
+
+const makePointerEvent = ({
+  pointerId = 1,
+  clientX = 110,
+  clientY = 220,
+  isPrimary = true,
+}: { pointerId?: number; clientX?: number; clientY?: number; isPrimary?: boolean } = {}): PointerEvent =>
+  ({
+    pointerId,
+    clientX,
+    clientY,
+    isPrimary,
+    preventDefault: vi.fn(),
+  }) as unknown as PointerEvent;
+
+const createGestureEditor = () => {
+  const selection = endpoints(
+    { page_idx: 0, x: 100, y: 200, width: 50, height: 20 },
+    { page_idx: 0, x: 200, y: 200, width: 30, height: 20 },
+  );
+  const menuItems = [{ label: '링크 열기', onclick: vi.fn() }];
+
+  return {
+    selection,
+    readOnly: true,
+    pageSizes: [{ width: 800, height: 1000 }],
+    pageEls: {
+      0: {
+        getBoundingClientRect: () => pageRect(0, 0, 800, 1000),
+      },
+    },
+    safeDisplayZoom: vi.fn(() => 1),
+    selectionEndpoints: vi.fn(() => selection),
+    selectionHitTest: vi.fn(() => true),
+    interactiveHitTest: vi.fn(() => ({ type: 'text' })),
+    collectContextMenuContributions: vi.fn(() => menuItems),
+    openContextMenu: vi.fn(),
+    closeContextMenu: vi.fn(),
+    clientToLocal: vi.fn(() => ({ page: 0, x: 120, y: 220 })),
+    enqueue: vi.fn(),
+    flush: vi.fn(),
+  };
+};
+
+describe('TouchGestureController', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      cb(0);
+      return 1;
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('includes context menu contributions when long-press opens a touch menu on a selection', () => {
+    const editor = createGestureEditor();
+    const controller = new TouchGestureController(editor as never);
+
+    controller.handlePointerDown(makePointerEvent(), { page: 0, x: 120, y: 220 });
+    vi.advanceTimersByTime(LONG_PRESS_MS);
+
+    expect(editor.collectContextMenuContributions).toHaveBeenCalledWith({
+      hit: { type: 'text' },
+      clientX: 110,
+      clientY: 220,
+    });
+    expect(editor.openContextMenu).toHaveBeenCalledWith({
+      x: 165,
+      y: 200,
+      source: 'touch',
+      placement: 'top',
+      extraItems: [{ label: '링크 열기', onclick: expect.any(Function) }],
+    });
+  });
+
+  it('extends the selection from a dragged handle and reopens the touch menu on pointer up', () => {
+    const editor = createGestureEditor();
+    editor.clientToLocal = vi.fn(() => ({ page: 0, x: 250, y: 240 }));
+    const controller = new TouchGestureController(editor as never);
+
+    controller.handleSelectionHandlePointerDown('from', makePointerEvent({ clientX: 110, clientY: 220 }));
+    controller.handleSelectionHandlePointerMove(makePointerEvent({ clientX: 250, clientY: 240 }));
+    controller.handleSelectionHandlePointerUp(makePointerEvent({ clientX: 250, clientY: 240 }));
+
+    expect(editor.enqueue).toHaveBeenCalledWith({
+      type: 'selection',
+      op: {
+        type: 'extend_to',
+        anchor: editor.selection.to_position,
+        head_page: 0,
+        head_x: 250,
+        head_y: 240,
+        base_selection: undefined,
+      },
+    });
+    expect(editor.flush).toHaveBeenCalled();
+    expect(editor.openContextMenu).toHaveBeenLastCalledWith({
+      x: 165,
+      y: 200,
+      source: 'touch',
+      placement: 'top',
+      extraItems: [{ label: '링크 열기', onclick: expect.any(Function) }],
+    });
+  });
+});
+
+describe('computeSelectionHandleVisual', () => {
+  it('places the end (to) handle at the endpoint relative to the surface', () => {
+    const result = computeSelectionHandleVisual({
+      kind: 'to',
+      endpoint: endpoint(0, 200, 200, 30, 20),
+      pageRect: pageRect(0, 0, 800, 1000),
+      surfaceRect: pageRect(0, 0, 800, 1000),
+      zoom: 1,
+    });
+    expect(result).toEqual({ left: 179, top: 196, touchHeight: 44, paintLeft: 14, paintTop: 4, stemHeight: 20 });
+  });
+
+  it('places the start (from) handle above the line with its stem pointing down', () => {
+    const result = computeSelectionHandleVisual({
+      kind: 'from',
+      endpoint: endpoint(0, 100, 200, 50, 20),
+      pageRect: pageRect(0, 0, 800, 1000),
+      surfaceRect: pageRect(0, 0, 800, 1000),
+      zoom: 1,
+    });
+    expect(result).toEqual({ left: 77, top: 180, touchHeight: 44, paintLeft: 14, paintTop: 4, stemHeight: 20 });
+  });
+
+  it('offsets by the surface origin and scales by zoom', () => {
+    const result = computeSelectionHandleVisual({
+      kind: 'to',
+      endpoint: endpoint(0, 200, 200, 30, 20),
+      pageRect: pageRect(50, 100, 800, 1000),
+      surfaceRect: pageRect(10, 5, 800, 1000),
+      zoom: 2,
+    });
+    expect(result).toEqual({ left: 419, top: 495, touchHeight: 56, paintLeft: 14, paintTop: 0, stemHeight: 40 });
   });
 });

--- a/apps/website/src/routes/usersite/wildcard/[slug]/DocumentViewV2.svelte
+++ b/apps/website/src/routes/usersite/wildcard/[slug]/DocumentViewV2.svelte
@@ -23,6 +23,7 @@
   import { Img } from '$lib/components';
   import { Editor as EditorComponent } from '$lib/editor-ffi/components';
   import { Editor, setupEditorContext } from '$lib/editor-ffi/editor.svelte';
+  import { registerLinkContextMenu } from '$lib/editor-ffi/handlers/link';
   import { unwrapError } from '$lib/graphql';
   import { graphql } from '$mearie';
   import BodyUnavailable from './BodyUnavailable.svelte';
@@ -289,6 +290,12 @@
     if (ctx.editor) {
       ctx.editor.protectContent = document?.protectContent ?? false;
     }
+  });
+
+  $effect(() => {
+    const editor = ctx.editor;
+    if (!editor) return;
+    return registerLinkContextMenu(editor);
   });
 
   $effect(() => {


### PR DESCRIPTION
v2 공개 모바일 뷰어에 선택 핸들과 컨텍스트 메뉴가 없어 텍스트를 선택하거나   
선택 영역에 동작을 적용할 수 없던 문제를 해결했습니다.   
길게 누르면 단어를 선택해 그 위에 메뉴(복사·잘라내기·붙여넣기·전체 선택, 링크 위에서는 링크 열기)를 띄우고,   
양 끝 핸들을 끌어 범위를 조절하도록 했습니다.
핸들이 그려지지 않던 문제는 좌표 계산 derived가 선택 상태를 의존성으로 잡지 못한 게 원인이라   
반응형 읽기 순서를 바로잡아 해결했고, 공개 뷰어에서 본문이 먼저 렌더되도록 함께 보정했습니다. 