### PR TITLE
child-slot index와 block-only traversal을 혼용하지 않기

### DIFF
--- a/crates/editor-commands/src/commands/delete_empty_paragraph_backward.rs
+++ b/crates/editor-commands/src/commands/delete_empty_paragraph_backward.rs
@@ -1,8 +1,9 @@
-use editor_model::Node;
+use editor_model::{ChildView, Node};
 use editor_state::Selection;
 use editor_state::last_cursor_position;
 use editor_transaction::{Transaction, fulfill};
 
+use crate::helpers::prev_sibling;
 use crate::{CommandError, CommandResult};
 
 pub fn delete_empty_paragraph_backward(tr: &mut Transaction) -> CommandResult {
@@ -31,19 +32,12 @@ pub fn delete_empty_paragraph_backward(tr: &mut Transaction) -> CommandResult {
             return Ok(false);
         }
 
-        let parent = node.parent().ok_or(CommandError::NoParent(pos.node))?;
-        let idx = parent
-            .child_blocks()
-            .position(|b| b.id() == node.id())
-            .ok_or_else(|| CommandError::orphan_child(pos.node, parent.id()))?;
-        if idx == 0 {
-            return Ok(false);
-        }
-        let prev = match parent.child_blocks().nth(idx - 1) {
-            Some(prev) => prev,
-            None => return Ok(false),
+        let parent_id = node.parent().ok_or(CommandError::NoParent(pos.node))?.id();
+        let prev = match prev_sibling(&node) {
+            Some(ChildView::Block(prev)) => prev,
+            _ => return Ok(false),
         };
-        (prev.id(), parent.id())
+        (prev.id(), parent_id)
     };
 
     let paragraph_id = pos.node;
@@ -121,6 +115,19 @@ mod tests {
             doc { root {
                 p1: paragraph {}
                 paragraph { text("a") }
+            } }
+            selection: (p1, 0)
+        };
+        transact_fail!(initial, |tr| delete_empty_paragraph_backward(&mut tr));
+    }
+
+    #[test]
+    fn image_prev_sibling_returns_false() {
+        let (initial, ..) = state! {
+            doc { root {
+                paragraph { text("a") }
+                image
+                p1: paragraph {}
             } }
             selection: (p1, 0)
         };

--- a/crates/editor-commands/src/commands/delete_empty_paragraph_forward.rs
+++ b/crates/editor-commands/src/commands/delete_empty_paragraph_forward.rs
@@ -1,8 +1,9 @@
-use editor_model::Node;
+use editor_model::{ChildView, Node};
 use editor_state::Selection;
 use editor_state::first_cursor_position;
 use editor_transaction::{Transaction, fulfill};
 
+use crate::helpers::next_sibling;
 use crate::{CommandError, CommandResult};
 
 pub fn delete_empty_paragraph_forward(tr: &mut Transaction) -> CommandResult {
@@ -31,16 +32,12 @@ pub fn delete_empty_paragraph_forward(tr: &mut Transaction) -> CommandResult {
             return Ok(false);
         }
 
-        let parent = node.parent().ok_or(CommandError::NoParent(pos.node))?;
-        let idx = parent
-            .child_blocks()
-            .position(|b| b.id() == node.id())
-            .ok_or_else(|| CommandError::orphan_child(pos.node, parent.id()))?;
-        let next = match parent.child_blocks().nth(idx + 1) {
-            Some(next) => next,
-            None => return Ok(false),
+        let parent_id = node.parent().ok_or(CommandError::NoParent(pos.node))?.id();
+        let next = match next_sibling(&node) {
+            Some(ChildView::Block(next)) => next,
+            _ => return Ok(false),
         };
-        (next.id(), parent.id())
+        (next.id(), parent_id)
     };
 
     let paragraph_id = pos.node;
@@ -118,6 +115,19 @@ mod tests {
             doc { root {
                 paragraph { text("a") }
                 p1: paragraph {}
+            } }
+            selection: (p1, 0)
+        };
+        transact_fail!(initial, |tr| delete_empty_paragraph_forward(&mut tr));
+    }
+
+    #[test]
+    fn image_next_sibling_returns_false() {
+        let (initial, ..) = state! {
+            doc { root {
+                p1: paragraph {}
+                image
+                paragraph { text("a") }
             } }
             selection: (p1, 0)
         };

--- a/crates/editor-commands/src/commands/delete_page_break_backward.rs
+++ b/crates/editor-commands/src/commands/delete_page_break_backward.rs
@@ -1,7 +1,7 @@
 use editor_model::{ChildView, Node, NodeType};
 use editor_transaction::Transaction;
 
-use crate::helpers::remove_atom_leaf;
+use crate::helpers::{prev_sibling, remove_atom_leaf};
 use crate::{CommandError, CommandResult};
 
 pub fn delete_page_break_backward(tr: &mut Transaction) -> CommandResult {
@@ -23,20 +23,9 @@ pub fn delete_page_break_backward(tr: &mut Transaction) -> CommandResult {
             .node(pos.node)
             .ok_or(CommandError::NodeNotFound(pos.node))?;
 
-        let parent = match node.parent() {
-            Some(parent) => parent,
-            None => return Ok(false),
-        };
-        let idx = match parent.child_blocks().position(|b| b.id() == node.id()) {
-            Some(idx) => idx,
-            None => return Ok(false),
-        };
-        if idx == 0 {
-            return Ok(false);
-        }
-        let prev = match parent.child_blocks().nth(idx - 1) {
-            Some(prev) => prev,
-            None => return Ok(false),
+        let prev = match prev_sibling(&node) {
+            Some(ChildView::Block(prev)) => prev,
+            _ => return Ok(false),
         };
 
         if !matches!(prev.node(), Node::Paragraph(_)) {
@@ -165,6 +154,21 @@ mod tests {
             doc {
                 root {
                     horizontal_rule
+                    p1: paragraph { text("hello") }
+                }
+            }
+            selection: (p1, 0)
+        };
+        transact_fail!(initial, |tr| delete_page_break_backward(&mut tr));
+    }
+
+    #[test]
+    fn image_prev_sibling_returns_false() {
+        let (initial, ..) = state! {
+            doc {
+                root {
+                    paragraph { page_break }
+                    image
                     p1: paragraph { text("hello") }
                 }
             }

--- a/crates/editor-commands/src/commands/insert_page_break_into_prev_paragraph.rs
+++ b/crates/editor-commands/src/commands/insert_page_break_into_prev_paragraph.rs
@@ -1,7 +1,7 @@
 use editor_model::{ChildView, Node, NodeType, PlainNode, PlainPageBreakNode, Subtree};
 use editor_transaction::Transaction;
 
-use crate::helpers::find_ancestor_textblock;
+use crate::helpers::{find_ancestor_textblock, prev_sibling};
 use crate::{CommandError, CommandResult};
 
 pub fn insert_page_break_into_prev_paragraph(tr: &mut Transaction) -> CommandResult {
@@ -32,17 +32,12 @@ pub fn insert_page_break_into_prev_paragraph(tr: &mut Transaction) -> CommandRes
             return Ok(false);
         }
 
-        let parent = paragraph
+        paragraph
             .parent()
             .ok_or(CommandError::NoParent(paragraph_id))?;
-        let Some(idx) = parent.child_blocks().position(|b| b.id() == paragraph.id()) else {
-            return Ok(false);
-        };
-        if idx == 0 {
-            return Ok(false);
-        }
-        let Some(prev) = parent.child_blocks().nth(idx - 1) else {
-            return Ok(false);
+        let prev = match prev_sibling(&paragraph) {
+            Some(ChildView::Block(prev)) => prev,
+            _ => return Ok(false),
         };
         if !matches!(prev.node(), Node::Paragraph(_)) {
             return Ok(false);
@@ -102,6 +97,21 @@ mod tests {
             doc {
                 root {
                     blockquote { paragraph { text("a") } }
+                    p1: paragraph { text("hello") }
+                }
+            }
+            selection: (p1, 0)
+        };
+        transact_fail!(initial, |tr| insert_page_break_into_prev_paragraph(&mut tr));
+    }
+
+    #[test]
+    fn image_prev_sibling_returns_false() {
+        let (initial, ..) = state! {
+            doc {
+                root {
+                    paragraph { text("a") }
+                    image
                     p1: paragraph { text("hello") }
                 }
             }

--- a/crates/editor-commands/src/commands/join_paragraph_backward.rs
+++ b/crates/editor-commands/src/commands/join_paragraph_backward.rs
@@ -2,6 +2,7 @@ use editor_model::{ChildView, NodeType};
 use editor_state::{Affinity, Position, Selection};
 use editor_transaction::Transaction;
 
+use crate::helpers::prev_sibling;
 use crate::{CommandError, CommandResult};
 
 pub fn join_paragraph_backward(tr: &mut Transaction) -> CommandResult {
@@ -28,18 +29,11 @@ pub fn join_paragraph_backward(tr: &mut Transaction) -> CommandResult {
         if pos.offset > 0 {
             return Ok(false);
         }
-        let parent = node.parent().ok_or(CommandError::NoParent(pos.node))?;
-        let index = parent
-            .child_blocks()
-            .position(|b| b.id() == pos.node)
-            .ok_or_else(|| CommandError::orphan_child(pos.node, parent.id()))?;
-        if index == 0 {
-            return Ok(false);
-        }
-        let prev = parent
-            .child_blocks()
-            .nth(index - 1)
-            .ok_or(CommandError::NodeNotFound(pos.node))?;
+        node.parent().ok_or(CommandError::NoParent(pos.node))?;
+        let prev = match prev_sibling(&node) {
+            Some(ChildView::Block(prev)) => prev,
+            _ => return Ok(false),
+        };
         if prev.node_type() != NodeType::Paragraph {
             return Ok(false);
         }
@@ -264,5 +258,20 @@ mod tests {
             selection: (m, 2, <)
         };
         assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn image_between_paragraphs_returns_false() {
+        let (initial, ..) = state! {
+            doc {
+                root {
+                    paragraph { text("Hello") }
+                    image
+                    p1: paragraph { text("World") }
+                }
+            }
+            selection: (p1, 0)
+        };
+        transact_fail!(initial, |tr| join_paragraph_backward(&mut tr));
     }
 }

--- a/crates/editor-commands/src/commands/lift_empty_list_item.rs
+++ b/crates/editor-commands/src/commands/lift_empty_list_item.rs
@@ -74,6 +74,32 @@ mod tests {
     }
 
     #[test]
+    fn tr_329_lift_empty_top_level_after_image_keeps_selection_live() {
+        let (initial, ..) = state! {
+            doc {
+                root {
+                    image
+                    bullet_list {
+                        list_item { p1: paragraph {} }
+                    }
+                }
+            }
+            selection: (p1, 0)
+        };
+        let (actual, ..) = transact!(initial, |tr| lift_empty_list_item(&mut tr));
+        let (expected, ..) = state! {
+            doc {
+                root {
+                    image
+                    p1: paragraph {}
+                }
+            }
+            selection: (p1, 0)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
     fn non_collapsed_returns_false() {
         let (initial, ..) = state! {
             doc {

--- a/crates/editor-commands/src/helpers/list.rs
+++ b/crates/editor-commands/src/helpers/list.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use editor_crdt::Dot;
-use editor_model::{DocView, NodeType, Subtree};
+use editor_model::{ChildView, DocView, NodeType, Subtree};
 use editor_state::{Affinity, Position, Selection};
 use editor_transaction::{Transaction, fulfill};
 
@@ -172,13 +172,16 @@ pub(crate) fn lift_list_item_inner(tr: &mut Transaction, list_item_id: Dot) -> C
                 (children, child_count)
             };
             for (i, child_id) in children.iter().enumerate() {
-                tr.move_node(*child_id, owner_id, list_index + 1 + i)?;
+                let target_index = list_index + 1 + i;
+                tr.move_node(*child_id, owner_id, target_index)?;
                 if i == 0 {
                     new_para_id = {
                         let view = tr.state().view();
                         view.node(owner_id)
-                            .and_then(|o| o.child_blocks().nth(list_index + 1))
-                            .map(|p| p.id())
+                            .and_then(|o| match o.child_at(target_index) {
+                                Some(ChildView::Block(p)) => Some(p.id()),
+                                _ => None,
+                            })
                     };
                 }
             }
@@ -194,8 +197,10 @@ pub(crate) fn lift_list_item_inner(tr: &mut Transaction, list_item_id: Dot) -> C
                 let new_list_elem = {
                     let view = tr.state().view();
                     view.node(owner_id)
-                        .and_then(|o| o.child_blocks().nth(list_index + 1 + child_count))
-                        .map(|b| b.id())
+                        .and_then(|o| match o.child_at(list_index + 1 + child_count) {
+                            Some(ChildView::Block(b)) => Some(b.id()),
+                            _ => None,
+                        })
                         .ok_or(CommandError::NodeNotFound(owner_id))?
                 };
                 for (i, item_id) in after_items.iter().enumerate() {

--- a/crates/editor-core/src/handle/key.rs
+++ b/crates/editor-core/src/handle/key.rs
@@ -933,6 +933,33 @@ mod tests {
     }
 
     #[test]
+    fn enter_on_empty_list_item_after_image_keeps_selection_live() {
+        let (state, ..) = state! {
+            doc {
+                root {
+                    image
+                    bullet_list {
+                        list_item { p1: paragraph {} }
+                    }
+                }
+            }
+            selection: (p1, 0)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.apply(key(Key::Enter));
+        let (expected, ..) = state! {
+            doc {
+                root {
+                    image
+                    p1: paragraph {}
+                }
+            }
+            selection: (p1, 0)
+        };
+        assert_state_eq!(editor.state(), &expected);
+    }
+
+    #[test]
     fn backspace_merges_list_items() {
         let (state, ..) = state! {
             doc {


### PR DESCRIPTION
- 이미지 같은 block-level leaf 뒤의 빈 목록 항목에서 Enter를 눌러 목록을 해제할 때, selection이 죽은 node를 가리키지 않아 크래시나지 않는다.
- 같은 구조에서 lift_empty_list_item이 실행될 때, move된 paragraph를 잘못 재조회하지 않아 StablePosition::capture panic이 나지 않는다.
- block-level leaf 뒤의 빈 paragraph에서 Backspace를 눌러도, leaf 너머 paragraph와 잘못 병합하지 않는다.
- block-level leaf 앞의 빈 paragraph에서 Delete를 눌러도, leaf 너머 paragraph를 잘못 당겨오지 않는다.
- block-level leaf 뒤 paragraph 시작에서 Backspace를 눌러도, leaf 너머 paragraph의 page break를 잘못 지우지 않는다.
- block-level leaf 뒤 paragraph 시작에서 page break 삽입 경로가 실행되어도, leaf 너머 paragraph에 page break를 잘못 넣지 않는다.
- 두 paragraph 사이에 block-level leaf가 있을 때 paragraph 시작에서 Backspace를 눌러도, leaf를 건너뛰어 paragraph끼리 잘못 join하지 않는다.