### PR TITLE
앱 에디터 오류 발생 시 마지막 렌더 유지

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorView.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorView.kt
@@ -133,56 +133,64 @@ internal fun EditorView(
   }
 
   Box(modifier) {
-    val session = runtime.session ?: return@Box
-    val editor = session.editor
-    val focusManager = LocalFocusManager.current
-    var previousSelection by remember(editor) { mutableStateOf(editor.selection) }
-    LaunchedEffect(editor, themeVariant) {
-      val changed = PlatformModule.editorHost.setThemeVariant(themeVariant)
-      if (changed) {
-        for (registeredEditor in EditorRegistry.snapshot()) {
-          registeredEditor.enqueue(Message.System(SystemEvent.ThemeVariantChanged))
+    val session = runtime.session
+    val editor = session?.editor ?: runtime.failedEditor ?: return@Box
+    val sessionActive = session != null
+
+    if (session != null) {
+      val focusManager = LocalFocusManager.current
+      var previousSelection by remember(editor) { mutableStateOf(editor.selection) }
+      LaunchedEffect(editor, themeVariant) {
+        val changed = PlatformModule.editorHost.setThemeVariant(themeVariant)
+        if (changed) {
+          for (registeredEditor in EditorRegistry.snapshot()) {
+            registeredEditor.enqueue(Message.System(SystemEvent.ThemeVariantChanged))
+          }
         }
       }
-    }
-    val autoSurroundEnabled = Preference.autoSurroundEnabled
-    LaunchedEffect(autoSurroundEnabled) {
-      PlatformModule.editorHost.setAutoSurroundEnabled(autoSurroundEnabled)
-    }
-    LaunchedEffect(editor, editor.selection, uiState.focused) {
-      val currentSelection = editor.selection
-      val selectionCleared = previousSelection != null && currentSelection == null
-      previousSelection = currentSelection
-      if (selectionCleared && uiState.focused) {
-        focusManager.clearFocus()
+      val autoSurroundEnabled = Preference.autoSurroundEnabled
+      LaunchedEffect(autoSurroundEnabled) {
+        PlatformModule.editorHost.setAutoSurroundEnabled(autoSurroundEnabled)
       }
-    }
-    SideEffect { editor.focusManager = focusManager }
-    DisposableEffect(session, uiState) {
-      onDispose {
-        uiState.clear()
-        runtime.clear(session)
+      LaunchedEffect(editor, editor.selection, uiState.focused) {
+        val currentSelection = editor.selection
+        val selectionCleared = previousSelection != null && currentSelection == null
+        previousSelection = currentSelection
+        if (selectionCleared && uiState.focused) {
+          focusManager.clearFocus()
+        }
+      }
+      SideEffect { editor.focusManager = focusManager }
+      DisposableEffect(session, uiState) {
+        onDispose {
+          uiState.clear()
+          runtime.clear(session)
+        }
       }
     }
 
-    Box(
-      Modifier.fillMaxWidth()
-        .focusRequester(editor.focusRequester)
-        .onFocusChanged {
-          uiState.updateFocus(it.isFocused)
-          editor.enqueue(Message.System(SystemEvent.SetFocused(it.isFocused)))
-        }
-        .editorInput(
-          enabled = editorInputEnabled,
-          session = session,
-          uiState = uiState,
-          platform = platform,
-          bringIntoViewRequests = bringIntoViewRequests,
-          suppressSoftwareKeyboard = suppressSoftwareKeyboard,
-          clipboard = PlatformModule.clipboard,
-        )
-        .focusable()
-    ) {
+    val editorInteractionModifier =
+      if (session != null) {
+        Modifier.focusRequester(editor.focusRequester)
+          .onFocusChanged {
+            uiState.updateFocus(it.isFocused)
+            editor.enqueue(Message.System(SystemEvent.SetFocused(it.isFocused)))
+          }
+          .editorInput(
+            enabled = editorInputEnabled,
+            session = session,
+            uiState = uiState,
+            platform = platform,
+            bringIntoViewRequests = bringIntoViewRequests,
+            suppressSoftwareKeyboard = suppressSoftwareKeyboard,
+            clipboard = PlatformModule.clipboard,
+          )
+          .focusable()
+      } else {
+        Modifier
+      }
+
+    Box(Modifier.fillMaxWidth().then(editorInteractionModifier)) {
       val pageSpacing =
         when (layoutSpec) {
           is EditorDocumentLayoutSpec.Continuous -> 0.dp
@@ -196,8 +204,10 @@ internal fun EditorView(
         verticalArrangement = Arrangement.spacedBy(pageSpacing),
       ) {
         editor.pageSizes.forEachIndexed { index, size ->
-          val pageCursor = editor.cursor?.takeIf { it.pageIdx == index }
-          val pageExternalElements = editor.externalElements.filter { it.pageIdx == index }
+          val pageCursor = editor.cursor?.takeIf { sessionActive && it.pageIdx == index }
+          val pageExternalElements =
+            if (sessionActive) editor.externalElements.filter { it.pageIdx == index }
+            else emptyList()
           EditorPageSurface(
             page = index,
             width = size.width,
@@ -210,7 +220,7 @@ internal fun EditorView(
               },
             showDebugOverlay = showDebugSurfaceOverlay,
             backgroundOverlay = {
-              if (layoutSpec is EditorDocumentLayoutSpec.Paginated) {
+              if (sessionActive && layoutSpec is EditorDocumentLayoutSpec.Paginated) {
                 EditorLineHighlightOverlay(
                   cursor = pageCursor,
                   focused = uiState.focused,
@@ -221,24 +231,30 @@ internal fun EditorView(
               }
             },
             foregroundOverlay = {
-              EditorExternalElementOverlay(
-                elements = pageExternalElements,
-                displayZoom = displayZoom,
-              )
-              EditorCursorOverlay(
-                cursor = pageCursor,
-                focused = uiState.focused,
-                displayZoom = displayZoom,
-              )
+              if (sessionActive) {
+                EditorExternalElementOverlay(
+                  elements = pageExternalElements,
+                  displayZoom = displayZoom,
+                )
+                EditorCursorOverlay(
+                  cursor = pageCursor,
+                  focused = uiState.focused,
+                  displayZoom = displayZoom,
+                )
+              }
               // TODO(editor-parity): selection rect, composition rect, 인라인 맞춤법 하이라이트,
               // 인라인 리마크 하이라이트 같은 foreground overlay도 surface-local로 채워 넣어야 한다.
             },
             modifier =
-              Modifier.editorPagePositionTracker(
-                uiState = uiState,
-                page = index,
-                density = density.density,
-              ),
+              if (sessionActive) {
+                Modifier.editorPagePositionTracker(
+                  uiState = uiState,
+                  page = index,
+                  density = density.density,
+                )
+              } else {
+                Modifier
+              },
           )
         }
       }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/runtime/EditorRuntime.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/runtime/EditorRuntime.kt
@@ -15,6 +15,8 @@ import kotlinx.coroutines.launch
 
 @Stable
 class EditorRuntime(private val uiScope: CoroutineScope) {
+  private data class Failure(val error: Throwable, val editor: Editor?)
+
   private sealed interface Attachment {
     val editor: Editor
   }
@@ -27,6 +29,7 @@ class EditorRuntime(private val uiScope: CoroutineScope) {
   }
 
   private var attachment by mutableStateOf<Attachment?>(null)
+  private var failure by mutableStateOf<Failure?>(null)
 
   val editor: Editor?
     get() = attachment?.editor
@@ -34,8 +37,13 @@ class EditorRuntime(private val uiScope: CoroutineScope) {
   internal val session: DocumentEditingSession?
     get() = (attachment as? DocumentSession)?.session
 
-  var error by mutableStateOf<Throwable?>(null)
-    private set
+  val error: Throwable?
+    get() = failure?.error
+
+  // The editor is already disposed; retain it only to keep its last committed surfaces composed
+  // until the error is cleared.
+  internal val failedEditor: Editor?
+    get() = failure?.editor
 
   val canCreateEditor: Boolean
     get() = editor == null && error == null
@@ -124,7 +132,7 @@ class EditorRuntime(private val uiScope: CoroutineScope) {
     val detail = error.cause?.let { "$error; cause=$it" } ?: error.toString()
     Logger.e(error) { "Editor failed: $detail" }
     Sentry.captureException(error)
-    this.error = error
+    failure = Failure(error = error, editor = editor)
     clear()
   }
 
@@ -134,7 +142,7 @@ class EditorRuntime(private val uiScope: CoroutineScope) {
   }
 
   fun clearError() {
-    error = null
+    failure = null
   }
 
   fun focus(): Boolean = editor?.focus() == true

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/surface/EditorPageSurface.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/surface/EditorPageSurface.kt
@@ -58,7 +58,8 @@ internal fun EditorPageSurface(
   val displayZoom = zoomController.displayZoom
   val renderZoom = zoomController.renderZoom
   val scaleFactor = density.density.toDouble() * renderZoom.toDouble()
-  val editor = LocalEditorRuntime.current.editor ?: return
+  val runtime = LocalEditorRuntime.current
+  val editor = runtime.editor ?: runtime.failedEditor ?: return
 
   val trigger = remember {
     MutableSharedFlow<Long>(replay = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -981,10 +981,11 @@ fun EditorScreen(entityId: String) {
     }
   }
 
+  val layoutEditor = editor ?: runtime.failedEditor
   val preloadedLayoutSpec =
     remember(document?.layoutMode) { resolveEditorLoadingLayoutSpec(document?.layoutMode) }
   val layoutSpec: EditorDocumentLayoutSpec =
-    editor?.state?.rootAttrs?.layoutMode?.toEditorDocumentLayoutSpec()
+    layoutEditor?.state?.rootAttrs?.layoutMode?.toEditorDocumentLayoutSpec()
       ?: preloadedLayoutSpec
       ?: EditorDocumentLayoutSpec.Continuous(maxWidth = 600f)
   val background =
@@ -1019,7 +1020,7 @@ fun EditorScreen(entityId: String) {
         hideContextMenu = { uiState.contextMenu.hide() },
         openSheet = { subPaneState.open(EditorSubPane.Comments) },
       )
-    val pageSizes = editorState.pageSizes
+    val layoutPageSizes = layoutEditor?.pageSizes.orEmpty()
     val density = LocalDensity.current.density
     val focusManager = LocalFocusManager.current
     val haptic = LocalHapticFeedback.current
@@ -1279,12 +1280,12 @@ fun EditorScreen(entityId: String) {
         is EditorDocumentLayoutSpec.Continuous -> 0f
       }
     val pagesContentHeight =
-      layoutSpec.resolvePagesContentHeight(pageSizes, displayZoom, density = density)
+      layoutSpec.resolvePagesContentHeight(layoutPageSizes, displayZoom, density = density)
     val bodyGeometry =
       resolveEditorBodyGeometry(
         visibleArea = visibleArea,
         layoutSpec = layoutSpec,
-        pageSizes = pageSizes,
+        pageSizes = layoutPageSizes,
         displayZoom = displayZoom,
       )
     val distanceToPagesBottom =
@@ -1316,14 +1317,14 @@ fun EditorScreen(entityId: String) {
     val headerTrackWidth =
       resolveEditorHeaderTrackWidth(
         layoutSpec = layoutSpec,
-        resolvedPageWidth = resolveEditorPageWidth(pageSizes),
+        resolvedPageWidth = resolveEditorPageWidth(layoutPageSizes),
         visibleBodyWidth = visibleArea.visibleBodySize.width,
         bodyTrackWidth = bodyTrackWidth,
       )
     val editorGeometryValid =
       hasValidEditorGeometry(
         editorAttached = editor != null,
-        pageSizes = pageSizes,
+        pageSizes = editorState.pageSizes,
         trackWidth = bodyTrackWidth,
       )
     val editorReady = !loading && editorGeometryValid && editorSessionAttached
@@ -1400,7 +1401,7 @@ fun EditorScreen(entityId: String) {
             zoomController = zoomController,
             viewportState = screenState.viewportState,
             uiState = uiState,
-            pageSizes = pageSizes,
+            pageSizes = layoutPageSizes,
             viewportWidth = visibleArea.visibleBodySize.width,
             density = density,
             onZoomSnap = { haptic.performHapticFeedback(HapticFeedbackType.SegmentTick) },
@@ -1531,11 +1532,11 @@ fun EditorScreen(entityId: String) {
               viewportState = screenState.viewportState,
               visibleArea = visibleArea,
               layoutSpec = layoutSpec,
-              pageSizes = pageSizes,
+              pageSizes = layoutPageSizes,
               displayZoom = displayZoom,
               modifier = Modifier.fillMaxSize(),
             )
-          } else {
+          } else if (runtime.error == null) {
             EditorLoadingSkeleton(
               layoutSpec = layoutSpec,
               topInset = topInset,
@@ -1619,7 +1620,7 @@ fun EditorScreen(entityId: String) {
                     placeholder = editorState.placeholder,
                     geometry = bodyGeometry,
                     layoutSpec = layoutSpec,
-                    pageSizes = pageSizes,
+                    pageSizes = layoutPageSizes,
                     displayZoom = displayZoom,
                     modifier = Modifier.fillMaxSize(),
                     onLoadTemplate = ::openTemplateSheet,

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/runtime/EditorRuntimeTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/runtime/EditorRuntimeTest.kt
@@ -107,4 +107,26 @@ class EditorRuntimeTest {
     assertSame(second, runtime.session)
     assertNull(runtime.error)
   }
+
+  @Test
+  fun fatalErrorRetainsEditorWithoutKeepingItActive() = runTest {
+    val editor = Editor(FakeFfiEditor(), this, StandardTestDispatcher(testScheduler))
+    val session = createSession(editor)
+    val runtime = EditorRuntime(uiScope = this)
+    val failure = IllegalStateException("fatal editor failure")
+
+    runtime.attach(session)
+    runtime.reportError(session, failure)
+    runCurrent()
+
+    assertSame(failure, runtime.error)
+    assertNull(runtime.editor)
+    assertNull(runtime.session)
+    assertSame(editor, runtime.failedEditor)
+
+    runtime.clearError()
+
+    assertNull(runtime.error)
+    assertNull(runtime.failedEditor)
+  }
 }


### PR DESCRIPTION
- 에디터 오류 다이얼로그가 열린 동안 제목, 부제목과 마지막으로 렌더링된 문서 화면 유지
- 실패한 에디터는 활성 session에서 즉시 분리해 입력과 편집 overlay는 중단하고, 이미 렌더링된 surface만 오류 해제 전까지 보존
- 오류 상태에서 loading skeleton을 다시 표시하지 않으며 관련 runtime 회귀 테스트 추가