### PR TITLE
전체 선택 범위를 문서 양끝 위치로 정규화

### DIFF
--- a/crates/editor-clipboard/src/slice.rs
+++ b/crates/editor-clipboard/src/slice.rs
@@ -7,7 +7,7 @@ use editor_model::{
 };
 use editor_resource::Resource;
 use editor_state::State;
-use editor_state::{CellRect, ResolvedSelection};
+use editor_state::{CellRect, ResolvedSelection, document_content_selection};
 use serde::{Deserialize, Serialize};
 
 use crate::html::parse as html_parse;
@@ -34,8 +34,12 @@ impl Slice {
         if let Some(rect) = rs.as_cell_rect() {
             return Some(extract_cell_rect(state, &view, &rect));
         }
-        let common_id = common_ancestor(&view, &rs)?;
-        let common_nv = view.node(common_id)?;
+        let full_document = covers_document_content(&view, &rs);
+        let common_nv = if full_document {
+            view.root()?
+        } else {
+            view.node(common_ancestor(&view, &rs)?)?
+        };
         let common_depth = block_path_of(&common_nv).len();
 
         let from = rs.from();
@@ -49,19 +53,20 @@ impl Slice {
 
         let fragment = build_fragment(state, &common_nv, &rs);
 
-        if can_use_as_slice_roots(&fragment.children) {
-            Some(Slice::new(
+        let mut slice = if can_use_as_slice_roots(&fragment.children) {
+            Slice::new(
                 fragment.children,
                 open_start.saturating_sub(1),
                 open_end.saturating_sub(1),
-            ))
+            )
         } else {
-            Some(Slice::new(
-                vec![fragment],
-                open_start.max(1),
-                open_end.max(1),
-            ))
+            Slice::new(vec![fragment], open_start.max(1), open_end.max(1))
+        };
+        if full_document {
+            clear_open_edge_carry(&mut slice.content, slice.open_start, true);
+            clear_open_edge_carry(&mut slice.content, slice.open_end, false);
         }
+        Some(slice)
     }
 
     pub fn to_text(&self) -> String {
@@ -113,6 +118,32 @@ impl Slice {
             text: self.to_text(),
         }
     }
+}
+
+fn covers_document_content(view: &DocView, selection: &ResolvedSelection) -> bool {
+    let Some(document) =
+        document_content_selection(view).and_then(|selection| selection.resolve(view))
+    else {
+        return false;
+    };
+    selection.from().path() == document.from().path()
+        && selection.to().path() == document.to().path()
+}
+
+fn clear_open_edge_carry(content: &mut [Fragment], depth: u32, start: bool) {
+    if depth == 0 {
+        return;
+    }
+    let fragment = if start {
+        content.first_mut()
+    } else {
+        content.last_mut()
+    };
+    let Some(fragment) = fragment else {
+        return;
+    };
+    fragment.carry.clear();
+    clear_open_edge_carry(&mut fragment.children, depth - 1, start);
 }
 
 fn can_use_as_slice_roots(fragments: &[Fragment]) -> bool {
@@ -333,7 +364,7 @@ mod tests {
     use editor_macros::state;
     use editor_model::{AtomLeaf, CalloutVariant, Modifier, NodeType};
     use editor_resource::Resource;
-    use editor_state::{Position, Selection};
+    use editor_state::{Affinity, Position, Selection};
 
     fn cell_rect_sel(state: &State, anchor_cell: Dot, head_cell: Dot) -> editor_state::Selection {
         use editor_state::{Position, Selection};
@@ -415,7 +446,7 @@ mod tests {
     }
 
     #[test]
-    fn extract_all_inline_content_drops_source_block_context() {
+    fn extract_full_document_paragraph_preserves_block_context() {
         let (state, ..) = state! {
             doc { root {
                 p1: paragraph [alignment(editor_model::Alignment::Center)] carry([bold]) {
@@ -427,8 +458,37 @@ mod tests {
 
         let slice = Slice::extract(&state).expect("non-collapsed");
 
-        assert_eq!(slice.open_start, 0);
-        assert_eq!(slice.open_end, 0);
+        assert_eq!(slice.open_start, 1);
+        assert_eq!(slice.open_end, 1);
+        assert_eq!(slice.content.len(), 1);
+        let paragraph = &slice.content[0];
+        assert!(matches!(paragraph.node, PlainNode::Paragraph(_)));
+        assert_eq!(paragraph.children.len(), 1);
+        assert!(matches!(paragraph.children[0].node, PlainNode::Text(_)));
+        assert!(paragraph.carry.is_empty());
+        assert!(
+            paragraph
+                .modifiers
+                .iter()
+                .any(|modifier| matches!(modifier, Modifier::Alignment { .. }))
+        );
+    }
+
+    #[test]
+    fn extract_complete_paragraph_in_larger_document_remains_bare_inline() {
+        let (state, ..) = state! {
+            doc { root {
+                p1: paragraph [alignment(editor_model::Alignment::Center)] carry([bold]) {
+                    text("Hello")
+                }
+                paragraph { text("after") }
+            } }
+            selection: (p1, 0) -> (p1, 5)
+        };
+
+        let slice = Slice::extract(&state).expect("non-collapsed");
+
+        assert_eq!((slice.open_start, slice.open_end), (0, 0));
         assert_eq!(slice.content.len(), 1);
         assert!(matches!(slice.content[0].node, PlainNode::Text(_)));
         assert!(slice.content[0].carry.is_empty());
@@ -438,6 +498,53 @@ mod tests {
                 .iter()
                 .all(|modifier| !matches!(modifier, Modifier::Alignment { .. }))
         );
+    }
+
+    #[test]
+    fn extract_full_document_is_direction_and_affinity_independent() {
+        let (state, first, last) = state! {
+            doc { root {
+                first: paragraph { text("first") }
+                last: paragraph { text("last") }
+            } }
+            selection: (first, 0, >) -> (last, 4, <)
+        };
+        let forward = Slice::extract(&state).expect("forward selection");
+        let backward_state = State {
+            selection: Some(Selection::new(
+                Position {
+                    node: last,
+                    offset: 4,
+                    affinity: Affinity::Downstream,
+                },
+                Position {
+                    node: first,
+                    offset: 0,
+                    affinity: Affinity::Upstream,
+                },
+            )),
+            ..state
+        };
+
+        let backward = Slice::extract(&backward_state).expect("backward selection");
+
+        assert_eq!(backward, forward);
+        assert_eq!((forward.open_start, forward.open_end), (1, 1));
+    }
+
+    #[test]
+    fn extract_full_document_with_leading_unit_keeps_open_trailing_paragraph() {
+        let (state, _root, _trailing) = state! {
+            doc { _root: root { image _trailing: paragraph { text("after") } } }
+            selection: (_root, 0, >) -> (_trailing, 5, <)
+        };
+
+        let slice = Slice::extract(&state).expect("non-collapsed");
+
+        assert_eq!((slice.open_start, slice.open_end), (0, 1));
+        assert_eq!(slice.content.len(), 2);
+        assert!(matches!(slice.content[0].node, PlainNode::Image(_)));
+        assert!(matches!(slice.content[1].node, PlainNode::Paragraph(_)));
     }
 
     #[test]
@@ -869,8 +976,11 @@ mod tests {
             Position::new(para, 3),
         )));
         let slice = Slice::extract(&s).expect("non-collapsed");
-        let tab_frag = slice
-            .content
+        assert_eq!((slice.open_start, slice.open_end), (1, 1));
+        let paragraph = slice.content.first().expect("paragraph wrapper");
+        assert!(matches!(paragraph.node, PlainNode::Paragraph(_)));
+        let tab_frag = paragraph
+            .children
             .iter()
             .find(|c| matches!(c.node, PlainNode::Tab(_)))
             .expect("Tab must appear in extracted slice");

--- a/crates/editor-commands/src/commands/insert_slice.rs
+++ b/crates/editor-commands/src/commands/insert_slice.rs
@@ -206,6 +206,7 @@ mod tests {
                 source: paragraph [alignment(Alignment::Right)] carry([italic]) {
                     text("XY") [bold]
                 }
+                paragraph { text("after") }
             } }
             selection: (source, 0) -> (source, 2)
         };

--- a/crates/editor-commands/src/commands/select_all.rs
+++ b/crates/editor-commands/src/commands/select_all.rs
@@ -1,39 +1,30 @@
-use editor_state::{Affinity, Position, Selection};
+use editor_state::document_content_selection;
 use editor_transaction::Transaction;
 
 use crate::CommandResult;
 
 pub fn select_all(tr: &mut Transaction) -> CommandResult {
-    let (root_id, children_count) = {
+    let selection = {
         let view = tr.view();
-        let root = view.root().expect("root must exist");
-        (root.id(), root.children().count())
+        document_content_selection(&view)
+            .and_then(|selection| selection.normalize(&view))
+            .expect("root must have a canonical document selection")
     };
 
-    if children_count == 0 {
-        tr.set_selection(Some(Selection::collapsed(Position::new(root_id, 0))))?;
-    } else {
-        tr.set_selection(Some(Selection::new(
-            Position {
-                node: root_id,
-                offset: 0,
-                affinity: Affinity::Downstream,
-            },
-            Position {
-                node: root_id,
-                offset: children_count,
-                affinity: Affinity::Upstream,
-            },
-        )))?;
+    if tr.selection() == Some(selection) {
+        return Ok(false);
     }
 
+    tr.set_selection(Some(selection))?;
     Ok(true)
 }
 
 #[cfg(test)]
 mod tests {
+    use editor_crdt::Dot;
     use editor_macros::state;
-    use editor_state::{Affinity, Position};
+    use editor_model::ChildView;
+    use editor_state::{Affinity, Position, Selection, State};
 
     use super::*;
     use crate::test_utils::*;
@@ -52,9 +43,9 @@ mod tests {
 
     #[test]
     fn select_all_single_paragraph() {
-        let (state, r) = state! {
-            doc { r: root { paragraph { text("hello") } } }
-            selection: (r, 0)
+        let (state, paragraph) = state! {
+            doc { root { paragraph: paragraph { text("hello") } } }
+            selection: (paragraph, 2)
         };
 
         let (actual, ..) = transact!(state, |tr| select_all(&mut tr));
@@ -62,10 +53,10 @@ mod tests {
         assert_eq!(
             actual.selection,
             Some(Selection::new(
-                Position::new(r, 0),
+                Position::new(paragraph, 0),
                 Position {
-                    node: r,
-                    offset: 1,
+                    node: paragraph,
+                    offset: 5,
                     affinity: Affinity::Upstream,
                 },
             ))
@@ -74,59 +65,39 @@ mod tests {
 
     #[test]
     fn select_all_multiple_paragraphs() {
-        let (state, r) = state! {
+        let (state, first, last) = state! {
             doc {
-                r: root {
-                    paragraph { text("hello") }
+                root {
+                    first: paragraph { text("hello") }
                     paragraph { text("world") }
-                    paragraph { text("!") }
+                    last: paragraph { text("!") }
                 }
             }
-            selection: (r, 0)
+            selection: (first, 0)
         };
 
         let (actual, ..) = transact!(state, |tr| select_all(&mut tr));
 
         let sel = actual.selection.unwrap();
-        assert_eq!(sel.anchor, Position::new(r, 0));
+        assert_eq!(sel.anchor, Position::new(first, 0));
         assert_eq!(
             sel.head,
             Position {
-                node: r,
-                offset: 3,
+                node: last,
+                offset: 1,
                 affinity: Affinity::Upstream,
             },
         );
     }
 
     #[test]
-    fn select_all_images_only() {
-        // Root content requires a trailing Paragraph, so projection appends a
-        // derived paragraph after the three images → 4 children total.
-        let (state, r) = state! {
-            doc { r: root { image image image } }
-            selection: (r, 0)
-        };
-
-        let (actual, ..) = transact!(state, |tr| select_all(&mut tr));
-
-        let sel = actual.selection.unwrap();
-        assert_eq!(sel.anchor, Position::new(r, 0));
-        assert_eq!(
-            sel.head,
-            Position {
-                node: r,
-                offset: 4,
-                affinity: Affinity::Upstream,
-            },
-        );
-    }
-
-    #[test]
-    fn select_all_empty_paragraph() {
-        let (state, r) = state! {
-            doc { r: root { paragraph {} } }
-            selection: (r, 0)
+    fn select_all_descends_through_list_edges() {
+        let (state, first, trailing) = state! {
+            doc { root {
+                bullet_list { list_item { first: paragraph { text("first") } } }
+                trailing: paragraph {}
+            } }
+            selection: (trailing, 0)
         };
 
         let (actual, ..) = transact!(state, |tr| select_all(&mut tr));
@@ -134,13 +105,150 @@ mod tests {
         assert_eq!(
             actual.selection,
             Some(Selection::new(
-                Position::new(r, 0),
+                Position::new(first, 0),
                 Position {
-                    node: r,
-                    offset: 1,
+                    node: trailing,
+                    offset: 0,
                     affinity: Affinity::Upstream,
                 },
             ))
         );
+    }
+
+    #[test]
+    fn select_all_uses_derived_trailing_paragraph_cursor() {
+        let (state, root) = state! {
+            doc { root: root { image image image } }
+            selection: (root, 0)
+        };
+
+        let (actual, ..) = transact!(state, |tr| select_all(&mut tr));
+        let trailing = {
+            let view = actual.view();
+            let root = view.node(root).expect("root");
+            assert_eq!(root.children().count(), 4);
+            let Some(ChildView::Block(trailing)) = root.last_child() else {
+                panic!("projection must append a trailing paragraph");
+            };
+            trailing.id()
+        };
+
+        assert_eq!(
+            actual.selection,
+            Some(Selection::new(
+                Position::new(root, 0),
+                Position {
+                    node: trailing,
+                    offset: 0,
+                    affinity: Affinity::Upstream,
+                },
+            ))
+        );
+    }
+
+    fn assert_leading_unit_selection(state: State, root: Dot, trailing: Dot) {
+        let (actual, ..) = transact!(state, |tr| select_all(&mut tr));
+        assert_eq!(
+            actual.selection,
+            Some(Selection::new(
+                Position::new(root, 0),
+                Position {
+                    node: trailing,
+                    offset: 0,
+                    affinity: Affinity::Upstream,
+                },
+            ))
+        );
+    }
+
+    #[test]
+    fn select_all_uses_parent_boundary_for_leading_units() {
+        let (image_state, image_root, image_trailing) = state! {
+            doc { image_root: root { image image_trailing: paragraph {} } }
+            selection: (image_trailing, 0)
+        };
+        assert_leading_unit_selection(image_state, image_root, image_trailing);
+
+        let (blockquote_state, blockquote_root, blockquote_trailing) = state! {
+            doc { blockquote_root: root {
+                blockquote { paragraph { text("quote") } }
+                blockquote_trailing: paragraph {}
+            } }
+            selection: (blockquote_trailing, 0)
+        };
+        assert_leading_unit_selection(blockquote_state, blockquote_root, blockquote_trailing);
+
+        let (callout_state, callout_root, callout_trailing) = state! {
+            doc { callout_root: root {
+                callout { paragraph { text("callout") } }
+                callout_trailing: paragraph {}
+            } }
+            selection: (callout_trailing, 0)
+        };
+        assert_leading_unit_selection(callout_state, callout_root, callout_trailing);
+
+        let (fold_state, fold_root, fold_trailing) = state! {
+            doc { fold_root: root {
+                fold {
+                    fold_title { text("title") }
+                    fold_content { paragraph { text("content") } }
+                }
+                fold_trailing: paragraph {}
+            } }
+            selection: (fold_trailing, 0)
+        };
+        assert_leading_unit_selection(fold_state, fold_root, fold_trailing);
+
+        let (table_state, table_root, table_trailing) = state! {
+            doc { table_root: root {
+                table { table_row { table_cell { paragraph { text("cell") } } } }
+                table_trailing: paragraph {}
+            } }
+            selection: (table_trailing, 0)
+        };
+        assert_leading_unit_selection(table_state, table_root, table_trailing);
+    }
+
+    #[test]
+    fn select_all_empty_paragraph() {
+        let (state, paragraph) = state! {
+            doc { root { paragraph: paragraph {} } }
+            selection: (paragraph, 0)
+        };
+
+        let (actual, ..) = transact!(state, |tr| select_all(&mut tr));
+
+        assert_eq!(
+            actual.selection,
+            Some(Selection::collapsed(Position {
+                node: paragraph,
+                offset: 0,
+                affinity: Affinity::Upstream,
+            }))
+        );
+    }
+
+    #[test]
+    fn select_all_is_idempotent_for_canonical_selection() {
+        let (state, paragraph) = state! {
+            doc { root { paragraph: paragraph { text("hello") } } }
+            selection: (paragraph, 0)
+        };
+        let state = State {
+            selection: Some(Selection::new(
+                Position::new(paragraph, 0),
+                Position {
+                    node: paragraph,
+                    offset: 5,
+                    affinity: Affinity::Upstream,
+                },
+            )),
+            ..state
+        };
+        let mut tr = Transaction::new(&state);
+
+        assert!(!select_all(&mut tr).expect("select all succeeds"));
+        assert!(!tr.selection_changed());
+        assert_eq!(tr.selection(), state.selection);
     }
 }

--- a/crates/editor-core/src/editor.rs
+++ b/crates/editor-core/src/editor.rs
@@ -4773,14 +4773,89 @@ mod tests {
     #[test]
     fn fold_unit_selection_starts_internal_dnd() {
         let (mut editor, _, _) = fold_editor_with_unit_selection();
+        let expected = editor.state().selection.expect("fold unit selection");
+
+        let actual = start_internal_dnd_source(&mut editor);
+
+        assert_eq!(actual, expected);
+    }
+
+    fn start_internal_dnd_source(editor: &mut Editor) -> Selection {
         editor.apply(Message::Dnd {
             op: DndOp::StartInternalSelection,
         });
-        assert!(
-            matches!(editor.dnd, DndState::InternalDnd { .. }),
-            "fold unit selection must produce InternalDnd state, got {:?}",
-            editor.dnd
-        );
+        let DndState::InternalDnd { source, .. } = &editor.dnd else {
+            panic!("expected InternalDnd, got {:?}", editor.dnd);
+        };
+        let view = editor.state().view();
+        let ctx = StableResolveCtx::from_live(&view, editor.state().projected.seq_checkout());
+        source.resolve(&ctx).expect("source restores")
+    }
+
+    #[test]
+    fn internal_dnd_preserves_full_document_source_beginning_with_fold() {
+        let (initial, _root, _trailing) = state! {
+            doc { _root: root {
+                fold {
+                    fold_title { text("title") }
+                    fold_content { paragraph { text("content") } }
+                }
+                _trailing: paragraph { text("after") }
+            } }
+            selection: (_root, 0, >) -> (_trailing, 5, <)
+        };
+        let expected = initial.selection.expect("full-document selection");
+        let mut editor = Editor::new_test(initial);
+
+        let actual = start_internal_dnd_source(&mut editor);
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn internal_dnd_preserves_full_document_source_beginning_with_table() {
+        let (initial, _root, _trailing) = state! {
+            doc { _root: root {
+                table { table_row { table_cell { paragraph { text("cell") } } } }
+                _trailing: paragraph { text("after") }
+            } }
+            selection: (_root, 0, >) -> (_trailing, 5, <)
+        };
+        let expected = initial.selection.expect("full-document selection");
+        let mut editor = Editor::new_test(initial);
+
+        let actual = start_internal_dnd_source(&mut editor);
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn internal_dnd_preserves_cross_isolating_normalized_source() {
+        let (mut initial, _title, _outside) = state! {
+            doc { root {
+                fold {
+                    _title: fold_title { text("title") }
+                    fold_content { paragraph { text("content") } }
+                }
+                _outside: paragraph { text("outside") }
+                paragraph { text("trailing") }
+            } }
+            selection: (_title, 2) -> (_outside, 3)
+        };
+        let normalized = {
+            let view = initial.view();
+            initial
+                .selection
+                .expect("selection")
+                .normalize(&view)
+                .expect("selection normalizes")
+        };
+        initial.selection = Some(normalized);
+        let mut editor = Editor::new_test(initial);
+
+        let actual = start_internal_dnd_source(&mut editor);
+
+        assert_eq!(actual, normalized);
     }
 
     // drop_internal_selection 단계별 디버그: 어느 단계에서 실패하는지 확인

--- a/crates/editor-core/src/handle/dnd.rs
+++ b/crates/editor-core/src/handle/dnd.rs
@@ -4,7 +4,7 @@ use crate::error::EditorError;
 use crate::message::{DndDropPayload, DndOp, ExternalDndPayloadKind, InputModifiers};
 use editor_clipboard::Slice;
 use editor_commands::{self as commands};
-use editor_model::{ChildView, DocView, Fragment, Node, PlainFileNode, PlainImageNode, PlainNode};
+use editor_model::{DocView, Fragment, Node, PlainFileNode, PlainImageNode, PlainNode};
 use editor_state::{Position, Selection, StableResolveCtx, StableSelection, State};
 use editor_view::DropTarget;
 
@@ -24,10 +24,8 @@ pub fn handle_dnd_op(editor: &mut Editor, op: DndOp) -> Result<(), EditorError> 
                 .selection
                 .as_ref()
                 .filter(|selection| !selection.is_collapsed())
-                .map(|selection| snap_to_block_unit(&view, selection))
-                .filter(|selection| !selection.is_collapsed())
                 .map_or(DndState::Idle, |source| DndState::InternalDnd {
-                    source: StableSelection::capture(&source, &view),
+                    source: StableSelection::capture(source, &view),
                     drop_target: None,
                 });
             Ok(())
@@ -205,27 +203,6 @@ fn position_inside_selection(view: &DocView, position: Position, selection: &Sel
         return false;
     };
     *resolved_selection.from() < resolved_position && resolved_position < *resolved_selection.to()
-}
-
-/// anchor가 isolating+monolithic 블록(fold/table)의 parent 경계에 있으면
-/// 해당 블록의 단위 선택으로 스냅한다. promote_cross_isolating이 만드는
-/// (parent, fold_idx)→(external_pos) 선택을 DnD 소스로 정제하기 위해 사용.
-fn snap_to_block_unit(view: &DocView, selection: &Selection) -> Selection {
-    let anchor = selection.anchor;
-    if let Some(node) = view.node(anchor.node) {
-        let spec = node.spec();
-        if !spec.is_textblock()
-            && !spec.inline
-            && let Some(ChildView::Block(child)) = node.children().nth(anchor.offset)
-        {
-            let child_spec = child.spec();
-            if child_spec.isolating && child_spec.monolithic {
-                let unit_end = Position::new(anchor.node, anchor.offset + 1);
-                return Selection::new(anchor, unit_end);
-            }
-        }
-    }
-    *selection
 }
 
 fn can_apply_drop(

--- a/crates/editor-core/src/handle/selection.rs
+++ b/crates/editor-core/src/handle/selection.rs
@@ -1605,7 +1605,7 @@ mod tests {
 
     #[test]
     fn expand_all_selects_document_range() {
-        let (state, ..) = state! {
+        let (state, p1, p2) = state! {
             doc { root { p1: paragraph { text("hello") } p2: paragraph { text("world") } } }
             selection: (p1, 1) -> (p1, 3)
         };
@@ -1619,8 +1619,17 @@ mod tests {
         });
 
         let sel = editor.state().selection.expect("selection exists in test");
-        assert_eq!(sel.anchor.offset, 0);
-        assert_eq!(sel.head.offset, 2);
+        assert_eq!(
+            sel,
+            Selection::new(
+                Position::new(p1, 0),
+                Position {
+                    node: p2,
+                    offset: 5,
+                    affinity: Affinity::Upstream,
+                },
+            )
+        );
         assert!(!editor.undo_history.can_undo());
     }
 

--- a/crates/editor-state/src/lib.rs
+++ b/crates/editor-state/src/lib.rs
@@ -81,6 +81,6 @@ pub use stable_selection::{StableSelection, remap_selection};
 pub use state::*;
 pub use to_plain::to_plain;
 pub use traversal::{
-    LeafGroup, blocks_in_range, first_cursor_position, last_cursor_position, leaf_groups_in_range,
-    leaf_spans_in_range, leaves_in_block_range,
+    LeafGroup, blocks_in_range, document_content_selection, first_cursor_position,
+    last_cursor_position, leaf_groups_in_range, leaf_spans_in_range, leaves_in_block_range,
 };

--- a/crates/editor-state/src/traversal.rs
+++ b/crates/editor-state/src/traversal.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use editor_crdt::Dot;
 use editor_model::{ChildView, DocView, Modifier, ModifierType, NodeType, NodeView, OwnModifier};
 
-use crate::{Position, selection::ResolvedSelection};
+use crate::{Affinity, Position, classify, selection::ResolvedSelection, selection::Selection};
 
 pub struct TextRun {
     pub host: Dot,
@@ -528,16 +528,54 @@ pub fn last_cursor_position(node: &NodeView) -> Option<Position> {
     }
 }
 
+pub fn document_content_selection(view: &DocView) -> Option<Selection> {
+    let root = view.root()?;
+    let Some(first) = root.first_child() else {
+        return Some(Selection::collapsed(Position::new(root.id(), 0)));
+    };
+    let last = root.last_child()?;
+    let child_count = root.child_count();
+
+    let start = if classify::child_is_unit(&first) {
+        Position::new(root.id(), 0)
+    } else {
+        match first {
+            ChildView::Block(block) => first_cursor_position(&block)?,
+            ChildView::Leaf(_) => Position::new(root.id(), 0),
+        }
+    };
+    let end = if classify::child_is_unit(&last) {
+        Position::new(root.id(), child_count)
+    } else {
+        match last {
+            ChildView::Block(block) => last_cursor_position(&block)?,
+            ChildView::Leaf(_) => Position::new(root.id(), child_count),
+        }
+    };
+
+    Some(Selection::new(
+        Position {
+            affinity: Affinity::Downstream,
+            ..start
+        },
+        Position {
+            affinity: Affinity::Upstream,
+            ..end
+        },
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use editor_crdt::{Dot, InputEvent, ListOp, build_oplog};
+    use editor_macros::state;
     use editor_model::{
         AliasLog, AtomLeaf, DocLogs, DocView, ModifierAttrLog, NodeAttrLog, NodeType, ProjectedDoc,
         SeqItem, SpanLog, project_document,
     };
 
-    use crate::{Position, selection::Selection};
+    use crate::{Affinity, Position, selection::Selection};
 
     fn leaves_in_range<'a>(rs: &ResolvedSelection<'a>) -> Vec<editor_model::LeafView<'a>> {
         let mut out = Vec::new();
@@ -1040,6 +1078,84 @@ mod tests {
 
         let last = last_cursor_position(&para_nv).unwrap();
         assert_eq!(last.offset, 0);
+    }
+
+    #[test]
+    fn document_content_selection_uses_inline_edges_for_paragraph() {
+        let (state, paragraph) = state! {
+            doc { root { paragraph: paragraph { text("hello") } } }
+            selection: none
+        };
+        let view = state.view();
+
+        assert_eq!(
+            document_content_selection(&view),
+            Some(Selection::new(
+                Position {
+                    node: paragraph,
+                    offset: 0,
+                    affinity: Affinity::Downstream,
+                },
+                Position {
+                    node: paragraph,
+                    offset: 5,
+                    affinity: Affinity::Upstream,
+                },
+            ))
+        );
+    }
+
+    #[test]
+    fn document_content_selection_descends_through_list_edges() {
+        let (state, first, trailing) = state! {
+            doc { root {
+                bullet_list { list_item { first: paragraph { text("first") } } }
+                trailing: paragraph {}
+            } }
+            selection: none
+        };
+        let view = state.view();
+
+        assert_eq!(
+            document_content_selection(&view),
+            Some(Selection::new(
+                Position {
+                    node: first,
+                    offset: 0,
+                    affinity: Affinity::Downstream,
+                },
+                Position {
+                    node: trailing,
+                    offset: 0,
+                    affinity: Affinity::Upstream,
+                },
+            ))
+        );
+    }
+
+    #[test]
+    fn document_content_selection_uses_parent_boundary_for_leading_unit() {
+        let (state, root, trailing) = state! {
+            doc { root: root { image trailing: paragraph {} } }
+            selection: none
+        };
+        let view = state.view();
+
+        assert_eq!(
+            document_content_selection(&view),
+            Some(Selection::new(
+                Position {
+                    node: root,
+                    offset: 0,
+                    affinity: Affinity::Downstream,
+                },
+                Position {
+                    node: trailing,
+                    offset: 0,
+                    affinity: Affinity::Upstream,
+                },
+            ))
+        );
     }
 
     // §4.9: proptest — invariants


### PR DESCRIPTION
전체 선택이 root 전체 범위 대신 문서 양끝 content에 맞는 selection position을 사용하도록 변경

- 문단과 리스트 양끝은 실제 cursor position까지 내려가고, 이미지·blockquote·callout·fold·table은 root child 전체를 포함하는 block boundary를 유지
- 이미 같은 전체 선택이면 selection step을 만들지 않도록 `select_all`을 멱등적으로 처리
- 전체 문서 Slice는 root context를 유지해 paragraph alignment 같은 block modifier를 복사하고 open edge의 carry는 제외
- internal DnD가 드래그 시작 시 선택 범위를 다시 해석하지 않고 현재 선택된 범위 그대로 source로 저장