### PR TITLE
에디터 이탈 시 live ack를 저장 성공으로 인정

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/DocumentEditingSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/DocumentEditingSession.kt
@@ -17,20 +17,18 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
 
-internal sealed interface LocalDurabilityResult {
-  data object Captured : LocalDurabilityResult
+internal sealed interface EditingCheckpointResult {
+  data object Protected : EditingCheckpointResult
 
-  data class EditFailed(val cause: Throwable) : LocalDurabilityResult
+  data class EditFailed(val cause: Throwable) : EditingCheckpointResult
 
-  data class CaptureFailed(val cause: Throwable) : LocalDurabilityResult
+  data class ProtectionFailed(val cause: Throwable) : EditingCheckpointResult
 
-  data object SessionStopped : LocalDurabilityResult
+  data object SessionStopped : EditingCheckpointResult
 }
 
 internal interface DocumentEditingClose {
-  suspend fun awaitLocalDurability(): LocalDurabilityResult
-
-  suspend fun retryLocalDurability(): LocalDurabilityResult
+  suspend fun awaitCheckpoint(): EditingCheckpointResult
 
   fun cancel()
 }
@@ -54,72 +52,34 @@ internal class DocumentEditingSession(
   }
 
   private inner class Close(private val quiescence: LocalEditQuiescence) : DocumentEditingClose {
-    private inner class Attempt {
-      private val result = CompletableDeferred<LocalDurabilityResult>()
-      private val work =
-        scope.launch(start = CoroutineStart.LAZY) {
-          if (state.load() === State.Closed) {
-            result.complete(LocalDurabilityResult.SessionStopped)
-            return@launch
-          }
-          val settledEdits =
-            try {
-              editResult.await()
-            } catch (e: CancellationException) {
-              if (state.load() === State.Closed) {
-                result.complete(LocalDurabilityResult.SessionStopped)
-                return@launch
-              }
-              throw e
-            }
-          val captureResult =
-            try {
-              engine.captureNow()
-              Result.success(Unit)
-            } catch (e: CancellationException) {
-              throw e
-            } catch (e: Throwable) {
-              Result.failure(e)
-            }
-
-          result.complete(resolveResult(settledEdits, captureResult))
-        }
-
-      fun start() {
-        work.start()
-      }
-
-      suspend fun await(): LocalDurabilityResult = result.await()
-
-      fun stop() {
-        if (result.complete(LocalDurabilityResult.SessionStopped)) {
-          work.cancel()
-        }
-      }
-    }
-
     private val editResult: Deferred<Result<Unit>> =
       scope.async(start = CoroutineStart.UNDISPATCHED) { quiescence.await() }
-    private val attempts = AtomicReference(Attempt().also(Attempt::start))
-
-    override suspend fun awaitLocalDurability(): LocalDurabilityResult = attempts.load().await()
-
-    override suspend fun retryLocalDurability(): LocalDurabilityResult {
-      while (true) {
-        val current = attempts.load()
-        val currentResult = current.await()
-        if (currentResult !is LocalDurabilityResult.CaptureFailed) return currentResult
-        val currentState = state.load()
-        if (currentState === State.Closed) return LocalDurabilityResult.SessionStopped
-        if (currentState !is State.Closing || currentState.close !== this) return currentResult
-
-        val next = Attempt()
-        if (attempts.compareAndSet(current, next)) {
-          next.start()
-          return next.await()
+    private val result = CompletableDeferred<EditingCheckpointResult>()
+    private val work =
+      scope.launch(start = CoroutineStart.LAZY) {
+        if (state.load() === State.Closed) {
+          result.complete(EditingCheckpointResult.SessionStopped)
+          return@launch
         }
+        val settledEdits =
+          try {
+            editResult.await()
+          } catch (e: CancellationException) {
+            if (state.load() === State.Closed) {
+              result.complete(EditingCheckpointResult.SessionStopped)
+              return@launch
+            }
+            throw e
+          }
+        val checkpoint = engine.checkpointCurrentFrontier()
+        result.complete(resolveResult(settledEdits, checkpoint))
       }
+
+    init {
+      work.start()
     }
+
+    override suspend fun awaitCheckpoint(): EditingCheckpointResult = result.await()
 
     override fun cancel() {
       val current = state.load()
@@ -130,21 +90,21 @@ internal class DocumentEditingSession(
 
     fun stop() {
       editResult.cancel()
-      attempts.load().stop()
+      if (result.complete(EditingCheckpointResult.SessionStopped)) work.cancel()
     }
 
     private fun resolveResult(
       editResult: Result<Unit>,
-      captureResult: Result<Unit>,
-    ): LocalDurabilityResult {
-      if (state.load() === State.Closed) return LocalDurabilityResult.SessionStopped
-      captureResult.exceptionOrNull()?.let {
-        return LocalDurabilityResult.CaptureFailed(it)
-      }
+      checkpointResult: Result<Unit>,
+    ): EditingCheckpointResult {
+      if (state.load() === State.Closed) return EditingCheckpointResult.SessionStopped
       editResult.exceptionOrNull()?.let {
-        return LocalDurabilityResult.EditFailed(it)
+        return EditingCheckpointResult.EditFailed(it)
       }
-      return LocalDurabilityResult.Captured
+      checkpointResult.exceptionOrNull()?.let {
+        return EditingCheckpointResult.ProtectionFailed(it)
+      }
+      return EditingCheckpointResult.Protected
     }
   }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/sync/SyncEngine.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/sync/SyncEngine.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.selects.select
 
 data class PushResult(val heads: ByteArray, val durableHeads: ByteArray)
 
@@ -67,6 +68,8 @@ class SyncEngine(
   private var inflight = false
   private var persistTail: Deferred<Result<Unit>> = CompletableDeferred(Result.success(Unit))
   private var persistQueued = false
+  private var pushTail: Deferred<Result<Unit>> = CompletableDeferred(Result.success(Unit))
+  private var pushQueued = false
   private val flushWaiters = mutableListOf<CompletableDeferred<Unit>>()
   private var flushAfterInflight = false
   private var idleJob: Job? = null
@@ -155,6 +158,57 @@ class SyncEngine(
     setDurableHeads(result.durableHeads)
   }
 
+  private fun pushFresh(): Deferred<Result<Unit>> {
+    if (pushQueued) return pushTail
+    pushQueued = true
+    val previous = pushTail
+    val run =
+      scope.async(start = CoroutineStart.UNDISPATCHED) {
+        previous.await()
+        pushQueued = false
+        catchingNonCancellation {
+          if (stopped) return@catchingNonCancellation
+          drain()
+        }
+      }
+    pushTail = run
+    return run
+  }
+
+  private suspend fun frontierCoveredBy(heads: ByteArray): Boolean {
+    val missing = editor.missingChangesetsFor(heads)
+    return missing.bytes.isEmpty() && missing.withheld == 0
+  }
+
+  private suspend fun currentFrontierIsProtected(): Boolean =
+    frontierCoveredBy(capturedHeads) || frontierCoveredBy(confirmedHeads)
+
+  private fun captureWithOneRetry(): Deferred<Result<Unit>> =
+    scope.async(start = CoroutineStart.UNDISPATCHED) {
+      val first = catchingNonCancellation { capture() }
+      if (currentFrontierIsProtected()) return@async Result.success(Unit)
+      if (first.isSuccess) return@async first
+
+      val retry = catchingNonCancellation { capture() }
+      if (currentFrontierIsProtected()) Result.success(Unit) else retry
+    }
+
+  private fun checkpointFailure(
+    captureResult: Result<Unit>,
+    pushResult: Result<Unit>,
+  ): Result<Unit> {
+    val captureFailure = captureResult.exceptionOrNull()
+    val pushFailure = pushResult.exceptionOrNull()
+    val failure =
+      captureFailure
+        ?: pushFailure
+        ?: IllegalStateException("Current editor frontier is not protected")
+    if (captureFailure != null && pushFailure != null && pushFailure !== failure) {
+      failure.addSuppressed(pushFailure)
+    }
+    return Result.failure(failure)
+  }
+
   private suspend fun prune() {
     if (stopped) return
     val missing = editor.missingChangesetsFor(durableHeads)
@@ -208,7 +262,7 @@ class SyncEngine(
         captureFailuresFlow.value += 1
       }
       if (stopped) return
-      drain()
+      pushFresh().await().getOrThrow()
       if (stopped) return
       captureError?.let { throw it }
       finishSuccess(startedAt)
@@ -287,6 +341,40 @@ class SyncEngine(
     capture()
   }
 
+  suspend fun checkpointCurrentFrontier(): Result<Unit> =
+    try {
+      checkpointCurrentFrontierUnchecked()
+    } catch (e: CancellationException) {
+      throw e
+    } catch (e: Throwable) {
+      Result.failure(e)
+    }
+
+  private suspend fun checkpointCurrentFrontierUnchecked(): Result<Unit> {
+    if (currentFrontierIsProtected()) return Result.success(Unit)
+
+    val capture = captureWithOneRetry()
+    val push = pushFresh()
+    var captureResult: Result<Unit>? = null
+    var pushResult: Result<Unit>? = null
+
+    while (true) {
+      if (currentFrontierIsProtected()) return Result.success(Unit)
+      if (captureResult != null && pushResult != null) {
+        return checkpointFailure(captureResult, pushResult)
+      }
+
+      select {
+        if (captureResult == null) {
+          capture.onAwait { captureResult = it }
+        }
+        if (pushResult == null) {
+          push.onAwait { pushResult = it }
+        }
+      }
+    }
+  }
+
   suspend fun flushNow() {
     if (inflight) {
       val waiter = CompletableDeferred<Unit>()
@@ -294,7 +382,7 @@ class SyncEngine(
       waiter.await()
     }
     capture()
-    drain()
+    pushFresh().await().getOrThrow()
   }
 
   fun schedule() {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorRouteLeaveInterceptor.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorRouteLeaveInterceptor.kt
@@ -1,7 +1,7 @@
 package co.typie.screen.editor.editor
 
 import co.typie.editor.DocumentEditingClose
-import co.typie.editor.LocalDurabilityResult
+import co.typie.editor.EditingCheckpointResult
 import co.typie.navigation.RouteRemovalDecision
 import co.typie.navigation.RouteRemovalInterceptor
 import co.typie.navigation.RouteRemovalPreparation
@@ -16,7 +16,7 @@ internal class EditorRouteLeaveInterceptor(
   private val beginClose: () -> DocumentEditingClose,
   private val resolveDecision: suspend () -> RouteRemovalDecision,
   private val delayedFeedbackMillis: Long = DEFAULT_DELAYED_FEEDBACK_MILLIS,
-  private val localDurabilityWatchdogMillis: Long = DEFAULT_LOCAL_DURABILITY_WATCHDOG_MILLIS,
+  private val checkpointWatchdogMillis: Long = DEFAULT_CHECKPOINT_WATCHDOG_MILLIS,
   private val showDelayedFeedback: () -> Unit = {},
   private val hideDelayedFeedback: () -> Unit = {},
 ) : RouteRemovalInterceptor {
@@ -39,7 +39,7 @@ internal class EditorRouteLeaveInterceptor(
       }
     close = currentClose
 
-    return if (awaitLocalDurability(currentClose, onDelayed)) {
+    return if (awaitCheckpoint(currentClose, onDelayed)) {
       RouteRemovalPreparation.Ready
     } else {
       RouteRemovalPreparation.NeedsDecision
@@ -62,14 +62,15 @@ internal class EditorRouteLeaveInterceptor(
     }
   }
 
-  private suspend fun awaitLocalDurability(
+  private suspend fun awaitCheckpoint(
     close: DocumentEditingClose,
     onDelayed: (suspend () -> Unit)? = null,
   ): Boolean {
-    suspend fun awaitResult(): Boolean = awaitLocalDurabilityWithOneRetry(close)
+    suspend fun awaitResult(): Boolean =
+      close.awaitCheckpoint() == EditingCheckpointResult.Protected
 
     return try {
-      withTimeoutOrNull(localDurabilityWatchdogMillis) {
+      withTimeoutOrNull(checkpointWatchdogMillis) {
         if (onDelayed == null) return@withTimeoutOrNull awaitResult()
 
         coroutineScope {
@@ -88,16 +89,6 @@ internal class EditorRouteLeaveInterceptor(
     }
   }
 
-  private suspend fun awaitLocalDurabilityWithOneRetry(close: DocumentEditingClose): Boolean {
-    val first = close.awaitLocalDurability()
-    return when {
-      first == LocalDurabilityResult.Captured -> true
-      first is LocalDurabilityResult.CaptureFailed ->
-        close.retryLocalDurability() == LocalDurabilityResult.Captured
-      else -> false
-    }
-  }
-
   private fun hideDelayedFeedbackIfVisible() {
     if (!delayedFeedbackVisible) return
     delayedFeedbackVisible = false
@@ -106,6 +97,6 @@ internal class EditorRouteLeaveInterceptor(
 
   private companion object {
     const val DEFAULT_DELAYED_FEEDBACK_MILLIS = 350L
-    const val DEFAULT_LOCAL_DURABILITY_WATCHDOG_MILLIS = 3_000L
+    const val DEFAULT_CHECKPOINT_WATCHDOG_MILLIS = 3_000L
   }
 }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/DocumentEditingSessionTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/DocumentEditingSessionTest.kt
@@ -36,9 +36,12 @@ import kotlinx.coroutines.test.runTest
 
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 class DocumentEditingSessionTest {
-  private class FakeTransport : SyncTransport {
-    override suspend fun push(changesets: ByteArray): PushResult =
+  private class FakeTransport(
+    private val pushFn: suspend (ByteArray) -> PushResult = {
       PushResult(heads = enc(), durableHeads = enc())
+    }
+  ) : SyncTransport {
+    override suspend fun push(changesets: ByteArray): PushResult = pushFn(changesets)
 
     override suspend fun pull(sinceSeq: String?): PullResult =
       PullResult(
@@ -62,8 +65,9 @@ class DocumentEditingSessionTest {
     store: FakeDeltaStore = FakeDeltaStore(),
     syncEditor: FakeSyncEditor = FakeSyncEditor(),
     editor: Editor = Editor(FakeFfiEditor(), this, StandardTestDispatcher(testScheduler)),
+    pushFn: suspend (ByteArray) -> PushResult = { PushResult(heads = enc(), durableHeads = enc()) },
   ): Harness {
-    val transport = FakeTransport()
+    val transport = FakeTransport(pushFn)
     val scope = CoroutineScope(coroutineContext)
     val engine =
       SyncEngine(
@@ -94,6 +98,47 @@ class DocumentEditingSessionTest {
         scope = scope,
       )
     return Harness(editor = editor, session = session, store = store)
+  }
+
+  @Test
+  fun closeSucceedsThroughExactLiveAckWhenLocalCaptureFails() = runTest {
+    val store = FakeDeltaStore()
+    store.onPut = { throw IllegalStateException("disk unavailable") }
+    val syncEditor = FakeSyncEditor()
+    val (_, session) =
+      harness(
+        store = store,
+        syncEditor = syncEditor,
+        pushFn = { PushResult(heads = enc(1), durableHeads = enc()) },
+      )
+    runCurrent()
+    syncEditor.known.add(1)
+
+    val result = session.beginClose().awaitCheckpoint()
+
+    assertEquals(EditingCheckpointResult.Protected, result)
+  }
+
+  @Test
+  fun editFailureRemainsTerminalWhenLiveAckProtectsCommittedState() = runTest {
+    val store = FakeDeltaStore()
+    store.onPut = { throw IllegalStateException("disk unavailable") }
+    val failure = IllegalStateException("edit failed")
+    val syncEditor = FakeSyncEditor()
+    val (_, session) =
+      harness(
+        store = store,
+        syncEditor = syncEditor,
+        pushFn = { PushResult(heads = enc(1), durableHeads = enc()) },
+      )
+    runCurrent()
+    syncEditor.known.add(1)
+    session.submit { _, _ -> CompletableDeferred<Unit>().apply { completeExceptionally(failure) } }
+
+    val result = session.beginClose().awaitCheckpoint()
+
+    assertTrue(result is EditingCheckpointResult.EditFailed)
+    assertEquals(failure, result.cause)
   }
 
   @Test
@@ -149,7 +194,7 @@ class DocumentEditingSessionTest {
     assertFalse(started)
 
     val close = session.beginClose()
-    val result = async(start = CoroutineStart.UNDISPATCHED) { close.awaitLocalDurability() }
+    val result = async(start = CoroutineStart.UNDISPATCHED) { close.awaitCheckpoint() }
 
     assertNull(session.submit { _, context -> async(context) {} })
     assertFalse(result.isCompleted)
@@ -161,7 +206,43 @@ class DocumentEditingSessionTest {
     gate.complete(Unit)
     advanceUntilIdle()
 
-    assertEquals(LocalDurabilityResult.Captured, result.await())
+    assertEquals(EditingCheckpointResult.Protected, result.await())
+  }
+
+  @Test
+  fun closeCapturesFinalAcceptedEditInPendingStore() = runTest {
+    val syncEditor = FakeSyncEditor()
+    val editor =
+      Editor(
+        FakeFfiEditor(
+          onTick = {
+            syncEditor.known.add(1)
+            listOf(EditorEvent.StateChanged(listOf(StateField.Doc)))
+          }
+        ),
+        this,
+        StandardTestDispatcher(testScheduler),
+      )
+    val (_, session, store) = harness(syncEditor = syncEditor, editor = editor)
+    val gate = CompletableDeferred<Unit>()
+    val accepted = session.submit { sessionEditor, context ->
+      async(context = context) {
+        gate.await()
+        sessionEditor.await { enqueue(Message.System(SystemEvent.Initialize)) }
+      }
+    }
+    assertNotNull(accepted)
+
+    val close = session.beginClose()
+    val result = async(start = CoroutineStart.UNDISPATCHED) { close.awaitCheckpoint() }
+    runCurrent()
+    assertFalse(result.isCompleted)
+
+    gate.complete(Unit)
+    advanceUntilIdle()
+
+    assertEquals(EditingCheckpointResult.Protected, result.await())
+    assertEquals(listOf("1"), store.load("doc").map { it.id })
   }
 
   @Test
@@ -190,7 +271,7 @@ class DocumentEditingSessionTest {
       }
     }
     val close = session.beginClose()
-    val result = async(start = CoroutineStart.UNDISPATCHED) { close.awaitLocalDurability() }
+    val result = async(start = CoroutineStart.UNDISPATCHED) { close.awaitCheckpoint() }
 
     session.stop()
     testScheduler.runCurrent()
@@ -200,104 +281,83 @@ class DocumentEditingSessionTest {
     advanceUntilIdle()
 
     assertTrue(completedWhenStopped)
-    assertEquals(LocalDurabilityResult.SessionStopped, result.await())
+    assertEquals(EditingCheckpointResult.SessionStopped, result.await())
   }
 
   @Test
-  fun retryAfterCaptureFailureStartsOneSerializedAttempt() = runTest {
-    var failing = true
-    var loads = 0
+  fun cancelledCloseKeepsCompletedCheckpointResult() = runTest {
+    var puts = 0
     val store = FakeDeltaStore()
-    val (_, session) = harness(store)
-    store.onLoad = {
-      loads += 1
-      if (failing) throw IllegalStateException("disk unavailable")
-      emptyList()
-    }
-    val close = session.beginClose()
-
-    assertTrue(close.awaitLocalDurability() is LocalDurabilityResult.CaptureFailed)
-    val loadsAfterFailure = loads
-    failing = false
-
-    val firstRetry = async { close.retryLocalDurability() }
-    val secondRetry = async { close.retryLocalDurability() }
-    advanceUntilIdle()
-
-    assertEquals(LocalDurabilityResult.Captured, firstRetry.await())
-    assertEquals(LocalDurabilityResult.Captured, secondRetry.await())
-    assertEquals(loadsAfterFailure + 1, loads)
-  }
-
-  @Test
-  fun cancelledCloseCannotStartAnotherCaptureAttempt() = runTest {
-    var loads = 0
-    val store = FakeDeltaStore()
-    val (_, session) = harness(store)
-    store.onLoad = {
-      loads += 1
+    val syncEditor = FakeSyncEditor()
+    val (_, session) = harness(store = store, syncEditor = syncEditor)
+    runCurrent()
+    syncEditor.known.add(1)
+    store.onPut = {
+      puts += 1
       throw IllegalStateException("disk unavailable")
     }
     val close = session.beginClose()
-    val failure = close.awaitLocalDurability()
+    val failure = close.awaitCheckpoint()
     close.cancel()
 
-    assertEquals(failure, close.retryLocalDurability())
-    assertEquals(1, loads)
+    assertEquals(failure, close.awaitCheckpoint())
+    assertTrue(failure is EditingCheckpointResult.ProtectionFailed)
+    assertEquals(2, puts)
     assertNotNull(session.submit { _, context -> async(context) {} })
   }
 
   @Test
   fun editFailureStillCapturesCommittedEditorState() = runTest {
-    var loads = 0
     val store = FakeDeltaStore()
-    val (_, session) = harness(store)
-    store.onLoad = {
-      loads += 1
-      emptyList()
-    }
+    val syncEditor = FakeSyncEditor()
+    val (_, session) = harness(store = store, syncEditor = syncEditor)
+    runCurrent()
+    syncEditor.known.add(1)
     val failure = IllegalStateException("edit failed")
 
     session.submit { _, _ -> CompletableDeferred<Unit>().apply { completeExceptionally(failure) } }
 
-    val result = session.beginClose().awaitLocalDurability()
+    val result = session.beginClose().awaitCheckpoint()
 
-    assertTrue(result is LocalDurabilityResult.EditFailed)
+    assertTrue(result is EditingCheckpointResult.EditFailed)
     assertEquals(failure, result.cause)
-    assertEquals(1, loads)
+    assertEquals(listOf("1"), store.load("doc").map { it.id })
   }
 
   @Test
   fun repeatedAwaitsShareOneCaptureAttempt() = runTest {
-    var loads = 0
+    var puts = 0
     val store = FakeDeltaStore()
-    val (_, session) = harness(store)
-    store.onLoad = {
-      loads += 1
-      emptyList()
-    }
+    val syncEditor = FakeSyncEditor()
+    val (_, session) = harness(store = store, syncEditor = syncEditor)
+    runCurrent()
+    syncEditor.known.add(1)
+    store.onPut = { puts += 1 }
     val close = session.beginClose()
 
-    val first = async { close.awaitLocalDurability() }
-    val second = async { close.awaitLocalDurability() }
+    val first = async { close.awaitCheckpoint() }
+    val second = async { close.awaitCheckpoint() }
     advanceUntilIdle()
 
-    assertEquals(LocalDurabilityResult.Captured, first.await())
-    assertEquals(LocalDurabilityResult.Captured, second.await())
-    assertEquals(1, loads)
+    assertEquals(EditingCheckpointResult.Protected, first.await())
+    assertEquals(EditingCheckpointResult.Protected, second.await())
+    assertEquals(1, puts)
   }
 
   @Test
   fun cancellingAwaiterDoesNotCancelSessionOwnedCapture() = runTest {
     val captureGate = CompletableDeferred<Unit>()
     val store = FakeDeltaStore()
-    val (_, session) = harness(store)
+    val syncEditor = FakeSyncEditor()
+    val (_, session) = harness(store = store, syncEditor = syncEditor)
+    runCurrent()
+    syncEditor.known.add(1)
     store.onLoad = {
       captureGate.await()
       emptyList()
     }
     val close = session.beginClose()
-    val first = async { close.awaitLocalDurability() }
+    val first = async { close.awaitCheckpoint() }
 
     testScheduler.runCurrent()
     assertFalse(first.isCompleted)
@@ -309,6 +369,6 @@ class DocumentEditingSessionTest {
     captureGate.complete(Unit)
     advanceUntilIdle()
 
-    assertEquals(LocalDurabilityResult.Captured, close.awaitLocalDurability())
+    assertEquals(EditingCheckpointResult.Protected, close.awaitCheckpoint())
   }
 }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/sync/SyncEngineTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/sync/SyncEngineTest.kt
@@ -2,8 +2,11 @@ package co.typie.editor.sync
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -14,7 +17,7 @@ class SyncEngineTest {
   private var clock = 0L
 
   private fun TestScope.engine(
-    editor: FakeSyncEditor,
+    editor: SyncEditor,
     store: FakeDeltaStore,
     initialServerHeads: ByteArray = enc(),
     initialDurableHeads: ByteArray = enc(),
@@ -34,6 +37,248 @@ class SyncEngineTest {
       onEvent = onEvent,
       now = { clock++ },
     )
+
+  @Test
+  fun checkpointReturnsFailureWhenFrontierInspectionFails() = runTest {
+    val failure = IllegalStateException("editor unavailable")
+    val baseEditor = FakeSyncEditor()
+    var failInspection = false
+    val editor =
+      object : SyncEditor by baseEditor {
+        override suspend fun missingChangesetsFor(confirmedHeads: ByteArray): MissingBytes {
+          if (failInspection) throw failure
+          return baseEditor.missingChangesetsFor(confirmedHeads)
+        }
+      }
+    val engine =
+      engine(editor, FakeDeltaStore()) { PushResult(heads = enc(1), durableHeads = enc()) }
+    runCurrent()
+    baseEditor.known.add(1)
+    failInspection = true
+
+    val checkpoint = engine.checkpointCurrentFrontier()
+
+    assertEquals(failure, checkpoint.exceptionOrNull())
+    engine.stop()
+  }
+
+  @Test
+  fun checkpointReturnsAfterLocalCaptureWhileLivePushIsPending() = runTest {
+    val editor = FakeSyncEditor()
+    val store = FakeDeltaStore()
+    val pushStarted = CompletableDeferred<Unit>()
+    val releasePush = CompletableDeferred<Unit>()
+    val engine =
+      engine(editor, store) {
+        pushStarted.complete(Unit)
+        releasePush.await()
+        PushResult(heads = enc(1), durableHeads = enc())
+      }
+    runCurrent()
+    editor.known.add(1)
+
+    val checkpoint = async { engine.checkpointCurrentFrontier() }
+    runCurrent()
+
+    assertTrue(pushStarted.isCompleted)
+    assertTrue(checkpoint.await().isSuccess)
+    assertEquals(listOf("1"), store.load("doc1").map { it.id })
+
+    releasePush.complete(Unit)
+    advanceUntilIdle()
+    engine.stop()
+  }
+
+  @Test
+  fun checkpointReturnsAfterLiveAckWhileLocalCaptureIsPending() = runTest {
+    val editor = FakeSyncEditor()
+    val store = FakeDeltaStore()
+    val captureStarted = CompletableDeferred<Unit>()
+    val releaseCapture = CompletableDeferred<Unit>()
+    store.onPut = { record ->
+      captureStarted.complete(Unit)
+      releaseCapture.await()
+      store.defaultPut(record)
+    }
+    val engine = engine(editor, store) { PushResult(heads = enc(1), durableHeads = enc()) }
+    runCurrent()
+    editor.known.add(1)
+
+    val checkpoint = async { engine.checkpointCurrentFrontier() }
+    runCurrent()
+
+    assertTrue(captureStarted.isCompleted)
+    assertTrue(checkpoint.await().isSuccess)
+    assertFalse(releaseCapture.isCompleted)
+
+    releaseCapture.complete(Unit)
+    advanceUntilIdle()
+    engine.stop()
+  }
+
+  @Test
+  fun checkpointAcceptsExistingExactConfirmedFrontierWithoutStartingWork() = runTest {
+    val editor = FakeSyncEditor()
+    val store = FakeDeltaStore()
+    var puts = 0
+    var pushes = 0
+    store.onPut = { puts++ }
+    val engine =
+      engine(editor, store) {
+        pushes++
+        PushResult(heads = enc(), durableHeads = enc())
+      }
+    runCurrent()
+    editor.known.add(1)
+    engine.setConfirmedHeads(enc(1))
+
+    val startedAt = testScheduler.currentTime
+    assertTrue(engine.checkpointCurrentFrontier().isSuccess)
+    assertEquals(startedAt, testScheduler.currentTime)
+    assertEquals(0, puts)
+    assertEquals(0, pushes)
+    engine.stop()
+  }
+
+  @Test
+  fun checkpointAcceptsNewLiveAckWhenCaptureFailsAndDurableHeadsLag() = runTest {
+    val editor = FakeSyncEditor()
+    val store = FakeDeltaStore()
+    var puts = 0
+    store.onPut = {
+      puts++
+      throw IllegalStateException("disk unavailable")
+    }
+    val engine = engine(editor, store) { PushResult(heads = enc(1), durableHeads = enc()) }
+    runCurrent()
+    editor.known.add(1)
+
+    val checkpoint = engine.checkpointCurrentFrontier()
+
+    assertTrue(checkpoint.isSuccess)
+    assertTrue(puts >= 1)
+    engine.stop()
+  }
+
+  @Test
+  fun checkpointRejectsStaleLiveAckAndRetriesCaptureOnce() = runTest {
+    val editor = FakeSyncEditor()
+    val store = FakeDeltaStore()
+    var puts = 0
+    store.onPut = {
+      puts++
+      throw IllegalStateException("disk unavailable")
+    }
+    val engine = engine(editor, store) { PushResult(heads = enc(), durableHeads = enc()) }
+    runCurrent()
+    editor.known.add(1)
+
+    val checkpoint = engine.checkpointCurrentFrontier()
+
+    assertTrue(checkpoint.isFailure)
+    assertEquals(2, puts)
+    engine.stop()
+  }
+
+  @Test
+  fun checkpointRetriesOnlyExplicitCaptureFailure() = runTest {
+    val editor = FakeSyncEditor()
+    val store = FakeDeltaStore()
+    var loads = 0
+    store.onLoad = {
+      loads++
+      emptyList()
+    }
+    val engine = engine(editor, store) { PushResult(heads = enc(), durableHeads = enc()) }
+    runCurrent()
+    loads = 0
+    editor.known.add(1)
+    editor.withheld = 1
+
+    val checkpoint = engine.checkpointCurrentFrontier()
+
+    assertTrue(checkpoint.isFailure)
+    assertEquals(1, loads)
+    engine.stop()
+  }
+
+  @Test
+  fun checkpointWaitsForPendingLiveAckAfterBothCaptureAttemptsFail() = runTest {
+    val editor = FakeSyncEditor()
+    val store = FakeDeltaStore()
+    val pushStarted = CompletableDeferred<Unit>()
+    val releasePush = CompletableDeferred<Unit>()
+    var puts = 0
+    store.onPut = {
+      puts++
+      throw IllegalStateException("disk unavailable")
+    }
+    val engine =
+      engine(editor, store) {
+        pushStarted.complete(Unit)
+        releasePush.await()
+        PushResult(heads = enc(1), durableHeads = enc())
+      }
+    runCurrent()
+    editor.known.add(1)
+
+    val checkpoint = async { engine.checkpointCurrentFrontier() }
+    runCurrent()
+
+    assertTrue(pushStarted.isCompleted)
+    assertEquals(2, puts)
+    assertFalse(checkpoint.isCompleted)
+
+    releasePush.complete(Unit)
+    assertTrue(checkpoint.await().isSuccess)
+    engine.stop()
+  }
+
+  @Test
+  fun checkpointWaitsForPendingCaptureAfterLivePushFails() = runTest {
+    val editor = FakeSyncEditor()
+    val store = FakeDeltaStore()
+    val captureStarted = CompletableDeferred<Unit>()
+    val releaseCapture = CompletableDeferred<Unit>()
+    store.onPut = { record ->
+      captureStarted.complete(Unit)
+      releaseCapture.await()
+      store.defaultPut(record)
+    }
+    val engine = engine(editor, store) { throw IllegalStateException("network unavailable") }
+    runCurrent()
+    editor.known.add(1)
+
+    val checkpoint = async { engine.checkpointCurrentFrontier() }
+    runCurrent()
+
+    assertTrue(captureStarted.isCompleted)
+    assertFalse(checkpoint.isCompleted)
+
+    releaseCapture.complete(Unit)
+    assertTrue(checkpoint.await().isSuccess)
+    engine.stop()
+  }
+
+  @Test
+  fun checkpointFailsAfterBothDurabilityPathsTerminate() = runTest {
+    val editor = FakeSyncEditor()
+    val store = FakeDeltaStore()
+    var puts = 0
+    store.onPut = {
+      puts++
+      throw IllegalStateException("disk unavailable")
+    }
+    val engine = engine(editor, store) { throw IllegalStateException("network unavailable") }
+    runCurrent()
+    editor.known.add(1)
+
+    val checkpoint = engine.checkpointCurrentFrontier()
+
+    assertTrue(checkpoint.isFailure)
+    assertEquals(2, puts)
+    engine.stop()
+  }
 
   @Test
   fun staleStoreDeltaIsAdoptedAndPushed() = runTest {

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/EditorRouteLeaveInterceptorTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/EditorRouteLeaveInterceptorTest.kt
@@ -1,7 +1,7 @@
 package co.typie.screen.editor.editor
 
 import co.typie.editor.DocumentEditingClose
-import co.typie.editor.LocalDurabilityResult
+import co.typie.editor.EditingCheckpointResult
 import co.typie.navigation.RouteRemovalDecision
 import co.typie.navigation.RouteRemovalPreparation
 import kotlin.test.Test
@@ -25,7 +25,7 @@ class EditorRouteLeaveInterceptorTest {
     var restored = 0
     val interceptor =
       interceptor(
-        awaitResult = { LocalDurabilityResult.EditFailed(IllegalStateException("edit")) },
+        awaitResult = { EditingCheckpointResult.EditFailed(IllegalStateException("edit")) },
         onCancel = { cancelled++ },
         restoreInput = { restored++ },
       )
@@ -54,26 +54,23 @@ class EditorRouteLeaveInterceptorTest {
   }
 
   @Test
-  fun localDurabilityWaitIsBounded() = runTest {
+  fun checkpointWaitIsBounded() = runTest {
     val interceptor =
-      interceptor(awaitResult = { awaitCancellation() }, localDurabilityWatchdogMillis = 10)
+      interceptor(awaitResult = { awaitCancellation() }, checkpointWatchdogMillis = 10)
 
     assertEquals(RouteRemovalPreparation.NeedsDecision, interceptor.prepare())
     assertEquals(10L, currentTime)
   }
 
   @Test
-  fun defaultLocalDurabilityWatchdogExpiresAtThreeSeconds() = runTest {
+  fun defaultCheckpointWatchdogExpiresAtThreeSeconds() = runTest {
     val interceptor =
       EditorRouteLeaveInterceptor(
         finalizeInput = {},
         restoreInput = {},
         beginClose = {
           object : DocumentEditingClose {
-            override suspend fun awaitLocalDurability(): LocalDurabilityResult = awaitCancellation()
-
-            override suspend fun retryLocalDurability(): LocalDurabilityResult =
-              error("A timeout must not start a retry")
+            override suspend fun awaitCheckpoint(): EditingCheckpointResult = awaitCancellation()
 
             override fun cancel() = Unit
           }
@@ -87,15 +84,15 @@ class EditorRouteLeaveInterceptorTest {
 
   @Test
   fun delayedFeedbackStartsAtSoftThresholdAndSuccessStillAllowsRemoval() = runTest {
-    val durability = CompletableDeferred<LocalDurabilityResult>()
+    val checkpoint = CompletableDeferred<EditingCheckpointResult>()
     var delayed = 0
     var shown = 0
     var hidden = 0
     val interceptor =
       interceptor(
-        awaitResult = { durability.await() },
+        awaitResult = { checkpoint.await() },
         delayedFeedbackMillis = 10,
-        localDurabilityWatchdogMillis = 30,
+        checkpointWatchdogMillis = 30,
         showDelayedFeedback = { shown++ },
         hideDelayedFeedback = { hidden++ },
       )
@@ -114,38 +111,32 @@ class EditorRouteLeaveInterceptorTest {
     assertEquals(1, shown)
     assertFalse(preparation.isCompleted)
 
-    durability.complete(LocalDurabilityResult.Captured)
+    checkpoint.complete(EditingCheckpointResult.Protected)
     assertEquals(RouteRemovalPreparation.Ready, preparation.await())
     assertEquals(1, hidden)
   }
 
   @Test
-  fun captureRetryContinuesAcrossSoftThresholdWithoutRestarting() = runTest {
-    val failure = LocalDurabilityResult.CaptureFailed(IllegalStateException("still unavailable"))
-    val retryCompletion = CompletableDeferred<LocalDurabilityResult>()
-    var retries = 0
+  fun checkpointWaitContinuesAcrossSoftThresholdWithoutRestarting() = runTest {
+    val checkpoint = CompletableDeferred<EditingCheckpointResult>()
+    var waits = 0
     val interceptor =
       interceptor(
-        awaitResult = { failure },
-        retryResult = {
-          retries++
-          retryCompletion.await()
+        awaitResult = {
+          waits++
+          checkpoint.await()
         },
         delayedFeedbackMillis = 10,
-        localDurabilityWatchdogMillis = 30,
+        checkpointWatchdogMillis = 30,
       )
 
     val preparation = async { interceptor.prepare(onDelayed = {}) }
-    runCurrent()
-    assertEquals(1, retries)
-
     advanceTimeBy(10)
     runCurrent()
-    assertEquals(1, retries)
 
-    retryCompletion.complete(failure)
-    assertEquals(RouteRemovalPreparation.NeedsDecision, preparation.await())
-    assertEquals(1, retries)
+    assertEquals(1, waits)
+    checkpoint.complete(EditingCheckpointResult.Protected)
+    assertEquals(RouteRemovalPreparation.Ready, preparation.await())
   }
 
   @Test
@@ -155,7 +146,7 @@ class EditorRouteLeaveInterceptorTest {
       interceptor(
         awaitResult = { awaitCancellation() },
         delayedFeedbackMillis = 10,
-        localDurabilityWatchdogMillis = 20,
+        checkpointWatchdogMillis = 20,
         showDelayedFeedback = { shown++ },
       )
 
@@ -166,15 +157,15 @@ class EditorRouteLeaveInterceptorTest {
 
   @Test
   fun rollbackDismissesVisibleDelayedFeedbackOnce() = runTest {
-    val durability = CompletableDeferred<LocalDurabilityResult>()
+    val checkpoint = CompletableDeferred<EditingCheckpointResult>()
     var shown = 0
     var hidden = 0
     val interceptor =
       interceptor(
-        awaitResult = { durability.await() },
-        onCancel = { durability.complete(LocalDurabilityResult.SessionStopped) },
+        awaitResult = { checkpoint.await() },
+        onCancel = { checkpoint.complete(EditingCheckpointResult.SessionStopped) },
         delayedFeedbackMillis = 10,
-        localDurabilityWatchdogMillis = 30,
+        checkpointWatchdogMillis = 30,
         showDelayedFeedback = { shown++ },
         hideDelayedFeedback = { hidden++ },
       )
@@ -190,27 +181,12 @@ class EditorRouteLeaveInterceptorTest {
   }
 
   @Test
-  fun retriesCaptureFailureOnceBeforeAllowingRemoval() = runTest {
-    var retries = 0
+  fun protectionFailureNeedsDecision() = runTest {
     val interceptor =
       interceptor(
-        awaitResult = { LocalDurabilityResult.CaptureFailed(IllegalStateException("disk")) },
-        retryResult = {
-          retries++
-          LocalDurabilityResult.Captured
-        },
-      )
-
-    assertEquals(RouteRemovalPreparation.Ready, interceptor.prepare())
-    assertEquals(1, retries)
-  }
-
-  @Test
-  fun twoCaptureFailuresNeedDecision() = runTest {
-    val interceptor =
-      interceptor(
-        awaitResult = { LocalDurabilityResult.CaptureFailed(IllegalStateException("unprotected")) },
-        retryResult = { LocalDurabilityResult.CaptureFailed(IllegalStateException("unprotected")) },
+        awaitResult = {
+          EditingCheckpointResult.ProtectionFailed(IllegalStateException("unprotected"))
+        }
       )
 
     assertEquals(RouteRemovalPreparation.NeedsDecision, interceptor.prepare())
@@ -218,12 +194,11 @@ class EditorRouteLeaveInterceptorTest {
 }
 
 private fun interceptor(
-  awaitResult: suspend () -> LocalDurabilityResult = { LocalDurabilityResult.Captured },
-  retryResult: suspend () -> LocalDurabilityResult = { LocalDurabilityResult.Captured },
+  awaitResult: suspend () -> EditingCheckpointResult = { EditingCheckpointResult.Protected },
   onCancel: () -> Unit = {},
   restoreInput: () -> Unit = {},
   delayedFeedbackMillis: Long = 350,
-  localDurabilityWatchdogMillis: Long = 3_000,
+  checkpointWatchdogMillis: Long = 3_000,
   showDelayedFeedback: () -> Unit = {},
   hideDelayedFeedback: () -> Unit = {},
 ): EditorRouteLeaveInterceptor =
@@ -232,9 +207,7 @@ private fun interceptor(
     restoreInput = restoreInput,
     beginClose = {
       object : DocumentEditingClose {
-        override suspend fun awaitLocalDurability(): LocalDurabilityResult = awaitResult()
-
-        override suspend fun retryLocalDurability(): LocalDurabilityResult = retryResult()
+        override suspend fun awaitCheckpoint(): EditingCheckpointResult = awaitResult()
 
         override fun cancel() {
           onCancel()
@@ -243,7 +216,7 @@ private fun interceptor(
     },
     resolveDecision = { RouteRemovalDecision.CancelRemoval },
     delayedFeedbackMillis = delayedFeedbackMillis,
-    localDurabilityWatchdogMillis = localDurabilityWatchdogMillis,
+    checkpointWatchdogMillis = checkpointWatchdogMillis,
     showDelayedFeedback = showDelayedFeedback,
     hideDelayedFeedback = hideDelayedFeedback,
   )

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/EditorRouteRemovalNavigationStackDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/EditorRouteRemovalNavigationStackDesktopTest.kt
@@ -10,8 +10,8 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.dp
 import co.typie.editor.DocumentEditingClose
+import co.typie.editor.EditingCheckpointResult
 import co.typie.editor.EditorLocalEditCoordinator
-import co.typie.editor.LocalDurabilityResult
 import co.typie.route.Route
 import co.typie.screen.editor.editor.EditorRouteLeaveInterceptor
 import co.typie.ui.component.topbar.TopBarState
@@ -43,19 +43,16 @@ class EditorRouteRemovalNavigationStackDesktopTest {
         beginClose = {
           val quiescence = localEdits.quiesce()
           object : DocumentEditingClose {
-            override suspend fun awaitLocalDurability(): LocalDurabilityResult {
+            override suspend fun awaitCheckpoint(): EditingCheckpointResult {
               barrierStarted.complete(Unit)
               val editResult = quiescence.await()
               captureStarted.complete(Unit)
               releaseCapture.await()
               return editResult.fold(
-                onSuccess = { LocalDurabilityResult.Captured },
-                onFailure = { LocalDurabilityResult.EditFailed(it) },
+                onSuccess = { EditingCheckpointResult.Protected },
+                onFailure = { EditingCheckpointResult.EditFailed(it) },
               )
             }
-
-            override suspend fun retryLocalDurability(): LocalDurabilityResult =
-              LocalDurabilityResult.Captured
 
             override fun cancel() {
               quiescence.resume()


### PR DESCRIPTION
에디터 이탈 시 마지막 변경이 로컬 DB 또는 서버 live stream 중 한 곳에 정확히 보호됐는지 확인합니다.

- `DocumentEditingSession`의 local capture/retry API를 하나의 checkpoint 계약으로 정리합니다.
- `SyncEngine`이 `capturedHeads`와 `confirmedHeads`를 기준으로 현재 frontier의 exact coverage를 검사하고, local capture와 live push 중 먼저 성공한 경로로 이탈을 허용합니다.
- 한 경로가 실패해도 다른 경로가 진행 중이면 watchdog 안에서 계속 기다립니다. accepted edit 실패는 보호 성공과 무관하게 이탈 실패로 유지하며 `durableHeads`는 기다리지 않습니다.