### PR TITLE
앱 에디터 surface 세션 스케줄러 도입

### DIFF
--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/render/RenderCanvas.android.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/render/RenderCanvas.android.kt
@@ -27,7 +27,7 @@ internal actual fun RenderCanvas(
   desiredPixelSize: IntSize,
   trigger: SharedFlow<Long>,
   onAttach: (handle: Long) -> Unit,
-  onDetach: () -> Unit,
+  onDetach: (releaseBuffer: () -> Unit) -> Unit,
   onResize: () -> Unit,
   onBitmapCommitted: (pixelSize: IntSize, version: Long) -> Unit,
 ) {
@@ -35,6 +35,7 @@ internal actual fun RenderCanvas(
   var imageBitmap by remember { mutableStateOf<ImageBitmap?>(null) }
 
   val currentOnAttach by rememberUpdatedState(onAttach)
+  val currentOnDetach by rememberUpdatedState(onDetach)
   val currentOnResize by rememberUpdatedState(onResize)
   val currentOnBitmapCommitted by rememberUpdatedState(onBitmapCommitted)
 
@@ -110,9 +111,8 @@ internal actual fun RenderCanvas(
     onDispose {
       val handle = bufferHandle
       if (handle != 0L) {
-        onDetach()
-        RenderBuffer.free(handle)
         bufferHandle = 0L
+        currentOnDetach { RenderBuffer.free(handle) }
       }
     }
   }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Editor.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Editor.kt
@@ -93,6 +93,19 @@ internal constructor(
   private val pendingSettles: AtomicReference<PersistentList<PendingSettle>> =
     AtomicReference(persistentListOf())
   private val queued: AtomicBoolean = AtomicBoolean(false)
+  private val surfaceScheduler =
+    EditorSurfaceScheduler(
+      inner = inner,
+      scope = scope,
+      dispatcher = dispatcher,
+      mutex = mutex,
+      versionCounter = versionCounter,
+      disposed = disposed,
+      markPageAttached = { page -> attachedPages.updatePersistent { it.adding(page) } },
+      markPageDetached = { page -> markSurfacePageDetached(page) },
+      onPageSettled = { page, version -> onPageSettled(page, version) },
+      notifyFailure = { error -> notifyFailure(error) },
+    )
 
   @PublishedApi
   internal val listeners:
@@ -307,40 +320,17 @@ internal constructor(
     }
   }
 
-  fun attachSurface(page: Int, handle: Long, width: Double, height: Double, scaleFactor: Double) {
-    attachedPages.updatePersistent { it.add(page) }
-    try {
-      inner.attachSurface(page, handle, width, height, scaleFactor)
-    } catch (e: Throwable) {
-      attachedPages.updatePersistent { it.remove(page) }
-      notifyFailure(e)
-    }
-  }
+  internal fun attachSurface(
+    page: Int,
+    handle: Long,
+    width: Double,
+    height: Double,
+    scaleFactor: Double,
+  ): SurfaceSessionHandle = surfaceScheduler.attachSurface(page, handle, width, height, scaleFactor)
 
-  fun detachSurface(page: Int) {
-    attachedPages.updatePersistent { it.remove(page) }
-    withFailureNotification {
-      inner.detachSurface(page)
-      pendingSettles.load().forEach { it.markDetached(page) }
-    }
-  }
-
-  fun resizeSurface(page: Int, width: Double, height: Double, scaleFactor: Double) =
-    withFailureNotification {
-      inner.resizeSurface(page, width, height, scaleFactor)
-    }
-
-  fun renderSurface(page: Int): Long = runBlocking {
-    withSuspendFailureNotification(defaultValue = { versionCounter.load() }) {
-      val (presented, version) =
-        mutex.withLock { inner.renderSurface(page) to versionCounter.load() }
-      if (!presented) {
-        // Skipped render: the page already shows the current state and no new frame
-        // (hence no onBitmapCommitted → onPageSettled) will arrive — settle it here.
-        onPageSettled(page, version)
-      }
-      version
-    }
+  private fun markSurfacePageDetached(page: Int) {
+    attachedPages.updatePersistent { it.removing(page) }
+    pendingSettles.load().forEach { it.markDetached(page) }
   }
 
   fun onPageSettled(page: Int, version: Long) {
@@ -487,6 +477,7 @@ internal constructor(
     pendingSettles.exchange(persistentListOf()).forEach { it.cancel() }
     listeners.store(persistentMapOf())
     attachedPages.store(persistentSetOf())
+    surfaceScheduler.dispose()
   }
 
   private fun readSnapshot(version: Long, events: List<EditorEvent>): EditorState {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorSurfaceScheduler.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorSurfaceScheduler.kt
@@ -1,0 +1,443 @@
+package co.typie.editor
+
+import co.typie.editor.ffi.Editor as FfiEditor
+import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.AtomicLong
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.PersistentMap
+import kotlinx.collections.immutable.PersistentSet
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentMapOf
+import kotlinx.collections.immutable.persistentSetOf
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+private typealias SurfacePresentedCallback = (version: Long) -> Unit
+
+internal class SurfaceSessionHandle
+internal constructor(
+  private val scheduler: EditorSurfaceScheduler,
+  internal val id: Long,
+  internal val page: Int,
+) {
+  fun requestRender(onPresented: SurfacePresentedCallback) {
+    scheduler.requestRender(this, onPresented)
+  }
+
+  fun requestResize(
+    width: Double,
+    height: Double,
+    scaleFactor: Double,
+    onPresented: SurfacePresentedCallback,
+  ) {
+    scheduler.requestResize(this, width, height, scaleFactor, onPresented)
+  }
+
+  fun detach(onDetached: () -> Unit = {}) {
+    scheduler.detachSurface(this, onDetached)
+  }
+}
+
+private data class SurfaceSession(val id: Long)
+
+private data class SurfaceSessionKey(val page: Int, val sessionId: Long)
+
+private sealed interface SurfaceCommand {
+  val sessionId: Long
+  val page: Int
+}
+
+private data class SurfaceAttachCommand(
+  override val sessionId: Long,
+  override val page: Int,
+  val handle: Long,
+  val width: Double,
+  val height: Double,
+  val scaleFactor: Double,
+) : SurfaceCommand
+
+private sealed interface SurfaceRenderCommand : SurfaceCommand {
+  val onPresented: SurfacePresentedCallback
+}
+
+private data class SurfaceRenderOnlyCommand(
+  override val sessionId: Long,
+  override val page: Int,
+  override val onPresented: SurfacePresentedCallback,
+) : SurfaceRenderCommand
+
+private data class SurfaceResizeAndRenderCommand(
+  override val sessionId: Long,
+  override val page: Int,
+  val width: Double,
+  val height: Double,
+  val scaleFactor: Double,
+  override val onPresented: SurfacePresentedCallback,
+) : SurfaceRenderCommand
+
+private data class SurfaceDetachCommand(
+  override val sessionId: Long,
+  override val page: Int,
+  val onDetached: () -> Unit,
+) : SurfaceCommand
+
+@OptIn(ExperimentalAtomicApi::class)
+internal class EditorSurfaceScheduler(
+  private val inner: FfiEditor,
+  private val scope: CoroutineScope,
+  private val dispatcher: CoroutineDispatcher,
+  private val mutex: Mutex,
+  private val versionCounter: AtomicLong,
+  private val disposed: AtomicBoolean,
+  private val markPageAttached: (Int) -> Unit,
+  private val markPageDetached: (Int) -> Unit,
+  private val onPageSettled: (Int, Long) -> Unit,
+  private val notifyFailure: (Throwable) -> Unit,
+) {
+  private val sessionCounter: AtomicLong = AtomicLong(0L)
+  private val sessions: AtomicReference<PersistentMap<Int, SurfaceSession>> =
+    AtomicReference(persistentMapOf())
+  private val commands: AtomicReference<PersistentList<SurfaceCommand>> =
+    AtomicReference(persistentListOf())
+  private val scheduled: AtomicBoolean = AtomicBoolean(false)
+  private val attachedSessions: AtomicReference<PersistentMap<Int, Long>> =
+    AtomicReference(persistentMapOf())
+  private val pendingAttachSessions: AtomicReference<PersistentSet<SurfaceSessionKey>> =
+    AtomicReference(persistentSetOf())
+
+  fun attachSurface(
+    page: Int,
+    handle: Long,
+    width: Double,
+    height: Double,
+    scaleFactor: Double,
+  ): SurfaceSessionHandle {
+    val sessionId = sessionCounter.addAndFetch(1L)
+    val surface = SurfaceSessionHandle(this, sessionId, page)
+    if (disposed.load()) return surface
+
+    sessions.updatePersistent { it.putting(page, SurfaceSession(sessionId)) }
+    pendingAttachSessions.updatePersistent { it.adding(SurfaceSessionKey(page, sessionId)) }
+    markPageAttached(page)
+    enqueue(
+      SurfaceAttachCommand(
+        sessionId = sessionId,
+        page = page,
+        handle = handle,
+        width = width,
+        height = height,
+        scaleFactor = scaleFactor,
+      )
+    )
+    return surface
+  }
+
+  fun requestRender(surface: SurfaceSessionHandle, onPresented: SurfacePresentedCallback) {
+    if (disposed.load() || !isActive(surface)) return
+    enqueue(
+      SurfaceRenderOnlyCommand(
+        sessionId = surface.id,
+        page = surface.page,
+        onPresented = onPresented,
+      )
+    )
+  }
+
+  fun requestResize(
+    surface: SurfaceSessionHandle,
+    width: Double,
+    height: Double,
+    scaleFactor: Double,
+    onPresented: SurfacePresentedCallback,
+  ) {
+    if (disposed.load() || !isActive(surface)) return
+    enqueue(
+      SurfaceResizeAndRenderCommand(
+        sessionId = surface.id,
+        page = surface.page,
+        width = width,
+        height = height,
+        scaleFactor = scaleFactor,
+        onPresented = onPresented,
+      )
+    )
+  }
+
+  fun detachSurface(surface: SurfaceSessionHandle, onDetached: () -> Unit = {}) {
+    if (disposed.load() && !requiresDeferredDetach(surface.page, surface.id)) {
+      invokeDetached(onDetached)
+      return
+    }
+
+    if (!disposed.load() && removeIfCurrent(surface)) {
+      markPageDetached(surface.page)
+    }
+    enqueue(
+      SurfaceDetachCommand(sessionId = surface.id, page = surface.page, onDetached = onDetached)
+    )
+  }
+
+  fun dispose() {
+    sessions.store(persistentMapOf())
+    val retainedCommands = commands.updatePersistent { queue ->
+      queue.filterIsInstance<SurfaceDetachCommand>().toPersistentList()
+    }
+    if (retainedCommands.isNotEmpty()) {
+      schedule()
+    }
+  }
+
+  private fun removeIfCurrent(surface: SurfaceSessionHandle): Boolean {
+    while (true) {
+      val current = sessions.load()
+      if (current[surface.page]?.id != surface.id) return false
+      if (sessions.compareAndSet(current, current.removing(surface.page))) return true
+    }
+  }
+
+  private fun isActive(surface: SurfaceSessionHandle): Boolean =
+    sessions.load()[surface.page]?.id == surface.id
+
+  private fun isActive(page: Int, sessionId: Long): Boolean = sessions.load()[page]?.id == sessionId
+
+  private fun requiresDeferredDetach(page: Int, sessionId: Long): Boolean =
+    attachedSessions.load()[page] == sessionId ||
+      pendingAttachSessions.load().contains(SurfaceSessionKey(page, sessionId))
+
+  private fun enqueue(command: SurfaceCommand) {
+    if (disposed.load() && command !is SurfaceDetachCommand) {
+      return
+    }
+    if (
+      disposed.load() &&
+        command is SurfaceDetachCommand &&
+        !requiresDeferredDetach(command.page, command.sessionId)
+    ) {
+      invokeDetached(command.onDetached)
+      return
+    }
+
+    commands.updatePersistent { queue -> queue.coalesce(command) }
+    schedule()
+  }
+
+  private fun PersistentList<SurfaceCommand>.coalesce(
+    command: SurfaceCommand
+  ): PersistentList<SurfaceCommand> =
+    when (command) {
+      is SurfaceAttachCommand -> adding(command)
+      is SurfaceRenderOnlyCommand -> coalesceRender(command)
+      is SurfaceResizeAndRenderCommand -> coalesceResize(command)
+      is SurfaceDetachCommand -> coalesceDetach(command)
+    }
+
+  private fun PersistentList<SurfaceCommand>.coalesceRender(
+    command: SurfaceRenderOnlyCommand
+  ): PersistentList<SurfaceCommand> {
+    var replaced = false
+    val next =
+      map { queued ->
+          when {
+            queued is SurfaceResizeAndRenderCommand && queued.sessionId == command.sessionId -> {
+              replaced = true
+              queued.copy(onPresented = command.onPresented)
+            }
+            queued is SurfaceRenderOnlyCommand && queued.sessionId == command.sessionId -> {
+              replaced = true
+              command
+            }
+            else -> queued
+          }
+        }
+        .toPersistentList()
+    return if (replaced) next else next.adding(command)
+  }
+
+  private fun PersistentList<SurfaceCommand>.coalesceResize(
+    command: SurfaceResizeAndRenderCommand
+  ): PersistentList<SurfaceCommand> =
+    filterNot {
+        it.sessionId == command.sessionId &&
+          (it is SurfaceRenderOnlyCommand || it is SurfaceResizeAndRenderCommand)
+      }
+      .toPersistentList()
+      .adding(command)
+
+  private fun PersistentList<SurfaceCommand>.coalesceDetach(
+    command: SurfaceDetachCommand
+  ): PersistentList<SurfaceCommand> =
+    filterNot {
+        it.sessionId == command.sessionId &&
+          (it is SurfaceRenderOnlyCommand || it is SurfaceResizeAndRenderCommand)
+      }
+      .toPersistentList()
+      .adding(command)
+
+  private fun schedule() {
+    if (!scheduled.compareAndSet(expectedValue = false, newValue = true)) return
+    scope.launch(dispatcher) {
+      try {
+        drain()
+      } catch (e: CancellationException) {
+        scheduled.store(false)
+        throw e
+      } catch (e: Throwable) {
+        scheduled.store(false)
+        notifyFailure(e)
+        if (commands.load().isNotEmpty()) {
+          schedule()
+        }
+      }
+    }
+  }
+
+  private suspend fun drain() {
+    while (true) {
+      val batch = commands.exchange(persistentListOf())
+      if (batch.isNotEmpty()) {
+        flush(batch)
+      }
+
+      scheduled.store(false)
+      if (commands.load().isEmpty()) return
+      if (!scheduled.compareAndSet(expectedValue = false, newValue = true)) return
+    }
+  }
+
+  private suspend fun flush(batch: PersistentList<SurfaceCommand>) {
+    for (command in batch) {
+      try {
+        when (command) {
+          is SurfaceAttachCommand -> flushAttach(command)
+          is SurfaceRenderCommand -> flushRender(command)
+          is SurfaceDetachCommand -> flushDetach(command)
+        }
+      } catch (e: CancellationException) {
+        throw e
+      } catch (e: Throwable) {
+        handleFailure(command, e)
+      }
+    }
+  }
+
+  private suspend fun flushAttach(command: SurfaceAttachCommand) {
+    val key = SurfaceSessionKey(command.page, command.sessionId)
+    if (disposed.load() || !isActive(command.page, command.sessionId)) {
+      removePendingAttach(key)
+      return
+    }
+
+    var attached = false
+    mutex.withLock {
+      if (!disposed.load() && isActive(command.page, command.sessionId)) {
+        inner.attachSurface(
+          command.page,
+          command.handle,
+          command.width,
+          command.height,
+          command.scaleFactor,
+        )
+        attachedSessions.updatePersistent { it.putting(command.page, command.sessionId) }
+        attached = true
+      }
+    }
+
+    removePendingAttach(key)
+    if (!attached) {
+      return
+    }
+
+    if (!isActive(command.page, command.sessionId) && !disposed.load()) {
+      detachAttachedSession(command.page, command.sessionId)
+    }
+  }
+
+  private suspend fun flushRender(command: SurfaceRenderCommand) {
+    if (disposed.load() || !isActive(command.page, command.sessionId)) return
+
+    val (presented, version) =
+      mutex.withLock {
+        if (disposed.load() || !isActive(command.page, command.sessionId)) {
+          return
+        }
+
+        if (command is SurfaceResizeAndRenderCommand) {
+          inner.resizeSurface(command.page, command.width, command.height, command.scaleFactor)
+        }
+        inner.renderSurface(command.page) to versionCounter.load()
+      }
+
+    if (!isActive(command.page, command.sessionId)) return
+    if (presented) {
+      command.onPresented(version)
+    } else {
+      // Skipped render: no bitmap commit will arrive for this page, so the editor
+      // settle barrier must be released here.
+      onPageSettled(command.page, version)
+    }
+  }
+
+  private suspend fun flushDetach(command: SurfaceDetachCommand) {
+    removePendingAttach(SurfaceSessionKey(command.page, command.sessionId))
+    detachAttachedSession(command.page, command.sessionId)
+    invokeDetached(command.onDetached)
+  }
+
+  private suspend fun detachAttachedSession(page: Int, sessionId: Long) {
+    if (attachedSessions.load()[page] != sessionId) return
+    mutex.withLock {
+      if (attachedSessions.load()[page] == sessionId) {
+        inner.detachSurface(page)
+        removeAttachedSession(page, sessionId)
+      }
+    }
+  }
+
+  private fun removeAttachedSession(page: Int, sessionId: Long) {
+    attachedSessions.updatePersistent { current ->
+      if (current[page] == sessionId) current.removing(page) else current
+    }
+  }
+
+  private fun removePendingAttach(key: SurfaceSessionKey) {
+    pendingAttachSessions.updatePersistent { it.removing(key) }
+  }
+
+  private fun handleFailure(command: SurfaceCommand, error: Throwable) {
+    notifyFailure(error)
+    when (command) {
+      is SurfaceAttachCommand -> {
+        removePendingAttach(SurfaceSessionKey(command.page, command.sessionId))
+        val surface = SurfaceSessionHandle(this, command.sessionId, command.page)
+        if (removeIfCurrent(surface)) {
+          markPageDetached(command.page)
+        }
+      }
+      is SurfaceRenderCommand -> onPageSettled(command.page, versionCounter.load())
+      is SurfaceDetachCommand -> Unit
+    }
+  }
+
+  private fun invokeDetached(onDetached: () -> Unit) {
+    try {
+      onDetached()
+    } catch (e: Throwable) {
+      notifyFailure(e)
+    }
+  }
+
+  private inline fun <T> AtomicReference<T>.updatePersistent(transform: (T) -> T): T {
+    while (true) {
+      val current = load()
+      val next = transform(current)
+      if (compareAndSet(current, next)) return next
+    }
+  }
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/render/RenderCanvas.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/render/RenderCanvas.kt
@@ -11,7 +11,7 @@ internal expect fun RenderCanvas(
   desiredPixelSize: IntSize,
   trigger: SharedFlow<Long>,
   onAttach: (handle: Long) -> Unit,
-  onDetach: () -> Unit,
+  onDetach: (releaseBuffer: () -> Unit) -> Unit,
   onResize: () -> Unit,
   onBitmapCommitted: (pixelSize: IntSize, version: Long) -> Unit,
 )

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/surface/EditorPageSurface.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/surface/EditorPageSurface.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import co.typie.editor.LocalEditorZoomController
+import co.typie.editor.SurfaceSessionHandle
 import co.typie.editor.ffi.EditorEvent
 import co.typie.editor.render.RenderCanvas
 import co.typie.editor.runtime.LocalEditorRuntime
@@ -61,13 +62,16 @@ internal fun EditorPageSurface(
   val trigger = remember {
     MutableSharedFlow<Long>(replay = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
   }
-  val render =
-    remember(editor, page) {
-      {
-        val version = editor.renderSurface(page)
+  val onPresented =
+    remember(trigger) {
+      { version: Long ->
         trigger.tryEmit(version)
+        Unit
       }
     }
+  var surfaceSession by remember(editor, page) { mutableStateOf<SurfaceSessionHandle?>(null) }
+  val render =
+    remember(editor, page, onPresented) { { surfaceSession?.requestRender(onPresented) } }
 
   val widthDouble = width.toDouble()
   val heightDouble = height.toDouble()
@@ -147,12 +151,15 @@ internal fun EditorPageSurface(
             desiredPixelSize = desiredPixelSize,
             trigger = trigger,
             onAttach = { handle ->
-              editor.attachSurface(page, handle, widthDouble, heightDouble, scaleFactor)
+              surfaceSession =
+                editor.attachSurface(page, handle, widthDouble, heightDouble, scaleFactor)
             },
-            onDetach = { editor.detachSurface(page) },
+            onDetach = { releaseBuffer ->
+              surfaceSession?.detach(releaseBuffer) ?: releaseBuffer()
+              surfaceSession = null
+            },
             onResize = {
-              editor.resizeSurface(page, widthDouble, heightDouble, scaleFactor)
-              render()
+              surfaceSession?.requestResize(widthDouble, heightDouble, scaleFactor, onPresented)
             },
             onBitmapCommitted = { size, version ->
               committedPixelSize = size

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorAwaitTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorAwaitTest.kt
@@ -527,7 +527,7 @@ class EditorAwaitTest {
     }
 
   @Test
-  fun render_skip_settles_page_and_releases_await() =
+  fun requested_render_skip_settles_page_and_releases_await() =
     runTest(dispatcher) {
       val fakeCursor =
         CursorMetrics(pageIdx = 0, caret = Rect(1f, 0f, 0f, 0f), line = Rect(0f, 0f, 0f, 0f))
@@ -540,7 +540,8 @@ class EditorAwaitTest {
           renderSurfaceProvider = { false },
         )
       val editor = Editor(fake, this, dispatcher)
-      editor.attachSurface(page = 0, handle = 0L, width = 0.0, height = 0.0, scaleFactor = 1.0)
+      val surface =
+        editor.attachSurface(page = 0, handle = 0L, width = 0.0, height = 0.0, scaleFactor = 1.0)
 
       var returned = false
       val job =
@@ -553,12 +554,86 @@ class EditorAwaitTest {
 
       // A skipped render presents no new frame, so no bitmap commit (and no
       // onPageSettled from the surface) will ever arrive for this page.
-      editor.renderSurface(0)
+      val presentedVersions = mutableListOf<Long>()
+      surface.requestRender { presentedVersions += it }
       dispatcher.scheduler.advanceUntilIdle()
 
       assertTrue(returned)
       assertEquals(fakeCursor, editor.cursor)
+      assertEquals(emptyList(), presentedVersions)
       job.join()
+    }
+
+  @Test
+  fun surface_render_requests_are_deferred_and_coalesced() =
+    runTest(dispatcher) {
+      val fake = FakeFfiEditor()
+      val editor = Editor(fake, this, dispatcher)
+      val firstCallbackVersions = mutableListOf<Long>()
+      val latestCallbackVersions = mutableListOf<Long>()
+      val surface =
+        editor.attachSurface(page = 0, handle = 1L, width = 0.0, height = 0.0, scaleFactor = 1.0)
+
+      surface.requestRender { firstCallbackVersions += it }
+      surface.requestRender { latestCallbackVersions += it }
+
+      assertEquals(0, fake.renderCount)
+
+      dispatcher.scheduler.advanceUntilIdle()
+
+      assertEquals(1, fake.renderCount)
+      assertEquals(emptyList(), firstCallbackVersions)
+      assertEquals(listOf(0L), latestCallbackVersions)
+    }
+
+  @Test
+  fun surface_resize_request_replaces_pending_render_and_renders_latest_size() =
+    runTest(dispatcher) {
+      val fake = FakeFfiEditor()
+      val editor = Editor(fake, this, dispatcher)
+      val presentedVersions = mutableListOf<Long>()
+      val surface =
+        editor.attachSurface(page = 0, handle = 1L, width = 0.0, height = 0.0, scaleFactor = 1.0)
+
+      surface.requestRender { presentedVersions += it }
+      surface.requestResize(width = 10.0, height = 20.0, scaleFactor = 2.0) {
+        presentedVersions += it
+      }
+      surface.requestResize(width = 12.0, height = 24.0, scaleFactor = 3.0) {
+        presentedVersions += it
+      }
+
+      assertEquals(0, fake.renderCount)
+      assertEquals(emptyList(), fake.resizeCalls)
+
+      dispatcher.scheduler.advanceUntilIdle()
+
+      assertEquals(
+        listOf(
+          FakeFfiEditor.SurfaceResizeCall(page = 0, width = 12.0, height = 24.0, scaleFactor = 3.0)
+        ),
+        fake.resizeCalls,
+      )
+      assertEquals(1, fake.renderCount)
+      assertEquals(listOf(0L), presentedVersions)
+    }
+
+  @Test
+  fun detach_surface_drops_pending_surface_render_request() =
+    runTest(dispatcher) {
+      val fake = FakeFfiEditor()
+      val editor = Editor(fake, this, dispatcher)
+      val presentedVersions = mutableListOf<Long>()
+
+      val surface =
+        editor.attachSurface(page = 0, handle = 1L, width = 0.0, height = 0.0, scaleFactor = 1.0)
+      surface.requestRender { presentedVersions += it }
+      surface.detach()
+
+      dispatcher.scheduler.advanceUntilIdle()
+
+      assertEquals(0, fake.renderCount)
+      assertEquals(emptyList(), presentedVersions)
     }
 
   @Test
@@ -612,7 +687,7 @@ class EditorAwaitTest {
         FakeFfiEditor(onTick = { listOf(renderInvalidated()) }, cursorProvider = { fakeCursor })
       val editor = Editor(fake, this, dispatcher)
       editor.attachSurface(0, 0L, 0.0, 0.0, 1.0)
-      editor.attachSurface(1, 0L, 0.0, 0.0, 1.0)
+      val pageOne = editor.attachSurface(1, 1L, 0.0, 0.0, 1.0)
 
       var returned = false
       val job =
@@ -626,7 +701,7 @@ class EditorAwaitTest {
       dispatcher.scheduler.advanceUntilIdle()
       assertFalse(returned)
 
-      editor.detachSurface(1)
+      pageOne.detach()
       dispatcher.scheduler.advanceUntilIdle()
       assertTrue(returned)
       job.join()
@@ -688,19 +763,135 @@ class EditorAwaitTest {
     }
 
   @Test
-  fun renderSurface_returns_current_version_counter() =
+  fun requested_surface_render_reports_current_version_counter_when_frame_is_presented() =
     runTest(dispatcher) {
       val fake =
         FakeFfiEditor(onTick = { listOf(EditorEvent.StateChanged(listOf(StateField.Cursor))) })
       val editor = Editor(fake, this, dispatcher)
+      val presentedVersions = mutableListOf<Long>()
+      val surface =
+        editor.attachSurface(page = 0, handle = 1L, width = 0.0, height = 0.0, scaleFactor = 1.0)
 
-      val v0 = editor.renderSurface(0)
-      assertEquals(0L, v0)
+      surface.requestRender { presentedVersions += it }
+      dispatcher.scheduler.advanceUntilIdle()
+      assertEquals(listOf(0L), presentedVersions)
 
       editor.sync { enqueue(sampleMessage) }
-      val v1 = editor.renderSurface(0)
-      assertEquals(1L, v1)
+      surface.requestRender { presentedVersions += it }
+      dispatcher.scheduler.advanceUntilIdle()
+
+      assertEquals(listOf(0L, 1L), presentedVersions)
       assertEquals(2, fake.renderCount)
+    }
+
+  @Test
+  fun stale_surface_session_does_not_present_after_reattach() =
+    runTest(dispatcher) {
+      val fake = FakeFfiEditor()
+      val editor = Editor(fake, this, dispatcher)
+      val staleVersions = mutableListOf<Long>()
+      val currentVersions = mutableListOf<Long>()
+
+      val stale =
+        editor.attachSurface(page = 0, handle = 1L, width = 0.0, height = 0.0, scaleFactor = 1.0)
+      stale.requestRender { staleVersions += it }
+      stale.detach()
+      val current =
+        editor.attachSurface(page = 0, handle = 2L, width = 0.0, height = 0.0, scaleFactor = 1.0)
+      current.requestRender { currentVersions += it }
+
+      dispatcher.scheduler.advanceUntilIdle()
+
+      assertEquals(emptyList(), staleVersions)
+      assertEquals(listOf(0L), currentVersions)
+      assertEquals(1, fake.renderCount)
+      assertEquals(0, fake.lastRenderedPage)
+    }
+
+  @Test
+  fun surface_detach_releases_buffer_after_scheduler_detaches_surface() =
+    runTest(dispatcher) {
+      val fake = FakeFfiEditor()
+      val editor = Editor(fake, this, dispatcher)
+      val surface =
+        editor.attachSurface(page = 0, handle = 11L, width = 0.0, height = 0.0, scaleFactor = 1.0)
+
+      dispatcher.scheduler.advanceUntilIdle()
+      surface.detach { fake.surfaceEvents += "release:11" }
+
+      assertEquals(listOf("attach:0:11"), fake.surfaceEvents)
+
+      dispatcher.scheduler.advanceUntilIdle()
+
+      assertEquals(listOf("attach:0:11", "detach:0", "release:11"), fake.surfaceEvents)
+    }
+
+  @Test
+  fun surface_detach_after_editor_dispose_detaches_before_releasing_buffer() =
+    runTest(dispatcher) {
+      val fake = FakeFfiEditor()
+      val editor = Editor(fake, this, dispatcher)
+      val surface =
+        editor.attachSurface(page = 0, handle = 11L, width = 0.0, height = 0.0, scaleFactor = 1.0)
+
+      dispatcher.scheduler.advanceUntilIdle()
+      editor.dispose()
+      surface.detach { fake.surfaceEvents += "release:11" }
+
+      assertEquals(listOf("attach:0:11"), fake.surfaceEvents)
+
+      dispatcher.scheduler.advanceUntilIdle()
+
+      assertEquals(listOf("attach:0:11", "detach:0", "release:11"), fake.surfaceEvents)
+    }
+
+  @Test
+  fun surface_render_failure_settles_failed_page_and_continues_remaining_pages() =
+    runTest(dispatcher) {
+      val fakeCursor =
+        CursorMetrics(pageIdx = 0, caret = Rect(1f, 0f, 0f, 0f), line = Rect(0f, 0f, 0f, 0f))
+      val failure = IllegalStateException("render boom")
+      val fake =
+        FakeFfiEditor(
+          onTick = {
+            listOf(EditorEvent.StateChanged(listOf(StateField.Cursor)), renderInvalidated())
+          },
+          cursorProvider = { fakeCursor },
+          renderSurfaceProvider = { page ->
+            if (page == 0) throw failure
+            true
+          },
+        )
+      val reported = mutableListOf<Throwable>()
+      val editor = Editor(fake, this, dispatcher, onError = { _, error -> reported += error })
+      val failedSurface =
+        editor.attachSurface(page = 0, handle = 10L, width = 0.0, height = 0.0, scaleFactor = 1.0)
+      val continuingSurface =
+        editor.attachSurface(page = 1, handle = 11L, width = 0.0, height = 0.0, scaleFactor = 1.0)
+      val presentedVersions = mutableListOf<Long>()
+
+      var returned = false
+      val job =
+        launch(dispatcher) {
+          editor.await { enqueue(sampleMessage) }
+          returned = true
+        }
+      dispatcher.scheduler.advanceUntilIdle()
+      assertFalse(returned)
+
+      failedSurface.requestRender { error("failed surface should not present") }
+      continuingSurface.requestRender { presentedVersions += it }
+      dispatcher.scheduler.advanceUntilIdle()
+
+      assertEquals(listOf<Throwable>(failure), reported)
+      assertEquals(listOf("attach:0:10", "attach:1:11", "render:0", "render:1"), fake.surfaceEvents)
+      assertEquals(listOf(1L), presentedVersions)
+      editor.onPageSettled(page = 1, version = 1L)
+      dispatcher.scheduler.advanceUntilIdle()
+
+      assertTrue(returned)
+      assertEquals(fakeCursor, editor.cursor)
+      job.join()
     }
 
   @Test

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/FakeFfiEditor.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/FakeFfiEditor.kt
@@ -69,10 +69,19 @@ internal class FakeFfiEditor(
     },
   var renderSurfaceProvider: (Int) -> Boolean = { true },
 ) : co.typie.editor.ffi.Editor {
+  data class SurfaceResizeCall(
+    val page: Int,
+    val width: Double,
+    val height: Double,
+    val scaleFactor: Double,
+  )
+
   val enqueued = mutableListOf<Message>()
   var tickCount: Int = 0
   var renderCount: Int = 0
   var lastRenderedPage: Int? = null
+  val resizeCalls = mutableListOf<SurfaceResizeCall>()
+  val surfaceEvents = mutableListOf<String>()
   var trackedRangesCallCount: Int = 0
   var trackedRangesContainingPositionCallCount: Int = 0
   var placeholderCallCount: Int = 0
@@ -155,18 +164,24 @@ internal class FakeFfiEditor(
     height: Double,
     scaleFactor: Double,
   ) {
+    surfaceEvents += "attach:$page:$handle"
     attached += page
   }
 
   override fun detachSurface(page: Int) {
+    surfaceEvents += "detach:$page"
     attached -= page
   }
 
   override fun invalidateSurface(page: Int) = Unit
 
-  override fun resizeSurface(page: Int, width: Double, height: Double, scaleFactor: Double) = Unit
+  override fun resizeSurface(page: Int, width: Double, height: Double, scaleFactor: Double) {
+    surfaceEvents += "resize:$page:$width:$height:$scaleFactor"
+    resizeCalls += SurfaceResizeCall(page, width, height, scaleFactor)
+  }
 
   override fun renderSurface(page: Int): Boolean {
+    surfaceEvents += "render:$page"
     renderCount += 1
     lastRenderedPage = page
     return renderSurfaceProvider(page)

--- a/apps/mobile/compose/src/skikoMain/kotlin/co/typie/editor/render/RenderCanvas.skiko.kt
+++ b/apps/mobile/compose/src/skikoMain/kotlin/co/typie/editor/render/RenderCanvas.skiko.kt
@@ -28,7 +28,7 @@ internal actual fun RenderCanvas(
   desiredPixelSize: IntSize,
   trigger: SharedFlow<Long>,
   onAttach: (handle: Long) -> Unit,
-  onDetach: () -> Unit,
+  onDetach: (releaseBuffer: () -> Unit) -> Unit,
   onResize: () -> Unit,
   onBitmapCommitted: (pixelSize: IntSize, version: Long) -> Unit,
 ) {
@@ -36,6 +36,7 @@ internal actual fun RenderCanvas(
   var bitmap by remember { mutableStateOf<ImageBitmap?>(null) }
 
   val currentOnAttach by rememberUpdatedState(onAttach)
+  val currentOnDetach by rememberUpdatedState(onDetach)
   val currentOnResize by rememberUpdatedState(onResize)
   val currentOnBitmapCommitted by rememberUpdatedState(onBitmapCommitted)
 
@@ -164,9 +165,8 @@ internal actual fun RenderCanvas(
     onDispose {
       val handle = bufferHandle
       if (handle != 0L) {
-        onDetach()
-        RenderBuffer.free(handle)
         bufferHandle = 0L
+        currentOnDetach { RenderBuffer.free(handle) }
       }
     }
   }


### PR DESCRIPTION
- TR-354를 해결: JVM desktop에서 resize를 빠르게 하다 보면 프리즈되는 현상을 해결함
- https://github.com/penxle/typie/pull/4620 에서 웹 쪽에 도입했던 surface scheduler 개념을 앱에도 비슷하게 확장해서 도입 
- 앱은 native RenderBuffer와 PendingSettle 대기가 있어서 attach/resize/render/detach/free까지 session scheduler가 소유하도록 정리