### PR TITLE
웹 노트 drag 취소 시 순서와 상태 복원

### DIFF
--- a/apps/website/src/routes/website/(dashboard)/@notes/Note.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@notes/Note.svelte
@@ -5,6 +5,7 @@
   import { autosize, tooltip } from '@typie/ui/actions';
   import { HorizontalDivider, Icon, Menu, MenuItem, Submenu, TimeAgo } from '@typie/ui/components';
   import { Dialog } from '@typie/ui/notification';
+  import { onDestroy } from 'svelte';
   import CheckIcon from '~icons/lucide/check';
   import CircleIcon from '~icons/lucide/circle';
   import CircleCheckIcon from '~icons/lucide/circle-check';
@@ -44,6 +45,7 @@
     onupdatecontent: (id: string, content: string) => void;
     ondragstart: () => void;
     ondragend: () => void;
+    ondragcancel: () => void;
     ondragmove: (noteId: string) => void;
     onaddentity: (noteId: string) => void;
     onremoveentity: (noteId: string, entityId: string) => void;
@@ -64,6 +66,7 @@
     onupdatecontent,
     ondragstart,
     ondragend,
+    ondragcancel,
     ondragmove,
     onaddentity,
     onremoveentity,
@@ -90,7 +93,9 @@
   }
 
   const DRAG_THRESHOLD = 5;
-  let dragCleanup: (() => void) | null = null;
+  let cancelDrag: (() => void) | null = null;
+
+  onDestroy(() => cancelDrag?.());
 
   $effect(() => {
     const serverContent = note.content;
@@ -163,6 +168,7 @@
     e.preventDefault();
     const el = e.currentTarget as HTMLElement;
     const rect = el.getBoundingClientRect();
+    const pointerId = e.pointerId;
 
     const state = {
       startX: e.clientX,
@@ -172,17 +178,27 @@
       started: false,
       ghost: null as HTMLElement | null,
       cursorStyle: null as HTMLStyleElement | null,
+      active: true,
     };
 
-    const cleanup = () => {
+    const cleanup = (cancelled = false) => {
+      if (!state.active) return;
+      const wasStarted = state.started;
+      state.active = false;
       state.ghost?.remove();
       state.cursorStyle?.remove();
       document.removeEventListener('pointermove', handleMove);
       document.removeEventListener('pointerup', handleUp);
-      dragCleanup = null;
+      document.removeEventListener('pointercancel', handleCancel);
+      cancelDrag = null;
+      if (cancelled && wasStarted) {
+        ondragcancel();
+      }
     };
 
     const handleMove = (ev: PointerEvent) => {
+      if (ev.pointerId !== pointerId) return;
+
       const dist = Math.abs(ev.clientX - state.startX) + Math.abs(ev.clientY - state.startY);
 
       if (!state.started && dist > DRAG_THRESHOLD) {
@@ -227,19 +243,28 @@
       }
     };
 
-    const handleUp = () => {
-      if (state.started) {
+    const handleUp = (ev: PointerEvent) => {
+      if (ev.pointerId !== pointerId) return;
+
+      const wasStarted = state.started;
+      cleanup();
+      if (wasStarted) {
         ondragend();
       } else {
         onexpand(note.id);
       }
-      cleanup();
     };
 
-    dragCleanup?.();
+    const handleCancel = (ev: PointerEvent) => {
+      if (ev.pointerId !== pointerId) return;
+      cleanup(true);
+    };
+
+    cancelDrag?.();
     document.addEventListener('pointermove', handleMove);
     document.addEventListener('pointerup', handleUp);
-    dragCleanup = cleanup;
+    document.addEventListener('pointercancel', handleCancel);
+    cancelDrag = () => cleanup(true);
   }}
   ontransitionend={(e) => {
     if (e.target === e.currentTarget && e.propertyName === 'opacity' && resolving && !cancelling) {

--- a/apps/website/src/routes/website/(dashboard)/@notes/Notes.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@notes/Notes.svelte
@@ -256,6 +256,21 @@
     };
   };
 
+  const handleDragCancel = (noteId: string) => {
+    if (dragging?.noteId !== noteId) return;
+
+    const { originalIndex } = dragging;
+    const currentIndex = localNoteOrder.indexOf(noteId);
+    dragging = null;
+
+    if (currentIndex === -1 || originalIndex === -1 || currentIndex === originalIndex) return;
+
+    const restoredOrder = [...localNoteOrder];
+    const [removed] = restoredOrder.splice(currentIndex, 1);
+    restoredOrder.splice(originalIndex, 0, removed);
+    localNoteOrder = restoredOrder;
+  };
+
   const handleExpand = (noteId: string) => {
     expandedNoteId = noteId;
   };
@@ -557,6 +572,7 @@
               onchangecolor={handleChangeColor}
               oncollapse={handleCollapse}
               ondelete={handleDeleteNote}
+              ondragcancel={() => handleDragCancel(note.id)}
               ondragend={handleDragEnd}
               ondragmove={handleNoteDragEnter}
               ondragstart={() => handleDragStart(note.id)}
@@ -610,6 +626,7 @@
                 onchangecolor={handleChangeColor}
                 oncollapse={handleCollapse}
                 ondelete={handleDeleteNote}
+                ondragcancel={() => handleDragCancel(note.id)}
                 ondragend={handleDragEnd}
                 ondragmove={handleNoteDragEnter}
                 ondragstart={() => handleDragStart(note.id)}

--- a/apps/website/src/routes/website/(dashboard)/@widgets/widgets/DocumentRelatedNoteWidget.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@widgets/widgets/DocumentRelatedNoteWidget.svelte
@@ -155,6 +155,21 @@
     };
   };
 
+  const handleDragCancel = (noteId: string) => {
+    if (dragging?.noteId !== noteId) return;
+
+    const { originalIndex } = dragging;
+    const currentIndex = localNoteOrder.indexOf(noteId);
+    dragging = null;
+
+    if (currentIndex === -1 || originalIndex === -1 || currentIndex === originalIndex) return;
+
+    const restoredOrder = [...localNoteOrder];
+    const [removed] = restoredOrder.splice(currentIndex, 1);
+    restoredOrder.splice(originalIndex, 0, removed);
+    localNoteOrder = restoredOrder;
+  };
+
   const moveDraggingNote = (noteId: string) => {
     if (dragging && dragging.noteId !== noteId) {
       const draggedIndex = localNoteOrder.indexOf(dragging.noteId);
@@ -367,6 +382,7 @@
           note$key={note}
           onAddNote={() => handleAddNote('shortcut')}
           onBeginResolve={() => handleBeginResolve(note.id)}
+          onDragCancel={() => handleDragCancel(note.id)}
           onDragEnd={handleDragEnd}
           onDragEnter={() => moveDraggingNote(note.id)}
           onDragMove={updateDraggingPosition}

--- a/apps/website/src/routes/website/(dashboard)/@widgets/widgets/DocumentRelatedNoteWidgetItem.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@widgets/widgets/DocumentRelatedNoteWidgetItem.svelte
@@ -7,6 +7,7 @@
   import { HorizontalDivider, Icon, Menu, MenuItem, Submenu } from '@typie/ui/components';
   import { Dialog } from '@typie/ui/notification';
   import mixpanel from 'mixpanel-browser';
+  import { onDestroy } from 'svelte';
   import CheckIcon from '~icons/lucide/check';
   import CircleIcon from '~icons/lucide/circle';
   import CircleCheckIcon from '~icons/lucide/circle-check';
@@ -24,6 +25,7 @@
     resolving: boolean;
     onAddNote: () => void;
     onBeginResolve: () => void;
+    onDragCancel: () => void;
     onDragEnd: (clientX: number, clientY: number) => void;
     onDragEnter: () => void;
     onDragMove: (clientX: number, clientY: number) => void;
@@ -38,6 +40,7 @@
     resolving,
     onAddNote,
     onBeginResolve,
+    onDragCancel,
     onDragEnd,
     onDragEnter,
     onDragMove,
@@ -94,7 +97,9 @@
   const colorHex = $derived(getNoteColor(note.data.color) ?? token('colors.surface.default'));
 
   const DRAG_THRESHOLD = 5;
-  let dragCleanup: (() => void) | null = null;
+  let cancelDrag: (() => void) | null = null;
+
+  onDestroy(() => cancelDrag?.());
 
   let cancelling = $state(false);
   const displayStatus = $derived(cancelling ? 'OPEN' : resolving ? 'RESOLVED' : note.data.status);
@@ -220,6 +225,7 @@
     e.preventDefault();
     const el = e.currentTarget as HTMLElement;
     const rect = el.getBoundingClientRect();
+    const pointerId = e.pointerId;
 
     const state = {
       startX: e.clientX,
@@ -229,17 +235,27 @@
       started: false,
       ghost: null as HTMLElement | null,
       cursorStyle: null as HTMLStyleElement | null,
+      active: true,
     };
 
-    const cleanup = () => {
+    const cleanup = (cancelled = false) => {
+      if (!state.active) return;
+      const wasStarted = state.started;
+      state.active = false;
       state.ghost?.remove();
       state.cursorStyle?.remove();
       document.removeEventListener('pointermove', handleMove);
       document.removeEventListener('pointerup', handleUp);
-      dragCleanup = null;
+      document.removeEventListener('pointercancel', handleCancel);
+      cancelDrag = null;
+      if (cancelled && wasStarted) {
+        onDragCancel();
+      }
     };
 
     const handleMove = (ev: PointerEvent) => {
+      if (ev.pointerId !== pointerId) return;
+
       const dist = Math.abs(ev.clientX - state.startX) + Math.abs(ev.clientY - state.startY);
 
       if (!state.started && dist > DRAG_THRESHOLD) {
@@ -277,16 +293,25 @@
     };
 
     const handleUp = (ev: PointerEvent) => {
-      if (state.started) {
+      if (ev.pointerId !== pointerId) return;
+
+      const wasStarted = state.started;
+      cleanup();
+      if (wasStarted) {
         onDragEnd(ev.clientX, ev.clientY);
       }
-      cleanup();
     };
 
-    dragCleanup?.();
+    const handleCancel = (ev: PointerEvent) => {
+      if (ev.pointerId !== pointerId) return;
+      cleanup(true);
+    };
+
+    cancelDrag?.();
     document.addEventListener('pointermove', handleMove);
     document.addEventListener('pointerup', handleUp);
-    dragCleanup = cleanup;
+    document.addEventListener('pointercancel', handleCancel);
+    cancelDrag = () => cleanup(true);
   }}
   ontransitionend={(e) => {
     if (e.target === e.currentTarget && e.propertyName === 'opacity' && resolving && !cancelling) {

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanelNote.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanelNote.svelte
@@ -127,6 +127,21 @@
     };
   };
 
+  const handleDragCancel = (noteId: string) => {
+    if (dragging?.noteId !== noteId) return;
+
+    const { originalIndex } = dragging;
+    const currentIndex = localNoteOrder.indexOf(noteId);
+    dragging = null;
+
+    if (currentIndex === -1 || originalIndex === -1 || currentIndex === originalIndex) return;
+
+    const restoredOrder = [...localNoteOrder];
+    const [removed] = restoredOrder.splice(currentIndex, 1);
+    restoredOrder.splice(originalIndex, 0, removed);
+    localNoteOrder = restoredOrder;
+  };
+
   const moveDraggingNote = (noteId: string) => {
     if (dragging && dragging.noteId !== noteId) {
       const draggedIndex = localNoteOrder.indexOf(dragging.noteId);
@@ -323,6 +338,7 @@
           note$key={note}
           onAddNote={() => handleAddNote('shortcut')}
           onBeginResolve={() => handleBeginResolve(note.id)}
+          onDragCancel={() => handleDragCancel(note.id)}
           onDragEnd={handleDragEnd}
           onDragEnter={() => moveDraggingNote(note.id)}
           onDragMove={updateDraggingPosition}
@@ -391,6 +407,7 @@
               onBeginResolve={() => {
                 /* noop: resolved notes */
               }}
+              onDragCancel={() => handleDragCancel(note.id)}
               onDragEnd={handleDragEnd}
               onDragEnter={() => moveDraggingNote(note.id)}
               onDragMove={updateDraggingPosition}

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanelNoteItem.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanelNoteItem.svelte
@@ -7,6 +7,7 @@
   import { HorizontalDivider, Icon, Menu, MenuItem, Submenu } from '@typie/ui/components';
   import { Dialog } from '@typie/ui/notification';
   import mixpanel from 'mixpanel-browser';
+  import { onDestroy } from 'svelte';
   import CheckIcon from '~icons/lucide/check';
   import CircleIcon from '~icons/lucide/circle';
   import CircleCheckIcon from '~icons/lucide/circle-check';
@@ -23,6 +24,7 @@
     resolving: boolean;
     onAddNote: () => void;
     onBeginResolve: () => void;
+    onDragCancel: () => void;
     onDragEnd: (clientX: number, clientY: number) => void;
     onDragEnter: () => void;
     onDragMove: (clientX: number, clientY: number) => void;
@@ -36,6 +38,7 @@
     resolving,
     onAddNote,
     onBeginResolve,
+    onDragCancel,
     onDragEnd,
     onDragEnter,
     onDragMove,
@@ -92,7 +95,9 @@
   const colorHex = $derived(getNoteColor(note.data.color) ?? token('colors.surface.default'));
 
   const DRAG_THRESHOLD = 5;
-  let dragCleanup: (() => void) | null = null;
+  let cancelDrag: (() => void) | null = null;
+
+  onDestroy(() => cancelDrag?.());
 
   $effect(() => {
     const serverContent = note.data.content;
@@ -217,6 +222,7 @@
     e.preventDefault();
     const el = e.currentTarget as HTMLElement;
     const rect = el.getBoundingClientRect();
+    const pointerId = e.pointerId;
 
     const state = {
       startX: e.clientX,
@@ -226,17 +232,27 @@
       started: false,
       ghost: null as HTMLElement | null,
       cursorStyle: null as HTMLStyleElement | null,
+      active: true,
     };
 
-    const cleanup = () => {
+    const cleanup = (cancelled = false) => {
+      if (!state.active) return;
+      const wasStarted = state.started;
+      state.active = false;
       state.ghost?.remove();
       state.cursorStyle?.remove();
       document.removeEventListener('pointermove', handleMove);
       document.removeEventListener('pointerup', handleUp);
-      dragCleanup = null;
+      document.removeEventListener('pointercancel', handleCancel);
+      cancelDrag = null;
+      if (cancelled && wasStarted) {
+        onDragCancel();
+      }
     };
 
     const handleMove = (ev: PointerEvent) => {
+      if (ev.pointerId !== pointerId) return;
+
       const dist = Math.abs(ev.clientX - state.startX) + Math.abs(ev.clientY - state.startY);
 
       if (!state.started && dist > DRAG_THRESHOLD) {
@@ -274,16 +290,25 @@
     };
 
     const handleUp = (ev: PointerEvent) => {
-      if (state.started) {
+      if (ev.pointerId !== pointerId) return;
+
+      const wasStarted = state.started;
+      cleanup();
+      if (wasStarted) {
         onDragEnd(ev.clientX, ev.clientY);
       }
-      cleanup();
     };
 
-    dragCleanup?.();
+    const handleCancel = (ev: PointerEvent) => {
+      if (ev.pointerId !== pointerId) return;
+      cleanup(true);
+    };
+
+    cancelDrag?.();
     document.addEventListener('pointermove', handleMove);
     document.addEventListener('pointerup', handleUp);
-    dragCleanup = cleanup;
+    document.addEventListener('pointercancel', handleCancel);
+    cancelDrag = () => cleanup(true);
   }}
   ontransitionend={(e) => {
     if (e.target === e.currentTarget && e.propertyName === 'opacity' && resolving && !cancelling) {


### PR DESCRIPTION
- 노트 drag가 pointer cancel 또는 item 제거로 종료되면 ghost와 edge auto scroll 정리
- 취소된 reorder는 원래 위치로 복원
- #4946 후속