### PR TITLE
앱 secondary 툴바/바텀 패널 리팩토링 및 디버그

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarDefaults.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarDefaults.kt
@@ -115,22 +115,44 @@ internal sealed interface BlockquoteVariantPanelTarget {
     BlockquoteVariantPanelTarget
 }
 
+internal data class EditorToolbarScope(
+  val pageKey: EditorToolbarPageKey,
+  val ownerNodeId: String? = null,
+) {
+  companion object {
+    val Main = EditorToolbarScope(EditorToolbarPageKey.Main)
+  }
+}
+
 internal class EditorToolbarPage(
   val key: EditorToolbarPageKey,
   val icon: IconData,
   val contentDescription: String,
+  val ownerNodeId: String? = null,
   val scrollState: ScrollState? = null,
   val content: @Composable (EditorToolbarPageScope) -> Unit,
-)
+) {
+  val toolbarScope: EditorToolbarScope = EditorToolbarScope(key, ownerNodeId)
+}
 
 internal class EditorToolbarPageScope(
+  val toolbarScope: EditorToolbarScope,
   val activeBottomPanel: EditorToolbarBottomPanel?,
   val activeSecondaryToolbar: EditorToolbarSecondary?,
   val commandScope: CoroutineScope,
   val hasNextPage: Boolean,
   val navigateToPage: (EditorToolbarPageKey) -> Unit,
-  val toggleSecondaryToolbar: (EditorToolbarSecondary) -> Unit,
-  val toggleBottomPanel: (EditorToolbarBottomPanel) -> Unit,
+  private val onSecondaryToolbarToggle: (EditorToolbarSecondary, EditorToolbarScope) -> Unit,
+  val clearSecondaryToolbar: () -> Unit,
+  private val onBottomPanelToggle: (EditorToolbarBottomPanel, EditorToolbarScope) -> Unit,
   val sendMessage: (Message) -> Unit,
   val performToolAction: (EditorToolbarToolAction) -> Unit,
-)
+) {
+  fun toggleSecondaryToolbar(secondary: EditorToolbarSecondary) {
+    onSecondaryToolbarToggle(secondary, toolbarScope)
+  }
+
+  fun toggleBottomPanel(panel: EditorToolbarBottomPanel) {
+    onBottomPanelToggle(panel, toolbarScope)
+  }
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarHost.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarHost.kt
@@ -42,7 +42,6 @@ import co.typie.editor.scroll.awaitWithBringIntoView
 import co.typie.graphql.fragment.EditorSettingsFontFamily_family
 import co.typie.screen.editor.editor.state.EditorInputEffect
 import co.typie.screen.editor.editor.toolbar.contextual.ImageResizeSecondaryToolbar
-import co.typie.screen.editor.editor.toolbar.contextual.TextOptionMode
 import co.typie.screen.editor.editor.toolbar.contextual.TextOptionsToolbar
 import co.typie.screen.editor.editor.toolbar.contextual.rememberTextToolbarPage
 import co.typie.ui.component.ResponsiveContainerDefaults
@@ -84,8 +83,6 @@ internal fun EditorToolbarHost(
     }
   }
 
-  val onTextOptionModeChange: (TextOptionMode?) -> Unit =
-    remember(sessionState) { { mode -> sessionState.activeTextOptionMode = mode } }
   val latestRunToolbarModal = rememberUpdatedState<(suspend () -> Unit) -> Unit>(::runToolbarModal)
   val runToolbarModalAction: (suspend () -> Unit) -> Unit = remember {
     { block -> latestRunToolbarModal.value(block) }
@@ -101,7 +98,6 @@ internal fun EditorToolbarHost(
       selection = editorState.selection,
       fontFamilies = fontFamilies,
       activeTextOptionMode = activeTextOptionMode,
-      onTextOptionModeChange = onTextOptionModeChange,
       runToolbarModal = runToolbarModalAction,
       commentEnabled = commentEnabled,
       onCommentRequest = onCommentRequest,
@@ -144,7 +140,7 @@ internal fun EditorToolbarHost(
     )
   val currentPageKey =
     pagerState.settledPageKey.takeIf { toolbarPresented && it in toolbarContext.pageKeys }
-  val selectedNodeId = toolbarContext.selectedNodeId
+  val currentToolbarScope = pages.firstOrNull { page -> page.key == currentPageKey }?.toolbarScope
   val secondaryToolbarVisible = toolbarPresented && activeSecondaryToolbar != null
   val fixedAction =
     fixedActionFor(
@@ -159,15 +155,20 @@ internal fun EditorToolbarHost(
       !restoringKeyboard
     }
 
+  fun syncToolbarScopedSurfaces(currentScope: EditorToolbarScope?) {
+    sessionState.clearSecondaryToolbarIfInvalid(currentScope)
+    val currentPanel = inputState.panel
+    if (currentPanel?.scope != null && currentPanel.scope != currentScope) {
+      onInputEffects(inputState.dispatch(ToolbarIntent.RestoreEditorInput, latestEnvironment.value))
+    }
+  }
+
   LaunchedEffect(environment) { onInputEffects(inputState.onEnvironmentChanged(environment)) }
-  LaunchedEffect(toolbarPresented, currentPageKey, selectedNodeId) {
+  LaunchedEffect(toolbarPresented, currentToolbarScope, panel?.scope) {
     if (!toolbarPresented) {
-      sessionState.activeSecondaryToolbar = null
+      sessionState.clearSecondaryToolbar()
     } else {
-      sessionState.clearSecondaryToolbarIfInvalid(
-        currentPageKey = currentPageKey,
-        selectedNodeId = selectedNodeId,
-      )
+      syncToolbarScopedSurfaces(currentToolbarScope)
     }
   }
   LaunchedEffect(activeSecondaryToolbar) {
@@ -250,8 +251,13 @@ internal fun EditorToolbarHost(
     onInputEffects(inputState.dispatch(ToolbarIntent.RestoreEditorInput, environment))
   }
 
-  fun toggleBottomPanel(panel: EditorToolbarBottomPanel) {
-    onInputEffects(inputState.dispatch(ToolbarIntent.OpenPanel(panel), environment))
+  fun toggleBottomPanel(panel: EditorToolbarBottomPanel, scope: EditorToolbarScope) {
+    onInputEffects(inputState.dispatch(ToolbarIntent.OpenPanel(panel, scope), environment))
+  }
+
+  fun requestBottomPanelFromPanel(panel: EditorToolbarBottomPanel) {
+    val scope = inputState.panel?.scope ?: currentToolbarScope ?: EditorToolbarScope.Main
+    toggleBottomPanel(panel, scope)
   }
 
   AnimatedVisibility(
@@ -284,22 +290,21 @@ internal fun EditorToolbarHost(
           fixedAction = fixedAction,
           onEditorInputRequest = ::restoreEditorInput,
           onKeyboardDismissRequest = {
-            sessionState.activeSecondaryToolbar = null
+            sessionState.clearSecondaryToolbar()
             onInputEffects(inputState.dispatch(ToolbarIntent.DismissInput, environment))
           },
           onBottomPanelToggle = ::toggleBottomPanel,
           onEditorMessage = { message -> sendEditorMessages(listOf(message)) },
           onToolAction = onToolAction,
           onCurrentPageKeyChange = { pageKey ->
-            sessionState.clearSecondaryToolbarIfInvalid(
-              currentPageKey = pageKey,
-              selectedNodeId = selectedNodeId,
-            )
+            val pageScope = pages.firstOrNull { page -> page.key == pageKey }?.toolbarScope
+            syncToolbarScopedSurfaces(pageScope)
           },
           activeSecondaryToolbar = activeSecondaryToolbar,
-          onSecondaryToolbarToggle = { secondary ->
-            sessionState.toggleSecondaryToolbar(secondary)
+          onSecondaryToolbarToggle = { secondary, scope ->
+            sessionState.toggleSecondaryToolbar(secondary, scope)
           },
+          onSecondaryToolbarClear = { sessionState.clearSecondaryToolbar() },
           secondaryToolbarVisible = secondaryToolbarVisible,
           onSecondaryToolbarInLayoutChange = { sessionState.secondaryToolbarInLayout = it },
           secondaryToolbar = {
@@ -309,7 +314,16 @@ internal fun EditorToolbarHost(
                   mode = secondary.mode,
                   editorState = editorState,
                   fontFamilies = fontFamilies,
-                  onModeChange = onTextOptionModeChange,
+                  onModeChange = { mode ->
+                    if (mode == null) {
+                      sessionState.clearSecondaryToolbar()
+                    } else {
+                      sessionState.toggleSecondaryToolbar(
+                        EditorToolbarSecondary.TextOption(mode),
+                        EditorToolbarScope(EditorToolbarPageKey.Text),
+                      )
+                    }
+                  },
                   sendMessages = ::sendEditorMessages,
                   runToolbarModal = runToolbarModalAction,
                   modifier = Modifier.fillMaxWidth(),
@@ -317,7 +331,7 @@ internal fun EditorToolbarHost(
               is EditorToolbarSecondary.ImageResize ->
                 ImageResizeSecondaryToolbar(
                   nodeId = secondary.nodeId,
-                  onClose = { sessionState.activeSecondaryToolbar = null },
+                  onClose = { sessionState.clearSecondaryToolbar() },
                   modifier = Modifier.fillMaxWidth(),
                 )
               null -> Unit
@@ -353,7 +367,7 @@ internal fun EditorToolbarHost(
                   panel = visiblePanel,
                   height = bottomPanelHeight,
                   onEditorInputRequest = ::restoreEditorInput,
-                  onBottomPanelRequest = ::toggleBottomPanel,
+                  onBottomPanelRequest = ::requestBottomPanelFromPanel,
                   onEditorMessage = { message -> sendEditorMessages(listOf(message)) },
                   onToolAction = onToolAction,
                 )

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarInputState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarInputState.kt
@@ -28,7 +28,10 @@ internal data class ToolbarInputEnvironment(
 }
 
 internal sealed interface ToolbarIntent {
-  data class OpenPanel(val panel: EditorToolbarBottomPanel) : ToolbarIntent
+  data class OpenPanel(
+    val panel: EditorToolbarBottomPanel,
+    val scope: EditorToolbarScope = EditorToolbarScope.Main,
+  ) : ToolbarIntent
 
   data object RestoreEditorInput : ToolbarIntent
 
@@ -91,6 +94,7 @@ internal sealed interface PanelKeyboardSpace {
 
 internal data class PanelSession(
   val panel: EditorToolbarBottomPanel,
+  val scope: EditorToolbarScope,
   val height: Dp,
   val keyboardSpace: PanelKeyboardSpace?,
 )
@@ -241,7 +245,7 @@ internal class EditorToolbarInputState {
     environment: ToolbarInputEnvironment,
   ): List<EditorInputEffect> =
     when (intent) {
-      is ToolbarIntent.OpenPanel -> openPanel(intent.panel, environment)
+      is ToolbarIntent.OpenPanel -> openPanel(intent.panel, intent.scope, environment)
       ToolbarIntent.RestoreEditorInput -> restoreEditorInput(environment)
       ToolbarIntent.DismissInput -> dismissInput(environment)
       ToolbarIntent.HideInput -> hideInput()
@@ -250,14 +254,15 @@ internal class EditorToolbarInputState {
 
   private fun openPanel(
     nextPanel: EditorToolbarBottomPanel,
+    nextScope: EditorToolbarScope,
     environment: ToolbarInputEnvironment,
   ): List<EditorInputEffect> {
     val currentPanel = panel
     if (currentPanel != null) {
-      if (currentPanel.panel == nextPanel) {
+      if (currentPanel.panel == nextPanel && currentPanel.scope == nextScope) {
         return restoreEditorInput(environment)
       } else {
-        panel = currentPanel.copy(panel = nextPanel)
+        panel = currentPanel.copy(panel = nextPanel, scope = nextScope)
         lastPanelSnapshot = PanelSnapshot(nextPanel, currentPanel.height)
       }
       return emptyList()
@@ -292,7 +297,13 @@ internal class EditorToolbarInputState {
       } else {
         0.dp
       }
-    panel = PanelSession(panel = nextPanel, height = panelHeight, keyboardSpace = keyboardSpace)
+    panel =
+      PanelSession(
+        panel = nextPanel,
+        scope = nextScope,
+        height = panelHeight,
+        keyboardSpace = keyboardSpace,
+      )
     lastPanelSnapshot = PanelSnapshot(nextPanel, panelHeight)
 
     return if (imeVisible || currentRestoreInset != null) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarPages.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarPages.kt
@@ -97,7 +97,7 @@ internal fun rememberEditorToolbarPages(
             embed = toolbarContext.selectedNode as? PlainNode.Embed,
             nodeId = toolbarContext.selectedNodeId,
           )
-        EditorToolbarPageKey.Archived -> editorArchivedToolbarPage()
+        EditorToolbarPageKey.Archived -> editorArchivedToolbarPage(toolbarContext.selectedNodeId)
         EditorToolbarPageKey.HorizontalRule ->
           editorHorizontalRuleToolbarPage(toolbarContext.horizontalRuleTarget)
         EditorToolbarPageKey.List -> editorListToolbarPage(toolbarContext.listMode)
@@ -123,12 +123,13 @@ internal fun EditorToolbarPages(
   fixedAction: ToolbarFixedAction,
   onEditorInputRequest: () -> Unit,
   onKeyboardDismissRequest: () -> Unit,
-  onBottomPanelToggle: (EditorToolbarBottomPanel) -> Unit,
+  onBottomPanelToggle: (EditorToolbarBottomPanel, EditorToolbarScope) -> Unit,
   onEditorMessage: (Message) -> Unit = {},
   onToolAction: (EditorToolbarToolAction) -> Unit = {},
   onCurrentPageKeyChange: (EditorToolbarPageKey?) -> Unit = {},
   activeSecondaryToolbar: EditorToolbarSecondary? = null,
-  onSecondaryToolbarToggle: (EditorToolbarSecondary) -> Unit = {},
+  onSecondaryToolbarToggle: (EditorToolbarSecondary, EditorToolbarScope) -> Unit = { _, _ -> },
+  onSecondaryToolbarClear: () -> Unit = {},
   secondaryToolbarVisible: Boolean = false,
   onSecondaryToolbarInLayoutChange: (Boolean) -> Unit = {},
   secondaryToolbar: @Composable () -> Unit = {},
@@ -633,13 +634,15 @@ internal fun EditorToolbarPages(
             pages.forEachIndexed { index, page ->
               val pageScope =
                 EditorToolbarPageScope(
+                  toolbarScope = page.toolbarScope,
                   activeBottomPanel = activeBottomPanel,
                   activeSecondaryToolbar = activeSecondaryToolbar,
                   commandScope = commandScope,
                   hasNextPage = index < lastPageIndex,
                   navigateToPage = ::navigateToPage,
-                  toggleSecondaryToolbar = onSecondaryToolbarToggle,
-                  toggleBottomPanel = onBottomPanelToggle,
+                  onSecondaryToolbarToggle = onSecondaryToolbarToggle,
+                  clearSecondaryToolbar = onSecondaryToolbarClear,
+                  onBottomPanelToggle = onBottomPanelToggle,
                   sendMessage = onEditorMessage,
                   performToolAction = onToolAction,
                 )

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarSessionState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarSessionState.kt
@@ -13,49 +13,46 @@ internal fun rememberEditorToolbarSessionState(key: Any? = Unit): EditorToolbarS
   remember(key) { EditorToolbarSessionState() }
 
 internal sealed interface EditorToolbarSecondary {
-  val pageKey: EditorToolbarPageKey
-  val ownerNodeId: String?
-    get() = null
+  data class TextOption(val mode: TextOptionMode) : EditorToolbarSecondary
 
-  data class TextOption(val mode: TextOptionMode) : EditorToolbarSecondary {
-    override val pageKey = EditorToolbarPageKey.Text
-  }
-
-  data class ImageResize(val nodeId: String) : EditorToolbarSecondary {
-    override val pageKey = EditorToolbarPageKey.Image
-    override val ownerNodeId = nodeId
-  }
+  data class ImageResize(val nodeId: String) : EditorToolbarSecondary
 }
+
+internal data class SecondaryToolbarSession(
+  val toolbar: EditorToolbarSecondary,
+  val scope: EditorToolbarScope,
+)
 
 @Stable
 internal class EditorToolbarSessionState {
-  var activeSecondaryToolbar by mutableStateOf<EditorToolbarSecondary?>(null)
+  private var secondarySession by mutableStateOf<SecondaryToolbarSession?>(null)
 
-  var activeTextOptionMode: TextOptionMode?
+  val activeSecondaryToolbar: EditorToolbarSecondary?
+    get() = secondarySession?.toolbar
+
+  val activeTextOptionMode: TextOptionMode?
     get() = (activeSecondaryToolbar as? EditorToolbarSecondary.TextOption)?.mode
-    set(value) {
-      activeSecondaryToolbar = value?.let(EditorToolbarSecondary::TextOption)
-    }
 
   var modalActive by mutableStateOf(false)
   var secondaryToolbarInLayout by mutableStateOf(false)
 
-  fun toggleSecondaryToolbar(secondary: EditorToolbarSecondary) {
-    activeSecondaryToolbar =
-      if (activeSecondaryToolbar == secondary) {
+  fun toggleSecondaryToolbar(secondary: EditorToolbarSecondary, scope: EditorToolbarScope) {
+    val nextSession = SecondaryToolbarSession(toolbar = secondary, scope = scope)
+    secondarySession =
+      if (secondarySession == nextSession) {
         null
       } else {
-        secondary
+        nextSession
       }
   }
 
-  fun clearSecondaryToolbarIfInvalid(
-    currentPageKey: EditorToolbarPageKey?,
-    selectedNodeId: String?,
-  ) {
-    activeSecondaryToolbar = activeSecondaryToolbar?.takeIf { secondary ->
-      currentPageKey == secondary.pageKey &&
-        (secondary.ownerNodeId == null || secondary.ownerNodeId == selectedNodeId)
+  fun clearSecondaryToolbar() {
+    secondarySession = null
+  }
+
+  fun clearSecondaryToolbarIfInvalid(currentScope: EditorToolbarScope?) {
+    if (secondarySession?.scope != currentScope) {
+      secondarySession = null
     }
   }
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/bottom/Variants.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/bottom/Variants.kt
@@ -77,7 +77,7 @@ internal fun BottomToolbarHorizontalRuleVariants(
         selected = variant == target.currentVariant,
         preview = { HorizontalRuleVariantPreview(variant = variant) },
         onClick = {
-          onEditorMessage(target.message(variant))
+          target.messageOrNull(variant)?.let(onEditorMessage)
           onEditorInputRequest()
         },
       )
@@ -99,7 +99,7 @@ internal fun BottomToolbarBlockquoteVariants(
         selected = variant == target.currentVariant,
         preview = { BlockquoteVariantPreview(variant = variant) },
         onClick = {
-          onEditorMessage(target.message(variant))
+          target.messageOrNull(variant)?.let(onEditorMessage)
           onEditorInputRequest()
         },
       )
@@ -452,6 +452,10 @@ private fun DrawScope.drawDiamondStroke(
   drawPath(path = path, color = color, style = Stroke(width = stroke))
 }
 
+internal fun HorizontalRuleVariantPanelTarget.messageOrNull(
+  variant: HorizontalRuleVariant
+): Message? = if (variant == currentVariant) null else message(variant)
+
 private fun HorizontalRuleVariantPanelTarget.message(variant: HorizontalRuleVariant): Message =
   when (this) {
     HorizontalRuleVariantPanelTarget.Insertion ->
@@ -461,6 +465,9 @@ private fun HorizontalRuleVariantPanelTarget.message(variant: HorizontalRuleVari
         NodeOp.SetAttrs(id = nodeId, attrs = PlainNode.HorizontalRule(variant = variant))
       )
   }
+
+internal fun BlockquoteVariantPanelTarget.messageOrNull(variant: BlockquoteVariant): Message? =
+  if (variant == currentVariant) null else message(variant)
 
 private fun BlockquoteVariantPanelTarget.message(variant: BlockquoteVariant): Message =
   when (this) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/ArchivedToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/ArchivedToolbar.kt
@@ -6,11 +6,12 @@ import co.typie.screen.editor.editor.toolbar.EditorToolbarPage
 import co.typie.screen.editor.editor.toolbar.EditorToolbarPageKey
 import co.typie.screen.editor.editor.toolbar.EditorToolbarRow
 
-internal fun editorArchivedToolbarPage(): EditorToolbarPage =
+internal fun editorArchivedToolbarPage(nodeId: String?): EditorToolbarPage =
   EditorToolbarPage(
     key = EditorToolbarPageKey.Archived,
     icon = Lucide.Eye,
     contentDescription = "보관된 블록 툴바",
+    ownerNodeId = nodeId,
     content = { scope ->
       EditorToolbarRow(scope = scope) {
         EditorToolbarButton(icon = Lucide.Eye, contentDescription = "보관된 블록 보기", onClick = {})

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/BlockquoteToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/BlockquoteToolbar.kt
@@ -19,6 +19,7 @@ internal fun editorBlockquoteToolbarPage(
     key = EditorToolbarPageKey.Blockquote,
     icon = Lucide.Quote,
     contentDescription = "인용구 툴바",
+    ownerNodeId = target?.id,
     content = { scope ->
       EditorToolbarRow(scope = scope) {
         EditorToolbarButton(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/CalloutToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/CalloutToolbar.kt
@@ -18,6 +18,7 @@ internal fun editorCalloutToolbarPage(
     key = EditorToolbarPageKey.Callout,
     icon = Lucide.GalleryVerticalEnd,
     contentDescription = "강조 툴바",
+    ownerNodeId = target?.id,
     content = { scope ->
       EditorToolbarRow(scope = scope) {
         EditorToolbarButton(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/EmbedToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/EmbedToolbar.kt
@@ -58,6 +58,7 @@ internal fun editorEmbedToolbarPage(embed: PlainNode.Embed?, nodeId: String?): E
     key = EditorToolbarPageKey.Embed,
     icon = Lucide.FileUp,
     contentDescription = "임베드 툴바",
+    ownerNodeId = nodeId,
     content = { scope -> EditorEmbedToolbar(scope = scope, embed = embed, nodeId = nodeId) },
   )
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/FileToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/FileToolbar.kt
@@ -41,6 +41,7 @@ internal fun editorFileToolbarPage(file: PlainNode.File?, nodeId: String?): Edit
     key = EditorToolbarPageKey.File,
     icon = Lucide.Paperclip,
     contentDescription = "파일 툴바",
+    ownerNodeId = nodeId,
     content = { scope -> EditorFileToolbar(scope = scope, file = file, nodeId = nodeId) },
   )
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/FoldToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/FoldToolbar.kt
@@ -13,6 +13,7 @@ internal fun editorFoldToolbarPage(targetId: String?): EditorToolbarPage =
     key = EditorToolbarPageKey.Fold,
     icon = Lucide.ChevronsDownUp,
     contentDescription = "접기 툴바",
+    ownerNodeId = targetId,
     content = { scope ->
       EditorToolbarRow(scope = scope) {
         EditorToolbarButton(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/HorizontalRuleToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/HorizontalRuleToolbar.kt
@@ -20,6 +20,7 @@ internal fun editorHorizontalRuleToolbarPage(
     key = EditorToolbarPageKey.HorizontalRule,
     icon = Typie.HorizontalRule,
     contentDescription = "구분선 툴바",
+    ownerNodeId = target?.id,
     content = { scope ->
       EditorToolbarRow(scope = scope) {
         EditorToolbarButton(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/ImageResizeSecondaryToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/ImageResizeSecondaryToolbar.kt
@@ -1,13 +1,9 @@
 package co.typie.screen.editor.editor.toolbar.contextual
 
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -20,7 +16,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.style.TextAlign
@@ -35,27 +30,12 @@ import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.NodeOp
 import co.typie.editor.ffi.PlainNode
 import co.typie.editor.runtime.LocalEditorRuntime
-import co.typie.ext.InteractionScope
-import co.typie.icons.Lucide
-import co.typie.screen.editor.editor.toolbar.EditorToolbarIconButton
-import co.typie.screen.editor.editor.toolbar.EditorToolbarSurfaceBackground
-import co.typie.screen.editor.editor.toolbar.ToolbarBackdropBlurRadius
-import co.typie.screen.editor.editor.toolbar.ToolbarBorderWidth
-import co.typie.screen.editor.editor.toolbar.ToolbarCapsuleShape
-import co.typie.screen.editor.editor.toolbar.ToolbarFixedActionPadding
-import co.typie.screen.editor.editor.toolbar.ToolbarFixedActionShape
 import co.typie.screen.editor.editor.toolbar.ToolbarFixedActionWidth
 import co.typie.screen.editor.editor.toolbar.ToolbarLabelTextStyle
 import co.typie.screen.editor.editor.toolbar.ToolbarPageVerticalPadding
-import co.typie.screen.editor.editor.toolbar.ToolbarSecondaryHeight
-import co.typie.screen.editor.editor.toolbar.preserveEditorFocusOnToolbarInteraction
 import co.typie.ui.component.Slider
 import co.typie.ui.component.Text
 import co.typie.ui.theme.AppTheme
-import co.typie.ui.theme.LocalHazeState
-import co.typie.ui.theme.shadow
-import dev.chrisbanes.haze.blur.blurEffect
-import dev.chrisbanes.haze.hazeEffect
 import kotlin.math.roundToInt
 
 private const val IMAGE_RESIZE_HAPTIC_STEP = 5
@@ -176,26 +156,11 @@ private fun ImageResizeSecondaryToolbarSurface(
   modifier: Modifier = Modifier,
   content: @Composable RowScope.() -> Unit,
 ) {
-  val hazeState = LocalHazeState.current
-  val toolbarSurfaceColor = AppTheme.colors.surfaceDefault
-
-  Box(
-    modifier =
-      modifier
-        .fillMaxWidth()
-        .height(ToolbarSecondaryHeight)
-        .shadow(AppTheme.shadows.sm, ToolbarCapsuleShape)
-        .clip(ToolbarCapsuleShape)
-        .hazeEffect(hazeState) {
-          blurEffect {
-            backgroundColor = toolbarSurfaceColor
-            blurRadius = ToolbarBackdropBlurRadius
-          }
-        }
-        .border(ToolbarBorderWidth, AppTheme.colors.borderEmphasis, ToolbarCapsuleShape)
-        .preserveEditorFocusOnToolbarInteraction()
+  ToolbarSecondarySurface(
+    onClose = onClose,
+    closeContentDescription = "이미지 폭 조정 닫기",
+    modifier = modifier,
   ) {
-    EditorToolbarSurfaceBackground(shape = ToolbarCapsuleShape)
     Row(
       modifier =
         Modifier.fillMaxSize()
@@ -210,25 +175,5 @@ private fun ImageResizeSecondaryToolbarSurface(
     ) {
       content()
     }
-    Box(modifier = Modifier.align(Alignment.CenterStart)) {
-      ImageResizeCloseButton(onClick = onClose)
-    }
-  }
-}
-
-@Composable
-private fun ImageResizeCloseButton(onClick: () -> Unit) {
-  InteractionScope {
-    EditorToolbarIconButton(
-      icon = Lucide.X,
-      contentDescription = "이미지 폭 조정 닫기",
-      onClick = onClick,
-      shape = ToolbarFixedActionShape,
-      fixedActionSurface = true,
-      inheritInteractionSource = true,
-      modifier =
-        Modifier.width(ToolbarFixedActionWidth).fillMaxHeight().padding(ToolbarFixedActionPadding),
-      iconSize = 20.dp,
-    )
   }
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/ImageToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/ImageToolbar.kt
@@ -41,6 +41,7 @@ internal fun editorImageToolbarPage(image: PlainNode.Image?, nodeId: String?): E
     key = EditorToolbarPageKey.Image,
     icon = Lucide.Image,
     contentDescription = "이미지 툴바",
+    ownerNodeId = nodeId,
     content = { scope -> EditorImageToolbar(scope = scope, image = image, nodeId = nodeId) },
   )
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/TextOptionsToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/TextOptionsToolbar.kt
@@ -9,7 +9,6 @@ import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -18,13 +17,10 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.relocation.BringIntoViewRequester
 import androidx.compose.foundation.relocation.bringIntoViewRequester
@@ -65,31 +61,19 @@ import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.Modifier as EditorModifier
 import co.typie.editor.ffi.ModifierOp
 import co.typie.editor.ffi.ModifierState
-import co.typie.ext.InteractionScope
-import co.typie.ext.LocalInteractionSource
-import co.typie.ext.pressScale
 import co.typie.graphql.fragment.EditorSettingsFontFamily_family
 import co.typie.graphql.type.FontState
 import co.typie.icons.Lucide
 import co.typie.screen.editor.editor.toolbar.EditorToolbarLabelButton
-import co.typie.screen.editor.editor.toolbar.EditorToolbarSurfaceBackground
-import co.typie.screen.editor.editor.toolbar.ToolbarBackdropBlurRadius
-import co.typie.screen.editor.editor.toolbar.ToolbarBorderWidth
 import co.typie.screen.editor.editor.toolbar.ToolbarButtonShape
 import co.typie.screen.editor.editor.toolbar.ToolbarButtonSize
-import co.typie.screen.editor.editor.toolbar.ToolbarCapsuleShape
-import co.typie.screen.editor.editor.toolbar.ToolbarFixedActionPadding
-import co.typie.screen.editor.editor.toolbar.ToolbarFixedActionPressedScale
-import co.typie.screen.editor.editor.toolbar.ToolbarFixedActionShape
 import co.typie.screen.editor.editor.toolbar.ToolbarFixedActionWidth
 import co.typie.screen.editor.editor.toolbar.ToolbarItemGap
 import co.typie.screen.editor.editor.toolbar.ToolbarLabelHorizontalPadding
 import co.typie.screen.editor.editor.toolbar.ToolbarLabelTextStyle
 import co.typie.screen.editor.editor.toolbar.ToolbarPageEndPadding
 import co.typie.screen.editor.editor.toolbar.ToolbarPageVerticalPadding
-import co.typie.screen.editor.editor.toolbar.ToolbarSecondaryHeight
 import co.typie.screen.editor.editor.toolbar.ToolbarTextOptionsSwitchMillis
-import co.typie.screen.editor.editor.toolbar.preserveEditorFocusOnToolbarInteraction
 import co.typie.ui.component.FontSpecimen
 import co.typie.ui.component.LabelPosition
 import co.typie.ui.component.Text
@@ -101,13 +85,8 @@ import co.typie.ui.component.dialog.DialogScope
 import co.typie.ui.component.dialog.LocalDialog
 import co.typie.ui.component.dialog.dismiss
 import co.typie.ui.component.dialog.resolve
-import co.typie.ui.icon.Icon
 import co.typie.ui.theme.AppShapes
 import co.typie.ui.theme.AppTheme
-import co.typie.ui.theme.LocalHazeState
-import co.typie.ui.theme.shadow
-import dev.chrisbanes.haze.blur.blurEffect
-import dev.chrisbanes.haze.hazeEffect
 import kotlin.math.roundToInt
 
 @Composable
@@ -181,12 +160,9 @@ private fun TextOptionsContent(
         onSelect = { sendSet(sendMessages, EditorModifier.TextColor(it)) },
       )
     TextOptionMode.BackgroundColor ->
-      ColorOptions(
-        options = EditorValues.textBackgroundColor,
+      TextBackgroundColorOptions(
         currentValue = modifierState?.backgroundColor.uniformValue { it.value },
         editorTheme = editorTheme,
-        swatchShape = TextBackgroundSwatchShape,
-        showSlashForNullTheme = true,
         onSelect = { sendSet(sendMessages, EditorModifier.BackgroundColor(it)) },
       )
     TextOptionMode.FontFamily ->
@@ -236,27 +212,13 @@ private fun TextOptionsToolbarSurface(
   content: @Composable () -> Unit,
 ) {
   val scrollState = rememberScrollState()
-  val hazeState = LocalHazeState.current
-  val toolbarSurfaceColor = AppTheme.colors.surfaceDefault
   val scrollStartPadding = ToolbarFixedActionWidth
 
-  Box(
-    modifier =
-      modifier
-        .fillMaxWidth()
-        .height(ToolbarSecondaryHeight)
-        .shadow(AppTheme.shadows.sm, ToolbarCapsuleShape)
-        .clip(ToolbarCapsuleShape)
-        .hazeEffect(hazeState) {
-          blurEffect {
-            backgroundColor = toolbarSurfaceColor
-            blurRadius = ToolbarBackdropBlurRadius
-          }
-        }
-        .border(ToolbarBorderWidth, AppTheme.colors.borderEmphasis, ToolbarCapsuleShape)
-        .preserveEditorFocusOnToolbarInteraction()
+  ToolbarSecondarySurface(
+    onClose = onClose,
+    closeContentDescription = "텍스트 옵션 닫기",
+    modifier = modifier,
   ) {
-    EditorToolbarSurfaceBackground(shape = ToolbarCapsuleShape)
     Row(
       modifier =
         Modifier.fillMaxSize()
@@ -272,43 +234,23 @@ private fun TextOptionsToolbarSurface(
     ) {
       content()
     }
-    Box(modifier = Modifier.align(Alignment.CenterStart)) {
-      TextOptionsCloseButton(onClick = onClose)
-    }
   }
 }
 
 @Composable
-private fun TextOptionsCloseButton(onClick: () -> Unit) {
-  InteractionScope {
-    val interactionSource =
-      LocalInteractionSource.current ?: remember { MutableInteractionSource() }
-
-    Box(
-      modifier =
-        Modifier.width(ToolbarFixedActionWidth)
-          .fillMaxHeight()
-          .padding(ToolbarFixedActionPadding)
-          .pressScale(ToolbarFixedActionPressedScale)
-          .focusProperties { canFocus = false }
-          .semantics {
-            contentDescription = "텍스트 옵션 닫기"
-            role = Role.Button
-          }
-          .clip(ToolbarFixedActionShape)
-          .background(AppTheme.colors.surfaceDefault.copy(alpha = 0.72f), ToolbarFixedActionShape)
-          .border(ToolbarBorderWidth, AppTheme.colors.borderDefault, ToolbarFixedActionShape)
-          .clickable(interactionSource = interactionSource, indication = null, onClick = onClick),
-      contentAlignment = Alignment.Center,
-    ) {
-      Icon(
-        icon = Lucide.X,
-        contentDescription = null,
-        modifier = Modifier.size(20.dp),
-        tint = AppTheme.colors.textDefault,
-      )
-    }
-  }
+internal fun TextBackgroundColorOptions(
+  currentValue: String?,
+  editorTheme: ResolvedEditorTheme,
+  onSelect: (String) -> Unit,
+) {
+  ColorOptions(
+    options = EditorValues.textBackgroundColor,
+    currentValue = currentValue,
+    editorTheme = editorTheme,
+    swatchShape = TextBackgroundSwatchShape,
+    showSlashForNullTheme = true,
+    onSelect = onSelect,
+  )
 }
 
 @Composable

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/TextToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/TextToolbar.kt
@@ -44,6 +44,7 @@ import co.typie.screen.editor.editor.toolbar.EditorToolbarPage
 import co.typie.screen.editor.editor.toolbar.EditorToolbarPageKey
 import co.typie.screen.editor.editor.toolbar.EditorToolbarPageScope
 import co.typie.screen.editor.editor.toolbar.EditorToolbarRow
+import co.typie.screen.editor.editor.toolbar.EditorToolbarSecondary
 import co.typie.ui.component.LabelPosition
 import co.typie.ui.component.Text
 import co.typie.ui.component.TextField
@@ -64,7 +65,6 @@ internal fun rememberTextToolbarPage(
   selection: Selection?,
   fontFamilies: List<EditorSettingsFontFamily_family>,
   activeTextOptionMode: TextOptionMode?,
-  onTextOptionModeChange: (TextOptionMode?) -> Unit,
   runToolbarModal: (suspend () -> Unit) -> Unit,
   commentEnabled: Boolean,
   onCommentRequest: () -> Unit,
@@ -76,7 +76,6 @@ internal fun rememberTextToolbarPage(
     selection,
     fontFamilies,
     activeTextOptionMode,
-    onTextOptionModeChange,
     runToolbarModal,
     commentEnabled,
     onCommentRequest,
@@ -94,7 +93,6 @@ internal fun rememberTextToolbarPage(
           selection = selection,
           fontFamilies = fontFamilies,
           activeTextOptionMode = activeTextOptionMode,
-          onTextOptionModeChange = onTextOptionModeChange,
           runToolbarModal = runToolbarModal,
           commentEnabled = commentEnabled,
           onCommentRequest = onCommentRequest,
@@ -112,7 +110,6 @@ private fun EditorTextToolbar(
   selection: Selection?,
   fontFamilies: List<EditorSettingsFontFamily_family>,
   activeTextOptionMode: TextOptionMode?,
-  onTextOptionModeChange: (TextOptionMode?) -> Unit,
   runToolbarModal: (suspend () -> Unit) -> Unit,
   commentEnabled: Boolean,
   onCommentRequest: () -> Unit,
@@ -138,12 +135,16 @@ private fun EditorTextToolbar(
   val rubyEnabled = ruby !is Tri.Mixed && (!selectionCollapsed || rubyActive)
 
   fun toggleMode(mode: TextOptionMode) {
-    onTextOptionModeChange(if (activeTextOptionMode == mode) null else mode)
+    if (activeTextOptionMode == mode) {
+      scope.clearSecondaryToolbar()
+    } else {
+      scope.toggleSecondaryToolbar(EditorToolbarSecondary.TextOption(mode))
+    }
   }
 
   fun openLinkInput() {
     if (!linkEnabled) return
-    onTextOptionModeChange(null)
+    scope.clearSecondaryToolbar()
     runToolbarModal {
       withFrameNanos {}
       val message = dialog.promptLinkMessage(linkHref)
@@ -155,7 +156,7 @@ private fun EditorTextToolbar(
 
   fun openRubyInput() {
     if (!rubyEnabled) return
-    onTextOptionModeChange(null)
+    scope.clearSecondaryToolbar()
     runToolbarModal {
       withFrameNanos {}
       val message = dialog.promptRubyMessage(rubyText)

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/ToolbarSecondarySurface.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/ToolbarSecondarySurface.kt
@@ -1,0 +1,83 @@
+package co.typie.screen.editor.editor.toolbar.contextual
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import co.typie.ext.InteractionScope
+import co.typie.icons.Lucide
+import co.typie.screen.editor.editor.toolbar.EditorToolbarIconButton
+import co.typie.screen.editor.editor.toolbar.EditorToolbarSurfaceBackground
+import co.typie.screen.editor.editor.toolbar.ToolbarBackdropBlurRadius
+import co.typie.screen.editor.editor.toolbar.ToolbarBorderWidth
+import co.typie.screen.editor.editor.toolbar.ToolbarCapsuleShape
+import co.typie.screen.editor.editor.toolbar.ToolbarFixedActionPadding
+import co.typie.screen.editor.editor.toolbar.ToolbarFixedActionShape
+import co.typie.screen.editor.editor.toolbar.ToolbarFixedActionWidth
+import co.typie.screen.editor.editor.toolbar.ToolbarSecondaryHeight
+import co.typie.screen.editor.editor.toolbar.preserveEditorFocusOnToolbarInteraction
+import co.typie.ui.theme.AppTheme
+import co.typie.ui.theme.LocalHazeState
+import co.typie.ui.theme.shadow
+import dev.chrisbanes.haze.blur.blurEffect
+import dev.chrisbanes.haze.hazeEffect
+
+@Composable
+internal fun ToolbarSecondarySurface(
+  onClose: () -> Unit,
+  closeContentDescription: String,
+  modifier: Modifier = Modifier,
+  content: @Composable BoxScope.() -> Unit,
+) {
+  val hazeState = LocalHazeState.current
+  val toolbarSurfaceColor = AppTheme.colors.surfaceDefault
+
+  Box(
+    modifier =
+      modifier
+        .fillMaxWidth()
+        .height(ToolbarSecondaryHeight)
+        .shadow(AppTheme.shadows.sm, ToolbarCapsuleShape)
+        .clip(ToolbarCapsuleShape)
+        .hazeEffect(hazeState) {
+          blurEffect {
+            backgroundColor = toolbarSurfaceColor
+            blurRadius = ToolbarBackdropBlurRadius
+          }
+        }
+        .border(ToolbarBorderWidth, AppTheme.colors.borderEmphasis, ToolbarCapsuleShape)
+        .preserveEditorFocusOnToolbarInteraction()
+  ) {
+    EditorToolbarSurfaceBackground(shape = ToolbarCapsuleShape)
+    content()
+    Box(modifier = Modifier.align(Alignment.CenterStart)) {
+      ToolbarSecondaryCloseButton(contentDescription = closeContentDescription, onClick = onClose)
+    }
+  }
+}
+
+@Composable
+private fun ToolbarSecondaryCloseButton(contentDescription: String, onClick: () -> Unit) {
+  InteractionScope {
+    EditorToolbarIconButton(
+      icon = Lucide.X,
+      contentDescription = contentDescription,
+      onClick = onClick,
+      shape = ToolbarFixedActionShape,
+      fixedActionSurface = true,
+      inheritInteractionSource = true,
+      modifier =
+        Modifier.width(ToolbarFixedActionWidth).fillMaxHeight().padding(ToolbarFixedActionPadding),
+      iconSize = 20.dp,
+    )
+  }
+}

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarInputStateTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarInputStateTest.kt
@@ -49,6 +49,7 @@ class ToolbarInputStateTest {
     assertEquals(
       PanelSession(
         panel = EditorToolbarBottomPanel.Insert,
+        scope = EditorToolbarScope.Main,
         height = 288.dp,
         keyboardSpace = PanelKeyboardSpace.FollowIme(inset = 320.dp),
       ),
@@ -105,6 +106,58 @@ class ToolbarInputStateTest {
     assertEquals(288.dp, state.panel?.height)
     assertEquals(320.dp, state.panel?.keyboardSpace?.inset)
     assertEquals(emptyList(), effects)
+  }
+
+  @Test
+  fun panel_session_keeps_opening_toolbar_scope() {
+    val state = EditorToolbarInputState()
+    val environment = toolbarInputEnvironment(imeBottom = 320.dp)
+    val blockquoteScope =
+      EditorToolbarScope(pageKey = EditorToolbarPageKey.Blockquote, ownerNodeId = "blockquote-1")
+
+    state.onEnvironmentChanged(environment)
+    state.dispatch(
+      ToolbarIntent.OpenPanel(
+        panel =
+          EditorToolbarBottomPanel.BlockquoteVariants(
+            BlockquoteVariantPanelTarget.Existing(
+              nodeId = "blockquote-1",
+              currentVariant = co.typie.editor.ffi.BlockquoteVariant.LeftLine,
+            )
+          ),
+        scope = blockquoteScope,
+      ),
+      environment,
+    )
+
+    assertEquals(blockquoteScope, state.panel?.scope)
+  }
+
+  @Test
+  fun switching_panel_replaces_session_scope() {
+    val state = EditorToolbarInputState()
+    val environment = toolbarInputEnvironment(imeBottom = 320.dp)
+    val blockquoteScope =
+      EditorToolbarScope(pageKey = EditorToolbarPageKey.Blockquote, ownerNodeId = "blockquote-1")
+
+    state.onEnvironmentChanged(environment)
+    state.dispatch(
+      ToolbarIntent.OpenPanel(
+        panel =
+          EditorToolbarBottomPanel.BlockquoteVariants(
+            BlockquoteVariantPanelTarget.Existing(
+              nodeId = "blockquote-1",
+              currentVariant = co.typie.editor.ffi.BlockquoteVariant.LeftLine,
+            )
+          ),
+        scope = blockquoteScope,
+      ),
+      environment,
+    )
+    state.dispatch(ToolbarIntent.OpenPanel(EditorToolbarBottomPanel.Tools), environment)
+
+    assertEquals(EditorToolbarBottomPanel.Tools, state.activeBottomPanel)
+    assertEquals(EditorToolbarScope.Main, state.panel?.scope)
   }
 
   @Test

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarSecondaryStateTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarSecondaryStateTest.kt
@@ -8,14 +8,15 @@ class ToolbarSecondaryStateTest {
   @Test
   fun image_resize_secondary_toggles_for_same_node() {
     val state = EditorToolbarSessionState()
+    val scope = EditorToolbarScope(EditorToolbarPageKey.Image, "image-1")
 
-    state.toggleSecondaryToolbar(EditorToolbarSecondary.ImageResize(nodeId = "image-1"))
+    state.toggleSecondaryToolbar(EditorToolbarSecondary.ImageResize(nodeId = "image-1"), scope)
     assertEquals(
       EditorToolbarSecondary.ImageResize(nodeId = "image-1"),
       state.activeSecondaryToolbar,
     )
 
-    state.toggleSecondaryToolbar(EditorToolbarSecondary.ImageResize(nodeId = "image-1"))
+    state.toggleSecondaryToolbar(EditorToolbarSecondary.ImageResize(nodeId = "image-1"), scope)
     assertEquals(null, state.activeSecondaryToolbar)
   }
 
@@ -23,8 +24,14 @@ class ToolbarSecondaryStateTest {
   fun text_and_image_secondary_states_are_mutually_exclusive() {
     val state = EditorToolbarSessionState()
 
-    state.activeTextOptionMode = TextOptionMode.FontSize
-    state.toggleSecondaryToolbar(EditorToolbarSecondary.ImageResize(nodeId = "image-1"))
+    state.toggleSecondaryToolbar(
+      EditorToolbarSecondary.TextOption(TextOptionMode.FontSize),
+      EditorToolbarScope(EditorToolbarPageKey.Text),
+    )
+    state.toggleSecondaryToolbar(
+      EditorToolbarSecondary.ImageResize(nodeId = "image-1"),
+      EditorToolbarScope(EditorToolbarPageKey.Image, "image-1"),
+    )
 
     assertEquals(
       EditorToolbarSecondary.ImageResize(nodeId = "image-1"),
@@ -37,18 +44,18 @@ class ToolbarSecondaryStateTest {
   fun image_resize_secondary_closes_when_page_or_node_no_longer_matches() {
     val state = EditorToolbarSessionState()
 
-    state.toggleSecondaryToolbar(EditorToolbarSecondary.ImageResize(nodeId = "image-1"))
-    state.clearSecondaryToolbarIfInvalid(
-      currentPageKey = EditorToolbarPageKey.Image,
-      selectedNodeId = "image-2",
+    state.toggleSecondaryToolbar(
+      EditorToolbarSecondary.ImageResize(nodeId = "image-1"),
+      EditorToolbarScope(EditorToolbarPageKey.Image, "image-1"),
     )
+    state.clearSecondaryToolbarIfInvalid(EditorToolbarScope(EditorToolbarPageKey.Image, "image-2"))
     assertEquals(null, state.activeSecondaryToolbar)
 
-    state.toggleSecondaryToolbar(EditorToolbarSecondary.ImageResize(nodeId = "image-1"))
-    state.clearSecondaryToolbarIfInvalid(
-      currentPageKey = EditorToolbarPageKey.Text,
-      selectedNodeId = "image-1",
+    state.toggleSecondaryToolbar(
+      EditorToolbarSecondary.ImageResize(nodeId = "image-1"),
+      EditorToolbarScope(EditorToolbarPageKey.Image, "image-1"),
     )
+    state.clearSecondaryToolbarIfInvalid(EditorToolbarScope(EditorToolbarPageKey.Text))
     assertEquals(null, state.activeSecondaryToolbar)
   }
 
@@ -56,21 +63,21 @@ class ToolbarSecondaryStateTest {
   fun secondary_toolbar_stays_open_when_page_and_owner_match() {
     val state = EditorToolbarSessionState()
 
-    state.toggleSecondaryToolbar(EditorToolbarSecondary.ImageResize(nodeId = "image-1"))
-    state.clearSecondaryToolbarIfInvalid(
-      currentPageKey = EditorToolbarPageKey.Image,
-      selectedNodeId = "image-1",
+    state.toggleSecondaryToolbar(
+      EditorToolbarSecondary.ImageResize(nodeId = "image-1"),
+      EditorToolbarScope(EditorToolbarPageKey.Image, "image-1"),
     )
+    state.clearSecondaryToolbarIfInvalid(EditorToolbarScope(EditorToolbarPageKey.Image, "image-1"))
     assertEquals(
       EditorToolbarSecondary.ImageResize(nodeId = "image-1"),
       state.activeSecondaryToolbar,
     )
 
-    state.activeTextOptionMode = TextOptionMode.FontSize
-    state.clearSecondaryToolbarIfInvalid(
-      currentPageKey = EditorToolbarPageKey.Text,
-      selectedNodeId = null,
+    state.toggleSecondaryToolbar(
+      EditorToolbarSecondary.TextOption(TextOptionMode.FontSize),
+      EditorToolbarScope(EditorToolbarPageKey.Text),
     )
+    state.clearSecondaryToolbarIfInvalid(EditorToolbarScope(EditorToolbarPageKey.Text))
     assertEquals(
       EditorToolbarSecondary.TextOption(TextOptionMode.FontSize),
       state.activeSecondaryToolbar,
@@ -81,11 +88,11 @@ class ToolbarSecondaryStateTest {
   fun text_secondary_closes_when_page_is_not_text() {
     val state = EditorToolbarSessionState()
 
-    state.activeTextOptionMode = TextOptionMode.FontSize
-    state.clearSecondaryToolbarIfInvalid(
-      currentPageKey = EditorToolbarPageKey.Image,
-      selectedNodeId = "image-1",
+    state.toggleSecondaryToolbar(
+      EditorToolbarSecondary.TextOption(TextOptionMode.FontSize),
+      EditorToolbarScope(EditorToolbarPageKey.Text),
     )
+    state.clearSecondaryToolbarIfInvalid(EditorToolbarScope(EditorToolbarPageKey.Image, "image-1"))
 
     assertEquals(null, state.activeSecondaryToolbar)
   }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/toolbar/bottom/VariantsTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/toolbar/bottom/VariantsTest.kt
@@ -1,0 +1,54 @@
+package co.typie.screen.editor.editor.toolbar.bottom
+
+import co.typie.editor.ffi.BlockquoteVariant
+import co.typie.editor.ffi.HorizontalRuleVariant
+import co.typie.editor.ffi.Message
+import co.typie.editor.ffi.NodeOp
+import co.typie.editor.ffi.PlainNode
+import co.typie.screen.editor.editor.toolbar.BlockquoteVariantPanelTarget
+import co.typie.screen.editor.editor.toolbar.HorizontalRuleVariantPanelTarget
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class VariantsTest {
+  @Test
+  fun current_horizontal_rule_variant_returns_no_message() {
+    val target =
+      HorizontalRuleVariantPanelTarget.Existing(
+        nodeId = "hr",
+        currentVariant = HorizontalRuleVariant.Line,
+      )
+
+    assertNull(target.messageOrNull(HorizontalRuleVariant.Line))
+    assertEquals(
+      Message.Node(
+        NodeOp.SetAttrs(
+          id = "hr",
+          attrs = PlainNode.HorizontalRule(variant = HorizontalRuleVariant.DashedLine),
+        )
+      ),
+      target.messageOrNull(HorizontalRuleVariant.DashedLine),
+    )
+  }
+
+  @Test
+  fun current_blockquote_variant_returns_no_message() {
+    val target =
+      BlockquoteVariantPanelTarget.Existing(
+        nodeId = "blockquote",
+        currentVariant = BlockquoteVariant.LeftLine,
+      )
+
+    assertNull(target.messageOrNull(BlockquoteVariant.LeftLine))
+    assertEquals(
+      Message.Node(
+        NodeOp.SetAttrs(
+          id = "blockquote",
+          attrs = PlainNode.Blockquote(variant = BlockquoteVariant.LeftQuote),
+        )
+      ),
+      target.messageOrNull(BlockquoteVariant.LeftQuote),
+    )
+  }
+}

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/toolbar/EditorToolbarPagesDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/toolbar/EditorToolbarPagesDesktopTest.kt
@@ -1468,7 +1468,7 @@ class EditorToolbarPagesDesktopTest {
             fixedAction = ToolbarFixedAction.DismissInput,
             onEditorInputRequest = {},
             onKeyboardDismissRequest = {},
-            onBottomPanelToggle = {},
+            onBottomPanelToggle = { _, _ -> },
             modifier = Modifier.fillMaxSize(),
           )
         }


### PR DESCRIPTION
- secondary toolbar / bottom panel을 소유하는 contextual toolbar가 사라지거나 툴바 페이지가 이동되면 닫힘
- ToolbarSecondarySurface를 만들어서 secondary toolbar들이 공유하게 함
- Variants 바텀 패널에서 현재 variant를 다시 누르면 엔진에 메시지를 새로 보내지 않고 닫음