### PR TITLE
컨텍스트 툴바 auto target 추가, 툴바 스크롤 떨림 방지

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarContext.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarContext.kt
@@ -72,9 +72,15 @@ internal fun resolveEditorToolbarContext(state: EditorState): EditorToolbarConte
     (selectedBlock?.node as? PlainNode.HorizontalRule)?.let { node ->
       EditorToolbarNodeTarget(id = selectedBlock.id, node = node)
     }
-  var blockquoteTarget: EditorToolbarNodeTarget<PlainNode.Blockquote>? = null
-  var calloutTarget: EditorToolbarNodeTarget<PlainNode.Callout>? = null
-  var foldTargetId: String? = null
+  var blockquoteTarget =
+    (selectedBlock?.node as? PlainNode.Blockquote)?.let { node ->
+      EditorToolbarNodeTarget(id = selectedBlock.id, node = node)
+    }
+  var calloutTarget =
+    (selectedBlock?.node as? PlainNode.Callout)?.let { node ->
+      EditorToolbarNodeTarget(id = selectedBlock.id, node = node)
+    }
+  var foldTargetId = selectedBlock?.id?.takeIf { selectedBlock.node == PlainNode.Fold }
   var tableMode: EditorToolbarTableMode? =
     if (selectedPageKey == EditorToolbarPageKey.Table) EditorToolbarTableMode.Selected else null
   val ancestorIds = blockState?.ancestors.orEmpty().mapTo(mutableSetOf()) { it.id }
@@ -191,6 +197,9 @@ private fun PlainNode.selectedToolbarPageKey(): EditorToolbarPageKey? =
     is PlainNode.Embed -> EditorToolbarPageKey.Embed
     is PlainNode.Archived -> EditorToolbarPageKey.Archived
     is PlainNode.HorizontalRule -> EditorToolbarPageKey.HorizontalRule
+    is PlainNode.Blockquote -> EditorToolbarPageKey.Blockquote
+    is PlainNode.Callout -> EditorToolbarPageKey.Callout
+    PlainNode.Fold -> EditorToolbarPageKey.Fold
     is PlainNode.Table -> EditorToolbarPageKey.Table
     else -> null
   }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarPagerState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarPagerState.kt
@@ -38,6 +38,7 @@ internal class ToolbarPagerState {
   var settledPageKey by mutableStateOf(EditorToolbarPageKey.Main)
   var recentManualPageKeys by mutableStateOf(listOf(EditorToolbarPageKey.Main))
   var previousPageKeys by mutableStateOf<List<EditorToolbarPageKey>?>(null)
+  var previousPageScrollRanges by mutableStateOf<List<Int>?>(null)
   var lastAppliedAutoTargetKey by mutableStateOf<Any?>(null)
 
   fun recordManualPageKey(pageKey: EditorToolbarPageKey) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarPages.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarPages.kt
@@ -164,11 +164,16 @@ internal fun EditorToolbarPages(
     val validAutoTargetKey = validAutoTargetPageKey?.let { autoTargetKey ?: it }
     val pageKeysChangedInFrame =
       pagerState.previousPageKeys?.let { previousPageKeys -> previousPageKeys != pageKeys } == true
+    val pageScrollRangesChangedInFrame =
+      pagerState.previousPageScrollRanges?.let { previousPageScrollRanges ->
+        previousPageScrollRanges != pageScrollRanges
+      } == true
+    val pageLayoutChangedInFrame = pageKeysChangedInFrame || pageScrollRangesChangedInFrame
     val retainedPageIndex = pages.indexOfFirst { page -> page.key == pagerState.settledPageKey }
     val autoTargetAllowsRetainedPage =
       validAutoTargetPageKey == null || validAutoTargetPageKey == pagerState.settledPageKey
     val canRetainSettledPagePosition =
-      pageKeysChangedInFrame && retainedPageIndex >= 0 && autoTargetAllowsRetainedPage
+      pageLayoutChangedInFrame && retainedPageIndex >= 0 && autoTargetAllowsRetainedPage
     val retainedPagePosition =
       if (canRetainSettledPagePosition) {
         val retainedScrollState = pages[retainedPageIndex].scrollState
@@ -445,6 +450,7 @@ internal fun EditorToolbarPages(
       val initialized = previousPageKeys != null
       val pageKeysChanged = previousPageKeys != null && previousPageKeys != pageKeys
       pagerState.previousPageKeys = pageKeys
+      pagerState.previousPageScrollRanges = pageScrollRanges
       if (pageKeysChanged) {
         pagerState.indicatorPulse++
       }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarContextTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarContextTest.kt
@@ -99,6 +99,90 @@ class ToolbarContextTest {
   }
 
   @Test
+  fun selectedBlockquoteAutoTargetsBlockquote() {
+    val context =
+      resolveEditorToolbarContext(
+        editorState(
+          selection = singleBlockSelection(),
+          blockState =
+            blockState(
+              ancestors = listOf(block("root", rootNode())),
+              nodes = listOf(block("blockquote", PlainNode.Blockquote())),
+            ),
+        )
+      )
+
+    assertEquals(
+      listOf(EditorToolbarPageKey.Main, EditorToolbarPageKey.Blockquote),
+      context.pageKeys,
+    )
+    assertEquals(EditorToolbarPageKey.Blockquote, context.autoTargetPageKey)
+    assertEquals(
+      EditorToolbarAutoTargetKey(
+        pageKey = EditorToolbarPageKey.Blockquote,
+        selectedNodeId = "blockquote",
+      ),
+      context.autoTargetKey,
+    )
+    assertEquals(
+      EditorToolbarNodeTarget(id = "blockquote", node = PlainNode.Blockquote()),
+      context.blockquoteTarget,
+    )
+  }
+
+  @Test
+  fun selectedCalloutAutoTargetsCallout() {
+    val context =
+      resolveEditorToolbarContext(
+        editorState(
+          selection = singleBlockSelection(),
+          blockState =
+            blockState(
+              ancestors = listOf(block("root", rootNode())),
+              nodes = listOf(block("callout", PlainNode.Callout())),
+            ),
+        )
+      )
+
+    assertEquals(listOf(EditorToolbarPageKey.Main, EditorToolbarPageKey.Callout), context.pageKeys)
+    assertEquals(EditorToolbarPageKey.Callout, context.autoTargetPageKey)
+    assertEquals(
+      EditorToolbarAutoTargetKey(
+        pageKey = EditorToolbarPageKey.Callout,
+        selectedNodeId = "callout",
+      ),
+      context.autoTargetKey,
+    )
+    assertEquals(
+      EditorToolbarNodeTarget(id = "callout", node = PlainNode.Callout()),
+      context.calloutTarget,
+    )
+  }
+
+  @Test
+  fun selectedFoldAutoTargetsFold() {
+    val context =
+      resolveEditorToolbarContext(
+        editorState(
+          selection = singleBlockSelection(),
+          blockState =
+            blockState(
+              ancestors = listOf(block("root", rootNode())),
+              nodes = listOf(block("fold", PlainNode.Fold)),
+            ),
+        )
+      )
+
+    assertEquals(listOf(EditorToolbarPageKey.Main, EditorToolbarPageKey.Fold), context.pageKeys)
+    assertEquals(EditorToolbarPageKey.Fold, context.autoTargetPageKey)
+    assertEquals(
+      EditorToolbarAutoTargetKey(pageKey = EditorToolbarPageKey.Fold, selectedNodeId = "fold"),
+      context.autoTargetKey,
+    )
+    assertEquals("fold", context.foldTargetId)
+  }
+
+  @Test
   fun ancestorContextsAreIncludedAfterText() {
     val context =
       resolveEditorToolbarContext(
@@ -343,6 +427,63 @@ class ToolbarContextTest {
     )
     assertEquals(null, context.autoTargetPageKey)
     assertEquals(EditorToolbarTableMode.InTable, context.tableMode)
+  }
+
+  @Test
+  fun cursorInsideFoldTitleKeepsFoldPageAvailableWithoutAutoTarget() {
+    val context =
+      resolveEditorToolbarContext(
+        editorState(
+          selection = collapsedSelection(),
+          modifierState = modifierState(inlineText = true),
+          blockState =
+            blockState(
+              ancestors =
+                listOf(
+                  block("fold-title", PlainNode.FoldTitle),
+                  block("fold", PlainNode.Fold),
+                  block("root", rootNode()),
+                )
+            ),
+        )
+      )
+
+    assertEquals(
+      listOf(EditorToolbarPageKey.Main, EditorToolbarPageKey.Text, EditorToolbarPageKey.Fold),
+      context.pageKeys,
+    )
+    assertEquals(null, context.autoTargetPageKey)
+    assertEquals(null, context.autoTargetKey)
+    assertEquals("fold", context.foldTargetId)
+  }
+
+  @Test
+  fun cursorInsideFoldContentKeepsFoldPageAvailableWithoutAutoTarget() {
+    val context =
+      resolveEditorToolbarContext(
+        editorState(
+          selection = collapsedSelection(),
+          modifierState = modifierState(inlineText = true),
+          blockState =
+            blockState(
+              ancestors =
+                listOf(
+                  block("paragraph", PlainNode.Paragraph),
+                  block("fold-content", PlainNode.FoldContent),
+                  block("fold", PlainNode.Fold),
+                  block("root", rootNode()),
+                )
+            ),
+        )
+      )
+
+    assertEquals(
+      listOf(EditorToolbarPageKey.Main, EditorToolbarPageKey.Text, EditorToolbarPageKey.Fold),
+      context.pageKeys,
+    )
+    assertEquals(null, context.autoTargetPageKey)
+    assertEquals(null, context.autoTargetKey)
+    assertEquals("fold", context.foldTargetId)
   }
 
   private fun editorState(

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/toolbar/EditorToolbarPagesDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/toolbar/EditorToolbarPagesDesktopTest.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.test.swipe
 import androidx.compose.ui.test.swipeWithVelocity
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import co.typie.ext.horizontalScroll
 import co.typie.icons.Lucide
@@ -1044,6 +1045,78 @@ class EditorToolbarPagesDesktopTest {
   }
 
   @Test
+  fun retainedManualFoldPageStaysFixedWhenTextToolbarExtentChanges() = runComposeUiTest {
+    val pageKeys =
+      mutableStateOf(
+        listOf(EditorToolbarPageKey.Main, EditorToolbarPageKey.Text, EditorToolbarPageKey.Fold)
+      )
+    val autoTarget = mutableStateOf<EditorToolbarPageKey?>(null)
+    val autoTargetRevision = mutableStateOf(0L)
+    val textItemWidth = mutableStateOf(80.dp)
+    lateinit var textScrollState: ScrollState
+    setContent {
+      textScrollState = rememberScrollState()
+      ToolbarTestContent(
+        textScrollState = textScrollState,
+        pageKeys = pageKeys.value,
+        autoTargetPageKey = autoTarget.value,
+        autoTargetRevision = autoTargetRevision.value,
+        textItemWidth = textItemWidth.value,
+      )
+    }
+    waitForIdle()
+    goToFoldPage(textScrollState)
+    val initialTextMax = textScrollState.maxValue
+    val initialFoldLeft = pageLeft(FoldPageTag)
+
+    mainClock.autoAdvance = false
+    textItemWidth.value = 84.dp
+    mainClock.advanceTimeByFrame()
+
+    assertTrue(
+      textScrollState.maxValue > initialTextMax,
+      "test setup should increase text toolbar extent",
+    )
+    assertNear(initialFoldLeft, pageLeft(FoldPageTag), "fold page should stay in place")
+
+    mainClock.autoAdvance = true
+    waitForIdle()
+    assertPageActive(FoldPageTag)
+  }
+
+  @Test
+  fun textToolbarExtentChangeDoesNotPulseIndicator() = runComposeUiTest {
+    val textItemWidth = mutableStateOf(80.dp)
+    lateinit var pagerState: ToolbarPagerState
+    lateinit var textScrollState: ScrollState
+    setContent {
+      textScrollState = rememberScrollState()
+      pagerState = rememberToolbarPagerState()
+      ToolbarTestContent(
+        textScrollState = textScrollState,
+        pagerState = pagerState,
+        textItemWidth = textItemWidth.value,
+      )
+    }
+    waitForIdle()
+    val initialTextMax = textScrollState.maxValue
+    val initialPulse = pagerState.indicatorPulse
+
+    textItemWidth.value = 84.dp
+    waitForIdle()
+
+    assertTrue(
+      textScrollState.maxValue > initialTextMax,
+      "test setup should increase text toolbar extent",
+    )
+    assertEquals(
+      initialPulse,
+      pagerState.indicatorPulse,
+      "indicator should not pulse when only a page scroll range changes",
+    )
+  }
+
+  @Test
   fun retainedPagerStateRestoresPageAndInternalScrollAfterToolbarRecomposes() = runComposeUiTest {
     val visible = mutableStateOf(true)
     val pageKeys = mutableStateOf(DefaultPageKeys)
@@ -1372,8 +1445,14 @@ class EditorToolbarPagesDesktopTest {
     autoTargetRevision: Long = 0L,
     visible: Boolean = true,
     pagerState: ToolbarPagerState = rememberToolbarPagerState(),
+    textItemWidth: Dp = 80.dp,
   ) {
-    val pages = rememberToolbarTestPages(textScrollState = textScrollState, pageKeys = pageKeys)
+    val pages =
+      rememberToolbarTestPages(
+        textScrollState = textScrollState,
+        pageKeys = pageKeys,
+        textItemWidth = textItemWidth,
+      )
     val commandScope = rememberCoroutineScope()
     ToolbarTestTheme {
       Box(Modifier.width(360.dp).height(ToolbarStackHeight).testTag(ToolbarTag)) {
@@ -1403,7 +1482,8 @@ class EditorToolbarPagesDesktopTest {
       LocalAppColors provides LightColors,
       LocalAppShadows provides LightAppShadows,
       LocalThemeMode provides ResolvedThemeMode.Light,
-      LocalHazeBlurStyle provides HazeBlurStyle(blurRadius = 20.dp, noiseFactor = 0f, colorEffects = listOf()),
+      LocalHazeBlurStyle provides
+        HazeBlurStyle(blurRadius = 20.dp, noiseFactor = 0f, colorEffects = listOf()),
       content = content,
     )
   }
@@ -1412,8 +1492,9 @@ class EditorToolbarPagesDesktopTest {
   private fun rememberToolbarTestPages(
     textScrollState: ScrollState,
     pageKeys: List<EditorToolbarPageKey>,
+    textItemWidth: Dp,
   ): List<EditorToolbarPage> =
-    remember(textScrollState, pageKeys) {
+    remember(textScrollState, pageKeys, textItemWidth) {
       pageKeys.map { key ->
         when (key) {
           EditorToolbarPageKey.Main ->
@@ -1440,7 +1521,7 @@ class EditorToolbarPagesDesktopTest {
                 ) {
                   repeat(16) { index ->
                     Box(
-                      Modifier.size(width = 80.dp, height = ToolbarButtonSize)
+                      Modifier.size(width = textItemWidth, height = ToolbarButtonSize)
                         .testTag("text-item-$index")
                     )
                   }


### PR DESCRIPTION
- blockquote/callout/fold 노드 자체가 선택됐을 때 해당 컨텍스트 툴바로 auto target
- 텍스트 툴바 scroll range가 바뀌는 프레임에도 현재 fold 툴바 페이지 위치가 흔들리지 않도록 함
- scroll range 변화만으로는 toolbar page indicator가 다시 표시되지 않도록 함