### PR TITLE
앱 swipe back 제스처 개선

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationPopGestureSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationPopGestureSession.kt
@@ -2,6 +2,29 @@ package co.typie.navigation
 
 import androidx.compose.ui.geometry.Offset
 import kotlin.math.abs
+import kotlin.math.max
+
+internal sealed interface NavigationPopActivation {
+  data object Pending : NavigationPopActivation
+
+  data object Rejected : NavigationPopActivation
+
+  data class Ready(val overshootX: Float) : NavigationPopActivation
+}
+
+internal fun resolveNavigationPopActivation(
+  dragFromStart: Offset,
+  activationDistance: Float,
+): NavigationPopActivation {
+  val distance = activationDistance.coerceAtLeast(0f)
+  if (max(abs(dragFromStart.x), abs(dragFromStart.y)) < distance) {
+    return NavigationPopActivation.Pending
+  }
+  if (dragFromStart.x <= 0f || abs(dragFromStart.x) <= abs(dragFromStart.y)) {
+    return NavigationPopActivation.Rejected
+  }
+  return NavigationPopActivation.Ready(overshootX = (dragFromStart.x - distance).coerceAtLeast(0f))
+}
 
 internal class NavigationPopGestureSession {
   private var state = State.Possible
@@ -12,17 +35,17 @@ internal class NavigationPopGestureSession {
   val isClaimed: Boolean
     get() = state == State.Claimed
 
-  val isMultiTouchRejected: Boolean
-    get() = multiTouchRejected
-
   val isSystemBackZoneRejected: Boolean
     get() = systemBackZoneRejected
 
   val hasPressedDragPointer: Boolean
     get() = pressedDragPointerCount > 0
 
+  val isCurrentSequenceRejected: Boolean
+    get() = multiTouchRejected || systemBackZoneRejected || state == State.Rejected
+
   fun tryClaim(initialDrag: Offset, childConsumed: Boolean): Boolean {
-    if (multiTouchRejected || systemBackZoneRejected || state != State.Possible) {
+    if (isCurrentSequenceRejected || state != State.Possible) {
       return false
     }
     if (initialDrag == Offset.Zero && !childConsumed) {
@@ -35,6 +58,10 @@ internal class NavigationPopGestureSession {
         State.Rejected
       }
     return isClaimed
+  }
+
+  fun rejectCurrentSequence() {
+    state = State.Rejected
   }
 
   fun updatePressedDragPointerCount(count: Int, downInSystemBackZone: Boolean = false): Boolean {
@@ -50,17 +77,17 @@ internal class NavigationPopGestureSession {
         multiTouchRejected = false
         systemBackZoneRejected = downInSystemBackZone
         if (state != State.Claimed) {
-          state = State.Possible
+          state = if (systemBackZoneRejected) State.Rejected else State.Possible
         }
       }
       count == 0 && multiTouchRejected -> state = State.Rejected
-      count == 0 && state != State.Claimed -> state = State.Possible
+      count == 0 && state != State.Claimed && state != State.Rejected -> state = State.Possible
     }
     return !wasMultiTouchRejected && multiTouchRejected
   }
 
   fun reset() {
-    state = if (multiTouchRejected) State.Rejected else State.Possible
+    state = if (isCurrentSequenceRejected) State.Rejected else State.Possible
   }
 
   private enum class State {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationPopNestedScroll.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationPopNestedScroll.kt
@@ -7,25 +7,29 @@ import androidx.compose.ui.unit.Velocity
 
 internal class NavigationPopNestedScroll : NestedScrollConnection {
   private val gestureSession = NavigationPopGestureSession()
+  private var activationDistance = 0f
   private var canStart: () -> Boolean = { false }
   private var onStart: () -> Unit = {}
   private var onDrag: (Float) -> Unit = {}
-  private var onRelease: () -> Unit = {}
+  private var onRelease: (Float) -> Unit = {}
   private var onCancel: () -> Unit = {}
+  private var scrollInterruption: ScrollInterruption? = null
+  private var pressedPointerId: Long? = null
+  private var pointerDownPosition: Offset? = null
+  private var pointerPosition: Offset? = null
 
-  val isMultiTouchRejected: Boolean
-    get() = gestureSession.isMultiTouchRejected
-
-  val isSystemBackZoneRejected: Boolean
-    get() = gestureSession.isSystemBackZoneRejected
+  val isCurrentSequenceRejected: Boolean
+    get() = gestureSession.isCurrentSequenceRejected
 
   fun update(
+    activationDistance: Float,
     canStart: () -> Boolean,
     onStart: () -> Unit,
     onDrag: (Float) -> Unit,
-    onRelease: () -> Unit,
+    onRelease: (Float) -> Unit,
     onCancel: () -> Unit,
   ) {
+    this.activationDistance = activationDistance
     this.canStart = canStart
     this.onStart = onStart
     this.onDrag = onDrag
@@ -33,15 +37,57 @@ internal class NavigationPopNestedScroll : NestedScrollConnection {
     this.onCancel = onCancel
   }
 
-  fun updatePressedDragPointerCount(count: Int, downInSystemBackZone: Boolean = false) {
-    if (gestureSession.updatePressedDragPointerCount(count, downInSystemBackZone)) {
+  fun registerScrollInterruption(
+    owner: Any,
+    isScrollInProgress: () -> Boolean,
+    interrupt: () -> Unit,
+  ) {
+    scrollInterruption = ScrollInterruption(owner, isScrollInProgress, interrupt)
+  }
+
+  fun unregisterScrollInterruption(owner: Any) {
+    if (scrollInterruption?.owner === owner) {
+      scrollInterruption = null
+    }
+  }
+
+  fun updatePressedDragPointerCount(
+    count: Int,
+    downInSystemBackZone: Boolean = false,
+    pointerId: Long? = null,
+    position: Offset? = null,
+  ) {
+    val isFirstDown = count == 1 && !gestureSession.hasPressedDragPointer
+    when {
+      isFirstDown -> {
+        pressedPointerId = pointerId
+        pointerDownPosition = position
+        pointerPosition = position
+      }
+      count == 1 && pointerId == pressedPointerId -> pointerPosition = position
+      count == 0 -> {
+        pressedPointerId = null
+        pointerDownPosition = null
+        pointerPosition = null
+      }
+    }
+    val currentScrollInterruption = scrollInterruption
+    val interruptsScrolling =
+      isFirstDown && currentScrollInterruption?.isScrollInProgress?.invoke() == true
+    val wasClaimed = gestureSession.isClaimed
+    gestureSession.updatePressedDragPointerCount(count, downInSystemBackZone)
+    if (interruptsScrolling) {
+      gestureSession.rejectCurrentSequence()
+      currentScrollInterruption.interrupt()
+    }
+    if (wasClaimed && !gestureSession.isClaimed) {
       onCancel()
     }
   }
 
-  fun finishDirectGesture() {
+  fun finishDirectGesture(velocityX: Float) {
     gestureSession.reset()
-    onRelease()
+    onRelease(velocityX)
   }
 
   fun cancelDirectGesture() {
@@ -75,36 +121,56 @@ internal class NavigationPopNestedScroll : NestedScrollConnection {
       source != NestedScrollSource.UserInput ||
         !gestureSession.hasPressedDragPointer ||
         gestureSession.isClaimed ||
+        gestureSession.isCurrentSequenceRejected ||
         !canStart()
     ) {
       return Offset.Zero
     }
-    if (
-      !gestureSession.tryClaim(
-        initialDrag = consumed + available,
-        childConsumed = consumed != Offset.Zero,
-      )
-    ) {
+    if (consumed != Offset.Zero) {
+      gestureSession.rejectCurrentSequence()
       return Offset.Zero
     }
 
-    onStart()
-    onDrag(available.x)
+    val dragFromStart =
+      pointerPosition?.let { current -> pointerDownPosition?.let { down -> current - down } }
+        ?: return Offset.Zero
+    val activation = resolveNavigationPopActivation(dragFromStart, activationDistance)
+    when (activation) {
+      NavigationPopActivation.Pending -> return Offset.Zero
+      NavigationPopActivation.Rejected -> {
+        gestureSession.rejectCurrentSequence()
+        return Offset.Zero
+      }
+      is NavigationPopActivation.Ready -> {
+        if (!gestureSession.tryClaim(initialDrag = dragFromStart, childConsumed = false)) {
+          return Offset.Zero
+        }
+
+        onStart()
+        onDrag(activation.overshootX)
+      }
+    }
     return available
   }
 
   override suspend fun onPreFling(available: Velocity): Velocity =
-    if (releaseClaimedGesture()) available else Velocity.Zero
+    if (releaseClaimedGesture(available.x)) available else Velocity.Zero
 
   override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity =
-    if (releaseClaimedGesture()) available else Velocity.Zero
+    if (releaseClaimedGesture(consumed.x + available.x)) available else Velocity.Zero
 
-  private fun releaseClaimedGesture(): Boolean {
+  private fun releaseClaimedGesture(velocityX: Float): Boolean {
     if (!gestureSession.isClaimed) {
       return false
     }
     gestureSession.reset()
-    onRelease()
+    onRelease(velocityX)
     return true
   }
+
+  private class ScrollInterruption(
+    val owner: Any,
+    val isScrollInProgress: () -> Boolean,
+    val interrupt: () -> Unit,
+  )
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationStack.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationStack.kt
@@ -27,13 +27,18 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerInputChange
+import androidx.compose.ui.input.pointer.PointerInputScope
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChangeIgnoreConsumed
+import androidx.compose.ui.input.pointer.util.VelocityTracker
+import androidx.compose.ui.input.pointer.util.addPointerInputChange
 import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastFirstOrNull
 import androidx.lifecycle.ViewModelStoreOwner
@@ -72,6 +77,112 @@ private enum class AnimState {
   Pop,
   Dragging,
   PopGestureCommitted,
+}
+
+private val NavigationPopActivationDistance = 15.dp
+
+internal fun shouldCommitNavigationPop(
+  progress: Float,
+  velocityX: Float,
+  containerWidth: Float,
+): Boolean {
+  val logicalVelocity = velocityX / containerWidth
+  return if (abs(logicalVelocity) >= 1f) logicalVelocity > 0f else progress > 0.5f
+}
+
+private class NavigationPopPointerVelocity {
+  private val tracker = VelocityTracker()
+
+  fun update(pressedPointerCount: Int, change: PointerInputChange?) {
+    if (pressedPointerCount > 1) {
+      reset()
+      return
+    }
+    change?.let { tracker.addPointerInputChange(it) }
+  }
+
+  fun release(maximumVelocity: Float): Float {
+    val velocityX = tracker.calculateVelocity(Velocity(maximumVelocity, maximumVelocity)).x
+    reset()
+    return velocityX
+  }
+
+  fun reset() {
+    tracker.resetTracking()
+  }
+}
+
+private suspend fun PointerInputScope.detectNavigationPopDrag(
+  activationDistance: Float,
+  pointerVelocity: NavigationPopPointerVelocity,
+  canStart: () -> Boolean,
+  isSequenceRejected: () -> Boolean,
+  onStart: () -> Unit,
+  onDrag: (Float) -> Unit,
+  onRelease: (Float) -> Unit,
+  onCancel: () -> Unit,
+) {
+  awaitEachGesture {
+    val down = awaitFirstDown(requireUnconsumed = false)
+    if (!down.type.isTouchDragPointer() || !canStart()) return@awaitEachGesture
+
+    var activationOvershootX = 0f
+    while (true) {
+      val event = awaitPointerEvent(PointerEventPass.Main)
+      if (event.changes.count { it.pressed } != 1) return@awaitEachGesture
+      val change = event.changes.fastFirstOrNull { it.id == down.id } ?: return@awaitEachGesture
+      if (!change.pressed) return@awaitEachGesture
+
+      when (
+        val activation =
+          resolveNavigationPopActivation(
+            dragFromStart = change.position - down.position,
+            activationDistance = activationDistance,
+          )
+      ) {
+        NavigationPopActivation.Pending -> continue
+        NavigationPopActivation.Rejected -> return@awaitEachGesture
+        is NavigationPopActivation.Ready -> {
+          if (isSequenceRejected() || !canStart() || change.isConsumed) {
+            return@awaitEachGesture
+          }
+          change.consume()
+          activationOvershootX = activation.overshootX
+          break
+        }
+      }
+    }
+
+    onStart()
+    onDrag(activationOvershootX)
+    while (true) {
+      if (isSequenceRejected()) {
+        pointerVelocity.reset()
+        onCancel()
+        return@awaitEachGesture
+      }
+
+      val event = awaitPointerEvent(PointerEventPass.Main)
+      if (event.changes.count { it.pressed } > 1) {
+        pointerVelocity.reset()
+        onCancel()
+        return@awaitEachGesture
+      }
+      val change = event.changes.fastFirstOrNull { it.id == down.id }
+      if (change == null) {
+        pointerVelocity.reset()
+        onRelease(0f)
+        return@awaitEachGesture
+      }
+
+      onDrag(change.positionChangeIgnoreConsumed().x)
+      if (!change.pressed) {
+        onRelease(pointerVelocity.release(viewConfiguration.maximumFlingVelocity))
+        return@awaitEachGesture
+      }
+      change.consume()
+    }
+  }
 }
 
 @Composable
@@ -135,10 +246,19 @@ fun NavigationStack(
 
   val progress = remember { Animatable(0f) }
 
-  var lastDragAmount by remember { mutableStateOf(0f) }
   val popNestedScroll = remember { NavigationPopNestedScroll() }
+  val navigationPopActivationDistance =
+    with(LocalDensity.current) { NavigationPopActivationDistance.toPx() }
   val backGestureZoneWidth by rememberUpdatedState(systemBackGestureZoneWidth())
+  val popPointerVelocity = remember { NavigationPopPointerVelocity() }
   var predictiveBackActive by remember { mutableStateOf(false) }
+
+  fun canStartPopGesture(): Boolean =
+    navigator.canPop &&
+      !navigator.isTransitioning &&
+      !predictiveBackActive &&
+      containerWidth > 0f &&
+      (animState == AnimState.Idle || animState == AnimState.Dragging)
 
   fun clearRemovedRoutes(removedRoutes: List<Route>) {
     removedRoutes.forEach { removedRoute ->
@@ -315,7 +435,6 @@ fun NavigationStack(
   }
 
   fun updatePopDrag(dragAmount: Float) {
-    lastDragAmount = dragAmount
     scope.launch {
       val newValue = (progress.value + dragAmount / containerWidth).coerceIn(0f, 1f)
       progress.snapTo(newValue)
@@ -344,10 +463,15 @@ fun NavigationStack(
     }
   }
 
-  fun finishPopDrag() {
-    val velocity = lastDragAmount * 1000f / 16f
+  fun finishPopDrag(velocityX: Float) {
     scope.launch {
-      if (progress.value > 0.5f || velocity > 1000f) {
+      if (
+        shouldCommitNavigationPop(
+          progress = progress.value,
+          velocityX = velocityX,
+          containerWidth = containerWidth,
+        )
+      ) {
         commitPopDrag()
       } else {
         progress.animateTo(0f, spring(stiffness = StiffnessMediumLow))
@@ -367,13 +491,8 @@ fun NavigationStack(
   }
 
   popNestedScroll.update(
-    canStart = {
-      navigator.canPop &&
-        !navigator.isTransitioning &&
-        !predictiveBackActive &&
-        containerWidth > 0f &&
-        (animState == AnimState.Idle || animState == AnimState.Dragging)
-    },
+    activationDistance = navigationPopActivationDistance,
+    canStart = ::canStartPopGesture,
     onStart = ::startPopDrag,
     onDrag = ::updatePopDrag,
     onRelease = ::finishPopDrag,
@@ -526,7 +645,7 @@ fun NavigationStack(
               val event = awaitPointerEvent(PointerEventPass.Initial)
               val pressedDragPointerCount =
                 event.changes.count { change -> change.type.isTouchDragPointer() && change.pressed }
-              val down =
+              val activePointer =
                 if (pressedDragPointerCount == 1) {
                   event.changes.fastFirstOrNull { change ->
                     change.type.isTouchDragPointer() && change.pressed
@@ -534,9 +653,22 @@ fun NavigationStack(
                 } else {
                   null
                 }
+              val releasedPointer =
+                if (pressedDragPointerCount == 0) {
+                  event.changes.fastFirstOrNull { change ->
+                    change.type.isTouchDragPointer() && change.previousPressed && !change.pressed
+                  }
+                } else {
+                  null
+                }
+              val pointerSample = activePointer ?: releasedPointer
+              popPointerVelocity.update(pressedDragPointerCount, pointerSample)
               popNestedScroll.updatePressedDragPointerCount(
                 count = pressedDragPointerCount,
-                downInSystemBackZone = down != null && down.position.x < backGestureZoneWidth,
+                downInSystemBackZone =
+                  activePointer != null && activePointer.position.x < backGestureZoneWidth,
+                pointerId = pointerSample?.id?.value,
+                position = pointerSample?.position,
               )
             }
           }
@@ -710,78 +842,17 @@ fun NavigationStack(
       Box(
         Modifier.fillMaxSize()
           .thenIf(navigator.canPop) {
-            pointerInput(Unit) {
-              val slop = viewConfiguration.touchSlop
-              awaitEachGesture {
-                val down = awaitFirstDown(requireUnconsumed = false)
-                if (!down.type.isTouchDragPointer()) {
-                  return@awaitEachGesture
-                }
-                if (navigator.isTransitioning) return@awaitEachGesture
-                val popGestureSession = NavigationPopGestureSession()
-                if (animState != AnimState.Idle && animState != AnimState.Dragging)
-                  return@awaitEachGesture
-                var overSlopX = 0f
-                var claimed = false
-                while (!claimed) {
-                  val event = awaitPointerEvent(PointerEventPass.Main)
-                  if (event.changes.count { it.pressed } != 1) return@awaitEachGesture
-                  val change =
-                    event.changes.fastFirstOrNull { it.id == down.id } ?: return@awaitEachGesture
-                  if (!change.pressed) return@awaitEachGesture
-                  val dx = change.position.x - down.position.x
-                  val dy = change.position.y - down.position.y
-                  if (abs(dx) > slop || abs(dy) > slop) {
-                    if (
-                      popNestedScroll.isMultiTouchRejected ||
-                        popNestedScroll.isSystemBackZoneRejected ||
-                        predictiveBackActive ||
-                        !popGestureSession.tryClaim(
-                          initialDrag = Offset(dx, dy),
-                          childConsumed = change.isConsumed,
-                        )
-                    ) {
-                      return@awaitEachGesture
-                    }
-                    val confirmEvent = awaitPointerEvent(PointerEventPass.Main)
-                    val confirmChange =
-                      confirmEvent.changes.fastFirstOrNull { it.id == down.id }
-                        ?: return@awaitEachGesture
-                    if (!confirmChange.pressed) return@awaitEachGesture
-                    if (confirmChange.isConsumed) return@awaitEachGesture
-                    if (popNestedScroll.isMultiTouchRejected) return@awaitEachGesture
-                    if (confirmEvent.changes.count { it.pressed } != 1) return@awaitEachGesture
-                    confirmChange.consume()
-                    overSlopX = confirmChange.position.x - down.position.x
-                    claimed = true
-                  }
-                }
-                startPopDrag()
-                updatePopDrag(overSlopX)
-                // blocker가 Main pass 전에 consume하므로 isConsumed를 무시하고 loop.
-                // 자식 scrollable이 이 포인터를 take over하지 못하도록 우리가 계속 consume.
-                var dragging = true
-                while (dragging) {
-                  if (popNestedScroll.isMultiTouchRejected) {
-                    // Close after progress updates that may have been queued before root rejection.
-                    popNestedScroll.cancelDirectGesture()
-                    return@awaitEachGesture
-                  }
-                  val event = awaitPointerEvent(PointerEventPass.Main)
-                  if (event.changes.count { it.pressed } > 1) {
-                    popNestedScroll.cancelDirectGesture()
-                    return@awaitEachGesture
-                  }
-                  val change = event.changes.fastFirstOrNull { it.id == down.id }
-                  if (change == null) {
-                    dragging = false
-                    continue
-                  }
-                  updatePopDrag(change.positionChangeIgnoreConsumed().x)
-                  if (!change.pressed) dragging = false else change.consume()
-                }
-                popNestedScroll.finishDirectGesture()
-              }
+            pointerInput(navigationPopActivationDistance) {
+              detectNavigationPopDrag(
+                activationDistance = navigationPopActivationDistance,
+                pointerVelocity = popPointerVelocity,
+                canStart = ::canStartPopGesture,
+                isSequenceRejected = { popNestedScroll.isCurrentSequenceRejected },
+                onStart = ::startPopDrag,
+                onDrag = ::updatePopDrag,
+                onRelease = popNestedScroll::finishDirectGesture,
+                onCancel = popNestedScroll::cancelDirectGesture,
+              )
             }
           }
           .graphicsLayer {
@@ -846,69 +917,22 @@ fun NavigationStack(
         }
       }
 
-      // 엣지 제스처 감지 영역 (첫 touch slop 이동이 소비되지 않은 오른쪽 드래그일 때만 claim)
+      // 엣지 제스처 감지 영역 (15dp를 넘긴 dominant-right drag만 claim)
       if (navigator.canPop && (animState == AnimState.Idle || animState == AnimState.Dragging)) {
         Box(
-          Modifier.fillMaxHeight().width(20.dp).align(Alignment.CenterStart).pointerInput(Unit) {
-            val slop = viewConfiguration.touchSlop
-            awaitEachGesture {
-              val down = awaitFirstDown(requireUnconsumed = false)
-              if (!down.type.isTouchDragPointer()) {
-                return@awaitEachGesture
-              }
-              if (navigator.isTransitioning) return@awaitEachGesture
-              val popGestureSession = NavigationPopGestureSession()
-              var overSlopX = 0f
-              var claimed = false
-              while (!claimed) {
-                val event = awaitPointerEvent(PointerEventPass.Main)
-                if (event.changes.count { it.pressed } != 1) return@awaitEachGesture
-                val change =
-                  event.changes.fastFirstOrNull { it.id == down.id } ?: return@awaitEachGesture
-                if (!change.pressed) return@awaitEachGesture
-                val dx = change.position.x - down.position.x
-                val dy = change.position.y - down.position.y
-                if (abs(dx) > slop || abs(dy) > slop) {
-                  if (
-                    popNestedScroll.isMultiTouchRejected ||
-                      popNestedScroll.isSystemBackZoneRejected ||
-                      predictiveBackActive ||
-                      !popGestureSession.tryClaim(
-                        initialDrag = Offset(dx, dy),
-                        childConsumed = change.isConsumed,
-                      )
-                  ) {
-                    return@awaitEachGesture
-                  }
-                  change.consume()
-                  overSlopX = dx
-                  claimed = true
-                }
-              }
-              startPopDrag()
-              updatePopDrag(overSlopX)
-              var dragging = true
-              while (dragging) {
-                if (popNestedScroll.isMultiTouchRejected) {
-                  // Close after progress updates that may have been queued before root rejection.
-                  popNestedScroll.cancelDirectGesture()
-                  return@awaitEachGesture
-                }
-                val event = awaitPointerEvent(PointerEventPass.Main)
-                if (event.changes.count { it.pressed } > 1) {
-                  popNestedScroll.cancelDirectGesture()
-                  return@awaitEachGesture
-                }
-                val change = event.changes.fastFirstOrNull { it.id == down.id }
-                if (change == null) {
-                  dragging = false
-                  continue
-                }
-                updatePopDrag(change.positionChangeIgnoreConsumed().x)
-                if (!change.pressed) dragging = false else change.consume()
-              }
-              popNestedScroll.finishDirectGesture()
-            }
+          Modifier.fillMaxHeight().width(20.dp).align(Alignment.CenterStart).pointerInput(
+            navigationPopActivationDistance
+          ) {
+            detectNavigationPopDrag(
+              activationDistance = navigationPopActivationDistance,
+              pointerVelocity = popPointerVelocity,
+              canStart = ::canStartPopGesture,
+              isSequenceRejected = { popNestedScroll.isCurrentSequenceRejected },
+              onStart = ::startPopDrag,
+              onDrag = ::updatePopDrag,
+              onRelease = popNestedScroll::finishDirectGesture,
+              onCancel = popNestedScroll::cancelDirectGesture,
+            )
           }
         )
       }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -1219,6 +1219,7 @@ fun EditorScreen(entityId: String) {
         visibleArea = visibleArea,
         magnifierFocalPositionInRoot = magnifierFocalPositionInRoot,
         viewportScrollableState = viewportScrollableState,
+        isCurrentNavigationRoute = nav.current == Route.Editor(entityId),
         editorInteractionEnabled = editorInteractionEnabled,
         platformIndirectScaleEnabled = platformIndirectScaleEnabled,
         viewportContentWidth = bodyTrackWidth,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayout.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayout.kt
@@ -1,5 +1,6 @@
 package co.typie.screen.editor.editor.layout
 
+import androidx.compose.foundation.MutatePriority
 import androidx.compose.foundation.gestures.Scrollable2DState
 import androidx.compose.foundation.gestures.ScrollableDefaults
 import androidx.compose.foundation.layout.Box
@@ -9,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -60,6 +62,7 @@ import kotlin.coroutines.coroutineContext
 import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.roundToInt
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
@@ -89,6 +92,7 @@ internal fun EditorScreenLayout(
   magnifierFocalPositionInRoot: Offset? = null,
   viewportScrollableState: Scrollable2DState,
   viewportContentWidth: Float,
+  isCurrentNavigationRoute: Boolean = true,
   editorInteractionEnabled: Boolean = true,
   platformIndirectScaleEnabled: Boolean = editorInteractionEnabled,
   viewportScrollReconcileMode: EditorViewportScrollReconcileMode,
@@ -118,6 +122,20 @@ internal fun EditorScreenLayout(
   val coroutineScope = rememberCoroutineScope()
   var smoothScrollJob by remember { mutableStateOf<Job?>(null) }
   var layoutBoundsInRoot by remember { mutableStateOf<Rect?>(null) }
+  if (isCurrentNavigationRoute) {
+    DisposableEffect(navigationPopNestedScroll, viewportScrollableState) {
+      navigationPopNestedScroll?.registerScrollInterruption(
+        owner = viewportScrollableState,
+        isScrollInProgress = { viewportScrollableState.isScrollInProgress },
+        interrupt = {
+          coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            viewportScrollableState.scroll(MutatePriority.UserInput) {}
+          }
+        },
+      )
+      onDispose { navigationPopNestedScroll?.unregisterScrollInterruption(viewportScrollableState) }
+    }
+  }
   LaunchedEffect(
     state.viewportState.isTransforming,
     state.viewportState.isDirectManipulationInProgress,

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/navigation/NavigationPopNestedScrollTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/navigation/NavigationPopNestedScrollTest.kt
@@ -1,0 +1,81 @@
+package co.typie.navigation
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.unit.Velocity
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+
+class NavigationPopNestedScrollTest {
+  @Test
+  fun nestedActivationUsesRootDisplacementAndForwardsOnlyOvershoot() {
+    val fixture = Fixture()
+    fixture.pointerDown()
+    fixture.pointerMoveTo(x = 14f)
+
+    assertEquals(Offset.Zero, fixture.postScroll(availableX = 4f))
+
+    fixture.pointerMoveTo(x = 20f)
+
+    assertEquals(Offset(x = 6f, y = 0f), fixture.postScroll(availableX = 6f))
+    assertEquals(1, fixture.startCount)
+    assertEquals(listOf(5f), fixture.dragAmounts)
+  }
+
+  @Test
+  fun nestedReleaseForwardsTheActualPreFlingVelocity() = runTest {
+    val fixture = Fixture()
+    fixture.claimNestedGesture()
+
+    fixture.connection.onPreFling(Velocity(x = 640f, y = 12f))
+
+    assertEquals(640f, fixture.releasedVelocityX)
+  }
+
+  private class Fixture {
+    val dragAmounts = mutableListOf<Float>()
+    var startCount = 0
+    var releasedVelocityX: Float? = null
+    val connection =
+      NavigationPopNestedScroll().apply {
+        update(
+          activationDistance = 15f,
+          canStart = { true },
+          onStart = { startCount += 1 },
+          onDrag = dragAmounts::add,
+          onRelease = { releasedVelocityX = it },
+          onCancel = {},
+        )
+      }
+
+    fun pointerDown() {
+      updatePointer(count = 1, pointerId = 1L)
+    }
+
+    fun pointerMoveTo(x: Float) {
+      updatePointer(count = 1, pointerId = 1L, x = x)
+    }
+
+    fun postScroll(availableX: Float): Offset =
+      connection.onPostScroll(
+        consumed = Offset.Zero,
+        available = Offset(x = availableX, y = 0f),
+        source = NestedScrollSource.UserInput,
+      )
+
+    fun claimNestedGesture() {
+      pointerDown()
+      pointerMoveTo(x = 20f)
+      postScroll(availableX = 20f)
+    }
+
+    private fun updatePointer(count: Int, pointerId: Long, x: Float = 0f) {
+      connection.updatePressedDragPointerCount(
+        count = count,
+        pointerId = pointerId,
+        position = Offset(x = x, y = 0f),
+      )
+    }
+  }
+}

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/interaction/EditorInteractionsDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/interaction/EditorInteractionsDesktopTest.kt
@@ -599,7 +599,7 @@ class EditorInteractionsDesktopTest {
   }
 
   @Test
-  fun `desktop trackpad click drag cancelled back swipe returns editor to origin`() =
+  fun `slow desktop trackpad click drag returns editor to origin before halfway`() =
     runComposeUiTest {
       val fixture = Fixture(scrollConsumer = { Offset.Zero })
       val navigator = Navigator(Route.Home)
@@ -608,7 +608,7 @@ class EditorInteractionsDesktopTest {
       onNodeWithTag(NavigationEditorTag).performTrackpadInput {
         moveTo(Offset(x = 80f, y = center.y))
         press()
-        repeat(12) { moveBy(Offset(x = 5f, y = 0f), delayMillis = 1L) }
+        repeat(12) { moveBy(Offset(x = 5f, y = 0f), delayMillis = 100L) }
       }
       waitUntil { onNodeWithTag(NavigationEditorTag).fetchSemanticsNode().boundsInRoot.left > 0.5f }
       onNodeWithTag(NavigationEditorTag).performTrackpadInput { release() }
@@ -637,23 +637,6 @@ class EditorInteractionsDesktopTest {
 
     waitUntil { navigator.current == Route.Home && !navigator.isTransitioning }
     onAllNodes(hasTestTag(NavigationEditorTag)).assertCountEquals(0)
-  }
-
-  @Test
-  fun `rapid desktop trackpad release rolls cancelled back swipe to origin`() = runComposeUiTest {
-    val fixture = Fixture(scrollConsumer = { Offset.Zero })
-    val navigator = Navigator(Route.Home)
-    setNavigationEditorContent(fixture = fixture, navigator = navigator)
-
-    onNodeWithTag(NavigationEditorTag).performTrackpadInput {
-      moveTo(Offset(x = 80f, y = center.y))
-      press()
-      repeat(12) { moveBy(Offset(x = 5f, y = 0f), delayMillis = 1L) }
-      release()
-    }
-
-    waitUntil { onNodeWithTag(NavigationEditorTag).fetchSemanticsNode().boundsInRoot.left <= 0.5f }
-    assertEquals(NavigationEditorRoute, navigator.current)
   }
 
   @Test
@@ -805,27 +788,19 @@ class EditorInteractionsDesktopTest {
   }
 
   @Test
-  fun `rapid main editor viewport release rolls cancelled back swipe to origin`() =
-    runComposeUiTest {
-      val fixture = Fixture(scrollConsumer = { Offset.Zero })
-      val navigator = Navigator(Route.Home)
-      setNavigationEditorContent(fixture = fixture, navigator = navigator)
+  fun `rapid main editor viewport release commits before halfway`() = runComposeUiTest {
+    val fixture = Fixture(scrollConsumer = { Offset.Zero })
+    val navigator = Navigator(Route.Home)
+    setNavigationEditorContent(fixture = fixture, navigator = navigator)
 
-      onNodeWithTag(NavigationEditorTag).performTouchInput {
-        down(Offset(x = 80f, y = center.y))
-        repeat(12) { moveBy(Offset(x = 5f, y = 0f), delayMillis = 1L) }
-        moveBy(Offset(x = 1f, y = 0f), delayMillis = 1L)
-        up()
-      }
-      waitForIdle()
-
-      assertEquals(NavigationEditorRoute, navigator.current)
-      assertEquals(
-        expected = 0f,
-        actual = onNodeWithTag(NavigationEditorTag).fetchSemanticsNode().boundsInRoot.left,
-        absoluteTolerance = 0.5f,
-      )
+    onNodeWithTag(NavigationEditorTag).performTouchInput {
+      down(Offset(x = 80f, y = center.y))
+      repeat(12) { moveBy(Offset(x = 5f, y = 0f), delayMillis = 1L) }
+      moveBy(Offset(x = 1f, y = 0f), delayMillis = 1L)
+      up()
     }
+    waitUntil { navigator.current == Route.Home && !navigator.isTransitioning }
+  }
 
   @Test
   fun `rapid edge release completes committed back swipe`() = runComposeUiTest {
@@ -841,28 +816,6 @@ class EditorInteractionsDesktopTest {
     }
 
     waitUntil { navigator.current == Route.Home && !navigator.isTransitioning }
-  }
-
-  @Test
-  fun `rapid edge release rolls cancelled back swipe to origin`() = runComposeUiTest {
-    val fixture = Fixture(scrollConsumer = { Offset.Zero })
-    val navigator = Navigator(Route.Home)
-    setNavigationEditorContent(fixture = fixture, navigator = navigator)
-
-    onNodeWithTag(NavigationEditorTag).performTouchInput {
-      down(Offset(x = 10f, y = center.y))
-      repeat(12) { moveBy(Offset(x = 5f, y = 0f), delayMillis = 1L) }
-      moveBy(Offset(x = 1f, y = 0f), delayMillis = 1L)
-      up()
-    }
-    waitForIdle()
-
-    assertEquals(NavigationEditorRoute, navigator.current)
-    assertEquals(
-      expected = 0f,
-      actual = onNodeWithTag(NavigationEditorTag).fetchSemanticsNode().boundsInRoot.left,
-      absoluteTolerance = 0.5f,
-    )
   }
 
   @Test

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/NavigationStackDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/NavigationStackDesktopTest.kt
@@ -1,14 +1,19 @@
 package co.typie.navigation
 
+import androidx.compose.foundation.MutatePriority
+import androidx.compose.foundation.gestures.Scrollable2DState
 import androidx.compose.foundation.gestures.rememberScrollable2DState
 import androidx.compose.foundation.gestures.scrollable2D
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.TouchInjectionScope
@@ -24,6 +29,12 @@ import co.typie.ui.component.topbar.TopBarState
 import kotlin.math.abs
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalTestApi::class)
 class NavigationStackDesktopTest {
@@ -130,6 +141,144 @@ class NavigationStackDesktopTest {
       },
     )
 
+  @Test
+  fun releaseDecisionUsesScreenNormalizedVelocityBeforeProgress() {
+    assertEquals(true, shouldCommitNavigationPop(0.51f, 100f, 320f))
+    assertEquals(false, shouldCommitNavigationPop(0.5f, 100f, 320f))
+    assertEquals(true, shouldCommitNavigationPop(0.2f, 320f, 320f))
+    assertEquals(false, shouldCommitNavigationPop(0.8f, -320f, 320f))
+    assertEquals(false, shouldCommitNavigationPop(0.2f, 399f, 400f))
+  }
+
+  @Test
+  fun edgeTouchThatInterruptsScrollingCannotPopUntilTheNextGesture() = runComposeUiTest {
+    val navigator = Navigator(Route.Home)
+    val editorRoute = Route.Editor("document-id")
+    lateinit var scrollableState: Scrollable2DState
+    lateinit var compositionScope: CoroutineScope
+
+    setContent {
+      NavigationStack(
+        navigator = navigator,
+        topBarState = remember { TopBarState() },
+        modifier = Modifier.size(width = 320.dp, height = 640.dp),
+      ) { route ->
+        if (route == editorRoute) {
+          compositionScope = rememberCoroutineScope()
+          scrollableState = rememberScrollable2DState { Offset.Zero }
+          val connection = LocalNavigationPopNestedScroll.current
+          val owner = remember { Any() }
+          DisposableEffect(connection, owner) {
+            connection?.registerScrollInterruption(
+              owner = owner,
+              isScrollInProgress = { scrollableState.isScrollInProgress },
+              interrupt = {
+                compositionScope.launch(start = CoroutineStart.UNDISPATCHED) {
+                  scrollableState.scroll(MutatePriority.UserInput) {}
+                }
+              },
+            )
+            onDispose { connection?.unregisterScrollInterruption(owner) }
+          }
+        }
+        Box(
+          Modifier.fillMaxSize().testTag(if (route == editorRoute) EditorRouteTag else HomeRouteTag)
+        )
+      }
+      LaunchedEffect(Unit) { navigator.navigate(editorRoute) }
+    }
+    waitUntil { navigator.current == editorRoute && !navigator.isTransitioning }
+
+    val releaseScroll = CompletableDeferred<Unit>()
+    var scrollCancelled = false
+    val scrollJob =
+      compositionScope.launch(start = CoroutineStart.UNDISPATCHED) {
+        try {
+          scrollableState.scroll(MutatePriority.Default) { releaseScroll.await() }
+        } catch (_: CancellationException) {
+          scrollCancelled = true
+        }
+      }
+    waitUntil { scrollableState.isScrollInProgress }
+
+    try {
+      onNodeWithTag(EditorRouteTag).performTouchInput {
+        down(Offset(x = 10f, y = center.y))
+        moveBy(Offset(x = 220f, y = 0f))
+        up()
+      }
+      waitUntil { scrollCancelled }
+
+      assertEquals(editorRoute, navigator.current)
+
+      onNodeWithTag(EditorRouteTag).performTouchInput {
+        down(Offset(x = 10f, y = center.y))
+        moveBy(Offset(x = 220f, y = 0f))
+        up()
+      }
+      waitForIdle()
+
+      assertEquals(Route.Home, navigator.current)
+    } finally {
+      releaseScroll.complete(Unit)
+      scrollJob.cancel()
+    }
+  }
+
+  @Test
+  fun edgeBackSwipeDiscardsTheFifteenDpActivationDistance() = runComposeUiTest {
+    val navigator = Navigator(Route.Home)
+    val editorRoute = Route.Editor("document-id")
+    var activationDistancePx = 0f
+
+    setContent {
+      activationDistancePx = with(LocalDensity.current) { 15.dp.toPx() }
+      NavigationStack(
+        navigator = navigator,
+        topBarState = remember { TopBarState() },
+        modifier = Modifier.size(width = 320.dp, height = 640.dp),
+      ) { route ->
+        Box(
+          Modifier.fillMaxSize().testTag(if (route == editorRoute) EditorRouteTag else HomeRouteTag)
+        )
+      }
+      LaunchedEffect(Unit) { navigator.navigate(editorRoute) }
+    }
+    waitUntil { navigator.current == editorRoute && !navigator.isTransitioning }
+    val routeNode = onNodeWithTag(EditorRouteTag)
+
+    routeNode.performTouchInput {
+      down(Offset(x = 10f, y = center.y))
+      moveBy(Offset(x = activationDistancePx - 1f, y = 0f))
+    }
+    waitForIdle()
+    assertTrue(abs(routeNode.fetchSemanticsNode().boundsInRoot.left) < 0.1f)
+
+    routeNode.performTouchInput { moveBy(Offset(x = 1f, y = 0f)) }
+    waitForIdle()
+    assertTrue(abs(routeNode.fetchSemanticsNode().boundsInRoot.left) < 0.1f)
+
+    routeNode.performTouchInput { moveBy(Offset(x = 5f, y = 0f)) }
+    waitUntil { routeNode.fetchSemanticsNode().boundsInRoot.left > 4f }
+    assertTrue(abs(routeNode.fetchSemanticsNode().boundsInRoot.left - 5f) < 0.5f)
+
+    routeNode.performTouchInput { up() }
+    waitForIdle()
+    assertEquals(editorRoute, navigator.current)
+  }
+
+  @Test
+  fun fastReverseEdgeReleaseCancelsEvenAfterHalfway() =
+    assertGestureDoesNotPop(
+      scrollConsumer = { Offset.Zero },
+      gesture = {
+        down(Offset(x = 10f, y = center.y))
+        moveBy(Offset(x = 220f, y = 0f), delayMillis = 500L)
+        repeat(8) { moveBy(Offset(x = -5f, y = 0f), delayMillis = 1L) }
+        up()
+      },
+    )
+
   private fun assertGestureDoesNotPop(
     scrollConsumer: (Offset) -> Offset,
     gesture: TouchInjectionScope.() -> Unit,
@@ -156,8 +305,7 @@ class NavigationStackDesktopTest {
     onNodeWithTag(EditorRouteTag).performTrackpadInput {
       moveTo(if (startAtEdge) Offset(x = 10f, y = center.y) else center)
       press()
-      moveBy(Offset(x = 220f, y = 0f))
-      moveBy(Offset(x = 1f, y = 0f))
+      repeat(11) { moveBy(Offset(x = 20f, y = 0f), delayMillis = 100L) }
     }
     waitUntil { onNodeWithTag(EditorRouteTag).fetchSemanticsNode().boundsInRoot.left > 100f }
     onNodeWithTag(EditorRouteTag).performTrackpadInput { release() }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayoutDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayoutDesktopTest.kt
@@ -155,6 +155,7 @@ class EditorScreenLayoutDesktopTest {
     val navigationPopNestedScroll =
       NavigationPopNestedScroll().apply {
         update(
+          activationDistance = 15f,
           canStart = { true },
           onStart = {},
           onDrag = { navigationDragCount += 1 },
@@ -311,6 +312,7 @@ class EditorScreenLayoutDesktopTest {
     val navigationPopNestedScroll =
       NavigationPopNestedScroll().apply {
         update(
+          activationDistance = 15f,
           canStart = { true },
           onStart = {},
           onDrag = { navigationDragCount += 1 },
@@ -368,7 +370,18 @@ class EditorScreenLayoutDesktopTest {
 
     // NavigationStack supplies this root pointer membership in production. This isolated layout
     // test provides the same admission state before exercising the nested-scroll connection.
-    navigationPopNestedScroll.updatePressedDragPointerCount(count = 1, downInSystemBackZone = false)
+    navigationPopNestedScroll.updatePressedDragPointerCount(
+      count = 1,
+      downInSystemBackZone = false,
+      pointerId = 1L,
+      position = Offset.Zero,
+    )
+    navigationPopNestedScroll.updatePressedDragPointerCount(
+      count = 1,
+      downInSystemBackZone = false,
+      pointerId = 1L,
+      position = Offset(x = 120f, y = 0f),
+    )
     onNodeWithTag(LayoutTag).performTouchInput {
       swipe(start = center, end = Offset(x = center.x + 120f, y = center.y))
     }


### PR DESCRIPTION
- 에디터 영역 및 edge 영역의 swipe back 제스처 모두 slop 15dp 초과 이동분부터 화면을 slide함
- 현재 route 에디터가 scroll/fling 중일 때 첫 touch는 스크롤만 멈추고, 그 pointer sequence에서는 swipe back 할 수 없도록 함
- 전체/edge 경로는 Compose pointer velocity, nested 경로는 실제 pre/post-fling velocity로 release 판정
    - 1 screen width/s 이상이면 velocity 방향으로 commit/cancel
    - 그 미만이면 progress 50% 초과 여부로 판정
    - 충분히 빠른 반대 방향 release는 progress가 50%를 넘었어도 cancel
    - 이 조건은 iOS 호환 구현인 [Flutter Cupertino route](https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/cupertino/route.dart)의 정책을 따름