### PR TITLE
에디터 진입 시 selection 복원

### DIFF
--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/platform/PlatformModule.android.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/platform/PlatformModule.android.kt
@@ -19,6 +19,9 @@ actual object PlatformModule {
   actual val ksafePrefs: KSafe by lazy {
     KSafe(context = context, fileName = "prefs", memoryPolicy = KSafeMemoryPolicy.PLAIN_TEXT)
   }
+  actual val ksafeState: KSafe by lazy {
+    KSafe(context = context, fileName = "state", memoryPolicy = KSafeMemoryPolicy.PLAIN_TEXT)
+  }
   actual val ksafeVault: KSafe by lazy { KSafe(context = context, fileName = "vault") }
   actual val clipboard: Clipboard by lazy { AndroidClipboard(context) }
   actual val deviceInfo: DeviceInfo by lazy { AndroidDeviceInfo(context) }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/preview/EditorPreview.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/preview/EditorPreview.kt
@@ -230,7 +230,7 @@ private fun EditorPreviewContent(
         enqueue(Message.Selection(SelectionOp.Expand(SelectionExpansionUnit.All)))
         modifiers.forEach { modifier -> enqueue(Message.Modifier(ModifierOp.Set(modifier))) }
       }
-      enqueue(Message.Selection(SelectionOp.SetFlat(start = 0, end = 0)))
+      enqueue(Message.Selection(SelectionOp.Unset))
       enqueue(Message.System(SystemEvent.SetFocused(false)))
     }
   }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/platform/PlatformModule.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/platform/PlatformModule.kt
@@ -14,6 +14,7 @@ enum class Platform {
 expect object PlatformModule {
   val platform: Platform
   val ksafePrefs: KSafe
+  val ksafeState: KSafe
   val ksafeVault: KSafe
   val clipboard: Clipboard
   val deviceInfo: DeviceInfo

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -87,6 +87,7 @@ import co.typie.icons.Lucide
 import co.typie.navigation.Nav
 import co.typie.platform.PlatformModule
 import co.typie.route.Route
+import co.typie.screen.editor.editor.entry.rememberEditorEntryStateSession
 import co.typie.screen.editor.editor.findreplace.FindReplaceToolbar
 import co.typie.screen.editor.editor.findreplace.FindReplaceTopBarCenter
 import co.typie.screen.editor.editor.findreplace.FindReplaceTopBarLeading
@@ -241,6 +242,13 @@ fun EditorScreen(entityId: String) {
   val editor = runtime.editor
   val editorState = editor?.state ?: EditorState.Initial
   val bringIntoViewRequests = rememberEditorBringIntoViewRequests()
+  val entryState =
+    rememberEditorEntryStateSession(
+      documentId = document?.id,
+      editor = editor,
+      editorFocused = uiState.focused,
+      bringIntoViewRequests = bringIntoViewRequests,
+    )
   val findReplace =
     rememberEditorFindReplaceSession(
       documentLocked = documentLocked,
@@ -727,6 +735,8 @@ fun EditorScreen(entityId: String) {
             subtitleFocusRequestVersion = subtitleFocusRequestVersion.value,
             onTitleChange = model::updateTitleDraft,
             onSubtitleChange = model::updateSubtitleDraft,
+            onTitleFocused = entryState::markTitleFocused,
+            onSubtitleFocused = entryState::markSubtitleFocused,
             onHeightChanged = screenState::updateHeaderHeight,
             onEnterDocument = {
               model.flushDraftsAsync()

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/entry/EditorEntryStateSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/entry/EditorEntryStateSession.kt
@@ -1,0 +1,111 @@
+package co.typie.screen.editor.editor.entry
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.snapshotFlow
+import co.typie.editor.Editor
+import co.typie.editor.ffi.Message
+import co.typie.editor.ffi.Selection
+import co.typie.editor.ffi.SelectionOp
+import co.typie.editor.ffi.StableSelection
+import co.typie.editor.scroll.EditorBringIntoViewRequests
+import co.typie.editor.scroll.EditorBringIntoViewTarget
+import co.typie.editor.scroll.awaitWithBringIntoView
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.filterNotNull
+
+@Stable
+internal class EditorEntryStateSession(
+  private val markElementFocused: (EditorEntryTarget) -> Unit
+) {
+  fun markTitleFocused() {
+    markElementFocused(EditorEntryTarget.Title)
+  }
+
+  fun markSubtitleFocused() {
+    markElementFocused(EditorEntryTarget.Subtitle)
+  }
+}
+
+@Composable
+internal fun rememberEditorEntryStateSession(
+  documentId: String?,
+  editor: Editor?,
+  editorFocused: Boolean,
+  bringIntoViewRequests: EditorBringIntoViewRequests,
+): EditorEntryStateSession {
+  val store = remember { EditorEntryStateStore() }
+  val controller = remember { EditorEntryStateSessionController(store = store) }
+  val currentEditorFocused = rememberUpdatedState(editorFocused)
+
+  LaunchedEffect(documentId, editor, bringIntoViewRequests) {
+    val activeDocumentId = documentId ?: return@LaunchedEffect
+    val activeEditor = editor ?: return@LaunchedEffect
+    val saved = store.load(activeDocumentId) ?: return@LaunchedEffect
+    if (saved.target != EditorEntryTarget.Body) {
+      return@LaunchedEffect
+    }
+    val selection = saved.bodySelection ?: return@LaunchedEffect
+
+    activeEditor.awaitWithBringIntoView(bringIntoViewRequests) {
+      enqueue(Message.Selection(SelectionOp.SetFrozen(selection = selection)))
+      beforeCommit { bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead) }
+    }
+  }
+
+  LaunchedEffect(documentId, editor) {
+    val activeDocumentId = documentId ?: return@LaunchedEffect
+    val activeEditor = editor ?: return@LaunchedEffect
+
+    snapshotFlow { activeEditor.selection }
+      .filterNotNull()
+      .collect { selection ->
+        if (!currentEditorFocused.value) {
+          return@collect
+        }
+
+        controller.saveBodySelection(
+          documentId = activeDocumentId,
+          editor = activeEditor,
+          selection = selection,
+        )
+      }
+  }
+
+  return remember(documentId, controller) {
+    EditorEntryStateSession { target ->
+      documentId?.let { activeDocumentId ->
+        controller.saveElementFocus(documentId = activeDocumentId, target = target)
+      }
+    }
+  }
+}
+
+private class EditorEntryStateSessionController(private val store: EditorEntryStateStore) {
+  fun saveElementFocus(documentId: String, target: EditorEntryTarget) {
+    save(documentId = documentId, target = target, bodySelection = null)
+  }
+
+  fun saveBodySelection(documentId: String, editor: Editor, selection: Selection) {
+    val frozen = editor.freezeSelection(selection) ?: return
+    save(documentId = documentId, target = EditorEntryTarget.Body, bodySelection = frozen)
+  }
+
+  @OptIn(ExperimentalTime::class)
+  private fun save(documentId: String, target: EditorEntryTarget, bodySelection: StableSelection?) {
+    store.save(
+      documentId = documentId,
+      state =
+        StoredEditorEntryState(
+          target = target,
+          bodySelection = bodySelection,
+          updatedAt = Clock.System.now().toEpochMilliseconds(),
+        ),
+    )
+  }
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/entry/EditorEntryStateStore.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/entry/EditorEntryStateStore.kt
@@ -1,0 +1,41 @@
+package co.typie.screen.editor.editor.entry
+
+import co.typie.editor.ffi.StableSelection
+import co.typie.serialization.json
+import co.typie.storage.AppState
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+
+@Serializable
+internal enum class EditorEntryTarget {
+  Title,
+  Subtitle,
+  Body,
+}
+
+@Serializable
+internal data class StoredEditorEntryState(
+  val target: EditorEntryTarget,
+  val bodySelection: StableSelection? = null,
+  val updatedAt: Long,
+)
+
+internal class EditorEntryStateStore(
+  private val read: (documentId: String) -> String? = AppState::getSerializedEditorEntryState,
+  private val write: (documentId: String, value: String) -> Unit =
+    AppState::setSerializedEditorEntryState,
+) {
+  fun load(documentId: String): StoredEditorEntryState? {
+    val raw = read(documentId) ?: return null
+    return try {
+      json.decodeFromString<StoredEditorEntryState>(raw)
+    } catch (_: Exception) {
+      null
+    }
+  }
+
+  fun save(documentId: String, state: StoredEditorEntryState) {
+    write(documentId, json.encodeToString(state))
+  }
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/header/EditorHeader.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/header/EditorHeader.kt
@@ -61,6 +61,8 @@ internal fun EditorHeader(
   modifier: Modifier = Modifier,
   onTitleChange: (String) -> Unit,
   onSubtitleChange: (String) -> Unit,
+  onTitleFocused: () -> Unit,
+  onSubtitleFocused: () -> Unit,
   onHeightChanged: (Float) -> Unit,
   onEnterDocument: () -> Unit,
 ) {
@@ -129,6 +131,7 @@ internal fun EditorHeader(
         onEnterDocument = { subtitleInputState.requestFocus() },
         onFocusPrevious = {},
         onBackspaceAtStart = {},
+        onFocused = onTitleFocused,
         modifier = Modifier.fillMaxWidth(),
         textInputState = titleInputState,
       )
@@ -161,6 +164,7 @@ internal fun EditorHeader(
             titleInputState.requestFocus()
           }
         },
+        onFocused = onSubtitleFocused,
         modifier = Modifier.fillMaxWidth(),
         textInputState = subtitleInputState,
       )
@@ -189,6 +193,7 @@ private fun EditorHeaderField(
   onEnterDocument: () -> Unit,
   onFocusPrevious: () -> Unit,
   onBackspaceAtStart: () -> Unit,
+  onFocused: () -> Unit,
   modifier: Modifier = Modifier,
   textInputState: TextInputState,
 ) {
@@ -196,43 +201,49 @@ private fun EditorHeaderField(
     value = text,
     onValueChange = onValueChange,
     modifier =
-      modifier.textInputFocusable(textInputState).onPreviewKeyEvent {
-        if (it.type != KeyEventType.KeyDown) {
-          return@onPreviewKeyEvent false
+      modifier
+        .textInputFocusable(textInputState) {
+          if (it.isFocused) {
+            onFocused()
+          }
         }
+        .onPreviewKeyEvent {
+          if (it.type != KeyEventType.KeyDown) {
+            return@onPreviewKeyEvent false
+          }
 
-        when (it.key) {
-          Key.DirectionDown -> {
-            onFocusNext()
-            true
-          }
-          Key.DirectionUp -> {
-            onFocusPrevious()
-            true
-          }
-          Key.Enter -> {
-            if (it.isShiftPressed) {
-              false
-            } else {
-              onEnterDocument()
+          when (it.key) {
+            Key.DirectionDown -> {
+              onFocusNext()
               true
             }
-          }
-          Key.Tab -> {
-            if (it.isShiftPressed) {
+            Key.DirectionUp -> {
               onFocusPrevious()
-            } else {
-              onFocusNext()
+              true
             }
-            true
+            Key.Enter -> {
+              if (it.isShiftPressed) {
+                false
+              } else {
+                onEnterDocument()
+                true
+              }
+            }
+            Key.Tab -> {
+              if (it.isShiftPressed) {
+                onFocusPrevious()
+              } else {
+                onFocusNext()
+              }
+              true
+            }
+            Key.Backspace -> {
+              onBackspaceAtStart()
+              false
+            }
+            else -> false
           }
-          Key.Backspace -> {
-            onBackspaceAtStart()
-            false
-          }
-          else -> false
-        }
-      },
+        },
     textStyle = style.copy(color = AppTheme.colors.textDefault),
     cursorBrush = SolidColor(AppTheme.colors.textDefault),
     keyboardOptions = KeyboardOptions(imeAction = imeAction),

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/storage/AppState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/storage/AppState.kt
@@ -1,0 +1,21 @@
+package co.typie.storage
+
+import co.typie.platform.PlatformModule
+import eu.anifantakis.lib.ksafe.KSafeWriteMode
+
+object AppState {
+  private const val EditorEntryStatePrefix = "editor_entry_state:"
+
+  fun getSerializedEditorEntryState(documentId: String): String? =
+    PlatformModule.ksafeState.getDirect<String?>(editorEntryStateKey(documentId), null)
+
+  fun setSerializedEditorEntryState(documentId: String, value: String) {
+    PlatformModule.ksafeState.putDirect(
+      key = editorEntryStateKey(documentId),
+      value = value,
+      mode = KSafeWriteMode.Plain,
+    )
+  }
+
+  private fun editorEntryStateKey(documentId: String): String = "$EditorEntryStatePrefix$documentId"
+}

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorAwaitWithBringIntoViewTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorAwaitWithBringIntoViewTest.kt
@@ -2,13 +2,16 @@ package co.typie.editor.scroll
 
 import co.typie.editor.Editor
 import co.typie.editor.FakeFfiEditor
+import co.typie.editor.ffi.EditorEvent
 import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.SystemEvent
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -49,6 +52,36 @@ class EditorAwaitWithBringIntoViewTest {
         request(EditorBringIntoViewTarget.CurrentCursorLine),
         requests.activateForVersion(version = 1L),
       )
+    }
+
+  @Test
+  fun `await bringIntoView request survives cancel before commit`() =
+    runTest(dispatcher) {
+      val requests = EditorBringIntoViewRequests()
+      val editor =
+        Editor(FakeFfiEditor(onTick = { listOf(EditorEvent.RenderInvalidated) }), this, dispatcher)
+      editor.attachSurface(page = 0, handle = 0L, width = 0.0, height = 0.0, scaleFactor = 1.0)
+
+      val job =
+        launch(dispatcher) {
+          editor.awaitWithBringIntoView(requests) {
+            enqueue(Message.System(SystemEvent.Initialize))
+            beforeCommit { bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead) }
+          }
+        }
+      dispatcher.scheduler.advanceUntilIdle()
+
+      assertNull(requests.activateForVersion(version = 1L))
+      requests.cancel()
+
+      editor.onPageSettled(page = 0, version = 1L)
+      dispatcher.scheduler.advanceUntilIdle()
+
+      assertEquals(
+        request(EditorBringIntoViewTarget.CurrentSelectionHead),
+        requests.activateForVersion(version = 1L),
+      )
+      job.join()
     }
 
   private fun request(

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/entry/EditorEntryStateStoreTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/entry/EditorEntryStateStoreTest.kt
@@ -1,0 +1,58 @@
+package co.typie.screen.editor.editor.entry
+
+import co.typie.editor.ffi.Affinity
+import co.typie.editor.ffi.StablePosition
+import co.typie.editor.ffi.StablePositionBinding
+import co.typie.editor.ffi.StableSelection
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class EditorEntryStateStoreTest {
+  @Test
+  fun saves_entry_state_under_document_scoped_keys() {
+    val rawEntries = mutableMapOf<String, String>()
+    val store =
+      EditorEntryStateStore(
+        read = rawEntries::get,
+        write = { documentId, value -> rawEntries[documentId] = value },
+      )
+
+    val first = StoredEditorEntryState(target = EditorEntryTarget.Title, updatedAt = 10L)
+    val second =
+      StoredEditorEntryState(
+        target = EditorEntryTarget.Body,
+        bodySelection = stableSelection(),
+        updatedAt = 20L,
+      )
+
+    store.save(documentId = "doc-a", state = first)
+    store.save(documentId = "doc-b", state = second)
+
+    assertEquals(setOf("doc-a", "doc-b"), rawEntries.keys)
+    assertEquals(first, store.load(documentId = "doc-a"))
+    assertEquals(second, store.load(documentId = "doc-b"))
+  }
+
+  @Test
+  fun returns_null_for_malformed_entry_state() {
+    val rawEntries = mutableMapOf("doc-a" to "{")
+    val store =
+      EditorEntryStateStore(
+        read = rawEntries::get,
+        write = { documentId, value -> rawEntries[documentId] = value },
+      )
+
+    assertNull(store.load(documentId = "doc-a"))
+  }
+}
+
+private fun stableSelection(): StableSelection {
+  val position =
+    StablePosition(
+      chain = emptyList(),
+      binding = StablePositionBinding.ContainerStart,
+      affinity = Affinity.Downstream,
+    )
+  return StableSelection(anchor = position, head = position)
+}

--- a/apps/mobile/compose/src/desktopMain/kotlin/co/typie/platform/PlatformModule.desktop.kt
+++ b/apps/mobile/compose/src/desktopMain/kotlin/co/typie/platform/PlatformModule.desktop.kt
@@ -13,6 +13,8 @@ actual object PlatformModule {
   actual val platform: Platform = Platform.Desktop
   actual val ksafePrefs: KSafe =
     KSafe(fileName = "prefs", memoryPolicy = KSafeMemoryPolicy.PLAIN_TEXT)
+  actual val ksafeState: KSafe =
+    KSafe(fileName = "state", memoryPolicy = KSafeMemoryPolicy.PLAIN_TEXT)
   actual val ksafeVault: KSafe = KSafe(fileName = "vault")
   actual val clipboard: Clipboard = DesktopClipboard()
   actual val deviceInfo: DeviceInfo = DesktopDeviceInfo()

--- a/apps/mobile/compose/src/iosMain/kotlin/co/typie/platform/PlatformModule.ios.kt
+++ b/apps/mobile/compose/src/iosMain/kotlin/co/typie/platform/PlatformModule.ios.kt
@@ -23,6 +23,8 @@ actual object PlatformModule {
   actual val platform: Platform = Platform.iOS
   actual val ksafePrefs: KSafe =
     KSafe(fileName = "prefs", memoryPolicy = KSafeMemoryPolicy.PLAIN_TEXT)
+  actual val ksafeState: KSafe =
+    KSafe(fileName = "state", memoryPolicy = KSafeMemoryPolicy.PLAIN_TEXT)
   actual val ksafeVault: KSafe = KSafe(fileName = "vault")
   actual val clipboard: Clipboard = IOSClipboard()
   actual val deviceInfo: DeviceInfo = IOSDeviceInfo()

--- a/apps/website/src/lib/editor-ffi/components/View.svelte
+++ b/apps/website/src/lib/editor-ffi/components/View.svelte
@@ -3,7 +3,7 @@
   import { css } from '@typie/styled-system/css';
   import { getThemeContext } from '@typie/ui/context';
   import { elementScrollViewport, windowScrollViewport } from '@typie/ui/utils';
-  import { tick, untrack } from 'svelte';
+  import { untrack } from 'svelte';
   import { graphql } from '$mearie';
   import {
     CONTINUOUS_MIN_WIDTH,
@@ -160,9 +160,6 @@
         readyFired = true;
         loadFonts(document.data.editorFontFamilies);
         onReady?.();
-        if (active) {
-          void tick().then(() => editor.focus());
-        }
       }
     });
   });

--- a/crates/editor-ffi/src/host.rs
+++ b/crates/editor-ffi/src/host.rs
@@ -99,12 +99,7 @@ impl EditorHost {
         changesets: Vec<u8>,
         viewport: Complex<editor_view::Viewport>,
     ) -> EditorResult<Owned<crate::editor::Editor>> {
-        let mut state = crate::graph::state_from_changesets(changesets)?;
-        let selection = {
-            let view = state.view();
-            editor_state::doc_start_selection(&view)
-        };
-        state.selection = selection;
+        let state = crate::graph::state_from_changesets(changesets)?;
         let viewport = viewport.from_ffi()?;
         let core = editor_core::Editor::new(state, viewport, Arc::clone(&self.resource));
         Ok(into_owned(crate::editor::Editor::new(core)))
@@ -117,12 +112,7 @@ impl EditorHost {
         viewport: Complex<editor_view::Viewport>,
     ) -> EditorResult<Owned<crate::editor::Editor>> {
         let pending = crate::graph::decode_length_prefixed(&pending_encoded)?;
-        let mut state = crate::graph::state_from_changesets_with_pending(server, pending)?;
-        let selection = {
-            let view = state.view();
-            editor_state::doc_start_selection(&view)
-        };
-        state.selection = selection;
+        let state = crate::graph::state_from_changesets_with_pending(server, pending)?;
         let viewport = viewport.from_ffi()?;
         let core = editor_core::Editor::new(state, viewport, Arc::clone(&self.resource));
         Ok(into_owned(crate::editor::Editor::new(core)))
@@ -243,6 +233,15 @@ mod tests {
         }
     }
 
+    fn test_viewport() -> editor_view::Viewport {
+        editor_view::Viewport::new(320.0, 640.0, 1.0)
+    }
+
+    fn graph_from_plain(plain: &editor_model::PlainDoc) -> Vec<u8> {
+        let state = editor_state::State::from_plain(plain).unwrap();
+        editor_crdt::wire::encode(&state.graph().changesets_as_vec()).unwrap()
+    }
+
     #[test]
     fn set_theme_variant_returns_true_on_change() {
         let host = make_host();
@@ -280,5 +279,44 @@ mod tests {
 
         assert!(modifiers.contains(&editor_model::Modifier::FontSize { value: 1600 }));
         assert!(modifiers.contains(&editor_model::Modifier::BlockGap { value: 120 }));
+    }
+
+    #[test]
+    fn create_editor_from_graph_preserves_missing_selection() {
+        let host = make_host();
+        let plain =
+            crate::doc_builder::build_default_doc(editor_model::PlainRootNode::default(), vec![]);
+        let graph = graph_from_plain(&plain);
+
+        let editor = host
+            .create_editor_from_graph(graph, test_viewport())
+            .unwrap();
+
+        assert!(editor.selection().unwrap().is_none());
+    }
+
+    #[test]
+    fn create_editor_from_doc_preserves_missing_selection() {
+        let host = make_host();
+        let plain =
+            crate::doc_builder::build_default_doc(editor_model::PlainRootNode::default(), vec![]);
+
+        let editor = host.create_editor_from_doc(plain, test_viewport()).unwrap();
+
+        assert!(editor.selection().unwrap().is_none());
+    }
+
+    #[test]
+    fn create_editor_from_graph_with_pending_preserves_missing_selection() {
+        let host = make_host();
+        let plain =
+            crate::doc_builder::build_default_doc(editor_model::PlainRootNode::default(), vec![]);
+        let graph = graph_from_plain(&plain);
+
+        let editor = host
+            .create_editor_from_graph_with_pending(graph, vec![], test_viewport())
+            .unwrap();
+
+        assert!(editor.selection().unwrap().is_none());
     }
 }

--- a/crates/editor-state/src/load_builder.rs
+++ b/crates/editor-state/src/load_builder.rs
@@ -5,9 +5,9 @@ use editor_model::{
     classify,
 };
 
+use crate::Selection;
 use crate::fragment_builder::{GraphSink, emit_text_run};
 use crate::projected_state::{ProjectedState, SpineError};
-use crate::{Selection, doc_start_selection};
 
 #[derive(Debug)]
 pub enum BuildError {
@@ -202,11 +202,7 @@ pub(crate) fn load_from_plain(
     let mut graph = build_graph_from_plain(template)?;
     graph.commit_mut();
     let state = ProjectedState::from_graph(graph)?;
-    let sel = {
-        let view = state.view();
-        doc_start_selection(&view)
-    };
-    Ok((state, sel))
+    Ok((state, None))
 }
 
 #[cfg(test)]
@@ -514,24 +510,15 @@ mod tests {
     }
 
     #[test]
-    fn load_returns_initial_caret() {
+    fn load_returns_no_initial_selection() {
         let template = default_doc();
         let (state, sel) = load_from_plain(&template).expect("loads");
-        let sel = sel.expect("doc-start caret present");
-        assert_eq!(sel.anchor, sel.head, "caret is collapsed");
-
-        let view = state.view();
-        let node = view
-            .node(sel.anchor.node)
-            .expect("caret node is live in the view");
-        assert!(
-            sel.anchor.offset <= node.children().count(),
-            "caret offset within node bounds"
-        );
+        assert!(sel.is_none());
+        assert!(state.view().root().is_some());
     }
 
     #[test]
-    fn load_empty_paragraph_caret_at_zero() {
+    fn load_empty_paragraph_returns_no_initial_selection() {
         let para = block_entry(vec![], PlainNode::Paragraph(PlainParagraphNode {}));
         let root = block_entry(vec![para], PlainNode::Root(PlainRootNode::default()));
         let template = PlainDoc {
@@ -540,7 +527,7 @@ mod tests {
         };
 
         let (state, sel) = load_from_plain(&template).expect("loads");
-        let sel = sel.expect("caret present");
+        assert!(sel.is_none());
 
         let view = state.view();
         let para = view
@@ -549,9 +536,7 @@ mod tests {
             .child_blocks()
             .next()
             .expect("paragraph");
-        let para_dot = para.dot().expect("paragraph is a real node");
-        assert_eq!(sel.anchor.node, para_dot);
-        assert_eq!(sel.anchor.offset, 0);
+        assert!(para.dot().is_some());
     }
 
     #[test]


### PR DESCRIPTION
- 문서 기본 selection은 null
- 앱: 에디터 진입 시 아무 곳에서 포커스하지 않음, 하지만 마지막으로 본문에 포커스했고 selection이 있었다면 그 selection을 복원하고 스크롤함
- 웹: 새 문서 진입 시 제목에 포커스하도록 디버그