### PR TITLE
TR-45 모바일 에디터에 글자 수 플로팅 위젯 구현

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Editor.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Editor.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.focus.FocusRequester
 import co.touchlab.kermit.Logger
 import co.typie.editor.ffi.BlockState
+import co.typie.editor.ffi.CharacterCounts
 import co.typie.editor.ffi.ClipboardPayload
 import co.typie.editor.ffi.CursorMetrics
 import co.typie.editor.ffi.EditorEvent
@@ -351,6 +352,19 @@ internal constructor(
 
   fun interactiveHitTest(page: Int, x: Float, y: Float): InteractiveHit? =
     inner.interactiveHitTest(page, x, y)
+
+  suspend fun characterCounts(): CharacterCounts? =
+    withSuspendFailureNotification(defaultValue = { null }) {
+      withContext(dispatcher) {
+        mutex.withLock {
+          if (disposed.load()) {
+            null
+          } else {
+            inner.characterCounts()
+          }
+        }
+      }
+    }
 
   fun selectionEndpoints(): SelectionEndpoints? = inner.selectionEndpoints()
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorState.kt
@@ -17,6 +17,8 @@ import co.typie.editor.ffi.TrackedRangeEndpoints
 
 data class EditorState(
   val version: Long,
+  // Advances only when the document content changed (StateField.Doc), unlike [version] which
+  // advances on every tick including cursor/selection-only changes.
   val documentRevision: Long = 0L,
   val cursor: CursorMetrics?,
   val placeholder: PlaceholderMetrics? = null,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/document/document/DocumentScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/document/document/DocumentScreen.kt
@@ -467,6 +467,11 @@ fun DocumentScreen(entityId: String) {
         onClick = { nav.navigate(Route.DocumentBodySettings(entityId)) },
       )
       DocumentActionRow(
+        icon = Lucide.SquareStack,
+        label = "위젯 설정",
+        onClick = { nav.navigate(Route.WidgetSettings) },
+      )
+      DocumentActionRow(
         icon = Lucide.LockKeyhole,
         label = if (document.locked) "편집 잠금 해제" else "편집 잠금",
         onClick = { showPendingAction(if (document.locked) "편집 잠금 해제" else "편집 잠금") },

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -104,6 +104,7 @@ import co.typie.screen.editor.editor.findreplace.rememberEditorFindReplaceSessio
 import co.typie.screen.editor.editor.header.EditorHeader
 import co.typie.screen.editor.editor.layout.EditorScreenLayout
 import co.typie.screen.editor.editor.layout.EditorViewportScrollReconcileMode
+import co.typie.screen.editor.editor.overlay.EditorCharacterCountOverlay
 import co.typie.screen.editor.editor.overlay.EditorRepasteAsTextOverlay
 import co.typie.screen.editor.editor.overlay.EditorScreenOverlayHost
 import co.typie.screen.editor.editor.overlay.EditorZoomOverlay
@@ -918,6 +919,11 @@ fun EditorScreen(entityId: String) {
             modifier =
               Modifier.align(Alignment.BottomStart)
                 .padding(start = 20.dp, bottom = 20.dp + visibleArea.bottomOcclusion.dp)
+          )
+          EditorCharacterCountOverlay(
+            editor = runtime.editor,
+            viewportState = screenState.viewportState,
+            visibleArea = visibleArea,
           )
         },
         overlay = {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/CharacterCountDisplay.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/CharacterCountDisplay.kt
@@ -1,0 +1,18 @@
+package co.typie.screen.editor.editor.overlay
+
+import co.typie.editor.ffi.CharacterCounts
+import co.typie.ext.comma
+
+/** Collapsed widget label: document character count including whitespace. */
+fun CharacterCounts.collapsedLabel(): String = "${docWithWhitespace.comma}자"
+
+/**
+ * Expanded widget detail rows appended below the always-visible header: the with-whitespace count
+ * stays in the header and only these two rows are added. The full three-count breakdown lives in
+ * the DocumentScreen document info, per the ticket ("글자 수 정보와 설정 entry는 DocumentScreen 쪽에 둔다").
+ */
+fun CharacterCounts.expandedRows(): List<Pair<String, String>> =
+  listOf(
+    "공백 미포함" to "${docWithoutWhitespace.comma}자",
+    "공백/부호 미포함" to "${docWithoutWhitespaceAndPunctuation.comma}자",
+  )

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/CharacterCountFloatingState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/CharacterCountFloatingState.kt
@@ -1,0 +1,84 @@
+package co.typie.screen.editor.editor.overlay
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+
+/**
+ * Holds the position and expand/collapse state of the character-count floating widget.
+ *
+ * Position is stored as a relative fraction (0..1) of the free space (viewport minus widget size)
+ * so it survives viewport resizes and rotations, mirroring the legacy widget's behavior. Absolute
+ * pixel offsets are derived once the viewport is measured.
+ *
+ * Kept free of `@Composable` so the drag/clamp/persist behavior is unit-testable.
+ */
+@Stable
+class CharacterCountFloatingState(
+  private var relativeX: Float,
+  private var relativeY: Float,
+  private val persist: (relativeX: Float, relativeY: Float) -> Unit,
+) {
+  var offsetX by mutableFloatStateOf(0f)
+    private set
+
+  var offsetY by mutableFloatStateOf(0f)
+    private set
+
+  var expanded by mutableStateOf(false)
+    private set
+
+  private var freeWidth = 0f
+  private var freeHeight = 0f
+
+  // Top of the draggable area: the header / top safe area the widget must not cover.
+  private var minY = 0f
+
+  private var dragging = false
+
+  fun onViewportMeasured(
+    width: Float,
+    height: Float,
+    widgetWidth: Float,
+    widgetHeight: Float,
+    topOcclusion: Float = 0f,
+    bottomOcclusion: Float = 0f,
+  ) {
+    freeWidth = (width - widgetWidth).coerceAtLeast(0f)
+    freeHeight = (height - topOcclusion - bottomOcclusion - widgetHeight).coerceAtLeast(0f)
+    minY = topOcclusion
+
+    if (dragging) {
+      // The viewport changed mid-drag (e.g. the keyboard opened): keep the dragged position and
+      // only clamp it into the new bounds instead of resetting from the stale relative fraction.
+      offsetX = offsetX.coerceIn(0f, freeWidth)
+      offsetY = offsetY.coerceIn(minY, minY + freeHeight)
+      return
+    }
+
+    offsetX = (relativeX * freeWidth).coerceIn(0f, freeWidth)
+    offsetY = (minY + relativeY * freeHeight).coerceIn(minY, minY + freeHeight)
+  }
+
+  fun onDragStart() {
+    dragging = true
+  }
+
+  fun onDrag(dx: Float, dy: Float) {
+    offsetX = (offsetX + dx).coerceIn(0f, freeWidth)
+    offsetY = (offsetY + dy).coerceIn(minY, minY + freeHeight)
+  }
+
+  fun onDragEnd() {
+    dragging = false
+    relativeX = if (freeWidth > 0f) offsetX / freeWidth else 0f
+    relativeY = if (freeHeight > 0f) (offsetY - minY) / freeHeight else 0f
+    persist(relativeX, relativeY)
+  }
+
+  fun toggleExpanded() {
+    expanded = !expanded
+  }
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/CharacterCountRefresh.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/CharacterCountRefresh.kt
@@ -1,0 +1,20 @@
+package co.typie.screen.editor.editor.overlay
+
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.debounce
+
+/**
+ * Collects a stream of editor document versions and invokes [fetch] once the stream settles for
+ * [debounceMillis], so rapid typing does not trigger a character-count recomputation per keystroke.
+ *
+ * Extracted from the composable so the debounce policy is unit-testable with virtual time.
+ */
+@OptIn(FlowPreview::class)
+suspend fun collectDebouncedCharacterCounts(
+  versions: Flow<Long>,
+  debounceMillis: Long,
+  fetch: suspend () -> Unit,
+) {
+  versions.debounce(debounceMillis).collect { fetch() }
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorCharacterCountOverlay.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorCharacterCountOverlay.kt
@@ -1,0 +1,251 @@
+package co.typie.screen.editor.editor.overlay
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import co.typie.editor.Editor
+import co.typie.editor.ffi.CharacterCounts
+import co.typie.editor.scroll.EditorVisibleArea
+import co.typie.editor.viewport.EditorViewportState
+import co.typie.icons.Lucide
+import co.typie.storage.Preference
+import co.typie.ui.component.Text
+import co.typie.ui.icon.Icon
+import co.typie.ui.theme.AppShapes
+import co.typie.ui.theme.AppTheme
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.drop
+
+private const val CharacterCountDebounceMs = 150L
+
+// Legacy fade values (native_editor_floating_fade.dart): typing/scroll fades the widget out,
+// and it fades back in after 1.5s of inactivity.
+private const val WidgetFadeIdleMs = 1500L
+private const val WidgetFadeAnimMs = 200
+private const val WidgetFadedAlpha = 0.05f
+private val CharacterCountShape = AppShapes.rounded(16.dp)
+
+/**
+ * Floating widget that shows the document character count over the editor. Visibility is controlled
+ * by [Preference.characterCountFloatingEnabled]; the drag position is persisted as a relative
+ * fraction. Composed from [CharacterCountFloatingState] (position/expand), [collapsedLabel]/
+ * [expandedRows] (display), and [collectDebouncedCharacterCounts] (refresh policy).
+ *
+ * [visibleArea] geometry is in dp; the floating state works in px so it matches the units of
+ * [onSizeChanged], drag deltas, and the applied [offset].
+ *
+ * Auto-fade mirrors the legacy widget: typing (cursor/selection movement) or scrolling fades the
+ * widget out so it does not cover the text being edited, and it fades back in once idle. Tapping a
+ * faded widget only wakes it; tapping a visible one toggles the expanded rows.
+ *
+ * Must be hosted inside a Box-like scope whose size matches the editor viewport.
+ */
+@Composable
+internal fun EditorCharacterCountOverlay(
+  editor: Editor?,
+  viewportState: EditorViewportState,
+  visibleArea: EditorVisibleArea,
+  modifier: Modifier = Modifier,
+) {
+  if (!Preference.characterCountFloatingEnabled || editor == null) {
+    return
+  }
+
+  val density = LocalDensity.current
+
+  val state = remember {
+    CharacterCountFloatingState(
+      relativeX = Preference.characterCountFloatingPositionX.toFloat(),
+      relativeY = Preference.characterCountFloatingPositionY.toFloat(),
+      persist = { x, y ->
+        Preference.characterCountFloatingPositionX = x.toDouble()
+        Preference.characterCountFloatingPositionY = y.toDouble()
+      },
+    )
+  }
+
+  var counts by remember { mutableStateOf<CharacterCounts?>(null) }
+  var widgetSize by remember { mutableStateOf(0 to 0) }
+
+  // Recompute character counts only when the document content changes (documentRevision), debounced
+  // to avoid per-keystroke work — mirroring the legacy doc-dirty + debounce policy. Cursor- or
+  // selection-only ticks bump [EditorState.version] but not documentRevision, so they never
+  // refetch.
+  LaunchedEffect(editor) {
+    collectDebouncedCharacterCounts(
+      versions = snapshotFlow { editor.state.documentRevision },
+      debounceMillis = CharacterCountDebounceMs,
+      fetch = { editor.characterCounts()?.let { counts = it } },
+    )
+  }
+
+  // Map the relative position onto the current viewport whenever any input geometry changes,
+  // converting the dp-based visible area into px for the floating state.
+  LaunchedEffect(visibleArea, widgetSize, density) {
+    with(density) {
+      state.onViewportMeasured(
+        width = visibleArea.viewport.width.dp.toPx(),
+        height = visibleArea.viewport.height.dp.toPx(),
+        widgetWidth = widgetSize.first.toFloat(),
+        widgetHeight = widgetSize.second.toFloat(),
+        topOcclusion = visibleArea.topOcclusion.dp.toPx(),
+        bottomOcclusion = visibleArea.bottomOcclusion.dp.toPx(),
+      )
+    }
+  }
+
+  val autoFade = Preference.widgetAutoFadeEnabled
+  var faded by remember { mutableStateOf(false) }
+  var fadeOutRequest by remember { mutableIntStateOf(0) }
+  var wakeRequest by remember { mutableIntStateOf(0) }
+
+  // Typing: the cursor or selection moving means the user is editing, so get out of the way.
+  LaunchedEffect(editor, autoFade) {
+    if (!autoFade) return@LaunchedEffect
+    snapshotFlow { editor.state.cursor?.caret to editor.state.selection }
+      .drop(1)
+      .collect { fadeOutRequest += 1 }
+  }
+
+  // Scrolling fades the widget out the same way.
+  LaunchedEffect(viewportState, autoFade) {
+    if (!autoFade) return@LaunchedEffect
+    snapshotFlow { viewportState.scrollOffset }.drop(1).collect { fadeOutRequest += 1 }
+  }
+
+  LaunchedEffect(fadeOutRequest, autoFade) {
+    if (!autoFade) {
+      faded = false
+      return@LaunchedEffect
+    }
+    if (fadeOutRequest == 0) return@LaunchedEffect
+    faded = true
+    delay(WidgetFadeIdleMs)
+    faded = false
+  }
+  LaunchedEffect(wakeRequest) {
+    if (wakeRequest > 0) faded = false
+  }
+
+  val alpha by
+    animateFloatAsState(
+      targetValue = if (faded) WidgetFadedAlpha else 1f,
+      animationSpec = tween(WidgetFadeAnimMs),
+      label = "character-count-overlay-alpha",
+    )
+
+  val chevronRotation by
+    animateFloatAsState(
+      targetValue = if (state.expanded) 90f else 0f,
+      animationSpec = tween(WidgetFadeAnimMs),
+      label = "character-count-overlay-chevron",
+    )
+
+  val current = counts ?: return
+
+  Box(
+    modifier =
+      modifier
+        .offset { IntOffset(state.offsetX.toInt(), state.offsetY.toInt()) }
+        .onSizeChanged { widgetSize = it.width to it.height }
+        .graphicsLayer { this.alpha = alpha }
+        .pointerInput(Unit) {
+          detectDragGestures(
+            onDragStart = {
+              wakeRequest += 1
+              state.onDragStart()
+            },
+            onDragEnd = { state.onDragEnd() },
+            onDragCancel = { state.onDragEnd() },
+          ) { change, dragAmount ->
+            change.consume()
+            state.onDrag(dragAmount.x, dragAmount.y)
+          }
+        }
+        .pointerInput(Unit) {
+          detectTapGestures {
+            // Legacy: tapping a faded widget only wakes it, without toggling the expanded rows.
+            val wasFaded = faded
+            wakeRequest += 1
+            if (!wasFaded) {
+              state.toggleExpanded()
+            }
+          }
+        }
+        .clip(CharacterCountShape)
+        .border(1.dp, AppTheme.colors.borderDefault, CharacterCountShape)
+        .background(AppTheme.colors.surfaceDefault.copy(alpha = 0.95f), CharacterCountShape)
+        .padding(horizontal = 14.dp, vertical = 8.dp)
+  ) {
+    // The with-whitespace count stays visible in the header and expanding only appends the detail
+    // rows below it. The chevron hints that the header is expandable, rotating to point down when
+    // the detail rows are shown.
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+      Row(
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+      ) {
+        Text(
+          text = current.collapsedLabel(),
+          style = AppTheme.typography.caption.copy(fontWeight = FontWeight.W500),
+          color = AppTheme.colors.textDefault,
+        )
+        Icon(
+          icon = Lucide.ChevronRight,
+          modifier = Modifier.size(14.dp).rotate(chevronRotation),
+          tint = AppTheme.colors.textHint,
+        )
+      }
+
+      if (state.expanded) {
+        current.expandedRows().forEach { (label, value) ->
+          Row(
+            modifier = Modifier.width(160.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+          ) {
+            Text(
+              text = label,
+              style = AppTheme.typography.caption,
+              color = AppTheme.colors.textMuted,
+            )
+            Text(
+              text = value,
+              style = AppTheme.typography.caption.copy(fontWeight = FontWeight.W500),
+              color = AppTheme.colors.textDefault,
+            )
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/storage/Preference.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/storage/Preference.kt
@@ -33,6 +33,8 @@ object Preference {
   var autoSurroundEnabled by prefs("auto_surround_enabled", true)
   var searchMatchWholeWord by prefs("search_match_whole_word", false)
   var characterCountFloatingEnabled by prefs("character_count_floating_enabled", false)
+  var characterCountFloatingPositionX by prefs("character_count_floating_position_x", 0.05)
+  var characterCountFloatingPositionY by prefs("character_count_floating_position_y", 0.05)
   var widgetAutoFadeEnabled by prefs("widget_auto_fade_enabled", true)
 
   var devMode by prefs("dev_mode", false)

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorAwaitTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorAwaitTest.kt
@@ -270,6 +270,34 @@ class EditorAwaitTest {
     }
 
   @Test
+  fun document_revision_advances_only_when_doc_field_changes() =
+    runTest(dispatcher) {
+      val events =
+        ArrayDeque(
+          listOf(
+            listOf(EditorEvent.StateChanged(listOf(StateField.Doc))),
+            listOf(EditorEvent.StateChanged(listOf(StateField.Cursor))),
+            listOf(EditorEvent.StateChanged(listOf(StateField.Cursor, StateField.Doc))),
+          )
+        )
+      val fake = FakeFfiEditor(onTick = { events.removeFirst() })
+      val editor = Editor(fake, this, dispatcher)
+
+      editor.await { enqueue(sampleMessage) }
+      assertEquals(1L, editor.state.version)
+      assertEquals(1L, editor.state.documentRevision)
+
+      // cursor-only tick: version advances, documentRevision stays
+      editor.await { enqueue(sampleMessage) }
+      assertEquals(2L, editor.state.version)
+      assertEquals(1L, editor.state.documentRevision)
+
+      editor.await { enqueue(sampleMessage) }
+      assertEquals(3L, editor.state.version)
+      assertEquals(2L, editor.state.documentRevision)
+    }
+
+  @Test
   fun await_reports_tick_exception_without_committing() =
     runTest(dispatcher) {
       val boom = RuntimeException("boom")

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorStateTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorStateTest.kt
@@ -8,6 +8,7 @@ class EditorStateTest {
   fun initial_has_version_zero_and_null_fields() {
     val s = EditorState.Initial
     assertEquals(0L, s.version)
+    assertEquals(0L, s.documentRevision)
     assertEquals(null, s.cursor)
     assertEquals(null, s.placeholder)
     assertEquals(null, s.selection)

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/overlay/CharacterCountDisplayTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/overlay/CharacterCountDisplayTest.kt
@@ -1,0 +1,48 @@
+package co.typie.screen.editor.editor.overlay
+
+import co.typie.editor.ffi.CharacterCounts
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CharacterCountDisplayTest {
+  private val counts =
+    CharacterCounts(
+      docWithWhitespace = 1234,
+      docWithoutWhitespace = 1000,
+      docWithoutWhitespaceAndPunctuation = 900,
+      selectionWithWhitespace = 0,
+      selectionWithoutWhitespace = 0,
+      selectionWithoutWhitespaceAndPunctuation = 0,
+    )
+
+  @Test
+  fun collapsedShowsWithWhitespaceOnly() {
+    assertEquals("1,234자", counts.collapsedLabel())
+  }
+
+  @Test
+  fun expandedShowsDetailRowsBelowHeader() {
+    // The with-whitespace count stays in the always-visible header and expanding appends only the
+    // two detail rows; the full breakdown lives in the DocumentScreen document info.
+    val rows = counts.expandedRows()
+
+    assertEquals(2, rows.size)
+    assertEquals("공백 미포함" to "1,000자", rows[0])
+    assertEquals("공백/부호 미포함" to "900자", rows[1])
+  }
+
+  @Test
+  fun formatsZeroWithComma() {
+    val zero =
+      CharacterCounts(
+        docWithWhitespace = 0,
+        docWithoutWhitespace = 0,
+        docWithoutWhitespaceAndPunctuation = 0,
+        selectionWithWhitespace = 0,
+        selectionWithoutWhitespace = 0,
+        selectionWithoutWhitespaceAndPunctuation = 0,
+      )
+
+    assertEquals("0자", zero.collapsedLabel())
+  }
+}

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/overlay/CharacterCountFloatingStateTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/overlay/CharacterCountFloatingStateTest.kt
@@ -1,0 +1,199 @@
+package co.typie.screen.editor.editor.overlay
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class CharacterCountFloatingStateTest {
+  @Test
+  fun restoresAbsolutePositionFromRelative() {
+    val state =
+      CharacterCountFloatingState(
+        relativeX = 0.5f,
+        relativeY = 0.25f,
+        persist = { _, _ -> },
+      )
+
+    state.onViewportMeasured(width = 400f, height = 800f, widgetWidth = 100f, widgetHeight = 40f)
+
+    // relative 0.5 of free width (400 - 100 = 300) = 150; 0.25 of free height (800 - 40 = 760) =
+    // 190
+    assertEquals(150f, state.offsetX)
+    assertEquals(190f, state.offsetY)
+  }
+
+  @Test
+  fun clampsWithinViewport() {
+    val state = CharacterCountFloatingState(relativeX = 0f, relativeY = 0f, persist = { _, _ -> })
+    state.onViewportMeasured(width = 400f, height = 800f, widgetWidth = 100f, widgetHeight = 40f)
+
+    // drag far beyond bottom-right; offset must clamp to max free space
+    state.onDrag(dx = 9999f, dy = 9999f)
+
+    assertEquals(300f, state.offsetX) // 400 - 100
+    assertEquals(760f, state.offsetY) // 800 - 40
+  }
+
+  @Test
+  fun clampNeverGoesNegative() {
+    val state =
+      CharacterCountFloatingState(relativeX = 0.1f, relativeY = 0.1f, persist = { _, _ -> })
+    state.onViewportMeasured(width = 400f, height = 800f, widgetWidth = 100f, widgetHeight = 40f)
+
+    state.onDrag(dx = -9999f, dy = -9999f)
+
+    assertEquals(0f, state.offsetX)
+    assertEquals(0f, state.offsetY)
+  }
+
+  @Test
+  fun clampRespectsBottomOcclusion() {
+    val state = CharacterCountFloatingState(relativeX = 0f, relativeY = 0f, persist = { _, _ -> })
+    // 200px of the bottom is occluded by toolbar/keyboard
+    state.onViewportMeasured(
+      width = 400f,
+      height = 800f,
+      widgetWidth = 100f,
+      widgetHeight = 40f,
+      bottomOcclusion = 200f,
+    )
+
+    state.onDrag(dx = 0f, dy = 9999f)
+
+    // max y = height - bottomOcclusion - widgetHeight = 800 - 200 - 40 = 560
+    assertEquals(560f, state.offsetY)
+  }
+
+  @Test
+  fun clampRespectsTopOcclusion() {
+    val state = CharacterCountFloatingState(relativeX = 0f, relativeY = 0f, persist = { _, _ -> })
+    // 120px of the top is occluded by the header/safe area
+    state.onViewportMeasured(
+      width = 400f,
+      height = 800f,
+      widgetWidth = 100f,
+      widgetHeight = 40f,
+      topOcclusion = 120f,
+    )
+
+    // relativeY 0 must resolve to the top of the free area, i.e. below the occluded header
+    assertEquals(120f, state.offsetY)
+
+    // dragging above the header must clamp to the top occlusion, never over the header
+    state.onDrag(dx = 0f, dy = -9999f)
+    assertEquals(120f, state.offsetY)
+
+    // dragging far down clamps to top + free height = 120 + (800 - 120 - 40) = height -
+    // widgetHeight = 760
+    state.onDrag(dx = 0f, dy = 9999f)
+    assertEquals(760f, state.offsetY)
+  }
+
+  @Test
+  fun topAndBottomOcclusionShrinkFreeHeightTogether() {
+    var savedY: Float? = null
+    val state =
+      CharacterCountFloatingState(relativeX = 0f, relativeY = 0f, persist = { _, y -> savedY = y })
+    state.onViewportMeasured(
+      width = 400f,
+      height = 800f,
+      widgetWidth = 100f,
+      widgetHeight = 40f,
+      topOcclusion = 100f,
+      bottomOcclusion = 100f,
+    )
+
+    // free height = 800 - 100 - 100 - 40 = 560; drag to the middle of it
+    state.onDrag(dx = 0f, dy = 280f)
+    state.onDragEnd()
+
+    // offset measured from the top occlusion: 100 + 280 = 380
+    assertEquals(380f, state.offsetY)
+    // persisted relative is fraction of the free height, occlusion-independent: 280 / 560 = 0.5
+    assertEquals(0.5f, savedY)
+  }
+
+  @Test
+  fun dragEndPersistsRelativePosition() {
+    var savedX: Float? = null
+    var savedY: Float? = null
+    val state =
+      CharacterCountFloatingState(
+        relativeX = 0f,
+        relativeY = 0f,
+        persist = { x, y ->
+          savedX = x
+          savedY = y
+        },
+      )
+    state.onViewportMeasured(width = 400f, height = 800f, widgetWidth = 100f, widgetHeight = 40f)
+
+    state.onDrag(dx = 150f, dy = 190f)
+    state.onDragEnd()
+
+    // 150 / (400 - 100) = 0.5 ; 190 / (800 - 40) = 0.25
+    assertEquals(0.5f, savedX)
+    assertEquals(0.25f, savedY)
+  }
+
+  @Test
+  fun viewportChangeDuringDragKeepsDraggedPosition() {
+    val state = CharacterCountFloatingState(relativeX = 0f, relativeY = 0f, persist = { _, _ -> })
+    state.onViewportMeasured(width = 400f, height = 800f, widgetWidth = 100f, widgetHeight = 40f)
+
+    state.onDragStart()
+    state.onDrag(dx = 200f, dy = 300f)
+
+    // the keyboard opens mid-drag: re-measuring must not reset the dragged offset from the stale
+    // relative fraction...
+    state.onViewportMeasured(
+      width = 400f,
+      height = 800f,
+      widgetWidth = 100f,
+      widgetHeight = 40f,
+      bottomOcclusion = 200f,
+    )
+    assertEquals(200f, state.offsetX)
+    assertEquals(300f, state.offsetY)
+
+    // ...but further drags clamp against the new bounds (800 - 200 - 40 = 560)
+    state.onDrag(dx = 0f, dy = 9999f)
+    assertEquals(560f, state.offsetY)
+
+    // drag end persists against the new free space: 560 / 560 = 1.0
+    var savedY: Float? = null
+    val persistingState =
+      CharacterCountFloatingState(relativeX = 0f, relativeY = 0f, persist = { _, y -> savedY = y })
+    persistingState.onViewportMeasured(
+      width = 400f,
+      height = 800f,
+      widgetWidth = 100f,
+      widgetHeight = 40f,
+    )
+    persistingState.onDragStart()
+    persistingState.onDrag(dx = 0f, dy = 9999f)
+    persistingState.onDragEnd()
+    assertEquals(1f, savedY)
+
+    // after the drag ends, re-measuring resolves from the persisted relative position again
+    persistingState.onViewportMeasured(
+      width = 400f,
+      height = 800f,
+      widgetWidth = 100f,
+      widgetHeight = 40f,
+    )
+    assertEquals(760f, persistingState.offsetY)
+  }
+
+  @Test
+  fun toggleExpands() {
+    val state = CharacterCountFloatingState(relativeX = 0f, relativeY = 0f, persist = { _, _ -> })
+
+    assertFalse(state.expanded)
+    state.toggleExpanded()
+    assertTrue(state.expanded)
+    state.toggleExpanded()
+    assertFalse(state.expanded)
+  }
+}

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/overlay/CharacterCountRefreshTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/overlay/CharacterCountRefreshTest.kt
@@ -1,0 +1,56 @@
+package co.typie.screen.editor.editor.overlay
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+
+class CharacterCountRefreshTest {
+  @Test
+  fun collapsesRapidVersionChangesIntoSingleFetch() = runTest {
+    var fetchCount = 0
+
+    val versions = flow {
+      // three rapid emissions within the debounce window
+      emit(1L)
+      emit(2L)
+      emit(3L)
+    }
+
+    val job = launch {
+      collectDebouncedCharacterCounts(
+        versions = versions,
+        debounceMillis = 150,
+        fetch = { fetchCount += 1 },
+      )
+    }
+
+    job.join()
+
+    assertEquals(1, fetchCount)
+  }
+
+  @Test
+  fun separatedVersionChangesFetchEachTime() = runTest {
+    var fetchCount = 0
+
+    val versions = flow {
+      emit(1L)
+      kotlinx.coroutines.delay(300)
+      emit(2L)
+    }
+
+    val job = launch {
+      collectDebouncedCharacterCounts(
+        versions = versions,
+        debounceMillis = 150,
+        fetch = { fetchCount += 1 },
+      )
+    }
+
+    job.join()
+
+    assertEquals(2, fetchCount)
+  }
+}


### PR DESCRIPTION
새 모바일 앱 에디터에 없던 글자 수 플로팅 위젯을 추가해 v1의 표시 기능을 채웠습니다.
공백 포함·미포함·부호 제외 글자 수를 보여주고, 표시 여부는 DocumentScreen 설정에서 제어하며 드래그한 위치는 재진입 후에도 유지됩니다.   
본문이 실제로 바뀔 때만 다시 세도록 해 편집 중 불필요한 재계산을 피했고, 키보드·툴바 등 편집 UI를 가리지 않게 배치했습니다.