### PR TITLE
PageBreak 뒤 trailing paragraph를 projection에서 보완

### DIFF
--- a/crates/editor-commands/src/commands/insert_slice_at.rs
+++ b/crates/editor-commands/src/commands/insert_slice_at.rs
@@ -163,6 +163,13 @@ mod tests {
             .collect()
     }
 
+    fn assert_trailing_paragraph_is_synthetic(state: &editor_state::State) {
+        let view = state.view();
+        let trailing = view.root().unwrap().child_blocks().last().unwrap();
+        assert_eq!(trailing.node_type(), NodeType::Paragraph);
+        assert!(trailing.id().is_synthetic());
+    }
+
     fn block_texts(view: &DocView, root: Dot) -> Vec<String> {
         view.node(root)
             .unwrap()
@@ -697,7 +704,7 @@ mod tests {
     }
 
     #[test]
-    fn insert_page_break_slice_at_root_paragraph_end_creates_following_paragraph() {
+    fn insert_page_break_slice_at_root_paragraph_end_uses_synthetic_following_paragraph() {
         let (initial, p1) = state! {
             doc { root { p1: paragraph { text("World") } } }
             selection: none
@@ -722,6 +729,7 @@ mod tests {
             selection: (p2, 0)
         };
         assert_state_eq!(&actual, &expected);
+        assert_trailing_paragraph_is_synthetic(&actual);
         assert!(!inserted.is_collapsed());
     }
 
@@ -751,6 +759,7 @@ mod tests {
             selection: (p2, 0)
         };
         assert_state_eq!(&actual, &expected);
+        assert_trailing_paragraph_is_synthetic(&actual);
         assert!(!inserted.is_collapsed());
     }
 
@@ -823,6 +832,7 @@ mod tests {
             selection: (p3, 0)
         };
         assert_state_eq!(&actual, &expected);
+        assert_trailing_paragraph_is_synthetic(&actual);
         assert_eq!(
             inserted,
             Selection::new(

--- a/crates/editor-commands/src/helpers/slice.rs
+++ b/crates/editor-commands/src/helpers/slice.rs
@@ -16,7 +16,10 @@ use crate::{CommandError, CommandResult};
 
 mod page_break;
 
-use page_break::{insert_terminal_page_break_from_edge, prepare_page_breaks_for_position};
+use page_break::{
+    insert_terminal_page_break_from_edge, paragraph_ends_with_page_break,
+    prepare_page_breaks_for_position,
+};
 
 enum InlineMode {
     Formatted,
@@ -106,7 +109,7 @@ pub(crate) fn insert_slice_at_position(
     if slice.is_empty() {
         return Ok(None);
     }
-    let (slice, trailing_block_context) = prepare_page_breaks_for_position(tr, &position, slice);
+    let slice = prepare_page_breaks_for_position(tr, &position, slice);
     if slice.is_empty() {
         return Ok(None);
     }
@@ -144,7 +147,7 @@ pub(crate) fn insert_slice_at_position(
             return Ok(None);
         };
         let position = materialize_position_block(tr, position)?;
-        insert_blocks_at_block_boundary(tr, position, blocks, trailing_block_context)
+        insert_blocks_at_block_boundary(tr, position, blocks)
     }
 }
 
@@ -412,7 +415,13 @@ fn insert_blocks_in_textblock(
         && blocks
             .last()
             .is_some_and(|b| same_textblock_type(&b.node, p2_id, tr));
-    let merge_end_into_start = merge_start && merge_end && blocks.len() == 1;
+    let terminal_page_break_edge = merge_start
+        && blocks.len() == 1
+        && blocks
+            .first()
+            .is_some_and(|fragment| paragraph_ends_with_page_break(fragment));
+    let merge_end_into_start =
+        merge_start && merge_end && blocks.len() == 1 && !terminal_page_break_edge;
 
     let middle_start = if merge_start { 1 } else { 0 };
     let middle_end = if merge_end {
@@ -420,7 +429,10 @@ fn insert_blocks_in_textblock(
     } else {
         blocks.len()
     };
-    let merge_end = merge_end && !merge_end_into_start && middle_end >= middle_start;
+    let merge_end = merge_end
+        && !merge_end_into_start
+        && !terminal_page_break_edge
+        && middle_end >= middle_start;
 
     let mut last_caret: Option<Position> = None;
     let mut inserted_range = InsertedRange::default();
@@ -500,13 +512,6 @@ fn insert_blocks_in_textblock(
         }
     }
 
-    let keep_trailing_page_break_context = terminal_page_break_start.is_some();
-    if let Some(start) = terminal_page_break_start {
-        let end = position_at_start_of_block(tr, p2_id)?;
-        inserted_range.include_position_range(start, end);
-        last_caret = Some(end);
-    }
-
     let safe_to_remove = |tr: &Transaction, target: Dot| -> bool {
         let view = tr.state().view();
         let Some(target_node) = view.node(target) else {
@@ -532,7 +537,14 @@ fn insert_blocks_in_textblock(
     if !merge_start && safe_to_remove(tr, textblock_id) {
         tr.remove_subtree(textblock_id)?;
     }
-    if !merge_end && !keep_trailing_page_break_context && safe_to_remove(tr, p2_id) {
+    let p2_is_last_child = {
+        let view = tr.state().view();
+        view.node(container_id)
+            .and_then(|container| container.last_child())
+            .is_some_and(|child| matches!(child, ChildView::Block(block) if block.id() == p2_id))
+    };
+    let can_remove_p2 = terminal_page_break_start.is_none() || p2_is_last_child;
+    if !merge_end && can_remove_p2 && safe_to_remove(tr, p2_id) {
         tr.remove_subtree(p2_id)?;
     }
 
@@ -543,6 +555,14 @@ fn insert_blocks_in_textblock(
             .unwrap_or_default()
     };
     tr.apply_steps(steps)?;
+
+    if let Some(start) = terminal_page_break_start {
+        let following_id = block_child_id(tr, container_id, textblock_index + 1)
+            .ok_or_else(|| CommandError::Corrupted("PageBreak has no following block".into()))?;
+        let end = position_at_start_of_block(tr, following_id)?;
+        inserted_range.include_position_range(start, end);
+        last_caret = Some(end);
+    }
 
     let mut final_pos = match last_caret {
         Some(p) => p,
@@ -599,23 +619,15 @@ fn insert_blocks_at_block_boundary(
     tr: &mut Transaction,
     position: Position,
     blocks: Vec<Fragment>,
-    trailing_block_context: Option<Fragment>,
 ) -> Result<Option<Selection>, CommandError> {
     let container_id = position.node;
     let base_index = position.offset;
-    let payload_block_count = blocks.len();
-    let inserted_block_count = payload_block_count + usize::from(trailing_block_context.is_some());
+    let block_count = blocks.len();
+    let terminal_page_break = blocks.last().is_some_and(paragraph_ends_with_page_break);
     tr.batch(|tr| {
         for (offset, block) in blocks.iter().enumerate() {
             let subtree = block.clone().into_subtree();
             tr.insert_subtree(container_id, base_index + offset, subtree)?;
-        }
-        if let Some(context) = &trailing_block_context {
-            tr.insert_subtree(
-                container_id,
-                base_index + payload_block_count,
-                context.clone().into_subtree(),
-            )?;
         }
         let steps = {
             let view = tr.state().view();
@@ -627,9 +639,17 @@ fn insert_blocks_at_block_boundary(
         Ok::<(), CommandError>(())
     })?;
 
-    if let Some(id) = block_child_id(tr, container_id, base_index + inserted_block_count - 1)
-        && let Ok(mut final_pos) = position_at_end_of_block(tr, id)
-    {
+    let trailing_synthetic = terminal_page_break
+        .then(|| block_child_id(tr, container_id, base_index + block_count))
+        .flatten()
+        .filter(|id| id.is_synthetic());
+    let final_position = trailing_synthetic
+        .and_then(|id| position_at_start_of_block(tr, id).ok())
+        .or_else(|| {
+            block_child_id(tr, container_id, base_index + block_count - 1)
+                .and_then(|id| position_at_end_of_block(tr, id).ok())
+        });
+    if let Some(mut final_pos) = final_position {
         final_pos.affinity = Affinity::Downstream;
         tr.set_selection(Some(Selection::collapsed(final_pos)))?;
     }
@@ -637,7 +657,7 @@ fn insert_blocks_at_block_boundary(
     Ok(Some(selection_over_inserted_blocks(
         container_id,
         base_index,
-        payload_block_count,
+        block_count,
     )))
 }
 

--- a/crates/editor-commands/src/helpers/slice/page_break.rs
+++ b/crates/editor-commands/src/helpers/slice/page_break.rs
@@ -12,9 +12,9 @@ pub(super) fn prepare_page_breaks_for_position(
     tr: &Transaction,
     position: &Position,
     slice: Slice,
-) -> (Slice, Option<Fragment>) {
+) -> Slice {
     if !contains_page_break(&slice.content) {
-        return (slice, None);
+        return slice;
     }
 
     let in_textblock = position_in_textblock(tr, position);
@@ -31,23 +31,16 @@ pub(super) fn prepare_page_breaks_for_position(
     let content = sanitized.fragments;
 
     if content.is_empty() {
-        return (Slice::new(vec![], 0, 0), None);
+        return Slice::new(vec![], 0, 0);
     }
 
     let terminal_bare_page_break =
         top_level_inline && content.last().is_some_and(is_page_break_fragment);
     if root_textblock && terminal_bare_page_break {
-        return (
-            Slice::new(
-                vec![paragraph_with_children(content), empty_paragraph_fragment()],
-                1,
-                1,
-            ),
-            None,
-        );
+        return Slice::new(vec![paragraph_with_children(content)], 1, 1);
     }
 
-    let mut prepared = if root_boundary && top_level_inline {
+    if root_boundary && top_level_inline {
         Slice::new(vec![paragraph_with_children(content)], 0, 0)
     } else {
         Slice::new(
@@ -55,32 +48,7 @@ pub(super) fn prepare_page_breaks_for_position(
             slice.open_start.min(sanitized.open_start),
             slice.open_end.min(sanitized.open_end),
         )
-    };
-
-    if root_textblock
-        && prepared.open_end > 0
-        && prepared
-            .content
-            .last()
-            .is_some_and(paragraph_ends_with_page_break)
-    {
-        prepared.content.push(empty_paragraph_fragment());
-        prepared.open_end = 1;
     }
-
-    let trailing_block_context = if root_boundary
-        && root_boundary_is_at_end(tr, position)
-        && prepared
-            .content
-            .last()
-            .is_some_and(paragraph_ends_with_page_break)
-    {
-        Some(empty_paragraph_fragment())
-    } else {
-        None
-    };
-
-    (prepared, trailing_block_context)
 }
 
 pub(super) fn insert_terminal_page_break_from_edge(
@@ -204,7 +172,7 @@ fn contains_page_break(fragments: &[Fragment]) -> bool {
         .any(|fragment| is_page_break_fragment(fragment) || contains_page_break(&fragment.children))
 }
 
-fn paragraph_ends_with_page_break(fragment: &Fragment) -> bool {
+pub(super) fn paragraph_ends_with_page_break(fragment: &Fragment) -> bool {
     fragment.node.as_type() == NodeType::Paragraph
         && fragment.children.last().is_some_and(is_page_break_fragment)
 }
@@ -216,17 +184,6 @@ fn paragraph_with_children(children: Vec<Fragment>) -> Fragment {
         carry: vec![],
         children,
     }
-}
-
-fn empty_paragraph_fragment() -> Fragment {
-    paragraph_with_children(vec![])
-}
-
-fn root_boundary_is_at_end(tr: &Transaction, position: &Position) -> bool {
-    tr.state()
-        .view()
-        .root()
-        .is_some_and(|root| position.offset >= root.children().count())
 }
 
 fn position_is_in_root_paragraph(tr: &Transaction, position: &Position) -> bool {

--- a/crates/editor-model/src/seq/normalize.rs
+++ b/crates/editor-model/src/seq/normalize.rs
@@ -202,6 +202,34 @@ fn first_type(e: &ContentExpr) -> NodeType {
     }
 }
 
+fn last_known_child(children: &[RawChild]) -> Option<&RawChild> {
+    children.iter().rev().find(|child| {
+        child
+            .as_child_type()
+            .is_some_and(|node_type| node_type != NodeType::Unknown)
+    })
+}
+
+fn complete_root_trailing_editable_paragraph(node: &mut RawNode) {
+    if node.node_type != NodeType::Root {
+        return;
+    }
+    let Some(RawChild::Block(paragraph)) = last_known_child(&node.children) else {
+        return;
+    };
+    if paragraph.node_type != NodeType::Paragraph
+        || last_known_child(&paragraph.children).and_then(RawChild::as_child_type)
+            != Some(NodeType::PageBreak)
+    {
+        return;
+    }
+    node.children.push(RawChild::Block(scaffold_block(
+        NodeType::Paragraph,
+        0,
+        node.id,
+    )));
+}
+
 fn drop_context_invalid_here(node: &mut RawNode, path: &[NodeType]) {
     node.children.retain(|c| {
         let Some(t) = c.as_child_type() else {
@@ -278,6 +306,7 @@ pub fn normalize_content_shallow(node: &mut RawNode, ancestors: &[NodeType]) {
             repair_preserving_unknown(node, repair_general);
         }
     }
+    complete_root_trailing_editable_paragraph(node);
     path.pop();
 }
 
@@ -319,6 +348,7 @@ fn normalize_node(node: &mut RawNode, path: &mut Vec<NodeType>) {
     if node.node_type == NodeType::Table {
         normalize_grid(node);
     }
+    complete_root_trailing_editable_paragraph(node);
     path.pop();
 }
 
@@ -327,10 +357,22 @@ mod tests {
     use editor_crdt::Dot;
 
     use super::*;
-    use crate::seq::{AtomLeaf, BlockTree, flatten, validate_block_tree as validate_flat};
+    use crate::seq::{AtomLeaf, BlockTree, validate_block_tree as validate_flat};
 
     fn valid(t: &RawTree) -> Result<(), crate::SchemaError> {
         validate_flat(&BlockTree::from_raw(t))
+    }
+
+    fn find_leaf(tree: &RawTree, id: Dot) -> Option<&super::super::SeqItem> {
+        fn in_node(node: &RawNode, id: Dot) -> Option<&super::super::SeqItem> {
+            node.children.iter().find_map(|child| match child {
+                RawChild::Leaf { id: leaf_id, item } if *leaf_id == id => Some(item),
+                RawChild::Block(block) => in_node(block, id),
+                RawChild::Leaf { .. } => None,
+            })
+        }
+
+        tree.roots.iter().find_map(|root| in_node(root, id))
     }
 
     fn fold(kids: Vec<(u64, NodeType)>) -> RawNode {
@@ -408,6 +450,104 @@ mod tests {
         assert!(matches!(
             &node.children[1],
             RawChild::Block(b) if b.node_type == NodeType::Paragraph && b.id.is_synthetic()
+        ));
+    }
+
+    #[test]
+    fn normalize_root_adds_trailing_paragraph_after_page_break() {
+        let paragraph_id = Dot::new(1, 1);
+        let tree = RawTree {
+            roots: vec![RawNode {
+                attrs: vec![],
+                id: Dot::ROOT,
+                node_type: NodeType::Root,
+                children: vec![RawChild::Block(RawNode {
+                    attrs: vec![],
+                    id: paragraph_id,
+                    node_type: NodeType::Paragraph,
+                    children: vec![RawChild::Leaf {
+                        id: Dot::new(1, 2),
+                        item: super::super::SeqItem::Atom(AtomLeaf::PageBreak),
+                    }],
+                })],
+            }],
+        };
+
+        let normalized = normalize(tree);
+        let root = &normalized.roots[0];
+
+        assert_eq!(root.children.len(), 2);
+        assert!(matches!(
+            &root.children[0],
+            RawChild::Block(paragraph) if paragraph.id == paragraph_id
+        ));
+        assert!(matches!(
+            &root.children[1],
+            RawChild::Block(paragraph)
+                if paragraph.node_type == NodeType::Paragraph && paragraph.id.is_synthetic()
+        ));
+    }
+
+    #[test]
+    fn normalize_content_shallow_adds_trailing_paragraph_after_page_break() {
+        let mut root = RawNode {
+            attrs: vec![],
+            id: Dot::ROOT,
+            node_type: NodeType::Root,
+            children: vec![RawChild::Block(RawNode {
+                attrs: vec![],
+                id: Dot::new(1, 1),
+                node_type: NodeType::Paragraph,
+                children: vec![RawChild::Leaf {
+                    id: Dot::new(1, 2),
+                    item: super::super::SeqItem::Atom(AtomLeaf::PageBreak),
+                }],
+            })],
+        };
+
+        normalize_content_shallow(&mut root, &[]);
+
+        assert!(matches!(
+            &root.children[..],
+            [RawChild::Block(_), RawChild::Block(paragraph)]
+                if paragraph.node_type == NodeType::Paragraph && paragraph.id.is_synthetic()
+        ));
+    }
+
+    #[test]
+    fn normalize_root_ignores_unknown_after_terminal_page_break() {
+        let tree = RawTree {
+            roots: vec![RawNode {
+                attrs: vec![],
+                id: Dot::ROOT,
+                node_type: NodeType::Root,
+                children: vec![RawChild::Block(RawNode {
+                    attrs: vec![],
+                    id: Dot::new(1, 1),
+                    node_type: NodeType::Paragraph,
+                    children: vec![
+                        RawChild::Leaf {
+                            id: Dot::new(1, 2),
+                            item: super::super::SeqItem::Atom(AtomLeaf::PageBreak),
+                        },
+                        RawChild::Leaf {
+                            id: Dot::new(1, 3),
+                            item: super::super::SeqItem::Unknown {
+                                tag: 999,
+                                bytes: vec![],
+                            },
+                        },
+                    ],
+                })],
+            }],
+        };
+
+        let normalized = normalize(tree);
+
+        assert!(matches!(
+            &normalized.roots[0].children[..],
+            [RawChild::Block(_), RawChild::Block(paragraph)]
+                if paragraph.node_type == NodeType::Paragraph && paragraph.id.is_synthetic()
         ));
     }
 
@@ -858,18 +998,19 @@ mod tests {
             ],
         };
         let out = normalize(RawTree { roots: vec![node] });
-        let flat = flatten(&out);
         assert!(
-            flat.iter().any(|(d, item)| *d == unknown
-                && matches!(item, super::super::SeqItem::Unknown { tag: 999, .. })),
+            matches!(
+                find_leaf(&out, unknown),
+                Some(super::super::SeqItem::Unknown { tag: 999, .. })
+            ),
             "normalize가 unknown 리프를 드롭/변형하면 안 된다"
         );
         assert!(
-            flat.iter().any(|(d, _)| *d == pb1),
+            find_leaf(&out, pb1).is_some(),
             "매치되는 첫 PageBreak는 유지"
         );
         assert!(
-            !flat.iter().any(|(d, _)| *d == pb2),
+            find_leaf(&out, pb2).is_none(),
             "unmatched-drop 경로가 실제로 두번째 PageBreak를 드롭해야 이 케이스가 유의미하다"
         );
     }
@@ -1198,24 +1339,22 @@ mod tests {
             ],
         };
         let out = normalize(RawTree { roots: vec![node] });
-        let flat = flatten(&out);
         assert!(
-            flat.iter().any(|(d, item)| *d == block_atom_unknown
-                && matches!(
-                    item,
-                    super::super::SeqItem::BlockAtom {
-                        leaf: AtomLeaf::Unknown(_),
-                        ..
-                    }
-                )),
+            matches!(
+                find_leaf(&out, block_atom_unknown),
+                Some(super::super::SeqItem::BlockAtom {
+                    leaf: AtomLeaf::Unknown(_),
+                    ..
+                })
+            ),
             "an AtomLeaf::Unknown-bearing leaf must survive normalize unmodified"
         );
         assert!(
-            flat.iter().any(|(d, _)| *d == pb1),
+            find_leaf(&out, pb1).is_some(),
             "matching first PageBreak kept"
         );
         assert!(
-            !flat.iter().any(|(d, _)| *d == pb2),
+            find_leaf(&out, pb2).is_none(),
             "unmatched-drop must still drop the extra PageBreak"
         );
         assert!(valid(&out).is_ok());

--- a/crates/editor-state/src/projected_state.rs
+++ b/crates/editor-state/src/projected_state.rs
@@ -90,6 +90,38 @@ fn collect_subtree_nodes(tree: &BlockTree, node: &BlockNode, out: &mut Vec<Dot>)
     }
 }
 
+fn last_known_child_for_shallow_root_repair(
+    tree: &BlockTree,
+    block: &BlockNode,
+) -> Option<RawChild> {
+    (0..block.children.len())
+        .rev()
+        .find_map(|index| match block.children.get(index)? {
+            Child::Leaf { id, item }
+                if item
+                    .as_child_type()
+                    .is_some_and(|ty| ty != NodeType::Unknown) =>
+            {
+                Some(RawChild::Leaf {
+                    id: *id,
+                    item: item.clone(),
+                })
+            }
+            Child::Block(id) => tree
+                .get(*id)
+                .filter(|child| child.node_type != NodeType::Unknown)
+                .map(|child| {
+                    RawChild::Block(RawNode {
+                        id: child.id,
+                        node_type: child.node_type,
+                        attrs: child.attrs.clone(),
+                        children: Vec::new(),
+                    })
+                }),
+            Child::Leaf { .. } => None,
+        })
+}
+
 type BlockLeafPlan = Vec<(Dot, Vec<(Dot, Option<NodeType>)>)>;
 
 /// Plan the index/derivation entries for a freshly re-projected (nested scratch)
@@ -771,11 +803,12 @@ impl ProjectedState {
     }
 
     /// Re-establish the Root's own schema content rule on the flat tree by running the
-    /// nested `normalize_content_shallow` over a shallow (direct-children-only) view of
-    /// the root and reconciling the result back: existing blocks keep their real flat
-    /// subtree, newly scaffolded blocks are grafted in (and returned for indexing), and
-    /// rule-dropped blocks are forgotten. The Root rule only ever appends/drops direct
-    /// children, so an empty-children shallow view is faithful.
+    /// nested `normalize_content_shallow` over a shallow view of the root and reconciling
+    /// the result back: existing blocks keep their real flat subtree, newly scaffolded
+    /// blocks are grafted in (and returned for indexing), and rule-dropped blocks are
+    /// forgotten. The last direct Paragraph carries its last schema-known child so
+    /// Root-level completion can distinguish a terminal PageBreak from an editable
+    /// trailing Paragraph without cloning the Paragraph's full content.
     fn repair_root_content_shallow(&mut self) -> Vec<RawNode> {
         let root_id = self.projected.tree.root;
         let Some(root) = self.projected.tree.get(root_id) else {
@@ -787,6 +820,11 @@ impl ProjectedState {
             attrs: root.attrs.clone(),
             children: Vec::new(),
         };
+        let last_root_block = last_known_child_for_shallow_root_repair(&self.projected.tree, root)
+            .and_then(|child| match child {
+                RawChild::Block(block) => Some(block.id),
+                RawChild::Leaf { .. } => None,
+            });
         for c in &root.children {
             match c {
                 Child::Leaf { id, item } => shallow.children.push(RawChild::Leaf {
@@ -794,17 +832,28 @@ impl ProjectedState {
                     item: item.clone(),
                 }),
                 Child::Block(id) => {
-                    let (nt, attrs) = self
-                        .projected
-                        .tree
-                        .get(*id)
+                    let block = self.projected.tree.get(*id);
+                    let (nt, attrs) = block
                         .map(|b| (b.node_type, b.attrs.clone()))
                         .unwrap_or((NodeType::Paragraph, Vec::new()));
+                    let children = if Some(*id) == last_root_block && nt == NodeType::Paragraph {
+                        block
+                            .and_then(|block| {
+                                last_known_child_for_shallow_root_repair(
+                                    &self.projected.tree,
+                                    block,
+                                )
+                            })
+                            .into_iter()
+                            .collect()
+                    } else {
+                        Vec::new()
+                    };
                     shallow.children.push(RawChild::Block(RawNode {
                         id: *id,
                         node_type: nt,
                         attrs,
-                        children: Vec::new(),
+                        children,
                     }));
                 }
             }
@@ -2467,6 +2516,62 @@ mod tests {
         assert_eq!(p.node_type(), NodeType::Paragraph);
         assert_eq!(p.inline_text(), "Hi");
         assert!(state.block_modifiers().modifiers_of(Dot::ROOT).is_empty());
+    }
+
+    #[test]
+    fn terminal_page_break_warm_projection_adds_synthetic_trailing_paragraph() {
+        use editor_model::AtomLeaf;
+
+        let mut warm = ProjectedState::empty();
+        let _ = warm.take_layout_dirty();
+
+        warm.apply(EditOp::Seq(ListOp::Ins {
+            pos: 1,
+            item: SeqItem::Atom(AtomLeaf::PageBreak),
+        }))
+        .unwrap();
+
+        let children: Vec<(NodeType, Dot)> = warm
+            .view()
+            .root()
+            .unwrap()
+            .child_blocks()
+            .map(|block| (block.node_type(), block.id()))
+            .collect();
+        assert_eq!(children.len(), 2);
+        assert_eq!(children[1].0, NodeType::Paragraph);
+        assert!(children[1].1.is_synthetic());
+        assert!(!matches!(warm.take_layout_dirty(), LayoutDirty::Full));
+
+        let cold = ProjectedState::from_graph(warm.graph().clone()).unwrap();
+        assert_eq!(warm.projected(), cold.projected());
+    }
+
+    #[test]
+    fn unknown_root_block_after_page_break_does_not_hide_trailing_completion() {
+        use editor_model::AtomLeaf;
+
+        let mut warm = ProjectedState::empty();
+        warm.apply(EditOp::Seq(ListOp::Ins {
+            pos: 1,
+            item: SeqItem::Atom(AtomLeaf::PageBreak),
+        }))
+        .unwrap();
+        warm.apply(seq_block(2, NodeType::Unknown, vec![Dot::ROOT]))
+            .unwrap();
+
+        let cold = ProjectedState::from_graph(warm.graph().clone()).unwrap();
+        assert_eq!(warm.projected(), cold.projected());
+        assert!(
+            warm.view()
+                .root()
+                .unwrap()
+                .child_blocks()
+                .last()
+                .unwrap()
+                .id()
+                .is_synthetic()
+        );
     }
 
     #[test]


### PR DESCRIPTION
- Root의 마지막 Paragraph가 PageBreak로 끝나면 projection이 synthetic empty Paragraph를 보완하도록 변경. command를 거치지 않는 CRDT op와 cold/localized projection에서도 같은 문서 형태를 보장
- localized root repair가 마지막 schema-known Paragraph와 마지막 child만 normalizer에 전달해 cold projection과 같은 규칙을 사용
- PageBreak slice 삽입에서 trailing Paragraph를 직접 생성하던 로직을 제거하고, projection이 만든 다음 Paragraph를 caret target으로 사용. 문단 중간의 authored suffix는 그대로 보존