### PR TITLE
fulfill이 삽입만으로 유효해지는 content만 보완

### DIFF
--- a/crates/editor-clipboard/src/html/serialize.rs
+++ b/crates/editor-clipboard/src/html/serialize.rs
@@ -254,11 +254,7 @@ mod tests {
 
     #[test]
     fn serialize_prepends_charset_meta() {
-        let slice = Slice {
-            fragment: Fragment::leaf(PlainNode::Root(PlainRootNode::default())),
-            open_start: 0,
-            open_end: 0,
-        };
+        let slice = Slice::new(vec![], 0, 0);
         let html = to_html(&slice, &Resource::new_test());
         assert!(html.starts_with(r#"<meta charset="utf-8">"#));
     }

--- a/crates/editor-model/src/schema/content.rs
+++ b/crates/editor-model/src/schema/content.rs
@@ -53,6 +53,105 @@ impl ContentExpr {
         self.validate(types).is_ok()
     }
 
+    /// Returns the deterministic additions needed to make `supplied` valid.
+    /// Existing nodes are never removed, reordered, or replaced.
+    pub fn completion_insertions(&self, supplied: &[NodeType]) -> Option<Vec<(usize, NodeType)>> {
+        if self.matches_sequence(supplied) {
+            return Some(vec![]);
+        }
+
+        let insertions = self.compute_insertions(supplied);
+        let mut completed = supplied.to_vec();
+        for &(index, node_type) in &insertions {
+            if index > completed.len() {
+                return None;
+            }
+            completed.insert(index, node_type);
+        }
+
+        self.matches_sequence(&completed).then_some(insertions)
+    }
+
+    fn compute_insertions(&self, supplied: &[NodeType]) -> Vec<(usize, NodeType)> {
+        match self {
+            Self::Empty | Self::Any | Self::ZeroOrMore(_) | Self::Optional(_) => vec![],
+            Self::Single(node_type) => supplied
+                .is_empty()
+                .then_some((0, *node_type))
+                .into_iter()
+                .collect(),
+            Self::OneOrMore(inner) => supplied
+                .is_empty()
+                .then(|| (0, Self::first_type(inner)))
+                .into_iter()
+                .collect(),
+            Self::Choice(choices) => supplied
+                .is_empty()
+                .then(|| (0, Self::first_type(&choices[0])))
+                .into_iter()
+                .collect(),
+            Self::Seq(exprs) => Self::compute_seq_insertions(exprs, supplied),
+        }
+    }
+
+    fn compute_seq_insertions(
+        exprs: &[ContentExpr],
+        supplied: &[NodeType],
+    ) -> Vec<(usize, NodeType)> {
+        let mut insertions = Vec::new();
+        let mut supplied_index = 0;
+
+        for expr in exprs {
+            match expr {
+                Self::Single(node_type) => {
+                    if supplied.get(supplied_index) == Some(node_type) {
+                        supplied_index += 1;
+                    } else {
+                        insertions.push((supplied_index + insertions.len(), *node_type));
+                    }
+                }
+                Self::ZeroOrMore(inner) | Self::OneOrMore(inner) => {
+                    let mut consumed = 0;
+                    while supplied
+                        .get(supplied_index)
+                        .is_some_and(|node_type| inner.matches(*node_type))
+                    {
+                        supplied_index += 1;
+                        consumed += 1;
+                    }
+
+                    if matches!(expr, Self::OneOrMore(_)) && consumed == 0 {
+                        insertions
+                            .push((supplied_index + insertions.len(), Self::first_type(inner)));
+                    }
+                }
+                Self::Optional(inner)
+                    if supplied
+                        .get(supplied_index)
+                        .is_some_and(|node_type| inner.matches(*node_type)) =>
+                {
+                    supplied_index += 1;
+                }
+                Self::Optional(_) => {}
+                _ => {}
+            }
+        }
+
+        insertions
+    }
+
+    fn first_type(expr: &ContentExpr) -> NodeType {
+        match expr {
+            Self::Single(node_type) => *node_type,
+            Self::Choice(choices) => Self::first_type(&choices[0]),
+            Self::OneOrMore(inner) | Self::ZeroOrMore(inner) | Self::Optional(inner) => {
+                Self::first_type(inner)
+            }
+            Self::Seq(exprs) => Self::first_type(&exprs[0]),
+            Self::Empty | Self::Any => unreachable!("Empty/Any content has no type"),
+        }
+    }
+
     /// Whether `node_type` may appear freely (any count, any position relative
     /// to peers in the same repeatable group) — i.e. it is inside a `ZeroOrMore`
     /// or `OneOrMore`. Types only reachable through `Single`/`Optional`/fixed
@@ -266,5 +365,50 @@ impl ContentExpr {
                 Ok(())
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn completion_insertions_returns_empty_for_valid_sequence() {
+        let content = &NodeType::Fold.spec().content;
+
+        assert_eq!(
+            content.completion_insertions(&[NodeType::FoldTitle, NodeType::FoldContent]),
+            Some(vec![])
+        );
+    }
+
+    #[test]
+    fn completion_insertions_adds_required_children_without_reordering_supplied_nodes() {
+        let fold = &NodeType::Fold.spec().content;
+        let list_item = &NodeType::ListItem.spec().content;
+
+        assert_eq!(
+            fold.completion_insertions(&[NodeType::FoldTitle]),
+            Some(vec![(1, NodeType::FoldContent)])
+        );
+        assert_eq!(
+            list_item.completion_insertions(&[NodeType::BulletList]),
+            Some(vec![(0, NodeType::Paragraph)])
+        );
+    }
+
+    #[test]
+    fn completion_insertions_rejects_sequences_that_require_removal_or_reordering() {
+        let paragraph = &NodeType::Paragraph.spec().content;
+        let fold = &NodeType::Fold.spec().content;
+
+        assert_eq!(
+            paragraph.completion_insertions(&[NodeType::PageBreak, NodeType::Text]),
+            None
+        );
+        assert_eq!(
+            fold.completion_insertions(&[NodeType::FoldContent, NodeType::FoldTitle]),
+            None
+        );
     }
 }

--- a/crates/editor-transaction/src/fulfill.rs
+++ b/crates/editor-transaction/src/fulfill.rs
@@ -12,7 +12,10 @@ pub fn fulfill(node: &NodeView) -> Vec<Step> {
         return vec![];
     }
 
-    let insertions = compute_insertions(&spec.content, &child_types);
+    let insertions = spec
+        .content
+        .completion_insertions(&child_types)
+        .unwrap_or_default();
     let total_children = node.child_count();
     insertions
         .into_iter()
@@ -48,81 +51,6 @@ fn known_child_types(node: &NodeView) -> (Vec<NodeType>, Vec<usize>) {
         real_indices.push(i);
     }
     (types, real_indices)
-}
-
-fn compute_insertions(content: &ContentExpr, existing: &[NodeType]) -> Vec<(usize, NodeType)> {
-    match content {
-        ContentExpr::Empty
-        | ContentExpr::Any
-        | ContentExpr::ZeroOrMore(_)
-        | ContentExpr::Optional(_) => vec![],
-
-        ContentExpr::Single(t) => {
-            if existing.is_empty() {
-                vec![(0, *t)]
-            } else {
-                vec![]
-            }
-        }
-
-        ContentExpr::OneOrMore(inner) => {
-            if existing.is_empty() {
-                vec![(0, first_type(inner))]
-            } else {
-                vec![]
-            }
-        }
-
-        ContentExpr::Choice(choices) => {
-            if existing.is_empty() {
-                vec![(0, first_type(&choices[0]))]
-            } else {
-                vec![]
-            }
-        }
-
-        ContentExpr::Seq(exprs) => compute_seq_insertions(exprs, existing),
-    }
-}
-
-/// Handle Seq patterns. Walk through expressions and existing children in parallel.
-fn compute_seq_insertions(exprs: &[ContentExpr], existing: &[NodeType]) -> Vec<(usize, NodeType)> {
-    let mut insertions = Vec::new();
-    let mut existing_idx = 0;
-
-    for expr in exprs.iter() {
-        match expr {
-            ContentExpr::Single(t) => {
-                if existing_idx < existing.len() && existing[existing_idx] == *t {
-                    existing_idx += 1;
-                } else {
-                    insertions.push((existing_idx + insertions.len(), *t));
-                }
-            }
-            ContentExpr::ZeroOrMore(inner) | ContentExpr::OneOrMore(inner) => {
-                let is_one_or_more = matches!(expr, ContentExpr::OneOrMore(_));
-
-                let mut consumed = 0;
-                while existing_idx < existing.len() && inner.matches(existing[existing_idx]) {
-                    existing_idx += 1;
-                    consumed += 1;
-                }
-
-                if is_one_or_more && consumed == 0 {
-                    insertions.push((existing_idx + insertions.len(), first_type(inner)));
-                }
-            }
-            ContentExpr::Optional(inner)
-                if existing_idx < existing.len() && inner.matches(existing[existing_idx]) =>
-            {
-                existing_idx += 1;
-            }
-            ContentExpr::Optional(_) => {}
-            _ => {}
-        }
-    }
-
-    insertions
 }
 
 fn first_type(expr: &ContentExpr) -> NodeType {
@@ -253,21 +181,17 @@ mod tests {
     /// (the missing type sorts after every known child, so the repair index
     /// falls back to `total_children`). This oracle instead hits `Some(_)`: an
     /// interior real_indices lookup succeeds because the missing child must be
-    /// inserted *before* an already-present known child, with an Unknown
-    /// placeholder sitting between the two known children (`[Known, Unknown,
-    /// Known]`). Physical order here is deliberately [FoldContent, Unknown,
-    /// FoldTitle] — wrong content-order, so `fulfill` must still insert the
-    /// missing FoldTitle, and it must land at real index 0 (immediately before
-    /// the physically-first FoldContent), not appended at the tail.
+    /// inserted *before* an already-present known child. Physical order here
+    /// is [FoldContent, Unknown], so `fulfill` must insert the missing FoldTitle
+    /// at real index 0, not append it after the Unknown.
     #[test]
-    fn fulfill_remaps_insertion_index_via_real_indices_hit_between_unknowns() {
+    fn fulfill_remaps_insertion_index_via_real_indices_hit_before_unknown() {
         use editor_crdt::Dot;
         use editor_model::{BlockNode, BlockTree, Child, ChildList, DocView, ProjectedDoc};
 
         let fold_id = Dot::new(1, 0);
         let content_id = Dot::new(1, 1);
         let unknown_id = Dot::new(1, 2);
-        let title_id = Dot::new(1, 3);
 
         let mut nodes = editor_model::imbl::HashMap::new();
         nodes.insert(
@@ -276,11 +200,7 @@ mod tests {
                 id: fold_id,
                 node_type: NodeType::Fold,
                 attrs: vec![],
-                children: ChildList::from(vec![
-                    Child::Block(content_id),
-                    Child::Block(unknown_id),
-                    Child::Block(title_id),
-                ]),
+                children: ChildList::from(vec![Child::Block(content_id), Child::Block(unknown_id)]),
             },
         );
         nodes.insert(
@@ -301,16 +221,6 @@ mod tests {
                 children: ChildList::new(),
             },
         );
-        nodes.insert(
-            title_id,
-            BlockNode {
-                id: title_id,
-                node_type: NodeType::FoldTitle,
-                attrs: vec![],
-                children: ChildList::new(),
-            },
-        );
-
         let doc = ProjectedDoc {
             tree: BlockTree {
                 nodes,
@@ -342,7 +252,7 @@ mod tests {
     /// regression that dropped the `real_indices` remap entirely (using the
     /// filtered index directly as the real index) would slip through both
     /// unnoticed. This oracle puts the Unknown *before* the insertion point
-    /// (`[Unknown, FoldContent, FoldTitle]`), so the real index (1, past the
+    /// (`[Unknown, FoldContent]`), so the real index (1, past the
     /// Unknown) diverges from the filtered index (0, Unknown excluded) —
     /// only the `real_indices` lookup, not the raw filtered index, produces
     /// the expected step.
@@ -354,7 +264,6 @@ mod tests {
         let fold_id = Dot::new(1, 0);
         let unknown_id = Dot::new(1, 1);
         let content_id = Dot::new(1, 2);
-        let title_id = Dot::new(1, 3);
 
         let mut nodes = editor_model::imbl::HashMap::new();
         nodes.insert(
@@ -363,11 +272,7 @@ mod tests {
                 id: fold_id,
                 node_type: NodeType::Fold,
                 attrs: vec![],
-                children: ChildList::from(vec![
-                    Child::Block(unknown_id),
-                    Child::Block(content_id),
-                    Child::Block(title_id),
-                ]),
+                children: ChildList::from(vec![Child::Block(unknown_id), Child::Block(content_id)]),
             },
         );
         nodes.insert(
@@ -388,16 +293,6 @@ mod tests {
                 children: ChildList::new(),
             },
         );
-        nodes.insert(
-            title_id,
-            BlockNode {
-                id: title_id,
-                node_type: NodeType::FoldTitle,
-                attrs: vec![],
-                children: ChildList::new(),
-            },
-        );
-
         let doc = ProjectedDoc {
             tree: BlockTree {
                 nodes,


### PR DESCRIPTION
- `fulfill`이 후보 insertion을 적용한 결과가 스키마상 유효할 때만 required child를 보완하도록 변경
- completion 계산을 `ContentExpr`로 옮김
- PageBreak 뒤 Text나 순서가 뒤집힌 Fold처럼 insertion만으로 고칠 수 없는 sequence에는 repair step을 생성하지 않음