### PR TITLE
드롭다운 스타일 순서 정렬

### DIFF
--- a/apps/website/src/lib/editor-ffi/components/toolbar/ToolbarStyleSelect.svelte
+++ b/apps/website/src/lib/editor-ffi/components/toolbar/ToolbarStyleSelect.svelte
@@ -25,7 +25,13 @@
 
   const ctx = getEditorContext();
 
-  const styleEntries = $derived(ctx.editor?.styleEntries ?? []);
+  const styleEntries = $derived(
+    (ctx.editor?.styleEntries ?? []).toSorted((a, b) => {
+      if (a.id === 'base') return -1;
+      if (b.id === 'base') return 1;
+      return a.name.localeCompare(b.name);
+    }),
+  );
   const appliedStyle = $derived(ctx.editor?.appliedStyle);
   const currentStyleId = $derived(appliedStyle?.type === 'uniform' ? appliedStyle.value.value : undefined);
   const currentStyle = $derived(styleEntries.find((s) => s.id === currentStyleId));


### PR DESCRIPTION
`base` 를 가장 먼저, 나머지를 id 사전순으로 표시함
