### PR TITLE
TR-250 스타일 적용 후 문자 연속 입력할 때 첫 글자만 스타일이 적용되던 문제 수정

### DIFF
--- a/crates/editor-core/src/handle/text_input.rs
+++ b/crates/editor-core/src/handle/text_input.rs
@@ -16,14 +16,26 @@ use crate::message::*;
 fn replace_text_range(tr: &mut Transaction, start: usize, end: usize, text: &str) -> CommandResult {
     let doc = tr.doc();
     let replacement_modifiers = uniform_text_modifiers_in_range(&doc, start, end);
-    let start_pos = ResolvedPosition::from_flat(&doc, start)
-        .ok_or(CommandError::Corrupted("flat start unresolvable".into()))?;
-    let end_pos = ResolvedPosition::from_flat(&doc, end)
-        .ok_or(CommandError::Corrupted("flat end unresolvable".into()))?;
+    let resolve_selection_from_flat = || -> Result<Selection, CommandError> {
+        let start_pos = ResolvedPosition::from_flat(&doc, start)
+            .ok_or(CommandError::Corrupted("flat start unresolvable".into()))?;
+        let end_pos = ResolvedPosition::from_flat(&doc, end)
+            .ok_or(CommandError::Corrupted("flat end unresolvable".into()))?;
+        Ok(Selection::new((&start_pos).into(), (&end_pos).into()))
+    };
+    let current_selection_flat_range = |selection: Selection| -> Option<(usize, usize)> {
+        let anchor = selection.anchor.resolve(&doc)?.to_flat();
+        let head = selection.head.resolve(&doc)?.to_flat();
+        Some((anchor.min(head), anchor.max(head)))
+    };
+    let selection = tr
+        .selection()
+        .filter(|selection| current_selection_flat_range(*selection) == Some((start, end)))
+        .map_or_else(|| resolve_selection_from_flat(), Ok)?;
 
     commands::chain!(
         tr,
-        commands::set_selection(Selection::new((&start_pos).into(), (&end_pos).into())),
+        commands::set_selection(selection),
         commands::optional!(commands::ensure_paragraph()),
         commands::optional!(commands::delete_selection()),
         |tr| apply_replacement_modifiers(tr, text, replacement_modifiers.as_deref()),
@@ -784,6 +796,7 @@ pub fn handle_flat_ime_ops(editor: &mut Editor, ops: Vec<FlatImeOp>) -> Result<(
 #[cfg(test)]
 mod tests {
     use editor_macros::state;
+    use editor_model::Modifier;
     use editor_state::assert_state_eq;
 
     use super::*;
@@ -1639,6 +1652,26 @@ mod tests {
         editor
     }
 
+    fn paragraph_run_texts_and_styles(editor: &Editor) -> Vec<(String, Option<String>)> {
+        let paragraph = editor
+            .state()
+            .doc
+            .root()
+            .expect("root exists")
+            .children()
+            .next()
+            .expect("paragraph exists");
+        paragraph
+            .children()
+            .filter_map(|child| match child.node() {
+                editor_model::Node::Text(text) => {
+                    Some((text.text.to_string(), child.entry().style.get().clone()))
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
     #[test]
     fn flat_ime_text_replacement() {
         let (s, ..) = state! {
@@ -1665,6 +1698,65 @@ mod tests {
             selection: (t1, 1)
         };
         assert_state_eq!(editor.state(), &expected);
+    }
+
+    #[test]
+    fn flat_ime_repeated_insert_preserves_style_run_affinity() {
+        let (s, ..) = state! {
+            doc { root { paragraph { t1: text("ac") } } }
+            selection: (t1, 1)
+        };
+        let mut editor = editor_with_resource(s);
+        editor.apply(Message::Style {
+            op: StyleOp::Define {
+                style_id: "green".into(),
+                name: "Green".into(),
+                modifiers: vec![Modifier::TextColor {
+                    value: "#00ff00".into(),
+                }],
+            },
+        });
+        editor.apply(Message::Style {
+            op: StyleOp::ApplyToSelection {
+                style_id: "green".into(),
+            },
+        });
+
+        editor.apply(Message::TextInput {
+            ops: vec![FlatImeOp::ReplaceSelection { text: "f".into() }],
+        });
+        assert_eq!(
+            paragraph_run_texts_and_styles(&editor),
+            vec![
+                ("a".into(), None),
+                ("f".into(), Some("green".into())),
+                ("c".into(), None),
+            ]
+        );
+        let current_flat = editor
+            .state()
+            .selection
+            .and_then(|selection| selection.head.resolve(&editor.state().doc))
+            .map(|pos| pos.to_flat())
+            .expect("selection head resolves to flat");
+        editor.apply(Message::TextInput {
+            ops: vec![
+                FlatImeOp::SetSelection {
+                    start: current_flat,
+                    end: current_flat,
+                },
+                FlatImeOp::ReplaceSelection { text: "f".into() },
+            ],
+        });
+
+        assert_eq!(
+            paragraph_run_texts_and_styles(&editor),
+            vec![
+                ("a".into(), None),
+                ("ff".into(), Some("green".into())),
+                ("c".into(), None),
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
스타일 적용 후 글자를 연속 입력할 때 첫 글자만 새 스타일로 들어가고 이후 글자부터 기존 스타일로 입력되던 문제를 수정했습니다.   
스타일 적용 자체에는 문제가 없었고, 입력 중 selection을 flat offset 기준으로 다시 복원하는 과정에서   
커서가 스타일 run 경계에서 앞쪽 run으로 붙는 것이 원인이었습니다.   
이번에는 같은 flat range를 다시 처리할 때 기존 selection을 그대로 사용하도록 해서   
입력 중에도 커서 위치가 유지되도록 했습니다.