### PR TITLE
slice를 top level node 목록으로 표현

### DIFF
--- a/crates/editor-clipboard/src/html/parse/mod.rs
+++ b/crates/editor-clipboard/src/html/parse/mod.rs
@@ -11,7 +11,6 @@ pub mod walker;
 use crate::slice::Slice;
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD;
-use editor_model::{Fragment, PlainNode, PlainRootNode};
 use editor_resource::Resource;
 use scraper::{Html, Selector};
 use std::sync::OnceLock;
@@ -66,16 +65,11 @@ fn fallback_body_parse(doc: &Html, resource: &Resource) -> Slice {
     for child in body.children() {
         crate::html::parse::walker::walk(child, &mut children, &[], &[], &sheet, resource);
     }
-    Slice {
-        fragment: Fragment {
-            node: PlainNode::Root(PlainRootNode::default()),
-            modifiers: vec![],
-            carry: vec![],
-            children: crate::html::parse::schema_normalize::normalize(children),
-        },
-        open_start: 0,
-        open_end: 0,
-    }
+    Slice::new(
+        crate::html::parse::schema_normalize::normalize(children),
+        0,
+        0,
+    )
 }
 
 #[cfg(test)]
@@ -84,7 +78,9 @@ mod tests {
     use crate::test_doc::DocBuilder;
     use editor_crdt::Dot;
     use editor_macros::state;
-    use editor_model::{AtomLeaf, Modifier, NodeType, PlainParagraphNode, PlainTextNode};
+    use editor_model::{
+        AtomLeaf, Fragment, Modifier, NodeType, PlainNode, PlainParagraphNode, PlainTextNode,
+    };
     use editor_resource::{FontFamily, FontFamilySource, FontWeight, Resource, ThemeVariant};
     use editor_state::{Position, Selection};
 
@@ -121,7 +117,7 @@ mod tests {
         let stripped = &html[html.find("<div data-root>").unwrap()..];
 
         let parsed = Slice::from_html(stripped, &resource);
-        let colors: Vec<String> = parsed.fragment.children[0]
+        let colors: Vec<String> = parsed.content[0]
             .children
             .iter()
             .filter_map(|f| {
@@ -138,20 +134,16 @@ mod tests {
     fn from_html_body_paragraph() {
         let html = "<p>Hello</p>";
         let slice = Slice::from_html(html, &Resource::new_test());
-        assert!(matches!(slice.fragment.node, PlainNode::Root(_)));
-        assert_eq!(slice.fragment.children.len(), 1);
-        assert!(matches!(
-            slice.fragment.children[0].node,
-            PlainNode::Paragraph(_)
-        ));
+        assert_eq!(slice.content.len(), 1);
+        assert!(matches!(slice.content[0].node, PlainNode::Paragraph(_)));
     }
 
     #[test]
     fn from_html_ignores_apple_interchange_newline_break() {
         let html = r#"<p>Hello</p><br class="Apple-interchange-newline">"#;
         let slice = Slice::from_html(html, &Resource::new_test());
-        assert_eq!(slice.fragment.children.len(), 1);
-        let p = &slice.fragment.children[0];
+        assert_eq!(slice.content.len(), 1);
+        let p = &slice.content[0];
         assert!(matches!(p.node, PlainNode::Paragraph(_)));
         assert_eq!(p.children.len(), 1);
         assert!(matches!(&p.children[0].node, PlainNode::Text(t) if t.text == "Hello"));
@@ -161,7 +153,7 @@ mod tests {
     fn from_html_text_newline_is_ignored() {
         let html = "<p style=\"white-space:break-spaces\"><span>a\nb</span></p>";
         let slice = Slice::from_html(html, &Resource::new_test());
-        let p = &slice.fragment.children[0];
+        let p = &slice.content[0];
         assert_eq!(p.children.len(), 1);
         assert!(matches!(&p.children[0].node, PlainNode::Text(t) if t.text == "ab"));
     }
@@ -170,7 +162,7 @@ mod tests {
     fn from_html_trailing_text_newline_is_ignored() {
         let html = "<p style=\"white-space:break-spaces\"><span>a\n</span></p>";
         let slice = Slice::from_html(html, &Resource::new_test());
-        let p = &slice.fragment.children[0];
+        let p = &slice.content[0];
         assert_eq!(p.children.len(), 1);
         assert!(matches!(&p.children[0].node, PlainNode::Text(t) if t.text == "a"));
     }
@@ -179,7 +171,7 @@ mod tests {
     fn from_html_text_crlf_is_ignored() {
         let html = "<p><span>a\r\nb\rc</span></p>";
         let slice = Slice::from_html(html, &Resource::new_test());
-        let p = &slice.fragment.children[0];
+        let p = &slice.content[0];
         assert_eq!(p.children.len(), 1);
         assert!(matches!(&p.children[0].node, PlainNode::Text(t) if t.text == "abc"));
     }
@@ -188,7 +180,7 @@ mod tests {
     fn from_html_br_still_becomes_hard_break() {
         let html = "<p>a<br>b</p>";
         let slice = Slice::from_html(html, &Resource::new_test());
-        let p = &slice.fragment.children[0];
+        let p = &slice.content[0];
         assert_eq!(p.children.len(), 3);
         assert!(matches!(&p.children[0].node, PlainNode::Text(t) if t.text == "a"));
         assert!(matches!(p.children[1].node, PlainNode::HardBreak(_)));
@@ -199,7 +191,7 @@ mod tests {
     fn from_html_bold_italic_modifiers() {
         let html = "<p><strong><em>hi</em></strong></p>";
         let slice = Slice::from_html(html, &Resource::new_test());
-        let p = &slice.fragment.children[0];
+        let p = &slice.content[0];
         let text_frag = &p.children[0];
         assert!(matches!(text_frag.node, PlainNode::Text(_)));
         let mods: std::collections::HashSet<_> = text_frag.modifiers.iter().collect();
@@ -211,46 +203,34 @@ mod tests {
     fn from_html_text_in_root_wrapped_in_paragraph() {
         let html = "hello";
         let slice = Slice::from_html(html, &Resource::new_test());
-        assert_eq!(slice.fragment.children.len(), 1);
-        assert!(matches!(
-            slice.fragment.children[0].node,
-            PlainNode::Paragraph(_)
-        ));
+        assert_eq!(slice.content.len(), 1);
+        assert!(matches!(slice.content[0].node, PlainNode::Paragraph(_)));
     }
 
     #[test]
     fn from_html_orphan_li_wrapped_in_ul() {
         let html = "<li>a</li>";
         let slice = Slice::from_html(html, &Resource::new_test());
-        assert!(matches!(
-            slice.fragment.children[0].node,
-            PlainNode::BulletList(_)
-        ));
+        assert!(matches!(slice.content[0].node, PlainNode::BulletList(_)));
     }
 
     #[test]
     fn from_html_orphan_tr_wrapped_in_table() {
         let html = "<tr><td>a</td></tr>";
         let slice = Slice::from_html(html, &Resource::new_test());
-        assert!(matches!(
-            slice.fragment.children[0].node,
-            PlainNode::Table(_)
-        ));
+        assert!(matches!(slice.content[0].node, PlainNode::Table(_)));
     }
 
     #[test]
     fn from_html_invalid_meta_falls_back_to_body() {
         let html = r#"<meta data-slice-v2="!!!notbase64!!!" data-version="1"><div data-root><p>hello</p></div>"#;
         let slice = Slice::from_html(html, &Resource::new_test());
-        assert_eq!(slice.fragment.children.len(), 1);
-        assert!(matches!(
-            slice.fragment.children[0].node,
-            PlainNode::Paragraph(_)
-        ));
+        assert_eq!(slice.content.len(), 1);
+        assert!(matches!(slice.content[0].node, PlainNode::Paragraph(_)));
     }
 
     #[test]
-    fn from_html_legacy_v1_meta_attribute_is_unrecognized_and_falls_back() {
+    fn from_html_legacy_meta_attribute_is_unrecognized_and_falls_back() {
         let (s, ..) = state! {
             doc { root { p1: paragraph { text("Hello") } } }
             selection: (p1, 0) -> (p1, 5)
@@ -262,20 +242,17 @@ mod tests {
         let slice = Slice::from_html(&legacy_html, &Resource::new_test());
         assert_ne!(
             slice, original,
-            "a v1-named meta payload must not be decoded as the current schema"
+            "a legacy-named meta payload must not be decoded as the current schema"
         );
-        assert_eq!(slice.fragment.children.len(), 1);
-        assert!(matches!(
-            slice.fragment.children[0].node,
-            PlainNode::Paragraph(_)
-        ));
+        assert_eq!(slice.content.len(), 1);
+        assert!(matches!(slice.content[0].node, PlainNode::Paragraph(_)));
     }
 
     #[test]
     fn from_html_callout_variant_restored() {
         let html = r#"<aside data-callout data-variant="warning"><p>warn</p></aside>"#;
         let slice = Slice::from_html(html, &Resource::new_test());
-        let aside = &slice.fragment.children[0];
+        let aside = &slice.content[0];
         if let PlainNode::Callout(c) = &aside.node {
             assert!(matches!(c.variant, editor_model::CalloutVariant::Warning));
         } else {
@@ -287,7 +264,7 @@ mod tests {
     fn from_html_inline_style_to_modifiers() {
         let html = r#"<p><span style="font-weight:700;color:#ff0000;text-decoration:underline">x</span></p>"#;
         let slice = Slice::from_html(html, &Resource::new_test());
-        let text_frag = &slice.fragment.children[0].children[0];
+        let text_frag = &slice.content[0].children[0];
         let mods: Vec<_> = text_frag.modifiers.iter().collect();
         assert!(
             mods.iter()
@@ -304,7 +281,7 @@ mod tests {
     fn parse_strong_span_font_weight_does_not_duplicate_bold() {
         let html = r#"<p><strong><span style="font-weight:700">x</span></strong></p>"#;
         let slice = Slice::from_html(html, &Resource::new_test());
-        let text_frag = &slice.fragment.children[0].children[0];
+        let text_frag = &slice.content[0].children[0];
         let bold_count = text_frag
             .modifiers
             .iter()
@@ -326,7 +303,7 @@ mod tests {
     fn parse_em_span_font_style_does_not_duplicate_italic() {
         let html = r#"<p><em><span style="font-style:italic">x</span></em></p>"#;
         let slice = Slice::from_html(html, &Resource::new_test());
-        let text_frag = &slice.fragment.children[0].children[0];
+        let text_frag = &slice.content[0].children[0];
         let italic_count = text_frag
             .modifiers
             .iter()
@@ -339,7 +316,7 @@ mod tests {
     fn parse_u_span_text_decoration_does_not_duplicate_underline() {
         let html = r#"<p><u><span style="text-decoration:underline">x</span></u></p>"#;
         let slice = Slice::from_html(html, &Resource::new_test());
-        let text_frag = &slice.fragment.children[0].children[0];
+        let text_frag = &slice.content[0].children[0];
         let underline_count = text_frag
             .modifiers
             .iter()
@@ -352,7 +329,7 @@ mod tests {
     fn parse_s_span_text_decoration_does_not_duplicate_strikethrough() {
         let html = r#"<p><s><span style="text-decoration:line-through">x</span></s></p>"#;
         let slice = Slice::from_html(html, &Resource::new_test());
-        let text_frag = &slice.fragment.children[0].children[0];
+        let text_frag = &slice.content[0].children[0];
         let strike_count = text_frag
             .modifiers
             .iter()
@@ -380,7 +357,7 @@ mod tests {
         }]);
         let html = r#"<p><span style="font-family:Pretendard;font-weight:700">x</span></p>"#;
         let slice = Slice::from_html(html, &resource);
-        let text_frag = &slice.fragment.children[0].children[0];
+        let text_frag = &slice.content[0].children[0];
         assert!(
             text_frag
                 .modifiers
@@ -410,7 +387,7 @@ mod tests {
         }]);
         let html = r#"<p><span style="font-family:Pretendard;font-weight:700">x</span></p>"#;
         let slice = Slice::from_html(html, &resource);
-        let text_frag = &slice.fragment.children[0].children[0];
+        let text_frag = &slice.content[0].children[0];
         assert!(
             text_frag
                 .modifiers
@@ -445,26 +422,21 @@ mod tests {
             ],
         }]);
         let original = Slice {
-            fragment: Fragment {
-                node: PlainNode::Root(PlainRootNode::default()),
+            content: vec![Fragment {
+                node: PlainNode::Paragraph(PlainParagraphNode::default()),
                 modifiers: vec![],
                 carry: vec![],
-                children: vec![Fragment {
-                    node: PlainNode::Paragraph(PlainParagraphNode::default()),
-                    modifiers: vec![],
-                    carry: vec![],
-                    children: vec![
-                        Fragment::leaf(PlainNode::Text(PlainTextNode { text: "x".into() }))
-                            .with_modifiers(vec![
-                                Modifier::FontFamily {
-                                    value: "Pretendard".into(),
-                                },
-                                Modifier::Bold,
-                                Modifier::FontWeight { value: 700 },
-                            ]),
-                    ],
-                }],
-            },
+                children: vec![
+                    Fragment::leaf(PlainNode::Text(PlainTextNode { text: "x".into() }))
+                        .with_modifiers(vec![
+                            Modifier::FontFamily {
+                                value: "Pretendard".into(),
+                            },
+                            Modifier::Bold,
+                            Modifier::FontWeight { value: 700 },
+                        ]),
+                ],
+            }],
             open_start: 0,
             open_end: 0,
         };
@@ -472,7 +444,7 @@ mod tests {
         let body_start = html.find("<div data-root>").expect("root div present");
         let body_only = &html[body_start..];
         let parsed = Slice::from_html(body_only, &resource);
-        let text_frag = &parsed.fragment.children[0].children[0];
+        let text_frag = &parsed.content[0].children[0];
         let bold_count = text_frag
             .modifiers
             .iter()
@@ -505,7 +477,7 @@ mod tests {
         }]);
         let html = r#"<p><span style="font:italic bold 16px Arial">x</span></p>"#;
         let slice = Slice::from_html(html, &resource);
-        let t = find_text(&slice.fragment).unwrap();
+        let t = find_text(&slice).unwrap();
         assert!(t.modifiers.iter().any(|m| matches!(m, Modifier::Italic)));
         assert!(
             t.modifiers
@@ -525,7 +497,7 @@ mod tests {
         );
     }
 
-    fn find_text(root: &Fragment) -> Option<&Fragment> {
+    fn find_text(slice: &Slice) -> Option<&Fragment> {
         fn rec(f: &Fragment) -> Option<&Fragment> {
             if matches!(f.node, PlainNode::Text(_)) {
                 return Some(f);
@@ -537,7 +509,7 @@ mod tests {
             }
             None
         }
-        rec(root)
+        slice.content.iter().find_map(rec)
     }
 
     #[test]
@@ -546,7 +518,7 @@ mod tests {
             r#"<div style="color:red"><p>x</p></div>"#,
             &Resource::new_test(),
         );
-        let t = find_text(&s.fragment).unwrap();
+        let t = find_text(&s).unwrap();
         assert!(
             t.modifiers
                 .iter()
@@ -560,7 +532,7 @@ mod tests {
             r#"<div style="color:red"><p style="color:blue">x</p></div>"#,
             &Resource::new_test(),
         );
-        let t = find_text(&s.fragment).unwrap();
+        let t = find_text(&s).unwrap();
         assert!(
             t.modifiers
                 .iter()
@@ -579,7 +551,7 @@ mod tests {
             r#"<div style="background:yellow"><p>x</p></div>"#,
             &Resource::new_test(),
         );
-        let t = find_text(&s.fragment).unwrap();
+        let t = find_text(&s).unwrap();
         assert!(
             t.modifiers
                 .iter()
@@ -593,7 +565,7 @@ mod tests {
             r#"<style>.a { color: red; }</style><div class="a"><p>x</p></div>"#,
             &Resource::new_test(),
         );
-        let t = find_text(&s.fragment).unwrap();
+        let t = find_text(&s).unwrap();
         assert!(
             t.modifiers
                 .iter()
@@ -607,7 +579,7 @@ mod tests {
             r#"<style>p { color: red; }</style><p style="color:blue">x</p>"#,
             &Resource::new_test(),
         );
-        let t = find_text(&s.fragment).unwrap();
+        let t = find_text(&s).unwrap();
         assert!(
             t.modifiers
                 .iter()
@@ -621,7 +593,7 @@ mod tests {
             r#"<style>p { color: blue; } .c { color: red; }</style><p class="c">x</p>"#,
             &Resource::new_test(),
         );
-        let t = find_text(&s.fragment).unwrap();
+        let t = find_text(&s).unwrap();
         assert!(
             t.modifiers
                 .iter()
@@ -635,7 +607,7 @@ mod tests {
             r#"<a href="https://a.com"><span>nested</span></a>"#,
             &Resource::new_test(),
         );
-        let t = find_text(&s.fragment).unwrap();
+        let t = find_text(&s).unwrap();
         assert!(
             t.modifiers
                 .iter()
@@ -649,7 +621,7 @@ mod tests {
             r#"<p><a href="https://a.com">a</a><span>b</span></p>"#,
             &Resource::new_test(),
         );
-        let p = &s.fragment.children[0];
+        let p = &s.content[0];
         let mut ta: Option<&Fragment> = None;
         let mut tb: Option<&Fragment> = None;
         fn collect<'a>(
@@ -700,14 +672,14 @@ mod tests {
             }
             None
         }
-        let p = find_block(&s.fragment).unwrap();
+        let p = s.content.iter().find_map(find_block).unwrap();
         assert!(p.modifiers.iter().any(|m| matches!(
             m,
             Modifier::Alignment {
                 value: editor_model::Alignment::Center
             }
         )));
-        let t = find_text(&s.fragment).unwrap();
+        let t = find_text(&s).unwrap();
         assert!(
             !t.modifiers
                 .iter()
@@ -721,7 +693,7 @@ mod tests {
             r#"<p style="color:red !important">x</p>"#,
             &Resource::new_test(),
         );
-        let t = find_text(&s.fragment).unwrap();
+        let t = find_text(&s).unwrap();
         assert!(
             !t.modifiers
                 .iter()
@@ -735,7 +707,7 @@ mod tests {
             r#"<style>p { color: red !important; }</style><p>x</p>"#,
             &Resource::new_test(),
         );
-        let t = find_text(&s.fragment).unwrap();
+        let t = find_text(&s).unwrap();
         assert!(
             !t.modifiers
                 .iter()
@@ -746,7 +718,7 @@ mod tests {
     #[test]
     fn orphan_tr_wraps() {
         let s = Slice::from_html("<tr><td>a</td></tr>", &Resource::new_test());
-        assert!(matches!(s.fragment.children[0].node, PlainNode::Table(_)));
+        assert!(matches!(s.content[0].node, PlainNode::Table(_)));
     }
 
     fn register_test_family(resource: &mut Resource, name: &str) {
@@ -765,7 +737,7 @@ mod tests {
         let resource = Resource::new_test();
         let html = r#"<p><span style="color:rgb(192,0,0)">red text</span></p>"#;
         let slice = Slice::from_html(html, &resource);
-        let t = find_text(&slice.fragment).unwrap();
+        let t = find_text(&slice).unwrap();
         assert!(
             t.modifiers
                 .iter()
@@ -780,7 +752,7 @@ mod tests {
         register_test_family(&mut resource, "Pretendard");
         let html = r#"<p><span style="font-family:'Arial', Pretendard, sans-serif">x</span></p>"#;
         let slice = Slice::from_html(html, &resource);
-        let t = find_text(&slice.fragment).unwrap();
+        let t = find_text(&slice).unwrap();
         assert!(
             t.modifiers
                 .iter()
@@ -794,7 +766,7 @@ mod tests {
         let resource = Resource::new_test();
         let html = r#"<p><span style="font-family:Calibri">x</span></p>"#;
         let slice = Slice::from_html(html, &resource);
-        let t = find_text(&slice.fragment).unwrap();
+        let t = find_text(&slice).unwrap();
         assert!(
             !t.modifiers
                 .iter()
@@ -822,7 +794,7 @@ mod tests {
         }]);
         let html = r#"<p><span style="font-family:Pretendard;font-weight:350">x</span></p>"#;
         let slice = Slice::from_html(html, &resource);
-        let t = find_text(&slice.fragment).unwrap();
+        let t = find_text(&slice).unwrap();
         assert!(
             t.modifiers
                 .iter()
@@ -836,7 +808,7 @@ mod tests {
         let resource = Resource::new_test();
         let html = r#"<p><span style="font-size:16px">x</span></p>"#;
         let slice = Slice::from_html(html, &resource);
-        let t = find_text(&slice.fragment).unwrap();
+        let t = find_text(&slice).unwrap();
         assert!(
             t.modifiers
                 .iter()
@@ -850,7 +822,7 @@ mod tests {
         let resource = Resource::new_test();
         let html = r#"<p><span style="font-size:1.5rem">x</span></p>"#;
         let slice = Slice::from_html(html, &resource);
-        let t = find_text(&slice.fragment).unwrap();
+        let t = find_text(&slice).unwrap();
         assert!(
             t.modifiers
                 .iter()
@@ -865,7 +837,7 @@ mod tests {
         resource.theme.set_variant(ThemeVariant::DarkBlack);
         let html = r#"<p><span style="color:#ffffff">x</span></p>"#;
         let slice = Slice::from_html(html, &resource);
-        let t = find_text(&slice.fragment).unwrap();
+        let t = find_text(&slice).unwrap();
         let key = t
             .modifiers
             .iter()
@@ -885,7 +857,7 @@ mod tests {
         let resource = Resource::new_test();
         let html = r#"<p><span style="background-color:transparent">x</span></p>"#;
         let slice = Slice::from_html(html, &resource);
-        let t = find_text(&slice.fragment).unwrap();
+        let t = find_text(&slice).unwrap();
         assert!(
             t.modifiers
                 .iter()
@@ -899,7 +871,7 @@ mod tests {
         let resource = Resource::new_test();
         let html = r#"<p><span style="letter-spacing:normal">x</span></p>"#;
         let slice = Slice::from_html(html, &resource);
-        let t = find_text(&slice.fragment).unwrap();
+        let t = find_text(&slice).unwrap();
         assert!(
             t.modifiers
                 .iter()
@@ -913,7 +885,7 @@ mod tests {
         let resource = Resource::new_test();
         let html = r#"<p><span style="letter-spacing:0.07em">x</span></p>"#;
         let slice = Slice::from_html(html, &resource);
-        let t = find_text(&slice.fragment).unwrap();
+        let t = find_text(&slice).unwrap();
         assert!(
             t.modifiers
                 .iter()
@@ -941,7 +913,7 @@ mod tests {
         }]);
         let html = r#"<p><span style="font-family:Pretendard"><strong>x</strong></span></p>"#;
         let slice = Slice::from_html(html, &resource);
-        let t = find_text(&slice.fragment).unwrap();
+        let t = find_text(&slice).unwrap();
         let bold_count = t
             .modifiers
             .iter()
@@ -971,7 +943,7 @@ mod tests {
         }]);
         let html = r#"<p><span style="font-family:Pretendard"><strong>x</strong></span></p>"#;
         let slice = Slice::from_html(html, &resource);
-        let t = find_text(&slice.fragment).unwrap();
+        let t = find_text(&slice).unwrap();
         let bold_count = t
             .modifiers
             .iter()
@@ -996,7 +968,7 @@ mod tests {
         let resource = Resource::new_test();
         let html = r#"<p><strong>x</strong></p>"#;
         let slice = Slice::from_html(html, &resource);
-        let t = find_text(&slice.fragment).unwrap();
+        let t = find_text(&slice).unwrap();
         assert!(t.modifiers.iter().any(|m| matches!(m, Modifier::Bold)));
         assert!(
             !t.modifiers
@@ -1024,7 +996,7 @@ mod tests {
         }]);
         let html = r#"<p><span style="font-family:Pretendard;font-weight:800">x</span></p>"#;
         let slice = Slice::from_html(html, &resource);
-        let t = find_text(&slice.fragment).unwrap();
+        let t = find_text(&slice).unwrap();
         assert!(
             t.modifiers
                 .iter()
@@ -1056,7 +1028,7 @@ mod tests {
         }]);
         let html = r#"<p><span style="font-family:Pretendard;font-weight:900">x</span></p>"#;
         let slice = Slice::from_html(html, &resource);
-        let t = find_text(&slice.fragment).unwrap();
+        let t = find_text(&slice).unwrap();
         assert!(
             t.modifiers
                 .iter()
@@ -1084,7 +1056,7 @@ mod tests {
         }]);
         let html = r#"<p><span style="font-family:Pretendard;font-weight:600">x</span></p>"#;
         let slice = Slice::from_html(html, &resource);
-        let t = find_text(&slice.fragment).unwrap();
+        let t = find_text(&slice).unwrap();
         assert!(
             t.modifiers
                 .iter()
@@ -1112,7 +1084,7 @@ mod tests {
         }]);
         let html = r#"<p><span style="font-family:Pretendard;font-weight:300">x</span></p>"#;
         let slice = Slice::from_html(html, &resource);
-        let t = find_text(&slice.fragment).unwrap();
+        let t = find_text(&slice).unwrap();
         assert!(
             t.modifiers
                 .iter()
@@ -1126,7 +1098,7 @@ mod tests {
         let resource = Resource::new_test();
         let html = r#"<p><span style="font-family:Calibri;font-weight:800">x</span></p>"#;
         let slice = Slice::from_html(html, &resource);
-        let t = find_text(&slice.fragment).unwrap();
+        let t = find_text(&slice).unwrap();
         assert!(
             t.modifiers
                 .iter()
@@ -1144,7 +1116,7 @@ mod tests {
         let resource = Resource::new_test();
         let html = r#"<p><span style="font-family:Calibri;font-weight:300">x</span></p>"#;
         let slice = Slice::from_html(html, &resource);
-        let t = find_text(&slice.fragment).unwrap();
+        let t = find_text(&slice).unwrap();
         assert!(
             t.modifiers
                 .iter()
@@ -1167,7 +1139,7 @@ mod tests {
         }]);
         let html = r#"<p><span style="font-family:Pretendard"><strong><span style="font-weight:normal">x</span></strong></span></p>"#;
         let slice = Slice::from_html(html, &resource);
-        let t = find_text(&slice.fragment).unwrap();
+        let t = find_text(&slice).unwrap();
         assert!(
             t.modifiers
                 .iter()
@@ -1193,7 +1165,7 @@ mod tests {
         }]);
         let html = r#"<p><span style="font-family:Pretendard"><strong><span style="font-family:Calibri;font-weight:normal">x</span></strong></span></p>"#;
         let slice = Slice::from_html(html, &resource);
-        let t = find_text(&slice.fragment).unwrap();
+        let t = find_text(&slice).unwrap();
         assert!(
             t.modifiers
                 .iter()
@@ -1225,7 +1197,7 @@ mod tests {
         }]);
         let html = r#"<p><span style="font-family:Pretendard"><strong style="font-weight:400">x</strong></span></p>"#;
         let slice = Slice::from_html(html, &resource);
-        let t = find_text(&slice.fragment).unwrap();
+        let t = find_text(&slice).unwrap();
         assert!(
             t.modifiers
                 .iter()
@@ -1253,7 +1225,7 @@ mod tests {
         }]);
         let html = r#"<p><span style="font-family:Pretendard"><span style="font-weight:bolder">x</span></span></p>"#;
         let slice = Slice::from_html(html, &resource);
-        let t = find_text(&slice.fragment).unwrap();
+        let t = find_text(&slice).unwrap();
         assert!(
             t.modifiers
                 .iter()
@@ -1285,7 +1257,7 @@ mod tests {
         }]);
         let html = r#"<p><span style="font-family:Pretendard;font-weight:700"><span style="font-weight:lighter">x</span></span></p>"#;
         let slice = Slice::from_html(html, &resource);
-        let t = find_text(&slice.fragment).unwrap();
+        let t = find_text(&slice).unwrap();
         assert!(
             t.modifiers
                 .iter()
@@ -1327,7 +1299,7 @@ mod tests {
         ]);
         let html = r#"<p><span style="font-family:OnlyLight"><strong><span style="font-family:Heavy;font-weight:bolder">x</span></strong></span></p>"#;
         let slice = Slice::from_html(html, &resource);
-        let t = find_text(&slice.fragment).unwrap();
+        let t = find_text(&slice).unwrap();
         assert!(
             t.modifiers
                 .iter()
@@ -1362,7 +1334,7 @@ mod tests {
             matches!(f.node, editor_model::PlainNode::Tab(_)) || f.children.iter().any(has_tab)
         }
         assert!(
-            has_tab(&parsed.fragment),
+            parsed.content.iter().any(has_tab),
             "parsed HTML must contain a Tab node"
         );
     }

--- a/crates/editor-clipboard/src/html/serialize.rs
+++ b/crates/editor-clipboard/src/html/serialize.rs
@@ -13,8 +13,8 @@ pub fn to_html(slice: &Slice, resource: &Resource) -> String {
         r#"<meta data-slice-v2="{meta_b64}" data-version="1">"#,
     ));
     out.push_str("<div data-root>");
-    for child in &slice.fragment.children {
-        serialize_node(child, resource, &mut out);
+    for fragment in &slice.content {
+        serialize_node(fragment, resource, &mut out);
     }
     out.push_str("</div>");
     out
@@ -238,17 +238,13 @@ mod tests {
     use editor_crdt::Dot;
     use editor_macros::state;
     use editor_model::{
-        Fragment, Modifier, NodeType, PlainNode, PlainParagraphNode, PlainRootNode, PlainTextNode,
+        Fragment, Modifier, NodeType, PlainNode, PlainParagraphNode, PlainTextNode,
     };
     use editor_state::{Position, Selection};
 
     #[test]
     fn serialize_empty_slice_with_meta() {
-        let slice = Slice {
-            fragment: Fragment::leaf(PlainNode::Root(PlainRootNode::default())),
-            open_start: 0,
-            open_end: 0,
-        };
+        let slice = Slice::new(vec![], 0, 0);
         let html = to_html(&slice, &Resource::new_test());
         assert!(html.contains("data-slice-v2="));
         assert!(html.contains("data-version=\"1\""));
@@ -281,22 +277,17 @@ mod tests {
     #[test]
     fn serialize_text_with_bold_and_italic() {
         let slice = Slice {
-            fragment: Fragment {
-                node: PlainNode::Root(PlainRootNode::default()),
+            content: vec![Fragment {
+                node: PlainNode::Paragraph(PlainParagraphNode::default()),
                 modifiers: vec![],
                 carry: vec![],
-                children: vec![Fragment {
-                    node: PlainNode::Paragraph(PlainParagraphNode::default()),
-                    modifiers: vec![],
-                    carry: vec![],
-                    children: vec![
-                        Fragment::leaf(PlainNode::Text(PlainTextNode {
-                            text: "bold italic".into(),
-                        }))
-                        .with_modifiers(vec![Modifier::Bold, Modifier::Italic]),
-                    ],
-                }],
-            },
+                children: vec![
+                    Fragment::leaf(PlainNode::Text(PlainTextNode {
+                        text: "bold italic".into(),
+                    }))
+                    .with_modifiers(vec![Modifier::Bold, Modifier::Italic]),
+                ],
+            }],
             open_start: 0,
             open_end: 0,
         };
@@ -307,27 +298,22 @@ mod tests {
     #[test]
     fn serialize_text_with_style_modifiers() {
         let slice = Slice {
-            fragment: Fragment {
-                node: PlainNode::Root(PlainRootNode::default()),
+            content: vec![Fragment {
+                node: PlainNode::Paragraph(PlainParagraphNode::default()),
                 modifiers: vec![],
                 carry: vec![],
-                children: vec![Fragment {
-                    node: PlainNode::Paragraph(PlainParagraphNode::default()),
-                    modifiers: vec![],
-                    carry: vec![],
-                    children: vec![
-                        Fragment::leaf(PlainNode::Text(PlainTextNode {
-                            text: "styled".into(),
-                        }))
-                        .with_modifiers(vec![
-                            Modifier::FontSize { value: 1600 },
-                            Modifier::TextColor {
-                                value: "#ff0000".into(),
-                            },
-                        ]),
-                    ],
-                }],
-            },
+                children: vec![
+                    Fragment::leaf(PlainNode::Text(PlainTextNode {
+                        text: "styled".into(),
+                    }))
+                    .with_modifiers(vec![
+                        Modifier::FontSize { value: 1600 },
+                        Modifier::TextColor {
+                            value: "#ff0000".into(),
+                        },
+                    ]),
+                ],
+            }],
             open_start: 0,
             open_end: 0,
         };
@@ -341,29 +327,24 @@ mod tests {
     #[test]
     fn serialize_palette_keys_resolve_to_theme_hex() {
         let slice = Slice {
-            fragment: Fragment {
-                node: PlainNode::Root(PlainRootNode::default()),
+            content: vec![Fragment {
+                node: PlainNode::Paragraph(PlainParagraphNode::default()),
                 modifiers: vec![],
                 carry: vec![],
-                children: vec![Fragment {
-                    node: PlainNode::Paragraph(PlainParagraphNode::default()),
-                    modifiers: vec![],
-                    carry: vec![],
-                    children: vec![
-                        Fragment::leaf(PlainNode::Text(PlainTextNode {
-                            text: "colored".into(),
-                        }))
-                        .with_modifiers(vec![
-                            Modifier::TextColor {
-                                value: "red".into(),
-                            },
-                            Modifier::BackgroundColor {
-                                value: "yellow".into(),
-                            },
-                        ]),
-                    ],
-                }],
-            },
+                children: vec![
+                    Fragment::leaf(PlainNode::Text(PlainTextNode {
+                        text: "colored".into(),
+                    }))
+                    .with_modifiers(vec![
+                        Modifier::TextColor {
+                            value: "red".into(),
+                        },
+                        Modifier::BackgroundColor {
+                            value: "yellow".into(),
+                        },
+                    ]),
+                ],
+            }],
             open_start: 0,
             open_end: 0,
         };
@@ -377,26 +358,19 @@ mod tests {
     #[test]
     fn serialize_background_none_resolves_to_transparent() {
         let slice = Slice {
-            fragment: Fragment {
-                node: PlainNode::Root(PlainRootNode::default()),
+            content: vec![Fragment {
+                node: PlainNode::Paragraph(PlainParagraphNode::default()),
                 modifiers: vec![],
                 carry: vec![],
-                children: vec![Fragment {
-                    node: PlainNode::Paragraph(PlainParagraphNode::default()),
-                    modifiers: vec![],
-                    carry: vec![],
-                    children: vec![
-                        Fragment::leaf(PlainNode::Text(PlainTextNode {
-                            text: "plain".into(),
-                        }))
-                        .with_modifiers(vec![
-                            Modifier::BackgroundColor {
-                                value: "none".into(),
-                            },
-                        ]),
-                    ],
-                }],
-            },
+                children: vec![
+                    Fragment::leaf(PlainNode::Text(PlainTextNode {
+                        text: "plain".into(),
+                    }))
+                    .with_modifiers(vec![Modifier::BackgroundColor {
+                        value: "none".into(),
+                    }]),
+                ],
+            }],
             open_start: 0,
             open_end: 0,
         };
@@ -410,24 +384,19 @@ mod tests {
     #[test]
     fn serialize_text_with_link() {
         let slice = Slice {
-            fragment: Fragment {
-                node: PlainNode::Root(PlainRootNode::default()),
+            content: vec![Fragment {
+                node: PlainNode::Paragraph(PlainParagraphNode::default()),
                 modifiers: vec![],
                 carry: vec![],
-                children: vec![Fragment {
-                    node: PlainNode::Paragraph(PlainParagraphNode::default()),
-                    modifiers: vec![],
-                    carry: vec![],
-                    children: vec![
-                        Fragment::leaf(PlainNode::Text(PlainTextNode {
-                            text: "click".into(),
-                        }))
-                        .with_modifiers(vec![Modifier::Link {
-                            href: "https://example.com".into(),
-                        }]),
-                    ],
-                }],
-            },
+                children: vec![
+                    Fragment::leaf(PlainNode::Text(PlainTextNode {
+                        text: "click".into(),
+                    }))
+                    .with_modifiers(vec![Modifier::Link {
+                        href: "https://example.com".into(),
+                    }]),
+                ],
+            }],
             open_start: 0,
             open_end: 0,
         };

--- a/crates/editor-clipboard/src/slice.rs
+++ b/crates/editor-clipboard/src/slice.rs
@@ -2,8 +2,8 @@ use std::collections::BTreeMap;
 
 use editor_crdt::Dot;
 use editor_model::{
-    ChildView, DocView, Fragment, LeafView, Modifier, ModifierType, NodeView, OwnModifier,
-    PlainNode, PlainRootNode, PlainTextNode,
+    ChildView, DocView, Fragment, LeafView, Modifier, ModifierType, NodeType, NodeView,
+    OwnModifier, PlainNode, PlainTextNode,
 };
 use editor_resource::Resource;
 use editor_state::State;
@@ -17,11 +17,10 @@ use crate::text::parse as text_parse;
 use crate::text::serialize as text_serialize;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Slice {
-    pub fragment: Fragment,
-    #[serde(default)]
+    pub content: Vec<Fragment>,
     pub open_start: u32,
-    #[serde(default)]
     pub open_end: u32,
 }
 
@@ -49,11 +48,20 @@ impl Slice {
             (to_block_depth.saturating_sub(common_depth)) as u32 + to.is_inline_position() as u32;
 
         let fragment = build_fragment(state, &common_nv, &rs);
-        Some(Slice {
-            fragment,
-            open_start,
-            open_end,
-        })
+
+        if can_use_as_slice_roots(&fragment.children) {
+            Some(Slice::new(
+                fragment.children,
+                open_start.saturating_sub(1),
+                open_end.saturating_sub(1),
+            ))
+        } else {
+            Some(Slice::new(
+                vec![fragment],
+                open_start.max(1),
+                open_end.max(1),
+            ))
+        }
     }
 
     pub fn to_text(&self) -> String {
@@ -79,12 +87,24 @@ impl Slice {
         }
     }
 
+    pub fn new(content: Vec<Fragment>, open_start: u32, open_end: u32) -> Self {
+        if content.is_empty() {
+            Self {
+                content,
+                open_start: 0,
+                open_end: 0,
+            }
+        } else {
+            Self {
+                content,
+                open_start,
+                open_end,
+            }
+        }
+    }
+
     pub fn is_empty(&self) -> bool {
-        self.fragment.children.is_empty()
-            && !matches!(
-                self.fragment.node,
-                PlainNode::Text(_) | PlainNode::HardBreak(_) | PlainNode::Tab(_)
-            )
+        self.content.is_empty()
     }
 
     pub fn to_payload(&self, resource: &Resource) -> ClipboardPayload {
@@ -93,6 +113,19 @@ impl Slice {
             text: self.to_text(),
         }
     }
+}
+
+fn can_use_as_slice_roots(fragments: &[Fragment]) -> bool {
+    !fragments.is_empty()
+        && (fragments
+            .iter()
+            .all(|fragment| fragment.node.as_type().spec().inline)
+            || fragments.iter().all(|fragment| {
+                NodeType::Root
+                    .spec()
+                    .content
+                    .matches(fragment.node.as_type())
+            }))
 }
 
 fn common_ancestor(view: &DocView, rs: &ResolvedSelection) -> Option<Dot> {
@@ -261,11 +294,7 @@ fn build_fragment(state: &State, nv: &NodeView, rs: &ResolvedSelection) -> Fragm
 
 fn extract_cell_rect(state: &State, view: &DocView, rect: &CellRect) -> Slice {
     let Some(table) = view.node(rect.table_id()) else {
-        return Slice {
-            fragment: Fragment::leaf(PlainNode::Root(PlainRootNode::default())),
-            open_start: 0,
-            open_end: 0,
-        };
+        return Slice::new(vec![], 0, 0);
     };
     let mut rows: Vec<Fragment> = Vec::new();
     for r in rect.rows().clone() {
@@ -294,16 +323,7 @@ fn extract_cell_rect(state: &State, view: &DocView, rect: &CellRect) -> Slice {
         carry: vec![],
         children: rows,
     };
-    Slice {
-        fragment: Fragment {
-            node: PlainNode::Root(PlainRootNode::default()),
-            modifiers: vec![],
-            carry: vec![],
-            children: vec![table_frag],
-        },
-        open_start: 0,
-        open_end: 0,
-    }
+    Slice::new(vec![table_frag], 0, 0)
 }
 
 #[cfg(test)]
@@ -349,20 +369,16 @@ mod tests {
 
     #[test]
     fn is_empty_recognizes_bare_container() {
-        let slice = Slice {
-            fragment: Fragment::leaf(PlainNode::Root(PlainRootNode::default())),
-            open_start: 0,
-            open_end: 0,
-        };
+        let slice = Slice::new(vec![], 0, 0);
         assert!(slice.is_empty());
     }
 
     #[test]
     fn is_empty_keeps_text_leaf_non_empty() {
         let slice = Slice {
-            fragment: Fragment::leaf(PlainNode::Text(PlainTextNode {
+            content: vec![Fragment::leaf(PlainNode::Text(PlainTextNode {
                 text: "hello".into(),
-            })),
+            }))],
             open_start: 0,
             open_end: 0,
         };
@@ -372,7 +388,9 @@ mod tests {
     #[test]
     fn is_empty_keeps_tab_leaf_non_empty() {
         let slice = Slice {
-            fragment: Fragment::leaf(PlainNode::Tab(editor_model::PlainTabNode::default())),
+            content: vec![Fragment::leaf(PlainNode::Tab(
+                editor_model::PlainTabNode::default(),
+            ))],
             open_start: 0,
             open_end: 0,
         };
@@ -380,20 +398,16 @@ mod tests {
     }
 
     #[test]
-    fn extract_inline_within_single_textblock_wraps_in_open_textblock() {
-        // No more text-node identity: an inline selection within one textblock
-        // yields the (carved) textblock fragment with both edges open so paste
-        // merges the run inline.
+    fn extract_inline_within_single_textblock_is_bare_inline() {
         let (s, ..) = state! {
             doc { root { p1: paragraph { text("Hello World") } } }
             selection: (p1, 1) -> (p1, 4)
         };
         let slice = Slice::extract(&s).expect("non-collapsed");
-        assert_eq!(slice.open_start, 1);
-        assert_eq!(slice.open_end, 1);
-        assert!(matches!(slice.fragment.node, PlainNode::Paragraph(_)));
-        assert_eq!(slice.fragment.children.len(), 1);
-        if let editor_model::PlainNode::Text(t) = &slice.fragment.children[0].node {
+        assert_eq!(slice.open_start, 0);
+        assert_eq!(slice.open_end, 0);
+        assert_eq!(slice.content.len(), 1);
+        if let editor_model::PlainNode::Text(t) = &slice.content[0].node {
             assert_eq!(t.text, "ell");
         } else {
             panic!("expected text run child");
@@ -401,7 +415,33 @@ mod tests {
     }
 
     #[test]
-    fn extract_inline_within_fold_title_wraps_in_open_textblock() {
+    fn extract_all_inline_content_drops_source_block_context() {
+        let (state, ..) = state! {
+            doc { root {
+                p1: paragraph [alignment(editor_model::Alignment::Center)] carry([bold]) {
+                    text("Hello")
+                }
+            } }
+            selection: (p1, 0) -> (p1, 5)
+        };
+
+        let slice = Slice::extract(&state).expect("non-collapsed");
+
+        assert_eq!(slice.open_start, 0);
+        assert_eq!(slice.open_end, 0);
+        assert_eq!(slice.content.len(), 1);
+        assert!(matches!(slice.content[0].node, PlainNode::Text(_)));
+        assert!(slice.content[0].carry.is_empty());
+        assert!(
+            slice.content[0]
+                .modifiers
+                .iter()
+                .all(|modifier| !matches!(modifier, Modifier::Alignment { .. }))
+        );
+    }
+
+    #[test]
+    fn extract_inline_within_fold_title_is_bare_inline() {
         let (s, ..) = state! {
             doc { root { fold {
                 ft1: fold_title { text("Hello World") }
@@ -410,15 +450,66 @@ mod tests {
             selection: (ft1, 1) -> (ft1, 4)
         };
         let slice = Slice::extract(&s).expect("non-collapsed");
-        assert_eq!(slice.open_start, 1);
-        assert_eq!(slice.open_end, 1);
-        assert!(matches!(slice.fragment.node, PlainNode::FoldTitle(_)));
-        assert_eq!(slice.fragment.children.len(), 1);
-        if let editor_model::PlainNode::Text(t) = &slice.fragment.children[0].node {
+        assert_eq!(slice.open_start, 0);
+        assert_eq!(slice.open_end, 0);
+        assert_eq!(slice.content.len(), 1);
+        if let editor_model::PlainNode::Text(t) = &slice.content[0].node {
             assert_eq!(t.text, "ell");
         } else {
             panic!("expected text run child");
         }
+    }
+
+    #[test]
+    fn extract_closed_callout_child_does_not_include_fold_content_context() {
+        let (state, ..) = state! {
+            doc { root {
+                fold {
+                    fold_title { text("title") }
+                    content: fold_content {
+                        paragraph { text("inside") }
+                        callout { paragraph { text("moved") } }
+                    }
+                }
+                paragraph { text("after") }
+            } }
+            selection: (content, 1) -> (content, 2)
+        };
+
+        let slice = Slice::extract(&state).expect("non-collapsed");
+
+        assert_eq!(slice.open_start, 0);
+        assert_eq!(slice.open_end, 0);
+        assert_eq!(slice.content.len(), 1);
+        assert!(matches!(slice.content[0].node, PlainNode::Callout(_)));
+    }
+
+    #[test]
+    fn extract_portable_children_drops_non_root_common_context() {
+        let (state, ..) = state! {
+            doc { root {
+                fold {
+                    fold_title { text("title") }
+                    fold_content {
+                        p1: paragraph { text("first") }
+                        p2: paragraph { text("second") }
+                    }
+                }
+            } }
+            selection: (p1, 2) -> (p2, 3)
+        };
+
+        let slice = Slice::extract(&state).expect("non-collapsed");
+
+        assert_eq!(slice.open_start, 1);
+        assert_eq!(slice.open_end, 1);
+        assert_eq!(slice.content.len(), 2);
+        assert!(
+            slice
+                .content
+                .iter()
+                .all(|fragment| matches!(fragment.node, PlainNode::Paragraph(_)))
+        );
     }
 
     #[test]
@@ -437,10 +528,35 @@ mod tests {
         assert_eq!(slice.open_start, 3);
         assert_eq!(slice.open_end, 3);
         assert!(matches!(
-            slice.fragment.node,
+            slice.content[0].node,
             editor_model::PlainNode::BulletList(_)
         ));
-        assert_eq!(slice.fragment.children.len(), 2);
+        assert_eq!(slice.content[0].children.len(), 2);
+    }
+
+    #[test]
+    fn extract_complete_list_item_retains_open_list_context() {
+        let (state, ..) = state! {
+            doc { root {
+                list: bullet_list {
+                    list_item { paragraph { text("first") } }
+                    list_item { paragraph { text("second") } }
+                }
+            } }
+            selection: (list, 0) -> (list, 1)
+        };
+
+        let slice = Slice::extract(&state).expect("non-collapsed");
+
+        assert_eq!(slice.open_start, 1);
+        assert_eq!(slice.open_end, 1);
+        assert_eq!(slice.content.len(), 1);
+        assert!(matches!(slice.content[0].node, PlainNode::BulletList(_)));
+        assert_eq!(slice.content[0].children.len(), 1);
+        assert!(matches!(
+            slice.content[0].children[0].node,
+            PlainNode::ListItem(_)
+        ));
     }
 
     #[test]
@@ -459,13 +575,9 @@ mod tests {
         let slice = Slice::extract(&s).expect("non-collapsed");
         assert_eq!(slice.open_start, 0);
         assert_eq!(slice.open_end, 0);
+        assert_eq!(slice.content.len(), 1);
         assert!(matches!(
-            slice.fragment.node,
-            editor_model::PlainNode::Root(_)
-        ));
-        assert_eq!(slice.fragment.children.len(), 1);
-        assert!(matches!(
-            slice.fragment.children[0].node,
+            slice.content[0].node,
             editor_model::PlainNode::Image(_)
         ));
     }
@@ -483,22 +595,12 @@ mod tests {
         };
         let slice = Slice::extract(&s).expect("non-collapsed");
 
-        assert_eq!(slice.open_start, 2);
-        assert_eq!(slice.open_end, 2);
-        assert!(matches!(slice.fragment.node, PlainNode::Root(_)));
-        assert_eq!(slice.fragment.children.len(), 3);
-        assert!(matches!(
-            slice.fragment.children[0].node,
-            PlainNode::Paragraph(_)
-        ));
-        assert!(matches!(
-            slice.fragment.children[1].node,
-            PlainNode::Image(_)
-        ));
-        assert!(matches!(
-            slice.fragment.children[2].node,
-            PlainNode::Paragraph(_)
-        ));
+        assert_eq!(slice.open_start, 1);
+        assert_eq!(slice.open_end, 1);
+        assert_eq!(slice.content.len(), 3);
+        assert!(matches!(slice.content[0].node, PlainNode::Paragraph(_)));
+        assert!(matches!(slice.content[1].node, PlainNode::Image(_)));
+        assert!(matches!(slice.content[2].node, PlainNode::Paragraph(_)));
     }
 
     #[test]
@@ -513,15 +615,15 @@ mod tests {
             selection: (root, 0) -> (root, 1)
         };
         let slice = Slice::extract(&s).expect("non-collapsed");
-        assert_eq!(slice.fragment.children.len(), 1);
-        let PlainNode::Callout(plain) = &slice.fragment.children[0].node else {
+        assert_eq!(slice.content.len(), 1);
+        let PlainNode::Callout(plain) = &slice.content[0].node else {
             panic!("expected callout fragment");
         };
         assert_eq!(plain.variant, CalloutVariant::Warning);
     }
 
     #[test]
-    fn extract_across_paragraphs_open_two() {
+    fn extract_across_paragraphs_opens_edge_paragraphs() {
         let (s, ..) = state! {
             doc { root {
                 p1: paragraph { text("abc") }
@@ -530,13 +632,9 @@ mod tests {
             selection: (p1, 1) -> (p2, 2)
         };
         let slice = Slice::extract(&s).expect("non-collapsed");
-        assert_eq!(slice.open_start, 2);
-        assert_eq!(slice.open_end, 2);
-        assert!(matches!(
-            slice.fragment.node,
-            editor_model::PlainNode::Root(_)
-        ));
-        assert_eq!(slice.fragment.children.len(), 2);
+        assert_eq!(slice.open_start, 1);
+        assert_eq!(slice.open_end, 1);
+        assert_eq!(slice.content.len(), 2);
     }
 
     #[test]
@@ -549,12 +647,10 @@ mod tests {
             selection: (p1, 1) -> (p2, 0)
         };
         let slice = Slice::extract(&s).expect("non-collapsed");
-        assert!(matches!(slice.fragment.node, PlainNode::Root(_)));
-        assert_eq!(slice.fragment.children.len(), 2);
+        assert_eq!(slice.content.len(), 2);
         assert!(
             slice
-                .fragment
-                .children
+                .content
                 .iter()
                 .all(|child| matches!(child.node, PlainNode::Paragraph(_)))
         );
@@ -572,15 +668,15 @@ mod tests {
         };
         let slice = Slice::extract(&s).expect("non-collapsed");
 
-        assert_eq!(slice.fragment.children.len(), 2);
+        assert_eq!(slice.content.len(), 2);
         assert!(
-            slice.fragment.children[0]
+            slice.content[0]
                 .modifiers
                 .iter()
                 .any(|m| matches!(m, Modifier::Bold))
         );
         assert!(
-            slice.fragment.children[1]
+            slice.content[1]
                 .modifiers
                 .iter()
                 .any(|m| matches!(m, Modifier::Italic))
@@ -607,11 +703,10 @@ mod tests {
 
         let slice = Slice::extract(&s).expect("non-collapsed");
 
-        assert!(matches!(slice.fragment.node, PlainNode::Root(_)));
-        assert_eq!(slice.open_start, 2);
+        assert_eq!(slice.open_start, 1);
         assert_eq!(slice.open_end, 0);
-        assert_eq!(slice.fragment.children.len(), 1);
-        let paragraph = &slice.fragment.children[0];
+        assert_eq!(slice.content.len(), 1);
+        let paragraph = &slice.content[0];
         assert!(matches!(paragraph.node, PlainNode::Paragraph(_)));
         assert!(paragraph.children.is_empty());
     }
@@ -648,7 +743,7 @@ mod tests {
     #[test]
     fn from_payload_text_only() {
         let parsed = Slice::from_payload(None, "hello\n\nworld", &Resource::new_test());
-        assert_eq!(parsed.fragment.children.len(), 3);
+        assert_eq!(parsed.content.len(), 3);
     }
 
     #[test]
@@ -672,9 +767,8 @@ mod tests {
             ..state
         };
         let slice = Slice::extract(&state).expect("cell-rect must extract");
-        assert!(matches!(slice.fragment.node, PlainNode::Root(_)));
-        assert_eq!(slice.fragment.children.len(), 1);
-        let table = &slice.fragment.children[0];
+        assert_eq!(slice.content.len(), 1);
+        let table = &slice.content[0];
         assert!(matches!(table.node, PlainNode::Table(_)));
         assert_eq!(table.children.len(), 2);
         for row in &table.children {
@@ -704,7 +798,7 @@ mod tests {
             ..state
         };
         let slice = Slice::extract(&state).unwrap();
-        let table = &slice.fragment.children[0];
+        let table = &slice.content[0];
         assert_eq!(table.children.len(), 1);
         assert_eq!(table.children[0].children.len(), 2);
     }
@@ -724,9 +818,8 @@ mod tests {
             Position::new(para, 3),
         )));
         let slice = Slice::extract(&s).expect("non-collapsed");
-        let para = &slice.fragment;
-        let tab_frag = para
-            .children
+        let tab_frag = slice
+            .content
             .iter()
             .find(|c| matches!(c.node, PlainNode::Tab(_)))
             .expect("Tab must appear in extracted slice");
@@ -755,7 +848,7 @@ mod tests {
             ..state
         };
         let slice = Slice::extract(&state).unwrap();
-        let table = &slice.fragment.children[0];
+        let table = &slice.content[0];
         assert_eq!(table.children.len(), 1);
         assert_eq!(table.children[0].children.len(), 1);
     }
@@ -782,13 +875,21 @@ mod tests {
     #[test]
     fn extract_closed_block_fills_carry() {
         let (s, ..) = state! {
-            doc { r: root { p1: paragraph carry([bold]) { text("X") } } }
+            doc { r: root {
+                p1: paragraph [alignment(editor_model::Alignment::Center)] carry([bold]) {
+                    text("X")
+                }
+            } }
             selection: (r, 0, >) -> (r, 1, <)
         };
         let slice = Slice::extract(&s).expect("non-collapsed");
-        assert!(matches!(slice.fragment.node, PlainNode::Root(_)));
-        let para = &slice.fragment.children[0];
+        let para = &slice.content[0];
         assert!(matches!(para.node, PlainNode::Paragraph(_)));
+        assert!(
+            para.modifiers
+                .iter()
+                .any(|modifier| matches!(modifier, Modifier::Alignment { .. }))
+        );
         assert!(
             para.carry.iter().any(|m| matches!(m, Modifier::Bold)),
             "a fully-contained block carries its carry modifiers into the fragment, got {:?}",
@@ -803,25 +904,27 @@ mod tests {
             selection: (p1, 1) -> (p1, 3)
         };
         let slice = Slice::extract(&s).expect("non-collapsed");
-        assert!(matches!(slice.fragment.node, PlainNode::Paragraph(_)));
         assert!(
-            slice.fragment.carry.is_empty(),
-            "an open (partial) block fragment discards carry, got {:?}",
-            slice.fragment.carry
+            slice
+                .content
+                .iter()
+                .all(|fragment| fragment.carry.is_empty()),
+            "bare inline fragments discard source block carry, got {:?}",
+            slice.content
         );
     }
 
     #[test]
     fn slice_without_carry_round_trips_and_defaults_empty() {
         let slice = Slice {
-            fragment: Fragment {
+            content: vec![Fragment {
                 node: PlainNode::Paragraph(editor_model::PlainParagraphNode::default()),
                 modifiers: vec![],
                 carry: vec![],
                 children: vec![Fragment::leaf(PlainNode::Text(PlainTextNode {
                     text: "hi".into(),
                 }))],
-            },
+            }],
             open_start: 0,
             open_end: 0,
         };
@@ -845,7 +948,7 @@ mod tests {
 
         let resource = Resource::new_test();
         let parsed = Slice::from_payload(Some(&payload.html), &payload.text, &resource);
-        let para = &parsed.fragment.children[0];
+        let para = &parsed.content[0];
         assert!(
             para.carry.iter().any(|m| matches!(m, Modifier::Bold)),
             "carry survives the data-slice-v2 payload wire, got {:?}",

--- a/crates/editor-clipboard/src/text/parse.rs
+++ b/crates/editor-clipboard/src/text/parse.rs
@@ -1,6 +1,4 @@
-use editor_model::{
-    Fragment, PlainNode, PlainParagraphNode, PlainRootNode, PlainTabNode, PlainTextNode,
-};
+use editor_model::{Fragment, PlainNode, PlainParagraphNode, PlainTabNode, PlainTextNode};
 
 use crate::slice::Slice;
 
@@ -14,16 +12,7 @@ pub fn from_text(text: &str) -> Slice {
     };
     let open_depth = u32::from(!children.is_empty());
 
-    Slice {
-        fragment: Fragment {
-            node: PlainNode::Root(PlainRootNode::default()),
-            modifiers: vec![],
-            carry: vec![],
-            children,
-        },
-        open_start: open_depth,
-        open_end: open_depth,
-    }
+    Slice::new(children, open_depth, open_depth)
 }
 
 fn push_line_with_tabs(line: &str, inline: &mut Vec<Fragment>) {
@@ -57,9 +46,8 @@ mod tests {
     use super::*;
 
     fn only_paragraph(slice: &Slice) -> &Fragment {
-        assert!(matches!(slice.fragment.node, PlainNode::Root(_)));
-        assert_eq!(slice.fragment.children.len(), 1);
-        let paragraph = &slice.fragment.children[0];
+        assert_eq!(slice.content.len(), 1);
+        let paragraph = &slice.content[0];
         assert!(matches!(paragraph.node, PlainNode::Paragraph(_)));
         paragraph
     }
@@ -78,8 +66,7 @@ mod tests {
     #[test]
     fn from_text_empty_is_empty_slice() {
         let slice = from_text("");
-        assert!(matches!(slice.fragment.node, PlainNode::Root(_)));
-        assert!(slice.fragment.children.is_empty());
+        assert!(slice.content.is_empty());
         assert_eq!(slice.open_start, 0);
         assert_eq!(slice.open_end, 0);
     }
@@ -101,19 +88,19 @@ mod tests {
     #[test]
     fn from_text_multiple_lines_become_multiple_paragraphs() {
         let slice = Slice::from_text("a\nb\nc");
-        assert_eq!(slice.fragment.children.len(), 3);
-        assert_eq!(paragraph_text(&slice.fragment.children[0]), "a");
-        assert_eq!(paragraph_text(&slice.fragment.children[1]), "b");
-        assert_eq!(paragraph_text(&slice.fragment.children[2]), "c");
+        assert_eq!(slice.content.len(), 3);
+        assert_eq!(paragraph_text(&slice.content[0]), "a");
+        assert_eq!(paragraph_text(&slice.content[1]), "b");
+        assert_eq!(paragraph_text(&slice.content[2]), "c");
     }
 
     #[test]
     fn from_text_blank_line_becomes_empty_paragraph() {
         let slice = Slice::from_text("first\n\nsecond");
-        assert_eq!(slice.fragment.children.len(), 3);
-        assert_eq!(paragraph_text(&slice.fragment.children[0]), "first");
-        assert!(slice.fragment.children[1].children.is_empty());
-        assert_eq!(paragraph_text(&slice.fragment.children[2]), "second");
+        assert_eq!(slice.content.len(), 3);
+        assert_eq!(paragraph_text(&slice.content[0]), "first");
+        assert!(slice.content[1].children.is_empty());
+        assert_eq!(paragraph_text(&slice.content[2]), "second");
         assert_eq!(slice.open_start, 1);
         assert_eq!(slice.open_end, 1);
     }
@@ -121,11 +108,11 @@ mod tests {
     #[test]
     fn from_text_single_newline_splits_paragraph() {
         let slice = Slice::from_text("line1\nline2");
-        assert_eq!(slice.fragment.children.len(), 2);
-        assert_eq!(paragraph_text(&slice.fragment.children[0]), "line1");
-        assert_eq!(paragraph_text(&slice.fragment.children[1]), "line2");
+        assert_eq!(slice.content.len(), 2);
+        assert_eq!(paragraph_text(&slice.content[0]), "line1");
+        assert_eq!(paragraph_text(&slice.content[1]), "line2");
         assert!(
-            !slice.fragment.children.iter().any(|p| p
+            !slice.content.iter().any(|p| p
                 .children
                 .iter()
                 .any(|c| matches!(c.node, PlainNode::HardBreak(_)))),
@@ -149,24 +136,24 @@ mod tests {
     #[test]
     fn from_text_crlf_normalizes_to_lf() {
         let slice = Slice::from_text("a\r\nb");
-        assert_eq!(slice.fragment.children.len(), 2);
-        assert_eq!(paragraph_text(&slice.fragment.children[0]), "a");
-        assert_eq!(paragraph_text(&slice.fragment.children[1]), "b");
+        assert_eq!(slice.content.len(), 2);
+        assert_eq!(paragraph_text(&slice.content[0]), "a");
+        assert_eq!(paragraph_text(&slice.content[1]), "b");
     }
 
     #[test]
     fn from_text_crlf_double_splits_paragraph() {
         let slice = Slice::from_text("a\r\n\r\nb");
-        assert_eq!(slice.fragment.children.len(), 3);
-        assert!(slice.fragment.children[1].children.is_empty());
+        assert_eq!(slice.content.len(), 3);
+        assert!(slice.content[1].children.is_empty());
     }
 
     #[test]
     fn from_text_bare_cr_splits_paragraph() {
         let slice = Slice::from_text("a\rb");
-        assert_eq!(slice.fragment.children.len(), 2);
-        assert_eq!(paragraph_text(&slice.fragment.children[0]), "a");
-        assert_eq!(paragraph_text(&slice.fragment.children[1]), "b");
+        assert_eq!(slice.content.len(), 2);
+        assert_eq!(paragraph_text(&slice.content[0]), "a");
+        assert_eq!(paragraph_text(&slice.content[1]), "b");
     }
 
     #[test]

--- a/crates/editor-clipboard/src/text/serialize.rs
+++ b/crates/editor-clipboard/src/text/serialize.rs
@@ -4,7 +4,9 @@ use editor_model::{Fragment, PlainNode, Schema};
 pub fn to_text(slice: &Slice) -> String {
     let mut out = String::new();
     let mut context = TextContext::default();
-    walk(&slice.fragment, &mut out, &mut context);
+    for fragment in &slice.content {
+        walk(fragment, &mut out, &mut context);
+    }
     out
 }
 

--- a/crates/editor-commands/src/commands/fill_cell_rect_with_slice.rs
+++ b/crates/editor-commands/src/commands/fill_cell_rect_with_slice.rs
@@ -97,10 +97,7 @@ fn cell_plain_paint(tr: &Transaction, cell_id: Dot, pending: &PendingModifiers) 
 }
 
 fn slice_to_cell_blocks(slice: &Slice) -> Vec<Fragment> {
-    let top_children: Vec<&Fragment> = match &slice.fragment.node {
-        PlainNode::Root(_) => slice.fragment.children.iter().collect(),
-        _ => vec![&slice.fragment],
-    };
+    let top_children: Vec<&Fragment> = slice.content.iter().collect();
 
     let mut out: Vec<Fragment> = Vec::new();
     let mut inline_run: Vec<Fragment> = Vec::new();

--- a/crates/editor-commands/src/commands/insert_slice.rs
+++ b/crates/editor-commands/src/commands/insert_slice.rs
@@ -34,8 +34,8 @@ mod tests {
     use editor_crdt::Dot;
     use editor_macros::state;
     use editor_model::{
-        Alignment, ChildView, Fragment, Modifier, NodeType, PlainFoldTitleNode, PlainNode,
-        PlainParagraphNode, PlainRootNode, PlainTextNode,
+        Alignment, ChildView, Fragment, Modifier, NodeType, PlainNode, PlainParagraphNode,
+        PlainTextNode,
     };
     use editor_resource::Resource;
     use editor_state::{Position, Selection, State};
@@ -70,21 +70,16 @@ mod tests {
 
     fn root_with_paragraph(text: &str) -> Slice {
         Slice {
-            fragment: Fragment {
-                node: PlainNode::Root(PlainRootNode::default()),
+            content: vec![Fragment {
+                node: PlainNode::Paragraph(PlainParagraphNode::default()),
                 modifiers: vec![],
                 carry: vec![],
-                children: vec![Fragment {
-                    node: PlainNode::Paragraph(PlainParagraphNode::default()),
-                    modifiers: vec![],
-                    carry: vec![],
-                    children: vec![Fragment::leaf(PlainNode::Text(PlainTextNode {
-                        text: text.into(),
-                    }))],
-                }],
-            },
-            open_start: 2,
-            open_end: 2,
+                children: vec![Fragment::leaf(PlainNode::Text(PlainTextNode {
+                    text: text.into(),
+                }))],
+            }],
+            open_start: 1,
+            open_end: 1,
         }
     }
 
@@ -101,16 +96,14 @@ mod tests {
 
     fn open_fold_title_slice(text: &str) -> Slice {
         Slice {
-            fragment: Fragment {
-                node: PlainNode::FoldTitle(PlainFoldTitleNode::default()),
+            content: vec![Fragment {
+                node: PlainNode::Text(PlainTextNode { text: text.into() }),
                 modifiers: vec![],
                 carry: vec![],
-                children: vec![Fragment::leaf(PlainNode::Text(PlainTextNode {
-                    text: text.into(),
-                }))],
-            },
-            open_start: 1,
-            open_end: 1,
+                children: vec![],
+            }],
+            open_start: 0,
+            open_end: 0,
         }
     }
 
@@ -120,11 +113,7 @@ mod tests {
             doc { root { p1: paragraph { text("Hello") } } }
             selection: (p1, 2)
         };
-        let empty = Slice {
-            fragment: Fragment::leaf(PlainNode::Root(PlainRootNode::default())),
-            open_start: 0,
-            open_end: 0,
-        };
+        let empty = Slice::new(vec![], 0, 0);
         let (actual, ..) = transact_fail!(initial.clone(), |tr| insert_slice(
             &mut tr,
             empty,
@@ -165,12 +154,7 @@ mod tests {
             children: vec![],
         };
         let slice = Slice {
-            fragment: Fragment {
-                node: PlainNode::Root(PlainRootNode::default()),
-                modifiers: vec![],
-                carry: vec![],
-                children: vec![empty_paragraph(), empty_paragraph()],
-            },
+            content: vec![empty_paragraph(), empty_paragraph()],
             open_start: 1,
             open_end: 1,
         };
@@ -216,9 +200,46 @@ mod tests {
     }
 
     #[test]
+    fn insert_bare_inline_at_block_boundary_materializes_default_paragraph() {
+        let (source, ..) = state! {
+            doc { root {
+                source: paragraph [alignment(Alignment::Right)] carry([italic]) {
+                    text("XY") [bold]
+                }
+            } }
+            selection: (source, 0) -> (source, 2)
+        };
+        let slice = Slice::extract(&source).expect("non-collapsed");
+        assert!(
+            slice
+                .content
+                .iter()
+                .all(|fragment| fragment.carry.is_empty())
+        );
+
+        let (initial, ..) = state! {
+            doc { root: root { paragraph { text("Z") } } }
+            selection: (root, 1, >)
+        };
+        let (actual, ..) = transact!(initial, |tr| insert_slice(
+            &mut tr,
+            slice,
+            SliceProvenance::Formatted
+        ));
+        let (expected, ..) = state! {
+            doc { root {
+                paragraph { text("Z") }
+                inserted: paragraph { text("XY") [bold] }
+            } }
+            selection: (inserted, 2)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
     fn insert_open_paragraph_text_into_fold_title_uses_open_inline_content() {
         let (source, ..) = state! {
-            doc { root { p1: paragraph { text("body") } } }
+            doc { root { p1: paragraph { text("body") [bold] } } }
             selection: (p1, 0) -> (p1, 4)
         };
         let slice = Slice::extract(&source).expect("non-collapsed");
@@ -246,6 +267,34 @@ mod tests {
     }
 
     #[test]
+    fn insert_plain_text_slice_into_fold_title_opens_paragraph_context() {
+        let slice = Slice::from_text("body");
+        assert_eq!((slice.open_start, slice.open_end), (1, 1));
+        assert!(matches!(slice.content[0].node, PlainNode::Paragraph(_)));
+
+        let (initial, ..) = state! {
+            doc { root { fold {
+                ft: fold_title { text("title") }
+                fold_content { paragraph {} }
+            } } }
+            selection: (ft, 5)
+        };
+        let (actual, ..) = transact!(initial, |tr| insert_slice(
+            &mut tr,
+            slice,
+            SliceProvenance::Formatted
+        ));
+        let (expected, ..) = state! {
+            doc { root { fold {
+                ft: fold_title { text("titlebody") }
+                fold_content { paragraph {} }
+            } } }
+            selection: (ft, 9)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
     fn insert_open_fold_title_text_into_paragraph_uses_open_inline_content() {
         let (initial, ..) = state! {
             doc { root { p: paragraph {} } }
@@ -264,6 +313,34 @@ mod tests {
     }
 
     #[test]
+    fn open_edge_inline_fallback_does_not_flatten_closed_middle_textblock() {
+        let (initial, ..) = state! {
+            doc { root { fold {
+                ft: fold_title { text("title") }
+                fold_content { paragraph {} }
+            } } }
+            selection: (ft, 5)
+        };
+        let slice = Slice {
+            content: vec![
+                paragraph_fragment("A"),
+                paragraph_fragment("M"),
+                paragraph_fragment("B"),
+            ],
+            open_start: 1,
+            open_end: 1,
+        };
+
+        let (actual, ..) = transact_fail!(initial.clone(), |tr| insert_slice(
+            &mut tr,
+            slice,
+            SliceProvenance::Formatted
+        ));
+
+        assert_state_eq!(&actual, &initial);
+    }
+
+    #[test]
     fn insert_block_slice_into_paragraph_preserves_block_structure() {
         use editor_model::{PlainBulletListNode, PlainListItemNode};
         let (initial, ..) = state! {
@@ -271,22 +348,17 @@ mod tests {
             selection: (p1, 5)
         };
         let slice = Slice {
-            fragment: Fragment {
-                node: PlainNode::Root(PlainRootNode::default()),
+            content: vec![Fragment {
+                node: PlainNode::BulletList(PlainBulletListNode::default()),
                 modifiers: vec![],
                 carry: vec![],
                 children: vec![Fragment {
-                    node: PlainNode::BulletList(PlainBulletListNode::default()),
+                    node: PlainNode::ListItem(PlainListItemNode::default()),
                     modifiers: vec![],
                     carry: vec![],
-                    children: vec![Fragment {
-                        node: PlainNode::ListItem(PlainListItemNode::default()),
-                        modifiers: vec![],
-                        carry: vec![],
-                        children: vec![paragraph_fragment("X")],
-                    }],
+                    children: vec![paragraph_fragment("X")],
                 }],
-            },
+            }],
             open_start: 0,
             open_end: 0,
         };
@@ -369,12 +441,7 @@ mod tests {
             selection: (r, 1, >)
         };
         let slice = Slice {
-            fragment: Fragment {
-                node: PlainNode::Root(PlainRootNode::default()),
-                modifiers: vec![],
-                carry: vec![],
-                children: vec![paragraph_fragment("X"), paragraph_fragment("Y")],
-            },
+            content: vec![paragraph_fragment("X"), paragraph_fragment("Y")],
             open_start: 0,
             open_end: 0,
         };
@@ -403,25 +470,20 @@ mod tests {
             selection: (p1, 0)
         };
         let slice = Slice {
-            fragment: Fragment {
-                node: PlainNode::Root(PlainRootNode::default()),
-                modifiers: vec![],
-                carry: vec![],
-                children: vec![
-                    Fragment {
-                        node: PlainNode::Callout(PlainCalloutNode::default()),
-                        modifiers: vec![],
-                        carry: vec![],
-                        children: vec![paragraph_fragment("1")],
-                    },
-                    Fragment {
-                        node: PlainNode::Paragraph(PlainParagraphNode::default()),
-                        modifiers: vec![],
-                        carry: vec![],
-                        children: vec![],
-                    },
-                ],
-            },
+            content: vec![
+                Fragment {
+                    node: PlainNode::Callout(PlainCalloutNode::default()),
+                    modifiers: vec![],
+                    carry: vec![],
+                    children: vec![paragraph_fragment("1")],
+                },
+                Fragment {
+                    node: PlainNode::Paragraph(PlainParagraphNode::default()),
+                    modifiers: vec![],
+                    carry: vec![],
+                    children: vec![],
+                },
+            ],
             open_start: 0,
             open_end: 0,
         };
@@ -447,14 +509,9 @@ mod tests {
             selection: (p1, 5)
         };
         let slice = Slice {
-            fragment: Fragment {
-                node: PlainNode::Root(PlainRootNode::default()),
-                modifiers: vec![],
-                carry: vec![],
-                children: vec![paragraph_fragment("first"), paragraph_fragment("second")],
-            },
-            open_start: 2,
-            open_end: 2,
+            content: vec![paragraph_fragment("first"), paragraph_fragment("second")],
+            open_start: 1,
+            open_end: 1,
         };
         let (actual, ..) = transact!(initial, |tr| insert_slice(
             &mut tr,
@@ -472,6 +529,76 @@ mod tests {
     }
 
     #[test]
+    fn structural_insert_opens_only_edge_paragraphs_and_preserves_closed_middle() {
+        let (initial, ..) = state! {
+            doc { root { p1: paragraph { text("xy") } } }
+            selection: (p1, 1)
+        };
+        let slice = Slice {
+            content: vec![
+                paragraph_fragment("A"),
+                Fragment {
+                    node: NodeType::Callout.into_node().to_plain(),
+                    modifiers: vec![],
+                    carry: vec![],
+                    children: vec![paragraph_fragment("M")],
+                },
+                paragraph_fragment("B"),
+            ],
+            open_start: 1,
+            open_end: 1,
+        };
+
+        let (actual, ..) = transact!(initial, |tr| insert_slice(
+            &mut tr,
+            slice,
+            SliceProvenance::Formatted
+        ));
+        let (expected, ..) = state! {
+            doc { root {
+                paragraph { text("xA") }
+                callout { paragraph { text("M") } }
+                p2: paragraph { text("By") }
+            } }
+            selection: (p2, 1)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn structural_insert_opens_compatible_outer_context_before_merging_textblock_edges() {
+        let (initial, ..) = state! {
+            doc { root { blockquote { p1: paragraph { text("xy") } } } }
+            selection: (p1, 1)
+        };
+        let slice = Slice {
+            content: vec![Fragment {
+                node: NodeType::Blockquote.into_node().to_plain(),
+                modifiers: vec![],
+                carry: vec![],
+                children: vec![paragraph_fragment("A"), paragraph_fragment("B")],
+            }],
+            open_start: 2,
+            open_end: 2,
+        };
+
+        let (actual, ..) = transact!(initial, |tr| insert_slice(
+            &mut tr,
+            slice,
+            SliceProvenance::Formatted
+        ));
+
+        let (expected, ..) = state! {
+            doc { root { blockquote {
+                paragraph { text("xA") }
+                p2: paragraph { text("By") }
+            } } }
+            selection: (p2, 1)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
     fn insert_image_at_text_middle_splits_paragraph_and_inserts() {
         use editor_model::PlainImageNode;
         let (initial, ..) = state! {
@@ -479,12 +606,7 @@ mod tests {
             selection: (p1, 3)
         };
         let slice = Slice {
-            fragment: Fragment {
-                node: PlainNode::Root(PlainRootNode::default()),
-                modifiers: vec![],
-                carry: vec![],
-                children: vec![Fragment::leaf(PlainNode::Image(PlainImageNode::default()))],
-            },
+            content: vec![Fragment::leaf(PlainNode::Image(PlainImageNode::default()))],
             open_start: 0,
             open_end: 0,
         };
@@ -512,12 +634,7 @@ mod tests {
             selection: (p1, 0)
         };
         let slice = Slice {
-            fragment: Fragment {
-                node: PlainNode::Root(PlainRootNode::default()),
-                modifiers: vec![],
-                carry: vec![],
-                children: vec![Fragment::leaf(PlainNode::Image(PlainImageNode::default()))],
-            },
+            content: vec![Fragment::leaf(PlainNode::Image(PlainImageNode::default()))],
             open_start: 0,
             open_end: 0,
         };
@@ -559,12 +676,7 @@ mod tests {
         );
 
         let slice = Slice {
-            fragment: Fragment {
-                node: PlainNode::Root(PlainRootNode::default()),
-                modifiers: vec![],
-                carry: vec![],
-                children: vec![Fragment::leaf(PlainNode::Image(PlainImageNode::default()))],
-            },
+            content: vec![Fragment::leaf(PlainNode::Image(PlainImageNode::default()))],
             open_start: 0,
             open_end: 0,
         };
@@ -594,24 +706,19 @@ mod tests {
             pending_modifiers: [bold]
         };
         let slice = Slice {
-            fragment: Fragment {
-                node: PlainNode::Root(PlainRootNode::default()),
+            content: vec![Fragment {
+                node: PlainNode::Paragraph(PlainParagraphNode::default()),
                 modifiers: vec![],
                 carry: vec![],
                 children: vec![Fragment {
-                    node: PlainNode::Paragraph(PlainParagraphNode::default()),
-                    modifiers: vec![],
+                    node: PlainNode::Text(PlainTextNode { text: "XY".into() }),
+                    modifiers: vec![Modifier::Italic],
                     carry: vec![],
-                    children: vec![Fragment {
-                        node: PlainNode::Text(PlainTextNode { text: "XY".into() }),
-                        modifiers: vec![Modifier::Italic],
-                        carry: vec![],
-                        children: vec![],
-                    }],
+                    children: vec![],
                 }],
-            },
-            open_start: 2,
-            open_end: 2,
+            }],
+            open_start: 1,
+            open_end: 1,
         };
         let (actual, ..) = transact!(initial, |tr| insert_slice(
             &mut tr,
@@ -648,7 +755,7 @@ mod tests {
         };
         let original = Slice::extract(&source).expect("non-collapsed");
         assert!(
-            original.fragment.children[3]
+            original.content[3]
                 .carry
                 .iter()
                 .any(|m| matches!(m, Modifier::Bold)),
@@ -675,7 +782,7 @@ mod tests {
             Slice::extract(&pasted).expect("re-extract pasted blocks")
         };
         assert_eq!(
-            reextracted.fragment.children, original.fragment.children,
+            reextracted.content, original.content,
             "paint, block format, and carry all survive the copy-paste round trip"
         );
     }
@@ -690,19 +797,16 @@ mod tests {
         };
         let original = Slice::extract(&source).expect("non-collapsed");
         assert!(
-            original.fragment.children[0]
-                .modifiers
-                .iter()
-                .any(|m| matches!(
-                    m,
-                    Modifier::Alignment {
-                        value: Alignment::Center
-                    }
-                )),
+            original.content[0].modifiers.iter().any(|m| matches!(
+                m,
+                Modifier::Alignment {
+                    value: Alignment::Center
+                }
+            )),
             "sanity: extracted paragraph is center-aligned"
         );
         assert!(
-            original.fragment.children[0]
+            original.content[0]
                 .carry
                 .iter()
                 .any(|m| matches!(m, Modifier::Bold)),
@@ -749,7 +853,7 @@ mod tests {
         let payload = original.to_payload(&Resource::new_test());
         let parsed = Slice::from_payload(Some(&payload.html), &payload.text, &Resource::new_test());
         assert!(
-            matches!(parsed.fragment.children[0].node, PlainNode::Image(_)),
+            matches!(parsed.content[0].node, PlainNode::Image(_)),
             "sanity: payload carries the image"
         );
 
@@ -796,8 +900,10 @@ mod tests {
         };
         let open = Slice::extract(&src).expect("non-collapsed");
         assert!(
-            open.fragment.carry.is_empty(),
-            "sanity: an open (inline) fragment carries no carry"
+            open.content
+                .iter()
+                .all(|fragment| fragment.carry.is_empty()),
+            "sanity: bare inline fragments carry no block carry"
         );
 
         let (initial, p1, ..) = state! {

--- a/crates/editor-commands/src/commands/insert_slice_at.rs
+++ b/crates/editor-commands/src/commands/insert_slice_at.rs
@@ -21,8 +21,8 @@ mod tests {
     use editor_crdt::Dot;
     use editor_macros::state;
     use editor_model::{
-        ChildView, DocView, Fragment, NodeType, PlainImageNode, PlainNode, PlainParagraphNode,
-        PlainRootNode, PlainTextNode,
+        ChildView, DocView, Fragment, NodeType, PlainBulletListNode, PlainImageNode,
+        PlainListItemNode, PlainNode, PlainParagraphNode, PlainTextNode,
     };
     use editor_state::{Affinity, Position, Selection};
     use editor_transaction::Transaction;
@@ -31,12 +31,7 @@ mod tests {
 
     fn image_slice() -> Slice {
         Slice {
-            fragment: Fragment {
-                node: PlainNode::Root(PlainRootNode::default()),
-                modifiers: vec![],
-                carry: vec![],
-                children: vec![Fragment::leaf(PlainNode::Image(PlainImageNode::default()))],
-            },
+            content: vec![Fragment::leaf(PlainNode::Image(PlainImageNode::default()))],
             open_start: 0,
             open_end: 0,
         }
@@ -50,6 +45,24 @@ mod tests {
             children: vec![Fragment::leaf(PlainNode::Text(PlainTextNode {
                 text: text.into(),
             }))],
+        }
+    }
+
+    fn open_bullet_list_slice(text: &str, open_start: u32, open_end: u32) -> Slice {
+        Slice {
+            content: vec![Fragment {
+                node: PlainNode::BulletList(PlainBulletListNode::default()),
+                modifiers: vec![],
+                carry: vec![],
+                children: vec![Fragment {
+                    node: PlainNode::ListItem(PlainListItemNode::default()),
+                    modifiers: vec![],
+                    carry: vec![],
+                    children: vec![paragraph_fragment(text)],
+                }],
+            }],
+            open_start,
+            open_end,
         }
     }
 
@@ -69,6 +82,21 @@ mod tests {
             .unwrap()
             .child_blocks()
             .map(|b| b.inline_text())
+            .collect()
+    }
+
+    fn list_item_texts(view: &DocView, list: Dot) -> Vec<String> {
+        view.node(list)
+            .unwrap()
+            .child_blocks()
+            .map(|item| {
+                item.descendants()
+                    .filter_map(|child| match child {
+                        ChildView::Leaf(leaf) => leaf.as_char(),
+                        ChildView::Block(_) => None,
+                    })
+                    .collect()
+            })
             .collect()
     }
 
@@ -216,12 +244,7 @@ mod tests {
         };
         let root = initial.view().root().unwrap().id();
         let slice = Slice {
-            fragment: Fragment {
-                node: PlainNode::Root(PlainRootNode::default()),
-                modifiers: vec![],
-                carry: vec![],
-                children: vec![paragraph_fragment("A"), paragraph_fragment("B")],
-            },
+            content: vec![paragraph_fragment("A"), paragraph_fragment("B")],
             open_start: 0,
             open_end: 0,
         };
@@ -272,14 +295,9 @@ mod tests {
         };
         let root = initial.view().root().unwrap().id();
         let slice = Slice {
-            fragment: Fragment {
-                node: PlainNode::Root(PlainRootNode::default()),
-                modifiers: vec![],
-                carry: vec![],
-                children: vec![paragraph_fragment("first"), paragraph_fragment("second")],
-            },
-            open_start: 2,
-            open_end: 2,
+            content: vec![paragraph_fragment("first"), paragraph_fragment("second")],
+            open_start: 1,
+            open_end: 1,
         };
 
         let mut tr = Transaction::new(&initial);
@@ -315,6 +333,120 @@ mod tests {
                 },
             )
         );
+    }
+
+    #[test]
+    fn insert_open_list_context_merges_items_at_list_boundary() {
+        let (initial, list) = state! {
+            doc { root {
+                list: bullet_list {
+                    list_item { paragraph { text("A") } }
+                    list_item { paragraph { text("C") } }
+                }
+                paragraph {}
+            } }
+            selection: none
+        };
+
+        let mut tr = Transaction::new(&initial);
+        let inserted = insert_slice_at(
+            &mut tr,
+            Position::new(list, 1),
+            open_bullet_list_slice("B", 1, 1),
+            SliceProvenance::Formatted,
+        )
+        .expect("command succeeds");
+        assert!(inserted.is_some());
+        let (actual, ..) = tr.commit();
+
+        let view = actual.view();
+        let list = view.node(list).expect("list remains");
+        assert_eq!(list.child_blocks().count(), 3);
+        assert_eq!(list_item_texts(&view, list.id()), ["A", "B", "C"]);
+    }
+
+    #[test]
+    fn insert_open_list_context_with_only_start_edge_open_merges_item() {
+        let (initial, list) = state! {
+            doc { root {
+                list: bullet_list { list_item { paragraph { text("A") } } }
+                paragraph {}
+            } }
+            selection: none
+        };
+        let mut tr = Transaction::new(&initial);
+
+        assert!(
+            insert_slice_at(
+                &mut tr,
+                Position::new(list, 1),
+                open_bullet_list_slice("B", 3, 0),
+                SliceProvenance::Formatted,
+            )
+            .expect("command succeeds")
+            .is_some()
+        );
+        let (actual, ..) = tr.commit();
+
+        assert_eq!(list_item_texts(&actual.view(), list), ["A", "B"]);
+    }
+
+    #[test]
+    fn insert_open_list_context_with_only_end_edge_open_merges_item() {
+        let (initial, list) = state! {
+            doc { root {
+                list: bullet_list { list_item { paragraph { text("A") } } }
+                paragraph {}
+            } }
+            selection: none
+        };
+        let mut tr = Transaction::new(&initial);
+
+        assert!(
+            insert_slice_at(
+                &mut tr,
+                Position::new(list, 1),
+                open_bullet_list_slice("B", 0, 3),
+                SliceProvenance::Formatted,
+            )
+            .expect("command succeeds")
+            .is_some()
+        );
+        let (actual, ..) = tr.commit();
+
+        assert_eq!(list_item_texts(&actual.view(), list), ["A", "B"]);
+    }
+
+    #[test]
+    fn block_boundary_rejects_closed_invalid_root_without_unwrapping() {
+        let (initial, root) = state! {
+            doc { root: root { paragraph {} } }
+            selection: none
+        };
+        let slice = Slice {
+            content: vec![Fragment {
+                node: NodeType::FoldContent.into_node().to_plain(),
+                modifiers: vec![],
+                carry: vec![],
+                children: vec![paragraph_fragment("inside")],
+            }],
+            open_start: 0,
+            open_end: 0,
+        };
+        let mut tr = Transaction::new(&initial);
+
+        assert!(
+            insert_slice_at(
+                &mut tr,
+                Position::new(root, 0),
+                slice,
+                SliceProvenance::Formatted,
+            )
+            .expect("invalid insertion is a no-op")
+            .is_none()
+        );
+        let (actual, ..) = tr.commit();
+        assert_eq!(kinds(&actual.view(), root), vec![NodeType::Paragraph]);
     }
 
     #[test]

--- a/crates/editor-commands/src/commands/paste_cells_into_cell_rect.rs
+++ b/crates/editor-commands/src/commands/paste_cells_into_cell_rect.rs
@@ -104,7 +104,7 @@ pub fn paste_cells_into_cell_rect(tr: &mut Transaction, slice: Slice) -> Command
 }
 
 fn extract_source_rows(slice: &Slice) -> Option<Vec<Vec<Fragment>>> {
-    let table = find_table_fragment(&slice.fragment)?;
+    let table = slice.content.iter().find_map(find_table_fragment)?;
     let mut rows: Vec<Vec<Fragment>> = Vec::new();
     for r in &table.children {
         if !matches!(r.node, PlainNode::TableRow(_)) {

--- a/crates/editor-commands/src/helpers/slice.rs
+++ b/crates/editor-commands/src/helpers/slice.rs
@@ -106,13 +106,16 @@ pub(crate) fn insert_slice_at_position(
     let position = materialize_position_block(tr, position)?;
     let in_textblock = position_in_textblock(tr, &position);
     if in_textblock {
+        let slice = open_slice_for_textblock_parent(tr, &position, &slice).unwrap_or(slice);
         let mode = build_inline_mode(tr, &position, provenance)?;
         if let Some(fragments) =
             inline_content_fragments_for_textblock_insert(tr, &position, &slice)
         {
             insert_content_as_inline_at_position(tr, position, fragments, &mode)
-        } else {
+        } else if can_split_textblock_at_position(tr, &position) {
             insert_blocks_in_textblock_at_position(tr, position, &slice, &mode)
+        } else {
+            Ok(None)
         }
     } else {
         insert_blocks_at_block_boundary(tr, position, &slice)
@@ -127,26 +130,7 @@ fn position_in_textblock(tr: &Transaction, position: &Position) -> bool {
 }
 
 fn top_level_fragments(slice: &Slice) -> Vec<&Fragment> {
-    match &slice.fragment.node {
-        PlainNode::Root(_) => slice.fragment.children.iter().collect(),
-        _ => vec![&slice.fragment],
-    }
-}
-
-fn open_content_fragments(mut fragments: Vec<&Fragment>, open_depth: u32) -> Vec<&Fragment> {
-    for _ in 0..open_depth {
-        let mut next = Vec::new();
-        for fragment in fragments {
-            if Schema::node_spec(fragment.node.as_type()).is_leaf() || fragment.children.is_empty()
-            {
-                next.push(fragment);
-            } else {
-                next.extend(fragment.children.iter());
-            }
-        }
-        fragments = next;
-    }
-    fragments
+    slice.content.iter().collect()
 }
 
 fn fragments_fit_parent(parent_type: NodeType, fragments: &[&Fragment]) -> bool {
@@ -179,6 +163,36 @@ fn can_split_textblock_for_structural_insert(view: &DocView, textblock_id: Dot) 
     parent.spec().content.matches_sequence(&child_types)
 }
 
+fn can_split_textblock_at_position(tr: &Transaction, position: &Position) -> bool {
+    let view = tr.state().view();
+    find_ancestor_textblock(&view, position.node)
+        .is_some_and(|textblock| can_split_textblock_for_structural_insert(&view, textblock))
+}
+
+fn open_slice_for_textblock_parent(
+    tr: &Transaction,
+    position: &Position,
+    slice: &Slice,
+) -> Option<Slice> {
+    let view = tr.state().view();
+    let textblock_id = find_ancestor_textblock(&view, position.node)?;
+    if !can_split_textblock_for_structural_insert(&view, textblock_id) {
+        return None;
+    }
+    let parent_type = view.node(textblock_id)?.parent()?.node_type();
+    let (content, open_start, open_end) = open_fragments_for_parent(
+        top_level_fragments(slice),
+        slice.open_start,
+        slice.open_end,
+        parent_type,
+    )?;
+    Some(Slice::new(
+        content.into_iter().cloned().collect(),
+        open_start,
+        open_end,
+    ))
+}
+
 fn inline_content_fragments_for_textblock_insert<'a>(
     tr: &Transaction,
     position: &Position,
@@ -196,13 +210,17 @@ fn inline_content_fragments_for_textblock_insert<'a>(
         return Some(top_level);
     }
 
-    if slice.open_start == 0 {
+    if slice.open_start == 0 && slice.open_end == 0 {
         return None;
     }
 
-    let open_content = open_content_fragments(top_level.clone(), slice.open_start);
-    if !fragments_are_inline(&open_content) || !fragments_fit_parent(textblock_type, &open_content)
-    {
+    let (open_content, _, _) = open_fragments_for_parent(
+        top_level.clone(),
+        slice.open_start,
+        slice.open_end,
+        textblock_type,
+    )?;
+    if !fragments_are_inline(&open_content) {
         return None;
     }
 
@@ -357,10 +375,7 @@ fn insert_blocks_in_textblock(
     let p2_id = block_child_id(tr, container_id, textblock_index + 1)
         .ok_or_else(|| CommandError::Corrupted("split produced no right half".into()))?;
 
-    let blocks: Vec<&Fragment> = match &slice.fragment.node {
-        PlainNode::Root(_) => slice.fragment.children.iter().collect(),
-        _ => vec![&slice.fragment],
-    };
+    let blocks: Vec<&Fragment> = slice.content.iter().collect();
 
     let merge_start = slice.open_start > 0
         && blocks
@@ -554,10 +569,9 @@ fn insert_blocks_at_block_boundary(
         .node(container_id)
         .ok_or(CommandError::NodeNotFound(container_id))?
         .node_type();
-    let blocks = block_boundary_fragments(slice, container_type);
-    if blocks.is_empty() {
+    let Some(blocks) = block_boundary_fragments(slice, container_type) else {
         return Ok(None);
-    }
+    };
 
     let block_count = blocks.len();
     tr.batch(|tr| {
@@ -589,22 +603,89 @@ fn insert_blocks_at_block_boundary(
     )))
 }
 
-fn block_boundary_fragments(slice: &Slice, container_type: NodeType) -> Vec<Fragment> {
+fn block_boundary_fragments(slice: &Slice, container_type: NodeType) -> Option<Vec<Fragment>> {
     let top_level = top_level_fragments(slice);
     if fragments_are_inline(&top_level)
         && Schema::node_spec(container_type)
             .content
             .matches(NodeType::Paragraph)
     {
-        return vec![Fragment {
+        return Some(vec![Fragment {
             node: PlainNode::Paragraph(PlainParagraphNode::default()),
             modifiers: vec![],
             carry: vec![],
             children: top_level.into_iter().cloned().collect(),
-        }];
+        }]);
     }
 
-    top_level.into_iter().cloned().collect()
+    open_fragments_for_parent(top_level, slice.open_start, slice.open_end, container_type)
+        .map(|(fragments, _, _)| fragments.into_iter().cloned().collect())
+}
+
+fn open_fragments_for_parent<'a>(
+    mut candidates: Vec<&'a Fragment>,
+    mut open_start: u32,
+    mut open_end: u32,
+    parent_type: NodeType,
+) -> Option<(Vec<&'a Fragment>, u32, u32)> {
+    let content = &Schema::node_spec(parent_type).content;
+    loop {
+        if candidates.is_empty() {
+            return None;
+        }
+        if fragments_fit_parent(parent_type, &candidates) {
+            return Some((candidates, open_start, open_end));
+        }
+
+        let first_rejected = !content.matches(candidates.first()?.node.as_type());
+        let last_rejected = !content.matches(candidates.last()?.node.as_type());
+        if !first_rejected && !last_rejected {
+            return None;
+        }
+
+        if candidates.len() == 1 {
+            let can_open_start = first_rejected && open_start > 0;
+            let can_open_end = last_rejected && open_end > 0;
+            if !can_open_start && !can_open_end {
+                return None;
+            }
+            let only = candidates.pop()?;
+            if only.children.is_empty() {
+                return None;
+            }
+            candidates.extend(&only.children);
+            if can_open_start {
+                open_start -= 1;
+            }
+            if can_open_end {
+                open_end -= 1;
+            }
+            continue;
+        }
+
+        if first_rejected {
+            if open_start == 0 {
+                return None;
+            }
+            let first = candidates.remove(0);
+            if first.children.is_empty() {
+                return None;
+            }
+            candidates.splice(0..0, &first.children);
+            open_start -= 1;
+        }
+        if last_rejected {
+            if open_end == 0 {
+                return None;
+            }
+            let last = candidates.pop()?;
+            if last.children.is_empty() {
+                return None;
+            }
+            candidates.extend(&last.children);
+            open_end -= 1;
+        }
+    }
 }
 
 fn selection_over_inserted_blocks(

--- a/crates/editor-core/src/editor.rs
+++ b/crates/editor-core/src/editor.rs
@@ -4057,6 +4057,62 @@ mod tests {
     }
 
     #[test]
+    fn internal_drop_moves_only_selected_callout_out_of_fold_content() {
+        let (initial, root, _content, _after) = state! {
+            doc {
+                root: root {
+                    fold {
+                        fold_title { text("title") }
+                        content: fold_content {
+                            paragraph { text("inside") }
+                            callout { paragraph { text("moved") } }
+                        }
+                    }
+                    after: paragraph { text("after") }
+                }
+            }
+            selection: (content, 1) -> (content, 2)
+        };
+        let slice = editor_clipboard::Slice::extract(&initial).expect("callout slice");
+        assert_eq!((slice.open_start, slice.open_end), (0, 0));
+        assert_eq!(slice.content.len(), 1);
+        assert!(matches!(slice.content[0].node, PlainNode::Callout(_)));
+
+        let mut editor = Editor::new_test(initial);
+        editor.apply(Message::System {
+            event: crate::message::SystemEvent::Initialize,
+        });
+        let source = editor.state().selection.expect("callout selection");
+
+        crate::handle::apply_drop_for_test(
+            &mut editor,
+            Position::new(root, 1),
+            DndDropPayload::InternalSelection,
+            InputModifiers::default(),
+            Some(source),
+        )
+        .expect("callout move should succeed");
+
+        let (expected, ..) = state! {
+            doc {
+                root {
+                    fold {
+                        fold_title { text("title") }
+                        fold_content {
+                            paragraph { text("inside") }
+                            paragraph {}
+                        }
+                    }
+                    callout { paragraph { text("moved") } }
+                    paragraph { text("after") }
+                }
+            }
+            selection: none
+        };
+        editor_state::assert_doc_eq!(editor.state(), &expected);
+    }
+
+    #[test]
     fn normalize_gap_phantom_some_for_leading_unit() {
         let (state, ..) = state! {
             doc { root: root { image paragraph { text("b") } } }
@@ -4408,17 +4464,9 @@ mod tests {
         let slice = Slice::extract(&state).expect("Slice::extract must succeed");
 
         // Print slice content for debugging
-        eprintln!("slice fragment node: {:?}", slice.fragment.node);
-        eprintln!(
-            "slice fragment modifiers count: {}",
-            slice.fragment.modifiers.len()
-        );
-        for m in &slice.fragment.modifiers {
-            eprintln!("  root modifier: {:?}", m);
-        }
-        for (i, child) in slice.fragment.children.iter().enumerate() {
+        for (i, child) in slice.content.iter().enumerate() {
             eprintln!(
-                "  child[{}]: {:?}, modifiers: {:?}",
+                "  root[{}]: {:?}, modifiers: {:?}",
                 i, child.node, child.modifiers
             );
             for (j, gc) in child.children.iter().enumerate() {

--- a/crates/editor-core/src/handle/clipboard.rs
+++ b/crates/editor-core/src/handle/clipboard.rs
@@ -213,7 +213,7 @@ fn slice_has_table(slice: &Slice) -> bool {
         }
         f.children.iter().any(walk)
     }
-    walk(&slice.fragment)
+    slice.content.iter().any(walk)
 }
 
 #[cfg(test)]

--- a/crates/editor-core/src/handle/dnd.rs
+++ b/crates/editor-core/src/handle/dnd.rs
@@ -6,7 +6,7 @@ use editor_clipboard::Slice;
 use editor_commands::{self as commands};
 use editor_model::{
     ChildView, ContextExpr, DocView, Fragment, Node, NodeType, PlainFileNode, PlainImageNode,
-    PlainNode, PlainRootNode, Schema,
+    PlainNode, Schema,
 };
 use editor_state::{Position, Selection, StableResolveCtx, StableSelection, State};
 use editor_view::DropTarget;
@@ -350,7 +350,7 @@ fn slice_content_fits_target_context(view: &DocView, position: Position, slice: 
         }
         fragment.children.iter().all(|c| check(c, base))
     }
-    check(&slice.fragment, &base)
+    slice.content.iter().all(|fragment| check(fragment, &base))
 }
 
 fn drop_slice_at(
@@ -478,14 +478,5 @@ fn files_slice(image_count: u32, file_count: u32) -> Slice {
         children.push(Fragment::leaf(PlainNode::File(PlainFileNode { id: None })));
     }
 
-    Slice {
-        fragment: Fragment {
-            node: PlainNode::Root(PlainRootNode::default()),
-            modifiers: vec![],
-            carry: vec![],
-            children,
-        },
-        open_start: 0,
-        open_end: 0,
-    }
+    Slice::new(children, 0, 0)
 }


### PR DESCRIPTION
- TR-378 해결: FoldContent 안의 Callout처럼 공통 부모의 child만 선택했을 때, 선택하지 않은 context까지 Slice에 포함되어 선택한 block만 복사/이동하지 못하던 문제를 수정
- `Slice`의 `fragment` -> `content`로 바꿈: top-level node들을 직접 보관함. inline content거나 문서 최상위에 놓을 수 있는 block이면 불필요한 공통 부모를 제거
- `ListItem`처럼 단독으로 삽입할 수 없는 node는 최소 wrapper와 openness를 유지. 붙여넣을 때는 대상이 허용하지 않는 양끝의 열린 wrapper만 벗기고, 중간에 완전히 선택된 block은 그대로 보존