### PR TITLE
앱 에디터 스크롤바 위에서 트랙패드 스크롤

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractions.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractions.kt
@@ -224,14 +224,14 @@ private class EditorInteractionsNode(
   }
 
   override fun onPointerEvent(pointerEvent: PointerEvent, pass: PointerEventPass, bounds: IntSize) {
-    if (routeIndirectPointerPass(pointerEvent = pointerEvent, pass = pass)) {
+    if (routePointerPass(pointerEvent = pointerEvent, pass = pass)) {
       return
     }
     if (!enabled || density <= 0f) {
       cancelInteraction(clearSuppression = true)
       return
     }
-    if (pointerEvent.changes.any { change -> change.pressed && !change.previousPressed }) {
+    if (pointerEvent.changes.any(PointerInputChange::isUnconsumedDown)) {
       onEditorPointerInput()
     }
 
@@ -308,15 +308,33 @@ private class EditorInteractionsNode(
     finishReleasedPointers(pointerEvent)
   }
 
-  private fun routeIndirectPointerPass(
-    pointerEvent: PointerEvent,
-    pass: PointerEventPass,
-  ): Boolean {
-    if (pass == PointerEventPass.Initial) {
-      handleIndirectPointerEvent(pointerEvent)
+  private fun routePointerPass(pointerEvent: PointerEvent, pass: PointerEventPass): Boolean {
+    if (pointerEvent.type.isIndirectPointerEvent()) {
+      if (pass == PointerEventPass.Initial) {
+        handleIndirectPointerEvent(pointerEvent)
+      }
       return true
     }
-    return pass != PointerEventPass.Main || pointerEvent.type.isIndirectPointerEvent()
+
+    val hasFreshDown =
+      pointerEvent.changes.any { change -> change.pressed && !change.previousPressed }
+    // Track membership before the screen observer's Final pass, but let shared overlay siblings
+    // claim direct gestures during Main before admitting a new editor sequence.
+    return when (pass) {
+      PointerEventPass.Initial -> true
+      PointerEventPass.Main -> {
+        if (hasFreshDown && enabled && density > 0f) {
+          registerPointerDowns(pointerEvent)
+        }
+        hasFreshDown
+      }
+      PointerEventPass.Final -> {
+        if (hasFreshDown) {
+          discardConsumedPointerDowns(pointerEvent)
+        }
+        !hasFreshDown
+      }
+    }
   }
 
   override fun onCancelPointerInput() {
@@ -353,18 +371,35 @@ private class EditorInteractionsNode(
   }
 
   private fun registerPointerDowns(pointerEvent: PointerEvent) {
-    pointerEvent.changes
-      .filter { change -> change.pressed && !change.previousPressed }
-      .forEach { change ->
-        pointers[change.id.value] = change.type
-        if (
-          physicalDragLockHandle == null &&
-            change.type == PointerType.Mouse &&
-            change.type.isTouchDragPointer()
-        ) {
-          physicalDragLockHandle = scrollGestureLockState.acquire()
-        }
+    pointerEvent.changes.filter(PointerInputChange::isUnconsumedDown).forEach { change ->
+      pointers[change.id.value] = change.type
+      if (
+        physicalDragLockHandle == null &&
+          change.type == PointerType.Mouse &&
+          change.type.isTouchDragPointer()
+      ) {
+        physicalDragLockHandle = scrollGestureLockState.acquire()
       }
+    }
+  }
+
+  private fun discardConsumedPointerDowns(pointerEvent: PointerEvent) {
+    var pointerRemoved = false
+    pointerEvent.changes
+      .filter { change -> change.pressed && !change.previousPressed && change.isConsumed }
+      .forEach { change ->
+        if (pointers.remove(change.id.value) != null) {
+          pointerRemoved = true
+        }
+        singlePointerStreams -= change.id.value
+      }
+    if (!pointerRemoved) {
+      return
+    }
+    if (!hasPhysicalDragPointer()) {
+      releasePhysicalDragLock()
+    }
+    onScreenPointerMembershipChanged()
   }
 
   private fun isEditorTouchPointer(pointerId: Long): Boolean =
@@ -376,27 +411,25 @@ private class EditorInteractionsNode(
     }
 
   private fun forwardSinglePointerChanges(pointerEvent: PointerEvent) {
-    pointerEvent.changes
-      .filter { change -> change.pressed && !change.previousPressed }
-      .forEach { change ->
-        val rootPosition = positionInRoot(change.position)
-        val tapEnabled = geometry.isTapEligible(change.position)
-        val editorPosition = geometry.resolveInteractionPosition(change.position)
-        singlePointerStreams += change.id.value
-        if (
-          interactionController.onPointerDown(
-            pointerId = change.id.value,
-            position = editorPosition,
-            nowMillis = change.uptimeMillis,
-            tapEnabled = tapEnabled,
-            inputModifiers = pointerEvent.inputModifiers(),
-            positionInRoot = rootPosition,
-            touchPanDriver = if (change.type.isTouchDragPointer()) scrollDriver else null,
-          )
-        ) {
-          change.consume()
-        }
+    pointerEvent.changes.filter(PointerInputChange::isUnconsumedDown).forEach { change ->
+      val rootPosition = positionInRoot(change.position)
+      val tapEnabled = geometry.isTapEligible(change.position)
+      val editorPosition = geometry.resolveInteractionPosition(change.position)
+      singlePointerStreams += change.id.value
+      if (
+        interactionController.onPointerDown(
+          pointerId = change.id.value,
+          position = editorPosition,
+          nowMillis = change.uptimeMillis,
+          tapEnabled = tapEnabled,
+          inputModifiers = pointerEvent.inputModifiers(),
+          positionInRoot = rootPosition,
+          touchPanDriver = if (change.type.isTouchDragPointer()) scrollDriver else null,
+        )
+      ) {
+        change.consume()
       }
+    }
 
     pointerEvent.changes
       .filter { change ->
@@ -458,14 +491,15 @@ private class EditorInteractionsNode(
       suppressUntilAllUp = false
       physicalSequenceYieldedToIndirectInput = false
     }
-    if (
-      pointers.values.none { pointerType ->
-        pointerType == PointerType.Mouse && pointerType.isTouchDragPointer()
-      }
-    ) {
+    if (!hasPhysicalDragPointer()) {
       releasePhysicalDragLock()
     }
   }
+
+  private fun hasPhysicalDragPointer(): Boolean =
+    pointers.values.any { pointerType ->
+      pointerType == PointerType.Mouse && pointerType.isTouchDragPointer()
+    }
 
   private fun cancelAndSuppress(pointerEvent: PointerEvent) {
     physicalSequenceYieldedToIndirectInput = false
@@ -876,6 +910,9 @@ private class EditorScreenPointerObserverNode(var sequence: EditorScreenPointerS
     super.onDetach()
   }
 }
+
+private fun PointerInputChange.isUnconsumedDown(): Boolean =
+  pressed && !previousPressed && !isConsumed
 
 private fun PointerEvent.inputModifiers(): InputModifiers {
   val modifiers = keyboardModifiers

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -131,6 +131,7 @@ import co.typie.screen.editor.editor.layout.EditorViewportScrollReconcileMode
 import co.typie.screen.editor.editor.overlay.EditorCharacterCountOverlay
 import co.typie.screen.editor.editor.overlay.EditorRepasteAsTextOverlay
 import co.typie.screen.editor.editor.overlay.EditorScreenOverlayHost
+import co.typie.screen.editor.editor.overlay.EditorScrollbars
 import co.typie.screen.editor.editor.overlay.EditorZoomOverlay
 import co.typie.screen.editor.editor.placeholder.EditorDocumentPlaceholder
 import co.typie.screen.editor.editor.spellcheck.SpellcheckOverlay
@@ -1283,6 +1284,14 @@ fun EditorScreen(entityId: String) {
               viewportState = screenState.viewportState,
               visibleArea = visibleArea,
             )
+            EditorScrollbars(
+              viewportState = screenState.viewportState,
+              visibleArea = visibleArea,
+              layoutSpec = layoutSpec,
+              pageSizes = pageSizes,
+              displayZoom = displayZoom,
+              modifier = Modifier.fillMaxSize(),
+            )
           } else {
             EditorLoadingSkeleton(
               layoutSpec = layoutSpec,
@@ -1299,9 +1308,6 @@ fun EditorScreen(entityId: String) {
                 viewportState = screenState.viewportState,
                 visibleArea = visibleArea,
                 autoScrollPolicy = autoScrollPolicy,
-                layoutSpec = layoutSpec,
-                pageSizes = pageSizes,
-                displayZoom = displayZoom,
                 onTableAxisActionsRequest = { target, openedSelection ->
                   findReplace.close()
                   aiFeedback.close()

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayout.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayout.kt
@@ -26,12 +26,17 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollDispatcher
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.input.pointer.PointerEvent
+import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.PointerInputModifierNode
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import co.typie.editor.ext.unclippedBoundsInRoot
 import co.typie.editor.interaction.EditorPlatformIndirectScaleBridge
@@ -77,6 +82,25 @@ private enum class EditorScreenLayoutSlot {
 private const val EditorViewportScrollAnchorTolerance = 1f
 
 private object EditorViewportNestedScrollConnection : NestedScrollConnection
+
+private data object SharePointerInputWithSiblingsElement :
+  ModifierNodeElement<SharePointerInputWithSiblingsNode>() {
+  override fun create(): SharePointerInputWithSiblingsNode = SharePointerInputWithSiblingsNode()
+
+  override fun update(node: SharePointerInputWithSiblingsNode) = Unit
+}
+
+private class SharePointerInputWithSiblingsNode : Modifier.Node(), PointerInputModifierNode {
+  override fun sharePointerInputWithSiblings(): Boolean = true
+
+  override fun onPointerEvent(pointerEvent: PointerEvent, pass: PointerEventPass, bounds: IntSize) =
+    Unit
+
+  override fun onCancelPointerInput() = Unit
+}
+
+private fun Modifier.sharePointerInputWithSiblings(): Modifier =
+  this then SharePointerInputWithSiblingsElement
 
 internal enum class EditorViewportScrollReconcileMode {
   Disabled,
@@ -329,7 +353,10 @@ internal fun EditorScreenLayout(
         .map { it.measure(viewportConstraints) }
     val viewportOverlayPlaceables =
       subcompose(EditorScreenLayoutSlot.ViewportOverlay) {
-          Box(modifier = Modifier.fillMaxSize().clipToBounds(), content = viewportOverlay)
+          Box(
+            modifier = Modifier.fillMaxSize().clipToBounds().sharePointerInputWithSiblings(),
+            content = viewportOverlay,
+          )
         }
         .map { it.measure(viewportConstraints) }
     val overlayPlaceables =

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorScreenOverlayHost.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorScreenOverlayHost.kt
@@ -19,13 +19,11 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import co.typie.editor.Editor
-import co.typie.editor.body.EditorDocumentLayoutSpec
 import co.typie.editor.ext.unclippedBoundsInRoot
 import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.Selection
 import co.typie.editor.ffi.SelectionExpansionUnit
 import co.typie.editor.ffi.SelectionOp
-import co.typie.editor.ffi.Size as PageSize
 import co.typie.editor.runtime.LocalEditorRuntime
 import co.typie.editor.runtime.LocalEditorUiState
 import co.typie.editor.scroll.EditorAutoScrollMode
@@ -41,9 +39,6 @@ internal fun EditorScreenOverlayHost(
   viewportState: EditorViewportState,
   visibleArea: EditorVisibleArea,
   autoScrollPolicy: EditorAutoScrollPolicy,
-  layoutSpec: EditorDocumentLayoutSpec,
-  pageSizes: List<PageSize>,
-  displayZoom: Float,
   onTableAxisActionsRequest: (EditorTableAxisActionsTarget, Selection?) -> Unit,
   showDebugOverlay: Boolean = false,
   modifier: Modifier = Modifier,
@@ -82,15 +77,6 @@ internal fun EditorScreenOverlayHost(
         overlayBoundsInRoot = coordinates.unclippedBoundsInRoot()
       }
   ) {
-    EditorScrollbars(
-      viewportState = viewportState,
-      visibleArea = visibleArea,
-      layoutSpec = layoutSpec,
-      pageSizes = pageSizes,
-      displayZoom = displayZoom,
-      modifier = Modifier.fillMaxSize(),
-    )
-
     if (showDebugOverlay) {
       DebugViewportLine(y = visibleArea.visibleViewportTop, color = Color(0xFF00C853))
       DebugViewportLine(y = visibleArea.visibleViewportBottom, color = Color(0xFF00C853))

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorScrollbars.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorScrollbars.kt
@@ -511,6 +511,7 @@ private fun EditorScrollbarThumb(
 
           awaitEachGesture {
             val down = awaitFirstDown(requireUnconsumed = false)
+            down.consume()
             if (!latestDirectDragEnabled.value) {
               var cancelled = false
               val longPressed =

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayoutDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayoutDesktopTest.kt
@@ -1,14 +1,18 @@
 package co.typie.screen.editor.editor.layout
 
 import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.rememberScrollable2DState
 import androidx.compose.foundation.gestures.rememberScrollableState
 import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -17,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.onNodeWithTag
@@ -27,6 +32,7 @@ import androidx.compose.ui.test.swipe
 import androidx.compose.ui.unit.dp
 import co.typie.editor.EditorState
 import co.typie.editor.body.EditorDocumentLayoutSpec
+import co.typie.editor.ffi.Size as PageSize
 import co.typie.editor.interaction.EditorInteractionMode
 import co.typie.editor.interaction.EditorInteractionScope
 import co.typie.editor.interaction.LocalEditorInteractionScope
@@ -41,13 +47,103 @@ import co.typie.editor.scroll.resolveEditorAutoScrollPolicy
 import co.typie.editor.viewport.EditorViewportState
 import co.typie.navigation.LocalNavigationPopNestedScroll
 import co.typie.navigation.NavigationPopNestedScroll
+import co.typie.screen.editor.editor.overlay.EditorScrollbars
 import co.typie.screen.editor.editor.state.EditorScreenState
+import co.typie.ui.theme.LightColors
+import co.typie.ui.theme.LocalAppColors
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalTestApi::class)
 class EditorScreenLayoutDesktopTest {
+  @Test
+  fun viewportOverlayWheelReachesViewport() = runComposeUiTest {
+    val fixture = ViewportOverlayFixture()
+    setViewportOverlayContent(fixture = fixture, viewportOverlay = { ViewportOverlayTarget() })
+
+    onNodeWithTag(LayoutTag).performMouseInput {
+      moveTo(Offset(x = 30f, y = 16f))
+      scroll(Offset(x = 0f, y = 120f))
+    }
+    waitForIdle()
+
+    assertTrue(fixture.scrollDeltas.isNotEmpty())
+  }
+
+  @Test
+  fun viewportOverlayConsumedDownDoesNotStartEditorGesture() = runComposeUiTest {
+    val fixture = ViewportOverlayFixture()
+    setViewportOverlayContent(fixture = fixture, viewportOverlay = { ViewportOverlayTarget() })
+
+    onNodeWithTag(ViewportOverlayTag).performTouchInput {
+      down(center)
+      up()
+    }
+    waitForIdle()
+
+    assertEquals(0, fixture.editorPointerInputCount)
+    assertEquals(EditorInteractionMode.Idle, fixture.interactionScope.controller.interactionMode)
+  }
+
+  @Test
+  fun scrollbarOwnsDownAndSharesWheelWithViewport() = runComposeUiTest {
+    val fixture = ViewportOverlayFixture()
+    setViewportOverlayContent(
+      fixture = fixture,
+      viewportOverlay = {
+        CompositionLocalProvider(LocalAppColors provides LightColors) {
+          EditorScrollbars(
+            viewportState = fixture.viewportState,
+            visibleArea = fixture.visibleArea,
+            layoutSpec = fixture.layoutSpec,
+            pageSizes = fixture.pageSizes,
+            displayZoom = 1f,
+          )
+        }
+      },
+    )
+    runOnIdle { fixture.viewportState.scrollToY(1f) }
+    waitForIdle()
+
+    onNodeWithTag(LayoutTag).performTouchInput {
+      down(Offset(x = TestViewportSize.width - 20f, y = 32f))
+      up()
+    }
+    waitForIdle()
+    assertEquals(0, fixture.editorPointerInputCount, "scrollbar down reached editor")
+
+    onNodeWithTag(LayoutTag).performMouseInput {
+      moveTo(center)
+      scroll(Offset(x = 0f, y = 120f))
+    }
+    waitForIdle()
+    assertTrue(fixture.scrollDeltas.isNotEmpty(), "wheel outside the thumb did not reach viewport")
+    runOnIdle { fixture.scrollDeltas.clear() }
+
+    onNodeWithTag(LayoutTag).performMouseInput {
+      moveTo(Offset(x = TestViewportSize.width - 20f, y = 32f))
+      scroll(Offset(x = 0f, y = 120f))
+    }
+    waitForIdle()
+
+    assertTrue(fixture.scrollDeltas.isNotEmpty(), "wheel over the thumb did not reach viewport")
+  }
+
+  @Test
+  fun regularOverlayStillBlocksViewportWheel() = runComposeUiTest {
+    val fixture = ViewportOverlayFixture()
+    setViewportOverlayContent(fixture = fixture, overlay = { ViewportOverlayTarget() })
+
+    onNodeWithTag(LayoutTag).performMouseInput {
+      moveTo(center)
+      scroll(Offset(x = 0f, y = 120f))
+    }
+    waitForIdle()
+
+    assertTrue(fixture.scrollDeltas.isEmpty())
+  }
+
   @Test
   fun toolbarOverlaysWithoutShrinkingViewport() = runComposeUiTest {
     var measuredViewportSize = Size.Zero
@@ -391,8 +487,94 @@ class EditorScreenLayoutDesktopTest {
     assertTrue(navigationDragCount > 0)
   }
 
+  private fun androidx.compose.ui.test.ComposeUiTest.setViewportOverlayContent(
+    fixture: ViewportOverlayFixture,
+    viewportOverlay: @Composable BoxScope.() -> Unit = {},
+    overlay: @Composable () -> Unit = {},
+  ) {
+    setContent {
+      val coroutineScope = rememberCoroutineScope()
+      val interactionScope = remember { EditorInteractionScope(coroutineScope = coroutineScope) }
+      fixture.interactionScope = interactionScope
+      CompositionLocalProvider(
+        LocalEditorBringIntoViewRequests provides rememberEditorBringIntoViewRequests(),
+        LocalEditorInteractionScope provides interactionScope,
+        LocalEditorUiState provides fixture.uiState,
+      ) {
+        EditorScreenLayout(
+          state = remember { EditorScreenState(fixture.viewportState) },
+          scrollFrame = fixture.scrollFrame,
+          visibleArea = fixture.visibleArea,
+          viewportScrollableState =
+            rememberScrollable2DState { delta ->
+              fixture.scrollDeltas += delta
+              delta
+            },
+          viewportContentWidth = TestViewportSize.width,
+          viewportScrollReconcileMode = EditorViewportScrollReconcileMode.Disabled,
+          onEditorPointerInput = { fixture.editorPointerInputCount += 1 },
+          onMeasuredViewportSizeChange = {},
+          header = {},
+          body = { interactionModifier -> Box(interactionModifier.fillMaxWidth().height(800.dp)) },
+          viewportOverlay = viewportOverlay,
+          overlay = overlay,
+          toolbar = {},
+          modifier =
+            Modifier.size(width = TestViewportSize.width.dp, height = TestViewportSize.height.dp)
+              .testTag(LayoutTag),
+        )
+      }
+    }
+    waitForIdle()
+  }
+
+  @Composable
+  private fun ViewportOverlayTarget() {
+    Box(
+      Modifier.fillMaxSize()
+        .testTag(ViewportOverlayTag)
+        .pointerInput(Unit) { detectDragGestures { change, _ -> change.consume() } }
+        .pointerInput(Unit) { detectTapGestures(onTap = {}) }
+    )
+  }
+
+  private class ViewportOverlayFixture {
+    val viewportState = EditorViewportState()
+    val visibleArea = EditorVisibleArea(viewport = TestViewportSize)
+    val uiState = EditorUiState()
+    lateinit var interactionScope: EditorInteractionScope
+    val scrollDeltas = mutableListOf<Offset>()
+    var editorPointerInputCount = 0
+
+    val layoutSpec =
+      EditorDocumentLayoutSpec.Paginated(
+        pageWidth = TestViewportSize.width,
+        pageHeight = TestViewportSize.height,
+        pageMarginTop = 0f,
+        pageMarginBottom = 0f,
+        pageMarginLeft = 0f,
+        pageMarginRight = 0f,
+      )
+    val pageSizes =
+      listOf(PageSize(width = TestViewportSize.width, height = TestViewportSize.height * 2f))
+
+    val scrollFrame =
+      EditorScrollFrame(
+        state = EditorState.Initial,
+        layoutSpec = layoutSpec,
+        displayZoom = 1f,
+        visibleArea = visibleArea,
+        autoScrollPolicy = resolveEditorAutoScrollPolicy(visibleArea),
+        headerHeight = 0f,
+        density = 1f,
+        editorBounds = EditorBoundsInContainer(),
+      )
+  }
+
   private companion object {
     const val LayoutTag = "editor-screen-layout"
     const val SubPaneTag = "editor-screen-layout-subpane"
+    const val ViewportOverlayTag = "editor-screen-layout-viewport-overlay-target"
+    val TestViewportSize = Size(width = 320f, height = 640f)
   }
 }


### PR DESCRIPTION
- scrollbar를 EditorScreenOverlayHost에서 ViewportOverlay로 옮김
- scrollbar 위에서 trackpad/wheel scroll이 에디터 viewport에 도달할 수 있도록 함
- direct pointer gesture는 scrollbar가 계속 소유함
- scrollbar, zoom indicator, character count처럼 viewport에 종속된 overlay는 sibling pointer input을 공유
    - trackpad/wheel scroll은 기존 editor viewport 경로에서 처리
    - context menu 등 일반 overlay는 기존처럼 입력 독점
- fresh Down은 Main pass에서 pointer membership만 기록하고, overlay의 consumption을 확인한 뒤 editor gesture로 시작
    - scrollbar thumb는 Down을 consume해 drag와 long press를 계속 소유
    - 소비된 Down은 editor pointer sequence와 physical drag lock에서 제거