### PR TITLE
앱 에디터 trackpad/wheel zoom 지원

### DIFF
--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/interaction/EditorPlatformIndirectScale.android.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/interaction/EditorPlatformIndirectScale.android.kt
@@ -1,0 +1,14 @@
+package co.typie.editor.interaction
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
+import androidx.compose.ui.input.pointer.isCtrlPressed
+
+internal actual fun Modifier.editorPlatformIndirectScale(
+  bridge: EditorPlatformIndirectScaleBridge,
+  enabled: Boolean,
+  density: Float,
+): Modifier = this
+
+internal actual fun PointerKeyboardModifiers.isEditorIndirectZoomModifierPressed(): Boolean =
+  isCtrlPressed

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionController.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionController.kt
@@ -165,17 +165,20 @@ internal class EditorInteractionController(
     )
   }
 
-  fun beginPointerSignalZoom(): Boolean =
+  fun beginIndirectZoom(): Boolean =
     if (ensurePointerInputEnabled()) {
-      gestures.beginPointerSignalZoom(context = gestureContext)
+      gestures.beginIndirectZoom(context = gestureContext)
     } else {
       false
     }
 
-  fun updatePointerSignalZoom(focalInEditorPx: Offset, normalizedDelta: Float): Boolean =
+  fun cancelPendingPointerForIndirectInput(): Boolean =
+    gestures.cancelPendingPointerForIndirectInput(context = gestureContext)
+
+  fun updateIndirectScrollZoom(focalInRootPx: Offset, normalizedDelta: Float): Boolean =
     if (ensurePointerInputEnabled()) {
-      gestures.updatePointerSignalZoom(
-        focalInEditorPx = focalInEditorPx,
+      gestures.updateIndirectScrollZoom(
+        focalInRootPx = focalInRootPx,
         normalizedDelta = normalizedDelta,
         context = gestureContext,
       )
@@ -183,8 +186,19 @@ internal class EditorInteractionController(
       false
     }
 
-  fun endPointerSignalZoom() {
-    gestures.endPointerSignalZoom(context = gestureContext)
+  fun updateIndirectScaleZoom(focalInRootPx: Offset, scaleFactor: Float): Boolean =
+    if (ensurePointerInputEnabled()) {
+      gestures.updateIndirectScaleZoom(
+        focalInRootPx = focalInRootPx,
+        scaleFactor = scaleFactor,
+        context = gestureContext,
+      )
+    } else {
+      false
+    }
+
+  fun endIndirectZoom() {
+    gestures.endIndirectZoom(context = gestureContext)
   }
 
   fun onLongPressTimer(pointerId: Long, position: Offset, nowMillis: Long): Boolean =

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionGestures.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionGestures.kt
@@ -416,28 +416,49 @@ internal class EditorInteractionGestures(
     return true
   }
 
-  fun beginPointerSignalZoom(context: EditorGestureContext): Boolean {
+  fun beginIndirectZoom(context: EditorGestureContext): Boolean {
     if (!context.mode.canApply(EditorInteractionEvent.ViewportZoomStart)) {
       return false
     }
-    if (!context.semantics.viewportZoom.beginPointerSignal()) {
+    if (!context.semantics.viewportZoom.beginIndirect()) {
       return false
     }
     context.applyModeEvent(EditorInteractionEvent.ViewportZoomStart)
     return true
   }
 
-  fun updatePointerSignalZoom(
-    focalInEditorPx: Offset,
+  fun cancelPendingPointerForIndirectInput(context: EditorGestureContext): Boolean {
+    if (
+      context.mode != EditorInteractionMode.Idle ||
+        (!tap.hasActivePointer && !pan.hasPendingPointer)
+    ) {
+      return false
+    }
+    cancel(context = context)
+    return true
+  }
+
+  fun updateIndirectScrollZoom(
+    focalInRootPx: Offset,
     normalizedDelta: Float,
     context: EditorGestureContext,
   ): Boolean =
-    context.semantics.viewportZoom.updatePointerSignal(
-      focalInEditorPx = focalInEditorPx,
+    context.semantics.viewportZoom.updateIndirectScroll(
+      focalInRootPx = focalInRootPx,
       normalizedDelta = normalizedDelta,
     )
 
-  fun endPointerSignalZoom(context: EditorGestureContext) {
+  fun updateIndirectScaleZoom(
+    focalInRootPx: Offset,
+    scaleFactor: Float,
+    context: EditorGestureContext,
+  ): Boolean =
+    context.semantics.viewportZoom.updateIndirectScale(
+      focalInRootPx = focalInRootPx,
+      scaleFactor = scaleFactor,
+    )
+
+  fun endIndirectZoom(context: EditorGestureContext) {
     context.semantics.viewportZoom.end()
     context.applyModeEvent(EditorInteractionEvent.ViewportZoomEnd)
   }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractions.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractions.kt
@@ -25,6 +25,8 @@ import androidx.compose.ui.semantics.scrollByOffset
 import androidx.compose.ui.unit.IntSize
 import co.typie.editor.ffi.InputModifiers
 import co.typie.editor.viewport.normalizeEditorViewportWheelZoomDelta
+import co.typie.ext.ScrollGestureLockHandle
+import co.typie.ext.ScrollGestureLockState
 import co.typie.platform.isTouchDragPointer
 import kotlin.math.abs
 import kotlin.math.min
@@ -34,14 +36,13 @@ import kotlinx.coroutines.launch
 
 private const val EditorTapSlopDp = 8f
 private const val WheelBurstGapMs = 56L
-private const val WheelTailDeltaPx = 0.8f
-private const val WheelTailStreakToReset = 3
-private const val WheelModeSwitchMinDeltaPx = 1.5f
 
 internal fun Modifier.editorInteractions(
   interactionController: EditorInteractionController,
   geometry: EditorInteractionGeometry,
   screenPointerSequence: EditorScreenPointerSequence,
+  platformIndirectScaleBridge: EditorPlatformIndirectScaleBridge,
+  scrollGestureLockState: ScrollGestureLockState,
   scrollableState: Scrollable2DState? = null,
   nestedScrollDispatcher: NestedScrollDispatcher? = null,
   flingBehavior: FlingBehavior? = null,
@@ -49,7 +50,7 @@ internal fun Modifier.editorInteractions(
   maximumFlingVelocity: Float = Float.MAX_VALUE,
   density: Float,
   enabled: Boolean = true,
-  onViewportWheelScroll: () -> Unit = {},
+  onViewportIndirectInput: () -> Unit = {},
   onNestedScrollCancel: () -> Unit = {},
 ): Modifier =
   this then
@@ -57,6 +58,8 @@ internal fun Modifier.editorInteractions(
       interactionController = interactionController,
       geometry = geometry,
       screenPointerSequence = screenPointerSequence,
+      platformIndirectScaleBridge = platformIndirectScaleBridge,
+      scrollGestureLockState = scrollGestureLockState,
       scrollableState = scrollableState,
       nestedScrollDispatcher = nestedScrollDispatcher,
       flingBehavior = flingBehavior,
@@ -64,7 +67,7 @@ internal fun Modifier.editorInteractions(
       maximumFlingVelocity = maximumFlingVelocity,
       density = density,
       enabled = enabled,
-      onViewportWheelScroll = onViewportWheelScroll,
+      onViewportIndirectInput = onViewportIndirectInput,
       onNestedScrollCancel = onNestedScrollCancel,
     )
 
@@ -72,6 +75,8 @@ private data class EditorInteractionsElement(
   private val interactionController: EditorInteractionController,
   private val geometry: EditorInteractionGeometry,
   private val screenPointerSequence: EditorScreenPointerSequence,
+  private val platformIndirectScaleBridge: EditorPlatformIndirectScaleBridge,
+  private val scrollGestureLockState: ScrollGestureLockState,
   private val scrollableState: Scrollable2DState?,
   private val nestedScrollDispatcher: NestedScrollDispatcher?,
   private val flingBehavior: FlingBehavior?,
@@ -79,7 +84,7 @@ private data class EditorInteractionsElement(
   private val maximumFlingVelocity: Float,
   private val density: Float,
   private val enabled: Boolean,
-  private val onViewportWheelScroll: () -> Unit,
+  private val onViewportIndirectInput: () -> Unit,
   private val onNestedScrollCancel: () -> Unit,
 ) : ModifierNodeElement<EditorInteractionsNode>() {
   override fun create(): EditorInteractionsNode =
@@ -87,6 +92,8 @@ private data class EditorInteractionsElement(
       interactionController = interactionController,
       geometry = geometry,
       screenPointerSequence = screenPointerSequence,
+      platformIndirectScaleBridge = platformIndirectScaleBridge,
+      scrollGestureLockState = scrollGestureLockState,
       scrollableState = scrollableState,
       nestedScrollDispatcher = nestedScrollDispatcher,
       flingBehavior = flingBehavior,
@@ -94,7 +101,7 @@ private data class EditorInteractionsElement(
       maximumFlingVelocity = maximumFlingVelocity,
       density = density,
       enabled = enabled,
-      onViewportWheelScroll = onViewportWheelScroll,
+      onViewportIndirectInput = onViewportIndirectInput,
       onNestedScrollCancel = onNestedScrollCancel,
     )
 
@@ -103,6 +110,8 @@ private data class EditorInteractionsElement(
       interactionController = interactionController,
       geometry = geometry,
       screenPointerSequence = screenPointerSequence,
+      platformIndirectScaleBridge = platformIndirectScaleBridge,
+      scrollGestureLockState = scrollGestureLockState,
       scrollableState = scrollableState,
       nestedScrollDispatcher = nestedScrollDispatcher,
       flingBehavior = flingBehavior,
@@ -110,7 +119,7 @@ private data class EditorInteractionsElement(
       maximumFlingVelocity = maximumFlingVelocity,
       density = density,
       enabled = enabled,
-      onViewportWheelScroll = onViewportWheelScroll,
+      onViewportIndirectInput = onViewportIndirectInput,
       onNestedScrollCancel = onNestedScrollCancel,
     )
   }
@@ -120,6 +129,8 @@ private class EditorInteractionsNode(
   var interactionController: EditorInteractionController,
   var geometry: EditorInteractionGeometry,
   var screenPointerSequence: EditorScreenPointerSequence,
+  var platformIndirectScaleBridge: EditorPlatformIndirectScaleBridge,
+  var scrollGestureLockState: ScrollGestureLockState,
   var scrollableState: Scrollable2DState?,
   var nestedScrollDispatcher: NestedScrollDispatcher?,
   var flingBehavior: FlingBehavior?,
@@ -127,16 +138,23 @@ private class EditorInteractionsNode(
   var maximumFlingVelocity: Float,
   var density: Float,
   var enabled: Boolean,
-  var onViewportWheelScroll: () -> Unit,
+  var onViewportIndirectInput: () -> Unit,
   var onNestedScrollCancel: () -> Unit,
-) : Modifier.Node(), PointerInputModifierNode, SemanticsModifierNode, EditorScreenPointerListener {
+) :
+  Modifier.Node(),
+  PointerInputModifierNode,
+  SemanticsModifierNode,
+  EditorScreenPointerListener,
+  EditorPlatformIndirectScaleOwner {
   private val pointers = mutableMapOf<Long, PointerType>()
   private val singlePointerStreams = mutableSetOf<Long>()
   private var suppressUntilAllUp = false
   private var wheelLastEventMillis: Long? = null
-  private var wheelLowDeltaStreak = 0
   private var wheelZoomActive = false
   private var wheelZoomTimeoutJob: Job? = null
+  private var scaleZoomActive = false
+  private var physicalSequenceYieldedToIndirectInput = false
+  private var physicalDragLockHandle: ScrollGestureLockHandle? = null
   private val scrollDriver =
     EditorViewportScrollDriver(
       scrollableState = { scrollableState },
@@ -150,12 +168,15 @@ private class EditorInteractionsNode(
 
   override fun onAttach() {
     screenPointerSequence.attach(this)
+    platformIndirectScaleBridge.attach(this)
   }
 
   fun update(
     interactionController: EditorInteractionController,
     geometry: EditorInteractionGeometry,
     screenPointerSequence: EditorScreenPointerSequence,
+    platformIndirectScaleBridge: EditorPlatformIndirectScaleBridge,
+    scrollGestureLockState: ScrollGestureLockState,
     scrollableState: Scrollable2DState?,
     nestedScrollDispatcher: NestedScrollDispatcher?,
     flingBehavior: FlingBehavior?,
@@ -163,13 +184,15 @@ private class EditorInteractionsNode(
     maximumFlingVelocity: Float,
     density: Float,
     enabled: Boolean,
-    onViewportWheelScroll: () -> Unit,
+    onViewportIndirectInput: () -> Unit,
     onNestedScrollCancel: () -> Unit,
   ) {
     val inputOwnerChanged =
       this.interactionController !== interactionController ||
         this.geometry !== geometry ||
         this.screenPointerSequence !== screenPointerSequence ||
+        this.platformIndirectScaleBridge !== platformIndirectScaleBridge ||
+        this.scrollGestureLockState !== scrollGestureLockState ||
         this.scrollableState !== scrollableState ||
         this.nestedScrollDispatcher !== nestedScrollDispatcher ||
         this.flingBehavior !== flingBehavior
@@ -180,9 +203,15 @@ private class EditorInteractionsNode(
       this.screenPointerSequence.detach(this)
       screenPointerSequence.attach(this)
     }
+    if (this.platformIndirectScaleBridge !== platformIndirectScaleBridge) {
+      this.platformIndirectScaleBridge.detach(this)
+      platformIndirectScaleBridge.attach(this)
+    }
     this.interactionController = interactionController
     this.geometry = geometry
     this.screenPointerSequence = screenPointerSequence
+    this.platformIndirectScaleBridge = platformIndirectScaleBridge
+    this.scrollGestureLockState = scrollGestureLockState
     this.scrollableState = scrollableState
     this.nestedScrollDispatcher = nestedScrollDispatcher
     this.flingBehavior = flingBehavior
@@ -190,19 +219,14 @@ private class EditorInteractionsNode(
     this.maximumFlingVelocity = maximumFlingVelocity
     this.density = density
     this.enabled = enabled
-    this.onViewportWheelScroll = onViewportWheelScroll
+    this.onViewportIndirectInput = onViewportIndirectInput
     this.onNestedScrollCancel = onNestedScrollCancel
   }
 
   override fun onPointerEvent(pointerEvent: PointerEvent, pass: PointerEventPass, bounds: IntSize) {
-    if (pass != PointerEventPass.Main) {
+    if (routeIndirectPointerPass(pointerEvent = pointerEvent, pass = pass)) {
       return
     }
-    if (pointerEvent.type == PointerEventType.Scroll) {
-      handlePointerSignal(pointerEvent)
-      return
-    }
-    finishWheelZoom()
     if (!enabled || density <= 0f) {
       cancelInteraction(clearSuppression = true)
       return
@@ -213,6 +237,24 @@ private class EditorInteractionsNode(
       dragSlopPx = min(touchSlop, EditorTapSlopDp * density)
     )
     registerPointerDowns(pointerEvent)
+    if (
+      scaleZoomActive &&
+        pointers.isNotEmpty() &&
+        pointers.values.all { pointerType -> pointerType == PointerType.Mouse }
+    ) {
+      suppressUntilAllUp = true
+      physicalSequenceYieldedToIndirectInput = true
+    }
+    if (physicalSequenceYieldedToIndirectInput) {
+      consumeEditorChanges(pointerEvent)
+      finishReleasedPointers(pointerEvent)
+      return
+    }
+    if (pointers.isEmpty()) {
+      return
+    }
+    finishWheelZoom()
+    finishScaleZoom()
     val pressedTouchChanges = pressedTouchChanges(pointerEvent)
 
     if (screenPointerSequence.hasForeignTouchPointer(::isEditorTouchPointer)) {
@@ -263,13 +305,24 @@ private class EditorInteractionsNode(
     finishReleasedPointers(pointerEvent)
   }
 
+  private fun routeIndirectPointerPass(
+    pointerEvent: PointerEvent,
+    pass: PointerEventPass,
+  ): Boolean {
+    if (pass == PointerEventPass.Initial) {
+      handleIndirectPointerEvent(pointerEvent)
+      return true
+    }
+    return pass != PointerEventPass.Main || pointerEvent.type.isIndirectPointerEvent()
+  }
+
   override fun onCancelPointerInput() {
     cancelInteraction(clearSuppression = true)
   }
 
   override fun onScreenPointerMembershipChanged() {
     if (
-      pointers.values.none { pointerType -> pointerType == PointerType.Touch } ||
+      (pointers.isEmpty() && interactionController.interactionMode == EditorInteractionMode.Idle) ||
         !screenPointerSequence.hasForeignTouchPointer(::isEditorTouchPointer)
     ) {
       return
@@ -281,6 +334,8 @@ private class EditorInteractionsNode(
     pointers.clear()
     singlePointerStreams.clear()
     suppressUntilAllUp = false
+    physicalSequenceYieldedToIndirectInput = false
+    releasePhysicalDragLock()
   }
 
   override fun SemanticsPropertyReceiver.applySemantics() {
@@ -297,7 +352,16 @@ private class EditorInteractionsNode(
   private fun registerPointerDowns(pointerEvent: PointerEvent) {
     pointerEvent.changes
       .filter { change -> change.pressed && !change.previousPressed }
-      .forEach { change -> pointers[change.id.value] = change.type }
+      .forEach { change ->
+        pointers[change.id.value] = change.type
+        if (
+          physicalDragLockHandle == null &&
+            change.type == PointerType.Mouse &&
+            change.type.isTouchDragPointer()
+        ) {
+          physicalDragLockHandle = scrollGestureLockState.acquire()
+        }
+      }
   }
 
   private fun isEditorTouchPointer(pointerId: Long): Boolean =
@@ -389,10 +453,19 @@ private class EditorInteractionsNode(
       }
     if (pointers.isEmpty() && !screenPointerSequence.hasScreenPointers) {
       suppressUntilAllUp = false
+      physicalSequenceYieldedToIndirectInput = false
+    }
+    if (
+      pointers.values.none { pointerType ->
+        pointerType == PointerType.Mouse && pointerType.isTouchDragPointer()
+      }
+    ) {
+      releasePhysicalDragLock()
     }
   }
 
   private fun cancelAndSuppress(pointerEvent: PointerEvent) {
+    physicalSequenceYieldedToIndirectInput = false
     interactionController.cancel()
     scrollDriver.cancel()
     suppressUntilAllUp = pointerEvent.changes.any { change -> change.pressed }
@@ -405,11 +478,13 @@ private class EditorInteractionsNode(
       singlePointerStreams.isNotEmpty() ||
         interactionController.interactionMode != EditorInteractionMode.Idle
     suppressUntilAllUp = true
+    physicalSequenceYieldedToIndirectInput = false
+    finishWheelZoom()
+    finishScaleZoom()
     if (hadEditorInteraction) {
       interactionController.cancel()
     }
     scrollDriver.cancel()
-    finishWheelZoom()
   }
 
   private fun consumeEditorChanges(pointerEvent: PointerEvent) {
@@ -418,12 +493,45 @@ private class EditorInteractionsNode(
       .forEach(PointerInputChange::consume)
   }
 
+  private fun handleIndirectPointerEvent(pointerEvent: PointerEvent): Boolean {
+    when (pointerEvent.type) {
+      PointerEventType.Scroll -> {
+        finishScaleZoom()
+        handlePointerSignal(pointerEvent)
+      }
+      PointerEventType.PanStart,
+      PointerEventType.PanMove,
+      PointerEventType.PanEnd -> {
+        finishWheelZoom()
+        finishScaleZoom()
+        handleTrackpadPan(pointerEvent)
+      }
+      PointerEventType.ScaleStart,
+      PointerEventType.ScaleChange,
+      PointerEventType.ScaleEnd -> {
+        finishWheelZoom()
+        handleScale(pointerEvent)
+      }
+      else -> return false
+    }
+    return true
+  }
+
   private fun handlePointerSignal(pointerEvent: PointerEvent) {
     if (!enabled || density <= 0f) {
       finishWheelZoom()
       return
     }
-    if (pointers.isNotEmpty()) {
+    if (screenPointerSequence.hasScreenPointers) {
+      finishWheelZoom()
+      pointerEvent.changes.forEach(PointerInputChange::consume)
+      return
+    }
+    if (
+      pointers.isNotEmpty() &&
+        !physicalSequenceYieldedToIndirectInput &&
+        !yieldPendingPhysicalPointerToIndirectInput()
+    ) {
       finishWheelZoom()
       pointerEvent.changes.forEach(PointerInputChange::consume)
       return
@@ -435,60 +543,50 @@ private class EditorInteractionsNode(
     if (scrollDelta == Offset.Zero) {
       return
     }
-    val zoomModified =
-      pointerEvent.keyboardModifiers.isCtrlPressed || pointerEvent.keyboardModifiers.isMetaPressed
+    val zoomModified = pointerEvent.keyboardModifiers.isEditorIndirectZoomModifierPressed()
     if (!zoomModified) {
       finishWheelZoom()
       if (scrollDriver.launchPointerSignalScroll(scrollDelta = scrollDelta, density = density)) {
-        onViewportWheelScroll()
+        onViewportIndirectInput()
         pointerEvent.changes.forEach(PointerInputChange::consume)
       }
       return
     }
 
-    val change = pointerEvent.changes.firstOrNull() ?: return
+    handleModifiedPointerScroll(pointerEvent = pointerEvent, scrollDelta = scrollDelta)
+  }
+
+  private fun handleModifiedPointerScroll(pointerEvent: PointerEvent, scrollDelta: Offset) {
+    val change = pointerEvent.changes.firstOrNull { candidate -> !candidate.isConsumed } ?: return
     val dominantDelta =
       if (abs(scrollDelta.y) >= abs(scrollDelta.x)) scrollDelta.y else scrollDelta.x
     if (!dominantDelta.isFinite() || dominantDelta == 0f) {
       return
     }
     val normalizedDelta = normalizeEditorViewportWheelZoomDelta(dominantDelta)
-    val deltaMagnitude = abs(normalizedDelta)
     val elapsed = wheelLastEventMillis?.let { change.uptimeMillis - it } ?: Long.MAX_VALUE
     if (elapsed > WheelBurstGapMs) {
       finishWheelZoom()
     }
     wheelLastEventMillis = change.uptimeMillis
-    if (deltaMagnitude <= WheelTailDeltaPx) {
-      wheelLowDeltaStreak += 1
-      if (wheelLowDeltaStreak >= WheelTailStreakToReset) {
-        finishWheelZoom()
-        return
-      }
-    } else {
-      wheelLowDeltaStreak = 0
-    }
     if (!wheelZoomActive) {
-      if (
-        deltaMagnitude < WheelModeSwitchMinDeltaPx ||
-          !interactionController.beginPointerSignalZoom()
-      ) {
+      if (!interactionController.beginIndirectZoom()) {
         return
       }
       wheelZoomActive = true
     }
-    val focalInEditor = geometry.resolveInteractionPosition(change.position)
+    val focalInRoot = positionInRoot(change.position)
     if (
-      focalInEditor == null ||
-        !interactionController.updatePointerSignalZoom(
-          focalInEditorPx = focalInEditor,
-          normalizedDelta = normalizedDelta,
-        )
+      !interactionController.updateIndirectScrollZoom(
+        focalInRootPx = focalInRoot,
+        normalizedDelta = normalizedDelta,
+      )
     ) {
       finishWheelZoom()
       return
     }
     keepWheelZoomAlive()
+    onViewportIndirectInput()
     pointerEvent.changes.forEach(PointerInputChange::consume)
   }
 
@@ -503,12 +601,134 @@ private class EditorInteractionsNode(
   private fun finishWheelZoom() {
     wheelZoomTimeoutJob?.cancel()
     wheelZoomTimeoutJob = null
-    wheelLowDeltaStreak = 0
     wheelLastEventMillis = null
     if (wheelZoomActive) {
       wheelZoomActive = false
-      interactionController.endPointerSignalZoom()
+      interactionController.endIndirectZoom()
     }
+  }
+
+  private fun handleTrackpadPan(pointerEvent: PointerEvent) {
+    if (!enabled || density <= 0f) {
+      return
+    }
+    if (!canAcceptIndirectInput() && !yieldPendingPhysicalPointerToIndirectInput()) {
+      pointerEvent.changes.forEach(PointerInputChange::consume)
+      return
+    }
+    if (pointerEvent.type == PointerEventType.PanMove) {
+      val panOffset =
+        pointerEvent.changes.firstNotNullOfOrNull { change ->
+          change.panOffset.takeIf { offset -> !change.isConsumed && offset.isUsablePanOffset() }
+        }
+      if (panOffset != null && scrollDriver.launchTrackpadPan(panOffset)) {
+        onViewportIndirectInput()
+      }
+    }
+    pointerEvent.changes.forEach(PointerInputChange::consume)
+  }
+
+  private fun handleScale(pointerEvent: PointerEvent) {
+    if (!enabled || density <= 0f) {
+      finishScaleZoom()
+      return
+    }
+    when (pointerEvent.type) {
+      PointerEventType.ScaleStart -> {
+        beginIndirectScale()
+      }
+      PointerEventType.ScaleChange -> {
+        if (!canAcceptIndirectInput()) {
+          finishScaleZoom()
+          pointerEvent.changes.forEach(PointerInputChange::consume)
+          return
+        }
+        val change =
+          if (scaleZoomActive) {
+            pointerEvent.changes.firstOrNull { candidate ->
+              !candidate.isConsumed && candidate.scaleFactor.isUsableScaleChange()
+            }
+          } else {
+            null
+          }
+        if (change != null) {
+          updateIndirectScale(
+            focalInRootPx = positionInRoot(change.position),
+            scaleFactor = change.scaleFactor,
+          )
+        }
+      }
+      PointerEventType.ScaleEnd -> endIndirectScale()
+    }
+    pointerEvent.changes.forEach(PointerInputChange::consume)
+  }
+
+  private fun canAcceptIndirectInput(): Boolean =
+    enabled &&
+      density > 0f &&
+      (pointers.isEmpty() || physicalSequenceYieldedToIndirectInput) &&
+      !screenPointerSequence.hasScreenPointers
+
+  override fun beginIndirectScale(): Boolean {
+    finishWheelZoom()
+    if (scaleZoomActive) {
+      return false
+    }
+    if (!canAcceptIndirectInput() && !yieldPendingPhysicalPointerToIndirectInput()) {
+      return false
+    }
+    scaleZoomActive = interactionController.beginIndirectZoom()
+    return scaleZoomActive
+  }
+
+  override fun updateIndirectScale(focalInRootPx: Offset, scaleFactor: Float): Boolean {
+    if (!scaleZoomActive || !canAcceptIndirectInput()) {
+      finishScaleZoom()
+      return false
+    }
+    if (
+      !interactionController.updateIndirectScaleZoom(
+        focalInRootPx = focalInRootPx,
+        scaleFactor = scaleFactor,
+      )
+    ) {
+      finishScaleZoom()
+      return false
+    }
+    onViewportIndirectInput()
+    return true
+  }
+
+  override fun endIndirectScale() {
+    finishScaleZoom()
+  }
+
+  private fun finishScaleZoom() {
+    if (scaleZoomActive) {
+      scaleZoomActive = false
+      interactionController.endIndirectZoom()
+    }
+  }
+
+  private fun yieldPendingPhysicalPointerToIndirectInput(): Boolean {
+    if (
+      screenPointerSequence.hasScreenPointers ||
+        pointers.isEmpty() ||
+        pointers.values.any { pointerType -> pointerType != PointerType.Mouse } ||
+        !interactionController.cancelPendingPointerForIndirectInput()
+    ) {
+      return false
+    }
+    singlePointerStreams.clear()
+    scrollDriver.cancel()
+    suppressUntilAllUp = true
+    physicalSequenceYieldedToIndirectInput = true
+    return true
+  }
+
+  private fun releasePhysicalDragLock() {
+    physicalDragLockHandle?.release()
+    physicalDragLockHandle = null
   }
 
   private fun cancelInteraction(clearSuppression: Boolean) {
@@ -520,6 +740,9 @@ private class EditorInteractionsNode(
     }
     scrollDriver.cancel()
     finishWheelZoom()
+    finishScaleZoom()
+    releasePhysicalDragLock()
+    physicalSequenceYieldedToIndirectInput = false
     if (clearSuppression) {
       suppressUntilAllUp = false
     }
@@ -528,9 +751,28 @@ private class EditorInteractionsNode(
   override fun onDetach() {
     cancelInteraction(clearSuppression = true)
     screenPointerSequence.detach(this)
+    platformIndirectScaleBridge.detach(this)
     super.onDetach()
   }
 }
+
+private fun Offset.isUsablePanOffset(): Boolean {
+  if (this == Offset.Zero) {
+    return false
+  }
+  return x.isFinite() && y.isFinite()
+}
+
+private fun Float.isUsableScaleChange(): Boolean = isFinite() && this > 0f && this != 1f
+
+private fun PointerEventType.isIndirectPointerEvent(): Boolean =
+  this == PointerEventType.Scroll ||
+    this == PointerEventType.PanStart ||
+    this == PointerEventType.PanMove ||
+    this == PointerEventType.PanEnd ||
+    this == PointerEventType.ScaleStart ||
+    this == PointerEventType.ScaleChange ||
+    this == PointerEventType.ScaleEnd
 
 internal class EditorScreenPointerSequence {
   private val screenPointers = mutableSetOf<Long>()

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorPlatformIndirectScale.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorPlatformIndirectScale.kt
@@ -1,0 +1,44 @@
+package co.typie.editor.interaction
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
+
+internal expect fun Modifier.editorPlatformIndirectScale(
+  bridge: EditorPlatformIndirectScaleBridge,
+  enabled: Boolean,
+  density: Float,
+): Modifier
+
+internal expect fun PointerKeyboardModifiers.isEditorIndirectZoomModifierPressed(): Boolean
+
+internal class EditorPlatformIndirectScaleBridge {
+  private var owner: EditorPlatformIndirectScaleOwner? = null
+
+  fun attach(owner: EditorPlatformIndirectScaleOwner) {
+    this.owner = owner
+  }
+
+  fun detach(owner: EditorPlatformIndirectScaleOwner) {
+    if (this.owner === owner) {
+      this.owner = null
+    }
+  }
+
+  fun begin(): Boolean = owner?.beginIndirectScale() == true
+
+  fun update(focalInRootPx: Offset, scaleFactor: Float): Boolean =
+    owner?.updateIndirectScale(focalInRootPx, scaleFactor) == true
+
+  fun end() {
+    owner?.endIndirectScale()
+  }
+}
+
+internal interface EditorPlatformIndirectScaleOwner {
+  fun beginIndirectScale(): Boolean
+
+  fun updateIndirectScale(focalInRootPx: Offset, scaleFactor: Float): Boolean
+
+  fun endIndirectScale()
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorViewportScrollDriver.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorViewportScrollDriver.kt
@@ -132,25 +132,11 @@ internal class EditorViewportScrollDriver(
   }
 
   fun launchPointerSignalScroll(scrollDelta: Offset, density: Float): Boolean {
-    val state = scrollableState() ?: return false
-    val dispatcher = nestedScrollDispatcher() ?: return false
     val delta = editorViewportWheelScrollDeltaPx(scrollDelta = scrollDelta, density = density)
-    if (delta == Offset.Zero) {
-      return false
-    }
-    launch {
-      state.scroll(MutatePriority.UserInput) {
-        // Pointer signals are independent deltas without a drag/fling terminal. Do not let a
-        // nested parent claim them as a user drag that can never be released.
-        dispatchScroll(
-          delta = delta,
-          dispatcher = dispatcher,
-          source = NestedScrollSource.SideEffect,
-        )
-      }
-    }
-    return true
+    return launchIndirectScroll(delta)
   }
+
+  fun launchTrackpadPan(panOffset: Offset): Boolean = launchIndirectScroll(panOffset)
 
   suspend fun performSemanticsScroll(offset: Offset): Offset {
     val state = scrollableState() ?: return Offset.Zero
@@ -169,6 +155,26 @@ internal class EditorViewportScrollDriver(
       }
     }
     return previousValue
+  }
+
+  private fun launchIndirectScroll(delta: Offset): Boolean {
+    val state = scrollableState() ?: return false
+    val dispatcher = nestedScrollDispatcher() ?: return false
+    if (delta == Offset.Zero || !delta.x.isFinite() || !delta.y.isFinite()) {
+      return false
+    }
+    launch {
+      state.scroll(MutatePriority.UserInput) {
+        // Indirect input has deltas but no editor-owned drag/fling terminal. Do not let a nested
+        // parent claim it as a user drag that can never be released.
+        dispatchScroll(
+          delta = delta,
+          dispatcher = dispatcher,
+          source = NestedScrollSource.SideEffect,
+        )
+      }
+    }
+    return true
   }
 
   private suspend fun performFling(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorPanGesture.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorPanGesture.kt
@@ -31,6 +31,9 @@ internal class EditorPanGesture {
 
   private var active = false
 
+  val hasPendingPointer: Boolean
+    get() = session != null && !active
+
   fun prepareFresh(
     pointerId: Long,
     position: Offset,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/semantics/EditorViewportZoomSemantic.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/semantics/EditorViewportZoomSemantic.kt
@@ -31,8 +31,8 @@ internal class EditorViewportZoomSemantic {
   private var config: EditorViewportZoomSemanticConfig? = null
   private var transformActive = false
   private var pinchSession: PinchSession? = null
-  private var pointerSignalZoomActive = false
-  private var pointerSignalRawZoom: Float? = null
+  private var indirectZoomActive = false
+  private var indirectRawZoom: Float? = null
 
   fun configure(config: EditorViewportZoomSemanticConfig?) {
     if (config?.isUsable != true && (transformActive || hasActiveZoom)) {
@@ -91,24 +91,39 @@ internal class EditorViewportZoomSemantic {
     return true
   }
 
-  fun beginPointerSignal(): Boolean {
+  fun beginIndirect(): Boolean {
     val currentConfig = config?.takeIf { it.isUsable } ?: return false
     beginTransform(currentConfig)
-    pointerSignalZoomActive = true
-    pointerSignalRawZoom = null
+    indirectZoomActive = true
+    indirectRawZoom = null
     return true
   }
 
-  fun updatePointerSignal(focalInEditorPx: Offset, normalizedDelta: Float): Boolean {
-    val currentConfig = config?.takeIf { it.isUsable } ?: return false
-    if (!normalizedDelta.isFinite() || normalizedDelta == 0f || !pointerSignalZoomActive) {
+  fun updateIndirectScroll(focalInRootPx: Offset, normalizedDelta: Float): Boolean {
+    if (!normalizedDelta.isFinite() || normalizedDelta == 0f) {
       return false
+    }
+    return updateIndirectScale(
+      focalInRootPx = focalInRootPx,
+      scaleFactor = exp((-normalizedDelta / PointerSignalZoomDivisor).toDouble()).toFloat(),
+    )
+  }
+
+  fun updateIndirectScale(focalInRootPx: Offset, scaleFactor: Float): Boolean {
+    val currentConfig = config?.takeIf { it.isUsable } ?: return false
+    if (!indirectZoomActive || !isValidScaleUpdate(focalInRootPx, scaleFactor)) {
+      return false
+    }
+    if (scaleFactor == 1f) {
+      return true
     }
 
     val viewportState = currentConfig.viewportState
     val effectiveScrollTarget = viewportState.effectiveTransformScrollTarget
     val unappliedScrollDelta = effectiveScrollTarget - viewportState.scrollOffset
-    val focalInEditor = currentConfig.toEditorDp(focalInEditorPx) + unappliedScrollDelta
+    val editorRect = currentConfig.uiState.editorRectInRoot() ?: return false
+    val focalInEditor =
+      currentConfig.toEditorDp(focalInRootPx - editorRect.topLeft) + unappliedScrollDelta
     val previousZoom = currentConfig.zoomController.displayZoom
     val anchor =
       currentConfig
@@ -117,13 +132,13 @@ internal class EditorViewportZoomSemantic {
     val previousAnchorDisplayPosition =
       currentConfig.resolveAnchorDisplayPosition(anchor = anchor, displayZoom = previousZoom)
         ?: return false
-    val baseZoom = pointerSignalRawZoom ?: previousZoom
+    val baseZoom = indirectRawZoom ?: previousZoom
     val nextRawZoom =
       clampDocumentZoom(
-        zoom = baseZoom * exp((-normalizedDelta / PointerSignalZoomDivisor).toDouble()).toFloat(),
+        zoom = baseZoom * scaleFactor,
         bounds = computePaginatedZoomBounds(currentConfig.layoutSpec.pageWidth),
       )
-    pointerSignalRawZoom = nextRawZoom
+    indirectRawZoom = nextRawZoom
 
     val nextZoom = setZoom(config = currentConfig, zoom = nextRawZoom)
     val nextAnchorDisplayPosition =
@@ -141,8 +156,8 @@ internal class EditorViewportZoomSemantic {
       config?.zoomController?.commitRenderZoom()
     }
     pinchSession = null
-    pointerSignalZoomActive = false
-    pointerSignalRawZoom = null
+    indirectZoomActive = false
+    indirectRawZoom = null
     if (transformActive) {
       config?.viewportState?.endTransform()
       transformActive = false
@@ -155,7 +170,7 @@ internal class EditorViewportZoomSemantic {
   }
 
   private val hasActiveZoom: Boolean
-    get() = pinchSession != null || pointerSignalZoomActive
+    get() = pinchSession != null || indirectZoomActive
 
   private fun beginTransform(config: EditorViewportZoomSemanticConfig) {
     if (!transformActive) {
@@ -202,6 +217,13 @@ private val EditorPinchSample.isUsable: Boolean
       focalInRootPx.y.isFinite() &&
       distancePx.isFinite() &&
       distancePx > 0f
+
+private fun isValidScaleUpdate(focalInRootPx: Offset, scaleFactor: Float): Boolean {
+  if (!focalInRootPx.x.isFinite() || !focalInRootPx.y.isFinite()) {
+    return false
+  }
+  return scaleFactor.isFinite() && scaleFactor > 0f
+}
 
 private fun EditorViewportZoomSemanticConfig.resolveAnchor(
   focalInRootPx: Offset

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -1142,6 +1142,13 @@ fun EditorScreen(entityId: String) {
         }
       }
     val editorInteractionEnabled = editorReady && !popoverOverlayState.isOutsideDismissGestureActive
+    val platformIndirectScaleEnabled =
+      editorInteractionEnabled &&
+        screenState.sceneInForeground &&
+        !nav.isTransitioning &&
+        !subPaneBlocksEditorInput &&
+        !screenShortcutModeActive &&
+        popoverOverlayState.entry == null
     SideEffect {
       val viewportZoomConfig =
         (layoutSpec as? EditorDocumentLayoutSpec.Paginated)?.let { paginatedLayoutSpec ->
@@ -1213,9 +1220,10 @@ fun EditorScreen(entityId: String) {
         magnifierFocalPositionInRoot = magnifierFocalPositionInRoot,
         viewportScrollableState = viewportScrollableState,
         editorInteractionEnabled = editorInteractionEnabled,
+        platformIndirectScaleEnabled = platformIndirectScaleEnabled,
         viewportContentWidth = bodyTrackWidth,
         viewportScrollReconcileMode = viewportScrollReconcileMode,
-        onViewportWheelScroll = { uiState.contextMenu.hide() },
+        onViewportIndirectInput = { uiState.contextMenu.hide() },
         onMeasuredViewportSizeChange = { viewport ->
           val editor = runtime.editor
           if (editor != null && viewport.width > 0f && viewport.height > 0f) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayout.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayout.kt
@@ -32,9 +32,11 @@ import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
 import co.typie.editor.ext.unclippedBoundsInRoot
+import co.typie.editor.interaction.EditorPlatformIndirectScaleBridge
 import co.typie.editor.interaction.EditorScreenPointerSequence
 import co.typie.editor.interaction.LocalEditorInteractionScope
 import co.typie.editor.interaction.editorInteractions
+import co.typie.editor.interaction.editorPlatformIndirectScale
 import co.typie.editor.interaction.observeEditorScreenPointerSequence
 import co.typie.editor.runtime.LocalEditorUiState
 import co.typie.editor.scroll.EditorBringIntoViewBehavior
@@ -46,6 +48,7 @@ import co.typie.editor.scroll.LocalEditorBringIntoViewRequests
 import co.typie.editor.scroll.isEditorScrollTargetVisible
 import co.typie.editor.scroll.resolveEditorScrollIntent
 import co.typie.editor.viewport.EditorViewportState
+import co.typie.ext.LocalScrollGestureLockState
 import co.typie.navigation.LocalNavigationPopNestedScroll
 import co.typie.navigation.navigationPopNestedScroll
 import co.typie.screen.editor.editor.overlay.editorMagnifier
@@ -87,8 +90,9 @@ internal fun EditorScreenLayout(
   viewportScrollableState: Scrollable2DState,
   viewportContentWidth: Float,
   editorInteractionEnabled: Boolean = true,
+  platformIndirectScaleEnabled: Boolean = editorInteractionEnabled,
   viewportScrollReconcileMode: EditorViewportScrollReconcileMode,
-  onViewportWheelScroll: () -> Unit = {},
+  onViewportIndirectInput: () -> Unit = {},
   onMeasuredViewportSizeChange: (Size) -> Unit,
   header: @Composable () -> Unit,
   body: @Composable (Modifier) -> Unit,
@@ -99,6 +103,8 @@ internal fun EditorScreenLayout(
   modifier: Modifier = Modifier,
 ) {
   val density = LocalDensity.current
+  val scrollGestureLockState = LocalScrollGestureLockState.current
+  val platformIndirectScaleBridge = remember { EditorPlatformIndirectScaleBridge() }
   val viewConfiguration = LocalViewConfiguration.current
   val bringIntoViewRequests = LocalEditorBringIntoViewRequests.current
   val interactionScope = LocalEditorInteractionScope.current
@@ -148,19 +154,26 @@ internal fun EditorScreenLayout(
   ) { constraints ->
     val editorInteractionModifier =
       Modifier.editorInteractions(
-        interactionController = interactionScope.controller,
-        geometry = interactionScope,
-        screenPointerSequence = screenPointerSequence,
-        scrollableState = viewportScrollableState,
-        nestedScrollDispatcher = viewportNestedScrollDispatcher,
-        flingBehavior = viewportFlingBehavior,
-        touchSlop = viewConfiguration.touchSlop,
-        maximumFlingVelocity = viewConfiguration.maximumFlingVelocity,
-        density = density.density,
-        enabled = editorInteractionEnabled,
-        onViewportWheelScroll = onViewportWheelScroll,
-        onNestedScrollCancel = { navigationPopNestedScroll?.cancel() },
-      )
+          interactionController = interactionScope.controller,
+          geometry = interactionScope,
+          screenPointerSequence = screenPointerSequence,
+          platformIndirectScaleBridge = platformIndirectScaleBridge,
+          scrollGestureLockState = scrollGestureLockState,
+          scrollableState = viewportScrollableState,
+          nestedScrollDispatcher = viewportNestedScrollDispatcher,
+          flingBehavior = viewportFlingBehavior,
+          touchSlop = viewConfiguration.touchSlop,
+          maximumFlingVelocity = viewConfiguration.maximumFlingVelocity,
+          density = density.density,
+          enabled = editorInteractionEnabled,
+          onViewportIndirectInput = onViewportIndirectInput,
+          onNestedScrollCancel = { navigationPopNestedScroll?.cancel() },
+        )
+        .editorPlatformIndirectScale(
+          bridge = platformIndirectScaleBridge,
+          enabled = platformIndirectScaleEnabled,
+          density = density.density,
+        )
     val viewportWidth = constraints.maxWidth / density.density
     val resolvedContentWidth =
       resolveEditorViewportContentWidth(

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/semantics/EditorViewportZoomSemanticTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/semantics/EditorViewportZoomSemanticTest.kt
@@ -111,15 +111,15 @@ class EditorViewportZoomSemanticTest {
   }
 
   @Test
-  fun `pointer signal zoom shares the viewport zoom semantic`() {
+  fun `indirect scroll zoom shares the viewport zoom semantic`() {
     val fixture = Fixture()
     val normalizedDeltaForOneAndHalfZoom = -240f * ln(1.5f)
 
-    assertTrue(fixture.semantic.beginPointerSignal())
+    assertTrue(fixture.semantic.beginIndirect())
     assertTrue(fixture.viewportState.isTransforming)
     assertTrue(
-      fixture.semantic.updatePointerSignal(
-        focalInEditorPx = Offset(80f, 150f),
+      fixture.semantic.updateIndirectScroll(
+        focalInRootPx = Offset(80f, 150f),
         normalizedDelta = normalizedDeltaForOneAndHalfZoom,
       )
     )
@@ -133,7 +133,7 @@ class EditorViewportZoomSemanticTest {
   }
 
   @Test
-  fun `pointer signal anchor follows the actual page width inside the layout track`() {
+  fun `indirect scroll anchor follows the actual page width inside the layout track`() {
     val fixture =
       Fixture(
         pageSizes = listOf(PageSize(width = 700f, height = 960f)),
@@ -144,16 +144,16 @@ class EditorViewportZoomSemanticTest {
       )
     val normalizedDeltaForOneAndHalfZoom = -240f * ln(1.5f)
 
-    assertTrue(fixture.semantic.beginPointerSignal())
+    assertTrue(fixture.semantic.beginIndirect())
     assertTrue(
-      fixture.semantic.updatePointerSignal(Offset(310f, 0f), normalizedDeltaForOneAndHalfZoom)
+      fixture.semantic.updateIndirectScroll(Offset(310f, 0f), normalizedDeltaForOneAndHalfZoom)
     )
 
     assertEquals(Offset(35f, 0f), fixture.viewportState.scrollOffset)
   }
 
   @Test
-  fun `pointer signal target is restored after zoom bounds are measured`() {
+  fun `indirect scroll target is restored after zoom bounds are measured`() {
     val fixture =
       Fixture(
         measuredViewportSize = Size(width = 720f, height = 900f),
@@ -161,9 +161,9 @@ class EditorViewportZoomSemanticTest {
       )
     val normalizedDeltaForOneAndHalfZoom = -240f * ln(1.5f)
 
-    assertTrue(fixture.semantic.beginPointerSignal())
+    assertTrue(fixture.semantic.beginIndirect())
     assertTrue(
-      fixture.semantic.updatePointerSignal(Offset(300f, 0f), normalizedDeltaForOneAndHalfZoom)
+      fixture.semantic.updateIndirectScroll(Offset(300f, 0f), normalizedDeltaForOneAndHalfZoom)
     )
     assertEquals(Offset.Zero, fixture.viewportState.scrollOffset)
 
@@ -176,7 +176,7 @@ class EditorViewportZoomSemanticTest {
   }
 
   @Test
-  fun `pointer signal updates remain cumulative before zoom bounds are measured`() {
+  fun `indirect scroll updates remain cumulative before zoom bounds are measured`() {
     val fixture =
       Fixture(
         measuredViewportSize = Size(width = 720f, height = 900f),
@@ -184,12 +184,12 @@ class EditorViewportZoomSemanticTest {
       )
     val normalizedDeltaForOneAndHalfZoom = -240f * ln(1.5f)
 
-    assertTrue(fixture.semantic.beginPointerSignal())
+    assertTrue(fixture.semantic.beginIndirect())
     assertTrue(
-      fixture.semantic.updatePointerSignal(Offset(300f, 0f), normalizedDeltaForOneAndHalfZoom)
+      fixture.semantic.updateIndirectScroll(Offset(300f, 0f), normalizedDeltaForOneAndHalfZoom)
     )
     assertTrue(
-      fixture.semantic.updatePointerSignal(Offset(300f, 0f), normalizedDeltaForOneAndHalfZoom)
+      fixture.semantic.updateIndirectScroll(Offset(300f, 0f), normalizedDeltaForOneAndHalfZoom)
     )
     assertEquals(2f, fixture.zoomController.displayZoom, 0.0001f)
     assertEquals(Offset.Zero, fixture.viewportState.scrollOffset)
@@ -200,6 +200,23 @@ class EditorViewportZoomSemanticTest {
     )
 
     assertEquals(Offset(300f, 0f), fixture.viewportState.scrollOffset)
+  }
+
+  @Test
+  fun `native scale uses the same root physical focal anchor`() {
+    val fixture =
+      Fixture(editorBoundsInRoot = Rect(left = 100f, top = 200f, right = 820f, bottom = 2200f))
+
+    assertTrue(fixture.semantic.beginIndirect())
+    assertTrue(
+      fixture.semantic.updateIndirectScale(focalInRootPx = Offset(180f, 350f), scaleFactor = 1.5f)
+    )
+
+    assertEquals(1.5f, fixture.zoomController.displayZoom, 0.0001f)
+    assertEquals(Offset(40f, 75f), fixture.viewportState.scrollOffset)
+
+    fixture.semantic.end()
+    assertEquals(fixture.zoomController.displayZoom, fixture.zoomController.renderZoom, 0.0001f)
   }
 
   private class Fixture(

--- a/apps/mobile/compose/src/desktopMain/kotlin/co/typie/editor/interaction/EditorPlatformIndirectScale.desktop.kt
+++ b/apps/mobile/compose/src/desktopMain/kotlin/co/typie/editor/interaction/EditorPlatformIndirectScale.desktop.kt
@@ -1,0 +1,17 @@
+package co.typie.editor.interaction
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
+import androidx.compose.ui.input.pointer.isCtrlPressed
+import androidx.compose.ui.input.pointer.isMetaPressed
+
+internal actual fun Modifier.editorPlatformIndirectScale(
+  bridge: EditorPlatformIndirectScaleBridge,
+  enabled: Boolean,
+  density: Float,
+): Modifier = this
+
+internal actual fun PointerKeyboardModifiers.isEditorIndirectZoomModifierPressed(): Boolean =
+  if (isMacOs()) isMetaPressed else isCtrlPressed
+
+private fun isMacOs(): Boolean = System.getProperty("os.name").startsWith("Mac", ignoreCase = true)

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/interaction/EditorInteractionsDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/interaction/EditorInteractionsDesktopTest.kt
@@ -15,31 +15,40 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollDispatcher
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.pan
+import androidx.compose.ui.test.performKeyInput
 import androidx.compose.ui.test.performMouseInput
 import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.performTrackpadInput
+import androidx.compose.ui.test.scale
 import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import co.typie.editor.Editor
 import co.typie.editor.EditorZoomController
+import co.typie.editor.FakeFfiEditor
 import co.typie.editor.PagePoint
 import co.typie.editor.body.EditorDocumentLayoutSpec
 import co.typie.editor.ffi.Size as PageSize
 import co.typie.editor.interaction.semantics.EditorViewportZoomSemanticConfig
 import co.typie.editor.runtime.EditorUiState
 import co.typie.editor.viewport.EditorViewportState
+import co.typie.ext.ScrollGestureLockState
 import co.typie.navigation.LocalNavigationPopNestedScroll
 import co.typie.navigation.NavigationStack
 import co.typie.navigation.Navigator
@@ -49,11 +58,13 @@ import co.typie.ui.component.topbar.TopBarState
 import kotlin.math.abs
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
@@ -76,6 +87,457 @@ class EditorInteractionsDesktopTest {
     waitForIdle()
 
     assertTrue(fixture.touchPanDeltas.isNotEmpty())
+  }
+
+  @Test
+  fun `editor physical click drag owns desktop scroll translation until release`() =
+    runComposeUiTest {
+      val fixture = Fixture()
+      setEditorContent(fixture)
+
+      onNodeWithTag(EditorTag).performTrackpadInput {
+        moveTo(Offset(x = 100f, y = 100f))
+        press()
+      }
+      waitForIdle()
+      assertTrue(fixture.scrollGestureLockState.isLocked)
+
+      onNodeWithTag(EditorTag).performTrackpadInput {
+        moveBy(Offset(x = 20f, y = 0f))
+        release()
+      }
+      waitForIdle()
+
+      assertFalse(fixture.scrollGestureLockState.isLocked)
+      assertTrue(fixture.touchPanDeltas.isNotEmpty())
+    }
+
+  @Test
+  fun `desktop command pointer scroll zooms without moving navigation`() = runComposeUiTest {
+    val fixture = Fixture(scrollConsumer = { Offset.Zero })
+    val navigator = Navigator(Route.Home)
+    setNavigationEditorContent(fixture = fixture, navigator = navigator)
+    val editor = onNodeWithTag(NavigationEditorTag)
+    val initialZoom = fixture.zoomController.displayZoom
+
+    editor.performMouseInput { moveTo(center) }
+    editor.performKeyInput { keyDown(Key.MetaLeft) }
+    editor.performMouseInput { repeat(24) { scroll(Offset(x = 0f, y = -0.1f)) } }
+    editor.performKeyInput { keyUp(Key.MetaLeft) }
+    mainClock.advanceTimeBy(100)
+    waitForIdle()
+
+    assertTrue(fixture.zoomController.displayZoom > initialZoom)
+    assertEquals(fixture.zoomController.displayZoom, fixture.zoomController.renderZoom, 0.0001f)
+    assertEquals(EditorInteractionMode.Idle, fixture.controller.interactionMode)
+    assertEquals(NavigationEditorRoute, navigator.current)
+    assertEquals(
+      expected = 0f,
+      actual = editor.fetchSemanticsNode().boundsInRoot.left,
+      absoluteTolerance = 0.5f,
+    )
+  }
+
+  @Test
+  fun `desktop ctrl pointer scroll remains viewport scroll`() = runComposeUiTest {
+    val fixture = Fixture()
+    setEditorContent(fixture)
+    val editor = onNodeWithTag(EditorTag)
+    val initialZoom = fixture.zoomController.displayZoom
+
+    editor.performMouseInput { moveTo(center) }
+    editor.performKeyInput { keyDown(Key.CtrlLeft) }
+    editor.performMouseInput { scroll(Offset(x = 0f, y = -96f)) }
+    editor.performKeyInput { keyUp(Key.CtrlLeft) }
+    waitForIdle()
+
+    assertEquals(initialZoom, fixture.zoomController.displayZoom, 0.0001f)
+    assertTrue(fixture.touchPanDeltas.isNotEmpty())
+  }
+
+  @Test
+  fun `modified pointer scroll reaches editor before a child consumes it`() = runComposeUiTest {
+    val fixture = Fixture()
+    setEditorContent(fixture, consumeIndirectInputAtChild = true)
+    val editor = onNodeWithTag(EditorTag)
+    val initialZoom = fixture.zoomController.displayZoom
+
+    editor.performMouseInput { moveTo(center) }
+    editor.performKeyInput { keyDown(Key.MetaLeft) }
+    editor.performMouseInput { scroll(Offset(x = 0f, y = -96f)) }
+    editor.performKeyInput { keyUp(Key.MetaLeft) }
+    waitForIdle()
+
+    assertTrue(fixture.zoomController.displayZoom > initialZoom)
+  }
+
+  @Test
+  fun `command scroll takes over a pressed tap and allows following scale`() = runComposeUiTest {
+    val fixture = Fixture(tapEligible = true)
+    setEditorContent(fixture)
+    val editor = onNodeWithTag(EditorTag)
+    val initialZoom = fixture.zoomController.displayZoom
+
+    editor.performMouseInput {
+      moveTo(center)
+      press()
+    }
+    waitForIdle()
+    assertEquals(1, fixture.host.longPressDispatchScheduleCount)
+
+    editor.performKeyInput { keyDown(Key.MetaLeft) }
+    editor.performMouseInput { scroll(Offset(x = 0f, y = -24f)) }
+    editor.performKeyInput { keyUp(Key.MetaLeft) }
+    waitForIdle()
+
+    assertTrue(fixture.host.longPressDispatchCancelCount > 0)
+    assertTrue(fixture.zoomController.displayZoom > initialZoom)
+    val zoomAfterScroll = fixture.zoomController.displayZoom
+    runOnIdle {
+      assertTrue(fixture.platformIndirectScaleBridge.begin())
+      assertTrue(
+        fixture.platformIndirectScaleBridge.update(
+          focalInRootPx = Offset(x = 180f, y = 160f),
+          scaleFactor = 1.1f,
+        )
+      )
+      fixture.platformIndirectScaleBridge.end()
+    }
+    assertTrue(fixture.zoomController.displayZoom > zoomAfterScroll)
+    editor.performMouseInput { release() }
+    waitForIdle()
+
+    assertEquals(EditorInteractionMode.Idle, fixture.controller.interactionMode)
+    assertFalse(fixture.scrollGestureLockState.isLocked)
+  }
+
+  @Test
+  fun `common trackpad scale event does not start physical gestures`() = runComposeUiTest {
+    val fixture = Fixture()
+    setEditorContent(fixture)
+    val initialZoom = fixture.zoomController.displayZoom
+
+    onNodeWithTag(EditorTag).performTrackpadInput {
+      updatePointerTo(Offset(x = 180f, y = 160f))
+      scale(1.25f)
+    }
+    waitForIdle()
+
+    assertEquals(initialZoom * 1.25f, fixture.zoomController.displayZoom, 0.0001f)
+    assertEquals(fixture.zoomController.displayZoom, fixture.zoomController.renderZoom, 0.0001f)
+    assertEquals(EditorInteractionMode.Idle, fixture.controller.interactionMode)
+    assertEquals(0, fixture.host.tapDispatchScheduleCount)
+    assertEquals(0, fixture.host.longPressDispatchScheduleCount)
+    assertTrue(fixture.touchPanDeltas.isEmpty())
+  }
+
+  @Test
+  fun `common trackpad scale event precedes child consumption`() = runComposeUiTest {
+    val fixture = Fixture()
+    setEditorContent(fixture, consumeIndirectInputAtChild = true)
+    val initialZoom = fixture.zoomController.displayZoom
+
+    onNodeWithTag(EditorTag).performTrackpadInput {
+      updatePointerTo(Offset(x = 180f, y = 160f))
+      scale(1.25f)
+    }
+    waitForIdle()
+
+    assertEquals(initialZoom * 1.25f, fixture.zoomController.displayZoom, 0.0001f)
+  }
+
+  @Test
+  fun `common trackpad scale event does not move navigation route`() = runComposeUiTest {
+    val fixture = Fixture(scrollConsumer = { Offset.Zero })
+    val navigator = Navigator(Route.Home)
+    setNavigationEditorContent(fixture = fixture, navigator = navigator)
+    val initialZoom = fixture.zoomController.displayZoom
+
+    onNodeWithTag(NavigationEditorTag).performTrackpadInput {
+      updatePointerTo(Offset(x = 180f, y = 160f))
+      scale(1.2f)
+    }
+    waitForIdle()
+
+    assertTrue(fixture.zoomController.displayZoom > initialZoom)
+    assertEquals(NavigationEditorRoute, navigator.current)
+    assertEquals(
+      expected = 0f,
+      actual = onNodeWithTag(NavigationEditorTag).fetchSemanticsNode().boundsInRoot.left,
+      absoluteTolerance = 0.5f,
+    )
+  }
+
+  @Test
+  fun `platform indirect scale bridge uses the editor interaction owner`() = runComposeUiTest {
+    val fixture = Fixture()
+    setEditorContent(fixture)
+    val initialZoom = fixture.zoomController.displayZoom
+
+    runOnIdle {
+      assertTrue(fixture.platformIndirectScaleBridge.begin())
+      assertTrue(
+        fixture.platformIndirectScaleBridge.update(
+          focalInRootPx = Offset(x = 180f, y = 160f),
+          scaleFactor = 1.25f,
+        )
+      )
+      fixture.platformIndirectScaleBridge.end()
+    }
+
+    assertEquals(initialZoom * 1.25f, fixture.zoomController.displayZoom, 0.0001f)
+    assertEquals(fixture.zoomController.displayZoom, fixture.zoomController.renderZoom, 0.0001f)
+    assertEquals(EditorInteractionMode.Idle, fixture.controller.interactionMode)
+  }
+
+  @Test
+  fun `platform indirect scale reports accepted editor input`() = runComposeUiTest {
+    val fixture = Fixture()
+    var acceptedInputCount = 0
+    setEditorContent(fixture = fixture, onViewportIndirectInput = { acceptedInputCount += 1 })
+
+    runOnIdle {
+      assertTrue(fixture.platformIndirectScaleBridge.begin())
+      assertTrue(
+        fixture.platformIndirectScaleBridge.update(
+          focalInRootPx = Offset(x = 180f, y = 160f),
+          scaleFactor = 1.1f,
+        )
+      )
+      fixture.platformIndirectScaleBridge.end()
+    }
+
+    assertEquals(1, acceptedInputCount)
+  }
+
+  @Test
+  fun `platform indirect scale takes over a pending physical pan candidate`() = runComposeUiTest {
+    val fixture = Fixture()
+    setEditorContent(fixture)
+    val initialZoom = fixture.zoomController.displayZoom
+
+    onNodeWithTag(EditorTag).performTrackpadInput {
+      moveTo(Offset(x = 100f, y = 100f))
+      press()
+    }
+    waitForIdle()
+
+    runOnIdle {
+      assertTrue(fixture.platformIndirectScaleBridge.begin())
+      assertTrue(
+        fixture.platformIndirectScaleBridge.update(
+          focalInRootPx = Offset(x = 180f, y = 160f),
+          scaleFactor = 1.1f,
+        )
+      )
+      fixture.platformIndirectScaleBridge.end()
+    }
+
+    onNodeWithTag(EditorTag).performTrackpadInput { release() }
+    waitForIdle()
+    assertTrue(fixture.zoomController.displayZoom > initialZoom)
+    assertEquals(EditorInteractionMode.Idle, fixture.controller.interactionMode)
+    assertFalse(fixture.scrollGestureLockState.isLocked)
+  }
+
+  @Test
+  fun `platform indirect scale takes over a pressed tap`() = runComposeUiTest {
+    val fixture = Fixture(tapEligible = true)
+    setEditorContent(fixture)
+    val editor = onNodeWithTag(EditorTag)
+    val initialZoom = fixture.zoomController.displayZoom
+
+    editor.performMouseInput {
+      moveTo(center)
+      press()
+    }
+    waitForIdle()
+
+    runOnIdle {
+      assertTrue(fixture.platformIndirectScaleBridge.begin())
+      assertTrue(
+        fixture.platformIndirectScaleBridge.update(
+          focalInRootPx = Offset(x = 180f, y = 160f),
+          scaleFactor = 1.1f,
+        )
+      )
+      fixture.platformIndirectScaleBridge.end()
+    }
+
+    assertTrue(fixture.host.longPressDispatchCancelCount > 0)
+    assertTrue(fixture.zoomController.displayZoom > initialZoom)
+    editor.performMouseInput { release() }
+    waitForIdle()
+
+    assertEquals(EditorInteractionMode.Idle, fixture.controller.interactionMode)
+    assertFalse(fixture.scrollGestureLockState.isLocked)
+  }
+
+  @Test
+  fun `late mouse press joins an active platform indirect scale without starting long press`() =
+    runComposeUiTest {
+      val fixture = Fixture(tapEligible = true)
+      setEditorContent(fixture)
+      val editor = onNodeWithTag(EditorTag)
+      val initialZoom = fixture.zoomController.displayZoom
+
+      runOnIdle { assertTrue(fixture.platformIndirectScaleBridge.begin()) }
+      editor.performMouseInput {
+        moveTo(center)
+        press()
+      }
+      waitForIdle()
+
+      assertEquals(EditorInteractionMode.ViewportZooming, fixture.controller.interactionMode)
+      assertEquals(0, fixture.host.longPressDispatchScheduleCount)
+      runOnIdle {
+        assertTrue(
+          fixture.platformIndirectScaleBridge.update(
+            focalInRootPx = Offset(x = 180f, y = 160f),
+            scaleFactor = 1.1f,
+          )
+        )
+        fixture.platformIndirectScaleBridge.end()
+      }
+
+      assertTrue(fixture.zoomController.displayZoom > initialZoom)
+      editor.performMouseInput { release() }
+      waitForIdle()
+      assertEquals(EditorInteractionMode.Idle, fixture.controller.interactionMode)
+      assertFalse(fixture.scrollGestureLockState.isLocked)
+    }
+
+  @Test
+  fun `platform indirect scale cannot take over an active physical pan`() = runComposeUiTest {
+    val fixture = Fixture(tapEligible = true)
+    setEditorContent(fixture)
+    val editor = onNodeWithTag(EditorTag)
+    val initialZoom = fixture.zoomController.displayZoom
+
+    editor.performMouseInput {
+      moveTo(Offset(x = 100f, y = 100f))
+      press()
+      moveTo(Offset(x = 120f, y = 100f))
+    }
+    waitForIdle()
+    assertEquals(EditorInteractionMode.Panning, fixture.controller.interactionMode)
+    val panDeltaCountBeforeIndirectInput = fixture.touchPanDeltas.size
+
+    editor.performKeyInput { keyDown(Key.MetaLeft) }
+    editor.performMouseInput { scroll(Offset(x = 0f, y = -24f)) }
+    editor.performKeyInput { keyUp(Key.MetaLeft) }
+    editor.performTrackpadInput {
+      updatePointerTo(Offset(x = 120f, y = 100f))
+      pan(Offset(x = -40f, y = 60f))
+    }
+    assertEquals(EditorInteractionMode.Panning, fixture.controller.interactionMode)
+    assertEquals(panDeltaCountBeforeIndirectInput, fixture.touchPanDeltas.size)
+    runOnIdle { assertFalse(fixture.platformIndirectScaleBridge.begin()) }
+
+    editor.performMouseInput { release() }
+    waitForIdle()
+    assertEquals(initialZoom, fixture.zoomController.displayZoom, 0.0001f)
+    assertEquals(EditorInteractionMode.Idle, fixture.controller.interactionMode)
+    assertFalse(fixture.scrollGestureLockState.isLocked)
+  }
+
+  @Test
+  fun `foreign physical sequence cancels active platform indirect scale`() = runComposeUiTest {
+    val fixture = Fixture()
+    setEditorContent(fixture = fixture, editorWidth = 300.dp)
+
+    runOnIdle {
+      assertTrue(fixture.platformIndirectScaleBridge.begin())
+      assertTrue(
+        fixture.platformIndirectScaleBridge.update(
+          focalInRootPx = Offset(x = 180f, y = 160f),
+          scaleFactor = 1.1f,
+        )
+      )
+    }
+
+    onNodeWithTag(RootTag).performTouchInput {
+      down(pointerId = 0, position = Offset(x = 350f, y = 100f))
+    }
+
+    runOnIdle {
+      assertEquals(EditorInteractionMode.Idle, fixture.controller.interactionMode)
+      assertFalse(
+        fixture.platformIndirectScaleBridge.update(
+          focalInRootPx = Offset(x = 180f, y = 160f),
+          scaleFactor = 1.1f,
+        )
+      )
+    }
+
+    onNodeWithTag(RootTag).performTouchInput { up(pointerId = 0) }
+  }
+
+  @Test
+  fun `common trackpad pan event scrolls without moving navigation`() = runComposeUiTest {
+    val fixture = Fixture(scrollConsumer = { Offset.Zero })
+    val navigator = Navigator(Route.Home)
+    setNavigationEditorContent(fixture = fixture, navigator = navigator)
+
+    onNodeWithTag(NavigationEditorTag).performTrackpadInput {
+      updatePointerTo(Offset(x = 180f, y = 160f))
+      pan(Offset(x = -40f, y = 60f))
+    }
+    waitForIdle()
+
+    assertTrue(fixture.touchPanDeltas.isNotEmpty())
+    assertEquals(NavigationEditorRoute, navigator.current)
+    assertEquals(
+      expected = 0f,
+      actual = onNodeWithTag(NavigationEditorTag).fetchSemanticsNode().boundsInRoot.left,
+      absoluteTolerance = 0.5f,
+    )
+  }
+
+  @Test
+  fun `common trackpad pan event takes over a pending physical candidate`() = runComposeUiTest {
+    val fixture = Fixture(scrollConsumer = { Offset.Zero })
+    setEditorContent(fixture)
+    val editor = onNodeWithTag(EditorTag)
+
+    editor.performMouseInput {
+      moveTo(center)
+      press()
+    }
+    waitForIdle()
+    editor.performTrackpadInput {
+      updatePointerTo(center)
+      pan(Offset(x = -40f, y = 60f))
+    }
+    editor.performMouseInput { release() }
+    waitForIdle()
+
+    assertTrue(fixture.touchPanDeltas.isNotEmpty())
+    assertEquals(EditorInteractionMode.Idle, fixture.controller.interactionMode)
+    assertFalse(fixture.scrollGestureLockState.isLocked)
+  }
+
+  @Test
+  fun `modified physical click drag remains pan and never zooms`() = runComposeUiTest {
+    val fixture = Fixture()
+    setEditorContent(fixture)
+    val editor = onNodeWithTag(EditorTag)
+    val initialZoom = fixture.zoomController.displayZoom
+
+    editor.performKeyInput { keyDown(Key.MetaLeft) }
+    editor.performTrackpadInput {
+      moveTo(Offset(x = 100f, y = 100f))
+      press()
+      moveBy(Offset(x = 20f, y = 0f))
+      release()
+    }
+    editor.performKeyInput { keyUp(Key.MetaLeft) }
+    waitForIdle()
+
+    assertTrue(fixture.touchPanDeltas.isNotEmpty())
+    assertEquals(initialZoom, fixture.zoomController.displayZoom, 0.0001f)
+    assertEquals(initialZoom, fixture.zoomController.renderZoom, 0.0001f)
+    assertFalse(fixture.scrollGestureLockState.isLocked)
   }
 
   @Test
@@ -202,31 +664,33 @@ class EditorInteractionsDesktopTest {
   }
 
   @Test
-  fun `pointer signal scroll does not interrupt a pressed pointer sequence`() = runComposeUiTest {
-    val fixture = Fixture(scrollConsumer = { Offset.Zero })
-    val navigator = Navigator(Route.Home)
-    setNavigationEditorContent(fixture = fixture, navigator = navigator)
+  fun `pointer signal scroll takes over a pending pointer without moving navigation`() =
+    runComposeUiTest {
+      val fixture = Fixture(scrollConsumer = { Offset.Zero })
+      val navigator = Navigator(Route.Home)
+      setNavigationEditorContent(fixture = fixture, navigator = navigator)
 
-    onNodeWithTag(NavigationEditorTag).performMouseInput {
-      moveTo(Offset(x = 80f, y = center.y))
-      press()
-    }
-    waitForIdle()
-    listOf(-120f, -80f, -40f, -20f).forEach { deltaX ->
-      onNodeWithTag(NavigationEditorTag).performMouseInput { scroll(Offset(x = deltaX, y = 0f)) }
+      onNodeWithTag(NavigationEditorTag).performMouseInput {
+        moveTo(Offset(x = 80f, y = center.y))
+        press()
+      }
       waitForIdle()
-    }
-    onNodeWithTag(NavigationEditorTag).performMouseInput { release() }
-    waitForIdle()
+      listOf(-120f, -80f, -40f, -20f).forEach { deltaX ->
+        onNodeWithTag(NavigationEditorTag).performMouseInput { scroll(Offset(x = deltaX, y = 0f)) }
+        waitForIdle()
+      }
+      onNodeWithTag(NavigationEditorTag).performMouseInput { release() }
+      waitForIdle()
 
-    assertTrue(fixture.touchPanDeltas.isEmpty())
-    assertEquals(NavigationEditorRoute, navigator.current)
-    assertEquals(
-      expected = 0f,
-      actual = onNodeWithTag(NavigationEditorTag).fetchSemanticsNode().boundsInRoot.left,
-      absoluteTolerance = 0.5f,
-    )
-  }
+      assertTrue(fixture.touchPanDeltas.any { delta -> delta.x > 0f })
+      assertEquals(NavigationEditorRoute, navigator.current)
+      assertEquals(
+        expected = 0f,
+        actual = onNodeWithTag(NavigationEditorTag).fetchSemanticsNode().boundsInRoot.left,
+        absoluteTolerance = 0.5f,
+      )
+      assertFalse(fixture.scrollGestureLockState.isLocked)
+    }
 
   @Test
   fun `accessibility scroll does not move navigation route`() = runComposeUiTest {
@@ -1073,6 +1537,8 @@ class EditorInteractionsDesktopTest {
     fixture: Fixture,
     includeInteractionBoundary: () -> Boolean = { true },
     editorWidth: androidx.compose.ui.unit.Dp = 400.dp,
+    consumeIndirectInputAtChild: Boolean = false,
+    onViewportIndirectInput: () -> Unit = {},
     onCoroutineScope: (CoroutineScope) -> Unit = {},
   ) {
     setContent {
@@ -1095,17 +1561,40 @@ class EditorInteractionsDesktopTest {
                   interactionController = fixture.controller,
                   geometry = fixture.host,
                   screenPointerSequence = screenPointerSequence,
+                  platformIndirectScaleBridge = fixture.platformIndirectScaleBridge,
+                  scrollGestureLockState = fixture.scrollGestureLockState,
                   scrollableState = fixture.scrollableState,
                   nestedScrollDispatcher = nestedScrollDispatcher,
                   flingBehavior = fixture.flingBehavior,
                   touchSlop = 8f,
                   density = 1f,
+                  onViewportIndirectInput = onViewportIndirectInput,
                 )
               } else {
                 Modifier
               }
             )
-        )
+        ) {
+          if (consumeIndirectInputAtChild) {
+            Box(
+              Modifier.fillMaxSize().pointerInput(Unit) {
+                awaitPointerEventScope {
+                  while (true) {
+                    val event = awaitPointerEvent(PointerEventPass.Main)
+                    if (
+                      event.type == PointerEventType.Scroll ||
+                        event.type == PointerEventType.ScaleStart ||
+                        event.type == PointerEventType.ScaleChange ||
+                        event.type == PointerEventType.ScaleEnd
+                    ) {
+                      event.changes.forEach { change -> change.consume() }
+                    }
+                  }
+                }
+              }
+            )
+          }
+        }
         if (editorWidth < 400.dp) {
           Box(
             Modifier.align(androidx.compose.ui.Alignment.TopEnd).size(400.dp - editorWidth, 400.dp)
@@ -1141,6 +1630,8 @@ class EditorInteractionsDesktopTest {
                   interactionController = fixture.controller,
                   geometry = fixture.host,
                   screenPointerSequence = screenPointerSequence,
+                  platformIndirectScaleBridge = fixture.platformIndirectScaleBridge,
+                  scrollGestureLockState = fixture.scrollGestureLockState,
                   scrollableState = fixture.scrollableState,
                   nestedScrollDispatcher = nestedScrollDispatcher,
                   flingBehavior = fixture.flingBehavior,
@@ -1165,6 +1656,7 @@ class EditorInteractionsDesktopTest {
     editorBoundsInRoot: Rect = Rect(left = 0f, top = 0f, right = 400f, bottom = 400f),
     pageSize: PageSize = PageSize(width = 720f, height = 960f),
     flingBehaviorOverride: FlingBehavior? = null,
+    tapEligible: Boolean = false,
   ) {
     val touchPanDeltas = mutableListOf<Offset>()
     val flingPanDeltas = mutableListOf<Offset>()
@@ -1233,14 +1725,17 @@ class EditorInteractionsDesktopTest {
         pageMarginRight = 0f,
       )
     private val pageSizes = listOf(pageSize)
-    private val zoomController = EditorZoomController()
+    val zoomController = EditorZoomController()
+    val platformIndirectScaleBridge = EditorPlatformIndirectScaleBridge()
+    val scrollGestureLockState = ScrollGestureLockState()
     private val uiState =
       EditorUiState().apply {
         updateDisplayZoom(1f)
         updatePageOffset(page = 0, offset = Offset.Zero)
         updateEditorBounds(boundsInRoot = editorBoundsInRoot, density = 1f)
       }
-    val host = TestHost()
+    val host = TestHost(tapEligible = tapEligible)
+    private val editor = Editor(FakeFfiEditor(), CoroutineScope(Job()), Dispatchers.Unconfined)
     private val semantics =
       EditorInteractionSemantics(effects = host).apply {
         zoomController.syncLayout(layoutSpec = layoutSpec, viewportWidth = 400f)
@@ -1259,7 +1754,7 @@ class EditorInteractionsDesktopTest {
       }
     val controller =
       EditorInteractionController(
-        editorProvider = { error("Pinch routing must not access the editor") },
+        editorProvider = { editor },
         effects = host,
         geometry = host,
         semantics = semantics,
@@ -1267,14 +1762,21 @@ class EditorInteractionsDesktopTest {
       )
   }
 
-  private class TestHost : EditorInteractionEffects, EditorInteractionGeometry {
+  private class TestHost(private val tapEligible: Boolean) :
+    EditorInteractionEffects, EditorInteractionGeometry {
     var pointerStreamCancelCount = 0
+    var tapDispatchScheduleCount = 0
+    var longPressDispatchScheduleCount = 0
+    var longPressDispatchCancelCount = 0
 
     override val density: Float = 1f
 
-    override fun resolveInteractionPosition(positionInSurface: Offset): Offset? = null
+    override fun resolveInteractionPosition(positionInSurface: Offset): Offset? =
+      positionInSurface.takeIf {
+        tapEligible
+      }
 
-    override fun isTapEligible(positionInSurface: Offset): Boolean = false
+    override fun isTapEligible(positionInSurface: Offset): Boolean = tapEligible
 
     override fun resolvePoint(positionInNode: Offset): PagePoint? = null
 
@@ -1284,7 +1786,9 @@ class EditorInteractionsDesktopTest {
 
     override fun dispatchEdgeAutoScroll(delta: Offset): Offset = Offset.Zero
 
-    override fun scheduleTapDispatch(dispatchAtMillis: Long) = Unit
+    override fun scheduleTapDispatch(dispatchAtMillis: Long) {
+      tapDispatchScheduleCount += 1
+    }
 
     override fun cancelTapDispatch() {
       pointerStreamCancelCount += 1
@@ -1294,9 +1798,13 @@ class EditorInteractionsDesktopTest {
       pointerId: Long,
       position: Offset,
       dispatchAtMillis: Long,
-    ) = Unit
+    ) {
+      longPressDispatchScheduleCount += 1
+    }
 
-    override fun cancelLongPressDispatch() = Unit
+    override fun cancelLongPressDispatch() {
+      longPressDispatchCancelCount += 1
+    }
 
     override fun launchInteraction(block: suspend () -> Unit) = Unit
 

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ext/DesktopScrollTranslationTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ext/DesktopScrollTranslationTest.kt
@@ -97,6 +97,55 @@ class DesktopScrollTranslationTest {
       SwingUtilities.invokeAndWait { window.dispose() }
     }
   }
+
+  @Test
+  fun editorOwnedMouseDragDoesNotDispatchSyntheticScrollOrFling() {
+    val target = WheelEventRecorder()
+    lateinit var window: ComposeWindow
+    lateinit var handler: Any
+    var locked = false
+
+    SwingUtilities.invokeAndWait {
+      window = ComposeWindow()
+      handler = createDragToScrollHandler(window) { locked }
+      val mouseListener = handler.field<MouseListener>("mouseListener")
+
+      val modifiedButtonMask = InputEvent.BUTTON1_DOWN_MASK or InputEvent.CTRL_DOWN_MASK
+      mouseListener.mousePressed(
+        mouseEvent(target, MouseEvent.MOUSE_PRESSED, x = 0, y = 100, modifiers = modifiedButtonMask)
+      )
+      locked = true
+      handler
+        .field<MouseMotionListener>("motionListener")
+        .mouseDragged(
+          mouseEvent(
+            target,
+            MouseEvent.MOUSE_DRAGGED,
+            x = 40,
+            y = 130,
+            modifiers = modifiedButtonMask,
+          )
+        )
+      mouseListener.mouseReleased(
+        mouseEvent(
+          target,
+          MouseEvent.MOUSE_RELEASED,
+          x = 40,
+          y = 130,
+          modifiers = modifiedButtonMask,
+        )
+      )
+      locked = false
+    }
+    SwingUtilities.invokeAndWait {}
+
+    try {
+      assertEquals(0, target.wheelEvents.size)
+      assertEquals(null, handler.field<Timer?>("flingTimer"))
+    } finally {
+      SwingUtilities.invokeAndWait { window.dispose() }
+    }
+  }
 }
 
 private fun assertDiagonalWheelEvents(target: WheelEventRecorder) {
@@ -111,11 +160,14 @@ private fun assertDiagonalWheelEvents(target: WheelEventRecorder) {
   assertEquals(-7.5, vertical.preciseWheelRotation)
 }
 
-private fun createDragToScrollHandler(window: ComposeWindow): Any {
+private fun createDragToScrollHandler(
+  window: ComposeWindow,
+  isScrollGestureLocked: () -> Boolean = { false },
+): Any {
   val handlerClass = Class.forName("co.typie.ext.DragToScrollHandler")
   return handlerClass.declaredConstructors.single().run {
     isAccessible = true
-    newInstance(window, 1.0, { false })
+    newInstance(window, 1.0, isScrollGestureLocked)
   }
 }
 
@@ -137,15 +189,11 @@ private class WheelEventRecorder : Component() {
   }
 }
 
-private fun mouseEvent(target: Component, id: Int, x: Int, y: Int): MouseEvent =
-  MouseEvent(
-    target,
-    id,
-    System.currentTimeMillis(),
-    InputEvent.BUTTON1_DOWN_MASK,
-    x,
-    y,
-    1,
-    false,
-    MouseEvent.BUTTON1,
-  )
+private fun mouseEvent(
+  target: Component,
+  id: Int,
+  x: Int,
+  y: Int,
+  modifiers: Int = InputEvent.BUTTON1_DOWN_MASK,
+): MouseEvent =
+  MouseEvent(target, id, System.currentTimeMillis(), modifiers, x, y, 1, false, MouseEvent.BUTTON1)

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayoutDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayoutDesktopTest.kt
@@ -366,9 +366,13 @@ class EditorScreenLayoutDesktopTest {
     }
     waitForIdle()
 
+    // NavigationStack supplies this root pointer membership in production. This isolated layout
+    // test provides the same admission state before exercising the nested-scroll connection.
+    navigationPopNestedScroll.updatePressedDragPointerCount(count = 1, downInSystemBackZone = false)
     onNodeWithTag(LayoutTag).performTouchInput {
       swipe(start = center, end = Offset(x = center.x + 120f, y = center.y))
     }
+    navigationPopNestedScroll.updatePressedDragPointerCount(count = 0, downInSystemBackZone = false)
     waitForIdle()
 
     assertTrue(navigationDragCount > 0)

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorDocumentManipulationDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorDocumentManipulationDesktopTest.kt
@@ -55,6 +55,7 @@ import co.typie.editor.ffi.TableOverlayColumn
 import co.typie.editor.ffi.TableOverlayRow
 import co.typie.editor.interaction.EditorInteractionMode
 import co.typie.editor.interaction.EditorInteractionScope
+import co.typie.editor.interaction.EditorPlatformIndirectScaleBridge
 import co.typie.editor.interaction.EditorScreenPointerSequence
 import co.typie.editor.interaction.LocalEditorInteractionScope
 import co.typie.editor.interaction.editorInteractions
@@ -595,7 +596,7 @@ class EditorDocumentManipulationDesktopTest {
           eventType = PointerEventType.Scroll,
           position = Offset(x = 42f, y = 30f),
           scrollDelta = Offset(x = 0f, y = -12f),
-          keyboardModifiers = PointerKeyboardModifiers(isCtrlPressed = true),
+          keyboardModifiers = PointerKeyboardModifiers(isMetaPressed = true),
         )
       }
       waitForIdle()
@@ -1179,6 +1180,8 @@ class EditorDocumentManipulationDesktopTest {
                 interactionController = interactionScope.controller,
                 geometry = interactionScope,
                 screenPointerSequence = screenPointerSequence,
+                platformIndirectScaleBridge = remember { EditorPlatformIndirectScaleBridge() },
+                scrollGestureLockState = scrollGestureLockState,
                 scrollableState = scrollableState,
                 nestedScrollDispatcher = nestedScrollDispatcher,
                 touchSlop = 8f,

--- a/apps/mobile/compose/src/iosMain/kotlin/co/typie/editor/interaction/EditorPlatformIndirectScale.ios.kt
+++ b/apps/mobile/compose/src/iosMain/kotlin/co/typie/editor/interaction/EditorPlatformIndirectScale.ios.kt
@@ -1,0 +1,55 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package co.typie.editor.interaction
+
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
+import androidx.compose.ui.input.pointer.isMetaPressed
+import androidx.compose.ui.layout.boundsInRoot
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.uikit.LocalUIViewController
+import kotlinx.cinterop.ExperimentalForeignApi
+import swiftPMImport.co.typie.compose.EditorIndirectScaleGestureBridge
+
+internal actual fun Modifier.editorPlatformIndirectScale(
+  bridge: EditorPlatformIndirectScaleBridge,
+  enabled: Boolean,
+  density: Float,
+): Modifier = composed {
+  val view = LocalUIViewController.current.view
+  val gestureBridge = remember(view) { EditorIndirectScaleGestureBridge(view = view) }
+  var boundsInRoot by remember { mutableStateOf(Rect.Zero) }
+
+  SideEffect {
+    gestureBridge.onShouldBegin = { x, y ->
+      if (!enabled || density <= 0f) {
+        false
+      } else {
+        boundsInRoot.contains(Offset(x.toFloat() * density, y.toFloat() * density))
+      }
+    }
+    gestureBridge.onBegin = bridge::begin
+    gestureBridge.onScale = { x, y, scaleFactor ->
+      bridge.update(Offset(x.toFloat() * density, y.toFloat() * density), scaleFactor.toFloat())
+    }
+    gestureBridge.onEnd = bridge::end
+    if (!enabled) {
+      gestureBridge.endActive()
+    }
+  }
+  DisposableEffect(gestureBridge) { onDispose { gestureBridge.dispose() } }
+
+  onGloballyPositioned { coordinates -> boundsInRoot = coordinates.boundsInRoot() }
+}
+
+internal actual fun PointerKeyboardModifiers.isEditorIndirectZoomModifierPressed(): Boolean =
+  isMetaPressed

--- a/apps/mobile/ios/Bridge/Sources/Bridge/EditorIndirectScaleGestureBridge.swift
+++ b/apps/mobile/ios/Bridge/Sources/Bridge/EditorIndirectScaleGestureBridge.swift
@@ -1,0 +1,96 @@
+import UIKit
+
+/// Workaround for https://youtrack.jetbrains.com/issue/CMP-9895.
+///
+/// Compose Multiplatform 1.11.1 does not translate iOS indirect pinch input from `UIEvent`
+/// into its common scale pointer events. This bridge recognizes only UIKit zero-touch pinches
+/// and forwards them to the editor's shared zoom semantic. Remove it when Compose provides that
+/// event path.
+@MainActor @objcMembers public final class EditorIndirectScaleGestureBridge: NSObject,
+  UIGestureRecognizerDelegate
+{
+  public var onShouldBegin: ((Double, Double) -> Bool)?
+  public var onBegin: (() -> Bool)?
+  public var onScale: ((Double, Double, Double) -> Bool)?
+  public var onEnd: (() -> Void)?
+
+  private weak var view: UIView?
+  private var recognizer: UIPinchGestureRecognizer!
+  private var active = false
+
+  public init(view: UIView) {
+    self.view = view
+    super.init()
+
+    recognizer = UIPinchGestureRecognizer(target: self, action: #selector(handlePinch(_:)))
+    recognizer.cancelsTouchesInView = false
+    recognizer.delaysTouchesBegan = false
+    recognizer.delaysTouchesEnded = false
+    recognizer.delegate = self
+    view.addGestureRecognizer(recognizer)
+  }
+
+  public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+    guard
+      gestureRecognizer === recognizer,
+      recognizer.numberOfTouches == 0,
+      let view
+    else {
+      return false
+    }
+    let focal = recognizer.location(in: view)
+    return onShouldBegin?(focal.x, focal.y) ?? false
+  }
+
+  public func gestureRecognizer(
+    _ gestureRecognizer: UIGestureRecognizer,
+    shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+  ) -> Bool {
+    true
+  }
+
+  public func endActive() {
+    guard active else {
+      return
+    }
+    active = false
+    onEnd?()
+  }
+
+  public func dispose() {
+    endActive()
+    recognizer.delegate = nil
+    view?.removeGestureRecognizer(recognizer)
+    onShouldBegin = nil
+    onBegin = nil
+    onScale = nil
+    onEnd = nil
+  }
+
+  @objc private func handlePinch(_ recognizer: UIPinchGestureRecognizer) {
+    guard let view else {
+      endActive()
+      return
+    }
+
+    switch recognizer.state {
+    case .began:
+      active = recognizer.numberOfTouches == 0 && (onBegin?() ?? false)
+      recognizer.scale = 1
+    case .changed:
+      guard active else {
+        return
+      }
+      let focal = recognizer.location(in: view)
+      let scaleFactor = recognizer.scale
+      recognizer.scale = 1
+      if !(onScale?(focal.x, focal.y, scaleFactor) ?? false) {
+        endActive()
+      }
+    case .ended, .cancelled, .failed:
+      endActive()
+    default:
+      break
+    }
+  }
+}


### PR DESCRIPTION
trackpad가 연결된 환경에서 trackpad pinch와 modifier+scroll을 editor zoom 입력으로 처리하고, physical click-drag와 간접 포인터 입력이 서로의 gesture를 방해하던 문제 수정 (jvm desktop에서의 native pinch는 따로 지원하지 않음)

- Cmd/Ctrl+trackpad/wheel scroll을 editor zoom으로 처리
    - macOS Desktop과 iOS에서는 Cmd, Android와 그 외 Desktop에서는 Ctrl을 zoom modifier로 사용
- 아직 시작되지 않은 tap, long press, pan 후보와 간접 포인터 입력이 겹치면 Scroll/Pan/Scale이 해당 sequence를 이어받도록 처리
    - Cmd+scroll이나 pinch가 cursor 이동과 magnifier를 시작하지 않음
    - Cmd+scroll 직후 별도의 tap 없이 이어지는 pinch도 정상적으로 zoom
    - 이미 시작된 physical pan이나 document gesture는 간접 입력에 빼앗기지 않음
- platform별 native scale 입력을 공통 editor interaction owner에 연결
    - iOS에서는 physical touch가 없는 trackpad pinch를 연결
    - Compose가 제공하는 Scale/Pan event는 공통 pointer boundary에서 처리
- context menu가 열린 상태에서 간접 포인터 입력이 시작되면 menu를 닫고 viewport 입력을 처리