### PR TITLE
맞춤법 검사 오류 응답 캐시 방지

### DIFF
--- a/apps/api/src/external/spellcheck-core.ts
+++ b/apps/api/src/external/spellcheck-core.ts
@@ -317,6 +317,7 @@ export const createSpellcheck =
         const key = `spellcheck:${rapidhash(normalized.text)}`;
 
         let xml: string | null;
+        let providerXml: string | undefined;
         try {
           xml = await dependencies.cacheGet(key);
         } catch (err) {
@@ -325,19 +326,12 @@ export const createSpellcheck =
         signal?.throwIfAborted();
 
         if (!xml) {
-          let providerXml: string;
           try {
             providerXml = await dependencies.requestXml(normalized.text, signal);
           } catch (err) {
             throw asChunkError(err, 'provider-request', chunkIndex, chunks.length, signal);
           }
           xml = providerXml;
-          signal?.throwIfAborted();
-          try {
-            await dependencies.cacheSet(key, CACHE_TTL_SECONDS, providerXml);
-          } catch (err) {
-            throw asChunkError(err, 'cache-write', chunkIndex, chunks.length, signal);
-          }
           signal?.throwIfAborted();
         }
 
@@ -347,11 +341,22 @@ export const createSpellcheck =
         } catch (err) {
           throw asChunkError(err, 'parse', chunkIndex, chunks.length, signal);
         }
+        let result: SpellingError[];
         try {
-          return mapChunkResponse(parsed, chunk, normalized);
+          result = mapChunkResponse(parsed, chunk, normalized);
         } catch (err) {
           throw asChunkError(err, 'provider-response', chunkIndex, chunks.length, signal);
         }
+
+        if (providerXml !== undefined) {
+          try {
+            await dependencies.cacheSet(key, CACHE_TTL_SECONDS, providerXml);
+          } catch (err) {
+            throw asChunkError(err, 'cache-write', chunkIndex, chunks.length, signal);
+          }
+          signal?.throwIfAborted();
+        }
+        return result;
       },
       { concurrency: MAX_CONCURRENCY },
     );

--- a/apps/api/src/external/spellcheck.test.ts
+++ b/apps/api/src/external/spellcheck.test.ts
@@ -8,6 +8,7 @@ const NO_ERROR = '문법 및 철자 오류가 발견되지 않았습니다.';
 
 const response = (body: string) => `<PnuNlpSpeller><PnuErrorWordList>${body}</PnuErrorWordList></PnuNlpSpeller>`;
 const noErrorXml = response(`<Error>${NO_ERROR}</Error>`);
+const providerErrorXml = response('<Error>temporary provider failure</Error>');
 const wordXml = response('<PnuErrorWord><nErrorIdx>0</nErrorIdx><m_nStart>0</m_nStart><m_nEnd>1</m_nEnd></PnuErrorWord>');
 
 const createDependencies = (overrides: Partial<SpellcheckDependencies> = {}): SpellcheckDependencies => ({
@@ -67,6 +68,23 @@ test('a later chunk failure rejects the whole check', async () => {
   const text = `${'a'.repeat(300)}\n${'b'.repeat(300)}`;
 
   await assert.rejects(() => check(text));
+});
+
+test('provider responses are cached only after successful interpretation', async () => {
+  const cache = new Map<string, string>();
+  let requestCount = 0;
+  const check = createSpellcheck({
+    cacheGet: async (key) => cache.get(key) ?? null,
+    cacheSet: async (key, _ttlSeconds, value) => {
+      cache.set(key, value);
+    },
+    requestXml: async () => (++requestCount === 1 ? providerErrorXml : noErrorXml),
+  });
+
+  await assert.rejects(() => check('문장'));
+  assert.deepEqual(await check('문장'), []);
+  assert.deepEqual(await check('문장'), []);
+  assert.equal(requestCount, 2);
 });
 
 test('request abort preserves the exact signal reason', async () => {


### PR DESCRIPTION
기존에는 provider XML 응답을 해석하기 전에 캐시해서 오류 응답도 캐시하는 문제가 있었음