### PR TITLE
syncTextInputValue가 텍스트 교체 시 커서가 끝에 있었던 경우 커서 위치 보존

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ext/TextInputState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ext/TextInputState.kt
@@ -136,7 +136,14 @@ internal fun syncTextInputValue(currentValue: TextFieldValue, text: String): Tex
     return currentValue
   }
 
-  val selection = clampTextInputRange(currentValue.selection, text.length)
+  val selection =
+    if (
+      currentValue.selection.collapsed && currentValue.selection.end == currentValue.text.length
+    ) {
+      TextRange(text.length)
+    } else {
+      clampTextInputRange(currentValue.selection, text.length)
+    }
   return TextFieldValue(text = text, selection = selection)
 }
 

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/ext/TextInputStateTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/ext/TextInputStateTest.kt
@@ -63,6 +63,27 @@ class TextInputStateTest {
   }
 
   @Test
+  fun sync_text_input_value_keeps_cursor_at_text_end_when_external_text_grows() {
+    val currentValue = TextFieldValue(text = "", selection = TextRange.Zero)
+
+    val result = syncTextInputValue(currentValue = currentValue, text = "recent search")
+
+    assertEquals(
+      TextFieldValue(text = "recent search", selection = TextRange("recent search".length)),
+      result,
+    )
+  }
+
+  @Test
+  fun sync_text_input_value_keeps_middle_selection_when_external_text_grows() {
+    val currentValue = TextFieldValue(text = "hello", selection = TextRange(1, 4))
+
+    val result = syncTextInputValue(currentValue = currentValue, text = "hello world")
+
+    assertEquals(TextFieldValue(text = "hello world", selection = TextRange(1, 4)), result)
+  }
+
+  @Test
   fun sync_text_input_value_keeps_state_when_text_matches() {
     val currentValue =
       TextFieldValue(text = "hello", selection = TextRange(1, 4), composition = TextRange(1, 4))


### PR DESCRIPTION
- 기존에는 검색 스크린에서 최근 검색어를 선택하면 검색어 삽입 후 커서 위치가 0에 머물러 있었음
- syncTextInputValue가 동기화 시 커서가 기존 텍스트 끝에 collapsed되어 있었다면 새 텍스트에서도 끝 위치를 유지하도록 변경
- 중간 커서와 선택 영역은 기존 위치를 보존하므로 다른 시나리오에는 영향이 없음
- Compose의 state-based text input 모델과도 일치함