### PR TITLE
웹 이미지/파일/임베드 첨부 안정성

### DIFF
--- a/apps/website/src/lib/editor-ffi/components/ExternalEmbed.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ExternalEmbed.svelte
@@ -11,6 +11,7 @@
   import Trash2Icon from '~icons/lucide/trash-2';
   import { graphql } from '$mearie';
   import { getEditorContext } from '../editor.svelte';
+  import { createDeleteEmbedNodeMessage, processEmbedUpload } from '../handlers/embed-flow';
   import ExternalElementWrapper from './ExternalElementWrapper.svelte';
   import type { ExternalElement } from '@typie/editor-ffi/browser';
 
@@ -25,10 +26,10 @@
   const embedData = $derived(element.data.type === 'embed' ? element.data : undefined);
   const embedId = $derived(embedData?.id || undefined);
   const asset = $derived(embedId ? ctx.editor?.embedAssets.get(embedId) : undefined);
+  const inflight = $derived(ctx.editor?.inflightEmbeds.get(element.node));
   const canEdit = $derived(!ctx.editor?.readOnly);
 
   let inflightUrl = $state('');
-  let inflight = $state(false);
   let error = $state(false);
 
   const selectedBlockNodes = $derived(ctx.editor?.blockState?.nodes ?? []);
@@ -59,42 +60,62 @@
   );
 
   const handleSubmit = async () => {
-    if (!inflightUrl || !ctx.editor) return;
+    const editor = ctx.editor;
+    if (!inflightUrl || !editor) return;
 
     error = false;
-    inflight = true;
+    const url = inflightUrl;
+    const uploadId = crypto.randomUUID();
+    const isCurrent = () =>
+      ctx.editor === editor &&
+      !editor.destroyed &&
+      !editor.readOnly &&
+      editor.inflightEmbeds.get(element.node)?.uploadId === uploadId &&
+      editor.externalElements.some((external) => external.node === element.node && external.data.type === 'embed' && !external.data.id);
 
-    try {
-      const url = /^[^:]+:\/\//.test(inflightUrl) ? inflightUrl : `https://${inflightUrl}`;
-      const result = await unfurlEmbed({ input: { url } });
+    const result = await processEmbedUpload({
+      url,
+      nodeId: element.node,
+      setPending: () => editor.inflightEmbeds.set(element.node, { uploadId, url }),
+      clearPending: () => {
+        if (editor.inflightEmbeds.get(element.node)?.uploadId === uploadId) editor.inflightEmbeds.delete(element.node);
+      },
+      isCurrent,
+      unfurl: async (normalizedUrl) => {
+        const result = await unfurlEmbed({ input: { url: normalizedUrl } });
+        return {
+          id: result.unfurlEmbed.id,
+          url: result.unfurlEmbed.url,
+          title: result.unfurlEmbed.title ?? null,
+          description: result.unfurlEmbed.description ?? null,
+          thumbnailUrl: result.unfurlEmbed.thumbnailUrl ?? null,
+          html: result.unfurlEmbed.html ?? null,
+        };
+      },
+      setEmbedAsset: (value) => editor.embedAssets.set(value.id, value),
+      commit: (message) => {
+        if (!isCurrent()) throw new Error('Embed upload is no longer current');
+        editor.enqueue(message);
+        editor.flush();
+      },
+    });
 
-      ctx.editor.embedAssets.set(result.unfurlEmbed.id, {
-        id: result.unfurlEmbed.id,
-        url: result.unfurlEmbed.url,
-        title: result.unfurlEmbed.title ?? null,
-        description: result.unfurlEmbed.description ?? null,
-        thumbnailUrl: result.unfurlEmbed.thumbnailUrl ?? null,
-        html: result.unfurlEmbed.html ?? null,
-      });
-
-      ctx.editor.enqueue({
-        type: 'node',
-        op: { type: 'set_attrs', id: element.node, attrs: { type: 'embed', id: result.unfurlEmbed.id } },
-      });
-
-      ctx.editor.focus();
-    } catch {
+    if (result === 'uploaded') {
+      editor.focus();
+    } else if (result === 'failed') {
       error = true;
       Toast.error('링크를 임베드할 수 없습니다.');
-    } finally {
-      inflight = false;
-      inflightUrl = '';
     }
+    inflightUrl = '';
   };
 
   const deleteNode = () => {
-    ctx.editor?.enqueue({ type: 'node', op: { type: 'delete', id: element.node } });
-    ctx.editor?.focus();
+    const editor = ctx.editor;
+    if (!editor) return;
+
+    editor.inflightEmbeds.delete(element.node);
+    editor.enqueue(createDeleteEmbedNodeMessage(element.node));
+    editor.focus();
   };
 </script>
 

--- a/apps/website/src/lib/editor-ffi/components/ExternalFile.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ExternalFile.svelte
@@ -53,8 +53,12 @@
   });
 
   const deleteNode = () => {
-    ctx.editor?.enqueue(createDeleteNodeMessage(element.node));
-    ctx.editor?.focus();
+    const editor = ctx.editor;
+    if (!editor) return;
+
+    editor.inflightFiles.delete(element.node);
+    editor.enqueue(createDeleteNodeMessage(element.node));
+    editor.focus();
   };
 
   const handleUpload = () => {
@@ -85,14 +89,28 @@
   const processFile = async (file: File) => {
     const editor = ctx.editor;
     if (!editor) return;
+    const uploadId = crypto.randomUUID();
+    const isCurrent = () =>
+      ctx.editor === editor &&
+      !editor.destroyed &&
+      !editor.readOnly &&
+      editor.inflightFiles.get(element.node)?.uploadId === uploadId &&
+      editor.externalElements.some((external) => external.node === element.node && external.data.type === 'file' && !external.data.id);
 
     const result = await processFileUpload({
       file,
       nodeId: element.node,
-      setInflightFile: (nodeId, data) => editor.inflightFiles.set(nodeId, data),
-      deleteInflightFile: (nodeId) => editor.inflightFiles.delete(nodeId),
+      setInflightFile: (nodeId, data) => editor.inflightFiles.set(nodeId, { ...data, uploadId }),
+      deleteInflightFile: (nodeId) => {
+        if (editor.inflightFiles.get(nodeId)?.uploadId === uploadId) editor.inflightFiles.delete(nodeId);
+      },
       setFileAsset: (a) => ctx.fileAssets.set(a.id, a),
-      enqueue: (message) => editor.enqueue(message),
+      isCurrent,
+      commit: (message) => {
+        if (!isCurrent()) throw new Error('File upload is no longer current');
+        editor.enqueue(message);
+        editor.flush();
+      },
       focus: () => editor.focus(),
       uploadFileAsFile,
     });

--- a/apps/website/src/lib/editor-ffi/components/ExternalImage.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ExternalImage.svelte
@@ -95,31 +95,45 @@
     }
   });
 
-  $effect(() => {
-    if (asset && inflight) {
-      const url = inflight.url;
-      ctx.editor?.inflightImages.delete(element.node);
-      URL.revokeObjectURL(url);
-    }
-  });
-
   const deleteNode = () => {
-    ctx.editor?.enqueue(deleteNodeMessage(element.node));
-    ctx.editor?.focus();
+    const editor = ctx.editor;
+    if (!editor) return;
+
+    const pending = editor.inflightImages.get(element.node);
+    if (pending) {
+      editor.inflightImages.delete(element.node);
+      URL.revokeObjectURL(pending.url);
+    }
+    editor.enqueue(deleteNodeMessage(element.node));
+    editor.focus();
   };
 
   const processFile = async (file: File) => {
     const editor = ctx.editor;
     if (!editor || !imageData) return;
+    const uploadId = crypto.randomUUID();
+    const isCurrent = () =>
+      ctx.editor === editor &&
+      !editor.destroyed &&
+      !editor.readOnly &&
+      editor.inflightImages.get(element.node)?.uploadId === uploadId &&
+      editor.externalElements.some((external) => external.node === element.node && external.data.type === 'image' && !external.data.id);
 
     const result = await processImageUpload({
       file,
       nodeId: element.node,
       getProportion: () => proportion,
-      setInflightImage: (nodeId, image) => editor.inflightImages.set(nodeId, image),
-      deleteInflightImage: (nodeId) => editor.inflightImages.delete(nodeId),
+      setInflightImage: (nodeId, image) => editor.inflightImages.set(nodeId, { ...image, uploadId }),
+      deleteInflightImage: (nodeId) => {
+        if (editor.inflightImages.get(nodeId)?.uploadId === uploadId) editor.inflightImages.delete(nodeId);
+      },
       setImageAsset: (asset) => editor.imageAssets.set(asset.id, asset),
-      enqueue: (message) => editor.enqueue(message),
+      isCurrent,
+      commit: (message) => {
+        if (!isCurrent()) throw new Error('Image upload is no longer current');
+        editor.enqueue(message);
+        editor.flush();
+      },
       focus: () => editor.focus(),
       createObjectUrl: (file) => URL.createObjectURL(file),
       revokeObjectUrl: (url) => URL.revokeObjectURL(url),

--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -500,7 +500,7 @@ export class Editor {
   protectContent = $state(false);
 
   imageAssets = $state(new SvelteMap<string, ImageAsset>());
-  inflightImages = $state(new SvelteMap<string, { url: string; width: number; height: number }>());
+  inflightImages = $state(new SvelteMap<string, { uploadId: string; url: string; width: number; height: number }>());
 
   contextMenu = $state({
     isOpen: false,
@@ -511,7 +511,7 @@ export class Editor {
     extraItems: [] as ContextMenuItem[],
   });
 
-  inflightFiles = $state(new SvelteMap<string, { name: string; size: number }>());
+  inflightFiles = $state(new SvelteMap<string, { uploadId: string; name: string; size: number }>());
 
   spellcheckErrors = $state<SpellcheckError[]>([]);
   trackedRanges = $state<TrackedRange[]>([]);
@@ -525,6 +525,7 @@ export class Editor {
   requestCommentCompose: (() => void) | null = null;
 
   embedAssets = $state(new SvelteMap<string, EmbedAsset>());
+  inflightEmbeds = $state(new SvelteMap<string, { uploadId: string; url: string }>());
   archivedAssets = $state(new SvelteMap<string, ArchivedAsset>());
 
   characterCounts = $state({

--- a/apps/website/src/lib/editor-ffi/handlers/asset-hydration.test.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/asset-hydration.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createAssetHydrator } from './asset-hydration';
+
+type Asset = { id: string };
+
+const createHarness = (fetchAssets: (ids: string[]) => Promise<Asset[]>) => {
+  const assets = new Map<string, Asset>();
+  const wait = vi.fn(() => Promise.resolve());
+  const hydrator = createAssetHydrator({
+    hasAsset: (id) => assets.has(id),
+    fetchAssets,
+    putAsset: (asset) => assets.set(asset.id, asset),
+    wait,
+    retryDelays: [0, 100, 300],
+  });
+  return { assets, hydrator, wait };
+};
+
+describe('asset hydration', () => {
+  it('fetches only referenced assets missing from the local maps', async () => {
+    const fetchAssets = vi.fn(async (ids: string[]) => ids.map((id) => ({ id })));
+    const { assets, hydrator } = createHarness(fetchAssets);
+    assets.set('present', { id: 'present' });
+
+    await hydrator.update(['present', 'missing', 'missing']);
+
+    expect(fetchAssets).toHaveBeenCalledWith(['missing']);
+    expect(assets.has('missing')).toBe(true);
+  });
+
+  it('retries IDs that are not materialized yet', async () => {
+    let attempt = 0;
+    const fetchAssets = vi.fn(async () => (++attempt < 3 ? [] : [{ id: 'late' }]));
+    const { assets, hydrator, wait } = createHarness(fetchAssets);
+
+    await hydrator.update(['late']);
+
+    expect(fetchAssets).toHaveBeenCalledTimes(3);
+    expect(wait).toHaveBeenNthCalledWith(1, 100);
+    expect(wait).toHaveBeenNthCalledWith(2, 300);
+    expect(assets.has('late')).toBe(true);
+  });
+
+  it('splits large reference sets into bounded batches', async () => {
+    const fetchAssets = vi.fn(async (ids: string[]) => ids.map((id) => ({ id })));
+    const { hydrator } = createHarness(fetchAssets);
+    const ids = Array.from({ length: 51 }, (_, index) => `asset-${index}`);
+
+    await hydrator.update(ids);
+
+    expect(fetchAssets.mock.calls.map(([batch]) => batch.length)).toEqual([50, 1]);
+  });
+
+  it('waits for an explicit retry after a network failure', async () => {
+    let online = false;
+    const fetchAssets = vi.fn(async () => {
+      if (!online) throw new Error('offline');
+      return [{ id: 'asset-1' }];
+    });
+    const { assets, hydrator } = createHarness(fetchAssets);
+
+    await hydrator.update(['asset-1']);
+    await hydrator.update(['asset-1']);
+    expect(fetchAssets).toHaveBeenCalledTimes(1);
+    expect(assets.has('asset-1')).toBe(false);
+
+    online = true;
+    await hydrator.retry();
+
+    expect(fetchAssets).toHaveBeenCalledTimes(2);
+    expect(assets.has('asset-1')).toBe(true);
+  });
+
+  it('does not restart materialization retries until recovery or a new reference', async () => {
+    const fetchAssets = vi.fn(async () => []);
+    const { hydrator } = createHarness(fetchAssets);
+
+    await hydrator.update(['missing']);
+    await hydrator.update(['missing']);
+    expect(fetchAssets).toHaveBeenCalledTimes(3);
+
+    await hydrator.update([]);
+    await hydrator.update(['missing']);
+    expect(fetchAssets).toHaveBeenCalledTimes(6);
+  });
+
+  it('does not cache a result whose reference disappeared while fetching', async () => {
+    const { promise, resolve } = Promise.withResolvers<Asset[]>();
+    const { assets, hydrator } = createHarness(() => promise);
+
+    const first = hydrator.update(['removed']);
+    const second = hydrator.update([]);
+    resolve([{ id: 'removed' }]);
+    await Promise.all([first, second]);
+
+    expect(assets.has('removed')).toBe(false);
+  });
+
+  it('does nothing after it is destroyed', async () => {
+    const fetchAssets = vi.fn(async () => [{ id: 'asset-1' }]);
+    const { hydrator } = createHarness(fetchAssets);
+    hydrator.destroy();
+
+    await hydrator.update(['asset-1']);
+
+    expect(fetchAssets).not.toHaveBeenCalled();
+  });
+});

--- a/apps/website/src/lib/editor-ffi/handlers/asset-hydration.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/asset-hydration.ts
@@ -1,0 +1,102 @@
+type Asset = { id: string };
+
+type AssetHydratorOptions<T extends Asset> = {
+  hasAsset: (id: string) => boolean;
+  fetchAssets: (ids: string[]) => Promise<readonly T[]>;
+  putAsset: (asset: T) => void;
+  wait?: (delay: number) => Promise<void>;
+  retryDelays?: number[];
+  batchSize?: number;
+};
+
+export const createAssetHydrator = <T extends Asset>({
+  hasAsset,
+  fetchAssets,
+  putAsset,
+  wait = (delay) => new Promise((resolve) => setTimeout(resolve, delay)),
+  retryDelays = [0, 500, 1500],
+  batchSize = 50,
+}: AssetHydratorOptions<T>) => {
+  let referencedIds = new Set<string>();
+  const suppressedIds = new Set<string>();
+  let queued = false;
+  let destroyed = false;
+  let running: Promise<void> | null = null;
+
+  const hydrate = async () => {
+    while (!destroyed) {
+      const batch = [...referencedIds].filter((id) => !hasAsset(id) && !suppressedIds.has(id)).slice(0, batchSize);
+      if (batch.length === 0) return;
+
+      let missing = batch;
+      for (const delay of retryDelays) {
+        if (delay > 0) await wait(delay);
+        if (destroyed) return;
+
+        missing = missing.filter((id) => referencedIds.has(id) && !hasAsset(id));
+        if (missing.length === 0) break;
+
+        let fetched: readonly T[];
+        try {
+          fetched = await fetchAssets(missing);
+        } catch {
+          for (const id of missing) {
+            if (referencedIds.has(id) && !hasAsset(id)) suppressedIds.add(id);
+          }
+          return;
+        }
+        if (destroyed) return;
+
+        const requested = new Set(missing);
+        for (const asset of fetched) {
+          if (!(requested.has(asset.id) && referencedIds.has(asset.id))) {
+            continue;
+          }
+
+          putAsset(asset);
+          suppressedIds.delete(asset.id);
+        }
+      }
+
+      for (const id of missing) {
+        if (referencedIds.has(id) && !hasAsset(id)) {
+          suppressedIds.add(id);
+        }
+      }
+    }
+  };
+
+  const schedule = () => {
+    if (destroyed) return Promise.resolve();
+    queued = true;
+    running ??= (async () => {
+      while (queued && !destroyed) {
+        queued = false;
+        await hydrate();
+      }
+    })().finally(() => {
+      running = null;
+    });
+    return running;
+  };
+
+  return {
+    update(ids: Iterable<string>) {
+      const nextIds = new Set(ids);
+      for (const id of referencedIds) {
+        if (!nextIds.has(id)) suppressedIds.delete(id);
+      }
+      referencedIds = nextIds;
+      return schedule();
+    },
+    retry() {
+      suppressedIds.clear();
+      return schedule();
+    },
+    destroy() {
+      destroyed = true;
+      referencedIds.clear();
+      suppressedIds.clear();
+    },
+  };
+};

--- a/apps/website/src/lib/editor-ffi/handlers/embed-flow.test.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/embed-flow.test.ts
@@ -1,27 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import type { Message } from '@typie/editor-ffi/browser';
-
-const createSetEmbedAttrsMessage = (nodeId: string, embedId: string): Message => ({
-  type: 'node',
-  op: {
-    type: 'set_attrs',
-    id: nodeId,
-    attrs: {
-      type: 'embed',
-      id: embedId,
-    },
-  },
-});
-
-const createDeleteNodeMessage = (nodeId: string): Message => ({
-  type: 'node',
-  op: {
-    type: 'delete',
-    id: nodeId,
-  },
-});
-
-const normalizeUrl = (raw: string): string => (/^[^:]+:\/\//.test(raw) ? raw : `https://${raw}`);
+import { createDeleteEmbedNodeMessage, createSetEmbedAttrsMessage, normalizeEmbedUrl, processEmbedUpload } from './embed-flow';
+import type { EmbedAsset } from '../types';
 
 describe('embed flow messages', () => {
   it('creates a set_attrs message with embed type and id', () => {
@@ -36,7 +15,7 @@ describe('embed flow messages', () => {
   });
 
   it('creates a delete message for a node', () => {
-    expect(createDeleteNodeMessage('node-1')).toEqual({
+    expect(createDeleteEmbedNodeMessage('node-1')).toEqual({
       type: 'node',
       op: {
         type: 'delete',
@@ -48,18 +27,81 @@ describe('embed flow messages', () => {
 
 describe('URL normalization', () => {
   it('adds https:// prefix when scheme is missing', () => {
-    expect(normalizeUrl('example.com')).toBe('https://example.com');
+    expect(normalizeEmbedUrl('example.com')).toBe('https://example.com');
   });
 
   it('preserves https:// URLs as-is', () => {
-    expect(normalizeUrl('https://example.com')).toBe('https://example.com');
+    expect(normalizeEmbedUrl('https://example.com')).toBe('https://example.com');
   });
 
   it('preserves http:// URLs as-is', () => {
-    expect(normalizeUrl('http://example.com')).toBe('http://example.com');
+    expect(normalizeEmbedUrl('http://example.com')).toBe('http://example.com');
   });
 
   it('preserves URLs with other schemes as-is', () => {
-    expect(normalizeUrl('ftp://example.com')).toBe('ftp://example.com');
+    expect(normalizeEmbedUrl('ftp://example.com')).toBe('ftp://example.com');
+  });
+});
+
+const asset: EmbedAsset = {
+  id: 'embed-1',
+  url: 'https://example.com',
+  title: 'Example',
+  description: null,
+  thumbnailUrl: null,
+  html: null,
+};
+
+describe('embed upload processing', () => {
+  it('keeps pending state through local commit and clears it afterwards', async () => {
+    let pending = false;
+    let commitSawPending = false;
+    const assets = new Map<string, EmbedAsset>();
+
+    const result = await processEmbedUpload({
+      url: 'example.com',
+      nodeId: 'node-1',
+      setPending: () => (pending = true),
+      clearPending: () => (pending = false),
+      isCurrent: () => pending,
+      unfurl: async () => asset,
+      setEmbedAsset: (value) => assets.set(value.id, value),
+      commit: (message) => {
+        commitSawPending = pending;
+        expect(message).toEqual(createSetEmbedAttrsMessage('node-1', asset.id));
+      },
+    });
+
+    expect(result).toBe('uploaded');
+    expect(commitSawPending).toBe(true);
+    expect(pending).toBe(false);
+    expect(assets.get(asset.id)).toEqual(asset);
+  });
+
+  it('does not cache or commit an unfurl that is no longer current', async () => {
+    const { promise, resolve } = Promise.withResolvers<EmbedAsset>();
+    let pending = false;
+    let current = true;
+    let committed = false;
+    const assets = new Map<string, EmbedAsset>();
+
+    const upload = processEmbedUpload({
+      url: 'example.com',
+      nodeId: 'node-1',
+      setPending: () => (pending = true),
+      clearPending: () => (pending = false),
+      isCurrent: () => current,
+      unfurl: () => promise,
+      setEmbedAsset: (value) => assets.set(value.id, value),
+      commit: () => (committed = true),
+    });
+
+    current = false;
+    resolve(asset);
+
+    await expect(upload).resolves.toBe('cancelled');
+    expect(pending).toBe(false);
+    expect(assets.size).toBe(0);
+    expect(committed).toBe(false);
   });
 });

--- a/apps/website/src/lib/editor-ffi/handlers/embed-flow.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/embed-flow.ts
@@ -1,0 +1,55 @@
+import type { Message } from '@typie/editor-ffi/browser';
+import type { EmbedAsset } from '../types';
+
+export const createSetEmbedAttrsMessage = (nodeId: string, embedId: string): Message => ({
+  type: 'node',
+  op: {
+    type: 'set_attrs',
+    id: nodeId,
+    attrs: { type: 'embed', id: embedId },
+  },
+});
+
+export const createDeleteEmbedNodeMessage = (nodeId: string): Message => ({
+  type: 'node',
+  op: { type: 'delete', id: nodeId },
+});
+
+export const normalizeEmbedUrl = (raw: string): string => (/^[^:]+:\/\//.test(raw) ? raw : `https://${raw}`);
+
+export const processEmbedUpload = async ({
+  url,
+  nodeId,
+  setPending,
+  clearPending,
+  isCurrent,
+  unfurl,
+  setEmbedAsset,
+  commit,
+}: {
+  url: string;
+  nodeId: string;
+  setPending: () => void;
+  clearPending: () => void;
+  isCurrent: () => boolean;
+  unfurl: (url: string) => Promise<EmbedAsset>;
+  setEmbedAsset: (asset: EmbedAsset) => void;
+  commit: (message: Message) => void;
+}): Promise<'uploaded' | 'failed' | 'cancelled'> => {
+  setPending();
+
+  try {
+    const asset = await unfurl(normalizeEmbedUrl(url));
+    if (!isCurrent()) {
+      clearPending();
+      return 'cancelled';
+    }
+    setEmbedAsset(asset);
+    commit(createSetEmbedAttrsMessage(nodeId, asset.id));
+    clearPending();
+    return 'uploaded';
+  } catch {
+    clearPending();
+    return 'failed';
+  }
+};

--- a/apps/website/src/lib/editor-ffi/handlers/file-flow.test.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/file-flow.test.ts
@@ -17,13 +17,16 @@ const createDeps = () => {
   const inflight = new Map<string, { name: string; size: number }>();
   const assets = new Map<string, FileAsset>();
   const focus = vi.fn();
+  let commitSawInflight = false;
 
   return {
     deps: {
       setInflightFile: (nodeId: string, data: { name: string; size: number }) => inflight.set(nodeId, data),
       deleteInflightFile: (nodeId: string) => inflight.delete(nodeId),
       setFileAsset: (asset: FileAsset) => assets.set(asset.id, asset),
-      enqueue: (message: Message) => {
+      isCurrent: () => true,
+      commit: (message: Message) => {
+        commitSawInflight = inflight.has('node-1');
         messages.push(message);
       },
       focus,
@@ -32,6 +35,7 @@ const createDeps = () => {
     inflight,
     assets,
     focus,
+    commitSawInflight: () => commitSawInflight,
   };
 };
 
@@ -62,8 +66,8 @@ describe('v2 file flow messages', () => {
 });
 
 describe('v2 file upload processing', () => {
-  it('stores inflight state, persists uploaded file id, and calls focus', async () => {
-    const { deps, messages, inflight, assets, focus } = createDeps();
+  it('keeps inflight state through local commit and clears it afterwards', async () => {
+    const { deps, messages, inflight, assets, focus, commitSawInflight } = createDeps();
     const file = createFile('document.pdf', 'application/pdf', 204_800);
     const asset = createAsset('file-1');
 
@@ -75,10 +79,33 @@ describe('v2 file upload processing', () => {
     });
 
     expect(result).toBe('uploaded');
+    expect(commitSawInflight()).toBe(true);
     expect(inflight.has('node-1')).toBe(false);
     expect(assets.get('file-1')).toEqual(asset);
     expect(messages).toEqual([createSetFileAttrsMessage('node-1', 'file-1')]);
     expect(focus).toHaveBeenCalledOnce();
+  });
+
+  it('does not cache or commit an upload that is no longer current', async () => {
+    const { deps, messages, inflight, assets } = createDeps();
+    const { promise, resolve } = Promise.withResolvers<FileAsset>();
+    let current = true;
+
+    const upload = processFileUpload({
+      file: createFile('document.pdf', 'application/pdf'),
+      nodeId: 'node-1',
+      ...deps,
+      isCurrent: () => current,
+      uploadFileAsFile: () => promise,
+    });
+
+    current = false;
+    resolve(createAsset('file-1'));
+
+    await expect(upload).resolves.toBe('cancelled');
+    expect(assets.size).toBe(0);
+    expect(messages).toEqual([]);
+    expect(inflight.has('node-1')).toBe(false);
   });
 
   it('stores inflight with original file name and size before upload resolves', async () => {

--- a/apps/website/src/lib/editor-ffi/handlers/file-flow.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/file-flow.ts
@@ -44,7 +44,8 @@ export const processFileUpload = async ({
   setInflightFile,
   deleteInflightFile,
   setFileAsset,
-  enqueue,
+  isCurrent,
+  commit,
   focus,
   uploadFileAsFile,
 }: {
@@ -53,17 +54,22 @@ export const processFileUpload = async ({
   setInflightFile: (nodeId: string, inflight: { name: string; size: number }) => void;
   deleteInflightFile: (nodeId: string) => void;
   setFileAsset: (asset: FileAsset) => void;
-  enqueue: (message: Message) => void;
+  isCurrent: () => boolean;
+  commit: (message: Message) => void;
   focus: () => void;
   uploadFileAsFile: UploadFileAsFile;
-}): Promise<'uploaded' | 'failed'> => {
+}): Promise<'uploaded' | 'failed' | 'cancelled'> => {
   setInflightFile(nodeId, { name: file.name, size: file.size });
 
   try {
     const uploaded = await uploadFileAsFile(file);
-    deleteInflightFile(nodeId);
+    if (!isCurrent()) {
+      deleteInflightFile(nodeId);
+      return 'cancelled';
+    }
     setFileAsset(uploaded);
-    enqueue(createSetFileAttrsMessage(nodeId, uploaded.id));
+    commit(createSetFileAttrsMessage(nodeId, uploaded.id));
+    deleteInflightFile(nodeId);
     focus();
     return 'uploaded';
   } catch {

--- a/apps/website/src/lib/editor-ffi/handlers/image-flow.test.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/image-flow.test.ts
@@ -30,13 +30,16 @@ const createDeps = () => {
   const inflight = new Map<string, { url: string; width: number; height: number }>();
   const assets = new Map<string, ImageAsset>();
   const focus = vi.fn();
+  let commitSawInflight = false;
 
   return {
     deps: {
       setInflightImage: (nodeId: string, image: { url: string; width: number; height: number }) => inflight.set(nodeId, image),
       deleteInflightImage: (nodeId: string) => inflight.delete(nodeId),
       setImageAsset: (asset: ImageAsset) => assets.set(asset.id, asset),
-      enqueue: (message: Message) => {
+      isCurrent: () => true,
+      commit: (message: Message) => {
+        commitSawInflight = inflight.has('node-1');
         messages.push(message);
       },
       focus,
@@ -45,6 +48,7 @@ const createDeps = () => {
     inflight,
     assets,
     focus,
+    commitSawInflight: () => commitSawInflight,
   };
 };
 
@@ -203,8 +207,8 @@ describe('v2 image picker flow', () => {
 });
 
 describe('v2 image upload processing', () => {
-  it('stores inflight preview, persists uploaded image id, and cleans up object url', async () => {
-    const { deps, messages, inflight, assets, focus } = createDeps();
+  it('keeps the preview pending through local commit and clears it afterwards', async () => {
+    const { deps, messages, inflight, assets, focus, commitSawInflight } = createDeps();
     const revokeObjectUrl = vi.fn();
 
     const result = await processImageUpload({
@@ -221,9 +225,38 @@ describe('v2 image upload processing', () => {
     expect(result).toBe('uploaded');
     expect(assets.get('image-1')).toEqual(createAsset('image-1'));
     expect(messages).toEqual([setImageAttrsMessage('node-1', 'image-1', 100)]);
-    expect(inflight.get('node-1')).toEqual({ url: 'blob:image', width: 320, height: 240 });
-    expect(revokeObjectUrl).not.toHaveBeenCalled();
+    expect(commitSawInflight()).toBe(true);
+    expect(inflight.has('node-1')).toBe(false);
+    expect(revokeObjectUrl).toHaveBeenCalledWith('blob:image');
     expect(focus).toHaveBeenCalled();
+  });
+
+  it('does not cache or commit an upload that is no longer current', async () => {
+    const { deps, messages, inflight, assets } = createDeps();
+    const revokeObjectUrl = vi.fn();
+    const { promise, resolve } = Promise.withResolvers<ImageAsset>();
+    let current = true;
+
+    const upload = processImageUpload({
+      file: createFile('image.png', 'image/png'),
+      nodeId: 'node-1',
+      getProportion: () => 100,
+      ...deps,
+      isCurrent: () => current,
+      createObjectUrl: () => 'blob:image',
+      revokeObjectUrl,
+      readImageDimensions: async () => ({ width: 320, height: 240 }),
+      uploadImageFile: () => promise,
+    });
+
+    current = false;
+    resolve(createAsset('image-1'));
+
+    await expect(upload).resolves.toBe('cancelled');
+    expect(assets.size).toBe(0);
+    expect(messages).toEqual([]);
+    expect(inflight.has('node-1')).toBe(false);
+    expect(revokeObjectUrl).toHaveBeenCalledWith('blob:image');
   });
 
   it('업로드가 실패하면 미리보기를 정리하고 빈 노드를 삭제한다', async () => {
@@ -235,6 +268,7 @@ describe('v2 image upload processing', () => {
       nodeId: 'node-1',
       getProportion: () => 100,
       ...deps,
+      isCurrent: () => inflight.has('node-1'),
       createObjectUrl: () => 'blob:image',
       revokeObjectUrl,
       readImageDimensions: async () => ({ width: 320, height: 240 }),

--- a/apps/website/src/lib/editor-ffi/handlers/image-flow.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/image-flow.ts
@@ -125,7 +125,8 @@ export const processImageUpload = async ({
   setInflightImage,
   deleteInflightImage,
   setImageAsset,
-  enqueue,
+  isCurrent,
+  commit,
   focus,
   createObjectUrl,
   revokeObjectUrl,
@@ -138,30 +139,47 @@ export const processImageUpload = async ({
   setInflightImage: (nodeId: string, image: { url: string; width: number; height: number }) => void;
   deleteInflightImage: (nodeId: string) => void;
   setImageAsset: (asset: ImageAsset) => void;
-  enqueue: (message: Message) => void;
+  isCurrent: () => boolean;
+  commit: (message: Message) => void;
   focus: () => void;
   createObjectUrl: (file: File) => string;
   revokeObjectUrl: (url: string) => void;
   readImageDimensions: ReadImageDimensions;
   uploadImageFile: UploadImageFile;
-}): Promise<'uploaded' | 'failed'> => {
+}): Promise<'uploaded' | 'failed' | 'cancelled'> => {
   const objectUrl = createObjectUrl(file);
   setInflightImage(nodeId, { url: objectUrl, width: 0, height: 0 });
 
+  const cancel = (): 'cancelled' => {
+    deleteInflightImage(nodeId);
+    revokeObjectUrl(objectUrl);
+    return 'cancelled';
+  };
+
   try {
     const { width, height } = await readImageDimensions(objectUrl);
+    if (!isCurrent()) return cancel();
     setInflightImage(nodeId, { url: objectUrl, width, height });
 
     const uploaded = await uploadImageFile(file);
+    if (!isCurrent()) return cancel();
     setImageAsset(uploaded);
-    enqueue(setImageAttrsMessage(nodeId, uploaded.id, getProportion()));
+    commit(setImageAttrsMessage(nodeId, uploaded.id, getProportion()));
+    deleteInflightImage(nodeId);
+    revokeObjectUrl(objectUrl);
     focus();
 
     return 'uploaded';
   } catch {
+    if (isCurrent()) {
+      try {
+        commit(deleteNodeMessage(nodeId));
+      } catch {
+        // The original commit failure is already represented by the failed result.
+      }
+    }
     deleteInflightImage(nodeId);
     revokeObjectUrl(objectUrl);
-    enqueue(deleteNodeMessage(nodeId));
     focus();
     return 'failed';
   }

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditor.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditor.svelte
@@ -22,7 +22,9 @@
   import { BottomToolbar, Editor as EditorComponent, TopToolbar } from '$lib/editor-ffi/components';
   import { IS_MAC } from '$lib/editor-ffi/constants';
   import { browserScaleFactor, Editor, getEditorContext } from '$lib/editor-ffi/editor.svelte';
+  import { createAssetHydrator } from '$lib/editor-ffi/handlers/asset-hydration';
   import { registerLinkContextMenu } from '$lib/editor-ffi/handlers/link';
+  import { cache, mearieClient } from '$lib/graphql';
   import { getDocumentChannels, getSyncConnection } from '$lib/sync';
   import { graphql } from '$mearie';
   import DocumentMenu from '../../@context-menu/DocumentMenu.svelte';
@@ -205,6 +207,47 @@
     `),
   );
 
+  const assetsByIdsQuery = graphql(`
+    query DocumentEditorV2_AssetsByIds_Query($slug: String!, $ids: [ID!]!) {
+      document(slug: $slug) {
+        id
+        assetsByIds(ids: $ids) {
+          __typename
+
+          ... on Image {
+            id
+            url
+            originalUrl
+            width
+            height
+            placeholder
+          }
+
+          ... on File {
+            id
+            url
+            name
+            size
+          }
+
+          ... on Embed {
+            id
+            url
+            title
+            description
+            thumbnailUrl
+            html
+          }
+
+          ... on DocumentArchivedNode {
+            id
+            content
+          }
+        }
+      }
+    }
+  `);
+
   graphql(`
     fragment EditorContextV2_user on User {
       id
@@ -244,6 +287,42 @@
   const isOwner = $derived(query.data.me.id === entity?.user.id || query.data.me.role === 'ADMIN');
   const title = $derived(document?.title ?? '');
   const assets = $derived(document?.assets);
+
+  type DocumentAsset = NonNullable<typeof assets>[number];
+
+  const putAsset = (editor: Editor, asset: DocumentAsset) => {
+    if (asset.__typename === 'Image') {
+      editor.imageAssets.set(asset.id, {
+        id: asset.id,
+        url: asset.url,
+        originalUrl: asset.originalUrl,
+        width: asset.width,
+        height: asset.height,
+        placeholder: asset.placeholder,
+      });
+    } else if (asset.__typename === 'File') {
+      ctx.fileAssets.set(asset.id, {
+        id: asset.id,
+        url: asset.url,
+        name: asset.name,
+        size: asset.size,
+      });
+    } else if (asset.__typename === 'Embed') {
+      editor.embedAssets.set(asset.id, {
+        id: asset.id,
+        url: asset.url,
+        title: asset.title ?? null,
+        description: asset.description ?? null,
+        thumbnailUrl: asset.thumbnailUrl ?? null,
+        html: asset.html ?? null,
+      });
+    } else if (asset.__typename === 'DocumentArchivedNode') {
+      editor.archivedAssets.set(asset.id, {
+        id: asset.id,
+        content: asset.content,
+      });
+    }
+  };
 
   const fontFamilies = $derived(document?.fontFamilies ?? []);
 
@@ -351,41 +430,55 @@
 
     if (assets) {
       for (const asset of assets) {
-        if (asset.__typename === 'Image') {
-          editor.imageAssets.set(asset.id, {
-            id: asset.id,
-            url: asset.url,
-            originalUrl: asset.originalUrl,
-            width: asset.width,
-            height: asset.height,
-            placeholder: asset.placeholder,
-          });
-        } else if (asset.__typename === 'File') {
-          ctx.fileAssets.set(asset.id, {
-            id: asset.id,
-            url: asset.url,
-            name: asset.name,
-            size: asset.size,
-          });
-        } else if (asset.__typename === 'Embed') {
-          editor.embedAssets.set(asset.id, {
-            id: asset.id,
-            url: asset.url,
-            title: asset.title ?? null,
-            description: asset.description ?? null,
-            thumbnailUrl: asset.thumbnailUrl ?? null,
-            html: asset.html ?? null,
-          });
-        } else if (asset.__typename === 'DocumentArchivedNode') {
-          editor.archivedAssets.set(asset.id, {
-            id: asset.id,
-            content: asset.content,
-          });
-        }
+        putAsset(editor, asset);
       }
     }
   });
 
+  $effect(() => {
+    const editor = ctx.editor;
+    const slug = entity?.slug;
+    const currentDocumentId = documentId;
+    if (!editor || !slug || !currentDocumentId) return;
+
+    const hydrator = createAssetHydrator<DocumentAsset>({
+      hasAsset: (id) => editor.imageAssets.has(id) || ctx.fileAssets.has(id) || editor.embedAssets.has(id) || editor.archivedAssets.has(id),
+      fetchAssets: async (ids) => {
+        await cache.invalidate({ __typename: 'Document', id: currentDocumentId, $field: 'assetsByIds', $args: { ids } });
+        const result = await mearieClient.query(assetsByIdsQuery, { slug, ids });
+        return result.document.assetsByIds;
+      },
+      putAsset: (asset) => putAsset(editor, asset),
+    });
+
+    let hydrationQueued = false;
+    let stopped = false;
+    const updateReferences = () => {
+      hydrationQueued = false;
+      if (stopped) return;
+      void hydrator.update(editor.externalElements.flatMap(({ data }) => (data.id ? [data.id] : [])));
+    };
+    const scheduleHydration = () => {
+      if (hydrationQueued) return;
+      hydrationQueued = true;
+      // Editor invalidates the lazy external-elements cache after emitting state_changed.
+      queueMicrotask(updateReferences);
+    };
+
+    scheduleHydration();
+    const offStateChanged = editor.on('state_changed', (_, { fields }) => {
+      if (fields.includes('doc')) scheduleHydration();
+    });
+    const retry = () => void hydrator.retry();
+    window.addEventListener('online', retry);
+
+    return () => {
+      stopped = true;
+      offStateChanged();
+      window.removeEventListener('online', retry);
+      hydrator.destroy();
+    };
+  });
   let titleUpdateTimeout: ReturnType<typeof setTimeout> | null = null;
   let subtitleUpdateTimeout: ReturnType<typeof setTimeout> | null = null;
   let pusher = $state<Pusher | null>(null);


### PR DESCRIPTION
앱과 동일하게..

- 업로드 완료 시 setAttrs까지 끝났음을 보장
- 삭제/교체된 노드에 stale 업로드가 적용되지 않게 함
- 임베드 업로드 상태도 이미지/파일과 동일하게 에디터가 소유하게 함 (임베드 중 뷰포트 밖으로 나가도 업로드 계속 함)
- document.assets에 누락된 거 보충 조회 (remote changeset, pending changeset, 서버의 document materialization보다 앞서는 changeset)