### PR TITLE
hard break, drag-selection 디버그

### DIFF
--- a/crates/editor-core/src/handle/navigation.rs
+++ b/crates/editor-core/src/handle/navigation.rs
@@ -615,6 +615,42 @@ mod tests {
     }
 
     #[test]
+    fn shift_right_from_range_ending_after_trailing_hard_break_extends_to_paragraph_break() {
+        let (state, p1, p2) = state! {
+            doc {
+                root {
+                    p1: paragraph {
+                        hard_break
+                        hard_break
+                    }
+                    p2: paragraph {}
+                }
+            }
+            selection: (p1, 0, >) -> (p1, 2, <)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.view.layout(&editor.state.doc);
+
+        shift_right(&mut editor);
+
+        assert_eq!(
+            editor.state().selection,
+            Some(Selection::new(
+                Position {
+                    node_id: p1,
+                    offset: 0,
+                    affinity: Affinity::Downstream,
+                },
+                Position {
+                    node_id: p2,
+                    offset: 0,
+                    affinity: Affinity::Upstream,
+                },
+            ))
+        );
+    }
+
+    #[test]
     fn shift_word_right_from_range_ending_at_empty_paragraph_start_stops_at_empty_paragraph_break()
     {
         let (state, r, t1, _p1) = state! {

--- a/crates/editor-view/src/measure/text/measure.rs
+++ b/crates/editor-view/src/measure/text/measure.rs
@@ -542,7 +542,7 @@ mod tests {
         let MeasuredContent::Line(c) = &b.children[1].content else {
             panic!()
         };
-        assert_eq!(a.child_range, Some(0..2));
+        assert_eq!(a.child_range, Some(0..1));
         assert_eq!(c.child_range, Some(2..3));
     }
 
@@ -562,7 +562,7 @@ mod tests {
         let MeasuredContent::Line(b2) = &b.children[1].content else {
             panic!()
         };
-        assert_eq!(a.child_range, Some(0..1));
+        assert_eq!(a.child_range, Some(0..0));
         assert_eq!(b2.child_range, Some(1..1));
     }
 
@@ -586,7 +586,7 @@ mod tests {
                 _ => panic!(),
             })
             .collect();
-        assert_eq!(ranges, vec![Some(0..2), Some(2..3), Some(3..4)]);
+        assert_eq!(ranges, vec![Some(0..1), Some(2..2), Some(3..4)]);
     }
 
     #[test]

--- a/crates/editor-view/src/measure/text/segment.rs
+++ b/crates/editor-view/src/measure/text/segment.rs
@@ -8,10 +8,9 @@ use editor_model::{Node, NodeRef};
 ///
 /// `child_range` is the paragraph-offset interval this segment owns. Matching
 /// against a cursor's `Position::offset` is inclusive of both endpoints
-/// (`start <= offset && offset <= end`, not `Range::contains`). When the
-/// segment is terminated by a `hard_break`, `end` is the index *after* that
-/// `hard_break` so the offset right after the break still resolves to this
-/// segment under `Upstream` affinity.
+/// (`start <= offset && offset <= end`, not `Range::contains`). A `hard_break`
+/// is the selectable gap between adjacent segments, not part of either
+/// segment's range.
 pub(crate) enum Segment<'a> {
     Text {
         children: Vec<NodeRef<'a>>,
@@ -34,7 +33,6 @@ impl<'a> Segment<'a> {
 ///
 /// Invariants (debug-asserted):
 /// - The returned vec is non-empty.
-/// - Adjacent segments share a boundary: `a.child_range().end == b.child_range().start`.
 /// - Number of segments equals (number of `hard_break` children) + 1, except
 ///   when the paragraph ends with `hard_break` an additional trailing `Empty`
 ///   segment is appended (so the user-visible "cursor after trailing
@@ -50,18 +48,17 @@ pub(crate) fn split_into_segments<'a>(paragraph: &NodeRef<'a>) -> Vec<Segment<'a
         child_count = idx + 1;
         match child.node() {
             Node::HardBreak(_) => {
-                let end = idx + 1;
                 if buf.is_empty() {
                     segments.push(Segment::Empty {
-                        child_range: seg_start..end,
+                        child_range: seg_start..seg_start,
                     });
                 } else {
                     segments.push(Segment::Text {
                         children: std::mem::take(&mut buf),
-                        child_range: seg_start..end,
+                        child_range: seg_start..idx,
                     });
                 }
-                seg_start = end;
+                seg_start = idx + 1;
                 last_was_hard_break = true;
             }
             Node::Text(_) | Node::Tab(_) => {
@@ -91,9 +88,6 @@ pub(crate) fn split_into_segments<'a>(paragraph: &NodeRef<'a>) -> Vec<Segment<'a
     }
 
     debug_assert!(!segments.is_empty());
-    for pair in segments.windows(2) {
-        debug_assert_eq!(pair[0].child_range().end, pair[1].child_range().start);
-    }
     for seg in &segments {
         debug_assert!(seg.child_range().start <= seg.child_range().end);
     }
@@ -137,7 +131,7 @@ mod tests {
         let (doc, p1) = doc! { root { p1: paragraph { hard_break } } };
         let p = doc.node(p1).unwrap();
         let segs = split_into_segments(&p);
-        assert_eq!(variants(&segs), vec![("empty", 0..1), ("empty", 1..1)]);
+        assert_eq!(variants(&segs), vec![("empty", 0..0), ("empty", 1..1)]);
     }
 
     #[test]
@@ -145,7 +139,7 @@ mod tests {
         let (doc, p1) = doc! { root { p1: paragraph { text("a") hard_break } } };
         let p = doc.node(p1).unwrap();
         let segs = split_into_segments(&p);
-        assert_eq!(variants(&segs), vec![("text", 0..2), ("empty", 2..2)]);
+        assert_eq!(variants(&segs), vec![("text", 0..1), ("empty", 2..2)]);
     }
 
     #[test]
@@ -153,7 +147,7 @@ mod tests {
         let (doc, p1) = doc! { root { p1: paragraph { hard_break text("a") } } };
         let p = doc.node(p1).unwrap();
         let segs = split_into_segments(&p);
-        assert_eq!(variants(&segs), vec![("empty", 0..1), ("text", 1..2)]);
+        assert_eq!(variants(&segs), vec![("empty", 0..0), ("text", 1..2)]);
     }
 
     #[test]
@@ -161,7 +155,7 @@ mod tests {
         let (doc, p1) = doc! { root { p1: paragraph { text("hel") hard_break text("lo") } } };
         let p = doc.node(p1).unwrap();
         let segs = split_into_segments(&p);
-        assert_eq!(variants(&segs), vec![("text", 0..2), ("text", 2..3)]);
+        assert_eq!(variants(&segs), vec![("text", 0..1), ("text", 2..3)]);
     }
 
     #[test]
@@ -173,7 +167,7 @@ mod tests {
         let segs = split_into_segments(&p);
         assert_eq!(
             variants(&segs),
-            vec![("text", 0..2), ("empty", 2..3), ("text", 3..4)]
+            vec![("text", 0..1), ("empty", 2..2), ("text", 3..4)]
         );
     }
 

--- a/crates/editor-view/src/query/grapheme.rs
+++ b/crates/editor-view/src/query/grapheme.rs
@@ -88,10 +88,42 @@ fn x_at_offset_raw(line: &LayoutLine, pos: &Position) -> f32 {
         return x;
     }
 
-    line.glyph_runs
-        .last()
-        .map(|r| r.x + r.width)
-        .unwrap_or(line.empty_caret_x)
+    if pos.node_id == line.node_id
+        && let Some(range) = &line.child_range
+    {
+        if pos.offset == range.start {
+            return line_content_start_x(line);
+        }
+        if pos.offset == range.end {
+            return line_content_end_x(line);
+        }
+    }
+
+    line_content_end_x(line)
+}
+
+fn line_content_start_x(line: &LayoutLine) -> f32 {
+    let mut x: Option<f32> = None;
+    for run in &line.glyph_runs {
+        x = Some(x.map_or(run.x, |current| current.min(run.x)));
+    }
+    for gap in &line.tab_gaps {
+        x = Some(x.map_or(gap.x, |current| current.min(gap.x)));
+    }
+    x.unwrap_or(line.empty_caret_x)
+}
+
+fn line_content_end_x(line: &LayoutLine) -> f32 {
+    let mut x: Option<f32> = None;
+    for run in &line.glyph_runs {
+        let end = run.x + run.width;
+        x = Some(x.map_or(end, |current| current.max(end)));
+    }
+    for gap in &line.tab_gaps {
+        let end = gap.x + gap.width;
+        x = Some(x.map_or(end, |current| current.max(end)));
+    }
+    x.unwrap_or(line.empty_caret_x)
 }
 
 pub fn position_at_x(line: &LayoutLine, local_x: f32) -> Position {

--- a/crates/editor-view/src/query/hard_break.rs
+++ b/crates/editor-view/src/query/hard_break.rs
@@ -1,0 +1,125 @@
+use editor_common::Rect;
+use editor_model::{Doc, Node};
+use editor_state::{Affinity, Position, ResolvedSelection, Selection};
+
+use crate::page::{LayoutPage, PageRect};
+use crate::paginate::{LayoutContent, LayoutLine};
+
+use super::common::page_for_y;
+use super::layout_index::{LayoutEntry, LayoutIndex, LayoutPoint};
+
+pub(crate) struct HardBreakGeometry {
+    pub(crate) rect: PageRect,
+    pub(crate) line_right: f32,
+}
+
+pub(crate) struct SelectedHardBreak {
+    pub(crate) selection: Selection,
+    pub(crate) geometry: HardBreakGeometry,
+}
+
+pub(crate) fn included_in_selection(
+    layout_index: &LayoutIndex,
+    selection: &ResolvedSelection<'_>,
+) -> Vec<SelectedHardBreak> {
+    let mut hard_breaks = Vec::new();
+    for entry in layout_index.entries() {
+        let Some(hard_break) = hard_break_for_entry(layout_index, selection.doc(), entry) else {
+            continue;
+        };
+        if !selection.contains_range(hard_break.selection) {
+            continue;
+        }
+        if hard_breaks
+            .iter()
+            .any(|existing: &SelectedHardBreak| existing.selection == hard_break.selection)
+        {
+            continue;
+        }
+        hard_breaks.push(hard_break);
+    }
+    hard_breaks
+}
+
+pub(crate) fn drag_selection_for_entry(
+    layout_index: &LayoutIndex,
+    doc: &Doc,
+    entry: &LayoutEntry,
+    point: LayoutPoint,
+) -> Option<Selection> {
+    let hard_break = hard_break_for_entry(layout_index, doc, entry)?;
+    let rect = hard_break.geometry.rect.rect;
+    let page_y = point.y - point.page_y_start;
+    let x_mid = rect.x + rect.width / 2.0;
+    if hard_break.geometry.rect.page_idx == point.page_idx
+        && page_y >= rect.y
+        && page_y <= rect.bottom()
+        && point.x >= x_mid
+        && point.x <= hard_break.geometry.line_right
+    {
+        Some(hard_break.selection)
+    } else {
+        None
+    }
+}
+
+fn hard_break_for_entry(
+    layout_index: &LayoutIndex,
+    doc: &Doc,
+    entry: &LayoutEntry,
+) -> Option<SelectedHardBreak> {
+    let LayoutContent::Line(line) = entry.content(layout_index)? else {
+        return None;
+    };
+    let selection = hard_break_for_line(doc, line)?;
+    let geometry = geometry_for_line_entry(entry, line, selection, layout_index.pages())?;
+    Some(SelectedHardBreak {
+        selection,
+        geometry,
+    })
+}
+
+fn hard_break_for_line(doc: &Doc, line: &LayoutLine) -> Option<Selection> {
+    let range = line.child_range.as_ref()?;
+    let index = range.end;
+    let paragraph = doc.node(line.node_id)?;
+    let child = paragraph.children().nth(index)?;
+    if !matches!(child.node(), Node::HardBreak(_)) {
+        return None;
+    }
+    Some(Selection::new(
+        Position {
+            node_id: line.node_id,
+            offset: index,
+            affinity: Affinity::Downstream,
+        },
+        Position {
+            node_id: line.node_id,
+            offset: index + 1,
+            affinity: Affinity::Upstream,
+        },
+    ))
+}
+
+fn geometry_for_line_entry(
+    entry: &LayoutEntry,
+    line: &LayoutLine,
+    hard_break: Selection,
+    pages: &[LayoutPage],
+) -> Option<HardBreakGeometry> {
+    let page_idx = page_for_y(pages, entry.rect.y)?;
+    let x = entry.rect.x + super::grapheme::x_at_offset(line, &hard_break.anchor);
+    let width = entry.rect.height * 0.15;
+    Some(HardBreakGeometry {
+        rect: PageRect::new(
+            page_idx,
+            Rect::from_xywh(
+                x,
+                entry.rect.y - pages[page_idx].y_start,
+                width,
+                entry.rect.height,
+            ),
+        ),
+        line_right: entry.rect.right(),
+    })
+}

--- a/crates/editor-view/src/query/mod.rs
+++ b/crates/editor-view/src/query/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod composition;
 pub(crate) mod cursor;
 pub(crate) mod dnd;
 pub(crate) mod grapheme;
+pub(crate) mod hard_break;
 pub(crate) mod interactive;
 pub(crate) mod layout_index;
 pub(crate) mod link;

--- a/crates/editor-view/src/query/selection.rs
+++ b/crates/editor-view/src/query/selection.rs
@@ -100,6 +100,7 @@ fn selection_rect_sets(
     }
 
     let pages = layout_index.pages();
+    let hard_breaks = super::hard_break::included_in_selection(layout_index, selection);
     let paragraph_breaks = super::paragraph_break::included_in_selection(layout_index, selection);
 
     let from = Position::from(selection.from());
@@ -135,6 +136,10 @@ fn selection_rect_sets(
         selection.doc(),
     );
 
+    for hard_break in hard_breaks {
+        let rect = hard_break_rect(hard_break.geometry);
+        rects.push_same(rect);
+    }
     for paragraph_break in paragraph_breaks {
         let rect = paragraph_break_rect(paragraph_break.geometry);
         rects.push_same(rect);
@@ -142,6 +147,11 @@ fn selection_rect_sets(
     rects.sort_by_position();
 
     rects
+}
+
+fn hard_break_rect(geometry: super::hard_break::HardBreakGeometry) -> SelectionRect {
+    let rect = geometry.rect;
+    PageRect::with_meta(rect.page_idx, rect.rect, SelectionRectKind::Text)
 }
 
 fn paragraph_break_rect(geometry: super::paragraph_break::ParagraphBreakGeometry) -> SelectionRect {
@@ -308,27 +318,6 @@ fn attached(layout_index: &LayoutIndex, entry: &LayoutEntry, pos: &Position) -> 
     }
 }
 
-/// True when `child_range` owns more slots than the number of distinct text
-/// children — the surplus is non-text content (in practice, a trailing
-/// `hard_break`).
-fn line_has_trailing_non_text(line: &LayoutLine) -> bool {
-    let Some(range) = &line.child_range else {
-        return false;
-    };
-    if line.glyph_runs.is_empty() {
-        return false;
-    }
-    let mut text_child_count = 1usize;
-    let mut prev = line.glyph_runs[0].node_id;
-    for run in line.glyph_runs.iter().skip(1) {
-        if run.node_id != prev {
-            text_child_count += 1;
-            prev = run.node_id;
-        }
-    }
-    range.end.saturating_sub(range.start) > text_child_count
-}
-
 fn strut_line_has_selectable_child_range(line: &LayoutLine) -> bool {
     line.glyph_runs.is_empty()
         && line.tab_gaps.is_empty()
@@ -411,65 +400,39 @@ fn visit_line(
     let contains_from = from_owner.is_some_and(|entry| entry.is_node(layout_index, node));
     let contains_to = to_owner.is_some_and(|entry| entry.is_node(layout_index, node));
 
-    let hb_placeholder = node.rect.height * 0.15;
-    // Without an explicit extension, a trailing hard_break enveloped by the
-    // selection reads as zero width because `x_at_offset` pins to the last
-    // run's right edge.
-    let trailing_hb = line_has_trailing_non_text(line);
-    let at_line_trailing = |pos: &Position| -> bool {
-        line.child_range
-            .as_ref()
-            .is_some_and(|r| pos.node_id == line.node_id && pos.offset == r.end && r.end > r.start)
-    };
+    let placeholder_width = node.rect.height * 0.15;
 
     let (x_start, x_end) = match (*phase, contains_from, contains_to) {
         (Phase::Before, true, true) => {
             let x0 = super::grapheme::x_at_offset(line, from);
-            let mut x1 = super::grapheme::x_at_offset(line, to);
-            if trailing_hb && at_line_trailing(to) {
-                x1 += hb_placeholder;
-            }
+            let x1 = super::grapheme::x_at_offset(line, to);
             *phase = Phase::After;
             (x0, x1)
         }
         (Phase::Before, true, false) => {
             let x0 = super::grapheme::x_at_offset(line, from);
-            let mut x1 = line_end_x(line);
-            if trailing_hb {
-                x1 += hb_placeholder;
-            }
+            let x1 = line_end_x(line);
             *phase = Phase::Inside;
             (x0, x1)
         }
         (Phase::Inside, false, false) => {
             let x0 = line_start_x(line);
-            let mut x1 = line_end_x(line);
-            if trailing_hb {
-                x1 += hb_placeholder;
-            }
+            let x1 = line_end_x(line);
             (x0, x1)
         }
         (Phase::Inside, false, true) => {
             let x0 = line_start_x(line);
-            let mut x1 = super::grapheme::x_at_offset(line, to);
-            if trailing_hb && at_line_trailing(to) {
-                x1 += hb_placeholder;
-            }
+            let x1 = super::grapheme::x_at_offset(line, to);
             *phase = Phase::After;
             (x0, x1)
         }
         _ => return,
     };
 
-    // Both endpoints at paragraph-level offsets in the same line collapse
-    // onto the same x via `x_at_offset` — show a placeholder so the
-    // hard_break still reads as selected.
-    let spans_hard_break =
-        from.node_id == line.node_id && to.node_id == line.node_id && from.offset != to.offset;
     let width = if x_end > x_start {
         x_end - x_start
-    } else if spans_hard_break || strut_line_has_selectable_child_range(line) {
-        hb_placeholder
+    } else if strut_line_has_selectable_child_range(line) {
+        placeholder_width
     } else {
         return;
     };
@@ -957,6 +920,35 @@ mod tests {
                 SelectionRectKind::ParagraphBreak,
             ],
             "two hard_break rects and the paragraph break must be visible, got {rects:?}"
+        );
+    }
+
+    #[test]
+    fn trailing_hard_break_after_soft_wrap_line_is_visible() {
+        let (state, p1, _t1, ..) = state! {
+            doc {
+                root (layout_mode: editor_model::LayoutMode::Continuous { max_width: 40 }) {
+                    p1: paragraph {
+                        t1: text("abcdefgh")
+                        hard_break
+                        text("z")
+                    }
+                }
+            }
+            selection: (t1, 8, >) -> (p1, 2, <)
+        };
+        let view = layout(&state.doc);
+        let trailing_line_y = line_y_for_child_range(&view, p1, 1..1)
+            .expect("soft-wrapped trailing hard_break line exists");
+        let resolved = state.selection.unwrap().resolve(&state.doc).unwrap();
+        let rects = view.selection_rects(&resolved);
+
+        assert_eq!(rects.len(), 1, "hard_break must be visible, got {rects:?}");
+        assert_eq!(rects[0].meta, SelectionRectKind::Text);
+        assert!(rects[0].rect.width > 0.0, "got {rects:?}");
+        assert!(
+            (rects[0].rect.y - trailing_line_y).abs() < 0.01,
+            "hard_break rect must be on trailing wrapped line y={trailing_line_y}, got {rects:?}",
         );
     }
 

--- a/crates/editor-view/src/view.rs
+++ b/crates/editor-view/src/view.rs
@@ -244,6 +244,11 @@ impl View {
             .layout_index
             .exact_entry(point, is_drag_exact_hit_entry)
         {
+            if let Some(selection) =
+                query::hard_break::drag_selection_for_entry(&result.layout_index, doc, entry, point)
+            {
+                return Some(selection);
+            }
             if let Some(selection) = query::paragraph_break::drag_selection_for_entry(
                 &result.layout_index,
                 doc,
@@ -723,8 +728,7 @@ fn drag_boundary_fallback(
     let mut after: Option<DragFallbackCandidate> = None;
 
     for entry in layout_index.entries_on_page(point.page_idx) {
-        let Some(candidate) = drag_fallback_candidate(layout_index, entry, doc, anchor, point)
-        else {
+        let Some(candidate) = drag_fallback_candidate(layout_index, entry, point) else {
             continue;
         };
         let slot = if point.y >= entry.rect.y && point.y < entry.rect.bottom() {
@@ -785,8 +789,6 @@ impl DragFallbackCandidate {
 fn drag_fallback_candidate(
     layout_index: &query::layout_index::LayoutIndex,
     entry: &query::layout_index::LayoutEntry,
-    doc: &Doc,
-    anchor: &ResolvedPosition,
     point: query::layout_index::LayoutPoint,
 ) -> Option<DragFallbackCandidate> {
     match entry.content(layout_index)? {
@@ -798,8 +800,7 @@ fn drag_fallback_candidate(
             } else if point.y >= entry.rect.bottom() {
                 end
             } else {
-                let point_pos = position_in_line(line, &entry.rect, point.x).resolve(doc)?;
-                if anchor < &point_pos { end } else { start }
+                position_in_line(line, &entry.rect, point.x)
             };
             Some(DragFallbackCandidate::new(
                 entry,
@@ -1269,6 +1270,169 @@ mod tests {
                 },
             )
         );
+    }
+
+    #[test]
+    fn hit_test_extending_next_line_page_margin_after_paragraph_break_returns_next_paragraph_start()
+    {
+        let (doc, _p1, t1, t2) = doc! {
+            root {
+                p1: paragraph { t1: text("aa") }
+                paragraph { t2: text("bb") }
+            }
+        };
+        let mut view = View::new_test();
+        view.layout(&doc);
+        let state = mk_state(doc.clone());
+        let next_line = view
+            .cursor_metrics(&state, &Position::new(t2, 0))
+            .expect("line after paragraph break has cursor metrics");
+
+        let hit = view
+            .hit_test_extending(
+                &state.doc,
+                Position::new(t1, 0),
+                next_line.page_idx,
+                next_line.line.x - 12.0,
+                next_line.line.y + next_line.line.height / 2.0,
+            )
+            .unwrap();
+
+        assert_eq!(hit, Selection::collapsed(Position::new(t2, 0)));
+    }
+
+    #[test]
+    fn hit_test_extending_hard_break_rect_returns_hard_break_selection() {
+        let (doc, p1, _t1, _t2) = doc! {
+            root {
+                p1: paragraph {
+                    t1: text("a")
+                    hard_break
+                    t2: text("b")
+                }
+            }
+        };
+        let mut view = View::new_test();
+        view.layout(&doc);
+        let hard_break = Selection::new(
+            Position {
+                node_id: p1,
+                offset: 1,
+                affinity: Affinity::Downstream,
+            },
+            Position {
+                node_id: p1,
+                offset: 2,
+                affinity: Affinity::Upstream,
+            },
+        );
+        let hard_break_rect = view
+            .selection_rects(
+                &hard_break
+                    .resolve(&doc)
+                    .expect("hard_break selection resolves"),
+            )
+            .into_iter()
+            .find(|rect| rect.meta == crate::query::SelectionRectKind::Text)
+            .expect("hard_break rect exists");
+
+        let hit = view
+            .hit_test_extending(
+                &doc,
+                Position::new(p1, 0),
+                hard_break_rect.page_idx,
+                hard_break_rect.rect.x + hard_break_rect.rect.width / 2.0,
+                hard_break_rect.rect.y + hard_break_rect.rect.height / 2.0,
+            )
+            .unwrap();
+
+        assert_eq!(hit, hard_break);
+    }
+
+    #[test]
+    fn hit_test_extending_hard_break_line_right_side_returns_hard_break_selection() {
+        let (doc, p1, _t1, _t2) = doc! {
+            root {
+                p1: paragraph {
+                    t1: text("a")
+                    hard_break
+                    t2: text("b")
+                }
+            }
+        };
+        let mut view = View::new_test();
+        view.layout(&doc);
+        let hard_break = Selection::new(
+            Position {
+                node_id: p1,
+                offset: 1,
+                affinity: Affinity::Downstream,
+            },
+            Position {
+                node_id: p1,
+                offset: 2,
+                affinity: Affinity::Upstream,
+            },
+        );
+        let hard_break_rect = view
+            .selection_rects(
+                &hard_break
+                    .resolve(&doc)
+                    .expect("hard_break selection resolves"),
+            )
+            .into_iter()
+            .find(|rect| rect.meta == crate::query::SelectionRectKind::Text)
+            .expect("hard_break rect exists");
+
+        let hit = view
+            .hit_test_extending(
+                &doc,
+                Position::new(p1, 0),
+                hard_break_rect.page_idx,
+                hard_break_rect.rect.right() + 12.0,
+                hard_break_rect.rect.y + hard_break_rect.rect.height / 2.0,
+            )
+            .unwrap();
+
+        assert_eq!(hit, hard_break);
+    }
+
+    #[test]
+    fn hit_test_extending_next_line_page_margin_after_hard_break_returns_next_line_start() {
+        let (doc, p1, _t1, t2) = doc! {
+            root {
+                p1: paragraph {
+                    t1: text("a")
+                    hard_break
+                    t2: text("b")
+                }
+            }
+        };
+        let mut view = View::new_test();
+        view.layout(&doc);
+        let state = mk_state(doc.clone());
+        let next_line = view
+            .cursor_metrics(
+                &state,
+                &Position {
+                    node_id: p1,
+                    offset: 2,
+                    affinity: Affinity::Downstream,
+                },
+            )
+            .expect("line after hard_break has cursor metrics");
+
+        let hit = view
+            .hit_test_extending(
+                &state.doc,
+                Position::new(p1, 0),
+                next_line.page_idx,
+                next_line.line.x - 12.0,
+                next_line.line.y + next_line.line.height / 2.0,
+            )
+            .unwrap();
+
+        assert_eq!(hit, Selection::collapsed(Position::new(t2, 0)));
     }
 
     #[test]


### PR DESCRIPTION
- paragraph 끝의 hard break 까지 선택된 후, shift + right로 더 이상 확장이 안 되는 문제를 해결
- soft wrap 된 줄의 hb는 시각화되지 않는 문제를 해결
- hb rect를 드래그해서 선택할 수 있도록 함 (paragraph break처럼)
- 다음 line 왼쪽 gutter까지 드래그하면 다음 줄이 전체 선택되는 버그를 해결