### PR TITLE
앱/웹 blob 업로드 동시성 제한

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/blob/BlobService.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/blob/BlobService.kt
@@ -12,6 +12,8 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.headers
 import io.ktor.http.quote
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -25,7 +27,10 @@ internal class BlobUploadException(val stage: BlobUploadStage, cause: Throwable)
   RuntimeException("Blob upload failed at $stage", cause)
 
 object BlobService {
-  suspend fun upload(file: PickedFile): String {
+  private const val MaxConcurrentUploads = 5
+  private val uploadSemaphore = Semaphore(MaxConcurrentUploads)
+
+  suspend fun upload(file: PickedFile): String = uploadSemaphore.withPermit {
     val resolvedMimeType = file.mimeType ?: "application/octet-stream"
     val result =
       withBlobUploadStage(BlobUploadStage.IssueUploadUrl) {

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -62,6 +62,7 @@
     "mearie": "^0.1.7",
     "mixpanel-browser": "^2.80.0",
     "nanoid": "^5.1.16",
+    "p-limit": "^7.3.0",
     "query-string": "^9.4.1",
     "remeda": "^2.39.0",
     "svelte": "^5.56.4",

--- a/apps/website/src/lib/editor-ffi/handlers/file-flow.test.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/file-flow.test.ts
@@ -161,29 +161,34 @@ describe('v2 file upload processing', () => {
 
   it('handles multiple concurrent uploads independently', async () => {
     const { deps, messages, inflight, assets } = createDeps();
+    const uploadA = Promise.withResolvers<FileAsset>();
+    const uploadB = Promise.withResolvers<FileAsset>();
 
-    const [result1, result2] = await Promise.all([
-      processFileUpload({
-        file: createFile('a.pdf', 'application/pdf'),
-        nodeId: 'node-a',
-        ...deps,
-        uploadFileAsFile: async () => ({ id: 'file-a', name: 'a.pdf', size: '1024', url: 'https://example.com/a.pdf' }),
-      }),
-      processFileUpload({
-        file: createFile('b.pdf', 'application/pdf'),
-        nodeId: 'node-b',
-        ...deps,
-        uploadFileAsFile: async () => ({ id: 'file-b', name: 'b.pdf', size: '2048', url: 'https://example.com/b.pdf' }),
-      }),
-    ]);
+    const resultA = processFileUpload({
+      file: createFile('a.pdf', 'application/pdf'),
+      nodeId: 'node-a',
+      ...deps,
+      uploadFileAsFile: () => uploadA.promise,
+    });
+    const resultB = processFileUpload({
+      file: createFile('b.pdf', 'application/pdf'),
+      nodeId: 'node-b',
+      ...deps,
+      uploadFileAsFile: () => uploadB.promise,
+    });
 
-    expect(result1).toBe('uploaded');
-    expect(result2).toBe('uploaded');
+    uploadB.resolve({ id: 'file-b', name: 'b.pdf', size: '2048', url: 'https://example.com/b.pdf' });
+    await expect(resultB).resolves.toBe('uploaded');
+    expect(messages).toEqual([createSetFileAttrsMessage('node-b', 'file-b')]);
+
+    uploadA.resolve({ id: 'file-a', name: 'a.pdf', size: '1024', url: 'https://example.com/a.pdf' });
+    await expect(resultA).resolves.toBe('uploaded');
+
     expect(assets.has('file-a')).toBe(true);
     expect(assets.has('file-b')).toBe(true);
     expect(inflight.has('node-a')).toBe(false);
     expect(inflight.has('node-b')).toBe(false);
-    expect(messages).toHaveLength(2);
+    expect(messages).toEqual([createSetFileAttrsMessage('node-b', 'file-b'), createSetFileAttrsMessage('node-a', 'file-a')]);
   });
 
   it('first upload success does not affect second upload failure', async () => {

--- a/apps/website/src/lib/utils/blob.svelte
+++ b/apps/website/src/lib/utils/blob.svelte
@@ -1,7 +1,11 @@
 <script lang="ts" module>
   import ky from 'ky';
+  import pLimit from 'p-limit';
   import { mearieClient } from '$lib/graphql';
   import { graphql } from '$mearie';
+
+  const MAX_CONCURRENT_BLOB_UPLOADS = 5;
+  const limitBlobUploads = pLimit(MAX_CONCURRENT_BLOB_UPLOADS);
 
   const issueBlobUploadUrlMutation = graphql(`
     mutation BlobUtils_IssueBlobUploadUrl($input: IssueBlobUploadUrlInput!) {
@@ -39,26 +43,27 @@
     }
   `);
 
-  export const uploadBlob = async (file: File) => {
-    const {
-      issueBlobUploadUrl: { path, url, fields },
-    } = await mearieClient.mutation(issueBlobUploadUrlMutation, { input: { filename: file.name } });
+  export const uploadBlob = (file: File) =>
+    limitBlobUploads(async () => {
+      const {
+        issueBlobUploadUrl: { path, url, fields },
+      } = await mearieClient.mutation(issueBlobUploadUrlMutation, { input: { filename: file.name } });
 
-    const formData = new FormData();
-    for (const [key, value] of Object.entries<string>(fields)) {
-      formData.append(key, value);
-    }
+      const formData = new FormData();
+      for (const [key, value] of Object.entries<string>(fields)) {
+        formData.append(key, value);
+      }
 
-    formData.append('Content-Type', file.type);
-    formData.append('file', file);
+      formData.append('Content-Type', file.type);
+      formData.append('file', file);
 
-    await ky.post(url, {
-      body: formData,
-      timeout: false,
+      await ky.post(url, {
+        body: formData,
+        timeout: false,
+      });
+
+      return path;
     });
-
-    return path;
-  };
 
   export const uploadBlobAsFile = async (file: File) => {
     const path = await uploadBlob(file);

--- a/apps/website/src/lib/utils/blob.test.ts
+++ b/apps/website/src/lib/utils/blob.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { uploadBlob } from './blob.svelte';
+
+const mocks = vi.hoisted(() => ({
+  mutation: vi.fn(),
+  post: vi.fn(),
+}));
+
+vi.mock('$lib/graphql', () => ({
+  mearieClient: { mutation: mocks.mutation },
+}));
+
+vi.mock('$mearie', () => ({
+  graphql: vi.fn(() => ({})),
+}));
+
+vi.mock('ky', () => ({
+  default: { post: mocks.post },
+}));
+
+const files = Array.from({ length: 6 }, (_, index) => new File([`file-${index}`], `file-${index}.txt`, { type: 'text/plain' }));
+
+const prepareTransfers = () => {
+  const transfers = files.map(() => Promise.withResolvers<boolean>());
+  let transferIndex = 0;
+  let active = 0;
+  let maxActive = 0;
+
+  mocks.mutation.mockImplementation(async (_document, { input }: { input: { filename: string } }) => ({
+    issueBlobUploadUrl: {
+      path: `path/${input.filename}`,
+      url: `https://uploads.example/${input.filename}`,
+      fields: {},
+    },
+  }));
+  mocks.post.mockImplementation(() => {
+    const transfer = transfers[transferIndex++];
+    active++;
+    maxActive = Math.max(maxActive, active);
+    return transfer.promise.finally(() => active--);
+  });
+
+  return { transfers, maxActive: () => maxActive };
+};
+
+describe('blob upload concurrency', () => {
+  beforeEach(() => {
+    mocks.mutation.mockReset();
+    mocks.post.mockReset();
+  });
+
+  it('starts the sixth transfer after one of five succeeds', async () => {
+    const { transfers, maxActive } = prepareTransfers();
+    const uploads = files.map(uploadBlob);
+
+    try {
+      await vi.waitFor(() => expect(mocks.post).toHaveBeenCalledTimes(5));
+      expect(mocks.mutation).toHaveBeenCalledTimes(5);
+      expect(maxActive()).toBe(5);
+
+      transfers[0].resolve(true);
+      await vi.waitFor(() => expect(mocks.post).toHaveBeenCalledTimes(6));
+
+      for (const { resolve } of transfers.slice(1)) resolve(true);
+      await expect(Promise.all(uploads)).resolves.toHaveLength(6);
+      expect(maxActive()).toBe(5);
+    } finally {
+      for (const { resolve } of transfers) resolve(true);
+      await Promise.allSettled(uploads);
+    }
+  });
+
+  it('starts the sixth transfer after one of five fails', async () => {
+    const { transfers, maxActive } = prepareTransfers();
+    const uploads = files.map((file) => uploadBlob(file).catch((err: unknown) => err));
+
+    try {
+      await vi.waitFor(() => expect(mocks.post).toHaveBeenCalledTimes(5));
+      expect(mocks.mutation).toHaveBeenCalledTimes(5);
+      expect(maxActive()).toBe(5);
+
+      transfers[0].reject(new Error('transfer failed'));
+      await vi.waitFor(() => expect(mocks.post).toHaveBeenCalledTimes(6));
+
+      for (const { resolve } of transfers.slice(1)) resolve(true);
+      const results = await Promise.all(uploads);
+      expect(results[0]).toBeInstanceOf(Error);
+      expect(maxActive()).toBe(5);
+    } finally {
+      for (const { resolve } of transfers) resolve(true);
+      await Promise.allSettled(uploads);
+    }
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -535,6 +535,9 @@ importers:
       nanoid:
         specifier: ^5.1.16
         version: 5.1.16
+      p-limit:
+        specifier: ^7.3.0
+        version: 7.3.0
       query-string:
         specifier: ^9.4.1
         version: 9.4.1
@@ -7265,6 +7268,10 @@ packages:
   p-limit@5.0.0:
     resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
     engines: {node: '>=18'}
+
+  p-limit@7.3.0:
+    resolution: {integrity: sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==}
+    engines: {node: '>=20'}
 
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
@@ -15694,6 +15701,10 @@ snapshots:
       yocto-queue: 0.1.0
 
   p-limit@5.0.0:
+    dependencies:
+      yocto-queue: 1.2.2
+
+  p-limit@7.3.0:
     dependencies:
       yocto-queue: 1.2.2
 


### PR DESCRIPTION
- 앱과 웹의 blob 업로드를 전역 최대 5개로 제한
  - 앱은 `Semaphore`, 웹은 `p-limit` 사용
- 업로드 URL 발급과 blob 전송만 제한하고 asset persist와 임베드 unfurl은 기존 경로 유지
- 성공/실패 시 다음 업로드가 진행되고, 완료 순서와 관계없이 각 노드에 올바른 asset ID가 반영되는 테스트 추가

5개의 근거
- Uppy XHR Upload: 기본 5개
- Uppy AWS S3: 기본 6개
- Apple URLSession: 호스트별 기본 연결 수 6개