### PR TITLE
stable selection, tracked range 계약 리팩토링

### DIFF
--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -72,7 +72,7 @@ export type AiFeedback = {
   category: string | null;
 };
 
-export type TrackedRangePosition = Pick<TrackedRange, 'anchor' | 'head' | 'invalid'>;
+export type TrackedRangePosition = Pick<TrackedRange, 'anchor' | 'head'>;
 
 let wasmInitPromise: Promise<void> | null = null;
 const VIEWPORT_RESIZE_DEBOUNCE_MS = 50;
@@ -85,7 +85,7 @@ const VIEWPORT_RESIZE_DEBOUNCE_MS = 50;
  * 넘기지 않도록 `live`를 가려서 전달한다. (TR-252)
  */
 export function pickMatchSelection(match: Selection, live?: TrackedRangePosition): Selection {
-  return live && !live.invalid ? { anchor: live.anchor, head: live.head } : match;
+  return live ? { anchor: live.anchor, head: live.head } : match;
 }
 
 function ensureWasmInitialized(): Promise<void> {
@@ -716,7 +716,7 @@ export class Editor {
 
   trackedItemRects(id: string): PageRect[] | null {
     const range = this.trackedRanges.find((r) => r.id === id);
-    if (!range || range.invalid) return null;
+    if (!range) return null;
     return range.rects.length > 0 ? range.rects : null;
   }
 
@@ -1220,14 +1220,12 @@ export class Editor {
     if (this.activeSpellcheckErrorId === id) return;
 
     const restoreToNormalGroup = (errorId: string) => {
-      const range = this.trackedRanges.find((r) => r.id === errorId);
-      if (!range || range.invalid) return;
+      if (!this.trackedRanges.some((r) => r.id === errorId)) return;
       this.enqueue({ type: 'tracked_range', op: { type: 'set_group', id: errorId, group: 'spellcheck' } });
     };
 
     const promoteToActiveGroup = (errorId: string): boolean => {
-      const range = this.trackedRanges.find((r) => r.id === errorId);
-      if (!range || range.invalid) return false;
+      if (!this.trackedRanges.some((r) => r.id === errorId)) return false;
       this.enqueue({ type: 'tracked_range', op: { type: 'set_group', id: errorId, group: 'spellcheck-active' } });
       return true;
     };
@@ -1403,8 +1401,7 @@ export class Editor {
   }
 
   isCommentLocatable(id: string): boolean {
-    const r = this.trackedRanges.find((x) => x.id === id);
-    return !!r && !r.invalid;
+    return this.trackedRanges.some((x) => x.id === id);
   }
 
   commentIdsAt(page: number, x: number, y: number): string[] {
@@ -1418,8 +1415,7 @@ export class Editor {
     if (this.activeCommentId === id) return;
 
     const move = (cid: string, group: 'comment' | 'comment-active'): boolean => {
-      const range = this.trackedRanges.find((r) => r.id === cid);
-      if (!range || range.invalid) return false;
+      if (!this.trackedRanges.some((r) => r.id === cid)) return false;
       this.enqueue({ type: 'tracked_range', op: { type: 'set_group', id: cid, group } });
       return true;
     };
@@ -1440,14 +1436,12 @@ export class Editor {
     if (this.activeAiFeedbackId === id) return;
 
     const restoreToNormalGroup = (feedbackId: string) => {
-      const range = this.trackedRanges.find((r) => r.id === feedbackId);
-      if (!range || range.invalid) return;
+      if (!this.trackedRanges.some((r) => r.id === feedbackId)) return;
       this.enqueue({ type: 'tracked_range', op: { type: 'set_group', id: feedbackId, group: 'ai-feedback' } });
     };
 
     const promoteToActiveGroup = (feedbackId: string): boolean => {
-      const range = this.trackedRanges.find((r) => r.id === feedbackId);
-      if (!range || range.invalid) return false;
+      if (!this.trackedRanges.some((r) => r.id === feedbackId)) return false;
       this.enqueue({ type: 'tracked_range', op: { type: 'set_group', id: feedbackId, group: 'ai-feedback-active' } });
       return true;
     };
@@ -1593,14 +1587,13 @@ export class Editor {
       const isStale = (e: SpellcheckError): boolean => {
         const r = rangeById.get(e.id);
         if (!r) return true;
-        if (r.invalid) return true;
         if (r.text !== e.context) return true;
         return false;
       };
 
       for (const e of this.spellcheckErrors) {
         const r = rangeById.get(e.id);
-        if (r && !r.invalid && r.text !== e.context) {
+        if (r && r.text !== e.context) {
           this.enqueue({ type: 'tracked_range', op: { type: 'remove', id: e.id } });
         }
       }
@@ -1613,7 +1606,7 @@ export class Editor {
 
       this.aiFeedbacks = this.aiFeedbacks.filter((f) => {
         const r = rangeById.get(f.id);
-        return r !== undefined && !r.invalid;
+        return r !== undefined;
       });
 
       if (this.activeAiFeedbackId !== null && !this.aiFeedbacks.some((f) => f.id === this.activeAiFeedbackId)) {

--- a/apps/website/src/lib/editor-ffi/search.test.ts
+++ b/apps/website/src/lib/editor-ffi/search.test.ts
@@ -7,11 +7,10 @@ const matchSelection = {
 } as const;
 
 describe('pickMatchSelection', () => {
-  it('uses the live range when it is valid (reflects positions shifted by edits)', () => {
+  it('uses the live range when it is present (reflects positions shifted by edits)', () => {
     const liveRange = {
       anchor: { node_id: 't1', offset: 10 },
       head: { node_id: 't1', offset: 12 },
-      invalid: false,
     };
     expect(pickMatchSelection(matchSelection, liveRange)).toEqual({
       anchor: liveRange.anchor,
@@ -23,14 +22,5 @@ describe('pickMatchSelection', () => {
     // TR-252: search() 직후엔 stale한 tracked range를 넘기지 않으려고 호출부가 live를 가린다.
     // 이때 검색으로 갓 계산한 match 위치를 그대로 써야 한다.
     expect(pickMatchSelection(matchSelection)).toEqual(matchSelection);
-  });
-
-  it('falls back to the match selection when the live range is invalid', () => {
-    const invalidLive = {
-      anchor: { node_id: 't1', offset: 2 },
-      head: { node_id: 't1', offset: 4 },
-      invalid: true,
-    };
-    expect(pickMatchSelection(matchSelection, invalidLive)).toEqual(matchSelection);
   });
 });

--- a/crates/editor-core/src/editor.rs
+++ b/crates/editor-core/src/editor.rs
@@ -10,7 +10,7 @@ use editor_state::{
     DocFlatExt, PendingModifier, Position, ResolvedPosition, ResolvedPositionFlatExt, Selection,
     StableSelection, State, closest_empty_paragraph_break_end_between, farther_endpoint,
 };
-use editor_transaction::{Effect, HistoryMeta, HistoryTag, Step, StepError, Transaction};
+use editor_transaction::{Effect, HistoryMeta, HistoryTag, StepError, Transaction};
 use editor_view::{GapPhantom, PageRect, PendingStyle, View, Viewport};
 use hashbrown::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
@@ -21,7 +21,7 @@ use crate::dnd::DndState;
 use crate::error::EditorError;
 use crate::event::{EditorEvent, FontData};
 use crate::handle;
-use crate::history::{History, HistoryPlayback};
+use crate::history::{History, HistoryPlaybackStep};
 use crate::ime::{Ime, ImeRange};
 use crate::message::*;
 use crate::state_field::StateField;
@@ -322,9 +322,6 @@ impl Editor {
 
         let mut scored: Vec<(usize, String, TrackedRangeHit)> = Vec::new();
         for range in iter {
-            if range.explicitly_invalid {
-                continue;
-            }
             let Some(sel) = range.locate(&self.state.doc) else {
                 continue;
             };
@@ -579,9 +576,6 @@ impl Editor {
                 continue;
             };
             if !group.enabled {
-                continue;
-            }
-            if range.explicitly_invalid {
                 continue;
             }
             let Some(sel) = range.locate(&self.state.doc) else {
@@ -979,11 +973,13 @@ impl Editor {
         self.history.last_tag()
     }
 
-    pub(crate) fn history_last_inverse_steps(&self) -> Option<Vec<Step>> {
-        self.history.last_inverse_steps()
+    pub(crate) fn history_last_inverse_playback_steps(
+        &self,
+    ) -> Option<Vec<crate::history::HistoryPlaybackStep>> {
+        self.history.last_inverse_playback_steps()
     }
 
-    pub(crate) fn try_undo(&mut self) -> Option<HistoryPlayback> {
+    pub(crate) fn try_undo(&mut self) -> Option<Vec<HistoryPlaybackStep>> {
         if let Mode::Probe { ref mut changed } = self.mode {
             *changed |= self.history.can_undo();
             return None;
@@ -991,7 +987,7 @@ impl Editor {
         self.history.undo()
     }
 
-    pub(crate) fn try_redo(&mut self) -> Option<HistoryPlayback> {
+    pub(crate) fn try_redo(&mut self) -> Option<Vec<HistoryPlaybackStep>> {
         if let Mode::Probe { ref mut changed } = self.mode {
             *changed |= self.history.can_redo();
             return None;
@@ -999,7 +995,7 @@ impl Editor {
         self.history.redo()
     }
 
-    pub(crate) fn try_undo_auto_replacement(&mut self) -> Option<HistoryPlayback> {
+    pub(crate) fn try_undo_auto_replacement(&mut self) -> Option<Vec<HistoryPlaybackStep>> {
         let is_auto = matches!(self.history.last_tag(), Some(HistoryTag::AutoReplacement));
         if !is_auto {
             return None;
@@ -1035,14 +1031,14 @@ impl Editor {
             .state
             .selection
             .as_ref()
-            .map(|s| StableSelection::freeze(s, &self.state.doc));
+            .map(|s| StableSelection::capture(s, &self.state.doc));
         let (mut next, applied_ops) = self
             .state
             .receive_remote_changeset(changeset)
             .map_err(|e| EditorError::Step(StepError::State(e)))?;
         next.selection = frozen.map(|f| {
-            let thawed = f.thaw(&next.doc);
-            thawed.normalize(&next.doc).unwrap_or(thawed)
+            let restored = f.restore(&next.doc);
+            restored.normalize(&next.doc).unwrap_or(restored)
         });
         self.state = next;
         if !applied_ops.is_empty() {
@@ -3783,7 +3779,7 @@ mod tests {
         let DndState::InternalDnd { ref source, .. } = editor.dnd else {
             panic!("expected InternalDnd");
         };
-        let sel = source.thaw(&editor.state.doc);
+        let sel = source.restore(&editor.state.doc);
 
         // Extract slice
         let mut state = editor.state().clone();
@@ -3819,7 +3815,7 @@ mod tests {
         }
 
         // Step 1: set_selection + delete_selection in separate transact
-        let stable_target = StableSelection::freeze(
+        let stable_target = StableSelection::capture(
             &Selection::collapsed(Position::new(NodeId::ROOT, 2)),
             &editor.state.doc,
         );
@@ -3835,7 +3831,7 @@ mod tests {
         }
 
         // Step 2: insert_slice_at in separate transact
-        let target = stable_target.thaw(&editor.state.doc).head;
+        let target = stable_target.restore(&editor.state.doc).head;
         eprintln!(
             "target position after deletion: node={:?} offset={}",
             target.node_id, target.offset
@@ -3880,7 +3876,7 @@ mod tests {
             let DndState::InternalDnd { ref source, .. } = editor.dnd.clone() else {
                 panic!("expected InternalDnd state");
             };
-            let sel = source.thaw(&editor.state.doc);
+            let sel = source.restore(&editor.state.doc);
             assert!(
                 !sel.is_collapsed(),
                 "source selection must not be collapsed"

--- a/crates/editor-core/src/handle/clipboard.rs
+++ b/crates/editor-core/src/handle/clipboard.rs
@@ -2,7 +2,7 @@ use editor_clipboard::Slice;
 use editor_commands::{self as commands};
 use editor_model::{Fragment, PlainNode};
 use editor_state::enclosing_table_cell;
-use editor_transaction::{HistoryMeta, HistoryTag};
+use editor_transaction::{HistoryMeta, HistoryTag, StepError, StepRecord, Transaction};
 
 use crate::editor::Editor;
 use crate::error::EditorError;
@@ -53,12 +53,22 @@ pub fn handle_clipboard_op(editor: &mut Editor, op: ClipboardOp) -> Result<(), E
                 return Ok(());
             };
             let plain_text = plain_text.clone();
-            let Some(inverse_steps) = editor.history_last_inverse_steps() else {
+            let Some(inverse_playback_steps) = editor.history_last_inverse_playback_steps() else {
                 return Ok(());
             };
+            let source_records: Vec<StepRecord> = inverse_playback_steps
+                .iter()
+                .rev()
+                .map(|step| step.source.clone())
+                .collect();
+            let inverse_steps = inverse_playback_steps
+                .into_iter()
+                .map(|step| step.step_to_apply)
+                .collect();
             let plain_slice = Slice::from_text(&plain_text);
             editor.transact(|tr| {
                 tr.apply_steps(inverse_steps)?;
+                let replacement_start = tr.step_records_len();
                 commands::chain!(
                     tr,
                     commands::optional!(commands::materialize_gap_paragraph()),
@@ -66,10 +76,33 @@ pub fn handle_clipboard_op(editor: &mut Editor, op: ClipboardOp) -> Result<(), E
                     commands::optional!(commands::delete_selection()),
                     |tr| commands::insert_slice(tr, plain_slice.clone()),
                 )?;
+                let replacement_records = tr.step_records_since(replacement_start).to_vec();
+                apply_repaste_as_text_remaps(tr, &source_records, &replacement_records)?;
                 Ok(())
             })
         }
     }
+}
+
+fn apply_repaste_as_text_remaps(
+    tr: &mut Transaction,
+    source_records: &[StepRecord],
+    replacement_records: &[StepRecord],
+) -> Result<(), StepError> {
+    let source_inserts: Vec<_> = source_records
+        .iter()
+        .flat_map(|record| record.effect.text_inserts.iter())
+        .collect();
+    let replacement_inserts: Vec<_> = replacement_records
+        .iter()
+        .flat_map(|record| record.effect.text_inserts.iter())
+        .collect();
+
+    super::history::apply_insert_effect_remaps(
+        tr,
+        source_inserts.iter().copied(),
+        replacement_inserts.iter().copied(),
+    )
 }
 
 fn is_cell_rect_selection(tr: &editor_transaction::Transaction) -> bool {
@@ -107,7 +140,7 @@ mod tests {
     use crate::state_field::StateField;
     use editor_macros::state;
     use editor_model::ModifierType;
-    use editor_state::{DocFlatExt, ResolvedPositionFlatExt, assert_state_eq};
+    use editor_state::{DocFlatExt, ResolvedPositionFlatExt, Selection, assert_state_eq};
     use editor_transaction::HistoryTag;
 
     use super::*;
@@ -958,6 +991,52 @@ mod tests {
             selection: (t3, 6)
         };
         editor_state::assert_state_eq!(editor.state(), &expected);
+    }
+
+    #[test]
+    fn repaste_as_text_remaps_tracked_range_on_pasted_text() {
+        let (s_source, ..) = state! {
+            doc { root { paragraph { t1: text("hello") [bold] } } }
+            selection: (t1, 0) -> (t1, 5)
+        };
+        let payload = Slice::extract(&s_source).unwrap().to_payload();
+
+        let (s_target, ..) = state! {
+            doc { root { paragraph { t2: text("Hi") } } }
+            selection: (t2, 1)
+        };
+        let mut editor = Editor::new_test(s_target);
+
+        editor.apply(Message::Clipboard {
+            op: ClipboardOp::Paste {
+                html: Some(payload.html),
+                text: payload.text,
+            },
+        });
+        let selection = editor.state().selection.unwrap();
+        let pasted = Selection::new(
+            editor_state::Position::new(selection.head.node_id, selection.head.offset - 5),
+            selection.head,
+        );
+        editor.apply(Message::TrackedRange {
+            op: TrackedRangeOp::Add {
+                id: "r".into(),
+                group: "comment".into(),
+                selection: pasted,
+                metadata: String::new(),
+            },
+        });
+
+        editor.apply(Message::Clipboard {
+            op: ClipboardOp::RepasteAsText,
+        });
+
+        let range = editor.tracked_ranges().get("r").expect("range present");
+        let resolved = range
+            .locate(&editor.state().doc)
+            .and_then(|sel| sel.resolve(&editor.state().doc))
+            .map(|resolved| resolved.collect_text());
+        assert_eq!(resolved.as_deref(), Some("hello"));
     }
 
     #[test]

--- a/crates/editor-core/src/handle/dnd.rs
+++ b/crates/editor-core/src/handle/dnd.rs
@@ -28,7 +28,7 @@ pub fn handle_dnd_op(editor: &mut Editor, op: DndOp) -> Result<(), EditorError> 
                 .map(|selection| snap_to_block_unit(&editor.state.doc, selection))
                 .filter(|selection| !selection.is_collapsed())
                 .map_or(DndState::Idle, |source| DndState::InternalDnd {
-                    source: StableSelection::freeze(&source, &editor.state.doc),
+                    source: StableSelection::capture(&source, &editor.state.doc),
                     drop_target: None,
                 });
             Ok(())
@@ -50,7 +50,7 @@ pub fn handle_dnd_op(editor: &mut Editor, op: DndOp) -> Result<(), EditorError> 
             modifiers,
         } => {
             let internal_source = if let DndState::InternalDnd { source, .. } = &editor.dnd {
-                let selection = source.thaw(&editor.state.doc);
+                let selection = source.restore(&editor.state.doc);
                 (!selection.is_collapsed()).then_some(selection)
             } else {
                 None
@@ -96,7 +96,7 @@ pub fn handle_dnd_op(editor: &mut Editor, op: DndOp) -> Result<(), EditorError> 
             payload, modifiers, ..
         } => {
             let internal_source = if let DndState::InternalDnd { source, .. } = &editor.dnd {
-                let selection = source.thaw(&editor.state.doc);
+                let selection = source.restore(&editor.state.doc);
                 (!selection.is_collapsed()).then_some(selection)
             } else {
                 None
@@ -358,12 +358,13 @@ fn drop_internal_selection_at(
         );
     }
 
-    let stable_target = StableSelection::freeze(&Selection::collapsed(position), &editor.state.doc);
+    let stable_target =
+        StableSelection::capture(&Selection::collapsed(position), &editor.state.doc);
     editor.transact(|tr| {
         commands::set_selection(tr, source)?;
         commands::delete_selection(tr)?;
 
-        let target = stable_target.thaw(&tr.doc()).head;
+        let target = stable_target.restore(&tr.doc()).head;
         if let Some(inserted_selection) = commands::insert_slice_at(tr, target, slice.clone())?
             && !inserted_selection.is_collapsed()
         {

--- a/crates/editor-core/src/handle/history.rs
+++ b/crates/editor-core/src/handle/history.rs
@@ -5,6 +5,7 @@ use editor_transaction::{
 
 use crate::editor::Editor;
 use crate::error::EditorError;
+use crate::history::HistoryPlaybackStep;
 use crate::message::*;
 
 pub fn handle_history_op(editor: &mut Editor, op: HistoryOp) -> Result<(), EditorError> {
@@ -15,7 +16,7 @@ pub fn handle_history_op(editor: &mut Editor, op: HistoryOp) -> Result<(), Edito
 
     if let Some(playback) = playback {
         editor.transact(|tr| {
-            apply_history_playback(tr, &playback.steps_to_apply, &playback.source_steps)?;
+            apply_history_playback(tr, &playback)?;
             Ok(())
         })?;
         // Redo re-applies the original tagged entry. Restore last_tag so that
@@ -29,58 +30,60 @@ pub fn handle_history_op(editor: &mut Editor, op: HistoryOp) -> Result<(), Edito
 
 pub(super) fn apply_history_playback(
     tr: &mut Transaction,
-    steps_to_apply: &[Step],
-    source_steps: &[StepRecord],
+    steps: &[HistoryPlaybackStep],
 ) -> Result<bool, StepError> {
     tr.update_meta(|m| m.history = HistoryMeta::Skip);
 
-    let doc_steps = history_playback_doc_steps(steps_to_apply);
-    let state_steps = history_playback_state_steps(steps_to_apply);
+    let doc_playback_steps = history_playback_doc_steps(steps);
+    let doc_steps = doc_playback_steps
+        .iter()
+        .map(|step| step.step_to_apply.clone())
+        .collect();
+    let state_steps = history_playback_state_steps(steps);
     let playback_steps = tr.apply_steps(doc_steps)?;
-    apply_stable_position_remaps_for_playback(tr, source_steps, &playback_steps)?;
-    // Stable selections in local state steps must thaw after remaps from the
+    apply_stable_position_remaps_for_playback(tr, &doc_playback_steps, &playback_steps)?;
+    // Stable selections in local state steps must restore after remaps from the
     // freshly replayed doc entries have been installed.
     tr.apply_steps(state_steps)?;
 
-    Ok(!steps_to_apply.is_empty())
+    Ok(!steps.is_empty())
 }
 
-fn history_playback_doc_steps(steps: &[Step]) -> Vec<Step> {
+fn history_playback_doc_steps(steps: &[HistoryPlaybackStep]) -> Vec<&HistoryPlaybackStep> {
     steps
         .iter()
-        .filter(|step| step.is_doc_step())
-        .cloned()
+        .filter(|step| step.step_to_apply.is_doc_step())
         .collect()
 }
 
-fn history_playback_state_steps(steps: &[Step]) -> Vec<Step> {
+fn history_playback_state_steps(steps: &[HistoryPlaybackStep]) -> Vec<Step> {
     steps
         .iter()
-        .filter(|step| !step.is_doc_step())
-        .cloned()
+        .filter(|step| !step.step_to_apply.is_doc_step())
+        .map(|step| step.step_to_apply.clone())
         .collect()
 }
 
 fn apply_stable_position_remaps_for_playback(
     tr: &mut Transaction,
-    source: &[StepRecord],
+    source: &[&HistoryPlaybackStep],
     playback_steps: &[StepRecord],
 ) -> Result<(), StepError> {
-    let source_text_steps = source.iter().filter(|record| has_text_effect(record));
-    let playback_text_steps = playback_steps
-        .iter()
-        .filter(|record| has_text_effect(record));
-    // TODO: history playback step을 pair로 들고 zip을 없앤다.
-    for (source_step, playback_step) in source_text_steps.zip(playback_text_steps) {
+    for idx in 0..source.len() {
+        let source_step = source[idx];
+        let playback_step = &playback_steps[idx];
+        if !has_text_effect(&source_step.source) || !has_text_effect(playback_step) {
+            continue;
+        }
         apply_remove_to_insert_remaps(
             tr,
-            &source_step.effect.text_removes,
-            &playback_step.effect.text_inserts,
+            source_step.source.effect.text_removes.iter(),
+            playback_step.effect.text_inserts.iter(),
         )?;
-        apply_insert_to_insert_remaps(
+        apply_insert_effect_remaps(
             tr,
-            &source_step.effect.text_inserts,
-            &playback_step.effect.text_inserts,
+            source_step.source.effect.text_inserts.iter(),
+            playback_step.effect.text_inserts.iter(),
         )?;
     }
     Ok(())
@@ -90,29 +93,40 @@ fn has_text_effect(record: &StepRecord) -> bool {
     !record.effect.text_inserts.is_empty() || !record.effect.text_removes.is_empty()
 }
 
-fn apply_remove_to_insert_remaps(
+fn apply_remove_to_insert_remaps<'a>(
     tr: &mut Transaction,
-    from_effects: &[TextRemoveEffect],
-    to_effects: &[TextInsertEffect],
+    from_effects: impl ExactSizeIterator<Item = &'a TextRemoveEffect>,
+    to_effects: impl ExactSizeIterator<Item = &'a TextInsertEffect>,
 ) -> Result<(), StepError> {
-    for (from, to) in from_effects.iter().zip(to_effects.iter()) {
+    if from_effects.len() != to_effects.len() {
+        return Ok(());
+    }
+
+    for (from, to) in from_effects.zip(to_effects) {
         apply_entry_remaps(tr, &from.entries, &from.text, &to.entries, &to.text)?;
     }
     Ok(())
 }
 
-fn apply_insert_to_insert_remaps(
+pub(super) fn apply_insert_effect_remaps<'a>(
     tr: &mut Transaction,
-    from_effects: &[TextInsertEffect],
-    to_effects: &[TextInsertEffect],
+    from_effects: impl ExactSizeIterator<Item = &'a TextInsertEffect>,
+    to_effects: impl ExactSizeIterator<Item = &'a TextInsertEffect>,
 ) -> Result<(), StepError> {
-    for (from, to) in from_effects.iter().zip(to_effects.iter()) {
+    // HistoryPlaybackStep pairs the semantic source step with the step applied
+    // during undo/redo. Text effects are still emitted independently by those
+    // applications; if their shape differs, entry mapping is ambiguous.
+    if from_effects.len() != to_effects.len() {
+        return Ok(());
+    }
+
+    for (from, to) in from_effects.zip(to_effects) {
         apply_entry_remaps(tr, &from.entries, &from.text, &to.entries, &to.text)?;
     }
     Ok(())
 }
 
-fn apply_entry_remaps(
+pub(super) fn apply_entry_remaps(
     tr: &mut Transaction,
     from_entries: &[EntryDot],
     from_text: &str,
@@ -136,9 +150,26 @@ mod tests_playback {
     use editor_crdt::EntryDot;
     use editor_macros::state;
     use editor_model::{NodeId, StableEntryResolution};
-    use editor_transaction::{HistoryMeta, Step, StepRecord, Transaction};
+    use editor_transaction::{
+        HistoryMeta, Step, StepEffect, StepRecord, TextInsertEffect, Transaction,
+    };
 
     use super::*;
+    use crate::history::HistoryPlaybackStep;
+
+    fn playback_step(source: StepRecord, step_to_apply: Step) -> HistoryPlaybackStep {
+        HistoryPlaybackStep {
+            source,
+            step_to_apply,
+        }
+    }
+
+    fn empty_record(step: Step) -> StepRecord {
+        StepRecord {
+            step,
+            effect: StepEffect::default(),
+        }
+    }
 
     #[test]
     fn applies_doc_steps_and_marks_history_skip() {
@@ -147,17 +178,15 @@ mod tests_playback {
             selection: (t, 1)
         };
         let mut tr = Transaction::new(&state);
+        let step = Step::InsertText {
+            node_id: t,
+            offset: 1,
+            text: "x".into(),
+        };
 
-        let changed = apply_history_playback(
-            &mut tr,
-            &[Step::InsertText {
-                node_id: t,
-                offset: 1,
-                text: "x".into(),
-            }],
-            &[],
-        )
-        .unwrap();
+        let changed =
+            apply_history_playback(&mut tr, &[playback_step(empty_record(step.clone()), step)])
+                .unwrap();
 
         assert!(changed);
         assert!(matches!(tr.meta().history, HistoryMeta::Skip));
@@ -171,8 +200,7 @@ mod tests_playback {
 
         apply_history_playback(
             &mut tr,
-            std::slice::from_ref(&source_step.step),
-            std::slice::from_ref(&source_step),
+            &[playback_step(source_step.clone(), source_step.step.clone())],
         )
         .unwrap();
 
@@ -195,20 +223,41 @@ mod tests_playback {
         let (state, t, source_step, old_x) = state_after_insert_then_remove();
         let mut tr = Transaction::new(&state);
 
-        apply_history_playback(
-            &mut tr,
-            &[Step::InsertText {
-                node_id: t,
-                offset: 1,
-                text: "y".into(),
-            }],
-            std::slice::from_ref(&source_step),
-        )
-        .unwrap();
+        let step = Step::InsertText {
+            node_id: t,
+            offset: 1,
+            text: "y".into(),
+        };
+        apply_history_playback(&mut tr, &[playback_step(source_step, step)]).unwrap();
 
         assert_eq!(
             tr.doc().text_identity().resolve_stable_entry(old_x),
             StableEntryResolution::Deleted(old_x)
+        );
+    }
+
+    #[test]
+    fn skips_insert_remaps_when_effect_counts_differ() {
+        let (state, t, old_a, old_b, source_effects) = state_after_two_inserts_then_remove();
+        let mut tr = Transaction::new(&state);
+
+        tr.insert_text(t, 0, "a").unwrap();
+        let replacement_effects: Vec<TextInsertEffect> = tr
+            .step_records_since(0)
+            .iter()
+            .flat_map(|record| record.effect.text_inserts.iter().cloned())
+            .collect();
+
+        apply_insert_effect_remaps(&mut tr, source_effects.iter(), replacement_effects.iter())
+            .unwrap();
+
+        assert_eq!(
+            tr.doc().text_identity().resolve_stable_entry(old_a),
+            StableEntryResolution::Deleted(old_a)
+        );
+        assert_eq!(
+            tr.doc().text_identity().resolve_stable_entry(old_b),
+            StableEntryResolution::Deleted(old_b)
         );
     }
 
@@ -229,6 +278,44 @@ mod tests_playback {
         assert_eq!(removed.doc.text_view(t).unwrap().text(), "a");
 
         (removed, t, insert_record, old_x)
+    }
+
+    fn state_after_two_inserts_then_remove() -> (
+        editor_state::State,
+        NodeId,
+        EntryDot,
+        EntryDot,
+        Vec<TextInsertEffect>,
+    ) {
+        let (initial, t) = state! {
+            doc { root { paragraph { t: text("") } } }
+            selection: (t, 0)
+        };
+
+        let mut insert_a_tr = Transaction::new(&initial);
+        insert_a_tr.insert_text(t, 0, "a").unwrap();
+        let (with_a, insert_a_records, ..) = insert_a_tr.commit();
+        let insert_a_effect = insert_a_records[0].effect.text_inserts[0].clone();
+        let old_a = insert_a_effect.entries[0];
+
+        let mut insert_b_tr = Transaction::new(&with_a);
+        insert_b_tr.insert_text(t, 1, "b").unwrap();
+        let (with_ab, insert_b_records, ..) = insert_b_tr.commit();
+        let insert_b_effect = insert_b_records[0].effect.text_inserts[0].clone();
+        let old_b = insert_b_effect.entries[0];
+
+        let mut remove_tr = Transaction::new(&with_ab);
+        remove_tr.remove_text(t, 0, 2).unwrap();
+        let (removed, ..) = remove_tr.commit();
+        assert_eq!(removed.doc.text_view(t).unwrap().text(), "");
+
+        (
+            removed,
+            t,
+            old_a,
+            old_b,
+            vec![insert_a_effect, insert_b_effect],
+        )
     }
 }
 

--- a/crates/editor-core/src/handle/key.rs
+++ b/crates/editor-core/src/handle/key.rs
@@ -15,11 +15,7 @@ pub fn handle_key_event(editor: &mut Editor, event: KeyEvent) -> Result<(), Edit
         && let Some(playback) = editor.try_undo_auto_replacement()
     {
         editor.transact(|tr| {
-            super::history::apply_history_playback(
-                tr,
-                &playback.steps_to_apply,
-                &playback.source_steps,
-            )?;
+            super::history::apply_history_playback(tr, &playback)?;
             Ok(())
         })?;
         return Ok(());

--- a/crates/editor-core/src/handle/remote.rs
+++ b/crates/editor-core/src/handle/remote.rs
@@ -284,11 +284,11 @@ mod tests {
         editor.receive_remote_changeset(cs);
         let _ = editor.tick().unwrap();
 
-        // handle_remote must normalize after thaw, expanding to the image (child[0]) node selection.
+        // handle_remote must normalize after restore, expanding to the image (child[0]) node selection.
         let sel = editor.state().selection.expect("selection exists in test");
         assert!(
             !sel.is_collapsed(),
-            "remote thaw must normalize collapsed-on-atom, got {:?}",
+            "remote restore must normalize collapsed-on-atom, got {:?}",
             sel
         );
         assert_eq!(

--- a/crates/editor-core/src/handle/selection.rs
+++ b/crates/editor-core/src/handle/selection.rs
@@ -33,7 +33,7 @@ pub fn handle_selection_op(editor: &mut Editor, op: SelectionOp) -> Result<(), E
         }),
         SelectionOp::SetFrozen { selection } => editor.transact(|tr| {
             tr.update_meta(|m| m.history = HistoryMeta::Skip);
-            let live = selection.thaw(&tr.doc());
+            let live = selection.restore(&tr.doc());
             commands::set_selection(tr, live)?;
             Ok(())
         }),
@@ -375,7 +375,7 @@ mod tests {
             selection: (t1, 0)
         };
         let target = Selection::collapsed(Position::new(t1, 3));
-        let frozen = StableSelection::freeze(&target, &state.doc);
+        let frozen = StableSelection::capture(&target, &state.doc);
         let mut editor = Editor::new_test(state);
         editor.apply(Message::Selection {
             op: SelectionOp::SetFrozen { selection: frozen },

--- a/crates/editor-core/src/handle/tracked_range.rs
+++ b/crates/editor-core/src/handle/tracked_range.rs
@@ -22,8 +22,8 @@ pub fn handle_tracked_range_op(editor: &mut Editor, op: TrackedRangeOp) -> Resul
                     msg: "TrackedRange::Add: selection must resolve against current doc".into(),
                 });
             }
-            let new_range =
-                TrackedRange::from_selection(id.clone(), group, selection, metadata, doc);
+            let selection = selection.capture(doc);
+            let new_range = TrackedRange::new(id.clone(), group, selection, metadata, doc);
             let would_change = editor
                 .tracked_ranges()
                 .get(&id)
@@ -40,8 +40,7 @@ pub fn handle_tracked_range_op(editor: &mut Editor, op: TrackedRangeOp) -> Resul
             metadata,
         } => {
             let doc = &editor.state().doc;
-            let new_range =
-                TrackedRange::from_stable_selection(id.clone(), group, selection, metadata, doc);
+            let new_range = TrackedRange::new(id.clone(), group, selection, metadata, doc);
             let would_change = editor
                 .tracked_ranges()
                 .get(&id)
@@ -158,12 +157,6 @@ fn classify_replace_text(
             selection: None,
         };
     };
-    if range.explicitly_invalid {
-        return ReplaceTextClassification {
-            outcome: TrackedRangeReplaceOutcome::Invalid,
-            selection: None,
-        };
-    }
     let Some(selection) = range.locate(&editor.state.doc) else {
         return ReplaceTextClassification {
             outcome: TrackedRangeReplaceOutcome::Invalid,
@@ -424,7 +417,7 @@ mod tests {
             selection: (t1, 1) -> (t1, 4)
         };
         let sel = state.selection.unwrap();
-        let stable = editor_state::StableSelection::freeze(&sel, &state.doc);
+        let stable = editor_state::StableSelection::capture(&sel, &state.doc);
         let mut editor = Editor::new_test(state);
         let events = editor.apply(add_frozen_op("a", stable));
         assert!(editor.tracked_ranges().contains("a"));
@@ -447,7 +440,7 @@ mod tests {
             selection: (t1, 1) -> (t1, 4)
         };
         let sel = state.selection.unwrap();
-        let stable = editor_state::StableSelection::freeze(&sel, &state.doc);
+        let stable = editor_state::StableSelection::capture(&sel, &state.doc);
         let mut editor = Editor::new_test(state);
         editor.apply(add_frozen_op("a", stable.clone()));
         let events = editor.apply(add_frozen_op("a", stable));
@@ -464,7 +457,7 @@ mod tests {
             selection: (t1, 1) -> (t1, 4)
         };
         let sel = state.selection.unwrap();
-        let stable = editor_state::StableSelection::freeze(&sel, &state.doc);
+        let stable = editor_state::StableSelection::capture(&sel, &state.doc);
 
         let mut a = Editor::new_test(state.clone());
         a.apply(add_op("r", sel));
@@ -482,7 +475,7 @@ mod tests {
             selection: (t1, 1) -> (t1, 4)
         };
         let sel = state.selection.unwrap();
-        let stable = editor_state::StableSelection::freeze(&sel, &state.doc);
+        let stable = editor_state::StableSelection::capture(&sel, &state.doc);
         assert_probe_predicts_apply(state, add_frozen_op("a", stable));
     }
 
@@ -493,7 +486,7 @@ mod tests {
             selection: (t1, 1) -> (t1, 4)
         };
         let sel = state.selection.unwrap();
-        let stable = editor_state::StableSelection::freeze(&sel, &state.doc);
+        let stable = editor_state::StableSelection::capture(&sel, &state.doc);
 
         let mut editor = Editor::new_test(state);
         editor.apply(add_frozen_op("a", stable.clone()));

--- a/crates/editor-core/src/history.rs
+++ b/crates/editor-core/src/history.rs
@@ -6,9 +6,10 @@ pub struct HistoryEntry {
     pub tag: Option<HistoryTag>,
 }
 
-pub struct HistoryPlayback {
-    pub steps_to_apply: Vec<Step>,
-    pub source_steps: Vec<StepRecord>,
+#[derive(Clone)]
+pub struct HistoryPlaybackStep {
+    pub source: StepRecord,
+    pub step_to_apply: Step,
 }
 
 pub struct History {
@@ -79,44 +80,51 @@ impl History {
         self.bump_last_tag_revision();
     }
 
-    pub fn undo(&mut self) -> Option<HistoryPlayback> {
+    pub fn undo(&mut self) -> Option<Vec<HistoryPlaybackStep>> {
         let entry = self.undos.pop()?;
-        let source_steps: Vec<StepRecord> = entry.steps.iter().rev().cloned().collect();
-        let steps: Vec<Step> = source_steps
+        let steps: Vec<HistoryPlaybackStep> = entry
+            .steps
             .iter()
-            .map(|record| record.step.inverse())
+            .rev()
+            .cloned()
+            .map(|source| HistoryPlaybackStep {
+                step_to_apply: source.step.inverse(),
+                source,
+            })
             .collect();
         self.redos.push(entry);
-        Some(HistoryPlayback {
-            steps_to_apply: steps,
-            source_steps,
-        })
+        Some(steps)
     }
 
-    pub fn last_inverse_steps(&self) -> Option<Vec<Step>> {
+    pub fn last_inverse_playback_steps(&self) -> Option<Vec<HistoryPlaybackStep>> {
         let entry = self.undos.last()?;
         Some(
             entry
                 .steps
                 .iter()
                 .rev()
-                .map(|record| record.step.inverse())
+                .cloned()
+                .map(|source| HistoryPlaybackStep {
+                    step_to_apply: source.step.inverse(),
+                    source,
+                })
                 .collect(),
         )
     }
 
-    pub fn redo(&mut self) -> Option<HistoryPlayback> {
+    pub fn redo(&mut self) -> Option<Vec<HistoryPlaybackStep>> {
         let entry = self.redos.pop()?;
-        let source_steps = entry.steps.clone();
-        let steps = source_steps
+        let steps = entry
+            .steps
             .iter()
-            .map(|record| record.step.clone())
+            .cloned()
+            .map(|source| HistoryPlaybackStep {
+                step_to_apply: source.step.clone(),
+                source,
+            })
             .collect();
         self.undos.push(entry);
-        Some(HistoryPlayback {
-            steps_to_apply: steps,
-            source_steps,
-        })
+        Some(steps)
     }
 
     /// Called after redo so that backspace shortcuts still fire correctly.
@@ -185,8 +193,8 @@ mod tests {
         let from_sel = Selection::collapsed(Position::new(NodeId::ROOT, from));
         let to_sel = Selection::collapsed(Position::new(NodeId::ROOT, to));
         Step::SetSelection {
-            old: Some(StableSelection::freeze(&from_sel, &s.doc)),
-            new: Some(StableSelection::freeze(&to_sel, &s.doc)),
+            old: Some(StableSelection::capture(&from_sel, &s.doc)),
+            new: Some(StableSelection::capture(&to_sel, &s.doc)),
         }
     }
 
@@ -205,6 +213,13 @@ mod tests {
         }
     }
 
+    fn playback_steps(playback: Vec<HistoryPlaybackStep>) -> Vec<Step> {
+        playback
+            .into_iter()
+            .map(|step| step.step_to_apply)
+            .collect()
+    }
+
     #[test]
     fn undo_returns_inverse_steps_in_reverse() {
         let s = fixture_state();
@@ -214,11 +229,11 @@ mod tests {
             Instant::now(),
         );
 
-        let undone = h.undo().unwrap().steps_to_apply;
+        let undone = playback_steps(h.undo().unwrap());
         assert_eq!(undone.len(), 2);
         assert!(matches!(&undone[0], Step::SetSelection { old, new }
-            if old.as_ref().map(|ss| ss.thaw(&s.doc).head.offset) == Some(1)
-                && new.as_ref().map(|ss| ss.thaw(&s.doc).head.offset) == Some(0)));
+            if old.as_ref().map(|ss| ss.restore(&s.doc).head.offset) == Some(1)
+                && new.as_ref().map(|ss| ss.restore(&s.doc).head.offset) == Some(0)));
         assert!(matches!(&undone[1], Step::RemoveText { .. }));
     }
 
@@ -228,7 +243,7 @@ mod tests {
         h.push_at(&[record(text_step())], Instant::now());
         h.undo();
 
-        let redone = h.redo().unwrap().steps_to_apply;
+        let redone = playback_steps(h.redo().unwrap());
         assert_eq!(redone.len(), 1);
         assert!(matches!(&redone[0], Step::InsertText { text, .. } if text == "x"));
     }
@@ -251,8 +266,10 @@ mod tests {
 
         h.push_at(&[step_record.clone()], Instant::now());
 
-        assert_eq!(h.undos[0].steps, vec![step_record]);
-        let undone = h.undo().unwrap().steps_to_apply;
+        assert_eq!(h.undos[0].steps, vec![step_record.clone()]);
+        let playback = h.undo().unwrap();
+        assert_eq!(playback[0].source, step_record);
+        let undone = playback_steps(playback);
         assert_eq!(undone.len(), 1);
         assert!(matches!(&undone[0], Step::RemoveText { .. }));
     }
@@ -286,7 +303,7 @@ mod tests {
         h.push_at(&[record(text_step())], t);
         h.push_at(&[record(text_step())], t + Duration::from_millis(100));
 
-        let undone = h.undo().unwrap().steps_to_apply;
+        let undone = playback_steps(h.undo().unwrap());
         assert_eq!(undone.len(), 2);
         assert!(h.undo().is_none());
     }
@@ -382,7 +399,7 @@ mod tests {
         h.push_at(&[record(text_step())], t + Duration::from_millis(150));
 
         assert!(h.can_undo(), "steps must not be dropped");
-        let undone = h.undo().unwrap().steps_to_apply;
+        let undone = playback_steps(h.undo().unwrap());
         assert_eq!(undone.len(), 1);
     }
 
@@ -395,11 +412,11 @@ mod tests {
             Instant::now(),
         );
 
-        let undone = h.undo().unwrap().steps_to_apply;
+        let undone = playback_steps(h.undo().unwrap());
         assert_eq!(undone.len(), 1);
         assert!(matches!(&undone[0], Step::RemoveText { .. }));
 
-        let redone = h.redo().unwrap().steps_to_apply;
+        let redone = playback_steps(h.redo().unwrap());
         assert_eq!(redone.len(), 1);
         assert!(matches!(&redone[0], Step::InsertText { .. }));
     }
@@ -438,7 +455,7 @@ mod tests {
     }
 
     #[test]
-    fn last_inverse_steps_returns_inverse_of_top_entry_without_mutation() {
+    fn last_inverse_playback_steps_return_source_and_inverse_without_mutation() {
         let mut h = History::new(Duration::from_millis(300));
         h.push_tagged_at(
             &[record(text_step())],
@@ -451,9 +468,10 @@ mod tests {
         let redos_before = h.redos_len();
         let tag_before = h.last_tag().cloned();
 
-        let inverse = h.last_inverse_steps().expect("Some");
+        let inverse = h.last_inverse_playback_steps().expect("Some");
         assert_eq!(inverse.len(), 1);
-        assert!(matches!(&inverse[0], Step::RemoveText { .. }));
+        assert!(matches!(&inverse[0].source.step, Step::InsertText { .. }));
+        assert!(matches!(&inverse[0].step_to_apply, Step::RemoveText { .. }));
 
         assert_eq!(h.undos_len(), undos_before);
         assert_eq!(h.redos_len(), redos_before);
@@ -461,9 +479,9 @@ mod tests {
     }
 
     #[test]
-    fn last_inverse_steps_returns_none_on_empty() {
+    fn last_inverse_playback_steps_returns_none_on_empty() {
         let h = History::new(Duration::from_millis(300));
-        assert!(h.last_inverse_steps().is_none());
+        assert!(h.last_inverse_playback_steps().is_none());
     }
 
     #[test]

--- a/crates/editor-core/src/tests/tracked_decoration_integration.rs
+++ b/crates/editor-core/src/tests/tracked_decoration_integration.rs
@@ -150,7 +150,7 @@ fn invalidated_range_produces_no_marks() {
 }
 
 #[test]
-fn collapsed_on_thaw_produces_no_marks() {
+fn collapsed_on_restore_produces_no_marks() {
     let (initial, t1) = state! {
         doc { root { paragraph { t1: text("hello") } } }
         selection: (t1, 1) -> (t1, 4)
@@ -175,7 +175,7 @@ fn collapsed_on_thaw_produces_no_marks() {
 
     assert!(
         editor.tracked_decoration_marks_for_test().is_empty(),
-        "collapsed-on-thaw range must not draw"
+        "collapsed-on-restore range must not draw"
     );
 }
 

--- a/crates/editor-core/src/tests/tracked_range_hit_test.rs
+++ b/crates/editor-core/src/tests/tracked_range_hit_test.rs
@@ -35,8 +35,8 @@ fn hit_test_returns_single_range_when_only_one_covers_point() {
 
     let range = editor.tracked_ranges().get("a").unwrap();
     let resolved = range
-        .selection
-        .thaw(&editor.state().doc)
+        .locate(&editor.state().doc)
+        .expect("range resolves")
         .resolve(&editor.state().doc)
         .unwrap();
     let rects = editor.view().selection_rects(&resolved);
@@ -71,20 +71,21 @@ fn hit_test_excludes_invalid_range() {
     let sel = state.selection.unwrap();
     let mut editor = make_test_editor(state);
     editor.apply(add_msg("a", "comment", sel));
-    editor.apply(Message::TrackedRange {
-        op: TrackedRangeOp::Invalidate { id: "a".into() },
-    });
 
     let range = editor.tracked_ranges().get("a").unwrap();
     let resolved = range
-        .selection
-        .thaw(&editor.state().doc)
+        .locate(&editor.state().doc)
+        .expect("range resolves")
         .resolve(&editor.state().doc)
         .unwrap();
     let rects = editor.view().selection_rects(&resolved);
     let r = rects[0].rect;
     let cx = r.x + r.width * 0.5;
     let cy = r.y + r.height * 0.5;
+
+    editor.apply(Message::TrackedRange {
+        op: TrackedRangeOp::Invalidate { id: "a".into() },
+    });
 
     let hits = editor.tracked_ranges_at(rects[0].page_idx, cx, cy, None);
     assert!(hits.is_empty(), "invalid range must not appear in hits");
@@ -103,8 +104,8 @@ fn hit_test_filters_by_group() {
 
     let range = editor.tracked_ranges().get("a").unwrap();
     let resolved = range
-        .selection
-        .thaw(&editor.state().doc)
+        .locate(&editor.state().doc)
+        .expect("range resolves")
         .resolve(&editor.state().doc)
         .unwrap();
     let rects = editor.view().selection_rects(&resolved);
@@ -138,8 +139,8 @@ fn hit_test_sorts_overlapping_ranges_narrowest_first() {
 
     let range = editor.tracked_ranges().get("inner").unwrap();
     let resolved = range
-        .selection
-        .thaw(&editor.state().doc)
+        .locate(&editor.state().doc)
+        .expect("range resolves")
         .resolve(&editor.state().doc)
         .unwrap();
     let rects = editor.view().selection_rects(&resolved);
@@ -177,8 +178,8 @@ fn hit_test_ignores_decoration_enabled_flag() {
 
     let range = editor.tracked_ranges().get("a").unwrap();
     let resolved = range
-        .selection
-        .thaw(&editor.state().doc)
+        .locate(&editor.state().doc)
+        .expect("range resolves")
         .resolve(&editor.state().doc)
         .unwrap();
     let rects = editor.view().selection_rects(&resolved);
@@ -209,8 +210,8 @@ fn hit_test_breaks_char_count_ties_by_id_alphabetically() {
 
     let range = editor.tracked_ranges().get("aaa").unwrap();
     let resolved = range
-        .selection
-        .thaw(&editor.state().doc)
+        .locate(&editor.state().doc)
+        .expect("range resolves")
         .resolve(&editor.state().doc)
         .unwrap();
     let rects = editor.view().selection_rects(&resolved);

--- a/crates/editor-core/src/tests/tracked_range_integration.rs
+++ b/crates/editor-core/src/tests/tracked_range_integration.rs
@@ -16,16 +16,16 @@ fn add_message(id: &str, group: &str, selection: Selection) -> Message {
     }
 }
 
-fn thawed_offsets(editor: &Editor, id: &str) -> (usize, usize) {
+fn restored_offsets(editor: &Editor, id: &str) -> (usize, usize) {
     let range = editor.tracked_ranges().get(id).expect("range present");
-    let sel = range.selection.thaw(&editor.state().doc);
+    let sel = range.selection.restore(&editor.state().doc);
     (sel.anchor.offset, sel.head.offset)
 }
 
 /// True when the range no longer maps back to its original covered content.
 /// This is the actual signal hit-test/render/FFI use to treat a comment as
-/// "no location".
-fn is_unlocatable(editor: &Editor, id: &str) -> bool {
+/// unlocated for current range semantics.
+fn is_unlocated(editor: &Editor, id: &str) -> bool {
     let range = editor.tracked_ranges().get(id).expect("range present");
     range.locate(&editor.state().doc).is_none()
 }
@@ -62,7 +62,7 @@ fn range_position_shifts_when_text_inserted_before_it() {
     let mut editor = Editor::new_test(initial);
     editor.apply(add_message("r", "g", sel));
 
-    assert_eq!(thawed_offsets(&editor, "r"), (1, 4));
+    assert_eq!(restored_offsets(&editor, "r"), (1, 4));
 
     editor.apply(Message::Selection {
         op: SelectionOp::Set {
@@ -73,7 +73,7 @@ fn range_position_shifts_when_text_inserted_before_it() {
         op: InsertionOp::Text { text: "X".into() },
     });
 
-    let (a, h) = thawed_offsets(&editor, "r");
+    let (a, h) = restored_offsets(&editor, "r");
     assert_eq!((a, h), (2, 5), "range must shift by inserted length");
 }
 
@@ -112,7 +112,7 @@ fn frozen_range_does_not_expand_when_text_inserted_at_right_boundary() {
         selection: (t1, 1) -> (t1, 4)
     };
     let sel = initial.selection.unwrap();
-    let frozen = editor_state::StableSelection::freeze(&sel, &initial.doc);
+    let frozen = editor_state::StableSelection::capture(&sel, &initial.doc);
     let mut editor = Editor::new_test(initial);
     editor.apply(Message::TrackedRange {
         op: TrackedRangeOp::AddFrozen {
@@ -145,7 +145,7 @@ fn range_shrinks_at_right_edge_after_covering_delete_and_undo() {
         doc { root { paragraph { t1: text("ㅁㄴㅇㅁㅁㅁㅁㄴㅁㅇ") } } }
         selection: (t1, 4) -> (t1, 6)
     };
-    let frozen = editor_state::StableSelection::freeze(&initial.selection.unwrap(), &initial.doc);
+    let frozen = editor_state::StableSelection::capture(&initial.selection.unwrap(), &initial.doc);
     let mut editor = Editor::new_test(initial);
     editor.apply(Message::TrackedRange {
         op: TrackedRangeOp::AddFrozen {
@@ -169,7 +169,7 @@ fn range_shrinks_at_right_edge_after_covering_delete_and_undo() {
         op: DeletionOp::Selection,
     });
     assert!(
-        is_unlocatable(&editor, "r"),
+        is_unlocated(&editor, "r"),
         "range should be unlocatable while its whole content is deleted"
     );
 
@@ -315,7 +315,7 @@ fn range_restores_after_full_delete_undo_following_partial_boundary_delete() {
         op: DeletionOp::Selection,
     });
     assert!(
-        is_unlocatable(&editor, "r"),
+        is_unlocated(&editor, "r"),
         "range should be unlocatable while all remaining text is deleted"
     );
 
@@ -340,7 +340,7 @@ fn range_marked_invalid_when_all_covered_text_deleted() {
     let sel = initial.selection.unwrap();
     let mut editor = Editor::new_test(initial);
     editor.apply(add_message("r", "g", sel));
-    assert!(!is_unlocatable(&editor, "r"));
+    assert!(!is_unlocated(&editor, "r"));
 
     editor.apply(Message::Selection {
         op: SelectionOp::Set {
@@ -355,7 +355,7 @@ fn range_marked_invalid_when_all_covered_text_deleted() {
     });
 
     assert!(
-        is_unlocatable(&editor, "r"),
+        is_unlocated(&editor, "r"),
         "deleting the covered text must collapse the range"
     );
 }
@@ -371,7 +371,7 @@ fn range_collapses_when_text_deleted_beyond_its_bounds() {
     let sel = initial.selection.unwrap();
     let mut editor = Editor::new_test(initial);
     editor.apply(add_message("r", "g", sel));
-    assert!(!is_unlocatable(&editor, "r"));
+    assert!(!is_unlocated(&editor, "r"));
 
     editor.apply(Message::Selection {
         op: SelectionOp::Set {
@@ -385,9 +385,9 @@ fn range_collapses_when_text_deleted_beyond_its_bounds() {
         op: DeletionOp::Selection,
     });
 
-    let (a, h) = thawed_offsets(&editor, "r");
+    let (a, h) = restored_offsets(&editor, "r");
     assert!(
-        is_unlocatable(&editor, "r"),
+        is_unlocated(&editor, "r"),
         "deleting text beyond the range bounds must collapse it, got anchor={a} head={h}"
     );
 }
@@ -407,7 +407,7 @@ fn range_across_two_paragraphs_collapses_when_wider_selection_deleted() {
     let sel = initial.selection.unwrap();
     let mut editor = Editor::new_test(initial);
     editor.apply(add_message("r", "g", sel));
-    assert!(!is_unlocatable(&editor, "r"));
+    assert!(!is_unlocated(&editor, "r"));
 
     editor.apply(Message::Selection {
         op: SelectionOp::Set {
@@ -421,9 +421,9 @@ fn range_across_two_paragraphs_collapses_when_wider_selection_deleted() {
         op: DeletionOp::Selection,
     });
 
-    let (a, h) = thawed_offsets(&editor, "r");
+    let (a, h) = restored_offsets(&editor, "r");
     assert!(
-        is_unlocatable(&editor, "r"),
+        is_unlocated(&editor, "r"),
         "deleting both paragraphs must collapse the cross-node range, got anchor={a} head={h}"
     );
 }
@@ -443,7 +443,7 @@ fn range_across_two_paragraphs_collapses_when_tail_survives() {
     let sel = initial.selection.unwrap();
     let mut editor = Editor::new_test(initial);
     editor.apply(add_message("r", "g", sel));
-    assert!(!is_unlocatable(&editor, "r"));
+    assert!(!is_unlocated(&editor, "r"));
 
     // Delete p1 'llo' .. p2 'wor' (covers the comment), leaving p2 'ld' alive.
     editor.apply(Message::Selection {
@@ -458,9 +458,9 @@ fn range_across_two_paragraphs_collapses_when_tail_survives() {
         op: DeletionOp::Selection,
     });
 
-    let (a, h) = thawed_offsets(&editor, "r");
+    let (a, h) = restored_offsets(&editor, "r");
     assert!(
-        is_unlocatable(&editor, "r"),
+        is_unlocated(&editor, "r"),
         "comment whose covered text was deleted (tail survives) must be unlocatable, got anchor={a} head={h}"
     );
 }
@@ -547,7 +547,7 @@ fn comment_in_second_paragraph_collapses_when_its_text_deleted_via_merge() {
     let sel = initial.selection.unwrap();
     let mut editor = Editor::new_test(initial);
     editor.apply(add_message("r", "g", sel));
-    assert!(!is_unlocatable(&editor, "r"));
+    assert!(!is_unlocated(&editor, "r"));
 
     // Delete all of p1 + 'wor' of p2, merging paragraphs, leaving p2 'ld'.
     let t1 = _t1;
@@ -563,9 +563,9 @@ fn comment_in_second_paragraph_collapses_when_its_text_deleted_via_merge() {
         op: DeletionOp::Selection,
     });
 
-    let (a, h) = thawed_offsets(&editor, "r");
+    let (a, h) = restored_offsets(&editor, "r");
     assert!(
-        is_unlocatable(&editor, "r"),
+        is_unlocated(&editor, "r"),
         "comment inside p2 whose text was deleted must be unlocatable, got anchor={a} head={h}"
     );
 }
@@ -596,7 +596,7 @@ fn range_stays_locatable_when_one_covered_char_survives() {
     });
 
     assert!(
-        !is_unlocatable(&editor, "r"),
+        !is_unlocated(&editor, "r"),
         "range must survive while one covered char ('l') is still alive"
     );
 }
@@ -626,7 +626,7 @@ fn range_unaffected_by_deletion_elsewhere_stays_locatable() {
     });
 
     assert!(
-        !is_unlocatable(&editor, "r"),
+        !is_unlocated(&editor, "r"),
         "comment on 'world' must survive deletion of preceding 'hello '"
     );
 }
@@ -643,14 +643,14 @@ fn collapsed_range_on_live_text_is_handled_consistently() {
     let mut editor = Editor::new_test(initial);
     editor.apply(add_message("r", "g", sel));
 
-    // No deletion: locate must agree with is_collapsed().
+    // No deletion: locate must reject collapsed tracked ranges.
     let range = editor.tracked_ranges().get("r").unwrap();
     let located = range.locate(&editor.state().doc);
-    let thawed_collapsed = range.selection.thaw(&editor.state().doc).is_collapsed();
+    let restored_collapsed = range.selection.restore(&editor.state().doc).is_collapsed();
     assert_eq!(
         located.is_none(),
-        thawed_collapsed,
-        "locate must agree with is_collapsed for a collapsed range on live text"
+        restored_collapsed,
+        "tracked range locate must reject collapsed selections"
     );
 }
 
@@ -658,7 +658,7 @@ fn collapsed_range_on_live_text_is_handled_consistently() {
 fn range_collapses_when_covered_text_deleted_but_following_char_survives() {
     // The real app repro that still leaks: comment covers 'wor' (0..3) of
     // "world". Delete exactly 'wor', leaving 'ld'. NO paragraph merge.
-    // head was frozen Bind::Right onto the char AT offset 3 ('l'), which is
+    // head was captured Bind::Right onto the char AT offset 3 ('l'), which is
     // OUTSIDE the comment and survives -> head's anchor dot is alive even though
     // every covered char ('w','o','r') is gone. Must still be unlocatable.
     let (initial, t1) = state! {
@@ -668,7 +668,7 @@ fn range_collapses_when_covered_text_deleted_but_following_char_survives() {
     let sel = initial.selection.unwrap();
     let mut editor = Editor::new_test(initial);
     editor.apply(add_message("r", "g", sel));
-    assert!(!is_unlocatable(&editor, "r"));
+    assert!(!is_unlocated(&editor, "r"));
 
     editor.apply(Message::Selection {
         op: SelectionOp::Set {
@@ -682,9 +682,9 @@ fn range_collapses_when_covered_text_deleted_but_following_char_survives() {
         op: DeletionOp::Selection,
     });
 
-    let (a, h) = thawed_offsets(&editor, "r");
+    let (a, h) = restored_offsets(&editor, "r");
     assert!(
-        is_unlocatable(&editor, "r"),
+        is_unlocated(&editor, "r"),
         "comment whose covered chars are all gone must be unlocatable even if the following char survives, got anchor={a} head={h}"
     );
 }
@@ -724,7 +724,7 @@ fn range_stays_locatable_when_endpoint_chars_die_but_middle_survives() {
     });
 
     assert!(
-        !is_unlocatable(&editor, "r"),
+        !is_unlocated(&editor, "r"),
         "range must survive while covered middle chars remain alive"
     );
 }
@@ -747,14 +747,14 @@ fn range_positions_revert_after_undo() {
     editor.apply(Message::Insertion {
         op: InsertionOp::Text { text: "X".into() },
     });
-    assert_eq!(thawed_offsets(&editor, "r"), (2, 5));
+    assert_eq!(restored_offsets(&editor, "r"), (2, 5));
 
     editor.apply(Message::History {
         op: HistoryOp::Undo,
     });
 
     assert_eq!(
-        thawed_offsets(&editor, "r"),
+        restored_offsets(&editor, "r"),
         (1, 4),
         "undo must restore the original positions"
     );
@@ -823,7 +823,7 @@ fn freeze_then_add_frozen_roundtrip_yields_same_registry_entry() {
     a.apply(add_message("r", "g", sel));
     let from_add = a.tracked_ranges().get("r").unwrap().clone();
 
-    let stable = editor_state::StableSelection::freeze(&sel, &state.doc);
+    let stable = editor_state::StableSelection::capture(&sel, &state.doc);
     let json = serde_json::to_string(&stable).unwrap();
     let restored: editor_state::StableSelection = serde_json::from_str(&json).unwrap();
 
@@ -842,13 +842,13 @@ fn freeze_then_add_frozen_roundtrip_yields_same_registry_entry() {
 }
 
 #[test]
-fn add_frozen_with_unresolvable_dots_marks_invalid_on_thaw() {
+fn add_frozen_with_unresolvable_dots_remains_unlocated() {
     let (state_a, _t1) = state! {
         doc { root { paragraph { t1: text("hello") } } }
         selection: (t1, 1) -> (t1, 4)
     };
     let sel = state_a.selection.unwrap();
-    let stable = editor_state::StableSelection::freeze(&sel, &state_a.doc);
+    let stable = editor_state::StableSelection::capture(&sel, &state_a.doc);
 
     let (state_b, _) = state! {
         doc { root { paragraph { t2: text("world") } } }
@@ -865,7 +865,7 @@ fn add_frozen_with_unresolvable_dots_marks_invalid_on_thaw() {
         },
     });
     assert!(b.tracked_ranges().contains("r"));
-    assert!(is_unlocatable(&b, "r"));
+    assert!(is_unlocated(&b, "r"));
 }
 
 #[test]
@@ -877,7 +877,7 @@ fn range_recovers_from_invalid_after_undo() {
     let sel = state.selection.unwrap();
     let mut editor = Editor::new_test(state);
     editor.apply(add_message("r", "g", sel));
-    assert!(!is_unlocatable(&editor, "r"));
+    assert!(!is_unlocated(&editor, "r"));
     let old_entries = visible_entry_dots(&editor, t1)[1..4].to_vec();
 
     editor.apply(Message::Selection {
@@ -892,7 +892,7 @@ fn range_recovers_from_invalid_after_undo() {
         op: DeletionOp::Selection,
     });
     assert!(
-        is_unlocatable(&editor, "r"),
+        is_unlocated(&editor, "r"),
         "deleting covered text must collapse the range"
     );
 
@@ -900,7 +900,7 @@ fn range_recovers_from_invalid_after_undo() {
         op: HistoryOp::Undo,
     });
     assert!(
-        !is_unlocatable(&editor, "r"),
+        !is_unlocated(&editor, "r"),
         "undo must restore range to valid"
     );
     let current_entries = visible_entry_dots(&editor, t1);
@@ -1011,6 +1011,6 @@ fn set_group_preserves_deleted_trailing_boundary_before_later_insert() {
     assert_eq!(
         located_text(&editor, "r").as_deref(),
         Some("bc"),
-        "moving a range between decoration groups must not refreeze its deleted trailing boundary"
+        "moving a range between decoration groups must not recapture its deleted trailing boundary"
     );
 }

--- a/crates/editor-core/src/tests/tracked_range_replace_integration.rs
+++ b/crates/editor-core/src/tests/tracked_range_replace_integration.rs
@@ -175,7 +175,7 @@ fn explicitly_invalid_range_emits_invalid_and_no_op() {
 }
 
 #[test]
-fn collapsed_on_thaw_emits_invalid() {
+fn collapsed_on_restore_emits_invalid() {
     let (initial, t1) = state! {
         doc { root { paragraph { t1: text("hello world") } } }
         selection: (t1, 6) -> (t1, 11)

--- a/crates/editor-core/src/tracked_range.rs
+++ b/crates/editor-core/src/tracked_range.rs
@@ -1,5 +1,5 @@
-use editor_model::Doc;
-use editor_state::{Selection, StableSelection};
+use editor_model::{Doc, Node};
+use editor_state::{Bind, Position, Selection, StablePosition, StableSelection};
 use editor_view::PageRect;
 use hashbrown::{HashMap, HashSet};
 
@@ -141,50 +141,94 @@ impl TrackedRangeRegistry {
 }
 
 impl TrackedRange {
-    pub fn from_selection(
-        id: TrackedRangeId,
-        group: String,
-        selection: Selection,
-        metadata: String,
-        doc: &Doc,
-    ) -> Self {
-        let selection = StableSelection::freeze_covered_range(&selection, doc)
-            .unwrap_or_else(|| StableSelection::freeze(&selection, doc));
-        Self {
-            id,
-            group,
-            selection,
-            metadata,
-            explicitly_invalid: false,
-        }
-    }
-
-    pub fn from_stable_selection(
+    pub fn new(
         id: TrackedRangeId,
         group: String,
         selection: StableSelection,
         metadata: String,
         doc: &Doc,
     ) -> Self {
-        // FFI/persisted callers can pass a StableSelection frozen with user
-        // selection semantics. If it still locates, lower it again with tracked
-        // range boundary policy so typing at the boundary stays outside.
-        let selection = selection
-            .locate(doc)
-            .and_then(|sel| StableSelection::freeze_covered_range(&sel, doc))
-            .unwrap_or(selection);
         Self {
             id,
             group,
-            selection,
+            selection: covered_selection(selection, doc),
             metadata,
             explicitly_invalid: false,
         }
     }
 
     pub fn locate(&self, doc: &Doc) -> Option<Selection> {
-        self.selection.locate(doc)
+        if self.explicitly_invalid || !self.selection.is_preserved(doc) {
+            return None;
+        }
+        let sel = self.selection.restore(doc);
+        let sel = sel.normalize(doc)?;
+        sel.resolve(doc)?;
+        (!sel.is_collapsed()).then_some(sel)
     }
+}
+
+fn covered_selection(selection: StableSelection, doc: &Doc) -> StableSelection {
+    if !selection.is_preserved(doc) {
+        return selection;
+    }
+
+    let live = selection.restore(doc);
+    let Some(live) = live.normalize(doc) else {
+        return selection;
+    };
+    let Some(resolved) = live.resolve(doc) else {
+        return selection;
+    };
+    if resolved.is_collapsed() {
+        return selection;
+    }
+
+    let start = Position::from(resolved.from());
+    let end = Position::from(resolved.to());
+    let mut first = None;
+    let mut last = None;
+    resolved.for_each_text_node(|node, span| {
+        let Node::Text(text_node) = node.node() else {
+            return;
+        };
+        let first_entry_dot = text_node
+            .text
+            .entry_dot_at(span.start)
+            .expect("covered span start must be in text bounds");
+        let last_entry_dot = text_node
+            .text
+            .entry_dot_at(span.end - 1)
+            .expect("covered span end must be in text bounds");
+
+        first.get_or_insert((node.id(), span.start, first_entry_dot));
+        last = Some((node.id(), span.end, last_entry_dot));
+    });
+
+    let anchor = match first {
+        Some((node_id, boundary_offset, entry_dot)) => StablePosition::capture_text_endpoint(
+            node_id,
+            entry_dot,
+            boundary_offset,
+            Bind::Left,
+            start.affinity,
+            doc,
+        ),
+        None => StablePosition::capture(start, doc),
+    };
+    let head = match last {
+        Some((node_id, boundary_offset, entry_dot)) => StablePosition::capture_text_endpoint(
+            node_id,
+            entry_dot,
+            boundary_offset,
+            Bind::Right,
+            end.affinity,
+            doc,
+        ),
+        None => StablePosition::capture(end, doc),
+    };
+
+    StableSelection { anchor, head }
 }
 
 #[cfg(test)]
@@ -198,7 +242,13 @@ mod tests {
             selection: (t1, 0) -> (t1, 5)
         };
         let sel = s.selection.unwrap();
-        TrackedRange::from_selection(id.into(), group.into(), sel, String::new(), &s.doc)
+        TrackedRange::new(
+            id.into(),
+            group.into(),
+            StableSelection::capture(&sel, &s.doc),
+            String::new(),
+            &s.doc,
+        )
     }
 
     #[test]
@@ -278,6 +328,26 @@ mod tests {
     }
 
     #[test]
+    fn locate_returns_none_when_range_is_explicitly_invalid() {
+        let (state, ..) = state! {
+            doc { root { paragraph { t1: text("hello") } } }
+            selection: (t1, 0) -> (t1, 5)
+        };
+        let sel = state.selection.unwrap();
+        let mut range = TrackedRange {
+            id: "a".into(),
+            group: "g1".into(),
+            selection: StableSelection::capture(&sel, &state.doc),
+            metadata: String::new(),
+            explicitly_invalid: false,
+        };
+
+        range.explicitly_invalid = true;
+
+        assert!(range.locate(&state.doc).is_none());
+    }
+
+    #[test]
     fn locate_follows_moved_entry_dot() {
         let (state, t1, t2) = state! {
             doc {
@@ -288,13 +358,13 @@ mod tests {
             }
             selection: (t1, 0) -> (t1, 1)
         };
-        let range = TrackedRange::from_selection(
-            "a".into(),
-            "g1".into(),
-            *state.selection.as_ref().unwrap(),
-            String::new(),
-            &state.doc,
-        );
+        let range = TrackedRange {
+            id: "a".into(),
+            group: "g1".into(),
+            selection: StableSelection::capture(state.selection.as_ref().unwrap(), &state.doc),
+            metadata: String::new(),
+            explicitly_invalid: false,
+        };
         let selected_entry = state
             .doc
             .text_view(t1)
@@ -311,9 +381,9 @@ mod tests {
             })
             .unwrap();
 
-        let located = range.locate(&state.doc).expect("range locates after move");
-        assert_eq!(located.anchor.node_id, t2);
-        assert_eq!(located.head.node_id, t2);
+        let resolved = range.locate(&state.doc).expect("range locates after move");
+        assert_eq!(resolved.anchor.node_id, t2);
+        assert_eq!(resolved.head.node_id, t2);
         assert_eq!(state.doc.text_view(t2).unwrap().text(), "a");
     }
 

--- a/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
@@ -576,7 +576,6 @@ export interface TrackedRange {
     anchor: Position;
     head: Position;
     metadata: string;
-    invalid: boolean;
     rects: PageRect[];
     text: string;
 }

--- a/crates/editor-ffi/pkg/server/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/server/editor_ffi.d.ts
@@ -603,7 +603,6 @@ export interface TrackedRange {
     anchor: Position;
     head: Position;
     metadata: string;
-    invalid: boolean;
     rects: PageRect[];
     text: string;
 }

--- a/crates/editor-ffi/src/editor.rs
+++ b/crates/editor-ffi/src/editor.rs
@@ -42,7 +42,6 @@ pub struct TrackedRange {
     pub anchor: editor_state::Position,
     pub head: editor_state::Position,
     pub metadata: String,
-    pub invalid: bool,
     pub rects: Vec<editor_view::PageRect>,
     pub text: String,
 }
@@ -398,7 +397,7 @@ impl Editor {
                     msg: "freeze_selection: anchor or head not addressable in current doc".into(),
                 });
             }
-            Ok(editor_state::StableSelection::freeze(&sel, doc).into_ffi()?)
+            Ok(editor_state::StableSelection::capture(&sel, doc).into_ffi()?)
         })
     }
 
@@ -429,37 +428,24 @@ impl Editor {
             };
             let view = inner.editor.view();
             let result: Vec<TrackedRange> = ranges
-                .map(|r| {
-                    let located = if r.explicitly_invalid {
-                        None
-                    } else {
-                        r.locate(doc)
-                    };
-                    let invalid = located.is_none();
-                    let sel = located.unwrap_or_else(|| r.selection.thaw(doc));
-                    let resolved = if invalid { None } else { sel.resolve(doc) };
-                    let rects = match &resolved {
-                        Some(resolved) => view
-                            .selection_rects(resolved)
-                            .into_iter()
-                            .map(|sr| sr.without_meta())
-                            .collect(),
-                        None => Vec::new(),
-                    };
-                    let text = match &resolved {
-                        Some(resolved) => resolved.collect_text(),
-                        None => String::new(),
-                    };
-                    TrackedRange {
+                .filter_map(|r| {
+                    let sel = r.locate(doc)?;
+                    let resolved = sel.resolve(doc)?;
+                    let rects = view
+                        .selection_rects(&resolved)
+                        .into_iter()
+                        .map(|sr| sr.without_meta())
+                        .collect();
+                    let text = resolved.collect_text();
+                    Some(TrackedRange {
                         id: r.id.clone(),
                         group: r.group.clone(),
                         anchor: sel.anchor,
                         head: sel.head,
                         metadata: r.metadata.clone(),
-                        invalid,
                         rects,
                         text,
-                    }
+                    })
                 })
                 .collect();
             Ok(result.into_ffi()?)
@@ -1060,11 +1046,10 @@ mod tests {
         let r = ranges.iter().find(|x| x.id == "r").expect("range present");
         assert_eq!(r.anchor.offset, 1);
         assert_eq!(r.head.offset, 8);
-        assert!(!r.invalid);
     }
 
     #[test]
-    fn ffi_tracked_ranges_exports_located_endpoints_after_history_remap() {
+    fn ffi_tracked_ranges_exports_resolved_endpoints_after_history_remap() {
         let (initial, t1) = state! {
             doc { root { paragraph { t1: text("ㅁㄴㅇㅁㅁㅁㅁㄴㅁㅇ") } } }
             selection: (t1, 4) -> (t1, 6)
@@ -1159,7 +1144,42 @@ mod tests {
         assert_eq!(r.text, "ㅁ");
         assert_eq!(r.anchor.offset, 4);
         assert_eq!(r.head.offset, 5);
-        assert!(!r.invalid);
+    }
+
+    #[test]
+    fn ffi_tracked_ranges_omits_unresolved_ranges() {
+        let (state_a, _t1) = state! {
+            doc { root { paragraph { t1: text("hello") } } }
+            selection: (t1, 1) -> (t1, 4)
+        };
+        let editor_a = make_ffi_editor(state_a.clone());
+        let stable = editor_a
+            .freeze_selection(state_a.selection.unwrap())
+            .expect("freeze");
+
+        let (state_b, ..) = state! {
+            doc { root { paragraph { t2: text("world") } } }
+            selection: (t2, 0)
+        };
+        let editor_b = make_ffi_editor(state_b);
+        editor_b
+            .enqueue(
+                editor_core::Message::TrackedRange {
+                    op: editor_core::TrackedRangeOp::AddFrozen {
+                        id: "r".into(),
+                        group: "comment".into(),
+                        selection: stable,
+                        metadata: String::new(),
+                    },
+                }
+                .into_ffi()
+                .unwrap(),
+            )
+            .expect("enqueue add");
+        let _ = editor_b.tick().expect("tick add");
+
+        let ranges = editor_b.tracked_ranges(None).expect("ffi ok");
+        assert!(ranges.is_empty());
     }
 
     #[test]

--- a/crates/editor-state/src/selection.rs
+++ b/crates/editor-state/src/selection.rs
@@ -92,7 +92,7 @@ impl Selection {
         ResolvedSelection::resolve(doc, *self)
     }
 
-    pub fn freeze(&self, doc: &Doc) -> crate::StableSelection {
-        crate::StableSelection::freeze(self, doc)
+    pub fn capture(&self, doc: &Doc) -> crate::StableSelection {
+        crate::StableSelection::capture(self, doc)
     }
 }

--- a/crates/editor-state/src/stable_position.rs
+++ b/crates/editor-state/src/stable_position.rs
@@ -10,7 +10,7 @@ use crate::bind::Bind;
 /// One link in the structural chain from root to the cursor's leaf node.
 ///
 /// `child_dot` is this node's dot in its parent's `children` RGA. For the
-/// root link, `child_dot` is unused (freeze writes `Dot::new(0, 0)`, thaw
+/// root link, `child_dot` is unused (capture writes `Dot::new(0, 0)`, restore
 /// ignores).
 #[ffi]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -47,7 +47,117 @@ pub enum StablePosition {
     },
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) enum StablePositionResolution {
+    Live(Position),
+    RemappedLive(Position),
+    DeletedEntryBoundary(Position),
+    MissingTextEntryFallback(Position),
+    MissingChildFallback(Position),
+    InvalidLeafTypeFallback(Position),
+    DeadChainFallback(Position),
+    Unresolved,
+}
+
+impl StablePositionResolution {
+    pub(crate) fn position(self) -> Option<Position> {
+        match self {
+            Self::Live(pos)
+            | Self::RemappedLive(pos)
+            | Self::DeletedEntryBoundary(pos)
+            | Self::MissingTextEntryFallback(pos)
+            | Self::MissingChildFallback(pos)
+            | Self::InvalidLeafTypeFallback(pos)
+            | Self::DeadChainFallback(pos) => Some(pos),
+            Self::Unresolved => None,
+        }
+    }
+
+    pub(crate) fn is_preserved(self) -> bool {
+        matches!(
+            self,
+            Self::Live(_) | Self::RemappedLive(_) | Self::DeletedEntryBoundary(_)
+        )
+    }
+}
+
 impl StablePosition {
+    pub fn capture(pos: Position, doc: &Doc) -> Self {
+        let entry = doc
+            .get_entry(pos.node_id)
+            .expect("StablePosition::capture: pos must resolve against doc at capture time");
+        let chain = build_chain(pos.node_id, doc);
+
+        match &entry.node {
+            Node::Text(text) => {
+                if text.text.is_empty() {
+                    StablePosition::ContainerStart {
+                        chain,
+                        affinity: pos.affinity,
+                    }
+                } else {
+                    let (char_index, bind) = if pos.offset == 0 {
+                        (0, Bind::Left)
+                    } else if pos.affinity == Affinity::Downstream && pos.offset < text.text.len() {
+                        (pos.offset, Bind::Left)
+                    } else {
+                        (pos.offset - 1, Bind::Right)
+                    };
+                    let char_dot = text
+                        .text
+                        .entry_dot_at(char_index)
+                        .expect("StablePosition::capture: offset within text bounds")
+                        .0;
+                    StablePosition::Char {
+                        chain,
+                        char_dot,
+                        offset: pos.offset,
+                        bind,
+                        affinity: pos.affinity,
+                    }
+                }
+            }
+            _ => {
+                let children = &entry.children;
+                if children.is_empty() || pos.offset == 0 {
+                    StablePosition::ContainerStart {
+                        chain,
+                        affinity: pos.affinity,
+                    }
+                } else {
+                    let child_dot = children
+                        .dot_at(pos.offset)
+                        .expect("StablePosition::capture: offset within children bounds")
+                        .expect("StablePosition::capture: dot_at within bounds yields Some");
+                    StablePosition::Child {
+                        chain,
+                        child_dot,
+                        offset: pos.offset,
+                        bind: Bind::Right,
+                        affinity: pos.affinity,
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn capture_text_endpoint(
+        node_id: NodeId,
+        entry_dot: EntryDot,
+        boundary_offset: usize,
+        bind: Bind,
+        affinity: Affinity,
+        doc: &Doc,
+    ) -> Self {
+        StablePosition::Char {
+            chain: build_chain(node_id, doc),
+            char_dot: entry_dot.0,
+            offset: boundary_offset,
+            bind,
+            affinity,
+        }
+    }
+
     pub fn chain(&self) -> &[ChainLink] {
         match self {
             Self::Char { chain, .. }
@@ -72,76 +182,30 @@ impl StablePosition {
             Self::ContainerStart { .. } => Bind::Right,
         }
     }
-}
 
-pub(crate) fn freeze_position(pos: Position, doc: &Doc) -> StablePosition {
-    let entry = doc
-        .get_entry(pos.node_id)
-        .expect("freeze_position: pos must resolve against doc at freeze time");
-    let chain = build_chain(pos.node_id, doc);
-
-    match &entry.node {
-        Node::Text(text) => {
-            if text.text.is_empty() {
-                StablePosition::ContainerStart {
-                    chain,
-                    affinity: pos.affinity,
-                }
-            } else {
-                let (char_index, bind) = if pos.offset == 0 {
-                    (0, Bind::Left)
-                } else if pos.affinity == Affinity::Downstream && pos.offset < text.text.len() {
-                    (pos.offset, Bind::Left)
-                } else {
-                    (pos.offset - 1, Bind::Right)
-                };
-                let char_dot = text
-                    .text
-                    .entry_dot_at(char_index)
-                    .expect("freeze_position: offset within text bounds")
-                    .0;
-                StablePosition::Char {
-                    chain,
-                    char_dot,
-                    offset: pos.offset,
-                    bind,
-                    affinity: pos.affinity,
-                }
-            }
-        }
-        _ => {
-            let children = &entry.children;
-            if children.is_empty() || pos.offset == 0 {
-                StablePosition::ContainerStart {
-                    chain,
-                    affinity: pos.affinity,
-                }
-            } else {
-                let child_dot = children
-                    .dot_at(pos.offset)
-                    .expect("freeze_position: offset within children bounds")
-                    .expect("freeze_position: dot_at within bounds yields Some");
-                StablePosition::Child {
-                    chain,
-                    child_dot,
-                    offset: pos.offset,
-                    bind: Bind::Right,
-                    affinity: pos.affinity,
-                }
-            }
-        }
+    pub fn is_preserved(&self, doc: &Doc) -> bool {
+        resolve_position(self, doc).is_preserved()
     }
 }
 
-pub(crate) fn thaw_position(sp: &StablePosition, doc: &Doc) -> Position {
-    if let Some(pos) = resolve_current_char_position(sp, doc) {
-        return pos;
+pub(crate) fn restore_position(sp: &StablePosition, doc: &Doc) -> Position {
+    resolve_position(sp, doc)
+        .position()
+        .expect("restore_position: stable position must resolve")
+}
+
+pub(crate) fn resolve_position(sp: &StablePosition, doc: &Doc) -> StablePositionResolution {
+    if let Some(resolution) = resolve_current_char_position(sp, doc) {
+        return resolution;
     }
     if let Some(pos) = resolve_deleted_char_position(sp, doc) {
-        return pos;
+        return StablePositionResolution::DeletedEntryBoundary(pos);
     }
 
     let chain = sp.chain();
+    if chain.is_empty() {
+        return StablePositionResolution::Unresolved;
+    }
     let mut live_idx: usize = 0;
     for (i, link) in chain.iter().enumerate() {
         if doc.get_entry(link.node_id).is_some() {
@@ -159,14 +223,17 @@ pub(crate) fn thaw_position(sp: &StablePosition, doc: &Doc) -> Position {
     let anc = doc.get_entry(anc_id).expect("live ancestor must exist");
     let dead_dot = chain[live_idx + 1].child_dot;
     let offset = nearest_live_sibling_offset(&anc.children, dead_dot, sp.bind());
-    Position {
+    StablePositionResolution::DeadChainFallback(Position {
         node_id: anc_id,
         offset,
         affinity: sp.affinity(),
-    }
+    })
 }
 
-fn resolve_current_char_position(sp: &StablePosition, doc: &Doc) -> Option<Position> {
+fn resolve_current_char_position(
+    sp: &StablePosition,
+    doc: &Doc,
+) -> Option<StablePositionResolution> {
     let StablePosition::Char {
         char_dot,
         bind,
@@ -177,6 +244,7 @@ fn resolve_current_char_position(sp: &StablePosition, doc: &Doc) -> Option<Posit
         return None;
     };
     let text_identity = doc.text_identity();
+    let stable_entry = EntryDot(*char_dot);
     let entry_dot = match text_identity.resolve_stable_entry(EntryDot(*char_dot)) {
         StableEntryResolution::Live(entry_dot) => entry_dot,
         StableEntryResolution::Deleted(_) | StableEntryResolution::Cycle(_) => return None,
@@ -187,15 +255,19 @@ fn resolve_current_char_position(sp: &StablePosition, doc: &Doc) -> Option<Posit
         Bind::Left => rank,
         Bind::Right => rank + 1,
     };
-    Some(Position {
+    let pos = Position {
         node_id: location.node_id,
         offset,
         affinity: *affinity,
+    };
+    Some(if entry_dot == stable_entry {
+        StablePositionResolution::Live(pos)
+    } else {
+        StablePositionResolution::RemappedLive(pos)
     })
 }
 
-// TODO: 위치 해석 결과를 타입으로 나눠 range fallback을 구분한다.
-fn resolve_primary(sp: &StablePosition, doc: &Doc) -> Position {
+fn resolve_primary(sp: &StablePosition, doc: &Doc) -> StablePositionResolution {
     let leaf_id = sp.chain().last().expect("non-empty chain").node_id;
     let entry = doc.get_entry(leaf_id).expect("leaf alive");
     match sp {
@@ -213,19 +285,19 @@ fn resolve_primary(sp: &StablePosition, doc: &Doc) -> Position {
                         doc.text_identity().char_for(entry_dot).is_none(),
                         "known deleted char should resolve through deleted-entry fallback before primary fallback"
                     );
-                    return Position {
+                    return StablePositionResolution::MissingTextEntryFallback(Position {
                         node_id: leaf_id,
                         offset: (*offset).min(text.text.len()),
                         affinity: *affinity,
-                    };
+                    });
                 }
                 resolve_dot_in_text(&text.text, entry_dot, *offset, *bind, leaf_id, *affinity)
             }
-            _ => Position {
+            _ => StablePositionResolution::InvalidLeafTypeFallback(Position {
                 node_id: leaf_id,
                 offset: 0,
                 affinity: *affinity,
-            },
+            }),
         },
         StablePosition::Child {
             child_dot,
@@ -234,11 +306,11 @@ fn resolve_primary(sp: &StablePosition, doc: &Doc) -> Position {
             affinity,
             ..
         } => match &entry.node {
-            Node::Text(_) => Position {
+            Node::Text(_) => StablePositionResolution::InvalidLeafTypeFallback(Position {
                 node_id: leaf_id,
                 offset: 0,
                 affinity: *affinity,
-            },
+            }),
             _ => resolve_dot_in_children(
                 &entry.children,
                 *child_dot,
@@ -248,11 +320,13 @@ fn resolve_primary(sp: &StablePosition, doc: &Doc) -> Position {
                 *affinity,
             ),
         },
-        StablePosition::ContainerStart { affinity, .. } => Position {
-            node_id: leaf_id,
-            offset: 0,
-            affinity: *affinity,
-        },
+        StablePosition::ContainerStart { affinity, .. } => {
+            StablePositionResolution::Live(Position {
+                node_id: leaf_id,
+                offset: 0,
+                affinity: *affinity,
+            })
+        }
     }
 }
 
@@ -287,7 +361,7 @@ fn resolve_dot_in_text(
     bind: Bind,
     node_id: NodeId,
     aff: Affinity,
-) -> Position {
+) -> StablePositionResolution {
     let fallback = fallback_offset.min(text.len());
     match text.visible_offset_of_entry(entry_dot) {
         Some(off) => {
@@ -295,17 +369,17 @@ fn resolve_dot_in_text(
                 Bind::Left => off,
                 Bind::Right => off + 1,
             };
-            Position {
+            StablePositionResolution::Live(Position {
                 node_id,
                 offset,
                 affinity: aff,
-            }
+            })
         }
-        None => Position {
+        None => StablePositionResolution::MissingTextEntryFallback(Position {
             node_id,
             offset: fallback,
             affinity: aff,
-        },
+        }),
     }
 }
 
@@ -331,14 +405,14 @@ fn resolve_dot_in_children(
     bind: Bind,
     node_id: NodeId,
     aff: Affinity,
-) -> Position {
+) -> StablePositionResolution {
     let fallback = fallback_offset.min(children.len());
     if !children.contains_dot(dot) {
-        return Position {
+        return StablePositionResolution::MissingChildFallback(Position {
             node_id,
             offset: fallback,
             affinity: aff,
-        };
+        });
     }
     match children.live_offset_of(dot) {
         Some(off) => {
@@ -346,11 +420,11 @@ fn resolve_dot_in_children(
                 Bind::Left => off,
                 Bind::Right => off + 1,
             };
-            Position {
+            StablePositionResolution::Live(Position {
                 node_id,
                 offset,
                 affinity: aff,
-            }
+            })
         }
         None => {
             let offset = match bind {
@@ -360,11 +434,11 @@ fn resolve_dot_in_children(
                     .map(|o| o + 1)
                     .unwrap_or(fallback),
             };
-            Position {
+            StablePositionResolution::MissingChildFallback(Position {
                 node_id,
                 offset,
                 affinity: aff,
-            }
+            })
         }
     }
 }
@@ -394,13 +468,13 @@ pub(crate) fn build_chain(node_id: NodeId, doc: &Doc) -> Vec<ChainLink> {
     while let Some(id) = cur {
         let entry = doc
             .get_entry(id)
-            .expect("build_chain: ancestor must be alive in doc at freeze time");
+            .expect("build_chain: ancestor must be alive in doc at capture time");
         let parent = *entry.parent.get();
         let child_dot = match parent {
             Some(parent_id) => {
                 let parent_entry = doc
                     .get_entry(parent_id)
-                    .expect("build_chain: parent must be alive in doc at freeze time");
+                    .expect("build_chain: parent must be alive in doc at capture time");
                 parent_entry
                     .children
                     .dot_for(&id)
@@ -465,11 +539,11 @@ mod tests {
     }
 
     #[test]
-    fn freeze_offset_zero_text_yields_char_left_on_first_char() {
+    fn capture_offset_zero_text_yields_char_left_on_first_char() {
         use editor_macros::doc;
         let (doc, t1) = doc! { root { paragraph { t1: text("hi") } } };
         let pos = crate::Position::new(t1, 0);
-        let sp = super::freeze_position(pos, &doc);
+        let sp = StablePosition::capture(pos, &doc);
         let StablePosition::Char { char_dot, bind, .. } = &sp else {
             panic!("expected Char");
         };
@@ -484,11 +558,11 @@ mod tests {
     }
 
     #[test]
-    fn freeze_text_interior_downstream_yields_char_left_on_following_char() {
+    fn capture_text_interior_downstream_yields_char_left_on_following_char() {
         use editor_macros::doc;
         let (doc, t1) = doc! { root { paragraph { t1: text("hi") } } };
         let pos = crate::Position::new(t1, 1);
-        let sp = super::freeze_position(pos, &doc);
+        let sp = StablePosition::capture(pos, &doc);
         match sp {
             StablePosition::Char {
                 chain,
@@ -510,30 +584,30 @@ mod tests {
     }
 
     #[test]
-    fn freeze_empty_text_yields_container_start() {
+    fn capture_empty_text_yields_container_start() {
         use editor_macros::doc;
         let (doc, t1) = doc! { root { paragraph { t1: text("") } } };
         let pos = crate::Position::new(t1, 0);
-        let sp = super::freeze_position(pos, &doc);
+        let sp = StablePosition::capture(pos, &doc);
         assert!(matches!(sp, StablePosition::ContainerStart { .. }));
     }
 
     #[test]
-    fn freeze_container_offset_zero_yields_container_start() {
+    fn capture_container_offset_zero_yields_container_start() {
         use editor_macros::doc;
         let (doc, p1) = doc! { root { p1: paragraph { text("x") } } };
         let pos = crate::Position::new(p1, 0);
-        let sp = super::freeze_position(pos, &doc);
+        let sp = StablePosition::capture(pos, &doc);
         assert!(matches!(sp, StablePosition::ContainerStart { .. }));
         assert_eq!(sp.chain().last().unwrap().node_id, p1);
     }
 
     #[test]
-    fn freeze_container_middle_yields_child_right() {
+    fn capture_container_middle_yields_child_right() {
         use editor_macros::doc;
         let (doc, p1, t1) = doc! { root { p1: paragraph { t1: text("x") } } };
         let pos = crate::Position::new(p1, 1);
-        let sp = super::freeze_position(pos, &doc);
+        let sp = StablePosition::capture(pos, &doc);
         match sp {
             StablePosition::Child {
                 chain,
@@ -551,34 +625,34 @@ mod tests {
     }
 
     #[test]
-    fn thaw_roundtrip_char_middle_in_unchanged_doc() {
+    fn restore_roundtrip_char_middle_in_unchanged_doc() {
         use editor_macros::doc;
         let (doc, t1) = doc! { root { paragraph { t1: text("hello") } } };
         let pos = crate::Position::new(t1, 3);
-        let sp = super::freeze_position(pos, &doc);
-        let back = super::thaw_position(&sp, &doc);
+        let sp = StablePosition::capture(pos, &doc);
+        let back = super::restore_position(&sp, &doc);
         assert_eq!(back, pos);
     }
 
     #[test]
-    fn thaw_roundtrip_container_start() {
+    fn restore_roundtrip_container_start() {
         use editor_macros::doc;
         let (doc, t1) = doc! { root { paragraph { t1: text("hi") } } };
         let pos = crate::Position::new(t1, 0);
-        let sp = super::freeze_position(pos, &doc);
-        let back = super::thaw_position(&sp, &doc);
+        let sp = StablePosition::capture(pos, &doc);
+        let back = super::restore_position(&sp, &doc);
         assert_eq!(back, pos);
     }
 
     #[test]
-    fn thaw_position_bound_to_surviving_char_tracks_it_after_previous_char_delete() {
+    fn restore_position_bound_to_surviving_char_tracks_it_after_previous_char_delete() {
         use editor_macros::state;
         let (state, t1) = state! {
             doc { root { paragraph { t1: text("abc") } } }
             selection: (t1, 0)
         };
         let pos = crate::Position::new(t1, 2);
-        let sp = super::freeze_position(pos, &state.doc);
+        let sp = StablePosition::capture(pos, &state.doc);
 
         // offset 2 with downstream affinity binds to the left side of 'c'.
         let b_dot = {
@@ -603,13 +677,13 @@ mod tests {
             })
             .unwrap();
 
-        let back = super::thaw_position(&sp, &state.doc);
+        let back = super::restore_position(&sp, &state.doc);
         assert_eq!(back.node_id, t1);
         assert_eq!(back.offset, 1);
     }
 
     #[test]
-    fn thaw_deleted_left_bound_char_uses_previous_visible_boundary() {
+    fn resolve_position_classifies_deleted_entry_boundary() {
         use editor_macros::state;
         let (state, t1) = state! {
             doc { root { paragraph { t1: text("abc") } } }
@@ -620,7 +694,43 @@ mod tests {
             offset: 1,
             affinity: crate::Affinity::Downstream,
         };
-        let sp = super::freeze_position(pos, &state.doc);
+        let sp = StablePosition::capture(pos, &state.doc);
+        let char_dot = match &sp {
+            StablePosition::Char { char_dot, .. } => *char_dot,
+            other => panic!("expected Char, got {other:?}"),
+        };
+
+        let (state, _op) = state
+            .apply(editor_model::DocOp::Text {
+                node_id: t1,
+                op: editor_crdt::TextOp::RemoveChar {
+                    observed: EntryDot(char_dot),
+                },
+            })
+            .unwrap();
+
+        let resolved = super::resolve_position(&sp, &state.doc);
+        assert!(matches!(
+            resolved,
+            StablePositionResolution::DeletedEntryBoundary(position)
+                if position.node_id == t1 && position.offset == 1
+        ));
+        assert!(sp.is_preserved(&state.doc));
+    }
+
+    #[test]
+    fn restore_deleted_left_bound_char_uses_previous_visible_boundary() {
+        use editor_macros::state;
+        let (state, t1) = state! {
+            doc { root { paragraph { t1: text("abc") } } }
+            selection: (t1, 0)
+        };
+        let pos = crate::Position {
+            node_id: t1,
+            offset: 1,
+            affinity: crate::Affinity::Downstream,
+        };
+        let sp = StablePosition::capture(pos, &state.doc);
 
         let b_dot = {
             let entry = state.doc.get_entry(t1).unwrap();
@@ -644,13 +754,13 @@ mod tests {
             })
             .unwrap();
 
-        let back = super::thaw_position(&sp, &state.doc);
+        let back = super::restore_position(&sp, &state.doc);
         assert_eq!(back.node_id, t1);
         assert_eq!(back.offset, 1);
     }
 
     #[test]
-    fn thaw_deleted_right_bound_char_uses_next_visible_boundary() {
+    fn restore_deleted_right_bound_char_uses_next_visible_boundary() {
         use editor_macros::state;
         let (state, t1) = state! {
             doc { root { paragraph { t1: text("abc") } } }
@@ -661,7 +771,7 @@ mod tests {
             offset: 2,
             affinity: crate::Affinity::Upstream,
         };
-        let sp = super::freeze_position(pos, &state.doc);
+        let sp = StablePosition::capture(pos, &state.doc);
 
         let b_dot = {
             let entry = state.doc.get_entry(t1).unwrap();
@@ -685,13 +795,13 @@ mod tests {
             })
             .unwrap();
 
-        let back = super::thaw_position(&sp, &state.doc);
+        let back = super::restore_position(&sp, &state.doc);
         assert_eq!(back.node_id, t1);
         assert_eq!(back.offset, 1);
     }
 
     #[test]
-    fn thaw_deleted_left_bound_char_ignores_post_delete_move() {
+    fn restore_deleted_left_bound_char_ignores_post_delete_move() {
         use editor_crdt::TextOp;
         use editor_macros::state;
         use editor_model::DocOp;
@@ -710,7 +820,7 @@ mod tests {
             offset: 1,
             affinity: crate::Affinity::Downstream,
         };
-        let sp = super::freeze_position(pos, &state.doc);
+        let sp = StablePosition::capture(pos, &state.doc);
         let b_dot = match &sp {
             StablePosition::Char { char_dot, bind, .. } => {
                 assert_eq!(*bind, crate::Bind::Left);
@@ -743,13 +853,13 @@ mod tests {
             .unwrap();
 
         assert_eq!(state.doc.text_view(t2).unwrap().text(), "x");
-        let back = super::thaw_position(&sp, &state.doc);
+        let back = super::restore_position(&sp, &state.doc);
         assert_eq!(back.node_id, t1);
         assert_eq!(back.offset, 1);
     }
 
     #[test]
-    fn thaw_deleted_right_bound_char_ignores_post_delete_move() {
+    fn restore_deleted_right_bound_char_ignores_post_delete_move() {
         use editor_crdt::TextOp;
         use editor_macros::state;
         use editor_model::DocOp;
@@ -768,7 +878,7 @@ mod tests {
             offset: 2,
             affinity: crate::Affinity::Upstream,
         };
-        let sp = super::freeze_position(pos, &state.doc);
+        let sp = StablePosition::capture(pos, &state.doc);
         let b_dot = match &sp {
             StablePosition::Char { char_dot, bind, .. } => {
                 assert_eq!(*bind, crate::Bind::Right);
@@ -801,13 +911,13 @@ mod tests {
             .unwrap();
 
         assert_eq!(state.doc.text_view(t2).unwrap().text(), "x");
-        let back = super::thaw_position(&sp, &state.doc);
+        let back = super::restore_position(&sp, &state.doc);
         assert_eq!(back.node_id, t1);
         assert_eq!(back.offset, 1);
     }
 
     #[test]
-    fn thaw_deleted_moved_char_uses_deleted_text_fallback_when_original_leaf_dead() {
+    fn restore_deleted_moved_char_uses_deleted_text_fallback_when_original_leaf_dead() {
         use editor_crdt::TextOp;
         use editor_macros::state;
         use editor_model::DocOp;
@@ -826,7 +936,7 @@ mod tests {
             offset: 1,
             affinity: crate::Affinity::Downstream,
         };
-        let sp = super::freeze_position(pos, &state.doc);
+        let sp = StablePosition::capture(pos, &state.doc);
         let b_dot = match &sp {
             StablePosition::Char { char_dot, bind, .. } => {
                 assert_eq!(*bind, crate::Bind::Left);
@@ -859,13 +969,13 @@ mod tests {
             .unwrap();
         let state = remove_node(&state, p1);
 
-        let back = super::thaw_position(&sp, &state.doc);
+        let back = super::restore_position(&sp, &state.doc);
         assert_eq!(back.node_id, t2);
         assert_eq!(back.offset, 1);
     }
 
     #[test]
-    fn thaw_deleted_moved_left_bound_at_target_start_stays_in_target() {
+    fn restore_deleted_moved_left_bound_at_target_start_stays_in_target() {
         use editor_crdt::TextOp;
         use editor_macros::state;
         use editor_model::DocOp;
@@ -884,7 +994,7 @@ mod tests {
             offset: 0,
             affinity: crate::Affinity::Downstream,
         };
-        let sp = super::freeze_position(pos, &state.doc);
+        let sp = StablePosition::capture(pos, &state.doc);
         let a_dot = match &sp {
             StablePosition::Char { char_dot, bind, .. } => {
                 assert_eq!(*bind, crate::Bind::Left);
@@ -910,13 +1020,13 @@ mod tests {
             .unwrap();
         let state = remove_node(&state, p1);
 
-        let back = super::thaw_position(&sp, &state.doc);
+        let back = super::restore_position(&sp, &state.doc);
         assert_eq!(back.node_id, t2);
         assert_eq!(back.offset, 0);
     }
 
     #[test]
-    fn thaw_deleted_moved_right_bound_at_target_end_stays_in_target() {
+    fn restore_deleted_moved_right_bound_at_target_end_stays_in_target() {
         use editor_crdt::TextOp;
         use editor_macros::state;
         use editor_model::DocOp;
@@ -935,7 +1045,7 @@ mod tests {
             offset: 1,
             affinity: crate::Affinity::Upstream,
         };
-        let sp = super::freeze_position(pos, &state.doc);
+        let sp = StablePosition::capture(pos, &state.doc);
         let a_dot = match &sp {
             StablePosition::Char { char_dot, bind, .. } => {
                 assert_eq!(*bind, crate::Bind::Right);
@@ -968,21 +1078,21 @@ mod tests {
             .unwrap();
         let state = remove_node(&state, p1);
 
-        let back = super::thaw_position(&sp, &state.doc);
+        let back = super::restore_position(&sp, &state.doc);
         assert_eq!(back.node_id, t2);
         assert_eq!(back.offset, 1);
     }
 
     #[test]
-    fn thaw_resurrection_dot_absent_node_alive_falls_back_to_frozen_offset() {
+    fn restore_resurrection_dot_absent_node_alive_falls_back_to_captured_offset() {
         // `Doc::from_plain` rebuilds the doc under a fresh actor seed, so replayed
         // text inserts get new Dots while NodeIds are preserved verbatim — the
-        // exact shape an undo produces. The original char_dot is gone, so thaw
-        // falls back to the frozen leaf offset clamped to the live length.
+        // exact shape an undo produces. The original char_dot is gone, so restore
+        // falls back to the captured leaf offset clamped to the live length.
         use editor_macros::doc;
         let (doc1, t1) = doc! { root { paragraph { t1: text("a") } } };
         let pos = crate::Position::new(t1, 1);
-        let sp = super::freeze_position(pos, &doc1);
+        let sp = StablePosition::capture(pos, &doc1);
 
         let plain = doc1.to_plain();
         let (doc2, _) = editor_model::Doc::from_plain(plain);
@@ -997,14 +1107,15 @@ mod tests {
             other => panic!("expected Char, got {:?}", other),
         };
         assert!(!doc2_text.text.contains_visible_entry(EntryDot(sp_char_dot)));
+        assert!(!sp.is_preserved(&doc2));
 
-        let back = super::thaw_position(&sp, &doc2);
+        let back = super::restore_position(&sp, &doc2);
         assert_eq!(back.node_id, t1);
         assert_eq!(back.offset, 1);
     }
 
     #[test]
-    fn thaw_deleted_entry_without_remap_uses_deleted_boundary_not_fresh_replacement() {
+    fn restore_deleted_entry_without_remap_uses_deleted_boundary_not_fresh_replacement() {
         use editor_crdt::TextOp;
         use editor_macros::state;
         use editor_model::DocOp;
@@ -1018,7 +1129,7 @@ mod tests {
             offset: 2,
             affinity: crate::Affinity::Downstream,
         };
-        let sp = super::freeze_position(pos, &state.doc);
+        let sp = StablePosition::capture(pos, &state.doc);
         let char_dot = match &sp {
             StablePosition::Char { char_dot, .. } => *char_dot,
             other => panic!("expected char stable position, got {other:?}"),
@@ -1059,13 +1170,13 @@ mod tests {
                 .is_some()
         );
 
-        let back = super::thaw_position(&sp, &state.doc);
+        let back = super::restore_position(&sp, &state.doc);
         assert_eq!(back.node_id, t1);
         assert_eq!(back.offset, 2);
     }
 
     #[test]
-    fn thaw_deleted_entry_with_remap_uses_fresh_replacement_location() {
+    fn restore_deleted_entry_with_remap_uses_fresh_replacement_location() {
         use editor_crdt::TextOp;
         use editor_macros::state;
         use editor_model::DocOp;
@@ -1079,7 +1190,7 @@ mod tests {
             offset: 1,
             affinity: crate::Affinity::Downstream,
         };
-        let sp = super::freeze_position(pos, &state.doc);
+        let sp = StablePosition::capture(pos, &state.doc);
         let char_dot = match &sp {
             StablePosition::Char { char_dot, .. } => *char_dot,
             other => panic!("expected char stable position, got {other:?}"),
@@ -1118,13 +1229,13 @@ mod tests {
             .unwrap();
 
         assert_eq!(state.doc.text_view(t1).unwrap().text(), "acb");
-        let back = super::thaw_position(&sp, &state.doc);
+        let back = super::restore_position(&sp, &state.doc);
         assert_eq!(back.node_id, t1);
         assert_eq!(back.offset, 2);
     }
 
     #[test]
-    fn thaw_leaf_dead_walks_to_nearest_live_sibling_right() {
+    fn restore_leaf_dead_walks_to_nearest_live_sibling_right() {
         use editor_macros::state;
         let (state, p2, t2) = state! {
             doc {
@@ -1137,11 +1248,11 @@ mod tests {
             selection: (t2, 0)
         };
         let pos = crate::Position::new(t2, 0);
-        let sp = super::freeze_position(pos, &state.doc);
+        let sp = StablePosition::capture(pos, &state.doc);
 
         let dead_state = remove_node(&state, p2);
 
-        let back = super::thaw_position(&sp, &dead_state.doc);
+        let back = super::restore_position(&sp, &dead_state.doc);
         assert_eq!(back.node_id, editor_model::NodeId::ROOT);
         assert_eq!(back.offset, 1);
     }
@@ -1165,7 +1276,7 @@ mod tests {
         let mut stack = vec![node_id];
         while let Some(id) = stack.pop() {
             to_remove.push(id);
-            let entry = state.doc.get_entry(id).expect("node alive at freeze time");
+            let entry = state.doc.get_entry(id).expect("node alive at capture time");
             for child in entry.children.iter() {
                 stack.push(*child);
             }
@@ -1195,18 +1306,18 @@ mod tests {
     }
 
     #[test]
-    fn thaw_leaf_dead_no_live_siblings_clamps_to_zero() {
+    fn restore_leaf_dead_no_live_siblings_clamps_to_zero() {
         use editor_macros::state;
         let (state, p1, t1) = state! {
             doc { root { p1: paragraph { t1: text("x") } } }
             selection: (t1, 0)
         };
         let pos = crate::Position::new(t1, 0);
-        let sp = super::freeze_position(pos, &state.doc);
+        let sp = StablePosition::capture(pos, &state.doc);
 
         let dead_state = remove_node(&state, p1);
 
-        let back = super::thaw_position(&sp, &dead_state.doc);
+        let back = super::restore_position(&sp, &dead_state.doc);
         assert_eq!(back.node_id, editor_model::NodeId::ROOT);
         assert_eq!(back.offset, 0);
     }

--- a/crates/editor-state/src/stable_selection.rs
+++ b/crates/editor-state/src/stable_selection.rs
@@ -1,12 +1,10 @@
 use editor_macros::ffi;
-use editor_model::{Doc, Node, NodeId};
+use editor_model::Doc;
 use serde::{Deserialize, Serialize};
 
 use crate::normalize::enclosing_unit_at_subtree_overlap;
-use crate::position::Position;
 use crate::selection::Selection;
-use crate::stable_position::{StablePosition, build_chain, freeze_position, thaw_position};
-use crate::{Affinity, Bind};
+use crate::stable_position::{StablePosition, restore_position};
 
 #[ffi]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -17,68 +15,29 @@ pub struct StableSelection {
 }
 
 impl StableSelection {
-    pub fn freeze(sel: &Selection, doc: &Doc) -> Self {
-        let anchor = freeze_position(sel.anchor, doc);
+    pub fn capture(sel: &Selection, doc: &Doc) -> Self {
+        let anchor = StablePosition::capture(sel.anchor, doc);
         let head = if sel.is_collapsed() {
             anchor.clone()
         } else {
-            freeze_position(sel.head, doc)
+            StablePosition::capture(sel.head, doc)
         };
         StableSelection { anchor, head }
     }
 
-    pub fn freeze_covered_range(sel: &Selection, doc: &Doc) -> Option<Self> {
-        let resolved = sel.resolve(doc)?;
-        if resolved.is_collapsed() {
-            return None;
-        }
-
-        let start = Position::from(resolved.from());
-        let end = Position::from(resolved.to());
-        let covered_entries = covered_entry_endpoints(&resolved);
-
-        let anchor = match covered_entries.first {
-            Some(endpoint) => freeze_text_endpoint(
-                endpoint.node_id,
-                endpoint.entry_dot,
-                endpoint.boundary_offset,
-                Bind::Left,
-                start.affinity,
-                doc,
-            ),
-            None => freeze_position(start, doc),
-        };
-        let head = match covered_entries.last {
-            Some(endpoint) => freeze_text_endpoint(
-                endpoint.node_id,
-                endpoint.entry_dot,
-                endpoint.boundary_offset,
-                Bind::Right,
-                end.affinity,
-                doc,
-            ),
-            None => freeze_position(end, doc),
-        };
-
-        Some(StableSelection { anchor, head })
+    /// Returns whether both stored endpoints still preserve their stable
+    /// identity in `doc`. Fallback-only restoration is intentionally rejected.
+    pub fn is_preserved(&self, doc: &Doc) -> bool {
+        self.anchor.is_preserved(doc) && (self.anchor == self.head || self.head.is_preserved(doc))
     }
 
-    /// Thaws and normalizes, returning `Some` only when the selection locates
-    /// to a non-empty span.
-    // TODO: cursor thaw와 range locate를 분리한다.
-    pub fn locate(&self, doc: &Doc) -> Option<Selection> {
-        let sel = self.thaw(doc);
-        let sel = sel.normalize(doc).unwrap_or(sel);
-        (!sel.is_collapsed()).then_some(sel)
-    }
-
-    pub fn thaw(&self, doc: &Doc) -> Selection {
+    pub fn restore(&self, doc: &Doc) -> Selection {
         let was_collapsed = self.anchor == self.head;
-        let a = thaw_position(&self.anchor, doc);
+        let a = restore_position(&self.anchor, doc);
         if was_collapsed {
             return Selection { anchor: a, head: a };
         }
-        let h = thaw_position(&self.head, doc);
+        let h = restore_position(&self.head, doc);
         let candidate = Selection { anchor: a, head: h };
         if invariants_ok(&candidate, doc) {
             candidate
@@ -107,69 +66,9 @@ fn invariants_ok(sel: &Selection, doc: &Doc) -> bool {
     true
 }
 
-#[derive(Clone, Copy)]
-struct CoveredEntryEndpoint {
-    node_id: NodeId,
-    boundary_offset: usize,
-    entry_dot: editor_crdt::EntryDot,
-}
-
-#[derive(Default)]
-struct CoveredEntryEndpoints {
-    first: Option<CoveredEntryEndpoint>,
-    last: Option<CoveredEntryEndpoint>,
-}
-
-fn covered_entry_endpoints(resolved: &crate::ResolvedSelection<'_>) -> CoveredEntryEndpoints {
-    let mut endpoints = CoveredEntryEndpoints::default();
-    resolved.for_each_text_node(|node, span| {
-        let Node::Text(text_node) = node.node() else {
-            return;
-        };
-        let first_index = span.start;
-        let last_index = span.end - 1;
-        let first_entry_dot = text_node
-            .text
-            .entry_dot_at(first_index)
-            .expect("covered span start must be in text bounds");
-        let last_entry_dot = text_node
-            .text
-            .entry_dot_at(last_index)
-            .expect("covered span end must be in text bounds");
-
-        endpoints.first.get_or_insert(CoveredEntryEndpoint {
-            node_id: node.id(),
-            boundary_offset: span.start,
-            entry_dot: first_entry_dot,
-        });
-        endpoints.last = Some(CoveredEntryEndpoint {
-            node_id: node.id(),
-            boundary_offset: span.end,
-            entry_dot: last_entry_dot,
-        });
-    });
-    endpoints
-}
-
-fn freeze_text_endpoint(
-    node_id: NodeId,
-    entry_dot: editor_crdt::EntryDot,
-    boundary_offset: usize,
-    bind: Bind,
-    affinity: Affinity,
-    doc: &Doc,
-) -> StablePosition {
-    StablePosition::Char {
-        chain: build_chain(node_id, doc),
-        char_dot: entry_dot.0,
-        offset: boundary_offset,
-        bind,
-        affinity,
-    }
-}
-
 #[cfg(test)]
 mod tests {
+    use crate::{Affinity, Bind};
     use editor_macros::state;
     use editor_model::NodeId;
 
@@ -182,11 +81,24 @@ mod tests {
             selection: (t1, 3)
         };
         let sel = state.selection.unwrap();
-        let stable = StableSelection::freeze(&sel, &state.doc);
-        let back = stable.thaw(&state.doc);
+        let stable = StableSelection::capture(&sel, &state.doc);
+        let back = stable.restore(&state.doc);
         assert_eq!(back, sel);
         assert!(back.is_collapsed());
         assert_eq!(back.anchor, back.head);
+    }
+
+    #[test]
+    fn is_preserved_returns_true_when_cursor_endpoint_is_live() {
+        let (state, ..) = state! {
+            doc { root { paragraph { t1: text("hello") } } }
+            selection: (t1, 3)
+        };
+        let sel = state.selection.unwrap();
+        let stable = StableSelection::capture(&sel, &state.doc);
+
+        assert!(stable.is_preserved(&state.doc));
+        assert_eq!(stable.restore(&state.doc), sel);
     }
 
     #[test]
@@ -196,8 +108,8 @@ mod tests {
             selection: (t1, 1) -> (t1, 4)
         };
         let sel = state.selection.unwrap();
-        let stable = StableSelection::freeze(&sel, &state.doc);
-        let back = stable.thaw(&state.doc);
+        let stable = StableSelection::capture(&sel, &state.doc);
+        let back = stable.restore(&state.doc);
         assert_eq!(back, sel);
     }
 
@@ -212,12 +124,60 @@ mod tests {
             }
             selection: (t1, 2) -> (t2, 3)
         };
-        let stable = StableSelection::freeze(state.selection.as_ref().unwrap(), &state.doc);
+        let stable = StableSelection::capture(state.selection.as_ref().unwrap(), &state.doc);
 
         let dead_state = remove_paragraph(&state, p1);
-        let back = stable.thaw(&dead_state.doc);
+        let back = stable.restore(&dead_state.doc);
         assert!(back.is_collapsed());
         assert_eq!(back.head.node_id, t2);
+    }
+
+    #[test]
+    fn is_preserved_rejects_missing_child_fallback() {
+        use crate::stable_position::ChainLink;
+        use editor_crdt::Dot;
+
+        let (state, _p1, p2) = state! {
+            doc {
+                root {
+                    p1: paragraph { text("a") }
+                    p2: paragraph { text("b") }
+                }
+            }
+            selection: none
+        };
+        let root_chain = vec![ChainLink {
+            node_id: NodeId::ROOT,
+            child_dot: Dot::new(0, 0),
+        }];
+        let missing_anchor = StablePosition::Child {
+            chain: root_chain.clone(),
+            child_dot: Dot::new(999, 999),
+            offset: 0,
+            bind: Bind::Right,
+            affinity: Affinity::Downstream,
+        };
+        let p2_dot = state
+            .doc
+            .get_entry(NodeId::ROOT)
+            .unwrap()
+            .children
+            .dot_for(&p2)
+            .unwrap();
+        let live_head = StablePosition::Child {
+            chain: root_chain,
+            child_dot: p2_dot,
+            offset: 1,
+            bind: Bind::Right,
+            affinity: Affinity::Downstream,
+        };
+        let stable = StableSelection {
+            anchor: missing_anchor,
+            head: live_head,
+        };
+
+        assert!(stable.restore(&state.doc).resolve(&state.doc).is_some());
+        assert!(!stable.is_preserved(&state.doc));
     }
 
     fn remove_paragraph(state: &crate::State, p_id: NodeId) -> crate::State {

--- a/crates/editor-transaction/src/step.rs
+++ b/crates/editor-transaction/src/step.rs
@@ -429,7 +429,7 @@ mod tests {
         };
         s.selection
             .as_ref()
-            .map(|sel| StableSelection::freeze(sel, &s.doc))
+            .map(|sel| StableSelection::capture(sel, &s.doc))
     }
 
     #[test]

--- a/crates/editor-transaction/src/steps/set_selection.rs
+++ b/crates/editor-transaction/src/steps/set_selection.rs
@@ -12,7 +12,7 @@ pub(crate) fn apply_to(
     _old: Option<StableSelection>,
     new: Option<StableSelection>,
 ) -> Result<(), StepError> {
-    let live = new.map(|s| s.thaw(&batched.doc));
+    let live = new.map(|s| s.restore(&batched.doc));
     batched.set_selection(live);
     Ok(())
 }
@@ -42,8 +42,8 @@ mod tests {
             old: s
                 .selection
                 .as_ref()
-                .map(|sel| StableSelection::freeze(sel, &s.doc)),
-            new: Some(StableSelection::freeze(&new_live, &s.doc)),
+                .map(|sel| StableSelection::capture(sel, &s.doc)),
+            new: Some(StableSelection::capture(&new_live, &s.doc)),
         };
         let output = step.apply(&s).unwrap();
 
@@ -66,8 +66,8 @@ mod tests {
         let original_live = s.selection.expect("fixture has selection");
         let new_live = Selection::collapsed(Position::new(t1, 3));
         let step = Step::SetSelection {
-            old: Some(StableSelection::freeze(&original_live, &s.doc)),
-            new: Some(StableSelection::freeze(&new_live, &s.doc)),
+            old: Some(StableSelection::capture(&original_live, &s.doc)),
+            new: Some(StableSelection::capture(&new_live, &s.doc)),
         };
         let s2 = step.apply(&s).unwrap().state;
         let s3 = step.inverse().apply(&s2).unwrap().state;

--- a/crates/editor-transaction/src/transaction.rs
+++ b/crates/editor-transaction/src/transaction.rs
@@ -43,7 +43,7 @@ impl Transaction {
         let selection_stable = state
             .selection
             .as_ref()
-            .map(|s| StableSelection::freeze(s, &state.doc));
+            .map(|s| StableSelection::capture(s, &state.doc));
         Self {
             state: state.clone(),
             selection_stable,
@@ -88,6 +88,14 @@ impl Transaction {
         self.steps.iter().any(|s| s.is_selection_step())
     }
 
+    pub fn step_records_len(&self) -> usize {
+        self.step_records.len()
+    }
+
+    pub fn step_records_since(&self, start: usize) -> &[StepRecord] {
+        &self.step_records[start.min(self.step_records.len())..]
+    }
+
     pub fn push_effect(&mut self, effect: Effect) {
         self.effects.push(effect);
     }
@@ -124,7 +132,7 @@ impl Transaction {
         self.state.selection = self
             .selection_stable
             .as_ref()
-            .map(|stable| stable.thaw(&self.state.doc));
+            .map(|stable| stable.restore(&self.state.doc));
     }
 
     pub fn savepoint(&self) -> Savepoint {
@@ -401,7 +409,7 @@ impl Transaction {
         let old = self.selection_stable.clone();
         let new = new_effective
             .as_ref()
-            .map(|s| StableSelection::freeze(s, &self.state.doc));
+            .map(|s| StableSelection::capture(s, &self.state.doc));
         if new_effective == self.state.selection && new == old {
             return Ok(());
         }
@@ -472,7 +480,7 @@ impl Transaction {
         // State-only steps (SetSelection/SetComposition/SetPendingModifiers)
         // write a single field nothing else reads during step replay, so only
         // the last of each kind affects the final state. Defer them until after
-        // all doc steps have replayed: SetSelection.apply_to thaws against the
+        // all doc steps have replayed: SetSelection.apply_to restores against the
         // current doc, and during undo the relevant selection sits between doc
         // edits whose inverses are applied later in the same batch — running it
         // in place would resolve against a half-restored doc.
@@ -1075,10 +1083,10 @@ mod tests {
                 let old_sel = old.as_ref().expect("old must be Some");
                 let new_sel_stable = new.as_ref().expect("new must be Some");
                 assert_eq!(
-                    old_sel.thaw(&state.doc),
+                    old_sel.restore(&state.doc),
                     Selection::collapsed(Position::new(t1, 0))
                 );
-                assert_eq!(new_sel_stable.thaw(&state.doc), new_sel);
+                assert_eq!(new_sel_stable.restore(&state.doc), new_sel);
             }
             _ => panic!("expected SetSelection"),
         }

--- a/crates/editor-transaction/tests/roundtrip.rs
+++ b/crates/editor-transaction/tests/roundtrip.rs
@@ -135,8 +135,8 @@ fn set_node_and_selection_combined() {
         old: state2
             .selection
             .as_ref()
-            .map(|s| StableSelection::freeze(s, &state2.doc)),
-        new: Some(StableSelection::freeze(&new_sel, &state2.doc)),
+            .map(|s| StableSelection::capture(s, &state2.doc)),
+        new: Some(StableSelection::capture(&new_sel, &state2.doc)),
     };
     let state3 = set_sel.apply(&state2).unwrap().state;
 


### PR DESCRIPTION
- `StableSelection` / `StablePosition` 계약을 `capture`, `is_preserved`, `restore` 중심으로 정리
  - `capture`: 구 `freeze`
  - `is_preserved`: 저장된 endpoint의 stable identity가 현재 문서에서도 보존되는지 확인
  - `restore`: `is_preserved` 여부와 별개로 현재 문서에서 가능한 position/selection을 best-effort로 복원
  - 실제 복원은 `capture`의 역연산이 아니므로, `freeze` / `thaw`처럼 대칭적으로 읽히는 이름 대신 `capture` / `is_preserved` / `restore`로 분리
- `StableSelection`에서 tracked range 관련 boundary 정책을 제거하고 `TrackedRange` 쪽에 응집시킴
- `TrackedRange::locate`는 preserved endpoint / normalize / resolve / non-collapsed를 모두 만족할 때만 selection을 반환
- history undo/redo playback이 source step과 적용 step을 pair로 유지하도록 정리하고, text effect shape이 다르면 partial stable-position remap을 하지 않음
- FFI tracked range export는 resolve 가능한 range만 내보내도록 바꾸고 `invalid` 필드를 제거
- repaste-as-text 이후에도 tracked range가 새 text entry로 remap되도록 history source effect와 replacement effect를 연결 (사실상 런타임에서 일어나기 어려운 시나리오지만 방어적으로 처리)