### PR TITLE
앱 continuous 페이지 너비 디버그

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/body/EditorBodyGeometry.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/body/EditorBodyGeometry.kt
@@ -27,27 +27,18 @@ internal fun resolveEditorBodyGeometry(
       1f
     }
   val visibleBodySize = visibleArea.visibleBodySize
-  val maxPageWidth = pageSizes.maxOfOrNull(PageSize::width) ?: 0f
-  val preferredPageWidth =
-    when (layoutSpec) {
-      is EditorDocumentLayoutSpec.Continuous -> layoutSpec.maxWidth
-      is EditorDocumentLayoutSpec.Paginated -> layoutSpec.pageWidth
-    }
+  val maxPageWidth = resolveEditorPageWidth(pageSizes) ?: 0f
   val pageColumnWidth =
     when (layoutSpec) {
       is EditorDocumentLayoutSpec.Continuous ->
         when {
-          preferredPageWidth > 0f && visibleBodySize.width > 0f ->
-            preferredPageWidth.coerceAtMost(visibleBodySize.width)
-          preferredPageWidth > 0f -> preferredPageWidth
-          maxPageWidth > 0f && visibleBodySize.width > 0f ->
-            maxPageWidth.coerceAtMost(visibleBodySize.width)
+          // Continuous.maxWidth caps content; engine page sizes also include its page margins.
           maxPageWidth > 0f -> maxPageWidth
           else -> visibleBodySize.width
         }
       is EditorDocumentLayoutSpec.Paginated ->
         when {
-          preferredPageWidth > 0f -> preferredPageWidth * effectiveDisplayZoom
+          layoutSpec.pageWidth > 0f -> layoutSpec.pageWidth * effectiveDisplayZoom
           maxPageWidth > 0f -> maxPageWidth * effectiveDisplayZoom
           else -> visibleBodySize.width
         }
@@ -70,6 +61,9 @@ internal fun resolveEditorBodyGeometry(
       },
   )
 }
+
+internal fun resolveEditorPageWidth(pageSizes: List<PageSize>): Float? =
+  pageSizes.asSequence().map(PageSize::width).filter { it.isFinite() && it > 0f }.maxOrNull()
 
 internal fun resolveMinimumBodyHeight(
   viewportHeight: Float,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -55,6 +55,7 @@ import co.typie.editor.body.EditorBody
 import co.typie.editor.body.EditorDocumentLayoutSpec
 import co.typie.editor.body.resolveBaseBottomSpace
 import co.typie.editor.body.resolveEditorBodyGeometry
+import co.typie.editor.body.resolveEditorPageWidth
 import co.typie.editor.body.resolvePagesContentHeight
 import co.typie.editor.body.toEditorDocumentLayoutSpec
 import co.typie.editor.external.EditorExternalElementState
@@ -939,14 +940,13 @@ fun EditorScreen(entityId: String) {
         targetLineHeight = typewriterTargetLineHeight,
       )
     val bodyTrackWidth = bodyGeometry.pageColumnWidth.coerceAtLeast(0f)
-    val isPaginatedLayout = layoutSpec is EditorDocumentLayoutSpec.Paginated
     val headerTrackWidth =
-      if (isPaginatedLayout) {
-          visibleArea.visibleBodySize.width
-        } else {
-          bodyTrackWidth
-        }
-        .coerceAtLeast(0f)
+      resolveEditorHeaderTrackWidth(
+        layoutSpec = layoutSpec,
+        resolvedPageWidth = resolveEditorPageWidth(pageSizes),
+        visibleBodyWidth = visibleArea.visibleBodySize.width,
+        bodyTrackWidth = bodyTrackWidth,
+      )
     val viewportScrollableState = rememberScrollable2DState { delta ->
       consumeEditorViewportTouchPan(
         viewportState = screenState.viewportState,
@@ -1361,6 +1361,22 @@ fun EditorScreen(entityId: String) {
     }
   }
 }
+
+internal fun resolveEditorHeaderTrackWidth(
+  layoutSpec: EditorDocumentLayoutSpec,
+  resolvedPageWidth: Float?,
+  visibleBodyWidth: Float,
+  bodyTrackWidth: Float,
+): Float =
+  when (layoutSpec) {
+    is EditorDocumentLayoutSpec.Continuous ->
+      if (resolvedPageWidth != null && resolvedPageWidth.isFinite() && resolvedPageWidth > 0f) {
+        bodyTrackWidth
+      } else {
+        0f
+      }
+    is EditorDocumentLayoutSpec.Paginated -> visibleBodyWidth
+  }.coerceAtLeast(0f)
 
 @Composable
 private fun EditorBodyLoadingSkeleton(modifier: Modifier = Modifier) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/header/EditorHeader.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/header/EditorHeader.kt
@@ -94,7 +94,7 @@ internal fun EditorHeader(
   ) {
     val contentModifier = Modifier.run {
       when {
-        layoutSpec is EditorDocumentLayoutSpec.Paginated && trackWidth > 0f -> width(trackWidth.dp)
+        trackWidth > 0f -> width(trackWidth.dp)
         else -> widthIn(max = ResponsiveContainerDefaults.MaxWidth).fillMaxWidth()
       }
     }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/body/EditorBodyGeometryTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/body/EditorBodyGeometryTest.kt
@@ -8,7 +8,7 @@ import kotlin.test.assertEquals
 
 class EditorBodyGeometryTest {
   @Test
-  fun `geometry respects visible occlusion when resolving body height and page column width`() {
+  fun `continuous geometry uses the engine page width after content reaches its cap`() {
     val geometry =
       resolveEditorBodyGeometry(
         visibleArea =
@@ -19,13 +19,31 @@ class EditorBodyGeometryTest {
             imeInset = 100f,
           ),
         layoutSpec = EditorDocumentLayoutSpec.Continuous(maxWidth = 600f),
-        pageSizes = listOf(PageSize(width = 600f, height = 800f)),
+        pageSizes = listOf(PageSize(width = 640f, height = 800f)),
         displayZoom = 1f,
       )
 
-    assertEquals(600f, geometry.pageColumnWidth)
+    assertEquals(640f, geometry.pageColumnWidth)
     assertEquals(620f, geometry.minimumBodyHeight)
     assertEquals(40f, geometry.topSpacerHeight)
+  }
+
+  @Test
+  fun `continuous geometry follows the engine page width across the content cap boundary`() {
+    val geometry =
+      resolveEditorBodyGeometry(
+        visibleArea =
+          EditorVisibleArea(
+            viewport = Size(width = 620f, height = 900f),
+            headerHeight = 120f,
+            topInset = 120f,
+          ),
+        layoutSpec = EditorDocumentLayoutSpec.Continuous(maxWidth = 600f),
+        pageSizes = listOf(PageSize(width = 620f, height = 800f)),
+        displayZoom = 1f,
+      )
+
+    assertEquals(620f, geometry.pageColumnWidth)
   }
 
   @Test
@@ -46,6 +64,29 @@ class EditorBodyGeometryTest {
     assertEquals(360f, geometry.pageColumnWidth)
     assertEquals(568f, geometry.minimumBodyHeight)
     assertEquals(40f, geometry.topSpacerHeight)
+  }
+
+  @Test
+  fun `continuous geometry ignores invalid engine page widths`() {
+    val geometry =
+      resolveEditorBodyGeometry(
+        visibleArea =
+          EditorVisibleArea(
+            viewport = Size(width = 720f, height = 900f),
+            headerHeight = 120f,
+            topInset = 120f,
+          ),
+        layoutSpec = EditorDocumentLayoutSpec.Continuous(maxWidth = 600f),
+        pageSizes =
+          listOf(
+            PageSize(width = 0f, height = 800f),
+            PageSize(width = -1f, height = 800f),
+            PageSize(width = Float.POSITIVE_INFINITY, height = 800f),
+          ),
+        displayZoom = 1f,
+      )
+
+    assertEquals(720f, geometry.pageColumnWidth)
   }
 
   @Test

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/EditorHeaderTrackWidthTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/EditorHeaderTrackWidthTest.kt
@@ -1,0 +1,67 @@
+package co.typie.screen.editor.editor
+
+import co.typie.editor.body.EditorDocumentLayoutSpec
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class EditorHeaderTrackWidthTest {
+  @Test
+  fun `continuous header uses the responsive fallback before page metrics arrive`() {
+    val width =
+      resolveEditorHeaderTrackWidth(
+        layoutSpec = EditorDocumentLayoutSpec.Continuous(maxWidth = 600f),
+        resolvedPageWidth = null,
+        visibleBodyWidth = 720f,
+        bodyTrackWidth = 720f,
+      )
+
+    assertEquals(0f, width)
+  }
+
+  @Test
+  fun `continuous header uses the resolved body track after page metrics arrive`() {
+    val width =
+      resolveEditorHeaderTrackWidth(
+        layoutSpec = EditorDocumentLayoutSpec.Continuous(maxWidth = 600f),
+        resolvedPageWidth = 640f,
+        visibleBodyWidth = 720f,
+        bodyTrackWidth = 640f,
+      )
+
+    assertEquals(640f, width)
+  }
+
+  @Test
+  fun `continuous header keeps the responsive fallback for an invalid page width`() {
+    val width =
+      resolveEditorHeaderTrackWidth(
+        layoutSpec = EditorDocumentLayoutSpec.Continuous(maxWidth = 600f),
+        resolvedPageWidth = Float.POSITIVE_INFINITY,
+        visibleBodyWidth = 720f,
+        bodyTrackWidth = 720f,
+      )
+
+    assertEquals(0f, width)
+  }
+
+  @Test
+  fun `paginated header keeps using the visible body width`() {
+    val width =
+      resolveEditorHeaderTrackWidth(
+        layoutSpec =
+          EditorDocumentLayoutSpec.Paginated(
+            pageWidth = 720f,
+            pageHeight = 960f,
+            pageMarginTop = 72f,
+            pageMarginBottom = 72f,
+            pageMarginLeft = 64f,
+            pageMarginRight = 64f,
+          ),
+        resolvedPageWidth = null,
+        visibleBodyWidth = 960f,
+        bodyTrackWidth = 720f,
+      )
+
+    assertEquals(960f, width)
+  }
+}

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/header/EditorHeaderDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/header/EditorHeaderDesktopTest.kt
@@ -1,0 +1,61 @@
+package co.typie.screen.editor.editor.header
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import co.typie.editor.body.EditorDocumentLayoutSpec
+import co.typie.ui.theme.LocalThemeMode
+import co.typie.ui.theme.ResolvedThemeMode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+class EditorHeaderDesktopTest {
+  @Test
+  fun continuousHeaderAlignsTitleFieldToTheProvidedPageTrack() = runComposeUiTest {
+    setContent {
+      CompositionLocalProvider(
+        LocalDensity provides Density(1f),
+        LocalThemeMode provides ResolvedThemeMode.Light,
+      ) {
+        Box(Modifier.width(720.dp)) {
+          EditorHeader(
+            title = Title,
+            subtitle = "",
+            layoutSpec = EditorDocumentLayoutSpec.Continuous(maxWidth = 600f),
+            trackWidth = 640f,
+            loading = false,
+            topInset = 0.dp,
+            onTitleChange = {},
+            onSubtitleChange = {},
+            onTitleFocused = {},
+            onSubtitleFocused = {},
+            onHeightChanged = {},
+            onEnterDocument = {},
+          )
+        }
+      }
+    }
+    waitForIdle()
+
+    val titleWidth =
+      onNode(hasText(Title) and hasSetTextAction(), useUnmergedTree = true)
+        .fetchSemanticsNode()
+        .boundsInRoot
+        .width
+
+    assertEquals(600f, titleWidth, absoluteTolerance = 0.01f)
+  }
+
+  private companion object {
+    const val Title = "Document title"
+  }
+}


### PR DESCRIPTION
- #4325에서 continuous `max_width`가 페이지 폭이 아니라 콘텐츠 최대 폭을 뜻하도록 바뀌었지만, 앱은 기존처럼 page track 폭으로 해석해 넓은 viewport에서 엔진 페이지보다 40px 좁은 트랙을 만들고 있었음
- 본문과 external element가 놓이는 body track, header track이 엔진의 유효한 `pageSizes.width`를 공통 기준으로 사용하도록 변경
- page metrics가 도착하기 전이거나 width가 유효하지 않으면 responsive fallback을 유지하고, paginated 동작은 변경하지 않음 -> 문제가 많음. 후속 PR에서 수정 예정