### PR TITLE
TR-257 이미지 노드 삽입 후 파일 선택을 취소하면 노드가 삭제되는 문제 수정

### DIFF
--- a/apps/website/src/lib/editor-ffi/components/ExternalImage.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ExternalImage.svelte
@@ -15,11 +15,13 @@
   import {
     calculateImageContainerSize,
     calculateImageWidth,
-    createDeleteNodeMessage,
-    createSetImageAttrsMessage,
+    deleteNodeMessage,
     deriveImageStage,
+    openImagePicker,
     processImageUpload,
+    queuePendingImages,
     resolveImageSrc,
+    setImageAttrsMessage,
   } from '../handlers/image-flow';
   import { getImageDimensions, uploadImageFile } from '../handlers/upload';
   import ExternalElementWrapper from './ExternalElementWrapper.svelte';
@@ -102,7 +104,7 @@
   });
 
   const deleteNode = () => {
-    ctx.editor?.enqueue(createDeleteNodeMessage(element.node_id));
+    ctx.editor?.enqueue(deleteNodeMessage(element.node_id));
     ctx.editor?.focus();
   };
 
@@ -133,34 +135,7 @@
   const handleUpload = () => {
     if (!canEdit) return;
 
-    const picker = document.createElement('input');
-    picker.type = 'file';
-    picker.accept = 'image/*';
-    picker.multiple = true;
-
-    picker.addEventListener('change', () => {
-      const files = [...(picker.files ?? [])];
-      if (files.length === 0) {
-        deleteNode();
-        return;
-      }
-
-      void processFile(files[0]);
-
-      for (const file of files.slice(1)) {
-        ctx.pendingImageDrops.push(file);
-        ctx.editor?.enqueue({
-          type: 'insertion',
-          op: { type: 'fragment', fragment: { node: { type: 'image', id: undefined } } },
-        });
-      }
-    });
-
-    picker.addEventListener('cancel', () => {
-      deleteNode();
-    });
-
-    picker.click();
+    openImagePicker(ctx, (file) => void processFile(file));
   };
 
   const handleDragOver = (event: DragEvent) => {
@@ -185,13 +160,7 @@
     event.stopPropagation();
     void processFile(file);
 
-    for (const next of rest) {
-      ctx.pendingImageDrops.push(next);
-      ctx.editor?.enqueue({
-        type: 'insertion',
-        op: { type: 'fragment', fragment: { node: { type: 'image', id: undefined } } },
-      });
-    }
+    queuePendingImages(ctx, rest);
   };
 
   const getWidthBounds = (boundsWidth: number) => {
@@ -243,7 +212,7 @@
 
     isResizing = false;
     initialResizeData = null;
-    ctx.editor?.enqueue(createSetImageAttrsMessage(element.node_id, imageId, proportion));
+    ctx.editor?.enqueue(setImageAttrsMessage(element.node_id, imageId, proportion));
     ctx.editor?.focus();
   };
 

--- a/apps/website/src/lib/editor-ffi/handlers/image-flow.test.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/image-flow.test.ts
@@ -3,11 +3,13 @@ import {
   calculateImageContainerSize,
   calculateImageHeight,
   calculateImageWidth,
-  createDeleteNodeMessage,
-  createSetImageAttrsMessage,
+  deleteNodeMessage,
   getFirstImageFile,
+  openImagePicker,
   processImageUpload,
+  queuePendingImages,
   resolveImageSrc,
+  setImageAttrsMessage,
 } from './image-flow';
 import type { Message } from '@typie/editor-ffi/browser';
 import type { ImageAsset } from '../types';
@@ -63,7 +65,7 @@ describe('이미지 표시 여부 결정', () => {
 
 describe('v2 image flow messages', () => {
   it('creates a v2 node attrs message for uploaded image id and rounded proportion', () => {
-    expect(createSetImageAttrsMessage('node-1', 'image-1', 74.6)).toEqual({
+    expect(setImageAttrsMessage('node-1', 'image-1', 74.6)).toEqual({
       type: 'node',
       op: {
         type: 'set_attrs',
@@ -78,7 +80,7 @@ describe('v2 image flow messages', () => {
   });
 
   it('creates a v2 node delete message for placeholder cleanup and deletion', () => {
-    expect(createDeleteNodeMessage('node-1')).toEqual({
+    expect(deleteNodeMessage('node-1')).toEqual({
       type: 'node',
       op: {
         type: 'delete',
@@ -102,6 +104,102 @@ describe('v2 image drop filtering', () => {
   });
 });
 
+const createCtx = () => {
+  const messages: Message[] = [];
+  const pendingImageDrops: File[] = [];
+  const editor = {
+    enqueue: (message: Message) => {
+      messages.push(message);
+    },
+  };
+
+  return {
+    ctx: { editor, pendingImageDrops } as never,
+    messages,
+    pendingImageDrops,
+  };
+};
+
+describe('v2 pending image queueing', () => {
+  it('각 파일을 pending 큐에 넣고 빈 이미지 노드 삽입 메시지를 보낸다', () => {
+    const { ctx, messages, pendingImageDrops } = createCtx();
+    const first = createFile('first.png', 'image/png');
+    const second = createFile('second.png', 'image/png');
+
+    queuePendingImages(ctx, [first, second]);
+
+    expect(pendingImageDrops).toEqual([first, second]);
+    expect(messages).toEqual([
+      {
+        type: 'insertion',
+        op: { type: 'fragment', fragment: { node: { type: 'image', id: undefined } } },
+      },
+      {
+        type: 'insertion',
+        op: { type: 'fragment', fragment: { node: { type: 'image', id: undefined } } },
+      },
+    ]);
+  });
+
+  it('파일이 없으면 아무것도 하지 않는다', () => {
+    const { ctx, messages, pendingImageDrops } = createCtx();
+
+    queuePendingImages(ctx, []);
+
+    expect(pendingImageDrops).toEqual([]);
+    expect(messages).toEqual([]);
+  });
+});
+
+describe('v2 image picker flow', () => {
+  const setPickerFiles = (picker: HTMLInputElement, files: File[]) => {
+    Object.defineProperty(picker, 'files', { value: files });
+  };
+
+  it('파일 선택을 취소하면 노드를 유지한다', () => {
+    const { ctx, messages } = createCtx();
+    const processFile = vi.fn();
+
+    const picker = openImagePicker(ctx, processFile);
+    picker.dispatchEvent(new Event('cancel'));
+
+    expect(processFile).not.toHaveBeenCalled();
+    expect(messages).toEqual([]);
+  });
+
+  it('파일 없이 선택을 마치면 노드를 유지한다', () => {
+    const { ctx, messages } = createCtx();
+    const processFile = vi.fn();
+
+    const picker = openImagePicker(ctx, processFile);
+    setPickerFiles(picker, []);
+    picker.dispatchEvent(new Event('change'));
+
+    expect(processFile).not.toHaveBeenCalled();
+    expect(messages).toEqual([]);
+  });
+
+  it('첫 파일은 현재 노드에 업로드하고 나머지는 새 이미지 노드로 삽입한다', () => {
+    const { ctx, messages, pendingImageDrops } = createCtx();
+    const processFile = vi.fn();
+    const first = createFile('first.png', 'image/png');
+    const second = createFile('second.png', 'image/png');
+
+    const picker = openImagePicker(ctx, processFile);
+    setPickerFiles(picker, [first, second]);
+    picker.dispatchEvent(new Event('change'));
+
+    expect(processFile).toHaveBeenCalledExactlyOnceWith(first);
+    expect(pendingImageDrops).toEqual([second]);
+    expect(messages).toEqual([
+      {
+        type: 'insertion',
+        op: { type: 'fragment', fragment: { node: { type: 'image', id: undefined } } },
+      },
+    ]);
+  });
+});
+
 describe('v2 image upload processing', () => {
   it('stores inflight preview, persists uploaded image id, and cleans up object url', async () => {
     const { deps, messages, inflight, assets, focus } = createDeps();
@@ -120,13 +218,13 @@ describe('v2 image upload processing', () => {
 
     expect(result).toBe('uploaded');
     expect(assets.get('image-1')).toEqual(createAsset('image-1'));
-    expect(messages).toEqual([createSetImageAttrsMessage('node-1', 'image-1', 100)]);
+    expect(messages).toEqual([setImageAttrsMessage('node-1', 'image-1', 100)]);
     expect(inflight.get('node-1')).toEqual({ url: 'blob:image', width: 320, height: 240 });
     expect(revokeObjectUrl).not.toHaveBeenCalled();
     expect(focus).toHaveBeenCalled();
   });
 
-  it('cleans up preview and leaves node as empty placeholder when upload fails', async () => {
+  it('업로드가 실패하면 미리보기를 정리하고 빈 노드를 삭제한다', async () => {
     const { deps, messages, inflight, focus } = createDeps();
     const revokeObjectUrl = vi.fn();
 
@@ -144,7 +242,7 @@ describe('v2 image upload processing', () => {
     });
 
     expect(result).toBe('failed');
-    expect(messages).toEqual([]);
+    expect(messages).toEqual([deleteNodeMessage('node-1')]);
     expect(inflight.has('node-1')).toBe(false);
     expect(revokeObjectUrl).toHaveBeenCalledWith('blob:image');
     expect(focus).toHaveBeenCalled();

--- a/apps/website/src/lib/editor-ffi/handlers/image-flow.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/image-flow.ts
@@ -1,4 +1,5 @@
 import type { Message } from '@typie/editor-ffi/browser';
+import type { EditorContext } from '../editor.svelte';
 import type { ImageAsset, ImageStage } from '../types';
 
 export const deriveImageStage = ({
@@ -19,7 +20,7 @@ export const deriveImageStage = ({
 type UploadImageFile = (file: File) => Promise<ImageAsset>;
 type ReadImageDimensions = (src: string) => Promise<{ width: number; height: number }>;
 
-export const createSetImageAttrsMessage = (nodeId: string, imageId: string | undefined, proportion: number): Message => ({
+export const setImageAttrsMessage = (nodeId: string, imageId: string | undefined, proportion: number): Message => ({
   type: 'node',
   op: {
     type: 'set_attrs',
@@ -32,13 +33,47 @@ export const createSetImageAttrsMessage = (nodeId: string, imageId: string | und
   },
 });
 
-export const createDeleteNodeMessage = (nodeId: string): Message => ({
+export const deleteNodeMessage = (nodeId: string): Message => ({
   type: 'node',
   op: {
     type: 'delete',
     id: nodeId,
   },
 });
+
+const insertEmptyImageMessage = (): Message => ({
+  type: 'insertion',
+  op: { type: 'fragment', fragment: { node: { type: 'image', id: undefined } } },
+});
+
+export const queuePendingImages = (ctx: EditorContext, files: File[]): void => {
+  ctx.pendingImageDrops.push(...files);
+  files.forEach(() => ctx.editor?.enqueue(insertEmptyImageMessage()));
+};
+
+const imagePicker = (ctx: EditorContext, processFile: (file: File) => void): HTMLInputElement => {
+  const picker = document.createElement('input');
+  picker.type = 'file';
+  picker.accept = 'image/*';
+  picker.multiple = true;
+
+  picker.addEventListener('change', () => uploadImages(ctx, processFile, picker.files));
+
+  return picker;
+};
+
+const uploadImages = (ctx: EditorContext, processFile: (file: File) => void, files: FileList | null): void => {
+  const picked = [...(files ?? [])];
+  [picked.shift()].filter((file) => file !== undefined).forEach((file) => processFile(file));
+  queuePendingImages(ctx, picked);
+};
+
+export const openImagePicker = (ctx: EditorContext, processFile: (file: File) => void): HTMLInputElement => {
+  const picker = imagePicker(ctx, processFile);
+  picker.click();
+
+  return picker;
+};
 
 export const getFirstImageFile = (files: Iterable<File>): File | undefined => {
   return [...files].find((file) => file.type.startsWith('image/'));
@@ -113,13 +148,14 @@ export const processImageUpload = async ({
 
     const uploaded = await uploadImageFile(file);
     setImageAsset(uploaded);
-    enqueue(createSetImageAttrsMessage(nodeId, uploaded.id, getProportion()));
+    enqueue(setImageAttrsMessage(nodeId, uploaded.id, getProportion()));
     focus();
 
     return 'uploaded';
   } catch {
     deleteInflightImage(nodeId);
     revokeObjectUrl(objectUrl);
+    enqueue(deleteNodeMessage(nodeId));
     focus();
     return 'failed';
   }


### PR DESCRIPTION
이미지 노드를 삽입한 뒤 파일 선택 창을 열었다가 그냥 닫으면 방금 만든 노드가 사라지던 문제를 수정했습니다.
업로드에 실패하면 빈 노드를 남기지 않고 정리하자는 의도의 로직이 실패 경로가 아니라 선택 취소 경로에 들어가 있던 것이 원인이었습니다.
선택을 취소하는 것은 노드를 지우겠다는 뜻이 아니므로 v1과 같이 placeholder를 그대로 두어 나중에 다시 선택할 수 있게 했고,   
빈 노드 정리는 원래 의도대로 실제 업로드가 실패한 시점에만 일어나도록 했습니다.