### PR TITLE
새 undoable record가 last_tag를 invalidate

### DIFF
--- a/crates/editor-core/src/editor.rs
+++ b/crates/editor-core/src/editor.rs
@@ -978,6 +978,7 @@ impl Editor {
         let undoable = !recorded.is_empty() || transient_fields_changed(&self.state, &state);
 
         match meta.history {
+            HistoryMeta::Skip if undoable => self.undo_history.invalidate_last_tag(),
             HistoryMeta::Skip => self.undo_history.clear_last_tag(),
             HistoryMeta::Record if undoable => self.undo_history.record(
                 UndoEntry {
@@ -1407,7 +1408,7 @@ impl Editor {
                 let restored = f.resolve(&ctx)?;
                 Some(restored.normalize(&view).unwrap_or(restored))
             });
-            self.undo_history.clear_last_tag();
+            self.undo_history.invalidate_last_tag();
         }
         self.state = next;
         self.pending_ops.extend(applied_ops);

--- a/crates/editor-core/src/handle/clipboard.rs
+++ b/crates/editor-core/src/handle/clipboard.rs
@@ -1359,6 +1359,65 @@ mod tests {
     }
 
     #[test]
+    fn repaste_as_text_does_not_revive_after_selection_change_then_undo() {
+        let (s_source, ..) = state! {
+            doc { root { p1: paragraph { text("hello") } } }
+            selection: (p1, 0) -> (p1, 5)
+        };
+        let payload = Slice::extract(&s_source).unwrap().to_payload();
+
+        let (s_target, p2) = state! {
+            doc { root { p2: paragraph { text("Hi") } } }
+            selection: (p2, 1)
+        };
+        let mut editor = Editor::new_test(s_target);
+
+        editor.apply(Message::Clipboard {
+            op: ClipboardOp::Paste {
+                html: Some(payload.html.clone()),
+                text: payload.text.clone(),
+            },
+        });
+        editor.apply(Message::Selection {
+            op: SelectionOp::Set {
+                selection: editor_state::Selection::collapsed(editor_state::Position::new(p2, 0)),
+            },
+        });
+        assert!(
+            editor.last_history_tag().is_none(),
+            "selection movement invalidates the first paste"
+        );
+
+        editor.apply(Message::Clipboard {
+            op: ClipboardOp::Paste {
+                html: Some(payload.html),
+                text: payload.text,
+            },
+        });
+        assert!(
+            matches!(
+                editor.last_history_tag(),
+                Some(HistoryTag::PasteHtml { .. })
+            ),
+            "second paste exposes a fresh repaste affordance"
+        );
+
+        editor.apply(Message::History {
+            op: HistoryOp::Undo,
+        });
+        assert!(
+            editor.last_history_tag().is_none(),
+            "undoing the second paste must not revive the invalidated first paste"
+        );
+
+        let before = editor.state().clone();
+        editor.apply(Message::Clipboard {
+            op: ClipboardOp::RepasteAsText,
+        });
+        editor_state::assert_state_eq!(editor.state(), &before);
+    }
+
+    #[test]
     fn repaste_as_text_expires_after_undo() {
         let (s_source, ..) = state! {
             doc { root { p1: paragraph { text("hello") } } }

--- a/crates/editor-state/src/undo.rs
+++ b/crates/editor-state/src/undo.rs
@@ -113,6 +113,23 @@ impl UndoHistory {
         }
     }
 
+    pub fn invalidate_last_tag(&mut self) {
+        let mut changed = false;
+        if let Some(entry) = self.undos.last_mut()
+            && entry.tag.is_some()
+        {
+            entry.tag = None;
+            changed = true;
+        }
+        if self.last_tag.is_some() {
+            self.last_tag = None;
+            changed = true;
+        }
+        if changed {
+            self.bump_last_tag_revision();
+        }
+    }
+
     pub fn sync_last_tag_from_top(&mut self) {
         let last_tag = self.undos.last().and_then(|e| e.tag.clone());
         let should_bump = self.last_tag != last_tag || last_tag.is_some();
@@ -155,6 +172,7 @@ impl UndoHistory {
                 .ops
                 .extend(entry.ops);
         } else {
+            self.invalidate_last_tag();
             self.undos.push(entry);
         }
         self.last_push = Some(now);
@@ -498,7 +516,7 @@ mod tests {
     }
 
     #[test]
-    fn last_tag_tracks_record_and_syncs_on_undo_redo() {
+    fn last_tag_tracks_record_invalidates_previous_tag_and_syncs_on_undo_redo() {
         let mut state = ProjectedState::empty();
         let mut history = UndoHistory::new(Duration::from_secs(0));
 
@@ -539,10 +557,9 @@ mod tests {
         );
 
         history.undo(&mut state, TransientState::default());
-        assert_eq!(
-            history.last_tag(),
-            Some(&HistoryTag::AutoReplacement),
-            "undo syncs last_tag to the new (tagged) top"
+        assert!(
+            history.last_tag().is_none(),
+            "new undoable record invalidates the previous entry's tag"
         );
 
         history.redo(&mut state, TransientState::default());


### PR DESCRIPTION
- 붙여넣기 -> 이동 -> 붙여넣기 -> undo가 엉뚱한 위치에서 첫 붙여넣기의 repasteAsText를 할 수 있게 되는 버그를 해결
- 텍스트 대치의 취소도 대치 직후에만 가능하도록 함