### PR TITLE
코멘트 하이라이트에 커서가 가려지지 않도록 함

### DIFF
--- a/apps/website/src/lib/editor-ffi/components/Page.svelte
+++ b/apps/website/src/lib/editor-ffi/components/Page.svelte
@@ -152,18 +152,20 @@
       };
     }}
   >
-    {#each [0, 1, 2, 3] as layer (layer)}
-      <canvas
-        style:z-index={layer}
-        class={css({ position: 'absolute', inset: '0', height: 'full', width: 'full', imageRendering: 'pixelated' })}
-        {@attach (canvas) => {
-          canvases[layer] = canvas;
-          return () => {
-            canvases[layer] = undefined;
-          };
-        }}
-      ></canvas>
-    {/each}
+    <div class={css({ position: 'absolute', inset: '0', isolation: 'isolate' })}>
+      {#each [0, 1, 2, 3] as layer (layer)}
+        <canvas
+          style:z-index={layer}
+          class={css({ position: 'absolute', inset: '0', height: 'full', width: 'full', imageRendering: 'pixelated' })}
+          {@attach (canvas) => {
+            canvases[layer] = canvas;
+            return () => {
+              canvases[layer] = undefined;
+            };
+          }}
+        ></canvas>
+      {/each}
+    </div>
 
     {#each externalElements as element (element.node_id)}
       <ExternalElement {element} />


### PR DESCRIPTION
4개 page layer의 stacking context를 isolate해서 코멘트 하이라이트같은 것이 그려지는 z index 높은 레이어들이 caret과 같은 다른 오버레이를 가리지 않도록 함