### PR TITLE
앱 문서 reload 시 로컬 변경 보호, 본문 설정 실시간 동기화

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/DocumentEditingSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/DocumentEditingSession.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.snapshotFlow
 import co.typie.editor.sync.RemoteChangesetPipeline
 import co.typie.editor.sync.SyncEngine
 import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.AtomicInt
 import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.coroutines.CoroutineContext
@@ -16,6 +17,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.selects.select
 
 internal sealed interface EditingCheckpointResult {
   data object Protected : EditingCheckpointResult
@@ -24,11 +26,15 @@ internal sealed interface EditingCheckpointResult {
 
   data class ProtectionFailed(val cause: Throwable) : EditingCheckpointResult
 
+  data object StopCancelled : EditingCheckpointResult
+
   data object SessionStopped : EditingCheckpointResult
 }
 
-internal interface DocumentEditingClose {
+internal interface DocumentEditingStop {
   suspend fun awaitCheckpoint(): EditingCheckpointResult
+
+  suspend fun retryCheckpoint(): EditingCheckpointResult
 
   fun cancel()
 }
@@ -44,60 +50,96 @@ internal class DocumentEditingSession(
   private sealed interface State {
     data object Active : State
 
-    data object StartingClose : State
+    data object StartingStop : State
 
-    class Closing(val close: Close) : State
+    class PreparingStop(val preparation: StopPreparation) : State
+
+    class ResumingStop(val preparation: StopPreparation) : State
 
     data object Closed : State
   }
 
-  private inner class Close(private val quiescence: LocalEditQuiescence) : DocumentEditingClose {
+  private inner class StopPreparation(private val quiescence: LocalEditQuiescence) {
+    private val owners = AtomicInt(1)
+    private val stopped = CompletableDeferred<Unit>()
     private val editResult: Deferred<Result<Unit>> =
       scope.async(start = CoroutineStart.UNDISPATCHED) { quiescence.await() }
-    private val result = CompletableDeferred<EditingCheckpointResult>()
-    private val work =
-      scope.launch(start = CoroutineStart.LAZY) {
-        if (state.load() === State.Closed) {
-          result.complete(EditingCheckpointResult.SessionStopped)
-          return@launch
-        }
-        val settledEdits =
-          try {
-            editResult.await()
-          } catch (e: CancellationException) {
-            if (state.load() === State.Closed) {
-              result.complete(EditingCheckpointResult.SessionStopped)
-              return@launch
-            }
-            throw e
-          }
-        val checkpoint = engine.checkpointCurrentFrontier()
-        result.complete(resolveResult(settledEdits, checkpoint))
-      }
+    private val initialAttempt: Deferred<EditingCheckpointResult> =
+      scope.async(start = CoroutineStart.UNDISPATCHED) { runCheckpoint() }
+    private val retryAttempt = AtomicReference<Deferred<EditingCheckpointResult>?>(null)
 
-    init {
-      work.start()
+    val stoppedSignal: Deferred<Unit>
+      get() = stopped
+
+    val isStopped: Boolean
+      get() = stopped.isCompleted
+
+    fun retain(): Boolean {
+      while (true) {
+        val current = owners.load()
+        if (current <= 0) return false
+        if (owners.compareAndSet(current, current + 1)) return true
+      }
     }
 
-    override suspend fun awaitCheckpoint(): EditingCheckpointResult = result.await()
+    fun release(): Boolean {
+      while (true) {
+        val current = owners.load()
+        if (current <= 0) return false
+        val next = current - 1
+        if (owners.compareAndSet(current, next)) return next == 0
+      }
+    }
 
-    override fun cancel() {
-      val current = state.load()
-      if (current !is State.Closing || current.close !== this) return
-      if (!state.compareAndSet(current, State.Active)) return
+    fun resume() {
       quiescence.resume()
     }
 
     fun stop() {
+      if (!stopped.complete(Unit)) return
       editResult.cancel()
-      if (result.complete(EditingCheckpointResult.SessionStopped)) work.cancel()
+      initialAttempt.cancel()
+      retryAttempt.load()?.cancel()
+    }
+
+    fun initialCheckpoint(): Deferred<EditingCheckpointResult> = initialAttempt
+
+    fun retryCheckpoint(): Deferred<EditingCheckpointResult> {
+      if (!initialAttempt.isCompleted) return initialAttempt
+      while (true) {
+        if (isStopped) {
+          return CompletableDeferred(EditingCheckpointResult.SessionStopped)
+        }
+        val current = retryAttempt.load()
+        if (current != null && !current.isCompleted) return current
+        val next = scope.async(start = CoroutineStart.LAZY) { runCheckpoint() }
+        if (retryAttempt.compareAndSet(current, next)) {
+          next.start()
+          return next
+        }
+        next.cancel()
+      }
+    }
+
+    private suspend fun runCheckpoint(): EditingCheckpointResult {
+      if (isStopped) return EditingCheckpointResult.SessionStopped
+      val settledEdits =
+        try {
+          editResult.await()
+        } catch (e: CancellationException) {
+          if (isStopped) return EditingCheckpointResult.SessionStopped
+          throw e
+        }
+      if (isStopped) return EditingCheckpointResult.SessionStopped
+      val checkpoint = engine.checkpointCurrentFrontier()
+      return resolveResult(settledEdits, checkpoint)
     }
 
     private fun resolveResult(
       editResult: Result<Unit>,
       checkpointResult: Result<Unit>,
     ): EditingCheckpointResult {
-      if (state.load() === State.Closed) return EditingCheckpointResult.SessionStopped
+      if (isStopped) return EditingCheckpointResult.SessionStopped
       editResult.exceptionOrNull()?.let {
         return EditingCheckpointResult.EditFailed(it)
       }
@@ -106,6 +148,50 @@ internal class DocumentEditingSession(
       }
       return EditingCheckpointResult.Protected
     }
+  }
+
+  private inner class StopHandle(private val preparation: StopPreparation) : DocumentEditingStop {
+    private val active = AtomicBoolean(true)
+    private val cancelled = CompletableDeferred<Unit>()
+
+    override suspend fun awaitCheckpoint(): EditingCheckpointResult =
+      await(preparation.initialCheckpoint())
+
+    override suspend fun retryCheckpoint(): EditingCheckpointResult =
+      terminalResult() ?: await(preparation.retryCheckpoint())
+
+    override fun cancel() {
+      if (!active.compareAndSet(expectedValue = true, newValue = false)) return
+      cancelled.complete(Unit)
+      release(preparation)
+    }
+
+    private suspend fun await(attempt: Deferred<EditingCheckpointResult>): EditingCheckpointResult {
+      terminalResult()?.let {
+        return it
+      }
+      val result =
+        try {
+          select<EditingCheckpointResult> {
+            preparation.stoppedSignal.onAwait { EditingCheckpointResult.SessionStopped }
+            cancelled.onAwait { EditingCheckpointResult.StopCancelled }
+            attempt.onAwait { it }
+          }
+        } catch (e: CancellationException) {
+          terminalResult()?.let {
+            return it
+          }
+          throw e
+        }
+      return terminalResult() ?: result
+    }
+
+    private fun terminalResult(): EditingCheckpointResult? =
+      when {
+        preparation.isStopped -> EditingCheckpointResult.SessionStopped
+        !active.load() -> EditingCheckpointResult.StopCancelled
+        else -> null
+      }
   }
 
   private val state = AtomicReference<State>(State.Active)
@@ -117,15 +203,32 @@ internal class DocumentEditingSession(
     return editor.trackLocalEdit { context -> start(editor, context) }
   }
 
-  fun beginClose(): DocumentEditingClose {
-    val starting = State.StartingClose
-    check(state.compareAndSet(State.Active, starting)) { "Document editing session is not active" }
-    val close = Close(editor.quiesceLocalEdits())
-    if (!state.compareAndSet(starting, State.Closing(close))) {
-      close.stop()
+  fun beginStop(): DocumentEditingStop {
+    while (true) {
+      when (val current = state.load()) {
+        State.Active -> {
+          if (!state.compareAndSet(current, State.StartingStop)) continue
+          val preparation = StopPreparation(editor.quiesceLocalEdits())
+          if (!state.compareAndSet(State.StartingStop, State.PreparingStop(preparation))) {
+            preparation.stop()
+          }
+          return StopHandle(preparation)
+        }
+        State.StartingStop -> continue
+        is State.PreparingStop -> {
+          if (current.preparation.retain()) return StopHandle(current.preparation)
+        }
+        is State.ResumingStop -> continue
+        State.Closed -> error("Document editing session is not active")
+      }
     }
-    return close
   }
+
+  internal val protectionGeneration: Long
+    get() = engine.protectionGeneration
+
+  internal suspend fun awaitProtectionAfter(observedGeneration: Long): Boolean =
+    engine.awaitProtectionAfter(observedGeneration)
 
   fun start() {
     check(state.load() === State.Active) { "Document editing session is not active" }
@@ -163,9 +266,26 @@ internal class DocumentEditingSession(
   fun stop() {
     val previous = state.exchange(State.Closed)
     if (previous === State.Closed) return
-    if (previous is State.Closing) previous.close.stop()
+    when (previous) {
+      is State.PreparingStop -> previous.preparation.stop()
+      is State.ResumingStop -> previous.preparation.stop()
+      else -> {}
+    }
     revisionJob.exchange(null)?.cancel()
     pipeline.stop()
     engine.stop()
+  }
+
+  private fun release(preparation: StopPreparation) {
+    if (!preparation.release()) return
+    while (true) {
+      val current = state.load()
+      if (current !is State.PreparingStop || current.preparation !== preparation) return
+      val resuming = State.ResumingStop(preparation)
+      if (!state.compareAndSet(current, resuming)) continue
+      preparation.resume()
+      state.compareAndSet(resuming, State.Active)
+      return
+    }
   }
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/DocumentProtectedReload.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/DocumentProtectedReload.kt
@@ -1,0 +1,234 @@
+package co.typie.editor
+
+import co.touchlab.kermit.Logger
+import io.sentry.kotlin.multiplatform.Sentry
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.selects.select
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+
+internal enum class DocumentReloadFailureDecision {
+  Retry,
+  Discard,
+}
+
+internal enum class DocumentProtectedReloadResult {
+  Replaced,
+  NotCurrent,
+  SessionStopped,
+}
+
+private sealed interface FailureResolution {
+  data class Decision(val decision: DocumentReloadFailureDecision) : FailureResolution
+
+  data class ProtectionAdvanced(val active: Boolean) : FailureResolution
+}
+
+private sealed interface RecoveryResult {
+  data object Protected : RecoveryResult
+
+  data object SessionStopped : RecoveryResult
+
+  data object StopCancelled : RecoveryResult
+
+  data class TimedOut(val observedGeneration: Long) : RecoveryResult
+}
+
+internal suspend fun runProtectedDocumentReload(
+  session: DocumentEditingSession,
+  finalizeInput: () -> Unit,
+  onStopAcquired: () -> Unit = {},
+  showDelayedFeedback: () -> Unit = {},
+  hideDelayedFeedback: () -> Unit = {},
+  resolveFailure: suspend () -> DocumentReloadFailureDecision,
+  replaceIfCurrent: (DocumentEditingSession) -> Boolean,
+  delayedFeedbackMillis: Long = 350,
+  checkpointWatchdogMillis: Long = 3_000,
+  retryWindowMillis: Long = 3_000,
+): DocumentProtectedReloadResult {
+  finalizeInput()
+  val stop = session.beginStop()
+  try {
+    onStopAcquired()
+    var observedGeneration = session.protectionGeneration
+    val initialResult =
+      withDelayedFeedback(
+        delayMillis = delayedFeedbackMillis,
+        timeoutMillis = checkpointWatchdogMillis,
+        show = showDelayedFeedback,
+        hide = hideDelayedFeedback,
+      ) {
+        stop.awaitCheckpoint()
+      }
+
+    when (initialResult) {
+      EditingCheckpointResult.Protected -> return replaceExact(session, replaceIfCurrent)
+      EditingCheckpointResult.SessionStopped -> return DocumentProtectedReloadResult.SessionStopped
+      EditingCheckpointResult.StopCancelled -> return DocumentProtectedReloadResult.NotCurrent
+      is EditingCheckpointResult.EditFailed,
+      is EditingCheckpointResult.ProtectionFailed,
+      null -> {}
+    }
+
+    while (true) {
+      when (
+        val resolution =
+          awaitFailureResolution(
+            session = session,
+            observedGeneration = observedGeneration,
+            resolveFailure = resolveFailure,
+          )
+      ) {
+        is FailureResolution.Decision ->
+          when (resolution.decision) {
+            DocumentReloadFailureDecision.Discard -> return replaceExact(session, replaceIfCurrent)
+            DocumentReloadFailureDecision.Retry -> {
+              // TODO: 저장 실패 상태 인디케이터가 생기면 reload 실패 시 admission을 다시 열고
+              // `계속 편집`을 제공한다. 현재는 실패 상태를 숨기지 않기 위해 재시도 modal로 막는다.
+            }
+          }
+        is FailureResolution.ProtectionAdvanced -> {
+          if (!resolution.active) return DocumentProtectedReloadResult.SessionStopped
+        }
+      }
+
+      observedGeneration = session.protectionGeneration
+      when (
+        val recovery =
+          runRecoveryWindow(
+            session = session,
+            stop = stop,
+            initialObservedGeneration = observedGeneration,
+            delayedFeedbackMillis = delayedFeedbackMillis,
+            retryWindowMillis = retryWindowMillis,
+            showDelayedFeedback = showDelayedFeedback,
+            hideDelayedFeedback = hideDelayedFeedback,
+          )
+      ) {
+        RecoveryResult.Protected -> return replaceExact(session, replaceIfCurrent)
+        RecoveryResult.SessionStopped -> return DocumentProtectedReloadResult.SessionStopped
+        RecoveryResult.StopCancelled -> return DocumentProtectedReloadResult.NotCurrent
+        is RecoveryResult.TimedOut -> observedGeneration = recovery.observedGeneration
+      }
+    }
+  } finally {
+    try {
+      runReloadFeedback("hide", hideDelayedFeedback)
+    } finally {
+      stop.cancel()
+    }
+  }
+}
+
+private suspend fun <T> withDelayedFeedback(
+  delayMillis: Long,
+  timeoutMillis: Long,
+  show: () -> Unit,
+  hide: () -> Unit,
+  block: suspend () -> T,
+): T? = coroutineScope {
+  val feedback =
+    launch(start = CoroutineStart.UNDISPATCHED) {
+      delay(delayMillis)
+      runReloadFeedback("show", show)
+    }
+  try {
+    withTimeoutOrNull(timeoutMillis) { block() }
+  } finally {
+    feedback.cancel()
+    try {
+      withContext(NonCancellable) { feedback.join() }
+    } finally {
+      runReloadFeedback("hide", hide)
+    }
+  }
+}
+
+private inline fun runReloadFeedback(stage: String, block: () -> Unit) {
+  try {
+    block()
+  } catch (e: CancellationException) {
+    throw e
+  } catch (e: Throwable) {
+    runCatching { Logger.w(e) { "Document protected reload feedback failed: $stage" } }
+    runCatching { Sentry.captureException(e) }
+  }
+}
+
+private suspend fun awaitFailureResolution(
+  session: DocumentEditingSession,
+  observedGeneration: Long,
+  resolveFailure: suspend () -> DocumentReloadFailureDecision,
+): FailureResolution = coroutineScope {
+  val decision = async { FailureResolution.Decision(resolveFailure()) }
+  val protection = async {
+    FailureResolution.ProtectionAdvanced(session.awaitProtectionAfter(observedGeneration))
+  }
+  try {
+    select {
+      decision.onAwait { it }
+      protection.onAwait { it }
+    }
+  } finally {
+    decision.cancel()
+    protection.cancel()
+    withContext(NonCancellable) {
+      try {
+        decision.join()
+      } finally {
+        protection.join()
+      }
+    }
+  }
+}
+
+private suspend fun runRecoveryWindow(
+  session: DocumentEditingSession,
+  stop: DocumentEditingStop,
+  initialObservedGeneration: Long,
+  delayedFeedbackMillis: Long,
+  retryWindowMillis: Long,
+  showDelayedFeedback: () -> Unit,
+  hideDelayedFeedback: () -> Unit,
+): RecoveryResult {
+  var observedGeneration = initialObservedGeneration
+  suspend fun retryUntilProtected(): RecoveryResult {
+    while (true) {
+      when (stop.retryCheckpoint()) {
+        EditingCheckpointResult.Protected -> return RecoveryResult.Protected
+        EditingCheckpointResult.SessionStopped -> return RecoveryResult.SessionStopped
+        EditingCheckpointResult.StopCancelled -> return RecoveryResult.StopCancelled
+        is EditingCheckpointResult.EditFailed,
+        is EditingCheckpointResult.ProtectionFailed -> {}
+      }
+      if (!session.awaitProtectionAfter(observedGeneration)) {
+        return RecoveryResult.SessionStopped
+      }
+      observedGeneration = session.protectionGeneration
+    }
+  }
+  return withDelayedFeedback(
+    delayMillis = delayedFeedbackMillis,
+    timeoutMillis = retryWindowMillis,
+    show = showDelayedFeedback,
+    hide = hideDelayedFeedback,
+  ) {
+    retryUntilProtected()
+  } ?: RecoveryResult.TimedOut(observedGeneration)
+}
+
+private fun replaceExact(
+  session: DocumentEditingSession,
+  replaceIfCurrent: (DocumentEditingSession) -> Boolean,
+): DocumentProtectedReloadResult =
+  if (replaceIfCurrent(session)) {
+    DocumentProtectedReloadResult.Replaced
+  } else {
+    DocumentProtectedReloadResult.NotCurrent
+  }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/runtime/EditorRuntime.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/runtime/EditorRuntime.kt
@@ -104,6 +104,18 @@ class EditorRuntime(private val uiScope: CoroutineScope) {
     }
   }
 
+  internal fun reportError(session: DocumentEditingSession, error: Throwable) {
+    if (error is CancellationException) {
+      throw error
+    }
+    uiScope.launch {
+      if (this@EditorRuntime.session !== session) {
+        return@launch
+      }
+      fail(error)
+    }
+  }
+
   private fun fail(error: Throwable) {
     if (this.error != null) {
       return

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/sync/SyncEngine.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/sync/SyncEngine.kt
@@ -12,6 +12,8 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.select
 
@@ -54,6 +56,8 @@ class SyncEngine(
   private val onPermanentError: (Throwable) -> Unit = {},
   private val now: () -> Long,
 ) : SyncHeadsSink {
+  private data class ProtectionState(val generation: Long = 0, val stopped: Boolean = false)
+
   private companion object {
     const val IDLE_MS = 500L
     const val MAX_WAIT_MS = 3000L
@@ -85,6 +89,10 @@ class SyncEngine(
   val retryAttempt: StateFlow<Int> = retryAttemptFlow
   private val captureFailuresFlow = MutableStateFlow(0)
   val captureFailures: StateFlow<Int> = captureFailuresFlow
+  private val protectionStateFlow = MutableStateFlow(ProtectionState())
+
+  internal val protectionGeneration: Long
+    get() = protectionStateFlow.value.generation
 
   init {
     scope.launch(start = CoroutineStart.UNDISPATCHED) { firePush() }
@@ -141,7 +149,10 @@ class SyncEngine(
           if (missing.withheld > 0) {
             onEvent(SyncEvent.PersistWithheld(missing.withheld))
           } else {
-            capturedHeads = heads
+            if (!protectionStateFlow.value.stopped && !capturedHeads.contentEquals(heads)) {
+              capturedHeads = heads
+              publishProtectionAdvance()
+            }
           }
         }
       }
@@ -338,7 +349,9 @@ class SyncEngine(
   }
 
   override fun setConfirmedHeads(heads: ByteArray) {
+    if (protectionStateFlow.value.stopped || confirmedHeads.contentEquals(heads)) return
     confirmedHeads = heads
+    publishProtectionAdvance()
   }
 
   override fun setDurableHeads(heads: ByteArray) {
@@ -357,6 +370,9 @@ class SyncEngine(
   suspend fun captureNow() {
     capture()
   }
+
+  internal suspend fun awaitProtectionAfter(observedGeneration: Long): Boolean =
+    !protectionStateFlow.first { it.stopped || it.generation > observedGeneration }.stopped
 
   suspend fun checkpointCurrentFrontier(): Result<Unit> =
     try {
@@ -429,6 +445,13 @@ class SyncEngine(
 
   fun stop() {
     stopped = true
+    protectionStateFlow.update { it.copy(stopped = true) }
     clearTimers()
+  }
+
+  private fun publishProtectionAdvance() {
+    protectionStateFlow.update { state ->
+      if (state.stopped) state else state.copy(generation = state.generation + 1)
+    }
   }
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/sync/ws/DocumentWsChannel.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/sync/ws/DocumentWsChannel.kt
@@ -40,6 +40,14 @@ sealed interface AttachEvent {
   data class PermanentErrorEvent(val code: String) : AttachEvent
 }
 
+internal fun AttachEvent.replacementSnapshotInFlight(): Boolean? =
+  when (this) {
+    AttachEvent.SnapshotRestart,
+    AttachEvent.ReloadEvent -> true
+    is AttachEvent.PermanentErrorEvent -> false
+    else -> null
+  }
+
 class DocumentWsChannel(
   private val connection: SyncWsConnection,
   private val documentId: String,
@@ -100,9 +108,7 @@ class DocumentWsChannel(
   }
 
   fun freshSubscribe(): Flow<AttachEvent> = channelFlow {
-    launch(start = CoroutineStart.UNDISPATCHED) {
-      events.collect { send(it) }
-    }
+    launch(start = CoroutineStart.UNDISPATCHED) { events.collect { send(it) } }
     scope.launch {
       if (cursor != null || snapshotDone) {
         restartGeneration()
@@ -250,6 +256,25 @@ class DocumentWsChannel(
     permanentlyFailed = false
     retryAttempts = 0
     if (_events.subscriptionCount.value > 0) reattach()
+  }
+
+  /** document-scoped attach ownership을 유지한 채 모든 subscriber를 새 snapshot으로 전환한다. */
+  fun retryFresh() {
+    permanentlyFailed = false
+    retryAttempts = 0
+    retryJob?.cancel()
+    retryJob = null
+    if (_events.subscriptionCount.value > 0) {
+      restartGeneration()
+    } else {
+      cursor = null
+      probe = null
+      snapshotDone = false
+      liveSeq = null
+      awaitingAck = false
+      attachWatchdogJob?.cancel()
+      attachWatchdogJob = null
+    }
   }
 
   private fun reattach() {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/sync/ws/SyncWs.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/sync/ws/SyncWs.kt
@@ -128,8 +128,9 @@ object SyncWs {
     }
 
   fun retryDocument(documentId: String) {
-    channels.remove(documentId)
     connection.resetTerminal()
+    // 활성 consumer가 남아 있으면 channel identity를 바꾸지 않는다. WS detach는 document-scoped다.
+    channels[documentId]?.retryFresh()
   }
 
   /** 재구독 전환 시 연결 terminal + 열린 채널의 permanent 실패를 방어적으로 리셋·재attach 한다. */

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/document/bodysettings/DocumentBodySettingsScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/document/bodysettings/DocumentBodySettingsScreen.kt
@@ -22,11 +22,15 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.lifecycle.viewmodel.compose.viewModel
 import co.typie.editor.DefaultRootPaginatedLayout
+import co.typie.editor.DocumentEditingSession
+import co.typie.editor.DocumentProtectedReloadResult
+import co.typie.editor.DocumentReloadFailureDecision
 import co.typie.editor.Editor
 import co.typie.editor.EditorScope
 import co.typie.editor.currentEditorThemeVariant
@@ -37,17 +41,37 @@ import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.SystemEvent
 import co.typie.editor.ffi.Viewport
 import co.typie.editor.preview.EditorPreview
+import co.typie.editor.runProtectedDocumentReload
 import co.typie.editor.runtime.EditorRuntime
-import co.typie.editor.sync.ws.loadDocumentSnapshotBytes
+import co.typie.editor.sync.ActiveDocumentEditingSessions
+import co.typie.editor.sync.ChangesetDeltaStore
+import co.typie.editor.sync.RemoteChangesetPipeline
+import co.typie.editor.sync.SyncEngine
+import co.typie.editor.sync.asSyncEditor
+import co.typie.editor.sync.concatChangesets
+import co.typie.editor.sync.isPermanentSyncError
+import co.typie.editor.sync.orphanSweeper
+import co.typie.editor.sync.syncAppScope
+import co.typie.editor.sync.ws.AttachEvent
+import co.typie.editor.sync.ws.DocumentSyncBaseline
+import co.typie.editor.sync.ws.SyncWs
+import co.typie.editor.sync.ws.WsSyncTransport
+import co.typie.editor.sync.ws.replacementSnapshotInFlight
 import co.typie.ext.imePadding
 import co.typie.ext.verticalScroll
 import co.typie.graphql.QueryState
+import co.typie.navigation.Nav
+import co.typie.navigation.RouteRemovalDecision
 import co.typie.platform.PlatformModule
-import co.typie.result.onOk
-import co.typie.result.result
 import co.typie.result.withDefaultExceptionHandler
+import co.typie.route.Route
+import co.typie.screen.editor.editor.EditorRouteLeaveInterceptor
 import co.typie.ui.component.Screen
 import co.typie.ui.component.Text
+import co.typie.ui.component.dialog.DialogResult
+import co.typie.ui.component.dialog.LocalDialog
+import co.typie.ui.component.dialog.confirm
+import co.typie.ui.component.dialog.error
 import co.typie.ui.component.editorsettings.EditorSettingsBasicStyleSection
 import co.typie.ui.component.editorsettings.EditorSettingsDetailLayoutSection
 import co.typie.ui.component.editorsettings.EditorSettingsLayoutSection
@@ -58,23 +82,40 @@ import co.typie.ui.component.editorsettings.toEditorModifiers
 import co.typie.ui.component.editorsettings.toEditorStyleSettings
 import co.typie.ui.component.sheet.LocalSheet
 import co.typie.ui.component.toast.LocalToast
+import co.typie.ui.component.toast.ToastType
 import co.typie.ui.component.topbar.ProvideTopBar
 import co.typie.ui.component.topbar.topBarScrollOffset
 import co.typie.ui.skeleton.Skeleton
 import co.typie.ui.state.rememberScrollState
 import co.typie.ui.theme.AppShapes
 import co.typie.ui.theme.AppTheme
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.time.Clock
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
+@OptIn(ExperimentalAtomicApi::class)
 @Composable
 fun DocumentBodySettingsScreen(entityId: String) {
+  val nav = Nav.current
+  val dialog = LocalDialog.current
   val model = viewModel { DocumentBodySettingsViewModel(entityId) }
   val scope = rememberCoroutineScope()
   val scrollState = rememberScrollState()
   val sheet = LocalSheet.current
   val toast = LocalToast.current
+  val focusManager = LocalFocusManager.current
 
   ProvideTopBar(
     center = { Text("본문 설정", style = AppTheme.typography.title) },
@@ -88,12 +129,16 @@ fun DocumentBodySettingsScreen(entityId: String) {
   ) { contentPadding ->
     val data = (model.query.state as? QueryState.Success)?.data ?: return@Screen
     val document = data.entity.node.onDocument ?: return@Screen
-    var graph by remember(document.id) { mutableStateOf<ByteArray?>(null) }
-    LaunchedEffect(document.id) {
-      result<ByteArray, Nothing> { loadDocumentSnapshotBytes(document.id) }
-        .withDefaultExceptionHandler(toast)
-        .onOk { graph = it }
-    }
+    val settingsRuntime = remember(document.id) { EditorRuntime(uiScope = scope) }
+    val previewRuntime = remember(document.id) { EditorRuntime(uiScope = scope) }
+    var load by remember(document.id) { mutableStateOf<DocumentBodySettingsLoad?>(null) }
+    var liveLoad by remember(document.id) { mutableStateOf<DocumentBodySettingsLoad?>(null) }
+    var reloadRequest by
+      remember(document.id) { mutableStateOf<DocumentBodySettingsReloadRequest?>(null) }
+    var loaderFailedCode by remember(document.id) { mutableStateOf<String?>(null) }
+    var routeLeaveActive by remember(document.id) { mutableStateOf(false) }
+    val channel = remember(document.id) { SyncWs.channel(document.id) }
+    val graph = load?.graph
 
     val colors = AppTheme.colors
     val layoutDirection = LocalLayoutDirection.current
@@ -104,17 +149,221 @@ fun DocumentBodySettingsScreen(entityId: String) {
     val graphKey = remember(graph) { graph?.let { it.size to it.contentHashCode() } }
     var initial by
       remember(document.id, graphKey) { mutableStateOf<DocumentBodySettingsInitialState?>(null) }
-    val settingsRuntime = remember(document.id) { EditorRuntime(uiScope = scope) }
-    val previewRuntime = remember(document.id) { EditorRuntime(uiScope = scope) }
     val previewGraph = if (initial?.hasText == true) graph else null
     var bodyStyle by remember(document.id) { mutableStateOf<EditorStyleSettings?>(null) }
     val editorThemeVariant = currentEditorThemeVariant()
     var layout by remember(document.id) { mutableStateOf<LayoutMode?>(null) }
     val resolvedBodyStyle = bodyStyle ?: EditorStyleSettings()
     val resolvedLayout = layout ?: DefaultRootPaginatedLayout
-    val controlsEnabled = initial != null && settingsRuntime.editor != null
+    val controlsEnabled =
+      initial != null &&
+        settingsRuntime.session != null &&
+        liveLoad === load &&
+        reloadRequest == null &&
+        !routeLeaveActive
 
-    DisposableEffect(settingsRuntime) { onDispose { settingsRuntime.clear() } }
+    var savingToastId by remember(document.id, toast) { mutableStateOf<Long?>(null) }
+
+    fun dismissSavingToast() {
+      val id = savingToastId ?: return
+      savingToastId = null
+      if (toast.state?.id == id) toast.dismiss()
+    }
+
+    fun finishReloadRequest(request: DocumentBodySettingsReloadRequest) {
+      if (reloadRequest !== request) return
+      reloadRequest = null
+      request.policyJob = null
+      request.completion.complete(Unit)
+    }
+
+    fun claimReloadReplacement(request: DocumentBodySettingsReloadRequest): Boolean {
+      if (
+        reloadRequest !== request ||
+          settingsRuntime.session !== request.session ||
+          load !== request.load ||
+          liveLoad !== request.load
+      ) {
+        return false
+      }
+
+      val needsSnapshot = !request.snapshotInFlight
+      settingsRuntime.clear(request.session)
+      liveLoad = null
+      load = null
+      finishReloadRequest(request)
+      if (needsSnapshot) SyncWs.retryDocument(document.id)
+      return true
+    }
+
+    fun launchReloadPolicy(
+      request: DocumentBodySettingsReloadRequest
+    ): CompletableDeferred<Boolean> {
+      val acquired = CompletableDeferred<Boolean>()
+      if (
+        routeLeaveActive ||
+          reloadRequest !== request ||
+          settingsRuntime.session !== request.session ||
+          load !== request.load ||
+          liveLoad !== request.load ||
+          request.policyJob != null
+      ) {
+        acquired.complete(false)
+        return acquired
+      }
+
+      val job =
+        scope.launch(start = CoroutineStart.UNDISPATCHED) {
+          try {
+            when (
+              runProtectedDocumentReload(
+                session = request.session,
+                finalizeInput = {
+                  focusManager.clearFocus()
+                  settingsRuntime.blur()
+                  request.session.editor.sync {
+                    enqueue(Message.System(SystemEvent.SetFocused(false)))
+                  }
+                  settingsRuntime.deactivateScene()
+                },
+                onStopAcquired = { acquired.complete(true) },
+                showDelayedFeedback = {
+                  toast.show(ToastType.Loading, "저장 중…")
+                  savingToastId = toast.state?.id
+                },
+                hideDelayedFeedback = { dismissSavingToast() },
+                resolveFailure = {
+                  val result =
+                    dialog.confirm(
+                      title = "최신 버전을 불러올 수 없어요",
+                      message = "최근 변경사항을 안전하게 저장하지 못했어요.",
+                      confirmText = "변경사항 버리고 불러오기",
+                      cancelText = "다시 시도",
+                      confirmIsDestructive = true,
+                    )
+                  if (result is DialogResult.Resolved) {
+                    DocumentReloadFailureDecision.Discard
+                  } else {
+                    DocumentReloadFailureDecision.Retry
+                  }
+                },
+                replaceIfCurrent = { claimReloadReplacement(request) },
+              )
+            ) {
+              DocumentProtectedReloadResult.Replaced -> Unit
+              DocumentProtectedReloadResult.NotCurrent,
+              DocumentProtectedReloadResult.SessionStopped -> finishReloadRequest(request)
+            }
+          } catch (e: CancellationException) {
+            throw e
+          } catch (e: Throwable) {
+            if (reloadRequest === request && settingsRuntime.session === request.session) {
+              finishReloadRequest(request)
+              settingsRuntime.reportError(request.session, e)
+            }
+          }
+        }
+      request.policyJob = job
+      job.invokeOnCompletion {
+        acquired.complete(false)
+        if (request.policyJob === job) request.policyJob = null
+      }
+      return acquired
+    }
+
+    suspend fun requestReload(
+      session: DocumentEditingSession,
+      activeLoad: DocumentBodySettingsLoad,
+      snapshotInFlight: Boolean,
+    ) {
+      val current = reloadRequest
+      val request =
+        if (current?.session === session && current.load === activeLoad) {
+          current.also { it.snapshotInFlight = it.snapshotInFlight || snapshotInFlight }
+        } else {
+          current?.policyJob?.cancel()
+          current?.let { finishReloadRequest(it) }
+          if (
+            settingsRuntime.session !== session || load !== activeLoad || liveLoad !== activeLoad
+          ) {
+            return
+          }
+          DocumentBodySettingsReloadRequest(
+              session = session,
+              load = activeLoad,
+              snapshotInFlight = snapshotInFlight,
+            )
+            .also { reloadRequest = it }
+        }
+      if (!routeLeaveActive && request.policyJob == null) {
+        launchReloadPolicy(request)
+      }
+      request.completion.await()
+    }
+
+    LaunchedEffect(document.id, channel) {
+      val snapshotChunks = mutableListOf<ByteArray>()
+      channel.freshSubscribe().collect { event ->
+        val replacementSnapshotInFlight = event.replacementSnapshotInFlight()
+        if (replacementSnapshotInFlight != null) {
+          if (replacementSnapshotInFlight) snapshotChunks.clear()
+
+          val session = settingsRuntime.session
+          val activeLoad = load
+          if (session != null && activeLoad != null && liveLoad === activeLoad) {
+            requestReload(session, activeLoad, replacementSnapshotInFlight)
+          } else if (event is AttachEvent.PermanentErrorEvent) {
+            load = null
+            loaderFailedCode = event.code
+          } else if (session == null) {
+            load = null
+          }
+          return@collect
+        }
+
+        when (event) {
+          is AttachEvent.SnapshotChunkEvent -> snapshotChunks += event.bytes
+          is AttachEvent.SnapshotEndEvent -> {
+            val candidate =
+              DocumentBodySettingsLoad(
+                graph = snapshotChunks.concatChangesets(),
+                baseline =
+                  DocumentSyncBaseline(
+                    seq = event.seq,
+                    heads = event.heads.copyOf(),
+                    durableHeads = event.durableHeads.copyOf(),
+                  ),
+              )
+            snapshotChunks.clear()
+            if (settingsRuntime.session == null) {
+              load = candidate
+            }
+          }
+          is AttachEvent.ChangesetsEvent -> load?.queue(event)
+          AttachEvent.SnapshotRestart,
+          AttachEvent.ReloadEvent,
+          is AttachEvent.PermanentErrorEvent -> error("Replacement event was not classified")
+        }
+      }
+    }
+
+    LaunchedEffect(loaderFailedCode) {
+      loaderFailedCode ?: return@LaunchedEffect
+      dialog.error(nav) {
+        loaderFailedCode = null
+        load = null
+        SyncWs.retryDocument(document.id)
+      }
+    }
+
+    LaunchedEffect(settingsRuntime.error) {
+      settingsRuntime.error ?: return@LaunchedEffect
+      dialog.error(nav) {
+        settingsRuntime.clearError()
+        load = null
+        SyncWs.retryDocument(document.id)
+      }
+    }
 
     LaunchedEffect(graphKey) {
       val currentGraph = graph ?: return@LaunchedEffect
@@ -140,27 +389,222 @@ fun DocumentBodySettingsScreen(entityId: String) {
       if (layout == null) layout = nextInitial.layout
     }
 
-    LaunchedEffect(settingsRuntime, graphKey, editorThemeVariant) {
-      val currentGraph = graph ?: return@LaunchedEffect
+    LaunchedEffect(load, document.id, channel) {
+      val readyLoad = load ?: return@LaunchedEffect
       if (!settingsRuntime.canCreateEditor) return@LaunchedEffect
-      settingsRuntime.attach(
-        Editor.create(
-          graph = currentGraph,
-          viewport = Viewport(width = 1f, height = 1f, scaleFactor = 1.0),
-          scope = scope,
-          themeVariant = editorThemeVariant,
-          onError = { activeEditor, error -> settingsRuntime.reportError(activeEditor, error) },
+      val pending = ChangesetDeltaStore.load(document.id).map { it.changeset }
+      if (load !== readyLoad) return@LaunchedEffect
+      val bootstrapFailure = AtomicReference<Throwable?>(null)
+      var readyEditor: Editor? = null
+      var session: DocumentEditingSession? = null
+      var attached = false
+      var registered = false
+      val engineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+
+      try {
+        val createdEditor =
+          Editor.createWithPending(
+            graph = readyLoad.graph,
+            pending = pending,
+            viewport = Viewport(width = 1f, height = 1f, scaleFactor = 1.0),
+            scope = scope,
+            themeVariant = editorThemeVariant,
+            onError = { activeEditor, error ->
+              if (settingsRuntime.editor === activeEditor) {
+                settingsRuntime.reportError(activeEditor, error)
+              } else {
+                bootstrapFailure.compareAndSet(expectedValue = null, newValue = error)
+              }
+            },
+          )
+        readyEditor = createdEditor
+        bootstrapFailure.load()?.let { throw it }
+
+        lateinit var createdSession: DocumentEditingSession
+        readyLoad.activate(
+          apply = { event ->
+            for (bundle in event.bundles) {
+              if (bundle.isNotEmpty()) createdEditor.receiveRemoteChangeset(bundle)
+              bootstrapFailure.load()?.let { throw it }
+            }
+          },
+          startLive = { baseline ->
+            suspend fun awaitStreamReloadDecision() {
+              requestReload(createdSession, readyLoad, snapshotInFlight = true)
+            }
+            suspend fun awaitPullReloadDecision() {
+              requestReload(createdSession, readyLoad, snapshotInFlight = false)
+            }
+
+            val transport =
+              WsSyncTransport(
+                channel = channel,
+                connection = SyncWs.connection,
+                documentId = document.id,
+                onReload = { awaitStreamReloadDecision() },
+                scope = engineScope,
+              )
+            val engine =
+              SyncEngine(
+                editor = createdEditor.asSyncEditor(),
+                documentId = document.id,
+                initialServerHeads = baseline.heads,
+                initialDurableHeads = baseline.durableHeads,
+                store = ChangesetDeltaStore,
+                pushFn = { transport.push(it) },
+                scope = engineScope,
+                isPermanent = ::isPermanentSyncError,
+                now = { Clock.System.now().toEpochMilliseconds() },
+              )
+            val pipeline =
+              RemoteChangesetPipeline(
+                editor = createdEditor.asSyncEditor(),
+                headsSink = engine,
+                transport = transport,
+                initialSeq = baseline.seq,
+                scope = engineScope,
+                onNeedsReload = { awaitPullReloadDecision() },
+              )
+            createdSession =
+              DocumentEditingSession(
+                documentId = document.id,
+                editor = createdEditor,
+                engine = engine,
+                pipeline = pipeline,
+                scope = engineScope,
+              )
+            session = createdSession
+            settingsRuntime.attach(createdSession)
+            check(settingsRuntime.session === createdSession)
+            attached = true
+            createdSession.start()
+            ActiveDocumentEditingSessions.register(createdSession)
+            registered = true
+            liveLoad = readyLoad
+          },
         )
-      )
+
+        awaitCancellation()
+      } catch (e: CancellationException) {
+        throw e
+      } catch (e: Throwable) {
+        if (load === readyLoad) settingsRuntime.reportError(e)
+      } finally {
+        if (liveLoad === readyLoad) liveLoad = null
+        val closingSession = session
+        val closingRequest = reloadRequest?.takeIf {
+          it.session === closingSession && it.load === readyLoad
+        }
+        closingRequest?.policyJob?.cancel()
+        closingRequest?.let { finishReloadRequest(it) }
+        if (closingSession != null) {
+          settingsRuntime.clear(closingSession)
+          closingSession.stop()
+          if (registered) ActiveDocumentEditingSessions.unregister(closingSession)
+        } else {
+          readyEditor?.dispose()
+        }
+        engineScope.cancel()
+        if (attached) syncAppScope.launch { orphanSweeper.sweep() }
+      }
+    }
+
+    val settingsEditor = settingsRuntime.editor
+    val authoritativeRootAttrs = settingsEditor?.rootAttrs
+    val authoritativeRootModifiers = settingsEditor?.rootModifiers
+    LaunchedEffect(settingsEditor, authoritativeRootAttrs, authoritativeRootModifiers) {
+      val rootAttrs = authoritativeRootAttrs ?: return@LaunchedEffect
+      val rootModifiers = authoritativeRootModifiers ?: return@LaunchedEffect
+      layout = rootAttrs.layoutMode
+      bodyStyle = rootModifiers.toEditorStyleSettings()
+    }
+
+    val leaveInterceptor =
+      remember(settingsEditor, settingsRuntime.session, dialog, toast) {
+        val activeEditor = settingsEditor ?: return@remember null
+        val activeSession =
+          settingsRuntime.session?.takeIf { it.editor === activeEditor } ?: return@remember null
+        EditorRouteLeaveInterceptor(
+          finalizeInput = {
+            focusManager.clearFocus()
+            settingsRuntime.blur()
+            activeEditor.sync { enqueue(Message.System(SystemEvent.SetFocused(false))) }
+            settingsRuntime.deactivateScene()
+          },
+          restoreInput = {},
+          beginStop = activeSession::beginStop,
+          onPreparationStarted = {
+            routeLeaveActive = true
+            try {
+              val request = reloadRequest?.takeIf {
+                it.session === activeSession && it.load === load
+              }
+              request?.policyJob?.cancelAndJoin()
+            } catch (throwable: Throwable) {
+              routeLeaveActive = false
+              throw throwable
+            }
+          },
+          resumeReloadBeforeRollback = {
+            routeLeaveActive = false
+            val request = reloadRequest?.takeIf {
+              it.session === activeSession &&
+                settingsRuntime.session === activeSession &&
+                it.load === load &&
+                liveLoad === it.load
+            }
+            if (request == null) {
+              false
+            } else {
+              val stopAcquired = launchReloadPolicy(request).await()
+              val reloadOwnsStop =
+                stopAcquired &&
+                  (request.policyJob?.isActive == true || settingsRuntime.session !== activeSession)
+              if (!reloadOwnsStop) finishReloadRequest(request)
+              reloadOwnsStop
+            }
+          },
+          showDelayedFeedback = {
+            toast.show(ToastType.Loading, "저장 중…")
+            savingToastId = toast.state?.id
+          },
+          hideDelayedFeedback = { dismissSavingToast() },
+          resolveDecision = {
+            val result =
+              dialog.confirm(
+                title = "저장을 완료하지 못했어요",
+                message = "지금 닫으면 최근 변경사항을 잃을 수 있어요.",
+                confirmText = "저장하지 않고 닫기",
+                cancelText = "계속 편집",
+                confirmIsDestructive = true,
+              )
+            if (result is DialogResult.Resolved) {
+              RouteRemovalDecision.ProceedWithRemoval
+            } else {
+              RouteRemovalDecision.CancelRemoval
+            }
+          },
+        )
+      }
+    DisposableEffect(nav, entityId, leaveInterceptor) {
+      val unregister = leaveInterceptor?.let {
+        nav.routeRemovals.register(Route.DocumentBodySettings(entityId), it)
+      }
+      onDispose {
+        unregister?.invoke()
+        dismissSavingToast()
+      }
     }
 
     fun save(block: EditorScope.() -> Unit) {
       if (!controlsEnabled) return
-      val activeEditor = settingsRuntime.editor ?: return
-      scope.launch {
-        model
-          .updateBodySettings(editor = activeEditor, documentId = document.id, block = block)
-          .withDefaultExceptionHandler(toast)
+      val activeSession = settingsRuntime.session ?: return
+      activeSession.submit { activeEditor, context ->
+        activeEditor.scope.launch(context) {
+          model
+            .applyAndRelayBodySettings(editor = activeEditor, block = block)
+            .withDefaultExceptionHandler(toast)
+        }
       }
     }
 
@@ -268,3 +712,48 @@ private data class DocumentBodySettingsInitialState(
   val style: EditorStyleSettings,
   val layout: LayoutMode,
 )
+
+internal class DocumentBodySettingsLoad(val graph: ByteArray, baseline: DocumentSyncBaseline) {
+  private val pending = mutableListOf<AttachEvent.ChangesetsEvent>()
+  private var currentBaseline = baseline
+  private var live = false
+
+  fun queue(event: AttachEvent.ChangesetsEvent): Boolean {
+    if (live) return false
+    pending += event
+    return true
+  }
+
+  suspend fun activate(
+    apply: suspend (AttachEvent.ChangesetsEvent) -> Unit,
+    startLive: (DocumentSyncBaseline) -> Unit,
+  ) {
+    check(!live)
+    while (pending.isNotEmpty()) {
+      val batch = pending.toList()
+      pending.clear()
+      for (event in batch) {
+        apply(event)
+        currentBaseline =
+          currentBaseline.copy(
+            seq = event.seq.ifEmpty { currentBaseline.seq },
+            heads = event.heads.copyOf(),
+            durableHeads = event.durableHeads.copyOf(),
+          )
+      }
+    }
+    startLive(currentBaseline)
+    check(pending.isEmpty()) { "Changeset queued during non-suspending live cutover" }
+    live = true
+  }
+}
+
+private class DocumentBodySettingsReloadRequest(
+  val session: DocumentEditingSession,
+  val load: DocumentBodySettingsLoad,
+  snapshotInFlight: Boolean,
+) {
+  val completion = CompletableDeferred<Unit>()
+  var policyJob: Job? = null
+  var snapshotInFlight = snapshotInFlight
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/document/bodysettings/DocumentBodySettingsViewModel.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/document/bodysettings/DocumentBodySettingsViewModel.kt
@@ -9,7 +9,6 @@ import co.typie.editor.EditorLocalChangesetBus
 import co.typie.editor.EditorLocalChangesetTracker
 import co.typie.editor.EditorScope
 import co.typie.editor.FontLoader
-import co.typie.editor.sync.ws.SyncWs
 import co.typie.graphql.Apollo
 import co.typie.graphql.DocumentBodySettingsScreen_Query
 import co.typie.graphql.PlaceholderResolver
@@ -27,8 +26,9 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
 internal class DocumentBodySettingsViewModel(private val entityId: String) : ViewModel() {
-  private val saveMutex = Mutex()
-  private val changesetTracker = EditorLocalChangesetTracker()
+  private val relayMutex = Mutex()
+  private var changesetTracker = EditorLocalChangesetTracker()
+  private var trackedEditor: Editor? = null
 
   val query =
     Apollo.watchQuery(scope = viewModelScope, placeholderData = placeholderData()) {
@@ -63,19 +63,20 @@ internal class DocumentBodySettingsViewModel(private val entityId: String) : Vie
     }
   }
 
-  internal suspend fun updateBodySettings(
+  internal suspend fun applyAndRelayBodySettings(
     editor: Editor,
-    documentId: String,
     block: EditorScope.() -> Unit,
-  ): Result<ByteArray?, Nothing> = result {
-    saveMutex.withLock {
+  ): Result<Unit, Nothing> = result {
+    relayMutex.withLock {
+      if (trackedEditor !== editor) {
+        changesetTracker = EditorLocalChangesetTracker()
+        trackedEditor = editor
+      }
       val changesets = changesetTracker.collect(editor = editor, block = block)
-      if (changesets.isEmpty()) return@withLock null
+      if (changesets.isEmpty()) return@withLock
 
-      val response = SyncWs.connection.push(documentId, changesets)
-      changesetTracker.markSynced(response.heads)
+      changesetTracker.markSynced(editor)
       EditorLocalChangesetBus.publish(entityId = entityId, changesets = changesets)
-      changesets
     }
   }
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorRouteLeaveInterceptor.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorRouteLeaveInterceptor.kt
@@ -1,34 +1,39 @@
 package co.typie.screen.editor.editor
 
-import co.typie.editor.DocumentEditingClose
+import co.typie.editor.DocumentEditingStop
 import co.typie.editor.EditingCheckpointResult
 import co.typie.navigation.RouteRemovalDecision
 import co.typie.navigation.RouteRemovalInterceptor
 import co.typie.navigation.RouteRemovalPreparation
 import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 
 internal class EditorRouteLeaveInterceptor(
   private val finalizeInput: () -> Unit,
   private val restoreInput: () -> Unit,
-  private val beginClose: () -> DocumentEditingClose,
+  private val beginStop: () -> DocumentEditingStop,
+  private val onPreparationStarted: suspend () -> Unit = {},
+  private val resumeReloadBeforeRollback: suspend () -> Boolean = { false },
   private val resolveDecision: suspend () -> RouteRemovalDecision,
   private val delayedFeedbackMillis: Long = DEFAULT_DELAYED_FEEDBACK_MILLIS,
   private val checkpointWatchdogMillis: Long = DEFAULT_CHECKPOINT_WATCHDOG_MILLIS,
   private val showDelayedFeedback: () -> Unit = {},
   private val hideDelayedFeedback: () -> Unit = {},
 ) : RouteRemovalInterceptor {
-  private var close: DocumentEditingClose? = null
+  private var stop: DocumentEditingStop? = null
+  private var reloadPaused = false
   private var delayedFeedbackVisible = false
 
   override suspend fun prepare(onDelayed: (suspend () -> Unit)?): RouteRemovalPreparation {
-    check(close == null) { "Editor leave preparation is already active" }
-    val currentClose =
+    check(stop == null) { "Editor leave preparation is already active" }
+    val currentStop =
       try {
         finalizeInput()
-        beginClose()
+        beginStop()
       } catch (throwable: Throwable) {
         try {
           restoreInput()
@@ -37,37 +42,60 @@ internal class EditorRouteLeaveInterceptor(
         }
         throw throwable
       }
-    close = currentClose
+    stop = currentStop
 
-    return if (awaitCheckpoint(currentClose, onDelayed)) {
-      RouteRemovalPreparation.Ready
-    } else {
-      RouteRemovalPreparation.NeedsDecision
+    try {
+      withContext(NonCancellable) {
+        onPreparationStarted()
+        reloadPaused = true
+      }
+      return if (awaitCheckpoint(currentStop, onDelayed)) {
+        RouteRemovalPreparation.Ready
+      } else {
+        RouteRemovalPreparation.NeedsDecision
+      }
+    } catch (throwable: Throwable) {
+      if (stop === currentStop) stop = null
+      val shouldResumeReload = reloadPaused
+      reloadPaused = false
+      val failure =
+        withContext(NonCancellable) { releaseStop(currentStop, shouldResumeReload, throwable) }
+      throw failure ?: throwable
     }
   }
 
   override suspend fun resolveDecision(): RouteRemovalDecision = resolveDecision.invoke()
 
   override suspend fun rollback() {
-    val currentClose = close ?: return
-    close = null
-    try {
-      currentClose.cancel()
-    } finally {
+    val currentStop = stop ?: return
+    stop = null
+    val shouldResumeReload = reloadPaused
+    reloadPaused = false
+    releaseStop(currentStop, shouldResumeReload, initialFailure = null)?.let { throw it }
+  }
+
+  private suspend fun releaseStop(
+    currentStop: DocumentEditingStop,
+    shouldResumeReload: Boolean,
+    initialFailure: Throwable?,
+  ): Throwable? {
+    var reloadResumed = false
+    var failure = initialFailure
+    if (shouldResumeReload) {
       try {
-        hideDelayedFeedbackIfVisible()
-      } finally {
-        restoreInput()
+        reloadResumed = resumeReloadBeforeRollback()
+      } catch (throwable: Throwable) {
+        failure = recordFailure(failure, throwable)
       }
     }
+    return cleanup(currentStop, restore = !reloadResumed, failure)
   }
 
   private suspend fun awaitCheckpoint(
-    close: DocumentEditingClose,
+    stop: DocumentEditingStop,
     onDelayed: (suspend () -> Unit)? = null,
   ): Boolean {
-    suspend fun awaitResult(): Boolean =
-      close.awaitCheckpoint() == EditingCheckpointResult.Protected
+    suspend fun awaitResult(): Boolean = stop.awaitCheckpoint() == EditingCheckpointResult.Protected
 
     return try {
       withTimeoutOrNull(checkpointWatchdogMillis) {
@@ -93,6 +121,38 @@ internal class EditorRouteLeaveInterceptor(
     if (!delayedFeedbackVisible) return
     delayedFeedbackVisible = false
     hideDelayedFeedback()
+  }
+
+  private fun cleanup(
+    currentStop: DocumentEditingStop,
+    restore: Boolean,
+    initialFailure: Throwable?,
+  ): Throwable? {
+    var failure = initialFailure
+    try {
+      currentStop.cancel()
+    } catch (throwable: Throwable) {
+      failure = recordFailure(failure, throwable)
+    }
+    try {
+      hideDelayedFeedbackIfVisible()
+    } catch (throwable: Throwable) {
+      failure = recordFailure(failure, throwable)
+    }
+    if (restore) {
+      try {
+        restoreInput()
+      } catch (throwable: Throwable) {
+        failure = recordFailure(failure, throwable)
+      }
+    }
+    return failure
+  }
+
+  private fun recordFailure(primary: Throwable?, cleanupFailure: Throwable): Throwable {
+    if (primary == null) return cleanupFailure
+    if (cleanupFailure !== primary) primary.addSuppressed(cleanupFailure)
+    return primary
   }
 
   private companion object {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -46,6 +46,8 @@ import co.typie.domain.subscription.editorIsReadOnly
 import co.typie.domain.subscription.gate
 import co.typie.domain.subscription.shouldAttemptPush
 import co.typie.editor.DocumentEditingSession
+import co.typie.editor.DocumentProtectedReloadResult
+import co.typie.editor.DocumentReloadFailureDecision
 import co.typie.editor.Editor
 import co.typie.editor.EditorLocalChangesetBus
 import co.typie.editor.EditorState
@@ -76,6 +78,7 @@ import co.typie.editor.interaction.LocalEditorInteractionScope
 import co.typie.editor.interaction.allowsViewportScrollReconcile
 import co.typie.editor.interaction.semantics.EditorViewportZoomSemanticConfig
 import co.typie.editor.rememberEditorZoomController
+import co.typie.editor.runProtectedDocumentReload
 import co.typie.editor.runtime.EditorRuntime
 import co.typie.editor.runtime.EditorUiState
 import co.typie.editor.runtime.LocalEditorRuntime
@@ -94,7 +97,6 @@ import co.typie.editor.sync.DocumentEditorLoad
 import co.typie.editor.sync.RemoteChangesetPipeline
 import co.typie.editor.sync.SyncEngine
 import co.typie.editor.sync.asSyncEditor
-import co.typie.editor.sync.catchingNonCancellation
 import co.typie.editor.sync.isPermanentSyncError
 import co.typie.editor.sync.isSubscriptionRequiredSyncError
 import co.typie.editor.sync.orphanSweeper
@@ -105,6 +107,7 @@ import co.typie.editor.sync.ws.DocumentGraphLoaderEvent
 import co.typie.editor.sync.ws.SyncWs
 import co.typie.editor.sync.ws.SyncWsException
 import co.typie.editor.sync.ws.WsSyncTransport
+import co.typie.editor.sync.ws.replacementSnapshotInFlight
 import co.typie.editor.viewport.consumeEditorViewportTouchPan
 import co.typie.ext.LocalScrollGestureLockState
 import co.typie.ext.ime
@@ -195,15 +198,29 @@ import co.typie.ui.theme.LocalHazeState
 import dev.chrisbanes.haze.HazeState
 import kotlin.time.Clock
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.decodeFromJsonElement
+
+private class EditorReloadRequest(
+  val session: DocumentEditingSession,
+  val load: DocumentEditorLoad,
+  snapshotInFlight: Boolean,
+) {
+  val completion = CompletableDeferred<Unit>()
+  var policyJob: Job? = null
+  var snapshotInFlight = snapshotInFlight
+}
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
@@ -236,7 +253,8 @@ fun EditorScreen(entityId: String) {
   var syncActiveLoadState by remember(entityId) { mutableStateOf<DocumentEditorLoad?>(null) }
   val pendingChangesets = remember(entityId) { mutableListOf<AttachEvent.ChangesetsEvent>() }
   var loaderFailedCode by remember(entityId) { mutableStateOf<String?>(null) }
-  var loaderRetryGeneration by remember(entityId) { mutableStateOf(0) }
+  var reloadRequest by remember(entityId) { mutableStateOf<EditorReloadRequest?>(null) }
+  var routeRemovalOwnsPriority by remember(entityId) { mutableStateOf(false) }
 
   LaunchedEffect(Unit) { SubscriptionService.refresh() }
 
@@ -281,10 +299,7 @@ fun EditorScreen(entityId: String) {
       if (syncActiveLoadState === failedLoad) syncActiveLoadState = null
       pendingChangesets.clear()
       failedLoad?.close()
-      documentId?.let {
-        SyncWs.retryDocument(it)
-        loaderRetryGeneration += 1
-      }
+      documentId?.let(SyncWs::retryDocument)
     }
   }
   val legacyDocument = !loading && document != null && document.state == null
@@ -508,6 +523,133 @@ fun EditorScreen(entityId: String) {
     if (toast.state?.id == id) toast.dismiss()
   }
 
+  fun finishReloadRequest(request: EditorReloadRequest) {
+    if (reloadRequest !== request) return
+    reloadRequest = null
+    request.policyJob = null
+    request.completion.complete(Unit)
+  }
+
+  fun claimReloadReplacement(request: EditorReloadRequest): Boolean {
+    if (
+      reloadRequest !== request ||
+        runtime.session !== request.session ||
+        editorLoadState !== request.load ||
+        syncActiveLoadState !== request.load
+    ) {
+      return false
+    }
+
+    val needsSnapshot = !request.snapshotInFlight
+    runtime.clear(request.session)
+    editorLoadState = null
+    syncActiveLoadState = null
+    pendingChangesets.clear()
+    request.load.close()
+    finishReloadRequest(request)
+    if (needsSnapshot) documentId?.let(SyncWs::retryDocument)
+    return true
+  }
+
+  fun launchReloadPolicy(request: EditorReloadRequest): CompletableDeferred<Boolean> {
+    val acquired = CompletableDeferred<Boolean>()
+    if (
+      routeRemovalOwnsPriority ||
+        reloadRequest !== request ||
+        runtime.session !== request.session ||
+        editorLoadState !== request.load ||
+        request.policyJob != null
+    ) {
+      acquired.complete(false)
+      return acquired
+    }
+
+    val job =
+      scope.launch(start = CoroutineStart.UNDISPATCHED) {
+        try {
+          val result =
+            runProtectedDocumentReload(
+              session = request.session,
+              finalizeInput = {
+                runtime.blur()
+                uiState.updateFocus(false)
+                request.session.editor.sync {
+                  enqueue(Message.System(SystemEvent.SetFocused(false)))
+                }
+                runtime.deactivateScene()
+              },
+              onStopAcquired = { acquired.complete(true) },
+              showDelayedFeedback = {
+                toast.show(ToastType.Loading, "저장 중…")
+                savingToastId = toast.state?.id
+              },
+              hideDelayedFeedback = { dismissSavingToast() },
+              resolveFailure = {
+                val result =
+                  dialog.confirm(
+                    title = "최신 버전을 불러올 수 없어요",
+                    message = "최근 변경사항을 안전하게 저장하지 못했어요.",
+                    confirmText = "변경사항 버리고 불러오기",
+                    cancelText = "다시 시도",
+                    confirmIsDestructive = true,
+                  )
+                if (result is DialogResult.Resolved) {
+                  DocumentReloadFailureDecision.Discard
+                } else {
+                  DocumentReloadFailureDecision.Retry
+                }
+              },
+              replaceIfCurrent = { claimReloadReplacement(request) },
+            )
+          when (result) {
+            DocumentProtectedReloadResult.Replaced -> {
+              try {
+                model.refetchDocumentAfterReload()
+              } finally {
+                model.bumpReloadGeneration()
+              }
+            }
+            DocumentProtectedReloadResult.NotCurrent,
+            DocumentProtectedReloadResult.SessionStopped -> finishReloadRequest(request)
+          }
+        } catch (e: CancellationException) {
+          throw e
+        } catch (e: Throwable) {
+          if (reloadRequest === request && runtime.session === request.session) {
+            finishReloadRequest(request)
+            runtime.reportError(request.session, e)
+          }
+        }
+      }
+    request.policyJob = job
+    job.invokeOnCompletion {
+      acquired.complete(false)
+      if (request.policyJob === job) request.policyJob = null
+    }
+    return acquired
+  }
+
+  suspend fun requestReload(
+    session: DocumentEditingSession,
+    load: DocumentEditorLoad,
+    snapshotInFlight: Boolean,
+  ) {
+    val current = reloadRequest
+    val request =
+      if (current?.session === session && current.load === load) {
+        current.also { it.snapshotInFlight = it.snapshotInFlight || snapshotInFlight }
+      } else {
+        current?.policyJob?.cancel()
+        current?.let { finishReloadRequest(it) }
+        EditorReloadRequest(session = session, load = load, snapshotInFlight = snapshotInFlight)
+          .also { reloadRequest = it }
+      }
+    if (!routeRemovalOwnsPriority && request.policyJob == null) {
+      launchReloadPolicy(request)
+    }
+    request.completion.await()
+  }
+
   val leaveInterceptor =
     remember(activeEditor, editingSession, dialog, toast) {
       activeEditor?.let { editor ->
@@ -532,7 +674,34 @@ fun EditorScreen(entityId: String) {
               runtime.focus()
             }
           },
-          beginClose = session::beginClose,
+          beginStop = session::beginStop,
+          onPreparationStarted = {
+            routeRemovalOwnsPriority = true
+            try {
+              val request = reloadRequest?.takeIf {
+                it.session === session && it.load === editorLoadState
+              }
+              request?.policyJob?.cancelAndJoin()
+            } catch (throwable: Throwable) {
+              routeRemovalOwnsPriority = false
+              throw throwable
+            }
+          },
+          resumeReloadBeforeRollback = {
+            routeRemovalOwnsPriority = false
+            val request = reloadRequest?.takeIf {
+              it.session === session && runtime.session === session && it.load === editorLoadState
+            }
+            if (request == null) {
+              false
+            } else {
+              val stopAcquired = launchReloadPolicy(request).await()
+              val reloadOwnsStop =
+                stopAcquired && (request.policyJob?.isActive == true || runtime.session !== session)
+              if (!reloadOwnsStop) finishReloadRequest(request)
+              reloadOwnsStop
+            }
+          },
           showDelayedFeedback = {
             toast.show(ToastType.Loading, "저장 중…")
             savingToastId = toast.state?.id
@@ -566,7 +735,7 @@ fun EditorScreen(entityId: String) {
     }
   }
 
-  LaunchedEffect(documentId, loaderRetryGeneration) {
+  LaunchedEffect(documentId) {
     val currentDocumentId = documentId ?: return@LaunchedEffect
     loaderFailedCode = null
     val channel = SyncWs.channel(currentDocumentId)
@@ -582,8 +751,26 @@ fun EditorScreen(entityId: String) {
         ) {
           pendingChangesets += event
         }
-        when (val outcome = loader.handle(event)) {
+        val outcome = loader.handle(event)
+        val replacementSnapshotInFlight = event.replacementSnapshotInFlight()
+        if (replacementSnapshotInFlight != null) {
+          val session = runtime.session
+          val activeLoad = editorLoadState
+          if (session != null && activeLoad != null && syncActiveLoadState === activeLoad) {
+            requestReload(
+              session = session,
+              load = activeLoad,
+              snapshotInFlight = replacementSnapshotInFlight,
+            )
+            return@collect
+          }
+        }
+        when (outcome) {
           is DocumentGraphLoaderEvent.Loaded -> {
+            if (currentLoad != null && syncActiveLoadState === currentLoad) {
+              runCatching { outcome.handle.abort() }
+              return@collect
+            }
             var nextLoad: DocumentEditorLoad? = null
             var installed = false
             try {
@@ -600,6 +787,9 @@ fun EditorScreen(entityId: String) {
                 )
 
               val previousLoad = editorLoadState
+              if (previousLoad != null && syncActiveLoadState === previousLoad) {
+                return@collect
+              }
               runtime.clear()
               editorLoadState = null
               if (syncActiveLoadState === previousLoad) syncActiveLoadState = null
@@ -643,7 +833,6 @@ fun EditorScreen(entityId: String) {
     dialog.error(nav) {
       documentId?.let { SyncWs.retryDocument(it) }
       loaderFailedCode = null
-      loaderRetryGeneration += 1
     }
   }
 
@@ -681,26 +870,18 @@ fun EditorScreen(entityId: String) {
 
       lateinit var createdEngine: SyncEngine
       lateinit var createdSession: DocumentEditingSession
-      val handleNeedsReload: suspend () -> Unit = {
-        catchingNonCancellation { createdEngine.captureNow() }
-        createdSession.stop()
-        model.refetchDocument()
-        model.bumpReloadGeneration()
-        runtime.clear(createdSession)
-        if (editorLoadState === readyLoad) {
-          editorLoadState = null
-          if (syncActiveLoadState === readyLoad) syncActiveLoadState = null
-          pendingChangesets.clear()
-          readyLoad.close()
-          loaderRetryGeneration += 1
-        }
+      val handleStreamReload: suspend () -> Unit = {
+        requestReload(createdSession, readyLoad, snapshotInFlight = true)
+      }
+      val handlePullReload: suspend () -> Unit = {
+        requestReload(createdSession, readyLoad, snapshotInFlight = false)
       }
       val transport =
         WsSyncTransport(
           channel = SyncWs.channel(currentDocumentId),
           connection = SyncWs.connection,
           documentId = currentDocumentId,
-          onReload = handleNeedsReload,
+          onReload = handleStreamReload,
           scope = engineScope,
         )
       createdEngine =
@@ -728,7 +909,7 @@ fun EditorScreen(entityId: String) {
           transport = transport,
           initialSeq = effectiveBaseline.seq,
           scope = engineScope,
-          onNeedsReload = handleNeedsReload,
+          onNeedsReload = handlePullReload,
         )
       createdSession =
         DocumentEditingSession(
@@ -750,6 +931,11 @@ fun EditorScreen(entityId: String) {
     } finally {
       if (syncActiveLoadState === readyLoad) syncActiveLoadState = null
       val closingSession = session
+      val closingRequest = reloadRequest?.takeIf {
+        it.session === closingSession && it.load === readyLoad
+      }
+      closingRequest?.policyJob?.cancel()
+      closingRequest?.let { finishReloadRequest(it) }
       closingSession?.let {
         runtime.clear(it)
         it.stop()

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorViewModel.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorViewModel.kt
@@ -157,11 +157,20 @@ class EditorViewModel(val entityId: String) : ViewModel() {
     flushDrafts()
   }
 
-  suspend fun refetchDocument() {
-    Apollo.query(EditorScreen_Query(entityId = entityId))
-      .fetchPolicy(FetchPolicy.NetworkOnly)
-      .execute()
-    query.refetch()
+  internal suspend fun refetchDocumentAfterReload() {
+    try {
+      Apollo.query(EditorScreen_Query(entityId = entityId))
+        .fetchPolicy(FetchPolicy.NetworkOnly)
+        .execute()
+      query.refetch()
+    } catch (e: CancellationException) {
+      throw e
+    } catch (e: Exception) {
+      Logger.w(e) { "EditorViewModel: document metadata refetch after reload failed" }
+      if (!e.isRecoverableNetworkError()) {
+        runCatching { Sentry.captureException(e) }
+      }
+    }
   }
 
   internal suspend fun resolveExternalAssets(ids: List<String>): List<EditorExternalAsset> {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/editorsettings/EditorSettingsSnapSlider.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/editorsettings/EditorSettingsSnapSlider.kt
@@ -48,6 +48,7 @@ import co.typie.ui.icon.Icon
 import co.typie.ui.theme.AppShapes
 import co.typie.ui.theme.AppTheme
 import kotlin.math.roundToInt
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.launch
 
 @Composable
@@ -174,7 +175,9 @@ private fun ValueBadge(
       val clamped = parsed.coerceIn(fullRange)
       val rounded =
         ((clamped.toFloat() - fullRange.first) / step).roundToInt() * step + fullRange.first
-      scope.launch { onValueChange(rounded.coerceIn(fullRange)) }
+      scope.launch(start = CoroutineStart.UNDISPATCHED) {
+        onValueChange(rounded.coerceIn(fullRange))
+      }
     }
   }
 

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/DocumentEditingSessionTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/DocumentEditingSessionTest.kt
@@ -25,6 +25,7 @@ import kotlin.test.assertTrue
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
@@ -114,7 +115,7 @@ class DocumentEditingSessionTest {
     runCurrent()
     syncEditor.known.add(1)
 
-    val result = session.beginClose().awaitCheckpoint()
+    val result = session.beginStop().awaitCheckpoint()
 
     assertEquals(EditingCheckpointResult.Protected, result)
   }
@@ -135,7 +136,7 @@ class DocumentEditingSessionTest {
     syncEditor.known.add(1)
     session.submit { _, _ -> CompletableDeferred<Unit>().apply { completeExceptionally(failure) } }
 
-    val result = session.beginClose().awaitCheckpoint()
+    val result = session.beginStop().awaitCheckpoint()
 
     assertTrue(result is EditingCheckpointResult.EditFailed)
     assertEquals(failure, result.cause)
@@ -193,7 +194,7 @@ class DocumentEditingSessionTest {
     assertNotNull(accepted)
     assertFalse(started)
 
-    val close = session.beginClose()
+    val close = session.beginStop()
     val result = async(start = CoroutineStart.UNDISPATCHED) { close.awaitCheckpoint() }
 
     assertNull(session.submit { _, context -> async(context) {} })
@@ -233,7 +234,7 @@ class DocumentEditingSessionTest {
     }
     assertNotNull(accepted)
 
-    val close = session.beginClose()
+    val close = session.beginStop()
     val result = async(start = CoroutineStart.UNDISPATCHED) { close.awaitCheckpoint() }
     runCurrent()
     assertFalse(result.isCompleted)
@@ -248,9 +249,9 @@ class DocumentEditingSessionTest {
   @Test
   fun staleCloseCannotReopenANewerClose() = runTest {
     val (_, session) = harness()
-    val first = session.beginClose()
+    val first = session.beginStop()
     first.cancel()
-    val second = session.beginClose()
+    val second = session.beginStop()
 
     first.cancel()
 
@@ -270,7 +271,7 @@ class DocumentEditingSessionTest {
         sessionEditor.await { enqueue(Message.System(SystemEvent.Initialize)) }
       }
     }
-    val close = session.beginClose()
+    val close = session.beginStop()
     val result = async(start = CoroutineStart.UNDISPATCHED) { close.awaitCheckpoint() }
 
     session.stop()
@@ -285,7 +286,7 @@ class DocumentEditingSessionTest {
   }
 
   @Test
-  fun cancelledCloseKeepsCompletedCheckpointResult() = runTest {
+  fun cancelledStopCannotReuseCompletedCheckpointResult() = runTest {
     var puts = 0
     val store = FakeDeltaStore()
     val syncEditor = FakeSyncEditor()
@@ -296,12 +297,14 @@ class DocumentEditingSessionTest {
       puts += 1
       throw IllegalStateException("disk unavailable")
     }
-    val close = session.beginClose()
+    val close = session.beginStop()
     val failure = close.awaitCheckpoint()
     close.cancel()
 
-    assertEquals(failure, close.awaitCheckpoint())
     assertTrue(failure is EditingCheckpointResult.ProtectionFailed)
+    assertEquals(EditingCheckpointResult.StopCancelled, close.awaitCheckpoint())
+    assertEquals(EditingCheckpointResult.StopCancelled, close.retryCheckpoint())
+    advanceUntilIdle()
     assertEquals(2, puts)
     assertNotNull(session.submit { _, context -> async(context) {} })
   }
@@ -317,7 +320,7 @@ class DocumentEditingSessionTest {
 
     session.submit { _, _ -> CompletableDeferred<Unit>().apply { completeExceptionally(failure) } }
 
-    val result = session.beginClose().awaitCheckpoint()
+    val result = session.beginStop().awaitCheckpoint()
 
     assertTrue(result is EditingCheckpointResult.EditFailed)
     assertEquals(failure, result.cause)
@@ -333,7 +336,7 @@ class DocumentEditingSessionTest {
     runCurrent()
     syncEditor.known.add(1)
     store.onPut = { puts += 1 }
-    val close = session.beginClose()
+    val close = session.beginStop()
 
     val first = async { close.awaitCheckpoint() }
     val second = async { close.awaitCheckpoint() }
@@ -356,7 +359,7 @@ class DocumentEditingSessionTest {
       captureGate.await()
       emptyList()
     }
-    val close = session.beginClose()
+    val close = session.beginStop()
     val first = async { close.awaitCheckpoint() }
 
     testScheduler.runCurrent()
@@ -370,5 +373,109 @@ class DocumentEditingSessionTest {
     advanceUntilIdle()
 
     assertEquals(EditingCheckpointResult.Protected, close.awaitCheckpoint())
+  }
+
+  @Test
+  fun cancellingOneOfTwoStopHandlesKeepsAdmissionClosed() = runTest {
+    val (_, session) = harness()
+    val first = session.beginStop()
+    val second = session.beginStop()
+
+    first.cancel()
+    assertNull(session.submit { _, _ -> CompletableDeferred(Unit) })
+
+    second.cancel()
+    assertNotNull(session.submit { _, _ -> CompletableDeferred(Unit) })
+  }
+
+  @Test
+  fun cancelledStopHandleCannotObserveSharedProtectedResult() = runTest {
+    val (_, session) = harness()
+    val editGate = CompletableDeferred<Unit>()
+    assertNotNull(session.submit { _, context -> async(context) { editGate.await() } })
+    val cancelled = session.beginStop()
+    val remaining = session.beginStop()
+    val cancelledResult = async { cancelled.awaitCheckpoint() }
+
+    cancelled.cancel()
+
+    assertEquals(EditingCheckpointResult.StopCancelled, cancelledResult.await())
+    editGate.complete(Unit)
+    advanceUntilIdle()
+    assertEquals(EditingCheckpointResult.Protected, remaining.awaitCheckpoint())
+    remaining.cancel()
+  }
+
+  @Test
+  fun concurrentRetriesShareOneAttemptAndKeepTheSameFrontier() = runTest {
+    var loads = 0
+    val store = FakeDeltaStore()
+    store.onLoad = {
+      loads += 1
+      emptyList()
+    }
+    store.onPut = { throw IllegalStateException("disk unavailable") }
+    val syncEditor = FakeSyncEditor()
+    val (_, session) =
+      harness(
+        store = store,
+        syncEditor = syncEditor,
+        pushFn = { throw IllegalStateException("network unavailable") },
+      )
+    runCurrent()
+    syncEditor.known.add(1)
+    val stop = session.beginStop()
+    assertTrue(stop.awaitCheckpoint() is EditingCheckpointResult.ProtectionFailed)
+    val loadsBeforeRetry = loads
+    val retryGate = CompletableDeferred<Unit>()
+    store.onLoad = {
+      loads += 1
+      retryGate.await()
+      emptyList()
+    }
+
+    val first = async { stop.retryCheckpoint() }
+    runCurrent()
+    val second = async { stop.retryCheckpoint() }
+    runCurrent()
+
+    assertEquals(loadsBeforeRetry + 1, loads)
+    assertNull(session.submit { _, _ -> CompletableDeferred(Unit) })
+
+    retryGate.complete(Unit)
+    advanceUntilIdle()
+
+    assertTrue(first.await() is EditingCheckpointResult.ProtectionFailed)
+    assertTrue(second.await() is EditingCheckpointResult.ProtectionFailed)
+    assertEquals(loadsBeforeRetry + 2, loads)
+    stop.cancel()
+  }
+
+  @Test
+  fun finalReleaseCannotReopenAdmissionBehindANewerStop() = runTest {
+    val (editor, session) = harness()
+
+    repeat(100) {
+      val first = session.beginStop()
+      val raceGate = CompletableDeferred<Unit>()
+      val release =
+        async(Dispatchers.Default) {
+          raceGate.await()
+          first.cancel()
+        }
+      val next =
+        async(Dispatchers.Default) {
+          raceGate.await()
+          session.beginStop()
+        }
+
+      raceGate.complete(Unit)
+      val second = next.await()
+      release.await()
+
+      assertNull(editor.trackLocalEdit { CompletableDeferred(Unit) })
+      second.cancel()
+      assertNotNull(session.submit { _, _ -> CompletableDeferred(Unit) })
+    }
   }
 }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/DocumentProtectedReloadTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/DocumentProtectedReloadTest.kt
@@ -1,0 +1,499 @@
+package co.typie.editor
+
+import co.typie.editor.sync.FakeDeltaStore
+import co.typie.editor.sync.FakeSyncEditor
+import co.typie.editor.sync.PullResult
+import co.typie.editor.sync.PushResult
+import co.typie.editor.sync.RemoteChangesetEvent
+import co.typie.editor.sync.RemoteChangesetPipeline
+import co.typie.editor.sync.SyncEngine
+import co.typie.editor.sync.SyncTransport
+import co.typie.editor.sync.enc
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+class DocumentProtectedReloadTest {
+  private class FakeTransport(private val pushFn: suspend (ByteArray) -> PushResult) :
+    SyncTransport {
+    override suspend fun push(changesets: ByteArray): PushResult = pushFn(changesets)
+
+    override suspend fun pull(sinceSeq: String?): PullResult =
+      PullResult(
+        changesets = emptyList(),
+        seq = "",
+        heads = enc(),
+        durableHeads = enc(),
+        needsReload = false,
+      )
+
+    override fun subscribe(sinceSeq: String?): Flow<RemoteChangesetEvent> = emptyFlow()
+  }
+
+  private data class Harness(
+    val session: DocumentEditingSession,
+    val engine: SyncEngine,
+    val syncEditor: FakeSyncEditor,
+  )
+
+  private fun TestScope.harness(
+    store: FakeDeltaStore = FakeDeltaStore(),
+    pushFn: suspend (ByteArray) -> PushResult = { PushResult(heads = enc(), durableHeads = enc()) },
+  ): Harness {
+    val syncEditor = FakeSyncEditor()
+    val scope = CoroutineScope(coroutineContext)
+    val transport = FakeTransport(pushFn)
+    val engine =
+      SyncEngine(
+        editor = syncEditor,
+        documentId = "doc",
+        initialServerHeads = enc(),
+        initialDurableHeads = enc(),
+        store = store,
+        pushFn = transport::push,
+        scope = scope,
+        now = { 0L },
+      )
+    val pipeline =
+      RemoteChangesetPipeline(
+        editor = syncEditor,
+        headsSink = engine,
+        transport = transport,
+        initialSeq = "",
+        scope = scope,
+        onNeedsReload = {},
+      )
+    val session =
+      DocumentEditingSession(
+        documentId = "doc",
+        editor = Editor(FakeFfiEditor(), this, StandardTestDispatcher(testScheduler)),
+        engine = engine,
+        pipeline = pipeline,
+        scope = scope,
+      )
+    runCurrent()
+    return Harness(session = session, engine = engine, syncEditor = syncEditor)
+  }
+
+  private fun failingStore(onPut: (suspend () -> Unit)? = null): FakeDeltaStore =
+    FakeDeltaStore().apply {
+      this.onPut = {
+        onPut?.invoke()
+        throw IllegalStateException("disk unavailable")
+      }
+    }
+
+  private suspend fun failingPush(changesets: ByteArray): PushResult {
+    throw IllegalStateException("network unavailable")
+  }
+
+  @Test
+  fun protectedFrontierReplacesWithoutFailureDecision() = runTest {
+    val (session) = harness()
+    var decisions = 0
+
+    val result =
+      runProtectedDocumentReload(
+        session = session,
+        finalizeInput = {},
+        resolveFailure = {
+          decisions += 1
+          DocumentReloadFailureDecision.Retry
+        },
+        replaceIfCurrent = {
+          it.stop()
+          true
+        },
+      )
+
+    assertEquals(DocumentProtectedReloadResult.Replaced, result)
+    assertEquals(0, decisions)
+  }
+
+  @Test
+  fun retryKeepsAdmissionClosedAndSharesTheInFlightCheckpoint() = runTest {
+    var putCalls = 0
+    val retryStarted = CompletableDeferred<Unit>()
+    val releaseRetry = CompletableDeferred<Unit>()
+    val store = failingStore {
+      putCalls += 1
+      if (putCalls >= 3) {
+        retryStarted.complete(Unit)
+        releaseRetry.await()
+      }
+    }
+    val (session, _, syncEditor) = harness(store = store, pushFn = ::failingPush)
+    syncEditor.known.add(1)
+    var decisions = 0
+    val policy =
+      async(start = CoroutineStart.UNDISPATCHED) {
+        runProtectedDocumentReload(
+          session = session,
+          finalizeInput = {},
+          resolveFailure = {
+            decisions += 1
+            if (decisions == 1) DocumentReloadFailureDecision.Retry else awaitCancellation()
+          },
+          replaceIfCurrent = { false },
+        )
+      }
+    retryStarted.await()
+
+    val observerStop = session.beginStop()
+    val observer = async { observerStop.retryCheckpoint() }
+    runCurrent()
+
+    assertEquals(3, putCalls)
+    assertNull(session.submit { _, context -> async(context) {} })
+
+    policy.cancelAndJoin()
+    assertNull(session.submit { _, context -> async(context) {} })
+    releaseRetry.complete(Unit)
+    observer.cancelAndJoin()
+    observerStop.cancel()
+    assertNotNull(session.submit { _, context -> async(context) {} }).join()
+    session.stop()
+  }
+
+  @Test
+  fun immediateRetryFailureWaitsTheCompleteProductWindow() = runTest {
+    val (session, _, syncEditor) = harness(store = failingStore(), pushFn = ::failingPush)
+    syncEditor.known.add(1)
+    var decisions = 0
+    val policy =
+      async(start = CoroutineStart.UNDISPATCHED) {
+        runProtectedDocumentReload(
+          session = session,
+          finalizeInput = {},
+          resolveFailure = {
+            decisions += 1
+            if (decisions == 1) DocumentReloadFailureDecision.Retry else awaitCancellation()
+          },
+          replaceIfCurrent = { false },
+        )
+      }
+    runCurrent()
+
+    advanceTimeBy(2_999)
+    runCurrent()
+    assertEquals(1, decisions)
+
+    advanceTimeBy(1)
+    runCurrent()
+    assertEquals(2, decisions)
+
+    policy.cancelAndJoin()
+    session.stop()
+  }
+
+  @Test
+  fun exactProtectionCancelsTheVisibleDecisionAndReplaces() = runTest {
+    val (session, engine, syncEditor) = harness(store = failingStore(), pushFn = ::failingPush)
+    syncEditor.known.add(1)
+    val dialogStarted = CompletableDeferred<Unit>()
+    var dialogCancelled = false
+    val policy =
+      async(start = CoroutineStart.UNDISPATCHED) {
+        runProtectedDocumentReload(
+          session = session,
+          finalizeInput = {},
+          resolveFailure = {
+            dialogStarted.complete(Unit)
+            try {
+              awaitCancellation()
+            } finally {
+              dialogCancelled = true
+            }
+          },
+          replaceIfCurrent = {
+            it.stop()
+            true
+          },
+        )
+      }
+    dialogStarted.await()
+
+    engine.setConfirmedHeads(enc(1))
+    runCurrent()
+
+    assertEquals(DocumentProtectedReloadResult.Replaced, policy.await())
+    assertTrue(dialogCancelled)
+  }
+
+  @Test
+  fun partialProtectionRechecksWithoutExtendingTheRecoveryWindow() = runTest {
+    val (session, engine, syncEditor) = harness(store = failingStore(), pushFn = ::failingPush)
+    syncEditor.known.addAll(listOf(1, 2, 3))
+    var decisions = 0
+    var replacements = 0
+    val firstDialog = CompletableDeferred<Unit>()
+    val policy =
+      async(start = CoroutineStart.UNDISPATCHED) {
+        runProtectedDocumentReload(
+          session = session,
+          finalizeInput = {},
+          resolveFailure = {
+            decisions += 1
+            firstDialog.complete(Unit)
+            awaitCancellation()
+          },
+          replaceIfCurrent = {
+            replacements += 1
+            false
+          },
+        )
+      }
+    firstDialog.await()
+
+    engine.setConfirmedHeads(enc(1))
+    runCurrent()
+    advanceTimeBy(1_000)
+    engine.setConfirmedHeads(enc(2))
+    runCurrent()
+    advanceTimeBy(1_999)
+    runCurrent()
+
+    assertEquals(1, decisions)
+    assertEquals(0, replacements)
+
+    advanceTimeBy(1)
+    runCurrent()
+    assertEquals(2, decisions)
+    assertEquals(0, replacements)
+
+    policy.cancelAndJoin()
+    session.stop()
+  }
+
+  @Test
+  fun discardReplacesTheExactUnprotectedSession() = runTest {
+    val (session, _, syncEditor) = harness(store = failingStore(), pushFn = ::failingPush)
+    syncEditor.known.add(1)
+
+    val result =
+      runProtectedDocumentReload(
+        session = session,
+        finalizeInput = {},
+        resolveFailure = { DocumentReloadFailureDecision.Discard },
+        replaceIfCurrent = {
+          it.stop()
+          true
+        },
+      )
+
+    assertEquals(DocumentProtectedReloadResult.Replaced, result)
+  }
+
+  @Test
+  fun cancellationReleasesOnlyTheReloadStopHandle() = runTest {
+    val (session, _, syncEditor) = harness(store = failingStore(), pushFn = ::failingPush)
+    syncEditor.known.add(1)
+    val dialogStarted = CompletableDeferred<Unit>()
+    var dialogCancelled = false
+    val policy =
+      async(start = CoroutineStart.UNDISPATCHED) {
+        runProtectedDocumentReload(
+          session = session,
+          finalizeInput = {},
+          resolveFailure = {
+            dialogStarted.complete(Unit)
+            try {
+              awaitCancellation()
+            } finally {
+              dialogCancelled = true
+            }
+          },
+          replaceIfCurrent = { false },
+        )
+      }
+    dialogStarted.await()
+    val otherStop = session.beginStop()
+
+    policy.cancelAndJoin()
+
+    assertTrue(dialogCancelled)
+    assertNull(session.submit { _, context -> async(context) {} })
+    otherStop.cancel()
+    assertNotNull(session.submit { _, context -> async(context) {} }).join()
+    session.stop()
+  }
+
+  @Test
+  fun feedbackCleanupFailureDoesNotFailReloadAndStillReleasesTheStop() = runTest {
+    val (session) = harness()
+
+    assertEquals(
+      DocumentProtectedReloadResult.NotCurrent,
+      runProtectedDocumentReload(
+        session = session,
+        finalizeInput = {},
+        hideDelayedFeedback = { error("feedback cleanup failed") },
+        resolveFailure = { error("protected frontier must not ask") },
+        replaceIfCurrent = { false },
+      ),
+    )
+
+    assertNotNull(session.submit { _, context -> async(context) {} }).join()
+    session.stop()
+  }
+
+  @Test
+  fun delayedFeedbackFailureDoesNotFailReload() = runTest {
+    val putStarted = CompletableDeferred<Unit>()
+    val releasePut = CompletableDeferred<Unit>()
+    val store = failingStore {
+      putStarted.complete(Unit)
+      releasePut.await()
+    }
+    val (session, _, syncEditor) = harness(store = store, pushFn = ::failingPush)
+    syncEditor.known.add(1)
+    var feedbackAttempts = 0
+    val policy =
+      async(start = CoroutineStart.UNDISPATCHED) {
+        runProtectedDocumentReload(
+          session = session,
+          finalizeInput = {},
+          showDelayedFeedback = {
+            feedbackAttempts += 1
+            error("feedback display failed")
+          },
+          resolveFailure = { DocumentReloadFailureDecision.Discard },
+          replaceIfCurrent = { false },
+          delayedFeedbackMillis = 10,
+          checkpointWatchdogMillis = 20,
+        )
+      }
+    putStarted.await()
+
+    advanceTimeBy(20)
+    runCurrent()
+
+    assertEquals(DocumentProtectedReloadResult.NotCurrent, policy.await())
+    assertEquals(1, feedbackAttempts)
+    releasePut.complete(Unit)
+    runCurrent()
+    assertNotNull(session.submit { _, context -> async(context) {} }).join()
+    session.stop()
+  }
+
+  @Test
+  fun failedIdentityClaimReleasesAdmissionWithoutClaimingAnotherGeneration() = runTest {
+    val (session) = harness()
+    var claims = 0
+
+    val result =
+      runProtectedDocumentReload(
+        session = session,
+        finalizeInput = {},
+        resolveFailure = { error("protected frontier must not ask") },
+        replaceIfCurrent = {
+          claims += 1
+          false
+        },
+      )
+
+    assertEquals(DocumentProtectedReloadResult.NotCurrent, result)
+    assertEquals(1, claims)
+    assertNotNull(session.submit { _, context -> async(context) {} }).join()
+    session.stop()
+  }
+
+  @Test
+  fun stopAcquisitionCallbackRunsBeforeThePolicySuspends() = runTest {
+    val putStarted = CompletableDeferred<Unit>()
+    val releasePut = CompletableDeferred<Unit>()
+    val releasePush = CompletableDeferred<Unit>()
+    val store = failingStore {
+      putStarted.complete(Unit)
+      releasePut.await()
+    }
+    val (session, _, syncEditor) =
+      harness(
+        store = store,
+        pushFn = {
+          releasePush.await()
+          failingPush(it)
+        },
+      )
+    syncEditor.known.add(1)
+    val events = mutableListOf<String>()
+
+    val policy =
+      async(start = CoroutineStart.UNDISPATCHED) {
+        runProtectedDocumentReload(
+          session = session,
+          finalizeInput = { events += "finalize" },
+          onStopAcquired = { events += "acquired" },
+          resolveFailure = { awaitCancellation() },
+          replaceIfCurrent = { false },
+        )
+      }
+    putStarted.await()
+
+    assertEquals(listOf("finalize", "acquired"), events)
+    assertFalse(policy.isCompleted)
+
+    policy.cancelAndJoin()
+    releasePut.complete(Unit)
+    releasePush.complete(Unit)
+    runCurrent()
+    session.stop()
+  }
+
+  @Test
+  fun protectionAdvanceDuringAFailedAttemptIsObservedFromThePreAttemptCursor() = runTest {
+    var putCalls = 0
+    val firstPutStarted = CompletableDeferred<Unit>()
+    val releaseFirstPut = CompletableDeferred<Unit>()
+    val retryStarted = CompletableDeferred<Unit>()
+    val store = failingStore {
+      putCalls += 1
+      when (putCalls) {
+        1 -> {
+          firstPutStarted.complete(Unit)
+          releaseFirstPut.await()
+        }
+        3 -> retryStarted.complete(Unit)
+      }
+    }
+    val (session, engine, syncEditor) = harness(store = store, pushFn = ::failingPush)
+    syncEditor.known.addAll(listOf(1, 2))
+    val policy =
+      async(start = CoroutineStart.UNDISPATCHED) {
+        runProtectedDocumentReload(
+          session = session,
+          finalizeInput = {},
+          resolveFailure = { awaitCancellation() },
+          replaceIfCurrent = { false },
+        )
+      }
+    firstPutStarted.await()
+
+    engine.setConfirmedHeads(enc(1))
+    releaseFirstPut.complete(Unit)
+    retryStarted.await()
+
+    assertTrue(putCalls >= 3)
+    assertNull(session.submit { _, context -> async(context) {} })
+
+    policy.cancelAndJoin()
+    session.stop()
+  }
+}

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/FakeFfiEditor.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/FakeFfiEditor.kt
@@ -58,6 +58,8 @@ internal class FakeFfiEditor(
   var tableOverlaysProvider: () -> List<TableOverlay> = { emptyList() },
   var imeProvider: (Int, Int) -> Ime? = { _, _ -> EmptyIme },
   var lastHistoryTagProvider: () -> HistoryTag? = { null },
+  var currentHeadsProvider: () -> ByteArray = { ByteArray(0) },
+  var localChangesetsSinceProvider: (ByteArray) -> ByteArray = { ByteArray(0) },
   var selectionHitProvider: (Int, Float, Float) -> Boolean = { _, _, _ -> false },
   var cursorHitProvider: (Int, Float, Float) -> Boolean = { _, _, _ -> false },
   var interactiveHitProvider: (Int, Float, Float) -> InteractiveHit? = { _, _, _ -> null },
@@ -67,6 +69,7 @@ internal class FakeFfiEditor(
     { _, _ ->
       emptyList()
     },
+  var receiveRemoteChangesetProvider: (ByteArray) -> Unit = {},
   var detachSurfaceProvider: (Int) -> Unit = {},
   var renderSurfaceProvider: (Int) -> Boolean = { true },
 ) : co.typie.editor.ffi.Editor {
@@ -193,9 +196,12 @@ internal class FakeFfiEditor(
 
   override fun inspectStateAsMacro(): String = ""
 
-  override fun receiveRemoteChangeset(payload: ByteArray) = Unit
+  override fun receiveRemoteChangeset(payload: ByteArray) {
+    receiveRemoteChangesetProvider(payload)
+  }
 
-  override fun localChangesetsSince(remoteHeadsPayload: ByteArray): ByteArray = ByteArray(0)
+  override fun localChangesetsSince(remoteHeadsPayload: ByteArray): ByteArray =
+    localChangesetsSinceProvider(remoteHeadsPayload)
 
   override fun changesetIds(): List<String> = emptyList()
 
@@ -207,7 +213,7 @@ internal class FakeFfiEditor(
 
   override fun splitChangesets(payload: ByteArray): List<ChangesetEntry> = emptyList()
 
-  override fun currentHeads(): ByteArray = ByteArray(0)
+  override fun currentHeads(): ByteArray = currentHeadsProvider()
 
   override fun setDoc(plain: PlainDoc) = Unit
 

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/runtime/EditorRuntimeTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/runtime/EditorRuntimeTest.kt
@@ -9,10 +9,13 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class EditorRuntimeTest {
   private fun TestScope.createSession(editor: Editor): DocumentEditingSession =
     createTestDocumentEditingSession(editor, CoroutineScope(coroutineContext))
@@ -87,5 +90,21 @@ class EditorRuntimeTest {
     runtime.clear(second)
     assertNull(runtime.editor)
     assertNull(runtime.session)
+  }
+
+  @Test
+  fun staleSessionErrorCannotClearReplacement() = runTest {
+    val first = createSession(Editor(FakeFfiEditor(), this, StandardTestDispatcher(testScheduler)))
+    val second = createSession(Editor(FakeFfiEditor(), this, StandardTestDispatcher(testScheduler)))
+    val runtime = EditorRuntime(uiScope = this)
+
+    runtime.attach(first)
+    runtime.reportError(first, IllegalStateException("stale reload failure"))
+    runtime.attach(second)
+    runCurrent()
+
+    assertSame(second.editor, runtime.editor)
+    assertSame(second, runtime.session)
+    assertNull(runtime.error)
   }
 }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/sync/SyncEngineTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/sync/SyncEngineTest.kt
@@ -44,6 +44,76 @@ class SyncEngineTest {
     )
 
   @Test
+  fun confirmedHeadAdvanceWakesProtectionWaiter() = runTest {
+    val engine =
+      engine(FakeSyncEditor(), FakeDeltaStore()) { PushResult(heads = enc(), durableHeads = enc()) }
+    val observed = engine.protectionGeneration
+    val waiter = async { engine.awaitProtectionAfter(observed) }
+
+    engine.setConfirmedHeads(enc(1))
+
+    assertTrue(waiter.await())
+    engine.stop()
+  }
+
+  @Test
+  fun identicalConfirmedHeadsDoNotAdvanceProtectionGeneration() = runTest {
+    val engine =
+      engine(FakeSyncEditor(), FakeDeltaStore()) { PushResult(heads = enc(), durableHeads = enc()) }
+    engine.setConfirmedHeads(enc(1))
+    val observed = engine.protectionGeneration
+
+    engine.setConfirmedHeads(enc(1))
+
+    assertEquals(observed, engine.protectionGeneration)
+    engine.stop()
+  }
+
+  @Test
+  fun localCaptureWakesProtectionWaiter() = runTest {
+    val syncEditor = FakeSyncEditor()
+    val engine =
+      engine(syncEditor, FakeDeltaStore()) { PushResult(heads = enc(), durableHeads = enc()) }
+    runCurrent()
+    syncEditor.known.add(1)
+    val observed = engine.protectionGeneration
+    val waiter = async { engine.awaitProtectionAfter(observed) }
+
+    engine.captureNow()
+
+    assertTrue(waiter.await())
+    engine.stop()
+  }
+
+  @Test
+  fun durableHeadAdvanceDoesNotWakeProtectionWaiter() = runTest {
+    val engine =
+      engine(FakeSyncEditor(), FakeDeltaStore()) { PushResult(heads = enc(), durableHeads = enc()) }
+    val observed = engine.protectionGeneration
+    val waiter = async { engine.awaitProtectionAfter(observed) }
+
+    engine.setDurableHeads(enc(1))
+    runCurrent()
+
+    assertFalse(waiter.isCompleted)
+    waiter.cancel()
+    engine.stop()
+  }
+
+  @Test
+  fun stopTerminatesProtectionWaiterWithoutAdvancingProof() = runTest {
+    val engine =
+      engine(FakeSyncEditor(), FakeDeltaStore()) { PushResult(heads = enc(), durableHeads = enc()) }
+    val observed = engine.protectionGeneration
+    val waiter = async { engine.awaitProtectionAfter(observed) }
+
+    engine.stop()
+
+    assertFalse(waiter.await())
+    assertEquals(observed, engine.protectionGeneration)
+  }
+
+  @Test
   fun checkpointReturnsFailureWhenFrontierInspectionFails() = runTest {
     val failure = IllegalStateException("editor unavailable")
     val baseEditor = FakeSyncEditor()

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/sync/ws/AttachEventReloadTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/sync/ws/AttachEventReloadTest.kt
@@ -1,0 +1,23 @@
+package co.typie.editor.sync.ws
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class AttachEventReloadTest {
+  @Test
+  fun reloadEventsDescribeWhetherAReplacementSnapshotAlreadyStarted() {
+    assertEquals(true, AttachEvent.SnapshotRestart.replacementSnapshotInFlight())
+    assertEquals(true, AttachEvent.ReloadEvent.replacementSnapshotInFlight())
+    assertEquals(false, AttachEvent.PermanentErrorEvent("forbidden").replacementSnapshotInFlight())
+    assertNull(
+      AttachEvent.ChangesetsEvent(
+          seq = "1",
+          bundles = emptyList(),
+          heads = byteArrayOf(),
+          durableHeads = byteArrayOf(),
+        )
+        .replacementSnapshotInFlight()
+    )
+  }
+}

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/sync/ws/DocumentWsChannelTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/sync/ws/DocumentWsChannelTest.kt
@@ -363,10 +363,7 @@ class DocumentWsChannelTest {
     socket0.serverSend(snapshotEnd("6-0"))
     socket0.serverSend(changesets("7-0", emptyList()))
     runCurrent()
-    assertEquals(
-      listOf(endS("6-0"), changesetsS("7-0", emptyList())),
-      events.snapshots(),
-    )
+    assertEquals(listOf(endS("6-0"), changesetsS("7-0", emptyList())), events.snapshots())
 
     socket0.serverClose(1006)
     advanceTimeBy(1_000)
@@ -392,6 +389,44 @@ class DocumentWsChannelTest {
 
     assertEquals(1, socket.sent.count { it is WsClientMessage.Attach })
     assertTrue(socket.sent.none { it is WsClientMessage.Detach })
+  }
+
+  @Test
+  fun retryFreshRestartsOneGenerationForAllActiveSubscribers() = runTest {
+    val (_, channel, sockets) = harness()
+    val firstEvents = mutableListOf<AttachEvent>()
+    val secondEvents = mutableListOf<AttachEvent>()
+    val firstJob = collectJob(channel.freshSubscribe(), firstEvents)
+    collectJob(channel.events, secondEvents)
+    runCurrent()
+    val socket = sockets[0]
+    handshake(socket)
+    socket.serverSend(WsServerMessage.AttachAck(documentId = DOC_ID))
+    socket.serverSend(snapshotEnd("1-0"))
+    runCurrent()
+    firstEvents.clear()
+    secondEvents.clear()
+
+    channel.retryFresh()
+    runCurrent()
+
+    assertEquals(listOf(EventSnapshot.Restart), firstEvents.snapshots())
+    assertEquals(listOf(EventSnapshot.Restart), secondEvents.snapshots())
+    assertEquals(1, socket.sent.count { it is WsClientMessage.Detach })
+    assertEquals(2, socket.sent.count { it is WsClientMessage.Attach })
+
+    socket.serverSend(WsServerMessage.AttachAck(documentId = DOC_ID))
+    socket.serverSend(chunk("B2", 2, 0, byteArrayOf(2)))
+    socket.serverSend(snapshotEnd("2-0"))
+    runCurrent()
+
+    val replacement = listOf(EventSnapshot.Restart, chunkS("B2", 2, 0, byteArrayOf(2)), endS("2-0"))
+    assertEquals(replacement, firstEvents.snapshots())
+    assertEquals(replacement, secondEvents.snapshots())
+
+    firstJob.cancel()
+    runCurrent()
+    assertEquals(1, socket.sent.count { it is WsClientMessage.Detach })
   }
 
   @Test

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/document/bodysettings/DocumentBodySettingsSyncTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/document/bodysettings/DocumentBodySettingsSyncTest.kt
@@ -1,0 +1,223 @@
+package co.typie.screen.document.bodysettings
+
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import co.typie.editor.Editor
+import co.typie.editor.EditorLocalChangesetBus
+import co.typie.editor.FakeFfiEditor
+import co.typie.editor.ffi.EditorEvent
+import co.typie.editor.ffi.LayoutMode
+import co.typie.editor.ffi.Message
+import co.typie.editor.ffi.Modifier as EditorModifier
+import co.typie.editor.ffi.PlainRootNode
+import co.typie.editor.ffi.StateField
+import co.typie.editor.ffi.SystemEvent
+import co.typie.editor.sync.PullResult
+import co.typie.editor.sync.PushResult
+import co.typie.editor.sync.RemoteChangesetEvent
+import co.typie.editor.sync.RemoteChangesetPipeline
+import co.typie.editor.sync.SyncHeadsSink
+import co.typie.editor.sync.SyncTransport
+import co.typie.editor.sync.asSyncEditor
+import co.typie.editor.sync.ws.AttachEvent
+import co.typie.editor.sync.ws.DocumentSyncBaseline
+import co.typie.result.Result
+import co.typie.ui.component.editorsettings.EditorStyleSettings
+import co.typie.ui.component.editorsettings.toEditorStyleSettings
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+
+class DocumentBodySettingsSyncTest {
+  @Test
+  fun bodySettingsEditPublishesLocalChangesetsForAnotherOpenEditor() = runTest {
+    val entityId = "body-settings-local-relay"
+    val changesets = byteArrayOf(7, 8)
+    var heads = byteArrayOf(1)
+    val editor =
+      Editor(
+        FakeFfiEditor(
+          onTick = {
+            heads = byteArrayOf(2)
+            emptyList()
+          },
+          currentHeadsProvider = { heads },
+          localChangesetsSinceProvider = { baseHeads ->
+            assertContentEquals(byteArrayOf(1), baseHeads)
+            changesets
+          },
+        ),
+        backgroundScope,
+        StandardTestDispatcher(testScheduler),
+      )
+    val store = ViewModelStore()
+    val provider =
+      ViewModelProvider.create(
+        store = store,
+        factory = viewModelFactory { initializer { DocumentBodySettingsViewModel(entityId) } },
+      )
+    val model = provider[DocumentBodySettingsViewModel::class]
+
+    EditorLocalChangesetBus.consume(entityId)
+    try {
+      val result =
+        model.applyAndRelayBodySettings(editor) {
+          enqueue(Message.System(SystemEvent.SetFocused(false)))
+        }
+
+      assertIs<Result.Ok<Unit>>(result)
+      assertContentEquals(changesets, EditorLocalChangesetBus.consume(entityId).single())
+    } finally {
+      store.clear()
+      editor.dispose()
+      EditorLocalChangesetBus.consume(entityId)
+    }
+  }
+
+  @Test
+  fun bootstrapAndInstalledLiveSinkApplyEachBundleOnceAndProjectRootState() = runTest {
+    val load =
+      DocumentBodySettingsLoad(
+        graph = byteArrayOf(0),
+        baseline =
+          DocumentSyncBaseline(seq = "1-0", heads = byteArrayOf(1), durableHeads = byteArrayOf(1)),
+      )
+    val bootstrap = changesetsEvent(seq = "2-0", value = 2)
+    val queuedDuringDrain = changesetsEvent(seq = "3-0", value = 3)
+    val received = mutableListOf<Int>()
+    var currentValue = 0
+    val ffi =
+      FakeFfiEditor(
+        receiveRemoteChangesetProvider = { payload ->
+          currentValue = payload.single().toInt()
+          received += currentValue
+        },
+        onTick = { listOf(EditorEvent.StateChanged(listOf(StateField.Doc))) },
+        rootAttrsProvider = {
+          PlainRootNode(layoutMode = LayoutMode.Continuous(maxWidth = 600 + currentValue))
+        },
+        rootModifiersProvider = { listOf(EditorModifier.FontSize(1200 + currentValue)) },
+      )
+    val editor = Editor(ffi, backgroundScope, StandardTestDispatcher(testScheduler))
+    val transport = RecordingTransport()
+    val sink = RecordingHeadsSink()
+    var pipeline: RemoteChangesetPipeline? = null
+    var liveBaseline: DocumentSyncBaseline? = null
+
+    assertTrue(load.queue(bootstrap))
+    load.activate(
+      apply = { event ->
+        event.bundles.forEach { editor.receiveRemoteChangeset(it) }
+        if (event.seq == "2-0") assertTrue(load.queue(queuedDuringDrain))
+      },
+      startLive = { baseline ->
+        liveBaseline = baseline
+        pipeline =
+          RemoteChangesetPipeline(
+              editor = editor.asSyncEditor(),
+              headsSink = sink,
+              transport = transport,
+              initialSeq = baseline.seq,
+              scope = backgroundScope,
+              onNeedsReload = {},
+            )
+            .also { it.start() }
+      },
+    )
+
+    runCurrent()
+    transport.subscriptionEvents.send(remoteEvent(seq = "4-0", value = 4))
+    runCurrent()
+
+    assertEquals(listOf(2, 3, 4), received)
+    assertEquals("3-0", liveBaseline?.seq)
+    assertContentEquals(byteArrayOf(3), liveBaseline?.heads)
+    assertEquals(listOf<String?>("3-0"), transport.subscribeCalls)
+    assertEquals(LayoutMode.Continuous(maxWidth = 604), editor.rootAttrs?.layoutMode)
+    assertEquals(EditorStyleSettings(fontSize = 1204), editor.rootModifiers.toEditorStyleSettings())
+
+    pipeline?.stop()
+    editor.dispose()
+  }
+
+  @Test
+  fun rootModifiersProjectAllSupportedBodySettings() {
+    val modifiers =
+      listOf(
+        EditorModifier.FontFamily("RIDIBatang"),
+        EditorModifier.FontSize(1500),
+        EditorModifier.FontWeight(700),
+        EditorModifier.LetterSpacing(10),
+        EditorModifier.LineHeight(180),
+        EditorModifier.ParagraphIndent(120),
+        EditorModifier.BlockGap(140),
+      )
+
+    assertEquals(
+      EditorStyleSettings(
+        fontFamily = "RIDIBatang",
+        fontSize = 1500,
+        fontWeight = 700,
+        letterSpacing = 10,
+        lineHeight = 180,
+        paragraphIndent = 120,
+        blockGap = 140,
+      ),
+      modifiers.toEditorStyleSettings(),
+    )
+  }
+
+  private fun changesetsEvent(seq: String, value: Int) =
+    AttachEvent.ChangesetsEvent(
+      seq = seq,
+      bundles = listOf(byteArrayOf(value.toByte())),
+      heads = byteArrayOf(value.toByte()),
+      durableHeads = byteArrayOf(value.toByte()),
+    )
+
+  private fun remoteEvent(seq: String, value: Int) =
+    RemoteChangesetEvent(
+      changesets = listOf(byteArrayOf(value.toByte())),
+      seq = seq,
+      heads = byteArrayOf(value.toByte()),
+      durableHeads = byteArrayOf(value.toByte()),
+    )
+}
+
+private class RecordingTransport : SyncTransport {
+  val subscriptionEvents = Channel<RemoteChangesetEvent>(Channel.UNLIMITED)
+  val subscribeCalls = mutableListOf<String?>()
+
+  override suspend fun push(changesets: ByteArray): PushResult =
+    PushResult(heads = ByteArray(0), durableHeads = ByteArray(0))
+
+  override suspend fun pull(sinceSeq: String?): PullResult =
+    PullResult(
+      changesets = emptyList(),
+      seq = sinceSeq.orEmpty(),
+      heads = ByteArray(0),
+      durableHeads = ByteArray(0),
+      needsReload = false,
+    )
+
+  override fun subscribe(sinceSeq: String?): Flow<RemoteChangesetEvent> {
+    subscribeCalls += sinceSeq
+    return flow { for (event in subscriptionEvents) emit(event) }
+  }
+}
+
+private class RecordingHeadsSink : SyncHeadsSink {
+  override fun setConfirmedHeads(heads: ByteArray) = Unit
+
+  override fun setDurableHeads(heads: ByteArray) = Unit
+}

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/EditorRouteLeaveInterceptorTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/EditorRouteLeaveInterceptorTest.kt
@@ -1,6 +1,6 @@
 package co.typie.screen.editor.editor
 
-import co.typie.editor.DocumentEditingClose
+import co.typie.editor.DocumentEditingStop
 import co.typie.editor.EditingCheckpointResult
 import co.typie.navigation.RouteRemovalDecision
 import co.typie.navigation.RouteRemovalPreparation
@@ -8,10 +8,13 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.currentTime
 import kotlinx.coroutines.test.runCurrent
@@ -45,7 +48,7 @@ class EditorRouteLeaveInterceptorTest {
       EditorRouteLeaveInterceptor(
         finalizeInput = {},
         restoreInput = { restored++ },
-        beginClose = { throw failure },
+        beginStop = { throw failure },
         resolveDecision = { RouteRemovalDecision.CancelRemoval },
       )
 
@@ -68,9 +71,11 @@ class EditorRouteLeaveInterceptorTest {
       EditorRouteLeaveInterceptor(
         finalizeInput = {},
         restoreInput = {},
-        beginClose = {
-          object : DocumentEditingClose {
+        beginStop = {
+          object : DocumentEditingStop {
             override suspend fun awaitCheckpoint(): EditingCheckpointResult = awaitCancellation()
+
+            override suspend fun retryCheckpoint(): EditingCheckpointResult = awaitCancellation()
 
             override fun cancel() = Unit
           }
@@ -191,6 +196,221 @@ class EditorRouteLeaveInterceptorTest {
 
     assertEquals(RouteRemovalPreparation.NeedsDecision, interceptor.prepare())
   }
+
+  @Test
+  fun routeAcquiresItsStopBeforeSuspendingReload() = runTest {
+    var routeOwnsStop = false
+    val interceptor =
+      EditorRouteLeaveInterceptor(
+        finalizeInput = {},
+        restoreInput = {},
+        beginStop = {
+          routeOwnsStop = true
+          object : DocumentEditingStop {
+            override suspend fun awaitCheckpoint() = EditingCheckpointResult.Protected
+
+            override suspend fun retryCheckpoint() = EditingCheckpointResult.Protected
+
+            override fun cancel() {
+              routeOwnsStop = false
+            }
+          }
+        },
+        onPreparationStarted = { assertTrue(routeOwnsStop) },
+        resolveDecision = { RouteRemovalDecision.CancelRemoval },
+      )
+
+    assertEquals(RouteRemovalPreparation.Ready, interceptor.prepare())
+    assertTrue(routeOwnsStop)
+  }
+
+  @Test
+  fun rollbackRestartsPendingReloadBeforeReleasingRouteStop() = runTest {
+    var routeOwnsStop = false
+    var reloadOwnsStop = false
+    var restored = 0
+    val interceptor =
+      EditorRouteLeaveInterceptor(
+        finalizeInput = {},
+        restoreInput = { restored += 1 },
+        beginStop = {
+          routeOwnsStop = true
+          object : DocumentEditingStop {
+            override suspend fun awaitCheckpoint() =
+              EditingCheckpointResult.ProtectionFailed(IllegalStateException("unprotected"))
+
+            override suspend fun retryCheckpoint() = awaitCheckpoint()
+
+            override fun cancel() {
+              assertTrue(reloadOwnsStop)
+              routeOwnsStop = false
+            }
+          }
+        },
+        resumeReloadBeforeRollback = {
+          assertTrue(routeOwnsStop)
+          reloadOwnsStop = true
+          true
+        },
+        resolveDecision = { RouteRemovalDecision.CancelRemoval },
+      )
+    assertEquals(RouteRemovalPreparation.NeedsDecision, interceptor.prepare())
+
+    interceptor.rollback()
+
+    assertFalse(routeOwnsStop)
+    assertTrue(reloadOwnsStop)
+    assertEquals(0, restored)
+  }
+
+  @Test
+  fun rollbackRestoresInputOnceWhenThereIsNoPendingReload() = runTest {
+    var restored = 0
+    val interceptor =
+      interceptor(
+        awaitResult = {
+          EditingCheckpointResult.ProtectionFailed(IllegalStateException("unprotected"))
+        },
+        restoreInput = { restored += 1 },
+        resumeReloadBeforeRollback = { false },
+      )
+    assertEquals(RouteRemovalPreparation.NeedsDecision, interceptor.prepare())
+
+    interceptor.rollback()
+    interceptor.rollback()
+
+    assertEquals(1, restored)
+  }
+
+  @Test
+  fun failedReloadResumeCleansUpRouteOwnershipBeforePropagating() = runTest {
+    val checkpoint = CompletableDeferred<EditingCheckpointResult>()
+    val failure = IllegalStateException("reload launch failed")
+    var cancelled = false
+    var hidden = false
+    var restored = false
+    val interceptor =
+      interceptor(
+        awaitResult = { checkpoint.await() },
+        onCancel = {
+          cancelled = true
+          checkpoint.complete(EditingCheckpointResult.StopCancelled)
+        },
+        restoreInput = { restored = true },
+        delayedFeedbackMillis = 10,
+        checkpointWatchdogMillis = 30,
+        showDelayedFeedback = {},
+        hideDelayedFeedback = { hidden = true },
+        resumeReloadBeforeRollback = { throw failure },
+      )
+    val preparation = async { interceptor.prepare(onDelayed = {}) }
+    advanceTimeBy(10)
+    runCurrent()
+
+    assertEquals(failure, assertFailsWith<IllegalStateException> { interceptor.rollback() })
+
+    assertTrue(cancelled)
+    assertTrue(hidden)
+    assertTrue(restored)
+    assertEquals(RouteRemovalPreparation.NeedsDecision, preparation.await())
+  }
+
+  @Test
+  fun cancelledReloadLaunchReturnsFalseAndRestoresInput() = runTest {
+    val reloadAcquired = CompletableDeferred<Boolean>()
+    var restored = 0
+    val interceptor =
+      interceptor(
+        awaitResult = {
+          EditingCheckpointResult.ProtectionFailed(IllegalStateException("unprotected"))
+        },
+        restoreInput = { restored += 1 },
+        resumeReloadBeforeRollback = { reloadAcquired.await() },
+      )
+    assertEquals(RouteRemovalPreparation.NeedsDecision, interceptor.prepare())
+    val rollback = async { interceptor.rollback() }
+    runCurrent()
+    assertFalse(rollback.isCompleted)
+
+    reloadAcquired.complete(false)
+    rollback.await()
+
+    assertEquals(1, restored)
+  }
+
+  @Test
+  fun cancelledPreparationRestartsPendingReloadBeforeReleasingRouteStop() = runTest {
+    var routeOwnsStop = false
+    var reloadOwnsStop = false
+    var restored = 0
+    val interceptor =
+      EditorRouteLeaveInterceptor(
+        finalizeInput = {},
+        restoreInput = { restored += 1 },
+        beginStop = {
+          routeOwnsStop = true
+          object : DocumentEditingStop {
+            override suspend fun awaitCheckpoint(): EditingCheckpointResult = awaitCancellation()
+
+            override suspend fun retryCheckpoint(): EditingCheckpointResult = awaitCancellation()
+
+            override fun cancel() {
+              assertTrue(reloadOwnsStop)
+              routeOwnsStop = false
+            }
+          }
+        },
+        onPreparationStarted = {},
+        resumeReloadBeforeRollback = {
+          assertTrue(routeOwnsStop)
+          reloadOwnsStop = true
+          true
+        },
+        resolveDecision = { RouteRemovalDecision.CancelRemoval },
+      )
+    val preparation = async(start = CoroutineStart.UNDISPATCHED) { interceptor.prepare() }
+
+    preparation.cancelAndJoin()
+
+    assertFalse(routeOwnsStop)
+    assertTrue(reloadOwnsStop)
+    assertEquals(0, restored)
+  }
+
+  @Test
+  fun cancellationDuringReloadHandoffFinishesHandoffBeforeReleasingRouteStop() = runTest {
+    val handoffCanFinish = CompletableDeferred<Unit>()
+    val ownershipEvents = mutableListOf<String>()
+    val interceptor =
+      EditorRouteLeaveInterceptor(
+        finalizeInput = {},
+        restoreInput = { ownershipEvents += "input restored" },
+        beginStop = {
+          object : DocumentEditingStop {
+            override suspend fun awaitCheckpoint(): EditingCheckpointResult = awaitCancellation()
+
+            override suspend fun retryCheckpoint(): EditingCheckpointResult = awaitCancellation()
+
+            override fun cancel() {
+              ownershipEvents += "route released"
+            }
+          }
+        },
+        onPreparationStarted = { handoffCanFinish.await() },
+        resumeReloadBeforeRollback = {
+          ownershipEvents += "reload resumed"
+          true
+        },
+        resolveDecision = { RouteRemovalDecision.CancelRemoval },
+      )
+    val preparation = async(start = CoroutineStart.UNDISPATCHED) { interceptor.prepare() }
+
+    preparation.cancel()
+    handoffCanFinish.complete(Unit)
+    preparation.join()
+
+    assertEquals(listOf("reload resumed", "route released"), ownershipEvents)
+  }
 }
 
 private fun interceptor(
@@ -201,13 +421,16 @@ private fun interceptor(
   checkpointWatchdogMillis: Long = 3_000,
   showDelayedFeedback: () -> Unit = {},
   hideDelayedFeedback: () -> Unit = {},
+  resumeReloadBeforeRollback: suspend () -> Boolean = { false },
 ): EditorRouteLeaveInterceptor =
   EditorRouteLeaveInterceptor(
     finalizeInput = {},
     restoreInput = restoreInput,
-    beginClose = {
-      object : DocumentEditingClose {
+    beginStop = {
+      object : DocumentEditingStop {
         override suspend fun awaitCheckpoint(): EditingCheckpointResult = awaitResult()
+
+        override suspend fun retryCheckpoint(): EditingCheckpointResult = awaitResult()
 
         override fun cancel() {
           onCancel()
@@ -219,4 +442,5 @@ private fun interceptor(
     checkpointWatchdogMillis = checkpointWatchdogMillis,
     showDelayedFeedback = showDelayedFeedback,
     hideDelayedFeedback = hideDelayedFeedback,
+    resumeReloadBeforeRollback = resumeReloadBeforeRollback,
   )

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/sync/DocumentEditingDurabilityIntegrationTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/sync/DocumentEditingDurabilityIntegrationTest.kt
@@ -50,7 +50,7 @@ class DocumentEditingDurabilityIntegrationTest {
       }
       assertNotNull(edit)
 
-      assertEquals(EditingCheckpointResult.Protected, session.beginClose().awaitCheckpoint())
+      assertEquals(EditingCheckpointResult.Protected, session.beginStop().awaitCheckpoint())
       assertEquals(listOf("1"), store.load("doc").map { it.id })
       session.stop()
       ActiveDocumentEditingSessions.unregister(session)

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/sync/ws/SyncWsTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/sync/ws/SyncWsTest.kt
@@ -1,20 +1,18 @@
 package co.typie.editor.sync.ws
 
 import kotlin.test.Test
-import kotlin.test.assertNotSame
 import kotlin.test.assertSame
 
 class SyncWsTest {
   @Test
-  fun retryDocumentEvictsRegistryEntrySoNextLookupCreatesFreshChannel() {
+  fun retryDocumentKeepsTheSharedChannelIdentity() {
     val documentId = "SYNC-WS-RETRY-TEST"
     val first = SyncWs.channel(documentId)
     assertSame(first, SyncWs.channel(documentId))
 
     SyncWs.retryDocument(documentId)
 
-    val second = SyncWs.channel(documentId)
-    assertNotSame(first, second)
+    assertSame(first, SyncWs.channel(documentId))
 
     SyncWs.retryDocument(documentId)
   }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/EditorRouteRemovalNavigationStackDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/EditorRouteRemovalNavigationStackDesktopTest.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.dp
-import co.typie.editor.DocumentEditingClose
+import co.typie.editor.DocumentEditingStop
 import co.typie.editor.EditingCheckpointResult
 import co.typie.editor.EditorLocalEditCoordinator
 import co.typie.route.Route
@@ -40,9 +40,9 @@ class EditorRouteRemovalNavigationStackDesktopTest {
       EditorRouteLeaveInterceptor(
         finalizeInput = {},
         restoreInput = {},
-        beginClose = {
+        beginStop = {
           val quiescence = localEdits.quiesce()
-          object : DocumentEditingClose {
+          object : DocumentEditingStop {
             override suspend fun awaitCheckpoint(): EditingCheckpointResult {
               barrierStarted.complete(Unit)
               val editResult = quiescence.await()
@@ -53,6 +53,8 @@ class EditorRouteRemovalNavigationStackDesktopTest {
                 onFailure = { EditingCheckpointResult.EditFailed(it) },
               )
             }
+
+            override suspend fun retryCheckpoint(): EditingCheckpointResult = awaitCheckpoint()
 
             override fun cancel() {
               quiescence.resume()


### PR DESCRIPTION
## 요약
- 에디터 route-leave 가드처럼 reload 중에도 local DB capture를 보장할 수 있도록 함
- 에디터와 본문 설정 둘 다 대칭적으로 고침. 본문 설정도 이제 에디터처럼 동기화함

## 상세
- DocumentEditingSession이 여러 route leave·reload 호출자의 stop intent와 동일한 quiesced frontier를 함께 관리하도록 변경
- 메인 에디터와 본문 설정이 exact local capture 또는 server live ack를 확인한 뒤에만 현재 session을 교체하도록 protected reload 정책 통일
- 보호 실패 시 reload는 편집을 멈춘 상태로 다시 시도하거나 명시적으로 변경사항을 버리도록 하고, route leave는 기존처럼 계속 편집하거나 저장하지 않고 닫을 수 있도록 intent별 UX 유지
- route leave와 reload가 겹쳐도 하나의 작업 취소가 편집 admission을 잘못 다시 열거나 replacement session에 영향을 주지 않도록 stop ownership과 session identity 검증 보강
- 본문 설정에 기존 SyncEngine과 RemoteChangesetPipeline을 연결해 다른 기기의 root layout·style 변경을 control과 preview에 실시간 반영
- snapshot에서 live changeset으로 전환하는 동안 도착한 변경을 정확히 한 번 적용하고, 같은 프로세스 editor를 위한 EditorLocalChangesetBus relay는 유지
- 활성 consumer가 공유하는 document channel identity를 유지한 채 replacement snapshot generation만 다시 시작하도록 reload 경로 정리
- 숫자 입력의 focus-loss commit, delayed feedback, reload 후 metadata refetch의 실패 경계를 보완하고 관련 회귀 테스트 추가