### PR TITLE
앱 페이지 크기 변경 시 surface resize 누락 수정

### DIFF
--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/render/RenderCanvas.android.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/render/RenderCanvas.android.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.core.graphics.createBitmap
+import co.typie.editor.SurfaceConfiguration
 import com.sun.jna.Pointer
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.conflate
@@ -25,6 +26,7 @@ import kotlinx.coroutines.flow.conflate
 internal actual fun RenderCanvas(
   modifier: Modifier,
   desiredPixelSize: IntSize,
+  configuration: SurfaceConfiguration,
   trigger: SharedFlow<Long>,
   onAttach: (handle: Long) -> Unit,
   onDetach: (releaseBuffer: () -> Unit) -> Unit,
@@ -39,7 +41,7 @@ internal actual fun RenderCanvas(
   val currentOnResize by rememberUpdatedState(onResize)
   val currentOnBitmapCommitted by rememberUpdatedState(onBitmapCommitted)
 
-  LaunchedEffect(desiredPixelSize) {
+  LaunchedEffect(desiredPixelSize, configuration) {
     if (desiredPixelSize.width <= 0 || desiredPixelSize.height <= 0) return@LaunchedEffect
     if (bufferHandle == 0L) {
       val handle = RenderBuffer.allocate(desiredPixelSize.width, desiredPixelSize.height)

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorSurfaceScheduler.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorSurfaceScheduler.kt
@@ -17,6 +17,12 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
+internal data class SurfaceConfiguration(
+  val width: Double,
+  val height: Double,
+  val scaleFactor: Double,
+)
+
 private typealias SurfacePresentedCallback = (version: Long) -> Unit
 
 internal class SurfaceSessionHandle
@@ -29,13 +35,8 @@ internal constructor(
     scheduler.requestRender(this, onPresented)
   }
 
-  fun requestResize(
-    width: Double,
-    height: Double,
-    scaleFactor: Double,
-    onPresented: SurfacePresentedCallback,
-  ) {
-    scheduler.requestResize(this, width, height, scaleFactor, onPresented)
+  fun requestResize(configuration: SurfaceConfiguration, onPresented: SurfacePresentedCallback) {
+    scheduler.requestResize(this, configuration, onPresented)
   }
 
   fun detach(onDetached: () -> Unit = {}) {
@@ -44,6 +45,8 @@ internal constructor(
 }
 
 private data class SurfaceSession(val id: Long)
+
+private data class AttachedSurfaceSession(val id: Long, val configuration: SurfaceConfiguration)
 
 private data class SurfaceSessionKey(val page: Int, val sessionId: Long)
 
@@ -56,9 +59,7 @@ private data class SurfaceAttachCommand(
   override val sessionId: Long,
   override val page: Int,
   val handle: Long,
-  val width: Double,
-  val height: Double,
-  val scaleFactor: Double,
+  val configuration: SurfaceConfiguration,
 ) : SurfaceCommand
 
 private sealed interface SurfaceRenderCommand : SurfaceCommand {
@@ -74,9 +75,7 @@ private data class SurfaceRenderOnlyCommand(
 private data class SurfaceResizeAndRenderCommand(
   override val sessionId: Long,
   override val page: Int,
-  val width: Double,
-  val height: Double,
-  val scaleFactor: Double,
+  val configuration: SurfaceConfiguration,
   override val onPresented: SurfacePresentedCallback,
 ) : SurfaceRenderCommand
 
@@ -104,7 +103,7 @@ internal class EditorSurfaceScheduler(
   private val commands: AtomicReference<PersistentList<SurfaceCommand>> =
     AtomicReference(persistentListOf())
   private val scheduled: AtomicBoolean = AtomicBoolean(false)
-  private val attachedSessions: AtomicReference<PersistentMap<Int, Long>> =
+  private val attachedSessions: AtomicReference<PersistentMap<Int, AttachedSurfaceSession>> =
     AtomicReference(persistentMapOf())
   private val pendingAttachSessions: AtomicReference<PersistentSet<SurfaceSessionKey>> =
     AtomicReference(persistentSetOf())
@@ -128,9 +127,7 @@ internal class EditorSurfaceScheduler(
         sessionId = sessionId,
         page = page,
         handle = handle,
-        width = width,
-        height = height,
-        scaleFactor = scaleFactor,
+        configuration = SurfaceConfiguration(width, height, scaleFactor),
       )
     )
     return surface
@@ -149,9 +146,7 @@ internal class EditorSurfaceScheduler(
 
   fun requestResize(
     surface: SurfaceSessionHandle,
-    width: Double,
-    height: Double,
-    scaleFactor: Double,
+    configuration: SurfaceConfiguration,
     onPresented: SurfacePresentedCallback,
   ) {
     if (disposed.load() || !isActive(surface)) return
@@ -159,9 +154,7 @@ internal class EditorSurfaceScheduler(
       SurfaceResizeAndRenderCommand(
         sessionId = surface.id,
         page = surface.page,
-        width = width,
-        height = height,
-        scaleFactor = scaleFactor,
+        configuration = configuration,
         onPresented = onPresented,
       )
     )
@@ -205,7 +198,7 @@ internal class EditorSurfaceScheduler(
   private fun isActive(page: Int, sessionId: Long): Boolean = sessions.load()[page]?.id == sessionId
 
   private fun requiresDeferredDetach(page: Int, sessionId: Long): Boolean =
-    attachedSessions.load()[page] == sessionId ||
+    attachedSessions.load()[page]?.id == sessionId ||
       pendingAttachSessions.load().contains(SurfaceSessionKey(page, sessionId))
 
   private fun enqueue(command: SurfaceCommand) {
@@ -239,40 +232,43 @@ internal class EditorSurfaceScheduler(
     command: SurfaceRenderOnlyCommand
   ): PersistentList<SurfaceCommand> {
     var replaced = false
-    val next = map { queued ->
-      when {
-        queued is SurfaceResizeAndRenderCommand && queued.sessionId == command.sessionId -> {
-          replaced = true
-          queued.copy(onPresented = command.onPresented)
+    val next =
+      map { queued ->
+          when {
+            queued is SurfaceResizeAndRenderCommand && queued.sessionId == command.sessionId -> {
+              replaced = true
+              queued.copy(onPresented = command.onPresented)
+            }
+            queued is SurfaceRenderOnlyCommand && queued.sessionId == command.sessionId -> {
+              replaced = true
+              command
+            }
+            else -> queued
+          }
         }
-        queued is SurfaceRenderOnlyCommand && queued.sessionId == command.sessionId -> {
-          replaced = true
-          command
-        }
-        else -> queued
-      }
-    }
-      .toPersistentList()
+        .toPersistentList()
     return if (replaced) next else next.adding(command)
   }
 
   private fun PersistentList<SurfaceCommand>.coalesceResize(
     command: SurfaceResizeAndRenderCommand
-  ): PersistentList<SurfaceCommand> = filterNot {
-    it.sessionId == command.sessionId &&
-      (it is SurfaceRenderOnlyCommand || it is SurfaceResizeAndRenderCommand)
-  }
-    .toPersistentList()
-    .adding(command)
+  ): PersistentList<SurfaceCommand> =
+    filterNot {
+        it.sessionId == command.sessionId &&
+          (it is SurfaceRenderOnlyCommand || it is SurfaceResizeAndRenderCommand)
+      }
+      .toPersistentList()
+      .adding(command)
 
   private fun PersistentList<SurfaceCommand>.coalesceDetach(
     command: SurfaceDetachCommand
-  ): PersistentList<SurfaceCommand> = filterNot {
-    it.sessionId == command.sessionId &&
-      (it is SurfaceRenderOnlyCommand || it is SurfaceResizeAndRenderCommand)
-  }
-    .toPersistentList()
-    .adding(command)
+  ): PersistentList<SurfaceCommand> =
+    filterNot {
+        it.sessionId == command.sessionId &&
+          (it is SurfaceRenderOnlyCommand || it is SurfaceResizeAndRenderCommand)
+      }
+      .toPersistentList()
+      .adding(command)
 
   private fun schedule() {
     if (!scheduled.compareAndSet(expectedValue = false, newValue = true)) return
@@ -333,11 +329,13 @@ internal class EditorSurfaceScheduler(
       inner.attachSurface(
         command.page,
         command.handle,
-        command.width,
-        command.height,
-        command.scaleFactor,
+        command.configuration.width,
+        command.configuration.height,
+        command.configuration.scaleFactor,
       )
-      attachedSessions.updatePersistent { it.putting(command.page, command.sessionId) }
+      attachedSessions.updatePersistent {
+        it.putting(command.page, AttachedSurfaceSession(command.sessionId, command.configuration))
+      }
       attached = true
     }
 
@@ -354,13 +352,49 @@ internal class EditorSurfaceScheduler(
   private suspend fun flushRender(command: SurfaceRenderCommand) {
     if (disposed.load() || !isActive(command.page, command.sessionId)) return
 
-    // Reading the version before rendering under-reports what the frame may
-    // contain, which only delays a settle until the follow-up render command;
-    // the skip path below then settles it with a fresh read.
-    val version = versionCounter.load()
-    if (command is SurfaceResizeAndRenderCommand) {
-      inner.resizeSurface(command.page, command.width, command.height, command.scaleFactor)
+    val applied =
+      when (command) {
+        is SurfaceResizeAndRenderCommand -> {
+          val configuration = command.configuration
+          inner.resizeSurface(
+            command.page,
+            configuration.width,
+            configuration.height,
+            configuration.scaleFactor,
+          )
+          attachedSessions.updatePersistent { sessions ->
+            if (sessions[command.page]?.id == command.sessionId) {
+              sessions.putting(
+                command.page,
+                AttachedSurfaceSession(command.sessionId, configuration),
+              )
+            } else {
+              sessions
+            }
+          }
+          configuration
+        }
+
+        is SurfaceRenderOnlyCommand -> {
+          val attached = attachedSessions.load()[command.page]
+          if (attached?.id != command.sessionId) return
+          attached.configuration
+        }
+      }
+    val pageSize = inner.pageSizes().getOrNull(command.page)
+    if (
+      pageSize != null &&
+        (pageSize.width.toDouble() != applied.width || pageSize.height.toDouble() != applied.height)
+    ) {
+      // A tick changed logical page geometry before the matching surface resize was applied.
+      // Rendering here would put the new layout into an old target. Settle this attempt;
+      // the published state will request the matching resize-and-render.
+      onPageSettled(command.page, versionCounter.load())
+      return
     }
+    // Reading the version before rendering under-reports what the frame may contain,
+    // which only delays a settle until the follow-up render command.
+    val version = versionCounter.load()
     val presented = inner.renderSurface(command.page)
 
     if (!isActive(command.page, command.sessionId)) return
@@ -388,14 +422,14 @@ internal class EditorSurfaceScheduler(
   }
 
   private suspend fun detachAttachedSession(page: Int, sessionId: Long) {
-    if (attachedSessions.load()[page] != sessionId) return
+    if (attachedSessions.load()[page]?.id != sessionId) return
     inner.detachSurface(page)
     removeAttachedSession(page, sessionId)
   }
 
   private fun removeAttachedSession(page: Int, sessionId: Long) {
     attachedSessions.updatePersistent { current ->
-      if (current[page] == sessionId) current.removing(page) else current
+      if (current[page]?.id == sessionId) current.removing(page) else current
     }
   }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/render/RenderCanvas.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/render/RenderCanvas.kt
@@ -3,12 +3,14 @@ package co.typie.editor.render
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.IntSize
+import co.typie.editor.SurfaceConfiguration
 import kotlinx.coroutines.flow.SharedFlow
 
 @Composable
 internal expect fun RenderCanvas(
   modifier: Modifier,
   desiredPixelSize: IntSize,
+  configuration: SurfaceConfiguration,
   trigger: SharedFlow<Long>,
   onAttach: (handle: Long) -> Unit,
   onDetach: (releaseBuffer: () -> Unit) -> Unit,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/surface/EditorPageSurface.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/surface/EditorPageSurface.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import co.typie.editor.LocalEditorZoomController
+import co.typie.editor.SurfaceConfiguration
 import co.typie.editor.SurfaceSessionHandle
 import co.typie.editor.ffi.EditorEvent
 import co.typie.editor.render.RenderCanvas
@@ -70,19 +71,21 @@ internal fun EditorPageSurface(
       }
     }
   var surfaceSession by remember(editor, page) { mutableStateOf<SurfaceSessionHandle?>(null) }
-  val render =
-    remember(editor, page, onPresented) { { surfaceSession?.requestRender(onPresented) } }
 
   val widthDouble = width.toDouble()
   val heightDouble = height.toDouble()
-  val renderWidthPx = round(widthDouble * density.density.toDouble() * renderZoom.toDouble())
-  val renderHeightPx = round(heightDouble * density.density.toDouble() * renderZoom.toDouble())
-  val renderWidthPxInt = renderWidthPx.toInt().coerceAtLeast(1)
-  val renderHeightPxInt = renderHeightPx.toInt().coerceAtLeast(1)
-  val desiredPixelSize = IntSize(renderWidthPxInt, renderHeightPxInt)
+  val configuration =
+    SurfaceConfiguration(width = widthDouble, height = heightDouble, scaleFactor = scaleFactor)
+  val desiredPixelSize =
+    IntSize(
+      width = round(configuration.width * configuration.scaleFactor).toInt().coerceAtLeast(1),
+      height = round(configuration.height * configuration.scaleFactor).toInt().coerceAtLeast(1),
+    )
   var committedPixelSize by remember { mutableStateOf(desiredPixelSize) }
   var committedRenderZoom by remember { mutableFloatStateOf(renderZoom) }
   val currentRenderZoom by rememberUpdatedState(renderZoom)
+  val render =
+    remember(editor, page, onPresented) { { surfaceSession?.requestRender(onPresented) } }
   var renderActive by remember(editor, page) { mutableStateOf(false) }
 
   val safeCommittedRenderZoom = if (committedRenderZoom > 0f) committedRenderZoom else 1f
@@ -149,6 +152,7 @@ internal fun EditorPageSurface(
                 transformOrigin = TransformOrigin(0f, 0f),
               ),
             desiredPixelSize = desiredPixelSize,
+            configuration = configuration,
             trigger = trigger,
             onAttach = { handle ->
               surfaceSession =
@@ -158,9 +162,7 @@ internal fun EditorPageSurface(
               surfaceSession?.detach(releaseBuffer) ?: releaseBuffer()
               surfaceSession = null
             },
-            onResize = {
-              surfaceSession?.requestResize(widthDouble, heightDouble, scaleFactor, onPresented)
-            },
+            onResize = { surfaceSession?.requestResize(configuration, onPresented) },
             onBitmapCommitted = { size, version ->
               committedPixelSize = size
               committedRenderZoom = currentRenderZoom

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorAwaitTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorAwaitTest.kt
@@ -13,6 +13,7 @@ import co.typie.editor.ffi.ProseTrackedRangeRegistration
 import co.typie.editor.ffi.Rect
 import co.typie.editor.ffi.SelectionExpansionUnit
 import co.typie.editor.ffi.SelectionOp
+import co.typie.editor.ffi.Size
 import co.typie.editor.ffi.StateField
 import co.typie.editor.ffi.SystemEvent
 import co.typie.editor.ffi.TrackedRange
@@ -832,10 +833,10 @@ class EditorAwaitTest {
         editor.attachSurface(page = 0, handle = 1L, width = 0.0, height = 0.0, scaleFactor = 1.0)
 
       surface.requestRender { presentedVersions += it }
-      surface.requestResize(width = 10.0, height = 20.0, scaleFactor = 2.0) {
+      surface.requestResize(SurfaceConfiguration(width = 10.0, height = 20.0, scaleFactor = 2.0)) {
         presentedVersions += it
       }
-      surface.requestResize(width = 12.0, height = 24.0, scaleFactor = 3.0) {
+      surface.requestResize(SurfaceConfiguration(width = 12.0, height = 24.0, scaleFactor = 3.0)) {
         presentedVersions += it
       }
 
@@ -852,6 +853,79 @@ class EditorAwaitTest {
       )
       assertEquals(1, fake.renderCount)
       assertEquals(listOf(0L), presentedVersions)
+    }
+
+  @Test
+  fun render_settles_without_rendering_when_engine_page_size_differs_from_surface() =
+    runTest(dispatcher) {
+      var pageSize = Size(width = 1f, height = 2f)
+      val fake =
+        FakeFfiEditor(
+          onTick = { listOf(EditorEvent.RenderInvalidated) },
+          pageSizesProvider = { listOf(pageSize) },
+        )
+      val editor = Editor(fake, this, dispatcher)
+      val surface =
+        editor.attachSurface(page = 0, handle = 1L, width = 1.0, height = 2.0, scaleFactor = 1.0)
+      dispatcher.scheduler.advanceUntilIdle()
+
+      pageSize = Size(width = 3f, height = 4f)
+      var returned = false
+      val job =
+        launch(dispatcher) {
+          editor.await { enqueue(sampleMessage) }
+          returned = true
+        }
+      dispatcher.scheduler.advanceUntilIdle()
+      assertFalse(returned)
+
+      surface.requestRender { version -> editor.onPageSettled(page = 0, version = version) }
+      dispatcher.scheduler.advanceUntilIdle()
+
+      assertTrue(returned)
+      assertEquals(0, fake.renderCount)
+      job.join()
+    }
+
+  @Test
+  fun stale_surface_resize_settles_without_rendering() =
+    runTest(dispatcher) {
+      var pageSize = Size(width = 1f, height = 2f)
+      val fake =
+        FakeFfiEditor(
+          onTick = { listOf(EditorEvent.RenderInvalidated) },
+          pageSizesProvider = { listOf(pageSize) },
+        )
+      val editor = Editor(fake, this, dispatcher)
+      val surface =
+        editor.attachSurface(page = 0, handle = 1L, width = 1.0, height = 2.0, scaleFactor = 1.0)
+      dispatcher.scheduler.advanceUntilIdle()
+
+      pageSize = Size(width = 3f, height = 4f)
+      var returned = false
+      val job =
+        launch(dispatcher) {
+          editor.await { enqueue(sampleMessage) }
+          returned = true
+        }
+      dispatcher.scheduler.advanceUntilIdle()
+      assertFalse(returned)
+
+      surface.requestResize(SurfaceConfiguration(width = 1.0, height = 2.0, scaleFactor = 1.0)) {
+        version ->
+        editor.onPageSettled(page = 0, version = version)
+      }
+      dispatcher.scheduler.advanceUntilIdle()
+
+      assertTrue(returned)
+      assertEquals(
+        listOf(
+          FakeFfiEditor.SurfaceResizeCall(page = 0, width = 1.0, height = 2.0, scaleFactor = 1.0)
+        ),
+        fake.resizeCalls,
+      )
+      assertEquals(0, fake.renderCount)
+      job.join()
     }
 
   @Test

--- a/apps/mobile/compose/src/skikoMain/kotlin/co/typie/editor/render/RenderCanvas.skiko.kt
+++ b/apps/mobile/compose/src/skikoMain/kotlin/co/typie/editor/render/RenderCanvas.skiko.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asComposeImageBitmap
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
+import co.typie.editor.SurfaceConfiguration
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.conflate
 import org.jetbrains.skia.Bitmap
@@ -26,6 +27,7 @@ import org.jetbrains.skia.impl.use
 internal actual fun RenderCanvas(
   modifier: Modifier,
   desiredPixelSize: IntSize,
+  configuration: SurfaceConfiguration,
   trigger: SharedFlow<Long>,
   onAttach: (handle: Long) -> Unit,
   onDetach: (releaseBuffer: () -> Unit) -> Unit,
@@ -40,7 +42,7 @@ internal actual fun RenderCanvas(
   val currentOnResize by rememberUpdatedState(onResize)
   val currentOnBitmapCommitted by rememberUpdatedState(onBitmapCommitted)
 
-  LaunchedEffect(desiredPixelSize) {
+  LaunchedEffect(desiredPixelSize, configuration) {
     if (desiredPixelSize.width <= 0 || desiredPixelSize.height <= 0) return@LaunchedEffect
     if (bufferHandle == 0L) {
       val handle = RenderBuffer.allocate(desiredPixelSize.width, desiredPixelSize.height)


### PR DESCRIPTION
페이지 크기와 render zoom이 함께 바뀌어 최종 pixel buffer 크기가 같으면 surface resize가 실행되지 않아, 이전 페이지 크기의 surface에 새 layout을 렌더링할 수 있던 문제를 수정함

- 논리 width, height, scale factor를 surface configuration으로 묶어 pixel size와 함께 resize 기준으로 사용
- surface session에 실제 적용된 configuration을 기록하고 최신 editor page 크기와 일치할 때만 render
- 오래된 render 또는 resize 명령이 실행되면 잘못된 bitmap을 만들지 않고 해당 시도를 settle
- page 크기와 surface 크기가 다른 render 및 stale resize 회귀 테스트 추가