### PR TITLE
앱 에디터 나가기 개선

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/document/document/DocumentScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/document/document/DocumentScreen.kt
@@ -332,11 +332,12 @@ fun DocumentScreen(entityId: String) {
         if (confirmation is DialogResult.Resolved) {
           val documentRoute = Route.Document(entityId)
           val editorRoute = Route.Editor(entityId)
-          val matchingEditorPresent = nav.current == documentRoute && nav.previous == editorRoute
+          val deletionRoute = nav.current.takeIf { it == documentRoute }
+          val matchingEditorPresent = deletionRoute != null && nav.previous == editorRoute
           if (!matchingEditorPresent) {
             val deleteResult = model.deleteDocument(document.id).withDefaultExceptionHandler(toast)
-            if (deleteResult.isOk) {
-              withContext(NonCancellable) { nav.pop() }
+            if (deleteResult.isOk && deletionRoute != null) {
+              withContext(NonCancellable) { if (nav.current === deletionRoute) nav.pop() }
             }
           } else {
             val preparation =

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/sync/SyncTestFakes.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/sync/SyncTestFakes.kt
@@ -14,16 +14,18 @@ internal fun createTestDocumentEditingSession(
   editor: Editor,
   scope: CoroutineScope,
   documentId: String = "doc",
+  syncEditor: FakeSyncEditor = FakeSyncEditor(),
+  store: DeltaStore = FakeDeltaStore(),
+  pushFn: suspend (ByteArray) -> PushResult = TestSyncTransport::push,
 ): DocumentEditingSession {
-  val syncEditor = FakeSyncEditor()
   val engine =
     SyncEngine(
       editor = syncEditor,
       documentId = documentId,
       initialServerHeads = enc(),
       initialDurableHeads = enc(),
-      store = FakeDeltaStore(),
-      pushFn = TestSyncTransport::push,
+      store = store,
+      pushFn = pushFn,
       scope = scope,
       now = { 0L },
     )

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/sync/DocumentEditingDurabilityIntegrationTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/sync/DocumentEditingDurabilityIntegrationTest.kt
@@ -1,0 +1,77 @@
+package co.typie.editor.sync
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import co.typie.editor.EditingCheckpointResult
+import co.typie.editor.Editor
+import co.typie.editor.FakeFfiEditor
+import co.typie.editor.ffi.EditorEvent
+import co.typie.editor.ffi.Message
+import co.typie.editor.ffi.StateField
+import co.typie.editor.ffi.SystemEvent
+import co.typie.sync.db.SyncDatabase
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+
+class DocumentEditingDurabilityIntegrationTest {
+  @Test
+  fun capturedEditIsPushedByOrphanSweeperAfterSessionStops() = runTest {
+    val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+    SyncDatabase.Schema.create(driver)
+    val store = SqlDeltaStore(SyncDatabase(driver))
+    val syncEditor = FakeSyncEditor()
+    val editor =
+      Editor(
+        FakeFfiEditor(
+          onTick = {
+            syncEditor.known.add(1)
+            listOf(EditorEvent.StateChanged(listOf(StateField.Doc)))
+          }
+        ),
+        this,
+        StandardTestDispatcher(testScheduler),
+      )
+    val session =
+      createTestDocumentEditingSession(
+        editor = editor,
+        scope = this,
+        syncEditor = syncEditor,
+        store = store,
+        pushFn = { throw IllegalStateException("offline") },
+      )
+    ActiveDocumentEditingSessions.register(session)
+    try {
+      val edit = session.submit { sessionEditor, context ->
+        async(context) { sessionEditor.await { enqueue(Message.System(SystemEvent.Initialize)) } }
+      }
+      assertNotNull(edit)
+
+      assertEquals(EditingCheckpointResult.Protected, session.beginClose().awaitCheckpoint())
+      assertEquals(listOf("1"), store.load("doc").map { it.id })
+      session.stop()
+      ActiveDocumentEditingSessions.unregister(session)
+
+      var pushedDocumentId: String? = null
+      var pushedChangesets: ByteArray? = null
+      OrphanSweeper(
+          store = store,
+          pushFn = { documentId, changesets ->
+            pushedDocumentId = documentId
+            pushedChangesets = changesets
+          },
+          openDocumentIds = { ActiveDocumentEditingSessions.openDocumentIds() },
+        )
+        .sweep()
+
+      assertEquals("doc", pushedDocumentId)
+      assertContentEquals(enc(1), pushedChangesets)
+    } finally {
+      session.stop()
+      ActiveDocumentEditingSessions.unregister(session)
+    }
+  }
+}


### PR DESCRIPTION
- 삭제를 시작한 정확한 Document route가 여전히 현재 화면일 때만 삭제 성공 후 pop
- 통합 테스트 추가