### PR TITLE
앱 에디터 trackpad scroll과 back swipe 입력 분리

### DIFF
--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/platform/PlatformModule.android.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/platform/PlatformModule.android.kt
@@ -2,6 +2,7 @@ package co.typie.platform
 
 import android.annotation.SuppressLint
 import android.content.Context
+import androidx.compose.ui.input.pointer.PointerType
 import co.typie.editor.ffi.EditorHost
 import co.typie.editor.ffi.JnaEditorHost
 import co.typie.migration.AndroidLegacyMigrationPlatformSource
@@ -37,3 +38,5 @@ actual object PlatformModule {
   }
   actual val diskCache: DiskCache by lazy { diskCache() }
 }
+
+internal actual fun PointerType.isTouchDragPointer(): Boolean = this == PointerType.Touch

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractions.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractions.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.semantics.scrollByOffset
 import androidx.compose.ui.unit.IntSize
 import co.typie.editor.ffi.InputModifiers
 import co.typie.editor.viewport.normalizeEditorViewportWheelZoomDelta
+import co.typie.platform.isTouchDragPointer
 import kotlin.math.abs
 import kotlin.math.min
 import kotlinx.coroutines.Job
@@ -323,7 +324,7 @@ private class EditorInteractionsNode(
             tapEnabled = tapEnabled,
             inputModifiers = pointerEvent.inputModifiers(),
             positionInRoot = rootPosition,
-            touchPanDriver = if (change.type == PointerType.Touch) scrollDriver else null,
+            touchPanDriver = if (change.type.isTouchDragPointer()) scrollDriver else null,
           )
         ) {
           change.consume()
@@ -420,6 +421,11 @@ private class EditorInteractionsNode(
   private fun handlePointerSignal(pointerEvent: PointerEvent) {
     if (!enabled || density <= 0f) {
       finishWheelZoom()
+      return
+    }
+    if (pointers.isNotEmpty()) {
+      finishWheelZoom()
+      pointerEvent.changes.forEach(PointerInputChange::consume)
       return
     }
     val scrollDelta =

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorViewportScrollDriver.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorViewportScrollDriver.kt
@@ -65,7 +65,11 @@ internal class EditorViewportScrollDriver(
         state.scroll(MutatePriority.UserInput) {
           pan.precedingSelfFling?.job?.join()
           for (delta in pan.deltas) {
-            dispatchScroll(delta = delta, dispatcher = dispatcher)
+            dispatchScroll(
+              delta = delta,
+              dispatcher = dispatcher,
+              source = NestedScrollSource.UserInput,
+            )
           }
         }
       } finally {
@@ -136,7 +140,13 @@ internal class EditorViewportScrollDriver(
     }
     launch {
       state.scroll(MutatePriority.UserInput) {
-        dispatchScroll(delta = delta, dispatcher = dispatcher)
+        // Pointer signals are independent deltas without a drag/fling terminal. Do not let a
+        // nested parent claim them as a user drag that can never be released.
+        dispatchScroll(
+          delta = delta,
+          dispatcher = dispatcher,
+          source = NestedScrollSource.SideEffect,
+        )
       }
     }
     return true
@@ -149,7 +159,12 @@ internal class EditorViewportScrollDriver(
     state.scroll(MutatePriority.Default) {
       animate(Offset.VectorConverter, Offset.Zero, offset) { currentValue, _ ->
         val delta = currentValue - previousValue
-        val consumed = dispatchScroll(delta = delta, dispatcher = dispatcher)
+        val consumed =
+          dispatchScroll(
+            delta = delta,
+            dispatcher = dispatcher,
+            source = NestedScrollSource.SideEffect,
+          )
         previousValue += consumed
       }
     }
@@ -194,7 +209,7 @@ private class ActiveSelfFling {
 private fun Scroll2DScope.dispatchScroll(
   delta: Offset,
   dispatcher: NestedScrollDispatcher,
-  source: NestedScrollSource = NestedScrollSource.UserInput,
+  source: NestedScrollSource,
 ): Offset {
   val preConsumed = dispatcher.dispatchPreScroll(delta, source)
   val available = delta - preConsumed

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationPopGestureSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationPopGestureSession.kt
@@ -7,7 +7,7 @@ internal class NavigationPopGestureSession {
   private var state = State.Possible
   private var multiTouchRejected = false
   private var systemBackZoneRejected = false
-  private var pressedPointerCount = 0
+  private var pressedDragPointerCount = 0
 
   val isClaimed: Boolean
     get() = state == State.Claimed
@@ -17,6 +17,9 @@ internal class NavigationPopGestureSession {
 
   val isSystemBackZoneRejected: Boolean
     get() = systemBackZoneRejected
+
+  val hasPressedDragPointer: Boolean
+    get() = pressedDragPointerCount > 0
 
   fun tryClaim(initialDrag: Offset, childConsumed: Boolean): Boolean {
     if (multiTouchRejected || systemBackZoneRejected || state != State.Possible) {
@@ -34,10 +37,10 @@ internal class NavigationPopGestureSession {
     return isClaimed
   }
 
-  fun updatePressedPointerCount(count: Int, downInSystemBackZone: Boolean = false): Boolean {
+  fun updatePressedDragPointerCount(count: Int, downInSystemBackZone: Boolean = false): Boolean {
     val wasMultiTouchRejected = multiTouchRejected
-    val previousCount = pressedPointerCount
-    pressedPointerCount = count
+    val previousCount = pressedDragPointerCount
+    pressedDragPointerCount = count
     when {
       count > 1 -> {
         multiTouchRejected = true

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationPopNestedScroll.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationPopNestedScroll.kt
@@ -33,8 +33,8 @@ internal class NavigationPopNestedScroll : NestedScrollConnection {
     this.onCancel = onCancel
   }
 
-  fun updatePressedPointerCount(count: Int, downInSystemBackZone: Boolean = false) {
-    if (gestureSession.updatePressedPointerCount(count, downInSystemBackZone)) {
+  fun updatePressedDragPointerCount(count: Int, downInSystemBackZone: Boolean = false) {
+    if (gestureSession.updatePressedDragPointerCount(count, downInSystemBackZone)) {
       onCancel()
     }
   }
@@ -71,7 +71,12 @@ internal class NavigationPopNestedScroll : NestedScrollConnection {
     available: Offset,
     source: NestedScrollSource,
   ): Offset {
-    if (source != NestedScrollSource.UserInput || gestureSession.isClaimed || !canStart()) {
+    if (
+      source != NestedScrollSource.UserInput ||
+        !gestureSession.hasPressedDragPointer ||
+        gestureSession.isClaimed ||
+        !canStart()
+    ) {
       return Offset.Zero
     }
     if (

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationStack.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationStack.kt
@@ -41,6 +41,7 @@ import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import co.touchlab.kermit.Logger
 import co.typie.ext.pointerIgnore
 import co.typie.ext.thenIf
+import co.typie.platform.isTouchDragPointer
 import co.typie.route.Route
 import co.typie.route.RouteTransitionStyle
 import co.typie.route.keepAlive
@@ -523,12 +524,18 @@ fun NavigationStack(
           awaitPointerEventScope {
             while (true) {
               val event = awaitPointerEvent(PointerEventPass.Initial)
-              val pressedCount = event.changes.count { change -> change.pressed }
+              val pressedDragPointerCount =
+                event.changes.count { change -> change.type.isTouchDragPointer() && change.pressed }
               val down =
-                if (pressedCount == 1) event.changes.fastFirstOrNull { change -> change.pressed }
-                else null
-              popNestedScroll.updatePressedPointerCount(
-                count = pressedCount,
+                if (pressedDragPointerCount == 1) {
+                  event.changes.fastFirstOrNull { change ->
+                    change.type.isTouchDragPointer() && change.pressed
+                  }
+                } else {
+                  null
+                }
+              popNestedScroll.updatePressedDragPointerCount(
+                count = pressedDragPointerCount,
                 downInSystemBackZone = down != null && down.position.x < backGestureZoneWidth,
               )
             }
@@ -707,6 +714,9 @@ fun NavigationStack(
               val slop = viewConfiguration.touchSlop
               awaitEachGesture {
                 val down = awaitFirstDown(requireUnconsumed = false)
+                if (!down.type.isTouchDragPointer()) {
+                  return@awaitEachGesture
+                }
                 if (navigator.isTransitioning) return@awaitEachGesture
                 val popGestureSession = NavigationPopGestureSession()
                 if (animState != AnimState.Idle && animState != AnimState.Dragging)
@@ -843,6 +853,9 @@ fun NavigationStack(
             val slop = viewConfiguration.touchSlop
             awaitEachGesture {
               val down = awaitFirstDown(requireUnconsumed = false)
+              if (!down.type.isTouchDragPointer()) {
+                return@awaitEachGesture
+              }
               if (navigator.isTransitioning) return@awaitEachGesture
               val popGestureSession = NavigationPopGestureSession()
               var overSlopX = 0f

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/platform/PlatformModule.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/platform/PlatformModule.kt
@@ -1,5 +1,6 @@
 package co.typie.platform
 
+import androidx.compose.ui.input.pointer.PointerType
 import co.typie.editor.ffi.EditorHost
 import co.typie.migration.LegacyMigrationPlatformSource
 import co.typie.storage.DiskCache
@@ -25,3 +26,5 @@ expect object PlatformModule {
   val editorHost: EditorHost
   val diskCache: DiskCache
 }
+
+internal expect fun PointerType.isTouchDragPointer(): Boolean

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/navigation/NavigationPopGestureSessionTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/navigation/NavigationPopGestureSessionTest.kt
@@ -19,18 +19,18 @@ class NavigationPopGestureSessionTest {
   fun multiTouchRejectsClaimsUntilEveryPointerIsUp() {
     val session = NavigationPopGestureSession()
 
-    session.updatePressedPointerCount(1)
-    session.updatePressedPointerCount(2)
+    session.updatePressedDragPointerCount(1)
+    session.updatePressedDragPointerCount(2)
     assertFalse(session.tryClaim(initialDrag = Offset(x = 10f, y = 0f), childConsumed = false))
 
     session.reset()
-    session.updatePressedPointerCount(1)
+    session.updatePressedDragPointerCount(1)
     assertFalse(session.tryClaim(initialDrag = Offset(x = 10f, y = 0f), childConsumed = false))
 
-    session.updatePressedPointerCount(0)
+    session.updatePressedDragPointerCount(0)
     assertFalse(session.tryClaim(initialDrag = Offset(x = 10f, y = 0f), childConsumed = false))
 
-    session.updatePressedPointerCount(1)
+    session.updatePressedDragPointerCount(1)
     assertTrue(session.tryClaim(initialDrag = Offset(x = 10f, y = 0f), childConsumed = false))
   }
 
@@ -38,10 +38,10 @@ class NavigationPopGestureSessionTest {
   fun multiTouchRejectsAnAlreadyClaimedSession() {
     val session = NavigationPopGestureSession()
 
-    session.updatePressedPointerCount(1)
+    session.updatePressedDragPointerCount(1)
     assertTrue(session.tryClaim(initialDrag = Offset(x = 10f, y = 0f), childConsumed = false))
 
-    assertTrue(session.updatePressedPointerCount(2))
+    assertTrue(session.updatePressedDragPointerCount(2))
     assertFalse(session.isClaimed)
   }
 
@@ -49,15 +49,15 @@ class NavigationPopGestureSessionTest {
   fun downInSystemBackZoneRejectsClaimsUntilNextGesture() {
     val session = NavigationPopGestureSession()
 
-    session.updatePressedPointerCount(1, downInSystemBackZone = true)
+    session.updatePressedDragPointerCount(1, downInSystemBackZone = true)
     assertTrue(session.isSystemBackZoneRejected)
     assertFalse(session.tryClaim(initialDrag = Offset(x = 10f, y = 0f), childConsumed = false))
 
     session.reset()
     assertFalse(session.tryClaim(initialDrag = Offset(x = 10f, y = 0f), childConsumed = false))
 
-    session.updatePressedPointerCount(0)
-    session.updatePressedPointerCount(1)
+    session.updatePressedDragPointerCount(0)
+    session.updatePressedDragPointerCount(1)
     assertFalse(session.isSystemBackZoneRejected)
     assertTrue(session.tryClaim(initialDrag = Offset(x = 10f, y = 0f), childConsumed = false))
   }
@@ -66,10 +66,10 @@ class NavigationPopGestureSessionTest {
   fun claimedSessionSurvivesAllUpUntilNestedScrollTerminal() {
     val session = NavigationPopGestureSession()
 
-    session.updatePressedPointerCount(1)
+    session.updatePressedDragPointerCount(1)
     assertTrue(session.tryClaim(initialDrag = Offset(x = 10f, y = 0f), childConsumed = false))
 
-    session.updatePressedPointerCount(0)
+    session.updatePressedDragPointerCount(0)
     assertTrue(session.isClaimed)
 
     session.reset()

--- a/apps/mobile/compose/src/desktopMain/kotlin/co/typie/platform/PlatformModule.desktop.kt
+++ b/apps/mobile/compose/src/desktopMain/kotlin/co/typie/platform/PlatformModule.desktop.kt
@@ -1,5 +1,6 @@
 package co.typie.platform
 
+import androidx.compose.ui.input.pointer.PointerType
 import co.typie.editor.ffi.EditorHost
 import co.typie.editor.ffi.JnaEditorHost
 import co.typie.migration.DesktopLegacyMigrationPlatformSource
@@ -29,3 +30,6 @@ actual object PlatformModule {
   }
   actual val diskCache: DiskCache = diskCache()
 }
+
+internal actual fun PointerType.isTouchDragPointer(): Boolean =
+  this == PointerType.Touch || this == PointerType.Mouse

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/interaction/EditorInteractionsDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/interaction/EditorInteractionsDesktopTest.kt
@@ -22,9 +22,13 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performMouseInput
 import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.performTrackpadInput
 import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
@@ -57,6 +61,222 @@ import kotlinx.coroutines.yield
 
 @OptIn(ExperimentalTestApi::class)
 class EditorInteractionsDesktopTest {
+  @Test
+  fun `desktop trackpad click drag scrolls the viewport like touch`() = runComposeUiTest {
+    val fixture = Fixture()
+    setEditorContent(fixture)
+
+    onNodeWithTag(EditorTag).performTrackpadInput {
+      moveTo(Offset(x = 100f, y = 100f))
+      press()
+      moveBy(Offset(x = 4f, y = 0f))
+      moveBy(Offset(x = 8f, y = 0f))
+      release()
+    }
+    waitForIdle()
+
+    assertTrue(fixture.touchPanDeltas.isNotEmpty())
+  }
+
+  @Test
+  fun `desktop trackpad click drag commits main editor back swipe`() = runComposeUiTest {
+    val fixture = Fixture(scrollConsumer = { Offset.Zero })
+    val navigator = Navigator(Route.Home)
+    setNavigationEditorContent(fixture = fixture, navigator = navigator)
+
+    onNodeWithTag(NavigationEditorTag).performTrackpadInput {
+      moveTo(Offset(x = 80f, y = center.y))
+      press()
+      repeat(18) { moveBy(Offset(x = 10f, y = 0f), delayMillis = 1L) }
+    }
+    waitUntil { onNodeWithTag(NavigationEditorTag).fetchSemanticsNode().boundsInRoot.left > 100f }
+    onNodeWithTag(NavigationEditorTag).performTrackpadInput { release() }
+
+    waitUntil { navigator.current == Route.Home && !navigator.isTransitioning }
+    onAllNodes(hasTestTag(NavigationEditorTag)).assertCountEquals(0)
+  }
+
+  @Test
+  fun `desktop trackpad click drag ignores overlapping scroll signals`() = runComposeUiTest {
+    val fixture = Fixture(scrollConsumer = { Offset.Zero })
+    val navigator = Navigator(Route.Home)
+    setNavigationEditorContent(fixture = fixture, navigator = navigator)
+
+    onNodeWithTag(NavigationEditorTag).performMouseInput {
+      moveTo(Offset(x = 80f, y = center.y))
+      press()
+    }
+    waitForIdle()
+    repeat(18) {
+      onNodeWithTag(NavigationEditorTag).performMouseInput {
+        moveBy(Offset(x = 10f, y = 0f), delayMillis = 1L)
+      }
+      waitForIdle()
+      onNodeWithTag(NavigationEditorTag).performMouseInput { scroll(Offset(x = -1f, y = 0f)) }
+      waitForIdle()
+    }
+    onNodeWithTag(NavigationEditorTag).performMouseInput { release() }
+    waitForIdle()
+
+    assertEquals(Route.Home, navigator.current)
+    onAllNodes(hasTestTag(NavigationEditorTag)).assertCountEquals(0)
+  }
+
+  @Test
+  fun `desktop trackpad click drag cancelled back swipe returns editor to origin`() =
+    runComposeUiTest {
+      val fixture = Fixture(scrollConsumer = { Offset.Zero })
+      val navigator = Navigator(Route.Home)
+      setNavigationEditorContent(fixture = fixture, navigator = navigator)
+
+      onNodeWithTag(NavigationEditorTag).performTrackpadInput {
+        moveTo(Offset(x = 80f, y = center.y))
+        press()
+        repeat(12) { moveBy(Offset(x = 5f, y = 0f), delayMillis = 1L) }
+      }
+      waitUntil { onNodeWithTag(NavigationEditorTag).fetchSemanticsNode().boundsInRoot.left > 0.5f }
+      onNodeWithTag(NavigationEditorTag).performTrackpadInput { release() }
+      waitForIdle()
+
+      assertEquals(NavigationEditorRoute, navigator.current)
+      assertEquals(
+        expected = 0f,
+        actual = onNodeWithTag(NavigationEditorTag).fetchSemanticsNode().boundsInRoot.left,
+        absoluteTolerance = 0.5f,
+      )
+    }
+
+  @Test
+  fun `rapid desktop trackpad release completes committed back swipe`() = runComposeUiTest {
+    val fixture = Fixture(scrollConsumer = { Offset.Zero })
+    val navigator = Navigator(Route.Home)
+    setNavigationEditorContent(fixture = fixture, navigator = navigator)
+
+    onNodeWithTag(NavigationEditorTag).performTrackpadInput {
+      moveTo(Offset(x = 80f, y = center.y))
+      press()
+      repeat(18) { moveBy(Offset(x = 10f, y = 0f), delayMillis = 1L) }
+      release()
+    }
+
+    waitUntil { navigator.current == Route.Home && !navigator.isTransitioning }
+    onAllNodes(hasTestTag(NavigationEditorTag)).assertCountEquals(0)
+  }
+
+  @Test
+  fun `rapid desktop trackpad release rolls cancelled back swipe to origin`() = runComposeUiTest {
+    val fixture = Fixture(scrollConsumer = { Offset.Zero })
+    val navigator = Navigator(Route.Home)
+    setNavigationEditorContent(fixture = fixture, navigator = navigator)
+
+    onNodeWithTag(NavigationEditorTag).performTrackpadInput {
+      moveTo(Offset(x = 80f, y = center.y))
+      press()
+      repeat(12) { moveBy(Offset(x = 5f, y = 0f), delayMillis = 1L) }
+      release()
+    }
+
+    waitUntil { onNodeWithTag(NavigationEditorTag).fetchSemanticsNode().boundsInRoot.left <= 0.5f }
+    assertEquals(NavigationEditorRoute, navigator.current)
+  }
+
+  @Test
+  fun `pointer signal scroll does not move navigation route`() = runComposeUiTest {
+    val fixture = Fixture(scrollConsumer = { Offset.Zero })
+    val navigator = Navigator(Route.Home)
+    setNavigationEditorContent(fixture = fixture, navigator = navigator)
+
+    onNodeWithTag(NavigationEditorTag).performMouseInput {
+      moveTo(Offset(x = 80f, y = center.y))
+      listOf(-18f, -9f, -4f, -2f, -1f).forEach { deltaX -> scroll(Offset(x = deltaX, y = 0f)) }
+    }
+    waitForIdle()
+
+    assertTrue(fixture.touchPanDeltas.any { delta -> delta.x > 0f })
+    assertEquals(NavigationEditorRoute, navigator.current)
+    assertEquals(
+      expected = 0f,
+      actual = onNodeWithTag(NavigationEditorTag).fetchSemanticsNode().boundsInRoot.left,
+      absoluteTolerance = 0.5f,
+    )
+  }
+
+  @Test
+  fun `pointer signal scroll does not interrupt a pressed pointer sequence`() = runComposeUiTest {
+    val fixture = Fixture(scrollConsumer = { Offset.Zero })
+    val navigator = Navigator(Route.Home)
+    setNavigationEditorContent(fixture = fixture, navigator = navigator)
+
+    onNodeWithTag(NavigationEditorTag).performMouseInput {
+      moveTo(Offset(x = 80f, y = center.y))
+      press()
+    }
+    waitForIdle()
+    listOf(-120f, -80f, -40f, -20f).forEach { deltaX ->
+      onNodeWithTag(NavigationEditorTag).performMouseInput { scroll(Offset(x = deltaX, y = 0f)) }
+      waitForIdle()
+    }
+    onNodeWithTag(NavigationEditorTag).performMouseInput { release() }
+    waitForIdle()
+
+    assertTrue(fixture.touchPanDeltas.isEmpty())
+    assertEquals(NavigationEditorRoute, navigator.current)
+    assertEquals(
+      expected = 0f,
+      actual = onNodeWithTag(NavigationEditorTag).fetchSemanticsNode().boundsInRoot.left,
+      absoluteTolerance = 0.5f,
+    )
+  }
+
+  @Test
+  fun `accessibility scroll does not move navigation route`() = runComposeUiTest {
+    val fixture = Fixture(scrollConsumer = { Offset.Zero })
+    val navigator = Navigator(Route.Home)
+    setNavigationEditorContent(fixture = fixture, navigator = navigator)
+
+    onNodeWithTag(NavigationEditorTag).performSemanticsAction(SemanticsActions.ScrollBy) { action ->
+      assertTrue(action(12f, 0f))
+    }
+    waitForIdle()
+
+    assertTrue(fixture.touchPanDeltas.any { delta -> delta.x > 0f })
+    assertEquals(NavigationEditorRoute, navigator.current)
+    assertEquals(
+      expected = 0f,
+      actual = onNodeWithTag(NavigationEditorTag).fetchSemanticsNode().boundsInRoot.left,
+      absoluteTolerance = 0.5f,
+    )
+  }
+
+  @Test
+  fun `accessibility scroll remains navigation inert while a pointer is pressed`() =
+    runComposeUiTest {
+      val fixture = Fixture(scrollConsumer = { Offset.Zero })
+      val navigator = Navigator(Route.Home)
+      setNavigationEditorContent(fixture = fixture, navigator = navigator)
+
+      onNodeWithTag(NavigationEditorTag).performMouseInput {
+        moveTo(Offset(x = 80f, y = center.y))
+        press()
+      }
+      waitForIdle()
+      onNodeWithTag(NavigationEditorTag).performSemanticsAction(SemanticsActions.ScrollBy) { action
+        ->
+        assertTrue(action(120f, 0f))
+      }
+      waitForIdle()
+      onNodeWithTag(NavigationEditorTag).performMouseInput { release() }
+      waitForIdle()
+
+      assertTrue(fixture.touchPanDeltas.any { delta -> delta.x > 0f })
+      assertEquals(NavigationEditorRoute, navigator.current)
+      assertEquals(
+        expected = 0f,
+        actual = onNodeWithTag(NavigationEditorTag).fetchSemanticsNode().boundsInRoot.left,
+        absoluteTolerance = 0.5f,
+      )
+    }
+
   @Test
   fun `interaction boundary preserves accessibility scroll by action`() = runComposeUiTest {
     val fixture = Fixture()

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/NavigationStackDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/NavigationStackDesktopTest.kt
@@ -12,8 +12,11 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.TouchInjectionScope
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.performTrackpadInput
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.dp
 import co.typie.route.Route
@@ -24,6 +27,11 @@ import kotlin.test.assertEquals
 
 @OptIn(ExperimentalTestApi::class)
 class NavigationStackDesktopTest {
+  @Test
+  fun mainAreaTrackpadClickDragPopsOnDesktop() = assertTrackpadClickDragPops(startAtEdge = false)
+
+  @Test fun edgeTrackpadClickDragPopsOnDesktop() = assertTrackpadClickDragPops(startAtEdge = true)
+
   @Test
   fun verticalScrollSessionDoesNotBecomeBackSwipeAfterTurningRight() =
     assertGestureDoesNotPop(
@@ -126,6 +134,38 @@ class NavigationStackDesktopTest {
     scrollConsumer: (Offset) -> Offset,
     gesture: TouchInjectionScope.() -> Unit,
   ) = assertGestureResult(scrollConsumer, shouldPop = false, gesture)
+
+  private fun assertTrackpadClickDragPops(startAtEdge: Boolean) = runComposeUiTest {
+    val navigator = Navigator(Route.Home)
+    val editorRoute = Route.Editor("document-id")
+
+    setContent {
+      NavigationStack(
+        navigator = navigator,
+        topBarState = remember { TopBarState() },
+        modifier = Modifier.size(width = 320.dp, height = 640.dp),
+      ) { route ->
+        Box(
+          Modifier.fillMaxSize().testTag(if (route == editorRoute) EditorRouteTag else HomeRouteTag)
+        )
+      }
+      LaunchedEffect(Unit) { navigator.navigate(editorRoute) }
+    }
+    waitUntil { navigator.current == editorRoute && !navigator.isTransitioning }
+
+    onNodeWithTag(EditorRouteTag).performTrackpadInput {
+      moveTo(if (startAtEdge) Offset(x = 10f, y = center.y) else center)
+      press()
+      moveBy(Offset(x = 220f, y = 0f))
+      moveBy(Offset(x = 1f, y = 0f))
+    }
+    waitUntil { onNodeWithTag(EditorRouteTag).fetchSemanticsNode().boundsInRoot.left > 100f }
+    onNodeWithTag(EditorRouteTag).performTrackpadInput { release() }
+    waitForIdle()
+
+    assertEquals(Route.Home, navigator.current)
+    onAllNodes(hasTestTag(EditorRouteTag)).assertCountEquals(0)
+  }
 
   private fun assertGesturePops(
     scrollConsumer: (Offset) -> Offset,

--- a/apps/mobile/compose/src/iosMain/kotlin/co/typie/platform/PlatformModule.ios.kt
+++ b/apps/mobile/compose/src/iosMain/kotlin/co/typie/platform/PlatformModule.ios.kt
@@ -2,6 +2,7 @@
 
 package co.typie.platform
 
+import androidx.compose.ui.input.pointer.PointerType
 import co.typie.editor.ffi.EditorHost
 import co.typie.editor.ffi.IosEditorHost
 import co.typie.migration.IOSLegacyMigrationPlatformSource
@@ -44,3 +45,5 @@ actual object PlatformModule {
   }
   actual val diskCache: DiskCache = diskCache()
 }
+
+internal actual fun PointerType.isTouchDragPointer(): Boolean = this == PointerType.Touch


### PR DESCRIPTION
에디터의 physical drag와 trackpad·wheel scroll이 같은 nested scroll 입력으로 처리되어, trackpad scroll이 back swipe로 오인되거나 실제 back swipe가 release 후 중간 위치에 멈출 수 있던 문제 수정

- navigation pop이 실제로 눌려 있는 drag pointer의 `UserInput`에만 반응하도록 변경
    - Android와 iOS에서는 touch drag만 인정
    - JVM Desktop에서는 touch와 mouse click-drag를 인정해 모바일 시뮬레이터처럼 pan과 main-area back swipe를 사용할 수 있도록 유지
- trackpad·wheel pointer signal과 accessibility scroll은 editor viewport만 움직이고 navigation pop에는 참여하지 않도록 분리
    - 오른쪽 방향 trackpad scroll이 back swipe를 반복해서 시도하지 않음
    - pointer signal scroll의 기존 editor pan·zoom 동작은 유지
- physical pointer sequence가 진행 중일 때 함께 들어오는 scroll frame이 현재 pan이나 back swipe를 취소하지 않도록 처리
    - Desktop main editor 영역의 click-drag back swipe가 시작 직후 되돌아가거나 release 위치에 멈추던 문제를 방지
- navigation pop은 admitted pointer가 실제로 눌려 있는 동안만 nested drag를 시작하도록 제한
    - release는 commit 또는 cancel terminal까지 완료
    - 기존 20dp edge swipe와 touch multi-pointer rejection 동작은 유지
- main-area back swipe commit/cancel, rapid release, move와 scroll frame이 섞인 입력, trackpad·wheel scroll, accessibility scroll을 Compose regression test로 보호