### PR TITLE
paragraph break

### DIFF
--- a/crates/editor-clipboard/src/slice.rs
+++ b/crates/editor-clipboard/src/slice.rs
@@ -203,6 +203,7 @@ fn extract_cell_rect(rect: &CellRect<'_>) -> Slice {
 mod tests {
     use super::*;
     use editor_macros::state;
+    use editor_model::Modifier;
     use editor_resource::Resource;
 
     fn set_run_style(state: State, run_id: editor_model::NodeId, style_id: &str) -> State {
@@ -367,6 +368,98 @@ mod tests {
             editor_model::PlainNode::Root(_)
         ));
         assert_eq!(slice.fragment.children.len(), 2);
+    }
+
+    #[test]
+    fn extract_paragraph_break_only_preserves_plain_text_separator() {
+        let (s, ..) = state! {
+            doc { root {
+                paragraph { t1: text("a") }
+                paragraph { t2: text("b") }
+            } }
+            selection: (t1, 1) -> (t2, 0)
+        };
+        let slice = Slice::extract(&s).expect("non-collapsed");
+        assert!(matches!(slice.fragment.node, PlainNode::Root(_)));
+        assert_eq!(slice.fragment.children.len(), 2);
+        assert!(
+            slice
+                .fragment
+                .children
+                .iter()
+                .all(|child| matches!(child.node, PlainNode::Paragraph(_)))
+        );
+        assert_eq!(slice.to_text(), "\n\n");
+    }
+
+    #[test]
+    fn extract_paragraph_break_only_preserves_paragraph_modifiers() {
+        let (s, ..) = state! {
+            doc { root {
+                paragraph [bold] { t1: text("a") }
+                paragraph [italic] { t2: text("b") }
+            } }
+            selection: (t1, 1) -> (t2, 0)
+        };
+        let slice = Slice::extract(&s).expect("non-collapsed");
+
+        assert_eq!(slice.fragment.children.len(), 2);
+        assert!(
+            slice.fragment.children[0]
+                .modifiers
+                .iter()
+                .any(|m| matches!(m, Modifier::Bold))
+        );
+        assert!(
+            slice.fragment.children[1]
+                .modifiers
+                .iter()
+                .any(|m| matches!(m, Modifier::Italic))
+        );
+    }
+
+    #[test]
+    fn extract_empty_paragraph_break_before_non_paragraph_copies_empty_paragraph() {
+        let (s, p1, ..) = state! {
+            doc { root {
+                p1: paragraph {}
+                image
+                paragraph {}
+            } }
+            selection: none
+        };
+        let selection = editor_state::paragraph_break_selection_at_paragraph_end(
+            &s.doc,
+            editor_state::Position::new(p1, 0),
+        )
+        .expect("empty paragraph has break");
+        let s = State {
+            selection: Some(selection),
+            ..s
+        };
+
+        let slice = Slice::extract(&s).expect("non-collapsed");
+
+        assert!(matches!(slice.fragment.node, PlainNode::Root(_)));
+        assert_eq!(slice.open_start, 1);
+        assert_eq!(slice.open_end, 0);
+        assert_eq!(slice.fragment.children.len(), 1);
+        let paragraph = &slice.fragment.children[0];
+        assert!(matches!(paragraph.node, PlainNode::Paragraph(_)));
+        assert!(paragraph.children.is_empty());
+    }
+
+    #[test]
+    fn extract_range_starting_with_paragraph_break_preserves_plain_text_separator() {
+        let (s, ..) = state! {
+            doc { root {
+                paragraph { t1: text("a") }
+                paragraph { t2: text("bc") }
+            } }
+            selection: (t1, 1) -> (t2, 1)
+        };
+        let slice = Slice::extract(&s).expect("non-collapsed");
+        assert_eq!(slice.to_text(), "\n\nb");
     }
 
     #[test]

--- a/crates/editor-clipboard/src/text/serialize.rs
+++ b/crates/editor-clipboard/src/text/serialize.rs
@@ -1,52 +1,54 @@
 use crate::slice::Slice;
-use editor_model::{Fragment, PlainNode};
+use editor_model::{Fragment, PlainNode, Schema};
 
 pub fn to_text(slice: &Slice) -> String {
     let mut out = String::new();
-    walk(&slice.fragment, &mut out);
+    let mut context = TextContext::default();
+    walk(&slice.fragment, &mut out, &mut context);
     out
 }
 
-fn walk(fragment: &Fragment, out: &mut String) {
+#[derive(Default)]
+struct TextContext {
+    seen_textblock: bool,
+}
+
+fn walk(fragment: &Fragment, out: &mut String, context: &mut TextContext) {
     match &fragment.node {
         PlainNode::Text(t) => out.push_str(&t.text),
         PlainNode::HardBreak(_) => out.push('\n'),
         PlainNode::Tab(_) => out.push('\t'),
-        PlainNode::Table(_) => walk_table(fragment, out),
+        PlainNode::Table(_) => walk_table(fragment, out, context),
         _ => {
-            let is_block = is_block_node(&fragment.node);
-            let first_in_block = is_block && !out.is_empty() && !out.ends_with("\n\n");
-            if first_in_block {
-                if out.ends_with('\n') {
-                    out.push('\n');
-                } else {
-                    out.push_str("\n\n");
-                }
+            if is_textblock_node(&fragment.node) {
+                separate_textblock(out, context);
             }
             for child in &fragment.children {
-                walk(child, out);
+                walk(child, out, context);
             }
         }
     }
 }
 
-fn is_block_node(n: &PlainNode) -> bool {
-    !matches!(
-        n,
-        PlainNode::Text(_) | PlainNode::HardBreak(_) | PlainNode::Tab(_)
-    )
+fn is_textblock_node(n: &PlainNode) -> bool {
+    Schema::node_spec(n.as_type()).is_textblock()
 }
 
-// TSV-style emission: tabs between cells, newlines between rows. Cell content
-// is flattened to inline text so multi-block cells don't shred the row layout.
-fn walk_table(table: &Fragment, out: &mut String) {
-    if !out.is_empty() && !out.ends_with("\n\n") {
+fn separate_textblock(out: &mut String, context: &mut TextContext) {
+    if context.seen_textblock && !out.ends_with("\n\n") {
         if out.ends_with('\n') {
             out.push('\n');
         } else {
             out.push_str("\n\n");
         }
     }
+    context.seen_textblock = true;
+}
+
+// TSV-style emission: tabs between cells, newlines between rows. Cell content
+// is flattened to inline text so multi-block cells don't shred the row layout.
+fn walk_table(table: &Fragment, out: &mut String, context: &mut TextContext) {
+    separate_textblock(out, context);
     let mut first_row = true;
     for row in &table.children {
         if !matches!(row.node, PlainNode::TableRow(_)) {
@@ -110,6 +112,12 @@ mod tests {
         };
         let slice = Slice::extract(&s).unwrap();
         assert_eq!(slice.to_text(), "first\nline\n\nsecond");
+    }
+
+    #[test]
+    fn to_text_preserves_empty_paragraph_separator() {
+        let slice = Slice::from_text("\n\n");
+        assert_eq!(slice.to_text(), "\n\n");
     }
 
     #[test]

--- a/crates/editor-commands/src/commands/delete_selection.rs
+++ b/crates/editor-commands/src/commands/delete_selection.rs
@@ -387,6 +387,65 @@ mod tests {
     }
 
     #[test]
+    fn delete_empty_paragraph_break_before_non_paragraph_removes_empty_owner() {
+        let (initial, ..) = state! {
+            doc { r: root {
+                p1: paragraph {}
+                callout { paragraph { t2: text("callout") } }
+                paragraph { t3: text("tail") }
+            } }
+            selection: (p1, 0) -> (r, 1, <)
+        };
+        let (actual, ..) = transact!(initial, |tr| delete_selection(&mut tr));
+        let (expected, ..) = state! {
+            doc { root {
+                callout { paragraph { t2: text("callout") } }
+                paragraph { t3: text("tail") }
+            } }
+            selection: (t2, 0)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn delete_empty_paragraph_break_before_paragraph_keeps_next_paragraph_identity() {
+        let (initial, ..) = state! {
+            doc { root {
+                p1: paragraph {}
+                p2: paragraph { t2: text("next") }
+            } }
+            selection: (p1, 0) -> (t2, 0)
+        };
+        let (actual, ..) = transact!(initial, |tr| delete_selection(&mut tr));
+        let (expected, ..) = state! {
+            doc { root {
+                p2: paragraph { t2: text("next") }
+            } }
+            selection: (t2, 0)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn delete_range_containing_empty_paragraph_break_keeps_non_empty_paragraph_identity() {
+        let (initial, ..) = state! {
+            doc { root {
+                p1: paragraph {}
+                p2: paragraph { t2: text("next") }
+            } }
+            selection: (p1, 0) -> (t2, 2)
+        };
+        let (actual, ..) = transact!(initial, |tr| delete_selection(&mut tr));
+        let (expected, ..) = state! {
+            doc { root {
+                p2: paragraph { t2: text("xt") }
+            } }
+            selection: (t2, 0)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
     fn delete_selected_trailing_empty_paragraph_after_textblock_creates_new_trailing_paragraph() {
         let (initial, ..) = state! {
             doc { r1: root {

--- a/crates/editor-commands/src/commands/insert_slice.rs
+++ b/crates/editor-commands/src/commands/insert_slice.rs
@@ -112,6 +112,24 @@ mod tests {
     }
 
     #[test]
+    fn insert_paragraph_break_slice_into_paragraph_middle_splits_once() {
+        let (initial, ..) = state! {
+            doc { root { paragraph { t1: text("asd") } } }
+            selection: (t1, 1)
+        };
+        let slice = Slice::from_text("\n\n");
+        let (actual, ..) = transact!(initial, |tr| insert_slice(&mut tr, slice));
+        let (expected, ..) = state! {
+            doc { root {
+                paragraph { t1: text("a") }
+                paragraph { t2: text("sd") }
+            } }
+            selection: (t2, 0)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
     fn insert_open_paragraph_at_block_boundary_inserts_paragraph() {
         let (initial, ..) = state! {
             doc { r: root {

--- a/crates/editor-commands/src/helpers/deletion.rs
+++ b/crates/editor-commands/src/helpers/deletion.rs
@@ -1,5 +1,5 @@
-use editor_model::{Doc, Node, NodeId, PlainNode, PlainParagraphNode, Subtree};
-use editor_state::{Affinity, Position, Selection};
+use editor_model::{Doc, Node, NodeId, NodeRef, PlainNode, PlainParagraphNode, Subtree};
+use editor_state::{Affinity, Position, Selection, paragraph_break_selection_at_paragraph_end};
 use editor_transaction::{Transaction, compact, fulfill, prune};
 
 use super::{
@@ -40,6 +40,7 @@ pub(crate) fn selection_for_node(
 }
 
 pub(crate) fn delete_selection_range(tr: &mut Transaction, selection: Selection) -> CommandResult {
+    let selection = lower_exact_empty_paragraph_break_delete_range(&tr.doc(), selection);
     if selection.is_collapsed() {
         return Ok(false);
     }
@@ -175,6 +176,41 @@ pub(crate) fn delete_selection_range(tr: &mut Transaction, selection: Selection)
         apply_first_text_marker_lift(tr, &captured)?;
     }
     Ok(true)
+}
+
+fn lower_exact_empty_paragraph_break_delete_range(doc: &Doc, selection: Selection) -> Selection {
+    let Some(resolved) = selection.resolve(doc) else {
+        return selection;
+    };
+    let from = Position::from(resolved.from());
+    let to = Position::from(resolved.to());
+    let Some(paragraph_break) = paragraph_break_selection_at_paragraph_end(doc, from) else {
+        return selection;
+    };
+    if Selection::new(from, to) != paragraph_break {
+        return selection;
+    }
+    let Some(start) = empty_paragraph_delete_start(doc, from) else {
+        return selection;
+    };
+
+    Selection::new(start, to)
+}
+
+fn empty_paragraph_delete_start(doc: &Doc, position: Position) -> Option<Position> {
+    let paragraph = doc.node(position.node_id)?;
+    if !matches!(paragraph.node(), Node::Paragraph(_)) || paragraph.children().next().is_some() {
+        return None;
+    }
+    before_node_position(&paragraph)
+}
+
+fn before_node_position(node: &NodeRef<'_>) -> Option<Position> {
+    Some(Position {
+        node_id: node.parent()?.id(),
+        offset: node.index()?,
+        affinity: Affinity::Downstream,
+    })
 }
 
 fn ensure_selection_after_child_range_delete(

--- a/crates/editor-core/src/editor.rs
+++ b/crates/editor-core/src/editor.rs
@@ -8,7 +8,7 @@ use editor_resource::ThemeVariant;
 use editor_resource::{CharacterCount, Resource, count_text};
 use editor_state::{
     DocFlatExt, PendingModifier, Position, ResolvedPosition, ResolvedPositionFlatExt, Selection,
-    StableSelection, State,
+    StableSelection, State, closest_empty_paragraph_break_end_between, farther_endpoint,
 };
 use editor_transaction::{Effect, HistoryMeta, HistoryTag, Step, StepError, Transaction};
 use editor_view::{GapPhantom, PageRect, PendingStyle, View, Viewport};
@@ -932,20 +932,47 @@ impl Editor {
                 let resource = self.resource.lock().unwrap();
                 self.view.would_resolve_movement(pos, movement, &resource)
             };
-            return match probe_result {
-                Some((sel, would_px)) => {
-                    let sel_changed = sel != current_sel;
-                    let px_changed = would_px != current_px;
-                    if let Mode::Probe { ref mut changed } = self.mode {
-                        *changed |= sel_changed || px_changed;
-                    }
-                    sel
-                }
-                None => None,
+            let (target, px_changed) = match probe_result {
+                Some((sel, would_px)) => (sel, would_px != current_px),
+                None => (None, false),
             };
+            let sel = target;
+            if let Mode::Probe { ref mut changed } = self.mode {
+                *changed |= sel.is_some() && sel != current_sel || px_changed;
+            };
+            return sel;
         }
-        let resource = self.resource.lock().unwrap();
-        self.view.resolve_movement(pos, movement, &resource)
+        let target = {
+            let resource = self.resource.lock().unwrap();
+            self.view.resolve_movement(pos, movement, &resource)
+        };
+        target
+    }
+
+    pub(crate) fn resolve_extend_movement(
+        &mut self,
+        selection: Selection,
+        movement: &Movement,
+    ) -> Option<Selection> {
+        let target = self.resolve_movement(&selection.head, movement)?;
+        let doc = &self.state.doc;
+        let current_is_unit = selection.is_unit_node_selection(doc);
+        let fixed = if current_is_unit {
+            farther_endpoint(doc, target.head, selection.anchor, selection.head)
+        } else {
+            selection.anchor
+        };
+        let mut head = farther_endpoint(doc, fixed, target.anchor, target.head);
+        if !current_is_unit
+            && matches!(
+                movement,
+                Movement::Grapheme { .. } | Movement::Word { .. } | Movement::Sentence { .. }
+            )
+            && let Some(stop) = closest_empty_paragraph_break_end_between(doc, selection.head, head)
+        {
+            head = stop;
+        }
+        Some(Selection::new(fixed, head))
     }
 
     pub fn last_history_tag(&self) -> Option<&HistoryTag> {

--- a/crates/editor-core/src/handle/clipboard.rs
+++ b/crates/editor-core/src/handle/clipboard.rs
@@ -330,6 +330,50 @@ mod tests {
     }
 
     #[test]
+    fn paste_empty_paragraph_break_before_non_paragraph_into_text_middle_splits_once() {
+        let (source, p1, ..) = state! {
+            doc { root {
+                p1: paragraph {}
+                image
+                paragraph {}
+            } }
+            selection: none
+        };
+        let selection = editor_state::paragraph_break_selection_at_paragraph_end(
+            &source.doc,
+            editor_state::Position::new(p1, 0),
+        )
+        .expect("empty paragraph before non-paragraph has break");
+        let source = editor_state::State {
+            selection: Some(selection),
+            ..source
+        };
+        let payload = Slice::extract(&source).expect("non-collapsed").to_payload();
+
+        let (target, _t1) = state! {
+            doc { root { paragraph { t1: text("asd") } } }
+            selection: (t1, 1)
+        };
+        let mut editor = Editor::new_test(target);
+
+        editor.apply(Message::Clipboard {
+            op: ClipboardOp::Paste {
+                html: Some(payload.html),
+                text: payload.text,
+            },
+        });
+
+        let (expected, ..) = state! {
+            doc { root {
+                paragraph { text("a") }
+                paragraph { t2: text("sd") }
+            } }
+            selection: (t2, 0)
+        };
+        assert_state_eq!(editor.state(), &expected);
+    }
+
+    #[test]
     fn paste_open_empty_paragraph_range_into_text_middle_inserts_boundary() {
         let (source, _p1, _t1) = state! {
             doc { root {

--- a/crates/editor-core/src/handle/navigation.rs
+++ b/crates/editor-core/src/handle/navigation.rs
@@ -1,8 +1,7 @@
-use editor_model::{Doc, Node, NodeId, Schema};
+use editor_model::{Doc, NodeId, Schema};
 use editor_state::{
-    Affinity, GapCursor, Position, ResolvedPosition, Selection, cell_rect_selection,
-    enclosing_table_cell, farther_endpoint, gap_cursor_selection_between,
-    gap_cursor_selection_leading,
+    Affinity, GapCursor, Position, Selection, cell_rect_selection, enclosing_table_cell,
+    gap_cursor_selection_between, gap_cursor_selection_leading,
 };
 use editor_transaction::HistoryMeta;
 
@@ -210,7 +209,6 @@ pub fn handle_navigation_op(editor: &mut Editor, op: NavigationOp) -> Result<(),
                     let left_or_right = matches!(movement, Movement::Grapheme { .. });
                     let base_position = Position::from(base);
                     let base_is_inline = base.is_inline_position();
-                    let base_is_block = base.is_block_position();
                     // Drop the doc borrow before calling the mutable wrapper.
                     drop(resolved);
 
@@ -231,25 +229,7 @@ pub fn handle_navigation_op(editor: &mut Editor, op: NavigationOp) -> Result<(),
                     } else {
                         let view_target = editor.resolve_movement(&base_position, &movement);
 
-                        match view_target {
-                            Some(sel) => sel,
-                            None if base_is_block => {
-                                // Block positions are container boundaries, so
-                                // the view has no caret rect to move from.
-                                let resolved = base_position
-                                    .resolve(&editor.state.doc)
-                                    .expect("base position node still exists");
-                                Selection::collapsed(move_from_block_position(
-                                    editor, &resolved, !backward,
-                                ))
-                            }
-                            None => {
-                                // Inline positions have a caret base. If the
-                                // view has no destination, the range simply
-                                // collapses to that base.
-                                Selection::collapsed(base_position)
-                            }
-                        }
+                        view_target.unwrap_or_else(|| Selection::collapsed(base_position))
                     };
 
                     editor.transact(|tr| {
@@ -321,7 +301,12 @@ pub fn handle_navigation_op(editor: &mut Editor, op: NavigationOp) -> Result<(),
                 }
             }
 
-            let new_selection = editor.resolve_movement(&selection.head, &movement);
+            let new_selection = if extend {
+                editor.resolve_extend_movement(selection, &movement)
+            } else {
+                editor.resolve_movement(&selection.head, &movement)
+            };
+
             if let Some(new_selection) = new_selection {
                 if extend {
                     let is_cell_movement = matches!(
@@ -356,26 +341,9 @@ pub fn handle_navigation_op(editor: &mut Editor, op: NavigationOp) -> Result<(),
                     }
                 }
 
-                let final_selection = if extend {
-                    let doc = &editor.state.doc;
-                    let fixed = if selection.is_unit_node_selection(doc) {
-                        farther_endpoint(doc, new_selection.head, selection.anchor, selection.head)
-                    } else {
-                        selection.anchor
-                    };
-                    // The farther-from-fixed head rule generalizes to every
-                    // extend: a no-op for collapsed targets, and for a unit
-                    // target it pulls the whole unit in one step.
-                    let head =
-                        farther_endpoint(doc, fixed, new_selection.anchor, new_selection.head);
-                    Selection::new(fixed, head)
-                } else {
-                    new_selection
-                };
-
                 editor.transact(|tr| {
                     tr.update_meta(|meta| meta.history = HistoryMeta::Skip);
-                    tr.set_selection(Some(final_selection))?;
+                    tr.set_selection(Some(new_selection))?;
                     Ok(())
                 })?;
             }
@@ -428,153 +396,6 @@ fn gap_cursor_from_inner_edge(
         };
     }
     None
-}
-
-fn move_from_block_position(
-    editor: &Editor,
-    position: &ResolvedPosition<'_>,
-    go_forward: bool,
-) -> Position {
-    debug_assert!(position.is_block_position());
-
-    let doc = position.doc();
-    let node = doc
-        .node(position.node_id())
-        .expect("resolved position node exists");
-    let children: Vec<NodeId> = node.children().map(|child| child.id()).collect();
-
-    if go_forward {
-        if position.offset() < children.len()
-            && let Some(pos) = leaf_block_edge(editor, children[position.offset()], false)
-        {
-            return pos;
-        }
-
-        if let Some(next_pos) = find_next_cursor_position_forward(editor, position.node_id()) {
-            return next_pos;
-        }
-
-        if let Some(last) = children.last().copied()
-            && let Some(pos) = leaf_block_edge(editor, last, true)
-        {
-            return pos;
-        }
-
-        if let Some(pos) = leaf_block_edge(editor, NodeId::ROOT, true) {
-            return pos;
-        }
-
-        Position::from(position)
-    } else {
-        if position.offset() > 0 && !children.is_empty() {
-            let child_idx = (position.offset() - 1).min(children.len() - 1);
-            if let Some(pos) = leaf_block_edge(editor, children[child_idx], true) {
-                return pos;
-            }
-        }
-
-        if let Some(prev_pos) = find_prev_cursor_position_backward(editor, position.node_id()) {
-            return prev_pos;
-        }
-
-        if let Some(first) = children.first().copied()
-            && let Some(pos) = leaf_block_edge(editor, first, false)
-        {
-            return pos;
-        }
-
-        if let Some(pos) = leaf_block_edge(editor, NodeId::ROOT, false) {
-            return pos;
-        }
-
-        Position::from(position)
-    }
-}
-
-fn leaf_block_edge(editor: &Editor, node_id: NodeId, at_end: bool) -> Option<Position> {
-    let doc = &editor.state.doc;
-    let node = doc.node(node_id)?;
-    let spec = Schema::node_spec(node.as_type());
-    if let Node::Text(t) = node.node() {
-        return Some(Position {
-            node_id,
-            offset: if at_end { t.text.len() } else { 0 },
-            affinity: if at_end {
-                Affinity::Upstream
-            } else {
-                Affinity::Downstream
-            },
-        });
-    }
-
-    if let Some(pos) = editor.view.editable_position_inside(node_id, at_end) {
-        return Some(pos);
-    }
-
-    if spec.is_textblock() {
-        return Some(Position {
-            node_id,
-            offset: if at_end { node.children().count() } else { 0 },
-            affinity: if at_end {
-                Affinity::Upstream
-            } else {
-                Affinity::Downstream
-            },
-        });
-    }
-
-    let child_id = if at_end {
-        node.last_child().map(|child| child.id())
-    } else {
-        node.first_child().map(|child| child.id())
-    };
-    if spec.is_leaf() || child_id.is_none() {
-        let parent = node.parent()?;
-        let idx = node.index()?;
-        return Some(Position {
-            node_id: parent.id(),
-            offset: if at_end { idx + 1 } else { idx },
-            affinity: if at_end {
-                Affinity::Upstream
-            } else {
-                Affinity::Downstream
-            },
-        });
-    }
-
-    leaf_block_edge(editor, child_id?, at_end)
-}
-
-fn find_next_cursor_position_forward(editor: &Editor, node_id: NodeId) -> Option<Position> {
-    let doc = &editor.state.doc;
-    let mut current_id = node_id;
-    loop {
-        let current = doc.node(current_id)?;
-        let parent = current.parent()?;
-        let idx = current.index()?;
-        let siblings: Vec<NodeId> = parent.children().map(|child| child.id()).collect();
-        if let Some(next) = siblings.get(idx + 1).copied() {
-            return leaf_block_edge(editor, next, false);
-        }
-        current_id = parent.id();
-    }
-}
-
-fn find_prev_cursor_position_backward(editor: &Editor, node_id: NodeId) -> Option<Position> {
-    let doc = &editor.state.doc;
-    let mut current_id = node_id;
-    loop {
-        let current = doc.node(current_id)?;
-        let parent = current.parent()?;
-        let idx = current.index()?;
-        let siblings: Vec<NodeId> = parent.children().map(|child| child.id()).collect();
-        if idx > 0
-            && let Some(prev) = siblings.get(idx - 1).copied()
-        {
-            return leaf_block_edge(editor, prev, true);
-        }
-        current_id = parent.id();
-    }
 }
 
 /// Exit a gap into `node_id`'s inner content; if it has none (e.g. an
@@ -653,7 +474,8 @@ fn step_cell(doc: &Doc, cell_id: NodeId, backward: bool, vertical: bool) -> Opti
 mod tests {
     use editor_macros::state;
     use editor_state::{
-        Position, assert_state_eq, gap_cursor_selection_between, gap_cursor_selection_leading,
+        Affinity, Position, Selection, assert_state_eq, gap_cursor_selection_between,
+        gap_cursor_selection_leading,
     };
 
     use crate::editor::Editor;
@@ -742,6 +564,279 @@ mod tests {
                 extend: true,
             },
         });
+    }
+
+    fn shift_word_right(editor: &mut Editor) {
+        editor.apply(Message::Navigation {
+            op: NavigationOp::Move {
+                movement: Movement::Word {
+                    direction: Direction::Forward,
+                },
+                extend: true,
+            },
+        });
+    }
+
+    #[test]
+    fn shift_right_from_range_ending_at_empty_paragraph_start_stops_at_empty_paragraph_break() {
+        let (state, r, t1, _p1) = state! {
+            doc {
+                r: root [block_gap(200)] {
+                    paragraph {
+                        t1: text("bb")
+                    }
+                    p1: paragraph {}
+                    image
+                    paragraph {}
+                }
+            }
+            selection: (t1, 1, >) -> (p1, 0, <)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.view.layout(&editor.state.doc);
+
+        shift_right(&mut editor);
+
+        assert_eq!(
+            editor.state().selection,
+            Some(Selection::new(
+                Position {
+                    node_id: t1,
+                    offset: 1,
+                    affinity: Affinity::Downstream,
+                },
+                Position {
+                    node_id: r,
+                    offset: 2,
+                    affinity: Affinity::Upstream,
+                },
+            ))
+        );
+    }
+
+    #[test]
+    fn shift_word_right_from_range_ending_at_empty_paragraph_start_stops_at_empty_paragraph_break()
+    {
+        let (state, r, t1, _p1) = state! {
+            doc {
+                r: root [block_gap(200)] {
+                    paragraph {
+                        t1: text("bb")
+                    }
+                    p1: paragraph {}
+                    image
+                    paragraph {}
+                }
+            }
+            selection: (t1, 1, >) -> (p1, 0, <)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.view.layout(&editor.state.doc);
+
+        shift_word_right(&mut editor);
+
+        assert_eq!(
+            editor.state().selection,
+            Some(Selection::new(
+                Position {
+                    node_id: t1,
+                    offset: 1,
+                    affinity: Affinity::Downstream,
+                },
+                Position {
+                    node_id: r,
+                    offset: 2,
+                    affinity: Affinity::Upstream,
+                },
+            ))
+        );
+    }
+
+    #[test]
+    fn shift_left_from_range_ending_at_empty_paragraph_start_stops_at_previous_paragraph_break() {
+        let (state, t1, _p1) = state! {
+            doc {
+                root [block_gap(200)] {
+                    paragraph {
+                        t1: text("bb")
+                    }
+                    p1: paragraph {}
+                    image
+                    paragraph {}
+                }
+            }
+            selection: (t1, 0, >) -> (p1, 0, <)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.view.layout(&editor.state.doc);
+
+        shift_left(&mut editor);
+
+        assert_eq!(
+            editor.state().selection,
+            Some(Selection::new(
+                Position {
+                    node_id: t1,
+                    offset: 0,
+                    affinity: Affinity::Downstream,
+                },
+                Position {
+                    node_id: t1,
+                    offset: 2,
+                    affinity: Affinity::Upstream,
+                },
+            ))
+        );
+    }
+
+    #[test]
+    fn shift_left_from_empty_paragraph_break_plus_atom_returns_to_paragraph_break() {
+        let (state, r, p1) = state! {
+            doc {
+                r: root [block_gap(200)] {
+                    p1: paragraph {}
+                    image
+                    paragraph {}
+                }
+            }
+            selection: (p1, 0)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.view.layout(&editor.state.doc);
+
+        shift_right(&mut editor);
+        shift_right(&mut editor);
+        assert_eq!(
+            editor.state().selection,
+            Some(Selection::new(
+                Position {
+                    node_id: p1,
+                    offset: 0,
+                    affinity: Affinity::Downstream,
+                },
+                Position {
+                    node_id: r,
+                    offset: 2,
+                    affinity: Affinity::Upstream,
+                },
+            ))
+        );
+
+        shift_left(&mut editor);
+
+        assert_eq!(
+            editor.state().selection,
+            Some(Selection::new(
+                Position {
+                    node_id: p1,
+                    offset: 0,
+                    affinity: Affinity::Downstream,
+                },
+                Position {
+                    node_id: r,
+                    offset: 1,
+                    affinity: Affinity::Upstream,
+                },
+            ))
+        );
+
+        shift_left(&mut editor);
+
+        assert_eq!(
+            editor.state().selection,
+            Some(Selection::collapsed(Position::new(p1, 0)))
+        );
+    }
+
+    #[test]
+    fn shift_right_from_empty_paragraph_break_enters_following_callout_content() {
+        let (state, _r, p1, p2) = state! {
+            doc {
+                r: root [block_gap(200)] {
+                    p1: paragraph {}
+                    callout {
+                        p2: paragraph {}
+                    }
+                    paragraph {}
+                }
+            }
+            selection: (p1, 0)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.view.layout(&editor.state.doc);
+
+        shift_right(&mut editor);
+        shift_right(&mut editor);
+
+        assert_eq!(
+            editor.state().selection,
+            Some(Selection::new(
+                Position {
+                    node_id: p1,
+                    offset: 0,
+                    affinity: Affinity::Downstream,
+                },
+                Position {
+                    node_id: p2,
+                    offset: 0,
+                    affinity: Affinity::Upstream,
+                },
+            ))
+        );
+    }
+
+    #[test]
+    fn shift_left_from_empty_paragraph_break_plus_callout_returns_to_paragraph_break() {
+        let (state, r, p1, p2) = state! {
+            doc {
+                r: root [block_gap(200)] {
+                    p1: paragraph {}
+                    callout {
+                        p2: paragraph {}
+                    }
+                    paragraph {}
+                }
+            }
+            selection: (p1, 0)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.view.layout(&editor.state.doc);
+
+        shift_right(&mut editor);
+        shift_right(&mut editor);
+        assert_eq!(
+            editor.state().selection,
+            Some(Selection::new(
+                Position {
+                    node_id: p1,
+                    offset: 0,
+                    affinity: Affinity::Downstream,
+                },
+                Position {
+                    node_id: p2,
+                    offset: 0,
+                    affinity: Affinity::Upstream,
+                },
+            ))
+        );
+
+        shift_left(&mut editor);
+
+        assert_eq!(
+            editor.state().selection,
+            Some(Selection::new(
+                Position {
+                    node_id: p1,
+                    offset: 0,
+                    affinity: Affinity::Downstream,
+                },
+                Position {
+                    node_id: r,
+                    offset: 1,
+                    affinity: Affinity::Upstream,
+                },
+            ))
+        );
     }
 
     #[test]

--- a/crates/editor-core/src/handle/selection.rs
+++ b/crates/editor-core/src/handle/selection.rs
@@ -550,6 +550,109 @@ mod tests {
     }
 
     #[test]
+    fn extend_to_visual_paragraph_break_selects_next_paragraph_start() {
+        let (state, _p1, t1, t2) = state! {
+            doc {
+                root {
+                    p1: paragraph { t1: text("aa") }
+                    paragraph { t2: text("bb") }
+                }
+            }
+            selection: (t1, 0)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.view.layout(&editor.state.doc);
+        let paragraph_break = editor_state::paragraph_break_selection_at_paragraph_end(
+            &editor.state.doc,
+            Position::new(t1, 2),
+        )
+        .expect("P -> P has PB");
+        let resolved = paragraph_break
+            .resolve(&editor.state.doc)
+            .expect("paragraph break selection resolves");
+        let rect = editor
+            .view
+            .selection_rects(&resolved)
+            .into_iter()
+            .find(|rect| rect.meta == editor_view::SelectionRectKind::ParagraphBreak)
+            .expect("paragraph break rect exists");
+
+        editor.apply(Message::Selection {
+            op: SelectionOp::ExtendTo {
+                anchor: Position::new(t1, 0),
+                head_page: rect.page_idx,
+                head_x: rect.rect.right() + 4.0,
+                head_y: rect.rect.y + rect.rect.height / 2.0,
+                base_selection: None,
+                allow_collapse: false,
+            },
+        });
+
+        let sel = editor.state().selection.expect("selection exists in test");
+        assert_eq!(
+            sel,
+            Selection::new(
+                Position::new(t1, 0),
+                Position {
+                    node_id: t2,
+                    offset: 0,
+                    affinity: Affinity::Upstream,
+                }
+            )
+        );
+        assert!(!editor.history.can_undo());
+    }
+
+    #[test]
+    fn extend_to_visual_removable_empty_paragraph_break_stops_before_next_block() {
+        let (state, t1, empty) = state! {
+            doc {
+                root {
+                    paragraph { t1: text("bb") }
+                    empty: paragraph {}
+                    image
+                    paragraph {}
+                }
+            }
+            selection: (t1, 0)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.view.layout(&editor.state.doc);
+        let paragraph_break = editor_state::paragraph_break_selection_at_paragraph_end(
+            &editor.state.doc,
+            Position::new(empty, 0),
+        )
+        .expect("removable empty paragraph has PB");
+        let resolved = paragraph_break
+            .resolve(&editor.state.doc)
+            .expect("paragraph break selection resolves");
+        let rect = editor
+            .view
+            .selection_rects(&resolved)
+            .into_iter()
+            .find(|rect| rect.meta == editor_view::SelectionRectKind::ParagraphBreak)
+            .expect("paragraph break rect exists");
+
+        editor.apply(Message::Selection {
+            op: SelectionOp::ExtendTo {
+                anchor: Position::new(t1, 0),
+                head_page: rect.page_idx,
+                head_x: rect.rect.right() + 4.0,
+                head_y: rect.rect.y + rect.rect.height / 2.0,
+                base_selection: None,
+                allow_collapse: false,
+            },
+        });
+
+        let sel = editor.state().selection.expect("selection exists in test");
+        assert_eq!(
+            sel,
+            Selection::new(Position::new(t1, 0), paragraph_break.head)
+        );
+        assert!(!editor.history.can_undo());
+    }
+
+    #[test]
     fn extend_to_with_allow_collapse_applies_collapsed_result() {
         let (state, ..) = state! {
             doc { root { paragraph { t: text("hello") } } }
@@ -580,12 +683,12 @@ mod tests {
     }
 
     #[test]
-    fn extend_to_block_gap_from_text_middle_selects_to_block_edge() {
-        let (state, p1, t1, p2) = state! {
+    fn extend_to_paragraph_gap_from_text_middle_selects_paragraph_break() {
+        let (state, p1, t1, p2, t2) = state! {
             doc {
                 root {
                     p1: paragraph { t1: text("hello") }
-                    p2: paragraph { text("world") }
+                    p2: paragraph { t2: text("world") }
                 }
             }
             selection: (t1, 2)
@@ -613,17 +716,23 @@ mod tests {
         let sel = editor.state().selection.expect("selection exists in test");
         assert!(!sel.is_collapsed(), "block-gap drag collapsed to {:?}", sel);
         assert_eq!(sel.anchor, Position::new(t1, 2));
-        assert_eq!(sel.head.node_id, t1);
-        assert_eq!(sel.head.offset, 5);
+        assert_eq!(
+            sel.head,
+            Position {
+                node_id: t2,
+                offset: 0,
+                affinity: Affinity::Upstream,
+            }
+        );
         assert!(!editor.history.can_undo());
     }
 
     #[test]
-    fn extend_up_to_block_gap_from_text_middle_selects_to_block_edge() {
-        let (state, p1, p2, t2) = state! {
+    fn extend_up_to_paragraph_gap_from_text_middle_excludes_previous_paragraph_break() {
+        let (state, p1, _t1, p2, t2) = state! {
             doc {
                 root {
-                    p1: paragraph { text("hello") }
+                    p1: paragraph { t1: text("hello") }
                     p2: paragraph { t2: text("world") }
                 }
             }
@@ -652,8 +761,14 @@ mod tests {
         let sel = editor.state().selection.expect("selection exists in test");
         assert!(!sel.is_collapsed(), "block-gap drag collapsed to {:?}", sel);
         assert_eq!(sel.anchor, Position::new(t2, 2));
-        assert_eq!(sel.head.node_id, t2);
-        assert_eq!(sel.head.offset, 0);
+        assert_eq!(
+            sel.head,
+            Position {
+                node_id: t2,
+                offset: 0,
+                affinity: Affinity::Downstream,
+            }
+        );
         assert!(!editor.history.can_undo());
     }
 
@@ -695,13 +810,13 @@ mod tests {
     }
 
     #[test]
-    fn extend_to_monolithic_internal_block_gap_selects_to_block_edge() {
-        let (state, callout, p1, t1, p2) = state! {
+    fn extend_to_monolithic_internal_paragraph_gap_selects_paragraph_break() {
+        let (state, callout, p1, t1, p2, t2) = state! {
             doc {
                 root {
                     callout: callout {
                         p1: paragraph { t1: text("one") }
-                        p2: paragraph { text("two") }
+                        p2: paragraph { t2: text("two") }
                     }
                 }
             }
@@ -731,8 +846,14 @@ mod tests {
         let sel = editor.state().selection.expect("selection exists in test");
         assert!(!sel.is_collapsed(), "block-gap drag collapsed to {:?}", sel);
         assert_eq!(sel.anchor, Position::new(t1, 1));
-        assert_eq!(sel.head.node_id, t1);
-        assert_eq!(sel.head.offset, 3);
+        assert_eq!(
+            sel.head,
+            Position {
+                node_id: t2,
+                offset: 0,
+                affinity: Affinity::Upstream,
+            }
+        );
         assert!(!editor.history.can_undo());
     }
 

--- a/crates/editor-state/src/lib.rs
+++ b/crates/editor-state/src/lib.rs
@@ -11,6 +11,7 @@ mod flat;
 mod gap_cursor;
 mod modifier_resolution;
 mod normalize;
+mod paragraph_break;
 mod pending_modifier;
 mod pending_style;
 mod position;
@@ -34,6 +35,9 @@ pub use flat::*;
 pub use gap_cursor::*;
 pub use modifier_resolution::*;
 pub use normalize::farther_endpoint;
+pub use paragraph_break::{
+    closest_empty_paragraph_break_end_between, paragraph_break_selection_at_paragraph_end,
+};
 pub use pending_modifier::*;
 pub use pending_style::*;
 pub use position::*;

--- a/crates/editor-state/src/normalize.rs
+++ b/crates/editor-state/src/normalize.rs
@@ -5,34 +5,13 @@ use editor_model::{Doc, Node, NodeId, NodeRef, Schema};
 
 use crate::affinity::Affinity;
 use crate::gap_cursor::between_monolithic_at;
-use crate::position::Position;
+use crate::paragraph_break::selection_exactly_matches_trailing_paragraph_break;
+use crate::position::{Position, logical_boundary};
 use crate::resolved_selection::ResolvedSelection;
 use crate::selection::Selection;
 
 fn boundary_identity(doc: &Doc, pos: Position) -> Vec<usize> {
-    let node = doc
-        .node(pos.node_id)
-        .expect("boundary_identity: node must exist");
-    if let Node::Text(text) = node.node() {
-        let len = text.text.len();
-        let mut path = node.path();
-        if pos.offset == 0 {
-            return path;
-        }
-        if pos.offset == len {
-            // A text node's path last element is its index inside the parent;
-            // the boundary immediately after the node is that index + 1.
-            if let Some(last) = path.last_mut() {
-                *last += 1;
-            }
-            return path;
-        }
-        path.push(pos.offset);
-        return path;
-    }
-    let mut path = node.path();
-    path.push(pos.offset);
-    path
+    logical_boundary(doc, pos).expect("boundary_identity: node must exist")
 }
 
 fn descend_or_stay_at_textblock<'a>(
@@ -366,6 +345,9 @@ impl<'a> ResolvedSelection<'a> {
         let a_resolved = a.resolve(doc).expect("normalized anchor resolves");
         let h_resolved = h.resolve(doc).expect("normalized head resolves");
         if subtree_violation(a_resolved.path(), h_resolved.path()) {
+            if selection_exactly_matches_trailing_paragraph_break(doc, Selection::new(a, h)) {
+                return Selection { anchor: a, head: h };
+            }
             if let Some(sel) = enclosing_unit_at_subtree_overlap(doc, a_in, h_in) {
                 return sel;
             }

--- a/crates/editor-state/src/paragraph_break.rs
+++ b/crates/editor-state/src/paragraph_break.rs
@@ -1,0 +1,413 @@
+use editor_model::{Doc, Node, NodeRef, NodeType};
+
+use crate::{
+    Affinity, NodeRefCursorExt, Position, ResolvedSelection, Selection,
+    position_before_or_same_logical_boundary, positions_at_same_logical_boundary,
+};
+
+pub fn paragraph_break_selection_at_paragraph_end(
+    doc: &Doc,
+    position: Position,
+) -> Option<Selection> {
+    let paragraph = paragraph_owner(doc, position)?;
+    let end = paragraph_end_boundary_position(paragraph)?;
+    if !positions_at_same_logical_boundary(doc, position, end) {
+        return None;
+    }
+    trailing_break_for_paragraph(paragraph)
+}
+
+pub(crate) fn selection_exactly_matches_trailing_paragraph_break(
+    doc: &Doc,
+    selection: Selection,
+) -> bool {
+    let Some(resolved) = selection.resolve(doc) else {
+        return false;
+    };
+    let from = Position::from(resolved.from());
+    let to = Position::from(resolved.to());
+    let Some(paragraph_break) = paragraph_break_selection_at_paragraph_end(doc, from) else {
+        return false;
+    };
+    Selection::new(from, to) == paragraph_break
+}
+
+pub fn closest_empty_paragraph_break_end_between(
+    doc: &Doc,
+    from: Position,
+    to: Position,
+) -> Option<Position> {
+    if positions_at_same_logical_boundary(doc, from, to) {
+        return None;
+    }
+
+    let range = Selection::new(from, to).resolve(doc)?;
+    let forward = range.anchor() < range.head();
+    let mut best = None;
+    collect_closest_empty_paragraph_break_end(
+        doc,
+        &range,
+        range.common_ancestor(),
+        from,
+        to,
+        forward,
+        &mut best,
+    );
+    best
+}
+
+fn trailing_break_for_paragraph(paragraph: NodeRef<'_>) -> Option<Selection> {
+    if !matches!(paragraph.node(), Node::Paragraph(_)) {
+        return None;
+    }
+
+    if paragraph_has_trailing_page_break(&paragraph) {
+        return None;
+    }
+
+    let Some(next) = paragraph.next_sibling() else {
+        return None;
+    };
+
+    if matches!(next.node(), Node::Paragraph(_)) {
+        return Some(Selection::new(
+            paragraph_end_boundary_position(paragraph)?,
+            paragraph_start_boundary_position(next)?,
+        ));
+    }
+
+    if !paragraph_is_empty(&paragraph) || !empty_paragraph_is_removable(&paragraph) {
+        return None;
+    }
+
+    Some(Selection::new(
+        Position {
+            node_id: paragraph.id(),
+            offset: 0,
+            affinity: Affinity::Downstream,
+        },
+        after_node_position(&paragraph)?,
+    ))
+}
+
+fn paragraph_owner<'a>(doc: &'a Doc, pos: Position) -> Option<NodeRef<'a>> {
+    doc.node(pos.node_id)?
+        .ancestors()
+        .find(|node| matches!(node.node(), Node::Paragraph(_)))
+}
+
+fn paragraph_start_boundary_position(paragraph: NodeRef<'_>) -> Option<Position> {
+    if !matches!(paragraph.node(), Node::Paragraph(_)) {
+        return None;
+    }
+    Some(Position {
+        affinity: Affinity::Upstream,
+        ..paragraph.first_cursor_position()?
+    })
+}
+
+fn paragraph_end_boundary_position(paragraph: NodeRef<'_>) -> Option<Position> {
+    if !matches!(paragraph.node(), Node::Paragraph(_)) {
+        return None;
+    }
+    Some(Position {
+        affinity: Affinity::Downstream,
+        ..paragraph.last_cursor_position()?
+    })
+}
+
+fn paragraph_is_empty(paragraph: &NodeRef<'_>) -> bool {
+    if !matches!(paragraph.node(), Node::Paragraph(_)) {
+        return false;
+    }
+    paragraph.children().all(|child| match child.node() {
+        Node::Text(text) => text.text.is_empty(),
+        _ => false,
+    })
+}
+
+fn paragraph_has_trailing_page_break(paragraph: &NodeRef<'_>) -> bool {
+    paragraph
+        .last_child()
+        .is_some_and(|child| matches!(child.node(), Node::PageBreak(_)))
+}
+
+fn empty_paragraph_is_removable(paragraph: &NodeRef<'_>) -> bool {
+    let Some(parent) = paragraph.parent() else {
+        return false;
+    };
+    let Some(index) = paragraph.index() else {
+        return false;
+    };
+    let remaining: Vec<NodeType> = parent
+        .children()
+        .enumerate()
+        .filter_map(|(i, child)| (i != index).then_some(child.as_type()))
+        .collect();
+    parent.spec().content.validate(&remaining).is_ok()
+}
+
+fn after_node_position(node: &NodeRef<'_>) -> Option<Position> {
+    Some(Position {
+        node_id: node.parent()?.id(),
+        offset: node.index()? + 1,
+        affinity: Affinity::Upstream,
+    })
+}
+
+fn collect_closest_empty_paragraph_break_end(
+    doc: &Doc,
+    range: &ResolvedSelection<'_>,
+    node: NodeRef<'_>,
+    from: Position,
+    to: Position,
+    forward: bool,
+    best: &mut Option<Position>,
+) {
+    if !range.intersects_subtree(&node) {
+        return;
+    }
+    if matches!(node.node(), Node::Paragraph(_))
+        && let Some(selection) =
+            paragraph_break_selection_at_paragraph_end(doc, Position::new(node.id(), 0))
+        && head_crosses_position(doc, from, selection.head, to, forward)
+        && best.is_none_or(|current| closer_to_head(doc, selection.head, current, forward))
+    {
+        *best = Some(selection.head);
+    }
+    for child in node.children() {
+        collect_closest_empty_paragraph_break_end(doc, range, child, from, to, forward, best);
+    }
+}
+
+fn head_crosses_position(
+    doc: &Doc,
+    from: Position,
+    stop: Position,
+    to: Position,
+    forward: bool,
+) -> bool {
+    if positions_at_same_logical_boundary(doc, from, stop) {
+        return false;
+    }
+    if forward {
+        position_before_or_same_logical_boundary(doc, from, stop)
+            && position_before_or_same_logical_boundary(doc, stop, to)
+    } else {
+        position_before_or_same_logical_boundary(doc, stop, from)
+            && position_before_or_same_logical_boundary(doc, to, stop)
+    }
+}
+
+fn closer_to_head(doc: &Doc, candidate: Position, current: Position, forward: bool) -> bool {
+    if forward {
+        position_before_or_same_logical_boundary(doc, candidate, current)
+    } else {
+        position_before_or_same_logical_boundary(doc, current, candidate)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use editor_macros::doc;
+
+    #[test]
+    fn p_to_p_has_paragraph_break_selection() {
+        let (doc, _p1, t1, _p2, t2) = doc! {
+            root {
+                p1: paragraph { t1: text("a") }
+                p2: paragraph { t2: text("b") }
+            }
+        };
+
+        assert_eq!(
+            paragraph_break_selection_at_paragraph_end(&doc, Position::new(t1, 1)),
+            Some(Selection::new(
+                Position {
+                    node_id: t1,
+                    offset: 1,
+                    affinity: Affinity::Downstream,
+                },
+                Position {
+                    node_id: t2,
+                    offset: 0,
+                    affinity: Affinity::Upstream,
+                }
+            ))
+        );
+    }
+
+    #[test]
+    fn p_to_non_paragraph_has_no_break() {
+        let (doc, _p, t) = doc! {
+            root {
+                p: paragraph { t: text("a") }
+                callout { paragraph { text("b") } }
+                paragraph {}
+            }
+        };
+
+        assert_eq!(
+            paragraph_break_selection_at_paragraph_end(&doc, Position::new(t, 1)),
+            None
+        );
+    }
+
+    #[test]
+    fn paragraph_with_trailing_page_break_has_no_paragraph_break() {
+        let (doc, p, _t) = doc! {
+            root {
+                p: paragraph { t: text("a") page_break }
+                paragraph { text("b") }
+            }
+        };
+
+        assert_eq!(
+            paragraph_break_selection_at_paragraph_end(&doc, Position::new(p, 2)),
+            None
+        );
+    }
+
+    #[test]
+    fn page_break_only_paragraph_has_no_paragraph_break() {
+        let (doc, p) = doc! {
+            root {
+                p: paragraph { page_break }
+                paragraph { text("b") }
+            }
+        };
+
+        assert_eq!(
+            paragraph_break_selection_at_paragraph_end(&doc, Position::new(p, 1)),
+            None
+        );
+    }
+
+    #[test]
+    fn removable_empty_before_non_paragraph_has_paragraph_break_selection() {
+        let (doc, root, e) = doc! {
+            root: root {
+                e: paragraph {}
+                callout { paragraph { text("b") } }
+                paragraph {}
+            }
+        };
+
+        assert_eq!(
+            paragraph_break_selection_at_paragraph_end(&doc, Position::new(e, 0)),
+            Some(Selection::new(
+                Position::new(e, 0),
+                Position {
+                    node_id: root,
+                    offset: 1,
+                    affinity: Affinity::Upstream,
+                }
+            ))
+        );
+    }
+
+    #[test]
+    fn required_trailing_empty_has_no_break() {
+        let (doc, e) = doc! {
+            root {
+                callout { paragraph { text("b") } }
+                e: paragraph {}
+            }
+        };
+
+        assert_eq!(
+            paragraph_break_selection_at_paragraph_end(&doc, Position::new(e, 0)),
+            None
+        );
+    }
+
+    #[test]
+    fn removable_trailing_empty_has_no_break() {
+        let (doc, e) = doc! {
+            root {
+                paragraph { text("b") }
+                e: paragraph {}
+            }
+        };
+
+        assert_eq!(
+            paragraph_break_selection_at_paragraph_end(&doc, Position::new(e, 0)),
+            None
+        );
+    }
+
+    #[test]
+    fn selection_normalize_preserves_paragraph_break_range_affinities() {
+        let (doc, _p1, t1, _p2, t2) = doc! {
+            root {
+                p1: paragraph { t1: text("a") }
+                p2: paragraph { t2: text("b") }
+            }
+        };
+
+        let selection = Selection::new(Position::new(t1, 1), Position::new(t2, 0))
+            .normalize(&doc)
+            .expect("selection normalizes");
+        assert_eq!(
+            selection,
+            paragraph_break_selection_at_paragraph_end(&doc, Position::new(t1, 1))
+                .expect("P -> P has paragraph break")
+        );
+    }
+
+    #[test]
+    fn selection_normalize_preserves_reversed_paragraph_break_direction() {
+        let (doc, _p1, t1, _p2, t2) = doc! {
+            root {
+                p1: paragraph { t1: text("a") }
+                p2: paragraph { t2: text("b") }
+            }
+        };
+
+        let paragraph_break =
+            paragraph_break_selection_at_paragraph_end(&doc, Position::new(t1, 1))
+                .expect("P -> P has paragraph break");
+        let selection = Selection::new(Position::new(t2, 0), Position::new(t1, 1))
+            .normalize(&doc)
+            .expect("selection normalizes");
+        assert_eq!(
+            selection,
+            Selection::new(paragraph_break.head, paragraph_break.anchor)
+        );
+    }
+
+    #[test]
+    fn selection_normalize_preserves_removable_empty_paragraph_break() {
+        let (doc, root, p1) = doc! {
+            root: root {
+                p1: paragraph {}
+                image
+                paragraph {}
+            }
+        };
+
+        let selection = Selection::new(
+            Position::new(p1, 0),
+            Position {
+                node_id: root,
+                offset: 1,
+                affinity: Affinity::Upstream,
+            },
+        )
+        .normalize(&doc)
+        .expect("selection normalizes");
+
+        assert_eq!(
+            selection,
+            Selection::new(
+                Position::new(p1, 0),
+                Position {
+                    node_id: root,
+                    offset: 1,
+                    affinity: Affinity::Upstream,
+                },
+            )
+        );
+    }
+}

--- a/crates/editor-state/src/position.rs
+++ b/crates/editor-state/src/position.rs
@@ -1,5 +1,5 @@
 use editor_macros::ffi;
-use editor_model::{Doc, NodeId};
+use editor_model::{Doc, Node, NodeId};
 use serde::{Deserialize, Serialize};
 
 use crate::affinity::Affinity;
@@ -67,4 +67,41 @@ impl Position {
     pub fn resolve<'a>(&self, doc: &'a Doc) -> Option<ResolvedPosition<'a>> {
         ResolvedPosition::resolve(doc, *self)
     }
+}
+
+pub(crate) fn logical_boundary(doc: &Doc, pos: Position) -> Option<Vec<usize>> {
+    let node = doc.node(pos.node_id)?;
+    if let Node::Text(text) = node.node() {
+        let len = text.text.len();
+        let mut path = node.path();
+        if pos.offset == 0 {
+            return Some(path);
+        }
+        if pos.offset == len {
+            if let Some(last) = path.last_mut() {
+                *last += 1;
+            }
+            return Some(path);
+        }
+        path.push(pos.offset);
+        return Some(path);
+    }
+
+    let mut path = node.path();
+    path.push(pos.offset);
+    Some(path)
+}
+
+pub fn positions_at_same_logical_boundary(doc: &Doc, a: Position, b: Position) -> bool {
+    logical_boundary(doc, a) == logical_boundary(doc, b)
+}
+
+pub fn position_before_or_same_logical_boundary(doc: &Doc, a: Position, b: Position) -> bool {
+    if positions_at_same_logical_boundary(doc, a, b) {
+        return true;
+    }
+    let (Some(a), Some(b)) = (a.resolve(doc), b.resolve(doc)) else {
+        return false;
+    };
+    a <= b
 }

--- a/crates/editor-state/src/resolved_selection.rs
+++ b/crates/editor-state/src/resolved_selection.rs
@@ -67,6 +67,13 @@ impl<'a> ResolvedSelection<'a> {
         self.from() <= pos && pos <= self.to()
     }
 
+    pub fn contains_range(&self, range: Selection) -> bool {
+        let Some(resolved) = range.resolve(self.doc) else {
+            return false;
+        };
+        self.from() <= resolved.from() && resolved.to() <= self.to()
+    }
+
     /// Deepest ancestor that contains both `anchor` and `head`.
     ///
     /// Walks the two ancestor chains from the root downward and returns the last node

--- a/crates/editor-state/src/selection_expansion.rs
+++ b/crates/editor-state/src/selection_expansion.rs
@@ -2,7 +2,7 @@ use editor_common::StrExt;
 use editor_model::{Doc, Node, NodeId, NodeRef};
 use editor_resource::Resource;
 
-use crate::{Affinity, Position, Selection};
+use crate::{Affinity, Position, Selection, paragraph_break_selection_at_paragraph_end};
 
 pub fn resolve_word_selection_expansion(
     doc: &Doc,
@@ -196,20 +196,14 @@ fn paragraph_at(doc: &Doc, position: Position) -> Option<NodeRef<'_>> {
 fn paragraph_selection(paragraph: NodeRef<'_>) -> Option<Selection> {
     let child_count = paragraph.children().count();
     if child_count == 0 {
-        let parent_id = paragraph.parent()?.id();
-        let index = paragraph.index()?;
-        return Some(Selection::new(
+        return paragraph_break_selection_at_paragraph_end(
+            paragraph.doc(),
             Position {
-                node_id: parent_id,
-                offset: index,
+                node_id: paragraph.id(),
+                offset: 0,
                 affinity: Affinity::Downstream,
             },
-            Position {
-                node_id: parent_id,
-                offset: index + 1,
-                affinity: Affinity::Upstream,
-            },
-        ));
+        );
     }
 
     Some(Selection::new(
@@ -241,20 +235,7 @@ fn empty_textblock_selection_at(doc: &Doc, position: Position) -> Option<Selecti
         return None;
     }
 
-    let parent_id = textblock.parent()?.id();
-    let index = textblock.index()?;
-    Some(Selection::new(
-        Position {
-            node_id: parent_id,
-            offset: index,
-            affinity: Affinity::Downstream,
-        },
-        Position {
-            node_id: parent_id,
-            offset: index + 1,
-            affinity: Affinity::Upstream,
-        },
-    ))
+    paragraph_break_selection_at_paragraph_end(doc, position)
 }
 
 #[derive(Clone, Copy)]
@@ -620,34 +601,24 @@ mod tests {
     }
 
     #[test]
-    fn word_expansion_on_empty_paragraph_selects_paragraph_unit() {
+    fn word_expansion_on_required_empty_paragraph_returns_none() {
         let resource = Resource::new_test();
-        let (state, root, _p) = state! {
-            doc { root: root { p: paragraph {} } }
+        let (state, _p) = state! {
+            doc { root { p: paragraph {} } }
             selection: (p, 0)
         };
 
         let actual =
             resolve_word_selection_expansion(&state.doc, state.selection.unwrap(), &resource);
 
-        assert_eq!(
-            actual,
-            Some(Selection::new(
-                Position::new(root, 0),
-                Position {
-                    node_id: root,
-                    offset: 1,
-                    affinity: Affinity::Upstream,
-                },
-            ))
-        );
+        assert_eq!(actual, None);
     }
 
     #[test]
-    fn word_expansion_on_empty_text_paragraph_selects_paragraph_unit() {
+    fn word_expansion_on_empty_paragraph_selects_its_trailing_paragraph_break() {
         let resource = Resource::new_test();
-        let (state, root, _p) = state! {
-            doc { root: root { p: paragraph { text("") } } }
+        let (state, p, t) = state! {
+            doc { root { p: paragraph {} paragraph { t: text("next") } } }
             selection: (p, 0)
         };
 
@@ -657,10 +628,10 @@ mod tests {
         assert_eq!(
             actual,
             Some(Selection::new(
-                Position::new(root, 0),
+                Position::new(p, 0),
                 Position {
-                    node_id: root,
-                    offset: 1,
+                    node_id: t,
+                    offset: 0,
                     affinity: Affinity::Upstream,
                 },
             ))
@@ -740,27 +711,17 @@ mod tests {
     }
 
     #[test]
-    fn sentence_expansion_on_empty_paragraph_selects_paragraph_unit() {
+    fn sentence_expansion_on_required_empty_paragraph_returns_none() {
         let resource = Resource::new_test();
-        let (state, root, _p) = state! {
-            doc { root: root { p: paragraph {} } }
+        let (state, _p) = state! {
+            doc { root { p: paragraph {} } }
             selection: (p, 0)
         };
 
         let actual =
             resolve_sentence_selection_expansion(&state.doc, state.selection.unwrap(), &resource);
 
-        assert_eq!(
-            actual,
-            Some(Selection::new(
-                Position::new(root, 0),
-                Position {
-                    node_id: root,
-                    offset: 1,
-                    affinity: Affinity::Upstream,
-                },
-            ))
-        );
+        assert_eq!(actual, None);
     }
 
     #[test]
@@ -868,9 +829,9 @@ mod tests {
     }
 
     #[test]
-    fn paragraph_expansion_on_empty_paragraph_selects_paragraph_unit() {
-        let (state, root, _p) = state! {
-            doc { root: root { p: paragraph {} } }
+    fn paragraph_expansion_on_empty_paragraph_selects_its_trailing_paragraph_break() {
+        let (state, p, t) = state! {
+            doc { root { p: paragraph {} paragraph { t: text("next") } } }
             selection: (p, 0)
         };
 
@@ -879,10 +840,10 @@ mod tests {
         assert_eq!(
             actual,
             Some(Selection::new(
-                Position::new(root, 0),
+                Position::new(p, 0),
                 Position {
-                    node_id: root,
-                    offset: 1,
+                    node_id: t,
+                    offset: 0,
                     affinity: Affinity::Upstream,
                 },
             ))

--- a/crates/editor-view/src/measure/measurer.rs
+++ b/crates/editor-view/src/measure/measurer.rs
@@ -331,8 +331,11 @@ mod tests {
             })
             .expect("should find atom");
 
-        assert_eq!(atom.index, 0, "atom index should reflect current position");
-        assert_eq!(atom.parent_id, NodeId::ROOT);
+        assert_eq!(
+            atom.attachment.index, 0,
+            "atom index should reflect current position"
+        );
+        assert_eq!(atom.attachment.parent_id, NodeId::ROOT);
     }
 
     fn make_op(id: editor_crdt::Dot, payload: DocOp) -> Op<DocOp> {

--- a/crates/editor-view/src/page_fragment.rs
+++ b/crates/editor-view/src/page_fragment.rs
@@ -4,7 +4,9 @@ use editor_model::NodeId;
 use crate::glyph_run::{GlyphRun, RubyAnnotation};
 use crate::measure::TabGap;
 use crate::page::LayoutPage;
-use crate::paginate::{LayoutAtom, LayoutContent, LayoutLine, LayoutNode, LayoutTree, NavUnit};
+use crate::paginate::{
+    ChildAttachment, LayoutAtom, LayoutContent, LayoutLine, LayoutNode, LayoutTree,
+};
 use crate::query::Edges;
 use crate::style::{BoxStyle, DecorationData};
 
@@ -34,7 +36,7 @@ pub struct PageFragmentBox {
     pub edges: Edges<bool>,
     pub decorations: Vec<PageFragmentDecoration>,
     pub children: Vec<PageFragmentNode>,
-    pub nav: Option<NavUnit>,
+    pub attachment: Option<ChildAttachment>,
 }
 
 #[derive(Debug, Clone)]
@@ -61,8 +63,7 @@ pub struct PageFragmentLine {
 #[derive(Debug, Clone)]
 pub struct PageFragmentAtom {
     pub node_id: NodeId,
-    pub parent_id: NodeId,
-    pub index: usize,
+    pub attachment: ChildAttachment,
 }
 
 impl PageFragmentNode {
@@ -136,7 +137,7 @@ fn fragment_node(node: &LayoutNode, page: &LayoutPage) -> Option<PageFragmentNod
                     .iter()
                     .filter_map(|child| fragment_node(child, page))
                     .collect(),
-                nav: b.nav,
+                attachment: b.attachment,
             });
             return Some(PageFragmentNode { rect, content });
         }
@@ -216,7 +217,6 @@ fn fragment_line(line: &LayoutLine) -> PageFragmentLine {
 fn fragment_atom(atom: &LayoutAtom) -> PageFragmentAtom {
     PageFragmentAtom {
         node_id: atom.node_id,
-        parent_id: atom.parent_id,
-        index: atom.index,
+        attachment: atom.attachment,
     }
 }

--- a/crates/editor-view/src/paginate/paginator.rs
+++ b/crates/editor-view/src/paginate/paginator.rs
@@ -88,10 +88,8 @@ impl Paginator {
                     }
                     Direction::Horizontal => self.place_horizontal(b, node),
                 };
-                if b.style.monolithic
-                    && let LayoutContent::Box(lb) = &mut placed.content
-                {
-                    lb.nav = Some(NavUnit {
+                if let LayoutContent::Box(lb) = &mut placed.content {
+                    lb.attachment = (lb.node_id != parent_id).then_some(ChildAttachment {
                         parent_id,
                         index: child_index,
                     });
@@ -129,8 +127,10 @@ impl Paginator {
                     rect: Rect::from_xywh(x, y, node.width, node.height),
                     content: LayoutContent::Atom(LayoutAtom {
                         node_id: a.node_id,
-                        parent_id,
-                        index: child_index,
+                        attachment: ChildAttachment {
+                            parent_id,
+                            index: child_index,
+                        },
                     }),
                 }
             }
@@ -275,7 +275,7 @@ impl Paginator {
                 node_id: measured.node_id,
                 style: measured.style.clone(),
                 children,
-                nav: None,
+                attachment: None,
             }),
         }
     }
@@ -328,7 +328,7 @@ impl Paginator {
                 node_id: measured.node_id,
                 style: measured.style.clone(),
                 children,
-                nav: None,
+                attachment: None,
             }),
         }
     }
@@ -596,20 +596,17 @@ fn place_node_at(
                         .collect()
                 }
             };
+            let attachment = Some(ChildAttachment {
+                parent_id,
+                index: child_index,
+            });
             LayoutNode {
                 rect: Rect::from_xywh(x, y, node.width, node.height),
                 content: LayoutContent::Box(LayoutBox {
                     node_id: b.node_id,
                     style: b.style.clone(),
                     children,
-                    nav: if b.style.monolithic {
-                        Some(NavUnit {
-                            parent_id,
-                            index: child_index,
-                        })
-                    } else {
-                        None
-                    },
+                    attachment,
                 }),
             }
         }
@@ -635,8 +632,10 @@ fn place_node_at(
             rect: Rect::from_xywh(x, y, node.width, node.height),
             content: LayoutContent::Atom(LayoutAtom {
                 node_id: a.node_id,
-                parent_id,
-                index: child_index,
+                attachment: ChildAttachment {
+                    parent_id,
+                    index: child_index,
+                },
             }),
         },
         MeasuredContent::Spacing(h) => LayoutNode {
@@ -1633,16 +1632,20 @@ mod tests {
         );
     }
 
-    fn nav_of(tree: &LayoutTree, pages: &[LayoutPage], id: NodeId) -> Option<NavUnit> {
+    fn attachment_of(
+        tree: &LayoutTree,
+        pages: &[LayoutPage],
+        id: NodeId,
+    ) -> Option<ChildAttachment> {
         let layout_index = LayoutIndex::new(tree.clone(), pages);
         match &layout_index.box_entry(id)?.content(&layout_index)? {
-            LayoutContent::Box(b) => b.nav,
+            LayoutContent::Box(b) => b.attachment,
             _ => None,
         }
     }
 
     #[test]
-    fn monolithic_box_carries_nav_linkage() {
+    fn monolithic_box_carries_attachment_linkage() {
         let (st, r, f, ..) = state! {
             doc { r: root {
                 f: fold { fold_title { text("t") } fold_content { paragraph { text("c") } } }
@@ -1655,8 +1658,8 @@ mod tests {
         let tree = view.layout_tree_for_test().expect("laid out");
         let pages = view.pages();
         assert_eq!(
-            nav_of(tree, pages, f),
-            Some(NavUnit {
+            attachment_of(tree, pages, f),
+            Some(ChildAttachment {
                 parent_id: r,
                 index: 0
             })
@@ -1664,7 +1667,7 @@ mod tests {
     }
 
     #[test]
-    fn monolithic_box_in_table_cell_carries_nav_linkage() {
+    fn monolithic_box_in_table_cell_carries_attachment_linkage() {
         let (st, tc, f, ..) = state! {
             doc { root {
                 table { table_row { tc: table_cell {
@@ -1679,8 +1682,8 @@ mod tests {
         let tree = view.layout_tree_for_test().expect("laid out");
         let pages = view.pages();
         assert_eq!(
-            nav_of(tree, pages, f),
-            Some(NavUnit {
+            attachment_of(tree, pages, f),
+            Some(ChildAttachment {
                 parent_id: tc,
                 index: 0
             }),

--- a/crates/editor-view/src/paginate/types.rs
+++ b/crates/editor-view/src/paginate/types.rs
@@ -42,7 +42,7 @@ pub enum SpacingKind {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct NavUnit {
+pub struct ChildAttachment {
     pub parent_id: NodeId,
     pub index: usize,
 }
@@ -52,7 +52,7 @@ pub struct LayoutBox {
     pub node_id: NodeId,
     pub style: BoxStyle,
     pub children: Vec<LayoutNode>,
-    pub nav: Option<NavUnit>,
+    pub attachment: Option<ChildAttachment>,
 }
 
 #[derive(Debug, Clone)]
@@ -77,6 +77,5 @@ pub struct LayoutLine {
 #[derive(Debug, Clone)]
 pub struct LayoutAtom {
     pub node_id: NodeId,
-    pub parent_id: NodeId,
-    pub index: usize,
+    pub attachment: ChildAttachment,
 }

--- a/crates/editor-view/src/query/cursor.rs
+++ b/crates/editor-view/src/query/cursor.rs
@@ -107,7 +107,7 @@ mod tests {
                             content_edge_x: None,
                         }),
                     }],
-                    nav: None,
+                    attachment: None,
                 }),
             },
         }
@@ -181,7 +181,7 @@ mod tests {
                             content_edge_x: None,
                         }),
                     }],
-                    nav: None,
+                    attachment: None,
                 }),
             },
         };
@@ -230,7 +230,7 @@ mod tests {
                             content_edge_x: None,
                         }),
                     }],
-                    nav: None,
+                    attachment: None,
                 }),
             },
         };
@@ -283,7 +283,7 @@ mod tests {
                             content_edge_x: None,
                         }),
                     }],
-                    nav: None,
+                    attachment: None,
                 }),
             },
         };
@@ -331,7 +331,7 @@ mod tests {
                             content_edge_x: None,
                         }),
                     }],
-                    nav: None,
+                    attachment: None,
                 }),
             },
         };
@@ -381,11 +381,13 @@ mod tests {
                         rect: Rect::from_xywh(10.0, 5.0, 150.0, 40.0),
                         content: LayoutContent::Atom(LayoutAtom {
                             node_id: NodeId::new(),
-                            parent_id: para_id,
-                            index: 0,
+                            attachment: ChildAttachment {
+                                parent_id: para_id,
+                                index: 0,
+                            },
                         }),
                     }],
-                    nav: None,
+                    attachment: None,
                 }),
             },
         };
@@ -450,7 +452,7 @@ mod tests {
                             }),
                         },
                     ],
-                    nav: None,
+                    attachment: None,
                 }),
             },
         };
@@ -502,7 +504,7 @@ mod tests {
                             content_edge_x: None,
                         }),
                     }],
-                    nav: None,
+                    attachment: None,
                 }),
             },
         };

--- a/crates/editor-view/src/query/dnd.rs
+++ b/crates/editor-view/src/query/dnd.rs
@@ -70,7 +70,10 @@ fn dnd_position_for_entry(
 ) -> Option<Position> {
     match entry.content(layout_index)? {
         LayoutContent::Line(line) => Some(position_in_line(line, &entry.rect, point.x)),
-        LayoutContent::Atom(atom) => Some(Position::new(atom.parent_id, atom.index + 1)),
+        LayoutContent::Atom(atom) => Some(Position::new(
+            atom.attachment.parent_id,
+            atom.attachment.index + 1,
+        )),
         LayoutContent::Box(b) => box_edge_position(layout_index, doc, b, point),
         LayoutContent::Spacing(SpacingKind::Gap { position }) => Some(*position),
         LayoutContent::Spacing(SpacingKind::Fill) => None,
@@ -171,8 +174,8 @@ fn drop_child(
                 rect: entry.rect,
             })
         }
-        LayoutContent::Atom(atom) => (atom.parent_id == parent_id).then(|| DropChild {
-            offset: atom.index,
+        LayoutContent::Atom(atom) => (atom.attachment.parent_id == parent_id).then(|| DropChild {
+            offset: atom.attachment.index,
             rect: entry.rect,
         }),
         LayoutContent::Line(_) | LayoutContent::Spacing(_) => None,
@@ -350,7 +353,7 @@ mod tests {
                     monolithic: false,
                 },
                 children,
-                nav: None,
+                attachment: None,
             }),
         }
     }

--- a/crates/editor-view/src/query/interactive.rs
+++ b/crates/editor-view/src/query/interactive.rs
@@ -191,7 +191,7 @@ mod tests {
                     ..Default::default()
                 },
                 children,
-                nav: None,
+                attachment: None,
             }),
         }
     }

--- a/crates/editor-view/src/query/layout_index.rs
+++ b/crates/editor-view/src/query/layout_index.rs
@@ -396,11 +396,13 @@ fn rect_overlaps_y_range(rect: &Rect, y_start: f32, y_end: f32) -> bool {
 
 fn position_matches_node(node: &LayoutNode, pos: &Position) -> bool {
     match &node.content {
-        LayoutContent::Box(b) => b
-            .nav
-            .is_some_and(|unit| position_attaches_to_child(pos, unit.parent_id, unit.index)),
+        LayoutContent::Box(b) => b.attachment.is_some_and(|attachment| {
+            position_attaches_to_child(pos, attachment.parent_id, attachment.index)
+        }),
         LayoutContent::Line(line) => position_matches_line(line, pos),
-        LayoutContent::Atom(atom) => position_attaches_to_child(pos, atom.parent_id, atom.index),
+        LayoutContent::Atom(atom) => {
+            position_attaches_to_child(pos, atom.attachment.parent_id, atom.attachment.index)
+        }
         LayoutContent::Spacing(_) => false,
     }
 }
@@ -519,9 +521,24 @@ mod tests {
                     monolithic: false,
                 },
                 children,
-                nav: None,
+                attachment: None,
             }),
         }
+    }
+
+    fn attached_box_node(
+        id: NodeId,
+        parent_id: NodeId,
+        index: usize,
+        rect: Rect,
+        children: Vec<LayoutNode>,
+    ) -> LayoutNode {
+        let mut node = box_node(id, rect, children);
+        let LayoutContent::Box(b) = &mut node.content else {
+            unreachable!("box_node creates a box");
+        };
+        b.attachment = Some(ChildAttachment { parent_id, index });
+        node
     }
 
     fn line_id(layout_index: &LayoutIndex, entry: &LayoutEntry) -> NodeId {
@@ -578,6 +595,45 @@ mod tests {
             entry.content(&layout_index),
             Some(LayoutContent::Box(b)) if b.node_id == box_id
         ));
+    }
+
+    #[test]
+    fn entry_for_position_resolves_attached_non_monolithic_box_edges() {
+        let box_id = NodeId::new();
+        let tree = LayoutTree {
+            root: box_node(
+                NodeId::ROOT,
+                Rect::from_xywh(0.0, 0.0, 200.0, 20.0),
+                vec![attached_box_node(
+                    box_id,
+                    NodeId::ROOT,
+                    0,
+                    Rect::from_xywh(0.0, 0.0, 200.0, 20.0),
+                    vec![line_node(NodeId::new(), 0.0, 0.0, "hello", 10.0)],
+                )],
+            ),
+        };
+        let pages = [page(0.0, 100.0)];
+        let layout_index = LayoutIndex::new(tree, &pages);
+
+        for pos in [
+            Position {
+                node_id: NodeId::ROOT,
+                offset: 0,
+                affinity: Affinity::Downstream,
+            },
+            Position {
+                node_id: NodeId::ROOT,
+                offset: 1,
+                affinity: Affinity::Upstream,
+            },
+        ] {
+            let entry = layout_index.entry_for_position(&pos).unwrap();
+            assert!(matches!(
+                entry.content(&layout_index),
+                Some(LayoutContent::Box(b)) if b.node_id == box_id
+            ));
+        }
     }
 
     #[test]

--- a/crates/editor-view/src/query/link.rs
+++ b/crates/editor-view/src/query/link.rs
@@ -120,7 +120,7 @@ mod tests {
                     ..Default::default()
                 },
                 children,
-                nav: None,
+                attachment: None,
             }),
         }
     }

--- a/crates/editor-view/src/query/mod.rs
+++ b/crates/editor-view/src/query/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod interactive;
 pub(crate) mod layout_index;
 pub(crate) mod link;
 pub(crate) mod navigation;
+pub(crate) mod paragraph_break;
 pub(crate) mod placeholder;
 pub(crate) mod pointer_style;
 pub(crate) mod segmentation;

--- a/crates/editor-view/src/query/navigation.rs
+++ b/crates/editor-view/src/query/navigation.rs
@@ -172,8 +172,9 @@ fn move_grapheme_forward(layout_index: &LayoutIndex, pos: &Position) -> Option<S
             }
             Some(landed_entry(layout_index, next, false, true))
         }
+        LayoutContent::Box(b) => move_box_boundary(layout_index, entry, b, pos, true),
         _ => {
-            let nv = nav_unit(layout_index, entry)?;
+            let nv = unit_attachment(layout_index, entry)?;
             if let Some(next) = next_navigable_entry(layout_index, entry) {
                 Some(landed_entry(layout_index, next, false, true))
             } else {
@@ -284,8 +285,9 @@ fn move_grapheme_backward(layout_index: &LayoutIndex, pos: &Position) -> Option<
             }
             Some(landed_entry(layout_index, prev, true, false))
         }
+        LayoutContent::Box(b) => move_box_boundary(layout_index, entry, b, pos, false),
         _ => {
-            let nv = nav_unit(layout_index, entry)?;
+            let nv = unit_attachment(layout_index, entry)?;
             if let Some(prev) = prev_navigable_entry(layout_index, entry) {
                 Some(landed_entry(layout_index, prev, true, false))
             } else {
@@ -299,6 +301,7 @@ fn move_line_horizontal_forward(layout_index: &LayoutIndex, pos: &Position) -> O
     let entry = layout_index.entry_for_position(pos)?;
     match entry.content(layout_index)? {
         LayoutContent::Line(line) => Some(Selection::collapsed(last_position_in_line(line))),
+        LayoutContent::Box(b) => move_box_boundary(layout_index, entry, b, pos, true),
         _ => None,
     }
 }
@@ -307,6 +310,7 @@ fn move_line_horizontal_backward(layout_index: &LayoutIndex, pos: &Position) -> 
     let entry = layout_index.entry_for_position(pos)?;
     match entry.content(layout_index)? {
         LayoutContent::Line(line) => Some(Selection::collapsed(first_position_in_line(line))),
+        LayoutContent::Box(b) => move_box_boundary(layout_index, entry, b, pos, false),
         _ => None,
     }
 }
@@ -524,10 +528,12 @@ fn last_position_in_line(line: &LayoutLine) -> Position {
 fn first_position_in_entry(layout_index: &LayoutIndex, entry: &LayoutEntry) -> Position {
     match entry.content(layout_index) {
         Some(LayoutContent::Line(line)) => first_position_in_line(line),
-        Some(LayoutContent::Atom(atom)) => Position::new(atom.parent_id, atom.index),
-        Some(LayoutContent::Box(b)) if b.nav.is_some() => {
-            let unit = b.nav.expect("checked is_some");
-            Position::new(unit.parent_id, unit.index)
+        Some(LayoutContent::Atom(atom)) => {
+            Position::new(atom.attachment.parent_id, atom.attachment.index)
+        }
+        Some(LayoutContent::Box(b)) if b.style.monolithic && b.attachment.is_some() => {
+            let attachment = b.attachment.expect("checked is_some");
+            Position::new(attachment.parent_id, attachment.index)
         }
         _ => {
             unreachable!("first_position_in_entry called on non-navigable entry")
@@ -538,10 +544,12 @@ fn first_position_in_entry(layout_index: &LayoutIndex, entry: &LayoutEntry) -> P
 fn last_position_in_entry(layout_index: &LayoutIndex, entry: &LayoutEntry) -> Position {
     match entry.content(layout_index) {
         Some(LayoutContent::Line(line)) => last_position_in_line(line),
-        Some(LayoutContent::Atom(atom)) => Position::new(atom.parent_id, atom.index),
-        Some(LayoutContent::Box(b)) if b.nav.is_some() => {
-            let unit = b.nav.expect("checked is_some");
-            Position::new(unit.parent_id, unit.index)
+        Some(LayoutContent::Atom(atom)) => {
+            Position::new(atom.attachment.parent_id, atom.attachment.index)
+        }
+        Some(LayoutContent::Box(b)) if b.style.monolithic && b.attachment.is_some() => {
+            let attachment = b.attachment.expect("checked is_some");
+            Position::new(attachment.parent_id, attachment.index)
         }
         _ => {
             unreachable!("last_position_in_entry called on non-navigable entry")
@@ -549,9 +557,64 @@ fn last_position_in_entry(layout_index: &LayoutIndex, entry: &LayoutEntry) -> Po
     }
 }
 
+pub(super) fn move_box_boundary(
+    layout_index: &LayoutIndex,
+    entry: &LayoutEntry,
+    b: &LayoutBox,
+    pos: &Position,
+    forward: bool,
+) -> Option<Selection> {
+    let pivot = box_boundary_pivot(layout_index, entry, b, pos)?;
+    let target = navigable_from_pivot(layout_index, pivot, forward)?;
+    Some(landed_entry(layout_index, target, !forward, forward))
+}
+
+fn box_boundary_pivot(
+    layout_index: &LayoutIndex,
+    entry: &LayoutEntry,
+    b: &LayoutBox,
+    pos: &Position,
+) -> Option<usize> {
+    b.attachment?;
+    let idx = layout_index.entry_index(entry)?;
+    Some(match pos.affinity {
+        Affinity::Downstream => idx,
+        Affinity::Upstream => index_after_box_subtree(layout_index, idx, b.node_id),
+    })
+}
+
+fn index_after_box_subtree(layout_index: &LayoutIndex, idx: usize, node_id: NodeId) -> usize {
+    layout_index
+        .entries()
+        .enumerate()
+        .skip(idx + 1)
+        .find(|(_, entry)| !entry.ancestors().contains(&node_id))
+        .map(|(idx, _)| idx)
+        .unwrap_or_else(|| layout_index.entries().len())
+}
+
+fn navigable_from_pivot(
+    layout_index: &LayoutIndex,
+    pivot: usize,
+    forward: bool,
+) -> Option<&LayoutEntry> {
+    if forward {
+        layout_index
+            .entries()
+            .skip(pivot)
+            .find(|entry| is_navigable_entry(layout_index, entry))
+    } else {
+        layout_index
+            .entries()
+            .take(pivot)
+            .rev()
+            .find(|entry| is_navigable_entry(layout_index, entry))
+    }
+}
+
 /// First (`at_end=false`) / last (`at_end=true`) editable caret position
-/// *inside* `node_id`'s subtree — descends past the node's own `nav`
-/// bracket into its children. `None` when the node is not a Box (atoms
+/// *inside* `node_id`'s subtree — descends past the node's own attachment
+/// boundary into its children. `None` when the node is not a Box (atoms
 /// have no inner navigable) or has no navigable descendant.
 pub(crate) fn editable_position_inside(
     layout_index: &LayoutIndex,
@@ -621,11 +684,9 @@ pub(super) fn next_navigable_entry<'a>(
     entry: &LayoutEntry,
 ) -> Option<&'a LayoutEntry> {
     let idx = layout_index.entry_index(entry)?;
-    let skipped_subtree = unit_box_id(layout_index, entry);
     layout_index
         .entries()
         .skip(idx + 1)
-        .filter(|entry| skipped_subtree.is_none_or(|node_id| !entry.ancestors().contains(&node_id)))
         .find(|entry| is_navigable_entry(layout_index, entry))
 }
 
@@ -634,12 +695,10 @@ pub(super) fn prev_navigable_entry<'a>(
     entry: &LayoutEntry,
 ) -> Option<&'a LayoutEntry> {
     let idx = layout_index.entry_index(entry)?;
-    let skipped_subtree = unit_box_id(layout_index, entry);
     layout_index
         .entries()
         .take(idx)
         .rev()
-        .filter(|entry| skipped_subtree.is_none_or(|node_id| !entry.ancestors().contains(&node_id)))
         .find(|entry| is_navigable_entry(layout_index, entry))
 }
 
@@ -761,13 +820,6 @@ fn is_navigable_inside(layout_index: &LayoutIndex, entry: &LayoutEntry, node_id:
     is_navigable_entry(layout_index, entry) && entry.ancestors().contains(&node_id)
 }
 
-fn unit_box_id(layout_index: &LayoutIndex, entry: &LayoutEntry) -> Option<NodeId> {
-    let LayoutContent::Box(b) = entry.content(layout_index)? else {
-        return None;
-    };
-    b.nav.is_some().then_some(b.node_id)
-}
-
 fn compare_navigation_band_entry(
     a: &LayoutEntry,
     b: &LayoutEntry,
@@ -805,18 +857,16 @@ fn axis_distance(start: f32, end: f32, value: f32) -> f32 {
     }
 }
 
-fn nav_unit(layout_index: &LayoutIndex, entry: &LayoutEntry) -> Option<NavUnit> {
+fn unit_attachment(layout_index: &LayoutIndex, entry: &LayoutEntry) -> Option<ChildAttachment> {
     match entry.content(layout_index)? {
-        LayoutContent::Atom(atom) => Some(NavUnit {
-            parent_id: atom.parent_id,
-            index: atom.index,
-        }),
-        LayoutContent::Box(b) => b.nav,
+        LayoutContent::Atom(atom) => Some(atom.attachment),
+        LayoutContent::Box(b) if b.style.monolithic => b.attachment,
+        LayoutContent::Box(_) => None,
         LayoutContent::Line(_) | LayoutContent::Spacing(_) => None,
     }
 }
 
-fn unit_selection(nv: NavUnit, forward: bool) -> Selection {
+fn unit_selection(nv: ChildAttachment, forward: bool) -> Selection {
     let front = Position {
         node_id: nv.parent_id,
         offset: nv.index,
@@ -844,7 +894,7 @@ pub(crate) fn landed_entry(
     at_end: bool,
     forward: bool,
 ) -> Selection {
-    if let Some(nv) = nav_unit(layout_index, entry) {
+    if let Some(nv) = unit_attachment(layout_index, entry) {
         return unit_selection(nv, forward);
     }
     let pos = if at_end {
@@ -864,13 +914,7 @@ fn navigate_to_entry(
         Some(LayoutContent::Line(line)) => {
             Selection::collapsed(position_in_line(line, &entry.rect, preferred_x))
         }
-        Some(LayoutContent::Atom(atom)) => unit_selection(
-            NavUnit {
-                parent_id: atom.parent_id,
-                index: atom.index,
-            },
-            true,
-        ),
+        Some(LayoutContent::Atom(atom)) => unit_selection(atom.attachment, true),
         _ => {
             unreachable!("navigate_to_entry called on non-navigable")
         }
@@ -940,17 +984,25 @@ mod tests {
             rect: Rect::from_xywh(0.0, y, 200.0, 20.0),
             content: LayoutContent::Atom(LayoutAtom {
                 node_id,
-                parent_id,
-                index,
+                attachment: ChildAttachment { parent_id, index },
             }),
         }
     }
 
     fn make_box_node(y: f32, h: f32, children: Vec<LayoutNode>) -> LayoutNode {
+        make_box_node_with_id(NodeId::new(), y, h, children)
+    }
+
+    fn make_box_node_with_id(
+        node_id: NodeId,
+        y: f32,
+        h: f32,
+        children: Vec<LayoutNode>,
+    ) -> LayoutNode {
         LayoutNode {
             rect: Rect::from_xywh(0.0, y, 200.0, h),
             content: LayoutContent::Box(LayoutBox {
-                node_id: NodeId::new(),
+                node_id,
                 style: BoxStyle {
                     direction: LayoutDirection::Vertical,
                     padding: EdgeInsets::ZERO,
@@ -961,7 +1013,50 @@ mod tests {
                     monolithic: false,
                 },
                 children,
-                nav: None,
+                attachment: None,
+            }),
+        }
+    }
+
+    fn make_attached_box_node(
+        parent_id: NodeId,
+        index: usize,
+        node_id: NodeId,
+        y: f32,
+        h: f32,
+        children: Vec<LayoutNode>,
+    ) -> LayoutNode {
+        let mut node = make_box_node_with_id(node_id, y, h, children);
+        let LayoutContent::Box(b) = &mut node.content else {
+            unreachable!("make_box_node_with_id returns a box");
+        };
+        b.attachment = Some(ChildAttachment { parent_id, index });
+        node
+    }
+
+    fn make_paragraph_line(
+        paragraph_id: NodeId,
+        text_id: NodeId,
+        y: f32,
+        text: &str,
+    ) -> LayoutNode {
+        let n = text.chars().count();
+        LayoutNode {
+            rect: Rect::from_xywh(0.0, y, 200.0, 20.0),
+            content: LayoutContent::Line(LayoutLine {
+                node_id: paragraph_id,
+                baseline: 16.0,
+                ascent: 14.0,
+                descent: 4.0,
+                cursor_ascent: 14.0,
+                cursor_descent: 4.0,
+                glyph_runs: vec![GlyphRun::make_test_run(text_id, 0, text, 0.0, gs(n))],
+                ruby_annotations: vec![],
+                empty_caret_x: 0.0,
+                child_range: None,
+                tab_gaps: vec![],
+                is_phantom: false,
+                content_edge_x: None,
             }),
         }
     }
@@ -1768,6 +1863,139 @@ mod tests {
     }
 
     #[test]
+    fn grapheme_forward_from_attached_box_leading_boundary_uses_next_stream_entry() {
+        let paragraph_id = NodeId::new();
+        let text_id = NodeId::new();
+        let tree = LayoutTree {
+            root: make_box_node_with_id(
+                NodeId::ROOT,
+                0.0,
+                20.0,
+                vec![make_attached_box_node(
+                    NodeId::ROOT,
+                    0,
+                    paragraph_id,
+                    0.0,
+                    20.0,
+                    vec![make_paragraph_line(paragraph_id, text_id, 0.0, "ab")],
+                )],
+            ),
+        };
+
+        let sel = mov(
+            &tree,
+            Position {
+                node_id: NodeId::ROOT,
+                offset: 0,
+                affinity: Affinity::Downstream,
+            },
+            Movement::Grapheme {
+                direction: Direction::Forward,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(sel, Selection::collapsed(Position::new(text_id, 0)));
+    }
+
+    #[test]
+    fn grapheme_backward_from_attached_box_trailing_boundary_uses_prev_stream_entry() {
+        let paragraph_id = NodeId::new();
+        let text_id = NodeId::new();
+        let tree = LayoutTree {
+            root: make_box_node_with_id(
+                NodeId::ROOT,
+                0.0,
+                20.0,
+                vec![make_attached_box_node(
+                    NodeId::ROOT,
+                    0,
+                    paragraph_id,
+                    0.0,
+                    20.0,
+                    vec![make_paragraph_line(paragraph_id, text_id, 0.0, "ab")],
+                )],
+            ),
+        };
+
+        let sel = mov(
+            &tree,
+            Position {
+                node_id: NodeId::ROOT,
+                offset: 1,
+                affinity: Affinity::Upstream,
+            },
+            Movement::Grapheme {
+                direction: Direction::Backward,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            sel,
+            Selection::collapsed(Position {
+                node_id: text_id,
+                offset: 2,
+                affinity: Affinity::Upstream,
+            })
+        );
+    }
+
+    #[test]
+    fn grapheme_movement_skips_empty_attached_box_by_stream_order() {
+        let before_id = NodeId::new();
+        let empty_box_id = NodeId::new();
+        let after_id = NodeId::new();
+        let tree = LayoutTree {
+            root: make_box_node_with_id(
+                NodeId::ROOT,
+                0.0,
+                60.0,
+                vec![
+                    make_line_node(before_id, 0.0, "aa"),
+                    make_attached_box_node(NodeId::ROOT, 1, empty_box_id, 20.0, 20.0, vec![]),
+                    make_line_node(after_id, 40.0, "bb"),
+                ],
+            ),
+        };
+
+        let forward = mov(
+            &tree,
+            Position {
+                node_id: NodeId::ROOT,
+                offset: 1,
+                affinity: Affinity::Downstream,
+            },
+            Movement::Grapheme {
+                direction: Direction::Forward,
+            },
+        )
+        .unwrap();
+        assert_eq!(forward, Selection::collapsed(Position::new(after_id, 0)));
+
+        let backward = mov(
+            &tree,
+            Position {
+                node_id: NodeId::ROOT,
+                offset: 2,
+                affinity: Affinity::Upstream,
+            },
+            Movement::Grapheme {
+                direction: Direction::Backward,
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            backward,
+            Selection::collapsed(Position {
+                node_id: before_id,
+                offset: 2,
+                affinity: Affinity::Upstream,
+            })
+        );
+    }
+
+    #[test]
     fn grapheme_backward_from_text_after_atom_selects_atom_backward() {
         let f = fixture();
         // Moving backward from the start of "baz" whose previous navigable is an atom must produce a backward node selection.
@@ -2432,14 +2660,14 @@ mod tests {
     }
 
     #[test]
-    fn fold_node_selection_arrow_left_steps_out_backward() {
-        let (st, r, before) = state! {
+    fn fold_trailing_boundary_arrow_left_enters_fold_content() {
+        let (st, r, c) = state! {
             doc { r: root {
-                paragraph { before: text("prev") }
-                fold { fold_title { text("t") } fold_content { paragraph { text("c") } } }
+                paragraph { text("prev") }
+                fold { fold_title { text("t") } fold_content { paragraph { c: text("c") } } }
                 paragraph { text("after") }
             } }
-            selection: (before, 0)
+            selection: (c, 0)
         };
         let mut view = View::new_test();
         view.layout(&st.doc);
@@ -2456,10 +2684,10 @@ mod tests {
                 },
                 &Resource::new_test(),
             )
-            .expect("arrow-left must move from a fold node-selection");
+            .expect("arrow-left must move from the fold trailing boundary");
         assert!(sel.is_collapsed());
-        assert_eq!(sel.head.node_id, before);
-        assert_eq!(sel.head.offset, 4);
+        assert_eq!(sel.head.node_id, c);
+        assert_eq!(sel.head.offset, 1);
     }
 
     #[test]

--- a/crates/editor-view/src/query/paragraph_break.rs
+++ b/crates/editor-view/src/query/paragraph_break.rs
@@ -1,0 +1,187 @@
+use editor_common::Rect;
+use editor_model::{Doc, Node};
+use editor_state::{
+    Affinity, NodeRefCursorExt, Position, ResolvedPosition, ResolvedSelection, Selection,
+    paragraph_break_selection_at_paragraph_end, position_before_or_same_logical_boundary,
+};
+
+use crate::page::{LayoutPage, PageRect};
+use crate::paginate::{LayoutContent, SpacingKind};
+
+use super::common::page_for_y;
+use super::layout_index::{LayoutEntry, LayoutIndex, LayoutPoint};
+
+pub(crate) struct ParagraphBreakGeometry {
+    pub(crate) rect: PageRect,
+    pub(crate) line_right: f32,
+}
+
+pub(crate) struct SelectedParagraphBreak {
+    pub(crate) selection: Selection,
+    pub(crate) geometry: ParagraphBreakGeometry,
+}
+
+pub(crate) fn included_in_selection(
+    layout_index: &LayoutIndex,
+    selection: &ResolvedSelection<'_>,
+) -> Vec<SelectedParagraphBreak> {
+    let mut paragraph_breaks = Vec::new();
+    for entry in layout_index.entries() {
+        let Some(paragraph_break) = paragraph_break_for_entry(layout_index, selection.doc(), entry)
+        else {
+            continue;
+        };
+        if !selection.contains_range(paragraph_break.selection) {
+            continue;
+        }
+        if paragraph_breaks
+            .iter()
+            .any(|existing: &SelectedParagraphBreak| {
+                existing.selection == paragraph_break.selection
+            })
+        {
+            continue;
+        }
+        paragraph_breaks.push(paragraph_break);
+    }
+    paragraph_breaks
+}
+
+fn geometry(
+    layout_index: &LayoutIndex,
+    paragraph_break: Selection,
+    pages: &[LayoutPage],
+) -> Option<ParagraphBreakGeometry> {
+    let pos = paragraph_break.anchor;
+    let entry = layout_index.entry_for_position(&pos)?;
+    let LayoutContent::Line(line) = entry.content(layout_index)? else {
+        return None;
+    };
+    geometry_for_line_entry(entry, line, paragraph_break, pages)
+}
+
+pub(crate) fn drag_selection_for_entry(
+    layout_index: &LayoutIndex,
+    doc: &Doc,
+    anchor: &ResolvedPosition<'_>,
+    entry: &LayoutEntry,
+    point: LayoutPoint,
+) -> Option<Selection> {
+    let paragraph_break = paragraph_break_for_entry(layout_index, doc, entry)?;
+    match entry.content(layout_index)? {
+        LayoutContent::Line(_) => {
+            let rect = paragraph_break.geometry.rect.rect;
+            let page_y = point.y - point.page_y_start;
+            let x_mid = rect.x + rect.width / 2.0;
+            if paragraph_break.geometry.rect.page_idx == point.page_idx
+                && page_y >= rect.y
+                && page_y <= rect.bottom()
+                && point.x >= x_mid
+                && point.x <= paragraph_break.geometry.line_right
+            {
+                Some(paragraph_break.selection)
+            } else {
+                None
+            }
+        }
+        LayoutContent::Spacing(SpacingKind::Gap { .. }) => {
+            let resolved = paragraph_break.selection.resolve(doc)?;
+            if position_before_or_same_logical_boundary(
+                doc,
+                Position::from(anchor),
+                Position::from(resolved.from()),
+            ) {
+                Some(paragraph_break.selection)
+            } else {
+                Some(Selection::collapsed(paragraph_break.selection.head))
+            }
+        }
+        LayoutContent::Box(_) | LayoutContent::Atom(_) | LayoutContent::Spacing(_) => None,
+    }
+}
+
+fn paragraph_break_for_entry(
+    layout_index: &LayoutIndex,
+    doc: &Doc,
+    entry: &LayoutEntry,
+) -> Option<SelectedParagraphBreak> {
+    match entry.content(layout_index)? {
+        LayoutContent::Line(line) => {
+            let selection = paragraph_break_for_line(doc, line)?;
+            let geometry = geometry_for_line_entry(entry, line, selection, layout_index.pages())?;
+            Some(SelectedParagraphBreak {
+                selection,
+                geometry,
+            })
+        }
+        LayoutContent::Spacing(SpacingKind::Gap { position }) => {
+            let selection = paragraph_break_before_gap_boundary(doc, *position)?;
+            let geometry = geometry(layout_index, selection, layout_index.pages())?;
+            Some(SelectedParagraphBreak {
+                selection,
+                geometry,
+            })
+        }
+        LayoutContent::Box(_) | LayoutContent::Atom(_) | LayoutContent::Spacing(_) => None,
+    }
+}
+
+fn paragraph_break_for_line(doc: &Doc, line: &crate::paginate::LayoutLine) -> Option<Selection> {
+    if !line_can_host_visual_paragraph_break(line) {
+        return None;
+    }
+    let line_end = super::grapheme::last_position_in_line(line);
+    paragraph_break_selection_at_paragraph_end(doc, line_end)
+}
+
+fn line_can_host_visual_paragraph_break(line: &crate::paginate::LayoutLine) -> bool {
+    let strut_line_represents_inline_child = line.glyph_runs.is_empty()
+        && line.tab_gaps.is_empty()
+        && line
+            .child_range
+            .as_ref()
+            .is_some_and(|range| range.start < range.end);
+    !strut_line_represents_inline_child
+}
+
+fn paragraph_break_before_gap_boundary(doc: &Doc, position: Position) -> Option<Selection> {
+    let parent = doc.node(position.node_id)?;
+    let previous = position
+        .offset
+        .checked_sub(1)
+        .and_then(|index| parent.children().nth(index))?;
+    if !matches!(previous.node(), Node::Paragraph(_)) {
+        return None;
+    }
+    paragraph_break_selection_at_paragraph_end(
+        doc,
+        Position {
+            affinity: Affinity::Downstream,
+            ..previous.last_cursor_position()?
+        },
+    )
+}
+
+fn geometry_for_line_entry(
+    entry: &LayoutEntry,
+    line: &crate::paginate::LayoutLine,
+    paragraph_break: Selection,
+    pages: &[LayoutPage],
+) -> Option<ParagraphBreakGeometry> {
+    let pos = paragraph_break.anchor;
+    let page_idx = page_for_y(pages, entry.rect.y)?;
+    let x = entry.rect.x + super::grapheme::x_at_offset(line, &pos);
+    let width = entry.rect.height * 0.15;
+    Some(ParagraphBreakGeometry {
+        rect: PageRect::new(
+            page_idx,
+            Rect::from_xywh(
+                x,
+                entry.rect.y - pages[page_idx].y_start,
+                width,
+                entry.rect.height,
+            ),
+        ),
+        line_right: entry.rect.right(),
+    })
+}

--- a/crates/editor-view/src/query/pointer_style.rs
+++ b/crates/editor-view/src/query/pointer_style.rs
@@ -139,8 +139,10 @@ mod tests {
             rect: Rect::from_xywh(x, y, w, h),
             content: LayoutContent::Atom(LayoutAtom {
                 node_id: id,
-                parent_id,
-                index: 0,
+                attachment: ChildAttachment {
+                    parent_id,
+                    index: 0,
+                },
             }),
         }
     }
@@ -168,7 +170,7 @@ mod tests {
                     monolithic: false,
                     ..Default::default()
                 },
-                nav: None,
+                attachment: None,
                 children,
             }),
         }

--- a/crates/editor-view/src/query/segmentation.rs
+++ b/crates/editor-view/src/query/segmentation.rs
@@ -8,7 +8,9 @@ use crate::measure::TabGap;
 use crate::paginate::*;
 
 use super::layout_index::LayoutIndex;
-use super::navigation::{landed_entry, next_navigable_entry, prev_navigable_entry};
+use super::navigation::{
+    landed_entry, move_box_boundary, next_navigable_entry, prev_navigable_entry,
+};
 
 pub fn move_word_forward(
     layout_index: &LayoutIndex,
@@ -18,9 +20,12 @@ pub fn move_word_forward(
     let entry = layout_index.entry_for_position(pos)?;
     let line = match entry.content(layout_index)? {
         LayoutContent::Line(l) => l,
-        LayoutContent::Atom(_) | LayoutContent::Box(LayoutBox { nav: Some(_), .. }) => {
+        LayoutContent::Atom(_) => {
             let next = next_navigable_entry(layout_index, entry)?;
             return Some(landed_entry(layout_index, next, false, true));
+        }
+        LayoutContent::Box(b) => {
+            return move_box_boundary(layout_index, entry, b, pos, true);
         }
         _ => return None,
     };
@@ -43,9 +48,12 @@ pub fn move_word_backward(
     let entry = layout_index.entry_for_position(pos)?;
     let line = match entry.content(layout_index)? {
         LayoutContent::Line(l) => l,
-        LayoutContent::Atom(_) | LayoutContent::Box(LayoutBox { nav: Some(_), .. }) => {
+        LayoutContent::Atom(_) => {
             let prev = prev_navigable_entry(layout_index, entry)?;
             return Some(landed_entry(layout_index, prev, true, false));
+        }
+        LayoutContent::Box(b) => {
+            return move_box_boundary(layout_index, entry, b, pos, false);
         }
         _ => return None,
     };
@@ -68,9 +76,12 @@ pub fn move_sentence_forward(
     let entry = layout_index.entry_for_position(pos)?;
     let line = match entry.content(layout_index)? {
         LayoutContent::Line(l) => l,
-        LayoutContent::Atom(_) | LayoutContent::Box(LayoutBox { nav: Some(_), .. }) => {
+        LayoutContent::Atom(_) => {
             let next = next_navigable_entry(layout_index, entry)?;
             return Some(landed_entry(layout_index, next, false, true));
+        }
+        LayoutContent::Box(b) => {
+            return move_box_boundary(layout_index, entry, b, pos, true);
         }
         _ => return None,
     };
@@ -93,9 +104,12 @@ pub fn move_sentence_backward(
     let entry = layout_index.entry_for_position(pos)?;
     let line = match entry.content(layout_index)? {
         LayoutContent::Line(l) => l,
-        LayoutContent::Atom(_) | LayoutContent::Box(LayoutBox { nav: Some(_), .. }) => {
+        LayoutContent::Atom(_) => {
             let prev = prev_navigable_entry(layout_index, entry)?;
             return Some(landed_entry(layout_index, prev, true, false));
+        }
+        LayoutContent::Box(b) => {
+            return move_box_boundary(layout_index, entry, b, pos, false);
         }
         _ => return None,
     };
@@ -129,6 +143,16 @@ fn line_items(line: &LayoutLine) -> Vec<LineItem<'_>> {
 }
 
 pub fn line_char_index(line: &LayoutLine, pos: &Position) -> Option<usize> {
+    if line_items(line).is_empty()
+        && pos.node_id == line.node_id
+        && line
+            .child_range
+            .as_ref()
+            .is_none_or(|range| pos.offset >= range.start && pos.offset <= range.end)
+    {
+        return Some(0);
+    }
+
     let mut char_count = 0;
     for item in line_items(line) {
         match item {
@@ -461,7 +485,7 @@ mod tests {
                         rect: Rect::from_xywh(0.0, 0.0, width, 20.0),
                         content: LayoutContent::Line(line),
                     }],
-                    nav: None,
+                    attachment: None,
                 }),
             },
         }
@@ -486,8 +510,10 @@ mod tests {
             rect: Rect::from_xywh(0.0, 20.0, 200.0, 20.0),
             content: LayoutContent::Atom(LayoutAtom {
                 node_id: atom_id,
-                parent_id: atom_parent,
-                index: 0,
+                attachment: ChildAttachment {
+                    parent_id: atom_parent,
+                    index: 0,
+                },
             }),
         };
         let tree = LayoutTree {
@@ -497,7 +523,7 @@ mod tests {
                     node_id: NodeId::new(),
                     style: make_box_style(),
                     children: vec![line, atom],
-                    nav: None,
+                    attachment: None,
                 }),
             },
         };
@@ -538,8 +564,10 @@ mod tests {
             rect: Rect::from_xywh(0.0, 0.0, 200.0, 20.0),
             content: LayoutContent::Atom(LayoutAtom {
                 node_id: atom_id,
-                parent_id: atom_parent,
-                index: 0,
+                attachment: ChildAttachment {
+                    parent_id: atom_parent,
+                    index: 0,
+                },
             }),
         };
         let line = LayoutNode {
@@ -553,7 +581,7 @@ mod tests {
                     node_id: NodeId::new(),
                     style: make_box_style(),
                     children: vec![atom, line],
-                    nav: None,
+                    attachment: None,
                 }),
             },
         };

--- a/crates/editor-view/src/query/selection.rs
+++ b/crates/editor-view/src/query/selection.rs
@@ -13,6 +13,7 @@ use super::layout_index::{LayoutEntry, LayoutIndex};
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum SelectionRectKind {
     Text,
+    ParagraphBreak,
     Atom,
     Block,
 }
@@ -23,6 +24,41 @@ pub type SelectionRect = PageRect<SelectionRectKind>;
 struct SelectionRectSets {
     pub line_box_rects: Vec<SelectionRect>,
     pub text_rects: Vec<SelectionRect>,
+}
+
+impl SelectionRectSets {
+    fn empty() -> Self {
+        Self {
+            line_box_rects: Vec::new(),
+            text_rects: Vec::new(),
+        }
+    }
+
+    fn mirrored(rects: Vec<SelectionRect>) -> Self {
+        Self {
+            line_box_rects: rects.clone(),
+            text_rects: rects,
+        }
+    }
+
+    fn push_same(&mut self, rect: SelectionRect) {
+        self.line_box_rects.push(rect.clone());
+        self.text_rects.push(rect);
+    }
+
+    fn sort_by_position(&mut self) {
+        let mut pairs: Vec<_> = std::mem::take(&mut self.line_box_rects)
+            .into_iter()
+            .zip(std::mem::take(&mut self.text_rects))
+            .collect();
+        pairs.sort_by(|(a, _), (b, _)| {
+            a.page_idx
+                .cmp(&b.page_idx)
+                .then_with(|| a.rect.y.total_cmp(&b.rect.y))
+                .then_with(|| a.rect.x.total_cmp(&b.rect.x))
+        });
+        (self.line_box_rects, self.text_rects) = pairs.into_iter().unzip();
+    }
 }
 
 #[ffi]
@@ -54,20 +90,17 @@ fn selection_rect_sets(
     selection: &editor_state::ResolvedSelection<'_>,
 ) -> SelectionRectSets {
     if selection.is_collapsed() {
-        return SelectionRectSets {
-            line_box_rects: vec![],
-            text_rects: vec![],
-        };
+        return SelectionRectSets::empty();
     }
 
     if let Some(cell_rect) = selection.as_cell_rect() {
         let ids: Vec<_> = cell_rect.cells().map(|cell| cell.id()).collect();
         let rects = block_selection_rects(layout_index, &ids);
-        return SelectionRectSets {
-            line_box_rects: rects.clone(),
-            text_rects: rects,
-        };
+        return SelectionRectSets::mirrored(rects);
     }
+
+    let pages = layout_index.pages();
+    let paragraph_breaks = super::paragraph_break::included_in_selection(layout_index, selection);
 
     let from = Position::from(selection.from());
     let to = Position::from(selection.to());
@@ -75,12 +108,11 @@ fn selection_rect_sets(
     // boundary positions are disambiguated by affinity
     // rather than by the permissive per-line `line_contains_position`.
     //
-    // `LayoutIndex::entry_for_position` is permissive on purpose for navigation: a monolithic box
-    // owns both of its bracket positions, and an atom owns both of its edges.
-    // For rect attribution those permissive matches are wrong when the endpoint
-    // is semantically a container boundary — the box-level phase machine (and
-    // the `fully && monolithic` branch) must fire. Strip an owner whose
-    // attachment to the endpoint is not the affinity-selected one.
+    // `LayoutIndex::entry_for_position` is permissive on purpose for navigation: an attached
+    // box owns its child-boundary positions, and an atom owns both of its edges.
+    // For rect attribution those box matches are structural container boundaries
+    // that the box-level phase machine must claim. Strip them, while keeping atom
+    // ownership only on the affinity-selected edge.
     let from_owner = layout_index
         .entry_for_position(&from)
         .filter(|entry| attached(layout_index, entry, &from));
@@ -88,10 +120,7 @@ fn selection_rect_sets(
         .entry_for_position(&to)
         .filter(|entry| attached(layout_index, entry, &to));
     let mut phase = Phase::Before;
-    let mut rects = SelectionRectSets {
-        line_box_rects: Vec::new(),
-        text_rects: Vec::new(),
-    };
+    let mut rects = SelectionRectSets::empty();
 
     visit_node(
         &layout_index.tree().root,
@@ -102,11 +131,22 @@ fn selection_rect_sets(
         to_owner,
         &mut phase,
         &mut rects,
-        layout_index.pages(),
+        pages,
         selection.doc(),
     );
 
+    for paragraph_break in paragraph_breaks {
+        let rect = paragraph_break_rect(paragraph_break.geometry);
+        rects.push_same(rect);
+    }
+    rects.sort_by_position();
+
     rects
+}
+
+fn paragraph_break_rect(geometry: super::paragraph_break::ParagraphBreakGeometry) -> SelectionRect {
+    let rect = geometry.rect;
+    PageRect::with_meta(rect.page_idx, rect.rect, SelectionRectKind::ParagraphBreak)
 }
 
 pub(crate) fn block_selection_rects(
@@ -256,10 +296,12 @@ fn selected_external_atom_hit_test(
 //   via its own phase transitions.
 fn attached(layout_index: &LayoutIndex, entry: &LayoutEntry, pos: &Position) -> bool {
     match entry.content(layout_index) {
-        Some(LayoutContent::Box(b)) => b.nav.is_none(),
+        Some(LayoutContent::Box(_)) => false,
         Some(LayoutContent::Atom(atom)) => {
-            let leading = pos.offset == atom.index && pos.affinity == Affinity::Downstream;
-            let trailing = pos.offset == atom.index + 1 && pos.affinity == Affinity::Upstream;
+            let leading =
+                pos.offset == atom.attachment.index && pos.affinity == Affinity::Downstream;
+            let trailing =
+                pos.offset == atom.attachment.index + 1 && pos.affinity == Affinity::Upstream;
             leading || trailing
         }
         _ => true,
@@ -285,6 +327,15 @@ fn line_has_trailing_non_text(line: &LayoutLine) -> bool {
         }
     }
     range.end.saturating_sub(range.start) > text_child_count
+}
+
+fn strut_line_has_selectable_child_range(line: &LayoutLine) -> bool {
+    line.glyph_runs.is_empty()
+        && line.tab_gaps.is_empty()
+        && line
+            .child_range
+            .as_ref()
+            .is_some_and(|range| range.start < range.end)
 }
 
 fn ruby_band(line: &LayoutLine) -> f32 {
@@ -417,7 +468,7 @@ fn visit_line(
         from.node_id == line.node_id && to.node_id == line.node_id && from.offset != to.offset;
     let width = if x_end > x_start {
         x_end - x_start
-    } else if line.glyph_runs.is_empty() || spans_hard_break {
+    } else if spans_hard_break || strut_line_has_selectable_child_range(line) {
         hb_placeholder
     } else {
         return;
@@ -454,8 +505,8 @@ fn visit_atom(
     pages: &[LayoutPage],
     doc: &Doc,
 ) {
-    let is_from = from.node_id == atom.parent_id && from.offset == atom.index;
-    let is_to = to.node_id == atom.parent_id && to.offset == atom.index + 1;
+    let is_from = from.node_id == atom.attachment.parent_id && from.offset == atom.attachment.index;
+    let is_to = to.node_id == atom.attachment.parent_id && to.offset == atom.attachment.index + 1;
 
     if *phase == Phase::Before && is_from {
         *phase = Phase::Inside;
@@ -479,8 +530,7 @@ fn visit_atom(
             ),
             SelectionRectKind::Atom,
         );
-        rects.line_box_rects.push(rect.clone());
-        rects.text_rects.push(rect);
+        rects.push_same(rect);
     }
 
     if is_to {
@@ -582,8 +632,7 @@ fn visit_box(
                 ),
                 SelectionRectKind::Block,
             );
-            rects.line_box_rects.push(rect.clone());
-            rects.text_rects.push(rect);
+            rects.push_same(rect);
         }
     }
 }
@@ -592,7 +641,7 @@ fn visit_box(
 mod tests {
     use editor_macros::{doc, state};
     use editor_model::NodeId;
-    use editor_state::{Position, Selection};
+    use editor_state::{Affinity, Position, Selection};
 
     use super::*;
     use crate::view::View;
@@ -609,6 +658,34 @@ mod tests {
             LayoutContent::Box(bx) => bx.children.iter().find_map(first_line),
             LayoutContent::Atom(_) | LayoutContent::Spacing(_) => None,
         }
+    }
+
+    fn line_y_for_child_range(
+        view: &View,
+        node_id: NodeId,
+        child_range: std::ops::Range<usize>,
+    ) -> Option<f32> {
+        fn find(
+            node: &LayoutNode,
+            node_id: NodeId,
+            child_range: &std::ops::Range<usize>,
+        ) -> Option<f32> {
+            match &node.content {
+                LayoutContent::Line(line)
+                    if line.node_id == node_id
+                        && line.child_range.as_ref() == Some(child_range) =>
+                {
+                    Some(node.rect.y)
+                }
+                LayoutContent::Box(bx) => bx
+                    .children
+                    .iter()
+                    .find_map(|child| find(child, node_id, child_range)),
+                LayoutContent::Line(_) | LayoutContent::Atom(_) | LayoutContent::Spacing(_) => None,
+            }
+        }
+
+        find(&view.layout_tree_for_test()?.root, node_id, &child_range)
     }
 
     #[test]
@@ -634,6 +711,309 @@ mod tests {
         assert_eq!(rects[0].meta, SelectionRectKind::Text);
         assert!(rects[0].rect.width > 0.0);
         assert!(rects[0].rect.height > 0.0);
+    }
+
+    #[test]
+    fn paragraph_break_selection_has_paragraph_break_rect() {
+        let (doc, _p1, t1, _p2, _t2) = doc! {
+            root {
+                p1: paragraph { t1: text("a") }
+                p2: paragraph { t2: text("b") }
+            }
+        };
+        let view = layout(&doc);
+
+        let sel =
+            editor_state::paragraph_break_selection_at_paragraph_end(&doc, Position::new(t1, 1))
+                .expect("P -> P has paragraph break");
+        let resolved = sel.resolve(&doc).unwrap();
+        let rects = view.selection_rects(&resolved);
+
+        assert_eq!(rects.len(), 1);
+        assert_eq!(rects[0].meta, SelectionRectKind::ParagraphBreak);
+        assert!(rects[0].rect.width > 0.0);
+        assert!(rects[0].rect.height > 0.0);
+    }
+
+    #[test]
+    fn removable_empty_paragraph_break_selection_has_paragraph_break_rect() {
+        let (doc, root, p1) = doc! {
+            root: root {
+                p1: paragraph {}
+                callout { paragraph { text("callout") } }
+                paragraph { text("tail") }
+            }
+        };
+        let view = layout(&doc);
+
+        let sel = Selection::new(
+            Position::new(p1, 0),
+            Position {
+                node_id: root,
+                offset: 1,
+                affinity: Affinity::Upstream,
+            },
+        );
+        let resolved = sel.resolve(&doc).unwrap();
+        let rects = view.selection_rects(&resolved);
+
+        assert_eq!(rects.len(), 1);
+        assert_eq!(rects[0].meta, SelectionRectKind::ParagraphBreak);
+        assert!(rects[0].rect.width > 0.0);
+        assert!(rects[0].rect.height > 0.0);
+    }
+
+    #[test]
+    fn selection_containing_paragraph_break_shows_paragraph_break_rect() {
+        let (doc, _p1, t1, _p2, t2) = doc! {
+            root {
+                p1: paragraph { t1: text("a") }
+                p2: paragraph { t2: text("bc") }
+            }
+        };
+        let view = layout(&doc);
+
+        let sel = Selection::new(
+            Position {
+                node_id: t1,
+                offset: 1,
+                affinity: Affinity::Downstream,
+            },
+            Position::new(t2, 1),
+        );
+        let resolved = sel.resolve(&doc).unwrap();
+        let rects = view.selection_rects(&resolved);
+
+        assert!(
+            rects.iter().any(|r| r.meta == SelectionRectKind::Text),
+            "range must still show selected text, got {rects:?}"
+        );
+        assert!(
+            rects
+                .iter()
+                .any(|r| r.meta == SelectionRectKind::ParagraphBreak),
+            "range containing PB must show PB affordance, got {rects:?}"
+        );
+    }
+
+    #[test]
+    fn selection_to_next_paragraph_start_with_upstream_affinity_shows_paragraph_break_rect() {
+        let (state, ..) = state! {
+            doc {
+                root [block_gap(200)] {
+                    paragraph {
+                        t1: text("aa")
+                    }
+                    paragraph {
+                        t2: text("bb")
+                    }
+                }
+            }
+            selection: (t1, 1, >) -> (t2, 0, <)
+        };
+        let view = layout(&state.doc);
+        let resolved = state.selection.unwrap().resolve(&state.doc).unwrap();
+        let rects = view.selection_rects(&resolved);
+
+        assert!(
+            rects
+                .iter()
+                .any(|r| r.meta == SelectionRectKind::ParagraphBreak),
+            "range ending at next paragraph start must show PB affordance, got {rects:?}"
+        );
+    }
+
+    #[test]
+    fn reversed_selection_from_next_paragraph_text_shows_paragraph_break_rect() {
+        let (state, ..) = state! {
+            doc {
+                root [block_gap(200)] {
+                    paragraph {
+                        t1: text("aa")
+                    }
+                    paragraph {
+                        t2: text("bb")
+                    }
+                }
+            }
+            selection: (t2, 1) -> (t1, 2)
+        };
+        let view = layout(&state.doc);
+        let resolved = state.selection.unwrap().resolve(&state.doc).unwrap();
+        let rects = view.selection_rects(&resolved);
+
+        assert!(
+            rects
+                .iter()
+                .any(|r| r.meta == SelectionRectKind::ParagraphBreak),
+            "reversed range containing PB must show PB affordance, got {rects:?}"
+        );
+    }
+
+    #[test]
+    fn selection_from_text_middle_to_empty_paragraph_shows_text_and_paragraph_break_only() {
+        let (doc, _p1, t1, p2) = doc! {
+            root {
+                p1: paragraph { t1: text("abc") }
+                p2: paragraph {}
+                paragraph { text("tail") }
+            }
+        };
+        let view = layout(&doc);
+
+        let sel = Selection::new(
+            Position::new(t1, 1),
+            Position {
+                node_id: p2,
+                offset: 0,
+                affinity: Affinity::Downstream,
+            },
+        );
+        let resolved = sel.resolve(&doc).unwrap();
+        let rects = view.selection_rects(&resolved);
+        let kinds: Vec<_> = rects.iter().map(|r| r.meta).collect();
+
+        assert_eq!(
+            kinds,
+            vec![SelectionRectKind::Text, SelectionRectKind::ParagraphBreak],
+            "empty paragraph placeholder rect must not be emitted, got {rects:?}"
+        );
+    }
+
+    #[test]
+    fn selection_from_empty_paragraph_to_text_shows_paragraph_break_and_text_only() {
+        let (doc, p1, _p2, t2) = doc! {
+            root {
+                p1: paragraph {}
+                p2: paragraph { t2: text("abc") }
+            }
+        };
+        let view = layout(&doc);
+
+        let sel = Selection::new(Position::new(p1, 0), Position::new(t2, 1));
+        let resolved = sel.resolve(&doc).unwrap();
+        let rects = view.selection_rects(&resolved);
+        let kinds: Vec<_> = rects.iter().map(|r| r.meta).collect();
+
+        assert_eq!(
+            kinds,
+            vec![SelectionRectKind::ParagraphBreak, SelectionRectKind::Text],
+            "empty paragraph placeholder rect must not be emitted, got {rects:?}"
+        );
+    }
+
+    #[test]
+    fn selection_through_empty_paragraph_shows_paragraph_breaks_without_placeholder() {
+        let (doc, _p1, t1, _p2, _p3, t3) = doc! {
+            root {
+                p1: paragraph { t1: text("abc") }
+                p2: paragraph {}
+                p3: paragraph { t3: text("tail") }
+            }
+        };
+        let view = layout(&doc);
+
+        let sel = Selection::new(Position::new(t1, 1), Position::new(t3, 1));
+        let resolved = sel.resolve(&doc).unwrap();
+        let rects = view.selection_rects(&resolved);
+        let kinds: Vec<_> = rects.iter().map(|r| r.meta).collect();
+
+        assert_eq!(
+            kinds,
+            vec![
+                SelectionRectKind::Text,
+                SelectionRectKind::ParagraphBreak,
+                SelectionRectKind::ParagraphBreak,
+                SelectionRectKind::Text,
+            ],
+            "empty paragraph placeholder rect must not be emitted, got {rects:?}"
+        );
+    }
+
+    #[test]
+    fn paragraph_boundary_selection_over_two_hard_breaks_shows_each_break_and_pb() {
+        let (state, ..) = state! {
+            doc {
+                root {
+                    p1: paragraph {
+                        hard_break
+                        hard_break
+                    }
+                    p2: paragraph {}
+                }
+            }
+            selection: (p1, 0, >) -> (p2, 0, <)
+        };
+        let view = layout(&state.doc);
+        let resolved = state.selection.unwrap().resolve(&state.doc).unwrap();
+        let rects = view.selection_rects(&resolved);
+        let kinds: Vec<_> = rects.iter().map(|r| r.meta).collect();
+
+        assert_eq!(
+            kinds,
+            vec![
+                SelectionRectKind::Text,
+                SelectionRectKind::Text,
+                SelectionRectKind::ParagraphBreak,
+            ],
+            "two hard_break rects and the paragraph break must be visible, got {rects:?}"
+        );
+    }
+
+    #[test]
+    fn paragraph_break_after_trailing_hard_break_uses_trailing_empty_line() {
+        let (state, p1, _p2) = state! {
+            doc {
+                root [block_gap(200)] {
+                    p1: paragraph {
+                        hard_break
+                        hard_break
+                    }
+                    p2: paragraph {}
+                }
+            }
+            selection: (p1, 2, >) -> (p2, 0, <)
+        };
+        let view = layout(&state.doc);
+        let trailing_line_y = line_y_for_child_range(&view, p1, 2..2)
+            .expect("trailing empty line after hard_breaks exists");
+        let resolved = state.selection.unwrap().resolve(&state.doc).unwrap();
+        let rects = view.selection_rects(&resolved);
+
+        assert_eq!(rects.len(), 1, "got {rects:?}");
+        assert_eq!(rects[0].meta, SelectionRectKind::ParagraphBreak);
+        assert!(
+            (rects[0].rect.y - trailing_line_y).abs() < 0.01,
+            "PB must be drawn on trailing empty line y={trailing_line_y}, got {rects:?}",
+        );
+    }
+
+    #[test]
+    fn root_selection_over_atom_and_hard_break_paragraph_shows_hard_break_rects() {
+        let (state, ..) = state! {
+            doc {
+                r1: root {
+                    image
+                    paragraph {
+                        hard_break
+                        hard_break
+                    }
+                }
+            }
+            selection: (r1, 0, >) -> (r1, 2, <)
+        };
+        let view = layout(&state.doc);
+        let resolved = state.selection.unwrap().resolve(&state.doc).unwrap();
+        let rects = view.selection_rects(&resolved);
+        let text_rect_count = rects
+            .iter()
+            .filter(|rect| rect.meta == SelectionRectKind::Text)
+            .count();
+
+        assert_eq!(
+            text_rect_count, 2,
+            "both hard_breaks in the selected paragraph must be visible, got {rects:?}"
+        );
     }
 
     #[test]
@@ -791,7 +1171,11 @@ mod tests {
             assert_eq!(line_box.meta, text.meta);
             assert!((line_box.rect.x - text.rect.x).abs() < 0.01);
             assert!((line_box.rect.width - text.rect.width).abs() < 0.01);
-            assert!(line_box.rect.height > text.rect.height);
+            if line_box.meta == SelectionRectKind::Text {
+                assert!(line_box.rect.height > text.rect.height);
+            } else {
+                assert!((line_box.rect.height - text.rect.height).abs() < 0.01);
+            }
         }
     }
 
@@ -809,10 +1193,11 @@ mod tests {
         let resolved = sel.resolve(&doc).unwrap();
         let rects = view.selection_rects(&resolved);
 
-        assert_eq!(rects.len(), 2);
+        assert_eq!(rects.len(), 3);
         assert_eq!(rects[0].meta, SelectionRectKind::Text);
-        assert_eq!(rects[1].meta, SelectionRectKind::Text);
-        assert!(rects[0].rect.y < rects[1].rect.y);
+        assert_eq!(rects[1].meta, SelectionRectKind::ParagraphBreak);
+        assert_eq!(rects[2].meta, SelectionRectKind::Text);
+        assert!(rects[0].rect.y < rects[2].rect.y);
     }
 
     #[test]
@@ -1148,8 +1533,8 @@ mod tests {
 
         assert_eq!(
             rects.len(),
-            4,
-            "expected text rects for a/b/c plus an empty-line placeholder for p1, got {:?}",
+            3,
+            "expected text rects for a/b/c without an empty paragraph placeholder for p1, got {:?}",
             rects,
         );
         assert!(
@@ -1279,12 +1664,11 @@ mod tests {
     }
 
     #[test]
-    fn empty_paragraph_after_atom_node_selected_emits_placeholder_rect() {
+    fn empty_paragraph_after_atom_node_selected_emits_no_rect() {
         // Node-selecting the empty paragraph that follows an image atom.
         // (r1, 1, >) means Downstream-attached-to-child[1] (the paragraph),
         // (r1, 2, <) means Upstream-attached-to-child[1] (the paragraph);
         // both endpoints bracket the empty paragraph from the root level.
-        // The empty-line placeholder rect inside that paragraph must render.
         let (state, ..) = state! {
             doc {
                 r1: root {
@@ -1298,17 +1682,14 @@ mod tests {
         let resolved = state.selection.unwrap().resolve(&state.doc).unwrap();
         let rects = view.selection_rects(&resolved);
 
-        assert_eq!(rects.len(), 1, "got {:?}", rects);
-        assert_eq!(rects[0].meta, SelectionRectKind::Text);
-        assert!(rects[0].rect.width > 0.0);
-        assert!(rects[0].rect.height > 0.0);
+        assert!(rects.is_empty(), "got {:?}", rects);
     }
 
     #[test]
     fn paragraph_after_atom_node_selected_emits_text_rect() {
         // Non-empty counterpart of the previous test. The same affinity-bracket
         // pattern around child[1] must also paint the line for a populated
-        // paragraph — proving the fix is not limited to the empty-line branch.
+        // paragraph.
         let (state, ..) = state! {
             doc {
                 r1: root {
@@ -1345,11 +1726,9 @@ mod tests {
         let resolved = sel.resolve(&doc).unwrap();
         let rects = view.selection_rects(&resolved);
 
-        assert_eq!(rects.len(), 2);
+        assert_eq!(rects.len(), 1);
         assert_eq!(rects[0].meta, SelectionRectKind::Text);
         assert!(rects[0].rect.width > 0.0);
-        assert_eq!(rects[1].meta, SelectionRectKind::Text);
-        assert!(rects[1].rect.width > 0.0);
     }
 
     #[test]
@@ -1511,7 +1890,12 @@ mod tests {
             .resolve(&doc)
             .unwrap();
         let rects = view.selection_rects(&resolved);
-        let last = rects[1].rect;
+        let last = rects
+            .iter()
+            .rev()
+            .find(|rect| rect.meta == SelectionRectKind::Text)
+            .unwrap()
+            .rect;
 
         let probe_x = last.x + last.width + 50.0;
         let probe_y = last.y + last.height * 0.5;

--- a/crates/editor-view/src/query/visit.rs
+++ b/crates/editor-view/src/query/visit.rs
@@ -174,7 +174,7 @@ mod tests {
                     monolithic: false,
                 },
                 children,
-                nav: None,
+                attachment: None,
             }),
         }
     }

--- a/crates/editor-view/src/view.rs
+++ b/crates/editor-view/src/view.rs
@@ -16,7 +16,7 @@ use crate::measure::{MeasuredTree, Measurer};
 use crate::page::LayoutPage;
 use crate::page_fragment::PageFragmentTree;
 use crate::paginate::{
-    LayoutAtom, LayoutContent, LayoutLine, LayoutNode, NavUnit, Paginator, SpacingKind,
+    ChildAttachment, LayoutAtom, LayoutContent, LayoutLine, LayoutNode, Paginator, SpacingKind,
 };
 use crate::query;
 use crate::query::{CursorMetrics, PointerStyle, SelectionEndpoints, SelectionRect};
@@ -244,11 +244,20 @@ impl View {
             .layout_index
             .exact_entry(point, is_drag_exact_hit_entry)
         {
+            if let Some(selection) = query::paragraph_break::drag_selection_for_entry(
+                &result.layout_index,
+                doc,
+                &anchor,
+                entry,
+                point,
+            ) {
+                return Some(selection);
+            }
             return match entry.content(&result.layout_index) {
                 Some(LayoutContent::Line(_) | LayoutContent::Atom(_)) => {
                     text_or_atom_selection_for_entry(&result.layout_index, entry, point.x)
                 }
-                Some(LayoutContent::Box(b)) if b.nav.is_some() => b.nav.map(select_unit),
+                Some(LayoutContent::Box(b)) if b.style.monolithic => b.attachment.map(select_unit),
                 Some(LayoutContent::Spacing(SpacingKind::Gap { .. })) => {
                     drag_boundary_fallback(&result.layout_index, doc, &anchor, point)
                 }
@@ -684,7 +693,7 @@ fn is_drag_exact_hit_entry(_entry: &query::layout_index::LayoutEntry, node: &Lay
         LayoutContent::Line(_)
         | LayoutContent::Atom(_)
         | LayoutContent::Spacing(SpacingKind::Gap { .. }) => true,
-        LayoutContent::Box(b) => b.nav.is_some(),
+        LayoutContent::Box(b) => b.style.monolithic && b.attachment.is_some(),
         LayoutContent::Spacing(SpacingKind::Fill) => false,
     }
 }
@@ -803,11 +812,11 @@ fn drag_fallback_candidate(
             let hit = select_atom(atom);
             Some(DragFallbackCandidate::new(entry, point, hit.anchor, hit))
         }
-        LayoutContent::Box(b) if b.nav.is_some() => {
+        LayoutContent::Box(b) if b.style.monolithic && b.attachment.is_some() => {
             if point.y >= entry.rect.y && point.y < entry.rect.bottom() {
                 return None;
             }
-            let hit = select_unit(b.nav?);
+            let hit = select_unit(b.attachment?);
             Some(DragFallbackCandidate::new(entry, point, hit.anchor, hit))
         }
         LayoutContent::Box(_) | LayoutContent::Spacing(_) => None,
@@ -821,28 +830,28 @@ fn position_in_line(line: &LayoutLine, rect: &Rect, x: f32) -> Position {
 fn select_atom(atom: &LayoutAtom) -> Selection {
     Selection::new(
         Position {
-            node_id: atom.parent_id,
-            offset: atom.index,
+            node_id: atom.attachment.parent_id,
+            offset: atom.attachment.index,
             affinity: Affinity::Downstream,
         },
         Position {
-            node_id: atom.parent_id,
-            offset: atom.index + 1,
+            node_id: atom.attachment.parent_id,
+            offset: atom.attachment.index + 1,
             affinity: Affinity::Upstream,
         },
     )
 }
 
-fn select_unit(nav: NavUnit) -> Selection {
+fn select_unit(attachment: ChildAttachment) -> Selection {
     Selection::new(
         Position {
-            node_id: nav.parent_id,
-            offset: nav.index,
+            node_id: attachment.parent_id,
+            offset: attachment.index,
             affinity: Affinity::Downstream,
         },
         Position {
-            node_id: nav.parent_id,
-            offset: nav.index + 1,
+            node_id: attachment.parent_id,
+            offset: attachment.index + 1,
             affinity: Affinity::Upstream,
         },
     )
@@ -1026,7 +1035,7 @@ mod tests {
     }
 
     #[test]
-    fn hit_test_extending_in_root_block_gap_returns_anchor_side_target() {
+    fn hit_test_extending_in_paragraph_block_gap_returns_paragraph_break() {
         let (doc, p1, t1, p2) = doc! {
             root {
                 p1: paragraph { t1: text("one") }
@@ -1052,18 +1061,256 @@ mod tests {
             )
             .unwrap();
 
-        let end = Position {
-            node_id: t1,
-            offset: 3,
-            affinity: Affinity::Upstream,
-        };
-        assert!(sel.is_collapsed());
-        assert_eq!(sel.anchor, end);
-        assert_eq!(sel.head, end);
+        assert_eq!(
+            sel,
+            editor_state::paragraph_break_selection_at_paragraph_end(&doc, Position::new(t1, 3))
+                .expect("P -> P has PB")
+        );
     }
 
     #[test]
-    fn hit_test_extending_in_monolithic_internal_block_gap_returns_inner_target() {
+    fn hit_test_extending_in_paragraph_gap_selects_paragraph_break() {
+        let (doc, p1, t1, p2, _t2) = doc! {
+            root [block_gap(200)] {
+                p1: paragraph { t1: text("one") }
+                p2: paragraph { t2: text("two") }
+            }
+        };
+        let mut view = View::new_test();
+        view.layout(&doc);
+        let p1_rect = view.node_box_rects(&[p1])[0].rect;
+        let p2_rect = view.node_box_rects(&[p2])[0].rect;
+        assert!(
+            p1_rect.bottom() < p2_rect.y,
+            "test requires a visible paragraph gap"
+        );
+
+        let hit = view
+            .hit_test_extending(
+                &doc,
+                Position::new(t1, 3),
+                0,
+                p1_rect.x + p1_rect.width / 2.0,
+                (p1_rect.bottom() + p2_rect.y) / 2.0,
+            )
+            .unwrap();
+
+        assert_eq!(
+            hit,
+            editor_state::paragraph_break_selection_at_paragraph_end(&doc, Position::new(t1, 3))
+                .expect("P -> P has PB")
+        );
+    }
+
+    #[test]
+    fn hit_test_extending_up_to_paragraph_gap_excludes_previous_paragraph_break() {
+        let (doc, p1, _t1, p2, t2) = doc! {
+            root [block_gap(200)] {
+                p1: paragraph { t1: text("one") }
+                p2: paragraph { t2: text("two") }
+            }
+        };
+        let mut view = View::new_test();
+        view.layout(&doc);
+        let p1_rect = view.node_box_rects(&[p1])[0].rect;
+        let p2_rect = view.node_box_rects(&[p2])[0].rect;
+        assert!(
+            p1_rect.bottom() < p2_rect.y,
+            "test requires a visible paragraph gap"
+        );
+
+        let hit = view
+            .hit_test_extending(
+                &doc,
+                Position::new(t2, 1),
+                0,
+                p2_rect.x + p2_rect.width / 2.0,
+                (p1_rect.bottom() + p2_rect.y) / 2.0,
+            )
+            .unwrap();
+
+        assert_eq!(
+            hit,
+            Selection::collapsed(Position {
+                node_id: t2,
+                offset: 0,
+                affinity: Affinity::Upstream,
+            })
+        );
+    }
+
+    #[test]
+    fn hit_test_extending_in_gap_after_text_paragraph_before_atom_is_not_paragraph_break() {
+        let (doc, p1, t1, image) = doc! {
+            root [block_gap(200)] {
+                p1: paragraph { t1: text("one") }
+                image: image
+                paragraph { text("tail") }
+            }
+        };
+        let mut view = View::new_test();
+        view.layout(&doc);
+        let p1_rect = view.node_box_rects(&[p1])[0].rect;
+        let image_rect = view
+            .external_elements(&doc, None)
+            .into_iter()
+            .find(|element| element.node_id == image)
+            .expect("image external element exists")
+            .bounds;
+        assert!(
+            p1_rect.bottom() < image_rect.y,
+            "test requires a visible paragraph gap"
+        );
+
+        let hit = view
+            .hit_test_extending(
+                &doc,
+                Position::new(t1, 1),
+                0,
+                p1_rect.x + p1_rect.width / 2.0,
+                (p1_rect.bottom() + image_rect.y) / 2.0,
+            )
+            .unwrap();
+
+        assert_eq!(
+            hit,
+            Selection::collapsed(Position {
+                node_id: t1,
+                offset: 3,
+                affinity: Affinity::Upstream,
+            })
+        );
+    }
+
+    #[test]
+    fn hit_test_extending_in_gap_after_removable_empty_paragraph_selects_paragraph_break() {
+        let (doc, p1, empty, image) = doc! {
+            root [block_gap(200)] {
+                p1: paragraph { text("one") }
+                empty: paragraph {}
+                image: image
+                paragraph { text("tail") }
+            }
+        };
+        let mut view = View::new_test();
+        view.layout(&doc);
+        let empty_rect = view.node_box_rects(&[empty])[0].rect;
+        let image_rect = view
+            .external_elements(&doc, None)
+            .into_iter()
+            .find(|element| element.node_id == image)
+            .expect("image external element exists")
+            .bounds;
+        assert!(
+            empty_rect.bottom() < image_rect.y,
+            "test requires a visible paragraph gap"
+        );
+
+        let hit = view
+            .hit_test_extending(
+                &doc,
+                Position::new(p1, 0),
+                0,
+                empty_rect.x + empty_rect.width / 2.0,
+                (empty_rect.bottom() + image_rect.y) / 2.0,
+            )
+            .unwrap();
+
+        assert_eq!(
+            hit,
+            editor_state::paragraph_break_selection_at_paragraph_end(&doc, Position::new(empty, 0))
+                .expect("removable empty paragraph has PB")
+        );
+    }
+
+    #[test]
+    fn hit_test_extending_paragraph_break_right_side_returns_next_paragraph_start() {
+        let (doc, _p1, t1, t2) = doc! {
+            root {
+                p1: paragraph { t1: text("aa") }
+                paragraph { t2: text("bb") }
+            }
+        };
+        let mut view = View::new_test();
+        view.layout(&doc);
+        let pb_selection =
+            editor_state::paragraph_break_selection_at_paragraph_end(&doc, Position::new(t1, 2))
+                .expect("P -> P has PB")
+                .resolve(&doc)
+                .unwrap();
+        let pb_rect = view
+            .selection_rects(&pb_selection)
+            .into_iter()
+            .find(|rect| rect.meta == crate::query::SelectionRectKind::ParagraphBreak)
+            .expect("paragraph break rect exists");
+
+        let hit = view
+            .hit_test_extending(
+                &doc,
+                Position::new(t1, 0),
+                pb_rect.page_idx,
+                pb_rect.rect.right() + 4.0,
+                pb_rect.rect.y + pb_rect.rect.height / 2.0,
+            )
+            .unwrap();
+
+        assert_eq!(
+            hit,
+            Selection::new(
+                Position {
+                    node_id: t1,
+                    offset: 2,
+                    affinity: Affinity::Downstream,
+                },
+                Position {
+                    node_id: t2,
+                    offset: 0,
+                    affinity: Affinity::Upstream,
+                },
+            )
+        );
+    }
+
+    #[test]
+    fn hit_test_extending_removable_empty_paragraph_break_right_side_returns_block_boundary() {
+        let (doc, root, p1) = doc! {
+            root: root {
+                p1: paragraph {}
+                image
+                paragraph {}
+            }
+        };
+        let mut view = View::new_test();
+        view.layout(&doc);
+        let pb_end = Position {
+            node_id: root,
+            offset: 1,
+            affinity: Affinity::Upstream,
+        };
+        let pb_selection = Selection::new(Position::new(p1, 0), pb_end)
+            .resolve(&doc)
+            .unwrap();
+        let pb_rect = view
+            .selection_rects(&pb_selection)
+            .into_iter()
+            .find(|rect| rect.meta == crate::query::SelectionRectKind::ParagraphBreak)
+            .expect("paragraph break rect exists");
+
+        let hit = view
+            .hit_test_extending(
+                &doc,
+                Position::new(p1, 0),
+                pb_rect.page_idx,
+                pb_rect.rect.right() + 4.0,
+                pb_rect.rect.y + pb_rect.rect.height / 2.0,
+            )
+            .unwrap();
+
+        assert_eq!(hit, Selection::new(Position::new(p1, 0), pb_end));
+    }
+
+    #[test]
+    fn hit_test_extending_in_monolithic_internal_paragraph_gap_returns_paragraph_break() {
         let (doc, callout, p1, t1, p2) = doc! {
             root {
                 callout: callout {
@@ -1092,14 +1339,11 @@ mod tests {
             )
             .unwrap();
 
-        let end = Position {
-            node_id: t1,
-            offset: 3,
-            affinity: Affinity::Upstream,
-        };
-        assert!(sel.is_collapsed());
-        assert_eq!(sel.anchor, end);
-        assert_eq!(sel.head, end);
+        assert_eq!(
+            sel,
+            editor_state::paragraph_break_selection_at_paragraph_end(&doc, Position::new(t1, 3))
+                .expect("P -> P has PB")
+        );
     }
 
     #[test]
@@ -2095,7 +2339,11 @@ mod tests {
             .resolve(&doc)
             .unwrap();
 
-        let rects = view.selection_rects(&resolved);
+        let rects: Vec<_> = view
+            .selection_rects(&resolved)
+            .into_iter()
+            .filter(|rect| rect.meta == crate::query::SelectionRectKind::Text)
+            .collect();
         let first = rects[0].rect;
         let last = rects[1].rect;
         let max_x = last.x + last.width;


### PR DESCRIPTION
## paragraph break
- 별도의 노드 없음
- paragraph break를 가리키는 특정 selection을 포함할 때 paragraph break selection rect가 표시됨
- paragraph 내부 마지막 inline position에서 다음 paragraph 첫 inline position까지 선택되면 paragraph break
- 문서 마지막 paragraph는 pb를 가질 수 없음
- 비어있지 않은 paragraph 뒤에 non-paragraph가 오면 그 paragraph는 pb를 가질 수 없음
- paragraph unit selection은 이제 사라짐
- drag selection: pb가 있을 곳을 드래그해서 pb를 선택할 수 있음
- 특수 케이스: empty paragraph(E) 뒤에 non-paragraph가 오면 `(E, 0) -> (parent, index + 1, <)`로서 pb를 표현
   - 키보드로 확장 내비게이션 할 때는 기존 head와 새 head 사이에 empty paragraph pb end가 있으면 거기서 한번 멈춤
- page break가 있는 paragraph에는 pb가 없음

## 변경 사항
- Empty paragraph를 plain text에서 `\n\n`로 직렬화/파싱할 수 있도록 수정
- PB를 선택해서 복사/붙여넣기하면 선택한 PB 수만큼 paragraph boundary가 삽입되도록 slice 추출/삽입 동작 정리
- Empty paragraph에서도 word/sentence 단위 이동으로 다른 paragraph로 이동할 수 있도록 수정
- `move_from_block_position` fallback 없이 block position에서의 이동을 `resolve_movement`가 처리하도록 navigation 경로 정리
- `resolve_movement` probe에서 `would_resolve_movement`가 `Some((None, same_px))`를 반환할 때 `changed = true`가 되던 false-positive 수정