### PR TITLE
앱 슬라이더 햅틱 정책 통일

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/ImageResizeSecondaryToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/ImageResizeSecondaryToolbar.kt
@@ -10,14 +10,8 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.hapticfeedback.HapticFeedbackType
-import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -39,7 +33,6 @@ import co.typie.ui.component.Text
 import co.typie.ui.theme.AppTheme
 import kotlin.math.roundToInt
 
-private const val IMAGE_RESIZE_HAPTIC_STEP = 5
 private val ImageResizeToolbarItemGap = 8.dp
 private val ImageResizeToolbarEndPadding = 12.dp
 
@@ -78,33 +71,15 @@ internal fun ImageResizeSecondaryToolbar(
       range.last.toFloat(),
     )
   val currentPercent = currentProportion.roundToInt()
-  val haptic = LocalHapticFeedback.current
-  var lastHapticStop by remember(nodeId) { mutableStateOf<Int?>(null) }
 
   DisposableEffect(nodeId) { onDispose { imageState.resizeDraftProportions.remove(nodeId) } }
 
-  fun maybeHaptic(value: Float) {
-    val percent = value.roundToInt()
-    val stop =
-      when {
-        percent == range.first || percent == range.last -> percent
-        percent % IMAGE_RESIZE_HAPTIC_STEP == 0 -> percent
-        else -> null
-      }
-    if (stop != null && stop != lastHapticStop) {
-      haptic.performHapticFeedback(HapticFeedbackType.SegmentTick)
-      lastHapticStop = stop
-    }
-  }
-
   fun updateDraft(value: Float) {
     val next = value.coerceIn(range.first.toFloat(), range.last.toFloat())
-    maybeHaptic(next)
     imageState.resizeDraftProportions[nodeId] = next
   }
 
   fun startDraft() {
-    lastHapticStop = null
     imageState.resizeDraftProportions[nodeId] = currentProportion
   }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/editorsettings/EditorSettingsScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/editorsettings/EditorSettingsScreen.kt
@@ -12,8 +12,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.hapticfeedback.HapticFeedbackType
-import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.unit.dp
 import co.typie.domain.settings.SettingControlRow
 import co.typie.domain.settings.SettingSwitch
@@ -33,7 +31,6 @@ import co.typie.ui.theme.AppTheme
 @Composable
 fun EditorSettingsScreen() {
   val scrollState = rememberScrollState()
-  val haptic = LocalHapticFeedback.current
 
   ProvideTopBar(
     center = { Text("에디터", style = AppTheme.typography.title) },
@@ -92,10 +89,7 @@ fun EditorSettingsScreen() {
                 range = 0f..100f,
                 step = 5f,
                 onDragStart = {},
-                onDrag = { next ->
-                  haptic.performHapticFeedback(HapticFeedbackType.SegmentTick)
-                  Preference.typewriterPosition = next.toDouble() / 100.0
-                },
+                onDrag = { next -> Preference.typewriterPosition = next.toDouble() / 100.0 },
                 onDragEnd = {},
                 fillColor = AppTheme.colors.textDefault.copy(alpha = 0.75f),
                 modifier = Modifier.weight(1f).height(32.dp),

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/Slider.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/Slider.kt
@@ -19,10 +19,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.changedToUp
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.times
@@ -31,6 +33,25 @@ import co.typie.ui.theme.AppTheme
 import co.typie.ui.theme.shadow
 import kotlin.math.abs
 import kotlin.math.roundToInt
+
+private const val MAX_REGULAR_HAPTIC_INTERVALS = 8
+
+internal fun sliderHapticFeedbackType(
+  range: ClosedFloatingPointRange<Float>,
+  step: Float?,
+  value: Float,
+): HapticFeedbackType? {
+  val normalizedStep = step?.takeIf { it > 0f }
+  if (normalizedStep == null) {
+    return if (value == range.start || value == range.endInclusive) HapticFeedbackType.GestureEnd
+    else null
+  }
+
+  val intervals =
+    ((range.endInclusive - range.start).coerceAtLeast(0f) / normalizedStep).roundToInt()
+  return if (intervals <= MAX_REGULAR_HAPTIC_INTERVALS) HapticFeedbackType.SegmentTick
+  else HapticFeedbackType.SegmentFrequentTick
+}
 
 internal class SliderGestureSession(
   initialValue: Float,
@@ -88,7 +109,9 @@ internal fun Slider(
   thumbContent: @Composable BoxScope.(Boolean) -> Unit = {},
 ) {
   val density = LocalDensity.current
+  val hapticFeedback = LocalHapticFeedback.current
   val currentValue by rememberUpdatedState(value)
+  val currentHapticFeedback by rememberUpdatedState(hapticFeedback)
   val currentOnDragStart by rememberUpdatedState(onDragStart)
   val currentOnDrag by rememberUpdatedState(onDrag)
   val currentOnDragEnd by rememberUpdatedState(onDragEnd)
@@ -145,7 +168,11 @@ internal fun Slider(
                 initialValue = currentValue,
                 valueFromX = ::valueFromX,
                 onDragStart = { currentOnDragStart() },
-                onDrag = { next -> currentOnDrag(next) },
+                onDrag = { next ->
+                  sliderHapticFeedbackType(range, normalizedStep, next)
+                    ?.let(currentHapticFeedback::performHapticFeedback)
+                  currentOnDrag(next)
+                },
               )
 
             while (true) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/editorsettings/EditorSettingsSnapSlider.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/editorsettings/EditorSettingsSnapSlider.kt
@@ -28,10 +28,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
@@ -67,7 +65,6 @@ internal fun EditorSettingsSnapSlider(
 ) {
   val scope = rememberCoroutineScope()
   val focusManager = LocalFocusManager.current
-  val haptic = LocalHapticFeedback.current
   val bringIntoViewRequester = remember { BringIntoViewRequester() }
 
   var isDragging by remember { mutableStateOf(false) }
@@ -107,10 +104,7 @@ internal fun EditorSettingsSnapSlider(
         dragValue = value
         focusManager.clearFocus()
       },
-      onDrag = { next ->
-        haptic.performHapticFeedback(HapticFeedbackType.SegmentTick)
-        dragValue = next.roundToInt().coerceIn(range.first, range.last)
-      },
+      onDrag = { next -> dragValue = next.roundToInt().coerceIn(range.first, range.last) },
       onDragEnd = { next ->
         val rounded = next.roundToInt().coerceIn(range.first, range.last)
         dragValue = rounded

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/ui/component/SliderTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/ui/component/SliderTest.kt
@@ -1,5 +1,6 @@
 package co.typie.ui.component
 
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -57,5 +58,84 @@ class SliderTest {
 
     assertEquals(45.4f, gesture.release())
     assertEquals(listOf("start", "drag:45.4"), events)
+  }
+
+  @Test
+  fun discrete_slider_uses_regular_ticks_through_eight_intervals() {
+    assertEquals(HapticFeedbackType.SegmentTick, sliderHapticFeedbackType(0f..8f, 1f, 4f))
+  }
+
+  @Test
+  fun discrete_slider_uses_frequent_ticks_above_eight_intervals() {
+    assertEquals(HapticFeedbackType.SegmentFrequentTick, sliderHapticFeedbackType(0f..9f, 1f, 4f))
+  }
+
+  @Test
+  fun current_discrete_slider_ranges_use_frequent_ticks() {
+    listOf(800f..2400f to 100f, -10f..40f to 5f, 80f..220f to 10f, 0f..100f to 5f).forEach {
+      (range, step) ->
+      assertEquals(
+        HapticFeedbackType.SegmentFrequentTick,
+        sliderHapticFeedbackType(range, step, range.start),
+      )
+    }
+  }
+
+  @Test
+  fun continuous_slider_uses_gesture_end_only_at_boundaries() {
+    assertEquals(null, sliderHapticFeedbackType(0f..100f, null, 50f))
+    assertEquals(HapticFeedbackType.GestureEnd, sliderHapticFeedbackType(0f..100f, null, 0f))
+    assertEquals(HapticFeedbackType.GestureEnd, sliderHapticFeedbackType(0f..100f, null, 100f))
+    assertEquals(null, sliderHapticFeedbackType(0f..100f, 0f, 50f))
+    assertEquals(null, sliderHapticFeedbackType(0f..100f, -1f, 50f))
+    assertEquals(HapticFeedbackType.GestureEnd, sliderHapticFeedbackType(0f..100f, -1f, 100f))
+  }
+
+  @Test
+  fun continuous_slider_emits_gesture_end_only_when_entering_a_clamped_boundary() {
+    val haptics = mutableListOf<HapticFeedbackType>()
+    val gesture =
+      SliderGestureSession(
+        initialValue = 50f,
+        valueFromX = { it.coerceIn(0f, 100f) },
+        onDragStart = {},
+        onDrag = { value ->
+          val haptic: HapticFeedbackType? = sliderHapticFeedbackType(0f..100f, null, value)
+          if (haptic != null) {
+            haptics += haptic
+          }
+        },
+      )
+
+    gesture.start()
+    gesture.updateAt(100f)
+    gesture.updateAt(120f)
+    gesture.updateAt(80f)
+    gesture.updateAt(100f)
+
+    assertEquals(listOf(HapticFeedbackType.GestureEnd, HapticFeedbackType.GestureEnd), haptics)
+  }
+
+  @Test
+  fun discrete_dense_slider_emits_one_tick_for_a_repeated_endpoint_update() {
+    val haptics = mutableListOf<HapticFeedbackType>()
+    val gesture =
+      SliderGestureSession(
+        initialValue = 50f,
+        valueFromX = { it.coerceIn(0f, 100f) },
+        onDragStart = {},
+        onDrag = { value ->
+          val haptic: HapticFeedbackType? = sliderHapticFeedbackType(0f..100f, 5f, value)
+          if (haptic != null) {
+            haptics += haptic
+          }
+        },
+      )
+
+    gesture.start()
+    gesture.updateAt(100f)
+    gesture.updateAt(120f)
+
+    assertEquals(listOf(HapticFeedbackType.SegmentFrequentTick), haptics)
   }
 }


### PR DESCRIPTION
## 배경

- Android Compose는 이산 선택에 `SegmentTick`, 선택지가 많은 경우에 `SegmentFrequentTick`을 제공하지만 구체적인 수치 기준은 정의하지 않음
- Wear Material3 Slider가 최소·최대를 제외한 step을 최대 8개까지 segmented control로 표현하는 기준을 참고
- Wear의 `steps`와 Typie의 interval은 단위가 직접 대응하지 않으므로, 이를 밀도 판단의 참고점으로만 삼아 8구간까지 `SegmentTick`, 그보다 많으면 `SegmentFrequentTick`을 사용하는 보수적인 Typie 정책으로 정의

참고:

- https://developer.android.com/reference/kotlin/androidx/compose/ui/hapticfeedback/HapticFeedbackType
- https://android.googlesource.com/platform/frameworks/support/+/faea5bc11aa75a503acf2753de366cc516f79a51/wear/compose/compose-material3/src/main/java/androidx/wear/compose/material3/Slider.kt

## 변경

- 공용 Slider가 이산형/연속형 값 특성에 따라 햅틱을 일관되게 처리하도록 변경
- 이산 슬라이더는 실제 값이 바뀔 때만 구간 밀도에 맞는 tick을 주고, 연속형 이미지 리사이즈는 최소/최대 도달 시에만 피드백
- 설정 화면과 이미지 리사이즈에 흩어진 햅틱 구현 및 5% stop을 제거하고 경계 진입·중복 억제 회귀 테스트 추가