### PR TITLE
앱 에디터 long press 이후 pan scroll 복구

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionGestures.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionGestures.kt
@@ -454,6 +454,7 @@ internal class EditorInteractionGestures(
     }
     val started = longPress.start(pointerId = pointerId, position = position, context = context)
     if (started) {
+      pan.cancel(context = context)
       tap.markTapDispatched()
       if (longPress.isWordSelection) {
         tap.clearTapHistory()

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
@@ -2489,6 +2489,69 @@ class EditorInteractionControllerTest {
     }
 
   @Test
+  fun `fresh pan can start after long press ends`() =
+    runTest(StandardTestDispatcher()) {
+      val editor = Editor(FakeFfiEditor(), this, StandardTestDispatcher(testScheduler))
+      editor.sync {}
+      val host = TestHost(this)
+      val controller =
+        EditorInteractionController(
+          editorProvider = { editor },
+          effects = host,
+          geometry = host,
+          uiStateProvider = { host.uiState },
+          platformProvider = { Platform.iOS },
+        )
+      val driver = TestPanGestureDriver(shouldCatchTouch = false)
+      controller.updateTapSlop(8f)
+      val start = Offset(10f, 20f)
+
+      controller.onPointerDown(
+        pointerId = 1L,
+        position = start,
+        positionInRoot = start,
+        nowMillis = 0L,
+        touchPanDriver = driver,
+      )
+      assertTrue(controller.onLongPressTimer(pointerId = 1L, position = start, nowMillis = 500L))
+      assertTrue(
+        controller.onPointerUp(
+          pointerId = 1L,
+          position = start,
+          positionInRoot = start,
+          nowMillis = 520L,
+        )
+      )
+
+      controller.onPointerDown(
+        pointerId = 2L,
+        position = start,
+        positionInRoot = start,
+        nowMillis = 600L,
+        touchPanDriver = driver,
+      )
+      assertFalse(
+        controller.onPointerMove(
+          pointerId = 2L,
+          position = start + Offset(4f, 0f),
+          positionInRoot = start + Offset(4f, 0f),
+          nowMillis = 610L,
+        )
+      )
+      assertTrue(
+        controller.onPointerMove(
+          pointerId = 2L,
+          position = start + Offset(12f, 0f),
+          positionInRoot = start + Offset(12f, 0f),
+          nowMillis = 620L,
+        )
+      )
+
+      assertEquals(EditorInteractionMode.Panning, controller.interactionMode)
+      assertEquals(listOf(Offset(4f, 0f)), driver.updates)
+    }
+
+  @Test
   fun `android long press uses engine cursor hit result for cursor mode admission`() =
     runTest(StandardTestDispatcher()) {
       val fake =


### PR DESCRIPTION
에디터에서 long press를 끝낸 뒤 다음 한 손가락 pan scroll이 시작되지 않는 문제 수정

- pointer down에서 준비한 pending pan이 long press가 시작된 뒤에도 남아 있던 문제 수정
    - 다음 pointer down에서 fresh pan 준비가 거부되던 원인이었음
- long press가 실제로 시작되면 함께 대기하던 pan을 취소하도록 변경
    - 다음 pointer sequence는 기존 `EditorPanGesture`의 fresh pan 경로를 그대로 사용
    - touch slop을 지나기 전에는 scroll하지 않고, slop을 지난 뒤 정상적으로 pan을 시작
- long press 종료 후 다음 fresh pan이 다시 시작되는 경로를 regression test로 보호