### PR TITLE
앱 에디터 스켈레톤 위치 디버그 등

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorView.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorView.kt
@@ -50,7 +50,7 @@ internal fun EditorView(
   viewportWidth: Float,
   viewportHeight: Float,
   modifier: Modifier = Modifier,
-  textInputSessionEnabled: Boolean = true,
+  editorInputEnabled: Boolean = true,
   suppressSoftwareKeyboard: Boolean = false,
   showDebugSurfaceOverlay: Boolean = false,
 ) {
@@ -171,11 +171,11 @@ internal fun EditorView(
           editor.enqueue(Message.System(SystemEvent.SetFocused(it.isFocused)))
         }
         .editorInput(
+          enabled = editorInputEnabled,
           editor = editor,
           uiState = uiState,
           platform = platform,
           bringIntoViewRequests = bringIntoViewRequests,
-          textInputSessionEnabled = textInputSessionEnabled,
           suppressSoftwareKeyboard = suppressSoftwareKeyboard,
         )
         .focusable()
@@ -211,13 +211,15 @@ internal fun EditorView(
               },
             showDebugOverlay = showDebugSurfaceOverlay,
             backgroundOverlay = {
-              EditorLineHighlightOverlay(
-                cursor = pageCursor,
-                focused = uiState.focused,
-                displayZoom = displayZoom,
-                pageWidth = size.width,
-                enabled = Preference.lineHighlightEnabled,
-              )
+              if (layoutSpec is EditorDocumentLayoutSpec.Paginated) {
+                EditorLineHighlightOverlay(
+                  cursor = pageCursor,
+                  focused = uiState.focused,
+                  displayZoom = displayZoom,
+                  pageWidth = size.width,
+                  enabled = Preference.lineHighlightEnabled,
+                )
+              }
             },
             foregroundOverlay = {
               EditorExternalElementOverlay(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/body/EditorBody.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/body/EditorBody.kt
@@ -24,9 +24,12 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import co.typie.editor.EditorView
 import co.typie.editor.ext.unclippedBoundsInRoot
+import co.typie.editor.overlay.EditorExtensionAreaLineHighlightOverlay
+import co.typie.editor.runtime.LocalEditorRuntime
 import co.typie.editor.runtime.LocalEditorUiState
 import co.typie.editor.scroll.EditorAutoScrollPolicy
 import co.typie.editor.sync.DocumentEditorLoad
+import co.typie.storage.Preference
 
 private val DebugTopPaddingColor = Color(0x22FF5ACD)
 private val DebugBottomPaddingColor = Color(0x22FF8A00)
@@ -39,13 +42,14 @@ internal fun EditorBody(
   layoutSpec: EditorDocumentLayoutSpec,
   autoScrollPolicy: EditorAutoScrollPolicy,
   modifier: Modifier = Modifier,
-  textInputSessionEnabled: Boolean = true,
+  editorInputEnabled: Boolean = true,
   suppressSoftwareKeyboard: Boolean = false,
   showDebugBodyOverlay: Boolean = false,
   showDebugSurfaceOverlay: Boolean = false,
   overlay: @Composable BoxScope.() -> Unit = {},
 ) {
   val density = LocalDensity.current
+  val editor = LocalEditorRuntime.current.editor
   val uiState = LocalEditorUiState.current
   var bodyContentHeight by remember { mutableFloatStateOf(0f) }
   val extensionAreaFillSpacerHeight =
@@ -65,6 +69,15 @@ internal fun EditorBody(
 
   Box(modifier = modifier.fillMaxWidth()) {
     EditorExtensionArea(layoutSpec = layoutSpec, modifier = containerModifier) {
+      if (layoutSpec is EditorDocumentLayoutSpec.Continuous) {
+        EditorExtensionAreaLineHighlightOverlay(
+          cursor = editor?.cursor,
+          focused = uiState.focused,
+          editorBounds = uiState.editorBoundsInContainer,
+          viewportTransform = uiState.resolveViewportTransform(editor?.pageSizes.orEmpty()),
+          enabled = Preference.lineHighlightEnabled,
+        )
+      }
       Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.TopCenter) {
         Column(
           modifier =
@@ -107,7 +120,7 @@ internal fun EditorBody(
                 viewportWidth = geometry.visibleBodySize.width,
                 viewportHeight = geometry.visibleBodySize.height,
                 modifier = Modifier.fillMaxWidth(),
-                textInputSessionEnabled = textInputSessionEnabled,
+                editorInputEnabled = editorInputEnabled,
                 suppressSoftwareKeyboard = suppressSoftwareKeyboard,
                 showDebugSurfaceOverlay = showDebugSurfaceOverlay,
               )

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorInput.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorInput.kt
@@ -50,7 +50,7 @@ internal fun Modifier.editorInput(
   uiState: EditorUiState,
   platform: Platform,
   bringIntoViewRequests: EditorBringIntoViewRequests,
-  textInputSessionEnabled: Boolean,
+  enabled: Boolean = true,
   suppressSoftwareKeyboard: Boolean,
 ): Modifier =
   this then
@@ -59,7 +59,7 @@ internal fun Modifier.editorInput(
       uiState = uiState,
       platform = platform,
       bringIntoViewRequests = bringIntoViewRequests,
-      textInputSessionEnabled = textInputSessionEnabled,
+      enabled = enabled,
       suppressSoftwareKeyboard = suppressSoftwareKeyboard,
     )
 
@@ -77,14 +77,14 @@ internal expect suspend fun PlatformTextInputSessionScope.createEditorInputReque
 internal expect fun requiresEditorInputSessionRestartForSoftwareKeyboardSuppression(): Boolean
 
 internal fun shouldRestartEditorInputSession(
-  previousTextInputSessionEnabled: Boolean,
-  textInputSessionEnabled: Boolean,
+  previousEnabled: Boolean,
+  enabled: Boolean,
   previousSuppressSoftwareKeyboard: Boolean,
   suppressSoftwareKeyboard: Boolean,
   restartOnSoftwareKeyboardSuppressionChange: Boolean =
     requiresEditorInputSessionRestartForSoftwareKeyboardSuppression(),
 ): Boolean =
-  previousTextInputSessionEnabled != textInputSessionEnabled ||
+  previousEnabled != enabled ||
     (previousSuppressSoftwareKeyboard != suppressSoftwareKeyboard &&
       restartOnSoftwareKeyboardSuppressionChange)
 
@@ -111,7 +111,7 @@ private data class EditorInputElement(
   private val uiState: EditorUiState,
   private val platform: Platform,
   private val bringIntoViewRequests: EditorBringIntoViewRequests,
-  private val textInputSessionEnabled: Boolean,
+  private val enabled: Boolean,
   private val suppressSoftwareKeyboard: Boolean,
 ) : ModifierNodeElement<EditorInputNode>() {
   override fun create(): EditorInputNode =
@@ -120,7 +120,7 @@ private data class EditorInputElement(
       uiState = uiState,
       platform = platform,
       bringIntoViewRequests = bringIntoViewRequests,
-      textInputSessionEnabled = textInputSessionEnabled,
+      enabled = enabled,
       suppressSoftwareKeyboard = suppressSoftwareKeyboard,
     )
 
@@ -129,10 +129,7 @@ private data class EditorInputElement(
     node.uiState = uiState
     node.updatePlatform(platform)
     node.bringIntoViewRequests = bringIntoViewRequests
-    node.updateInputSessionPolicy(
-      textInputSessionEnabled = textInputSessionEnabled,
-      suppressSoftwareKeyboard = suppressSoftwareKeyboard,
-    )
+    node.updateInputPolicy(enabled = enabled, suppressSoftwareKeyboard = suppressSoftwareKeyboard)
   }
 }
 
@@ -142,7 +139,7 @@ internal class EditorInputNode(
   var uiState: EditorUiState,
   var platform: Platform,
   var bringIntoViewRequests: EditorBringIntoViewRequests,
-  textInputSessionEnabled: Boolean,
+  enabled: Boolean,
   suppressSoftwareKeyboard: Boolean,
 ) : Modifier.Node(), FocusEventModifierNode, PlatformTextInputModifierNode, KeyInputModifierNode {
   private var focusedJob: Job? = null
@@ -150,7 +147,7 @@ internal class EditorInputNode(
   private var bindings = createBindings(platform)
     private set
 
-  private var textInputSessionEnabled = textInputSessionEnabled
+  private var enabled = enabled
   private var suppressSoftwareKeyboard = suppressSoftwareKeyboard
   private val platformInputBridge = EditorPlatformInputBridge()
 
@@ -162,25 +159,19 @@ internal class EditorInputNode(
     platformInputBridge.reset()
   }
 
-  fun updateInputSessionPolicy(
-    textInputSessionEnabled: Boolean,
-    suppressSoftwareKeyboard: Boolean,
-  ) {
+  fun updateInputPolicy(enabled: Boolean, suppressSoftwareKeyboard: Boolean) {
     val shouldRestart =
       shouldRestartEditorInputSession(
-        previousTextInputSessionEnabled = this.textInputSessionEnabled,
-        textInputSessionEnabled = textInputSessionEnabled,
+        previousEnabled = this.enabled,
+        enabled = enabled,
         previousSuppressSoftwareKeyboard = this.suppressSoftwareKeyboard,
         suppressSoftwareKeyboard = suppressSoftwareKeyboard,
       )
-    if (
-      this.textInputSessionEnabled == textInputSessionEnabled &&
-        this.suppressSoftwareKeyboard == suppressSoftwareKeyboard
-    ) {
+    if (this.enabled == enabled && this.suppressSoftwareKeyboard == suppressSoftwareKeyboard) {
       return
     }
 
-    this.textInputSessionEnabled = textInputSessionEnabled
+    this.enabled = enabled
     this.suppressSoftwareKeyboard = suppressSoftwareKeyboard
     if (shouldRestart) {
       syncTextInputSession()
@@ -189,8 +180,7 @@ internal class EditorInputNode(
 
   private fun dispatch(
     messages: List<Message>,
-    bringIntoViewTarget: EditorBringIntoViewTarget? =
-      EditorBringIntoViewTarget.CurrentSelectionHead,
+    bringIntoViewTarget: EditorBringIntoViewTarget? = EditorBringIntoViewTarget.CurrentSelectionHead,
   ) {
     if (messages.isEmpty()) return
     coroutineScope.launch {
@@ -228,8 +218,7 @@ internal class EditorInputNode(
 
   private fun dispatchSync(
     messages: List<Message>,
-    bringIntoViewTarget: EditorBringIntoViewTarget? =
-      EditorBringIntoViewTarget.CurrentSelectionHead,
+    bringIntoViewTarget: EditorBringIntoViewTarget? = EditorBringIntoViewTarget.CurrentSelectionHead,
   ): EditorState? {
     if (messages.isEmpty()) return null
     return editor.syncWithBringIntoView(bringIntoViewRequests) {
@@ -317,7 +306,7 @@ internal class EditorInputNode(
   }
 
   override fun onKeyEvent(event: KeyEvent): Boolean {
-    if (event.type != KeyEventType.KeyDown) return false
+    if (!enabled || event.type != KeyEventType.KeyDown) return false
     val binding = bindings.find { matchesKeyBinding(it, platform, event) }
     if (binding != null) {
       if (editor.ime?.composing != null) {
@@ -390,7 +379,7 @@ internal class EditorInputNode(
   }
 
   override fun onPreKeyEvent(event: KeyEvent): Boolean {
-    if (event.type != KeyEventType.KeyDown) return false
+    if (!enabled || event.type != KeyEventType.KeyDown) return false
     val binding = bindings.find { matchesKeyBinding(it, platform, event) } ?: return false
     if (editor.ime?.composing != null) {
       recordHardwareKey(
@@ -436,7 +425,7 @@ internal class EditorInputNode(
   }
 
   private fun syncTextInputSession() {
-    val sessionEnabled = focused && textInputSessionEnabled
+    val sessionEnabled = focused && enabled
     editor.inputRecorder?.record { seq, t ->
       RecordedInputEntry.Session(seq = seq, t = t, event = if (sessionEnabled) "start" else "stop")
     }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/overlay/LineHighlight.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/overlay/LineHighlight.kt
@@ -2,11 +2,36 @@ package co.typie.editor.overlay
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.unit.dp
+import co.typie.editor.EditorViewportTransform
 import co.typie.editor.ffi.CursorMetrics
 import co.typie.editor.ffi.Rect
+import co.typie.editor.runtime.EditorBoundsInContainer
 import co.typie.ui.theme.AppTheme
+
+internal data class EditorLineHighlightBand(val top: Float, val height: Float)
+
+internal fun resolveEditorExtensionAreaLineHighlightBand(
+  cursor: CursorMetrics,
+  editorBounds: EditorBoundsInContainer,
+  viewportTransform: EditorViewportTransform,
+): EditorLineHighlightBand? {
+  if (!editorBounds.isValid) return null
+  val line = cursor.line
+  if (!line.y.isFinite() || !line.height.isFinite() || line.height <= 0f) return null
+  val linePosition =
+    viewportTransform.localToGlobal(page = cursor.pageIdx, x = 0f, y = line.y) ?: return null
+  val displayZoom = viewportTransform.displayZoom.takeIf { it.isFinite() && it > 0f } ?: 1f
+  return EditorLineHighlightBand(
+    top = editorBounds.y + linePosition.y,
+    height = line.height * displayZoom,
+  )
+}
 
 internal fun resolveEditorLineHighlightOverlayRect(
   cursor: CursorMetrics,
@@ -38,4 +63,29 @@ internal fun EditorLineHighlightOverlay(
     )
 
   Box(Modifier.editorOverlayRect(rect).background(AppTheme.colors.surfaceInset.copy(alpha = 0.55f)))
+}
+
+@Composable
+internal fun EditorExtensionAreaLineHighlightOverlay(
+  cursor: CursorMetrics?,
+  focused: Boolean,
+  editorBounds: EditorBoundsInContainer,
+  viewportTransform: EditorViewportTransform,
+  enabled: Boolean,
+) {
+  if (!enabled || !focused) return
+  val currentCursor = cursor ?: return
+  val band =
+    resolveEditorExtensionAreaLineHighlightBand(
+      cursor = currentCursor,
+      editorBounds = editorBounds,
+      viewportTransform = viewportTransform,
+    ) ?: return
+
+  Box(
+    Modifier.fillMaxWidth()
+      .graphicsLayer { translationY = band.top.dp.toPx() }
+      .height(band.height.dp)
+      .background(AppTheme.colors.surfaceInset.copy(alpha = 0.55f))
+  )
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorLoadingSkeleton.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorLoadingSkeleton.kt
@@ -1,0 +1,128 @@
+package co.typie.screen.editor.editor
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import co.typie.editor.body.EditorDocumentLayoutSpec
+import co.typie.editor.ffi.Size
+import co.typie.screen.editor.editor.header.EditorHeader
+import co.typie.ui.component.Text
+import co.typie.ui.skeleton.Skeleton
+import co.typie.ui.theme.AppTheme
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.floatOrNull
+
+private const val ContinuousPageHorizontalPadding = 20f
+
+internal fun resolveEditorLoadingLayoutSpec(
+  encodedLayoutMode: JsonElement?
+): EditorDocumentLayoutSpec? {
+  val value = encodedLayoutMode as? JsonObject ?: return null
+  return when ((value["type"] as? JsonPrimitive)?.contentOrNull) {
+    "continuous" -> value.positiveFloat("maxWidth")?.let(EditorDocumentLayoutSpec::Continuous)
+    "paginated" ->
+      EditorDocumentLayoutSpec.Paginated(
+        pageWidth = value.positiveFloat("pageWidth") ?: return null,
+        pageHeight = value.positiveFloat("pageHeight") ?: return null,
+        pageMarginTop = value.nonNegativeFloat("pageMarginTop") ?: return null,
+        pageMarginBottom = value.nonNegativeFloat("pageMarginBottom") ?: return null,
+        pageMarginLeft = value.nonNegativeFloat("pageMarginLeft") ?: return null,
+        pageMarginRight = value.nonNegativeFloat("pageMarginRight") ?: return null,
+      )
+    else -> null
+  }
+}
+
+private fun JsonObject.positiveFloat(key: String): Float? =
+  (get(key) as? JsonPrimitive)?.floatOrNull?.takeIf { it.isFinite() && it > 0f }
+
+private fun JsonObject.nonNegativeFloat(key: String): Float? =
+  (get(key) as? JsonPrimitive)?.floatOrNull?.takeIf { it.isFinite() && it >= 0f }
+
+internal fun resolveEditorLoadingTrackWidth(
+  layoutSpec: EditorDocumentLayoutSpec,
+  availableWidth: Float,
+): Float {
+  val available = availableWidth.takeIf { it.isFinite() && it > 0f } ?: return 0f
+  return when (layoutSpec) {
+    is EditorDocumentLayoutSpec.Continuous -> {
+      val contentCap = layoutSpec.maxWidth.takeIf { it.isFinite() && it > 0f }
+      minOf(available, contentCap?.plus(ContinuousPageHorizontalPadding * 2f) ?: available)
+    }
+    is EditorDocumentLayoutSpec.Paginated -> available
+  }
+}
+
+internal fun hasValidEditorGeometry(
+  editorAttached: Boolean,
+  pageSizes: List<Size>,
+  trackWidth: Float,
+): Boolean =
+  editorAttached &&
+    trackWidth.isPositiveFinite() &&
+    pageSizes.isNotEmpty() &&
+    pageSizes.all { it.width.isPositiveFinite() && it.height.isPositiveFinite() }
+
+private fun Float.isPositiveFinite(): Boolean = isFinite() && this > 0f
+
+@Composable
+internal fun EditorLoadingSkeleton(
+  layoutSpec: EditorDocumentLayoutSpec,
+  topInset: Dp,
+  background: Color,
+  modifier: Modifier = Modifier,
+) {
+  Skeleton(enabled = true, modifier = modifier.fillMaxSize().background(background)) {
+    BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+      val trackWidth =
+        resolveEditorLoadingTrackWidth(layoutSpec = layoutSpec, availableWidth = maxWidth.value)
+      Column {
+        EditorHeader(
+          title = "",
+          subtitle = "",
+          layoutSpec = layoutSpec,
+          trackWidth = trackWidth,
+          loading = true,
+          enabled = false,
+          topInset = topInset,
+          onTitleChange = {},
+          onSubtitleChange = {},
+          onTitleFocused = {},
+          onSubtitleFocused = {},
+          onHeightChanged = {},
+          onEnterDocument = {},
+        )
+        EditorBodyLoadingSkeleton(trackWidth = trackWidth, modifier = Modifier.fillMaxSize())
+      }
+    }
+  }
+}
+
+@Composable
+private fun EditorBodyLoadingSkeleton(trackWidth: Float, modifier: Modifier = Modifier) {
+  Box(modifier = modifier, contentAlignment = Alignment.TopCenter) {
+    Column(
+      modifier =
+        Modifier.width(trackWidth.dp)
+          .padding(horizontal = ContinuousPageHorizontalPadding.dp, vertical = 32.dp),
+      verticalArrangement = Arrangement.spacedBy(14.dp),
+    ) {
+      Skeleton.list(6) { text(16..34) }
+        .forEach { line -> Text(text = line, style = AppTheme.typography.body) }
+    }
+  }
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.graphql
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.graphql
@@ -30,6 +30,7 @@ query EditorScreen_Query($entityId: ID!) {
         locked
         nullableTitle
         subtitle
+        layoutMode
         state {
           updatedAt
         }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -7,9 +7,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.rememberScrollable2DState
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
@@ -176,7 +174,6 @@ import co.typie.serialization.json
 import co.typie.storage.Preference
 import co.typie.ui.component.ResponsiveContainerDefaults
 import co.typie.ui.component.Screen
-import co.typie.ui.component.Text
 import co.typie.ui.component.dialog.LocalDialog
 import co.typie.ui.component.dialog.error
 import co.typie.ui.component.popover.LocalPopoverOverlayState
@@ -184,7 +181,6 @@ import co.typie.ui.component.sheet.LocalSheet
 import co.typie.ui.component.toast.LocalToast
 import co.typie.ui.component.toast.ToastType
 import co.typie.ui.component.topbar.ProvideTopBar
-import co.typie.ui.skeleton.Skeleton
 import co.typie.ui.theme.AppTheme
 import co.typie.ui.theme.LocalHazeState
 import dev.chrisbanes.haze.HazeState
@@ -682,8 +678,11 @@ fun EditorScreen(entityId: String) {
     }
   }
 
+  val preloadedLayoutSpec =
+    remember(document?.layoutMode) { resolveEditorLoadingLayoutSpec(document?.layoutMode) }
   val layoutSpec: EditorDocumentLayoutSpec =
     editor?.state?.rootAttrs?.layoutMode?.toEditorDocumentLayoutSpec()
+      ?: preloadedLayoutSpec
       ?: EditorDocumentLayoutSpec.Continuous(maxWidth = 600f)
   val background =
     when (layoutSpec) {
@@ -828,7 +827,7 @@ fun EditorScreen(entityId: String) {
           suppressSoftwareKeyboard = toolbarSuppressesSoftwareKeyboard,
         )
       } ?: true
-    val editorTextInputSessionEnabled = toolbarTextInputSessionEnabled && !subPaneBlocksEditorInput
+    val editorInputEnabledByToolbar = toolbarTextInputSessionEnabled && !subPaneBlocksEditorInput
     val editorSuppressesSoftwareKeyboard =
       toolbarSuppressesSoftwareKeyboard || subPaneBlocksEditorInput
     val previousImeVisible = remember { mutableStateOf(imeVisible) }
@@ -996,6 +995,30 @@ fun EditorScreen(entityId: String) {
         visibleBodyWidth = visibleArea.visibleBodySize.width,
         bodyTrackWidth = bodyTrackWidth,
       )
+    val editorGeometryValid =
+      hasValidEditorGeometry(
+        editorAttached = editor != null,
+        pageSizes = pageSizes,
+        trackWidth = bodyTrackWidth,
+      )
+    val editorReady = !loading && editorGeometryValid
+    val editorInteractionFocused = editorReady && uiState.focused && screenState.sceneInForeground
+
+    LaunchedEffect(editor, editorGeometryValid) {
+      val attachedEditor = editor ?: return@LaunchedEffect
+      if (!editorGeometryValid && runtime.editor === attachedEditor) {
+        runtime.reportError(
+          attachedEditor,
+          IllegalStateException("Attached editor has invalid geometry"),
+        )
+      }
+    }
+    LaunchedEffect(editor, editorReady) {
+      if (!editorReady) {
+        runtime.blur()
+        focusManager.clearFocus(force = true)
+      }
+    }
     val viewportScrollableState = rememberScrollable2DState { delta ->
       consumeEditorViewportTouchPan(
         viewportState = screenState.viewportState,
@@ -1017,9 +1040,7 @@ fun EditorScreen(entityId: String) {
       )
     val viewportScrollReconcileMode =
       if (
-        uiState.focused &&
-          screenState.sceneInForeground &&
-          editor != null &&
+        editorInteractionFocused &&
           interactionScope.controller.interactionMode.allowsViewportScrollReconcile
       ) {
         if (subPaneLayoutInfo != null) {
@@ -1061,10 +1082,10 @@ fun EditorScreen(entityId: String) {
         density = density,
         scrollGestureLockState = scrollGestureLockState,
         viewportZoomConfig = viewportZoomConfig,
-        pointerInputEnabled = { !popoverOverlayState.isOutsideDismissGestureActive },
+        pointerInputEnabled = { editorReady && !popoverOverlayState.isOutsideDismissGestureActive },
         onSelectionHaptic = { haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove) },
         onRequestSoftwareKeyboard = {
-          if (editorTextInputSessionEnabled && !editorSuppressesSoftwareKeyboard) {
+          if (editorReady && editorInputEnabledByToolbar && !editorSuppressesSoftwareKeyboard) {
             keyboardController?.show()
           }
         },
@@ -1077,6 +1098,7 @@ fun EditorScreen(entityId: String) {
     val debugWheelZoomModifier =
       if (
         PlatformModule.platform == co.typie.platform.Platform.Desktop &&
+          editorReady &&
           paginatedLayout != null &&
           density > 0f
       ) {
@@ -1102,9 +1124,7 @@ fun EditorScreen(entityId: String) {
           }
         }
     }
-    LaunchedEffect(uiState.focused, screenState.sceneInForeground, editor) {
-      val editorInteractionFocused =
-        uiState.focused && screenState.sceneInForeground && editor != null
+    LaunchedEffect(editorInteractionFocused) {
       if (!editorInteractionFocused) {
         uiState.contextMenu.hide()
         bringIntoViewRequests.cancel()
@@ -1126,6 +1146,7 @@ fun EditorScreen(entityId: String) {
         visibleArea = visibleArea,
         magnifierFocalPositionInRoot = magnifierFocalPositionInRoot,
         viewportScrollableState = viewportScrollableState,
+        viewportInputEnabled = editorReady,
         viewportContentWidth = bodyTrackWidth,
         viewportScrollReconcileMode = viewportScrollReconcileMode,
         onViewportWheelScroll = { uiState.contextMenu.hide() },
@@ -1153,7 +1174,8 @@ fun EditorScreen(entityId: String) {
             subtitle = model.subtitleDraft,
             layoutSpec = layoutSpec,
             trackWidth = headerTrackWidth,
-            loading = loading,
+            loading = false,
+            enabled = editorReady,
             topInset = topInset,
             subtitleFocusRequestVersion = subtitleFocusRequestVersion.value,
             onTitleChange = model::updateTitleDraft,
@@ -1172,57 +1194,71 @@ fun EditorScreen(entityId: String) {
           )
         },
         viewportOverlay = {
-          EditorZoomOverlay(
-            modifier =
-              Modifier.align(Alignment.BottomStart)
-                .padding(start = 20.dp, bottom = 20.dp + visibleArea.bottomOcclusion.dp)
-          )
-          EditorCharacterCountOverlay(
-            editor = runtime.editor,
-            viewportState = screenState.viewportState,
-            visibleArea = visibleArea,
-          )
-        },
-        overlay = {
-          Box(modifier = Modifier.fillMaxSize()) {
-            EditorScreenOverlayHost(
+          if (editorReady) {
+            EditorZoomOverlay(
+              modifier =
+                Modifier.align(Alignment.BottomStart)
+                  .padding(start = 20.dp, bottom = 20.dp + visibleArea.bottomOcclusion.dp)
+            )
+            EditorCharacterCountOverlay(
+              editor = runtime.editor,
               viewportState = screenState.viewportState,
               visibleArea = visibleArea,
-              autoScrollPolicy = autoScrollPolicy,
+            )
+          } else {
+            EditorLoadingSkeleton(
               layoutSpec = layoutSpec,
-              pageSizes = pageSizes,
-              displayZoom = displayZoom,
-              onTableAxisActionsRequest = { target, openedSelection ->
-                findReplace.close()
-                aiFeedback.close()
-                spellcheck.close()
-                uiState.contextMenu.hide()
-                subPaneState.open(
-                  EditorSubPane.TableAxisActions(target = target, openedSelection = openedSelection)
-                )
-              },
-              showDebugOverlay = devMode && model.debugViewportOverlayVisible,
+              topInset = topInset,
+              background = background,
               modifier = Modifier.fillMaxSize(),
             )
-            SpellcheckOverlay(
-              session = spellcheck,
-              visibleArea = visibleAreas.base,
-              modifier = Modifier.fillMaxSize(),
-            )
-            AiFeedbackOverlay(
-              session = aiFeedback,
-              visibleArea = visibleAreas.base,
-              modifier = Modifier.fillMaxSize(),
-            )
-            val activeEditor = runtime.editor
-            if (activeEditor != null) {
-              EditorRepasteAsTextOverlay(
-                editor = activeEditor,
-                visibleArea = visibleAreas.base,
-                visible = repasteAsTextVisible,
-                bringIntoViewRequests = bringIntoViewRequests,
+          }
+        },
+        overlay = {
+          if (editorReady) {
+            Box(modifier = Modifier.fillMaxSize()) {
+              EditorScreenOverlayHost(
+                viewportState = screenState.viewportState,
+                visibleArea = visibleArea,
+                autoScrollPolicy = autoScrollPolicy,
+                layoutSpec = layoutSpec,
+                pageSizes = pageSizes,
+                displayZoom = displayZoom,
+                onTableAxisActionsRequest = { target, openedSelection ->
+                  findReplace.close()
+                  aiFeedback.close()
+                  spellcheck.close()
+                  uiState.contextMenu.hide()
+                  subPaneState.open(
+                    EditorSubPane.TableAxisActions(
+                      target = target,
+                      openedSelection = openedSelection,
+                    )
+                  )
+                },
+                showDebugOverlay = devMode && model.debugViewportOverlayVisible,
                 modifier = Modifier.fillMaxSize(),
               )
+              SpellcheckOverlay(
+                session = spellcheck,
+                visibleArea = visibleAreas.base,
+                modifier = Modifier.fillMaxSize(),
+              )
+              AiFeedbackOverlay(
+                session = aiFeedback,
+                visibleArea = visibleAreas.base,
+                modifier = Modifier.fillMaxSize(),
+              )
+              val activeEditor = runtime.editor
+              if (activeEditor != null) {
+                EditorRepasteAsTextOverlay(
+                  editor = activeEditor,
+                  visibleArea = visibleAreas.base,
+                  visible = repasteAsTextVisible,
+                  bringIntoViewRequests = bringIntoViewRequests,
+                  modifier = Modifier.fillMaxSize(),
+                )
+              }
             }
           }
         },
@@ -1235,12 +1271,12 @@ fun EditorScreen(entityId: String) {
               layoutSpec = layoutSpec,
               autoScrollPolicy = autoScrollPolicy,
               modifier = Modifier.then(debugWheelZoomModifier),
-              textInputSessionEnabled = editorTextInputSessionEnabled,
-              suppressSoftwareKeyboard = editorSuppressesSoftwareKeyboard,
+              editorInputEnabled = editorReady && editorInputEnabledByToolbar,
+              suppressSoftwareKeyboard = !editorReady || editorSuppressesSoftwareKeyboard,
               showDebugBodyOverlay = devMode && model.debugBodyOverlayVisible,
               showDebugSurfaceOverlay = devMode && model.debugSurfaceOverlayVisible,
               overlay = {
-                if (!documentLocked) {
+                if (editorReady && !documentLocked) {
                   EditorDocumentPlaceholder(
                     placeholder = editorState.placeholder,
                     geometry = bodyGeometry,
@@ -1251,7 +1287,7 @@ fun EditorScreen(entityId: String) {
                     onLoadTemplate = ::openTemplateSheet,
                   )
                 }
-                if (comments.virtualThreadGuardVisible) {
+                if (editorReady && comments.virtualThreadGuardVisible) {
                   val guardInteractionSource = remember { MutableInteractionSource() }
                   Box(
                     modifier =
@@ -1265,10 +1301,6 @@ fun EditorScreen(entityId: String) {
                 }
               },
             )
-          } else {
-            Skeleton(enabled = true, modifier = Modifier.fillMaxSize()) {
-              EditorBodyLoadingSkeleton(modifier = Modifier.fillMaxSize())
-            }
           }
         },
         toolbar = {
@@ -1380,7 +1412,7 @@ fun EditorScreen(entityId: String) {
         modifier =
           Modifier.padding(start = startInset, end = endInset).editorScreenShortcutFocusTarget(
             active = screenShortcutModeActive,
-            enabled = screenState.sceneInForeground && !subPaneBlocksEditorInput,
+            enabled = editorReady && screenState.sceneInForeground && !subPaneBlocksEditorInput,
             editorFocused = uiState.focused,
             selection = editorState.selection,
           ) { event ->
@@ -1410,22 +1442,6 @@ internal fun resolveEditorHeaderTrackWidth(
       }
     is EditorDocumentLayoutSpec.Paginated -> visibleBodyWidth
   }.coerceAtLeast(0f)
-
-@Composable
-private fun EditorBodyLoadingSkeleton(modifier: Modifier = Modifier) {
-  Box(modifier = modifier, contentAlignment = Alignment.TopCenter) {
-    Column(
-      modifier =
-        Modifier.fillMaxWidth()
-          .widthIn(max = ResponsiveContainerDefaults.MaxWidth)
-          .padding(horizontal = 20.dp, vertical = 32.dp),
-      verticalArrangement = Arrangement.spacedBy(14.dp),
-    ) {
-      Skeleton.list(6) { text(16..34) }
-        .forEach { line -> Text(text = line, style = AppTheme.typography.body) }
-    }
-  }
-}
 
 internal fun enterDocumentStartFromHeader(
   editor: Editor?,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/header/EditorHeader.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/header/EditorHeader.kt
@@ -56,6 +56,7 @@ internal fun EditorHeader(
   layoutSpec: EditorDocumentLayoutSpec,
   trackWidth: Float,
   loading: Boolean,
+  enabled: Boolean = true,
   topInset: Dp,
   subtitleFocusRequestVersion: Int = 0,
   modifier: Modifier = Modifier,
@@ -72,16 +73,18 @@ internal fun EditorHeader(
     rememberTextInputState(
       value = title,
       onValueChange = onTitleChange,
+      enabled = enabled,
       onDismiss = onEnterDocument,
     )
   val subtitleInputState =
     rememberTextInputState(
       value = subtitle,
       onValueChange = onSubtitleChange,
+      enabled = enabled,
       onDismiss = onEnterDocument,
     )
-  LaunchedEffect(subtitleFocusRequestVersion) {
-    if (subtitleFocusRequestVersion > 0) {
+  LaunchedEffect(subtitleFocusRequestVersion, enabled) {
+    if (enabled && subtitleFocusRequestVersion > 0) {
       subtitleInputState.requestFocus()
     }
   }
@@ -126,6 +129,7 @@ internal fun EditorHeader(
             fontWeight = FontWeight.Bold,
           ),
         showSkeleton = showSkeleton,
+        enabled = enabled,
         imeAction = ImeAction.Next,
         onFocusNext = { subtitleInputState.requestFocus() },
         onEnterDocument = { subtitleInputState.requestFocus() },
@@ -155,6 +159,7 @@ internal fun EditorHeader(
             fontWeight = FontWeight.Medium,
           ),
         showSkeleton = showSkeleton,
+        enabled = enabled,
         imeAction = ImeAction.Done,
         onFocusNext = onEnterDocument,
         onEnterDocument = onEnterDocument,
@@ -188,6 +193,7 @@ private fun EditorHeaderField(
   style: TextStyle,
   placeholderStyle: TextStyle,
   showSkeleton: Boolean,
+  enabled: Boolean,
   imeAction: ImeAction,
   onFocusNext: () -> Unit,
   onEnterDocument: () -> Unit,
@@ -200,9 +206,10 @@ private fun EditorHeaderField(
   BasicTextField(
     value = text,
     onValueChange = onValueChange,
+    enabled = enabled,
     modifier =
       modifier
-        .textInputFocusable(textInputState) {
+        .textInputFocusable(textInputState, enabled = enabled) {
           if (it.isFocused) {
             onFocused()
           }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayout.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayout.kt
@@ -80,6 +80,7 @@ internal fun EditorScreenLayout(
   magnifierFocalPositionInRoot: Offset? = null,
   viewportScrollableState: Scrollable2DState,
   viewportContentWidth: Float,
+  viewportInputEnabled: Boolean = true,
   viewportScrollReconcileMode: EditorViewportScrollReconcileMode,
   onViewportWheelScroll: () -> Unit = {},
   onMeasuredViewportSizeChange: (Size) -> Unit,
@@ -149,17 +150,23 @@ internal fun EditorScreenLayout(
       )
     val viewportContentPlaceables =
       subcompose(EditorScreenLayoutSlot.ViewportContent) {
+          val viewportInputModifier =
+            if (viewportInputEnabled) {
+              Modifier.scrollable2D(state = viewportScrollableState)
+                .editorViewportWheelScroll(
+                  viewportState = state.viewportState,
+                  onScrollConsumed = onViewportWheelScroll,
+                )
+            } else {
+              Modifier
+            }
           Layout(
             modifier =
               Modifier.fillMaxSize()
                 .clipToBounds()
                 .hazeSource(toolbarBackdropHazeState)
                 .navigationPopNestedScroll()
-                .scrollable2D(state = viewportScrollableState)
-                .editorViewportWheelScroll(
-                  viewportState = state.viewportState,
-                  onScrollConsumed = onViewportWheelScroll,
-                ),
+                .then(viewportInputModifier),
             content = {
               Column {
                 Box(modifier = Modifier.width(viewportWidth.dp)) { header() }
@@ -515,7 +522,8 @@ private fun Modifier.editorViewportWheelScroll(
           continue
         }
 
-        // DesktopScrollTranslation turns mouse drags into synthetic wheel events; handle those here
+        // DesktopScrollTranslation turns mouse drags into synthetic wheel events; handle those
+        // here
         // as the same viewport pan path because scrollable2D currently has no wheel handling.
         viewportState.updateScrollableInteractionInProgress(true)
         val consumed =

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/input/EditorInputKeyHandlingTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/input/EditorInputKeyHandlingTest.kt
@@ -49,8 +49,8 @@ class EditorInputKeyHandlingTest {
   fun `input session restarts when suppression changes on platforms that require restart`() {
     assertTrue(
       shouldRestartEditorInputSession(
-        previousTextInputSessionEnabled = true,
-        textInputSessionEnabled = true,
+        previousEnabled = true,
+        enabled = true,
         previousSuppressSoftwareKeyboard = false,
         suppressSoftwareKeyboard = true,
         restartOnSoftwareKeyboardSuppressionChange = true,
@@ -62,8 +62,8 @@ class EditorInputKeyHandlingTest {
   fun `input session does not restart for suppression-only change when platform can hide keyboard surface`() {
     assertFalse(
       shouldRestartEditorInputSession(
-        previousTextInputSessionEnabled = true,
-        textInputSessionEnabled = true,
+        previousEnabled = true,
+        enabled = true,
         previousSuppressSoftwareKeyboard = false,
         suppressSoftwareKeyboard = true,
         restartOnSoftwareKeyboardSuppressionChange = false,
@@ -75,8 +75,8 @@ class EditorInputKeyHandlingTest {
   fun `input session restarts when enabled state changes`() {
     assertTrue(
       shouldRestartEditorInputSession(
-        previousTextInputSessionEnabled = false,
-        textInputSessionEnabled = true,
+        previousEnabled = false,
+        enabled = true,
         previousSuppressSoftwareKeyboard = true,
         suppressSoftwareKeyboard = true,
         restartOnSoftwareKeyboardSuppressionChange = false,

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/overlay/LineHighlightTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/overlay/LineHighlightTest.kt
@@ -1,9 +1,13 @@
 package co.typie.editor.overlay
 
+import androidx.compose.ui.geometry.Offset
+import co.typie.editor.EditorViewportTransform
 import co.typie.editor.ffi.CursorMetrics
 import co.typie.editor.ffi.Rect
+import co.typie.editor.runtime.EditorBoundsInContainer
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class LineHighlightTest {
   private val cursor =
@@ -14,7 +18,35 @@ class LineHighlightTest {
     )
 
   @Test
-  fun `line highlight uses page wide cursor line rect in page display coordinates`() {
+  fun `continuous line highlight resolves into extension area coordinates`() {
+    val band =
+      resolveEditorExtensionAreaLineHighlightBand(
+        cursor = cursor,
+        editorBounds = EditorBoundsInContainer(x = 20f, y = 40f, width = 640f, height = 900f),
+        viewportTransform =
+          EditorViewportTransform(
+            pageOffsets = mapOf(1 to Offset(x = 0f, y = 12f)),
+            displayZoom = 1.5f,
+          ),
+      )
+
+    assertEquals(EditorLineHighlightBand(top = 160f, height = 36f), band)
+  }
+
+  @Test
+  fun `continuous line highlight is unresolved until its page position is measured`() {
+    val band =
+      resolveEditorExtensionAreaLineHighlightBand(
+        cursor = cursor,
+        editorBounds = EditorBoundsInContainer(x = 20f, y = 40f, width = 640f, height = 900f),
+        viewportTransform = EditorViewportTransform(pageOffsets = emptyMap(), displayZoom = 1.5f),
+      )
+
+    assertNull(band)
+  }
+
+  @Test
+  fun `paginated line highlight stays page wide in page display coordinates`() {
     val rect =
       resolveEditorLineHighlightOverlayRect(cursor = cursor, pageWidth = 360f, displayZoom = 1.5f)
 

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/EditorLoadingSkeletonTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/EditorLoadingSkeletonTest.kt
@@ -1,0 +1,135 @@
+package co.typie.screen.editor.editor
+
+import co.typie.editor.body.EditorDocumentLayoutSpec
+import co.typie.editor.ffi.Size
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+class EditorLoadingSkeletonTest {
+  @Test
+  fun `loading layout resolves continuous server json`() {
+    val encoded = buildJsonObject {
+      put("type", "continuous")
+      put("maxWidth", 720)
+    }
+
+    assertEquals(
+      EditorDocumentLayoutSpec.Continuous(maxWidth = 720f),
+      resolveEditorLoadingLayoutSpec(encoded),
+    )
+  }
+
+  @Test
+  fun `loading layout resolves paginated server json`() {
+    val encoded = buildJsonObject {
+      put("type", "paginated")
+      put("pageWidth", 794)
+      put("pageHeight", 1123)
+      put("pageMarginTop", 96)
+      put("pageMarginBottom", 96)
+      put("pageMarginLeft", 0)
+      put("pageMarginRight", 80)
+    }
+
+    assertEquals(
+      EditorDocumentLayoutSpec.Paginated(
+        pageWidth = 794f,
+        pageHeight = 1123f,
+        pageMarginTop = 96f,
+        pageMarginBottom = 96f,
+        pageMarginLeft = 0f,
+        pageMarginRight = 80f,
+      ),
+      resolveEditorLoadingLayoutSpec(encoded),
+    )
+  }
+
+  @Test
+  fun `continuous loading track includes both page margins inside the available width`() {
+    assertEquals(
+      640f,
+      resolveEditorLoadingTrackWidth(
+        layoutSpec = EditorDocumentLayoutSpec.Continuous(maxWidth = 600f),
+        availableWidth = 720f,
+      ),
+    )
+  }
+
+  @Test
+  fun `continuous loading track shrinks at the responsive boundary`() {
+    assertEquals(
+      620f,
+      resolveEditorLoadingTrackWidth(
+        layoutSpec = EditorDocumentLayoutSpec.Continuous(maxWidth = 600f),
+        availableWidth = 620f,
+      ),
+    )
+  }
+
+  @Test
+  fun `paginated loading track uses the available width`() {
+    assertEquals(
+      960f,
+      resolveEditorLoadingTrackWidth(layoutSpec = paginatedLayout(), availableWidth = 960f),
+    )
+  }
+
+  @Test
+  fun `loading track rejects invalid available widths`() {
+    assertEquals(
+      0f,
+      resolveEditorLoadingTrackWidth(
+        layoutSpec = EditorDocumentLayoutSpec.Continuous(maxWidth = 600f),
+        availableWidth = Float.NaN,
+      ),
+    )
+  }
+
+  @Test
+  fun `ready geometry requires an attached editor with finite positive pages and track`() {
+    assertEquals(
+      false,
+      hasValidEditorGeometry(
+        editorAttached = false,
+        pageSizes = listOf(Size(width = 640f, height = 800f)),
+        trackWidth = 640f,
+      ),
+    )
+    assertEquals(
+      false,
+      hasValidEditorGeometry(
+        editorAttached = true,
+        pageSizes = emptyList<Size>(),
+        trackWidth = 640f,
+      ),
+    )
+    assertEquals(
+      false,
+      hasValidEditorGeometry(
+        editorAttached = true,
+        pageSizes = listOf(Size(width = 640f, height = Float.NaN)),
+        trackWidth = 640f,
+      ),
+    )
+    assertEquals(
+      true,
+      hasValidEditorGeometry(
+        editorAttached = true,
+        pageSizes = listOf(Size(width = 640f, height = 800f)),
+        trackWidth = 640f,
+      ),
+    )
+  }
+
+  private fun paginatedLayout() =
+    EditorDocumentLayoutSpec.Paginated(
+      pageWidth = 720f,
+      pageHeight = 960f,
+      pageMarginTop = 72f,
+      pageMarginBottom = 72f,
+      pageMarginLeft = 64f,
+      pageMarginRight = 64f,
+    )
+}

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/input/EditorInputEnabledDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/input/EditorInputEnabledDesktopTest.kt
@@ -1,0 +1,80 @@
+package co.typie.editor.input
+
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import co.typie.editor.Editor
+import co.typie.editor.FakeFfiEditor
+import co.typie.editor.runtime.EditorUiState
+import co.typie.editor.scroll.LocalEditorBringIntoViewRequests
+import co.typie.editor.scroll.rememberEditorBringIntoViewRequests
+import co.typie.platform.Platform
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+
+@OptIn(ExperimentalTestApi::class)
+class EditorInputEnabledDesktopTest {
+  @Test
+  fun disabledEditorInputDoesNotDispatchHardwareKeys() = runComposeUiTest {
+    val fake = FakeFfiEditor()
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val editor = Editor(fake, scope)
+
+    try {
+      setContent {
+        val focusRequester = remember { FocusRequester() }
+        val bringIntoViewRequests = rememberEditorBringIntoViewRequests()
+        androidx.compose.runtime.CompositionLocalProvider(
+          LocalEditorBringIntoViewRequests provides bringIntoViewRequests
+        ) {
+          Box(
+            Modifier.size(200.dp)
+              .testTag(InputTag)
+              .focusRequester(focusRequester)
+              .editorInput(
+                editor = editor,
+                uiState = EditorUiState(),
+                platform = Platform.Desktop,
+                bringIntoViewRequests = bringIntoViewRequests,
+                enabled = false,
+                suppressSoftwareKeyboard = true,
+              )
+              .focusable()
+          )
+          LaunchedEffect(Unit) { focusRequester.requestFocus() }
+        }
+      }
+      waitForIdle()
+
+      onNodeWithTag(InputTag).performKeyInput {
+        keyDown(Key.A)
+        keyUp(Key.A)
+      }
+      waitForIdle()
+
+      assertTrue(fake.enqueued.isEmpty())
+    } finally {
+      scope.cancel()
+    }
+  }
+
+  private companion object {
+    const val InputTag = "editor-input-disabled"
+  }
+}

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/EditorLoadingInputDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/EditorLoadingInputDesktopTest.kt
@@ -1,0 +1,80 @@
+package co.typie.screen.editor.editor
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import co.typie.editor.body.EditorDocumentLayoutSpec
+import co.typie.ui.theme.LocalThemeMode
+import co.typie.ui.theme.ResolvedThemeMode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+class EditorLoadingInputDesktopTest {
+  @Test
+  fun loadingSkeletonBlocksEditorInput() = runComposeUiTest {
+    var underlyingEvents by mutableIntStateOf(0)
+
+    setContent {
+      Box(Modifier.size(width = 320.dp, height = 640.dp).testTag(RootTag)) {
+        Box(
+          Modifier.fillMaxSize().pointerInput(Unit) {
+            awaitPointerEventScope {
+              while (true) {
+                val event = awaitPointerEvent(PointerEventPass.Main)
+                if (event.type == PointerEventType.Press || event.type == PointerEventType.Scroll) {
+                  underlyingEvents += 1
+                }
+              }
+            }
+          }
+        )
+        CompositionLocalProvider(
+          LocalDensity provides Density(1f),
+          LocalThemeMode provides ResolvedThemeMode.Light,
+        ) {
+          EditorLoadingSkeleton(
+            layoutSpec = EditorDocumentLayoutSpec.Continuous(maxWidth = 600f),
+            topInset = 0.dp,
+            background = Color.White,
+            modifier = Modifier.fillMaxSize(),
+          )
+        }
+      }
+    }
+    waitForIdle()
+
+    onAllNodes(hasSetTextAction(), useUnmergedTree = true).assertCountEquals(0)
+    onNodeWithTag(RootTag).performTouchInput { click(center) }
+    onNodeWithTag(RootTag).performMouseInput { scroll(Offset(x = 0f, y = 120f)) }
+    waitForIdle()
+
+    assertEquals(0, underlyingEvents)
+  }
+
+  private companion object {
+    const val RootTag = "editor-loading-input-root"
+  }
+}

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/header/EditorHeaderDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/header/EditorHeaderDesktopTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.v2.runComposeUiTest
@@ -53,6 +54,35 @@ class EditorHeaderDesktopTest {
         .width
 
     assertEquals(600f, titleWidth, absoluteTolerance = 0.01f)
+  }
+
+  @Test
+  fun disabledHeaderExposesNoTextEditingAction() = runComposeUiTest {
+    setContent {
+      CompositionLocalProvider(
+        LocalDensity provides Density(1f),
+        LocalThemeMode provides ResolvedThemeMode.Light,
+      ) {
+        EditorHeader(
+          title = Title,
+          subtitle = "",
+          layoutSpec = EditorDocumentLayoutSpec.Continuous(maxWidth = 600f),
+          trackWidth = 640f,
+          loading = false,
+          enabled = false,
+          topInset = 0.dp,
+          onTitleChange = {},
+          onSubtitleChange = {},
+          onTitleFocused = {},
+          onSubtitleFocused = {},
+          onHeightChanged = {},
+          onEnterDocument = {},
+        )
+      }
+    }
+    waitForIdle()
+
+    onAllNodes(hasText(Title) and hasSetTextAction(), useUnmergedTree = true).assertCountEquals(0)
   }
 
   private companion object {

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayoutDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayoutDesktopTest.kt
@@ -10,8 +10,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.swipe
 import androidx.compose.ui.unit.dp
 import co.typie.editor.EditorState
 import co.typie.editor.body.EditorDocumentLayoutSpec
@@ -68,5 +73,60 @@ class EditorScreenLayoutDesktopTest {
     waitForIdle()
 
     assertEquals(Size(width = 320f, height = 640f), measuredViewportSize)
+  }
+
+  @Test
+  fun disabledViewportInputDoesNotPanFromTouchOrWheel() = runComposeUiTest {
+    var consumed = Offset.Zero
+
+    setContent {
+      val visibleArea = EditorVisibleArea(viewport = Size(width = 320f, height = 640f))
+      val scrollFrame =
+        EditorScrollFrame(
+          state = EditorState.Initial,
+          layoutSpec = EditorDocumentLayoutSpec.Continuous(maxWidth = 320f),
+          displayZoom = 1f,
+          visibleArea = visibleArea,
+          autoScrollPolicy = resolveEditorAutoScrollPolicy(visibleArea),
+          headerHeight = 0f,
+          density = 1f,
+          editorBounds = EditorBoundsInContainer(),
+        )
+      CompositionLocalProvider(
+        LocalEditorBringIntoViewRequests provides rememberEditorBringIntoViewRequests()
+      ) {
+        EditorScreenLayout(
+          state = remember { EditorScreenState(EditorViewportState()) },
+          scrollFrame = scrollFrame,
+          visibleArea = visibleArea,
+          viewportScrollableState =
+            rememberScrollable2DState {
+              consumed += it
+              it
+            },
+          viewportContentWidth = 320f,
+          viewportInputEnabled = false,
+          viewportScrollReconcileMode = EditorViewportScrollReconcileMode.Disabled,
+          onMeasuredViewportSizeChange = {},
+          header = {},
+          body = { Box(Modifier.fillMaxWidth().height(800.dp)) },
+          toolbar = {},
+          modifier = Modifier.size(width = 320.dp, height = 640.dp).testTag(LayoutTag),
+        )
+      }
+    }
+    waitForIdle()
+
+    onNodeWithTag(LayoutTag).performTouchInput {
+      swipe(start = center, end = Offset(x = center.x, y = center.y - 120f))
+    }
+    onNodeWithTag(LayoutTag).performMouseInput { scroll(Offset(x = 0f, y = 120f)) }
+    waitForIdle()
+
+    assertEquals(Offset.Zero, consumed)
+  }
+
+  private companion object {
+    const val LayoutTag = "editor-screen-layout"
   }
 }


### PR DESCRIPTION
- 로딩 skeleton과 실제 header/body가 같은 layout mode와 track width 기준을 사용하도록 정리해 로드 전후 위치·너비 drift를 제거
- Editor가 attach되고 유효한 page geometry가 준비되기 전에는 header, text/hardware input, pointer/scroll, shortcut, overlay가 활성화되지 않도록 readiness 경계를 통일
- continuous line highlight는 extension area 전체 폭으로 렌더링하고, paginated에서는 기존처럼 page 내부로 제한