### PR TITLE
앱 본문 설정 첫 변경이 반영되지 않는 문제 수정

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/document/bodysettings/DocumentBodySettingsScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/document/bodysettings/DocumentBodySettingsScreen.kt
@@ -226,7 +226,7 @@ fun DocumentBodySettingsScreen(entityId: String) {
             style = resolvedBodyStyle,
             fontFamilies = model.fontFamilies,
             sheet = sheet,
-            onStyleChange = ::saveStyle,
+            onStyleChange = { style -> saveStyle(style) },
           )
 
           EditorSettingsSectionDivider()
@@ -234,12 +234,15 @@ fun DocumentBodySettingsScreen(entityId: String) {
           EditorSettingsLayoutSection(
             layout = resolvedLayout,
             sheet = sheet,
-            onLayoutChange = ::saveLayout,
+            onLayoutChange = { layout -> saveLayout(layout) },
           )
 
           EditorSettingsSectionDivider()
 
-          EditorSettingsDetailLayoutSection(style = resolvedBodyStyle, onStyleChange = ::saveStyle)
+          EditorSettingsDetailLayoutSection(
+            style = resolvedBodyStyle,
+            onStyleChange = { style -> saveStyle(style) },
+          )
         }
       }
 


### PR DESCRIPTION
새 문서의 본문 설정에서 크기·자간·행간과 레이아웃의 첫 변경이 반영되지 않다가 다른 설정 변경 후 동작하는 문제 수정. 설정 준비 상태가 바뀌면 각 컨트롤이 최신 저장 콜백을 받도록 함