### PR TITLE
앱 본문 설정 미리보기 텍스트 유지

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/preview/EditorPreview.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/preview/EditorPreview.kt
@@ -38,15 +38,15 @@ import co.typie.editor.body.EditorDocumentLayoutSpec
 import co.typie.editor.body.resolvePaginatedPageGap
 import co.typie.editor.body.toEditorDocumentLayoutSpec
 import co.typie.editor.currentEditorThemeVariant
+import co.typie.editor.enqueueRootLayoutMode
+import co.typie.editor.enqueueRootModifier
 import co.typie.editor.ffi.LayoutMode
 import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.Modifier as EditorModifier
-import co.typie.editor.ffi.ModifierOp
 import co.typie.editor.ffi.ModifierType
 import co.typie.editor.ffi.PlainDoc
 import co.typie.editor.ffi.PlainNode
 import co.typie.editor.ffi.PlainNodeEntry
-import co.typie.editor.ffi.SelectionExpansionUnit
 import co.typie.editor.ffi.SelectionOp
 import co.typie.editor.ffi.SystemEvent
 import co.typie.editor.ffi.Viewport
@@ -88,17 +88,23 @@ internal fun EditorPreview(
 ) {
   val colors = AppTheme.colors
   val scope = rememberCoroutineScope()
-  val doc = remember(layoutMode) { defaultPreviewDoc(layoutMode).withPreviewRootModifiers() }
-  val sourceKey = remember(graph, doc) { graph?.let { it.size to it.contentHashCode() } ?: doc }
-  val layoutSpec = remember(layoutMode) { layoutMode.toEditorDocumentLayoutSpec() }
+  val sourceKey =
+    remember(graph) { graph?.let { it.size to it.contentHashCode() } ?: GeneratedPreviewSourceKey }
+  val doc =
+    remember(runtime, sourceKey) {
+      defaultPreviewDoc(layoutMode).withPreviewRootModifiers(modifiers)
+    }
+  val presentedLayoutMode = runtime.editor?.rootAttrs?.layoutMode ?: layoutMode
+  val layoutSpec =
+    remember(presentedLayoutMode) { presentedLayoutMode.toEditorDocumentLayoutSpec() }
   val background =
     when (layoutSpec) {
       is EditorDocumentLayoutSpec.Continuous -> colors.surfaceDefault
       is EditorDocumentLayoutSpec.Paginated -> colors.surfaceInset
     }
-  val uiState = remember(sourceKey) { EditorUiState() }
-  val zoomController = remember { EditorZoomController(scope = scope) }
-  val bringIntoViewRequests = remember(sourceKey) { EditorBringIntoViewRequests() }
+  val uiState = remember(runtime, sourceKey) { EditorUiState() }
+  val zoomController = remember(runtime, sourceKey) { EditorZoomController(scope = scope) }
+  val bringIntoViewRequests = remember(runtime, sourceKey) { EditorBringIntoViewRequests() }
   val hintHazeState = remember { HazeState() }
   val hintShape = AppShapes.rounded(AppShapes.sm)
   val hintEvents = remember { MutableSharedFlow<Unit>(extraBufferCapacity = 1) }
@@ -110,6 +116,23 @@ internal fun EditorPreview(
       hintAlpha.animateTo(1f, tween(PreviewHintFadeMillis))
       delay(PreviewHintVisibleMillis.toLong())
       hintAlpha.animateTo(0f, tween(PreviewHintFadeMillis))
+    }
+  }
+  LaunchedEffect(runtime.editor, layoutMode, modifiers) {
+    val editor = runtime.editor ?: return@LaunchedEffect
+    val currentModifiers = editor.rootModifiers.orEmpty().toPreviewRootModifierMap()
+    val changedModifiers = modifiers.filter { modifier ->
+      val type = modifier.previewRootModifierType() ?: return@filter false
+      currentModifiers[type] != modifier
+    }
+
+    editor.sync {
+      if (editor.rootAttrs?.layoutMode != layoutMode) {
+        enqueueRootLayoutMode(layoutMode)
+      }
+      changedModifiers.forEach { modifier -> enqueueRootModifier(modifier) }
+      enqueue(Message.Selection(SelectionOp.Unset))
+      enqueue(Message.System(SystemEvent.SetFocused(false)))
     }
   }
 
@@ -156,7 +179,6 @@ internal fun EditorPreview(
               graph = graph,
               doc = doc,
               sourceKey = sourceKey,
-              modifiers = modifiers,
               editorScope = scope,
               runtime = runtime,
               uiState = uiState,
@@ -206,7 +228,6 @@ private fun EditorPreviewContent(
   graph: ByteArray?,
   doc: PlainDoc,
   sourceKey: Any,
-  modifiers: List<EditorModifier>,
   editorScope: CoroutineScope,
   runtime: EditorRuntime,
   uiState: EditorUiState,
@@ -220,29 +241,7 @@ private fun EditorPreviewContent(
   val displayZoom = zoomController.displayZoom
   val editor = runtime.editor
 
-  LaunchedEffect(editor, modifiers) {
-    if (editor == null) {
-      return@LaunchedEffect
-    }
-
-    editor.await {
-      if (modifiers.isNotEmpty()) {
-        enqueue(Message.Selection(SelectionOp.Expand(SelectionExpansionUnit.All)))
-        modifiers.forEach { modifier -> enqueue(Message.Modifier(ModifierOp.Set(modifier))) }
-      }
-      enqueue(Message.Selection(SelectionOp.Unset))
-      enqueue(Message.System(SystemEvent.SetFocused(false)))
-    }
-  }
-
-  LaunchedEffect(
-    sourceKey,
-    viewportWidth,
-    viewportHeight,
-    density.density,
-    themeVariant,
-    modifiers,
-  ) {
+  LaunchedEffect(runtime, sourceKey, viewportWidth, viewportHeight, density.density, themeVariant) {
     val viewport =
       Viewport(
         width = viewportWidth,
@@ -262,7 +261,7 @@ private fun EditorPreviewContent(
           )
         } else {
           Editor.createFromDoc(
-            doc = doc.withPreviewRootModifiers(modifiers),
+            doc = doc,
             viewport = viewport,
             themeVariant = themeVariant,
             scope = editorScope,
@@ -277,7 +276,7 @@ private fun EditorPreviewContent(
           e.enqueue(Message.System(SystemEvent.ThemeVariantChanged))
         }
       }
-      activeEditor.await {
+      activeEditor.sync {
         enqueue(
           Message.System(
             SystemEvent.Resize(
@@ -384,11 +383,6 @@ private fun defaultPreviewDoc(layoutMode: LayoutMode): PlainDoc {
   )
 }
 
-private fun PlainDoc.withPreviewRootModifiers(): PlainDoc {
-  val rootModifiers = DefaultPreviewRootModifiers + root.modifiers
-  return copy(root = root.copy(modifiers = rootModifiers))
-}
-
 private fun PlainDoc.withPreviewRootModifiers(modifiers: List<EditorModifier>): PlainDoc {
   val rootModifiers =
     DefaultPreviewRootModifiers + root.modifiers + modifiers.toPreviewRootModifierMap()
@@ -396,23 +390,23 @@ private fun PlainDoc.withPreviewRootModifiers(modifiers: List<EditorModifier>): 
 }
 
 private fun List<EditorModifier>.toPreviewRootModifierMap(): Map<ModifierType, EditorModifier> =
-  mapNotNull { modifier ->
-      val type =
-        when (modifier) {
-          is EditorModifier.FontFamily -> ModifierType.FontFamily
-          is EditorModifier.FontSize -> ModifierType.FontSize
-          is EditorModifier.FontWeight -> ModifierType.FontWeight
-          is EditorModifier.TextColor -> ModifierType.TextColor
-          is EditorModifier.BackgroundColor -> ModifierType.BackgroundColor
-          is EditorModifier.LetterSpacing -> ModifierType.LetterSpacing
-          is EditorModifier.LineHeight -> ModifierType.LineHeight
-          is EditorModifier.ParagraphIndent -> ModifierType.ParagraphIndent
-          is EditorModifier.BlockGap -> ModifierType.BlockGap
-          else -> null
-        }
-      type?.let { it to modifier }
-    }
-    .toMap()
+  mapNotNull { modifier -> modifier.previewRootModifierType()?.let { it to modifier } }.toMap()
+
+private fun EditorModifier.previewRootModifierType(): ModifierType? =
+  when (this) {
+    is EditorModifier.FontFamily -> ModifierType.FontFamily
+    is EditorModifier.FontSize -> ModifierType.FontSize
+    is EditorModifier.FontWeight -> ModifierType.FontWeight
+    is EditorModifier.TextColor -> ModifierType.TextColor
+    is EditorModifier.BackgroundColor -> ModifierType.BackgroundColor
+    is EditorModifier.LetterSpacing -> ModifierType.LetterSpacing
+    is EditorModifier.LineHeight -> ModifierType.LineHeight
+    is EditorModifier.ParagraphIndent -> ModifierType.ParagraphIndent
+    is EditorModifier.BlockGap -> ModifierType.BlockGap
+    else -> null
+  }
+
+private data object GeneratedPreviewSourceKey
 
 private val DefaultPreviewRootModifiers =
   mapOf(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/document/bodysettings/DocumentBodySettingsScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/document/bodysettings/DocumentBodySettingsScreen.kt
@@ -107,10 +107,6 @@ fun DocumentBodySettingsScreen(entityId: String) {
     val settingsRuntime = remember(document.id) { EditorRuntime(uiScope = scope) }
     val previewRuntime = remember(document.id) { EditorRuntime(uiScope = scope) }
     val previewGraph = if (initial?.hasText == true) graph else null
-    val pendingPreviewChangesets =
-      remember(if (previewGraph == null) null else graphKey) {
-        mutableStateOf<List<ByteArray>>(emptyList())
-      }
     var bodyStyle by remember(document.id) { mutableStateOf<EditorStyleSettings?>(null) }
     val editorThemeVariant = currentEditorThemeVariant()
     var layout by remember(document.id) { mutableStateOf<LayoutMode?>(null) }
@@ -158,14 +154,6 @@ fun DocumentBodySettingsScreen(entityId: String) {
       )
     }
 
-    LaunchedEffect(previewRuntime.editor, pendingPreviewChangesets.value) {
-      val previewEditor = previewRuntime.editor ?: return@LaunchedEffect
-      val changesets = pendingPreviewChangesets.value
-      if (changesets.isEmpty()) return@LaunchedEffect
-      pendingPreviewChangesets.value = emptyList()
-      changesets.forEach { previewEditor.receiveRemoteChangeset(it) }
-    }
-
     fun save(block: EditorScope.() -> Unit) {
       if (!controlsEnabled) return
       val activeEditor = settingsRuntime.editor ?: return
@@ -173,11 +161,6 @@ fun DocumentBodySettingsScreen(entityId: String) {
         model
           .updateBodySettings(editor = activeEditor, documentId = document.id, block = block)
           .withDefaultExceptionHandler(toast)
-          .onOk { changesets ->
-            if (changesets != null && previewGraph != null) {
-              pendingPreviewChangesets.value = pendingPreviewChangesets.value + changesets
-            }
-          }
       }
     }
 
@@ -255,8 +238,7 @@ fun DocumentBodySettingsScreen(entityId: String) {
             shape = previewShape,
             contentTopPadding = topBarClearance,
             graph = previewGraph,
-            modifiers =
-              if (previewGraph == null) resolvedBodyStyle.toEditorModifiers() else emptyList(),
+            modifiers = resolvedBodyStyle.toEditorModifiers(),
           )
         } else {
           Skeleton.Bone(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/presetsettings/PresetSettingsScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/presetsettings/PresetSettingsScreen.kt
@@ -99,7 +99,7 @@ fun PresetSettingsScreen() {
     val previewContainerHeight = topBarClearance + previewHeight
     val previewShape = RoundedCornerShape(bottomStart = AppShapes.xl, bottomEnd = AppShapes.xl)
     val style = model.preset.toEditorStyleSettings()
-    val previewRuntime = remember(layout) { EditorRuntime(uiScope = scope) }
+    val previewRuntime = remember { EditorRuntime(uiScope = scope) }
 
     Box(
       modifier =

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/preview/EditorPreviewDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/preview/EditorPreviewDesktopTest.kt
@@ -1,0 +1,185 @@
+package co.typie.editor.preview
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import co.typie.editor.Editor
+import co.typie.editor.EditorRootId
+import co.typie.editor.FakeFfiEditor
+import co.typie.editor.ffi.EditorEvent
+import co.typie.editor.ffi.LayoutMode
+import co.typie.editor.ffi.Message
+import co.typie.editor.ffi.NodeOp
+import co.typie.editor.ffi.PlainNode
+import co.typie.editor.ffi.PlainRootNode
+import co.typie.editor.runtime.EditorRuntime
+import co.typie.ui.theme.LocalThemeMode
+import co.typie.ui.theme.ResolvedThemeMode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+
+@OptIn(ExperimentalTestApi::class)
+class EditorPreviewDesktopTest {
+  @Test
+  fun generatedPreviewKeepsItsEditorWhenPageSizeChanges() = runComposeUiTest {
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+    val fake = FakeFfiEditor(rootAttrsProvider = { PlainRootNode(layoutMode = A4Layout) })
+    val editor = Editor(fake, scope, Dispatchers.Unconfined)
+    val runtime = EditorRuntime(scope).apply { attach(editor) }
+    var layout by mutableStateOf<LayoutMode>(A4Layout)
+    editor.sync {}
+
+    try {
+      setPreviewContent(runtime = runtime, layout = { layout })
+      waitForIdle()
+
+      runOnIdle { layout = B6Layout }
+      waitForIdle()
+
+      runOnIdle { assertSame(editor, runtime.editor) }
+    } finally {
+      runtime.clear()
+      scope.cancel()
+    }
+  }
+
+  @Test
+  fun graphPreviewAppliesPageSizeBeforePersistedChangesReturn() = runComposeUiTest {
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+    val fake = FakeFfiEditor(rootAttrsProvider = { PlainRootNode(layoutMode = A4Layout) })
+    val editor = Editor(fake, scope, Dispatchers.Unconfined)
+    val runtime = EditorRuntime(scope).apply { attach(editor) }
+    var layout by mutableStateOf<LayoutMode>(A4Layout)
+    editor.sync {}
+
+    try {
+      setPreviewContent(runtime = runtime, graph = byteArrayOf(1), layout = { layout })
+      waitForIdle()
+      fake.enqueued.clear()
+
+      runOnIdle { layout = B6Layout }
+      waitUntil { fake.enqueued.filterIsInstance<Message.Node>().isNotEmpty() }
+
+      assertEquals(
+        listOf(
+          Message.Node(
+            NodeOp.SetAttrs(id = EditorRootId, attrs = PlainNode.Root(layoutMode = B6Layout))
+          )
+        ),
+        fake.enqueued.filterIsInstance<Message.Node>(),
+      )
+    } finally {
+      runtime.clear()
+      scope.cancel()
+    }
+  }
+
+  @Test
+  fun previewUpdatesEditorLayoutBeforeRenderInvalidation() = runComposeUiTest {
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+    var reportedLayout: LayoutMode = A4Layout
+    val fake =
+      FakeFfiEditor(
+        onTick = { listOf(EditorEvent.RenderInvalidated) },
+        rootAttrsProvider = { PlainRootNode(layoutMode = reportedLayout) },
+      )
+    val editor = Editor(fake, scope, Dispatchers.Unconfined)
+    val runtime = EditorRuntime(scope).apply { attach(editor) }
+    var layout by mutableStateOf<LayoutMode>(A4Layout)
+    editor.sync {}
+
+    try {
+      setPreviewContent(runtime = runtime, layout = { layout })
+      waitForIdle()
+
+      val surface =
+        editor.attachSurface(
+          page = 0,
+          handle = 1L,
+          width = A4Layout.pageWidth.toDouble(),
+          height = A4Layout.pageHeight.toDouble(),
+          scaleFactor = 1.0,
+        )
+      var observeNextRender = false
+      var layoutAtRender: LayoutMode? = null
+      val off =
+        editor.on<EditorEvent.RenderInvalidated> { _, _ ->
+          if (observeNextRender) {
+            layoutAtRender = editor.rootAttrs?.layoutMode
+            editor.onPageSettled(page = 0, version = Long.MAX_VALUE)
+          }
+        }
+
+      runOnIdle {
+        observeNextRender = true
+        reportedLayout = B6Layout
+        layout = B6Layout
+      }
+      waitUntil { layoutAtRender != null }
+
+      assertEquals(B6Layout, layoutAtRender)
+      off()
+      surface.detach()
+    } finally {
+      runtime.clear()
+      scope.cancel()
+    }
+  }
+
+  private fun androidx.compose.ui.test.ComposeUiTest.setPreviewContent(
+    runtime: EditorRuntime,
+    graph: ByteArray? = null,
+    layout: () -> LayoutMode,
+  ) {
+    setContent {
+      CompositionLocalProvider(
+        LocalDensity provides Density(1f),
+        LocalThemeMode provides ResolvedThemeMode.Light,
+      ) {
+        EditorPreview(
+          layoutMode = layout(),
+          runtime = runtime,
+          modifier = Modifier.size(0.dp),
+          shape = RoundedCornerShape(0.dp),
+          graph = graph,
+        )
+      }
+    }
+  }
+
+  private companion object {
+    val A4Layout =
+      LayoutMode.Paginated(
+        pageWidth = 794,
+        pageHeight = 1123,
+        pageMarginTop = 94,
+        pageMarginBottom = 94,
+        pageMarginLeft = 94,
+        pageMarginRight = 94,
+      )
+
+    val B6Layout =
+      LayoutMode.Paginated(
+        pageWidth = 484,
+        pageHeight = 686,
+        pageMarginTop = 57,
+        pageMarginBottom = 57,
+        pageMarginLeft = 57,
+        pageMarginRight = 57,
+      )
+  }
+}


### PR DESCRIPTION
본문 설정에서 페이지 레이아웃을 변경할 때 미리보기 editor가 다시 생성되면서, 빈 문서의 미리보기 텍스트가 사라지거나 변경사항 반영이 늦어질 수 있던 문제를 수정함

- 페이지 레이아웃이 바뀌어도 본문 설정 및 프리셋 미리보기의 editor/runtime을 유지
- 선택한 레이아웃과 본문 서식을 저장 changeset을 기다리지 않고 preview editor의 root에 바로 반영