### PR TITLE
범위에 modifier 적용시 affinity 체크 안 하도록 함

### DIFF
--- a/crates/editor-commands/src/commands/set_modifier.rs
+++ b/crates/editor-commands/src/commands/set_modifier.rs
@@ -509,6 +509,36 @@ mod tests {
     }
 
     #[test]
+    fn range_set_alignment_ending_at_empty_paragraph_start_applies_to_both_paragraphs() {
+        use editor_model::Alignment;
+        let (initial, ..) = state! {
+            doc {
+                root {
+                    p1: paragraph { text("hello") }
+                    p2: paragraph {}
+                }
+            }
+            selection: (p1, 0, >) -> (p2, 0, <)
+        };
+        let (actual, ..) = transact!(initial, |tr| set_modifier(
+            &mut tr,
+            Modifier::Alignment {
+                value: Alignment::Center
+            }
+        ));
+        let (expected, ..) = state! {
+            doc {
+                root {
+                    p1: paragraph [alignment(Alignment::Center)] { text("hello") }
+                    p2: paragraph [alignment(Alignment::Center)] {}
+                }
+            }
+            selection: (p1, 0, >) -> (p2, 0, <)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
     fn range_set_font_size_across_two_paragraphs_at_block_level() {
         let (initial, ..) = state! {
             doc { r: root {

--- a/crates/editor-commands/src/helpers/modifiers.rs
+++ b/crates/editor-commands/src/helpers/modifiers.rs
@@ -119,7 +119,10 @@ pub(crate) fn collect_applicable_targets_in_range(
         ) else {
             continue;
         };
-        if !(start <= hi_r && lo_r <= end) {
+        // Coverage is positional: a normalized forward selection carries an
+        // Upstream head, so comparing ResolvedPositions would drop a block
+        // whose extent starts exactly at the selection end on affinity alone.
+        if !(start.path() <= hi_r.path() && lo_r.path() <= end.path()) {
             continue;
         }
         if targets.contains(&node.node_type()) {


### PR DESCRIPTION
빈 문단에서 끝나는 set_modifier 호출 등이 마지막 빈 문단에 적용되지 않는 문제 수정
