### PR TITLE
웹/앱 툴바가 새로운 color modifier 계약을 따르지 않는 문제 수정

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/TextOptionMode.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/TextOptionMode.kt
@@ -24,6 +24,8 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import co.typie.editor.EditorValues
 import co.typie.editor.ffi.Alignment as FfiAlignment
+import co.typie.editor.ffi.BackgroundColorValue
+import co.typie.editor.ffi.TextColorValue
 import co.typie.editor.ffi.Tri
 import co.typie.graphql.fragment.EditorSettingsFontFamily_family
 import co.typie.graphql.type.FontFamilySource
@@ -54,6 +56,22 @@ internal inline fun <T, R> Tri<T>?.uniformValue(transform: (T) -> R): R? =
   when (this) {
     is Tri.Uniform -> transform(value)
     else -> null
+  }
+
+internal fun Tri<TextColorValue>?.textColorCurrentValue(): String? =
+  when (this) {
+    is Tri.Uniform -> value.value
+    Tri.Absent -> "black"
+    Tri.Mixed,
+    null -> null
+  }
+
+internal fun Tri<BackgroundColorValue>?.backgroundColorCurrentValue(): String? =
+  when (this) {
+    is Tri.Uniform -> value.value
+    Tri.Absent -> "none"
+    Tri.Mixed,
+    null -> null
   }
 
 internal fun Tri<*>?.hasUniformValue(): Boolean = this is Tri.Uniform<*>

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/TextOptionsToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/TextOptionsToolbar.kt
@@ -153,7 +153,7 @@ private fun TextOptionsContent(
     TextOptionMode.TextColor ->
       ColorOptions(
         options = EditorValues.textColor,
-        currentValue = modifierState?.textColor.uniformValue { it.value },
+        currentValue = modifierState?.textColor.textColorCurrentValue(),
         editorTheme = editorTheme,
         swatchShape = ToolbarButtonShape,
         showSlashForNullTheme = false,
@@ -161,7 +161,7 @@ private fun TextOptionsContent(
       )
     TextOptionMode.BackgroundColor ->
       TextBackgroundColorOptions(
-        currentValue = modifierState?.backgroundColor.uniformValue { it.value },
+        currentValue = modifierState?.backgroundColor.backgroundColorCurrentValue(),
         editorTheme = editorTheme,
         onSelect = { sendSet(sendMessages, EditorModifier.BackgroundColor(it)) },
       )

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/TextToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/TextToolbar.kt
@@ -118,8 +118,8 @@ private fun EditorTextToolbar(
   val dialog = LocalDialog.current
   val variant = currentEditorThemeVariant()
   val editorTheme = remember(variant) { EditorTheme.resolve(variant) }
-  val textColor = modifierState?.textColor.uniformValue { it.value }
-  val backgroundColor = modifierState?.backgroundColor.uniformValue { it.value }
+  val textColor = modifierState?.textColor.textColorCurrentValue()
+  val backgroundColor = modifierState?.backgroundColor.backgroundColorCurrentValue()
   val fontFamily = modifierState?.fontFamily.uniformValue { it.value }
   val fontWeight = modifierState?.fontWeight.uniformValue { it.value }
   val fontSize = modifierState?.fontSize.uniformValue { it.value }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/toolbar/contextual/TextOptionModeTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/toolbar/contextual/TextOptionModeTest.kt
@@ -1,9 +1,47 @@
 package co.typie.screen.editor.editor.toolbar.contextual
 
+import co.typie.editor.ffi.BackgroundColorValue
+import co.typie.editor.ffi.TextColorValue
+import co.typie.editor.ffi.Tri
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class TextOptionModeTest {
+  @Test
+  fun `textColorCurrentValue maps uniform to its value`() {
+    assertEquals("red", Tri.Uniform(TextColorValue("red")).textColorCurrentValue())
+  }
+
+  @Test
+  fun `textColorCurrentValue maps absent to black`() {
+    assertEquals("black", Tri.Absent.textColorCurrentValue())
+  }
+
+  @Test
+  fun `textColorCurrentValue maps mixed and null to null`() {
+    assertEquals(null, Tri.Mixed.textColorCurrentValue())
+    assertEquals(null, (null as Tri<TextColorValue>?).textColorCurrentValue())
+  }
+
+  @Test
+  fun `backgroundColorCurrentValue maps uniform to its value`() {
+    assertEquals(
+      "yellow",
+      Tri.Uniform(BackgroundColorValue("yellow")).backgroundColorCurrentValue(),
+    )
+  }
+
+  @Test
+  fun `backgroundColorCurrentValue maps absent to none`() {
+    assertEquals("none", Tri.Absent.backgroundColorCurrentValue())
+  }
+
+  @Test
+  fun `backgroundColorCurrentValue maps mixed and null to null`() {
+    assertEquals(null, Tri.Mixed.backgroundColorCurrentValue())
+    assertEquals(null, (null as Tri<BackgroundColorValue>?).backgroundColorCurrentValue())
+  }
+
   @Test
   fun `toolbarFontWeightLabel uses numeric fallback for available unnamed weight`() {
     assertEquals("950", toolbarFontWeightLabel(950))

--- a/apps/website/src/lib/editor-ffi/components/toolbar/BottomToolbar.svelte
+++ b/apps/website/src/lib/editor-ffi/components/toolbar/BottomToolbar.svelte
@@ -69,7 +69,11 @@
   };
 
   const currentTextColor = $derived(
-    ctx.editor?.modifierState?.text_color?.type === 'uniform' ? ctx.editor.modifierState.text_color.value.value : undefined,
+    ctx.editor?.modifierState?.text_color?.type === 'uniform'
+      ? ctx.editor.modifierState.text_color.value.value
+      : ctx.editor?.modifierState?.text_color?.type === 'absent'
+        ? 'black'
+        : undefined,
   );
 
   const currentTextBackgroundColor = $derived(


### PR DESCRIPTION
이로 인해 text_color/background_color가 툴바에서 제대로 표시되지 않는 문제를 해결함
