### PR TITLE
tracked item reveveal scroll이 union rect를 기준으로 함

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorGeometry.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorGeometry.kt
@@ -1,0 +1,83 @@
+package co.typie.editor
+
+import androidx.compose.ui.geometry.Rect
+import co.typie.editor.body.EditorDocumentLayoutSpec
+import co.typie.editor.body.resolvePageContentTop
+import co.typie.editor.ffi.PageRect
+import co.typie.editor.ffi.Size as PageSize
+
+data class VerticalSpan(val top: Float = 0f, val bottom: Float = 0f) {
+  val isValid: Boolean
+    get() = bottom > top
+
+  val height: Float
+    get() = (bottom - top).coerceAtLeast(0f)
+}
+
+internal fun pageRectsToContentRect(
+  rects: Iterable<PageRect>,
+  layoutSpec: EditorDocumentLayoutSpec,
+  pageSizes: List<PageSize>,
+  displayZoom: Float = 1f,
+  density: Float = 0f,
+  contentOriginX: Float = 0f,
+  contentOriginY: Float = 0f,
+): Rect? {
+  val zoom = normalizeDisplayZoom(displayZoom)
+  return unionRects(
+    rects.mapNotNull { pageRect ->
+      val pageTop =
+        layoutSpec.resolvePageContentTop(
+          page = pageRect.pageIdx,
+          pageSizes = pageSizes,
+          displayZoom = zoom,
+          density = density,
+        ) ?: return@mapNotNull null
+      val rect = pageRect.rect
+      val left = contentOriginX + rect.x * zoom
+      val top = contentOriginY + pageTop + rect.y * zoom
+      Rect(
+        left = left,
+        top = top,
+        right = left + rect.width * zoom,
+        bottom = top + rect.height * zoom,
+      )
+    }
+  )
+}
+
+internal fun unionRects(rects: Iterable<Rect?>): Rect? {
+  var left = Float.POSITIVE_INFINITY
+  var top = Float.POSITIVE_INFINITY
+  var right = Float.NEGATIVE_INFINITY
+  var bottom = Float.NEGATIVE_INFINITY
+
+  for (rect in rects) {
+    if (
+      rect == null ||
+        !rect.left.isFinite() ||
+        !rect.top.isFinite() ||
+        !rect.right.isFinite() ||
+        !rect.bottom.isFinite()
+    ) {
+      continue
+    }
+    left = minOf(left, rect.left, rect.right)
+    top = minOf(top, rect.top, rect.bottom)
+    right = maxOf(right, rect.left, rect.right)
+    bottom = maxOf(bottom, rect.top, rect.bottom)
+  }
+
+  return if (left == Float.POSITIVE_INFINITY) {
+    null
+  } else {
+    Rect(left = left, top = top, right = right, bottom = bottom)
+  }
+}
+
+private fun normalizeDisplayZoom(displayZoom: Float): Float =
+  if (displayZoom.isFinite() && displayZoom > 0f) {
+    displayZoom
+  } else {
+    1f
+  }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorViewportTransform.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorViewportTransform.kt
@@ -5,14 +5,6 @@ import co.typie.editor.ffi.Size
 
 data class PagePoint(val page: Int, val x: Float, val y: Float)
 
-data class VerticalSpan(val top: Float = 0f, val bottom: Float = 0f) {
-  val isValid: Boolean
-    get() = bottom > top
-
-  val height: Float
-    get() = (bottom - top).coerceAtLeast(0f)
-}
-
 data class EditorViewportAnchor(val page: Int, val x: Float, val y: Float)
 
 data class EditorViewportTransform(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorAutoScrollPolicy.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorAutoScrollPolicy.kt
@@ -86,8 +86,10 @@ internal fun resolveEditorScrollOffset(
 
   val targetTopInViewport = targetTopInContent - currentScroll
   val targetBottomInViewport = targetBottomInContent - currentScroll
+  val targetHeight = (targetBottomInContent - targetTopInContent).coerceAtLeast(0f)
 
   return when {
+    targetHeight > range.height -> targetTopInContent - range.top
     targetBottomInViewport > range.bottom -> targetBottomInContent - range.bottom
     targetTopInViewport < range.top -> targetTopInContent - range.top
     else -> null

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorScrollIntent.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorScrollIntent.kt
@@ -3,8 +3,8 @@ package co.typie.editor.scroll
 import co.typie.editor.EditorState
 import co.typie.editor.VerticalSpan
 import co.typie.editor.body.EditorDocumentLayoutSpec
-import co.typie.editor.body.resolvePageContentTop
-import co.typie.editor.ffi.Size as PageSize
+import co.typie.editor.ffi.PageRect
+import co.typie.editor.pageRectsToContentRect
 import co.typie.editor.runtime.EditorBoundsInContainer
 import co.typie.editor.runtime.EditorUiState
 
@@ -22,13 +22,7 @@ internal data class EditorScrollFrame(
 internal sealed interface EditorBringIntoViewTarget {
   data object CurrentSelectionHead : EditorBringIntoViewTarget
 
-  data class OverlayRect(
-    val pageIdx: Int,
-    val left: Float,
-    val top: Float,
-    val width: Float,
-    val height: Float,
-  ) : EditorBringIntoViewTarget
+  data class PageRects(val rects: List<PageRect>) : EditorBringIntoViewTarget
 }
 
 internal sealed interface EditorScrollIntentResult {
@@ -133,11 +127,21 @@ internal fun isEditorScrollTargetVisible(
 
 internal fun resolveBringIntoViewTargetHeight(
   state: EditorState,
+  layoutSpec: EditorDocumentLayoutSpec,
   target: EditorBringIntoViewTarget,
   displayZoom: Float,
+  density: Float = 0f,
 ): Float? {
-  val targetRect = resolveBringIntoViewTargetPageRect(state = state, target = target) ?: return null
-  return targetRect.height * displayZoom
+  val targetRects =
+    resolveBringIntoViewTargetPageRects(state = state, target = target) ?: return null
+  return pageRectsToContentRect(
+      rects = targetRects,
+      layoutSpec = layoutSpec,
+      pageSizes = state.pageSizes,
+      displayZoom = displayZoom,
+      density = density,
+    )
+    ?.height
 }
 
 private fun resolveBringIntoViewTargetRect(
@@ -149,44 +153,39 @@ private fun resolveBringIntoViewTargetRect(
   density: Float,
   target: EditorBringIntoViewTarget,
 ): VerticalSpan? {
-  val targetRect = resolveBringIntoViewTargetPageRect(state = state, target = target) ?: return null
-  val offsetY =
-    resolveTargetOffsetY(
+  val targetRects =
+    resolveBringIntoViewTargetPageRects(state = state, target = target) ?: return null
+  val contentRect =
+    pageRectsToContentRect(
+      rects = targetRects,
       layoutSpec = layoutSpec,
       pageSizes = state.pageSizes,
-      page = targetRect.pageIdx,
-      y = targetRect.y,
       displayZoom = displayZoom,
       density = density,
+      contentOriginY = headerHeight + editorTopInContainer,
     ) ?: return null
-  val contentTop = headerHeight + editorTopInContainer + offsetY
-  return VerticalSpan(top = contentTop, bottom = contentTop + targetRect.height * displayZoom)
+  return VerticalSpan(top = contentRect.top, bottom = contentRect.bottom)
 }
 
-private data class BringIntoViewTargetPageRect(val pageIdx: Int, val y: Float, val height: Float)
-
-private fun resolveBringIntoViewTargetPageRect(
+private fun resolveBringIntoViewTargetPageRects(
   state: EditorState,
   target: EditorBringIntoViewTarget,
-): BringIntoViewTargetPageRect? =
+): List<PageRect>? =
   when (target) {
-    EditorBringIntoViewTarget.CurrentSelectionHead -> resolveCurrentSelectionHeadPageRect(state)
-    is EditorBringIntoViewTarget.OverlayRect ->
-      BringIntoViewTargetPageRect(pageIdx = target.pageIdx, y = target.top, height = target.height)
+    EditorBringIntoViewTarget.CurrentSelectionHead ->
+      resolveCurrentSelectionHeadPageRect(state)?.let(::listOf)
+    is EditorBringIntoViewTarget.PageRects -> target.rects.takeIf { it.isNotEmpty() }
   }
 
-private fun resolveCollapsedSelectionHeadPageRect(
-  state: EditorState
-): BringIntoViewTargetPageRect? {
+internal fun List<PageRect>.toPageRectsTarget(): EditorBringIntoViewTarget.PageRects? =
+  takeIf { it.isNotEmpty() }?.let(EditorBringIntoViewTarget::PageRects)
+
+private fun resolveCollapsedSelectionHeadPageRect(state: EditorState): PageRect? {
   val cursor = state.cursor ?: return null
-  return BringIntoViewTargetPageRect(
-    pageIdx = cursor.pageIdx,
-    y = cursor.line.y,
-    height = cursor.line.height,
-  )
+  return PageRect(pageIdx = cursor.pageIdx, rect = cursor.line)
 }
 
-private fun resolveCurrentSelectionHeadPageRect(state: EditorState): BringIntoViewTargetPageRect? {
+private fun resolveCurrentSelectionHeadPageRect(state: EditorState): PageRect? {
   val selection = state.selection ?: return null
   if (selection.anchor == selection.head) {
     return resolveCollapsedSelectionHeadPageRect(state)
@@ -198,37 +197,8 @@ private fun resolveCurrentSelectionHeadPageRect(state: EditorState): BringIntoVi
       endpoints.fromPosition -> endpoints.from
       else -> return null
     }
-  return BringIntoViewTargetPageRect(
-    pageIdx = headRect.pageIdx,
-    y = headRect.rect.y,
-    height = headRect.rect.height,
-  )
+  return headRect
 }
-
-private fun resolveTargetOffsetY(
-  layoutSpec: EditorDocumentLayoutSpec,
-  pageSizes: List<PageSize>,
-  page: Int,
-  y: Float,
-  displayZoom: Float,
-  density: Float,
-): Float? {
-  val pageTop =
-    layoutSpec.resolvePageContentTop(
-      pageSizes = pageSizes,
-      page = page,
-      displayZoom = displayZoom,
-      density = density,
-    ) ?: return null
-  return pageTop + y * normalizeDisplayZoom(displayZoom)
-}
-
-private fun normalizeDisplayZoom(displayZoom: Float): Float =
-  if (displayZoom.isFinite() && displayZoom > 0f) {
-    displayZoom
-  } else {
-    1f
-  }
 
 private fun resolveBringIntoViewTargetOffset(
   mode: EditorAutoScrollMode,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -527,8 +527,10 @@ fun EditorScreen(entityId: String) {
     val typewriterTargetLineHeight =
       resolveBringIntoViewTargetHeight(
         state = editorState,
+        layoutSpec = layoutSpec,
         target = EditorBringIntoViewTarget.CurrentSelectionHead,
         displayZoom = displayZoom,
+        density = density,
       ) ?: 0f
     val subPaneLayoutInfo = subPaneState.layoutInfo
     val subPaneBottomOcclusion = resolveSubPaneBottomOcclusion(subPaneLayoutInfo)

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceEditorRanges.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceEditorRanges.kt
@@ -7,6 +7,7 @@ import co.typie.editor.ffi.Selection
 import co.typie.editor.ffi.TrackedRange
 import co.typie.editor.ffi.TrackedRangeOp
 import co.typie.editor.scroll.EditorBringIntoViewTarget
+import co.typie.editor.scroll.toPageRectsTarget
 
 internal const val SEARCH_MATCH_RANGE_GROUP = "search-match"
 internal const val ACTIVE_SEARCH_MATCH_RANGE_GROUP = "search-match-active"
@@ -153,16 +154,7 @@ internal fun Editor.replaceAllFindReplaceRanges(
   }
 }
 
-internal fun List<TrackedRange>.searchMatchScrollTarget(
-  id: String?
-): EditorBringIntoViewTarget.OverlayRect? {
+internal fun List<TrackedRange>.searchMatchScrollTarget(id: String?): EditorBringIntoViewTarget? {
   if (id == null) return null
-  val rect = searchMatchRanges().firstOrNull { it.id == id }?.rects?.firstOrNull() ?: return null
-  return EditorBringIntoViewTarget.OverlayRect(
-    pageIdx = rect.pageIdx,
-    left = rect.rect.x,
-    top = rect.rect.y,
-    width = rect.rect.width,
-    height = rect.rect.height,
-  )
+  return searchMatchRanges().firstOrNull { it.id == id }?.rects?.toPageRectsTarget()
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/spellcheck/EditorSpellcheckSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/spellcheck/EditorSpellcheckSession.kt
@@ -21,6 +21,7 @@ import co.typie.editor.scroll.EditorBringIntoViewBehavior
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.EditorBringIntoViewTarget
 import co.typie.editor.scroll.syncWithBringIntoView
+import co.typie.editor.scroll.toPageRectsTarget
 import co.typie.screen.editor.editor.state.EditorOverlayOcclusion
 import co.typie.ui.component.toast.LocalToast
 import co.typie.ui.component.toast.ToastType
@@ -372,16 +373,7 @@ internal fun rememberEditorSpellcheckSession(
 private fun RawSpellcheckResult.toSpellcheckResult(): SpellcheckResult =
   SpellcheckResult(id = id, context = context, corrections = corrections, explanation = explanation)
 
-private fun List<TrackedRange>.spellcheckScrollTarget(
-  id: String?
-): EditorBringIntoViewTarget.OverlayRect? {
+private fun List<TrackedRange>.spellcheckScrollTarget(id: String?): EditorBringIntoViewTarget? {
   if (id == null) return null
-  val rect = spellcheckRanges().firstOrNull { it.id == id }?.rects?.firstOrNull() ?: return null
-  return EditorBringIntoViewTarget.OverlayRect(
-    pageIdx = rect.pageIdx,
-    left = rect.rect.x,
-    top = rect.rect.y,
-    width = rect.rect.width,
-    height = rect.rect.height,
-  )
+  return spellcheckRanges().firstOrNull { it.id == id }?.rects?.toPageRectsTarget()
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/comments/EditorCommentsSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/comments/EditorCommentsSession.kt
@@ -16,6 +16,7 @@ import co.typie.editor.ffi.TrackedRange
 import co.typie.editor.scroll.EditorBringIntoViewBehavior
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.EditorBringIntoViewTarget
+import co.typie.editor.scroll.toPageRectsTarget
 import co.typie.ui.component.toast.LocalToast
 import co.typie.ui.component.toast.ToastType
 
@@ -274,16 +275,9 @@ internal fun rememberEditorCommentsSession(
 
 private fun List<TrackedRange>.commentThreadScrollTarget(
   threadId: String?
-): EditorBringIntoViewTarget.OverlayRect? {
+): EditorBringIntoViewTarget? {
   if (threadId == null) {
     return null
   }
-  val rect = commentRanges().firstOrNull { it.id == threadId }?.rects?.firstOrNull() ?: return null
-  return EditorBringIntoViewTarget.OverlayRect(
-    pageIdx = rect.pageIdx,
-    left = rect.rect.x,
-    top = rect.rect.y,
-    width = rect.rect.width,
-    height = rect.rect.height,
-  )
+  return commentRanges().firstOrNull { it.id == threadId }?.rects?.toPageRectsTarget()
 }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/FakeFfiEditor.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/FakeFfiEditor.kt
@@ -142,6 +142,8 @@ internal class FakeFfiEditor(
 
   override fun pageSizes(): List<Size> = pageSizesProvider()
 
+  override fun pageBackingSizes(): List<Size> = pageSizesProvider()
+
   override fun externalElements(): List<ExternalElement> = externalElementsProvider()
 
   override fun pageExternalElements(page: Int): List<ExternalElement> = emptyList()

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/GeometryTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/GeometryTest.kt
@@ -1,6 +1,10 @@
 package co.typie.editor
 
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import co.typie.editor.body.EditorDocumentLayoutSpec
+import co.typie.editor.ffi.PageRect
+import co.typie.editor.ffi.Rect as FfiRect
 import co.typie.editor.ffi.Size
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -23,6 +27,52 @@ class GeometryTest {
   private val offsetsCentered = mapOf(0 to Offset(50f, 0f), 1 to Offset(50f, 600f))
   private val sizesCentered =
     listOf(Size(width = 300f, height = 600f), Size(width = 300f, height = 400f))
+
+  @Test
+  fun unionRects_returns_the_union_of_all_valid_rects() {
+    val rect =
+      unionRects(
+        listOf(
+          Rect(left = 40f, top = 420f, right = 70f, bottom = 450f),
+          Rect(left = 30f, top = 380f, right = 60f, bottom = 410f),
+          Rect(left = 80f, top = 460f, right = 20f, bottom = 500f),
+        )
+      )
+
+    assertEquals(Rect(left = 20f, top = 380f, right = 80f, bottom = 500f), rect)
+  }
+
+  @Test
+  fun unionRects_returns_null_when_no_valid_rects_are_present() {
+    assertNull(unionRects(emptyList()))
+    assertNull(unionRects(listOf(Rect(left = Float.NaN, top = 0f, right = 10f, bottom = 20f))))
+  }
+
+  @Test
+  fun pageRectsToContentRect_returns_the_content_union_across_pages() {
+    val rect =
+      pageRectsToContentRect(
+        rects =
+          listOf(
+            PageRect(pageIdx = 0, rect = FfiRect(x = 20f, y = 50f, width = 10f, height = 10f)),
+            PageRect(pageIdx = 1, rect = FfiRect(x = 3f, y = 20f, width = 5f, height = 5f)),
+          ),
+        layoutSpec =
+          EditorDocumentLayoutSpec.Paginated(
+            pageWidth = 100f,
+            pageHeight = 100f,
+            pageMarginTop = 0f,
+            pageMarginBottom = 0f,
+            pageMarginLeft = 0f,
+            pageMarginRight = 0f,
+          ),
+        pageSizes = listOf(Size(width = 100f, height = 100f), Size(width = 100f, height = 100f)),
+        contentOriginX = 5f,
+        contentOriginY = 10f,
+      )
+
+    assertEquals(Rect(left = 8f, top = 60f, right = 35f, bottom = 159f), rect)
+  }
 
   @Test
   fun localToGlobal_adds_page_offset() {

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorAutoScrollPolicyTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorAutoScrollPolicyTest.kt
@@ -66,6 +66,19 @@ class EditorAutoScrollPolicyTest {
   }
 
   @Test
+  fun `keep-visible policy aligns oversized target top to the guarded visible area`() {
+    val offset =
+      resolveKeepVisibleScrollOffset(
+        currentScroll = 300f,
+        targetTopInContent = 1000f,
+        targetBottomInContent = 1700f,
+        visibleArea = testVisibleArea(),
+      )
+
+    assertEquals(860f, offset)
+  }
+
+  @Test
   fun `resolved policy keeps keep-visible mode active when typewriter is disabled`() {
     val policy =
       resolveEditorAutoScrollPolicy(

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorBringIntoViewRequestsTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorBringIntoViewRequestsTest.kt
@@ -1,5 +1,7 @@
 package co.typie.editor.scroll
 
+import co.typie.editor.ffi.PageRect
+import co.typie.editor.ffi.Rect as FfiRect
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -7,13 +9,9 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class EditorBringIntoViewRequestsTest {
-  private val overlayTarget =
-    EditorBringIntoViewTarget.OverlayRect(
-      pageIdx = 0,
-      left = 0f,
-      top = 10f,
-      width = 20f,
-      height = 30f,
+  private val pageRectsTarget =
+    EditorBringIntoViewTarget.PageRects(
+      listOf(PageRect(pageIdx = 0, rect = FfiRect(x = 0f, y = 10f, width = 20f, height = 30f)))
     )
 
   @Test
@@ -63,7 +61,7 @@ class EditorBringIntoViewRequestsTest {
       requests.activateForVersion(version = 2L),
     )
 
-    requests.requestForVersion(target = overlayTarget, version = 3L)
+    requests.requestForVersion(target = pageRectsTarget, version = 3L)
 
     assertEquals(
       request(EditorBringIntoViewTarget.CurrentSelectionHead),
@@ -76,7 +74,7 @@ class EditorBringIntoViewRequestsTest {
       )
     )
     assertNull(requests.activateForVersion(version = 2L))
-    assertEquals(request(overlayTarget), requests.activateForVersion(version = 3L))
+    assertEquals(request(pageRectsTarget), requests.activateForVersion(version = 3L))
   }
 
   @Test
@@ -89,7 +87,7 @@ class EditorBringIntoViewRequestsTest {
     )
     assertNull(requests.activateForVersion(version = 258L))
 
-    requests.requestForVersion(target = overlayTarget, version = 260L)
+    requests.requestForVersion(target = pageRectsTarget, version = 260L)
 
     assertEquals(
       request(EditorBringIntoViewTarget.CurrentSelectionHead),
@@ -102,7 +100,7 @@ class EditorBringIntoViewRequestsTest {
       )
     )
 
-    assertEquals(request(overlayTarget), requests.activateForVersion(version = 260L))
+    assertEquals(request(pageRectsTarget), requests.activateForVersion(version = 260L))
   }
 
   @Test
@@ -113,7 +111,7 @@ class EditorBringIntoViewRequestsTest {
       target = EditorBringIntoViewTarget.CurrentSelectionHead,
       version = 291L,
     )
-    requests.requestForVersion(target = overlayTarget, version = 292L)
+    requests.requestForVersion(target = pageRectsTarget, version = 292L)
 
     assertEquals(
       request(EditorBringIntoViewTarget.CurrentSelectionHead),
@@ -126,7 +124,7 @@ class EditorBringIntoViewRequestsTest {
       )
     )
 
-    assertEquals(request(overlayTarget), requests.activateForVersion(version = 292L))
+    assertEquals(request(pageRectsTarget), requests.activateForVersion(version = 292L))
   }
 
   @Test
@@ -137,9 +135,9 @@ class EditorBringIntoViewRequestsTest {
       target = EditorBringIntoViewTarget.CurrentSelectionHead,
       version = 291L,
     )
-    requests.requestForVersion(target = overlayTarget, version = 292L)
+    requests.requestForVersion(target = pageRectsTarget, version = 292L)
 
-    assertEquals(request(overlayTarget), requests.activateForVersion(version = 292L))
+    assertEquals(request(pageRectsTarget), requests.activateForVersion(version = 292L))
   }
 
   @Test
@@ -155,7 +153,7 @@ class EditorBringIntoViewRequestsTest {
       requests.activateForVersion(version = 1L),
     )
 
-    requests.requestForVersion(target = overlayTarget, version = 2L)
+    requests.requestForVersion(target = pageRectsTarget, version = 2L)
     requests.cancel()
 
     assertFalse(

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorScrollResolverTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorScrollResolverTest.kt
@@ -194,6 +194,37 @@ class EditorScrollResolverTest {
   }
 
   @Test
+  fun `page rects target reveals the vertical union across pages`() {
+    val frame =
+      frame(
+        state =
+          state(
+            cursor = null,
+            selection = null,
+            pageSizes =
+              listOf(PageSize(width = 300f, height = 620f), PageSize(width = 300f, height = 620f)),
+          ),
+        layoutSpec = paginatedLayout(),
+      )
+
+    val intent =
+      resolveEditorScrollIntent(
+        frame = frame,
+        target =
+          EditorBringIntoViewTarget.PageRects(
+            listOf(
+              PageRect(pageIdx = 0, rect = FfiRect(x = 0f, y = 500f, width = 40f, height = 20f)),
+              PageRect(pageIdx = 0, rect = FfiRect(x = 0f, y = 580f, width = 40f, height = 20f)),
+              PageRect(pageIdx = 1, rect = FfiRect(x = 0f, y = 20f, width = 40f, height = 20f)),
+            )
+          ),
+        currentScroll = 0f,
+      )
+
+    assertScrollTo(intent, 440f)
+  }
+
+  @Test
   fun `selection head target height resolves from endpoint when range selection has no cursor`() {
     val anchor = position(offset = 1)
     val head = position(offset = 8)
@@ -212,11 +243,38 @@ class EditorScrollResolverTest {
               ),
             pageSizes = listOf(PageSize(width = 300f, height = 620f)),
           ),
+        layoutSpec = EditorDocumentLayoutSpec.Continuous(maxWidth = 300f),
         target = EditorBringIntoViewTarget.CurrentSelectionHead,
         displayZoom = 1.5f,
       )
 
     assertEquals(30f, requireNotNull(height), 0.0001f)
+  }
+
+  @Test
+  fun `page rects target height resolves from the vertical union across pages`() {
+    val height =
+      resolveBringIntoViewTargetHeight(
+        state =
+          state(
+            cursor = null,
+            selection = null,
+            pageSizes =
+              listOf(PageSize(width = 300f, height = 620f), PageSize(width = 300f, height = 620f)),
+          ),
+        layoutSpec = paginatedLayout(),
+        target =
+          EditorBringIntoViewTarget.PageRects(
+            listOf(
+              PageRect(pageIdx = 0, rect = FfiRect(x = 0f, y = 500f, width = 40f, height = 20f)),
+              PageRect(pageIdx = 0, rect = FfiRect(x = 0f, y = 580f, width = 40f, height = 20f)),
+              PageRect(pageIdx = 1, rect = FfiRect(x = 0f, y = 20f, width = 40f, height = 20f)),
+            )
+          ),
+        displayZoom = 1f,
+      )
+
+    assertEquals(184f, requireNotNull(height), 0.0001f)
   }
 
   @Test

--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -1087,10 +1087,6 @@ export class Editor {
     return samePosition(selection.head, endpoints.to_position) ? endpoints.to : endpoints.from;
   }
 
-  trackedItemFirstRect(id: string): PageRect | null {
-    return this.trackedItemRects(id)?.[0] ?? null;
-  }
-
   trackedItemRects(id: string): PageRect[] | null {
     const range = this.trackedRanges.find((r) => r.id === id);
     if (!range) return null;

--- a/apps/website/src/lib/editor-ffi/geometry.test.ts
+++ b/apps/website/src/lib/editor-ffi/geometry.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { boundingClientRect, pageRectsToVirtualElement } from './geometry';
+import type { Editor } from './editor.svelte';
+
+describe('boundingClientRect', () => {
+  it('returns the bounding union of all client rects', () => {
+    const rect = boundingClientRect([new DOMRect(20, 40, 10, 20), new DOMRect(5, 80, 20, 10), new DOMRect(40, 30, 5, 5)]);
+
+    expect(rect?.left).toBe(5);
+    expect(rect?.top).toBe(30);
+    expect(rect?.width).toBe(40);
+    expect(rect?.height).toBe(60);
+  });
+
+  it('returns null when no rects are present', () => {
+    expect(boundingClientRect([])).toBeNull();
+  });
+
+  it('ignores non-finite rects', () => {
+    expect(boundingClientRect([new DOMRect(NaN, 0, 10, 10)])).toBeNull();
+  });
+});
+
+describe('pageRectsToVirtualElement', () => {
+  it('keeps an empty bounding rect fallback for empty virtual elements', () => {
+    const editor = { pageEls: [], safeDisplayZoom: () => 1 } as unknown as Editor;
+    const virtualElement = pageRectsToVirtualElement(editor, []);
+
+    const rect = virtualElement.getBoundingClientRect();
+    expect(rect.width).toBe(0);
+    expect(rect.height).toBe(0);
+    expect([...(virtualElement.getClientRects?.() ?? [])]).toEqual([]);
+  });
+});

--- a/apps/website/src/lib/editor-ffi/geometry.ts
+++ b/apps/website/src/lib/editor-ffi/geometry.ts
@@ -11,7 +11,7 @@ export function pageRectToClientRect(editor: Editor, { page_idx, rect }: PageRec
   return new DOMRect(pageRect.left + rect.x * zoom, pageRect.top + rect.y * zoom, rect.width * zoom, rect.height * zoom);
 }
 
-function pageRectsToClientRects(editor: Editor, rects: PageRect[]): DOMRect[] {
+export function pageRectsToClientRects(editor: Editor, rects: PageRect[]): DOMRect[] {
   const out: DOMRect[] = [];
 
   for (const rect of rects) {
@@ -22,27 +22,38 @@ function pageRectsToClientRects(editor: Editor, rects: PageRect[]): DOMRect[] {
   return out;
 }
 
-function boundingClientRect(rects: DOMRect[]): DOMRect {
-  if (rects.length === 0) return new DOMRect();
-
+export function boundingClientRect(rects: Iterable<DOMRect | null | undefined>): DOMRect | null {
   let minX = Infinity;
   let minY = Infinity;
   let maxX = -Infinity;
   let maxY = -Infinity;
 
   for (const rect of rects) {
+    if (
+      !rect ||
+      !Number.isFinite(rect.left) ||
+      !Number.isFinite(rect.top) ||
+      !Number.isFinite(rect.right) ||
+      !Number.isFinite(rect.bottom)
+    ) {
+      continue;
+    }
     minX = Math.min(minX, rect.left);
     minY = Math.min(minY, rect.top);
     maxX = Math.max(maxX, rect.right);
     maxY = Math.max(maxY, rect.bottom);
   }
 
-  return new DOMRect(minX, minY, maxX - minX, maxY - minY);
+  return minX === Infinity ? null : new DOMRect(minX, minY, maxX - minX, maxY - minY);
+}
+
+export function pageRectsToClientRect(editor: Editor, rects: PageRect[]): DOMRect | null {
+  return boundingClientRect(pageRectsToClientRects(editor, rects));
 }
 
 export function pageRectsToVirtualElement(editor: Editor, rects: PageRect[]): ReferenceElement {
   return {
-    getBoundingClientRect: () => boundingClientRect(pageRectsToClientRects(editor, rects)),
+    getBoundingClientRect: () => pageRectsToClientRect(editor, rects) ?? new DOMRect(),
     getClientRects: () => pageRectsToClientRects(editor, rects),
   };
 }

--- a/apps/website/src/lib/editor-ffi/scroll.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/scroll.svelte.ts
@@ -1,6 +1,7 @@
 import { getAppContext } from '@typie/ui/context';
 import { tick, untrack } from 'svelte';
 import { CONTINUOUS_VIEW_PADDING } from './constants';
+import { pageRectsToClientRect } from './geometry';
 import {
   resolveKeepVisibleBottomPadding,
   resolveNearestScrollTop,
@@ -9,7 +10,7 @@ import {
 } from './scroll';
 import type { PageRect } from '@typie/editor-ffi/browser';
 import type { Editor, EditorContext } from './editor.svelte';
-import type { EditorVisibleArea, RevealTargetSpan } from './scroll';
+import type { EditorVisibleArea } from './scroll';
 
 export type EditorScrollRevealMode = 'nearest' | 'typewriter';
 
@@ -133,15 +134,15 @@ export class EditorScrollScope {
       this.#pendingRequest = null;
       if (!request) return;
 
-      const rect = this.#resolveTargetRect(request.target);
-      if (!rect) return;
+      const rects = this.#resolveTargetRects(request.target);
+      if (!rects) return;
 
       const mode = request.mode === 'typewriter' && this.#typewriterPreferences().enabled ? 'typewriter' : 'nearest';
       void this.bottomPadding;
       await tick();
 
       this.#applyCommit({
-        rect,
+        rects,
         mode,
         behavior: request.behavior,
       });
@@ -153,30 +154,33 @@ export class EditorScrollScope {
     }
   }
 
-  #resolveTargetRect(target: EditorScrollIntoViewTarget): PageRect | null {
+  #resolveTargetRects(target: EditorScrollIntoViewTarget): PageRect[] | null {
     switch (target.type) {
       case 'current_selection_head': {
-        return this.#editor.selectionHeadRect();
+        const rect = this.#editor.selectionHeadRect();
+        return rect ? [rect] : null;
       }
       case 'tracked_item': {
-        return this.#editor.trackedItemFirstRect(target.id);
+        return this.#editor.trackedItemRects(target.id);
       }
     }
   }
 
-  #applyCommit({ rect, mode, behavior }: { rect: PageRect; mode: EditorScrollRevealMode; behavior: ScrollBehavior }): void {
+  #applyCommit({ rects, mode, behavior }: { rects: PageRect[]; mode: EditorScrollRevealMode; behavior: ScrollBehavior }): void {
     const viewport = this.#editor.scrollViewport;
     if (!viewport) return;
 
-    const span = this.#pageRectToScrollSpan(rect);
-    if (!span) return;
-
     const viewportRect = viewport.getRect();
+    const targetRect = pageRectsToClientRect(this.#editor, rects);
+    if (!targetRect) return;
+
+    const scrollTop = viewport.getScrollTop();
     const metrics = {
-      scrollTop: viewport.getScrollTop(),
+      scrollTop,
       clientHeight: viewportRect.bottom - viewportRect.top,
       scrollHeight: viewport.getScrollHeight(),
-      ...span,
+      targetTop: targetRect.top - viewportRect.top + scrollTop,
+      targetBottom: targetRect.bottom - viewportRect.top + scrollTop,
       visibleArea: this.visibleArea,
     };
     const nextTop =
@@ -189,27 +193,14 @@ export class EditorScrollScope {
     }
   }
 
-  #pageRectToScrollSpan({ page_idx, rect }: PageRect): RevealTargetSpan | null {
-    const pageEl = this.#editor.pageEls[page_idx];
-    const viewport = this.#editor.scrollViewport;
-    if (!pageEl || !viewport) return null;
-
-    const zoom = this.#editor.safeDisplayZoom();
-    const pageRect = pageEl.getBoundingClientRect();
-    const viewportRect = viewport.getRect();
-    const targetTop = pageRect.top - viewportRect.top + viewport.getScrollTop() + rect.y * zoom;
-    const targetBottom = targetTop + rect.height * zoom;
-    return { targetTop, targetBottom };
-  }
-
   #keepVisibleBottomPadding(): number {
     const target = this.#keepVisibleTarget;
     if (!target) {
       return 0;
     }
 
-    const rect = this.#resolveTargetRect(target);
-    if (!rect) {
+    const rects = this.#resolveTargetRects(target);
+    if (!rects) {
       return 0;
     }
 

--- a/apps/website/src/lib/editor-ffi/scroll.test.ts
+++ b/apps/website/src/lib/editor-ffi/scroll.test.ts
@@ -42,6 +42,19 @@ describe('resolveNearestScrollTop', () => {
       }),
     ).toBeNull();
   });
+
+  it('aligns an oversized target top to the guarded visible area', () => {
+    expect(
+      resolveNearestScrollTop({
+        scrollTop: 300,
+        clientHeight: 400,
+        scrollHeight: 2000,
+        targetTop: 1000,
+        targetBottom: 1500,
+        visibleArea: { topInset: 10, bottomInset: 20 },
+      }),
+    ).toBe(930);
+  });
 });
 
 describe('resolveTypewriterScrollTop', () => {

--- a/apps/website/src/lib/editor-ffi/scroll.ts
+++ b/apps/website/src/lib/editor-ffi/scroll.ts
@@ -65,7 +65,11 @@ export function resolveNearestScrollTop({
   }
 
   let nextTop: number | null = null;
-  if (targetBottom - safeScrollTop > rangeBottom) {
+  const targetHeight = Math.max(0, finiteOrZero(targetBottom) - finiteOrZero(targetTop));
+  const rangeHeight = rangeBottom - rangeTop;
+  if (targetHeight > rangeHeight) {
+    nextTop = finiteOrZero(targetTop) - rangeTop;
+  } else if (targetBottom - safeScrollTop > rangeBottom) {
     nextTop = finiteOrZero(targetBottom) - rangeBottom;
   } else if (targetTop - safeScrollTop < rangeTop) {
     nextTop = finiteOrZero(targetTop) - rangeTop;


### PR DESCRIPTION
- 여러 줄에 걸쳐서 여러 rect를 가지는 tracked item으로 reveal scroll 할 때 union rect를 기준으로 함
- union rect가 너무 크면 viewport top margin쪽에 target top이 오는 위치에 스크롤함
- 리팩토링