### PR TITLE
웹 에디터 extension area 복구

### DIFF
--- a/apps/website/src/lib/editor-ffi/components/View.svelte
+++ b/apps/website/src/lib/editor-ffi/components/View.svelte
@@ -256,10 +256,9 @@
       <EditorZoom {active} editor={ctx.editor} {isPaginated} {pageWidth} viewportWidth={clientWidth ?? 0}>
         <!-- svelte-ignore a11y_click_events_have_key_events -->
         <div
-          bind:this={ctx.editor.surfaceEl}
+          bind:this={ctx.editor.extensionAreaEl}
           style:cursor
           style:min-width={editorMinWidth}
-          style:max-width={continuousMaxFrameWidth}
           style:padding-bottom={`${ctx.scroll?.bottomPadding ?? 0}px`}
           class={css({
             position: 'relative',
@@ -268,7 +267,6 @@
             alignItems: 'center',
             flexGrow: '1',
             width: 'full',
-            marginX: 'auto',
             userSelect: 'none',
             ...(isPaginated && {
               rowGap: 'var(--page-gap)',

--- a/apps/website/src/lib/editor-ffi/components/ViewportOverlay.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ViewportOverlay.svelte
@@ -43,7 +43,7 @@
     if (!editor) return;
 
     const scrollContainer = editor.scrollContainerEl;
-    const surface = editor.surfaceEl;
+    const extensionAreaEl = editor.extensionAreaEl;
     const visualViewport = window.visualViewport;
     const passive = { passive: true } as AddEventListenerOptions;
     const passiveCapture = { passive: true, capture: true } as AddEventListenerOptions;
@@ -55,7 +55,7 @@
     visualViewport?.addEventListener('scroll', overlay.requestSync, passive);
     visualViewport?.addEventListener('resize', overlay.requestSync, passive);
     if (scrollContainer) resizeObserver?.observe(scrollContainer);
-    if (surface) resizeObserver?.observe(surface);
+    if (extensionAreaEl) resizeObserver?.observe(extensionAreaEl);
 
     overlay.requestSync();
 

--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -489,7 +489,7 @@ export class Editor {
 
   inputEl = $state<HTMLTextAreaElement>();
   pageEls = $state<Record<number, HTMLDivElement | undefined>>({});
-  surfaceEl = $state<HTMLDivElement>();
+  extensionAreaEl = $state<HTMLDivElement>();
   scrollContainerEl = $state<HTMLDivElement>();
   scrollViewport = $state<ScrollViewport>();
   scrollRootEl = $state<HTMLElement | null>();


### PR DESCRIPTION
- #4430 에서 발생한 회귀를 수정
- surfaceArea 대신 extensionArea 라는 명시적인 이름 사용