### PR TITLE
앱 홈 이어쓰기 리스트 변하면 페이지 0으로 초기화

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/home/home/HomeScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/home/home/HomeScreen.kt
@@ -388,7 +388,11 @@ private fun SearchBar(placeholder: String, onClick: suspend () -> Unit) {
 @Composable
 private fun ContinueWritingSection(docs: List<HomeScreen_ContinueWriting_document>) {
   Column {
-    val pagerState = rememberPagerState(pageCount = { docs.size })
+    val pagerState =
+      rememberPagerState(
+        key = docs.joinToString(separator = "|", prefix = "continue-writing:") { it.entity.id },
+        pageCount = { docs.size },
+      )
 
     Row(
       modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),


### PR DESCRIPTION
그래야 방금 본 문서가 보임