### PR TITLE
빈 문단 carry가 누락되는 버그 수정

### DIFF
--- a/crates/editor-commands/src/commands/split_paragraph.rs
+++ b/crates/editor-commands/src/commands/split_paragraph.rs
@@ -558,6 +558,35 @@ mod tests {
     }
 
     #[test]
+    fn split_empty_paragraph_preserves_carry() {
+        let (initial, ..) = state! {
+            doc {
+                root {
+                    paragraph carry([font_size(2400), font_family("RIDIBatang".to_string())]) {
+                        text("1") [font_size(2400), font_family("RIDIBatang".to_string())]
+                    }
+                    p1: paragraph carry([font_size(2400), font_family("RIDIBatang".to_string())]) {}
+                }
+            }
+            selection: (p1, 0)
+        };
+        let (actual, ..) = transact!(initial, |tr| split_paragraph(&mut tr));
+        let (expected, ..) = state! {
+            doc {
+                root {
+                    paragraph carry([font_size(2400), font_family("RIDIBatang".to_string())]) {
+                        text("1") [font_size(2400), font_family("RIDIBatang".to_string())]
+                    }
+                    paragraph carry([font_size(2400), font_family("RIDIBatang".to_string())]) {}
+                    p2: paragraph carry([font_size(2400), font_family("RIDIBatang".to_string())]) {}
+                }
+            }
+            selection: (p2, 0)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
     fn split_carry_excludes_pending() {
         let (initial, ..) = state! {
             doc { root { p1: paragraph { text("Hello") } } }

--- a/crates/editor-commands/src/helpers/modifiers.rs
+++ b/crates/editor-commands/src/helpers/modifiers.rs
@@ -9,8 +9,7 @@ use editor_model::{
 use editor_resource::{Resource, find_bold_target, find_unbold_target, match_weight};
 use editor_state::{
     PendingModifiers, Position, ProjectedState, ResolvedSelection, Selection, apply_pending,
-    continuation_at, continuation_from_neighbors, leaf_groups_in_range, leaf_span_in_range,
-    resolve_modifier_state_in_range,
+    continuation_at, leaf_groups_in_range, leaf_span_in_range, resolve_modifier_state_in_range,
 };
 use editor_transaction::Transaction;
 use strum::IntoEnumIterator;
@@ -175,9 +174,8 @@ pub(crate) fn apply_modifier_to_node(
 }
 
 pub(crate) fn continuation_paint_at(state: &ProjectedState, pos: Position) -> Vec<Modifier> {
-    continuation_from_neighbors(state, pos.node, pos.offset)
+    continuation_at(state, pos.node, pos.offset)
         .into_iter()
-        .flatten()
         .filter(|(ty, _)| ty.is_carry_kind())
         .map(|(_, m)| m)
         .collect()


### PR DESCRIPTION
빈 문단이 split될 때 양쪽의 carry가 초기화되어 서식이 유지되지 않는 문제를 해결함
