### PR TITLE
에디터 HTML 붙여넣기 결과가 없으면 일반 텍스트 사용

### DIFF
--- a/crates/editor-clipboard/src/lib.rs
+++ b/crates/editor-clipboard/src/lib.rs
@@ -9,4 +9,4 @@ pub mod text;
 pub(crate) mod test_doc;
 
 pub use payload::ClipboardPayload;
-pub use slice::Slice;
+pub use slice::{PayloadSource, Slice};

--- a/crates/editor-clipboard/src/slice.rs
+++ b/crates/editor-clipboard/src/slice.rs
@@ -24,6 +24,12 @@ pub struct Slice {
     pub open_end: u32,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PayloadSource {
+    Html,
+    Text,
+}
+
 impl Slice {
     pub fn extract(state: &State) -> Option<Slice> {
         let view = state.view();
@@ -85,11 +91,19 @@ impl Slice {
         html_parse::from_html(html, resource)
     }
 
-    pub fn from_payload(html: Option<&str>, text: &str, resource: &Resource) -> Slice {
-        match html {
-            Some(h) if !h.is_empty() => Self::from_html(h, resource),
-            _ => Self::from_text(text),
+    pub fn from_payload(
+        html: Option<&str>,
+        text: &str,
+        resource: &Resource,
+    ) -> (Slice, PayloadSource) {
+        if let Some(html) = html.filter(|html| !html.is_empty()) {
+            let slice = Self::from_html(html, resource);
+            if !slice.is_empty() {
+                return (slice, PayloadSource::Html);
+            }
         }
+
+        (Self::from_text(text), PayloadSource::Text)
     }
 
     pub fn new(content: Vec<Fragment>, open_start: u32, open_end: u32) -> Self {
@@ -894,14 +908,27 @@ mod tests {
         assert!(!payload.text.is_empty());
 
         let resource = Resource::new_test();
-        let parsed = Slice::from_payload(Some(&payload.html), &payload.text, &resource);
+        let (parsed, source) = Slice::from_payload(Some(&payload.html), &payload.text, &resource);
+        assert_eq!(source, PayloadSource::Html);
         assert_eq!(parsed, original);
     }
 
     #[test]
     fn from_payload_text_only() {
-        let parsed = Slice::from_payload(None, "hello\n\nworld", &Resource::new_test());
+        let (parsed, source) = Slice::from_payload(None, "hello\n\nworld", &Resource::new_test());
+        assert_eq!(source, PayloadSource::Text);
         assert_eq!(parsed.content.len(), 3);
+    }
+
+    #[test]
+    fn from_payload_falls_back_to_text_when_html_yields_empty_slice() {
+        let (parsed, source) = Slice::from_payload(
+            Some("<script>ignored</script>"),
+            "plain",
+            &Resource::new_test(),
+        );
+        assert_eq!(source, PayloadSource::Text);
+        assert_eq!(parsed.to_text(), "plain");
     }
 
     #[test]
@@ -1108,7 +1135,8 @@ mod tests {
         let payload = original.to_payload(&Resource::new_test());
 
         let resource = Resource::new_test();
-        let parsed = Slice::from_payload(Some(&payload.html), &payload.text, &resource);
+        let (parsed, source) = Slice::from_payload(Some(&payload.html), &payload.text, &resource);
+        assert_eq!(source, PayloadSource::Html);
         let para = &parsed.content[0];
         assert!(
             para.carry.iter().any(|m| matches!(m, Modifier::Bold)),

--- a/crates/editor-commands/src/commands/insert_slice.rs
+++ b/crates/editor-commands/src/commands/insert_slice.rs
@@ -1141,7 +1141,9 @@ mod tests {
         };
         let original = Slice::extract(&source).expect("non-collapsed");
         let payload = original.to_payload(&Resource::new_test());
-        let parsed = Slice::from_payload(Some(&payload.html), &payload.text, &Resource::new_test());
+        let (parsed, source) =
+            Slice::from_payload(Some(&payload.html), &payload.text, &Resource::new_test());
+        assert_eq!(source, editor_clipboard::PayloadSource::Html);
         assert!(
             matches!(parsed.content[0].node, PlainNode::Image(_)),
             "sanity: payload carries the image"

--- a/crates/editor-core/src/handle/clipboard.rs
+++ b/crates/editor-core/src/handle/clipboard.rs
@@ -1,4 +1,4 @@
-use editor_clipboard::Slice;
+use editor_clipboard::{PayloadSource, Slice};
 use editor_commands::{self as commands};
 use editor_common::HistoryTag;
 use editor_model::{Fragment, PlainNode};
@@ -20,11 +20,11 @@ pub fn handle_clipboard_op(editor: &mut Editor, op: ClipboardOp) -> Result<(), E
             Ok(())
         }),
         ClipboardOp::Paste { html, text } => {
-            let slice = {
+            let (slice, source) = {
                 let resource = editor.resource.lock().unwrap();
                 Slice::from_payload(html.as_deref(), &text, &resource)
             };
-            let is_html_paste = html.as_deref().is_some_and(|h| !h.is_empty());
+            let is_html_paste = source == PayloadSource::Html;
             let provenance = if is_html_paste {
                 commands::types::SliceProvenance::Formatted
             } else {
@@ -1118,6 +1118,29 @@ mod tests {
                 text: "plain".into(),
             },
         });
+        assert!(editor.last_history_tag().is_none());
+    }
+
+    #[test]
+    fn paste_html_that_yields_empty_slice_falls_back_to_plain_text() {
+        let (s, ..) = state! {
+            doc { root { p1: paragraph { text("") } } }
+            selection: (p1, 0)
+        };
+        let mut editor = Editor::new_test(s);
+
+        editor.apply(Message::Clipboard {
+            op: ClipboardOp::Paste {
+                html: Some("<script>ignored</script>".into()),
+                text: "plain".into(),
+            },
+        });
+
+        let (expected, ..) = state! {
+            doc { root { p1: paragraph { text("plain") } } }
+            selection: (p1, 5)
+        };
+        assert_state_eq!(editor.state(), &expected);
         assert!(editor.last_history_tag().is_none());
     }
 

--- a/crates/editor-core/src/handle/dnd.rs
+++ b/crates/editor-core/src/handle/dnd.rs
@@ -2,7 +2,7 @@ use crate::dnd::DndState;
 use crate::editor::Editor;
 use crate::error::EditorError;
 use crate::message::{DndDropPayload, DndOp, ExternalDndPayloadKind, InputModifiers};
-use editor_clipboard::Slice;
+use editor_clipboard::{PayloadSource, Slice};
 use editor_commands::{self as commands};
 use editor_model::{DocView, Fragment, Node, PlainFileNode, PlainImageNode, PlainNode};
 use editor_state::{Position, Selection, StableResolveCtx, StableSelection, State};
@@ -251,9 +251,13 @@ fn apply_drop(
 ) -> Result<(), EditorError> {
     match payload {
         DndDropPayload::Text { text, html } => {
-            let (slice, provenance) = {
+            let (slice, source) = {
                 let resource = editor.resource.lock().unwrap();
-                slice_from_drop_text_payload(&text, html.as_deref(), &resource)
+                Slice::from_payload(html.as_deref(), &text, &resource)
+            };
+            let provenance = match source {
+                PayloadSource::Html => commands::types::SliceProvenance::Formatted,
+                PayloadSource::Text => commands::types::SliceProvenance::Plain,
             };
             // TODO: Legacy drop_external filled missing inline styles from
             // the target cascade. Keep this as a separate parity issue rather than
@@ -311,24 +315,6 @@ fn drop_slice_at(
         }
         Ok(())
     })
-}
-
-fn slice_from_drop_text_payload(
-    text: &str,
-    html: Option<&str>,
-    resource: &editor_resource::Resource,
-) -> (Slice, commands::types::SliceProvenance) {
-    if let Some(html) = html.filter(|html| !html.is_empty()) {
-        let slice = Slice::from_html(html, resource);
-        if !slice.is_empty() {
-            return (slice, commands::types::SliceProvenance::Formatted);
-        }
-    }
-
-    (
-        Slice::from_text(text),
-        commands::types::SliceProvenance::Plain,
-    )
 }
 
 fn drop_internal_selection_at(


### PR DESCRIPTION
- HTML clipboard payload에서 에디터 콘텐츠를 얻지 못하면 함께 전달된 일반 텍스트로 fallback하고, 복구 가능한 HTML은 기존 서식 붙여넣기 유지
- `Slice::from_payload`가 실제로 사용한 `PayloadSource`를 반환하도록 해 Clipboard의 provenance와 “텍스트만 붙여넣기” 상태를 선택 결과에 맞게 처리
- DnD도 같은 payload 선택 정책을 사용하도록 통합하고 빈 HTML 결과에 대한 회귀 테스트 추가