### PR TITLE
앱 검색/관련 노트/코멘트 종료 시 에디터 selection과 focus 복원

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteCard.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteCard.kt
@@ -128,6 +128,7 @@ internal fun NoteCard(
   onCollapse: () -> Unit,
   onContentChange: (String) -> Unit,
   onBlur: () -> Unit,
+  onInputFocused: () -> Unit = {},
   onToggleStatus: () -> Unit,
   onColorChange: (String) -> Unit,
   onAddEntity: () -> Unit,
@@ -215,6 +216,7 @@ internal fun NoteCard(
           onCollapse = onCollapse,
           onContentChange = onContentChange,
           onBlur = onBlur,
+          onInputFocused = onInputFocused,
           onToggleStatus = onToggleStatus,
           onColorChange = onColorChange,
           onAddEntity = onAddEntity,
@@ -247,6 +249,7 @@ private fun NoteExpandedContent(
   onCollapse: () -> Unit,
   onContentChange: (String) -> Unit,
   onBlur: () -> Unit,
+  onInputFocused: () -> Unit,
   onToggleStatus: () -> Unit,
   onColorChange: (String) -> Unit,
   onAddEntity: () -> Unit,
@@ -276,6 +279,7 @@ private fun NoteExpandedContent(
             content = content,
             onValueChange = onContentChange,
             onBlur = onBlur,
+            onInputFocused = onInputFocused,
             readOnly = !contentEditable,
           )
         }
@@ -674,16 +678,16 @@ private fun NoteCollapsedMetaRow(note: NoteCard_note) {
 
     val trailingWidth =
       buildList {
-        overflowPlaceable?.let { add(it.width) }
-        separatorPlaceable?.let { add(it.width) }
-        add(timePlaceable.width)
-      }
+          overflowPlaceable?.let { add(it.width) }
+          separatorPlaceable?.let { add(it.width) }
+          add(timePlaceable.width)
+        }
         .sum() +
         spacingPx *
           (buildList {
-            overflowPlaceable?.let { add(Unit) }
-            separatorPlaceable?.let { add(Unit) }
-          }
+              overflowPlaceable?.let { add(Unit) }
+              separatorPlaceable?.let { add(Unit) }
+            }
             .size)
 
     val chipMaxWidth =
@@ -790,6 +794,7 @@ private fun NoteContentEditor(
   content: String,
   onValueChange: (String) -> Unit,
   onBlur: () -> Unit,
+  onInputFocused: () -> Unit,
   readOnly: Boolean,
 ) {
   val focusManager = LocalFocusManager.current
@@ -808,6 +813,7 @@ private fun NoteContentEditor(
         Modifier.fillMaxWidth().defaultMinSize(minHeight = 90.dp).textInputFocusable(
           textInputState
         ) { state ->
+          if (state.isFocused) onInputFocused()
           if (!state.isFocused) {
             onBlur()
           }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteList.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteList.kt
@@ -73,6 +73,7 @@ internal class NoteListActions(
   val onDelete: (NoteCard_note) -> Unit,
   val onMoveNote:
     suspend (noteId: String, lowerOrder: String?, upperOrder: String?) -> Result<Unit, Nothing>,
+  val onInputFocused: () -> Unit = {},
 )
 
 @Composable
@@ -236,6 +237,7 @@ internal fun NoteList(
                   }
                 },
                 onBlur = { if (interactive && !isLoading) actions.onBlur(note.id) },
+                onInputFocused = actions.onInputFocused,
                 onToggleStatus = { if (interactive && !isLoading) actions.onToggleStatus(note) },
                 onColorChange = { nextColor ->
                   if (interactive && !isLoading) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorFocusReturnSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorFocusReturnSession.kt
@@ -1,0 +1,215 @@
+package co.typie.screen.editor.editor
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.withFrameNanos
+import co.typie.editor.Editor
+import co.typie.editor.ffi.Message
+import co.typie.editor.ffi.Selection
+import co.typie.editor.ffi.SelectionOp
+import co.typie.editor.ffi.StableSelection
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.launch
+
+@Stable
+internal class EditorFocusReturnSession(
+  private val scope: CoroutineScope,
+  private val freezeSelection: suspend (Editor, Selection) -> StableSelection? =
+    { editor, selection ->
+      editor.freezeSelection(selection)
+    },
+  private val applySelection: suspend (Editor, StableSelection) -> Unit = { editor, selection ->
+    editor.sync { enqueue(Message.Selection(SelectionOp.SetFrozen(selection = selection))) }
+  },
+  private val focusEditor: (Editor) -> Unit = { it.focus() },
+  private val awaitFocusBoundary: suspend () -> Unit = { withFrameNanos {} },
+) {
+  private var currentContext: EditorContext? = null
+  private var state: State = State.Idle
+  private var pendingBoundaryJob: Job? = null
+
+  fun observeEditorContext(
+    editor: Editor?,
+    focused: Boolean,
+    selection: Selection?,
+    contextActive: Boolean,
+  ) {
+    if (!contextActive || editor == null) {
+      if (currentContext != null || state !is State.Idle) {
+        invalidate()
+      }
+      return
+    }
+
+    val context =
+      currentContext?.takeIf { it.editor === editor }
+        ?: run {
+          clearState(resetContext = true)
+          EditorContext(editor).also { currentContext = it }
+        }
+
+    when (val current = state) {
+      State.Idle -> {
+        if (focused && selection != null) beginEligible(context)
+      }
+      is State.Eligible -> {
+        when {
+          focused && selection == null -> clearState(resetContext = false)
+          !focused -> beginPendingBlur(current.context)
+        }
+      }
+      is State.PendingBlur -> {
+        when {
+          focused && selection != null -> beginEligible(context)
+          focused -> clearState(resetContext = false)
+        }
+      }
+      is State.Captured -> Unit
+    }
+  }
+
+  fun onAuxiliaryInputFocused() {
+    val context =
+      when (val current = state) {
+        is State.Eligible -> current.context
+        is State.PendingBlur -> current.context
+        State.Idle,
+        is State.Captured -> return
+      }
+    if (!isRestorable(context)) return
+
+    val selection = context.editor.state.selection ?: return
+    pendingBoundaryJob?.cancel()
+    pendingBoundaryJob = null
+    state =
+      State.Captured(
+        context = context,
+        stableSelection =
+          scope.async {
+            try {
+              freezeSelection(context.editor, selection)
+            } catch (error: CancellationException) {
+              throw error
+            } catch (_: Throwable) {
+              null
+            }
+          },
+      )
+  }
+
+  suspend fun restore() {
+    val captured = state as? State.Captured ?: return
+    awaitFocusBoundary()
+    if (state !== captured) return
+
+    state = State.Idle
+    if (!isRestorable(captured.context)) {
+      captured.stableSelection.cancel()
+      return
+    }
+
+    if (captured.context.editor.currentSelection() != null) {
+      captured.stableSelection.cancel()
+      focusBestEffort(captured.context)
+      return
+    }
+
+    val stableSelection = captured.stableSelection.awaitBestEffort()
+    if (!isRestorable(captured.context)) return
+
+    if (captured.context.editor.currentSelection() == null && stableSelection != null) {
+      applySelectionBestEffort(captured.context.editor, stableSelection)
+    }
+
+    if (!isRestorable(captured.context)) return
+    if (captured.context.editor.currentSelection() == null) return
+    focusBestEffort(captured.context)
+  }
+
+  fun invalidate() {
+    clearState(resetContext = true)
+  }
+
+  private fun beginEligible(context: EditorContext) {
+    clearState(resetContext = false)
+    state = State.Eligible(context)
+  }
+
+  private fun beginPendingBlur(context: EditorContext) {
+    val pending = State.PendingBlur(context)
+    state = pending
+    pendingBoundaryJob?.cancel()
+    pendingBoundaryJob = scope.launch {
+      try {
+        awaitFocusBoundary()
+      } catch (error: CancellationException) {
+        throw error
+      } catch (_: Throwable) {
+        // A failed boundary still expires eligibility.
+      }
+      if (state === pending && isRestorable(context)) {
+        state = State.Idle
+        pendingBoundaryJob = null
+      }
+    }
+  }
+
+  private fun clearState(resetContext: Boolean) {
+    pendingBoundaryJob?.cancel()
+    pendingBoundaryJob = null
+    (state as? State.Captured)?.stableSelection?.cancel()
+    state = State.Idle
+    if (resetContext) {
+      currentContext = null
+    }
+  }
+
+  private fun isRestorable(context: EditorContext): Boolean = currentContext === context
+
+  private fun Editor.currentSelection(): Selection? = state.selection
+
+  private fun focusBestEffort(context: EditorContext) {
+    if (!isRestorable(context)) return
+    runCatching { focusEditor(context.editor) }
+  }
+
+  private suspend fun Deferred<StableSelection?>.awaitBestEffort(): StableSelection? =
+    try {
+      await()
+    } catch (error: CancellationException) {
+      currentCoroutineContext().ensureActive()
+      null
+    } catch (_: Throwable) {
+      null
+    }
+
+  private suspend fun applySelectionBestEffort(editor: Editor, selection: StableSelection) {
+    try {
+      applySelection(editor, selection)
+    } catch (error: CancellationException) {
+      currentCoroutineContext().ensureActive()
+    } catch (_: Throwable) {
+      // Selection restoration is silent and best-effort.
+    }
+  }
+
+  private class EditorContext(val editor: Editor)
+
+  private sealed interface State {
+    data object Idle : State
+
+    data class Eligible(val context: EditorContext) : State
+
+    data class PendingBlur(val context: EditorContext) : State
+
+    data class Captured(
+      val context: EditorContext,
+      val stableSelection: Deferred<StableSelection?>,
+    ) : State
+  }
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -114,6 +114,7 @@ import co.typie.ext.ime
 import co.typie.graphql.QueryState
 import co.typie.navigation.Nav
 import co.typie.navigation.NavigationResult
+import co.typie.navigation.PlatformBackHandler
 import co.typie.navigation.RouteRemovalDecision
 import co.typie.platform.PlatformModule
 import co.typie.platform.connectivityService
@@ -231,6 +232,7 @@ fun EditorScreen(entityId: String) {
   val toast = LocalToast.current
   val model = viewModel { EditorViewModel(entityId) }
   val scope = rememberCoroutineScope()
+  val focusReturnSession = remember(entityId) { EditorFocusReturnSession(scope = scope) }
   val runtime = remember(entityId) { EditorRuntime(uiScope = scope) }
   val interactionScope = remember(entityId) { EditorInteractionScope(coroutineScope = scope) }
   val uiState = remember(entityId) { EditorUiState() }
@@ -255,6 +257,8 @@ fun EditorScreen(entityId: String) {
   var loaderFailedCode by remember(entityId) { mutableStateOf<String?>(null) }
   var reloadRequest by remember(entityId) { mutableStateOf<EditorReloadRequest?>(null) }
   var routeRemovalOwnsPriority by remember(entityId) { mutableStateOf(false) }
+
+  DisposableEffect(focusReturnSession) { onDispose { focusReturnSession.invalidate() } }
 
   LaunchedEffect(Unit) { SubscriptionService.refresh() }
 
@@ -323,6 +327,14 @@ fun EditorScreen(entityId: String) {
     }
   }
   val editorState = editor?.state ?: EditorState.Initial
+  SideEffect {
+    focusReturnSession.observeEditorContext(
+      editor = editor,
+      focused = uiState.focused,
+      selection = editorState.selection,
+      contextActive = screenState.sceneInForeground && !editorReadOnly,
+    )
+  }
   val externalAssetIds =
     remember(editorState.externalElements) {
       editorState.externalElements
@@ -368,9 +380,14 @@ fun EditorScreen(entityId: String) {
       requestEditorFocus()
     }
   }
-  fun closeFindReplaceFromShortcut() {
-    findReplace.close()
-    requestEditorFocusIfSelectionActive()
+  val focusStealingSurfaceActive =
+    findReplace.active ||
+      subPaneState.active == EditorSubPane.RelatedNotes ||
+      subPaneState.active == EditorSubPane.Comments
+  LaunchedEffect(focusStealingSurfaceActive) {
+    if (!focusStealingSurfaceActive) {
+      focusReturnSession.restore()
+    }
   }
   suspend fun ensureSpellcheckSubscription(): Boolean {
     return SubscriptionService.gate(sheet = sheet, action = GatedAction.Spellcheck)
@@ -419,6 +436,21 @@ fun EditorScreen(entityId: String) {
       ensureSubscription = ::ensureAiFeedbackSubscription,
       ensureAiOptIn = ::ensureAiOptIn,
     )
+  fun closeSpellcheckAndRestoreEditorFocus() {
+    spellcheck.close()
+    requestEditorFocusIfSelectionActive()
+  }
+  fun closeAiFeedbackAndRestoreEditorFocus() {
+    aiFeedback.close()
+    requestEditorFocusIfSelectionActive()
+  }
+  PlatformBackHandler(enabled = findReplace.active || spellcheck.active || aiFeedback.active) {
+    when {
+      findReplace.active -> findReplace.close()
+      spellcheck.active -> closeSpellcheckAndRestoreEditorFocus()
+      aiFeedback.active -> closeAiFeedbackAndRestoreEditorFocus()
+    }
+  }
 
   when {
     findReplace.active -> {
@@ -426,7 +458,10 @@ fun EditorScreen(entityId: String) {
         leading = { FindReplaceTopBarLeading(session = findReplace) },
         leadingKey = FindReplaceTopBarLeadingKey,
         center = {
-          FindReplaceTopBarCenter(session = findReplace, onEscape = ::closeFindReplaceFromShortcut)
+          FindReplaceTopBarCenter(
+            session = findReplace,
+            onInputFocused = focusReturnSession::onAuxiliaryInputFocused,
+          )
         },
         centerKey = FindReplaceTopBarCenterKey,
         trailing = { FindReplaceTopBarTrailing(session = findReplace) },
@@ -1058,20 +1093,12 @@ fun EditorScreen(entityId: String) {
         spellcheckActive = spellcheck.active,
         aiFeedbackActive = aiFeedback.active,
       )
-    fun closeSpellcheckFromShortcut() {
-      spellcheck.close()
-      requestEditorFocusIfSelectionActive()
-    }
-    fun closeAiFeedbackFromShortcut() {
-      aiFeedback.close()
-      requestEditorFocusIfSelectionActive()
-    }
     val screenShortcutActions =
       EditorScreenShortcutActions(
         openFindReplace = ::openFindReplace,
-        closeFindReplace = ::closeFindReplaceFromShortcut,
-        closeSpellcheck = ::closeSpellcheckFromShortcut,
-        closeAiFeedback = ::closeAiFeedbackFromShortcut,
+        closeFindReplace = findReplace.close,
+        closeSpellcheck = ::closeSpellcheckAndRestoreEditorFocus,
+        closeAiFeedback = ::closeAiFeedbackAndRestoreEditorFocus,
       )
     suspend fun openTemplateSheet() {
       val activeEditor = runtime.editor ?: return
@@ -1620,7 +1647,7 @@ fun EditorScreen(entityId: String) {
             visibleState = findReplaceToolbarTransition,
             bottomInset = findReplaceToolbarBottomInset,
             modifier = Modifier,
-            onEscape = ::closeFindReplaceFromShortcut,
+            onInputFocused = focusReturnSession::onAuxiliaryInputFocused,
           )
           EditorToolbarHost(
             editorState = editorState,
@@ -1717,6 +1744,7 @@ fun EditorScreen(entityId: String) {
             maxTopInset = topInset,
             safeBottomInset = bottomSafeInset,
             trustedImeBottomInset = trustedImeBottom,
+            onAuxiliaryInputFocused = focusReturnSession::onAuxiliaryInputFocused,
             modifier = Modifier.fillMaxSize(),
           )
         },

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceToolbar.kt
@@ -64,8 +64,8 @@ internal fun FindReplaceToolbar(
   session: EditorFindReplaceSession,
   visibleState: MutableTransitionState<Boolean>,
   bottomInset: Dp,
+  onInputFocused: () -> Unit,
   modifier: Modifier = Modifier,
-  onEscape: () -> Unit = {},
 ) {
   AnimatedVisibility(
     visibleState = visibleState,
@@ -104,7 +104,11 @@ internal fun FindReplaceToolbar(
               ),
           verticalAlignment = Alignment.CenterVertically,
         ) {
-          ReplaceTextField(session = session, modifier = Modifier.weight(1f), onEscape = onEscape)
+          ReplaceTextField(
+            session = session,
+            modifier = Modifier.weight(1f),
+            onInputFocused = onInputFocused,
+          )
           Spacer(Modifier.width(ToolbarItemGap))
           EditorToolbarButton(
             icon = Lucide.Replace,
@@ -143,7 +147,7 @@ internal fun FindReplaceToolbar(
 private fun ReplaceTextField(
   session: EditorFindReplaceSession,
   modifier: Modifier = Modifier,
-  onEscape: () -> Unit = {},
+  onInputFocused: () -> Unit,
 ) {
   val inputState =
     rememberTextInputState(
@@ -167,8 +171,8 @@ private fun ReplaceTextField(
         .clip(shape)
         .background(AppTheme.colors.surfaceInset, shape)
         .padding(horizontal = 10.dp)
-        .textInputFocusable(inputState)
-        .onPreviewKeyEvent { event -> handleReplaceInputShortcut(event, session, onEscape) },
+        .textInputFocusable(inputState) { state -> if (state.isFocused) onInputFocused() }
+        .onPreviewKeyEvent { event -> handleReplaceInputShortcut(event, session) },
     decorationBox = { innerTextField ->
       Box(contentAlignment = Alignment.CenterStart) {
         if (session.replaceText.isEmpty()) {
@@ -189,11 +193,10 @@ private fun ReplaceTextField(
 private fun handleReplaceInputShortcut(
   event: KeyEvent,
   session: EditorFindReplaceSession,
-  onEscape: () -> Unit,
 ): Boolean =
   when {
     matchesEditorShortcut(event = event, platform = PlatformModule.platform, key = Key.Escape) -> {
-      onEscape()
+      session.close()
       true
     }
     matchesEditorShortcut(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceTopBar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceTopBar.kt
@@ -59,7 +59,10 @@ internal fun FindReplaceTopBarLeading(session: EditorFindReplaceSession) {
 }
 
 @Composable
-internal fun FindReplaceTopBarCenter(session: EditorFindReplaceSession, onEscape: () -> Unit = {}) {
+internal fun FindReplaceTopBarCenter(
+  session: EditorFindReplaceSession,
+  onInputFocused: () -> Unit,
+) {
   val inputState =
     rememberTextInputState(
       value = session.findText,
@@ -101,9 +104,9 @@ internal fun FindReplaceTopBarCenter(session: EditorFindReplaceSession, onEscape
       keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
       keyboardActions = KeyboardActions(onSearch = { session.findNext() }),
       modifier =
-        Modifier.weight(1f).textInputFocusable(inputState).onPreviewKeyEvent { event ->
-          handleFindInputShortcut(event, session, onEscape)
-        },
+        Modifier.weight(1f)
+          .textInputFocusable(inputState) { state -> if (state.isFocused) onInputFocused() }
+          .onPreviewKeyEvent { event -> handleFindInputShortcut(event, session) },
       decorationBox = { innerTextField ->
         Box(contentAlignment = Alignment.CenterStart) {
           if (session.findText.isEmpty()) {
@@ -124,14 +127,10 @@ internal fun FindReplaceTopBarCenter(session: EditorFindReplaceSession, onEscape
   }
 }
 
-private fun handleFindInputShortcut(
-  event: KeyEvent,
-  session: EditorFindReplaceSession,
-  onEscape: () -> Unit,
-): Boolean =
+private fun handleFindInputShortcut(event: KeyEvent, session: EditorFindReplaceSession): Boolean =
   when {
     matchesEditorShortcut(event = event, platform = PlatformModule.platform, key = Key.Escape) -> {
-      onEscape()
+      session.close()
       true
     }
     matchesEditorShortcut(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/EditorSubPaneHost.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/EditorSubPaneHost.kt
@@ -25,6 +25,7 @@ internal fun EditorSubPaneHost(
   maxTopInset: Dp,
   safeBottomInset: Dp,
   trustedImeBottomInset: Dp,
+  onAuxiliaryInputFocused: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
   val editor = LocalEditorRuntime.current.editor
@@ -43,6 +44,7 @@ internal fun EditorSubPaneHost(
         maxTopInset = maxTopInset,
         safeBottomInset = safeBottomInset,
         trustedImeBottomInset = trustedImeBottomInset,
+        onInputFocused = onAuxiliaryInputFocused,
         onDismissStarted = state::beginDismiss,
         onDismiss = state::dismiss,
         onLayoutInfoChanged = state::updateLayoutInfo,
@@ -62,7 +64,10 @@ internal fun EditorSubPaneHost(
           composeLocation = comments.session.composeLocation,
           createEnabled = comments.session.topBarCreateEnabled,
           onFreezeCurrentSelection = comments.session.freezeCurrentSelection,
-          onInputFocusChanged = comments.session.onInputFocusChanged,
+          onInputFocusChanged = { focused ->
+            comments.session.onInputFocusChanged(focused)
+            if (focused) onAuxiliaryInputFocused()
+          },
           maxTopInset = maxTopInset,
           safeBottomInset = safeBottomInset,
           trustedImeBottomInset = trustedImeBottomInset,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/relatednotes/RelatedNotesSheet.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/relatednotes/RelatedNotesSheet.kt
@@ -84,6 +84,7 @@ internal fun RelatedNotesSheet(
   maxTopInset: Dp,
   safeBottomInset: Dp,
   trustedImeBottomInset: Dp,
+  onInputFocused: () -> Unit,
   onDismissStarted: () -> Unit,
   onDismiss: () -> Unit,
   onLayoutInfoChanged: (EditorSubPaneLayoutInfo) -> Unit,
@@ -181,6 +182,7 @@ internal fun RelatedNotesSheet(
       saveNoteContent = ::saveNoteContent,
       saveNoteColor = ::saveNoteColor,
       collapseExpandedNote = ::collapseExpandedNote,
+      onInputFocused = onInputFocused,
     )
   }
 }
@@ -197,6 +199,7 @@ private fun RelatedNotesSheetContent(
   saveNoteContent: suspend (noteId: String, content: String) -> Boolean,
   saveNoteColor: suspend (noteId: String, color: String) -> Boolean,
   collapseExpandedNote: suspend () -> Boolean,
+  onInputFocused: () -> Unit,
 ) {
   val nav = Nav.current
   val dialog = LocalDialog.current
@@ -483,6 +486,7 @@ private fun RelatedNotesSheetContent(
           onMoveNote = { noteId, lowerOrder, upperOrder ->
             model.moveNote(noteId = noteId, lowerOrder = lowerOrder, upperOrder = upperOrder)
           },
+          onInputFocused = onInputFocused,
         )
       val reorderState = rememberNoteListReorderState(items = listItems, scrollState = scrollState)
 

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/EditorFocusReturnSessionTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/EditorFocusReturnSessionTest.kt
@@ -1,0 +1,397 @@
+package co.typie.screen.editor.editor
+
+import co.typie.editor.Editor
+import co.typie.editor.FakeFfiEditor
+import co.typie.editor.ffi.Affinity
+import co.typie.editor.ffi.Position
+import co.typie.editor.ffi.Selection
+import co.typie.editor.ffi.StablePosition
+import co.typie.editor.ffi.StableSelection
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class EditorFocusReturnSessionTest {
+  @Test
+  fun capturesOnlyWhenFocusedEditorSelectionHandsFocusToAuxiliaryInput() = runTest {
+    val editor = testEditor(selection("eligible"))
+    val frozenSelections = mutableListOf<Selection>()
+    val session = session(frozenSelections = frozenSelections)
+
+    observe(session, editor, focused = true)
+    session.onAuxiliaryInputFocused()
+    runCurrent()
+
+    assertEquals(listOf(selection("eligible")), frozenSelections)
+  }
+
+  @Test
+  fun doesNotCaptureFromUnfocusedOrSelectionlessEditor() = runTest {
+    val editor = testEditor(selection("retained"))
+    val frozenSelections = mutableListOf<Selection>()
+    val session = session(frozenSelections = frozenSelections)
+
+    observe(session, editor, focused = false)
+    session.onAuxiliaryInputFocused()
+    editor.setSelection(null)
+    observe(session, editor, focused = true)
+    session.onAuxiliaryInputFocused()
+    runCurrent()
+
+    assertTrue(frozenSelections.isEmpty())
+  }
+
+  @Test
+  fun auxiliaryFocusFreezesTheTransferTimeSelection() = runTest {
+    val editor = testEditor(selection("eligible"))
+    val frozenSelections = mutableListOf<Selection>()
+    val session = session(frozenSelections = frozenSelections)
+
+    observe(session, editor, focused = true)
+    editor.setSelection(selection("transfer"))
+    session.onAuxiliaryInputFocused()
+    runCurrent()
+
+    assertEquals(listOf(selection("transfer")), frozenSelections)
+  }
+
+  @Test
+  fun editorBlurCanBeClaimedWithinTheFocusBoundary() = runTest {
+    val editor = testEditor(selection("eligible"))
+    val boundary = CompletableDeferred<Unit>()
+    val frozenSelections = mutableListOf<Selection>()
+    val session = session(frozenSelections = frozenSelections, awaitFocusBoundary = boundary::await)
+
+    observe(session, editor, focused = true)
+    observe(session, editor, focused = false)
+    session.onAuxiliaryInputFocused()
+    runCurrent()
+
+    assertEquals(listOf(selection("eligible")), frozenSelections)
+  }
+
+  @Test
+  fun expiredEditorBlurBoundaryCannotBeClaimed() = runTest {
+    val editor = testEditor(selection("eligible"))
+    val boundary = CompletableDeferred<Unit>()
+    val frozenSelections = mutableListOf<Selection>()
+    val session = session(frozenSelections = frozenSelections, awaitFocusBoundary = boundary::await)
+
+    observe(session, editor, focused = true)
+    observe(session, editor, focused = false)
+    boundary.complete(Unit)
+    runCurrent()
+    session.onAuxiliaryInputFocused()
+    runCurrent()
+
+    assertTrue(frozenSelections.isEmpty())
+  }
+
+  @Test
+  fun additionalAuxiliaryInputFocusKeepsTheOriginalCapture() = runTest {
+    val editor = testEditor(selection("eligible"))
+    val frozenSelections = mutableListOf<Selection>()
+    val session = session(frozenSelections = frozenSelections)
+
+    capture(session, editor)
+    session.onAuxiliaryInputFocused()
+    runCurrent()
+
+    assertEquals(listOf(selection("eligible")), frozenSelections)
+  }
+
+  @Test
+  fun currentSelectionWinsWithoutWaitingForOrApplyingCapture() = runTest {
+    val editor = testEditor(selection("eligible"))
+    val freezeGate = CompletableDeferred<StableSelection?>()
+    var applyRequests = 0
+    var focusRequests = 0
+    val session =
+      EditorFocusReturnSession(
+        scope = this,
+        freezeSelection = { _, _ -> freezeGate.await() },
+        applySelection = { _, _ -> applyRequests += 1 },
+        focusEditor = { focusRequests += 1 },
+        awaitFocusBoundary = {},
+      )
+
+    capture(session, editor)
+    editor.setSelection(selection("current"))
+    session.restore()
+
+    assertEquals(0, applyRequests)
+    assertEquals(1, focusRequests)
+    assertFalse(freezeGate.isCompleted)
+  }
+
+  @Test
+  fun selectionAppearingDuringStableResolutionWinsWithoutApplyingCapture() = runTest {
+    val editor = testEditor(selection("eligible"))
+    val freezeGate = CompletableDeferred<StableSelection?>()
+    var applyRequests = 0
+    var focusRequests = 0
+    val session =
+      EditorFocusReturnSession(
+        scope = this,
+        freezeSelection = { _, _ -> freezeGate.await() },
+        applySelection = { _, _ -> applyRequests += 1 },
+        focusEditor = { focusRequests += 1 },
+        awaitFocusBoundary = {},
+      )
+
+    capture(session, editor)
+    editor.setSelection(null)
+    val restore = launch { session.restore() }
+    runCurrent()
+    editor.setSelection(selection("current"))
+    freezeGate.complete(stableSelection("captured"))
+    restore.join()
+
+    assertEquals(0, applyRequests)
+    assertEquals(1, focusRequests)
+  }
+
+  @Test
+  fun capturedSelectionIsAppliedBeforeFocusWhenCurrentSelectionIsMissing() = runTest {
+    val editor = testEditor(selection("eligible"))
+    val events = mutableListOf<String>()
+    val session =
+      EditorFocusReturnSession(
+        scope = this,
+        freezeSelection = { _, _ -> stableSelection("captured") },
+        applySelection = { _, stable ->
+          events += "apply:${stable.anchor.chain.single()}"
+          editor.setSelection(selection("restored"))
+        },
+        focusEditor = { events += "focus" },
+        awaitFocusBoundary = {},
+      )
+
+    capture(session, editor)
+    editor.setSelection(null)
+    session.restore()
+
+    assertEquals(listOf("apply:captured", "focus"), events)
+  }
+
+  @Test
+  fun failedFreezeDoesNotFocusSelectionlessEditor() = runTest {
+    val editor = testEditor(selection("eligible"))
+    var focusRequests = 0
+    val session =
+      EditorFocusReturnSession(
+        scope = this,
+        freezeSelection = { _, _ -> error("freeze failed") },
+        applySelection = { _, _ -> error("must not apply") },
+        focusEditor = { focusRequests += 1 },
+        awaitFocusBoundary = {},
+      )
+
+    capture(session, editor)
+    editor.setSelection(null)
+    session.restore()
+
+    assertEquals(0, focusRequests)
+  }
+
+  @Test
+  fun failedApplyDoesNotFocusSelectionlessEditor() = runTest {
+    val editor = testEditor(selection("eligible"))
+    var focusRequests = 0
+    val session =
+      EditorFocusReturnSession(
+        scope = this,
+        freezeSelection = { _, _ -> stableSelection("captured") },
+        applySelection = { _, _ -> error("apply failed") },
+        focusEditor = { focusRequests += 1 },
+        awaitFocusBoundary = {},
+      )
+
+    capture(session, editor)
+    editor.setSelection(null)
+    session.restore()
+
+    assertEquals(0, focusRequests)
+  }
+
+  @Test
+  fun focusFailureIsSilentAndCaptureIsConsumedOnce() = runTest {
+    val editor = testEditor(selection("eligible"))
+    var focusRequests = 0
+    val session =
+      EditorFocusReturnSession(
+        scope = this,
+        freezeSelection = { _, _ -> stableSelection("captured") },
+        applySelection = { _, _ -> error("must not apply") },
+        focusEditor = {
+          focusRequests += 1
+          error("focus failed")
+        },
+        awaitFocusBoundary = {},
+      )
+
+    capture(session, editor)
+    repeat(2) { session.restore() }
+
+    assertEquals(1, focusRequests)
+  }
+
+  @Test
+  fun cancellationDuringRestoreBoundaryPreservesCapture() = runTest {
+    val editor = testEditor(selection("eligible"))
+    val restoreBoundary = CompletableDeferred<Unit>()
+    var focusRequests = 0
+    val session =
+      EditorFocusReturnSession(
+        scope = this,
+        freezeSelection = { _, _ -> stableSelection("captured") },
+        applySelection = { _, _ -> error("must not apply") },
+        focusEditor = { focusRequests += 1 },
+        awaitFocusBoundary = restoreBoundary::await,
+      )
+
+    capture(session, editor)
+    val cancelledRestore = launch { session.restore() }
+    runCurrent()
+    cancelledRestore.cancelAndJoin()
+    restoreBoundary.complete(Unit)
+    session.restore()
+
+    assertEquals(1, focusRequests)
+  }
+
+  @Test
+  fun inactiveContextCannotBeRevivedByReobservingTheSameEditor() = runTest {
+    val editor = testEditor(selection("eligible"))
+    val freezeGate = CompletableDeferred<StableSelection?>()
+    var applyRequests = 0
+    var focusRequests = 0
+    val session =
+      EditorFocusReturnSession(
+        scope = this,
+        freezeSelection = { _, _ -> freezeGate.await() },
+        applySelection = { _, _ -> applyRequests += 1 },
+        focusEditor = { focusRequests += 1 },
+        awaitFocusBoundary = {},
+      )
+
+    capture(session, editor)
+    editor.setSelection(null)
+    val restore = launch { session.restore() }
+    runCurrent()
+    observe(session, editor, focused = false, contextActive = false)
+    observe(session, editor, focused = true)
+    freezeGate.complete(stableSelection("captured"))
+    restore.join()
+
+    assertEquals(0, applyRequests)
+    assertEquals(0, focusRequests)
+  }
+
+  @Test
+  fun editorReplacementOrRemovalDiscardsCapture() = runTest {
+    val editor = testEditor(selection("eligible"))
+    val replacement = testEditor(selection("replacement"))
+    var focusRequests = 0
+    val session = session(focusEditor = { focusRequests += 1 })
+
+    capture(session, editor)
+    observe(session, replacement, focused = true)
+    session.restore()
+    capture(session, replacement)
+    session.observeEditorContext(
+      editor = null,
+      focused = false,
+      selection = null,
+      contextActive = true,
+    )
+    session.restore()
+
+    assertEquals(0, focusRequests)
+  }
+
+  @Test
+  fun explicitInvalidationDiscardsCapture() = runTest {
+    val editor = testEditor(selection("eligible"))
+    var focusRequests = 0
+    val session = session(focusEditor = { focusRequests += 1 })
+
+    capture(session, editor)
+    session.invalidate()
+    session.restore()
+
+    assertEquals(0, focusRequests)
+  }
+
+  private fun TestScope.testEditor(initialSelection: Selection?): TestEditor {
+    var selection = initialSelection
+    val ffi = FakeFfiEditor(selectionProvider = { selection })
+    val editor = Editor(ffi, this, StandardTestDispatcher(testScheduler))
+    val testEditor = TestEditor(editor = editor, updateSelection = { selection = it })
+    testEditor.setSelection(initialSelection)
+    return testEditor
+  }
+
+  private fun TestScope.session(
+    frozenSelections: MutableList<Selection> = mutableListOf(),
+    focusEditor: (Editor) -> Unit = {},
+    awaitFocusBoundary: suspend () -> Unit = {},
+  ): EditorFocusReturnSession =
+    EditorFocusReturnSession(
+      scope = this,
+      freezeSelection = { _, selection ->
+        frozenSelections += selection
+        stableSelection(selection.anchor.node)
+      },
+      applySelection = { _, _ -> },
+      focusEditor = focusEditor,
+      awaitFocusBoundary = awaitFocusBoundary,
+    )
+
+  private fun observe(
+    session: EditorFocusReturnSession,
+    editor: TestEditor,
+    focused: Boolean,
+    contextActive: Boolean = true,
+  ) {
+    session.observeEditorContext(
+      editor = editor.editor,
+      focused = focused,
+      selection = editor.editor.state.selection,
+      contextActive = contextActive,
+    )
+  }
+
+  private fun TestScope.capture(session: EditorFocusReturnSession, editor: TestEditor) {
+    observe(session, editor, focused = true)
+    session.onAuxiliaryInputFocused()
+    runCurrent()
+  }
+}
+
+private class TestEditor(val editor: Editor, private val updateSelection: (Selection?) -> Unit) {
+  fun setSelection(selection: Selection?) {
+    updateSelection(selection)
+    editor.sync {}
+  }
+}
+
+private fun selection(node: String): Selection {
+  val position = Position(node = node, offset = 0, affinity = Affinity.Downstream)
+  return Selection(anchor = position, head = position)
+}
+
+private fun stableSelection(node: String): StableSelection {
+  val position = StablePosition(chain = listOf(node), child = null, affinity = Affinity.Downstream)
+  return StableSelection(anchor = position, head = position)
+}

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/EditorAuxiliaryFocusBoundaryDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/EditorAuxiliaryFocusBoundaryDesktopTest.kt
@@ -1,0 +1,111 @@
+package co.typie.screen.editor.editor
+
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.v2.runComposeUiTest
+import co.typie.editor.runtime.EditorUiState
+import co.typie.screen.editor.editor.subpane.comments.CommentComposer
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class EditorAuxiliaryFocusBoundaryDesktopTest {
+  @Test
+  fun commentComposerFocusArrivesBeforeTheEditorBlurBoundaryExpires() = runComposeUiTest {
+    val fixture = FocusBoundaryFixture()
+    mainClock.autoAdvance = false
+
+    setContent { FocusBoundaryContent(fixture) }
+    advanceUntil(fixture, "observed:true")
+
+    onNode(hasSetTextAction()).performClick()
+    advanceUntil(fixture, BlurBoundaryExpired)
+
+    fixture.assertAuxiliaryFocusPrecedesBlurBoundary()
+  }
+
+  private fun androidx.compose.ui.test.ComposeUiTest.advanceUntil(
+    fixture: FocusBoundaryFixture,
+    event: String,
+  ) {
+    repeat(MaxFrames) {
+      if (event in fixture.events) return
+      mainClock.advanceTimeByFrame()
+    }
+    assertTrue(event in fixture.events, "Expected $event in ${fixture.events}")
+  }
+}
+
+private class FocusBoundaryFixture {
+  val editorFocusRequester = FocusRequester()
+  val events = mutableListOf<String>()
+
+  fun assertAuxiliaryFocusPrecedesBlurBoundary() {
+    val auxiliaryFocusIndex = events.indexOf("auxiliary:true")
+    val blurBoundaryIndex = events.indexOf(BlurBoundaryExpired)
+    assertTrue(auxiliaryFocusIndex >= 0, "Missing auxiliary focus event: $events")
+    assertTrue(blurBoundaryIndex >= 0, "Missing blur boundary event: $events")
+    assertTrue(
+      auxiliaryFocusIndex < blurBoundaryIndex,
+      "Auxiliary focus must arrive before the editor blur boundary expires: $events",
+    )
+  }
+}
+
+@Composable
+private fun FocusBoundaryContent(fixture: FocusBoundaryFixture) {
+  val uiState = remember { EditorUiState() }
+  var observedEditorFocusOnce by remember { mutableStateOf(false) }
+
+  Box(
+    Modifier.focusRequester(fixture.editorFocusRequester)
+      .onFocusChanged { state ->
+        fixture.events += "editor:${state.isFocused}"
+        uiState.updateFocus(state.isFocused)
+      }
+      .focusable()
+  )
+
+  SideEffect {
+    fixture.events += "observed:${uiState.focused}"
+    if (uiState.focused) {
+      observedEditorFocusOnce = true
+    }
+  }
+
+  LaunchedEffect(uiState.focused, observedEditorFocusOnce) {
+    if (observedEditorFocusOnce && !uiState.focused) {
+      withFrameNanos {}
+      fixture.events += BlurBoundaryExpired
+    }
+  }
+
+  CommentComposer(
+    value = "",
+    onValueChange = {},
+    placeholder = "코멘트 작성...",
+    submitting = false,
+    onFocusChange = { focused -> fixture.events += "auxiliary:$focused" },
+    onSubmit = {},
+  )
+
+  LaunchedEffect(Unit) { fixture.editorFocusRequester.requestFocus() }
+}
+
+private const val BlurBoundaryExpired = "blur-boundary-expired"
+private const val MaxFrames = 10


### PR DESCRIPTION
- 검색/관련 노트/코멘트 입력이 에디터 포커스를 가져갈 때 당시 selection을 저장하고, 마지막 보조 UI가 닫히면 selection과 focus 복원
- 종료 시 에디터에 이미 selection이 있으면 selection 복원을 건너뛰고 현재 selection을 유지한 채 focus만 복원
- 원래 에디터가 focus와 selection을 갖지 않았거나 화면 이탈 / read-only 전환 / 에디터 교체가 발생한 경우에는 복원하지 않으며, 복원 시 reveal/scroll은 하지 않음