### PR TITLE
앱 에디터 initialize 전에 register

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Editor.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Editor.kt
@@ -541,23 +541,29 @@ internal constructor(
     ): Editor {
       var createdEditor: Editor? = null
       return try {
-        val editor =
-          withContext(Dispatchers.Default) {
-            val editor = Editor(createInner(), scope, dispatcher, onError)
-            createdEditor = editor
+        withContext(Dispatchers.Default) {
+          val editor = Editor(createInner(), scope, dispatcher, onError)
+          createdEditor = editor
 
-            editor.on<EditorEvent.FontDataMissing>(FontLoader.fontDataMissingHandler)
+          editor.on<EditorEvent.FontDataMissing>(FontLoader.fontDataMissingHandler)
+          var initialized = false
+          EditorRegistry.register(editor)
+          try {
             PlatformModule.editorHost.setThemeVariant(themeVariant)
             editor.awaitOrThrow {
               enqueue(Message.System(SystemEvent.ThemeVariantChanged))
               enqueue(Message.System(SystemEvent.Initialize))
             }
-            editor
+            initialized = true
+          } finally {
+            if (!initialized) {
+              EditorRegistry.unregister(editor)
+            }
           }
 
-        EditorRegistry.register(editor)
-        createdEditor = null
-        editor
+          createdEditor = null
+          editor
+        }
       } finally {
         createdEditor?.dispose()
       }


### PR DESCRIPTION
- 웹과 동일
- 초기화 중인 에디터가 FontsChanged를 놓치지 않도록 함