### PR TITLE
fix: 서로 다른 폰트 크기 경계에서 입력 시 직후 노드의 크기가 적용되는 문제 수정

### DIFF
--- a/crates/editor-commands/src/helpers/modifiers.rs
+++ b/crates/editor-commands/src/helpers/modifiers.rs
@@ -27,7 +27,8 @@ pub(crate) fn resolve_base_modifiers(node: &NodeRef, offset: usize) -> Vec<Modif
                 return node.modifiers().cloned().collect();
             }
 
-            node.modifiers()
+            let mut out: Vec<Modifier> = node
+                .modifiers()
                 .filter(|m| {
                     let expand = &m.spec().expand;
                     match expand {
@@ -38,10 +39,35 @@ pub(crate) fn resolve_base_modifiers(node: &NodeRef, offset: usize) -> Vec<Modif
                     }
                 })
                 .cloned()
-                .collect()
+                .collect();
+
+            if at_start {
+                fold_prev_sibling_carryover(node, &mut out);
+            }
+
+            out
         }
         Node::Paragraph(_) => node.modifiers().cloned().collect(),
         _ => vec![],
+    }
+}
+
+fn fold_prev_sibling_carryover(node: &NodeRef, out: &mut Vec<Modifier>) {
+    let Some(prev) = node.prev_sibling() else {
+        return;
+    };
+    if !matches!(prev.node(), Node::Text(_)) {
+        return;
+    }
+    for m in prev.modifiers() {
+        if !matches!(m.spec().expand, Expand::After | Expand::Both) {
+            continue;
+        }
+        let t = m.as_type();
+        if out.iter().any(|e| e.as_type() == t) {
+            continue;
+        }
+        out.push(m.clone());
     }
 }
 
@@ -709,5 +735,84 @@ mod tests {
         assert!(is_tab_metric_modifier(ModifierType::LetterSpacing));
         assert!(!is_tab_metric_modifier(ModifierType::Bold));
         assert!(!is_tab_metric_modifier(ModifierType::TextColor));
+    }
+
+    #[test]
+    fn boundary_at_start_of_next_text_inherits_preceding_font_size() {
+        let (state, ..) = state! {
+            doc { root { paragraph {
+                t1: text("hello") [font_size(3000)]
+                t2: text("world") [font_size(1200)]
+            } } }
+            selection: (t2, 0)
+        };
+        let node = node_at(&state);
+        let result = resolve_effective_modifiers(&node, 0, &state.pending_modifiers);
+        assert!(
+            result
+                .iter()
+                .any(|m| matches!(m, Modifier::FontSize { value: 3000 })),
+            "preceding sibling's font_size must carry to caret at start of next text"
+        );
+        assert!(
+            !result
+                .iter()
+                .any(|m| matches!(m, Modifier::FontSize { value: 1200 })),
+            "current node's Expand::After modifier must not appear at offset 0"
+        );
+    }
+
+    #[test]
+    fn boundary_at_start_does_not_double_count_existing_modifier_type() {
+        let (state, ..) = state! {
+            doc { root { paragraph {
+                t1: text("hello") [bold]
+                t2: text("world") [bold]
+            } } }
+            selection: (t2, 0)
+        };
+        let node = node_at(&state);
+        let result = resolve_effective_modifiers(&node, 0, &state.pending_modifiers);
+        let bolds = result
+            .iter()
+            .filter(|m| matches!(m, Modifier::Bold))
+            .count();
+        assert_eq!(bolds, 1, "prev sibling carryover must not duplicate types");
+    }
+
+    #[test]
+    fn boundary_at_start_excludes_link_from_preceding_sibling() {
+        let (state, ..) = state! {
+            doc { root { paragraph {
+                t1: text("Click") [link(href: "https://example.com".to_string())]
+                t2: text("World")
+            } } }
+            selection: (t2, 0)
+        };
+        let node = node_at(&state);
+        let result = resolve_effective_modifiers(&node, 0, &state.pending_modifiers);
+        assert!(
+            !result.iter().any(|m| matches!(m, Modifier::Link { .. })),
+            "Expand::None modifiers must not bleed across sibling boundary"
+        );
+    }
+
+    #[test]
+    fn boundary_skips_fold_when_prev_sibling_is_not_text() {
+        let (state, ..) = state! {
+            doc { root { paragraph {
+                hard_break {}
+                t2: text("world") [font_size(3000)]
+            } } }
+            selection: (t2, 0)
+        };
+        let node = node_at(&state);
+        let result = resolve_effective_modifiers(&node, 0, &state.pending_modifiers);
+        assert!(
+            !result
+                .iter()
+                .any(|m| matches!(m, Modifier::FontSize { value: 3000 })),
+            "non-text prev sibling must not trigger carryover"
+        );
     }
 }

--- a/crates/editor-state/src/modifier_resolution.rs
+++ b/crates/editor-state/src/modifier_resolution.rs
@@ -35,7 +35,8 @@ fn resolve_base_modifiers(node: &NodeRef, offset: usize) -> Vec<Modifier> {
                 return node.own_modifiers().cloned().collect::<Vec<_>>();
             }
 
-            node.own_modifiers()
+            let mut out: Vec<Modifier> = node
+                .own_modifiers()
                 .filter(|m| {
                     let expand = &m.spec().expand;
                     match expand {
@@ -46,7 +47,13 @@ fn resolve_base_modifiers(node: &NodeRef, offset: usize) -> Vec<Modifier> {
                     }
                 })
                 .cloned()
-                .collect()
+                .collect();
+
+            if at_start {
+                fold_prev_sibling_carryover_own(node, &mut out);
+            }
+
+            out
         }
         Node::Paragraph(_) => {
             let mut seen: Vec<ModifierType> = Vec::new();
@@ -107,6 +114,25 @@ fn resolve_base_modifiers(node: &NodeRef, offset: usize) -> Vec<Modifier> {
             out
         }
         _ => vec![],
+    }
+}
+
+fn fold_prev_sibling_carryover_own(node: &NodeRef, out: &mut Vec<Modifier>) {
+    let Some(prev) = node.prev_sibling() else {
+        return;
+    };
+    if !matches!(prev.node(), Node::Text(_)) {
+        return;
+    }
+    for m in prev.own_modifiers() {
+        if !matches!(m.spec().expand, Expand::After | Expand::Both) {
+            continue;
+        }
+        let t = m.as_type();
+        if out.iter().any(|e| e.as_type() == t) {
+            continue;
+        }
+        out.push(m.clone());
     }
 }
 
@@ -1308,6 +1334,85 @@ mod tests {
             !eff.iter()
                 .any(|m| matches!(m, Modifier::LineHeight { value: 200 })),
             "block modifier from style must not surface"
+        );
+    }
+
+    #[test]
+    fn boundary_at_start_of_next_text_inherits_preceding_font_size() {
+        let (state, ..) = state! {
+            doc { root { paragraph {
+                t1: text("hello") [font_size(3000)]
+                t2: text("world") [font_size(1200)]
+            } } }
+            selection: (t2, 0)
+        };
+        let head = state.selection.as_ref().unwrap().head;
+        let result = resolve_effective_modifiers_at(&state, &head);
+        assert!(
+            result
+                .iter()
+                .any(|m| matches!(m, Modifier::FontSize { value: 3000 })),
+            "preceding sibling's font_size must carry to caret at start of next text"
+        );
+        assert!(
+            !result
+                .iter()
+                .any(|m| matches!(m, Modifier::FontSize { value: 1200 })),
+            "current node's Expand::After modifier must not appear at offset 0"
+        );
+    }
+
+    #[test]
+    fn boundary_at_start_does_not_double_count_existing_modifier_type() {
+        let (state, ..) = state! {
+            doc { root { paragraph {
+                t1: text("hello") [bold]
+                t2: text("world") [bold]
+            } } }
+            selection: (t2, 0)
+        };
+        let head = state.selection.as_ref().unwrap().head;
+        let result = resolve_effective_modifiers_at(&state, &head);
+        let bolds = result
+            .iter()
+            .filter(|m| matches!(m, Modifier::Bold))
+            .count();
+        assert_eq!(bolds, 1, "prev sibling carryover must not duplicate types");
+    }
+
+    #[test]
+    fn boundary_at_start_excludes_link_from_preceding_sibling() {
+        let (state, ..) = state! {
+            doc { root { paragraph {
+                t1: text("Click") [link(href: "https://example.com".to_string())]
+                t2: text("World")
+            } } }
+            selection: (t2, 0)
+        };
+        let head = state.selection.as_ref().unwrap().head;
+        let result = resolve_effective_modifiers_at(&state, &head);
+        assert!(
+            !result.iter().any(|m| matches!(m, Modifier::Link { .. })),
+            "Expand::None modifiers must not bleed across sibling boundary"
+        );
+    }
+
+    #[test]
+    fn boundary_skips_fold_when_prev_sibling_is_not_text() {
+        let (state, ..) = state! {
+            doc { root { paragraph {
+                hard_break {}
+                t2: text("world") [font_size(3000)]
+            } } }
+            selection: (t2, 0)
+        };
+        let head = state.selection.as_ref().unwrap().head;
+        let result = resolve_effective_modifiers_at(&state, &head);
+        assert!(
+            !result
+                .iter()
+                .any(|m| matches!(m, Modifier::FontSize { value: 3000 })),
+            "non-text prev sibling must not trigger carryover"
         );
     }
 }


### PR DESCRIPTION
 인접 텍스트 노드 경계에서 직전 텍스트의 `Expand::After | Both` modifier를 caret 위치까지 fold 하는 `fold_prev_sibling_carryover` 단계를 추가.        
  
  - 직전 텍스트가 없거나 비텍스트 노드(예: `hard_break`)면 미적용              
  - 동일 `ModifierType`이 이미 base에 있으면 중복 추가하지 않음
  - `Expand::None`(예: Link)은 경계를 넘기지 않도록 제외            