### PR TITLE
안드로이드 이미지/파일 업로드 불가한 문제 수정

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarHost.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarHost.kt
@@ -46,6 +46,8 @@ import co.typie.screen.editor.editor.toolbar.contextual.ImageResizeSecondaryTool
 import co.typie.screen.editor.editor.toolbar.contextual.TableAlignmentSecondaryToolbar
 import co.typie.screen.editor.editor.toolbar.contextual.TableCellBackgroundSecondaryToolbar
 import co.typie.screen.editor.editor.toolbar.contextual.TextOptionsToolbar
+import co.typie.screen.editor.editor.toolbar.contextual.rememberEditorFilePicker
+import co.typie.screen.editor.editor.toolbar.contextual.rememberEditorImagePicker
 import co.typie.screen.editor.editor.toolbar.contextual.rememberTextToolbarPage
 import co.typie.ui.component.ResponsiveContainerDefaults
 import kotlinx.coroutines.launch
@@ -106,8 +108,15 @@ internal fun EditorToolbarHost(
       commentEnabled = commentEnabled,
       onCommentRequest = onCommentRequest,
     )
+  val pickImage = rememberEditorImagePicker(commandScope)
+  val pickFile = rememberEditorFilePicker(commandScope)
   val pages =
-    rememberEditorToolbarPages(toolbarContext = toolbarContext, textToolbarPage = textToolbarPage)
+    rememberEditorToolbarPages(
+      toolbarContext = toolbarContext,
+      textToolbarPage = textToolbarPage,
+      pickImage = pickImage,
+      pickFile = pickFile,
+    )
   val panel = inputState.panel
   val activeBottomPanel = panel?.panel
   val effectiveImeInset = effectiveImeInset(environment)

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarPages.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarPages.kt
@@ -75,8 +75,10 @@ import kotlinx.coroutines.launch
 internal fun rememberEditorToolbarPages(
   toolbarContext: EditorToolbarContext,
   textToolbarPage: EditorToolbarPage,
+  pickImage: (nodeId: String) -> Unit,
+  pickFile: (nodeId: String) -> Unit,
 ): List<EditorToolbarPage> {
-  return remember(toolbarContext, textToolbarPage) {
+  return remember(toolbarContext, textToolbarPage, pickImage, pickFile) {
     toolbarContext.pageKeys.map { key ->
       when (key) {
         EditorToolbarPageKey.Main ->
@@ -86,11 +88,13 @@ internal fun rememberEditorToolbarPages(
           editorImageToolbarPage(
             image = toolbarContext.selectedNode as? PlainNode.Image,
             nodeId = toolbarContext.selectedNodeId,
+            pickImage = pickImage,
           )
         EditorToolbarPageKey.File ->
           editorFileToolbarPage(
             file = toolbarContext.selectedNode as? PlainNode.File,
             nodeId = toolbarContext.selectedNodeId,
+            pickFile = pickFile,
           )
         EditorToolbarPageKey.Embed ->
           editorEmbedToolbarPage(
@@ -289,13 +293,12 @@ internal fun EditorToolbarPages(
 
     LaunchedEffect(pages, pageMetrics) {
       snapshotFlow {
-          pages.mapIndexedNotNull { index, page ->
-            val scrollState = page.scrollState ?: return@mapIndexedNotNull null
-            val target =
-              pageMetrics.internalScrollFor(index, pagerState.scrollPosition).roundToInt()
-            scrollState to target.coerceIn(0, scrollState.maxValue)
-          }
+        pages.mapIndexedNotNull { index, page ->
+          val scrollState = page.scrollState ?: return@mapIndexedNotNull null
+          val target = pageMetrics.internalScrollFor(index, pagerState.scrollPosition).roundToInt()
+          scrollState to target.coerceIn(0, scrollState.maxValue)
         }
+      }
         .collect { scrollTargets ->
           scrollTargets.forEach { (scrollState, target) ->
             if (scrollState.value != target) {
@@ -461,10 +464,10 @@ internal fun EditorToolbarPages(
         validAutoTargetKey != null && pagerState.lastAppliedAutoTargetKey != validAutoTargetKey
       }
       snapshotFlow {
-          scrollableState.isScrollInProgress ||
-            pagerState.pointerScrollGestureActive ||
-            pagerState.decayFlingInProgress
-        }
+        scrollableState.isScrollInProgress ||
+          pagerState.pointerScrollGestureActive ||
+          pagerState.decayFlingInProgress
+      }
         .first { inProgress -> !inProgress }
       val targetPageKey =
         pendingAutoTargetPageKey

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/FileToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/FileToolbar.kt
@@ -1,6 +1,8 @@
 package co.typie.screen.editor.editor.toolbar.contextual
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
 import co.typie.domain.blob.BlobService
@@ -37,37 +39,40 @@ import co.typie.screen.editor.editor.toolbar.EditorToolbarPageScope
 import co.typie.screen.editor.editor.toolbar.EditorToolbarRow
 import co.typie.ui.component.toast.LocalToast
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
-internal fun editorFileToolbarPage(file: PlainNode.File?, nodeId: String?): EditorToolbarPage =
+internal fun editorFileToolbarPage(
+  file: PlainNode.File?,
+  nodeId: String?,
+  pickFile: (nodeId: String) -> Unit,
+): EditorToolbarPage =
   EditorToolbarPage(
     key = EditorToolbarPageKey.File,
     icon = Lucide.Paperclip,
     contentDescription = "파일 툴바",
     ownerNodeId = nodeId,
-    content = { scope -> EditorFileToolbar(scope = scope, file = file, nodeId = nodeId) },
+    content = { scope ->
+      EditorFileToolbar(scope = scope, file = file, nodeId = nodeId, pickFile = pickFile)
+    },
   )
 
+// Must be composed outside the toolbar's AnimatedVisibility: on Android the system picker hides
+// the IME, which unmounts the toolbar pages, and an ActivityResult launcher registered there
+// would be unregistered before the result arrives.
 @Composable
-private fun EditorFileToolbar(
-  scope: EditorToolbarPageScope,
-  file: PlainNode.File?,
-  nodeId: String?,
-  modifier: Modifier = Modifier,
-) {
+internal fun rememberEditorFilePicker(commandScope: CoroutineScope): (nodeId: String) -> Unit {
   val toast = LocalToast.current
   val runtime = LocalEditorRuntime.current
   val bringIntoViewRequests = LocalEditorBringIntoViewRequests.current
-  val uriHandler = LocalUriHandler.current
   val externalElementState = LocalEditorExternalElementState.current
   val fileState = externalElementState.files
-  val fileId = file?.id
-  val asset = fileId?.let(fileState.assets::get)
-  val uploading = nodeId?.let { fileState.uploads.containsKey(it) } == true
-  val hasFile = fileId != null || uploading
+  val pendingNodeId = remember { mutableStateOf<String?>(null) }
 
   val picker =
     rememberFilePicker(selectionMode = FilePickerSelectionMode.Multiple) { result ->
+      val selectedNodeId = pendingNodeId.value
+      pendingNodeId.value = null
       val files =
         when (result) {
           FilePickerResult.Cancelled -> return@rememberFilePicker
@@ -82,103 +87,124 @@ private fun EditorFileToolbar(
             result.files
           }
         }
-      val selectedNodeId =
-        nodeId
-          ?: run {
-            files.forEach { it.close() }
-            return@rememberFilePicker
-          }
+      if (selectedNodeId == null) {
+        files.forEach { it.close() }
+        return@rememberFilePicker
+      }
       val selectedFile = files.first()
       val selectedUpload = selectedFile.toFileUpload()
       val restUploads = files.drop(1).map { file -> file to file.toFileUpload() }
 
-      val uploadJob =
-        scope.commandScope.launch {
-          fileState.uploads[selectedNodeId] = selectedUpload
+      val uploadJob = commandScope.launch {
+        fileState.uploads[selectedNodeId] = selectedUpload
 
-          val restNodeIds =
+        val restNodeIds =
+          try {
+            insertFilePlaceholders(
+              editor = runtime.editor,
+              bringIntoViewRequests = bringIntoViewRequests,
+              count = restUploads.size,
+            )
+          } catch (error: CancellationException) {
+            throw error
+          } catch (_: Throwable) {
+            toast.error("파일 업로드에 실패했어요.")
+            emptyList()
+          }
+
+        if (restNodeIds.size < restUploads.size) {
+          toast.error("일부 파일을 삽입하지 못했어요.")
+        }
+
+        restNodeIds.zip(restUploads).forEach { (newNodeId, pending) ->
+          fileState.uploads[newNodeId] = pending.second
+        }
+
+        fun launchUpload(targetNodeId: String, file: PickedFile, upload: EditorFileUpload) {
+          val job = launch {
             try {
-              insertFilePlaceholders(
-                editor = runtime.editor,
-                bringIntoViewRequests = bringIntoViewRequests,
-                count = restUploads.size,
+              // TODO(TR-38): Check restrictedBlob before starting file uploads and
+              // surface the
+              // plan upgrade flow instead of letting the upload proceed.
+              completeAttachmentOperation(
+                persist = { uploadFileAsset(file) },
+                isCurrent = { fileState.uploads[targetNodeId] === upload },
+                cache = externalElementState::put,
+                commit = { uploaded ->
+                  val editor = checkNotNull(runtime.editor) { "No active editor is available" }
+                  val committedState =
+                    editor.awaitWithBringIntoView(bringIntoViewRequests) {
+                      if (editor.ime?.composing != null) {
+                        enqueue(Message.TextInput(listOf(FlatImeOp.CommitAsIs)))
+                      }
+                      enqueue(
+                        Message.Node(
+                          NodeOp.SetAttrs(
+                            id = targetNodeId,
+                            attrs = PlainNode.File(id = uploaded.id),
+                          )
+                        )
+                      )
+                      beforeCommit {
+                        bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+                      }
+                    }
+                  checkNotNull(committedState) { "Editor file attrs did not commit" }
+                },
+                clearPending = {
+                  if (fileState.uploads[targetNodeId] === upload) {
+                    fileState.uploads.remove(targetNodeId)
+                  }
+                },
               )
             } catch (error: CancellationException) {
               throw error
-            } catch (_: Throwable) {
+            } catch (error: Throwable) {
+              reportAttachmentFailure(AttachmentKind.File, error)
               toast.error("파일 업로드에 실패했어요.")
-              emptyList()
             }
-
-          if (restNodeIds.size < restUploads.size) {
-            toast.error("일부 파일을 삽입하지 못했어요.")
           }
-
-          restNodeIds.zip(restUploads).forEach { (newNodeId, pending) ->
-            fileState.uploads[newNodeId] = pending.second
-          }
-
-          fun launchUpload(targetNodeId: String, file: PickedFile, upload: EditorFileUpload) {
-            val job = launch {
-              try {
-                // TODO(TR-38): Check restrictedBlob before starting file uploads and
-                // surface the
-                // plan upgrade flow instead of letting the upload proceed.
-                completeAttachmentOperation(
-                  persist = { uploadFileAsset(file) },
-                  isCurrent = { fileState.uploads[targetNodeId] === upload },
-                  cache = externalElementState::put,
-                  commit = { uploaded ->
-                    val editor = checkNotNull(runtime.editor) { "No active editor is available" }
-                    val committedState =
-                      editor.awaitWithBringIntoView(bringIntoViewRequests) {
-                        if (editor.ime?.composing != null) {
-                          enqueue(Message.TextInput(listOf(FlatImeOp.CommitAsIs)))
-                        }
-                        enqueue(
-                          Message.Node(
-                            NodeOp.SetAttrs(
-                              id = targetNodeId,
-                              attrs = PlainNode.File(id = uploaded.id),
-                            )
-                          )
-                        )
-                        beforeCommit {
-                          bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
-                        }
-                      }
-                    checkNotNull(committedState) { "Editor file attrs did not commit" }
-                  },
-                  clearPending = {
-                    if (fileState.uploads[targetNodeId] === upload) {
-                      fileState.uploads.remove(targetNodeId)
-                    }
-                  },
-                )
-              } catch (error: CancellationException) {
-                throw error
-              } catch (error: Throwable) {
-                reportAttachmentFailure(AttachmentKind.File, error)
-                toast.error("파일 업로드에 실패했어요.")
-              }
-            }
-            job.invokeOnCompletion { file.close() }
-          }
-
-          launchUpload(targetNodeId = selectedNodeId, file = selectedFile, upload = selectedUpload)
-          restNodeIds.zip(restUploads).forEach { (newNodeId, pending) ->
-            launchUpload(targetNodeId = newNodeId, file = pending.first, upload = pending.second)
-          }
+          job.invokeOnCompletion { file.close() }
         }
+
+        launchUpload(targetNodeId = selectedNodeId, file = selectedFile, upload = selectedUpload)
+        restNodeIds.zip(restUploads).forEach { (newNodeId, pending) ->
+          launchUpload(targetNodeId = newNodeId, file = pending.first, upload = pending.second)
+        }
+      }
       uploadJob.invokeOnCompletion { files.forEach { it.close() } }
     }
+
+  return remember(picker) {
+    { nodeId ->
+      pendingNodeId.value = nodeId
+      picker("*/*")
+    }
+  }
+}
+
+@Composable
+private fun EditorFileToolbar(
+  scope: EditorToolbarPageScope,
+  file: PlainNode.File?,
+  nodeId: String?,
+  pickFile: (nodeId: String) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val uriHandler = LocalUriHandler.current
+  val externalElementState = LocalEditorExternalElementState.current
+  val fileState = externalElementState.files
+  val fileId = file?.id
+  val asset = fileId?.let(fileState.assets::get)
+  val uploading = nodeId?.let { fileState.uploads.containsKey(it) } == true
+  val hasFile = fileId != null || uploading
 
   EditorToolbarRow(scope = scope, modifier = modifier) {
     if (!hasFile) {
       EditorToolbarButton(
         icon = Lucide.Paperclip,
         contentDescription = "파일 첨부",
-        onClick = { picker("*/*") },
+        onClick = { nodeId?.let(pickFile) },
       )
     }
     if (asset != null) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/ImageToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/ImageToolbar.kt
@@ -1,6 +1,8 @@
 package co.typie.screen.editor.editor.toolbar.contextual
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import co.typie.domain.blob.BlobService
 import co.typie.editor.Editor
@@ -39,36 +41,40 @@ import co.typie.screen.editor.editor.toolbar.EditorToolbarRow
 import co.typie.screen.editor.editor.toolbar.EditorToolbarSecondary
 import co.typie.ui.component.toast.LocalToast
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
-internal fun editorImageToolbarPage(image: PlainNode.Image?, nodeId: String?): EditorToolbarPage =
+internal fun editorImageToolbarPage(
+  image: PlainNode.Image?,
+  nodeId: String?,
+  pickImage: (nodeId: String) -> Unit,
+): EditorToolbarPage =
   EditorToolbarPage(
     key = EditorToolbarPageKey.Image,
     icon = Lucide.Image,
     contentDescription = "이미지 툴바",
     ownerNodeId = nodeId,
-    content = { scope -> EditorImageToolbar(scope = scope, image = image, nodeId = nodeId) },
+    content = { scope ->
+      EditorImageToolbar(scope = scope, image = image, nodeId = nodeId, pickImage = pickImage)
+    },
   )
 
+// Must be composed outside the toolbar's AnimatedVisibility: on Android the system picker hides
+// the IME, which unmounts the toolbar pages, and an ActivityResult launcher registered there
+// would be unregistered before the result arrives.
 @Composable
-private fun EditorImageToolbar(
-  scope: EditorToolbarPageScope,
-  image: PlainNode.Image?,
-  nodeId: String?,
-  modifier: Modifier = Modifier,
-) {
+internal fun rememberEditorImagePicker(commandScope: CoroutineScope): (nodeId: String) -> Unit {
   val toast = LocalToast.current
   val runtime = LocalEditorRuntime.current
   val bringIntoViewRequests = LocalEditorBringIntoViewRequests.current
   val externalElementState = LocalEditorExternalElementState.current
   val imageState = externalElementState.images
-  val imageId = image?.id
-  val readyAsset = imageId?.let(imageState.assets::get)
-  val uploading = nodeId?.let { imageState.uploads.containsKey(it) } == true
-  val hasImage = imageId != null || uploading
+  val pendingNodeId = remember { mutableStateOf<String?>(null) }
 
   val picker =
     rememberFilePicker(selectionMode = FilePickerSelectionMode.Multiple) { result ->
+      val selectedNodeId = pendingNodeId.value
+      pendingNodeId.value = null
       val files =
         when (result) {
           FilePickerResult.Cancelled -> return@rememberFilePicker
@@ -83,12 +89,10 @@ private fun EditorImageToolbar(
             result.files
           }
         }
-      val selectedNodeId =
-        nodeId
-          ?: run {
-            files.forEach { it.close() }
-            return@rememberFilePicker
-          }
+      if (selectedNodeId == null) {
+        files.forEach { it.close() }
+        return@rememberFilePicker
+      }
       val imageUploads = files.mapNotNull { file ->
         val upload =
           file.toImageUploadOrNull()
@@ -106,93 +110,115 @@ private fun EditorImageToolbar(
       val (selectedImage, selectedUpload) = imageUploads.first()
       val restUploads = imageUploads.drop(1)
 
-      val uploadJob =
-        scope.commandScope.launch {
-          imageState.uploads[selectedNodeId] = selectedUpload
+      val uploadJob = commandScope.launch {
+        imageState.uploads[selectedNodeId] = selectedUpload
 
-          val restNodeIds =
+        val restNodeIds =
+          try {
+            insertImagePlaceholders(
+              editor = runtime.editor,
+              bringIntoViewRequests = bringIntoViewRequests,
+              count = restUploads.size,
+            )
+          } catch (error: CancellationException) {
+            throw error
+          } catch (_: Throwable) {
+            toast.error("이미지 업로드에 실패했어요.")
+            emptyList()
+          }
+
+        if (skippedImageCount > 0 || restNodeIds.size < restUploads.size) {
+          toast.error("일부 이미지를 삽입하지 못했어요.")
+        }
+
+        restNodeIds.zip(restUploads).forEach { (newNodeId, pending) ->
+          imageState.uploads[newNodeId] = pending.second
+        }
+
+        fun launchUpload(targetNodeId: String, file: PickedFile, upload: EditorImageUpload) {
+          val job = launch {
             try {
-              insertImagePlaceholders(
-                editor = runtime.editor,
-                bringIntoViewRequests = bringIntoViewRequests,
-                count = restUploads.size,
+              // TODO(TR-38): Check restrictedBlob before starting image uploads and
+              // surface the
+              // plan upgrade flow instead of letting the upload proceed.
+              completeAttachmentOperation(
+                persist = { uploadImageAsset(file) },
+                isCurrent = { imageState.uploads[targetNodeId] === upload },
+                cache = externalElementState::put,
+                commit = { uploaded ->
+                  val editor = checkNotNull(runtime.editor) { "No active editor is available" }
+                  val committedState =
+                    editor.awaitWithBringIntoView(bringIntoViewRequests) {
+                      if (editor.ime?.composing != null) {
+                        enqueue(Message.TextInput(listOf(FlatImeOp.CommitAsIs)))
+                      }
+                      enqueue(
+                        Message.Node(
+                          NodeOp.SetAttr(
+                            id = targetNodeId,
+                            attr = NodeAttr.Image(ImageNodeAttr.Id(uploaded.id)),
+                          )
+                        )
+                      )
+                      beforeCommit {
+                        bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+                      }
+                    }
+                  checkNotNull(committedState) { "Editor image attrs did not commit" }
+                },
+                clearPending = {
+                  if (imageState.uploads[targetNodeId] === upload) {
+                    imageState.uploads.remove(targetNodeId)
+                  }
+                },
               )
             } catch (error: CancellationException) {
               throw error
-            } catch (_: Throwable) {
+            } catch (error: Throwable) {
+              reportAttachmentFailure(AttachmentKind.Image, error)
               toast.error("이미지 업로드에 실패했어요.")
-              emptyList()
             }
-
-          if (skippedImageCount > 0 || restNodeIds.size < restUploads.size) {
-            toast.error("일부 이미지를 삽입하지 못했어요.")
           }
-
-          restNodeIds.zip(restUploads).forEach { (newNodeId, pending) ->
-            imageState.uploads[newNodeId] = pending.second
-          }
-
-          fun launchUpload(targetNodeId: String, file: PickedFile, upload: EditorImageUpload) {
-            val job = launch {
-              try {
-                // TODO(TR-38): Check restrictedBlob before starting image uploads and
-                // surface the
-                // plan upgrade flow instead of letting the upload proceed.
-                completeAttachmentOperation(
-                  persist = { uploadImageAsset(file) },
-                  isCurrent = { imageState.uploads[targetNodeId] === upload },
-                  cache = externalElementState::put,
-                  commit = { uploaded ->
-                    val editor = checkNotNull(runtime.editor) { "No active editor is available" }
-                    val committedState =
-                      editor.awaitWithBringIntoView(bringIntoViewRequests) {
-                        if (editor.ime?.composing != null) {
-                          enqueue(Message.TextInput(listOf(FlatImeOp.CommitAsIs)))
-                        }
-                        enqueue(
-                          Message.Node(
-                            NodeOp.SetAttr(
-                              id = targetNodeId,
-                              attr = NodeAttr.Image(ImageNodeAttr.Id(uploaded.id)),
-                            )
-                          )
-                        )
-                        beforeCommit {
-                          bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
-                        }
-                      }
-                    checkNotNull(committedState) { "Editor image attrs did not commit" }
-                  },
-                  clearPending = {
-                    if (imageState.uploads[targetNodeId] === upload) {
-                      imageState.uploads.remove(targetNodeId)
-                    }
-                  },
-                )
-              } catch (error: CancellationException) {
-                throw error
-              } catch (error: Throwable) {
-                reportAttachmentFailure(AttachmentKind.Image, error)
-                toast.error("이미지 업로드에 실패했어요.")
-              }
-            }
-            job.invokeOnCompletion { file.close() }
-          }
-
-          launchUpload(targetNodeId = selectedNodeId, file = selectedImage, upload = selectedUpload)
-          restNodeIds.zip(restUploads).forEach { (newNodeId, pending) ->
-            launchUpload(targetNodeId = newNodeId, file = pending.first, upload = pending.second)
-          }
+          job.invokeOnCompletion { file.close() }
         }
+
+        launchUpload(targetNodeId = selectedNodeId, file = selectedImage, upload = selectedUpload)
+        restNodeIds.zip(restUploads).forEach { (newNodeId, pending) ->
+          launchUpload(targetNodeId = newNodeId, file = pending.first, upload = pending.second)
+        }
+      }
       uploadJob.invokeOnCompletion { imageUploads.forEach { (file) -> file.close() } }
     }
+
+  return remember(picker) {
+    { nodeId ->
+      pendingNodeId.value = nodeId
+      picker("image/*")
+    }
+  }
+}
+
+@Composable
+private fun EditorImageToolbar(
+  scope: EditorToolbarPageScope,
+  image: PlainNode.Image?,
+  nodeId: String?,
+  pickImage: (nodeId: String) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val externalElementState = LocalEditorExternalElementState.current
+  val imageState = externalElementState.images
+  val imageId = image?.id
+  val readyAsset = imageId?.let(imageState.assets::get)
+  val uploading = nodeId?.let { imageState.uploads.containsKey(it) } == true
+  val hasImage = imageId != null || uploading
 
   EditorToolbarRow(scope = scope, modifier = modifier) {
     if (!hasImage) {
       EditorToolbarButton(
         icon = Lucide.Image,
         contentDescription = "이미지 선택",
-        onClick = { picker("image/*") },
+        onClick = { nodeId?.let(pickImage) },
       )
     }
     if (readyAsset != null && nodeId != null) {


### PR DESCRIPTION
툴바에 엮인 picker scope가 실제 file picker가 떴을 때 유실되고 있어 scope를 툴바 위쪽으로 호이스팅함
