### PR TITLE
JVM Desktop drag release 시 scroll 유실 방지

### DIFF
--- a/apps/mobile/compose/src/desktopMain/kotlin/co/typie/ext/DesktopScrollTranslation.kt
+++ b/apps/mobile/compose/src/desktopMain/kotlin/co/typie/ext/DesktopScrollTranslation.kt
@@ -168,8 +168,8 @@ private class DragToScrollHandler(
       return
     }
 
-    stopFling()
-    val generation = ++flingGeneration
+    // The pending drag dispatch and its fling belong to the same input generation.
+    val generation = flingGeneration
     val timer =
       Timer(FLING_FRAME_MS) { event ->
         if (generation != flingGeneration) {

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ext/DesktopScrollTranslationTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ext/DesktopScrollTranslationTest.kt
@@ -3,12 +3,14 @@ package co.typie.ext
 import androidx.compose.ui.awt.ComposeWindow
 import java.awt.AWTEvent
 import java.awt.Component
+import java.awt.event.AWTEventListener
 import java.awt.event.InputEvent
 import java.awt.event.MouseEvent
 import java.awt.event.MouseListener
 import java.awt.event.MouseMotionListener
 import java.awt.event.MouseWheelEvent
 import javax.swing.SwingUtilities
+import javax.swing.Timer
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -33,21 +35,80 @@ class DesktopScrollTranslationTest {
     SwingUtilities.invokeAndWait {}
 
     try {
-      assertEquals(
-        expected = 2,
-        actual = target.wheelEvents.size,
-        message = target.wheelEvents.joinToString { "${it.preciseWheelRotation}:${it.modifiersEx}" },
-      )
-      val horizontal =
-        target.wheelEvents.single { it.modifiersEx and InputEvent.SHIFT_DOWN_MASK != 0 }
-      val vertical =
-        target.wheelEvents.single { it.modifiersEx and InputEvent.SHIFT_DOWN_MASK == 0 }
-      assertEquals(-10.0, horizontal.preciseWheelRotation)
-      assertEquals(-7.5, vertical.preciseWheelRotation)
+      assertDiagonalWheelEvents(target)
     } finally {
       SwingUtilities.invokeAndWait { window.dispose() }
     }
   }
+
+  @Test
+  fun mouseReleaseKeepsPendingDragScroll() {
+    val target = WheelEventRecorder()
+    lateinit var window: ComposeWindow
+    lateinit var handler: Any
+
+    SwingUtilities.invokeAndWait {
+      window = ComposeWindow()
+      handler = createDragToScrollHandler(window)
+      val mouseListener = handler.field<MouseListener>("mouseListener")
+
+      mouseListener.mousePressed(mouseEvent(target, MouseEvent.MOUSE_PRESSED, x = 0, y = 100))
+      handler
+        .field<MouseMotionListener>("motionListener")
+        .mouseDragged(mouseEvent(target, MouseEvent.MOUSE_DRAGGED, x = 40, y = 130))
+      mouseListener.mouseReleased(mouseEvent(target, MouseEvent.MOUSE_RELEASED, x = 40, y = 130))
+      handler.field<Timer?>("flingTimer")?.stop()
+    }
+    SwingUtilities.invokeAndWait {}
+
+    try {
+      assertDiagonalWheelEvents(target)
+    } finally {
+      SwingUtilities.invokeAndWait { window.dispose() }
+    }
+  }
+
+  @Test
+  fun childPressCancelsPendingDragScroll() {
+    val target = WheelEventRecorder()
+    lateinit var window: ComposeWindow
+    lateinit var handler: Any
+
+    SwingUtilities.invokeAndWait {
+      window = ComposeWindow()
+      handler = createDragToScrollHandler(window)
+      val childPressTarget = object : Component() {}
+      window.add(childPressTarget)
+      val mouseListener = handler.field<MouseListener>("mouseListener")
+
+      mouseListener.mousePressed(mouseEvent(target, MouseEvent.MOUSE_PRESSED, x = 0, y = 100))
+      handler
+        .field<MouseMotionListener>("motionListener")
+        .mouseDragged(mouseEvent(target, MouseEvent.MOUSE_DRAGGED, x = 40, y = 130))
+      handler
+        .field<AWTEventListener>("awtEventListener")
+        .eventDispatched(mouseEvent(childPressTarget, MouseEvent.MOUSE_PRESSED, x = 0, y = 100))
+    }
+    SwingUtilities.invokeAndWait {}
+
+    try {
+      assertEquals(0, target.wheelEvents.size)
+    } finally {
+      SwingUtilities.invokeAndWait { window.dispose() }
+    }
+  }
+}
+
+private fun assertDiagonalWheelEvents(target: WheelEventRecorder) {
+  assertEquals(
+    expected = 2,
+    actual = target.wheelEvents.size,
+    message = target.wheelEvents.joinToString { "${it.preciseWheelRotation}:${it.modifiersEx}" },
+  )
+  val horizontal = target.wheelEvents.single { it.modifiersEx and InputEvent.SHIFT_DOWN_MASK != 0 }
+  val vertical = target.wheelEvents.single { it.modifiersEx and InputEvent.SHIFT_DOWN_MASK == 0 }
+  assertEquals(-10.0, horizontal.preciseWheelRotation)
+  assertEquals(-7.5, vertical.preciseWheelRotation)
 }
 
 private fun createDragToScrollHandler(window: ComposeWindow): Any {


### PR DESCRIPTION
- 런타임에서 거의 발생하기 어려운 시나리오지만 프로덕션 코드 diff가 적고 수정 방향이 명확해서 올림
- JVM Desktop에서 AWT Event Dispatch Thread(EDT)가 밀려 drag와 release가 함께 대기하면, release보다 뒤에 예약된 마지막 scroll event가 fling 시작 시 폐기될 수 있던 문제 수정
- drag에서 이어지는 fling은 같은 input generation을 사용해 pending scroll을 유지하고, 새 mouse press가 이전 scroll을 취소하는 기존 동작은 보존
- release 시 pending scroll 보존과 창 내부 새 press의 이전 scroll 취소를 회귀 테스트로 검증