### PR TITLE
앱 에디터 탭 직후 trackpad zoom이 double tap으로 처리되는 문제 수정

### DIFF
--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/platform/PlatformModule.android.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/platform/PlatformModule.android.kt
@@ -2,6 +2,8 @@ package co.typie.platform
 
 import android.annotation.SuppressLint
 import android.content.Context
+import androidx.compose.ui.input.pointer.PointerEvent
+import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerType
 import co.typie.editor.ffi.EditorHost
 import co.typie.editor.ffi.JnaEditorHost
@@ -40,3 +42,5 @@ actual object PlatformModule {
 }
 
 internal actual fun PointerType.isTouchDragPointer(): Boolean = this == PointerType.Touch
+
+internal actual fun PointerEvent.isDirectMousePress(): Boolean = type == PointerEventType.Press

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionGestures.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionGestures.kt
@@ -496,6 +496,7 @@ internal class EditorInteractionGestures(
     context: EditorGestureContext,
   ) {
     if (previousMode != currentMode && currentMode == EditorInteractionMode.ViewportZooming) {
+      tap.clearTapHistory()
       pan.cancel(context = context)
       resetPointerOwnedState(context = context)
     }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractions.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractions.kt
@@ -27,6 +27,7 @@ import co.typie.editor.ffi.InputModifiers
 import co.typie.editor.viewport.normalizeEditorViewportWheelZoomDelta
 import co.typie.ext.ScrollGestureLockHandle
 import co.typie.ext.ScrollGestureLockState
+import co.typie.platform.isDirectMousePress
 import co.typie.platform.isTouchDragPointer
 import kotlin.math.abs
 import kotlin.math.min
@@ -231,7 +232,7 @@ private class EditorInteractionsNode(
       cancelInteraction(clearSuppression = true)
       return
     }
-    if (pointerEvent.changes.any(PointerInputChange::isUnconsumedDown)) {
+    if (pointerEvent.changes.any { change -> change.isUnconsumedDirectDown(pointerEvent) }) {
       onEditorPointerInput()
     }
 
@@ -316,8 +317,7 @@ private class EditorInteractionsNode(
       return true
     }
 
-    val hasFreshDown =
-      pointerEvent.changes.any { change -> change.pressed && !change.previousPressed }
+    val hasFreshDown = pointerEvent.changes.any { change -> change.isDirectDown(pointerEvent) }
     // Track membership before the screen observer's Final pass, but let shared overlay siblings
     // claim direct gestures during Main before admitting a new editor sequence.
     return when (pass) {
@@ -371,22 +371,24 @@ private class EditorInteractionsNode(
   }
 
   private fun registerPointerDowns(pointerEvent: PointerEvent) {
-    pointerEvent.changes.filter(PointerInputChange::isUnconsumedDown).forEach { change ->
-      pointers[change.id.value] = change.type
-      if (
-        physicalDragLockHandle == null &&
-          change.type == PointerType.Mouse &&
-          change.type.isTouchDragPointer()
-      ) {
-        physicalDragLockHandle = scrollGestureLockState.acquire()
+    pointerEvent.changes
+      .filter { it.isUnconsumedDirectDown(pointerEvent) }
+      .forEach { change ->
+        pointers[change.id.value] = change.type
+        if (
+          physicalDragLockHandle == null &&
+            change.type == PointerType.Mouse &&
+            change.type.isTouchDragPointer()
+        ) {
+          physicalDragLockHandle = scrollGestureLockState.acquire()
+        }
       }
-    }
   }
 
   private fun discardConsumedPointerDowns(pointerEvent: PointerEvent) {
     var pointerRemoved = false
     pointerEvent.changes
-      .filter { change -> change.pressed && !change.previousPressed && change.isConsumed }
+      .filter { change -> change.isDirectDown(pointerEvent) && change.isConsumed }
       .forEach { change ->
         if (pointers.remove(change.id.value) != null) {
           pointerRemoved = true
@@ -411,25 +413,27 @@ private class EditorInteractionsNode(
     }
 
   private fun forwardSinglePointerChanges(pointerEvent: PointerEvent) {
-    pointerEvent.changes.filter(PointerInputChange::isUnconsumedDown).forEach { change ->
-      val rootPosition = positionInRoot(change.position)
-      val tapEnabled = geometry.isTapEligible(change.position)
-      val editorPosition = geometry.resolveInteractionPosition(change.position)
-      singlePointerStreams += change.id.value
-      if (
-        interactionController.onPointerDown(
-          pointerId = change.id.value,
-          position = editorPosition,
-          nowMillis = change.uptimeMillis,
-          tapEnabled = tapEnabled,
-          inputModifiers = pointerEvent.inputModifiers(),
-          positionInRoot = rootPosition,
-          touchPanDriver = if (change.type.isTouchDragPointer()) scrollDriver else null,
-        )
-      ) {
-        change.consume()
+    pointerEvent.changes
+      .filter { it.isUnconsumedDirectDown(pointerEvent) }
+      .forEach { change ->
+        val rootPosition = positionInRoot(change.position)
+        val tapEnabled = geometry.isTapEligible(change.position)
+        val editorPosition = geometry.resolveInteractionPosition(change.position)
+        singlePointerStreams += change.id.value
+        if (
+          interactionController.onPointerDown(
+            pointerId = change.id.value,
+            position = editorPosition,
+            nowMillis = change.uptimeMillis,
+            tapEnabled = tapEnabled,
+            inputModifiers = pointerEvent.inputModifiers(),
+            positionInRoot = rootPosition,
+            touchPanDriver = if (change.type.isTouchDragPointer()) scrollDriver else null,
+          )
+        ) {
+          change.consume()
+        }
       }
-    }
 
     pointerEvent.changes
       .filter { change ->
@@ -911,8 +915,11 @@ private class EditorScreenPointerObserverNode(var sequence: EditorScreenPointerS
   }
 }
 
-private fun PointerInputChange.isUnconsumedDown(): Boolean =
-  pressed && !previousPressed && !isConsumed
+private fun PointerInputChange.isDirectDown(pointerEvent: PointerEvent): Boolean =
+  pressed && !previousPressed && (type != PointerType.Mouse || pointerEvent.isDirectMousePress())
+
+private fun PointerInputChange.isUnconsumedDirectDown(pointerEvent: PointerEvent): Boolean =
+  isDirectDown(pointerEvent) && !isConsumed
 
 private fun PointerEvent.inputModifiers(): InputModifiers {
   val modifiers = keyboardModifiers

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/platform/PlatformModule.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/platform/PlatformModule.kt
@@ -1,5 +1,6 @@
 package co.typie.platform
 
+import androidx.compose.ui.input.pointer.PointerEvent
 import androidx.compose.ui.input.pointer.PointerType
 import co.typie.editor.ffi.EditorHost
 import co.typie.migration.LegacyMigrationPlatformSource
@@ -28,3 +29,5 @@ expect object PlatformModule {
 }
 
 internal expect fun PointerType.isTouchDragPointer(): Boolean
+
+internal expect fun PointerEvent.isDirectMousePress(): Boolean

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
@@ -152,6 +152,46 @@ class EditorInteractionControllerTest {
     }
 
   @Test
+  fun `indirect zoom breaks consecutive tap history`() =
+    runTest(StandardTestDispatcher()) {
+      val fake = FakeFfiEditor()
+      val editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
+      editor.sync {}
+      val host = TestHost(this)
+      val controller =
+        EditorInteractionController(
+          editorProvider = { editor },
+          effects = host,
+          geometry = host,
+          uiStateProvider = { host.uiState },
+          semantics = viewportZoomEnabledSemantics(effects = host),
+        )
+      controller.updateTapSlop(8f)
+      val start = Offset(10f, 20f)
+
+      controller.onPointerDown(pointerId = 1L, position = start, nowMillis = 0L)
+      controller.onPointerUp(pointerId = 1L, position = start, nowMillis = 40L)
+      controller.onTapTimer(nowMillis = 250L)
+      advanceUntilIdle()
+
+      assertTrue(controller.beginIndirectZoom())
+      controller.endIndirectZoom()
+
+      assertFalse(controller.onPointerDown(pointerId = 2L, position = start, nowMillis = 320L))
+      controller.onPointerUp(pointerId = 2L, position = start, nowMillis = 360L)
+      controller.onTapTimer(nowMillis = 570L)
+      advanceUntilIdle()
+
+      assertEquals(
+        listOf<Message>(
+          Message.Selection(SelectionOp.SetAt(page = 0, x = 10f, y = 20f)),
+          Message.Selection(SelectionOp.SetAt(page = 0, x = 10f, y = 20f)),
+        ),
+        fake.enqueued,
+      )
+    }
+
+  @Test
   fun `plain drag past tap slop cancels tap timer without taking over selection`() =
     runTest(StandardTestDispatcher()) {
       val editor = Editor(FakeFfiEditor(), this, StandardTestDispatcher(testScheduler))

--- a/apps/mobile/compose/src/desktopMain/kotlin/co/typie/platform/PlatformModule.desktop.kt
+++ b/apps/mobile/compose/src/desktopMain/kotlin/co/typie/platform/PlatformModule.desktop.kt
@@ -1,5 +1,8 @@
 package co.typie.platform
 
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.input.pointer.PointerEvent
+import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerType
 import co.typie.editor.ffi.EditorHost
 import co.typie.editor.ffi.JnaEditorHost
@@ -33,3 +36,7 @@ actual object PlatformModule {
 
 internal actual fun PointerType.isTouchDragPointer(): Boolean =
   this == PointerType.Touch || this == PointerType.Mouse
+
+@OptIn(ExperimentalComposeUiApi::class)
+internal actual fun PointerEvent.isDirectMousePress(): Boolean =
+  type == PointerEventType.Press && button != null

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/interaction/EditorInteractionsDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/interaction/EditorInteractionsDesktopTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
@@ -20,8 +21,11 @@ import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollDispatcher
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.input.pointer.PointerButtons
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
+import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.platform.testTag
@@ -38,6 +42,7 @@ import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.performTrackpadInput
 import androidx.compose.ui.test.scale
 import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.test.v2.runSkikoComposeUiTest
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import co.typie.editor.Editor
@@ -138,6 +143,32 @@ class EditorInteractionsDesktopTest {
       absoluteTolerance = 0.5f,
     )
   }
+
+  @OptIn(InternalComposeUiApi::class)
+  @Test
+  fun `command scroll with stale primary button state does not start direct gestures`() =
+    runSkikoComposeUiTest {
+      val fixture = Fixture(tapEligible = true)
+      setEditorContent(fixture)
+      val initialZoom = fixture.zoomController.displayZoom
+
+      runOnIdle {
+        scene.sendPointerEvent(
+          eventType = PointerEventType.Scroll,
+          position = Offset(x = 200f, y = 200f),
+          scrollDelta = Offset(x = 0f, y = -24f),
+          timeMillis = 100L,
+          type = PointerType.Mouse,
+          buttons = PointerButtons(isPrimaryPressed = true),
+          keyboardModifiers = PointerKeyboardModifiers(isMetaPressed = true),
+        )
+      }
+      waitForIdle()
+
+      assertEquals(0, fixture.host.tapDispatchScheduleCount)
+      assertEquals(0, fixture.host.longPressDispatchScheduleCount)
+      assertTrue(fixture.zoomController.displayZoom > initialZoom)
+    }
 
   @Test
   fun `desktop ctrl pointer scroll remains viewport scroll`() = runComposeUiTest {
@@ -1826,7 +1857,8 @@ class EditorInteractionsDesktopTest {
 
     override fun isTapEligible(positionInSurface: Offset): Boolean = tapEligible
 
-    override fun resolvePoint(positionInNode: Offset): PagePoint? = null
+    override fun resolvePoint(positionInNode: Offset): PagePoint? =
+      PagePoint(page = 0, x = positionInNode.x, y = positionInNode.y).takeIf { tapEligible }
 
     override fun resolvePagePosition(page: Int, x: Float, y: Float): Offset? = null
 

--- a/apps/mobile/compose/src/iosMain/kotlin/co/typie/platform/PlatformModule.ios.kt
+++ b/apps/mobile/compose/src/iosMain/kotlin/co/typie/platform/PlatformModule.ios.kt
@@ -2,6 +2,9 @@
 
 package co.typie.platform
 
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.input.pointer.PointerEvent
+import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerType
 import co.typie.editor.ffi.EditorHost
 import co.typie.editor.ffi.IosEditorHost
@@ -47,3 +50,7 @@ actual object PlatformModule {
 }
 
 internal actual fun PointerType.isTouchDragPointer(): Boolean = this == PointerType.Touch
+
+@OptIn(ExperimentalComposeUiApi::class)
+internal actual fun PointerEvent.isDirectMousePress(): Boolean =
+  type == PointerEventType.Press && button != null


### PR DESCRIPTION
JVM Desktop에서 탭 직후 Cmd+trackpad scroll로 zoom하면 Skiko가 보정한 synthetic Mouse Press가 두 번째 탭으로 들어가 단어가 선택되던 문제 수정

- Mouse Down은 실제 button transition이 있는 Press일 때만 direct pointer gesture로 시작
    - changed button이 없는 synthetic Press는 tap, long press, physical drag 후보를 만들지 않음
    - 실제 mouse click·click-drag와 기존 indirect Scroll/Pan/Scale 경로는 유지
- viewport zoom이 시작되면 consecutive tap history를 초기화
    - zoom 전후의 탭이 double tap으로 이어지지 않음