### PR TITLE
루비 텍스트 폰트 폴백 렌더링 디버그

### DIFF
--- a/crates/editor-renderer/src/renderer.rs
+++ b/crates/editor-renderer/src/renderer.rs
@@ -866,59 +866,60 @@ impl<'a> RenderVisitor<'a> {
 
         for ann in rubies {
             let color = self.theme.color(&ann.color);
+            for glyph_run in &ann.glyph_runs {
+                let adapter = editor_view::glyph_run::GlyphRun {
+                    family_id: glyph_run.family_id,
+                    weight: glyph_run.weight,
+                    font_size: ann.font_size,
+                    synthesis: ann.synthesis,
+                    color: ann.color.clone(),
+                    background_color: None,
+                    glyphs: glyph_run.glyphs.clone(),
+                    decoration: editor_view::glyph_run::TextDecoration::default(),
+                    offset_range: 0..0,
+                    link: None,
+                    text: String::new(),
+                    x: ann.x,
+                    width: ann.width,
+                    graphemes: Vec::<GraphemeSpan>::new(),
+                    cursor_ascent: 0.0,
+                    cursor_descent: 0.0,
+                };
 
-            let adapter = editor_view::glyph_run::GlyphRun {
-                family_id: ann.family_id,
-                weight: ann.weight,
-                font_size: ann.font_size,
-                synthesis: ann.synthesis,
-                color: ann.color.clone(),
-                background_color: None,
-                glyphs: ann.glyphs.clone(),
-                decoration: editor_view::glyph_run::TextDecoration::default(),
-                offset_range: 0..0,
-                link: None,
-                text: String::new(),
-                x: ann.x,
-                width: ann.width,
-                graphemes: Vec::<GraphemeSpan>::new(),
-                cursor_ascent: 0.0,
-                cursor_descent: 0.0,
-            };
+                if self.text_mode == TextRenderMode::VectorExport {
+                    let resource = Arc::clone(&self.renderer.resource);
+                    let fonts = resource.lock().unwrap();
+                    self.sink
+                        .draw_glyph_run(&adapter, color, base_transform, &fonts.font_registry);
+                    continue;
+                }
 
-            if self.text_mode == TextRenderMode::VectorExport {
                 let resource = Arc::clone(&self.renderer.resource);
-                let fonts = resource.lock().unwrap();
-                self.sink
-                    .draw_glyph_run(&adapter, color, base_transform, &fonts.font_registry);
-                continue;
-            }
-
-            let resource = Arc::clone(&self.renderer.resource);
-            let resource_guard = resource.lock().unwrap();
-            let font_generation = resource_guard.font_registry.font_generation();
-            let positioned = crate::glyph::rasterize(
-                &adapter,
-                &resource_guard.font_registry,
-                &mut self.renderer.scale_ctx,
-                &mut self.renderer.glyph_cache,
-                &mut self.renderer.svg_path_glyph_cache,
-                self.scale_factor,
-                base_transform,
-            );
-            drop(resource_guard);
-
-            for pg in &positioned.rasters {
-                draw_positioned_raster_glyph(
-                    self.sink,
-                    &mut self.renderer.baked_glyph_cache,
-                    pg,
-                    color,
-                    font_generation,
+                let resource_guard = resource.lock().unwrap();
+                let font_generation = resource_guard.font_registry.font_generation();
+                let positioned = crate::glyph::rasterize(
+                    &adapter,
+                    &resource_guard.font_registry,
+                    &mut self.renderer.scale_ctx,
+                    &mut self.renderer.glyph_cache,
+                    &mut self.renderer.svg_path_glyph_cache,
+                    self.scale_factor,
+                    base_transform,
                 );
-            }
-            for pg in &positioned.svg_paths {
-                draw_positioned_svg_path_glyph(self.sink, pg, color);
+                drop(resource_guard);
+
+                for pg in &positioned.rasters {
+                    draw_positioned_raster_glyph(
+                        self.sink,
+                        &mut self.renderer.baked_glyph_cache,
+                        pg,
+                        color,
+                        font_generation,
+                    );
+                }
+                for pg in &positioned.svg_paths {
+                    draw_positioned_svg_path_glyph(self.sink, pg, color);
+                }
             }
         }
     }
@@ -2332,8 +2333,8 @@ mod tests {
     }
 
     #[test]
-    fn line_with_ruby_annotation_renders_glyph_through_raster_path() {
-        use editor_view::glyph_run::{Glyph, RubyAnnotation, Synthesis};
+    fn line_with_ruby_annotation_renders_each_font_run_through_raster_path() {
+        use editor_view::glyph_run::{Glyph, RubyAnnotation, RubyGlyphRun, Synthesis};
 
         // Pretendard-Regular 'A' (U+0041) is glyph id 3, which has an outline.
         const TEST_FONT: &[u8] = include_bytes!("../../../assets/Pretendard-Regular.ttf");
@@ -2367,11 +2368,10 @@ mod tests {
 
         let mut resource = Resource::new_test();
         let compressed = editor_resource::compress_zstd(TEST_FONT);
-        resource.add_font_base("test", 400, &compressed).unwrap();
-        let family_id = resource
-            .font_registry
-            .intern_id("test")
-            .expect("test font must be registered");
+        resource.add_font_base("first", 400, &compressed).unwrap();
+        resource.add_font_base("second", 400, &compressed).unwrap();
+        let first_family_id = resource.font_registry.intern_id("first").unwrap();
+        let second_family_id = resource.font_registry.intern_id("second").unwrap();
 
         let state = State::empty();
         let doc = state.view();
@@ -2382,18 +2382,31 @@ mod tests {
             renderer.page_visitor(&mut sink, &doc, 1.0, LayerSet::of(&[RenderLayer::Content]));
 
         let ruby = RubyAnnotation {
-            family_id,
-            weight: 400,
             font_size: 8.0,
             synthesis: Synthesis::default(),
             color: "text.black".to_string(),
             ascent: 6.0,
             descent: 2.0,
-            glyphs: vec![Glyph {
-                id: 3,
-                x: 0.0,
-                y: 0.0,
-            }], // 'A'
+            glyph_runs: vec![
+                RubyGlyphRun {
+                    family_id: first_family_id,
+                    weight: 400,
+                    glyphs: vec![Glyph {
+                        id: 3,
+                        x: 0.0,
+                        y: 0.0,
+                    }],
+                },
+                RubyGlyphRun {
+                    family_id: second_family_id,
+                    weight: 400,
+                    glyphs: vec![Glyph {
+                        id: 3,
+                        x: 10.0,
+                        y: 0.0,
+                    }],
+                },
+            ],
             x: 0.0,
             baseline_y: -8.0,
             width: 10.0,
@@ -2414,8 +2427,8 @@ mod tests {
         // SVG 테이블이 없는 Pretendard outline glyph 는 raster 경로(draw_glyph → draw_image)로
         // 렌더된다. fill_path 는 SVG 테이블 glyph 전용.
         assert!(
-            sink.image_draws > 0,
-            "ruby annotation glyph must be rendered through the raster glyph path"
+            sink.image_draws >= 2,
+            "each ruby font run must be rendered through the raster glyph path"
         );
         assert_eq!(sink.path_fills, 0);
     }

--- a/crates/editor-view/src/glyph_run.rs
+++ b/crates/editor-view/src/glyph_run.rs
@@ -47,15 +47,20 @@ pub struct GlyphRun {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct RubyAnnotation {
+pub struct RubyGlyphRun {
     pub family_id: FontId,
     pub weight: u16,
+    pub glyphs: Vec<Glyph>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RubyAnnotation {
     pub font_size: f32,
     pub synthesis: Synthesis,
     pub color: String,
     pub ascent: f32,
     pub descent: f32,
-    pub glyphs: Vec<Glyph>,
+    pub glyph_runs: Vec<RubyGlyphRun>,
     pub x: f32,
     pub baseline_y: f32,
     pub width: f32,

--- a/crates/editor-view/src/measure/nodes/line_geometry.rs
+++ b/crates/editor-view/src/measure/nodes/line_geometry.rs
@@ -132,8 +132,10 @@ fn expand_line(
     if delta != 0.0 {
         for ann in &mut ruby_annotations {
             ann.baseline_y += delta;
-            for g in &mut ann.glyphs {
-                g.y += delta;
+            for run in &mut ann.glyph_runs {
+                for g in &mut run.glyphs {
+                    g.y += delta;
+                }
             }
         }
     }

--- a/crates/editor-view/src/measure/text/inline.rs
+++ b/crates/editor-view/src/measure/text/inline.rs
@@ -153,6 +153,8 @@ pub(crate) struct RubyGroup {
     pub text: String,
     pub offset_range: Range<usize>,
     pub total_base_chars: usize,
+    pub requested_font_family: String,
+    pub requested_font_weight: u16,
 }
 
 pub(crate) fn identify_ruby_groups(node: &NodeView) -> Vec<RubyGroup> {
@@ -184,10 +186,15 @@ pub(crate) fn identify_ruby_groups(node: &NodeView) -> Vec<RubyGroup> {
                         }
                         _ => {
                             flush(&mut current, &mut groups);
+                            let style = style_from_effective_modifiers(
+                                &item.effective.values().cloned().collect::<Vec<_>>(),
+                            );
                             current = Some(RubyGroup {
                                 text: t.to_owned(),
                                 offset_range: offset..offset + 1,
                                 total_base_chars: 1,
+                                requested_font_family: style.font_family,
+                                requested_font_weight: style.font_weight,
                             });
                         }
                     },
@@ -623,8 +630,75 @@ mod tests {
                 text: "x".to_string(),
                 offset_range: 0..2,
                 total_base_chars: 2,
+                requested_font_family: editor_model::DEFAULT_FONT_FAMILY.to_string(),
+                requested_font_weight: editor_model::DEFAULT_FONT_WEIGHT,
             }]
         );
+    }
+
+    #[test]
+    fn ruby_group_keeps_first_requested_font_family_and_weight() {
+        let mut l = build_logs(vec![ch('a'), ch('b')]);
+        l.block_modifiers = ModifierAttrLog::new()
+            .apply(
+                Dot::new(66, 1),
+                ModifierAttrOp::SetModifier {
+                    target: Dot::ROOT,
+                    modifier: Modifier::FontFamily {
+                        value: "First".to_string(),
+                    },
+                },
+            )
+            .unwrap()
+            .apply(
+                Dot::new(66, 2),
+                ModifierAttrOp::SetModifier {
+                    target: Dot::ROOT,
+                    modifier: Modifier::FontWeight { value: 300 },
+                },
+            )
+            .unwrap();
+        l.spans = SpanLog::new()
+            .apply(
+                Dot::new(67, 1),
+                SpanOp::AddSpan {
+                    start: anc(leaf(0), Bias::Before),
+                    end: anc(leaf(1), Bias::After),
+                    modifier: Modifier::Ruby {
+                        text: "x".to_string(),
+                    },
+                },
+            )
+            .unwrap()
+            .apply(
+                Dot::new(67, 2),
+                SpanOp::AddSpan {
+                    start: anc(leaf(1), Bias::Before),
+                    end: anc(leaf(1), Bias::After),
+                    modifier: Modifier::FontFamily {
+                        value: "Second".to_string(),
+                    },
+                },
+            )
+            .unwrap()
+            .apply(
+                Dot::new(67, 3),
+                SpanOp::AddSpan {
+                    start: anc(leaf(1), Bias::Before),
+                    end: anc(leaf(1), Bias::After),
+                    modifier: Modifier::FontWeight { value: 700 },
+                },
+            )
+            .unwrap();
+
+        let pd = project_document(&l).unwrap();
+        let view = DocView::new(&pd);
+        let para = view.root().unwrap().child_blocks().next().unwrap();
+        let groups = identify_ruby_groups(&para);
+
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].requested_font_family, "First");
+        assert_eq!(groups[0].requested_font_weight, 300);
     }
 
     #[test]

--- a/crates/editor-view/src/measure/text/measure.rs
+++ b/crates/editor-view/src/measure/text/measure.rs
@@ -243,8 +243,10 @@ fn measure_segment<'a>(
                 .into_iter()
                 .map(|mut a| {
                     a.baseline_y += extra_top;
-                    for g in &mut a.glyphs {
-                        g.y += extra_top;
+                    for run in &mut a.glyph_runs {
+                        for g in &mut run.glyphs {
+                            g.y += extra_top;
+                        }
                     }
                     a
                 })

--- a/crates/editor-view/src/measure/text/ruby.rs
+++ b/crates/editor-view/src/measure/text/ruby.rs
@@ -27,11 +27,55 @@ use parley::style::{
 };
 use parley::{OverflowWrap, WordBreak};
 
-use crate::glyph_run::{Glyph, RubyAnnotation, Synthesis};
+use crate::glyph_run::{Glyph, RubyAnnotation, RubyGlyphRun, Synthesis};
 
 use super::extract::ExtractedLine;
 use super::inline::RubyGroup;
+use super::style_run::resolve_font_family_weight;
 use crate::glyph_run::GlyphRun;
+
+#[derive(Debug)]
+struct RubyFontRun {
+    byte_range: std::ops::Range<usize>,
+    family_id: u16,
+    weight: u16,
+}
+
+fn resolve_ruby_font_runs(
+    text: &str,
+    family: &str,
+    weight: u16,
+    resource: &mut Resource,
+) -> Vec<RubyFontRun> {
+    let requested_family_id = resource.font_registry.intern(family);
+    let mut runs: Vec<RubyFontRun> = Vec::new();
+    let mut byte_offset = 0;
+
+    for ch in text.chars() {
+        let char_byte_end = byte_offset + ch.len_utf8();
+        let (family_id, resolved_weight) = resolve_font_family_weight(
+            &resource.font_registry,
+            requested_family_id,
+            weight,
+            ch as u32,
+        );
+        if let Some(last) = runs.last_mut()
+            && last.family_id == family_id
+            && last.weight == resolved_weight
+        {
+            last.byte_range.end = char_byte_end;
+        } else {
+            runs.push(RubyFontRun {
+                byte_range: byte_offset..char_byte_end,
+                family_id,
+                weight: resolved_weight,
+            });
+        }
+        byte_offset = char_byte_end;
+    }
+
+    runs
+}
 
 pub(crate) fn build_ruby_annotations(
     line: &ExtractedLine,
@@ -47,14 +91,12 @@ pub(crate) fn build_ruby_annotations(
     }
 
     struct Pending {
-        family_id: u16,
-        weight: u16,
         font_size: f32,
         synthesis: Synthesis,
         color: String,
         ascent: f32,
         descent: f32,
-        glyphs_relative: Vec<Glyph>,
+        glyph_runs_relative: Vec<RubyGlyphRun>,
         x: f32,
         width: f32,
     }
@@ -114,25 +156,22 @@ pub(crate) fn build_ruby_annotations(
         let first = &slice[0];
         let ruby_font_size = (first.font_size * RUBY_FONT_SIZE_RATIO).max(RUBY_FONT_SIZE_MIN_PX);
 
-        let family_name = resource
-            .font_registry
-            .family_name_opt(first.family_id)
-            .unwrap_or_default()
-            .to_owned();
-
-        let ruby_style = TextStyle {
-            font_family: FontFamily::Single(FontFamilyName::Named(Cow::Owned(family_name))),
-            font_size: ruby_font_size,
-            font_weight: ParleyFontWeight::new(first.weight as f32),
-            line_height: LineHeight::FontSizeRelative(1.0),
-            brush: TextBrush { run_index: 0 },
-            font_features: FontFeatures::Source(Cow::Borrowed(
-                "\"ss05\" 1, \"cv12\" 1, \"ss18\" 1",
-            )),
-            word_break: WordBreak::BreakAll,
-            overflow_wrap: OverflowWrap::Anywhere,
-            ..TextStyle::default()
-        };
+        let font_runs = resolve_ruby_font_runs(
+            &ruby_slice,
+            &group.requested_font_family,
+            group.requested_font_weight,
+            resource,
+        );
+        let family_names = font_runs
+            .iter()
+            .map(|run| {
+                resource
+                    .font_registry
+                    .family_name_opt(run.family_id)
+                    .unwrap_or_default()
+                    .to_owned()
+            })
+            .collect::<Vec<_>>();
 
         let resource = &mut *resource;
         let mut builder = resource.layout_context.style_run_builder(
@@ -141,8 +180,24 @@ pub(crate) fn build_ruby_annotations(
             1.0,
             true,
         );
-        let idx = builder.push_style(ruby_style);
-        builder.push_style_run(idx, 0..ruby_slice.len());
+        for (run_index, (font_run, family_name)) in font_runs.iter().zip(&family_names).enumerate()
+        {
+            let ruby_style = TextStyle {
+                font_family: FontFamily::Single(FontFamilyName::Named(Cow::Borrowed(family_name))),
+                font_size: ruby_font_size,
+                font_weight: ParleyFontWeight::new(font_run.weight as f32),
+                line_height: LineHeight::FontSizeRelative(1.0),
+                brush: TextBrush { run_index },
+                font_features: FontFeatures::Source(Cow::Borrowed(
+                    "\"ss05\" 1, \"cv12\" 1, \"ss18\" 1",
+                )),
+                word_break: WordBreak::BreakAll,
+                overflow_wrap: OverflowWrap::Anywhere,
+                ..TextStyle::default()
+            };
+            let style_index = builder.push_style(ruby_style);
+            builder.push_style_run(style_index, font_run.byte_range.clone());
+        }
 
         let mut layout = builder.build(&ruby_slice);
         layout.break_all_lines(None);
@@ -159,32 +214,39 @@ pub(crate) fn build_ruby_annotations(
         let ruby_x = (base_min_x + (base_width - ruby_width) / 2.0)
             .clamp(0.0, (line_width - ruby_width).max(0.0));
 
-        let mut glyphs_relative = Vec::new();
+        let mut glyph_runs_relative = Vec::new();
         for item in ruby_line.items() {
             if let parley::PositionedLayoutItem::GlyphRun(gr) = item {
+                let font_run = &font_runs[gr.style().brush.run_index];
                 let run_x = gr.offset();
                 let mut adv = 0.0;
-                for g in gr.glyphs() {
-                    let gx = adv + g.x;
-                    adv += g.advance;
-                    glyphs_relative.push(Glyph {
-                        id: g.id,
-                        x: run_x + gx,
-                        y: g.y,
-                    });
-                }
+                let glyphs = gr
+                    .glyphs()
+                    .map(|g| {
+                        let gx = adv + g.x;
+                        adv += g.advance;
+                        Glyph {
+                            id: g.id,
+                            x: run_x + gx,
+                            y: g.y,
+                        }
+                    })
+                    .collect();
+                glyph_runs_relative.push(RubyGlyphRun {
+                    family_id: font_run.family_id,
+                    weight: font_run.weight,
+                    glyphs,
+                });
             }
         }
 
         pending.push(Pending {
-            family_id: first.family_id,
-            weight: first.weight,
             font_size: ruby_font_size,
             synthesis: first.synthesis,
             color: first.color.clone(),
             ascent: ruby_ascent,
             descent: ruby_descent,
-            glyphs_relative,
+            glyph_runs_relative,
             x: ruby_x,
             width: ruby_width,
         });
@@ -202,24 +264,24 @@ pub(crate) fn build_ruby_annotations(
     pending
         .into_iter()
         .map(|p| {
-            let glyphs: Vec<Glyph> = p
-                .glyphs_relative
+            let glyph_runs = p
+                .glyph_runs_relative
                 .into_iter()
-                .map(|g| Glyph {
-                    id: g.id,
-                    x: p.x + g.x,
-                    y: baseline_y + g.y,
+                .map(|mut run| {
+                    for glyph in &mut run.glyphs {
+                        glyph.x += p.x;
+                        glyph.y += baseline_y;
+                    }
+                    run
                 })
                 .collect();
             RubyAnnotation {
-                family_id: p.family_id,
-                weight: p.weight,
                 font_size: p.font_size,
                 synthesis: p.synthesis,
                 color: p.color,
                 ascent: p.ascent,
                 descent: p.descent,
-                glyphs,
+                glyph_runs,
                 x: p.x,
                 baseline_y,
                 width: p.width,
@@ -232,7 +294,7 @@ pub(crate) fn build_ruby_annotations(
 mod tests {
     use std::ops::Range;
 
-    use editor_resource::Resource;
+    use editor_resource::{FontFamily, FontFamilySource, FontWeight, Resource, compress_zstd};
 
     use super::*;
     use crate::glyph_run::{GraphemeSpan, TextDecoration};
@@ -285,7 +347,77 @@ mod tests {
             text: text.to_string(),
             offset_range,
             total_base_chars,
+            requested_font_family: editor_model::DEFAULT_FONT_FAMILY.to_string(),
+            requested_font_weight: editor_model::DEFAULT_FONT_WEIGHT,
         }
+    }
+
+    fn fallback_resource() -> Resource {
+        const TEST_FONT: &[u8] = include_bytes!("../../../assets/test-font.ttf");
+
+        let mut resource = Resource::new_test();
+        resource.set_fonts(vec![
+            FontFamily {
+                name: "Primary".to_string(),
+                source: FontFamilySource::Default,
+                weights: vec![FontWeight {
+                    value: 400,
+                    hash: "primary".to_string(),
+                    chunks: vec![vec!['A' as u32, 'A' as u32, 'C' as u32, 'C' as u32]],
+                }],
+            },
+            FontFamily {
+                name: "Fallback".to_string(),
+                source: FontFamilySource::Fallback,
+                weights: vec![FontWeight {
+                    value: 700,
+                    hash: "fallback".to_string(),
+                    chunks: vec![vec!['B' as u32, 'B' as u32]],
+                }],
+            },
+        ]);
+
+        let font = compress_zstd(TEST_FONT);
+        let empty_chunk = compress_zstd(&0u32.to_be_bytes());
+        for (family, weight) in [("Primary", 400), ("Fallback", 700)] {
+            resource.add_font_base(family, weight, &font).unwrap();
+            resource
+                .add_font_chunk(family, weight, 0, &empty_chunk)
+                .unwrap();
+        }
+        resource
+    }
+
+    #[test]
+    fn ruby_resolves_each_character_from_group_first_requested_font() {
+        let mut resource = fallback_resource();
+        let fallback = resource.font_registry.intern_id("Fallback").unwrap();
+        let primary = resource.font_registry.intern_id("Primary").unwrap();
+        let mut base_run = make_run(0..1, "B", 0.0, 32.0, 16.0);
+        base_run.family_id = fallback;
+        base_run.weight = 700;
+        let line = make_line(vec![base_run]);
+        let groups = vec![RubyGroup {
+            text: "ABC".to_string(),
+            offset_range: 0..1,
+            total_base_chars: 1,
+            requested_font_family: "Primary".to_string(),
+            requested_font_weight: 400,
+        }];
+        let mut offsets = vec![0];
+
+        let annotations =
+            build_ruby_annotations(&line, 200.0, &groups, &mut offsets, &mut resource);
+
+        assert_eq!(annotations.len(), 1);
+        assert_eq!(
+            annotations[0]
+                .glyph_runs
+                .iter()
+                .map(|run| (run.family_id, run.weight))
+                .collect::<Vec<_>>(),
+            vec![(primary, 400), (fallback, 700), (primary, 400)]
+        );
     }
 
     #[test]

--- a/crates/editor-view/src/measure/text/style_run.rs
+++ b/crates/editor-view/src/measure/text/style_run.rs
@@ -14,16 +14,35 @@ pub(crate) struct StyleRun {
     pub line_height: f32,
 }
 
+pub(crate) fn resolve_font_family_weight(
+    font_registry: &FontRegistry,
+    requested_family_id: u16,
+    weight: u16,
+    codepoint: u32,
+) -> (u16, u16) {
+    let placeholder_id = font_registry
+        .placeholder_family_id()
+        .expect("placeholder family must be registered before resolving style runs");
+
+    match font_registry.resolve(requested_family_id, weight, codepoint) {
+        Resolution::Ready(target) => (target.family_id, target.weight),
+        Resolution::Pending {
+            target,
+            needs_base: false,
+        } => (target.family_id, target.weight),
+        Resolution::Pending {
+            needs_base: true, ..
+        }
+        | Resolution::Missing => (placeholder_id, PLACEHOLDER_WEIGHT),
+    }
+}
+
 pub(crate) fn resolve_style_runs(
     text: &str,
     runs: &[TextRun],
     font_registry: &mut FontRegistry,
 ) -> Vec<StyleRun> {
     let mut style_runs: Vec<StyleRun> = Vec::new();
-
-    let placeholder_id = font_registry
-        .placeholder_family_id()
-        .expect("placeholder family must be registered before resolving style runs");
 
     for (run_index, run) in runs.iter().enumerate() {
         let requested_family_id = font_registry.intern(&run.style.font_family);
@@ -36,17 +55,7 @@ pub(crate) fn resolve_style_runs(
             let char_byte_end = byte_offset + ch.len_utf8();
 
             let (resolved_family, resolved_weight) =
-                match font_registry.resolve(requested_family_id, weight, ch as u32) {
-                    Resolution::Ready(target) => (target.family_id, target.weight),
-                    Resolution::Pending {
-                        target,
-                        needs_base: false,
-                    } => (target.family_id, target.weight),
-                    Resolution::Pending {
-                        needs_base: true, ..
-                    }
-                    | Resolution::Missing => (placeholder_id, PLACEHOLDER_WEIGHT),
-                };
+                resolve_font_family_weight(font_registry, requested_family_id, weight, ch as u32);
 
             let can_merge = style_runs.last().is_some_and(|last: &StyleRun| {
                 last.family == resolved_family


### PR DESCRIPTION
- TR-358, TR-366을 해결: 루비 텍스트의 일부 글리프가 보이지 않던 문제를 수정
- 기존에는 루비 셰이핑에서 폴백 폰트를 사용해도 결과 글리프를 본문 첫 런의 폰트로 렌더링하고 있었음
- 루비는 본문 첫 텍스트의 요청 font family/weight를 따르고, 루비 문자별로 실제 사용할 폰트와 weight를 resolve하도록 변경
- 실제 폰트별 glyph run을 보존해 raster/vector renderer가 각각 올바른 폰트로 렌더링하도록 함