### PR TITLE
ResolvedSelection::contains_leaf_slot

### DIFF
--- a/crates/editor-clipboard/src/slice.rs
+++ b/crates/editor-clipboard/src/slice.rs
@@ -216,23 +216,13 @@ fn build_fragment(state: &State, nv: &NodeView, rs: &ResolvedSelection) -> Fragm
     let to_block_path = &to.path()[..to.path().len().saturating_sub(1)];
 
     let children: Vec<ChildView> = nv.children().collect();
-    let lo = if nv.id() == from.node() {
-        from.offset()
-    } else {
-        0
-    };
-    let hi = if nv.id() == to.node() {
-        to.offset()
-    } else {
-        children.len()
-    };
 
     let mut out: Vec<Fragment> = Vec::new();
     let mut run: Option<RunAccum> = None;
     for (i, c) in children.iter().enumerate() {
         match c {
             ChildView::Leaf(l) => {
-                if i < lo || i >= hi {
+                if !rs.contains_leaf_slot(nv, i) {
                     flush_run(&mut run, &mut out);
                     continue;
                 }
@@ -463,6 +453,37 @@ mod tests {
         assert!(matches!(
             slice.fragment.children[0].node,
             editor_model::PlainNode::Image(_)
+        ));
+    }
+
+    #[test]
+    fn extract_range_between_paragraphs_excludes_image_before_selection() {
+        let (s, ..) = state! {
+            doc { root {
+                image
+                p1: paragraph { text("asd") }
+                image
+                p2: paragraph {}
+            } }
+            selection: (p1, 3) -> (p2, 0)
+        };
+        let slice = Slice::extract(&s).expect("non-collapsed");
+
+        assert_eq!(slice.open_start, 2);
+        assert_eq!(slice.open_end, 2);
+        assert!(matches!(slice.fragment.node, PlainNode::Root(_)));
+        assert_eq!(slice.fragment.children.len(), 3);
+        assert!(matches!(
+            slice.fragment.children[0].node,
+            PlainNode::Paragraph(_)
+        ));
+        assert!(matches!(
+            slice.fragment.children[1].node,
+            PlainNode::Image(_)
+        ));
+        assert!(matches!(
+            slice.fragment.children[2].node,
+            PlainNode::Paragraph(_)
         ));
     }
 

--- a/crates/editor-core/src/block_state.rs
+++ b/crates/editor-core/src/block_state.rs
@@ -1,7 +1,7 @@
 use editor_crdt::Dot;
 use editor_macros::ffi;
 use editor_model::{ChildView, DocView, NodeView, PlainNode, Schema};
-use editor_state::{Affinity, Position, ResolvedSelection, Selection, State};
+use editor_state::{ResolvedSelection, Selection, State};
 use serde::{Deserialize, Serialize};
 
 #[ffi]
@@ -100,7 +100,6 @@ fn collect_contained(node: &NodeView, rs: &ResolvedSelection, out: &mut Vec<Bloc
     // Descend even when self is wholly contained: nested non-inline children
     // (e.g., paragraphs inside a blockquote) must be enumerated too.
     if rs.intersects_subtree(node) {
-        let view = rs.view();
         for (i, child) in node.children().enumerate() {
             match child {
                 ChildView::Block(b) => collect_contained(&b, rs, out),
@@ -109,23 +108,7 @@ fn collect_contained(node: &NodeView, rs: &ResolvedSelection, out: &mut Vec<Bloc
                     if Schema::node_spec(l.node_type()).inline {
                         continue;
                     }
-                    let (Some(start), Some(end)) = (
-                        Position {
-                            node: node.id(),
-                            offset: i,
-                            affinity: Affinity::Downstream,
-                        }
-                        .resolve(view),
-                        Position {
-                            node: node.id(),
-                            offset: i + 1,
-                            affinity: Affinity::Upstream,
-                        }
-                        .resolve(view),
-                    ) else {
-                        continue;
-                    };
-                    if rs.from() <= &start && &end <= rs.to() {
+                    if rs.contains_leaf_slot(node, i) {
                         out.push(Block {
                             id: l.dot(),
                             node: leaf_node.to_plain(),

--- a/crates/editor-state/src/position.rs
+++ b/crates/editor-state/src/position.rs
@@ -66,11 +66,8 @@ pub fn inline_leaf_dots_in_range(view: &DocView, from: &Position, to: &Position)
     let Some(rs) = Selection::new(*from, *to).resolve(view) else {
         return Vec::new();
     };
-    let lo = rs.from().position();
-    let hi = rs.to().position();
-    let (Some(lo_r), Some(hi_r)) = (lo.resolve(view), hi.resolve(view)) else {
-        return Vec::new();
-    };
+    let from = rs.from().path();
+    let to = rs.to().path();
 
     let mut blocks = Vec::new();
     if let Some(root) = view.root() {
@@ -84,35 +81,11 @@ pub fn inline_leaf_dots_in_range(view: &DocView, from: &Position, to: &Position)
 
     let mut out = Vec::new();
     for block in blocks {
-        let block_id = block.id();
         let mut base: Vec<usize> = block.ancestors().filter_map(|n| n.index()).collect();
         base.reverse();
         for (i, child) in block.children().enumerate() {
             let ChildView::Leaf(l) = child else { continue };
-            let start = ResolvedPosition {
-                view,
-                position: Position::new(block_id, i),
-                path: {
-                    let mut p = base.clone();
-                    p.push(i);
-                    p
-                },
-            };
-            let end = ResolvedPosition {
-                view,
-                position: Position::new(block_id, i + 1),
-                path: {
-                    let mut p = base.clone();
-                    p.push(i + 1);
-                    p
-                },
-            };
-            // Coverage is positional: a leaf is inside the range when its
-            // extent lies within [lo, hi] by path. Comparing full
-            // ResolvedPositions would fold in caret affinity, which drops the
-            // last leaf whenever `hi` sits at a block end with Upstream affinity
-            // (the canonical caret form there) — even though the range covers it.
-            if lo_r.path() <= start.path.as_slice() && end.path.as_slice() <= hi_r.path() {
+            if crate::traversal::leaf_slot_is_covered(i, &base, from, to) {
                 out.push(l.dot());
             }
         }

--- a/crates/editor-state/src/selection.rs
+++ b/crates/editor-state/src/selection.rs
@@ -83,6 +83,13 @@ impl<'a> ResolvedSelection<'a> {
         crate::traversal::contains_subtree(self, node)
     }
 
+    /// Returns whether a direct leaf child slot of `block` is fully covered by
+    /// this selection. The slot is interpreted as the half-open path extent
+    /// `[slot, slot + 1)`, so coverage is independent of endpoint affinity.
+    pub fn contains_leaf_slot(&self, block: &NodeView, slot: usize) -> bool {
+        crate::traversal::contains_leaf_slot(self, block, slot)
+    }
+
     pub fn intersects_subtree(&self, node: &NodeView) -> bool {
         crate::traversal::intersects_subtree(self, node)
     }
@@ -489,6 +496,35 @@ mod tests {
         assert_eq!(
             rs.contains_subtree(&out_node),
             traversal::contains_subtree(&rs, &out_node),
+        );
+    }
+
+    #[test]
+    fn contains_leaf_slot_method_matches_free_fn() {
+        use crate::traversal;
+
+        let (pd, p1, p2) = two_paras();
+        let view = DocView::new(&pd);
+        let rs = Selection::new(Position::new(p1, 1), Position::new(p2, 0))
+            .resolve(&view)
+            .unwrap();
+        let p1_node = view.node(p1).unwrap();
+        let p2_node = view.node(p2).unwrap();
+        let root_node = view.root().unwrap();
+        let block_rs = Selection::new(
+            Position::new(root_node.id(), 0),
+            Position::new(root_node.id(), 1),
+        )
+        .resolve(&view)
+        .unwrap();
+
+        assert!(!rs.contains_leaf_slot(&p1_node, 0));
+        assert!(rs.contains_leaf_slot(&p1_node, 1));
+        assert!(!rs.contains_leaf_slot(&p2_node, 0));
+        assert!(!block_rs.contains_leaf_slot(&root_node, 0));
+        assert_eq!(
+            rs.contains_leaf_slot(&p1_node, 1),
+            traversal::contains_leaf_slot(&rs, &p1_node, 1),
         );
     }
 

--- a/crates/editor-state/src/traversal.rs
+++ b/crates/editor-state/src/traversal.rs
@@ -142,14 +142,7 @@ pub fn leaves_in_block_range<'a>(
     let mut out = Vec::new();
     for (i, child) in block.children().enumerate() {
         if let ChildView::Leaf(l) = child {
-            // A leaf fills the half-open content slot [i, i+1). It is inside the
-            // selection iff its start path >= from and its end path <= to, so the
-            // leaf at the exclusive `to` boundary is not over-collected.
-            let mut start = base.clone();
-            start.push(i);
-            let mut end = base.clone();
-            end.push(i + 1);
-            if from <= start.as_slice() && end.as_slice() <= to {
+            if leaf_slot_is_covered(i, &base, from, to) {
                 out.push((i, l));
             }
         }
@@ -157,7 +150,25 @@ pub fn leaves_in_block_range<'a>(
     out
 }
 
-fn leaf_slot_is_covered(slot: usize, base: &[usize], from: &[usize], to: &[usize]) -> bool {
+pub(crate) fn contains_leaf_slot(rs: &ResolvedSelection, block: &NodeView, slot: usize) -> bool {
+    if !matches!(block.child_at(slot), Some(ChildView::Leaf(_))) {
+        return false;
+    }
+    // A leaf fills the half-open content slot [slot, slot + 1). It is inside the
+    // selection iff its extent lies within [from, to] by path, so the leaf at
+    // the exclusive `to` boundary is not over-collected.
+    let from = rs.from().path();
+    let to = rs.to().path();
+    let base = node_path(block);
+    leaf_slot_is_covered(slot, &base, from, to)
+}
+
+pub(crate) fn leaf_slot_is_covered(
+    slot: usize,
+    base: &[usize],
+    from: &[usize],
+    to: &[usize],
+) -> bool {
     let mut start = base.to_vec();
     start.push(slot);
     let mut end = base.to_vec();
@@ -317,11 +328,7 @@ pub fn leaf_groups_in_range<'a>(rs: &ResolvedSelection<'a>) -> Vec<LeafGroup<'a>
                 let ChildView::Leaf(l) = child else {
                     continue;
                 };
-                let mut start = base.clone();
-                start.push(i);
-                let mut end = base.clone();
-                end.push(i + 1);
-                if !(from <= start.as_slice() && end.as_slice() <= to) {
+                if !leaf_slot_is_covered(i, &base, from, to) {
                     continue;
                 }
                 let ty = l.node_type();


### PR DESCRIPTION
- 기존 잘못된 endpoint 기반 판단 로직도 모두 contains_leaf_slot으로 통일함
- 복사할 때 선택되지 않은 것까지 복사되는 버그를 해결함