### PR TITLE
앱 edge auto scroll pointer 위치 추적 책임 정리

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorTableColumnResizeGesture.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorTableColumnResizeGesture.kt
@@ -11,7 +11,6 @@ import co.typie.editor.interaction.semantics.resolveTableColumnResizePlacement
 internal class EditorTableColumnResizeGesture {
   private var pointerId: Long? = null
   private var downPosition = Offset.Zero
-  private var previousPosition = Offset.Zero
   private var currentPosition = Offset.Zero
   private var dragSlop = 0f
   private var dragging = false
@@ -50,7 +49,6 @@ internal class EditorTableColumnResizeGesture {
     }
     this.pointerId = pointerId
     downPosition = position
-    previousPosition = position
     currentPosition = position
     dragging = false
     context.semantics.tableColumnResize.press(editor = context.editor, placement = placement)
@@ -62,11 +60,8 @@ internal class EditorTableColumnResizeGesture {
     if (this.pointerId != pointerId) {
       return false
     }
-    previousPosition = currentPosition
-    currentPosition = position
-    var deltaPx = currentPosition.x - previousPosition.x
     if (!dragging) {
-      if (!shouldStartDrag(pointerId = pointerId, position = currentPosition)) {
+      if (!shouldStartDrag(pointerId = pointerId, position = position)) {
         return true
       }
       if (
@@ -83,19 +78,12 @@ internal class EditorTableColumnResizeGesture {
         return false
       }
       context.effects.setScrollGestureLocked(true)
-      deltaPx = currentPosition.x - downPosition.x
     }
-    context.semantics.tableColumnResize.update(deltaPx = deltaPx)
+    moveTo(position = position, context = context)
     context.semantics.edgeAutoScroll.track(
       edgePosition = currentPosition,
       context = context,
-      onScroll = { consumed ->
-        currentPosition += consumed
-        previousPosition += consumed
-        if (consumed.x != 0f) {
-          context.semantics.tableColumnResize.update(deltaPx = consumed.x)
-        }
-      },
+      onScroll = { scrolledPosition -> moveTo(position = scrolledPosition, context = context) },
     )
     return true
   }
@@ -127,9 +115,16 @@ internal class EditorTableColumnResizeGesture {
   fun reset() {
     pointerId = null
     downPosition = Offset.Zero
-    previousPosition = Offset.Zero
     currentPosition = Offset.Zero
     dragging = false
+  }
+
+  private fun moveTo(position: Offset, context: EditorGestureContext) {
+    val deltaPx = position.x - currentPosition.x
+    currentPosition = position
+    if (deltaPx != 0f) {
+      context.semantics.tableColumnResize.update(deltaPx = deltaPx)
+    }
   }
 
   private fun clear() {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/semantics/EditorEdgeAutoScrollSemantic.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/semantics/EditorEdgeAutoScrollSemantic.kt
@@ -99,7 +99,7 @@ internal class EditorEdgeAutoScrollSemantic {
     trackWithResult(
       edgePosition = edgePosition,
       context = context,
-      onScroll = { result -> onScroll(result.consumedDelta) },
+      onScroll = { result -> onScroll(result.edgePosition) },
     )
   }
 
@@ -149,11 +149,7 @@ internal class EditorEdgeAutoScrollSemantic {
           delay(EditorEdgeAutoScrollTickMillis)
           val request = activeRequest ?: break
           val viewport = context.geometry.resolveEdgeAutoScrollViewport() ?: break
-          val plan =
-            planFor(
-              edgePosition = request.edgePosition + request.accumulatedScroll,
-              viewport = viewport,
-            )
+          val plan = planFor(edgePosition = request.edgePosition, viewport = viewport)
           if (plan.isNoOp) {
             break
           }
@@ -174,15 +170,17 @@ internal class EditorEdgeAutoScrollSemantic {
             continue
           }
 
+          val scrolledPosition = request.edgePosition + consumed
           request.onScroll(
             EditorEdgeAutoScrollResult(
+              edgePosition = scrolledPosition,
               requestedDelta = delta,
               consumedDelta = consumed,
               viewport = context.geometry.resolveEdgeAutoScrollViewport() ?: viewport,
             )
           )
           if (activeRequest === request) {
-            activeRequest = request.copy(accumulatedScroll = request.accumulatedScroll + consumed)
+            activeRequest = request.copy(edgePosition = scrolledPosition)
           }
         }
       } finally {
@@ -272,11 +270,11 @@ private fun reachedScrollBoundary(requestedDelta: Float, consumedDelta: Float): 
 
 private data class EditorEdgeAutoScrollRequest(
   val edgePosition: Offset,
-  val accumulatedScroll: Offset = Offset.Zero,
   val onScroll: (EditorEdgeAutoScrollResult) -> Unit,
 )
 
 private data class EditorEdgeAutoScrollResult(
+  val edgePosition: Offset,
   val requestedDelta: Offset,
   val consumedDelta: Offset,
   val viewport: EditorEdgeAutoScrollViewport,

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
@@ -1365,6 +1365,55 @@ class EditorInteractionControllerTest {
     }
 
   @Test
+  fun `edge auto-scroll reports position advanced by actual consumption and skips zero`() =
+    runTest(StandardTestDispatcher()) {
+      val testEditor = Editor(FakeFfiEditor(), this, StandardTestDispatcher(testScheduler))
+      val host =
+        TestHost(this).apply {
+          edgeAutoScrollViewport = testEdgeAutoScrollViewport(ComposeRect(0f, 0f, 100f, 100f))
+          edgeAutoScrollConsumedDelta = Offset(2f, 3f)
+        }
+      val semantics = EditorInteractionSemantics(effects = host)
+      val context =
+        object : EditorGestureContext {
+          override val editor = testEditor
+          override val semantics = semantics
+          override val effects = host
+          override val geometry = host
+          override val mode = EditorInteractionMode.Idle
+          override val uiState = host.uiState
+          override val readOnly = false
+          override val platform = Platform.Desktop
+
+          override fun applyModeEvent(event: EditorInteractionEvent) = Unit
+
+          override fun reduceMode(event: EditorInteractionEvent) = Unit
+        }
+      val reportedPositions = mutableListOf<Offset>()
+
+      semantics.edgeAutoScroll.track(edgePosition = Offset(80f, 95f), context = context) {
+        reportedPositions += it
+        semantics.edgeAutoScroll.stop()
+      }
+      advanceTimeBy(32)
+      runCurrent()
+
+      assertEquals(listOf(Offset(82f, 98f)), reportedPositions)
+      assertEquals(1, host.edgeAutoScrollDispatchCount)
+
+      host.edgeAutoScrollConsumedDelta = Offset.Zero
+      semantics.edgeAutoScroll.track(edgePosition = Offset(80f, 95f), context = context) {
+        reportedPositions += it
+      }
+      advanceTimeBy(32)
+      runCurrent()
+      semantics.edgeAutoScroll.stop()
+
+      assertEquals(listOf(Offset(82f, 98f)), reportedPositions)
+      assertTrue(host.edgeAutoScrollDispatchCount > 1)
+    }
+
+  @Test
   fun `selection from handle drag anchors opposite document endpoint for reverse selection`() =
     runTest(StandardTestDispatcher()) {
       val selection =
@@ -2384,7 +2433,8 @@ class EditorInteractionControllerTest {
       val host =
         TestHost(this).apply {
           edgeAutoScrollViewport = testEdgeAutoScrollViewport(ComposeRect(0f, 0f, 100f, 100f))
-          edgeAutoScrollConsumedDelta = Offset(5f, 8f)
+          edgeAutoScrollConsumedDelta = Offset(2f, 8f)
+          edgeAutoScrollMovesViewport = true
         }
       val controller =
         EditorInteractionController(
@@ -2405,27 +2455,29 @@ class EditorInteractionControllerTest {
       advanceTimeBy(16)
       runCurrent()
 
+      host.edgeAutoScrollConsumedDelta = Offset(0f, 8f)
+      advanceTimeBy(16)
+      runCurrent()
+
       assertTrue(
         controller.onPointerMove(
           pointerId = 1L,
-          position = Offset(85f, 95f),
+          position = Offset(82f, 111f),
           positionInRoot = Offset(80f, 95f),
-          nowMillis = 36L,
+          nowMillis = 52L,
         )
       )
       assertTrue(
         controller.onPointerUp(
           pointerId = 1L,
-          position = Offset(85f, 95f),
+          position = Offset(82f, 111f),
           positionInRoot = Offset(80f, 95f),
-          nowMillis = 40L,
+          nowMillis = 56L,
         )
       )
       assertEquals(
         listOf(
-          Message.Node(
-            NodeOp.Table(id = "table", op = TableOp.SetColumnWidths(listOf(0.625f, 0.375f)))
-          )
+          Message.Node(NodeOp.Table(id = "table", op = TableOp.SetColumnWidths(listOf(0.6f, 0.4f))))
         ),
         fake.enqueued.filterIsInstance<Message.Node>(),
       )


### PR DESCRIPTION
- edge auto scroll이 현재 pointer 위치를 직접 추적하도록 변경
- column resize의 pointer move와 auto scroll을 하나의 경로로 통합
- 관련 회귀 테스트 보강