### PR TITLE
앱 에디터 헤더 영역에서 스크롤/줌 지원

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/body/EditorBody.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/body/EditorBody.kt
@@ -47,7 +47,6 @@ internal fun EditorBody(
   layoutSpec: EditorDocumentLayoutSpec,
   autoScrollPolicy: EditorAutoScrollPolicy,
   modifier: Modifier = Modifier,
-  interactionModifier: Modifier = Modifier,
   editorInputEnabled: Boolean = true,
   suppressSoftwareKeyboard: Boolean = false,
   showDebugBodyOverlay: Boolean = false,
@@ -71,7 +70,7 @@ internal fun EditorBody(
       .trackEditorInteractionSurfaceBounds(uiState = uiState, density = density.density)
 
   Box(modifier = modifier.fillMaxWidth()) {
-    Box(modifier = interactionSurfaceModifier.then(interactionModifier)) {
+    Box(modifier = interactionSurfaceModifier) {
       if (layoutSpec is EditorDocumentLayoutSpec.Continuous) {
         EditorExtensionAreaLineHighlightOverlay(
           cursor = editor?.cursor,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionGeometry.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionGeometry.kt
@@ -6,9 +6,11 @@ import co.typie.editor.PagePoint
 internal interface EditorInteractionGeometry {
   val density: Float
 
-  fun resolveInteractionPosition(positionInSurface: Offset): Offset?
+  fun containsDocumentInteraction(positionInRoot: Offset): Boolean
 
-  fun isTapEligible(positionInSurface: Offset): Boolean
+  fun resolveInteractionPosition(positionInRoot: Offset): Offset?
+
+  fun isTapEligible(positionInRoot: Offset): Boolean
 
   fun resolvePoint(positionInNode: Offset): PagePoint?
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionScope.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionScope.kt
@@ -114,38 +114,29 @@ internal class EditorInteractionScope(
     scrollGestureLockState = null
   }
 
-  override fun resolveInteractionPosition(positionInSurface: Offset): Offset? {
+  override fun containsDocumentInteraction(positionInRoot: Offset): Boolean =
+    editor != null && density > 0f && uiState?.containsDocumentInteraction(positionInRoot) == true
+
+  override fun resolveInteractionPosition(positionInRoot: Offset): Offset? {
     if (editor == null) {
       return null
     }
-    val bounds = uiState?.editorBoundsInContainer ?: return null
-    if (!bounds.isValid || density <= 0f) {
+    val bounds = uiState?.editorRectInRoot() ?: return null
+    if (density <= 0f) {
       return null
     }
 
-    return Offset(
-      x = positionInSurface.x - bounds.x * density,
-      y = positionInSurface.y - bounds.y * density,
-    )
+    return Offset(x = positionInRoot.x - bounds.left, y = positionInRoot.y - bounds.top)
   }
 
-  override fun isTapEligible(positionInSurface: Offset): Boolean {
-    if (editor == null || density <= 0f) {
-      return false
-    }
-    val bounds = uiState?.editorBoundsInContainer ?: return false
-    if (!bounds.isValid) {
+  override fun isTapEligible(positionInRoot: Offset): Boolean {
+    if (!containsDocumentInteraction(positionInRoot)) {
       return false
     }
     if (outsidePageTapEnabled) {
       return true
     }
-    val x = positionInSurface.x / density
-    val y = positionInSurface.y / density
-    return x >= bounds.x &&
-      x <= bounds.x + bounds.width &&
-      y >= bounds.y &&
-      y <= bounds.y + bounds.height
+    return uiState?.editorRectInRoot()?.contains(positionInRoot) == true
   }
 
   override fun resolvePoint(positionInNode: Offset): PagePoint? {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractions.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractions.kt
@@ -38,6 +38,16 @@ import kotlinx.coroutines.launch
 private const val EditorTapSlopDp = 8f
 private const val WheelBurstGapMs = 56L
 
+private enum class EditorDirectPointerAdmission {
+  Document,
+  HeaderViewportOnly,
+}
+
+private data class EditorDirectPointer(
+  val type: PointerType,
+  val admission: EditorDirectPointerAdmission,
+)
+
 internal fun Modifier.editorInteractions(
   interactionController: EditorInteractionController,
   geometry: EditorInteractionGeometry,
@@ -147,8 +157,9 @@ private class EditorInteractionsNode(
   SemanticsModifierNode,
   EditorScreenPointerListener,
   EditorPlatformIndirectScaleOwner {
-  private val pointers = mutableMapOf<Long, PointerType>()
+  private val pointers = mutableMapOf<Long, EditorDirectPointer>()
   private val singlePointerStreams = mutableSetOf<Long>()
+  private var directPointerEventProcessedInInitial = false
   private var suppressUntilAllUp = false
   private var wheelLastEventMillis: Long? = null
   private var wheelZoomActive = false
@@ -232,7 +243,11 @@ private class EditorInteractionsNode(
       cancelInteraction(clearSuppression = true)
       return
     }
-    if (pointerEvent.changes.any { change -> change.isUnconsumedDirectDown(pointerEvent) }) {
+    if (
+      pointerEvent.changes.any { change ->
+        change.isDirectDown(pointerEvent) && change.id.value in pointers
+      }
+    ) {
       onEditorPointerInput()
     }
 
@@ -240,11 +255,10 @@ private class EditorInteractionsNode(
     interactionController.updateColumnResizeSlop(
       dragSlopPx = min(touchSlop, EditorTapSlopDp * density)
     )
-    registerPointerDowns(pointerEvent)
     if (
       scaleZoomActive &&
         pointers.isNotEmpty() &&
-        pointers.values.all { pointerType -> pointerType == PointerType.Mouse }
+        pointers.values.all { pointer -> pointer.type == PointerType.Mouse }
     ) {
       suppressUntilAllUp = true
       physicalSequenceYieldedToIndirectInput = true
@@ -269,7 +283,7 @@ private class EditorInteractionsNode(
       finishReleasedPointers(pointerEvent)
       return
     }
-    if (pointers.values.count { pointerType -> pointerType == PointerType.Touch } > 2) {
+    if (pointers.values.count { pointer -> pointer.type == PointerType.Touch } > 2) {
       cancelAndSuppress(pointerEvent)
       return
     }
@@ -310,6 +324,11 @@ private class EditorInteractionsNode(
   }
 
   private fun routePointerPass(pointerEvent: PointerEvent, pass: PointerEventPass): Boolean {
+    if (pass == PointerEventPass.Initial) {
+      directPointerEventProcessedInInitial = false
+    } else if (pass == PointerEventPass.Final) {
+      directPointerEventProcessedInInitial = false
+    }
     if (pointerEvent.type.isIndirectPointerEvent()) {
       if (pass == PointerEventPass.Initial) {
         handleIndirectPointerEvent(pointerEvent)
@@ -318,22 +337,31 @@ private class EditorInteractionsNode(
     }
 
     val hasFreshDown = pointerEvent.changes.any { change -> change.isDirectDown(pointerEvent) }
-    // Track membership before the screen observer's Final pass, but let shared overlay siblings
-    // claim direct gestures during Main before admitting a new editor sequence.
+    if (hasFreshDown) {
+      when (pass) {
+        PointerEventPass.Initial -> {
+          if (enabled && density > 0f) {
+            registerProvisionalPointerDowns(pointerEvent)
+          }
+          return true
+        }
+        PointerEventPass.Main -> return true
+        PointerEventPass.Final -> {
+          discardConsumedDocumentDowns(pointerEvent)
+          return false
+        }
+      }
+    }
+
+    // Header pointers must arbitrate before descendant fields in Initial, while document-only
+    // sequences keep their existing Main-pass ordering; this latch prevents duplicate processing.
     return when (pass) {
-      PointerEventPass.Initial -> true
-      PointerEventPass.Main -> {
-        if (hasFreshDown && enabled && density > 0f) {
-          registerPointerDowns(pointerEvent)
-        }
-        hasFreshDown
+      PointerEventPass.Initial -> {
+        directPointerEventProcessedInInitial = hasHeaderViewportPointer()
+        !directPointerEventProcessedInInitial
       }
-      PointerEventPass.Final -> {
-        if (hasFreshDown) {
-          discardConsumedPointerDowns(pointerEvent)
-        }
-        !hasFreshDown
-      }
+      PointerEventPass.Main -> directPointerEventProcessedInInitial
+      PointerEventPass.Final -> true
     }
   }
 
@@ -354,6 +382,7 @@ private class EditorInteractionsNode(
   override fun onGlobalAllUp() {
     pointers.clear()
     singlePointerStreams.clear()
+    directPointerEventProcessedInInitial = false
     suppressUntilAllUp = false
     physicalSequenceYieldedToIndirectInput = false
     releasePhysicalDragLock()
@@ -370,11 +399,18 @@ private class EditorInteractionsNode(
     scrollByOffset(scrollDriver::performSemanticsScroll)
   }
 
-  private fun registerPointerDowns(pointerEvent: PointerEvent) {
+  private fun registerProvisionalPointerDowns(pointerEvent: PointerEvent) {
     pointerEvent.changes
       .filter { it.isUnconsumedDirectDown(pointerEvent) }
       .forEach { change ->
-        pointers[change.id.value] = change.type
+        val positionInRoot = positionInRoot(change.position)
+        val admission =
+          if (geometry.containsDocumentInteraction(positionInRoot)) {
+            EditorDirectPointerAdmission.Document
+          } else {
+            EditorDirectPointerAdmission.HeaderViewportOnly
+          }
+        pointers[change.id.value] = EditorDirectPointer(type = change.type, admission = admission)
         if (
           physicalDragLockHandle == null &&
             change.type == PointerType.Mouse &&
@@ -385,10 +421,16 @@ private class EditorInteractionsNode(
       }
   }
 
-  private fun discardConsumedPointerDowns(pointerEvent: PointerEvent) {
+  private fun discardConsumedDocumentDowns(pointerEvent: PointerEvent) {
     var pointerRemoved = false
     pointerEvent.changes
-      .filter { change -> change.isDirectDown(pointerEvent) && change.isConsumed }
+      .filter { change ->
+        if (!change.isDirectDown(pointerEvent)) {
+          return@filter false
+        }
+        val pointer = pointers[change.id.value] ?: return@filter false
+        change.isConsumed && pointer.admission == EditorDirectPointerAdmission.Document
+      }
       .forEach { change ->
         if (pointers.remove(change.id.value) != null) {
           pointerRemoved = true
@@ -404,21 +446,34 @@ private class EditorInteractionsNode(
     onScreenPointerMembershipChanged()
   }
 
+  private fun hasHeaderViewportPointer(): Boolean =
+    pointers.values.any { pointer ->
+      pointer.admission == EditorDirectPointerAdmission.HeaderViewportOnly
+    }
+
   private fun isEditorTouchPointer(pointerId: Long): Boolean =
-    pointers[pointerId] == PointerType.Touch
+    pointers[pointerId]?.type == PointerType.Touch
 
   private fun pressedTouchChanges(pointerEvent: PointerEvent): List<PointerInputChange> =
     pointerEvent.changes.filter { change ->
-      change.pressed && pointers[change.id.value] == PointerType.Touch
+      change.pressed && pointers[change.id.value]?.type == PointerType.Touch
     }
 
   private fun forwardSinglePointerChanges(pointerEvent: PointerEvent) {
     pointerEvent.changes
-      .filter { it.isUnconsumedDirectDown(pointerEvent) }
+      .filter { change -> change.isDirectDown(pointerEvent) && change.id.value in pointers }
       .forEach { change ->
         val rootPosition = positionInRoot(change.position)
-        val tapEnabled = geometry.isTapEligible(change.position)
-        val editorPosition = geometry.resolveInteractionPosition(change.position)
+        val pointer = checkNotNull(pointers[change.id.value])
+        val editorPosition =
+          resolveInteractionPosition(pointer = pointer, positionInRoot = rootPosition)
+        if (pointer.admission == EditorDirectPointerAdmission.Document && editorPosition == null) {
+          cancelAndSuppress(pointerEvent)
+          return
+        }
+        val tapEnabled =
+          pointer.admission == EditorDirectPointerAdmission.Document &&
+            geometry.isTapEligible(rootPosition)
         singlePointerStreams += change.id.value
         if (
           interactionController.onPointerDown(
@@ -441,7 +496,13 @@ private class EditorInteractionsNode(
       }
       .forEach { change ->
         val rootPosition = positionInRoot(change.position)
-        val editorPosition = geometry.resolveInteractionPosition(change.position)
+        val pointer = pointers[change.id.value] ?: return@forEach
+        val editorPosition =
+          resolveInteractionPosition(pointer = pointer, positionInRoot = rootPosition)
+        if (pointer.admission == EditorDirectPointerAdmission.Document && editorPosition == null) {
+          cancelAndSuppress(pointerEvent)
+          return
+        }
         if (
           interactionController.onPointerMove(
             pointerId = change.id.value,
@@ -461,7 +522,13 @@ private class EditorInteractionsNode(
       }
       .forEach { change ->
         val rootPosition = positionInRoot(change.position)
-        val editorPosition = geometry.resolveInteractionPosition(change.position)
+        val pointer = pointers[change.id.value] ?: return@forEach
+        val editorPosition =
+          resolveInteractionPosition(pointer = pointer, positionInRoot = rootPosition)
+        if (pointer.admission == EditorDirectPointerAdmission.Document && editorPosition == null) {
+          cancelAndSuppress(pointerEvent)
+          return
+        }
         if (
           interactionController.onPointerUp(
             pointerId = change.id.value,
@@ -475,6 +542,15 @@ private class EditorInteractionsNode(
         singlePointerStreams -= change.id.value
       }
   }
+
+  private fun resolveInteractionPosition(
+    pointer: EditorDirectPointer,
+    positionInRoot: Offset,
+  ): Offset? =
+    when (pointer.admission) {
+      EditorDirectPointerAdmission.Document -> geometry.resolveInteractionPosition(positionInRoot)
+      EditorDirectPointerAdmission.HeaderViewportOnly -> null
+    }
 
   private fun resolvePinchSample(changes: List<PointerInputChange>): EditorPinchSample? =
     resolveEditorPinchSample(
@@ -501,8 +577,8 @@ private class EditorInteractionsNode(
   }
 
   private fun hasPhysicalDragPointer(): Boolean =
-    pointers.values.any { pointerType ->
-      pointerType == PointerType.Mouse && pointerType.isTouchDragPointer()
+    pointers.values.any { pointer ->
+      pointer.type == PointerType.Mouse && pointer.type.isTouchDragPointer()
     }
 
   private fun cancelAndSuppress(pointerEvent: PointerEvent) {
@@ -755,7 +831,7 @@ private class EditorInteractionsNode(
     if (
       screenPointerSequence.hasScreenPointers ||
         pointers.isEmpty() ||
-        pointers.values.any { pointerType -> pointerType != PointerType.Mouse } ||
+        pointers.values.any { pointer -> pointer.type != PointerType.Mouse } ||
         !interactionController.cancelPendingPointerForIndirectInput()
     ) {
       return false
@@ -776,6 +852,7 @@ private class EditorInteractionsNode(
     val hadPointers = pointers.isNotEmpty() || suppressUntilAllUp
     pointers.clear()
     singlePointerStreams.clear()
+    directPointerEventProcessedInInitial = false
     if (hadPointers) {
       interactionController.cancel()
     }
@@ -915,7 +992,7 @@ private class EditorScreenPointerObserverNode(var sequence: EditorScreenPointerS
   }
 }
 
-private fun PointerInputChange.isDirectDown(pointerEvent: PointerEvent): Boolean =
+internal fun PointerInputChange.isDirectDown(pointerEvent: PointerEvent): Boolean =
   pressed && !previousPressed && (type != PointerType.Mouse || pointerEvent.isDirectMousePress())
 
 private fun PointerInputChange.isUnconsumedDirectDown(pointerEvent: PointerEvent): Boolean =

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/runtime/EditorUiState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/runtime/EditorUiState.kt
@@ -80,6 +80,10 @@ class EditorUiState {
 
   fun editorRectInRoot(): Rect? = editorBoundsInRoot.takeIf { it.isUsable }
 
+  internal fun containsDocumentInteraction(positionInRoot: Offset): Boolean =
+    interactionSurfaceBoundsInRoot.isUsable &&
+      interactionSurfaceBoundsInRoot.contains(positionInRoot)
+
   fun textClippingRectInRoot(): Rect? = editorClippedBoundsInRoot.takeIf { it.isUsable }
 
   fun cursorRectInRoot(cursor: CursorMetrics?): Rect? {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -1386,7 +1386,7 @@ fun EditorScreen(entityId: String) {
             }
           }
         },
-        body = { editorInteractionModifier ->
+        body = {
           val editorLoad = editorLoadState
           if (editorLoad != null) {
             EditorBody(
@@ -1395,7 +1395,6 @@ fun EditorScreen(entityId: String) {
               layoutSpec = layoutSpec,
               autoScrollPolicy = autoScrollPolicy,
               modifier = Modifier,
-              interactionModifier = editorInteractionModifier,
               editorInputEnabled = editorReady && editorInputEnabledByToolbar && !editorReadOnly,
               suppressSoftwareKeyboard =
                 !editorReady || editorSuppressesSoftwareKeyboard || editorReadOnly,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayout.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayout.kt
@@ -44,6 +44,7 @@ import co.typie.editor.interaction.EditorScreenPointerSequence
 import co.typie.editor.interaction.LocalEditorInteractionScope
 import co.typie.editor.interaction.editorInteractions
 import co.typie.editor.interaction.editorPlatformIndirectScale
+import co.typie.editor.interaction.isDirectDown
 import co.typie.editor.interaction.observeEditorScreenPointerSequence
 import co.typie.editor.runtime.LocalEditorUiState
 import co.typie.editor.scroll.EditorBringIntoViewBehavior
@@ -99,8 +100,32 @@ private class SharePointerInputWithSiblingsNode : Modifier.Node(), PointerInputM
   override fun onCancelPointerInput() = Unit
 }
 
+private data object ViewportDirectControlElement :
+  ModifierNodeElement<ViewportDirectControlNode>() {
+  override fun create(): ViewportDirectControlNode = ViewportDirectControlNode()
+
+  override fun update(node: ViewportDirectControlNode) = Unit
+}
+
+private class ViewportDirectControlNode : Modifier.Node(), PointerInputModifierNode {
+  override fun onPointerEvent(pointerEvent: PointerEvent, pass: PointerEventPass, bounds: IntSize) {
+    if (pass != PointerEventPass.Initial) {
+      return
+    }
+    pointerEvent.changes.forEach { change ->
+      if (change.isDirectDown(pointerEvent)) {
+        change.consume()
+      }
+    }
+  }
+
+  override fun onCancelPointerInput() = Unit
+}
+
 private fun Modifier.sharePointerInputWithSiblings(): Modifier =
   this then SharePointerInputWithSiblingsElement
+
+internal fun Modifier.viewportDirectControl(): Modifier = this then ViewportDirectControlElement
 
 internal enum class EditorViewportScrollReconcileMode {
   Disabled,
@@ -123,7 +148,7 @@ internal fun EditorScreenLayout(
   onEditorPointerInput: () -> Unit = {},
   onMeasuredViewportSizeChange: (Size) -> Unit,
   header: @Composable () -> Unit,
-  body: @Composable (Modifier) -> Unit,
+  body: @Composable () -> Unit,
   viewportOverlay: @Composable BoxScope.() -> Unit = {},
   overlay: @Composable () -> Unit = {},
   toolbar: @Composable () -> Unit,
@@ -242,7 +267,8 @@ internal fun EditorScreenLayout(
                 .clipToBounds()
                 .hazeSource(toolbarBackdropHazeState)
                 .navigationPopNestedScroll()
-                .nestedScroll(EditorViewportNestedScrollConnection, viewportNestedScrollDispatcher),
+                .nestedScroll(EditorViewportNestedScrollConnection, viewportNestedScrollDispatcher)
+                .then(editorInteractionModifier),
             content = {
               Column {
                 Box(modifier = Modifier.width(viewportWidth.dp)) { header() }
@@ -252,7 +278,7 @@ internal fun EditorScreenLayout(
                       translationX = -state.viewportState.scrollOffset.x * density.density
                     }
                 ) {
-                  body(editorInteractionModifier)
+                  body()
                 }
               }
             },

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorCharacterCountOverlay.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorCharacterCountOverlay.kt
@@ -4,8 +4,10 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.detectDragGestures
-import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.waitForUpOrCancellation
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -27,6 +29,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.PointerInputScope
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
@@ -38,6 +41,7 @@ import co.typie.editor.ffi.CharacterCounts
 import co.typie.editor.scroll.EditorVisibleArea
 import co.typie.editor.viewport.EditorViewportState
 import co.typie.icons.Lucide
+import co.typie.screen.editor.editor.layout.viewportDirectControl
 import co.typie.storage.Preference
 import co.typie.ui.component.Text
 import co.typie.ui.icon.Icon
@@ -153,9 +157,7 @@ internal fun EditorCharacterCountOverlay(
     delay(WidgetFadeIdleMs)
     faded = false
   }
-  LaunchedEffect(wakeRequest) {
-    if (wakeRequest > 0) faded = false
-  }
+  LaunchedEffect(wakeRequest) { if (wakeRequest > 0) faded = false }
 
   val alpha by
     animateFloatAsState(
@@ -179,6 +181,7 @@ internal fun EditorCharacterCountOverlay(
         .offset { IntOffset(state.offsetX.toInt(), state.offsetY.toInt()) }
         .onSizeChanged { widgetSize = it.width to it.height }
         .graphicsLayer { this.alpha = alpha }
+        .viewportDirectControl()
         .pointerInput(Unit) {
           detectDragGestures(
             onDragStart = {
@@ -193,7 +196,7 @@ internal fun EditorCharacterCountOverlay(
           }
         }
         .pointerInput(Unit) {
-          detectTapGestures {
+          detectTapAfterConsumedDown {
             // Legacy: tapping a faded widget only wakes it, without toggling the expanded rows.
             val wasFaded = faded
             wakeRequest += 1
@@ -229,10 +232,7 @@ internal fun EditorCharacterCountOverlay(
 
       if (state.expanded) {
         current.expandedRows().forEach { (label, value) ->
-          Row(
-            modifier = Modifier.width(160.dp),
-            horizontalArrangement = Arrangement.SpaceBetween,
-          ) {
+          Row(modifier = Modifier.width(160.dp), horizontalArrangement = Arrangement.SpaceBetween) {
             Text(
               text = label,
               style = AppTheme.typography.caption,
@@ -247,5 +247,14 @@ internal fun EditorCharacterCountOverlay(
         }
       }
     }
+  }
+}
+
+internal suspend fun PointerInputScope.detectTapAfterConsumedDown(onTap: () -> Unit) {
+  awaitEachGesture {
+    awaitFirstDown(requireUnconsumed = false)
+    val up = waitForUpOrCancellation() ?: return@awaitEachGesture
+    up.consume()
+    onTap()
   }
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorScrollbars.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorScrollbars.kt
@@ -51,6 +51,7 @@ import co.typie.editor.viewport.EditorViewportScrollbarMetrics
 import co.typie.editor.viewport.EditorViewportState
 import co.typie.editor.viewport.resolveEditorViewportScrollbarMetrics
 import co.typie.editor.viewport.resolveEditorViewportScrollbarScrollPositionFromDrag
+import co.typie.screen.editor.editor.layout.viewportDirectControl
 import co.typie.ui.component.Text
 import co.typie.ui.theme.AppShapes
 import co.typie.ui.theme.AppTheme
@@ -502,7 +503,11 @@ private fun EditorScrollbarThumb(
   ) {
     Box(
       modifier =
-        Modifier.fillMaxSize().pointerInput(horizontal, viewportState, density) {
+        Modifier.fillMaxSize().viewportDirectControl().pointerInput(
+          horizontal,
+          viewportState,
+          density,
+        ) {
           val touchSlop = viewConfiguration.touchSlop
           val touchSlopSquared = touchSlop * touchSlop
 

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
@@ -3408,9 +3408,11 @@ class EditorInteractionControllerTest {
     var edgeAutoScrollMovesViewport = false
     val requestedBringIntoViewVersions = mutableListOf<Long>()
 
-    override fun resolveInteractionPosition(positionInSurface: Offset): Offset = positionInSurface
+    override fun containsDocumentInteraction(positionInRoot: Offset): Boolean = true
 
-    override fun isTapEligible(positionInSurface: Offset): Boolean = true
+    override fun resolveInteractionPosition(positionInRoot: Offset): Offset = positionInRoot
+
+    override fun isTapEligible(positionInRoot: Offset): Boolean = true
 
     override fun resolvePoint(positionInNode: Offset): PagePoint? {
       if (density <= 0f) {

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionScopeTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionScopeTest.kt
@@ -1,12 +1,21 @@
 package co.typie.editor.interaction
 
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import co.typie.editor.Editor
 import co.typie.editor.EditorState
+import co.typie.editor.FakeFfiEditor
+import co.typie.editor.body.EditorDocumentLayoutSpec
 import co.typie.editor.runtime.EditorUiState
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.EditorVisibleArea
 import co.typie.editor.viewport.EditorViewportState
 import co.typie.ext.ScrollGestureLockState
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -32,5 +41,63 @@ class EditorInteractionScopeTest {
       )
 
       scope.onEditorStateChanged(EditorState.Initial)
+    }
+
+  @Test
+  fun `root Down eligibility and mapping distinguish header from document body`() =
+    runTest(StandardTestDispatcher()) {
+      val uiState =
+        EditorUiState().apply {
+          updateInteractionSurfaceBounds(
+            boundsInRoot = Rect(left = 0f, top = 120f, right = 400f, bottom = 920f),
+            density = 1f,
+          )
+          updateEditorBounds(
+            boundsInRoot = Rect(left = 40f, top = 200f, right = 360f, bottom = 680f),
+            density = 1f,
+          )
+        }
+      val scope = EditorInteractionScope(coroutineScope = this)
+      scope.update(
+        editor = Editor(FakeFfiEditor(), this, StandardTestDispatcher(testScheduler)),
+        bringIntoViewRequests = EditorBringIntoViewRequests(),
+        uiState = uiState,
+        density = 1f,
+        visibleArea = EditorVisibleArea(),
+        viewportState = EditorViewportState(),
+        scrollGestureLockState = ScrollGestureLockState(),
+        viewportZoomConfig = null,
+        layoutSpec = EditorDocumentLayoutSpec.Continuous(maxWidth = 320f),
+        onSelectionHaptic = {},
+        onRequestSoftwareKeyboard = {},
+      )
+
+      val headerPositionInRoot = Offset(x = 80f, y = 100f)
+      val bodyPositionInRoot = Offset(x = 80f, y = 240f)
+
+      // Down admission is decided in root coordinates. The cross-boundary
+      // headerFieldPanClaimsViewportWithoutPromotingReleaseToFieldOrEditor layout test protects
+      // this classification from being promoted after the pointer moves into the body.
+      assertFalse(scope.containsDocumentInteraction(headerPositionInRoot))
+      assertTrue(scope.containsDocumentInteraction(bodyPositionInRoot))
+      assertFalse(
+        scope.isTapEligible(headerPositionInRoot),
+        "header root Down must not be document-eligible",
+      )
+      assertTrue(
+        scope.isTapEligible(bodyPositionInRoot),
+        "body root Down must remain document-eligible",
+      )
+
+      val bodyMapped = assertNotNull(scope.resolveInteractionPosition(bodyPositionInRoot))
+      assertEquals(
+        Offset(x = 40f, y = 40f),
+        bodyMapped,
+        "body mapping must subtract the editor rect top-left in root",
+      )
+
+      val headerMapped = assertNotNull(scope.resolveInteractionPosition(headerPositionInRoot))
+      assertEquals(Offset(x = 40f, y = -100f), headerMapped)
+      assertTrue(headerMapped.y < 0f, "mapping above the body must stay valid and negative")
     }
 }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/interaction/EditorInteractionsDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/interaction/EditorInteractionsDesktopTest.kt
@@ -96,6 +96,50 @@ class EditorInteractionsDesktopTest {
   }
 
   @Test
+  fun `document pointer cancels when interaction mapping becomes unavailable`() = runComposeUiTest {
+    val fixture = Fixture(tapEligible = true)
+    setEditorContent(fixture)
+    val editor = onNodeWithTag(EditorTag)
+
+    editor.performTouchInput { down(pointerId = 0, position = Offset(x = 100f, y = 100f)) }
+    assertEquals(1, fixture.host.longPressDispatchScheduleCount)
+    runOnIdle { fixture.host.interactionMappingAvailable = false }
+
+    try {
+      editor.performTouchInput { moveTo(pointerId = 0, position = Offset(x = 120f, y = 100f)) }
+      waitForIdle()
+
+      assertEquals(EditorInteractionMode.Idle, fixture.controller.interactionMode)
+      assertTrue(fixture.touchPanDeltas.isEmpty())
+      assertEquals(1, fixture.host.pointerCancelEnqueueCount)
+      assertEquals(1, fixture.host.longPressDispatchCancelCount)
+    } finally {
+      editor.performTouchInput { up(pointerId = 0) }
+    }
+  }
+
+  @Test
+  fun `header Down stays pan only after moving into document body`() = runComposeUiTest {
+    val fixture = Fixture(tapEligible = true, documentDownEligible = false)
+    setEditorContent(fixture)
+
+    onNodeWithTag(EditorTag).performTouchInput {
+      down(pointerId = 0, position = Offset(x = 100f, y = 40f))
+      moveTo(pointerId = 0, position = Offset(x = 100f, y = 120f))
+      up(pointerId = 0)
+    }
+    waitForIdle()
+
+    assertTrue(fixture.touchPanDeltas.isNotEmpty())
+    assertEquals(0, fixture.host.tapDispatchScheduleCount)
+    assertEquals(0, fixture.host.longPressDispatchScheduleCount)
+    assertEquals(0, fixture.host.pointerCancelEnqueueCount)
+    assertEquals(EditorInteractionMode.Idle, fixture.controller.interactionMode)
+    assertFalse(fixture.controller.tableColumnResizePresentation.pressed)
+    assertEquals(null, fixture.controller.tableColumnResizePresentation.draft)
+  }
+
+  @Test
   fun `editor physical click drag owns desktop scroll translation until release`() =
     runComposeUiTest {
       val fixture = Fixture()
@@ -1736,6 +1780,7 @@ class EditorInteractionsDesktopTest {
     pageSize: PageSize = PageSize(width = 720f, height = 960f),
     flingBehaviorOverride: FlingBehavior? = null,
     tapEligible: Boolean = false,
+    documentDownEligible: Boolean = tapEligible,
   ) {
     val touchPanDeltas = mutableListOf<Offset>()
     val flingPanDeltas = mutableListOf<Offset>()
@@ -1813,7 +1858,7 @@ class EditorInteractionsDesktopTest {
         updatePageOffset(page = 0, offset = Offset.Zero)
         updateEditorBounds(boundsInRoot = editorBoundsInRoot, density = 1f)
       }
-    val host = TestHost(tapEligible = tapEligible)
+    val host = TestHost(tapEligible = tapEligible, documentDownEligible = documentDownEligible)
     private val editor = Editor(FakeFfiEditor(), CoroutineScope(Job()), Dispatchers.Unconfined)
     private val semantics =
       EditorInteractionSemantics(effects = host).apply {
@@ -1841,8 +1886,10 @@ class EditorInteractionsDesktopTest {
       )
   }
 
-  private class TestHost(private val tapEligible: Boolean) :
+  private class TestHost(private val tapEligible: Boolean, val documentDownEligible: Boolean) :
     EditorInteractionEffects, EditorInteractionGeometry {
+    var interactionMappingAvailable = tapEligible
+    var pointerCancelEnqueueCount = 0
     var pointerStreamCancelCount = 0
     var tapDispatchScheduleCount = 0
     var longPressDispatchScheduleCount = 0
@@ -1850,12 +1897,14 @@ class EditorInteractionsDesktopTest {
 
     override val density: Float = 1f
 
-    override fun resolveInteractionPosition(positionInSurface: Offset): Offset? =
-      positionInSurface.takeIf {
-        tapEligible
+    override fun containsDocumentInteraction(positionInRoot: Offset): Boolean = documentDownEligible
+
+    override fun resolveInteractionPosition(positionInRoot: Offset): Offset? =
+      positionInRoot.takeIf {
+        interactionMappingAvailable
       }
 
-    override fun isTapEligible(positionInSurface: Offset): Boolean = tapEligible
+    override fun isTapEligible(positionInRoot: Offset): Boolean = tapEligible
 
     override fun resolvePoint(positionInNode: Offset): PagePoint? =
       PagePoint(page = 0, x = positionInNode.x, y = positionInNode.y).takeIf { tapEligible }
@@ -1892,7 +1941,9 @@ class EditorInteractionsDesktopTest {
 
     override fun requestSoftwareKeyboard() = Unit
 
-    override fun enqueuePointerCancel() = Unit
+    override fun enqueuePointerCancel() {
+      pointerCancelEnqueueCount += 1
+    }
 
     override fun setScrollGestureLocked(locked: Boolean) = Unit
 

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayoutDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayoutDesktopTest.kt
@@ -1,6 +1,8 @@
 package co.typie.screen.editor.editor.layout
 
 import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.rememberScrollable2DState
@@ -12,39 +14,72 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.pointer.PointerButtons
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerId
+import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.scene.ComposeScenePointer
+import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertIsNotFocused
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.pan
+import androidx.compose.ui.test.performKeyInput
 import androidx.compose.ui.test.performMouseInput
 import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.performTrackpadInput
 import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.scale
 import androidx.compose.ui.test.swipe
+import androidx.compose.ui.test.v2.runSkikoComposeUiTest
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
+import co.typie.editor.Editor
 import co.typie.editor.EditorState
+import co.typie.editor.EditorZoomController
+import co.typie.editor.FakeFfiEditor
 import co.typie.editor.body.EditorDocumentLayoutSpec
 import co.typie.editor.ffi.Size as PageSize
 import co.typie.editor.interaction.EditorInteractionMode
 import co.typie.editor.interaction.EditorInteractionScope
 import co.typie.editor.interaction.LocalEditorInteractionScope
+import co.typie.editor.interaction.semantics.EditorViewportZoomSemanticConfig
 import co.typie.editor.runtime.EditorBoundsInContainer
 import co.typie.editor.runtime.EditorUiState
 import co.typie.editor.runtime.LocalEditorUiState
+import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.EditorScrollFrame
 import co.typie.editor.scroll.EditorVisibleArea
 import co.typie.editor.scroll.LocalEditorBringIntoViewRequests
 import co.typie.editor.scroll.rememberEditorBringIntoViewRequests
 import co.typie.editor.scroll.resolveEditorAutoScrollPolicy
 import co.typie.editor.viewport.EditorViewportState
+import co.typie.ext.ScrollGestureLockState
 import co.typie.navigation.LocalNavigationPopNestedScroll
 import co.typie.navigation.NavigationPopNestedScroll
 import co.typie.screen.editor.editor.overlay.EditorScrollbars
@@ -53,10 +88,503 @@ import co.typie.ui.theme.LightColors
 import co.typie.ui.theme.LocalAppColors
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 
 @OptIn(ExperimentalTestApi::class)
 class EditorScreenLayoutDesktopTest {
+  @Test
+  fun headerWheelReachesViewportScrollableState() = runComposeUiTest {
+    val fixture = HeaderInputFixture()
+    try {
+      setHeaderInputContent(fixture)
+
+      onNodeWithTag(LayoutTag).performMouseInput {
+        moveTo(Offset(x = 280f, y = HeaderHeightPx / 2f))
+        scroll(Offset(x = 0f, y = 120f))
+      }
+      waitForIdle()
+
+      assertTrue(fixture.scrollDeltas.isNotEmpty())
+    } finally {
+      fixture.close()
+    }
+  }
+
+  @Test
+  fun stationaryHeaderFieldTapRetainsFocusAndPlacesCaret() = runComposeUiTest {
+    val fixture = HeaderInputFixture()
+    try {
+      setHeaderInputContent(fixture)
+
+      onNodeWithTag(HeaderFieldTag).performTouchInput {
+        down(Offset(x = 180f, y = center.y))
+        up()
+      }
+      waitForIdle()
+
+      onNodeWithTag(HeaderFieldTag).assertIsFocused()
+      assertTrue(fixture.headerFocused)
+      assertNotEquals(TextRange.Zero, fixture.fieldValue.selection)
+    } finally {
+      fixture.close()
+    }
+  }
+
+  @Test
+  fun headerFieldPanClaimsViewportWithoutPromotingReleaseToFieldOrEditor() = runComposeUiTest {
+    val fixture = HeaderInputFixture()
+    try {
+      setHeaderInputContent(fixture)
+
+      onNodeWithTag(LayoutTag).performTouchInput {
+        down(pointerId = 0, position = Offset(x = 80f, y = 40f))
+        moveTo(pointerId = 0, position = Offset(x = 82f, y = HeaderHeightPx + 100f))
+        up(pointerId = 0)
+      }
+      waitForIdle()
+
+      assertTrue(fixture.scrollDeltas.isNotEmpty())
+      onNodeWithTag(HeaderFieldTag).assertIsNotFocused()
+      assertEquals(TextRange.Zero, fixture.fieldValue.selection)
+      assertTrue(fixture.fake.enqueued.isEmpty())
+      assertEquals(EditorInteractionMode.Idle, fixture.interactionScope.controller.interactionMode)
+    } finally {
+      fixture.close()
+    }
+  }
+
+  @Test
+  fun viewportDirectControlConsumesBeforeHeaderOwnerAdmission() = runComposeUiTest {
+    val fixture = HeaderInputFixture()
+    var controlDownCount = 0
+    try {
+      setHeaderInputContent(
+        fixture = fixture,
+        viewportOverlay = {
+          Box(
+            Modifier.width(160.dp)
+              .height(HeaderHeightPx.dp)
+              .testTag(HeaderControlTag)
+              .viewportDirectControl()
+              .pointerInput(Unit) {
+                awaitEachGesture {
+                  awaitFirstDown(requireUnconsumed = false)
+                  controlDownCount += 1
+                }
+              }
+          )
+        },
+      )
+
+      onNodeWithTag(HeaderControlTag).performTouchInput {
+        down(Offset(x = 80f, y = 40f))
+        moveTo(Offset(x = 82f, y = HeaderHeightPx + 100f))
+        up()
+      }
+      waitForIdle()
+
+      assertEquals(1, controlDownCount)
+      assertTrue(fixture.scrollDeltas.isEmpty())
+      assertEquals(0, fixture.editorPointerInputCount)
+      assertEquals(EditorInteractionMode.Idle, fixture.interactionScope.controller.interactionMode)
+    } finally {
+      fixture.close()
+    }
+  }
+
+  @Test
+  fun viewportDirectControlMarksOnlyItsOwnHitRegion() = runComposeUiTest {
+    val fixture = HeaderInputFixture()
+    try {
+      setHeaderInputContent(
+        fixture = fixture,
+        viewportOverlay = {
+          Box(
+            Modifier.width(160.dp)
+              .height(HeaderHeightPx.dp)
+              .testTag(HeaderControlTag)
+              .viewportDirectControl()
+          )
+        },
+      )
+
+      onNodeWithTag(LayoutTag).performTouchInput {
+        down(pointerId = 0, position = Offset(x = 80f, y = 40f))
+        moveTo(pointerId = 0, position = Offset(x = 82f, y = HeaderHeightPx + 100f))
+        up(pointerId = 0)
+      }
+      waitForIdle()
+      assertTrue(fixture.scrollDeltas.isEmpty())
+      assertEquals(0, fixture.editorPointerInputCount)
+
+      runOnIdle {
+        fixture.scrollDeltas.clear()
+        fixture.editorPointerInputCount = 0
+      }
+      onNodeWithTag(LayoutTag).performTouchInput {
+        down(pointerId = 0, position = Offset(x = 280f, y = 40f))
+        moveTo(pointerId = 0, position = Offset(x = 282f, y = HeaderHeightPx + 100f))
+        up(pointerId = 0)
+      }
+      waitForIdle()
+
+      assertTrue(fixture.scrollDeltas.isNotEmpty())
+      assertTrue(fixture.editorPointerInputCount > 0)
+      assertEquals(EditorInteractionMode.Idle, fixture.interactionScope.controller.interactionMode)
+    } finally {
+      fixture.close()
+    }
+  }
+
+  @OptIn(InternalComposeUiApi::class)
+  @Test
+  fun stalePrimaryScrollOverViewportDirectControlReachesViewport() = runSkikoComposeUiTest {
+    val fixture = HeaderInputFixture()
+    try {
+      setHeaderInputContent(
+        fixture = fixture,
+        viewportOverlay = {
+          Box(Modifier.width(160.dp).height(HeaderHeightPx.dp).viewportDirectControl())
+        },
+      )
+
+      runOnIdle {
+        scene.sendPointerEvent(
+          eventType = PointerEventType.Scroll,
+          position = Offset(x = 80f, y = 40f),
+          scrollDelta = Offset(x = 0f, y = -24f),
+          timeMillis = 100L,
+          type = PointerType.Mouse,
+          buttons = PointerButtons(isPrimaryPressed = true),
+        )
+      }
+      waitForIdle()
+
+      assertTrue(fixture.scrollDeltas.isNotEmpty())
+    } finally {
+      fixture.close()
+    }
+  }
+
+  @Test
+  fun controlFirstMixedPointerSequenceSuppressesEditorUntilAllUp() = runComposeUiTest {
+    val fixture = HeaderInputFixture()
+    var controlDragCount = 0
+    try {
+      setHeaderInputContent(
+        fixture = fixture,
+        viewportOverlay = { MixedPointerControl { controlDragCount += 1 } },
+      )
+      val initialZoom = fixture.zoomController.displayZoom
+      val root = onNodeWithTag(LayoutTag)
+
+      root.performTouchInput {
+        down(pointerId = 0, position = ControlPointerStart)
+        down(pointerId = 1, position = EditorPointerStart)
+        updatePointerTo(pointerId = 0, position = ControlPointerMove)
+        updatePointerTo(pointerId = 1, position = EditorPointerMove)
+        move()
+      }
+      waitForIdle()
+
+      assertTrue(controlDragCount > 0)
+      assertMixedEditorSideSuppressed(fixture = fixture, expectedZoom = initialZoom)
+
+      root.performTouchInput {
+        up(pointerId = 0)
+        updatePointerTo(pointerId = 1, position = EditorSurvivorMove)
+        move()
+        up(pointerId = 1)
+      }
+      waitForIdle()
+
+      assertMixedEditorSideSuppressed(fixture = fixture, expectedZoom = initialZoom)
+      assertFreshHeaderBodyPinchWorks(fixture)
+    } finally {
+      fixture.close()
+    }
+  }
+
+  @Test
+  fun editorFirstMixedPointerSequenceSuppressesEditorUntilAllUp() = runComposeUiTest {
+    val fixture = HeaderInputFixture()
+    var controlDragCount = 0
+    try {
+      setHeaderInputContent(
+        fixture = fixture,
+        viewportOverlay = { MixedPointerControl { controlDragCount += 1 } },
+      )
+      val initialZoom = fixture.zoomController.displayZoom
+      val root = onNodeWithTag(LayoutTag)
+
+      root.performTouchInput {
+        down(pointerId = 0, position = EditorPointerStart)
+        down(pointerId = 1, position = ControlPointerStart)
+        updatePointerTo(pointerId = 0, position = EditorPointerMove)
+        updatePointerTo(pointerId = 1, position = ControlPointerMove)
+        move()
+      }
+      waitForIdle()
+
+      assertTrue(controlDragCount > 0)
+      assertMixedEditorSideSuppressed(fixture = fixture, expectedZoom = initialZoom)
+
+      root.performTouchInput {
+        up(pointerId = 1)
+        updatePointerTo(pointerId = 0, position = EditorSurvivorMove)
+        move()
+        up(pointerId = 0)
+      }
+      waitForIdle()
+
+      assertMixedEditorSideSuppressed(fixture = fixture, expectedZoom = initialZoom)
+      assertFreshHeaderBodyPinchWorks(fixture)
+    } finally {
+      fixture.close()
+    }
+  }
+
+  @OptIn(InternalComposeUiApi::class)
+  @Test
+  fun sameEventMixedPointerDownsSuppressEditorUntilAllUp() = runSkikoComposeUiTest {
+    val fixture = HeaderInputFixture()
+    var controlDragCount = 0
+    try {
+      setHeaderInputContent(
+        fixture = fixture,
+        viewportOverlay = { MixedPointerControl { controlDragCount += 1 } },
+      )
+      val initialZoom = fixture.zoomController.displayZoom
+
+      runOnIdle {
+        scene.sendPointerEvent(
+          eventType = PointerEventType.Press,
+          pointers =
+            listOf(
+              touchScenePointer(id = 0L, position = ControlPointerStart),
+              touchScenePointer(id = 1L, position = EditorPointerStart),
+            ),
+          timeMillis = 100L,
+        )
+        scene.sendPointerEvent(
+          eventType = PointerEventType.Move,
+          pointers =
+            listOf(
+              touchScenePointer(id = 0L, position = ControlPointerMove),
+              touchScenePointer(id = 1L, position = EditorPointerMove),
+            ),
+          timeMillis = 116L,
+        )
+      }
+      waitForIdle()
+
+      assertTrue(controlDragCount > 0)
+      assertMixedEditorSideSuppressed(fixture = fixture, expectedZoom = initialZoom)
+
+      runOnIdle {
+        scene.sendPointerEvent(
+          eventType = PointerEventType.Release,
+          pointers =
+            listOf(
+              touchScenePointer(id = 0L, position = ControlPointerMove, pressed = false),
+              touchScenePointer(id = 1L, position = EditorPointerMove),
+            ),
+          timeMillis = 132L,
+        )
+        scene.sendPointerEvent(
+          eventType = PointerEventType.Move,
+          pointers = listOf(touchScenePointer(id = 1L, position = EditorSurvivorMove)),
+          timeMillis = 148L,
+        )
+        scene.sendPointerEvent(
+          eventType = PointerEventType.Release,
+          pointers =
+            listOf(touchScenePointer(id = 1L, position = EditorSurvivorMove, pressed = false)),
+          timeMillis = 164L,
+        )
+      }
+      waitForIdle()
+
+      assertMixedEditorSideSuppressed(fixture = fixture, expectedZoom = initialZoom)
+      assertFreshHeaderBodyPinchWorks(fixture)
+    } finally {
+      fixture.close()
+    }
+  }
+
+  @Test
+  fun scrollSemanticsOwnerStaysFixedWhileHeaderAndBodyShareOnlyVerticalTranslation() =
+    runComposeUiTest {
+      val fixture = HeaderInputFixture()
+      try {
+        setHeaderInputContent(fixture)
+
+        val layoutBounds = onNodeWithTag(LayoutTag).fetchSemanticsNode().boundsInRoot
+        val ownerBefore =
+          onAllNodes(HasScrollByAction, useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .single { node -> node.boundsInRoot.width >= TestViewportSize.width }
+            .boundsInRoot
+        val headerBefore = checkNotNull(fixture.headerPositionInRoot)
+        val bodyBefore = checkNotNull(fixture.bodyPositionInRoot)
+
+        assertEquals(layoutBounds, ownerBefore)
+
+        runOnIdle { fixture.viewportState.scrollTo(Offset(x = 40f, y = 60f)) }
+        waitForIdle()
+
+        val ownerAfter =
+          onAllNodes(HasScrollByAction, useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .single { node -> node.boundsInRoot.width >= TestViewportSize.width }
+            .boundsInRoot
+        val headerAfter = checkNotNull(fixture.headerPositionInRoot)
+        val bodyAfter = checkNotNull(fixture.bodyPositionInRoot)
+
+        assertEquals(layoutBounds, ownerAfter)
+        assertEquals(headerBefore.y - 60f, headerAfter.y)
+        assertEquals(bodyBefore.y - 60f, bodyAfter.y)
+        assertEquals(headerBefore.x, headerAfter.x)
+        assertEquals(bodyBefore.x - 40f, bodyAfter.x)
+      } finally {
+        fixture.close()
+      }
+    }
+
+  @Test
+  fun twoHeaderPointersPinchViewport() = runComposeUiTest {
+    val fixture = HeaderInputFixture()
+    try {
+      setHeaderInputContent(fixture)
+      val initialZoom = fixture.zoomController.displayZoom
+      val root = onNodeWithTag(LayoutTag)
+
+      root.performTouchInput {
+        down(pointerId = 0, position = Offset(x = 80f, y = 30f))
+        down(pointerId = 1, position = Offset(x = 160f, y = 50f))
+        updatePointerTo(pointerId = 0, position = Offset(x = 60f, y = 25f))
+        updatePointerTo(pointerId = 1, position = Offset(x = 180f, y = 55f))
+        move()
+      }
+      assertEquals(
+        EditorInteractionMode.ViewportZooming,
+        fixture.interactionScope.controller.interactionMode,
+      )
+      assertTrue(fixture.zoomController.displayZoom > initialZoom)
+
+      root.performTouchInput {
+        up(pointerId = 1)
+        up(pointerId = 0)
+      }
+      waitForIdle()
+      assertEquals(EditorInteractionMode.Idle, fixture.interactionScope.controller.interactionMode)
+      assertEquals(fixture.zoomController.displayZoom, fixture.zoomController.renderZoom)
+    } finally {
+      fixture.close()
+    }
+  }
+
+  @Test
+  fun headerAndBodyPointersPinchViewport() = runComposeUiTest {
+    val fixture = HeaderInputFixture()
+    try {
+      setHeaderInputContent(fixture)
+      val initialZoom = fixture.zoomController.displayZoom
+      val root = onNodeWithTag(LayoutTag)
+
+      root.performTouchInput {
+        down(pointerId = 0, position = Offset(x = 100f, y = 40f))
+        down(pointerId = 1, position = Offset(x = 140f, y = HeaderHeightPx + 80f))
+        updatePointerTo(pointerId = 0, position = Offset(x = 90f, y = 20f))
+        updatePointerTo(pointerId = 1, position = Offset(x = 150f, y = HeaderHeightPx + 110f))
+        move()
+      }
+      assertEquals(
+        EditorInteractionMode.ViewportZooming,
+        fixture.interactionScope.controller.interactionMode,
+      )
+      assertTrue(fixture.zoomController.displayZoom > initialZoom)
+
+      root.performTouchInput {
+        up(pointerId = 1)
+        up(pointerId = 0)
+      }
+      waitForIdle()
+      assertEquals(EditorInteractionMode.Idle, fixture.interactionScope.controller.interactionMode)
+      assertEquals(fixture.zoomController.displayZoom, fixture.zoomController.renderZoom)
+    } finally {
+      fixture.close()
+    }
+  }
+
+  @Test
+  fun metaModifiedWheelWithHeaderFocalZoomsViewport() = runComposeUiTest {
+    val fixture = HeaderInputFixture()
+    try {
+      setHeaderInputContent(fixture)
+      val initialZoom = fixture.zoomController.displayZoom
+
+      val root = onNodeWithTag(LayoutTag)
+      root.performKeyInput { keyDown(Key.MetaLeft) }
+      root.performMouseInput {
+        moveTo(Offset(x = 280f, y = HeaderHeightPx / 2f))
+        scroll(Offset(x = 0f, y = -48f))
+      }
+      root.performKeyInput { keyUp(Key.MetaLeft) }
+      mainClock.advanceTimeBy(100)
+      waitForIdle()
+
+      assertTrue(fixture.zoomController.displayZoom > initialZoom)
+      assertEquals(EditorInteractionMode.Idle, fixture.interactionScope.controller.interactionMode)
+    } finally {
+      fixture.close()
+    }
+  }
+
+  @Test
+  fun commonTrackpadScaleWithHeaderFocalZoomsViewport() = runComposeUiTest {
+    val fixture = HeaderInputFixture()
+    try {
+      setHeaderInputContent(fixture)
+      val initialZoom = fixture.zoomController.displayZoom
+
+      onNodeWithTag(LayoutTag).performTrackpadInput {
+        updatePointerTo(Offset(x = 280f, y = HeaderHeightPx / 2f))
+        scale(1.2f)
+      }
+      waitForIdle()
+
+      assertTrue(fixture.zoomController.displayZoom > initialZoom)
+      assertEquals(fixture.zoomController.displayZoom, fixture.zoomController.renderZoom)
+      assertEquals(EditorInteractionMode.Idle, fixture.interactionScope.controller.interactionMode)
+    } finally {
+      fixture.close()
+    }
+  }
+
+  @Test
+  fun commonTrackpadPanWithHeaderFocalScrollsViewport() = runComposeUiTest {
+    val fixture = HeaderInputFixture()
+    try {
+      setHeaderInputContent(fixture)
+
+      onNodeWithTag(LayoutTag).performTrackpadInput {
+        updatePointerTo(Offset(x = 280f, y = HeaderHeightPx / 2f))
+        pan(Offset(x = 0f, y = -80f))
+      }
+      waitForIdle()
+
+      assertTrue(fixture.scrollDeltas.isNotEmpty())
+    } finally {
+      fixture.close()
+    }
+  }
+
   @Test
   fun viewportOverlayWheelReachesViewport() = runComposeUiTest {
     val fixture = ViewportOverlayFixture()
@@ -178,7 +706,7 @@ class EditorScreenLayoutDesktopTest {
           viewportScrollReconcileMode = EditorViewportScrollReconcileMode.Disabled,
           onMeasuredViewportSizeChange = { measuredViewportSize = it },
           header = {},
-          body = { interactionModifier -> Box(interactionModifier.fillMaxWidth().height(800.dp)) },
+          body = { Box(Modifier.fillMaxWidth().height(800.dp)) },
           toolbar = { Box(Modifier.fillMaxWidth().height(96.dp)) },
           modifier = Modifier.size(width = 320.dp, height = 640.dp),
         )
@@ -228,7 +756,7 @@ class EditorScreenLayoutDesktopTest {
           viewportScrollReconcileMode = EditorViewportScrollReconcileMode.Disabled,
           onMeasuredViewportSizeChange = {},
           header = {},
-          body = { interactionModifier -> Box(interactionModifier.fillMaxWidth().height(800.dp)) },
+          body = { Box(Modifier.fillMaxWidth().height(800.dp)) },
           toolbar = {},
           modifier = Modifier.size(width = 320.dp, height = 640.dp).testTag(LayoutTag),
         )
@@ -292,7 +820,7 @@ class EditorScreenLayoutDesktopTest {
           viewportScrollReconcileMode = EditorViewportScrollReconcileMode.Disabled,
           onMeasuredViewportSizeChange = {},
           header = {},
-          body = { interactionModifier -> Box(interactionModifier.fillMaxWidth().height(800.dp)) },
+          body = { Box(Modifier.fillMaxWidth().height(800.dp)) },
           toolbar = {},
           subPane = {
             Box(
@@ -363,7 +891,7 @@ class EditorScreenLayoutDesktopTest {
           viewportScrollReconcileMode = EditorViewportScrollReconcileMode.Disabled,
           onMeasuredViewportSizeChange = {},
           header = {},
-          body = { interactionModifier -> Box(interactionModifier.fillMaxWidth().height(800.dp)) },
+          body = { Box(Modifier.fillMaxWidth().height(800.dp)) },
           toolbar = {},
           subPane = {
             Box(
@@ -424,7 +952,7 @@ class EditorScreenLayoutDesktopTest {
       val uiState = remember {
         EditorUiState().apply {
           updateInteractionSurfaceBounds(
-            boundsInRoot = Rect(left = 0f, top = 0f, right = 320f, bottom = 640f),
+            boundsInRoot = Rect(left = 0f, top = HeaderHeightPx, right = 320f, bottom = 640f),
             density = 1f,
           )
         }
@@ -436,7 +964,7 @@ class EditorScreenLayoutDesktopTest {
           displayZoom = 1f,
           visibleArea = visibleArea,
           autoScrollPolicy = resolveEditorAutoScrollPolicy(visibleArea),
-          headerHeight = 0f,
+          headerHeight = HeaderHeightPx,
           density = 1f,
           editorBounds = EditorBoundsInContainer(),
         )
@@ -455,8 +983,8 @@ class EditorScreenLayoutDesktopTest {
           viewportContentWidth = 320f,
           viewportScrollReconcileMode = EditorViewportScrollReconcileMode.Disabled,
           onMeasuredViewportSizeChange = {},
-          header = {},
-          body = { interactionModifier -> Box(interactionModifier.fillMaxWidth().height(800.dp)) },
+          header = { Box(Modifier.fillMaxWidth().height(HeaderHeightPx.dp).testTag(HeaderTag)) },
+          body = { Box(Modifier.fillMaxWidth().height(800.dp).testTag(BodyTag)) },
           toolbar = {},
           modifier = Modifier.size(width = 320.dp, height = 640.dp).testTag(LayoutTag),
         )
@@ -470,21 +998,110 @@ class EditorScreenLayoutDesktopTest {
       count = 1,
       downInSystemBackZone = false,
       pointerId = 1L,
-      position = Offset.Zero,
+      position = Offset(x = 80f, y = HeaderHeightPx / 2f),
     )
     navigationPopNestedScroll.updatePressedDragPointerCount(
       count = 1,
       downInSystemBackZone = false,
       pointerId = 1L,
-      position = Offset(x = 120f, y = 0f),
+      position = Offset(x = 200f, y = HeaderHeightPx / 2f),
     )
     onNodeWithTag(LayoutTag).performTouchInput {
-      swipe(start = center, end = Offset(x = center.x + 120f, y = center.y))
+      swipe(
+        start = Offset(x = 80f, y = HeaderHeightPx / 2f),
+        end = Offset(x = 200f, y = HeaderHeightPx / 2f),
+      )
     }
     navigationPopNestedScroll.updatePressedDragPointerCount(count = 0, downInSystemBackZone = false)
     waitForIdle()
 
     assertTrue(navigationDragCount > 0)
+  }
+
+  private fun androidx.compose.ui.test.ComposeUiTest.setHeaderInputContent(
+    fixture: HeaderInputFixture,
+    viewportOverlay: @Composable BoxScope.() -> Unit = {},
+  ) {
+    setContent {
+      val interactionScope = remember {
+        EditorInteractionScope(coroutineScope = fixture.coroutineScope)
+      }
+      fixture.interactionScope = interactionScope
+      val bringIntoViewRequests = remember { EditorBringIntoViewRequests() }
+      val scrollGestureLockState = remember { ScrollGestureLockState() }
+      val viewportScrollableState = rememberScrollable2DState { delta ->
+        fixture.scrollDeltas += delta
+        delta
+      }
+
+      SideEffect {
+        interactionScope.update(
+          editor = fixture.editor,
+          bringIntoViewRequests = bringIntoViewRequests,
+          uiState = fixture.uiState,
+          visibleArea = fixture.visibleArea,
+          viewportState = fixture.viewportState,
+          density = 1f,
+          scrollGestureLockState = scrollGestureLockState,
+          viewportZoomConfig = fixture.viewportZoomConfig,
+          layoutSpec = fixture.layoutSpec,
+          onSelectionHaptic = {},
+          onRequestSoftwareKeyboard = {},
+        )
+      }
+
+      CompositionLocalProvider(
+        LocalEditorBringIntoViewRequests provides bringIntoViewRequests,
+        LocalEditorInteractionScope provides interactionScope,
+        LocalEditorUiState provides fixture.uiState,
+      ) {
+        EditorScreenLayout(
+          state = remember { EditorScreenState(fixture.viewportState) },
+          scrollFrame = fixture.scrollFrame,
+          visibleArea = fixture.visibleArea,
+          viewportScrollableState = viewportScrollableState,
+          viewportContentWidth = HeaderFixtureContentWidth,
+          viewportScrollReconcileMode = EditorViewportScrollReconcileMode.Disabled,
+          onEditorPointerInput = { fixture.editorPointerInputCount += 1 },
+          onMeasuredViewportSizeChange = {},
+          header = {
+            Box(
+              Modifier.width(TestViewportSize.width.dp)
+                .height(HeaderHeightPx.dp)
+                .testTag(HeaderTag)
+                .onGloballyPositioned { coordinates ->
+                  fixture.headerPositionInRoot = coordinates.positionInRoot()
+                }
+            ) {
+              BasicTextField(
+                value = fixture.fieldValue,
+                onValueChange = { fixture.fieldValue = it },
+                modifier =
+                  Modifier.width(240.dp).height(64.dp).testTag(HeaderFieldTag).onFocusChanged {
+                    fixture.headerFocused = it.isFocused
+                  },
+              )
+            }
+          },
+          body = {
+            Box(
+              Modifier.fillMaxWidth()
+                .height(HeaderFixtureBodyHeight.dp)
+                .testTag(BodyTag)
+                .onGloballyPositioned { coordinates ->
+                  fixture.bodyPositionInRoot = coordinates.positionInRoot()
+                }
+            )
+          },
+          viewportOverlay = viewportOverlay,
+          toolbar = {},
+          modifier =
+            Modifier.size(width = TestViewportSize.width.dp, height = TestViewportSize.height.dp)
+              .testTag(LayoutTag),
+        )
+      }
+    }
+    waitForIdle()
   }
 
   private fun androidx.compose.ui.test.ComposeUiTest.setViewportOverlayContent(
@@ -515,7 +1132,7 @@ class EditorScreenLayoutDesktopTest {
           onEditorPointerInput = { fixture.editorPointerInputCount += 1 },
           onMeasuredViewportSizeChange = {},
           header = {},
-          body = { interactionModifier -> Box(interactionModifier.fillMaxWidth().height(800.dp)) },
+          body = { Box(Modifier.fillMaxWidth().height(800.dp)) },
           viewportOverlay = viewportOverlay,
           overlay = overlay,
           toolbar = {},
@@ -528,11 +1145,76 @@ class EditorScreenLayoutDesktopTest {
     waitForIdle()
   }
 
+  private fun assertMixedEditorSideSuppressed(fixture: HeaderInputFixture, expectedZoom: Float) {
+    assertTrue(fixture.scrollDeltas.isEmpty())
+    assertEquals(expectedZoom, fixture.zoomController.displayZoom)
+    assertEquals(EditorInteractionMode.Idle, fixture.interactionScope.controller.interactionMode)
+    assertTrue(fixture.fake.enqueued.isEmpty())
+  }
+
+  private fun androidx.compose.ui.test.ComposeUiTest.assertFreshHeaderBodyPinchWorks(
+    fixture: HeaderInputFixture
+  ) {
+    val zoomBeforePinch = fixture.zoomController.displayZoom
+    val root = onNodeWithTag(LayoutTag)
+    root.performTouchInput {
+      down(pointerId = 0, position = Offset(x = 180f, y = 40f))
+      down(pointerId = 1, position = Offset(x = 240f, y = HeaderHeightPx + 80f))
+      updatePointerTo(pointerId = 0, position = Offset(x = 170f, y = 20f))
+      updatePointerTo(pointerId = 1, position = Offset(x = 250f, y = HeaderHeightPx + 110f))
+      move()
+    }
+    waitForIdle()
+
+    assertEquals(
+      EditorInteractionMode.ViewportZooming,
+      fixture.interactionScope.controller.interactionMode,
+    )
+    assertTrue(fixture.zoomController.displayZoom > zoomBeforePinch)
+
+    root.performTouchInput {
+      up(pointerId = 1)
+      up(pointerId = 0)
+    }
+    waitForIdle()
+    assertEquals(EditorInteractionMode.Idle, fixture.interactionScope.controller.interactionMode)
+  }
+
+  @Composable
+  private fun MixedPointerControl(onDrag: () -> Unit) {
+    Box(
+      Modifier.width(160.dp)
+        .height(HeaderHeightPx.dp)
+        .testTag(HeaderControlTag)
+        .viewportDirectControl()
+        .pointerInput(onDrag) {
+          detectDragGestures { change, _ ->
+            change.consume()
+            onDrag()
+          }
+        }
+    )
+  }
+
+  @OptIn(InternalComposeUiApi::class)
+  private fun touchScenePointer(
+    id: Long,
+    position: Offset,
+    pressed: Boolean = true,
+  ): ComposeScenePointer =
+    ComposeScenePointer(
+      id = PointerId(id),
+      position = position,
+      pressed = pressed,
+      type = PointerType.Touch,
+    )
+
   @Composable
   private fun ViewportOverlayTarget() {
     Box(
       Modifier.fillMaxSize()
         .testTag(ViewportOverlayTag)
+        .viewportDirectControl()
         .pointerInput(Unit) { detectDragGestures { change, _ -> change.consume() } }
         .pointerInput(Unit) { detectTapGestures(onTap = {}) }
     )
@@ -571,10 +1253,119 @@ class EditorScreenLayoutDesktopTest {
       )
   }
 
+  private class HeaderInputFixture {
+    val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+    val fake =
+      FakeFfiEditor(
+        pageSizesProvider = {
+          listOf(PageSize(width = HeaderFixtureContentWidth, height = HeaderFixtureBodyHeight))
+        }
+      )
+    val editor = Editor(fake, coroutineScope)
+    val viewportState = EditorViewportState()
+    val visibleArea = EditorVisibleArea(viewport = TestViewportSize)
+    val scrollDeltas = mutableListOf<Offset>()
+    val zoomController =
+      EditorZoomController().apply {
+        syncLayout(layoutSpec = HeaderFixtureLayoutSpec, viewportWidth = TestViewportSize.width)
+      }
+    val uiState =
+      EditorUiState().apply {
+        updateDisplayZoom(1f)
+        updatePageOffset(page = 0, offset = Offset.Zero)
+        updateInteractionSurfaceBounds(
+          boundsInRoot =
+            Rect(
+              left = 0f,
+              top = HeaderHeightPx,
+              right = HeaderFixtureContentWidth,
+              bottom = HeaderHeightPx + HeaderFixtureBodyHeight,
+            ),
+          density = 1f,
+        )
+        updateEditorBounds(
+          boundsInRoot =
+            Rect(
+              left = 0f,
+              top = HeaderHeightPx,
+              right = HeaderFixtureContentWidth,
+              bottom = HeaderHeightPx + HeaderFixtureBodyHeight,
+            ),
+          density = 1f,
+        )
+      }
+    val viewportZoomConfig =
+      EditorViewportZoomSemanticConfig(
+        layoutSpec = HeaderFixtureLayoutSpec,
+        zoomController = zoomController,
+        viewportState = viewportState,
+        uiState = uiState,
+        pageSizes =
+          listOf(PageSize(width = HeaderFixtureContentWidth, height = HeaderFixtureBodyHeight)),
+        viewportWidth = TestViewportSize.width,
+        density = 1f,
+        onZoomSnap = {},
+      )
+    val layoutSpec: EditorDocumentLayoutSpec = HeaderFixtureLayoutSpec
+    val scrollFrame =
+      EditorScrollFrame(
+        state = EditorState.Initial,
+        layoutSpec = layoutSpec,
+        displayZoom = 1f,
+        visibleArea = visibleArea,
+        autoScrollPolicy = resolveEditorAutoScrollPolicy(visibleArea),
+        headerHeight = HeaderHeightPx,
+        density = 1f,
+        editorBounds =
+          EditorBoundsInContainer(
+            x = 0f,
+            y = 0f,
+            width = HeaderFixtureContentWidth,
+            height = HeaderFixtureBodyHeight,
+          ),
+      )
+    lateinit var interactionScope: EditorInteractionScope
+    var fieldValue by mutableStateOf(TextFieldValue(HeaderText, TextRange.Zero))
+    var headerFocused = false
+    var headerPositionInRoot: Offset? = null
+    var bodyPositionInRoot: Offset? = null
+    var editorPointerInputCount = 0
+
+    fun close() {
+      coroutineScope.cancel()
+    }
+  }
+
   private companion object {
+    val HasScrollByAction =
+      SemanticsMatcher("has ScrollBy action") { node ->
+        node.config.contains(SemanticsActions.ScrollBy)
+      }
+    const val BodyTag = "editor-screen-layout-body"
+    const val HeaderControlTag = "editor-screen-layout-header-control"
+    const val HeaderFieldTag = "editor-screen-layout-header-field"
+    const val HeaderTag = "editor-screen-layout-header"
     const val LayoutTag = "editor-screen-layout"
     const val SubPaneTag = "editor-screen-layout-subpane"
     const val ViewportOverlayTag = "editor-screen-layout-viewport-overlay-target"
+    const val HeaderFixtureBodyHeight = 800f
+    const val HeaderFixtureContentWidth = 640f
+    const val HeaderHeightPx = 96f
+    const val HeaderText = "Header title"
+    val ControlPointerMove = Offset(x = 40f, y = 40f)
+    val ControlPointerStart = Offset(x = 80f, y = 40f)
+    val EditorPointerMove = Offset(x = 300f, y = HeaderHeightPx + 140f)
+    val EditorPointerStart = Offset(x = 280f, y = 40f)
+    val EditorSurvivorMove = Offset(x = 300f, y = HeaderHeightPx + 220f)
+    val HeaderFixtureLayoutSpec =
+      EditorDocumentLayoutSpec.Paginated(
+        pageWidth = HeaderFixtureContentWidth,
+        pageHeight = HeaderFixtureBodyHeight,
+        pageMarginTop = 0f,
+        pageMarginBottom = 0f,
+        pageMarginLeft = 0f,
+        pageMarginRight = 0f,
+      )
     val TestViewportSize = Size(width = 320f, height = 640f)
   }
 }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorCharacterCountOverlayDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorCharacterCountOverlayDesktopTest.kt
@@ -1,0 +1,74 @@
+package co.typie.screen.editor.editor.overlay
+
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import co.typie.screen.editor.editor.layout.viewportDirectControl
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+class EditorCharacterCountOverlayDesktopTest {
+  @Test
+  fun tapDetectorAcceptsDownConsumedByDirectControlMarker() = runComposeUiTest {
+    var tapCount = 0
+    setContent {
+      Box(
+        Modifier.size(120.dp).testTag(OverlayTag).viewportDirectControl().pointerInput(Unit) {
+          detectTapAfterConsumedDown { tapCount += 1 }
+        }
+      )
+    }
+
+    onNodeWithTag(OverlayTag).performTouchInput {
+      down(center)
+      up()
+    }
+    waitForIdle()
+
+    assertEquals(1, tapCount)
+  }
+
+  @Test
+  fun consumedDragCancelsTap() = runComposeUiTest {
+    var dragCount = 0
+    var tapCount = 0
+    setContent {
+      Box(
+        Modifier.size(120.dp)
+          .testTag(OverlayTag)
+          .viewportDirectControl()
+          .pointerInput(Unit) {
+            detectDragGestures { change, _ ->
+              change.consume()
+              dragCount += 1
+            }
+          }
+          .pointerInput(Unit) { detectTapAfterConsumedDown { tapCount += 1 } }
+      )
+    }
+
+    onNodeWithTag(OverlayTag).performTouchInput {
+      down(center)
+      moveBy(Offset(x = 40f, y = 0f))
+      up()
+    }
+    waitForIdle()
+
+    assertEquals(1, dragCount)
+    assertEquals(0, tapCount)
+  }
+
+  private companion object {
+    const val OverlayTag = "editor-character-count-overlay"
+  }
+}

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorDocumentManipulationDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorDocumentManipulationDesktopTest.kt
@@ -948,6 +948,76 @@ class EditorDocumentManipulationDesktopTest {
   }
 
   @Test
+  fun rootAttachedColumnResizeUsesEditorRootOffsetAcrossSyntheticHeader() = runComposeUiTest {
+    val selection =
+      Selection(
+        anchor = Position("cell-text", 0, Affinity.Downstream),
+        head = Position("cell-text", 0, Affinity.Downstream),
+      )
+    val shallowTable =
+      tableOverlay(isFocused = true, focusedRowIndex = 0, focusedColIndex = 0)
+        .copy(bounds = Rect(x = 10f, y = 20f, width = 100f, height = 20f))
+    val fake =
+      FakeFfiEditor(
+        selectionProvider = { selection },
+        pageSizesProvider = { listOf(Size(width = 120f, height = 120f)) },
+        tableOverlaysProvider = { listOf(shallowTable) },
+      )
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val editor = Editor(fake, scope)
+    val uiState =
+      EditorUiState().apply {
+        updateFocus(true)
+        updatePageOffset(page = 0, offset = Offset.Zero)
+        updateInteractionSurfaceBounds(
+          ComposeRect(left = 0f, top = SyntheticHeaderHeight, right = 120f, bottom = 160f),
+          density = 1f,
+        )
+        updateEditorBounds(
+          ComposeRect(left = 0f, top = SyntheticHeaderHeight, right = 120f, bottom = 160f),
+          density = 1f,
+        )
+      }
+    val runtime = EditorRuntime(scope).apply { attach(editor) }
+    lateinit var interactionScope: EditorInteractionScope
+    editor.sync {}
+    try {
+      setOverlayHostContent(
+        editor = editor,
+        runtime = runtime,
+        uiState = uiState,
+        scope = scope,
+        onInteractionScope = { interactionScope = it },
+      )
+      waitForIdle()
+
+      onNodeWithTag(RootTag).performTouchInput {
+        down(Offset(x = 60f, y = SyntheticHeaderHeight + 30f))
+        moveTo(Offset(x = 80f, y = SyntheticHeaderHeight / 2f))
+        up()
+      }
+      waitUntil(timeoutMillis = 1_000L) {
+        fake.enqueued.filterIsInstance<Message.Node>().isNotEmpty()
+      }
+
+      assertEquals(
+        listOf(
+          Message.Node(
+            NodeOp.Table(id = "table", op = TableOp.SetColumnWidths(widths = listOf(0.6f, 0.4f)))
+          )
+        ),
+        fake.enqueued.filterIsInstance<Message.Node>(),
+      )
+      assertEquals(EditorInteractionMode.Idle, interactionScope.controller.interactionMode)
+      assertFalse(interactionScope.controller.tableColumnResizePresentation.pressed)
+      assertNull(interactionScope.controller.tableColumnResizePresentation.draft)
+    } finally {
+      runtime.clear(editor)
+      scope.cancel()
+    }
+  }
+
+  @Test
   fun tableColumnResizeHandleDragDoesNothingWhenReadOnly() = runComposeUiTest {
     val selection =
       Selection(
@@ -1325,6 +1395,7 @@ class EditorDocumentManipulationDesktopTest {
 
   private companion object {
     const val RootTag = "editor-document-manipulation-root"
+    const val SyntheticHeaderHeight = 40f
     val TestRootSize = ComposeSize(width = 120f, height = 120f)
     val TestRootRect = ComposeRect(Offset.Zero, TestRootSize)
 

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorOverlayLayoutSynchronizationDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorOverlayLayoutSynchronizationDesktopTest.kt
@@ -501,9 +501,11 @@ class EditorOverlayLayoutSynchronizationDesktopTest {
   ) : EditorInteractionGeometry {
     override val density = 1f
 
-    override fun resolveInteractionPosition(positionInSurface: Offset): Offset = positionInSurface
+    override fun containsDocumentInteraction(positionInRoot: Offset): Boolean = true
 
-    override fun isTapEligible(positionInSurface: Offset): Boolean = true
+    override fun resolveInteractionPosition(positionInRoot: Offset): Offset = positionInRoot
+
+    override fun isTapEligible(positionInRoot: Offset): Boolean = true
 
     override fun resolvePoint(positionInNode: Offset): PagePoint? = null
 


### PR DESCRIPTION
- 에디터 입력 범위를 본문에서 제목/부제목을 포함한 viewport 전체로 넓혀 헤더에서도 touch pan, trackpad scroll, pinch zoom 지원
- 제목/부제목의 탭·포커스·커서 동작은 유지하고, 헤더에서 시작한 입력이 본문 편집 입력으로 전환되지 않도록 함
- 스크롤바와 글자 수 위젯의 직접 조작은 기존처럼 유지하면서 trackpad/wheel/zoom 입력은 viewport에서 함께 처리
- 헤더/본문 혼합 pinch와 overlay control 혼합 입력에 대한 회귀 테스트 추가