### PR TITLE
에디터 이탈 시 마지막 변경 저장 확인

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationStack.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationStack.kt
@@ -60,7 +60,11 @@ import co.typie.ui.theme.AppShapes
 import co.typie.ui.theme.AppTheme
 import kotlin.math.abs
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -152,7 +156,15 @@ fun NavigationStack(
     animState = AnimState.Idle
   }
 
-  suspend fun animateRemovalTo(target: Route): Boolean {
+  fun commitRemovalTo(target: Route) {
+    val removedRoutes = navigator.performPopTo(target)
+    visibleRoute = navigator.current
+    behindRoute = null
+    animState = AnimState.Idle
+    clearRemovedRoutes(removedRoutes)
+  }
+
+  suspend fun animateRemovalTo(target: Route, verifyPreparedSegment: Boolean = true): Boolean {
     val requiresTransition = target != navigator.current
     val continuesPopGesture =
       animState == AnimState.PopGestureCommitted &&
@@ -175,18 +187,14 @@ fun NavigationStack(
       }
     }
 
-    if (!navigator.routeRemovals.activeSegmentIsCurrent()) {
+    if (verifyPreparedSegment && !navigator.routeRemovals.activeSegmentIsCurrent()) {
       navigator.routeRemovals.rollbackActiveSegment()
       settleAtCurrentRoute()
       return false
     }
 
     if (!requiresTransition) return true
-    val removedRoutes = navigator.performPopTo(target)
-    visibleRoute = navigator.current
-    behindRoute = null
-    animState = AnimState.Idle
-    clearRemovedRoutes(removedRoutes)
+    commitRemovalTo(target)
     return true
   }
 
@@ -196,7 +204,11 @@ fun NavigationStack(
       check(targetIndex >= 0) { "Removal target is not in the navigation stack" }
       val routesToRemove =
         navigator.stack.subList(targetIndex + 1, navigator.stack.size).asReversed()
-      val segment = navigator.routeRemovals.prepareSegment(routesToRemove, target)
+      val segment =
+        navigator.routeRemovals.prepareSegment(routesToRemove, target) { delayedRoute ->
+          animateRemovalTo(delayedRoute, verifyPreparedSegment = false)
+          navigator.routeRemovals.commitReadyPrefix()
+        }
       if (!animateRemovalTo(segment.destination)) continue
 
       if (segment.blockedRoute == null) {
@@ -211,6 +223,76 @@ fun NavigationStack(
     }
     navigator.routeRemovals.commitSegment()
     return NavigationResult.ReachedTarget
+  }
+
+  suspend fun performCommittedGestureRemoval(target: Route): NavigationResult = coroutineScope {
+    var delayed = false
+    val exitAnimation =
+      async(start = CoroutineStart.UNDISPATCHED) {
+        progress.animateTo(1f, spring(stiffness = StiffnessMediumLow))
+      }
+
+    suspend fun settleGestureAtCurrentRoute() {
+      exitAnimation.cancelAndJoin()
+      progress.animateTo(0f, spring(stiffness = StiffnessMediumLow))
+      settleAtCurrentRoute()
+    }
+
+    suspend fun rollbackGestureAndRetry(): NavigationResult {
+      try {
+        navigator.routeRemovals.rollbackActiveSegment()
+      } finally {
+        settleGestureAtCurrentRoute()
+      }
+      return performProgressiveRemoval(target)
+    }
+
+    try {
+      val targetIndex = navigator.stack.lastIndexOf(target)
+      check(targetIndex >= 0) { "Removal target is not in the navigation stack" }
+      val routesToRemove =
+        navigator.stack.subList(targetIndex + 1, navigator.stack.size).asReversed()
+      val segment =
+        navigator.routeRemovals.prepareSegment(routesToRemove, target) {
+          settleGestureAtCurrentRoute()
+          delayed = true
+        }
+
+      if (!navigator.routeRemovals.activeSegmentIsCurrent()) {
+        return@coroutineScope rollbackGestureAndRetry()
+      }
+
+      if (segment.blockedRoute == null) {
+        if (delayed) {
+          if (!animateRemovalTo(target)) {
+            return@coroutineScope performProgressiveRemoval(target)
+          }
+        } else {
+          exitAnimation.await()
+        }
+        if (!navigator.routeRemovals.activeSegmentIsCurrent()) {
+          return@coroutineScope rollbackGestureAndRetry()
+        }
+
+        if (!delayed) commitRemovalTo(target)
+        navigator.routeRemovals.commitSegment()
+        return@coroutineScope NavigationResult.ReachedTarget
+      }
+
+      if (!delayed) settleGestureAtCurrentRoute()
+      if (!navigator.routeRemovals.activeSegmentIsCurrent()) {
+        return@coroutineScope rollbackGestureAndRetry()
+      }
+
+      navigator.routeRemovals.commitReadyPrefix()
+      navigator.routeRemovals.resolveBlockedRoute()?.let {
+        return@coroutineScope it
+      }
+      performProgressiveRemoval(target)
+    } catch (throwable: Throwable) {
+      withContext(NonCancellable) { settleGestureAtCurrentRoute() }
+      throw throwable
+    }
   }
 
   fun startPopDrag() {
@@ -352,30 +434,54 @@ fun NavigationStack(
               (currentAnimState == AnimState.PopGestureCommitted && targetRoute == behindRoute))
         ) {
           try {
-            val result = performProgressiveRemoval(targetRoute)
+            val result =
+              when (navigator.peekRemovalPolicy()) {
+                RouteRemovalPolicy.Intercept ->
+                  if (
+                    currentAnimState == AnimState.PopGestureCommitted && targetRoute == behindRoute
+                  ) {
+                    performCommittedGestureRemoval(targetRoute)
+                  } else {
+                    performProgressiveRemoval(targetRoute)
+                  }
+                RouteRemovalPolicy.BypassInterceptors -> {
+                  check(animateRemovalTo(targetRoute))
+                  NavigationResult.ReachedTarget
+                }
+              }
             navigator.consumePopRequest()
             navigator.completeTransition(result = result)
           } catch (e: Throwable) {
             withContext(NonCancellable) {
-              val rollbackFailure =
-                try {
-                  navigator.routeRemovals.rollbackActiveSegment()
-                  null
-                } catch (throwable: Throwable) {
-                  throwable
+              if (navigator.peekRemovalPolicy() == RouteRemovalPolicy.BypassInterceptors) {
+                // Server deletion already succeeded. Do not strand the deleted document because
+                // presentation failed; finish the exact prepared removal without another prompt.
+                val removedRoutes = navigator.performPopTo(targetRoute)
+                settleAtCurrentRoute()
+                clearRemovedRoutes(removedRoutes)
+                navigator.consumePopRequest()
+                navigator.completeTransition()
+              } else {
+                val rollbackFailure =
+                  try {
+                    navigator.routeRemovals.rollbackActiveSegment()
+                    null
+                  } catch (throwable: Throwable) {
+                    throwable
+                  }
+                val settleFailure =
+                  try {
+                    settleAtCurrentRoute()
+                    null
+                  } catch (throwable: Throwable) {
+                    throwable
+                  }
+                listOfNotNull(rollbackFailure, settleFailure).forEach { cleanupFailure ->
+                  if (cleanupFailure !== e) e.addSuppressed(cleanupFailure)
                 }
-              val settleFailure =
-                try {
-                  settleAtCurrentRoute()
-                  null
-                } catch (throwable: Throwable) {
-                  throwable
-                }
-              listOfNotNull(rollbackFailure, settleFailure).forEach { cleanupFailure ->
-                if (cleanupFailure !== e) e.addSuppressed(cleanupFailure)
+                navigator.consumePopRequest()
+                navigator.completeTransition(e)
               }
-              navigator.consumePopRequest()
-              navigator.completeTransition(e)
             }
             if (e is CancellationException) throw e
           }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/Navigator.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/Navigator.kt
@@ -33,6 +33,7 @@ class Navigator(startRoute: Route) {
 
   private val viewModelStores = mutableMapOf<Route, ViewModelStore>()
   internal val routeRemovals = RouteRemovalCoordinator()
+  private var removalLeaseActive by mutableStateOf(false)
 
   val current: Route
     get() = _stack.last()
@@ -47,13 +48,14 @@ class Navigator(startRoute: Route) {
     private set
 
   private var pendingPopTarget: Route? by mutableStateOf(null)
+  private var pendingRemovalPolicy = RouteRemovalPolicy.Intercept
   val popRequested: Boolean
     get() = pendingPopTarget != null
 
   private var transitionCompletion: CompletableDeferred<NavigationResult>? = null
 
   val isTransitioning: Boolean
-    get() = transitionCompletion?.isActive == true
+    get() = transitionCompletion?.isActive == true || removalLeaseActive
 
   fun viewModelStoreFor(route: Route): ViewModelStore {
     return viewModelStores.getOrPut(route) { ViewModelStore() }
@@ -91,9 +93,74 @@ class Navigator(startRoute: Route) {
 
   internal fun consumePopRequest() {
     pendingPopTarget = null
+    pendingRemovalPolicy = RouteRemovalPolicy.Intercept
   }
 
   internal fun peekPopTarget(): Route? = pendingPopTarget
+
+  internal fun peekRemovalPolicy(): RouteRemovalPolicy = pendingRemovalPolicy
+
+  internal suspend fun prepareAdjacentRemoval(
+    currentRoute: Route,
+    adjacentRoute: Route,
+  ): PreparedAdjacentRemoval? {
+    if (isTransitioning || current != currentRoute || previous != adjacentRoute) {
+      return null
+    }
+    if (!routeRemovals.hasInterceptor(adjacentRoute)) {
+      return null
+    }
+
+    removalLeaseActive = true
+    return try {
+      val target =
+        _stack.getOrNull(_stack.lastIndex - 2) ?: return null.also { removalLeaseActive = false }
+      val segment =
+        routeRemovals.prepareSegment(
+          routesToRemove = listOf(adjacentRoute),
+          requestedTarget = target,
+        )
+      if (segment.blockedRoute != null || !routeRemovals.activeSegmentIsCurrent()) {
+        routeRemovals.rollbackActiveSegment()
+        removalLeaseActive = false
+        null
+      } else {
+        PreparedAdjacentRemoval(
+          currentRoute = currentRoute,
+          adjacentRoute = adjacentRoute,
+          targetRoute = target,
+        )
+      }
+    } catch (throwable: Throwable) {
+      removalLeaseActive = false
+      throw throwable
+    }
+  }
+
+  internal suspend fun commitAdjacentRemoval(prepared: PreparedAdjacentRemoval): NavigationResult {
+    check(!prepared.consumed) { "Prepared adjacent removal was already consumed" }
+    check(removalLeaseActive) { "Adjacent removal lease is not active" }
+    check(current == prepared.currentRoute && previous == prepared.adjacentRoute) {
+      "Prepared Document/Editor pair is no longer adjacent"
+    }
+    routeRemovals.commitSegment()
+    prepared.consumed = true
+    removalLeaseActive = false
+    return requestRemoval(
+      target = prepared.targetRoute,
+      policy = RouteRemovalPolicy.BypassInterceptors,
+    )
+  }
+
+  internal suspend fun rollbackAdjacentRemoval(prepared: PreparedAdjacentRemoval) {
+    if (prepared.consumed) return
+    prepared.consumed = true
+    try {
+      routeRemovals.rollbackActiveSegment()
+    } finally {
+      removalLeaseActive = false
+    }
+  }
 
   internal fun performPopTo(route: Route): List<Route> {
     val index = _stack.lastIndexOf(route)
@@ -119,7 +186,10 @@ class Navigator(startRoute: Route) {
 
   suspend fun popToRoot(): NavigationResult = popTo(_stack.first())
 
-  private suspend fun requestRemoval(target: Route): NavigationResult {
+  private suspend fun requestRemoval(
+    target: Route,
+    policy: RouteRemovalPolicy = RouteRemovalPolicy.Intercept,
+  ): NavigationResult {
     val activeTransition = transitionCompletion
     if (activeTransition?.isActive == true) {
       return if (popRequested && pendingPopTarget == target) {
@@ -128,13 +198,17 @@ class Navigator(startRoute: Route) {
         NavigationResult.NotStarted
       }
     }
+    if (removalLeaseActive) return NavigationResult.NotStarted
+
     val deferred = CompletableDeferred<NavigationResult>()
     transitionCompletion = deferred
+    pendingRemovalPolicy = policy
     pendingPopTarget = target
     return deferred.await()
   }
 
   private suspend fun resultForCurrentRoute(): NavigationResult {
+    if (removalLeaseActive) return NavigationResult.NotStarted
     val activeTransition = transitionCompletion
     return when {
       activeTransition?.isActive != true -> NavigationResult.ReachedTarget
@@ -147,4 +221,18 @@ class Navigator(startRoute: Route) {
     viewModelStores.values.forEach { it.clear() }
     viewModelStores.clear()
   }
+}
+
+internal enum class RouteRemovalPolicy {
+  Intercept,
+  BypassInterceptors,
+}
+
+internal class PreparedAdjacentRemoval
+internal constructor(
+  internal val currentRoute: Route,
+  internal val adjacentRoute: Route,
+  internal val targetRoute: Route,
+) {
+  internal var consumed = false
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/RouteRemovalCoordinator.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/RouteRemovalCoordinator.kt
@@ -15,7 +15,7 @@ internal enum class RouteRemovalDecision {
 }
 
 internal interface RouteRemovalInterceptor {
-  suspend fun prepare(): RouteRemovalPreparation
+  suspend fun prepare(onDelayed: (suspend () -> Unit)? = null): RouteRemovalPreparation
 
   suspend fun resolveDecision(): RouteRemovalDecision
 
@@ -33,6 +33,7 @@ internal class RouteRemovalCoordinator {
   private val interceptors = mutableMapOf<Route, RegisteredInterceptor>()
   private val approvedRoutes = mutableListOf<PreparedRoute>()
   private val preparedRoutes = mutableListOf<PreparedRoute>()
+  private var preparingRoute: PreparedRoute? = null
   private var blockedRoute: PreparedRoute? = null
 
   fun register(route: Route, interceptor: RouteRemovalInterceptor): () -> Unit {
@@ -48,17 +49,22 @@ internal class RouteRemovalCoordinator {
   fun activeSegmentIsCurrent(): Boolean {
     val preparedCurrent = preparedRoutes.all { interceptors[it.route] === it.registration }
     val approvedRoutesCurrent = approvedRoutes.all { interceptors[it.route] === it.registration }
+    val preparing = preparingRoute
     val blocked = blockedRoute
     return preparedCurrent &&
       approvedRoutesCurrent &&
+      (preparing == null || interceptors[preparing.route] === preparing.registration) &&
       (blocked == null || interceptors[blocked.route] === blocked.registration)
   }
+
+  fun hasInterceptor(route: Route): Boolean = route in interceptors
 
   suspend fun prepareSegment(
     routesToRemove: List<Route>,
     requestedTarget: Route,
+    onDelayed: (suspend (Route) -> Unit)? = null,
   ): PreparedRemovalSegment {
-    check(preparedRoutes.isEmpty() && blockedRoute == null) {
+    check(preparedRoutes.isEmpty() && preparingRoute == null && blockedRoute == null) {
       "A route removal segment is already active"
     }
 
@@ -73,13 +79,16 @@ internal class RouteRemovalCoordinator {
         }
 
         val preparedRoute = PreparedRoute(route, registration)
+        preparingRoute = preparedRoute
         val preparation =
           try {
-            registration.interceptor.prepare()
+            registration.interceptor.prepare(onDelayed?.let { callback -> { callback(route) } })
           } catch (throwable: Throwable) {
+            if (preparingRoute === preparedRoute) preparingRoute = null
             throwable.addCleanupFailure(rollbackRoutes(listOf(preparedRoute)))
             throw throwable
           }
+        if (preparingRoute === preparedRoute) preparingRoute = null
         when (preparation) {
           RouteRemovalPreparation.Ready -> preparedRoutes += preparedRoute
           RouteRemovalPreparation.NeedsDecision -> {
@@ -104,6 +113,7 @@ internal class RouteRemovalCoordinator {
 
   /** Called after an unblocked segment has actually left the stack. */
   fun commitSegment() {
+    check(preparingRoute == null) { "A route removal preparation is still active" }
     preparedRoutes.clear()
     blockedRoute = null
     approvedRoutes.clear()
@@ -137,10 +147,12 @@ internal class RouteRemovalCoordinator {
   suspend fun rollbackActiveSegment() {
     val routes = buildList {
       blockedRoute?.let(::add)
+      preparingRoute?.let(::add)
       addAll(preparedRoutes.asReversed())
       addAll(approvedRoutes.asReversed())
     }
     blockedRoute = null
+    preparingRoute = null
     preparedRoutes.clear()
     approvedRoutes.clear()
     rollbackRoutes(routes)?.let { throw it }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/document/document/DocumentScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/document/document/DocumentScreen.kt
@@ -62,8 +62,12 @@ import co.typie.graphql.type.DocumentType
 import co.typie.graphql.type.EntityVisibility
 import co.typie.icons.Lucide
 import co.typie.navigation.Nav
+import co.typie.navigation.NavigationResult
+import co.typie.navigation.PreparedAdjacentRemoval
+import co.typie.result.DEFAULT_ERROR_MESSAGE
 import co.typie.result.isOk
 import co.typie.result.onOk
+import co.typie.result.result
 import co.typie.result.withDefaultExceptionHandler
 import co.typie.route.Route
 import co.typie.storage.Preference
@@ -135,25 +139,19 @@ fun DocumentScreen(entityId: String) {
 
     val targetRoute = nav.stack.getOrNull(nav.stack.lastIndex - 2)
     if (targetRoute != null) {
-      nav.popTo(targetRoute)
+      return nav.popTo(targetRoute) is NavigationResult.ReachedTarget
     } else {
-      nav.pop()
-    }
-    return true
-  }
-
-  suspend fun popAfterDelete() {
-    withContext(NonCancellable) {
-      if (!popDocumentAndMatchingEditorIfPresent()) {
-        nav.pop()
-      }
+      return nav.pop() is NavigationResult.ReachedTarget
     }
   }
 
   suspend fun replaceWithDuplicatedEditor(duplicatedEntityId: String) {
     withContext(NonCancellable) {
-      popDocumentAndMatchingEditorIfPresent()
-      nav.navigate(Route.Editor(duplicatedEntityId))
+      val hasMatchingEditor = nav.previous == Route.Editor(entityId)
+      if (hasMatchingEditor && !popDocumentAndMatchingEditorIfPresent()) return@withContext
+      if (nav.navigate(Route.Editor(duplicatedEntityId)) !is NavigationResult.ReachedTarget) {
+        return@withContext
+      }
       toast.success("문서를 복제했어요.")
     }
   }
@@ -323,7 +321,7 @@ fun DocumentScreen(entityId: String) {
     }
     val deleteDocument: suspend () -> Unit = {
       if (!loading) {
-        val result =
+        val confirmation =
           dialog.confirm(
             title = "문서 삭제",
             message =
@@ -331,10 +329,41 @@ fun DocumentScreen(entityId: String) {
             confirmText = "삭제하기",
             confirmIsDestructive = true,
           )
-        if (result is DialogResult.Resolved) {
-          val deleteResult = model.deleteDocument(document.id).withDefaultExceptionHandler(toast)
-          if (deleteResult.isOk) {
-            popAfterDelete()
+        if (confirmation is DialogResult.Resolved) {
+          val documentRoute = Route.Document(entityId)
+          val editorRoute = Route.Editor(entityId)
+          val matchingEditorPresent = nav.current == documentRoute && nav.previous == editorRoute
+          if (!matchingEditorPresent) {
+            val deleteResult = model.deleteDocument(document.id).withDefaultExceptionHandler(toast)
+            if (deleteResult.isOk) {
+              withContext(NonCancellable) { nav.pop() }
+            }
+          } else {
+            val preparation =
+              result<PreparedAdjacentRemoval?, Nothing> {
+                  nav.prepareAdjacentRemoval(documentRoute, editorRoute)
+                }
+                .withDefaultExceptionHandler(toast)
+            preparation.onOk { prepared ->
+              if (prepared == null) {
+                toast.error(DEFAULT_ERROR_MESSAGE)
+                return@onOk
+              }
+
+              var removalCommitted = false
+              try {
+                val deleteResult =
+                  model.deleteDocument(document.id).withDefaultExceptionHandler(toast)
+                if (deleteResult.isOk) {
+                  withContext(NonCancellable) { nav.commitAdjacentRemoval(prepared) }
+                  removalCommitted = true
+                }
+              } finally {
+                if (!removalCommitted) {
+                  nav.rollbackAdjacentRemoval(prepared)
+                }
+              }
+            }
           }
         }
       }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorRouteLeaveInterceptor.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorRouteLeaveInterceptor.kt
@@ -1,0 +1,111 @@
+package co.typie.screen.editor.editor
+
+import co.typie.editor.DocumentEditingClose
+import co.typie.editor.LocalDurabilityResult
+import co.typie.navigation.RouteRemovalDecision
+import co.typie.navigation.RouteRemovalInterceptor
+import co.typie.navigation.RouteRemovalPreparation
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withTimeoutOrNull
+
+internal class EditorRouteLeaveInterceptor(
+  private val finalizeInput: () -> Unit,
+  private val restoreInput: () -> Unit,
+  private val beginClose: () -> DocumentEditingClose,
+  private val resolveDecision: suspend () -> RouteRemovalDecision,
+  private val delayedFeedbackMillis: Long = DEFAULT_DELAYED_FEEDBACK_MILLIS,
+  private val localDurabilityWatchdogMillis: Long = DEFAULT_LOCAL_DURABILITY_WATCHDOG_MILLIS,
+  private val showDelayedFeedback: () -> Unit = {},
+  private val hideDelayedFeedback: () -> Unit = {},
+) : RouteRemovalInterceptor {
+  private var close: DocumentEditingClose? = null
+  private var delayedFeedbackVisible = false
+
+  override suspend fun prepare(onDelayed: (suspend () -> Unit)?): RouteRemovalPreparation {
+    check(close == null) { "Editor leave preparation is already active" }
+    val currentClose =
+      try {
+        finalizeInput()
+        beginClose()
+      } catch (throwable: Throwable) {
+        try {
+          restoreInput()
+        } catch (cleanupFailure: Throwable) {
+          if (cleanupFailure !== throwable) throwable.addSuppressed(cleanupFailure)
+        }
+        throw throwable
+      }
+    close = currentClose
+
+    return if (awaitLocalDurability(currentClose, onDelayed)) {
+      RouteRemovalPreparation.Ready
+    } else {
+      RouteRemovalPreparation.NeedsDecision
+    }
+  }
+
+  override suspend fun resolveDecision(): RouteRemovalDecision = resolveDecision.invoke()
+
+  override suspend fun rollback() {
+    val currentClose = close ?: return
+    close = null
+    try {
+      currentClose.cancel()
+    } finally {
+      try {
+        hideDelayedFeedbackIfVisible()
+      } finally {
+        restoreInput()
+      }
+    }
+  }
+
+  private suspend fun awaitLocalDurability(
+    close: DocumentEditingClose,
+    onDelayed: (suspend () -> Unit)? = null,
+  ): Boolean {
+    suspend fun awaitResult(): Boolean = awaitLocalDurabilityWithOneRetry(close)
+
+    return try {
+      withTimeoutOrNull(localDurabilityWatchdogMillis) {
+        if (onDelayed == null) return@withTimeoutOrNull awaitResult()
+
+        coroutineScope {
+          val result = async(start = CoroutineStart.UNDISPATCHED) { awaitResult() }
+          val earlyResult = withTimeoutOrNull(delayedFeedbackMillis) { result.await() }
+          if (earlyResult != null) return@coroutineScope earlyResult
+
+          onDelayed()
+          showDelayedFeedback()
+          delayedFeedbackVisible = true
+          result.await()
+        }
+      } == true
+    } finally {
+      hideDelayedFeedbackIfVisible()
+    }
+  }
+
+  private suspend fun awaitLocalDurabilityWithOneRetry(close: DocumentEditingClose): Boolean {
+    val first = close.awaitLocalDurability()
+    return when {
+      first == LocalDurabilityResult.Captured -> true
+      first is LocalDurabilityResult.CaptureFailed ->
+        close.retryLocalDurability() == LocalDurabilityResult.Captured
+      else -> false
+    }
+  }
+
+  private fun hideDelayedFeedbackIfVisible() {
+    if (!delayedFeedbackVisible) return
+    delayedFeedbackVisible = false
+    hideDelayedFeedback()
+  }
+
+  private companion object {
+    const val DEFAULT_DELAYED_FEEDBACK_MILLIS = 350L
+    const val DEFAULT_LOCAL_DURABILITY_WATCHDOG_MILLIS = 3_000L
+  }
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -107,6 +107,8 @@ import co.typie.ext.LocalScrollGestureLockState
 import co.typie.ext.ime
 import co.typie.graphql.QueryState
 import co.typie.navigation.Nav
+import co.typie.navigation.NavigationResult
+import co.typie.navigation.RouteRemovalDecision
 import co.typie.platform.PlatformModule
 import co.typie.platform.connectivityService
 import co.typie.route.Route
@@ -175,7 +177,9 @@ import co.typie.serialization.json
 import co.typie.storage.Preference
 import co.typie.ui.component.ResponsiveContainerDefaults
 import co.typie.ui.component.Screen
+import co.typie.ui.component.dialog.DialogResult
 import co.typie.ui.component.dialog.LocalDialog
+import co.typie.ui.component.dialog.confirm
 import co.typie.ui.component.dialog.error
 import co.typie.ui.component.popover.LocalPopoverOverlayState
 import co.typie.ui.component.sheet.LocalSheet
@@ -461,8 +465,7 @@ fun EditorScreen(entityId: String) {
                       uiState = uiState,
                       flushDrafts = { model.flush() },
                     )
-                    nav.navigate(target)
-                    delivered = nav.current == target
+                    delivered = nav.navigate(target) is NavigationResult.ReachedTarget
                   } finally {
                     if (!delivered) {
                       DocumentCharacterCountSnapshots.remove(entityId)
@@ -500,6 +503,71 @@ fun EditorScreen(entityId: String) {
   }
 
   val activeEditor = runtime.editor
+  var savingToastId by remember(entityId, toast) { mutableStateOf<Long?>(null) }
+
+  fun dismissSavingToast() {
+    val id = savingToastId ?: return
+    savingToastId = null
+    if (toast.state?.id == id) toast.dismiss()
+  }
+
+  val leaveInterceptor =
+    remember(activeEditor, editingSession, dialog, toast) {
+      activeEditor?.let { editor ->
+        val session = editingSession?.takeIf { it.editor === editor } ?: return@remember null
+        var restoreFocusAfterRollback = false
+        EditorRouteLeaveInterceptor(
+          finalizeInput = {
+            restoreFocusAfterRollback = uiState.focused
+            runtime.blur()
+            uiState.updateFocus(false)
+            editor.sync { enqueue(Message.System(SystemEvent.SetFocused(false))) }
+            runtime.deactivateScene()
+          },
+          restoreInput = {
+            val shouldRestoreFocus = restoreFocusAfterRollback
+            restoreFocusAfterRollback = false
+            if (
+              shouldRestoreFocus &&
+                nav.current == Route.Editor(entityId) &&
+                runtime.editor === editor
+            ) {
+              runtime.focus()
+            }
+          },
+          beginClose = session::beginClose,
+          showDelayedFeedback = {
+            toast.show(ToastType.Loading, "저장 중…")
+            savingToastId = toast.state?.id
+          },
+          hideDelayedFeedback = { dismissSavingToast() },
+          resolveDecision = {
+            val result =
+              dialog.confirm(
+                title = "저장을 완료하지 못했어요",
+                message = "지금 닫으면 최근 변경사항을 잃을 수 있어요.",
+                confirmText = "저장하지 않고 닫기",
+                cancelText = "계속 편집",
+                confirmIsDestructive = true,
+              )
+            if (result is DialogResult.Resolved) {
+              RouteRemovalDecision.ProceedWithRemoval
+            } else {
+              RouteRemovalDecision.CancelRemoval
+            }
+          },
+        )
+      }
+    }
+  DisposableEffect(nav, entityId, leaveInterceptor) {
+    val unregister = leaveInterceptor?.let {
+      nav.routeRemovals.register(Route.Editor(entityId), it)
+    }
+    onDispose {
+      unregister?.invoke()
+      dismissSavingToast()
+    }
+  }
 
   LaunchedEffect(documentId, loaderRetryGeneration) {
     val currentDocumentId = documentId ?: return@LaunchedEffect

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/state/EditorScreenState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/state/EditorScreenState.kt
@@ -12,8 +12,6 @@ import co.typie.editor.ffi.SystemEvent
 import co.typie.editor.runtime.EditorRuntime
 import co.typie.editor.runtime.EditorUiState
 import co.typie.editor.scroll.EditorVisibleArea
-import co.typie.editor.sync.ActiveDocumentEditingSessions
-import co.typie.editor.sync.catchingNonCancellation
 import co.typie.editor.viewport.EditorViewportState
 import kotlin.math.max
 
@@ -58,7 +56,6 @@ internal class EditorScreenState internal constructor(val viewportState: EditorV
     runtime.editor?.enqueue(Message.System(SystemEvent.SetFocused(false)))
     runtime.deactivateScene()
     flushDrafts()
-    catchingNonCancellation { ActiveDocumentEditingSessions.flushSyncAll() }
     withFrameNanos {}
   }
 

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/navigation/NavigatorTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/navigation/NavigatorTest.kt
@@ -4,9 +4,11 @@ import co.typie.route.Route
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNotSame
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
@@ -210,6 +212,197 @@ class NavigatorTest {
     assertNotSame(originalStore, recreatedStore)
   }
 
+  @Test
+  fun preparedAdjacentRemovalCommitsExactDocumentEditorPair() = runTest {
+    val nav = Navigator(Route.Home)
+    val editorRoute = Route.Editor("1")
+    val documentRoute = Route.Document("1")
+    navigateAndComplete(nav, editorRoute)
+    navigateAndComplete(nav, documentRoute)
+    nav.routeRemovals.register(
+      editorRoute,
+      RecordingNavigatorInterceptor(RouteRemovalPreparation.Ready),
+    )
+
+    val prepared = assertNotNull(nav.prepareAdjacentRemoval(documentRoute, editorRoute))
+
+    assertTrue(nav.isTransitioning)
+    val commit = async { nav.commitAdjacentRemoval(prepared) }
+    advanceUntilIdle()
+
+    assertEquals(documentRoute, nav.current)
+    assertTrue(nav.popRequested)
+    assertEquals(RouteRemovalPolicy.BypassInterceptors, nav.peekRemovalPolicy())
+    val target = assertNotNull(nav.peekPopTarget())
+    val removedRoutes = nav.performPopTo(target)
+    nav.consumePopRequest()
+    nav.completeTransition()
+
+    assertEquals(NavigationResult.ReachedTarget, commit.await())
+    assertEquals(listOf(documentRoute, editorRoute), removedRoutes)
+    assertEquals(Route.Home, nav.current)
+    assertFalse(nav.isTransitioning)
+  }
+
+  @Test
+  fun adjacentRemovalDoesNotProvideDelayedPresentationCallback() = runTest {
+    val nav = Navigator(Route.Home)
+    val editorRoute = Route.Editor("1")
+    val documentRoute = Route.Document("1")
+    var receivedDelayedCallback = true
+    navigateAndComplete(nav, editorRoute)
+    navigateAndComplete(nav, documentRoute)
+    nav.routeRemovals.register(
+      editorRoute,
+      object : RouteRemovalInterceptor {
+        override suspend fun prepare(onDelayed: (suspend () -> Unit)?): RouteRemovalPreparation {
+          receivedDelayedCallback = onDelayed != null
+          return RouteRemovalPreparation.Ready
+        }
+
+        override suspend fun resolveDecision(): RouteRemovalDecision =
+          RouteRemovalDecision.CancelRemoval
+
+        override suspend fun rollback() = Unit
+      },
+    )
+
+    val prepared = assertNotNull(nav.prepareAdjacentRemoval(documentRoute, editorRoute))
+
+    assertFalse(receivedDelayedCallback)
+    nav.rollbackAdjacentRemoval(prepared)
+  }
+
+  @Test
+  fun navigateToCurrentDuringAdjacentRemovalPreparationIsNotStarted() = runTest {
+    val nav = Navigator(Route.Home)
+    val editorRoute = Route.Editor("1")
+    val documentRoute = Route.Document("1")
+    navigateAndComplete(nav, editorRoute)
+    navigateAndComplete(nav, documentRoute)
+    nav.routeRemovals.register(
+      editorRoute,
+      RecordingNavigatorInterceptor(RouteRemovalPreparation.Ready),
+    )
+    val prepared = assertNotNull(nav.prepareAdjacentRemoval(documentRoute, editorRoute))
+
+    assertEquals(NavigationResult.NotStarted, nav.navigate(documentRoute))
+
+    nav.rollbackAdjacentRemoval(prepared)
+  }
+
+  @Test
+  fun adjacentRemovalRollbackKeepsPairAndReleasesNavigationLease() = runTest {
+    val nav = Navigator(Route.Home)
+    val editorRoute = Route.Editor("1")
+    val documentRoute = Route.Document("1")
+    val interceptor = RecordingNavigatorInterceptor(RouteRemovalPreparation.Ready)
+    navigateAndComplete(nav, editorRoute)
+    navigateAndComplete(nav, documentRoute)
+    nav.routeRemovals.register(editorRoute, interceptor)
+    val prepared = assertNotNull(nav.prepareAdjacentRemoval(documentRoute, editorRoute))
+
+    nav.rollbackAdjacentRemoval(prepared)
+
+    assertEquals(documentRoute, nav.current)
+    assertEquals(editorRoute, nav.previous)
+    assertEquals(1, interceptor.rollbacks)
+    assertFalse(nav.isTransitioning)
+    navigateAndComplete(nav, Route.Space)
+    assertEquals(Route.Space, nav.current)
+  }
+
+  @Test
+  fun adjacentRemovalStillCommitsAfterEditorInterceptorReplacement() = runTest {
+    val nav = Navigator(Route.Home)
+    val editorRoute = Route.Editor("1")
+    val documentRoute = Route.Document("1")
+    navigateAndComplete(nav, editorRoute)
+    navigateAndComplete(nav, documentRoute)
+    nav.routeRemovals.register(
+      editorRoute,
+      RecordingNavigatorInterceptor(RouteRemovalPreparation.Ready),
+    )
+    val prepared = assertNotNull(nav.prepareAdjacentRemoval(documentRoute, editorRoute))
+
+    nav.routeRemovals.register(
+      editorRoute,
+      RecordingNavigatorInterceptor(RouteRemovalPreparation.Ready),
+    )
+    val commit = async { nav.commitAdjacentRemoval(prepared) }
+    advanceUntilIdle()
+
+    assertEquals(documentRoute, nav.current)
+    val target = assertNotNull(nav.peekPopTarget())
+    nav.performPopTo(target)
+    nav.consumePopRequest()
+    nav.completeTransition()
+
+    assertEquals(NavigationResult.ReachedTarget, commit.await())
+    assertEquals(Route.Home, nav.current)
+    assertFalse(nav.isTransitioning)
+  }
+
+  @Test
+  fun adjacentRemovalPreparationFailsIfInterceptorIsReplacedWhilePreparing() = runTest {
+    val nav = Navigator(Route.Home)
+    val editorRoute = Route.Editor("1")
+    val documentRoute = Route.Document("1")
+    val preparationStarted = CompletableDeferred<Unit>()
+    val releasePreparation = CompletableDeferred<Unit>()
+    var rollbacks = 0
+    navigateAndComplete(nav, editorRoute)
+    navigateAndComplete(nav, documentRoute)
+    nav.routeRemovals.register(
+      editorRoute,
+      object : RouteRemovalInterceptor {
+        override suspend fun prepare(onDelayed: (suspend () -> Unit)?): RouteRemovalPreparation {
+          preparationStarted.complete(Unit)
+          releasePreparation.await()
+          return RouteRemovalPreparation.Ready
+        }
+
+        override suspend fun resolveDecision(): RouteRemovalDecision =
+          RouteRemovalDecision.CancelRemoval
+
+        override suspend fun rollback() {
+          rollbacks++
+        }
+      },
+    )
+
+    val preparation = async { nav.prepareAdjacentRemoval(documentRoute, editorRoute) }
+    advanceUntilIdle()
+    assertTrue(preparationStarted.isCompleted)
+    nav.routeRemovals.register(
+      editorRoute,
+      RecordingNavigatorInterceptor(RouteRemovalPreparation.Ready),
+    )
+    releasePreparation.complete(Unit)
+    advanceUntilIdle()
+
+    assertNull(preparation.await())
+    assertEquals(1, rollbacks)
+    assertFalse(nav.isTransitioning)
+  }
+
+  @Test
+  fun failedAdjacentPreparationKeepsBothRoutes() = runTest {
+    val nav = Navigator(Route.Home)
+    val editorRoute = Route.Editor("1")
+    val documentRoute = Route.Document("1")
+    navigateAndComplete(nav, editorRoute)
+    navigateAndComplete(nav, documentRoute)
+    val interceptor = RecordingNavigatorInterceptor(RouteRemovalPreparation.NeedsDecision)
+    nav.routeRemovals.register(editorRoute, interceptor)
+
+    assertNull(nav.prepareAdjacentRemoval(documentRoute, editorRoute))
+    assertEquals(documentRoute, nav.current)
+    assertEquals(editorRoute, nav.previous)
+    assertEquals(1, interceptor.rollbacks)
+    assertFalse(nav.isTransitioning)
+  }
+
   context(testScope: TestScope)
   private suspend fun navigateAndComplete(nav: Navigator, route: Route) {
     with(testScope) {
@@ -250,5 +443,19 @@ class NavigatorTest {
       advanceUntilIdle()
       job.join()
     }
+  }
+}
+
+private class RecordingNavigatorInterceptor(private val preparation: RouteRemovalPreparation) :
+  RouteRemovalInterceptor {
+  var rollbacks = 0
+
+  override suspend fun prepare(onDelayed: (suspend () -> Unit)?): RouteRemovalPreparation =
+    preparation
+
+  override suspend fun resolveDecision(): RouteRemovalDecision = RouteRemovalDecision.CancelRemoval
+
+  override suspend fun rollback() {
+    rollbacks++
   }
 }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/navigation/RouteRemovalCoordinatorTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/navigation/RouteRemovalCoordinatorTest.kt
@@ -5,10 +5,57 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertSame
+import kotlin.test.assertTrue
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
 
 class RouteRemovalCoordinatorTest {
+  @Test
+  fun delayedPreparationRemainsOwnedWhileRouteBecomesVisible() = runTest {
+    val coordinator = RouteRemovalCoordinator()
+    val editorRoute = Route.Editor("editor")
+    var delayedRoute: Route? = null
+    var currentDuringDelayed = false
+    val editor =
+      RecordingRemovalInterceptor(
+        preparation = RouteRemovalPreparation.Ready,
+        onPrepare = { onDelayed -> checkNotNull(onDelayed).invoke() },
+      )
+    coordinator.register(editorRoute, editor)
+
+    val segment =
+      coordinator.prepareSegment(
+        routesToRemove = listOf(editorRoute),
+        requestedTarget = Route.Home,
+        onDelayed = { route ->
+          delayedRoute = route
+          currentDuringDelayed = coordinator.activeSegmentIsCurrent()
+        },
+      )
+
+    assertEquals(editorRoute, delayedRoute)
+    assertTrue(currentDuringDelayed)
+    assertEquals(Route.Home, segment.destination)
+  }
+
+  @Test
+  fun preparationWithoutDelayedCallbackDoesNotProvidePresentationHook() = runTest {
+    val coordinator = RouteRemovalCoordinator()
+    val editorRoute = Route.Editor("editor")
+    var receivedCallback = true
+    coordinator.register(
+      editorRoute,
+      RecordingRemovalInterceptor(
+        preparation = RouteRemovalPreparation.Ready,
+        onPrepare = { onDelayed -> receivedCallback = onDelayed != null },
+      ),
+    )
+
+    coordinator.prepareSegment(listOf(editorRoute), Route.Home)
+
+    assertEquals(false, receivedCallback)
+  }
+
   @Test
   fun hiddenFailureStopsAtEditorAfterCommittingReadyPrefix() = runTest {
     val coordinator = RouteRemovalCoordinator()
@@ -217,13 +264,15 @@ private class RecordingRemovalInterceptor(
   private val preparation: RouteRemovalPreparation,
   private val preparationFailure: Throwable? = null,
   private val rollbackFailure: Throwable? = null,
+  private val onPrepare: suspend ((suspend () -> Unit)?) -> Unit = {},
 ) : RouteRemovalInterceptor {
   var decision: RouteRemovalDecision = RouteRemovalDecision.CancelRemoval
   var prepares: Int = 0
   var rollbacks: Int = 0
 
-  override suspend fun prepare(): RouteRemovalPreparation {
+  override suspend fun prepare(onDelayed: (suspend () -> Unit)?): RouteRemovalPreparation {
     prepares++
+    onPrepare(onDelayed)
     preparationFailure?.let { throw it }
     return preparation
   }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/EditorRouteLeaveInterceptorTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/EditorRouteLeaveInterceptorTest.kt
@@ -1,0 +1,249 @@
+package co.typie.screen.editor.editor
+
+import co.typie.editor.DocumentEditingClose
+import co.typie.editor.LocalDurabilityResult
+import co.typie.navigation.RouteRemovalDecision
+import co.typie.navigation.RouteRemovalPreparation
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.currentTime
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class EditorRouteLeaveInterceptorTest {
+  @Test
+  fun editFailureNeedsDecisionAndRollbackRestoresInput() = runTest {
+    var cancelled = 0
+    var restored = 0
+    val interceptor =
+      interceptor(
+        awaitResult = { LocalDurabilityResult.EditFailed(IllegalStateException("edit")) },
+        onCancel = { cancelled++ },
+        restoreInput = { restored++ },
+      )
+
+    assertEquals(RouteRemovalPreparation.NeedsDecision, interceptor.prepare())
+    assertEquals(RouteRemovalDecision.CancelRemoval, interceptor.resolveDecision())
+    interceptor.rollback()
+    assertEquals(1, cancelled)
+    assertEquals(1, restored)
+  }
+
+  @Test
+  fun closeStartFailureRestoresInput() = runTest {
+    var restored = 0
+    val failure = IllegalStateException("stale session")
+    val interceptor =
+      EditorRouteLeaveInterceptor(
+        finalizeInput = {},
+        restoreInput = { restored++ },
+        beginClose = { throw failure },
+        resolveDecision = { RouteRemovalDecision.CancelRemoval },
+      )
+
+    assertEquals(failure, assertFailsWith<IllegalStateException> { interceptor.prepare() })
+    assertEquals(1, restored)
+  }
+
+  @Test
+  fun localDurabilityWaitIsBounded() = runTest {
+    val interceptor =
+      interceptor(awaitResult = { awaitCancellation() }, localDurabilityWatchdogMillis = 10)
+
+    assertEquals(RouteRemovalPreparation.NeedsDecision, interceptor.prepare())
+    assertEquals(10L, currentTime)
+  }
+
+  @Test
+  fun defaultLocalDurabilityWatchdogExpiresAtThreeSeconds() = runTest {
+    val interceptor =
+      EditorRouteLeaveInterceptor(
+        finalizeInput = {},
+        restoreInput = {},
+        beginClose = {
+          object : DocumentEditingClose {
+            override suspend fun awaitLocalDurability(): LocalDurabilityResult = awaitCancellation()
+
+            override suspend fun retryLocalDurability(): LocalDurabilityResult =
+              error("A timeout must not start a retry")
+
+            override fun cancel() = Unit
+          }
+        },
+        resolveDecision = { RouteRemovalDecision.CancelRemoval },
+      )
+
+    assertEquals(RouteRemovalPreparation.NeedsDecision, interceptor.prepare())
+    assertEquals(3_000L, currentTime)
+  }
+
+  @Test
+  fun delayedFeedbackStartsAtSoftThresholdAndSuccessStillAllowsRemoval() = runTest {
+    val durability = CompletableDeferred<LocalDurabilityResult>()
+    var delayed = 0
+    var shown = 0
+    var hidden = 0
+    val interceptor =
+      interceptor(
+        awaitResult = { durability.await() },
+        delayedFeedbackMillis = 10,
+        localDurabilityWatchdogMillis = 30,
+        showDelayedFeedback = { shown++ },
+        hideDelayedFeedback = { hidden++ },
+      )
+
+    val preparation = async { interceptor.prepare(onDelayed = { delayed++ }) }
+    runCurrent()
+    advanceTimeBy(9)
+    runCurrent()
+    assertEquals(0, delayed)
+    assertEquals(0, shown)
+    assertFalse(preparation.isCompleted)
+
+    advanceTimeBy(1)
+    runCurrent()
+    assertEquals(1, delayed)
+    assertEquals(1, shown)
+    assertFalse(preparation.isCompleted)
+
+    durability.complete(LocalDurabilityResult.Captured)
+    assertEquals(RouteRemovalPreparation.Ready, preparation.await())
+    assertEquals(1, hidden)
+  }
+
+  @Test
+  fun captureRetryContinuesAcrossSoftThresholdWithoutRestarting() = runTest {
+    val failure = LocalDurabilityResult.CaptureFailed(IllegalStateException("still unavailable"))
+    val retryCompletion = CompletableDeferred<LocalDurabilityResult>()
+    var retries = 0
+    val interceptor =
+      interceptor(
+        awaitResult = { failure },
+        retryResult = {
+          retries++
+          retryCompletion.await()
+        },
+        delayedFeedbackMillis = 10,
+        localDurabilityWatchdogMillis = 30,
+      )
+
+    val preparation = async { interceptor.prepare(onDelayed = {}) }
+    runCurrent()
+    assertEquals(1, retries)
+
+    advanceTimeBy(10)
+    runCurrent()
+    assertEquals(1, retries)
+
+    retryCompletion.complete(failure)
+    assertEquals(RouteRemovalPreparation.NeedsDecision, preparation.await())
+    assertEquals(1, retries)
+  }
+
+  @Test
+  fun directPreparationDoesNotShowRouteRemovalFeedback() = runTest {
+    var shown = 0
+    val interceptor =
+      interceptor(
+        awaitResult = { awaitCancellation() },
+        delayedFeedbackMillis = 10,
+        localDurabilityWatchdogMillis = 20,
+        showDelayedFeedback = { shown++ },
+      )
+
+    assertEquals(RouteRemovalPreparation.NeedsDecision, interceptor.prepare())
+    assertEquals(20L, currentTime)
+    assertEquals(0, shown)
+  }
+
+  @Test
+  fun rollbackDismissesVisibleDelayedFeedbackOnce() = runTest {
+    val durability = CompletableDeferred<LocalDurabilityResult>()
+    var shown = 0
+    var hidden = 0
+    val interceptor =
+      interceptor(
+        awaitResult = { durability.await() },
+        onCancel = { durability.complete(LocalDurabilityResult.SessionStopped) },
+        delayedFeedbackMillis = 10,
+        localDurabilityWatchdogMillis = 30,
+        showDelayedFeedback = { shown++ },
+        hideDelayedFeedback = { hidden++ },
+      )
+
+    val preparation = async { interceptor.prepare(onDelayed = {}) }
+    advanceTimeBy(10)
+    runCurrent()
+    assertEquals(1, shown)
+
+    interceptor.rollback()
+    assertEquals(RouteRemovalPreparation.NeedsDecision, preparation.await())
+    assertEquals(1, hidden)
+  }
+
+  @Test
+  fun retriesCaptureFailureOnceBeforeAllowingRemoval() = runTest {
+    var retries = 0
+    val interceptor =
+      interceptor(
+        awaitResult = { LocalDurabilityResult.CaptureFailed(IllegalStateException("disk")) },
+        retryResult = {
+          retries++
+          LocalDurabilityResult.Captured
+        },
+      )
+
+    assertEquals(RouteRemovalPreparation.Ready, interceptor.prepare())
+    assertEquals(1, retries)
+  }
+
+  @Test
+  fun twoCaptureFailuresNeedDecision() = runTest {
+    val interceptor =
+      interceptor(
+        awaitResult = { LocalDurabilityResult.CaptureFailed(IllegalStateException("unprotected")) },
+        retryResult = { LocalDurabilityResult.CaptureFailed(IllegalStateException("unprotected")) },
+      )
+
+    assertEquals(RouteRemovalPreparation.NeedsDecision, interceptor.prepare())
+  }
+}
+
+private fun interceptor(
+  awaitResult: suspend () -> LocalDurabilityResult = { LocalDurabilityResult.Captured },
+  retryResult: suspend () -> LocalDurabilityResult = { LocalDurabilityResult.Captured },
+  onCancel: () -> Unit = {},
+  restoreInput: () -> Unit = {},
+  delayedFeedbackMillis: Long = 350,
+  localDurabilityWatchdogMillis: Long = 3_000,
+  showDelayedFeedback: () -> Unit = {},
+  hideDelayedFeedback: () -> Unit = {},
+): EditorRouteLeaveInterceptor =
+  EditorRouteLeaveInterceptor(
+    finalizeInput = {},
+    restoreInput = restoreInput,
+    beginClose = {
+      object : DocumentEditingClose {
+        override suspend fun awaitLocalDurability(): LocalDurabilityResult = awaitResult()
+
+        override suspend fun retryLocalDurability(): LocalDurabilityResult = retryResult()
+
+        override fun cancel() {
+          onCancel()
+        }
+      }
+    },
+    resolveDecision = { RouteRemovalDecision.CancelRemoval },
+    delayedFeedbackMillis = delayedFeedbackMillis,
+    localDurabilityWatchdogMillis = localDurabilityWatchdogMillis,
+    showDelayedFeedback = showDelayedFeedback,
+    hideDelayedFeedback = hideDelayedFeedback,
+  )

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/EditorRouteRemovalNavigationStackDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/EditorRouteRemovalNavigationStackDesktopTest.kt
@@ -1,0 +1,100 @@
+package co.typie.navigation
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import co.typie.editor.DocumentEditingClose
+import co.typie.editor.EditorLocalEditCoordinator
+import co.typie.editor.LocalDurabilityResult
+import co.typie.route.Route
+import co.typie.screen.editor.editor.EditorRouteLeaveInterceptor
+import co.typie.ui.component.topbar.TopBarState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlinx.coroutines.CompletableDeferred
+
+@OptIn(ExperimentalTestApi::class)
+class EditorRouteRemovalNavigationStackDesktopTest {
+  @Test
+  fun editorIsRemovedOnlyAfterLocalEditBarrierAndCaptureComplete() = runComposeUiTest {
+    val navigator = Navigator(Route.Home)
+    val editorRoute = Route.Editor("editor")
+    val localEdits = EditorLocalEditCoordinator()
+    val pendingEdit = checkNotNull(localEdits.register())
+    val popRequested = CompletableDeferred<Unit>()
+    val barrierStarted = CompletableDeferred<Unit>()
+    val captureStarted = CompletableDeferred<Unit>()
+    val releaseCapture = CompletableDeferred<Unit>()
+    var popResult: NavigationResult? = null
+
+    navigator.routeRemovals.register(
+      editorRoute,
+      EditorRouteLeaveInterceptor(
+        finalizeInput = {},
+        restoreInput = {},
+        beginClose = {
+          val quiescence = localEdits.quiesce()
+          object : DocumentEditingClose {
+            override suspend fun awaitLocalDurability(): LocalDurabilityResult {
+              barrierStarted.complete(Unit)
+              val editResult = quiescence.await()
+              captureStarted.complete(Unit)
+              releaseCapture.await()
+              return editResult.fold(
+                onSuccess = { LocalDurabilityResult.Captured },
+                onFailure = { LocalDurabilityResult.EditFailed(it) },
+              )
+            }
+
+            override suspend fun retryLocalDurability(): LocalDurabilityResult =
+              LocalDurabilityResult.Captured
+
+            override fun cancel() {
+              quiescence.resume()
+            }
+          }
+        },
+        resolveDecision = { error("Successful capture must not require a decision") },
+      ),
+    )
+
+    setContent {
+      NavigationStack(
+        navigator = navigator,
+        topBarState = remember { TopBarState() },
+        modifier = Modifier.size(width = 320.dp, height = 640.dp),
+      ) {
+        Box(Modifier.fillMaxSize())
+      }
+      LaunchedEffect(Unit) {
+        navigator.navigate(editorRoute)
+        popRequested.await()
+        popResult = navigator.pop()
+      }
+    }
+    waitUntil { navigator.current == editorRoute && !navigator.isTransitioning }
+
+    popRequested.complete(Unit)
+    waitUntil { barrierStarted.isCompleted }
+    assertFalse(captureStarted.isCompleted)
+    assertEquals(editorRoute, navigator.current)
+    assertNull(popResult)
+
+    localEdits.complete(pendingEdit)
+    waitUntil { captureStarted.isCompleted }
+    assertEquals(editorRoute, navigator.current)
+    assertNull(popResult)
+
+    releaseCapture.complete(Unit)
+    waitUntil { navigator.current == Route.Home && popResult != null }
+    assertEquals(NavigationResult.ReachedTarget, popResult)
+  }
+}

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/RouteRemovalNavigationStackDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/RouteRemovalNavigationStackDesktopTest.kt
@@ -1,5 +1,6 @@
 package co.typie.navigation
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.rememberScrollable2DState
 import androidx.compose.foundation.gestures.scrollable2D
 import androidx.compose.foundation.layout.Box
@@ -11,6 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.click
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.v2.runComposeUiTest
@@ -40,7 +42,7 @@ class RouteRemovalNavigationStackDesktopTest {
     navigator.routeRemovals.register(
       guardedRoute,
       object : RouteRemovalInterceptor {
-        override suspend fun prepare(): RouteRemovalPreparation =
+        override suspend fun prepare(onDelayed: (suspend () -> Unit)?): RouteRemovalPreparation =
           RouteRemovalPreparation.NeedsDecision
 
         override suspend fun resolveDecision(): RouteRemovalDecision {
@@ -94,7 +96,7 @@ class RouteRemovalNavigationStackDesktopTest {
     navigator.routeRemovals.register(
       guardedRoute,
       object : RouteRemovalInterceptor {
-        override suspend fun prepare(): RouteRemovalPreparation {
+        override suspend fun prepare(onDelayed: (suspend () -> Unit)?): RouteRemovalPreparation {
           preparationStarted.complete(Unit)
           releasePreparation.await()
           return RouteRemovalPreparation.Ready
@@ -130,7 +132,7 @@ class RouteRemovalNavigationStackDesktopTest {
     navigator.routeRemovals.register(
       guardedRoute,
       object : RouteRemovalInterceptor {
-        override suspend fun prepare(): RouteRemovalPreparation {
+        override suspend fun prepare(onDelayed: (suspend () -> Unit)?): RouteRemovalPreparation {
           replacementPrepareCount++
           return RouteRemovalPreparation.Ready
         }
@@ -159,7 +161,7 @@ class RouteRemovalNavigationStackDesktopTest {
     navigator.routeRemovals.register(
       guardedRoute,
       object : RouteRemovalInterceptor {
-        override suspend fun prepare(): RouteRemovalPreparation =
+        override suspend fun prepare(onDelayed: (suspend () -> Unit)?): RouteRemovalPreparation =
           RouteRemovalPreparation.NeedsDecision
 
         override suspend fun resolveDecision(): RouteRemovalDecision =
@@ -199,6 +201,14 @@ class RouteRemovalNavigationStackDesktopTest {
     assertEquals(guardedRoute, navigator.current)
     assertEquals(listOf(Route.Home, guardedRoute), navigator.stack)
   }
+
+  @Test
+  fun mainAreaBackSwipeDoesNotMoveWhileRemovalIsPreparing() =
+    assertBackSwipeDoesNotMoveWhileRemovalIsPreparing(startAtEdge = false)
+
+  @Test
+  fun edgeBackSwipeDoesNotMoveWhileRemovalIsPreparing() =
+    assertBackSwipeDoesNotMoveWhileRemovalIsPreparing(startAtEdge = true)
 
   @Test
   fun committedBackSwipeContinuesFromReleasedPosition() = runComposeUiTest {
@@ -242,6 +252,261 @@ class RouteRemovalNavigationStackDesktopTest {
     )
     clock.autoAdvance = true
     waitUntil { navigator.current == Route.Home && !navigator.isTransitioning }
+  }
+
+  @Test
+  fun committedBackSwipeContinuesWhileRemovalIsPreparing() = runComposeUiTest {
+    val navigator = Navigator(Route.Home)
+    val guardedRoute = Route.Folder("guarded")
+    val preparationStarted = CompletableDeferred<Unit>()
+    val releasePreparation = CompletableDeferred<Unit>()
+
+    navigator.routeRemovals.register(
+      guardedRoute,
+      object : RouteRemovalInterceptor {
+        override suspend fun prepare(onDelayed: (suspend () -> Unit)?): RouteRemovalPreparation {
+          preparationStarted.complete(Unit)
+          releasePreparation.await()
+          return RouteRemovalPreparation.Ready
+        }
+
+        override suspend fun resolveDecision(): RouteRemovalDecision =
+          error("Ready preparation must not require a decision")
+
+        override suspend fun rollback() = Unit
+      },
+    )
+
+    setContent {
+      NavigationStack(
+        navigator = navigator,
+        topBarState = remember { TopBarState() },
+        modifier = Modifier.size(width = 320.dp, height = 640.dp),
+      ) { route ->
+        Box(
+          Modifier.fillMaxSize()
+            .testTag(if (route == guardedRoute) GuardedRouteTag else HomeRouteTag)
+        )
+      }
+      LaunchedEffect(Unit) { navigator.navigate(guardedRoute) }
+    }
+    waitUntil { navigator.current == guardedRoute && !navigator.isTransitioning }
+
+    val clock = mainClock
+    val routeNode = onNodeWithTag(GuardedRouteTag)
+    routeNode.performTouchInput {
+      down(center)
+      moveBy(Offset(x = 100f, y = 0f))
+      moveBy(Offset(x = 120f, y = 0f))
+      clock.autoAdvance = false
+      up()
+    }
+    clock.advanceTimeByFrame()
+    val releasedLeft = routeNode.fetchSemanticsNode().boundsInRoot.left
+    clock.advanceTimeBy(100L)
+    val animatedLeft = routeNode.fetchSemanticsNode().boundsInRoot.left
+
+    try {
+      assertTrue(preparationStarted.isCompleted)
+      assertEquals(guardedRoute, navigator.current)
+      assertTrue(
+        animatedLeft > releasedLeft,
+        "A committed back swipe must continue while removal prepares: " +
+          "released=$releasedLeft, animated=$animatedLeft",
+      )
+    } finally {
+      releasePreparation.complete(Unit)
+      clock.autoAdvance = true
+    }
+    waitUntil { navigator.current == Route.Home && !navigator.isTransitioning }
+  }
+
+  @Test
+  fun delayedCommittedBackSwipeReturnsToRouteThenAutomaticallyPops() = runComposeUiTest {
+    val navigator = Navigator(Route.Home)
+    val guardedRoute = Route.Folder("guarded")
+    val delayedRouteSettled = CompletableDeferred<Unit>()
+    val releasePreparation = CompletableDeferred<Unit>()
+
+    navigator.routeRemovals.register(
+      guardedRoute,
+      object : RouteRemovalInterceptor {
+        override suspend fun prepare(onDelayed: (suspend () -> Unit)?): RouteRemovalPreparation {
+          checkNotNull(onDelayed).invoke()
+          delayedRouteSettled.complete(Unit)
+          releasePreparation.await()
+          return RouteRemovalPreparation.Ready
+        }
+
+        override suspend fun resolveDecision(): RouteRemovalDecision =
+          error("Ready preparation must not require a decision")
+
+        override suspend fun rollback() = Unit
+      },
+    )
+
+    setContent {
+      NavigationStack(
+        navigator = navigator,
+        topBarState = remember { TopBarState() },
+        modifier = Modifier.size(width = 320.dp, height = 640.dp),
+      ) { route ->
+        Box(
+          Modifier.fillMaxSize()
+            .testTag(if (route == guardedRoute) GuardedRouteTag else HomeRouteTag)
+        )
+      }
+      LaunchedEffect(Unit) { navigator.navigate(guardedRoute) }
+    }
+    waitUntil { navigator.current == guardedRoute && !navigator.isTransitioning }
+
+    val routeNode = onNodeWithTag(GuardedRouteTag)
+    routeNode.performTouchInput {
+      down(center)
+      moveBy(Offset(x = 100f, y = 0f))
+      moveBy(Offset(x = 120f, y = 0f))
+      up()
+    }
+    waitUntil { delayedRouteSettled.isCompleted }
+
+    assertEquals(guardedRoute, navigator.current)
+    assertEquals(0f, routeNode.fetchSemanticsNode().boundsInRoot.left)
+
+    releasePreparation.complete(Unit)
+    waitUntil { navigator.current == Route.Home && !navigator.isTransitioning }
+  }
+
+  @Test
+  fun slowHiddenRouteBecomesCurrentThenMultiPopAutomaticallyContinues() = runComposeUiTest {
+    val navigator = Navigator(Route.Home)
+    val guardedRoute = Route.Folder("guarded")
+    val topRoute = Route.Document("top")
+    val requestRemoval = CompletableDeferred<Unit>()
+    val delayedRouteSettled = CompletableDeferred<Unit>()
+    val releasePreparation = CompletableDeferred<Unit>()
+    var removalResult: NavigationResult? = null
+
+    navigator.routeRemovals.register(
+      guardedRoute,
+      object : RouteRemovalInterceptor {
+        override suspend fun prepare(onDelayed: (suspend () -> Unit)?): RouteRemovalPreparation {
+          checkNotNull(onDelayed).invoke()
+          delayedRouteSettled.complete(Unit)
+          releasePreparation.await()
+          return RouteRemovalPreparation.Ready
+        }
+
+        override suspend fun resolveDecision(): RouteRemovalDecision =
+          error("Ready preparation must not require a decision")
+
+        override suspend fun rollback() = Unit
+      },
+    )
+
+    setContent {
+      NavigationStack(
+        navigator = navigator,
+        topBarState = remember { TopBarState() },
+        modifier = Modifier.size(width = 320.dp, height = 640.dp),
+      ) { route ->
+        Box(Modifier.fillMaxSize().testTag(route.toString()))
+      }
+      LaunchedEffect(Unit) {
+        navigator.navigate(guardedRoute)
+        navigator.navigate(topRoute)
+        requestRemoval.await()
+        removalResult = navigator.popTo(Route.Home)
+      }
+    }
+    waitUntil { navigator.current == topRoute && !navigator.isTransitioning }
+
+    requestRemoval.complete(Unit)
+    waitUntil { delayedRouteSettled.isCompleted }
+
+    assertEquals(guardedRoute, navigator.current)
+    assertEquals(listOf(Route.Home, guardedRoute), navigator.stack)
+    assertEquals(null, removalResult)
+
+    releasePreparation.complete(Unit)
+    waitUntil { navigator.current == Route.Home && removalResult != null }
+    assertEquals(NavigationResult.ReachedTarget, removalResult)
+  }
+
+  @Test
+  fun failedRemovalRestoresCommittedBackSwipeBeforeRequestingDecision() = runComposeUiTest {
+    val navigator = Navigator(Route.Home)
+    val guardedRoute = Route.Folder("guarded")
+    val preparationStarted = CompletableDeferred<Unit>()
+    val preparationResult = CompletableDeferred<RouteRemovalPreparation>()
+    val decisionStarted = CompletableDeferred<Unit>()
+    val releaseDecision = CompletableDeferred<Unit>()
+    var homeClicks = 0
+
+    navigator.routeRemovals.register(
+      guardedRoute,
+      object : RouteRemovalInterceptor {
+        override suspend fun prepare(onDelayed: (suspend () -> Unit)?): RouteRemovalPreparation {
+          preparationStarted.complete(Unit)
+          return preparationResult.await()
+        }
+
+        override suspend fun resolveDecision(): RouteRemovalDecision {
+          decisionStarted.complete(Unit)
+          releaseDecision.await()
+          return RouteRemovalDecision.CancelRemoval
+        }
+
+        override suspend fun rollback() = Unit
+      },
+    )
+
+    setContent {
+      NavigationStack(
+        navigator = navigator,
+        topBarState = remember { TopBarState() },
+        modifier = Modifier.size(width = 320.dp, height = 640.dp),
+      ) { route ->
+        Box(
+          Modifier.fillMaxSize()
+            .testTag(if (route == guardedRoute) GuardedRouteTag else HomeRouteTag)
+            .then(if (route == Route.Home) Modifier.clickable { homeClicks++ } else Modifier)
+        )
+      }
+      LaunchedEffect(Unit) { navigator.navigate(guardedRoute) }
+    }
+    waitUntil { navigator.current == guardedRoute && !navigator.isTransitioning }
+
+    val clock = mainClock
+    val routeNode = onNodeWithTag(GuardedRouteTag)
+    try {
+      routeNode.performTouchInput {
+        down(center)
+        moveBy(Offset(x = 100f, y = 0f))
+        moveBy(Offset(x = 120f, y = 0f))
+        clock.autoAdvance = false
+        up()
+      }
+      clock.advanceTimeBy(2_000L)
+
+      assertTrue(preparationStarted.isCompleted)
+      assertEquals(guardedRoute, navigator.current)
+      onNodeWithTag(HomeRouteTag).performTouchInput { click(center) }
+      assertEquals(0, homeClicks)
+
+      preparationResult.complete(RouteRemovalPreparation.NeedsDecision)
+      clock.autoAdvance = true
+      waitUntil { decisionStarted.isCompleted }
+
+      assertEquals(guardedRoute, navigator.current)
+      assertEquals(0f, routeNode.fetchSemanticsNode().boundsInRoot.left)
+    } finally {
+      preparationResult.complete(RouteRemovalPreparation.NeedsDecision)
+      releaseDecision.complete(Unit)
+      clock.autoAdvance = true
+    }
+
+    waitUntil { !navigator.isTransitioning }
+    assertEquals(listOf(Route.Home, guardedRoute), navigator.stack)
   }
 
   @Test
@@ -305,7 +570,7 @@ class RouteRemovalNavigationStackDesktopTest {
       navigator.routeRemovals.register(
         guardedRoute,
         object : RouteRemovalInterceptor {
-          override suspend fun prepare(): RouteRemovalPreparation =
+          override suspend fun prepare(onDelayed: (suspend () -> Unit)?): RouteRemovalPreparation =
             RouteRemovalPreparation.NeedsDecision
 
           override suspend fun resolveDecision(): RouteRemovalDecision = throw decisionFailure
@@ -346,11 +611,75 @@ class RouteRemovalNavigationStackDesktopTest {
     }
   }
 
+  private fun assertBackSwipeDoesNotMoveWhileRemovalIsPreparing(startAtEdge: Boolean) =
+    runComposeUiTest {
+      val navigator = Navigator(Route.Home)
+      val route = Route.Folder("preparing")
+      val popRequested = CompletableDeferred<Unit>()
+      val preparationStarted = CompletableDeferred<Unit>()
+      val releasePreparation = CompletableDeferred<Unit>()
+
+      navigator.routeRemovals.register(
+        route,
+        object : RouteRemovalInterceptor {
+          override suspend fun prepare(onDelayed: (suspend () -> Unit)?): RouteRemovalPreparation {
+            preparationStarted.complete(Unit)
+            releasePreparation.await()
+            return RouteRemovalPreparation.Ready
+          }
+
+          override suspend fun resolveDecision(): RouteRemovalDecision =
+            error("Ready preparation must not require a decision")
+
+          override suspend fun rollback() = Unit
+        },
+      )
+
+      setContent {
+        NavigationStack(
+          navigator = navigator,
+          topBarState = remember { TopBarState() },
+          modifier = Modifier.size(width = 320.dp, height = 640.dp),
+        ) {
+          Box(Modifier.fillMaxSize().testTag(if (it == route) PreparingRouteTag else HomeRouteTag))
+        }
+        LaunchedEffect(Unit) {
+          navigator.navigate(route)
+          popRequested.await()
+          navigator.pop()
+        }
+      }
+      waitUntil { navigator.current == route && !navigator.isTransitioning }
+
+      val routeNode = onNodeWithTag(PreparingRouteTag)
+      val settledLeft = routeNode.fetchSemanticsNode().boundsInRoot.left
+      popRequested.complete(Unit)
+      waitUntil { preparationStarted.isCompleted }
+
+      val draggedLeft =
+        try {
+          routeNode.performTouchInput {
+            down(if (startAtEdge) Offset(x = 10f, y = center.y) else center)
+            moveBy(Offset(x = 100f, y = 0f))
+            moveBy(Offset(x = 120f, y = 0f))
+          }
+          mainClock.advanceTimeByFrame()
+          routeNode.fetchSemanticsNode().boundsInRoot.left
+        } finally {
+          routeNode.performTouchInput { up() }
+          releasePreparation.complete(Unit)
+        }
+
+      waitUntil { navigator.current == Route.Home && !navigator.isTransitioning }
+      assertEquals(settledLeft, draggedLeft)
+    }
+
   private companion object {
     const val GuardedRouteTag = "guarded-route"
     const val HomeRouteTag = "home-route"
     const val UnguardedRouteTag = "unguarded-route"
     const val TopRouteTag = "top-route"
     const val BackgroundRouteTag = "background-route"
+    const val PreparingRouteTag = "preparing-route"
   }
 }


### PR DESCRIPTION
Editor route가 제거되기 전에 마지막 local edit의 로컬 저장 여부를 확인하고, 확인할 수 없는 경우 사용자 선택 없이 닫히지 않도록 합니다.

- top bar back, system back, back swipe, programmatic multi-pop을 공통 route removal 계약으로 연결합니다.
- 이미 받아들인 local edit을 모두 commit한 뒤 로컬 capture를 기다리고, 실패하면 한 번 재시도합니다. 350ms를 넘으면 `저장 중…`토스트를 표시하고 완료 시 원래 이동을 자동으로 이어갑니다.
- 3초 내 저장을 확인하지 못하면 계속 편집하거나 저장하지 않고 닫도록 선택하게 하며, Document 삭제도 인접한 동일 문서 Editor의 준비가 성공한 경우에만 진행합니다.