### PR TITLE
구독 상태기계 버그 수정

### DIFF
--- a/apps/api/scripts/backfill-iap-expired.ts
+++ b/apps/api/scripts/backfill-iap-expired.ts
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+
+// 구 renewal:cancel 크론이 로컬 상태만 보고 잘못 EXPIRED 처리한 IAP 구독을 스토어와 대조해 복구한다.
+// 일상 재조정 크론은 (동시 환불의 부활 위험 때문에) EXPIRED 를 건드리지 않으므로, 롤아웃 시 이 백필을 1회 실행한다.
+// 환불/철회된 구독은 스토어가 활성 상태를 반환하지 않으므로, 스토어가 실제 활성일 때만 복구한다(부활 위험 없음).
+//
+// 유저당 바인딩은 하나뿐이므로, 유저당 "가장 최근" EXPIRED IAP 구독 하나만 되살린다(여러 개 되살리면 ACTIVE 유니크 위반).
+// 되살릴 때 플랜/만료일은 스토어의 현재 값을 그대로 반영한다.
+//
+// 미리보기: DRY_RUN=1 doppler run -- node scripts/backfill-iap-expired.ts
+// 실제 적용: doppler run -- node scripts/backfill-iap-expired.ts
+
+import { InAppPurchaseStore, PlanAvailability, SubscriptionState } from '@typie/lib/enums';
+import dayjs from 'dayjs';
+import { and, eq, inArray, ne, notExists, sql } from 'drizzle-orm';
+import { alias } from 'drizzle-orm/pg-core';
+import { db, first, Plans, Subscriptions, UserInAppPurchases } from '#/db/index.ts';
+import * as appstore from '#/external/appstore.ts';
+import * as googleplay from '#/external/googleplay.ts';
+
+const dryRun = !!process.env.DRY_RUN;
+
+const LIVE_STATES = [
+  SubscriptionState.ACTIVE,
+  SubscriptionState.WILL_EXPIRE,
+  SubscriptionState.IN_GRACE_PERIOD,
+  SubscriptionState.WILL_ACTIVATE,
+];
+
+const other = alias(Subscriptions, 'other');
+
+// 다른 live 구독이 없는(=현재 접근이 없는) EXPIRED IAP 구독을 모은다.
+const rows = await db
+  .select({
+    id: Subscriptions.id,
+    userId: Subscriptions.userId,
+    expiresAt: Subscriptions.expiresAt,
+    store: UserInAppPurchases.store,
+    identifier: UserInAppPurchases.identifier,
+  })
+  .from(Subscriptions)
+  .innerJoin(Plans, eq(Subscriptions.planId, Plans.id))
+  .innerJoin(UserInAppPurchases, eq(UserInAppPurchases.userId, Subscriptions.userId))
+  .where(
+    and(
+      eq(Subscriptions.state, SubscriptionState.EXPIRED),
+      eq(Plans.availability, PlanAvailability.IN_APP_PURCHASE),
+      notExists(
+        db
+          .select({ one: sql`1` })
+          .from(other)
+          .where(and(eq(other.userId, Subscriptions.userId), ne(other.id, Subscriptions.id), inArray(other.state, LIVE_STATES))),
+      ),
+    ),
+  );
+
+// 유저당 가장 최근 만료 행 하나만 남긴다. (오름차순 정렬 후 Map 이 마지막 값을 유지 → 가장 최근)
+const candidates = [
+  ...new Map(rows.toSorted((a, b) => dayjs(a.expiresAt).valueOf() - dayjs(b.expiresAt).valueOf()).map((row) => [row.userId, row])).values(),
+];
+
+console.log(`대상 유저(EXPIRED IAP, 현재 접근 없음): ${candidates.length}명 (dryRun=${dryRun})`);
+
+let reactivated = 0;
+let untouched = 0;
+const failed: string[] = [];
+
+for (const candidate of candidates) {
+  // 스토어가 실제 활성인지 + 현재 플랜/만료일 조회.
+  // 일시적 조회 실패(타임아웃·레이트리밋·자격증명 등)를 "비활성"과 섞지 않는다 — 실패는 별도 추적해 재실행을 유도한다.
+  let planId: string | null = null;
+  let expiresAt: dayjs.Dayjs | null = null;
+  let lookupFailed = false;
+
+  if (candidate.store === InAppPurchaseStore.APP_STORE) {
+    // getSubscriptionStatus 는 조회 실패를 'error'(전 환경 실패)로, 확인됐으나 활성 아님을 'unknown' 등으로 구분하고,
+    // 후보 originalTransactionId 와 일치하는 시리즈만 본다(getSubscription 은 비활성·실패를 모두 throw 하고 첫 시리즈만 돌려줌).
+    const status = await appstore.getSubscriptionStatus(candidate.identifier);
+    if (status.kind === 'error') {
+      lookupFailed = true;
+    } else if (status.kind === 'active' && status.productId && status.expiresDate && dayjs(status.expiresDate).isAfter(dayjs())) {
+      planId = status.productId.toUpperCase();
+      expiresAt = dayjs(status.expiresDate);
+    }
+    // 그 외(unknown/grace/suspended/expired/revoked)는 활성 확인 불가 — 되살리지 않고 유지
+  } else if (candidate.store === InAppPurchaseStore.GOOGLE_PLAY) {
+    try {
+      const subscription = await googleplay.getSubscription(candidate.identifier);
+      const item = subscription.lineItems?.[0];
+      const basePlanId = item?.offerDetails?.basePlanId;
+      if (
+        subscription.subscriptionState === 'SUBSCRIPTION_STATE_ACTIVE' &&
+        basePlanId &&
+        item?.expiryTime &&
+        dayjs(item.expiryTime).isAfter(dayjs())
+      ) {
+        planId = basePlanId.toUpperCase();
+        expiresAt = dayjs(item.expiryTime);
+      }
+      // 그 외(EXPIRED/CANCELED/ON_HOLD 등)는 스토어가 확인해 준 비활성 — 유지
+    } catch (err) {
+      // getSubscription 은 비활성은 정상 응답으로 상태를 돌려주므로, throw 는 일시적 조회 실패다.
+      lookupFailed = true;
+      console.log(`  ! ${candidate.id} (google): 조회 실패 — ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  if (lookupFailed) {
+    failed.push(candidate.id);
+    continue;
+  }
+
+  if (!planId || !expiresAt) {
+    untouched += 1;
+    continue;
+  }
+
+  const nextExpiresAt = expiresAt;
+  const nextPlanId = planId;
+
+  const applied = await db.transaction(async (tx) => {
+    // 되살릴 플랜이 실제 IAP 플랜인지 확인
+    const plan = await tx
+      .select({ id: Plans.id })
+      .from(Plans)
+      .where(and(eq(Plans.id, nextPlanId), eq(Plans.availability, PlanAvailability.IN_APP_PURCHASE)))
+      .then(first);
+    if (!plan) {
+      return false;
+    }
+
+    // ACTIVE 유니크 위반 방지: 조회 이후 이 유저에게 live 구독이 생겼는지 재확인한다.
+    const live = await tx
+      .select({ id: Subscriptions.id })
+      .from(Subscriptions)
+      .where(and(eq(Subscriptions.userId, candidate.userId), inArray(Subscriptions.state, LIVE_STATES)))
+      .for('update')
+      .then(first);
+    if (live) {
+      return false;
+    }
+
+    if (!dryRun) {
+      await tx
+        .update(Subscriptions)
+        .set({ state: SubscriptionState.ACTIVE, planId: plan.id, expiresAt: nextExpiresAt })
+        .where(eq(Subscriptions.id, candidate.id));
+    }
+
+    return true;
+  });
+
+  if (applied) {
+    reactivated += 1;
+    console.log(
+      `  ✓ ${candidate.id} (user ${candidate.userId}, ${candidate.store}) → ACTIVE plan=${nextPlanId} (~${nextExpiresAt.toISOString()})`,
+    );
+  } else {
+    untouched += 1;
+  }
+}
+
+console.log(`완료: 재활성 ${reactivated}, 유지 ${untouched}, 조회실패 ${failed.length}${dryRun ? ' (DRY_RUN — 실제 변경 없음)' : ''}`);
+
+// 조회 실패가 남으면 잘못 만료된 유료 유저가 복구되지 않고 묻힐 수 있으므로, 실패 후보를 남기고 nonzero 로 종료해 재실행을 유도한다.
+if (failed.length > 0) {
+  console.log(`조회 실패(재실행 필요) 후보: ${failed.join(', ')}`);
+  process.exit(1);
+}
+
+process.exit(0);

--- a/apps/api/src/external/appstore.ts
+++ b/apps/api/src/external/appstore.ts
@@ -54,6 +54,85 @@ export const getSubscription = async (transactionId: string) => {
   throw new Error('Transaction not found');
 };
 
+export type ReconcileSubscriptionStatus =
+  | { kind: 'active'; expiresDate: number | undefined; productId: string | undefined }
+  | { kind: 'grace'; expiresDate: number | undefined }
+  | { kind: 'suspended' }
+  | { kind: 'expired' }
+  | { kind: 'revoked' }
+  | { kind: 'unknown' } // 조회는 됐으나 이 트랜잭션을 못 찾음 / 다루지 않는 상태 — 안전하게 건너뜀
+  | { kind: 'error' }; // 모든 환경에서 조회 실패(네트워크·자격증명·서명검증 등) — 호출부에서 재시도/알림해야 함
+
+// 재조정용: 스토어가 명시적으로 상태를 반환한 경우에만 active/inactive 를 판정하고,
+// 조회 실패(일시적 오류 포함)·모호 상태(BILLING_RETRY 등)는 unknown 으로 남겨 만료 오판정을 막는다.
+export const getSubscriptionStatus = async (transactionId: string): Promise<ReconcileSubscriptionStatus> => {
+  let anyLookupSucceeded = false;
+
+  for (const environment of environments) {
+    const client = clients[environment];
+    const verifier = verifiers[environment];
+
+    // matched 이후의 예외는 조회 실패가 아니라 서명 검증 실패다. unknown(안전 스킵)으로 위장하면 재시도·알림 없이
+    // 오판정이 무기한 방치되므로 error 로 구분한다.
+    let matched = false;
+    try {
+      const response = await client.getAllSubscriptionStatuses(transactionId);
+      anyLookupSucceeded = true;
+      const transactionInfo = (response.data ?? [])
+        .flatMap((group) => group.lastTransactions ?? [])
+        .find((item) => item.originalTransactionId === transactionId);
+      if (!transactionInfo) {
+        continue;
+      }
+      matched = true;
+
+      if (transactionInfo.status === Status.ACTIVE) {
+        let expiresDate: number | undefined;
+        let productId: string | undefined;
+        if (transactionInfo.signedTransactionInfo) {
+          const transaction = await verifier.verifyAndDecodeTransaction(transactionInfo.signedTransactionInfo);
+          expiresDate = transaction.expiresDate;
+          productId = transaction.productId;
+        }
+        return { kind: 'active', expiresDate, productId };
+      }
+
+      if (transactionInfo.status === Status.BILLING_GRACE_PERIOD) {
+        // 유예 기간의 실제 마감일은 트랜잭션 만료일(이미 과거)이 아니라 renewalInfo 에 있다.
+        let expiresDate: number | undefined;
+        if (transactionInfo.signedRenewalInfo) {
+          const renewalInfo = await verifier.verifyAndDecodeRenewalInfo(transactionInfo.signedRenewalInfo);
+          expiresDate = renewalInfo.gracePeriodExpiresDate;
+        }
+        return { kind: 'grace', expiresDate };
+      }
+
+      // BILLING_RETRY 는 재청구 중(권한 없음)이지만 복구 가능하므로 EXPIRED(종료)와 구분한다.
+      if (transactionInfo.status === Status.BILLING_RETRY) {
+        return { kind: 'suspended' };
+      }
+
+      if (transactionInfo.status === Status.EXPIRED) {
+        return { kind: 'expired' };
+      }
+
+      if (transactionInfo.status === Status.REVOKED) {
+        return { kind: 'revoked' };
+      }
+
+      return { kind: 'unknown' };
+    } catch {
+      if (matched) {
+        return { kind: 'error' };
+      }
+      // 이 환경 조회 실패 — 다음 환경 시도
+    }
+  }
+
+  // 조회에 한 번이라도 성공했으나 트랜잭션을 못 찾음 → unknown(안전 스킵). 전 환경 실패 → error(재시도/알림).
+  return anyLookupSucceeded ? { kind: 'unknown' } : { kind: 'error' };
+};
+
 export const decodeNotification = async (signedPayload: string) => {
   for (const environment of environments) {
     const verifier = verifiers[environment];

--- a/apps/api/src/external/googleplay.ts
+++ b/apps/api/src/external/googleplay.ts
@@ -19,6 +19,13 @@ export const getSubscription = async (purchaseToken: string) => {
   return response.data;
 };
 
+// 만료 60일 경과 등으로 스토어가 purchase token 제공을 영구 중단한 경우(404/410). 재시도해도 복구되지 않는다.
+export const isPurchaseTokenGoneError = (error: unknown): boolean => {
+  const err = error as { status?: unknown; response?: { status?: unknown } } | null | undefined;
+  const status = err?.response?.status ?? err?.status;
+  return status === 404 || status === 410;
+};
+
 export type OneTimeProductNotificationType = 1 | 2; // 1: ONE_TIME_PRODUCT_PURCHASED, 2: ONE_TIME_PRODUCT_CANCELED
 export type VoidedProductType = 1 | 2; // 1: PRODUCT_TYPE_SUBSCRIPTION, 2: PRODUCT_TYPE_ONE_TIME
 export type RefundType = 1 | 2; // 1: REFUND_TYPE_FULL_REFUND, 2: REFUND_TYPE_QUANTITY_BASED_PARTIAL_REFUND

--- a/apps/api/src/graphql/resolvers/admin.ts
+++ b/apps/api/src/graphql/resolvers/admin.ts
@@ -1,8 +1,7 @@
 import { DocumentType, EntityState, PaymentInvoiceState, PaymentOutcome, SubscriptionState, UserRole, UserState } from '@typie/lib/enums';
 import { TypieError } from '@typie/lib/errors';
 import { bootstrapSchema } from '@typie/lib/validation';
-import dayjs from 'dayjs';
-import { and, count, desc, eq, getTableColumns, ilike, ne, or, sql } from 'drizzle-orm';
+import { and, count, desc, eq, getTableColumns, ilike, inArray, ne, or, sql } from 'drizzle-orm';
 import { fetchBootstrap, putBootstrap } from '#/bootstrap.ts';
 import { redis } from '#/cache.ts';
 import {
@@ -277,6 +276,23 @@ builder.mutationFields((t) => ({
       await assertAdminPermission({ sessionId: ctx.session.id });
 
       return await db.transaction(async (tx) => {
+        // 갱신 잡과 직렬화한다. 갱신 잡도 구독 행을 잠그므로, 여기서 먼저 잠그면 환불 처리(외부 호출 포함) 중에
+        // 갱신 잡이 새 인보이스를 청구·커밋해 만료된 구독에 결제가 남는 경합을 막는다.
+        // 교착 방지: 모든 갱신·환불 경로는 구독 → 인보이스 순으로 잠근다. subscriptionId 는 불변 컬럼이라
+        // 무락 조회가 안전하고, 인보이스 상태(PAID)는 아래 잠금 조회에서 재검증한다.
+        const invoiceRef = await tx
+          .select({ subscriptionId: PaymentInvoices.subscriptionId })
+          .from(PaymentInvoices)
+          .where(eq(PaymentInvoices.id, input.invoiceId))
+          .then(firstOrThrow);
+
+        await tx
+          .select({ id: Subscriptions.id })
+          .from(Subscriptions)
+          .where(eq(Subscriptions.id, invoiceRef.subscriptionId))
+          .for('no key update')
+          .then(firstOrThrow);
+
         const invoice = await tx
           .select()
           .from(PaymentInvoices)
@@ -303,8 +319,18 @@ builder.mutationFields((t) => ({
         await tx.update(PaymentInvoices).set({ state: PaymentInvoiceState.CANCELED }).where(eq(PaymentInvoices.id, invoice.id));
 
         await tx
+          .update(PaymentInvoices)
+          .set({ state: PaymentInvoiceState.CANCELED })
+          .where(
+            and(
+              eq(PaymentInvoices.subscriptionId, invoice.subscriptionId),
+              inArray(PaymentInvoices.state, [PaymentInvoiceState.OVERDUE, PaymentInvoiceState.UPCOMING]),
+            ),
+          );
+
+        await tx
           .update(Subscriptions)
-          .set({ state: SubscriptionState.EXPIRED, expiresAt: dayjs() })
+          .set({ state: SubscriptionState.EXPIRED, expiresAt: sql`LEAST(${Subscriptions.expiresAt}, NOW())` })
           .where(eq(Subscriptions.id, invoice.subscriptionId));
 
         return true;

--- a/apps/api/src/graphql/resolvers/payment.ts
+++ b/apps/api/src/graphql/resolvers/payment.ts
@@ -40,6 +40,7 @@ import * as portone from '#/external/portone.ts';
 import { getSubscriptionExpiresAt, hasBillableUsageDuring, payAmountWithBillingKey, payInvoiceWithBillingKey } from '#/utils/index.ts';
 import { createTrialSubscription } from '#/utils/plan.ts';
 import { delay } from '#/utils/promise.ts';
+import { getUserUuid } from '#/utils/user.ts';
 import { builder } from '../builder.ts';
 import {
   CreditCode,
@@ -377,7 +378,14 @@ builder.mutationFields((t) => ({
       const activeSubscription = await db
         .select({ id: Subscriptions.id, expiresAt: Subscriptions.expiresAt })
         .from(Subscriptions)
-        .where(and(eq(Subscriptions.userId, ctx.session.userId), eq(Subscriptions.state, SubscriptionState.ACTIVE)))
+        .innerJoin(Plans, eq(Subscriptions.planId, Plans.id))
+        .where(
+          and(
+            eq(Subscriptions.userId, ctx.session.userId),
+            eq(Subscriptions.state, SubscriptionState.ACTIVE),
+            eq(Plans.availability, PlanAvailability.BILLING_KEY),
+          ),
+        )
         .then(firstOrThrow);
 
       const plan = await db
@@ -424,7 +432,14 @@ builder.mutationFields((t) => ({
       const willExpireSubscription = await db
         .select({ id: Subscriptions.id })
         .from(Subscriptions)
-        .where(and(eq(Subscriptions.userId, ctx.session.userId), eq(Subscriptions.state, SubscriptionState.WILL_EXPIRE)))
+        .innerJoin(Plans, eq(Subscriptions.planId, Plans.id))
+        .where(
+          and(
+            eq(Subscriptions.userId, ctx.session.userId),
+            eq(Subscriptions.state, SubscriptionState.WILL_EXPIRE),
+            eq(Plans.availability, PlanAvailability.BILLING_KEY),
+          ),
+        )
         .then(firstOrThrow);
 
       const willActivateSubscription = await db
@@ -488,12 +503,23 @@ builder.mutationFields((t) => ({
       let planId: string;
       let startsAt: dayjs.Dayjs;
       let expiresAt: dayjs.Dayjs;
+      // Google 은 purchaseToken 이 바뀔 때 이전 토큰을 알려준다: 비만료 재가입/플랜 변경은 linkedPurchaseToken 으로,
+      // 만료 후 Play 구독 센터 재구독(out-of-app)은 outOfAppPurchaseContext.expiredPurchaseToken 으로(acknowledge 후 소멸).
+      let previousPurchaseTokens: string[] = [];
+      // 스토어 응답의 계정 식별자로 현재 세션 소유가 증명됐는지. 증명 없이 이전 토큰이 타 계정에 바인딩돼 있으면 배정을 거부한다.
+      let ownershipVerified = false;
 
       if (input.store === InAppPurchaseStore.APP_STORE) {
         const subscription = await appstore.getSubscription(input.data);
 
         if (!subscription.productId || !subscription.originalTransactionId || !subscription.purchaseDate || !subscription.expiresDate) {
           throw new Error('required fields are missing');
+        }
+
+        // 소유권 검증: 다른 유저의 구매(예: 복구 경로가 잘못 흘려보낸 구매)가 현재 세션에 바인딩되는 것을 막는다.
+        // appAccountToken 이 없는 레거시 구매는 통과시킨다.
+        if (subscription.appAccountToken && subscription.appAccountToken !== getUserUuid(ctx.session.userId)) {
+          throw new TypieError({ code: 'in_app_purchase_account_mismatch' });
         }
 
         identifier = subscription.originalTransactionId;
@@ -512,10 +538,24 @@ builder.mutationFields((t) => ({
           throw new Error('required fields are missing');
         }
 
+        // 소유권 검증: 다른 유저의 구매가 현재 세션에 바인딩되는 것을 막는다.
+        // 만료 후 재구독(out-of-app)은 externalAccountIdentifiers 없이 이전 구매의 식별자를
+        // outOfAppPurchaseContext 로만 노출하므로 그쪽도 함께 본다. 둘 다 없는 레거시 구매는 통과.
+        const obfuscatedAccountId =
+          subscription.externalAccountIdentifiers?.obfuscatedExternalAccountId ??
+          subscription.outOfAppPurchaseContext?.expiredExternalAccountIdentifiers?.obfuscatedExternalAccountId;
+        if (obfuscatedAccountId && obfuscatedAccountId !== getUserUuid(ctx.session.userId)) {
+          throw new TypieError({ code: 'in_app_purchase_account_mismatch' });
+        }
+
         identifier = input.data;
         planId = item.offerDetails.basePlanId.toUpperCase();
         startsAt = dayjs(subscription.startTime);
         expiresAt = dayjs(item.expiryTime);
+        previousPurchaseTokens = [subscription.linkedPurchaseToken, subscription.outOfAppPurchaseContext?.expiredPurchaseToken].filter(
+          (token): token is string => !!token,
+        );
+        ownershipVerified = !!obfuscatedAccountId;
       } else {
         throw new Error('Invalid store');
       }
@@ -531,6 +571,55 @@ builder.mutationFields((t) => ({
         .then(firstOrThrow);
 
       return await db.transaction(async (tx) => {
+        // 이전 purchaseToken 을 보유한 "다른" 타이피 계정이 있으면(같은 스토어 계정에서 플랜 변경/재구독으로 토큰이 바뀐 경우),
+        // 그 구독을 만료시키고 바인딩을 제거한다. 하나의 스토어 구독이 여러 타이피 계정에 동시에 활성화되는 것을 막는다.
+        // (같은 계정의 토큰 변경은 아래 userId 기준 upsert 가 바인딩을 이동시키므로 여기서 건드리지 않는다)
+        for (const previousPurchaseToken of previousPurchaseTokens) {
+          const previousBinding = await tx
+            .select({ userId: UserInAppPurchases.userId })
+            .from(UserInAppPurchases)
+            .where(
+              and(
+                eq(UserInAppPurchases.store, InAppPurchaseStore.GOOGLE_PLAY),
+                eq(UserInAppPurchases.identifier, previousPurchaseToken),
+                ne(UserInAppPurchases.userId, ctx.session.userId),
+              ),
+            )
+            .then(first);
+
+          if (previousBinding) {
+            // 계정 증빙 없는 구매(레거시·out-of-app)의 이전 토큰이 다른 계정 소유 — 정당한 주인이 따로 있다는 뜻이므로
+            // 현재 세션에 임의 배정하지 않고 거부한다. 주인 계정으로 로그인하면 복구 경로가 다시 등록한다.
+            if (!ownershipVerified) {
+              throw new TypieError({ code: 'in_app_purchase_account_mismatch' });
+            }
+
+            await tx
+              .update(Subscriptions)
+              .set({ state: SubscriptionState.EXPIRED, expiresAt: sql`LEAST(${Subscriptions.expiresAt}, NOW())` })
+              .where(
+                and(
+                  eq(Subscriptions.userId, previousBinding.userId),
+                  inArray(Subscriptions.state, [
+                    SubscriptionState.ACTIVE,
+                    SubscriptionState.WILL_EXPIRE,
+                    SubscriptionState.IN_GRACE_PERIOD,
+                  ]),
+                  inArray(
+                    Subscriptions.planId,
+                    tx.select({ id: Plans.id }).from(Plans).where(eq(Plans.availability, PlanAvailability.IN_APP_PURCHASE)),
+                  ),
+                ),
+              );
+
+            await tx
+              .delete(UserInAppPurchases)
+              .where(
+                and(eq(UserInAppPurchases.store, InAppPurchaseStore.GOOGLE_PLAY), eq(UserInAppPurchases.identifier, previousPurchaseToken)),
+              );
+          }
+        }
+
         if (trialSubscription) {
           await tx
             .update(Subscriptions)
@@ -574,6 +663,12 @@ builder.mutationFields((t) => ({
             target: [Subscriptions.userId],
             targetWhere: eq(Subscriptions.state, SubscriptionState.ACTIVE),
             set: { planId, startsAt, expiresAt, renewedAt: startsAt },
+            // 상단 eligibility 검사 이후 동시에 커밋된 다른 채널(빌링키 등) ACTIVE 구독을 IAP 값으로 덮어쓰지 않는다.
+            // 충돌 행이 IAP 가 아니면 no-op → returning 이 비어 firstOrThrow 로 트랜잭션 전체가 롤백된다(오염 대신 실패).
+            setWhere: inArray(
+              Subscriptions.planId,
+              tx.select({ id: Plans.id }).from(Plans).where(eq(Plans.availability, PlanAvailability.IN_APP_PURCHASE)),
+            ),
           })
           .returning()
           .then(firstOrThrow);
@@ -604,18 +699,13 @@ builder.mutationFields((t) => ({
         .then(first);
 
       return await db.transaction(async (tx) => {
+        // 교착 방지 전역 락 순서: WILL_ACTIVATE 구독 → 주 구독 → 인보이스.
+        // 환불·갱신 재시도가 구독을 잠근 채 인보이스를 갱신하므로, 여기서 인보이스를 구독보다 먼저 잠그면 역순 교착이 된다.
         if (willActivateSubscription) {
           await tx.delete(Subscriptions).where(eq(Subscriptions.id, willActivateSubscription.id));
         }
 
-        if (activeSubscription.state === SubscriptionState.IN_GRACE_PERIOD) {
-          await tx
-            .update(PaymentInvoices)
-            .set({ state: PaymentInvoiceState.CANCELED })
-            .where(and(eq(PaymentInvoices.subscriptionId, activeSubscription.id), eq(PaymentInvoices.state, PaymentInvoiceState.OVERDUE)));
-        }
-
-        return await tx
+        const subscription = await tx
           .update(Subscriptions)
           .set(
             activeSubscription.state === SubscriptionState.ACTIVE
@@ -625,6 +715,15 @@ builder.mutationFields((t) => ({
           .where(eq(Subscriptions.id, activeSubscription.id))
           .returning()
           .then(firstOrThrow);
+
+        if (activeSubscription.state === SubscriptionState.IN_GRACE_PERIOD) {
+          await tx
+            .update(PaymentInvoices)
+            .set({ state: PaymentInvoiceState.CANCELED })
+            .where(and(eq(PaymentInvoices.subscriptionId, activeSubscription.id), eq(PaymentInvoices.state, PaymentInvoiceState.OVERDUE)));
+        }
+
+        return subscription;
       });
     },
   }),
@@ -635,8 +734,25 @@ builder.mutationFields((t) => ({
       const willExpireSubscription = await db
         .select({ id: Subscriptions.id })
         .from(Subscriptions)
-        .where(and(eq(Subscriptions.userId, ctx.session.userId), eq(Subscriptions.state, SubscriptionState.WILL_EXPIRE)))
+        .innerJoin(Plans, eq(Subscriptions.planId, Plans.id))
+        .where(
+          and(
+            eq(Subscriptions.userId, ctx.session.userId),
+            eq(Subscriptions.state, SubscriptionState.WILL_EXPIRE),
+            eq(Plans.availability, PlanAvailability.BILLING_KEY),
+          ),
+        )
         .then(firstOrThrow);
+
+      const willActivateSubscription = await db
+        .select({ id: Subscriptions.id })
+        .from(Subscriptions)
+        .where(and(eq(Subscriptions.userId, ctx.session.userId), eq(Subscriptions.state, SubscriptionState.WILL_ACTIVATE)))
+        .then(first);
+
+      if (willActivateSubscription) {
+        throw new TypieError({ code: 'plan_change_scheduled' });
+      }
 
       return await db.transaction(async (tx) => {
         return await tx

--- a/apps/api/src/graphql/resolvers/user.ts
+++ b/apps/api/src/graphql/resolvers/user.ts
@@ -23,7 +23,6 @@ import dayjs from 'dayjs';
 import { and, asc, desc, eq, gt, gte, inArray, isNotNull, lt, ne, sql, sum } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 import qs from 'query-string';
-import * as uuid from 'uuid';
 import { redis } from '#/cache.ts';
 import {
   CouponRedemptions,
@@ -67,7 +66,7 @@ import { evaluateCouponCondition } from '#/utils/coupon.ts';
 import { getDocumentFontFamilies } from '#/utils/document.ts';
 import { assertActiveSubscription } from '#/utils/plan.ts';
 import { delay } from '#/utils/promise.ts';
-import { getUserUsage } from '#/utils/user.ts';
+import { getUserUsage, getUserUuid } from '#/utils/user.ts';
 import { builder } from '../builder.ts';
 import {
   CharacterCountChange,
@@ -131,8 +130,7 @@ User.implement({
     }),
 
     uuid: t.string({
-      // just a randomly-picked uuid for namespace
-      resolve: (self) => uuid.v5(self.id, '1d394eb5-c61c-4c49-944e-05c9f9435adf'),
+      resolve: (self) => getUserUuid(self.id),
     }),
 
     hasPassword: t.boolean({ resolve: (user) => !!user.password }),

--- a/apps/api/src/mq/tasks/index.ts
+++ b/apps/api/src/mq/tasks/index.ts
@@ -20,6 +20,8 @@ import {
 } from './email.ts';
 import { DocumentIndexJob, FolderIndexJob } from './search.ts';
 import {
+  SubscriptionReconcileInAppPurchaseCron,
+  SubscriptionReconcileInAppPurchaseJob,
   SubscriptionRenewalCancelJob,
   SubscriptionRenewalCron,
   SubscriptionRenewalInitialJob,
@@ -40,6 +42,7 @@ export const jobs = [
   SubscriptionRenewalRetryJob,
   SubscriptionRenewalPlanChangeJob,
   SubscriptionRenewalCancelJob,
+  SubscriptionReconcileInAppPurchaseJob,
   SendSubscriptionGracePeriodEmailJob,
   SendSubscriptionExpiringEmailJob,
   SendSubscriptionExpiredEmailJob,
@@ -52,6 +55,7 @@ export const crons = [
   DocumentSyncScanCron,
   DocumentGCScanCron,
   SubscriptionRenewalCron,
+  SubscriptionReconcileInAppPurchaseCron,
 ];
 
 export type Jobs = typeof jobs;

--- a/apps/api/src/mq/tasks/subscription-reconcile.test.ts
+++ b/apps/api/src/mq/tasks/subscription-reconcile.test.ts
@@ -1,0 +1,227 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { SubscriptionState } from '@typie/lib/enums';
+import dayjs from 'dayjs';
+import { resolveReconcileAction } from './subscription-reconcile.ts';
+import type { ReconcileAction, ReconcileStoreState } from './subscription-reconcile.ts';
+
+const now = dayjs('2026-07-01T00:00:00.000Z');
+const recentlyExpired = now.subtract(1, 'hour'); // 만료 경과(하루 미만)
+const longExpired = now.subtract(2, 'days'); // 만료 경과(하루 초과)
+const future = now.add(30, 'days');
+const storeLater = now.add(30, 'days'); // 스토어가 알려준 더 나중 만료일
+const storeMuchLater = now.add(60, 'days'); // 로컬(미래)보다도 더 나중인 스토어 만료일
+
+const resolve = (params: {
+  storeState: ReconcileStoreState;
+  storeExpiresAt?: dayjs.Dayjs | null;
+  currentState: SubscriptionState;
+  currentExpiresAt: dayjs.Dayjs;
+}): ReconcileAction =>
+  resolveReconcileAction({
+    storeState: params.storeState,
+    storeExpiresAt: params.storeExpiresAt ?? null,
+    currentState: params.currentState,
+    currentExpiresAt: params.currentExpiresAt,
+    now,
+  });
+
+// active: 유실된 갱신 복구
+test('active + stale ACTIVE with a later store expiry recovers', () => {
+  const action = resolve({
+    storeState: 'active',
+    storeExpiresAt: storeLater,
+    currentState: SubscriptionState.ACTIVE,
+    currentExpiresAt: recentlyExpired,
+  });
+  assert.equal(action.type, 'recover');
+  assert.ok(action.type === 'recover' && action.expiresAt.isSame(storeLater));
+});
+
+test('active recovers a WILL_EXPIRE row (cancel then re-enable)', () => {
+  assert.equal(
+    resolve({
+      storeState: 'active',
+      storeExpiresAt: storeLater,
+      currentState: SubscriptionState.WILL_EXPIRE,
+      currentExpiresAt: longExpired,
+    }).type,
+    'recover',
+  );
+});
+
+test('active advances a not-yet-expired row when the store confirms a strictly later expiry (missed renewal, no 24h lockout)', () => {
+  const action = resolve({
+    storeState: 'active',
+    storeExpiresAt: storeMuchLater,
+    currentState: SubscriptionState.ACTIVE,
+    currentExpiresAt: future,
+  });
+  assert.equal(action.type, 'recover');
+  assert.ok(action.type === 'recover' && action.expiresAt.isSame(storeMuchLater));
+});
+
+test('active recovers an IN_GRACE_PERIOD row', () => {
+  assert.equal(
+    resolve({
+      storeState: 'active',
+      storeExpiresAt: storeLater,
+      currentState: SubscriptionState.IN_GRACE_PERIOD,
+      currentExpiresAt: longExpired,
+    }).type,
+    'recover',
+  );
+});
+
+test('active never resurrects an EXPIRED (refunded/revoked) row', () => {
+  assert.deepEqual(
+    resolve({ storeState: 'active', storeExpiresAt: storeLater, currentState: SubscriptionState.EXPIRED, currentExpiresAt: longExpired }),
+    { type: 'none' },
+  );
+});
+
+test('active is a no-op for a healthy row whose expiry is still in the future', () => {
+  assert.deepEqual(
+    resolve({ storeState: 'active', storeExpiresAt: future, currentState: SubscriptionState.ACTIVE, currentExpiresAt: future }),
+    { type: 'none' },
+  );
+});
+
+test('active does not shorten expiry when the store expiry is not later', () => {
+  assert.deepEqual(
+    resolve({
+      storeState: 'active',
+      storeExpiresAt: recentlyExpired,
+      currentState: SubscriptionState.ACTIVE,
+      currentExpiresAt: recentlyExpired,
+    }),
+    { type: 'none' },
+  );
+});
+
+test('active is a no-op without a store expiry', () => {
+  assert.deepEqual(
+    resolve({ storeState: 'active', storeExpiresAt: null, currentState: SubscriptionState.ACTIVE, currentExpiresAt: longExpired }),
+    { type: 'none' },
+  );
+});
+
+// grace: 유예 접근 복원
+test('grace restores IN_GRACE_PERIOD from a stale ACTIVE row', () => {
+  assert.deepEqual(resolve({ storeState: 'grace', currentState: SubscriptionState.ACTIVE, currentExpiresAt: recentlyExpired }), {
+    type: 'grace',
+  });
+});
+
+test('grace restores IN_GRACE_PERIOD from a WILL_EXPIRE row', () => {
+  assert.deepEqual(resolve({ storeState: 'grace', currentState: SubscriptionState.WILL_EXPIRE, currentExpiresAt: recentlyExpired }), {
+    type: 'grace',
+  });
+});
+
+test('grace is a no-op when the row is already IN_GRACE_PERIOD', () => {
+  assert.deepEqual(resolve({ storeState: 'grace', currentState: SubscriptionState.IN_GRACE_PERIOD, currentExpiresAt: recentlyExpired }), {
+    type: 'none',
+  });
+});
+
+test('grace never resurrects an EXPIRED row', () => {
+  assert.deepEqual(resolve({ storeState: 'grace', currentState: SubscriptionState.EXPIRED, currentExpiresAt: longExpired }), {
+    type: 'none',
+  });
+});
+
+test('grace is a no-op while the paid period is still in the future', () => {
+  assert.deepEqual(resolve({ storeState: 'grace', currentState: SubscriptionState.ACTIVE, currentExpiresAt: future }), { type: 'none' });
+});
+
+// suspended: 보류·재청구·일시중지 (비권한이나 복구 가능)
+test('suspended moves a stale ACTIVE row to WILL_EXPIRE', () => {
+  assert.deepEqual(resolve({ storeState: 'suspended', currentState: SubscriptionState.ACTIVE, currentExpiresAt: recentlyExpired }), {
+    type: 'suspend',
+  });
+});
+
+test('suspended moves an IN_GRACE_PERIOD row to WILL_EXPIRE', () => {
+  assert.deepEqual(
+    resolve({ storeState: 'suspended', currentState: SubscriptionState.IN_GRACE_PERIOD, currentExpiresAt: recentlyExpired }),
+    {
+      type: 'suspend',
+    },
+  );
+});
+
+test('suspended is a no-op when the row is already WILL_EXPIRE', () => {
+  assert.deepEqual(resolve({ storeState: 'suspended', currentState: SubscriptionState.WILL_EXPIRE, currentExpiresAt: recentlyExpired }), {
+    type: 'none',
+  });
+});
+
+test('suspended never resurrects an EXPIRED row', () => {
+  assert.deepEqual(resolve({ storeState: 'suspended', currentState: SubscriptionState.EXPIRED, currentExpiresAt: longExpired }), {
+    type: 'none',
+  });
+});
+
+test('suspended is a no-op while the paid period is still in the future (pause scheduled, not in effect)', () => {
+  assert.deepEqual(resolve({ storeState: 'suspended', currentState: SubscriptionState.ACTIVE, currentExpiresAt: future }), {
+    type: 'none',
+  });
+});
+
+// expired: 일반 만료 (하루 여유)
+test('expired expires a row whose local expiry is more than a day old', () => {
+  assert.deepEqual(resolve({ storeState: 'expired', currentState: SubscriptionState.ACTIVE, currentExpiresAt: longExpired }), {
+    type: 'expire',
+  });
+});
+
+test('expired waits when the local expiry is only recently past (buffer against store API lag)', () => {
+  assert.deepEqual(resolve({ storeState: 'expired', currentState: SubscriptionState.ACTIVE, currentExpiresAt: recentlyExpired }), {
+    type: 'none',
+  });
+});
+
+test('expired revokes immediately when the store ended a still-future local period (revocation/chargeback)', () => {
+  assert.deepEqual(resolve({ storeState: 'expired', currentState: SubscriptionState.ACTIVE, currentExpiresAt: future }), {
+    type: 'expire',
+  });
+});
+
+test('expired expires a WILL_EXPIRE row past the buffer', () => {
+  assert.deepEqual(resolve({ storeState: 'expired', currentState: SubscriptionState.WILL_EXPIRE, currentExpiresAt: longExpired }), {
+    type: 'expire',
+  });
+});
+
+test('expired is a no-op for a row that is already EXPIRED', () => {
+  assert.deepEqual(resolve({ storeState: 'expired', currentState: SubscriptionState.EXPIRED, currentExpiresAt: longExpired }), {
+    type: 'none',
+  });
+});
+
+// revoked: 환불·철회 (즉시, 만료일 무관)
+test('revoked expires a mid-term row immediately even with a future expiry', () => {
+  assert.deepEqual(resolve({ storeState: 'revoked', currentState: SubscriptionState.ACTIVE, currentExpiresAt: future }), {
+    type: 'expire',
+  });
+});
+
+test('revoked expires an IN_GRACE_PERIOD row immediately', () => {
+  assert.deepEqual(resolve({ storeState: 'revoked', currentState: SubscriptionState.IN_GRACE_PERIOD, currentExpiresAt: recentlyExpired }), {
+    type: 'expire',
+  });
+});
+
+test('revoked is a no-op for a row that is already EXPIRED', () => {
+  assert.deepEqual(resolve({ storeState: 'revoked', currentState: SubscriptionState.EXPIRED, currentExpiresAt: longExpired }), {
+    type: 'none',
+  });
+});
+
+// unknown: 조회 실패 — 아무 것도 하지 않음
+test('unknown is always a no-op', () => {
+  assert.deepEqual(resolve({ storeState: 'unknown', currentState: SubscriptionState.ACTIVE, currentExpiresAt: longExpired }), {
+    type: 'none',
+  });
+});

--- a/apps/api/src/mq/tasks/subscription-reconcile.ts
+++ b/apps/api/src/mq/tasks/subscription-reconcile.ts
@@ -1,0 +1,68 @@
+import { SubscriptionState } from '@typie/lib/enums';
+import type dayjs from 'dayjs';
+
+// 스토어에서 확인된 구독 상태. suspended = 보류·재청구·일시중지(권한 없음이나 복구 가능),
+// expired = 일반 만료, revoked = 환불·철회, unknown = 조회 실패/모호(아무 것도 하지 않음).
+export type ReconcileStoreState = 'active' | 'grace' | 'suspended' | 'expired' | 'revoked' | 'unknown';
+
+export type ReconcileAction =
+  { type: 'none' } | { type: 'recover'; expiresAt: dayjs.Dayjs } | { type: 'grace' } | { type: 'suspend' } | { type: 'expire' };
+
+type ResolveReconcileActionParams = {
+  storeState: ReconcileStoreState;
+  storeExpiresAt: dayjs.Dayjs | null;
+  currentState: SubscriptionState;
+  currentExpiresAt: dayjs.Dayjs;
+  now: dayjs.Dayjs;
+};
+
+// 스토어 상태와 (잠금 하에 재조회한) 현재 DB 상태를 받아 취할 동작을 결정하는 순수 함수.
+// I/O 없이 결정만 담당해 상태×상태 매트릭스를 단위 테스트할 수 있게 한다.
+export const resolveReconcileAction = ({
+  storeState,
+  storeExpiresAt,
+  currentState,
+  currentExpiresAt,
+  now,
+}: ResolveReconcileActionParams): ReconcileAction => {
+  const isLive =
+    currentState === SubscriptionState.ACTIVE ||
+    currentState === SubscriptionState.WILL_EXPIRE ||
+    currentState === SubscriptionState.IN_GRACE_PERIOD;
+
+  const expired = currentExpiresAt.isBefore(now);
+
+  // 유실된 갱신 복구. 스토어가 더 나중 만료일을 확인해 주면(=갱신 발생) 로컬 만료가 아직 지나기 전이라도 즉시 반영해,
+  // 다음 일일 재조정까지 로컬의 옛 만료일에 걸려 접근이 끊기는 것을 막는다. 만료일이 실제로 뒤로 갈 때만 동작하므로
+  // WILL_EXPIRE(해지 후 재개) 도 되살릴 수 있고, EXPIRED(환불/철회) 행은 isLive 에서 제외되어 되살리지 않는다.
+  if (storeState === 'active' && storeExpiresAt && isLive && storeExpiresAt.isAfter(currentExpiresAt)) {
+    return { type: 'recover', expiresAt: storeExpiresAt };
+  }
+
+  // 유예 접근 복원. 이미 유예/만료된 행은 대상이 아니다.
+  if (storeState === 'grace' && (currentState === SubscriptionState.ACTIVE || currentState === SubscriptionState.WILL_EXPIRE) && expired) {
+    return { type: 'grace' };
+  }
+
+  // 보류·재청구·일시중지: 접근은 중단(WILL_EXPIRE + 만료 경과 → 비권한)하되 재조정이 계속 감시해 복구 가능하게 둔다.
+  if (
+    storeState === 'suspended' &&
+    (currentState === SubscriptionState.ACTIVE || currentState === SubscriptionState.IN_GRACE_PERIOD) &&
+    expired
+  ) {
+    return { type: 'suspend' };
+  }
+
+  // expired: 스토어가 종료를 확인. 로컬 만료가 미래면 스토어가 결제 기간 전에 끝낸 것(철회·환불류)이므로 즉시 회수하고,
+  //   로컬 만료가 이미 지났으면 일반 만료로 보되 갱신 직후 stale EXPIRED(스토어 API 지연) 대비 하루 여유를 둔다.
+  // revoked: 환불·철회 — 남은 결제 기간과 무관하게 즉시 회수한다.
+  if (
+    isLive &&
+    ((storeState === 'expired' && (currentExpiresAt.isAfter(now) || currentExpiresAt.isBefore(now.subtract(1, 'day')))) ||
+      storeState === 'revoked')
+  ) {
+    return { type: 'expire' };
+  }
+
+  return { type: 'none' };
+};

--- a/apps/api/src/mq/tasks/subscription.ts
+++ b/apps/api/src/mq/tasks/subscription.ts
@@ -1,13 +1,17 @@
 import * as Sentry from '@sentry/node';
 import { SUBSCRIPTION_GRACE_DAYS } from '@typie/lib/const';
-import { PaymentInvoiceState, PlanAvailability, SubscriptionState } from '@typie/lib/enums';
+import { InAppPurchaseStore, PaymentInvoiceState, PlanAvailability, SubscriptionState } from '@typie/lib/enums';
 import dayjs from 'dayjs';
-import { and, desc, eq, lte, ne, sql } from 'drizzle-orm';
-import { db, first, firstOrThrow, PaymentInvoices, Plans, Subscriptions, UserBillingKeys } from '#/db/index.ts';
+import { and, desc, eq, inArray, lte, ne, sql } from 'drizzle-orm';
+import { db, first, firstOrThrow, PaymentInvoices, Plans, Subscriptions, UserBillingKeys, UserInAppPurchases } from '#/db/index.ts';
+import * as appstore from '#/external/appstore.ts';
+import * as googleplay from '#/external/googleplay.ts';
 import * as portone from '#/external/portone.ts';
 import { getSubscriptionExpiresAt, hasBillableUsageDuring, payInvoiceWithBillingKey } from '#/utils/index.ts';
 import { enqueueJob } from '../index.ts';
 import { defineCron, defineJob } from '../types.ts';
+import { resolveReconcileAction } from './subscription-reconcile.ts';
+import type { ReconcileStoreState } from './subscription-reconcile.ts';
 
 export const SubscriptionRenewalCron = defineCron('subscription:renewal', '0 10 * * *', async () => {
   const now = dayjs();
@@ -48,10 +52,19 @@ export const SubscriptionRenewalCron = defineCron('subscription:renewal', '0 10 
         await enqueueJob('subscription:renewal:plan-change', subscription.id);
       }
 
+      // IAP 는 스토어 웹훅/재조정 크론이 만료를 담당한다. 여기서 처리하면 스토어가 갱신·재개한 구독을
+      // 잘못 만료시킬 수 있으므로 제외한다(빌링키·트라이얼만 처리).
       const cancelSubscriptions = await tx
         .select({ id: Subscriptions.id })
         .from(Subscriptions)
-        .where(and(eq(Subscriptions.state, SubscriptionState.WILL_EXPIRE), lte(Subscriptions.expiresAt, now)));
+        .innerJoin(Plans, eq(Subscriptions.planId, Plans.id))
+        .where(
+          and(
+            eq(Subscriptions.state, SubscriptionState.WILL_EXPIRE),
+            lte(Subscriptions.expiresAt, now),
+            ne(Plans.availability, PlanAvailability.IN_APP_PURCHASE),
+          ),
+        );
 
       for (const subscription of cancelSubscriptions) {
         await enqueueJob('subscription:renewal:cancel', subscription.id);
@@ -67,6 +80,7 @@ export const SubscriptionRenewalInitialJob = defineJob('subscription:renewal:ini
       .select({
         id: Subscriptions.id,
         userId: Subscriptions.userId,
+        state: Subscriptions.state,
         renewedAt: Subscriptions.renewedAt,
         expiresAt: Subscriptions.expiresAt,
         plan: { fee: Plans.fee, interval: Plans.interval },
@@ -74,7 +88,12 @@ export const SubscriptionRenewalInitialJob = defineJob('subscription:renewal:ini
       .from(Subscriptions)
       .innerJoin(Plans, eq(Subscriptions.planId, Plans.id))
       .where(eq(Subscriptions.id, subscriptionId))
+      .for('no key update', { of: Subscriptions })
       .then(firstOrThrow);
+
+    if (subscription.state !== SubscriptionState.ACTIVE || dayjs(subscription.expiresAt).isAfter(dayjs())) {
+      return;
+    }
 
     const hasUsage = await hasBillableUsageDuring(tx, subscription.userId, subscription.renewedAt, subscription.expiresAt);
 
@@ -146,17 +165,43 @@ export const SubscriptionRenewalInitialJob = defineJob('subscription:renewal:ini
 
 export const SubscriptionRenewalRetryJob = defineJob('subscription:renewal:retry', async (invoiceId: string) => {
   await db.transaction(async (tx) => {
+    // 교착 방지: 모든 갱신·환불 경로는 구독 → 인보이스 순으로 잠근다(환불은 구독을 잠근 채 인보이스를 갱신한다).
+    // subscriptionId 는 불변 컬럼이라 무락 조회가 안전하고, 인보이스 상태는 아래 잠금 조회에서 재검증한다.
+    const invoiceRef = await tx
+      .select({ subscriptionId: PaymentInvoices.subscriptionId })
+      .from(PaymentInvoices)
+      .where(eq(PaymentInvoices.id, invoiceId))
+      .then(firstOrThrow);
+
+    await tx
+      .select({ id: Subscriptions.id })
+      .from(Subscriptions)
+      .where(eq(Subscriptions.id, invoiceRef.subscriptionId))
+      .for('no key update')
+      .then(firstOrThrow);
+
     const invoice = await tx
       .select({
         id: PaymentInvoices.id,
-        subscription: { id: Subscriptions.id, userId: Subscriptions.userId, expiresAt: Subscriptions.expiresAt },
+        state: PaymentInvoices.state,
+        subscription: {
+          id: Subscriptions.id,
+          userId: Subscriptions.userId,
+          state: Subscriptions.state,
+          expiresAt: Subscriptions.expiresAt,
+        },
         plan: { interval: Plans.interval },
       })
       .from(PaymentInvoices)
       .innerJoin(Subscriptions, eq(PaymentInvoices.subscriptionId, Subscriptions.id))
       .innerJoin(Plans, eq(Subscriptions.planId, Plans.id))
       .where(eq(PaymentInvoices.id, invoiceId))
+      .for('no key update', { of: PaymentInvoices })
       .then(firstOrThrow);
+
+    if (invoice.state !== PaymentInvoiceState.OVERDUE || invoice.subscription.state !== SubscriptionState.IN_GRACE_PERIOD) {
+      return;
+    }
 
     const success = await payInvoiceWithBillingKey(tx, invoice.id);
     if (success) {
@@ -189,11 +234,22 @@ export const SubscriptionRenewalRetryJob = defineJob('subscription:renewal:retry
 export const SubscriptionRenewalPlanChangeJob = defineJob('subscription:renewal:plan-change', async (subscriptionId: string) => {
   await db.transaction(async (tx) => {
     const subscription = await tx
-      .select({ id: Subscriptions.id, userId: Subscriptions.userId, startsAt: Subscriptions.startsAt, plan: { fee: Plans.fee } })
+      .select({
+        id: Subscriptions.id,
+        userId: Subscriptions.userId,
+        state: Subscriptions.state,
+        startsAt: Subscriptions.startsAt,
+        plan: { fee: Plans.fee },
+      })
       .from(Subscriptions)
       .innerJoin(Plans, eq(Subscriptions.planId, Plans.id))
       .where(eq(Subscriptions.id, subscriptionId))
+      .for('no key update', { of: Subscriptions })
       .then(firstOrThrow);
+
+    if (subscription.state !== SubscriptionState.WILL_ACTIVATE || dayjs(subscription.startsAt).isAfter(dayjs())) {
+      return;
+    }
 
     const invoice = await tx
       .insert(PaymentInvoices)
@@ -229,15 +285,61 @@ export const SubscriptionRenewalPlanChangeJob = defineJob('subscription:renewal:
 export const SubscriptionRenewalCancelJob = defineJob('subscription:renewal:cancel', async (subscriptionId: string) => {
   const billingKey = await db.transaction(async (tx) => {
     const subscription = await tx
-      .select({ userId: Subscriptions.userId })
+      .select({
+        userId: Subscriptions.userId,
+        state: Subscriptions.state,
+        expiresAt: Subscriptions.expiresAt,
+        availability: Plans.availability,
+      })
       .from(Subscriptions)
+      .innerJoin(Plans, eq(Subscriptions.planId, Plans.id))
       .where(eq(Subscriptions.id, subscriptionId))
+      .for('no key update', { of: Subscriptions })
       .then(firstOrThrow);
 
+    // IAP 배제를 상태 변경보다 먼저 한다 — 구버전이 큐에 넣었거나 롤백된 워커가 만든 IAP 잡이 배포 중 재시도돼도
+    // IAP 구독을 EXPIRED(재조정으로 복구 불가)로 만들지 않도록 한다. IAP 만료는 스토어 웹훅/재조정이 담당한다.
+    if (
+      subscription.availability === PlanAvailability.IN_APP_PURCHASE ||
+      subscription.state !== SubscriptionState.WILL_EXPIRE ||
+      dayjs(subscription.expiresAt).isAfter(dayjs())
+    ) {
+      return null;
+    }
+
+    // 빌링키 취소 확정 또는 트라이얼 만료 — 둘 다 EXPIRED 로 전이한다.
     await tx
       .update(Subscriptions)
       .set({ state: SubscriptionState.EXPIRED, expiresAt: sql`LEAST(${Subscriptions.expiresAt}, NOW())` })
       .where(eq(Subscriptions.id, subscriptionId));
+
+    // 빌링키 정리는 BILLING_KEY 플랜에만 해당한다(트라이얼은 빌링키가 없음).
+    if (subscription.availability !== PlanAvailability.BILLING_KEY) {
+      return null;
+    }
+
+    const remainingBillingKeySubscription = await tx
+      .select({ id: Subscriptions.id })
+      .from(Subscriptions)
+      .innerJoin(Plans, eq(Subscriptions.planId, Plans.id))
+      .where(
+        and(
+          eq(Subscriptions.userId, subscription.userId),
+          ne(Subscriptions.id, subscriptionId),
+          inArray(Subscriptions.state, [
+            SubscriptionState.ACTIVE,
+            SubscriptionState.WILL_ACTIVATE,
+            SubscriptionState.WILL_EXPIRE,
+            SubscriptionState.IN_GRACE_PERIOD,
+          ]),
+          eq(Plans.availability, PlanAvailability.BILLING_KEY),
+        ),
+      )
+      .then(first);
+
+    if (remainingBillingKeySubscription) {
+      return null;
+    }
 
     const billingKey = await tx
       .delete(UserBillingKeys)
@@ -255,4 +357,171 @@ export const SubscriptionRenewalCancelJob = defineJob('subscription:renewal:canc
       Sentry.captureException(err);
     }
   }
+});
+
+export const SubscriptionReconcileInAppPurchaseCron = defineCron('subscription:reconcile-iap', '0 4 * * *', async () => {
+  const subscriptions = await db
+    .select({ id: Subscriptions.id })
+    .from(Subscriptions)
+    .innerJoin(Plans, eq(Subscriptions.planId, Plans.id))
+    .where(
+      and(
+        eq(Plans.availability, PlanAvailability.IN_APP_PURCHASE),
+        inArray(Subscriptions.state, [SubscriptionState.ACTIVE, SubscriptionState.WILL_EXPIRE, SubscriptionState.IN_GRACE_PERIOD]),
+      ),
+    );
+
+  for (const subscription of subscriptions) {
+    await enqueueJob('subscription:reconcile-iap:sync', subscription.id);
+  }
+});
+
+export const SubscriptionReconcileInAppPurchaseJob = defineJob('subscription:reconcile-iap:sync', async (subscriptionId: string) => {
+  const subscription = await db
+    .select({ id: Subscriptions.id, userId: Subscriptions.userId, state: Subscriptions.state, expiresAt: Subscriptions.expiresAt })
+    .from(Subscriptions)
+    .where(eq(Subscriptions.id, subscriptionId))
+    .then(first);
+
+  if (!subscription) {
+    return;
+  }
+
+  const binding = await db
+    .select({ store: UserInAppPurchases.store, identifier: UserInAppPurchases.identifier })
+    .from(UserInAppPurchases)
+    .where(eq(UserInAppPurchases.userId, subscription.userId))
+    .then(first);
+
+  if (!binding) {
+    return;
+  }
+
+  // 스토어가 명시적으로 상태를 확인해 준 경우에만 판정한다.
+  // 조회 실패(네트워크·타임아웃·5xx)나 모호 상태는 unknown 으로 두어, 실결제 구독을 잘못 만료시키지 않는다.
+  // suspended = 보류·재청구·일시중지(권한 없음이나 복구 가능), expired = 일반 만료(하루 여유 후), revoked = 환불·철회(즉시).
+  let storeState: ReconcileStoreState = 'unknown';
+  let storeExpiresAt: dayjs.Dayjs | null = null;
+  let storePlanId: string | null = null;
+
+  if (binding.store === InAppPurchaseStore.APP_STORE) {
+    const status = await appstore.getSubscriptionStatus(binding.identifier);
+    if (status.kind === 'error') {
+      // 전 환경 조회 실패. 조용히 스킵하면 재시도·알림이 없으므로 던져서 큐 재시도와 Sentry 캡처를 발동시킨다.
+      throw new Error('appstore reconcile status lookup failed');
+    }
+
+    if (status.kind === 'active' || status.kind === 'grace') {
+      storeState = status.kind;
+      storeExpiresAt = status.expiresDate ? dayjs(status.expiresDate) : null;
+      if (status.kind === 'active') {
+        storePlanId = status.productId?.toUpperCase() ?? null;
+      }
+    } else if (status.kind === 'suspended' || status.kind === 'expired' || status.kind === 'revoked') {
+      storeState = status.kind;
+    }
+    // status.kind === 'unknown' 은 storeState = 'unknown' 유지(안전 스킵)
+  } else if (binding.store === InAppPurchaseStore.GOOGLE_PLAY) {
+    // getSubscription 은 조회 실패 시 throw 한다. 삼키지 않고 전파해 큐 재시도·Sentry 를 발동시킨다.
+    // 단 404/410(만료 60일 경과 등으로 토큰 제공 영구 중단)은 재시도가 무의미한 확정 응답이므로,
+    // 로컬 만료가 이미 지난 행에 한해 스토어 확인 만료로 취급한다 — 영구 재시도 루프로 stale ACTIVE 가 방치되는 것을 막는다.
+    const googlePlaySubscription = await googleplay.getSubscription(binding.identifier).catch((err: unknown) => {
+      if (googleplay.isPurchaseTokenGoneError(err) && dayjs(subscription.expiresAt).isBefore(dayjs())) {
+        return null;
+      }
+      throw err;
+    });
+
+    if (googlePlaySubscription === null) {
+      storeState = 'expired';
+    } else {
+      const expiryTime = googlePlaySubscription.lineItems?.[0]?.expiryTime;
+      const googlePlayState = googlePlaySubscription.subscriptionState;
+      if (googlePlayState === 'SUBSCRIPTION_STATE_ACTIVE') {
+        storeState = 'active';
+        storeExpiresAt = expiryTime ? dayjs(expiryTime) : null;
+        storePlanId = googlePlaySubscription.lineItems?.[0]?.offerDetails?.basePlanId?.toUpperCase() ?? null;
+      } else if (googlePlayState === 'SUBSCRIPTION_STATE_IN_GRACE_PERIOD') {
+        storeState = 'grace';
+        storeExpiresAt = expiryTime ? dayjs(expiryTime) : null;
+      } else if (googlePlayState === 'SUBSCRIPTION_STATE_ON_HOLD' || googlePlayState === 'SUBSCRIPTION_STATE_PAUSED') {
+        storeState = 'suspended';
+      } else if (googlePlayState === 'SUBSCRIPTION_STATE_EXPIRED') {
+        storeState = 'expired';
+      }
+      // 그 외(CANCELED/PENDING 등) 는 storeState = 'unknown' 유지(안전 스킵)
+    }
+  }
+
+  if (storeState === 'unknown') {
+    return;
+  }
+
+  const now = dayjs();
+
+  // 스토어 조회 이후 웹훅이 상태를 바꿨을 수 있으므로, 트랜잭션 안에서 행을 잠그고 재조회한 뒤 판정한다.
+  await db.transaction(async (tx) => {
+    // 조회 이후 바인딩이 다른 구매로 교체됐다면(재구독 등) 이 스토어 결과는 stale 이므로 중단한다.
+    const freshBinding = await tx
+      .select({ store: UserInAppPurchases.store, identifier: UserInAppPurchases.identifier })
+      .from(UserInAppPurchases)
+      .where(eq(UserInAppPurchases.userId, subscription.userId))
+      .for('no key update')
+      .then(first);
+
+    if (!freshBinding || freshBinding.store !== binding.store || freshBinding.identifier !== binding.identifier) {
+      return;
+    }
+
+    const fresh = await tx
+      .select({ state: Subscriptions.state, expiresAt: Subscriptions.expiresAt })
+      .from(Subscriptions)
+      .where(eq(Subscriptions.id, subscription.id))
+      .for('no key update', { of: Subscriptions })
+      .then(firstOrThrow);
+
+    // 스토어 조회 시점 이후 웹훅이 상태/만료일을 바꿨다면(예: 갱신이 사이에 도착) 스토어 응답이 이미 stale 이다.
+    // 이 경우 판정하지 않고 중단한다 — 다음 재조정이 갱신된 상태에 맞춰 스토어를 다시 조회한다.
+    if (fresh.state !== subscription.state || !dayjs(fresh.expiresAt).isSame(dayjs(subscription.expiresAt))) {
+      return;
+    }
+
+    const action = resolveReconcileAction({
+      storeState,
+      storeExpiresAt,
+      currentState: fresh.state,
+      currentExpiresAt: dayjs(fresh.expiresAt),
+      now,
+    });
+
+    if (action.type === 'recover') {
+      // 유실된 웹훅에 플랜 변경이 포함됐을 수 있으므로, 스토어가 알려준 플랜이 유효한 IAP 플랜이면 함께 동기화한다.
+      const storePlan = storePlanId
+        ? await tx
+            .select({ id: Plans.id })
+            .from(Plans)
+            .where(and(eq(Plans.id, storePlanId), eq(Plans.availability, PlanAvailability.IN_APP_PURCHASE)))
+            .then(first)
+        : null;
+
+      await tx
+        .update(Subscriptions)
+        .set({
+          state: SubscriptionState.ACTIVE,
+          renewedAt: fresh.expiresAt,
+          expiresAt: action.expiresAt,
+          ...(storePlan && { planId: storePlan.id }),
+        })
+        .where(eq(Subscriptions.id, subscription.id));
+    } else if (action.type === 'grace') {
+      await tx.update(Subscriptions).set({ state: SubscriptionState.IN_GRACE_PERIOD }).where(eq(Subscriptions.id, subscription.id));
+    } else if (action.type === 'suspend') {
+      await tx.update(Subscriptions).set({ state: SubscriptionState.WILL_EXPIRE }).where(eq(Subscriptions.id, subscription.id));
+    } else if (action.type === 'expire') {
+      await tx
+        .update(Subscriptions)
+        .set({ state: SubscriptionState.EXPIRED, expiresAt: sql`LEAST(${Subscriptions.expiresAt}, NOW())` })
+        .where(eq(Subscriptions.id, subscription.id));
+    }
+  });
 });

--- a/apps/api/src/rest/iap.ts
+++ b/apps/api/src/rest/iap.ts
@@ -1,7 +1,8 @@
 import { DeliveryStatus, RefundPreference } from '@apple/app-store-server-library';
+import * as Sentry from '@sentry/node';
 import { InAppPurchaseStore, PlanAvailability, SubscriptionState } from '@typie/lib/enums';
 import dayjs from 'dayjs';
-import { and, desc, eq, inArray, sql } from 'drizzle-orm';
+import { and, desc, eq, inArray, lt, lte, ne, sql } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { match } from 'ts-pattern';
 import { db, first, Plans, Subscriptions, UserInAppPurchases, UserTrials } from '#/db/index.ts';
@@ -46,7 +47,13 @@ iap.post('/appstore', async (c) => {
   const planId = notification.data.transaction?.productId?.toUpperCase();
 
   if (!originalTransactionId) {
-    return c.json({ error: 'invalid_request' }, 400);
+    await slack.sendMessage({
+      channel: 'iap',
+      username: '인앱결제 알림',
+      iconEmoji: ':credit_card:',
+      message: `\`\`\`\n${JSON.stringify({ source: 'rest/appstore', reason: 'no_transaction', notification }, null, 2)}\n\`\`\``,
+    });
+    return c.json({}, 200);
   }
 
   const inAppPurchase = await db
@@ -64,73 +71,190 @@ iap.post('/appstore', async (c) => {
   const subscription = await getLiveInAppPurchaseSubscription(inAppPurchase.userId);
 
   await match(notification.notificationType)
-    .with('DID_RENEW', 'SUBSCRIBED', async () => {
+    .with('DID_RENEW', 'SUBSCRIBED', 'OFFER_REDEEMED', 'REFUND_REVERSED', async () => {
+      const purchaseDate = dayjs(notification.data.transaction?.purchaseDate);
+      const expiresDate = dayjs(notification.data.transaction?.expiresDate);
+      const plan = planId ? await db.select({ id: Plans.id }).from(Plans).where(eq(Plans.id, planId)).then(first) : null;
+
       if (subscription) {
+        // 스냅샷 비교 후 무조건 갱신하면 동시·역순 재전송이 최신 갱신을 짧은 만료일로 되돌릴 수 있다.
+        // 조건을 UPDATE 안으로 옮겨(커밋된 최신 행 값과 재평가됨) 만료일 단조 증가를 원자적으로 보장한다.
+        // 동시 환불로 EXPIRED 가 된 행은 되살리지 않는다 — 웹훅 UPDATE 는 EXPIRED 를 벗어나게 하지 않는다(부활은 insert·재조정 경로만).
         await db
           .update(Subscriptions)
           .set({
             state: SubscriptionState.ACTIVE,
-            renewedAt: dayjs(notification.data.transaction?.purchaseDate),
-            expiresAt: dayjs(notification.data.transaction?.expiresDate),
+            ...(plan && { planId: plan.id }),
+            renewedAt: purchaseDate,
+            expiresAt: expiresDate,
           })
-          .where(eq(Subscriptions.id, subscription.id));
-      } else if (planId) {
-        const plan = await db.select({ id: Plans.id }).from(Plans).where(eq(Plans.id, planId)).then(first);
-        if (plan) {
-          const startsAt = dayjs(notification.data.transaction?.purchaseDate);
-          const expiresAt = dayjs(notification.data.transaction?.expiresDate);
-          await db
-            .insert(Subscriptions)
-            .values({
-              userId: inAppPurchase.userId,
-              planId,
-              startsAt,
-              expiresAt,
-              renewedAt: startsAt,
-              state: SubscriptionState.ACTIVE,
-            })
-            .onConflictDoUpdate({
-              target: [Subscriptions.userId],
-              targetWhere: eq(Subscriptions.state, SubscriptionState.ACTIVE),
-              set: { planId, startsAt, expiresAt, renewedAt: startsAt },
-            });
+          .where(
+            and(
+              eq(Subscriptions.id, subscription.id),
+              ne(Subscriptions.state, SubscriptionState.EXPIRED),
+              lte(Subscriptions.expiresAt, expiresDate),
+            ),
+          );
+      } else if (plan && expiresDate.isAfter(dayjs())) {
+        // 알림의 서명 데이터는 발행 시점 기준이라(최대 72시간 재전송) 환불 이후 도착한 stale 갱신이
+        // 새 ACTIVE 행을 만들 수 있다. 삽입 전에 현재 스토어 상태로 자격을 확인해 이 부활 창을 닫는다.
+        // 조회~삽입 사이에 환불이 일어나는 경우는 이후 도착하는 REFUND/REVOKE 웹훅이 이 행을 회수한다.
+        const status = await appstore.getSubscriptionStatus(originalTransactionId);
+        if (status.kind === 'error' || status.kind === 'unknown') {
+          // 자격을 판정할 수 없으면 삽입도 폐기도 하지 않고 5xx 로 재전송을 유도한다 — 신규 결제를 조용히 잃지 않는다.
+          throw new Error('appstore subscription status lookup failed');
         }
+        if (status.kind !== 'active' && status.kind !== 'grace') {
+          return;
+        }
+
+        await db
+          .insert(Subscriptions)
+          .values({
+            userId: inAppPurchase.userId,
+            planId: plan.id,
+            startsAt: purchaseDate,
+            expiresAt: expiresDate,
+            renewedAt: purchaseDate,
+            state: SubscriptionState.ACTIVE,
+          })
+          .onConflictDoUpdate({
+            target: [Subscriptions.userId],
+            targetWhere: eq(Subscriptions.state, SubscriptionState.ACTIVE),
+            set: { planId: plan.id, startsAt: purchaseDate, expiresAt: expiresDate, renewedAt: purchaseDate },
+            // 충돌하는 ACTIVE 행이 IAP 이고 만료일이 역행하지 않을 때만 갱신한다.
+            // 다른 채널(빌링키 등)의 ACTIVE 구독을 덮어쓰지 않고, stale 재전송이 최신 갱신을 되돌리지 못하게 한다.
+            setWhere: and(
+              inArray(
+                Subscriptions.planId,
+                db.select({ id: Plans.id }).from(Plans).where(eq(Plans.availability, PlanAvailability.IN_APP_PURCHASE)),
+              ),
+              lte(Subscriptions.expiresAt, expiresDate),
+            ),
+          });
       }
     })
     .with('EXPIRED', 'GRACE_PERIOD_EXPIRED', async () => {
-      if (subscription) {
+      if (!subscription) {
+        return;
+      }
+
+      // Apple 은 실패한 알림을 최대 72시간 재전송하고, DID_RENEW 유실 시 로컬 만료일이 갱신을 반영하지 못한다.
+      // 로컬 만료일만으론 stale 여부를 구분할 수 없으므로 현재 스토어 상태를 직접 조회해 실제 비활성일 때만 회수한다.
+      const status = await appstore.getSubscriptionStatus(originalTransactionId);
+      if (status.kind === 'error') {
+        // 스토어 조회 실패 — 회수를 보류하고 5xx 로 재전송을 유도한다.
+        throw new Error('appstore subscription status lookup failed');
+      }
+
+      if (status.kind === 'active') {
+        // 스토어는 여전히 활성 = stale EXPIRED. 갱신이 반영되지 않았으면 만료일을 끌어올려 락아웃을 막는다.
+        // renewedAt 은 스냅샷이 아닌 갱신 시점의 실제 이전 만료일(행의 현재 값)을 쓴다.
+        // 스토어 조회~갱신 사이 동시 REFUND/REVOKE 가 EXPIRED+만료일 clip 을 먼저 커밋하면 만료일 조건만으론
+        // 환불된 행을 부활시키므로, EXPIRED 가 아닌 행만 복구한다.
+        if (status.expiresDate) {
+          const storeExpiresAt = dayjs(status.expiresDate);
+          await db
+            .update(Subscriptions)
+            .set({ state: SubscriptionState.ACTIVE, renewedAt: sql`${Subscriptions.expiresAt}`, expiresAt: storeExpiresAt })
+            .where(
+              and(
+                eq(Subscriptions.id, subscription.id),
+                ne(Subscriptions.state, SubscriptionState.EXPIRED),
+                lt(Subscriptions.expiresAt, storeExpiresAt),
+              ),
+            );
+        }
+        return;
+      }
+
+      if (status.kind === 'grace') {
+        // 유예 중 — 회수하지 않는다.
+        return;
+      }
+
+      if (status.kind === 'suspended') {
+        // 재청구 중 — 권한은 없지만(만료일 경과로 이미 차단) 복구 가능하므로 종료하지 않고 live 로 남겨
+        // 재조정 크론이 계속 다루게 한다. EXPIRED 로 보내면 재조정 대상에서 빠져 복구 경로가 사라진다.
         await db
           .update(Subscriptions)
-          .set({ state: SubscriptionState.EXPIRED, expiresAt: sql`LEAST(${Subscriptions.expiresAt}, NOW())` })
-          .where(eq(Subscriptions.id, subscription.id));
+          .set({ state: SubscriptionState.WILL_EXPIRE })
+          .where(
+            and(
+              eq(Subscriptions.id, subscription.id),
+              ne(Subscriptions.state, SubscriptionState.EXPIRED),
+              lte(Subscriptions.expiresAt, dayjs()),
+            ),
+          );
+        return;
       }
+
+      if (status.kind === 'unknown') {
+        // 조회는 됐으나 이 트랜잭션을 확인할 수 없음 — 판정을 보류한다(재조정 크론이 다시 다룬다).
+        return;
+      }
+
+      // 확정 종료(expired/revoked). expired 는 조회~갱신 사이 동시 갱신이 만료일을 미래로 올렸으면 건드리지
+      // 않도록 CAS(만료일이 현재 이하일 때만)로 회수하고, revoked(환불·철회)는 스토어 확정 종료이므로 즉시 회수한다.
+      await db
+        .update(Subscriptions)
+        .set({ state: SubscriptionState.EXPIRED, expiresAt: sql`LEAST(${Subscriptions.expiresAt}, NOW())` })
+        .where(
+          status.kind === 'revoked'
+            ? eq(Subscriptions.id, subscription.id)
+            : and(eq(Subscriptions.id, subscription.id), lte(Subscriptions.expiresAt, dayjs())),
+        );
     })
     .with('DID_CHANGE_RENEWAL_PREF', async () => {
       if (subscription && planId) {
         const plan = await db.select({ id: Plans.id }).from(Plans).where(eq(Plans.id, planId)).then(first);
         if (plan) {
+          // stale 재전송이 갱신된 만료일을 되돌리지 못하게 단조 가드를 건다. 갱신이 사이에 끼었다면
+          // 그 갱신 트랜잭션이 이미 최신 플랜을 반영하므로(DID_RENEW 가 planId 동기화) 여기서 건너뛰어도 안전하다.
+          const expiresDate = dayjs(notification.data.transaction?.expiresDate);
           await db
             .update(Subscriptions)
-            .set({ planId, expiresAt: dayjs(notification.data.transaction?.expiresDate) })
-            .where(eq(Subscriptions.id, subscription.id));
+            .set({ planId, expiresAt: expiresDate })
+            .where(
+              and(
+                eq(Subscriptions.id, subscription.id),
+                ne(Subscriptions.state, SubscriptionState.EXPIRED),
+                lte(Subscriptions.expiresAt, expiresDate),
+              ),
+            );
         }
       }
     })
     .with('DID_CHANGE_RENEWAL_STATUS', async () => {
       if (subscription) {
+        // 상태 전제조건을 스냅샷이 아닌 UPDATE 조건으로 검사해 동시 전이(환불로 EXPIRED 등)와 원자적으로 배타한다.
         if (notification.subtype === 'AUTO_RENEW_DISABLED') {
-          await db.update(Subscriptions).set({ state: SubscriptionState.WILL_EXPIRE }).where(eq(Subscriptions.id, subscription.id));
-        } else if (notification.subtype === 'AUTO_RENEW_ENABLED' && subscription.state === SubscriptionState.WILL_EXPIRE) {
-          await db.update(Subscriptions).set({ state: SubscriptionState.ACTIVE }).where(eq(Subscriptions.id, subscription.id));
+          await db
+            .update(Subscriptions)
+            .set({ state: SubscriptionState.WILL_EXPIRE })
+            .where(and(eq(Subscriptions.id, subscription.id), eq(Subscriptions.state, SubscriptionState.ACTIVE)));
+        } else if (notification.subtype === 'AUTO_RENEW_ENABLED') {
+          await db
+            .update(Subscriptions)
+            .set({ state: SubscriptionState.ACTIVE })
+            .where(and(eq(Subscriptions.id, subscription.id), eq(Subscriptions.state, SubscriptionState.WILL_EXPIRE)));
         }
       }
     })
     .with('RENEWAL_EXTENDED', async () => {
       if (subscription) {
+        // 연장은 만료일이 늘어나는 방향만 유효하다 — stale 재전송이 갱신된 만료일을 되돌리지 못하게 한다.
+        const expiresDate = dayjs(notification.data.transaction?.expiresDate);
         await db
           .update(Subscriptions)
-          .set({ expiresAt: dayjs(notification.data.transaction?.expiresDate) })
-          .where(eq(Subscriptions.id, subscription.id));
+          .set({ expiresAt: expiresDate })
+          .where(
+            and(
+              eq(Subscriptions.id, subscription.id),
+              ne(Subscriptions.state, SubscriptionState.EXPIRED),
+              lte(Subscriptions.expiresAt, expiresDate),
+            ),
+          );
       }
     })
     .with('REFUND', 'REVOKE', async () => {
@@ -158,14 +282,24 @@ iap.post('/appstore', async (c) => {
     })
     .with('DID_FAIL_TO_RENEW', async () => {
       if (subscription) {
+        // 알림의 서명된 만료일은 갱신에 실패한 기간의 끝이다. 로컬 만료일이 그보다 뒤면 이미 더 최신 갱신
+        // (DID_RENEW)이 반영된 것이므로, 최대 72시간 재전송되는 stale 실패 알림이 새 기간을 회수하지 못하게 한다.
+        const failedExpiresDate = dayjs(notification.data.transaction?.expiresDate);
         await db
           .update(Subscriptions)
           .set(
             notification.subtype === 'GRACE_PERIOD'
               ? { state: SubscriptionState.IN_GRACE_PERIOD }
-              : { state: SubscriptionState.EXPIRED, expiresAt: sql`LEAST(${Subscriptions.expiresAt}, NOW())` },
+              : // 유예 없이 재청구(billing retry): 권한은 없지만 복구 가능하므로 WILL_EXPIRE(만료일 경과)로 둔다.
+                { state: SubscriptionState.WILL_EXPIRE, expiresAt: sql`LEAST(${Subscriptions.expiresAt}, NOW())` },
           )
-          .where(eq(Subscriptions.id, subscription.id));
+          .where(
+            and(
+              eq(Subscriptions.id, subscription.id),
+              ne(Subscriptions.state, SubscriptionState.EXPIRED),
+              lte(Subscriptions.expiresAt, failedExpiresDate),
+            ),
+          );
       }
     })
     .otherwise(async () => {
@@ -184,6 +318,7 @@ iap.post('/googleplay', async (c) => {
   const notification = await c.req.json<DeveloperNotification>();
 
   if (notification.subscriptionNotification) {
+    // 조회 실패(일시적 오류 포함)는 throw 하여 5xx 로 응답 → Pub/Sub 가 재전송한다. 200 으로 삼키면 알림이 영구 유실된다.
     const googlePlaySubscription = await googleplay.getSubscription(notification.subscriptionNotification.purchaseToken);
 
     const item = googlePlaySubscription.lineItems?.[0];
@@ -220,18 +355,38 @@ iap.post('/googleplay', async (c) => {
 
     await match(googlePlaySubscription.subscriptionState)
       .with('SUBSCRIPTION_STATE_ACTIVE', async () => {
+        const expiresAt = dayjs(item.expiryTime);
         if (subscription) {
-          await db
+          // 스냅샷 비교가 아닌 조건부 UPDATE 로 만료일 단조 증가를 원자적으로 보장한다(동시·역순 전달 대비).
+          // renewedAt 은 스냅샷이 아닌 갱신 시점의 실제 이전 만료일(행의 현재 값)을 쓴다.
+          // 동시 환불로 EXPIRED 가 된 행은 되살리지 않는다 — 웹훅 UPDATE 는 EXPIRED 를 벗어나게 하지 않는다(부활은 insert·재조정 경로만).
+          const renewed = await db
             .update(Subscriptions)
-            .set({
-              state: SubscriptionState.ACTIVE,
-              renewedAt: subscription.expiresAt,
-              expiresAt: dayjs(item.expiryTime),
-            })
-            .where(eq(Subscriptions.id, subscription.id));
-        } else {
+            .set({ state: SubscriptionState.ACTIVE, planId, renewedAt: sql`${Subscriptions.expiresAt}`, expiresAt })
+            .where(
+              and(
+                eq(Subscriptions.id, subscription.id),
+                ne(Subscriptions.state, SubscriptionState.EXPIRED),
+                lt(Subscriptions.expiresAt, expiresAt),
+              ),
+            )
+            .returning({ id: Subscriptions.id });
+
+          if (renewed.length === 0) {
+            // 만료일이 같은 재전송·상태 복구(재구독 등) — 상태·플랜만 동기화한다. 만료일이 이미 앞서 있으면 no-op.
+            await db
+              .update(Subscriptions)
+              .set({ state: SubscriptionState.ACTIVE, planId })
+              .where(
+                and(
+                  eq(Subscriptions.id, subscription.id),
+                  ne(Subscriptions.state, SubscriptionState.EXPIRED),
+                  eq(Subscriptions.expiresAt, expiresAt),
+                ),
+              );
+          }
+        } else if (expiresAt.isAfter(dayjs())) {
           const startsAt = dayjs(googlePlaySubscription.startTime);
-          const expiresAt = dayjs(item.expiryTime);
           await db
             .insert(Subscriptions)
             .values({
@@ -246,38 +401,71 @@ iap.post('/googleplay', async (c) => {
               target: [Subscriptions.userId],
               targetWhere: eq(Subscriptions.state, SubscriptionState.ACTIVE),
               set: { planId, startsAt, expiresAt, renewedAt: startsAt },
+              // 충돌하는 ACTIVE 행이 IAP 이고 만료일이 역행하지 않을 때만 갱신한다.
+              // 다른 채널(빌링키 등)의 ACTIVE 구독을 덮어쓰지 않고, stale 재전송이 최신 갱신을 되돌리지 못하게 한다.
+              setWhere: and(
+                inArray(
+                  Subscriptions.planId,
+                  db.select({ id: Plans.id }).from(Plans).where(eq(Plans.availability, PlanAvailability.IN_APP_PURCHASE)),
+                ),
+                lte(Subscriptions.expiresAt, expiresAt),
+              ),
             });
         }
       })
       .with('SUBSCRIPTION_STATE_EXPIRED', async () => {
         if (subscription) {
+          // SUBSCRIPTION_REVOKED(12)는 스토어가 확정한 중도 환불·철회이므로 만료일이 미래여도 즉시 회수한다.
+          // 자연 만료는 조회~갱신 사이 동시 갱신이 만료일을 미래로 올렸으면 건드리지 않는다(CAS).
+          const revoked = notification.subscriptionNotification?.notificationType === 12;
           await db
             .update(Subscriptions)
             .set({ state: SubscriptionState.EXPIRED, expiresAt: sql`LEAST(${Subscriptions.expiresAt}, NOW())` })
-            .where(eq(Subscriptions.id, subscription.id));
+            .where(
+              revoked
+                ? eq(Subscriptions.id, subscription.id)
+                : and(eq(Subscriptions.id, subscription.id), lte(Subscriptions.expiresAt, dayjs())),
+            );
         }
       })
       .with('SUBSCRIPTION_STATE_CANCELED', async () => {
         if (subscription) {
-          await db.update(Subscriptions).set({ state: SubscriptionState.WILL_EXPIRE }).where(eq(Subscriptions.id, subscription.id));
+          await db
+            .update(Subscriptions)
+            .set({ state: SubscriptionState.WILL_EXPIRE })
+            .where(and(eq(Subscriptions.id, subscription.id), ne(Subscriptions.state, SubscriptionState.EXPIRED)));
         }
       })
       .with('SUBSCRIPTION_STATE_IN_GRACE_PERIOD', async () => {
         if (subscription) {
-          await db.update(Subscriptions).set({ state: SubscriptionState.IN_GRACE_PERIOD }).where(eq(Subscriptions.id, subscription.id));
+          await db
+            .update(Subscriptions)
+            .set({ state: SubscriptionState.IN_GRACE_PERIOD })
+            .where(and(eq(Subscriptions.id, subscription.id), ne(Subscriptions.state, SubscriptionState.EXPIRED)));
         }
       })
       .with('SUBSCRIPTION_STATE_ON_HOLD', async () => {
         if (subscription) {
+          // 계정 보류(payment on hold): 권한은 없지만 복구 가능하므로 WILL_EXPIRE(만료일 경과)로 둔다.
+          // 조회~갱신 사이 동시 갱신이 만료일을 미래로 올렸으면 건드리지 않는다(CAS).
           await db
             .update(Subscriptions)
-            .set({ state: SubscriptionState.EXPIRED, expiresAt: sql`LEAST(${Subscriptions.expiresAt}, NOW())` })
-            .where(eq(Subscriptions.id, subscription.id));
+            .set({ state: SubscriptionState.WILL_EXPIRE, expiresAt: sql`LEAST(${Subscriptions.expiresAt}, NOW())` })
+            .where(
+              and(
+                eq(Subscriptions.id, subscription.id),
+                ne(Subscriptions.state, SubscriptionState.EXPIRED),
+                lte(Subscriptions.expiresAt, dayjs()),
+              ),
+            );
         }
       })
       .with('SUBSCRIPTION_STATE_PAUSED', async () => {
         if (subscription) {
-          await db.update(Subscriptions).set({ state: SubscriptionState.WILL_EXPIRE }).where(eq(Subscriptions.id, subscription.id));
+          await db
+            .update(Subscriptions)
+            .set({ state: SubscriptionState.WILL_EXPIRE })
+            .where(and(eq(Subscriptions.id, subscription.id), ne(Subscriptions.state, SubscriptionState.EXPIRED)));
         }
       })
       .with('SUBSCRIPTION_STATE_PENDING', 'SUBSCRIPTION_STATE_PENDING_PURCHASE_CANCELED', async () => {
@@ -292,25 +480,36 @@ iap.post('/googleplay', async (c) => {
         });
       });
   } else if (notification.voidedPurchaseNotification && notification.voidedPurchaseNotification.productType === 1) {
+    const purchaseToken = notification.voidedPurchaseNotification.purchaseToken;
+
     const inAppPurchase = await db
       .select({ userId: UserInAppPurchases.userId })
       .from(UserInAppPurchases)
-      .where(
-        and(
-          eq(UserInAppPurchases.identifier, notification.voidedPurchaseNotification.purchaseToken),
-          eq(UserInAppPurchases.store, InAppPurchaseStore.GOOGLE_PLAY),
-        ),
-      )
+      .where(and(eq(UserInAppPurchases.identifier, purchaseToken), eq(UserInAppPurchases.store, InAppPurchaseStore.GOOGLE_PLAY)))
       .then(first);
 
     if (inAppPurchase) {
-      const subscription = await getLiveInAppPurchaseSubscription(inAppPurchase.userId);
+      // 위조 방지: 엔드포인트 인증이 없으므로, 스토어가 실제로 종료(EXPIRED)를 확인해 준 경우에만 회수한다.
+      // CANCELED(만료 전까지 권한 유지)·IN_GRACE_PERIOD 등은 여전히 권한이 있으므로 "비-ACTIVE"를 회수 근거로 삼지 않는다.
+      // 조회 실패(일시적 오류)는 판정하지 않고 재시도한다 — 실결제 사용자 오만료 방지.
+      let revoked: boolean;
+      try {
+        const googlePlaySubscription = await googleplay.getSubscription(purchaseToken);
+        revoked = googlePlaySubscription.subscriptionState === 'SUBSCRIPTION_STATE_EXPIRED';
+      } catch (err) {
+        Sentry.captureException(err);
+        return c.json({ error: 'retry' }, 500);
+      }
 
-      if (subscription) {
-        await db
-          .update(Subscriptions)
-          .set({ state: SubscriptionState.EXPIRED, expiresAt: sql`LEAST(${Subscriptions.expiresAt}, NOW())` })
-          .where(eq(Subscriptions.id, subscription.id));
+      if (revoked) {
+        const subscription = await getLiveInAppPurchaseSubscription(inAppPurchase.userId);
+
+        if (subscription) {
+          await db
+            .update(Subscriptions)
+            .set({ state: SubscriptionState.EXPIRED, expiresAt: sql`LEAST(${Subscriptions.expiresAt}, NOW())` })
+            .where(eq(Subscriptions.id, subscription.id));
+        }
       }
     }
   } else {

--- a/apps/api/src/utils/payment.ts
+++ b/apps/api/src/utils/payment.ts
@@ -143,6 +143,13 @@ export const payAmountWithBillingKey = async (
         creditAmount,
         data: {},
       };
+    } else if (params.amount === 0) {
+      return {
+        status: 'succeeded',
+        billingAmount: 0,
+        creditAmount: 0,
+        data: {},
+      };
     }
 
     throw new Error('Invalid billing amount');
@@ -244,6 +251,16 @@ export const payInvoiceWithBillingKey = async (tx: Transaction, invoiceId: strin
         .update(UserPaymentCredits)
         .set({ amount: paymentCredit.amount - creditAmount })
         .where(eq(UserPaymentCredits.id, paymentCredit.id));
+
+      return true;
+    } else if (invoice.amount === 0) {
+      await tx.insert(PaymentRecords).values({
+        invoiceId: invoice.id,
+        outcome: PaymentOutcome.SUCCESS,
+        billingAmount: 0,
+        creditAmount: 0,
+        data: {},
+      });
 
       return true;
     }

--- a/apps/api/src/utils/plan.ts
+++ b/apps/api/src/utils/plan.ts
@@ -1,9 +1,9 @@
 import { PlanId } from '@typie/lib/const';
 import { SubscriptionState } from '@typie/lib/enums';
 import { TypieError } from '@typie/lib/errors';
-import { and, eq, inArray } from 'drizzle-orm';
+import dayjs from 'dayjs';
+import { and, eq, gt, inArray, or } from 'drizzle-orm';
 import { db, first, firstOrThrow, Subscriptions, UserTrials } from '#/db/index.ts';
-import type dayjs from 'dayjs';
 import type { Transaction } from '#/db/index.ts';
 
 export const ACTIVE_SUBSCRIPTION_STATES = [SubscriptionState.ACTIVE, SubscriptionState.WILL_EXPIRE, SubscriptionState.IN_GRACE_PERIOD];
@@ -13,10 +13,19 @@ type AssertActiveSubscriptionParams = {
 };
 
 export const hasActiveSubscription = async ({ userId }: { userId: string }) => {
+  // WILL_EXPIRE 는 만료일이 지나면(해지 확정·일시중지·보류 등) 권한이 없어야 한다. ACTIVE/IN_GRACE_PERIOD 는 상태만으로 판정한다.
   const subscription = await db
     .select({ id: Subscriptions.id })
     .from(Subscriptions)
-    .where(and(eq(Subscriptions.userId, userId), inArray(Subscriptions.state, ACTIVE_SUBSCRIPTION_STATES)))
+    .where(
+      and(
+        eq(Subscriptions.userId, userId),
+        or(
+          inArray(Subscriptions.state, [SubscriptionState.ACTIVE, SubscriptionState.IN_GRACE_PERIOD]),
+          and(eq(Subscriptions.state, SubscriptionState.WILL_EXPIRE), gt(Subscriptions.expiresAt, dayjs())),
+        ),
+      ),
+    )
     .then(first);
 
   return !!subscription;

--- a/apps/api/src/utils/user.ts
+++ b/apps/api/src/utils/user.ts
@@ -1,6 +1,14 @@
 import { EntityState } from '@typie/lib/enums';
 import { and, eq, sql, sum } from 'drizzle-orm';
+import * as uuid from 'uuid';
 import { db, DocumentContents, Documents, DocumentStates, Entities, firstOrThrow } from '#/db/index.ts';
+
+// 유저 id 로부터 결정적으로 파생하는 외부 계정 식별자. IAP 구매 시 appAccountToken / obfuscatedAccountId 로 쓰이며,
+// 등록/복구 시 스토어가 돌려준 계정 식별자와 대조해 다른 유저의 구매가 현재 세션에 바인딩되는 것을 막는다.
+// 네임스페이스 값 자체는 의미가 없고 그냥 임의로 고른 UUID다 — 안정적으로 고정돼 있기만 하면 된다(바꾸면 기존 식별자가 전부 달라짐).
+const USER_UUID_NAMESPACE = '1d394eb5-c61c-4c49-944e-05c9f9435adf';
+
+export const getUserUuid = (userId: string): string => uuid.v5(userId, USER_UUID_NAMESPACE);
 
 type GetUserUsageParams = {
   userId: string;

--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/platform/PurchaseService.android.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/platform/PurchaseService.android.kt
@@ -12,6 +12,7 @@ import com.android.billingclient.api.PendingPurchasesParams
 import com.android.billingclient.api.ProductDetails
 import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.QueryProductDetailsParams
+import com.android.billingclient.api.QueryPurchasesParams
 import kotlin.collections.mapNotNull
 import kotlin.collections.orEmpty
 import kotlin.coroutines.resume
@@ -57,10 +58,31 @@ internal class AndroidPurchaseService(private val context: Context) : PurchaseSe
   override suspend fun launch() {
     try {
       ensureConnected()
+      recoverPurchases()
     } catch (e: CancellationException) {
       throw e
     } catch (_: Exception) {
       // best effort
+    }
+  }
+
+  private suspend fun recoverPurchases() {
+    val params = QueryPurchasesParams.newBuilder().setProductType(ProductType.SUBS).build()
+
+    val purchases = suspendCancellableCoroutine { continuation ->
+      billingClient.queryPurchasesAsync(params) { billingResult, purchases ->
+        if (billingResult.responseCode == BillingResponseCode.OK) {
+          continuation.resume(purchases)
+        } else {
+          continuation.resume(emptyList())
+        }
+      }
+    }
+
+    for (purchase in purchases) {
+      if (!purchase.isAcknowledged) {
+        handlePurchase(purchase)
+      }
     }
   }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/subscription/Entitlement.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/subscription/Entitlement.kt
@@ -1,7 +1,16 @@
 package co.typie.domain.subscription
 
+import co.typie.graphql.type.PlanAvailability
 import co.typie.graphql.type.SubscriptionState
+import kotlin.time.Duration.Companion.days
 import kotlin.time.Instant
+
+// 유예 상한. refresh 실패 시 lastKnown 폴백(오프라인)에서 유예 상태가 무기한 유지되는 것만 막고, 온라인에서는 서버가 권위 있게 판정한다.
+// 채널별 정책이 달라 상한도 달리한다: 빌링키는 서버가 SUBSCRIPTION_GRACE_DAYS(7일) 후 만료시키고,
+// IAP 는 스토어 유예 최대치(App Store 최대 28일, Google Play 최대 30일)를 덮는다.
+// (이상적으로는 스토어별 실제 유예 마감일을 서버가 노출해 그에 맞춰 판정해야 한다 — 후속 과제)
+private val BILLING_KEY_GRACE_DURATION = 7.days
+private val STORE_GRACE_DURATION = 31.days
 
 sealed interface Entitlement {
   data object Unknown : Entitlement
@@ -11,12 +20,30 @@ sealed interface Entitlement {
   data object Expired : Entitlement
 }
 
+// 권한 판정이 뒤집히는 시각. 유예 중이면 만료일이 아니라 유예 상한이 마감이므로,
+// 시계 틱(오프라인 강등)도 이 시각에 맞춰 예약해야 한다.
+fun entitlementDeadline(subscription: Subscription): Instant =
+  if (subscription.state == SubscriptionState.IN_GRACE_PERIOD) {
+    val graceBound =
+      if (subscription.availability == PlanAvailability.BILLING_KEY) BILLING_KEY_GRACE_DURATION
+      else STORE_GRACE_DURATION
+    subscription.expiresAt + graceBound
+  } else {
+    subscription.expiresAt
+  }
+
 fun resolveEntitlement(subscription: Subscription?, now: Instant): Entitlement {
-  if (subscription == null || subscription.expiresAt <= now) {
+  if (subscription == null) {
     return Entitlement.Expired
   }
-  return Entitlement.Active(
-    subscription = subscription,
-    inGracePeriod = subscription.state == SubscriptionState.IN_GRACE_PERIOD,
-  )
+  if (subscription.state == SubscriptionState.IN_GRACE_PERIOD) {
+    if (now <= entitlementDeadline(subscription)) {
+      return Entitlement.Active(subscription = subscription, inGracePeriod = true)
+    }
+    return Entitlement.Expired
+  }
+  if (subscription.expiresAt <= now) {
+    return Entitlement.Expired
+  }
+  return Entitlement.Active(subscription = subscription, inGracePeriod = false)
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/subscription/SubscriptionPurchaseService.graphql
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/subscription/SubscriptionPurchaseService.graphql
@@ -2,6 +2,16 @@ query SubscriptionPurchaseService_Query {
   me {
     id
     uuid
+
+    subscription {
+      id
+      state
+
+      plan {
+        id
+        availability
+      }
+    }
   }
 }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/subscription/SubscriptionPurchaseService.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/subscription/SubscriptionPurchaseService.kt
@@ -8,14 +8,18 @@ import androidx.compose.runtime.snapshotFlow
 import co.typie.graphql.Apollo
 import co.typie.graphql.SubscriptionPurchaseService_Query
 import co.typie.graphql.SubscriptionPurchaseService_SubscribeOrChangePlanWithInAppPurchase_Mutation
+import co.typie.graphql.TypieError
 import co.typie.graphql.executeMutation
 import co.typie.graphql.type.InAppPurchaseStore
+import co.typie.graphql.type.PlanAvailability
 import co.typie.graphql.type.SubscribeOrChangePlanWithInAppPurchaseInput
 import co.typie.platform.ActivityContext
 import co.typie.platform.Platform
 import co.typie.platform.PlatformModule
 import co.typie.platform.PurchaseEvent
 import co.typie.platform.PurchaseProduct
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
@@ -51,6 +55,9 @@ object SubscriptionPurchaseService {
   private val _completions = MutableSharedFlow<Unit>()
   val completions: SharedFlow<Unit> = _completions
 
+  private val _failures = MutableSharedFlow<PurchaseFailure>()
+  val failures: SharedFlow<PurchaseFailure> = _failures
+
   var registrationGeneration by mutableStateOf(0L)
     private set
 
@@ -85,16 +92,34 @@ object SubscriptionPurchaseService {
 
   context(_: ActivityContext)
   suspend fun purchase(product: PurchaseProduct): Boolean {
-    val accountId =
+    val me =
       try {
-        Apollo.query(SubscriptionPurchaseService_Query()).execute().dataOrThrow().me.uuid
+        Apollo.query(SubscriptionPurchaseService_Query())
+          .fetchPolicy(FetchPolicy.NetworkOnly)
+          .execute()
+          .dataOrThrow()
+          .me
       } catch (e: CancellationException) {
         throw e
       } catch (_: Exception) {
+        _failures.emit(PurchaseFailure.PreflightFailed)
         return false
       }
 
-    return PlatformModule.purchaseService.purchase(product = product, accountId = accountId)
+    // 서버는 만료일과 무관하게 비-EXPIRED 상태의 타 채널 구독이 있으면 subscription_already_exists 로 거부한다.
+    // 앱 내 결제 후 과금됐는데 등록이 거부되는 것을 막기 위해, 캐시가 아닌 최신 서버 응답으로 동일 기준을 선차단한다.
+    // (me.subscription 은 비-EXPIRED 구독만 노출하므로 non-null 이면 서버가 거부한다)
+    val current = me.subscription
+    if (
+      current != null &&
+        current.plan.availability != PlanAvailability.IN_APP_PURCHASE &&
+        current.plan.availability != PlanAvailability.TRIAL
+    ) {
+      _failures.emit(PurchaseFailure.ConflictBeforePurchase)
+      return false
+    }
+
+    return PlatformModule.purchaseService.purchase(product = product, accountId = me.uuid)
   }
 
   suspend fun awaitRegistration(sinceGeneration: Long) {
@@ -139,12 +164,26 @@ object SubscriptionPurchaseService {
       }
     } catch (e: CancellationException) {
       throw e
+    } catch (e: TypieError) {
+      // 스토어 과금은 이미 발생했고 트랜잭션은 미완료로 남아 다음 앱 실행 시 자동 재시도된다
+      // (iOS 는 pending 재전송, Android 는 recoverPurchases). 여기서는 사유만 사용자에게 알린다.
+      when (e.code) {
+        "subscription_already_exists" -> _failures.emit(PurchaseFailure.ConflictAfterPurchase)
+        "in_app_purchase_account_mismatch" -> _failures.emit(PurchaseFailure.AccountMismatch)
+      }
     } catch (_: Exception) {
       // best effort
     } finally {
       registrationGeneration += 1
     }
   }
+}
+
+enum class PurchaseFailure {
+  ConflictBeforePurchase,
+  ConflictAfterPurchase,
+  AccountMismatch,
+  PreflightFailed,
 }
 
 internal fun storeProductIds(platform: Platform): List<String> =

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/subscription/SubscriptionService.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/subscription/SubscriptionService.kt
@@ -84,16 +84,18 @@ object SubscriptionService {
     }
 
     scope.launch {
-      snapshotFlow { subscription?.expiresAt }
+      // 만료일이 아닌 유효 판정 마감(유예 중이면 유예 상한)에 예약한다 — 만료일 틱만으로는
+      // 유예 상한 도달 시 재평가가 없어 오프라인 유예 권한이 무기한 유지된다.
+      snapshotFlow { subscription?.let(::entitlementDeadline) }
         .distinctUntilChanged()
-        .collectLatest { expiresAt ->
-          if (expiresAt == null) return@collectLatest
+        .collectLatest { deadline ->
+          if (deadline == null) return@collectLatest
           while (true) {
-            val remaining = expiresAt - Clock.System.now()
+            val remaining = deadline - Clock.System.now()
             if (!remaining.isPositive()) break
             delay(remaining)
           }
-          // 만료 시각 도달: 서버 판정 우선(갱신 결제가 반영됐으면 새 expiresAt으로 이 collect가 재시작됨),
+          // 판정 마감 도달: 서버 판정 우선(갱신 결제가 반영됐으면 새 마감으로 이 collect가 재시작됨),
           // 확인 불가(오프라인)면 clockTick 재평가로 비관 강등된다.
           query.refetch()
           clockTick += 1

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/subscription/enrollplan/EnrollPlanScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/subscription/enrollplan/EnrollPlanScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import co.typie.domain.subscription.PurchaseFailure
 import co.typie.domain.subscription.SubscriptionCelebrationSheet
 import co.typie.domain.subscription.SubscriptionFeatureList
 import co.typie.domain.subscription.SubscriptionPurchaseService
@@ -81,6 +82,20 @@ fun EnrollPlanScreen() {
     SubscriptionPurchaseService.completions.collect {
       sheet.present {
         SubscriptionCelebrationSheet(title = "구독이 시작됐어요!", message = "타이피의 모든 기능을 자유롭게 이용해보세요.")
+      }
+    }
+  }
+
+  LaunchedEffect(Unit) {
+    SubscriptionPurchaseService.failures.collect {
+      when (it) {
+        PurchaseFailure.ConflictBeforePurchase ->
+          toast.error("이미 이용 중인 구독이 있어 스토어 결제를 시작할 수 없어요. 웹사이트에서 기존 구독을 확인해주세요.")
+        PurchaseFailure.ConflictAfterPurchase ->
+          toast.error("이미 이용 중인 구독이 있어 스토어 결제를 등록하지 못했어요. 기존 구독이 정리되면 자동으로 다시 등록을 시도해요.")
+        PurchaseFailure.AccountMismatch ->
+          toast.error("이 스토어 결제는 다른 타이피 계정에 연결돼 있어요. 구매할 때 사용한 계정으로 로그인해주세요.")
+        PurchaseFailure.PreflightFailed -> toast.error("일시적인 오류가 발생했어요. 잠시 후 다시 시도해주세요.")
       }
     }
   }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/domain/subscription/EntitlementResolverTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/domain/subscription/EntitlementResolverTest.kt
@@ -5,6 +5,7 @@ import co.typie.graphql.type.SubscriptionState
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Instant
 
@@ -14,6 +15,7 @@ class EntitlementResolverTest {
   private fun subscription(
     state: SubscriptionState = SubscriptionState.ACTIVE,
     expiresAt: Instant = now + 1.hours,
+    availability: PlanAvailability = PlanAvailability.IN_APP_PURCHASE,
   ) =
     Subscription(
       id = "SUB1",
@@ -23,7 +25,7 @@ class EntitlementResolverTest {
       planId = "PL1",
       planName = "FULL ACCESS",
       fee = 4900,
-      availability = PlanAvailability.IN_APP_PURCHASE,
+      availability = availability,
     )
 
   @Test
@@ -47,6 +49,69 @@ class EntitlementResolverTest {
   }
 
   @Test
+  fun gracePeriodWithPastExpiryIsActive() {
+    val entitlement =
+      resolveEntitlement(
+        subscription(state = SubscriptionState.IN_GRACE_PERIOD, expiresAt = now - 1.hours),
+        now,
+      )
+    assertIs<Entitlement.Active>(entitlement)
+    assertEquals(true, entitlement.inGracePeriod)
+  }
+
+  @Test
+  fun gracePeriodWithinMaxDurationIsActive() {
+    val entitlement =
+      resolveEntitlement(
+        subscription(state = SubscriptionState.IN_GRACE_PERIOD, expiresAt = now - 25.days),
+        now,
+      )
+    assertIs<Entitlement.Active>(entitlement)
+    assertEquals(true, entitlement.inGracePeriod)
+  }
+
+  @Test
+  fun gracePeriodBeyondMaxDurationIsExpired() {
+    assertEquals(
+      Entitlement.Expired,
+      resolveEntitlement(
+        subscription(state = SubscriptionState.IN_GRACE_PERIOD, expiresAt = now - 40.days),
+        now,
+      ),
+    )
+  }
+
+  @Test
+  fun billingKeyGraceWithinPolicyIsActive() {
+    val entitlement =
+      resolveEntitlement(
+        subscription(
+          state = SubscriptionState.IN_GRACE_PERIOD,
+          expiresAt = now - 5.days,
+          availability = PlanAvailability.BILLING_KEY,
+        ),
+        now,
+      )
+    assertIs<Entitlement.Active>(entitlement)
+    assertEquals(true, entitlement.inGracePeriod)
+  }
+
+  @Test
+  fun billingKeyGraceBeyondPolicyIsExpired() {
+    assertEquals(
+      Entitlement.Expired,
+      resolveEntitlement(
+        subscription(
+          state = SubscriptionState.IN_GRACE_PERIOD,
+          expiresAt = now - 10.days,
+          availability = PlanAvailability.BILLING_KEY,
+        ),
+        now,
+      ),
+    )
+  }
+
+  @Test
   fun pastExpiryIsExpiredEvenWithStaleActiveState() {
     assertEquals(
       Entitlement.Expired,
@@ -57,5 +122,46 @@ class EntitlementResolverTest {
   @Test
   fun expiryAtExactNowIsExpired() {
     assertEquals(Entitlement.Expired, resolveEntitlement(subscription(expiresAt = now), now))
+  }
+
+  @Test
+  fun deadlineIsExpiryOutsideGrace() {
+    val sub = subscription()
+    assertEquals(sub.expiresAt, entitlementDeadline(sub))
+  }
+
+  @Test
+  fun deadlineIsGraceBoundInGrace() {
+    val storeSub =
+      subscription(state = SubscriptionState.IN_GRACE_PERIOD, expiresAt = now - 1.hours)
+    assertEquals(storeSub.expiresAt + 31.days, entitlementDeadline(storeSub))
+
+    val billingKeySub =
+      subscription(
+        state = SubscriptionState.IN_GRACE_PERIOD,
+        expiresAt = now - 1.hours,
+        availability = PlanAvailability.BILLING_KEY,
+      )
+    assertEquals(billingKeySub.expiresAt + 7.days, entitlementDeadline(billingKeySub))
+  }
+
+  @Test
+  fun entitlementFlipsAcrossDeadline() {
+    // 틱 루프가 이 마감에 예약되므로, 마감 전후로 판정이 실제로 뒤집혀야 오프라인 강등이 성립한다.
+    val subs =
+      listOf(
+        subscription(),
+        subscription(state = SubscriptionState.IN_GRACE_PERIOD, expiresAt = now - 1.hours),
+        subscription(
+          state = SubscriptionState.IN_GRACE_PERIOD,
+          expiresAt = now - 1.hours,
+          availability = PlanAvailability.BILLING_KEY,
+        ),
+      )
+    for (sub in subs) {
+      val deadline = entitlementDeadline(sub)
+      assertIs<Entitlement.Active>(resolveEntitlement(sub, deadline - 1.hours))
+      assertEquals(Entitlement.Expired, resolveEntitlement(sub, deadline + 1.hours))
+    }
   }
 }

--- a/apps/mobile/ios/Bridge/Sources/Bridge/SubscriptionPurchaseBridge.swift
+++ b/apps/mobile/ios/Bridge/Sources/Bridge/SubscriptionPurchaseBridge.swift
@@ -154,6 +154,7 @@ import StoreKit
     private func handleTransactionUpdate(_ result: VerificationResult<Transaction>) {
         switch result {
         case .verified(let transaction):
+            pendingTransactions[transaction.originalID] = transaction
             let payload = PurchaseEventPayload(
                 type: "restored",
                 productId: transaction.productID,
@@ -161,7 +162,6 @@ import StoreKit
                 transactionId: String(transaction.id),
             )
             purchaseObserver?(payload)
-            Task { await transaction.finish() }
         case .unverified:
             break
         }

--- a/apps/website/src/routes/website/(dashboard)/@preference/BillingTab.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@preference/BillingTab.svelte
@@ -70,6 +70,8 @@
   );
 
   const isTrial = $derived(user.data.subscription?.plan.availability === PlanAvailability.TRIAL);
+  const isBillingKey = $derived(user.data.subscription?.plan.availability === PlanAvailability.BILLING_KEY);
+  const isInAppPurchase = $derived(user.data.subscription?.plan.availability === PlanAvailability.IN_APP_PURCHASE);
 
   const [scheduleSubscriptionCancellation] = createMutation(
     graphql(`
@@ -212,6 +214,14 @@
               <span>
                 {dayjs(subscription.expiresAt).formatAsDate()}에 {comma(subscription.plan.fee)}원 결제 예정
               </span>
+            {:else if subscription.state === SubscriptionState.IN_GRACE_PERIOD}
+              <span class={css({ color: 'text.danger' })}>
+                결제에 실패했어요. {dayjs(subscription.expiresAt).formatAsDate()}까지 결제 수단을 확인해 주세요.
+              </span>
+            {:else if subscription.state === SubscriptionState.WILL_EXPIRE && user.data.nextSubscription}
+              <span>
+                {dayjs(subscription.expiresAt).formatAsDate()}에 다음 플랜으로 전환 예정
+              </span>
             {:else if subscription.state === SubscriptionState.WILL_EXPIRE}
               <span class={css({ color: 'text.danger' })}>
                 {dayjs(subscription.expiresAt).formatAsDate()} 해지 예정
@@ -223,7 +233,7 @@
           {/snippet}
         </SettingsRow>
 
-        {#if subscription.state === SubscriptionState.ACTIVE && !user.data.nextSubscription && PlanPair[subscription.plan.id as keyof typeof PlanPair]}
+        {#if subscription.state === SubscriptionState.ACTIVE && isBillingKey && !user.data.nextSubscription && PlanPair[subscription.plan.id as keyof typeof PlanPair]}
           <SettingsDivider />
 
           <SettingsRow>
@@ -266,7 +276,7 @@
           </SettingsRow>
         {/if}
 
-        {#if subscription.state === SubscriptionState.WILL_EXPIRE && !user.data.nextSubscription}
+        {#if subscription.state === SubscriptionState.WILL_EXPIRE && !user.data.nextSubscription && (isTrial || isBillingKey)}
           <SettingsDivider />
 
           {#if isTrial}
@@ -322,6 +332,12 @@
           {/if}
         {/if}
       </SettingsCard>
+
+      {#if isInAppPurchase}
+        <p class={css({ marginTop: '12px', fontSize: '13px', color: 'text.faint' })}>
+          이 구독은 앱에서 결제되었어요. 플랜 변경 및 해지는 App Store 또는 Google Play에서 관리할 수 있어요.
+        </p>
+      {/if}
 
       {#if user.data.nextSubscription}
         {@const nextSubscription = user.data.nextSubscription}
@@ -450,7 +466,7 @@
     </div>
   </div>
 
-  {#if user.data.subscription?.state === SubscriptionState.ACTIVE || user.data.subscription?.state === SubscriptionState.IN_GRACE_PERIOD}
+  {#if isBillingKey && (user.data.subscription?.state === SubscriptionState.ACTIVE || user.data.subscription?.state === SubscriptionState.IN_GRACE_PERIOD)}
     <!-- Subscription Cancellation Section -->
     <div>
       <h2 class={css({ fontSize: '16px', fontWeight: 'semibold', color: 'text.default', marginBottom: '24px' })}>구독 해지</h2>


### PR DESCRIPTION
- 플랜 변경 예약 시 갱신 크론이 빌링키를 삭제해 새 플랜이 영구 활성화 불능이던 문제 수정 — `renewal:cancel`이 빌링키 구독 취소 시 다른 live 빌링키 구독이 없을 때만 빌링키 삭제
- 트라이얼/IAP 만료가 유저의 웹 빌링키를 삭제하던 채널 교차 오염 차단
- `renewal:cancel`이 IAP 구독을 로컬 상태만으로 `EXPIRED` 처리하던 문제 수정(프로덕션에서 결제 구독 5건 파괴 확인) — IAP 배제 가드를 상태 변경 앞에 배치, 갱신·만료 크론 대상에서 IAP 제외
- `renewal:initial`/`plan-change` 잡에 행 잠금 + 처리시점 상태·만료 재검증 추가 → 재시도/동시 실행 시 이중청구·주기 이중전진 방지
- `renewal:retry`가 invoice/구독 상태를 재검증 → 취소된 invoice 재청구 및 `EXPIRED` 구독 부활 방지
- 갱신·환불·해지 경로의 락 순서를 `WILL_ACTIVATE` 구독 → 주 구독 → invoice로 통일 → PortOne 결제/환불 성공 후 DB만 롤백될 수 있던 교착 제거
- IAP 재조정 크론(`subscription:reconcile-iap`) 신설 — 매일 Apple/Google 재조회로 stale `ACTIVE` 정리, 유실된 갱신 복구(만료일 + 스토어 플랜 동기화); 판정은 순수 함수 `resolveReconcileAction`으로 추출 + 27케이스 매트릭스 테스트
- 재조정이 행 잠금 + 스냅샷 CAS로 웹훅과 직렬화, 조회·서명검증 실패는 throw(BullMQ 재시도 + Sentry), Google 404/410(토큰 제공 영구 중단)은 로컬 만료 경과 시 스토어 확인 만료로 처리 → 영구 재시도 루프 방지
- IAP 웹훅의 모든 만료일 기록을 조건부 UPDATE(만료일 단조 증가)로 원자화 → 최대 72시간 재전송되는 stale/역순 알림이 최신 갱신을 짧은 만료일로 되돌리던 문제 차단 (`DID_RENEW`·`DID_CHANGE_RENEWAL_PREF`·`RENEWAL_EXTENDED`·Google `SUBSCRIPTION_STATE_ACTIVE`·신규 구독 upsert)
- 웹훅 UPDATE가 `EXPIRED` 행을 되살리지 못하도록 전 핸들러에 상태 가드 → 동시 환불된 구독 부활 차단(부활은 insert·재조정 경로만)
- IAP 웹훅 신규 구독 생성 분기에 `expiresAt` 미래 가드 + 현재 스토어 자격 확인 추가 → 환불 이후 도착한 stale 갱신이 새 `ACTIVE` 구독을 만들던 창 제거
- 신규 구독 upsert에 `setWhere`(IAP 플랜 + 만료일 비역행 한정) → 동시 커밋된 빌링키 `ACTIVE` 구독을 IAP 값으로 덮어쓰지 않음 (웹훅·뮤테이션 동일)
- Apple `EXPIRED`/`GRACE_PERIOD_EXPIRED`가 현재 스토어 상태를 직접 조회해 판정 — `active`면 만료일 인상(`DID_RENEW` 유실 락아웃 방지), `suspended`는 `WILL_EXPIRE`(복구 가능 유지), `expired`만 CAS 회수, `revoked`는 즉시 회수, 조회 실패는 5xx로 재전송 유도
- Apple `DID_FAIL_TO_RENEW`에 서명 만료일 상한 → 갱신 이후 도착한 stale 실패 알림이 새 기간을 회수하던 문제 차단; `DID_CHANGE_RENEWAL_STATUS` 상태 전제를 WHERE로 원자화 + 유예 상태 덮어쓰기 가드
- Apple `DID_RENEW`·Google `SUBSCRIPTION_STATE_ACTIVE` 분기에서 `planId` 동기화 + `renewedAt`/`expiresAt` 역행 방지, `OFFER_REDEEMED`·`REFUND_REVERSED` 처리 추가
- Google `SUBSCRIPTION_REVOKED`(중도 환불)는 만료일이 미래여도 즉시 회수, 자연 만료만 CAS; `SUBSCRIPTION_STATE_ON_HOLD`/`SUBSCRIPTION_STATE_PAUSED`는 `WILL_EXPIRE`(복구 가능)
- transaction 없는 Apple 알림을 200 ack 처리(무한 재시도 방지), Google `getSubscription` 실패는 throw → Pub/Sub 재전송(조용한 알림 유실 제거)
- Google voided 알림을 스토어 재확인으로 하드닝(위조 강제 만료 방지)
- `appstore.getSubscriptionStatus` 신설 — 요청한 `originalTransactionId`와 일치하는 시리즈만 판정, `active`/`grace`/`suspended`/`expired`/`revoked`/`unknown`/`error` 구분, 유예 마감은 `renewalInfo`의 `gracePeriodExpiresDate` 사용
- IAP 등록 뮤테이션에 계정 소유권 검증 — `appAccountToken`/`obfuscatedExternalAccountId`를 세션 파생 UUID(v5)와 대조해 불일치 거부 (`User.uuid` 노출, `getUserUuid` 유틸 추출)
- Google 만료 후 구독 센터 재구독의 `outOfAppPurchaseContext` 검증 — 이전 계정 식별자 대조 + 계정 증빙 없는 구매의 이전 토큰이 타 계정 소유면 배정 거부
- `linkedPurchaseToken`/`expiredPurchaseToken` 마이그레이션 — 이전 토큰을 보유한 다른 계정의 구독 만료 + 바인딩 제거 → 스토어 결제 1건이 여러 계정에 동시 활성화되는 것 차단
- `cancelSubscriptionCancellation`에 `BILLING_KEY` 필터 + `WILL_ACTIVATE` 공존 거부 → 트라이얼 무료 승격 및 이중 `ACTIVE` 차단
- `schedulePlanChange`·`cancelPlanChange`에 `BILLING_KEY` 필터 추가
- `adminRefundPayment`가 구독 우선 잠금으로 갱신 잡과 직렬화, `expiresAt`를 `LEAST`로 설정하고 관련 미결제 invoice 정리
- amount=0 인보이스가 결제 실패로 처리되던 문제 → no-op 성공 처리
- `hasActiveSubscription`이 `WILL_EXPIRE`를 만료일이 미래일 때만 활성으로 판정
- 구 크론이 잘못 만료시킨 IAP 구독 복구용 1회성 백필 스크립트(`scripts/backfill-iap-expired.ts`) 추가 — 스토어 실활성만 재활성(환불 부활 위험 없음), `DRY_RUN` 지원
- 웹 BillingTab에서 IAP 구독자에게 빌링키 전용 버튼 숨김 + 스토어 관리 안내, 유예/플랜 전환 예정 문구 추가
- 모바일 `resolveEntitlement`가 `IN_GRACE_PERIOD`를 만료로 오판정하지 않도록 수정 + 오프라인 유예 상한을 채널별(빌링키 7일/스토어 31일)로 적용 (+회귀 테스트)
- 모바일 시계 틱을 만료일이 아닌 판정 마감(`entitlementDeadline`)에 예약 → 오프라인에서 유예 상한 도달 후에도 권한이 무기한 유지되던 문제 수정
- iOS restored 트랜잭션을 서버 등록 성공 후 finish, Android 앱 시작 시 미승인 구매 복구 경로 추가
- 모바일에서 다른 채널로 활성 구독 중이면 앱 내 결제 차단 (과금 후 서버 거부 방지) — 캐시가 아닌 최신 서버 상태로 선차단
- 모바일 결제 실패를 토스트로 표면화 — 선차단/과금 후 등록 거부/계정 불일치/일시 오류 구분 안내 (기존엔 조용히 무시)