### PR TITLE
앱 에디터 줌 중에 오버레이들 프레임 싱크 맞추기

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/body/EditorBody.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/body/EditorBody.kt
@@ -16,10 +16,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.boundsInRoot
-import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.onPlaced
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
@@ -27,6 +26,7 @@ import co.typie.editor.EditorView
 import co.typie.editor.ext.unclippedBoundsInRoot
 import co.typie.editor.interaction.LocalEditorInteractionScope
 import co.typie.editor.overlay.EditorExtensionAreaLineHighlightOverlay
+import co.typie.editor.runtime.EditorUiState
 import co.typie.editor.runtime.LocalEditorRuntime
 import co.typie.editor.runtime.LocalEditorUiState
 import co.typie.editor.scroll.EditorAutoScrollPolicy
@@ -67,12 +67,8 @@ internal fun EditorBody(
       )
     }
   val interactionSurfaceModifier =
-    Modifier.fillMaxWidth().onGloballyPositioned { coordinates ->
-      uiState.updateInteractionSurfaceBounds(
-        boundsInRoot = coordinates.unclippedBoundsInRoot(),
-        density = density.density,
-      )
-    }
+    Modifier.fillMaxWidth()
+      .trackEditorInteractionSurfaceBounds(uiState = uiState, density = density.density)
 
   Box(modifier = modifier.fillMaxWidth()) {
     Box(modifier = interactionSurfaceModifier.then(interactionModifier)) {
@@ -80,9 +76,10 @@ internal fun EditorBody(
         EditorExtensionAreaLineHighlightOverlay(
           cursor = editor?.cursor,
           focused = uiState.focused,
-          editorBounds = uiState.editorBoundsInContainer,
-          viewportTransform = uiState.resolveViewportTransform(editor?.pageSizes.orEmpty()),
+          editorBounds = { uiState.editorBoundsInContainer },
+          viewportTransform = { uiState.resolveViewportTransform(editor?.pageSizes.orEmpty()) },
           enabled = Preference.lineHighlightEnabled,
+          modifier = Modifier.matchParentSize(),
         )
       }
       Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.TopCenter) {
@@ -113,13 +110,8 @@ internal fun EditorBody(
 
             Box(
               modifier =
-                Modifier.fillMaxWidth().onGloballyPositioned { coordinates ->
-                  uiState.updateEditorBounds(
-                    boundsInRoot = coordinates.unclippedBoundsInRoot(),
-                    clippedBoundsInRoot = coordinates.boundsInRoot(),
-                    density = density.density,
-                  )
-                }
+                Modifier.fillMaxWidth()
+                  .trackEditorContentBounds(uiState = uiState, density = density.density)
             ) {
               EditorView(
                 load = load,
@@ -156,40 +148,44 @@ internal fun EditorBody(
           }
         }
       }
-      val editorBounds = uiState.editorBoundsInContainer
-      if (editor != null && editorBounds.isValid && density.density > 0f) {
-        val editorRectInSurface =
-          Rect(
-            left = editorBounds.x * density.density,
-            top = editorBounds.y * density.density,
-            right = (editorBounds.x + editorBounds.width) * density.density,
-            bottom = (editorBounds.y + editorBounds.height) * density.density,
-          )
+      if (editor != null) {
         EditorTableColumnResizeOverlay(
           editor = editor,
           uiState = uiState,
           geometry = interactionScope,
-          editorOffsetInSurface = editorRectInSurface.topLeft,
           presentation = interactionScope.controller.tableColumnResizePresentation,
         )
         EditorTableCellSelectionOverlay(
           editor = editor,
           uiState = uiState,
-          editorRectInOverlay = editorRectInSurface,
           density = density.density,
         )
-        EditorSelectionHandleOverlay(
-          editor = editor,
-          uiState = uiState,
-          editorRectInOverlay = editorRectInSurface,
-          density = density.density,
-        )
+        EditorSelectionHandleOverlay(editor = editor, uiState = uiState, density = density.density)
       }
     }
 
     Box(modifier = Modifier.fillMaxSize(), content = overlay)
   }
 }
+
+internal fun Modifier.trackEditorInteractionSurfaceBounds(
+  uiState: EditorUiState,
+  density: Float,
+): Modifier = onPlaced { coordinates ->
+  uiState.updateInteractionSurfaceBounds(
+    boundsInRoot = coordinates.unclippedBoundsInRoot(),
+    density = density,
+  )
+}
+
+internal fun Modifier.trackEditorContentBounds(uiState: EditorUiState, density: Float): Modifier =
+  onPlaced { coordinates ->
+    uiState.updateEditorBounds(
+      boundsInRoot = coordinates.unclippedBoundsInRoot(),
+      clippedBoundsInRoot = coordinates.boundsInRoot(),
+      density = density,
+    )
+  }
 
 private fun Modifier.debugBackground(enabled: Boolean, color: Color): Modifier =
   if (enabled) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/overlay/LineHighlight.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/overlay/LineHighlight.kt
@@ -1,13 +1,12 @@
 package co.typie.editor.overlay
 
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import co.typie.editor.EditorViewportTransform
 import co.typie.editor.ffi.CursorMetrics
 import co.typie.editor.ffi.Rect
@@ -69,23 +68,26 @@ internal fun EditorLineHighlightOverlay(
 internal fun EditorExtensionAreaLineHighlightOverlay(
   cursor: CursorMetrics?,
   focused: Boolean,
-  editorBounds: EditorBoundsInContainer,
-  viewportTransform: EditorViewportTransform,
+  editorBounds: () -> EditorBoundsInContainer,
+  viewportTransform: () -> EditorViewportTransform,
   enabled: Boolean,
+  modifier: Modifier = Modifier,
 ) {
   if (!enabled || !focused) return
   val currentCursor = cursor ?: return
-  val band =
-    resolveEditorExtensionAreaLineHighlightBand(
-      cursor = currentCursor,
-      editorBounds = editorBounds,
-      viewportTransform = viewportTransform,
-    ) ?: return
+  val color = AppTheme.colors.surfaceInset.copy(alpha = 0.55f)
 
-  Box(
-    Modifier.fillMaxWidth()
-      .graphicsLayer { translationY = band.top.dp.toPx() }
-      .height(band.height.dp)
-      .background(AppTheme.colors.surfaceInset.copy(alpha = 0.55f))
-  )
+  Canvas(modifier) {
+    val band =
+      resolveEditorExtensionAreaLineHighlightBand(
+        cursor = currentCursor,
+        editorBounds = editorBounds(),
+        viewportTransform = viewportTransform(),
+      ) ?: return@Canvas
+    drawRect(
+      color = color,
+      topLeft = Offset(x = 0f, y = band.top * density),
+      size = Size(width = size.width, height = band.height * density),
+    )
+  }
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/runtime/EditorUiState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/runtime/EditorUiState.kt
@@ -189,6 +189,18 @@ data class EditorBoundsInContainer(
 ) {
   val isValid: Boolean
     get() = width > 0f && height > 0f
+
+  internal fun toPxRect(density: Float): Rect? {
+    if (!isValid || density <= 0f) {
+      return null
+    }
+    return Rect(
+      left = x * density,
+      top = y * density,
+      right = (x + width) * density,
+      bottom = (y + height) * density,
+    )
+  }
 }
 
 val LocalEditorUiState = compositionLocalOf<EditorUiState> { error("No EditorUiState provided") }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/surface/EditorPagePositionTrackerNode.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/surface/EditorPagePositionTrackerNode.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.positionInParent
 import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.node.GlobalPositionAwareModifierNode
+import androidx.compose.ui.node.LayoutAwareModifierNode
 import androidx.compose.ui.node.ModifierNodeElement
 import co.typie.editor.runtime.EditorUiState
 
@@ -35,14 +36,21 @@ private class EditorPagePositionTrackerNode(
   var uiState: EditorUiState,
   var page: Int,
   var density: Float,
-) : Modifier.Node(), GlobalPositionAwareModifierNode {
-  override fun onGloballyPositioned(coordinates: LayoutCoordinates) {
+) : Modifier.Node(), GlobalPositionAwareModifierNode, LayoutAwareModifierNode {
+  override fun onPlaced(coordinates: LayoutCoordinates) {
     if (density <= 0f) {
       return
     }
 
     val pos = coordinates.positionInParent()
     uiState.updatePageOffset(page = page, offset = Offset(pos.x / density, pos.y / density))
+  }
+
+  override fun onGloballyPositioned(coordinates: LayoutCoordinates) {
+    if (density <= 0f) {
+      return
+    }
+
     uiState.updatePagePositionInRoot(
       page = page,
       positionInRoot = coordinates.positionInRoot(),

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorScreenOverlayHost.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorScreenOverlayHost.kt
@@ -51,27 +51,19 @@ internal fun EditorScreenOverlayHost(
   val bringIntoViewRequests = LocalEditorBringIntoViewRequests.current
   var overlayBoundsInRoot by remember { mutableStateOf<Rect?>(null) }
   val overlayBounds = overlayBoundsInRoot
-  val editorBoundsInContainer = uiState.editorBoundsInContainer
-  val editorRectInViewport =
-    if (editorBoundsInContainer.isValid && density.density > 0f) {
-      val left =
-        editorBoundsInContainer.x * density.density - viewportState.scrollOffset.x * density.density
-      val top =
-        (visibleArea.headerHeight + editorBoundsInContainer.y) * density.density -
-          (viewportState.scrollOffset.y * density.density).roundToInt()
-      Rect(
-        left = left,
-        top = top,
-        right = left + editorBoundsInContainer.width * density.density,
-        bottom = top + editorBoundsInContainer.height * density.density,
-      )
-    } else {
-      null
-    }
   val editorRectInOverlay = overlayBounds?.let { bounds ->
     uiState.editorRectInRoot()?.translate(translateX = -bounds.left, translateY = -bounds.top)
   }
-
+  val editorRectInViewport: () -> Rect? = {
+    uiState.editorBoundsInContainer
+      .toPxRect(density.density)
+      ?.translate(
+        translateX = -viewportState.scrollOffset.x * density.density,
+        translateY =
+          visibleArea.headerHeight * density.density -
+            (viewportState.scrollOffset.y * density.density).roundToInt(),
+      )
+  }
   Box(
     modifier =
       modifier.fillMaxSize().onGloballyPositioned { coordinates ->
@@ -100,16 +92,13 @@ internal fun EditorScreenOverlayHost(
     if (overlayBounds != null) {
       val editor = runtime.editor
       if (editor != null) {
-        if (editorRectInViewport != null) {
-          EditorTableAxisSelectionOverlay(
-            editor = editor,
-            uiState = uiState,
-            editorRectInOverlay = editorRectInViewport,
-            overlaySize = overlayBounds.size,
-            density = density.density,
-            onTableAxisActionsRequest = onTableAxisActionsRequest,
-          )
-        }
+        EditorTableAxisSelectionOverlay(
+          editor = editor,
+          uiState = uiState,
+          editorRectInOverlay = editorRectInViewport,
+          density = density.density,
+          onTableAxisActionsRequest = onTableAxisActionsRequest,
+        )
 
         if (editorRectInOverlay != null && contextMenu.isVisibleFor(editor.state)) {
           val anchor =

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorSelectionHandleOverlay.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorSelectionHandleOverlay.kt
@@ -1,18 +1,13 @@
 package co.typie.screen.editor.editor.overlay
 
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.translate
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.IntOffset
 import co.typie.editor.Editor
 import co.typie.editor.EditorViewportTransform
 import co.typie.editor.ext.isCollapsed
@@ -25,29 +20,61 @@ import co.typie.editor.interaction.gestures.resolveSelectionHandleGeometry
 import co.typie.editor.interaction.hasActiveTableCellSelection
 import co.typie.editor.runtime.EditorUiState
 import co.typie.ui.theme.AppTheme
-import kotlin.math.roundToInt
 
 @Composable
-internal fun EditorSelectionHandleOverlay(
-  editor: Editor,
-  uiState: EditorUiState,
-  editorRectInOverlay: Rect,
-  density: Float,
-) {
+internal fun EditorSelectionHandleOverlay(editor: Editor, uiState: EditorUiState, density: Float) {
   if (!uiState.focused || editor.selection.isCollapsed() || hasActiveTableCellSelection(editor)) {
     return
   }
 
-  val placements =
-    resolveSelectionHandleOverlayPlacements(
-      editor = editor,
-      uiState = uiState,
-      editorRectInOverlay = editorRectInOverlay,
-      density = density,
-    ) ?: return
+  if (editor.tickSelectionEndpoints == null) {
+    return
+  }
+
   val color = AppTheme.colors.textDefault
 
-  placements.forEach { placement -> EditorSelectionHandle(placement = placement, color = color) }
+  Canvas(modifier = Modifier.fillMaxSize()) {
+    val editorRect = uiState.editorBoundsInContainer.toPxRect(density) ?: return@Canvas
+    val placements =
+      resolveSelectionHandleOverlayPlacements(
+        editor = editor,
+        uiState = uiState,
+        editorRectInOverlay = editorRect,
+        density = density,
+      ) ?: return@Canvas
+    placements.forEach { placement ->
+      val geometry = resolveSelectionHandleOverlayGeometry(placement, density)
+      translate(
+        left = geometry.touchTargetTopLeft.x + geometry.paintTopLeftInTouchTarget.x,
+        top = geometry.touchTargetTopLeft.y + geometry.paintTopLeftInTouchTarget.y,
+      ) {
+        val centerX = geometry.radiusPx
+        if (placement.type == EditorSelectionHandleType.From) {
+          drawCircle(
+            color = color,
+            radius = geometry.radiusPx,
+            center = Offset(centerX, geometry.radiusPx),
+          )
+          drawRect(
+            color = color,
+            topLeft = Offset(centerX - geometry.stemWidthPx / 2f, geometry.radiusPx * 2f),
+            size = Size(geometry.stemWidthPx, geometry.stemHeightPx),
+          )
+        } else {
+          drawRect(
+            color = color,
+            topLeft = Offset(centerX - geometry.stemWidthPx / 2f, 0f),
+            size = Size(geometry.stemWidthPx, geometry.stemHeightPx),
+          )
+          drawCircle(
+            color = color,
+            radius = geometry.radiusPx,
+            center = Offset(centerX, geometry.stemHeightPx + geometry.radiusPx),
+          )
+        }
+      }
+    }
+  }
 }
 
 internal fun resolveSelectionHandleOverlayPlacements(
@@ -123,56 +150,4 @@ private fun resolveSelectionHandleOverlayPlacement(
     endpointTopLeftInOverlay = topLeft,
     stemHeightPx = stemHeightPx,
   )
-}
-
-@Composable
-private fun EditorSelectionHandle(placement: EditorSelectionHandleOverlayPlacement, color: Color) {
-  val localDensity = LocalDensity.current
-  val geometry = resolveSelectionHandleOverlayGeometry(placement, localDensity.density)
-
-  Box(
-    modifier =
-      Modifier.offset {
-          IntOffset(
-            geometry.touchTargetTopLeft.x.roundToInt(),
-            geometry.touchTargetTopLeft.y.roundToInt(),
-          )
-        }
-        .size(
-          width = with(localDensity) { geometry.touchTargetSize.width.toDp() },
-          height = with(localDensity) { geometry.touchTargetSize.height.toDp() },
-        )
-  ) {
-    Canvas(modifier = Modifier.matchParentSize()) {
-      translate(
-        left = geometry.paintTopLeftInTouchTarget.x,
-        top = geometry.paintTopLeftInTouchTarget.y,
-      ) {
-        val centerX = geometry.radiusPx
-        if (placement.type == EditorSelectionHandleType.From) {
-          drawCircle(
-            color = color,
-            radius = geometry.radiusPx,
-            center = Offset(centerX, geometry.radiusPx),
-          )
-          drawRect(
-            color = color,
-            topLeft = Offset(centerX - geometry.stemWidthPx / 2f, geometry.radiusPx * 2f),
-            size = Size(geometry.stemWidthPx, geometry.stemHeightPx),
-          )
-        } else {
-          drawRect(
-            color = color,
-            topLeft = Offset(centerX - geometry.stemWidthPx / 2f, 0f),
-            size = Size(geometry.stemWidthPx, geometry.stemHeightPx),
-          )
-          drawCircle(
-            color = color,
-            radius = geometry.radiusPx,
-            center = Offset(centerX, geometry.stemHeightPx + geometry.radiusPx),
-          )
-        }
-      }
-    }
-  }
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorTableAxisSelectionOverlay.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorTableAxisSelectionOverlay.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
@@ -15,12 +14,12 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import co.typie.editor.Editor
 import co.typie.editor.EditorViewportTransform
@@ -63,8 +62,7 @@ internal data class EditorTableAxisSelector(
 internal fun EditorTableAxisSelectionOverlay(
   editor: Editor,
   uiState: EditorUiState,
-  editorRectInOverlay: Rect,
-  overlaySize: Size,
+  editorRectInOverlay: () -> Rect?,
   density: Float,
   onTableAxisActionsRequest: (EditorTableAxisActionsTarget, Selection?) -> Unit,
 ) {
@@ -72,31 +70,57 @@ internal fun EditorTableAxisSelectionOverlay(
     return
   }
 
-  val placements =
-    resolveTableAxisSelectorOverlayPlacements(
-      editor = editor,
-      uiState = uiState,
-      editorRectInOverlay = editorRectInOverlay,
-      overlaySize = overlaySize,
-      density = density,
-    )
-  if (placements.isEmpty()) {
+  val selectors = resolveTableAxisSelectors(editor)
+  if (selectors.isEmpty()) {
     return
   }
 
-  Box(modifier = Modifier.fillMaxSize()) {
-    placements.forEach { placement ->
-      EditorTableAxisSelectorButton(
-        placement = placement,
-        onClick = {
-          val selector = placement.selector
-          editor.sendTableAxisOp(
-            selector = selector,
-            op = TableOp.SelectAxis(axis = selector.axis, index = selector.index),
-          )
-          onTableAxisActionsRequest(selector.toActionsTarget(), editor.selection)
-        },
+  Layout(
+    modifier = Modifier.fillMaxSize(),
+    content = {
+      selectors.forEach { selector ->
+        EditorTableAxisSelectorButton(
+          selector = selector,
+          onClick = {
+            editor.sendTableAxisOp(
+              selector = selector,
+              op = TableOp.SelectAxis(axis = selector.axis, index = selector.index),
+            )
+            onTableAxisActionsRequest(selector.toActionsTarget(), editor.selection)
+          },
+        )
+      }
+    },
+  ) { measurables, constraints ->
+    val placeables = measurables.mapIndexed { index, measurable ->
+      val (width, height) = selectors[index].buttonSize()
+      measurable.measure(
+        constraints.copy(
+          minWidth = width.roundToPx(),
+          maxWidth = width.roundToPx(),
+          minHeight = height.roundToPx(),
+          maxHeight = height.roundToPx(),
+        )
       )
+    }
+
+    layout(width = constraints.maxWidth, height = constraints.maxHeight) {
+      val currentEditorRect = editorRectInOverlay() ?: return@layout
+      val placements =
+        resolveTableAxisSelectorOverlayPlacements(
+          editor = editor,
+          uiState = uiState,
+          editorRectInOverlay = currentEditorRect,
+          overlaySize =
+            Size(width = constraints.maxWidth.toFloat(), height = constraints.maxHeight.toFloat()),
+          density = density,
+        )
+      placeables.zip(placements).forEach { (placeable, placement) ->
+        placeable.place(
+          x = placement.buttonRect.left.roundToInt(),
+          y = placement.buttonRect.top.roundToInt(),
+        )
+      }
     }
   }
 }
@@ -247,6 +271,12 @@ private fun EditorTableAxisSelector.tableMessage(op: TableOp): Message =
 private fun EditorTableAxisSelector.toActionsTarget(): EditorTableAxisActionsTarget =
   EditorTableAxisActionsTarget(tableId = overlay.tableId, axis = axis, index = index, count = count)
 
+private fun EditorTableAxisSelector.buttonSize(): Pair<Dp, Dp> =
+  when (axis) {
+    Axis.Horizontal -> TableAxisSelectorRowButtonWidth to TableAxisSelectorRowButtonHeight
+    Axis.Vertical -> TableAxisSelectorColumnButtonWidth to TableAxisSelectorColumnButtonHeight
+  }
+
 internal fun resolveSelectorButtonRect(
   center: Offset,
   axis: Axis,
@@ -290,30 +320,22 @@ private fun resolvePositionInOverlay(
 }
 
 @Composable
-private fun EditorTableAxisSelectorButton(
-  placement: EditorTableAxisSelectorOverlayPlacement,
-  onClick: () -> Unit,
-) {
+private fun EditorTableAxisSelectorButton(selector: EditorTableAxisSelector, onClick: () -> Unit) {
   val icon =
-    when (placement.selector.axis) {
+    when (selector.axis) {
       Axis.Horizontal -> Lucide.EllipsisVertical
       Axis.Vertical -> Lucide.Ellipsis
     }
   val description =
-    when (placement.selector.axis) {
+    when (selector.axis) {
       Axis.Horizontal -> "행 메뉴"
       Axis.Vertical -> "열 메뉴"
     }
+  val (width, height) = selector.buttonSize()
   Box(
     modifier =
-      Modifier.offset {
-          IntOffset(
-            x = placement.buttonRect.left.roundToInt(),
-            y = placement.buttonRect.top.roundToInt(),
-          )
-        }
-        .width(placement.width)
-        .height(placement.height)
+      Modifier.width(width)
+        .height(height)
         .shadow(AppTheme.shadows.sm, TableAxisSelectorButtonShape)
         .clip(TableAxisSelectorButtonShape)
         .border(1.dp, AppTheme.colors.borderEmphasis, TableAxisSelectorButtonShape)

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorTableCellSelectionOverlay.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorTableCellSelectionOverlay.kt
@@ -1,7 +1,6 @@
 package co.typie.screen.editor.editor.overlay
 
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -22,37 +21,35 @@ import co.typie.ui.theme.AppTheme
 internal fun EditorTableCellSelectionOverlay(
   editor: Editor,
   uiState: EditorUiState,
-  editorRectInOverlay: Rect,
   density: Float,
 ) {
   if (!uiState.focused) {
     return
   }
 
-  val placements =
-    resolveTableCellSelectionOverlayPlacements(
-      editor = editor,
-      uiState = uiState,
-      editorRectInOverlay = editorRectInOverlay,
-      density = density,
-    )
-  if (placements.isEmpty()) {
+  if (resolveTableCellSelections(editor).isEmpty()) {
     return
   }
   val color = AppTheme.colors.textDefault
 
-  Box(modifier = Modifier.fillMaxSize()) {
-    Canvas(modifier = Modifier.fillMaxSize()) {
-      placements.forEach { placement ->
-        drawRect(
-          color = color,
-          topLeft = placement.outline.topLeft,
-          size = placement.outline.size,
-          style = Stroke(width = placement.borderWidthPx),
-        )
-        placement.handleCenter?.let { handleCenter ->
-          drawCircle(color = color, radius = placement.handleRadiusPx, center = handleCenter)
-        }
+  Canvas(modifier = Modifier.fillMaxSize()) {
+    val editorRect = uiState.editorBoundsInContainer.toPxRect(density) ?: return@Canvas
+    val placements =
+      resolveTableCellSelectionOverlayPlacements(
+        editor = editor,
+        uiState = uiState,
+        editorRectInOverlay = editorRect,
+        density = density,
+      )
+    placements.forEach { placement ->
+      drawRect(
+        color = color,
+        topLeft = placement.outline.topLeft,
+        size = placement.outline.size,
+        style = Stroke(width = placement.borderWidthPx),
+      )
+      placement.handleCenter?.let { handleCenter ->
+        drawCircle(color = color, radius = placement.handleRadiusPx, center = handleCenter)
       }
     }
   }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorTableColumnResizeOverlay.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorTableColumnResizeOverlay.kt
@@ -1,7 +1,6 @@
 package co.typie.screen.editor.editor.overlay
 
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -23,7 +22,6 @@ internal fun EditorTableColumnResizeOverlay(
   editor: Editor,
   uiState: EditorUiState,
   geometry: EditorInteractionGeometry,
-  editorOffsetInSurface: Offset,
   presentation: EditorTableColumnResizePresentation,
 ) {
   val density = geometry.density
@@ -31,31 +29,31 @@ internal fun EditorTableColumnResizeOverlay(
     return
   }
 
-  val placement = resolveTableColumnResizePlacement(editor = editor, geometry = geometry) ?: return
   val color = AppTheme.colors.palette.blue
-  val activeDraft = presentation.draft
-  val resizeHandleActive = activeDraft != null || presentation.pressed
-  val visualCenterX =
-    editorOffsetInSurface.x +
-      (activeDraft?.let {
-        it.baseCenterX + resolveTableColumnResizePreviewDelta(it) * it.pxPerPageUnit
-      } ?: placement.centerX)
-  val visualTop = editorOffsetInSurface.y + (activeDraft?.top ?: placement.top)
-  val visualBottom = editorOffsetInSurface.y + (activeDraft?.bottom ?: placement.bottom)
-  val visualWidth = TableColumnResizeVisualWidthDp * density
-  val verticalInset = 2f * density
 
-  Box(modifier = Modifier.fillMaxSize()) {
-    Canvas(modifier = Modifier.fillMaxSize()) {
-      val height = (visualBottom - visualTop - verticalInset * 2f).coerceAtLeast(0f)
-      if (height > 0f) {
-        drawRoundRect(
-          color = color.copy(alpha = if (resizeHandleActive) 0.85f else 0.35f),
-          topLeft = Offset(x = visualCenterX - visualWidth / 2f, y = visualTop + verticalInset),
-          size = Size(width = visualWidth, height = height),
-          cornerRadius = CornerRadius(visualWidth / 2f, visualWidth / 2f),
-        )
-      }
+  Canvas(modifier = Modifier.fillMaxSize()) {
+    val editorOffset = uiState.editorBoundsInContainer.toPxRect(density)?.topLeft ?: return@Canvas
+    val placement =
+      resolveTableColumnResizePlacement(editor = editor, geometry = geometry) ?: return@Canvas
+    val activeDraft = presentation.draft
+    val resizeHandleActive = activeDraft != null || presentation.pressed
+    val visualCenterX =
+      editorOffset.x +
+        (activeDraft?.let {
+          it.baseCenterX + resolveTableColumnResizePreviewDelta(it) * it.pxPerPageUnit
+        } ?: placement.centerX)
+    val visualTop = editorOffset.y + (activeDraft?.top ?: placement.top)
+    val visualBottom = editorOffset.y + (activeDraft?.bottom ?: placement.bottom)
+    val visualWidth = TableColumnResizeVisualWidthDp * density
+    val verticalInset = 2f * density
+    val height = (visualBottom - visualTop - verticalInset * 2f).coerceAtLeast(0f)
+    if (height > 0f) {
+      drawRoundRect(
+        color = color.copy(alpha = if (resizeHandleActive) 0.85f else 0.35f),
+        topLeft = Offset(x = visualCenterX - visualWidth / 2f, y = visualTop + verticalInset),
+        size = Size(width = visualWidth, height = height),
+        cornerRadius = CornerRadius(visualWidth / 2f, visualWidth / 2f),
+      )
     }
   }
 }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorDocumentManipulationDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorDocumentManipulationDesktopTest.kt
@@ -1251,22 +1251,10 @@ class EditorDocumentManipulationDesktopTest {
               editor = editor,
               uiState = uiState,
               geometry = interactionScope,
-              editorOffsetInSurface =
-                uiState.editorBoundsInContainer.let { bounds -> Offset(bounds.x, bounds.y) },
               presentation = interactionScope.controller.tableColumnResizePresentation,
             )
-            EditorTableCellSelectionOverlay(
-              editor = editor,
-              uiState = uiState,
-              editorRectInOverlay = uiState.editorRectInSurface(),
-              density = 1f,
-            )
-            EditorSelectionHandleOverlay(
-              editor = editor,
-              uiState = uiState,
-              editorRectInOverlay = uiState.editorRectInSurface(),
-              density = 1f,
-            )
+            EditorTableCellSelectionOverlay(editor = editor, uiState = uiState, density = 1f)
+            EditorSelectionHandleOverlay(editor = editor, uiState = uiState, density = 1f)
           }
         }
       }
@@ -1280,16 +1268,6 @@ class EditorDocumentManipulationDesktopTest {
       updatePageOffset(page = 0, offset = Offset.Zero)
       updateInteractionSurfaceBounds(TestRootRect, density = 1f)
       updateEditorBounds(TestRootRect, density = 1f)
-    }
-
-  private fun EditorUiState.editorRectInSurface(): ComposeRect =
-    editorBoundsInContainer.let { bounds ->
-      ComposeRect(
-        left = bounds.x,
-        top = bounds.y,
-        right = bounds.x + bounds.width,
-        bottom = bounds.y + bounds.height,
-      )
     }
 
   private fun testPaginatedLayoutSpec(): EditorDocumentLayoutSpec.Paginated =

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorOverlayLayoutSynchronizationDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorOverlayLayoutSynchronizationDesktopTest.kt
@@ -1,0 +1,543 @@
+package co.typie.screen.editor.editor.overlay
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import co.typie.editor.Editor
+import co.typie.editor.FakeFfiEditor
+import co.typie.editor.PagePoint
+import co.typie.editor.body.trackEditorContentBounds
+import co.typie.editor.body.trackEditorInteractionSurfaceBounds
+import co.typie.editor.ffi.Affinity
+import co.typie.editor.ffi.Alignment
+import co.typie.editor.ffi.CursorMetrics
+import co.typie.editor.ffi.PageRect
+import co.typie.editor.ffi.Position
+import co.typie.editor.ffi.Selection
+import co.typie.editor.ffi.SelectionEndpoints
+import co.typie.editor.ffi.Size
+import co.typie.editor.ffi.TableBorderStyle
+import co.typie.editor.ffi.TableOverlay
+import co.typie.editor.ffi.TableOverlayCellSelection
+import co.typie.editor.ffi.TableOverlayColumn
+import co.typie.editor.ffi.TableOverlayRow
+import co.typie.editor.interaction.EditorEdgeAutoScrollViewport
+import co.typie.editor.interaction.EditorInteractionGeometry
+import co.typie.editor.interaction.semantics.EditorTableColumnResizePresentation
+import co.typie.editor.overlay.EditorExtensionAreaLineHighlightOverlay
+import co.typie.editor.runtime.EditorUiState
+import co.typie.editor.surface.editorPagePositionTracker
+import co.typie.ui.theme.LightAppShadows
+import co.typie.ui.theme.LightColors
+import co.typie.ui.theme.LocalAppColors
+import co.typie.ui.theme.LocalAppShadows
+import co.typie.ui.theme.LocalThemeMode
+import co.typie.ui.theme.ResolvedThemeMode
+import kotlin.math.roundToInt
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+
+@OptIn(ExperimentalTestApi::class)
+class EditorOverlayLayoutSynchronizationDesktopTest {
+  @Test
+  fun firstZoomedTableAxisPlacementUsesTheNewPagePosition() = runComposeUiTest {
+    val zoom = mutableStateOf(1f)
+    val uiState = focusedUiState()
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val editor =
+      Editor(
+        FakeFfiEditor(
+          selectionProvider = {
+            val position = Position("cell-text", 0, Affinity.Downstream)
+            Selection(anchor = position, head = position)
+          },
+          pageSizesProvider = {
+            listOf(Size(width = 100f, height = 100f), Size(width = 100f, height = 100f))
+          },
+          tableOverlaysProvider = { listOf(tableOverlay()) },
+        ),
+        scope,
+      )
+    editor.sync {}
+    mainClock.autoAdvance = false
+
+    try {
+      setContent {
+        CompositionLocalProvider(
+          LocalDensity provides Density(1f),
+          LocalAppColors provides LightColors,
+          LocalAppShadows provides LightAppShadows,
+          LocalThemeMode provides ResolvedThemeMode.Light,
+        ) {
+          Box(Modifier.size(RootSize.dp)) {
+            Box(
+              Modifier.offset {
+                  val pageOffset = (PageOffsetAtZoomOne * zoom.value).roundToInt()
+                  IntOffset(pageOffset, pageOffset)
+                }
+                .size(PageSizeAtZoomOne.dp * zoom.value)
+                .testTag(PageTag)
+                .editorPagePositionTracker(uiState = uiState, page = 1, density = 1f)
+            )
+            EditorTableAxisSelectionOverlay(
+              editor = editor,
+              uiState = uiState,
+              editorRectInOverlay = { Rect(0f, 0f, RootSize, RootSize) },
+              density = 1f,
+              onTableAxisActionsRequest = { _, _ -> },
+            )
+          }
+        }
+      }
+      mainClock.advanceTimeByFrame()
+
+      runOnUiThread {
+        uiState.updateDisplayZoom(2f)
+        zoom.value = 2f
+      }
+      mainClock.advanceTimeByFrame()
+
+      val pageBounds = onNodeWithTag(PageTag).fetchSemanticsNode().boundsInRoot
+      val menuBounds =
+        onNodeWithContentDescription(ColumnMenuDescription).fetchSemanticsNode().boundsInRoot
+      assertEquals(58f, menuBounds.left - pageBounds.left, absoluteTolerance = 0.01f)
+      assertEquals(31f, menuBounds.top - pageBounds.top, absoluteTolerance = 0.01f)
+
+      runOnUiThread {
+        uiState.updateDisplayZoom(1f)
+        zoom.value = 1f
+      }
+      mainClock.advanceTimeByFrame()
+
+      val zoomedOutPageBounds = onNodeWithTag(PageTag).fetchSemanticsNode().boundsInRoot
+      val zoomedOutMenuBounds =
+        onNodeWithContentDescription(ColumnMenuDescription).fetchSemanticsNode().boundsInRoot
+      assertEquals(
+        23f,
+        zoomedOutMenuBounds.left - zoomedOutPageBounds.left,
+        absoluteTolerance = 0.01f,
+      )
+      assertEquals(
+        11f,
+        zoomedOutMenuBounds.top - zoomedOutPageBounds.top,
+        absoluteTolerance = 0.01f,
+      )
+    } finally {
+      scope.cancel()
+    }
+  }
+
+  @Test
+  fun firstZoomedEditorBodyPlacementPublishesTheNewEditorBounds() = runComposeUiTest {
+    val zoom = mutableStateOf(1f)
+    val uiState = EditorUiState()
+    mainClock.autoAdvance = false
+
+    setContent {
+      CompositionLocalProvider(LocalDensity provides Density(1f)) {
+        Box(Modifier.size(RootSize.dp)) {
+          Box(
+            Modifier.offset {
+                IntOffset(
+                  InteractionSurfaceOffset.roundToInt(),
+                  InteractionSurfaceOffset.roundToInt(),
+                )
+              }
+              .size(InteractionSurfaceSize.dp)
+              .testTag(InteractionSurfaceTag)
+              .trackEditorInteractionSurfaceBounds(uiState = uiState, density = 1f)
+          ) {
+            Box(
+              Modifier.offset {
+                  val editorOffset = (EditorOffsetAtZoomOne * zoom.value).roundToInt()
+                  IntOffset(editorOffset, editorOffset)
+                }
+                .size(EditorSizeAtZoomOne.dp * zoom.value)
+                .testTag(EditorBoundsTag)
+                .trackEditorContentBounds(uiState = uiState, density = 1f)
+            )
+            Box(
+              Modifier.offset {
+                  val editorBounds = uiState.editorBoundsInContainer
+                  IntOffset(editorBounds.x.roundToInt(), editorBounds.y.roundToInt())
+                }
+                .size(EditorBoundsMarkerSize.dp)
+                .testTag(EditorBoundsMarkerTag)
+            )
+          }
+        }
+      }
+    }
+    mainClock.advanceTimeByFrame()
+
+    runOnUiThread { zoom.value = 2f }
+    mainClock.advanceTimeByFrame()
+
+    val editorBounds = onNodeWithTag(EditorBoundsTag).fetchSemanticsNode().boundsInRoot
+    val markerBounds = onNodeWithTag(EditorBoundsMarkerTag).fetchSemanticsNode().boundsInRoot
+    assertEquals(editorBounds.left, markerBounds.left, absoluteTolerance = 0.01f)
+    assertEquals(editorBounds.top, markerBounds.top, absoluteTolerance = 0.01f)
+  }
+
+  @Test
+  fun firstContinuousPageRelayoutDrawUsesTheNewPagePosition() = runComposeUiTest {
+    val firstPageHeight = mutableStateOf(ContinuousPageHeight)
+    val uiState = EditorUiState()
+    val cursor =
+      CursorMetrics(
+        pageIdx = 1,
+        caret = co.typie.editor.ffi.Rect(x = 0f, y = 10f, width = 1f, height = 10f),
+        line = co.typie.editor.ffi.Rect(x = 0f, y = 10f, width = 100f, height = 10f),
+      )
+    mainClock.autoAdvance = false
+
+    setContent {
+      CompositionLocalProvider(
+        LocalDensity provides Density(1f),
+        LocalAppColors provides LightColors,
+      ) {
+        Box(
+          Modifier.size(RootSize.dp)
+            .background(Color.White)
+            .testTag(RootTag)
+            .trackEditorInteractionSurfaceBounds(uiState = uiState, density = 1f)
+        ) {
+          EditorExtensionAreaLineHighlightOverlay(
+            cursor = cursor,
+            focused = true,
+            editorBounds = { uiState.editorBoundsInContainer },
+            viewportTransform = { uiState.resolveViewportTransform() },
+            enabled = true,
+            modifier = Modifier.matchParentSize(),
+          )
+          Column(
+            Modifier.offset { IntOffset(0, ContinuousEditorTop.roundToInt()) }
+              .fillMaxWidth()
+              .trackEditorContentBounds(uiState = uiState, density = 1f)
+          ) {
+            repeat(2) { page ->
+              val pageHeight = if (page == 0) firstPageHeight.value else ContinuousPageHeight
+              Box(
+                Modifier.size(width = ContinuousPageWidth.dp, height = pageHeight.dp)
+                  .editorPagePositionTracker(uiState = uiState, page = page, density = 1f)
+              )
+            }
+          }
+        }
+      }
+    }
+    mainClock.advanceTimeByFrame()
+    mainClock.advanceTimeByFrame()
+
+    runOnUiThread { firstPageHeight.value = ContinuousRelayoutPageHeight }
+    mainClock.advanceTimeByFrame()
+
+    val pixels = onNodeWithTag(RootTag).captureToImage().toPixelMap()
+    assertNotEquals(Color.White, pixels[ContinuousHighlightX, ContinuousRelayoutHighlightCenterY])
+  }
+
+  @Test
+  fun firstZoomedSelectionHandleDrawUsesTheNewPagePosition() = runComposeUiTest {
+    val zoom = mutableStateOf(1f)
+    val selection =
+      Selection(
+        anchor = Position("text", 0, Affinity.Downstream),
+        head = Position("text", 5, Affinity.Downstream),
+      )
+    val endpoints =
+      SelectionEndpoints(
+        from =
+          PageRect(
+            pageIdx = 1,
+            rect = co.typie.editor.ffi.Rect(x = 10f, y = 20f, width = 4f, height = 8f),
+          ),
+        to =
+          PageRect(
+            pageIdx = 1,
+            rect = co.typie.editor.ffi.Rect(x = 40f, y = 20f, width = 4f, height = 8f),
+          ),
+        fromPosition = selection.anchor,
+        toPosition = selection.head,
+      )
+    val uiState = focusedUiState()
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val editor =
+      Editor(
+        FakeFfiEditor(
+          selectionProvider = { selection },
+          selectionEndpointsProvider = { endpoints },
+          pageSizesProvider = {
+            listOf(Size(width = 100f, height = 100f), Size(width = 100f, height = 100f))
+          },
+        ),
+        scope,
+      )
+    editor.sync {}
+    mainClock.autoAdvance = false
+
+    try {
+      setContent {
+        CompositionLocalProvider(
+          LocalDensity provides Density(1f),
+          LocalAppColors provides LightColors,
+          LocalAppShadows provides LightAppShadows,
+          LocalThemeMode provides ResolvedThemeMode.Light,
+        ) {
+          Box(Modifier.size(RootSize.dp).background(Color.White).testTag(RootTag)) {
+            Box(
+              Modifier.offset {
+                  val pageOffset = (PageOffsetAtZoomOne * zoom.value).roundToInt()
+                  IntOffset(pageOffset, pageOffset)
+                }
+                .size(PageSizeAtZoomOne.dp * zoom.value)
+                .editorPagePositionTracker(uiState = uiState, page = 1, density = 1f)
+            )
+            EditorSelectionHandleOverlay(editor = editor, uiState = uiState, density = 1f)
+          }
+        }
+      }
+      mainClock.advanceTimeByFrame()
+
+      runOnUiThread {
+        uiState.updateDisplayZoom(2f)
+        zoom.value = 2f
+      }
+      mainClock.advanceTimeByFrame()
+
+      val pixels = onNodeWithTag(RootTag).captureToImage().toPixelMap()
+      assertEquals(LightColors.textDefault, pixels[ToHandleCenterX, ToHandleCenterY])
+    } finally {
+      scope.cancel()
+    }
+  }
+
+  @Test
+  fun firstZoomedTableCellHandleDrawUsesTheNewPagePosition() = runComposeUiTest {
+    val zoom = mutableStateOf(1f)
+    val uiState = focusedUiState()
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val editor =
+      Editor(
+        FakeFfiEditor(
+          selectionProvider = {
+            val position = Position("cell-text", 0, Affinity.Downstream)
+            Selection(anchor = position, head = position)
+          },
+          pageSizesProvider = {
+            listOf(Size(width = 100f, height = 100f), Size(width = 100f, height = 100f))
+          },
+          tableOverlaysProvider = {
+            listOf(
+              tableOverlay(
+                cellSelection =
+                  TableOverlayCellSelection(anchorRow = 0, anchorCol = 0, headRow = 0, headCol = 0)
+              )
+            )
+          },
+        ),
+        scope,
+      )
+    editor.sync {}
+    mainClock.autoAdvance = false
+
+    try {
+      setContent {
+        CompositionLocalProvider(
+          LocalDensity provides Density(1f),
+          LocalAppColors provides LightColors,
+          LocalAppShadows provides LightAppShadows,
+          LocalThemeMode provides ResolvedThemeMode.Light,
+        ) {
+          Box(Modifier.size(RootSize.dp).background(Color.White).testTag(RootTag)) {
+            Box(
+              Modifier.offset {
+                  val pageOffset = (PageOffsetAtZoomOne * zoom.value).roundToInt()
+                  IntOffset(pageOffset, pageOffset)
+                }
+                .size(PageSizeAtZoomOne.dp * zoom.value)
+                .editorPagePositionTracker(uiState = uiState, page = 1, density = 1f)
+            )
+            EditorTableCellSelectionOverlay(editor = editor, uiState = uiState, density = 1f)
+          }
+        }
+      }
+      mainClock.advanceTimeByFrame()
+
+      runOnUiThread {
+        uiState.updateDisplayZoom(2f)
+        zoom.value = 2f
+      }
+      mainClock.advanceTimeByFrame()
+
+      val pixels = onNodeWithTag(RootTag).captureToImage().toPixelMap()
+      assertEquals(LightColors.textDefault, pixels[TableCellHandleCenter, TableCellHandleCenter])
+    } finally {
+      scope.cancel()
+    }
+  }
+
+  @Test
+  fun firstZoomedTableColumnResizeDrawUsesTheNewPagePosition() = runComposeUiTest {
+    val zoom = mutableStateOf(1f)
+    val uiState = focusedUiState()
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val editor =
+      Editor(
+        FakeFfiEditor(
+          selectionProvider = {
+            val position = Position("cell-text", 0, Affinity.Downstream)
+            Selection(anchor = position, head = position)
+          },
+          pageSizesProvider = {
+            listOf(Size(width = 100f, height = 100f), Size(width = 100f, height = 100f))
+          },
+          tableOverlaysProvider = { listOf(tableOverlay()) },
+        ),
+        scope,
+      )
+    val interactionGeometry = TestInteractionGeometry(editor = editor, uiState = uiState)
+    editor.sync {}
+    mainClock.autoAdvance = false
+
+    try {
+      setContent {
+        CompositionLocalProvider(
+          LocalDensity provides Density(1f),
+          LocalAppColors provides LightColors,
+          LocalAppShadows provides LightAppShadows,
+          LocalThemeMode provides ResolvedThemeMode.Light,
+        ) {
+          Box(Modifier.size(RootSize.dp).background(Color.White).testTag(RootTag)) {
+            Box(
+              Modifier.offset {
+                  val pageOffset = (PageOffsetAtZoomOne * zoom.value).roundToInt()
+                  IntOffset(pageOffset, pageOffset)
+                }
+                .size(PageSizeAtZoomOne.dp * zoom.value)
+                .editorPagePositionTracker(uiState = uiState, page = 1, density = 1f)
+            )
+            EditorTableColumnResizeOverlay(
+              editor = editor,
+              uiState = uiState,
+              geometry = interactionGeometry,
+              presentation = EditorTableColumnResizePresentation(pressed = false, draft = null),
+            )
+          }
+        }
+      }
+      mainClock.advanceTimeByFrame()
+
+      runOnUiThread {
+        uiState.updateDisplayZoom(2f)
+        zoom.value = 2f
+      }
+      mainClock.advanceTimeByFrame()
+
+      val pixels = onNodeWithTag(RootTag).captureToImage().toPixelMap()
+      assertNotEquals(Color.White, pixels[TableColumnResizeCenterX, TableColumnResizeCenterY])
+    } finally {
+      scope.cancel()
+    }
+  }
+
+  private fun tableOverlay(cellSelection: TableOverlayCellSelection? = null): TableOverlay =
+    TableOverlay(
+      tableId = "table",
+      pageIdx = 1,
+      bounds = co.typie.editor.ffi.Rect(x = 10f, y = 20f, width = 100f, height = 80f),
+      borderStyle = TableBorderStyle.Solid,
+      align = Alignment.Left,
+      proportion = 1f,
+      contentWidth = 100f,
+      minProportionWidth = 83f,
+      maxProportionWidth = 100f,
+      rows = listOf(TableOverlayRow(index = 0, height = 40f, position = 40f)),
+      columns = listOf(TableOverlayColumn(index = 0, widthAsPx = 50f, position = 50f)),
+      rowCount = 1,
+      isLastRowFragment = true,
+      isFocused = true,
+      focusedRowIndex = 0,
+      focusedColIndex = 0,
+      cellSelection = cellSelection,
+    )
+
+  private fun focusedUiState(): EditorUiState =
+    EditorUiState().apply {
+      updateFocus(true)
+      updateDisplayZoom(1f)
+      val editorBounds = Rect(0f, 0f, RootSize, RootSize)
+      updateInteractionSurfaceBounds(boundsInRoot = editorBounds, density = 1f)
+      updateEditorBounds(boundsInRoot = editorBounds, density = 1f)
+    }
+
+  private class TestInteractionGeometry(
+    private val editor: Editor,
+    private val uiState: EditorUiState,
+  ) : EditorInteractionGeometry {
+    override val density = 1f
+
+    override fun resolveInteractionPosition(positionInSurface: Offset): Offset = positionInSurface
+
+    override fun isTapEligible(positionInSurface: Offset): Boolean = true
+
+    override fun resolvePoint(positionInNode: Offset): PagePoint? = null
+
+    override fun resolvePagePosition(page: Int, x: Float, y: Float): Offset? =
+      uiState.resolveViewportTransform(editor.pageSizes).localToGlobal(page = page, x = x, y = y)
+
+    override fun resolveEdgeAutoScrollViewport(): EditorEdgeAutoScrollViewport? = null
+  }
+
+  private companion object {
+    const val ColumnMenuDescription = "열 메뉴"
+    const val ContinuousEditorTop = 40f
+    const val ContinuousHighlightX = 10
+    const val ContinuousPageHeight = 100f
+    const val ContinuousPageWidth = 100f
+    const val ContinuousRelayoutHighlightCenterY = 255
+    const val ContinuousRelayoutPageHeight = 200f
+    const val EditorBoundsMarkerSize = 10f
+    const val EditorBoundsMarkerTag = "editor-bounds-marker"
+    const val EditorBoundsTag = "zoomed-editor-bounds"
+    const val EditorOffsetAtZoomOne = 40f
+    const val EditorSizeAtZoomOne = 100f
+    const val InteractionSurfaceOffset = 30f
+    const val InteractionSurfaceSize = 400f
+    const val InteractionSurfaceTag = "interaction-surface"
+    const val PageTag = "zoomed-page"
+    const val RootTag = "overlay-root"
+    const val PageOffsetAtZoomOne = 100f
+    const val PageSizeAtZoomOne = 100f
+    const val RootSize = 500f
+    const val TableCellHandleCenter = 320
+    const val TableColumnResizeCenterX = 320
+    const val TableColumnResizeCenterY = 300
+    const val ToHandleCenterX = 281
+    const val ToHandleCenterY = 264
+  }
+}


### PR DESCRIPTION
- page-local offset과 editor body bounds를 layout placement 시점에 게시
- selection handle / table cell selection handle / column resize handle / continuous 모드 line highlight는 draw 시점에 최신 geometry를 읽고, table axis selector는 layout placement에서 실제 composable을 배치