### PR TITLE
Kotlin FFI 바인딩 디버그

### DIFF
--- a/crates/editor-bindgen/src/kotlin.rs
+++ b/crates/editor-bindgen/src/kotlin.rs
@@ -118,6 +118,26 @@ fn resolve_default(field: &FfiField, kt_type: &str, ctx: &CodegenContext) -> Str
         return "emptyList()".into();
     }
 
+    if rust_ty.starts_with("HashMap<")
+        || rust_ty.starts_with("imbl::HashMap<")
+        || rust_ty.starts_with("std::collections::HashMap<")
+        || rust_ty.starts_with("hashbrown::HashMap<")
+        || rust_ty.starts_with("BTreeMap<")
+        || rust_ty.starts_with("std::collections::BTreeMap<")
+    {
+        return "emptyMap()".into();
+    }
+
+    if rust_ty.starts_with("HashSet<")
+        || rust_ty.starts_with("imbl::HashSet<")
+        || rust_ty.starts_with("std::collections::HashSet<")
+        || rust_ty.starts_with("hashbrown::HashSet<")
+        || rust_ty.starts_with("BTreeSet<")
+        || rust_ty.starts_with("std::collections::BTreeSet<")
+    {
+        return "emptySet()".into();
+    }
+
     if let Some(meta) = ctx.meta_map.get(rust_ty.as_str()) {
         match &meta.kind {
             FfiKind::Enum {
@@ -242,6 +262,15 @@ fn map_type_path(
                 map_syn_type(key_ty, custom_types, known_types),
                 map_syn_type(val_ty, custom_types, known_types)
             )
+        }
+        "HashSet"
+        | "imbl::HashSet"
+        | "std::collections::HashSet"
+        | "hashbrown::HashSet"
+        | "BTreeSet"
+        | "std::collections::BTreeSet" => {
+            let inner = extract_single_type_arg(args);
+            format!("Set<{}>", map_syn_type(inner, custom_types, known_types))
         }
         _ => {
             // Unknown generic wrapper. If the head identifier is a known Ffi type,
@@ -689,6 +718,51 @@ mod tests {
         assert_eq!(
             map_type("std::collections::BTreeMap<String, Vec<u32>>", &ct, &kt),
             "Map<String, List<Int>>"
+        );
+    }
+
+    #[test]
+    fn map_btreeset_types() {
+        let ct = empty_custom_types();
+        let mut kt = HashSet::new();
+        kt.insert("Modifier");
+        assert_eq!(
+            map_type("BTreeSet<Modifier>", &ct, &kt),
+            "Set<co.typie.editor.ffi.Modifier>"
+        );
+        assert_eq!(
+            map_type("std::collections::BTreeSet<String>", &ct, &kt),
+            "Set<String>"
+        );
+    }
+
+    #[test]
+    fn default_collections_use_empty_factories() {
+        let ctx = test_context(&[]);
+        let fields = vec![
+            FfiField {
+                name: "styles".into(),
+                serde_rename: None,
+                ty: "BTreeMap<String, PlainStyleEntry>".into(),
+                has_serde_default: true,
+                ffi_default_override: None,
+            },
+            FfiField {
+                name: "modifiers".into(),
+                serde_rename: None,
+                ty: "BTreeSet<Modifier>".into(),
+                has_serde_default: true,
+                ffi_default_override: None,
+            },
+        ];
+
+        assert_eq!(
+            resolve_default(&fields[0], "Map<String, PlainStyleEntry>", &ctx),
+            "emptyMap()"
+        );
+        assert_eq!(
+            resolve_default(&fields[1], "Set<Modifier>", &ctx),
+            "emptySet()"
         );
     }
 

--- a/crates/editor-ffi/src/editor.rs
+++ b/crates/editor-ffi/src/editor.rs
@@ -127,13 +127,14 @@ impl Editor {
     pub fn root_attrs(&self) -> EditorResult<Complex<editor_model::PlainRootNode>> {
         self.with_inner(|inner| {
             let doc = &inner.editor.state().doc;
-            let entry = doc
-                .get_entry(editor_model::NodeId::ROOT)
-                .expect("root entry must exist");
-            match &entry.node.to_plain() {
-                editor_model::PlainNode::Root(r) => Ok(r.clone().into_ffi()?),
-                _ => unreachable!("root entry must be Root"),
-            }
+            let root = crate::root::attrs(doc).expect("root entry must exist");
+            Ok(root.into_ffi()?)
+        })
+    }
+
+    pub fn root_modifiers(&self) -> EditorResult<Vec<Complex<editor_model::Modifier>>> {
+        self.with_inner(|inner| {
+            Ok(crate::root::base_style_modifiers(&inner.editor.state().doc).into_ffi()?)
         })
     }
 
@@ -393,11 +394,7 @@ impl Editor {
 
     pub fn insert_template_fragment(&self, changesets: Vec<u8>) -> EditorResult<()> {
         self.with_inner(|inner| {
-            let css: Vec<editor_crdt::Changeset<editor_model::DocOp>> =
-                editor_crdt::wire::decode(&changesets[..])
-                    .map_err(|e| FfiError::Deserialization(e.to_string()))?;
-            let graph = editor_crdt::OpGraph::from_changesets(css)?;
-            let template_doc = editor_model::Doc::from_op_graph(&graph)?;
+            let (template_doc, _) = crate::graph::doc_from_changesets(changesets)?;
             inner
                 .editor
                 .insert_template_fragment(template_doc.to_plain())?;
@@ -893,6 +890,23 @@ mod tests {
         let editor = make_ffi_editor(initial);
         let result = editor.modifier_state().expect("ffi call returns Ok");
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn ffi_root_modifiers_returns_root_base_style_modifiers() {
+        let (initial, ..) = state! {
+            doc {
+                styles { base: "기본" [font_size(1600), block_gap(120)] }
+                root @base [] { p: paragraph { t1: text("hello") } }
+            }
+            selection: (t1, 0)
+        };
+        let editor = make_ffi_editor(initial);
+
+        let result = editor.root_modifiers().expect("ffi call returns Ok");
+
+        assert!(result.contains(&editor_model::Modifier::FontSize { value: 1600 }));
+        assert!(result.contains(&editor_model::Modifier::BlockGap { value: 120 }));
     }
 
     #[test]

--- a/crates/editor-ffi/src/graph.rs
+++ b/crates/editor-ffi/src/graph.rs
@@ -1,0 +1,12 @@
+use crate::prelude::*;
+
+pub(crate) fn doc_from_changesets(
+    changesets: Vec<u8>,
+) -> EditorResult<(editor_model::Doc, editor_crdt::OpGraph<editor_model::DocOp>)> {
+    let css: Vec<editor_crdt::Changeset<editor_model::DocOp>> =
+        editor_crdt::wire::decode(&changesets[..])
+            .map_err(|e| FfiError::Deserialization(e.to_string()))?;
+    let graph = editor_crdt::OpGraph::from_changesets(css)?;
+    let doc = editor_model::Doc::from_op_graph(&graph)?;
+    Ok((doc, graph))
+}

--- a/crates/editor-ffi/src/host.rs
+++ b/crates/editor-ffi/src/host.rs
@@ -99,7 +99,7 @@ impl EditorHost {
         changesets: Vec<u8>,
         viewport: Complex<editor_view::Viewport>,
     ) -> EditorResult<Owned<crate::editor::Editor>> {
-        let (doc, graph) = doc_from_graph_changesets(changesets)?;
+        let (doc, graph) = crate::graph::doc_from_changesets(changesets)?;
         let selection = doc_start_selection(&doc)?;
         let state = editor_state::State::new(doc, graph, Some(selection));
         let viewport = viewport.from_ffi()?;
@@ -108,7 +108,7 @@ impl EditorHost {
     }
 
     pub fn extract_text_from_graph(&self, changesets: Vec<u8>) -> EditorResult<String> {
-        let (doc, _) = doc_from_graph_changesets(changesets)?;
+        let (doc, _) = crate::graph::doc_from_changesets(changesets)?;
         Ok(doc.extract_text())
     }
 
@@ -116,14 +116,17 @@ impl EditorHost {
         &self,
         changesets: Vec<u8>,
     ) -> EditorResult<Complex<editor_model::PlainRootNode>> {
-        let (doc, _) = doc_from_graph_changesets(changesets)?;
-        let entry = doc
-            .get_entry(editor_model::NodeId::ROOT)
-            .ok_or(FfiError::NoInitialCursorPosition)?;
-        match &entry.node.to_plain() {
-            editor_model::PlainNode::Root(r) => Ok(r.clone().into_ffi()?),
-            _ => unreachable!("root entry must be Root"),
-        }
+        let (doc, _) = crate::graph::doc_from_changesets(changesets)?;
+        let root = crate::root::attrs(&doc).ok_or(FfiError::NoInitialCursorPosition)?;
+        Ok(root.into_ffi()?)
+    }
+
+    pub fn root_modifiers_from_graph(
+        &self,
+        changesets: Vec<u8>,
+    ) -> EditorResult<Vec<Complex<editor_model::Modifier>>> {
+        let (doc, _) = crate::graph::doc_from_changesets(changesets)?;
+        Ok(crate::root::base_style_modifiers(&doc).into_ffi()?)
     }
 
     pub fn set_fonts(
@@ -221,17 +224,25 @@ mod tests {
             .unwrap();
         assert!(!result);
     }
-}
 
-fn doc_from_graph_changesets(
-    changesets: Vec<u8>,
-) -> EditorResult<(editor_model::Doc, editor_crdt::OpGraph<editor_model::DocOp>)> {
-    let css: Vec<editor_crdt::Changeset<editor_model::DocOp>> =
-        editor_crdt::wire::decode(&changesets[..])
-            .map_err(|e| FfiError::Deserialization(e.to_string()))?;
-    let graph = editor_crdt::OpGraph::from_changesets(css)?;
-    let doc = editor_model::Doc::from_op_graph(&graph)?;
-    Ok((doc, graph))
+    #[test]
+    fn root_modifiers_from_graph_returns_root_base_style_modifiers() {
+        let host = make_host();
+        let plain = crate::doc_builder::build_default_doc(
+            editor_model::PlainRootNode::default(),
+            vec![
+                editor_model::Modifier::FontSize { value: 1600 },
+                editor_model::Modifier::BlockGap { value: 120 },
+            ],
+        );
+        let (_, graph) = editor_model::Doc::from_plain(plain);
+        let graph = editor_crdt::wire::encode(&graph.changesets_as_vec()).unwrap();
+
+        let modifiers = host.root_modifiers_from_graph(graph).unwrap();
+
+        assert!(modifiers.contains(&editor_model::Modifier::FontSize { value: 1600 }));
+        assert!(modifiers.contains(&editor_model::Modifier::BlockGap { value: 120 }));
+    }
 }
 
 fn doc_start_selection(doc: &editor_model::Doc) -> EditorResult<editor_state::Selection> {

--- a/crates/editor-ffi/src/lib.rs
+++ b/crates/editor-ffi/src/lib.rs
@@ -11,9 +11,11 @@ mod convert;
 mod doc_builder;
 pub mod editor;
 mod error;
+mod graph;
 pub mod host;
 #[cfg(not(feature = "wasm-server"))]
 mod platform;
 mod prelude;
+mod root;
 #[cfg(feature = "wasm-server")]
 mod server;

--- a/crates/editor-ffi/src/root.rs
+++ b/crates/editor-ffi/src/root.rs
@@ -1,0 +1,23 @@
+pub(crate) fn attrs(doc: &editor_model::Doc) -> Option<editor_model::PlainRootNode> {
+    let entry = doc.get_entry(editor_model::NodeId::ROOT)?;
+    match &entry.node.to_plain() {
+        editor_model::PlainNode::Root(root) => Some(root.clone()),
+        _ => unreachable!("root entry must be Root"),
+    }
+}
+
+pub(crate) fn base_style_modifiers(doc: &editor_model::Doc) -> Vec<editor_model::Modifier> {
+    let Some(root) = doc.root() else {
+        return Vec::new();
+    };
+    let Some(style_id) = root.entry().style.get().as_deref() else {
+        return Vec::new();
+    };
+    if !doc.style_present(style_id) {
+        return Vec::new();
+    }
+    let Some(style) = doc.style_entry(style_id) else {
+        return Vec::new();
+    };
+    style.modifiers.iter().cloned().collect()
+}

--- a/crates/editor-macros/src/ffi_export_macro/meta.rs
+++ b/crates/editor-macros/src/ffi_export_macro/meta.rs
@@ -112,16 +112,33 @@ fn path_matches(path: &syn::Path, segments: &[&str]) -> bool {
         .all(|(seg, expected)| seg.ident == expected)
 }
 
-fn last_segment_name(ty: &syn::Type) -> Option<String> {
+fn type_name(ty: &syn::Type) -> Option<String> {
     if let syn::Type::Path(type_path) = ty {
-        type_path
-            .path
-            .segments
-            .last()
-            .map(|seg| seg.ident.to_string())
-    } else {
-        None
+        let seg = type_path.path.segments.last()?;
+        let ident = seg.ident.to_string();
+        if let syn::PathArguments::AngleBracketed(args) = &seg.arguments {
+            let mapped = args
+                .args
+                .iter()
+                .filter_map(|arg| match arg {
+                    syn::GenericArgument::Type(ty) => type_name(ty),
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+            if !mapped.is_empty() {
+                return Some(format!("{}<{}>", ident, mapped.join(", ")));
+            }
+        }
+        return Some(ident);
     }
+
+    if let syn::Type::Tuple(tuple) = ty
+        && tuple.elems.is_empty()
+    {
+        return Some("()".into());
+    }
+
+    None
 }
 
 fn extract_angle_bracketed_inner(seg: &syn::PathSegment) -> Option<&syn::Type> {
@@ -143,7 +160,7 @@ fn parse_param_type(ty: &syn::Type) -> FfiParamType {
         match ident.as_str() {
             "Complex" => {
                 if let Some(inner) = extract_angle_bracketed_inner(seg) {
-                    let inner_name = last_segment_name(inner).unwrap_or_default();
+                    let inner_name = type_name(inner).unwrap_or_default();
                     return FfiParamType::Complex(inner_name);
                 }
             }
@@ -173,7 +190,7 @@ fn parse_scalar_param(ty: &syn::Type) -> FfiScalarParam {
         if ident == "Complex"
             && let Some(inner) = extract_angle_bracketed_inner(seg)
         {
-            let inner_name = last_segment_name(inner).unwrap_or_default();
+            let inner_name = type_name(inner).unwrap_or_default();
             return FfiScalarParam::Complex(inner_name);
         }
         return FfiScalarParam::Primitive(ident);
@@ -202,13 +219,13 @@ fn parse_return_type_inner(ty: &syn::Type, impl_name: &str) -> FfiReturnType {
             }
             "Owned" => {
                 if let Some(inner) = extract_angle_bracketed_inner(seg) {
-                    let inner_name = resolve_self(last_segment_name(inner), impl_name);
+                    let inner_name = resolve_self(type_name(inner), impl_name);
                     return FfiReturnType::Owned(inner_name);
                 }
             }
             "Complex" => {
                 if let Some(inner) = extract_angle_bracketed_inner(seg) {
-                    let inner_name = last_segment_name(inner).unwrap_or_default();
+                    let inner_name = type_name(inner).unwrap_or_default();
                     return FfiReturnType::Complex(inner_name);
                 }
             }
@@ -244,13 +261,13 @@ fn parse_scalar_return(ty: &syn::Type, impl_name: &str) -> FfiScalarReturn {
         match ident.as_str() {
             "Complex" => {
                 if let Some(inner) = extract_angle_bracketed_inner(seg) {
-                    let inner_name = last_segment_name(inner).unwrap_or_default();
+                    let inner_name = type_name(inner).unwrap_or_default();
                     return FfiScalarReturn::Complex(inner_name);
                 }
             }
             "Owned" => {
                 if let Some(inner) = extract_angle_bracketed_inner(seg) {
-                    let inner_name = resolve_self(last_segment_name(inner), impl_name);
+                    let inner_name = resolve_self(type_name(inner), impl_name);
                     return FfiScalarReturn::Owned(inner_name);
                 }
             }
@@ -265,5 +282,40 @@ fn resolve_self(name: Option<String>, impl_name: &str) -> String {
         Some("Self") => impl_name.into(),
         Some(n) => n.into(),
         None => impl_name.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn complex_return_preserves_generic_type_arguments() {
+        let method: syn::ImplItemFn = syn::parse_quote! {
+            pub fn applied_style(
+                &self,
+            ) -> EditorResult<Complex<editor_common::Tri<editor_core::StyleRefValue>>> {
+                todo!()
+            }
+        };
+
+        let extracted = extract_method(&method, "Editor");
+
+        assert_eq!(
+            extracted.return_type,
+            FfiReturnType::Complex("Tri<StyleRefValue>".into())
+        );
+    }
+
+    #[test]
+    fn complex_param_preserves_generic_type_arguments() {
+        let ty: syn::Type = syn::parse_quote! {
+            Complex<editor_common::Tri<editor_core::StyleRefValue>>
+        };
+
+        assert_eq!(
+            parse_param_type(&ty),
+            FfiParamType::Complex("Tri<StyleRefValue>".into())
+        );
     }
 }


### PR DESCRIPTION
- `Complex<T>` 메서드 metadata에서 generic 인자를 보존해 `appliedStyle(): Tri<StyleRefValue>`가 생성되도록 수정
- Kotlin bindgen에서 `BTreeSet`을 `Set`으로 매핑하고 collection default를 `emptyMap()` / `emptySet()`으로 생성하도록 수정
- root modifier가 base style modifier로 전환된 현재 모델에 맞춰 `rootModifiers` / `rootModifiersFromGraph` FFI API 복구
- `editor.rs` / `host.rs`에 중복되어 있던 root projection과 graph materialization 로직을 private helper로 공유
