### PR TITLE
긴 문서에서 줄 강조 켜져있을 때 크래시 수정

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/body/EditorBody.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/body/EditorBody.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.unit.dp
 import co.typie.editor.EditorView
 import co.typie.editor.ext.unclippedBoundsInRoot
 import co.typie.editor.interaction.LocalEditorInteractionScope
-import co.typie.editor.overlay.EditorExtensionAreaLineHighlightOverlay
+import co.typie.editor.overlay.editorExtensionAreaLineHighlight
 import co.typie.editor.runtime.EditorUiState
 import co.typie.editor.runtime.LocalEditorRuntime
 import co.typie.editor.runtime.LocalEditorUiState
@@ -35,6 +35,7 @@ import co.typie.screen.editor.editor.overlay.EditorSelectionHandleOverlay
 import co.typie.screen.editor.editor.overlay.EditorTableCellSelectionOverlay
 import co.typie.screen.editor.editor.overlay.EditorTableColumnResizeOverlay
 import co.typie.storage.Preference
+import co.typie.ui.theme.AppTheme
 
 private val DebugTopPaddingColor = Color(0x22FF5ACD)
 private val DebugBottomPaddingColor = Color(0x22FF8A00)
@@ -68,19 +69,23 @@ internal fun EditorBody(
   val interactionSurfaceModifier =
     Modifier.fillMaxWidth()
       .trackEditorInteractionSurfaceBounds(uiState = uiState, density = density.density)
+      .run {
+        if (layoutSpec is EditorDocumentLayoutSpec.Continuous) {
+          editorExtensionAreaLineHighlight(
+            cursor = { editor?.cursor },
+            focused = { uiState.focused },
+            editorBounds = { uiState.editorBoundsInContainer },
+            viewportTransform = { uiState.resolveViewportTransform(editor?.pageSizes.orEmpty()) },
+            enabled = { Preference.lineHighlightEnabled },
+            color = AppTheme.colors.surfaceInset.copy(alpha = 0.55f),
+          )
+        } else {
+          this
+        }
+      }
 
   Box(modifier = modifier.fillMaxWidth()) {
     Box(modifier = interactionSurfaceModifier) {
-      if (layoutSpec is EditorDocumentLayoutSpec.Continuous) {
-        EditorExtensionAreaLineHighlightOverlay(
-          cursor = editor?.cursor,
-          focused = uiState.focused,
-          editorBounds = { uiState.editorBoundsInContainer },
-          viewportTransform = { uiState.resolveViewportTransform(editor?.pageSizes.orEmpty()) },
-          enabled = Preference.lineHighlightEnabled,
-          modifier = Modifier.matchParentSize(),
-        )
-      }
       Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.TopCenter) {
         Column(
           modifier =

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/overlay/LineHighlight.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/overlay/LineHighlight.kt
@@ -1,12 +1,13 @@
 package co.typie.editor.overlay
 
-import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
 import co.typie.editor.EditorViewportTransform
 import co.typie.editor.ffi.CursorMetrics
 import co.typie.editor.ffi.Rect
@@ -64,30 +65,25 @@ internal fun EditorLineHighlightOverlay(
   Box(Modifier.editorOverlayRect(rect).background(AppTheme.colors.surfaceInset.copy(alpha = 0.55f)))
 }
 
-@Composable
-internal fun EditorExtensionAreaLineHighlightOverlay(
-  cursor: CursorMetrics?,
-  focused: Boolean,
+internal fun Modifier.editorExtensionAreaLineHighlight(
+  cursor: () -> CursorMetrics?,
+  focused: () -> Boolean,
   editorBounds: () -> EditorBoundsInContainer,
   viewportTransform: () -> EditorViewportTransform,
-  enabled: Boolean,
-  modifier: Modifier = Modifier,
-) {
-  if (!enabled || !focused) return
-  val currentCursor = cursor ?: return
-  val color = AppTheme.colors.surfaceInset.copy(alpha = 0.55f)
-
-  Canvas(modifier) {
-    val band =
-      resolveEditorExtensionAreaLineHighlightBand(
-        cursor = currentCursor,
-        editorBounds = editorBounds(),
-        viewportTransform = viewportTransform(),
-      ) ?: return@Canvas
-    drawRect(
-      color = color,
-      topLeft = Offset(x = 0f, y = band.top * density),
-      size = Size(width = size.width, height = band.height * density),
-    )
-  }
+  enabled: () -> Boolean,
+  color: Color,
+): Modifier = drawBehind {
+  if (!enabled() || !focused()) return@drawBehind
+  val currentCursor = cursor() ?: return@drawBehind
+  val band =
+    resolveEditorExtensionAreaLineHighlightBand(
+      cursor = currentCursor,
+      editorBounds = editorBounds(),
+      viewportTransform = viewportTransform(),
+    ) ?: return@drawBehind
+  drawRect(
+    color = color,
+    topLeft = Offset(x = 0f, y = band.top * density),
+    size = Size(width = size.width, height = band.height * density),
+  )
 }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/EditorFocusReturnSessionTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/EditorFocusReturnSessionTest.kt
@@ -3,6 +3,7 @@ package co.typie.screen.editor.editor
 import co.typie.editor.Editor
 import co.typie.editor.FakeFfiEditor
 import co.typie.editor.ffi.Affinity
+import co.typie.editor.ffi.ChainSegment
 import co.typie.editor.ffi.Position
 import co.typie.editor.ffi.Selection
 import co.typie.editor.ffi.StablePosition
@@ -170,7 +171,7 @@ class EditorFocusReturnSessionTest {
         scope = this,
         freezeSelection = { _, _ -> stableSelection("captured") },
         applySelection = { _, stable ->
-          events += "apply:${stable.anchor.chain.single()}"
+          events += "apply:${(stable.anchor.chain.single() as ChainSegment.Real).dot}"
           editor.setSelection(selection("restored"))
         },
         focusEditor = { events += "focus" },
@@ -392,6 +393,11 @@ private fun selection(node: String): Selection {
 }
 
 private fun stableSelection(node: String): StableSelection {
-  val position = StablePosition(chain = listOf(node), child = null, affinity = Affinity.Downstream)
-  return StableSelection(anchor = position, head = position)
+  val position =
+    StablePosition(
+      chain = listOf(ChainSegment.Real(node)),
+      child = null,
+      affinity = Affinity.Downstream,
+    )
+  return StableSelection(version = 2, anchor = position, head = position)
 }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/overlay/LineHighlightDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/overlay/LineHighlightDesktopTest.kt
@@ -1,0 +1,81 @@
+package co.typie.editor.overlay
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import co.typie.editor.body.trackEditorInteractionSurfaceBounds
+import co.typie.editor.ffi.CursorMetrics
+import co.typie.editor.ffi.Rect
+import co.typie.editor.runtime.EditorUiState
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class LineHighlightDesktopTest {
+  @Test
+  fun continuousLineHighlightSurvivesContentTallerThanConstraintsLimit() = runComposeUiTest {
+    val uiState = EditorUiState()
+    val cursor =
+      CursorMetrics(
+        pageIdx = 0,
+        caret = Rect(x = 0f, y = 10f, width = 1f, height = 10f),
+        line = Rect(x = 0f, y = 10f, width = 100f, height = 10f),
+      )
+
+    setContent {
+      CompositionLocalProvider(LocalDensity provides Density(1f)) {
+        Layout(
+          content = {
+            Box(
+              modifier =
+                Modifier.fillMaxWidth()
+                  .trackEditorInteractionSurfaceBounds(uiState = uiState, density = 1f)
+                  .editorExtensionAreaLineHighlight(
+                    cursor = { cursor },
+                    focused = { true },
+                    editorBounds = { uiState.editorBoundsInContainer },
+                    viewportTransform = { uiState.resolveViewportTransform() },
+                    enabled = { true },
+                    color = Color.Black,
+                  )
+            ) {
+              Column {
+                repeat(ContentBlockCount) {
+                  Box(modifier = Modifier.fillMaxWidth().height(ContentBlockHeight.dp))
+                }
+              }
+            }
+          }
+        ) { measurables, constraints ->
+          val placeable =
+            measurables
+              .single()
+              .measure(
+                Constraints(
+                  minWidth = constraints.maxWidth,
+                  maxWidth = constraints.maxWidth,
+                  minHeight = 0,
+                  maxHeight = Constraints.Infinity,
+                )
+              )
+          layout(constraints.maxWidth, constraints.maxHeight) { placeable.place(0, 0) }
+        }
+      }
+    }
+  }
+
+  private companion object {
+    const val ContentBlockCount = 2
+    const val ContentBlockHeight = 150_000f
+  }
+}

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorOverlayLayoutSynchronizationDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorOverlayLayoutSynchronizationDesktopTest.kt
@@ -44,7 +44,7 @@ import co.typie.editor.ffi.TableOverlayRow
 import co.typie.editor.interaction.EditorEdgeAutoScrollViewport
 import co.typie.editor.interaction.EditorInteractionGeometry
 import co.typie.editor.interaction.semantics.EditorTableColumnResizePresentation
-import co.typie.editor.overlay.EditorExtensionAreaLineHighlightOverlay
+import co.typie.editor.overlay.editorExtensionAreaLineHighlight
 import co.typie.editor.runtime.EditorUiState
 import co.typie.editor.surface.editorPagePositionTracker
 import co.typie.ui.theme.LightAppShadows
@@ -226,15 +226,15 @@ class EditorOverlayLayoutSynchronizationDesktopTest {
             .background(Color.White)
             .testTag(RootTag)
             .trackEditorInteractionSurfaceBounds(uiState = uiState, density = 1f)
+            .editorExtensionAreaLineHighlight(
+              cursor = { cursor },
+              focused = { true },
+              editorBounds = { uiState.editorBoundsInContainer },
+              viewportTransform = { uiState.resolveViewportTransform() },
+              enabled = { true },
+              color = LightColors.surfaceInset.copy(alpha = 0.55f),
+            )
         ) {
-          EditorExtensionAreaLineHighlightOverlay(
-            cursor = cursor,
-            focused = true,
-            editorBounds = { uiState.editorBoundsInContainer },
-            viewportTransform = { uiState.resolveViewportTransform() },
-            enabled = true,
-            modifier = Modifier.matchParentSize(),
-          )
           Column(
             Modifier.offset { IntOffset(0, ContinuousEditorTop.roundToInt()) }
               .fillMaxWidth()


### PR DESCRIPTION
- continuous 모드 line highlight가 `matchParentSize`라서 Box가 문서 전체 높이의 고정 Constraints를 생성 — Compose Constraints는 262,143px 이상의 유한 치수를 표현하지 못해, 그보다 긴 문서를 포커스하는 순간 `IllegalArgumentException`으로 즉사 (#4905 회귀)
- overlay composable을 제거하고 interaction surface Box의 `drawBehind` modifier(`editorExtensionAreaLineHighlight`)로 대체 — 측정 없이 그리기만 하므로 한계 자체가 사라지고, cursor/focused/enabled까지 draw 시점에 읽어 줌 프레임 싱크는 유지하면서 커서 이동마다 돌던 리컴포지션은 제거
- unbounded 높이 측정 + 한계 초과 콘텐츠 구성으로 회귀 테스트 추가, 기존 overlay 프레임 싱크 테스트는 새 API로 이관
- `EditorFocusReturnSessionTest`가 StablePosition의 `ChainSegment`/`version` 마이그레이션에서 누락되어 desktopTest 컴파일이 깨져 있던 것도 함께 이관
