### PR TITLE
앱 에디터 단축키 보강

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorView.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorView.kt
@@ -9,7 +9,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.focusRequester
@@ -17,7 +21,6 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
-import co.typie.editor.EditorRegistry
 import co.typie.editor.body.EditorDocumentLayoutSpec
 import co.typie.editor.body.resolvePaginatedPageGap
 import co.typie.editor.external.EditorExternalElementOverlay
@@ -95,12 +98,21 @@ internal fun EditorView(
   Box(modifier) {
     val editor = runtime.editor ?: return@Box
     val focusManager = LocalFocusManager.current
+    var previousSelection by remember(editor) { mutableStateOf(editor.selection) }
     LaunchedEffect(editor, themeVariant) {
       val changed = PlatformModule.editorHost.setThemeVariant(themeVariant)
       if (changed) {
         for (e in EditorRegistry.snapshot()) {
           e.enqueue(Message.System(SystemEvent.ThemeVariantChanged))
         }
+      }
+    }
+    LaunchedEffect(editor, editor.selection, uiState.focused) {
+      val currentSelection = editor.selection
+      val selectionCleared = previousSelection != null && currentSelection == null
+      previousSelection = currentSelection
+      if (selectionCleared && uiState.focused) {
+        focusManager.clearFocus()
       }
     }
     SideEffect { editor.focusManager = focusManager }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -273,6 +273,15 @@ fun EditorScreen(entityId: String) {
       editorState = editorState,
       bringIntoViewRequests = bringIntoViewRequests,
     )
+  fun requestEditorFocusIfSelectionActive() {
+    if (editorState.selection != null) {
+      requestEditorFocus()
+    }
+  }
+  fun closeFindReplaceFromShortcut() {
+    findReplace.close()
+    requestEditorFocusIfSelectionActive()
+  }
   suspend fun ensureSpellcheckSubscription(): Boolean {
     return SubscriptionService.gate(
       sheet = sheet,
@@ -336,7 +345,9 @@ fun EditorScreen(entityId: String) {
       ProvideTopBar(
         leading = { FindReplaceTopBarLeading(session = findReplace) },
         leadingKey = FindReplaceTopBarLeadingKey,
-        center = { FindReplaceTopBarCenter(session = findReplace) },
+        center = {
+          FindReplaceTopBarCenter(session = findReplace, onEscape = ::closeFindReplaceFromShortcut)
+        },
         centerKey = FindReplaceTopBarCenterKey,
         trailing = { FindReplaceTopBarTrailing(session = findReplace) },
         trailingKey = FindReplaceTopBarTrailingKey,
@@ -463,6 +474,7 @@ fun EditorScreen(entityId: String) {
     val panelTransitionRunning =
       bottomPanelTransition.currentState != bottomPanelTransition.targetState
     val subPaneActive = subPaneState.activeKey != null
+    val screenShortcutModeActive = findReplace.active || spellcheck.active || aiFeedback.active
     val editorToolbarVisible =
       screenState.sceneInForeground && !subPaneActive && !findReplace.active
     val findReplaceToolbarVisible =
@@ -492,6 +504,38 @@ fun EditorScreen(entityId: String) {
         }
       }
     }
+    fun openFindReplace() {
+      aiFeedback.close()
+      spellcheck.close()
+      uiState.contextMenu.hide()
+      performInputEffects(toolbarInputState.dispatch(ToolbarIntent.Reset, toolbarInputEnvironment))
+      findReplace.open()
+    }
+    val screenShortcutContext =
+      EditorScreenShortcutContext(
+        platform = PlatformModule.platform,
+        sceneInForeground = screenState.sceneInForeground,
+        subPaneActive = subPaneActive,
+        editorFocused = uiState.focused,
+        findReplaceActive = findReplace.active,
+        spellcheckActive = spellcheck.active,
+        aiFeedbackActive = aiFeedback.active,
+      )
+    fun closeSpellcheckFromShortcut() {
+      spellcheck.close()
+      requestEditorFocusIfSelectionActive()
+    }
+    fun closeAiFeedbackFromShortcut() {
+      aiFeedback.close()
+      requestEditorFocusIfSelectionActive()
+    }
+    val screenShortcutActions =
+      EditorScreenShortcutActions(
+        openFindReplace = ::openFindReplace,
+        closeFindReplace = ::closeFindReplaceFromShortcut,
+        closeSpellcheck = ::closeSpellcheckFromShortcut,
+        closeAiFeedback = ::closeAiFeedbackFromShortcut,
+      )
     suspend fun openTemplateSheet() {
       val activeEditor = runtime.editor ?: return
       runtime.blur()
@@ -940,6 +984,7 @@ fun EditorScreen(entityId: String) {
             visibleState = findReplaceToolbarTransition,
             bottomInset = findReplaceToolbarBottomInset,
             modifier = Modifier,
+            onEscape = ::closeFindReplaceFromShortcut,
           )
           EditorToolbarHost(
             editorState = editorState,
@@ -955,15 +1000,7 @@ fun EditorScreen(entityId: String) {
             onInputEffects = ::performInputEffects,
             onToolAction = { action ->
               when (action) {
-                EditorToolbarToolAction.Search -> {
-                  aiFeedback.close()
-                  spellcheck.close()
-                  uiState.contextMenu.hide()
-                  performInputEffects(
-                    toolbarInputState.dispatch(ToolbarIntent.Reset, toolbarInputEnvironment)
-                  )
-                  findReplace.open()
-                }
+                EditorToolbarToolAction.Search -> openFindReplace()
                 EditorToolbarToolAction.RelatedNotes -> {
                   findReplace.close()
                   aiFeedback.close()
@@ -1014,7 +1051,19 @@ fun EditorScreen(entityId: String) {
             modifier = Modifier.fillMaxSize(),
           )
         },
-        modifier = Modifier.padding(start = startInset, end = endInset),
+        modifier =
+          Modifier.padding(start = startInset, end = endInset).editorScreenShortcutFocusTarget(
+            active = screenShortcutModeActive,
+            enabled = screenState.sceneInForeground && !subPaneActive,
+            editorFocused = uiState.focused,
+            selection = editorState.selection,
+          ) { event ->
+            handleEditorScreenShortcut(
+              event = event,
+              context = screenShortcutContext,
+              actions = screenShortcutActions,
+            )
+          },
       )
     }
   }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreenShortcut.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreenShortcut.kt
@@ -1,0 +1,174 @@
+package co.typie.screen.editor.editor
+
+import androidx.compose.foundation.focusable
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isAltPressed
+import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.isMetaPressed
+import androidx.compose.ui.input.key.isShiftPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import co.typie.editor.ffi.Selection
+import co.typie.platform.Platform
+
+internal enum class EditorScreenShortcutModifier {
+  Shift,
+  Mod,
+  Ctrl,
+  Alt,
+}
+
+internal data class EditorScreenShortcutContext(
+  val platform: Platform,
+  val sceneInForeground: Boolean,
+  val subPaneActive: Boolean,
+  val editorFocused: Boolean,
+  val findReplaceActive: Boolean,
+  val spellcheckActive: Boolean,
+  val aiFeedbackActive: Boolean,
+)
+
+internal data class EditorScreenShortcutActions(
+  val openFindReplace: () -> Unit,
+  val closeFindReplace: () -> Unit,
+  val closeSpellcheck: () -> Unit,
+  val closeAiFeedback: () -> Unit,
+)
+
+private data class EditorScreenShortcutBinding(
+  val key: Key,
+  val modifiers: Set<EditorScreenShortcutModifier> = emptySet(),
+  val enabled: (EditorScreenShortcutContext) -> Boolean = { true },
+  val action: (EditorScreenShortcutContext, EditorScreenShortcutActions) -> Boolean,
+)
+
+private val EditorScreenShortcutBindings =
+  listOf(
+    EditorScreenShortcutBinding(
+      key = Key.F,
+      modifiers = setOf(EditorScreenShortcutModifier.Mod),
+      enabled = ::isEditorScreenShortcutAvailable,
+      action = { _, actions ->
+        actions.openFindReplace()
+        true
+      },
+    ),
+    EditorScreenShortcutBinding(
+      key = Key.Escape,
+      enabled = ::isEditorScreenShortcutAvailable,
+      action = ::handleEscapeShortcut,
+    ),
+  )
+
+internal fun handleEditorScreenShortcut(
+  event: KeyEvent,
+  context: EditorScreenShortcutContext,
+  actions: EditorScreenShortcutActions,
+): Boolean {
+  val binding =
+    EditorScreenShortcutBindings.firstOrNull { binding ->
+      binding.enabled(context) &&
+        matchesEditorShortcut(
+          event = event,
+          platform = context.platform,
+          key = binding.key,
+          modifiers = binding.modifiers,
+        )
+    } ?: return false
+
+  return binding.action(context, actions)
+}
+
+@Composable
+internal fun Modifier.editorScreenShortcutFocusTarget(
+  active: Boolean,
+  enabled: Boolean,
+  editorFocused: Boolean,
+  selection: Selection?,
+  onPreviewKeyEvent: (KeyEvent) -> Boolean,
+): Modifier {
+  val focusRequester = remember { FocusRequester() }
+  var previousSelection by remember { mutableStateOf(selection) }
+  var fallbackFocusPending by remember { mutableStateOf(false) }
+
+  LaunchedEffect(active, enabled, editorFocused, selection) {
+    val selectionCleared = previousSelection != null && selection == null
+    previousSelection = selection
+
+    if (!active || !enabled || selection != null) {
+      fallbackFocusPending = false
+      return@LaunchedEffect
+    }
+
+    if (selectionCleared) {
+      fallbackFocusPending = true
+    }
+
+    if (fallbackFocusPending && !editorFocused) {
+      // After Escape clears the editor selection, no text input owns focus. Focus this non-text
+      // target on the next frame so a following Escape can close the active editor mode.
+      withFrameNanos {}
+      focusRequester.requestFocus()
+      fallbackFocusPending = false
+    }
+  }
+
+  return focusRequester(focusRequester)
+    .onPreviewKeyEvent(onPreviewKeyEvent)
+    .focusable(enabled = active && enabled)
+}
+
+internal fun matchesEditorShortcut(
+  event: KeyEvent,
+  platform: Platform,
+  key: Key,
+  modifiers: Set<EditorScreenShortcutModifier> = emptySet(),
+): Boolean {
+  if (event.type != KeyEventType.KeyDown) return false
+  if (event.key != key) return false
+
+  val modModifier = EditorScreenShortcutModifier.Mod in modifiers
+  val ctrlModifier = EditorScreenShortcutModifier.Ctrl in modifiers
+  val metaModifier = modModifier && platform != Platform.Android
+  val expectedCtrl = ctrlModifier || (modModifier && platform == Platform.Android)
+  val expectedMeta = metaModifier
+
+  return event.isShiftPressed == (EditorScreenShortcutModifier.Shift in modifiers) &&
+    event.isCtrlPressed == expectedCtrl &&
+    event.isMetaPressed == expectedMeta &&
+    event.isAltPressed == (EditorScreenShortcutModifier.Alt in modifiers)
+}
+
+private fun isEditorScreenShortcutAvailable(context: EditorScreenShortcutContext): Boolean =
+  context.sceneInForeground && !context.subPaneActive
+
+private fun handleEscapeShortcut(
+  context: EditorScreenShortcutContext,
+  actions: EditorScreenShortcutActions,
+): Boolean {
+  if (context.editorFocused) {
+    return false
+  }
+
+  when {
+    context.findReplaceActive -> actions.closeFindReplace()
+    context.spellcheckActive -> actions.closeSpellcheck()
+    context.aiFeedbackActive -> actions.closeAiFeedback()
+    else -> return false
+  }
+
+  return true
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceToolbar.kt
@@ -24,6 +24,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
@@ -32,6 +35,9 @@ import androidx.compose.ui.unit.dp
 import co.typie.ext.rememberTextInputState
 import co.typie.ext.textInputFocusable
 import co.typie.icons.Lucide
+import co.typie.platform.PlatformModule
+import co.typie.screen.editor.editor.EditorScreenShortcutModifier
+import co.typie.screen.editor.editor.matchesEditorShortcut
 import co.typie.screen.editor.editor.toolbar.EditorToolbarButton
 import co.typie.screen.editor.editor.toolbar.EditorToolbarSurfaceBackground
 import co.typie.screen.editor.editor.toolbar.ToolbarBorderWidth
@@ -59,6 +65,7 @@ internal fun FindReplaceToolbar(
   visibleState: MutableTransitionState<Boolean>,
   bottomInset: Dp,
   modifier: Modifier = Modifier,
+  onEscape: () -> Unit = {},
 ) {
   AnimatedVisibility(
     visibleState = visibleState,
@@ -97,7 +104,7 @@ internal fun FindReplaceToolbar(
               ),
           verticalAlignment = Alignment.CenterVertically,
         ) {
-          ReplaceTextField(session = session, modifier = Modifier.weight(1f))
+          ReplaceTextField(session = session, modifier = Modifier.weight(1f), onEscape = onEscape)
           Spacer(Modifier.width(ToolbarItemGap))
           EditorToolbarButton(
             icon = Lucide.Replace,
@@ -133,7 +140,11 @@ internal fun FindReplaceToolbar(
 }
 
 @Composable
-private fun ReplaceTextField(session: EditorFindReplaceSession, modifier: Modifier = Modifier) {
+private fun ReplaceTextField(
+  session: EditorFindReplaceSession,
+  modifier: Modifier = Modifier,
+  onEscape: () -> Unit = {},
+) {
   val inputState =
     rememberTextInputState(
       value = session.replaceText,
@@ -156,7 +167,8 @@ private fun ReplaceTextField(session: EditorFindReplaceSession, modifier: Modifi
         .clip(shape)
         .background(AppTheme.colors.surfaceInset, shape)
         .padding(horizontal = 10.dp)
-        .textInputFocusable(inputState),
+        .textInputFocusable(inputState)
+        .onPreviewKeyEvent { event -> handleReplaceInputShortcut(event, session, onEscape) },
     decorationBox = { innerTextField ->
       Box(contentAlignment = Alignment.CenterStart) {
         if (session.replaceText.isEmpty()) {
@@ -173,3 +185,29 @@ private fun ReplaceTextField(session: EditorFindReplaceSession, modifier: Modifi
     },
   )
 }
+
+private fun handleReplaceInputShortcut(
+  event: KeyEvent,
+  session: EditorFindReplaceSession,
+  onEscape: () -> Unit,
+): Boolean =
+  when {
+    matchesEditorShortcut(event = event, platform = PlatformModule.platform, key = Key.Escape) -> {
+      onEscape()
+      true
+    }
+    matchesEditorShortcut(
+      event = event,
+      platform = PlatformModule.platform,
+      key = Key.Enter,
+      modifiers = setOf(EditorScreenShortcutModifier.Mod),
+    ) -> {
+      session.replaceAll()
+      true
+    }
+    matchesEditorShortcut(event = event, platform = PlatformModule.platform, key = Key.Enter) -> {
+      session.replace()
+      true
+    }
+    else -> false
+  }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceTopBar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceTopBar.kt
@@ -20,6 +20,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.role
@@ -30,6 +33,9 @@ import androidx.compose.ui.unit.dp
 import co.typie.ext.rememberTextInputState
 import co.typie.ext.textInputFocusable
 import co.typie.icons.Lucide
+import co.typie.platform.PlatformModule
+import co.typie.screen.editor.editor.EditorScreenShortcutModifier
+import co.typie.screen.editor.editor.matchesEditorShortcut
 import co.typie.ui.component.Text
 import co.typie.ui.component.popover.PopoverMenu
 import co.typie.ui.component.topbar.TopBarButton
@@ -53,7 +59,7 @@ internal fun FindReplaceTopBarLeading(session: EditorFindReplaceSession) {
 }
 
 @Composable
-internal fun FindReplaceTopBarCenter(session: EditorFindReplaceSession) {
+internal fun FindReplaceTopBarCenter(session: EditorFindReplaceSession, onEscape: () -> Unit = {}) {
   val inputState =
     rememberTextInputState(
       value = session.findText,
@@ -94,7 +100,10 @@ internal fun FindReplaceTopBarCenter(session: EditorFindReplaceSession) {
       cursorBrush = SolidColor(AppTheme.colors.textDefault),
       keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
       keyboardActions = KeyboardActions(onSearch = { session.findNext() }),
-      modifier = Modifier.weight(1f).textInputFocusable(inputState),
+      modifier =
+        Modifier.weight(1f).textInputFocusable(inputState).onPreviewKeyEvent { event ->
+          handleFindInputShortcut(event, session, onEscape)
+        },
       decorationBox = { innerTextField ->
         Box(contentAlignment = Alignment.CenterStart) {
           if (session.findText.isEmpty()) {
@@ -114,6 +123,32 @@ internal fun FindReplaceTopBarCenter(session: EditorFindReplaceSession) {
     FindReplaceResultLabel(session = session)
   }
 }
+
+private fun handleFindInputShortcut(
+  event: KeyEvent,
+  session: EditorFindReplaceSession,
+  onEscape: () -> Unit,
+): Boolean =
+  when {
+    matchesEditorShortcut(event = event, platform = PlatformModule.platform, key = Key.Escape) -> {
+      onEscape()
+      true
+    }
+    matchesEditorShortcut(
+      event = event,
+      platform = PlatformModule.platform,
+      key = Key.Enter,
+      modifiers = setOf(EditorScreenShortcutModifier.Shift),
+    ) -> {
+      session.findPrevious()
+      true
+    }
+    matchesEditorShortcut(event = event, platform = PlatformModule.platform, key = Key.Enter) -> {
+      session.findNext()
+      true
+    }
+    else -> false
+  }
 
 @Composable
 internal fun FindReplaceTopBarTrailing(session: EditorFindReplaceSession) {


### PR DESCRIPTION
- 웹처럼 selection이 null이 될 때 에디터 blur
- ESC로 검색/맞춤법/AI 모드 종료
- mod-f로 검색
- 찾기 인풋에서 shift-enter로 이전 매치
- 바꾸기 인풋에서 mod-enter로 전부 바꾸기