### PR TITLE
툴바 modifier 해석 디버그

### DIFF
--- a/crates/editor-commands/src/commands/toggle_bold.rs
+++ b/crates/editor-commands/src/commands/toggle_bold.rs
@@ -1,9 +1,11 @@
 use editor_common::Tri;
 use editor_crdt::Dot;
-use editor_model::{ChildView, DocView, Modifier, ModifierType};
+use editor_model::{
+    ChildView, DEFAULT_FONT_FAMILY, DEFAULT_FONT_WEIGHT, DocView, Modifier, ModifierType,
+};
 use editor_resource::{Resource, find_bold_target, find_unbold_target};
-use editor_state::ResolvedSelection;
 use editor_state::{PendingModifier, PendingModifiers};
+use editor_state::{ResolvedSelection, inline_leaf_dots_in_range};
 use editor_state::{resolve_modifier_state, resolve_modifier_state_in_range};
 use editor_transaction::Transaction;
 
@@ -43,6 +45,22 @@ fn block_family(view: &DocView, elem: Dot) -> Option<String> {
     }
 }
 
+fn range_has_heavy_weight(view: &DocView, rs: &ResolvedSelection) -> bool {
+    let from = rs.from().position();
+    let to = rs.to().position();
+    inline_leaf_dots_in_range(view, &from, &to)
+        .into_iter()
+        .any(|dot| {
+            let Some(leaf) = view.leaf(dot) else {
+                return false;
+            };
+            matches!(
+                leaf.effective().get(&ModifierType::FontWeight),
+                Some(Modifier::FontWeight { value }) if *value >= 700
+            )
+        })
+}
+
 pub fn toggle_bold(tr: &mut Transaction, resource: &Resource) -> CommandResult {
     let Some(selection) = tr.selection() else {
         return Ok(false);
@@ -52,7 +70,16 @@ pub fn toggle_bold(tr: &mut Transaction, resource: &Resource) -> CommandResult {
         return toggle_bold_collapsed(tr, resource);
     }
 
-    let (first, last, current_weight, font_family, inherited_weight, is_bold) = {
+    let (
+        first,
+        last,
+        current_weight,
+        font_family,
+        inherited_weight,
+        is_bold,
+        synthetic_bold,
+        weight_bold,
+    ) = {
         let view = tr.view();
         let rs = selection
             .resolve(&view)
@@ -62,20 +89,18 @@ pub fn toggle_bold(tr: &mut Transaction, resource: &Resource) -> CommandResult {
         };
         let ms = resolve_modifier_state_in_range(&rs);
         let from_block = rs.from().node();
-        let inherited_weight = block_weight(&view, from_block).ok_or_else(|| {
-            CommandError::Corrupted("FontWeight missing in inherited modifiers".into())
-        })?;
+        let inherited_weight = block_weight(&view, from_block).unwrap_or(DEFAULT_FONT_WEIGHT);
         let current_weight = match &ms.font_weight {
             Tri::Uniform { value } => value.value,
             _ => inherited_weight,
         };
         let font_family = match &ms.font_family {
             Tri::Uniform { value } => value.value.clone(),
-            _ => block_family(&view, from_block).ok_or_else(|| {
-                CommandError::Corrupted("FontFamily missing in effective modifiers".into())
-            })?,
+            _ => block_family(&view, from_block).unwrap_or_else(|| DEFAULT_FONT_FAMILY.to_string()),
         };
         let is_bold = matches!(ms.effective_bold, Tri::Uniform { .. });
+        let synthetic_bold = !matches!(ms.bold, Tri::Absent);
+        let weight_bold = range_has_heavy_weight(&view, &rs);
         (
             first,
             last,
@@ -83,23 +108,37 @@ pub fn toggle_bold(tr: &mut Transaction, resource: &Resource) -> CommandResult {
             font_family,
             inherited_weight,
             is_bold,
+            synthetic_bold,
+            weight_bold,
         )
     };
 
     let available = resource.font_registry.weights(&font_family).unwrap_or(&[]);
 
     if is_bold {
-        tr.remove_span_modifier(first, last, Modifier::Bold)?;
-        let unbold = find_unbold_target(current_weight, available);
-        tr.remove_span_modifier(
-            first,
-            last,
-            Modifier::FontWeight {
-                value: current_weight,
-            },
-        )?;
-        if unbold != inherited_weight {
-            tr.add_span_modifier(first, last, Modifier::FontWeight { value: unbold })?;
+        if synthetic_bold {
+            tr.remove_span_modifier(first, last, Modifier::Bold)?;
+        }
+        if weight_bold {
+            let unbold = find_unbold_target(current_weight, available);
+            tr.remove_span_modifier(
+                first,
+                last,
+                Modifier::FontWeight {
+                    value: current_weight,
+                },
+            )?;
+            if unbold != inherited_weight {
+                tr.add_span_modifier(first, last, Modifier::FontWeight { value: unbold })?;
+            }
+        } else {
+            tr.remove_span_modifier(
+                first,
+                last,
+                Modifier::FontWeight {
+                    value: current_weight,
+                },
+            )?;
         }
     } else {
         match find_bold_target(current_weight, available) {
@@ -128,7 +167,7 @@ fn toggle_bold_collapsed(tr: &mut Transaction, resource: &Resource) -> CommandRe
     let selection = tr.selection().expect("entry caller guaranteed selection");
     let pos = selection.head;
 
-    let (current_weight, font_family, is_bold) = {
+    let (current_weight, font_family, is_bold, synthetic_bold, weight_bold) = {
         let ms = resolve_modifier_state(&tr.state().projected, &selection, tr.pending_modifiers())
             .ok_or(CommandError::Corrupted("cannot resolve selection".into()))?;
         let current_weight = match &ms.font_weight {
@@ -151,41 +190,50 @@ fn toggle_bold_collapsed(tr: &mut Transaction, resource: &Resource) -> CommandRe
             current_weight,
             font_family,
             matches!(ms.effective_bold, Tri::Uniform { .. }),
+            matches!(ms.bold, Tri::Uniform { .. }),
+            current_weight >= 700,
         )
     };
 
     let inherited_weight = {
         let view = tr.view();
-        let node = view
-            .node(pos.node)
+        view.node(pos.node)
             .ok_or(CommandError::NodeNotFound(pos.node))?;
-        match node.effective().get(&ModifierType::FontWeight) {
-            Some(Modifier::FontWeight { value }) => *value,
-            _ => {
-                return Err(CommandError::Corrupted(
-                    "FontWeight missing in inherited modifiers".into(),
-                ));
-            }
-        }
+        block_weight(&view, pos.node).unwrap_or(DEFAULT_FONT_WEIGHT)
     };
 
     let available = resource.font_registry.weights(&font_family).unwrap_or(&[]);
 
+    let mut replaced_types = Vec::new();
+    if is_bold {
+        if synthetic_bold {
+            replaced_types.push(ModifierType::Bold);
+        }
+        replaced_types.push(ModifierType::FontWeight);
+    } else if find_bold_target(current_weight, available).is_some() {
+        replaced_types.push(ModifierType::FontWeight);
+    } else {
+        replaced_types.push(ModifierType::Bold);
+    }
+
     let mut pending: PendingModifiers = tr
         .pending_modifiers()
         .iter()
-        .filter(|pm| {
-            let t = pm.as_type();
-            t != ModifierType::Bold && t != ModifierType::FontWeight
-        })
+        .filter(|pm| !replaced_types.contains(&pm.as_type()))
         .cloned()
         .collect();
 
     if is_bold {
-        let unbold = find_unbold_target(current_weight, available);
-        pending.push(PendingModifier::Unset {
-            ty: ModifierType::Bold,
-        });
+        if synthetic_bold {
+            pending.push(PendingModifier::Unset {
+                ty: ModifierType::Bold,
+            });
+        }
+        let unbold = if weight_bold {
+            find_unbold_target(current_weight, available)
+        } else {
+            DEFAULT_FONT_WEIGHT
+        };
         if unbold != inherited_weight {
             pending.push(PendingModifier::Set {
                 modifier: Modifier::FontWeight { value: unbold },
@@ -353,6 +401,12 @@ mod tests {
                 modifier: Modifier::FontWeight { .. }
             }
         )));
+        assert!(actual.pending_modifiers.iter().any(|pm| matches!(
+            pm,
+            PendingModifier::Unset {
+                ty: ModifierType::FontWeight
+            }
+        )));
     }
 
     #[test]
@@ -369,18 +423,44 @@ mod tests {
             selection: (p1, 3)
         };
         let (actual, ..) = transact!(initial, |tr| toggle_bold(&mut tr, &resource));
-        assert!(actual.pending_modifiers.iter().any(|pm| matches!(
-            pm,
-            PendingModifier::Unset {
-                ty: ModifierType::Bold
-            }
-        )));
+        assert!(
+            !actual
+                .pending_modifiers
+                .iter()
+                .any(|pm| pm.as_type() == ModifierType::Bold)
+        );
         assert!(actual.pending_modifiers.iter().any(|pm| matches!(
             pm,
             PendingModifier::Unset {
                 ty: ModifierType::FontWeight
             }
         )));
+    }
+
+    #[test]
+    fn collapsed_can_toggle_back_on_after_unbolding_to_inherited_weight() {
+        let resource = make_resource([("Pretendard", vec![400, 700])]);
+        let (initial, ..) = state! {
+            doc {
+                root [font_weight(400), font_family("Pretendard".to_string())] {
+                    p1: paragraph {
+                        text("Hello") [font_weight(400), font_family("Pretendard".to_string())]
+                    }
+                }
+            }
+            selection: (p1, 3)
+        };
+        let (actual, ..) = transact!(initial, |tr| {
+            toggle_bold(&mut tr, &resource).unwrap();
+            toggle_bold(&mut tr, &resource).unwrap();
+            toggle_bold(&mut tr, &resource)
+        });
+        assert_eq!(
+            actual.pending_modifiers.as_slice(),
+            &[PendingModifier::Set {
+                modifier: Modifier::FontWeight { value: 700 }
+            }]
+        );
     }
 
     #[test]
@@ -592,6 +672,64 @@ mod tests {
     }
 
     #[test]
+    fn range_toggle_off_inherited_synthetic_bold_reports_default_weight() {
+        let resource = make_resource([("Pretendard", vec![400, 700])]);
+        let (initial, ..) = state! {
+            doc {
+                root [font_weight(400), font_family("Pretendard".to_string())] {
+                    p1: paragraph [bold] {
+                        text("Hello")
+                    }
+                }
+            }
+            selection: (p1, 0) -> (p1, 5)
+        };
+        let (actual, ..) = transact!(initial, |tr| toggle_bold(&mut tr, &resource));
+        assert_eq!(
+            resolve_modifier_state(
+                &actual.projected,
+                actual.selection.as_ref().unwrap(),
+                &actual.pending_modifiers
+            )
+            .unwrap()
+            .font_weight,
+            Tri::Uniform {
+                value: editor_model::FontWeightValue { value: 400 }
+            }
+        );
+    }
+
+    #[test]
+    fn range_toggle_off_synthetic_bold_resets_mixed_nonbold_weights() {
+        let resource = make_resource([("Pretendard", vec![300, 400, 700])]);
+        let (initial, ..) = state! {
+            doc {
+                root [font_weight(400), font_family("Pretendard".to_string())] {
+                    p1: paragraph [bold] {
+                        text("A") [font_weight(300)]
+                        text("B") [font_weight(400)]
+                    }
+                }
+            }
+            selection: (p1, 0) -> (p1, 2)
+        };
+        let (actual, ..) = transact!(initial, |tr| toggle_bold(&mut tr, &resource));
+        let ms = resolve_modifier_state(
+            &actual.projected,
+            actual.selection.as_ref().unwrap(),
+            &actual.pending_modifiers,
+        )
+        .unwrap();
+        assert_eq!(ms.effective_bold, Tri::Absent);
+        assert_eq!(
+            ms.font_weight,
+            Tri::Uniform {
+                value: editor_model::FontWeightValue { value: 400 }
+            }
+        );
+    }
+
+    #[test]
     fn range_toggle_off_keeps_nondefault_unbold_weight() {
         let resource = make_resource([("Pretendard", vec![300, 400, 700])]);
         let (initial, ..) = state! {
@@ -734,6 +872,41 @@ mod tests {
             selection: (p1, 6) -> (p1, 11)
         };
         assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn range_double_toggle_under_root_style_reports_rendered_weight() {
+        let resource = make_resource([("Pretendard", vec![400, 700])]);
+        let (initial, ..) = state! {
+            doc {
+                styles {
+                    base: "기본" [font_size(1200), font_family("Pretendard".to_string()), font_weight(400), text_color("black".to_string()), background_color("none".to_string()), letter_spacing(0), line_height(160), block_gap(100), paragraph_indent(100)]
+                }
+                root @base {
+                    p1: paragraph {
+                        text("Hello World")
+                    }
+                }
+            }
+            selection: (p1, 6) -> (p1, 11)
+        };
+        let (actual, ..) = transact!(initial, |tr| {
+            toggle_bold(&mut tr, &resource).unwrap();
+            toggle_bold(&mut tr, &resource)
+        });
+
+        let ms = resolve_modifier_state(
+            &actual.projected,
+            actual.selection.as_ref().unwrap(),
+            &actual.pending_modifiers,
+        )
+        .unwrap();
+        assert_eq!(
+            ms.font_weight,
+            Tri::Uniform {
+                value: editor_model::FontWeightValue { value: 400 }
+            }
+        );
     }
 
     #[test]

--- a/crates/editor-commands/src/commands/toggle_modifier.rs
+++ b/crates/editor-commands/src/commands/toggle_modifier.rs
@@ -262,6 +262,27 @@ mod tests {
     }
 
     #[test]
+    fn range_toggle_italic_off_from_style_reports_off() {
+        let (initial, ..) = state! {
+            doc {
+                styles { em: "강조" [italic] }
+                root { p1: paragraph @em { text("HelloWorld") } }
+            }
+            selection: (p1, 0) -> (p1, 10)
+        };
+        let (actual, ..) = transact!(initial, |tr| toggle_modifier(&mut tr, ModifierType::Italic));
+
+        let view = actual.view();
+        let rs = actual
+            .selection
+            .as_ref()
+            .and_then(|selection| selection.resolve(&view))
+            .expect("selection still resolves");
+        let ms = resolve_modifier_state_in_range(&rs);
+        assert_eq!(ms.italic, Tri::Absent);
+    }
+
+    #[test]
     fn range_toggle_italic_mixed_turns_on() {
         let (initial, ..) = state! {
             doc { root { p: paragraph {

--- a/crates/editor-model/src/modifier.rs
+++ b/crates/editor-model/src/modifier.rs
@@ -148,6 +148,33 @@ impl Modifier {
     }
 }
 
+pub const DEFAULT_FONT_FAMILY: &str = "";
+pub const DEFAULT_FONT_SIZE: u32 = 1200;
+pub const DEFAULT_FONT_WEIGHT: u16 = 400;
+pub const DEFAULT_LETTER_SPACING: i32 = 0;
+pub const DEFAULT_LINE_HEIGHT: u32 = 160;
+
+pub fn text_style_default_modifier(ty: ModifierType) -> Option<Modifier> {
+    match ty {
+        ModifierType::FontFamily => Some(Modifier::FontFamily {
+            value: DEFAULT_FONT_FAMILY.to_string(),
+        }),
+        ModifierType::FontSize => Some(Modifier::FontSize {
+            value: DEFAULT_FONT_SIZE,
+        }),
+        ModifierType::FontWeight => Some(Modifier::FontWeight {
+            value: DEFAULT_FONT_WEIGHT,
+        }),
+        ModifierType::LetterSpacing => Some(Modifier::LetterSpacing {
+            value: DEFAULT_LETTER_SPACING,
+        }),
+        ModifierType::LineHeight => Some(Modifier::LineHeight {
+            value: DEFAULT_LINE_HEIGHT,
+        }),
+        _ => None,
+    }
+}
+
 impl ModifierState {
     pub fn set_uniform(&mut self, m: &Modifier) {
         match m {

--- a/crates/editor-state/src/lib.rs
+++ b/crates/editor-state/src/lib.rs
@@ -55,6 +55,7 @@ pub use flat::{
 pub use gap_cursor::{GapCursor, as_gap_cursor, gap_cursor_at};
 pub use layout_dirty::LayoutDirty;
 pub use load_builder::BuildError;
+pub use modifier_resolution::resolve_effective_modifiers_at;
 pub use modifier_span::resolve_modifier_span_selection;
 pub use modifier_state::{resolve_modifier_state, resolve_modifier_state_in_range};
 pub use normalize::{doc_start_selection, farther_endpoint, is_unit_node_selection};
@@ -72,7 +73,7 @@ pub use selection_expansion::{
     resolve_word_selection_expansion,
 };
 pub use stable_position::{StablePosition, StableResolveCtx};
-pub use stable_selection::{StableSelection, resolve_effective_modifiers_at};
+pub use stable_selection::StableSelection;
 pub use state::*;
 pub use to_plain::to_plain;
 pub use traversal::{first_cursor_position, last_cursor_position};

--- a/crates/editor-state/src/modifier_resolution.rs
+++ b/crates/editor-state/src/modifier_resolution.rs
@@ -10,6 +10,8 @@ use editor_model::{
 use crate::Position;
 use crate::affinity::Affinity;
 use crate::pending_modifier::PendingModifier;
+use crate::projected_state::ProjectedState;
+use crate::state::State;
 
 pub(crate) struct CaretCtx<'a> {
     pub(crate) view: &'a DocView<'a>,
@@ -60,6 +62,27 @@ fn apply_pending(out: &mut BTreeMap<ModifierType, Modifier>, pending: &[PendingM
             }
         }
     }
+}
+
+/// Effective inline modifiers a caret at `pos` would carry (no pending overrides).
+pub fn resolve_effective_modifiers_at(state: &State, pos: &Position) -> Vec<Modifier> {
+    caret_modifiers(&state.projected, pos, &[])
+        .into_values()
+        .collect()
+}
+
+pub(crate) fn caret_modifiers(
+    state: &ProjectedState,
+    pos: &Position,
+    pending: &[PendingModifier],
+) -> BTreeMap<ModifierType, Modifier> {
+    let view = state.view();
+    let ctx = CaretCtx {
+        view: &view,
+        doc: state.projected(),
+        block_modifiers: state.block_modifiers(),
+    };
+    resolve_caret_modifiers(pos, &ctx, pending)
 }
 
 fn self_path(host: &NodeView) -> Vec<(NodeType, Option<Dot>)> {
@@ -557,6 +580,22 @@ mod tests {
         let c = ctx(&pd, &view, &logs);
         let out = resolve_caret_modifiers(
             &Position::new(p, 1),
+            &c,
+            &[PendingModifier::Set {
+                modifier: Modifier::Italic,
+            }],
+        );
+        assert_eq!(out.get(&ModifierType::Italic), Some(&Modifier::Italic));
+    }
+
+    #[test]
+    fn empty_paragraph_pending_overlay_applies() {
+        let (logs, _root, p) = para(&[], Overlays::default());
+        let pd = project(&logs);
+        let view = DocView::new(&pd);
+        let c = ctx(&pd, &view, &logs);
+        let out = resolve_caret_modifiers(
+            &Position::new(p, 0),
             &c,
             &[PendingModifier::Set {
                 modifier: Modifier::Italic,

--- a/crates/editor-state/src/modifier_state.rs
+++ b/crates/editor-state/src/modifier_state.rs
@@ -1,14 +1,17 @@
 use std::collections::BTreeMap;
 
 use editor_common::Tri;
-use editor_model::{LeafView, Modifier, ModifierState, ModifierType, NodeType, NodeView, Schema};
+use editor_model::{
+    LeafView, Modifier, ModifierState, ModifierType, NodeType, NodeView, Schema,
+    text_style_default_modifier,
+};
 use strum::IntoEnumIterator;
 
+use crate::modifier_resolution::caret_modifiers;
 use crate::pending_modifier::PendingModifier;
 use crate::projected_state::ProjectedState;
 use crate::selection::ResolvedSelection;
 use crate::selection::Selection;
-use crate::stable_selection::caret_modifiers;
 use crate::traversal;
 
 pub enum RangeNode<'a> {
@@ -62,6 +65,52 @@ pub fn range_nodes<'a>(rs: &ResolvedSelection<'a>) -> Vec<RangeNode<'a>> {
     out
 }
 
+fn modifier_for_range_state(node: &RangeNode, ty: ModifierType) -> Option<Modifier> {
+    node.effective()
+        .get(&ty)
+        .cloned()
+        .or_else(|| text_style_default_modifier(ty))
+}
+
+fn modifier_for_caret_state(
+    caret: &BTreeMap<ModifierType, Modifier>,
+    textblock: &NodeView,
+    ty: ModifierType,
+) -> Option<Modifier> {
+    if !modifier_applies_at_caret(textblock, ty) {
+        return None;
+    }
+    if let Some(modifier) = caret.get(&ty) {
+        return Some(modifier.clone());
+    }
+    let default = text_style_default_modifier(ty)?;
+    (if Schema::modifier_spec(ty).inheritable {
+        textblock.effective().get(&ty).cloned()
+    } else {
+        None
+    })
+    .or(Some(default))
+}
+
+fn modifier_applies_at_caret(textblock: &NodeView, ty: ModifierType) -> bool {
+    let target = &Schema::modifier_spec(ty).target;
+    let targets = target.rightmost_node_types();
+    let block_path = textblock_type_path(textblock);
+    if targets.contains(&textblock.node_type()) && target.matches(&block_path) {
+        return true;
+    }
+    targets.contains(&NodeType::Text)
+        && Schema::node_spec(textblock.node_type())
+            .content
+            .matches(NodeType::Text)
+}
+
+fn textblock_type_path(textblock: &NodeView) -> Vec<NodeType> {
+    let mut path: Vec<_> = textblock.ancestors().map(|n| n.node_type()).collect();
+    path.reverse();
+    path
+}
+
 pub fn resolve_modifier_state_in_range(rs: &ResolvedSelection) -> ModifierState {
     let mut out = ModifierState::default();
     let nodes = range_nodes(rs);
@@ -78,7 +127,7 @@ pub fn resolve_modifier_state_in_range(rs: &ResolvedSelection) -> ModifierState 
             if !target.matches(&n.type_path()) {
                 continue;
             }
-            let value = n.effective().get(&ty).cloned();
+            let value = modifier_for_range_state(n, ty);
             match (value, &canonical) {
                 (Some(m), Some(c)) if &m == c => {}
                 (Some(_), Some(_)) => {
@@ -120,7 +169,7 @@ fn is_bold_set<'a>(mut mods: impl Iterator<Item = &'a Modifier>) -> bool {
 }
 
 fn leaf_is_bold(l: &LeafView) -> bool {
-    l.own_no_style(ModifierType::Bold).is_some()
+    matches!(l.effective().get(&ModifierType::Bold), Some(Modifier::Bold))
         || matches!(
             l.effective().get(&ModifierType::FontWeight),
             Some(Modifier::FontWeight { value }) if *value >= 700
@@ -166,11 +215,24 @@ pub fn resolve_modifier_state(
     let rs = sel.resolve(&view)?;
     if rs.is_collapsed() {
         let caret = caret_modifiers(state, &sel.head, pending);
+        let modifiers = if let Some(node) = view.node(sel.head.node)
+            && Schema::node_spec(node.node_type()).is_textblock()
+        {
+            let mut modifiers = BTreeMap::new();
+            for ty in ModifierType::iter() {
+                if let Some(modifier) = modifier_for_caret_state(&caret, &node, ty) {
+                    modifiers.insert(ty, modifier);
+                }
+            }
+            modifiers
+        } else {
+            caret
+        };
         let mut out = ModifierState::default();
-        for m in caret.values() {
+        for m in modifiers.values() {
             out.set_uniform(m);
         }
-        if is_bold_set(caret.values()) {
+        if is_bold_set(modifiers.values()) {
             out.effective_bold = Tri::Uniform { value: () };
         }
         Some(out)
@@ -183,7 +245,9 @@ pub fn resolve_modifier_state(
 mod tests {
     use editor_common::Tri;
     use editor_crdt::{Dot, ListOp, OpGraph};
-    use editor_model::{Anchor, Bias, EditOp, Modifier, ModifierAttrOp, NodeType, SeqItem, SpanOp};
+    use editor_model::{
+        Anchor, Bias, EditOp, Modifier, ModifierAttrOp, ModifierType, NodeType, SeqItem, SpanOp,
+    };
 
     use crate::pending_modifier::PendingModifier;
     use crate::projected_state::ProjectedState;
@@ -218,6 +282,27 @@ mod tests {
         (state, root, para)
     }
 
+    fn fold_title_state() -> (ProjectedState, Dot) {
+        let mut graph = OpGraph::<EditOp>::with_actor(1);
+        let root = Dot::ROOT;
+        let fold = graph
+            .add_mut(seq_block(0, NodeType::Fold, vec![root]))
+            .unwrap()
+            .id;
+        let title = graph
+            .add_mut(seq_block(1, NodeType::FoldTitle, vec![root, fold]))
+            .unwrap()
+            .id;
+        let content = graph
+            .add_mut(seq_block(2, NodeType::FoldContent, vec![root, fold]))
+            .unwrap()
+            .id;
+        graph
+            .add_mut(seq_block(3, NodeType::Paragraph, vec![root, fold, content]))
+            .unwrap();
+        (ProjectedState::from_graph(graph).unwrap(), title)
+    }
+
     fn sel(anchor: (Dot, usize), head: (Dot, usize)) -> Selection {
         Selection::new(
             Position::new(anchor.0, anchor.1),
@@ -229,25 +314,27 @@ mod tests {
         Selection::collapsed(Position::new(node, offset))
     }
 
+    fn first_leaf_dot(state: &ProjectedState, para: Dot) -> Dot {
+        let view = state.view();
+        let p = view.node(para).unwrap();
+        p.children()
+            .next()
+            .and_then(|c| {
+                if let editor_model::ChildView::Leaf(l) = c {
+                    Some(l.dot())
+                } else {
+                    None
+                }
+            })
+            .unwrap()
+    }
+
     // §4.1: collapsed uniform — caret inside a bold run → bold == Uniform; pending applies
     #[test]
     fn test_1_collapsed_uniform_bold() {
         let (mut state, _root, para) = simple_para_state(&['a', 'b']);
         // get the dot of 'a' leaf
-        let leaf_a = {
-            let view = state.view();
-            let p = view.node(para).unwrap();
-            p.children()
-                .next()
-                .and_then(|c| {
-                    if let editor_model::ChildView::Leaf(l) = c {
-                        Some(l.dot())
-                    } else {
-                        None
-                    }
-                })
-                .unwrap()
-        };
+        let leaf_a = first_leaf_dot(&state, para);
         state
             .apply(EditOp::Span(SpanOp::AddSpan {
                 start: Anchor {
@@ -291,6 +378,123 @@ mod tests {
         )
         .unwrap();
         assert_eq!(ms.italic, Tri::Uniform { value: () });
+    }
+
+    #[test]
+    fn range_clear_inheritable_value_reports_resolved_default_not_parent() {
+        let (mut state, root, para) = simple_para_state(&['a']);
+        state
+            .apply(EditOp::BlockModifier(ModifierAttrOp::SetModifier {
+                target: root,
+                modifier: Modifier::FontWeight { value: 500 },
+            }))
+            .unwrap();
+        let leaf_a = first_leaf_dot(&state, para);
+        state
+            .apply(EditOp::Span(SpanOp::AddSpan {
+                start: Anchor {
+                    id: leaf_a,
+                    bias: Bias::Before,
+                },
+                end: Anchor {
+                    id: leaf_a,
+                    bias: Bias::After,
+                },
+                modifier: Modifier::FontWeight { value: 700 },
+            }))
+            .unwrap();
+        state
+            .apply(EditOp::Span(SpanOp::RemoveSpan {
+                start: Anchor {
+                    id: leaf_a,
+                    bias: Bias::Before,
+                },
+                end: Anchor {
+                    id: leaf_a,
+                    bias: Bias::After,
+                },
+                modifier_type: ModifierType::FontWeight,
+            }))
+            .unwrap();
+
+        let s = sel((para, 0), (para, 1));
+        let ms = resolve_modifier_state(&state, &s, &[]).unwrap();
+        assert_eq!(
+            ms.font_weight,
+            Tri::Uniform {
+                value: editor_model::FontWeightValue { value: 400 }
+            }
+        );
+        assert_eq!(ms.effective_bold, Tri::Absent);
+    }
+
+    #[test]
+    fn collapsed_pending_unset_inheritable_value_reports_inserted_resolved_value() {
+        let (mut state, root, para) = simple_para_state(&['a']);
+        state
+            .apply(EditOp::BlockModifier(ModifierAttrOp::SetModifier {
+                target: root,
+                modifier: Modifier::FontWeight { value: 500 },
+            }))
+            .unwrap();
+        let leaf_a = {
+            let view = state.view();
+            let p = view.node(para).unwrap();
+            p.children()
+                .next()
+                .and_then(|c| {
+                    if let editor_model::ChildView::Leaf(l) = c {
+                        Some(l.dot())
+                    } else {
+                        None
+                    }
+                })
+                .unwrap()
+        };
+        state
+            .apply(EditOp::Span(SpanOp::AddSpan {
+                start: Anchor {
+                    id: leaf_a,
+                    bias: Bias::Before,
+                },
+                end: Anchor {
+                    id: leaf_a,
+                    bias: Bias::After,
+                },
+                modifier: Modifier::FontWeight { value: 700 },
+            }))
+            .unwrap();
+
+        let s = collapsed(para, 1);
+        let ms = resolve_modifier_state(
+            &state,
+            &s,
+            &[PendingModifier::Unset {
+                ty: ModifierType::FontWeight,
+            }],
+        )
+        .unwrap();
+        assert_eq!(
+            ms.font_weight,
+            Tri::Uniform {
+                value: editor_model::FontWeightValue { value: 500 }
+            }
+        );
+        assert_eq!(ms.effective_bold, Tri::Absent);
+    }
+
+    #[test]
+    fn collapsed_fold_title_does_not_report_line_height_default() {
+        let (state, title) = fold_title_state();
+        let s = collapsed(title, 0);
+        let ms = resolve_modifier_state(&state, &s, &[]).unwrap();
+        assert_eq!(ms.line_height, Tri::Absent);
+        assert_eq!(
+            ms.font_weight,
+            Tri::Uniform {
+                value: editor_model::FontWeightValue { value: 500 }
+            }
+        );
     }
 
     // §4.2: collapsed inherits — caret in para under root[font_size] → font_size Uniform
@@ -610,6 +814,22 @@ mod tests {
         );
     }
 
+    #[test]
+    fn effective_bold_counts_inherited_bold() {
+        let (mut state, _root, para) = simple_para_state(&['a']);
+        state
+            .apply(EditOp::BlockModifier(ModifierAttrOp::SetModifier {
+                target: para,
+                modifier: Modifier::Bold,
+            }))
+            .unwrap();
+
+        let s = sel((para, 0), (para, 1));
+        let ms = resolve_modifier_state(&state, &s, &[]).unwrap();
+        assert_eq!(ms.bold, Tri::Uniform { value: () });
+        assert_eq!(ms.effective_bold, Tri::Uniform { value: () });
+    }
+
     // §4.8b: some-bold → Mixed effective_bold
     #[test]
     fn test_8b_effective_bold_mixed() {
@@ -646,13 +866,10 @@ mod tests {
         assert_eq!(ms.effective_bold, Tri::Mixed);
     }
 
-    // §4.9: own-vs-inherited bold asymmetry
-    // A paragraph with a marker Bold applied but own-plain text in range
-    // → range effective_bold == Absent (own-only check via own_no_style)
-    // → collapsed caret in EMPTY paragraph with marker → effective_bold == Uniform
-    //   (caret resolution via empty_or_structural picks up node_markers)
+    // §4.9: marker modifiers seed an empty paragraph caret but do not restyle
+    // existing text in a non-empty paragraph.
     #[test]
-    fn test_9_own_vs_inherited_bold_asymmetry() {
+    fn test_9_marker_bold_applies_to_empty_caret_not_existing_range() {
         use editor_crdt::LwwRegOp;
         use editor_model::{EditOp, Marker, NodeLwwOp};
 
@@ -677,7 +894,7 @@ mod tests {
             "collapsed caret in empty paragraph with marker Bold → effective_bold Uniform"
         );
 
-        // Part B: paragraph with 'a' + marker — range effective_bold uses own_no_style → Absent
+        // Part B: paragraph with 'a' + marker — marker is not part of the leaf's rendered style.
         let (mut state, _root, para) = simple_para_state(&['a']);
         state
             .apply(EditOp::NodeMarker(NodeLwwOp {
@@ -695,7 +912,7 @@ mod tests {
         assert_eq!(
             ms_range.effective_bold,
             Tri::Absent,
-            "range with only inherited bold (no own span) → effective_bold Absent (own-only check)"
+            "range over existing text is not bolded by the paragraph marker"
         );
     }
 

--- a/crates/editor-state/src/stable_selection.rs
+++ b/crates/editor-state/src/stable_selection.rs
@@ -1,13 +1,7 @@
-use std::collections::BTreeMap;
-
 use editor_macros::ffi;
-use editor_model::{DocView, Modifier, ModifierType};
+use editor_model::DocView;
 use serde::{Deserialize, Serialize};
 
-use crate::Position;
-use crate::modifier_resolution::{CaretCtx, resolve_caret_modifiers};
-use crate::pending_modifier::PendingModifier;
-use crate::projected_state::ProjectedState;
 use crate::selection::Selection;
 use crate::stable_position::{StablePosition, StableResolveCtx};
 
@@ -50,41 +44,16 @@ impl StableSelection {
     }
 }
 
-/// Effective inline modifiers a caret at `pos` would carry (no pending overrides).
-pub fn resolve_effective_modifiers_at(
-    state: &crate::state::State,
-    pos: &Position,
-) -> Vec<Modifier> {
-    caret_modifiers(&state.projected, pos, &[])
-        .into_values()
-        .collect()
-}
-
-pub(crate) fn caret_modifiers(
-    state: &ProjectedState,
-    pos: &Position,
-    pending: &[PendingModifier],
-) -> BTreeMap<ModifierType, Modifier> {
-    let view = state.view();
-    let ctx = CaretCtx {
-        view: &view,
-        doc: state.projected(),
-        block_modifiers: state.block_modifiers(),
-    };
-    resolve_caret_modifiers(pos, &ctx, pending)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use editor_crdt::{Dot, InputEvent, ListOp, build_oplog};
     use editor_model::{
-        Anchor, Bias, DocLogs, ModifierAttrLog, NodeAttrLog, NodeMarkerLog, NodeStyleLog, NodeType,
-        ProjectedDoc, SeqItem, SpanLog, StyleLog, project_document,
+        DocLogs, ModifierAttrLog, NodeAttrLog, NodeMarkerLog, NodeStyleLog, NodeType, ProjectedDoc,
+        SeqItem, SpanLog, StyleLog, project_document,
     };
 
     use crate::Position;
-    use crate::projected_state::ProjectedState;
 
     fn block(node_type: NodeType, parents: Vec<Dot>) -> SeqItem {
         SeqItem::Block { node_type, parents }
@@ -130,30 +99,6 @@ mod tests {
         let logs = doclogs(&ev);
         let pd = project_document(&logs).unwrap();
         (pd, logs, root, para)
-    }
-
-    fn state_with_chars(chars: &[char]) -> (ProjectedState, Dot, Dot) {
-        use editor_crdt::OpGraph;
-        use editor_model::EditOp;
-        let mut graph = OpGraph::<EditOp>::with_actor(1);
-        let root = Dot::ROOT;
-        let para = graph
-            .add_mut(EditOp::Seq(ListOp::Ins {
-                pos: 0,
-                item: block(NodeType::Paragraph, vec![root]),
-            }))
-            .unwrap()
-            .id;
-        for (i, c) in chars.iter().enumerate() {
-            graph
-                .add_mut(EditOp::Seq(ListOp::Ins {
-                    pos: 1 + i,
-                    item: SeqItem::Char(*c),
-                }))
-                .unwrap();
-        }
-        let state = ProjectedState::from_graph(graph).unwrap();
-        (state, root, para)
     }
 
     // Test 1: StableSelection round-trip (unchanged doc)
@@ -246,91 +191,6 @@ mod tests {
             .expect("falls back to the canonical root");
         assert_eq!(resolved.anchor.node, Dot::ROOT);
         assert_eq!(resolved.head.node, Dot::ROOT);
-    }
-
-    // Test 5: collapsed caret modifiers — bolded char has Bold
-    #[test]
-    fn test_5_collapsed_caret_modifiers_bold() {
-        use editor_model::{EditOp, SpanOp};
-        let (mut state, _root, para) = state_with_chars(&['a', 'b']);
-        let leaf_a = state
-            .view()
-            .node(para)
-            .unwrap()
-            .children()
-            .next()
-            .and_then(|c| {
-                if let editor_model::ChildView::Leaf(l) = c {
-                    Some(l.dot())
-                } else {
-                    None
-                }
-            })
-            .unwrap();
-        state
-            .apply(EditOp::Span(SpanOp::AddSpan {
-                start: Anchor {
-                    id: leaf_a,
-                    bias: Bias::Before,
-                },
-                end: Anchor {
-                    id: leaf_a,
-                    bias: Bias::After,
-                },
-                modifier: Modifier::Bold,
-            }))
-            .unwrap();
-
-        let pos = Position::new(para, 1);
-        let result = caret_modifiers(&state, &pos, &[]);
-        assert_eq!(result.get(&ModifierType::Bold), Some(&Modifier::Bold));
-    }
-
-    // Test 5b: empty paragraph with marker surfaces modifiers
-    #[test]
-    fn test_5b_empty_para_marker_modifiers() {
-        use editor_crdt::{LwwRegOp, OpGraph};
-        use editor_model::{EditOp, Marker, NodeLwwOp};
-        let mut graph = OpGraph::<EditOp>::with_actor(1);
-        let root = Dot::ROOT;
-        let para = graph
-            .add_mut(EditOp::Seq(ListOp::Ins {
-                pos: 0,
-                item: block(NodeType::Paragraph, vec![root]),
-            }))
-            .unwrap()
-            .id;
-        let mut state = ProjectedState::from_graph(graph).unwrap();
-        state
-            .apply(EditOp::NodeMarker(NodeLwwOp {
-                target: para,
-                op: LwwRegOp::Set {
-                    value: Some(Marker {
-                        modifiers: vec![Modifier::Bold],
-                        style: None,
-                    }),
-                },
-            }))
-            .unwrap();
-
-        let pos = Position::new(para, 0);
-        let result = caret_modifiers(&state, &pos, &[]);
-        assert_eq!(result.get(&ModifierType::Bold), Some(&Modifier::Bold));
-    }
-
-    // Test 5c: pending overlay applies
-    #[test]
-    fn test_5c_pending_overlay() {
-        let (state, _root, para) = state_with_chars(&[]);
-        let pos = Position::new(para, 0);
-        let result = caret_modifiers(
-            &state,
-            &pos,
-            &[PendingModifier::Set {
-                modifier: Modifier::Italic,
-            }],
-        );
-        assert_eq!(result.get(&ModifierType::Italic), Some(&Modifier::Italic));
     }
 
     // Test 6: direction preserved — head-before-anchor stays that way after resolve

--- a/crates/editor-view/src/measure/text/resolve.rs
+++ b/crates/editor-view/src/measure/text/resolve.rs
@@ -1,4 +1,7 @@
-use editor_model::{Modifier, ModifierType};
+use editor_model::{
+    DEFAULT_FONT_FAMILY, DEFAULT_FONT_SIZE, DEFAULT_FONT_WEIGHT, DEFAULT_LETTER_SPACING,
+    DEFAULT_LINE_HEIGHT, Modifier, ModifierType,
+};
 use editor_state::{PendingModifier, PendingModifiers};
 
 #[derive(Clone)]
@@ -10,10 +13,9 @@ pub struct ResolvedTextStyle {
     pub line_height: f32,
 }
 
-const DEFAULT_FONT_SIZE_PX: f32 = 16.0;
-const DEFAULT_FONT_WEIGHT: u16 = 400;
-const DEFAULT_LINE_HEIGHT: f32 = 1.6;
 const PT_TO_PX: f32 = 96.0 / 72.0;
+const DEFAULT_FONT_SIZE_PX: f32 = DEFAULT_FONT_SIZE as f32 / 100.0 * PT_TO_PX;
+const DEFAULT_LINE_HEIGHT_RATIO: f32 = DEFAULT_LINE_HEIGHT as f32 / 100.0;
 
 /// `resolve_text_style`와 달리 ancestor 순회·Expand 필터링을 하지 않는다 — 호출자가
 /// 미리 평탄화한 effective set을 넘긴다는 계약.
@@ -47,14 +49,14 @@ pub fn style_from_effective_modifiers(modifiers: &[Modifier]) -> ResolvedTextSty
     }
 
     let final_font_size = font_size.unwrap_or(DEFAULT_FONT_SIZE_PX);
-    let ls_em = letter_spacing.unwrap_or(0.0);
+    let ls_em = letter_spacing.unwrap_or(DEFAULT_LETTER_SPACING as f32 / 100.0);
 
     ResolvedTextStyle {
-        font_family: font_family.unwrap_or_default(),
+        font_family: font_family.unwrap_or_else(|| DEFAULT_FONT_FAMILY.to_string()),
         font_weight: font_weight.unwrap_or(DEFAULT_FONT_WEIGHT),
         font_size: final_font_size,
         letter_spacing: ls_em * final_font_size,
-        line_height: line_height.unwrap_or(DEFAULT_LINE_HEIGHT),
+        line_height: line_height.unwrap_or(DEFAULT_LINE_HEIGHT_RATIO),
     }
 }
 
@@ -87,11 +89,13 @@ pub fn apply_pending_to_style(style: &mut ResolvedTextStyle, pending: &PendingMo
                 _ => {}
             },
             PendingModifier::Unset { ty } => match ty {
-                ModifierType::FontFamily => font_family = String::new(),
+                ModifierType::FontFamily => font_family = DEFAULT_FONT_FAMILY.to_string(),
                 ModifierType::FontWeight => font_weight = DEFAULT_FONT_WEIGHT,
                 ModifierType::FontSize => font_size = DEFAULT_FONT_SIZE_PX,
-                ModifierType::LetterSpacing => letter_spacing_em = 0.0,
-                ModifierType::LineHeight => line_height = DEFAULT_LINE_HEIGHT,
+                ModifierType::LetterSpacing => {
+                    letter_spacing_em = DEFAULT_LETTER_SPACING as f32 / 100.0;
+                }
+                ModifierType::LineHeight => line_height = DEFAULT_LINE_HEIGHT_RATIO,
                 _ => {}
             },
         }
@@ -115,7 +119,7 @@ mod tests {
         let style = style_from_effective_modifiers(&[]);
         assert_eq!(style.font_weight, DEFAULT_FONT_WEIGHT);
         assert!((style.font_size - DEFAULT_FONT_SIZE_PX).abs() < 0.01);
-        assert!((style.line_height - DEFAULT_LINE_HEIGHT).abs() < 0.01);
+        assert!((style.line_height - DEFAULT_LINE_HEIGHT_RATIO).abs() < 0.01);
         assert!((style.letter_spacing - 0.0).abs() < 0.01);
         assert_eq!(style.font_family, "");
     }
@@ -249,7 +253,7 @@ mod tests {
         assert_eq!(style.font_weight, DEFAULT_FONT_WEIGHT);
         assert!((style.font_size - DEFAULT_FONT_SIZE_PX).abs() < 0.01);
         assert!((style.letter_spacing - 0.0).abs() < 0.01);
-        assert!((style.line_height - DEFAULT_LINE_HEIGHT).abs() < 0.01);
+        assert!((style.line_height - DEFAULT_LINE_HEIGHT_RATIO).abs() < 0.01);
     }
 
     #[test]

--- a/crates/editor-view/src/query/placeholder.rs
+++ b/crates/editor-view/src/query/placeholder.rs
@@ -14,15 +14,14 @@ pub struct PlaceholderMetrics {
 }
 
 use editor_common::Rect;
-use editor_model::{Alignment, DocView, Modifier, ModifierType, NodeType};
+use editor_model::{
+    Alignment, DEFAULT_FONT_SIZE, DEFAULT_LETTER_SPACING, DEFAULT_LINE_HEIGHT, DocView, Modifier,
+    ModifierType, NodeType,
+};
 use editor_state::{PendingModifier, PendingModifiers};
 
 use super::layout_index::LayoutIndex;
 use crate::view_state::PendingStyle;
-
-const DEFAULT_FONT_SIZE: u32 = 1200;
-const DEFAULT_LINE_HEIGHT: u32 = 160;
-const DEFAULT_LETTER_SPACING: i32 = 0;
 
 pub(crate) fn placeholder_metrics(
     layout_index: &LayoutIndex,


### PR DESCRIPTION
- bold 해제하면 툴바에서 font weight가 `-`로 보이던 문제 수정
- bold 해제 후 다시 bold할 때 에러 나던 문제 수정
- 툴바 상태를 입력될 또는 렌더된 modifier 기준으로 표시
- caret modifier 해석 로직과 테스트를 modifier resolution 쪽으로 이동