### PR TITLE
layout scope 도입

### DIFF
--- a/crates/editor-core/src/handle/navigation.rs
+++ b/crates/editor-core/src/handle/navigation.rs
@@ -2989,6 +2989,75 @@ mod tests {
         );
     }
 
+    #[test]
+    fn arrow_down_from_short_cell_ignores_lower_line_in_same_row_neighbor() {
+        let (state, _tc1, p2) = state! {
+            doc {
+                root {
+                    table {
+                        table_row {
+                            table_cell { tc1: paragraph { text("d") } }
+                            table_cell { paragraph { text("e") hard_break text("f") } }
+                        }
+                    }
+                    p2: paragraph { text("below") }
+                }
+            }
+            selection: (tc1, 1)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.view.layout(&editor.state);
+        arrow(
+            &mut editor,
+            Movement::Line {
+                direction: Direction::Forward,
+                axis: Axis::Vertical,
+            },
+        );
+        let s = editor.state().selection.expect("selection exists in test");
+        assert!(s.is_collapsed());
+        assert_eq!(
+            s.head.node, p2,
+            "down from the short cell must exit the row, not enter a lower line in a neighboring cell"
+        );
+    }
+
+    #[test]
+    fn arrow_up_from_cell_exits_to_cell_above_same_column_not_lower_line_in_neighbor() {
+        let (state, top_left, _top_right, _bottom_left) = state! {
+            doc {
+                root {
+                    table {
+                        table_row {
+                            table_cell { top_left: paragraph { text("a") } }
+                            table_cell { top_right: paragraph { text("b") hard_break text("c") } }
+                        }
+                        table_row {
+                            table_cell { bottom_left: paragraph { text("d") } }
+                            table_cell { paragraph { text("e") } }
+                        }
+                    }
+                }
+            }
+            selection: (bottom_left, 0)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.view.layout(&editor.state);
+        arrow(
+            &mut editor,
+            Movement::Line {
+                direction: Direction::Backward,
+                axis: Axis::Vertical,
+            },
+        );
+        let s = editor.state().selection.expect("selection exists in test");
+        assert!(s.is_collapsed());
+        assert_eq!(
+            s.head.node, top_left,
+            "up from a cell must exit to the cell above in the same column, not a lower line in another column"
+        );
+    }
+
     // TR-199 회귀 방지: 가장자리 행 판정이 "마지막 직계 자식 서브트리"로 넓어지면서,
     // 자식이 단락 하나뿐이고 그 단락이 여러 줄로 접히는 monolithic(콜아웃 등)에서
     // 첫 줄에 있어도 가장자리로 오인될 수 있다. 첫 줄에서 down은 갭으로 나가지 말고

--- a/crates/editor-view/src/measure/container.rs
+++ b/crates/editor-view/src/measure/container.rs
@@ -172,6 +172,7 @@ pub(crate) fn layout_padded<'a>(
             },
             children,
             page_break_policy,
+            scope: false,
         }),
     }
 }

--- a/crates/editor-view/src/measure/nodes/blockquote.rs
+++ b/crates/editor-view/src/measure/nodes/blockquote.rs
@@ -145,6 +145,7 @@ pub(crate) fn measure_blockquote(
                     },
                     children,
                     page_break_policy: PageBreakPolicy::Auto,
+                    scope: false,
                 }),
             }
         }
@@ -497,6 +498,7 @@ mod tests {
                 },
                 children: MeasuredChildren::from_blocks(vec![line_node]),
                 page_break_policy: crate::measure::PageBreakPolicy::Auto,
+                scope: false,
             }),
         };
 

--- a/crates/editor-view/src/measure/nodes/fold.rs
+++ b/crates/editor-view/src/measure/nodes/fold.rs
@@ -73,6 +73,7 @@ pub(crate) fn measure_fold_title(
             },
             children: MeasuredChildren::from_blocks(children),
             page_break_policy: PageBreakPolicy::Avoid,
+            scope: false,
         }),
     };
 
@@ -166,6 +167,7 @@ pub(crate) fn measure_fold(
             },
             children: MeasuredChildren::from_blocks(children),
             page_break_policy: PageBreakPolicy::Auto,
+            scope: false,
         }),
     }
 }

--- a/crates/editor-view/src/measure/nodes/line_geometry.rs
+++ b/crates/editor-view/src/measure/nodes/line_geometry.rs
@@ -77,6 +77,7 @@ pub(crate) fn expand_first_line(
                                 style: b.style.clone(),
                                 children: new_children,
                                 page_break_policy: b.page_break_policy,
+                                scope: b.scope,
                             }),
                         },
                         top: running_y + expanded.top,
@@ -205,6 +206,7 @@ mod tests {
                 style,
                 children,
                 page_break_policy: PageBreakPolicy::Auto,
+                scope: false,
             }),
         }
     }
@@ -231,6 +233,7 @@ mod tests {
                 style: BoxStyle::default(),
                 children,
                 page_break_policy: PageBreakPolicy::Auto,
+                scope: false,
             }),
         };
         assert!(first_line_info(&only_spacing).is_none());

--- a/crates/editor-view/src/measure/nodes/paragraph.rs
+++ b/crates/editor-view/src/measure/nodes/paragraph.rs
@@ -99,6 +99,7 @@ pub(crate) fn measure_paragraph_block(
             },
             children: MeasuredChildren::from_blocks(children),
             page_break_policy: PageBreakPolicy::Auto,
+            scope: false,
         }),
     }
 }

--- a/crates/editor-view/src/measure/nodes/table.rs
+++ b/crates/editor-view/src/measure/nodes/table.rs
@@ -120,7 +120,7 @@ pub(crate) fn measure_table_cell(
     let mut seam = |child, w, ctx: &MeasureContext, r: &mut Resource| {
         measure_child(measurer, child, w, ctx, r)
     };
-    layout_padded(
+    let mut measured = layout_padded(
         node,
         width,
         ctx,
@@ -132,7 +132,12 @@ pub(crate) fn measure_table_cell(
             page_break_policy: PageBreakPolicy::Avoid,
         },
         &mut seam,
-    )
+    );
+    let MeasuredContent::Box(cell_box) = &mut measured.content else {
+        unreachable!()
+    };
+    cell_box.scope = true;
+    measured
 }
 
 pub(crate) fn measure_table(
@@ -165,6 +170,7 @@ pub(crate) fn measure_table(
                 },
                 children: MeasuredChildren::default(),
                 page_break_policy: PageBreakPolicy::Auto,
+                scope: false,
             }),
         };
     }
@@ -249,6 +255,7 @@ pub(crate) fn measure_table(
                 },
                 children: MeasuredChildren::from_blocks(row_children),
                 page_break_policy: PageBreakPolicy::Avoid,
+                scope: false,
             }),
         };
 
@@ -289,6 +296,7 @@ pub(crate) fn measure_table(
             },
             children: MeasuredChildren::from_blocks(row_measurements),
             page_break_policy: PageBreakPolicy::Auto,
+            scope: false,
         }),
     }
 }

--- a/crates/editor-view/src/measure/types.rs
+++ b/crates/editor-view/src/measure/types.rs
@@ -127,6 +127,7 @@ pub(crate) struct MeasuredBox {
     pub style: BoxStyle,
     pub children: MeasuredChildren,
     pub page_break_policy: PageBreakPolicy,
+    pub scope: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/editor-view/src/page_fragment.rs
+++ b/crates/editor-view/src/page_fragment.rs
@@ -297,6 +297,7 @@ mod tests {
                 style: empty_box_style(),
                 children,
                 attachment,
+                scope: false,
             }),
         }
     }
@@ -442,6 +443,7 @@ mod tests {
                 style,
                 children: vec![],
                 attachment: None,
+                scope: false,
             }),
         };
         let tree = LayoutTree { root };

--- a/crates/editor-view/src/paginate/paginator.rs
+++ b/crates/editor-view/src/paginate/paginator.rs
@@ -262,6 +262,7 @@ impl Paginator {
                 style: measured.style.clone(),
                 children,
                 attachment: None,
+                scope: measured.scope,
             }),
         }
     }
@@ -315,6 +316,7 @@ impl Paginator {
                 style: measured.style.clone(),
                 children,
                 attachment: None,
+                scope: measured.scope,
             }),
         }
     }
@@ -591,6 +593,7 @@ fn place_node_at(
                     style: b.style.clone(),
                     children,
                     attachment,
+                    scope: b.scope,
                 }),
             }
         }

--- a/crates/editor-view/src/paginate/types.rs
+++ b/crates/editor-view/src/paginate/types.rs
@@ -51,6 +51,7 @@ pub(crate) struct LayoutBox {
     pub style: BoxStyle,
     pub children: Vec<LayoutNode>,
     pub attachment: Option<ChildAttachment>,
+    pub scope: bool,
 }
 
 /// A positioned line. Shares the measured payload (glyph runs, ruby, tab
@@ -124,6 +125,7 @@ mod tests {
                         content: LayoutContent::Line(line),
                     }],
                     attachment: None,
+                    scope: false,
                 }),
             },
         };

--- a/crates/editor-view/src/query/dnd.rs
+++ b/crates/editor-view/src/query/dnd.rs
@@ -31,28 +31,55 @@ fn dnd_position(
     view: &DocView,
     point: LayoutPoint,
 ) -> Option<Position> {
-    let position = layout_index
-        .exact_entry_with(point, |entry, node| {
-            dnd_position_for_candidate(layout_index, view, entry, node, point)
-        })
-        .or_else(|| {
-            layout_index.closest_entry_with(point, |entry, node| {
-                dnd_position_for_candidate(layout_index, view, entry, node, point)
-            })
-        })
-        .map(|(_, position)| position)?;
+    let scope = layout_index.container_scope(point);
+    let position = if let Some(scope) = scope {
+        let in_scope_descendant = |entry: &LayoutEntry| {
+            layout_index.entry_is_in_scope(entry, scope) && !std::ptr::eq(entry, scope)
+        };
+        let in_scope = |entry: &LayoutEntry| layout_index.entry_is_in_scope(entry, scope);
+        exact_dnd_position(layout_index, view, point, &in_scope_descendant)
+            .or_else(|| exact_dnd_position(layout_index, view, point, &in_scope))
+            .or_else(|| closest_dnd_position(layout_index, view, point, &in_scope_descendant))
+            .or_else(|| closest_dnd_position(layout_index, view, point, &in_scope))
+    } else {
+        let all_entries = |_: &LayoutEntry| true;
+        exact_dnd_position(layout_index, view, point, &all_entries)
+            .or_else(|| closest_dnd_position(layout_index, view, point, &all_entries))
+    }?;
 
     position.resolve(view).is_some().then_some(position)
 }
 
-fn is_dnd_entry(_entry: &LayoutEntry, node: &crate::paginate::types::LayoutNode) -> bool {
-    matches!(
-        node.content,
-        LayoutContent::Line(_)
-            | LayoutContent::Atom(_)
-            | LayoutContent::Box(_)
-            | LayoutContent::Spacing(SpacingKind::Gap { .. })
-    )
+fn exact_dnd_position(
+    layout_index: &LayoutIndex,
+    view: &DocView,
+    point: LayoutPoint,
+    include: &impl Fn(&LayoutEntry) -> bool,
+) -> Option<Position> {
+    layout_index
+        .exact_entry_with(point, |entry, node| {
+            if !include(entry) {
+                return None;
+            }
+            dnd_position_for_candidate(layout_index, view, entry, node, point)
+        })
+        .map(|(_, position)| position)
+}
+
+fn closest_dnd_position(
+    layout_index: &LayoutIndex,
+    view: &DocView,
+    point: LayoutPoint,
+    include: &impl Fn(&LayoutEntry) -> bool,
+) -> Option<Position> {
+    layout_index
+        .closest_entry_with(point, |entry, node| {
+            if !include(entry) {
+                return None;
+            }
+            dnd_position_for_candidate(layout_index, view, entry, node, point)
+        })
+        .map(|(_, position)| position)
 }
 
 fn dnd_position_for_candidate(
@@ -65,6 +92,16 @@ fn dnd_position_for_candidate(
     is_dnd_entry(entry, node)
         .then(|| dnd_position_for_entry(layout_index, view, entry, point))
         .flatten()
+}
+
+fn is_dnd_entry(_entry: &LayoutEntry, node: &crate::paginate::types::LayoutNode) -> bool {
+    matches!(
+        node.content,
+        LayoutContent::Line(_)
+            | LayoutContent::Atom(_)
+            | LayoutContent::Box(_)
+            | LayoutContent::Spacing(SpacingKind::Gap { .. })
+    )
 }
 
 fn dnd_position_for_entry(
@@ -360,6 +397,76 @@ mod tests {
         logs(&items)
     }
 
+    fn table_with_short_cell_and_wrapped_neighbor() -> DocLogs {
+        let root = Dot::ROOT;
+        let table = Dot::new(15, 1);
+        let row = Dot::new(15, 2);
+        let left_cell = Dot::new(15, 3);
+        let left_para = Dot::new(15, 4);
+        let right_cell = Dot::new(15, 20);
+        let right_para = Dot::new(15, 21);
+
+        let mut items = vec![
+            (
+                table,
+                SeqItem::Block {
+                    node_type: NodeType::Table,
+                    parents: vec![root],
+                    attrs: vec![],
+                },
+            ),
+            (
+                row,
+                SeqItem::Block {
+                    node_type: NodeType::TableRow,
+                    parents: vec![root, table],
+                    attrs: vec![],
+                },
+            ),
+            (
+                left_cell,
+                SeqItem::Block {
+                    node_type: NodeType::TableCell,
+                    parents: vec![root, table, row],
+                    attrs: vec![],
+                },
+            ),
+            (
+                left_para,
+                SeqItem::Block {
+                    node_type: NodeType::Paragraph,
+                    parents: vec![root, table, row, left_cell],
+                    attrs: vec![],
+                },
+            ),
+            (Dot::new(15, 5), SeqItem::Char('x')),
+            (
+                right_cell,
+                SeqItem::Block {
+                    node_type: NodeType::TableCell,
+                    parents: vec![root, table, row],
+                    attrs: vec![],
+                },
+            ),
+            (
+                right_para,
+                SeqItem::Block {
+                    node_type: NodeType::Paragraph,
+                    parents: vec![root, table, row, right_cell],
+                    attrs: vec![],
+                },
+            ),
+        ];
+        for (i, ch) in "right cell text wraps onto a second visual line"
+            .chars()
+            .enumerate()
+        {
+            items.push((Dot::new(15, 22 + i as u64), SeqItem::Char(ch)));
+        }
+
+        logs(&items)
+    }
+
     #[test]
     fn drop_in_line_inline_indicator() {
         let doc = para_doc_data("Hello");
@@ -407,6 +514,104 @@ mod tests {
         );
 
         let _ = root_id;
+    }
+
+    #[test]
+    fn drop_target_side_gutter_routes_to_nearest_cell_scope_in_row() {
+        let doc = table_with_short_cell_and_wrapped_neighbor();
+        let pd = project_document(&doc).unwrap();
+        let (view, index) = build_index(&doc, 180.0, &pd);
+
+        let root = view.root().expect("root must exist");
+        let table = root.child_blocks().next().expect("table must exist");
+        let row = table.child_blocks().next().expect("row must exist");
+        let mut cells = row.child_blocks();
+        let left_cell = cells.next().expect("left cell must exist");
+        let left_para = left_cell
+            .child_blocks()
+            .next()
+            .expect("left paragraph must exist");
+        let right_cell = cells.next().expect("right cell must exist");
+        let right_para = right_cell
+            .child_blocks()
+            .next()
+            .expect("right paragraph must exist");
+
+        let left_cell_rect = index
+            .box_rect(&left_cell.id())
+            .expect("left cell must have a box");
+        let right_lines: Vec<_> = index
+            .entries()
+            .filter_map(|entry| {
+                let LayoutContent::Line(line) = entry.content(&index)? else {
+                    return None;
+                };
+                (line.node == right_para.id() && line.offset_range.is_some()).then_some(entry)
+            })
+            .collect();
+        assert!(
+            right_lines.len() >= 2,
+            "right cell text must wrap to at least two lines"
+        );
+        let second_right_line = right_lines[1];
+
+        let x = left_cell_rect.x - 0.25;
+        let page_y = second_right_line.rect.y - index.pages()[0].y_start
+            + second_right_line.rect.height / 2.0;
+
+        let target =
+            drop_target_at(&index, &view, 0, x, page_y).expect("gutter drop in row must resolve");
+
+        assert_eq!(
+            target.position.node,
+            left_para.id(),
+            "row side gutter drop must route to the nearest cell scope"
+        );
+    }
+
+    #[test]
+    fn drop_target_cell_padding_uses_cell_block_boundary() {
+        let doc = table_with_short_cell_and_wrapped_neighbor();
+        let pd = project_document(&doc).unwrap();
+        let (view, index) = build_index(&doc, 180.0, &pd);
+
+        let root = view.root().expect("root must exist");
+        let table = root.child_blocks().next().expect("table must exist");
+        let row = table.child_blocks().next().expect("row must exist");
+        let cell = row.child_blocks().next().expect("cell must exist");
+        let para = cell
+            .child_blocks()
+            .next()
+            .expect("cell paragraph must exist");
+
+        let cell_rect = index.box_rect(&cell.id()).expect("cell must have a box");
+        let para_rect = index
+            .box_rect(&para.id())
+            .expect("paragraph must have a box");
+        let x = para_rect.x + para_rect.width * 0.5;
+
+        let top_padding_y = (cell_rect.y + para_rect.y) * 0.5 - index.pages()[0].y_start;
+        let top_target = drop_target_at(&index, &view, 0, x, top_padding_y)
+            .expect("cell top padding drop must resolve");
+        assert_eq!(top_target.position.node, cell.id());
+        assert_eq!(top_target.position.offset, 0);
+        assert!(
+            matches!(top_target.indicator, DropIndicator::Block { .. }),
+            "cell padding drop should be a block boundary, got {:?}",
+            top_target.indicator
+        );
+
+        let bottom_padding_y =
+            (para_rect.bottom() + cell_rect.bottom()) * 0.5 - index.pages()[0].y_start;
+        let bottom_target = drop_target_at(&index, &view, 0, x, bottom_padding_y)
+            .expect("cell bottom padding drop must resolve");
+        assert_eq!(bottom_target.position.node, cell.id());
+        assert_eq!(bottom_target.position.offset, 1);
+        assert!(
+            matches!(bottom_target.indicator, DropIndicator::Block { .. }),
+            "cell padding drop should be a block boundary, got {:?}",
+            bottom_target.indicator
+        );
     }
 
     fn two_para_gap_doc() -> DocLogs {

--- a/crates/editor-view/src/query/hit_test.rs
+++ b/crates/editor-view/src/query/hit_test.rs
@@ -15,9 +15,20 @@ pub(crate) fn hit_test(
     y: f32,
 ) -> Option<Selection> {
     let point = layout_index.point(page_idx, x, y)?;
+    let scope = layout_index.container_scope(point);
+    let in_scope = |entry: &LayoutEntry| {
+        scope.is_none_or(|scope| layout_index.entry_is_in_scope(entry, scope))
+    };
+
     layout_index
-        .exact_entry(point, is_text_or_atom_hit_entry)
-        .or_else(|| layout_index.closest_entry(point, is_text_or_atom_hit_entry))
+        .exact_entry(point, |entry, node| {
+            in_scope(entry) && is_text_or_atom_hit_entry(entry, node)
+        })
+        .or_else(|| {
+            layout_index.closest_entry(point, |entry, node| {
+                in_scope(entry) && is_text_or_atom_hit_entry(entry, node)
+            })
+        })
         .and_then(|entry| text_or_atom_selection_for_entry(layout_index, entry, point.x))
 }
 
@@ -31,8 +42,14 @@ pub(crate) fn hit_test_extending(
 ) -> Option<Selection> {
     let point = layout_index.point(page_idx, x, y)?;
     let anchor = anchor.resolve(view)?;
+    let scope = layout_index.container_scope(point);
 
-    if let Some(entry) = layout_index.exact_entry(point, is_drag_exact_hit_entry) {
+    let is_scoped_drag_exact_hit_entry = |entry: &LayoutEntry, node: &LayoutNode| {
+        is_drag_exact_hit_entry(entry, node)
+            && scope.is_none_or(|scope| layout_index.entry_is_in_scope(entry, scope))
+    };
+
+    if let Some(entry) = layout_index.exact_entry(point, is_scoped_drag_exact_hit_entry) {
         if let Some(selection) =
             hard_break::drag_selection_for_entry(layout_index, view, entry, point)
         {
@@ -51,13 +68,13 @@ pub(crate) fn hit_test_extending(
                 b.attachment.as_ref().map(select_unit)
             }
             Some(LayoutContent::Spacing(SpacingKind::Gap { .. })) => {
-                drag_boundary_fallback(layout_index, view, &anchor, point)
+                drag_boundary_fallback(layout_index, view, &anchor, point, scope)
             }
             Some(LayoutContent::Box(_) | LayoutContent::Spacing(SpacingKind::Fill)) | None => None,
         };
     }
 
-    drag_boundary_fallback(layout_index, view, &anchor, point)
+    drag_boundary_fallback(layout_index, view, &anchor, point, scope)
 }
 
 fn is_text_or_atom_hit_entry(_entry: &LayoutEntry, node: &LayoutNode) -> bool {
@@ -96,12 +113,16 @@ fn drag_boundary_fallback(
     view: &DocView,
     anchor: &ResolvedPosition,
     point: LayoutPoint,
+    scope: Option<&LayoutEntry>,
 ) -> Option<Selection> {
     let mut inside: Option<DragFallbackCandidate> = None;
     let mut before: Option<DragFallbackCandidate> = None;
     let mut after: Option<DragFallbackCandidate> = None;
 
     for entry in layout_index.entries_on_page(point.page_idx) {
+        if scope.is_some_and(|scope| !layout_index.entry_is_in_scope(entry, scope)) {
+            continue;
+        }
         let Some(candidate) = drag_fallback_candidate(layout_index, entry, point) else {
             continue;
         };
@@ -407,6 +428,80 @@ mod tests {
         (pd, para_id, index)
     }
 
+    fn table_with_short_cell_and_wrapped_neighbor(
+        width: f32,
+    ) -> (ProjectedDoc, Dot, Dot, Dot, LayoutIndex) {
+        let root = Dot::ROOT;
+        let table = Dot::new(15, 1);
+        let row = Dot::new(15, 2);
+        let left_cell = Dot::new(15, 3);
+        let left_para = Dot::new(15, 4);
+        let right_cell = Dot::new(15, 20);
+        let right_para = Dot::new(15, 21);
+
+        let mut items = vec![
+            (
+                table,
+                SeqItem::Block {
+                    node_type: NodeType::Table,
+                    parents: vec![root],
+                    attrs: vec![],
+                },
+            ),
+            (
+                row,
+                SeqItem::Block {
+                    node_type: NodeType::TableRow,
+                    parents: vec![root, table],
+                    attrs: vec![],
+                },
+            ),
+            (
+                left_cell,
+                SeqItem::Block {
+                    node_type: NodeType::TableCell,
+                    parents: vec![root, table, row],
+                    attrs: vec![],
+                },
+            ),
+            (
+                left_para,
+                SeqItem::Block {
+                    node_type: NodeType::Paragraph,
+                    parents: vec![root, table, row, left_cell],
+                    attrs: vec![],
+                },
+            ),
+            (Dot::new(15, 5), SeqItem::Char('x')),
+            (
+                right_cell,
+                SeqItem::Block {
+                    node_type: NodeType::TableCell,
+                    parents: vec![root, table, row],
+                    attrs: vec![],
+                },
+            ),
+            (
+                right_para,
+                SeqItem::Block {
+                    node_type: NodeType::Paragraph,
+                    parents: vec![root, table, row, right_cell],
+                    attrs: vec![],
+                },
+            ),
+        ];
+        for (i, ch) in "right cell text wraps onto a second visual line"
+            .chars()
+            .enumerate()
+        {
+            items.push((Dot::new(15, 22 + i as u64), SeqItem::Char(ch)));
+        }
+
+        let doc = logs(&items);
+        let (pd, index) = build_index(&doc, width);
+        (pd, left_cell, left_para, right_para, index)
+    }
+
     fn two_para_gap_doc(width: f32) -> (ProjectedDoc, Dot, Dot, LayoutIndex) {
         let root = Dot::ROOT;
         let p1 = Dot::new(13, 1);
@@ -466,6 +561,25 @@ mod tests {
         None
     }
 
+    fn line_entries_for_para<'a>(
+        index: &'a LayoutIndex,
+        para_id: &Dot,
+    ) -> Vec<(
+        &'a crate::query::layout_index::LayoutEntry,
+        &'a crate::paginate::types::LayoutLine,
+    )> {
+        index
+            .entries()
+            .filter_map(|entry| {
+                let node = entry.node(index)?;
+                let LayoutContent::Line(line) = &node.content else {
+                    return None;
+                };
+                (line.node == *para_id && line.offset_range.is_some()).then_some((entry, line))
+            })
+            .collect()
+    }
+
     #[test]
     fn hit_test_text_line_caret() {
         let (_pd, para_id, index) = para_doc("Hello", 400.0);
@@ -514,6 +628,62 @@ mod tests {
         assert_eq!(sel.anchor.node, para_id);
         assert_eq!(sel.anchor.offset, 2);
         assert_eq!(sel.anchor.affinity, Affinity::Upstream);
+    }
+
+    #[test]
+    fn hit_test_inside_short_table_cell_stays_in_that_cell_when_neighbor_wraps() {
+        let (_pd, left_cell, left_para, right_para, index) =
+            table_with_short_cell_and_wrapped_neighbor(180.0);
+
+        let left_cell_rect = index
+            .box_rect(&left_cell)
+            .expect("left cell must have a box");
+        let right_lines = line_entries_for_para(&index, &right_para);
+        assert!(
+            right_lines.len() >= 2,
+            "right cell text must wrap to at least two lines"
+        );
+        let (second_right_line, _) = right_lines[1];
+
+        let x = left_cell_rect.x + left_cell_rect.width / 2.0;
+        let page_y = second_right_line.rect.y - index.pages()[0].y_start
+            + second_right_line.rect.height / 2.0;
+
+        let sel = hit_test(&index, 0, x, page_y).expect("click inside table cell must hit");
+
+        assert_eq!(sel.anchor, sel.head);
+        assert_eq!(
+            sel.anchor.node, left_para,
+            "click inside the left cell must resolve within that cell"
+        );
+    }
+
+    #[test]
+    fn hit_test_side_gutter_routes_to_nearest_cell_scope_in_row() {
+        let (_pd, left_cell, left_para, right_para, index) =
+            table_with_short_cell_and_wrapped_neighbor(180.0);
+
+        let left_cell_rect = index
+            .box_rect(&left_cell)
+            .expect("left cell must have a box");
+        let right_lines = line_entries_for_para(&index, &right_para);
+        assert!(
+            right_lines.len() >= 2,
+            "right cell text must wrap to at least two lines"
+        );
+        let (second_right_line, _) = right_lines[1];
+
+        let x = left_cell_rect.x - 0.25;
+        let page_y = second_right_line.rect.y - index.pages()[0].y_start
+            + second_right_line.rect.height / 2.0;
+
+        let sel = hit_test(&index, 0, x, page_y).expect("gutter click in row must hit");
+
+        assert_eq!(sel.anchor, sel.head);
+        assert_eq!(
+            sel.anchor.node, left_para,
+            "row side gutter must route to the nearest cell scope, not the y-nearest neighboring cell line"
+        );
     }
 
     #[test]

--- a/crates/editor-view/src/query/layout_index.rs
+++ b/crates/editor-view/src/query/layout_index.rs
@@ -17,6 +17,7 @@ pub(crate) struct LayoutIndex {
     pages: Vec<LayoutPage>,
     entries: Vec<LayoutEntry>,
     boxes_by_node_id: HashMap<Dot, LayoutEntryId>,
+    scope_by_node: HashMap<Dot, LayoutEntryId>,
     entries_by_node: HashMap<Dot, Vec<LayoutEntryId>>,
     spatial_entries: Vec<SpatialEntry>,
     entries_by_page: Vec<Vec<LayoutEntryId>>,
@@ -49,6 +50,7 @@ struct LayoutIndexBuilder<'a> {
     pages: &'a [LayoutPage],
     entries: Vec<LayoutEntry>,
     boxes_by_node_id: HashMap<Dot, LayoutEntryId>,
+    scope_by_node: HashMap<Dot, LayoutEntryId>,
     entries_by_node: HashMap<Dot, Vec<LayoutEntryId>>,
     ancestors: Vec<Dot>,
     path: Vec<usize>,
@@ -62,6 +64,7 @@ impl LayoutIndex {
             pages,
             entries: Vec::new(),
             boxes_by_node_id: HashMap::new(),
+            scope_by_node: HashMap::new(),
             entries_by_node: HashMap::new(),
             ancestors: Vec::new(),
             path: Vec::new(),
@@ -74,6 +77,7 @@ impl LayoutIndex {
             pages: pages.to_vec(),
             entries: builder.entries,
             boxes_by_node_id: builder.boxes_by_node_id,
+            scope_by_node: builder.scope_by_node,
             entries_by_node: builder.entries_by_node,
             spatial_entries: builder.spatial,
             entries_by_page: builder.entries_by_page,
@@ -270,6 +274,71 @@ impl LayoutIndex {
             .is_some_and(|entry| entry.rect.contains(point.x, point.y))
     }
 
+    pub(crate) fn scope_at(&self, point: LayoutPoint) -> Option<&LayoutEntry> {
+        self.scope_entry_ids_on_page(point.page_idx)
+            .filter(|&&entry_id| {
+                let entry = &self.entries[entry_id];
+                entry.rect.contains(point.x, point.y)
+            })
+            .min_by(|&&a, &&b| {
+                rect_area(&self.entries[a].rect).total_cmp(&rect_area(&self.entries[b].rect))
+            })
+            .map(|&entry_id| &self.entries[entry_id])
+    }
+
+    pub(crate) fn nearest_scope_in_row(&self, point: LayoutPoint) -> Option<&LayoutEntry> {
+        self.scope_entry_ids_on_page(point.page_idx)
+            .filter(|&&entry_id| {
+                let rect = &self.entries[entry_id].rect;
+                point.y >= rect.y && point.y <= rect.bottom()
+            })
+            .min_by(|&&a, &&b| {
+                let a_rect = &self.entries[a].rect;
+                let b_rect = &self.entries[b].rect;
+                compare_distance_key(
+                    (
+                        axis_distance(a_rect.x, a_rect.right(), point.x),
+                        rect_area(a_rect),
+                    ),
+                    (
+                        axis_distance(b_rect.x, b_rect.right(), point.x),
+                        rect_area(b_rect),
+                    ),
+                )
+            })
+            .map(|&entry_id| &self.entries[entry_id])
+    }
+
+    pub(crate) fn container_scope(&self, point: LayoutPoint) -> Option<&LayoutEntry> {
+        self.scope_at(point)
+            .or_else(|| self.nearest_scope_in_row(point))
+    }
+
+    pub(crate) fn scope_for_entry(&self, entry: &LayoutEntry) -> Option<&LayoutEntry> {
+        let entry_id = self.entry_index(entry)?;
+        if self.is_scope_entry_id(entry_id) {
+            return Some(&self.entries[entry_id]);
+        }
+        self.containing_scope_for_entry(entry)
+    }
+
+    pub(crate) fn containing_scope_for_entry(&self, entry: &LayoutEntry) -> Option<&LayoutEntry> {
+        entry
+            .ancestors
+            .iter()
+            .rev()
+            .find_map(|node| self.scope_by_node.get(node))
+            .map(|&scope_id| &self.entries[scope_id])
+    }
+
+    pub(crate) fn entry_is_in_scope(&self, entry: &LayoutEntry, scope: &LayoutEntry) -> bool {
+        if std::ptr::eq(entry, scope) {
+            return true;
+        }
+        self.containing_scope_for_entry(entry)
+            .is_some_and(|entry_scope| std::ptr::eq(entry_scope, scope))
+    }
+
     pub(crate) fn entries_on_page(&self, page_idx: usize) -> Vec<&LayoutEntry> {
         match self.entries_by_page.get(page_idx) {
             Some(ids) => ids.iter().map(|&id| &self.entries[id]).collect(),
@@ -341,6 +410,24 @@ impl LayoutIndex {
             .iter()
             .position(|candidate| std::ptr::eq(candidate, entry))
     }
+
+    fn scope_entry_ids_on_page(
+        &self,
+        page_idx: usize,
+    ) -> impl Iterator<Item = &LayoutEntryId> + '_ {
+        self.entries_by_page
+            .get(page_idx)
+            .into_iter()
+            .flatten()
+            .filter(|&&entry_id| self.is_scope_entry_id(entry_id))
+    }
+
+    fn is_scope_entry_id(&self, entry_id: LayoutEntryId) -> bool {
+        let Some(LayoutContent::Box(b)) = self.entries[entry_id].content(self) else {
+            return false;
+        };
+        self.scope_by_node.get(&b.node) == Some(&entry_id)
+    }
 }
 
 impl LayoutEntry {
@@ -372,6 +459,9 @@ impl LayoutIndexBuilder<'_> {
             LayoutContent::Box(b) => {
                 let id = self.add_entry(node.rect);
                 self.boxes_by_node_id.insert(b.node, id);
+                if b.scope {
+                    self.scope_by_node.insert(b.node, id);
+                }
                 if let Some(attachment) = &b.attachment {
                     self.register_match_node(attachment.parent, id);
                 }
@@ -453,6 +543,7 @@ fn node_geometry_eq(a: &LayoutNode, b: &LayoutNode) -> bool {
         (LayoutContent::Box(x), LayoutContent::Box(y)) => {
             x.node == y.node
                 && x.attachment == y.attachment
+                && x.scope == y.scope
                 && x.children.len() == y.children.len()
                 && x.children
                     .iter()
@@ -722,6 +813,7 @@ mod tests {
                         content: LayoutContent::Line(line),
                     }],
                     attachment: None,
+                    scope: false,
                 }),
             },
         };

--- a/crates/editor-view/src/query/link.rs
+++ b/crates/editor-view/src/query/link.rs
@@ -176,6 +176,7 @@ mod tests {
                 },
                 children,
                 attachment: None,
+                scope: false,
             }),
         }
     }

--- a/crates/editor-view/src/query/navigation.rs
+++ b/crates/editor-view/src/query/navigation.rs
@@ -12,6 +12,8 @@ use super::grapheme::{first_position_in_line, last_position_in_line};
 use super::layout_index::{LayoutEntry, LayoutIndex};
 use super::segmentation;
 
+mod vertical_target;
+
 pub(crate) fn resolve_movement(
     layout_index: &LayoutIndex,
     pos: &Position,
@@ -288,6 +290,10 @@ fn move_grapheme_backward(layout_index: &LayoutIndex, pos: &Position) -> Option<
     }
 }
 
+// Horizontal movement is intentionally document-order or current-line boundary
+// movement in v2. Scope-aware geometry is reserved for vertical target search,
+// where multiple table-cell scopes share a y range and document order cannot
+// identify the visually above/below target.
 fn move_line_horizontal_forward(layout_index: &LayoutIndex, pos: &Position) -> Option<Selection> {
     let entry = layout_index.entry_for_position(pos)?;
     match entry.content(layout_index)? {
@@ -315,17 +321,21 @@ fn move_line_vertical_forward(
         return (None, preferred_x);
     };
     let x = preferred_x.unwrap_or_else(|| compute_preferred_x(layout_index, entry, pos));
-    let y = entry.rect.bottom();
-    let target = navigable_below_at_x(layout_index, y, x);
+    let target = vertical_target::below(layout_index, entry, x);
     let sel = if let Some(t) = target {
-        let s = escape_empty_line_trap(
+        let mut s = escape_empty_line_trap(
             layout_index,
             navigate_to_entry(layout_index, t, x),
             Some(t),
             pos,
             true,
         );
-        Some(skip_over_when_stuck(layout_index, s, t, pos, x, true))
+        if is_empty_line_stuck(layout_index, t, &s, pos) {
+            if let Some(next) = vertical_target::below(layout_index, t, x) {
+                s = navigate_to_entry(layout_index, next, x);
+            }
+        }
+        Some(s)
     } else {
         line_end_fallback(layout_index, entry, true)
     };
@@ -341,53 +351,49 @@ fn move_line_vertical_backward(
         return (None, preferred_x);
     };
     let x = preferred_x.unwrap_or_else(|| compute_preferred_x(layout_index, entry, pos));
-    let y = entry.rect.y;
-    let target = navigable_above_at_x(layout_index, y, x);
+    let target = vertical_target::above(layout_index, entry, x);
     let sel = if let Some(t) = target {
-        let s = escape_empty_line_trap(
+        let mut s = escape_empty_line_trap(
             layout_index,
             navigate_to_entry(layout_index, t, x),
             Some(t),
             pos,
             false,
         );
-        Some(skip_over_when_stuck(layout_index, s, t, pos, x, false))
+        if is_empty_line_stuck(layout_index, t, &s, pos) {
+            if let Some(next) = vertical_target::above(layout_index, t, x) {
+                s = navigate_to_entry(layout_index, next, x);
+            }
+        }
+        Some(s)
     } else {
         line_end_fallback(layout_index, entry, false)
     };
     (sel, Some(x))
 }
 
-fn skip_over_when_stuck(
+fn is_empty_line_stuck(
     layout_index: &LayoutIndex,
-    sel: Selection,
     target: &LayoutEntry,
+    sel: &Selection,
     pos: &Position,
-    x: f32,
-    forward: bool,
-) -> Selection {
+) -> bool {
     let Some(LayoutContent::Line(line)) = target.content(layout_index) else {
-        return sel;
+        return false;
     };
     if !line.glyph_runs.is_empty() {
-        return sel;
+        return false;
     }
     let Some(range) = &line.offset_range else {
-        return sel;
+        return false;
     };
     if range.start != range.end {
-        return sel;
+        return false;
     }
     if sel.head.node != pos.node || sel.head.offset != pos.offset {
-        return sel;
+        return false;
     }
-    let next = if forward {
-        navigable_below_at_x(layout_index, target.rect.bottom(), x)
-    } else {
-        navigable_above_at_x(layout_index, target.rect.y, x)
-    };
-    next.map(|entry| navigate_to_entry(layout_index, entry, x))
-        .unwrap_or(sel)
+    true
 }
 
 fn line_end_fallback(
@@ -689,9 +695,28 @@ pub(crate) fn navigable_below_at_x(
     y_threshold: f32,
     x: f32,
 ) -> Option<&LayoutEntry> {
+    navigable_below_at_x_filtered(layout_index, y_threshold, x, |_| true)
+}
+
+pub(crate) fn navigable_above_at_x(
+    layout_index: &LayoutIndex,
+    y_threshold: f32,
+    x: f32,
+) -> Option<&LayoutEntry> {
+    navigable_above_at_x_filtered(layout_index, y_threshold, x, |_| true)
+}
+
+fn navigable_below_at_x_filtered<'a>(
+    layout_index: &'a LayoutIndex,
+    y_threshold: f32,
+    x: f32,
+    mut include: impl FnMut(&LayoutEntry) -> bool,
+) -> Option<&'a LayoutEntry> {
     let candidates: Vec<&LayoutEntry> = layout_index
         .entries()
-        .filter(|entry| is_navigable_entry(layout_index, entry) && entry.rect.y >= y_threshold)
+        .filter(|entry| {
+            is_navigable_entry(layout_index, entry) && entry.rect.y >= y_threshold && include(entry)
+        })
         .collect();
     let top = candidates.iter().copied().min_by(|a, b| {
         a.rect
@@ -706,15 +731,18 @@ pub(crate) fn navigable_below_at_x(
         .min_by(|a, b| compare_navigation_band_entry(a, b, x, true))
 }
 
-pub(crate) fn navigable_above_at_x(
-    layout_index: &LayoutIndex,
+fn navigable_above_at_x_filtered<'a>(
+    layout_index: &'a LayoutIndex,
     y_threshold: f32,
     x: f32,
-) -> Option<&LayoutEntry> {
+    mut include: impl FnMut(&LayoutEntry) -> bool,
+) -> Option<&'a LayoutEntry> {
     let candidates: Vec<&LayoutEntry> = layout_index
         .entries()
         .filter(|entry| {
-            is_navigable_entry(layout_index, entry) && entry.rect.bottom() <= y_threshold
+            is_navigable_entry(layout_index, entry)
+                && entry.rect.bottom() <= y_threshold
+                && include(entry)
         })
         .collect();
     let bottom = candidates.iter().copied().min_by(|a, b| {
@@ -1096,9 +1124,11 @@ mod tests {
                                 content: LayoutContent::Line(line),
                             }],
                             attachment: None,
+                            scope: false,
                         }),
                     }],
                     attachment: None,
+                    scope: false,
                 }),
             },
         };

--- a/crates/editor-view/src/query/navigation/vertical_target.rs
+++ b/crates/editor-view/src/query/navigation/vertical_target.rs
@@ -1,0 +1,245 @@
+use std::collections::HashMap;
+
+use super::{
+    compare_navigation_band_entry, is_navigable_entry, navigable_above_at_x,
+    navigable_above_at_x_filtered, navigable_below_at_x, navigable_below_at_x_filtered,
+};
+use crate::query::layout_index::{LayoutEntry, LayoutIndex};
+
+const TARGET_EPSILON: f32 = 0.5;
+
+pub(super) fn below<'a>(
+    layout_index: &'a LayoutIndex,
+    entry: &'a LayoutEntry,
+    x: f32,
+) -> Option<&'a LayoutEntry> {
+    if let Some(scope) = layout_index.scope_for_entry(entry) {
+        navigable_below_at_x_filtered(layout_index, entry.rect.bottom(), x, |candidate| {
+            !std::ptr::eq(candidate, entry) && layout_index.entry_is_in_scope(candidate, scope)
+        })
+        .or_else(|| below_exiting_scope(layout_index, scope, x))
+    } else {
+        navigable_below_at_x(layout_index, entry.rect.bottom(), x)
+    }
+}
+
+pub(super) fn above<'a>(
+    layout_index: &'a LayoutIndex,
+    entry: &'a LayoutEntry,
+    x: f32,
+) -> Option<&'a LayoutEntry> {
+    if let Some(scope) = layout_index.scope_for_entry(entry) {
+        navigable_above_at_x_filtered(layout_index, entry.rect.y, x, |candidate| {
+            !std::ptr::eq(candidate, entry) && layout_index.entry_is_in_scope(candidate, scope)
+        })
+        .or_else(|| above_exiting_scope(layout_index, scope, x))
+    } else {
+        navigable_above_at_x(layout_index, entry.rect.y, x)
+    }
+}
+
+fn below_exiting_scope<'a>(
+    layout_index: &'a LayoutIndex,
+    scope: &'a LayoutEntry,
+    x: f32,
+) -> Option<&'a LayoutEntry> {
+    let boundary_y = scope.rect.bottom();
+    let mut scoped_groups = Vec::new();
+    let mut scoped_group_by_scope = HashMap::new();
+    let mut targets = Vec::new();
+
+    for entry in layout_index.entries() {
+        if !is_navigable_entry(layout_index, entry) {
+            continue;
+        }
+        let Some(candidate_scope) = layout_index.containing_scope_for_entry(entry) else {
+            if entry.rect.y >= boundary_y - TARGET_EPSILON {
+                targets.push(VerticalTarget {
+                    band: entry,
+                    landing: entry,
+                });
+            }
+            continue;
+        };
+        // Adjacent table-row scope rects can touch or overlap at collapsed borders.
+        // The scope top separates vertical scope bands; boundary_y still gates the
+        // landing entry inside the chosen scope.
+        if std::ptr::eq(candidate_scope, scope)
+            || candidate_scope.rect.y <= scope.rect.y + TARGET_EPSILON
+            || entry.rect.y < boundary_y - TARGET_EPSILON
+        {
+            continue;
+        }
+        push_scoped_landing_candidate(
+            &mut scoped_groups,
+            &mut scoped_group_by_scope,
+            candidate_scope,
+            entry,
+        );
+    }
+
+    for group in scoped_groups {
+        if let Some(landing) = closest_below(
+            group.landings.into_iter().map(|entry| VerticalTarget {
+                band: entry,
+                landing: entry,
+            }),
+            x,
+        ) {
+            targets.push(VerticalTarget {
+                band: group.scope,
+                landing,
+            });
+        }
+    }
+
+    closest_below(targets.into_iter(), x)
+}
+
+fn above_exiting_scope<'a>(
+    layout_index: &'a LayoutIndex,
+    scope: &'a LayoutEntry,
+    x: f32,
+) -> Option<&'a LayoutEntry> {
+    let boundary_y = scope.rect.y;
+    let mut scoped_groups = Vec::new();
+    let mut scoped_group_by_scope = HashMap::new();
+    let mut targets = Vec::new();
+
+    for entry in layout_index.entries() {
+        if !is_navigable_entry(layout_index, entry) {
+            continue;
+        }
+        let Some(candidate_scope) = layout_index.containing_scope_for_entry(entry) else {
+            if entry.rect.bottom() <= boundary_y + TARGET_EPSILON {
+                targets.push(VerticalTarget {
+                    band: entry,
+                    landing: entry,
+                });
+            }
+            continue;
+        };
+        // Use scope top to reject same-row peer scopes even when collapsed borders
+        // make the previous row's bottom overlap this scope boundary.
+        if std::ptr::eq(candidate_scope, scope)
+            || candidate_scope.rect.y >= scope.rect.y - TARGET_EPSILON
+            || entry.rect.bottom() > boundary_y + TARGET_EPSILON
+        {
+            continue;
+        }
+        push_scoped_landing_candidate(
+            &mut scoped_groups,
+            &mut scoped_group_by_scope,
+            candidate_scope,
+            entry,
+        );
+    }
+
+    for group in scoped_groups {
+        if let Some(landing) = closest_above(
+            group.landings.into_iter().map(|entry| VerticalTarget {
+                band: entry,
+                landing: entry,
+            }),
+            x,
+        ) {
+            targets.push(VerticalTarget {
+                band: group.scope,
+                landing,
+            });
+        }
+    }
+
+    closest_above(targets.into_iter(), x)
+}
+
+#[derive(Clone, Copy)]
+struct VerticalTarget<'a> {
+    // Geometry used to choose the next vertical band. For scoped targets this is
+    // the scope entry; for scopeless targets it is the navigable entry itself.
+    band: &'a LayoutEntry,
+    landing: &'a LayoutEntry,
+}
+
+struct ScopedLandingCandidates<'a> {
+    scope: &'a LayoutEntry,
+    landings: Vec<&'a LayoutEntry>,
+}
+
+fn push_scoped_landing_candidate<'a>(
+    groups: &mut Vec<ScopedLandingCandidates<'a>>,
+    group_by_scope: &mut HashMap<*const LayoutEntry, usize>,
+    scope: &'a LayoutEntry,
+    landing: &'a LayoutEntry,
+) {
+    let key = scope as *const LayoutEntry;
+    let group_idx = if let Some(&idx) = group_by_scope.get(&key) {
+        idx
+    } else {
+        let idx = groups.len();
+        group_by_scope.insert(key, idx);
+        groups.push(ScopedLandingCandidates {
+            scope,
+            landings: Vec::new(),
+        });
+        idx
+    };
+    groups[group_idx].landings.push(landing);
+}
+
+fn closest_below<'a>(
+    targets: impl Iterator<Item = VerticalTarget<'a>>,
+    x: f32,
+) -> Option<&'a LayoutEntry> {
+    let candidates: Vec<_> = targets.collect();
+    let top = candidates
+        .iter()
+        .copied()
+        .min_by(|a, b| compare_below_band(a.band, b.band))?;
+    let band_end = top.band.rect.bottom();
+    candidates
+        .into_iter()
+        .filter(|target| target.band.rect.y < band_end)
+        .min_by(|a, b| compare_vertical_target_band(a, b, x, true))
+        .map(|target| target.landing)
+}
+
+fn closest_above<'a>(
+    targets: impl Iterator<Item = VerticalTarget<'a>>,
+    x: f32,
+) -> Option<&'a LayoutEntry> {
+    let candidates: Vec<_> = targets.collect();
+    let bottom = candidates
+        .iter()
+        .copied()
+        .min_by(|a, b| compare_above_band(a.band, b.band))?;
+    let band_start = bottom.band.rect.y;
+    candidates
+        .into_iter()
+        .filter(|target| target.band.rect.bottom() > band_start)
+        .min_by(|a, b| compare_vertical_target_band(a, b, x, false))
+        .map(|target| target.landing)
+}
+
+fn compare_below_band(a: &LayoutEntry, b: &LayoutEntry) -> std::cmp::Ordering {
+    a.rect
+        .y
+        .total_cmp(&b.rect.y)
+        .then(a.rect.x.total_cmp(&b.rect.x))
+}
+
+fn compare_above_band(a: &LayoutEntry, b: &LayoutEntry) -> std::cmp::Ordering {
+    b.rect
+        .bottom()
+        .total_cmp(&a.rect.bottom())
+        .then(a.rect.x.total_cmp(&b.rect.x))
+}
+
+fn compare_vertical_target_band(
+    a: &VerticalTarget<'_>,
+    b: &VerticalTarget<'_>,
+    x: f32,
+    forward: bool,
+) -> std::cmp::Ordering {
+    compare_navigation_band_entry(a.band, b.band, x, forward)
+}

--- a/crates/editor-view/src/query/segmentation.rs
+++ b/crates/editor-view/src/query/segmentation.rs
@@ -506,9 +506,11 @@ mod tests {
                                 content: LayoutContent::Line(line),
                             }],
                             attachment: None,
+                            scope: false,
                         }),
                     }],
                     attachment: None,
+                    scope: false,
                 }),
             },
         };

--- a/crates/editor-view/src/query/visit.rs
+++ b/crates/editor-view/src/query/visit.rs
@@ -121,6 +121,7 @@ mod tests {
                 style: empty_box_style(),
                 children,
                 attachment: None,
+                scope: false,
             }),
         }
     }
@@ -288,6 +289,7 @@ mod tests {
                 style,
                 children: vec![line_node(line_id, 10.0, 20.0)],
                 attachment: None,
+                scope: false,
             }),
         };
         let tree = LayoutTree { root };

--- a/crates/editor-view/src/table_overlay.rs
+++ b/crates/editor-view/src/table_overlay.rs
@@ -455,6 +455,7 @@ mod tests {
                 style: empty_box_style(),
                 children,
                 attachment: None,
+                scope: false,
             }),
         }
     }


### PR DESCRIPTION
- 레거시의 scope 개념을 다시 제대로 도입
- 아직 table cell만 스코프임
- hit test, drag extension, DnD, vertical navigation에서 사용됨
- vertical navigation exit를 cell boundary 기준 scope-aware target search로 변경
  - horizontal navigation은 원래처럼 document order로 움직여도 동작에 차이가 없어서 고치지 않음
  
 
## Layout Scope

Layout scope는 table cell처럼 자체적인 편집 영역을 형성하는 layout box를 표시하는 query-time containment primitive입니다.

일반 block flow에서는 y/x 거리나 document order만으로 hit target과 navigation target을 고를 수 있지만, table row에서는 여러 cell이 같은 y range를 공유합니다. 이때 cell 내부 클릭이나 arrow up/down은 먼저 현재 cell scope 안에서 해석되어야 하고, cell 밖으로 나갈 때만 scope boundary를 기준으로 다음 target을 찾아야 합니다.

이번 변경에서는 table cell만 scope producer이며, scope는 style이나 schema node type이 아니라 layout query가 hit test, DnD, vertical navigation에서 공유하는 containment 계약입니다.