### PR TITLE
앱 에디터 pan scroll 관성 급감 수정

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorPanGesture.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorPanGesture.kt
@@ -7,6 +7,8 @@ import co.typie.editor.interaction.EditorGestureContext
 import co.typie.editor.interaction.EditorInteractionEvent
 import co.typie.editor.interaction.canApply
 
+private const val PointerMoveStoppedTimeoutMillis = 40L
+
 internal interface EditorPanGestureDriver {
   val shouldCatchTouch: Boolean
   val touchSlop: Float
@@ -97,10 +99,13 @@ internal class EditorPanGesture {
       if (delta != Offset.Zero) {
         current.driver.update(delta)
       }
-      velocityTracker.addPosition(nowMillis, position)
+      if (pressed) {
+        velocityTracker.addPosition(nowMillis, position)
+        current.lastVelocitySampleAtMillis = nowMillis
+      }
       current.lastPosition = position
       if (!pressed) {
-        finish(context = context)
+        finish(nowMillis = nowMillis, context = context)
       }
       return true
     }
@@ -126,12 +131,14 @@ internal class EditorPanGesture {
         return false
       }
       velocityTracker.addPosition(nowMillis, position)
+      current.lastVelocitySampleAtMillis = nowMillis
       current.driver.update(delta)
       current.lastPosition = position
       return true
     }
 
     velocityTracker.addPosition(nowMillis, position)
+    current.lastVelocitySampleAtMillis = nowMillis
     val fromStart = position - current.startPosition
     val distance = fromStart.getDistance()
     val touchSlop = current.driver.touchSlop.coerceAtLeast(0f)
@@ -184,6 +191,7 @@ internal class EditorPanGesture {
         pointerId = pointerId,
         startPosition = position,
         lastPosition = position,
+        lastVelocitySampleAtMillis = nowMillis,
         startKind = startKind,
         driver = driver,
       )
@@ -208,11 +216,16 @@ internal class EditorPanGesture {
     return true
   }
 
-  private fun finish(context: EditorGestureContext) {
+  private fun finish(nowMillis: Long, context: EditorGestureContext) {
     val current = session ?: return
     val maximum =
       current.driver.maximumFlingVelocity.takeIf { it.isFinite() && it > 0f } ?: Float.MAX_VALUE
-    val velocity = velocityTracker.calculateVelocity(Velocity(maximum, maximum))
+    val velocity =
+      if (nowMillis - current.lastVelocitySampleAtMillis > PointerMoveStoppedTimeoutMillis) {
+        Velocity.Zero
+      } else {
+        velocityTracker.calculateVelocity(Velocity(maximum, maximum))
+      }
     current.driver.end(velocity)
     context.applyModeEvent(EditorInteractionEvent.PanEnd)
     clear()
@@ -228,6 +241,7 @@ internal class EditorPanGesture {
     val pointerId: Long,
     val startPosition: Offset,
     var lastPosition: Offset,
+    var lastVelocitySampleAtMillis: Long,
     val startKind: StartKind,
     val driver: EditorPanGestureDriver,
     var driverStarted: Boolean = false,

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
@@ -1543,6 +1543,98 @@ class EditorInteractionControllerTest {
     }
 
   @Test
+  fun `pan release preserves velocity from recent movement`() =
+    runTest(StandardTestDispatcher()) {
+      val editor = Editor(FakeFfiEditor(), this, StandardTestDispatcher(testScheduler))
+      val host = TestHost(this)
+      val controller =
+        EditorInteractionController(
+          editorProvider = { editor },
+          effects = host,
+          geometry = host,
+          uiStateProvider = { host.uiState },
+        )
+      val driver = TestPanGestureDriver(shouldCatchTouch = false)
+      controller.updateTapSlop(8f)
+      val start = Offset(10f, 20f)
+
+      controller.onPointerDown(
+        pointerId = 1L,
+        position = start,
+        positionInRoot = start,
+        nowMillis = 0L,
+        touchPanDriver = driver,
+      )
+      controller.onPointerMove(
+        pointerId = 1L,
+        position = start + Offset(20f, 0f),
+        positionInRoot = start + Offset(20f, 0f),
+        nowMillis = 10L,
+      )
+      controller.onPointerMove(
+        pointerId = 1L,
+        position = start + Offset(40f, 0f),
+        positionInRoot = start + Offset(40f, 0f),
+        nowMillis = 20L,
+      )
+      controller.onPointerUp(
+        pointerId = 1L,
+        position = start + Offset(40f, 0f),
+        positionInRoot = start + Offset(40f, 0f),
+        nowMillis = 55L,
+      )
+
+      val velocity = driver.endVelocities.single()
+      assertTrue(velocity.x > 1_500f, "Expected recent pan velocity, got $velocity")
+      assertTrue(velocity.y in -0.01f..0.01f, "Expected horizontal pan velocity, got $velocity")
+    }
+
+  @Test
+  fun `pan release after pointer stops has no velocity`() =
+    runTest(StandardTestDispatcher()) {
+      val editor = Editor(FakeFfiEditor(), this, StandardTestDispatcher(testScheduler))
+      val host = TestHost(this)
+      val controller =
+        EditorInteractionController(
+          editorProvider = { editor },
+          effects = host,
+          geometry = host,
+          uiStateProvider = { host.uiState },
+        )
+      val driver = TestPanGestureDriver(shouldCatchTouch = false)
+      controller.updateTapSlop(8f)
+      val start = Offset(10f, 20f)
+
+      controller.onPointerDown(
+        pointerId = 1L,
+        position = start,
+        positionInRoot = start,
+        nowMillis = 0L,
+        touchPanDriver = driver,
+      )
+      controller.onPointerMove(
+        pointerId = 1L,
+        position = start + Offset(20f, 0f),
+        positionInRoot = start + Offset(20f, 0f),
+        nowMillis = 10L,
+      )
+      controller.onPointerMove(
+        pointerId = 1L,
+        position = start + Offset(40f, 0f),
+        positionInRoot = start + Offset(40f, 0f),
+        nowMillis = 20L,
+      )
+      controller.onPointerUp(
+        pointerId = 1L,
+        position = start + Offset(40f, 0f),
+        positionInRoot = start + Offset(40f, 0f),
+        nowMillis = 61L,
+      )
+
+      assertEquals(Velocity.Zero, driver.endVelocities.single())
+    }
+
+  @Test
   fun `editor pointer stream does not start long press from selection handle hit target`() =
     runTest(StandardTestDispatcher()) {
       val selection =
@@ -2966,6 +3058,7 @@ class EditorInteractionControllerTest {
     override val touchSlop: Float = 8f
     override val maximumFlingVelocity: Float = 10_000f
     var startCount = 0
+    val endVelocities = mutableListOf<Velocity>()
     val updates = mutableListOf<Offset>()
 
     override fun start(): Boolean {
@@ -2979,7 +3072,9 @@ class EditorInteractionControllerTest {
       updates += delta
     }
 
-    override fun end(velocity: Velocity) = Unit
+    override fun end(velocity: Velocity) {
+      endVelocities += velocity
+    }
 
     override fun cancel() = Unit
   }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/interaction/EditorInteractionsDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/interaction/EditorInteractionsDesktopTest.kt
@@ -425,11 +425,12 @@ class EditorInteractionsDesktopTest {
 
     onNodeWithTag(EditorTag).performTouchInput {
       moveTo(pointerId = 0, position = Offset(50f, 101f))
+      moveTo(pointerId = 0, position = Offset(50f, 102f))
     }
     waitForIdle()
 
     assertEquals(EditorInteractionMode.Panning, fixture.controller.interactionMode)
-    assertEquals(Offset(x = 0f, y = 1f), fixture.touchPanDeltas.single())
+    assertEquals(listOf(Offset(x = 0f, y = 1f), Offset(x = 0f, y = 1f)), fixture.touchPanDeltas)
     assertTrue(fixture.nestedScrollAvailable.isNotEmpty())
 
     onNodeWithTag(EditorTag).performTouchInput { up(pointerId = 0) }
@@ -551,6 +552,7 @@ class EditorInteractionsDesktopTest {
 
       onNodeWithTag(EditorTag).performTouchInput {
         down(pointerId = 0, position = Offset(100f, 100f))
+        moveTo(pointerId = 0, position = Offset(120f, 100f))
         moveTo(pointerId = 0, position = Offset(140f, 100f))
         up(pointerId = 0)
       }
@@ -657,6 +659,7 @@ class EditorInteractionsDesktopTest {
 
       onNodeWithTag(EditorTag).performTouchInput {
         down(pointerId = 0, position = Offset(100f, 100f))
+        moveTo(pointerId = 0, position = Offset(120f, 100f))
         moveTo(pointerId = 0, position = Offset(140f, 100f))
         up(pointerId = 0)
       }
@@ -714,6 +717,7 @@ class EditorInteractionsDesktopTest {
 
     onNodeWithTag(EditorTag).performTouchInput {
       down(pointerId = 0, position = Offset(100f, 100f))
+      moveTo(pointerId = 0, position = Offset(120f, 100f))
       moveTo(pointerId = 0, position = Offset(140f, 100f))
       up(pointerId = 0)
     }


### PR DESCRIPTION
에디터에서 pan scroll 후 손을 놓는 순간 fling velocity가 낮아져 관성 scroll이 바로 느려지거나 멈추는 문제 수정

- pointer up 좌표를 velocity sample로 추가하던 처리 제거
    - up 좌표는 마지막 move와 같은 정지 sample이라 최근 이동 속도를 낮추거나 반대 방향으로 왜곡할 수 있었음
    - Compose 기본 gesture처럼 pressed 상태의 pointer move만 velocity 계산에 사용
- 마지막 move와 release 사이 시간에 따라 fling 시작 속도를 결정
    - 40ms 이내에 release하면 최근 이동 속도를 유지
    - 40ms 넘게 새 move가 없으면 실제로 멈춘 것으로 보고 velocity를 0으로 처리
- fresh pan과 pinch 이후 resumed pan이 같은 규칙을 사용하도록 `EditorPanGesture` 안에서 처리
- 최근 이동 후 release와 정지 후 release를 regression test로 보호
- 기존 fling interruption 및 pinch → pan Compose test가 pointer up sample에 의존하지 않도록 실제 move frame 보강