### PR TITLE
repasteAsText 오버레이 조건 수정

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -107,7 +107,6 @@ import co.typie.screen.editor.editor.layout.EditorViewportScrollReconcileMode
 import co.typie.screen.editor.editor.overlay.EditorRepasteAsTextOverlay
 import co.typie.screen.editor.editor.overlay.EditorScreenOverlayHost
 import co.typie.screen.editor.editor.overlay.EditorZoomOverlay
-import co.typie.screen.editor.editor.overlay.RepasteAsTextOverlayHeight
 import co.typie.screen.editor.editor.placeholder.EditorDocumentPlaceholder
 import co.typie.screen.editor.editor.spellcheck.SpellcheckOverlay
 import co.typie.screen.editor.editor.spellcheck.SpellcheckTopBarCenter
@@ -654,13 +653,11 @@ fun EditorScreen(entityId: String) {
       } else {
         maxOf(toolbarBottomOcclusion.value, findReplaceToolbarOcclusion).value.coerceAtLeast(0f)
       }
-    val repasteAsTextVisible = !documentLocked && editorState.lastHistoryTag is HistoryTag.PasteHtml
-    val repasteAsTextOcclusion =
-      if (repasteAsTextVisible) {
-        RepasteAsTextOverlayHeight.value
-      } else {
-        0f
-      }
+    val repasteAsTextVisible =
+      !documentLocked &&
+        uiState.focused &&
+        editorState.selection != null &&
+        editorState.lastHistoryTag is HistoryTag.PasteHtml
     val visibleAreas =
       screenState.resolveEditorVisibleAreas(
         topInset = topInset.value,
@@ -670,17 +667,11 @@ fun EditorScreen(entityId: String) {
         overlayOcclusion =
           EditorOverlayOcclusion(
             top = maxOf(spellcheck.occlusion.top, aiFeedback.occlusion.top),
-            bottom =
-              maxOf(
-                spellcheck.occlusion.bottom,
-                aiFeedback.occlusion.bottom,
-                repasteAsTextOcclusion,
-              ),
+            bottom = maxOf(spellcheck.occlusion.bottom, aiFeedback.occlusion.bottom),
             bottomScrollReserve =
               maxOf(
                 spellcheck.occlusion.bottomScrollReserve,
                 aiFeedback.occlusion.bottomScrollReserve,
-                repasteAsTextOcclusion,
               ),
           ),
       )

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorRepasteAsTextOverlay.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorRepasteAsTextOverlay.kt
@@ -37,10 +37,8 @@ import co.typie.ui.theme.AppTheme
 import co.typie.ui.theme.shadow
 import kotlinx.coroutines.launch
 
-internal val RepasteAsTextOverlayHeight = 40.dp
-
 private val RepasteAsTextOverlayShape = AppShapes.rounded(AppShapes.full)
-private val RepasteAsTextOverlayBottomGap = 12.dp
+private val RepasteAsTextOverlayTopGap = 12.dp
 private val RepasteAsTextOverlayEasing = CubicBezierEasing(0.215f, 0.61f, 0.355f, 1f)
 private const val RepasteAsTextOverlayAnimationMillis = 150
 
@@ -64,7 +62,7 @@ internal fun EditorRepasteAsTextOverlay(
       ) +
         scaleIn(
           initialScale = 0.96f,
-          transformOrigin = TransformOrigin(0.5f, 1f),
+          transformOrigin = TransformOrigin(0.5f, 0f),
           animationSpec =
             tween(
               durationMillis = RepasteAsTextOverlayAnimationMillis,
@@ -81,7 +79,7 @@ internal fun EditorRepasteAsTextOverlay(
       ) +
         scaleOut(
           targetScale = 0.96f,
-          transformOrigin = TransformOrigin(0.5f, 1f),
+          transformOrigin = TransformOrigin(0.5f, 0f),
           animationSpec =
             tween(
               durationMillis = RepasteAsTextOverlayAnimationMillis,
@@ -93,8 +91,8 @@ internal fun EditorRepasteAsTextOverlay(
     Box(
       modifier =
         Modifier.fillMaxSize()
-          .padding(bottom = visibleArea.bottomOcclusion.dp + RepasteAsTextOverlayBottomGap),
-      contentAlignment = Alignment.BottomCenter,
+          .padding(top = visibleArea.visibleViewportTop.dp + RepasteAsTextOverlayTopGap),
+      contentAlignment = Alignment.TopCenter,
     ) {
       Row(
         modifier =

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/FakeFfiEditor.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/FakeFfiEditor.kt
@@ -34,8 +34,6 @@ import co.typie.editor.ffi.Size
 import co.typie.editor.ffi.StablePosition
 import co.typie.editor.ffi.StablePositionBinding
 import co.typie.editor.ffi.StableSelection
-import co.typie.editor.ffi.StyleInfo
-import co.typie.editor.ffi.StyleRefValue
 import co.typie.editor.ffi.TableOverlay
 import co.typie.editor.ffi.TrackedRange
 import co.typie.editor.ffi.TrackedRangeEndpoints
@@ -112,12 +110,6 @@ internal class FakeFfiEditor(
 
   override fun blockState(): BlockState = blockStateProvider()
 
-  override fun styleEntries(): List<StyleInfo> = emptyList()
-
-  override fun appliedStyle(): Tri<StyleRefValue> = Tri.Absent
-
-  override fun styleDivergence(): Boolean = false
-
   override fun characterCounts(): CharacterCounts = characterCountsProvider()
 
   override fun copySelection(): ClipboardPayload? = null
@@ -168,6 +160,8 @@ internal class FakeFfiEditor(
   override fun detachSurface(page: Int) {
     attached -= page
   }
+
+  override fun invalidateSurface(page: Int) = Unit
 
   override fun resizeSurface(page: Int, width: Double, height: Double, scaleFactor: Double) = Unit
 

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorContextMenuOverlayDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorContextMenuOverlayDesktopTest.kt
@@ -23,6 +23,7 @@ import co.typie.ui.theme.LocalThemeMode
 import co.typie.ui.theme.ResolvedThemeMode
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -118,6 +119,47 @@ class EditorContextMenuOverlayDesktopTest {
     }
   }
 
+  @Test
+  fun repasteOverlayShowsWithoutCursorWhenVisible() = runComposeUiTest {
+    val fake = FakeFfiEditor()
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val editor = Editor(fake, scope)
+    try {
+      setRepasteContent(editor)
+
+      waitForIdle()
+      assertEquals(1, onAllNodesWithText("서식 없이 다시 붙여넣기").fetchSemanticsNodes().size)
+    } finally {
+      scope.cancel()
+      editor.dispose()
+    }
+  }
+
+  @Test
+  fun repasteOverlayStaysNearTopWhenBottomIsOccluded() = runComposeUiTest {
+    val fake = FakeFfiEditor()
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val editor = Editor(fake, scope)
+    try {
+      setRepasteContent(
+        editor = editor,
+        visibleArea =
+          EditorVisibleArea(
+            viewport = Size(width = 400f, height = 700f),
+            topInset = 24f,
+            bottomOcclusionInset = 280f,
+          ),
+      )
+
+      waitForIdle()
+      val top = onNodeWithText("서식 없이 다시 붙여넣기").fetchSemanticsNode().boundsInRoot.top
+      assertTrue(top < 120f, "expected top placement, got y=$top")
+    } finally {
+      scope.cancel()
+      editor.dispose()
+    }
+  }
+
   private fun androidx.compose.ui.test.ComposeUiTest.setMenuContent(
     showCopyCutActions: Boolean = true,
     onCopy: () -> Unit = {},
@@ -155,7 +197,10 @@ class EditorContextMenuOverlayDesktopTest {
     }
   }
 
-  private fun androidx.compose.ui.test.ComposeUiTest.setRepasteContent(editor: Editor) {
+  private fun androidx.compose.ui.test.ComposeUiTest.setRepasteContent(
+    editor: Editor,
+    visibleArea: EditorVisibleArea = EditorVisibleArea(viewport = Size(width = 400f, height = 700f)),
+  ) {
     setContent {
       CompositionLocalProvider(
         LocalAppColors provides LightColors,
@@ -164,7 +209,7 @@ class EditorContextMenuOverlayDesktopTest {
       ) {
         EditorRepasteAsTextOverlay(
           editor = editor,
-          visibleArea = EditorVisibleArea(viewport = Size(width = 400f, height = 700f)),
+          visibleArea = visibleArea,
           visible = true,
           bringIntoViewRequests = EditorBringIntoViewRequests(),
         )

--- a/apps/website/src/lib/editor-ffi/components/RepasteAsText.svelte
+++ b/apps/website/src/lib/editor-ffi/components/RepasteAsText.svelte
@@ -9,16 +9,24 @@
   const { editor } = getEditorContext();
   const viewportOverlay = getViewportOverlayContext();
 
-  let show = $derived(editor !== undefined && !editor.readOnly && editor.lastHistoryTag?.type === 'paste_html');
+  let show = $derived(
+    editor !== undefined &&
+      !editor.readOnly &&
+      editor.focused &&
+      editor.selection !== undefined &&
+      editor.lastHistoryTag?.type === 'paste_html',
+  );
 
   const point = $derived.by(() => {
-    const cursor = editor?.cursor;
-    if (!show || !editor || !cursor) {
+    if (!show || !editor) {
       return null;
     }
 
     void viewportOverlay.change;
-    const rect = pageRectToClientRect(editor, { page_idx: cursor.page_idx, rect: cursor.caret });
+    const anchor = editor.cursor ? { page_idx: editor.cursor.page_idx, rect: editor.cursor.caret } : editor.selectionHeadRect();
+    if (!anchor) return null;
+
+    const rect = pageRectToClientRect(editor, anchor);
     if (!rect) return null;
 
     return { x: rect.left, y: rect.bottom + 4 };


### PR DESCRIPTION
- 기존: cursor 있을 때 보임
- 새 조건: focus & selection & !locked 일 때 보임
- 앱에서는 repasteAsText 오버레이를 화면 위쪽에 배치하며 이제 visible area에 간섭하지 않음