### PR TITLE
웹 drag selection pointer up에서 최신 위치 반영

### DIFF
--- a/apps/website/src/lib/editor-ffi/handlers/pointer.test.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/pointer.test.ts
@@ -283,4 +283,42 @@ describe('pointer native drag admission', () => {
     });
     vi.unstubAllGlobals();
   });
+
+  it('reprojects a pending drag selection from current geometry on pointer up', () => {
+    const animationFrames: FrameRequestCallback[] = [];
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      animationFrames.push(callback);
+      return animationFrames.length;
+    });
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+
+    try {
+      let pageTop = 200;
+      const editor = createEditor();
+      const target = createPointerTarget({ captured: true });
+      editor.clientToLocal = vi.fn((clientX: number, clientY: number) => ({ page: 0, x: clientX - 100, y: clientY - pageTop }));
+
+      handlePointerDown(editor, createPointerEvent({ target, clientX: 110, clientY: 220 }));
+      editor.enqueue.mockClear();
+
+      handlePointerMove(editor, createPointerEvent({ target, clientX: 130, clientY: 220 }));
+      pageTop = 180;
+      handlePointerUp(editor, createPointerEvent({ target, clientX: 130, clientY: 220 }));
+
+      expect(editor.enqueue).toHaveBeenLastCalledWith({
+        type: 'selection',
+        op: {
+          type: 'extend_to',
+          anchor: collapsedSelection.anchor,
+          head_page: 0,
+          head_x: 30,
+          head_y: 40,
+          base_selection: undefined,
+          allow_collapse: true,
+        },
+      });
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
 });

--- a/apps/website/src/lib/editor-ffi/handlers/pointer.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/pointer.ts
@@ -151,7 +151,7 @@ export const handlePointerUp: EditorEventHandler<HTMLElement, PointerEvent> = (e
   }
 
   state.releasePointer(e.currentTarget, e.pointerId);
-  state.finishPointerUp(editor, e.pointerId);
+  state.finishPointerUp(editor, e.pointerId, { clientX: e.clientX, clientY: e.clientY });
   editor.flush();
   editor.resumeToolbarSync();
   editor.endNativeDragAdmission({ restoreFocus: true });
@@ -338,11 +338,17 @@ class PointerState {
     }
   }
 
-  finishPointerUp(editor: Editor, pointerId: number): void {
+  finishPointerUp(editor: Editor, pointerId: number, pointer: { clientX: number; clientY: number }): void {
     const session = this.#session;
     if (!session || session.pointerId !== pointerId) return;
 
     this.#flushDragPending(editor);
+    if (session.dragging) {
+      const local = editor.clientToLocal(pointer.clientX, pointer.clientY);
+      if (local) {
+        this.#extendSelectionTo(editor, { ...local, ...pointer }, { respectThreshold: false });
+      }
+    }
     if (session.nativeDragCandidate && !session.nativeDragStarted) {
       editor.enqueue({ type: 'selection', op: { type: 'set_at', page: session.down.page, x: session.down.x, y: session.down.y } });
       editor.scrollIntoView({ target: { type: 'current_selection_head' }, mode: 'nearest' });


### PR DESCRIPTION
- edge auto scroll의 마지막 callback 이후 viewport가 더 움직여도 pointer up 시 최신 geometry로 selection 위치 갱신 (edge auto scroll의 callback은 스로틀되기 때문에)
- pending pointer move와 기존 drag threshold 동작을 유지하는 회귀 테스트 추가