### PR TITLE
텍스트 identity 기반 selection remap 정리

### DIFF
--- a/crates/editor-commands/src/commands/apply_style_to_selection.rs
+++ b/crates/editor-commands/src/commands/apply_style_to_selection.rs
@@ -5,7 +5,7 @@ use editor_transaction::Transaction;
 use crate::CommandResult;
 use crate::helpers::{
     clear_inline_modifier_types_in_selection, collect_run_nodes_in_selection,
-    compact_and_restore_selection,
+    compact_textblocks_for_nodes,
 };
 
 pub fn apply_style_to_selection(tr: &mut Transaction, style_id: String) -> CommandResult {
@@ -45,7 +45,7 @@ pub fn apply_style_to_selection(tr: &mut Transaction, style_id: String) -> Comma
     }
 
     if style_modifier_types.is_empty() {
-        compact_and_restore_selection(tr, &run_ids)?;
+        compact_textblocks_for_nodes(tr, &run_ids)?;
     } else if clear_inline_modifier_types_in_selection(tr, &style_modifier_types)? {
         changed = true;
     }

--- a/crates/editor-commands/src/commands/clear_all_modifiers.rs
+++ b/crates/editor-commands/src/commands/clear_all_modifiers.rs
@@ -3,7 +3,7 @@ use editor_state::{PendingModifier, PendingModifiers, Position};
 use editor_transaction::Transaction;
 
 use crate::helpers::{
-    collect_text_nodes_in_range, compact_and_restore_selection, is_text_applicable,
+    collect_text_nodes_in_range, compact_textblocks_for_nodes, is_text_applicable,
     resolve_effective_modifiers,
 };
 use crate::{CommandError, CommandResult};
@@ -82,7 +82,7 @@ fn clear_all_modifiers_range(tr: &mut Transaction) -> CommandResult {
         }
     }
 
-    compact_and_restore_selection(tr, &node_ids)?;
+    compact_textblocks_for_nodes(tr, &node_ids)?;
     Ok(true)
 }
 
@@ -186,11 +186,11 @@ mod tests {
                     paragraph {
                         text("He") [italic]
                         t1: text("lloWo")
-                        text("rld") [italic]
+                        t2: text("rld") [italic]
                     }
                 }
             }
-            selection: (t1, 0) -> (t1, 5)
+            selection: (t1, 0) -> (t2, 0)
         };
         assert_state_eq!(&actual, &expected);
     }
@@ -219,8 +219,7 @@ mod tests {
         assert_state_eq!(&actual, &expected);
     }
 
-    // Backward selection: compact normalizes to a forward selection — pin that
-    // whole-state contract instead of only checking one modifier on one node.
+    // Backward selection keeps anchor/head direction after inline cleanup.
     #[test]
     fn range_backward_selection_clears() {
         let (initial, ..) = state! {
@@ -230,14 +229,14 @@ mod tests {
         let (actual, ..) = transact!(initial, |tr| clear_all_modifiers(&mut tr));
         let (expected, ..) = state! {
             doc { root { paragraph { t1: text("Hello") } } }
-            selection: (t1, 0) -> (t1, 5)
+            selection: (t1, 5) -> (t1, 0)
         };
         assert_state_eq!(&actual, &expected);
     }
 
     // Regression guard: a partial selection over modifier-free text triggers the
     // boundary splits inside `collect_text_nodes_in_range`. Because the range
-    // path always reaches `compact_and_restore_selection` (no early return),
+    // path always reaches `compact_textblocks_for_nodes` (no early return),
     // those splits are merged back and the document is left unchanged. If an
     // early-return ever skips compact, this fails with a fragmented text run.
     #[test]

--- a/crates/editor-commands/src/commands/create_style_from_selection.rs
+++ b/crates/editor-commands/src/commands/create_style_from_selection.rs
@@ -72,6 +72,31 @@ mod tests {
     }
 
     #[test]
+    fn ignores_zero_width_boundary_text_when_capturing_uniform_modifiers() {
+        let (initial, ..) = state! {
+            doc {
+                root {
+                    paragraph {
+                        t1: text("a") [bold]
+                        t2: text("b") [italic]
+                    }
+                }
+            }
+            selection: (t1, 0) -> (t2, 0)
+        };
+        let (actual, ..) = transact!(initial, |tr| create_style_from_selection(
+            &mut tr,
+            "s1".into(),
+            "x".into()
+        ));
+
+        let style = actual.doc.style_entry("s1").unwrap();
+        let mods: Vec<Modifier> = style.modifiers.iter().cloned().collect();
+        assert!(mods.contains(&Modifier::Bold));
+        assert!(!mods.contains(&Modifier::Italic));
+    }
+
+    #[test]
     fn sets_style_ref_on_selected_runs() {
         let (initial, ..) = state! {
             doc { root { paragraph { t1: text("Hello") [font_size(800)] } } }

--- a/crates/editor-commands/src/commands/edit_modifier.rs
+++ b/crates/editor-commands/src/commands/edit_modifier.rs
@@ -3,8 +3,8 @@ use editor_state::{Position, resolve_modifier_span_at};
 use editor_transaction::Transaction;
 
 use crate::helpers::{
-    apply_modifier_to_node, collect_text_nodes_in_range, compact_and_restore_selection,
-    compact_textblock_preserving_caret, filter_applicable_node_ids, is_text_applicable,
+    apply_modifier_to_node, collect_text_nodes_in_range, compact_textblock_at_position,
+    compact_textblocks_for_nodes, filter_applicable_node_ids, is_text_applicable,
 };
 use crate::{CommandError, CommandResult};
 
@@ -74,7 +74,7 @@ fn edit_modifier_collapsed(
         }
     }
 
-    compact_textblock_preserving_caret(tr, pos)?;
+    compact_textblock_at_position(tr, pos)?;
     Ok(true)
 }
 
@@ -117,7 +117,7 @@ fn edit_modifier_range(
         }
     }
 
-    compact_and_restore_selection(tr, &node_ids)?;
+    compact_textblocks_for_nodes(tr, &node_ids)?;
     Ok(true)
 }
 

--- a/crates/editor-commands/src/commands/set_modifier.rs
+++ b/crates/editor-commands/src/commands/set_modifier.rs
@@ -4,7 +4,7 @@ use editor_transaction::Transaction;
 
 use crate::helpers::{
     apply_modifier_to_node, collect_applicable_targets_in_range, collect_text_nodes_in_range,
-    compact_and_restore_selection, filter_applicable_node_ids, is_text_applicable, is_unit_variant,
+    compact_textblocks_for_nodes, filter_applicable_node_ids, is_text_applicable, is_unit_variant,
     resolve_applicable_target_collapsed,
 };
 use crate::{CommandError, CommandResult};
@@ -138,7 +138,7 @@ fn set_modifier_range_text(tr: &mut Transaction, modifier: &Modifier) -> Command
         apply_modifier_to_node(tr, &node, modifier)?;
     }
 
-    compact_and_restore_selection(tr, &node_ids)?;
+    compact_textblocks_for_nodes(tr, &node_ids)?;
 
     Ok(true)
 }
@@ -408,11 +408,11 @@ mod tests {
                     paragraph {
                         text("He")
                         t1: text("lloWo") [font_size(2400)]
-                        text("rld")
+                        t2: text("rld")
                     }
                 }
             }
-            selection: (t1, 0) -> (t1, 5)
+            selection: (t1, 0) -> (t2, 0)
         };
         assert_state_eq!(&actual, &expected);
     }

--- a/crates/editor-commands/src/commands/toggle_bold.rs
+++ b/crates/editor-commands/src/commands/toggle_bold.rs
@@ -7,7 +7,7 @@ use editor_state::{
 use editor_transaction::Transaction;
 
 use crate::helpers::{
-    collect_text_nodes_in_range, compact_and_restore_selection, filter_applicable_node_ids,
+    collect_text_nodes_in_range, compact_textblocks_for_nodes, filter_applicable_node_ids,
     resolve_inherited_modifiers,
 };
 use crate::{CommandError, CommandResult};
@@ -48,7 +48,7 @@ pub fn toggle_bold(tr: &mut Transaction, resource: &Resource) -> CommandResult {
         toggle_bold_on_range(tr, resource, &applicable_node_ids)?;
     }
 
-    compact_and_restore_selection(tr, &node_ids)?;
+    compact_textblocks_for_nodes(tr, &node_ids)?;
 
     Ok(true)
 }
@@ -831,6 +831,203 @@ mod tests {
     }
 
     #[test]
+    fn range_toggle_on_backward_boundary_excludes_left_text() {
+        let resource = make_resource([("Pretendard", vec![400, 700])]);
+        let (initial, ..) = state! {
+            doc {
+                styles {
+                    base: "기본" [font_size(1200), font_family("Pretendard".to_string()), font_weight(400), text_color("black".to_string()), background_color("none".to_string()), letter_spacing(0), line_height(160), block_gap(50), paragraph_indent(50)]
+                }
+                root @base {
+                    paragraph {
+                        t1: text("aa")
+                    }
+                    paragraph {
+                        t2: text("bb")
+                    }
+                }
+            }
+            selection: (t2, 2, <) -> (t1, 2, >)
+        };
+        let (actual, ..) = transact!(initial, |tr| toggle_bold(&mut tr, &resource));
+        let (expected, ..) = state! {
+            doc {
+                styles {
+                    base: "기본" [font_size(1200), font_family("Pretendard".to_string()), font_weight(400), text_color("black".to_string()), background_color("none".to_string()), letter_spacing(0), line_height(160), block_gap(50), paragraph_indent(50)]
+                }
+                root @base {
+                    paragraph {
+                        t1: text("aa")
+                    }
+                    paragraph {
+                        t2: text("bb") [font_weight(700)]
+                    }
+                }
+            }
+            selection: (t2, 2, <) -> (t1, 2, >)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn range_toggle_on_forward_boundary_excludes_right_text_start() {
+        let resource = make_resource([("Pretendard", vec![400, 700])]);
+        let (initial, ..) = state! {
+            doc {
+                styles {
+                    base: "기본" [font_size(1200), font_family("Pretendard".to_string()), font_weight(400), text_color("black".to_string()), background_color("none".to_string()), letter_spacing(0), line_height(160), block_gap(50), paragraph_indent(50)]
+                }
+                root @base {
+                    paragraph {
+                        t1: text("aa")
+                    }
+                    paragraph {
+                        t2: text("bb")
+                    }
+                }
+            }
+            selection: (t1, 1, >) -> (t2, 0, <)
+        };
+        let (actual, ..) = transact!(initial, |tr| toggle_bold(&mut tr, &resource));
+        let (expected, ..) = state! {
+            doc {
+                styles {
+                    base: "기본" [font_size(1200), font_family("Pretendard".to_string()), font_weight(400), text_color("black".to_string()), background_color("none".to_string()), letter_spacing(0), line_height(160), block_gap(50), paragraph_indent(50)]
+                }
+                root @base {
+                    paragraph {
+                        t1: text("a")
+                        t2: text("a") [font_weight(700)]
+                    }
+                    paragraph {
+                        t3: text("bb")
+                    }
+                }
+            }
+            selection: (t2, 0, >) -> (t3, 0, <)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn range_double_toggle_forward_boundary_restores_original_selection() {
+        let resource = make_resource([("Pretendard", vec![400, 700])]);
+        let (initial, ..) = state! {
+            doc {
+                styles {
+                    base: "기본" [font_size(1200), font_family("Pretendard".to_string()), font_weight(400), text_color("black".to_string()), background_color("none".to_string()), letter_spacing(0), line_height(160), block_gap(50), paragraph_indent(50)]
+                }
+                root @base {
+                    paragraph {
+                        t1: text("aa")
+                    }
+                    paragraph {
+                        t2: text("bb")
+                    }
+                }
+            }
+            selection: (t1, 1, >) -> (t2, 0, <)
+        };
+        let (actual, ..) = transact!(initial, |tr| {
+            toggle_bold(&mut tr, &resource).unwrap();
+            toggle_bold(&mut tr, &resource)
+        });
+        let (expected, ..) = state! {
+            doc {
+                styles {
+                    base: "기본" [font_size(1200), font_family("Pretendard".to_string()), font_weight(400), text_color("black".to_string()), background_color("none".to_string()), letter_spacing(0), line_height(160), block_gap(50), paragraph_indent(50)]
+                }
+                root @base {
+                    paragraph {
+                        t1: text("aa")
+                    }
+                    paragraph {
+                        t2: text("bb")
+                    }
+                }
+            }
+            selection: (t1, 1, >) -> (t2, 0, <)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn range_toggle_off_preserves_start_of_text_merged_by_compact() {
+        let resource = make_resource([("Pretendard", vec![400, 700])]);
+        let (initial, ..) = state! {
+            doc {
+                styles {
+                    base: "기본" [font_size(1200), font_family("Pretendard".to_string()), font_weight(400), text_color("black".to_string()), background_color("none".to_string()), letter_spacing(0), line_height(160), block_gap(50), paragraph_indent(50)]
+                }
+                root @base {
+                    paragraph {
+                        text("a")
+                        t1: text("a") [font_weight(700)]
+                    }
+                    paragraph {
+                        t2: text("bb")
+                    }
+                }
+            }
+            selection: (t1, 0, >) -> (t2, 0, <)
+        };
+        let (actual, ..) = transact!(initial, |tr| toggle_bold(&mut tr, &resource));
+        let (expected, ..) = state! {
+            doc {
+                styles {
+                    base: "기본" [font_size(1200), font_family("Pretendard".to_string()), font_weight(400), text_color("black".to_string()), background_color("none".to_string()), letter_spacing(0), line_height(160), block_gap(50), paragraph_indent(50)]
+                }
+                root @base {
+                    paragraph {
+                        t1: text("aa")
+                    }
+                    paragraph {
+                        t2: text("bb")
+                    }
+                }
+            }
+            selection: (t1, 1, >) -> (t2, 0, <)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn range_toggle_on_preserves_paragraph_end_after_split_before_hard_break() {
+        let resource = make_resource([("Pretendard", vec![400, 700])]);
+        let (initial, ..) = state! {
+            doc {
+                styles {
+                    base: "기본" [font_size(1200), font_family("Pretendard".to_string()), font_weight(400), text_color("black".to_string()), background_color("none".to_string()), letter_spacing(0), line_height(160), block_gap(50), paragraph_indent(50)]
+                }
+                root @base {
+                    p1: paragraph {
+                        t1: text("aa")
+                        hard_break
+                    }
+                }
+            }
+            selection: (t1, 1, >) -> (p1, 2, <)
+        };
+        let (actual, ..) = transact!(initial, |tr| toggle_bold(&mut tr, &resource));
+        let (expected, ..) = state! {
+            doc {
+                styles {
+                    base: "기본" [font_size(1200), font_family("Pretendard".to_string()), font_weight(400), text_color("black".to_string()), background_color("none".to_string()), letter_spacing(0), line_height(160), block_gap(50), paragraph_indent(50)]
+                }
+                root @base {
+                    p1: paragraph {
+                        t1: text("a")
+                        t2: text("a") [font_weight(700)]
+                        hard_break
+                    }
+                }
+            }
+            selection: (t2, 0, >) -> (p1, 3, <)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
     fn backward_selection_works() {
         let resource = make_resource([("Pretendard", vec![400, 700])]);
         let (initial, ..) = state! {
@@ -968,7 +1165,7 @@ mod tests {
                     }
                 }
             }
-            selection: (t1, 0) -> (t1, 5)
+            selection: (t1, 0) -> (t2, 0)
         };
         assert_state_eq!(&actual, &expected);
     }

--- a/crates/editor-commands/src/commands/toggle_modifier.rs
+++ b/crates/editor-commands/src/commands/toggle_modifier.rs
@@ -3,7 +3,7 @@ use editor_state::{PendingModifier, PendingModifiers, Position, resolve_effectiv
 use editor_transaction::Transaction;
 
 use crate::helpers::{
-    check_range_all_has_modifier, collect_text_nodes_in_range, compact_and_restore_selection,
+    check_range_all_has_modifier, collect_text_nodes_in_range, compact_textblocks_for_nodes,
     filter_applicable_node_ids,
 };
 use crate::{CommandError, CommandResult};
@@ -66,7 +66,7 @@ pub fn toggle_modifier(tr: &mut Transaction, modifier_type: ModifierType) -> Com
         }
     }
 
-    compact_and_restore_selection(tr, &node_ids)?;
+    compact_textblocks_for_nodes(tr, &node_ids)?;
 
     Ok(true)
 }
@@ -443,9 +443,9 @@ mod tests {
             doc { root { paragraph {
                 text("He")
                 t1: text("lloWo") [italic]
-                text("rld")
+                t2: text("rld")
             } } }
-            selection: (t1, 0) -> (t1, 5)
+            selection: (t1, 0) -> (t2, 0)
         };
         assert_state_eq!(&actual, &expected);
     }

--- a/crates/editor-commands/src/helpers/range.rs
+++ b/crates/editor-commands/src/helpers/range.rs
@@ -1,4 +1,4 @@
-use editor_model::{Doc, Node, NodeId, NodeRef};
+use editor_model::{Node, NodeId, NodeRef};
 use editor_state::{Position, ResolvedSelection, Selection};
 use editor_transaction::{Transaction, compact};
 
@@ -65,7 +65,14 @@ pub(crate) fn collect_text_nodes_in_range(
         .node(to_end_id)
         .ok_or(CommandError::NodeNotFound(to_end_id))?;
     let to_pos = match to_end_node.node() {
-        Node::Text(t) => Position::new(to_end_id, t.text.len()),
+        Node::Text(t) => {
+            let offset = if to_needs_split {
+                t.text.len()
+            } else {
+                to.offset.min(t.text.len())
+            };
+            Position::new(to_end_id, offset)
+        }
         _ => Position::new(to_end_id, to.offset),
     };
 
@@ -82,46 +89,61 @@ fn walk_text_nodes_in_range(node: &NodeRef<'_>, rs: &ResolvedSelection<'_>, out:
     if !rs.intersects_subtree(node) {
         return;
     }
-    if matches!(node.node(), Node::Text(_) | Node::Tab(_)) {
-        out.push(node.id());
-        return;
+    match node.node() {
+        Node::Text(text) => {
+            let from = rs.from();
+            let to = rs.to();
+            let len = text.text.len();
+            let start = if from.node_id() == node.id() {
+                from.offset().min(len)
+            } else {
+                0
+            };
+            let end = if to.node_id() == node.id() {
+                to.offset().min(len)
+            } else {
+                len
+            };
+            if end > start {
+                out.push(node.id());
+            }
+            return;
+        }
+        Node::Tab(_) => {
+            if rs.contains_subtree(node) {
+                out.push(node.id());
+            }
+            return;
+        }
+        _ => {}
     }
     for child in node.children() {
         walk_text_nodes_in_range(&child, rs, out);
     }
 }
 
-pub(crate) fn compact_textblock_preserving_caret(
+pub(crate) fn compact_textblock_at_position(
     tr: &mut Transaction,
-    caret: Position,
+    pos: Position,
 ) -> Result<(), CommandError> {
     let doc = tr.doc();
-    let Some(node) = doc.node(caret.node_id) else {
+    let Some(node) = doc.node(pos.node_id) else {
         return Ok(());
     };
-    let Node::Text(text_node) = node.node() else {
+    let Node::Text(_) = node.node() else {
         return Ok(());
     };
-    let at_end = caret.offset == text_node.text.len();
-    let Some(tb_id) = find_ancestor_textblock(&doc, caret.node_id) else {
-        return Ok(());
-    };
-    let Some(abs) = text_offset_in_textblock(&doc, tb_id, caret.node_id, caret.offset) else {
+    let Some(tb_id) = find_ancestor_textblock(&doc, pos.node_id) else {
         return Ok(());
     };
 
     let doc = tr.doc();
     let tb = doc.node(tb_id).ok_or(CommandError::NodeNotFound(tb_id))?;
     tr.apply_steps(compact(&tb))?;
-
-    let doc = tr.doc();
-    if let Some(new_pos) = position_from_text_offset(&doc, tb_id, abs, at_end) {
-        tr.set_selection(Some(Selection::new(new_pos, new_pos)))?;
-    }
     Ok(())
 }
 
-pub(crate) fn compact_and_restore_selection(
+pub(crate) fn compact_textblocks_for_nodes(
     tr: &mut Transaction,
     node_ids: &[NodeId],
 ) -> Result<(), CommandError> {
@@ -135,20 +157,6 @@ pub(crate) fn compact_and_restore_selection(
         }
     }
 
-    let original = tr.selection().expect("entry caller guaranteed selection");
-    let endpoints_are_text = doc
-        .node(original.anchor.node_id)
-        .is_some_and(|n| matches!(n.node(), Node::Text(_)))
-        && doc
-            .node(original.head.node_id)
-            .is_some_and(|n| matches!(n.node(), Node::Text(_)));
-
-    let sel_offsets = if endpoints_are_text {
-        selection_offsets_in_textblocks(&doc, node_ids)
-    } else {
-        None
-    };
-
     for tb_id in &textblock_ids {
         let doc = tr.doc();
         if let Some(tb) = doc.node(*tb_id) {
@@ -156,82 +164,5 @@ pub(crate) fn compact_and_restore_selection(
         }
     }
 
-    if let Some((from_tb, from_abs, to_tb, to_abs)) = sel_offsets {
-        let doc = tr.doc();
-        if let (Some(from_pos), Some(to_pos)) = (
-            position_from_text_offset(&doc, from_tb, from_abs, false),
-            position_from_text_offset(&doc, to_tb, to_abs, true),
-        ) {
-            tr.set_selection(Some(Selection::new(from_pos, to_pos)))?;
-        }
-    }
-
     Ok(())
-}
-
-fn selection_offsets_in_textblocks(
-    doc: &Doc,
-    node_ids: &[NodeId],
-) -> Option<(NodeId, usize, NodeId, usize)> {
-    let first_id = *node_ids.first()?;
-    let last_id = *node_ids.last()?;
-    let from_tb = find_ancestor_textblock(doc, first_id)?;
-    let to_tb = find_ancestor_textblock(doc, last_id)?;
-    let from_abs = text_offset_in_textblock(doc, from_tb, first_id, 0)?;
-    let node_len = match doc.node(last_id)?.node() {
-        Node::Text(t) => t.text.len(),
-        _ => 0,
-    };
-    let to_abs = text_offset_in_textblock(doc, to_tb, last_id, node_len)?;
-    Some((from_tb, from_abs, to_tb, to_abs))
-}
-
-fn text_offset_in_textblock(
-    doc: &Doc,
-    tb_id: NodeId,
-    node_id: NodeId,
-    local_offset: usize,
-) -> Option<usize> {
-    let tb = doc.node(tb_id)?;
-    let mut abs = 0;
-    for child in tb.children() {
-        if child.id() == node_id {
-            return Some(abs + local_offset);
-        }
-        if let Node::Text(t) = child.node() {
-            abs += t.text.len();
-        }
-    }
-    None
-}
-
-fn position_from_text_offset(
-    doc: &Doc,
-    tb_id: NodeId,
-    abs_offset: usize,
-    end_bias: bool,
-) -> Option<Position> {
-    let tb = doc.node(tb_id)?;
-    let mut remaining = abs_offset;
-    for child in tb.children() {
-        if let Node::Text(t) = child.node() {
-            let len = t.text.len();
-            let fits = if end_bias {
-                remaining <= len
-            } else {
-                remaining < len
-            };
-            if fits {
-                return Some(Position::new(child.id(), remaining));
-            }
-            remaining -= len;
-        }
-    }
-    tb.children().last().map(|child| {
-        let len = match child.node() {
-            Node::Text(t) => t.text.len(),
-            _ => 0,
-        };
-        Position::new(child.id(), len)
-    })
 }

--- a/crates/editor-commands/src/helpers/slice.rs
+++ b/crates/editor-commands/src/helpers/slice.rs
@@ -7,7 +7,7 @@ use editor_state::{Affinity, Position, Selection};
 use editor_transaction::{Transaction, fulfill};
 
 use super::{
-    compact_textblock_preserving_caret, find_ancestor_textblock, insert_hard_break_at_caret,
+    compact_textblock_at_position, find_ancestor_textblock, insert_hard_break_at_caret,
     insert_tab_at_caret, insert_text_at_caret,
 };
 use crate::{CommandError, CommandResult};
@@ -447,7 +447,7 @@ fn insert_blocks_in_textblock(
     if merge_end_into_start {
         tr.merge_node(p2_id, textblock_id)?;
         let caret = last_caret.unwrap_or(head);
-        compact_textblock_preserving_caret(tr, caret)?;
+        compact_textblock_at_position(tr, caret)?;
         last_caret = tr.selection().map(|s| s.head);
     }
 

--- a/crates/editor-commands/src/helpers/style.rs
+++ b/crates/editor-commands/src/helpers/style.rs
@@ -5,7 +5,7 @@ use editor_state::{Position, ResolvedSelection, State};
 use editor_transaction::Transaction;
 
 use crate::CommandError;
-use crate::helpers::{collect_text_nodes_in_range, compact_and_restore_selection};
+use crate::helpers::{collect_text_nodes_in_range, compact_textblocks_for_nodes};
 
 /// Collects textblock node ids whose subtree intersects the selection.
 /// Includes textblocks that are only partially covered. For a collapsed
@@ -55,8 +55,23 @@ fn walk_text_nodes<'a>(node: &NodeRef<'a>, rs: &ResolvedSelection<'a>, out: &mut
     if !rs.intersects_subtree(node) {
         return;
     }
-    if matches!(node.node(), Node::Text(_)) {
-        out.push(*node);
+    if let Node::Text(text) = node.node() {
+        let from = rs.from();
+        let to = rs.to();
+        let len = text.text.len();
+        let start = if from.node_id() == node.id() {
+            from.offset().min(len)
+        } else {
+            0
+        };
+        let end = if to.node_id() == node.id() {
+            to.offset().min(len)
+        } else {
+            len
+        };
+        if end > start {
+            out.push(*node);
+        }
         return;
     }
     for child in node.children() {
@@ -189,7 +204,7 @@ pub(crate) fn clear_inline_modifier_types_in_selection(
         }
     }
 
-    compact_and_restore_selection(tr, &node_ids)?;
+    compact_textblocks_for_nodes(tr, &node_ids)?;
     Ok(changed)
 }
 

--- a/crates/editor-core/src/editor.rs
+++ b/crates/editor-core/src/editor.rs
@@ -2199,7 +2199,7 @@ mod tests {
             panic!("t1 must be Text")
         };
         assert!(
-            t.text.iter_with_dot().any(|(_, c)| c == 'x'),
+            t.text.iter_visible_entries().any(|(_, c)| c == 'x'),
             "remote insert applied"
         );
     }

--- a/crates/editor-core/src/font.rs
+++ b/crates/editor-core/src/font.rs
@@ -112,6 +112,9 @@ pub(crate) fn derive_font_updates_from_ops(
             } => {
                 affected_text_nodes.insert(*node_id);
             }
+            DocOp::MoveText { to_node_id, .. } => {
+                affected_text_nodes.insert(*to_node_id);
+            }
             DocOp::Modifier {
                 node_id,
                 op: OrMapOp::Set { key, .. },
@@ -416,5 +419,55 @@ mod tests {
             result.keys().collect::<Vec<_>>()
         );
         assert!(result[&key].contains_key(&t1));
+    }
+
+    #[test]
+    fn derive_font_updates_includes_move_text_target_scope() {
+        use editor_macros::state;
+        use editor_model::DocOp;
+
+        let (state, t1, t2) = state! {
+            doc {
+                root [font_family("Source".to_string()), font_weight(400)] {
+                    paragraph {
+                        t1: text("가")
+                    }
+                    paragraph {
+                        t2: text("") [font_family("Target".to_string()), font_weight(700)]
+                    }
+                }
+            }
+            selection: (t1, 0)
+        };
+        let entry = state
+            .doc
+            .text_view(t1)
+            .unwrap()
+            .visible_entries()
+            .next()
+            .unwrap()
+            .0;
+        let (state, move_op) = state
+            .apply(DocOp::MoveText {
+                entry,
+                to_node_id: t2,
+                after: None,
+            })
+            .unwrap();
+
+        let result = derive_font_updates_from_ops(
+            &state.doc,
+            &editor_resource::FontRegistry::new(),
+            &[move_op],
+        );
+
+        let key = ("Target".to_string(), 700u16);
+        assert!(
+            result.contains_key(&key),
+            "MoveText target scope should request target font; keys = {:?}",
+            result.keys().collect::<Vec<_>>()
+        );
+        assert!(result[&key].contains_key(&t2));
+        assert!(result[&key][&t2].contains(&('가' as u32)));
     }
 }

--- a/crates/editor-core/src/tracked_range.rs
+++ b/crates/editor-core/src/tracked_range.rs
@@ -1,4 +1,4 @@
-use editor_crdt::Dot;
+use editor_crdt::EntryDot;
 use editor_model::{Doc, Node};
 use editor_state::{ResolvedSelection, Selection, StableSelection};
 use editor_view::PageRect;
@@ -18,8 +18,7 @@ pub struct TrackedRange {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct TrackedTextAnchor {
-    node_id: editor_model::NodeId,
-    dot: Dot,
+    entry_dot: EntryDot,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -174,13 +173,7 @@ impl TrackedRange {
 
 impl TrackedTextAnchor {
     fn is_alive(&self, doc: &Doc) -> bool {
-        let Some(entry) = doc.get_entry(self.node_id) else {
-            return false;
-        };
-        match &entry.node {
-            Node::Text(text) => text.text.live_offset_of(self.dot).is_some(),
-            _ => false,
-        }
+        doc.text_identity().is_alive(self.entry_dot)
     }
 }
 
@@ -215,12 +208,9 @@ fn collect_text_anchors_walk(
             total
         };
         if end > start {
-            for idx in start + 1..=end {
-                if let Ok(Some(dot)) = text_node.text.dot_at(idx) {
-                    out.push(TrackedTextAnchor {
-                        node_id: node.id(),
-                        dot,
-                    });
+            for idx in start..end {
+                if let Ok(entry_dot) = text_node.text.entry_dot_at(idx) {
+                    out.push(TrackedTextAnchor { entry_dot });
                 }
             }
         }
@@ -325,6 +315,44 @@ mod tests {
     fn invalidate_unknown_id_returns_false() {
         let mut reg = TrackedRangeRegistry::new();
         assert!(!reg.invalidate("x"));
+    }
+
+    #[test]
+    fn tracked_text_anchor_alive_follows_moved_entry_dot() {
+        let (state, t1, t2) = state! {
+            doc {
+                root {
+                    paragraph { t1: text("a") }
+                    paragraph { t2: text("") }
+                }
+            }
+            selection: (t1, 0) -> (t1, 1)
+        };
+        let range = TrackedRange::new(
+            "a".into(),
+            "g1".into(),
+            StableSelection::freeze(state.selection.as_ref().unwrap(), &state.doc),
+            String::new(),
+            &state.doc,
+        );
+        let anchor = range
+            .covered_text
+            .as_ref()
+            .unwrap()
+            .anchors
+            .first()
+            .unwrap()
+            .clone();
+        let (state, _) = state
+            .apply(editor_model::DocOp::MoveText {
+                entry: anchor.entry_dot,
+                to_node_id: t2,
+                after: None,
+            })
+            .unwrap();
+
+        assert!(anchor.is_alive(&state.doc));
+        assert_eq!(state.doc.text_view(t2).unwrap().text(), "a");
     }
 
     #[test]

--- a/crates/editor-crdt/src/dot.rs
+++ b/crates/editor-crdt/src/dot.rs
@@ -9,16 +9,18 @@ use std::str::FromStr;
 /// across future primitives (sequence-CRDT, OR-Set add tokens, LWW register timestamps,
 /// op identity).
 ///
-/// **`clock` is per-actor monotonic — *not a strict Lamport timestamp*.**
-/// We don't bump our clock when observing remote ops, so cross-actor comparison
-/// does not reflect causal precedence. Sufficient for RGA tie-break (deterministic
-/// ordering) but reusing this for LWW winner determination requires the op-generation
-/// layer to provide Lamport semantics (`L = max(L_self, observed_max) + 1`) separately.
+/// **`clock` is per-actor monotonic, with Lamport-style advancement owned by
+/// the op-generation layer.** Raw `Dot` construction does not inspect causal
+/// context; it is just a pair. `OpGraph` advances its local next clock past
+/// received remote ops before authoring later local ops, so dots created through
+/// `OpGraph::add` after `receive_changeset` are causally later than the received
+/// clock. Cross-actor comparison is still only a deterministic total order unless
+/// the op was generated through that clock-management layer.
 ///
 /// `Ord` / `PartialOrd` are implemented manually — `derive` depends on field
-/// declaration order, which is fragile. Clock-primary is just a setup that *can*
-/// evolve into a Lamport-compatible form later; it is not itself a Lamport guarantee
-/// (see caveat above).
+/// declaration order, which is fragile. Clock-primary matches the ordering used
+/// by the clock-management layer, but the Lamport guarantee comes from `OpGraph`,
+/// not from constructing a `Dot` by hand.
 ///
 /// Serializes as the string `"{base62(actor)}_{base62(clock)}"`. The actor field is
 /// a randomly-generated u64 and routinely overflows JS Number's 53-bit safe range,

--- a/crates/editor-crdt/src/error.rs
+++ b/crates/editor-crdt/src/error.rs
@@ -20,6 +20,9 @@ pub enum CrdtError {
     #[error("offset {offset} out of bounds (len {len})")]
     OffsetOutOfBounds { offset: usize, len: usize },
 
+    #[error("text entry {dot:?} not found")]
+    EntryNotFound { dot: Dot },
+
     #[error("changeset has no ops")]
     EmptyChangeset,
 

--- a/crates/editor-crdt/src/lib.rs
+++ b/crates/editor-crdt/src/lib.rs
@@ -22,7 +22,7 @@ pub use ormap::{OrMap, OrMapOp};
 pub use orset::{OrSet, OrSetOp};
 pub use rga::{Rga, RgaOp};
 pub use sync::SyncMessage;
-pub use text::{Text, TextOp};
+pub use text::{EntryDot, PlacementId, Text, TextOp, TextPlacement};
 pub use to_plain::ToPlain;
 
 #[cfg(test)]

--- a/crates/editor-crdt/src/rga.rs
+++ b/crates/editor-crdt/src/rga.rs
@@ -117,7 +117,7 @@ impl<T> Rga<T> {
     /// in the same DFS order `iter_with_dot` uses. The third tuple element is the
     /// `alive` flag. Orphan entries (anchor not yet arrived) are not yielded, matching
     /// `iter_with_dot`.
-    pub(crate) fn iter_all_in_order(&self) -> impl Iterator<Item = (Dot, &T, bool)> + '_ {
+    pub fn iter_all_in_order(&self) -> impl Iterator<Item = (Dot, &T, bool)> + '_ {
         AllIterWithDot::new(self)
     }
 

--- a/crates/editor-crdt/src/text.rs
+++ b/crates/editor-crdt/src/text.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-use crate::{CrdtError, Dot, Rga, RgaOp, ToPlain};
+use crate::{CrdtError, Dot, ToPlain};
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, editor_macros::Wire)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -9,73 +9,158 @@ pub enum TextOp {
     #[wire(n(0))]
     InsertChar {
         #[wire(n(0))]
-        after: Option<Dot>,
+        after: Option<PlacementId>,
         #[wire(n(1))]
         ch: char,
     },
     #[wire(n(1))]
     RemoveChar {
         #[wire(n(0))]
-        observed: Dot,
+        observed: EntryDot,
     },
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, editor_macros::Wire)]
+#[wire(transparent)]
+#[serde(transparent)]
+pub struct EntryDot(pub Dot);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, editor_macros::Wire)]
+#[wire(transparent)]
+#[serde(transparent)]
+pub struct PlacementId(pub Dot);
+
+impl From<Dot> for EntryDot {
+    fn from(dot: Dot) -> Self {
+        Self(dot)
+    }
+}
+
+impl From<EntryDot> for Dot {
+    fn from(entry: EntryDot) -> Self {
+        entry.0
+    }
+}
+
+impl From<Dot> for PlacementId {
+    fn from(dot: Dot) -> Self {
+        Self(dot)
+    }
+}
+
+impl From<PlacementId> for Dot {
+    fn from(placement: PlacementId) -> Self {
+        placement.0
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TextPlacement {
+    pub placement_id: PlacementId,
+    pub entry_dot: EntryDot,
+    pub ch: char,
+}
+
+/// Materialized visible text for a text node.
+///
+/// The canonical CRDT placement history lives at the document level. This type
+/// intentionally stores only the current visible projection so callers can read
+/// text nodes ergonomically without carrying `Doc` through every path.
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
-pub struct Text(Rga<char>);
+pub struct Text {
+    visible: imbl::Vector<TextPlacement>,
+}
 
 impl Text {
     pub fn new() -> Self {
-        Self(Rga::new())
+        Self {
+            visible: imbl::Vector::new(),
+        }
     }
 
-    /// Returns `Err` if the same `Dot` arrives with a different payload.
-    /// Delegates to `Rga<char>::apply` after mapping `TextOp` → `RgaOp<char>`.
-    pub fn apply(&self, id: Dot, op: TextOp) -> Result<Self, CrdtError> {
-        let rga_op = match op {
-            TextOp::InsertChar { after, ch } => RgaOp::Insert { after, value: ch },
-            TextOp::RemoveChar { observed } => RgaOp::Remove { observed },
+    pub fn from_visible_placements<I>(visible: I) -> Self
+    where
+        I: IntoIterator<Item = TextPlacement>,
+    {
+        Self {
+            visible: visible.into_iter().collect(),
+        }
+    }
+
+    pub fn entry_dot_at(&self, char_index: usize) -> Result<EntryDot, CrdtError> {
+        let Some(placement) = self.visible.get(char_index) else {
+            return Err(CrdtError::OffsetOutOfBounds {
+                offset: char_index,
+                len: self.len(),
+            });
         };
-        self.0.apply(id, rga_op).map(Self)
+        Ok(placement.entry_dot)
     }
 
-    pub fn contains_dot(&self, dot: Dot) -> bool {
-        self.0.contains_dot(dot)
+    pub fn placement_at_visible_offset(
+        &self,
+        char_offset: usize,
+    ) -> Result<Option<PlacementId>, CrdtError> {
+        if char_offset == 0 {
+            return Ok(None);
+        }
+        self.visible
+            .get(char_offset - 1)
+            .map(|placement| Some(placement.placement_id))
+            .ok_or(CrdtError::OffsetOutOfBounds {
+                offset: char_offset,
+                len: self.len(),
+            })
     }
 
-    pub fn dot_at(&self, char_offset: usize) -> Result<Option<Dot>, CrdtError> {
-        self.0.dot_at(char_offset)
+    pub fn placement_before_offset(
+        &self,
+        char_offset: usize,
+    ) -> Result<Option<PlacementId>, CrdtError> {
+        self.placement_at_visible_offset(char_offset)
     }
 
-    pub fn live_offset_of(&self, dot: Dot) -> Option<usize> {
-        self.0.live_offset_of(dot)
+    pub fn contains_visible_entry(&self, entry_dot: EntryDot) -> bool {
+        self.visible
+            .iter()
+            .any(|placement| placement.entry_dot == entry_dot)
     }
 
-    pub fn next_live_offset_after(&self, dot: Dot) -> Option<usize> {
-        self.0.next_live_offset_after(dot)
+    pub fn visible_offset_of_entry(&self, entry_dot: EntryDot) -> Option<usize> {
+        self.visible
+            .iter()
+            .position(|placement| placement.entry_dot == entry_dot)
     }
 
-    pub fn prev_live_offset_before(&self, dot: Dot) -> Option<usize> {
-        self.0.prev_live_offset_before(dot)
+    pub fn iter_visible_entries(&self) -> impl Iterator<Item = (EntryDot, char)> + '_ {
+        self.visible
+            .iter()
+            .map(|placement| (placement.entry_dot, placement.ch))
     }
 
-    pub fn iter_with_dot(&self) -> impl Iterator<Item = (Dot, char)> + '_ {
-        self.0.iter_with_dot().map(|(d, &c)| (d, c))
+    pub fn iter_visible_placements(&self) -> impl Iterator<Item = TextPlacement> + '_ {
+        self.visible.iter().copied()
     }
 
-    /// Count of reachable + alive characters — equal to `to_string().chars().count()`.
+    pub fn visible_rank_of_placement(&self, placement: PlacementId) -> Option<usize> {
+        self.visible
+            .iter()
+            .position(|entry| entry.placement_id == placement)
+    }
+
     pub fn len(&self) -> usize {
-        self.0.len()
+        self.visible.len()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
+        self.visible.is_empty()
     }
 }
 
 impl fmt::Display for Text {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for ch in self.0.iter() {
-            write!(f, "{ch}")?;
+        for placement in &self.visible {
+            write!(f, "{}", placement.ch)?;
         }
         Ok(())
     }
@@ -92,8 +177,17 @@ impl ToPlain for Text {
 mod tests {
     use super::*;
 
+    fn placement(id: u64, clock: u64, ch: char) -> TextPlacement {
+        let dot = Dot::new(id, clock);
+        TextPlacement {
+            placement_id: PlacementId(dot),
+            entry_dot: EntryDot(dot),
+            ch,
+        }
+    }
+
     #[test]
-    fn new_yields_empty_state() {
+    fn new_yields_empty_projection() {
         let t = Text::new();
         assert_eq!(t.len(), 0);
         assert!(t.is_empty());
@@ -101,220 +195,42 @@ mod tests {
     }
 
     #[test]
-    fn default_equals_new() {
-        assert_eq!(Text::default(), Text::new());
-    }
-
-    #[test]
-    fn apply_insert_char_yields_value_via_display() {
-        let t = Text::new()
-            .apply(
-                Dot::new(1, 0),
-                TextOp::InsertChar {
-                    after: None,
-                    ch: 'a',
-                },
-            )
-            .unwrap();
-        assert_eq!(t.to_string(), "a");
-        assert_eq!(t.len(), 1);
-    }
-
-    #[test]
-    fn apply_remove_char_tombstones_observed() {
-        let t = Text::new()
-            .apply(
-                Dot::new(1, 0),
-                TextOp::InsertChar {
-                    after: None,
-                    ch: 'a',
-                },
-            )
-            .unwrap()
-            .apply(
-                Dot::new(u64::MAX, 0),
-                TextOp::RemoveChar {
-                    observed: Dot::new(1, 0),
-                },
-            )
-            .unwrap();
-        assert_eq!(t.to_string(), "");
-        assert_eq!(t.len(), 0);
-    }
-
-    #[test]
-    fn display_chars_count_matches_len() {
-        let t = Text::new()
-            .apply(
-                Dot::new(1, 0),
-                TextOp::InsertChar {
-                    after: None,
-                    ch: 'h',
-                },
-            )
-            .unwrap()
-            .apply(
-                Dot::new(1, 1),
-                TextOp::InsertChar {
-                    after: Some(Dot::new(1, 0)),
-                    ch: 'i',
-                },
-            )
-            .unwrap();
+    fn visible_projection_reads_like_text() {
+        let t = Text::from_visible_placements([placement(1, 0, 'h'), placement(1, 1, 'i')]);
         assert_eq!(t.to_string(), "hi");
-        assert_eq!(t.len(), t.to_string().chars().count());
+        assert_eq!(t.len(), 2);
+        assert_eq!(
+            t.iter_visible_entries().collect::<Vec<_>>(),
+            vec![
+                (EntryDot(Dot::new(1, 0)), 'h'),
+                (EntryDot(Dot::new(1, 1)), 'i')
+            ]
+        );
     }
 
     #[test]
-    fn dot_at_delegates_to_rga() {
+    fn entry_and_placement_offsets_are_explicit() {
         let d1 = Dot::new(1, 0);
-        let d2 = Dot::new(1, 1);
-        let t = Text::new()
-            .apply(
-                d1,
-                TextOp::InsertChar {
-                    after: None,
-                    ch: 'h',
-                },
-            )
-            .unwrap()
-            .apply(
-                d2,
-                TextOp::InsertChar {
-                    after: Some(d1),
-                    ch: 'i',
-                },
-            )
-            .unwrap();
-        assert_eq!(t.dot_at(0), Ok(None));
-        assert_eq!(t.dot_at(1), Ok(Some(d1)));
-        assert_eq!(t.dot_at(2), Ok(Some(d2)));
-        assert!(t.dot_at(3).is_err());
-    }
+        let d2 = Dot::new(2, 0);
+        let t = Text::from_visible_placements([
+            TextPlacement {
+                placement_id: PlacementId(d1),
+                entry_dot: EntryDot(d1),
+                ch: 'h',
+            },
+            TextPlacement {
+                placement_id: PlacementId(d2),
+                entry_dot: EntryDot(Dot::new(1, 1)),
+                ch: 'i',
+            },
+        ]);
 
-    #[test]
-    fn empty_text_plain_is_empty_string() {
-        let t = Text::new();
-        assert_eq!(t.to_plain(), "");
-    }
-
-    #[test]
-    fn two_chars_plain() {
-        let d1 = Dot::new(1, 0);
-        let d2 = Dot::new(1, 1);
-        let t = Text::new()
-            .apply(
-                d1,
-                TextOp::InsertChar {
-                    after: None,
-                    ch: 'h',
-                },
-            )
-            .unwrap()
-            .apply(
-                d2,
-                TextOp::InsertChar {
-                    after: Some(d1),
-                    ch: 'i',
-                },
-            )
-            .unwrap();
-        assert_eq!(t.to_plain(), "hi");
-    }
-
-    #[test]
-    fn text_live_offset_of_finds_alive_char() {
-        let t = Text::new();
-        let d1 = Dot::new(1, 0);
-        let d2 = Dot::new(1, 1);
-        let t = t
-            .apply(
-                d1,
-                TextOp::InsertChar {
-                    after: None,
-                    ch: 'h',
-                },
-            )
-            .unwrap();
-        let t = t
-            .apply(
-                d2,
-                TextOp::InsertChar {
-                    after: Some(d1),
-                    ch: 'i',
-                },
-            )
-            .unwrap();
-
-        assert_eq!(t.live_offset_of(d1), Some(0));
-        assert_eq!(t.live_offset_of(d2), Some(1));
-    }
-
-    #[test]
-    fn text_next_prev_live_offset_walks_past_tombstones() {
-        let t = Text::new();
-        let d1 = Dot::new(1, 0);
-        let d2 = Dot::new(1, 1);
-        let d3 = Dot::new(1, 2);
-        let t = t
-            .apply(
-                d1,
-                TextOp::InsertChar {
-                    after: None,
-                    ch: 'a',
-                },
-            )
-            .unwrap();
-        let t = t
-            .apply(
-                d2,
-                TextOp::InsertChar {
-                    after: Some(d1),
-                    ch: 'b',
-                },
-            )
-            .unwrap();
-        let t = t
-            .apply(
-                d3,
-                TextOp::InsertChar {
-                    after: Some(d2),
-                    ch: 'c',
-                },
-            )
-            .unwrap();
-        let t = t
-            .apply(Dot::new(1, 3), TextOp::RemoveChar { observed: d2 })
-            .unwrap();
-
-        assert_eq!(t.next_live_offset_after(d2), Some(1));
-        assert_eq!(t.prev_live_offset_before(d2), Some(0));
-        assert_eq!(t.next_live_offset_after(d3), None);
-        assert_eq!(t.prev_live_offset_before(d1), None);
-    }
-
-    #[test]
-    fn iter_with_dot_yields_pairs() {
-        let d1 = Dot::new(1, 0);
-        let d2 = Dot::new(1, 1);
-        let t = Text::new()
-            .apply(
-                d1,
-                TextOp::InsertChar {
-                    after: None,
-                    ch: 'h',
-                },
-            )
-            .unwrap()
-            .apply(
-                d2,
-                TextOp::InsertChar {
-                    after: Some(d1),
-                    ch: 'i',
-                },
-            )
-            .unwrap();
-        let pairs: Vec<(Dot, char)> = t.iter_with_dot().collect();
-        assert_eq!(pairs, vec![(d1, 'h'), (d2, 'i')]);
+        assert_eq!(t.entry_dot_at(0), Ok(EntryDot(d1)));
+        assert_eq!(t.entry_dot_at(1), Ok(EntryDot(Dot::new(1, 1))));
+        assert!(t.entry_dot_at(2).is_err());
+        assert_eq!(t.placement_at_visible_offset(0), Ok(None));
+        assert_eq!(t.placement_at_visible_offset(1), Ok(Some(PlacementId(d1))));
+        assert_eq!(t.placement_at_visible_offset(2), Ok(Some(PlacementId(d2))));
+        assert!(t.placement_at_visible_offset(3).is_err());
     }
 }

--- a/crates/editor-ffi/src/server.rs
+++ b/crates/editor-ffi/src/server.rs
@@ -655,7 +655,7 @@ mod tests {
             DocOp::Text {
                 node_id: txt,
                 op: editor_crdt::TextOp::InsertChar {
-                    after: Some(a_dot),
+                    after: Some(editor_crdt::PlacementId(a_dot)),
                     ch: 'b',
                 },
             },
@@ -871,7 +871,9 @@ mod tests {
             &mut g,
             DocOp::Text {
                 node_id: t2,
-                op: editor_crdt::TextOp::RemoveChar { observed: t2_a },
+                op: editor_crdt::TextOp::RemoveChar {
+                    observed: editor_crdt::EntryDot(t2_a),
+                },
             },
         );
         add(
@@ -919,7 +921,7 @@ mod tests {
             payload: DocOp::Text {
                 node_id: t2,
                 op: editor_crdt::TextOp::InsertChar {
-                    after: Some(t2_a),
+                    after: Some(editor_crdt::PlacementId(t2_a)),
                     ch: 'Z',
                 },
             },

--- a/crates/editor-model/benches/wire_size.rs
+++ b/crates/editor-model/benches/wire_size.rs
@@ -4,7 +4,7 @@
 
 use std::time::Instant;
 
-use editor_crdt::{Changeset, Dot, OpGraph, OrMapOp, RgaOp, TextOp};
+use editor_crdt::{Changeset, OpGraph, OrMapOp, PlacementId, RgaOp, TextOp};
 use editor_model::{DocOp, NodeId, NodeType};
 
 fn main() {
@@ -19,14 +19,14 @@ fn main() {
 
 fn build_typing(actor: u64, paragraph: NodeId, text: &str) -> OpGraph<DocOp> {
     let mut g = OpGraph::with_actor(actor);
-    let mut prev: Option<Dot> = None;
+    let mut prev: Option<PlacementId> = None;
     for ch in text.chars() {
         let payload = DocOp::Text {
             node_id: paragraph,
             op: TextOp::InsertChar { after: prev, ch },
         };
         let (ng, op) = g.add(payload).unwrap();
-        prev = Some(op.id);
+        prev = Some(PlacementId(op.id));
         g = ng;
     }
     g.commit()
@@ -96,7 +96,7 @@ fn mixed_edit() {
         })
         .unwrap()
         .0;
-    let mut prev = None;
+    let mut prev: Option<PlacementId> = None;
     for ch in "Hello, world!".chars() {
         let (ng, op) = g
             .add(DocOp::Text {
@@ -104,7 +104,7 @@ fn mixed_edit() {
                 op: TextOp::InsertChar { after: prev, ch },
             })
             .unwrap();
-        prev = Some(op.id);
+        prev = Some(PlacementId(op.id));
         g = ng;
     }
     measure("mixed-edit", g.commit().changesets_as_vec());

--- a/crates/editor-model/src/doc.rs
+++ b/crates/editor-model/src/doc.rs
@@ -1,20 +1,23 @@
-use editor_crdt::{Dot, OpGraph, OrMap};
+use editor_crdt::{Dot, OpGraph, OrMap, Text, TextPlacement};
 use hashbrown::HashSet;
 use std::collections::VecDeque;
 
 use crate::apply_doc_op;
 use crate::doc_op::DocOp;
+use crate::doc_text_store::DocTextStore;
 use crate::entry::NodeEntry;
 use crate::error::ModelError;
 use crate::id::NodeId;
 use crate::node_ref::NodeRef;
 use crate::nodes::{Node, NodeType};
 use crate::style::StyleEntry;
+use crate::text_view::{TextIdentityView, TextView};
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub struct Doc {
     pub(crate) nodes: OrMap<NodeId, NodeType>,
     pub(crate) entries: imbl::HashMap<NodeId, NodeEntry>,
+    pub(crate) text: DocTextStore,
     pub(crate) styles: OrMap<String, ()>,
     pub(crate) style_entries: imbl::HashMap<String, StyleEntry>,
 }
@@ -50,6 +53,14 @@ impl Doc {
 
     pub fn node(&self, id: NodeId) -> Option<NodeRef<'_>> {
         self.get_entry(id).map(|_| NodeRef::new(self, id))
+    }
+
+    pub fn text_view(&self, id: NodeId) -> Option<TextView<'_>> {
+        self.node(id)?.as_text()
+    }
+
+    pub fn text_identity(&self) -> TextIdentityView<'_> {
+        TextIdentityView::new(self)
     }
 
     pub fn root(&self) -> Option<NodeRef<'_>> {
@@ -105,12 +116,38 @@ impl Doc {
         out.trim_end_matches('\n').to_string()
     }
 
+    pub(crate) fn refresh_text_projection(&mut self, node_id: NodeId) {
+        let Some(visible) = self.text_projection_for(node_id) else {
+            return;
+        };
+        let Some(entry) = self.entries.get_mut(&node_id) else {
+            return;
+        };
+        let Node::Text(text_node) = &mut entry.node else {
+            return;
+        };
+        text_node.text = Text::from_visible_placements(visible);
+    }
+
+    fn text_projection_for(&self, node_id: NodeId) -> Option<Vec<TextPlacement>> {
+        let entry = self.get_entry(node_id)?;
+        let Node::Text(_) = &entry.node else {
+            return None;
+        };
+        Some(self.text.visible_placements_for_node(node_id))
+    }
+
     fn extract_text_recursive(&self, node_id: NodeId, out: &mut String) {
         let Some(entry) = self.get_entry(node_id) else {
             return;
         };
         match &entry.node {
-            Node::Text(t) => out.push_str(&t.text.to_string()),
+            Node::Text(_) => out.push_str(
+                &self
+                    .text_view(node_id)
+                    .map(|text| text.text())
+                    .unwrap_or_default(),
+            ),
             Node::HardBreak(_)
             | Node::PageBreak(_)
             | Node::Image(_)
@@ -129,6 +166,8 @@ impl Doc {
     pub fn verify(&self) -> Result<(), ModelError> {
         self.verify_root_uniqueness()?;
         self.verify_tree_reciprocity()?;
+        #[cfg(any(test, debug_assertions))]
+        self.verify_text_store()?;
         Ok(())
     }
 
@@ -200,10 +239,37 @@ impl Doc {
 
         Ok(())
     }
+
+    #[cfg(any(test, debug_assertions))]
+    fn verify_text_store(&self) -> Result<(), ModelError> {
+        if !self.text.index_matches_rebuild(self) {
+            return Err(ModelError::TextIndexDesync);
+        }
+
+        for (node_id, node_type) in self.nodes_iter() {
+            if *node_type != NodeType::Text {
+                continue;
+            }
+            let entry = self
+                .get_entry(*node_id)
+                .ok_or(ModelError::NodeNotFound(*node_id))?;
+            let Node::Text(text_node) = &entry.node else {
+                return Err(ModelError::TextProjectionDesync { node_id: *node_id });
+            };
+            let actual: Vec<TextPlacement> = text_node.text.iter_visible_placements().collect();
+            let expected = self.text.visible_placements_for_node(*node_id);
+            if actual != expected {
+                return Err(ModelError::TextProjectionDesync { node_id: *node_id });
+            }
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use editor_crdt::{EntryDot, PlacementId};
     use editor_macros::doc;
 
     use super::*;
@@ -236,6 +302,27 @@ mod tests {
     fn verify_accepts_rooted_doc() {
         let (doc, ..) = doc! { root {} };
         assert!(doc.verify().is_ok());
+    }
+
+    #[test]
+    fn verify_rejects_stale_text_projection() {
+        let (mut doc, t1) = doc! {
+            root {
+                paragraph {
+                    t1: text("a")
+                }
+            }
+        };
+        let entry = doc.entries.get_mut(&t1).unwrap();
+        let Node::Text(text_node) = &mut entry.node else {
+            panic!("expected text node");
+        };
+        text_node.text = Text::new();
+
+        assert_eq!(
+            doc.verify(),
+            Err(ModelError::TextProjectionDesync { node_id: t1 })
+        );
     }
 
     #[test]
@@ -434,7 +521,7 @@ mod tests {
             DocOp::Text {
                 node_id: txt,
                 op: editor_crdt::TextOp::InsertChar {
-                    after: Some(a_dot),
+                    after: Some(PlacementId(a_dot)),
                     ch: 'b',
                 },
             },
@@ -459,6 +546,124 @@ mod tests {
             Doc::from_op_graph_at(&g, &unknown),
             Err(ModelError::InvalidHead { .. })
         ));
+    }
+
+    #[test]
+    fn text_index_uses_birth_location_fallback_for_unmoved_entries() {
+        use crate::doc_op::DocOp;
+
+        let mut graph = OpGraph::<DocOp>::new();
+        let text_id = NodeId::new();
+
+        let apply = |graph: &mut OpGraph<DocOp>, doc: Doc, payload: DocOp| {
+            let (next_graph, op) = graph.clone().add(payload).unwrap();
+            *graph = next_graph;
+            let doc = apply_doc_op(doc, &op).unwrap();
+            (doc, op)
+        };
+
+        let (doc, _) = apply(
+            &mut graph,
+            Doc::empty(),
+            DocOp::Presence {
+                node_id: text_id,
+                op: editor_crdt::OrMapOp::Set {
+                    key: text_id,
+                    value: NodeType::Text,
+                },
+            },
+        );
+        let (doc, insert) = apply(
+            &mut graph,
+            doc,
+            DocOp::Text {
+                node_id: text_id,
+                op: editor_crdt::TextOp::InsertChar {
+                    after: None,
+                    ch: 'a',
+                },
+            },
+        );
+
+        let entry = EntryDot(insert.id);
+        assert_eq!(
+            doc.text_identity()
+                .current_location(entry)
+                .map(|loc| (loc.node_id, loc.placement_id)),
+            Some((text_id, PlacementId(insert.id)))
+        );
+        assert!(doc.text.moved_location(entry).is_none());
+        assert!(doc.text.index_matches_rebuild(&doc));
+    }
+
+    #[test]
+    fn text_current_location_uses_materialized_index_after_move() {
+        use crate::doc_op::DocOp;
+
+        let mut graph = OpGraph::<DocOp>::new();
+        let t1 = NodeId::new();
+        let t2 = NodeId::new();
+
+        let apply = |graph: &mut OpGraph<DocOp>, doc: Doc, payload: DocOp| {
+            let (next_graph, op) = graph.clone().add(payload).unwrap();
+            *graph = next_graph;
+            let doc = apply_doc_op(doc, &op).unwrap();
+            (doc, op)
+        };
+
+        let (doc, _) = apply(
+            &mut graph,
+            Doc::empty(),
+            DocOp::Presence {
+                node_id: t1,
+                op: editor_crdt::OrMapOp::Set {
+                    key: t1,
+                    value: NodeType::Text,
+                },
+            },
+        );
+        let (doc, _) = apply(
+            &mut graph,
+            doc,
+            DocOp::Presence {
+                node_id: t2,
+                op: editor_crdt::OrMapOp::Set {
+                    key: t2,
+                    value: NodeType::Text,
+                },
+            },
+        );
+        let (doc, insert) = apply(
+            &mut graph,
+            doc,
+            DocOp::Text {
+                node_id: t1,
+                op: editor_crdt::TextOp::InsertChar {
+                    after: None,
+                    ch: 'a',
+                },
+            },
+        );
+        let (doc, move_op) = apply(
+            &mut graph,
+            doc,
+            DocOp::MoveText {
+                entry: EntryDot(insert.id),
+                to_node_id: t2,
+                after: None,
+            },
+        );
+
+        let current = doc.text.moved_location(EntryDot(insert.id)).unwrap();
+        assert_eq!(current.owner_text_node, t2);
+        assert_eq!(current.placement, PlacementId(move_op.id));
+        assert_eq!(
+            doc.text_identity()
+                .current_location(EntryDot(insert.id))
+                .map(|loc| (loc.node_id, loc.placement_id)),
+            Some((t2, PlacementId(move_op.id)))
+        );
+        assert!(doc.text.index_matches_rebuild(&doc));
     }
 
     #[test]

--- a/crates/editor-model/src/doc_op.rs
+++ b/crates/editor-model/src/doc_op.rs
@@ -1,6 +1,7 @@
-use editor_crdt::{LwwRegOp, Op, OrMapOp, OrSetOp, RgaOp, TextOp};
+use editor_crdt::{EntryDot, LwwRegOp, Op, OrMapOp, OrSetOp, PlacementId, RgaOp, TextOp};
 use serde::{Deserialize, Serialize};
 
+use crate::text_index::CurrentTextLocation;
 use crate::{
     AnchorKind, Doc, ModelError, Modifier, ModifierType, Node, NodeAttr, NodeEntry, NodeId,
     NodeType, StyleEntry,
@@ -72,6 +73,15 @@ pub enum DocOp {
         #[wire(n(1))]
         op: LwwRegOp<Option<crate::marker::Marker>>,
     },
+    #[wire(n(9))]
+    MoveText {
+        #[wire(n(0))]
+        entry: EntryDot,
+        #[wire(n(1))]
+        to_node_id: NodeId,
+        #[wire(n(2))]
+        after: Option<PlacementId>,
+    },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, editor_macros::Wire)]
@@ -127,6 +137,13 @@ pub fn apply_doc_op(mut doc: Doc, op: &Op<DocOp>) -> Result<Doc, ModelError> {
             {
                 doc.entries.insert(*key, NodeEntry::new(value.into_node()));
             }
+            if let OrMapOp::Set {
+                key,
+                value: NodeType::Text,
+            } = presence_op
+            {
+                doc.refresh_text_projection(*key);
+            }
         }
         DocOp::Parent {
             node_id,
@@ -169,32 +186,56 @@ pub fn apply_doc_op(mut doc: Doc, op: &Op<DocOp>) -> Result<Doc, ModelError> {
         DocOp::Text {
             node_id,
             op: text_op,
-        } => {
-            let entry = doc
-                .entries
-                .get_mut(node_id)
-                .ok_or(ModelError::NodeNotFound(*node_id))?;
-            if let TextOp::InsertChar {
-                after: Some(anchor),
-                ..
-            } = text_op
-            {
-                let Node::Text(t) = &entry.node else {
+        } => match text_op {
+            TextOp::InsertChar { after, ch } => {
+                let entry = doc
+                    .entries
+                    .get(node_id)
+                    .ok_or(ModelError::NodeNotFound(*node_id))?;
+                let Node::Text(_) = &entry.node else {
                     return Err(ModelError::AttrNodeKindMismatch);
                 };
-                if !t.text.contains_dot(*anchor) {
+                if let Some(anchor) = after
+                    && !doc.text.contains_placement(*node_id, *anchor)
+                {
                     return Err(ModelError::OrphanAnchor {
                         node_id: *node_id,
-                        anchor: *anchor,
+                        anchor: anchor.0,
                         kind: AnchorKind::Text,
                     });
                 }
+                doc.text.register_insert(
+                    EntryDot(op.id),
+                    *node_id,
+                    PlacementId(op.id),
+                    *after,
+                    *ch,
+                )?;
+                doc.refresh_text_projection(*node_id);
             }
-            let Node::Text(t) = &mut entry.node else {
-                return Err(ModelError::AttrNodeKindMismatch);
-            };
-            t.text = t.text.apply(op.id, text_op.clone()).expect("local apply");
-        }
+            TextOp::RemoveChar { observed } => {
+                let entry = doc
+                    .entries
+                    .get(node_id)
+                    .ok_or(ModelError::NodeNotFound(*node_id))?;
+                let Node::Text(_) = &entry.node else {
+                    return Err(ModelError::AttrNodeKindMismatch);
+                };
+                if doc.text_identity().char_for(*observed).is_none() {
+                    return Err(ModelError::Crdt(editor_crdt::CrdtError::EntryNotFound {
+                        dot: observed.0,
+                    }));
+                }
+                let old_owner = doc
+                    .text_identity()
+                    .current_location(*observed)
+                    .map(|loc| loc.node_id);
+                doc.text.mark_deleted(*observed, op.id);
+                if let Some(owner) = old_owner {
+                    doc.refresh_text_projection(owner);
+                }
+            }
+        },
         DocOp::Modifier {
             node_id,
             op: ormap_op,
@@ -254,6 +295,48 @@ pub fn apply_doc_op(mut doc: Doc, op: &Op<DocOp>) -> Result<Doc, ModelError> {
                 .apply(op.id, lww_op.clone())
                 .expect("local apply");
         }
+        DocOp::MoveText {
+            entry,
+            to_node_id,
+            after,
+        } => {
+            let ch = doc
+                .text_identity()
+                .char_for(*entry)
+                .ok_or(ModelError::Crdt(editor_crdt::CrdtError::EntryNotFound {
+                    dot: entry.0,
+                }))?;
+            let current_before = doc.text_identity().current_location(*entry);
+            let target_entry = doc
+                .entries
+                .get(to_node_id)
+                .ok_or(ModelError::NodeNotFound(*to_node_id))?;
+            let Node::Text(_) = &target_entry.node else {
+                return Err(ModelError::AttrNodeKindMismatch);
+            };
+            if let Some(anchor) = after
+                && !doc.text.contains_placement(*to_node_id, *anchor)
+            {
+                return Err(ModelError::OrphanAnchor {
+                    node_id: *to_node_id,
+                    anchor: anchor.0,
+                    kind: AnchorKind::Text,
+                });
+            }
+            doc.text
+                .insert_placement(*to_node_id, PlacementId(op.id), *entry, *after, ch)?;
+            let candidate = CurrentTextLocation {
+                owner_text_node: *to_node_id,
+                placement: PlacementId(op.id),
+            };
+            if current_before.is_none_or(|loc| candidate.placement.0 > loc.placement_id.0) {
+                doc.text.record_current_location(*entry, candidate);
+                if let Some(old_location) = current_before {
+                    doc.refresh_text_projection(old_location.node_id);
+                }
+            }
+            doc.refresh_text_projection(*to_node_id);
+        }
         DocOp::Style {
             style_id,
             op: style_op,
@@ -303,7 +386,8 @@ pub fn apply_doc_op(mut doc: Doc, op: &Op<DocOp>) -> Result<Doc, ModelError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use editor_crdt::{OpGraph, TextOp};
+    use crate::PlainNode;
+    use editor_crdt::{EntryDot, OpGraph, PlacementId, TextOp};
 
     fn first_op<P: Clone>(graph: &OpGraph<P>, payload: P) -> (OpGraph<P>, Op<P>) {
         graph.clone().add(payload).unwrap()
@@ -616,7 +700,7 @@ mod tests {
         graph = g;
         let doc = apply_doc_op(Doc::empty(), &presence).unwrap();
 
-        let bad_anchor = editor_crdt::Dot::new(999, 999);
+        let bad_anchor = editor_crdt::PlacementId(editor_crdt::Dot::new(999, 999));
         let (_, bad_text_op) = first_op(
             &graph,
             DocOp::Text {
@@ -666,7 +750,7 @@ mod tests {
         );
         graph = g;
         let doc = apply_doc_op(doc, &op1).unwrap();
-        let dot1 = op1.id;
+        let dot1 = PlacementId(op1.id);
 
         let (_, op2) = first_op(
             &graph,
@@ -688,6 +772,804 @@ mod tests {
     }
 
     #[test]
+    fn move_text_rehomes_entry_without_deleting_source_placement() {
+        let mut graph = OpGraph::<DocOp>::new();
+        let t1 = NodeId::new();
+        let t2 = NodeId::new();
+
+        let (g, t1_presence) = first_op(
+            &graph,
+            DocOp::Presence {
+                node_id: t1,
+                op: OrMapOp::Set {
+                    key: t1,
+                    value: NodeType::Text,
+                },
+            },
+        );
+        graph = g;
+        let doc = apply_doc_op(Doc::empty(), &t1_presence).unwrap();
+
+        let (g, t2_presence) = first_op(
+            &graph,
+            DocOp::Presence {
+                node_id: t2,
+                op: OrMapOp::Set {
+                    key: t2,
+                    value: NodeType::Text,
+                },
+            },
+        );
+        graph = g;
+        let doc = apply_doc_op(doc, &t2_presence).unwrap();
+
+        let (g, insert) = first_op(
+            &graph,
+            DocOp::Text {
+                node_id: t1,
+                op: TextOp::InsertChar {
+                    after: None,
+                    ch: 'a',
+                },
+            },
+        );
+        graph = g;
+        let doc = apply_doc_op(doc, &insert).unwrap();
+
+        let (_, move_op) = first_op(
+            &graph,
+            DocOp::MoveText {
+                entry: EntryDot(insert.id),
+                to_node_id: t2,
+                after: None,
+            },
+        );
+        let doc = apply_doc_op(doc, &move_op).unwrap();
+
+        assert_eq!(doc.text_view(t1).unwrap().text(), "");
+        assert_eq!(doc.text_view(t2).unwrap().text(), "a");
+
+        let Node::Text(source) = &doc.get_entry(t1).unwrap().node else {
+            panic!("source must be text");
+        };
+        assert_eq!(source.text.to_string(), "");
+        assert_eq!(source.text.len(), 0);
+        let source_placements = doc.text.all_placements_for_node(t1);
+        assert_eq!(source_placements.len(), 1);
+        assert_eq!(source_placements[0].placement_id, PlacementId(insert.id));
+        assert_eq!(source_placements[0].entry_dot, EntryDot(insert.id));
+
+        let Node::Text(target) = &doc.get_entry(t2).unwrap().node else {
+            panic!("target must be text");
+        };
+        assert_eq!(target.text.to_string(), "a");
+        assert_eq!(target.text.len(), 1);
+        let target_placements = doc.text.all_placements_for_node(t2);
+        assert_eq!(target_placements.len(), 1);
+        assert_eq!(target_placements[0].placement_id, PlacementId(move_op.id));
+        assert_eq!(target_placements[0].entry_dot, EntryDot(insert.id));
+        assert_eq!(target_placements[0].ch, 'a');
+    }
+
+    #[test]
+    fn materialized_text_accessors_read_content_after_move() {
+        let mut graph = OpGraph::<DocOp>::new();
+        let t1 = NodeId::new();
+        let t2 = NodeId::new();
+
+        let (g, t1_presence) = first_op(
+            &graph,
+            DocOp::Presence {
+                node_id: t1,
+                op: OrMapOp::Set {
+                    key: t1,
+                    value: NodeType::Text,
+                },
+            },
+        );
+        graph = g;
+        let doc = apply_doc_op(Doc::empty(), &t1_presence).unwrap();
+
+        let (g, t2_presence) = first_op(
+            &graph,
+            DocOp::Presence {
+                node_id: t2,
+                op: OrMapOp::Set {
+                    key: t2,
+                    value: NodeType::Text,
+                },
+            },
+        );
+        graph = g;
+        let doc = apply_doc_op(doc, &t2_presence).unwrap();
+
+        let (g, insert) = first_op(
+            &graph,
+            DocOp::Text {
+                node_id: t1,
+                op: TextOp::InsertChar {
+                    after: None,
+                    ch: 'a',
+                },
+            },
+        );
+        graph = g;
+        let doc = apply_doc_op(doc, &insert).unwrap();
+
+        let (_, move_op) = first_op(
+            &graph,
+            DocOp::MoveText {
+                entry: EntryDot(insert.id),
+                to_node_id: t2,
+                after: None,
+            },
+        );
+        let doc = apply_doc_op(doc, &move_op).unwrap();
+
+        assert_eq!(doc.text_view(t1).unwrap().text(), "");
+        assert_eq!(doc.text_view(t2).unwrap().text(), "a");
+        assert_eq!(
+            doc.text_view(t2)
+                .unwrap()
+                .visible_entries()
+                .collect::<Vec<_>>(),
+            vec![(EntryDot(insert.id), 'a')]
+        );
+        assert!(doc.text_view(NodeId::ROOT).is_none());
+
+        let target = doc.node(t2).unwrap();
+        assert_eq!(target.as_text().unwrap().text(), "a");
+
+        let plain = doc.to_plain();
+        let PlainNode::Text(source_plain) = &plain.nodes.get(&t1).unwrap().node else {
+            panic!("source must be text");
+        };
+        let PlainNode::Text(target_plain) = &plain.nodes.get(&t2).unwrap().node else {
+            panic!("target must be text");
+        };
+        assert_eq!(source_plain.text, "");
+        assert_eq!(target_plain.text, "a");
+    }
+
+    #[test]
+    fn move_text_after_must_exist_in_target_all_placements() {
+        let mut graph = OpGraph::<DocOp>::new();
+        let t1 = NodeId::new();
+        let t2 = NodeId::new();
+
+        let (g, t1_presence) = first_op(
+            &graph,
+            DocOp::Presence {
+                node_id: t1,
+                op: OrMapOp::Set {
+                    key: t1,
+                    value: NodeType::Text,
+                },
+            },
+        );
+        graph = g;
+        let doc = apply_doc_op(Doc::empty(), &t1_presence).unwrap();
+
+        let (g, t2_presence) = first_op(
+            &graph,
+            DocOp::Presence {
+                node_id: t2,
+                op: OrMapOp::Set {
+                    key: t2,
+                    value: NodeType::Text,
+                },
+            },
+        );
+        graph = g;
+        let doc = apply_doc_op(doc, &t2_presence).unwrap();
+
+        let (g, insert) = first_op(
+            &graph,
+            DocOp::Text {
+                node_id: t1,
+                op: TextOp::InsertChar {
+                    after: None,
+                    ch: 'a',
+                },
+            },
+        );
+        graph = g;
+        let doc = apply_doc_op(doc, &insert).unwrap();
+
+        let (_, move_op) = first_op(
+            &graph,
+            DocOp::MoveText {
+                entry: EntryDot(insert.id),
+                to_node_id: t2,
+                after: Some(PlacementId(Dot::new(99, 0))),
+            },
+        );
+
+        let result = apply_doc_op(doc, &move_op);
+        assert!(matches!(
+            result,
+            Err(ModelError::OrphanAnchor {
+                kind: AnchorKind::Text,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn remove_char_deletes_moved_entry_globally() {
+        let mut graph = OpGraph::<DocOp>::new();
+        let t1 = NodeId::new();
+        let t2 = NodeId::new();
+
+        let (g, t1_presence) = first_op(
+            &graph,
+            DocOp::Presence {
+                node_id: t1,
+                op: OrMapOp::Set {
+                    key: t1,
+                    value: NodeType::Text,
+                },
+            },
+        );
+        graph = g;
+        let doc = apply_doc_op(Doc::empty(), &t1_presence).unwrap();
+
+        let (g, t2_presence) = first_op(
+            &graph,
+            DocOp::Presence {
+                node_id: t2,
+                op: OrMapOp::Set {
+                    key: t2,
+                    value: NodeType::Text,
+                },
+            },
+        );
+        graph = g;
+        let doc = apply_doc_op(doc, &t2_presence).unwrap();
+
+        let (g, insert) = first_op(
+            &graph,
+            DocOp::Text {
+                node_id: t1,
+                op: TextOp::InsertChar {
+                    after: None,
+                    ch: 'a',
+                },
+            },
+        );
+        graph = g;
+        let doc = apply_doc_op(doc, &insert).unwrap();
+
+        let (g, move_op) = first_op(
+            &graph,
+            DocOp::MoveText {
+                entry: EntryDot(insert.id),
+                to_node_id: t2,
+                after: None,
+            },
+        );
+        graph = g;
+        let doc = apply_doc_op(doc, &move_op).unwrap();
+
+        let (_, remove) = first_op(
+            &graph,
+            DocOp::Text {
+                node_id: t1,
+                op: TextOp::RemoveChar {
+                    observed: EntryDot(insert.id),
+                },
+            },
+        );
+        let doc = apply_doc_op(doc, &remove).unwrap();
+
+        assert_eq!(doc.text_view(t1).unwrap().text(), "");
+        assert_eq!(doc.text_view(t2).unwrap().text(), "");
+
+        let Node::Text(_) = &doc.get_entry(t1).unwrap().node else {
+            panic!("source must be text");
+        };
+        assert_eq!(doc.text.all_placements_for_node(t1).len(), 1);
+
+        let Node::Text(_) = &doc.get_entry(t2).unwrap().node else {
+            panic!("target must be text");
+        };
+        assert_eq!(doc.text.all_placements_for_node(t2).len(), 1);
+    }
+
+    #[test]
+    fn remove_char_rejects_non_text_node_id() {
+        let mut graph = OpGraph::<DocOp>::new();
+        let t1 = NodeId::new();
+        let p1 = NodeId::new();
+
+        let (g, t1_presence) = first_op(
+            &graph,
+            DocOp::Presence {
+                node_id: t1,
+                op: OrMapOp::Set {
+                    key: t1,
+                    value: NodeType::Text,
+                },
+            },
+        );
+        graph = g;
+        let doc = apply_doc_op(Doc::empty(), &t1_presence).unwrap();
+
+        let (g, p1_presence) = first_op(
+            &graph,
+            DocOp::Presence {
+                node_id: p1,
+                op: OrMapOp::Set {
+                    key: p1,
+                    value: NodeType::Paragraph,
+                },
+            },
+        );
+        graph = g;
+        let doc = apply_doc_op(doc, &p1_presence).unwrap();
+
+        let (g, insert) = first_op(
+            &graph,
+            DocOp::Text {
+                node_id: t1,
+                op: TextOp::InsertChar {
+                    after: None,
+                    ch: 'a',
+                },
+            },
+        );
+        graph = g;
+        let doc = apply_doc_op(doc, &insert).unwrap();
+
+        let (_, remove) = first_op(
+            &graph,
+            DocOp::Text {
+                node_id: p1,
+                op: TextOp::RemoveChar {
+                    observed: EntryDot(insert.id),
+                },
+            },
+        );
+
+        assert_eq!(
+            apply_doc_op(doc, &remove),
+            Err(ModelError::AttrNodeKindMismatch)
+        );
+    }
+
+    #[test]
+    fn move_text_after_delete_does_not_resurrect_entry() {
+        let mut graph = OpGraph::<DocOp>::new();
+        let t1 = NodeId::new();
+        let t2 = NodeId::new();
+
+        let (g, t1_presence) = first_op(
+            &graph,
+            DocOp::Presence {
+                node_id: t1,
+                op: OrMapOp::Set {
+                    key: t1,
+                    value: NodeType::Text,
+                },
+            },
+        );
+        graph = g;
+        let doc = apply_doc_op(Doc::empty(), &t1_presence).unwrap();
+
+        let (g, t2_presence) = first_op(
+            &graph,
+            DocOp::Presence {
+                node_id: t2,
+                op: OrMapOp::Set {
+                    key: t2,
+                    value: NodeType::Text,
+                },
+            },
+        );
+        graph = g;
+        let doc = apply_doc_op(doc, &t2_presence).unwrap();
+
+        let (g, insert) = first_op(
+            &graph,
+            DocOp::Text {
+                node_id: t1,
+                op: TextOp::InsertChar {
+                    after: None,
+                    ch: 'a',
+                },
+            },
+        );
+        graph = g;
+        let doc = apply_doc_op(doc, &insert).unwrap();
+
+        let (g, remove) = first_op(
+            &graph,
+            DocOp::Text {
+                node_id: t1,
+                op: TextOp::RemoveChar {
+                    observed: EntryDot(insert.id),
+                },
+            },
+        );
+        graph = g;
+        let doc = apply_doc_op(doc, &remove).unwrap();
+
+        let (_, move_op) = first_op(
+            &graph,
+            DocOp::MoveText {
+                entry: EntryDot(insert.id),
+                to_node_id: t2,
+                after: None,
+            },
+        );
+        let doc = apply_doc_op(doc, &move_op).unwrap();
+
+        assert_eq!(doc.text_view(t1).unwrap().text(), "");
+        assert_eq!(doc.text_view(t2).unwrap().text(), "");
+        let Node::Text(_) = &doc.get_entry(t2).unwrap().node else {
+            panic!("target must be text");
+        };
+        assert_eq!(doc.text.all_placements_for_node(t2).len(), 1);
+    }
+
+    #[test]
+    fn move_text_later_placement_wins() {
+        let mut graph = OpGraph::<DocOp>::new();
+        let t1 = NodeId::new();
+        let t2 = NodeId::new();
+        let t3 = NodeId::new();
+
+        let mut doc = Doc::empty();
+        for node_id in [t1, t2, t3] {
+            let (g, presence) = first_op(
+                &graph,
+                DocOp::Presence {
+                    node_id,
+                    op: OrMapOp::Set {
+                        key: node_id,
+                        value: NodeType::Text,
+                    },
+                },
+            );
+            graph = g;
+            doc = apply_doc_op(doc, &presence).unwrap();
+        }
+
+        let (g, insert) = first_op(
+            &graph,
+            DocOp::Text {
+                node_id: t1,
+                op: TextOp::InsertChar {
+                    after: None,
+                    ch: 'a',
+                },
+            },
+        );
+        graph = g;
+        let doc = apply_doc_op(doc, &insert).unwrap();
+
+        let (g, move_to_t2) = first_op(
+            &graph,
+            DocOp::MoveText {
+                entry: EntryDot(insert.id),
+                to_node_id: t2,
+                after: None,
+            },
+        );
+        graph = g;
+        let doc = apply_doc_op(doc, &move_to_t2).unwrap();
+
+        let (_, move_to_t3) = first_op(
+            &graph,
+            DocOp::MoveText {
+                entry: EntryDot(insert.id),
+                to_node_id: t3,
+                after: None,
+            },
+        );
+        let doc = apply_doc_op(doc, &move_to_t3).unwrap();
+
+        assert_eq!(doc.text_view(t1).unwrap().text(), "");
+        assert_eq!(doc.text_view(t2).unwrap().text(), "");
+        assert_eq!(doc.text_view(t3).unwrap().text(), "a");
+    }
+
+    #[test]
+    fn move_text_older_placement_does_not_win_when_applied_later() {
+        let mut graph = OpGraph::<DocOp>::new();
+        let t1 = NodeId::new();
+        let t2 = NodeId::new();
+        let t3 = NodeId::new();
+
+        let mut doc = Doc::empty();
+        for node_id in [t1, t2, t3] {
+            let (g, presence) = first_op(
+                &graph,
+                DocOp::Presence {
+                    node_id,
+                    op: OrMapOp::Set {
+                        key: node_id,
+                        value: NodeType::Text,
+                    },
+                },
+            );
+            graph = g;
+            doc = apply_doc_op(doc, &presence).unwrap();
+        }
+
+        let (g, insert) = first_op(
+            &graph,
+            DocOp::Text {
+                node_id: t1,
+                op: TextOp::InsertChar {
+                    after: None,
+                    ch: 'a',
+                },
+            },
+        );
+        graph = g;
+        let doc = apply_doc_op(doc, &insert).unwrap();
+
+        let (g, move_to_t2) = first_op(
+            &graph,
+            DocOp::MoveText {
+                entry: EntryDot(insert.id),
+                to_node_id: t2,
+                after: None,
+            },
+        );
+        graph = g;
+        let (_, move_to_t3) = first_op(
+            &graph,
+            DocOp::MoveText {
+                entry: EntryDot(insert.id),
+                to_node_id: t3,
+                after: None,
+            },
+        );
+
+        let doc = apply_doc_op(doc, &move_to_t3).unwrap();
+        let doc = apply_doc_op(doc, &move_to_t2).unwrap();
+
+        assert_eq!(doc.text_view(t1).unwrap().text(), "");
+        assert_eq!(doc.text_view(t2).unwrap().text(), "");
+        assert_eq!(doc.text_view(t3).unwrap().text(), "a");
+        assert!(doc.text.index_matches_rebuild(&doc));
+    }
+
+    #[test]
+    fn move_text_apply_is_idempotent_for_same_op() {
+        let mut graph = OpGraph::<DocOp>::new();
+        let t1 = NodeId::new();
+        let t2 = NodeId::new();
+
+        let (g, t1_presence) = first_op(
+            &graph,
+            DocOp::Presence {
+                node_id: t1,
+                op: OrMapOp::Set {
+                    key: t1,
+                    value: NodeType::Text,
+                },
+            },
+        );
+        graph = g;
+        let doc = apply_doc_op(Doc::empty(), &t1_presence).unwrap();
+
+        let (g, t2_presence) = first_op(
+            &graph,
+            DocOp::Presence {
+                node_id: t2,
+                op: OrMapOp::Set {
+                    key: t2,
+                    value: NodeType::Text,
+                },
+            },
+        );
+        graph = g;
+        let doc = apply_doc_op(doc, &t2_presence).unwrap();
+
+        let (g, insert) = first_op(
+            &graph,
+            DocOp::Text {
+                node_id: t1,
+                op: TextOp::InsertChar {
+                    after: None,
+                    ch: 'a',
+                },
+            },
+        );
+        graph = g;
+        let doc = apply_doc_op(doc, &insert).unwrap();
+
+        let (_, move_op) = first_op(
+            &graph,
+            DocOp::MoveText {
+                entry: EntryDot(insert.id),
+                to_node_id: t2,
+                after: None,
+            },
+        );
+        let doc = apply_doc_op(doc, &move_op).unwrap();
+        let doc = apply_doc_op(doc, &move_op).unwrap();
+
+        assert_eq!(doc.text_view(t2).unwrap().text(), "a");
+        let Node::Text(_) = &doc.get_entry(t2).unwrap().node else {
+            panic!("target must be text");
+        };
+        assert_eq!(doc.text.all_placements_for_node(t2).len(), 1);
+    }
+
+    #[test]
+    fn move_text_can_read_entry_from_tombstoned_source_shell() {
+        let mut graph = OpGraph::<DocOp>::new();
+        let t1 = NodeId::new();
+        let t2 = NodeId::new();
+
+        let (g, t1_presence) = first_op(
+            &graph,
+            DocOp::Presence {
+                node_id: t1,
+                op: OrMapOp::Set {
+                    key: t1,
+                    value: NodeType::Text,
+                },
+            },
+        );
+        graph = g;
+        let doc = apply_doc_op(Doc::empty(), &t1_presence).unwrap();
+
+        let (g, t2_presence) = first_op(
+            &graph,
+            DocOp::Presence {
+                node_id: t2,
+                op: OrMapOp::Set {
+                    key: t2,
+                    value: NodeType::Text,
+                },
+            },
+        );
+        graph = g;
+        let doc = apply_doc_op(doc, &t2_presence).unwrap();
+
+        let (g, insert) = first_op(
+            &graph,
+            DocOp::Text {
+                node_id: t1,
+                op: TextOp::InsertChar {
+                    after: None,
+                    ch: 'a',
+                },
+            },
+        );
+        graph = g;
+        let doc = apply_doc_op(doc, &insert).unwrap();
+
+        let observed: Vec<_> = doc.nodes_tags_for(&t1).copied().collect();
+        let (g, delete_shell) = first_op(
+            &graph,
+            DocOp::Presence {
+                node_id: t1,
+                op: OrMapOp::Unset { observed },
+            },
+        );
+        graph = g;
+        let doc = apply_doc_op(doc, &delete_shell).unwrap();
+        assert!(doc.get_entry(t1).is_none());
+
+        let (_, move_op) = first_op(
+            &graph,
+            DocOp::MoveText {
+                entry: EntryDot(insert.id),
+                to_node_id: t2,
+                after: None,
+            },
+        );
+        let doc = apply_doc_op(doc, &move_op).unwrap();
+
+        assert_eq!(doc.text_view(t2).unwrap().text(), "a");
+        let Node::Text(_) = &doc.entries.get(&t1).unwrap().node else {
+            panic!("source must remain historical text");
+        };
+        let source_placements = doc.text.all_placements_for_node(t1);
+        assert_eq!(source_placements.len(), 1);
+        assert_eq!(source_placements[0].entry_dot, EntryDot(insert.id));
+    }
+
+    #[test]
+    fn move_text_to_tombstoned_target_records_hidden_placement() {
+        let mut graph = OpGraph::<DocOp>::new();
+        let t1 = NodeId::new();
+        let t2 = NodeId::new();
+
+        let (g, t1_presence) = first_op(
+            &graph,
+            DocOp::Presence {
+                node_id: t1,
+                op: OrMapOp::Set {
+                    key: t1,
+                    value: NodeType::Text,
+                },
+            },
+        );
+        graph = g;
+        let doc = apply_doc_op(Doc::empty(), &t1_presence).unwrap();
+
+        let (g, t2_presence) = first_op(
+            &graph,
+            DocOp::Presence {
+                node_id: t2,
+                op: OrMapOp::Set {
+                    key: t2,
+                    value: NodeType::Text,
+                },
+            },
+        );
+        graph = g;
+        let doc = apply_doc_op(doc, &t2_presence).unwrap();
+
+        let (g, insert) = first_op(
+            &graph,
+            DocOp::Text {
+                node_id: t1,
+                op: TextOp::InsertChar {
+                    after: None,
+                    ch: 'a',
+                },
+            },
+        );
+        graph = g;
+        let doc = apply_doc_op(doc, &insert).unwrap();
+
+        let observed: Vec<_> = doc.nodes_tags_for(&t2).copied().collect();
+        let (g, delete_shell) = first_op(
+            &graph,
+            DocOp::Presence {
+                node_id: t2,
+                op: OrMapOp::Unset { observed },
+            },
+        );
+        graph = g;
+        let doc = apply_doc_op(doc, &delete_shell).unwrap();
+        assert!(doc.get_entry(t2).is_none());
+
+        let (g, move_op) = first_op(
+            &graph,
+            DocOp::MoveText {
+                entry: EntryDot(insert.id),
+                to_node_id: t2,
+                after: None,
+            },
+        );
+        graph = g;
+        let doc = apply_doc_op(doc, &move_op).unwrap();
+
+        assert_eq!(doc.text_view(t1).unwrap().text(), "");
+        let Node::Text(_) = &doc.entries.get(&t2).unwrap().node else {
+            panic!("target must remain historical text");
+        };
+        let target_placements = doc.text.all_placements_for_node(t2);
+        assert_eq!(target_placements.len(), 1);
+        assert_eq!(target_placements[0].placement_id, PlacementId(move_op.id));
+        assert_eq!(target_placements[0].entry_dot, EntryDot(insert.id));
+
+        let (_, revive_target) = first_op(
+            &graph,
+            DocOp::Presence {
+                node_id: t2,
+                op: OrMapOp::Set {
+                    key: t2,
+                    value: NodeType::Text,
+                },
+            },
+        );
+        let doc = apply_doc_op(doc, &revive_target).unwrap();
+
+        assert_eq!(doc.text_view(t2).unwrap().text(), "a");
+        assert!(doc.text.index_matches_rebuild(&doc));
+    }
+
+    #[test]
     fn wire_round_trip_text_op() {
         use editor_crdt::Dot;
         use editor_crdt::wire::{CollectCtx, DecCtx, EncCtx, Wire};
@@ -695,7 +1577,7 @@ mod tests {
         let op = DocOp::Text {
             node_id: NodeId::new(),
             op: editor_crdt::TextOp::InsertChar {
-                after: Some(dot),
+                after: Some(PlacementId(dot)),
                 ch: '가',
             },
         };
@@ -724,7 +1606,7 @@ mod tests {
                 op: TextOp::InsertChar { after: prev, ch },
             };
             let (ng, op) = g.add(payload).unwrap();
-            prev = Some(op.id);
+            prev = Some(PlacementId(op.id));
             g = ng;
         }
         g.commit().changesets_as_vec()
@@ -737,6 +1619,33 @@ mod tests {
         let decoded: Vec<editor_crdt::Changeset<DocOp>> =
             editor_crdt::wire::decode(&bytes).unwrap();
         assert_eq!(decoded, css);
+    }
+
+    #[test]
+    fn run_grouping_expands_after_links_as_placement_ids() {
+        let css = build_typing("abc");
+        let bytes = editor_crdt::wire::encode(&css).unwrap();
+        let decoded: Vec<editor_crdt::Changeset<DocOp>> =
+            editor_crdt::wire::decode(&bytes).unwrap();
+
+        let ops = &decoded[0].ops;
+        assert_eq!(ops.len(), 3);
+
+        let assert_insert = |index: usize, expected_after: Option<PlacementId>, expected_ch| {
+            let DocOp::Text {
+                op: TextOp::InsertChar { after, ch },
+                ..
+            } = &ops[index].payload
+            else {
+                panic!("expected text insert at index {index}");
+            };
+            assert_eq!(*after, expected_after);
+            assert_eq!(*ch, expected_ch);
+        };
+
+        assert_insert(0, None, 'a');
+        assert_insert(1, Some(PlacementId(ops[0].id)), 'b');
+        assert_insert(2, Some(PlacementId(ops[1].id)), 'c');
     }
 
     #[test]
@@ -928,6 +1837,23 @@ mod tests {
     }
 
     #[test]
+    fn move_text_wire_round_trip() {
+        let target = NodeId::new();
+        let entry = EntryDot(Dot::new(1, 0));
+        let placement = PlacementId(Dot::new(2, 0));
+        assert_round_trip(vec![DocOp::MoveText {
+            entry,
+            to_node_id: target,
+            after: Some(placement),
+        }]);
+        assert_round_trip(vec![DocOp::MoveText {
+            entry,
+            to_node_id: target,
+            after: None,
+        }]);
+    }
+
+    #[test]
     fn empty_bundle_round_trip() {
         let bytes = editor_crdt::wire::encode::<DocOp>(&[]).unwrap();
         assert!(bytes.is_empty());
@@ -951,9 +1877,11 @@ const VARIANT_NODE_STYLE: u8 = 6;
 const VARIANT_ESCAPE: u8 = 7;
 const EXT_STYLE: u8 = 0;
 const EXT_MARKER: u8 = 1;
+const EXT_MOVE_TEXT: u8 = 2;
 
 const VARIANT_STYLE: u8 = 8 + EXT_STYLE;
 const VARIANT_NODE_MARKER: u8 = 8 + EXT_MARKER;
+const VARIANT_MOVE_TEXT: u8 = 8 + EXT_MOVE_TEXT;
 
 const ENTRY_TAG_RUN_BIT: u8 = 0b1000_0000;
 const ENTRY_TAG_NODE_ID_EXPLICIT: u8 = 0b0100_0000;
@@ -1074,6 +2002,7 @@ impl WireChangeset for DocOp {
                     match ext {
                         EXT_STYLE => VARIANT_STYLE,
                         EXT_MARKER => VARIANT_NODE_MARKER,
+                        EXT_MOVE_TEXT => VARIANT_MOVE_TEXT,
                         n => return Err(WireError::UnknownPayloadVariant { tag: n }),
                     }
                 } else {
@@ -1166,7 +2095,7 @@ fn try_match_text_run(ops: &[Op<DocOp>], start: usize) -> Option<usize> {
         if op.id.actor != actor || op.id.clock != expected_clock {
             break;
         }
-        if *after != Some(prev_id) {
+        if *after != Some(PlacementId(prev_id)) {
             break;
         }
         prev_id = op.id;
@@ -1185,6 +2114,7 @@ fn encode_single_op_entry(
     let (tag_variant, ext) = match variant {
         VARIANT_STYLE => (VARIANT_ESCAPE, Some(EXT_STYLE)),
         VARIANT_NODE_MARKER => (VARIANT_ESCAPE, Some(EXT_MARKER)),
+        VARIANT_MOVE_TEXT => (VARIANT_ESCAPE, Some(EXT_MOVE_TEXT)),
         v => (v, None),
     };
     let node_id_explicit = !matches!(prev_node_id, Some(prev) if *prev == node_id);
@@ -1247,7 +2177,7 @@ fn encode_text_run_entry(
         None => out.push(0),
         Some(d) => {
             out.push(1);
-            <Dot as editor_crdt::wire::Wire>::encode(&d, ctx, out)?;
+            <PlacementId as editor_crdt::wire::Wire>::encode(&d, ctx, out)?;
         }
     }
     out.extend_from_slice(chars.as_bytes());
@@ -1324,6 +2254,15 @@ fn describe_doc_op(p: &DocOp) -> (u8, u8, NodeId) {
             };
             (VARIANT_STYLE, sub, NodeId::ROOT)
         }
+        DocOp::MoveText {
+            to_node_id, after, ..
+        } => {
+            let mut sub = 0;
+            if after.is_some() {
+                sub |= 0b001;
+            }
+            (VARIANT_MOVE_TEXT, sub, *to_node_id)
+        }
     }
 }
 
@@ -1369,12 +2308,12 @@ fn encode_doc_op_payload(
         DocOp::Text { op, .. } => match op {
             editor_crdt::TextOp::InsertChar { after, ch } => {
                 if let Some(d) = after {
-                    <Dot as Wire>::encode(d, ctx, out)?;
+                    <PlacementId as Wire>::encode(d, ctx, out)?;
                 }
                 <char as Wire>::encode(ch, ctx, out)?;
             }
             editor_crdt::TextOp::RemoveChar { observed } => {
-                <Dot as Wire>::encode(observed, ctx, out)?;
+                <EntryDot as Wire>::encode(observed, ctx, out)?;
             }
         },
         DocOp::Modifier { op, .. } => match op {
@@ -1424,6 +2363,12 @@ fn encode_doc_op_payload(
                 StyleOp::Presence(editor_crdt::OrMapOp::Unset { observed }) => {
                     <Vec<Dot> as Wire>::encode(observed, ctx, out)?;
                 }
+            }
+        }
+        DocOp::MoveText { entry, after, .. } => {
+            <EntryDot as Wire>::encode(entry, ctx, out)?;
+            if let Some(after) = after {
+                <PlacementId as Wire>::encode(after, ctx, out)?;
             }
         }
     }
@@ -1508,7 +2453,7 @@ fn decode_doc_op_payload(
         VARIANT_TEXT => {
             if subflag & 1 == 0 {
                 let after = if subflag & 0b010 != 0 {
-                    Some(<Dot as Wire>::decode(ctx, input)?)
+                    Some(<PlacementId as Wire>::decode(ctx, input)?)
                 } else {
                     None
                 };
@@ -1518,7 +2463,7 @@ fn decode_doc_op_payload(
                     op: editor_crdt::TextOp::InsertChar { after, ch },
                 })
             } else {
-                let observed = <Dot as Wire>::decode(ctx, input)?;
+                let observed = <EntryDot as Wire>::decode(ctx, input)?;
                 Ok(DocOp::Text {
                     node_id,
                     op: editor_crdt::TextOp::RemoveChar { observed },
@@ -1589,6 +2534,19 @@ fn decode_doc_op_payload(
             };
             Ok(DocOp::Style { style_id, op })
         }
+        VARIANT_MOVE_TEXT => {
+            let entry = <EntryDot as Wire>::decode(ctx, input)?;
+            let after = if subflag & 0b001 != 0 {
+                Some(<PlacementId as Wire>::decode(ctx, input)?)
+            } else {
+                None
+            };
+            Ok(DocOp::MoveText {
+                entry,
+                to_node_id: node_id,
+                after,
+            })
+        }
         n => Err(WireError::UnknownPayloadVariant { tag: n }),
     }
 }
@@ -1606,9 +2564,11 @@ fn decode_text_run_entry(
         return Err(WireError::InvalidRunLength { got: run_len });
     }
     let after_tag = <u8 as editor_crdt::wire::Wire>::decode(ctx, input)?;
-    let first_after = match after_tag {
+    let first_after: Option<PlacementId> = match after_tag {
         0 => None,
-        1 => Some(<Dot as editor_crdt::wire::Wire>::decode(ctx, input)?),
+        1 => Some(<PlacementId as editor_crdt::wire::Wire>::decode(
+            ctx, input,
+        )?),
         n => {
             return Err(WireError::UnknownVariant {
                 ty: "RunAfter",
@@ -1637,7 +2597,7 @@ fn decode_text_run_entry(
         let after = if i == 0 {
             first_after
         } else {
-            Some(prev_id_inner.unwrap())
+            Some(PlacementId(prev_id_inner.unwrap()))
         };
         let parents = if i == 0 {
             match first_op_parents {

--- a/crates/editor-model/src/doc_text_store.rs
+++ b/crates/editor-model/src/doc_text_store.rs
@@ -1,0 +1,402 @@
+use editor_crdt::{CrdtError, Dot, EntryDot, PlacementId, Rga, RgaOp, TextPlacement};
+
+#[cfg(any(test, debug_assertions))]
+use crate::doc::Doc;
+use crate::id::NodeId;
+use crate::text_entry_store::TextEntryStore;
+use crate::text_index::{CurrentTextLocation, TextIndex};
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct TextPlacementRecord {
+    entry_dot: EntryDot,
+    ch: char,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct StoredTextPlacement {
+    placement: TextPlacement,
+    alive: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum EntryBoundary {
+    Before,
+    After,
+}
+
+#[derive(Clone, Debug, PartialEq, Default)]
+pub(crate) struct DocTextStore {
+    entries: TextEntryStore,
+    index: TextIndex,
+    placements_by_node: imbl::HashMap<NodeId, Rga<TextPlacementRecord>>,
+}
+
+impl DocTextStore {
+    pub(crate) fn register_insert(
+        &mut self,
+        entry_dot: EntryDot,
+        birth_node: NodeId,
+        initial_placement: PlacementId,
+        after: Option<PlacementId>,
+        ch: char,
+    ) -> Result<(), CrdtError> {
+        self.insert_placement_record(birth_node, initial_placement, entry_dot, after, ch)?;
+        self.entries
+            .register_insert(entry_dot, birth_node, initial_placement, ch);
+        Ok(())
+    }
+
+    pub(crate) fn insert_placement(
+        &mut self,
+        owner_text_node: NodeId,
+        placement: PlacementId,
+        entry_dot: EntryDot,
+        after: Option<PlacementId>,
+        ch: char,
+    ) -> Result<(), CrdtError> {
+        self.insert_placement_record(owner_text_node, placement, entry_dot, after, ch)
+    }
+
+    pub(crate) fn mark_deleted(&mut self, entry_dot: EntryDot, remove_dot: Dot) {
+        self.entries.mark_deleted(entry_dot, remove_dot);
+        self.index.clear_moved_location(entry_dot);
+    }
+
+    pub(crate) fn record_current_location(
+        &mut self,
+        entry_dot: EntryDot,
+        current: CurrentTextLocation,
+    ) {
+        if self.entries.is_deleted(entry_dot) {
+            self.index.clear_moved_location(entry_dot);
+            return;
+        }
+        self.index.set_current_location(
+            entry_dot,
+            self.entries.birth_location_for(entry_dot),
+            current,
+        );
+    }
+
+    pub(crate) fn current_location(&self, entry_dot: EntryDot) -> Option<CurrentTextLocation> {
+        if self.entries.is_deleted(entry_dot) {
+            return None;
+        }
+        self.index.moved_location(entry_dot).or_else(|| {
+            let (owner_text_node, placement) = self.entries.birth_location_for(entry_dot)?;
+            Some(CurrentTextLocation {
+                owner_text_node,
+                placement,
+            })
+        })
+    }
+
+    pub(crate) fn is_deleted(&self, entry_dot: EntryDot) -> bool {
+        self.entries.is_deleted(entry_dot)
+    }
+
+    pub(crate) fn char_for(&self, entry_dot: EntryDot) -> Option<char> {
+        self.entries.char_for(entry_dot)
+    }
+
+    pub(crate) fn contains_placement(&self, node_id: NodeId, placement: PlacementId) -> bool {
+        self.placements_by_node
+            .get(&node_id)
+            .is_some_and(|placements| placements.contains_dot(placement.0))
+    }
+
+    pub(crate) fn visible_offset_before_entry(
+        &self,
+        entry_dot: EntryDot,
+    ) -> Option<(NodeId, usize)> {
+        self.visible_offset_near_entry(entry_dot, EntryBoundary::Before)
+    }
+
+    pub(crate) fn visible_offset_after_entry(
+        &self,
+        entry_dot: EntryDot,
+    ) -> Option<(NodeId, usize)> {
+        self.visible_offset_near_entry(entry_dot, EntryBoundary::After)
+    }
+
+    #[cfg(any(test, debug_assertions))]
+    pub(crate) fn all_placements_for_node(&self, node_id: NodeId) -> Vec<TextPlacement> {
+        self.stored_placements_for_node(node_id)
+            .into_iter()
+            .map(|stored| stored.placement)
+            .collect()
+    }
+
+    fn stored_placements_for_node(&self, node_id: NodeId) -> Vec<StoredTextPlacement> {
+        self.placements_by_node
+            .get(&node_id)
+            .into_iter()
+            .flat_map(|placements| {
+                placements
+                    .iter_all_in_order()
+                    .map(|(placement_id, entry, alive)| StoredTextPlacement {
+                        placement: TextPlacement {
+                            placement_id: PlacementId(placement_id),
+                            entry_dot: entry.entry_dot,
+                            ch: entry.ch,
+                        },
+                        alive,
+                    })
+            })
+            .collect()
+    }
+
+    pub(crate) fn visible_placements_for_node(&self, node_id: NodeId) -> Vec<TextPlacement> {
+        self.stored_placements_for_node(node_id)
+            .into_iter()
+            .filter_map(|stored| {
+                self.stored_placement_is_visible(node_id, stored)
+                    .then_some(stored.placement)
+            })
+            .collect()
+    }
+
+    fn stored_placement_is_visible(&self, node_id: NodeId, stored: StoredTextPlacement) -> bool {
+        let placement = stored.placement;
+        stored.alive
+            && !self.is_deleted(placement.entry_dot)
+            && self
+                .current_location(placement.entry_dot)
+                .is_some_and(|current| {
+                    current.owner_text_node == node_id
+                        && current.placement == placement.placement_id
+                })
+    }
+
+    fn latest_placement_for_entry(
+        &self,
+        entry_dot: EntryDot,
+        horizon: Option<PlacementId>,
+    ) -> Option<(NodeId, PlacementId)> {
+        self.placements_by_node
+            .iter()
+            .flat_map(|(node_id, placements)| {
+                placements
+                    .iter_all_in_order()
+                    .map(move |(placement_id, record, _)| {
+                        (*node_id, PlacementId(placement_id), record.entry_dot)
+                    })
+            })
+            .filter(|(_, _, candidate)| *candidate == entry_dot)
+            .filter(|(_, placement_id, _)| {
+                horizon.is_none_or(|horizon| placement_id.0 <= horizon.0)
+            })
+            .max_by_key(|(_, placement_id, _)| placement_id.0)
+            .map(|(node_id, placement_id, _)| (node_id, placement_id))
+    }
+
+    fn visible_offset_near_entry(
+        &self,
+        entry_dot: EntryDot,
+        boundary: EntryBoundary,
+    ) -> Option<(NodeId, usize)> {
+        let horizon = self.entries.delete_horizon_for(entry_dot).map(PlacementId);
+        let (owner, target_placement) = self.latest_placement_for_entry(entry_dot, horizon)?;
+        let placements = self.placements_by_node.get(&owner)?;
+
+        let mut passed_target = false;
+        let mut visible_offset = 0;
+        for (placement_id, record, alive) in placements.iter_all_in_order() {
+            let placement = TextPlacement {
+                placement_id: PlacementId(placement_id),
+                entry_dot: record.entry_dot,
+                ch: record.ch,
+            };
+
+            if placement.placement_id == target_placement {
+                match boundary {
+                    EntryBoundary::Before => {
+                        return Some((owner, visible_offset));
+                    }
+                    EntryBoundary::After => {
+                        passed_target = true;
+                        continue;
+                    }
+                }
+            }
+
+            // A deleted entry's stable boundary is tied to the target placement's
+            // historical position. Later fresh inserts are not revivals of that
+            // EntryDot, even if RGA sibling ordering places them before the
+            // tombstoned placement.
+            let within_horizon =
+                horizon.is_none_or(|horizon| placement.placement_id.0 <= horizon.0);
+            if within_horizon
+                && self.stored_placement_is_visible(owner, StoredTextPlacement { placement, alive })
+            {
+                if passed_target {
+                    return Some((owner, visible_offset));
+                }
+                visible_offset += 1;
+            }
+        }
+
+        passed_target.then_some((owner, visible_offset))
+    }
+
+    fn insert_placement_record(
+        &mut self,
+        node_id: NodeId,
+        placement: PlacementId,
+        entry_dot: EntryDot,
+        after: Option<PlacementId>,
+        ch: char,
+    ) -> Result<(), CrdtError> {
+        let placements = self
+            .placements_by_node
+            .get(&node_id)
+            .cloned()
+            .unwrap_or_default();
+        let next = placements.apply(
+            placement.0,
+            RgaOp::Insert {
+                after: after.map(Into::into),
+                value: TextPlacementRecord { entry_dot, ch },
+            },
+        )?;
+        self.placements_by_node.insert(node_id, next);
+        Ok(())
+    }
+
+    #[cfg(any(test, debug_assertions))]
+    pub(crate) fn birth_location_for(&self, entry_dot: EntryDot) -> Option<(NodeId, PlacementId)> {
+        self.entries.birth_location_for(entry_dot)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn moved_location(&self, entry_dot: EntryDot) -> Option<CurrentTextLocation> {
+        self.index.moved_location(entry_dot)
+    }
+
+    #[cfg(any(test, debug_assertions))]
+    pub(crate) fn index_matches_rebuild(&self, doc: &Doc) -> bool {
+        self.index == TextIndex::rebuild(doc)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use editor_crdt::{EntryDot, LwwRegOp, OpGraph, OrMapOp, RgaOp, TextOp};
+
+    use crate::{Doc, DocOp, ModelError, NodeId, NodeType, apply_doc_op};
+
+    fn apply(
+        graph: &mut OpGraph<DocOp>,
+        doc: Doc,
+        payload: DocOp,
+    ) -> (Doc, editor_crdt::Op<DocOp>) {
+        let (next_graph, op) = graph.clone().add(payload).unwrap();
+        *graph = next_graph;
+        let doc = apply_doc_op(doc, &op).unwrap();
+        (doc, op)
+    }
+
+    #[test]
+    fn verify_rejects_stale_text_index() {
+        let mut graph = OpGraph::<DocOp>::new();
+        let root = NodeId::ROOT;
+        let t1 = NodeId::new();
+        let t2 = NodeId::new();
+
+        let (doc, _) = apply(
+            &mut graph,
+            Doc::empty(),
+            DocOp::Presence {
+                node_id: root,
+                op: OrMapOp::Set {
+                    key: root,
+                    value: NodeType::Root,
+                },
+            },
+        );
+        let (doc, _) = apply(
+            &mut graph,
+            doc,
+            DocOp::Presence {
+                node_id: t1,
+                op: OrMapOp::Set {
+                    key: t1,
+                    value: NodeType::Text,
+                },
+            },
+        );
+        let (doc, _) = apply(
+            &mut graph,
+            doc,
+            DocOp::Presence {
+                node_id: t2,
+                op: OrMapOp::Set {
+                    key: t2,
+                    value: NodeType::Text,
+                },
+            },
+        );
+        let (doc, _) = apply(
+            &mut graph,
+            doc,
+            DocOp::Parent {
+                node_id: t1,
+                op: LwwRegOp::Set { value: Some(root) },
+            },
+        );
+        let (doc, t1_child) = apply(
+            &mut graph,
+            doc,
+            DocOp::Children {
+                node_id: root,
+                op: RgaOp::Insert {
+                    after: None,
+                    value: t1,
+                },
+            },
+        );
+        let (doc, _) = apply(
+            &mut graph,
+            doc,
+            DocOp::Parent {
+                node_id: t2,
+                op: LwwRegOp::Set { value: Some(root) },
+            },
+        );
+        let (doc, _) = apply(
+            &mut graph,
+            doc,
+            DocOp::Children {
+                node_id: root,
+                op: RgaOp::Insert {
+                    after: Some(t1_child.id),
+                    value: t2,
+                },
+            },
+        );
+        let (doc, insert) = apply(
+            &mut graph,
+            doc,
+            DocOp::Text {
+                node_id: t1,
+                op: TextOp::InsertChar {
+                    after: None,
+                    ch: 'a',
+                },
+            },
+        );
+        let (mut doc, _) = apply(
+            &mut graph,
+            doc,
+            DocOp::MoveText {
+                entry: EntryDot(insert.id),
+                to_node_id: t2,
+                after: None,
+            },
+        );
+
+        doc.text.index.clear_moved_location(EntryDot(insert.id));
+
+        assert_eq!(doc.verify(), Err(ModelError::TextIndexDesync));
+    }
+}

--- a/crates/editor-model/src/error.rs
+++ b/crates/editor-model/src/error.rs
@@ -68,6 +68,12 @@ pub enum ModelError {
     #[error("parent/child desync: parent {parent:?}, child {child:?}")]
     ParentChildDesync { parent: NodeId, child: NodeId },
 
+    #[error("text projection desync at node {node_id:?}")]
+    TextProjectionDesync { node_id: NodeId },
+
+    #[error("text current-location index desync")]
+    TextIndexDesync,
+
     #[error("root uniqueness violation: count = {count}")]
     RootUniquenessViolation { count: usize },
 

--- a/crates/editor-model/src/lib.rs
+++ b/crates/editor-model/src/lib.rs
@@ -4,6 +4,7 @@ mod alignment;
 mod canonical;
 mod doc;
 mod doc_op;
+mod doc_text_store;
 mod entry;
 mod error;
 mod fragment;
@@ -16,6 +17,9 @@ mod plain;
 mod schema;
 mod style;
 mod subtree;
+mod text_entry_store;
+mod text_index;
+mod text_view;
 mod validate;
 
 #[cfg(any(test, feature = "test-utils"))]
@@ -38,6 +42,7 @@ pub use plain::*;
 pub use schema::*;
 pub use style::*;
 pub use subtree::*;
+pub use text_view::*;
 pub use validate::*;
 
 #[cfg(any(test, feature = "test-utils"))]

--- a/crates/editor-model/src/node_ref.rs
+++ b/crates/editor-model/src/node_ref.rs
@@ -9,6 +9,7 @@ use crate::id::NodeId;
 use crate::marker::Marker;
 use crate::modifier::{Modifier, ModifierType};
 use crate::nodes::{Node, NodeType};
+use crate::text_view::TextView;
 
 #[derive(Clone, Copy)]
 pub struct NodeRef<'a> {
@@ -37,6 +38,13 @@ impl<'a> NodeRef<'a> {
 
     pub fn node(&self) -> &'a Node {
         &self.entry().node
+    }
+
+    pub fn as_text(&self) -> Option<TextView<'a>> {
+        let Node::Text(text_node) = self.node() else {
+            return None;
+        };
+        Some(TextView::new(self.id, text_node))
     }
 
     pub fn marker(&self) -> Option<&'a Marker> {

--- a/crates/editor-model/src/nodes/text.rs
+++ b/crates/editor-model/src/nodes/text.rs
@@ -40,7 +40,7 @@ impl PlainTextNode {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use editor_crdt::{Dot, TextOp};
+    use editor_crdt::{Dot, EntryDot, PlacementId, TextPlacement};
 
     #[test]
     fn empty_text_node() {
@@ -52,16 +52,12 @@ mod tests {
     #[test]
     fn apply_insert_char_via_wrapper() {
         let mut t = TextNode::default();
-        t.text = t
-            .text
-            .apply(
-                Dot::new(1, 0),
-                TextOp::InsertChar {
-                    after: None,
-                    ch: 'a',
-                },
-            )
-            .unwrap();
+        let dot = Dot::new(1, 0);
+        t.text = Text::from_visible_placements([TextPlacement {
+            placement_id: PlacementId(dot),
+            entry_dot: EntryDot(dot),
+            ch: 'a',
+        }]);
         assert_eq!(t.text.len(), 1);
         assert_eq!(t.text.to_string(), "a");
     }

--- a/crates/editor-model/src/plain.rs
+++ b/crates/editor-model/src/plain.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-use editor_crdt::{Dot, LwwRegOp, OpGraph, OrMapOp, OrSetOp, RgaOp, TextOp, ToPlain};
+use editor_crdt::{Dot, LwwRegOp, OpGraph, OrMapOp, OrSetOp, PlacementId, RgaOp, TextOp, ToPlain};
 use editor_macros::ffi;
 use serde::{Deserialize, Serialize};
 
@@ -181,7 +181,7 @@ fn emit_node(
     }
 
     if let PlainNode::Text(PlainTextNode { text }) = &entry.node {
-        let mut prev: Option<Dot> = None;
+        let mut prev: Option<PlacementId> = None;
         for ch in text.chars() {
             let dot = apply_and_record(
                 graph,
@@ -191,7 +191,7 @@ fn emit_node(
                     op: TextOp::InsertChar { after: prev, ch },
                 },
             );
-            prev = Some(dot);
+            prev = Some(PlacementId(dot));
         }
     }
 

--- a/crates/editor-model/src/text_entry_store.rs
+++ b/crates/editor-model/src/text_entry_store.rs
@@ -1,0 +1,99 @@
+use editor_crdt::{EntryDot, PlacementId};
+
+use crate::id::NodeId;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct TextEntryMeta {
+    pub(crate) ch: char,
+    pub(crate) birth_node: NodeId,
+    pub(crate) initial_placement: PlacementId,
+}
+
+#[derive(Clone, Debug, PartialEq, Default)]
+pub(crate) struct TextEntryStore {
+    entry_meta: imbl::HashMap<EntryDot, TextEntryMeta>,
+    deleted_entries: imbl::HashMap<EntryDot, imbl::OrdSet<editor_crdt::Dot>>,
+}
+
+impl TextEntryStore {
+    pub(crate) fn register_insert(
+        &mut self,
+        entry_dot: EntryDot,
+        birth_node: NodeId,
+        initial_placement: PlacementId,
+        ch: char,
+    ) {
+        let meta = TextEntryMeta {
+            ch,
+            birth_node,
+            initial_placement,
+        };
+        if let Some(existing) = self.entry_meta.get(&entry_dot) {
+            debug_assert_eq!(existing, &meta);
+            return;
+        }
+        self.entry_meta.insert(entry_dot, meta);
+    }
+
+    pub(crate) fn char_for(&self, entry_dot: EntryDot) -> Option<char> {
+        self.entry_meta.get(&entry_dot).map(|meta| meta.ch)
+    }
+
+    pub(crate) fn birth_location_for(&self, entry_dot: EntryDot) -> Option<(NodeId, PlacementId)> {
+        self.entry_meta
+            .get(&entry_dot)
+            .map(|meta| (meta.birth_node, meta.initial_placement))
+    }
+
+    pub(crate) fn mark_deleted(&mut self, entry_dot: EntryDot, remove_dot: editor_crdt::Dot) {
+        self.deleted_entries
+            .entry(entry_dot)
+            .or_default()
+            .insert(remove_dot);
+    }
+
+    pub(crate) fn is_deleted(&self, entry_dot: EntryDot) -> bool {
+        self.deleted_entries
+            .get(&entry_dot)
+            .is_some_and(|dots| !dots.is_empty())
+    }
+
+    pub(crate) fn delete_horizon_for(&self, entry_dot: EntryDot) -> Option<editor_crdt::Dot> {
+        self.deleted_entries
+            .get(&entry_dot)
+            .and_then(|dots| dots.iter().next().copied())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn delete_dots_for(&self, entry_dot: EntryDot) -> Vec<editor_crdt::Dot> {
+        self.deleted_entries
+            .get(&entry_dot)
+            .map(|dots| dots.iter().copied().collect())
+            .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use editor_crdt::{Dot, EntryDot, PlacementId};
+
+    use crate::NodeId;
+
+    use super::TextEntryStore;
+
+    #[test]
+    fn deletion_tracks_remove_op_dots() {
+        let entry = EntryDot(Dot::new(1, 0));
+        let remove_a = Dot::new(2, 0);
+        let remove_b = Dot::new(3, 0);
+        let mut store = TextEntryStore::default();
+        store.register_insert(entry, NodeId::ROOT, PlacementId(entry.0), 'x');
+
+        store.mark_deleted(entry, remove_a);
+        store.mark_deleted(entry, remove_a);
+        store.mark_deleted(entry, remove_b);
+
+        assert!(store.is_deleted(entry));
+        assert_eq!(store.delete_dots_for(entry), vec![remove_a, remove_b]);
+    }
+}

--- a/crates/editor-model/src/text_index.rs
+++ b/crates/editor-model/src/text_index.rs
@@ -1,0 +1,83 @@
+use editor_crdt::{EntryDot, PlacementId};
+
+#[cfg(any(test, debug_assertions))]
+use crate::doc::Doc;
+use crate::id::NodeId;
+#[cfg(any(test, debug_assertions))]
+use crate::nodes::Node;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct CurrentTextLocation {
+    pub(crate) owner_text_node: NodeId,
+    pub(crate) placement: PlacementId,
+}
+
+#[derive(Clone, Debug, PartialEq, Default)]
+pub(crate) struct TextIndex {
+    moved_locations: imbl::HashMap<EntryDot, CurrentTextLocation>,
+}
+
+impl TextIndex {
+    #[cfg(any(test, debug_assertions))]
+    pub(crate) fn rebuild(doc: &Doc) -> Self {
+        let mut current_locations = imbl::HashMap::new();
+        for (node_id, entry) in doc.entries.iter() {
+            let Node::Text(_) = &entry.node else {
+                continue;
+            };
+            for placement in doc.text.all_placements_for_node(*node_id) {
+                if doc.text.is_deleted(placement.entry_dot) {
+                    continue;
+                }
+                let candidate = CurrentTextLocation {
+                    owner_text_node: *node_id,
+                    placement: placement.placement_id,
+                };
+                let should_replace = current_locations.get(&placement.entry_dot).is_none_or(
+                    |current: &CurrentTextLocation| candidate.placement.0 > current.placement.0,
+                );
+                if should_replace {
+                    current_locations.insert(placement.entry_dot, candidate);
+                }
+            }
+        }
+
+        let mut moved_locations = imbl::HashMap::new();
+        for (entry_dot, current) in current_locations {
+            let Some((birth_node, initial_placement)) = doc.text.birth_location_for(entry_dot)
+            else {
+                continue;
+            };
+            if current.owner_text_node != birth_node || current.placement != initial_placement {
+                moved_locations.insert(entry_dot, current);
+            }
+        }
+
+        Self { moved_locations }
+    }
+
+    pub(crate) fn moved_location(&self, entry_dot: EntryDot) -> Option<CurrentTextLocation> {
+        self.moved_locations.get(&entry_dot).copied()
+    }
+
+    pub(crate) fn set_current_location(
+        &mut self,
+        entry_dot: EntryDot,
+        birth_location: Option<(NodeId, PlacementId)>,
+        current: CurrentTextLocation,
+    ) {
+        let Some((birth_node, initial_placement)) = birth_location else {
+            return;
+        };
+
+        if current.owner_text_node == birth_node && current.placement == initial_placement {
+            self.clear_moved_location(entry_dot);
+        } else {
+            self.moved_locations.insert(entry_dot, current);
+        }
+    }
+
+    pub(crate) fn clear_moved_location(&mut self, entry_dot: EntryDot) {
+        self.moved_locations.remove(&entry_dot);
+    }
+}

--- a/crates/editor-model/src/text_view.rs
+++ b/crates/editor-model/src/text_view.rs
@@ -1,0 +1,127 @@
+use editor_crdt::{EntryDot, PlacementId, TextPlacement};
+
+use crate::doc::Doc;
+use crate::id::NodeId;
+use crate::nodes::{Node, TextNode};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TextEntryLocation {
+    pub node_id: NodeId,
+    pub placement_id: PlacementId,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct TextView<'a> {
+    id: NodeId,
+    node: &'a TextNode,
+}
+
+impl<'a> TextView<'a> {
+    pub(crate) fn new(id: NodeId, node: &'a TextNode) -> Self {
+        Self { id, node }
+    }
+
+    pub fn id(&self) -> NodeId {
+        self.id
+    }
+
+    pub fn node(&self) -> &'a TextNode {
+        self.node
+    }
+
+    pub fn text(&self) -> String {
+        self.node.text.to_string()
+    }
+
+    pub fn len(&self) -> usize {
+        self.node.text.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.node.text.is_empty()
+    }
+
+    pub fn visible_entries(&self) -> impl Iterator<Item = (EntryDot, char)> + '_ {
+        self.node.text.iter_visible_entries()
+    }
+
+    pub fn visible_placements(&self) -> impl Iterator<Item = TextPlacement> + '_ {
+        self.node.text.iter_visible_placements()
+    }
+
+    pub fn last_visible_placement(&self) -> Option<TextPlacement> {
+        self.visible_placements().last()
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct TextIdentityView<'a> {
+    doc: &'a Doc,
+}
+
+impl<'a> TextIdentityView<'a> {
+    pub(crate) fn new(doc: &'a Doc) -> Self {
+        Self { doc }
+    }
+
+    pub fn current_location(&self, entry_dot: EntryDot) -> Option<TextEntryLocation> {
+        self.doc
+            .text
+            .current_location(entry_dot)
+            .map(|location| TextEntryLocation {
+                node_id: location.owner_text_node,
+                placement_id: location.placement,
+            })
+    }
+
+    pub fn is_alive(&self, entry_dot: EntryDot) -> bool {
+        self.current_location(entry_dot).is_some_and(|location| {
+            self.visible_rank_of_placement(location.node_id, location.placement_id)
+                .is_some()
+        })
+    }
+
+    pub fn is_deleted(&self, entry_dot: EntryDot) -> bool {
+        self.doc.text.is_deleted(entry_dot)
+    }
+
+    pub fn visible_rank_of_placement(
+        &self,
+        node_id: NodeId,
+        placement_id: PlacementId,
+    ) -> Option<usize> {
+        let entry = self.doc.get_entry(node_id)?;
+        let Node::Text(text_node) = &entry.node else {
+            return None;
+        };
+        text_node.text.visible_rank_of_placement(placement_id)
+    }
+
+    pub fn visible_offset_before_deleted_entry(
+        &self,
+        entry_dot: EntryDot,
+    ) -> Option<(NodeId, usize)> {
+        let (node_id, offset) = self.doc.text.visible_offset_before_entry(entry_dot)?;
+        self.live_text_offset(node_id, offset)
+    }
+
+    pub fn visible_offset_after_deleted_entry(
+        &self,
+        entry_dot: EntryDot,
+    ) -> Option<(NodeId, usize)> {
+        let (node_id, offset) = self.doc.text.visible_offset_after_entry(entry_dot)?;
+        self.live_text_offset(node_id, offset)
+    }
+
+    pub fn char_for(&self, entry_dot: EntryDot) -> Option<char> {
+        self.doc.text.char_for(entry_dot)
+    }
+
+    fn live_text_offset(&self, node_id: NodeId, offset: usize) -> Option<(NodeId, usize)> {
+        let entry = self.doc.get_entry(node_id)?;
+        let Node::Text(text_node) = &entry.node else {
+            return None;
+        };
+        Some((node_id, offset.min(text_node.text.len())))
+    }
+}

--- a/crates/editor-model/tests/wire_proptest.rs
+++ b/crates/editor-model/tests/wire_proptest.rs
@@ -1,7 +1,7 @@
 //! Generated changesets exercise wire syntactic round-trip only; semantic validity
 //! (e.g. anchor NodeId existing in the doc) is not guaranteed by `arb_doc_op_sequence`.
 
-use editor_crdt::{Dot, OpGraph, OrMapOp, RgaOp, TextOp, wire};
+use editor_crdt::{Dot, OpGraph, OrMapOp, PlacementId, RgaOp, TextOp, wire};
 use editor_model::{DocOp, Modifier, ModifierType, NodeId, NodeType};
 use proptest::prelude::*;
 
@@ -25,7 +25,10 @@ fn arb_doc_op() -> impl Strategy<Value = DocOp> {
     prop_oneof![
         (any::<char>(), prop::option::of(arb_dot())).prop_map(|(ch, after)| DocOp::Text {
             node_id: NodeId::new(),
-            op: TextOp::InsertChar { after, ch },
+            op: TextOp::InsertChar {
+                after: after.map(PlacementId),
+                ch,
+            },
         }),
         Just(()).prop_map(|_| {
             let id = NodeId::new();

--- a/crates/editor-state/src/stable_position.rs
+++ b/crates/editor-state/src/stable_position.rs
@@ -1,4 +1,4 @@
-use editor_crdt::Dot;
+use editor_crdt::{Dot, EntryDot};
 use editor_macros::ffi;
 use editor_model::{Doc, Node, NodeId};
 use serde::{Deserialize, Serialize};
@@ -65,7 +65,7 @@ impl StablePosition {
     }
 
     /// Returns `Bind::Right` for `ContainerStart` (irrelevant; resolution is
-    /// unconditional offset 0).
+    /// unconditional offset 0 while the leaf is alive).
     pub fn bind(&self) -> Bind {
         match self {
             Self::Char { bind, .. } | Self::Child { bind, .. } => *bind,
@@ -82,22 +82,29 @@ pub(crate) fn freeze_position(pos: Position, doc: &Doc) -> StablePosition {
 
     match &entry.node {
         Node::Text(text) => {
-            if text.text.is_empty() || pos.offset == 0 {
+            if text.text.is_empty() {
                 StablePosition::ContainerStart {
                     chain,
                     affinity: pos.affinity,
                 }
             } else {
+                let (char_index, bind) = if pos.offset == 0 {
+                    (0, Bind::Left)
+                } else if pos.affinity == Affinity::Downstream && pos.offset < text.text.len() {
+                    (pos.offset, Bind::Left)
+                } else {
+                    (pos.offset - 1, Bind::Right)
+                };
                 let char_dot = text
                     .text
-                    .dot_at(pos.offset)
+                    .entry_dot_at(char_index)
                     .expect("freeze_position: offset within text bounds")
-                    .expect("freeze_position: dot_at within bounds yields Some");
+                    .0;
                 StablePosition::Char {
                     chain,
                     char_dot,
                     offset: pos.offset,
-                    bind: Bind::Right,
+                    bind,
                     affinity: pos.affinity,
                 }
             }
@@ -127,6 +134,13 @@ pub(crate) fn freeze_position(pos: Position, doc: &Doc) -> StablePosition {
 }
 
 pub(crate) fn thaw_position(sp: &StablePosition, doc: &Doc) -> Position {
+    if let Some(pos) = resolve_current_char_position(sp, doc) {
+        return pos;
+    }
+    if let Some(pos) = resolve_deleted_char_position(sp, doc) {
+        return pos;
+    }
+
     let chain = sp.chain();
     let mut live_idx: usize = 0;
     for (i, link) in chain.iter().enumerate() {
@@ -152,6 +166,30 @@ pub(crate) fn thaw_position(sp: &StablePosition, doc: &Doc) -> Position {
     }
 }
 
+fn resolve_current_char_position(sp: &StablePosition, doc: &Doc) -> Option<Position> {
+    let StablePosition::Char {
+        char_dot,
+        bind,
+        affinity,
+        ..
+    } = sp
+    else {
+        return None;
+    };
+    let text_identity = doc.text_identity();
+    let location = text_identity.current_location(EntryDot(*char_dot))?;
+    let rank = text_identity.visible_rank_of_placement(location.node_id, location.placement_id)?;
+    let offset = match bind {
+        Bind::Left => rank,
+        Bind::Right => rank + 1,
+    };
+    Some(Position {
+        node_id: location.node_id,
+        offset,
+        affinity: *affinity,
+    })
+}
+
 fn resolve_primary(sp: &StablePosition, doc: &Doc) -> Position {
     let leaf_id = sp.chain().last().expect("non-empty chain").node_id;
     let entry = doc.get_entry(leaf_id).expect("leaf alive");
@@ -164,7 +202,21 @@ fn resolve_primary(sp: &StablePosition, doc: &Doc) -> Position {
             ..
         } => match &entry.node {
             Node::Text(text) => {
-                resolve_dot_in_text(&text.text, *char_dot, *offset, *bind, leaf_id, *affinity)
+                if doc.text_identity().is_deleted(EntryDot(*char_dot)) {
+                    return Position {
+                        node_id: leaf_id,
+                        offset: (*offset).min(text.text.len()),
+                        affinity: *affinity,
+                    };
+                }
+                resolve_dot_in_text(
+                    &text.text,
+                    EntryDot(*char_dot),
+                    *offset,
+                    *bind,
+                    leaf_id,
+                    *affinity,
+                )
             }
             _ => Position {
                 node_id: leaf_id,
@@ -201,23 +253,38 @@ fn resolve_primary(sp: &StablePosition, doc: &Doc) -> Position {
     }
 }
 
+fn resolve_deleted_char_position(sp: &StablePosition, doc: &Doc) -> Option<Position> {
+    let StablePosition::Char {
+        char_dot,
+        bind,
+        affinity,
+        ..
+    } = sp
+    else {
+        return None;
+    };
+    let entry_dot = EntryDot(*char_dot);
+    if !doc.text_identity().is_deleted(entry_dot) {
+        return None;
+    }
+    let (node_id, offset) = deleted_text_entry_offset(doc, entry_dot, *bind)?;
+    Some(Position {
+        node_id,
+        offset,
+        affinity: *affinity,
+    })
+}
+
 fn resolve_dot_in_text(
     text: &editor_crdt::Text,
-    dot: editor_crdt::Dot,
+    entry_dot: EntryDot,
     fallback_offset: usize,
     bind: Bind,
     node_id: NodeId,
     aff: Affinity,
 ) -> Position {
     let fallback = fallback_offset.min(text.len());
-    if !text.contains_dot(dot) {
-        return Position {
-            node_id,
-            offset: fallback,
-            affinity: aff,
-        };
-    }
-    match text.live_offset_of(dot) {
+    match text.visible_offset_of_entry(entry_dot) {
         Some(off) => {
             let offset = match bind {
                 Bind::Left => off,
@@ -229,20 +296,26 @@ fn resolve_dot_in_text(
                 affinity: aff,
             }
         }
-        None => {
-            let offset = match bind {
-                Bind::Right => text.next_live_offset_after(dot).unwrap_or(fallback),
-                Bind::Left => text
-                    .prev_live_offset_before(dot)
-                    .map(|o| o + 1)
-                    .unwrap_or(fallback),
-            };
-            Position {
-                node_id,
-                offset,
-                affinity: aff,
-            }
-        }
+        None => Position {
+            node_id,
+            offset: fallback,
+            affinity: aff,
+        },
+    }
+}
+
+fn deleted_text_entry_offset(
+    doc: &Doc,
+    entry_dot: EntryDot,
+    bind: Bind,
+) -> Option<(NodeId, usize)> {
+    match bind {
+        Bind::Left => doc
+            .text_identity()
+            .visible_offset_before_deleted_entry(entry_dot),
+        Bind::Right => doc
+            .text_identity()
+            .visible_offset_after_deleted_entry(entry_dot),
     }
 }
 
@@ -387,17 +460,26 @@ mod tests {
     }
 
     #[test]
-    fn freeze_offset_zero_text_yields_container_start() {
+    fn freeze_offset_zero_text_yields_char_left_on_first_char() {
         use editor_macros::doc;
         let (doc, t1) = doc! { root { paragraph { t1: text("hi") } } };
         let pos = crate::Position::new(t1, 0);
         let sp = super::freeze_position(pos, &doc);
-        assert!(matches!(sp, StablePosition::ContainerStart { .. }));
+        let StablePosition::Char { char_dot, bind, .. } = &sp else {
+            panic!("expected Char");
+        };
+        assert_eq!(*bind, Bind::Left);
+        let entry = doc.get_entry(t1).unwrap();
+        let text = match &entry.node {
+            editor_model::Node::Text(t) => t,
+            _ => panic!("t1 must be a Text node"),
+        };
+        assert_eq!(*char_dot, text.text.entry_dot_at(0).unwrap().0);
         assert_eq!(sp.chain().last().unwrap().node_id, t1);
     }
 
     #[test]
-    fn freeze_offset_one_text_yields_char_right_on_first_char() {
+    fn freeze_text_interior_downstream_yields_char_left_on_following_char() {
         use editor_macros::doc;
         let (doc, t1) = doc! { root { paragraph { t1: text("hi") } } };
         let pos = crate::Position::new(t1, 1);
@@ -410,13 +492,13 @@ mod tests {
                 ..
             } => {
                 assert_eq!(chain.last().unwrap().node_id, t1);
-                assert_eq!(bind, Bind::Right);
+                assert_eq!(bind, Bind::Left);
                 let entry = doc.get_entry(t1).unwrap();
                 let text = match &entry.node {
                     editor_model::Node::Text(t) => t,
                     _ => panic!("t1 must be a Text node"),
                 };
-                assert_eq!(char_dot, text.text.dot_at(1).unwrap().unwrap());
+                assert_eq!(char_dot, text.text.entry_dot_at(1).unwrap().0);
             }
             other => panic!("expected Char, got {:?}", other),
         }
@@ -484,7 +566,7 @@ mod tests {
     }
 
     #[test]
-    fn thaw_char_dot_tombstoned_walks_to_nearest_live_in_bind_direction() {
+    fn thaw_position_bound_to_surviving_char_tracks_it_after_previous_char_delete() {
         use editor_macros::state;
         let (state, t1) = state! {
             doc { root { paragraph { t1: text("abc") } } }
@@ -493,25 +575,396 @@ mod tests {
         let pos = crate::Position::new(t1, 2);
         let sp = super::freeze_position(pos, &state.doc);
 
-        // Rga::dot_at(N) yields the entry at iter position N-1; offset 0 is the
-        // "before first" sentinel returning None. dot_at(2) targets 'b'.
+        // offset 2 with downstream affinity binds to the left side of 'c'.
         let b_dot = {
             let entry = state.doc.get_entry(t1).unwrap();
             let text = match &entry.node {
                 editor_model::Node::Text(t) => t,
                 _ => unreachable!(),
             };
-            text.text.dot_at(2).unwrap().unwrap()
+            let StablePosition::Char { char_dot, bind, .. } = &sp else {
+                panic!("expected Char");
+            };
+            assert_eq!(*char_dot, text.text.entry_dot_at(2).unwrap().0);
+            assert_eq!(*bind, crate::Bind::Left);
+            text.text.entry_dot_at(1).unwrap().0
         };
         let (state, _op) = state
             .apply(editor_model::DocOp::Text {
                 node_id: t1,
-                op: editor_crdt::TextOp::RemoveChar { observed: b_dot },
+                op: editor_crdt::TextOp::RemoveChar {
+                    observed: EntryDot(b_dot),
+                },
             })
             .unwrap();
 
         let back = super::thaw_position(&sp, &state.doc);
         assert_eq!(back.node_id, t1);
+        assert_eq!(back.offset, 1);
+    }
+
+    #[test]
+    fn thaw_deleted_left_bound_char_uses_previous_visible_boundary() {
+        use editor_macros::state;
+        let (state, t1) = state! {
+            doc { root { paragraph { t1: text("abc") } } }
+            selection: (t1, 0)
+        };
+        let pos = crate::Position {
+            node_id: t1,
+            offset: 1,
+            affinity: crate::Affinity::Downstream,
+        };
+        let sp = super::freeze_position(pos, &state.doc);
+
+        let b_dot = {
+            let entry = state.doc.get_entry(t1).unwrap();
+            let text = match &entry.node {
+                editor_model::Node::Text(t) => t,
+                _ => unreachable!(),
+            };
+            let StablePosition::Char { char_dot, bind, .. } = &sp else {
+                panic!("expected Char");
+            };
+            assert_eq!(*char_dot, text.text.entry_dot_at(1).unwrap().0);
+            assert_eq!(*bind, crate::Bind::Left);
+            *char_dot
+        };
+        let (state, _op) = state
+            .apply(editor_model::DocOp::Text {
+                node_id: t1,
+                op: editor_crdt::TextOp::RemoveChar {
+                    observed: EntryDot(b_dot),
+                },
+            })
+            .unwrap();
+
+        let back = super::thaw_position(&sp, &state.doc);
+        assert_eq!(back.node_id, t1);
+        assert_eq!(back.offset, 1);
+    }
+
+    #[test]
+    fn thaw_deleted_right_bound_char_uses_next_visible_boundary() {
+        use editor_macros::state;
+        let (state, t1) = state! {
+            doc { root { paragraph { t1: text("abc") } } }
+            selection: (t1, 0)
+        };
+        let pos = crate::Position {
+            node_id: t1,
+            offset: 2,
+            affinity: crate::Affinity::Upstream,
+        };
+        let sp = super::freeze_position(pos, &state.doc);
+
+        let b_dot = {
+            let entry = state.doc.get_entry(t1).unwrap();
+            let text = match &entry.node {
+                editor_model::Node::Text(t) => t,
+                _ => unreachable!(),
+            };
+            let StablePosition::Char { char_dot, bind, .. } = &sp else {
+                panic!("expected Char");
+            };
+            assert_eq!(*char_dot, text.text.entry_dot_at(1).unwrap().0);
+            assert_eq!(*bind, crate::Bind::Right);
+            *char_dot
+        };
+        let (state, _op) = state
+            .apply(editor_model::DocOp::Text {
+                node_id: t1,
+                op: editor_crdt::TextOp::RemoveChar {
+                    observed: EntryDot(b_dot),
+                },
+            })
+            .unwrap();
+
+        let back = super::thaw_position(&sp, &state.doc);
+        assert_eq!(back.node_id, t1);
+        assert_eq!(back.offset, 1);
+    }
+
+    #[test]
+    fn thaw_deleted_left_bound_char_ignores_post_delete_move() {
+        use editor_crdt::TextOp;
+        use editor_macros::state;
+        use editor_model::DocOp;
+
+        let (state, t1, t2) = state! {
+            doc {
+                root {
+                    paragraph { t1: text("abc") }
+                    paragraph { t2: text("x") }
+                }
+            }
+            selection: (t1, 0)
+        };
+        let pos = crate::Position {
+            node_id: t1,
+            offset: 1,
+            affinity: crate::Affinity::Downstream,
+        };
+        let sp = super::freeze_position(pos, &state.doc);
+        let b_dot = match &sp {
+            StablePosition::Char { char_dot, bind, .. } => {
+                assert_eq!(*bind, crate::Bind::Left);
+                *char_dot
+            }
+            other => panic!("expected char stable position, got {other:?}"),
+        };
+        let t2_tail = state
+            .doc
+            .text_view(t2)
+            .unwrap()
+            .last_visible_placement()
+            .unwrap()
+            .placement_id;
+
+        let (state, _) = state
+            .apply(DocOp::Text {
+                node_id: t1,
+                op: TextOp::RemoveChar {
+                    observed: EntryDot(b_dot),
+                },
+            })
+            .unwrap();
+        let (state, _) = state
+            .apply(DocOp::MoveText {
+                entry: EntryDot(b_dot),
+                to_node_id: t2,
+                after: Some(t2_tail),
+            })
+            .unwrap();
+
+        assert_eq!(state.doc.text_view(t2).unwrap().text(), "x");
+        let back = super::thaw_position(&sp, &state.doc);
+        assert_eq!(back.node_id, t1);
+        assert_eq!(back.offset, 1);
+    }
+
+    #[test]
+    fn thaw_deleted_right_bound_char_ignores_post_delete_move() {
+        use editor_crdt::TextOp;
+        use editor_macros::state;
+        use editor_model::DocOp;
+
+        let (state, t1, t2) = state! {
+            doc {
+                root {
+                    paragraph { t1: text("abc") }
+                    paragraph { t2: text("x") }
+                }
+            }
+            selection: (t1, 0)
+        };
+        let pos = crate::Position {
+            node_id: t1,
+            offset: 2,
+            affinity: crate::Affinity::Upstream,
+        };
+        let sp = super::freeze_position(pos, &state.doc);
+        let b_dot = match &sp {
+            StablePosition::Char { char_dot, bind, .. } => {
+                assert_eq!(*bind, crate::Bind::Right);
+                *char_dot
+            }
+            other => panic!("expected char stable position, got {other:?}"),
+        };
+        let t2_tail = state
+            .doc
+            .text_view(t2)
+            .unwrap()
+            .last_visible_placement()
+            .unwrap()
+            .placement_id;
+
+        let (state, _) = state
+            .apply(DocOp::Text {
+                node_id: t1,
+                op: TextOp::RemoveChar {
+                    observed: EntryDot(b_dot),
+                },
+            })
+            .unwrap();
+        let (state, _) = state
+            .apply(DocOp::MoveText {
+                entry: EntryDot(b_dot),
+                to_node_id: t2,
+                after: Some(t2_tail),
+            })
+            .unwrap();
+
+        assert_eq!(state.doc.text_view(t2).unwrap().text(), "x");
+        let back = super::thaw_position(&sp, &state.doc);
+        assert_eq!(back.node_id, t1);
+        assert_eq!(back.offset, 1);
+    }
+
+    #[test]
+    fn thaw_deleted_moved_char_uses_deleted_text_fallback_when_original_leaf_dead() {
+        use editor_crdt::TextOp;
+        use editor_macros::state;
+        use editor_model::DocOp;
+
+        let (state, p1, t1, t2) = state! {
+            doc {
+                root {
+                    p1: paragraph { t1: text("ab") }
+                    paragraph { t2: text("x") }
+                }
+            }
+            selection: (t1, 0)
+        };
+        let pos = crate::Position {
+            node_id: t1,
+            offset: 1,
+            affinity: crate::Affinity::Downstream,
+        };
+        let sp = super::freeze_position(pos, &state.doc);
+        let b_dot = match &sp {
+            StablePosition::Char { char_dot, bind, .. } => {
+                assert_eq!(*bind, crate::Bind::Left);
+                *char_dot
+            }
+            other => panic!("expected char stable position, got {other:?}"),
+        };
+        let t2_tail = state
+            .doc
+            .text_view(t2)
+            .unwrap()
+            .last_visible_placement()
+            .unwrap()
+            .placement_id;
+
+        let (state, _) = state
+            .apply(DocOp::MoveText {
+                entry: EntryDot(b_dot),
+                to_node_id: t2,
+                after: Some(t2_tail),
+            })
+            .unwrap();
+        let (state, _) = state
+            .apply(DocOp::Text {
+                node_id: t2,
+                op: TextOp::RemoveChar {
+                    observed: EntryDot(b_dot),
+                },
+            })
+            .unwrap();
+        let state = remove_node(&state, p1);
+
+        let back = super::thaw_position(&sp, &state.doc);
+        assert_eq!(back.node_id, t2);
+        assert_eq!(back.offset, 1);
+    }
+
+    #[test]
+    fn thaw_deleted_moved_left_bound_at_target_start_stays_in_target() {
+        use editor_crdt::TextOp;
+        use editor_macros::state;
+        use editor_model::DocOp;
+
+        let (state, p1, t1, t2) = state! {
+            doc {
+                root {
+                    p1: paragraph { t1: text("a") }
+                    paragraph { t2: text("") }
+                }
+            }
+            selection: (t1, 0)
+        };
+        let pos = crate::Position {
+            node_id: t1,
+            offset: 0,
+            affinity: crate::Affinity::Downstream,
+        };
+        let sp = super::freeze_position(pos, &state.doc);
+        let a_dot = match &sp {
+            StablePosition::Char { char_dot, bind, .. } => {
+                assert_eq!(*bind, crate::Bind::Left);
+                *char_dot
+            }
+            other => panic!("expected char stable position, got {other:?}"),
+        };
+
+        let (state, _) = state
+            .apply(DocOp::MoveText {
+                entry: EntryDot(a_dot),
+                to_node_id: t2,
+                after: None,
+            })
+            .unwrap();
+        let (state, _) = state
+            .apply(DocOp::Text {
+                node_id: t2,
+                op: TextOp::RemoveChar {
+                    observed: EntryDot(a_dot),
+                },
+            })
+            .unwrap();
+        let state = remove_node(&state, p1);
+
+        let back = super::thaw_position(&sp, &state.doc);
+        assert_eq!(back.node_id, t2);
+        assert_eq!(back.offset, 0);
+    }
+
+    #[test]
+    fn thaw_deleted_moved_right_bound_at_target_end_stays_in_target() {
+        use editor_crdt::TextOp;
+        use editor_macros::state;
+        use editor_model::DocOp;
+
+        let (state, p1, t1, t2) = state! {
+            doc {
+                root {
+                    p1: paragraph { t1: text("a") }
+                    paragraph { t2: text("x") }
+                }
+            }
+            selection: (t1, 0)
+        };
+        let pos = crate::Position {
+            node_id: t1,
+            offset: 1,
+            affinity: crate::Affinity::Upstream,
+        };
+        let sp = super::freeze_position(pos, &state.doc);
+        let a_dot = match &sp {
+            StablePosition::Char { char_dot, bind, .. } => {
+                assert_eq!(*bind, crate::Bind::Right);
+                *char_dot
+            }
+            other => panic!("expected char stable position, got {other:?}"),
+        };
+        let t2_tail = state
+            .doc
+            .text_view(t2)
+            .unwrap()
+            .last_visible_placement()
+            .unwrap()
+            .placement_id;
+
+        let (state, _) = state
+            .apply(DocOp::MoveText {
+                entry: EntryDot(a_dot),
+                to_node_id: t2,
+                after: Some(t2_tail),
+            })
+            .unwrap();
+        let (state, _) = state
+            .apply(DocOp::Text {
+                node_id: t2,
+                op: TextOp::RemoveChar {
+                    observed: EntryDot(a_dot),
+                },
+            })
+            .unwrap();
+        let state = remove_node(&state, p1);
+
+        let back = super::thaw_position(&sp, &state.doc);
+        assert_eq!(back.node_id, t2);
         assert_eq!(back.offset, 1);
     }
 
@@ -538,11 +991,63 @@ mod tests {
             StablePosition::Char { char_dot, .. } => *char_dot,
             other => panic!("expected Char, got {:?}", other),
         };
-        assert!(!doc2_text.text.contains_dot(sp_char_dot));
+        assert!(!doc2_text.text.contains_visible_entry(EntryDot(sp_char_dot)));
 
         let back = super::thaw_position(&sp, &doc2);
         assert_eq!(back.node_id, t1);
         assert_eq!(back.offset, 1);
+    }
+
+    #[test]
+    fn thaw_deleted_entry_with_fresh_replacement_falls_back_to_frozen_offset() {
+        use editor_crdt::TextOp;
+        use editor_macros::state;
+        use editor_model::DocOp;
+
+        let (state, t1) = state! {
+            doc { root { paragraph { t1: text("abc") } } }
+            selection: (t1, 0)
+        };
+        let pos = crate::Position {
+            node_id: t1,
+            offset: 2,
+            affinity: crate::Affinity::Downstream,
+        };
+        let sp = super::freeze_position(pos, &state.doc);
+        let char_dot = match &sp {
+            StablePosition::Char { char_dot, .. } => *char_dot,
+            other => panic!("expected char stable position, got {other:?}"),
+        };
+        let b_placement = {
+            let entry = state.doc.get_entry(t1).unwrap();
+            let text = match &entry.node {
+                editor_model::Node::Text(t) => t,
+                _ => unreachable!(),
+            };
+            text.text.placement_at_visible_offset(2).unwrap().unwrap()
+        };
+
+        let (state, _) = state
+            .apply(DocOp::Text {
+                node_id: t1,
+                op: TextOp::RemoveChar {
+                    observed: EntryDot(char_dot),
+                },
+            })
+            .unwrap();
+        let (state, _) = state
+            .apply(DocOp::Text {
+                node_id: t1,
+                op: TextOp::InsertChar {
+                    after: Some(b_placement),
+                    ch: 'c',
+                },
+            })
+            .unwrap();
+
+        let back = super::thaw_position(&sp, &state.doc);
+        assert_eq!(back.node_id, t1);
+        assert_eq!(back.offset, 2);
     }
 
     #[test]

--- a/crates/editor-state/tests/multi_replica_convergence.rs
+++ b/crates/editor-state/tests/multi_replica_convergence.rs
@@ -117,10 +117,10 @@ fn try_text_insert(state: &State, text_id: NodeId, ch: char, offset_hint: u8) ->
     let after = if offset == 0 {
         None
     } else {
-        // dot_at(0) is None (before-first-char); dot_at(k) is the dot at the
-        // boundary just after the k-th char — the natural anchor for an
-        // insert at offset k.
-        t.text.dot_at(offset).ok().flatten()
+        // placement_at_visible_offset(0) is None (before-first-char);
+        // placement_at_visible_offset(k) is the placement just before the
+        // insertion boundary at offset k.
+        t.text.placement_at_visible_offset(offset).ok().flatten()
     };
     Some(DocOp::Text {
         node_id: text_id,
@@ -138,7 +138,7 @@ fn try_text_remove(state: &State, text_id: NodeId, offset_hint: u8) -> Option<Do
         return None;
     }
     let pick = (offset_hint as usize) % len;
-    let dot = t.text.dot_at(pick + 1).ok().flatten()?;
+    let dot = t.text.entry_dot_at(pick).ok()?;
     Some(DocOp::Text {
         node_id: text_id,
         op: TextOp::RemoveChar { observed: dot },

--- a/crates/editor-transaction/src/steps/insert_subtree.rs
+++ b/crates/editor-transaction/src/steps/insert_subtree.rs
@@ -1,4 +1,4 @@
-use editor_crdt::{CrdtError, Dot, LwwRegOp, OrMapOp, RgaOp, TextOp};
+use editor_crdt::{CrdtError, Dot, LwwRegOp, OrMapOp, PlacementId, RgaOp, TextOp};
 use editor_model::{DocOp, NodeId, PlainNode, Subtree};
 use editor_state::BatchedState;
 
@@ -92,7 +92,7 @@ fn emit_pass1(batched: &mut BatchedState, subtree: &Subtree) -> Result<(), StepE
         })?;
     }
     if let PlainNode::Text(text_node) = &subtree.node {
-        let mut after: Option<Dot> = None;
+        let mut after: Option<PlacementId> = None;
         for ch in text_node.text.chars() {
             let op_id = batched
                 .apply(DocOp::Text {
@@ -100,7 +100,7 @@ fn emit_pass1(batched: &mut BatchedState, subtree: &Subtree) -> Result<(), StepE
                     op: TextOp::InsertChar { ch, after },
                 })?
                 .id;
-            after = Some(op_id);
+            after = Some(PlacementId(op_id));
         }
     }
     for child in &subtree.children {

--- a/crates/editor-transaction/src/steps/insert_text.rs
+++ b/crates/editor-transaction/src/steps/insert_text.rs
@@ -1,4 +1,4 @@
-use editor_crdt::{CrdtError, Dot, TextOp};
+use editor_crdt::{CrdtError, PlacementId, TextOp};
 use editor_model::{DocOp, Node, NodeId};
 use editor_state::BatchedState;
 
@@ -20,7 +20,7 @@ pub(crate) fn apply_to(
     text: &str,
 ) -> Result<(), StepError> {
     // Read: anchor dot at offset
-    let mut after: Option<Dot> = {
+    let mut after: Option<PlacementId> = {
         let entry = batched
             .doc
             .get_entry(node_id)
@@ -28,14 +28,17 @@ pub(crate) fn apply_to(
         let Node::Text(text_node) = &entry.node else {
             return Err(StepError::ExpectedTextNode(node_id));
         };
-        text_node.text.dot_at(offset).map_err(|e| match e {
-            CrdtError::OffsetOutOfBounds { offset, len } => StepError::OffsetOutOfBounds {
-                node_id,
-                offset,
-                len,
-            },
-            other => panic!("dot_at unexpected error: {other:?}"),
-        })?
+        text_node
+            .text
+            .placement_before_offset(offset)
+            .map_err(|e| match e {
+                CrdtError::OffsetOutOfBounds { offset, len } => StepError::OffsetOutOfBounds {
+                    node_id,
+                    offset,
+                    len,
+                },
+                other => panic!("placement_before_offset unexpected error: {other:?}"),
+            })?
     };
 
     // Sequential apply, chaining each emitted dot as the next `after`
@@ -46,7 +49,7 @@ pub(crate) fn apply_to(
                 op: TextOp::InsertChar { ch, after },
             })?
             .id;
-        after = Some(op_id);
+        after = Some(PlacementId(op_id));
     }
 
     validations.push(Validation::Node(node_id));

--- a/crates/editor-transaction/src/steps/merge_node.rs
+++ b/crates/editor-transaction/src/steps/merge_node.rs
@@ -1,4 +1,4 @@
-use editor_crdt::{Dot, LwwRegOp, OrMapOp, RgaOp, TextOp};
+use editor_crdt::{Dot, EntryDot, LwwRegOp, OrMapOp, PlacementId, RgaOp};
 use editor_model::{DocOp, Node, NodeId};
 use editor_state::BatchedState;
 
@@ -71,14 +71,24 @@ pub(crate) fn apply_to(
         }
 
         let target_end_dot: Option<Dot> = match &target_entry.node {
-            Node::Text(t) => t.text.iter_with_dot().last().map(|(d, _)| d),
+            Node::Text(_) => batched
+                .doc
+                .text_view(target_id)
+                .and_then(|text| text.last_visible_placement())
+                .map(|placement| placement.placement_id.0),
             _ => target_entry.children.iter_with_dot().last().map(|(d, _)| d),
         };
 
         let content_to_move = match &source_entry.node {
-            Node::Text(t) => {
-                let chars: Vec<(Dot, char)> = t.text.iter_with_dot().collect();
-                ContentMove::Text { chars }
+            Node::Text(_) => {
+                let entries: Vec<EntryDot> = batched
+                    .doc
+                    .text_view(node_id)
+                    .ok_or(StepError::ExpectedTextNode(node_id))?
+                    .visible_entries()
+                    .map(|(entry, _)| entry)
+                    .collect();
+                ContentMove::Text { entries }
             }
             _ => {
                 let children: Vec<(Dot, NodeId)> = source_entry
@@ -100,22 +110,17 @@ pub(crate) fn apply_to(
     };
 
     match content_to_move {
-        ContentMove::Text { chars } => {
-            let mut after = target_end_dot;
-            for (_, ch) in &chars {
+        ContentMove::Text { entries } => {
+            let mut after = target_end_dot.map(PlacementId);
+            for entry in entries {
                 let op_id = batched
-                    .apply(DocOp::Text {
-                        node_id: target_id,
-                        op: TextOp::InsertChar { ch: *ch, after },
+                    .apply(DocOp::MoveText {
+                        entry,
+                        to_node_id: target_id,
+                        after,
                     })?
                     .id;
-                after = Some(op_id);
-            }
-            for (target, _) in chars {
-                batched.apply(DocOp::Text {
-                    node_id,
-                    op: TextOp::RemoveChar { observed: target },
-                })?;
+                after = Some(PlacementId(op_id));
             }
         }
         ContentMove::Children { children } => {
@@ -167,7 +172,7 @@ pub(crate) fn apply_to(
 }
 
 enum ContentMove {
-    Text { chars: Vec<(Dot, char)> },
+    Text { entries: Vec<EntryDot> },
     Children { children: Vec<(Dot, NodeId)> },
 }
 
@@ -197,9 +202,22 @@ mod tests {
             target_id: t1,
             offset: 5,
         };
+        let source_entries: Vec<_> = state
+            .text(t2)
+            .text
+            .iter_visible_entries()
+            .map(|(entry, _)| entry)
+            .collect();
         let new_state = step.apply(&state).unwrap().state;
+        let target_entries: Vec<_> = new_state
+            .text(t1)
+            .text
+            .iter_visible_entries()
+            .map(|(entry, _)| entry)
+            .collect();
 
-        assert_eq!(new_state.text(t1).text.to_string(), "Hello World");
+        assert_eq!(new_state.doc.text_view(t1).unwrap().text(), "Hello World");
+        assert_eq!(&target_entries[5..], source_entries.as_slice());
         assert!(!new_state.has_node(t2));
         assert_eq!(new_state.node(p1).children().count(), 1);
     }

--- a/crates/editor-transaction/src/steps/remove_subtree.rs
+++ b/crates/editor-transaction/src/steps/remove_subtree.rs
@@ -66,11 +66,11 @@ pub(crate) fn apply_to(
         }
 
         if let Node::Text(text_node) = &entry.node {
-            for (target_dot, _) in text_node.text.iter_with_dot() {
+            for (target_entry, _) in text_node.text.iter_visible_entries() {
                 batched.apply(DocOp::Text {
                     node_id: *sub_id,
                     op: TextOp::RemoveChar {
-                        observed: target_dot,
+                        observed: target_entry,
                     },
                 })?;
             }

--- a/crates/editor-transaction/src/steps/remove_text.rs
+++ b/crates/editor-transaction/src/steps/remove_text.rs
@@ -1,4 +1,4 @@
-use editor_crdt::{CrdtError, Dot, TextOp};
+use editor_crdt::{CrdtError, EntryDot, TextOp};
 use editor_model::{DocOp, Node, NodeId};
 use editor_state::BatchedState;
 
@@ -21,8 +21,8 @@ pub(crate) fn apply_to(
 ) -> Result<(), StepError> {
     let len = text.chars().count();
 
-    // Read: collect target dots for offset..offset+len
-    let target_dots: Vec<Dot> = {
+    // Read: collect target entry dots for offset..offset+len
+    let target_dots: Vec<EntryDot> = {
         let entry = batched
             .doc
             .get_entry(node_id)
@@ -34,19 +34,14 @@ pub(crate) fn apply_to(
         for i in 0..len {
             let dot = text_node
                 .text
-                .dot_at(offset + i + 1)
+                .entry_dot_at(offset + i)
                 .map_err(|e| match e {
                     CrdtError::OffsetOutOfBounds { offset, len } => StepError::OffsetOutOfBounds {
                         node_id,
                         offset,
                         len,
                     },
-                    other => panic!("dot_at unexpected: {other:?}"),
-                })?
-                .ok_or_else(|| StepError::OffsetOutOfBounds {
-                    node_id,
-                    offset: offset + i + 1,
-                    len: text_node.text.len(),
+                    other => panic!("entry_dot_at unexpected: {other:?}"),
                 })?;
             dots.push(dot);
         }

--- a/crates/editor-transaction/src/steps/split_node.rs
+++ b/crates/editor-transaction/src/steps/split_node.rs
@@ -1,4 +1,4 @@
-use editor_crdt::{Dot, LwwRegOp, OrMapOp, RgaOp, TextOp};
+use editor_crdt::{Dot, EntryDot, LwwRegOp, OrMapOp, PlacementId, RgaOp};
 use editor_model::{DocOp, Modifier, Node, NodeAttr, NodeId};
 use editor_state::BatchedState;
 
@@ -42,8 +42,12 @@ pub(crate) fn apply_to(
             .ok_or(StepError::NodeNotFound(node_id))?;
 
         let content_split = match &entry.node {
-            Node::Text(text_node) => {
-                let len = text_node.text.len();
+            Node::Text(_) => {
+                let text = batched
+                    .doc
+                    .text_view(node_id)
+                    .ok_or(StepError::ExpectedTextNode(node_id))?;
+                let len = text.len();
                 if offset > len {
                     return Err(StepError::OffsetOutOfBounds {
                         node_id,
@@ -51,9 +55,12 @@ pub(crate) fn apply_to(
                         len,
                     });
                 }
-                let tail_chars: Vec<(Dot, char)> =
-                    text_node.text.iter_with_dot().skip(offset).collect();
-                ContentSplit::Text { tail_chars }
+                let tail_entries: Vec<EntryDot> = text
+                    .visible_entries()
+                    .skip(offset)
+                    .map(|(entry, _)| entry)
+                    .collect();
+                ContentSplit::Text { tail_entries }
             }
             _ => {
                 let children_count = entry.children.iter_with_dot().count();
@@ -129,22 +136,17 @@ pub(crate) fn apply_to(
         },
     })?;
     match content_split {
-        ContentSplit::Text { tail_chars } => {
-            for (target, _) in &tail_chars {
-                batched.apply(DocOp::Text {
-                    node_id,
-                    op: TextOp::RemoveChar { observed: *target },
-                })?;
-            }
-            let mut after: Option<Dot> = None;
-            for (_, ch) in tail_chars {
+        ContentSplit::Text { tail_entries } => {
+            let mut after: Option<PlacementId> = None;
+            for entry in tail_entries {
                 let op_id = batched
-                    .apply(DocOp::Text {
-                        node_id: new_node_id,
-                        op: TextOp::InsertChar { ch, after },
+                    .apply(DocOp::MoveText {
+                        entry,
+                        to_node_id: new_node_id,
+                        after,
                     })?
                     .id;
-                after = Some(op_id);
+                after = Some(PlacementId(op_id));
             }
         }
         ContentSplit::Children { tail_children } => {
@@ -183,7 +185,7 @@ pub(crate) fn apply_to(
 }
 
 enum ContentSplit {
-    Text { tail_chars: Vec<(Dot, char)> },
+    Text { tail_entries: Vec<EntryDot> },
     Children { tail_children: Vec<(Dot, NodeId)> },
 }
 
@@ -209,15 +211,29 @@ mod tests {
         };
 
         let t2 = NodeId::new();
+        let tail_entries: Vec<_> = state
+            .text(t1)
+            .text
+            .iter_visible_entries()
+            .skip(5)
+            .map(|(entry, _)| entry)
+            .collect();
         let step = Step::SplitNode {
             node_id: t1,
             offset: 5,
             new_node_id: t2,
         };
         let new_state = step.apply(&state).unwrap().state;
+        let moved_entries: Vec<_> = new_state
+            .text(t2)
+            .text
+            .iter_visible_entries()
+            .map(|(entry, _)| entry)
+            .collect();
 
-        assert_eq!(new_state.text(t1).text.to_string(), "Hello");
-        assert_eq!(new_state.text(t2).text.to_string(), " World");
+        assert_eq!(new_state.doc.text_view(t1).unwrap().text(), "Hello");
+        assert_eq!(new_state.doc.text_view(t2).unwrap().text(), " World");
+        assert_eq!(moved_entries, tail_entries);
         assert!(new_state.node(t2).modifiers().any(|m| *m == Modifier::Bold));
         assert_eq!(new_state.node(p1).children().count(), 2);
         let p1_children: Vec<NodeId> = new_state
@@ -380,7 +396,7 @@ mod tests {
         let state2 = step.apply(&state).unwrap().state;
         let state3 = step.inverse().apply(&state2).unwrap().state;
 
-        assert_eq!(state3.text(t1).text.to_string(), "Hello World");
+        assert_eq!(state3.doc.text_view(t1).unwrap().text(), "Hello World");
         assert!(!state3.has_node(t2));
     }
 }

--- a/crates/editor-transaction/src/transaction.rs
+++ b/crates/editor-transaction/src/transaction.rs
@@ -95,6 +95,8 @@ impl Transaction {
         self.ops.extend(ops);
         if let Step::SetSelection { new, .. } = &step {
             self.selection_stable = new.clone();
+        } else if step.is_doc_step() {
+            self.refresh_selection_from_stable();
         }
         self.steps.push(step);
         if validations.is_empty() {
@@ -106,6 +108,13 @@ impl Transaction {
             self.run_validations(&validations)?;
         }
         Ok(())
+    }
+
+    fn refresh_selection_from_stable(&mut self) {
+        self.state.selection = self
+            .selection_stable
+            .as_ref()
+            .map(|stable| stable.thaw(&self.state.doc));
     }
 
     pub fn savepoint(&self) -> Savepoint {
@@ -283,7 +292,12 @@ impl Transaction {
             .ok_or(StepError::NodeNotFound(target_id))?;
 
         let offset = match &target_entry.node {
-            Node::Text(t) => t.text.len(),
+            Node::Text(_) => self
+                .state
+                .doc
+                .text_view(target_id)
+                .map(|text| text.len())
+                .unwrap_or(0),
             _ => target_entry.children.len(),
         };
 
@@ -464,6 +478,7 @@ impl Transaction {
             }
         }
 
+        let has_doc_step = steps.iter().any(|step| step.is_doc_step());
         let mut validations: Vec<Validation> = Vec::new();
         let ops = self.state.batch_with_ops_mut::<_, StepError>(|batched| {
             for step in steps.iter() {
@@ -492,6 +507,9 @@ impl Transaction {
             if let Step::SetSelection { new, .. } = step {
                 self.selection_stable = new.clone();
             }
+        }
+        if has_doc_step && last_selection.is_none() {
+            self.refresh_selection_from_stable();
         }
         self.steps.extend(steps);
 
@@ -813,9 +831,41 @@ mod tests {
         let t2 = NodeId::new();
         tr.split_node(t1, 5, t2).unwrap();
 
-        assert_eq!(tr.doc().text(t1).text.to_string(), "Hello");
-        assert_eq!(tr.doc().text(t2).text.to_string(), " World");
+        assert_eq!(tr.doc().text_view(t1).unwrap().text(), "Hello");
+        assert_eq!(tr.doc().text_view(t2).unwrap().text(), " World");
         assert_eq!(tr.doc().get_entry(p1).unwrap().children.len(), 2);
+    }
+
+    #[test]
+    fn split_node_remaps_live_selection_without_selection_step() {
+        let (state, p1, t1) = state! {
+            doc { root { p1: paragraph { t1: text("aa") hard_break } } }
+            selection: (t1, 1, >) -> (p1, 2, <)
+        };
+
+        let mut tr = Transaction::new(&state);
+        let t2 = NodeId::new();
+        tr.split_node(t1, 1, t2).unwrap();
+
+        assert_eq!(
+            tr.selection(),
+            Some(Selection::new(
+                Position {
+                    node_id: t2,
+                    offset: 0,
+                    affinity: Affinity::Downstream,
+                },
+                Position {
+                    node_id: p1,
+                    offset: 3,
+                    affinity: Affinity::Upstream,
+                }
+            ))
+        );
+
+        let (_, steps, _, _, _) = tr.commit();
+        assert_eq!(steps.len(), 1);
+        assert!(matches!(&steps[0], Step::SplitNode { .. }));
     }
 
     #[test]
@@ -830,7 +880,7 @@ mod tests {
         tr.split_node(t1, 5, t2).unwrap();
         tr.merge_node(t2, t1).unwrap();
 
-        assert_eq!(tr.doc().text(t1).text.to_string(), "Hello World");
+        assert_eq!(tr.doc().text_view(t1).unwrap().text(), "Hello World");
         assert!(tr.doc().get_entry(t2).is_none());
         assert_eq!(tr.doc().get_entry(p1).unwrap().children.len(), 1);
 
@@ -840,6 +890,29 @@ mod tests {
             Step::MergeNode { offset, .. } => assert_eq!(*offset, 5),
             _ => panic!("expected MergeNode"),
         }
+    }
+
+    #[test]
+    fn merge_node_remaps_source_text_start_to_moved_content_start() {
+        let (state, t1, t2) = state! {
+            doc {
+                root {
+                    paragraph {
+                        t1: text("a")
+                        t2: text("b")
+                    }
+                }
+            }
+            selection: (t2, 0)
+        };
+
+        let mut tr = Transaction::new(&state);
+        tr.merge_node(t2, t1).unwrap();
+
+        assert_eq!(
+            tr.selection(),
+            Some(Selection::collapsed(Position::new(t1, 1)))
+        );
     }
 
     #[test]

--- a/crates/editor-view/src/measure/measurer.rs
+++ b/crates/editor-view/src/measure/measurer.rs
@@ -146,14 +146,34 @@ impl Measurer {
 }
 
 fn affected_node_ids_for_doc_op(op: &DocOp, old_doc: &Doc) -> Vec<NodeId> {
-    use editor_crdt::{LwwRegOp, OrMapOp, RgaOp};
+    use editor_crdt::{LwwRegOp, OrMapOp, RgaOp, TextOp};
     match op {
-        DocOp::Text { node_id, .. }
+        DocOp::Text {
+            node_id,
+            op: TextOp::InsertChar { .. },
+        }
         | DocOp::Modifier { node_id, .. }
         | DocOp::Attr { node_id, .. }
         | DocOp::NodeStyle { node_id, .. }
         | DocOp::NodeMarker { node_id, .. } => {
             vec![*node_id]
+        }
+        DocOp::Text {
+            op: TextOp::RemoveChar { observed },
+            ..
+        } => old_doc
+            .text_identity()
+            .current_location(*observed)
+            .map(|location| vec![location.node_id])
+            .unwrap_or_default(),
+        DocOp::MoveText {
+            entry, to_node_id, ..
+        } => {
+            let mut ids = vec![*to_node_id];
+            if let Some(old_location) = old_doc.text_identity().current_location(*entry) {
+                ids.push(old_location.node_id);
+            }
+            ids
         }
         DocOp::Style { style_id, .. } => old_doc
             .nodes_iter()
@@ -389,6 +409,65 @@ mod tests {
         assert!(
             measurer.cache.get(NodeId::ROOT).is_none(),
             "root should be invalidated"
+        );
+    }
+
+    #[test]
+    fn doc_ops_remove_char_invalidates_current_text_owner() {
+        use editor_crdt::TextOp;
+        use editor_macros::state;
+        use editor_model::DocOp;
+
+        let (state, t1, p2, t2) = state! {
+            doc {
+                root {
+                    paragraph { t1: text("a") }
+                    p2: paragraph { t2: text("") }
+                }
+            }
+            selection: (t1, 0)
+        };
+        let entry = state
+            .doc
+            .text_view(t1)
+            .unwrap()
+            .visible_entries()
+            .next()
+            .unwrap()
+            .0;
+        let (state, _) = state
+            .apply(DocOp::MoveText {
+                entry,
+                to_node_id: t2,
+                after: None,
+            })
+            .unwrap();
+        let old_doc = state.doc.clone();
+        let (state, remove_op) = state
+            .apply(DocOp::Text {
+                node_id: t1,
+                op: TextOp::RemoveChar { observed: entry },
+            })
+            .unwrap();
+
+        let mut measurer = Measurer::new_test();
+        measurer.cache.insert(NodeId::ROOT, dummy());
+        measurer.cache.insert(p2, dummy());
+        measurer.cache.insert(t2, dummy());
+
+        measurer.invalidate_with_doc_ops(&old_doc, &state.doc, &[remove_op]);
+
+        assert!(
+            measurer.cache.get(t2).is_none(),
+            "current text owner should be invalidated"
+        );
+        assert!(
+            measurer.cache.get(p2).is_none(),
+            "current owner ancestor should be invalidated"
+        );
+        assert!(
+            measurer.cache.get(NodeId::ROOT).is_none(),
+            "root should be invalidated through current owner ancestors"
         );
     }
 


### PR DESCRIPTION
## 변경사항

- doc-level `DocTextStore`를 추가해 text entry metadata, 삭제 상태, node별 placement history, current-location index를 관리
- text node 안의 `Text`는 더 이상 CRDT/history store가 아님. text node의 visible text는 derived projection임. (이제 doc-level store가 책임짐)
- Dot를 `EntryDot`과 `PlacementId`로 구별해서 사용함. 문자 identity와 placement identity를 구분. 이제 문자 하나가 move를 통해 여러 placement history를 가질 수 있기 때문에. selection/stable position은 EntryDot을 따라가지만, text node안의 순서/anchor는 PlacementId를 따라가야 함
- `DocOp::MoveText`를 추가해 기존 text entry를 다른 text node / 위치로 이동할 수 있도록 함
- split / merge가 text tail을 새 문자로 다시 만들지 않고 `MoveText`로 이동하도록 변경
- `StablePosition`이 text offset만이 아니라 `EntryDot + bind`를 기준으로 현재 text 위치를 다시 찾도록 변경
- transaction 적용 후 selection을 stable selection 기준으로 갱신하도록 정리
- command layer의 compact 후 selection offset fallback 경로 제거
- style range walker가 zero-width text range를 스타일 적용 대상으로 수집하지 않도록 정리

## 다음 이슈들을 해결함
- TR-255
- TR-259
- TR-260
- TR-261
- 코멘트 시작 위치에서 새로 입력한 텍스트가 코멘트 범위에 들어가지 않게 됨