### PR TITLE
layout/state 불일치 입력 디버그

### DIFF
--- a/crates/editor-core/src/dnd.rs
+++ b/crates/editor-core/src/dnd.rs
@@ -18,10 +18,10 @@ pub(crate) enum DndState {
 }
 
 impl DndState {
-    pub(crate) fn drop_target(&self) -> Option<DropTarget> {
+    pub(crate) fn drop_target(&self) -> Option<&DropTarget> {
         match self {
             Self::InternalDnd { drop_target, .. } | Self::ExternalDnd { drop_target, .. } => {
-                *drop_target
+                drop_target.as_ref()
             }
             _ => None,
         }

--- a/crates/editor-core/src/editor.rs
+++ b/crates/editor-core/src/editor.rs
@@ -9,6 +9,7 @@ use editor_resource::{CharacterCount, Resource, count_text};
 use editor_state::{
     LayoutDirty, Position, ResolvedPosition, ResolvedPositionFlatExt, Selection, StableSelection,
     State, closest_empty_paragraph_break_end_between, farther_endpoint, is_unit_node_selection,
+    remap_selection,
 };
 use editor_transaction::{Effect, HistoryMeta, MergeKind, StepError, Transaction};
 use editor_view::{GapPhantom, PageRect, PendingOverlay, View, Viewport};
@@ -626,7 +627,7 @@ impl Editor {
             self.state.projected_mut().commit();
         }
 
-        let layout_dirty = self.state.projected_mut().take_layout_dirty();
+        let layout_dirty = self.view.take_layout_dirty(&mut self.state);
 
         if !self.pending_ops.is_empty() {
             self.augment_font_state_from_ops(&layout_dirty);
@@ -1322,13 +1323,25 @@ impl Editor {
         }
     }
 
+    /// Rebinds the latest live selection by identity into the document snapshot
+    /// that produced the current layout.
+    pub(crate) fn layout_input_state(&self) -> Option<State> {
+        let mut state = self.view.layout_state()?.clone();
+        state.selection = self
+            .state
+            .selection
+            .and_then(|selection| remap_selection(selection, &self.state, &state));
+        Some(state)
+    }
+
     pub(crate) fn resolve_extend_movement(
         &mut self,
         selection: Selection,
         movement: &Movement,
+        state: &State,
     ) -> Option<Selection> {
         let target = self.resolve_movement(&selection.head, movement)?;
-        let doc = self.state.view();
+        let doc = state.view();
         let current_is_unit = is_unit_node_selection(&selection, &doc);
         let fixed = if current_is_unit {
             farther_endpoint(&doc, &target.head, &selection.anchor, &selection.head)
@@ -1853,7 +1866,8 @@ mod tests {
         PlainNodeEntry, PlainParagraphNode, PlainRootNode, PlainTextNode, SeqItem,
     };
     use editor_state::{
-        Affinity, PendingModifier, PendingModifiers, Position, Selection, StableResolveCtx, State,
+        Affinity, PendingModifier, PendingModifiers, Position, Selection, StablePosition,
+        StableResolveCtx, State,
     };
     use hashbrown::HashSet;
     use std::collections::BTreeMap;
@@ -3721,7 +3735,7 @@ mod tests {
             panic!("internal dnd should start from selected image");
         };
         *drop_target = Some(editor_view::DropTarget {
-            position: Position::new(p1, 3),
+            position: StablePosition::capture(&Position::new(p1, 3), &editor.state.view()),
             indicator: editor_view::DropIndicator::Inline {
                 page_idx: 0,
                 x: 0.0,
@@ -3789,7 +3803,10 @@ mod tests {
         editor.dnd = DndState::ExternalDnd {
             payload: ExternalDndPayloadKind::Text,
             drop_target: Some(editor_view::DropTarget {
-                position: Position::new(Dot::ROOT, 1),
+                position: StablePosition::capture(
+                    &Position::new(Dot::ROOT, 1),
+                    &editor.state.view(),
+                ),
                 indicator: editor_view::DropIndicator::Block {
                     page_idx: 0,
                     x: 0.0,
@@ -3848,7 +3865,10 @@ mod tests {
         editor.dnd = DndState::ExternalDnd {
             payload: ExternalDndPayloadKind::Text,
             drop_target: Some(editor_view::DropTarget {
-                position: Position::new(Dot::ROOT, 1),
+                position: StablePosition::capture(
+                    &Position::new(Dot::ROOT, 1),
+                    &editor.state.view(),
+                ),
                 indicator: editor_view::DropIndicator::Block {
                     page_idx: 0,
                     x: 0.0,
@@ -4307,9 +4327,7 @@ mod tests {
             .expect("cursor metrics")
             .caret;
 
-        let target = editor
-            .view
-            .drop_target_at(&editor.state, 0, caret.x, page_bottom - 1.0);
+        let target = editor.view.drop_target_at(0, caret.x, page_bottom - 1.0);
 
         assert!(
             target.is_some(),
@@ -4318,9 +4336,11 @@ mod tests {
             caret.height
         );
         if let Some(t) = target {
+            let view = editor.state.view();
+            let ctx = StableResolveCtx::from_live(&view, editor.state.projected.seq_checkout());
             assert_eq!(
-                t.position,
-                Position::new(Dot::ROOT, 2),
+                t.position.resolve(&ctx),
+                Some(Position::new(Dot::ROOT, 2)),
                 "drop target position must be (root, 2) - after paragraph"
             );
         }

--- a/crates/editor-core/src/handle/deletion.rs
+++ b/crates/editor-core/src/handle/deletion.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use editor_commands::{self as commands, CommandError, CommandResult};
 use editor_state::{
     Position, ResolvedPosition, ResolvedPositionFlatExt, Selection, flat_size, flat_text,
+    remap_selection,
 };
 use editor_transaction::Transaction;
 
@@ -58,7 +59,10 @@ pub fn handle_deletion_op(editor: &mut Editor, op: DeletionOp) -> Result<(), Edi
             })?;
         }
         DeletionOp::Move { movement } => {
-            let Some(selection) = editor.state().selection else {
+            let Some(input_state) = editor.layout_input_state() else {
+                return Ok(());
+            };
+            let Some(selection) = input_state.selection else {
                 return Ok(());
             };
             let head = selection.head;
@@ -70,6 +74,10 @@ pub fn handle_deletion_op(editor: &mut Editor, op: DeletionOp) -> Result<(), Edi
 
             if let Some(target) = target {
                 let selection = Selection::new(head, target.head);
+                let Some(selection) = remap_selection(selection, &input_state, &editor.state)
+                else {
+                    return Ok(());
+                };
                 editor.transact(|tr| {
                     commands::set_selection(tr, selection)?;
                     commands::delete_selection(tr)?;

--- a/crates/editor-core/src/handle/dnd.rs
+++ b/crates/editor-core/src/handle/dnd.rs
@@ -8,7 +8,8 @@ use editor_model::{
     ChildView, ContextExpr, DocView, Fragment, Node, NodeType, PlainFileNode, PlainImageNode,
     PlainNode, PlainRootNode, Schema,
 };
-use editor_state::{Position, Selection, StableResolveCtx, StableSelection};
+use editor_state::{Position, Selection, StableResolveCtx, StableSelection, State};
+use editor_view::DropTarget;
 
 #[derive(Debug, Clone, Copy)]
 enum SelectionAfterDrop {
@@ -17,7 +18,7 @@ enum SelectionAfterDrop {
 }
 
 pub fn handle_dnd_op(editor: &mut Editor, op: DndOp) -> Result<(), EditorError> {
-    let previous_drop_target = editor.dnd.drop_target();
+    let previous_drop_target = editor.dnd.drop_target().cloned();
     let result = match op {
         DndOp::StartInternalSelection => {
             let view = editor.state.view();
@@ -63,38 +64,41 @@ pub fn handle_dnd_op(editor: &mut Editor, op: DndOp) -> Result<(), EditorError> 
                 editor.dnd = DndState::Idle;
             }
 
-            let target = match editor.dnd.clone() {
-                DndState::InternalDnd { .. } => editor
-                    .view
-                    .drop_target_at(&editor.state, page, x, y)
-                    .filter(|target| {
-                        internal_source.as_ref().is_some_and(|source| {
+            let target = editor.view.drop_target_at(page, x, y);
+            let target = match (editor.dnd.clone(), target) {
+                (DndState::InternalDnd { .. }, Some(target)) => {
+                    let live_position = resolve_drop_position(&target, &editor.state);
+                    live_position.and_then(|live_position| {
+                        internal_source.as_ref().and_then(|source| {
                             let inside = {
                                 let view = editor.state.view();
-                                position_inside_selection(&view, target.position, source)
+                                position_inside_selection(&view, live_position, source)
                             };
-                            !inside
+                            (!inside
                                 && can_apply_drop(
                                     editor,
-                                    target.position,
+                                    live_position,
                                     DndDropPayload::InternalSelection,
                                     modifiers,
                                     Some(*source),
-                                )
+                                ))
+                            .then_some(target)
                         })
-                    }),
-                DndState::ExternalDnd { payload, .. } => editor
-                    .view
-                    .drop_target_at(&editor.state, page, x, y)
-                    .filter(|target| {
+                    })
+                }
+                (DndState::ExternalDnd { payload, .. }, Some(target)) => {
+                    let live_position = resolve_drop_position(&target, &editor.state);
+                    live_position.and_then(|live_position| {
                         can_apply_drop(
                             editor,
-                            target.position,
+                            live_position,
                             representative_external_payload(payload),
                             modifiers,
                             None,
                         )
-                    }),
+                        .then_some(target)
+                    })
+                }
                 _ => None,
             };
             editor.dnd.set_drop_target(target);
@@ -125,30 +129,34 @@ pub fn handle_dnd_op(editor: &mut Editor, op: DndOp) -> Result<(), EditorError> 
             let target = if accepts_payload {
                 match (&payload, internal_source.as_ref()) {
                     (DndDropPayload::InternalSelection, Some(source)) => {
-                        editor.dnd.drop_target().filter(|target| {
+                        editor.dnd.drop_target().cloned().and_then(|target| {
+                            let position = resolve_drop_position(&target, &editor.state)?;
                             let inside = {
                                 let view = editor.state.view();
-                                position_inside_selection(&view, target.position, source)
+                                position_inside_selection(&view, position, source)
                             };
-                            !inside
+                            (!inside
                                 && can_apply_drop(
                                     editor,
-                                    target.position,
+                                    position,
                                     DndDropPayload::InternalSelection,
                                     modifiers,
                                     Some(*source),
-                                )
+                                ))
+                            .then_some(position)
                         })
                     }
-                    _ => editor.dnd.drop_target().filter(|target| {
-                        can_apply_drop(editor, target.position, payload.clone(), modifiers, None)
+                    _ => editor.dnd.drop_target().cloned().and_then(|target| {
+                        let position = resolve_drop_position(&target, &editor.state)?;
+                        can_apply_drop(editor, position, payload.clone(), modifiers, None)
+                            .then_some(position)
                     }),
                 }
             } else {
                 None
             };
-            let result = if let Some(target) = target {
-                apply_drop(editor, target.position, payload, modifiers, internal_source)
+            let result = if let Some(position) = target {
+                apply_drop(editor, position, payload, modifiers, internal_source)
             } else {
                 Ok(())
             };
@@ -172,10 +180,16 @@ pub fn handle_dnd_op(editor: &mut Editor, op: DndOp) -> Result<(), EditorError> 
             Ok(())
         }
     };
-    if editor.dnd.drop_target() != previous_drop_target {
+    if editor.dnd.drop_target() != previous_drop_target.as_ref() {
         editor.invalidate_render();
     }
     result
+}
+
+fn resolve_drop_position(target: &DropTarget, state: &State) -> Option<Position> {
+    let view = state.view();
+    let ctx = StableResolveCtx::from_live(&view, state.projected.seq_checkout());
+    target.position.resolve(&ctx)
 }
 
 fn position_inside_selection(view: &DocView, position: Position, selection: &Selection) -> bool {

--- a/crates/editor-core/src/handle/navigation.rs
+++ b/crates/editor-core/src/handle/navigation.rs
@@ -3,7 +3,7 @@ use editor_model::{ChildView, DocView, Schema};
 use editor_state::{
     Affinity, GapCursor, Position, Selection, as_gap_cursor, cell_rect_selection,
     enclosing_table_cell, first_cursor_position, gap_cursor_selection_at, is_unit_node_selection,
-    last_cursor_position,
+    last_cursor_position, remap_selection,
 };
 use editor_transaction::HistoryMeta;
 
@@ -15,7 +15,10 @@ use crate::message::*;
 pub fn handle_navigation_op(editor: &mut Editor, op: NavigationOp) -> Result<(), EditorError> {
     match op {
         NavigationOp::Move { movement, extend } => {
-            let Some(selection) = editor.state.selection else {
+            let Some(input_state) = editor.layout_input_state() else {
+                return Ok(());
+            };
+            let Some(selection) = input_state.selection else {
                 if !extend && let Movement::Document { .. } = movement {
                     let probe_pos = Position {
                         node: Dot::ROOT,
@@ -23,14 +26,7 @@ pub fn handle_navigation_op(editor: &mut Editor, op: NavigationOp) -> Result<(),
                         affinity: Affinity::Upstream,
                     };
                     if let Some(target) = editor.resolve_movement(&probe_pos, &movement) {
-                        editor.transact(|tr| {
-                            tr.update_meta(|meta| meta.history = HistoryMeta::Skip);
-                            if tr.selection() != Some(target) {
-                                tr.clear_pending_format()?;
-                            }
-                            tr.set_selection(Some(target))?;
-                            Ok(())
-                        })?;
+                        set_navigation_selection(editor, &input_state, target)?;
                     }
                 }
                 return Ok(());
@@ -71,7 +67,7 @@ pub fn handle_navigation_op(editor: &mut Editor, op: NavigationOp) -> Result<(),
 
             if is_upward_exit && selection.is_collapsed() {
                 let leading_gap = {
-                    let view = editor.state.view();
+                    let view = input_state.view();
                     selection
                         .resolve(&view)
                         .and_then(|rs| as_gap_cursor(&rs))
@@ -87,7 +83,7 @@ pub fn handle_navigation_op(editor: &mut Editor, op: NavigationOp) -> Result<(),
                     Some(is_leading) => is_leading,
                     None => {
                         let resource = editor.resource.lock().unwrap();
-                        gap_cursor_selection_at(Dot::ROOT, 0, &editor.state.view()).is_none()
+                        gap_cursor_selection_at(Dot::ROOT, 0, &input_state.view()).is_none()
                             && editor
                                 .view
                                 .would_resolve_movement(
@@ -122,7 +118,7 @@ pub fn handle_navigation_op(editor: &mut Editor, op: NavigationOp) -> Result<(),
             if !extend {
                 // Exit: the current selection is itself a gap cursor.
                 let gap_exit = {
-                    let view = editor.state.view();
+                    let view = input_state.view();
                     match selection.resolve(&view).and_then(|rs| as_gap_cursor(&rs)) {
                         None => None,
                         Some(GapCursor::BetweenMonolithic {
@@ -188,14 +184,7 @@ pub fn handle_navigation_op(editor: &mut Editor, op: NavigationOp) -> Result<(),
                 };
                 if let Some(exit) = gap_exit {
                     if let Some(sel) = exit {
-                        editor.transact(|tr| {
-                            tr.update_meta(|meta| meta.history = HistoryMeta::Skip);
-                            if tr.selection() != Some(sel) {
-                                tr.clear_pending_format()?;
-                            }
-                            tr.set_selection(Some(sel))?;
-                            Ok(())
-                        })?;
+                        set_navigation_selection(editor, &input_state, sel)?;
                     }
                     return Ok(());
                 }
@@ -207,23 +196,16 @@ pub fn handle_navigation_op(editor: &mut Editor, op: NavigationOp) -> Result<(),
                 // paragraph-admittable checks), so a non-gap move falls
                 // through to the range endpoint policy below. Independent of
                 // resolve_movement's result.
-                if is_unit_node_selection(&selection, &editor.state.view()) {
+                if is_unit_node_selection(&selection, &input_state.view()) {
                     let parent = selection.anchor.node;
                     let idx = selection.anchor.offset.min(selection.head.offset);
                     let entry = if backward {
-                        gap_cursor_selection_at(parent, idx, &editor.state.view())
+                        gap_cursor_selection_at(parent, idx, &input_state.view())
                     } else {
-                        gap_cursor_selection_at(parent, idx + 1, &editor.state.view())
+                        gap_cursor_selection_at(parent, idx + 1, &input_state.view())
                     };
                     if let Some(sel) = entry {
-                        editor.transact(|tr| {
-                            tr.update_meta(|meta| meta.history = HistoryMeta::Skip);
-                            if tr.selection() != Some(sel) {
-                                tr.clear_pending_format()?;
-                            }
-                            tr.set_selection(Some(sel))?;
-                            Ok(())
-                        })?;
+                        set_navigation_selection(editor, &input_state, sel)?;
                         return Ok(());
                     }
                 }
@@ -240,7 +222,7 @@ pub fn handle_navigation_op(editor: &mut Editor, op: NavigationOp) -> Result<(),
                 // movement base: backward starts from `from`, forward starts
                 // from `to`.
                 if !selection.is_collapsed() {
-                    let view = editor.state.view();
+                    let view = input_state.view();
                     let Some(resolved) = selection.resolve(&view) else {
                         return Ok(());
                     };
@@ -299,8 +281,13 @@ pub fn handle_navigation_op(editor: &mut Editor, op: NavigationOp) -> Result<(),
                         Selection::collapsed(base_position)
                     } else if !left_or_right
                         && can_stop_at_gap
-                        && let Some(sel) =
-                            gap_cursor_from_inner_edge(editor, base_position, backward, &movement)
+                        && let Some(sel) = gap_cursor_from_inner_edge(
+                            editor,
+                            &input_state,
+                            base_position,
+                            backward,
+                            &movement,
+                        )
                     {
                         // Vertical/word/block movement can stop at an adjacent
                         // gap before asking the view for geometric movement.
@@ -313,19 +300,12 @@ pub fn handle_navigation_op(editor: &mut Editor, op: NavigationOp) -> Result<(),
 
                         view_target.unwrap_or_else(|| {
                             let collapsed = Selection::collapsed(base_position);
-                            let view = editor.state.view();
+                            let view = input_state.view();
                             collapsed.normalize(&view).unwrap_or(collapsed)
                         })
                     };
 
-                    editor.transact(|tr| {
-                        tr.update_meta(|meta| meta.history = HistoryMeta::Skip);
-                        if tr.selection() != Some(target) {
-                            tr.clear_pending_format()?;
-                        }
-                        tr.set_selection(Some(target))?;
-                        Ok(())
-                    })?;
+                    set_navigation_selection(editor, &input_state, target)?;
                     return Ok(());
                 }
 
@@ -344,20 +324,18 @@ pub fn handle_navigation_op(editor: &mut Editor, op: NavigationOp) -> Result<(),
                 // Ancestors are innermost-first, so one keypress crosses
                 // exactly one boundary.
                 if can_stop_at_gap
-                    && let Some(sel) =
-                        gap_cursor_from_inner_edge(editor, selection.head, backward, &movement)
+                    && let Some(sel) = gap_cursor_from_inner_edge(
+                        editor,
+                        &input_state,
+                        selection.head,
+                        backward,
+                        &movement,
+                    )
                 {
                     if matches!(movement, Movement::Line { .. }) {
                         editor.ensure_preferred_x_at(&selection.head);
                     }
-                    editor.transact(|tr| {
-                        tr.update_meta(|meta| meta.history = HistoryMeta::Skip);
-                        if tr.selection() != Some(sel) {
-                            tr.clear_pending_format()?;
-                        }
-                        tr.set_selection(Some(sel))?;
-                        Ok(())
-                    })?;
+                    set_navigation_selection(editor, &input_state, sel)?;
                     return Ok(());
                 }
             }
@@ -373,7 +351,7 @@ pub fn handle_navigation_op(editor: &mut Editor, op: NavigationOp) -> Result<(),
                 );
                 if is_cell_movement {
                     let new_sel = {
-                        let view = editor.state.view();
+                        let view = input_state.view();
                         selection
                             .resolve(&view)
                             .and_then(|rs| rs.as_cell_rect())
@@ -388,21 +366,14 @@ pub fn handle_navigation_op(editor: &mut Editor, op: NavigationOp) -> Result<(),
                             })
                     };
                     if let Some(new_sel) = new_sel {
-                        editor.transact(|tr| {
-                            tr.update_meta(|meta| meta.history = HistoryMeta::Skip);
-                            if tr.selection() != Some(new_sel) {
-                                tr.clear_pending_format()?;
-                            }
-                            tr.set_selection(Some(new_sel))?;
-                            Ok(())
-                        })?;
+                        set_navigation_selection(editor, &input_state, new_sel)?;
                         return Ok(());
                     }
                 }
             }
 
             let new_selection = if extend {
-                editor.resolve_extend_movement(selection, &movement)
+                editor.resolve_extend_movement(selection, &movement, &input_state)
             } else {
                 editor.resolve_movement(&selection.head, &movement)
             };
@@ -419,47 +390,47 @@ pub fn handle_navigation_op(editor: &mut Editor, op: NavigationOp) -> Result<(),
                     );
                     if is_cell_movement {
                         let current_cell =
-                            enclosing_table_cell(&editor.state.view(), selection.head.node);
+                            enclosing_table_cell(&input_state.view(), selection.head.node);
                         if let Some(current_cell) = current_cell {
                             let stays_in_cell =
-                                enclosing_table_cell(&editor.state.view(), new_selection.head.node)
+                                enclosing_table_cell(&input_state.view(), new_selection.head.node)
                                     == Some(current_cell);
                             let cell_sel = if !stays_in_cell {
-                                cell_rect_selection(
-                                    current_cell,
-                                    current_cell,
-                                    &editor.state.view(),
-                                )
+                                cell_rect_selection(current_cell, current_cell, &input_state.view())
                             } else {
                                 None
                             };
                             if let Some(cell_sel) = cell_sel {
-                                editor.transact(|tr| {
-                                    tr.update_meta(|meta| meta.history = HistoryMeta::Skip);
-                                    if tr.selection() != Some(cell_sel) {
-                                        tr.clear_pending_format()?;
-                                    }
-                                    tr.set_selection(Some(cell_sel))?;
-                                    Ok(())
-                                })?;
+                                set_navigation_selection(editor, &input_state, cell_sel)?;
                                 return Ok(());
                             }
                         }
                     }
                 }
 
-                editor.transact(|tr| {
-                    tr.update_meta(|meta| meta.history = HistoryMeta::Skip);
-                    if tr.selection() != Some(new_selection) {
-                        tr.clear_pending_format()?;
-                    }
-                    tr.set_selection(Some(new_selection))?;
-                    Ok(())
-                })?;
+                set_navigation_selection(editor, &input_state, new_selection)?;
             }
         }
     }
     Ok(())
+}
+
+fn set_navigation_selection(
+    editor: &mut Editor,
+    input_state: &editor_state::State,
+    selection: Selection,
+) -> Result<(), EditorError> {
+    let Some(selection) = remap_selection(selection, input_state, &editor.state) else {
+        return Ok(());
+    };
+    editor.transact(|tr| {
+        tr.update_meta(|meta| meta.history = HistoryMeta::Skip);
+        if tr.selection() != Some(selection) {
+            tr.clear_pending_format()?;
+        }
+        tr.set_selection(Some(selection))?;
+        Ok(())
+    })
 }
 
 fn child_view_dot(child: &ChildView) -> Dot {
@@ -471,11 +442,12 @@ fn child_view_dot(child: &ChildView) -> Dot {
 
 fn gap_cursor_from_inner_edge(
     editor: &Editor,
+    state: &editor_state::State,
     head: Position,
     backward: bool,
     movement: &Movement,
 ) -> Option<Selection> {
-    let doc = editor.state.view();
+    let doc = state.view();
     let start = doc.node(head.node)?;
     let vertical = matches!(movement, Movement::Line { .. });
     for monolithic in start.ancestors() {
@@ -3547,11 +3519,13 @@ mod tests {
                 },
             );
             eprintln!("TEST5 resolve_movement((r,1),back) = {tgt:?}");
+            let input_state = editor.state.clone();
             let ext = editor.resolve_extend_movement(
                 editor.state().selection.unwrap(),
                 &Movement::Grapheme {
                     direction: Direction::Backward,
                 },
+                &input_state,
             );
             eprintln!("TEST5 resolve_extend_movement(L1sel,back) = {ext:?}");
         }

--- a/crates/editor-core/src/handle/remote.rs
+++ b/crates/editor-core/src/handle/remote.rs
@@ -247,6 +247,7 @@ mod tests {
             changeset: cs.clone(),
         });
         let after_first = editor.state().selection;
+        let projected_after_first = std::sync::Arc::as_ptr(&editor.state().projected);
         let view = editor.state().view();
         let text_first = editor_state::flat_text(&view, 0..editor_state::flat_size(&view));
 
@@ -271,6 +272,11 @@ mod tests {
             after_first,
             editor.state().selection,
             "duplicate receive must leave the selection unchanged"
+        );
+        assert_eq!(
+            projected_after_first,
+            std::sync::Arc::as_ptr(&editor.state().projected),
+            "duplicate receive must preserve the projected document allocation"
         );
     }
 

--- a/crates/editor-core/src/handle/selection.rs
+++ b/crates/editor-core/src/handle/selection.rs
@@ -3,7 +3,7 @@ use editor_crdt::Dot;
 use editor_model::DocView;
 use editor_state::{
     Position, ResolvedPosition, ResolvedPositionFlatExt, Selection, StableResolveCtx,
-    cell_rect_selection, enclosing_table, enclosing_table_cell,
+    cell_rect_selection, enclosing_table, enclosing_table_cell, remap_selection,
     resolve_paragraph_selection_expansion, resolve_sentence_selection_expansion,
     resolve_word_selection_expansion, table_cell_ids,
 };
@@ -53,7 +53,10 @@ pub fn handle_selection_op(editor: &mut Editor, op: SelectionOp) -> Result<(), E
             Ok(())
         }),
         SelectionOp::SetAt { page, x, y } => {
-            let selection = editor.view.hit_test(page, x, y);
+            let selection = editor
+                .view
+                .hit_test(page, x, y)
+                .and_then(|selection| remap_layout_selection(editor, selection));
             editor.transact(|tr| {
                 tr.update_meta(|m| m.history = HistoryMeta::Skip);
                 if let Some(selection) = selection {
@@ -158,6 +161,11 @@ pub fn handle_selection_op(editor: &mut Editor, op: SelectionOp) -> Result<(), E
     }
 }
 
+fn remap_layout_selection(editor: &Editor, selection: Selection) -> Option<Selection> {
+    let layout_state = editor.view.layout_state()?;
+    remap_selection(selection, layout_state, &editor.state)
+}
+
 fn resolve_select_unit_at_selection(
     editor: &Editor,
     page: usize,
@@ -165,26 +173,23 @@ fn resolve_select_unit_at_selection(
     y: f32,
     unit: SelectionPointUnit,
 ) -> Option<Selection> {
+    let layout_state = editor.view.layout_state()?;
+    let layout_view = layout_state.view();
     let hit = editor.view.hit_test(page, x, y)?;
-    match unit {
+    let selection = match unit {
         SelectionPointUnit::Word => {
             let resource = editor.resource.lock().unwrap();
-            Some(
-                resolve_word_selection_expansion(&hit, &editor.state.view(), &resource)
-                    .unwrap_or(hit),
-            )
+            resolve_word_selection_expansion(&hit, &layout_view, &resource).unwrap_or(hit)
         }
         SelectionPointUnit::Sentence => {
             let resource = editor.resource.lock().unwrap();
-            Some(
-                resolve_sentence_selection_expansion(&hit, &editor.state.view(), &resource)
-                    .unwrap_or(hit),
-            )
+            resolve_sentence_selection_expansion(&hit, &layout_view, &resource).unwrap_or(hit)
         }
         SelectionPointUnit::Paragraph => {
-            Some(resolve_paragraph_selection_expansion(&hit, &editor.state.view()).unwrap_or(hit))
+            resolve_paragraph_selection_expansion(&hit, &layout_view).unwrap_or(hit)
         }
-    }
+    };
+    remap_layout_selection(editor, selection)
 }
 
 fn resolve_extend_to_selection(
@@ -196,7 +201,8 @@ fn resolve_extend_to_selection(
     base_selection: Option<Selection>,
     allow_collapse: bool,
 ) -> Option<Selection> {
-    let view = editor.state().view();
+    let input_state = editor.layout_input_state()?;
+    let view = input_state.view();
     let base_cell_rect_anchor = base_selection
         .as_ref()
         .and_then(|selection| selection.resolve(&view))
@@ -218,8 +224,7 @@ fn resolve_extend_to_selection(
                 .nearest_node_box(head_page, head_x, head_y, &cells)
             {
                 let is_cell_mode = started_from_cell_rect
-                    || editor
-                        .state
+                    || input_state
                         .selection
                         .as_ref()
                         .and_then(|selection| selection.resolve(&view))
@@ -227,7 +232,7 @@ fn resolve_extend_to_selection(
                 let is_same_cell_content_hit = if head_cell == anchor_cell && !is_cell_mode {
                     editor
                         .view
-                        .hit_test_extending(editor.state(), &anchor, head_page, head_x, head_y)
+                        .hit_test_extending(&input_state, &anchor, head_page, head_x, head_y)
                         .is_some_and(|hit| {
                             hit.source == ExtendingHitSource::Exact
                                 && selection_endpoints_inside_cell(
@@ -242,7 +247,7 @@ fn resolve_extend_to_selection(
                 if (head_cell != anchor_cell || is_cell_mode || !is_same_cell_content_hit)
                     && let Some(selection) = cell_rect_selection(anchor_cell, head_cell, &view)
                 {
-                    return Some(selection);
+                    return remap_layout_selection(editor, selection);
                 }
             }
         }
@@ -252,7 +257,7 @@ fn resolve_extend_to_selection(
     let head_hit =
         editor
             .view
-            .hit_test_extending(editor.state(), &anchor, head_page, head_x, head_y)?;
+            .hit_test_extending(&input_state, &anchor, head_page, head_x, head_y)?;
 
     let selection = if let Some(base_selection) = base_selection {
         extend_base_selection(&view, base_selection, head_hit.selection)?
@@ -261,7 +266,9 @@ fn resolve_extend_to_selection(
     };
     let selection = selection.normalize(&view).unwrap_or(selection);
 
-    (allow_collapse || !selection.is_collapsed()).then_some(selection)
+    (allow_collapse || !selection.is_collapsed())
+        .then_some(selection)
+        .and_then(|selection| remap_layout_selection(editor, selection))
 }
 
 fn selection_endpoints_inside_cell(view: &DocView, selection: &Selection, cell: Dot) -> bool {

--- a/crates/editor-core/src/tests/layout_state_input.rs
+++ b/crates/editor-core/src/tests/layout_state_input.rs
@@ -1,0 +1,289 @@
+use std::sync::Arc;
+
+use editor_common::{Direction, Movement};
+use editor_crdt::{Changeset, Dot, ListOp};
+use editor_macros::state;
+use editor_model::{ChildView, EditOp, NodeType, SeqItem};
+use editor_state::{Affinity, Position, Selection, State};
+use hashbrown::HashSet;
+
+use crate::editor::Editor;
+use crate::message::*;
+
+fn insert_root_paragraph_before_first_child(base: &State) -> Changeset<EditOp> {
+    let mut projected = base.projected.as_ref().clone();
+    let baseline: HashSet<Dot> = projected.graph().current_heads().copied().collect();
+    projected
+        .apply_batch(vec![EditOp::Seq(ListOp::Ins {
+            pos: 0,
+            item: SeqItem::Block {
+                node_type: NodeType::Paragraph,
+                parents: vec![Dot::ROOT],
+                attrs: vec![],
+            },
+        })])
+        .unwrap();
+    projected.commit();
+    projected
+        .graph()
+        .local_changesets_since(&baseline)
+        .unwrap()
+        .remove(0)
+}
+
+#[test]
+fn empty_and_selection_only_ticks_do_not_clone_the_projected_document() {
+    let (initial, p1) = state! {
+        doc { root { p1: paragraph { text("ab") } } }
+        selection: (p1, 0)
+    };
+    let mut editor = Editor::new_test(initial);
+    let projected = Arc::as_ptr(&editor.state.projected);
+
+    editor.tick().unwrap();
+    assert_eq!(Arc::as_ptr(&editor.state.projected), projected);
+
+    editor.enqueue(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::collapsed(Position::new(p1, 1)),
+        },
+    });
+    editor.tick().unwrap();
+    assert_eq!(Arc::as_ptr(&editor.state.projected), projected);
+}
+
+#[test]
+fn set_at_same_tick_as_remote_structure_selects_visible_atom_identity() {
+    let (initial, image, ..) = state! {
+        doc { root { image: image p1: paragraph { text("b") } } }
+        selection: none
+    };
+    let mut editor = Editor::new_test(initial.clone());
+    let external = editor
+        .view
+        .external_elements(&editor.state, None)
+        .into_iter()
+        .find(|element| element.node == image)
+        .expect("image must be laid out");
+
+    editor.enqueue(Message::Remote {
+        changeset: insert_root_paragraph_before_first_child(&initial),
+    });
+    editor.enqueue(Message::Selection {
+        op: SelectionOp::SetAt {
+            page: external.page_idx,
+            x: external.bounds.x + external.bounds.width / 2.0,
+            y: external.bounds.y + external.bounds.height / 2.0,
+        },
+    });
+    editor.tick().unwrap();
+
+    let selection = editor.state.selection.expect("tap must select the image");
+    assert_eq!(selection.anchor.node, Dot::ROOT);
+    assert_eq!((selection.anchor.offset, selection.head.offset), (1, 2));
+    assert!(matches!(
+        editor.state.view().root().unwrap().child_at(1),
+        Some(ChildView::Leaf(leaf)) if leaf.dot() == image
+    ));
+}
+
+#[test]
+fn select_unit_at_same_tick_as_remote_structure_selects_visible_atom_identity() {
+    let (initial, image, ..) = state! {
+        doc { root { image: image p1: paragraph { text("b") } } }
+        selection: none
+    };
+    let mut editor = Editor::new_test(initial.clone());
+    let external = editor
+        .view
+        .external_elements(&editor.state, None)
+        .into_iter()
+        .find(|element| element.node == image)
+        .expect("image must be laid out");
+
+    editor.enqueue(Message::Remote {
+        changeset: insert_root_paragraph_before_first_child(&initial),
+    });
+    editor.enqueue(Message::Selection {
+        op: SelectionOp::SelectUnitAt {
+            page: external.page_idx,
+            x: external.bounds.x + external.bounds.width / 2.0,
+            y: external.bounds.y + external.bounds.height / 2.0,
+            unit: SelectionPointUnit::Word,
+        },
+    });
+    editor.tick().unwrap();
+
+    let selection = editor.state.selection.expect("tap must select the image");
+    assert_eq!((selection.anchor.offset, selection.head.offset), (1, 2));
+}
+
+#[test]
+fn extend_to_same_tick_as_remote_structure_tracks_visible_atom_identity() {
+    let (initial, image, p1, ..) = state! {
+        doc { root { image: image p1: paragraph { text("b") } } }
+        selection: (p1, 0)
+    };
+    let layout_editor = Editor::new_test(initial.clone());
+    let external = layout_editor
+        .view
+        .external_elements(&layout_editor.state, None)
+        .into_iter()
+        .find(|element| element.node == image)
+        .expect("image must be laid out");
+
+    let mut editor = Editor::new_test(initial.clone());
+    editor.enqueue(Message::Remote {
+        changeset: insert_root_paragraph_before_first_child(&initial),
+    });
+    editor.enqueue(Message::Selection {
+        op: SelectionOp::ExtendTo {
+            anchor: Position::new(p1, 0),
+            head_page: external.page_idx,
+            head_x: external.bounds.x + external.bounds.width / 2.0,
+            head_y: external.bounds.y + external.bounds.height / 2.0,
+            base_selection: None,
+            allow_collapse: true,
+        },
+    });
+    editor.tick().unwrap();
+
+    assert_eq!(
+        editor.state.selection,
+        Some(Selection::new(
+            Position {
+                node: p1,
+                offset: 0,
+                affinity: Affinity::Upstream,
+            },
+            Position {
+                node: Dot::ROOT,
+                offset: 1,
+                affinity: Affinity::Downstream,
+            },
+        ))
+    );
+}
+
+#[test]
+fn dnd_drop_same_tick_as_remote_structure_uses_visible_atom_boundary() {
+    let (initial, image, ..) = state! {
+        doc { root { image: image p1: paragraph { text("b") } } }
+        selection: none
+    };
+    let mut editor = Editor::new_test(initial.clone());
+    let external = editor
+        .view
+        .external_elements(&editor.state, None)
+        .into_iter()
+        .find(|element| element.node == image)
+        .expect("image must be laid out");
+
+    editor.enqueue(Message::Dnd {
+        op: DndOp::EnterExternal {
+            payload: ExternalDndPayloadKind::Text,
+        },
+    });
+    editor.enqueue(Message::Remote {
+        changeset: insert_root_paragraph_before_first_child(&initial),
+    });
+    editor.enqueue(Message::Dnd {
+        op: DndOp::Over {
+            page: external.page_idx,
+            x: external.bounds.x + external.bounds.width / 2.0,
+            y: external.bounds.y + external.bounds.height / 2.0,
+            modifiers: InputModifiers::default(),
+        },
+    });
+    editor.enqueue(Message::Dnd {
+        op: DndOp::Drop {
+            page: external.page_idx,
+            x: external.bounds.x + external.bounds.width / 2.0,
+            y: external.bounds.y + external.bounds.height / 2.0,
+            payload: DndDropPayload::Text {
+                text: "X".into(),
+                html: None,
+            },
+            modifiers: InputModifiers::default(),
+        },
+    });
+    editor.tick().unwrap();
+
+    let view = editor.state.view();
+    let root = view.root().unwrap();
+    let image_index = root
+        .children()
+        .position(|child| matches!(child, ChildView::Leaf(leaf) if leaf.dot() == image));
+    assert_eq!(
+        image_index,
+        Some(1),
+        "drop must stay after the visible image"
+    );
+    assert!(
+        matches!(root.child_at(2), Some(ChildView::Block(block)) if block.inline_text() == "X")
+    );
+}
+
+#[test]
+fn navigation_same_tick_as_remote_structure_moves_from_visible_selection() {
+    let (initial, ..) = state! {
+        doc { root: root { image p1: paragraph { text("b") } } }
+        selection: (root, 0, >) -> (root, 1, <)
+    };
+    let change = insert_root_paragraph_before_first_child(&initial);
+    let movement = Movement::Grapheme {
+        direction: Direction::Forward,
+    };
+
+    let mut coalesced = Editor::new_test(initial.clone());
+    coalesced.enqueue(Message::Remote {
+        changeset: change.clone(),
+    });
+    coalesced.enqueue(Message::Navigation {
+        op: NavigationOp::Move {
+            movement,
+            extend: false,
+        },
+    });
+    coalesced.tick().unwrap();
+
+    let mut sequential = Editor::new_test(initial);
+    sequential.apply(Message::Remote { changeset: change });
+    sequential.apply(Message::Navigation {
+        op: NavigationOp::Move {
+            movement,
+            extend: false,
+        },
+    });
+
+    assert_eq!(coalesced.state.selection, sequential.state.selection);
+}
+
+#[test]
+fn deletion_move_same_tick_as_remote_structure_uses_visible_selection() {
+    let (initial, ..) = state! {
+        doc { root: root { image p1: paragraph { text("b") } } }
+        selection: (root, 0, >) -> (root, 1, <)
+    };
+    let change = insert_root_paragraph_before_first_child(&initial);
+    let movement = Movement::Word {
+        direction: Direction::Forward,
+    };
+
+    let mut coalesced = Editor::new_test(initial.clone());
+    coalesced.enqueue(Message::Remote {
+        changeset: change.clone(),
+    });
+    coalesced.enqueue(Message::Deletion {
+        op: DeletionOp::Move { movement },
+    });
+    coalesced.tick().unwrap();
+
+    let mut sequential = Editor::new_test(initial);
+    sequential.apply(Message::Remote { changeset: change });
+    sequential.apply(Message::Deletion {
+        op: DeletionOp::Move { movement },
+    });
+
+    editor_state::assert_state_eq!(coalesced.state(), sequential.state());
+}

--- a/crates/editor-core/src/tests/mod.rs
+++ b/crates/editor-core/src/tests/mod.rs
@@ -1,5 +1,6 @@
 mod alias_e2e;
 mod can_invariants;
+mod layout_state_input;
 mod perf_modifier;
 mod perf_tracked_resolve;
 mod set_doc;

--- a/crates/editor-state/src/apply.rs
+++ b/crates/editor-state/src/apply.rs
@@ -108,6 +108,9 @@ impl State {
         css: Vec<Changeset<EditOp>>,
     ) -> Result<(Self, Vec<Op<EditOp>>), StateError> {
         let (next_projected, applied) = self.projected.receive_changesets(css)?;
+        if applied.is_empty() {
+            return Ok((self.clone(), applied));
+        }
         let mut next = self.clone();
         next.projected = Arc::new(next_projected);
         Ok((next, applied))

--- a/crates/editor-state/src/lib.rs
+++ b/crates/editor-state/src/lib.rs
@@ -77,7 +77,7 @@ pub use selection_expansion::{
     resolve_word_selection_expansion,
 };
 pub use stable_position::{StablePosition, StablePositionChild, StableResolveCtx};
-pub use stable_selection::StableSelection;
+pub use stable_selection::{StableSelection, remap_selection};
 pub use state::*;
 pub use to_plain::to_plain;
 pub use traversal::{

--- a/crates/editor-state/src/stable_selection.rs
+++ b/crates/editor-state/src/stable_selection.rs
@@ -1,9 +1,12 @@
+use std::sync::Arc;
+
 use editor_macros::ffi;
 use editor_model::DocView;
 use serde::{Deserialize, Serialize};
 
 use crate::selection::Selection;
 use crate::stable_position::{StablePosition, StableResolveCtx};
+use crate::state::State;
 
 #[ffi]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -45,6 +48,27 @@ impl StableSelection {
     }
 }
 
+/// Remaps a selection that resolves in `source` into `target` by stable identity.
+///
+/// `selection` must resolve in `source`; debug builds assert this precondition.
+/// `None` means the captured selection could not resolve in `target`.
+pub fn remap_selection(selection: Selection, source: &State, target: &State) -> Option<Selection> {
+    debug_assert!(
+        {
+            let source_view = source.view();
+            selection.resolve(&source_view).is_some()
+        },
+        "remap_selection source selection must resolve"
+    );
+    if Arc::ptr_eq(&source.projected, &target.projected) {
+        return Some(selection);
+    }
+    let stable = StableSelection::capture(&selection, &source.view());
+    let target_view = target.view();
+    let ctx = StableResolveCtx::from_live(&target_view, target.projected.seq_checkout());
+    stable.resolve(&ctx)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -55,6 +79,17 @@ mod tests {
     };
 
     use crate::Position;
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "remap_selection source selection must resolve")]
+    fn remap_selection_requires_a_valid_source() {
+        let source = State::empty();
+        let target = source.clone();
+        let selection = Selection::collapsed(Position::new(Dot::new(9, 9), 0));
+
+        let _ = remap_selection(selection, &source, &target);
+    }
 
     fn block(node_type: NodeType, parents: Vec<Dot>) -> SeqItem {
         SeqItem::Block {

--- a/crates/editor-view/src/dnd.rs
+++ b/crates/editor-view/src/dnd.rs
@@ -1,5 +1,5 @@
 use editor_common::Rect;
-use editor_state::Position;
+use editor_state::StablePosition;
 
 use crate::PageRect;
 
@@ -38,9 +38,9 @@ impl DropIndicator {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct DropTarget {
-    pub position: Position,
+    pub position: StablePosition,
     pub indicator: DropIndicator,
 }
 

--- a/crates/editor-view/src/query/dnd.rs
+++ b/crates/editor-view/src/query/dnd.rs
@@ -4,9 +4,9 @@ use editor_model::{DocView, Node};
 use editor_state::Position;
 
 use super::layout_index::{LayoutEntry, LayoutIndex, LayoutPoint};
+use crate::DropIndicator;
 use crate::paginate::types::{LayoutContent, LayoutLine, SpacingKind};
 use crate::style::Direction;
-use crate::{DropIndicator, DropTarget};
 
 pub(crate) fn drop_target_at(
     layout_index: &LayoutIndex,
@@ -14,16 +14,13 @@ pub(crate) fn drop_target_at(
     page_idx: usize,
     x: f32,
     page_y: f32,
-) -> Option<DropTarget> {
+) -> Option<(Position, DropIndicator)> {
     let point = layout_index.point(page_idx, x, page_y)?;
     let position = dnd_position(layout_index, view, point)?;
     let position =
         promote_outer_edge_drop_position(layout_index, view, position).unwrap_or(position);
     let indicator = drop_indicator_from_position(layout_index, view, position)?;
-    Some(DropTarget {
-        position,
-        indicator,
-    })
+    Some((position, indicator))
 }
 
 fn dnd_position(
@@ -492,16 +489,16 @@ mod tests {
         let test_x = line_rect.x + line_rect.width * 0.5;
 
         let result = drop_target_at(&index, &view, 0, test_x, mid_y - para_rect.y);
-        let target = result.expect("drop target must be Some");
+        let (position, indicator) = result.expect("drop target must be Some");
 
         assert_eq!(
-            target.position.node, para_id,
+            position.node, para_id,
             "position.node must be the paragraph Dot"
         );
         assert!(
-            matches!(target.indicator, DropIndicator::Inline { .. }),
+            matches!(indicator, DropIndicator::Inline { .. }),
             "indicator must be Inline, got {:?}",
-            target.indicator
+            indicator
         );
 
         let LayoutContent::Line(line) = &entry.content(&index).unwrap() else {
@@ -509,7 +506,7 @@ mod tests {
         };
         let expected_pos = grapheme::position_at_x(line, test_x - line_rect.x);
         assert_eq!(
-            target.position.offset, expected_pos.offset,
+            position.offset, expected_pos.offset,
             "offset must match position_at_x"
         );
 
@@ -559,11 +556,11 @@ mod tests {
         let page_y = second_right_line.rect.y - index.pages()[0].y_start
             + second_right_line.rect.height / 2.0;
 
-        let target =
+        let (position, _) =
             drop_target_at(&index, &view, 0, x, page_y).expect("gutter drop in row must resolve");
 
         assert_eq!(
-            target.position.node,
+            position.node,
             left_para.id(),
             "row side gutter drop must route to the nearest cell scope"
         );
@@ -591,26 +588,27 @@ mod tests {
         let x = para_rect.x + para_rect.width * 0.5;
 
         let top_padding_y = (cell_rect.y + para_rect.y) * 0.5 - index.pages()[0].y_start;
-        let top_target = drop_target_at(&index, &view, 0, x, top_padding_y)
+        let (top_position, top_indicator) = drop_target_at(&index, &view, 0, x, top_padding_y)
             .expect("cell top padding drop must resolve");
-        assert_eq!(top_target.position.node, cell.id());
-        assert_eq!(top_target.position.offset, 0);
+        assert_eq!(top_position.node, cell.id());
+        assert_eq!(top_position.offset, 0);
         assert!(
-            matches!(top_target.indicator, DropIndicator::Block { .. }),
+            matches!(top_indicator, DropIndicator::Block { .. }),
             "cell padding drop should be a block boundary, got {:?}",
-            top_target.indicator
+            top_indicator
         );
 
         let bottom_padding_y =
             (para_rect.bottom() + cell_rect.bottom()) * 0.5 - index.pages()[0].y_start;
-        let bottom_target = drop_target_at(&index, &view, 0, x, bottom_padding_y)
-            .expect("cell bottom padding drop must resolve");
-        assert_eq!(bottom_target.position.node, cell.id());
-        assert_eq!(bottom_target.position.offset, 1);
+        let (bottom_position, bottom_indicator) =
+            drop_target_at(&index, &view, 0, x, bottom_padding_y)
+                .expect("cell bottom padding drop must resolve");
+        assert_eq!(bottom_position.node, cell.id());
+        assert_eq!(bottom_position.offset, 1);
         assert!(
-            matches!(bottom_target.indicator, DropIndicator::Block { .. }),
+            matches!(bottom_indicator, DropIndicator::Block { .. }),
             "cell padding drop should be a block boundary, got {:?}",
-            bottom_target.indicator
+            bottom_indicator
         );
     }
 
@@ -673,28 +671,29 @@ mod tests {
         let page = index.page(0).expect("page 0 must exist");
 
         let gap_page_y = gap_mid_y - page.y_start;
-        let gap_target = drop_target_at(&index, &view, 0, 10.0, gap_page_y)
+        let (gap_position, gap_indicator) = drop_target_at(&index, &view, 0, 10.0, gap_page_y)
             .expect("drop_target_at must resolve at a block edge in the inter-paragraph gap");
         assert!(
-            matches!(gap_target.indicator, DropIndicator::Block { .. }),
+            matches!(gap_indicator, DropIndicator::Block { .. }),
             "indicator in inter-paragraph gap must be Block, got {:?}",
-            gap_target.indicator
+            gap_indicator
         );
         assert_eq!(
-            gap_target.position.node, root_id,
+            gap_position.node, root_id,
             "drop in gap must resolve to root node"
         );
 
         let gap_bottom_page_y = p2_rect.y - 1.0 - page.y_start;
-        let gap_bottom_target = drop_target_at(&index, &view, 0, 10.0, gap_bottom_page_y)
-            .expect("drop_target_at must resolve at a block edge near the bottom of the gap");
+        let (gap_bottom_position, gap_bottom_indicator) =
+            drop_target_at(&index, &view, 0, 10.0, gap_bottom_page_y)
+                .expect("drop_target_at must resolve at a block edge near the bottom of the gap");
         assert!(
-            matches!(gap_bottom_target.indicator, DropIndicator::Block { .. }),
+            matches!(gap_bottom_indicator, DropIndicator::Block { .. }),
             "indicator near bottom of gap must be Block, got {:?}",
-            gap_bottom_target.indicator
+            gap_bottom_indicator
         );
         assert_eq!(
-            gap_bottom_target.position.node, root_id,
+            gap_bottom_position.node, root_id,
             "drop near bottom of gap must resolve to root node"
         );
     }
@@ -769,18 +768,18 @@ mod tests {
             atom_rect.y + atom_rect.height * 0.5 - index.page_y_start(0).unwrap_or(0.0);
 
         let result = drop_target_at(&index, &view, 0, mid_x, mid_y_page);
-        let target = result.expect("drop target on atom must be Some");
+        let (position, _) = result.expect("drop target on atom must be Some");
 
         assert_eq!(
-            target.position.node, expected_parent,
+            position.node, expected_parent,
             "position.node must be atom.attachment.parent (root Dot)"
         );
         assert_eq!(
-            target.position.node, root_id,
+            position.node, root_id,
             "atom attachment parent must be the root"
         );
         assert_eq!(
-            target.position.offset, expected_offset,
+            position.offset, expected_offset,
             "offset must be attachment.index + 1"
         );
     }

--- a/crates/editor-view/src/view.rs
+++ b/crates/editor-view/src/view.rs
@@ -4,7 +4,7 @@ use editor_common::{EdgeInsets, Movement};
 use editor_crdt::Dot;
 use editor_model::{LayoutMode, Node, NodeType, NodeView};
 use editor_resource::Resource;
-use editor_state::{LayoutDirty, Position, ResolvedSelection, Selection, State};
+use editor_state::{LayoutDirty, Position, ResolvedSelection, Selection, StablePosition, State};
 
 use crate::measure::Measurer;
 use crate::measure::context::measure_context;
@@ -24,6 +24,7 @@ const CONTINUOUS_CONTENT_CAP: f32 = 1024.0;
 pub struct View {
     resource: Arc<Mutex<Resource>>,
     layout: Option<LayoutResult>,
+    layout_state: Option<State>,
     fingerprint: Option<LayoutFingerprint>,
     viewport: Viewport,
     view_state: ViewState,
@@ -50,6 +51,7 @@ impl View {
             viewport,
             view_state: ViewState::new(),
             layout: None,
+            layout_state: None,
             fingerprint: None,
             measurer: Measurer::new(),
         }
@@ -102,9 +104,14 @@ impl View {
             LayoutDirty::Incremental { content, structural }
                 if content.is_empty() && structural.is_empty()
         );
-        if dirty_empty && self.layout.is_some() {
+        let same_projected_state = self
+            .layout_state
+            .as_ref()
+            .is_some_and(|layout_state| Arc::ptr_eq(&layout_state.projected, &state.projected));
+        if dirty_empty && same_projected_state && self.layout.is_some() {
             let (_, _, new_fingerprint) = self.build_pipeline(state);
             if self.fingerprint.as_ref() == Some(&new_fingerprint) {
+                self.layout_state = Some(state.clone());
                 return false;
             }
         }
@@ -144,6 +151,7 @@ impl View {
         }
 
         self.compute_inner(state, content_targets.as_deref());
+        self.layout_state = Some(state.clone());
 
         if pending_changed {
             self.view_state.preferred_x = None;
@@ -225,6 +233,25 @@ impl View {
 
     fn compute(&mut self, state: &State) {
         self.compute_inner(state, None);
+        self.layout_state = Some(state.clone());
+    }
+
+    pub fn layout_state(&self) -> Option<&State> {
+        self.layout_state.as_ref()
+    }
+
+    /// Consumes projected layout dirtiness without making the retained layout
+    /// snapshot force a copy-on-write clone of an otherwise unchanged document.
+    pub fn take_layout_dirty(&mut self, state: &mut State) -> LayoutDirty {
+        let layout_was_current = self
+            .layout_state
+            .take()
+            .is_some_and(|layout_state| Arc::ptr_eq(&layout_state.projected, &state.projected));
+        let dirty = state.projected_mut().take_layout_dirty();
+        if layout_was_current {
+            self.layout_state = Some(state.clone());
+        }
+        dirty
     }
 
     fn compute_inner(&mut self, state: &State, content_targets: Option<&[editor_crdt::Dot]>) {
@@ -332,13 +359,19 @@ impl View {
 
     pub fn drop_target_at(
         &self,
-        state: &State,
         page_idx: usize,
         x: f32,
         y: f32,
     ) -> Option<crate::dnd::DropTarget> {
         let layout_index = &self.layout.as_ref()?.layout_index;
-        crate::query::dnd::drop_target_at(layout_index, &state.view(), page_idx, x, y)
+        let layout_state = self.layout_state.as_ref()?;
+        let view = layout_state.view();
+        let (position, indicator) =
+            crate::query::dnd::drop_target_at(layout_index, &view, page_idx, x, y)?;
+        Some(crate::dnd::DropTarget {
+            position: StablePosition::capture(&position, &view),
+            indicator,
+        })
     }
 
     pub fn interactive_hit_test(
@@ -814,7 +847,7 @@ mod invalidation_tests {
         NodeType, SeqItem, TableNodeAttr,
     };
     use editor_resource::Resource;
-    use editor_state::{LayoutDirty, ProjectedState, State};
+    use editor_state::{LayoutDirty, Position, ProjectedState, Selection, State};
 
     use super::View;
     use crate::measure::context::measure_context;
@@ -854,6 +887,54 @@ mod invalidation_tests {
         let mut resource = view.resource.lock().unwrap();
         view.measurer
             .measure(&nv, content_width, &ctx, &mut resource)
+    }
+
+    #[test]
+    fn layout_state_tracks_the_state_used_by_the_layout() {
+        let mut projected = ProjectedState::empty();
+        projected.commit();
+        let paragraph = projected
+            .view()
+            .root()
+            .unwrap()
+            .child_blocks()
+            .next()
+            .unwrap()
+            .id();
+        let state = State::new(projected, None);
+        let mut view = make_view(800.0);
+
+        view.layout(&state);
+
+        let layout_state = view
+            .layout_state()
+            .expect("layout must retain its source state");
+        assert!(Arc::ptr_eq(&layout_state.projected, &state.projected));
+
+        let mut selection_state = state.clone();
+        selection_state.selection = Some(Selection::collapsed(Position::new(paragraph, 0)));
+        assert!(!view.reconcile(&selection_state, LayoutDirty::empty(), None, None,));
+        assert_eq!(
+            view.layout_state().and_then(|state| state.selection),
+            selection_state.selection,
+        );
+    }
+
+    #[test]
+    fn taking_layout_dirty_does_not_clone_a_current_layout_snapshot() {
+        let mut projected = ProjectedState::empty();
+        projected.commit();
+        let mut state = State::new(projected, None);
+        let mut view = make_view(800.0);
+        view.layout(&state);
+        let projected_before = Arc::as_ptr(&state.projected);
+
+        let _ = view.take_layout_dirty(&mut state);
+
+        assert_eq!(Arc::as_ptr(&state.projected), projected_before);
+        assert!(view.layout_state().is_some_and(|layout_state| {
+            Arc::ptr_eq(&layout_state.projected, &state.projected)
+        }));
     }
 
     #[test]


### PR DESCRIPTION
- TR-382 해결: 같은 tick에서 remote 구조 변경 뒤 layout 기반 입력을 처리하면, 이전 layout의 slot position을 최신 state에 적용해 화면에서 본 대상과 다른 content를 선택하거나 조작할 수 있던 문제 수정
- view에 `layout_state` 추가: layout을 만든 state를 함께 보관, layout state에서 해석한 selection을 현재 state로 stable하게 remap하도록 변경