### PR TITLE
앱 에디터 double tap drag가 종종 pan scroll로 인식되는 문제 수정

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionGestures.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionGestures.kt
@@ -26,7 +26,8 @@ import co.typie.editor.interaction.sessions.EditorDoubleTapDragSession
 
 internal class EditorInteractionGestures(
   contextProvider: () -> EditorGestureContext,
-  private val tap: EditorTapGesture = EditorTapGesture(tapSlopPx = 0f),
+  private val tap: EditorTapGesture =
+    EditorTapGesture(tapSlopPx = 0f, densityProvider = { contextProvider().geometry.density }),
   private val doubleTapDrag: EditorDoubleTapDragSession = EditorDoubleTapDragSession(),
   private val longPress: EditorLongPressGesture = EditorLongPressGesture(),
   private val pan: EditorPanGesture = EditorPanGesture(),
@@ -142,18 +143,18 @@ internal class EditorInteractionGestures(
           placement = columnResizePlacement,
           context = context,
         )
-    if (
+    when {
+      doubleTapDrag.active -> pan.cancel(context = context)
       columnResizePlacement == null &&
         !tableHandleHit &&
         selectionHandleType == null &&
-        touchPanDriver != null
-    ) {
-      pan.prepareFresh(
-        pointerId = pointerId,
-        position = positionInRoot,
-        nowMillis = nowMillis,
-        driver = touchPanDriver,
-      )
+        touchPanDriver != null ->
+        pan.prepareFresh(
+          pointerId = pointerId,
+          position = positionInRoot,
+          nowMillis = nowMillis,
+          driver = touchPanDriver,
+        )
     }
     if (
       tapEnabled &&
@@ -181,6 +182,11 @@ internal class EditorInteractionGestures(
     consumed: Boolean = false,
     context: EditorGestureContext,
   ): Boolean {
+    if (doubleTapDrag.active) {
+      val position = positionInEditor ?: return true
+      trackTapPointerMove(pointerId = pointerId, position = position, context = context)
+      return doubleTapDrag.handlePointerMove(position = position, tap = tap, context = context)
+    }
     if (positionInEditor == null) {
       val panConsumed =
         pan.update(
@@ -202,12 +208,7 @@ internal class EditorInteractionGestures(
       return longPress.update(position = position, context = context)
     }
 
-    val movedPastTapSlop =
-      tap.trackPointerMove(pointerId = pointerId, position = position, context = context)
-    if (movedPastTapSlop) {
-      longPress.cancelPending(pointerId = pointerId)
-      context.effects.cancelLongPressDispatch()
-    }
+    trackTapPointerMove(pointerId = pointerId, position = position, context = context)
     if (tableColumnResize.pending || tableColumnResize.active) {
       val wasActive = tableColumnResize.active
       val handled =
@@ -265,7 +266,7 @@ internal class EditorInteractionGestures(
       cancelTapAndLongPress(context = context)
       return true
     }
-    return doubleTapDrag.handlePointerMove(position = position, tap = tap, context = context)
+    return false
   }
 
   fun handlePointerUp(
@@ -544,6 +545,17 @@ internal class EditorInteractionGestures(
     doubleTapDrag.resetPointerOwnedState(context = context)
     if (tap.cancelActivePointerStream()) {
       context.effects.enqueuePointerCancel()
+    }
+  }
+
+  private fun trackTapPointerMove(
+    pointerId: Long,
+    position: Offset,
+    context: EditorGestureContext,
+  ) {
+    if (tap.trackPointerMove(pointerId = pointerId, position = position, context = context)) {
+      longPress.cancelPending(pointerId = pointerId)
+      context.effects.cancelLongPressDispatch()
     }
   }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorTapGesture.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorTapGesture.kt
@@ -22,12 +22,12 @@ internal const val EditorTapDispatchDelayMillis =
   EditorTapDownDelayMillis + EditorTapTimerDelayMillis
 
 private const val ConsecutiveTapMaxIntervalMillis = 300L
-private const val ConsecutiveTapMaxDistancePx = 20f
+private const val ConsecutiveTapMaxDistanceDp = 20f
 
 internal class EditorTapGesture(
   private var tapSlopPx: Float,
+  private val densityProvider: () -> Float,
   private val consecutiveTapMaxIntervalMillis: Long = ConsecutiveTapMaxIntervalMillis,
-  private val consecutiveTapMaxDistancePx: Float = ConsecutiveTapMaxDistancePx,
 ) {
   private var activePointerId: Long? = null
   private var downPosition = Offset.Zero
@@ -165,7 +165,7 @@ internal class EditorTapGesture(
     val previousTime = lastTapTimeMillis ?: return false
     val previousPosition = lastTapPosition ?: return false
     return nowMillis - previousTime < consecutiveTapMaxIntervalMillis &&
-      (position - previousPosition).getDistance() < consecutiveTapMaxDistancePx
+      (position - previousPosition).getDistance() < ConsecutiveTapMaxDistanceDp * densityProvider()
   }
 }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/sessions/EditorDoubleTapDragSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/sessions/EditorDoubleTapDragSession.kt
@@ -10,12 +10,13 @@ import co.typie.editor.interaction.gestures.EditorTapGesture
 import co.typie.editor.interaction.isViewportZooming
 import co.typie.editor.interaction.semantics.dispatchSelectionExtension
 
-private const val EditorDoubleTapDragStartThresholdPx = 4f
+private const val EditorDoubleTapDragStartThresholdDp = 4f
 
 internal class EditorDoubleTapDragSession {
   private var phase = EditorDoubleTapDragPhase.Idle
   private var pendingSelectionExtensionPosition: Offset? = null
   private var startPosition: Offset? = null
+  private var startThresholdPx = 0f
 
   val active: Boolean
     get() = phase != EditorDoubleTapDragPhase.Idle
@@ -41,6 +42,7 @@ internal class EditorDoubleTapDragSession {
     context.uiState.contextMenu.hide()
     context.effects.setScrollGestureLocked(true)
     startPosition = position
+    startThresholdPx = EditorDoubleTapDragStartThresholdDp * context.geometry.density
     phase = EditorDoubleTapDragPhase.Pending
     return true
   }
@@ -121,8 +123,7 @@ internal class EditorDoubleTapDragSession {
 
   private fun canStart(position: Offset): Boolean {
     val startPosition = startPosition ?: return false
-    return pending &&
-      (position - startPosition).getDistance() >= EditorDoubleTapDragStartThresholdPx
+    return pending && (position - startPosition).getDistance() >= startThresholdPx
   }
 
   private fun start(tap: EditorTapGesture, context: EditorGestureContext): Boolean {
@@ -154,6 +155,7 @@ internal class EditorDoubleTapDragSession {
   private fun stop(): Boolean {
     val wasActive = active
     startPosition = null
+    startThresholdPx = 0f
     phase = EditorDoubleTapDragPhase.Idle
     return wasActive
   }
@@ -162,8 +164,7 @@ internal class EditorDoubleTapDragSession {
     if (
       context.mode.isViewportZooming ||
         !dragging ||
-        (startPosition != null &&
-          (position - startPosition!!).getDistance() < EditorDoubleTapDragStartThresholdPx)
+        (startPosition != null && (position - startPosition!!).getDistance() < startThresholdPx)
     ) {
       return false
     }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
@@ -880,6 +880,75 @@ class EditorInteractionControllerTest {
     }
 
   @Test
+  fun `consecutive tap distance scales with density`() =
+    runTest(StandardTestDispatcher()) {
+      val editor = Editor(FakeFfiEditor(), this, StandardTestDispatcher(testScheduler))
+      editor.sync {}
+      val host = TestHost(this)
+      host.density = 2f
+      val controller =
+        EditorInteractionController(
+          editorProvider = { editor },
+          effects = host,
+          geometry = host,
+          uiStateProvider = { host.uiState },
+        )
+      controller.updateTapSlop(16f)
+      val firstTap = Offset(10f, 20f)
+      val secondTap = Offset(40f, 20f)
+
+      controller.onPointerDown(pointerId = 1L, position = firstTap, nowMillis = 0L)
+      controller.onPointerUp(pointerId = 1L, position = firstTap, nowMillis = 40L)
+      advanceUntilIdle()
+
+      assertTrue(controller.onPointerDown(pointerId = 2L, position = secondTap, nowMillis = 120L))
+      assertTrue(host.scrollGestureLockActive)
+    }
+
+  @Test
+  fun `double tap drag threshold scales with density`() =
+    runTest(StandardTestDispatcher()) {
+      val editor = Editor(FakeFfiEditor(), this, StandardTestDispatcher(testScheduler))
+      editor.sync {}
+      val host = TestHost(this)
+      host.density = 2f
+      val controller =
+        EditorInteractionController(
+          editorProvider = { editor },
+          effects = host,
+          geometry = host,
+          uiStateProvider = { host.uiState },
+        )
+      controller.updateTapSlop(16f)
+      val start = Offset(10f, 20f)
+
+      controller.onPointerDown(pointerId = 1L, position = start, nowMillis = 0L)
+      controller.onPointerUp(pointerId = 1L, position = start, nowMillis = 40L)
+      advanceUntilIdle()
+
+      assertTrue(controller.onPointerDown(pointerId = 2L, position = start, nowMillis = 120L))
+      advanceUntilIdle()
+
+      assertTrue(
+        controller.onPointerMove(
+          pointerId = 2L,
+          position = start + Offset(5f, 0f),
+          nowMillis = 140L,
+        )
+      )
+      assertEquals(EditorInteractionMode.Idle, controller.interactionMode)
+
+      assertTrue(
+        controller.onPointerMove(
+          pointerId = 2L,
+          position = start + Offset(9f, 0f),
+          nowMillis = 160L,
+        )
+      )
+      assertEquals(EditorInteractionMode.DoubleTapSelecting, controller.interactionMode)
+    }
+
+  @Test
   fun `double tap drag extends selection directly from controller workflow`() =
     runTest(StandardTestDispatcher()) {
       val selection =
@@ -2259,18 +2328,14 @@ class EditorInteractionControllerTest {
     onPointerUp(pointerId = SelectionHandleTestPointerId, position = Offset.Zero, nowMillis = 32L)
 
   @Test
-  fun `pending double tap drag locks scroll gesture until pointer up`() =
+  fun `pending double tap drag owns pointer sequence over pan until pointer up`() =
     runTest(StandardTestDispatcher()) {
       val selection =
         Selection(
           anchor = Position("text", 0, Affinity.Downstream),
           head = Position("text", 5, Affinity.Downstream),
         )
-      val fake =
-        FakeFfiEditor(
-          selectionProvider = { selection },
-          selectionEndpointsProvider = { selectionEndpoints() },
-        )
+      val fake = FakeFfiEditor(selectionProvider = { selection })
       val editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
       editor.sync {}
       val host = TestHost(this)
@@ -2282,22 +2347,53 @@ class EditorInteractionControllerTest {
           uiStateProvider = { host.uiState },
         )
       controller.updateTapSlop(8f)
+      val driver = TestPanGestureDriver(shouldCatchTouch = false)
       val start = Offset(10f, 20f)
 
-      controller.onPointerDown(pointerId = 1L, position = start, nowMillis = 0L)
-      controller.onPointerUp(pointerId = 1L, position = start, nowMillis = 40L)
+      controller.onPointerDown(
+        pointerId = 1L,
+        position = start,
+        positionInRoot = start,
+        nowMillis = 0L,
+        touchPanDriver = driver,
+      )
+      controller.onPointerUp(
+        pointerId = 1L,
+        position = start,
+        positionInRoot = start,
+        nowMillis = 40L,
+      )
       advanceUntilIdle()
 
-      controller.onPointerDown(pointerId = 2L, position = start, nowMillis = 120L)
+      controller.onPointerDown(
+        pointerId = 2L,
+        position = start,
+        positionInRoot = start,
+        nowMillis = 120L,
+        touchPanDriver = driver,
+      )
       advanceUntilIdle()
 
       assertTrue(host.scrollGestureLockActive)
 
-      controller.onPointerMove(pointerId = 2L, position = start + Offset(8f, 0f), nowMillis = 140L)
+      val moved = start + Offset(20f, 0f)
+      controller.onPointerMove(
+        pointerId = 2L,
+        position = moved,
+        positionInRoot = moved,
+        nowMillis = 140L,
+      )
 
+      assertEquals(0, driver.startCount)
+      assertEquals(EditorInteractionMode.DoubleTapSelecting, controller.interactionMode)
       assertTrue(host.scrollGestureLockActive)
 
-      controller.onPointerUp(pointerId = 2L, position = start + Offset(8f, 0f), nowMillis = 160L)
+      controller.onPointerUp(
+        pointerId = 2L,
+        position = moved,
+        positionInRoot = moved,
+        nowMillis = 160L,
+      )
       advanceUntilIdle()
 
       assertFalse(host.scrollGestureLockActive)

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/gestures/EditorTapGestureTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/gestures/EditorTapGestureTest.kt
@@ -15,7 +15,7 @@ class EditorTapGestureTest {
 
   @Test
   fun `tap timer can dispatch a primary click once`() {
-    val gesture = EditorTapGesture(tapSlopPx = 8f)
+    val gesture = createTapGesture()
 
     gesture.startPendingTap(pointerId = 1L, position = Offset(10f, 20f))
 
@@ -27,7 +27,7 @@ class EditorTapGestureTest {
 
   @Test
   fun `tap timer selection hit consumes pending tap without advancing click count`() {
-    val gesture = EditorTapGesture(tapSlopPx = 8f)
+    val gesture = createTapGesture()
 
     gesture.startPendingTap(pointerId = 1L, position = Offset.Zero)
     gesture.markTapDispatched()
@@ -41,7 +41,7 @@ class EditorTapGestureTest {
 
   @Test
   fun `tap timer range selection keeps tap available for pointer up dispatch`() {
-    val gesture = EditorTapGesture(tapSlopPx = 8f)
+    val gesture = createTapGesture()
 
     gesture.startPendingTap(pointerId = 1L, position = Offset.Zero)
 
@@ -51,7 +51,7 @@ class EditorTapGestureTest {
 
   @Test
   fun `consecutive tap inside configured window dispatches count two`() {
-    val gesture = EditorTapGesture(tapSlopPx = 8f)
+    val gesture = createTapGesture()
 
     gesture.startPendingTap(pointerId = 1L, position = Offset(10f, 20f))
     val firstClick =
@@ -64,7 +64,7 @@ class EditorTapGestureTest {
 
   @Test
   fun `double tap clears tap history so third tap dispatches count one`() {
-    val gesture = EditorTapGesture(tapSlopPx = 8f)
+    val gesture = createTapGesture()
 
     gesture.recordTap(nowMillis = 40L, position = Offset(10f, 20f), clickCount = 1)
     gesture.recordTap(nowMillis = 240L, position = Offset(18f, 26f), clickCount = 2)
@@ -79,7 +79,7 @@ class EditorTapGestureTest {
 
   @Test
   fun `consecutive taps after double tap can form a new double tap`() {
-    val gesture = EditorTapGesture(tapSlopPx = 8f)
+    val gesture = createTapGesture()
 
     gesture.recordTap(nowMillis = 40L, position = Offset(10f, 20f), clickCount = 1)
     gesture.recordTap(nowMillis = 240L, position = Offset(18f, 26f), clickCount = 2)
@@ -90,7 +90,7 @@ class EditorTapGestureTest {
 
   @Test
   fun `tap outside configured window resets click count`() {
-    val gesture = EditorTapGesture(tapSlopPx = 8f)
+    val gesture = createTapGesture()
 
     gesture.recordTap(nowMillis = 40L, position = Offset(10f, 20f), clickCount = 1)
 
@@ -104,7 +104,7 @@ class EditorTapGestureTest {
 
   @Test
   fun `moving inside tap slop keeps pending tap dispatch`() {
-    val gesture = EditorTapGesture(tapSlopPx = 8f)
+    val gesture = createTapGesture()
 
     gesture.startPendingTap(pointerId = 1L, position = Offset.Zero)
 
@@ -117,7 +117,7 @@ class EditorTapGestureTest {
 
   @Test
   fun `moving beyond tap slop cancels pending tap without starting selection drag`() {
-    val gesture = EditorTapGesture(tapSlopPx = 8f)
+    val gesture = createTapGesture()
 
     gesture.startPendingTap(pointerId = 1L, position = Offset.Zero)
 
@@ -128,7 +128,7 @@ class EditorTapGestureTest {
 
   @Test
   fun `plain drag does not advance consecutive tap count`() {
-    val gesture = EditorTapGesture(tapSlopPx = 8f)
+    val gesture = createTapGesture()
 
     gesture.recordTap(nowMillis = 100L, position = Offset.Zero, clickCount = 1)
     gesture.startPendingTap(pointerId = 2L, position = Offset.Zero)
@@ -143,7 +143,7 @@ class EditorTapGestureTest {
 
   @Test
   fun `cancelling active stream clears only the active tap candidate`() {
-    val gesture = EditorTapGesture(tapSlopPx = 8f)
+    val gesture = createTapGesture()
 
     gesture.startPendingTap(pointerId = 1L, position = Offset.Zero)
     assertTrue(gesture.cancelActivePointerStream())
@@ -156,4 +156,7 @@ class EditorTapGestureTest {
     startActivePointer(pointerId = pointerId, position = position)
     markTapPending()
   }
+
+  private fun createTapGesture(): EditorTapGesture =
+    EditorTapGesture(tapSlopPx = 8f, densityProvider = { 1f })
 }


### PR DESCRIPTION
- 더블 탭 인정 slop 디버그: 20px -> 20dp
- 더블 탭 드래그 시작 slop 디버그: 4px -> 4dp
- `DoubleTapDrag.Pending`이 되면 기존 pending pan을 취소하고 새 pan을 준비하지 않으며, 이후 move를 double tap drag 경로로 우선 처리
- 더블 탭 드래그를 시도했는데 swipe back 제스처가 들어가는 현상을 1차적으로 완화함