### PR TITLE
fold 동작 레거시 parity

### DIFF
--- a/crates/editor-core/src/editor.rs
+++ b/crates/editor-core/src/editor.rs
@@ -1271,6 +1271,13 @@ impl Editor {
         did_change
     }
 
+    pub(crate) fn set_fold_expanded(&mut self, id: Dot, expanded: bool) -> bool {
+        if self.view.fold_expanded(id) == expanded {
+            return false;
+        }
+        self.toggle_fold(id)
+    }
+
     pub(crate) fn fold_expanded(&self, id: Dot) -> bool {
         self.view.fold_expanded(id)
     }

--- a/crates/editor-core/src/handle/block.rs
+++ b/crates/editor-core/src/handle/block.rs
@@ -1,11 +1,14 @@
 use editor_commands::{self as commands};
-use editor_model::NodeType;
+use editor_crdt::Dot;
+use editor_model::{Node, NodeType};
+use editor_transaction::Transaction;
 
 use crate::editor::Editor;
 use crate::error::EditorError;
 use crate::message::*;
 
 pub fn handle_block_op(editor: &mut Editor, op: BlockOp) -> Result<(), EditorError> {
+    let mut created_fold = None;
     editor.transact(|tr| {
         match op {
             BlockOp::ToggleBlockquote { variant } => commands::chain!(
@@ -35,15 +38,44 @@ pub fn handle_block_op(editor: &mut Editor, op: BlockOp) -> Result<(), EditorErr
                     commands::normalize_selected_blocks_in_callout(),
                 ),
             ),
-            BlockOp::WrapFold => commands::chain!(
-                tr,
-                commands::optional!(commands::materialize_gap_paragraph()),
-                commands::optional!(commands::materialize_synthetic_selection_blocks()),
-                commands::wrap_selected_blocks_in_fold(),
-            ),
+            BlockOp::WrapFold => {
+                let enclosing_before = selection_enclosing_fold(tr);
+                let applied = commands::chain!(
+                    tr,
+                    commands::optional!(commands::materialize_gap_paragraph()),
+                    commands::optional!(commands::materialize_synthetic_selection_blocks()),
+                    commands::wrap_selected_blocks_in_fold(),
+                )?;
+                if applied {
+                    created_fold =
+                        selection_enclosing_fold(tr).filter(|id| Some(*id) != enclosing_before);
+                }
+                Ok(applied)
+            }
         }?;
         Ok(())
-    })
+    })?;
+
+    // Legacy parity: folds default collapsed, so a freshly created one is expanded explicitly.
+    if let Some(fold_id) = created_fold {
+        editor.set_fold_expanded(fold_id, true);
+    }
+    Ok(())
+}
+
+fn selection_enclosing_fold(tr: &Transaction) -> Option<Dot> {
+    let selection = tr.selection()?;
+    let view = tr.view();
+    let node = view.node(selection.head.node).or_else(|| {
+        view.leaf(selection.head.node)
+            .and_then(|leaf| leaf.parent())
+    })?;
+    if matches!(node.node(), Node::Fold(_)) {
+        return Some(node.id());
+    }
+    node.ancestors()
+        .find(|ancestor| matches!(ancestor.node(), Node::Fold(_)))
+        .map(|ancestor| ancestor.id())
 }
 
 #[cfg(test)]
@@ -303,6 +335,69 @@ mod tests {
             selection: (empty, 0) -> (p2, 1)
         };
         assert_state_eq!(editor.state(), &expected);
+    }
+
+    #[test]
+    fn wrap_fold_expands_created_fold() {
+        let (initial, ..) = state! {
+            doc { root { p1: paragraph { text("Hello") } paragraph {} } }
+            selection: (p1, 2)
+        };
+        let mut editor = Editor::new_test(initial);
+        editor.apply(Message::System {
+            event: SystemEvent::Initialize,
+        });
+        editor.apply(block_message(BlockOp::WrapFold));
+
+        let fold = editor
+            .state()
+            .view()
+            .root()
+            .expect("test document has root")
+            .child_blocks()
+            .find(|block| block.node_type() == NodeType::Fold)
+            .expect("fold created")
+            .id();
+        assert!(
+            editor.fold_expanded(fold),
+            "freshly created fold must be expanded"
+        );
+    }
+
+    #[test]
+    fn wrap_fold_expands_only_the_inner_fold() {
+        let (initial, f1, fc, _p1) = state! {
+            doc {
+                root {
+                    f1: fold {
+                        fold_title { text("Outer") }
+                        fc: fold_content { p1: paragraph { text("Body") } }
+                    }
+                    paragraph {}
+                }
+            }
+            selection: (p1, 1)
+        };
+        let mut editor = Editor::new_test(initial);
+        editor.apply(Message::System {
+            event: SystemEvent::Initialize,
+        });
+        editor.apply(block_message(BlockOp::WrapFold));
+
+        let inner = editor
+            .state()
+            .view()
+            .node(fc)
+            .expect("fold content exists")
+            .child_blocks()
+            .find(|block| block.node_type() == NodeType::Fold)
+            .expect("inner fold created")
+            .id();
+        assert!(editor.fold_expanded(inner), "inner fold must be expanded");
+        assert!(
+            !editor.fold_expanded(f1),
+            "pre-existing outer fold keeps its collapsed default"
+        );
     }
 
     #[test]

--- a/crates/editor-core/src/handle/navigation.rs
+++ b/crates/editor-core/src/handle/navigation.rs
@@ -2603,10 +2603,10 @@ mod tests {
     // stops at the inner gap, not the fold's outer boundary.
     #[test]
     fn arrow_up_nested_callouts_stops_at_innermost_boundary_first() {
-        let (state, fc, ..) = state! {
+        let (state, f, fc, ..) = state! {
             doc {
                 root {
-                    fold {
+                    f: fold {
                         fold_title { text("t") }
                         fc: fold_content {
                             callout { paragraph {} }
@@ -2620,6 +2620,7 @@ mod tests {
             selection: (p1, 0)
         };
         let mut editor = Editor::new_test(state);
+        editor.view.set_fold_state(&editor.state, f, true);
         editor.view.layout(&editor.state);
         let expected = gap_cursor_selection_at(fc, 1, &editor.state.view())
             .expect("inner between-callouts gap is valid");
@@ -2636,10 +2637,10 @@ mod tests {
 
     #[test]
     fn arrow_up_from_callout_at_fold_content_start_enters_inner_leading_gap() {
-        let (state, fc, ..) = state! {
+        let (state, f, fc, ..) = state! {
             doc {
                 root {
-                    fold {
+                    f: fold {
                         fold_title {}
                         fc: fold_content {
                             callout { p1: paragraph {} }
@@ -2651,6 +2652,7 @@ mod tests {
             selection: (p1, 0)
         };
         let mut editor = Editor::new_test(state);
+        editor.view.set_fold_state(&editor.state, f, true);
         editor.view.layout(&editor.state);
         let expected = gap_cursor_selection_at(fc, 0, &editor.state.view())
             .expect("gap between fold_content start boundary and callout is valid");
@@ -2667,10 +2669,10 @@ mod tests {
 
     #[test]
     fn arrow_down_from_callout_at_fold_content_end_enters_inner_trailing_gap() {
-        let (state, fc, ..) = state! {
+        let (state, f, fc, ..) = state! {
             doc {
                 root {
-                    fold {
+                    f: fold {
                         fold_title {}
                         fc: fold_content {
                             callout { p1: paragraph {} }
@@ -2682,6 +2684,7 @@ mod tests {
             selection: (p1, 0)
         };
         let mut editor = Editor::new_test(state);
+        editor.view.set_fold_state(&editor.state, f, true);
         editor.view.layout(&editor.state);
         let expected = gap_cursor_selection_at(fc, 1, &editor.state.view())
             .expect("gap between callout and fold_content end boundary is valid");
@@ -2730,10 +2733,10 @@ mod tests {
 
     #[test]
     fn arrow_down_from_inner_leading_gap_enters_callout_start() {
-        let (state, _fc, p1) = state! {
+        let (state, f, _fc, p1) = state! {
             doc {
                 root {
-                    fold {
+                    f: fold {
                         fold_title {}
                         fc: fold_content {
                             callout { p1: paragraph { text("ab") } }
@@ -2745,6 +2748,7 @@ mod tests {
             selection: (fc, 0, <)
         };
         let mut editor = Editor::new_test(state);
+        editor.view.set_fold_state(&editor.state, f, true);
         editor.view.layout(&editor.state);
         arrow(
             &mut editor,
@@ -2764,10 +2768,10 @@ mod tests {
 
     #[test]
     fn arrow_up_from_inner_leading_gap_exits_to_fold_title() {
-        let (state, ft, ..) = state! {
+        let (state, f, ft, ..) = state! {
             doc {
                 root {
-                    fold {
+                    f: fold {
                         ft: fold_title {}
                         fc: fold_content {
                             callout { p1: paragraph {} }
@@ -2779,6 +2783,7 @@ mod tests {
             selection: (p1, 0)
         };
         let mut editor = Editor::new_test(state);
+        editor.view.set_fold_state(&editor.state, f, true);
         editor.view.layout(&editor.state);
         arrow(
             &mut editor,
@@ -2815,10 +2820,10 @@ mod tests {
 
     #[test]
     fn arrow_up_from_inner_trailing_gap_enters_callout_end() {
-        let (state, _fc, p1) = state! {
+        let (state, f, _fc, p1) = state! {
             doc {
                 root {
-                    fold {
+                    f: fold {
                         fold_title {}
                         fc: fold_content {
                             callout { p1: paragraph { text("ab") } }
@@ -2830,6 +2835,7 @@ mod tests {
             selection: (fc, 1, >)
         };
         let mut editor = Editor::new_test(state);
+        editor.view.set_fold_state(&editor.state, f, true);
         editor.view.layout(&editor.state);
         arrow(
             &mut editor,
@@ -2849,10 +2855,10 @@ mod tests {
 
     #[test]
     fn arrow_down_from_inner_trailing_gap_exits_to_next_paragraph() {
-        let (state, _fc, _p1, p2) = state! {
+        let (state, f, _fc, _p1, p2) = state! {
             doc {
                 root {
-                    fold {
+                    f: fold {
                         fold_title {}
                         fc: fold_content {
                             callout { p1: paragraph {} }
@@ -2864,6 +2870,7 @@ mod tests {
             selection: (p1, 0)
         };
         let mut editor = Editor::new_test(state);
+        editor.view.set_fold_state(&editor.state, f, true);
         editor.view.layout(&editor.state);
         arrow(
             &mut editor,

--- a/crates/editor-core/src/handle/view.rs
+++ b/crates/editor-core/src/handle/view.rs
@@ -107,6 +107,25 @@ mod tests {
     }
 
     #[test]
+    fn fold_defaults_to_collapsed_on_load() {
+        let (initial, f1, ..) = state! {
+            doc { root {
+                f1: fold {
+                    ft1: fold_title { text("Title") }
+                    fold_content { paragraph { text("Body") } }
+                }
+            } }
+            selection: (ft1, 0)
+        };
+        let mut editor = Editor::new_test(initial);
+        editor.apply(Message::System {
+            event: SystemEvent::Initialize,
+        });
+
+        assert!(!editor.fold_expanded(f1), "folds load collapsed by default");
+    }
+
+    #[test]
     fn probe_toggle_fold_existing() {
         let (state, f1, ..) = state! {
             doc { root {
@@ -175,6 +194,10 @@ mod tests {
         editor.apply(Message::View {
             op: ViewOp::ToggleFold { id: f1 },
         });
+        assert!(editor.fold_expanded(f1), "first toggle expands the fold");
+        editor.apply(Message::View {
+            op: ViewOp::ToggleFold { id: f1 },
+        });
 
         assert_ne!(
             editor
@@ -203,6 +226,9 @@ mod tests {
         editor.apply(Message::System {
             event: SystemEvent::Initialize,
         });
+        editor.apply(Message::View {
+            op: ViewOp::ToggleFold { id: f1 },
+        });
         set_pending_format(&mut editor);
 
         editor.apply(Message::View {
@@ -228,6 +254,9 @@ mod tests {
             event: SystemEvent::Initialize,
         });
 
+        editor.apply(Message::View {
+            op: ViewOp::ToggleFold { id: f1 },
+        });
         editor.apply(Message::View {
             op: ViewOp::ToggleFold { id: f1 },
         });
@@ -264,6 +293,9 @@ mod tests {
             event: SystemEvent::Initialize,
         });
 
+        editor.apply(Message::View {
+            op: ViewOp::ToggleFold { id: f1 },
+        });
         editor.apply(Message::View {
             op: ViewOp::ToggleFold { id: f1 },
         });

--- a/crates/editor-view/src/measure/context.rs
+++ b/crates/editor-view/src/measure/context.rs
@@ -12,7 +12,7 @@ pub(crate) struct MeasureContext {
 
 impl MeasureContext {
     pub fn fold_expanded(&self, node: &Dot) -> bool {
-        self.fold_states.get(node).copied().unwrap_or(true)
+        self.fold_states.get(node).copied().unwrap_or(false)
     }
 
     pub fn external_height(&self, node: &Dot) -> Option<f32> {
@@ -64,13 +64,13 @@ mod tests {
     fn fold_expanded_default_and_set() {
         let id = Dot::new(1, 1);
         let ctx = MeasureContext::default();
-        assert!(ctx.fold_expanded(&id));
+        assert!(!ctx.fold_expanded(&id));
 
-        let ctx_false = MeasureContext {
-            fold_states: HashMap::from([(id, false)]),
+        let ctx_true = MeasureContext {
+            fold_states: HashMap::from([(id, true)]),
             ..Default::default()
         };
-        assert!(!ctx_false.fold_expanded(&id));
+        assert!(ctx_true.fold_expanded(&id));
     }
 
     #[test]

--- a/crates/editor-view/src/measure/nodes/fold.rs
+++ b/crates/editor-view/src/measure/nodes/fold.rs
@@ -34,7 +34,7 @@ pub(crate) fn measure_fold_title(
     let expanded = node
         .parent()
         .map(|p| ctx.fold_expanded(&p.id()))
-        .unwrap_or(true);
+        .unwrap_or(false);
     let padding = EdgeInsets {
         top: FOLD_TITLE_PADDING_Y,
         left: FOLD_TITLE_PADDING_X + FOLD_TITLE_ICON_WIDTH + FOLD_TITLE_ICON_GAP,
@@ -319,13 +319,12 @@ mod tests {
         let title = get_node(&view, ft_dot);
         let mut res = Resource::new_test();
 
-        let measured = measure_fold_title(
-            &mut Measurer::new(),
-            &title,
-            300.0,
-            &MeasureContext::default(),
-            &mut res,
-        );
+        let ctx_expanded = MeasureContext {
+            fold_states: HashMap::from([(editor_crdt::Dot::new(1, 1), true)]),
+            ..Default::default()
+        };
+        let measured =
+            measure_fold_title(&mut Measurer::new(), &title, 300.0, &ctx_expanded, &mut res);
         let MeasuredContent::Box(ref b) = measured.content else {
             panic!("expected Box");
         };
@@ -341,13 +340,14 @@ mod tests {
                 .all(|c| matches!(c.content, MeasuredContent::Line(_)))
         );
 
-        let ctx_false = MeasureContext {
-            fold_states: HashMap::from([(editor_crdt::Dot::new(1, 1), false)]),
-            ..Default::default()
-        };
-        let measured_false =
-            measure_fold_title(&mut Measurer::new(), &title, 300.0, &ctx_false, &mut res);
-        let MeasuredContent::Box(ref bf) = measured_false.content else {
+        let measured_default = measure_fold_title(
+            &mut Measurer::new(),
+            &title,
+            300.0,
+            &MeasureContext::default(),
+            &mut res,
+        );
+        let MeasuredContent::Box(ref bf) = measured_default.content else {
             panic!("expected Box");
         };
         let dec_f = &bf.style.decorations[0];
@@ -469,19 +469,17 @@ mod tests {
     #[test]
     fn fold_border_and_children() {
         use crate::measure::nodes::dispatch::measure_node;
-        let (doc, root_dot, _) = fold_doc();
+        let (doc, root_dot, fold_dot) = fold_doc();
         let pd = project_document(&doc).unwrap();
         let view = DocView::new(&pd);
         let root = get_node(&view, root_dot);
         let mut res = Resource::new_test();
 
-        let result = measure_node(
-            &mut Measurer::new(),
-            &root,
-            400.0,
-            &MeasureContext::default(),
-            &mut res,
-        );
+        let ctx_expanded = MeasureContext {
+            fold_states: HashMap::from([(fold_dot, true)]),
+            ..Default::default()
+        };
+        let result = measure_node(&mut Measurer::new(), &root, 400.0, &ctx_expanded, &mut res);
         let MeasuredContent::Box(ref rb) = result.content else {
             panic!("expected Box at root");
         };
@@ -502,23 +500,23 @@ mod tests {
         let fold = get_node(&view, fold_dot);
         let mut res = Resource::new_test();
 
-        let ctx_collapsed = MeasureContext {
-            fold_states: HashMap::from([(fold_dot, false)]),
-            ..Default::default()
-        };
-        let collapsed = measure_fold(&mut Measurer::new(), &fold, 300.0, &ctx_collapsed, &mut res);
-        let MeasuredContent::Box(ref cb) = collapsed.content else {
-            panic!("expected Box");
-        };
-        assert_eq!(cb.children.len(), 1);
-
-        let expanded = measure_fold(
+        let collapsed = measure_fold(
             &mut Measurer::new(),
             &fold,
             300.0,
             &MeasureContext::default(),
             &mut res,
         );
+        let MeasuredContent::Box(ref cb) = collapsed.content else {
+            panic!("expected Box");
+        };
+        assert_eq!(cb.children.len(), 1);
+
+        let ctx_expanded = MeasureContext {
+            fold_states: HashMap::from([(fold_dot, true)]),
+            ..Default::default()
+        };
+        let expanded = measure_fold(&mut Measurer::new(), &fold, 300.0, &ctx_expanded, &mut res);
         let MeasuredContent::Box(ref eb) = expanded.content else {
             panic!("expected Box");
         };
@@ -556,23 +554,6 @@ mod tests {
         let fold_id = Dot::new(1, 1);
         let mut res = Resource::new_test();
 
-        let ctx_collapsed = MeasureContext {
-            fold_states: HashMap::from([(fold_id, false)]),
-            ..Default::default()
-        };
-        let measured = measure_fold_title(
-            &mut Measurer::new(),
-            &title,
-            300.0,
-            &ctx_collapsed,
-            &mut res,
-        );
-        let MeasuredContent::Box(ref b) = measured.content else {
-            panic!("expected Box");
-        };
-        let dec = &b.style.decorations[0];
-        assert!(matches!(dec.data, DecorationData::Bool(false)));
-
         let measured_default = measure_fold_title(
             &mut Measurer::new(),
             &title,
@@ -580,7 +561,19 @@ mod tests {
             &MeasureContext::default(),
             &mut res,
         );
-        let MeasuredContent::Box(ref bd) = measured_default.content else {
+        let MeasuredContent::Box(ref b) = measured_default.content else {
+            panic!("expected Box");
+        };
+        let dec = &b.style.decorations[0];
+        assert!(matches!(dec.data, DecorationData::Bool(false)));
+
+        let ctx_expanded = MeasureContext {
+            fold_states: HashMap::from([(fold_id, true)]),
+            ..Default::default()
+        };
+        let measured_expanded =
+            measure_fold_title(&mut Measurer::new(), &title, 300.0, &ctx_expanded, &mut res);
+        let MeasuredContent::Box(ref bd) = measured_expanded.content else {
             panic!("expected Box");
         };
         let dec_d = &bd.style.decorations[0];
@@ -665,12 +658,13 @@ mod tests {
         let fold_id = fold_dot;
         let mut res = Resource::new_test();
 
-        let ctx_collapsed = MeasureContext {
-            fold_states: HashMap::from([(fold_id, false)]),
-            ..Default::default()
-        };
-        let result_collapsed =
-            measure_node(&mut Measurer::new(), &root, 400.0, &ctx_collapsed, &mut res);
+        let result_collapsed = measure_node(
+            &mut Measurer::new(),
+            &root,
+            400.0,
+            &MeasureContext::default(),
+            &mut res,
+        );
         let MeasuredContent::Box(ref rb) = result_collapsed.content else {
             panic!("expected Box at root");
         };
@@ -680,13 +674,12 @@ mod tests {
         };
         assert_eq!(fb.children.len(), 1);
 
-        let result_expanded = measure_node(
-            &mut Measurer::new(),
-            &root,
-            400.0,
-            &MeasureContext::default(),
-            &mut res,
-        );
+        let ctx_expanded = MeasureContext {
+            fold_states: HashMap::from([(fold_id, true)]),
+            ..Default::default()
+        };
+        let result_expanded =
+            measure_node(&mut Measurer::new(), &root, 400.0, &ctx_expanded, &mut res);
         let MeasuredContent::Box(ref rb2) = result_expanded.content else {
             panic!("expected Box at root");
         };

--- a/crates/editor-view/src/view.rs
+++ b/crates/editor-view/src/view.rs
@@ -1435,6 +1435,10 @@ mod incremental_tests {
 
         let mut view = make_view(800.0);
         view.layout(&state);
+        assert!(
+            view.toggle_fold(&state, fold),
+            "expand collapsed-by-default fold"
+        );
 
         let before_fold = cached_arc(&mut view, &state, fold);
         let before_unrelated = cached_arc(&mut view, &state, unrelated);
@@ -1481,6 +1485,10 @@ mod incremental_tests {
 
         let mut view = make_view(800.0);
         view.layout(&state);
+        assert!(
+            view.toggle_fold(&state, fold),
+            "expand collapsed-by-default fold"
+        );
 
         let before_fold = cached_arc(&mut view, &state, fold);
         let before_unrelated = cached_arc(&mut view, &state, unrelated);

--- a/crates/editor-view/src/view_state.rs
+++ b/crates/editor-view/src/view_state.rs
@@ -43,7 +43,7 @@ impl ViewState {
     }
 
     pub fn fold_expanded(&self, node_id: Dot) -> bool {
-        self.fold_states.get(&node_id).copied().unwrap_or(true)
+        self.fold_states.get(&node_id).copied().unwrap_or(false)
     }
 
     pub fn external_height(&self, node_id: Dot) -> Option<f32> {


### PR DESCRIPTION
fold 노드 동작을 레거시와 동일하게 맞춤

* 에디터 로드시: 접힌 상태로 로드
* 에디터에서 삽입시: 열린 상태로 삽입
* 뷰어 로드시: 접힌 상태로 로드

