### PR TITLE
여러가지 드래그 UX 개선 또는 디버그

### DIFF
--- a/apps/website/src/lib/editor-ffi/components/ExternalImage.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ExternalImage.svelte
@@ -218,7 +218,8 @@
     proportion = (newWidth / boundsWidth) * 100;
   };
 
-  const handleResizeEnd = () => {
+  const handleResizeEnd = (session: ResizeSession, event: PointerEvent) => {
+    handleResize(session, event);
     const finalProportion = Math.round(proportion);
     isResizing = false;
     ctx.editor?.enqueue({

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanel.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanel.svelte
@@ -95,6 +95,10 @@
   let previewWidth = $state<number | null>(null);
   let newWidth = $derived(previewWidth ?? storedWidth);
 
+  const updateResize = (session: ResizeSession, event: PointerEvent) => {
+    previewWidth = clamp(session.startWidth + Math.round(session.startX - event.clientX), minWidth, maxWidth);
+  };
+
   onDestroy(() => focusReturn.discard());
 </script>
 
@@ -211,10 +215,9 @@
         previewWidth = session.startWidth;
         return session;
       },
-      move: (session, event) => {
-        previewWidth = clamp(session.startWidth + Math.round(session.startX - event.clientX), minWidth, maxWidth);
-      },
-      end: () => {
+      move: updateResize,
+      end: (session, event) => {
+        updateResize(session, event);
         if (previewWidth !== null) app.preference.current.panelWidth = previewWidth;
         previewWidth = null;
       },

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanelTimeline.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanelTimeline.svelte
@@ -21,7 +21,6 @@
   import { getPane, getPaneGroup } from '../../@pane/context.svelte';
   import { getDocumentPanelFocusReturn } from './focus-return.svelte';
   import type { PointerCaptureCancelReason } from '@typie/ui/actions';
-  import type { PointerEventHandler } from 'svelte/elements';
   import type { DocumentPanelV2Timeline_document$key } from '$mearie';
 
   type Props = {
@@ -149,13 +148,6 @@
     };
   });
 
-  $effect(() => {
-    if (query.data && selectedHeadId === null && headsAsc.length > 0) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      selectedHeadId = headsAsc.at(-1)!.id;
-    }
-  });
-
   const scrollToHead = debounce((headId: string) => {
     const element = globalThis.document.querySelector(`[data-panel-timeline-head="${headId}"]`) as HTMLElement;
     element?.scrollIntoView({ behavior: 'smooth', block: 'center' });
@@ -209,32 +201,39 @@
   };
   const updateView = throttle(applyHead, 32);
 
-  let prevSelectedId: string | null = null;
-  $effect(() => {
-    const currentId = selectedHeadId;
-    if (!currentId || !query.data) return;
-    if (currentId === prevSelectedId) return;
-    prevSelectedId = currentId;
-    scrollToHead.call(currentId);
-    if (isDraggingSlider) {
-      updateView.call(currentId);
+  const selectHead = (headId: string, timing: 'throttled' | 'immediate') => {
+    const changed = selectedHeadId !== headId;
+    if (changed) {
+      selectedHeadId = headId;
+      scrollToHead.call(headId);
+    }
+
+    if (timing === 'throttled') {
+      if (changed) updateView.call(headId);
     } else {
       updateView.cancel();
-      void applyHead(currentId);
+      void applyHead(headId);
+    }
+  };
+
+  $effect(() => {
+    if (query.data && selectedHeadId === null && headsAsc.length > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      selectHead(headsAsc.at(-1)!.id, 'immediate');
     }
   });
 
-  const handleSlide: PointerEventHandler<HTMLElement> = (e) => {
-    if (!e.currentTarget.parentElement || headsAsc.length === 0) return;
-    const { left: parentLeft, width: parentWidth } = e.currentTarget.parentElement.getBoundingClientRect();
-    const ratio = clamp((e.clientX - parentLeft) / parentWidth, 0, 1);
+  const handleSlide = (event: PointerEvent & { currentTarget: HTMLElement }, timing: 'throttled' | 'immediate') => {
+    if (!event.currentTarget.parentElement || headsAsc.length === 0) return;
+    const { left: parentLeft, width: parentWidth } = event.currentTarget.parentElement.getBoundingClientRect();
+    const ratio = clamp((event.clientX - parentLeft) / parentWidth, 0, 1);
     const index = Math.round(ratio * max);
-    if (Object.hasOwn(headsAsc, index)) selectedHeadId = headsAsc[index].id;
+    if (Object.hasOwn(headsAsc, index)) selectHead(headsAsc[index].id, timing);
   };
 
   const handleSlideStart = (event: PointerEvent): true | null => {
     if (showTooltip || isDraggingSlider || !event.isPrimary || event.button !== 0) return null;
-    handleSlide(event as PointerEvent & { currentTarget: HTMLElement });
+    handleSlide(event as PointerEvent & { currentTarget: HTMLElement }, 'throttled');
     showTooltip = true;
     return true;
   };
@@ -242,24 +241,22 @@
   const handleSlideMove = (_: true, event: PointerEvent) => {
     event.preventDefault();
     isDraggingSlider = true;
-    handleSlide(event as PointerEvent & { currentTarget: HTMLElement });
+    handleSlide(event as PointerEvent & { currentTarget: HTMLElement }, 'throttled');
   };
 
-  const handleSlideEnd = () => {
+  const handleSlideEnd = (_: true, event: PointerEvent) => {
+    handleSlide(event as PointerEvent & { currentTarget: HTMLElement }, 'immediate');
     showTooltip = false;
     isDraggingSlider = false;
-    if (selectedHeadId) {
-      updateView.cancel();
-      void applyHead(selectedHeadId);
-    }
   };
 
   const handleSlideCancel = (_: true, reason: PointerCaptureCancelReason) => {
     showTooltip = false;
     isDraggingSlider = false;
-    updateView.cancel();
     if (reason !== 'destroy' && selectedHeadId) {
-      void applyHead(selectedHeadId);
+      selectHead(selectedHeadId, 'immediate');
+    } else {
+      updateView.cancel();
     }
   };
 
@@ -361,9 +358,7 @@
                   _hover: { backgroundColor: isSelected ? 'surface.muted' : 'surface.subtle' },
                 })}
                 data-panel-timeline-head={head.id}
-                onclick={() => {
-                  selectedHeadId = head.id;
-                }}
+                onclick={() => selectHead(head.id, 'immediate')}
                 type="button"
               >
                 <Icon

--- a/packages/ui/src/components/Slider.svelte
+++ b/packages/ui/src/components/Slider.svelte
@@ -67,7 +67,8 @@
       return true;
     },
     move: (_, event) => updateValue(event),
-    end: () => {
+    end: (_, event) => {
+      updateValue(event);
       isDragging = false;
       onchange?.();
     },

--- a/packages/ui/src/utils/remeda.ts
+++ b/packages/ui/src/utils/remeda.ts
@@ -27,8 +27,8 @@ export const throttle = <TArgs extends readonly unknown[]>(
     },
     {
       reducer: (_, ...args: TArgs) => args,
-      minQuietPeriodMs: delay,
-      triggerAt: 'start',
+      minGapMs: delay,
+      triggerAt: 'both',
     },
   );
   return { call, cancel };


### PR DESCRIPTION
- Slider, 이미지, 패널 resize를 빠르게 놓아도 마지막 pointerup 좌표가 최종 값에 반영되도록 함
- throttle 유틸 수정: leading-only throttle에서 leading+trailing throttle로 수정. 사용처는 타임라인 슬라이더밖에 없음. 
- 타임라인 슬라이더를 빠르게 드래그한 채 멈춰도 snapshot이 thumb를 따라오고, 놓을 때 최종 좌표의 snapshot을 즉시 적용하게 됨
- 타임라인의 스냅샷 선택과 적용을 `selectHead`로 모아 effect 실행 순서 의존을 제거