### PR TITLE
앱 에디터 'local edit'

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Editor.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Editor.kt
@@ -43,6 +43,7 @@ import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.concurrent.atomics.AtomicLong
 import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.coroutines.CoroutineContext
 import kotlin.reflect.KClass
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.PersistentMap
@@ -54,6 +55,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -96,9 +98,12 @@ internal constructor(
   private val versionCounter: AtomicLong = AtomicLong(0L)
   private val disposed: AtomicBoolean = AtomicBoolean(false)
   private val syncInProgress: AtomicBoolean = AtomicBoolean(false)
+  private val localEdits = EditorLocalEditCoordinator()
   private val attachedPages: AtomicReference<PersistentSet<Int>> =
     AtomicReference(persistentSetOf())
   private val pendingSettles: AtomicReference<PersistentList<PendingSettle>> =
+    AtomicReference(persistentListOf())
+  private val queuedLocalEdits: AtomicReference<PersistentList<LocalEdit>> =
     AtomicReference(persistentListOf())
   private val queued: AtomicBoolean = AtomicBoolean(false)
   private val surfaceScheduler =
@@ -140,8 +145,39 @@ internal constructor(
     focusManager?.clearFocus()
   }
 
+  internal fun trackLocalEdit(start: (CoroutineContext) -> Job) {
+    val localEdit = localEdits.register() ?: return
+    val completion =
+      try {
+        start(localEdit)
+      } catch (e: CancellationException) {
+        localEdit.fail(e)
+        throw e
+      } catch (e: Throwable) {
+        localEdit.fail(e)
+        notifyFailure(e)
+        return
+      }
+    completion.invokeOnCompletion { failure ->
+      if (failure == null) {
+        localEdit.complete()
+      } else {
+        localEdit.fail(failure)
+      }
+    }
+  }
+
+  internal fun quiesceLocalEdits(): LocalEditQuiescence = localEdits.quiesce()
+
   suspend fun await(beforeCommit: ((EditorState) -> Unit)? = null, block: EditorScope.() -> Unit) {
-    withSuspendFailureNotification { awaitOrThrow(beforeCommit = beforeCommit, block = block) }
+    try {
+      awaitOrThrow(beforeCommit = beforeCommit, block = block)
+    } catch (e: CancellationException) {
+      throw e
+    } catch (e: Throwable) {
+      notifyFailure(e)
+      throw e
+    }
   }
 
   private suspend fun awaitOrThrow(
@@ -158,40 +194,42 @@ internal constructor(
     block(collector)
     if (messages.isEmpty()) return
 
-    val (events, snapshot) =
-      withContext(NonCancellable + dispatcher) {
-        mutex.withLock {
-          if (disposed.load()) throw CancellationException("Editor disposed")
-          for (m in messages) inner.enqueue(m)
-          val e = inner.tick()
-          val version = versionCounter.addAndFetch(1L)
-          val s = readSnapshot(version = version, events = e)
-          e to s
-        }
-      }
-
-    val pending: PendingSettle? =
-      if (events.any { it is EditorEvent.RenderInvalidated }) {
-        val initial = attachedPages.load()
-        if (initial.isEmpty()) null
-        else
-          PendingSettle(initial, requiredVersion = snapshot.version).also {
-            pendingSettles.updatePersistent { list -> list.add(it) }
+    localEdits.run {
+      val (events, snapshot) =
+        withContext(NonCancellable + dispatcher) {
+          mutex.withLock {
+            if (disposed.load()) throw CancellationException("Editor disposed")
+            for (m in messages) inner.enqueue(m)
+            val e = inner.tick()
+            val version = versionCounter.addAndFetch(1L)
+            val s = readSnapshot(version = version, events = e)
+            e to s
           }
-      } else null
+        }
 
-    try {
-      emit(events)
-      pending?.await()
-    } finally {
-      if (pending != null) {
-        pendingSettles.updatePersistent { it.remove(pending) }
-      }
-      withContext(NonCancellable) {
-        mutex.withLock {
-          if (!disposed.load()) {
-            beforeCommit?.invoke(snapshot)
-            commit(snapshot)
+      val pending: PendingSettle? =
+        if (events.any { it is EditorEvent.RenderInvalidated }) {
+          val initial = attachedPages.load()
+          if (initial.isEmpty()) null
+          else
+            PendingSettle(initial, requiredVersion = snapshot.version).also {
+              pendingSettles.updatePersistent { list -> list.add(it) }
+            }
+        } else null
+
+      try {
+        emit(events)
+        pending?.await()
+      } finally {
+        if (pending != null) {
+          pendingSettles.updatePersistent { it.remove(pending) }
+        }
+        withContext(NonCancellable) {
+          mutex.withLock {
+            if (!disposed.load()) {
+              beforeCommit?.invoke(snapshot)
+              commit(snapshot)
+            }
           }
         }
       }
@@ -199,32 +237,37 @@ internal constructor(
   }
 
   fun sync(beforeCommit: ((EditorState) -> Unit)? = null, block: EditorScope.() -> Unit) {
+    val localEdit = localEdits.register() ?: return
     if (!syncInProgress.compareAndSet(expectedValue = false, newValue = true)) {
-      notifyFailure(IllegalStateException("nested sync is not supported"))
+      val error = IllegalStateException("nested sync is not supported")
+      localEdit.fail(error)
+      notifyFailure(error)
       return
     }
     try {
-      withFailureNotification {
-        runBlocking {
-          val events: List<EditorEvent>
-          mutex.withLock {
-            if (disposed.load()) error("Editor disposed")
-            val collector =
-              object : EditorScope {
-                override fun enqueue(message: Message) {
-                  inner.enqueue(message)
-                }
+      runBlocking {
+        val events: List<EditorEvent>
+        mutex.withLock {
+          if (disposed.load()) error("Editor disposed")
+          val collector =
+            object : EditorScope {
+              override fun enqueue(message: Message) {
+                inner.enqueue(message)
               }
-            block(collector)
-            events = inner.tick()
-            val version = versionCounter.addAndFetch(1L)
-            val snapshot = readSnapshot(version = version, events = events)
-            beforeCommit?.invoke(snapshot)
-            commit(snapshot)
-          }
-          emit(events)
+            }
+          block(collector)
+          events = inner.tick()
+          val version = versionCounter.addAndFetch(1L)
+          val snapshot = readSnapshot(version = version, events = events)
+          beforeCommit?.invoke(snapshot)
+          commit(snapshot)
         }
+        emit(events)
       }
+      localEdit.complete()
+    } catch (e: Throwable) {
+      localEdit.fail(e)
+      notifyFailure(e)
     } finally {
       syncInProgress.store(false)
     }
@@ -232,8 +275,16 @@ internal constructor(
 
   fun enqueue(message: Message) {
     if (disposed.load()) return
-    inner.enqueue(message)
-    scheduleTick()
+    val localEdit = localEdits.register() ?: return
+    try {
+      inner.enqueue(message)
+      queuedLocalEdits.updatePersistent { it.adding(localEdit) }
+      scheduleTick()
+    } catch (e: Throwable) {
+      localEdit.fail(e)
+      notifyFailure(e)
+      throw e
+    }
   }
 
   suspend fun can(message: Message): Boolean =
@@ -265,11 +316,13 @@ internal constructor(
   private fun scheduleTick() {
     if (!queued.compareAndSet(expectedValue = false, newValue = true)) return
     scope.launch(dispatcher) {
-      withSuspendFailureNotification {
+      var edits: PersistentList<LocalEdit> = persistentListOf()
+      try {
         val events =
           withContext(dispatcher) {
             mutex.withLock {
               queued.store(false)
+              edits = queuedLocalEdits.exchange(persistentListOf())
               if (disposed.load()) return@withLock emptyList()
               val e = inner.tick()
               val version = versionCounter.addAndFetch(1L)
@@ -278,6 +331,13 @@ internal constructor(
             }
           }
         emit(events)
+        edits.forEach(LocalEdit::complete)
+      } catch (e: CancellationException) {
+        edits.forEach { localEdit -> localEdit.fail(e) }
+        throw e
+      } catch (e: Throwable) {
+        edits.forEach { localEdit -> localEdit.fail(e) }
+        notifyFailure(e)
       }
     }
   }
@@ -446,20 +506,27 @@ internal constructor(
   }
 
   suspend fun insertTemplateFragment(changesets: ByteArray): Boolean =
-    withSuspendFailureNotification(defaultValue = { false }) {
-      val events =
-        withContext(NonCancellable + dispatcher) {
-          mutex.withLock {
-            if (disposed.load()) throw CancellationException("Editor disposed")
-            inner.insertTemplateFragment(changesets)
-            val e = inner.tick()
-            val version = versionCounter.addAndFetch(1L)
-            commit(readSnapshot(version = version, events = e))
-            e
+    try {
+      localEdits.run {
+        val events =
+          withContext(NonCancellable + dispatcher) {
+            mutex.withLock {
+              if (disposed.load()) throw CancellationException("Editor disposed")
+              inner.insertTemplateFragment(changesets)
+              val e = inner.tick()
+              val version = versionCounter.addAndFetch(1L)
+              commit(readSnapshot(version = version, events = e))
+              e
+            }
           }
-        }
-      emit(events)
-      true
+        emit(events)
+        true
+      }
+    } catch (e: CancellationException) {
+      throw e
+    } catch (e: Throwable) {
+      notifyFailure(e)
+      false
     }
 
   internal suspend fun currentHeads(): ByteArray =
@@ -482,6 +549,7 @@ internal constructor(
     if (!disposed.compareAndSet(expectedValue = false, newValue = true)) return
     EditorRegistry.unregisterAsync(this)
     pendingSettles.exchange(persistentListOf()).forEach { it.cancel() }
+    queuedLocalEdits.exchange(persistentListOf()).forEach(LocalEdit::complete)
     listeners.store(persistentMapOf())
     attachedPages.store(persistentSetOf())
     surfaceScheduler.dispose()

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorLocalEditCoordinator.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorLocalEditCoordinator.kt
@@ -1,0 +1,132 @@
+package co.typie.editor
+
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+
+internal class LocalEditQuiescence
+internal constructor(
+  private val awaitCompletion: suspend () -> Result<Unit>,
+  private val resumeEditing: () -> Unit,
+) {
+  suspend fun await(): Result<Unit> = awaitCompletion()
+
+  fun resume() {
+    resumeEditing()
+  }
+}
+
+internal class LocalEdit
+internal constructor(private val coordinator: EditorLocalEditCoordinator, internal val id: Long) :
+  AbstractCoroutineContextElement(Key) {
+  companion object Key : CoroutineContext.Key<LocalEdit>
+
+  internal fun belongsTo(coordinator: EditorLocalEditCoordinator): Boolean =
+    this.coordinator === coordinator
+
+  internal fun complete() {
+    coordinator.complete(this)
+  }
+
+  internal fun fail(cause: Throwable) {
+    coordinator.fail(this, cause)
+  }
+}
+
+internal class EditorLocalEditCoordinator {
+  private data class State(
+    val nextId: Long = 1L,
+    val accepting: Boolean = true,
+    val pending: Set<Long> = emptySet(),
+    val failures: Map<Long, Throwable> = emptyMap(),
+  )
+
+  private val state = MutableStateFlow(State())
+
+  fun register(): LocalEdit? {
+    while (true) {
+      val current = state.value
+      if (!current.accepting) return null
+      val localEdit = LocalEdit(this, current.nextId)
+      val next =
+        current.copy(nextId = current.nextId + 1L, pending = current.pending + localEdit.id)
+      if (state.compareAndSet(current, next)) return localEdit
+    }
+  }
+
+  suspend fun <T> run(block: suspend () -> T): T {
+    val current = currentCoroutineContext()[LocalEdit]
+    if (current?.belongsTo(this) == true) return block()
+
+    val localEdit = register() ?: throw CancellationException("Editor local edits quiesced")
+    try {
+      return withContext(localEdit) { block() }.also { localEdit.complete() }
+    } catch (e: Throwable) {
+      localEdit.fail(e)
+      throw e
+    }
+  }
+
+  fun quiesce(): LocalEditQuiescence {
+    val through = closeAdmission()
+    return LocalEditQuiescence(
+      awaitCompletion = { awaitThrough(through) },
+      resumeEditing = { resumeThrough(through) },
+    )
+  }
+
+  internal fun complete(localEdit: LocalEdit) {
+    update(localEdit) { current ->
+      current.copy(
+        pending = current.pending - localEdit.id,
+        failures = current.failures - localEdit.id,
+      )
+    }
+  }
+
+  internal fun fail(localEdit: LocalEdit, cause: Throwable) {
+    update(localEdit) { current ->
+      current.copy(
+        pending = current.pending - localEdit.id,
+        failures = current.failures + (localEdit.id to cause),
+      )
+    }
+  }
+
+  private fun closeAdmission(): Long {
+    while (true) {
+      val current = state.value
+      val through = current.nextId - 1L
+      if (!current.accepting) return through
+      if (state.compareAndSet(current, current.copy(accepting = false))) return through
+    }
+  }
+
+  private suspend fun awaitThrough(through: Long): Result<Unit> {
+    val settled = state.first { current -> current.pending.none { it <= through } }
+    val failure =
+      settled.failures.entries.filter { it.key <= through }.minByOrNull { it.key }?.value
+    return if (failure == null) Result.success(Unit) else Result.failure(failure)
+  }
+
+  private fun resumeThrough(through: Long) {
+    while (true) {
+      val current = state.value
+      val next =
+        current.copy(accepting = true, failures = current.failures.filterKeys { it > through })
+      if (state.compareAndSet(current, next)) return
+    }
+  }
+
+  private inline fun update(localEdit: LocalEdit, transform: (State) -> State) {
+    while (true) {
+      val current = state.value
+      if (localEdit.id !in current.pending) return
+      if (state.compareAndSet(current, transform(current))) return
+    }
+  }
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorInput.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorInput.kt
@@ -183,10 +183,12 @@ internal class EditorInputNode(
     bringIntoViewTarget: EditorBringIntoViewTarget? = EditorBringIntoViewTarget.CurrentSelectionHead,
   ) {
     if (messages.isEmpty()) return
-    coroutineScope.launch {
-      editor.awaitWithBringIntoView(bringIntoViewRequests) {
-        messages.forEach(::enqueue)
-        beforeCommit { bringIntoViewTarget?.let { target -> bringIntoView(target) } }
+    editor.trackLocalEdit { context ->
+      editor.scope.launch(context) {
+        editor.awaitWithBringIntoView(bringIntoViewRequests) {
+          messages.forEach(::enqueue)
+          beforeCommit { bringIntoViewTarget?.let { target -> bringIntoView(target) } }
+        }
       }
     }
   }
@@ -202,7 +204,11 @@ internal class EditorInputNode(
   }
 
   private fun dispatchBinding(binding: KeyBinding, clipboard: Clipboard) {
-    bindingCoalescer.submit(binding, clipboard)
+    if (binding.coalescible) {
+      editor.trackLocalEdit { localEdit -> bindingCoalescer.submit(binding, clipboard, localEdit) }
+    } else {
+      coroutineScope.launch { bindingCoalescer.submit(binding, clipboard).await() }
+    }
   }
 
   private suspend fun dispatchBindingMessages(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorKeyBindingCoalescer.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorKeyBindingCoalescer.kt
@@ -4,10 +4,16 @@ import co.typie.editor.KeyBinding
 import co.typie.editor.ffi.Message
 import co.typie.editor.scroll.EditorBringIntoViewTarget
 import co.typie.platform.Clipboard
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 // Key repeats can outpace per-event editor dispatch; draining every queued
 // coalescible binding into one dispatch keeps the pending work bounded to a
@@ -19,48 +25,107 @@ internal class EditorKeyBindingCoalescer(
   private val resolveMessages: suspend (KeyBinding, Clipboard) -> List<Message>,
   private val dispatch: suspend (List<Message>, EditorBringIntoViewTarget?) -> Unit,
 ) {
-  private data class Submission(val binding: KeyBinding, val clipboard: Clipboard)
+  private data class Submission(
+    val binding: KeyBinding,
+    val clipboard: Clipboard,
+    val localEditContext: CoroutineContext?,
+    val completion: CompletableDeferred<Unit>,
+  ) {
+    fun complete() {
+      completion.complete(Unit)
+    }
 
-  private val submissions = Channel<Submission>(Channel.UNLIMITED)
-  private var worker: Job? = null
-
-  fun submit(binding: KeyBinding, clipboard: Clipboard) {
-    ensureWorker()
-    submissions.trySend(Submission(binding, clipboard))
+    fun fail(error: Throwable) {
+      completion.completeExceptionally(error)
+    }
   }
 
-  private fun ensureWorker() {
-    if (worker?.isActive == true) return
-    worker = scope.launch {
-      for (first in submissions) {
-        drainFrom(first)
+  private inner class PendingBatch {
+    private val submissions = mutableListOf<Submission>()
+    private val messages = mutableListOf<Message>()
+    private var target: EditorBringIntoViewTarget? = null
+
+    fun add(submission: Submission, resolvedMessages: List<Message>) {
+      submissions += submission
+      messages += resolvedMessages
+      submission.binding.bringIntoViewTarget?.let { target = it }
+    }
+
+    suspend fun flush() {
+      if (submissions.isEmpty()) return
+      if (messages.isNotEmpty()) {
+        val context = submissions.firstNotNullOfOrNull { submission -> submission.localEditContext }
+        if (context == null) {
+          dispatch(messages.toList(), target)
+        } else {
+          withContext(context) { dispatch(messages.toList(), target) }
+        }
+      }
+      submissions.forEach(Submission::complete)
+      submissions.clear()
+      messages.clear()
+      target = null
+    }
+  }
+
+  private val submissions = Channel<Submission>(Channel.UNLIMITED)
+
+  init {
+    scope.launch {
+      try {
+        for (first in submissions) {
+          drainFrom(first)
+        }
+      } finally {
+        val cancellation = CancellationException("Editor key binding coalescer stopped")
+        submissions.close(cancellation)
+        while (true) {
+          val queued = submissions.tryReceive().getOrNull() ?: break
+          queued.fail(cancellation)
+        }
       }
     }
+  }
+
+  fun submit(
+    binding: KeyBinding,
+    clipboard: Clipboard,
+    localEditContext: CoroutineContext? = null,
+  ): Deferred<Unit> {
+    val submission = Submission(binding, clipboard, localEditContext, CompletableDeferred())
+    submissions.trySend(submission).getOrThrow()
+    return submission.completion
   }
 
   private suspend fun drainFrom(first: Submission) {
-    val batch = mutableListOf<Message>()
-    var batchTarget: EditorBringIntoViewTarget? = null
-
-    suspend fun flushBatch() {
-      if (batch.isEmpty()) return
-      dispatch(batch.toList(), batchTarget)
-      batch.clear()
-      batchTarget = null
-    }
-
+    val batch = PendingBatch()
+    val claimed = mutableListOf<Submission>()
     var current: Submission? = first
-    while (current != null) {
-      val binding = current.binding
-      if (binding.coalescible) {
-        batch += resolveMessages(binding, current.clipboard)
-        binding.bringIntoViewTarget?.let { batchTarget = it }
-      } else {
-        flushBatch()
-        dispatch(resolveMessages(binding, current.clipboard), binding.bringIntoViewTarget)
+    try {
+      while (current != null) {
+        claimed += current
+        val binding = current.binding
+        if (binding.coalescible) {
+          batch.add(current, resolveMessages(binding, current.clipboard))
+        } else {
+          batch.flush()
+          val messages = resolveMessages(binding, current.clipboard)
+          if (current.localEditContext == null) {
+            dispatch(messages, binding.bringIntoViewTarget)
+          } else {
+            withContext(current.localEditContext) {
+              dispatch(messages, binding.bringIntoViewTarget)
+            }
+          }
+          current.complete()
+        }
+        current = submissions.tryReceive().getOrNull()
       }
-      current = submissions.tryReceive().getOrNull()
+      batch.flush()
+    } catch (error: Throwable) {
+      claimed.forEach { it.fail(error) }
+      // A quiesced editor cancels one dispatch; only scope cancellation stops the worker itself.
+      if (error is CancellationException && !currentCoroutineContext().isActive) throw error
     }
-    flushBatch()
   }
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/EditorFindReplaceSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/EditorFindReplaceSession.kt
@@ -109,26 +109,32 @@ internal fun rememberEditorFindReplaceSession(
         state.findBy(offset = 1, editor = editor, bringIntoViewRequests = bringIntoViewRequests)
       }
     },
-    replace = {
-      scope.launch {
-        state.replaceActive(
-          editor = editor,
-          documentLocked = documentLocked,
-          onLocked = { toast.show(ToastType.Error, "잠긴 문서는 편집할 수 없어요.") },
-          bringIntoViewRequests = bringIntoViewRequests,
-        )
-      }
-    },
-    replaceAll = {
-      scope.launch {
-        state.replaceAllMatches(
-          editor = editor,
-          documentLocked = documentLocked,
-          onLocked = { toast.show(ToastType.Error, "잠긴 문서는 편집할 수 없어요.") },
-          bringIntoViewRequests = bringIntoViewRequests,
-        )
-      }
-    },
+    replace = replace@{
+        val activeEditor = editor ?: return@replace
+        activeEditor.trackLocalEdit { context ->
+          activeEditor.scope.launch(context) {
+            state.replaceActive(
+              editor = activeEditor,
+              documentLocked = documentLocked,
+              onLocked = { toast.show(ToastType.Error, "잠긴 문서는 편집할 수 없어요.") },
+              bringIntoViewRequests = bringIntoViewRequests,
+            )
+          }
+        }
+      },
+    replaceAll = replaceAll@{
+        val activeEditor = editor ?: return@replaceAll
+        activeEditor.trackLocalEdit { context ->
+          activeEditor.scope.launch(context) {
+            state.replaceAllMatches(
+              editor = activeEditor,
+              documentLocked = documentLocked,
+              onLocked = { toast.show(ToastType.Error, "잠긴 문서는 편집할 수 없어요.") },
+              bringIntoViewRequests = bringIntoViewRequests,
+            )
+          }
+        }
+      },
   )
 }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorRepasteAsTextOverlay.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorRepasteAsTextOverlay.kt
@@ -102,10 +102,12 @@ internal fun EditorRepasteAsTextOverlay(
             .background(AppTheme.colors.surfaceDefault, RepasteAsTextOverlayShape)
             .semantics(mergeDescendants = true) {}
             .clickable {
-              editor.scope.launch {
-                editor.awaitWithBringIntoView(bringIntoViewRequests) {
-                  enqueue(Message.Clipboard(ClipboardOp.RepasteAsText))
-                  beforeCommit { bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead) }
+              editor.trackLocalEdit { context ->
+                editor.scope.launch(context) {
+                  editor.awaitWithBringIntoView(bringIntoViewRequests) {
+                    enqueue(Message.Clipboard(ClipboardOp.RepasteAsText))
+                    beforeCommit { bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead) }
+                  }
                 }
               }
               editor.focus()

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/spellcheck/EditorSpellcheckSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/spellcheck/EditorSpellcheckSession.kt
@@ -327,19 +327,21 @@ internal fun rememberEditorSpellcheckSession(
           return@applySuggestion
         }
 
-        scope.launch {
-          activeEditor.replaceSpellcheckRangeText(
-            id = id,
-            expectedText = result.context,
-            replacement = replacement,
-          )
-          programmaticSelectionToSkip = activeEditor.state.selection
-          val nextId = model.remove(id, activateReplacement = true)
-          if (nextId != null) {
-            updateCompactOverlayHeightForRange(nextId)
+        activeEditor.trackLocalEdit { context ->
+          activeEditor.scope.launch(context) {
+            activeEditor.replaceSpellcheckRangeText(
+              id = id,
+              expectedText = result.context,
+              replacement = replacement,
+            )
+            programmaticSelectionToSkip = activeEditor.state.selection
+            val nextId = model.remove(id, activateReplacement = true)
+            if (nextId != null) {
+              updateCompactOverlayHeightForRange(nextId)
+            }
+            updateActiveRangeDecoration()
+            requestRangeIntoView(nextId)
           }
-          updateActiveRangeDecoration()
-          requestRangeIntoView(nextId)
         }
       },
     directEdit = directEdit@{ id ->

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarHost.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarHost.kt
@@ -238,18 +238,20 @@ internal fun EditorToolbarHost(
       return
     }
 
-    commandScope.launch {
-      val editor = runtime.editor ?: return@launch
-      val committedState =
-        editor.awaitWithBringIntoView(bringIntoViewRequests) {
-          if (editor.ime?.composing != null) {
-            enqueue(Message.TextInput(listOf(FlatImeOp.CommitAsIs)))
+    val editor = runtime.editor ?: return
+    editor.trackLocalEdit { context ->
+      editor.scope.launch(context) {
+        val committedState =
+          editor.awaitWithBringIntoView(bringIntoViewRequests) {
+            if (editor.ime?.composing != null) {
+              enqueue(Message.TextInput(listOf(FlatImeOp.CommitAsIs)))
+            }
+            messages.forEach(::enqueue)
+            beforeCommit { bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead) }
           }
-          messages.forEach(::enqueue)
-          beforeCommit { bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead) }
+        if (committedState == null) {
+          Logger.e { "Editor toolbar messages did not commit" }
         }
-      if (committedState == null) {
-        Logger.e { "Editor toolbar messages did not commit" }
       }
     }
   }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/bottom/Nodes.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/bottom/Nodes.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -72,7 +71,6 @@ internal fun BottomToolbarNodes(
 ) {
   val runtime = LocalEditorRuntime.current
   val bringIntoViewRequests = LocalEditorBringIntoViewRequests.current
-  val scope = rememberCoroutineScope()
   val editor = runtime.editor
   val showPageBreak = editor?.rootAttrs?.layoutMode is LayoutMode.Paginated
   val hasUnitSelection =
@@ -108,10 +106,12 @@ internal fun BottomToolbarNodes(
             is EditorToolbarNodeInsertAction.OpenPanel -> onBottomPanelRequest(action.panel)
             is EditorToolbarNodeInsertAction.SendMessage -> {
               val currentEditor = runtime.editor ?: return@NodeInsertTile
-              scope.launch {
-                currentEditor.awaitWithBringIntoView(bringIntoViewRequests) {
-                  enqueue(action.message)
-                  beforeCommit { bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead) }
+              currentEditor.trackLocalEdit { context ->
+                currentEditor.scope.launch(context) {
+                  currentEditor.awaitWithBringIntoView(bringIntoViewRequests) {
+                    enqueue(action.message)
+                    beforeCommit { bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead) }
+                  }
                 }
               }
               onEditorInputRequest()

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorAwaitTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorAwaitTest.kt
@@ -15,6 +15,7 @@ import co.typie.editor.ffi.StateField
 import co.typie.editor.ffi.SystemEvent
 import co.typie.editor.ffi.TrackedRange
 import co.typie.editor.ffi.TrackedRangeEndpoints
+import kotlin.coroutines.CoroutineContext
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -24,13 +25,17 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withContext
 
 private val sampleMessage: Message = Message.System(SystemEvent.Initialize)
 
@@ -293,19 +298,111 @@ class EditorAwaitTest {
     }
 
   @Test
-  fun await_reports_tick_exception_without_committing() =
+  fun await_reports_and_propagates_tick_exception_without_committing() =
     runTest(dispatcher) {
       val boom = RuntimeException("boom")
       val fake = FakeFfiEditor(onTick = { throw boom })
       val reported = mutableListOf<Throwable>()
       val editor = Editor(fake, this, dispatcher, onError = { _, error -> reported += error })
 
-      editor.await { enqueue(sampleMessage) }
+      val thrown = assertFailsWith<RuntimeException> { editor.await { enqueue(sampleMessage) } }
 
+      assertEquals(boom.message, thrown.message)
       assertEquals(1, reported.size)
       assertTrue(reported.single() is RuntimeException)
       assertEquals(boom.message, reported.single().message)
       assertEquals(EditorState.Initial, editor.state)
+    }
+
+  @Test
+  fun await_is_rejected_after_local_transactions_quiesce() =
+    runTest(dispatcher) {
+      val fake = FakeFfiEditor()
+      val editor = Editor(fake, this, dispatcher)
+      editor.quiesceLocalEdits()
+
+      assertFailsWith<CancellationException> { editor.await { enqueue(sampleMessage) } }
+
+      assertEquals(emptyList(), fake.enqueued)
+      assertEquals(0, fake.tickCount)
+    }
+
+  @Test
+  fun track_local_edit_registers_before_its_coroutine_starts() =
+    runTest(dispatcher) {
+      val editor = Editor(FakeFfiEditor(), this, dispatcher)
+      val gate = CompletableDeferred<Unit>()
+
+      editor.trackLocalEdit { context -> launch(context) { gate.await() } }
+      val quiescence = editor.quiesceLocalEdits()
+      val barrier = async(start = CoroutineStart.UNDISPATCHED) { quiescence.await() }
+
+      assertFalse(barrier.isCompleted)
+
+      dispatcher.scheduler.runCurrent()
+      assertFalse(barrier.isCompleted)
+
+      gate.complete(Unit)
+      dispatcher.scheduler.runCurrent()
+      assertTrue(barrier.await().isSuccess)
+    }
+
+  @Test
+  fun track_local_edit_is_rejected_after_quiesce() =
+    runTest(dispatcher) {
+      val editor = Editor(FakeFfiEditor(), this, dispatcher)
+      var started = false
+      editor.quiesceLocalEdits()
+
+      editor.trackLocalEdit { context -> launch(context) { started = true } }
+      dispatcher.scheduler.advanceUntilIdle()
+
+      assertFalse(started)
+    }
+
+  @Test
+  fun accepted_tracked_local_edit_can_commit_after_quiesce() =
+    runTest(dispatcher) {
+      val fake = FakeFfiEditor()
+      val editor = Editor(fake, this, dispatcher)
+
+      editor.trackLocalEdit { context ->
+        launch(context) { editor.await { enqueue(sampleMessage) } }
+      }
+      val quiescence = editor.quiesceLocalEdits()
+      val barrier = async(start = CoroutineStart.UNDISPATCHED) { quiescence.await() }
+
+      dispatcher.scheduler.advanceUntilIdle()
+
+      assertTrue(barrier.await().isSuccess)
+      assertEquals(listOf(sampleMessage), fake.enqueued)
+      assertEquals(1, fake.tickCount)
+    }
+
+  @Test
+  fun accepted_local_edit_can_commit_from_another_coroutine_after_quiesce() =
+    runTest(dispatcher) {
+      val fake = FakeFfiEditor()
+      val editor = Editor(fake, this, dispatcher)
+      val handedOff = CompletableDeferred<CoroutineContext>()
+      val completion = CompletableDeferred<Unit>()
+
+      editor.trackLocalEdit { context ->
+        handedOff.complete(context)
+        completion
+      }
+      val context = handedOff.await()
+      val quiescence = editor.quiesceLocalEdits()
+      val barrier = async(start = CoroutineStart.UNDISPATCHED) { quiescence.await() }
+
+      assertFalse(barrier.isCompleted)
+
+      withContext(context) { editor.await { enqueue(sampleMessage) } }
+      completion.complete(Unit)
+
+      assertTrue(barrier.await().isSuccess)
+      assertEquals(listOf(sampleMessage), fake.enqueued)
+      assertEquals(1, fake.tickCount)
     }
 
   @Test
@@ -329,6 +426,19 @@ class EditorAwaitTest {
     }
 
   @Test
+  fun sync_is_rejected_after_local_transactions_quiesce() =
+    runTest(dispatcher) {
+      val fake = FakeFfiEditor()
+      val editor = Editor(fake, this, dispatcher)
+      editor.quiesceLocalEdits()
+
+      editor.sync { enqueue(sampleMessage) }
+
+      assertEquals(emptyList(), fake.enqueued)
+      assertEquals(0, fake.tickCount)
+    }
+
+  @Test
   fun insert_template_fragment_calls_inner_ticks_and_commits() =
     runTest(dispatcher) {
       val fakeCursor =
@@ -349,6 +459,24 @@ class EditorAwaitTest {
       assertEquals(1, fake.tickCount)
       assertEquals(fakeCursor, editor.cursor)
       assertEquals(1L, editor.state.version)
+    }
+
+  @Test
+  fun insert_template_fragment_is_rejected_after_local_edits_quiesce() =
+    runTest(dispatcher) {
+      val fake = FakeFfiEditor()
+      val editor = Editor(fake, this, dispatcher)
+      val quiescence = editor.quiesceLocalEdits()
+
+      try {
+        assertFailsWith<CancellationException> {
+          editor.insertTemplateFragment(byteArrayOf(1, 2, 3))
+        }
+        assertTrue(fake.insertedTemplateFragments.isEmpty())
+        assertEquals(0, fake.tickCount)
+      } finally {
+        quiescence.resume()
+      }
     }
 
   @Test
@@ -960,6 +1088,55 @@ class EditorAwaitTest {
       dispatcher.scheduler.advanceUntilIdle()
       assertEquals(1, fake.tickCount)
       assertEquals(listOf(sampleMessage), fake.enqueued)
+    }
+
+  @Test
+  fun queued_enqueue_holds_local_transaction_barrier_until_tick_commits() =
+    runTest(dispatcher) {
+      val fake = FakeFfiEditor()
+      val editor = Editor(fake, this, dispatcher)
+
+      editor.enqueue(sampleMessage)
+      val quiescence = editor.quiesceLocalEdits()
+      val barrier = async(start = CoroutineStart.UNDISPATCHED) { quiescence.await() }
+
+      assertFalse(barrier.isCompleted)
+
+      dispatcher.scheduler.runCurrent()
+      assertTrue(barrier.await().isSuccess)
+      assertEquals(1, fake.tickCount)
+    }
+
+  @Test
+  fun queued_enqueue_failure_reaches_local_transaction_barrier() =
+    runTest(dispatcher) {
+      val boom = RuntimeException("boom")
+      val fake = FakeFfiEditor(onTick = { throw boom })
+      val editor = Editor(fake, this, dispatcher)
+
+      editor.enqueue(sampleMessage)
+      val quiescence = editor.quiesceLocalEdits()
+      val barrier = async { quiescence.await() }
+
+      dispatcher.scheduler.advanceUntilIdle()
+
+      val result = barrier.await()
+      assertTrue(result.isFailure)
+      assertEquals(boom.message, result.exceptionOrNull()?.message)
+    }
+
+  @Test
+  fun enqueue_is_rejected_after_local_transactions_quiesce() =
+    runTest(dispatcher) {
+      val fake = FakeFfiEditor()
+      val editor = Editor(fake, this, dispatcher)
+      editor.quiesceLocalEdits()
+
+      editor.enqueue(sampleMessage)
+      dispatcher.scheduler.advanceUntilIdle()
+
+      assertEquals(emptyList(), fake.enqueued)
+      assertEquals(0, fake.tickCount)
     }
 
   @Test

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorLocalEditCoordinatorTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorLocalEditCoordinatorTest.kt
@@ -1,0 +1,100 @@
+package co.typie.editor
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+class EditorLocalEditCoordinatorTest {
+  @Test
+  fun concurrentEditsAllReachTheQuiescenceBarrier() = runTest {
+    val coordinator = EditorLocalEditCoordinator()
+    val edits =
+      List(8) {
+          async(Dispatchers.Default) { List(1_000) { assertNotNull(coordinator.register()) } }
+        }
+        .awaitAll()
+        .flatten()
+    val quiescence = coordinator.quiesce()
+    val result = async { quiescence.await() }
+
+    edits
+      .chunked(1_000)
+      .map { chunk -> launch(Dispatchers.Default) { chunk.forEach(LocalEdit::complete) } }
+      .joinAll()
+
+    assertTrue(result.await().isSuccess)
+  }
+
+  @Test
+  fun barrierWaitsForEveryAcceptedEdit() = runTest {
+    val coordinator = EditorLocalEditCoordinator()
+    val first = assertNotNull(coordinator.register())
+    val second = assertNotNull(coordinator.register())
+    val quiescence = coordinator.quiesce()
+    val result = async { quiescence.await() }
+
+    second.complete()
+    runCurrent()
+    assertFalse(result.isCompleted)
+
+    first.complete()
+    assertTrue(result.await().isSuccess)
+  }
+
+  @Test
+  fun quiescenceRejectsNewEditsUntilResume() {
+    val coordinator = EditorLocalEditCoordinator()
+    val accepted = assertNotNull(coordinator.register())
+    val quiescence = coordinator.quiesce()
+
+    assertNull(coordinator.register())
+
+    accepted.complete()
+    quiescence.resume()
+    assertNotNull(coordinator.register())
+  }
+
+  @Test
+  fun barrierReportsAcceptedEditFailure() = runTest {
+    val coordinator = EditorLocalEditCoordinator()
+    val edit = assertNotNull(coordinator.register())
+    val quiescence = coordinator.quiesce()
+    val failure = IllegalStateException("commit failed")
+
+    edit.fail(failure)
+
+    val result = quiescence.await()
+    assertTrue(result.isFailure)
+    assertSame(failure, result.exceptionOrNull())
+  }
+
+  @Test
+  fun barrierRemembersFailureButWaitsForRemainingAcceptedEdit() = runTest {
+    val coordinator = EditorLocalEditCoordinator()
+    val failed = assertNotNull(coordinator.register())
+    val pending = assertNotNull(coordinator.register())
+    val quiescence = coordinator.quiesce()
+    val failure = IllegalStateException("commit failed")
+    val result = async { quiescence.await() }
+
+    failed.fail(failure)
+    runCurrent()
+    assertFalse(result.isCompleted)
+
+    pending.complete()
+    val settled = result.await()
+    assertTrue(settled.isFailure)
+    assertSame(failure, settled.exceptionOrNull())
+  }
+}

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/input/EditorKeyBindingCoalescerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/input/EditorKeyBindingCoalescerTest.kt
@@ -1,6 +1,7 @@
 package co.typie.editor.input
 
 import androidx.compose.ui.input.key.Key as ComposeKey
+import co.typie.editor.EditorLocalEditCoordinator
 import co.typie.editor.KeyBinding
 import co.typie.editor.ffi.Direction
 import co.typie.editor.ffi.Message
@@ -9,10 +10,17 @@ import co.typie.editor.ffi.NavigationOp
 import co.typie.editor.scroll.EditorBringIntoViewTarget
 import co.typie.platform.Clipboard
 import co.typie.platform.ClipboardReadPayload
+import kotlin.coroutines.CoroutineContext
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.TestScope
@@ -29,14 +37,15 @@ class EditorKeyBindingCoalescerTest {
     override suspend fun paste(): ClipboardReadPayload? = null
   }
 
-  private data class Dispatched(
-    val messages: List<Message>,
-    val target: EditorBringIntoViewTarget?,
-  )
+  private data class Dispatched(val messages: List<Message>, val target: EditorBringIntoViewTarget?)
 
-  private class Harness(scope: CoroutineScope) {
+  private class Harness(
+    private val scope: CoroutineScope,
+    private val onDispatch: suspend () -> Unit,
+  ) {
     val dispatched = mutableListOf<Dispatched>()
     var dispatchGate: CompletableDeferred<Unit>? = null
+    var dispatchFailure: Throwable? = null
     private val clipboard = FakeClipboard()
     private val messagesByBinding = mutableMapOf<KeyBinding, List<Message>>()
     private val coalescer =
@@ -44,10 +53,15 @@ class EditorKeyBindingCoalescerTest {
         scope = scope,
         resolveMessages = { binding, _ -> messagesByBinding.getValue(binding) },
         dispatch = { messages, target ->
+          onDispatch()
           dispatched += Dispatched(messages, target)
           dispatchGate?.let { gate ->
             dispatchGate = null
             gate.await()
+          }
+          dispatchFailure?.let { failure ->
+            dispatchFailure = null
+            throw failure
           }
         },
       )
@@ -56,7 +70,15 @@ class EditorKeyBindingCoalescerTest {
       message: Message,
       coalescible: Boolean = true,
       target: EditorBringIntoViewTarget? = EditorBringIntoViewTarget.CurrentSelectionHead,
-    ) {
+      localEditContext: CoroutineContext? = null,
+    ): Deferred<Unit> = submit(listOf(message), coalescible, target, localEditContext)
+
+    fun submit(
+      messages: List<Message>,
+      coalescible: Boolean = true,
+      target: EditorBringIntoViewTarget? = EditorBringIntoViewTarget.CurrentSelectionHead,
+      localEditContext: CoroutineContext? = null,
+    ): Deferred<Unit> {
       val binding =
         KeyBinding(
           key = ComposeKey.DirectionRight,
@@ -64,8 +86,12 @@ class EditorKeyBindingCoalescerTest {
           coalescible = coalescible,
           action = { emptyList() },
         )
-      messagesByBinding[binding] = listOf(message)
-      coalescer.submit(binding, clipboard)
+      messagesByBinding[binding] = messages
+      return coalescer.submit(binding, clipboard, localEditContext)
+    }
+
+    fun cancel() {
+      scope.cancel()
     }
   }
 
@@ -74,10 +100,13 @@ class EditorKeyBindingCoalescerTest {
       NavigationOp.Move(Movement.Grapheme(Direction.Forward), extend = index % 2 == 0)
     )
 
-  private fun runCoalescerTest(block: suspend TestScope.(Harness) -> Unit) = runTest {
+  private fun runCoalescerTest(
+    onDispatch: suspend () -> Unit = {},
+    block: suspend TestScope.(Harness) -> Unit,
+  ) = runTest {
     val workerScope = CoroutineScope(coroutineContext + Job())
     try {
-      block(Harness(workerScope))
+      block(Harness(workerScope, onDispatch))
     } finally {
       workerScope.cancel()
     }
@@ -94,6 +123,33 @@ class EditorKeyBindingCoalescerTest {
       listOf(Dispatched(messages, EditorBringIntoViewTarget.CurrentSelectionHead)),
       harness.dispatched,
     )
+  }
+
+  @Test
+  fun `empty coalescible binding completes without dispatch`() = runCoalescerTest { harness ->
+    val completion = harness.submit(messages = emptyList())
+
+    testScheduler.runCurrent()
+
+    assertTrue(completion.isCompleted)
+    assertEquals(emptyList(), harness.dispatched)
+  }
+
+  @Test
+  fun `accepted local edit reaches dispatch across the worker coroutine`() {
+    val coordinator = EditorLocalEditCoordinator()
+    val localEdit = assertNotNull(coordinator.register())
+    val quiescence = coordinator.quiesce()
+    var dispatchedWithinLocalEdit = false
+
+    runCoalescerTest(onDispatch = { coordinator.run { dispatchedWithinLocalEdit = true } }) {
+      harness ->
+      harness.submit(moveMessage(1), localEditContext = localEdit).await()
+
+      assertTrue(dispatchedWithinLocalEdit)
+      localEdit.complete()
+      assertTrue(quiescence.await().isSuccess)
+    }
   }
 
   @Test
@@ -155,5 +211,59 @@ class EditorKeyBindingCoalescerTest {
         ),
         harness.dispatched,
       )
+    }
+
+  @Test
+  fun `dispatch failure does not strand bindings queued for the next batch`() =
+    runCoalescerTest { harness ->
+      val gate = CompletableDeferred<Unit>()
+      harness.dispatchGate = gate
+      harness.dispatchFailure = IllegalStateException("dispatch failed")
+
+      val failed = harness.submit(moveMessage(1))
+      testScheduler.runCurrent()
+      val queued = harness.submit(moveMessage(2))
+      testScheduler.runCurrent()
+
+      gate.complete(Unit)
+      testScheduler.advanceUntilIdle()
+
+      assertFailsWith<IllegalStateException> { failed.await() }
+      assertFalse(queued.isCancelled)
+      queued.await()
+    }
+
+  @Test
+  fun `dispatch cancellation does not stop the worker with another binding queued`() =
+    runCoalescerTest { harness ->
+      val gate = CompletableDeferred<Unit>()
+      harness.dispatchGate = gate
+      harness.dispatchFailure = CancellationException("dispatch cancelled")
+
+      val cancelled = harness.submit(moveMessage(1))
+      testScheduler.runCurrent()
+      val queued = harness.submit(moveMessage(2))
+      testScheduler.runCurrent()
+
+      gate.complete(Unit)
+      testScheduler.advanceUntilIdle()
+
+      assertTrue(cancelled.isCancelled)
+      assertTrue(queued.isCompleted)
+    }
+
+  @Test
+  fun `worker cancellation terminates active and queued submissions`() =
+    runCoalescerTest { harness ->
+      harness.dispatchGate = CompletableDeferred()
+      val active = harness.submit(moveMessage(1))
+      testScheduler.runCurrent()
+      val queued = harness.submit(moveMessage(2))
+
+      harness.cancel()
+      testScheduler.runCurrent()
+
+      assertTrue(active.isCancelled)
+      assertTrue(queued.isCancelled)
     }
 }


### PR DESCRIPTION
마지막 입력까지 로컬 DB에 확실히 저장하도록 추적하기 위한 선행 작업

- Editor transaction 호출 시 local edit을 동기적으로 등록하고, await / sync / queued enqueue 등이 실제로 commit되거나 실패할 때까지 추적
- 비동기 producer는 등록된 local edit context를 기존 coroutine scope나 queue에 전달하고, key binding coalescer는 batching을 유지하면서 각 작업의 완료와 실패를 전달
- 신규 local edit를 막은 뒤 이미 등록된 작업이 모두 끝날 때까지 기다리고, 실패 시 이를 호출자에게 전달할 수 있는 EditorLocalEditCoordinator 도입