### PR TITLE
웹 pointer gesture의 소유권과 종료 처리 보강

### DIFF
--- a/apps/website/src/lib/dnd-handler.test.ts
+++ b/apps/website/src/lib/dnd-handler.test.ts
@@ -1,0 +1,126 @@
+import { createDndHandler } from '@typie/ui/utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const pointerEvent = (type: string, pointerId = 1, clientX = 0) => {
+  const event = new MouseEvent(type, { bubbles: true, button: 0, clientX });
+  Object.defineProperties(event, {
+    pointerId: { value: pointerId },
+    isPrimary: { value: pointerId === 1 },
+  });
+  return event as PointerEvent;
+};
+
+const installPointerCapture = (element: HTMLElement) => {
+  let capturedPointerId: number | null = null;
+
+  element.setPointerCapture = vi.fn((pointerId) => {
+    capturedPointerId = pointerId;
+  });
+  element.hasPointerCapture = vi.fn((pointerId) => capturedPointerId === pointerId);
+  element.releasePointerCapture = vi.fn((pointerId) => {
+    if (capturedPointerId !== pointerId) return;
+    capturedPointerId = null;
+    element.dispatchEvent(pointerEvent('lostpointercapture', pointerId));
+  });
+
+  return {
+    lose(pointerId: number) {
+      capturedPointerId = null;
+      element.dispatchEvent(pointerEvent('lostpointercapture', pointerId));
+    },
+  };
+};
+
+const installAnimationFrames = () => {
+  const callbacks: FrameRequestCallback[] = [];
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+    callbacks.push(callback);
+    return callbacks.length;
+  });
+  vi.stubGlobal('cancelAnimationFrame', vi.fn());
+
+  return {
+    flush() {
+      const current = [...callbacks];
+      callbacks.length = 0;
+      for (const callback of current) callback(0);
+    },
+  };
+};
+
+const createElement = () => {
+  const element = document.createElement('div');
+  document.body.append(element);
+  return element;
+};
+
+afterEach(() => {
+  document.body.replaceChildren();
+  document.body.style.cursor = '';
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('createDndHandler', () => {
+  it('routes move and end only from the owner pointer', () => {
+    const element = createElement();
+    installPointerCapture(element);
+    const frames = installAnimationFrames();
+    const onDragMove = vi.fn();
+    const onDragEnd = vi.fn();
+    const handler = createDndHandler(element, { threshold: 0, showGhost: false, onDragMove, onDragEnd });
+
+    element.dispatchEvent(pointerEvent('pointerdown', 1));
+    const ownerMove = pointerEvent('pointermove', 1, 10);
+    element.dispatchEvent(ownerMove);
+    frames.flush();
+
+    element.dispatchEvent(pointerEvent('pointermove', 2, 20));
+    frames.flush();
+    element.dispatchEvent(pointerEvent('pointerup', 2, 20));
+
+    expect(onDragMove).toHaveBeenCalledOnce();
+    expect(onDragMove).toHaveBeenCalledWith(ownerMove);
+    expect(onDragEnd).not.toHaveBeenCalled();
+
+    const ownerUp = pointerEvent('pointerup', 1, 10);
+    element.dispatchEvent(ownerUp);
+    expect(onDragEnd).toHaveBeenCalledOnce();
+    expect(onDragEnd).toHaveBeenCalledWith(ownerUp);
+    handler.destroy();
+  });
+
+  it('cancels an active drag when pointer capture is lost', () => {
+    const element = createElement();
+    const capture = installPointerCapture(element);
+    const frames = installAnimationFrames();
+    const onDragCancel = vi.fn();
+    const handler = createDndHandler(element, { threshold: 0, showGhost: false, onDragCancel });
+
+    element.dispatchEvent(pointerEvent('pointerdown'));
+    element.dispatchEvent(pointerEvent('pointermove', 1, 10));
+    frames.flush();
+    capture.lose(1);
+
+    expect(onDragCancel).toHaveBeenCalledOnce();
+    expect(handler.state().isDragging).toBe(false);
+    handler.destroy();
+    expect(onDragCancel).toHaveBeenCalledOnce();
+  });
+
+  it('cancels consumer state when destroyed during an active drag', () => {
+    const element = createElement();
+    installPointerCapture(element);
+    const frames = installAnimationFrames();
+    const onDragCancel = vi.fn();
+    const handler = createDndHandler(element, { threshold: 0, showGhost: false, onDragCancel });
+
+    element.dispatchEvent(pointerEvent('pointerdown'));
+    element.dispatchEvent(pointerEvent('pointermove', 1, 10));
+    frames.flush();
+    handler.destroy();
+
+    expect(onDragCancel).toHaveBeenCalledOnce();
+    expect(handler.state().isDragging).toBe(false);
+  });
+});

--- a/apps/website/src/lib/editor-ffi/components/Scrollbar.svelte
+++ b/apps/website/src/lib/editor-ffi/components/Scrollbar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { css } from '@typie/styled-system/css';
+  import { pointerCapture } from '@typie/ui/actions';
   import { getEditorContext } from '../editor.svelte';
   import type { Size } from '@typie/editor-ffi/browser';
 
@@ -21,6 +22,13 @@
     trackSize: number;
     thumbSize: number;
     thumbPos: number;
+  };
+  type ScrollDragSession = {
+    axis: 'x' | 'y';
+    startPointer: number;
+    startScroll: number;
+    maxScroll: number;
+    trackMinusThumb: number;
   };
 
   function axisGeometry(m: AxisMetric): AxisGeometry {
@@ -196,47 +204,47 @@
     };
   });
 
-  function startDrag(axis: 'x' | 'y', e: PointerEvent) {
-    if (!scrollContainer) return;
+  function startDrag(axis: 'x' | 'y', e: PointerEvent): ScrollDragSession | null {
+    if (!scrollContainer || dragAxis !== null || !e.isPrimary || e.button !== 0) return null;
     e.preventDefault();
     e.stopPropagation();
-
-    const target = e.currentTarget as HTMLElement;
-    target.setPointerCapture(e.pointerId);
 
     dragAxis = axis;
     markUserScroll();
     show('user');
 
     const geometryetry = axis === 'y' ? y : x;
-    const startPointer = axis === 'y' ? e.clientY : e.clientX;
-    const startScroll = axis === 'y' ? scrollContainer.scrollTop : scrollContainer.scrollLeft;
-    const maxScroll = geometryetry.maxScroll;
-    const trackMinusThumb = geometryetry.trackSize - geometryetry.thumbSize;
-
-    const onMove = (ev: PointerEvent) => {
-      if (!scrollContainer) return;
-      markUserScroll();
-      const delta = (((axis === 'y' ? ev.clientY : ev.clientX) - startPointer) / trackMinusThumb) * maxScroll;
-      if (axis === 'y') scrollContainer.scrollTop = startScroll + delta;
-      else scrollContainer.scrollLeft = startScroll + delta;
+    return {
+      axis,
+      startPointer: axis === 'y' ? e.clientY : e.clientX,
+      startScroll: axis === 'y' ? scrollContainer.scrollTop : scrollContainer.scrollLeft,
+      maxScroll: geometryetry.maxScroll,
+      trackMinusThumb: geometryetry.trackSize - geometryetry.thumbSize,
     };
+  }
 
-    const end = () => {
-      dragAxis = null;
-      target.removeEventListener('pointermove', onMove);
-      target.removeEventListener('pointerup', end);
-      target.removeEventListener('lostpointercapture', end);
-      show('user');
-    };
+  function moveDrag(session: ScrollDragSession, e: PointerEvent) {
+    if (!scrollContainer || dragAxis !== session.axis) return;
+    markUserScroll();
+    const position = session.axis === 'y' ? e.clientY : e.clientX;
+    const delta = ((position - session.startPointer) / session.trackMinusThumb) * session.maxScroll;
+    if (session.axis === 'y') scrollContainer.scrollTop = session.startScroll + delta;
+    else scrollContainer.scrollLeft = session.startScroll + delta;
+  }
 
-    target.addEventListener('pointermove', onMove);
-    target.addEventListener('pointerup', end);
-    target.addEventListener('lostpointercapture', end);
+  function finishDrag(session: ScrollDragSession) {
+    if (dragAxis !== session.axis) return;
+    dragAxis = null;
+    show('user');
+  }
+
+  function endDrag(session: ScrollDragSession, event: PointerEvent) {
+    moveDrag(session, event);
+    finishDrag(session);
   }
 
   function jumpTo(axis: 'x' | 'y', e: PointerEvent) {
-    if (!scrollContainer || e.target !== e.currentTarget) return;
+    if (!scrollContainer || e.target !== e.currentTarget || !e.isPrimary || e.button !== 0) return;
     e.preventDefault();
     e.stopPropagation();
     markUserScroll();
@@ -313,9 +321,14 @@
       aria-valuemax={geometry.maxScroll}
       aria-valuemin={0}
       aria-valuenow={isVertical ? metrics.scrollTop : metrics.scrollLeft}
-      onpointerdown={(e) => startDrag(axis, e)}
       role="slider"
       tabindex="-1"
+      use:pointerCapture={{
+        start: (event) => startDrag(axis, event),
+        move: moveDrag,
+        end: endDrag,
+        cancel: finishDrag,
+      }}
     ></div>
   </div>
 {/snippet}

--- a/apps/website/src/lib/editor-ffi/components/TableOverlay.svelte
+++ b/apps/website/src/lib/editor-ffi/components/TableOverlay.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { css } from '@typie/styled-system/css';
   import { center } from '@typie/styled-system/patterns';
+  import { pointerCapture } from '@typie/ui/actions';
   import { HorizontalDivider, Icon, Menu, MenuItem, Submenu } from '@typie/ui/components';
   import { getThemeContext } from '@typie/ui/context';
   import { clamp } from '@typie/ui/utils';
@@ -373,6 +374,50 @@
     resizing = { ...current, deltaX: currentTableX - current.startTableX };
   }
 
+  function startResize(event: PointerEvent, colIndex: number): TableResizeState | null {
+    if (!event.isPrimary || event.button !== 0 || resizing) return null;
+
+    const root = tableOverlayRoot;
+    if (!root || !editor) return null;
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    const state = {
+      pointerId: event.pointerId,
+      colIndex,
+      initialWidths: overlay.columns.map((column) => column.width_as_px),
+      startTableX: (event.clientX - root.getBoundingClientRect().left) / safeDisplayZoom,
+      deltaX: 0,
+    };
+    resizing = state;
+    resizeEdgeAutoScroll.update(editor, event, (clientX) => updateResize(state.pointerId, clientX));
+    return state;
+  }
+
+  function moveResize(state: TableResizeState, event: PointerEvent) {
+    if (!editor) return;
+    updateResize(state.pointerId, event.clientX);
+    resizeEdgeAutoScroll.update(editor, event, (clientX) => updateResize(state.pointerId, clientX));
+  }
+
+  function finishResize(state: TableResizeState, event: PointerEvent) {
+    updateResize(state.pointerId, event.clientX);
+    const finalState = resizing;
+    if (!finalState || finalState.pointerId !== state.pointerId) return;
+
+    resizing = null;
+    resizeEdgeAutoScroll.stop();
+    commitResize(finalState);
+    editor?.focus();
+  }
+
+  function cancelResize(state: TableResizeState) {
+    if (resizing?.pointerId !== state.pointerId) return;
+    resizing = null;
+    resizeEdgeAutoScroll.stop();
+  }
+
   function setBorderStyle(style: 'solid' | 'dashed' | 'dotted' | 'none') {
     enqueueTableOp({
       type: 'node',
@@ -717,84 +762,13 @@
           _hover: { opacity: '100', backgroundColor: 'accent.brand.default' },
         })}
         aria-label={isLastCol ? '테이블 너비 조절' : '열 너비 조절'}
-        onpointerdown={(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          if (resizing) return;
-
-          const target = e.currentTarget as HTMLElement;
-          const root = tableOverlayRoot;
-          if (!root || !editor) return;
-
-          const pointerId = e.pointerId;
-          const initialWidths = overlay.columns.map((column) => column.width_as_px);
-          const startTableX = (e.clientX - root.getBoundingClientRect().left) / safeDisplayZoom;
-          target.setPointerCapture(pointerId);
-          resizing = { pointerId, colIndex, initialWidths, startTableX, deltaX: 0 };
-
-          const removeListeners = () => {
-            target.removeEventListener('pointermove', onMove);
-            target.removeEventListener('pointerup', onUp);
-            target.removeEventListener('pointercancel', onCancel);
-            target.removeEventListener('lostpointercapture', onLostPointerCapture);
-          };
-
-          const onMove = (me: PointerEvent) => {
-            if (resizing?.pointerId !== me.pointerId) return;
-            if (!target.hasPointerCapture(me.pointerId)) return;
-            updateResize(me.pointerId, me.clientX);
-            resizeEdgeAutoScroll.update(editor, { clientX: me.clientX, clientY: me.clientY }, (clientX) => {
-              updateResize(me.pointerId, clientX);
-            });
-          };
-
-          const onUp = (ue: PointerEvent) => {
-            if (resizing?.pointerId !== ue.pointerId) return;
-            updateResize(ue.pointerId, ue.clientX);
-            const finalState = resizing;
-            if (!finalState || finalState.pointerId !== ue.pointerId) return;
-
-            resizing = null;
-            resizeEdgeAutoScroll.stop();
-            commitResize(finalState);
-            editor.focus();
-            removeListeners();
-            if (target.hasPointerCapture(ue.pointerId)) {
-              target.releasePointerCapture(ue.pointerId);
-            }
-          };
-
-          const onCancel = (ce: PointerEvent) => {
-            const finalState = resizing;
-            if (!finalState || finalState.pointerId !== ce.pointerId) return;
-
-            resizing = null;
-            resizeEdgeAutoScroll.stop();
-            commitResize(finalState);
-            editor.focus();
-            removeListeners();
-            if (target.hasPointerCapture(ce.pointerId)) {
-              target.releasePointerCapture(ce.pointerId);
-            }
-          };
-
-          const onLostPointerCapture = (le: PointerEvent) => {
-            if (resizing?.pointerId !== le.pointerId) return;
-
-            resizing = null;
-            resizeEdgeAutoScroll.stop();
-            removeListeners();
-          };
-
-          target.addEventListener('pointermove', onMove);
-          target.addEventListener('pointerup', onUp);
-          target.addEventListener('pointercancel', onCancel);
-          target.addEventListener('lostpointercapture', onLostPointerCapture);
-          resizeEdgeAutoScroll.update(editor, { clientX: e.clientX, clientY: e.clientY }, (clientX) => {
-            updateResize(pointerId, clientX);
-          });
-        }}
         type="button"
+        use:pointerCapture={{
+          start: (event) => startResize(event, colIndex),
+          move: moveResize,
+          end: finishResize,
+          cancel: cancelResize,
+        }}
       ></button>
     {/each}
   </div>

--- a/apps/website/src/lib/editor-ffi/components/View.svelte
+++ b/apps/website/src/lib/editor-ffi/components/View.svelte
@@ -3,7 +3,7 @@
   import { css } from '@typie/styled-system/css';
   import { getThemeContext } from '@typie/ui/context';
   import { elementScrollViewport, windowScrollViewport } from '@typie/ui/utils';
-  import { untrack } from 'svelte';
+  import { onDestroy, untrack } from 'svelte';
   import { graphql } from '$mearie';
   import {
     CONTINUOUS_MIN_WIDTH,
@@ -17,7 +17,15 @@
   import { handle } from '../handlers';
   import { handleContextMenu } from '../handlers/contextmenu';
   import { handleDragEnd, handleDragEnter, handleDragLeave, handleDragOver, handleDragStart, handleDrop } from '../handlers/dnd';
-  import { handleClick, handlePointerCancel, handlePointerDown, handlePointerMove, handlePointerUp } from '../handlers/pointer';
+  import {
+    cancelPointerInteraction,
+    handleClick,
+    handlePointerCancel,
+    handlePointerCaptureLost,
+    handlePointerDown,
+    handlePointerMove,
+    handlePointerUp,
+  } from '../handlers/pointer';
   import { setupEditorScroll } from '../scroll.svelte';
   import { touchPanLock } from '../touch-pan-lock';
   import Caret from './Caret.svelte';
@@ -53,6 +61,9 @@
   const ctx = getEditorContext();
   const theme = getThemeContext();
   setupEditorScroll(ctx);
+  onDestroy(() => {
+    if (ctx.editor) cancelPointerInteraction(ctx.editor);
+  });
 
   const document = createFragment(
     graphql(`
@@ -293,6 +304,7 @@
             if (event.relatedTarget === ctx.editor?.inputEl) return;
             ctx.editor?.blur();
           }}
+          onlostpointercapture={handle(ctx.editor, handlePointerCaptureLost)}
           onpointercancel={handle(ctx.editor, handlePointerCancel)}
           onpointerdown={handle(ctx.editor, handlePointerDown)}
           onpointerleave={() => ctx.editor?.clearLinkHover()}

--- a/apps/website/src/lib/editor-ffi/edge-auto-scroll.ts
+++ b/apps/website/src/lib/editor-ffi/edge-auto-scroll.ts
@@ -1,4 +1,4 @@
-import { handleDragScroll } from '@typie/ui/utils';
+import { createDragScroll } from '@typie/ui/utils';
 import {
   EDGE_AUTO_SCROLL_MAX_SPEED,
   EDGE_AUTO_SCROLL_MIN_SPEED,
@@ -13,7 +13,7 @@ type ClientPoint = {
 };
 
 export class EditorEdgeAutoScroll {
-  #cleanup: (() => void) | null = null;
+  #dragScroll: ReturnType<typeof createDragScroll> | null = null;
   #onScroll: ((clientX: number, clientY: number) => void) | null = null;
 
   update(editor: Editor, pointer: ClientPoint, onScroll: (clientX: number, clientY: number) => void): void {
@@ -25,21 +25,20 @@ export class EditorEdgeAutoScroll {
 
     this.stop();
     this.#onScroll = onScroll;
-    this.#cleanup =
-      handleDragScroll(viewport, true, {
-        axis: 'both',
-        initialPointer: pointer,
-        scrollZoneSize: EDGE_AUTO_SCROLL_THRESHOLD_PX,
-        minScrollSpeed: EDGE_AUTO_SCROLL_MIN_SPEED,
-        maxScrollSpeed: EDGE_AUTO_SCROLL_MAX_SPEED,
-        onScrollThrottleMs: EDGE_AUTO_SCROLL_THROTTLE_MS,
-        onScroll: (clientX, clientY) => this.#onScroll?.(clientX, clientY),
-      }) ?? null;
+    this.#dragScroll = createDragScroll(viewport, {
+      axis: 'both',
+      initialPointer: pointer,
+      scrollZoneSize: EDGE_AUTO_SCROLL_THRESHOLD_PX,
+      minScrollSpeed: EDGE_AUTO_SCROLL_MIN_SPEED,
+      maxScrollSpeed: EDGE_AUTO_SCROLL_MAX_SPEED,
+      onScrollThrottleMs: EDGE_AUTO_SCROLL_THROTTLE_MS,
+      onScroll: (clientX, clientY) => this.#onScroll?.(clientX, clientY),
+    });
   }
 
   stop(): void {
-    this.#cleanup?.();
-    this.#cleanup = null;
+    this.#dragScroll?.destroy();
+    this.#dragScroll = null;
     this.#onScroll = null;
   }
 }

--- a/apps/website/src/lib/editor-ffi/handlers/pointer.test.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/pointer.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
-import { handlePointerDown, handlePointerMove, handlePointerUp, markNativeSelectionDragStarted } from './pointer';
+import {
+  cancelPointerInteraction,
+  handlePointerCaptureLost,
+  handlePointerDown,
+  handlePointerMove,
+  handlePointerUp,
+  markNativeSelectionDragStarted,
+} from './pointer';
 import type { Editor } from '../editor.svelte';
 
 const collapsedSelection = {
@@ -42,6 +49,7 @@ const createPointerEvent = ({
   clientX = 110,
   clientY = 220,
   shiftKey = false,
+  isPrimary = true,
 }: {
   pointerId?: number;
   button?: number;
@@ -50,12 +58,14 @@ const createPointerEvent = ({
   clientX?: number;
   clientY?: number;
   shiftKey?: boolean;
+  isPrimary?: boolean;
 } = {}) => {
   return {
     pointerId,
     pointerType: 'mouse',
     button,
     buttons: button === 0 ? 1 : 0,
+    isPrimary,
     clientX,
     clientY,
     shiftKey,
@@ -186,6 +196,22 @@ describe('pointer native drag admission', () => {
     expect(editor.scrollIntoView).toHaveBeenCalledWith({ target: { type: 'current_selection_head' }, mode: 'nearest' });
   });
 
+  it('ignores a non-primary pointer without replacing the active selection interaction', () => {
+    const editor = createEditor();
+    const target = createPointerTarget({ captured: true });
+
+    handlePointerDown(editor, createPointerEvent({ target, pointerId: 1 }));
+    editor.enqueue.mockClear();
+    handlePointerDown(editor, createPointerEvent({ target, pointerId: 2, isPrimary: false }));
+    handlePointerUp(editor, createPointerEvent({ target, pointerId: 1 }));
+
+    expect(target.setPointerCapture).toHaveBeenCalledTimes(1);
+    expect(editor.enqueue).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'selection', op: expect.objectContaining({ type: 'set_at' }) }),
+    );
+    expect(editor.resumeToolbarSync).toHaveBeenCalledOnce();
+  });
+
   it('ignores non-touch pointer down on a selection handle marker', () => {
     const editor = createEditor();
     const target = createPointerTarget();
@@ -208,6 +234,34 @@ describe('pointer native drag admission', () => {
 
     handlePointerUp(editor, createPointerEvent({ target }));
     expect(editor.resumeToolbarSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels the active selection interaction when pointer capture is lost', () => {
+    const editor = createEditor();
+    const target = createPointerTarget({ captured: false });
+
+    handlePointerDown(editor, createPointerEvent({ target }));
+    handlePointerCaptureLost(editor, createPointerEvent({ target }));
+
+    expect(target.releasePointerCapture).not.toHaveBeenCalled();
+    expect(editor.resumeToolbarSync).toHaveBeenCalledOnce();
+    expect(editor.endNativeDragAdmission).toHaveBeenCalledWith({ restoreFocus: false });
+    handlePointerUp(editor, createPointerEvent({ target }));
+    expect(editor.resumeToolbarSync).toHaveBeenCalledOnce();
+  });
+
+  it('cancels the active selection interaction when its view is destroyed', () => {
+    const editor = createEditor();
+    const target = createPointerTarget({ captured: true });
+
+    handlePointerDown(editor, createPointerEvent({ target }));
+    cancelPointerInteraction(editor);
+
+    expect(target.releasePointerCapture).not.toHaveBeenCalled();
+    expect(editor.resumeToolbarSync).toHaveBeenCalledOnce();
+    expect(editor.endNativeDragAdmission).toHaveBeenCalledWith({ restoreFocus: false });
+    handlePointerUp(editor, createPointerEvent({ target }));
+    expect(editor.resumeToolbarSync).toHaveBeenCalledOnce();
   });
 
   it('does not suspend toolbar sync when admitting a native text-move drag', () => {

--- a/apps/website/src/lib/editor-ffi/handlers/pointer.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/pointer.ts
@@ -35,6 +35,8 @@ export const tryHandleInteractiveHit = (editor: Editor, hit: InteractiveHit, loc
 };
 
 export const handlePointerDown: EditorEventHandler<HTMLElement, PointerEvent> = (editor, e) => {
+  if (!e.isPrimary) return;
+
   const selectionHandleType = selectionHandleKindFromTarget(e.target);
   const isReadOnlyTouch = editor.readOnly && e.pointerType === 'touch';
   if (selectionHandleType && !isReadOnlyTouch) {
@@ -150,8 +152,8 @@ export const handlePointerUp: EditorEventHandler<HTMLElement, PointerEvent> = (e
     return;
   }
 
-  state.releasePointer(e.currentTarget, e.pointerId);
   state.finishPointerUp(editor, e.pointerId, { clientX: e.clientX, clientY: e.clientY });
+  state.releasePointer(e.currentTarget, e.pointerId);
   editor.flush();
   editor.resumeToolbarSync();
   editor.endNativeDragAdmission({ restoreFocus: true });
@@ -181,8 +183,27 @@ export const handlePointerCancel: EditorEventHandler<HTMLElement, PointerEvent> 
     return;
   }
 
-  state.releasePointer(e.currentTarget, e.pointerId);
   state.cancelPointer(e.pointerId);
+  state.releasePointer(e.currentTarget, e.pointerId);
+  editor.flush();
+  editor.resumeToolbarSync();
+  editor.endNativeDragAdmission({ restoreFocus: false });
+};
+
+export const handlePointerCaptureLost: EditorEventHandler<HTMLElement, PointerEvent> = (editor, e) => {
+  const state = PointerState.of(editor);
+  if (!state.hasActivePointer(e.pointerId)) return;
+
+  state.cancelPointer(e.pointerId);
+  editor.flush();
+  editor.resumeToolbarSync();
+  editor.endNativeDragAdmission({ restoreFocus: false });
+};
+
+export const cancelPointerInteraction = (editor: Editor): void => {
+  const state = PointerState.of(editor);
+  if (!state.cancelActivePointer()) return;
+
   editor.flush();
   editor.resumeToolbarSync();
   editor.endNativeDragAdmission({ restoreFocus: false });
@@ -333,7 +354,7 @@ class PointerState {
   }
 
   releasePointer(target: HTMLElement, pointerId: number): void {
-    if (this.#session?.captured && this.#session.pointerId === pointerId && target.hasPointerCapture(pointerId)) {
+    if (target.hasPointerCapture(pointerId)) {
       target.releasePointerCapture(pointerId);
     }
   }
@@ -362,6 +383,13 @@ class PointerState {
     this.#dragPending = null;
     this.#edgeAutoScroll.stop();
     this.#session = null;
+  }
+
+  cancelActivePointer(): boolean {
+    const pointerId = this.#session?.pointerId;
+    if (pointerId === undefined) return false;
+    this.cancelPointer(pointerId);
+    return true;
   }
 
   markNativeDragStarted(): void {

--- a/apps/website/src/lib/pane-dnd.test.ts
+++ b/apps/website/src/lib/pane-dnd.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { dragPane } from '../routes/website/(dashboard)/[slug]/@pane/dnd';
+import type { PaneGroup } from '../routes/website/(dashboard)/[slug]/@pane/context.svelte';
+
+const pointerEvent = ({
+  type,
+  pointerId = 1,
+  clientX = 0,
+  button = 0,
+  isPrimary = true,
+}: {
+  type: string;
+  pointerId?: number;
+  clientX?: number;
+  button?: number;
+  isPrimary?: boolean;
+}) => {
+  const event = new MouseEvent(type, { bubbles: true, button, clientX });
+  Object.defineProperties(event, {
+    pointerId: { value: pointerId },
+    isPrimary: { value: isPrimary },
+  });
+  return event as PointerEvent;
+};
+
+const createElement = () => {
+  const element = document.createElement('div');
+  let capturedPointerId: number | null = null;
+  element.setPointerCapture = vi.fn((pointerId) => {
+    capturedPointerId = pointerId;
+  });
+  element.hasPointerCapture = vi.fn((pointerId) => capturedPointerId === pointerId);
+  element.releasePointerCapture = vi.fn((pointerId) => {
+    if (capturedPointerId !== pointerId) return;
+    capturedPointerId = null;
+    element.dispatchEvent(pointerEvent({ type: 'lostpointercapture', pointerId }));
+  });
+  document.body.append(element);
+  return element;
+};
+
+const createPaneGroup = () =>
+  ({
+    draggingPaneId: null,
+    updateActiveZone: vi.fn(),
+    executeDrop: vi.fn(),
+    cancelDrag: vi.fn(),
+  }) as unknown as PaneGroup & {
+    updateActiveZone: ReturnType<typeof vi.fn>;
+    executeDrop: ReturnType<typeof vi.fn>;
+    cancelDrag: ReturnType<typeof vi.fn>;
+  };
+
+afterEach(() => {
+  document.body.replaceChildren();
+  document.body.style.cursor = '';
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('dragPane', () => {
+  it('ignores foreign pointer termination and drops only for the owner', () => {
+    const element = createElement();
+    const paneGroup = createPaneGroup();
+    const action = dragPane(element, { paneGroup, paneId: 'pane-1' });
+
+    element.dispatchEvent(pointerEvent({ type: 'pointerdown', pointerId: 1 }));
+    element.dispatchEvent(pointerEvent({ type: 'pointermove', pointerId: 1, clientX: 20 }));
+    element.dispatchEvent(pointerEvent({ type: 'pointerup', pointerId: 2, clientX: 20, isPrimary: false }));
+
+    expect(paneGroup.executeDrop).not.toHaveBeenCalled();
+    expect(paneGroup.draggingPaneId).toBe('pane-1');
+
+    element.dispatchEvent(pointerEvent({ type: 'pointerup', pointerId: 1, clientX: 20 }));
+    expect(paneGroup.executeDrop).toHaveBeenCalledOnce();
+    expect(paneGroup.cancelDrag).not.toHaveBeenCalled();
+    action?.destroy?.();
+  });
+
+  it('cancels external drag state when destroyed during a drag', () => {
+    const element = createElement();
+    const paneGroup = createPaneGroup();
+    const action = dragPane(element, { paneGroup, paneId: 'pane-1' });
+
+    element.dispatchEvent(pointerEvent({ type: 'pointerdown' }));
+    element.dispatchEvent(pointerEvent({ type: 'pointermove', clientX: 20 }));
+    action?.destroy?.();
+
+    expect(paneGroup.cancelDrag).toHaveBeenCalledOnce();
+    expect(paneGroup.draggingPaneId).toBeNull();
+    expect(document.body.style.cursor).toBe('');
+  });
+
+  it('does not start from a non-primary or non-left pointer', () => {
+    const element = createElement();
+    const paneGroup = createPaneGroup();
+    const action = dragPane(element, { paneGroup, paneId: 'pane-1' });
+
+    element.dispatchEvent(pointerEvent({ type: 'pointerdown', button: 2 }));
+    element.dispatchEvent(pointerEvent({ type: 'pointerdown', pointerId: 2, isPrimary: false }));
+
+    expect(element.setPointerCapture).not.toHaveBeenCalled();
+    action?.destroy?.();
+  });
+});

--- a/apps/website/src/lib/pointer-capture.test.ts
+++ b/apps/website/src/lib/pointer-capture.test.ts
@@ -155,6 +155,24 @@ describe('pointerCapture', () => {
     expect(start).toHaveBeenCalledOnce();
   });
 
+  it('supports programmatic cancellation without destroying the action', () => {
+    const element = createElement();
+    installPointerCapture(element);
+    const session = { id: 'owner' };
+    const start = vi.fn(() => session);
+    const cancel = vi.fn();
+    const action = pointerCapture(element, { start, cancel }) as ReturnType<typeof pointerCapture> & { cancel?: () => void };
+
+    element.dispatchEvent(pointerEvent('pointerdown'));
+    action.cancel?.();
+
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(cancel).toHaveBeenCalledWith(session, 'programmatic', undefined);
+    element.dispatchEvent(pointerEvent('pointerdown'));
+    expect(start).toHaveBeenCalledTimes(2);
+    action.destroy?.();
+  });
+
   it('cancels state changed by start when capture acquisition fails', () => {
     const element = createElement();
     installPointerCapture(element);

--- a/apps/website/src/routes/website/(dashboard)/@notes/Note.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@notes/Note.svelte
@@ -161,7 +161,7 @@
     }
   }}
   onpointerdown={(e) => {
-    if (expanded) return;
+    if (expanded || !e.isPrimary || e.button !== 0) return;
     const target = e.target as HTMLElement;
     if (target.closest('button, textarea, a')) return;
 

--- a/apps/website/src/routes/website/(dashboard)/@tree/EntityTree.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@tree/EntityTree.svelte
@@ -5,9 +5,9 @@
   import { contextMenu, portal } from '@typie/ui/actions';
   import { Icon } from '@typie/ui/components';
   import { Toast } from '@typie/ui/notification';
-  import { elementScrollViewport, handleDragScroll } from '@typie/ui/utils';
+  import { createDragScroll, elementScrollViewport } from '@typie/ui/utils';
   import mixpanel from 'mixpanel-browser';
-  import { tick } from 'svelte';
+  import { onDestroy, tick } from 'svelte';
   import { on } from 'svelte/events';
   import { SvelteMap } from 'svelte/reactivity';
   import { fade } from 'svelte/transition';
@@ -238,6 +238,7 @@
   let pendingTouchDrag = $state<PendingTouchDrag | null>(null);
   let pointerType = $state<PointerEvent['pointerType']>('mouse');
   let dragTimeout = $state<NodeJS.Timeout | null>(null);
+  let dragScroll: ReturnType<typeof createDragScroll> | null = null;
   let folderHoverTimeout = $state<NodeJS.Timeout | null>(null);
   let hoveredFolderId = $state<string | null>(null);
 
@@ -348,10 +349,7 @@
   };
 
   const handlePointerDown: PointerEventHandler<HTMLDivElement> = (e) => {
-    // NOTE: 우클릭 무시
-    if (e.button === 2) {
-      return;
-    }
+    if (!e.isPrimary || e.button !== 0 || dragging || pendingTouchDrag) return;
 
     const target = e.target as HTMLElement;
 
@@ -400,7 +398,12 @@
         };
 
         if (!pendingTouchDrag.element.hasPointerCapture(e.pointerId)) {
-          pendingTouchDrag.element.setPointerCapture(e.pointerId);
+          try {
+            pendingTouchDrag.element.setPointerCapture(e.pointerId);
+          } catch {
+            endDragging(true);
+            return;
+          }
         }
 
         lastPointerX = pendingTouchDrag.event.clientX;
@@ -644,9 +647,15 @@
     const scrollContainer = tree.parentElement;
     if (!scrollContainer) return;
 
-    return handleDragScroll(elementScrollViewport(scrollContainer), true, {
+    const current = createDragScroll(elementScrollViewport(scrollContainer), {
+      initialPointer: { clientX: lastPointerX, clientY: lastPointerY },
       onScroll: () => updateDropTarget(lastPointerX, lastPointerY),
     });
+    dragScroll = current;
+    return () => {
+      current.destroy();
+      if (dragScroll === current) dragScroll = null;
+    };
   });
 
   const handlePointerMove: PointerEventHandler<HTMLDivElement> = (e) => {
@@ -683,6 +692,7 @@
 
     lastPointerX = e.clientX;
     lastPointerY = e.clientY;
+    dragScroll?.updatePointer(e.clientX, e.clientY);
 
     if (dragging.eligible) {
       if (dragging.event.pointerType === 'touch' && e.cancelable) {
@@ -690,7 +700,12 @@
       }
 
       if (!dragging.element.hasPointerCapture(e.pointerId)) {
-        dragging.element.setPointerCapture(e.pointerId);
+        try {
+          dragging.element.setPointerCapture(e.pointerId);
+        } catch {
+          endDragging(true);
+          return;
+        }
       }
 
       dragging.ghost = {
@@ -703,7 +718,12 @@
       updateDropTarget(e.clientX, e.clientY);
     } else if (Math.abs(dragging.event.clientX - e.clientX) + Math.abs(dragging.event.clientY - e.clientY) > TOUCH_MOVE_THRESHOLD) {
       dragging.eligible = true;
-      dragging.element.setPointerCapture(e.pointerId);
+      try {
+        dragging.element.setPointerCapture(e.pointerId);
+      } catch {
+        endDragging(true);
+        return;
+      }
 
       const rect = dragging.element.getBoundingClientRect();
       dragging.ghost = {
@@ -793,13 +813,20 @@
     endDragging(true);
   };
 
-  const handlePointerCancel: PointerEventHandler<HTMLDivElement> = () => {
+  const handlePointerCancel: PointerEventHandler<HTMLDivElement> = (e) => {
     if (dragging) {
+      if (dragging.event.pointerId !== e.pointerId) return;
       endDragging(true);
       return;
     }
 
+    if (pendingTouchDrag?.event.pointerId !== e.pointerId) return;
     clearPendingTouchDrag();
+  };
+
+  const handleLostPointerCapture: PointerEventHandler<HTMLDivElement> = (e) => {
+    if (dragging?.event.pointerId !== e.pointerId) return;
+    endDragging(true);
   };
 
   const handleContextMenuCapture: MouseEventHandler<HTMLDivElement> = (e) => {
@@ -812,25 +839,27 @@
   };
 
   const endDragging = (canceled = false) => {
-    if (!dragging) {
+    const current = dragging;
+    if (!current) {
       clearPendingTouchDrag();
       return;
     }
 
+    dragging = null;
     clearPendingTouchDrag();
 
     clearFolderHoverTimeout();
-
-    if (dragging.eligible && dragging.element.hasPointerCapture(dragging.event.pointerId)) {
-      dragging.element.releasePointerCapture(dragging.event.pointerId);
-    }
 
     if (canceled) {
       paneGroup.cancelDrag();
     }
 
-    dragging = null;
+    if (current.eligible && current.element.hasPointerCapture(current.event.pointerId)) {
+      current.element.releasePointerCapture(current.event.pointerId);
+    }
   };
+
+  onDestroy(() => endDragging(true));
 
   const draggingEntityCount = $derived.by(() => {
     return countSelectedEntitiesForDragGhost(treeState.selectedEntityIds);
@@ -910,6 +939,7 @@
   })}
   onclick={handleClick}
   oncontextmenucapture={handleContextMenuCapture}
+  onlostpointercapture={handleLostPointerCapture}
   onpointercancelcapture={handlePointerCancel}
   onpointerdowncapture={handlePointerDown}
   onpointermovecapture={handlePointerMove}

--- a/apps/website/src/routes/website/(dashboard)/@widgets/widgets/DocumentRelatedNoteWidget.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@widgets/widgets/DocumentRelatedNoteWidget.svelte
@@ -5,9 +5,9 @@
   import { tooltip } from '@typie/ui/actions';
   import { Icon } from '@typie/ui/components';
   import { Toast } from '@typie/ui/notification';
-  import { animateFlip, elementScrollViewport, handleDragScroll } from '@typie/ui/utils';
+  import { animateFlip, createDragScroll, elementScrollViewport } from '@typie/ui/utils';
   import mixpanel from 'mixpanel-browser';
-  import { tick } from 'svelte';
+  import { tick, untrack } from 'svelte';
   import { SvelteSet } from 'svelte/reactivity';
   import ChevronDownIcon from '~icons/lucide/chevron-down';
   import ChevronUpIcon from '~icons/lucide/chevron-up';
@@ -80,9 +80,11 @@
   let dragging = $state<{
     noteId: string;
     originalIndex: number;
+    pointer: { clientX: number; clientY: number } | null;
   } | null>(null);
   let localNoteOrder = $state<string[]>([]);
   let scrollContainer = $state<HTMLElement | null>(null);
+  let dragScroll: ReturnType<typeof createDragScroll> | null = null;
   let isExpanded = $state((data.isExpanded as boolean) ?? false);
   let isCollapsed = $state((data.isCollapsed as boolean) ?? false);
 
@@ -152,6 +154,7 @@
     dragging = {
       noteId,
       originalIndex: localNoteOrder.indexOf(noteId),
+      pointer: null,
     };
   };
 
@@ -184,7 +187,7 @@
     }
   };
 
-  const updateDraggingPosition = (clientX: number, clientY: number) => {
+  const resolveDraggingPosition = (clientX: number, clientY: number) => {
     if (!dragging || !scrollContainer) return;
 
     const element = document.elementFromPoint(clientX, clientY);
@@ -193,6 +196,13 @@
 
     const noteId = noteElement.dataset.widgetNoteId;
     if (noteId) moveDraggingNote(noteId);
+  };
+
+  const updateDraggingPosition = (clientX: number, clientY: number) => {
+    if (!dragging) return;
+    dragging.pointer = { clientX, clientY };
+    dragScroll?.updatePointer(clientX, clientY);
+    resolveDraggingPosition(clientX, clientY);
   };
 
   const handleDragEnd = async (clientX: number, clientY: number) => {
@@ -254,11 +264,21 @@
   });
 
   $effect(() => {
-    if (!palette) {
-      return handleDragScroll(scrollContainer ? elementScrollViewport(scrollContainer) : null, !!dragging, {
-        onScroll: updateDraggingPosition,
-      });
-    }
+    const current = dragging;
+    if (palette || !scrollContainer || !current) return;
+
+    const initialPointer = untrack(() => current.pointer ?? undefined);
+    const activeDragScroll = createDragScroll(elementScrollViewport(scrollContainer), {
+      initialPointer,
+      onScroll: (clientX, clientY) => {
+        if (dragging === current) resolveDraggingPosition(clientX, clientY);
+      },
+    });
+    dragScroll = activeDragScroll;
+    return () => {
+      activeDragScroll.destroy();
+      if (dragScroll === activeDragScroll) dragScroll = null;
+    };
   });
 
   $effect.pre(() => {

--- a/apps/website/src/routes/website/(dashboard)/@widgets/widgets/DocumentRelatedNoteWidgetItem.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@widgets/widgets/DocumentRelatedNoteWidgetItem.svelte
@@ -218,7 +218,7 @@
     e.preventDefault();
   }}
   onpointerdown={(e) => {
-    if (palette) return;
+    if (palette || !e.isPrimary || e.button !== 0) return;
     const target = e.target as HTMLElement;
     if (target.closest('button, textarea')) return;
 

--- a/apps/website/src/routes/website/(dashboard)/Sidebar.svelte
+++ b/apps/website/src/routes/website/(dashboard)/Sidebar.svelte
@@ -2,7 +2,7 @@
   import { createFragment, createMutation } from '@mearie/svelte';
   import { css } from '@typie/styled-system/css';
   import { center, flex } from '@typie/styled-system/patterns';
-  import { tooltip } from '@typie/ui/actions';
+  import { pointerCapture, tooltip } from '@typie/ui/actions';
   import { Icon } from '@typie/ui/components';
   import { getAppContext } from '@typie/ui/context';
   import { clamp } from '@typie/ui/utils';
@@ -208,8 +208,8 @@
 
   type Resizer = {
     deltaX: number;
-    event: PointerEvent;
-    element: HTMLElement;
+    startWidth: number;
+    startX: number;
   };
 
   let treeScrollEl = $state<HTMLDivElement>();
@@ -231,7 +231,7 @@
   });
 
   let resizer = $state<Resizer | null>(null);
-  let newWidth = $derived(clamp((app.preference.current.sidebarWidth ?? 240) + (resizer?.deltaX ?? 0), 240, 480));
+  let newWidth = $derived(clamp((resizer?.startWidth ?? app.preference.current.sidebarWidth ?? 240) + (resizer?.deltaX ?? 0), 240, 480));
 
   const finishResizer = (commit: boolean) => {
     if (!resizer) return;
@@ -241,6 +241,27 @@
     }
 
     resizer = null;
+  };
+
+  const startResizer = (event: PointerEvent): Resizer | null => {
+    if (resizer || !event.isPrimary || event.button !== 0) return null;
+
+    resizer = {
+      deltaX: 0,
+      startWidth: app.preference.current.sidebarWidth ?? 240,
+      startX: event.clientX,
+    };
+    return resizer;
+  };
+
+  const moveResizer = (session: Resizer, event: PointerEvent) => {
+    if (!resizer) return;
+    resizer.deltaX = Math.round(event.clientX - session.startX);
+  };
+
+  const endResizer = (session: Resizer, event: PointerEvent) => {
+    moveResizer(session, event);
+    finishResizer(true);
   };
 
   let spaceMenuOpen = $state(false);
@@ -766,34 +787,6 @@
         opacity: '50',
       },
     })}
-    onlostpointercapture={(e) => {
-      if (!resizer || resizer.event.pointerId !== e.pointerId) return;
-      finishResizer(true);
-    }}
-    onpointercancelcapture={(e) => {
-      if (!resizer || resizer.event.pointerId !== e.pointerId) return;
-      finishResizer(false);
-    }}
-    onpointerdowncapture={(e) => {
-      if (e.button !== 0) return;
-
-      const element = e.currentTarget;
-      element.setPointerCapture(e.pointerId);
-
-      resizer = {
-        element,
-        event: e,
-        deltaX: 0,
-      };
-    }}
-    onpointermovecapture={(e) => {
-      if (!resizer || resizer.event.pointerId !== e.pointerId) return;
-
-      resizer.deltaX = Math.round(e.clientX - resizer.event.clientX);
-    }}
-    onpointerupcapture={(e) => {
-      if (!resizer || resizer.event.pointerId !== e.pointerId) return;
-      finishResizer(true);
-    }}
+    use:pointerCapture={{ start: startResizer, move: moveResizer, end: endResizer, cancel: () => finishResizer(false) }}
   ></div>
 </div>

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/Resizer.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/Resizer.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { css } from '@typie/styled-system/css';
+  import { pointerCapture } from '@typie/ui/actions';
   import { getPaneGroup } from './context.svelte';
   import { getMinSizeForMember } from './geometry';
   import { findMemberById } from './tree';
@@ -13,9 +14,12 @@
 
   const context = getPaneGroup();
   let isDragging = $state(false);
-  let startPosition = $state(0);
   let rafId: number | null = null;
-  let initialFlexes: number[] = [];
+
+  type ResizeSession = {
+    startPosition: number;
+    initialFlexes: number[];
+  };
 
   const getAxis = () => {
     if (!context.state.current.root) return null;
@@ -23,27 +27,29 @@
     return found?.type === 'axis' ? found : null;
   };
 
-  const handlePointerDown = (e: PointerEvent) => {
+  const handlePointerDown = (e: PointerEvent): ResizeSession | null => {
+    if (!e.isPrimary || e.button !== 0) return null;
+
     const axis = getAxis();
-    if (!axis) return;
+    if (!axis) return null;
 
     e.preventDefault();
     e.stopPropagation();
     isDragging = true;
     context.resizing = true;
 
-    const isHorizontal = resizer.direction === 'horizontal';
-    startPosition = isHorizontal ? e.clientX : e.clientY;
-    initialFlexes = [...axis.flexes];
-
-    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    return {
+      startPosition: resizer.direction === 'horizontal' ? e.clientX : e.clientY,
+      initialFlexes: [...axis.flexes],
+    };
   };
 
-  const updateSizes = (currentPosition: number) => {
+  const updateSizes = (session: ResizeSession, currentPosition: number) => {
     const axis = getAxis();
     if (!isDragging || !axis) return;
 
-    const deltaPixels = currentPosition - startPosition;
+    const { initialFlexes } = session;
+    const deltaPixels = currentPosition - session.startPosition;
     const totalSize = resizer.axisSize;
     if (totalSize <= 0) return;
 
@@ -113,7 +119,7 @@
     }
   };
 
-  const handlePointerMove = (e: PointerEvent) => {
+  const handlePointerMove = (session: ResizeSession, e: PointerEvent) => {
     if (!isDragging) return;
 
     if (rafId !== null) {
@@ -123,16 +129,12 @@
     rafId = requestAnimationFrame(() => {
       const isHorizontal = resizer.direction === 'horizontal';
       const currentPosition = isHorizontal ? e.clientX : e.clientY;
-      updateSizes(currentPosition);
+      updateSizes(session, currentPosition);
       rafId = null;
     });
   };
 
-  const handlePointerUp = (e: PointerEvent) => {
-    cleanupDrag(e);
-  };
-
-  const cleanupDrag = (e: PointerEvent) => {
+  const cleanupDrag = () => {
     if (rafId !== null) {
       cancelAnimationFrame(rafId);
       rafId = null;
@@ -140,8 +142,16 @@
 
     isDragging = false;
     context.resizing = false;
-    initialFlexes = [];
-    (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
+  };
+
+  const finishDrag = (session: ResizeSession, e: PointerEvent) => {
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+    const currentPosition = resizer.direction === 'horizontal' ? e.clientX : e.clientY;
+    updateSizes(session, currentPosition);
+    cleanupDrag();
   };
 </script>
 
@@ -162,12 +172,8 @@
     },
   })}
   aria-label="크기 조절"
-  onlostpointercapture={cleanupDrag}
-  onpointercancel={cleanupDrag}
-  onpointerdown={handlePointerDown}
-  onpointermovecapture={handlePointerMove}
-  onpointerup={handlePointerUp}
   type="button"
+  use:pointerCapture={{ start: handlePointerDown, move: handlePointerMove, end: finishDrag, cancel: cleanupDrag }}
 >
   <div
     style={resizer.direction === 'horizontal' ? 'left: -3px; right: -3px;' : 'top: -3px; bottom: -3px;'}

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/dnd.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/dnd.ts
@@ -1,3 +1,4 @@
+import { pointerCapture } from '@typie/ui/actions';
 import mixpanel from 'mixpanel-browser';
 import { findMemberById } from './tree';
 import type { Action } from 'svelte/action';
@@ -117,13 +118,16 @@ type DragPaneOptions = {
   paneId: string;
 };
 
+type DragPaneSession = {
+  startX: number;
+  startY: number;
+};
+
 export const dragPane: Action<HTMLElement, DragPaneOptions> = (node, options) => {
   let isDragging = false;
   let holdActivated = false;
   let holdTimer: ReturnType<typeof setTimeout> | null = null;
-  let activePointerId = -1;
-  let startX = 0;
-  let startY = 0;
+  let activeSession: DragPaneSession | null = null;
   const HOLD_DURATION = 300;
   const IMMEDIATE_DRAG_THRESHOLD = 8;
   const POST_HOLD_DRAG_THRESHOLD = 5;
@@ -144,41 +148,42 @@ export const dragPane: Action<HTMLElement, DragPaneOptions> = (node, options) =>
     clearHold();
     isDragging = false;
     holdActivated = false;
-    activePointerId = -1;
+    activeSession = null;
     options.paneGroup.draggingPaneId = null;
     node.style.cursor = 'grab';
     document.body.style.cursor = '';
   };
 
-  const handlePointerDown = (e: PointerEvent) => {
+  const handlePointerDown = (e: PointerEvent): DragPaneSession | null => {
+    if (e.button !== 0 || !e.isPrimary) return null;
+
     const target = e.target as HTMLElement;
     if (target.closest('button, [role="button"], [role="menu"], a[href], input, textarea, select')) {
-      return;
+      return null;
     }
 
     e.preventDefault();
     clearHold();
 
-    startX = e.clientX;
-    startY = e.clientY;
-    activePointerId = e.pointerId;
-    node.setPointerCapture(e.pointerId);
+    const session = { startX: e.clientX, startY: e.clientY };
+    activeSession = session;
 
     holdActivated = false;
     holdTimer = setTimeout(() => {
       holdTimer = null;
-      if (!node.hasPointerCapture(activePointerId)) return;
+      if (activeSession !== session) return;
       holdActivated = true;
       options.paneGroup.draggingPaneId = options.paneId;
       node.style.cursor = 'grabbing';
       document.body.style.cursor = 'grabbing';
     }, HOLD_DURATION);
+    return session;
   };
 
-  const handlePointerMove = (e: PointerEvent) => {
-    if (!node.hasPointerCapture(e.pointerId)) return;
+  const handlePointerMove = (session: DragPaneSession, e: PointerEvent) => {
+    if (activeSession !== session) return;
 
-    const dist = Math.abs(e.clientX - startX) + Math.abs(e.clientY - startY);
+    const dist = Math.abs(e.clientX - session.startX) + Math.abs(e.clientY - session.startY);
 
     if (!holdActivated) {
       if (dist > IMMEDIATE_DRAG_THRESHOLD) {
@@ -206,47 +211,33 @@ export const dragPane: Action<HTMLElement, DragPaneOptions> = (node, options) =>
     options.paneGroup.updateActiveZone(e.clientX, e.clientY);
   };
 
-  const handlePointerUp = (e: PointerEvent) => {
+  const handlePointerUp = () => {
     if (isDragging) {
       const dragItem: DragPane = { type: 'pane', paneId: options.paneId };
       options.paneGroup.executeDrop(dragItem);
     }
 
     resetState();
-    if (node.hasPointerCapture(e.pointerId)) {
-      node.releasePointerCapture(e.pointerId);
-    }
   };
 
-  const handlePointerCancel = (e: PointerEvent) => {
-    resetState();
-    options.paneGroup.cancelDrag();
-    if (node.hasPointerCapture(e.pointerId)) {
-      node.releasePointerCapture(e.pointerId);
-    }
-  };
-
-  const handleLostPointerCapture = () => {
+  const handlePointerCancel = () => {
     resetState();
     options.paneGroup.cancelDrag();
   };
+
+  const capture = pointerCapture(node, {
+    start: handlePointerDown,
+    move: handlePointerMove,
+    end: handlePointerUp,
+    cancel: handlePointerCancel,
+  });
 
   const handleKeyDown = (e: KeyboardEvent) => {
     if (e.key === 'Escape' && (holdActivated || holdTimer)) {
-      options.paneGroup.cancelDrag();
-      const capturedPointerId = activePointerId;
-      resetState();
-      if (capturedPointerId !== -1 && node.hasPointerCapture(capturedPointerId)) {
-        node.releasePointerCapture(capturedPointerId);
-      }
+      capture.cancel();
     }
   };
 
-  node.addEventListener('pointerdown', handlePointerDown);
-  node.addEventListener('pointermove', handlePointerMove);
-  node.addEventListener('pointerup', handlePointerUp);
-  node.addEventListener('pointercancel', handlePointerCancel);
-  node.addEventListener('lostpointercapture', handleLostPointerCapture);
   document.addEventListener('keydown', handleKeyDown);
 
   return {
@@ -254,12 +245,7 @@ export const dragPane: Action<HTMLElement, DragPaneOptions> = (node, options) =>
       options = newOptions;
     },
     destroy() {
-      clearHold();
-      node.removeEventListener('pointerdown', handlePointerDown);
-      node.removeEventListener('pointermove', handlePointerMove);
-      node.removeEventListener('pointerup', handlePointerUp);
-      node.removeEventListener('pointercancel', handlePointerCancel);
-      node.removeEventListener('lostpointercapture', handleLostPointerCapture);
+      capture.destroy();
       document.removeEventListener('keydown', handleKeyDown);
     },
   };

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanelNote.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanelNote.svelte
@@ -5,9 +5,9 @@
   import { tooltip } from '@typie/ui/actions';
   import { Button, Icon } from '@typie/ui/components';
   import { Toast } from '@typie/ui/notification';
-  import { animateFlip, elementScrollViewport, handleDragScroll } from '@typie/ui/utils';
+  import { animateFlip, createDragScroll, elementScrollViewport } from '@typie/ui/utils';
   import mixpanel from 'mixpanel-browser';
-  import { tick } from 'svelte';
+  import { tick, untrack } from 'svelte';
   import { SvelteSet } from 'svelte/reactivity';
   import ChevronRightIcon from '~icons/lucide/chevron-right';
   import PlusIcon from '~icons/lucide/plus';
@@ -68,9 +68,11 @@
   let dragging = $state<{
     noteId: string;
     originalIndex: number;
+    pointer: { clientX: number; clientY: number } | null;
   } | null>(null);
   let localNoteOrder = $state<string[]>([]);
   let scrollContainer = $state<HTMLElement | null>(null);
+  let dragScroll: ReturnType<typeof createDragScroll> | null = null;
 
   const sortedNotes = $derived.by(() => {
     if (localNoteOrder.length === 0) {
@@ -124,6 +126,7 @@
     dragging = {
       noteId,
       originalIndex: localNoteOrder.indexOf(noteId),
+      pointer: null,
     };
   };
 
@@ -156,7 +159,7 @@
     }
   };
 
-  const updateDraggingPosition = (clientX: number, clientY: number) => {
+  const resolveDraggingPosition = (clientX: number, clientY: number) => {
     if (!dragging || !scrollContainer) return;
 
     const element = document.elementFromPoint(clientX, clientY);
@@ -165,6 +168,13 @@
 
     const noteId = noteElement.dataset.relatedNoteId;
     if (noteId) moveDraggingNote(noteId);
+  };
+
+  const updateDraggingPosition = (clientX: number, clientY: number) => {
+    if (!dragging) return;
+    dragging.pointer = { clientX, clientY };
+    dragScroll?.updatePointer(clientX, clientY);
+    resolveDraggingPosition(clientX, clientY);
   };
 
   const handleDragEnd = async (clientX: number, clientY: number) => {
@@ -223,9 +233,21 @@
   });
 
   $effect(() => {
-    return handleDragScroll(scrollContainer ? elementScrollViewport(scrollContainer) : null, !!dragging, {
-      onScroll: updateDraggingPosition,
+    const current = dragging;
+    if (!scrollContainer || !current) return;
+
+    const initialPointer = untrack(() => current.pointer ?? undefined);
+    const activeDragScroll = createDragScroll(elementScrollViewport(scrollContainer), {
+      initialPointer,
+      onScroll: (clientX, clientY) => {
+        if (dragging === current) resolveDraggingPosition(clientX, clientY);
+      },
     });
+    dragScroll = activeDragScroll;
+    return () => {
+      activeDragScroll.destroy();
+      if (dragScroll === activeDragScroll) dragScroll = null;
+    };
   });
 
   $effect.pre(() => {

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanelNoteItem.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanelNoteItem.svelte
@@ -216,6 +216,7 @@
     e.preventDefault();
   }}
   onpointerdown={(e) => {
+    if (!e.isPrimary || e.button !== 0) return;
     const target = e.target as HTMLElement;
     if (target.closest('button, textarea')) return;
 

--- a/packages/ui/src/actions/pointer-capture.svelte.ts
+++ b/packages/ui/src/actions/pointer-capture.svelte.ts
@@ -1,6 +1,6 @@
 import type { ActionReturn } from 'svelte/action';
 
-export type PointerCaptureCancelReason = 'pointercancel' | 'lostpointercapture' | 'capture-failed' | 'destroy';
+export type PointerCaptureCancelReason = 'pointercancel' | 'lostpointercapture' | 'capture-failed' | 'programmatic' | 'destroy';
 
 export type PointerCaptureParameters<Session> = {
   start: (event: PointerEvent) => Session | null;
@@ -14,10 +14,15 @@ type ActiveSession<Session> = {
   value: Session;
 };
 
+export type PointerCaptureHandle<Session> = ActionReturn<PointerCaptureParameters<Session>> & {
+  cancel: () => void;
+  destroy: () => void;
+};
+
 export const pointerCapture = <Session>(
   element: HTMLElement,
   initialParameters: PointerCaptureParameters<Session>,
-): ActionReturn<PointerCaptureParameters<Session>> => {
+): PointerCaptureHandle<Session> => {
   let parameters = initialParameters;
   let active: ActiveSession<Session> | null = null;
 
@@ -77,6 +82,9 @@ export const pointerCapture = <Session>(
   element.addEventListener('lostpointercapture', handleLostPointerCapture);
 
   return {
+    cancel() {
+      cancel('programmatic');
+    },
     update(nextParameters) {
       parameters = nextParameters;
     },

--- a/packages/ui/src/utils/dnd-handler.ts
+++ b/packages/ui/src/utils/dnd-handler.ts
@@ -1,4 +1,5 @@
 import { token } from '@typie/styled-system/tokens';
+import { pointerCapture } from '../actions/pointer-capture.svelte';
 
 export type Ghost = {
   element: HTMLElement;
@@ -89,7 +90,6 @@ export const createDndHandler = (node: HTMLElement, options: DndHandlerOptions) 
   let dragStartEvent: PointerEvent | null = null;
   let dragTarget: HTMLElement | null = null;
   let ghost: Ghost | null = null;
-  let capturedPointerId: number | null = null;
   let animationFrameId: number | null = null;
   let hoveredTarget: HTMLElement | null = null;
 
@@ -121,11 +121,7 @@ export const createDndHandler = (node: HTMLElement, options: DndHandlerOptions) 
       removeGhost(ghost);
       ghost = null;
     }
-    if (capturedPointerId !== null) {
-      node.releasePointerCapture(capturedPointerId);
-      capturedPointerId = null;
-    }
-    if (animationFrameId) {
+    if (animationFrameId !== null) {
       cancelAnimationFrame(animationFrameId);
       animationFrameId = null;
     }
@@ -137,59 +133,47 @@ export const createDndHandler = (node: HTMLElement, options: DndHandlerOptions) 
     }
     dragging = false;
     isDragActive = false;
+    dragStartEvent = null;
     dragTarget = null;
     updateCursor(null);
   };
 
-  const handlePointerCancel = () => {
-    if (!dragging) {
-      return;
-    }
-
+  const cancelDrag = () => {
     cleanup();
     onDragCancel?.();
   };
 
-  const handlePointerDown = (e: PointerEvent) => {
-    if (e.button !== 0 || !e.isPrimary) return;
+  const handlePointerDown = (e: PointerEvent): true | null => {
+    if (e.button !== 0 || !e.isPrimary) return null;
 
     const target = e.target as HTMLElement;
 
     if (dragHandleSelector && !target.closest(dragHandleSelector)) {
-      return;
+      return null;
     }
 
     if (excludeSelectors.some((selector) => target.closest(selector))) {
-      return;
+      return null;
     }
 
     const extractedTarget = getDragTarget ? getDragTarget(e) : node;
-    if (!extractedTarget) return;
+    if (!extractedTarget) return null;
 
     if (canStartDrag && !canStartDrag(e, extractedTarget)) {
-      return;
+      return null;
     }
 
     dragging = true;
     dragStartEvent = e;
     dragTarget = extractedTarget;
-
-    node.setPointerCapture(e.pointerId);
-    capturedPointerId = e.pointerId;
-
     updateCursor(e);
+    return true;
   };
 
   const handlePointerMove = (e: PointerEvent) => {
-    if (animationFrameId) cancelAnimationFrame(animationFrameId);
+    if (animationFrameId !== null) cancelAnimationFrame(animationFrameId);
 
     animationFrameId = requestAnimationFrame(() => {
-      if (!dragging) {
-        updateCursor(e);
-        animationFrameId = null;
-        return;
-      }
-
       if (!dragStartEvent || !dragTarget) return;
 
       const distance = Math.sqrt(Math.pow(e.clientX - dragStartEvent.clientX, 2) + Math.pow(e.clientY - dragStartEvent.clientY, 2));
@@ -215,28 +199,34 @@ export const createDndHandler = (node: HTMLElement, options: DndHandlerOptions) 
   };
 
   const handlePointerUp = (e: PointerEvent) => {
-    if (dragging) {
-      const wasDragActive = isDragActive;
-      cleanup();
-      if (wasDragActive) {
-        onDragEnd?.(e);
-      }
+    const wasDragActive = isDragActive;
+    cleanup();
+    if (wasDragActive) {
+      onDragEnd?.(e);
     }
   };
+
+  const handlePointerHoverMove = (e: PointerEvent) => {
+    if (dragging) return;
+    updateCursor(e);
+  };
+
+  const capture = pointerCapture(node, {
+    start: handlePointerDown,
+    move: (_, e) => handlePointerMove(e),
+    end: (_, e) => handlePointerUp(e),
+    cancel: cancelDrag,
+  });
 
   const handleKeyDown = (e: KeyboardEvent) => {
     if (!(e.key === 'Escape' && dragging)) {
       return;
     }
 
-    cleanup();
-    onDragCancel?.();
+    capture.cancel();
   };
 
-  node.addEventListener('pointercancel', handlePointerCancel);
-  node.addEventListener('pointerdown', handlePointerDown);
-  node.addEventListener('pointermove', handlePointerMove);
-  node.addEventListener('pointerup', handlePointerUp);
+  node.addEventListener('pointermove', handlePointerHoverMove);
   window.addEventListener('keydown', handleKeyDown);
 
   updateCursor(null);
@@ -247,11 +237,8 @@ export const createDndHandler = (node: HTMLElement, options: DndHandlerOptions) 
       ghost,
     }),
     destroy: () => {
-      cleanup();
-      node.removeEventListener('pointercancel', handlePointerCancel);
-      node.removeEventListener('pointerdown', handlePointerDown);
-      node.removeEventListener('pointermove', handlePointerMove);
-      node.removeEventListener('pointerup', handlePointerUp);
+      capture.destroy();
+      node.removeEventListener('pointermove', handlePointerHoverMove);
       window.removeEventListener('keydown', handleKeyDown);
     },
   };


### PR DESCRIPTION
## 문제

- 위젯 목록·팔레트나 텍스트 치환 목록을 pointer A로 drag하는 동안 pointer B가 같은 영역에서 움직이거나 pointer up되면, B의 이벤트가 A의 drag move/end로 처리될 수 있었음
- 에디터 pane을 drag하던 중 pane이 다시 렌더링되거나 action이 제거되면 `draggingPaneId`, drop zone과 `grabbing` cursor가 남을 수 있었음
- 에디터에서 selection drag를 시작한 뒤 capture를 잃거나 문서를 전환해 View가 제거되면 toolbar sync와 native drag admission이 종료되지 않을 수 있었음
- Sidebar resizer, Pane resizer와 custom Scrollbar를 빠르게 움직인 뒤 마지막 frame 전에 release하면 pointerup 위치가 반영되지 않고 직전 pointermove 위치에서 멈출 수 있었음
- 테이블 열 resize가 `pointercancel`로 중단되면 취소된 중간 너비가 commit되고 에디터 focus까지 이동할 수 있었음
- Entity Tree나 관련 노트를 edge auto scroll하며 drag할 때 다른 touch/pen pointer가 움직이면, 전역 pointer listener가 그 좌표를 사용해 scroll 방향이나 reorder 대상이 바뀔 수 있었음
- 노트와 관련 노트 item을 우클릭하거나 secondary pointer로 누르면 context menu 조작인데도 drag 후보 상태가 만들어질 수 있었음
- Entity Tree의 long press/threshold drag에서 대상 element가 제거되는 등의 이유로 capture 획득이 실패하면 ghost와 외부 drag 상태가 남을 수 있었음

## 변경

- 공통 `pointerCapture` action에 programmatic cancel을 추가하고 공용 DnD와 pane DnD도 같은 owner pointer와 종료 lifecycle을 사용하도록 변경
- Table Overlay, custom Scrollbar, Sidebar와 Pane resizer의 수동 pointer capture를 session 기반 action으로 교체
    - 정상 종료는 최신 pointerup 좌표까지 반영
    - 취소된 preview는 폐기
    - 이미 적용 중인 resize/scroll 값은 마지막 반영 상태 유지
- 에디터 selection gesture가 non-primary pointer를 무시하고 capture 상실이나 View 종료 시 toolbar/native drag 상태를 정리하도록 보강
- Entity Tree의 지연 capture 구조는 유지하면서 capture 실패, capture 상실과 컴포넌트 종료를 취소로 처리
- Entity Tree와 관련 노트 reorder의 edge auto scroll이 전역 pointer listener 대신 현재 gesture가 전달한 좌표만 사용하도록 변경
- owner pointer, programmatic cancel, capture 상실과 destroy 동작에 대한 회귀 테스트 추가
- #4958 후속