### PR TITLE
StablePosition이 block level position을 유지, intersects_subtree 디버그, Step::ReplaceBlockType 도입

### DIFF
--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/FakeFfiEditor.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/FakeFfiEditor.kt
@@ -33,7 +33,6 @@ import co.typie.editor.ffi.Selection
 import co.typie.editor.ffi.SelectionEndpoints
 import co.typie.editor.ffi.Size
 import co.typie.editor.ffi.StablePosition
-import co.typie.editor.ffi.StablePositionBinding
 import co.typie.editor.ffi.StableSelection
 import co.typie.editor.ffi.TableOverlay
 import co.typie.editor.ffi.TrackedRange
@@ -235,11 +234,7 @@ internal class FakeFfiEditor(
   private companion object {
     val EmptyPosition = Position(node = "", offset = 0, affinity = Affinity.Downstream)
     val EmptyStablePosition =
-      StablePosition(
-        chain = emptyList(),
-        binding = StablePositionBinding.ContainerStart,
-        affinity = Affinity.Downstream,
-      )
+      StablePosition(chain = emptyList(), child = null, affinity = Affinity.Downstream)
     val EmptySelection = Selection(anchor = EmptyPosition, head = EmptyPosition)
     val EmptyRootAttrs = PlainRootNode(layoutMode = LayoutMode.Continuous(maxWidth = 0))
     val EmptyPlainDoc =

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/entry/EditorEntryStateStoreTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/entry/EditorEntryStateStoreTest.kt
@@ -2,7 +2,6 @@ package co.typie.screen.editor.editor.entry
 
 import co.typie.editor.ffi.Affinity
 import co.typie.editor.ffi.StablePosition
-import co.typie.editor.ffi.StablePositionBinding
 import co.typie.editor.ffi.StableSelection
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -48,11 +47,6 @@ class EditorEntryStateStoreTest {
 }
 
 private fun stableSelection(): StableSelection {
-  val position =
-    StablePosition(
-      chain = emptyList(),
-      binding = StablePositionBinding.ContainerStart,
-      affinity = Affinity.Downstream,
-    )
+  val position = StablePosition(chain = emptyList(), child = null, affinity = Affinity.Downstream)
   return StableSelection(anchor = position, head = position)
 }

--- a/crates/editor-commands/src/commands/set_list_kind.rs
+++ b/crates/editor-commands/src/commands/set_list_kind.rs
@@ -1,9 +1,9 @@
 use editor_crdt::Dot;
-use editor_model::{ChildView, DocView, NodeType, NodeView, PlainNodeEntry, Subtree};
-use editor_state::{Affinity, Position, ResolvedSelection, Selection};
+use editor_model::{ChildView, DocView, NodeType, NodeView, Subtree};
+use editor_state::{ResolvedSelection, Selection, StableResolveCtx, StableSelection};
 use editor_transaction::Transaction;
 
-use crate::helpers::{is_list_type, list_item_own_paragraph_intersects, path_from_ancestor};
+use crate::helpers::{is_list_type, list_item_own_paragraph_intersects};
 use crate::{CommandError, CommandResult};
 
 pub fn set_list_kind(tr: &mut Transaction, target_list_type: NodeType) -> CommandResult {
@@ -95,19 +95,18 @@ fn set_existing_list_kind(
     list_id: Dot,
     target_list_type: NodeType,
 ) -> CommandResult {
-    let (parent_id, current_type) = {
+    let current_type = {
         let view = tr.view();
         let list = view
             .node(list_id)
             .ok_or(CommandError::NodeNotFound(list_id))?;
-        let parent = list.parent().ok_or(CommandError::NoParent(list_id))?;
-        (parent.id(), list.node_type())
+        list.node_type()
     };
     if !is_list_type(current_type) || current_type == target_list_type {
         return Ok(false);
     }
 
-    replace_list_with_kind(tr, parent_id, list_id, target_list_type)
+    replace_list_with_kind(tr, list_id, target_list_type)
 }
 
 fn collect_existing_lists_in_range(rs: &ResolvedSelection<'_>) -> Vec<Dot> {
@@ -133,7 +132,9 @@ fn collect_existing_lists_in_block(
     }
 
     for child in node.child_blocks() {
-        collect_existing_lists_in_block(rs, &child, out);
+        if should_descend_into_child(rs, &child) {
+            collect_existing_lists_in_block(rs, &child, out);
+        }
     }
 }
 
@@ -192,7 +193,9 @@ fn collect_listable_wrap_runs_in_block(
     }
 
     for child in parent.child_blocks() {
-        collect_listable_wrap_runs_in_block(rs, &child, target_list_type, out);
+        if should_descend_into_child(rs, &child) {
+            collect_listable_wrap_runs_in_block(rs, &child, target_list_type, out);
+        }
     }
 }
 
@@ -237,6 +240,14 @@ fn child_intersects_selection(
         ChildView::Block(block) => rs.intersects_subtree(block),
         ChildView::Leaf(_) => rs.contains_leaf_slot(parent, slot),
     }
+}
+
+fn should_descend_into_child(rs: &ResolvedSelection<'_>, child: &NodeView<'_>) -> bool {
+    if !rs.intersects_subtree(child) {
+        return false;
+    }
+    child.node_type() == NodeType::ListItem
+        || !(rs.contains_subtree(child) && !is_run_child_type(child.node_type()))
 }
 
 fn flush_run(parent_id: Dot, current: &mut Vec<ListableRunChild>, out: &mut Vec<ListableWrapRun>) {
@@ -289,42 +300,9 @@ fn wrap_run_into_list(
         return Ok(false);
     }
 
-    let (insert_index, child_root_counts) = {
-        let view = tr.view();
-        (
-            run_insert_index(&view, run)?,
-            collect_run_child_root_counts(&view, run)?,
-        )
-    };
+    let insert_index = run_insert_index(&tr.view(), run)?;
 
-    // TODO(move-node-alias): Replace this run-relative selection restore with
-    // StableSelection once move_node can resolve old dots to re-emitted dots.
-    // Parent-slot endpoints around wrapped direct children are translated here
-    // manually because the run collapses to one list at the parent.
-    let (captured_anchor, captured_head) = {
-        let view = tr.view();
-        (
-            capture_wrapped_run_endpoint(
-                &view,
-                run,
-                insert_index,
-                &child_root_counts,
-                &move_roots,
-                &selection.anchor,
-            ),
-            capture_wrapped_run_endpoint(
-                &view,
-                run,
-                insert_index,
-                &child_root_counts,
-                &move_roots,
-                &selection.head,
-            ),
-        )
-    };
-
-    let mut new_roots = vec![None; move_roots.len()];
-    let mut new_list_id = None;
+    let stable_selection = StableSelection::capture(&selection, &tr.view());
 
     tr.batch::<_, CommandError>(|tr| {
         tr.insert_subtree(
@@ -333,33 +311,17 @@ fn wrap_run_into_list(
             Subtree::leaf(target_list_type.into_node().to_plain()),
         )?;
         let inserted_list_id = block_child_id_at(tr, run.parent_id, insert_index)?;
-        new_list_id = Some(inserted_list_id);
 
-        let mut root_index = 0;
         for child in &run.children {
             match child.node_type {
                 NodeType::Paragraph => {
                     let paragraph_id = child.id;
-                    append_new_list_item_with_paragraph(
-                        tr,
-                        inserted_list_id,
-                        paragraph_id,
-                        root_index,
-                        &mut new_roots,
-                    )?;
-                    root_index += 1;
+                    append_new_list_item_with_paragraph(tr, inserted_list_id, paragraph_id)?;
                 }
                 ty if is_list_type(ty) => {
                     let item_ids = real_list_item_ids(&tr.view(), child.id)?;
                     for item_id in item_ids {
-                        append_existing_list_item(
-                            tr,
-                            inserted_list_id,
-                            item_id,
-                            root_index,
-                            &mut new_roots,
-                        )?;
-                        root_index += 1;
+                        append_existing_list_item(tr, inserted_list_id, item_id)?;
                     }
                     if tr.view().node(child.id).is_some() {
                         tr.remove_subtree(child.id)?;
@@ -387,13 +349,8 @@ fn wrap_run_into_list(
 
     let restored = {
         let view = tr.view();
-        restore_run_selection_endpoints(
-            &view,
-            &new_roots,
-            new_list_id,
-            &captured_anchor,
-            &captured_head,
-        )
+        let ctx = StableResolveCtx::from_live(&view, tr.state().projected.seq_checkout());
+        stable_selection.resolve(&ctx)
     }
     .ok_or_else(|| CommandError::Corrupted("cannot restore list kind selection".into()))?;
     tr.set_selection(Some(restored))?;
@@ -403,7 +360,6 @@ fn wrap_run_into_list(
 
 fn replace_list_with_kind(
     tr: &mut Transaction,
-    parent_id: Dot,
     list_id: Dot,
     target_list_type: NodeType,
 ) -> CommandResult {
@@ -411,106 +367,29 @@ fn replace_list_with_kind(
         return Ok(false);
     };
 
-    let (index, subtree) = {
+    {
         let view = tr.view();
         let list = view
             .node(list_id)
             .ok_or(CommandError::NodeNotFound(list_id))?;
-        let index = list
-            .index()
-            .ok_or_else(|| CommandError::orphan_child(list_id, parent_id))?;
-        let subtree = capture_plain_subtree_as(&view, tr.state(), list_id, target_list_type)?;
-        (index, subtree)
-    };
+        if !is_list_type(list.node_type()) {
+            return Ok(false);
+        }
+    }
 
-    // TODO(move-node-alias): Replace this list-root-relative selection restore with
-    // StableSelection once remove/insert replacement can resolve old dots to new dots.
-    let (captured_anchor, captured_head) = {
-        let view = tr.view();
-        (
-            capture_run_endpoint(&view, &[list_id], &selection.anchor),
-            capture_run_endpoint(&view, &[list_id], &selection.head),
-        )
-    };
+    let stable_selection = StableSelection::capture(&selection, &tr.view());
 
-    let new_list_id = {
-        tr.batch::<_, CommandError>(|tr| {
-            tr.remove_subtree(list_id)?;
-            tr.insert_subtree(parent_id, index, subtree)?;
-            let fulfill_steps = {
-                let view = tr.view();
-                view.node(parent_id)
-                    .map(|parent| editor_transaction::fulfill(&parent))
-                    .unwrap_or_default()
-            };
-            tr.apply_steps(fulfill_steps)?;
-            Ok(())
-        })?;
-        block_child_id_at(tr, parent_id, index)?
-    };
+    tr.replace_block_type(list_id, target_list_type)?;
 
     let restored = {
         let view = tr.view();
-        restore_run_selection_endpoints(
-            &view,
-            &[Some(new_list_id)],
-            Some(new_list_id),
-            &captured_anchor,
-            &captured_head,
-        )
+        let ctx = StableResolveCtx::from_live(&view, tr.state().projected.seq_checkout());
+        stable_selection.resolve(&ctx)
     }
     .ok_or_else(|| CommandError::Corrupted("cannot restore list kind selection".into()))?;
     tr.set_selection(Some(restored))?;
 
     Ok(true)
-}
-
-fn capture_plain_subtree_as(
-    view: &DocView,
-    state: &editor_state::State,
-    block: Dot,
-    node_type: NodeType,
-) -> Result<Subtree, CommandError> {
-    let path = node_path_from_root(view, block)
-        .ok_or_else(|| CommandError::Corrupted("cannot locate list subtree".into()))?;
-    let plain = state.to_plain();
-    let entry = plain_entry_at_path(&plain.root, &path)
-        .ok_or_else(|| CommandError::Corrupted("cannot capture list subtree".into()))?;
-    let mut subtree = plain_entry_to_subtree(entry.clone());
-    subtree.node = node_type.into_node().to_plain();
-    Ok(subtree)
-}
-
-fn node_path_from_root(view: &DocView, node: Dot) -> Option<Vec<usize>> {
-    let mut path: Vec<usize> = view
-        .node(node)?
-        .ancestors()
-        .filter_map(|n| n.index())
-        .collect();
-    path.reverse();
-    Some(path)
-}
-
-fn plain_entry_at_path<'a>(root: &'a PlainNodeEntry, path: &[usize]) -> Option<&'a PlainNodeEntry> {
-    let mut entry = root;
-    for &index in path {
-        entry = entry.children.get(index)?;
-    }
-    Some(entry)
-}
-
-fn plain_entry_to_subtree(entry: PlainNodeEntry) -> Subtree {
-    Subtree {
-        node: entry.node,
-        modifiers: entry.modifiers.into_values().collect(),
-        carry: entry.carry,
-        children: entry
-            .children
-            .into_iter()
-            .map(plain_entry_to_subtree)
-            .collect(),
-        source_dots: Vec::new(),
-    }
 }
 
 fn collect_run_move_roots(view: &DocView, run: &ListableWrapRun) -> Result<Vec<Dot>, CommandError> {
@@ -523,20 +402,6 @@ fn collect_run_move_roots(view: &DocView, run: &ListableWrapRun) -> Result<Vec<D
         }
     }
     Ok(roots)
-}
-
-fn collect_run_child_root_counts(
-    view: &DocView,
-    run: &ListableWrapRun,
-) -> Result<Vec<usize>, CommandError> {
-    run.children
-        .iter()
-        .map(|child| match child.node_type {
-            NodeType::Paragraph => Ok(1),
-            ty if is_list_type(ty) => real_list_item_ids(view, child.id).map(|items| items.len()),
-            _ => Ok(0),
-        })
-        .collect()
 }
 
 fn run_insert_index(view: &DocView, run: &ListableWrapRun) -> Result<usize, CommandError> {
@@ -561,8 +426,6 @@ fn append_new_list_item_with_paragraph(
     tr: &mut Transaction,
     list_id: Dot,
     paragraph_id: Dot,
-    root_index: usize,
-    new_roots: &mut [Option<Dot>],
 ) -> Result<(), CommandError> {
     let target_len = real_list_len(&tr.view(), list_id)?;
     tr.insert_subtree(
@@ -572,7 +435,6 @@ fn append_new_list_item_with_paragraph(
     )?;
     let list_item_id = block_child_id_at(tr, list_id, target_len)?;
     tr.move_node(paragraph_id, list_item_id, 0)?;
-    new_roots[root_index] = first_real_child_id(&tr.view(), list_item_id);
     Ok(())
 }
 
@@ -580,12 +442,9 @@ fn append_existing_list_item(
     tr: &mut Transaction,
     list_id: Dot,
     item_id: Dot,
-    root_index: usize,
-    new_roots: &mut [Option<Dot>],
 ) -> Result<(), CommandError> {
     let target_len = real_list_len(&tr.view(), list_id)?;
     tr.move_node(item_id, list_id, target_len)?;
-    new_roots[root_index] = block_child_id_at(tr, list_id, target_len).ok();
     Ok(())
 }
 
@@ -607,154 +466,6 @@ fn block_child_id_at(tr: &Transaction, parent_id: Dot, index: usize) -> Result<D
         Some(ChildView::Block(block)) => Ok(block.id()),
         _ => Err(CommandError::NodeNotFound(parent_id)),
     }
-}
-
-fn first_real_child_id(view: &DocView, parent_id: Dot) -> Option<Dot> {
-    view.node(parent_id)?
-        .child_blocks()
-        .find(|child| child.id().as_op_dot().is_some())
-        .map(|child| child.id())
-}
-
-enum RunEndpoint {
-    Moved(RunAnchor),
-    ParentSlot(RunParentSlotAnchor),
-    Unchanged(Position),
-}
-
-struct RunAnchor {
-    root_index: usize,
-    path: Vec<usize>,
-    offset: usize,
-    affinity: Affinity,
-}
-
-struct RunParentSlotAnchor {
-    parent_id: Dot,
-    insert_index: usize,
-    root_boundary: usize,
-    affinity: Affinity,
-}
-
-fn capture_wrapped_run_endpoint(
-    view: &DocView,
-    run: &ListableWrapRun,
-    insert_index: usize,
-    child_root_counts: &[usize],
-    roots: &[Dot],
-    pos: &Position,
-) -> RunEndpoint {
-    if pos.node == run.parent_id {
-        let run_end = insert_index + run.children.len();
-        if (insert_index..=run_end).contains(&pos.offset) {
-            let child_boundary = pos.offset - insert_index;
-            let root_boundary = child_root_counts.iter().take(child_boundary).sum();
-            return RunEndpoint::ParentSlot(RunParentSlotAnchor {
-                parent_id: run.parent_id,
-                insert_index,
-                root_boundary,
-                affinity: pos.affinity,
-            });
-        }
-    }
-
-    capture_run_endpoint(view, roots, pos)
-}
-
-fn capture_run_endpoint(view: &DocView, roots: &[Dot], pos: &Position) -> RunEndpoint {
-    roots
-        .iter()
-        .enumerate()
-        .find_map(|(root_index, root)| {
-            path_from_ancestor(view, pos.node, *root).map(|path| RunAnchor {
-                root_index,
-                path,
-                offset: pos.offset,
-                affinity: pos.affinity,
-            })
-        })
-        .map(RunEndpoint::Moved)
-        .unwrap_or(RunEndpoint::Unchanged(*pos))
-}
-
-fn restore_run_selection_endpoints(
-    view: &DocView,
-    new_roots: &[Option<Dot>],
-    new_list_id: Option<Dot>,
-    anchor: &RunEndpoint,
-    head: &RunEndpoint,
-) -> Option<Selection> {
-    Some(Selection::new(
-        restore_run_endpoint(view, new_roots, new_list_id, anchor)?,
-        restore_run_endpoint(view, new_roots, new_list_id, head)?,
-    ))
-}
-
-fn restore_run_endpoint(
-    view: &DocView,
-    new_roots: &[Option<Dot>],
-    new_list_id: Option<Dot>,
-    endpoint: &RunEndpoint,
-) -> Option<Position> {
-    match endpoint {
-        RunEndpoint::Moved(anchor) => {
-            let root = *new_roots.get(anchor.root_index)?.as_ref()?;
-            restore_position_from_root(view, root, &anchor.path, anchor.offset, anchor.affinity)
-        }
-        RunEndpoint::ParentSlot(anchor) => {
-            restore_wrapped_parent_slot(view, new_roots, new_list_id?, anchor)
-        }
-        RunEndpoint::Unchanged(position) => position.resolve(view).map(|_| *position),
-    }
-}
-
-fn restore_wrapped_parent_slot(
-    view: &DocView,
-    new_roots: &[Option<Dot>],
-    new_list_id: Dot,
-    anchor: &RunParentSlotAnchor,
-) -> Option<Position> {
-    let position = if anchor.root_boundary == 0 {
-        Position {
-            node: anchor.parent_id,
-            offset: anchor.insert_index,
-            affinity: anchor.affinity,
-        }
-    } else if anchor.root_boundary >= new_roots.len() {
-        Position {
-            node: anchor.parent_id,
-            offset: anchor.insert_index + 1,
-            affinity: anchor.affinity,
-        }
-    } else {
-        Position {
-            node: new_list_id,
-            offset: anchor.root_boundary,
-            affinity: anchor.affinity,
-        }
-    };
-    position.resolve(view).map(|_| position)
-}
-
-fn restore_position_from_root(
-    view: &DocView,
-    root: Dot,
-    path: &[usize],
-    offset: usize,
-    affinity: Affinity,
-) -> Option<Position> {
-    let mut node = root;
-    for &idx in path {
-        match view.node(node)?.child_at(idx)? {
-            ChildView::Block(block) => node = block.id(),
-            ChildView::Leaf(_) => return None,
-        }
-    }
-    Some(Position {
-        node,
-        offset,
-        affinity,
-    })
 }
 
 #[cfg(test)]
@@ -1067,6 +778,40 @@ mod tests {
     }
 
     #[test]
+    fn full_nested_list_selection_converts_each_intersecting_list() {
+        let (initial, ..) = state! {
+            doc {
+                root: root {
+                    ordered_list {
+                        list_item {
+                            p1: paragraph { text("A") }
+                            ordered_list { list_item { p2: paragraph { text("B") } } }
+                        }
+                    }
+                    paragraph {}
+                }
+            }
+            selection: (root, 0, >) -> (root, 1, <)
+        };
+        let (actual, ..) = transact!(initial, |tr| set_list_kind(&mut tr, NodeType::BulletList));
+        let (expected, ..) = state! {
+            doc {
+                root: root {
+                    bullet_list {
+                        list_item {
+                            p1: paragraph { text("A") }
+                            bullet_list { list_item { p2: paragraph { text("B") } } }
+                        }
+                    }
+                    paragraph {}
+                }
+            }
+            selection: (root, 0, >) -> (root, 1, <)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
     fn nested_child_list_selection_does_not_convert_parent_list() {
         let (initial, ..) = state! {
             doc {
@@ -1170,6 +915,168 @@ mod tests {
                 }
             }
             selection: (p1, 0) -> (p2, 1)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn range_ending_after_unsupported_block_remaps_parent_slot_after_wrapped_run() {
+        let (initial, ..) = state! {
+            doc {
+                r1: root [font_weight(600), text_color("black".to_string()), background_color("none".to_string())] {
+                    bullet_list {
+                        list_item {
+                            p1: paragraph {
+                                text("ㅁㄴㅇ")
+                            }
+                        }
+                    }
+                    paragraph {
+                        text("ㅁㄴㅇ")
+                    }
+                    paragraph {
+                        text("ㅁㄴㅇㄴ")
+                    }
+                    table(proportion: 81) [alignment(editor_model::Alignment::Center)] {
+                        table_row {
+                            table_cell(col_width: Some(160)) {
+                                paragraph {}
+                            }
+                            table_cell {
+                                paragraph {}
+                            }
+                            table_cell(col_width: Some(160)) {
+                                paragraph {
+                                    text("ㅁㄴ")
+                                }
+                                paragraph {
+                                    text("ㅇㄴㅇ")
+                                }
+                            }
+                            table_cell(col_width: Some(160)) {
+                                paragraph {}
+                            }
+                        }
+                        table_row {
+                            table_cell(col_width: Some(160)) {
+                                paragraph {}
+                            }
+                            table_cell {
+                                paragraph {}
+                            }
+                            table_cell(col_width: Some(160)) {
+                                paragraph {}
+                            }
+                            table_cell(col_width: Some(160)) {
+                                paragraph {}
+                            }
+                        }
+                    }
+                    synthetic paragraph {}
+                }
+            }
+            selection: (r1, 4, <) -> (p1, 1, >)
+        };
+
+        let (actual, ..) = transact!(initial, |tr| set_list_kind(&mut tr, NodeType::OrderedList));
+        let (expected, ..) = state! {
+            doc {
+                r1: root [font_weight(600), text_color("black".to_string()), background_color("none".to_string())] {
+                    ordered_list {
+                        list_item {
+                            p1: paragraph {
+                                text("ㅁㄴㅇ")
+                            }
+                        }
+                        list_item {
+                            paragraph {
+                                text("ㅁㄴㅇ")
+                            }
+                        }
+                        list_item {
+                            paragraph {
+                                text("ㅁㄴㅇㄴ")
+                            }
+                        }
+                    }
+                    table(proportion: 81) [alignment(editor_model::Alignment::Center)] {
+                        table_row {
+                            table_cell(col_width: Some(160)) {
+                                paragraph {}
+                            }
+                            table_cell {
+                                paragraph {}
+                            }
+                            table_cell(col_width: Some(160)) {
+                                paragraph {
+                                    text("ㅁㄴ")
+                                }
+                                paragraph {
+                                    text("ㅇㄴㅇ")
+                                }
+                            }
+                            table_cell(col_width: Some(160)) {
+                                paragraph {}
+                            }
+                        }
+                        table_row {
+                            table_cell(col_width: Some(160)) {
+                                paragraph {}
+                            }
+                            table_cell {
+                                paragraph {}
+                            }
+                            table_cell(col_width: Some(160)) {
+                                paragraph {}
+                            }
+                            table_cell(col_width: Some(160)) {
+                                paragraph {}
+                            }
+                        }
+                    }
+                    synthetic paragraph {}
+                }
+            }
+            selection: (r1, 2, <) -> (p1, 1, >)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn range_over_unsupported_block_does_not_convert_its_internal_content() {
+        let (initial, ..) = state! {
+            doc {
+                root: root {
+                    bullet_list {
+                        list_item {
+                            p1: paragraph { text("A") }
+                        }
+                    }
+                    blockquote {
+                        paragraph { text("B") }
+                    }
+                    paragraph {}
+                }
+            }
+            selection: (root, 0, >) -> (root, 2, <)
+        };
+
+        let (actual, ..) = transact!(initial, |tr| set_list_kind(&mut tr, NodeType::OrderedList));
+        let (expected, ..) = state! {
+            doc {
+                root: root {
+                    ordered_list {
+                        list_item {
+                            p1: paragraph { text("A") }
+                        }
+                    }
+                    blockquote {
+                        paragraph { text("B") }
+                    }
+                    paragraph {}
+                }
+            }
+            selection: (root, 0, >) -> (root, 2, <)
         };
         assert_state_eq!(&actual, &expected);
     }

--- a/crates/editor-core/src/tests/alias_e2e.rs
+++ b/crates/editor-core/src/tests/alias_e2e.rs
@@ -1,6 +1,7 @@
 use editor_commands as commands;
 use editor_macros::state;
-use editor_state::{Position, Selection, StablePositionBinding, StableResolveCtx, StableSelection};
+use editor_model::NodeType;
+use editor_state::{Position, Selection, StableResolveCtx, StableSelection};
 use editor_transaction::Transaction;
 
 use crate::editor::Editor;
@@ -112,9 +113,8 @@ fn tracked_range_locate_survives_merge_precisely() {
 #[test]
 fn tracked_range_locate_survives_container_start_block_move() {
     // p1 is empty (0 children), so its offset-0 low endpoint captures as
-    // `StablePositionBinding::ContainerStart`, not `Adjacent` — `capture_range_start`
-    // only falls back to `ContainerStart` when the container has no children to
-    // bind against. The cross-block range keeps the overall selection non-collapsed,
+    // p1 has no children, so its offset-0 low endpoint has no child dot to bind
+    // against. The cross-block range keeps the overall selection non-collapsed,
     // since `TrackedRange::locate` filters collapsed ranges out structurally.
     let (state, p1, p2) = state! {
         doc {
@@ -130,14 +130,8 @@ fn tracked_range_locate_survives_container_start_block_move() {
     let sel_from_start = Selection::new(Position::new(p1, 0), Position::new(p2, 3));
     let stable = StableSelection::capture(&sel_from_start, &view_before);
 
-    assert!(matches!(
-        stable.anchor.binding,
-        StablePositionBinding::ContainerStart
-    ));
-    assert!(matches!(
-        stable.head.binding,
-        StablePositionBinding::Adjacent { .. }
-    ));
+    assert!(stable.anchor.child.is_none());
+    assert!(stable.head.child.is_some());
 
     let range = TrackedRange::new("r".into(), "g".into(), stable, String::new(), &state);
 
@@ -214,6 +208,69 @@ fn move_undo_redo_selection_resolves_precisely_across_generations() {
     assert_ne!(
         resolved_after_redo.anchor.node, p1,
         "redo must re-apply the move onto a fresh dot, not the original"
+    );
+}
+
+#[test]
+fn replace_block_type_undo_redo_selection_resolves_precisely_across_generations() {
+    let (initial, list, p1) = state! {
+        doc {
+            root {
+                list: ordered_list {
+                    list_item { p1: paragraph { text("hello") } }
+                }
+                paragraph {}
+            }
+        }
+        selection: (p1, 0)
+    };
+    let before_view = initial.view();
+    let sel_in_p1 = Selection::new(Position::new(p1, 1), Position::new(p1, 4));
+    let captured = StableSelection::capture(&sel_in_p1, &before_view);
+
+    let mut editor = Editor::new_test(initial);
+
+    editor
+        .transact(|tr| {
+            tr.replace_block_type(list, NodeType::BulletList)?;
+            Ok(())
+        })
+        .unwrap();
+    let (text_after_replace, resolved_after_replace) = resolve_text(&editor, &captured);
+    assert_eq!(text_after_replace, "ell");
+    assert_ne!(
+        resolved_after_replace.anchor.node, p1,
+        "the replaced subtree must now live under fresh dots"
+    );
+
+    let post_replace_view = editor.state().view();
+    let recaptured = StableSelection::capture(&resolved_after_replace, &post_replace_view);
+
+    editor.apply(Message::History {
+        op: HistoryOp::Undo,
+    });
+    let (text_orig_via_gen1, resolved_orig) = resolve_text(&editor, &captured);
+    assert_eq!(text_orig_via_gen1, "ell");
+    assert_eq!(
+        resolved_orig.anchor.node, p1,
+        "undo must restore the original paragraph dot"
+    );
+
+    let (text_orig_via_gen2, _) = resolve_text(&editor, &recaptured);
+    assert_eq!(
+        text_orig_via_gen2, "ell",
+        "an anchor captured against the replacement dots must still resolve to the \
+         original content after undo"
+    );
+
+    editor.apply(Message::History {
+        op: HistoryOp::Redo,
+    });
+    let (text_after_redo, resolved_after_redo) = resolve_text(&editor, &captured);
+    assert_eq!(text_after_redo, "ell");
+    assert_ne!(
+        resolved_after_redo.anchor.node, p1,
+        "redo must re-apply the replacement onto fresh dots"
     );
 }
 

--- a/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
@@ -396,8 +396,13 @@ export interface Size {
 
 export interface StablePosition {
     chain: Dot[];
-    binding: StablePositionBinding;
+    child: StablePositionChild | undefined;
     affinity: Affinity;
+}
+
+export interface StablePositionChild {
+    dot: Dot;
+    bind: Bind;
 }
 
 export interface StableSelection {
@@ -606,8 +611,6 @@ export type SelectionExpansionUnit = "word" | "sentence" | "paragraph" | "all";
 export type SelectionOp = { type: "set"; selection: Selection } | { type: "set_frozen"; selection: StableSelection } | { type: "unset" } | { type: "set_at"; page: number; x: number; y: number } | { type: "set_flat"; start: number; end: number } | { type: "extend_to"; anchor: Position; head_page: number; head_x: number; head_y: number; base_selection: Selection | undefined; allow_collapse?: boolean } | { type: "select_unit_at"; page: number; x: number; y: number; unit: SelectionPointUnit } | { type: "expand"; unit: SelectionExpansionUnit };
 
 export type SelectionPointUnit = "word" | "sentence" | "paragraph";
-
-export type StablePositionBinding = { type: "adjacent"; anchor: Dot; bind: Bind } | { type: "container_start" };
 
 export type StateField = "doc" | "root_attrs" | "selection" | "cursor" | "page_sizes" | "external_elements" | "table_overlays" | "link_rects" | "ime" | "modifiers" | "block" | "tracked_ranges" | "last_history_tag" | "placeholder";
 

--- a/crates/editor-ffi/pkg/server/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/server/editor_ffi.d.ts
@@ -443,8 +443,13 @@ export interface Size {
 
 export interface StablePosition {
     chain: Dot[];
-    binding: StablePositionBinding;
+    child: StablePositionChild | undefined;
     affinity: Affinity;
+}
+
+export interface StablePositionChild {
+    dot: Dot;
+    bind: Bind;
 }
 
 export interface StableSelection {
@@ -655,8 +660,6 @@ export type SelectionExpansionUnit = "word" | "sentence" | "paragraph" | "all";
 export type SelectionOp = { type: "set"; selection: Selection } | { type: "set_frozen"; selection: StableSelection } | { type: "unset" } | { type: "set_at"; page: number; x: number; y: number } | { type: "set_flat"; start: number; end: number } | { type: "extend_to"; anchor: Position; head_page: number; head_x: number; head_y: number; base_selection: Selection | undefined; allow_collapse?: boolean } | { type: "select_unit_at"; page: number; x: number; y: number; unit: SelectionPointUnit } | { type: "expand"; unit: SelectionExpansionUnit };
 
 export type SelectionPointUnit = "word" | "sentence" | "paragraph";
-
-export type StablePositionBinding = { type: "adjacent"; anchor: Dot; bind: Bind } | { type: "container_start" };
 
 export type StateField = "doc" | "root_attrs" | "selection" | "cursor" | "page_sizes" | "external_elements" | "table_overlays" | "link_rects" | "ime" | "modifiers" | "block" | "tracked_ranges" | "last_history_tag" | "placeholder";
 

--- a/crates/editor-state/src/lib.rs
+++ b/crates/editor-state/src/lib.rs
@@ -76,7 +76,7 @@ pub use selection_expansion::{
     resolve_paragraph_selection_expansion, resolve_sentence_selection_expansion,
     resolve_word_selection_expansion,
 };
-pub use stable_position::{StablePosition, StablePositionBinding, StableResolveCtx};
+pub use stable_position::{StablePosition, StablePositionChild, StableResolveCtx};
 pub use stable_selection::StableSelection;
 pub use state::*;
 pub use to_plain::to_plain;

--- a/crates/editor-state/src/stable_position.rs
+++ b/crates/editor-state/src/stable_position.rs
@@ -12,18 +12,18 @@ use crate::bind::Bind;
 
 #[ffi]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case", tag = "type")]
-pub enum StablePositionBinding {
-    Adjacent { anchor: Dot, bind: Bind },
-    ContainerStart,
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub struct StablePositionChild {
+    pub dot: Dot,
+    pub bind: Bind,
 }
 
 #[ffi]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
 pub struct StablePosition {
     pub chain: Vec<Dot>,
-    pub binding: StablePositionBinding,
+    pub child: Option<StablePositionChild>,
     pub affinity: Affinity,
 }
 
@@ -88,20 +88,17 @@ impl StablePosition {
         // this runs on the per-keystroke selection-capture path, so a linear scan makes
         // it `O(block)` inside a large paragraph.
         let child_count = host.child_count();
-        let binding = child_binding(child_count).map_or(
-            StablePositionBinding::ContainerStart,
-            |(offset, bind)| StablePositionBinding::Adjacent {
-                anchor: child_elem_id(
-                    &host
-                        .child_at(offset)
-                        .expect("child binding offset must be live"),
-                ),
-                bind,
-            },
-        );
+        let child = child_binding(child_count).map(|(offset, bind)| StablePositionChild {
+            dot: child_elem_id(
+                &host
+                    .child_at(offset)
+                    .expect("child binding offset must be live"),
+            ),
+            bind,
+        });
         StablePosition {
             chain,
-            binding,
+            child,
             affinity: pos.affinity,
         }
     }
@@ -168,8 +165,37 @@ impl<'a> StableResolveCtx<'a> {
     }
 }
 
-fn index_of(host: &NodeView, anchor: Dot) -> Option<usize> {
-    host.children().position(|c| child_elem_id(&c) == anchor)
+fn index_of(host: &NodeView, dot: Dot) -> Option<usize> {
+    host.children().position(|c| child_elem_id(&c) == dot)
+}
+
+fn direct_child_containing(host: &NodeView, target: Dot, ctx: &StableResolveCtx) -> Option<usize> {
+    let host_id = host.id();
+    let mut cursor = if ctx.view.node(target).is_some() {
+        Some(target)
+    } else {
+        ctx.view.block_of(target)
+    };
+
+    while let Some(id) = cursor {
+        let parent = ctx.view.parent_of(id)?;
+        if parent == host_id {
+            return index_of(host, id);
+        }
+        cursor = Some(parent);
+    }
+    None
+}
+
+fn is_inline_dot(dot: Dot, ctx: &StableResolveCtx) -> bool {
+    let dot = ctx.alias(dot);
+    ctx.view
+        .leaf(dot)
+        .is_some_and(|leaf| leaf.node_type().spec().inline)
+}
+
+fn resolves_via_child_parent(host: &NodeView, dot: Dot, ctx: &StableResolveCtx) -> bool {
+    is_inline_dot(dot, ctx) || host.spec().is_textblock()
 }
 
 fn offset_within(c: &NodeView, target: Dot, ctx: &StableResolveCtx) -> usize {
@@ -211,24 +237,49 @@ fn offset_within(c: &NodeView, target: Dot, ctx: &StableResolveCtx) -> usize {
 
 impl StablePosition {
     pub fn resolve(&self, ctx: &StableResolveCtx) -> Option<Position> {
-        if let StablePositionBinding::Adjacent { anchor, bind } = &self.binding {
-            let a = ctx.alias(*anchor);
-            let host_dot = if ctx.view.node(a).is_some() {
-                ctx.view.parent_of(a)
-            } else {
-                ctx.view.block_of(a)
-            };
-            if let Some(hd) = host_dot
-                && let Some(host) = ctx.view.node(hd)
-                && let Some(j) = index_of(&host, a)
-            {
-                return Some(Position {
-                    node: host.id(),
-                    offset: j + usize::from(*bind == Bind::Right),
-                    affinity: self.affinity,
-                });
-            }
+        if let Some(child) = &self.child
+            && is_inline_dot(child.dot, ctx)
+            && let Some(pos) = self.resolve_child_parent_boundary(ctx, child.dot, child.bind)
+        {
+            return Some(pos);
         }
+
+        let (host, next_child) = self.resolve_chain_host(ctx)?;
+        if next_child.is_none()
+            && let Some(child) = &self.child
+            && host.spec().is_textblock()
+            && let Some(pos) = self.resolve_child_parent_boundary(ctx, child.dot, child.bind)
+        {
+            return Some(pos);
+        }
+        Some(self.resolve_in_host(ctx, host, next_child))
+    }
+
+    fn resolve_child_parent_boundary(
+        &self,
+        ctx: &StableResolveCtx,
+        dot: Dot,
+        bind: Bind,
+    ) -> Option<Position> {
+        let dot = ctx.alias(dot);
+        let host_dot = if ctx.view.node(dot).is_some() {
+            ctx.view.parent_of(dot)
+        } else {
+            ctx.view.block_of(dot)
+        };
+        let host = ctx.view.node(host_dot?)?;
+        let offset = index_of(&host, dot)? + usize::from(bind == Bind::Right);
+        Some(Position {
+            node: host.id(),
+            offset,
+            affinity: self.affinity,
+        })
+    }
+
+    fn resolve_chain_host<'a>(
+        &self,
+        ctx: &'a StableResolveCtx<'a>,
+    ) -> Option<(NodeView<'a>, Option<Dot>)> {
         if self.chain.is_empty() {
             return None;
         }
@@ -246,25 +297,39 @@ impl StablePosition {
             return None;
         }
         let host = ctx.view.node(ctx.alias(self.chain[k])).unwrap();
-        let offset = if k == self.chain.len() - 1 {
-            match &self.binding {
-                StablePositionBinding::ContainerStart => 0,
-                StablePositionBinding::Adjacent { anchor, bind } => {
-                    let anchor = ctx.alias(*anchor);
-                    match index_of(&host, anchor) {
+        let next_child = (k < self.chain.len() - 1).then(|| ctx.alias(self.chain[k + 1]));
+        Some((host, next_child))
+    }
+
+    fn resolve_in_host(
+        &self,
+        ctx: &StableResolveCtx,
+        host: NodeView<'_>,
+        next_child: Option<Dot>,
+    ) -> Position {
+        let offset = if let Some(next_child) = next_child {
+            offset_within(&host, next_child, ctx)
+        } else {
+            match &self.child {
+                None => 0,
+                Some(StablePositionChild { dot, bind }) => {
+                    let aliased = ctx.alias(*dot);
+                    match index_of(&host, aliased).or_else(|| {
+                        (!resolves_via_child_parent(&host, aliased, ctx))
+                            .then(|| direct_child_containing(&host, aliased, ctx))
+                            .flatten()
+                    }) {
                         Some(j) => j + usize::from(*bind == Bind::Right),
-                        None => offset_within(&host, anchor, ctx),
+                        None => offset_within(&host, aliased, ctx),
                     }
                 }
             }
-        } else {
-            offset_within(&host, ctx.alias(self.chain[k + 1]), ctx)
         };
-        Some(Position {
+        Position {
             node: host.id(),
             offset,
             affinity: self.affinity,
-        })
+        }
     }
 }
 
@@ -331,7 +396,7 @@ mod tests {
         let (pd, para) = para_with(&[]);
         let view = DocView::new(&pd);
         let sp = StablePosition::capture(&Position::new(para, 0), &view);
-        assert!(matches!(sp.binding, StablePositionBinding::ContainerStart));
+        assert!(sp.child.is_none());
         assert_eq!(sp.chain.last(), Some(&para));
         assert_eq!(sp.chain.first(), view.root().map(|r| r.id()).as_ref());
     }
@@ -341,7 +406,7 @@ mod tests {
         let (pd, para) = para_with(&[SeqItem::Char('a'), SeqItem::Char('b')]);
         let view = DocView::new(&pd);
         let sp = StablePosition::capture(&Position::new(para, 0), &view);
-        assert!(matches!(sp.binding, StablePositionBinding::ContainerStart));
+        assert!(sp.child.is_none());
     }
 
     #[test]
@@ -355,11 +420,11 @@ mod tests {
         };
         let sp = StablePosition::capture(&pos, &view);
         assert_eq!(
-            sp.binding,
-            StablePositionBinding::Adjacent {
-                anchor: Dot::new(1, 3),
+            sp.child,
+            Some(StablePositionChild {
+                dot: Dot::new(1, 3),
                 bind: Bind::Left,
-            }
+            })
         );
     }
 
@@ -374,11 +439,11 @@ mod tests {
         };
         let sp = StablePosition::capture(&pos, &view);
         assert_eq!(
-            sp.binding,
-            StablePositionBinding::Adjacent {
-                anchor: Dot::new(1, 3),
+            sp.child,
+            Some(StablePositionChild {
+                dot: Dot::new(1, 3),
                 bind: Bind::Right,
-            }
+            })
         );
     }
 
@@ -393,11 +458,11 @@ mod tests {
         };
         let sp = StablePosition::capture(&pos, &view);
         assert_eq!(
-            sp.binding,
-            StablePositionBinding::Adjacent {
-                anchor: Dot::new(1, 3),
+            sp.child,
+            Some(StablePositionChild {
+                dot: Dot::new(1, 3),
                 bind: Bind::Right,
-            }
+            })
         );
     }
 
@@ -405,20 +470,30 @@ mod tests {
     fn types_construct_and_compare() {
         let sp = StablePosition {
             chain: vec![Dot::ROOT, Dot::new(1, 1)],
-            binding: StablePositionBinding::Adjacent {
-                anchor: Dot::new(1, 2),
+            child: Some(StablePositionChild {
+                dot: Dot::new(1, 2),
                 bind: Bind::Left,
-            },
+            }),
             affinity: Affinity::Downstream,
         };
         assert_eq!(sp.clone(), sp);
-        assert!(matches!(sp.binding, StablePositionBinding::Adjacent { .. }));
+        assert!(sp.child.is_some());
         let cs = StablePosition {
             chain: vec![Dot::ROOT],
-            binding: StablePositionBinding::ContainerStart,
+            child: None,
             affinity: Affinity::Upstream,
         };
         assert_ne!(sp, cs);
+    }
+
+    #[test]
+    fn old_binding_field_is_rejected() {
+        let value = serde_json::json!({
+            "chain": [Dot::ROOT],
+            "binding": { "type": "container_start" },
+            "affinity": Affinity::Downstream,
+        });
+        assert!(serde_json::from_value::<StablePosition>(value).is_err());
     }
 
     #[test]
@@ -460,7 +535,7 @@ mod tests {
         let ctx = StableResolveCtx::new(&view, &logs.seq);
         let pos = Position::new(para, 0);
         let sp = StablePosition::capture(&pos, &view);
-        assert!(matches!(sp.binding, StablePositionBinding::ContainerStart));
+        assert!(sp.child.is_none());
         assert_eq!(sp.resolve(&ctx), Some(pos));
     }
 
@@ -509,6 +584,53 @@ mod tests {
             let sp = StablePosition::capture(&pos, &view);
             assert_eq!(sp.resolve(&ctx), Some(pos), "root offset {offset}");
         }
+    }
+
+    #[test]
+    fn block_container_boundary_stays_in_captured_host_when_anchor_moves_inside_wrapper() {
+        let root = Dot::ROOT;
+        let p1 = Dot::new(1, 1);
+        let p2 = Dot::new(1, 2);
+        let pre_items = vec![
+            (p1, block(NodeType::Paragraph, vec![root])),
+            (p2, block(NodeType::Paragraph, vec![root])),
+        ];
+        let pre = project_document(&doclogs(&ins_only(&pre_items))).unwrap();
+        let pre_view = DocView::new(&pre);
+        let root_id = pre_view.root().unwrap().id();
+        let captured = StablePosition::capture(
+            &Position {
+                node: root_id,
+                offset: 1,
+                affinity: Affinity::Upstream,
+            },
+            &pre_view,
+        );
+
+        let list = Dot::new(2, 1);
+        let item = Dot::new(2, 2);
+        let moved_p1 = Dot::new(2, 3);
+        let post_items = vec![
+            (list, block(NodeType::BulletList, vec![root])),
+            (item, block(NodeType::ListItem, vec![root, list])),
+            (moved_p1, block(NodeType::Paragraph, vec![root, list, item])),
+            (p2, block(NodeType::Paragraph, vec![root])),
+        ];
+        let mut post_logs = doclogs(&ins_only(&post_items));
+        post_logs.aliases.apply(AliasOp {
+            pairs: vec![AliasRun {
+                old_start: p1,
+                len: 1,
+                new_start: moved_p1,
+            }],
+        });
+        let post = project_document(&post_logs).unwrap();
+        let post_view = DocView::new(&post);
+        let ctx = StableResolveCtx::new(&post_view, &post_logs.seq);
+
+        let resolved = captured.resolve(&ctx).unwrap();
+        assert_eq!(resolved.node, post_view.root().unwrap().id());
+        assert_eq!(resolved.offset, 1);
     }
 
     fn pre_post_delete_b() -> (ProjectedDoc, ProjectedDoc, DocLogs, Dot) {
@@ -711,10 +833,10 @@ mod tests {
         let ctx = StableResolveCtx::new(&view, &logs.seq);
         let sp = StablePosition {
             chain: vec![view.root().unwrap().id(), para],
-            binding: StablePositionBinding::Adjacent {
-                anchor: Dot::new(9, 9),
+            child: Some(StablePositionChild {
+                dot: Dot::new(9, 9),
                 bind: Bind::Left,
-            },
+            }),
             affinity: Affinity::Downstream,
         };
         let r = sp.resolve(&ctx).unwrap();
@@ -813,10 +935,10 @@ mod tests {
         let para_view = view.node(para).expect("paragraph survives normalize");
         let sp = StablePosition {
             chain: vec![view.root().unwrap().id(), bq, para],
-            binding: StablePositionBinding::Adjacent {
-                anchor: pb,
+            child: Some(StablePositionChild {
+                dot: pb,
                 bind: Bind::Left,
-            },
+            }),
             affinity: Affinity::Downstream,
         };
         let r = sp.resolve(&ctx).unwrap();
@@ -928,11 +1050,11 @@ mod tests {
         };
         let sp = StablePosition::capture(&pos, &pre_view);
         assert_eq!(
-            sp.binding,
-            StablePositionBinding::Adjacent {
-                anchor: a,
+            sp.child,
+            Some(StablePositionChild {
+                dot: a,
                 bind: Bind::Right,
-            }
+            })
         );
 
         let mut post_ev = ins_only(&pre_items);
@@ -993,11 +1115,11 @@ mod tests {
         };
         let sp = StablePosition::capture(&pos, &pre_view);
         assert_eq!(
-            sp.binding,
-            StablePositionBinding::Adjacent {
-                anchor: gen1,
+            sp.child,
+            Some(StablePositionChild {
+                dot: gen1,
                 bind: Bind::Right,
-            }
+            })
         );
 
         let mut ev = ins_only(&pre_items);
@@ -1064,11 +1186,11 @@ mod tests {
         };
         let sp = StablePosition::capture(&pos, &mid_view);
         assert_eq!(
-            sp.binding,
-            StablePositionBinding::Adjacent {
-                anchor: gen2,
+            sp.child,
+            Some(StablePositionChild {
+                dot: gen2,
                 bind: Bind::Right,
-            }
+            })
         );
 
         let mut post_ev = mid_ev.clone();
@@ -1112,7 +1234,7 @@ mod tests {
         let pre_view = DocView::new(&pre);
         let pos = Position::new(empty_para, 0);
         let sp = StablePosition::capture(&pos, &pre_view);
-        assert!(matches!(sp.binding, StablePositionBinding::ContainerStart));
+        assert!(sp.child.is_none());
         assert_eq!(sp.chain.last(), Some(&empty_para));
 
         let mut ev = ins_only(&pre_items);
@@ -1170,10 +1292,10 @@ mod tests {
         let root_id = view.root().unwrap().id();
         let sp = StablePosition {
             chain: vec![root_id],
-            binding: StablePositionBinding::Adjacent {
-                anchor: root_id,
+            child: Some(StablePositionChild {
+                dot: root_id,
                 bind: Bind::Left,
-            },
+            }),
             affinity: Affinity::Downstream,
         };
         let r = sp.resolve(&ctx).unwrap();

--- a/crates/editor-state/src/traversal.rs
+++ b/crates/editor-state/src/traversal.rs
@@ -18,10 +18,6 @@ fn node_path(node: &NodeView) -> Vec<usize> {
     p
 }
 
-fn is_prefix_of(prefix: &[usize], full: &[usize]) -> bool {
-    full.starts_with(prefix)
-}
-
 fn position_before_or_at_node_start(
     pos_path: &[usize],
     pos_offset: usize,
@@ -56,39 +52,30 @@ fn position_after_or_at_node_end(
     pos_path.len() == node_path.len() && pos_offset >= node_end_offset
 }
 
-fn path_intersects_range(node_path: &[usize], from_path: &[usize], to_path: &[usize]) -> bool {
-    // Case 1: node is an ancestor of either endpoint (node_path is a prefix of from/to path)
-    if is_prefix_of(node_path, from_path) || is_prefix_of(node_path, to_path) {
-        return true;
-    }
+fn subtree_end_path(node_path: &[usize], child_count: usize) -> Vec<usize> {
+    let Some((&last, parent)) = node_path.split_last() else {
+        return vec![child_count];
+    };
+    let mut end = parent.to_vec();
+    end.push(last + 1);
+    end
+}
 
-    // Case 2: node is a sibling between the endpoints under a shared parent
-    if !node_path.is_empty() {
-        let (&node_idx, node_parent) = node_path.split_last().unwrap();
-        if is_prefix_of(node_parent, from_path) && is_prefix_of(node_parent, to_path) {
-            let from_idx = from_path.get(node_parent.len()).copied().unwrap_or(0);
-            let to_idx = to_path.get(node_parent.len()).copied().unwrap_or(0);
-            let lo = from_idx.min(to_idx);
-            let hi = from_idx.max(to_idx);
-            if lo <= node_idx && node_idx <= hi {
-                return true;
-            }
-        }
-    }
-
-    // Case 3: node lies strictly between endpoints lexicographically
-    if node_path > from_path && node_path < to_path {
-        return true;
-    }
-
-    false
+fn subtree_intersects_range(
+    node_path: &[usize],
+    child_count: usize,
+    from_path: &[usize],
+    to_path: &[usize],
+) -> bool {
+    let end_path = subtree_end_path(node_path, child_count);
+    from_path < end_path.as_slice() && node_path < to_path
 }
 
 pub fn intersects_subtree(rs: &ResolvedSelection, node: &NodeView) -> bool {
     let from_path = rs.from().path();
     let to_path = rs.to().path();
     let np = node_path(node);
-    path_intersects_range(&np, from_path, to_path)
+    subtree_intersects_range(&np, node.child_count(), from_path, to_path)
 }
 
 pub fn contains_subtree(rs: &ResolvedSelection, node: &NodeView) -> bool {
@@ -206,7 +193,7 @@ fn last_child_slot(block: &NodeView, base: &[usize], to: &[usize]) -> Option<usi
 
 fn first_covered_leaf_dot(block: &NodeView, from: &[usize], to: &[usize]) -> Option<Dot> {
     let base = node_path(block);
-    if !path_intersects_range(&base, from, to) {
+    if !subtree_intersects_range(&base, block.child_count(), from, to) {
         return None;
     }
 
@@ -229,7 +216,7 @@ fn first_covered_leaf_dot(block: &NodeView, from: &[usize], to: &[usize]) -> Opt
 
 fn last_covered_leaf_dot(block: &NodeView, from: &[usize], to: &[usize]) -> Option<Dot> {
     let base = node_path(block);
-    if !path_intersects_range(&base, from, to) {
+    if !subtree_intersects_range(&base, block.child_count(), from, to) {
         return None;
     }
 
@@ -570,6 +557,31 @@ mod tests {
         assert!(
             intersects_subtree(&rs_p1, &root_nv),
             "root (ancestor) intersects"
+        );
+    }
+
+    #[test]
+    fn intersects_subtree_excludes_block_at_exclusive_end_boundary() {
+        let (pd, root, _p1, p2) = two_paras();
+        let view = DocView::new(&pd);
+        let rs = Selection::new(
+            Position {
+                node: root,
+                offset: 0,
+                affinity: crate::Affinity::Downstream,
+            },
+            Position {
+                node: root,
+                offset: 1,
+                affinity: crate::Affinity::Upstream,
+            },
+        )
+        .resolve(&view)
+        .unwrap();
+
+        assert!(
+            !intersects_subtree(&rs, &view.node(p2).unwrap()),
+            "block starting at the exclusive end boundary must not intersect"
         );
     }
 

--- a/crates/editor-transaction/src/error.rs
+++ b/crates/editor-transaction/src/error.rs
@@ -1,5 +1,5 @@
 use editor_crdt::Dot;
-use editor_model::ModifierType;
+use editor_model::{ModifierType, NodeType};
 use editor_state::StateError;
 
 #[derive(Debug, thiserror::Error)]
@@ -54,6 +54,18 @@ pub enum StepError {
 
     #[error("move target {block:?} carries unknown content and cannot move losslessly")]
     UnknownBearingMove { block: Dot },
+
+    #[error("replace target {block:?} carries unknown content and cannot replace type losslessly")]
+    UnknownBearingReplace { block: Dot },
+
+    #[error(
+        "cannot replace {block:?} block type from {old_type:?} to {new_type:?} without changing its children"
+    )]
+    IncompatibleBlockTypeReplacement {
+        block: Dot,
+        old_type: NodeType,
+        new_type: NodeType,
+    },
 
     #[error(transparent)]
     State(#[from] StateError),

--- a/crates/editor-transaction/src/step.rs
+++ b/crates/editor-transaction/src/step.rs
@@ -1,5 +1,5 @@
 use editor_crdt::{Dot, Op};
-use editor_model::{EditOp, Modifier, ModifierType, PlainNode, Subtree};
+use editor_model::{EditOp, Modifier, ModifierType, NodeType, PlainNode, Subtree};
 use editor_state::Selection;
 use editor_state::{BatchedState, Composition, PendingModifiers, State};
 use serde::{Deserialize, Serialize};
@@ -83,6 +83,11 @@ pub enum Step {
         block: Dot,
         old_node: PlainNode,
         new_node: PlainNode,
+    },
+    ReplaceBlockType {
+        block: Dot,
+        old_type: NodeType,
+        new_type: NodeType,
     },
     AddModifier {
         block: Dot,
@@ -202,6 +207,11 @@ impl Step {
                 old_node,
                 new_node,
             } => steps::set_node::apply_to(batched, *block, old_node, new_node),
+            Step::ReplaceBlockType {
+                block,
+                old_type,
+                new_type,
+            } => steps::replace_block_type::apply_to(batched, *block, *old_type, *new_type),
             Step::AddModifier { block, modifier } => {
                 steps::add_modifier::apply_to(batched, *block, modifier)
             }
@@ -269,6 +279,11 @@ impl Step {
                 old_node,
                 new_node,
             } => steps::set_node::inverse(*block, old_node.clone(), new_node.clone()),
+            Step::ReplaceBlockType {
+                block,
+                old_type,
+                new_type,
+            } => steps::replace_block_type::inverse(*block, *old_type, *new_type),
             Step::AddModifier { block, modifier } => {
                 steps::add_modifier::inverse(*block, modifier.clone())
             }

--- a/crates/editor-transaction/src/steps/mod.rs
+++ b/crates/editor-transaction/src/steps/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod remove_modifier;
 pub(crate) mod remove_span_modifier;
 pub(crate) mod remove_subtree;
 pub(crate) mod remove_text;
+pub(crate) mod replace_block_type;
 pub(crate) mod set_composition;
 pub(crate) mod set_node;
 pub(crate) mod set_node_carry;

--- a/crates/editor-transaction/src/steps/replace_block_type.rs
+++ b/crates/editor-transaction/src/steps/replace_block_type.rs
@@ -1,0 +1,85 @@
+use editor_crdt::Dot;
+use editor_model::{AliasOp, Child, EditOp, NodeType};
+use editor_state::BatchedState;
+
+use crate::steps::support;
+use crate::{Step, StepError};
+
+pub(crate) fn inverse(block: Dot, old_type: NodeType, new_type: NodeType) -> Step {
+    Step::ReplaceBlockType {
+        block,
+        old_type: new_type,
+        new_type: old_type,
+    }
+}
+
+pub(crate) fn apply_to(
+    batched: &mut BatchedState,
+    block: Dot,
+    _old_type: NodeType,
+    new_type: NodeType,
+) -> Result<(), StepError> {
+    let block = {
+        let view = batched.projected.view();
+        view.alias_classes().resolve_with(block, |dot| {
+            batched.projected.block_node_type(dot).is_some()
+        })
+    };
+
+    if support::subtree_has_unknown(&batched.projected, block) {
+        return Err(StepError::UnknownBearingReplace { block });
+    }
+
+    let (parent, index, subtree, dots) = {
+        let ps = &batched.projected;
+        let old_type = ps
+            .block_node_type(block)
+            .ok_or(StepError::NodeNotFound(block))?;
+        let child_types: Vec<NodeType> = ps
+            .block_children(block)
+            .ok_or(StepError::NodeNotFound(block))?
+            .into_iter()
+            .filter_map(|child| match child {
+                Child::Block(id) => ps.block_node_type(id),
+                Child::Leaf { item, .. } => item.as_child_type(),
+            })
+            .collect();
+        if !new_type.spec().content.matches_sequence(&child_types) {
+            return Err(StepError::IncompatibleBlockTypeReplacement {
+                block,
+                old_type,
+                new_type,
+            });
+        }
+
+        let parent = ps.parent_of(block).ok_or(StepError::NodeNotFound(block))?;
+        let children = support::child_elem_ids(ps, parent);
+        let index = children
+            .iter()
+            .position(|d| *d == block)
+            .ok_or(StepError::NodeNotFound(block))?;
+        let mut subtree =
+            support::capture_subtree(ps, block).ok_or(StepError::NodeNotFound(block))?;
+        subtree.node = new_type.into_node().to_plain();
+        let dots = support::subtree_dots(ps, block).ok_or(StepError::NodeNotFound(block))?;
+        (parent, index, subtree, dots)
+    };
+
+    for op in support::delete_dots_ops(&batched.projected, &dots) {
+        batched.apply(op)?;
+    }
+
+    let pos = support::child_seq_insert_pos(&batched.projected, parent, index)?;
+    let parents = support::self_inclusive_parents(&batched.projected, parent)
+        .ok_or(StepError::NodeNotFound(parent))?;
+    let mut seq_pos = pos;
+    let mut pairs = Vec::new();
+    support::emit_subtree(batched, &subtree, &parents, &mut seq_pos, &mut pairs)?;
+    if !pairs.is_empty() {
+        batched.apply(EditOp::Alias(AliasOp {
+            pairs: support::compress_alias_pairs(&pairs),
+        }))?;
+    }
+
+    Ok(())
+}

--- a/crates/editor-transaction/src/transaction.rs
+++ b/crates/editor-transaction/src/transaction.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use editor_crdt::Dot;
-use editor_model::{DocView, Modifier, ModifierType, PlainNode, Subtree};
+use editor_model::{DocView, Modifier, ModifierType, NodeType, PlainNode, Subtree};
 use editor_state::Selection;
 use editor_state::undo::RecordedOp;
 use editor_state::{BatchedState, Composition, PendingModifiers, State};
@@ -252,6 +252,19 @@ impl Transaction {
             block,
             old_node,
             new_node,
+        })
+    }
+
+    pub fn replace_block_type(&mut self, block: Dot, new_type: NodeType) -> Result<(), StepError> {
+        let old_type = self
+            .state
+            .projected
+            .block_node_type(block)
+            .ok_or(StepError::NodeNotFound(block))?;
+        self.apply_step(Step::ReplaceBlockType {
+            block,
+            old_type,
+            new_type,
         })
     }
 
@@ -1017,6 +1030,44 @@ mod tests {
         }
     }
 
+    fn assert_replace_type_pairs_match_content(
+        before_items: &BTreeMap<Dot, SeqItem>,
+        pd: &ProjectedState,
+        replaced: Dot,
+        new_type: NodeType,
+        pairs: &[editor_model::AliasRun],
+    ) {
+        for r in pairs {
+            for i in 0..r.len as u64 {
+                let old = Dot::new(r.old_start.actor, r.old_start.clock + i);
+                let new = Dot::new(r.new_start.actor, r.new_start.clock + i);
+                let old_item = before_items.get(&old).expect("replace 전 스냅샷에 존재");
+                let new_item = item_of(pd, new).expect("replace 후 상태에 존재");
+                match (old_item, &new_item) {
+                    (
+                        SeqItem::Block {
+                            node_type: old_type,
+                            ..
+                        },
+                        SeqItem::Block {
+                            node_type: actual_type,
+                            ..
+                        },
+                    ) if old == replaced => {
+                        assert_ne!(*old_type, new_type, "테스트 전제: root type changes");
+                        assert_eq!(*actual_type, new_type, "replaced block type mismatch");
+                    }
+                    (SeqItem::Char(a), SeqItem::Char(b)) => assert_eq!(a, b, "char 페어링 불일치"),
+                    (SeqItem::Atom(a), SeqItem::Atom(b)) => assert_eq!(a, b, "atom 페어링 불일치"),
+                    (SeqItem::Block { node_type: a, .. }, SeqItem::Block { node_type: b, .. }) => {
+                        assert_eq!(a, b, "descendant block 페어링 불일치")
+                    }
+                    (a, b) => panic!("kind 불일치 페어링: {a:?} -> {b:?}"),
+                }
+            }
+        }
+    }
+
     #[test]
     fn move_node_emits_single_alias_op_pairing_old_to_new() {
         let (state, root, p1) = state! {
@@ -1037,6 +1088,63 @@ mod tests {
         assert_eq!(total as usize, 3, "블록 1 + char 2 전부 페어링");
 
         assert_pairs_match_content(&before_items, &tr.state().projected, &alias_ops[0].pairs);
+    }
+
+    #[test]
+    fn replace_block_type_emits_alias_op_pairing_old_to_new() {
+        let (state, list, _p1) = state! {
+            doc { root {
+                list: ordered_list { list_item { p1: paragraph { text("ab") } } }
+                paragraph {}
+            } }
+            selection: (p1, 0)
+        };
+        let before_items = collect_items(&state.projected, list);
+
+        let mut tr = Transaction::new(&state);
+        tr.replace_block_type(list, NodeType::BulletList).unwrap();
+
+        let view = tr.state().view();
+        assert!(view.node(list).is_none(), "old list dot is tombstoned");
+        let new_list = view
+            .alias_classes()
+            .resolve_with(list, |dot| view.node(dot).is_some());
+        assert_eq!(
+            view.node(new_list).unwrap().node_type(),
+            NodeType::BulletList
+        );
+
+        let ops = tr.ops_for_test();
+        let alias_ops = alias_ops_in(&ops);
+        assert_eq!(alias_ops.len(), 1, "replace 1회당 alias op 1개");
+        let total: u32 = alias_ops[0].pairs.iter().map(|r| r.len).sum();
+        assert_eq!(total as usize, before_items.len(), "subtree 전부 페어링");
+
+        assert_replace_type_pairs_match_content(
+            &before_items,
+            &tr.state().projected,
+            list,
+            NodeType::BulletList,
+            &alias_ops[0].pairs,
+        );
+    }
+
+    #[test]
+    fn replace_block_type_rejects_incompatible_children() {
+        let (state, list, _p1) = state! {
+            doc { root {
+                list: ordered_list { list_item { p1: paragraph { text("ab") } } }
+                paragraph {}
+            } }
+            selection: (p1, 0)
+        };
+
+        let mut tr = Transaction::new(&state);
+        let result = tr.replace_block_type(list, NodeType::Paragraph);
+        assert!(matches!(
+            result,
+            Err(StepError::IncompatibleBlockTypeReplacement { block, .. }) if block == list
+        ));
     }
 
     #[test]

--- a/crates/editor-transaction/tests/transaction_acceptance.rs
+++ b/crates/editor-transaction/tests/transaction_acceptance.rs
@@ -606,6 +606,39 @@ mod tests {
     }
 
     #[test]
+    fn replace_block_type_inverse_round_trip() {
+        let (state, list) = state! {
+            doc {
+                root {
+                    list: ordered_list {
+                        list_item { paragraph { text("A") } }
+                    }
+                    paragraph {}
+                }
+            }
+            selection: (list, 0)
+        };
+        let before = snapshot(&state);
+        let step = Step::ReplaceBlockType {
+            block: list,
+            old_type: NodeType::OrderedList,
+            new_type: NodeType::BulletList,
+        };
+        let after = step.apply(&state).unwrap().state;
+        let view = after.view();
+        let replaced = view
+            .alias_classes()
+            .resolve_with(list, |dot| view.node(dot).is_some());
+        assert_eq!(
+            view.node(replaced).unwrap().node_type(),
+            NodeType::BulletList
+        );
+
+        let restored = step.inverse().apply(&after).unwrap().state;
+        assert_eq!(snapshot(&restored), before);
+    }
+
+    #[test]
     fn move_node_reorder_and_back() {
         let (state, ..) = state! {
             doc { root { paragraph { text("a") } p2: paragraph { text("b") } } }


### PR DESCRIPTION
- breaking change: StablePositionBinding을 제거, child: Option<StablePositionChild>로 표현 단순화
- StablePosition이 block level position을 유지함
- intersects_subtree를 half-open subtree range 기준으로 고침. boundary position에서 upstream인데도 뒤 노드까지 수집하지 않도록 함
- Step::ReplaceBlockType 추가: set_list_kind에서 사용. list type 교체할 때 remove + insert 하지 않고 대신 이것을 사용함. alias를 발행해서 StableSelection이 동작하게 함.
- set_list_kind: list화 불가능한 fully-contained block 내부를 내려가지 않도록 함
- list 관련 로직에서 수동 셀렉션 캡처/복원 로직을 완전히 제거하고 StableSelection으로 대체함
- 이 모든 것들이 고쳐짐으로써 TR-344 크래시가 일어나지 않게 됨