### PR TITLE
웹 pointer capture gesture의 취소 처리 통합

### DIFF
--- a/apps/website/src/lib/editor-ffi/components/ExternalImage.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ExternalImage.svelte
@@ -2,7 +2,7 @@
   import { flip, hide } from '@floating-ui/dom';
   import { css, cx } from '@typie/styled-system/css';
   import { center, flex } from '@typie/styled-system/patterns';
-  import { createFloatingActions } from '@typie/ui/actions';
+  import { createFloatingActions, pointerCapture } from '@typie/ui/actions';
   import { Icon, Img, RingSpinner } from '@typie/ui/components';
   import { Toast } from '@typie/ui/notification';
   import DownloadIcon from '~icons/lucide/download';
@@ -31,13 +31,20 @@
     element: ExternalElement;
   };
 
+  type ResizeSession = {
+    x: number;
+    width: number;
+    proportion: number;
+    reverse: boolean;
+    boundsWidth: number;
+  };
+
   let { element }: Props = $props();
 
   const ctx = getEditorContext();
 
   let proportion = $state(100);
   let isResizing = $state(false);
-  let initialResizeData: { x: number; width: number; proportion: number; reverse: boolean; boundsWidth: number } | null = null;
   let enlarged = $state(false);
   let containerEl = $state<HTMLDivElement>();
   let pickerOpened = $state(false);
@@ -186,14 +193,14 @@
     return Math.max(minWidth, Math.min(maxWidth, width));
   };
 
-  const handleResizeStart = (event: PointerEvent, reverse: boolean) => {
-    const target = event.currentTarget as HTMLElement;
-    target.setPointerCapture(event.pointerId);
+  const handleResizeStart = (event: PointerEvent, reverse: boolean): ResizeSession | null => {
+    if (isResizing || !event.isPrimary || event.button !== 0) return null;
+
     event.preventDefault();
     event.stopPropagation();
 
     isResizing = true;
-    initialResizeData = {
+    return {
       x: event.clientX,
       width: liveWidth,
       proportion,
@@ -202,28 +209,18 @@
     };
   };
 
-  const handleResize = (event: PointerEvent) => {
-    const target = event.currentTarget as HTMLElement;
-    if (!target.hasPointerCapture(event.pointerId) || !initialResizeData) return;
-
-    const { boundsWidth } = initialResizeData;
+  const handleResize = (session: ResizeSession, event: PointerEvent) => {
+    const { boundsWidth } = session;
     if (boundsWidth <= 0) return;
 
-    const dx =
-      (ctx.editor?.clientDeltaToLocalDelta(event.clientX - initialResizeData.x) ?? event.clientX - initialResizeData.x) *
-      (initialResizeData.reverse ? -1 : 1);
-    const newWidth = clampWidth(initialResizeData.width + dx * 2, boundsWidth);
+    const dx = (ctx.editor?.clientDeltaToLocalDelta(event.clientX - session.x) ?? event.clientX - session.x) * (session.reverse ? -1 : 1);
+    const newWidth = clampWidth(session.width + dx * 2, boundsWidth);
     proportion = (newWidth / boundsWidth) * 100;
   };
 
-  const handleResizeEnd = (event: PointerEvent) => {
-    const target = event.currentTarget as HTMLElement;
-    if (target.hasPointerCapture(event.pointerId)) {
-      target.releasePointerCapture(event.pointerId);
-    }
-
+  const handleResizeEnd = () => {
+    const finalProportion = Math.round(proportion);
     isResizing = false;
-    initialResizeData = null;
     ctx.editor?.enqueue({
       type: 'node',
       op: {
@@ -231,11 +228,16 @@
         id: element.node,
         attr: {
           type: 'image',
-          attr: { type: 'proportion', value: Math.round(proportion) },
+          attr: { type: 'proportion', value: finalProportion },
         },
       },
     });
     ctx.editor?.focus();
+  };
+
+  const handleResizeCancel = (session: ResizeSession) => {
+    proportion = session.proportion;
+    isResizing = false;
   };
 
   const handleOpenInNewTab = () => {
@@ -392,10 +394,13 @@
               _groupHover: { opacity: '100' },
             })}
             aria-label="이미지 크기 조절"
-            onpointerdown={(event) => handleResizeStart(event, true)}
-            onpointermove={handleResize}
-            onpointerup={handleResizeEnd}
             type="button"
+            use:pointerCapture={{
+              start: (event) => handleResizeStart(event, true),
+              move: handleResize,
+              end: handleResizeEnd,
+              cancel: handleResizeCancel,
+            }}
           ></button>
         </div>
 
@@ -417,10 +422,13 @@
               _groupHover: { opacity: '100' },
             })}
             aria-label="이미지 크기 조절"
-            onpointerdown={(event) => handleResizeStart(event, false)}
-            onpointermove={handleResize}
-            onpointerup={handleResizeEnd}
             type="button"
+            use:pointerCapture={{
+              start: (event) => handleResizeStart(event, false),
+              move: handleResize,
+              end: handleResizeEnd,
+              cancel: handleResizeCancel,
+            }}
           ></button>
         </div>
       {/if}

--- a/apps/website/src/lib/pointer-capture.test.ts
+++ b/apps/website/src/lib/pointer-capture.test.ts
@@ -1,0 +1,259 @@
+import { pointerCapture } from '@typie/ui/actions';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { PointerCaptureParameters } from '@typie/ui/actions';
+
+const pointerEvent = (type: string, pointerId = 1) => {
+  const event = new MouseEvent(type, { bubbles: true, button: 0 });
+  Object.defineProperties(event, {
+    pointerId: { value: pointerId },
+    isPrimary: { value: true },
+  });
+  return event as PointerEvent;
+};
+
+const installPointerCapture = (element: HTMLElement) => {
+  let capturedPointerId: number | null = null;
+
+  element.setPointerCapture = vi.fn((pointerId) => {
+    capturedPointerId = pointerId;
+  });
+  element.hasPointerCapture = vi.fn((pointerId) => capturedPointerId === pointerId);
+  element.releasePointerCapture = vi.fn((pointerId) => {
+    if (capturedPointerId !== pointerId) return;
+    capturedPointerId = null;
+    element.dispatchEvent(pointerEvent('lostpointercapture', pointerId));
+  });
+
+  return {
+    lose(pointerId: number) {
+      capturedPointerId = null;
+      element.dispatchEvent(pointerEvent('lostpointercapture', pointerId));
+    },
+  };
+};
+
+const createElement = () => {
+  const element = document.createElement('div');
+  document.body.append(element);
+  return element;
+};
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+describe('pointerCapture', () => {
+  it('does not capture when start declines the gesture', () => {
+    const element = createElement();
+    installPointerCapture(element);
+    const move = vi.fn();
+    const action = pointerCapture(element, { start: () => null, move });
+
+    element.dispatchEvent(pointerEvent('pointerdown'));
+    element.dispatchEvent(pointerEvent('pointermove'));
+
+    expect(element.setPointerCapture).not.toHaveBeenCalled();
+    expect(move).not.toHaveBeenCalled();
+    action.destroy?.();
+  });
+
+  it('routes only the owner pointer and ignores overlapping starts', () => {
+    const element = createElement();
+    installPointerCapture(element);
+    const session = { id: 'owner' };
+    const start = vi.fn(() => session);
+    const move = vi.fn();
+    const end = vi.fn();
+    const cancel = vi.fn();
+    const action = pointerCapture(element, { start, move, end, cancel });
+
+    element.dispatchEvent(pointerEvent('pointerdown', 1));
+    element.dispatchEvent(pointerEvent('pointerdown', 2));
+    element.dispatchEvent(pointerEvent('pointermove', 2));
+    element.dispatchEvent(pointerEvent('pointerup', 2));
+    element.dispatchEvent(pointerEvent('pointercancel', 2));
+    element.dispatchEvent(pointerEvent('lostpointercapture', 2));
+    const ownerMove = pointerEvent('pointermove', 1);
+    element.dispatchEvent(ownerMove);
+
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(move).toHaveBeenCalledOnce();
+    expect(move).toHaveBeenCalledWith(session, ownerMove);
+    expect(end).not.toHaveBeenCalled();
+    expect(cancel).not.toHaveBeenCalled();
+    action.destroy?.();
+  });
+
+  it('ends once and ignores capture loss caused by normal release', () => {
+    const element = createElement();
+    installPointerCapture(element);
+    const session = { id: 'owner' };
+    const end = vi.fn();
+    const cancel = vi.fn();
+    const action = pointerCapture(element, { start: () => session, end, cancel });
+
+    element.dispatchEvent(pointerEvent('pointerdown'));
+    const up = pointerEvent('pointerup');
+    element.dispatchEvent(up);
+    element.dispatchEvent(pointerEvent('pointerup'));
+
+    expect(element.releasePointerCapture).toHaveBeenCalledOnce();
+    expect(end).toHaveBeenCalledOnce();
+    expect(end).toHaveBeenCalledWith(session, up);
+    expect(cancel).not.toHaveBeenCalled();
+    action.destroy?.();
+  });
+
+  it('cancels once on pointer cancellation', () => {
+    const element = createElement();
+    installPointerCapture(element);
+    const session = { id: 'owner' };
+    const cancel = vi.fn();
+    const action = pointerCapture(element, { start: () => session, cancel });
+
+    element.dispatchEvent(pointerEvent('pointerdown'));
+    const event = pointerEvent('pointercancel');
+    element.dispatchEvent(event);
+
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(cancel).toHaveBeenCalledWith(session, 'pointercancel', event);
+    action.destroy?.();
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it('cancels when pointer capture is lost unexpectedly', () => {
+    const element = createElement();
+    const capture = installPointerCapture(element);
+    const session = { id: 'owner' };
+    const cancel = vi.fn();
+    const action = pointerCapture(element, { start: () => session, cancel });
+
+    element.dispatchEvent(pointerEvent('pointerdown'));
+    capture.lose(1);
+
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(cancel).toHaveBeenCalledWith(session, 'lostpointercapture', expect.any(MouseEvent));
+    action.destroy?.();
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it('cancels on destroy and removes its listeners', () => {
+    const element = createElement();
+    installPointerCapture(element);
+    const session = { id: 'owner' };
+    const start = vi.fn(() => session);
+    const cancel = vi.fn();
+    const action = pointerCapture(element, { start, cancel });
+
+    element.dispatchEvent(pointerEvent('pointerdown'));
+    action.destroy?.();
+
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(cancel).toHaveBeenCalledWith(session, 'destroy', undefined);
+    element.dispatchEvent(pointerEvent('pointerdown'));
+    expect(start).toHaveBeenCalledOnce();
+  });
+
+  it('cancels state changed by start when capture acquisition fails', () => {
+    const element = createElement();
+    installPointerCapture(element);
+    element.setPointerCapture = vi.fn(() => {
+      throw new DOMException('capture failed');
+    });
+    const session = { id: 'owner' };
+    const cancel = vi.fn();
+    const action = pointerCapture(element, { start: () => session, cancel });
+
+    const down = pointerEvent('pointerdown');
+    element.dispatchEvent(down);
+
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(cancel).toHaveBeenCalledWith(session, 'capture-failed', down);
+    action.destroy?.();
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it('uses updated callbacks without replacing active session data', () => {
+    const element = createElement();
+    installPointerCapture(element);
+    const session = { id: 'owner' };
+    const oldMove = vi.fn();
+    const newMove = vi.fn();
+    const action = pointerCapture(element, { start: () => session, move: oldMove });
+
+    element.dispatchEvent(pointerEvent('pointerdown'));
+    action.update?.({ start: () => ({ id: 'replacement' }), move: newMove });
+    const move = pointerEvent('pointermove');
+    element.dispatchEvent(move);
+
+    expect(oldMove).not.toHaveBeenCalled();
+    expect(newMove).toHaveBeenCalledWith(session, move);
+    action.destroy?.();
+  });
+
+  it('supports rollback policy without committing a cancelled preview', () => {
+    const element = createElement();
+    installPointerCapture(element);
+    let preview = 10;
+    let commitCount = 0;
+    const parameters: PointerCaptureParameters<number> = {
+      start: () => preview,
+      move: (_, event) => (preview = event.clientX),
+      end: () => commitCount++,
+      cancel: (initial) => (preview = initial),
+    };
+    const action = pointerCapture(element, parameters);
+
+    element.dispatchEvent(pointerEvent('pointerdown'));
+    const move = pointerEvent('pointermove');
+    Object.defineProperty(move, 'clientX', { value: 20 });
+    element.dispatchEvent(move);
+    element.dispatchEvent(pointerEvent('pointercancel'));
+
+    expect(preview).toBe(10);
+    expect(commitCount).toBe(0);
+    action.destroy?.();
+  });
+
+  it('finalizes live cancellation but not teardown', () => {
+    const element = createElement();
+    installPointerCapture(element);
+    let value = 10;
+    let dragging = false;
+    let finalizeCount = 0;
+    const parameters: PointerCaptureParameters<true> = {
+      start: () => {
+        dragging = true;
+        return true;
+      },
+      move: (_, event) => (value = event.clientX),
+      end: () => {
+        dragging = false;
+        finalizeCount++;
+      },
+      cancel: (_, reason) => {
+        dragging = false;
+        if (reason !== 'destroy') finalizeCount++;
+      },
+    };
+    const action = pointerCapture(element, parameters);
+
+    element.dispatchEvent(pointerEvent('pointerdown'));
+    const move = pointerEvent('pointermove');
+    Object.defineProperty(move, 'clientX', { value: 20 });
+    element.dispatchEvent(move);
+    element.dispatchEvent(pointerEvent('pointercancel'));
+
+    expect(value).toBe(20);
+    expect(dragging).toBe(false);
+    expect(finalizeCount).toBe(1);
+
+    element.dispatchEvent(pointerEvent('pointerdown'));
+    action.destroy?.();
+
+    expect(value).toBe(20);
+    expect(dragging).toBe(false);
+    expect(finalizeCount).toBe(1);
+  });
+});

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanel.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanel.svelte
@@ -2,6 +2,7 @@
   import { createFragment } from '@mearie/svelte';
   import { css } from '@typie/styled-system/css';
   import { flex } from '@typie/styled-system/patterns';
+  import { pointerCapture } from '@typie/ui/actions';
   import { Button, FullAccessBadge, Icon } from '@typie/ui/components';
   import { getAppContext } from '@typie/ui/context';
   import { clamp } from '@typie/ui/utils';
@@ -85,15 +86,14 @@
     paneGroup.state.current.panelExpandedByPaneId[paneId] && Object.hasOwn(paneGroup.state.current.panelTabByPaneId, paneId),
   );
 
-  type Resizer = {
-    deltaX: number;
-    eligible: boolean;
-    event: PointerEvent;
-    element: HTMLElement;
+  type ResizeSession = {
+    startX: number;
+    startWidth: number;
   };
 
-  let resizer = $state<Resizer | null>(null);
-  let newWidth = $derived(clamp((app.preference.current.panelWidth ?? minWidth) + (resizer?.deltaX ?? 0), minWidth, maxWidth));
+  const storedWidth = $derived(clamp(app.preference.current.panelWidth ?? minWidth, minWidth, maxWidth));
+  let previewWidth = $state<number | null>(null);
+  let newWidth = $derived(previewWidth ?? storedWidth);
 
   onDestroy(() => focusReturn.discard());
 </script>
@@ -203,34 +203,24 @@
         opacity: '50',
       },
     })}
-    onpointerdowncapture={(e) => {
-      resizer = {
-        element: e.currentTarget,
-        event: e,
-        deltaX: 0,
-        eligible: false,
-      };
-    }}
-    onpointermovecapture={(e) => {
-      if (!resizer) return;
-
-      if (!resizer.eligible) {
-        resizer.eligible = true;
-        resizer.element.setPointerCapture(e.pointerId);
-      }
-
-      resizer.deltaX = Math.round(resizer.event.clientX - e.clientX);
-    }}
-    onpointerupcapture={() => {
-      if (!resizer) return;
-
-      if (resizer.eligible && resizer.element.hasPointerCapture(resizer.event.pointerId)) {
-        resizer.element.releasePointerCapture(resizer.event.pointerId);
-      }
-
-      app.preference.current.panelWidth = newWidth;
-
-      resizer = null;
+    use:pointerCapture={{
+      start: (event): ResizeSession | null => {
+        if (!event.isPrimary || event.button !== 0) return null;
+        event.preventDefault();
+        const session = { startX: event.clientX, startWidth: storedWidth };
+        previewWidth = session.startWidth;
+        return session;
+      },
+      move: (session, event) => {
+        previewWidth = clamp(session.startWidth + Math.round(session.startX - event.clientX), minWidth, maxWidth);
+      },
+      end: () => {
+        if (previewWidth !== null) app.preference.current.panelWidth = previewWidth;
+        previewWidth = null;
+      },
+      cancel: () => {
+        previewWidth = null;
+      },
     }}
   ></div>
 

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanelTimeline.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanelTimeline.svelte
@@ -2,7 +2,7 @@
   import { createFragment, createMutation, createQuery } from '@mearie/svelte';
   import { css, cx } from '@typie/styled-system/css';
   import { center, flex, wrap } from '@typie/styled-system/patterns';
-  import { createFloatingActions, portal, tooltip } from '@typie/ui/actions';
+  import { createFloatingActions, pointerCapture, portal, tooltip } from '@typie/ui/actions';
   import { Icon, RingSpinner } from '@typie/ui/components';
   import { getThemeContext } from '@typie/ui/context';
   import { Toast } from '@typie/ui/notification';
@@ -10,7 +10,6 @@
   import dayjs from 'dayjs';
   import mixpanel from 'mixpanel-browser';
   import { onMount } from 'svelte';
-  import { on } from 'svelte/events';
   import { fly } from 'svelte/transition';
   import ClockRewindIcon from '~icons/lucide/clock-arrow-up';
   import IconClockFading from '~icons/lucide/clock-fading';
@@ -21,7 +20,7 @@
   import { graphql } from '$mearie';
   import { getPane, getPaneGroup } from '../../@pane/context.svelte';
   import { getDocumentPanelFocusReturn } from './focus-return.svelte';
-  import type { Action } from 'svelte/action';
+  import type { PointerCaptureCancelReason } from '@typie/ui/actions';
   import type { PointerEventHandler } from 'svelte/elements';
   import type { DocumentPanelV2Timeline_document$key } from '$mearie';
 
@@ -233,6 +232,37 @@
     if (Object.hasOwn(headsAsc, index)) selectedHeadId = headsAsc[index].id;
   };
 
+  const handleSlideStart = (event: PointerEvent): true | null => {
+    if (showTooltip || isDraggingSlider || !event.isPrimary || event.button !== 0) return null;
+    handleSlide(event as PointerEvent & { currentTarget: HTMLElement });
+    showTooltip = true;
+    return true;
+  };
+
+  const handleSlideMove = (_: true, event: PointerEvent) => {
+    event.preventDefault();
+    isDraggingSlider = true;
+    handleSlide(event as PointerEvent & { currentTarget: HTMLElement });
+  };
+
+  const handleSlideEnd = () => {
+    showTooltip = false;
+    isDraggingSlider = false;
+    if (selectedHeadId) {
+      updateView.cancel();
+      void applyHead(selectedHeadId);
+    }
+  };
+
+  const handleSlideCancel = (_: true, reason: PointerCaptureCancelReason) => {
+    showTooltip = false;
+    isDraggingSlider = false;
+    updateView.cancel();
+    if (reason !== 'destroy' && selectedHeadId) {
+      void applyHead(selectedHeadId);
+    }
+  };
+
   const restore = async () => {
     const head = shownHead;
     if (!head) return;
@@ -249,38 +279,6 @@
     focusReturn.restore();
     Toast.success(`${dayjs(head.updatedAt).formatAsSmart()} 시점으로 복원되었습니다`);
     mixpanel.track('document_timeline_restore');
-  };
-
-  const slider: Action<HTMLElement> = (element) => {
-    $effect(() => {
-      const dragstart = on(element, 'dragstart', (e) => e.preventDefault());
-      const pointerdown = on(element, 'pointerdown', (e) => {
-        handleSlide(e as PointerEvent & { currentTarget: HTMLElement });
-        showTooltip = true;
-        (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
-      });
-      const pointermove = on(element, 'pointermove', (e) => {
-        e.preventDefault();
-        if ((e.currentTarget as HTMLElement).hasPointerCapture(e.pointerId)) {
-          isDraggingSlider = true;
-          handleSlide(e as PointerEvent & { currentTarget: HTMLElement });
-        }
-      });
-      const pointerup = on(element, 'pointerup', () => {
-        showTooltip = false;
-        isDraggingSlider = false;
-        if (selectedHeadId) {
-          updateView.cancel();
-          void applyHead(selectedHeadId);
-        }
-      });
-      return () => {
-        dragstart();
-        pointerdown();
-        pointermove();
-        pointerup();
-      };
-    });
   };
 </script>
 
@@ -465,7 +463,12 @@
           class={cx('group', css({ position: 'relative', width: 'full', height: '16px', overflow: 'hidden', cursor: 'pointer' }))}
           aria-label="Timeline slider"
           type="button"
-          use:slider
+          use:pointerCapture={{
+            start: handleSlideStart,
+            move: handleSlideMove,
+            end: handleSlideEnd,
+            cancel: handleSlideCancel,
+          }}
         >
           <div
             class={css({
@@ -524,7 +527,12 @@
               _active: { scale: '[1.1]' },
             })}
             use:anchor
-            use:slider
+            use:pointerCapture={{
+              start: handleSlideStart,
+              move: handleSlideMove,
+              end: handleSlideEnd,
+              cancel: handleSlideCancel,
+            }}
           ></div>
         </div>
       </div>

--- a/packages/ui/src/actions/index.ts
+++ b/packages/ui/src/actions/index.ts
@@ -5,6 +5,7 @@ export * from './focus-trap.svelte';
 export * from './hover.svelte';
 export * from './infinite-scroll.svelte';
 export * from './outside-click.svelte';
+export * from './pointer-capture.svelte';
 export * from './portal.svelte';
 export * from './scroll-lock.svelte';
 export * from './textarea-scrollpadding.svelte';

--- a/packages/ui/src/actions/pointer-capture.svelte.ts
+++ b/packages/ui/src/actions/pointer-capture.svelte.ts
@@ -1,0 +1,92 @@
+import type { ActionReturn } from 'svelte/action';
+
+export type PointerCaptureCancelReason = 'pointercancel' | 'lostpointercapture' | 'capture-failed' | 'destroy';
+
+export type PointerCaptureParameters<Session> = {
+  start: (event: PointerEvent) => Session | null;
+  move?: (session: Session, event: PointerEvent) => void;
+  end?: (session: Session, event: PointerEvent) => void;
+  cancel?: (session: Session, reason: PointerCaptureCancelReason, event?: PointerEvent) => void;
+};
+
+type ActiveSession<Session> = {
+  pointerId: number;
+  value: Session;
+};
+
+export const pointerCapture = <Session>(
+  element: HTMLElement,
+  initialParameters: PointerCaptureParameters<Session>,
+): ActionReturn<PointerCaptureParameters<Session>> => {
+  let parameters = initialParameters;
+  let active: ActiveSession<Session> | null = null;
+
+  const release = (pointerId: number) => {
+    if (element.hasPointerCapture(pointerId)) {
+      element.releasePointerCapture(pointerId);
+    }
+  };
+
+  const cancel = (reason: PointerCaptureCancelReason, event?: PointerEvent) => {
+    const current = active;
+    if (!current || (event && event.pointerId !== current.pointerId)) return;
+
+    active = null;
+    if (reason !== 'lostpointercapture') {
+      release(current.pointerId);
+    }
+    parameters.cancel?.(current.value, reason, event);
+  };
+
+  const handlePointerDown = (event: PointerEvent) => {
+    if (active) return;
+
+    const value = parameters.start(event);
+    if (value === null) return;
+
+    active = { pointerId: event.pointerId, value };
+    try {
+      element.setPointerCapture(event.pointerId);
+    } catch {
+      cancel('capture-failed', event);
+    }
+  };
+
+  const handlePointerMove = (event: PointerEvent) => {
+    const current = active;
+    if (!current || event.pointerId !== current.pointerId) return;
+    parameters.move?.(current.value, event);
+  };
+
+  const handlePointerUp = (event: PointerEvent) => {
+    const current = active;
+    if (!current || event.pointerId !== current.pointerId) return;
+
+    active = null;
+    release(current.pointerId);
+    parameters.end?.(current.value, event);
+  };
+
+  const handlePointerCancel = (event: PointerEvent) => cancel('pointercancel', event);
+  const handleLostPointerCapture = (event: PointerEvent) => cancel('lostpointercapture', event);
+
+  element.addEventListener('pointerdown', handlePointerDown);
+  element.addEventListener('pointermove', handlePointerMove);
+  element.addEventListener('pointerup', handlePointerUp);
+  element.addEventListener('pointercancel', handlePointerCancel);
+  element.addEventListener('lostpointercapture', handleLostPointerCapture);
+
+  return {
+    update(nextParameters) {
+      parameters = nextParameters;
+    },
+    destroy() {
+      element.removeEventListener('pointerdown', handlePointerDown);
+      element.removeEventListener('pointermove', handlePointerMove);
+      element.removeEventListener('pointerup', handlePointerUp);
+      element.removeEventListener('pointercancel', handlePointerCancel);
+      element.removeEventListener('lostpointercapture', handleLostPointerCapture);
+      cancel('destroy');
+    },
+  };
+};

--- a/packages/ui/src/components/Slider.svelte
+++ b/packages/ui/src/components/Slider.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { css } from '@typie/styled-system/css';
-  import { tooltip } from '../actions';
+  import { pointerCapture, tooltip } from '../actions';
 
   type Props = {
     min?: number;
@@ -27,28 +27,6 @@
 
   const percentage = $derived(((value - min) / (max - min)) * 100);
   const tooltipMessage = $derived(tooltipFormatter(value));
-
-  const handlePointerDown = (event: PointerEvent) => {
-    if (disabled) return;
-
-    const target = event.currentTarget as HTMLElement;
-    target.setPointerCapture(event.pointerId);
-
-    isDragging = true;
-    updateValue(event);
-  };
-
-  const handlePointerMove = (event: PointerEvent) => {
-    if (!isDragging) return;
-    updateValue(event);
-  };
-
-  const handlePointerUp = (event: PointerEvent) => {
-    const target = event.currentTarget as HTMLElement;
-    target.releasePointerCapture(event.pointerId);
-    isDragging = false;
-    onchange?.();
-  };
 
   const updateValue = (event: PointerEvent) => {
     if (!trackEl || disabled) return;
@@ -79,11 +57,25 @@
   aria-valuemin={min}
   aria-valuenow={value}
   ondragstart={(e) => e.preventDefault()}
-  onpointerdown={handlePointerDown}
-  onpointermove={handlePointerMove}
-  onpointerup={handlePointerUp}
   role="slider"
   tabindex={disabled ? -1 : 0}
+  use:pointerCapture={{
+    start: (event) => {
+      if (disabled || !event.isPrimary || event.button !== 0) return null;
+      isDragging = true;
+      updateValue(event);
+      return true;
+    },
+    move: (_, event) => updateValue(event),
+    end: () => {
+      isDragging = false;
+      onchange?.();
+    },
+    cancel: (_, reason) => {
+      isDragging = false;
+      if (reason !== 'destroy') onchange?.();
+    },
+  }}
 >
   <div
     style:width="{percentage}%"


### PR DESCRIPTION
- Slider/이미지 resize/문서 패널 resize/타임라인 drag의 pointer capture 처리를 공통 action으로 통합
- pointer cancel, capture 상실, 컴포넌트 종료 시에도 gesture 상태 정리
- 취소된 preview는 원복하고, 이미 적용 중인 값은 마지막 상태로 유지