### PR TITLE
font family/weight 디버그

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/TextOptionMode.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/TextOptionMode.kt
@@ -80,10 +80,16 @@ internal val EditorSettingsFontFamily_family.representativeToolbarFont:
     }
   }
 
-internal fun toolbarFontWeightLabel(weight: Int, subfamilyDisplayName: String? = null): String =
-  EditorValues.fontWeight.firstOrNull { it.value == weight }?.label
-    ?: subfamilyDisplayName?.let { "$it ($weight)" }
-    ?: weight.toString()
+internal fun toolbarFontWeightLabel(
+  weight: Int,
+  subfamilyDisplayName: String? = null,
+  available: Boolean = true,
+): String =
+  if (!available) "(알 수 없는 굵기)"
+  else
+    EditorValues.fontWeight.firstOrNull { it.value == weight }?.label
+      ?: subfamilyDisplayName?.let { "$it ($weight)" }
+      ?: weight.toString()
 
 internal fun formatToolbarPointValue(value: Int): String {
   val whole = value / 100

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/TextToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/TextToolbar.kt
@@ -188,7 +188,7 @@ private fun EditorTextToolbar(
       subtle = true,
     )
     EditorToolbarLabelButton(
-      text = fontWeight?.let { toolbarFontWeightLabel(it) } ?: "-",
+      text = fontWeight?.let { toolbarFontWeightLabel(it, fontFamily, fontFamilies) } ?: "-",
       contentDescription = "폰트 굵기",
       onClick = { toggleMode(TextOptionMode.FontWeight) },
       selected = activeTextOptionMode == TextOptionMode.FontWeight,
@@ -438,5 +438,22 @@ private fun fontFamilyLabel(
   if (familyName == null) {
     return "-"
   }
-  return fontFamilies.firstOrNull { it.familyName == familyName }?.displayName ?: familyName
+  return fontFamilies.firstOrNull { it.familyName == familyName }?.displayName ?: "(알 수 없는 폰트)"
+}
+
+private fun toolbarFontWeightLabel(
+  weight: Int,
+  familyName: String?,
+  fontFamilies: List<EditorSettingsFontFamily_family>,
+): String {
+  val font =
+    (familyName
+        ?.let { name -> fontFamilies.firstOrNull { it.familyName == name } }
+        ?.activeToolbarFonts ?: fontFamilies.flatMap { it.activeToolbarFonts })
+      .firstOrNull { it.weight == weight }
+  return toolbarFontWeightLabel(
+    weight = weight,
+    subfamilyDisplayName = font?.subfamilyDisplayName,
+    available = font != null,
+  )
 }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/toolbar/contextual/TextOptionModeTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/toolbar/contextual/TextOptionModeTest.kt
@@ -1,0 +1,21 @@
+package co.typie.screen.editor.editor.toolbar.contextual
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TextOptionModeTest {
+  @Test
+  fun `toolbarFontWeightLabel uses numeric fallback for available unnamed weight`() {
+    assertEquals("950", toolbarFontWeightLabel(950))
+  }
+
+  @Test
+  fun `toolbarFontWeightLabel uses unknown fallback for unavailable weight`() {
+    assertEquals("(알 수 없는 굵기)", toolbarFontWeightLabel(weight = 950, available = false))
+  }
+
+  @Test
+  fun `toolbarFontWeightLabel uses unknown fallback for unavailable standard weight`() {
+    assertEquals("(알 수 없는 굵기)", toolbarFontWeightLabel(weight = 900, available = false))
+  }
+}

--- a/apps/website/src/lib/font-weight.test.ts
+++ b/apps/website/src/lib/font-weight.test.ts
@@ -48,12 +48,26 @@ describe('resolveFontWeightForFamily', () => {
 });
 
 describe('fontWeightValueLabel', () => {
-  it('uses numeric fallback for unavailable weights', () => {
-    expect(fontWeightValueLabel([{ weight: 300, state: 'ACTIVE' }], labels, 900)).toBe('900');
+  it('uses shared labels for registered weights', () => {
+    expect(fontWeightValueLabel([{ weight: 900, state: 'ACTIVE' }], labels, 900)).toBe('가장 굵게');
   });
 
-  it('uses configured labels only for available weights', () => {
-    expect(fontWeightValueLabel([{ weight: 900, state: 'ACTIVE' }], labels, 900)).toBe('가장 굵게');
+  it('uses subfamily fallback for registered weights without shared labels', () => {
+    expect(fontWeightValueLabel([{ weight: 450, state: 'ACTIVE', subfamilyDisplayName: 'Semi Condensed' }], labels, 450)).toBe(
+      'Semi Condensed (450)',
+    );
+  });
+
+  it('uses numeric fallback for registered weights without names', () => {
+    expect(fontWeightValueLabel([{ weight: 450, state: 'ACTIVE' }], labels, 450)).toBe('450');
+  });
+
+  it('uses unknown fallback for unavailable weights', () => {
+    expect(fontWeightValueLabel([{ weight: 450, state: 'ACTIVE' }], labels, 950)).toBe('(알 수 없는 굵기)');
+  });
+
+  it('uses unknown fallback for unavailable standard weights', () => {
+    expect(fontWeightValueLabel([{ weight: 300, state: 'ACTIVE' }], labels, 900)).toBe('(알 수 없는 굵기)');
   });
 });
 

--- a/apps/website/src/lib/font-weight.ts
+++ b/apps/website/src/lib/font-weight.ts
@@ -83,7 +83,11 @@ export const fontWeightLabel = (font: FontWeightFont, labels: readonly FontWeigh
 
 export const fontWeightValueLabel = (fonts: readonly FontWeightFont[], labels: readonly FontWeightLabel[], value: number): string => {
   const font = fonts.find((candidate) => candidate.weight === value);
-  return font ? fontWeightLabel(font, labels) : String(value);
+  if (!font) return '(알 수 없는 굵기)';
+  return (
+    labels.find((label) => label.value === value)?.label ??
+    (font.subfamilyDisplayName ? `${font.subfamilyDisplayName} (${value})` : String(value))
+  );
 };
 
 export const fontWeightItemsForFonts = (fonts: readonly FontWeightFont[], labels: readonly FontWeightLabel[]): FontWeightItem[] =>

--- a/crates/editor-model/src/modifier.rs
+++ b/crates/editor-model/src/modifier.rs
@@ -148,7 +148,7 @@ impl Modifier {
     }
 }
 
-pub const DEFAULT_FONT_FAMILY: &str = "";
+pub const DEFAULT_FONT_FAMILY: &str = "Pretendard";
 pub const DEFAULT_FONT_SIZE: u32 = 1200;
 pub const DEFAULT_FONT_WEIGHT: u16 = 400;
 pub const DEFAULT_LETTER_SPACING: i32 = 0;

--- a/crates/editor-state/src/modifier_state.rs
+++ b/crates/editor-state/src/modifier_state.rs
@@ -429,6 +429,44 @@ mod tests {
     }
 
     #[test]
+    fn range_clear_inheritable_font_family_reports_pretendard_default() {
+        let (mut state, root, para) = simple_para_state(&['a']);
+        state
+            .apply(EditOp::BlockModifier(ModifierAttrOp::SetModifier {
+                target: root,
+                modifier: Modifier::FontFamily {
+                    value: "Pretendard".to_string(),
+                },
+            }))
+            .unwrap();
+        let leaf_a = first_leaf_dot(&state, para);
+        state
+            .apply(EditOp::Span(SpanOp::RemoveSpan {
+                start: Anchor {
+                    id: leaf_a,
+                    bias: Bias::Before,
+                },
+                end: Anchor {
+                    id: leaf_a,
+                    bias: Bias::After,
+                },
+                modifier_type: ModifierType::FontFamily,
+            }))
+            .unwrap();
+
+        let s = sel((para, 0), (para, 1));
+        let ms = resolve_modifier_state(&state, &s, &[]).unwrap();
+        assert_eq!(
+            ms.font_family,
+            Tri::Uniform {
+                value: editor_model::FontFamilyValue {
+                    value: "Pretendard".to_string()
+                }
+            }
+        );
+    }
+
+    #[test]
     fn collapsed_pending_unset_inheritable_value_reports_inserted_resolved_value() {
         let (mut state, root, para) = simple_para_state(&['a']);
         state


### PR DESCRIPTION
- 프리텐다드로 지정하면 (알 수 없는 폰트) 뜨는 문제를 해결
- weight label 정책
  - 현재 family에 해당 weight가 없으면: (알 수 없는 굵기)
  - 현재 family에 해당 weight가 있으면: 
    - 표준 label 있으면 그 label
    - subfamily 있으면 Subfamily (value)
    - 둘 다 없으면 숫자