### PR TITLE
EditorOverlayPointerRouter, 인터랙션 개선

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionController.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionController.kt
@@ -73,6 +73,10 @@ internal class EditorInteractionController(
     gestures.updateTapSlop(tapSlopPx)
   }
 
+  fun clearTapHistory() {
+    gestures.clearTapHistory()
+  }
+
   fun canApplyModeEvent(event: EditorInteractionEvent): Boolean = mode.canApply(event)
 
   fun onPointerDown(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionGestures.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionGestures.kt
@@ -51,6 +51,10 @@ internal class EditorInteractionGestures(
     tap.updateTapSlop(tapSlopPx)
   }
 
+  fun clearTapHistory() {
+    tap.clearTapHistory()
+  }
+
   fun handlePointerDown(
     pointerId: Long,
     position: Offset,
@@ -115,10 +119,6 @@ internal class EditorInteractionGestures(
         )
     val tableHandleConsumed =
       tableHandleHit && tap.hasActivePointer && tableHandle.handleDragDown(position = position)
-    if (tableHandleConsumed) {
-      tap.markTapDispatched()
-      context.effects.cancelTapDispatch()
-    }
     if (tapEnabled && tap.hasActivePointer && !selectionHandleConsumed && !tableHandleConsumed) {
       longPress.prepare(pointerId = pointerId)
       context.effects.scheduleLongPressDispatch(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionScope.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionScope.kt
@@ -15,14 +15,17 @@ import co.typie.editor.scroll.EditorVisibleArea
 import co.typie.editor.viewport.EditorViewportState
 import co.typie.ext.ScrollGestureLockHandle
 import co.typie.ext.ScrollGestureLockState
+import co.typie.platform.Platform
 import co.typie.platform.PlatformModule
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
-internal class EditorInteractionScope(private val coroutineScope: CoroutineScope) :
-  EditorInteractionEffects, EditorInteractionGeometry {
+internal class EditorInteractionScope(
+  private val coroutineScope: CoroutineScope,
+  private val platformProvider: () -> Platform = { PlatformModule.platform },
+) : EditorInteractionEffects, EditorInteractionGeometry {
   private var editor: Editor? = null
   private var bringIntoViewRequests: EditorBringIntoViewRequests? = null
   private var uiState: EditorUiState? = null
@@ -45,7 +48,7 @@ internal class EditorInteractionScope(private val coroutineScope: CoroutineScope
       effects = this,
       geometry = this,
       semantics = semantics,
-      platformProvider = { PlatformModule.platform },
+      platformProvider = { platformProvider() },
       uiStateProvider = { checkNotNull(uiState) { "Editor interaction scope has no UI state" } },
       pointerInputEnabledProvider = { pointerInputEnabled() },
     )

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractions.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractions.kt
@@ -76,7 +76,7 @@ private class EditorInteractionsNode(
     }
 
     if (density <= 0f) {
-      cancelInteraction()
+      cancelInteractionIfOwnedPointer()
       return
     }
 
@@ -143,12 +143,18 @@ private class EditorInteractionsNode(
   }
 
   override fun onCancelPointerInput() {
-    cancelInteraction()
+    cancelInteractionIfOwnedPointer()
   }
 
   private fun cancelInteraction() {
     pointerOwnership.reset()
     interactionController.cancel()
+  }
+
+  private fun cancelInteractionIfOwnedPointer() {
+    if (pointerOwnership.hasPointers) {
+      cancelInteraction()
+    }
   }
 
   private fun activePositionOrCancel(position: Offset): Offset? {
@@ -160,7 +166,7 @@ private class EditorInteractionsNode(
   }
 
   override fun onDetach() {
-    cancelInteraction()
+    cancelInteractionIfOwnedPointer()
     super.onDetach()
   }
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorPointerOwnership.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorPointerOwnership.kt
@@ -3,6 +3,9 @@ package co.typie.editor.interaction
 internal class EditorPointerOwnership {
   private val pointerIds = mutableSetOf<Long>()
 
+  val hasPointers: Boolean
+    get() = pointerIds.isNotEmpty()
+
   fun acquire(pointerId: Long) {
     pointerIds += pointerId
   }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorTableHandleGesture.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorTableHandleGesture.kt
@@ -60,7 +60,6 @@ internal class EditorTableHandleGesture(
     }
     context.effects.cancelTapDispatch()
     context.effects.cancelLongPressDispatch()
-    context.effects.setScrollGestureLocked(true)
     context.uiState.contextMenu.hide()
     return true
   }
@@ -104,6 +103,9 @@ internal class EditorTableHandleGesture(
 
     context.uiState.contextMenu.hide()
     context.semantics.magnifier.hide()
+    context.effects.cancelTapDispatch()
+    context.effects.cancelLongPressDispatch()
+    context.effects.setScrollGestureLocked(true)
     context.reduceMode(EditorInteractionEvent.TableHandleDragStart)
     if (context.mode != EditorInteractionMode.TableCellHandleDragging) {
       resetPointerOwnedState(context = context)

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorOverlayPointerRouter.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorOverlayPointerRouter.kt
@@ -1,0 +1,268 @@
+package co.typie.screen.editor.editor.overlay
+
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.isCtrlPressed
+import androidx.compose.ui.input.pointer.isMetaPressed
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
+import co.typie.editor.Editor
+import co.typie.editor.interaction.EditorInteractionController
+import co.typie.editor.interaction.EditorInteractionScope
+import co.typie.editor.interaction.EditorPointerCoordinateResolver
+import co.typie.editor.interaction.LocalEditorInteractionScope
+import co.typie.editor.interaction.editorInteractions
+import co.typie.editor.runtime.EditorUiState
+import co.typie.editor.viewport.EditorViewportState
+import co.typie.editor.viewport.consumeEditorViewportWheelPan
+import co.typie.screen.editor.editor.viewport.editorPointerSignalWheelZoom
+import kotlin.math.roundToInt
+
+@Composable
+internal fun EditorOverlayPointerRouter(
+  editor: Editor,
+  uiState: EditorUiState,
+  editorRectInOverlay: Rect,
+  density: Float,
+  viewportState: EditorViewportState,
+) {
+  if (!uiState.focused || density <= 0f) {
+    return
+  }
+
+  val interactionScope = LocalEditorInteractionScope.current
+  val interactionController = interactionScope.controller
+  var activeTarget by remember { mutableStateOf<EditorOverlayPointerTarget?>(null) }
+  val targets =
+    retainActiveOverlayPointerTarget(
+      currentTargets =
+        resolveOverlayPointerTargets(
+          editor = editor,
+          uiState = uiState,
+          editorRectInOverlay = editorRectInOverlay,
+          density = density,
+        ),
+      activeTarget = activeTarget,
+    )
+
+  targets.forEach { target ->
+    key(target.key) {
+      EditorOverlayPointerRouterTarget(
+        target = target,
+        editorRectInOverlay = editorRectInOverlay,
+        density = density,
+        viewportState = viewportState,
+        interactionScope = interactionScope,
+        interactionController = interactionController,
+        onPointerStreamStart = { activeTarget = it },
+        onPointerStreamEnd = { activeTarget = null },
+      )
+    }
+  }
+}
+
+private data class EditorOverlayPointerTarget(val key: String, val rectInOverlay: Rect)
+
+private fun retainActiveOverlayPointerTarget(
+  currentTargets: List<EditorOverlayPointerTarget>,
+  activeTarget: EditorOverlayPointerTarget?,
+): List<EditorOverlayPointerTarget> {
+  activeTarget ?: return currentTargets
+
+  var retained = false
+  val targets = currentTargets.map { target ->
+    if (target.key == activeTarget.key) {
+      retained = true
+      activeTarget
+    } else {
+      target
+    }
+  }
+  return if (retained) targets else currentTargets + activeTarget
+}
+
+private fun resolveOverlayPointerTargets(
+  editor: Editor,
+  uiState: EditorUiState,
+  editorRectInOverlay: Rect,
+  density: Float,
+): List<EditorOverlayPointerTarget> =
+  buildList {
+      resolveTableCellSelectionOverlayPlacements(
+          editor = editor,
+          uiState = uiState,
+          editorRectInOverlay = editorRectInOverlay,
+          density = density,
+        )
+        .forEach { placement ->
+          placement.handleTouchTargetRect(density)?.let { rect ->
+            add(
+              EditorOverlayPointerTarget(
+                key = "table-cell:${placement.tableId}",
+                rectInOverlay = rect,
+              )
+            )
+          }
+        }
+
+      resolveSelectionHandleOverlayPlacements(
+          editor = editor,
+          uiState = uiState,
+          editorRectInOverlay = editorRectInOverlay,
+          density = density,
+        )
+        ?.forEach { placement ->
+          val geometry =
+            resolveSelectionHandleOverlayGeometry(placement = placement, density = density)
+          add(
+            EditorOverlayPointerTarget(
+              key = "selection:${placement.type}",
+              rectInOverlay =
+                Rect(
+                  topLeft = geometry.touchTargetTopLeft,
+                  bottomRight =
+                    geometry.touchTargetTopLeft +
+                      Offset(
+                        x = geometry.touchTargetSize.width,
+                        y = geometry.touchTargetSize.height,
+                      ),
+                ),
+            )
+          )
+        }
+    }
+    .filter { target -> target.rectInOverlay.width > 0f && target.rectInOverlay.height > 0f }
+
+@Composable
+private fun EditorOverlayPointerRouterTarget(
+  target: EditorOverlayPointerTarget,
+  editorRectInOverlay: Rect,
+  density: Float,
+  viewportState: EditorViewportState,
+  interactionScope: EditorInteractionScope,
+  interactionController: EditorInteractionController,
+  onPointerStreamStart: (EditorOverlayPointerTarget) -> Unit,
+  onPointerStreamEnd: () -> Unit,
+) {
+  val localDensity = LocalDensity.current
+  val currentTarget by rememberUpdatedState(target)
+
+  Box(
+    modifier =
+      Modifier.offset {
+          IntOffset(target.rectInOverlay.left.roundToInt(), target.rectInOverlay.top.roundToInt())
+        }
+        .size(
+          width = with(localDensity) { target.rectInOverlay.width.toDp() },
+          height = with(localDensity) { target.rectInOverlay.height.toDp() },
+        )
+        .pointerInput(target.key) {
+          awaitEachGesture {
+            awaitFirstDown(requireUnconsumed = false)
+            onPointerStreamStart(currentTarget)
+            try {
+              do {
+                val event = awaitPointerEvent()
+              } while (event.changes.any { change -> change.pressed })
+            } finally {
+              onPointerStreamEnd()
+            }
+          }
+        }
+        .editorOverlayViewportWheelInput(
+          viewportState = viewportState,
+          interactionScope = interactionScope,
+          targetRectInOverlay = target.rectInOverlay,
+        )
+        .editorInteractions(
+          density = density,
+          interactionController = interactionController,
+          coordinateResolver =
+            EditorOverlayPointerTargetCoordinateResolver(
+              editorRectInOverlay = editorRectInOverlay,
+              targetRectInOverlay = target.rectInOverlay,
+            ),
+        )
+  )
+}
+
+internal fun Modifier.editorOverlayViewportWheelInput(
+  viewportState: EditorViewportState,
+  interactionScope: EditorInteractionScope,
+  targetRectInOverlay: Rect,
+): Modifier =
+  editorPointerSignalWheelZoom(
+      key1 = interactionScope,
+      key2 = targetRectInOverlay,
+      onZoomSessionStart = interactionScope::beginPointerSignalZoom,
+      onZoom = { focalPosition, normalizedDelta ->
+        interactionScope.updatePointerSignalZoom(
+          focalPosition = targetRectInOverlay.topLeft + focalPosition,
+          normalizedDelta = normalizedDelta,
+        )
+      },
+      onZoomSessionEnd = interactionScope::endPointerSignalZoom,
+    )
+    .pointerInput(viewportState) {
+      awaitPointerEventScope {
+        while (true) {
+          val event = awaitPointerEvent(PointerEventPass.Main)
+          if (event.type != PointerEventType.Scroll) {
+            continue
+          }
+          if (event.keyboardModifiers.isCtrlPressed || event.keyboardModifiers.isMetaPressed) {
+            continue
+          }
+
+          val scrollDelta =
+            event.changes.fold(Offset.Zero) { delta, change ->
+              if (change.isConsumed) {
+                delta
+              } else {
+                delta + change.scrollDelta
+              }
+            }
+          if (scrollDelta == Offset.Zero) {
+            continue
+          }
+
+          viewportState.updateScrollableInteractionInProgress(true)
+          val consumed =
+            consumeEditorViewportWheelPan(viewportState = viewportState, scrollDelta = scrollDelta)
+          viewportState.updateScrollableInteractionInProgress(false)
+          if (consumed != Offset.Zero) {
+            event.changes.forEach { it.consume() }
+          }
+        }
+      }
+    }
+
+internal class EditorOverlayPointerTargetCoordinateResolver(
+  private val editorRectInOverlay: Rect,
+  private val targetRectInOverlay: Rect,
+) : EditorPointerCoordinateResolver {
+  override fun positionForPointerStart(position: Offset): Offset = positionInEditor(position)
+
+  override fun positionForTapStart(position: Offset): Offset = positionInEditor(position)
+
+  override fun positionForActivePointer(position: Offset): Offset = positionInEditor(position)
+
+  private fun positionInEditor(position: Offset): Offset =
+    targetRectInOverlay.topLeft + position - editorRectInOverlay.topLeft
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorScreenOverlayHost.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorScreenOverlayHost.kt
@@ -119,6 +119,7 @@ internal fun EditorScreenOverlayHost(
             uiState = uiState,
             editorRectInOverlay = editorRectInViewport,
             density = density.density,
+            viewportState = viewportState,
           )
           EditorTableCellSelectionOverlay(
             editor = editor,
@@ -139,6 +140,13 @@ internal fun EditorScreenOverlayHost(
             uiState = uiState,
             editorRectInOverlay = editorRectInViewport,
             density = density.density,
+          )
+          EditorOverlayPointerRouter(
+            editor = editor,
+            uiState = uiState,
+            editorRectInOverlay = editorRectInViewport,
+            density = density.density,
+            viewportState = viewportState,
           )
         }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorSelectionHandleOverlay.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorSelectionHandleOverlay.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.translate
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.unit.dp
 import co.typie.editor.Editor
 import co.typie.editor.EditorViewportTransform
 import co.typie.editor.ext.isCollapsed
@@ -88,6 +87,19 @@ internal data class EditorSelectionHandleOverlayPlacement(
   val stemHeightPx: Float,
 )
 
+internal fun resolveSelectionHandleOverlayGeometry(
+  placement: EditorSelectionHandleOverlayPlacement,
+  density: Float,
+) =
+  resolveSelectionHandleGeometry(
+    type = placement.type,
+    endpointTopLeftInOverlay = placement.endpointTopLeftInOverlay,
+    stemHeightPx = placement.stemHeightPx,
+    radiusPx = EditorSelectionHandleRadiusDp * density,
+    stemWidthPx = EditorSelectionHandleStemWidthDp * density,
+    touchTargetPx = EditorSelectionHandleTouchTargetDp * density,
+  )
+
 private fun resolveSelectionHandleOverlayPlacement(
   type: EditorSelectionHandleType,
   endpoint: PageRect,
@@ -116,18 +128,7 @@ private fun resolveSelectionHandleOverlayPlacement(
 @Composable
 private fun EditorSelectionHandle(placement: EditorSelectionHandleOverlayPlacement, color: Color) {
   val localDensity = LocalDensity.current
-  val radiusPx = with(localDensity) { EditorSelectionHandleRadiusDp.dp.toPx() }
-  val stemWidthPx = with(localDensity) { EditorSelectionHandleStemWidthDp.dp.toPx() }
-  val touchTargetPx = with(localDensity) { EditorSelectionHandleTouchTargetDp.dp.toPx() }
-  val geometry =
-    resolveSelectionHandleGeometry(
-      type = placement.type,
-      endpointTopLeftInOverlay = placement.endpointTopLeftInOverlay,
-      stemHeightPx = placement.stemHeightPx,
-      radiusPx = radiusPx,
-      stemWidthPx = stemWidthPx,
-      touchTargetPx = touchTargetPx,
-    )
+  val geometry = resolveSelectionHandleOverlayGeometry(placement, localDensity.density)
 
   Box(
     modifier =

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorTableCellSelectionOverlay.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorTableCellSelectionOverlay.kt
@@ -13,6 +13,7 @@ import co.typie.editor.EditorViewportTransform
 import co.typie.editor.interaction.EditorTableCellSelection
 import co.typie.editor.interaction.EditorTableCellSelectionBorderWidthDp
 import co.typie.editor.interaction.EditorTableCellSelectionHandleRadiusDp
+import co.typie.editor.interaction.EditorTableCellSelectionHandleTouchTargetDp
 import co.typie.editor.interaction.resolveTableCellSelections
 import co.typie.editor.runtime.EditorUiState
 import co.typie.ui.theme.AppTheme
@@ -89,6 +90,7 @@ internal fun resolveTableCellSelectionOverlayPlacements(
       }
 
     EditorTableCellSelectionOverlayPlacement(
+      tableId = activeSelection.overlay.tableId,
       outline = outline,
       handleCenter = handleCenter,
       borderWidthPx = EditorTableCellSelectionBorderWidthDp * density,
@@ -98,11 +100,26 @@ internal fun resolveTableCellSelectionOverlayPlacements(
 }
 
 internal data class EditorTableCellSelectionOverlayPlacement(
+  val tableId: String,
   val outline: Rect,
   val handleCenter: Offset?,
   val borderWidthPx: Float,
   val handleRadiusPx: Float,
 )
+
+internal fun EditorTableCellSelectionOverlayPlacement.handleTouchTargetRect(density: Float): Rect? {
+  val center = handleCenter ?: return null
+  val halfSize = EditorTableCellSelectionHandleTouchTargetDp * density / 2f
+  if (halfSize <= 0f) {
+    return null
+  }
+  return Rect(
+    left = center.x - halfSize,
+    top = center.y - halfSize,
+    right = center.x + halfSize,
+    bottom = center.y + halfSize,
+  )
+}
 
 private fun resolveOutlineInOverlay(
   activeSelection: EditorTableCellSelection,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorTableColumnResizeOverlay.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorTableColumnResizeOverlay.kt
@@ -1,7 +1,8 @@
 package co.typie.screen.editor.editor.overlay
 
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -18,7 +19,9 @@ import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import co.typie.editor.Editor
@@ -27,16 +30,23 @@ import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.NodeOp
 import co.typie.editor.ffi.TableOp
 import co.typie.editor.ffi.TableOverlay
+import co.typie.editor.interaction.EditorInteractionController
+import co.typie.editor.interaction.EditorInteractionScope
 import co.typie.editor.interaction.EditorTableCellSelection
 import co.typie.editor.interaction.EditorTableCellSelectionHandleTouchTargetDp
+import co.typie.editor.interaction.LocalEditorInteractionScope
+import co.typie.editor.interaction.editorInteractions
 import co.typie.editor.interaction.resolveActiveTableCellSelection
 import co.typie.editor.runtime.EditorUiState
+import co.typie.editor.viewport.EditorViewportState
 import co.typie.ui.theme.AppTheme
 import kotlin.math.abs
 import kotlin.math.max
+import kotlin.math.min
 import kotlin.math.roundToInt
 
 private const val TableColumnResizeTouchWidthDp = 24f
+private const val TableColumnResizeDragSlopDp = 8f
 private const val TableColumnResizeVisualWidthDp = 3f
 private const val TableColumnResizeMinColumnWidth = 40f
 private const val TableColumnResizeBorderWidth = 1f
@@ -84,6 +94,7 @@ internal fun EditorTableColumnResizeOverlay(
   uiState: EditorUiState,
   editorRectInOverlay: Rect,
   density: Float,
+  viewportState: EditorViewportState,
 ) {
   if (!uiState.focused || density <= 0f) {
     return
@@ -97,9 +108,13 @@ internal fun EditorTableColumnResizeOverlay(
       density = density,
     ) ?: return
   var draft by remember { mutableStateOf<EditorTableColumnResizeDraft?>(null) }
+  var resizeHandlePressed by remember { mutableStateOf(false) }
   val currentEditor by rememberUpdatedState(editor)
+  val interactionScope = LocalEditorInteractionScope.current
+  val interactionController = interactionScope.controller
   val color = AppTheme.colors.palette.blue
   val activeDraft = draft
+  val resizeHandleActive = activeDraft != null || resizeHandlePressed
   val visualCenterX =
     activeDraft?.let { it.baseCenterX + resolveResizeDelta(it) * it.pxPerPageUnit }
       ?: placement.centerX
@@ -113,7 +128,7 @@ internal fun EditorTableColumnResizeOverlay(
       val height = (visualBottom - visualTop - verticalInset * 2f).coerceAtLeast(0f)
       if (height > 0f) {
         drawRoundRect(
-          color = color.copy(alpha = if (activeDraft != null) 0.85f else 0.35f),
+          color = color.copy(alpha = if (resizeHandleActive) 0.85f else 0.35f),
           topLeft = Offset(x = visualCenterX - visualWidth / 2f, y = visualTop + verticalInset),
           size = Size(width = visualWidth, height = height),
           cornerRadius = CornerRadius(visualWidth / 2f, visualWidth / 2f),
@@ -125,6 +140,11 @@ internal fun EditorTableColumnResizeOverlay(
       TableColumnResizeHandle(
         rect = rect,
         density = density,
+        editorRectInOverlay = editorRectInOverlay,
+        viewportState = viewportState,
+        interactionScope = interactionScope,
+        interactionController = interactionController,
+        onPressedChange = { resizeHandlePressed = it },
         onStart = {
           uiState.contextMenu.hide()
           draft = placement.toDraft()
@@ -310,6 +330,16 @@ internal fun resolveTableResizeCommittedDelta(overlay: TableOverlay, deltaX: Flo
     deltaX = deltaX,
   )
 
+internal fun resolveTableResizePreviewDelta(overlay: TableOverlay, deltaX: Float): Float =
+  resolveTableResizePreviewDelta(
+    colCount = overlay.columns.size,
+    currentTableWidth = overlay.bounds.width,
+    contentWidth = overlay.contentWidth,
+    minProportionWidth = overlay.minProportionWidth,
+    maxProportionWidth = overlay.maxProportionWidth,
+    deltaX = deltaX,
+  )
+
 internal fun dragDeltaToPageDelta(deltaPx: Float, pxPerPageUnit: Float): Float =
   if (pxPerPageUnit.isFinite() && pxPerPageUnit > 0f) {
     deltaPx / pxPerPageUnit
@@ -367,6 +397,23 @@ private fun resolveTableResizeCommittedDelta(
   }
   return contentWidth * (proportion / 100f) - currentTableWidth
 }
+
+private fun resolveTableResizePreviewDelta(
+  colCount: Int,
+  currentTableWidth: Float,
+  contentWidth: Float,
+  minProportionWidth: Float,
+  maxProportionWidth: Float,
+  deltaX: Float,
+): Float =
+  clampTableResizeDelta(
+    colCount = colCount,
+    currentTableWidth = currentTableWidth,
+    contentWidth = contentWidth,
+    minProportionWidth = minProportionWidth,
+    maxProportionWidth = maxProportionWidth,
+    deltaX = deltaX,
+  )
 
 private fun clampTableColumnResizeDelta(widths: List<Float>, colIndex: Int, deltaX: Float): Float {
   if (widths.isEmpty() || colIndex < 0 || colIndex >= widths.lastIndex) {
@@ -439,14 +486,14 @@ private fun hasWidthChange(before: List<Float>, after: List<Float>): Boolean {
 
 private fun resolveResizeDelta(draft: EditorTableColumnResizeDraft): Float =
   if (draft.isTableResize) {
-    resolveTableResizeCommittedDelta(
+    resolveTableResizePreviewDelta(
       colCount = draft.initialWidths.size,
       currentTableWidth = draft.initialTableWidth,
       contentWidth = draft.contentWidth,
       minProportionWidth = draft.minProportionWidth,
       maxProportionWidth = draft.maxProportionWidth,
       deltaX = draft.deltaX,
-    ) ?: 0f
+    )
   } else {
     clampTableColumnResizeDelta(
       widths = draft.initialWidths,
@@ -512,29 +559,87 @@ private fun Editor.commitTableResize(draft: EditorTableColumnResizeDraft) {
 private fun TableColumnResizeHandle(
   rect: Rect,
   density: Float,
+  editorRectInOverlay: Rect,
+  viewportState: EditorViewportState,
+  interactionScope: EditorInteractionScope,
+  interactionController: EditorInteractionController,
+  onPressedChange: (Boolean) -> Unit,
   onStart: () -> Unit,
   onDrag: (Float) -> Unit,
   onEnd: () -> Unit,
 ) {
+  val viewConfiguration = LocalViewConfiguration.current
   val currentOnStart by rememberUpdatedState(onStart)
   val currentOnDrag by rememberUpdatedState(onDrag)
   val currentOnEnd by rememberUpdatedState(onEnd)
+  val currentOnPressedChange by rememberUpdatedState(onPressedChange)
+  val dragSlop = min(viewConfiguration.touchSlop, TableColumnResizeDragSlopDp * density)
   Box(
     modifier =
       Modifier.offset { IntOffset(x = rect.left.roundToInt(), y = rect.top.roundToInt()) }
         .width((rect.width / density).dp)
         .height((rect.height / density).dp)
-        .pointerInput(Unit) {
-          detectDragGestures(
-            onDragStart = { currentOnStart() },
-            onDrag = { change, dragAmount ->
-              change.consume()
-              currentOnDrag(dragAmount.x)
-            },
-            onDragEnd = { currentOnEnd() },
-            onDragCancel = { currentOnEnd() },
-          )
+        .pointerInput(interactionController) {
+          awaitPointerEventScope {
+            while (true) {
+              val event = awaitPointerEvent(PointerEventPass.Initial)
+              if (event.changes.any { it.pressed && !it.previousPressed }) {
+                interactionController.clearTapHistory()
+              }
+            }
+          }
         }
+        .pointerInput(Unit) {
+          awaitEachGesture {
+            val down = awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Final)
+            val pointerId = down.id
+            val start = down.position
+            var previous = start
+            var dragging = false
+            currentOnPressedChange(true)
+            interactionScope.cancelTapDispatch()
+            interactionScope.cancelLongPressDispatch()
+            try {
+              while (true) {
+                val event = awaitPointerEvent()
+                val change = event.changes.firstOrNull { it.id == pointerId } ?: break
+                if (!change.pressed) {
+                  break
+                }
+                val position = change.position
+                if (!dragging) {
+                  if ((position - start).getDistance() <= dragSlop) {
+                    continue
+                  }
+                  dragging = true
+                  currentOnStart()
+                }
+                currentOnDrag(position.x - previous.x)
+                previous = position
+                change.consume()
+              }
+            } finally {
+              if (dragging) {
+                currentOnEnd()
+              }
+              currentOnPressedChange(false)
+            }
+          }
+        }
+        .editorOverlayViewportWheelInput(
+          viewportState = viewportState,
+          interactionScope = interactionScope,
+          targetRectInOverlay = rect,
+        )
+        .editorInteractions(
+          density = density,
+          interactionController = interactionController,
+          coordinateResolver =
+            EditorOverlayPointerTargetCoordinateResolver(
+              editorRectInOverlay = editorRectInOverlay,
+              targetRectInOverlay = rect,
+            ),
+        )
   ) {}
 }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/viewport/EditorDebugWheelZoom.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/viewport/EditorDebugWheelZoom.kt
@@ -29,7 +29,24 @@ internal fun rememberEditorDebugWheelZoomModifier(
   onZoom: (focalPosition: Offset, normalizedDelta: Float) -> Boolean,
   onZoomSessionEnd: () -> Unit,
 ): Modifier {
-  return Modifier.pointerInput(state) {
+  return Modifier.editorPointerSignalWheelZoom(
+    key1 = state,
+    canZoom = { state.viewport.width > 0f },
+    onZoomSessionStart = onZoomSessionStart,
+    onZoom = onZoom,
+    onZoomSessionEnd = onZoomSessionEnd,
+  )
+}
+
+internal fun Modifier.editorPointerSignalWheelZoom(
+  key1: Any?,
+  key2: Any? = Unit,
+  canZoom: () -> Boolean = { true },
+  onZoomSessionStart: () -> Boolean,
+  onZoom: (focalPosition: Offset, normalizedDelta: Float) -> Boolean,
+  onZoomSessionEnd: () -> Unit,
+): Modifier =
+  pointerInput(key1, key2) {
     coroutineScope {
       var wheelLastEventTs: Long? = null
       var wheelLowDeltaStreak = 0
@@ -70,7 +87,7 @@ internal fun rememberEditorDebugWheelZoomModifier(
             finishWheelZoomSession()
             continue
           }
-          if (!dominantDelta.isFinite() || dominantDelta == 0f || state.viewport.width <= 0f) {
+          if (!dominantDelta.isFinite() || dominantDelta == 0f || !canZoom()) {
             continue
           }
 
@@ -116,7 +133,6 @@ internal fun rememberEditorDebugWheelZoomModifier(
       }
     }
   }
-}
 
 internal class EditorDebugWheelZoomSession(
   private val scope: CoroutineScope,

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
@@ -1524,7 +1524,7 @@ class EditorInteractionControllerTest {
     }
 
   @Test
-  fun `table cell handle tap does not dispatch cell tap`() =
+  fun `table cell handle tap dispatches a normal cell tap`() =
     runTest(StandardTestDispatcher()) {
       val selection =
         Selection(
@@ -1552,12 +1552,60 @@ class EditorInteractionControllerTest {
       val down = Offset(60f, 60f)
 
       assertTrue(controller.onPointerDown(pointerId = 1L, position = down, nowMillis = 0L))
-      controller.onTapTimer(nowMillis = 260L)
+      assertNull(host.scheduledTapDispatchAtMillis)
+      assertFalse(host.scrollGestureLockActive)
       assertTrue(controller.onPointerUp(pointerId = 1L, position = down, nowMillis = 300L))
       runCurrent()
 
-      assertEquals(emptyList(), fake.enqueued.filterIsInstance<Message.Selection>())
+      assertEquals(
+        listOf(Message.Selection(SelectionOp.SetAt(page = 0, x = 60f, y = 60f))),
+        fake.enqueued.filterIsInstance<Message.Selection>(),
+      )
       assertEquals(EditorInteractionMode.Idle, controller.interactionMode)
+    }
+
+  @Test
+  fun `table cell handle delayed drag does not dispatch a pending tap first`() =
+    runTest(StandardTestDispatcher()) {
+      val selection =
+        Selection(
+          anchor = Position("cell-text", 0, Affinity.Downstream),
+          head = Position("cell-text", 0, Affinity.Downstream),
+        )
+      val fake =
+        FakeFfiEditor(
+          selectionProvider = { selection },
+          tableOverlaysProvider = {
+            listOf(tableOverlay(isFocused = true, focusedRowIndex = 0, focusedColIndex = 0))
+          },
+        )
+      val editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
+      editor.sync {}
+      val host = TestHost(this)
+      val controller =
+        EditorInteractionController(
+          editorProvider = { editor },
+          effects = host,
+          geometry = host,
+          uiStateProvider = { host.uiState },
+        )
+      controller.updateTapSlop(8f)
+      val down = Offset(60f, 60f)
+
+      assertTrue(controller.onPointerDown(pointerId = 1L, position = down, nowMillis = 0L))
+      assertNull(host.scheduledTapDispatchAtMillis)
+      assertTrue(
+        controller.onPointerMove(pointerId = 1L, position = Offset(100f, 90f), nowMillis = 300L)
+      )
+
+      val messages = fake.enqueued.filterIsInstance<Message.Selection>().map { it.op }
+      assertEquals(1, messages.size)
+      val extend = messages.single() as SelectionOp.ExtendTo
+      assertEquals(selection.anchor, extend.anchor)
+      assertEquals(100f, extend.headX)
+      assertEquals(90f, extend.headY)
+      assertEquals(selection, extend.baseSelection)
+      assertFalse(extend.allowCollapse)
     }
 
   @Test

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorPointerOwnershipTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorPointerOwnershipTest.kt
@@ -10,14 +10,17 @@ class EditorPointerOwnershipTest {
     val ownership = EditorPointerOwnership()
 
     assertFalse(ownership.owns(pointerId = 1L))
+    assertFalse(ownership.hasPointers)
 
     ownership.acquire(pointerId = 1L)
 
+    assertTrue(ownership.hasPointers)
     assertTrue(ownership.owns(pointerId = 1L))
     assertFalse(ownership.owns(pointerId = 2L))
 
     ownership.release(pointerId = 1L)
 
+    assertFalse(ownership.hasPointers)
     assertFalse(ownership.owns(pointerId = 1L))
   }
 

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/overlay/EditorTableColumnResizeOverlayTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/overlay/EditorTableColumnResizeOverlayTest.kt
@@ -61,11 +61,19 @@ class EditorTableColumnResizeOverlayTest {
   }
 
   @Test
-  fun `table resize draft delta matches committed rounded proportion`() {
+  fun `table resize committed delta matches rounded proportion`() {
     val overlay = tableOverlay(bounds = FfiRect(x = 10f, y = 20f, width = 150f, height = 80f))
 
     assertEquals(0f, resolveTableResizeCommittedDelta(overlay = overlay, deltaX = 0.4f))
     assertEquals(10f, resolveTableResizeCommittedDelta(overlay = overlay, deltaX = 9.6f))
+  }
+
+  @Test
+  fun `table resize preview delta follows the pointer before rounded commit`() {
+    val overlay = tableOverlay(bounds = FfiRect(x = 10f, y = 20f, width = 150f, height = 80f))
+
+    assertEquals(0.4f, resolveTableResizePreviewDelta(overlay = overlay, deltaX = 0.4f))
+    assertEquals(9.6f, resolveTableResizePreviewDelta(overlay = overlay, deltaX = 9.6f))
   }
 
   @Test

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorOverlayPointerRouterDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorOverlayPointerRouterDesktopTest.kt
@@ -1,0 +1,912 @@
+package co.typie.screen.editor.editor.overlay
+
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect as ComposeRect
+import androidx.compose.ui.geometry.Size as ComposeSize
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
+import androidx.compose.ui.input.pointer.changedToUp
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SkikoComposeUiTest
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import co.typie.editor.Editor
+import co.typie.editor.EditorZoomController
+import co.typie.editor.FakeFfiEditor
+import co.typie.editor.body.EditorDocumentLayoutSpec
+import co.typie.editor.ffi.Affinity
+import co.typie.editor.ffi.Alignment
+import co.typie.editor.ffi.EditorEvent
+import co.typie.editor.ffi.Message
+import co.typie.editor.ffi.NodeOp
+import co.typie.editor.ffi.PageRect
+import co.typie.editor.ffi.Position
+import co.typie.editor.ffi.Rect
+import co.typie.editor.ffi.Selection
+import co.typie.editor.ffi.SelectionEndpoints
+import co.typie.editor.ffi.SelectionOp
+import co.typie.editor.ffi.Size
+import co.typie.editor.ffi.StateField
+import co.typie.editor.ffi.TableBorderStyle
+import co.typie.editor.ffi.TableOp
+import co.typie.editor.ffi.TableOverlay
+import co.typie.editor.ffi.TableOverlayCellSelection
+import co.typie.editor.ffi.TableOverlayColumn
+import co.typie.editor.ffi.TableOverlayRow
+import co.typie.editor.interaction.EditorInteractionScope
+import co.typie.editor.interaction.LocalEditorInteractionScope
+import co.typie.editor.interaction.semantics.EditorViewportZoomSemanticConfig
+import co.typie.editor.runtime.EditorRuntime
+import co.typie.editor.runtime.EditorUiState
+import co.typie.editor.runtime.LocalEditorRuntime
+import co.typie.editor.runtime.LocalEditorUiState
+import co.typie.editor.scroll.EditorBringIntoViewRequests
+import co.typie.editor.scroll.EditorVisibleArea
+import co.typie.editor.scroll.LocalEditorBringIntoViewRequests
+import co.typie.editor.scroll.resolveEditorAutoScrollPolicy
+import co.typie.editor.viewport.EditorViewportState
+import co.typie.ext.ScrollGestureLockState
+import co.typie.platform.Platform
+import co.typie.ui.theme.LightAppShadows
+import co.typie.ui.theme.LightColors
+import co.typie.ui.theme.LocalAppColors
+import co.typie.ui.theme.LocalAppShadows
+import co.typie.ui.theme.LocalThemeMode
+import co.typie.ui.theme.ResolvedThemeMode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+
+@OptIn(ExperimentalTestApi::class, InternalComposeUiApi::class, ExperimentalCoroutinesApi::class)
+class EditorOverlayPointerRouterDesktopTest {
+  @Test
+  fun selectionHandleRoutesDragBeforeLowerPointerOverlay() = runComposeUiTest {
+    val selection =
+      Selection(
+        anchor = Position("text", 0, Affinity.Downstream),
+        head = Position("text", 5, Affinity.Downstream),
+      )
+    val endpoints =
+      SelectionEndpoints(
+        from = PageRect(pageIdx = 0, rect = Rect(x = 10f, y = 20f, width = 4f, height = 8f)),
+        to = PageRect(pageIdx = 0, rect = Rect(x = 40f, y = 20f, width = 4f, height = 8f)),
+        fromPosition = Position("text", 0, Affinity.Downstream),
+        toPosition = Position("text", 5, Affinity.Downstream),
+      )
+    val fake =
+      FakeFfiEditor(
+        selectionProvider = { selection },
+        selectionEndpointsProvider = { endpoints },
+        pageSizesProvider = { listOf(Size(width = 120f, height = 120f)) },
+      )
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val editor = Editor(fake, scope)
+    val uiState =
+      EditorUiState().apply {
+        updateFocus(true)
+        updatePageOffset(page = 0, offset = Offset.Zero)
+        updateExtensionAreaBounds(TestRootRect, density = 1f)
+        updateEditorBounds(TestRootRect, density = 1f)
+      }
+    val runtime = EditorRuntime(scope).apply { attach(editor) }
+    editor.sync {}
+    try {
+      setOverlayHostContent(editor = editor, runtime = runtime, uiState = uiState, scope = scope)
+      waitForIdle()
+
+      onNodeWithTag(RootTag).performTouchInput {
+        down(Offset(x = 42f, y = 30f))
+        moveTo(Offset(x = 52f, y = 50f))
+      }
+      waitForIdle()
+
+      val extend =
+        fake.enqueued.filterIsInstance<Message.Selection>().single().op as SelectionOp.ExtendTo
+      assertEquals(endpoints.fromPosition, extend.anchor)
+      assertEquals(50f, extend.headX)
+      assertEquals(44f, extend.headY)
+      assertFalse(extend.allowCollapse)
+      assertNull(extend.baseSelection)
+    } finally {
+      runtime.clear(editor)
+      scope.cancel()
+    }
+  }
+
+  @Test
+  fun selectionHandleForwardsWheelScrollToViewport() = runComposeUiTest {
+    val selection =
+      Selection(
+        anchor = Position("text", 0, Affinity.Downstream),
+        head = Position("text", 5, Affinity.Downstream),
+      )
+    val endpoints =
+      SelectionEndpoints(
+        from = PageRect(pageIdx = 0, rect = Rect(x = 10f, y = 20f, width = 4f, height = 8f)),
+        to = PageRect(pageIdx = 0, rect = Rect(x = 40f, y = 20f, width = 4f, height = 8f)),
+        fromPosition = Position("text", 0, Affinity.Downstream),
+        toPosition = Position("text", 5, Affinity.Downstream),
+      )
+    val fake =
+      FakeFfiEditor(
+        selectionProvider = { selection },
+        selectionEndpointsProvider = { endpoints },
+        pageSizesProvider = { listOf(Size(width = 120f, height = 400f)) },
+      )
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val editor = Editor(fake, scope)
+    val uiState =
+      EditorUiState().apply {
+        updateFocus(true)
+        updatePageOffset(page = 0, offset = Offset.Zero)
+        updateExtensionAreaBounds(TestRootRect, density = 1f)
+        updateEditorBounds(
+          ComposeRect(Offset.Zero, ComposeSize(width = 120f, height = 400f)),
+          density = 1f,
+        )
+      }
+    val runtime = EditorRuntime(scope).apply { attach(editor) }
+    val viewportState = EditorViewportState()
+    editor.sync {}
+    try {
+      setOverlayHostContent(
+        editor = editor,
+        runtime = runtime,
+        uiState = uiState,
+        scope = scope,
+        viewportState = viewportState,
+        viewportContentSize = ComposeSize(width = 120f, height = 400f),
+      )
+      waitForIdle()
+
+      onNodeWithTag(RootTag).performMouseInput {
+        moveTo(Offset(x = 42f, y = 30f))
+        scroll(Offset(x = 0f, y = 120f))
+      }
+      waitForIdle()
+
+      assertTrue(viewportState.scrollOffset.y > 0f)
+    } finally {
+      runtime.clear(editor)
+      scope.cancel()
+    }
+  }
+
+  @Test
+  fun selectionHandleForwardsModifiedWheelScrollToViewportZoom() = runComposeUiTest {
+    val selection =
+      Selection(
+        anchor = Position("text", 0, Affinity.Downstream),
+        head = Position("text", 5, Affinity.Downstream),
+      )
+    val endpoints =
+      SelectionEndpoints(
+        from = PageRect(pageIdx = 0, rect = Rect(x = 10f, y = 20f, width = 4f, height = 8f)),
+        to = PageRect(pageIdx = 0, rect = Rect(x = 40f, y = 20f, width = 4f, height = 8f)),
+        fromPosition = Position("text", 0, Affinity.Downstream),
+        toPosition = Position("text", 5, Affinity.Downstream),
+      )
+    val pageSizes = listOf(Size(width = 120f, height = 120f))
+    val layoutSpec =
+      EditorDocumentLayoutSpec.Paginated(
+        pageWidth = 120f,
+        pageHeight = 120f,
+        pageMarginTop = 0f,
+        pageMarginBottom = 0f,
+        pageMarginLeft = 0f,
+        pageMarginRight = 0f,
+      )
+    val fake =
+      FakeFfiEditor(
+        selectionProvider = { selection },
+        selectionEndpointsProvider = { endpoints },
+        pageSizesProvider = { pageSizes },
+      )
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val editor = Editor(fake, scope)
+    val uiState =
+      EditorUiState().apply {
+        updateFocus(true)
+        updateDisplayZoom(1f)
+        updatePageOffset(page = 0, offset = Offset.Zero)
+        updateExtensionAreaBounds(TestRootRect, density = 1f)
+        updateEditorBounds(
+          ComposeRect(Offset.Zero, ComposeSize(width = 120f, height = 120f)),
+          density = 1f,
+        )
+      }
+    val runtime = EditorRuntime(scope).apply { attach(editor) }
+    val viewportState = EditorViewportState()
+    val zoomController =
+      EditorZoomController().apply { syncLayout(layoutSpec = layoutSpec, viewportWidth = 120f) }
+    val viewportZoomConfig =
+      EditorViewportZoomSemanticConfig(
+        layoutSpec = layoutSpec,
+        zoomController = zoomController,
+        viewportState = viewportState,
+        uiState = uiState,
+        pageSizes = pageSizes,
+        viewportWidth = 120f,
+        density = 1f,
+        onZoomSnap = {},
+      )
+    editor.sync {}
+    try {
+      setOverlayHostContent(
+        editor = editor,
+        runtime = runtime,
+        uiState = uiState,
+        scope = scope,
+        viewportState = viewportState,
+        viewportContentSize = ComposeSize(width = 120f, height = 400f),
+        layoutSpec = layoutSpec,
+        pageSizes = pageSizes,
+        viewportZoomConfig = viewportZoomConfig,
+      )
+      waitForIdle()
+
+      val previousZoom = zoomController.displayZoom
+      val scene = (this as SkikoComposeUiTest).scene
+      runOnUiThread {
+        scene.sendPointerEvent(
+          eventType = PointerEventType.Scroll,
+          position = Offset(x = 42f, y = 30f),
+          scrollDelta = Offset(x = 0f, y = -12f),
+          keyboardModifiers = PointerKeyboardModifiers(isCtrlPressed = true),
+        )
+      }
+      waitForIdle()
+
+      assertTrue(zoomController.displayZoom > previousZoom)
+    } finally {
+      runtime.clear(editor)
+      scope.cancel()
+    }
+  }
+
+  @Test
+  fun focusedOverlayRouterDoesNotBlockLowerPointerSurfaceOutsideHandleTargets() = runComposeUiTest {
+    val selection =
+      Selection(
+        anchor = Position("text", 0, Affinity.Downstream),
+        head = Position("text", 5, Affinity.Downstream),
+      )
+    val endpoints =
+      SelectionEndpoints(
+        from = PageRect(pageIdx = 0, rect = Rect(x = 10f, y = 20f, width = 4f, height = 8f)),
+        to = PageRect(pageIdx = 0, rect = Rect(x = 40f, y = 20f, width = 4f, height = 8f)),
+        fromPosition = Position("text", 0, Affinity.Downstream),
+        toPosition = Position("text", 5, Affinity.Downstream),
+      )
+    val fake =
+      FakeFfiEditor(
+        selectionProvider = { selection },
+        selectionEndpointsProvider = { endpoints },
+        pageSizesProvider = { listOf(Size(width = 120f, height = 120f)) },
+      )
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val editor = Editor(fake, scope)
+    val uiState =
+      EditorUiState().apply {
+        updateFocus(true)
+        updatePageOffset(page = 0, offset = Offset.Zero)
+        updateExtensionAreaBounds(TestRootRect, density = 1f)
+        updateEditorBounds(TestRootRect, density = 1f)
+      }
+    val runtime = EditorRuntime(scope).apply { attach(editor) }
+    var lowerPointerDownCount = 0
+    editor.sync {}
+    try {
+      setOverlayHostContent(
+        editor = editor,
+        runtime = runtime,
+        uiState = uiState,
+        scope = scope,
+        onLowerPointerDown = { lowerPointerDownCount += 1 },
+      )
+      waitForIdle()
+
+      onNodeWithTag(RootTag).performTouchInput {
+        down(Offset(x = 90f, y = 10f))
+        up()
+      }
+      waitForIdle()
+
+      assertEquals(1, lowerPointerDownCount)
+    } finally {
+      runtime.clear(editor)
+      scope.cancel()
+    }
+  }
+
+  @Test
+  fun selectionHandleDragHandsOffToTableCellHandleAfterCellSelectionAppears() =
+    runComposeUiTest test@{
+      val endpoints =
+        SelectionEndpoints(
+          from = PageRect(pageIdx = 0, rect = Rect(x = 10f, y = 20f, width = 4f, height = 8f)),
+          to = PageRect(pageIdx = 0, rect = Rect(x = 40f, y = 20f, width = 4f, height = 8f)),
+          fromPosition = Position("cell-text", 0, Affinity.Downstream),
+          toPosition = Position("cell-text", 2, Affinity.Downstream),
+        )
+      val selection = Selection(anchor = endpoints.fromPosition, head = endpoints.toPosition)
+      var tableOverlay = tableOverlay(isFocused = true)
+      val fake =
+        FakeFfiEditor(
+          onTick = { listOf(EditorEvent.StateChanged(listOf(StateField.TableOverlays))) },
+          selectionProvider = { selection },
+          selectionEndpointsProvider = { endpoints },
+          pageSizesProvider = { listOf(Size(width = 120f, height = 120f)) },
+          tableOverlaysProvider = { listOf(tableOverlay) },
+        )
+      val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+      val editor = Editor(fake, scope)
+      val uiState =
+        EditorUiState().apply {
+          updateFocus(true)
+          updatePageOffset(page = 0, offset = Offset.Zero)
+          updateExtensionAreaBounds(TestRootRect, density = 1f)
+          updateEditorBounds(TestRootRect, density = 1f)
+        }
+      val runtime = EditorRuntime(scope).apply { attach(editor) }
+      editor.sync {}
+      try {
+        setOverlayHostContent(editor = editor, runtime = runtime, uiState = uiState, scope = scope)
+        waitForIdle()
+
+        val root = onNodeWithTag(RootTag)
+        root.performTouchInput {
+          down(Offset(x = 42f, y = 30f))
+          moveTo(Offset(x = 52f, y = 50f))
+        }
+        waitForIdle()
+
+        tableOverlay =
+          tableOverlay(
+            isFocused = true,
+            cellSelection =
+              TableOverlayCellSelection(
+                backgroundColor = null,
+                anchorRow = 0,
+                anchorCol = 0,
+                headRow = 0,
+                headCol = 1,
+              ),
+          )
+        editor.sync {}
+        fake.enqueued.clear()
+        waitForIdle()
+
+        root.performTouchInput {
+          moveTo(Offset(x = 64f, y = 60f))
+          up()
+        }
+        waitForIdle()
+
+        val extend =
+          fake.enqueued.filterIsInstance<Message.Selection>().single().op as SelectionOp.ExtendTo
+        assertEquals(selection.anchor, extend.anchor)
+        assertEquals(selection, extend.baseSelection)
+        assertEquals(62f, extend.headX)
+        assertEquals(54f, extend.headY)
+        assertFalse(extend.allowCollapse)
+      } finally {
+        runtime.clear(editor)
+        scope.cancel()
+      }
+    }
+
+  @Test
+  fun tableColumnResizeHandleTapDispatchesNormalEditorTap() = runComposeUiTest {
+    val selection =
+      Selection(
+        anchor = Position("cell-text", 0, Affinity.Downstream),
+        head = Position("cell-text", 0, Affinity.Downstream),
+      )
+    val fake =
+      FakeFfiEditor(
+        selectionProvider = { selection },
+        pageSizesProvider = { listOf(Size(width = 120f, height = 120f)) },
+        tableOverlaysProvider = {
+          listOf(tableOverlay(isFocused = true, focusedRowIndex = 0, focusedColIndex = 0))
+        },
+      )
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val editor = Editor(fake, scope)
+    val uiState =
+      EditorUiState().apply {
+        updateFocus(true)
+        updatePageOffset(page = 0, offset = Offset.Zero)
+        updateExtensionAreaBounds(TestRootRect, density = 1f)
+        updateEditorBounds(TestRootRect, density = 1f)
+      }
+    val runtime = EditorRuntime(scope).apply { attach(editor) }
+    editor.sync {}
+    try {
+      setOverlayHostContent(editor = editor, runtime = runtime, uiState = uiState, scope = scope)
+      waitForIdle()
+
+      onNodeWithTag(RootTag).performTouchInput {
+        down(Offset(x = 60f, y = 30f))
+        up()
+      }
+      waitUntil { fake.enqueued.filterIsInstance<Message.Selection>().isNotEmpty() }
+
+      assertEquals(
+        listOf(Message.Selection(SelectionOp.SetAt(page = 0, x = 60f, y = 30f))),
+        fake.enqueued.filterIsInstance<Message.Selection>(),
+      )
+    } finally {
+      runtime.clear(editor)
+      scope.cancel()
+    }
+  }
+
+  @Test
+  fun tableColumnResizeHandleHoldDoesNotDispatchTapBeforePointerUp() = runComposeUiTest {
+    val selection =
+      Selection(
+        anchor = Position("cell-text", 0, Affinity.Downstream),
+        head = Position("cell-text", 0, Affinity.Downstream),
+      )
+    val fake =
+      FakeFfiEditor(
+        selectionProvider = { selection },
+        pageSizesProvider = { listOf(Size(width = 120f, height = 120f)) },
+        tableOverlaysProvider = {
+          listOf(tableOverlay(isFocused = true, focusedRowIndex = 0, focusedColIndex = 0))
+        },
+      )
+    val dispatcher = StandardTestDispatcher()
+    val scope = CoroutineScope(SupervisorJob() + dispatcher)
+    val editor = Editor(fake, scope)
+    val uiState =
+      EditorUiState().apply {
+        updateFocus(true)
+        updatePageOffset(page = 0, offset = Offset.Zero)
+        updateExtensionAreaBounds(TestRootRect, density = 1f)
+        updateEditorBounds(TestRootRect, density = 1f)
+      }
+    val runtime = EditorRuntime(scope).apply { attach(editor) }
+    editor.sync {}
+    try {
+      setOverlayHostContent(editor = editor, runtime = runtime, uiState = uiState, scope = scope)
+      waitForIdle()
+
+      onNodeWithTag(RootTag).performTouchInput {
+        down(Offset(x = 60f, y = 30f))
+        dispatcher.scheduler.advanceTimeBy(400L)
+        dispatcher.scheduler.runCurrent()
+        assertEquals(emptyList(), fake.enqueued.filterIsInstance<Message.Selection>())
+        up()
+      }
+      dispatcher.scheduler.advanceUntilIdle()
+      waitUntil { fake.enqueued.filterIsInstance<Message.Selection>().isNotEmpty() }
+
+      assertEquals(
+        listOf(Message.Selection(SelectionOp.SetAt(page = 0, x = 60f, y = 30f))),
+        fake.enqueued.filterIsInstance<Message.Selection>(),
+      )
+    } finally {
+      runtime.clear(editor)
+      scope.cancel()
+    }
+  }
+
+  @Test
+  fun tableColumnResizeHandleDownClearsTapHistoryBeforeDoubleTapDispatch() = runComposeUiTest {
+    val selection =
+      Selection(
+        anchor = Position("cell-text", 0, Affinity.Downstream),
+        head = Position("cell-text", 0, Affinity.Downstream),
+      )
+    val fake =
+      FakeFfiEditor(
+        selectionProvider = { selection },
+        pageSizesProvider = { listOf(Size(width = 120f, height = 120f)) },
+        tableOverlaysProvider = {
+          listOf(tableOverlay(isFocused = true, focusedRowIndex = 0, focusedColIndex = 0))
+        },
+      )
+    val dispatcher = StandardTestDispatcher()
+    val scope = CoroutineScope(SupervisorJob() + dispatcher)
+    val editor = Editor(fake, scope)
+    val uiState =
+      EditorUiState().apply {
+        updateFocus(true)
+        updatePageOffset(page = 0, offset = Offset.Zero)
+        updateExtensionAreaBounds(TestRootRect, density = 1f)
+        updateEditorBounds(TestRootRect, density = 1f)
+      }
+    val runtime = EditorRuntime(scope).apply { attach(editor) }
+    editor.sync {}
+    try {
+      setOverlayHostContent(editor = editor, runtime = runtime, uiState = uiState, scope = scope)
+      waitForIdle()
+
+      val root = onNodeWithTag(RootTag)
+      root.performTouchInput {
+        down(Offset(x = 60f, y = 30f))
+        up()
+      }
+      dispatcher.scheduler.advanceUntilIdle()
+      waitUntil { fake.enqueued.filterIsInstance<Message.Selection>().isNotEmpty() }
+      fake.enqueued.clear()
+
+      root.performTouchInput { down(Offset(x = 60f, y = 30f)) }
+      dispatcher.scheduler.runCurrent()
+
+      assertEquals(emptyList(), fake.enqueued.filterIsInstance<Message.Selection>())
+
+      root.performTouchInput { up() }
+      dispatcher.scheduler.advanceUntilIdle()
+      waitUntil { fake.enqueued.filterIsInstance<Message.Selection>().isNotEmpty() }
+
+      assertEquals(
+        listOf(Message.Selection(SelectionOp.SetAt(page = 0, x = 60f, y = 30f))),
+        fake.enqueued.filterIsInstance<Message.Selection>(),
+      )
+    } finally {
+      runtime.clear(editor)
+      scope.cancel()
+    }
+  }
+
+  @Test
+  fun tableColumnResizeHandleDragResizesColumn() = runComposeUiTest {
+    val selection =
+      Selection(
+        anchor = Position("cell-text", 0, Affinity.Downstream),
+        head = Position("cell-text", 0, Affinity.Downstream),
+      )
+    val fake =
+      FakeFfiEditor(
+        selectionProvider = { selection },
+        pageSizesProvider = { listOf(Size(width = 120f, height = 120f)) },
+        tableOverlaysProvider = {
+          listOf(tableOverlay(isFocused = true, focusedRowIndex = 0, focusedColIndex = 0))
+        },
+      )
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val editor = Editor(fake, scope)
+    val uiState =
+      EditorUiState().apply {
+        updateFocus(true)
+        updatePageOffset(page = 0, offset = Offset.Zero)
+        updateExtensionAreaBounds(TestRootRect, density = 1f)
+        updateEditorBounds(TestRootRect, density = 1f)
+      }
+    val runtime = EditorRuntime(scope).apply { attach(editor) }
+    editor.sync {}
+    try {
+      setOverlayHostContent(editor = editor, runtime = runtime, uiState = uiState, scope = scope)
+      waitForIdle()
+
+      onNodeWithTag(RootTag).performTouchInput {
+        down(Offset(x = 60f, y = 30f))
+        moveTo(Offset(x = 80f, y = 30f))
+        up()
+      }
+      waitUntil { fake.enqueued.filterIsInstance<Message.Node>().isNotEmpty() }
+
+      assertEquals(
+        listOf(
+          Message.Node(
+            NodeOp.Table(id = "table", op = TableOp.SetColumnWidths(widths = listOf(0.6f, 0.4f)))
+          )
+        ),
+        fake.enqueued.filterIsInstance<Message.Node>(),
+      )
+    } finally {
+      runtime.clear(editor)
+      scope.cancel()
+    }
+  }
+
+  @Test
+  fun tableColumnResizeHandleDragStartsWithinHandleHitArea() = runComposeUiTest {
+    val selection =
+      Selection(
+        anchor = Position("cell-text", 0, Affinity.Downstream),
+        head = Position("cell-text", 0, Affinity.Downstream),
+      )
+    val fake =
+      FakeFfiEditor(
+        selectionProvider = { selection },
+        pageSizesProvider = { listOf(Size(width = 120f, height = 120f)) },
+        tableOverlaysProvider = {
+          listOf(tableOverlay(isFocused = true, focusedRowIndex = 0, focusedColIndex = 0))
+        },
+      )
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val editor = Editor(fake, scope)
+    val uiState =
+      EditorUiState().apply {
+        updateFocus(true)
+        updatePageOffset(page = 0, offset = Offset.Zero)
+        updateExtensionAreaBounds(TestRootRect, density = 1f)
+        updateEditorBounds(TestRootRect, density = 1f)
+      }
+    val runtime = EditorRuntime(scope).apply { attach(editor) }
+    editor.sync {}
+    try {
+      setOverlayHostContent(editor = editor, runtime = runtime, uiState = uiState, scope = scope)
+      waitForIdle()
+
+      onNodeWithTag(RootTag).performTouchInput {
+        down(Offset(x = 60f, y = 30f))
+        moveTo(Offset(x = 70f, y = 30f))
+        up()
+      }
+      waitUntil { fake.enqueued.filterIsInstance<Message.Node>().isNotEmpty() }
+
+      assertEquals(
+        listOf(
+          Message.Node(
+            NodeOp.Table(id = "table", op = TableOp.SetColumnWidths(widths = listOf(0.55f, 0.45f)))
+          )
+        ),
+        fake.enqueued.filterIsInstance<Message.Node>(),
+      )
+    } finally {
+      runtime.clear(editor)
+      scope.cancel()
+    }
+  }
+
+  @Test
+  fun tableColumnResizeHandleDragIncludesPreSlopMovement() = runComposeUiTest {
+    val selection =
+      Selection(
+        anchor = Position("cell-text", 0, Affinity.Downstream),
+        head = Position("cell-text", 0, Affinity.Downstream),
+      )
+    val fake =
+      FakeFfiEditor(
+        selectionProvider = { selection },
+        pageSizesProvider = { listOf(Size(width = 120f, height = 120f)) },
+        tableOverlaysProvider = {
+          listOf(tableOverlay(isFocused = true, focusedRowIndex = 0, focusedColIndex = 0))
+        },
+      )
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val editor = Editor(fake, scope)
+    val uiState =
+      EditorUiState().apply {
+        updateFocus(true)
+        updatePageOffset(page = 0, offset = Offset.Zero)
+        updateExtensionAreaBounds(TestRootRect, density = 1f)
+        updateEditorBounds(TestRootRect, density = 1f)
+      }
+    val runtime = EditorRuntime(scope).apply { attach(editor) }
+    editor.sync {}
+    try {
+      setOverlayHostContent(editor = editor, runtime = runtime, uiState = uiState, scope = scope)
+      waitForIdle()
+
+      onNodeWithTag(RootTag).performTouchInput {
+        down(Offset(x = 60f, y = 30f))
+        moveTo(Offset(x = 61f, y = 30f))
+        moveTo(Offset(x = 80f, y = 30f))
+        up()
+      }
+      waitUntil { fake.enqueued.filterIsInstance<Message.Node>().isNotEmpty() }
+
+      assertEquals(
+        listOf(
+          Message.Node(
+            NodeOp.Table(id = "table", op = TableOp.SetColumnWidths(widths = listOf(0.6f, 0.4f)))
+          )
+        ),
+        fake.enqueued.filterIsInstance<Message.Node>(),
+      )
+    } finally {
+      runtime.clear(editor)
+      scope.cancel()
+    }
+  }
+
+  @Test
+  fun tableCellHandleRoutesDragBeforeLowerPointerOverlay() = runComposeUiTest {
+    val selection =
+      Selection(
+        anchor = Position("cell-text", 0, Affinity.Downstream),
+        head = Position("cell-text", 0, Affinity.Downstream),
+      )
+    val fake =
+      FakeFfiEditor(
+        selectionProvider = { selection },
+        pageSizesProvider = { listOf(Size(width = 120f, height = 120f)) },
+        tableOverlaysProvider = {
+          listOf(tableOverlay(isFocused = true, focusedRowIndex = 0, focusedColIndex = 0))
+        },
+      )
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val editor = Editor(fake, scope)
+    val uiState =
+      EditorUiState().apply {
+        updateFocus(true)
+        updatePageOffset(page = 0, offset = Offset.Zero)
+        updateExtensionAreaBounds(TestRootRect, density = 1f)
+        updateEditorBounds(TestRootRect, density = 1f)
+      }
+    val runtime = EditorRuntime(scope).apply { attach(editor) }
+    editor.sync {}
+    try {
+      setOverlayHostContent(editor = editor, runtime = runtime, uiState = uiState, scope = scope)
+      waitForIdle()
+
+      onNodeWithTag(RootTag).performTouchInput {
+        down(Offset(x = 60f, y = 60f))
+        moveTo(Offset(x = 100f, y = 90f))
+        up()
+      }
+      waitForIdle()
+
+      val extend =
+        fake.enqueued.filterIsInstance<Message.Selection>().single().op as SelectionOp.ExtendTo
+      assertEquals(selection.anchor, extend.anchor)
+      assertEquals(100f, extend.headX)
+      assertEquals(90f, extend.headY)
+      assertEquals(selection, extend.baseSelection)
+      assertFalse(extend.allowCollapse)
+    } finally {
+      runtime.clear(editor)
+      scope.cancel()
+    }
+  }
+
+  private fun androidx.compose.ui.test.ComposeUiTest.setOverlayHostContent(
+    editor: Editor,
+    runtime: EditorRuntime,
+    uiState: EditorUiState,
+    scope: CoroutineScope,
+    viewportState: EditorViewportState = EditorViewportState(),
+    viewportContentSize: ComposeSize = TestRootSize,
+    layoutSpec: EditorDocumentLayoutSpec = EditorDocumentLayoutSpec.Continuous(maxWidth = 120f),
+    pageSizes: List<Size> = listOf(Size(width = 120f, height = 120f)),
+    displayZoom: Float = 1f,
+    viewportZoomConfig: EditorViewportZoomSemanticConfig? = null,
+    onLowerPointerDown: () -> Unit = {},
+  ) {
+    setContent {
+      val interactionScope = remember {
+        EditorInteractionScope(coroutineScope = scope, platformProvider = { Platform.Desktop })
+      }
+      val rememberedViewportState = remember { viewportState }
+      val visibleArea = remember { EditorVisibleArea(viewport = TestRootSize) }
+      val bringIntoViewRequests = remember { EditorBringIntoViewRequests() }
+      val scrollGestureLockState = remember { ScrollGestureLockState() }
+
+      SideEffect {
+        rememberedViewportState.updateMeasuredBounds(
+          viewportSize = TestRootSize,
+          contentSize = viewportContentSize,
+        )
+      }
+      SideEffect {
+        interactionScope.update(
+          editor = editor,
+          bringIntoViewRequests = bringIntoViewRequests,
+          uiState = uiState,
+          visibleArea = visibleArea,
+          viewportState = rememberedViewportState,
+          density = 1f,
+          scrollGestureLockState = scrollGestureLockState,
+          viewportZoomConfig = viewportZoomConfig,
+          onSelectionHaptic = {},
+        )
+        interactionScope.onEditorStateChanged(editor.state)
+      }
+
+      CompositionLocalProvider(
+        LocalAppColors provides LightColors,
+        LocalAppShadows provides LightAppShadows,
+        LocalThemeMode provides ResolvedThemeMode.Light,
+        LocalEditorRuntime provides runtime,
+        LocalEditorUiState provides uiState,
+        LocalEditorBringIntoViewRequests provides bringIntoViewRequests,
+        LocalEditorInteractionScope provides interactionScope,
+      ) {
+        Box(Modifier.testTag(RootTag).size(120.dp)) {
+          LowerPointerOverlay(onPointerDown = onLowerPointerDown)
+          EditorScreenOverlayHost(
+            viewportState = rememberedViewportState,
+            visibleArea = visibleArea,
+            autoScrollPolicy = resolveEditorAutoScrollPolicy(visibleArea = visibleArea),
+            layoutSpec = layoutSpec,
+            pageSizes = pageSizes,
+            displayZoom = displayZoom,
+            onTableAxisActionsRequest = { _, _ -> },
+            modifier = Modifier.fillMaxSize(),
+          )
+        }
+      }
+    }
+  }
+
+  @Composable
+  private fun LowerPointerOverlay(onPointerDown: () -> Unit) {
+    Box(
+      Modifier.fillMaxSize().pointerInput(Unit) {
+        awaitEachGesture {
+          awaitFirstDown(requireUnconsumed = false)
+          onPointerDown()
+          while (true) {
+            val event = awaitPointerEvent()
+            val change = event.changes.first()
+            if (change.changedToUp()) {
+              change.consume()
+              break
+            }
+            change.consume()
+          }
+        }
+      }
+    )
+  }
+
+  private companion object {
+    const val RootTag = "editor-overlay-pointer-router-root"
+    val TestRootSize = ComposeSize(width = 120f, height = 120f)
+    val TestRootRect = ComposeRect(Offset.Zero, TestRootSize)
+
+    fun tableOverlay(
+      isFocused: Boolean = false,
+      focusedRowIndex: Int? = null,
+      focusedColIndex: Int? = null,
+      cellSelection: TableOverlayCellSelection? = null,
+    ): TableOverlay =
+      TableOverlay(
+        tableId = "table",
+        pageIdx = 0,
+        bounds = Rect(x = 10f, y = 20f, width = 100f, height = 80f),
+        borderStyle = TableBorderStyle.Solid,
+        align = Alignment.Left,
+        proportion = 1f,
+        contentWidth = 100f,
+        minProportionWidth = 83f,
+        maxProportionWidth = 100f,
+        rows =
+          listOf(
+            TableOverlayRow(index = 0, height = 40f, position = 40f, backgroundColor = null),
+            TableOverlayRow(index = 1, height = 40f, position = 80f, backgroundColor = null),
+          ),
+        columns =
+          listOf(
+            TableOverlayColumn(index = 0, widthAsPx = 50f, position = 50f, backgroundColor = null),
+            TableOverlayColumn(index = 1, widthAsPx = 50f, position = 100f, backgroundColor = null),
+          ),
+        rowCount = 2,
+        isLastRowFragment = true,
+        isFocused = isFocused,
+        focusedRowIndex = focusedRowIndex,
+        focusedColIndex = focusedColIndex,
+        cellSelection = cellSelection,
+      )
+  }
+}


### PR DESCRIPTION
- 제스처 핸드오프 퇴행을 방지하면서 에디터 overlay handle들이 스크롤바보다 먼저 포인터 제스처를 받도록 함
- full size overlay가 아니라 handle touch target rect 크기의 hit layer만 만듦
- 그 영역에서 포인터 제스처를 에디터 컨트롤러에 전달
- active pointer 중에는 해당 타겟을 유지
- 자잘한 인터랙션 개선