### PR TITLE
앱 네트워크 복구 시 active query 재시도

### DIFF
--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/platform/ConnectivityMonitor.android.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/platform/ConnectivityMonitor.android.kt
@@ -3,17 +3,32 @@ package co.typie.platform
 import android.content.Context
 import android.net.ConnectivityManager
 import android.net.Network
+import android.net.NetworkCapabilities
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 
-actual fun connectivityRestoredFlow(): Flow<Unit> = callbackFlow {
+actual fun connectivityAvailabilityFlow(): Flow<Boolean> = callbackFlow {
   val manager =
     PlatformModule.context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+  var defaultNetwork: Network? = null
   val callback =
     object : ConnectivityManager.NetworkCallback() {
       override fun onAvailable(network: Network) {
-        trySend(Unit)
+        defaultNetwork = network
+      }
+
+      override fun onCapabilitiesChanged(network: Network, capabilities: NetworkCapabilities) {
+        if (network == defaultNetwork) {
+          trySend(capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED))
+        }
+      }
+
+      override fun onLost(network: Network) {
+        if (network == defaultNetwork) {
+          defaultNetwork = null
+          trySend(false)
+        }
       }
     }
   manager.registerDefaultNetworkCallback(callback)

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/subscription/SubscriptionService.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/subscription/SubscriptionService.kt
@@ -23,7 +23,7 @@ sealed interface SubscriptionServiceState {
 }
 
 object SubscriptionService {
-  private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+  private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
   private val query = Apollo.watchQuery(scope = scope) { SubscriptionService_Query() }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/graphql/WatchQuery.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/graphql/WatchQuery.kt
@@ -6,8 +6,15 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import co.touchlab.kermit.Logger
 import co.typie.contract.Loadable
+import co.typie.platform.AppLifecycleService
+import co.typie.platform.AppLifecycleState
+import co.typie.platform.ConnectivityService
+import co.typie.platform.appLifecycleService as defaultAppLifecycleService
+import co.typie.platform.connectivityService as defaultConnectivityService
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.exception.ApolloNetworkException
+import com.apollographql.apollo.exception.ApolloOfflineException
 import com.apollographql.apollo.exception.CacheMissException
 import com.apollographql.cache.normalized.FetchPolicy
 import com.apollographql.cache.normalized.fetchPolicy
@@ -15,20 +22,26 @@ import com.apollographql.cache.normalized.refetchPolicyInterceptor
 import com.apollographql.cache.normalized.watch
 import io.sentry.kotlin.multiplatform.Sentry
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 
 class WatchQuery<D : Query.Data, out R>
-private constructor(
-  private val scope: CoroutineScope,
+internal constructor(
+  scope: CoroutineScope,
   private val apolloClient: ApolloClient,
   private val query: () -> Query<D>,
   private val placeholderData: D?,
   private val onInitialData: (suspend (D) -> Unit)?,
   private val skip: () -> Boolean = { false },
   private val resetOnChange: Boolean = true,
+  private val appLifecycleService: AppLifecycleService = defaultAppLifecycleService,
+  private val connectivityService: ConnectivityService = defaultConnectivityService,
+  stateDispatcher: CoroutineDispatcher = Dispatchers.Main.immediate,
 ) : Loadable<D> {
   override var state: QueryState<D> by mutableStateOf(QueryState.Loading)
     private set
@@ -69,9 +82,11 @@ private constructor(
 
   private var job: Job? = null
   private var initialized = false
+  private var recoveryGeneration = 0L
+  private val stateScope = CoroutineScope(scope.coroutineContext + stateDispatcher)
 
   init {
-    scope.launch {
+    stateScope.launch {
       snapshotFlow {
           val shouldSkip = skip()
           shouldSkip to if (shouldSkip) null else query()
@@ -85,6 +100,31 @@ private constructor(
           }
         }
     }
+
+    stateScope.launch {
+      var foregroundGeneration = appLifecycleService.snapshot.value.foregroundGeneration
+      var connectivityGeneration = connectivityService.restorationGeneration.value
+      combine(appLifecycleService.snapshot, connectivityService.restorationGeneration) {
+          lifecycle,
+          connectivity ->
+          lifecycle to connectivity
+        }
+        .collect { (lifecycle, connectivity) ->
+          val returnedToForeground = lifecycle.foregroundGeneration > foregroundGeneration
+          val restoredInForeground =
+            connectivity > connectivityGeneration && lifecycle.state == AppLifecycleState.Foreground
+          foregroundGeneration = lifecycle.foregroundGeneration
+          connectivityGeneration = connectivity
+
+          if (returnedToForeground || restoredInForeground) {
+            recoveryGeneration += 1
+            val error = (state as? QueryState.Error)?.exception
+            if (error?.isRecoverableNetworkError() == true) {
+              refetch()
+            }
+          }
+        }
+    }
   }
 
   private fun execute(query: Query<D>, resetState: Boolean = false) {
@@ -95,7 +135,8 @@ private constructor(
       state = QueryState.Loading
     }
 
-    job = scope.launch {
+    val attemptRecoveryGeneration = recoveryGeneration
+    job = stateScope.launch {
       try {
         apolloClient
           .query(query)
@@ -117,36 +158,44 @@ private constructor(
               val error =
                 response.exception ?: response.errors?.firstOrNull()?.let { Exception(it.message) }
               if (error != null) {
-                stateQuery = query
-                state = QueryState.Error(error)
-                runCatching {
-                  Logger.e {
-                    "GraphQL error (${query.name()}): ${error.message ?: "unknown error"}"
-                  }
-                }
-                runCatching { Sentry.captureException(error) }
+                publishError(query, error, attemptRecoveryGeneration)
               }
             }
           }
       } catch (e: CancellationException) {
         throw e
       } catch (e: Exception) {
-        stateQuery = query
-        state = QueryState.Error(e)
-        runCatching { Logger.e { "GraphQL error: ${e.message ?: "unknown error"}" } }
-        runCatching { Sentry.captureException(e) }
+        publishError(query, e, attemptRecoveryGeneration)
       }
     }
   }
 
-  override fun refetch() {
-    if (skip()) {
-      return
+  private fun publishError(query: Query<D>, error: Throwable, attemptRecoveryGeneration: Long) {
+    stateQuery = query
+    state = QueryState.Error(error)
+    runCatching {
+      Logger.e { "GraphQL error (${query.name()}): ${error.message ?: "unknown error"}" }
     }
+    runCatching { Sentry.captureException(error) }
 
-    execute(query())
+    if (error.isRecoverableNetworkError() && recoveryGeneration > attemptRecoveryGeneration) {
+      refetch()
+    }
+  }
+
+  override fun refetch() {
+    stateScope.launch {
+      if (skip()) {
+        return@launch
+      }
+
+      execute(query())
+    }
   }
 }
+
+private fun Throwable.isRecoverableNetworkError(): Boolean =
+  this is ApolloNetworkException || this is ApolloOfflineException
 
 fun <D : Query.Data> ApolloClient.watchQuery(
   scope: CoroutineScope,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/platform/AppLifecycleService.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/platform/AppLifecycleService.kt
@@ -1,0 +1,43 @@
+package co.typie.platform
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+internal enum class AppLifecycleState {
+  Foreground,
+  Background,
+}
+
+internal data class AppLifecycleSnapshot(
+  val state: AppLifecycleState,
+  val foregroundGeneration: Long,
+)
+
+internal class AppLifecycleService {
+  private val mutableSnapshot =
+    MutableStateFlow(
+      AppLifecycleSnapshot(state = AppLifecycleState.Background, foregroundGeneration = 0L)
+    )
+  private var hasBeenForeground = false
+
+  val snapshot: StateFlow<AppLifecycleSnapshot> = mutableSnapshot.asStateFlow()
+
+  fun update(foreground: Boolean) {
+    val current = mutableSnapshot.value
+    val nextState = if (foreground) AppLifecycleState.Foreground else AppLifecycleState.Background
+    if (current.state == nextState) return
+
+    val returnedToForeground = nextState == AppLifecycleState.Foreground && hasBeenForeground
+    mutableSnapshot.value =
+      AppLifecycleSnapshot(
+        state = nextState,
+        foregroundGeneration = current.foregroundGeneration + if (returnedToForeground) 1 else 0,
+      )
+    if (nextState == AppLifecycleState.Foreground) {
+      hasBeenForeground = true
+    }
+  }
+}
+
+internal val appLifecycleService = AppLifecycleService()

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/platform/ConnectivityMonitor.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/platform/ConnectivityMonitor.kt
@@ -2,4 +2,4 @@ package co.typie.platform
 
 import kotlinx.coroutines.flow.Flow
 
-expect fun connectivityRestoredFlow(): Flow<Unit>
+expect fun connectivityAvailabilityFlow(): Flow<Boolean>

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/platform/ConnectivityService.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/platform/ConnectivityService.kt
@@ -1,0 +1,24 @@
+package co.typie.platform
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+internal class ConnectivityService(private val availability: Flow<Boolean>) {
+  private val mutableRestorationGeneration = MutableStateFlow(0L)
+
+  val restorationGeneration: StateFlow<Long> = mutableRestorationGeneration.asStateFlow()
+
+  suspend fun monitor() {
+    var previous: Boolean? = null
+    availability.collect { available ->
+      if (previous == false && available) {
+        mutableRestorationGeneration.value += 1
+      }
+      previous = available
+    }
+  }
+}
+
+internal val connectivityService = ConnectivityService(connectivityAvailabilityFlow())

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -112,7 +112,7 @@ import co.typie.ext.ime
 import co.typie.graphql.QueryState
 import co.typie.navigation.Nav
 import co.typie.platform.PlatformModule
-import co.typie.platform.connectivityRestoredFlow
+import co.typie.platform.connectivityService
 import co.typie.route.Route
 import co.typie.screen.document.document.DocumentCharacterCountSnapshots
 import co.typie.screen.editor.editor.aifeedback.AiFeedbackOptInSheet
@@ -298,15 +298,13 @@ fun EditorScreen(entityId: String) {
         .distinct()
         .sorted()
     }
+  LaunchedEffect(assetHydrator) {
+    connectivityService.restorationGeneration.drop(1).collect { generation ->
+      assetHydrator.onConnectivityRestored(generation)
+    }
+  }
   LaunchedEffect(assetHydrator, assetQueryGeneration, externalAssetIds) {
     assetHydrator.resolve(externalAssetIds)
-  }
-  LaunchedEffect(assetHydrator) {
-    var connectivityGeneration = 0L
-    connectivityRestoredFlow().collect {
-      connectivityGeneration += 1
-      assetHydrator.onConnectivityRestored(connectivityGeneration)
-    }
   }
   LaunchedEffect(subPaneState.active, editorState.selection) {
     subPaneState.dismissTableAxisActionsIfSelectionChanged(editorState.selection)

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/shell/RootShell.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/shell/RootShell.kt
@@ -27,7 +27,8 @@ import co.typie.domain.pushnotification.PushNotificationService
 import co.typie.domain.pushnotification.PushNotificationToastEffect
 import co.typie.editor.sync.ActiveSyncEngines
 import co.typie.editor.sync.orphanSweeper
-import co.typie.platform.connectivityRestoredFlow
+import co.typie.platform.appLifecycleService
+import co.typie.platform.connectivityService
 import co.typie.route.AuthRoutes
 import co.typie.route.MainRoutes
 import co.typie.screen.system.maintenance.MaintenanceScreen
@@ -52,6 +53,7 @@ import co.typie.ui.component.toast.ToastOverlay
 import co.typie.ui.theme.AppTheme
 import co.typie.ui.theme.LocalHazeState
 import dev.chrisbanes.haze.hazeSource
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 
@@ -68,8 +70,10 @@ fun RootShell() {
   LaunchedEffect(Unit) { BootstrapService.launch() }
   LaunchedEffect(Unit) { PushNotificationService.launch() }
 
+  LaunchedEffect(Unit) { connectivityService.monitor() }
+
   LaunchedEffect(Unit) {
-    connectivityRestoredFlow().collect {
+    connectivityService.restorationGeneration.drop(1).collect {
       ActiveSyncEngines.retryAll()
       orphanSweeper.sweep()
     }
@@ -87,10 +91,19 @@ fun RootShell() {
   val lifecycleOwner = LocalLifecycleOwner.current
   val lifecycleScope = rememberCoroutineScope()
   DisposableEffect(lifecycleOwner) {
+    appLifecycleService.update(
+      foreground = lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)
+    )
     val observer = LifecycleEventObserver { _, event ->
       when (event) {
-        Lifecycle.Event.ON_START -> lifecycleScope.launch { orphanSweeper.sweep() }
-        Lifecycle.Event.ON_STOP -> lifecycleScope.launch { ActiveSyncEngines.flushAll() }
+        Lifecycle.Event.ON_START -> {
+          appLifecycleService.update(foreground = true)
+          lifecycleScope.launch { orphanSweeper.sweep() }
+        }
+        Lifecycle.Event.ON_STOP -> {
+          appLifecycleService.update(foreground = false)
+          lifecycleScope.launch { ActiveSyncEngines.flushAll() }
+        }
         else -> {}
       }
     }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/graphql/WatchQueryTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/graphql/WatchQueryTest.kt
@@ -1,0 +1,276 @@
+package co.typie.graphql
+
+import co.typie.platform.AppLifecycleService
+import co.typie.platform.ConnectivityService
+import com.apollographql.apollo.ApolloClient
+import com.apollographql.apollo.api.ApolloRequest
+import com.apollographql.apollo.api.ApolloResponse
+import com.apollographql.apollo.api.Operation
+import com.apollographql.apollo.exception.ApolloException
+import com.apollographql.apollo.exception.ApolloHttpException
+import com.apollographql.apollo.exception.ApolloNetworkException
+import com.apollographql.apollo.exception.ApolloOfflineException
+import com.apollographql.apollo.exception.JsonDataException
+import com.apollographql.apollo.network.NetworkTransport
+import com.apollographql.cache.normalized.memory.MemoryCacheFactory
+import com.apollographql.cache.normalized.normalizedCache
+import kotlin.coroutines.CoroutineContext
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WatchQueryTest {
+  @Test
+  fun foregroundReturnRetriesNetworkError() = runTest {
+    val lifecycle = AppLifecycleService().apply { update(foreground = true) }
+    val releaseRetry = CompletableDeferred<Unit>()
+    val transport = TestNetworkTransport { attempt ->
+      if (attempt == 2) releaseRetry.await()
+      ApolloNetworkException("offline")
+    }
+    val query = watchQuery(transport, lifecycle)
+    runCurrent()
+
+    assertEquals(1, transport.attempts)
+    assertIs<QueryState.Error>(query.state)
+
+    lifecycle.update(foreground = false)
+    lifecycle.update(foreground = true)
+    runCurrent()
+
+    assertIs<QueryState.Loading>(query.state)
+    assertEquals(2, transport.attempts)
+    releaseRetry.complete(Unit)
+  }
+
+  @Test
+  fun connectivityRestorationRetriesOnlyInForeground() = runTest {
+    val lifecycle = AppLifecycleService().apply { update(foreground = true) }
+    val availability = MutableSharedFlow<Boolean>()
+    val connectivity = ConnectivityService(availability)
+    backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { connectivity.monitor() }
+    availability.emit(true)
+    val transport = TestNetworkTransport { ApolloNetworkException("offline") }
+    val query = watchQuery(transport, lifecycle, connectivity)
+    runCurrent()
+    assertIs<QueryState.Error>(query.state)
+
+    lifecycle.update(foreground = false)
+    availability.emit(false)
+    availability.emit(true)
+    runCurrent()
+
+    assertEquals(1, transport.attempts)
+
+    lifecycle.update(foreground = true)
+    runCurrent()
+
+    assertEquals(2, transport.attempts)
+  }
+
+  @Test
+  fun connectivityRestorationInForegroundRetriesNetworkError() = runTest {
+    val lifecycle = AppLifecycleService().apply { update(foreground = true) }
+    val availability = MutableSharedFlow<Boolean>()
+    val connectivity = ConnectivityService(availability)
+    backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { connectivity.monitor() }
+    availability.emit(true)
+    val transport = TestNetworkTransport { ApolloNetworkException("offline") }
+    val query = watchQuery(transport, lifecycle, connectivity)
+    runCurrent()
+    assertIs<QueryState.Error>(query.state)
+
+    availability.emit(false)
+    availability.emit(true)
+    runCurrent()
+
+    assertEquals(2, transport.attempts)
+  }
+
+  @Test
+  fun foregroundReturnRetriesApolloOfflineError() = runTest {
+    val lifecycle = AppLifecycleService().apply { update(foreground = true) }
+    val transport = TestNetworkTransport { ApolloOfflineException() }
+    val query = watchQuery(transport, lifecycle)
+    runCurrent()
+    assertIs<QueryState.Error>(query.state)
+
+    lifecycle.update(foreground = false)
+    lifecycle.update(foreground = true)
+    runCurrent()
+
+    assertEquals(2, transport.attempts)
+  }
+
+  @Test
+  fun nonNetworkErrorsDoNotRecover() = runTest {
+    val errors =
+      listOf<ApolloException>(
+        JsonDataException("invalid data"),
+        ApolloHttpException(503, emptyList(), null, "unavailable"),
+      )
+
+    errors.forEach { error ->
+      val lifecycle = AppLifecycleService().apply { update(foreground = true) }
+      val transport = TestNetworkTransport { error }
+      val query = watchQuery(transport, lifecycle)
+      runCurrent()
+      assertIs<QueryState.Error>(query.state)
+
+      lifecycle.update(foreground = false)
+      lifecycle.update(foreground = true)
+      runCurrent()
+
+      assertEquals(1, transport.attempts)
+    }
+  }
+
+  @Test
+  fun skippedQueryDoesNotRecover() = runTest {
+    val lifecycle = AppLifecycleService().apply { update(foreground = true) }
+    val transport = TestNetworkTransport { ApolloNetworkException("offline") }
+    watchQuery(transport, lifecycle, skip = { true })
+    runCurrent()
+
+    lifecycle.update(foreground = false)
+    lifecycle.update(foreground = true)
+    runCurrent()
+
+    assertEquals(0, transport.attempts)
+  }
+
+  @Test
+  fun cancelledScopeDoesNotRecover() = runTest {
+    val lifecycle = AppLifecycleService().apply { update(foreground = true) }
+    val transport = TestNetworkTransport { ApolloNetworkException("offline") }
+    val scope = CoroutineScope(StandardTestDispatcher(testScheduler) + SupervisorJob())
+    val query = watchQuery(transport, lifecycle, scope = scope)
+    runCurrent()
+    assertIs<QueryState.Error>(query.state)
+
+    scope.cancel()
+    lifecycle.update(foreground = false)
+    lifecycle.update(foreground = true)
+    runCurrent()
+
+    assertEquals(1, transport.attempts)
+  }
+
+  @Test
+  fun recoveryDuringRequestRetriesOnceThenStopsWithoutNewEvent() = runTest {
+    val lifecycle = AppLifecycleService().apply { update(foreground = true) }
+    val releaseFirst = CompletableDeferred<Unit>()
+    val transport = TestNetworkTransport { attempt ->
+      if (attempt == 1) releaseFirst.await()
+      ApolloNetworkException("offline")
+    }
+    val query = watchQuery(transport, lifecycle)
+    runCurrent()
+
+    assertIs<QueryState.Loading>(query.state)
+    assertEquals(1, transport.attempts)
+
+    lifecycle.update(foreground = false)
+    lifecycle.update(foreground = true)
+    runCurrent()
+    releaseFirst.complete(Unit)
+    runCurrent()
+
+    assertIs<QueryState.Error>(query.state)
+    assertEquals(2, transport.attempts)
+    runCurrent()
+    assertEquals(2, transport.attempts)
+  }
+
+  @Test
+  fun nonMainParentCannotOwnQueryStateTransitions() = runTest {
+    val lifecycle = AppLifecycleService().apply { update(foreground = true) }
+    val parentScope = CoroutineScope(SupervisorJob() + NeverDispatcher)
+    val transport = TestNetworkTransport { ApolloNetworkException("offline") }
+    val query = watchQuery(transport, lifecycle, scope = parentScope)
+    runCurrent()
+
+    assertIs<QueryState.Error>(query.state)
+    assertEquals(1, transport.attempts)
+
+    lifecycle.update(foreground = false)
+    lifecycle.update(foreground = true)
+    runCurrent()
+
+    assertIs<QueryState.Error>(query.state)
+    assertEquals(2, transport.attempts)
+    parentScope.cancel()
+  }
+
+  private fun TestScope.watchQuery(
+    transport: TestNetworkTransport,
+    lifecycle: AppLifecycleService,
+    connectivity: ConnectivityService = ConnectivityService(emptyFlow()),
+    scope: CoroutineScope = backgroundScope,
+    skip: () -> Boolean = { false },
+  ): WatchQuery<PlanUpgradeSheet_Query.Data, PlanUpgradeSheet_Query.Data?> {
+    val client =
+      ApolloClient.Builder()
+        .networkTransport(transport)
+        .dispatcher(StandardTestDispatcher(testScheduler))
+        .normalizedCache(
+          MemoryCacheFactory(maxSizeBytes = 1024 * 1024),
+          typePolicies = emptyMap(),
+          fieldPolicies = emptyMap(),
+        )
+        .build()
+    return WatchQuery(
+      scope = scope,
+      apolloClient = client,
+      query = ::PlanUpgradeSheet_Query,
+      placeholderData = null,
+      onInitialData = null,
+      skip = skip,
+      resetOnChange = true,
+      appLifecycleService = lifecycle,
+      connectivityService = connectivity,
+      stateDispatcher = StandardTestDispatcher(testScheduler),
+    )
+  }
+}
+
+private object NeverDispatcher : CoroutineDispatcher() {
+  override fun dispatch(context: CoroutineContext, block: Runnable) {}
+}
+
+private class TestNetworkTransport(
+  private val response: suspend (attempt: Int) -> ApolloException
+) : NetworkTransport {
+  var attempts = 0
+    private set
+
+  override fun <D : Operation.Data> execute(request: ApolloRequest<D>): Flow<ApolloResponse<D>> =
+    flow {
+      val exception = response(++attempts)
+      emit(
+        ApolloResponse.Builder(request.operation, request.requestUuid)
+          .exception(exception)
+          .isLast(true)
+          .build()
+      )
+    }
+
+  override fun dispose() {}
+}

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/platform/AppLifecycleServiceTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/platform/AppLifecycleServiceTest.kt
@@ -1,0 +1,64 @@
+package co.typie.platform
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AppLifecycleServiceTest {
+  @Test
+  fun initialForegroundStateIsBaselineNotReturnEvent() {
+    val service = AppLifecycleService()
+
+    service.update(foreground = true)
+    service.update(foreground = true)
+
+    assertEquals(AppLifecycleState.Foreground, service.snapshot.value.state)
+    assertEquals(0, service.snapshot.value.foregroundGeneration)
+  }
+
+  @Test
+  fun firstForegroundAfterBackgroundBaselineIsNotReturnEvent() {
+    val service = AppLifecycleService()
+
+    service.update(foreground = false)
+    service.update(foreground = true)
+
+    assertEquals(AppLifecycleState.Foreground, service.snapshot.value.state)
+    assertEquals(0, service.snapshot.value.foregroundGeneration)
+  }
+
+  @Test
+  fun foregroundGenerationAdvancesOnlyAfterBackground() {
+    val service = AppLifecycleService()
+    service.update(foreground = true)
+
+    service.update(foreground = false)
+    service.update(foreground = true)
+    service.update(foreground = true)
+
+    assertEquals(AppLifecycleState.Foreground, service.snapshot.value.state)
+    assertEquals(1, service.snapshot.value.foregroundGeneration)
+  }
+
+  @Test
+  fun foregroundTransitionPublishesOneAtomicSnapshot() = runTest {
+    val service = AppLifecycleService().apply { update(foreground = true) }
+    val observed = mutableListOf<Pair<AppLifecycleState, Long>>()
+    backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+      service.snapshot.drop(1).collect { observed += it.state to it.foregroundGeneration }
+    }
+
+    service.update(foreground = false)
+    service.update(foreground = true)
+
+    assertEquals(
+      listOf(AppLifecycleState.Background to 0L, AppLifecycleState.Foreground to 1L),
+      observed,
+    )
+  }
+}

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/platform/ConnectivityServiceTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/platform/ConnectivityServiceTest.kt
@@ -1,0 +1,39 @@
+package co.typie.platform
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ConnectivityServiceTest {
+  @Test
+  fun firstAvailabilityIsBaseline() = runTest {
+    val availability = MutableSharedFlow<Boolean>()
+    val service = ConnectivityService(availability)
+    backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { service.monitor() }
+
+    availability.emit(true)
+
+    assertEquals(0, service.restorationGeneration.value)
+  }
+
+  @Test
+  fun generationAdvancesOnlyFromUnavailableToAvailable() = runTest {
+    val availability = MutableSharedFlow<Boolean>()
+    val service = ConnectivityService(availability)
+    backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { service.monitor() }
+
+    availability.emit(true)
+    availability.emit(true)
+    availability.emit(false)
+    availability.emit(false)
+    availability.emit(true)
+    availability.emit(true)
+
+    assertEquals(1, service.restorationGeneration.value)
+  }
+}

--- a/apps/mobile/compose/src/desktopMain/kotlin/co/typie/platform/ConnectivityMonitor.desktop.kt
+++ b/apps/mobile/compose/src/desktopMain/kotlin/co/typie/platform/ConnectivityMonitor.desktop.kt
@@ -3,4 +3,4 @@ package co.typie.platform
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 
-actual fun connectivityRestoredFlow(): Flow<Unit> = emptyFlow()
+actual fun connectivityAvailabilityFlow(): Flow<Boolean> = emptyFlow()

--- a/apps/mobile/compose/src/iosMain/kotlin/co/typie/platform/ConnectivityMonitor.ios.kt
+++ b/apps/mobile/compose/src/iosMain/kotlin/co/typie/platform/ConnectivityMonitor.ios.kt
@@ -16,13 +16,10 @@ import platform.Network.nw_path_status_satisfied
 import platform.darwin.DISPATCH_QUEUE_PRIORITY_DEFAULT
 import platform.darwin.dispatch_get_global_queue
 
-actual fun connectivityRestoredFlow(): Flow<Unit> = callbackFlow {
+actual fun connectivityAvailabilityFlow(): Flow<Boolean> = callbackFlow {
   val monitor = nw_path_monitor_create()
-  var wasSatisfied = true
   nw_path_monitor_set_update_handler(monitor) { path ->
-    val satisfied = nw_path_get_status(path) == nw_path_status_satisfied
-    if (satisfied && !wasSatisfied) trySend(Unit)
-    wasSatisfied = satisfied
+    trySend(nw_path_get_status(path) == nw_path_status_satisfied)
   }
   nw_path_monitor_set_queue(
     monitor,


### PR DESCRIPTION
- 네트워크 오류로 Error에 머문 살아 있는 `WatchQuery`를 연결 복구 또는 foreground 복귀 시 한 번 다시 실행
  - background에서 연결이 복구되면 foreground 복귀까지 요청을 미룸
  - HTTP/GraphQL/파싱 오류와 mutation/upload는 자동 재실행하지 않음
- `AppLifecycleService`와 앱 전역 `ConnectivityService`를 도입해 query, sync 재시도, asset hydration이 같은 복구 generation을 사용하도록 정리
  - Android는 `NET_CAPABILITY_VALIDATED`, iOS는 `NWPath.status == satisfied`를 복구 기준으로 사용
- lifecycle snapshot을 원자적으로 발행하고 `WatchQuery` 상태와 watcher job 전이를 Main에 confinement해 복구 이벤트와 요청 실패 race의 중복/누락을 방지