### PR TITLE
PageBreak가 포함된 slice를 삽입 위치에 맞게 처리

### DIFF
--- a/crates/editor-clipboard/src/slice.rs
+++ b/crates/editor-clipboard/src/slice.rs
@@ -441,6 +441,57 @@ mod tests {
     }
 
     #[test]
+    fn extract_page_break_only_is_bare_inline() {
+        let (state, ..) = state! {
+            doc { root { p1: paragraph { text("lo") page_break } } }
+            selection: (p1, 2) -> (p1, 3)
+        };
+
+        let slice = Slice::extract(&state).expect("non-collapsed");
+
+        assert_eq!(slice.open_start, 0);
+        assert_eq!(slice.open_end, 0);
+        assert_eq!(slice.content.len(), 1);
+        assert!(matches!(slice.content[0].node, PlainNode::PageBreak(_)));
+    }
+
+    #[test]
+    fn extract_text_through_page_break_is_bare_inline() {
+        let (state, ..) = state! {
+            doc { root { p1: paragraph { text("lo") page_break } } }
+            selection: (p1, 0) -> (p1, 3)
+        };
+
+        let slice = Slice::extract(&state).expect("non-collapsed");
+
+        assert_eq!(slice.open_start, 0);
+        assert_eq!(slice.open_end, 0);
+        assert_eq!(slice.content.len(), 2);
+        assert!(matches!(slice.content[0].node, PlainNode::Text(_)));
+        assert!(matches!(slice.content[1].node, PlainNode::PageBreak(_)));
+    }
+
+    #[test]
+    fn extract_whole_page_break_paragraph_keeps_closed_block() {
+        let (state, ..) = state! {
+            doc { root: root { paragraph { text("lo") page_break } paragraph {} } }
+            selection: (root, 0) -> (root, 1)
+        };
+
+        let slice = Slice::extract(&state).expect("non-collapsed");
+
+        assert_eq!(slice.open_start, 0);
+        assert_eq!(slice.open_end, 0);
+        assert_eq!(slice.content.len(), 1);
+        assert!(matches!(slice.content[0].node, PlainNode::Paragraph(_)));
+        assert_eq!(slice.content[0].children.len(), 2);
+        assert!(matches!(
+            slice.content[0].children[1].node,
+            PlainNode::PageBreak(_)
+        ));
+    }
+
+    #[test]
     fn extract_inline_within_fold_title_is_bare_inline() {
         let (s, ..) = state! {
             doc { root { fold {

--- a/crates/editor-commands/src/commands/insert_page_break_into_prev_paragraph.rs
+++ b/crates/editor-commands/src/commands/insert_page_break_into_prev_paragraph.rs
@@ -1,7 +1,9 @@
-use editor_model::{ChildView, Node, NodeType, PlainNode, PlainPageBreakNode, Subtree};
+use editor_model::{ChildView, Node};
 use editor_transaction::Transaction;
 
-use crate::helpers::{find_ancestor_textblock, prev_sibling};
+use crate::helpers::{
+    find_ancestor_textblock, insert_terminal_page_break_into_root_paragraph, prev_sibling,
+};
 use crate::{CommandError, CommandResult};
 
 pub fn insert_page_break_into_prev_paragraph(tr: &mut Transaction) -> CommandResult {
@@ -13,7 +15,7 @@ pub fn insert_page_break_into_prev_paragraph(tr: &mut Transaction) -> CommandRes
     }
     let pos = selection.head;
 
-    let (prev_id, insert_index) = {
+    let prev_id = {
         let view = tr.state().view();
         let Some(paragraph_id) = find_ancestor_textblock(&view, pos.node) else {
             return Ok(false);
@@ -42,23 +44,10 @@ pub fn insert_page_break_into_prev_paragraph(tr: &mut Transaction) -> CommandRes
         if !matches!(prev.node(), Node::Paragraph(_)) {
             return Ok(false);
         }
-        let has_page_break = prev.children().any(
-            |child| matches!(child, ChildView::Leaf(l) if l.node_type() == NodeType::PageBreak),
-        );
-        if has_page_break {
-            return Ok(false);
-        }
-
-        (prev.id(), prev.children().count())
+        prev.id()
     };
 
-    tr.insert_subtree(
-        prev_id,
-        insert_index,
-        Subtree::leaf(PlainNode::PageBreak(PlainPageBreakNode::default())),
-    )?;
-
-    Ok(true)
+    insert_terminal_page_break_into_root_paragraph(tr, prev_id)
 }
 
 #[cfg(test)]

--- a/crates/editor-commands/src/commands/insert_slice_at.rs
+++ b/crates/editor-commands/src/commands/insert_slice_at.rs
@@ -22,7 +22,8 @@ mod tests {
     use editor_macros::state;
     use editor_model::{
         ChildView, DocView, Fragment, NodeType, PlainBulletListNode, PlainHorizontalRuleNode,
-        PlainImageNode, PlainListItemNode, PlainNode, PlainParagraphNode, PlainTextNode,
+        PlainImageNode, PlainListItemNode, PlainNode, PlainPageBreakNode, PlainParagraphNode,
+        PlainTextNode,
     };
     use editor_state::{Affinity, Position, Selection};
     use editor_transaction::Transaction;
@@ -58,6 +59,27 @@ mod tests {
         }
     }
 
+    fn page_break_slice() -> Slice {
+        Slice {
+            content: vec![Fragment::leaf(PlainNode::PageBreak(
+                PlainPageBreakNode::default(),
+            ))],
+            open_start: 0,
+            open_end: 0,
+        }
+    }
+
+    fn text_and_page_break_slice(text: &str) -> Slice {
+        Slice {
+            content: vec![
+                Fragment::leaf(PlainNode::Text(PlainTextNode { text: text.into() })),
+                Fragment::leaf(PlainNode::PageBreak(PlainPageBreakNode::default())),
+            ],
+            open_start: 0,
+            open_end: 0,
+        }
+    }
+
     fn assert_rejected_slice_preserves_synthetic_target(
         initial: editor_state::State,
         target: Dot,
@@ -88,6 +110,27 @@ mod tests {
             children: vec![Fragment::leaf(PlainNode::Text(PlainTextNode {
                 text: text.into(),
             }))],
+        }
+    }
+
+    fn paragraph_with_page_break_fragment(text: &str) -> Fragment {
+        Fragment {
+            node: PlainNode::Paragraph(PlainParagraphNode::default()),
+            modifiers: vec![],
+            carry: vec![],
+            children: if text.is_empty() {
+                page_break_slice().content
+            } else {
+                text_and_page_break_slice(text).content
+            },
+        }
+    }
+
+    fn paragraph_with_page_break_slice(text: &str, open_start: u32, open_end: u32) -> Slice {
+        Slice {
+            content: vec![paragraph_with_page_break_fragment(text)],
+            open_start,
+            open_end,
         }
     }
 
@@ -622,5 +665,383 @@ mod tests {
                 },
             )
         );
+    }
+
+    #[test]
+    fn insert_page_break_slice_in_root_paragraph_middle_splits_at_terminal() {
+        let (initial, p1) = state! {
+            doc { root { p1: paragraph { text("World") } } }
+            selection: none
+        };
+
+        let mut tr = Transaction::new(&initial);
+        let inserted = insert_slice_at(
+            &mut tr,
+            Position::new(p1, 3),
+            page_break_slice(),
+            SliceProvenance::Formatted,
+        )
+        .expect("insert succeeds")
+        .expect("page break inserted");
+        let (actual, ..) = tr.commit();
+
+        let (expected, ..) = state! {
+            doc { root {
+                paragraph { text("Wor") page_break }
+                p2: paragraph { text("ld") }
+            } }
+            selection: (p2, 0)
+        };
+        assert_state_eq!(&actual, &expected);
+        assert!(!inserted.is_collapsed());
+    }
+
+    #[test]
+    fn insert_page_break_slice_at_root_paragraph_end_creates_following_paragraph() {
+        let (initial, p1) = state! {
+            doc { root { p1: paragraph { text("World") } } }
+            selection: none
+        };
+
+        let mut tr = Transaction::new(&initial);
+        let inserted = insert_slice_at(
+            &mut tr,
+            Position::new(p1, 5),
+            page_break_slice(),
+            SliceProvenance::Formatted,
+        )
+        .expect("insert succeeds")
+        .expect("page break inserted");
+        let (actual, ..) = tr.commit();
+
+        let (expected, ..) = state! {
+            doc { root {
+                paragraph { text("World") page_break }
+                p2: paragraph {}
+            } }
+            selection: (p2, 0)
+        };
+        assert_state_eq!(&actual, &expected);
+        assert!(!inserted.is_collapsed());
+    }
+
+    #[test]
+    fn insert_open_start_page_break_slice_at_root_paragraph_end_keeps_following_paragraph() {
+        let (initial, p1) = state! {
+            doc { root { p1: paragraph { text("World") } } }
+            selection: none
+        };
+
+        let mut tr = Transaction::new(&initial);
+        let inserted = insert_slice_at(
+            &mut tr,
+            Position::new(p1, 5),
+            paragraph_with_page_break_slice("lo", 1, 0),
+            SliceProvenance::Formatted,
+        )
+        .expect("insert succeeds")
+        .expect("page break inserted");
+        let (actual, ..) = tr.commit();
+
+        let (expected, ..) = state! {
+            doc { root {
+                paragraph { text("Worldlo") page_break }
+                p2: paragraph {}
+            } }
+            selection: (p2, 0)
+        };
+        assert_state_eq!(&actual, &expected);
+        assert!(!inserted.is_collapsed());
+    }
+
+    #[test]
+    fn insert_page_break_only_in_nested_paragraph_is_atomic_no_op() {
+        let (initial, p1) = state! {
+            doc { root { blockquote { p1: paragraph { text("Nested") } } paragraph {} } }
+            selection: none
+        };
+
+        let mut tr = Transaction::new(&initial);
+        let inserted = insert_slice_at(
+            &mut tr,
+            Position::new(p1, 3),
+            page_break_slice(),
+            SliceProvenance::Formatted,
+        )
+        .expect("invalid page break is a no-op");
+        assert!(inserted.is_none());
+        let (actual, ..) = tr.commit();
+
+        assert_state_eq!(&actual, &initial);
+    }
+
+    #[test]
+    fn insert_page_break_only_paragraph_nested_is_atomic_no_op() {
+        let (initial, p1) = state! {
+            doc { root { blockquote { p1: paragraph { text("Nested") } } paragraph {} } }
+            selection: none
+        };
+
+        let mut tr = Transaction::new(&initial);
+        let inserted = insert_slice_at(
+            &mut tr,
+            Position::new(p1, 3),
+            paragraph_with_page_break_slice("", 0, 0),
+            SliceProvenance::Formatted,
+        )
+        .expect("invalid page break is a no-op");
+        assert!(inserted.is_none());
+        let (actual, ..) = tr.commit();
+
+        assert_state_eq!(&actual, &initial);
+    }
+
+    #[test]
+    fn insert_page_break_at_root_block_gap_wraps_it_in_paragraph() {
+        let (initial, root) = state! {
+            doc { root: root { paragraph { text("before") } } }
+            selection: none
+        };
+
+        let mut tr = Transaction::new(&initial);
+        let inserted = insert_slice_at(
+            &mut tr,
+            Position::new(root, 1),
+            page_break_slice(),
+            SliceProvenance::Formatted,
+        )
+        .expect("insert succeeds")
+        .expect("page break inserted");
+        let (actual, ..) = tr.commit();
+
+        let (expected, ..) = state! {
+            doc { root {
+                paragraph { text("before") }
+                paragraph { page_break }
+                p3: paragraph {}
+            } }
+            selection: (p3, 0)
+        };
+        assert_state_eq!(&actual, &expected);
+        assert_eq!(
+            inserted,
+            Selection::new(
+                Position::new(root, 1),
+                Position {
+                    node: root,
+                    offset: 2,
+                    affinity: Affinity::Upstream,
+                },
+            )
+        );
+    }
+
+    #[test]
+    fn insert_non_terminal_page_break_drops_it_and_keeps_following_text() {
+        let (initial, p1) = state! {
+            doc { root { p1: paragraph { text("ab") } } }
+            selection: none
+        };
+        let slice = Slice {
+            content: vec![
+                Fragment::leaf(PlainNode::PageBreak(PlainPageBreakNode::default())),
+                Fragment::leaf(PlainNode::Text(PlainTextNode { text: "x".into() })),
+            ],
+            open_start: 0,
+            open_end: 0,
+        };
+
+        let mut tr = Transaction::new(&initial);
+        let inserted = insert_slice_at(
+            &mut tr,
+            Position::new(p1, 1),
+            slice,
+            SliceProvenance::Formatted,
+        )
+        .expect("insert succeeds")
+        .expect("text inserted");
+        let (actual, ..) = tr.commit();
+
+        let (expected, ..) = state! {
+            doc { root { p1: paragraph { text("axb") } } }
+            selection: (p1, 2)
+        };
+        assert_state_eq!(&actual, &expected);
+        assert!(!inserted.is_collapsed());
+    }
+
+    #[test]
+    fn insert_closed_page_break_paragraph_preserves_block_structure() {
+        let (initial, p1) = state! {
+            doc { root { p1: paragraph { text("World") } } }
+            selection: none
+        };
+        let root = initial.view().root().unwrap().id();
+
+        let mut tr = Transaction::new(&initial);
+        let inserted = insert_slice_at(
+            &mut tr,
+            Position::new(p1, 3),
+            paragraph_with_page_break_slice("lo", 0, 0),
+            SliceProvenance::Formatted,
+        )
+        .expect("insert succeeds")
+        .expect("paragraph inserted");
+        let (actual, ..) = tr.commit();
+
+        let (expected, ..) = state! {
+            doc { root {
+                paragraph { text("Wor") }
+                paragraph { text("lo") page_break }
+                paragraph { text("ld") }
+            } }
+            selection: none
+        };
+        editor_state::assert_doc_eq!(&actual, &expected);
+        assert_eq!(inserted.anchor, Position::new(root, 1));
+        assert_eq!(inserted.head.node, root);
+        assert_eq!(inserted.head.offset, 2);
+    }
+
+    #[test]
+    fn insert_open_page_break_paragraph_keeps_page_break_terminal() {
+        let (initial, p1) = state! {
+            doc { root { p1: paragraph { text("World") } } }
+            selection: none
+        };
+
+        let mut tr = Transaction::new(&initial);
+        let inserted = insert_slice_at(
+            &mut tr,
+            Position::new(p1, 3),
+            paragraph_with_page_break_slice("lo", 1, 1),
+            SliceProvenance::Formatted,
+        )
+        .expect("insert succeeds")
+        .expect("slice inserted");
+        let (actual, ..) = tr.commit();
+
+        let (expected, ..) = state! {
+            doc { root {
+                paragraph { text("Worlo") page_break }
+                p2: paragraph { text("ld") }
+            } }
+            selection: (p2, 0)
+        };
+        assert_state_eq!(&actual, &expected);
+        assert!(!inserted.is_collapsed());
+    }
+
+    #[test]
+    fn insert_closed_page_break_paragraph_nested_drops_only_page_break() {
+        let (initial, p1) = state! {
+            doc { root { blockquote { p1: paragraph { text("Nested") } } paragraph {} } }
+            selection: none
+        };
+
+        let mut tr = Transaction::new(&initial);
+        let inserted = insert_slice_at(
+            &mut tr,
+            Position::new(p1, 3),
+            paragraph_with_page_break_slice("lo", 0, 0),
+            SliceProvenance::Formatted,
+        )
+        .expect("insert succeeds")
+        .expect("paragraph inserted");
+        let (actual, ..) = tr.commit();
+
+        let (expected, ..) = state! {
+            doc { root {
+                blockquote {
+                    paragraph { text("Nes") }
+                    paragraph { text("lo") }
+                    paragraph { text("ted") }
+                }
+                paragraph {}
+            } }
+            selection: none
+        };
+        editor_state::assert_doc_eq!(&actual, &expected);
+        assert!(!inserted.is_collapsed());
+    }
+
+    #[test]
+    fn removing_first_page_break_only_block_does_not_transfer_its_openness() {
+        let (initial, p1) = state! {
+            doc { root { blockquote { p1: paragraph { text("Nested") } } paragraph {} } }
+            selection: none
+        };
+        let slice = Slice {
+            content: vec![
+                paragraph_with_page_break_fragment(""),
+                paragraph_fragment("x"),
+            ],
+            open_start: 1,
+            open_end: 1,
+        };
+
+        let mut tr = Transaction::new(&initial);
+        let inserted = insert_slice_at(
+            &mut tr,
+            Position::new(p1, 3),
+            slice,
+            SliceProvenance::Formatted,
+        )
+        .expect("insert succeeds")
+        .expect("text inserted");
+        let (actual, ..) = tr.commit();
+
+        let (expected, ..) = state! {
+            doc { root {
+                blockquote {
+                    paragraph { text("Nes") }
+                    paragraph { text("xted") }
+                }
+                paragraph {}
+            } }
+            selection: none
+        };
+        editor_state::assert_doc_eq!(&actual, &expected);
+        assert!(!inserted.is_collapsed());
+    }
+
+    #[test]
+    fn removing_last_page_break_only_block_does_not_transfer_its_openness() {
+        let (initial, p1) = state! {
+            doc { root { blockquote { p1: paragraph { text("Nested") } } paragraph {} } }
+            selection: none
+        };
+        let slice = Slice {
+            content: vec![
+                paragraph_fragment("x"),
+                paragraph_with_page_break_fragment(""),
+            ],
+            open_start: 1,
+            open_end: 1,
+        };
+
+        let mut tr = Transaction::new(&initial);
+        let inserted = insert_slice_at(
+            &mut tr,
+            Position::new(p1, 3),
+            slice,
+            SliceProvenance::Formatted,
+        )
+        .expect("insert succeeds")
+        .expect("text inserted");
+        let (actual, ..) = tr.commit();
+
+        let (expected, ..) = state! {
+            doc { root {
+                blockquote {
+                    paragraph { text("Nesx") }
+                    paragraph { text("ted") }
+                }
+                paragraph {}
+            } }
+            selection: none
+        };
+        editor_state::assert_doc_eq!(&actual, &expected);
+        assert!(!inserted.is_collapsed());
     }
 }

--- a/crates/editor-commands/src/helpers/insertion.rs
+++ b/crates/editor-commands/src/helpers/insertion.rs
@@ -3,8 +3,8 @@ use std::collections::BTreeMap;
 use editor_common::StrExt;
 use editor_crdt::Dot;
 use editor_model::{
-    ChildView, Modifier, ModifierType, PlainHardBreakNode, PlainNode, PlainTabNode, PlainTextNode,
-    Subtree,
+    ChildView, Modifier, ModifierType, Node, NodeType, PlainHardBreakNode, PlainNode,
+    PlainPageBreakNode, PlainTabNode, PlainTextNode, Subtree,
 };
 use editor_state::{Affinity, PendingModifiers, Position, Selection};
 use editor_transaction::{Step, Transaction};
@@ -320,6 +320,40 @@ pub(crate) fn materialize_caret_block(tr: &mut Transaction) -> Result<(), Comman
     })))?;
 
     Ok(())
+}
+
+pub(crate) fn insert_terminal_page_break_into_root_paragraph(
+    tr: &mut Transaction,
+    paragraph_id: Dot,
+) -> CommandResult {
+    let insert_index = {
+        let view = tr.state().view();
+        let Some(paragraph) = view.node(paragraph_id) else {
+            return Ok(false);
+        };
+        if !matches!(paragraph.node(), Node::Paragraph(_)) {
+            return Ok(false);
+        }
+        if paragraph
+            .parent()
+            .is_none_or(|parent| parent.id() != Dot::ROOT)
+        {
+            return Ok(false);
+        }
+        if paragraph.children().any(
+            |child| matches!(child, ChildView::Leaf(leaf) if leaf.node_type() == NodeType::PageBreak),
+        ) {
+            return Ok(false);
+        }
+        paragraph.children().count()
+    };
+
+    tr.insert_subtree(
+        paragraph_id,
+        insert_index,
+        Subtree::leaf(PlainNode::PageBreak(PlainPageBreakNode::default())),
+    )?;
+    Ok(true)
 }
 
 fn caret_paint(tr: &Transaction, block: Dot, offset: usize) -> Vec<Modifier> {

--- a/crates/editor-commands/src/helpers/slice.rs
+++ b/crates/editor-commands/src/helpers/slice.rs
@@ -14,6 +14,10 @@ use super::{
 use crate::types::SliceProvenance;
 use crate::{CommandError, CommandResult};
 
+mod page_break;
+
+use page_break::{insert_terminal_page_break_from_edge, prepare_page_breaks_for_position};
+
 enum InlineMode {
     Formatted,
     Plain(Vec<Modifier>),
@@ -102,6 +106,10 @@ pub(crate) fn insert_slice_at_position(
     if slice.is_empty() {
         return Ok(None);
     }
+    let (slice, trailing_block_context) = prepare_page_breaks_for_position(tr, &position, slice);
+    if slice.is_empty() {
+        return Ok(None);
+    }
 
     let in_textblock = position_in_textblock(tr, &position);
     if in_textblock {
@@ -110,7 +118,8 @@ pub(crate) fn insert_slice_at_position(
         if let Some(fragments) =
             inline_content_fragments_for_textblock_insert(tr, &position, candidate)
         {
-            if !fragments.iter().copied().any(is_insertable_inline_fragment) {
+            let fragments: Vec<Fragment> = fragments.into_iter().cloned().collect();
+            if !fragments.iter().any(is_insertable_inline_fragment) {
                 return Ok(None);
             }
             let position = materialize_position_block(tr, position)?;
@@ -135,7 +144,7 @@ pub(crate) fn insert_slice_at_position(
             return Ok(None);
         };
         let position = materialize_position_block(tr, position)?;
-        insert_blocks_at_block_boundary(tr, position, blocks)
+        insert_blocks_at_block_boundary(tr, position, blocks, trailing_block_context)
     }
 }
 
@@ -247,10 +256,9 @@ fn inline_content_fragments_for_textblock_insert<'a>(
 fn insert_content_as_inline_at_position(
     tr: &mut Transaction,
     position: Position,
-    fragments: Vec<&Fragment>,
+    fragments: Vec<Fragment>,
     mode: &InlineMode,
 ) -> Result<Option<Selection>, CommandError> {
-    let fragments: Vec<Fragment> = fragments.into_iter().cloned().collect();
     if fragments.is_empty() {
         return Ok(None);
     }
@@ -416,6 +424,7 @@ fn insert_blocks_in_textblock(
 
     let mut last_caret: Option<Position> = None;
     let mut inserted_range = InsertedRange::default();
+    let mut terminal_page_break_start: Option<Position> = None;
 
     if merge_start {
         let first = blocks[0];
@@ -429,11 +438,15 @@ fn insert_blocks_in_textblock(
             .expect("selection preserved through mutations")
             .head;
         let inserted = insert_inline_fragments(tr, &inline, mode)?;
+        let inserted_page_break = insert_terminal_page_break_from_edge(tr, textblock_id, &inline)?;
         let end = tr
             .selection()
             .expect("selection preserved through mutations")
             .head;
-        if inserted {
+        if inserted_page_break {
+            terminal_page_break_start = Some(start);
+            last_caret = Some(end);
+        } else if inserted {
             inserted_range.include_position_range(start, end);
             last_caret = Some(end);
         }
@@ -487,6 +500,13 @@ fn insert_blocks_in_textblock(
         }
     }
 
+    let keep_trailing_page_break_context = terminal_page_break_start.is_some();
+    if let Some(start) = terminal_page_break_start {
+        let end = position_at_start_of_block(tr, p2_id)?;
+        inserted_range.include_position_range(start, end);
+        last_caret = Some(end);
+    }
+
     let safe_to_remove = |tr: &Transaction, target: Dot| -> bool {
         let view = tr.state().view();
         let Some(target_node) = view.node(target) else {
@@ -512,7 +532,7 @@ fn insert_blocks_in_textblock(
     if !merge_start && safe_to_remove(tr, textblock_id) {
         tr.remove_subtree(textblock_id)?;
     }
-    if !merge_end && safe_to_remove(tr, p2_id) {
+    if !merge_end && !keep_trailing_page_break_context && safe_to_remove(tr, p2_id) {
         tr.remove_subtree(p2_id)?;
     }
 
@@ -579,14 +599,23 @@ fn insert_blocks_at_block_boundary(
     tr: &mut Transaction,
     position: Position,
     blocks: Vec<Fragment>,
+    trailing_block_context: Option<Fragment>,
 ) -> Result<Option<Selection>, CommandError> {
     let container_id = position.node;
     let base_index = position.offset;
-    let block_count = blocks.len();
+    let payload_block_count = blocks.len();
+    let inserted_block_count = payload_block_count + usize::from(trailing_block_context.is_some());
     tr.batch(|tr| {
         for (offset, block) in blocks.iter().enumerate() {
             let subtree = block.clone().into_subtree();
             tr.insert_subtree(container_id, base_index + offset, subtree)?;
+        }
+        if let Some(context) = &trailing_block_context {
+            tr.insert_subtree(
+                container_id,
+                base_index + payload_block_count,
+                context.clone().into_subtree(),
+            )?;
         }
         let steps = {
             let view = tr.state().view();
@@ -598,7 +627,7 @@ fn insert_blocks_at_block_boundary(
         Ok::<(), CommandError>(())
     })?;
 
-    if let Some(id) = block_child_id(tr, container_id, base_index + block_count - 1)
+    if let Some(id) = block_child_id(tr, container_id, base_index + inserted_block_count - 1)
         && let Ok(mut final_pos) = position_at_end_of_block(tr, id)
     {
         final_pos.affinity = Affinity::Downstream;
@@ -608,7 +637,7 @@ fn insert_blocks_at_block_boundary(
     Ok(Some(selection_over_inserted_blocks(
         container_id,
         base_index,
-        block_count,
+        payload_block_count,
     )))
 }
 

--- a/crates/editor-commands/src/helpers/slice/page_break.rs
+++ b/crates/editor-commands/src/helpers/slice/page_break.rs
@@ -1,0 +1,240 @@
+use editor_clipboard::Slice;
+use editor_crdt::Dot;
+use editor_model::{Fragment, NodeType, PlainNode, PlainParagraphNode};
+use editor_state::Position;
+use editor_transaction::Transaction;
+
+use super::{fragments_are_inline, position_in_textblock, top_level_fragments};
+use crate::CommandResult;
+use crate::helpers::{find_ancestor_textblock, insert_terminal_page_break_into_root_paragraph};
+
+pub(super) fn prepare_page_breaks_for_position(
+    tr: &Transaction,
+    position: &Position,
+    slice: Slice,
+) -> (Slice, Option<Fragment>) {
+    if !contains_page_break(&slice.content) {
+        return (slice, None);
+    }
+
+    let in_textblock = position_in_textblock(tr, position);
+    let root_textblock = in_textblock && position_is_in_root_paragraph(tr, position);
+    let root_boundary = !in_textblock && position.node == Dot::ROOT;
+    let inserts_root_paragraph = root_textblock || root_boundary;
+    let top_level_inline = fragments_are_inline(&top_level_fragments(&slice));
+
+    let sanitized = if top_level_inline {
+        sanitize_page_break_siblings(slice.content, inserts_root_paragraph)
+    } else {
+        sanitize_structural_page_break_roots(slice.content, inserts_root_paragraph)
+    };
+    let content = sanitized.fragments;
+
+    if content.is_empty() {
+        return (Slice::new(vec![], 0, 0), None);
+    }
+
+    let terminal_bare_page_break =
+        top_level_inline && content.last().is_some_and(is_page_break_fragment);
+    if root_textblock && terminal_bare_page_break {
+        return (
+            Slice::new(
+                vec![paragraph_with_children(content), empty_paragraph_fragment()],
+                1,
+                1,
+            ),
+            None,
+        );
+    }
+
+    let mut prepared = if root_boundary && top_level_inline {
+        Slice::new(vec![paragraph_with_children(content)], 0, 0)
+    } else {
+        Slice::new(
+            content,
+            slice.open_start.min(sanitized.open_start),
+            slice.open_end.min(sanitized.open_end),
+        )
+    };
+
+    if root_textblock
+        && prepared.open_end > 0
+        && prepared
+            .content
+            .last()
+            .is_some_and(paragraph_ends_with_page_break)
+    {
+        prepared.content.push(empty_paragraph_fragment());
+        prepared.open_end = 1;
+    }
+
+    let trailing_block_context = if root_boundary
+        && root_boundary_is_at_end(tr, position)
+        && prepared
+            .content
+            .last()
+            .is_some_and(paragraph_ends_with_page_break)
+    {
+        Some(empty_paragraph_fragment())
+    } else {
+        None
+    };
+
+    (prepared, trailing_block_context)
+}
+
+pub(super) fn insert_terminal_page_break_from_edge(
+    tr: &mut Transaction,
+    paragraph_id: Dot,
+    fragments: &[Fragment],
+) -> CommandResult {
+    if !fragments.last().is_some_and(is_page_break_fragment) {
+        return Ok(false);
+    }
+    insert_terminal_page_break_into_root_paragraph(tr, paragraph_id)
+}
+
+struct SanitizedPageBreaks {
+    fragments: Vec<Fragment>,
+    open_start: u32,
+    open_end: u32,
+}
+
+struct SanitizedPageBreakFragment {
+    fragment: Fragment,
+    open_start: u32,
+    open_end: u32,
+}
+
+fn sanitize_page_break_fragment(
+    mut fragment: Fragment,
+    root_paragraph: bool,
+) -> Option<SanitizedPageBreakFragment> {
+    let allow_terminal_page_break =
+        root_paragraph && fragment.node.as_type() == NodeType::Paragraph;
+    let had_children = !fragment.children.is_empty();
+    let sanitized = sanitize_page_break_siblings(fragment.children, allow_terminal_page_break);
+    fragment.children = sanitized.fragments;
+    (!had_children || !fragment.children.is_empty()).then_some(SanitizedPageBreakFragment {
+        fragment,
+        open_start: sanitized.open_start.saturating_add(1),
+        open_end: sanitized.open_end.saturating_add(1),
+    })
+}
+
+fn sanitize_page_break_siblings(
+    fragments: Vec<Fragment>,
+    allow_terminal_page_break: bool,
+) -> SanitizedPageBreaks {
+    let original_len = fragments.len();
+    let terminal_page_break = fragments
+        .len()
+        .checked_sub(1)
+        .filter(|&index| allow_terminal_page_break && is_page_break_fragment(&fragments[index]));
+
+    let retained: Vec<_> = fragments
+        .into_iter()
+        .enumerate()
+        .filter_map(|(index, fragment)| {
+            if is_page_break_fragment(&fragment) {
+                return (Some(index) == terminal_page_break).then_some((
+                    index,
+                    SanitizedPageBreakFragment {
+                        fragment,
+                        open_start: 1,
+                        open_end: 1,
+                    },
+                ));
+            }
+            sanitize_page_break_fragment(fragment, false).map(|fragment| (index, fragment))
+        })
+        .collect();
+    finish_page_break_sanitization(retained, original_len)
+}
+
+fn sanitize_structural_page_break_roots(
+    fragments: Vec<Fragment>,
+    allow_root_paragraph: bool,
+) -> SanitizedPageBreaks {
+    let original_len = fragments.len();
+    let retained = fragments
+        .into_iter()
+        .enumerate()
+        .filter_map(|(index, fragment)| {
+            if is_page_break_fragment(&fragment) {
+                return None;
+            }
+            let root_paragraph =
+                allow_root_paragraph && fragment.node.as_type() == NodeType::Paragraph;
+            sanitize_page_break_fragment(fragment, root_paragraph).map(|fragment| (index, fragment))
+        })
+        .collect();
+    finish_page_break_sanitization(retained, original_len)
+}
+
+fn finish_page_break_sanitization(
+    retained: Vec<(usize, SanitizedPageBreakFragment)>,
+    original_len: usize,
+) -> SanitizedPageBreaks {
+    let open_start = retained
+        .first()
+        .filter(|(index, _)| *index == 0)
+        .map_or(0, |(_, fragment)| fragment.open_start);
+    let open_end = retained
+        .last()
+        .filter(|(index, _)| *index + 1 == original_len)
+        .map_or(0, |(_, fragment)| fragment.open_end);
+    SanitizedPageBreaks {
+        fragments: retained
+            .into_iter()
+            .map(|(_, fragment)| fragment.fragment)
+            .collect(),
+        open_start,
+        open_end,
+    }
+}
+
+fn is_page_break_fragment(fragment: &Fragment) -> bool {
+    fragment.node.as_type() == NodeType::PageBreak
+}
+
+fn contains_page_break(fragments: &[Fragment]) -> bool {
+    fragments
+        .iter()
+        .any(|fragment| is_page_break_fragment(fragment) || contains_page_break(&fragment.children))
+}
+
+fn paragraph_ends_with_page_break(fragment: &Fragment) -> bool {
+    fragment.node.as_type() == NodeType::Paragraph
+        && fragment.children.last().is_some_and(is_page_break_fragment)
+}
+
+fn paragraph_with_children(children: Vec<Fragment>) -> Fragment {
+    Fragment {
+        node: PlainNode::Paragraph(PlainParagraphNode::default()),
+        modifiers: vec![],
+        carry: vec![],
+        children,
+    }
+}
+
+fn empty_paragraph_fragment() -> Fragment {
+    paragraph_with_children(vec![])
+}
+
+fn root_boundary_is_at_end(tr: &Transaction, position: &Position) -> bool {
+    tr.state()
+        .view()
+        .root()
+        .is_some_and(|root| position.offset >= root.children().count())
+}
+
+fn position_is_in_root_paragraph(tr: &Transaction, position: &Position) -> bool {
+    let view = tr.state().view();
+    find_ancestor_textblock(&view, position.node).is_some_and(|id| {
+        view.node(id).is_some_and(|node| {
+            node.node_type() == NodeType::Paragraph
+                && node.parent().is_some_and(|parent| parent.id() == Dot::ROOT)
+        })
+    })
+}

--- a/crates/editor-core/src/editor.rs
+++ b/crates/editor-core/src/editor.rs
@@ -3425,6 +3425,41 @@ mod tests {
     }
 
     #[test]
+    fn internal_dnd_text_and_page_break_source_allows_nested_inline_drop_indicator() {
+        let (initial, _p1, p2) = state! {
+            doc { root {
+                p1: paragraph { text("a") page_break }
+                blockquote { p2: paragraph { text("inside") } }
+                paragraph {}
+            } }
+            selection: (p1, 0) -> (p1, 2)
+        };
+        let mut editor = Editor::new_test(initial);
+        editor.apply(Message::System {
+            event: crate::message::SystemEvent::Initialize,
+        });
+        let caret = editor
+            .view()
+            .cursor_metrics(&editor.state, &Position::new(p2, 2))
+            .expect("cursor metrics")
+            .caret;
+
+        editor.apply(Message::Dnd {
+            op: DndOp::StartInternalSelection,
+        });
+        editor.apply(Message::Dnd {
+            op: DndOp::Over {
+                page: 0,
+                x: caret.x,
+                y: caret.y + caret.height * 0.5,
+                modifiers: InputModifiers::default(),
+            },
+        });
+
+        assert!(editor.drop_indicator_for_test().is_some());
+    }
+
+    #[test]
     fn internal_dnd_page_break_source_allows_root_inline_drop_indicator() {
         let (initial, _p1, p2) = state! {
             doc { root {
@@ -4011,6 +4046,104 @@ mod tests {
         let (expected, _p1_e) = state! {
             doc { root { p1: paragraph { text("hello worldhello") } } }
             selection: (p1, 11) -> (p1, 16)
+        };
+        editor_state::assert_state_eq!(editor.state(), &expected);
+    }
+
+    #[test]
+    fn internal_drop_moves_text_and_discards_page_break_at_nested_destination() {
+        let (initial, _p1, p2) = state! {
+            doc { root {
+                p1: paragraph { text("a") page_break }
+                blockquote { p2: paragraph { text("inside") } }
+                paragraph {}
+            } }
+            selection: (p1, 0) -> (p1, 2)
+        };
+        let source = initial.selection.expect("source selection");
+        let mut editor = Editor::new_test(initial);
+
+        crate::handle::apply_drop_for_test(
+            &mut editor,
+            Position::new(p2, 2),
+            DndDropPayload::InternalSelection,
+            InputModifiers::default(),
+            Some(source),
+        )
+        .expect("drop succeeds");
+
+        let (expected, ..) = state! {
+            doc { root {
+                paragraph {}
+                blockquote { p2: paragraph { text("inaside") } }
+                paragraph {}
+            } }
+            selection: (p2, 2) -> (p2, 3)
+        };
+        editor_state::assert_state_eq!(editor.state(), &expected);
+    }
+
+    #[test]
+    fn internal_drop_page_break_only_nested_preserves_source() {
+        let (initial, _p1, p2) = state! {
+            doc { root {
+                p1: paragraph { text("a") page_break }
+                blockquote { p2: paragraph { text("inside") } }
+                paragraph {}
+            } }
+            selection: (p1, 1) -> (p1, 2)
+        };
+        let source = initial.selection.expect("source selection");
+        let mut editor = Editor::new_test(initial.clone());
+
+        crate::handle::apply_drop_for_test(
+            &mut editor,
+            Position::new(p2, 2),
+            DndDropPayload::InternalSelection,
+            InputModifiers::default(),
+            Some(source),
+        )
+        .expect("drop is a no-op");
+
+        editor_state::assert_state_eq!(editor.state(), &initial);
+    }
+
+    #[test]
+    fn external_drop_inserts_text_and_discards_page_break_at_nested_destination() {
+        let (source, ..) = state! {
+            doc { root { p1: paragraph { text("a") page_break } } }
+            selection: (p1, 0) -> (p1, 2)
+        };
+        let payload = Slice::extract(&source)
+            .unwrap()
+            .to_payload(&Resource::new_test());
+        let (target, p2) = state! {
+            doc { root {
+                blockquote { p2: paragraph { text("inside") } }
+                paragraph {}
+            } }
+            selection: (p2, 0)
+        };
+        let mut editor = Editor::new_test(target);
+
+        crate::handle::apply_drop_for_test(
+            &mut editor,
+            Position::new(p2, 2),
+            DndDropPayload::Text {
+                text: payload.text,
+                html: Some(payload.html),
+            },
+            InputModifiers::default(),
+            None,
+        )
+        .expect("drop succeeds");
+
+        let (expected, ..) = state! {
+            doc { root {
+                blockquote { p2: paragraph { text("inaside") } }
+                paragraph {}
+            } }
+            selection: (p2, 2) -> (p2, 3)
         };
         editor_state::assert_state_eq!(editor.state(), &expected);
     }

--- a/crates/editor-core/src/handle/clipboard.rs
+++ b/crates/editor-core/src/handle/clipboard.rs
@@ -1001,6 +1001,66 @@ mod tests {
     }
 
     #[test]
+    fn paste_page_break_slice_in_root_paragraph_splits_at_terminal() {
+        let (source, ..) = state! {
+            doc { root { p1: paragraph { text("lo") page_break } } }
+            selection: (p1, 0) -> (p1, 3)
+        };
+        let payload = Slice::extract(&source)
+            .unwrap()
+            .to_payload(&Resource::new_test());
+        let (target, ..) = state! {
+            doc { root { p1: paragraph { text("World") } } }
+            selection: (p1, 3)
+        };
+        let mut editor = Editor::new_test(target);
+
+        editor.apply(Message::Clipboard {
+            op: ClipboardOp::Paste {
+                html: Some(payload.html),
+                text: payload.text,
+            },
+        });
+
+        let (expected, ..) = state! {
+            doc { root {
+                paragraph { text("Worlo") page_break }
+                p2: paragraph { text("ld") }
+            } }
+            selection: (p2, 0)
+        };
+        assert_state_eq!(editor.state(), &expected);
+    }
+
+    #[test]
+    fn paste_page_break_only_into_nested_selection_preserves_selection() {
+        let (source, ..) = state! {
+            doc { root { p1: paragraph { text("a") page_break } } }
+            selection: (p1, 1) -> (p1, 2)
+        };
+        let payload = Slice::extract(&source)
+            .unwrap()
+            .to_payload(&Resource::new_test());
+        let (target, ..) = state! {
+            doc { root {
+                blockquote { p2: paragraph { text("Nested") } }
+                paragraph {}
+            } }
+            selection: (p2, 1) -> (p2, 4)
+        };
+        let mut editor = Editor::new_test(target.clone());
+
+        editor.apply(Message::Clipboard {
+            op: ClipboardOp::Paste {
+                html: Some(payload.html),
+                text: payload.text,
+            },
+        });
+
+        assert_state_eq!(editor.state(), &target);
+    }
+
+    #[test]
     fn paste_html_sets_paste_html_tag() {
         let (s_source, ..) = state! {
             doc { root { p1: paragraph { text("hello") } } }

--- a/crates/editor-core/src/handle/dnd.rs
+++ b/crates/editor-core/src/handle/dnd.rs
@@ -4,10 +4,7 @@ use crate::error::EditorError;
 use crate::message::{DndDropPayload, DndOp, ExternalDndPayloadKind, InputModifiers};
 use editor_clipboard::Slice;
 use editor_commands::{self as commands};
-use editor_model::{
-    ChildView, ContextExpr, DocView, Fragment, Node, NodeType, PlainFileNode, PlainImageNode,
-    PlainNode, Schema,
-};
+use editor_model::{ChildView, DocView, Fragment, Node, PlainFileNode, PlainImageNode, PlainNode};
 use editor_state::{Position, Selection, StableResolveCtx, StableSelection, State};
 use editor_view::DropTarget;
 
@@ -319,40 +316,6 @@ pub(crate) fn apply_drop_for_test(
     apply_drop(editor, position, payload, modifiers, source)
 }
 
-/// A drop is rejected when the slice carries a leaf whose schema context cannot
-/// be satisfied at the drop target (e.g. a `page_break`, valid only directly
-/// under `Root > Paragraph`, dropped into a paragraph nested in a blockquote).
-/// Without this the inline-insert path silently relocates or drops such a leaf,
-/// so the probe would wrongly accept the drop.
-fn slice_content_fits_target_context(view: &DocView, position: Position, slice: &Slice) -> bool {
-    let mut textblock = view.node(position.node);
-    while let Some(node) = &textblock {
-        if node.spec().is_textblock() {
-            break;
-        }
-        textblock = node.parent();
-    }
-    let Some(textblock) = textblock else {
-        return true;
-    };
-    let mut base: Vec<NodeType> = textblock.ancestors().map(|a| a.node_type()).collect();
-    base.reverse();
-
-    fn check(fragment: &Fragment, base: &[NodeType]) -> bool {
-        let ty = fragment.node.as_type();
-        let spec = Schema::node_spec(ty);
-        if spec.is_leaf() && spec.context != ContextExpr::Any {
-            let mut path = base.to_vec();
-            path.push(ty);
-            if !spec.context.matches(&path) {
-                return false;
-            }
-        }
-        fragment.children.iter().all(|c| check(c, base))
-    }
-    slice.content.iter().all(|fragment| check(fragment, &base))
-}
-
 fn drop_slice_at(
     editor: &mut Editor,
     position: Position,
@@ -360,9 +323,6 @@ fn drop_slice_at(
     provenance: commands::types::SliceProvenance,
     selection: SelectionAfterDrop,
 ) -> Result<(), EditorError> {
-    if !slice_content_fits_target_context(&editor.state.view(), position, &slice) {
-        return Ok(());
-    }
     editor.transact(|tr| {
         let inserted_selection =
             commands::insert_slice_at(tr, position, slice.clone(), provenance)?;
@@ -424,10 +384,6 @@ fn drop_internal_selection_at(
         return Ok(());
     };
 
-    if !slice_content_fits_target_context(&editor.state.view(), position, &slice) {
-        return Ok(());
-    }
-
     if copy {
         return drop_slice_at(
             editor,
@@ -441,6 +397,7 @@ fn drop_internal_selection_at(
     let stable_target =
         StableSelection::capture(&Selection::collapsed(position), &editor.state.view());
     editor.transact(|tr| {
+        let savepoint = tr.savepoint();
         commands::set_selection(tr, source)?;
         commands::delete_selection(tr)?;
 
@@ -450,15 +407,20 @@ fn drop_internal_selection_at(
             stable_target.resolve(&ctx)
         };
         let Some(target) = resolved_target.map(|sel| sel.head) else {
+            tr.rollback(savepoint);
             return Ok(());
         };
-        if let Some(inserted_selection) = commands::insert_slice_at(
+        let Some(inserted_selection) = commands::insert_slice_at(
             tr,
             target,
             slice.clone(),
             commands::types::SliceProvenance::Formatted,
-        )? && !inserted_selection.is_collapsed()
-        {
+        )?
+        else {
+            tr.rollback(savepoint);
+            return Ok(());
+        };
+        if !inserted_selection.is_collapsed() {
             commands::set_selection(tr, inserted_selection)?;
         }
         Ok(())


### PR DESCRIPTION
- PageBreak가 포함된 slice를 root Paragraph에 삽입하면 PageBreak가 paragraph 끝에 놓이도록 분할하고, root block gap에서는 Paragraph로 감싸 뒤에 입력 가능한 Paragraph를 보장
- PageBreak를 허용하지 않는 nested destination에서는 PageBreak만 제거하고 나머지 content를 삽입. PageBreak만 남으면 mutation 없이 거부
- clipboard와 DnD가 같은 slice 삽입 정책을 사용하도록 하고, internal DnD move가 거부되면 source 삭제까지 rollback