### PR TITLE
탭 디버그 등

### DIFF
--- a/crates/editor-commands/src/commands/delete_selection.rs
+++ b/crates/editor-commands/src/commands/delete_selection.rs
@@ -541,6 +541,20 @@ mod tests {
     }
 
     #[test]
+    fn delete_text_after_tab_from_tab_boundary_selection() {
+        let (initial, ..) = state! {
+            doc { root { p1: paragraph { text("a") tab text("b") } } }
+            selection: (p1, 2, >) -> (p1, 3, <)
+        };
+        let (actual, ..) = transact!(initial, |tr| delete_selection(&mut tr));
+        let (expected, ..) = state! {
+            doc { root { p1: paragraph { text("a") tab } } }
+            selection: (p1, 2)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
     fn delete_image_and_full_text() {
         let (initial, ..) = state! {
             doc { r: root { image p1: paragraph { text("hello") } } }

--- a/crates/editor-commands/src/commands/delete_text_backward.rs
+++ b/crates/editor-commands/src/commands/delete_text_backward.rs
@@ -118,6 +118,23 @@ mod tests {
     }
 
     #[test]
+    fn delete_text_after_tab() {
+        let (initial, ..) = state! {
+            doc { root { p1: paragraph { text("a") tab text("b") } } }
+            selection: (p1, 3)
+        };
+        let (actual, ..) = transact!(initial, |tr| delete_text_backward(
+            &mut tr,
+            &Resource::new_test()
+        ));
+        let (expected, ..) = state! {
+            doc { root { p1: paragraph { text("a") tab } } }
+            selection: (p1, 2, <)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
     fn delete_at_start_of_text_returns_false() {
         let (initial, ..) = state! {
             doc { root { p1: paragraph { text("Hello") } } }

--- a/crates/editor-commands/src/commands/delete_text_forward.rs
+++ b/crates/editor-commands/src/commands/delete_text_forward.rs
@@ -113,6 +113,23 @@ mod tests {
     }
 
     #[test]
+    fn delete_text_after_tab() {
+        let (initial, ..) = state! {
+            doc { root { p1: paragraph { text("a") tab text("b") } } }
+            selection: (p1, 2)
+        };
+        let (actual, ..) = transact!(initial, |tr| delete_text_forward(
+            &mut tr,
+            &Resource::new_test()
+        ));
+        let (expected, ..) = state! {
+            doc { root { p1: paragraph { text("a") tab } } }
+            selection: (p1, 2)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
     fn delete_at_end_of_text_returns_false() {
         let (initial, ..) = state! {
             doc { root { p1: paragraph { text("Hello") } } }

--- a/crates/editor-commands/src/commands/merge_list_item_forward.rs
+++ b/crates/editor-commands/src/commands/merge_list_item_forward.rs
@@ -133,7 +133,7 @@ pub fn merge_list_item_forward(tr: &mut Transaction) -> CommandResult {
 
     tr.batch::<_, CommandError>(|tr| {
         if let Some(pb_offset) = trailing_page_break_offset {
-            tr.remove_text(next_block_id, pb_offset, 1)?;
+            tr.remove_child_slots(next_block_id, pb_offset, pb_offset + 1)?;
         }
         merge_element_cross_parent(tr, next_block_id, paragraph_id)?;
         let view = tr.view();

--- a/crates/editor-commands/src/commands/split_list_item.rs
+++ b/crates/editor-commands/src/commands/split_list_item.rs
@@ -3,8 +3,15 @@ use editor_model::{ChildView, Modifier, NodeType, Subtree};
 use editor_state::{Position, Selection};
 use editor_transaction::Transaction;
 
-use crate::helpers::{carryable_modifiers_at, find_enclosing_list_item_id};
+use crate::helpers::{
+    capture_atom_leaf_subtree_at, carryable_modifiers_at, find_enclosing_list_item_id,
+};
 use crate::{CommandError, CommandResult};
+
+enum TailSlot {
+    Char { ch: char, modifiers: Vec<Modifier> },
+    Atom { subtree: Subtree },
+}
 
 pub fn split_list_item(tr: &mut Transaction) -> CommandResult {
     let Some(selection) = tr.selection() else {
@@ -45,25 +52,28 @@ pub fn split_list_item(tr: &mut Transaction) -> CommandResult {
     let split_index = pos.offset;
     let para_len = paragraph.children().count();
 
-    // The leaves after the cursor cannot be reparented (move/split re-emit drops
-    // identity, and a list_item rejects a second paragraph), so capture their
-    // char + explicit (non-style) span modifiers and re-create them in the new
-    // item with the formatting intact.
-    let tail: Vec<(char, Vec<Modifier>)> = paragraph
-        .children()
-        .enumerate()
-        .skip(split_index)
-        .filter_map(|(slot, c)| match c {
-            ChildView::Leaf(l) => l.as_char().map(|ch| {
-                let mods: Vec<Modifier> = paragraph
-                    .leaf_state_at(slot)
-                    .map(|s| s.own.values().map(|o| o.value.clone()).collect())
-                    .unwrap_or_default();
-                (ch, mods)
-            }),
-            ChildView::Block(_) => None,
-        })
-        .collect();
+    // The inline slots after the cursor cannot be reparented (move/split re-emit
+    // drops identity, and a list_item rejects a second paragraph), so capture
+    // visible content plus leaf-owned formatting and re-create them in the new
+    // item's paragraph.
+    let mut tail: Vec<TailSlot> = Vec::new();
+    for (slot, c) in paragraph.children().enumerate().skip(split_index) {
+        match c {
+            ChildView::Leaf(l) => {
+                if let Some(ch) = l.as_char() {
+                    tail.push(TailSlot::Char {
+                        ch,
+                        modifiers: paragraph.leaf_own_modifiers_at(slot),
+                    });
+                } else if l.as_atom().is_some() {
+                    tail.push(TailSlot::Atom {
+                        subtree: capture_atom_leaf_subtree_at(&paragraph, slot)?,
+                    });
+                }
+            }
+            ChildView::Block(_) => {}
+        }
+    }
     let tail_len = para_len - split_index;
 
     let sublist_id: Option<Dot> = list_item
@@ -86,7 +96,7 @@ pub fn split_list_item(tr: &mut Transaction) -> CommandResult {
     drop(view);
 
     if tail_len > 0 {
-        tr.remove_text(paragraph_id, split_index, tail_len)?;
+        tr.remove_child_slots(paragraph_id, split_index, para_len)?;
     }
 
     let new_li = Subtree::leaf(NodeType::ListItem.into_node().to_plain()).with_children(vec![
@@ -125,28 +135,23 @@ pub fn split_list_item(tr: &mut Transaction) -> CommandResult {
         tr.move_node(*sublist, new_list_item_id, at)?;
     }
 
-    if !tail.is_empty() {
-        let text: String = tail.iter().map(|(ch, _)| *ch).collect();
-        tr.insert_text(new_paragraph_id, 0, &text)?;
-        let char_dots: Vec<_> = {
-            let view = tr.view();
-            view.node(new_paragraph_id)
-                .map(|p| {
-                    p.children()
-                        .filter_map(|c| match c {
-                            ChildView::Leaf(l) => l.as_char().map(|_| l.dot()),
-                            ChildView::Block(_) => None,
-                        })
-                        .collect()
-                })
-                .unwrap_or_default()
-        };
-        for (dot, (_, mods)) in char_dots.iter().zip(tail.iter()) {
-            for m in mods {
-                tr.add_span_modifier(*dot, *dot, m.clone())?;
+    let mut offset = 0usize;
+    let mut text = String::new();
+    let mut modifiers = Vec::new();
+    for slot in &tail {
+        match slot {
+            TailSlot::Char { ch, modifiers: m } => {
+                text.push(*ch);
+                modifiers.push(m.clone());
+            }
+            TailSlot::Atom { subtree } => {
+                flush_tail_text(tr, new_paragraph_id, &mut offset, &mut text, &mut modifiers)?;
+                tr.insert_subtree(new_paragraph_id, offset, subtree.clone())?;
+                offset += 1;
             }
         }
     }
+    flush_tail_text(tr, new_paragraph_id, &mut offset, &mut text, &mut modifiers)?;
 
     let marker = editor_model::Marker {
         modifiers: carryable,
@@ -161,6 +166,49 @@ pub fn split_list_item(tr: &mut Transaction) -> CommandResult {
     ))))?;
 
     Ok(true)
+}
+
+fn flush_tail_text(
+    tr: &mut Transaction,
+    paragraph_id: Dot,
+    offset: &mut usize,
+    text: &mut String,
+    modifiers: &mut Vec<Vec<Modifier>>,
+) -> Result<(), CommandError> {
+    if text.is_empty() {
+        return Ok(());
+    }
+    let start = *offset;
+    tr.insert_text(paragraph_id, start, text.as_str())?;
+    let char_dots: Vec<_> = {
+        let view = tr.view();
+        view.node(paragraph_id)
+            .map(|p| {
+                p.children()
+                    .skip(start)
+                    .take(modifiers.len())
+                    .filter_map(|c| match c {
+                        ChildView::Leaf(l) => l.as_char().map(|_| l.dot()),
+                        ChildView::Block(_) => None,
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    };
+    if char_dots.len() != modifiers.len() {
+        return Err(CommandError::Corrupted(
+            "inserted tail text dots missing".into(),
+        ));
+    }
+    for (dot, mods) in char_dots.iter().zip(modifiers.iter()) {
+        for m in mods {
+            tr.add_span_modifier(*dot, *dot, m.clone())?;
+        }
+    }
+    *offset += modifiers.len();
+    text.clear();
+    modifiers.clear();
+    Ok(())
 }
 
 #[cfg(test)]
@@ -246,6 +294,64 @@ mod tests {
                     bullet_list {
                         list_item { p1: paragraph { text("He") } }
                         list_item { p2: paragraph { text("llo") } }
+                    }
+                    paragraph {}
+                }
+            }
+            selection: (p2, 0)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn split_before_tab_preserves_tail_inline_atom() {
+        let (initial, _p1) = state! {
+            doc {
+                root {
+                    bullet_list {
+                        list_item { p1: paragraph { text("a") tab text("b") } }
+                    }
+                    paragraph {}
+                }
+            }
+            selection: (p1, 1)
+        };
+        let (actual, ..) = transact!(initial, |tr| split_list_item(&mut tr));
+        let (expected, _p1, _p2) = state! {
+            doc {
+                root {
+                    bullet_list {
+                        list_item { p1: paragraph { text("a") } }
+                        list_item { p2: paragraph { tab text("b") } }
+                    }
+                    paragraph {}
+                }
+            }
+            selection: (p2, 0)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn split_before_tab_preserves_tail_atom_modifiers() {
+        let (initial, _p1) = state! {
+            doc {
+                root {
+                    bullet_list {
+                        list_item { p1: paragraph { text("a") tab [font_size(2400)] text("b") } }
+                    }
+                    paragraph {}
+                }
+            }
+            selection: (p1, 1)
+        };
+        let (actual, ..) = transact!(initial, |tr| split_list_item(&mut tr));
+        let (expected, _p1, _p2) = state! {
+            doc {
+                root {
+                    bullet_list {
+                        list_item { p1: paragraph { text("a") } }
+                        list_item { p2: paragraph { tab [font_size(2400)] text("b") } }
                     }
                     paragraph {}
                 }

--- a/crates/editor-commands/src/commands/try_text_replacement.rs
+++ b/crates/editor-commands/src/commands/try_text_replacement.rs
@@ -5,8 +5,8 @@ use editor_resource::{CompiledPattern, Resource, TextReplacementRule};
 use editor_state::{Position, Selection};
 use editor_transaction::{HistoryMeta, Transaction};
 
-use crate::CommandResult;
 use crate::helpers::insert_hard_break_at_caret;
+use crate::{CommandError, CommandResult};
 
 pub fn try_text_replacement(tr: &mut Transaction, resource: &Resource) -> CommandResult {
     let rules = &resource.text_replacement_rules;
@@ -234,8 +234,11 @@ fn get_text_before_cursor(tr: &Transaction) -> Option<(Dot, String)> {
             ChildView::Leaf(l) => {
                 if let Some(ch) = l.as_char() {
                     text.push(ch);
-                } else if matches!(l.as_atom(), Some(AtomLeaf::HardBreak)) {
-                    text.push('\n');
+                } else {
+                    match l.as_atom() {
+                        Some(AtomLeaf::HardBreak) => text.push('\n'),
+                        _ => text.clear(),
+                    }
                 }
             }
             ChildView::Block(_) => {}
@@ -251,7 +254,26 @@ fn delete_one_backward(tr: &mut Transaction) -> CommandResult {
     if head.offset == 0 {
         return Ok(false);
     }
-    tr.remove_text(head.node, head.offset - 1, 1)?;
+    let remove_text = {
+        let view = tr.view();
+        let block = view
+            .node(head.node)
+            .ok_or(CommandError::NodeNotFound(head.node))?;
+        match block.child_at(head.offset - 1) {
+            Some(ChildView::Leaf(l)) if l.as_char().is_some() => true,
+            Some(ChildView::Leaf(l)) if matches!(l.as_atom(), Some(AtomLeaf::HardBreak)) => false,
+            _ => {
+                return Err(CommandError::Corrupted(
+                    "expected text replacement unit before cursor".into(),
+                ));
+            }
+        }
+    };
+    if remove_text {
+        tr.remove_text(head.node, head.offset - 1, 1)?;
+    } else {
+        tr.remove_child_slots(head.node, head.offset - 1, head.offset)?;
+    }
     tr.set_selection(Some(Selection::collapsed(Position::new(
         head.node,
         head.offset - 1,

--- a/crates/editor-commands/src/helpers/deletion.rs
+++ b/crates/editor-commands/src/helpers/deletion.rs
@@ -89,10 +89,10 @@ fn delete_child_slots(
                             }),
                         }
                         prev_char_idx = i;
-                    } else if let Some(atom) = l.as_atom() {
+                    } else if l.as_atom().is_some() {
                         slots.push(PlannedSlot::Subtree {
                             index: i,
-                            subtree: Subtree::leaf(atom.clone().into_node().to_plain()),
+                            subtree: capture_atom_leaf_subtree_at(&node, i)?,
                         });
                     }
                 }
@@ -170,9 +170,9 @@ fn text_subtree(text: String) -> Subtree {
     Subtree::leaf(PlainNode::Text(PlainTextNode { text }))
 }
 
-/// Snapshot of a projected block's subtree (block overlays + char/atom/block
-/// children), mirroring the substrate's capture so the removal step carries the
-/// data needed for its inverse. Char runs collapse into `Text` subtrees.
+/// Snapshot of a projected block's subtree, mirroring the substrate's capture so
+/// the removal step carries the data needed for its inverse. Char runs collapse
+/// into plain `Text` subtrees; atom leaves keep their own modifiers.
 fn capture_subtree(state: &State, block: Dot) -> Option<Subtree> {
     let view = state.view();
     let nv = view.node(block)?;
@@ -192,16 +192,16 @@ fn capture_subtree(state: &State, block: Dot) -> Option<Subtree> {
 
     let mut children: Vec<Subtree> = Vec::new();
     let mut pending = String::new();
-    for c in nv.children() {
+    for (slot, c) in nv.children().enumerate() {
         match c {
             ChildView::Leaf(l) => {
                 if let Some(ch) = l.as_char() {
                     pending.push(ch);
-                } else if let Some(atom) = l.as_atom() {
+                } else if l.as_atom().is_some() {
                     if !pending.is_empty() {
                         children.push(text_subtree(std::mem::take(&mut pending)));
                     }
-                    children.push(Subtree::leaf(atom.clone().into_node().to_plain()));
+                    children.push(capture_atom_leaf_subtree_at(&nv, slot).ok()?);
                 }
             }
             ChildView::Block(b) => {
@@ -226,6 +226,25 @@ fn capture_subtree(state: &State, block: Dot) -> Option<Subtree> {
     })
 }
 
+pub(crate) fn capture_atom_leaf_subtree_at(
+    node: &NodeView<'_>,
+    index: usize,
+) -> Result<Subtree, CommandError> {
+    let atom = match node.child_at(index) {
+        Some(ChildView::Leaf(l)) => l
+            .as_atom()
+            .ok_or_else(|| CommandError::Corrupted("expected atom leaf".into()))?
+            .clone(),
+        _ => return Err(CommandError::Corrupted("expected leaf at slot".into())),
+    };
+    Ok(Subtree {
+        node: atom.into_node().to_plain(),
+        modifiers: node.leaf_own_modifiers_at(index),
+        marker: None,
+        children: Vec::new(),
+    })
+}
+
 /// Remove a leaf atom (image/HR/tab/break) child at full-child `index`.
 /// The convenience `Transaction::remove_subtree` cannot address leaf atoms
 /// (it resolves index via `child_blocks()` and parent via the node map), so
@@ -240,14 +259,7 @@ pub(crate) fn remove_atom_leaf(
         let node = view
             .node(parent)
             .ok_or(CommandError::NodeNotFound(parent))?;
-        let atom = match node.child_at(index) {
-            Some(ChildView::Leaf(l)) => l
-                .as_atom()
-                .ok_or_else(|| CommandError::Corrupted("expected atom leaf".into()))?
-                .clone(),
-            _ => return Err(CommandError::Corrupted("expected leaf at slot".into())),
-        };
-        Subtree::leaf(atom.into_node().to_plain())
+        capture_atom_leaf_subtree_at(&node, index)?
     };
     tr.apply_steps(vec![Step::RemoveSubtree {
         parent,
@@ -286,21 +298,22 @@ pub(crate) fn remove_subtree_full(tr: &mut Transaction, child_id: Dot) -> Result
                 let leaf = view.leaf(dot).ok_or(CommandError::NodeNotFound(child_id))?;
                 let parent = leaf.parent().ok_or(CommandError::NoParent(child_id))?;
                 let parent_id = parent.id();
-                let (index, subtree) = parent
-                    .children()
-                    .enumerate()
-                    .find_map(|(i, c)| match &c {
-                        ChildView::Leaf(l) if l.dot() == dot => {
-                            let subtree = if let Some(ch) = l.as_char() {
-                                text_subtree(ch.to_string())
-                            } else {
-                                Subtree::leaf(l.as_atom()?.clone().into_node().to_plain())
-                            };
-                            Some((i, subtree))
-                        }
-                        _ => None,
-                    })
-                    .ok_or_else(|| CommandError::orphan_child(child_id, parent_id))?;
+                let mut found = None;
+                for (i, c) in parent.children().enumerate() {
+                    if let ChildView::Leaf(l) = &c
+                        && l.dot() == dot
+                    {
+                        let subtree = if let Some(ch) = l.as_char() {
+                            text_subtree(ch.to_string())
+                        } else {
+                            capture_atom_leaf_subtree_at(&parent, i)?
+                        };
+                        found = Some((i, subtree));
+                        break;
+                    }
+                }
+                let (index, subtree) =
+                    found.ok_or_else(|| CommandError::orphan_child(child_id, parent_id))?;
                 (parent_id, index, subtree)
             }
         }
@@ -1213,4 +1226,41 @@ fn fulfill_ancestors(tr: &mut Transaction, start_id: Dot, lca_id: Dot) -> Result
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use editor_macros::state;
+    use editor_model::{ChildView, Modifier};
+
+    #[test]
+    fn remove_subtree_full_captures_atom_leaf_modifiers() {
+        let (state, p1) = state! {
+            doc { root { p1: paragraph { tab [font_size(2400)] } } }
+            selection: (p1, 0)
+        };
+        let tab = {
+            let view = state.view();
+            let paragraph = view.node(p1).expect("paragraph exists");
+            match paragraph.child_at(0).expect("tab exists") {
+                ChildView::Leaf(leaf) => leaf.dot(),
+                ChildView::Block(_) => panic!("expected tab leaf"),
+            }
+        };
+
+        let mut tr = Transaction::new(&state);
+        remove_subtree_full(&mut tr, tab).unwrap();
+
+        let (_, steps, ..) = tr.commit();
+        let subtree = steps
+            .iter()
+            .find_map(|record| match &record.step {
+                Step::RemoveSubtree { subtree, .. } => Some(subtree),
+                _ => None,
+            })
+            .expect("tab deletion must record RemoveSubtree");
+
+        assert_eq!(subtree.modifiers, vec![Modifier::FontSize { value: 2400 }]);
+    }
 }

--- a/crates/editor-commands/src/helpers/modifiers.rs
+++ b/crates/editor-commands/src/helpers/modifiers.rs
@@ -16,8 +16,8 @@ pub(crate) fn resolve_effective_modifiers(
     apply_pending_delta(base_modifiers, pending_modifiers)
 }
 
-/// The own modifiers of the char leaf at direct child slot `slot`,
-/// read from its run segment; `None` if the slot doesn't hold a char leaf.
+/// Own modifiers of the char leaf at direct child slot `slot`; `None` if the slot
+/// doesn't hold a char leaf.
 fn char_leaf_own_values(node: &NodeView, slot: usize) -> Option<Vec<(ModifierType, Modifier)>> {
     let is_char = matches!(node.child_at(slot), Some(ChildView::Leaf(l)) if l.as_char().is_some());
     if !is_char {

--- a/crates/editor-core/src/handle/key.rs
+++ b/crates/editor-core/src/handle/key.rs
@@ -1226,6 +1226,36 @@ mod tests {
     }
 
     #[test]
+    fn backspace_after_text_following_tab_removes_text() {
+        let (state, ..) = state! {
+            doc { root { p1: paragraph { text("a") tab text("b") } } }
+            selection: (p1, 3)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.apply(key(Key::Backspace));
+        let (expected, ..) = state! {
+            doc { root { p1: paragraph { text("a") tab } } }
+            selection: (p1, 2, <)
+        };
+        assert_state_eq!(editor.state(), &expected);
+    }
+
+    #[test]
+    fn delete_before_text_following_tab_removes_text() {
+        let (state, ..) = state! {
+            doc { root { p1: paragraph { text("a") tab text("b") } } }
+            selection: (p1, 2)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.apply(key(Key::Delete));
+        let (expected, ..) = state! {
+            doc { root { p1: paragraph { text("a") tab } } }
+            selection: (p1, 2)
+        };
+        assert_state_eq!(editor.state(), &expected);
+    }
+
+    #[test]
     fn backspace_at_between_monolithic_gap_selects_prev_monolithic() {
         let (state, ..) = state! {
             doc { r: root {

--- a/crates/editor-core/src/handle/text_input.rs
+++ b/crates/editor-core/src/handle/text_input.rs
@@ -1339,6 +1339,66 @@ mod tests {
     }
 
     #[test]
+    fn delete_surrounding_backward_deletes_text_after_tab() {
+        let (state, ..) = state! {
+            doc { root { p1: paragraph { text("a") tab text("b") } } }
+            selection: (p1, 3)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.apply(Message::TextInput {
+            ops: vec![FlatImeOp::DeleteSurrounding {
+                before: 1,
+                after: 0,
+            }],
+        });
+        let (expected, ..) = state! {
+            doc { root { p1: paragraph { text("a") tab } } }
+            selection: (p1, 2)
+        };
+        assert_state_eq!(editor.state(), &expected);
+    }
+
+    #[test]
+    fn delete_surrounding_forward_deletes_text_after_tab() {
+        let (state, ..) = state! {
+            doc { root { p1: paragraph { text("a") tab text("b") } } }
+            selection: (p1, 2)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.apply(Message::TextInput {
+            ops: vec![FlatImeOp::DeleteSurrounding {
+                before: 0,
+                after: 1,
+            }],
+        });
+        let (expected, ..) = state! {
+            doc { root { p1: paragraph { text("a") tab } } }
+            selection: (p1, 2)
+        };
+        assert_state_eq!(editor.state(), &expected);
+    }
+
+    #[test]
+    fn replace_selection_empty_deletes_text_after_tab() {
+        let (state, ..) = state! {
+            doc { root { p1: paragraph { text("a") tab text("b") } } }
+            selection: (p1, 3)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.apply(Message::TextInput {
+            ops: vec![
+                FlatImeOp::SetSelection { start: 3, end: 4 },
+                FlatImeOp::ReplaceSelection { text: "".into() },
+            ],
+        });
+        let (expected, ..) = state! {
+            doc { root { p1: paragraph { text("a") tab } } }
+            selection: (p1, 2)
+        };
+        assert_state_eq!(editor.state(), &expected);
+    }
+
+    #[test]
     fn update_with_composition_replaces_region() {
         let (state, ..) = state! {
             doc { root { p1: paragraph { text("hello") } } }

--- a/crates/editor-core/src/text_replacement_tests.rs
+++ b/crates/editor-core/src/text_replacement_tests.rs
@@ -185,6 +185,40 @@ fn multiline_pattern_matches_across_hard_break() {
 }
 
 #[test]
+fn pattern_does_not_match_across_tab_atom() {
+    let (s, ..) = state! {
+        doc {
+            root {
+                p1: paragraph {
+                    text("a")
+                    tab
+                    text("b")
+                }
+            }
+        }
+        selection: (p1, 3)
+    };
+    let mut editor = Editor::new_test(s);
+    set_rules(&editor, vec![rule("abz", "X", false)]);
+
+    type_text(&mut editor, "z");
+
+    let (expected, ..) = state! {
+        doc {
+            root {
+                p1: paragraph {
+                    text("a")
+                    tab
+                    text("bz")
+                }
+            }
+        }
+        selection: (p1, 4)
+    };
+    assert_state_eq!(editor.state(), &expected);
+}
+
+#[test]
 fn backspace_immediately_after_replacement_restores_original() {
     let (s, ..) = state! {
         doc { root { p1: paragraph { text("") } } }

--- a/crates/editor-model/src/view/mod.rs
+++ b/crates/editor-model/src/view/mod.rs
@@ -112,6 +112,11 @@ impl<'a> DocView<'a> {
             .position(|c| matches!(c, Child::Leaf { id, .. } if *id == dot))?;
         self.node(block)?.leaf_state_at(slot)
     }
+    pub fn leaf_own_modifiers_by_dot_slow(&'a self, dot: Dot) -> Vec<Modifier> {
+        self.leaf_state_by_dot_slow(dot)
+            .map(|s| s.own_modifiers())
+            .unwrap_or_default()
+    }
 }
 
 impl<'a> NodeView<'a> {
@@ -284,6 +289,12 @@ pub struct LeafStateRef<'a> {
     pub own: &'a BTreeMap<ModifierType, OwnModifier>,
 }
 
+impl LeafStateRef<'_> {
+    pub fn own_modifiers(&self) -> Vec<Modifier> {
+        self.own.values().map(|o| o.value.clone()).collect()
+    }
+}
+
 impl<'a> NodeView<'a> {
     pub fn effective(&self) -> &'a BTreeMap<ModifierType, Modifier> {
         self.view
@@ -344,6 +355,11 @@ impl<'a> NodeView<'a> {
             eff: seg.eff.as_ref(),
             own: seg.own.as_ref(),
         })
+    }
+    pub fn leaf_own_modifiers_at(&self, child_slot: usize) -> Vec<Modifier> {
+        self.leaf_state_at(child_slot)
+            .map(|s| s.own_modifiers())
+            .unwrap_or_default()
     }
     pub fn inline(&self) -> Vec<InlineItem<'a>> {
         let doc = self.view.doc;

--- a/crates/editor-transaction/src/error.rs
+++ b/crates/editor-transaction/src/error.rs
@@ -21,6 +21,25 @@ pub enum StepError {
         len: usize,
     },
 
+    #[error("invalid child range [{from}, {to}) for node {parent:?}")]
+    InvalidChildRange { parent: Dot, from: usize, to: usize },
+
+    #[error("invalid child slot {index} for node {parent:?}")]
+    InvalidChildSlot { parent: Dot, index: usize },
+
+    #[error("expected text char at offset {offset} for node {block:?}")]
+    ExpectedText { block: Dot, offset: usize },
+
+    #[error(
+        "text mismatch at offset {offset} for node {block:?}: expected {expected:?}, found {actual:?}"
+    )]
+    TextMismatch {
+        block: Dot,
+        offset: usize,
+        expected: char,
+        actual: char,
+    },
+
     #[error("pending modifier {modifier_type:?} is not applicable to Text and cannot be staged")]
     InvalidPendingModifier { modifier_type: ModifierType },
 

--- a/crates/editor-transaction/src/revert.rs
+++ b/crates/editor-transaction/src/revert.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use editor_crdt::Dot;
-use editor_model::Modifier;
+use editor_model::{ChildView, Modifier, NodeView, PlainNode, Subtree};
 use editor_state::State;
 
 use crate::steps::support;
@@ -29,7 +29,7 @@ fn reconcile_node(tr: &mut Transaction, target: &State, id: Dot) -> Result<(), S
     reconcile_attrs(tr, target, id)?;
     reconcile_modifiers(tr, target, id)?;
     reconcile_node_marker(tr, target, id)?;
-    reconcile_text(tr, target, id)?;
+    reconcile_inline_children(tr, target, id)?;
     reconcile_children(tr, target, id)?;
     Ok(())
 }
@@ -122,41 +122,162 @@ fn reconcile_modifiers(tr: &mut Transaction, target: &State, id: Dot) -> Result<
     Ok(())
 }
 
-fn reconcile_text(tr: &mut Transaction, target: &State, id: Dot) -> Result<(), StepError> {
-    let (Some(cur), tgt) = (
-        tr.view().node(id).map(|n| n.inline_text()),
-        target.view().node(id).map(|n| n.inline_text()),
-    ) else {
-        return Ok(());
-    };
-    let Some(tgt) = tgt else {
-        return Ok(());
-    };
-    if cur == tgt {
-        return Ok(());
-    }
-    let cur_chars: Vec<char> = cur.chars().collect();
-    let tgt_chars: Vec<char> = tgt.chars().collect();
+#[derive(Clone, Debug, PartialEq)]
+enum InlineLeafToken {
+    Char(char),
+    Atom {
+        node: PlainNode,
+        modifiers: Vec<Modifier>,
+    },
+}
 
-    let mut p = 0;
-    while p < cur_chars.len() && p < tgt_chars.len() && cur_chars[p] == tgt_chars[p] {
-        p += 1;
+#[derive(Clone, Debug)]
+struct InlineLeafUnit {
+    slot: usize,
+    token: InlineLeafToken,
+}
+
+fn inline_leaf_units(node: &NodeView<'_>) -> Vec<InlineLeafUnit> {
+    let mut units = Vec::new();
+    for (slot, child) in node.children().enumerate() {
+        let ChildView::Leaf(leaf) = child else {
+            continue;
+        };
+        if let Some(ch) = leaf.as_char() {
+            units.push(InlineLeafUnit {
+                slot,
+                token: InlineLeafToken::Char(ch),
+            });
+        } else if let Some(atom) = leaf.as_atom() {
+            let atom_node = atom.clone().into_node().to_plain();
+            let modifiers = node.leaf_own_modifiers_at(slot);
+            units.push(InlineLeafUnit {
+                slot,
+                token: InlineLeafToken::Atom {
+                    node: atom_node,
+                    modifiers,
+                },
+            });
+        }
     }
-    let mut s = 0;
-    while s < (cur_chars.len() - p)
-        && s < (tgt_chars.len() - p)
-        && cur_chars[cur_chars.len() - 1 - s] == tgt_chars[tgt_chars.len() - 1 - s]
+    units
+}
+
+fn remove_inline_leaf_units(
+    tr: &mut Transaction,
+    id: Dot,
+    units: &[InlineLeafUnit],
+) -> Result<(), StepError> {
+    let mut ranges: Vec<(usize, usize)> = Vec::new();
+    for unit in units {
+        match ranges.last_mut() {
+            Some((_, end)) if *end == unit.slot => *end = unit.slot + 1,
+            _ => ranges.push((unit.slot, unit.slot + 1)),
+        }
+    }
+
+    for (from, to) in ranges.into_iter().rev() {
+        tr.remove_child_slots(id, from, to)?;
+    }
+    Ok(())
+}
+
+fn flush_insert_text(
+    tr: &mut Transaction,
+    id: Dot,
+    start: &mut Option<usize>,
+    text: &mut String,
+) -> Result<(), StepError> {
+    if let Some(offset) = start.take()
+        && !text.is_empty()
     {
-        s += 1;
+        tr.insert_text(id, offset, text)?;
+        text.clear();
     }
-    let remove_len = cur_chars.len() - s - p;
-    if remove_len > 0 {
-        tr.remove_text(id, p, remove_len)?;
+    Ok(())
+}
+
+fn insert_inline_leaf_units(
+    tr: &mut Transaction,
+    id: Dot,
+    units: &[InlineLeafUnit],
+) -> Result<(), StepError> {
+    let mut text_start = None;
+    let mut next_text_slot = 0;
+    let mut text = String::new();
+
+    for unit in units {
+        match &unit.token {
+            InlineLeafToken::Char(ch) => {
+                if text_start.is_none() || next_text_slot != unit.slot {
+                    flush_insert_text(tr, id, &mut text_start, &mut text)?;
+                    text_start = Some(unit.slot);
+                }
+                text.push(*ch);
+                next_text_slot = unit.slot + 1;
+            }
+            InlineLeafToken::Atom { node, modifiers } => {
+                flush_insert_text(tr, id, &mut text_start, &mut text)?;
+                tr.insert_subtree(
+                    id,
+                    unit.slot,
+                    Subtree {
+                        node: node.clone(),
+                        modifiers: modifiers.clone(),
+                        marker: None,
+                        children: Vec::new(),
+                    },
+                )?;
+                next_text_slot = unit.slot + 1;
+            }
+        }
     }
-    let insert: String = tgt_chars[p..tgt_chars.len() - s].iter().collect();
-    if !insert.is_empty() {
-        tr.insert_text(id, p, &insert)?;
+    flush_insert_text(tr, id, &mut text_start, &mut text)?;
+    Ok(())
+}
+
+fn reconcile_inline_children(
+    tr: &mut Transaction,
+    target: &State,
+    id: Dot,
+) -> Result<(), StepError> {
+    let (cur_units, tgt_units) = {
+        let cur_view = tr.view();
+        let Some(cur_node) = cur_view.node(id) else {
+            return Ok(());
+        };
+        let target_view = target.view();
+        let Some(tgt_node) = target_view.node(id) else {
+            return Ok(());
+        };
+        (inline_leaf_units(&cur_node), inline_leaf_units(&tgt_node))
+    };
+
+    let mut prefix = 0;
+    while prefix < cur_units.len()
+        && prefix < tgt_units.len()
+        && cur_units[prefix].token == tgt_units[prefix].token
+    {
+        prefix += 1;
     }
+
+    let mut suffix = 0;
+    while suffix < (cur_units.len() - prefix)
+        && suffix < (tgt_units.len() - prefix)
+        && cur_units[cur_units.len() - 1 - suffix].token
+            == tgt_units[tgt_units.len() - 1 - suffix].token
+    {
+        suffix += 1;
+    }
+
+    let cur_end = cur_units.len() - suffix;
+    let tgt_end = tgt_units.len() - suffix;
+    if prefix == cur_end && prefix == tgt_end {
+        return Ok(());
+    }
+
+    remove_inline_leaf_units(tr, id, &cur_units[prefix..cur_end])?;
+    insert_inline_leaf_units(tr, id, &tgt_units[prefix..tgt_end])?;
     Ok(())
 }
 
@@ -197,6 +318,7 @@ mod tests {
         CalloutVariant, ModifierType, Node, NodeType, NodeView, PlainCalloutNode, PlainNode,
         PlainParagraphNode, Subtree,
     };
+    use editor_state::assert_state_eq;
 
     fn snapshot(state: &State) -> Vec<(usize, NodeType, String)> {
         fn walk(nv: &NodeView, depth: usize, out: &mut Vec<(usize, NodeType, String)>) {
@@ -256,6 +378,110 @@ mod tests {
             reverted.view().node(p1).unwrap().inline_text(),
             "hello world"
         );
+    }
+
+    #[test]
+    fn reverts_text_change_after_tab() {
+        let (target, p1) = state! {
+            doc { root { p1: paragraph { text("a") tab text("b") } } }
+            selection: (p1, 0)
+        };
+        let mut pre = Transaction::new(&target);
+        pre.remove_text(p1, 2, 1).unwrap();
+        pre.insert_text(p1, 2, "c").unwrap();
+        let (changed, ..) = pre.commit();
+
+        let tr = build_revert_transaction(&changed, &target).unwrap();
+        let (reverted, ..) = tr.commit();
+
+        assert_state_eq!(&reverted, &target);
+    }
+
+    #[test]
+    fn reverts_text_change_after_hard_break() {
+        let (target, p1) = state! {
+            doc { root { p1: paragraph { text("a") hard_break text("b") } } }
+            selection: (p1, 0)
+        };
+        let mut pre = Transaction::new(&target);
+        pre.remove_text(p1, 2, 1).unwrap();
+        pre.insert_text(p1, 2, "c").unwrap();
+        let (changed, ..) = pre.commit();
+
+        let tr = build_revert_transaction(&changed, &target).unwrap();
+        let (reverted, ..) = tr.commit();
+
+        assert_state_eq!(&reverted, &target);
+    }
+
+    #[test]
+    fn reverts_inserted_tab() {
+        let (target, p1) = state! {
+            doc { root { p1: paragraph { text("ab") } } }
+            selection: (p1, 0)
+        };
+        let mut pre = Transaction::new(&target);
+        pre.insert_subtree(p1, 1, Subtree::leaf(PlainNode::Tab(Default::default())))
+            .unwrap();
+        let (changed, ..) = pre.commit();
+
+        let tr = build_revert_transaction(&changed, &target).unwrap();
+        let (reverted, ..) = tr.commit();
+
+        assert_state_eq!(&reverted, &target);
+    }
+
+    #[test]
+    fn reverts_deleted_tab() {
+        let (target, p1) = state! {
+            doc { root { p1: paragraph { text("a") tab text("b") } } }
+            selection: (p1, 0)
+        };
+        let mut pre = Transaction::new(&target);
+        pre.remove_child_slots(p1, 1, 2).unwrap();
+        let (changed, ..) = pre.commit();
+
+        let tr = build_revert_transaction(&changed, &target).unwrap();
+        let (reverted, ..) = tr.commit();
+
+        assert_state_eq!(&reverted, &target);
+    }
+
+    #[test]
+    fn reverts_inserted_hard_break() {
+        let (target, p1) = state! {
+            doc { root { p1: paragraph { text("ab") } } }
+            selection: (p1, 0)
+        };
+        let mut pre = Transaction::new(&target);
+        pre.insert_subtree(
+            p1,
+            1,
+            Subtree::leaf(PlainNode::HardBreak(Default::default())),
+        )
+        .unwrap();
+        let (changed, ..) = pre.commit();
+
+        let tr = build_revert_transaction(&changed, &target).unwrap();
+        let (reverted, ..) = tr.commit();
+
+        assert_state_eq!(&reverted, &target);
+    }
+
+    #[test]
+    fn reverts_deleted_hard_break() {
+        let (target, p1) = state! {
+            doc { root { p1: paragraph { text("a") hard_break text("b") } } }
+            selection: (p1, 0)
+        };
+        let mut pre = Transaction::new(&target);
+        pre.remove_child_slots(p1, 1, 2).unwrap();
+        let (changed, ..) = pre.commit();
+
+        let tr = build_revert_transaction(&changed, &target).unwrap();
+        let (reverted, ..) = tr.commit();
+
+        assert_state_eq!(&reverted, &target);
     }
 
     #[test]

--- a/crates/editor-transaction/src/steps/remove_text.rs
+++ b/crates/editor-transaction/src/steps/remove_text.rs
@@ -18,8 +18,7 @@ pub(crate) fn apply_to(
     offset: usize,
     text: &str,
 ) -> Result<(), StepError> {
-    let len = text.chars().count();
-    let dots = support::leaf_dots_in_range(&batched.projected, block, offset, len)?;
+    let dots = support::char_leaf_dots_for_text(&batched.projected, block, offset, text)?;
     let ops = support::delete_dots_ops(&batched.projected, &dots);
     for op in ops {
         batched.apply(op)?;

--- a/crates/editor-transaction/src/steps/support.rs
+++ b/crates/editor-transaction/src/steps/support.rs
@@ -7,7 +7,7 @@ use editor_model::{
 };
 use editor_state::{BatchedState, ProjectedState};
 
-use crate::StepError;
+use crate::{Step, StepError};
 
 pub(crate) fn block_node_type(ps: &ProjectedState, block: Dot) -> Option<NodeType> {
     ps.block_node_type(block)
@@ -149,30 +149,41 @@ pub(crate) fn insert_text_ops(
     Ok(ops)
 }
 
-pub(crate) fn leaf_dots_in_range(
+pub(crate) fn char_leaf_dots_for_text(
     ps: &ProjectedState,
     block: Dot,
     offset: usize,
-    len: usize,
+    text: &str,
 ) -> Result<Vec<Dot>, StepError> {
     let children = ps
         .block_children(block)
         .ok_or(StepError::NodeNotFound(block))?;
-    let mut dots = Vec::with_capacity(len);
-    for i in 0..len {
+    let mut dots = Vec::with_capacity(text.chars().count());
+    for (i, expected) in text.chars().enumerate() {
         let idx = offset + i;
         let child = children.get(idx).ok_or(StepError::OffsetOutOfBounds {
             block,
             offset: idx,
             len: children.len(),
         })?;
-        let dot = match child {
-            Child::Leaf { id, .. } => *id,
-            Child::Block(d) => {
-                editor_model::anchor_dot(*d).ok_or(StepError::NodeNotFound(block))?
+        match child {
+            Child::Leaf {
+                id,
+                item: SeqItem::Char(actual),
+            } if *actual == expected => dots.push(*id),
+            Child::Leaf {
+                item: SeqItem::Char(actual),
+                ..
+            } => {
+                return Err(StepError::TextMismatch {
+                    block,
+                    offset: idx,
+                    expected,
+                    actual: *actual,
+                });
             }
-        };
-        dots.push(dot);
+            _ => return Err(StepError::ExpectedText { block, offset: idx }),
+        }
     }
     Ok(dots)
 }
@@ -203,22 +214,132 @@ pub(crate) fn delete_dots_ops(ps: &ProjectedState, dots: &[Dot]) -> Vec<EditOp> 
     ops
 }
 
-pub(crate) fn read_text(ps: &ProjectedState, block: Dot, offset: usize, len: usize) -> String {
-    let Some(children) = ps.block_children(block) else {
-        return String::new();
-    };
-    children
-        .iter()
-        .filter_map(|c| match c {
+pub(crate) fn read_text(
+    ps: &ProjectedState,
+    block: Dot,
+    offset: usize,
+    len: usize,
+) -> Result<String, StepError> {
+    let children = ps
+        .block_children(block)
+        .ok_or(StepError::NodeNotFound(block))?;
+    if offset > children.len() {
+        return Err(StepError::OffsetOutOfBounds {
+            block,
+            offset,
+            len: children.len(),
+        });
+    }
+    let mut text = String::new();
+    for i in 0..len {
+        let idx = offset + i;
+        let child = children.get(idx).ok_or(StepError::OffsetOutOfBounds {
+            block,
+            offset: idx,
+            len: children.len(),
+        })?;
+        match child {
             Child::Leaf {
                 item: SeqItem::Char(ch),
                 ..
-            } => Some(*ch),
-            _ => None,
-        })
-        .skip(offset)
-        .take(len)
-        .collect()
+            } => text.push(*ch),
+            _ => return Err(StepError::ExpectedText { block, offset: idx }),
+        }
+    }
+    Ok(text)
+}
+
+pub(crate) fn remove_child_slots_steps(
+    ps: &ProjectedState,
+    parent: Dot,
+    from: usize,
+    to: usize,
+) -> Result<Vec<Step>, StepError> {
+    let children = ps
+        .block_children(parent)
+        .ok_or(StepError::NodeNotFound(parent))?;
+    if from > to {
+        return Err(StepError::InvalidChildRange { parent, from, to });
+    }
+    if from > children.len() {
+        return Err(StepError::IndexOutOfBounds {
+            parent,
+            index: from,
+            len: children.len(),
+        });
+    }
+    if to > children.len() {
+        return Err(StepError::IndexOutOfBounds {
+            parent,
+            index: to,
+            len: children.len(),
+        });
+    }
+    if to <= from {
+        return Ok(Vec::new());
+    }
+
+    let mut steps = Vec::new();
+    let mut text_offset = None;
+    let mut text = String::new();
+
+    for (idx, child) in children.iter().enumerate().skip(from).take(to - from) {
+        match child {
+            Child::Leaf {
+                item: SeqItem::Char(ch),
+                ..
+            } => {
+                if text_offset.is_none() {
+                    text_offset = Some(idx);
+                }
+                text.push(*ch);
+            }
+            Child::Leaf { id, item } => {
+                flush_remove_text_step(&mut steps, parent, &mut text_offset, &mut text);
+                let atom = match item {
+                    SeqItem::Atom(atom) => atom,
+                    SeqItem::BlockAtom { leaf, .. } => leaf,
+                    SeqItem::Char(_) | SeqItem::Block { .. } => {
+                        return Err(StepError::InvalidChildSlot { parent, index: idx });
+                    }
+                };
+                steps.push(Step::RemoveSubtree {
+                    parent,
+                    index: idx,
+                    subtree: atom_leaf_subtree(ps, *id, atom.clone()),
+                });
+            }
+            Child::Block(block) => {
+                flush_remove_text_step(&mut steps, parent, &mut text_offset, &mut text);
+                let subtree = capture_subtree(ps, *block).ok_or(StepError::NodeNotFound(*block))?;
+                steps.push(Step::RemoveSubtree {
+                    parent,
+                    index: idx,
+                    subtree,
+                });
+            }
+        }
+    }
+    flush_remove_text_step(&mut steps, parent, &mut text_offset, &mut text);
+    steps.reverse();
+    Ok(steps)
+}
+
+fn flush_remove_text_step(
+    steps: &mut Vec<Step>,
+    block: Dot,
+    offset: &mut Option<usize>,
+    text: &mut String,
+) {
+    if let Some(offset) = offset.take()
+        && !text.is_empty()
+    {
+        steps.push(Step::RemoveText {
+            block,
+            offset,
+            text: std::mem::take(text),
+        });
+    }
 }
 
 pub(crate) fn span_add(first: Dot, last: Dot, modifier: Modifier) -> EditOp {
@@ -278,9 +399,10 @@ pub(crate) fn node_marker_set(target: Dot, value: Option<Marker>) -> EditOp {
     })
 }
 
-/// Builds a `Subtree` snapshot of the projected block at `block`. Char/atom
-/// leaves are grouped into `Text` subtrees (per-char span styling is dropped —
-/// the M1 move/subtree path is structural). Nested blocks recurse.
+/// Builds a `Subtree` snapshot of the projected block at `block`. Char leaves
+/// are grouped into plain `Text` subtrees (per-char span styling is dropped —
+/// the M1 move/subtree path is structural). Atom leaves keep their own
+/// modifiers. Nested blocks recurse.
 pub fn capture_subtree(ps: &ProjectedState, block: Dot) -> Option<Subtree> {
     let node = ps.block_node(block)?.to_plain();
     let dot = editor_model::anchor_dot(block);
@@ -299,13 +421,19 @@ pub fn capture_subtree(ps: &ProjectedState, block: Dot) -> Option<Subtree> {
     let mut pending_text = String::new();
     for c in ps.block_children(block)? {
         match c {
-            Child::Leaf { item, .. } => match item {
+            Child::Leaf { id, item } => match item {
                 SeqItem::Char(ch) => pending_text.push(ch),
                 SeqItem::Atom(atom) => {
                     if !pending_text.is_empty() {
                         children.push(text_subtree(std::mem::take(&mut pending_text)));
                     }
-                    children.push(Subtree::leaf(atom.into_node().to_plain()));
+                    children.push(atom_leaf_subtree(ps, id, atom));
+                }
+                SeqItem::BlockAtom { leaf, .. } => {
+                    if !pending_text.is_empty() {
+                        children.push(text_subtree(std::mem::take(&mut pending_text)));
+                    }
+                    children.push(atom_leaf_subtree(ps, id, leaf));
                 }
                 _ => {}
             },
@@ -333,6 +461,15 @@ pub fn capture_subtree(ps: &ProjectedState, block: Dot) -> Option<Subtree> {
 
 fn text_subtree(text: String) -> Subtree {
     Subtree::leaf(PlainNode::Text(PlainTextNode { text }))
+}
+
+fn atom_leaf_subtree(ps: &ProjectedState, dot: Dot, atom: AtomLeaf) -> Subtree {
+    Subtree {
+        node: atom.into_node().to_plain(),
+        modifiers: ps.view().leaf_own_modifiers_by_dot_slow(dot),
+        marker: None,
+        children: Vec::new(),
+    }
 }
 
 /// Emits a captured/described subtree into the working state starting at

--- a/crates/editor-transaction/src/transaction.rs
+++ b/crates/editor-transaction/src/transaction.rs
@@ -119,13 +119,29 @@ impl Transaction {
         })
     }
 
+    /// Removes a contiguous run of text chars addressed by child-slot offset.
+    /// Every slot in the range must be a `Char`; inline atoms belong to
+    /// `remove_child_slots`.
     pub fn remove_text(&mut self, block: Dot, offset: usize, len: usize) -> Result<(), StepError> {
-        let text = support::read_text(&self.state.projected, block, offset, len);
+        let text = support::read_text(&self.state.projected, block, offset, len)?;
         self.apply_step(Step::RemoveText {
             block,
             offset,
             text,
         })
+    }
+
+    /// Removes direct child slots `[from, to)`, lowering char runs to
+    /// `RemoveText` and atom/block slots to `RemoveSubtree`.
+    pub fn remove_child_slots(
+        &mut self,
+        parent: Dot,
+        from: usize,
+        to: usize,
+    ) -> Result<(), StepError> {
+        let steps = support::remove_child_slots_steps(&self.state.projected, parent, from, to)?;
+        self.apply_steps(steps)?;
+        Ok(())
     }
 
     pub fn insert_subtree(
@@ -472,6 +488,127 @@ mod tests {
             Step::RemoveText { text, .. } => assert_eq!(text, " World"),
             _ => panic!("expected RemoveText"),
         }
+    }
+
+    #[test]
+    fn remove_text_after_atom_derives_content_from_child_slots() {
+        let (state, p1) = state! {
+            doc { root { p1: paragraph { text("a") tab text("b") } } }
+            selection: (p1, 0)
+        };
+        let mut tr = Transaction::new(&state);
+        tr.remove_text(p1, 2, 1).unwrap();
+        assert_eq!(block_text(tr.state(), &p1), "a");
+        let (_, steps, _, _, _) = tr.commit();
+        match &steps[0].step {
+            Step::RemoveText { text, .. } => assert_eq!(text, "b"),
+            _ => panic!("expected RemoveText"),
+        }
+    }
+
+    #[test]
+    fn remove_text_rejects_range_containing_atom() {
+        let (state, p1) = state! {
+            doc { root { p1: paragraph { text("a") tab text("b") } } }
+            selection: (p1, 0)
+        };
+        let mut tr = Transaction::new(&state);
+        let result = tr.remove_text(p1, 1, 2);
+        assert!(matches!(
+            result,
+            Err(StepError::ExpectedText {
+                block,
+                offset: 1,
+            }) if block == p1
+        ));
+        assert_eq!(block_text(tr.state(), &p1), "ab");
+    }
+
+    #[test]
+    fn remove_text_step_rejects_atom_slot() {
+        let (state, p1) = state! {
+            doc { root { p1: paragraph { text("a") tab text("b") } } }
+            selection: (p1, 0)
+        };
+        let result = Step::RemoveText {
+            block: p1,
+            offset: 1,
+            text: "b".into(),
+        }
+        .apply(&state);
+        assert!(matches!(
+            result,
+            Err(StepError::ExpectedText {
+                block,
+                offset: 1,
+            }) if block == p1
+        ));
+    }
+
+    #[test]
+    fn remove_text_step_rejects_text_mismatch() {
+        let (state, p1) = state! {
+            doc { root { p1: paragraph { text("a") } } }
+            selection: (p1, 0)
+        };
+        let result = Step::RemoveText {
+            block: p1,
+            offset: 0,
+            text: "x".into(),
+        }
+        .apply(&state);
+        assert!(matches!(
+            result,
+            Err(StepError::TextMismatch {
+                block,
+                offset: 0,
+                expected: 'x',
+                actual: 'a',
+            }) if block == p1
+        ));
+    }
+
+    #[test]
+    fn remove_child_slots_deletes_mixed_inline_range() {
+        let (state, p1) = state! {
+            doc { root { p1: paragraph { text("a") tab text("b") } } }
+            selection: (p1, 0)
+        };
+        let mut tr = Transaction::new(&state);
+        tr.remove_child_slots(p1, 1, 3).unwrap();
+        assert_eq!(block_text(tr.state(), &p1), "a");
+        let (_, steps, _, _, _) = tr.commit();
+        assert_eq!(steps.len(), 2);
+        assert!(steps.iter().any(|r| matches!(
+            &r.step,
+            Step::RemoveText { offset: 2, text, .. } if text == "b"
+        )));
+        assert!(
+            steps
+                .iter()
+                .any(|r| matches!(&r.step, Step::RemoveSubtree { index: 1, .. }))
+        );
+    }
+
+    #[test]
+    fn remove_child_slots_captures_atom_leaf_modifiers() {
+        let (state, p1) = state! {
+            doc { root { p1: paragraph { text("a") tab [font_size(2400)] } } }
+            selection: (p1, 0)
+        };
+        let mut tr = Transaction::new(&state);
+        tr.remove_child_slots(p1, 1, 2).unwrap();
+
+        let (_, steps, _, _, _) = tr.commit();
+        let subtree = steps
+            .iter()
+            .find_map(|r| match &r.step {
+                Step::RemoveSubtree { subtree, .. } => Some(subtree),
+                _ => None,
+            })
+            .expect("tab deletion must record RemoveSubtree");
+
+        assert_eq!(subtree.modifiers, vec![Modifier::FontSize { value: 2400 }]);
     }
 
     #[test]

--- a/crates/editor-view/src/measure/text/measure.rs
+++ b/crates/editor-view/src/measure/text/measure.rs
@@ -16,7 +16,7 @@ use editor_resource::Resource;
 use crate::glyph_run::RubyAnnotation;
 
 use super::extract::LineHeightConfig;
-use super::extract::{ExtractedLine, extract_lines};
+use super::extract::{ExtractedLine, extract_lines, resolve_link};
 use super::inline::{
     RubyGroup, Segment, TabMark, TextRun, collect_text_runs, identify_ruby_groups, split_segments,
 };
@@ -35,6 +35,7 @@ pub struct TabGap {
     pub offset_index: usize,
     pub x: f32,
     pub width: f32,
+    pub link: Option<String>,
 }
 
 /// The new (eg-walker) measured-line output. Mirrors `MeasuredLine` with the
@@ -255,6 +256,7 @@ fn measure_segment<'a>(
                     offset_index: tab_boxes[*id as usize].0.offset_index,
                     x: *x,
                     width: *pad,
+                    link: resolve_link(tab_boxes[*id as usize].0.own_modifiers),
                 })
                 .collect();
 
@@ -324,6 +326,7 @@ pub(crate) fn measure_paragraph(
                 &text[byte_range.clone()],
                 offset_range,
                 &runs,
+                &tabs,
                 width,
                 align,
                 seg_indent,
@@ -549,6 +552,62 @@ mod tests {
         }
         // Uncached and first-cached pass must also agree.
         assert_eq!(uncached.len(), first.len());
+    }
+
+    #[test]
+    fn seg_cache_reuse_distinguishes_tab_count_changes() {
+        use super::seg_cache::SegmentCache;
+
+        let one_tab = build_logs(vec![tab()]);
+        let two_tabs = build_logs(vec![tab(), tab()]);
+        let mut cache = SegmentCache::default();
+        let mut res = Resource::new_test();
+
+        let one_tab_pd = project_document(&one_tab).unwrap();
+        let one_tab_view = DocView::new(&one_tab_pd);
+        let one_tab_para = one_tab_view.root().unwrap().child_blocks().next().unwrap();
+        measure_paragraph(
+            &one_tab_para,
+            200.0,
+            Alignment::Left,
+            0.0,
+            None,
+            Some(&mut cache),
+            &mut res,
+        );
+
+        let two_tabs_pd = project_document(&two_tabs).unwrap();
+        let two_tabs_view = DocView::new(&two_tabs_pd);
+        let two_tabs_para = two_tabs_view.root().unwrap().child_blocks().next().unwrap();
+        let uncached = measure_paragraph(
+            &two_tabs_para,
+            200.0,
+            Alignment::Left,
+            0.0,
+            None,
+            None,
+            &mut res,
+        )
+        .0;
+        let reused = measure_paragraph(
+            &two_tabs_para,
+            200.0,
+            Alignment::Left,
+            0.0,
+            None,
+            Some(&mut cache),
+            &mut res,
+        )
+        .0;
+
+        let tab_offsets = |lines: &[MeasuredLine]| -> Vec<usize> {
+            lines
+                .iter()
+                .flat_map(|line| line.tab_gaps.iter().map(|gap| gap.offset_index))
+                .collect()
+        };
+        assert_eq!(tab_offsets(&uncached), vec![0, 1]);
+        assert_eq!(tab_offsets(&reused), tab_offsets(&uncached));
     }
 
     #[test]

--- a/crates/editor-view/src/measure/text/seg_cache.rs
+++ b/crates/editor-view/src/measure/text/seg_cache.rs
@@ -6,7 +6,7 @@ use editor_crdt::Dot;
 use editor_model::Alignment;
 use hashbrown::HashMap;
 
-use super::inline::TextRun;
+use super::inline::{TabMark, TextRun};
 use super::measure::MeasuredLine;
 use super::resolve::ResolvedTextStyle;
 
@@ -114,9 +114,10 @@ fn hash_style<H: Hasher>(s: &ResolvedTextStyle, h: &mut H) {
 }
 
 /// Content hash capturing everything a segment's measured output depends on: its
-/// text, the width/alignment/indent, the paragraph base style, and every inline
-/// run's byte range (relative), font style, effective modifiers, and own modifiers
-/// (so a color or decoration change — same glyphs, different output — still misses).
+/// text, width/alignment/indent, paragraph base style, inline text runs, and tab
+/// marks. Text runs hash relative byte/offset ranges and style/modifier state;
+/// tabs hash relative offset and style/modifier state because their measured gap
+/// and link rectangles are part of the cached `MeasuredLine`.
 ///
 /// `own_modifiers` is hashed alongside `effective` because the rendered
 /// link/color/decoration in the cached `MeasuredLine` are resolved from
@@ -126,6 +127,7 @@ pub(crate) fn segment_hash(
     seg_text: &str,
     seg_off: &Range<usize>,
     runs: &[TextRun],
+    tabs: &[TabMark],
     width: f32,
     align: Alignment,
     indent: f32,
@@ -154,6 +156,24 @@ pub(crate) fn segment_hash(
             o.value.hash(&mut h);
         }
         h.write_u8(0xff);
+    }
+    h.write_u8(0xfd);
+    for t in tabs
+        .iter()
+        .filter(|t| seg_off.start <= t.offset_index && t.offset_index < seg_off.end)
+    {
+        (t.offset_index - seg_off.start).hash(&mut h);
+        hash_style(&t.style, &mut h);
+        for (k, v) in t.effective.iter() {
+            k.hash(&mut h);
+            v.hash(&mut h);
+        }
+        h.write_u8(0xfb);
+        for (k, o) in t.own_modifiers.iter() {
+            k.hash(&mut h);
+            o.value.hash(&mut h);
+        }
+        h.write_u8(0xfc);
     }
     h.finish()
 }
@@ -208,13 +228,73 @@ mod tests {
                 effective: &effective,
                 style: style(),
             }];
-            segment_hash("a", &(0..1), &runs, 100.0, Alignment::Left, 0.0, &style())
+            segment_hash(
+                "a",
+                &(0..1),
+                &runs,
+                &[],
+                100.0,
+                Alignment::Left,
+                0.0,
+                &style(),
+            )
         };
 
         assert_ne!(
             hash_for(&mk_own(true)),
             hash_for(&mk_own(false)),
             "runs differing in an own modifier must hash differently"
+        );
+    }
+
+    #[test]
+    fn segment_hash_distinguishes_tab_own_modifier_value() {
+        let effective: BTreeMap<ModifierType, Modifier> = [(
+            ModifierType::Link,
+            Modifier::Link {
+                href: "https://example.com".to_string(),
+            },
+        )]
+        .into_iter()
+        .collect();
+
+        let mk_own = |href: &str| -> BTreeMap<ModifierType, OwnModifier> {
+            [(
+                ModifierType::Link,
+                OwnModifier {
+                    value: Modifier::Link {
+                        href: href.to_string(),
+                    },
+                },
+            )]
+            .into_iter()
+            .collect()
+        };
+
+        let hash_for = |own: &BTreeMap<ModifierType, OwnModifier>| {
+            let tabs = vec![TabMark {
+                offset_index: 0,
+                byte_offset: 0,
+                own_modifiers: own,
+                effective: &effective,
+                style: style(),
+            }];
+            segment_hash(
+                "",
+                &(0..1),
+                &[],
+                &tabs,
+                100.0,
+                Alignment::Left,
+                0.0,
+                &style(),
+            )
+        };
+
+        assert_ne!(
+            hash_for(&mk_own("https://example.com/a")),
+            hash_for(&mk_own("https://example.com/b")),
+            "tabs differing in an own modifier must hash differently"
         );
     }
 }

--- a/crates/editor-view/src/query/cursor.rs
+++ b/crates/editor-view/src/query/cursor.rs
@@ -71,8 +71,8 @@ mod tests {
     use editor_common::EdgeInsets;
     use editor_crdt::{Dot, InputEvent, ListOp, build_oplog};
     use editor_model::{
-        DocLogs, DocView, ModifierAttrLog, NodeAttrLog, NodeMarkerLog, NodeType, SeqItem, SpanLog,
-        project_document,
+        AtomLeaf, DocLogs, DocView, ModifierAttrLog, NodeAttrLog, NodeMarkerLog, NodeType, SeqItem,
+        SpanLog, project_document,
     };
     use editor_resource::Resource;
     use editor_state::Affinity;
@@ -147,6 +147,25 @@ mod tests {
         (para_id, index)
     }
 
+    fn para_items_doc(children: Vec<SeqItem>, width: f32) -> (editor_crdt::Dot, LayoutIndex) {
+        let root = Dot::ROOT;
+        let para = Dot::new(10, 1);
+        let mut items = vec![(
+            para,
+            SeqItem::Block {
+                node_type: NodeType::Paragraph,
+                parents: vec![root],
+            },
+        )];
+        for (i, child) in children.into_iter().enumerate() {
+            items.push((Dot::new(10, 2 + i as u64), child));
+        }
+        let doc = logs(&items);
+        let para_id = para;
+        let (_, index) = build_index(&doc, width);
+        (para_id, index)
+    }
+
     #[test]
     fn cursor_metrics_line_returns_some() {
         let (para_id, index) = para_doc("Hi", 400.0);
@@ -182,6 +201,30 @@ mod tests {
         );
         assert_eq!(cm.caret.width, 1.0, "caret.width must be 1.0");
         assert_eq!(cm.page_idx, 0, "page_idx must be 0");
+    }
+
+    #[test]
+    fn cursor_metrics_after_tab_only_line_returns_visible_caret() {
+        let (para_id, index) = para_items_doc(
+            vec![SeqItem::Atom(AtomLeaf::Tab), SeqItem::Atom(AtomLeaf::Tab)],
+            400.0,
+        );
+        let pos = Position {
+            node: para_id,
+            offset: 2,
+            affinity: Affinity::Upstream,
+        };
+
+        let cm =
+            cursor_metrics(&index, &pos, None).expect("cursor after tab-only line must resolve");
+
+        let entry = index.entry_for_position(&pos).unwrap();
+        let node = entry.node(&index).unwrap();
+        let LayoutContent::Line(line) = &node.content else {
+            panic!("entry must be a line");
+        };
+        assert_eq!(cm.caret.x, entry.rect.x + grapheme::x_at_offset(line, &pos));
+        assert!(cm.caret.height > 0.0, "caret must be visible");
     }
 
     #[test]

--- a/crates/editor-view/src/query/grapheme.rs
+++ b/crates/editor-view/src/query/grapheme.rs
@@ -3,25 +3,41 @@ use editor_state::Position;
 
 use crate::paginate::types::LayoutLine;
 
-pub(crate) fn last_position_in_line(line: &LayoutLine) -> Position {
-    if let Some(last_gap) = line.tab_gaps.last() {
-        let after_glyphs = line
-            .glyph_runs
-            .last()
-            .map(|r| last_gap.x + last_gap.width >= r.x + r.width)
-            .unwrap_or(true);
-        if after_glyphs {
-            return Position {
-                node: line.node,
-                offset: last_gap.offset_index + 1,
-                affinity: Affinity::Upstream,
-            };
+fn visual_bounds(line: &LayoutLine) -> (Option<(f32, usize)>, Option<(f32, usize)>) {
+    let mut first: Option<(f32, usize)> = None;
+    let mut last: Option<(f32, usize)> = None;
+
+    for run in &line.glyph_runs {
+        if first.is_none_or(|(x, _)| run.x < x) {
+            first = Some((run.x, run.offset_range.start));
+        }
+
+        let end_x = run.x + run.width;
+        if last.is_none_or(|(x, _)| end_x > x) {
+            last = Some((end_x, run.offset_range.end));
         }
     }
-    if let Some(run) = line.glyph_runs.last() {
+
+    for gap in &line.tab_gaps {
+        if first.is_none_or(|(x, _)| gap.x < x) {
+            first = Some((gap.x, gap.offset_index));
+        }
+
+        let end_x = gap.x + gap.width;
+        if last.is_none_or(|(x, _)| end_x > x) {
+            last = Some((end_x, gap.offset_index + 1));
+        }
+    }
+
+    (first, last)
+}
+
+pub(crate) fn last_position_in_line(line: &LayoutLine) -> Position {
+    let (_, last) = visual_bounds(line);
+    if let Some((_, offset)) = last {
         return Position {
             node: line.node,
-            offset: run.offset_range.end,
+            offset,
             affinity: Affinity::Upstream,
         };
     }
@@ -38,6 +54,19 @@ pub(crate) fn last_position_in_line(line: &LayoutLine) -> Position {
         };
     }
     Position::new(line.node, 0)
+}
+
+pub(crate) fn first_position_in_line(line: &LayoutLine) -> Position {
+    let (first, _) = visual_bounds(line);
+    if let Some((_, offset)) = first {
+        return Position::new(line.node, offset);
+    }
+    let offset = line.offset_range.as_ref().map(|r| r.start).unwrap_or(0);
+    Position {
+        node: line.node,
+        offset,
+        affinity: Affinity::Downstream,
+    }
 }
 
 pub(crate) fn x_at_offset(line: &LayoutLine, pos: &Position) -> f32 {
@@ -129,6 +158,10 @@ pub(crate) fn position_at_x(line: &LayoutLine, local_x: f32) -> Position {
             } else {
                 gap.offset_index + 1
             };
+            let last_position = last_position_in_line(line);
+            if offset == last_position.offset {
+                return last_position;
+            }
             return Position {
                 node: line.node,
                 offset,
@@ -137,21 +170,19 @@ pub(crate) fn position_at_x(line: &LayoutLine, local_x: f32) -> Position {
         }
     }
 
-    if line.glyph_runs.is_empty() {
+    if line.glyph_runs.is_empty() && line.tab_gaps.is_empty() {
         let offset = line.offset_range.as_ref().map(|r| r.start).unwrap_or(0);
         return Position::new(line.node, offset);
     }
 
-    let first = &line.glyph_runs[0];
-    let last = &line.glyph_runs[line.glyph_runs.len() - 1];
-    let last_offset = last.offset_range.end;
-
-    if local_x <= first.x {
-        return Position::new(line.node, first.offset_range.start);
+    if local_x <= line_content_start_x(line) {
+        return first_position_in_line(line);
     }
 
-    if local_x >= last.x + last.width {
-        return last_position_in_line(line);
+    let last_position = last_position_in_line(line);
+
+    if local_x >= line_content_end_x(line) {
+        return last_position;
     }
 
     for run in &line.glyph_runs {
@@ -168,13 +199,13 @@ pub(crate) fn position_at_x(line: &LayoutLine, local_x: f32) -> Position {
             cp_offset += g.codepoints as usize;
         }
         let offset = run.offset_range.start + cp_offset;
-        if offset == last_offset {
-            return last_position_in_line(line);
+        if offset == last_position.offset {
+            return last_position;
         }
         return Position::new(line.node, offset);
     }
 
-    Position::new(line.node, last_offset)
+    last_position
 }
 
 #[cfg(test)]
@@ -327,6 +358,76 @@ mod tests {
     }
 
     #[test]
+    fn position_at_x_handles_tab_only_line_edges() {
+        let n = node();
+        let l = line(
+            n,
+            Some(0..2),
+            vec![],
+            vec![
+                TabGap {
+                    offset_index: 0,
+                    x: 0.0,
+                    width: 40.0,
+                    link: None,
+                },
+                TabGap {
+                    offset_index: 1,
+                    x: 40.0,
+                    width: 40.0,
+                    link: None,
+                },
+            ],
+            0.0,
+            None,
+        );
+
+        let before = position_at_x(&l, -10.0);
+        assert_eq!(before.node, n);
+        assert_eq!(before.offset, 0);
+
+        let after = position_at_x(&l, 100.0);
+        assert_eq!(after.node, n);
+        assert_eq!(after.offset, 2);
+        assert_eq!(after.affinity, Affinity::Upstream);
+
+        let inside_last_gap_right_half = position_at_x(&l, 70.0);
+        assert_eq!(inside_last_gap_right_half.node, n);
+        assert_eq!(inside_last_gap_right_half.offset, 2);
+        assert_eq!(inside_last_gap_right_half.affinity, Affinity::Upstream);
+    }
+
+    #[test]
+    fn position_before_leading_tab_with_following_text_lands_at_line_start() {
+        let n = node();
+        let l = line(
+            n,
+            Some(0..3),
+            vec![run(2..3, 100.0, vec![gs(10.0, 1)])],
+            vec![
+                TabGap {
+                    offset_index: 0,
+                    x: 20.0,
+                    width: 40.0,
+                    link: None,
+                },
+                TabGap {
+                    offset_index: 1,
+                    x: 60.0,
+                    width: 40.0,
+                    link: None,
+                },
+            ],
+            20.0,
+            None,
+        );
+
+        let before = position_at_x(&l, 10.0);
+        assert_eq!(before.node, n);
+        assert_eq!(before.offset, 0);
+    }
+
+    #[test]
     fn last_position_in_line_cases() {
         let n = node();
 
@@ -347,6 +448,7 @@ mod tests {
             offset_index: 2,
             x: 20.0,
             width: 30.0,
+            link: None,
         };
         let l_tab = line(
             n,

--- a/crates/editor-view/src/query/hit_test.rs
+++ b/crates/editor-view/src/query/hit_test.rs
@@ -334,6 +334,25 @@ mod tests {
         (pd, para_id, index)
     }
 
+    fn para_items_doc(children: Vec<SeqItem>, width: f32) -> (ProjectedDoc, Dot, LayoutIndex) {
+        let root = Dot::ROOT;
+        let para = Dot::new(14, 1);
+        let mut items = vec![(
+            para,
+            SeqItem::Block {
+                node_type: NodeType::Paragraph,
+                parents: vec![root],
+            },
+        )];
+        for (i, child) in children.into_iter().enumerate() {
+            items.push((Dot::new(14, 2 + i as u64), child));
+        }
+        let doc = logs(&items);
+        let para_id = para;
+        let (pd, index) = build_index(&doc, width);
+        (pd, para_id, index)
+    }
+
     fn hr_doc(width: f32) -> (ProjectedDoc, Dot, LayoutIndex) {
         let root = Dot::ROOT;
         let hr = Dot::new(11, 1);
@@ -469,6 +488,26 @@ mod tests {
             sel.anchor.offset, expected_pos.offset,
             "anchor offset must match position_at_x for local_x"
         );
+    }
+
+    #[test]
+    fn hit_test_after_tab_only_line_lands_after_last_tab() {
+        let (_pd, para_id, index) = para_items_doc(
+            vec![SeqItem::Atom(AtomLeaf::Tab), SeqItem::Atom(AtomLeaf::Tab)],
+            400.0,
+        );
+        let (entry, line) = first_line_for_para(&index, &para_id).expect("must find tab line");
+        let last_gap = line.tab_gaps.last().expect("tab line must expose tab gap");
+        let local_x = last_gap.x + last_gap.width + 10.0;
+        let abs_x = entry.rect.x + local_x;
+        let page_y = entry.rect.y - index.pages()[0].y_start + entry.rect.height / 2.0;
+
+        let sel = hit_test(&index, 0, abs_x, page_y).expect("click must hit tab line");
+
+        assert_eq!(sel.anchor, sel.head);
+        assert_eq!(sel.anchor.node, para_id);
+        assert_eq!(sel.anchor.offset, 2);
+        assert_eq!(sel.anchor.affinity, Affinity::Upstream);
     }
 
     #[test]

--- a/crates/editor-view/src/query/layout_index.rs
+++ b/crates/editor-view/src/query/layout_index.rs
@@ -511,6 +511,10 @@ fn position_matches_line(line: &LayoutLine, pos: &Position) -> bool {
     line.glyph_runs
         .iter()
         .any(|run| pos.offset >= run.offset_range.start && pos.offset <= run.offset_range.end)
+        || line
+            .tab_gaps
+            .iter()
+            .any(|gap| pos.offset >= gap.offset_index && pos.offset <= gap.offset_index + 1)
 }
 
 fn position_attaches_to_child(pos: &Position, parent: &Dot, index: usize) -> bool {
@@ -553,7 +557,9 @@ fn rect_area(rect: &Rect) -> f32 {
 
 #[cfg(test)]
 mod tests {
-    use editor_common::EdgeInsets;
+    use std::sync::Arc;
+
+    use editor_common::{EdgeInsets, Rect, Size};
     use editor_crdt::{Dot, InputEvent, ListOp, build_oplog};
     use editor_model::{
         AtomLeaf, DocLogs, DocView, HorizontalRuleVariant, ModifierAttrLog, NodeAttrLog,
@@ -564,8 +570,11 @@ mod tests {
 
     use crate::measure::context::MeasureContext;
     use crate::measure::nodes::dispatch::measure_node;
+    use crate::measure::text::measure::{MeasuredLine, TabGap};
     use crate::measure::types::MeasuredTree;
     use crate::paginate::paginator::Paginator;
+    use crate::paginate::types::{LayoutBox, LayoutLine};
+    use crate::style::BoxStyle;
 
     use super::*;
 
@@ -671,6 +680,60 @@ mod tests {
         let entry = index.entry_for_position(&pos).expect("entry must exist");
         let node = entry.node(&index).expect("entry node must exist");
         assert!(matches!(&node.content, LayoutContent::Line(l) if l.node == para_id));
+    }
+
+    #[test]
+    fn entry_for_position_line_matches_tab_gap_offsets_without_line_offset_range() {
+        let para = Dot::new(30, 1);
+        let line = LayoutLine {
+            measured: Arc::new(MeasuredLine {
+                node: para,
+                height: 20.0,
+                baseline: 14.0,
+                ascent: 14.0,
+                descent: 4.0,
+                cursor_ascent: 14.0,
+                cursor_descent: 4.0,
+                glyph_runs: vec![],
+                ruby_annotations: vec![],
+                empty_caret_x: 0.0,
+                offset_range: None,
+                tab_gaps: vec![TabGap {
+                    offset_index: 5,
+                    x: 10.0,
+                    width: 40.0,
+                    link: None,
+                }],
+                is_phantom: false,
+                content_edge_x: None,
+            }),
+        };
+        let rect = Rect::from_xywh(0.0, 0.0, 200.0, 20.0);
+        let tree = LayoutTree {
+            root: LayoutNode {
+                rect,
+                content: LayoutContent::Box(LayoutBox {
+                    node: Dot::ROOT,
+                    style: BoxStyle::default(),
+                    children: vec![LayoutNode {
+                        rect,
+                        content: LayoutContent::Line(line),
+                    }],
+                    attachment: None,
+                }),
+            },
+        };
+        let page = LayoutPage::new(0.0, 100.0, Size::new(200.0, 100.0));
+        let index = LayoutIndex::new(tree, &[page]);
+
+        for offset in [5, 6] {
+            let pos = Position::new(para, offset);
+            let entry = index
+                .entry_for_position(&pos)
+                .expect("tab boundary position must resolve to its line");
+            let node = entry.node(&index).expect("entry node must exist");
+            assert!(matches!(&node.content, LayoutContent::Line(l) if l.node == para));
+        }
     }
 
     #[test]

--- a/crates/editor-view/src/query/link.rs
+++ b/crates/editor-view/src/query/link.rs
@@ -33,6 +33,18 @@ pub(crate) fn page_link_rects(layout_index: &LayoutIndex, page_idx: usize) -> Ve
                 );
                 push_rect(&mut out, page_idx, href.clone(), rect);
             }
+            for gap in &line.tab_gaps {
+                let Some(ref href) = gap.link else {
+                    continue;
+                };
+                let rect = Rect::from_xywh(
+                    entry.rect.x + gap.x,
+                    entry.rect.y - page.y_start,
+                    gap.width,
+                    entry.rect.height,
+                );
+                push_rect(&mut out, page_idx, href.clone(), rect);
+            }
         }
     }
     out
@@ -116,6 +128,7 @@ mod tests {
         w: f32,
         h: f32,
         glyph_runs: Vec<GlyphRun>,
+        tab_gaps: Vec<crate::measure::text::measure::TabGap>,
     ) -> LayoutNode {
         LayoutNode {
             rect: Rect::from_xywh(x, y, w, h),
@@ -132,7 +145,7 @@ mod tests {
                     ruby_annotations: vec![],
                     empty_caret_x: 0.0,
                     offset_range: None,
-                    tab_gaps: vec![],
+                    tab_gaps,
                     is_phantom: false,
                     content_edge_x: None,
                 }),
@@ -196,6 +209,7 @@ mod tests {
             180.0,
             20.0,
             vec![run_a, run_b, run_c, run_d],
+            vec![],
         );
         let root = box_node(root_id, 0.0, 0.0, 200.0, 40.0, vec![ln]);
         let index = build_index(root, vec![page(0.0, 100.0)]);
@@ -244,7 +258,7 @@ mod tests {
         let run_a = run(0..5, 0.0, vec![gs(10.0, 1); 5], Some("https://a.example"));
         let run_b = run(5..10, 50.0, vec![gs(10.0, 1); 5], None);
 
-        let ln = line_node(para_id, 20.0, 10.0, 180.0, 20.0, vec![run_a, run_b]);
+        let ln = line_node(para_id, 20.0, 10.0, 180.0, 20.0, vec![run_a, run_b], vec![]);
         let root = box_node(root_id, 0.0, 0.0, 200.0, 40.0, vec![ln]);
         let index = build_index(root, vec![page(0.0, 100.0)]);
 
@@ -260,5 +274,36 @@ mod tests {
 
         let miss_outside = link_hit_test(&index, 0, 200.0, 15.0);
         assert!(miss_outside.is_none(), "x=200 (outside any run) must miss");
+    }
+
+    #[test]
+    fn link_rects_include_tab_gaps() {
+        let root_id = elem(1, 0);
+        let para_id = elem(1, 1);
+
+        let ln = line_node(
+            para_id,
+            20.0,
+            10.0,
+            180.0,
+            20.0,
+            vec![],
+            vec![crate::measure::text::measure::TabGap {
+                offset_index: 0,
+                x: 40.0,
+                width: 32.0,
+                link: Some("https://tab.example".to_string()),
+            }],
+        );
+        let root = box_node(root_id, 0.0, 0.0, 200.0, 40.0, vec![ln]);
+        let index = build_index(root, vec![page(0.0, 100.0)]);
+
+        let links = page_link_rects(&index, 0);
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].href, "https://tab.example");
+        assert_eq!(links[0].rects[0], Rect::from_xywh(60.0, 10.0, 32.0, 20.0));
+
+        let hit = link_hit_test(&index, 0, 70.0, 15.0).expect("tab gap must hit");
+        assert_eq!(hit.href, "https://tab.example");
     }
 }

--- a/crates/editor-view/src/query/navigation.rs
+++ b/crates/editor-view/src/query/navigation.rs
@@ -8,6 +8,7 @@ use crate::paginate::types::{ChildAttachment, LayoutBox, LayoutContent, LayoutLi
 use crate::viewport::Viewport;
 
 use super::cursor::x_at_offset;
+use super::grapheme::{first_position_in_line, last_position_in_line};
 use super::layout_index::{LayoutEntry, LayoutIndex};
 use super::segmentation;
 
@@ -87,6 +88,18 @@ fn move_grapheme_forward(layout_index: &LayoutIndex, pos: &Position) -> Option<S
 
     match entry.content(layout_index)? {
         LayoutContent::Line(line) => {
+            if pos.node == line.node
+                && let Some(gap) = line
+                    .tab_gaps
+                    .iter()
+                    .find(|gap| pos.offset == gap.offset_index)
+            {
+                return Some(Selection::collapsed(Position {
+                    node: line.node,
+                    offset: gap.offset_index + 1,
+                    affinity: Affinity::Upstream,
+                }));
+            }
             if line.glyph_runs.is_empty()
                 && let Some(range) = &line.offset_range
                 && pos.node == line.node
@@ -121,16 +134,6 @@ fn move_grapheme_forward(layout_index: &LayoutIndex, pos: &Position) -> Option<S
                 if local == cp_acc
                     && let Some(next) = line.glyph_runs.get(i + 1)
                 {
-                    let separated_by_tab = line
-                        .tab_gaps
-                        .iter()
-                        .any(|gap| gap.x >= run.x - 0.5 && gap.x + gap.width <= next.x + 0.5);
-                    if separated_by_tab {
-                        return Some(Selection::collapsed(Position::new(
-                            line.node,
-                            next.offset_range.start,
-                        )));
-                    }
                     if let Some(g) = next.graphemes.first() {
                         return Some(Selection::collapsed(Position::new(
                             line.node,
@@ -183,6 +186,19 @@ fn move_grapheme_backward(layout_index: &LayoutIndex, pos: &Position) -> Option<
 
     match entry.content(layout_index)? {
         LayoutContent::Line(line) => {
+            if pos.node == line.node
+                && let Some(gap) = line
+                    .tab_gaps
+                    .iter()
+                    .rev()
+                    .find(|gap| pos.offset == gap.offset_index + 1)
+            {
+                return Some(Selection::collapsed(Position {
+                    node: line.node,
+                    offset: gap.offset_index,
+                    affinity: Affinity::Downstream,
+                }));
+            }
             if line.glyph_runs.is_empty()
                 && let Some(range) = &line.offset_range
                 && pos.node == line.node
@@ -221,16 +237,6 @@ fn move_grapheme_backward(layout_index: &LayoutIndex, pos: &Position) -> Option<
                 if pos.offset == run.offset_range.start && i > 0 {
                     let prev = &line.glyph_runs[i - 1];
                     let total = prev.offset_range.len();
-                    let separated_by_tab = line
-                        .tab_gaps
-                        .iter()
-                        .any(|gap| gap.x >= prev.x - 0.5 && gap.x + gap.width <= run.x + 0.5);
-                    if separated_by_tab {
-                        return Some(Selection::collapsed(Position::new(
-                            line.node,
-                            prev.offset_range.start + total,
-                        )));
-                    }
                     if let Some(g) = prev.graphemes.last() {
                         return Some(Selection::collapsed(Position::new(
                             line.node,
@@ -482,31 +488,6 @@ fn move_document_backward(layout_index: &LayoutIndex) -> Option<Selection> {
     Some(landed_entry(layout_index, nav, false, false))
 }
 
-fn first_position_in_line(line: &LayoutLine) -> Position {
-    let run_first = line.glyph_runs.first();
-    let leading_gap = line
-        .tab_gaps
-        .iter()
-        .filter(|g| run_first.is_none_or(|r| g.x < r.x))
-        .min_by(|a, b| a.x.total_cmp(&b.x));
-    if let Some(gap) = leading_gap {
-        return Position::new(line.node, gap.offset_index);
-    }
-    if let Some(run) = run_first {
-        return Position::new(line.node, run.offset_range.start);
-    }
-    let offset = line.offset_range.as_ref().map(|r| r.start).unwrap_or(0);
-    Position {
-        node: line.node,
-        offset,
-        affinity: Affinity::Upstream,
-    }
-}
-
-fn last_position_in_line(line: &LayoutLine) -> Position {
-    super::grapheme::last_position_in_line(line)
-}
-
 fn first_position_in_entry(layout_index: &LayoutIndex, entry: &LayoutEntry) -> Position {
     match entry.content(layout_index) {
         Some(LayoutContent::Line(line)) => first_position_in_line(line),
@@ -521,6 +502,19 @@ fn first_position_in_entry(layout_index: &LayoutIndex, entry: &LayoutEntry) -> P
             unreachable!("first_position_in_entry called on non-navigable entry")
         }
     }
+}
+
+fn first_position_for_entry_landing(layout_index: &LayoutIndex, entry: &LayoutEntry) -> Position {
+    let mut pos = first_position_in_entry(layout_index, entry);
+    // Landing from another entry treats a glyphless line start as the upstream
+    // structural boundary. Direct line-start movement uses `first_position_in_line`.
+    if let Some(LayoutContent::Line(line)) = entry.content(layout_index)
+        && line.glyph_runs.is_empty()
+        && line.tab_gaps.is_empty()
+    {
+        pos.affinity = Affinity::Upstream;
+    }
+    pos
 }
 
 fn last_position_in_entry(layout_index: &LayoutIndex, entry: &LayoutEntry) -> Position {
@@ -857,7 +851,7 @@ pub(crate) fn landed_entry(
     let pos = if at_end {
         last_position_in_entry(layout_index, entry)
     } else {
-        first_position_in_entry(layout_index, entry)
+        first_position_for_entry_landing(layout_index, entry)
     };
     Selection::collapsed(pos)
 }
@@ -896,8 +890,8 @@ mod tests {
     use editor_common::{Axis, Direction, EdgeInsets, Movement};
     use editor_crdt::{Dot, InputEvent, ListOp, build_oplog};
     use editor_model::{
-        DocLogs, DocView, ModifierAttrLog, NodeAttrLog, NodeMarkerLog, NodeType, SeqItem, SpanLog,
-        project_document,
+        AtomLeaf, DocLogs, DocView, ModifierAttrLog, NodeAttrLog, NodeMarkerLog, NodeType, SeqItem,
+        SpanLog, project_document,
     };
     use editor_resource::Resource;
     use editor_state::Position;
@@ -973,6 +967,25 @@ mod tests {
         )];
         for (i, ch) in text.chars().enumerate() {
             items.push((Dot::new(1, 2 + i as u64), SeqItem::Char(ch)));
+        }
+        let doc = logs(&items);
+        let para_id = para;
+        let (root_id, index) = build_index(&doc, width);
+        (root_id, para_id, index)
+    }
+
+    fn para_doc_items(children: Vec<SeqItem>, width: f32) -> (Dot, Dot, LayoutIndex) {
+        let root = Dot::ROOT;
+        let para = Dot::new(14, 1);
+        let mut items = vec![(
+            para,
+            SeqItem::Block {
+                node_type: NodeType::Paragraph,
+                parents: vec![root],
+            },
+        )];
+        for (i, child) in children.into_iter().enumerate() {
+            items.push((Dot::new(14, 2 + i as u64), child));
         }
         let doc = logs(&items);
         let para_id = para;
@@ -1136,6 +1149,138 @@ mod tests {
     }
 
     #[test]
+    fn grapheme_navigation_visits_each_consecutive_tab() {
+        let (_root_id, para_id, index) = para_doc_items(
+            vec![SeqItem::Atom(AtomLeaf::Tab), SeqItem::Atom(AtomLeaf::Tab)],
+            400.0,
+        );
+        let vp = viewport();
+        let res = Resource::new_test();
+
+        let (forward_first, _) = resolve_movement(
+            &index,
+            &Position::new(para_id, 0),
+            &Movement::Grapheme {
+                direction: Direction::Forward,
+            },
+            &vp,
+            &res,
+            None,
+        );
+        assert_eq!(
+            forward_first
+                .expect("forward over first tab must resolve")
+                .head
+                .offset,
+            1
+        );
+
+        let (forward_second, _) = resolve_movement(
+            &index,
+            &Position::new(para_id, 1),
+            &Movement::Grapheme {
+                direction: Direction::Forward,
+            },
+            &vp,
+            &res,
+            None,
+        );
+        assert_eq!(
+            forward_second
+                .expect("forward over second tab must resolve")
+                .head
+                .offset,
+            2
+        );
+
+        let (backward_second, _) = resolve_movement(
+            &index,
+            &Position::new(para_id, 2),
+            &Movement::Grapheme {
+                direction: Direction::Backward,
+            },
+            &vp,
+            &res,
+            None,
+        );
+        assert_eq!(
+            backward_second
+                .expect("backward over second tab must resolve")
+                .head
+                .offset,
+            1
+        );
+
+        let (backward_first, _) = resolve_movement(
+            &index,
+            &Position::new(para_id, 1),
+            &Movement::Grapheme {
+                direction: Direction::Backward,
+            },
+            &vp,
+            &res,
+            None,
+        );
+        assert_eq!(
+            backward_first
+                .expect("backward over first tab must resolve")
+                .head
+                .offset,
+            0
+        );
+    }
+
+    #[test]
+    fn grapheme_navigation_crosses_text_around_tab() {
+        let (_root_id, para_id, index) = para_doc_items(
+            vec![
+                SeqItem::Char('a'),
+                SeqItem::Atom(AtomLeaf::Tab),
+                SeqItem::Char('b'),
+            ],
+            400.0,
+        );
+        let vp = viewport();
+        let res = Resource::new_test();
+
+        let (forward, _) = resolve_movement(
+            &index,
+            &Position::new(para_id, 2),
+            &Movement::Grapheme {
+                direction: Direction::Forward,
+            },
+            &vp,
+            &res,
+            None,
+        );
+        assert_eq!(
+            forward
+                .expect("forward from after tab must reach following text")
+                .head
+                .offset,
+            3
+        );
+
+        let (backward, _) = resolve_movement(
+            &index,
+            &Position::new(para_id, 1),
+            &Movement::Grapheme {
+                direction: Direction::Backward,
+            },
+            &vp,
+            &res,
+            None,
+        );
+        assert_eq!(
+            backward
+                .expect("backward from before tab must reach preceding text")
+                .head
+                .offset,
+            0
+        );
+    }
+
+    #[test]
     fn line_horizontal() {
         let (_root_id, para_id, index) = para_doc("Hello", 400.0);
         let vp = viewport();
@@ -1175,6 +1320,32 @@ mod tests {
         let start_sel = start_sel.expect("line-start must resolve");
         assert_eq!(start_sel.head.node, para_id);
         assert_eq!(start_sel.head.offset, 0, "line-start must be at offset 0");
+    }
+
+    #[test]
+    fn line_horizontal_backward_empty_line_uses_start_affinity() {
+        let para_id = Dot::new(21, 1);
+        let line = vline(para_id, Some(3..3), vec![]);
+        let index = make_single_line_index(para_id, line, 20.0);
+        let vp = viewport();
+        let res = Resource::new_test();
+
+        let (sel, _) = resolve_movement(
+            &index,
+            &Position::new(para_id, 3),
+            &Movement::Line {
+                direction: Direction::Backward,
+                axis: Axis::Horizontal,
+            },
+            &vp,
+            &res,
+            None,
+        );
+
+        let sel = sel.expect("line-start on empty line must resolve");
+        assert_eq!(sel.head.node, para_id);
+        assert_eq!(sel.head.offset, 3);
+        assert_eq!(sel.head.affinity, Affinity::Downstream);
     }
 
     #[test]

--- a/crates/editor-view/src/query/segmentation.rs
+++ b/crates/editor-view/src/query/segmentation.rs
@@ -170,6 +170,9 @@ pub(crate) fn line_char_index(line: &LayoutLine, pos: &Position) -> Option<usize
                 if pos.node == line.node && pos.offset == gap.offset_index {
                     return Some(char_count);
                 }
+                if pos.node == line.node && pos.offset == gap.offset_index + 1 {
+                    return Some(char_count + 1);
+                }
                 char_count += 1;
             }
         }
@@ -189,8 +192,8 @@ pub(crate) fn position_at_char_index(line: &LayoutLine, char_index: usize) -> Op
                 remaining -= run_chars;
             }
             LineItem::Tab(gap) => {
-                if remaining == 0 {
-                    return Some(Position::new(line.node, gap.offset_index));
+                if remaining <= 1 {
+                    return Some(Position::new(line.node, gap.offset_index + remaining));
                 }
                 remaining -= 1;
             }
@@ -311,8 +314,8 @@ mod tests {
     use editor_common::Size;
     use editor_crdt::{Dot, InputEvent, ListOp, build_oplog};
     use editor_model::{
-        DocLogs, DocView, ModifierAttrLog, NodeAttrLog, NodeMarkerLog, NodeType, SeqItem, SpanLog,
-        project_document,
+        AtomLeaf, DocLogs, DocView, ModifierAttrLog, NodeAttrLog, NodeMarkerLog, NodeType, SeqItem,
+        SpanLog, project_document,
     };
     use editor_resource::Resource;
     use editor_state::Position;
@@ -391,6 +394,25 @@ mod tests {
         (para_id, index)
     }
 
+    fn para_doc_items(children: Vec<SeqItem>, width: f32) -> (Dot, LayoutIndex) {
+        let root = Dot::ROOT;
+        let para = Dot::new(15, 1);
+        let mut items = vec![(
+            para,
+            SeqItem::Block {
+                node_type: NodeType::Paragraph,
+                parents: vec![root],
+            },
+        )];
+        for (i, child) in children.into_iter().enumerate() {
+            items.push((Dot::new(15, 2 + i as u64), child));
+        }
+        let doc = logs(&items);
+        let para_id = para;
+        let (_, index) = build_index(&doc, width);
+        (para_id, index)
+    }
+
     fn gs(advance: f32, codepoints: u8) -> GraphemeSpan {
         GraphemeSpan {
             advance,
@@ -430,6 +452,15 @@ mod tests {
         offset_range: Option<std::ops::Range<usize>>,
         runs: Vec<GlyphRun>,
     ) -> LayoutLine {
+        vline_with_tabs(node, offset_range, runs, vec![])
+    }
+
+    fn vline_with_tabs(
+        node: Dot,
+        offset_range: Option<std::ops::Range<usize>>,
+        runs: Vec<GlyphRun>,
+        tab_gaps: Vec<TabGap>,
+    ) -> LayoutLine {
         LayoutLine {
             measured: std::sync::Arc::new(crate::measure::text::measure::MeasuredLine {
                 height: 0.0,
@@ -443,7 +474,7 @@ mod tests {
                 ruby_annotations: vec![],
                 empty_caret_x: 0.0,
                 offset_range,
-                tab_gaps: vec![],
+                tab_gaps,
                 is_phantom: false,
                 content_edge_x: None,
             }),
@@ -560,6 +591,62 @@ mod tests {
         assert_eq!(
             sel.head.offset, 11,
             "word_forward from offset 5 must cross run boundary to offset 11 (end of 'world' in run1)"
+        );
+    }
+
+    #[test]
+    fn word_backward_from_end_of_tab_only_line_resolves() {
+        let (para_id, index) = para_doc_items(
+            vec![SeqItem::Atom(AtomLeaf::Tab), SeqItem::Atom(AtomLeaf::Tab)],
+            400.0,
+        );
+        let res = Resource::new_test();
+
+        let sel = move_word_backward(&index, &Position::new(para_id, 2), &res.segmenters)
+            .expect("word backward from after trailing tab must resolve");
+
+        assert_eq!(sel.head.node, para_id);
+        assert_eq!(sel.head.offset, 0);
+    }
+
+    #[test]
+    fn char_index_round_trips_after_trailing_tab() {
+        let para_id = Dot::new(1, 1);
+        let line = vline_with_tabs(
+            para_id,
+            Some(0..2),
+            vec![],
+            vec![
+                TabGap {
+                    offset_index: 0,
+                    x: 0.0,
+                    width: 40.0,
+                    link: None,
+                },
+                TabGap {
+                    offset_index: 1,
+                    x: 40.0,
+                    width: 40.0,
+                    link: None,
+                },
+            ],
+        );
+
+        assert_eq!(line_char_index(&line, &Position::new(para_id, 0)), Some(0));
+        assert_eq!(line_char_index(&line, &Position::new(para_id, 1)), Some(1));
+        assert_eq!(line_char_index(&line, &Position::new(para_id, 2)), Some(2));
+
+        assert_eq!(
+            position_at_char_index(&line, 0),
+            Some(Position::new(para_id, 0))
+        );
+        assert_eq!(
+            position_at_char_index(&line, 1),
+            Some(Position::new(para_id, 1))
+        );
+        assert_eq!(
+            position_at_char_index(&line, 2),
+            Some(Position::new(para_id, 2))
         );
     }
 }

--- a/crates/editor-view/src/query/selection.rs
+++ b/crates/editor-view/src/query/selection.rs
@@ -657,6 +657,22 @@ mod tests {
         (logs(&items), root, para)
     }
 
+    fn para_doc_items(children: Vec<SeqItem>) -> (DocLogs, Dot, Dot) {
+        let root = Dot::ROOT;
+        let para = Dot::new(12, 1);
+        let mut items = vec![(
+            para,
+            SeqItem::Block {
+                node_type: NodeType::Paragraph,
+                parents: vec![root],
+            },
+        )];
+        for (i, child) in children.into_iter().enumerate() {
+            items.push((Dot::new(12, 2 + i as u64), child));
+        }
+        (logs(&items), root, para)
+    }
+
     fn first_line_for_para<'a>(
         index: &'a LayoutIndex,
         para_id: &Dot,
@@ -734,6 +750,44 @@ mod tests {
         assert!(
             (rects[0].rect.x + rects[0].rect.width - expected_right).abs() < 0.1,
             "rect right edge must equal entry.rect.x + x_at_offset(to)"
+        );
+    }
+
+    #[test]
+    fn tab_only_selection_has_visible_text_rect() {
+        let (doc, _root, para) = para_doc_items(vec![
+            SeqItem::Atom(AtomLeaf::Tab),
+            SeqItem::Atom(AtomLeaf::Tab),
+        ]);
+        let (pd, index) = build_index(&doc, 400.0);
+        let view = DocView::new(&pd);
+        let para_id = para;
+
+        let sel = Selection::new(
+            Position {
+                node: para_id,
+                offset: 0,
+                affinity: Affinity::Downstream,
+            },
+            Position {
+                node: para_id,
+                offset: 2,
+                affinity: Affinity::Upstream,
+            },
+        );
+        let rsel = sel.resolve(&view).expect("must resolve");
+
+        let rects = selection_text_rects(&index, &rsel);
+        assert_eq!(rects.len(), 1, "tab-only selection must produce one rect");
+        assert!(
+            rects[0].rect.width > 0.0,
+            "tab-only selection rect must span tab width, got {:?}",
+            rects
+        );
+        assert!(
+            rects[0].rect.height > 0.0,
+            "tab-only selection text rect must be visible, got {:?}",
+            rects
         );
     }
 


### PR DESCRIPTION
- 탭을 glyph run이 아닌 inline gap으로 측정/캐싱해서 커서, hit test, selection, navigation에서 같은 위치 정보를 쓰도록 정리
- 탭 사이/탭 뒤/탭만 있는 줄에서 커서 표시, selection 시각화, hit test 등등 디버그
- `remove_text`는 실제 text leaf 삭제 계약으로 유지하고, 탭/하드브레이크 같은 inline leaf 삭제는 `remove_child_slots`로 처리
- Backspace/Delete/selection deletion/text replacement/split/merge에서 inline leaf 포함 삭제가 같은 삭제 계약을 쓰도록 정리