### PR TITLE
앱 엔티티 reorder 애니메이션 디버그

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/entity/container/EntityContainerList.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/entity/container/EntityContainerList.kt
@@ -150,7 +150,7 @@ fun EntityContainerReorderListCard(
         val isDragging = reorderState.isDragging(entity.id)
 
         val rowModifier =
-          if (isDragging) {
+          if (isDragging || reorderState.isSettling(entity.id)) {
             Modifier
           } else {
             Modifier.animateBounds(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/reorder/ReorderableColumn.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/reorder/ReorderableColumn.kt
@@ -94,6 +94,8 @@ internal constructor(internal val edgeAutoScrollController: EdgeAutoScrollContro
 
   fun isDragging(key: K): Boolean = draggingKey == key
 
+  internal fun isSettling(key: K): Boolean = settling?.key == key
+
   internal val activeDragPointer: Offset?
     get() = activeDrag?.pointer
 


### PR DESCRIPTION
reorder 중 드래그 놓을 때 y=0으로 점프하고 되돌아오는 문제를 수정함