### PR TITLE
slice 삽입 거부 시 synthetic destination 보존

### DIFF
--- a/crates/editor-commands/src/commands/insert_slice_at.rs
+++ b/crates/editor-commands/src/commands/insert_slice_at.rs
@@ -21,13 +21,14 @@ mod tests {
     use editor_crdt::Dot;
     use editor_macros::state;
     use editor_model::{
-        ChildView, DocView, Fragment, NodeType, PlainBulletListNode, PlainImageNode,
-        PlainListItemNode, PlainNode, PlainParagraphNode, PlainTextNode,
+        ChildView, DocView, Fragment, NodeType, PlainBulletListNode, PlainHorizontalRuleNode,
+        PlainImageNode, PlainListItemNode, PlainNode, PlainParagraphNode, PlainTextNode,
     };
     use editor_state::{Affinity, Position, Selection};
     use editor_transaction::Transaction;
 
     use super::*;
+    use crate::test_utils::*;
 
     fn image_slice() -> Slice {
         Slice {
@@ -35,6 +36,48 @@ mod tests {
             open_start: 0,
             open_end: 0,
         }
+    }
+
+    fn horizontal_rule_slice() -> Slice {
+        Slice {
+            content: vec![Fragment::leaf(PlainNode::HorizontalRule(
+                PlainHorizontalRuleNode::default(),
+            ))],
+            open_start: 0,
+            open_end: 0,
+        }
+    }
+
+    fn empty_text_slice() -> Slice {
+        Slice {
+            content: vec![Fragment::leaf(PlainNode::Text(PlainTextNode {
+                text: String::new(),
+            }))],
+            open_start: 0,
+            open_end: 0,
+        }
+    }
+
+    fn assert_rejected_slice_preserves_synthetic_target(
+        initial: editor_state::State,
+        target: Dot,
+        slice: Slice,
+    ) {
+        assert!(target.is_synthetic(), "fixture target must be synthetic");
+        let mut tr = Transaction::new(&initial);
+        assert!(
+            insert_slice_at(
+                &mut tr,
+                Position::new(target, 0),
+                slice,
+                SliceProvenance::Formatted,
+            )
+            .expect("invalid insertion is a no-op")
+            .is_none()
+        );
+        let (actual, ..) = tr.commit();
+        assert_state_eq!(&actual, &initial);
+        assert!(actual.view().node(target).is_some());
     }
 
     fn paragraph_fragment(text: &str) -> Fragment {
@@ -447,6 +490,44 @@ mod tests {
         );
         let (actual, ..) = tr.commit();
         assert_eq!(kinds(&actual.view(), root), vec![NodeType::Paragraph]);
+    }
+
+    #[test]
+    fn rejected_slice_does_not_materialize_or_split_synthetic_textblock() {
+        let (initial, ..) = state! {
+            doc { root { blockquote paragraph {} } }
+            selection: none
+        };
+        let target = {
+            let view = initial.view();
+            view.root()
+                .unwrap()
+                .child_blocks()
+                .find(|block| block.node_type() == NodeType::Blockquote)
+                .unwrap()
+                .child_blocks()
+                .next()
+                .unwrap()
+                .id()
+        };
+        assert_rejected_slice_preserves_synthetic_target(initial, target, horizontal_rule_slice());
+    }
+
+    #[test]
+    fn rejected_empty_inline_slice_does_not_materialize_synthetic_textblock() {
+        let (initial, ..) = state! {
+            doc { root { image } }
+            selection: none
+        };
+        let target = initial
+            .view()
+            .root()
+            .unwrap()
+            .child_blocks()
+            .find(|block| block.node_type() == NodeType::Paragraph)
+            .unwrap()
+            .id();
+        assert_rejected_slice_preserves_synthetic_target(initial, target, empty_text_slice());
     }
 
     #[test]

--- a/crates/editor-commands/src/helpers/slice.rs
+++ b/crates/editor-commands/src/helpers/slice.rs
@@ -103,22 +103,39 @@ pub(crate) fn insert_slice_at_position(
         return Ok(None);
     }
 
-    let position = materialize_position_block(tr, position)?;
     let in_textblock = position_in_textblock(tr, &position);
     if in_textblock {
-        let slice = open_slice_for_textblock_parent(tr, &position, &slice).unwrap_or(slice);
-        let mode = build_inline_mode(tr, &position, provenance)?;
+        let opened = open_slice_for_textblock_parent(tr, &position, &slice);
+        let candidate = opened.as_ref().unwrap_or(&slice);
         if let Some(fragments) =
-            inline_content_fragments_for_textblock_insert(tr, &position, &slice)
+            inline_content_fragments_for_textblock_insert(tr, &position, candidate)
         {
-            insert_content_as_inline_at_position(tr, position, fragments, &mode)
-        } else if can_split_textblock_at_position(tr, &position) {
-            insert_blocks_in_textblock_at_position(tr, position, &slice, &mode)
-        } else {
-            Ok(None)
+            if !fragments.iter().copied().any(is_insertable_inline_fragment) {
+                return Ok(None);
+            }
+            let position = materialize_position_block(tr, position)?;
+            let mode = build_inline_mode(tr, &position, provenance)?;
+            return insert_content_as_inline_at_position(tr, position, fragments, &mode);
         }
+
+        let Some(slice) = opened else {
+            return Ok(None);
+        };
+        let position = materialize_position_block(tr, position)?;
+        let mode = build_inline_mode(tr, &position, provenance)?;
+        insert_blocks_in_textblock_at_position(tr, position, &slice, &mode)
     } else {
-        insert_blocks_at_block_boundary(tr, position, &slice)
+        let container_type = tr
+            .state()
+            .view()
+            .node(position.node)
+            .ok_or(CommandError::NodeNotFound(position.node))?
+            .node_type();
+        let Some(blocks) = block_boundary_fragments(&slice, container_type) else {
+            return Ok(None);
+        };
+        let position = materialize_position_block(tr, position)?;
+        insert_blocks_at_block_boundary(tr, position, blocks)
     }
 }
 
@@ -161,12 +178,6 @@ fn can_split_textblock_for_structural_insert(view: &DocView, textblock_id: Dot) 
     let mut child_types: Vec<NodeType> = parent.children().map(|c| child_node_type(&c)).collect();
     child_types.insert(index + 1, textblock.node_type());
     parent.spec().content.matches_sequence(&child_types)
-}
-
-fn can_split_textblock_at_position(tr: &Transaction, position: &Position) -> bool {
-    let view = tr.state().view();
-    find_ancestor_textblock(&view, position.node)
-        .is_some_and(|textblock| can_split_textblock_for_structural_insert(&view, textblock))
 }
 
 fn open_slice_for_textblock_parent(
@@ -296,6 +307,14 @@ fn insert_inline_fragments(
         }
     }
     Ok(any_change)
+}
+
+fn is_insertable_inline_fragment(fragment: &Fragment) -> bool {
+    match &fragment.node {
+        PlainNode::Text(t) => !t.text.is_empty(),
+        PlainNode::HardBreak(_) | PlainNode::Tab(_) => true,
+        _ => false,
+    }
 }
 
 #[derive(Clone)]
@@ -559,20 +578,10 @@ fn position_at_start_of_block(tr: &Transaction, block_id: Dot) -> Result<Positio
 fn insert_blocks_at_block_boundary(
     tr: &mut Transaction,
     position: Position,
-    slice: &Slice,
+    blocks: Vec<Fragment>,
 ) -> Result<Option<Selection>, CommandError> {
     let container_id = position.node;
     let base_index = position.offset;
-    let container_type = tr
-        .state()
-        .view()
-        .node(container_id)
-        .ok_or(CommandError::NodeNotFound(container_id))?
-        .node_type();
-    let Some(blocks) = block_boundary_fragments(slice, container_type) else {
-        return Ok(None);
-    };
-
     let block_count = blocks.len();
     tr.batch(|tr| {
         for (offset, block) in blocks.iter().enumerate() {


### PR DESCRIPTION
`insert_slice_at`가 무조건 synthetic destination을 먼저 materialize해, 삽입을 거부하고도 state가 바뀔 수 있던 문제 수정