### PR TITLE
insert_slice_at_position이 synthetic block materialize

### DIFF
--- a/crates/editor-commands/src/commands/insert_slice.rs
+++ b/crates/editor-commands/src/commands/insert_slice.rs
@@ -452,4 +452,53 @@ mod tests {
         };
         assert_state_eq!(&actual, &expected);
     }
+
+    #[test]
+    fn insert_image_slice_materializes_synthetic_trailing_paragraph() {
+        use editor_model::PlainImageNode;
+        use editor_state::{Position, Selection};
+
+        let (initial, ..) = state! {
+            doc { root { image } }
+            selection: none
+        };
+        let synth_p = {
+            let view = initial.view();
+            let root = view.root().unwrap();
+            root.child_blocks()
+                .find(|b| b.node_type() == NodeType::Paragraph)
+                .map(|b| b.id())
+                .expect("synthetic trailing paragraph")
+        };
+        assert!(
+            synth_p.is_synthetic(),
+            "trailing paragraph must be synthetic"
+        );
+
+        let slice = Slice {
+            fragment: Fragment {
+                node: PlainNode::Root(PlainRootNode::default()),
+                modifiers: vec![],
+                children: vec![Fragment::leaf(PlainNode::Image(PlainImageNode::default()))],
+            },
+            open_start: 0,
+            open_end: 0,
+        };
+        let mut tr = Transaction::new(&initial);
+        tr.set_selection(Some(Selection::collapsed(Position::new(synth_p, 0))))
+            .unwrap();
+
+        assert!(insert_slice(&mut tr, slice).unwrap());
+        let (actual, ..) = tr.commit();
+
+        let (expected, ..) = state! {
+            doc { r: root {
+                image
+                image
+                paragraph {}
+            } }
+            selection: (r, 1, >) -> (r, 2, <)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
 }

--- a/crates/editor-commands/src/commands/insert_slice_at.rs
+++ b/crates/editor-commands/src/commands/insert_slice_at.rs
@@ -322,4 +322,52 @@ mod tests {
             )
         );
     }
+
+    #[test]
+    fn insert_slice_at_image_materializes_synthetic_trailing_paragraph() {
+        let (initial, ..) = state! {
+            doc { root { image } }
+            selection: none
+        };
+        let root = initial.view().root().unwrap().id();
+        let synth_p = {
+            let view = initial.view();
+            let root = view.root().unwrap();
+            root.child_blocks()
+                .find(|b| b.node_type() == NodeType::Paragraph)
+                .map(|b| b.id())
+                .expect("synthetic trailing paragraph")
+        };
+        assert!(
+            synth_p.is_synthetic(),
+            "trailing paragraph must be synthetic"
+        );
+
+        let mut tr = Transaction::new(&initial);
+        let inserted_selection = insert_slice_at(&mut tr, Position::new(synth_p, 0), image_slice())
+            .expect("insert succeeds")
+            .expect("slice inserted");
+        let (actual, ..) = tr.commit();
+
+        let view = actual.view();
+        assert_eq!(
+            kinds(&view, root),
+            vec![NodeType::Image, NodeType::Image, NodeType::Paragraph]
+        );
+        assert_eq!(
+            inserted_selection,
+            Selection::new(
+                Position {
+                    node: root,
+                    offset: 1,
+                    affinity: Affinity::Downstream,
+                },
+                Position {
+                    node: root,
+                    offset: 2,
+                    affinity: Affinity::Upstream,
+                },
+            )
+        );
+    }
 }

--- a/crates/editor-commands/src/commands/join_paragraph_backward.rs
+++ b/crates/editor-commands/src/commands/join_paragraph_backward.rs
@@ -22,6 +22,9 @@ pub fn join_paragraph_backward(tr: &mut Transaction) -> CommandResult {
         if node.node_type() != NodeType::Paragraph {
             return Ok(false);
         }
+        if node.dot().is_none() {
+            return Ok(false);
+        }
         if pos.offset > 0 {
             return Ok(false);
         }

--- a/crates/editor-commands/src/helpers/insertion.rs
+++ b/crates/editor-commands/src/helpers/insertion.rs
@@ -168,31 +168,28 @@ fn apply_inline_modifiers(
     Ok(())
 }
 
-/// If a collapsed caret sits inside a projection-synthesized scaffold block (one
-/// with no authored op — e.g. the mandatory trailing paragraph the Root schema
-/// derives after a block-level unit like a horizontal rule), that block has no
-/// CRDT identity to parent inserted content to, so an insert against it fails
-/// with `OffsetOutOfBounds`. Materialize the synthetic block — and any synthetic
+/// If a position targets a projection-synthesized scaffold block (one with no
+/// authored op — e.g. the mandatory trailing paragraph the Root schema derives
+/// after a block-level unit like a horizontal rule), that block has no CRDT
+/// identity to parent inserted content to, so an insert against it fails with
+/// `OffsetOutOfBounds`. Materialize the synthetic block — and any synthetic
 /// ancestors up to the nearest real (or root) container — into real blocks and
-/// move the caret into the new real block, so the subsequent insert has a real
-/// target. No-op for a real caret block, the root, or a non-collapsed selection.
-pub(crate) fn materialize_caret_block(tr: &mut Transaction) -> Result<(), CommandError> {
-    let Some(selection) = tr.selection() else {
-        return Ok(());
-    };
-    if selection.anchor != selection.head {
-        return Ok(());
-    }
-    let caret = selection.head.node;
-    if caret.as_op_dot().is_some() || caret == Dot::ROOT {
-        return Ok(());
+/// return the equivalent position in the new real block. No-op for a real block
+/// or the root.
+pub(crate) fn materialize_position_block(
+    tr: &mut Transaction,
+    position: Position,
+) -> Result<Position, CommandError> {
+    let block = position.node;
+    if block.as_op_dot().is_some() || block == Dot::ROOT {
+        return Ok(position);
     }
 
     // Walk up to the nearest real (or root) ancestor, recording the synthetic
     // chain (deepest-first) so it can be rebuilt as real nested blocks.
     let (anchor_id, anchor_slot, chain) = {
         let view = tr.state().view();
-        let mut node = view.node(caret).ok_or(CommandError::NodeNotFound(caret))?;
+        let mut node = view.node(block).ok_or(CommandError::NodeNotFound(block))?;
         let mut chain = vec![node.node().to_plain()];
         loop {
             let parent = node.parent().ok_or(CommandError::NoParent(node.id()))?;
@@ -219,7 +216,7 @@ pub(crate) fn materialize_caret_block(tr: &mut Transaction) -> Result<(), Comman
 
     tr.insert_subtree(anchor_id, anchor_slot, subtree)?;
 
-    let new_caret = {
+    let materialized_block = {
         let view = tr.state().view();
         let mut cur = match view.node(anchor_id).and_then(|p| p.child_at(anchor_slot)) {
             Some(ChildView::Block(b)) => b.id(),
@@ -234,8 +231,30 @@ pub(crate) fn materialize_caret_block(tr: &mut Transaction) -> Result<(), Comman
         cur
     };
 
+    Ok(Position {
+        node: materialized_block,
+        ..position
+    })
+}
+
+/// Materialize the synthetic block containing a collapsed caret and move the
+/// caret into the new real block. No-op for a real caret block, the root, or a
+/// non-collapsed selection.
+pub(crate) fn materialize_caret_block(tr: &mut Transaction) -> Result<(), CommandError> {
+    let Some(selection) = tr.selection() else {
+        return Ok(());
+    };
+    if selection.anchor != selection.head {
+        return Ok(());
+    }
+    let caret = selection.head;
+    let materialized = materialize_position_block(tr, caret)?;
+    if materialized.node == caret.node {
+        return Ok(());
+    }
+
     tr.set_selection(Some(Selection::collapsed(Position {
-        node: new_caret,
+        node: materialized.node,
         offset: 0,
         affinity: Affinity::Downstream,
     })))?;

--- a/crates/editor-commands/src/helpers/slice.rs
+++ b/crates/editor-commands/src/helpers/slice.rs
@@ -8,7 +8,7 @@ use editor_transaction::{Transaction, fulfill};
 
 use super::{
     child_node_type, find_ancestor_textblock, insert_hard_break_at_caret, insert_tab_at_caret,
-    insert_text_at_caret,
+    insert_text_at_caret, materialize_position_block,
 };
 use crate::{CommandError, CommandResult};
 
@@ -21,6 +21,7 @@ pub(crate) fn insert_slice_at_position(
         return Ok(None);
     }
 
+    let position = materialize_position_block(tr, position)?;
     let in_textblock = position_in_textblock(tr, &position);
     if in_textblock {
         if let Some(fragments) =


### PR DESCRIPTION
- slice insertion 시 materialize
- join_paragraph_backward가 synthetic paragraph를 타겟으로 보지 않게 guard (런타임에서 일어나지 않지만..)