### PR TITLE
웹 에디터 교체 시 focus 상태 갱신 안정화

### DIFF
--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -761,7 +761,11 @@ export class Editor {
             return;
           }
 
-          this.#setFocused(false);
+          // DOM 제거 중 blur가 Svelte 렌더 안에서 $state를 갱신하지 않도록 다음 microtask로 미룬다.
+          queueMicrotask(() => {
+            if (this.#destroyed) return;
+            this.#setFocused(document.activeElement === this.inputEl);
+          });
         };
 
         el.addEventListener('focus', onFocus);


### PR DESCRIPTION
- 타임라인 패널에서 에디터 교체 시 `state_unsafe_mutation`이 발생하던 문제 수정
- DOM 제거 중 발생한 blur의 focus 상태를 렌더 완료 후 현재 input 기준으로 동기화