### PR TITLE
앱 보조 UI 종료 시 에디터 focus 복원 안정화

### DIFF
--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.android.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.android.kt
@@ -23,7 +23,9 @@ import androidx.compose.ui.platform.LocalDensity
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
-internal actual fun rememberEditorKeyboardState(): EditorKeyboardState {
+internal actual fun rememberEditorKeyboardState(
+  isEditorInputSessionActive: () -> Boolean
+): EditorKeyboardState {
   val configuration = LocalConfiguration.current
   val context = LocalContext.current
   val density = LocalDensity.current
@@ -38,6 +40,14 @@ internal actual fun rememberEditorKeyboardState(): EditorKeyboardState {
       imeBottom = imeBottomDp,
       animationSourceBottom = imeAnimationSourceBottomDp,
       animationTargetBottom = imeAnimationTargetBottomDp,
+    )
+  val imeHideOwnershipTracker = remember { EditorImeHideOwnershipTracker() }
+  val imeHideEventOwner =
+    imeHideOwnershipTracker.observe(
+      visible =
+        presentation == EditorKeyboardPresentation.Showing ||
+          presentation is EditorKeyboardPresentation.Shown,
+      editorInputSessionActive = isEditorInputSessionActive(),
     )
   val hardwareKeyboardVisible =
     configuration.keyboard != Configuration.KEYBOARD_NOKEYS &&
@@ -73,6 +83,7 @@ internal actual fun rememberEditorKeyboardState(): EditorKeyboardState {
         EditorKeyboardType.Software
       },
     imeFrameVisible = imeBottom > 0 || imeAnimationTargetBottom > 0,
+    imeHideEventOwner = imeHideEventOwner,
     presentation = presentation,
     hardwareKeyboardAttached = hardwareKeyboardVisible || externalKeyboardAttached,
   )

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteCard.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteCard.kt
@@ -128,7 +128,6 @@ internal fun NoteCard(
   onCollapse: () -> Unit,
   onContentChange: (String) -> Unit,
   onBlur: () -> Unit,
-  onInputFocused: () -> Unit = {},
   onToggleStatus: () -> Unit,
   onColorChange: (String) -> Unit,
   onAddEntity: () -> Unit,
@@ -216,7 +215,6 @@ internal fun NoteCard(
           onCollapse = onCollapse,
           onContentChange = onContentChange,
           onBlur = onBlur,
-          onInputFocused = onInputFocused,
           onToggleStatus = onToggleStatus,
           onColorChange = onColorChange,
           onAddEntity = onAddEntity,
@@ -249,7 +247,6 @@ private fun NoteExpandedContent(
   onCollapse: () -> Unit,
   onContentChange: (String) -> Unit,
   onBlur: () -> Unit,
-  onInputFocused: () -> Unit,
   onToggleStatus: () -> Unit,
   onColorChange: (String) -> Unit,
   onAddEntity: () -> Unit,
@@ -279,7 +276,6 @@ private fun NoteExpandedContent(
             content = content,
             onValueChange = onContentChange,
             onBlur = onBlur,
-            onInputFocused = onInputFocused,
             readOnly = !contentEditable,
           )
         }
@@ -794,7 +790,6 @@ private fun NoteContentEditor(
   content: String,
   onValueChange: (String) -> Unit,
   onBlur: () -> Unit,
-  onInputFocused: () -> Unit,
   readOnly: Boolean,
 ) {
   val focusManager = LocalFocusManager.current
@@ -813,7 +808,6 @@ private fun NoteContentEditor(
         Modifier.fillMaxWidth().defaultMinSize(minHeight = 90.dp).textInputFocusable(
           textInputState
         ) { state ->
-          if (state.isFocused) onInputFocused()
           if (!state.isFocused) {
             onBlur()
           }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteList.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteList.kt
@@ -73,7 +73,6 @@ internal class NoteListActions(
   val onDelete: (NoteCard_note) -> Unit,
   val onMoveNote:
     suspend (noteId: String, lowerOrder: String?, upperOrder: String?) -> Result<Unit, Nothing>,
-  val onInputFocused: () -> Unit = {},
 )
 
 @Composable
@@ -237,7 +236,6 @@ internal fun NoteList(
                   }
                 },
                 onBlur = { if (interactive && !isLoading) actions.onBlur(note.id) },
-                onInputFocused = actions.onInputFocused,
                 onToggleStatus = { if (interactive && !isLoading) actions.onToggleStatus(note) },
                 onColorChange = { nextColor ->
                   if (interactive && !isLoading) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorInput.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorInput.kt
@@ -255,8 +255,7 @@ internal class EditorInputNode(
 
   private fun dispatch(
     messages: List<Message>,
-    bringIntoViewTarget: EditorBringIntoViewTarget? =
-      EditorBringIntoViewTarget.CurrentSelectionHead,
+    bringIntoViewTarget: EditorBringIntoViewTarget? = EditorBringIntoViewTarget.CurrentSelectionHead,
   ) {
     if (messages.isEmpty()) return
     submit { sessionEditor, context ->
@@ -308,8 +307,7 @@ internal class EditorInputNode(
 
   private fun dispatchSync(
     messages: List<Message>,
-    bringIntoViewTarget: EditorBringIntoViewTarget? =
-      EditorBringIntoViewTarget.CurrentSelectionHead,
+    bringIntoViewTarget: EditorBringIntoViewTarget? = EditorBringIntoViewTarget.CurrentSelectionHead,
   ): EditorState? {
     if (messages.isEmpty()) return null
     return editor.syncWithBringIntoView(bringIntoViewRequests) {
@@ -569,6 +567,9 @@ internal class EditorInputNode(
               viewportTransform = { uiState.resolveViewportTransform(editor.pageSizes) },
               dispatch = { messages -> dispatch(messages) },
             )
+          val inputSessionUiState = uiState
+          val inputSessionOwner = Any()
+          inputSessionUiState.acquireInputSession(inputSessionOwner)
           try {
             // The ime window is only materialized while a session is active, so
             // the session must not start against a pre-activation snapshot.
@@ -624,13 +625,13 @@ internal class EditorInputNode(
                 // extracted-text monitors never go stale. drop(1): the initial
                 // emission is already handled above.
                 snapshotFlow {
-                  EditorImeNotifyKey(
-                    selection = editor.selection,
-                    cursor = editor.cursor,
-                    ime = editor.tickIme,
-                    paused = editor.imeNotificationsPaused,
-                  )
-                }
+                    EditorImeNotifyKey(
+                      selection = editor.selection,
+                      cursor = editor.cursor,
+                      ime = editor.tickIme,
+                      paused = editor.imeNotificationsPaused,
+                    )
+                  }
                   .imeNotificationEvents()
                   .collect { notifyImeStateChanged(editor) }
               }
@@ -638,7 +639,11 @@ internal class EditorInputNode(
               startInputMethod(request)
             }
           } finally {
-            uninstallPlatformSessionEffects()
+            try {
+              uninstallPlatformSessionEffects()
+            } finally {
+              inputSessionUiState.releaseInputSession(inputSessionOwner)
+            }
           }
         }
       } else {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/runtime/EditorUiState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/runtime/EditorUiState.kt
@@ -17,6 +17,11 @@ class EditorUiState {
   var focused by mutableStateOf(false)
     private set
 
+  private var inputSessionOwner by mutableStateOf<Any?>(null)
+
+  internal val editorInputSessionActive: Boolean
+    get() = inputSessionOwner != null
+
   internal val contextMenu = EditorContextMenuState()
 
   var displayZoom by mutableStateOf(1f)
@@ -36,8 +41,19 @@ class EditorUiState {
     this.focused = focused
   }
 
+  internal fun acquireInputSession(owner: Any) {
+    inputSessionOwner = owner
+  }
+
+  internal fun releaseInputSession(owner: Any) {
+    if (inputSessionOwner === owner) {
+      inputSessionOwner = null
+    }
+  }
+
   fun clear() {
     focused = false
+    inputSessionOwner = null
     contextMenu.reset()
     displayZoom = 1f
     pageOffsets.clear()

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorFocusReturnSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorFocusReturnSession.kt
@@ -10,11 +10,9 @@ import co.typie.editor.ffi.StableSelection
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
-import kotlinx.coroutines.launch
 
 @Stable
 internal class EditorFocusReturnSession(
@@ -31,13 +29,13 @@ internal class EditorFocusReturnSession(
 ) {
   private var currentContext: EditorContext? = null
   private var state: State = State.Idle
-  private var pendingBoundaryJob: Job? = null
 
   fun observeEditorContext(
     editor: Editor?,
     focused: Boolean,
     selection: Selection?,
     contextActive: Boolean,
+    auxiliaryOwnerActive: Boolean,
   ) {
     if (!contextActive || editor == null) {
       if (currentContext != null || state !is State.Idle) {
@@ -55,44 +53,29 @@ internal class EditorFocusReturnSession(
 
     when (val current = state) {
       State.Idle -> {
-        if (focused && selection != null) beginEligible(context)
+        if (focused && selection != null) beginEligible(context, selection)
       }
       is State.Eligible -> {
         when {
+          focused && selection != null -> beginEligible(context, selection)
           focused && selection == null -> clearState(resetContext = false)
-          !focused -> beginPendingBlur(current.context)
-        }
-      }
-      is State.PendingBlur -> {
-        when {
-          focused && selection != null -> beginEligible(context)
-          focused -> clearState(resetContext = false)
+          auxiliaryOwnerActive -> capture(current)
+          else -> clearState(resetContext = false)
         }
       }
       is State.Captured -> Unit
     }
   }
 
-  fun onAuxiliaryInputFocused() {
-    val context =
-      when (val current = state) {
-        is State.Eligible -> current.context
-        is State.PendingBlur -> current.context
-        State.Idle,
-        is State.Captured -> return
-      }
-    if (!isRestorable(context)) return
-
-    val selection = context.editor.state.selection ?: return
-    pendingBoundaryJob?.cancel()
-    pendingBoundaryJob = null
+  private fun capture(eligible: State.Eligible) {
+    if (!isRestorable(eligible.context)) return
     state =
       State.Captured(
-        context = context,
+        context = eligible.context,
         stableSelection =
           scope.async {
             try {
-              freezeSelection(context.editor, selection)
+              freezeSelection(eligible.context.editor, eligible.selection)
             } catch (error: CancellationException) {
               throw error
             } catch (_: Throwable) {
@@ -135,33 +118,11 @@ internal class EditorFocusReturnSession(
     clearState(resetContext = true)
   }
 
-  private fun beginEligible(context: EditorContext) {
-    clearState(resetContext = false)
-    state = State.Eligible(context)
-  }
-
-  private fun beginPendingBlur(context: EditorContext) {
-    val pending = State.PendingBlur(context)
-    state = pending
-    pendingBoundaryJob?.cancel()
-    pendingBoundaryJob = scope.launch {
-      try {
-        awaitFocusBoundary()
-      } catch (error: CancellationException) {
-        throw error
-      } catch (_: Throwable) {
-        // A failed boundary still expires eligibility.
-      }
-      if (state === pending && isRestorable(context)) {
-        state = State.Idle
-        pendingBoundaryJob = null
-      }
-    }
+  private fun beginEligible(context: EditorContext, selection: Selection) {
+    state = State.Eligible(context, selection)
   }
 
   private fun clearState(resetContext: Boolean) {
-    pendingBoundaryJob?.cancel()
-    pendingBoundaryJob = null
     (state as? State.Captured)?.stableSelection?.cancel()
     state = State.Idle
     if (resetContext) {
@@ -203,9 +164,7 @@ internal class EditorFocusReturnSession(
   private sealed interface State {
     data object Idle : State
 
-    data class Eligible(val context: EditorContext) : State
-
-    data class PendingBlur(val context: EditorContext) : State
+    data class Eligible(val context: EditorContext, val selection: Selection) : State
 
     data class Captured(
       val context: EditorContext,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -327,14 +327,6 @@ fun EditorScreen(entityId: String) {
     }
   }
   val editorState = editor?.state ?: EditorState.Initial
-  SideEffect {
-    focusReturnSession.observeEditorContext(
-      editor = editor,
-      focused = uiState.focused,
-      selection = editorState.selection,
-      contextActive = screenState.sceneInForeground && !editorReadOnly,
-    )
-  }
   val externalAssetIds =
     remember(editorState.externalElements) {
       editorState.externalElements
@@ -380,12 +372,22 @@ fun EditorScreen(entityId: String) {
       requestEditorFocus()
     }
   }
-  val focusStealingSurfaceActive =
+  val focusReturnOwnerActive =
     findReplace.active ||
-      subPaneState.active == EditorSubPane.RelatedNotes ||
-      subPaneState.active == EditorSubPane.Comments
-  LaunchedEffect(focusStealingSurfaceActive) {
-    if (!focusStealingSurfaceActive) {
+      (subPaneState.editorInputBlocked &&
+        (subPaneState.active == EditorSubPane.RelatedNotes ||
+          subPaneState.active == EditorSubPane.Comments))
+  SideEffect {
+    focusReturnSession.observeEditorContext(
+      editor = editor,
+      focused = uiState.focused,
+      selection = editorState.selection,
+      contextActive = screenState.sceneInForeground && !editorReadOnly,
+      auxiliaryOwnerActive = focusReturnOwnerActive,
+    )
+  }
+  LaunchedEffect(focusReturnOwnerActive) {
+    if (!focusReturnOwnerActive) {
       focusReturnSession.restore()
     }
   }
@@ -457,12 +459,7 @@ fun EditorScreen(entityId: String) {
       ProvideTopBar(
         leading = { FindReplaceTopBarLeading(session = findReplace) },
         leadingKey = FindReplaceTopBarLeadingKey,
-        center = {
-          FindReplaceTopBarCenter(
-            session = findReplace,
-            onInputFocused = focusReturnSession::onAuxiliaryInputFocused,
-          )
-        },
+        center = { FindReplaceTopBarCenter(session = findReplace) },
         centerKey = FindReplaceTopBarCenterKey,
         trailing = { FindReplaceTopBarTrailing(session = findReplace) },
         trailingKey = FindReplaceTopBarTrailingKey,
@@ -1033,7 +1030,8 @@ fun EditorScreen(entityId: String) {
     val bottomSafeInset = contentPadding.calculateBottomPadding()
     val imeBottom = WindowInsets.ime.asPaddingValues().calculateBottomPadding()
     val toolbarInputState = rememberEditorToolbarInputState()
-    val keyboardState = rememberEditorKeyboardState()
+    val keyboardState =
+      rememberEditorKeyboardState(isEditorInputSessionActive = { uiState.editorInputSessionActive })
     val toolbarPagerState = rememberToolbarPagerState(key = entityId)
     val toolbarSessionState = rememberEditorToolbarSessionState(key = entityId)
     val toolbarPanel = toolbarInputState.panel
@@ -1648,7 +1646,6 @@ fun EditorScreen(entityId: String) {
             visibleState = findReplaceToolbarTransition,
             bottomInset = findReplaceToolbarBottomInset,
             modifier = Modifier,
-            onInputFocused = focusReturnSession::onAuxiliaryInputFocused,
           )
           EditorToolbarHost(
             editorState = editorState,
@@ -1745,7 +1742,6 @@ fun EditorScreen(entityId: String) {
             maxTopInset = topInset,
             safeBottomInset = bottomSafeInset,
             trustedImeBottomInset = trustedImeBottom,
-            onAuxiliaryInputFocused = focusReturnSession::onAuxiliaryInputFocused,
             modifier = Modifier.fillMaxSize(),
           )
         },

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceToolbar.kt
@@ -64,7 +64,6 @@ internal fun FindReplaceToolbar(
   session: EditorFindReplaceSession,
   visibleState: MutableTransitionState<Boolean>,
   bottomInset: Dp,
-  onInputFocused: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
   AnimatedVisibility(
@@ -104,11 +103,7 @@ internal fun FindReplaceToolbar(
               ),
           verticalAlignment = Alignment.CenterVertically,
         ) {
-          ReplaceTextField(
-            session = session,
-            modifier = Modifier.weight(1f),
-            onInputFocused = onInputFocused,
-          )
+          ReplaceTextField(session = session, modifier = Modifier.weight(1f))
           Spacer(Modifier.width(ToolbarItemGap))
           EditorToolbarButton(
             icon = Lucide.Replace,
@@ -144,11 +139,7 @@ internal fun FindReplaceToolbar(
 }
 
 @Composable
-private fun ReplaceTextField(
-  session: EditorFindReplaceSession,
-  modifier: Modifier = Modifier,
-  onInputFocused: () -> Unit,
-) {
+private fun ReplaceTextField(session: EditorFindReplaceSession, modifier: Modifier = Modifier) {
   val inputState =
     rememberTextInputState(
       value = session.replaceText,
@@ -171,7 +162,7 @@ private fun ReplaceTextField(
         .clip(shape)
         .background(AppTheme.colors.surfaceInset, shape)
         .padding(horizontal = 10.dp)
-        .textInputFocusable(inputState) { state -> if (state.isFocused) onInputFocused() }
+        .textInputFocusable(inputState)
         .onPreviewKeyEvent { event -> handleReplaceInputShortcut(event, session) },
     decorationBox = { innerTextField ->
       Box(contentAlignment = Alignment.CenterStart) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceTopBar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceTopBar.kt
@@ -59,10 +59,7 @@ internal fun FindReplaceTopBarLeading(session: EditorFindReplaceSession) {
 }
 
 @Composable
-internal fun FindReplaceTopBarCenter(
-  session: EditorFindReplaceSession,
-  onInputFocused: () -> Unit,
-) {
+internal fun FindReplaceTopBarCenter(session: EditorFindReplaceSession) {
   val inputState =
     rememberTextInputState(
       value = session.findText,
@@ -104,9 +101,9 @@ internal fun FindReplaceTopBarCenter(
       keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
       keyboardActions = KeyboardActions(onSearch = { session.findNext() }),
       modifier =
-        Modifier.weight(1f)
-          .textInputFocusable(inputState) { state -> if (state.isFocused) onInputFocused() }
-          .onPreviewKeyEvent { event -> handleFindInputShortcut(event, session) },
+        Modifier.weight(1f).textInputFocusable(inputState).onPreviewKeyEvent { event ->
+          handleFindInputShortcut(event, session)
+        },
       decorationBox = { innerTextField ->
         Box(contentAlignment = Alignment.CenterStart) {
           if (session.findText.isEmpty()) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/EditorSubPaneHost.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/EditorSubPaneHost.kt
@@ -25,7 +25,6 @@ internal fun EditorSubPaneHost(
   maxTopInset: Dp,
   safeBottomInset: Dp,
   trustedImeBottomInset: Dp,
-  onAuxiliaryInputFocused: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
   val editor = LocalEditorRuntime.current.editor
@@ -44,7 +43,6 @@ internal fun EditorSubPaneHost(
         maxTopInset = maxTopInset,
         safeBottomInset = safeBottomInset,
         trustedImeBottomInset = trustedImeBottomInset,
-        onInputFocused = onAuxiliaryInputFocused,
         onDismissStarted = state::beginDismiss,
         onDismiss = state::dismiss,
         onLayoutInfoChanged = state::updateLayoutInfo,
@@ -64,10 +62,7 @@ internal fun EditorSubPaneHost(
           composeLocation = comments.session.composeLocation,
           createEnabled = comments.session.topBarCreateEnabled,
           onFreezeCurrentSelection = comments.session.freezeCurrentSelection,
-          onInputFocusChanged = { focused ->
-            comments.session.onInputFocusChanged(focused)
-            if (focused) onAuxiliaryInputFocused()
-          },
+          onInputFocusChanged = comments.session.onInputFocusChanged,
           maxTopInset = maxTopInset,
           safeBottomInset = safeBottomInset,
           trustedImeBottomInset = trustedImeBottomInset,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/relatednotes/RelatedNotesSheet.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/relatednotes/RelatedNotesSheet.kt
@@ -84,7 +84,6 @@ internal fun RelatedNotesSheet(
   maxTopInset: Dp,
   safeBottomInset: Dp,
   trustedImeBottomInset: Dp,
-  onInputFocused: () -> Unit,
   onDismissStarted: () -> Unit,
   onDismiss: () -> Unit,
   onLayoutInfoChanged: (EditorSubPaneLayoutInfo) -> Unit,
@@ -182,7 +181,6 @@ internal fun RelatedNotesSheet(
       saveNoteContent = ::saveNoteContent,
       saveNoteColor = ::saveNoteColor,
       collapseExpandedNote = ::collapseExpandedNote,
-      onInputFocused = onInputFocused,
     )
   }
 }
@@ -199,7 +197,6 @@ private fun RelatedNotesSheetContent(
   saveNoteContent: suspend (noteId: String, content: String) -> Boolean,
   saveNoteColor: suspend (noteId: String, color: String) -> Boolean,
   collapseExpandedNote: suspend () -> Boolean,
-  onInputFocused: () -> Unit,
 ) {
   val nav = Nav.current
   val dialog = LocalDialog.current
@@ -486,7 +483,6 @@ private fun RelatedNotesSheetContent(
           onMoveNote = { noteId, lowerOrder, upperOrder ->
             model.moveNote(noteId = noteId, lowerOrder = lowerOrder, upperOrder = upperOrder)
           },
-          onInputFocused = onInputFocused,
         )
       val reorderState = rememberNoteListReorderState(items = listItems, scrollState = scrollState)
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.kt
@@ -9,6 +9,11 @@ internal enum class EditorKeyboardType {
   Hardware,
 }
 
+internal enum class EditorImeInputOwner {
+  Editor,
+  Other,
+}
+
 internal sealed interface EditorKeyboardPresentation {
   data object Hidden : EditorKeyboardPresentation
 
@@ -23,6 +28,7 @@ internal data class EditorKeyboardState(
   val type: EditorKeyboardType,
   val imeFrameVisible: Boolean = false,
   val imeHideEventVersion: Int = 0,
+  val imeHideEventOwner: EditorImeInputOwner? = null,
   val presentation: EditorKeyboardPresentation = EditorKeyboardPresentation.Hidden,
   val hardwareKeyboardAttached: Boolean = type == EditorKeyboardType.Hardware,
 ) {
@@ -39,7 +45,30 @@ internal data class EditorKeyboardState(
       }
 }
 
-@Composable internal expect fun rememberEditorKeyboardState(): EditorKeyboardState
+internal class EditorImeHideOwnershipTracker {
+  private var previouslyVisible = false
+  private var hideEventOwner: EditorImeInputOwner? = null
+
+  fun observe(visible: Boolean, editorInputSessionActive: Boolean): EditorImeInputOwner? {
+    if (visible) {
+      hideEventOwner = null
+    } else if (previouslyVisible) {
+      hideEventOwner =
+        if (editorInputSessionActive) {
+          EditorImeInputOwner.Editor
+        } else {
+          EditorImeInputOwner.Other
+        }
+    }
+    previouslyVisible = visible
+    return hideEventOwner
+  }
+}
+
+@Composable
+internal expect fun rememberEditorKeyboardState(
+  isEditorInputSessionActive: () -> Boolean
+): EditorKeyboardState
 
 internal fun isImeVisible(imeBottom: Dp, safeBottomInset: Dp): Boolean = imeBottom > safeBottomInset
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarInputState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarInputState.kt
@@ -191,6 +191,7 @@ internal class EditorToolbarInputState {
         panel == null &&
         environment.focused &&
         environment.keyboardType == EditorKeyboardType.Software &&
+        environment.keyboardState.imeHideEventOwner == EditorImeInputOwner.Editor &&
         !environment.keyboardState.hardwareKeyboardAttached &&
         !environment.panelTransitionRunning
     ) {

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/runtime/EditorUiStateTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/runtime/EditorUiStateTest.kt
@@ -10,6 +10,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class EditorUiStateTest {
   @Test
@@ -70,6 +71,23 @@ class EditorUiStateTest {
     assertFalse(state.focused)
     assertNull(state.resolveViewportTransform().localToGlobal(page = 0, x = 0f, y = 0f))
     assertFalse(state.editorBoundsInContainer.isValid)
+  }
+
+  @Test
+  fun `stale input session release does not clear current ownership`() {
+    val state = EditorUiState()
+    val previousSession = Any()
+    val currentSession = Any()
+
+    state.acquireInputSession(previousSession)
+    state.acquireInputSession(currentSession)
+    state.releaseInputSession(previousSession)
+
+    assertTrue(state.editorInputSessionActive)
+
+    state.releaseInputSession(currentSession)
+
+    assertFalse(state.editorInputSessionActive)
   }
 
   @Test

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/EditorFocusReturnSessionTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/EditorFocusReturnSessionTest.kt
@@ -24,13 +24,13 @@ import kotlinx.coroutines.test.runTest
 @OptIn(ExperimentalCoroutinesApi::class)
 class EditorFocusReturnSessionTest {
   @Test
-  fun capturesOnlyWhenFocusedEditorSelectionHandsFocusToAuxiliaryInput() = runTest {
+  fun capturesWhenFocusedEditorSelectionBlursWhileAuxiliaryOwnerIsActive() = runTest {
     val editor = testEditor(selection("eligible"))
     val frozenSelections = mutableListOf<Selection>()
     val session = session(frozenSelections = frozenSelections)
 
-    observe(session, editor, focused = true)
-    session.onAuxiliaryInputFocused()
+    observe(session, editor, focused = true, auxiliaryOwnerActive = true)
+    observe(session, editor, focused = false, auxiliaryOwnerActive = true)
     runCurrent()
 
     assertEquals(listOf(selection("eligible")), frozenSelections)
@@ -42,70 +42,65 @@ class EditorFocusReturnSessionTest {
     val frozenSelections = mutableListOf<Selection>()
     val session = session(frozenSelections = frozenSelections)
 
-    observe(session, editor, focused = false)
-    session.onAuxiliaryInputFocused()
+    observe(session, editor, focused = false, auxiliaryOwnerActive = true)
     editor.setSelection(null)
-    observe(session, editor, focused = true)
-    session.onAuxiliaryInputFocused()
+    observe(session, editor, focused = true, auxiliaryOwnerActive = true)
+    observe(session, editor, focused = false, auxiliaryOwnerActive = true)
     runCurrent()
 
     assertTrue(frozenSelections.isEmpty())
   }
 
   @Test
-  fun auxiliaryFocusFreezesTheTransferTimeSelection() = runTest {
+  fun editorBlurFreezesTheTransferTimeSelection() = runTest {
     val editor = testEditor(selection("eligible"))
     val frozenSelections = mutableListOf<Selection>()
     val session = session(frozenSelections = frozenSelections)
 
-    observe(session, editor, focused = true)
+    observe(session, editor, focused = true, auxiliaryOwnerActive = true)
     editor.setSelection(selection("transfer"))
-    session.onAuxiliaryInputFocused()
+    observe(session, editor, focused = true, auxiliaryOwnerActive = true)
+    observe(session, editor, focused = false, auxiliaryOwnerActive = true)
     runCurrent()
 
     assertEquals(listOf(selection("transfer")), frozenSelections)
   }
 
   @Test
-  fun editorBlurCanBeClaimedWithinTheFocusBoundary() = runTest {
+  fun openingAuxiliarySurfaceWithoutEditorBlurDoesNotCapture() = runTest {
     val editor = testEditor(selection("eligible"))
-    val boundary = CompletableDeferred<Unit>()
     val frozenSelections = mutableListOf<Selection>()
-    val session = session(frozenSelections = frozenSelections, awaitFocusBoundary = boundary::await)
+    val session = session(frozenSelections = frozenSelections)
 
-    observe(session, editor, focused = true)
-    observe(session, editor, focused = false)
-    session.onAuxiliaryInputFocused()
-    runCurrent()
-
-    assertEquals(listOf(selection("eligible")), frozenSelections)
-  }
-
-  @Test
-  fun expiredEditorBlurBoundaryCannotBeClaimed() = runTest {
-    val editor = testEditor(selection("eligible"))
-    val boundary = CompletableDeferred<Unit>()
-    val frozenSelections = mutableListOf<Selection>()
-    val session = session(frozenSelections = frozenSelections, awaitFocusBoundary = boundary::await)
-
-    observe(session, editor, focused = true)
-    observe(session, editor, focused = false)
-    boundary.complete(Unit)
-    runCurrent()
-    session.onAuxiliaryInputFocused()
+    observe(session, editor, focused = true, auxiliaryOwnerActive = false)
+    observe(session, editor, focused = true, auxiliaryOwnerActive = true)
     runCurrent()
 
     assertTrue(frozenSelections.isEmpty())
   }
 
   @Test
-  fun additionalAuxiliaryInputFocusKeepsTheOriginalCapture() = runTest {
+  fun editorBlurWithoutAuxiliaryOwnerDoesNotCapture() = runTest {
+    val editor = testEditor(selection("eligible"))
+    val frozenSelections = mutableListOf<Selection>()
+    val session = session(frozenSelections = frozenSelections)
+
+    observe(session, editor, focused = true, auxiliaryOwnerActive = false)
+    observe(session, editor, focused = false, auxiliaryOwnerActive = false)
+    runCurrent()
+
+    assertTrue(frozenSelections.isEmpty())
+  }
+
+  @Test
+  fun auxiliaryTransitionKeepsTheOriginalCapture() = runTest {
     val editor = testEditor(selection("eligible"))
     val frozenSelections = mutableListOf<Selection>()
     val session = session(frozenSelections = frozenSelections)
 
     capture(session, editor)
-    session.onAuxiliaryInputFocused()
+    observe(session, editor, focused = false, auxiliaryOwnerActive = false)
+    observe(session, editor, focused = false, auxiliaryOwnerActive = true)
     runCurrent()
 
     assertEquals(listOf(selection("eligible")), frozenSelections)
@@ -315,6 +310,7 @@ class EditorFocusReturnSessionTest {
       focused = false,
       selection = null,
       contextActive = true,
+      auxiliaryOwnerActive = false,
     )
     session.restore()
 
@@ -364,18 +360,20 @@ class EditorFocusReturnSessionTest {
     editor: TestEditor,
     focused: Boolean,
     contextActive: Boolean = true,
+    auxiliaryOwnerActive: Boolean = false,
   ) {
     session.observeEditorContext(
       editor = editor.editor,
       focused = focused,
       selection = editor.editor.state.selection,
       contextActive = contextActive,
+      auxiliaryOwnerActive = auxiliaryOwnerActive,
     )
   }
 
   private fun TestScope.capture(session: EditorFocusReturnSession, editor: TestEditor) {
-    observe(session, editor, focused = true)
-    session.onAuxiliaryInputFocused()
+    observe(session, editor, focused = true, auxiliaryOwnerActive = true)
+    observe(session, editor, focused = false, auxiliaryOwnerActive = true)
     runCurrent()
   }
 }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardTypeTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardTypeTest.kt
@@ -70,6 +70,26 @@ class EditorKeyboardTypeTest {
   }
 
   @Test
+  fun ime_hide_ownership_is_preserved_until_the_keyboard_is_visible_again() {
+    val tracker = EditorImeHideOwnershipTracker()
+
+    assertNull(tracker.observe(visible = true, editorInputSessionActive = false))
+    assertEquals(
+      EditorImeInputOwner.Other,
+      tracker.observe(visible = false, editorInputSessionActive = false),
+    )
+    assertEquals(
+      EditorImeInputOwner.Other,
+      tracker.observe(visible = false, editorInputSessionActive = true),
+    )
+    assertNull(tracker.observe(visible = true, editorInputSessionActive = true))
+    assertEquals(
+      EditorImeInputOwner.Editor,
+      tracker.observe(visible = false, editorInputSessionActive = true),
+    )
+  }
+
+  @Test
   fun shown_keyboard_presentation_exposes_settled_ime_bottom() {
     val keyboardState =
       EditorKeyboardState(

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarInputStateTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarInputStateTest.kt
@@ -207,7 +207,17 @@ class ToolbarInputStateTest {
     val keyboardVisible = toolbarInputEnvironment(imeBottom = 320.dp)
 
     state.onEnvironmentChanged(keyboardVisible)
-    val effects = state.onEnvironmentChanged(toolbarInputEnvironment(imeBottom = 0.dp))
+    val effects =
+      state.onEnvironmentChanged(
+        toolbarInputEnvironment(
+          imeBottom = 0.dp,
+          keyboardState =
+            EditorKeyboardState(
+              type = EditorKeyboardType.Software,
+              imeHideEventOwner = EditorImeInputOwner.Editor,
+            ),
+        )
+      )
 
     assertEquals(listOf(EditorInputEffect.ClearFocus), effects)
     assertEquals(null, state.keyboardRestoreInset)
@@ -218,6 +228,29 @@ class ToolbarInputStateTest {
       state.onEnvironmentChanged(toolbarInputEnvironment(focused = false, imeBottom = 0.dp))
 
     assertEquals(emptyList(), focusCleared)
+  }
+
+  @Test
+  fun auxiliary_ime_hide_after_editor_focus_restore_keeps_focus() {
+    val state = EditorToolbarInputState()
+    val auxiliaryKeyboardVisible = toolbarInputEnvironment(focused = false, imeBottom = 320.dp)
+
+    state.onEnvironmentChanged(auxiliaryKeyboardVisible)
+    state.onEnvironmentChanged(auxiliaryKeyboardVisible.copy(focused = true))
+    val effects =
+      state.onEnvironmentChanged(
+        toolbarInputEnvironment(
+          focused = true,
+          imeBottom = 0.dp,
+          keyboardState =
+            EditorKeyboardState(
+              type = EditorKeyboardType.Software,
+              imeHideEventOwner = EditorImeInputOwner.Other,
+            ),
+        )
+      )
+
+    assertEquals(emptyList(), effects)
   }
 
   @Test
@@ -280,10 +313,7 @@ class ToolbarInputStateTest {
         toolbarInputEnvironment(
           imeBottom = 0.dp,
           keyboardState =
-            EditorKeyboardState(
-              type = EditorKeyboardType.Software,
-              hardwareKeyboardAttached = true,
-            ),
+            EditorKeyboardState(type = EditorKeyboardType.Software, hardwareKeyboardAttached = true),
         )
       )
 
@@ -298,7 +328,15 @@ class ToolbarInputStateTest {
     state.onEnvironmentChanged(keyboardVisible)
     state.dispatch(ToolbarIntent.OpenPanel(EditorToolbarBottomPanel.Insert), keyboardVisible)
 
-    val keyboardHidden = toolbarInputEnvironment(imeBottom = 0.dp)
+    val keyboardHidden =
+      toolbarInputEnvironment(
+        imeBottom = 0.dp,
+        keyboardState =
+          EditorKeyboardState(
+            type = EditorKeyboardType.Software,
+            imeHideEventOwner = EditorImeInputOwner.Editor,
+          ),
+      )
     state.onEnvironmentChanged(keyboardHidden)
     state.dispatch(ToolbarIntent.RestoreEditorInput, keyboardHidden)
     state.onEnvironmentChanged(toolbarInputEnvironment(imeBottom = 95.dp))

--- a/apps/mobile/compose/src/desktopMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.desktop.kt
+++ b/apps/mobile/compose/src/desktopMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.desktop.kt
@@ -2,6 +2,7 @@ package co.typie.screen.editor.editor.toolbar
 
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -9,13 +10,23 @@ import co.typie.dev.DesktopDebugKeyboard
 import co.typie.ext.ime
 
 @Composable
-internal actual fun rememberEditorKeyboardState(): EditorKeyboardState {
+internal actual fun rememberEditorKeyboardState(
+  isEditorInputSessionActive: () -> Boolean
+): EditorKeyboardState {
   val density = LocalDensity.current
   val imeBottom = with(density) { WindowInsets.ime.getBottom(this).toDp() }
+  val imeHideOwnershipTracker = remember { EditorImeHideOwnershipTracker() }
   return resolveDesktopEditorKeyboardState(
-    hardwareKeyboardConnected = DesktopDebugKeyboard.hardwareKeyboardConnected,
-    imeBottom = imeBottom,
-  )
+      hardwareKeyboardConnected = DesktopDebugKeyboard.hardwareKeyboardConnected,
+      imeBottom = imeBottom,
+    )
+    .copy(
+      imeHideEventOwner =
+        imeHideOwnershipTracker.observe(
+          visible = imeBottom > 0.dp,
+          editorInputSessionActive = isEditorInputSessionActive(),
+        )
+    )
 }
 
 internal fun resolveDesktopEditorKeyboardState(

--- a/apps/mobile/compose/src/iosMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.ios.kt
+++ b/apps/mobile/compose/src/iosMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.ios.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.unit.dp
 import platform.Foundation.NSNotificationCenter
@@ -22,10 +23,14 @@ import platform.UIKit.UIKeyboardWillHideNotification
 import swiftPMImport.co.typie.compose.EditorKeyboardBridge
 
 @Composable
-internal actual fun rememberEditorKeyboardState(): EditorKeyboardState {
+internal actual fun rememberEditorKeyboardState(
+  isEditorInputSessionActive: () -> Boolean
+): EditorKeyboardState {
+  val currentEditorInputSessionActive by rememberUpdatedState(isEditorInputSessionActive)
   var hardwareKeyboardMode by remember { mutableStateOf(isEditorHardwareKeyboardConnected()) }
   var imeFrameVisible by remember { mutableStateOf(false) }
   var imeHideEventVersion by remember { mutableIntStateOf(0) }
+  var imeHideEventOwner by remember { mutableStateOf<EditorImeInputOwner?>(null) }
   var presentation by remember {
     mutableStateOf<EditorKeyboardPresentation>(EditorKeyboardPresentation.Hidden)
   }
@@ -40,6 +45,19 @@ internal actual fun rememberEditorKeyboardState(): EditorKeyboardState {
   ) {
     val targetBottom =
       notification?.let(EditorKeyboardBridge::imeVisibleHeightWithNotification)?.dp ?: 0.dp
+    if (targetBottom > 0.dp) {
+      imeHideEventOwner = null
+    } else if (
+      presentation != EditorKeyboardPresentation.Hidden &&
+        presentation != EditorKeyboardPresentation.Hiding
+    ) {
+      imeHideEventOwner =
+        if (currentEditorInputSessionActive()) {
+          EditorImeInputOwner.Editor
+        } else {
+          EditorImeInputOwner.Other
+        }
+    }
     if (settlesImeBottom) {
       presentation =
         if (targetBottom > 0.dp) {
@@ -125,6 +143,14 @@ internal actual fun rememberEditorKeyboardState(): EditorKeyboardState {
         `object` = null,
         queue = NSOperationQueue.mainQueue,
       ) {
+        if (presentation != EditorKeyboardPresentation.Hiding) {
+          imeHideEventOwner =
+            if (currentEditorInputSessionActive()) {
+              EditorImeInputOwner.Editor
+            } else {
+              EditorImeInputOwner.Other
+            }
+        }
         presentation = EditorKeyboardPresentation.Hiding
         imeFrameVisible = false
         imeHideEventVersion++
@@ -161,6 +187,7 @@ internal actual fun rememberEditorKeyboardState(): EditorKeyboardState {
       },
     imeFrameVisible = imeFrameVisible,
     imeHideEventVersion = imeHideEventVersion,
+    imeHideEventOwner = imeHideEventOwner,
     presentation = presentation,
   )
 }


### PR DESCRIPTION
- #4929 의 후속
- 노트 subpane을 닫고 나서 키보드가 닫히기 시작하고, 복원 로직에 의해 포커스가 복원되자마자 키보드가 완전히 닫히면서 다시 blur되는 문제가 있었음
- 개별 입력 callback 대신, 복원 대상 보조 UI가 활성인 동안 에디터가 실제로 blur되는 시점에 capture
  - 노트 subpane의 필터 popover처럼 별도 callback이 없던 하위 UI가 focus를 가져가도 이제 복원할 수 있음
- subpane dismiss 시작 시 selection과 focus를 복원 (이제 애니메이션이 끝나는 것을 기다리지 않음)
- IME hide의 입력 세션 ownership을 확인해 에디터에서 시작된 hide만 에디터 blur로 처리