### PR TITLE
에디터 nav pop 제스처 direction lock

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationPopGestureSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationPopGestureSession.kt
@@ -1,0 +1,39 @@
+package co.typie.navigation
+
+import androidx.compose.ui.geometry.Offset
+import kotlin.math.abs
+
+internal class NavigationPopGestureSession {
+  private var state = State.Possible
+
+  val isClaimed: Boolean
+    get() = state == State.Claimed
+
+  fun tryClaim(initialDrag: Offset, childConsumed: Boolean): Boolean {
+    if (state != State.Possible) {
+      return false
+    }
+    if (initialDrag == Offset.Zero && !childConsumed) {
+      return false
+    }
+    state =
+      if (!childConsumed && initialDrag.isDominantRightDrag()) {
+        State.Claimed
+      } else {
+        State.Rejected
+      }
+    return isClaimed
+  }
+
+  fun reset() {
+    state = State.Possible
+  }
+
+  private enum class State {
+    Possible,
+    Claimed,
+    Rejected,
+  }
+}
+
+private fun Offset.isDominantRightDrag(): Boolean = x > 0f && abs(x) > abs(y)

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationStack.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationStack.kt
@@ -129,7 +129,7 @@ fun NavigationStack(
   val progress = remember { Animatable(0f) }
 
   var lastDragAmount by remember { mutableStateOf(0f) }
-  var nestedPopDragActive by remember { mutableStateOf(false) }
+  val nestedPopGestureSession = remember { NavigationPopGestureSession() }
 
   fun startPopDrag() {
     val prev = navigator.previous ?: return
@@ -148,7 +148,7 @@ fun NavigationStack(
   }
 
   fun finishPopDrag() {
-    nestedPopDragActive = false
+    nestedPopGestureSession.reset()
     val velocity = lastDragAmount * 1000f / 16f
     scope.launch {
       if (progress.value > 0.5f || velocity > 1000f) {
@@ -176,7 +176,7 @@ fun NavigationStack(
     remember(navigator.canPop, animState, containerWidth) {
       object : NestedScrollConnection {
         override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
-          if (source != NestedScrollSource.UserInput || !nestedPopDragActive) {
+          if (source != NestedScrollSource.UserInput || !nestedPopGestureSession.isClaimed) {
             return Offset.Zero
           }
 
@@ -191,37 +191,45 @@ fun NavigationStack(
         ): Offset {
           if (
             source != NestedScrollSource.UserInput ||
-              nestedPopDragActive ||
+              nestedPopGestureSession.isClaimed ||
               !navigator.canPop ||
               containerWidth <= 0f ||
-              (animState != AnimState.Idle && animState != AnimState.Dragging) ||
-              !available.isDominantRightDrag()
+              (animState != AnimState.Idle && animState != AnimState.Dragging)
+          ) {
+            return Offset.Zero
+          }
+          if (
+            !nestedPopGestureSession.tryClaim(
+              initialDrag = consumed + available,
+              childConsumed = consumed != Offset.Zero,
+            )
           ) {
             return Offset.Zero
           }
 
-          nestedPopDragActive = true
           startPopDrag()
           updatePopDrag(available.x)
           return available
         }
 
         override suspend fun onPreFling(available: Velocity): Velocity {
-          if (!nestedPopDragActive) {
+          val claimed = nestedPopGestureSession.isClaimed
+          nestedPopGestureSession.reset()
+          if (!claimed) {
             return Velocity.Zero
           }
 
-          nestedPopDragActive = false
           finishPopDrag()
           return available
         }
 
         override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
-          if (!nestedPopDragActive) {
+          val claimed = nestedPopGestureSession.isClaimed
+          nestedPopGestureSession.reset()
+          if (!claimed) {
             return Velocity.Zero
           }
 
-          nestedPopDragActive = false
           finishPopDrag()
           return available
         }
@@ -229,7 +237,7 @@ fun NavigationStack(
     }
 
   fun cancelPopDrag() {
-    nestedPopDragActive = false
+    nestedPopGestureSession.reset()
     scope.launch {
       progress.animateTo(0f, spring(stiffness = StiffnessMediumLow))
       behindRoute = null
@@ -498,6 +506,7 @@ fun NavigationStack(
               val slop = viewConfiguration.touchSlop
               awaitEachGesture {
                 val down = awaitFirstDown(requireUnconsumed = false)
+                val popGestureSession = NavigationPopGestureSession()
                 if (animState != AnimState.Idle && animState != AnimState.Dragging)
                   return@awaitEachGesture
                 var overSlopX = 0f
@@ -511,8 +520,14 @@ fun NavigationStack(
                   val dx = change.position.x - down.position.x
                   val dy = change.position.y - down.position.y
                   if (abs(dx) > slop || abs(dy) > slop) {
-                    if (dx <= 0f || abs(dx) <= abs(dy)) return@awaitEachGesture
-                    if (change.isConsumed) return@awaitEachGesture
+                    if (
+                      !popGestureSession.tryClaim(
+                        initialDrag = Offset(dx, dy),
+                        childConsumed = change.isConsumed,
+                      )
+                    ) {
+                      return@awaitEachGesture
+                    }
                     val confirmEvent = awaitPointerEvent(PointerEventPass.Main)
                     val confirmChange =
                       confirmEvent.changes.fastFirstOrNull { it.id == down.id }
@@ -608,13 +623,14 @@ fun NavigationStack(
         }
       }
 
-      // 엣지 제스처 감지 영역 (child consume 여부 무관하게 pop 우선)
+      // 엣지 제스처 감지 영역 (첫 touch slop 이동이 소비되지 않은 오른쪽 드래그일 때만 claim)
       if (navigator.canPop && (animState == AnimState.Idle || animState == AnimState.Dragging)) {
         Box(
           Modifier.fillMaxHeight().width(20.dp).align(Alignment.CenterStart).pointerInput(Unit) {
             val slop = viewConfiguration.touchSlop
             awaitEachGesture {
               val down = awaitFirstDown(requireUnconsumed = false)
+              val popGestureSession = NavigationPopGestureSession()
               var overSlopX = 0f
               var claimed = false
               while (!claimed) {
@@ -623,9 +639,17 @@ fun NavigationStack(
                 val change =
                   event.changes.fastFirstOrNull { it.id == down.id } ?: return@awaitEachGesture
                 if (!change.pressed) return@awaitEachGesture
-                if (change.isConsumed) return@awaitEachGesture
                 val dx = change.position.x - down.position.x
-                if (abs(dx) >= slop) {
+                val dy = change.position.y - down.position.y
+                if (abs(dx) > slop || abs(dy) > slop) {
+                  if (
+                    !popGestureSession.tryClaim(
+                      initialDrag = Offset(dx, dy),
+                      childConsumed = change.isConsumed,
+                    )
+                  ) {
+                    return@awaitEachGesture
+                  }
                   change.consume()
                   overSlopX = dx
                   claimed = true
@@ -666,5 +690,3 @@ private fun cornerRadius(progress: Float): Dp {
     }
   return maxRadius * factor.coerceIn(0f, 1f)
 }
-
-private fun Offset.isDominantRightDrag(): Boolean = x > 0f && abs(x) > abs(y)

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/navigation/NavigationPopGestureSessionTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/navigation/NavigationPopGestureSessionTest.kt
@@ -1,0 +1,17 @@
+package co.typie.navigation
+
+import androidx.compose.ui.geometry.Offset
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class NavigationPopGestureSessionTest {
+  @Test
+  fun zeroDeltaKeepsSessionPossibleForNextMovement() {
+    val session = NavigationPopGestureSession()
+
+    assertFalse(session.tryClaim(initialDrag = Offset.Zero, childConsumed = false))
+
+    assertTrue(session.tryClaim(initialDrag = Offset(x = 10f, y = 0f), childConsumed = false))
+  }
+}

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/NavigationStackDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/NavigationStackDesktopTest.kt
@@ -1,0 +1,150 @@
+package co.typie.navigation
+
+import androidx.compose.foundation.gestures.rememberScrollable2DState
+import androidx.compose.foundation.gestures.scrollable2D
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.TouchInjectionScope
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import co.typie.route.Route
+import co.typie.ui.component.topbar.TopBarState
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+class NavigationStackDesktopTest {
+  @Test
+  fun verticalScrollSessionDoesNotBecomeBackSwipeAfterTurningRight() =
+    assertGestureDoesNotPop(
+      scrollConsumer = { delta -> if (abs(delta.y) > abs(delta.x)) delta else Offset.Zero },
+      gesture = {
+        down(center)
+        moveBy(Offset(x = 0f, y = -120f))
+        moveBy(Offset(x = 220f, y = 0f))
+        up()
+      },
+    )
+
+  @Test
+  fun leftNoOpSessionDoesNotBecomeBackSwipeAfterTurningRight() =
+    assertGestureDoesNotPop(
+      scrollConsumer = { Offset.Zero },
+      gesture = {
+        down(center)
+        moveBy(Offset(x = -80f, y = 0f))
+        moveBy(Offset(x = 240f, y = 0f))
+        up()
+      },
+    )
+
+  @Test
+  fun horizontalScrollSessionDoesNotBecomeBackSwipeAtStartEdge() {
+    var consumedHorizontalDrag = false
+    assertGestureDoesNotPop(
+      scrollConsumer = { delta ->
+        if (!consumedHorizontalDrag && delta.x > 0f) {
+          consumedHorizontalDrag = true
+          delta
+        } else {
+          Offset.Zero
+        }
+      },
+      gesture = {
+        down(center)
+        moveBy(Offset(x = 80f, y = 0f))
+        moveBy(Offset(x = 160f, y = 0f))
+        up()
+      },
+    )
+  }
+
+  @Test
+  fun verticalEdgeSessionDoesNotBecomeBackSwipeAfterTurningRight() =
+    assertGestureDoesNotPop(
+      scrollConsumer = { delta -> if (abs(delta.y) > abs(delta.x)) delta else Offset.Zero },
+      gesture = {
+        down(Offset(x = 10f, y = center.y))
+        moveBy(Offset(x = 0f, y = -120f))
+        moveBy(Offset(x = 220f, y = 0f))
+        up()
+      },
+    )
+
+  @Test
+  fun rejectedSessionAllowsBackSwipeAfterPointerUp() =
+    assertGesturesPop(
+      scrollConsumer = { delta -> if (abs(delta.y) > abs(delta.x)) delta else Offset.Zero },
+      firstGesture = {
+        down(center)
+        moveBy(Offset(x = 0f, y = -120f))
+        moveBy(Offset(x = 220f, y = 0f))
+        up()
+      },
+      secondGesture = {
+        down(center)
+        moveBy(Offset(x = 220f, y = 0f))
+        up()
+      },
+    )
+
+  private fun assertGestureDoesNotPop(
+    scrollConsumer: (Offset) -> Offset,
+    gesture: TouchInjectionScope.() -> Unit,
+  ) = assertGestureResult(scrollConsumer, shouldPop = false, gesture)
+
+  private fun assertGesturesPop(
+    scrollConsumer: (Offset) -> Offset,
+    firstGesture: TouchInjectionScope.() -> Unit,
+    secondGesture: TouchInjectionScope.() -> Unit,
+  ) = assertGestureResult(scrollConsumer, shouldPop = true, firstGesture, secondGesture)
+
+  private fun assertGestureResult(
+    scrollConsumer: (Offset) -> Offset,
+    shouldPop: Boolean,
+    vararg gestures: TouchInjectionScope.() -> Unit,
+  ) = runComposeUiTest {
+    val navigator = Navigator(Route.Home)
+    val editorRoute = Route.Editor("document-id")
+
+    setContent {
+      NavigationStack(
+        navigator = navigator,
+        topBarState = remember { TopBarState() },
+        modifier = Modifier.size(width = 320.dp, height = 640.dp),
+      ) { route ->
+        val scrollableState = rememberScrollable2DState(scrollConsumer)
+        Box(
+          Modifier.fillMaxSize()
+            .testTag(if (route == editorRoute) EditorRouteTag else HomeRouteTag)
+            .navigationPopNestedScroll()
+            .scrollable2D(scrollableState)
+        )
+      }
+      LaunchedEffect(Unit) { navigator.navigate(editorRoute) }
+    }
+    waitUntil { navigator.current == editorRoute && !navigator.isTransitioning }
+
+    gestures.forEach { gesture ->
+      onNodeWithTag(EditorRouteTag).performTouchInput(gesture)
+      waitForIdle()
+    }
+
+    assertEquals(if (shouldPop) Route.Home else editorRoute, navigator.current)
+  }
+
+  private companion object {
+    const val EditorRouteTag = "editor-route"
+    const val HomeRouteTag = "home-route"
+  }
+}


### PR DESCRIPTION
- TR-393 해결: 세로/가로 스크롤이나 왼쪽 드래그로 시작한 포인터 세션이 중간에 nav pop으로 전환되지 않도록 direction lock
- nested scroll과 전체/edge back swipe가 첫 touch slop 이동에서만 pop을 claim하고, reject되면 손을 뗄 때까지 유지하도록 정책 통일
- 방향 전환, scroll 경계 도달, edge swipe와 pointer up 이후 reset을 검증하는 회귀 테스트 추가