### PR TITLE
앱 테이블/열 resize handle, 컬럼 너비 정책 정교화

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorScreenOverlayHost.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorScreenOverlayHost.kt
@@ -114,6 +114,12 @@ internal fun EditorScreenOverlayHost(
       val editor = runtime.editor
       if (editor != null) {
         if (editorRectInViewport != null) {
+          EditorTableColumnResizeOverlay(
+            editor = editor,
+            uiState = uiState,
+            editorRectInOverlay = editorRectInViewport,
+            density = density.density,
+          )
           EditorTableCellSelectionOverlay(
             editor = editor,
             uiState = uiState,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorTableColumnResizeOverlay.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorTableColumnResizeOverlay.kt
@@ -1,0 +1,561 @@
+package co.typie.screen.editor.editor.overlay
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import co.typie.editor.Editor
+import co.typie.editor.EditorViewportTransform
+import co.typie.editor.ffi.Message
+import co.typie.editor.ffi.NodeOp
+import co.typie.editor.ffi.TableOp
+import co.typie.editor.ffi.TableOverlay
+import co.typie.editor.interaction.EditorTableCellSelection
+import co.typie.editor.interaction.EditorTableCellSelectionHandleTouchTargetDp
+import co.typie.editor.interaction.resolveActiveTableCellSelection
+import co.typie.editor.runtime.EditorUiState
+import co.typie.ui.theme.AppTheme
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.roundToInt
+
+private const val TableColumnResizeTouchWidthDp = 24f
+private const val TableColumnResizeVisualWidthDp = 3f
+private const val TableColumnResizeMinColumnWidth = 40f
+private const val TableColumnResizeBorderWidth = 1f
+private const val TableResizeLimitEpsilon = 0.5f
+private const val TableResizeCommitEpsilon = 0.01f
+
+internal data class EditorTableColumnResizeTarget(
+  val overlay: TableOverlay,
+  val colIndex: Int,
+  val localColIndex: Int,
+  val isTableResize: Boolean,
+  val pageX: Float,
+)
+
+internal data class EditorTableColumnResizeOverlayPlacement(
+  val target: EditorTableColumnResizeTarget,
+  val centerX: Float,
+  val top: Float,
+  val bottom: Float,
+  val handleRects: List<Rect>,
+  val pxPerPageUnit: Float,
+)
+
+private data class EditorTableColumnResizeDraft(
+  val tableId: String,
+  val colIndex: Int,
+  val isTableResize: Boolean,
+  val baseCenterX: Float,
+  val top: Float,
+  val bottom: Float,
+  val initialWidths: List<Float>,
+  val initialTableWidth: Float,
+  val contentWidth: Float,
+  val minProportionWidth: Float,
+  val maxProportionWidth: Float,
+  val deltaX: Float,
+  val pxPerPageUnit: Float,
+) {
+  fun copyWithDelta(deltaX: Float): EditorTableColumnResizeDraft = copy(deltaX = deltaX)
+}
+
+@Composable
+internal fun EditorTableColumnResizeOverlay(
+  editor: Editor,
+  uiState: EditorUiState,
+  editorRectInOverlay: Rect,
+  density: Float,
+) {
+  if (!uiState.focused || density <= 0f) {
+    return
+  }
+
+  val placement =
+    resolveTableColumnResizeOverlayPlacement(
+      editor = editor,
+      uiState = uiState,
+      editorRectInOverlay = editorRectInOverlay,
+      density = density,
+    ) ?: return
+  var draft by remember { mutableStateOf<EditorTableColumnResizeDraft?>(null) }
+  val currentEditor by rememberUpdatedState(editor)
+  val color = AppTheme.colors.palette.blue
+  val activeDraft = draft
+  val visualCenterX =
+    activeDraft?.let { it.baseCenterX + resolveResizeDelta(it) * it.pxPerPageUnit }
+      ?: placement.centerX
+  val visualTop = activeDraft?.top ?: placement.top
+  val visualBottom = activeDraft?.bottom ?: placement.bottom
+  val visualWidth = TableColumnResizeVisualWidthDp * density
+  val verticalInset = 2f * density
+
+  Box(modifier = Modifier.fillMaxSize()) {
+    Canvas(modifier = Modifier.fillMaxSize()) {
+      val height = (visualBottom - visualTop - verticalInset * 2f).coerceAtLeast(0f)
+      if (height > 0f) {
+        drawRoundRect(
+          color = color.copy(alpha = if (activeDraft != null) 0.85f else 0.35f),
+          topLeft = Offset(x = visualCenterX - visualWidth / 2f, y = visualTop + verticalInset),
+          size = Size(width = visualWidth, height = height),
+          cornerRadius = CornerRadius(visualWidth / 2f, visualWidth / 2f),
+        )
+      }
+    }
+
+    placement.handleRects.forEach { rect ->
+      TableColumnResizeHandle(
+        rect = rect,
+        density = density,
+        onStart = {
+          uiState.contextMenu.hide()
+          draft = placement.toDraft()
+        },
+        onDrag = { deltaX ->
+          draft = draft?.let {
+            it.copyWithDelta(it.deltaX + dragDeltaToPageDelta(deltaX, it.pxPerPageUnit))
+          }
+        },
+        onEnd = {
+          val finished = draft
+          draft = null
+          finished?.let { currentEditor.commitTableResize(it) }
+        },
+      )
+    }
+  }
+}
+
+internal fun resolveTableColumnResizeTarget(
+  selection: EditorTableCellSelection
+): EditorTableColumnResizeTarget? {
+  val overlay = selection.overlay
+  if (!overlay.isFocused || overlay.columns.isEmpty()) {
+    return null
+  }
+  val colIndex = selection.range.colEnd
+  val localColIndex = overlay.columns.indexOfFirst { column -> column.index == colIndex }
+  if (localColIndex < 0) {
+    return null
+  }
+  val columnRight = overlay.columns[localColIndex].position
+  return EditorTableColumnResizeTarget(
+    overlay = overlay,
+    colIndex = colIndex,
+    localColIndex = localColIndex,
+    isTableResize = localColIndex == overlay.columns.lastIndex,
+    pageX = overlay.bounds.x + columnRight,
+  )
+}
+
+internal fun resolveTableColumnResizeOverlayPlacement(
+  editor: Editor,
+  uiState: EditorUiState,
+  editorRectInOverlay: Rect,
+  density: Float,
+): EditorTableColumnResizeOverlayPlacement? {
+  if (density <= 0f) {
+    return null
+  }
+  val selection = resolveActiveTableCellSelection(editor) ?: return null
+  val target = resolveTableColumnResizeTarget(selection) ?: return null
+  val overlay = target.overlay
+  val transform = uiState.resolveViewportTransform(pageSizes = editor.pageSizes)
+  val pxPerPageUnit = density * normalizedDisplayZoom(uiState.displayZoom)
+  val topCenter =
+    resolvePositionInOverlay(
+      page = overlay.pageIdx,
+      x = target.pageX,
+      y = overlay.bounds.y,
+      transform = transform,
+      editorRectInOverlay = editorRectInOverlay,
+      density = density,
+    ) ?: return null
+  val bottomCenter =
+    resolvePositionInOverlay(
+      page = overlay.pageIdx,
+      x = target.pageX,
+      y = overlay.bounds.y + overlay.bounds.height,
+      transform = transform,
+      editorRectInOverlay = editorRectInOverlay,
+      density = density,
+    ) ?: return null
+  val blockedCenter =
+    selection.geometry.handleCenter?.let { center ->
+      resolvePositionInOverlay(
+        page = overlay.pageIdx,
+        x = center.x,
+        y = center.y,
+        transform = transform,
+        editorRectInOverlay = editorRectInOverlay,
+        density = density,
+      )
+    }
+  val halfWidth = TableColumnResizeTouchWidthDp * density / 2f
+  val blockedHalfSize = EditorTableCellSelectionHandleTouchTargetDp * density / 2f
+  val handleRects =
+    splitTableColumnResizeHitRects(
+      centerX = topCenter.x,
+      top = topCenter.y,
+      bottom = bottomCenter.y,
+      halfWidth = halfWidth,
+      blockedCenter = blockedCenter,
+      blockedHalfSize = blockedHalfSize,
+    )
+  if (handleRects.isEmpty()) {
+    return null
+  }
+  return EditorTableColumnResizeOverlayPlacement(
+    target = target,
+    centerX = topCenter.x,
+    top = topCenter.y,
+    bottom = bottomCenter.y,
+    handleRects = handleRects,
+    pxPerPageUnit = pxPerPageUnit,
+  )
+}
+
+internal fun splitTableColumnResizeHitRects(
+  centerX: Float,
+  top: Float,
+  bottom: Float,
+  halfWidth: Float,
+  blockedCenter: Offset?,
+  blockedHalfSize: Float,
+): List<Rect> {
+  if (bottom <= top || halfWidth <= 0f) {
+    return emptyList()
+  }
+  val full =
+    Rect(left = centerX - halfWidth, top = top, right = centerX + halfWidth, bottom = bottom)
+  if (
+    blockedCenter == null ||
+      blockedHalfSize <= 0f ||
+      blockedCenter.x < full.left ||
+      blockedCenter.x > full.right
+  ) {
+    return listOf(full)
+  }
+
+  val blockedTop = (blockedCenter.y - blockedHalfSize).coerceIn(top, bottom)
+  val blockedBottom = (blockedCenter.y + blockedHalfSize).coerceIn(top, bottom)
+  if (blockedBottom <= top || blockedTop >= bottom || blockedTop >= blockedBottom) {
+    return listOf(full)
+  }
+
+  return buildList {
+    if (blockedTop > top) {
+      add(full.copy(bottom = blockedTop))
+    }
+    if (blockedBottom < bottom) {
+      add(full.copy(top = blockedBottom))
+    }
+  }
+}
+
+internal fun resizeTableColumnWidths(
+  widths: List<Float>,
+  colIndex: Int,
+  deltaX: Float,
+): List<Float> {
+  if (widths.isEmpty() || colIndex < 0 || colIndex >= widths.lastIndex) {
+    return widths
+  }
+  val clampedDelta =
+    clampTableColumnResizeDelta(widths = widths, colIndex = colIndex, deltaX = deltaX)
+  return widths.mapIndexed { index, width ->
+    when (index) {
+      colIndex -> width + clampedDelta
+      colIndex + 1 -> width - clampedDelta
+      else -> width
+    }
+  }
+}
+
+internal fun resolveTableResizeProportion(overlay: TableOverlay, deltaX: Float): Int? =
+  resolveTableResizeProportion(
+    colCount = overlay.columns.size,
+    currentTableWidth = overlay.bounds.width,
+    contentWidth = overlay.contentWidth,
+    minProportionWidth = overlay.minProportionWidth,
+    maxProportionWidth = overlay.maxProportionWidth,
+    deltaX = deltaX,
+  )
+
+internal fun resolveTableResizeCommittedDelta(overlay: TableOverlay, deltaX: Float): Float? =
+  resolveTableResizeCommittedDelta(
+    colCount = overlay.columns.size,
+    currentTableWidth = overlay.bounds.width,
+    contentWidth = overlay.contentWidth,
+    minProportionWidth = overlay.minProportionWidth,
+    maxProportionWidth = overlay.maxProportionWidth,
+    deltaX = deltaX,
+  )
+
+internal fun dragDeltaToPageDelta(deltaPx: Float, pxPerPageUnit: Float): Float =
+  if (pxPerPageUnit.isFinite() && pxPerPageUnit > 0f) {
+    deltaPx / pxPerPageUnit
+  } else {
+    0f
+  }
+
+private fun resolveTableResizeProportion(
+  colCount: Int,
+  currentTableWidth: Float,
+  contentWidth: Float,
+  minProportionWidth: Float,
+  maxProportionWidth: Float,
+  deltaX: Float,
+): Int? {
+  if (colCount <= 0 || contentWidth <= 0f) {
+    return null
+  }
+  val clampedDelta =
+    clampTableResizeDelta(
+      colCount = colCount,
+      currentTableWidth = currentTableWidth,
+      contentWidth = contentWidth,
+      minProportionWidth = minProportionWidth,
+      maxProportionWidth = maxProportionWidth,
+      deltaX = deltaX,
+    )
+  val nextWidth = currentTableWidth + clampedDelta
+  return ((nextWidth / contentWidth) * 100f).roundToInt().coerceAtLeast(0)
+}
+
+private fun resolveTableResizeCommittedDelta(
+  colCount: Int,
+  currentTableWidth: Float,
+  contentWidth: Float,
+  minProportionWidth: Float,
+  maxProportionWidth: Float,
+  deltaX: Float,
+): Float? {
+  if (contentWidth <= 0f) {
+    return null
+  }
+  val proportion =
+    resolveTableResizeProportion(
+      colCount = colCount,
+      currentTableWidth = currentTableWidth,
+      contentWidth = contentWidth,
+      minProportionWidth = minProportionWidth,
+      maxProportionWidth = maxProportionWidth,
+      deltaX = deltaX,
+    ) ?: return null
+  val initialProportion = ((currentTableWidth / contentWidth) * 100f).roundToInt().coerceAtLeast(0)
+  if (proportion == initialProportion) {
+    return 0f
+  }
+  return contentWidth * (proportion / 100f) - currentTableWidth
+}
+
+private fun clampTableColumnResizeDelta(widths: List<Float>, colIndex: Int, deltaX: Float): Float {
+  if (widths.isEmpty() || colIndex < 0 || colIndex >= widths.lastIndex) {
+    return 0f
+  }
+  val minDelta = TableColumnResizeMinColumnWidth - widths[colIndex]
+  val maxDelta = widths[colIndex + 1] - TableColumnResizeMinColumnWidth
+  if (minDelta > maxDelta) {
+    return 0f
+  }
+  return deltaX.coerceIn(minDelta, maxDelta)
+}
+
+private fun clampTableResizeDelta(
+  colCount: Int,
+  currentTableWidth: Float,
+  contentWidth: Float,
+  minProportionWidth: Float,
+  maxProportionWidth: Float,
+  deltaX: Float,
+): Float {
+  if (colCount <= 0 || contentWidth <= 0f) {
+    return 0f
+  }
+  val minTableWidth =
+    max(minTableWidthForColumns(colCount), minProportionWidth.takeIf { it.isFinite() } ?: 0f)
+  val maxTableWidth =
+    max(minTableWidth, maxProportionWidth.takeIf { it.isFinite() && it > 0f } ?: contentWidth)
+  val effectiveMinTableWidth =
+    if (currentTableWidth <= minTableWidth + TableResizeLimitEpsilon) {
+      currentTableWidth
+    } else {
+      minTableWidth
+    }
+  val minDelta = effectiveMinTableWidth - currentTableWidth
+  val maxDelta = maxTableWidth - currentTableWidth
+  if (minDelta > maxDelta) {
+    return 0f
+  }
+  return deltaX.coerceIn(minDelta, maxDelta)
+}
+
+private fun minTableWidthForColumns(colCount: Int): Float =
+  if (colCount <= 0) {
+    0f
+  } else {
+    TableColumnResizeMinColumnWidth * colCount + TableColumnResizeBorderWidth * (colCount + 1)
+  }
+
+private fun toRatioWidths(widths: List<Float>): List<Float> {
+  if (widths.isEmpty()) {
+    return emptyList()
+  }
+  val safe = widths.map { width -> if (width.isFinite() && width > 0f) width else 0f }
+  val total = safe.sum()
+  if (total <= 0f) {
+    return List(widths.size) { 1f / widths.size }
+  }
+  return safe.map { width -> width / total }
+}
+
+private fun hasWidthChange(before: List<Float>, after: List<Float>): Boolean {
+  if (before.size != after.size) {
+    return true
+  }
+  return before.indices.any { index ->
+    abs(before[index] - after[index]) > TableResizeCommitEpsilon
+  }
+}
+
+private fun resolveResizeDelta(draft: EditorTableColumnResizeDraft): Float =
+  if (draft.isTableResize) {
+    resolveTableResizeCommittedDelta(
+      colCount = draft.initialWidths.size,
+      currentTableWidth = draft.initialTableWidth,
+      contentWidth = draft.contentWidth,
+      minProportionWidth = draft.minProportionWidth,
+      maxProportionWidth = draft.maxProportionWidth,
+      deltaX = draft.deltaX,
+    ) ?: 0f
+  } else {
+    clampTableColumnResizeDelta(
+      widths = draft.initialWidths,
+      colIndex = draft.colIndex,
+      deltaX = draft.deltaX,
+    )
+  }
+
+private fun EditorTableColumnResizeOverlayPlacement.toDraft(): EditorTableColumnResizeDraft {
+  val overlay = target.overlay
+  return EditorTableColumnResizeDraft(
+    tableId = overlay.tableId,
+    colIndex = target.localColIndex,
+    isTableResize = target.isTableResize,
+    baseCenterX = centerX,
+    top = top,
+    bottom = bottom,
+    initialWidths = overlay.columns.map { column -> column.widthAsPx },
+    initialTableWidth = overlay.bounds.width,
+    contentWidth = overlay.contentWidth,
+    minProportionWidth = overlay.minProportionWidth,
+    maxProportionWidth = overlay.maxProportionWidth,
+    deltaX = 0f,
+    pxPerPageUnit = pxPerPageUnit,
+  )
+}
+
+private fun Editor.commitTableResize(draft: EditorTableColumnResizeDraft) {
+  val op =
+    if (draft.isTableResize) {
+      val proportion =
+        resolveTableResizeProportion(
+          colCount = draft.initialWidths.size,
+          currentTableWidth = draft.initialTableWidth,
+          contentWidth = draft.contentWidth,
+          minProportionWidth = draft.minProportionWidth,
+          maxProportionWidth = draft.maxProportionWidth,
+          deltaX = draft.deltaX,
+        ) ?: return
+      val initialProportion =
+        ((draft.initialTableWidth / draft.contentWidth) * 100f).roundToInt().coerceAtLeast(0)
+      if (proportion == initialProportion) {
+        return
+      }
+      TableOp.SetProportion(proportion = proportion)
+    } else {
+      val nextWidths =
+        resizeTableColumnWidths(
+          widths = draft.initialWidths,
+          colIndex = draft.colIndex,
+          deltaX = draft.deltaX,
+        )
+      if (!hasWidthChange(draft.initialWidths, nextWidths)) {
+        return
+      }
+      TableOp.SetColumnWidths(widths = toRatioWidths(nextWidths))
+    }
+
+  sync { enqueue(Message.Node(NodeOp.Table(id = draft.tableId, op = op))) }
+}
+
+@Composable
+private fun TableColumnResizeHandle(
+  rect: Rect,
+  density: Float,
+  onStart: () -> Unit,
+  onDrag: (Float) -> Unit,
+  onEnd: () -> Unit,
+) {
+  val currentOnStart by rememberUpdatedState(onStart)
+  val currentOnDrag by rememberUpdatedState(onDrag)
+  val currentOnEnd by rememberUpdatedState(onEnd)
+  Box(
+    modifier =
+      Modifier.offset { IntOffset(x = rect.left.roundToInt(), y = rect.top.roundToInt()) }
+        .width((rect.width / density).dp)
+        .height((rect.height / density).dp)
+        .pointerInput(Unit) {
+          detectDragGestures(
+            onDragStart = { currentOnStart() },
+            onDrag = { change, dragAmount ->
+              change.consume()
+              currentOnDrag(dragAmount.x)
+            },
+            onDragEnd = { currentOnEnd() },
+            onDragCancel = { currentOnEnd() },
+          )
+        }
+  ) {}
+}
+
+private fun resolvePositionInOverlay(
+  page: Int,
+  x: Float,
+  y: Float,
+  transform: EditorViewportTransform,
+  editorRectInOverlay: Rect,
+  density: Float,
+): Offset? {
+  val global = transform.localToGlobal(page = page, x = x, y = y) ?: return null
+  return Offset(
+    x = editorRectInOverlay.left + global.x * density,
+    y = editorRectInOverlay.top + global.y * density,
+  )
+}
+
+private fun normalizedDisplayZoom(displayZoom: Float): Float =
+  if (displayZoom.isFinite() && displayZoom > 0f) {
+    displayZoom
+  } else {
+    1f
+  }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
@@ -2936,6 +2936,8 @@ class EditorInteractionControllerTest {
         align = Alignment.Left,
         proportion = 1f,
         contentWidth = 100f,
+        minProportionWidth = 83f,
+        maxProportionWidth = 100f,
         rows =
           listOf(
             TableOverlayRow(index = 0, height = 40f, position = 40f, backgroundColor = null),

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorTableCellSelectionGeometryTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorTableCellSelectionGeometryTest.kt
@@ -109,6 +109,8 @@ class EditorTableCellSelectionGeometryTest {
       align = Alignment.Left,
       proportion = 1f,
       contentWidth = 100f,
+      minProportionWidth = 83f,
+      maxProportionWidth = 100f,
       rows = rows,
       columns =
         listOf(

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/overlay/EditorTableAxisSelectionOverlayTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/overlay/EditorTableAxisSelectionOverlayTest.kt
@@ -136,6 +136,8 @@ class EditorTableAxisSelectionOverlayTest {
       align = Alignment.Left,
       proportion = 1f,
       contentWidth = 100f,
+      minProportionWidth = 83f,
+      maxProportionWidth = 100f,
       rows = rows,
       columns =
         listOf(

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/overlay/EditorTableCellSelectionOverlayTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/overlay/EditorTableCellSelectionOverlayTest.kt
@@ -86,6 +86,8 @@ class EditorTableCellSelectionOverlayTest {
       align = Alignment.Left,
       proportion = 1f,
       contentWidth = 100f,
+      minProportionWidth = 83f,
+      maxProportionWidth = 100f,
       rows = rows,
       columns =
         listOf(

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/overlay/EditorTableColumnResizeOverlayTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/overlay/EditorTableColumnResizeOverlayTest.kt
@@ -1,0 +1,132 @@
+package co.typie.screen.editor.editor.overlay
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import co.typie.editor.ffi.Alignment
+import co.typie.editor.ffi.Rect as FfiRect
+import co.typie.editor.ffi.TableBorderStyle
+import co.typie.editor.ffi.TableOverlay
+import co.typie.editor.ffi.TableOverlayCellSelection
+import co.typie.editor.ffi.TableOverlayColumn
+import co.typie.editor.ffi.TableOverlayRow
+import co.typie.editor.interaction.EditorTableCellSelection
+import co.typie.editor.interaction.resolveTableCellSelectionGeometry
+import co.typie.editor.interaction.resolveTableCellSelectionRange
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class EditorTableColumnResizeOverlayTest {
+  @Test
+  fun `focused cell resolves the selected column right edge as a column resize target`() {
+    val selection = tableCellSelection(tableOverlay(focusedRowIndex = 0, focusedColIndex = 0))
+
+    val target = checkNotNull(resolveTableColumnResizeTarget(selection))
+
+    assertEquals(0, target.colIndex)
+    assertEquals(0, target.localColIndex)
+    assertFalse(target.isTableResize)
+    assertEquals(60f, target.pageX)
+  }
+
+  @Test
+  fun `last selected column resolves the table edge as a table resize target`() {
+    val selection = tableCellSelection(tableOverlay(focusedRowIndex = 0, focusedColIndex = 2))
+
+    val target = checkNotNull(resolveTableColumnResizeTarget(selection))
+
+    assertEquals(2, target.colIndex)
+    assertTrue(target.isTableResize)
+    assertEquals(190f, target.pageX)
+  }
+
+  @Test
+  fun `column resize clamps both adjacent columns to the minimum width`() {
+    val widths = listOf(50f, 70f, 60f)
+
+    assertEquals(listOf(80f, 40f, 60f), resizeTableColumnWidths(widths, colIndex = 0, deltaX = 40f))
+    assertEquals(
+      listOf(40f, 80f, 60f),
+      resizeTableColumnWidths(widths, colIndex = 0, deltaX = -20f),
+    )
+  }
+
+  @Test
+  fun `table resize proportion clamps to overlay min and max widths`() {
+    val overlay = tableOverlay(bounds = FfiRect(x = 10f, y = 20f, width = 150f, height = 80f))
+
+    assertEquals(124, resolveTableResizeProportion(overlay = overlay, deltaX = -80f))
+    assertEquals(160, resolveTableResizeProportion(overlay = overlay, deltaX = 80f))
+  }
+
+  @Test
+  fun `table resize draft delta matches committed rounded proportion`() {
+    val overlay = tableOverlay(bounds = FfiRect(x = 10f, y = 20f, width = 150f, height = 80f))
+
+    assertEquals(0f, resolveTableResizeCommittedDelta(overlay = overlay, deltaX = 0.4f))
+    assertEquals(10f, resolveTableResizeCommittedDelta(overlay = overlay, deltaX = 9.6f))
+  }
+
+  @Test
+  fun `drag delta converts screen pixels to page units`() {
+    assertEquals(10f, dragDeltaToPageDelta(deltaPx = 60f, pxPerPageUnit = 6f))
+    assertEquals(0f, dragDeltaToPageDelta(deltaPx = 60f, pxPerPageUnit = 0f))
+  }
+
+  @Test
+  fun `resize hit rect excludes the active cell selection handle target`() {
+    val rects =
+      splitTableColumnResizeHitRects(
+        centerX = 100f,
+        top = 0f,
+        bottom = 100f,
+        halfWidth = 12f,
+        blockedCenter = Offset(100f, 100f),
+        blockedHalfSize = 18f,
+      )
+
+    assertEquals(listOf(Rect(left = 88f, top = 0f, right = 112f, bottom = 82f)), rects)
+  }
+
+  private fun tableCellSelection(overlay: TableOverlay): EditorTableCellSelection {
+    val range = checkNotNull(resolveTableCellSelectionRange(overlay, selectionCollapsed = true))
+    val geometry = checkNotNull(resolveTableCellSelectionGeometry(overlay, range))
+    return EditorTableCellSelection(overlay = overlay, range = range, geometry = geometry)
+  }
+
+  private fun tableOverlay(
+    bounds: FfiRect = FfiRect(x = 10f, y = 20f, width = 100f, height = 80f),
+    focusedRowIndex: Int? = null,
+    focusedColIndex: Int? = null,
+    cellSelection: TableOverlayCellSelection? = null,
+  ): TableOverlay =
+    TableOverlay(
+      tableId = "table",
+      pageIdx = 0,
+      bounds = bounds,
+      borderStyle = TableBorderStyle.Solid,
+      align = Alignment.Left,
+      proportion = 1f,
+      contentWidth = 100f,
+      minProportionWidth = 83f,
+      maxProportionWidth = 160f,
+      rows =
+        listOf(
+          TableOverlayRow(index = 0, height = 40f, position = 40f, backgroundColor = null),
+          TableOverlayRow(index = 1, height = 40f, position = 80f, backgroundColor = null),
+        ),
+      columns =
+        listOf(
+          TableOverlayColumn(index = 0, widthAsPx = 50f, position = 50f, backgroundColor = null),
+          TableOverlayColumn(index = 1, widthAsPx = 70f, position = 120f, backgroundColor = null),
+          TableOverlayColumn(index = 2, widthAsPx = 60f, position = 180f, backgroundColor = null),
+        ),
+      rowCount = 2,
+      isLastRowFragment = true,
+      isFocused = true,
+      focusedRowIndex = focusedRowIndex,
+      focusedColIndex = focusedColIndex,
+      cellSelection = cellSelection,
+    )
+}

--- a/apps/website/src/lib/editor-ffi/components/TableOverlay.svelte
+++ b/apps/website/src/lib/editor-ffi/components/TableOverlay.svelte
@@ -124,11 +124,21 @@
     if (initialWidths.length === 0 || overlay.content_width <= 0) return 0;
 
     const currentTableWidth = overlay.bounds.width;
-    const minWidth = Math.max(minTableWidth(initialWidths.length), 0);
-    const maxWidth = Math.max(minWidth, overlay.content_width);
+    const minWidth = Math.max(minTableWidth(initialWidths.length), overlay.min_proportion_width ?? 0);
+    const maxWidth = Math.max(minWidth, overlay.max_proportion_width ?? overlay.content_width);
 
     const effectiveMinWidth = currentTableWidth <= minWidth + TABLE_RESIZE_LIMIT_EPSILON ? currentTableWidth : minWidth;
     return clamp(deltaX, effectiveMinWidth - currentTableWidth, maxWidth - currentTableWidth);
+  }
+
+  function toRatioWidths(widths: number[]): number[] {
+    if (widths.length === 0) return [];
+
+    const safe = widths.map((width) => (Number.isFinite(width) && width > 0 ? width : 0));
+    const total = safe.reduce((sum, width) => sum + width, 0);
+    if (total <= 0) return widths.map(() => 1 / widths.length);
+
+    return safe.map((width) => width / total);
   }
 
   function findOverlayIndex(boundaries: number[], value: number): number | null {
@@ -181,7 +191,8 @@
     if (targetEl instanceof Node && tableOverlayRoot.contains(targetEl)) return true;
     if (targetEl instanceof Node && !editor?.scrollContainerEl?.contains(targetEl)) return false;
     const rect = tableOverlayRoot.getBoundingClientRect();
-    return clientX >= rect.left && clientX <= rect.right && clientY >= rect.top && clientY <= rect.bottom;
+    const resizeSlop = (resizeIndicatorThickness * safeDisplayZoom) / 2;
+    return clientX >= rect.left && clientX <= rect.right + resizeSlop && clientY >= rect.top && clientY <= rect.bottom;
   }
 
   function syncHoverFromWindowPointer(clientX: number, clientY: number): void {
@@ -651,6 +662,7 @@
           pointerEvents: isActive ? 'auto' : 'none',
           opacity: isResizing ? '100' : '0',
           transition: '[opacity 0.15s]',
+          zIndex: isLastCol ? '[1]' : undefined,
           _hover: { opacity: '100', backgroundColor: 'accent.brand.default' },
         })}
         aria-label={isLastCol ? '테이블 너비 조절' : '열 너비 조절'}
@@ -693,7 +705,7 @@
                 const clampedDelta = clamp(resizing.deltaX, minDelta, maxDelta);
                 newWidths[colIndex] = resizing.initialWidths[colIndex] + clampedDelta;
                 newWidths[colIndex + 1] = resizing.initialWidths[colIndex + 1] - clampedDelta;
-                setColumnWidths(newWidths);
+                setColumnWidths(toRatioWidths(newWidths));
               }
             }
 

--- a/crates/editor-commands/src/commands/insert_table_axis.rs
+++ b/crates/editor-commands/src/commands/insert_table_axis.rs
@@ -181,7 +181,7 @@ mod tests {
     }
 
     #[test]
-    fn insert_col_preserves_existing_widths_and_new_col_is_none() {
+    fn insert_col_rebalances_widths_on_all_rows() {
         let (initial, tbl, ..) = state! {
             doc { root {
                 tbl: table {
@@ -218,9 +218,43 @@ mod tests {
                 .collect();
             assert_eq!(
                 widths,
-                vec![Some(300), None, Some(100), Some(100)],
-                "existing columns keep their widths, the inserted column starts with none"
+                vec![Some(225), Some(125), Some(75), Some(75)],
+                "existing column weights are rebalanced and the inserted column gets its own weight"
             );
+        }
+    }
+
+    #[test]
+    fn insert_row_carries_existing_width_weights() {
+        let (initial, tbl, ..) = state! {
+            doc { root {
+                tbl: table {
+                    table_row {
+                        r0c0: table_cell(col_width: Some(300u32)) { paragraph { text("A") } }
+                        table_cell(col_width: Some(100u32)) { paragraph { text("B") } }
+                    }
+                }
+            } }
+            selection: (r0c0, 0)
+        };
+        let (actual, ..) = transact!(initial, |tr| insert_table_axis(
+            &mut tr,
+            tbl,
+            Axis::Horizontal,
+            0,
+            true
+        ));
+        let v = actual.view();
+        let table = v.node(tbl).unwrap();
+        for row in table.child_blocks() {
+            let widths: Vec<Option<u32>> = row
+                .child_blocks()
+                .map(|cell| match cell.node() {
+                    editor_model::Node::TableCell(n) => *n.col_width.get(),
+                    _ => panic!("expected a table cell"),
+                })
+                .collect();
+            assert_eq!(widths, vec![Some(300), Some(100)]);
         }
     }
 

--- a/crates/editor-commands/src/commands/move_table_axis.rs
+++ b/crates/editor-commands/src/commands/move_table_axis.rs
@@ -2,7 +2,9 @@ use editor_common::Axis;
 use editor_crdt::Dot;
 use editor_transaction::Transaction;
 
-use crate::helpers::table_axis_selection;
+use crate::helpers::{
+    apply_col_width_weights_to_first_row, first_row_col_width_weights, table_axis_selection,
+};
 use crate::{CommandError, CommandResult};
 
 pub fn move_table_axis(
@@ -16,6 +18,11 @@ pub fn move_table_axis(
         return Ok(false);
     }
     let restore_axis_selection = selected_axis_to_restore(tr, table_id, axis, from);
+    let first_row_widths_to_restore = if axis == Axis::Horizontal && (from == 0 || to == 0) {
+        first_row_col_width_weights(tr, table_id)?
+    } else {
+        None
+    };
     match axis {
         Axis::Horizontal => {
             let row_id = {
@@ -53,6 +60,10 @@ pub fn move_table_axis(
                 tr.move_node(cell_id, *row_id, to)?;
             }
         }
+    }
+    if let Some(widths) = first_row_widths_to_restore {
+        let widths = widths.into_iter().map(Some).collect::<Vec<_>>();
+        apply_col_width_weights_to_first_row(tr, table_id, &widths)?;
     }
     if restore_axis_selection {
         let selection = table_axis_selection(tr, table_id, Some(axis), Some(to))?;
@@ -219,6 +230,43 @@ mod tests {
             }),
             "the moved row's cell keeps its background color"
         );
+    }
+
+    #[test]
+    fn move_row_to_first_keeps_first_row_width_weights() {
+        let (initial, tbl, ..) = state! {
+            doc { root {
+                tbl: table {
+                    table_row {
+                        r0c0: table_cell(col_width: Some(300u32)) { paragraph { text("A") } }
+                        table_cell(col_width: Some(100u32)) { paragraph { text("B") } }
+                    }
+                    table_row {
+                        table_cell { paragraph { text("C") } }
+                        table_cell { paragraph { text("D") } }
+                    }
+                }
+            } }
+            selection: (r0c0, 0)
+        };
+        let (actual, ..) = transact!(initial, |tr| move_table_axis(
+            &mut tr,
+            tbl,
+            Axis::Horizontal,
+            1,
+            0
+        ));
+        let view = actual.view();
+        let table = view.node(tbl).unwrap();
+        let first_row = table.child_blocks().next().unwrap();
+        let widths: Vec<Option<u32>> = first_row
+            .child_blocks()
+            .map(|cell| match cell.node() {
+                editor_model::Node::TableCell(n) => *n.col_width.get(),
+                _ => panic!("expected a table cell"),
+            })
+            .collect();
+        assert_eq!(widths, vec![Some(300), Some(100)]);
     }
 
     #[test]

--- a/crates/editor-commands/src/commands/set_table_column_widths.rs
+++ b/crates/editor-commands/src/commands/set_table_column_widths.rs
@@ -2,7 +2,7 @@ use editor_crdt::Dot;
 use editor_model::{PlainNode, PlainTableCellNode};
 use editor_transaction::Transaction;
 
-use crate::helpers::col_count_from_table;
+use crate::helpers::{col_count_from_table, column_width_weights};
 use crate::{CommandError, CommandResult};
 
 pub fn set_table_column_widths(
@@ -23,8 +23,9 @@ pub fn set_table_column_widths(
         (row_ids, n_cols)
     };
     let update_count = widths.len().min(n_cols);
+    let width_weights = column_width_weights(&widths);
     for row_id in &row_ids {
-        for (col_idx, &width) in widths.iter().enumerate().take(update_count) {
+        for (col_idx, &new_width) in width_weights.iter().enumerate().take(update_count) {
             let cell_id = {
                 let view = tr.view();
                 let row = view
@@ -34,11 +35,6 @@ pub fn set_table_column_widths(
                     .nth(col_idx)
                     .ok_or_else(|| CommandError::Corrupted("col index out of range".into()))?
                     .id()
-            };
-            let new_width = if width > 0.0 {
-                Some(width as u32)
-            } else {
-                None
             };
             tr.set_node(
                 cell_id,
@@ -94,6 +90,40 @@ mod tests {
             if let editor_model::Node::TableCell(n) = c1 {
                 assert_eq!(*n.col_width.get(), Some(200));
             }
+        }
+    }
+
+    #[test]
+    fn stores_fractional_widths_as_positive_weights() {
+        let (initial, tbl, ..) = state! {
+            doc { root {
+                tbl: table {
+                    table_row {
+                        r0c0: table_cell { paragraph { text("A") } }
+                        r0c1: table_cell { paragraph { text("B") } }
+                    }
+                }
+            } }
+            selection: (r0c0, 0)
+        };
+        let (actual, ..) = transact!(initial, |tr| set_table_column_widths(
+            &mut tr,
+            tbl,
+            vec![0.25, 0.75]
+        ));
+        let view = actual.view();
+        let table = view.node(tbl).unwrap();
+        let cells: Vec<_> = table
+            .child_blocks()
+            .next()
+            .unwrap()
+            .child_blocks()
+            .collect();
+        if let editor_model::Node::TableCell(n) = cells[0].node() {
+            assert_eq!(*n.col_width.get(), Some(2500));
+        }
+        if let editor_model::Node::TableCell(n) = cells[1].node() {
+            assert_eq!(*n.col_width.get(), Some(7500));
         }
     }
 

--- a/crates/editor-commands/src/helpers/table.rs
+++ b/crates/editor-commands/src/helpers/table.rs
@@ -9,6 +9,8 @@ use editor_transaction::{Transaction, fulfill};
 
 use crate::CommandError;
 
+const FRACTIONAL_COLUMN_WIDTH_WEIGHT_SCALE: f64 = 10_000.0;
+
 pub(crate) fn col_count_from_table(table: &NodeView<'_>) -> Result<usize, CommandError> {
     let first_row = table
         .child_blocks()
@@ -160,9 +162,158 @@ pub(crate) fn table_axis_selection(
         .ok_or_else(|| CommandError::Corrupted("cannot build cell rect selection".into()))
 }
 
-pub(crate) fn make_empty_table_cell() -> Subtree {
+pub(crate) fn column_width_weights(widths: &[f32]) -> Vec<Option<u32>> {
+    let scale = if widths
+        .iter()
+        .any(|width| width.is_finite() && *width > 0.0 && *width < 1.0)
+    {
+        FRACTIONAL_COLUMN_WIDTH_WEIGHT_SCALE
+    } else {
+        1.0
+    };
+    widths
+        .iter()
+        .map(|width| {
+            if !width.is_finite() || *width <= 0.0 {
+                None
+            } else {
+                Some(column_width_weight((*width as f64) * scale))
+            }
+        })
+        .collect()
+}
+
+pub(crate) fn first_row_col_width_weights(
+    tr: &Transaction,
+    table_id: Dot,
+) -> Result<Option<Vec<u32>>, CommandError> {
+    let view = tr.state().view();
+    let table = view
+        .node(table_id)
+        .ok_or(CommandError::NodeNotFound(table_id))?;
+    let Some(first_row) = table.child_blocks().next() else {
+        return Ok(None);
+    };
+    let mut widths = Vec::new();
+    for cell in first_row.child_blocks() {
+        let editor_model::Node::TableCell(cell_node) = cell.node() else {
+            return Ok(None);
+        };
+        let Some(width) = *cell_node.col_width.get() else {
+            return Ok(None);
+        };
+        if width == 0 {
+            return Ok(None);
+        }
+        widths.push(width);
+    }
+    Ok((!widths.is_empty()).then_some(widths))
+}
+
+pub(crate) fn inserted_col_width_weights(
+    existing_widths: &[u32],
+    insert_index: usize,
+) -> Vec<Option<u32>> {
+    if existing_widths.is_empty() {
+        return vec![Some(1)];
+    }
+
+    let new_col_count = existing_widths.len() + 1;
+    let inserted_share = 1.0 / new_col_count as f64;
+    let existing_scale = 1.0 - inserted_share;
+    let existing_total: f64 = existing_widths.iter().map(|width| *width as f64).sum();
+    let insert_at = insert_index.min(existing_widths.len());
+    let mut next_widths: Vec<Option<u32>> = existing_widths
+        .iter()
+        .map(|width| Some(column_width_weight(*width as f64 * existing_scale)))
+        .collect();
+    next_widths.insert(
+        insert_at,
+        Some(column_width_weight(existing_total * inserted_share)),
+    );
+    next_widths
+}
+
+pub(crate) fn apply_col_width_weights_to_first_row(
+    tr: &mut Transaction,
+    table_id: Dot,
+    widths: &[Option<u32>],
+) -> Result<(), CommandError> {
+    let cell_ids: Vec<Dot> = {
+        let view = tr.state().view();
+        let table = view
+            .node(table_id)
+            .ok_or(CommandError::NodeNotFound(table_id))?;
+        let first_row = table
+            .child_blocks()
+            .next()
+            .ok_or_else(|| CommandError::Corrupted("table has no rows".into()))?;
+        first_row.child_blocks().map(|cell| cell.id()).collect()
+    };
+    if cell_ids.len() != widths.len() {
+        return Ok(());
+    }
+    for (cell_id, width) in cell_ids.into_iter().zip(widths.iter().copied()) {
+        set_table_cell_col_width(tr, cell_id, width)?;
+    }
+    Ok(())
+}
+
+pub(crate) fn apply_col_width_weights_to_all_rows(
+    tr: &mut Transaction,
+    table_id: Dot,
+    widths: &[Option<u32>],
+) -> Result<(), CommandError> {
+    let row_ids: Vec<Dot> = {
+        let view = tr.state().view();
+        let table = view
+            .node(table_id)
+            .ok_or(CommandError::NodeNotFound(table_id))?;
+        table.child_blocks().map(|row| row.id()).collect()
+    };
+    for row_id in row_ids {
+        let cell_ids: Vec<Dot> = {
+            let view = tr.state().view();
+            let row = view
+                .node(row_id)
+                .ok_or(CommandError::NodeNotFound(row_id))?;
+            row.child_blocks()
+                .take(widths.len())
+                .map(|cell| cell.id())
+                .collect()
+        };
+        for (cell_id, width) in cell_ids.into_iter().zip(widths.iter().copied()) {
+            set_table_cell_col_width(tr, cell_id, width)?;
+        }
+    }
+    Ok(())
+}
+
+fn column_width_weight(width: f64) -> u32 {
+    if !width.is_finite() {
+        return 1;
+    }
+    width.round().clamp(1.0, u32::MAX as f64) as u32
+}
+
+fn set_table_cell_col_width(
+    tr: &mut Transaction,
+    cell_id: Dot,
+    col_width: Option<u32>,
+) -> Result<(), CommandError> {
+    tr.set_node(
+        cell_id,
+        PlainNode::TableCell(PlainTableCellNode {
+            col_width,
+            background_color: None,
+        }),
+    )?;
+    Ok(())
+}
+
+pub(crate) fn make_empty_table_cell(col_width: Option<u32>) -> Subtree {
     Subtree::leaf(PlainNode::TableCell(PlainTableCellNode {
-        col_width: None,
+        col_width,
         background_color: None,
     }))
     .with_children(vec![Subtree::leaf(PlainNode::Paragraph(
@@ -170,9 +321,14 @@ pub(crate) fn make_empty_table_cell() -> Subtree {
     ))])
 }
 
-fn make_empty_table_row(n_cols: usize) -> Subtree {
-    Subtree::leaf(PlainNode::TableRow(PlainTableRowNode {}))
-        .with_children((0..n_cols).map(|_| make_empty_table_cell()).collect())
+fn make_empty_table_row(n_cols: usize, col_widths: Option<&[u32]>) -> Subtree {
+    Subtree::leaf(PlainNode::TableRow(PlainTableRowNode {})).with_children(
+        (0..n_cols)
+            .map(|idx| {
+                make_empty_table_cell(col_widths.and_then(|widths| widths.get(idx)).copied())
+            })
+            .collect(),
+    )
 }
 
 /// Insert a fresh empty row at `index` in the table. The new row gets as many
@@ -189,7 +345,12 @@ pub(crate) fn insert_empty_table_row(
             .ok_or(CommandError::NodeNotFound(table_id))?;
         col_count_from_table(&table)?
     };
-    tr.insert_subtree(table_id, index, make_empty_table_row(n_cols))?;
+    let col_widths = first_row_col_width_weights(tr, table_id)?;
+    tr.insert_subtree(
+        table_id,
+        index,
+        make_empty_table_row(n_cols, col_widths.as_deref()),
+    )?;
     Ok(())
 }
 
@@ -199,6 +360,8 @@ pub(crate) fn insert_empty_table_column(
     table_id: Dot,
     index: usize,
 ) -> Result<(), CommandError> {
+    let next_widths = first_row_col_width_weights(tr, table_id)?
+        .map(|widths| inserted_col_width_weights(&widths, index));
     let row_ids: Vec<Dot> = {
         let view = tr.state().view();
         let table = view
@@ -207,7 +370,10 @@ pub(crate) fn insert_empty_table_column(
         table.child_blocks().map(|r| r.id()).collect()
     };
     for row_id in row_ids {
-        tr.insert_subtree(row_id, index, make_empty_table_cell())?;
+        tr.insert_subtree(row_id, index, make_empty_table_cell(None))?;
+    }
+    if let Some(widths) = next_widths {
+        apply_col_width_weights_to_all_rows(tr, table_id, &widths)?;
     }
     Ok(())
 }

--- a/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
@@ -418,6 +418,8 @@ export interface TableOverlay {
     align: Alignment;
     proportion: number;
     content_width: number;
+    min_proportion_width: number;
+    max_proportion_width: number;
     rows: TableOverlayRow[];
     columns: TableOverlayColumn[];
     row_count: number;

--- a/crates/editor-ffi/pkg/server/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/server/editor_ffi.d.ts
@@ -465,6 +465,8 @@ export interface TableOverlay {
     align: Alignment;
     proportion: number;
     content_width: number;
+    min_proportion_width: number;
+    max_proportion_width: number;
     rows: TableOverlayRow[];
     columns: TableOverlayColumn[];
     row_count: number;

--- a/crates/editor-view/src/table_overlay.rs
+++ b/crates/editor-view/src/table_overlay.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use crate::page_fragment::{PageFragmentBox, PageFragmentNode, PageFragmentTree};
 
 const TABLE_BORDER_WIDTH: f32 = 1.0;
+const MIN_CELL_WIDTH: f32 = 40.0;
 
 fn cell_background_color(view: &DocView, cell_id: Dot) -> Option<String> {
     view.node(cell_id)?
@@ -32,6 +33,8 @@ pub struct TableOverlay {
     pub align: Alignment,
     pub proportion: f32,
     pub content_width: f32,
+    pub min_proportion_width: f32,
+    pub max_proportion_width: f32,
     pub rows: Vec<TableOverlayRow>,
     pub columns: Vec<TableOverlayColumn>,
     pub row_count: usize,
@@ -189,7 +192,7 @@ fn build_table_overlay(
         })
         .unwrap_or(Alignment::Left);
 
-    let columns = rows
+    let columns: Vec<TableOverlayColumn> = rows
         .first()
         .map(|row| {
             row.cells
@@ -203,6 +206,8 @@ fn build_table_overlay(
                 .collect()
         })
         .unwrap_or_default();
+    let min_proportion_width = min_table_width(columns.len());
+    let max_proportion_width = content_width.max(0.0);
 
     let overlay_rows = rows
         .iter()
@@ -333,6 +338,8 @@ fn build_table_overlay(
         align,
         proportion,
         content_width,
+        min_proportion_width,
+        max_proportion_width,
         rows: overlay_rows,
         columns,
         row_count,
@@ -342,6 +349,13 @@ fn build_table_overlay(
         focused_col_index,
         cell_selection,
     })
+}
+
+fn min_table_width(col_count: usize) -> f32 {
+    if col_count == 0 {
+        return TABLE_BORDER_WIDTH;
+    }
+    col_count as f32 * MIN_CELL_WIDTH + (col_count + 1) as f32 * TABLE_BORDER_WIDTH
 }
 
 fn visible_rows(table_box: &PageFragmentBox, view: &DocView) -> Vec<OverlayRow> {
@@ -810,6 +824,8 @@ mod tests {
         assert_eq!(ov.bounds.x, 0.0);
         assert_eq!(ov.bounds.width, 600.0);
         assert_eq!(ov.bounds.height, 80.0);
+        assert_eq!(ov.min_proportion_width, 83.0);
+        assert_eq!(ov.max_proportion_width, 600.0);
 
         // table alignment is Center (set via block_modifiers)
         assert_eq!(ov.align, Alignment::Center);


### PR DESCRIPTION
- 앱에 테이블 열 및 테이블 proportion resize handle 추가
- 열 너비, 테이블 리사이즈 관련 정책 레거시와 패리티 맞춤. resize handle draft 이동 범위가 실제 조절 가능 범위와 일치하고 핸들을 놓았을 때 drift 없이 정확히 그 자리로 리사이즈됨
- 행/열 삽입과 행 이동 시 열 너비 적절히 리밸런싱되고 보존됨
- 마지막 열 resize handle의 테이블 밖으로 나간 오른쪽 절반이 hit target이 되지 못하는 문제 디버그