### PR TITLE
웹/앱 이미지 업로드/resize 디버그

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/external/EditorImageExternalElement.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/external/EditorImageExternalElement.kt
@@ -24,12 +24,14 @@ import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
 import co.typie.editor.ffi.ExternalElementData
+import co.typie.editor.ffi.ImageNodeAttr
 import co.typie.editor.ffi.Message
+import co.typie.editor.ffi.NodeAttr
 import co.typie.editor.ffi.NodeOp
-import co.typie.editor.ffi.PlainNode
 import co.typie.editor.runtime.LocalEditorRuntime
 import co.typie.icons.Lucide
 import co.typie.ui.component.Img
@@ -119,9 +121,9 @@ internal fun EditorImageExternalElement(
       editor?.sync {
         enqueue(
           Message.Node(
-            NodeOp.SetAttrs(
+            NodeOp.SetAttr(
               id = nodeId,
-              attrs = PlainNode.Image(id = data.id, proportion = nextProportion),
+              attr = NodeAttr.Image(ImageNodeAttr.Proportion(nextProportion)),
             )
           )
         )
@@ -263,17 +265,12 @@ private fun ImageResizeHandle(
   val currentOnEnd by rememberUpdatedState(onEnd)
   Box(
     modifier =
-      modifier.pointerInput(reverse) {
-        detectDragGestures(
-          onDragStart = { currentOnStart() },
-          onDrag = { change, dragAmount ->
-            change.consume()
-            currentOnDrag(dragAmount.x)
-          },
-          onDragEnd = { currentOnEnd() },
-          onDragCancel = { currentOnEnd() },
-        )
-      },
+      modifier.imageResizeHandlePointerInput(
+        key = reverse,
+        onStart = { currentOnStart() },
+        onDrag = { currentOnDrag(it) },
+        onEnd = { currentOnEnd() },
+      ),
     contentAlignment = Alignment.Center,
   ) {
     Canvas(modifier = Modifier.width(scope.scaledDp(RESIZE_HANDLE_VISUAL_WIDTH)).fillMaxHeight()) {
@@ -285,3 +282,26 @@ private fun ImageResizeHandle(
     }
   }
 }
+
+internal fun Modifier.imageResizeHandlePointerInput(
+  key: Any?,
+  onStart: () -> Unit,
+  onDrag: (Float) -> Unit,
+  onEnd: () -> Unit,
+): Modifier =
+  pointerInput(key) {
+    detectDragGestures(
+      orientationLock = null,
+      onDragStart = { _, _, _ -> onStart() },
+      onDrag = { change, dragAmount ->
+        change.consume()
+        onDrag(dragAmount.x)
+      },
+      onDragEnd = { change ->
+        val finalDeltaX = change.positionChange().x
+        if (finalDeltaX != 0f) onDrag(finalDeltaX)
+        onEnd()
+      },
+      onDragCancel = onEnd,
+    )
+  }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/ImageResizeSecondaryToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/ImageResizeSecondaryToolbar.kt
@@ -26,9 +26,10 @@ import co.typie.editor.external.IMAGE_MIN_PROPORTION
 import co.typie.editor.external.LocalEditorExternalElementState
 import co.typie.editor.external.imageResizeProportionRange
 import co.typie.editor.ffi.ExternalElementData
+import co.typie.editor.ffi.ImageNodeAttr
 import co.typie.editor.ffi.Message
+import co.typie.editor.ffi.NodeAttr
 import co.typie.editor.ffi.NodeOp
-import co.typie.editor.ffi.PlainNode
 import co.typie.editor.runtime.LocalEditorRuntime
 import co.typie.screen.editor.editor.toolbar.ToolbarFixedActionWidth
 import co.typie.screen.editor.editor.toolbar.ToolbarLabelTextStyle
@@ -113,7 +114,7 @@ internal fun ImageResizeSecondaryToolbar(
       editor.sync {
         enqueue(
           Message.Node(
-            NodeOp.SetAttrs(id = nodeId, attrs = PlainNode.Image(id = imageId, proportion = next))
+            NodeOp.SetAttr(id = nodeId, attr = NodeAttr.Image(ImageNodeAttr.Proportion(next)))
           )
         )
       }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/ImageToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/ImageToolbar.kt
@@ -10,8 +10,10 @@ import co.typie.editor.external.LocalEditorExternalElementState
 import co.typie.editor.ffi.ExternalElementData
 import co.typie.editor.ffi.FlatImeOp
 import co.typie.editor.ffi.Fragment
+import co.typie.editor.ffi.ImageNodeAttr
 import co.typie.editor.ffi.InsertionOp
 import co.typie.editor.ffi.Message
+import co.typie.editor.ffi.NodeAttr
 import co.typie.editor.ffi.NodeOp
 import co.typie.editor.ffi.PlainNode
 import co.typie.editor.runtime.LocalEditorRuntime
@@ -131,12 +133,7 @@ private fun EditorImageToolbar(
             imageState.uploads[newNodeId] = pending.second
           }
 
-          fun launchUpload(
-            targetNodeId: String,
-            file: PickedFile,
-            upload: EditorImageUpload,
-            proportion: Int,
-          ) {
+          fun launchUpload(targetNodeId: String, file: PickedFile, upload: EditorImageUpload) {
             val job = launch {
               try {
                 // TODO(TR-38): Check restrictedBlob before starting image uploads and
@@ -155,9 +152,9 @@ private fun EditorImageToolbar(
                         }
                         enqueue(
                           Message.Node(
-                            NodeOp.SetAttrs(
+                            NodeOp.SetAttr(
                               id = targetNodeId,
-                              attrs = PlainNode.Image(id = uploaded.id, proportion = proportion),
+                              attr = NodeAttr.Image(ImageNodeAttr.Id(uploaded.id)),
                             )
                           )
                         )
@@ -183,19 +180,9 @@ private fun EditorImageToolbar(
             job.invokeOnCompletion { file.close() }
           }
 
-          launchUpload(
-            targetNodeId = selectedNodeId,
-            file = selectedImage,
-            upload = selectedUpload,
-            proportion = image?.proportion ?: 100,
-          )
+          launchUpload(targetNodeId = selectedNodeId, file = selectedImage, upload = selectedUpload)
           restNodeIds.zip(restUploads).forEach { (newNodeId, pending) ->
-            launchUpload(
-              targetNodeId = newNodeId,
-              file = pending.first,
-              upload = pending.second,
-              proportion = 100,
-            )
+            launchUpload(targetNodeId = newNodeId, file = pending.first, upload = pending.second)
           }
         }
       uploadJob.invokeOnCompletion { imageUploads.forEach { (file) -> file.close() } }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/external/EditorImageResizeHandleDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/external/EditorImageResizeHandleDesktopTest.kt
@@ -1,0 +1,121 @@
+package co.typie.editor.external
+
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.changedToUp
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
+import androidx.compose.ui.platform.LocalViewConfiguration
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class EditorImageResizeHandleDesktopTest {
+  @Test
+  fun release_applies_final_up_event_delta_before_commit() = runComposeUiTest {
+    val deltas = mutableListOf<Float>()
+    var ended = false
+
+    setContent {
+      Box(
+        Modifier.testTag(HandleTag)
+          .size(width = 200.dp, height = 32.dp)
+          .imageResizeHandlePointerInput(
+            key = false,
+            onStart = {},
+            onDrag = { deltas += it },
+            onEnd = { ended = true },
+          )
+      )
+    }
+    waitForIdle()
+
+    onNodeWithTag(HandleTag).performTouchInput {
+      val y = center.y
+      down(Offset(x = width * 0.1f, y = y))
+      moveTo(Offset(x = width * 0.4f, y = y))
+      updatePointerTo(pointerId = 0, position = Offset(x = width.toFloat(), y = y))
+      up()
+    }
+    waitForIdle()
+
+    assertEquals(120f, deltas.last())
+    assertTrue(ended)
+  }
+
+  @Test
+  fun cancellation_commits_the_latest_delivered_draft() = runComposeUiTest {
+    val deltas = mutableListOf<Float>()
+    var draft = 0f
+    var committed: Float? = null
+    var touchSlop = 0f
+    var requestedDelta = 0f
+
+    setContent {
+      touchSlop = LocalViewConfiguration.current.touchSlop
+      Box(
+        Modifier.size(width = 200.dp, height = 32.dp).pointerInput(Unit) {
+          awaitEachGesture {
+            awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
+            var moveEvents = 0
+            while (true) {
+              val change = awaitPointerEvent(PointerEventPass.Initial).changes.first()
+              if (change.changedToUp()) break
+              if (change.positionChange() != Offset.Zero) {
+                moveEvents += 1
+                if (moveEvents >= 2) change.consume()
+              }
+            }
+          }
+        }
+      ) {
+        Box(
+          Modifier.testTag(CancelHandleTag)
+            .fillMaxSize()
+            .imageResizeHandlePointerInput(
+              key = false,
+              onStart = {},
+              onDrag = {
+                deltas += it
+                draft += it
+              },
+              onEnd = { committed = draft },
+            )
+        )
+      }
+    }
+    waitForIdle()
+
+    onNodeWithTag(CancelHandleTag).performTouchInput {
+      val y = center.y
+      requestedDelta = width * 0.3f
+      down(Offset(x = width * 0.1f, y = y))
+      moveTo(Offset(x = width * 0.4f, y = y))
+      moveTo(Offset(x = width * 0.7f, y = y))
+      up()
+    }
+    waitForIdle()
+
+    assertEquals(1, deltas.size)
+    assertEquals(requestedDelta - touchSlop, deltas.single(), absoluteTolerance = 0.001f)
+    assertEquals(deltas.sum(), committed)
+  }
+
+  private companion object {
+    const val HandleTag = "image-resize-handle"
+    const val CancelHandleTag = "cancel-image-resize-handle"
+  }
+}

--- a/apps/website/src/lib/editor-ffi/components/ExternalImage.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ExternalImage.svelte
@@ -21,7 +21,6 @@
     processImageUpload,
     queuePendingImages,
     resolveImageSrc,
-    setImageAttrsMessage,
   } from '../handlers/image-flow';
   import { getImageDimensions, uploadImageFile } from '../handlers/upload';
   import ExternalElementWrapper from './ExternalElementWrapper.svelte';
@@ -122,7 +121,6 @@
     const result = await processImageUpload({
       file,
       nodeId: element.node,
-      getProportion: () => proportion,
       setInflightImage: (nodeId, image) => editor.inflightImages.set(nodeId, { ...image, uploadId }),
       deleteInflightImage: (nodeId) => {
         if (editor.inflightImages.get(nodeId)?.uploadId === uploadId) editor.inflightImages.delete(nodeId);
@@ -226,7 +224,17 @@
 
     isResizing = false;
     initialResizeData = null;
-    ctx.editor?.enqueue(setImageAttrsMessage(element.node, imageId, proportion));
+    ctx.editor?.enqueue({
+      type: 'node',
+      op: {
+        type: 'set_attr',
+        id: element.node,
+        attr: {
+          type: 'image',
+          attr: { type: 'proportion', value: Math.round(proportion) },
+        },
+      },
+    });
     ctx.editor?.focus();
   };
 

--- a/apps/website/src/lib/editor-ffi/handlers/image-flow.test.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/image-flow.test.ts
@@ -9,7 +9,6 @@ import {
   processImageUpload,
   queuePendingImages,
   resolveImageSrc,
-  setImageAttrsMessage,
 } from './image-flow';
 import type { Message } from '@typie/editor-ffi/browser';
 import type { ImageAsset } from '../types';
@@ -70,21 +69,6 @@ describe('이미지 표시 여부 결정', () => {
 });
 
 describe('v2 image flow messages', () => {
-  it('creates a v2 node attrs message for uploaded image id and rounded proportion', () => {
-    expect(setImageAttrsMessage('node-1', 'image-1', 74.6)).toEqual({
-      type: 'node',
-      op: {
-        type: 'set_attrs',
-        id: 'node-1',
-        attrs: {
-          type: 'image',
-          id: 'image-1',
-          proportion: 75,
-        },
-      },
-    });
-  });
-
   it('creates a v2 node delete message for placeholder cleanup and deletion', () => {
     expect(deleteNodeMessage('node-1')).toEqual({
       type: 'node',
@@ -214,7 +198,6 @@ describe('v2 image upload processing', () => {
     const result = await processImageUpload({
       file: createFile('image.png', 'image/png'),
       nodeId: 'node-1',
-      getProportion: () => 100,
       ...deps,
       createObjectUrl: () => 'blob:image',
       revokeObjectUrl,
@@ -224,7 +207,19 @@ describe('v2 image upload processing', () => {
 
     expect(result).toBe('uploaded');
     expect(assets.get('image-1')).toEqual(createAsset('image-1'));
-    expect(messages).toEqual([setImageAttrsMessage('node-1', 'image-1', 100)]);
+    expect(messages).toEqual([
+      {
+        type: 'node',
+        op: {
+          type: 'set_attr',
+          id: 'node-1',
+          attr: {
+            type: 'image',
+            attr: { type: 'id', value: 'image-1' },
+          },
+        },
+      },
+    ]);
     expect(commitSawInflight()).toBe(true);
     expect(inflight.has('node-1')).toBe(false);
     expect(revokeObjectUrl).toHaveBeenCalledWith('blob:image');
@@ -240,7 +235,6 @@ describe('v2 image upload processing', () => {
     const upload = processImageUpload({
       file: createFile('image.png', 'image/png'),
       nodeId: 'node-1',
-      getProportion: () => 100,
       ...deps,
       isCurrent: () => current,
       createObjectUrl: () => 'blob:image',
@@ -266,7 +260,6 @@ describe('v2 image upload processing', () => {
     const result = await processImageUpload({
       file: createFile('image.png', 'image/png'),
       nodeId: 'node-1',
-      getProportion: () => 100,
       ...deps,
       isCurrent: () => inflight.has('node-1'),
       createObjectUrl: () => 'blob:image',

--- a/apps/website/src/lib/editor-ffi/handlers/image-flow.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/image-flow.ts
@@ -20,19 +20,6 @@ export const deriveImageStage = ({
 type UploadImageFile = (file: File) => Promise<ImageAsset>;
 type ReadImageDimensions = (src: string) => Promise<{ width: number; height: number }>;
 
-export const setImageAttrsMessage = (nodeId: string, imageId: string | undefined, proportion: number): Message => ({
-  type: 'node',
-  op: {
-    type: 'set_attrs',
-    id: nodeId,
-    attrs: {
-      type: 'image',
-      id: imageId,
-      proportion: Math.round(proportion),
-    },
-  },
-});
-
 export const deleteNodeMessage = (nodeId: string): Message => ({
   type: 'node',
   op: {
@@ -121,7 +108,6 @@ export const calculateImageContainerSize = ({
 export const processImageUpload = async ({
   file,
   nodeId,
-  getProportion,
   setInflightImage,
   deleteInflightImage,
   setImageAsset,
@@ -135,7 +121,6 @@ export const processImageUpload = async ({
 }: {
   file: File;
   nodeId: string;
-  getProportion: () => number;
   setInflightImage: (nodeId: string, image: { url: string; width: number; height: number }) => void;
   deleteInflightImage: (nodeId: string) => void;
   setImageAsset: (asset: ImageAsset) => void;
@@ -164,7 +149,17 @@ export const processImageUpload = async ({
     const uploaded = await uploadImageFile(file);
     if (!isCurrent()) return cancel();
     setImageAsset(uploaded);
-    commit(setImageAttrsMessage(nodeId, uploaded.id, getProportion()));
+    commit({
+      type: 'node',
+      op: {
+        type: 'set_attr',
+        id: nodeId,
+        attr: {
+          type: 'image',
+          attr: { type: 'id', value: uploaded.id },
+        },
+      },
+    });
     deleteInflightImage(nodeId);
     revokeObjectUrl(objectUrl);
     focus();

--- a/crates/editor-core/src/handle/node.rs
+++ b/crates/editor-core/src/handle/node.rs
@@ -6,6 +6,10 @@ use crate::message::*;
 
 pub fn handle_node_op(editor: &mut Editor, op: NodeOp) -> Result<(), EditorError> {
     editor.transact(|tr| match op {
+        NodeOp::SetAttr { id, attr } => {
+            tr.set_node_attr(id, attr)?;
+            Ok(())
+        }
         NodeOp::SetAttrs { id, attrs } => {
             tr.set_node(id, attrs)?;
             Ok(())
@@ -73,8 +77,8 @@ mod tests {
 
     use editor_macros::state;
     use editor_model::{
-        CalloutVariant, ChildView, HorizontalRuleVariant, Node, PlainDoc, PlainHorizontalRuleNode,
-        PlainNode, PlainNodeEntry,
+        CalloutVariant, ChildView, HorizontalRuleVariant, ImageNodeAttr, Node, NodeAttr, PlainDoc,
+        PlainHorizontalRuleNode, PlainNode, PlainNodeEntry,
     };
     use editor_state::{Affinity, Position, Selection, State, assert_state_eq};
 
@@ -221,6 +225,56 @@ mod tests {
             other => panic!("expected horizontal rule, got {other:?}"),
         };
         assert_eq!(variant, HorizontalRuleVariant::Zigzag);
+    }
+
+    #[test]
+    fn set_attr_updates_only_one_image_field_and_records_history() {
+        let (initial, image) = state! {
+            doc { root { image: image } }
+            selection: none
+        };
+        let mut editor = Editor::new_test(initial.clone());
+
+        editor.apply(Message::Node {
+            op: NodeOp::SetAttr {
+                id: image,
+                attr: NodeAttr::Image {
+                    attr: ImageNodeAttr::Id(Some("asset-1".to_string())),
+                },
+            },
+        });
+        editor.apply(Message::Node {
+            op: NodeOp::SetAttr {
+                id: image,
+                attr: NodeAttr::Image {
+                    attr: ImageNodeAttr::Proportion(65),
+                },
+            },
+        });
+
+        let attrs =
+            |editor: &Editor| match editor.state().view().leaf(image).unwrap().node().unwrap() {
+                Node::Image(node) => (node.id.get().clone(), *node.proportion.get()),
+                other => panic!("expected image, got {other:?}"),
+            };
+        assert_eq!(attrs(&editor), (Some("asset-1".to_string()), 65));
+
+        editor.apply(Message::History {
+            op: HistoryOp::Undo,
+        });
+        assert_eq!(attrs(&editor), (Some("asset-1".to_string()), 100));
+        editor.apply(Message::History {
+            op: HistoryOp::Undo,
+        });
+        assert_eq!(attrs(&editor), (None, 100));
+
+        editor.apply(Message::History {
+            op: HistoryOp::Redo,
+        });
+        editor.apply(Message::History {
+            op: HistoryOp::Redo,
+        });
+        assert_eq!(attrs(&editor), (Some("asset-1".to_string()), 65));
     }
     #[test]
     fn cycle_callout_variant_updates_target_and_records_history() {

--- a/crates/editor-core/src/message.rs
+++ b/crates/editor-core/src/message.rs
@@ -2,7 +2,7 @@ pub use editor_common::{Axis, DecorationStyle, Direction, Movement};
 use editor_crdt::Dot;
 use editor_macros::ffi;
 use editor_model::{
-    BlockquoteVariant, Fragment, Modifier, ModifierType, PlainNode, TableBorderStyle,
+    BlockquoteVariant, Fragment, Modifier, ModifierType, NodeAttr, PlainNode, TableBorderStyle,
 };
 use editor_state::{Position, Selection, StableSelection};
 use serde::{Deserialize, Serialize};
@@ -244,6 +244,7 @@ pub enum TableOp {
 pub enum NodeOp {
     Delete { id: Dot },
     CycleCalloutVariant { id: Dot },
+    SetAttr { id: Dot, attr: NodeAttr },
     SetAttrs { id: Dot, attrs: PlainNode },
     Unwrap { id: Dot },
     Table { id: Dot, op: TableOp },
@@ -465,4 +466,80 @@ pub enum Message {
     Remote {
         changeset: editor_crdt::Changeset<editor_model::EditOp>,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use editor_model::{CalloutNodeAttr, CalloutVariant, ImageNodeAttr};
+    use serde_json::json;
+
+    #[test]
+    fn image_node_attrs_use_type_and_value_wire_shape() {
+        let id = NodeAttr::Image {
+            attr: ImageNodeAttr::Id(Some("asset-1".to_string())),
+        };
+        let proportion = NodeAttr::Image {
+            attr: ImageNodeAttr::Proportion(65),
+        };
+
+        assert_eq!(
+            serde_json::to_value(id).unwrap(),
+            json!({
+                "type": "image",
+                "attr": { "type": "id", "value": "asset-1" },
+            })
+        );
+        assert_eq!(
+            serde_json::to_value(proportion).unwrap(),
+            json!({
+                "type": "image",
+                "attr": { "type": "proportion", "value": 65 },
+            })
+        );
+    }
+
+    #[test]
+    fn non_image_node_attr_uses_type_and_value_wire_shape() {
+        let attr = NodeAttr::Callout {
+            attr: CalloutNodeAttr::Variant(CalloutVariant::Warning),
+        };
+
+        assert_eq!(
+            serde_json::to_value(attr).unwrap(),
+            json!({
+                "type": "callout",
+                "attr": { "type": "variant", "value": "warning" },
+            })
+        );
+    }
+
+    #[test]
+    fn image_set_attr_message_roundtrips_through_json() {
+        let message = Message::Node {
+            op: NodeOp::SetAttr {
+                id: Dot::new(1, 2),
+                attr: NodeAttr::Image {
+                    attr: ImageNodeAttr::Proportion(65),
+                },
+            },
+        };
+        let value = serde_json::to_value(&message).unwrap();
+
+        assert_eq!(
+            value,
+            json!({
+                "type": "node",
+                "op": {
+                    "type": "set_attr",
+                    "id": "1_2",
+                    "attr": {
+                        "type": "image",
+                        "attr": { "type": "proportion", "value": 65 },
+                    },
+                },
+            })
+        );
+        assert_eq!(serde_json::from_value::<Message>(value).unwrap(), message);
+    }
 }

--- a/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
@@ -496,13 +496,13 @@ export interface Viewport {
 
 export type Alignment = "left" | "center" | "right" | "justify";
 
-export type ArchivedNodeAttr = { type: "id" } & string | undefined;
+export type ArchivedNodeAttr = { type: "id"; value: string | undefined };
 
 export type Axis = "horizontal" | "vertical";
 
 export type BlockOp = { type: "toggle_blockquote"; variant: BlockquoteVariant } | { type: "toggle_callout" } | { type: "wrap_fold" };
 
-export type BlockquoteNodeAttr = { type: "variant" } & BlockquoteVariant;
+export type BlockquoteNodeAttr = { type: "variant"; value: BlockquoteVariant };
 
 export type BlockquoteVariant = "left_line" | "left_quote" | "message_sent" | "message_received";
 
@@ -510,7 +510,7 @@ export type Break = "line" | "paragraph" | "page";
 
 export type BulletListNodeAttr = void;
 
-export type CalloutNodeAttr = { type: "variant" } & CalloutVariant;
+export type CalloutNodeAttr = { type: "variant"; value: CalloutVariant };
 
 export type CalloutVariant = "info" | "success" | "warning" | "danger";
 
@@ -530,13 +530,13 @@ export type EditorEvent = { type: "state_changed"; fields: StateField[] } | { ty
 
 export type Effect = { load_font: { family: string; weight: number; codepoints: number[] } };
 
-export type EmbedNodeAttr = { type: "id" } & string | undefined;
+export type EmbedNodeAttr = { type: "id"; value: string | undefined };
 
 export type ExternalDndPayloadKind = "text" | "html" | "image_files" | "files" | "mixed_files";
 
 export type ExternalElementData = { type: "image"; id: string | undefined; proportion: number } | { type: "file"; id: string | undefined } | { type: "embed"; id: string | undefined } | { type: "archived"; id: string | undefined };
 
-export type FileNodeAttr = { type: "id" } & string | undefined;
+export type FileNodeAttr = { type: "id"; value: string | undefined };
 
 export type FlatImeOp = { type: "set_selection"; start: number; end: number } | { type: "replace_selection"; text: string } | { type: "compose"; text: string } | { type: "delete_surrounding"; before: number; after: number } | { type: "delete_surrounding_utf16"; before: number; after: number } | { type: "set_composition"; start: number; end: number } | { type: "clear_composition" } | { type: "commit_as_is" } | { type: "move_cursor"; delta: number };
 
@@ -558,11 +558,11 @@ export type HistoryOp = { type: "undo" } | { type: "redo" };
 
 export type HistoryTag = { type: "auto_replacement" } | { type: "paste_html"; plain_text: string; start: number | undefined };
 
-export type HorizontalRuleNodeAttr = { type: "variant" } & HorizontalRuleVariant;
+export type HorizontalRuleNodeAttr = { type: "variant"; value: HorizontalRuleVariant };
 
 export type HorizontalRuleVariant = "line" | "dashed_line" | "circle_line" | "diamond_line" | "circle" | "diamond" | "three_circles" | "three_diamonds" | "zigzag";
 
-export type ImageNodeAttr = ({ type: "id" } & string | undefined) | ({ type: "proportion" } & number);
+export type ImageNodeAttr = { type: "id"; value: string | undefined } | { type: "proportion"; value: number };
 
 export type InsertionOp = { type: "text"; text: string } | { type: "break"; kind: Break } | { type: "fragment"; fragment: Fragment } | { type: "table"; rows: number; cols: number };
 
@@ -590,7 +590,7 @@ export type NavigationOp = { type: "move"; movement: Movement; extend: boolean }
 
 export type NodeAttr = { type: "root"; attr: RootNodeAttr } | { type: "paragraph"; attr: ParagraphNodeAttr } | { type: "blockquote"; attr: BlockquoteNodeAttr } | { type: "callout"; attr: CalloutNodeAttr } | { type: "text"; attr: TextNodeAttr } | { type: "bullet_list"; attr: BulletListNodeAttr } | { type: "ordered_list"; attr: OrderedListNodeAttr } | { type: "list_item"; attr: ListItemNodeAttr } | { type: "fold"; attr: FoldNodeAttr } | { type: "fold_title"; attr: FoldTitleNodeAttr } | { type: "fold_content"; attr: FoldContentNodeAttr } | { type: "table"; attr: TableNodeAttr } | { type: "table_row"; attr: TableRowNodeAttr } | { type: "table_cell"; attr: TableCellNodeAttr } | { type: "image"; attr: ImageNodeAttr } | { type: "file"; attr: FileNodeAttr } | { type: "embed"; attr: EmbedNodeAttr } | { type: "archived"; attr: ArchivedNodeAttr } | { type: "hard_break"; attr: HardBreakNodeAttr } | { type: "horizontal_rule"; attr: HorizontalRuleNodeAttr } | { type: "page_break"; attr: PageBreakNodeAttr } | { type: "tab"; attr: TabNodeAttr } | { type: "unknown"; tag: number; bytes: number[] };
 
-export type NodeOp = { type: "delete"; id: Dot } | { type: "cycle_callout_variant"; id: Dot } | { type: "set_attrs"; id: Dot; attrs: PlainNode } | { type: "unwrap"; id: Dot } | { type: "table"; id: Dot; op: TableOp };
+export type NodeOp = { type: "delete"; id: Dot } | { type: "cycle_callout_variant"; id: Dot } | { type: "set_attr"; id: Dot; attr: NodeAttr } | { type: "set_attrs"; id: Dot; attrs: PlainNode } | { type: "unwrap"; id: Dot } | { type: "table"; id: Dot; op: TableOp };
 
 export type OrderedListNodeAttr = void;
 
@@ -606,7 +606,7 @@ export type PlainNode = ({ type: "root" } & PlainRootNode) | ({ type: "paragraph
 
 export type PointerStyle = "default" | "text" | "pointer";
 
-export type RootNodeAttr = { type: "layout_mode" } & LayoutMode;
+export type RootNodeAttr = { type: "layout_mode"; value: LayoutMode };
 
 export type SelectionExpansionUnit = "word" | "sentence" | "paragraph" | "all";
 
@@ -622,9 +622,9 @@ export type TabNodeAttr = void;
 
 export type TableBorderStyle = "solid" | "dashed" | "dotted" | "none";
 
-export type TableCellNodeAttr = ({ type: "col_width" } & number | undefined) | ({ type: "background_color" } & string | undefined);
+export type TableCellNodeAttr = { type: "col_width"; value: number | undefined } | { type: "background_color"; value: string | undefined };
 
-export type TableNodeAttr = ({ type: "border_style" } & TableBorderStyle) | ({ type: "proportion" } & number);
+export type TableNodeAttr = { type: "border_style"; value: TableBorderStyle } | { type: "proportion"; value: number };
 
 export type TableOp = { type: "insert_axis"; axis: Axis; index: number; before: boolean } | { type: "delete_axis"; axis: Axis; index: number } | { type: "move_axis"; axis: Axis; from: number; to: number } | { type: "select_axis"; axis: Axis | undefined; index: number | undefined } | { type: "set_column_widths"; widths: number[] } | { type: "set_border_style"; border_style: TableBorderStyle } | { type: "set_proportion"; proportion: number } | { type: "set_axis_background_color"; axis: Axis; index: number; color: string | undefined } | { type: "set_cell_background_color"; color: string | undefined };
 

--- a/crates/editor-ffi/pkg/server/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/server/editor_ffi.d.ts
@@ -552,13 +552,13 @@ export interface Viewport {
 
 export type Alignment = "left" | "center" | "right" | "justify";
 
-export type ArchivedNodeAttr = { type: "id" } & string | undefined;
+export type ArchivedNodeAttr = { type: "id"; value: string | undefined };
 
 export type Axis = "horizontal" | "vertical";
 
 export type BlockOp = { type: "toggle_blockquote"; variant: BlockquoteVariant } | { type: "toggle_callout" } | { type: "wrap_fold" };
 
-export type BlockquoteNodeAttr = { type: "variant" } & BlockquoteVariant;
+export type BlockquoteNodeAttr = { type: "variant"; value: BlockquoteVariant };
 
 export type BlockquoteVariant = "left_line" | "left_quote" | "message_sent" | "message_received";
 
@@ -568,7 +568,7 @@ export type BulletListNodeAttr = void;
 
 export type BundleStatus = "applied" | "duplicate" | "failed";
 
-export type CalloutNodeAttr = { type: "variant" } & CalloutVariant;
+export type CalloutNodeAttr = { type: "variant"; value: CalloutVariant };
 
 export type CalloutVariant = "info" | "success" | "warning" | "danger";
 
@@ -588,13 +588,13 @@ export type EditorEvent = { type: "state_changed"; fields: StateField[] } | { ty
 
 export type Effect = { load_font: { family: string; weight: number; codepoints: number[] } };
 
-export type EmbedNodeAttr = { type: "id" } & string | undefined;
+export type EmbedNodeAttr = { type: "id"; value: string | undefined };
 
 export type ExternalDndPayloadKind = "text" | "html" | "image_files" | "files" | "mixed_files";
 
 export type ExternalElementData = { type: "image"; id: string | undefined; proportion: number } | { type: "file"; id: string | undefined } | { type: "embed"; id: string | undefined } | { type: "archived"; id: string | undefined };
 
-export type FileNodeAttr = { type: "id" } & string | undefined;
+export type FileNodeAttr = { type: "id"; value: string | undefined };
 
 export type FlatImeOp = { type: "set_selection"; start: number; end: number } | { type: "replace_selection"; text: string } | { type: "compose"; text: string } | { type: "delete_surrounding"; before: number; after: number } | { type: "delete_surrounding_utf16"; before: number; after: number } | { type: "set_composition"; start: number; end: number } | { type: "clear_composition" } | { type: "commit_as_is" } | { type: "move_cursor"; delta: number };
 
@@ -616,11 +616,11 @@ export type HistoryOp = { type: "undo" } | { type: "redo" };
 
 export type HistoryTag = { type: "auto_replacement" } | { type: "paste_html"; plain_text: string; start: number | undefined };
 
-export type HorizontalRuleNodeAttr = { type: "variant" } & HorizontalRuleVariant;
+export type HorizontalRuleNodeAttr = { type: "variant"; value: HorizontalRuleVariant };
 
 export type HorizontalRuleVariant = "line" | "dashed_line" | "circle_line" | "diamond_line" | "circle" | "diamond" | "three_circles" | "three_diamonds" | "zigzag";
 
-export type ImageNodeAttr = ({ type: "id" } & string | undefined) | ({ type: "proportion" } & number);
+export type ImageNodeAttr = { type: "id"; value: string | undefined } | { type: "proportion"; value: number };
 
 export type InsertionOp = { type: "text"; text: string } | { type: "break"; kind: Break } | { type: "fragment"; fragment: Fragment } | { type: "table"; rows: number; cols: number };
 
@@ -648,7 +648,7 @@ export type NavigationOp = { type: "move"; movement: Movement; extend: boolean }
 
 export type NodeAttr = { type: "root"; attr: RootNodeAttr } | { type: "paragraph"; attr: ParagraphNodeAttr } | { type: "blockquote"; attr: BlockquoteNodeAttr } | { type: "callout"; attr: CalloutNodeAttr } | { type: "text"; attr: TextNodeAttr } | { type: "bullet_list"; attr: BulletListNodeAttr } | { type: "ordered_list"; attr: OrderedListNodeAttr } | { type: "list_item"; attr: ListItemNodeAttr } | { type: "fold"; attr: FoldNodeAttr } | { type: "fold_title"; attr: FoldTitleNodeAttr } | { type: "fold_content"; attr: FoldContentNodeAttr } | { type: "table"; attr: TableNodeAttr } | { type: "table_row"; attr: TableRowNodeAttr } | { type: "table_cell"; attr: TableCellNodeAttr } | { type: "image"; attr: ImageNodeAttr } | { type: "file"; attr: FileNodeAttr } | { type: "embed"; attr: EmbedNodeAttr } | { type: "archived"; attr: ArchivedNodeAttr } | { type: "hard_break"; attr: HardBreakNodeAttr } | { type: "horizontal_rule"; attr: HorizontalRuleNodeAttr } | { type: "page_break"; attr: PageBreakNodeAttr } | { type: "tab"; attr: TabNodeAttr } | { type: "unknown"; tag: number; bytes: number[] };
 
-export type NodeOp = { type: "delete"; id: Dot } | { type: "cycle_callout_variant"; id: Dot } | { type: "set_attrs"; id: Dot; attrs: PlainNode } | { type: "unwrap"; id: Dot } | { type: "table"; id: Dot; op: TableOp };
+export type NodeOp = { type: "delete"; id: Dot } | { type: "cycle_callout_variant"; id: Dot } | { type: "set_attr"; id: Dot; attr: NodeAttr } | { type: "set_attrs"; id: Dot; attrs: PlainNode } | { type: "unwrap"; id: Dot } | { type: "table"; id: Dot; op: TableOp };
 
 export type OrderedListNodeAttr = void;
 
@@ -664,7 +664,7 @@ export type PlainNode = ({ type: "root" } & PlainRootNode) | ({ type: "paragraph
 
 export type PointerStyle = "default" | "text" | "pointer";
 
-export type RootNodeAttr = { type: "layout_mode" } & LayoutMode;
+export type RootNodeAttr = { type: "layout_mode"; value: LayoutMode };
 
 export type SelectionExpansionUnit = "word" | "sentence" | "paragraph" | "all";
 
@@ -680,9 +680,9 @@ export type TabNodeAttr = void;
 
 export type TableBorderStyle = "solid" | "dashed" | "dotted" | "none";
 
-export type TableCellNodeAttr = ({ type: "col_width" } & number | undefined) | ({ type: "background_color" } & string | undefined);
+export type TableCellNodeAttr = { type: "col_width"; value: number | undefined } | { type: "background_color"; value: string | undefined };
 
-export type TableNodeAttr = ({ type: "border_style" } & TableBorderStyle) | ({ type: "proportion" } & number);
+export type TableNodeAttr = { type: "border_style"; value: TableBorderStyle } | { type: "proportion"; value: number };
 
 export type TableOp = { type: "insert_axis"; axis: Axis; index: number; before: boolean } | { type: "delete_axis"; axis: Axis; index: number } | { type: "move_axis"; axis: Axis; from: number; to: number } | { type: "select_axis"; axis: Axis | undefined; index: number | undefined } | { type: "set_column_widths"; widths: number[] } | { type: "set_border_style"; border_style: TableBorderStyle } | { type: "set_proportion"; proportion: number } | { type: "set_axis_background_color"; axis: Axis; index: number; color: string | undefined } | { type: "set_cell_background_color"; color: string | undefined };
 

--- a/crates/editor-macros/src/node_attr_macro/codegen.rs
+++ b/crates/editor-macros/src/node_attr_macro/codegen.rs
@@ -141,7 +141,7 @@ pub fn generate(input: &NodeAttrInput) -> TokenStream {
     quote! {
         #[::editor_macros::ffi]
         #[derive(Debug, Clone, PartialEq, Eq, ::serde::Serialize, ::serde::Deserialize)]
-        #[serde(tag = "type", rename_all = "snake_case")]
+        #[serde(tag = "type", content = "value", rename_all = "snake_case")]
         pub enum #attr_ident {
             #(#attr_variants),*
         }

--- a/crates/editor-transaction/src/error.rs
+++ b/crates/editor-transaction/src/error.rs
@@ -7,6 +7,12 @@ pub enum StepError {
     #[error("node not found: {0:?}")]
     NodeNotFound(Dot),
 
+    #[error("node attr kind does not match target node: {block:?}")]
+    NodeAttrKindMismatch { block: Dot },
+
+    #[error("old and new node attrs refer to different fields: {block:?}")]
+    NodeAttrFieldMismatch { block: Dot },
+
     #[error("offset {offset} out of bounds for node {block:?} (len: {len})")]
     OffsetOutOfBounds {
         block: Dot,

--- a/crates/editor-transaction/src/step.rs
+++ b/crates/editor-transaction/src/step.rs
@@ -1,5 +1,5 @@
 use editor_crdt::{Dot, Op};
-use editor_model::{EditOp, Modifier, ModifierType, NodeType, PlainNode, Subtree};
+use editor_model::{EditOp, Modifier, ModifierType, NodeAttr, NodeType, PlainNode, Subtree};
 use editor_state::Selection;
 use editor_state::{BatchedState, Composition, PendingModifiers, State};
 use serde::{Deserialize, Serialize};
@@ -83,6 +83,11 @@ pub enum Step {
         block: Dot,
         old_node: PlainNode,
         new_node: PlainNode,
+    },
+    SetNodeAttr {
+        block: Dot,
+        old: NodeAttr,
+        new: NodeAttr,
     },
     ReplaceBlockType {
         block: Dot,
@@ -207,6 +212,9 @@ impl Step {
                 old_node,
                 new_node,
             } => steps::set_node::apply_to(batched, *block, old_node, new_node),
+            Step::SetNodeAttr { block, old, new } => {
+                steps::set_node_attr::apply_to(batched, *block, old, new)
+            }
             Step::ReplaceBlockType {
                 block,
                 old_type,
@@ -279,6 +287,9 @@ impl Step {
                 old_node,
                 new_node,
             } => steps::set_node::inverse(*block, old_node.clone(), new_node.clone()),
+            Step::SetNodeAttr { block, old, new } => {
+                steps::set_node_attr::inverse(*block, old.clone(), new.clone())
+            }
             Step::ReplaceBlockType {
                 block,
                 old_type,

--- a/crates/editor-transaction/src/steps/mod.rs
+++ b/crates/editor-transaction/src/steps/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod remove_text;
 pub(crate) mod replace_block_type;
 pub(crate) mod set_composition;
 pub(crate) mod set_node;
+pub(crate) mod set_node_attr;
 pub(crate) mod set_node_carry;
 pub(crate) mod set_pending_modifiers;
 pub(crate) mod set_selection;

--- a/crates/editor-transaction/src/steps/set_node_attr.rs
+++ b/crates/editor-transaction/src/steps/set_node_attr.rs
@@ -1,0 +1,45 @@
+use editor_crdt::Dot;
+use editor_model::{EditOp, NodeAttr, NodeAttrOp};
+use editor_state::BatchedState;
+
+use crate::{Step, StepError};
+
+pub(crate) fn inverse(block: Dot, old: NodeAttr, new: NodeAttr) -> Step {
+    Step::SetNodeAttr {
+        block,
+        old: new,
+        new: old,
+    }
+}
+
+pub(crate) fn apply_to(
+    batched: &mut BatchedState,
+    block: Dot,
+    old: &NodeAttr,
+    new: &NodeAttr,
+) -> Result<(), StepError> {
+    let node = batched
+        .projected
+        .block_node(block)
+        .or_else(|| batched.projected.atom_leaf_node(block))
+        .ok_or(StepError::NodeNotFound(block))?;
+    if !old.same_field(new) {
+        return Err(StepError::NodeAttrFieldMismatch { block });
+    }
+    if !node
+        .to_plain()
+        .to_attrs()
+        .iter()
+        .any(|attr| attr.same_field(new))
+    {
+        return Err(StepError::NodeAttrKindMismatch { block });
+    }
+    let Some(target) = editor_model::anchor_dot(block) else {
+        return Err(StepError::NodeNotFound(block));
+    };
+    batched.apply(EditOp::NodeAttr(NodeAttrOp {
+        target,
+        attr: new.clone(),
+    }))?;
+    Ok(())
+}

--- a/crates/editor-transaction/src/transaction.rs
+++ b/crates/editor-transaction/src/transaction.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use editor_crdt::Dot;
-use editor_model::{DocView, Modifier, ModifierType, NodeType, PlainNode, Subtree};
+use editor_model::{DocView, Modifier, ModifierType, NodeAttr, NodeType, PlainNode, Subtree};
 use editor_state::Selection;
 use editor_state::undo::RecordedOp;
 use editor_state::{BatchedState, Composition, PendingModifiers, State};
@@ -253,6 +253,22 @@ impl Transaction {
             old_node,
             new_node,
         })
+    }
+
+    pub fn set_node_attr(&mut self, block: Dot, new: NodeAttr) -> Result<(), StepError> {
+        let node = self
+            .state
+            .projected
+            .block_node(block)
+            .or_else(|| self.state.projected.atom_leaf_node(block))
+            .ok_or(StepError::NodeNotFound(block))?;
+        let old = node
+            .to_plain()
+            .to_attrs()
+            .into_iter()
+            .find(|attr| attr.same_field(&new))
+            .ok_or(StepError::NodeAttrKindMismatch { block })?;
+        self.apply_step(Step::SetNodeAttr { block, old, new })
     }
 
     pub fn replace_block_type(&mut self, block: Dot, new_type: NodeType) -> Result<(), StepError> {

--- a/crates/editor-transaction/tests/transaction_acceptance.rs
+++ b/crates/editor-transaction/tests/transaction_acceptance.rs
@@ -2,9 +2,9 @@ use editor_common::time::{Duration, Instant};
 use editor_crdt::Dot;
 use editor_macros::state;
 use editor_model::{
-    AtomLeaf, CalloutVariant, ChildView, EditOp, LayoutMode, Modifier, ModifierType, Node,
-    NodeAttrOp, NodeType, NodeView, PlainCalloutNode, PlainNode, PlainParagraphNode, PlainRootNode,
-    Subtree,
+    AtomLeaf, CalloutVariant, ChildView, EditOp, ImageNodeAttr, LayoutMode, Modifier, ModifierType,
+    Node, NodeAttr, NodeAttrOp, NodeType, NodeView, PlainCalloutNode, PlainNode,
+    PlainParagraphNode, PlainRootNode, Subtree,
 };
 use editor_state::undo::{RecordMerge, TransientState, UndoEntry, UndoHistory};
 use editor_state::{
@@ -61,6 +61,13 @@ fn snapshot(state: &State) -> Vec<(usize, NodeType, String)> {
         walk(&root, 0, &mut out);
     }
     out
+}
+
+fn image_attrs(state: &State, image: Dot) -> (Option<String>, u32) {
+    match state.view().leaf(image).unwrap().node().unwrap() {
+        Node::Image(node) => (node.id.get().clone(), *node.proportion.get()),
+        other => panic!("expected image, got {other:?}"),
+    }
 }
 
 #[test]
@@ -596,6 +603,103 @@ mod tests {
         } else {
             panic!("expected callout");
         }
+    }
+
+    #[test]
+    fn set_node_attr_preserves_independent_image_fields_in_both_orders() {
+        fn apply(id_first: bool) -> (Option<String>, u32) {
+            let (state, image) = state! {
+                doc { root { image: image } }
+                selection: none
+            };
+            let mut tr = Transaction::new(&state);
+            let id = NodeAttr::Image {
+                attr: ImageNodeAttr::Id(Some("asset-1".to_string())),
+            };
+            let proportion = NodeAttr::Image {
+                attr: ImageNodeAttr::Proportion(65),
+            };
+            if id_first {
+                tr.set_node_attr(image, id).unwrap();
+                tr.set_node_attr(image, proportion).unwrap();
+            } else {
+                tr.set_node_attr(image, proportion).unwrap();
+                tr.set_node_attr(image, id).unwrap();
+            }
+            image_attrs(tr.state(), image)
+        }
+
+        assert_eq!(apply(true), (Some("asset-1".to_string()), 65));
+        assert_eq!(apply(false), (Some("asset-1".to_string()), 65));
+    }
+
+    #[test]
+    fn set_node_attr_rejects_attr_for_another_node_kind() {
+        let (state, paragraph) = state! {
+            doc { root { paragraph: paragraph {} } }
+            selection: (paragraph, 0)
+        };
+        let mut tr = Transaction::new(&state);
+
+        let result = tr.set_node_attr(
+            paragraph,
+            NodeAttr::Image {
+                attr: ImageNodeAttr::Proportion(65),
+            },
+        );
+
+        assert!(matches!(
+            result,
+            Err(StepError::NodeAttrKindMismatch { block }) if block == paragraph
+        ));
+    }
+
+    #[test]
+    fn set_node_attr_inverse_restores_only_the_changed_field() {
+        let (state, image) = state! {
+            doc { root { image: image } }
+            selection: none
+        };
+        let old = NodeAttr::Image {
+            attr: ImageNodeAttr::Proportion(100),
+        };
+        let new = NodeAttr::Image {
+            attr: ImageNodeAttr::Proportion(65),
+        };
+        let step = Step::SetNodeAttr {
+            block: image,
+            old,
+            new,
+        };
+
+        let after = step.apply(&state).unwrap().state;
+        assert_eq!(image_attrs(&after, image), (None, 65));
+        let restored = step.inverse().apply(&after).unwrap().state;
+        assert_eq!(image_attrs(&restored, image), (None, 100));
+    }
+
+    #[test]
+    fn set_node_attr_step_rejects_different_old_and_new_fields() {
+        let (state, image) = state! {
+            doc { root { image: image } }
+            selection: none
+        };
+        let mut tr = Transaction::new(&state);
+        let result = tr.apply_steps(vec![Step::SetNodeAttr {
+            block: image,
+            old: NodeAttr::Image {
+                attr: ImageNodeAttr::Id(None),
+            },
+            new: NodeAttr::Image {
+                attr: ImageNodeAttr::Proportion(65),
+            },
+        }]);
+
+        assert!(matches!(
+            result,
+            Err(StepError::NodeAttrFieldMismatch { block }) if block == image
+        ));
+        assert_eq!(image_attrs(tr.state(), image), (None, 100));
     }
 
     #[test]


### PR DESCRIPTION
- TR-381 해결: resize가 이미지의 asset ID를 stale/null 값으로 함께 덮어써 placeholder로 돌아가는 문제 수정
- SetNodeAttr 추가: 업로드 완료는 asset ID만, handle/slider resize는 proportion만 변경해 업로드 중 조정한 크기를 유지
- NodeAttr FFI payload를 { type, value } 형태로 수정해 앱과 웹에서 SetAttr 메시지가 정상적으로 직렬화되도록 개선
- 웹 이미지 업로드/resize도 동일한 방식으로 전환해 ID와 proportion의 상호 덮어쓰기를 방지
- TR-374 해결: resize handle release 이벤트의 마지막 이동량을 commit 전에 반영