### PR TITLE
앱 route removal

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationStack.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationStack.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastFirstOrNull
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import co.touchlab.kermit.Logger
 import co.typie.ext.pointerIgnore
 import co.typie.ext.thenIf
 import co.typie.route.Route
@@ -58,13 +59,17 @@ import co.typie.ui.component.topbar.TopBarState
 import co.typie.ui.theme.AppShapes
 import co.typie.ui.theme.AppTheme
 import kotlin.math.abs
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 private enum class AnimState {
   Idle,
   Push,
   Pop,
   Dragging,
+  PopGestureCommitted,
 }
 
 @Composable
@@ -131,6 +136,83 @@ fun NavigationStack(
   var lastDragAmount by remember { mutableStateOf(0f) }
   val nestedPopGestureSession = remember { NavigationPopGestureSession() }
 
+  fun clearRemovedRoutes(removedRoutes: List<Route>) {
+    removedRoutes.forEach { removedRoute ->
+      topBarState.clearRoute(removedRoute)
+      exitTopBarState.clearRoute(removedRoute)
+      bottomBarState?.clearRoute(removedRoute)
+      exitBottomBarState?.clearRoute(removedRoute)
+    }
+  }
+
+  suspend fun settleAtCurrentRoute() {
+    progress.snapTo(0f)
+    visibleRoute = navigator.current
+    behindRoute = null
+    animState = AnimState.Idle
+  }
+
+  suspend fun animateRemovalTo(target: Route): Boolean {
+    val requiresTransition = target != navigator.current
+    val continuesPopGesture =
+      animState == AnimState.PopGestureCommitted &&
+        behindRoute == target &&
+        transitionStyle != RouteTransitionStyle.Fade
+    if (!requiresTransition) {
+      if (animState == AnimState.PopGestureCommitted) {
+        progress.animateTo(0f, spring(stiffness = StiffnessMediumLow))
+      }
+      settleAtCurrentRoute()
+    } else {
+      transitionStyle = visibleRoute.transitionStyleTo(target)
+      behindRoute = target
+      animState = AnimState.Pop
+      if (continuesPopGesture) {
+        progress.animateTo(1f, spring(stiffness = StiffnessMediumLow))
+      } else {
+        progress.snapTo(0f)
+        progress.animateTo(1f, tween(350, easing = FastOutSlowInEasing))
+      }
+    }
+
+    if (!navigator.routeRemovals.activeSegmentIsCurrent()) {
+      navigator.routeRemovals.rollbackActiveSegment()
+      settleAtCurrentRoute()
+      return false
+    }
+
+    if (!requiresTransition) return true
+    val removedRoutes = navigator.performPopTo(target)
+    visibleRoute = navigator.current
+    behindRoute = null
+    animState = AnimState.Idle
+    clearRemovedRoutes(removedRoutes)
+    return true
+  }
+
+  suspend fun performProgressiveRemoval(target: Route): NavigationResult {
+    while (navigator.current != target) {
+      val targetIndex = navigator.stack.lastIndexOf(target)
+      check(targetIndex >= 0) { "Removal target is not in the navigation stack" }
+      val routesToRemove =
+        navigator.stack.subList(targetIndex + 1, navigator.stack.size).asReversed()
+      val segment = navigator.routeRemovals.prepareSegment(routesToRemove, target)
+      if (!animateRemovalTo(segment.destination)) continue
+
+      if (segment.blockedRoute == null) {
+        navigator.routeRemovals.commitSegment()
+        return NavigationResult.ReachedTarget
+      }
+
+      navigator.routeRemovals.commitReadyPrefix()
+      navigator.routeRemovals.resolveBlockedRoute()?.let {
+        return it
+      }
+    }
+    navigator.routeRemovals.commitSegment()
+    return NavigationResult.ReachedTarget
+  }
+
   fun startPopDrag() {
     val prev = navigator.previous ?: return
     transitionStyle = visibleRoute.transitionStyleTo(prev)
@@ -152,23 +234,30 @@ fun NavigationStack(
     val velocity = lastDragAmount * 1000f / 16f
     scope.launch {
       if (progress.value > 0.5f || velocity > 1000f) {
-        val poppedRoute = visibleRoute
-        navigator.requestPop()
-        progress.animateTo(1f, spring(stiffness = StiffnessMediumLow))
-        navigator.performPop()
-        navigator.consumePopRequest()
-        // 드래그 중 pop()/popTo()가 걸어둔 transitionCompletion 해제
-        navigator.completeTransition()
-        visibleRoute = navigator.current
-        topBarState.clearRoute(poppedRoute)
-        exitTopBarState.clearRoute(poppedRoute)
-        bottomBarState?.clearRoute(poppedRoute)
-        exitBottomBarState?.clearRoute(poppedRoute)
+        val target = navigator.previous
+        if (target != null) {
+          try {
+            animState = AnimState.PopGestureCommitted
+            if (navigator.pop() == NavigationResult.NotStarted) {
+              progress.animateTo(0f, spring(stiffness = StiffnessMediumLow))
+              settleAtCurrentRoute()
+            }
+          } catch (e: CancellationException) {
+            withContext(NonCancellable) { settleAtCurrentRoute() }
+            throw e
+          } catch (e: Throwable) {
+            settleAtCurrentRoute()
+            Logger.e(e) { "Navigation gesture removal failed" }
+          }
+        } else {
+          progress.animateTo(0f, spring(stiffness = StiffnessMediumLow))
+          settleAtCurrentRoute()
+        }
       } else {
         progress.animateTo(0f, spring(stiffness = StiffnessMediumLow))
+        behindRoute = null
+        animState = AnimState.Idle
       }
-      behindRoute = null
-      animState = AnimState.Idle
     }
   }
 
@@ -193,6 +282,7 @@ fun NavigationStack(
             source != NestedScrollSource.UserInput ||
               nestedPopGestureSession.isClaimed ||
               !navigator.canPop ||
+              navigator.isTransitioning ||
               containerWidth <= 0f ||
               (animState != AnimState.Idle && animState != AnimState.Dragging)
           ) {
@@ -245,44 +335,43 @@ fun NavigationStack(
     }
   }
 
-  // requestPop: 애니메이션 먼저, 그 다음 상태 변경. 요청 시점에 전환/드래그 중이면
-  // 버리지 않고 보류했다가 Idle 복귀 시 처리한다 (드래그 커밋은 finishPopDrag가
-  // 직접 pop을 수행하고 요청을 소비하므로 여기로 오지 않는다).
+  // pop 요청은 이 collector가 애니메이션과 stack 변경을 함께 처리한다.
   LaunchedEffect(Unit) {
-    snapshotFlow { navigator.popRequested to animState }
-      .collect { (requested, currentAnimState) ->
-        if (requested && currentAnimState == AnimState.Idle) {
-          val popTarget = navigator.peekPopTarget()
-          val targetRoute = popTarget ?: navigator.previous
-          if (targetRoute == null) {
+    snapshotFlow { navigator.peekPopTarget() to animState }
+      .collect { (targetRoute, currentAnimState) ->
+        if (
+          targetRoute != null &&
+            (currentAnimState == AnimState.Idle ||
+              (currentAnimState == AnimState.PopGestureCommitted && targetRoute == behindRoute))
+        ) {
+          try {
+            val result = performProgressiveRemoval(targetRoute)
             navigator.consumePopRequest()
-            navigator.completeTransition()
-            return@collect
-          }
-
-          behindRoute = targetRoute
-          transitionStyle = visibleRoute.transitionStyleTo(targetRoute)
-          animState = AnimState.Pop
-          progress.snapTo(0f)
-          progress.animateTo(1f, tween(350, easing = FastOutSlowInEasing))
-          val removedRoutes =
-            if (popTarget != null) {
-              navigator.performPopTo(popTarget)
-            } else {
-              navigator.performPop()
-              listOf(visibleRoute)
+            navigator.completeTransition(result = result)
+          } catch (e: Throwable) {
+            withContext(NonCancellable) {
+              val rollbackFailure =
+                try {
+                  navigator.routeRemovals.rollbackActiveSegment()
+                  null
+                } catch (throwable: Throwable) {
+                  throwable
+                }
+              val settleFailure =
+                try {
+                  settleAtCurrentRoute()
+                  null
+                } catch (throwable: Throwable) {
+                  throwable
+                }
+              listOfNotNull(rollbackFailure, settleFailure).forEach { cleanupFailure ->
+                if (cleanupFailure !== e) e.addSuppressed(cleanupFailure)
+              }
+              navigator.consumePopRequest()
+              navigator.completeTransition(e)
             }
-          navigator.consumePopRequest()
-          visibleRoute = navigator.current
-          behindRoute = null
-          animState = AnimState.Idle
-          removedRoutes.forEach { removedRoute ->
-            topBarState.clearRoute(removedRoute)
-            exitTopBarState.clearRoute(removedRoute)
-            bottomBarState?.clearRoute(removedRoute)
-            exitBottomBarState?.clearRoute(removedRoute)
+            if (e is CancellationException) throw e
           }
-          navigator.completeTransition()
         }
       }
   }
@@ -312,10 +401,7 @@ fun NavigationStack(
           progress.snapTo(0f)
           progress.animateTo(1f, tween(350, easing = FastOutSlowInEasing))
           visibleRoute = navigator.current
-          topBarState.clearRoute(poppedRoute)
-          exitTopBarState.clearRoute(poppedRoute)
-          bottomBarState?.clearRoute(poppedRoute)
-          exitBottomBarState?.clearRoute(poppedRoute)
+          clearRemovedRoutes(listOf(poppedRoute))
           navigator.completeTransition()
         }
       }
@@ -348,7 +434,8 @@ fun NavigationStack(
         AnimState.Push ->
           topBarState.navDirection =
             if (useSwitchTopBarTransition) NavDirection.Switch else NavDirection.Push
-        AnimState.Pop ->
+        AnimState.Pop,
+        AnimState.PopGestureCommitted ->
           topBarState.navDirection =
             if (useSwitchTopBarTransition) NavDirection.Switch else NavDirection.Pop
         AnimState.Dragging ->
@@ -415,6 +502,7 @@ fun NavigationStack(
                 when (animState) {
                   AnimState.Push -> 1f - progress.value
                   AnimState.Pop -> progress.value
+                  AnimState.PopGestureCommitted -> 0f
                   AnimState.Dragging -> if (navigator.popRequested) progress.value else 0f
                   AnimState.Idle -> 1f
                 }
@@ -435,7 +523,8 @@ fun NavigationStack(
                 alpha =
                   when (animState) {
                     AnimState.Push -> progress.value
-                    AnimState.Pop -> 1f - progress.value
+                    AnimState.Pop,
+                    AnimState.PopGestureCommitted -> 1f - progress.value
                     AnimState.Dragging -> 1f - progress.value
                     AnimState.Idle -> 0f
                   }
@@ -484,14 +573,16 @@ fun NavigationStack(
       val mainTopBar =
         when (animState) {
           // Pop: 나가는 화면은 exitTopBarState
-          AnimState.Pop -> exitTopBarState
+          AnimState.Pop,
+          AnimState.PopGestureCommitted -> exitTopBarState
           AnimState.Dragging -> if (navigator.popRequested) exitTopBarState else topBarState
           else -> topBarState
         }
       val mainBottomBar =
         if (bottomBarState != null && exitBottomBarState != null) {
           when (animState) {
-            AnimState.Pop -> exitBottomBarState
+            AnimState.Pop,
+            AnimState.PopGestureCommitted -> exitBottomBarState
             AnimState.Dragging -> if (navigator.popRequested) exitBottomBarState else bottomBarState
             else -> bottomBarState
           }
@@ -571,6 +662,7 @@ fun NavigationStack(
                   when (animState) {
                     AnimState.Push -> p
                     AnimState.Pop -> 1f - p
+                    AnimState.PopGestureCommitted -> 1f
                     AnimState.Dragging -> if (navigator.popRequested) 1f - p else 1f
                     AnimState.Idle -> 1f
                   }
@@ -578,7 +670,8 @@ fun NavigationStack(
                 translationY =
                   when (animState) {
                     AnimState.Push -> containerHeight * (1f - p)
-                    AnimState.Pop -> containerHeight * p
+                    AnimState.Pop,
+                    AnimState.PopGestureCommitted -> containerHeight * p
                     AnimState.Dragging -> containerHeight * p
                     AnimState.Idle -> 0f
                   }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/Navigator.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/Navigator.kt
@@ -14,12 +14,21 @@ enum class NavOperation {
   Pop,
 }
 
+sealed interface NavigationResult {
+  data object ReachedTarget : NavigationResult
+
+  data class StoppedAt(val route: Route) : NavigationResult
+
+  data object NotStarted : NavigationResult
+}
+
 class Navigator(startRoute: Route) {
   private val _stack = mutableStateListOf(startRoute)
   val stack: List<Route>
     get() = _stack
 
   private val viewModelStores = mutableMapOf<Route, ViewModelStore>()
+  internal val routeRemovals = RouteRemovalCoordinator()
 
   val current: Route
     get() = _stack.last()
@@ -33,84 +42,54 @@ class Navigator(startRoute: Route) {
   var lastOperation: NavOperation = NavOperation.None
     private set
 
-  var popRequested: Boolean by mutableStateOf(false)
-    private set
+  private var pendingPopTarget: Route? by mutableStateOf(null)
+  val popRequested: Boolean
+    get() = pendingPopTarget != null
 
-  private var pendingPopTarget: Route? = null
-
-  private var transitionCompletion: CompletableDeferred<Unit>? = null
+  private var transitionCompletion: CompletableDeferred<NavigationResult>? = null
 
   val isTransitioning: Boolean
     get() = transitionCompletion?.isActive == true
-
-  suspend fun awaitTransitionIdle() {
-    while (true) {
-      val current = transitionCompletion ?: return
-      current.await()
-    }
-  }
 
   fun viewModelStoreFor(route: Route): ViewModelStore {
     return viewModelStores.getOrPut(route) { ViewModelStore() }
   }
 
-  suspend fun navigate(route: Route) {
-    if (isTransitioning) return
-    if (route == current) return
+  suspend fun navigate(route: Route): NavigationResult {
+    if (route == current) return resultForCurrentRoute()
     // 이미 스택에 있는 Route면 해당 위치까지 pop
     val existingIndex = _stack.indexOf(route)
     if (existingIndex >= 0) {
-      // 중간 Route 제거 (target과 current만 남김)
-      while (_stack.size > existingIndex + 2) {
-        val removed = _stack.removeAt(existingIndex + 1)
-        viewModelStores.remove(removed)?.clear()
-      }
-      pop()
-      return
+      return popTo(route)
     }
-    val deferred = CompletableDeferred<Unit>()
+    if (isTransitioning) return NavigationResult.NotStarted
+    val deferred = CompletableDeferred<NavigationResult>()
     transitionCompletion = deferred
     _stack.add(route)
     lastOperation = NavOperation.Push
-    deferred.await()
+    return deferred.await()
   }
 
-  suspend fun pop() {
-    if (!canPop) return
-    if (isTransitioning) return
-    val deferred = CompletableDeferred<Unit>()
-    transitionCompletion = deferred
-    pendingPopTarget = null
-    popRequested = true
-    deferred.await()
-  }
+  suspend fun pop(): NavigationResult =
+    previous?.let { target -> requestRemoval(target) } ?: NavigationResult.ReachedTarget
 
-  internal fun requestPop() {
-    if (canPop) {
-      pendingPopTarget = null
-      popRequested = true
+  internal fun completeTransition(
+    error: Throwable? = null,
+    result: NavigationResult = NavigationResult.ReachedTarget,
+  ) {
+    if (error == null) {
+      transitionCompletion?.complete(result)
+    } else {
+      transitionCompletion?.completeExceptionally(error)
     }
-  }
-
-  internal fun completeTransition() {
-    transitionCompletion?.complete(Unit)
     transitionCompletion = null
   }
 
   internal fun consumePopRequest() {
-    popRequested = false
     pendingPopTarget = null
   }
 
   internal fun peekPopTarget(): Route? = pendingPopTarget
-
-  internal fun performPop(): Boolean {
-    if (_stack.size <= 1) return false
-    val removed = _stack.removeAt(_stack.lastIndex)
-    viewModelStores.remove(removed)?.clear()
-    lastOperation = NavOperation.Pop
-    return true
-  }
 
   internal fun performPopTo(route: Route): List<Route> {
     val index = _stack.lastIndexOf(route)
@@ -127,21 +106,36 @@ class Navigator(startRoute: Route) {
     return removedRoutes
   }
 
-  suspend fun popTo(route: Route) {
+  suspend fun popTo(route: Route): NavigationResult {
     val index = _stack.lastIndexOf(route)
-    if (index < 0 || index == _stack.lastIndex) return
-    if (isTransitioning) return
-    val deferred = CompletableDeferred<Unit>()
-    transitionCompletion = deferred
-    pendingPopTarget = route
-    popRequested = true
-    deferred.await()
+    if (index < 0) return NavigationResult.NotStarted
+    if (index == _stack.lastIndex) return resultForCurrentRoute()
+    return requestRemoval(route)
   }
 
-  fun popToRoot() {
-    while (_stack.size > 1) {
-      val removed = _stack.removeAt(_stack.lastIndex)
-      viewModelStores.remove(removed)?.clear()
+  suspend fun popToRoot(): NavigationResult = popTo(_stack.first())
+
+  private suspend fun requestRemoval(target: Route): NavigationResult {
+    val activeTransition = transitionCompletion
+    if (activeTransition?.isActive == true) {
+      return if (popRequested && pendingPopTarget == target) {
+        activeTransition.await()
+      } else {
+        NavigationResult.NotStarted
+      }
+    }
+    val deferred = CompletableDeferred<NavigationResult>()
+    transitionCompletion = deferred
+    pendingPopTarget = target
+    return deferred.await()
+  }
+
+  private suspend fun resultForCurrentRoute(): NavigationResult {
+    val activeTransition = transitionCompletion
+    return when {
+      activeTransition?.isActive != true -> NavigationResult.ReachedTarget
+      !popRequested -> activeTransition.await()
+      else -> NavigationResult.NotStarted
     }
   }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/RouteRemovalCoordinator.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/RouteRemovalCoordinator.kt
@@ -1,0 +1,176 @@
+package co.typie.navigation
+
+import co.typie.route.Route
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
+
+internal enum class RouteRemovalPreparation {
+  Ready,
+  NeedsDecision,
+}
+
+internal enum class RouteRemovalDecision {
+  CancelRemoval,
+  ProceedWithRemoval,
+}
+
+internal interface RouteRemovalInterceptor {
+  suspend fun prepare(): RouteRemovalPreparation
+
+  suspend fun resolveDecision(): RouteRemovalDecision
+
+  suspend fun rollback()
+}
+
+internal data class PreparedRemovalSegment(val destination: Route, val blockedRoute: Route?)
+
+/** Coordinates route-local leave work without teaching Navigator about route-specific state. */
+internal class RouteRemovalCoordinator {
+  private data class RegisteredInterceptor(val interceptor: RouteRemovalInterceptor)
+
+  private data class PreparedRoute(val route: Route, val registration: RegisteredInterceptor)
+
+  private val interceptors = mutableMapOf<Route, RegisteredInterceptor>()
+  private val approvedRoutes = mutableListOf<PreparedRoute>()
+  private val preparedRoutes = mutableListOf<PreparedRoute>()
+  private var blockedRoute: PreparedRoute? = null
+
+  fun register(route: Route, interceptor: RouteRemovalInterceptor): () -> Unit {
+    val registration = RegisteredInterceptor(interceptor)
+    interceptors[route] = registration
+    return {
+      if (interceptors[route] === registration) {
+        interceptors.remove(route)
+      }
+    }
+  }
+
+  fun activeSegmentIsCurrent(): Boolean {
+    val preparedCurrent = preparedRoutes.all { interceptors[it.route] === it.registration }
+    val approvedRoutesCurrent = approvedRoutes.all { interceptors[it.route] === it.registration }
+    val blocked = blockedRoute
+    return preparedCurrent &&
+      approvedRoutesCurrent &&
+      (blocked == null || interceptors[blocked.route] === blocked.registration)
+  }
+
+  suspend fun prepareSegment(
+    routesToRemove: List<Route>,
+    requestedTarget: Route,
+  ): PreparedRemovalSegment {
+    check(preparedRoutes.isEmpty() && blockedRoute == null) {
+      "A route removal segment is already active"
+    }
+
+    try {
+      routesToRemove.forEach { route ->
+        val registration = interceptors[route] ?: return@forEach
+        val approved = approvedRoutes.firstOrNull { it.route == route }
+        if (approved != null) {
+          if (approved.registration === registration) return@forEach
+          approvedRoutes.remove(approved)
+          rollbackRoutes(listOf(approved))?.let { throw it }
+        }
+
+        val preparedRoute = PreparedRoute(route, registration)
+        val preparation =
+          try {
+            registration.interceptor.prepare()
+          } catch (throwable: Throwable) {
+            throwable.addCleanupFailure(rollbackRoutes(listOf(preparedRoute)))
+            throw throwable
+          }
+        when (preparation) {
+          RouteRemovalPreparation.Ready -> preparedRoutes += preparedRoute
+          RouteRemovalPreparation.NeedsDecision -> {
+            blockedRoute = preparedRoute
+            return PreparedRemovalSegment(destination = route, blockedRoute = route)
+          }
+        }
+      }
+    } catch (throwable: Throwable) {
+      throwable.addCleanupFailure(rollbackPreparedRoutes())
+      throw throwable
+    }
+
+    return PreparedRemovalSegment(destination = requestedTarget, blockedRoute = null)
+  }
+
+  /** Called after the routes above a blocked route have actually left the stack. */
+  fun commitReadyPrefix() {
+    preparedRoutes.clear()
+    approvedRoutes.clear()
+  }
+
+  /** Called after an unblocked segment has actually left the stack. */
+  fun commitSegment() {
+    preparedRoutes.clear()
+    blockedRoute = null
+    approvedRoutes.clear()
+  }
+
+  suspend fun resolveBlockedRoute(): NavigationResult? {
+    val blocked = checkNotNull(blockedRoute) { "No route is awaiting a removal decision" }
+    val currentRegistration = interceptors[blocked.route]
+    if (currentRegistration !== blocked.registration) {
+      blockedRoute = null
+      rollbackRoutes(listOf(blocked))?.let { throw it }
+      return null
+    }
+    val decision = blocked.registration.interceptor.resolveDecision()
+
+    return when (decision) {
+      RouteRemovalDecision.CancelRemoval -> {
+        blockedRoute = null
+        approvedRoutes.clear()
+        rollbackRoutes(listOf(blocked))?.let { throw it }
+        NavigationResult.StoppedAt(blocked.route)
+      }
+      RouteRemovalDecision.ProceedWithRemoval -> {
+        blockedRoute = null
+        approvedRoutes += blocked
+        null
+      }
+    }
+  }
+
+  suspend fun rollbackActiveSegment() {
+    val routes = buildList {
+      blockedRoute?.let(::add)
+      addAll(preparedRoutes.asReversed())
+      addAll(approvedRoutes.asReversed())
+    }
+    blockedRoute = null
+    preparedRoutes.clear()
+    approvedRoutes.clear()
+    rollbackRoutes(routes)?.let { throw it }
+  }
+
+  private suspend fun rollbackPreparedRoutes(): Throwable? {
+    val routes = preparedRoutes.asReversed().toList()
+    preparedRoutes.clear()
+    return rollbackRoutes(routes)
+  }
+
+  private suspend fun rollbackRoutes(routes: List<PreparedRoute>): Throwable? =
+    withContext(NonCancellable) {
+      var firstFailure: Throwable? = null
+      routes.forEach { prepared ->
+        try {
+          prepared.registration.interceptor.rollback()
+        } catch (throwable: Throwable) {
+          val previousFailure = firstFailure
+          if (previousFailure == null) {
+            firstFailure = throwable
+          } else if (throwable !== previousFailure) {
+            previousFailure.addSuppressed(throwable)
+          }
+        }
+      }
+      firstFailure
+    }
+
+  private fun Throwable.addCleanupFailure(failure: Throwable?) {
+    if (failure != null && failure !== this) addSuppressed(failure)
+  }
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/topbar/TopBarBackButton.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/topbar/TopBarBackButton.kt
@@ -13,5 +13,14 @@ fun TopBarBackButton(
   onClick: (suspend () -> Unit)? = null,
 ) {
   val navigator = Nav.current
-  TopBarButton(icon = icon, onClick = onClick ?: { navigator.pop() }, modifier = modifier)
+  TopBarButton(
+    icon = icon,
+    onClick =
+      onClick
+        ?: {
+          navigator.pop()
+          Unit
+        },
+    modifier = modifier,
+  )
 }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/navigation/NavigatorTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/navigation/NavigatorTest.kt
@@ -8,6 +8,7 @@ import kotlin.test.assertNotSame
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -36,6 +37,36 @@ class NavigatorTest {
   }
 
   @Test
+  fun duplicateNavigateWaitsForTheActivePush() = runTest {
+    val nav = Navigator(Route.Home)
+    val folderRoute = Route.Folder("1")
+    val first = async { nav.navigate(folderRoute) }
+    advanceUntilIdle()
+    val second = async { nav.navigate(folderRoute) }
+    advanceUntilIdle()
+
+    assertFalse(first.isCompleted)
+    assertFalse(second.isCompleted)
+    nav.completeTransition()
+
+    assertEquals(NavigationResult.ReachedTarget, first.await())
+    assertEquals(NavigationResult.ReachedTarget, second.await())
+  }
+
+  @Test
+  fun differentNavigateDuringActivePushIsNotStarted() = runTest {
+    val nav = Navigator(Route.Home)
+    val push = async { nav.navigate(Route.Folder("1")) }
+    advanceUntilIdle()
+
+    val result = nav.navigate(Route.Space)
+    nav.completeTransition()
+    push.await()
+
+    assertEquals(NavigationResult.NotStarted, result)
+  }
+
+  @Test
   fun pop() = runTest {
     val nav = Navigator(Route.Home)
     navigateAndComplete(nav, Route.Folder("1"))
@@ -47,8 +78,75 @@ class NavigatorTest {
   @Test
   fun popAtRoot() = runTest {
     val nav = Navigator(Route.Home)
-    nav.pop()
+    assertEquals(NavigationResult.ReachedTarget, nav.pop())
     assertEquals(Route.Home, nav.current)
+  }
+
+  @Test
+  fun popReturnsStoppedAtFromRemovalOperation() = runTest {
+    val nav = Navigator(Route.Home)
+    val editorRoute = Route.Editor("1")
+    navigateAndComplete(nav, editorRoute)
+    val result = async { nav.pop() }
+    advanceUntilIdle()
+
+    nav.consumePopRequest()
+    nav.completeTransition(result = NavigationResult.StoppedAt(editorRoute))
+
+    assertEquals(NavigationResult.StoppedAt(editorRoute), result.await())
+  }
+
+  @Test
+  fun overlappingPopWaitsForActiveRemovalResult() = runTest {
+    val nav = Navigator(Route.Home)
+    val editorRoute = Route.Editor("1")
+    navigateAndComplete(nav, editorRoute)
+    val first = async { nav.pop() }
+    advanceUntilIdle()
+    val second = async { nav.pop() }
+    advanceUntilIdle()
+
+    assertFalse(first.isCompleted)
+    assertFalse(second.isCompleted)
+    nav.consumePopRequest()
+    nav.completeTransition(result = NavigationResult.StoppedAt(editorRoute))
+
+    assertEquals(NavigationResult.StoppedAt(editorRoute), first.await())
+    assertEquals(NavigationResult.StoppedAt(editorRoute), second.await())
+  }
+
+  @Test
+  fun navigateToCurrentDuringRemovalDoesNotReportAStableOutcome() = runTest {
+    val nav = Navigator(Route.Home)
+    val editorRoute = Route.Editor("1")
+    navigateAndComplete(nav, editorRoute)
+    val removal = async { nav.pop() }
+    advanceUntilIdle()
+
+    val result = nav.navigate(editorRoute)
+    nav.consumePopRequest()
+    nav.completeTransition()
+    removal.await()
+
+    assertEquals(NavigationResult.NotStarted, result)
+  }
+
+  @Test
+  fun differentRemovalDuringActiveRemovalDoesNotReportAStableStop() = runTest {
+    val nav = Navigator(Route.Home)
+    val spaceRoute = Route.Space
+    val folderRoute = Route.Folder("1")
+    navigateAndComplete(nav, spaceRoute)
+    navigateAndComplete(nav, folderRoute)
+    val removal = async { nav.popTo(Route.Home) }
+    advanceUntilIdle()
+
+    val result = nav.pop()
+    nav.consumePopRequest()
+    nav.completeTransition()
+    removal.await()
+
+    assertEquals(NavigationResult.NotStarted, result)
   }
 
   @Test
@@ -66,7 +164,7 @@ class NavigatorTest {
   fun popToNotInStack() = runTest {
     val nav = Navigator(Route.Home)
     navigateAndComplete(nav, Route.Folder("1"))
-    nav.popTo(Route.Notes)
+    assertEquals(NavigationResult.NotStarted, nav.popTo(Route.Notes))
     assertEquals(Route.Folder("1"), nav.current)
     assertEquals(2, nav.stack.size)
   }
@@ -76,7 +174,12 @@ class NavigatorTest {
     val nav = Navigator(Route.Home)
     navigateAndComplete(nav, Route.Space)
     navigateAndComplete(nav, Route.Folder("1"))
-    nav.popToRoot()
+    val job = launch { nav.popToRoot() }
+    advanceUntilIdle()
+    nav.performPopTo(Route.Home)
+    nav.consumePopRequest()
+    nav.completeTransition()
+    job.join()
     assertEquals(Route.Home, nav.current)
     assertEquals(1, nav.stack.size)
   }
@@ -124,7 +227,7 @@ class NavigatorTest {
       val job = launch { nav.pop() }
       advanceUntilIdle()
       if (nav.popRequested) {
-        nav.performPop()
+        nav.previous?.let(nav::performPopTo)
         nav.consumePopRequest()
       }
       nav.completeTransition()

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/navigation/RouteRemovalCoordinatorTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/navigation/RouteRemovalCoordinatorTest.kt
@@ -1,0 +1,237 @@
+package co.typie.navigation
+
+import co.typie.route.Route
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
+
+class RouteRemovalCoordinatorTest {
+  @Test
+  fun hiddenFailureStopsAtEditorAfterCommittingReadyPrefix() = runTest {
+    val coordinator = RouteRemovalCoordinator()
+    val top = RecordingRemovalInterceptor(RouteRemovalPreparation.Ready)
+    val editor = RecordingRemovalInterceptor(RouteRemovalPreparation.NeedsDecision)
+    val topRoute = Route.Document("top")
+    val editorRoute = Route.Editor("editor")
+    val target = Route.Home
+    coordinator.register(topRoute, top)
+    coordinator.register(editorRoute, editor)
+
+    val segment =
+      coordinator.prepareSegment(
+        routesToRemove = listOf(topRoute, editorRoute),
+        requestedTarget = target,
+      )
+
+    assertEquals(editorRoute, segment.destination)
+    assertEquals(editorRoute, segment.blockedRoute)
+    coordinator.commitReadyPrefix()
+    editor.decision = RouteRemovalDecision.CancelRemoval
+    assertEquals(NavigationResult.StoppedAt(editorRoute), coordinator.resolveBlockedRoute())
+    assertEquals(0, top.rollbacks)
+    assertEquals(1, editor.rollbacks)
+  }
+
+  @Test
+  fun approvedRemovalContinuesTowardOriginalTarget() = runTest {
+    val coordinator = RouteRemovalCoordinator()
+    val editorRoute = Route.Editor("editor")
+    val target = Route.Home
+    val editor = RecordingRemovalInterceptor(RouteRemovalPreparation.NeedsDecision)
+    coordinator.register(editorRoute, editor)
+
+    coordinator.prepareSegment(listOf(editorRoute), target)
+    coordinator.commitReadyPrefix()
+    editor.decision = RouteRemovalDecision.ProceedWithRemoval
+    assertEquals(null, coordinator.resolveBlockedRoute())
+    assertEquals(0, editor.rollbacks)
+
+    val continued = coordinator.prepareSegment(listOf(editorRoute), target)
+    assertEquals(target, continued.destination)
+    assertEquals(null, continued.blockedRoute)
+  }
+
+  @Test
+  fun replacementAfterRemovalApprovalRequiresFreshPreparation() = runTest {
+    val coordinator = RouteRemovalCoordinator()
+    val editorRoute = Route.Editor("editor")
+    val original = RecordingRemovalInterceptor(RouteRemovalPreparation.NeedsDecision)
+    coordinator.register(editorRoute, original)
+    coordinator.prepareSegment(listOf(editorRoute), Route.Home)
+    coordinator.commitReadyPrefix()
+    original.decision = RouteRemovalDecision.ProceedWithRemoval
+    coordinator.resolveBlockedRoute()
+
+    val replacement = RecordingRemovalInterceptor(RouteRemovalPreparation.Ready)
+    coordinator.register(editorRoute, replacement)
+    val continued = coordinator.prepareSegment(listOf(editorRoute), Route.Home)
+
+    assertEquals(1, original.rollbacks)
+    assertEquals(1, replacement.prepares)
+    assertEquals(Route.Home, continued.destination)
+  }
+
+  @Test
+  fun rollbackAfterRemovalApprovalResumesApprovedInterceptor() = runTest {
+    val coordinator = RouteRemovalCoordinator()
+    val editorRoute = Route.Editor("editor")
+    val editor = RecordingRemovalInterceptor(RouteRemovalPreparation.NeedsDecision)
+    coordinator.register(editorRoute, editor)
+    coordinator.prepareSegment(listOf(editorRoute), Route.Home)
+    coordinator.commitReadyPrefix()
+    editor.decision = RouteRemovalDecision.ProceedWithRemoval
+    coordinator.resolveBlockedRoute()
+
+    coordinator.rollbackActiveSegment()
+
+    assertEquals(1, editor.rollbacks)
+  }
+
+  @Test
+  fun replacedReadyInterceptorInvalidatesActiveSegment() = runTest {
+    val coordinator = RouteRemovalCoordinator()
+    val editorRoute = Route.Editor("editor")
+    val original = RecordingRemovalInterceptor(RouteRemovalPreparation.Ready)
+    coordinator.register(editorRoute, original)
+    coordinator.prepareSegment(listOf(editorRoute), Route.Home)
+
+    coordinator.register(editorRoute, RecordingRemovalInterceptor(RouteRemovalPreparation.Ready))
+
+    assertEquals(false, coordinator.activeSegmentIsCurrent())
+    coordinator.rollbackActiveSegment()
+    assertEquals(1, original.rollbacks)
+  }
+
+  @Test
+  fun replacedBlockedInterceptorRestartsPreparationWithoutPromptingStaleHandler() = runTest {
+    val coordinator = RouteRemovalCoordinator()
+    val editorRoute = Route.Editor("editor")
+    val original = RecordingRemovalInterceptor(RouteRemovalPreparation.NeedsDecision)
+    coordinator.register(editorRoute, original)
+    coordinator.prepareSegment(listOf(editorRoute), Route.Home)
+    coordinator.commitReadyPrefix()
+    coordinator.register(editorRoute, RecordingRemovalInterceptor(RouteRemovalPreparation.Ready))
+
+    assertEquals(null, coordinator.resolveBlockedRoute())
+    assertEquals(1, original.rollbacks)
+  }
+
+  @Test
+  fun unregisteredBlockedInterceptorRestartsWithoutPromptingStaleHandler() = runTest {
+    val coordinator = RouteRemovalCoordinator()
+    val editorRoute = Route.Editor("editor")
+    val original = RecordingRemovalInterceptor(RouteRemovalPreparation.NeedsDecision)
+    val unregister = coordinator.register(editorRoute, original)
+    coordinator.prepareSegment(listOf(editorRoute), Route.Home)
+    coordinator.commitReadyPrefix()
+
+    unregister()
+
+    assertEquals(null, coordinator.resolveBlockedRoute())
+    assertEquals(1, original.rollbacks)
+  }
+
+  @Test
+  fun rollbackAttemptsEveryPreparedRouteAndPreservesFirstFailure() = runTest {
+    val coordinator = RouteRemovalCoordinator()
+    val firstFailure = IllegalStateException("first rollback failure")
+    val secondFailure = IllegalStateException("second rollback failure")
+    val secondToRollback =
+      RecordingRemovalInterceptor(
+        preparation = RouteRemovalPreparation.Ready,
+        rollbackFailure = secondFailure,
+      )
+    val firstToRollback =
+      RecordingRemovalInterceptor(
+        preparation = RouteRemovalPreparation.Ready,
+        rollbackFailure = firstFailure,
+      )
+    val secondRoute = Route.Document("second")
+    val firstRoute = Route.Editor("first")
+    coordinator.register(secondRoute, secondToRollback)
+    coordinator.register(firstRoute, firstToRollback)
+    coordinator.prepareSegment(listOf(secondRoute, firstRoute), Route.Home)
+
+    val thrown = assertFailsWith<IllegalStateException> { coordinator.rollbackActiveSegment() }
+
+    assertSame(firstFailure, thrown)
+    assertSame(secondFailure, thrown.suppressed.single())
+    assertEquals(1, firstToRollback.rollbacks)
+    assertEquals(1, secondToRollback.rollbacks)
+  }
+
+  @Test
+  fun preparationFailureRemainsPrimaryWhenRollbackAlsoFails() = runTest {
+    val coordinator = RouteRemovalCoordinator()
+    val preparationFailure = IllegalStateException("preparation failure")
+    val rollbackFailure = IllegalStateException("rollback failure")
+    val route = Route.Editor("editor")
+    coordinator.register(
+      route,
+      RecordingRemovalInterceptor(
+        preparation = RouteRemovalPreparation.Ready,
+        preparationFailure = preparationFailure,
+        rollbackFailure = rollbackFailure,
+      ),
+    )
+
+    val thrown =
+      assertFailsWith<IllegalStateException> {
+        coordinator.prepareSegment(listOf(route), Route.Home)
+      }
+
+    assertSame(preparationFailure, thrown)
+    assertSame(rollbackFailure, thrown.suppressed.single())
+  }
+
+  @Test
+  fun preparationCancellationRollsBackEveryPreparedRouteBeforeRethrowing() = runTest {
+    val coordinator = RouteRemovalCoordinator()
+    val cancellation = CancellationException("preparation cancelled")
+    val first = RecordingRemovalInterceptor(RouteRemovalPreparation.Ready)
+    val second =
+      RecordingRemovalInterceptor(
+        preparation = RouteRemovalPreparation.Ready,
+        preparationFailure = cancellation,
+      )
+    val firstRoute = Route.Document("first")
+    val secondRoute = Route.Editor("second")
+    coordinator.register(firstRoute, first)
+    coordinator.register(secondRoute, second)
+
+    val thrown =
+      assertFailsWith<CancellationException> {
+        coordinator.prepareSegment(listOf(firstRoute, secondRoute), Route.Home)
+      }
+
+    assertSame(cancellation, thrown)
+    assertEquals(1, first.rollbacks)
+    assertEquals(1, second.rollbacks)
+  }
+}
+
+private class RecordingRemovalInterceptor(
+  private val preparation: RouteRemovalPreparation,
+  private val preparationFailure: Throwable? = null,
+  private val rollbackFailure: Throwable? = null,
+) : RouteRemovalInterceptor {
+  var decision: RouteRemovalDecision = RouteRemovalDecision.CancelRemoval
+  var prepares: Int = 0
+  var rollbacks: Int = 0
+
+  override suspend fun prepare(): RouteRemovalPreparation {
+    prepares++
+    preparationFailure?.let { throw it }
+    return preparation
+  }
+
+  override suspend fun resolveDecision(): RouteRemovalDecision = decision
+
+  override suspend fun rollback() {
+    rollbacks++
+    rollbackFailure?.let { throw it }
+  }
+}

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/RouteRemovalNavigationStackDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/RouteRemovalNavigationStackDesktopTest.kt
@@ -1,0 +1,356 @@
+package co.typie.navigation
+
+import androidx.compose.foundation.gestures.rememberScrollable2DState
+import androidx.compose.foundation.gestures.scrollable2D
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import co.typie.route.Route
+import co.typie.ui.component.topbar.TopBarState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineExceptionHandler
+
+@OptIn(ExperimentalTestApi::class)
+class RouteRemovalNavigationStackDesktopTest {
+  @Test
+  fun cancelRemovalStopsMultiPopAfterGuardedRouteBecomesCurrent() = runComposeUiTest {
+    val navigator = Navigator(Route.Home)
+    val guardedRoute = Route.Folder("guarded")
+    val topRoute = Route.Document("top")
+    val popRequested = CompletableDeferred<Unit>()
+    var currentAtDecision: Route? = null
+    var rollbackCount = 0
+    var popResult: NavigationResult? = null
+
+    navigator.routeRemovals.register(
+      guardedRoute,
+      object : RouteRemovalInterceptor {
+        override suspend fun prepare(): RouteRemovalPreparation =
+          RouteRemovalPreparation.NeedsDecision
+
+        override suspend fun resolveDecision(): RouteRemovalDecision {
+          currentAtDecision = navigator.current
+          return RouteRemovalDecision.CancelRemoval
+        }
+
+        override suspend fun rollback() {
+          rollbackCount++
+        }
+      },
+    )
+
+    setContent {
+      NavigationStack(
+        navigator = navigator,
+        topBarState = remember { TopBarState() },
+        modifier = Modifier.size(width = 320.dp, height = 640.dp),
+      ) {
+        Box(Modifier.fillMaxSize())
+      }
+      LaunchedEffect(Unit) {
+        navigator.navigate(guardedRoute)
+        navigator.navigate(topRoute)
+        popRequested.await()
+        popResult = navigator.popTo(Route.Home)
+      }
+    }
+    waitUntil { navigator.current == topRoute && !navigator.isTransitioning }
+
+    popRequested.complete(Unit)
+    waitUntil { popResult != null }
+
+    assertEquals(guardedRoute, currentAtDecision)
+    assertEquals(NavigationResult.StoppedAt(guardedRoute), popResult)
+    assertEquals(listOf(Route.Home, guardedRoute), navigator.stack)
+    assertEquals(1, rollbackCount)
+  }
+
+  @Test
+  fun replacedInterceptorDuringPreparationRestartsRemoval() = runComposeUiTest {
+    val navigator = Navigator(Route.Home)
+    val guardedRoute = Route.Folder("guarded")
+    val popRequested = CompletableDeferred<Unit>()
+    val preparationStarted = CompletableDeferred<Unit>()
+    val releasePreparation = CompletableDeferred<Unit>()
+    var originalRollbackCount = 0
+    var replacementPrepareCount = 0
+    var popResult: Result<NavigationResult>? = null
+
+    navigator.routeRemovals.register(
+      guardedRoute,
+      object : RouteRemovalInterceptor {
+        override suspend fun prepare(): RouteRemovalPreparation {
+          preparationStarted.complete(Unit)
+          releasePreparation.await()
+          return RouteRemovalPreparation.Ready
+        }
+
+        override suspend fun resolveDecision(): RouteRemovalDecision =
+          error("Ready preparation must not require a decision")
+
+        override suspend fun rollback() {
+          originalRollbackCount++
+        }
+      },
+    )
+
+    setContent {
+      NavigationStack(
+        navigator = navigator,
+        topBarState = remember { TopBarState() },
+        modifier = Modifier.size(width = 320.dp, height = 640.dp),
+      ) {
+        Box(Modifier.fillMaxSize())
+      }
+      LaunchedEffect(Unit) {
+        navigator.navigate(guardedRoute)
+        popRequested.await()
+        popResult = runCatching { navigator.pop() }
+      }
+    }
+    waitUntil { navigator.current == guardedRoute && !navigator.isTransitioning }
+
+    popRequested.complete(Unit)
+    waitUntil { preparationStarted.isCompleted }
+    navigator.routeRemovals.register(
+      guardedRoute,
+      object : RouteRemovalInterceptor {
+        override suspend fun prepare(): RouteRemovalPreparation {
+          replacementPrepareCount++
+          return RouteRemovalPreparation.Ready
+        }
+
+        override suspend fun resolveDecision(): RouteRemovalDecision =
+          error("Ready preparation must not require a decision")
+
+        override suspend fun rollback() = Unit
+      },
+    )
+    releasePreparation.complete(Unit)
+    waitUntil { popResult != null }
+
+    assertEquals(NavigationResult.ReachedTarget, popResult?.getOrThrow())
+    assertEquals(Route.Home, navigator.current)
+    assertEquals(1, originalRollbackCount)
+    assertEquals(1, replacementPrepareCount)
+  }
+
+  @Test
+  fun backSwipeUsesRouteRemovalInterceptor() = runComposeUiTest {
+    val navigator = Navigator(Route.Home)
+    val guardedRoute = Route.Folder("guarded")
+    var rollbackCount = 0
+
+    navigator.routeRemovals.register(
+      guardedRoute,
+      object : RouteRemovalInterceptor {
+        override suspend fun prepare(): RouteRemovalPreparation =
+          RouteRemovalPreparation.NeedsDecision
+
+        override suspend fun resolveDecision(): RouteRemovalDecision =
+          RouteRemovalDecision.CancelRemoval
+
+        override suspend fun rollback() {
+          rollbackCount++
+        }
+      },
+    )
+
+    setContent {
+      NavigationStack(
+        navigator = navigator,
+        topBarState = remember { TopBarState() },
+        modifier = Modifier.size(width = 320.dp, height = 640.dp),
+      ) { route ->
+        val scrollableState = rememberScrollable2DState { Offset.Zero }
+        Box(
+          Modifier.fillMaxSize()
+            .testTag(if (route == guardedRoute) GuardedRouteTag else HomeRouteTag)
+            .navigationPopNestedScroll()
+            .scrollable2D(scrollableState)
+        )
+      }
+      LaunchedEffect(Unit) { navigator.navigate(guardedRoute) }
+    }
+    waitUntil { navigator.current == guardedRoute && !navigator.isTransitioning }
+
+    onNodeWithTag(GuardedRouteTag).performTouchInput {
+      down(center)
+      moveBy(Offset(x = 220f, y = 0f))
+      up()
+    }
+    waitUntil { rollbackCount == 1 && !navigator.isTransitioning }
+
+    assertEquals(guardedRoute, navigator.current)
+    assertEquals(listOf(Route.Home, guardedRoute), navigator.stack)
+  }
+
+  @Test
+  fun committedBackSwipeContinuesFromReleasedPosition() = runComposeUiTest {
+    val navigator = Navigator(Route.Home)
+    val route = Route.Folder("unguarded")
+
+    setContent {
+      NavigationStack(
+        navigator = navigator,
+        topBarState = remember { TopBarState() },
+        modifier = Modifier.size(width = 320.dp, height = 640.dp),
+      ) {
+        Box(Modifier.fillMaxSize().testTag(if (it == route) UnguardedRouteTag else HomeRouteTag))
+      }
+      LaunchedEffect(Unit) { navigator.navigate(route) }
+    }
+    waitUntil { navigator.current == route && !navigator.isTransitioning }
+
+    val clock = mainClock
+    val routeNode = onNodeWithTag(UnguardedRouteTag)
+    routeNode.performTouchInput {
+      down(center)
+      moveBy(Offset(x = 100f, y = 0f))
+      moveBy(Offset(x = 120f, y = 0f))
+      clock.autoAdvance = false
+      up()
+    }
+    clock.advanceTimeByFrame()
+    val releasedLeft = routeNode.fetchSemanticsNode().boundsInRoot.left
+    assertTrue(
+      releasedLeft > 150f,
+      "A committed back swipe must retain its released position: released=$releasedLeft",
+    )
+
+    clock.advanceTimeBy(100L)
+    val animatedLeft = routeNode.fetchSemanticsNode().boundsInRoot.left
+
+    assertTrue(
+      animatedLeft > releasedLeft,
+      "A committed back swipe must continue toward the exit: released=$releasedLeft, animated=$animatedLeft",
+    )
+    clock.autoAdvance = true
+    waitUntil { navigator.current == Route.Home && !navigator.isTransitioning }
+  }
+
+  @Test
+  fun differentTargetRemovalWaitsForCommittedBackSwipeToSettle() = runComposeUiTest {
+    val navigator = Navigator(Route.Home)
+    val middleRoute = Route.Folder("middle")
+    val topRoute = Route.Document("top")
+    val requestRemoval = CompletableDeferred<Unit>()
+    var removalResult: Result<NavigationResult>? = null
+
+    setContent {
+      NavigationStack(
+        navigator = navigator,
+        topBarState = remember { TopBarState() },
+        modifier = Modifier.size(width = 320.dp, height = 640.dp),
+      ) { route ->
+        Box(
+          Modifier.fillMaxSize().testTag(if (route == topRoute) TopRouteTag else BackgroundRouteTag)
+        )
+      }
+      LaunchedEffect(Unit) {
+        navigator.navigate(middleRoute)
+        navigator.navigate(topRoute)
+        requestRemoval.await()
+        removalResult = runCatching { navigator.popTo(Route.Home) }
+      }
+    }
+    waitUntil { navigator.current == topRoute && !navigator.isTransitioning }
+
+    val routeNode = onNodeWithTag(TopRouteTag)
+    routeNode.performTouchInput {
+      down(center)
+      moveBy(Offset(x = 100f, y = 0f))
+      moveBy(Offset(x = 120f, y = 0f))
+    }
+    requestRemoval.complete(Unit)
+    waitUntil { navigator.popRequested }
+    routeNode.performTouchInput { up() }
+    waitUntil { removalResult != null }
+
+    assertEquals(NavigationResult.ReachedTarget, removalResult?.getOrThrow())
+    assertEquals(Route.Home, navigator.current)
+    assertFalse(navigator.isTransitioning)
+  }
+
+  @Test
+  fun rollbackFailureStillCompletesRemovalTransition() {
+    val uncaughtFailure = CompletableDeferred<Throwable>()
+    runComposeUiTest(
+      effectContext =
+        CoroutineExceptionHandler { _, throwable -> uncaughtFailure.complete(throwable) }
+    ) {
+      val navigator = Navigator(Route.Home)
+      val guardedRoute = Route.Folder("guarded")
+      val popRequested = CompletableDeferred<Unit>()
+      val decisionFailure = IllegalStateException("decision failure")
+      val rollbackFailure = IllegalStateException("rollback failure")
+      var rollbackCount = 0
+      var popResult: Result<NavigationResult>? = null
+
+      navigator.routeRemovals.register(
+        guardedRoute,
+        object : RouteRemovalInterceptor {
+          override suspend fun prepare(): RouteRemovalPreparation =
+            RouteRemovalPreparation.NeedsDecision
+
+          override suspend fun resolveDecision(): RouteRemovalDecision = throw decisionFailure
+
+          override suspend fun rollback() {
+            rollbackCount++
+            throw rollbackFailure
+          }
+        },
+      )
+
+      setContent {
+        NavigationStack(
+          navigator = navigator,
+          topBarState = remember { TopBarState() },
+          modifier = Modifier.size(width = 320.dp, height = 640.dp),
+        ) {
+          Box(Modifier.fillMaxSize())
+        }
+        LaunchedEffect(Unit) {
+          navigator.navigate(guardedRoute)
+          popRequested.await()
+          popResult = runCatching { navigator.pop() }
+        }
+      }
+      waitUntil { navigator.current == guardedRoute && !navigator.isTransitioning }
+
+      popRequested.complete(Unit)
+      waitUntil { rollbackCount == 1 }
+      waitForIdle()
+
+      assertFalse(navigator.isTransitioning)
+      val failure = assertNotNull(popResult).exceptionOrNull()
+      assertEquals(decisionFailure::class, failure?.let { it::class })
+      assertEquals(decisionFailure.message, failure?.message)
+      assertEquals(listOf(rollbackFailure), decisionFailure.suppressed.toList())
+      assertFalse(uncaughtFailure.isCompleted)
+    }
+  }
+
+  private companion object {
+    const val GuardedRouteTag = "guarded-route"
+    const val HomeRouteTag = "home-route"
+    const val UnguardedRouteTag = "unguarded-route"
+    const val TopRouteTag = "top-route"
+    const val BackgroundRouteTag = "background-route"
+  }
+}


### PR DESCRIPTION
Editor route leave 시 local checkpoint를 적용할 수 있도록, route가 실제 stack에서 제거되기 전에 공통으로 준비·중단·재개할 수 있는 navigation 경계를 추가하는 작업. 이번 PR에는 Editor 전용 leave 동작은 포함하지 않고 generic route removal contract만 도입

- `Navigator`의 `pop` / `popTo` / 기존 route navigation이 `ReachedTarget` / `StoppedAt` / `NotStarted`를 반환하도록 하고, 같은 target 요청은 합류하고 충돌하는 target 요청은 기존 작업을 덮어쓰지 않도록 직렬화
- `RouteRemovalCoordinator`가 multi-pop 대상 route를 위에서부터 준비하고, 결정을 요구하는 route가 있으면 해당 화면까지 이동한 뒤 중단. 취소하면 그 route에서 멈추고 승인하면 원래 target까지 제거를 계속함
- TopBar / system back / back swipe / programmatic pop이 `NavigationStack`의 같은 route removal 경로를 사용하도록 통합. committed back swipe는 놓은 위치에서 animation을 이어가고, 다른 target 요청과 겹치면 gesture를 정리한 뒤 기존 요청을 수행
- interceptor 교체, coroutine 취소, prepare / decision / rollback 실패 시 stale preparation을 폐기하고 stack presentation과 transition completion을 정리
- Navigator 요청 직렬화, progressive multi-pop, interceptor 교체, back swipe 연동, rollback failure와 conflicting target race 회귀 테스트 추가