### PR TITLE
앱 에디터 적절한 시점에 commit preedit

### DIFF
--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/input/EditorInputConnection.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/input/EditorInputConnection.kt
@@ -100,7 +100,7 @@ internal class EditorInputConnection(
   }
 
   override fun finishComposingText(): Boolean {
-    batch.enqueue(FlatImeOp.ClearComposition)
+    batch.finishComposingText(hasActiveComposition = editor.ime?.composing != null)
     return true
   }
 
@@ -153,7 +153,7 @@ internal class EditorInputConnection(
   override fun getHandler() = null
 
   override fun closeConnection() {
-    batch.closeConnection()
+    batch.closeConnection(hasActiveComposition = editor.ime?.composing != null)
   }
 
   override fun commitContent(
@@ -208,9 +208,25 @@ private class ImeEditBatch(private val dispatch: (List<Message>) -> Unit) {
     return batchLevel > 0
   }
 
-  fun closeConnection() {
+  fun finishComposingText(hasActiveComposition: Boolean) {
+    pendingOps.add(
+      if (hasActiveComposition || hasPendingCompositionUpdate()) {
+        FlatImeOp.CommitAsIs
+      } else {
+        FlatImeOp.ClearComposition
+      }
+    )
+    flushIfReady()
+  }
+
+  fun closeConnection(hasActiveComposition: Boolean) {
     batchLevel = 0
-    enqueue(FlatImeOp.ClearComposition)
+    if ((hasActiveComposition || hasPendingCompositionUpdate()) && !hasPendingCommitAsIs()) {
+      pendingOps.add(FlatImeOp.CommitAsIs)
+    } else if (!hasPendingCommitAsIs()) {
+      pendingOps.add(FlatImeOp.ClearComposition)
+    }
+    flush()
   }
 
   fun enqueue(op: FlatImeOp) {
@@ -242,4 +258,23 @@ private class ImeEditBatch(private val dispatch: (List<Message>) -> Unit) {
     pendingMessages.add(Message.TextInput(pendingOps.toList()))
     pendingOps.clear()
   }
+
+  private fun hasPendingCompositionUpdate(): Boolean =
+    pendingOps.any { it.startsOrUpdatesComposition() } ||
+      pendingMessages.any { message ->
+        message is Message.TextInput && message.ops.any { it.startsOrUpdatesComposition() }
+      }
+
+  private fun hasPendingCommitAsIs(): Boolean =
+    pendingOps.any { it == FlatImeOp.CommitAsIs } ||
+      pendingMessages.any { message ->
+        message is Message.TextInput && message.ops.any { it == FlatImeOp.CommitAsIs }
+      }
+
+  private fun FlatImeOp.startsOrUpdatesComposition(): Boolean =
+    when (this) {
+      is FlatImeOp.Compose,
+      is FlatImeOp.SetComposition -> true
+      else -> false
+    }
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorImeCommandNormalizer.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorImeCommandNormalizer.kt
@@ -30,6 +30,7 @@ internal object EditorImeCommandNormalizer {
 
     val messages = mutableListOf<Message>()
     val ops = mutableListOf<FlatImeOp>()
+    var hasActiveComposition = ime?.composing != null
 
     for (command in commands) {
       if (command is CommitTextCommand && command.text == "\n") {
@@ -42,8 +43,25 @@ internal object EditorImeCommandNormalizer {
         continue
       }
 
-      val op = command.toFlatImeOp() ?: continue
+      val op =
+        if (command is FinishComposingTextCommand) {
+          if (hasActiveComposition) {
+            FlatImeOp.CommitAsIs
+          } else {
+            FlatImeOp.ClearComposition
+          }
+        } else {
+          command.toFlatImeOp()
+        } ?: continue
       ops += op
+      hasActiveComposition =
+        when (op) {
+          is FlatImeOp.Compose,
+          is FlatImeOp.SetComposition -> true
+          is FlatImeOp.ClearComposition,
+          is FlatImeOp.CommitAsIs -> false
+          else -> hasActiveComposition
+        }
     }
 
     if (ops.isNotEmpty()) {
@@ -85,7 +103,6 @@ internal object EditorImeCommandNormalizer {
       is SetComposingTextCommand -> FlatImeOp.Compose(text)
       is SetSelectionCommand -> FlatImeOp.SetSelection(start, end)
       is SetComposingRegionCommand -> FlatImeOp.SetComposition(start, end)
-      is FinishComposingTextCommand -> FlatImeOp.ClearComposition
       is DeleteSurroundingTextCommand ->
         FlatImeOp.DeleteSurroundingUtf16(lengthBeforeCursor, lengthAfterCursor)
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorInput.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorInput.kt
@@ -344,6 +344,12 @@ internal class EditorInputNode(
 
   private fun syncTextInputSession() {
     val sessionEnabled = focused && textInputSessionEnabled
+    if (!sessionEnabled && editor.ime?.composing != null) {
+      dispatchSync(
+        listOf(Message.TextInput(listOf(FlatImeOp.CommitAsIs))),
+        bringIntoViewTarget = null,
+      )
+    }
     focusedJob?.cancel()
     focusedJob = null
     platformInputBridge.reset()

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarHost.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarHost.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import co.typie.editor.EditorState
+import co.typie.editor.ffi.FlatImeOp
 import co.typie.editor.ffi.Message
 import co.typie.editor.runtime.LocalEditorRuntime
 import co.typie.editor.scroll.EditorBringIntoViewTarget
@@ -230,6 +231,9 @@ internal fun EditorToolbarHost(
 
     commandScope.launch {
       editor.awaitWithBringIntoView(bringIntoViewRequests) {
+        if (editor.ime?.composing != null) {
+          enqueue(Message.TextInput(listOf(FlatImeOp.CommitAsIs)))
+        }
         messages.forEach { enqueue(it) }
         beforeCommit { bringIntoView(bringIntoViewTarget) }
       }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/input/EditorImeCommandNormalizerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/input/EditorImeCommandNormalizerTest.kt
@@ -1,6 +1,8 @@
 package co.typie.editor.input
 
 import androidx.compose.ui.text.input.CommitTextCommand
+import androidx.compose.ui.text.input.FinishComposingTextCommand
+import androidx.compose.ui.text.input.SetComposingTextCommand
 import androidx.compose.ui.text.input.SetSelectionCommand
 import co.typie.editor.ffi.Direction
 import co.typie.editor.ffi.FlatImeOp
@@ -30,6 +32,38 @@ class EditorImeCommandNormalizerTest {
       EditorImeCommandNormalizer.normalize(listOf(CommitTextCommand("\n", 1)), ime = null)
 
     assertEquals(listOf(Message.Key(KeyEvent(Key.Enter))), messages)
+  }
+
+  @Test
+  fun `finish composing command clears composition without active preedit`() {
+    val messages =
+      EditorImeCommandNormalizer.normalize(listOf(FinishComposingTextCommand()), ime = null)
+
+    assertEquals(listOf(Message.TextInput(listOf(FlatImeOp.ClearComposition))), messages)
+  }
+
+  @Test
+  fun `finish composing command commits active preedit as-is`() {
+    val ime =
+      Ime(text = "ㅎ", windowStart = 0, selection = ImeRange(1, 1), composing = ImeRange(0, 1))
+    val messages =
+      EditorImeCommandNormalizer.normalize(listOf(FinishComposingTextCommand()), ime = ime)
+
+    assertEquals(listOf(Message.TextInput(listOf(FlatImeOp.CommitAsIs))), messages)
+  }
+
+  @Test
+  fun `finish composing command commits preedit started in same command batch`() {
+    val messages =
+      EditorImeCommandNormalizer.normalize(
+        listOf(SetComposingTextCommand("ㅎ", 1), FinishComposingTextCommand()),
+        ime = null,
+      )
+
+    assertEquals(
+      listOf(Message.TextInput(listOf(FlatImeOp.Compose("ㅎ"), FlatImeOp.CommitAsIs))),
+      messages,
+    )
   }
 
   @Test

--- a/apps/mobile/compose/src/desktopMain/kotlin/co/typie/editor/input/EditorInput.desktop.kt
+++ b/apps/mobile/compose/src/desktopMain/kotlin/co/typie/editor/input/EditorInput.desktop.kt
@@ -83,7 +83,8 @@ internal actual suspend fun PlatformTextInputSessionScope.createEditorInputReque
 
     override val editText: (block: TextEditingScope.() -> Unit) -> Unit = { block ->
       editor.syncWithBringIntoView(bringIntoViewRequests) {
-        val batch = EditorDesktopTextEditingBatch()
+        val batch =
+          EditorDesktopTextEditingBatch(initialHasActiveComposition = editor.ime?.composing != null)
         batch.block()
         for (message in batch.drainMessages()) {
           enqueue(message)
@@ -103,9 +104,11 @@ internal actual fun PlatformTextInputSessionScope.notifyImeSelectionChanged(edit
 }
 
 @OptIn(ExperimentalComposeUiApi::class)
-internal class EditorDesktopTextEditingBatch : TextEditingScope {
+internal class EditorDesktopTextEditingBatch(initialHasActiveComposition: Boolean = false) :
+  TextEditingScope {
   private val messages = mutableListOf<Message>()
   private val ops = mutableListOf<FlatImeOp>()
+  private var hasActiveComposition = initialHasActiveComposition
 
   override fun commitText(text: CharSequence, newCursorPosition: Int) {
     if (text.toString() == "\n") {
@@ -114,15 +117,23 @@ internal class EditorDesktopTextEditingBatch : TextEditingScope {
     } else {
       ops += FlatImeOp.Compose(text.toString())
       ops += FlatImeOp.CommitAsIs
+      hasActiveComposition = false
     }
   }
 
   override fun setComposingText(text: CharSequence, newCursorPosition: Int) {
     ops += FlatImeOp.Compose(text.toString())
+    hasActiveComposition = true
   }
 
   override fun finishComposingText() {
-    ops += FlatImeOp.ClearComposition
+    ops +=
+      if (hasActiveComposition) {
+        FlatImeOp.CommitAsIs
+      } else {
+        FlatImeOp.ClearComposition
+      }
+    hasActiveComposition = false
   }
 
   override fun deleteSurroundingTextInCodePoints(lengthBeforeCursor: Int, lengthAfterCursor: Int) {

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/input/EditorDesktopTextEditingBatchTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/input/EditorDesktopTextEditingBatchTest.kt
@@ -45,4 +45,38 @@ class EditorDesktopTextEditingBatchTest {
       batch.drainMessages(),
     )
   }
+
+  @Test
+  fun `finish composing text clears composition without active preedit`() {
+    val batch = EditorDesktopTextEditingBatch()
+
+    batch.finishComposingText()
+
+    assertEquals(
+      listOf(Message.TextInput(listOf(FlatImeOp.ClearComposition))),
+      batch.drainMessages(),
+    )
+  }
+
+  @Test
+  fun `finish composing text commits initial active preedit as-is`() {
+    val batch = EditorDesktopTextEditingBatch(initialHasActiveComposition = true)
+
+    batch.finishComposingText()
+
+    assertEquals(listOf(Message.TextInput(listOf(FlatImeOp.CommitAsIs))), batch.drainMessages())
+  }
+
+  @Test
+  fun `finish composing text commits preedit started in same batch`() {
+    val batch = EditorDesktopTextEditingBatch()
+
+    batch.setComposingText("ㅎ", 1)
+    batch.finishComposingText()
+
+    assertEquals(
+      listOf(Message.TextInput(listOf(FlatImeOp.Compose("ㅎ"), FlatImeOp.CommitAsIs))),
+      batch.drainMessages(),
+    )
+  }
 }


### PR DESCRIPTION
- 에디터 input session 종료 또는 blur될 때 active preedit이 있으면 CommitAsIs
- 툴바 조작은 에디터 포커스를 빼앗지 않으므로, 툴바가 메시지를 보내기 전에 commit