### PR TITLE
앱 이미지/파일 첨부 흐름 개선

### DIFF
--- a/apps/api/schema.graphql
+++ b/apps/api/schema.graphql
@@ -204,6 +204,7 @@ input DeleteWidgetInput {
 type Document implements IDocument {
   allowReaction: Boolean!
   assets: [DocumentAsset!]!
+  assetsByIds(ids: [ID!]!): [DocumentAsset!]!
   characterCount: Int!
   characterCountChange: CharacterCountChange!
   commentThreads(resolved: Boolean): [DocumentCommentThread!]!
@@ -449,6 +450,7 @@ type DocumentVersionMeta {
 type DocumentView implements IDocument {
   allowReaction: Boolean!
   assets: [DocumentAsset!]!
+  assetsByIds(ids: [ID!]!): [DocumentAsset!]!
   availableActions: [DocumentAvailableAction!]!
   body: DocumentViewBody!
   createdAt: DateTime!
@@ -683,6 +685,7 @@ input GenerateSingleSignOnAuthorizationUrlInput {
 
 interface IDocument {
   assets: [DocumentAsset!]!
+  assetsByIds(ids: [ID!]!): [DocumentAsset!]!
   createdAt: DateTime!
   excerpt: String!
   fontFamilies(sources: [FontFamilySource!]! = [DEFAULT, USER]): [DocumentFontFamily!]!

--- a/apps/api/src/graphql/resolvers/document-asset-policy.test.ts
+++ b/apps/api/src/graphql/resolvers/document-asset-policy.test.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { selectAuthorizedDocumentAssetIds, validateAndCanonicalizeDocumentAssetIds } from './document-asset-policy.ts';
+
+test('owner can resolve an asset before document materialization', () => {
+  assert.deepEqual(
+    selectAuthorizedDocumentAssetIds({
+      canonicalIds: ['IMG0OWNER'],
+      ownedIds: ['IMG0OWNER'],
+      referencedIds: [],
+    }),
+    ['IMG0OWNER'],
+  );
+});
+
+test('collaborator can resolve an asset after it is materialized in the document', () => {
+  assert.deepEqual(
+    selectAuthorizedDocumentAssetIds({
+      canonicalIds: ['FILE0SHARED'],
+      ownedIds: [],
+      referencedIds: ['FILE0SHARED'],
+    }),
+    ['FILE0SHARED'],
+  );
+});
+
+test('unowned and unreferenced asset ids are rejected without revealing a reason', () => {
+  assert.deepEqual(
+    selectAuthorizedDocumentAssetIds({
+      canonicalIds: ['EMBD0OTHER'],
+      ownedIds: [],
+      referencedIds: [],
+    }),
+    [],
+  );
+});
+
+test('requested ids are canonicalized while preserving request order', () => {
+  assert.deepEqual(validateAndCanonicalizeDocumentAssetIds(['FILE0B', 'IMG0A', 'FILE0B']), ['FILE0B', 'IMG0A']);
+});
+
+test('oversized requests are rejected before authorization work', () => {
+  assert.throws(() => validateAndCanonicalizeDocumentAssetIds(Array.from({ length: 51 }, (_, index) => `IMG0${index}`)));
+});
+
+test('unsupported and malformed ids are rejected', () => {
+  for (const id of ['U0USER', 'IMG-not-an-id']) {
+    assert.throws(() => validateAndCanonicalizeDocumentAssetIds([id]));
+  }
+});

--- a/apps/api/src/graphql/resolvers/document-asset-policy.ts
+++ b/apps/api/src/graphql/resolvers/document-asset-policy.ts
@@ -1,0 +1,46 @@
+import { TableCode } from '../../db/schemas/codes.ts';
+import { decodeDbId } from '../../db/schemas/id.ts';
+
+export const MAX_DOCUMENT_ASSET_IDS = 50;
+
+const supportedTableCodes = new Set<string>([TableCode.IMAGES, TableCode.FILES, TableCode.EMBEDS, TableCode.DOCUMENT_ARCHIVED_NODES]);
+
+const dbIdPattern = /^[A-Z]+0[A-Z0-9]+$/;
+
+export function validateAndCanonicalizeDocumentAssetIds(requestedIds: readonly string[]): string[] {
+  if (requestedIds.length > MAX_DOCUMENT_ASSET_IDS) {
+    throw new Error('Too many document asset ids');
+  }
+
+  const canonicalIds: string[] = [];
+  const seen = new Set<string>();
+  for (const id of requestedIds) {
+    if (!dbIdPattern.test(id) || !supportedTableCodes.has(decodeDbId(id))) {
+      throw new Error('Invalid document asset id');
+    }
+    if (!seen.has(id)) {
+      seen.add(id);
+      canonicalIds.push(id);
+    }
+  }
+
+  return canonicalIds;
+}
+
+export function selectAuthorizedDocumentAssetIds({
+  canonicalIds,
+  ownedIds,
+  referencedIds,
+}: {
+  canonicalIds: readonly string[];
+  ownedIds: readonly string[];
+  referencedIds: readonly string[];
+}): string[] {
+  const authorizedIds = new Set([...ownedIds, ...referencedIds]);
+  return canonicalIds.filter((id) => authorizedIds.has(id));
+}
+
+export function isOwnershipCapableDocumentAssetId(id: string): boolean {
+  const tableCode = decodeDbId(id);
+  return tableCode === TableCode.IMAGES || tableCode === TableCode.FILES || tableCode === TableCode.EMBEDS;
+}

--- a/apps/api/src/graphql/resolvers/document-assets-by-ids.test.ts
+++ b/apps/api/src/graphql/resolvers/document-assets-by-ids.test.ts
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { resolveDocumentAssetsByIds } from './document-assets-by-ids.ts';
+import type { DocumentAssetAccess } from './document-assets-by-ids.ts';
+
+test('resolver combines owner and materialized-reference access across asset types', async () => {
+  const ownershipRequests: string[][] = [];
+  const access: DocumentAssetAccess = {
+    loadOwnedIds: async ({ ids }) => {
+      ownershipRequests.push(ids);
+      return ['IMG0OWNED'];
+    },
+    loadReferencedIds: async () => ['FILE0SHARED', 'DAN0ARCHIVED'],
+  };
+
+  const result = await resolveDocumentAssetsByIds({
+    documentId: 'D0DOCUMENT',
+    userId: 'U0VIEWER',
+    requestedIds: ['IMG0OWNED', 'FILE0SHARED', 'EMBD0MISSING', 'DAN0ARCHIVED'],
+    access,
+  });
+
+  assert.deepEqual(result, ['IMG0OWNED', 'FILE0SHARED', 'DAN0ARCHIVED']);
+  assert.deepEqual(ownershipRequests, [['IMG0OWNED', 'FILE0SHARED', 'EMBD0MISSING']]);
+});
+
+test('owner resolves before materialization while an unrelated user asset remains hidden', async () => {
+  const access: DocumentAssetAccess = {
+    loadOwnedIds: async () => ['EMBD0OWNED'],
+    loadReferencedIds: async () => [],
+  };
+
+  assert.deepEqual(
+    await resolveDocumentAssetsByIds({
+      documentId: 'D0DOCUMENT',
+      userId: 'U0OWNER',
+      requestedIds: ['EMBD0OWNED', 'IMG0OTHER'],
+      access,
+    }),
+    ['EMBD0OWNED'],
+  );
+});
+
+test('anonymous or collaborator access uses materialized references only', async () => {
+  let ownershipLoads = 0;
+  const access: DocumentAssetAccess = {
+    loadOwnedIds: async () => {
+      ownershipLoads += 1;
+      return ['IMG0OTHER'];
+    },
+    loadReferencedIds: async () => ['FILE0SHARED'],
+  };
+
+  assert.deepEqual(
+    await resolveDocumentAssetsByIds({
+      documentId: 'D0DOCUMENT',
+      userId: null,
+      requestedIds: ['IMG0OTHER', 'FILE0SHARED'],
+      access,
+    }),
+    ['FILE0SHARED'],
+  );
+  assert.equal(ownershipLoads, 0);
+});
+
+test('archived nodes are reference-only even for authenticated users', async () => {
+  let requestedOwnedIds: string[] | null = null;
+  const access: DocumentAssetAccess = {
+    loadOwnedIds: async ({ ids }) => {
+      requestedOwnedIds = ids;
+      return ids;
+    },
+    loadReferencedIds: async () => [],
+  };
+
+  assert.deepEqual(
+    await resolveDocumentAssetsByIds({
+      documentId: 'D0DOCUMENT',
+      userId: 'U0USER',
+      requestedIds: ['DAN0ARCHIVED'],
+      access,
+    }),
+    [],
+  );
+  assert.equal(requestedOwnedIds, null);
+});
+
+test('empty input returns before the access gateway is invoked', async () => {
+  let calls = 0;
+  const access: DocumentAssetAccess = {
+    loadOwnedIds: async () => {
+      calls += 1;
+      return [];
+    },
+    loadReferencedIds: async () => {
+      calls += 1;
+      return [];
+    },
+  };
+
+  assert.deepEqual(
+    await resolveDocumentAssetsByIds({
+      documentId: 'D0DOCUMENT',
+      userId: 'U0USER',
+      requestedIds: [],
+      access,
+    }),
+    [],
+  );
+  assert.equal(calls, 0);
+});
+
+test('invalid input is rejected before the access gateway is invoked', async () => {
+  let calls = 0;
+  const access: DocumentAssetAccess = {
+    loadOwnedIds: async () => {
+      calls += 1;
+      return [];
+    },
+    loadReferencedIds: async () => {
+      calls += 1;
+      return [];
+    },
+  };
+
+  await assert.rejects(() =>
+    resolveDocumentAssetsByIds({
+      documentId: 'D0DOCUMENT',
+      userId: 'U0USER',
+      requestedIds: ['U0PROBE'],
+      access,
+    }),
+  );
+  assert.equal(calls, 0);
+});

--- a/apps/api/src/graphql/resolvers/document-assets-by-ids.ts
+++ b/apps/api/src/graphql/resolvers/document-assets-by-ids.ts
@@ -1,0 +1,39 @@
+import {
+  isOwnershipCapableDocumentAssetId,
+  selectAuthorizedDocumentAssetIds,
+  validateAndCanonicalizeDocumentAssetIds,
+} from './document-asset-policy.ts';
+
+export type DocumentAssetAccess = {
+  loadOwnedIds(input: { userId: string; ids: string[] }): Promise<readonly string[]>;
+  loadReferencedIds(input: { documentId: string }): Promise<readonly string[]>;
+};
+
+export async function resolveDocumentAssetsByIds({
+  documentId,
+  userId,
+  requestedIds,
+  access,
+}: {
+  documentId: string;
+  userId: string | null;
+  requestedIds: readonly string[];
+  access: DocumentAssetAccess;
+}): Promise<string[]> {
+  const canonicalIds = validateAndCanonicalizeDocumentAssetIds(requestedIds);
+  if (canonicalIds.length === 0) {
+    return [];
+  }
+  const ownershipCandidateIds = canonicalIds.filter(isOwnershipCapableDocumentAssetId);
+
+  const [ownedIds, referencedIds] = await Promise.all([
+    userId !== null && ownershipCandidateIds.length > 0 ? access.loadOwnedIds({ userId, ids: ownershipCandidateIds }) : Promise.resolve([]),
+    access.loadReferencedIds({ documentId }),
+  ]);
+
+  return selectAuthorizedDocumentAssetIds({
+    canonicalIds,
+    ownedIds,
+    referencedIds,
+  });
+}

--- a/apps/api/src/graphql/resolvers/document.ts
+++ b/apps/api/src/graphql/resolvers/document.ts
@@ -104,6 +104,7 @@ import {
   isTypeOf,
   User,
 } from '../objects.ts';
+import { resolveDocumentAssetsByIds } from './document-assets-by-ids.ts';
 import type { PlainDoc } from '@typie/editor-ffi/server';
 import type { Context } from '#/context.ts';
 import type { TemplatePreset } from '#/utils/entity.ts';
@@ -128,6 +129,108 @@ const DocumentAsset = builder.loadableUnion('DocumentAsset', {
   toKey: (item) => item.id,
   sort: true,
 });
+
+type MaterializedDocumentAssetIds = {
+  imageIds: string[];
+  fileIds: string[];
+  embedIds: string[];
+  archivedIds: string[];
+};
+
+async function loadMaterializedDocumentAssetIds(documentId: string): Promise<MaterializedDocumentAssetIds> {
+  const state = await db
+    .select({ json: DocumentStates.json })
+    .from(DocumentStates)
+    .where(eq(DocumentStates.documentId, documentId))
+    .then(first);
+
+  let assetIds: { imageIds: string[]; fileIds: string[]; embedIds: string[]; archivedIds: string[] };
+  if (state) {
+    assetIds = extractAssetIdsFromPlainDoc(state.json as PlainDoc);
+  } else {
+    const content = await db
+      .select({ snapshot: DocumentContents.snapshot })
+      .from(DocumentContents)
+      .where(eq(DocumentContents.documentId, documentId))
+      .then(firstOrThrow);
+    const doc = new LoroDoc();
+    doc.import(content.snapshot);
+    assetIds = extractAssetIdsFromLoroDoc(doc);
+  }
+
+  return assetIds;
+}
+
+async function loadExistingDocumentAssetIds({ imageIds, fileIds, embedIds, archivedIds }: MaterializedDocumentAssetIds): Promise<string[]> {
+  const [existingImageIds, existingFileIds, existingEmbedIds, existingArchivedIds] = await Promise.all([
+    imageIds.length > 0
+      ? db
+          .select({ id: Images.id })
+          .from(Images)
+          .where(inArray(Images.id, imageIds))
+          .then((rows) => rows.map(({ id }) => id))
+      : [],
+    fileIds.length > 0
+      ? db
+          .select({ id: Files.id })
+          .from(Files)
+          .where(inArray(Files.id, fileIds))
+          .then((rows) => rows.map(({ id }) => id))
+      : [],
+    embedIds.length > 0
+      ? db
+          .select({ id: Embeds.id })
+          .from(Embeds)
+          .where(inArray(Embeds.id, embedIds))
+          .then((rows) => rows.map(({ id }) => id))
+      : [],
+    archivedIds.length > 0
+      ? db
+          .select({ id: DocumentArchivedNodes.id })
+          .from(DocumentArchivedNodes)
+          .where(inArray(DocumentArchivedNodes.id, archivedIds))
+          .then((rows) => rows.map(({ id }) => id))
+      : [],
+  ]);
+
+  return [...existingImageIds, ...existingFileIds, ...existingEmbedIds, ...existingArchivedIds];
+}
+
+async function loadReferencedDocumentAssetIds(documentId: string): Promise<string[]> {
+  return await loadExistingDocumentAssetIds(await loadMaterializedDocumentAssetIds(documentId));
+}
+
+async function loadOwnedDocumentAssetIds(userId: string, ids: string[]): Promise<string[]> {
+  const imageIds = ids.filter((id) => decodeDbId(id) === TableCode.IMAGES);
+  const fileIds = ids.filter((id) => decodeDbId(id) === TableCode.FILES);
+  const embedIds = ids.filter((id) => decodeDbId(id) === TableCode.EMBEDS);
+
+  const [ownedImageIds, ownedFileIds, ownedEmbedIds] = await Promise.all([
+    imageIds.length > 0
+      ? db
+          .select({ id: Images.id })
+          .from(Images)
+          .where(and(eq(Images.userId, userId), inArray(Images.id, imageIds)))
+          .then((rows) => rows.map(({ id }) => id))
+      : [],
+    fileIds.length > 0
+      ? db
+          .select({ id: Files.id })
+          .from(Files)
+          .where(and(eq(Files.userId, userId), inArray(Files.id, fileIds)))
+          .then((rows) => rows.map(({ id }) => id))
+      : [],
+    embedIds.length > 0
+      ? db
+          .select({ id: Embeds.id })
+          .from(Embeds)
+          .where(and(eq(Embeds.userId, userId), inArray(Embeds.id, embedIds)))
+          .then((rows) => rows.map(({ id }) => id))
+      : [],
+  ]);
+
+  return [...ownedImageIds, ...ownedFileIds, ...ownedEmbedIds];
+}
 
 IDocument.implement({
   fields: (t) => ({
@@ -180,62 +283,23 @@ IDocument.implement({
     assets: t.field({
       type: [DocumentAsset],
       resolve: async (self) => {
-        const state = await db
-          .select({ json: DocumentStates.json })
-          .from(DocumentStates)
-          .where(eq(DocumentStates.documentId, self.id))
-          .then(first);
+        return await loadReferencedDocumentAssetIds(self.id);
+      },
+    }),
 
-        let imageIds: string[];
-        let fileIds: string[];
-        let embedIds: string[];
-        let archivedIds: string[];
-
-        if (state) {
-          ({ imageIds, fileIds, embedIds, archivedIds } = extractAssetIdsFromPlainDoc(state.json as PlainDoc));
-        } else {
-          const content = await db
-            .select({ snapshot: DocumentContents.snapshot })
-            .from(DocumentContents)
-            .where(eq(DocumentContents.documentId, self.id))
-            .then(firstOrThrow);
-          const doc = new LoroDoc();
-          doc.import(content.snapshot);
-          ({ imageIds, fileIds, embedIds, archivedIds } = extractAssetIdsFromLoroDoc(doc));
-        }
-
-        const [existingImageIds, existingFileIds, existingEmbedIds, existingArchivedIds] = await Promise.all([
-          imageIds.length > 0
-            ? db
-                .select({ id: Images.id })
-                .from(Images)
-                .where(inArray(Images.id, imageIds))
-                .then((r) => r.map((x) => x.id))
-            : [],
-          fileIds.length > 0
-            ? db
-                .select({ id: Files.id })
-                .from(Files)
-                .where(inArray(Files.id, fileIds))
-                .then((r) => r.map((x) => x.id))
-            : [],
-          embedIds.length > 0
-            ? db
-                .select({ id: Embeds.id })
-                .from(Embeds)
-                .where(inArray(Embeds.id, embedIds))
-                .then((r) => r.map((x) => x.id))
-            : [],
-          archivedIds.length > 0
-            ? db
-                .select({ id: DocumentArchivedNodes.id })
-                .from(DocumentArchivedNodes)
-                .where(inArray(DocumentArchivedNodes.id, archivedIds))
-                .then((r) => r.map((x) => x.id))
-            : [],
-        ]);
-
-        return [...existingImageIds, ...existingFileIds, ...existingEmbedIds, ...existingArchivedIds];
+    assetsByIds: t.field({
+      type: [DocumentAsset],
+      args: { ids: t.arg.idList() },
+      resolve: async (self, { ids }, ctx) => {
+        return await resolveDocumentAssetsByIds({
+          documentId: self.id,
+          userId: ctx.session?.userId ?? null,
+          requestedIds: ids,
+          access: {
+            loadOwnedIds: async ({ userId, ids }) => await loadOwnedDocumentAssetIds(userId, ids),
+            loadReferencedIds: async ({ documentId }) => await loadReferencedDocumentAssetIds(documentId),
+          },
+        });
       },
     }),
 

--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/platform/FilePicker.android.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/platform/FilePicker.android.kt
@@ -14,18 +14,30 @@ import androidx.compose.ui.platform.LocalContext
 @Composable
 actual fun rememberFilePicker(
   selectionMode: FilePickerSelectionMode,
-  onResult: (List<PickedFile>) -> Unit,
+  onResult: (FilePickerResult) -> Unit,
 ): (mimeType: String) -> Unit {
   val context = LocalContext.current
   val currentOnResult = rememberUpdatedState(onResult)
   val singleLauncher =
     rememberLauncherForActivityResult(contract = ActivityResultContracts.GetContent()) { uri ->
-      currentOnResult.value(uri?.let { context.readPlatformFile(it) }?.let(::listOf) ?: emptyList())
+      currentOnResult.value(
+        if (uri == null) {
+          FilePickerResult.Cancelled
+        } else {
+          aggregateSelectedFiles(listOf(runCatching { context.readPlatformFile(uri) }))
+        }
+      )
     }
   val multipleLauncher =
     rememberLauncherForActivityResult(contract = ActivityResultContracts.GetMultipleContents()) {
       uris ->
-      currentOnResult.value(uris.mapNotNull(context::readPlatformFile))
+      currentOnResult.value(
+        if (uris.isEmpty()) {
+          FilePickerResult.Cancelled
+        } else {
+          aggregateSelectedFiles(uris.map { uri -> runCatching { context.readPlatformFile(uri) } })
+        }
+      )
     }
 
   return remember(singleLauncher, multipleLauncher, selectionMode) {
@@ -38,8 +50,10 @@ actual fun rememberFilePicker(
   }
 }
 
-private fun Context.readPlatformFile(uri: Uri): PickedFile? {
-  val bytes = contentResolver.openInputStream(uri)?.use { it.readBytes() } ?: return null
+private fun Context.readPlatformFile(uri: Uri): PickedFile {
+  val bytes =
+    contentResolver.openInputStream(uri)?.use { it.readBytes() }
+      ?: error("Unable to open selected file")
   val mimeType = contentResolver.getType(uri)
   val imageSize = bytes.decodeImageSizeIfNeeded(mimeType)
   val filename =

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/blob/BlobService.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/blob/BlobService.kt
@@ -9,45 +9,67 @@ import io.ktor.client.request.forms.formData
 import io.ktor.client.request.forms.submitFormWithBinaryData
 import io.ktor.http.HttpHeaders
 import io.ktor.http.headers
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+
+internal enum class BlobUploadStage {
+  IssueUploadUrl,
+  TransferBytes,
+}
+
+internal class BlobUploadException(val stage: BlobUploadStage, cause: Throwable) :
+  RuntimeException("Blob upload failed at $stage", cause)
 
 object BlobService {
   suspend fun uploadBytes(bytes: ByteArray, filename: String, mimeType: String?): String {
     val resolvedMimeType = mimeType ?: "application/octet-stream"
     val result =
-      Apollo.executeMutation(
-        BlobService_IssueBlobUploadUrl_Mutation(
-          input = IssueBlobUploadUrlInput(filename = filename)
-        )
-      )
-
-    Http.submitFormWithBinaryData(
-      url = result.issueBlobUploadUrl.url,
-      formData =
-        formData {
-          result.issueBlobUploadUrl.fields.jsonObject.asStringMap().forEach {
-            append(it.key, it.value)
-          }
-
-          append("Content-Type", resolvedMimeType)
-
-          append(
-            key = "file",
-            value = bytes,
-            headers =
-              headers {
-                append(HttpHeaders.ContentType, resolvedMimeType)
-                append(HttpHeaders.ContentDisposition, """filename="$filename"""")
-              },
+      withBlobUploadStage(BlobUploadStage.IssueUploadUrl) {
+        Apollo.executeMutation(
+          BlobService_IssueBlobUploadUrl_Mutation(
+            input = IssueBlobUploadUrlInput(filename = filename)
           )
-        },
-    )
+        )
+      }
+
+    withBlobUploadStage(BlobUploadStage.TransferBytes) {
+      Http.submitFormWithBinaryData(
+        url = result.issueBlobUploadUrl.url,
+        formData =
+          formData {
+            result.issueBlobUploadUrl.fields.jsonObject.asStringMap().forEach {
+              append(it.key, it.value)
+            }
+
+            append("Content-Type", resolvedMimeType)
+
+            append(
+              key = "file",
+              value = bytes,
+              headers =
+                headers {
+                  append(HttpHeaders.ContentType, resolvedMimeType)
+                  append(HttpHeaders.ContentDisposition, """filename="$filename"""")
+                },
+            )
+          },
+      )
+    }
 
     return result.issueBlobUploadUrl.path
   }
 }
+
+private suspend inline fun <T> withBlobUploadStage(stage: BlobUploadStage, block: () -> T): T =
+  try {
+    block()
+  } catch (error: CancellationException) {
+    throw error
+  } catch (error: Throwable) {
+    throw BlobUploadException(stage = stage, cause = error)
+  }
 
 private fun JsonObject.asStringMap(): Map<String, String> {
   return mapValues { it.value.jsonPrimitive.content }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/entity/share/DocumentShareSheet.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/entity/share/DocumentShareSheet.kt
@@ -25,6 +25,7 @@ import co.typie.graphql.fragment.DocumentShare_entity
 import co.typie.graphql.type.DocumentContentRating
 import co.typie.graphql.type.EntityVisibility
 import co.typie.icons.Lucide
+import co.typie.platform.FilePickerResult
 import co.typie.platform.PickedFile
 import co.typie.platform.PlatformModule
 import co.typie.platform.rememberFilePicker
@@ -455,9 +456,17 @@ internal fun DocumentShareSheet(
     }
   }
 
-  val filePicker = rememberFilePicker { files ->
+  val filePicker = rememberFilePicker { result ->
     if (loading) return@rememberFilePicker
-    val file = files.firstOrNull() ?: return@rememberFilePicker
+    val file =
+      when (result) {
+        FilePickerResult.Cancelled -> return@rememberFilePicker
+        is FilePickerResult.Failed -> {
+          toast.error("대표 이미지를 불러오지 못했어요.")
+          return@rememberFilePicker
+        }
+        is FilePickerResult.Selected -> result.files.first()
+      }
     if (isUploadingThumbnail || isRemovingThumbnail) return@rememberFilePicker
 
     isUploadingThumbnail = true

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/entity/share/FolderShareSheet.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/entity/share/FolderShareSheet.kt
@@ -16,6 +16,7 @@ import co.typie.form.FormState
 import co.typie.graphql.fragment.FolderShare_entity
 import co.typie.graphql.type.EntityVisibility
 import co.typie.icons.Lucide
+import co.typie.platform.FilePickerResult
 import co.typie.platform.PickedFile
 import co.typie.platform.PlatformModule
 import co.typie.platform.rememberFilePicker
@@ -262,9 +263,17 @@ internal fun FolderShareSheet(
     }
   }
 
-  val filePicker = rememberFilePicker { files ->
+  val filePicker = rememberFilePicker { result ->
     if (loading) return@rememberFilePicker
-    val file = files.firstOrNull() ?: return@rememberFilePicker
+    val file =
+      when (result) {
+        FilePickerResult.Cancelled -> return@rememberFilePicker
+        is FilePickerResult.Failed -> {
+          toast.error("대표 이미지를 불러오지 못했어요.")
+          return@rememberFilePicker
+        }
+        is FilePickerResult.Selected -> result.files.first()
+      }
     if (isUploadingThumbnail || isRemovingThumbnail) return@rememberFilePicker
 
     isUploadingThumbnail = true

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/external/EditorEmbedExternalElement.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/external/EditorEmbedExternalElement.kt
@@ -34,14 +34,22 @@ import io.ktor.http.Url
 @Composable
 context(scope: EditorExternalElementRenderScope)
 internal fun EditorEmbedExternalElement(data: ExternalElementData.Embed, nodeId: String) {
-  val embedState = LocalEditorExternalElementState.current.embeds
+  val externalElementState = LocalEditorExternalElementState.current
+  val embedState = externalElementState.embeds
   val asset = data.id?.let(embedState.assets::get)
   val unfurl = embedState.unfurls[nodeId]
-  val resolvingAsset = data.id != null && asset == null && unfurl == null
+  val resolution = data.id?.let(externalElementState.resolutions::get)
+  val missingAsset = data.id != null && asset == null && unfurl == null
+  val unavailableAsset =
+    missingAsset &&
+      (resolution == EditorAssetResolution.RetryableFailure ||
+        resolution == EditorAssetResolution.Unavailable)
+  val resolvingAsset = missingAsset && !unavailableAsset
 
   when {
     asset != null -> EmbedCard(asset)
     unfurl != null || resolvingAsset -> EmbedLoading()
+    unavailableAsset -> EmbedUnavailable()
     else -> EmbedPlaceholder()
   }
 }
@@ -70,6 +78,12 @@ private fun EmbedLoading() {
       )
     },
   )
+}
+
+@Composable
+context(scope: EditorExternalElementRenderScope)
+private fun EmbedUnavailable() {
+  EditorExternalElementPlaceholder(icon = Lucide.FileUp, text = "링크를 불러올 수 없어요")
 }
 
 @Composable

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/external/EditorExternalElementState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/external/EditorExternalElementState.kt
@@ -9,12 +9,35 @@ internal class EditorExternalElementState {
   val images = EditorExternalImageElementState()
   val files = EditorExternalFileElementState()
   val embeds = EditorExternalEmbedElementState()
+  val resolutions = mutableStateMapOf<String, EditorAssetResolution>()
+
+  fun put(asset: EditorExternalAsset) {
+    when (asset) {
+      is EditorImageAsset -> images.assets[asset.id] = asset
+      is EditorFileAsset -> files.assets[asset.id] = asset
+      is EditorEmbedAsset -> embeds.assets[asset.id] = asset
+    }
+  }
 
   fun clear() {
     images.clear()
     files.clear()
     embeds.clear()
+    resolutions.clear()
   }
+
+  fun containsAsset(id: String): Boolean =
+    images.assets.containsKey(id) || files.assets.containsKey(id) || embeds.assets.containsKey(id)
+}
+
+internal sealed interface EditorAssetResolution {
+  data object InFlight : EditorAssetResolution
+
+  data object RetryableFailure : EditorAssetResolution
+
+  data class AwaitingMaterialization(val attempt: Int) : EditorAssetResolution
+
+  data object Unavailable : EditorAssetResolution
 }
 
 @Stable
@@ -56,30 +79,34 @@ internal class EditorExternalEmbedElementState {
   }
 }
 
+internal sealed interface EditorExternalAsset {
+  val id: String
+}
+
 internal data class EditorFileAsset(
-  val id: String,
+  override val id: String,
   val name: String,
   val url: String,
   val size: Long?,
-)
+) : EditorExternalAsset
 
 internal data class EditorImageAsset(
-  val id: String,
+  override val id: String,
   val url: String,
   val width: Int,
   val height: Int,
   val ratio: Double,
   val placeholder: String?,
-)
+) : EditorExternalAsset
 
 internal data class EditorEmbedAsset(
-  val id: String,
+  override val id: String,
   val url: String,
   val title: String?,
   val description: String?,
   val thumbnailUrl: String?,
   val html: String?,
-)
+) : EditorExternalAsset
 
 internal class EditorEmbedUnfurl
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/external/EditorFileExternalElement.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/external/EditorFileExternalElement.kt
@@ -29,16 +29,23 @@ import kotlin.math.roundToInt
 @Composable
 context(scope: EditorExternalElementRenderScope)
 internal fun EditorFileExternalElement(data: ExternalElementData.File, nodeId: String) {
-  val fileState = LocalEditorExternalElementState.current.files
+  val externalElementState = LocalEditorExternalElementState.current
+  val fileState = externalElementState.files
   val upload = fileState.uploads[nodeId]
   val asset = data.id?.let(fileState.assets::get)
   val hasFile = asset != null || upload != null
-  val resolvingAsset = data.id != null && asset == null && upload == null
+  val resolution = data.id?.let(externalElementState.resolutions::get)
+  val missingAsset = data.id != null && asset == null && upload == null
+  val unavailableAsset =
+    missingAsset &&
+      (resolution == EditorAssetResolution.RetryableFailure ||
+        resolution == EditorAssetResolution.Unavailable)
+  val resolvingAsset = missingAsset && !unavailableAsset
   val displayName = asset?.name ?: upload?.name ?: "파일"
   val displaySize = formatFileSize(asset?.size ?: upload?.size)
 
   if (!hasFile) {
-    FilePlaceholder(resolvingAsset = resolvingAsset)
+    FilePlaceholder(resolvingAsset = resolvingAsset, unavailableAsset = unavailableAsset)
     return
   }
 
@@ -98,12 +105,17 @@ internal fun EditorFileExternalElement(data: ExternalElementData.File, nodeId: S
 
 @Composable
 context(scope: EditorExternalElementRenderScope)
-private fun FilePlaceholder(resolvingAsset: Boolean) {
+private fun FilePlaceholder(resolvingAsset: Boolean, unavailableAsset: Boolean) {
   Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
     Box(modifier = Modifier.widthIn(max = scope.scaledDp(400f)).fillMaxWidth()) {
       EditorExternalElementPlaceholder(
         icon = Lucide.File,
-        text = if (resolvingAsset) "파일을 불러오는 중..." else "파일",
+        text =
+          when {
+            unavailableAsset -> "파일을 불러올 수 없어요"
+            resolvingAsset -> "파일을 불러오는 중..."
+            else -> "파일"
+          },
         trailing = {
           if (resolvingAsset) {
             Spinner(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/external/EditorImageExternalElement.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/external/EditorImageExternalElement.kt
@@ -54,11 +54,18 @@ internal fun EditorImageExternalElement(
 ) {
   val density = LocalDensity.current
   val editor = LocalEditorRuntime.current.editor
-  val imageState = LocalEditorExternalElementState.current.images
+  val externalElementState = LocalEditorExternalElementState.current
+  val imageState = externalElementState.images
   val upload = imageState.uploads[nodeId]
   val asset = data.id?.let(imageState.assets::get)
   val hasImage = asset != null || upload != null
-  val resolvingAsset = data.id != null && asset == null && upload == null
+  val resolution = data.id?.let(externalElementState.resolutions::get)
+  val missingAsset = data.id != null && asset == null && upload == null
+  val unavailableAsset =
+    missingAsset &&
+      (resolution == EditorAssetResolution.RetryableFailure ||
+        resolution == EditorAssetResolution.Unavailable)
+  val resolvingAsset = missingAsset && !unavailableAsset
   val ratio = asset?.ratio ?: upload?.ratio
   var activeResizeReverse by remember(nodeId) { mutableStateOf<Boolean?>(null) }
 
@@ -70,7 +77,7 @@ internal fun EditorImageExternalElement(
   }
 
   if (!hasImage) {
-    ImagePlaceholder(resolvingAsset = resolvingAsset)
+    ImagePlaceholder(resolvingAsset = resolvingAsset, unavailableAsset = unavailableAsset)
     return
   }
 
@@ -219,10 +226,15 @@ internal fun EditorImageExternalElement(
 
 @Composable
 context(scope: EditorExternalElementRenderScope)
-private fun ImagePlaceholder(resolvingAsset: Boolean) {
+private fun ImagePlaceholder(resolvingAsset: Boolean, unavailableAsset: Boolean) {
   EditorExternalElementPlaceholder(
     icon = Lucide.Image,
-    text = if (resolvingAsset) "이미지를 불러오는 중..." else "이미지",
+    text =
+      when {
+        unavailableAsset -> "이미지를 불러올 수 없어요"
+        resolvingAsset -> "이미지를 불러오는 중..."
+        else -> "이미지"
+      },
     trailing = {
       if (resolvingAsset) {
         Spinner(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/platform/FilePicker.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/platform/FilePicker.kt
@@ -15,11 +15,40 @@ enum class FilePickerSelectionMode {
   Multiple,
 }
 
+sealed interface FilePickerResult {
+  data object Cancelled : FilePickerResult
+
+  data class Selected(val files: List<PickedFile>, val unreadableCount: Int = 0) :
+    FilePickerResult {
+    init {
+      require(files.isNotEmpty())
+      require(unreadableCount >= 0)
+    }
+  }
+
+  data class Failed(val cause: Throwable) : FilePickerResult
+}
+
 @Composable
 expect fun rememberFilePicker(
   selectionMode: FilePickerSelectionMode = FilePickerSelectionMode.Single,
-  onResult: (List<PickedFile>) -> Unit,
+  onResult: (FilePickerResult) -> Unit,
 ): (mimeType: String) -> Unit
+
+internal fun aggregateSelectedFiles(files: List<Result<PickedFile>>): FilePickerResult {
+  val readableFiles = files.mapNotNull(Result<PickedFile>::getOrNull)
+  if (readableFiles.isNotEmpty()) {
+    return FilePickerResult.Selected(
+      files = readableFiles,
+      unreadableCount = files.size - readableFiles.size,
+    )
+  }
+
+  return FilePickerResult.Failed(
+    files.firstNotNullOfOrNull(Result<PickedFile>::exceptionOrNull)
+      ?: IllegalStateException("File picker returned no selected files")
+  )
+}
 
 internal fun pickedFilename(originalFilename: String?, mimeType: String?): String {
   val trimmedFilename = originalFilename?.trim()?.takeIf { it.isNotEmpty() }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorAssetHydrator.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorAssetHydrator.kt
@@ -1,0 +1,268 @@
+package co.typie.screen.editor.editor
+
+import co.touchlab.kermit.Logger
+import co.typie.editor.external.EditorAssetResolution
+import co.typie.editor.external.EditorExternalAsset
+import co.typie.editor.external.EditorExternalElementState
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+internal class EditorAssetHydrator(
+  private val state: EditorExternalElementState,
+  private val fetch: suspend (List<String>) -> List<EditorExternalAsset>,
+  private val waitBeforeRetry: suspend (attempt: Int) -> Unit = { attempt ->
+    delay(if (attempt == 1) 500 else 1_500)
+  },
+) {
+  private data class Request(
+    val ids: List<String>,
+    val queryGeneration: Long,
+    val connectivityGeneration: Long,
+    val recoveryIds: Set<String>,
+  )
+
+  private data class Retry(val attempts: Map<String, Int>)
+
+  private val stateMutex = Mutex()
+  private val resolverMutex = Mutex()
+  private var referencedIds = emptySet<String>()
+  private var queryGeneration = Long.MIN_VALUE
+  private var lastConnectivityGeneration = Long.MIN_VALUE
+  private val materializationAttempts = mutableMapOf<String, Int>()
+  private val recoveryProbeIds = mutableSetOf<String>()
+
+  suspend fun seed(assets: Collection<EditorExternalAsset>) {
+    stateMutex.withLock { mergeAssets(assets) }
+  }
+
+  suspend fun resolve(ids: Collection<String>) {
+    updateReferences(ids)
+    drain()
+  }
+
+  suspend fun onQueryRefresh(generation: Long, assets: Collection<EditorExternalAsset>) {
+    val startsNewGeneration = stateMutex.withLock {
+      mergeAssets(assets)
+      if (generation <= queryGeneration) {
+        false
+      } else {
+        queryGeneration = generation
+        for (id in referencedIds) {
+          materializationAttempts.remove(id)
+          recoveryProbeIds.remove(id)
+          state.resolutions.remove(id)
+        }
+        true
+      }
+    }
+
+    if (startsNewGeneration) {
+      drain()
+    }
+  }
+
+  suspend fun onConnectivityRestored(generation: Long) {
+    val startsNewGeneration = stateMutex.withLock {
+      if (generation <= lastConnectivityGeneration) {
+        false
+      } else {
+        lastConnectivityGeneration = generation
+        for (id in referencedIds) {
+          when (state.resolutions[id]) {
+            EditorAssetResolution.RetryableFailure -> state.resolutions.remove(id)
+            EditorAssetResolution.Unavailable -> recoveryProbeIds.add(id)
+            else -> Unit
+          }
+        }
+        true
+      }
+    }
+
+    if (startsNewGeneration) {
+      drain()
+    }
+  }
+
+  private suspend fun updateReferences(ids: Collection<String>) {
+    val nextIds = ids.toSet()
+    stateMutex.withLock {
+      for (removedId in referencedIds - nextIds) {
+        state.resolutions.remove(removedId)
+        materializationAttempts.remove(removedId)
+        recoveryProbeIds.remove(removedId)
+      }
+      referencedIds = nextIds
+    }
+  }
+
+  private suspend fun drain() {
+    resolverMutex.withLock {
+      while (true) {
+        val request = stateMutex.withLock { nextRequest() } ?: return
+        val assets =
+          try {
+            fetch(request.ids)
+          } catch (error: CancellationException) {
+            clearTransientRequestState(request.ids)
+            throw error
+          } catch (error: Throwable) {
+            val generationChanged = markFetchFailure(request)
+            if (generationChanged) {
+              continue
+            }
+            Logger.w(error) { "Editor asset hydration failed" }
+            return
+          }
+
+        val retry = stateMutex.withLock { mergeResponse(request, assets) }
+        if (retry != null) {
+          try {
+            waitBeforeRetry(retry.attempts.values.max())
+          } catch (error: CancellationException) {
+            clearTransientRequestState(retry.attempts.keys)
+            throw error
+          }
+          stateMutex.withLock {
+            for ((id, attempt) in retry.attempts) {
+              if (state.resolutions[id] == EditorAssetResolution.AwaitingMaterialization(attempt)) {
+                state.resolutions.remove(id)
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private fun nextRequest(): Request? {
+    val ids =
+      referencedIds
+        .asSequence()
+        .filterNot(state::containsAsset)
+        .filter { id -> recoveryProbeIds.contains(id) || state.resolutions[id] == null }
+        .sorted()
+        .take(MaxBatchSize)
+        .toList()
+    if (ids.isEmpty()) {
+      return null
+    }
+
+    ids.forEach { id -> state.resolutions[id] = EditorAssetResolution.InFlight }
+    return Request(
+      ids = ids,
+      queryGeneration = queryGeneration,
+      connectivityGeneration = lastConnectivityGeneration,
+      recoveryIds = ids.filterTo(mutableSetOf(), recoveryProbeIds::contains),
+    )
+  }
+
+  private suspend fun clearTransientRequestState(ids: Collection<String>) {
+    stateMutex.withLock {
+      for (id in ids) {
+        when (state.resolutions[id]) {
+          EditorAssetResolution.InFlight,
+          is EditorAssetResolution.AwaitingMaterialization -> state.resolutions.remove(id)
+          else -> Unit
+        }
+      }
+    }
+  }
+
+  private suspend fun markFetchFailure(request: Request): Boolean = stateMutex.withLock {
+    if (request.isObsolete()) {
+      request.ids.forEach { id ->
+        if (state.resolutions[id] == EditorAssetResolution.InFlight) {
+          state.resolutions.remove(id)
+        }
+      }
+      true
+    } else {
+      request.ids.forEach { id ->
+        recoveryProbeIds.remove(id)
+        if (id in referencedIds && !state.containsAsset(id)) {
+          state.resolutions[id] = EditorAssetResolution.RetryableFailure
+        } else {
+          state.resolutions.remove(id)
+        }
+      }
+      false
+    }
+  }
+
+  private fun mergeResponse(request: Request, assets: Collection<EditorExternalAsset>): Retry? {
+    val requestedIds = request.ids.toSet()
+    val returnedIds = mutableSetOf<String>()
+    for (asset in assets) {
+      if (asset.id !in requestedIds) {
+        continue
+      }
+      returnedIds.add(asset.id)
+      state.put(asset)
+      state.resolutions.remove(asset.id)
+      materializationAttempts.remove(asset.id)
+      recoveryProbeIds.remove(asset.id)
+    }
+
+    if (request.isObsolete()) {
+      request.ids.forEach { id ->
+        if (id !in returnedIds && state.resolutions[id] == EditorAssetResolution.InFlight) {
+          state.resolutions.remove(id)
+        }
+      }
+      return null
+    }
+
+    val retryAttempts = mutableMapOf<String, Int>()
+    for (id in request.ids) {
+      if (id in returnedIds) {
+        continue
+      }
+      if (id !in referencedIds) {
+        state.resolutions.remove(id)
+        materializationAttempts.remove(id)
+        recoveryProbeIds.remove(id)
+        continue
+      }
+      if (id in request.recoveryIds) {
+        recoveryProbeIds.remove(id)
+        state.resolutions[id] = EditorAssetResolution.Unavailable
+        continue
+      }
+
+      val attempt = (materializationAttempts[id] ?: 0) + 1
+      materializationAttempts[id] = attempt
+      if (attempt >= MaxMaterializationAttempts) {
+        state.resolutions[id] = EditorAssetResolution.Unavailable
+      } else {
+        state.resolutions[id] = EditorAssetResolution.AwaitingMaterialization(attempt)
+        retryAttempts[id] = attempt
+      }
+    }
+
+    return if (retryAttempts.isEmpty()) {
+      null
+    } else {
+      Retry(attempts = retryAttempts)
+    }
+  }
+
+  private fun Request.isObsolete(): Boolean =
+    queryGeneration != this@EditorAssetHydrator.queryGeneration ||
+      connectivityGeneration != lastConnectivityGeneration
+
+  private fun mergeAssets(assets: Collection<EditorExternalAsset>) {
+    for (asset in assets) {
+      state.put(asset)
+      state.resolutions.remove(asset.id)
+      materializationAttempts.remove(asset.id)
+      recoveryProbeIds.remove(asset.id)
+    }
+  }
+
+  private companion object {
+    const val MaxBatchSize = 50
+    const val MaxMaterializationAttempts = 3
+  }
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorExternalAssetMapper.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorExternalAssetMapper.kt
@@ -1,0 +1,64 @@
+package co.typie.screen.editor.editor
+
+import co.typie.editor.external.EditorEmbedAsset
+import co.typie.editor.external.EditorExternalAsset
+import co.typie.editor.external.EditorFileAsset
+import co.typie.editor.external.EditorImageAsset
+import co.typie.graphql.EditorScreen_PersistBlobAsFile_Mutation.PersistBlobAsFile
+import co.typie.graphql.EditorScreen_PersistBlobAsImage_Mutation.PersistBlobAsImage
+import co.typie.graphql.EditorScreen_UnfurlEmbed_Mutation.UnfurlEmbed
+import co.typie.graphql.fragment.EditorExternalAsset_asset
+
+internal fun EditorExternalAsset_asset.toEditorExternalAsset(): EditorExternalAsset? =
+  when (__typename) {
+    "Image" ->
+      onImage?.let { image ->
+        EditorImageAsset(
+          id = image.id,
+          url = image.url,
+          width = image.width,
+          height = image.height,
+          ratio = image.ratio,
+          placeholder = image.placeholder,
+        )
+      }
+    "File" ->
+      onFile?.let { file ->
+        EditorFileAsset(id = file.id, name = file.name, url = file.url, size = file.size)
+      }
+    "Embed" ->
+      onEmbed?.let { embed ->
+        EditorEmbedAsset(
+          id = embed.id,
+          url = embed.url,
+          title = embed.title,
+          description = embed.description,
+          thumbnailUrl = embed.thumbnailUrl,
+          html = embed.html,
+        )
+      }
+    else -> null
+  }
+
+internal fun PersistBlobAsImage.toEditorImageAsset(): EditorImageAsset =
+  EditorImageAsset(
+    id = id,
+    url = url,
+    width = width,
+    height = height,
+    ratio = ratio,
+    placeholder = placeholder,
+  )
+
+internal fun PersistBlobAsFile.toEditorFileAsset(): EditorFileAsset =
+  EditorFileAsset(id = id, name = name, url = url, size = size)
+
+internal fun UnfurlEmbed.toEditorEmbedAsset(): EditorEmbedAsset =
+  EditorEmbedAsset(
+    id = id,
+    url = url,
+    title = title,
+    description = description,
+    thumbnailUrl = thumbnailUrl,
+    html = html,
+  )

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.graphql
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.graphql
@@ -37,32 +37,7 @@ query EditorScreen_Query($entityId: ID!) {
           durableHeads
         }
         assets {
-          __typename
-
-          ... on Image {
-            id
-            url
-            width
-            height
-            ratio
-            placeholder
-          }
-
-          ... on File {
-            id
-            name
-            size
-            url
-          }
-
-          ... on Embed {
-            id
-            url
-            title
-            description
-            thumbnailUrl
-            html
-          }
+          ...EditorExternalAsset_asset
         }
         toolbarFontFamilies: fontFamilies(sources: [DEFAULT, USER, FALLBACK]) {
           ...EditorSettingsFontFamily_family
@@ -70,6 +45,47 @@ query EditorScreen_Query($entityId: ID!) {
         ...FontLoader_Document
       }
     }
+  }
+}
+
+query EditorScreen_AssetsByIds_Query($entityId: ID!, $ids: [ID!]!) {
+  entity(entityId: $entityId) @catch(to: THROW) {
+    node {
+      ... on Document {
+        assetsByIds(ids: $ids) {
+          ...EditorExternalAsset_asset
+        }
+      }
+    }
+  }
+}
+
+fragment EditorExternalAsset_asset on DocumentAsset {
+  __typename
+
+  ... on Image {
+    id
+    url
+    width
+    height
+    ratio
+    placeholder
+  }
+
+  ... on File {
+    id
+    name
+    size
+    url
+  }
+
+  ... on Embed {
+    id
+    url
+    title
+    description
+    thumbnailUrl
+    html
   }
 }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -54,13 +54,11 @@ import co.typie.editor.body.resolveBaseBottomSpace
 import co.typie.editor.body.resolveEditorBodyGeometry
 import co.typie.editor.body.resolvePagesContentHeight
 import co.typie.editor.body.toEditorDocumentLayoutSpec
-import co.typie.editor.external.EditorEmbedAsset
 import co.typie.editor.external.EditorExternalElementState
-import co.typie.editor.external.EditorFileAsset
-import co.typie.editor.external.EditorImageAsset
 import co.typie.editor.external.LocalEditorExternalElementState
 import co.typie.editor.ffi.Direction
 import co.typie.editor.ffi.EditorEvent
+import co.typie.editor.ffi.ExternalElementData
 import co.typie.editor.ffi.HistoryTag
 import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.Movement
@@ -99,6 +97,7 @@ import co.typie.ext.ime
 import co.typie.graphql.QueryState
 import co.typie.navigation.Nav
 import co.typie.platform.PlatformModule
+import co.typie.platform.connectivityRestoredFlow
 import co.typie.route.Route
 import co.typie.screen.document.document.DocumentCharacterCountSnapshots
 import co.typie.screen.editor.editor.aifeedback.AiFeedbackOptInSheet
@@ -200,6 +199,11 @@ fun EditorScreen(entityId: String) {
   val interactionScope = remember(entityId) { EditorInteractionScope(coroutineScope = scope) }
   val uiState = remember(entityId) { EditorUiState() }
   val externalElementState = remember(entityId) { EditorExternalElementState() }
+  val assetHydrator =
+    remember(entityId) {
+      EditorAssetHydrator(state = externalElementState, fetch = model::resolveExternalAssets)
+    }
+  var assetQueryGeneration by remember(entityId) { mutableStateOf(0L) }
   val zoomController = rememberEditorZoomController(key = entityId)
   val screenState = rememberEditorScreenState(key = entityId)
   val subPaneState = remember(entityId) { EditorSubPaneState() }
@@ -230,44 +234,14 @@ fun EditorScreen(entityId: String) {
       loading = loading,
     )
   }
-  LaunchedEffect(document?.assets, loading, externalElementState) {
+  LaunchedEffect(document?.assets, loading, model.reloadGeneration, assetHydrator) {
     if (!loading) {
-      for (asset in document?.assets.orEmpty()) {
-        when (asset.__typename) {
-          "Image" -> {
-            asset.onImage?.let { image ->
-              externalElementState.images.assets[image.id] =
-                EditorImageAsset(
-                  id = image.id,
-                  url = image.url,
-                  width = image.width,
-                  height = image.height,
-                  ratio = image.ratio,
-                  placeholder = image.placeholder,
-                )
-            }
-          }
-          "File" -> {
-            asset.onFile?.let { file ->
-              externalElementState.files.assets[file.id] =
-                EditorFileAsset(id = file.id, name = file.name, url = file.url, size = file.size)
-            }
-          }
-          "Embed" -> {
-            asset.onEmbed?.let { embed ->
-              externalElementState.embeds.assets[embed.id] =
-                EditorEmbedAsset(
-                  id = embed.id,
-                  url = embed.url,
-                  title = embed.title,
-                  description = embed.description,
-                  thumbnailUrl = embed.thumbnailUrl,
-                  html = embed.html,
-                )
-            }
-          }
+      val assets =
+        document?.assets.orEmpty().mapNotNull { asset ->
+          asset.editorExternalAsset_asset.toEditorExternalAsset()
         }
-      }
+      assetQueryGeneration += 1
+      assetHydrator.onQueryRefresh(generation = assetQueryGeneration, assets = assets)
     }
   }
   LaunchedEffect(runtime.error) {
@@ -288,6 +262,30 @@ fun EditorScreen(entityId: String) {
   }
   val editor = runtime.editor
   val editorState = editor?.state ?: EditorState.Initial
+  val externalAssetIds =
+    remember(editorState.externalElements) {
+      editorState.externalElements
+        .mapNotNull { element ->
+          when (val data = element.data) {
+            is ExternalElementData.Image -> data.id
+            is ExternalElementData.File -> data.id
+            is ExternalElementData.Embed -> data.id
+            is ExternalElementData.Archived -> null
+          }
+        }
+        .distinct()
+        .sorted()
+    }
+  LaunchedEffect(assetHydrator, assetQueryGeneration, externalAssetIds) {
+    assetHydrator.resolve(externalAssetIds)
+  }
+  LaunchedEffect(assetHydrator) {
+    var connectivityGeneration = 0L
+    connectivityRestoredFlow().collect {
+      connectivityGeneration += 1
+      assetHydrator.onConnectivityRestored(connectivityGeneration)
+    }
+  }
   LaunchedEffect(subPaneState.active, editorState.selection) {
     subPaneState.dismissTableAxisActionsIfSelectionChanged(editorState.selection)
   }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorViewModel.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorViewModel.kt
@@ -7,7 +7,9 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.typie.editor.FontLoader
+import co.typie.editor.external.EditorExternalAsset
 import co.typie.graphql.Apollo
+import co.typie.graphql.EditorScreen_AssetsByIds_Query
 import co.typie.graphql.EditorScreen_Query
 import co.typie.graphql.EditorScreen_UpdateDocument_Mutation
 import co.typie.graphql.EditorScreen_ViewEntity_Mutation
@@ -180,6 +182,21 @@ class EditorViewModel(val entityId: String) : ViewModel() {
       .fetchPolicy(FetchPolicy.NetworkOnly)
       .execute()
     query.refetch()
+  }
+
+  internal suspend fun resolveExternalAssets(ids: List<String>): List<EditorExternalAsset> {
+    if (ids.isEmpty()) {
+      return emptyList()
+    }
+
+    val data =
+      Apollo.query(EditorScreen_AssetsByIds_Query(entityId = entityId, ids = ids))
+        .fetchPolicy(FetchPolicy.NetworkOnly)
+        .execute()
+        .dataOrThrow()
+    return data.entity.node.onDocument?.assetsByIds.orEmpty().mapNotNull { asset ->
+      asset.editorExternalAsset_asset.toEditorExternalAsset()
+    }
   }
 
   fun flushDraftsAsync() {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarHost.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarHost.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import co.touchlab.kermit.Logger
 import co.typie.editor.EditorState
 import co.typie.editor.ffi.FlatImeOp
 import co.typie.editor.ffi.Message
@@ -236,16 +237,19 @@ internal fun EditorToolbarHost(
     if (messages.isEmpty()) {
       return
     }
-    val editor = runtime.editor ?: return
-    val bringIntoViewTarget = EditorBringIntoViewTarget.CurrentSelectionHead
 
     commandScope.launch {
-      editor.awaitWithBringIntoView(bringIntoViewRequests) {
-        if (editor.ime?.composing != null) {
-          enqueue(Message.TextInput(listOf(FlatImeOp.CommitAsIs)))
+      val editor = runtime.editor ?: return@launch
+      val committedState =
+        editor.awaitWithBringIntoView(bringIntoViewRequests) {
+          if (editor.ime?.composing != null) {
+            enqueue(Message.TextInput(listOf(FlatImeOp.CommitAsIs)))
+          }
+          messages.forEach(::enqueue)
+          beforeCommit { bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead) }
         }
-        messages.forEach { enqueue(it) }
-        beforeCommit { bringIntoView(bringIntoViewTarget) }
+      if (committedState == null) {
+        Logger.e { "Editor toolbar messages did not commit" }
       }
     }
   }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/AttachmentOperation.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/AttachmentOperation.kt
@@ -1,0 +1,72 @@
+package co.typie.screen.editor.editor.toolbar.contextual
+
+import co.touchlab.kermit.Logger
+import co.typie.domain.blob.BlobUploadException
+import io.sentry.kotlin.multiplatform.Sentry
+import kotlinx.coroutines.CancellationException
+
+internal enum class AttachmentKind {
+  Image,
+  File,
+  Embed,
+}
+
+internal enum class AttachmentFailureStage {
+  PersistAsset,
+  CommitDocument,
+}
+
+internal class AttachmentException(val stage: AttachmentFailureStage, cause: Throwable) :
+  RuntimeException("Attachment failed at $stage", cause)
+
+internal suspend fun <Asset> completeAttachmentOperation(
+  persist: suspend () -> Asset,
+  isCurrent: () -> Boolean = { true },
+  cache: (Asset) -> Unit,
+  commit: suspend (Asset) -> Unit,
+  clearPending: () -> Unit,
+): Asset? {
+  try {
+    val asset = withAttachmentStage(AttachmentFailureStage.PersistAsset) { persist() }
+    if (!isCurrent()) {
+      return null
+    }
+    withAttachmentStage(AttachmentFailureStage.PersistAsset) { cache(asset) }
+    withAttachmentStage(AttachmentFailureStage.CommitDocument) { commit(asset) }
+    clearPending()
+    return asset
+  } catch (error: CancellationException) {
+    throw error
+  } catch (error: Throwable) {
+    clearPending()
+    throw error
+  }
+}
+
+private suspend inline fun <T> withAttachmentStage(
+  stage: AttachmentFailureStage,
+  block: () -> T,
+): T =
+  try {
+    block()
+  } catch (error: CancellationException) {
+    throw error
+  } catch (error: BlobUploadException) {
+    throw error
+  } catch (error: AttachmentException) {
+    throw error
+  } catch (error: Throwable) {
+    throw AttachmentException(stage = stage, cause = error)
+  }
+
+internal fun reportAttachmentFailure(kind: AttachmentKind, error: Throwable) {
+  val stage =
+    when (error) {
+      is BlobUploadException -> error.stage.name
+      is AttachmentException -> error.stage.name
+      else -> "Unknown"
+    }
+  val cause = error.cause ?: error
+  Logger.e(cause) { "Attachment failed: kind=${kind.name}, stage=$stage" }
+  Sentry.captureException(cause)
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/EmbedToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/EmbedToolbar.kt
@@ -23,14 +23,20 @@ import androidx.compose.ui.unit.dp
 import co.typie.editor.external.EditorEmbedAsset
 import co.typie.editor.external.EditorEmbedUnfurl
 import co.typie.editor.external.LocalEditorExternalElementState
+import co.typie.editor.ffi.FlatImeOp
 import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.NodeOp
 import co.typie.editor.ffi.PlainNode
+import co.typie.editor.runtime.LocalEditorRuntime
+import co.typie.editor.scroll.EditorBringIntoViewTarget
+import co.typie.editor.scroll.LocalEditorBringIntoViewRequests
+import co.typie.editor.scroll.syncWithBringIntoView
 import co.typie.graphql.Apollo
 import co.typie.graphql.EditorScreen_UnfurlEmbed_Mutation
 import co.typie.graphql.executeMutation
 import co.typie.graphql.type.UnfurlEmbedInput
 import co.typie.icons.Lucide
+import co.typie.screen.editor.editor.toEditorEmbedAsset
 import co.typie.screen.editor.editor.toolbar.EditorToolbarButton
 import co.typie.screen.editor.editor.toolbar.EditorToolbarPage
 import co.typie.screen.editor.editor.toolbar.EditorToolbarPageKey
@@ -72,7 +78,10 @@ private fun EditorEmbedToolbar(
   val dialog = LocalDialog.current
   val toast = LocalToast.current
   val uriHandler = LocalUriHandler.current
-  val embedState = LocalEditorExternalElementState.current.embeds
+  val runtime = LocalEditorRuntime.current
+  val bringIntoViewRequests = LocalEditorBringIntoViewRequests.current
+  val externalElementState = LocalEditorExternalElementState.current
+  val embedState = externalElementState.embeds
   val embedId = embed?.id
   val asset = embedId?.let(embedState.assets::get)
   val unfurling = nodeId?.let { embedState.unfurls.containsKey(it) } == true
@@ -92,25 +101,40 @@ private fun EditorEmbedToolbar(
             embedState.unfurls[selectedNodeId] = unfurl
 
             try {
-              val embedded = unfurlEmbedAsset(url)
-              if (embedState.unfurls[selectedNodeId] !== unfurl) {
-                return@launch
-              }
-
-              embedState.assets[embedded.id] = embedded
-              scope.sendMessage(
-                Message.Node(
-                  NodeOp.SetAttrs(id = selectedNodeId, attrs = PlainNode.Embed(id = embedded.id))
-                )
+              completeAttachmentOperation(
+                persist = { unfurlEmbedAsset(url) },
+                isCurrent = { embedState.unfurls[selectedNodeId] === unfurl },
+                cache = externalElementState::put,
+                commit = { embedded ->
+                  val editor = checkNotNull(runtime.editor) { "No active editor is available" }
+                  val committedState =
+                    editor.syncWithBringIntoView(bringIntoViewRequests) {
+                      if (editor.ime?.composing != null) {
+                        enqueue(Message.TextInput(listOf(FlatImeOp.CommitAsIs)))
+                      }
+                      enqueue(
+                        Message.Node(
+                          NodeOp.SetAttrs(
+                            id = selectedNodeId,
+                            attrs = PlainNode.Embed(id = embedded.id),
+                          )
+                        )
+                      )
+                      beforeCommit { bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead) }
+                    }
+                  checkNotNull(committedState) { "Editor embed attrs did not commit" }
+                },
+                clearPending = {
+                  if (embedState.unfurls[selectedNodeId] === unfurl) {
+                    embedState.unfurls.remove(selectedNodeId)
+                  }
+                },
               )
             } catch (error: CancellationException) {
               throw error
-            } catch (_: Throwable) {
+            } catch (error: Throwable) {
+              reportAttachmentFailure(AttachmentKind.Embed, error)
               toast.error("링크를 임베드할 수 없어요.")
-            } finally {
-              if (embedState.unfurls[selectedNodeId] === unfurl) {
-                embedState.unfurls.remove(selectedNodeId)
-              }
             }
           }
         },
@@ -198,12 +222,5 @@ private suspend fun unfurlEmbedAsset(url: String): EditorEmbedAsset {
   val embed =
     Apollo.executeMutation(EditorScreen_UnfurlEmbed_Mutation(input = UnfurlEmbedInput(url = url)))
       .unfurlEmbed
-  return EditorEmbedAsset(
-    id = embed.id,
-    url = embed.url,
-    title = embed.title,
-    description = embed.description,
-    thumbnailUrl = embed.thumbnailUrl,
-    html = embed.html,
-  )
+  return embed.toEditorEmbedAsset()
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/FileToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/FileToolbar.kt
@@ -9,6 +9,7 @@ import co.typie.editor.external.EditorFileAsset
 import co.typie.editor.external.EditorFileUpload
 import co.typie.editor.external.LocalEditorExternalElementState
 import co.typie.editor.ffi.ExternalElementData
+import co.typie.editor.ffi.FlatImeOp
 import co.typie.editor.ffi.Fragment
 import co.typie.editor.ffi.InsertionOp
 import co.typie.editor.ffi.Message
@@ -19,14 +20,17 @@ import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.EditorBringIntoViewTarget
 import co.typie.editor.scroll.LocalEditorBringIntoViewRequests
 import co.typie.editor.scroll.awaitWithBringIntoView
+import co.typie.editor.scroll.syncWithBringIntoView
 import co.typie.graphql.Apollo
 import co.typie.graphql.EditorScreen_PersistBlobAsFile_Mutation
 import co.typie.graphql.executeMutation
 import co.typie.graphql.type.PersistBlobAsFileInput
 import co.typie.icons.Lucide
+import co.typie.platform.FilePickerResult
 import co.typie.platform.FilePickerSelectionMode
 import co.typie.platform.PickedFile
 import co.typie.platform.rememberFilePicker
+import co.typie.screen.editor.editor.toEditorFileAsset
 import co.typie.screen.editor.editor.toolbar.EditorToolbarButton
 import co.typie.screen.editor.editor.toolbar.EditorToolbarPage
 import co.typie.screen.editor.editor.toolbar.EditorToolbarPageKey
@@ -56,16 +60,31 @@ private fun EditorFileToolbar(
   val runtime = LocalEditorRuntime.current
   val bringIntoViewRequests = LocalEditorBringIntoViewRequests.current
   val uriHandler = LocalUriHandler.current
-  val fileState = LocalEditorExternalElementState.current.files
+  val externalElementState = LocalEditorExternalElementState.current
+  val fileState = externalElementState.files
   val fileId = file?.id
   val asset = fileId?.let(fileState.assets::get)
   val uploading = nodeId?.let { fileState.uploads.containsKey(it) } == true
   val hasFile = fileId != null || uploading
 
   val picker =
-    rememberFilePicker(selectionMode = FilePickerSelectionMode.Multiple) { files ->
+    rememberFilePicker(selectionMode = FilePickerSelectionMode.Multiple) { result ->
       val selectedNodeId = nodeId ?: return@rememberFilePicker
-      val selectedFile = files.firstOrNull() ?: return@rememberFilePicker
+      val files =
+        when (result) {
+          FilePickerResult.Cancelled -> return@rememberFilePicker
+          is FilePickerResult.Failed -> {
+            toast.error("파일을 불러올 수 없어요.")
+            return@rememberFilePicker
+          }
+          is FilePickerResult.Selected -> {
+            if (result.unreadableCount > 0) {
+              toast.error("일부 파일을 불러오지 못했어요.")
+            }
+            result.files
+          }
+        }
+      val selectedFile = files.first()
       val selectedUpload = selectedFile.toFileUpload()
       val restUploads = files.drop(1).map { file -> file to file.toFileUpload() }
 
@@ -99,24 +118,40 @@ private fun EditorFileToolbar(
             try {
               // TODO(TR-38): Check restrictedBlob before starting file uploads and surface the
               // plan upgrade flow instead of letting the upload proceed.
-              val uploaded = uploadFileAsset(file)
-              if (fileState.uploads[targetNodeId] !== upload) {
-                return@launch
-              }
-              fileState.assets[uploaded.id] = uploaded
-              scope.sendMessage(
-                Message.Node(
-                  NodeOp.SetAttrs(id = targetNodeId, attrs = PlainNode.File(id = uploaded.id))
-                )
+              completeAttachmentOperation(
+                persist = { uploadFileAsset(file) },
+                isCurrent = { fileState.uploads[targetNodeId] === upload },
+                cache = externalElementState::put,
+                commit = { uploaded ->
+                  val editor = checkNotNull(runtime.editor) { "No active editor is available" }
+                  val committedState =
+                    editor.syncWithBringIntoView(bringIntoViewRequests) {
+                      if (editor.ime?.composing != null) {
+                        enqueue(Message.TextInput(listOf(FlatImeOp.CommitAsIs)))
+                      }
+                      enqueue(
+                        Message.Node(
+                          NodeOp.SetAttrs(
+                            id = targetNodeId,
+                            attrs = PlainNode.File(id = uploaded.id),
+                          )
+                        )
+                      )
+                      beforeCommit { bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead) }
+                    }
+                  checkNotNull(committedState) { "Editor file attrs did not commit" }
+                },
+                clearPending = {
+                  if (fileState.uploads[targetNodeId] === upload) {
+                    fileState.uploads.remove(targetNodeId)
+                  }
+                },
               )
             } catch (error: CancellationException) {
               throw error
-            } catch (_: Throwable) {
+            } catch (error: Throwable) {
+              reportAttachmentFailure(AttachmentKind.File, error)
               toast.error("파일 업로드에 실패했어요.")
-            } finally {
-              if (fileState.uploads[targetNodeId] === upload) {
-                fileState.uploads.remove(targetNodeId)
-              }
             }
           }
         }
@@ -194,10 +229,5 @@ private suspend fun uploadFileAsset(file: PickedFile): EditorFileAsset {
         EditorScreen_PersistBlobAsFile_Mutation(input = PersistBlobAsFileInput(path = path))
       )
       .persistBlobAsFile
-  return EditorFileAsset(
-    id = uploaded.id,
-    name = uploaded.name,
-    url = uploaded.url,
-    size = uploaded.size,
-  )
+  return uploaded.toEditorFileAsset()
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/ImageToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/ImageToolbar.kt
@@ -8,6 +8,7 @@ import co.typie.editor.external.EditorImageAsset
 import co.typie.editor.external.EditorImageUpload
 import co.typie.editor.external.LocalEditorExternalElementState
 import co.typie.editor.ffi.ExternalElementData
+import co.typie.editor.ffi.FlatImeOp
 import co.typie.editor.ffi.Fragment
 import co.typie.editor.ffi.InsertionOp
 import co.typie.editor.ffi.Message
@@ -18,14 +19,17 @@ import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.EditorBringIntoViewTarget
 import co.typie.editor.scroll.LocalEditorBringIntoViewRequests
 import co.typie.editor.scroll.awaitWithBringIntoView
+import co.typie.editor.scroll.syncWithBringIntoView
 import co.typie.graphql.Apollo
 import co.typie.graphql.EditorScreen_PersistBlobAsImage_Mutation
 import co.typie.graphql.executeMutation
 import co.typie.graphql.type.PersistBlobAsImageInput
 import co.typie.icons.Lucide
+import co.typie.platform.FilePickerResult
 import co.typie.platform.FilePickerSelectionMode
 import co.typie.platform.PickedFile
 import co.typie.platform.rememberFilePicker
+import co.typie.screen.editor.editor.toEditorImageAsset
 import co.typie.screen.editor.editor.toolbar.EditorToolbarButton
 import co.typie.screen.editor.editor.toolbar.EditorToolbarPage
 import co.typie.screen.editor.editor.toolbar.EditorToolbarPageKey
@@ -55,18 +59,30 @@ private fun EditorImageToolbar(
   val toast = LocalToast.current
   val runtime = LocalEditorRuntime.current
   val bringIntoViewRequests = LocalEditorBringIntoViewRequests.current
-  val imageState = LocalEditorExternalElementState.current.images
+  val externalElementState = LocalEditorExternalElementState.current
+  val imageState = externalElementState.images
   val imageId = image?.id
   val readyAsset = imageId?.let(imageState.assets::get)
   val uploading = nodeId?.let { imageState.uploads.containsKey(it) } == true
   val hasImage = imageId != null || uploading
 
   val picker =
-    rememberFilePicker(selectionMode = FilePickerSelectionMode.Multiple) { files ->
+    rememberFilePicker(selectionMode = FilePickerSelectionMode.Multiple) { result ->
       val selectedNodeId = nodeId ?: return@rememberFilePicker
-      if (files.isEmpty()) {
-        return@rememberFilePicker
-      }
+      val files =
+        when (result) {
+          FilePickerResult.Cancelled -> return@rememberFilePicker
+          is FilePickerResult.Failed -> {
+            toast.error("이미지를 불러올 수 없어요.")
+            return@rememberFilePicker
+          }
+          is FilePickerResult.Selected -> {
+            if (result.unreadableCount > 0) {
+              toast.error("일부 이미지를 불러오지 못했어요.")
+            }
+            result.files
+          }
+        }
       val imageUploads = files.mapNotNull { file ->
         val upload = file.toImageUploadOrNull() ?: return@mapNotNull null
         file to upload
@@ -114,27 +130,40 @@ private fun EditorImageToolbar(
             try {
               // TODO(TR-38): Check restrictedBlob before starting image uploads and surface the
               // plan upgrade flow instead of letting the upload proceed.
-              val uploaded = uploadImageAsset(file)
-              if (imageState.uploads[targetNodeId] !== upload) {
-                return@launch
-              }
-              imageState.assets[uploaded.id] = uploaded
-              scope.sendMessage(
-                Message.Node(
-                  NodeOp.SetAttrs(
-                    id = targetNodeId,
-                    attrs = PlainNode.Image(id = uploaded.id, proportion = proportion),
-                  )
-                )
+              completeAttachmentOperation(
+                persist = { uploadImageAsset(file) },
+                isCurrent = { imageState.uploads[targetNodeId] === upload },
+                cache = externalElementState::put,
+                commit = { uploaded ->
+                  val editor = checkNotNull(runtime.editor) { "No active editor is available" }
+                  val committedState =
+                    editor.syncWithBringIntoView(bringIntoViewRequests) {
+                      if (editor.ime?.composing != null) {
+                        enqueue(Message.TextInput(listOf(FlatImeOp.CommitAsIs)))
+                      }
+                      enqueue(
+                        Message.Node(
+                          NodeOp.SetAttrs(
+                            id = targetNodeId,
+                            attrs = PlainNode.Image(id = uploaded.id, proportion = proportion),
+                          )
+                        )
+                      )
+                      beforeCommit { bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead) }
+                    }
+                  checkNotNull(committedState) { "Editor image attrs did not commit" }
+                },
+                clearPending = {
+                  if (imageState.uploads[targetNodeId] === upload) {
+                    imageState.uploads.remove(targetNodeId)
+                  }
+                },
               )
             } catch (error: CancellationException) {
               throw error
-            } catch (_: Throwable) {
+            } catch (error: Throwable) {
+              reportAttachmentFailure(AttachmentKind.Image, error)
               toast.error("이미지 업로드에 실패했어요.")
-            } finally {
-              if (imageState.uploads[targetNodeId] === upload) {
-                imageState.uploads.remove(targetNodeId)
-              }
             }
           }
         }
@@ -232,12 +261,5 @@ private suspend fun uploadImageAsset(file: PickedFile): EditorImageAsset {
         EditorScreen_PersistBlobAsImage_Mutation(input = PersistBlobAsImageInput(path = path))
       )
       .persistBlobAsImage
-  return EditorImageAsset(
-    id = uploaded.id,
-    url = uploaded.url,
-    width = uploaded.width,
-    height = uploaded.height,
-    ratio = uploaded.ratio,
-    placeholder = uploaded.placeholder,
-  )
+  return uploaded.toEditorImageAsset()
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/fontsettings/FontSettingsScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/fontsettings/FontSettingsScreen.kt
@@ -27,6 +27,7 @@ import co.typie.ext.verticalScroll
 import co.typie.graphql.FontSettingsScreen_Query
 import co.typie.icons.Lucide
 import co.typie.navigation.Nav
+import co.typie.platform.FilePickerResult
 import co.typie.platform.FilePickerSelectionMode
 import co.typie.platform.rememberFilePicker
 import co.typie.result.Result
@@ -74,8 +75,21 @@ fun FontSettingsScreen() {
   val sheet = LocalSheet.current
 
   val filePicker =
-    rememberFilePicker(selectionMode = FilePickerSelectionMode.Multiple) { files ->
-      if (files.isEmpty()) return@rememberFilePicker
+    rememberFilePicker(selectionMode = FilePickerSelectionMode.Multiple) { result ->
+      val files =
+        when (result) {
+          FilePickerResult.Cancelled -> return@rememberFilePicker
+          is FilePickerResult.Failed -> {
+            toast.error("폰트 파일을 불러오지 못했어요.")
+            return@rememberFilePicker
+          }
+          is FilePickerResult.Selected -> {
+            if (result.unreadableCount > 0) {
+              toast.error("일부 폰트 파일을 불러오지 못했어요.")
+            }
+            result.files
+          }
+        }
 
       scope.launch {
         model

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/updateprofile/UpdateProfileScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/updateprofile/UpdateProfileScreen.kt
@@ -26,6 +26,7 @@ import co.typie.ext.verticalScroll
 import co.typie.graphql.fragment.Img_image
 import co.typie.icons.Lucide
 import co.typie.navigation.Nav
+import co.typie.platform.FilePickerResult
 import co.typie.platform.rememberFilePicker
 import co.typie.result.onOk
 import co.typie.result.withDefaultExceptionHandler
@@ -57,8 +58,16 @@ fun UpdateProfileScreen() {
   val nav = Nav.current
   val toast = LocalToast.current
 
-  val filePicker = rememberFilePicker { files ->
-    val file = files.firstOrNull() ?: return@rememberFilePicker
+  val filePicker = rememberFilePicker { result ->
+    val file =
+      when (result) {
+        FilePickerResult.Cancelled -> return@rememberFilePicker
+        is FilePickerResult.Failed -> {
+          toast.error("프로필 사진을 불러오지 못했어요.")
+          return@rememberFilePicker
+        }
+        is FilePickerResult.Selected -> result.files.first()
+      }
 
     scope.launch {
       model

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/spacesettings/SpaceSettingsScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/spacesettings/SpaceSettingsScreen.kt
@@ -53,6 +53,7 @@ import co.typie.graphql.fragment.Img_image
 import co.typie.graphql.type.SiteDateDisplay
 import co.typie.icons.Lucide
 import co.typie.navigation.Nav
+import co.typie.platform.FilePickerResult
 import co.typie.platform.rememberFilePicker
 import co.typie.result.onOk
 import co.typie.result.withDefaultExceptionHandler
@@ -107,8 +108,16 @@ fun SpaceSettingsScreen() {
   val toast = LocalToast.current
   val sheet = LocalSheet.current
 
-  val filePicker = rememberFilePicker { files ->
-    val file = files.firstOrNull() ?: return@rememberFilePicker
+  val filePicker = rememberFilePicker { result ->
+    val file =
+      when (result) {
+        FilePickerResult.Cancelled -> return@rememberFilePicker
+        is FilePickerResult.Failed -> {
+          toast.error("로고 이미지를 불러오지 못했어요.")
+          return@rememberFilePicker
+        }
+        is FilePickerResult.Selected -> result.files.first()
+      }
     scope.launch {
       model
         .uploadLogo(file)

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/platform/FilePickerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/platform/FilePickerTest.kt
@@ -1,0 +1,54 @@
+package co.typie.platform
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertSame
+
+class FilePickerTest {
+  @Test
+  fun readableSelectionReturnsSelectedFiles() {
+    val file = pickedFile("readable.txt")
+
+    val result = aggregateSelectedFiles(listOf(Result.success(file)))
+
+    val selected = assertIs<FilePickerResult.Selected>(result)
+    assertEquals(listOf(file), selected.files)
+    assertEquals(0, selected.unreadableCount)
+  }
+
+  @Test
+  fun partialReadKeepsReadableFilesAndReportsUnreadableCount() {
+    val first = pickedFile("first.txt")
+    val second = pickedFile("second.txt")
+
+    val result =
+      aggregateSelectedFiles(
+        listOf(
+          Result.success(first),
+          Result.failure(IllegalStateException("unreadable")),
+          Result.success(second),
+        )
+      )
+
+    val selected = assertIs<FilePickerResult.Selected>(result)
+    assertEquals(listOf(first, second), selected.files)
+    assertEquals(1, selected.unreadableCount)
+  }
+
+  @Test
+  fun allReadsFailWithOriginalCause() {
+    val firstFailure = IllegalStateException("first")
+
+    val result =
+      aggregateSelectedFiles(
+        listOf(Result.failure(firstFailure), Result.failure(IllegalArgumentException("second")))
+      )
+
+    val failed = assertIs<FilePickerResult.Failed>(result)
+    assertSame(firstFailure, failed.cause)
+  }
+
+  private fun pickedFile(filename: String): PickedFile =
+    PickedFile(bytes = filename.encodeToByteArray(), filename = filename, mimeType = "text/plain")
+}

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/EditorAssetHydratorTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/EditorAssetHydratorTest.kt
@@ -1,0 +1,348 @@
+package co.typie.screen.editor.editor
+
+import co.typie.editor.external.EditorAssetResolution
+import co.typie.editor.external.EditorExternalAsset
+import co.typie.editor.external.EditorExternalElementState
+import co.typie.editor.external.EditorFileAsset
+import co.typie.editor.external.EditorImageAsset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class EditorAssetHydratorTest {
+  @Test
+  fun seededAssetsDoNotFetch() = runTest {
+    val state = EditorExternalElementState()
+    val calls = mutableListOf<List<String>>()
+    val hydrator =
+      hydrator(state) { ids ->
+        calls += ids
+        emptyList()
+      }
+    val image = imageAsset("IMG0SEEDED")
+
+    hydrator.seed(listOf(image))
+    hydrator.resolve(listOf(image.id))
+
+    assertEquals(emptyList(), calls)
+    assertEquals(image, state.images.assets[image.id])
+  }
+
+  @Test
+  fun duplicateMixedReferencesBecomeOneCanonicalMissingBatch() = runTest {
+    val state = EditorExternalElementState()
+    val calls = mutableListOf<List<String>>()
+    val seeded = imageAsset("IMG0SEEDED")
+    val file = fileAsset("FILE0MISSING")
+    val image = imageAsset("IMG0MISSING")
+    val assets = mapOf(file.id to file, image.id to image)
+    val hydrator =
+      hydrator(state) { ids ->
+        calls += ids
+        ids.mapNotNull(assets::get)
+      }
+
+    hydrator.seed(listOf(seeded))
+    hydrator.resolve(listOf(file.id, seeded.id, image.id, file.id))
+
+    assertEquals(listOf(listOf(file.id, image.id)), calls)
+    assertEquals(file, state.files.assets[file.id])
+    assertEquals(image, state.images.assets[image.id])
+  }
+
+  @Test
+  fun missingReferencesAreSplitIntoBoundedCanonicalBatches() = runTest {
+    val state = EditorExternalElementState()
+    val calls = mutableListOf<List<String>>()
+    val ids = (0..50).map { index -> "IMG${index.toString().padStart(8, '0')}" }
+    val assets = ids.associateWith(::imageAsset)
+    val hydrator =
+      hydrator(state) { batch ->
+        calls += batch
+        batch.mapNotNull(assets::get)
+      }
+
+    hydrator.resolve(ids.reversed())
+
+    assertEquals(listOf(50, 1), calls.map(List<String>::size))
+    assertEquals(ids, calls.flatten())
+  }
+
+  @Test
+  fun overlappingReferenceUpdatesDoNotDuplicateRequests() = runTest {
+    val state = EditorExternalElementState()
+    val calls = mutableListOf<List<String>>()
+    val releaseFirst = CompletableDeferred<Unit>()
+    val first = imageAsset("IMG0FIRST")
+    val second = fileAsset("FILE0SECOND")
+    val assets = mapOf(first.id to first, second.id to second)
+    val hydrator =
+      hydrator(state) { ids ->
+        calls += ids
+        if (calls.size == 1) releaseFirst.await()
+        ids.mapNotNull(assets::get)
+      }
+
+    val firstJob = launch { hydrator.resolve(listOf(first.id)) }
+    runCurrent()
+    val secondJob = launch { hydrator.resolve(listOf(first.id, second.id)) }
+    runCurrent()
+
+    assertEquals(listOf(listOf(first.id)), calls)
+    releaseFirst.complete(Unit)
+    advanceUntilIdle()
+
+    assertEquals(listOf(listOf(first.id), listOf(second.id)), calls)
+    assertTrue(firstJob.isCompleted)
+    assertTrue(secondJob.isCompleted)
+  }
+
+  @Test
+  fun referenceJoiningDuringBackoffReachesUnavailableWithItsOwnAttemptBudget() = runTest {
+    val state = EditorExternalElementState()
+    val firstId = "IMG0FIRST"
+    val joinedId = "FILE0JOINED"
+    val firstBackoffStarted = CompletableDeferred<Unit>()
+    val releaseFirstBackoff = CompletableDeferred<Unit>()
+    var backoffs = 0
+    val hydrator =
+      EditorAssetHydrator(
+        state = state,
+        fetch = { emptyList() },
+        waitBeforeRetry = {
+          backoffs += 1
+          if (backoffs == 1) {
+            firstBackoffStarted.complete(Unit)
+            releaseFirstBackoff.await()
+          }
+        },
+      )
+
+    val firstJob = launch { hydrator.resolve(listOf(firstId)) }
+    runCurrent()
+    assertTrue(firstBackoffStarted.isCompleted)
+
+    val joinedJob = launch { hydrator.resolve(listOf(firstId, joinedId)) }
+    runCurrent()
+    releaseFirstBackoff.complete(Unit)
+    advanceUntilIdle()
+
+    assertTrue(firstJob.isCompleted)
+    assertTrue(joinedJob.isCompleted)
+    assertEquals(EditorAssetResolution.Unavailable, state.resolutions[firstId])
+    assertEquals(EditorAssetResolution.Unavailable, state.resolutions[joinedId])
+  }
+
+  @Test
+  fun successfulOmissionRetriesExactlyThreeTimesThenBecomesUnavailable() = runTest {
+    val state = EditorExternalElementState()
+    var calls = 0
+    val delayedAttempts = mutableListOf<Int>()
+    val id = "IMG0LATE"
+    val hydrator =
+      EditorAssetHydrator(
+        state = state,
+        fetch = {
+          calls += 1
+          emptyList()
+        },
+        waitBeforeRetry = { attempt ->
+          delayedAttempts += attempt
+          delay(1)
+        },
+      )
+
+    hydrator.resolve(listOf(id))
+
+    assertEquals(3, calls)
+    assertEquals(listOf(1, 2), delayedAttempts)
+    assertEquals(EditorAssetResolution.Unavailable, state.resolutions[id])
+  }
+
+  @Test
+  fun queryFailureIsSuppressedUntilConnectivityRecovery() = runTest {
+    val state = EditorExternalElementState()
+    val id = "IMG0RETRY"
+    var calls = 0
+    var fail = true
+    val asset = imageAsset(id)
+    val hydrator =
+      hydrator(state) {
+        calls += 1
+        if (fail) error("offline")
+        listOf(asset)
+      }
+
+    hydrator.resolve(listOf(id))
+    hydrator.resolve(listOf(id))
+
+    assertEquals(1, calls)
+    assertEquals(EditorAssetResolution.RetryableFailure, state.resolutions[id])
+
+    fail = false
+    hydrator.onConnectivityRestored(generation = 1)
+    hydrator.onConnectivityRestored(generation = 1)
+
+    assertEquals(2, calls)
+    assertEquals(asset, state.images.assets[id])
+    assertNull(state.resolutions[id])
+  }
+
+  @Test
+  fun connectivityRecoveryDuringInFlightFailureRetriesInNewGeneration() = runTest {
+    val state = EditorExternalElementState()
+    val id = "IMG0RECOVERED"
+    val asset = imageAsset(id)
+    val firstFetchStarted = CompletableDeferred<Unit>()
+    val releaseFirstFetch = CompletableDeferred<Unit>()
+    var calls = 0
+    val hydrator =
+      hydrator(state) {
+        calls += 1
+        if (calls == 1) {
+          firstFetchStarted.complete(Unit)
+          releaseFirstFetch.await()
+          error("stale request failed")
+        }
+        listOf(asset)
+      }
+
+    val resolveJob = launch { hydrator.resolve(listOf(id)) }
+    runCurrent()
+    assertTrue(firstFetchStarted.isCompleted)
+
+    val recoveryJob = launch { hydrator.onConnectivityRestored(generation = 1) }
+    runCurrent()
+    releaseFirstFetch.complete(Unit)
+    advanceUntilIdle()
+
+    assertTrue(resolveJob.isCompleted)
+    assertTrue(recoveryJob.isCompleted)
+    assertEquals(2, calls)
+    assertEquals(asset, state.images.assets[id])
+    assertNull(state.resolutions[id])
+  }
+
+  @Test
+  fun connectivityGenerationGivesUnavailableOnlyOneProbeWithoutNewBackoffChain() = runTest {
+    val state = EditorExternalElementState()
+    val id = "IMG0UNAVAILABLE"
+    var calls = 0
+    val delayedAttempts = mutableListOf<Int>()
+    val hydrator =
+      EditorAssetHydrator(
+        state = state,
+        fetch = {
+          calls += 1
+          emptyList()
+        },
+        waitBeforeRetry = { attempt -> delayedAttempts += attempt },
+      )
+
+    hydrator.resolve(listOf(id))
+    hydrator.onConnectivityRestored(generation = 1)
+    hydrator.onConnectivityRestored(generation = 1)
+    hydrator.onConnectivityRestored(generation = 2)
+
+    assertEquals(5, calls)
+    assertEquals(listOf(1, 2), delayedAttempts)
+    assertEquals(EditorAssetResolution.Unavailable, state.resolutions[id])
+  }
+
+  @Test
+  fun queryRefreshGenerationRestoresThreeAttemptBudgetExactlyOnce() = runTest {
+    val state = EditorExternalElementState()
+    val id = "FILE0REFRESH"
+    var calls = 0
+    val hydrator =
+      hydrator(state) {
+        calls += 1
+        emptyList()
+      }
+
+    hydrator.resolve(listOf(id))
+    assertEquals(3, calls)
+
+    hydrator.onQueryRefresh(generation = 1, assets = emptyList())
+    assertEquals(6, calls)
+    hydrator.onQueryRefresh(generation = 1, assets = emptyList())
+    assertEquals(6, calls)
+
+    hydrator.onQueryRefresh(generation = 2, assets = emptyList())
+    assertEquals(9, calls)
+  }
+
+  @Test
+  fun removedReferencesClearTransientStateAndLateResponsesOnlyPopulateCache() = runTest {
+    val state = EditorExternalElementState()
+    val asset = imageAsset("IMG0REMOVED")
+    val release = CompletableDeferred<Unit>()
+    val hydrator =
+      hydrator(state) {
+        release.await()
+        listOf(asset)
+      }
+
+    val resolving = launch { hydrator.resolve(listOf(asset.id)) }
+    runCurrent()
+    assertEquals(EditorAssetResolution.InFlight, state.resolutions[asset.id])
+
+    val removing = launch { hydrator.resolve(emptyList()) }
+    runCurrent()
+    assertNull(state.resolutions[asset.id])
+
+    release.complete(Unit)
+    advanceUntilIdle()
+
+    assertTrue(resolving.isCompleted)
+    assertTrue(removing.isCompleted)
+    assertEquals(asset, state.images.assets[asset.id])
+    assertNull(state.resolutions[asset.id])
+  }
+
+  @Test
+  fun cancellationClearsStaleInFlightState() = runTest {
+    val state = EditorExternalElementState()
+    val id = "IMG0CANCELLED"
+    val hydrator = hydrator(state) { awaitCancellation() }
+
+    val job = launch { hydrator.resolve(listOf(id)) }
+    runCurrent()
+    assertEquals(EditorAssetResolution.InFlight, state.resolutions[id])
+
+    job.cancel()
+    advanceUntilIdle()
+
+    assertFalse(job.isActive)
+    assertNull(state.resolutions[id])
+  }
+
+  private fun hydrator(
+    state: EditorExternalElementState,
+    fetch: suspend (List<String>) -> List<EditorExternalAsset>,
+  ): EditorAssetHydrator = EditorAssetHydrator(state = state, fetch = fetch, waitBeforeRetry = {})
+
+  private fun imageAsset(id: String): EditorImageAsset =
+    EditorImageAsset(
+      id = id,
+      url = "https://example.com/$id",
+      width = 100,
+      height = 50,
+      ratio = 2.0,
+      placeholder = null,
+    )
+
+  private fun fileAsset(id: String): EditorFileAsset =
+    EditorFileAsset(id = id, name = "$id.txt", url = "https://example.com/$id", size = 10)
+}

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/toolbar/contextual/AttachmentOperationTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/toolbar/contextual/AttachmentOperationTest.kt
@@ -1,0 +1,105 @@
+package co.typie.screen.editor.editor.toolbar.contextual
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AttachmentOperationTest {
+  @Test
+  fun imageAndFilePendingRemainUntilLocalCommitCompletes() = runTest {
+    for (kind in listOf(AttachmentKind.Image, AttachmentKind.File)) {
+      var pending = true
+      var cached = false
+      val allowCommit = CompletableDeferred<Unit>()
+
+      val operation = async {
+        completeAttachmentOperation(
+          persist = { "$kind-asset" },
+          cache = { cached = true },
+          commit = { allowCommit.await() },
+          clearPending = { pending = false },
+        )
+      }
+      runCurrent()
+
+      assertTrue(cached, "$kind metadata should be cached before commit")
+      assertTrue(pending, "$kind pending should remain during commit")
+      assertFalse(operation.isCompleted)
+
+      allowCommit.complete(Unit)
+      assertEquals("$kind-asset", operation.await())
+      assertFalse(pending, "$kind pending should clear after commit")
+    }
+  }
+
+  @Test
+  fun imageAndFileCommitFailureDoesNotReportSuccessAndClearsPending() = runTest {
+    for (kind in listOf(AttachmentKind.Image, AttachmentKind.File)) {
+      var pending = true
+      val commitFailure = IllegalStateException("$kind commit failed")
+
+      val failure =
+        assertFailsWith<AttachmentException> {
+          completeAttachmentOperation(
+            persist = { "$kind-asset" },
+            cache = {},
+            commit = { throw commitFailure },
+            clearPending = { pending = false },
+          )
+        }
+
+      assertEquals(AttachmentFailureStage.CommitDocument, failure.stage)
+      assertSame(commitFailure, failure.cause)
+      assertFalse(pending)
+    }
+  }
+
+  @Test
+  fun persistenceFailureIsClassifiedAndClearsPending() = runTest {
+    var pending = true
+    val persistFailure = IllegalStateException("persist failed")
+
+    val failure =
+      assertFailsWith<AttachmentException> {
+        completeAttachmentOperation<String>(
+          persist = { throw persistFailure },
+          cache = {},
+          commit = {},
+          clearPending = { pending = false },
+        )
+      }
+
+    assertEquals(AttachmentFailureStage.PersistAsset, failure.stage)
+    assertSame(persistFailure, failure.cause)
+    assertFalse(pending)
+  }
+
+  @Test
+  fun cancellationPassesThroughWithoutBecomingAttachmentFailure() = runTest {
+    var pending = true
+    val cancellation = CancellationException("cancelled")
+
+    val thrown =
+      assertFailsWith<CancellationException> {
+        completeAttachmentOperation<String>(
+          persist = { throw cancellation },
+          cache = {},
+          commit = {},
+          clearPending = { pending = false },
+        )
+      }
+
+    assertSame(cancellation, thrown)
+    assertTrue(pending)
+  }
+}

--- a/apps/mobile/compose/src/desktopMain/kotlin/co/typie/platform/FilePicker.desktop.kt
+++ b/apps/mobile/compose/src/desktopMain/kotlin/co/typie/platform/FilePicker.desktop.kt
@@ -14,7 +14,7 @@ import javax.imageio.ImageIO
 @Composable
 actual fun rememberFilePicker(
   selectionMode: FilePickerSelectionMode,
-  onResult: (List<PickedFile>) -> Unit,
+  onResult: (FilePickerResult) -> Unit,
 ): (mimeType: String) -> Unit {
   val currentOnResult = rememberUpdatedState(onResult)
 
@@ -43,24 +43,32 @@ actual fun rememberFilePicker(
           isMultipleMode = selectionMode == FilePickerSelectionMode.Multiple
           isVisible = true
         }
-      val files =
-        dialog.files.map { file ->
-          val bytes = file.readBytes()
-          val image =
-            when (contentType) {
-              "image" -> bytes.decodeImageOrNull()
-              else -> null
+      val selectedFiles = dialog.files
+      currentOnResult.value(
+        if (selectedFiles.isEmpty()) {
+          FilePickerResult.Cancelled
+        } else {
+          aggregateSelectedFiles(
+            selectedFiles.map { file ->
+              runCatching {
+                val bytes = file.readBytes()
+                val image =
+                  when (contentType) {
+                    "image" -> bytes.decodeImageOrNull()
+                    else -> null
+                  }
+                PickedFile(
+                  bytes = bytes,
+                  filename = file.name,
+                  mimeType = file.probeContentType(),
+                  imageWidth = image?.width,
+                  imageHeight = image?.height,
+                )
+              }
             }
-          PickedFile(
-            bytes = bytes,
-            filename = file.name,
-            mimeType = file.probeContentType(),
-            imageWidth = image?.width,
-            imageHeight = image?.height,
           )
         }
-
-      currentOnResult.value(files)
+      )
     }
   }
 }

--- a/apps/mobile/compose/src/iosMain/kotlin/co/typie/platform/FilePicker.ios.kt
+++ b/apps/mobile/compose/src/iosMain/kotlin/co/typie/platform/FilePicker.ios.kt
@@ -3,14 +3,12 @@
 package co.typie.platform
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.setValue
 import kotlin.math.roundToInt
 import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.StableRef
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.useContents
 import kotlinx.cinterop.usePinned
@@ -31,22 +29,27 @@ import platform.UIKit.UIViewController
 import platform.UniformTypeIdentifiers.UTType
 import platform.UniformTypeIdentifiers.UTTypeData
 import platform.darwin.NSObject
+import platform.objc.OBJC_ASSOCIATION_RETAIN_NONATOMIC
+import platform.objc.objc_setAssociatedObject
 import platform.posix.memcpy
 
 @Composable
 actual fun rememberFilePicker(
   selectionMode: FilePickerSelectionMode,
-  onResult: (List<PickedFile>) -> Unit,
+  onResult: (FilePickerResult) -> Unit,
 ): (mimeType: String) -> Unit {
   val currentOnResult = rememberUpdatedState(onResult)
-  var delegateHolder by remember { mutableStateOf<NSObject?>(null) }
 
   return remember(selectionMode) {
     { mimeType: String ->
       val presenter =
         topViewController()
           ?: run {
-            currentOnResult.value(emptyList())
+            currentOnResult.value(
+              FilePickerResult.Failed(
+                IllegalStateException("No view controller can present the file picker")
+              )
+            )
             return@remember
           }
 
@@ -65,8 +68,8 @@ actual fun rememberFilePicker(
               UINavigationControllerDelegateProtocol {
               override fun imagePickerControllerDidCancel(picker: UIImagePickerController) {
                 picker.dismissViewControllerAnimated(true, completion = null)
-                delegateHolder = null
-                currentOnResult.value(emptyList())
+                picker.retainFilePickerDelegate(null)
+                currentOnResult.value(FilePickerResult.Cancelled)
               }
 
               override fun imagePickerController(
@@ -78,28 +81,36 @@ actual fun rememberFilePicker(
                 val data = image?.let { UIImageJPEGRepresentation(it, 0.9) }
 
                 picker.dismissViewControllerAnimated(true, completion = null)
-                delegateHolder = null
+                picker.retainFilePickerDelegate(null)
 
                 if (data == null) {
-                  currentOnResult.value(emptyList())
+                  currentOnResult.value(
+                    FilePickerResult.Failed(
+                      IllegalStateException("Unable to convert the selected image")
+                    )
+                  )
                   return
                 }
 
                 currentOnResult.value(
-                  listOf(
-                    PickedFile(
-                      bytes = data.toByteArray(),
-                      filename = pickedFilename(originalFilename = null, mimeType = "image/jpeg"),
-                      mimeType = "image/jpeg",
-                      imageWidth = image.pixelWidth(),
-                      imageHeight = image.pixelHeight(),
-                    )
+                  FilePickerResult.Selected(
+                    files =
+                      listOf(
+                        PickedFile(
+                          bytes = data.toByteArray(),
+                          filename =
+                            pickedFilename(originalFilename = null, mimeType = "image/jpeg"),
+                          mimeType = "image/jpeg",
+                          imageWidth = image.pixelWidth(),
+                          imageHeight = image.pixelHeight(),
+                        )
+                      )
                   )
                 )
               }
             }
 
-          delegateHolder = delegate
+          picker.retainFilePickerDelegate(delegate)
           picker.delegate = delegate
           presenter.presentViewController(picker, animated = true, completion = null)
         }
@@ -112,7 +123,7 @@ actual fun rememberFilePicker(
               }
             )
           val picker =
-            UIDocumentPickerViewController(forOpeningContentTypes = types).apply {
+            UIDocumentPickerViewController(forOpeningContentTypes = types, asCopy = true).apply {
               allowsMultipleSelection = selectionMode == FilePickerSelectionMode.Multiple
             }
 
@@ -122,35 +133,50 @@ actual fun rememberFilePicker(
                 controller: UIDocumentPickerViewController,
                 didPickDocumentsAtURLs: List<*>,
               ) {
-                delegateHolder = null
-                val files =
-                  didPickDocumentsAtURLs
-                    .mapNotNull { it as? NSURL }
-                    .mapNotNull { url ->
-                      val data = NSData.create(contentsOfURL = url) ?: return@mapNotNull null
-                      PickedFile(
-                        bytes = data.toByteArray(),
-                        filename = pickedFilename(url.lastPathComponent, mimeType = null),
-                        mimeType = mimeType,
-                      )
+                controller.retainFilePickerDelegate(null)
+                currentOnResult.value(
+                  aggregateSelectedFiles(
+                    didPickDocumentsAtURLs.map { value ->
+                      runCatching {
+                        val url = value as? NSURL ?: error("Selected document URL is unavailable")
+                        val data =
+                          NSData.create(contentsOfURL = url)
+                            ?: error("Unable to read selected document")
+                        PickedFile(
+                          bytes = data.toByteArray(),
+                          filename = pickedFilename(url.lastPathComponent, mimeType = null),
+                          mimeType = mimeType,
+                        )
+                      }
                     }
-
-                currentOnResult.value(files)
+                  )
+                )
               }
 
               override fun documentPickerWasCancelled(controller: UIDocumentPickerViewController) {
-                delegateHolder = null
-                currentOnResult.value(emptyList())
+                controller.retainFilePickerDelegate(null)
+                currentOnResult.value(FilePickerResult.Cancelled)
               }
             }
 
-          delegateHolder = delegate
+          picker.retainFilePickerDelegate(delegate)
           picker.delegate = delegate
           presenter.presentViewController(picker, animated = true, completion = null)
         }
       }
     }
   }
+}
+
+private val FilePickerDelegateAssociationKey = StableRef.create(Unit).asCPointer()
+
+private fun UIViewController.retainFilePickerDelegate(delegate: NSObject?) {
+  objc_setAssociatedObject(
+    `object` = this,
+    key = FilePickerDelegateAssociationKey,
+    value = delegate,
+    policy = OBJC_ASSOCIATION_RETAIN_NONATOMIC,
+  )
 }
 
 private fun topViewController(): UIViewController? {
@@ -164,6 +190,9 @@ private fun topViewController(): UIViewController? {
 }
 
 private fun NSData.toByteArray(): ByteArray {
+  if (length == 0uL) {
+    return ByteArray(0)
+  }
   val byteArray = ByteArray(length.toInt())
   byteArray.usePinned { pinned -> memcpy(pinned.addressOf(0), bytes, length) }
   return byteArray


### PR DESCRIPTION
- 파일 선택 결과를 취소/성공/실패로 구분
  - iOS document picker는 `asCopy = true`로 열어 iCloud나 외부 파일 제공자의 파일도 앱이 직접 읽을 수 있는 복사본으로 전달받도록 함
  - picker delegate를 picker의 associated object로 보관해, 파일을 선택하기 전에 delegate가 해제되어 callback이 사라지는 문제를 방지
  - 선택한 파일을 각각 읽고, 일부 파일만 읽지 못한 경우에는 성공한 파일을 유지하면서 실패 개수를 함께 전달
- 이미지/파일/임베드 첨부를 blob 전송, asset 저장, 문서 반영 단계로 나누고, `SetAttrs`가 로컬 에디터에 반영된 뒤 업로드 상태를 종료
- 노드에 asset ID가 있지만 초기 `document.assets`에 없는 경우를 위해 `assetsByIds`와 asset hydrator를 추가. materialization 지연 / query 갱신 / 네트워크 복구 시 누락 asset을 재조회