### PR TITLE
move_node child slot 인덱스 처리 수정

### DIFF
--- a/crates/editor-commands/src/commands/lift_first_paragraph.rs
+++ b/crates/editor-commands/src/commands/lift_first_paragraph.rs
@@ -235,6 +235,38 @@ mod tests {
     }
 
     #[test]
+    fn lift_after_image_keeps_paragraph_in_wrapper_slot() {
+        let (initial, ..) = state! {
+            doc {
+                root {
+                    image
+                    blockquote {
+                        p1: paragraph { text("A") }
+                        paragraph { text("B") }
+                    }
+                    paragraph { text("C") }
+                }
+            }
+            selection: (p1, 0)
+        };
+        let (actual, ..) = transact!(initial, |tr| lift_first_paragraph(&mut tr));
+        let (expected, ..) = state! {
+            doc {
+                root {
+                    image
+                    p1: paragraph { text("A") }
+                    blockquote {
+                        paragraph { text("B") }
+                    }
+                    paragraph { text("C") }
+                }
+            }
+            selection: (p1, 0)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
     fn cursor_on_text_node_at_start() {
         let (initial, ..) = state! {
             doc {

--- a/crates/editor-commands/src/commands/unwrap_blockquote.rs
+++ b/crates/editor-commands/src/commands/unwrap_blockquote.rs
@@ -112,6 +112,36 @@ mod tests {
     }
 
     #[test]
+    fn unwrap_blockquote_after_image_keeps_children_in_wrapper_slot() {
+        let (initial, bq, ..) = state! {
+            doc {
+                root {
+                    image
+                    bq: blockquote {
+                        p1: paragraph { text("a") }
+                        paragraph { text("b") }
+                    }
+                    paragraph { text("c") }
+                }
+            }
+            selection: (bq, 0)
+        };
+        let (actual, ..) = transact!(initial, |tr| unwrap_blockquote(&mut tr, bq));
+        let (expected, ..) = state! {
+            doc {
+                root {
+                    image
+                    p1: paragraph { text("a") }
+                    paragraph { text("b") }
+                    paragraph { text("c") }
+                }
+            }
+            selection: (p1, 0)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
     fn unwrap_non_blockquote_returns_false() {
         let (initial, p, ..) = state! {
             doc {

--- a/crates/editor-commands/src/commands/unwrap_fold.rs
+++ b/crates/editor-commands/src/commands/unwrap_fold.rs
@@ -2,7 +2,7 @@ use editor_crdt::Dot;
 use editor_model::{ChildView, Node, NodeType, PlainNode, PlainParagraphNode, Subtree};
 use editor_transaction::Transaction;
 
-use crate::helpers::place_caret_at_block_start;
+use crate::helpers::{child_node_type, place_caret_at_block_start};
 use crate::{CommandError, CommandResult};
 
 pub fn unwrap_fold(tr: &mut Transaction, node_id: Dot) -> CommandResult {
@@ -41,7 +41,7 @@ pub fn unwrap_fold(tr: &mut Transaction, node_id: Dot) -> CommandResult {
             .map(|b| (b.id(), b.node_type()))
             .collect();
 
-        let mut new_seq: Vec<NodeType> = parent.child_blocks().map(|b| b.node_type()).collect();
+        let mut new_seq: Vec<NodeType> = parent.children().map(|c| child_node_type(&c)).collect();
         new_seq.remove(fold_index);
         let mut insert_at = fold_index;
         if has_title_text {
@@ -76,8 +76,10 @@ pub fn unwrap_fold(tr: &mut Transaction, node_id: Dot) -> CommandResult {
             let new_para = {
                 let view = tr.view();
                 view.node(parent_id)
-                    .and_then(|p| p.child_blocks().nth(next_index))
-                    .map(|b| b.id())
+                    .and_then(|p| match p.child_at(next_index) {
+                        Some(ChildView::Block(block)) => Some(block.id()),
+                        _ => None,
+                    })
                     .ok_or(CommandError::NodeNotFound(parent_id))?
             };
             if !title_text.is_empty() {
@@ -100,8 +102,10 @@ pub fn unwrap_fold(tr: &mut Transaction, node_id: Dot) -> CommandResult {
             // stale; re-resolve the first lifted block at the fold's old slot.
             let view = tr.view();
             view.node(parent_id)
-                .and_then(|p| p.child_blocks().nth(fold_index))
-                .map(|b| b.id())
+                .and_then(|p| match p.child_at(fold_index) {
+                    Some(ChildView::Block(block)) => Some(block.id()),
+                    _ => None,
+                })
                 .ok_or_else(|| CommandError::Corrupted("lifted content missing".into()))?
         }
     };
@@ -168,6 +172,37 @@ mod tests {
                 root {
                     p1: paragraph { text("body") }
                     paragraph {}
+                }
+            }
+            selection: (p1, 0)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn unwrap_fold_after_image_keeps_content_in_fold_slot() {
+        let (initial, f, ..) = state! {
+            doc {
+                root {
+                    image
+                    f: fold {
+                        fold_title {}
+                        fold_content {
+                            p1: paragraph { text("body") }
+                        }
+                    }
+                    paragraph { text("tail") }
+                }
+            }
+            selection: (f, 0)
+        };
+        let (actual, ..) = transact!(initial, |tr| unwrap_fold(&mut tr, f));
+        let (expected, ..) = state! {
+            doc {
+                root {
+                    image
+                    p1: paragraph { text("body") }
+                    paragraph { text("tail") }
                 }
             }
             selection: (p1, 0)

--- a/crates/editor-commands/src/helpers/deletion.rs
+++ b/crates/editor-commands/src/helpers/deletion.rs
@@ -7,9 +7,9 @@ use editor_state::{Affinity, Position, Selection, State};
 use editor_transaction::{Step, Transaction, fulfill};
 
 use super::{
-    apply_first_text_marker_lift, capture_first_text_marker, find_ancestor_textblock,
-    find_enclosing_paragraph_id, find_lowest_common_ancestor, is_block_container,
-    merge_element_cross_parent, next_sibling, path_from_ancestor,
+    apply_first_text_marker_lift, capture_first_text_marker, child_elem_id,
+    find_ancestor_textblock, find_enclosing_paragraph_id, find_lowest_common_ancestor,
+    is_block_container, merge_element_cross_parent, next_sibling, path_from_ancestor,
 };
 use crate::{CommandError, CommandResult};
 
@@ -960,8 +960,8 @@ fn merge_containers(tr: &mut Transaction, target: Dot, source: Dot) -> Result<()
             let view = tr.state().view();
             view.node(target)
                 .map(|n| {
-                    n.child_blocks()
-                        .filter(|c| c.id().as_op_dot().is_some())
+                    n.children()
+                        .filter(|c| child_elem_id(c).as_op_dot().is_some())
                         .count()
                 })
                 .unwrap_or(0)
@@ -1117,7 +1117,11 @@ fn merge_after_delete(
                                 let from_len = {
                                     let view = tr.state().view();
                                     view.node(from_id)
-                                        .map(|n| n.child_blocks().count())
+                                        .map(|n| {
+                                            n.children()
+                                                .filter(|c| child_elem_id(c).as_op_dot().is_some())
+                                                .count()
+                                        })
                                         .unwrap_or(0)
                                 };
                                 tr.move_node(moved_id, from_id, from_len)?;

--- a/crates/editor-commands/src/helpers/lift.rs
+++ b/crates/editor-commands/src/helpers/lift.rs
@@ -66,7 +66,10 @@ pub(crate) fn lift(
         lifted_id = {
             let view = tr.state().view();
             view.node(wrapper_parent_id)
-                .and_then(|parent| parent.child_blocks().nth(target_index).map(|b| b.id()))
+                .and_then(|parent| match parent.child_at(target_index) {
+                    Some(editor_model::ChildView::Block(block)) => Some(block.id()),
+                    _ => None,
+                })
                 .ok_or_else(|| CommandError::Corrupted("lifted paragraph not found".into()))?
         };
 

--- a/crates/editor-commands/src/helpers/unwrap.rs
+++ b/crates/editor-commands/src/helpers/unwrap.rs
@@ -49,7 +49,10 @@ pub(crate) fn unwrap_block_wrapper(tr: &mut Transaction, node_id: Dot) -> Comman
     let first_lifted = {
         let view = tr.state().view();
         view.node(parent_id)
-            .and_then(|parent| parent.child_blocks().nth(node_index).map(|b| b.id()))
+            .and_then(|parent| match parent.child_at(node_index) {
+                Some(editor_model::ChildView::Block(block)) => Some(block.id()),
+                _ => None,
+            })
     };
     if let Some(block_id) = first_lifted {
         place_caret_at_block_start(tr, block_id)?;

--- a/crates/editor-core/src/handle/key.rs
+++ b/crates/editor-core/src/handle/key.rs
@@ -246,6 +246,68 @@ mod tests {
     }
 
     #[test]
+    fn enter_in_empty_blockquote_after_image_before_text_paragraph() {
+        let (state, ..) = state! {
+            doc {
+                root [text_color("black".to_string()), background_color("none".to_string())] {
+                    image
+                    blockquote {
+                        p1: paragraph {}
+                    }
+                    paragraph {
+                        text("1")
+                    }
+                }
+            }
+            selection: (p1, 0)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.apply(key(Key::Enter));
+        let (expected, ..) = state! {
+            doc {
+                root [text_color("black".to_string()), background_color("none".to_string())] {
+                    image
+                    p1: paragraph {}
+                    paragraph {
+                        text("1")
+                    }
+                }
+            }
+            selection: (p1, 0)
+        };
+        assert_state_eq!(editor.state(), &expected);
+    }
+
+    #[test]
+    fn enter_in_empty_blockquote_after_image_before_empty_paragraph() {
+        let (state, ..) = state! {
+            doc {
+                root [text_color("black".to_string()), background_color("none".to_string())] {
+                    image
+                    blockquote {
+                        p1: paragraph {}
+                    }
+                    paragraph {}
+                }
+            }
+            selection: (p1, 0)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.apply(key(Key::Enter));
+        let (expected, ..) = state! {
+            doc {
+                root [text_color("black".to_string()), background_color("none".to_string())] {
+                    image
+                    p1: paragraph {}
+                    paragraph {}
+                }
+            }
+            selection: (p1, 0)
+        };
+        assert_state_eq!(editor.state(), &expected);
+    }
+
+    #[test]
     fn shift_enter_inserts_hard_break() {
         let (state, ..) = state! {
             doc { root { p1: paragraph { text("hello") } } }

--- a/crates/editor-transaction/src/dissolve.rs
+++ b/crates/editor-transaction/src/dissolve.rs
@@ -23,7 +23,7 @@ pub fn dissolve(node: &NodeView) -> Vec<Step> {
         None => return vec![],
     };
 
-    let node_index = match parent.child_blocks().position(|b| b.id() == node.id()) {
+    let node_index = match node.index() {
         Some(i) => i,
         None => return vec![],
     };

--- a/crates/editor-transaction/src/revert.rs
+++ b/crates/editor-transaction/src/revert.rs
@@ -50,8 +50,8 @@ fn current_children(tr: &Transaction, id: Dot) -> Vec<Dot> {
 }
 
 fn reconcile_children(tr: &mut Transaction, target: &State, id: Dot) -> Result<(), StepError> {
-    let target_ids = target_children(target, id);
-    let target_set: HashSet<Dot> = target_ids.iter().copied().collect();
+    let target_children = target_children(target, id);
+    let target_set: HashSet<Dot> = target_children.iter().copied().collect();
 
     for cid in current_children(tr, id) {
         if !target_set.contains(&cid) {
@@ -59,17 +59,28 @@ fn reconcile_children(tr: &mut Transaction, target: &State, id: Dot) -> Result<(
         }
     }
 
-    for (index, cid) in target_ids.iter().enumerate() {
-        let cid = *cid;
+    for cid in target_children {
+        let target_index = target
+            .view()
+            .node(cid)
+            .and_then(|node| node.index())
+            .ok_or(StepError::NodeNotFound(cid))?;
         let live = tr.view().node(cid).is_some();
         if live {
-            let cur = current_children(tr, id);
-            if cur.iter().position(|x| *x == cid) != Some(index) {
-                tr.move_node(cid, id, index)?;
+            let current_location = {
+                let view = tr.view();
+                view.node(cid).and_then(|node| {
+                    let parent = node.parent()?;
+                    let index = node.index()?;
+                    Some((parent.id(), index))
+                })
+            };
+            if current_location != Some((id, target_index)) {
+                tr.move_node(cid, id, target_index)?;
             }
             reconcile_node(tr, target, cid)?;
         } else {
-            revive_node(tr, target, cid, id, index)?;
+            revive_node(tr, target, cid, id, target_index)?;
         }
     }
     Ok(())

--- a/crates/editor-transaction/src/steps/move_node.rs
+++ b/crates/editor-transaction/src/steps/move_node.rs
@@ -40,7 +40,7 @@ pub(crate) fn apply_to(
         batched.apply(op)?;
     }
 
-    let pos = support::block_seq_insert_pos(&batched.projected, new_parent, new_index)?;
+    let pos = support::child_seq_insert_pos(&batched.projected, new_parent, new_index)?;
     let parents = support::self_inclusive_parents(&batched.projected, new_parent)
         .ok_or(StepError::NodeNotFound(new_parent))?;
     let mut seq_pos = pos;

--- a/crates/editor-transaction/src/steps/support.rs
+++ b/crates/editor-transaction/src/steps/support.rs
@@ -17,14 +17,9 @@ pub(crate) fn children_count(ps: &ProjectedState, block: Dot) -> Option<usize> {
     ps.child_count(block)
 }
 
-pub(crate) fn child_block_ids(ps: &ProjectedState, block: Dot) -> Vec<Dot> {
-    ps.child_block_dots(block)
-}
-
 /// All children of `block` (chars, atom leaves, and nested blocks) as dots,
 /// in order. Block-level atoms (Image/HR/…) project as Child::Leaf, so this is
-/// the addressing the command layer uses (full child-slot index = offset),
-/// distinct from `child_block_ids` which is blocks-only.
+/// the addressing the command layer uses (full child-slot index = offset).
 pub(crate) fn child_elem_ids(ps: &ProjectedState, block: Dot) -> Vec<Dot> {
     ps.child_elem_dots(block)
 }
@@ -99,32 +94,6 @@ pub(crate) fn seq_insert_pos(ps: &ProjectedState, block: Dot, offset: usize) -> 
 
 pub(crate) fn subtree_dots(ps: &ProjectedState, block: Dot) -> Option<Vec<Dot>> {
     ps.is_block(block).then(|| ps.subtree_real_dots(block))
-}
-
-/// Seq position at which to insert a new block as the `block_index`-th block
-/// child of `parent`, accounting for nested subtrees (insert after the entire
-/// preceding sibling subtree, not just its token).
-pub(crate) fn block_seq_insert_pos(
-    ps: &ProjectedState,
-    parent: Dot,
-    block_index: usize,
-) -> Result<usize, StepError> {
-    let children = child_block_ids(ps, parent);
-    if block_index > children.len() {
-        return Err(StepError::IndexOutOfBounds {
-            parent,
-            index: block_index,
-            len: children.len(),
-        });
-    }
-    if block_index == 0 {
-        return seq_insert_pos(ps, parent, 0).ok_or(StepError::NodeNotFound(parent));
-    }
-    let prev = children[block_index - 1];
-    let max = ps
-        .subtree_max_seq_pos(prev)
-        .ok_or(StepError::NodeNotFound(prev))?;
-    Ok(max + 1)
 }
 
 pub(crate) fn insert_text_ops(

--- a/crates/editor-transaction/src/transaction.rs
+++ b/crates/editor-transaction/src/transaction.rs
@@ -177,6 +177,9 @@ impl Transaction {
         })
     }
 
+    /// Moves a block node to `new_parent` at `new_index`, counted in the same
+    /// full child-slot index domain as `insert_subtree` and `remove_subtree`.
+    /// Leaf siblings such as image atoms are included in this index domain.
     pub fn move_node(
         &mut self,
         block: Dot,
@@ -187,7 +190,7 @@ impl Transaction {
             let ps = &self.state.projected;
             let parent = ps.parent_of(block).ok_or(StepError::NodeNotFound(block))?;
             let index = ps
-                .child_block_dots(parent)
+                .child_elem_dots(parent)
                 .iter()
                 .position(|d| *d == block)
                 .ok_or(StepError::NodeNotFound(block))?;

--- a/crates/editor-transaction/tests/transaction_acceptance.rs
+++ b/crates/editor-transaction/tests/transaction_acceptance.rs
@@ -30,6 +30,19 @@ fn root_blocks(state: &State) -> Vec<(NodeType, String)> {
         .collect()
 }
 
+fn root_child_labels(state: &State) -> Vec<String> {
+    state
+        .view()
+        .root()
+        .unwrap()
+        .children()
+        .map(|child| match child {
+            ChildView::Block(block) => block.inline_text(),
+            ChildView::Leaf(leaf) => format!("{:?}", leaf.node_type()),
+        })
+        .collect()
+}
+
 fn snapshot(state: &State) -> Vec<(usize, NodeType, String)> {
     fn walk(nv: &NodeView, depth: usize, out: &mut Vec<(usize, NodeType, String)>) {
         out.push((depth, nv.node_type(), nv.inline_text()));
@@ -451,6 +464,29 @@ mod tests {
         };
         let restored = back.apply(&moved).unwrap().state;
         assert_eq!(snapshot(&restored), before);
+    }
+
+    #[test]
+    fn move_node_uses_full_child_slot_index() {
+        let (state, _p1, p2) = state! {
+            doc {
+                root {
+                    image
+                    p1: paragraph { text("a") }
+                    p2: paragraph { text("b") }
+                }
+            }
+            selection: (p1, 0)
+        };
+        let root = root_id(&state);
+        let mut tr = Transaction::new(&state);
+        tr.move_node(p2, root, 1).unwrap();
+        let (moved, ..) = tr.commit();
+
+        assert_eq!(
+            root_child_labels(&moved),
+            vec!["Image".to_string(), "b".to_string(), "a".to_string()]
+        );
     }
 
     #[test]


### PR DESCRIPTION
- `move_node`의 insert index를 block-only index가 아니라 full child-slot index로 해석하도록 수정
- 이미지 같은 block-level atom 뒤에서 `lift_first`, `unwrap`, `unwrap_fold`, revert/dissolve가 잘못된 위치에 노드를 삽입하던 문제 수정