### PR TITLE
앱 메인 drawer 애니메이션과 swipe 판정 개선

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/shell/MainDrawer.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/shell/MainDrawer.kt
@@ -1,12 +1,16 @@
 package co.typie.shell
 
+import androidx.compose.animation.core.exponentialDecay
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.DraggableAnchors
 import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.TargetedFlingBehavior
 import androidx.compose.foundation.gestures.anchoredDraggable
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.snapping.SnapLayoutInfoProvider
+import androidx.compose.foundation.gestures.snapping.snapFlingBehavior
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -34,12 +38,17 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChangeIgnoreConsumed
+import androidx.compose.ui.input.pointer.util.VelocityTracker
+import androidx.compose.ui.input.pointer.util.addPointerInputChange
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastFirstOrNull
 import androidx.compose.ui.zIndex
@@ -392,6 +401,7 @@ internal fun CreateSpaceSheet(model: MainDrawerViewModel) {
 fun MainDrawerOverlay(drawer: Drawer) {
   val density = LocalDensity.current
   val scope = rememberCoroutineScope()
+  val flingBehavior = rememberDrawerFlingBehavior(drawer)
 
   BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
     val panelWidthDp =
@@ -457,6 +467,7 @@ fun MainDrawerOverlay(drawer: Drawer) {
             state = drawer.state,
             orientation = Orientation.Horizontal,
             enabled = !drawer.isProgrammaticAnimating,
+            flingBehavior = flingBehavior,
           )
           .background(AppTheme.colors.surfaceDefault, panelShape)
           .statusBarsPadding()
@@ -465,6 +476,27 @@ fun MainDrawerOverlay(drawer: Drawer) {
     ) {
       MainDrawerContent()
     }
+  }
+}
+
+@Composable
+private fun rememberDrawerFlingBehavior(drawer: Drawer): TargetedFlingBehavior {
+  val velocityThresholdPx = with(LocalDensity.current) { DrawerDefaults.VelocityThreshold.toPx() }
+  return remember(drawer, velocityThresholdPx) {
+    snapFlingBehavior(
+      snapLayoutInfoProvider =
+        object : SnapLayoutInfoProvider {
+          override fun calculateApproachOffset(velocity: Float, decayOffset: Float): Float = 0f
+
+          override fun calculateSnapOffset(velocity: Float): Float {
+            val currentOffset = drawer.state.requireOffset()
+            val target = drawer.releaseTarget(velocity, velocityThresholdPx)
+            return drawer.state.anchors.positionOf(target) - currentOffset
+          }
+        },
+      decayAnimationSpec = exponentialDecay(),
+      snapAnimationSpec = DrawerDefaults.AnimationSpec,
+    )
   }
 }
 
@@ -487,14 +519,17 @@ fun mainDrawerSwipeToOpenModifier(drawer: Drawer, enabled: Boolean): Modifier {
 
   return Modifier.pointerInput(drawer) {
     val slop = viewConfiguration.touchSlop
+    val velocityThresholdPx = DrawerDefaults.VelocityThreshold.toPx()
 
     awaitEachGesture {
       val down = awaitFirstDown(requireUnconsumed = false)
-      if (drawer.isOpen || drawer.isProgrammaticAnimating) {
+      if (down.type == PointerType.Mouse || drawer.isOpen || drawer.isProgrammaticAnimating) {
         return@awaitEachGesture
       }
 
-      var overSlopX = 0f
+      val velocityTracker = VelocityTracker()
+      velocityTracker.addPointerInputChange(down)
+      var initialDragX = 0f
       var claimed = false
 
       while (!claimed) {
@@ -503,6 +538,8 @@ fun mainDrawerSwipeToOpenModifier(drawer: Drawer, enabled: Boolean): Modifier {
         if (!change.pressed) {
           return@awaitEachGesture
         }
+
+        velocityTracker.addPointerInputChange(change)
 
         val dx = change.position.x - down.position.x
         val dy = change.position.y - down.position.y
@@ -519,18 +556,18 @@ fun mainDrawerSwipeToOpenModifier(drawer: Drawer, enabled: Boolean): Modifier {
             return@awaitEachGesture
           }
 
+          velocityTracker.addPointerInputChange(confirmChange)
           confirmChange.consume()
-          overSlopX = confirmChange.position.x - down.position.x
+          initialDragX = confirmChange.position.x - down.position.x
           claimed = true
         }
       }
 
-      if (overSlopX != 0f) {
-        drawer.state.dispatchRawDelta(overSlopX)
-      }
+      if (initialDragX != 0f) drawer.state.dispatchRawDelta(initialDragX)
 
       // MainDrawerOverlay의 blocker가 Main pass에서 consume하므로 isConsumed 무시.
       // 자식 scrollable이 수직 slop을 잡아 제스처가 취소되지 않도록 우리가 계속 consume.
+      var releaseVelocityX = 0f
       var dragging = true
       while (dragging) {
         val event = awaitPointerEvent(PointerEventPass.Main)
@@ -539,12 +576,31 @@ fun mainDrawerSwipeToOpenModifier(drawer: Drawer, enabled: Boolean): Modifier {
           dragging = false
           continue
         }
+
+        velocityTracker.addPointerInputChange(change)
         val dx = change.positionChangeIgnoreConsumed().x
         if (dx != 0f) drawer.state.dispatchRawDelta(dx)
-        if (!change.pressed) dragging = false else change.consume()
+        if (!change.pressed) {
+          if (event.type == PointerEventType.Release) {
+            releaseVelocityX =
+              velocityTracker
+                .calculateVelocity(
+                  Velocity(
+                    viewConfiguration.maximumFlingVelocity,
+                    viewConfiguration.maximumFlingVelocity,
+                  )
+                )
+                .x
+          }
+          dragging = false
+        } else {
+          change.consume()
+        }
       }
 
-      scope.launch { drawer.settle() }
+      scope.launch {
+        drawer.settle(velocityX = releaseVelocityX, velocityThresholdPx = velocityThresholdPx)
+      }
     }
   }
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/drawer/Drawer.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/drawer/Drawer.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import kotlin.math.abs
 
 enum class DrawerAnchor {
   Closed,
@@ -51,8 +52,29 @@ class Drawer {
     if (isOpen) close() else open()
   }
 
-  suspend fun settle() {
-    runProgrammatic { state.animateTo(state.targetValue, DrawerDefaults.AnimationSpec) }
+  internal suspend fun settle(velocityX: Float, velocityThresholdPx: Float) {
+    val target = releaseTarget(velocityX, velocityThresholdPx)
+    runProgrammatic { state.animateTo(target, DrawerDefaults.AnimationSpec) }
+  }
+
+  internal fun releaseTarget(velocity: Float, velocityThreshold: Float): DrawerAnchor {
+    // Mirrors Foundation's anchored-draggable target selection with Material3's drawer threshold.
+    val offset = state.requireOffset()
+    val anchors = state.anchors
+    if (velocity == 0f) return anchors.closestAnchor(offset)!!
+
+    val movingForward = velocity > 0f
+    if (abs(velocity) >= velocityThreshold) {
+      return anchors.closestAnchor(offset, searchUpwards = movingForward)!!
+    }
+
+    val lowerAnchor = anchors.closestAnchor(offset, searchUpwards = false)!!
+    val upperAnchor = anchors.closestAnchor(offset, searchUpwards = true)!!
+    val origin = if (movingForward) lowerAnchor else upperAnchor
+    val destination = if (movingForward) upperAnchor else lowerAnchor
+    val distance = abs(anchors.positionOf(upperAnchor) - anchors.positionOf(lowerAnchor))
+    val threshold = distance * DrawerDefaults.PositionalThresholdFraction
+    return if (abs(offset - anchors.positionOf(origin)) >= threshold) destination else origin
   }
 
   private suspend inline fun runProgrammatic(block: () -> Unit) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/drawer/DrawerDefaults.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/drawer/DrawerDefaults.kt
@@ -1,7 +1,8 @@
 package co.typie.ui.component.drawer
 
-import androidx.compose.animation.core.SpringSpec
-import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
@@ -11,5 +12,10 @@ object DrawerDefaults {
   val EdgeHitSlop: Dp = 20.dp
   const val ScrimAlpha: Float = 0.5f
 
-  val AnimationSpec: SpringSpec<Float> = spring(stiffness = 500f)
+  // AndroidX support@83040cf Material3 NavigationDrawer: 50%, 400.dp/s, 256ms tween.
+  const val PositionalThresholdFraction: Float = 0.5f
+  val VelocityThreshold: Dp = 400.dp
+
+  val AnimationSpec: AnimationSpec<Float> =
+    tween(durationMillis = 256, easing = FastOutSlowInEasing)
 }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/ui/component/drawer/DrawerDefaultsTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/ui/component/drawer/DrawerDefaultsTest.kt
@@ -1,0 +1,24 @@
+package co.typie.ui.component.drawer
+
+import androidx.compose.animation.core.AnimationVector1D
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.VectorConverter
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DrawerDefaultsTest {
+  @Test
+  fun `drawer animation uses the Material3 duration and easing`() {
+    val vectorized = DrawerDefaults.AnimationSpec.vectorize(Float.VectorConverter)
+    val initial = AnimationVector1D(0f)
+    val target = AnimationVector1D(1f)
+    val initialVelocity = AnimationVector1D(0f)
+
+    assertEquals(256_000_000L, vectorized.getDurationNanos(initial, target, initialVelocity))
+    assertEquals(
+      FastOutSlowInEasing.transform(0.5f),
+      vectorized.getValueFromNanos(128_000_000L, initial, target, initialVelocity).value,
+      absoluteTolerance = 0.0001f,
+    )
+  }
+}

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/shell/MainDrawerGestureDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/shell/MainDrawerGestureDesktopTest.kt
@@ -1,0 +1,208 @@
+package co.typie.shell
+
+import androidx.compose.foundation.gestures.DraggableAnchors
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.LocalViewConfiguration
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.performTrackpadInput
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import co.typie.ui.component.drawer.Drawer
+import co.typie.ui.component.drawer.DrawerAnchor
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+class MainDrawerGestureDesktopTest {
+  @Test
+  fun `slow full area drag below halfway closes`() = runComposeUiTest {
+    lateinit var drawer: Drawer
+
+    setContent {
+      drawer = rememberTestDrawer()
+      DrawerSwipeHost(drawer)
+    }
+    waitForIdle()
+
+    onNodeWithTag(SwipeHostTag).performTouchInput {
+      down(Offset(x = 20f, y = center.y))
+      repeat(10) { moveBy(Offset(x = 12f, y = 0f), delayMillis = 50L) }
+      up()
+    }
+
+    waitUntil { abs(drawer.state.requireOffset() + 300f) < 0.1f }
+    assertEquals(DrawerAnchor.Closed, drawer.state.currentValue)
+  }
+
+  @Test
+  fun `slow full area drag past halfway opens`() = runComposeUiTest {
+    lateinit var drawer: Drawer
+
+    setContent {
+      drawer = rememberTestDrawer()
+      DrawerSwipeHost(drawer)
+    }
+    waitForIdle()
+
+    onNodeWithTag(SwipeHostTag).performTouchInput {
+      down(Offset(x = 20f, y = center.y))
+      repeat(15) { moveBy(Offset(x = 12f, y = 0f), delayMillis = 50L) }
+      up()
+    }
+
+    waitUntil { abs(drawer.state.requireOffset()) < 0.1f }
+    assertEquals(DrawerAnchor.Open, drawer.state.currentValue)
+  }
+
+  @Test
+  fun `fast full area release opens below halfway`() = runComposeUiTest {
+    lateinit var drawer: Drawer
+    var touchSlop = 0f
+
+    setContent {
+      drawer = rememberTestDrawer()
+      touchSlop = LocalViewConfiguration.current.touchSlop
+      DrawerSwipeHost(drawer)
+    }
+    waitForIdle()
+
+    onNodeWithTag(SwipeHostTag).performTouchInput {
+      down(Offset(x = 20f, y = center.y))
+      moveBy(Offset(x = touchSlop + 1f, y = 0f), delayMillis = 100L)
+      repeat(6) { moveBy(Offset(x = 10f, y = 0f), delayMillis = 1L) }
+      up()
+    }
+
+    waitUntil { abs(drawer.state.requireOffset()) < 0.1f }
+    assertEquals(DrawerAnchor.Open, drawer.state.currentValue)
+  }
+
+  @Test
+  fun `vertical dominant full area gesture stays rejected`() = runComposeUiTest {
+    lateinit var drawer: Drawer
+    var touchSlop = 0f
+
+    setContent {
+      drawer = rememberTestDrawer()
+      touchSlop = LocalViewConfiguration.current.touchSlop
+      DrawerSwipeHost(drawer)
+    }
+    waitForIdle()
+
+    onNodeWithTag(SwipeHostTag).performTouchInput {
+      down(center)
+      moveBy(Offset(x = 0f, y = touchSlop + 20f))
+      moveBy(Offset(x = 200f, y = 0f))
+      up()
+    }
+    waitForIdle()
+
+    assertEquals(-300f, drawer.state.requireOffset(), absoluteTolerance = 0.1f)
+  }
+
+  @Test
+  fun `horizontal pager touch drag owns the gesture`() = runComposeUiTest {
+    lateinit var drawer: Drawer
+    lateinit var pagerState: PagerState
+
+    setContent {
+      drawer = rememberTestDrawer()
+      pagerState = rememberPagerState(initialPage = 1, pageCount = { 2 })
+      DrawerSwipeHost(drawer) { TestPager(pagerState) }
+    }
+    waitForIdle()
+
+    onNodeWithTag(PagerTag).performTouchInput {
+      down(center)
+      repeat(8) { moveBy(Offset(x = 20f, y = 0f), delayMillis = 16L) }
+      up()
+    }
+    waitUntil { !pagerState.isScrollInProgress }
+
+    assertEquals(-300f, drawer.state.requireOffset(), absoluteTolerance = 0.1f)
+    assertEquals(0, pagerState.currentPage)
+  }
+
+  @Test
+  fun `mouse drag over horizontal pager never reveals the full area drawer`() = runComposeUiTest {
+    lateinit var drawer: Drawer
+    lateinit var pagerState: PagerState
+    var touchSlop = 0f
+
+    setContent {
+      drawer = rememberTestDrawer()
+      pagerState = rememberPagerState(initialPage = 1, pageCount = { 2 })
+      touchSlop = LocalViewConfiguration.current.touchSlop
+      DrawerSwipeHost(drawer) { TestPager(pagerState) }
+    }
+    waitForIdle()
+    val pager = onNodeWithTag(PagerTag)
+
+    pager.performTrackpadInput {
+      moveTo(center)
+      press()
+      moveBy(Offset(x = touchSlop + 5f, y = 0f), delayMillis = 16L)
+      moveBy(Offset(x = 180f, y = 0f), delayMillis = 16L)
+    }
+    waitForIdle()
+    assertEquals(-300f, drawer.state.requireOffset(), absoluteTolerance = 0.1f)
+
+    pager.performTrackpadInput {
+      moveBy(Offset(x = -220f, y = 0f), delayMillis = 16L)
+      release()
+    }
+    waitForIdle()
+
+    assertEquals(-300f, drawer.state.requireOffset(), absoluteTolerance = 0.1f)
+    assertEquals(1, pagerState.currentPage)
+  }
+
+  @Composable
+  private fun rememberTestDrawer(): Drawer = remember { Drawer().also { it.updateTestAnchors() } }
+
+  @Composable
+  private fun DrawerSwipeHost(drawer: Drawer, content: @Composable () -> Unit = {}) {
+    Box(
+      Modifier.size(width = 320.dp, height = 640.dp)
+        .testTag(SwipeHostTag)
+        .then(mainDrawerSwipeToOpenModifier(drawer, enabled = true))
+    ) {
+      content()
+    }
+  }
+
+  @Composable
+  private fun TestPager(state: PagerState) {
+    HorizontalPager(state = state, modifier = Modifier.fillMaxSize().testTag(PagerTag)) {
+      Box(Modifier.fillMaxSize())
+    }
+  }
+
+  private fun Drawer.updateTestAnchors() {
+    state.updateAnchors(
+      DraggableAnchors {
+        DrawerAnchor.Closed at -300f
+        DrawerAnchor.Open at 0f
+      },
+      DrawerAnchor.Closed,
+    )
+  }
+
+  private companion object {
+    const val PagerTag = "main-drawer-horizontal-pager"
+    const val SwipeHostTag = "main-drawer-swipe-host"
+  }
+}


### PR DESCRIPTION
- 메인 drawer의 열림/닫힘 애니메이션과 drag release 기준을 모든 경로에서 통일하고 조작감 개선
- Mouse click-drag로 drawer 열기 지원하지 않도록 함 (이어쓰기 캐러셀의 HorizontalPager와 간섭하고 불필요한 코드가 너무 많아지기 때문에. 이제 JVM Desktop에서 화면 스와이프해서 drawer 열 수 없음)
- 애니메이션을 Material3 NavigationDrawer 기준 256ms FastOutSlowIn tween으로 통일
- panel drag와 full-area swipe에 50% positional threshold와 400dp/s velocity threshold를 공통 적용