### PR TITLE
bringIntoViewTarget CurrentCursorLine를 없애고 CurrentSelectionHead로 통일

### DIFF
--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/input/EditorInputConnection.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/input/EditorInputConnection.kt
@@ -37,7 +37,7 @@ internal class EditorInputConnection(
       for (message in messages) {
         enqueue(message)
       }
-      beforeCommit { bringIntoView(EditorBringIntoViewTarget.CurrentCursorLine) }
+      beforeCommit { bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead) }
     }
   }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Keyboard.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Keyboard.kt
@@ -39,9 +39,8 @@ internal data class KeyBinding(
   val key: ComposeKey,
   val modifiers: Set<KeyModifier> = emptySet(),
   val predicate: (() -> Boolean)? = null,
-  // TODO(editor-parity): movement/selection shortcut은 키별 고정 target보다, dispatch 이후의
-  // 실제 scroll anchor(selection head 또는 cursor)를 따라가도록 정리해야 한다.
-  val bringIntoViewTarget: EditorBringIntoViewTarget? = EditorBringIntoViewTarget.CurrentCursorLine,
+  val bringIntoViewTarget: EditorBringIntoViewTarget? =
+    EditorBringIntoViewTarget.CurrentSelectionHead,
   val action: suspend Editor.(Clipboard) -> List<Message>,
 )
 
@@ -302,43 +301,36 @@ internal fun createBindings(platform: Platform): List<KeyBinding> {
     KeyBinding(
       ComposeKey.B,
       setOf(KeyModifier.Mod),
-      bringIntoViewTarget = EditorBringIntoViewTarget.CurrentSelectionHead,
       action = { listOf(toggleModifier(ModifierType.Bold)) },
     ),
     KeyBinding(
       ComposeKey.I,
       setOf(KeyModifier.Mod),
-      bringIntoViewTarget = EditorBringIntoViewTarget.CurrentSelectionHead,
       action = { listOf(toggleModifier(ModifierType.Italic)) },
     ),
     KeyBinding(
       ComposeKey.S,
       setOf(KeyModifier.Mod, KeyModifier.Shift),
-      bringIntoViewTarget = EditorBringIntoViewTarget.CurrentSelectionHead,
       action = { listOf(toggleModifier(ModifierType.Strikethrough)) },
     ),
     KeyBinding(
       ComposeKey.U,
       setOf(KeyModifier.Mod),
-      bringIntoViewTarget = EditorBringIntoViewTarget.CurrentSelectionHead,
       action = { listOf(toggleModifier(ModifierType.Underline)) },
     ),
     KeyBinding(
       ComposeKey.Backslash,
       setOf(KeyModifier.Mod),
-      bringIntoViewTarget = EditorBringIntoViewTarget.CurrentSelectionHead,
       action = { listOf(Message.Modifier(ModifierOp.ClearAll)) },
     ),
     KeyBinding(
       ComposeKey.Z,
       setOf(KeyModifier.Mod),
-      bringIntoViewTarget = EditorBringIntoViewTarget.CurrentSelectionHead,
       action = { listOf(Message.History(HistoryOp.Undo)) },
     ),
     KeyBinding(
       ComposeKey.Z,
       setOf(KeyModifier.Mod, KeyModifier.Shift),
-      bringIntoViewTarget = EditorBringIntoViewTarget.CurrentSelectionHead,
       action = { listOf(Message.History(HistoryOp.Redo)) },
     ),
     KeyBinding(
@@ -353,7 +345,6 @@ internal fun createBindings(platform: Platform): List<KeyBinding> {
     KeyBinding(
       ComposeKey.X,
       setOf(KeyModifier.Mod),
-      bringIntoViewTarget = EditorBringIntoViewTarget.CurrentSelectionHead,
       action = { clipboard ->
         val payload = copySelection() ?: return@KeyBinding emptyList()
         if (clipboard.copyRichText(html = payload.html, text = payload.text)) {
@@ -374,7 +365,6 @@ internal fun createBindings(platform: Platform): List<KeyBinding> {
     KeyBinding(
       ComposeKey.A,
       setOf(KeyModifier.Mod),
-      bringIntoViewTarget = EditorBringIntoViewTarget.CurrentSelectionHead,
       action = { listOf(Message.Selection(SelectionOp.Expand(SelectionExpansionUnit.All))) },
     ),
     KeyBinding(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorInput.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorInput.kt
@@ -188,7 +188,7 @@ internal class EditorInputNode(
 
   private fun dispatch(
     messages: List<Message>,
-    bringIntoViewTarget: EditorBringIntoViewTarget? = EditorBringIntoViewTarget.CurrentCursorLine,
+    bringIntoViewTarget: EditorBringIntoViewTarget? = EditorBringIntoViewTarget.CurrentSelectionHead,
   ) {
     if (messages.isEmpty()) return
     coroutineScope.launch {
@@ -222,7 +222,7 @@ internal class EditorInputNode(
 
   private fun dispatchSync(
     messages: List<Message>,
-    bringIntoViewTarget: EditorBringIntoViewTarget? = EditorBringIntoViewTarget.CurrentCursorLine,
+    bringIntoViewTarget: EditorBringIntoViewTarget? = EditorBringIntoViewTarget.CurrentSelectionHead,
   ): EditorState? {
     if (messages.isEmpty()) return null
     return editor.syncWithBringIntoView(bringIntoViewRequests) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionEffects.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionEffects.kt
@@ -24,5 +24,5 @@ internal interface EditorInteractionEffects {
 
   fun performSelectionHaptic()
 
-  fun requestCurrentCursorLine(version: Long)
+  fun requestCurrentSelectionHead(version: Long)
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionScope.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionScope.kt
@@ -229,9 +229,9 @@ internal class EditorInteractionScope(private val coroutineScope: CoroutineScope
     onSelectionHaptic?.invoke()
   }
 
-  override fun requestCurrentCursorLine(version: Long) {
+  override fun requestCurrentSelectionHead(version: Long) {
     bringIntoViewRequests?.requestForVersion(
-      target = EditorBringIntoViewTarget.CurrentCursorLine,
+      target = EditorBringIntoViewTarget.CurrentSelectionHead,
       version = version,
     )
   }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorTapGesture.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorTapGesture.kt
@@ -365,7 +365,7 @@ private fun EditorTapGesture.dispatchTap(
           else -> {
             context.uiState.contextMenu.hide()
             if (snapshot.cursor != null) {
-              context.semantics.cursorMove.requestCurrentCursorLine(version = snapshot.version)
+              context.semantics.cursorMove.requestCurrentSelectionHead(version = snapshot.version)
             }
           }
         }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/semantics/EditorCursorMoveSemantic.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/semantics/EditorCursorMoveSemantic.kt
@@ -16,8 +16,8 @@ internal class EditorCursorMoveSemantic(private val effects: EditorInteractionEf
 
   fun requestFocus(editor: Editor): Boolean = effects.requestFocus(editor)
 
-  fun requestCurrentCursorLine(version: Long) {
-    effects.requestCurrentCursorLine(version = version)
+  fun requestCurrentSelectionHead(version: Long) {
+    effects.requestCurrentSelectionHead(version = version)
   }
 
   fun launchPrimaryClick(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorScrollIntent.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorScrollIntent.kt
@@ -20,8 +20,6 @@ internal data class EditorScrollFrame(
 )
 
 internal sealed interface EditorBringIntoViewTarget {
-  data object CurrentCursorLine : EditorBringIntoViewTarget
-
   data object CurrentSelectionHead : EditorBringIntoViewTarget
 
   data class OverlayRect(
@@ -172,13 +170,14 @@ private fun resolveBringIntoViewTargetPageRect(
   target: EditorBringIntoViewTarget,
 ): BringIntoViewTargetPageRect? =
   when (target) {
-    EditorBringIntoViewTarget.CurrentCursorLine -> resolveCurrentCursorLinePageRect(state)
     EditorBringIntoViewTarget.CurrentSelectionHead -> resolveCurrentSelectionHeadPageRect(state)
     is EditorBringIntoViewTarget.OverlayRect ->
       BringIntoViewTargetPageRect(pageIdx = target.pageIdx, y = target.top, height = target.height)
   }
 
-private fun resolveCurrentCursorLinePageRect(state: EditorState): BringIntoViewTargetPageRect? {
+private fun resolveCollapsedSelectionHeadPageRect(
+  state: EditorState
+): BringIntoViewTargetPageRect? {
   val cursor = state.cursor ?: return null
   return BringIntoViewTargetPageRect(
     pageIdx = cursor.pageIdx,
@@ -190,7 +189,7 @@ private fun resolveCurrentCursorLinePageRect(state: EditorState): BringIntoViewT
 private fun resolveCurrentSelectionHeadPageRect(state: EditorState): BringIntoViewTargetPageRect? {
   val selection = state.selection ?: return null
   if (selection.anchor == selection.head) {
-    return resolveCurrentCursorLinePageRect(state)
+    return resolveCollapsedSelectionHeadPageRect(state)
   }
   val endpoints = state.selectionEndpoints ?: return null
   val headRect =

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorContextMenuActions.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorContextMenuActions.kt
@@ -85,7 +85,7 @@ internal fun rememberEditorContextMenuActions(
           val read = clipboard.paste() ?: return@launch
           editor.awaitWithBringIntoView(bringIntoViewRequests) {
             enqueue(Message.Clipboard(ClipboardOp.Paste(html = read.html, text = read.text)))
-            beforeCommit { bringIntoView(EditorBringIntoViewTarget.CurrentCursorLine) }
+            beforeCommit { bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead) }
           }
         }
       },

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/bottom/Nodes.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/bottom/Nodes.kt
@@ -97,7 +97,7 @@ internal fun BottomToolbarNodes(onEditorInputRequest: () -> Unit, modifier: Modi
           scope.launch {
             currentEditor.awaitWithBringIntoView(bringIntoViewRequests) {
               enqueue(item.message)
-              beforeCommit { bringIntoView(EditorBringIntoViewTarget.CurrentCursorLine) }
+              beforeCommit { bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead) }
             }
           }
           onEditorInputRequest()

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/KeyboardTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/KeyboardTest.kt
@@ -9,11 +9,13 @@ import co.typie.editor.ffi.KeyEvent as FfiKeyEvent
 import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.Movement
 import co.typie.editor.ffi.NavigationOp
+import co.typie.editor.scroll.EditorBringIntoViewTarget
 import co.typie.platform.Clipboard
 import co.typie.platform.ClipboardReadPayload
 import co.typie.platform.Platform
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
@@ -85,6 +87,24 @@ class KeyboardTest {
       modifiers = setOf(KeyModifier.Shift),
       expected = Movement.Page(Direction.Forward),
     )
+  }
+
+  @Test
+  fun navigationBindingsRevealCurrentSelectionHead() = runTest {
+    val editor = Editor(FakeFfiEditor(), this, Dispatchers.Unconfined)
+    val navigationBindings =
+      createBindings(Platform.Desktop).filter { binding ->
+        with(binding) { editor.action(NoopClipboard) }.singleOrNull() is Message.Navigation
+      }
+
+    assertTrue(navigationBindings.isNotEmpty())
+    navigationBindings.forEach { binding ->
+      assertEquals(
+        EditorBringIntoViewTarget.CurrentSelectionHead,
+        binding.bringIntoViewTarget,
+        "${binding.key} ${binding.modifiers}",
+      )
+    }
   }
 
   @Test

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
@@ -2063,7 +2063,7 @@ class EditorInteractionControllerTest {
 
     override fun performSelectionHaptic() = Unit
 
-    override fun requestCurrentCursorLine(version: Long) {
+    override fun requestCurrentSelectionHead(version: Long) {
       requestedBringIntoViewVersions += version
     }
   }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/semantics/EditorCursorMoveSemanticTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/semantics/EditorCursorMoveSemanticTest.kt
@@ -174,7 +174,7 @@ class EditorCursorMoveSemanticTest {
 
     override fun performSelectionHaptic() = error("Unused in direct cursor semantic dispatch tests")
 
-    override fun requestCurrentCursorLine(version: Long) =
+    override fun requestCurrentSelectionHead(version: Long) =
       error("Unused in direct cursor semantic dispatch tests")
   }
 }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorAutoScrollPolicyTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorAutoScrollPolicyTest.kt
@@ -122,7 +122,7 @@ class EditorAutoScrollPolicyTest {
   }
 
   @Test
-  fun `typewriter bottom padding can use actual space available below the cursor line top`() {
+  fun `typewriter bottom padding can use actual space available below the target line top`() {
     val policy =
       resolveEditorAutoScrollPolicy(
         visibleArea = testVisibleArea(),

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorAwaitWithBringIntoViewTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorAwaitWithBringIntoViewTest.kt
@@ -26,12 +26,12 @@ class EditorAwaitWithBringIntoViewTest {
 
       editor.awaitWithBringIntoView(requests) {
         enqueue(Message.System(SystemEvent.Initialize))
-        beforeCommit { bringIntoView(EditorBringIntoViewTarget.CurrentCursorLine) }
+        beforeCommit { bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead) }
       }
 
       assertNull(requests.activateForVersion(version = 0L))
       assertEquals(
-        request(EditorBringIntoViewTarget.CurrentCursorLine),
+        request(EditorBringIntoViewTarget.CurrentSelectionHead),
         requests.activateForVersion(version = 1L),
       )
     }
@@ -44,12 +44,12 @@ class EditorAwaitWithBringIntoViewTest {
 
       editor.syncWithBringIntoView(requests) {
         enqueue(Message.System(SystemEvent.Initialize))
-        beforeCommit { bringIntoView(EditorBringIntoViewTarget.CurrentCursorLine) }
+        beforeCommit { bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead) }
       }
 
       assertNull(requests.activateForVersion(version = 0L))
       assertEquals(
-        request(EditorBringIntoViewTarget.CurrentCursorLine),
+        request(EditorBringIntoViewTarget.CurrentSelectionHead),
         requests.activateForVersion(version = 1L),
       )
     }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorBringIntoViewRequestsTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorBringIntoViewRequestsTest.kt
@@ -7,32 +7,44 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class EditorBringIntoViewRequestsTest {
+  private val overlayTarget =
+    EditorBringIntoViewTarget.OverlayRect(
+      pageIdx = 0,
+      left = 0f,
+      top = 10f,
+      width = 20f,
+      height = 30f,
+    )
+
   @Test
   fun `bring-into-view target attaches to requested editor version only`() {
     val requests = EditorBringIntoViewRequests()
 
-    requests.requestForVersion(target = EditorBringIntoViewTarget.CurrentCursorLine, version = 11L)
+    requests.requestForVersion(
+      target = EditorBringIntoViewTarget.CurrentSelectionHead,
+      version = 11L,
+    )
 
     assertNull(requests.activateForVersion(version = 10L))
     assertEquals(
-      request(EditorBringIntoViewTarget.CurrentCursorLine),
+      request(EditorBringIntoViewTarget.CurrentSelectionHead),
       requests.activateForVersion(version = 11L),
     )
     assertEquals(
-      request(EditorBringIntoViewTarget.CurrentCursorLine),
+      request(EditorBringIntoViewTarget.CurrentSelectionHead),
       requests.activateForVersion(version = 11L),
     )
 
     assertTrue(
       requests.markApplied(
         version = 11L,
-        request = request(EditorBringIntoViewTarget.CurrentCursorLine),
+        request = request(EditorBringIntoViewTarget.CurrentSelectionHead),
       )
     )
     assertFalse(
       requests.markApplied(
         version = 11L,
-        request = request(EditorBringIntoViewTarget.CurrentCursorLine),
+        request = request(EditorBringIntoViewTarget.CurrentSelectionHead),
       )
     )
     assertNull(requests.activateForVersion(version = 11L))
@@ -42,126 +54,114 @@ class EditorBringIntoViewRequestsTest {
   fun `new bring-into-view request does not cancel active target for current editor version`() {
     val requests = EditorBringIntoViewRequests()
 
-    requests.requestForVersion(target = EditorBringIntoViewTarget.CurrentCursorLine, version = 2L)
+    requests.requestForVersion(
+      target = EditorBringIntoViewTarget.CurrentSelectionHead,
+      version = 2L,
+    )
     assertEquals(
-      request(EditorBringIntoViewTarget.CurrentCursorLine),
+      request(EditorBringIntoViewTarget.CurrentSelectionHead),
       requests.activateForVersion(version = 2L),
     )
 
-    requests.requestForVersion(
-      target = EditorBringIntoViewTarget.CurrentSelectionHead,
-      version = 3L,
-    )
+    requests.requestForVersion(target = overlayTarget, version = 3L)
 
     assertEquals(
-      request(EditorBringIntoViewTarget.CurrentCursorLine),
+      request(EditorBringIntoViewTarget.CurrentSelectionHead),
       requests.activateForVersion(version = 2L),
     )
     assertTrue(
       requests.markApplied(
         version = 2L,
-        request = request(EditorBringIntoViewTarget.CurrentCursorLine),
+        request = request(EditorBringIntoViewTarget.CurrentSelectionHead),
       )
     )
     assertNull(requests.activateForVersion(version = 2L))
-    assertEquals(
-      request(EditorBringIntoViewTarget.CurrentSelectionHead),
-      requests.activateForVersion(version = 3L),
-    )
+    assertEquals(request(overlayTarget), requests.activateForVersion(version = 3L))
   }
 
   @Test
   fun `newer request does not replace previous request before previous target version is built`() {
     val requests = EditorBringIntoViewRequests()
 
-    requests.requestForVersion(target = EditorBringIntoViewTarget.CurrentCursorLine, version = 259L)
-    assertNull(requests.activateForVersion(version = 258L))
-
     requests.requestForVersion(
       target = EditorBringIntoViewTarget.CurrentSelectionHead,
-      version = 260L,
+      version = 259L,
     )
+    assertNull(requests.activateForVersion(version = 258L))
+
+    requests.requestForVersion(target = overlayTarget, version = 260L)
 
     assertEquals(
-      request(EditorBringIntoViewTarget.CurrentCursorLine),
+      request(EditorBringIntoViewTarget.CurrentSelectionHead),
       requests.activateForVersion(version = 259L),
     )
     assertTrue(
       requests.markApplied(
         version = 259L,
-        request = request(EditorBringIntoViewTarget.CurrentCursorLine),
+        request = request(EditorBringIntoViewTarget.CurrentSelectionHead),
       )
     )
 
-    assertEquals(
-      request(EditorBringIntoViewTarget.CurrentSelectionHead),
-      requests.activateForVersion(version = 260L),
-    )
+    assertEquals(request(overlayTarget), requests.activateForVersion(version = 260L))
   }
 
   @Test
   fun `requests for consecutive editor versions attach to consecutive scroll frames`() {
     val requests = EditorBringIntoViewRequests()
 
-    requests.requestForVersion(target = EditorBringIntoViewTarget.CurrentCursorLine, version = 291L)
     requests.requestForVersion(
       target = EditorBringIntoViewTarget.CurrentSelectionHead,
-      version = 292L,
+      version = 291L,
     )
+    requests.requestForVersion(target = overlayTarget, version = 292L)
 
     assertEquals(
-      request(EditorBringIntoViewTarget.CurrentCursorLine),
+      request(EditorBringIntoViewTarget.CurrentSelectionHead),
       requests.activateForVersion(version = 291L),
     )
     assertTrue(
       requests.markApplied(
         version = 291L,
-        request = request(EditorBringIntoViewTarget.CurrentCursorLine),
+        request = request(EditorBringIntoViewTarget.CurrentSelectionHead),
       )
     )
 
-    assertEquals(
-      request(EditorBringIntoViewTarget.CurrentSelectionHead),
-      requests.activateForVersion(version = 292L),
-    )
+    assertEquals(request(overlayTarget), requests.activateForVersion(version = 292L))
   }
 
   @Test
   fun `skipped editor versions collapse to latest eligible bring-into-view request`() {
     val requests = EditorBringIntoViewRequests()
 
-    requests.requestForVersion(target = EditorBringIntoViewTarget.CurrentCursorLine, version = 291L)
     requests.requestForVersion(
       target = EditorBringIntoViewTarget.CurrentSelectionHead,
-      version = 292L,
+      version = 291L,
     )
+    requests.requestForVersion(target = overlayTarget, version = 292L)
 
-    assertEquals(
-      request(EditorBringIntoViewTarget.CurrentSelectionHead),
-      requests.activateForVersion(version = 292L),
-    )
+    assertEquals(request(overlayTarget), requests.activateForVersion(version = 292L))
   }
 
   @Test
   fun `cancel clears active and queued bring-into-view targets`() {
     val requests = EditorBringIntoViewRequests()
 
-    requests.requestForVersion(target = EditorBringIntoViewTarget.CurrentCursorLine, version = 1L)
+    requests.requestForVersion(
+      target = EditorBringIntoViewTarget.CurrentSelectionHead,
+      version = 1L,
+    )
     assertEquals(
-      request(EditorBringIntoViewTarget.CurrentCursorLine),
+      request(EditorBringIntoViewTarget.CurrentSelectionHead),
       requests.activateForVersion(version = 1L),
     )
 
-    requests.requestForVersion(
-      target = EditorBringIntoViewTarget.CurrentSelectionHead,
-      version = 2L,
-    )
+    requests.requestForVersion(target = overlayTarget, version = 2L)
     requests.cancel()
 
     assertFalse(
       requests.markApplied(
         version = 1L,
-        request = request(EditorBringIntoViewTarget.CurrentCursorLine),
+        request = request(EditorBringIntoViewTarget.CurrentSelectionHead),
       )
     )
     assertNull(requests.activateForVersion(version = 1L))
@@ -172,13 +172,16 @@ class EditorBringIntoViewRequestsTest {
   fun `activating same version does not consume active bring-into-view target`() {
     val requests = EditorBringIntoViewRequests()
 
-    requests.requestForVersion(target = EditorBringIntoViewTarget.CurrentCursorLine, version = 1L)
+    requests.requestForVersion(
+      target = EditorBringIntoViewTarget.CurrentSelectionHead,
+      version = 1L,
+    )
 
     requests.activateForVersion(version = 1L)
     requests.activateForVersion(version = 1L)
 
     assertEquals(
-      request(EditorBringIntoViewTarget.CurrentCursorLine),
+      request(EditorBringIntoViewTarget.CurrentSelectionHead),
       requests.activateForVersion(version = 1L),
     )
   }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorScrollResolverTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorScrollResolverTest.kt
@@ -20,7 +20,7 @@ import kotlin.test.assertNotNull
 
 class EditorScrollResolverTest {
   @Test
-  fun `resolver returns target scroll from cursor line and policy`() {
+  fun `resolver returns target scroll from collapsed selection head and policy`() {
     val frame =
       frame(
         state =
@@ -38,7 +38,7 @@ class EditorScrollResolverTest {
     val intent =
       resolveEditorScrollIntent(
         frame = frame,
-        target = EditorBringIntoViewTarget.CurrentCursorLine,
+        target = EditorBringIntoViewTarget.CurrentSelectionHead,
         currentScroll = 200f,
       )
 
@@ -66,7 +66,7 @@ class EditorScrollResolverTest {
     val intent =
       resolveEditorScrollIntent(
         frame = frame,
-        target = EditorBringIntoViewTarget.CurrentCursorLine,
+        target = EditorBringIntoViewTarget.CurrentSelectionHead,
         currentScroll = 200f,
       )
 
@@ -94,7 +94,7 @@ class EditorScrollResolverTest {
     val intent =
       resolveEditorScrollIntent(
         frame = frame,
-        target = EditorBringIntoViewTarget.CurrentCursorLine,
+        target = EditorBringIntoViewTarget.CurrentSelectionHead,
         currentScroll = 200f,
       )
 
@@ -122,7 +122,7 @@ class EditorScrollResolverTest {
     val intent =
       resolveEditorScrollIntent(
         frame = frame,
-        target = EditorBringIntoViewTarget.CurrentCursorLine,
+        target = EditorBringIntoViewTarget.CurrentSelectionHead,
         currentScroll = 0f,
       )
 
@@ -130,7 +130,7 @@ class EditorScrollResolverTest {
   }
 
   @Test
-  fun `selection head target resolves from selection endpoint instead of cursor line`() {
+  fun `selection head target resolves from selection endpoint instead of collapsed cursor line`() {
     val anchor = position(offset = 1)
     val head = position(offset = 8)
     val frame =
@@ -249,7 +249,7 @@ class EditorScrollResolverTest {
         uiState = uiState,
         headerHeight = 0f,
         pagesContentHeight = 620f,
-        target = EditorBringIntoViewTarget.CurrentCursorLine,
+        target = EditorBringIntoViewTarget.CurrentSelectionHead,
         density = 1f,
       )
 
@@ -265,7 +265,7 @@ class EditorScrollResolverTest {
   private fun state(
     cursor: CursorMetrics?,
     pageSizes: List<PageSize>,
-    selection: Selection? = null,
+    selection: Selection? = cursor?.let { collapsedSelection() },
     selectionEndpoints: SelectionEndpoints? = null,
   ): EditorState =
     EditorState(
@@ -310,4 +310,9 @@ class EditorScrollResolverTest {
 
   private fun position(offset: Int): Position =
     Position(node = "paragraph", offset = offset, affinity = Affinity.Downstream)
+
+  private fun collapsedSelection(): Selection {
+    val position = position(offset = 0)
+    return Selection(anchor = position, head = position)
+  }
 }

--- a/apps/mobile/compose/src/desktopMain/kotlin/co/typie/editor/input/EditorInput.desktop.kt
+++ b/apps/mobile/compose/src/desktopMain/kotlin/co/typie/editor/input/EditorInput.desktop.kt
@@ -88,7 +88,7 @@ internal actual suspend fun PlatformTextInputSessionScope.createEditorInputReque
         for (message in batch.drainMessages()) {
           enqueue(message)
         }
-        beforeCommit { bringIntoView(EditorBringIntoViewTarget.CurrentCursorLine) }
+        beforeCommit { bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead) }
       }
     }
   }


### PR DESCRIPTION
- CurrentSelectionHead가 collapsed일 때 cursor rect를 fallback으로 쓰므로 CurrentCursorLine이 따로 필요 없음
- 키보드로 선택 확장 시 typewriter나 cursor guard가 동작하지 않는 버그도 함께 해결