### PR TITLE
웹 관련 노트 reorder 중 edge auto scroll 위치 갱신

### DIFF
--- a/apps/website/src/routes/website/(dashboard)/@widgets/widgets/DocumentRelatedNoteWidget.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@widgets/widgets/DocumentRelatedNoteWidget.svelte
@@ -155,7 +155,7 @@
     };
   };
 
-  const handleDragEnter = (noteId: string) => {
+  const moveDraggingNote = (noteId: string) => {
     if (dragging && dragging.noteId !== noteId) {
       const draggedIndex = localNoteOrder.indexOf(dragging.noteId);
       const dropIndex = localNoteOrder.indexOf(noteId);
@@ -169,32 +169,52 @@
     }
   };
 
-  const handleDragEnd = async () => {
-    if (!dragging || !relatedDocument.data?.entity.id) return;
+  const updateDraggingPosition = (clientX: number, clientY: number) => {
+    if (!dragging || !scrollContainer) return;
 
-    const currentIndex = localNoteOrder.indexOf(dragging.noteId);
+    const element = document.elementFromPoint(clientX, clientY);
+    const noteElement = element?.closest('[data-widget-note-id]') as HTMLElement | null;
+    if (!noteElement || !scrollContainer.contains(noteElement)) return;
 
-    if (currentIndex !== -1 && dragging.originalIndex !== -1 && currentIndex !== dragging.originalIndex && sortedNotes.length > 1) {
+    const noteId = noteElement.dataset.widgetNoteId;
+    if (noteId) moveDraggingNote(noteId);
+  };
+
+  const handleDragEnd = async (clientX: number, clientY: number) => {
+    if (!dragging) return;
+
+    updateDraggingPosition(clientX, clientY);
+    const currentDragging = dragging;
+    const currentIndex = localNoteOrder.indexOf(currentDragging.noteId);
+    dragging = null;
+
+    const currentDocument = relatedDocument.data;
+    if (!currentDocument) return;
+
+    if (
+      currentIndex !== -1 &&
+      currentDragging.originalIndex !== -1 &&
+      currentIndex !== currentDragging.originalIndex &&
+      sortedNotes.length > 1
+    ) {
       const lowerNote = sortedNotes[currentIndex - 1] ?? null;
       const upperNote = sortedNotes[currentIndex + 1] ?? null;
 
       try {
         await moveNote({
           input: {
-            noteId: dragging.noteId,
+            noteId: currentDragging.noteId,
             lowerOrder: lowerNote?.order,
             upperOrder: upperNote?.order,
           },
         });
         mixpanel.track('move_related_note');
-        cache.invalidate({ __typename: 'Entity', id: relatedDocument.data.entity.id, $field: 'notes' });
+        cache.invalidate({ __typename: 'Entity', id: currentDocument.entity.id, $field: 'notes' });
       } catch {
-        localNoteOrder = relatedDocument.data.entity.notes.map((note) => note.id);
+        localNoteOrder = currentDocument.entity.notes.map((note) => note.id);
         Toast.error('노트 순서 변경에 실패했습니다. 잠시 후 다시 시도해주세요.');
       }
     }
-
-    dragging = null;
   };
 
   let prevNoteIds = $state<string[]>([]);
@@ -220,7 +240,9 @@
 
   $effect(() => {
     if (!palette) {
-      return handleDragScroll(scrollContainer ? elementScrollViewport(scrollContainer) : null, !!dragging);
+      return handleDragScroll(scrollContainer ? elementScrollViewport(scrollContainer) : null, !!dragging, {
+        onScroll: updateDraggingPosition,
+      });
     }
   });
 
@@ -346,8 +368,8 @@
           onAddNote={() => handleAddNote('shortcut')}
           onBeginResolve={() => handleBeginResolve(note.id)}
           onDragEnd={handleDragEnd}
-          onDragEnter={() => handleDragEnter(note.id)}
-          onDragMove={handleDragEnter}
+          onDragEnter={() => moveDraggingNote(note.id)}
+          onDragMove={updateDraggingPosition}
           onDragStart={() => handleDragStart(note.id)}
           onEndResolve={() => handleEndResolve(note.id)}
           {palette}

--- a/apps/website/src/routes/website/(dashboard)/@widgets/widgets/DocumentRelatedNoteWidgetItem.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@widgets/widgets/DocumentRelatedNoteWidgetItem.svelte
@@ -24,9 +24,9 @@
     resolving: boolean;
     onAddNote: () => void;
     onBeginResolve: () => void;
-    onDragEnd: () => void;
+    onDragEnd: (clientX: number, clientY: number) => void;
     onDragEnter: () => void;
-    onDragMove: (noteId: string) => void;
+    onDragMove: (clientX: number, clientY: number) => void;
     onDragStart: () => void;
     onEndResolve: () => void;
   };
@@ -272,21 +272,13 @@
       if (state.started && state.ghost) {
         state.ghost.style.left = `${ev.clientX - state.offsetX}px`;
         state.ghost.style.top = `${ev.clientY - state.offsetY}px`;
-
-        const elemBelow = document.elementFromPoint(ev.clientX, ev.clientY);
-        const noteBelow = elemBelow?.closest('[data-widget-note-id]') as HTMLElement | null;
-        if (noteBelow) {
-          const noteId = noteBelow.dataset.widgetNoteId;
-          if (noteId && noteId !== note.data.id) {
-            onDragMove(noteId);
-          }
-        }
+        onDragMove(ev.clientX, ev.clientY);
       }
     };
 
-    const handleUp = () => {
+    const handleUp = (ev: PointerEvent) => {
       if (state.started) {
-        onDragEnd();
+        onDragEnd(ev.clientX, ev.clientY);
       }
       cleanup();
     };

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanelNote.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanelNote.svelte
@@ -127,7 +127,7 @@
     };
   };
 
-  const handleDragEnter = (noteId: string) => {
+  const moveDraggingNote = (noteId: string) => {
     if (dragging && dragging.noteId !== noteId) {
       const draggedIndex = localNoteOrder.indexOf(dragging.noteId);
       const dropIndex = localNoteOrder.indexOf(noteId);
@@ -141,19 +141,38 @@
     }
   };
 
-  const handleDragEnd = async () => {
+  const updateDraggingPosition = (clientX: number, clientY: number) => {
+    if (!dragging || !scrollContainer) return;
+
+    const element = document.elementFromPoint(clientX, clientY);
+    const noteElement = element?.closest('[data-related-note-id]') as HTMLElement | null;
+    if (!noteElement || !scrollContainer.contains(noteElement)) return;
+
+    const noteId = noteElement.dataset.relatedNoteId;
+    if (noteId) moveDraggingNote(noteId);
+  };
+
+  const handleDragEnd = async (clientX: number, clientY: number) => {
     if (!dragging) return;
 
-    const currentIndex = localNoteOrder.indexOf(dragging.noteId);
+    updateDraggingPosition(clientX, clientY);
+    const currentDragging = dragging;
+    const currentIndex = localNoteOrder.indexOf(currentDragging.noteId);
+    dragging = null;
 
-    if (currentIndex !== -1 && dragging.originalIndex !== -1 && currentIndex !== dragging.originalIndex && sortedNotes.length > 1) {
+    if (
+      currentIndex !== -1 &&
+      currentDragging.originalIndex !== -1 &&
+      currentIndex !== currentDragging.originalIndex &&
+      sortedNotes.length > 1
+    ) {
       const lowerNote = sortedNotes[currentIndex - 1] ?? null;
       const upperNote = sortedNotes[currentIndex + 1] ?? null;
 
       try {
         await moveNote({
           input: {
-            noteId: dragging.noteId,
+            noteId: currentDragging.noteId,
             lowerOrder: lowerNote?.order,
             upperOrder: upperNote?.order,
           },
@@ -165,8 +184,6 @@
         Toast.error('노트 순서 변경에 실패했습니다. 잠시 후 다시 시도해주세요.');
       }
     }
-
-    dragging = null;
   };
 
   let prevNoteIds = $state<string[]>([]);
@@ -191,7 +208,9 @@
   });
 
   $effect(() => {
-    return handleDragScroll(scrollContainer ? elementScrollViewport(scrollContainer) : null, !!dragging);
+    return handleDragScroll(scrollContainer ? elementScrollViewport(scrollContainer) : null, !!dragging, {
+      onScroll: updateDraggingPosition,
+    });
   });
 
   $effect.pre(() => {
@@ -305,8 +324,8 @@
           onAddNote={() => handleAddNote('shortcut')}
           onBeginResolve={() => handleBeginResolve(note.id)}
           onDragEnd={handleDragEnd}
-          onDragEnter={() => handleDragEnter(note.id)}
-          onDragMove={handleDragEnter}
+          onDragEnter={() => moveDraggingNote(note.id)}
+          onDragMove={updateDraggingPosition}
           onDragStart={() => handleDragStart(note.id)}
           onEndResolve={() => handleEndResolve(note.id)}
           resolving={resolvingNoteIds.has(note.id)}
@@ -373,8 +392,8 @@
                 /* noop: resolved notes */
               }}
               onDragEnd={handleDragEnd}
-              onDragEnter={() => handleDragEnter(note.id)}
-              onDragMove={handleDragEnter}
+              onDragEnter={() => moveDraggingNote(note.id)}
+              onDragMove={updateDraggingPosition}
               onDragStart={() => handleDragStart(note.id)}
               onEndResolve={() => {
                 /* noop: resolved notes */

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanelNoteItem.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanelNoteItem.svelte
@@ -23,9 +23,9 @@
     resolving: boolean;
     onAddNote: () => void;
     onBeginResolve: () => void;
-    onDragEnd: () => void;
+    onDragEnd: (clientX: number, clientY: number) => void;
     onDragEnter: () => void;
-    onDragMove: (noteId: string) => void;
+    onDragMove: (clientX: number, clientY: number) => void;
     onDragStart: () => void;
     onEndResolve: () => void;
   };
@@ -269,21 +269,13 @@
       if (state.started && state.ghost) {
         state.ghost.style.left = `${ev.clientX - state.offsetX}px`;
         state.ghost.style.top = `${ev.clientY - state.offsetY}px`;
-
-        const elemBelow = document.elementFromPoint(ev.clientX, ev.clientY);
-        const noteBelow = elemBelow?.closest('[data-related-note-id]') as HTMLElement | null;
-        if (noteBelow) {
-          const noteId = noteBelow.dataset.relatedNoteId;
-          if (noteId && noteId !== note.data.id) {
-            onDragMove(noteId);
-          }
-        }
+        onDragMove(ev.clientX, ev.clientY);
       }
     };
 
-    const handleUp = () => {
+    const handleUp = (ev: PointerEvent) => {
       if (state.started) {
-        onDragEnd();
+        onDragEnd(ev.clientX, ev.clientY);
       }
       cleanup();
     };


### PR DESCRIPTION
- 관련 노트에서 edge auto scroll 중 현재 포인터 위치로 순서 갱신
- pointer up 직전에 최신 DOM geometry로 reorder 대상 재계산
- #4935 #4939 의 후속