### PR TITLE
앱 에디터에서 이미지와 파일 붙여넣기 지원

### DIFF
--- a/apps/mobile/compose/src/androidHostTest/kotlin/co/typie/platform/AndroidIncomingContentTest.kt
+++ b/apps/mobile/compose/src/androidHostTest/kotlin/co/typie/platform/AndroidIncomingContentTest.kt
@@ -1,0 +1,148 @@
+package co.typie.platform
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.test.runTest
+import kotlinx.io.Buffer
+
+class AndroidIncomingContentTest {
+  private data class Item(
+    val source: Source,
+    val html: String? = null,
+    val rawText: String? = null,
+    val coercedText: String? = null,
+    val attachment: IncomingContentItem? = null,
+    val unreadable: Boolean = false,
+  )
+
+  private enum class Source {
+    Uri,
+    Intent,
+    Other,
+  }
+
+  @Test
+  fun uriAndIntentUseCoercedTextWhenRawTextIsAbsent() = runTest {
+    for (source in listOf(Source.Uri, Source.Intent)) {
+      val candidates =
+        readAndroidIncomingContent(
+          clipItems = listOf(Item(source = source, coercedText = "$source fallback")),
+          html = Item::html,
+          rawText = Item::rawText,
+          coerceText = Item::coercedText,
+          materialize = { item -> item.attachment },
+        )
+
+      assertEquals("$source fallback", candidates?.text)
+      candidates?.close()
+    }
+  }
+
+  @Test
+  fun nonemptyHtmlSkipsAndroidAttachmentMaterialization() = runTest {
+    var materializations = 0
+
+    val candidates =
+      readAndroidIncomingContent(
+        clipItems = listOf(Item(source = Source.Other, html = "<p>rich</p>")),
+        html = Item::html,
+        rawText = Item::rawText,
+        coerceText = Item::coercedText,
+        materialize = {
+          materializations += 1
+          it.attachment
+        },
+      )
+
+    assertEquals(0, materializations)
+    assertEquals("<p>rich</p>", candidates?.html)
+    candidates?.close()
+  }
+
+  @Test
+  fun unreadableAttachmentDoesNotDiscardReadableSiblings() = runTest {
+    val readable = imageItem {}
+    val candidates =
+      readAndroidIncomingContent(
+        clipItems =
+          listOf(
+            Item(source = Source.Uri, attachment = readable),
+            Item(source = Source.Uri, unreadable = true),
+          ),
+        html = Item::html,
+        rawText = Item::rawText,
+        coerceText = Item::coercedText,
+        materialize = { item ->
+          if (item.unreadable) error("unreadable")
+          item.attachment
+        },
+      )
+
+    assertEquals(listOf(readable), candidates?.items)
+    assertEquals(1, candidates?.unreadableItemCount)
+    candidates?.close()
+  }
+
+  @Test
+  fun cancellationClosesPartiallyLoadedFilesExactlyOnce() = runTest {
+    var releases = 0
+    val firstLoaded = CompletableDeferred<Unit>()
+    val never = CompletableDeferred<Unit>()
+    val loading = async {
+      loadOwnedIncomingContentItems(
+        listOf(
+          { imageItem { releases += 1 }.also { firstLoaded.complete(Unit) } },
+          {
+            never.await()
+            null
+          },
+        )
+      )
+    }
+    firstLoaded.await()
+
+    loading.cancelAndJoin()
+
+    assertEquals(1, releases)
+  }
+
+  @Test
+  fun siblingFailurePreservesLoadedFilesAndCountsUnreadable() = runTest {
+    var releases = 0
+    val firstLoaded = CompletableDeferred<Unit>()
+
+    val loaded =
+      loadOwnedIncomingContentItems(
+        listOf(
+          { imageItem { releases += 1 }.also { firstLoaded.complete(Unit) } },
+          {
+            firstLoaded.await()
+            error("provider failed")
+          },
+        )
+      )
+
+    assertEquals(1, loaded.unreadableItemCount)
+    loaded.items.forEach { it.file.close() }
+    assertEquals(1, releases)
+  }
+
+  private fun imageItem(onRelease: () -> Unit): IncomingContentItem =
+    IncomingContentItem(
+      kind = IncomingContentItem.Kind.Image,
+      file =
+        PickedFile(
+          filename = "image.png",
+          mimeType = "image/png",
+          size = 1,
+          previewModel = Unit,
+          imageWidth = 1,
+          imageHeight = 1,
+          openSource = { Buffer() },
+          release = onRelease,
+        ),
+    )
+}

--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/input/EditorInput.android.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/input/EditorInput.android.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.platform.PlatformTextInputSessionScope
 import androidx.compose.ui.text.input.EditCommand
 import co.typie.editor.Editor
 import co.typie.editor.scroll.EditorBringIntoViewRequests
+import co.typie.platform.IncomingContentCandidates
 import java.util.WeakHashMap
 
 // Keyed per editor so notifyImeStateChanged can forward extracted-text
@@ -30,6 +31,7 @@ internal actual suspend fun PlatformTextInputSessionScope.createEditorInputReque
   textClippingRectInRoot: () -> Rect?,
   suppressSoftwareKeyboard: Boolean,
   isSessionCurrent: () -> Boolean,
+  onIncomingContent: (IncomingContentCandidates) -> Boolean,
 ): PlatformTextInputMethodRequest {
   val androidView = view
   val extractMonitor = ImeExtractMonitor()
@@ -40,6 +42,7 @@ internal actual suspend fun PlatformTextInputSessionScope.createEditorInputReque
         InputType.TYPE_TEXT_FLAG_MULTI_LINE or
         InputType.TYPE_TEXT_FLAG_CAP_SENTENCES
     outAttrs.imeOptions = EditorInfo.IME_ACTION_NONE or EditorInfo.IME_FLAG_NO_EXTRACT_UI
+    outAttrs.contentMimeTypes = arrayOf("*/*")
     val ctx = editor.tickIme
     outAttrs.initialSelStart = ctx?.let { it.windowUtf16Offset(it.selection.start) } ?: -1
     outAttrs.initialSelEnd = ctx?.let { it.windowUtf16Offset(it.selection.end) } ?: -1
@@ -50,6 +53,7 @@ internal actual suspend fun PlatformTextInputSessionScope.createEditorInputReque
         bringIntoViewRequests = bringIntoViewRequests,
         extractMonitor = extractMonitor,
         isSessionCurrent = isSessionCurrent,
+        onIncomingContent = onIncomingContent,
       )
     if (suppressSoftwareKeyboard) {
       androidView.post { hideEditorSoftwareKeyboard(androidView) }

--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/input/EditorInputConnection.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/input/EditorInputConnection.kt
@@ -24,6 +24,9 @@ import co.typie.editor.ffi.Message
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.EditorBringIntoViewTarget
 import co.typie.editor.scroll.syncWithBringIntoView
+import co.typie.platform.IncomingContentCandidates
+import co.typie.platform.IncomingContentItem
+import co.typie.platform.readPlatformFile
 import java.util.concurrent.Executor
 import java.util.function.IntConsumer
 
@@ -65,6 +68,7 @@ internal class EditorInputConnection(
   private val bringIntoViewRequests: EditorBringIntoViewRequests,
   private val extractMonitor: ImeExtractMonitor,
   isSessionCurrent: () -> Boolean,
+  private val onIncomingContent: (IncomingContentCandidates) -> Boolean,
 ) : InputConnection {
   private val batch =
     ImeEditBatch(isSessionCurrent) { messages ->
@@ -298,7 +302,60 @@ internal class EditorInputConnection(
     inputContentInfo: InputContentInfo,
     flags: Int,
     opts: Bundle?,
-  ): Boolean = false
+  ): Boolean {
+    val permissionRequested = flags and InputConnection.INPUT_CONTENT_GRANT_READ_URI_PERMISSION != 0
+    var permissionOwned = false
+    return try {
+      if (permissionRequested) {
+        inputContentInfo.requestPermission()
+        permissionOwned = true
+      }
+      val fallbackMimeType =
+        inputContentInfo.description.let { description ->
+          (0 until description.mimeTypeCount).firstNotNullOfOrNull { index ->
+            description.getMimeType(index)?.takeIf { it != "*/*" }
+          }
+        }
+      val file =
+        view.context.readPlatformFile(
+          uri = inputContentInfo.contentUri,
+          fallbackMimeType = fallbackMimeType,
+          release = {
+            if (permissionOwned) {
+              permissionOwned = false
+              runCatching(inputContentInfo::releasePermission)
+            }
+          },
+        )
+      val candidates =
+        IncomingContentCandidates(
+          items =
+            listOf(
+              IncomingContentItem(
+                kind =
+                  if (file.mimeType?.substringBefore('/') == "image") {
+                    IncomingContentItem.Kind.Image
+                  } else {
+                    IncomingContentItem.Kind.File
+                  },
+                file = file,
+              )
+            )
+        )
+      try {
+        onIncomingContent(candidates).also { accepted -> if (!accepted) candidates.close() }
+      } catch (error: Throwable) {
+        candidates.close()
+        throw error
+      }
+    } catch (_: Throwable) {
+      if (permissionOwned) {
+        permissionOwned = false
+        runCatching(inputContentInfo::releasePermission)
+      }
+      false
+    }
+  }
 
   override fun commitCompletion(text: CompletionInfo?): Boolean = false
 

--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/input/EditorPlatformInputBridge.android.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/input/EditorPlatformInputBridge.android.kt
@@ -13,11 +13,17 @@ internal actual class EditorPlatformInputBridge actual constructor() {
 
   actual fun onPreKeyEvent(
     event: KeyEvent,
-    editorState: () -> EditorState,
     inputCoroutineScope: CoroutineScope,
-    bindingMessages: suspend () -> List<Message>,
-    commit: suspend (List<Message>) -> EditorState?,
+    onAccepted: () -> Unit,
   ): Boolean = false
+
+  actual suspend fun dispatchAppOwnedKeyMessages(
+    messages: List<Message>,
+    preState: EditorState,
+    dispatch: suspend () -> EditorState?,
+  ) {
+    dispatch()
+  }
 
   actual fun shouldConsumeKeyEvent(event: KeyEvent): Boolean = false
 

--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/platform/FilePicker.android.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/platform/FilePicker.android.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.platform.LocalContext
+import java.io.File
 import kotlinx.io.asSource
 import kotlinx.io.buffered
 
@@ -52,8 +53,12 @@ actual fun rememberFilePicker(
   }
 }
 
-private fun Context.readPlatformFile(uri: Uri): PickedFile {
-  val mimeType = contentResolver.getType(uri)
+internal fun Context.readPlatformFile(
+  uri: Uri,
+  fallbackMimeType: String? = null,
+  release: () -> Unit = {},
+): PickedFile {
+  val mimeType = contentResolver.getType(uri) ?: fallbackMimeType
   val metadata = queryMetadata(uri)
   val imageSize = decodeImageSizeIfNeeded(uri, mimeType)
 
@@ -72,7 +77,45 @@ private fun Context.readPlatformFile(uri: Uri): PickedFile {
       contentResolver.openInputStream(uri)?.asSource()?.buffered()
         ?: error("Unable to open selected file")
     },
+    release = release,
   )
+}
+
+internal fun Context.copyClipboardFile(uri: Uri, fallbackMimeType: String? = null): PickedFile {
+  val mimeType = contentResolver.getType(uri) ?: fallbackMimeType
+  val metadata = queryMetadata(uri)
+  val directory = File(cacheDir, "incoming-clipboard").apply { mkdirs() }
+  val ownedFile = File.createTempFile("clipboard-", ".tmp", directory)
+
+  try {
+    contentResolver.openInputStream(uri)?.use { input ->
+      ownedFile.outputStream().use { output -> input.copyTo(output) }
+    } ?: error("Unable to open clipboard file")
+    val imageSize =
+      if (mimeType?.substringBefore('/') == "image") {
+        val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeFile(ownedFile.path, options)
+        options.outWidth
+          .takeIf { it > 0 }
+          ?.let { width -> options.outHeight.takeIf { it > 0 }?.let { height -> width to height } }
+      } else {
+        null
+      }
+
+    return PickedFile(
+      filename = pickedFilename(metadata.filename, mimeType),
+      mimeType = mimeType,
+      size = metadata.size ?: ownedFile.length(),
+      previewModel = ownedFile,
+      imageWidth = imageSize?.first,
+      imageHeight = imageSize?.second,
+      openSource = { ownedFile.inputStream().asSource().buffered() },
+      release = { ownedFile.delete() },
+    )
+  } catch (error: Throwable) {
+    ownedFile.delete()
+    throw error
+  }
 }
 
 private data class FileMetadata(val filename: String?, val size: Long?)

--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/platform/PlatformServiceModule.android.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/platform/PlatformServiceModule.android.kt
@@ -10,6 +10,7 @@ import android.os.Environment
 import android.provider.MediaStore
 import androidx.core.content.FileProvider
 import java.io.File
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -74,19 +75,84 @@ internal class AndroidClipboard(private val context: Context) : Clipboard {
         .getOrDefault(false)
     }
 
-  override suspend fun paste(): ClipboardReadPayload? =
-    withContext(Dispatchers.IO) {
-      runCatching {
+  override suspend fun paste(): IncomingContentCandidates? =
+    loadOwnedIncomingContentCandidates(Dispatchers.IO) {
+      try {
         val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-        val clip = clipboard.primaryClip ?: return@runCatching null
-        if (clip.itemCount == 0) return@runCatching null
-        val item = clip.getItemAt(0)
-        val html = item.htmlText
-        val text = item.coerceToText(context).toString()
-        ClipboardReadPayload(html = html, text = text)
+        val clip = clipboard.primaryClip ?: return@loadOwnedIncomingContentCandidates null
+        if (clip.itemCount == 0) return@loadOwnedIncomingContentCandidates null
+        val clipItems = List(clip.itemCount, clip::getItemAt)
+        readAndroidIncomingContent(
+          clipItems = clipItems,
+          html = { item -> item.htmlText },
+          rawText = { item -> item.text },
+          coerceText = { item -> item.coerceToText(context) },
+          materialize = { item ->
+            val uri = item.uri ?: item.intent?.data
+            if (uri == null) {
+              null
+            } else {
+              val file = context.copyClipboardFile(uri)
+              IncomingContentItem(
+                kind =
+                  if (file.mimeType?.substringBefore('/') == "image") {
+                    IncomingContentItem.Kind.Image
+                  } else {
+                    IncomingContentItem.Kind.File
+                  },
+                file = file,
+              )
+            }
+          },
+        )
+      } catch (error: CancellationException) {
+        throw error
+      } catch (_: Throwable) {
+        null
       }
-        .getOrNull()
     }
+}
+
+internal suspend fun <T> readAndroidIncomingContent(
+  clipItems: List<T>,
+  html: (T) -> String?,
+  rawText: (T) -> CharSequence?,
+  coerceText: (T) -> CharSequence?,
+  materialize: suspend (T) -> IncomingContentItem?,
+): IncomingContentCandidates? {
+  val richHtml = clipItems.firstNotNullOfOrNull { item -> html(item)?.takeIf(String::isNotEmpty) }
+  val directText = clipItems.firstNotNullOfOrNull { item ->
+    rawText(item)?.toString()?.takeIf(String::isNotEmpty)
+  }
+  val text =
+    directText
+      ?: if (richHtml == null) {
+        clipItems.firstNotNullOfOrNull { item ->
+          coerceText(item)?.toString()?.takeIf(String::isNotEmpty)
+        }
+      } else {
+        null
+      }
+
+  return materializeIncomingContentCandidates(html = richHtml, text = text) {
+    val loaded = mutableListOf<IncomingContentItem>()
+    var unreadableItemCount = 0
+    try {
+      for (item in clipItems) {
+        try {
+          materialize(item)?.let(loaded::add)
+        } catch (error: CancellationException) {
+          throw error
+        } catch (_: Throwable) {
+          unreadableItemCount += 1
+        }
+      }
+      LoadedIncomingContentItems(loaded, unreadableItemCount)
+    } catch (error: Throwable) {
+      loaded.forEach { it.file.close() }
+      throw error
+    }
+  }
 }
 
 internal class AndroidFileSystem(private val context: Context) : FileSystem {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Editor.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Editor.kt
@@ -194,76 +194,79 @@ internal constructor(
 
   internal fun quiesceLocalEdits(): LocalEditQuiescence = localEdits.quiesce()
 
-  suspend fun await(beforeCommit: ((EditorState) -> Unit)? = null, block: EditorScope.() -> Unit) {
-    try {
-      awaitOrThrow(beforeCommit = beforeCommit, mapEvents = { Unit }, block = block)
-    } catch (e: CancellationException) {
-      throw e
-    } catch (e: Throwable) {
-      notifyFailure(e)
-      throw e
-    }
-  }
+  suspend fun await(
+    beforeCommit: ((EditorState) -> Unit)? = null,
+    admit: () -> Boolean = { true },
+    block: EditorScope.() -> Unit,
+  ): Boolean =
+    await(beforeCommit = beforeCommit, admit = admit, mapEvents = { Unit }, block = block) != null
 
-  private suspend fun <T : Any> awaitOrThrow(
+  internal suspend fun <T : Any> await(
     beforeCommit: ((EditorState) -> Unit)? = null,
     admit: () -> Boolean = { true },
     mapEvents: (List<EditorEvent>) -> T,
     block: EditorScope.() -> Unit,
   ): T? {
-    val messages = mutableListOf<Message>()
-    val collector =
-      object : EditorScope {
-        override fun enqueue(message: Message) {
-          messages += message
-        }
-      }
-    block(collector)
-    if (messages.isEmpty()) return mapEvents(emptyList())
-
-    return localEdits.run {
-      val tick: EditorAwaitTick<T>? =
-        withContext(NonCancellable + dispatcher) {
-          mutex.withLock {
-            if (disposed.load()) throw CancellationException("Editor disposed")
-            if (!admit()) return@withLock null
-            for (m in messages) inner.enqueue(m)
-            val e = inner.tick()
-            val version = versionCounter.addAndFetch(1L)
-            val s = readSnapshot(version = version, events = e)
-            EditorAwaitTick(events = e, snapshot = s, value = mapEvents(e))
+    try {
+      val messages = mutableListOf<Message>()
+      val collector =
+        object : EditorScope {
+          override fun enqueue(message: Message) {
+            messages += message
           }
         }
-      if (tick == null) return@run null
-      val (events, snapshot, value) = tick
+      block(collector)
+      if (messages.isEmpty()) return mapEvents(emptyList())
 
-      val pending: PendingSettle? =
-        if (events.any { it is EditorEvent.RenderInvalidated }) {
-          val initial = attachedPages.load()
-          if (initial.isEmpty()) null
-          else
-            PendingSettle(initial, requiredVersion = snapshot.version).also {
-              pendingSettles.updatePersistent { list -> list.add(it) }
+      return localEdits.run {
+        val tick: EditorAwaitTick<T>? =
+          withContext(NonCancellable + dispatcher) {
+            mutex.withLock {
+              if (disposed.load()) throw CancellationException("Editor disposed")
+              if (!admit()) return@withLock null
+              for (m in messages) inner.enqueue(m)
+              val e = inner.tick()
+              val version = versionCounter.addAndFetch(1L)
+              val s = readSnapshot(version = version, events = e)
+              EditorAwaitTick(events = e, snapshot = s, value = mapEvents(e))
             }
-        } else null
+          }
+        if (tick == null) return@run null
+        val (events, snapshot, value) = tick
 
-      try {
-        emit(events)
-        pending?.await()
-      } finally {
-        if (pending != null) {
-          pendingSettles.updatePersistent { it.remove(pending) }
-        }
-        withContext(NonCancellable) {
-          mutex.withLock {
-            if (!disposed.load()) {
-              beforeCommit?.invoke(snapshot)
-              commit(snapshot)
+        val pending: PendingSettle? =
+          if (events.any { it is EditorEvent.RenderInvalidated }) {
+            val initial = attachedPages.load()
+            if (initial.isEmpty()) null
+            else
+              PendingSettle(initial, requiredVersion = snapshot.version).also {
+                pendingSettles.updatePersistent { list -> list.add(it) }
+              }
+          } else null
+
+        try {
+          emit(events)
+          pending?.await()
+        } finally {
+          if (pending != null) {
+            pendingSettles.updatePersistent { it.remove(pending) }
+          }
+          withContext(NonCancellable) {
+            mutex.withLock {
+              if (!disposed.load()) {
+                beforeCommit?.invoke(snapshot)
+                commit(snapshot)
+              }
             }
           }
         }
+        value
       }
-      value
+    } catch (e: CancellationException) {
+      throw e
+    } catch (e: Throwable) {
+      notifyFailure(e)
+      throw e
     }
   }
 
@@ -389,56 +392,39 @@ internal constructor(
     ranges: List<ProseTrackedRangeRegistration>,
     isCurrent: () -> Boolean,
   ): ProseRangeInstallOutcome? {
-    try {
-      val outcome =
-        awaitOrThrow(
-          admit = isCurrent,
-          mapEvents = { events ->
-            val matches = events.filterIsInstance<EditorEvent.ProseRangeInstallResult>()
-            check(matches.size == 1) {
-              "Expected exactly one prose range install result, got ${matches.size}"
-            }
-            matches.single().outcome
-          },
-        ) {
-          enqueue(
-            Message.TrackedRange(
-              TrackedRangeOp.ReplaceGroupsFromProse(
-                expectedText = expectedText,
-                groups = groups,
-                ranges = ranges,
-              )
+    val outcome =
+      await(
+        admit = isCurrent,
+        mapEvents = { events ->
+          val matches = events.filterIsInstance<EditorEvent.ProseRangeInstallResult>()
+          check(matches.size == 1) {
+            "Expected exactly one prose range install result, got ${matches.size}"
+          }
+          matches.single().outcome
+        },
+      ) {
+        enqueue(
+          Message.TrackedRange(
+            TrackedRangeOp.ReplaceGroupsFromProse(
+              expectedText = expectedText,
+              groups = groups,
+              ranges = ranges,
             )
           )
-        }
-      return outcome?.takeIf { isCurrent() }
-    } catch (e: CancellationException) {
-      throw e
-    } catch (e: Throwable) {
-      notifyFailure(e)
-      throw e
-    }
+        )
+      }
+    return outcome?.takeIf { isCurrent() }
   }
 
   internal suspend fun clearTrackedRangeGroups(
     groups: List<String>,
     admit: () -> Boolean = { true },
-  ): Boolean {
-    try {
-      val result =
-        awaitOrThrow(admit = admit, mapEvents = { Unit }) {
-          groups.forEach { group ->
-            enqueue(Message.TrackedRange(TrackedRangeOp.ClearGroup(group = group)))
-          }
-        }
-      return result != null
-    } catch (e: CancellationException) {
-      throw e
-    } catch (e: Throwable) {
-      notifyFailure(e)
-      throw e
-    }
-  }
+  ): Boolean =
+    await(admit = admit, mapEvents = { Unit }) {
+      groups.forEach { group ->
+        enqueue(Message.TrackedRange(TrackedRangeOp.ClearGroup(group = group)))
+      }
+    } != null
 
   private fun scheduleTick() {
     if (!queued.compareAndSet(expectedValue = false, newValue = true)) return
@@ -953,7 +939,7 @@ internal constructor(
             EditorRegistry.register(editor)
             try {
               PlatformModule.editorHost.setThemeVariant(themeVariant)
-              editor.awaitOrThrow(mapEvents = { Unit }) {
+              editor.await(mapEvents = { Unit }) {
                 enqueue(Message.System(SystemEvent.ThemeVariantChanged))
                 enqueue(Message.System(SystemEvent.Initialize))
               }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorView.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorView.kt
@@ -28,6 +28,7 @@ import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.SystemEvent
 import co.typie.editor.ffi.ThemeVariant
 import co.typie.editor.ffi.Viewport
+import co.typie.editor.input.LocalEditorIncomingContentHandler
 import co.typie.editor.input.editorInput
 import co.typie.editor.overlay.EditorCursorOverlay
 import co.typie.editor.overlay.EditorLineHighlightOverlay
@@ -57,6 +58,7 @@ internal fun EditorView(
   val runtime = LocalEditorRuntime.current
   val uiState = LocalEditorUiState.current
   val bringIntoViewRequests = LocalEditorBringIntoViewRequests.current
+  val incomingContentHandler = LocalEditorIncomingContentHandler.current
   val zoomController = LocalEditorZoomController.current
   val displayZoom = zoomController.displayZoom
   val themeVariant = currentEditorThemeVariant()
@@ -184,6 +186,7 @@ internal fun EditorView(
             bringIntoViewRequests = bringIntoViewRequests,
             suppressSoftwareKeyboard = suppressSoftwareKeyboard,
             clipboard = PlatformModule.clipboard,
+            incomingContentHandler = incomingContentHandler,
           )
           .focusable()
       } else {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Keyboard.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Keyboard.kt
@@ -26,6 +26,7 @@ import co.typie.editor.ffi.SelectionExpansionUnit
 import co.typie.editor.ffi.SelectionOp
 import co.typie.editor.scroll.EditorBringIntoViewTarget
 import co.typie.platform.Clipboard
+import co.typie.platform.IncomingContentMode
 import co.typie.platform.Platform
 
 internal enum class KeyModifier {
@@ -35,17 +36,41 @@ internal enum class KeyModifier {
   Alt,
 }
 
+internal sealed interface EditorKeyBindingAction {
+  data class Messages(
+    // Only actions that emit constant messages without reading editor or clipboard state may
+    // coalesce with neighboring key events.
+    val coalescible: Boolean,
+    val messages: suspend Editor.(Clipboard) -> List<Message>,
+  ) : EditorKeyBindingAction
+
+  data class Paste(val mode: IncomingContentMode) : EditorKeyBindingAction
+}
+
 internal data class KeyBinding(
   val key: ComposeKey,
   val modifiers: Set<KeyModifier> = emptySet(),
   val predicate: (() -> Boolean)? = null,
   val bringIntoViewTarget: EditorBringIntoViewTarget? =
     EditorBringIntoViewTarget.CurrentSelectionHead,
-  // Only bindings whose action emits constant messages without reading editor or
-  // clipboard state may coalesce with neighboring key events.
-  val coalescible: Boolean = true,
-  val action: suspend Editor.(Clipboard) -> List<Message>,
-)
+  val action: EditorKeyBindingAction,
+) {
+  constructor(
+    key: ComposeKey,
+    modifiers: Set<KeyModifier> = emptySet(),
+    predicate: (() -> Boolean)? = null,
+    bringIntoViewTarget: EditorBringIntoViewTarget? =
+      EditorBringIntoViewTarget.CurrentSelectionHead,
+    coalescible: Boolean = true,
+    action: suspend Editor.(Clipboard) -> List<Message>,
+  ) : this(
+    key = key,
+    modifiers = modifiers,
+    predicate = predicate,
+    bringIntoViewTarget = bringIntoViewTarget,
+    action = EditorKeyBindingAction.Messages(coalescible = coalescible, messages = action),
+  )
+}
 
 private fun move(movement: Movement, extend: Boolean): Message =
   Message.Navigation(NavigationOp.Move(movement, extend))
@@ -372,20 +397,12 @@ internal fun createBindings(platform: Platform): List<KeyBinding> {
     KeyBinding(
       ComposeKey.V,
       setOf(KeyModifier.Mod),
-      coalescible = false,
-      action = { clipboard ->
-        val read = clipboard.paste() ?: return@KeyBinding emptyList()
-        listOf(Message.Clipboard(ClipboardOp.Paste(html = read.html, text = read.text)))
-      },
+      action = EditorKeyBindingAction.Paste(IncomingContentMode.Rich),
     ),
     KeyBinding(
       ComposeKey.V,
       setOf(KeyModifier.Mod, KeyModifier.Shift),
-      coalescible = false,
-      action = { clipboard ->
-        val read = clipboard.paste() ?: return@KeyBinding emptyList()
-        listOf(Message.Clipboard(ClipboardOp.Paste(html = null, text = read.text)))
-      },
+      action = EditorKeyBindingAction.Paste(IncomingContentMode.PlainTextOnly),
     ),
     KeyBinding(
       ComposeKey.A,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorIncomingContentHandler.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorIncomingContentHandler.kt
@@ -1,0 +1,41 @@
+package co.typie.editor.input
+
+import androidx.compose.runtime.compositionLocalOf
+import co.typie.editor.DocumentEditingSession
+import co.typie.platform.Clipboard
+import co.typie.platform.IncomingContentCandidates
+import co.typie.platform.IncomingContentMode
+
+internal interface EditorIncomingContentHandler {
+  suspend fun handleClipboard(
+    session: DocumentEditingSession,
+    clipboard: Clipboard,
+    mode: IncomingContentMode,
+  ): Boolean
+
+  suspend fun handleCandidates(
+    session: DocumentEditingSession,
+    candidates: IncomingContentCandidates,
+    mode: IncomingContentMode = IncomingContentMode.Rich,
+  ): Boolean
+}
+
+internal val LocalEditorIncomingContentHandler =
+  compositionLocalOf<EditorIncomingContentHandler> { NoopEditorIncomingContentHandler }
+
+internal object NoopEditorIncomingContentHandler : EditorIncomingContentHandler {
+  override suspend fun handleClipboard(
+    session: DocumentEditingSession,
+    clipboard: Clipboard,
+    mode: IncomingContentMode,
+  ): Boolean = false
+
+  override suspend fun handleCandidates(
+    session: DocumentEditingSession,
+    candidates: IncomingContentCandidates,
+    mode: IncomingContentMode,
+  ): Boolean {
+    candidates.close()
+    return false
+  }
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorInput.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorInput.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.text.input.EditCommand
 import co.typie.editor.DocumentEditingSession
 import co.typie.editor.Editor
 import co.typie.editor.EditorEventListener
+import co.typie.editor.EditorKeyBindingAction
 import co.typie.editor.EditorState
 import co.typie.editor.KeyBinding
 import co.typie.editor.createBindings
@@ -45,8 +46,10 @@ import co.typie.ext.TextInputKey
 import co.typie.ext.notifyTextInputFocusChanged
 import co.typie.ext.registerTextInputClient
 import co.typie.platform.Clipboard
+import co.typie.platform.IncomingContentCandidates
 import co.typie.platform.Platform
 import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -62,6 +65,7 @@ internal fun Modifier.editorInput(
   enabled: Boolean = true,
   suppressSoftwareKeyboard: Boolean,
   clipboard: Clipboard,
+  incomingContentHandler: EditorIncomingContentHandler = NoopEditorIncomingContentHandler,
 ): Modifier =
   this then
     EditorInputElement(
@@ -72,6 +76,7 @@ internal fun Modifier.editorInput(
       enabled = enabled,
       suppressSoftwareKeyboard = suppressSoftwareKeyboard,
       clipboard = clipboard,
+      incomingContentHandler = incomingContentHandler,
     )
 
 @OptIn(ExperimentalComposeUiApi::class)
@@ -84,6 +89,7 @@ internal expect suspend fun PlatformTextInputSessionScope.createEditorInputReque
   textClippingRectInRoot: () -> Rect?,
   suppressSoftwareKeyboard: Boolean,
   isSessionCurrent: () -> Boolean,
+  onIncomingContent: (IncomingContentCandidates) -> Boolean,
 ): PlatformTextInputMethodRequest
 
 internal expect fun requiresEditorInputSessionRestartForSoftwareKeyboardSuppression(): Boolean
@@ -164,6 +170,7 @@ private data class EditorInputElement(
   private val enabled: Boolean,
   private val suppressSoftwareKeyboard: Boolean,
   private val clipboard: Clipboard,
+  private val incomingContentHandler: EditorIncomingContentHandler,
 ) : ModifierNodeElement<EditorInputNode>() {
   override fun create(): EditorInputNode =
     EditorInputNode(
@@ -174,6 +181,7 @@ private data class EditorInputElement(
       enabled = enabled,
       suppressSoftwareKeyboard = suppressSoftwareKeyboard,
       clipboard = clipboard,
+      incomingContentHandler = incomingContentHandler,
     )
 
   override fun update(node: EditorInputNode) {
@@ -183,6 +191,7 @@ private data class EditorInputElement(
     node.updatePlatform(platform)
     node.bringIntoViewRequests = bringIntoViewRequests
     node.clipboard = clipboard
+    node.incomingContentHandler = incomingContentHandler
     node.updateInputPolicy(enabled = enabled, suppressSoftwareKeyboard = suppressSoftwareKeyboard)
     if (node.session.editor !== previousEditor) {
       node.bindImeResync()
@@ -199,6 +208,7 @@ internal class EditorInputNode(
   enabled: Boolean,
   suppressSoftwareKeyboard: Boolean,
   var clipboard: Clipboard,
+  var incomingContentHandler: EditorIncomingContentHandler,
 ) : Modifier.Node(), FocusEventModifierNode, PlatformTextInputModifierNode, KeyInputModifierNode {
   private var focusedJob: Job? = null
   private var focused = false
@@ -277,7 +287,7 @@ internal class EditorInputNode(
     bindingCoalescer =
       EditorKeyBindingCoalescer(
         scope = coroutineScope,
-        resolveMessages = { binding, clipboard -> with(binding) { editor.action(clipboard) } },
+        resolveMessages = { action, clipboard -> action.messages(editor, clipboard) },
         dispatch = { messages, bringIntoViewTarget ->
           dispatchBindingMessages(messages = messages, bringIntoViewTarget = bringIntoViewTarget)
         },
@@ -287,10 +297,64 @@ internal class EditorInputNode(
 
   private fun dispatchBinding(binding: KeyBinding, clipboard: Clipboard) {
     val coalescer = bindingCoalescer ?: return
-    if (binding.coalescible) {
-      submit { _, localEdit -> coalescer.submit(binding, clipboard, localEdit) }
-    } else {
-      coroutineScope.launch { coalescer.submit(binding, clipboard).await() }
+    when (val action = binding.action) {
+      is EditorKeyBindingAction.Paste -> {
+        val capturedSession = session
+        val completion = coalescer.submitOrdered {
+          incomingContentHandler.handleClipboard(capturedSession, clipboard, action.mode)
+        }
+        coroutineScope.launch { completion.await() }
+      }
+      is EditorKeyBindingAction.Messages -> {
+        if (action.coalescible) {
+          submit { _, localEdit -> coalescer.submit(binding, clipboard, localEdit) }
+        } else {
+          val completion = coalescer.submit(binding, clipboard)
+          coroutineScope.launch { completion.await() }
+        }
+      }
+    }
+  }
+
+  private fun dispatchPreKeyBinding(binding: KeyBinding, clipboard: Clipboard) {
+    val coalescer = bindingCoalescer ?: return
+    when (val action = binding.action) {
+      is EditorKeyBindingAction.Paste -> dispatchBinding(binding, clipboard)
+      is EditorKeyBindingAction.Messages -> {
+        val preState = editor.state
+        // iOS can echo a native selection before this key's queued commit. Constant message
+        // actions are safe to resolve and register immediately; stateful or clipboard actions
+        // resolve inside the ordered queue so their side effects cannot overtake paste.
+        if (action.coalescible) {
+          coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            val messages = action.messages(editor, clipboard)
+            platformInputBridge.dispatchAppOwnedKeyMessages(messages, preState) {
+              var postState: EditorState? = null
+              coalescer
+                .submitOrdered {
+                  postState =
+                    dispatchBindingMessages(
+                      messages = messages,
+                      bringIntoViewTarget = binding.bringIntoViewTarget,
+                    )
+                }
+                .await()
+              postState
+            }
+          }
+        } else {
+          val completion = coalescer.submitOrdered {
+            val messages = action.messages(editor, clipboard)
+            platformInputBridge.dispatchAppOwnedKeyMessages(messages, preState) {
+              dispatchBindingMessages(
+                messages = messages,
+                bringIntoViewTarget = binding.bringIntoViewTarget,
+              )
+            }
+          }
+          coroutineScope.launch { completion.await() }
+        }
+      }
     }
   }
 
@@ -512,15 +576,8 @@ internal class EditorInputNode(
     val consumed =
       platformInputBridge.onPreKeyEvent(
         event = event,
-        editorState = { editor.state },
         inputCoroutineScope = coroutineScope,
-        bindingMessages = { with(binding) { editor.action(clipboard) } },
-        commit = { messages ->
-          dispatchBindingMessages(
-            messages = messages,
-            bringIntoViewTarget = binding.bringIntoViewTarget,
-          )
-        },
+        onAccepted = { dispatchPreKeyBinding(binding, clipboard) },
       )
     recordHardwareKey(
       event = event,
@@ -617,6 +674,20 @@ internal class EditorInputNode(
                   textClippingRectInRoot = uiState::textClippingRectInRoot,
                   suppressSoftwareKeyboard = suppressSoftwareKeyboard,
                   isSessionCurrent = { imeSessionGeneration == generationAtStart },
+                  onIncomingContent = { candidates ->
+                    if (imeSessionGeneration != generationAtStart || !focused || !enabled) {
+                      candidates.close()
+                      false
+                    } else {
+                      val commandStartSession = session
+                      coroutineScope
+                        .launch {
+                          incomingContentHandler.handleCandidates(commandStartSession, candidates)
+                        }
+                        .invokeOnCompletion { candidates.close() }
+                      true
+                    }
+                  },
                 )
               launch {
                 notifyImeStateChanged(editor)

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorKeyBindingCoalescer.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorKeyBindingCoalescer.kt
@@ -1,5 +1,6 @@
 package co.typie.editor.input
 
+import co.typie.editor.EditorKeyBindingAction
 import co.typie.editor.KeyBinding
 import co.typie.editor.ffi.Message
 import co.typie.editor.scroll.EditorBringIntoViewTarget
@@ -22,30 +23,40 @@ import kotlinx.coroutines.withContext
 // batched action would otherwise run before the preceding messages commit.
 internal class EditorKeyBindingCoalescer(
   private val scope: CoroutineScope,
-  private val resolveMessages: suspend (KeyBinding, Clipboard) -> List<Message>,
+  private val resolveMessages:
+    suspend (EditorKeyBindingAction.Messages, Clipboard) -> List<Message>,
   private val dispatch: suspend (List<Message>, EditorBringIntoViewTarget?) -> Unit,
 ) {
-  private data class Submission(
+  private sealed interface Submission {
+    val completion: CompletableDeferred<Unit>
+  }
+
+  private data class BindingSubmission(
     val binding: KeyBinding,
     val clipboard: Clipboard,
     val localEditContext: CoroutineContext?,
-    val completion: CompletableDeferred<Unit>,
-  ) {
-    fun complete() {
-      completion.complete(Unit)
-    }
+    override val completion: CompletableDeferred<Unit>,
+  ) : Submission
 
-    fun fail(error: Throwable) {
-      completion.completeExceptionally(error)
-    }
+  private data class OrderedActionSubmission(
+    val action: suspend () -> Unit,
+    override val completion: CompletableDeferred<Unit>,
+  ) : Submission
+
+  private fun Submission.complete() {
+    completion.complete(Unit)
+  }
+
+  private fun Submission.fail(error: Throwable) {
+    completion.completeExceptionally(error)
   }
 
   private inner class PendingBatch {
-    private val submissions = mutableListOf<Submission>()
+    private val submissions = mutableListOf<BindingSubmission>()
     private val messages = mutableListOf<Message>()
     private var target: EditorBringIntoViewTarget? = null
 
-    fun add(submission: Submission, resolvedMessages: List<Message>) {
+    fun add(submission: BindingSubmission, resolvedMessages: List<Message>) {
       submissions += submission
       messages += resolvedMessages
       submission.binding.bringIntoViewTarget?.let { target = it }
@@ -61,7 +72,7 @@ internal class EditorKeyBindingCoalescer(
           withContext(context) { dispatch(messages.toList(), target) }
         }
       }
-      submissions.forEach(Submission::complete)
+      submissions.forEach { it.complete() }
       submissions.clear()
       messages.clear()
       target = null
@@ -92,11 +103,22 @@ internal class EditorKeyBindingCoalescer(
     clipboard: Clipboard,
     localEditContext: CoroutineContext? = null,
   ): Deferred<Unit> {
-    val submission = Submission(binding, clipboard, localEditContext, CompletableDeferred())
+    val submission = BindingSubmission(binding, clipboard, localEditContext, CompletableDeferred())
     val result = submissions.trySend(submission)
     if (result.isClosed) {
       // Callers sit outside any coroutine (hardware key handlers), so a stopped
       // worker must surface as a failed completion, never a synchronous throw.
+      submission.fail(
+        result.exceptionOrNull() ?: CancellationException("Editor key binding coalescer stopped")
+      )
+    }
+    return submission.completion
+  }
+
+  fun submitOrdered(action: suspend () -> Unit): Deferred<Unit> {
+    val submission = OrderedActionSubmission(action, CompletableDeferred())
+    val result = submissions.trySend(submission)
+    if (result.isClosed) {
       submission.fail(
         result.exceptionOrNull() ?: CancellationException("Editor key binding coalescer stopped")
       )
@@ -111,20 +133,32 @@ internal class EditorKeyBindingCoalescer(
     try {
       while (current != null) {
         claimed += current
-        val binding = current.binding
-        if (binding.coalescible) {
-          batch.add(current, resolveMessages(binding, current.clipboard))
-        } else {
-          batch.flush()
-          val messages = resolveMessages(binding, current.clipboard)
-          if (current.localEditContext == null) {
-            dispatch(messages, binding.bringIntoViewTarget)
-          } else {
-            withContext(current.localEditContext) {
-              dispatch(messages, binding.bringIntoViewTarget)
+        when (val submission = current) {
+          is BindingSubmission -> {
+            val binding = submission.binding
+            val action =
+              binding.action as? EditorKeyBindingAction.Messages
+                ?: error("Only message key bindings may be submitted to the coalescer")
+            if (action.coalescible) {
+              batch.add(submission, resolveMessages(action, submission.clipboard))
+            } else {
+              batch.flush()
+              val messages = resolveMessages(action, submission.clipboard)
+              if (submission.localEditContext == null) {
+                dispatch(messages, binding.bringIntoViewTarget)
+              } else {
+                withContext(submission.localEditContext) {
+                  dispatch(messages, binding.bringIntoViewTarget)
+                }
+              }
+              submission.complete()
             }
           }
-          current.complete()
+          is OrderedActionSubmission -> {
+            batch.flush()
+            submission.action()
+            submission.complete()
+          }
         }
         current = submissions.tryReceive().getOrNull()
       }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorPlatformInputBridge.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorPlatformInputBridge.kt
@@ -13,11 +13,15 @@ internal expect class EditorPlatformInputBridge() {
 
   fun onPreKeyEvent(
     event: KeyEvent,
-    editorState: () -> EditorState,
     inputCoroutineScope: CoroutineScope,
-    bindingMessages: suspend () -> List<Message>,
-    commit: suspend (List<Message>) -> EditorState?,
+    onAccepted: () -> Unit,
   ): Boolean
+
+  suspend fun dispatchAppOwnedKeyMessages(
+    messages: List<Message>,
+    preState: EditorState,
+    dispatch: suspend () -> EditorState?,
+  )
 
   fun shouldConsumeKeyEvent(event: KeyEvent): Boolean
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorSelectionInputIntentTracker.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorSelectionInputIntentTracker.kt
@@ -33,7 +33,9 @@ internal class EditorSelectionInputIntentTracker(private val staleTimeoutMillis:
     expireStale(nowMillis)
     val move = messages.singleNavigationMoveOrNull()
     if (move == null) {
-      reset()
+      // A stateful key action may resolve after a later navigation was accepted. Its result must
+      // not clear that newer in-flight intent.
+      if (lifecycle !is SelectionInputLifecycle.InFlight) reset()
       return null
     }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/platform/Clipboard.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/platform/Clipboard.kt
@@ -7,7 +7,5 @@ interface Clipboard {
 
   suspend fun copyRichText(html: String, text: String): Boolean
 
-  suspend fun paste(): ClipboardReadPayload?
+  suspend fun paste(): IncomingContentCandidates?
 }
-
-data class ClipboardReadPayload(val html: String?, val text: String)

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/platform/IncomingContent.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/platform/IncomingContent.kt
@@ -1,0 +1,180 @@
+@file:OptIn(kotlin.concurrent.atomics.ExperimentalAtomicApi::class)
+
+package co.typie.platform
+
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withContext
+
+enum class IncomingContentMode {
+  Rich,
+  PlainTextOnly,
+}
+
+data class IncomingContentItem(val kind: Kind, val file: PickedFile) {
+  enum class Kind {
+    Image,
+    File,
+  }
+}
+
+internal suspend fun materializeIncomingContentCandidates(
+  html: String?,
+  text: String?,
+  loadItems: suspend () -> LoadedIncomingContentItems,
+): IncomingContentCandidates? {
+  val nonemptyHtml = html?.takeIf(String::isNotEmpty)
+  if (nonemptyHtml != null) {
+    return IncomingContentCandidates(html = nonemptyHtml, text = text)
+  }
+
+  val loaded = loadItems()
+  if (text.isNullOrEmpty() && loaded.items.isEmpty() && loaded.unreadableItemCount == 0) return null
+  return IncomingContentCandidates(
+    text = text,
+    items = loaded.items,
+    unreadableItemCount = loaded.unreadableItemCount,
+  )
+}
+
+internal data class LoadedIncomingContentItems(
+  val items: List<IncomingContentItem>,
+  val unreadableItemCount: Int = 0,
+) {
+  init {
+    require(unreadableItemCount >= 0)
+  }
+}
+
+internal suspend fun loadOwnedIncomingContentItems(
+  loaders: List<suspend () -> IncomingContentItem?>,
+  loaderContext: CoroutineContext = EmptyCoroutineContext,
+): LoadedIncomingContentItems {
+  val owners = List(loaders.size) { OwnedIncomingContentItem() }
+  return try {
+    val unreadableItemCount =
+      coroutineScope {
+          loaders.mapIndexed { index, load ->
+            async(loaderContext) {
+              try {
+                load()?.let(owners[index]::store)
+                false
+              } catch (error: kotlinx.coroutines.CancellationException) {
+                throw error
+              } catch (_: Throwable) {
+                true
+              }
+            }
+          }
+        }
+        .awaitAll()
+        .count { it }
+    currentCoroutineContext().ensureActive()
+    LoadedIncomingContentItems(
+      items = owners.mapNotNull(OwnedIncomingContentItem::take),
+      unreadableItemCount = unreadableItemCount,
+    )
+  } finally {
+    owners.forEach(OwnedIncomingContentItem::close)
+  }
+}
+
+internal suspend fun loadOwnedIncomingContentCandidates(
+  loaderContext: CoroutineContext,
+  load: suspend () -> IncomingContentCandidates?,
+): IncomingContentCandidates? {
+  val owner = AtomicReference<IncomingContentCandidates?>(null)
+  return try {
+    withContext(loaderContext) {
+      load()?.let { candidates ->
+        check(owner.compareAndSet(expectedValue = null, newValue = candidates))
+      }
+    }
+    currentCoroutineContext().ensureActive()
+    owner.exchange(null)
+  } finally {
+    owner.exchange(null)?.close()
+  }
+}
+
+private class OwnedIncomingContentItem {
+  private val item = AtomicReference<IncomingContentItem?>(null)
+
+  fun store(value: IncomingContentItem) {
+    check(item.compareAndSet(expectedValue = null, newValue = value))
+  }
+
+  fun take(): IncomingContentItem? = item.exchange(null)
+
+  fun close() {
+    item.exchange(null)?.file?.close()
+  }
+}
+
+class IncomingContentCandidates(
+  val html: String? = null,
+  val text: String? = null,
+  val items: List<IncomingContentItem> = emptyList(),
+  val unreadableItemCount: Int = 0,
+) {
+  private var selected = false
+
+  init {
+    require(unreadableItemCount >= 0)
+  }
+
+  fun select(mode: IncomingContentMode): SelectedIncomingContent {
+    check(!selected) { "Incoming content has already been selected" }
+    selected = true
+
+    if (mode == IncomingContentMode.PlainTextOnly) {
+      releaseItems()
+      return text?.takeIf(String::isNotEmpty)?.let {
+        SelectedIncomingContent.RichText(html = null, text = it)
+      } ?: SelectedIncomingContent.None
+    }
+
+    val nonemptyHtml = html?.takeIf(String::isNotEmpty)
+    if (nonemptyHtml != null) {
+      releaseItems()
+      return SelectedIncomingContent.RichText(html = nonemptyHtml, text = text.orEmpty())
+    }
+
+    if (items.isNotEmpty() || unreadableItemCount > 0) {
+      return SelectedIncomingContent.Attachments(items, unreadableItemCount)
+    }
+
+    return text?.takeIf(String::isNotEmpty)?.let {
+      SelectedIncomingContent.RichText(html = null, text = it)
+    } ?: SelectedIncomingContent.None
+  }
+
+  fun close() {
+    if (selected) return
+    selected = true
+    releaseItems()
+  }
+
+  private fun releaseItems() {
+    items.forEach { it.file.close() }
+  }
+}
+
+sealed interface SelectedIncomingContent {
+  data class RichText(val html: String?, val text: String) : SelectedIncomingContent
+
+  class Attachments(val items: List<IncomingContentItem>, val unreadableItemCount: Int = 0) :
+    SelectedIncomingContent {
+    fun close() {
+      items.forEach { it.file.close() }
+    }
+  }
+
+  data object None : SelectedIncomingContent
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
@@ -71,6 +72,7 @@ import co.typie.editor.ffi.Movement
 import co.typie.editor.ffi.NavigationOp
 import co.typie.editor.ffi.SystemEvent
 import co.typie.editor.input.EditorInputRecorder
+import co.typie.editor.input.LocalEditorIncomingContentHandler
 import co.typie.editor.input.buildInputLogPayload
 import co.typie.editor.input.sendInputLog
 import co.typie.editor.interaction.EditorInteractionScope
@@ -126,6 +128,9 @@ import co.typie.screen.editor.editor.aifeedback.AiFeedbackTopBarCenter
 import co.typie.screen.editor.editor.aifeedback.AiFeedbackTopBarLeading
 import co.typie.screen.editor.editor.aifeedback.AiFeedbackTopBarTrailing
 import co.typie.screen.editor.editor.aifeedback.rememberEditorAiFeedbackSession
+import co.typie.screen.editor.editor.attachment.DefaultEditorAttachmentImporter
+import co.typie.screen.editor.editor.attachment.LocalEditorAttachmentImporter
+import co.typie.screen.editor.editor.attachment.SessionEditorIncomingContentHandler
 import co.typie.screen.editor.editor.entry.rememberEditorEntryStateSession
 import co.typie.screen.editor.editor.findreplace.FindReplaceToolbar
 import co.typie.screen.editor.editor.findreplace.FindReplaceTopBarCenter
@@ -354,6 +359,25 @@ fun EditorScreen(entityId: String) {
     subPaneState.dismissTableAxisActionsIfSelectionChanged(editorState.selection)
   }
   val bringIntoViewRequests = rememberEditorBringIntoViewRequests()
+  val currentEditorReadOnly by rememberUpdatedState(editorReadOnly)
+  val attachmentImporter =
+    remember(runtime, externalElementState, bringIntoViewRequests) {
+      DefaultEditorAttachmentImporter(
+        externalElementState = externalElementState,
+        bringIntoViewRequests = bringIntoViewRequests,
+        isSessionCurrent = { session -> runtime.session === session && !currentEditorReadOnly },
+        backgroundScope = scope,
+      )
+    }
+  val incomingContentHandler =
+    remember(runtime, attachmentImporter, bringIntoViewRequests, toast) {
+      SessionEditorIncomingContentHandler(
+        importer = attachmentImporter,
+        bringIntoViewRequests = bringIntoViewRequests,
+        isSessionCurrent = { session -> runtime.session === session && !currentEditorReadOnly },
+        onAttachmentError = { message -> toast.error(message) },
+      )
+    }
   val entryState =
     rememberEditorEntryStateSession(
       documentId = document?.id,
@@ -1454,6 +1478,8 @@ fun EditorScreen(entityId: String) {
       LocalEditorExternalElementState provides externalElementState,
       LocalEditorZoomController provides zoomController,
       LocalEditorBringIntoViewRequests provides bringIntoViewRequests,
+      LocalEditorAttachmentImporter provides attachmentImporter,
+      LocalEditorIncomingContentHandler provides incomingContentHandler,
       LocalEditorInteractionScope provides interactionScope,
       LocalHazeState provides toolbarBackdropHazeState,
     ) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/attachment/EditorAttachmentImporter.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/attachment/EditorAttachmentImporter.kt
@@ -1,0 +1,384 @@
+@file:OptIn(ExperimentalUuidApi::class)
+
+package co.typie.screen.editor.editor.attachment
+
+import androidx.compose.runtime.compositionLocalOf
+import co.typie.editor.DocumentEditingSession
+import co.typie.editor.Editor
+import co.typie.editor.external.EditorExternalAsset
+import co.typie.editor.external.EditorExternalElementState
+import co.typie.editor.external.EditorFileUpload
+import co.typie.editor.external.EditorImageUpload
+import co.typie.editor.ffi.AttachmentPlaceholderKind
+import co.typie.editor.ffi.EditorEvent
+import co.typie.editor.ffi.ExternalElementData
+import co.typie.editor.ffi.FlatImeOp
+import co.typie.editor.ffi.ImageNodeAttr
+import co.typie.editor.ffi.InsertionOp
+import co.typie.editor.ffi.Message
+import co.typie.editor.ffi.NodeAttr
+import co.typie.editor.ffi.NodeOp
+import co.typie.editor.ffi.PlainNode
+import co.typie.editor.scroll.EditorBringIntoViewRequests
+import co.typie.editor.scroll.EditorBringIntoViewTarget
+import co.typie.platform.IncomingContentItem
+import co.typie.screen.editor.editor.toolbar.contextual.AttachmentKind
+import co.typie.screen.editor.editor.toolbar.contextual.completeAttachmentOperation
+import co.typie.screen.editor.editor.toolbar.contextual.reportAttachmentFailure
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.yield
+
+internal sealed interface EditorAttachmentDestination {
+  data object CurrentSelection : EditorAttachmentDestination
+
+  data class ExistingPlaceholder(val nodeId: String, val expectedKind: IncomingContentItem.Kind) :
+    EditorAttachmentDestination
+}
+
+internal fun interface EditorAttachmentImporter {
+  suspend fun import(
+    session: DocumentEditingSession,
+    items: List<IncomingContentItem>,
+    destination: EditorAttachmentDestination,
+    onCompleted: (importedCount: Int) -> Unit,
+  ): Boolean
+}
+
+internal val LocalEditorAttachmentImporter =
+  compositionLocalOf<EditorAttachmentImporter> { error("No EditorAttachmentImporter provided") }
+
+internal class DefaultEditorAttachmentImporter(
+  private val externalElementState: EditorExternalElementState,
+  private val bringIntoViewRequests: EditorBringIntoViewRequests,
+  private val persistence: EditorAttachmentPersistence = GraphqlEditorAttachmentPersistence,
+  private val isSessionCurrent: (DocumentEditingSession) -> Boolean,
+  private val backgroundScope: CoroutineScope,
+) : EditorAttachmentImporter {
+  private data class PreparedItem(val item: IncomingContentItem, val pending: Any)
+
+  private data class Target(val nodeId: String, val item: IncomingContentItem, val pending: Any)
+
+  override suspend fun import(
+    session: DocumentEditingSession,
+    items: List<IncomingContentItem>,
+    destination: EditorAttachmentDestination,
+    onCompleted: (importedCount: Int) -> Unit,
+  ): Boolean =
+    try {
+      importAtSelection(session, items, destination, onCompleted)
+    } catch (error: Throwable) {
+      items.closeAll()
+      throw error
+    }
+
+  private suspend fun importAtSelection(
+    session: DocumentEditingSession,
+    items: List<IncomingContentItem>,
+    destination: EditorAttachmentDestination,
+    onCompleted: (importedCount: Int) -> Unit,
+  ): Boolean {
+    if (items.isEmpty()) {
+      backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) {
+        yield()
+        onCompleted(0)
+      }
+      return false
+    }
+    if (!isSessionCurrent(session)) {
+      items.closeAll()
+      backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) {
+        yield()
+        onCompleted(0)
+      }
+      return false
+    }
+
+    val editor = session.editor
+    val command = session.submit { _, context ->
+      editor.scope.async(context) { mapTargets(session, editor, items, destination) }
+    }
+    if (command == null) {
+      items.closeAll()
+      backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) {
+        yield()
+        onCompleted(0)
+      }
+      return false
+    }
+
+    val targets = command.await()
+    items.filterNot { item -> targets.any { target -> target.item === item } }.closeAll()
+    if (targets.isEmpty()) {
+      backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) {
+        yield()
+        onCompleted(0)
+      }
+      return false
+    }
+
+    targets.forEach(::setPending)
+    backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) {
+      val importedCount =
+        try {
+          yield()
+          completeMappedImport(session, editor, targets)
+        } finally {
+          targets.forEach(::clearPending)
+          targets.map(Target::item).closeAll()
+        }
+      onCompleted(importedCount)
+    }
+    return true
+  }
+
+  private suspend fun completeMappedImport(
+    session: DocumentEditingSession,
+    editor: Editor,
+    targets: List<Target>,
+  ): Int = supervisorScope {
+    targets
+      .map { target ->
+        async {
+          try {
+            uploadTarget(session, editor, target)
+          } catch (error: CancellationException) {
+            throw error
+          } catch (error: Throwable) {
+            reportAttachmentFailure(target.item.kind.toAttachmentKind(), error)
+            false
+          }
+        }
+      }
+      .awaitAll()
+      .count { it }
+  }
+
+  private suspend fun mapTargets(
+    session: DocumentEditingSession,
+    editor: Editor,
+    items: List<IncomingContentItem>,
+    destination: EditorAttachmentDestination,
+  ): List<Target> {
+    val prepared = items.mapNotNull { item ->
+      item.pendingTokenOrNull()?.let { pending -> PreparedItem(item, pending) }
+    }
+    val targets = mutableListOf<Pair<String, PreparedItem>>()
+    var remaining = prepared
+
+    if (destination is EditorAttachmentDestination.ExistingPlaceholder) {
+      val first = prepared.firstOrNull() ?: return emptyList()
+      if (
+        first.item.kind != destination.expectedKind ||
+          !isAvailablePlaceholder(editor, destination.nodeId, destination.expectedKind)
+      ) {
+        return emptyList()
+      }
+      targets += destination.nodeId to first
+      remaining = prepared.drop(1)
+    }
+
+    if (remaining.isNotEmpty()) {
+      val requestId = Uuid.random().toHexString()
+      val requestKinds = remaining.map { it.item.kind.toPlaceholderKind() }
+      val nodeIds =
+        editor.await(
+          beforeCommit = { state ->
+            bringIntoViewRequests.requestForVersion(
+              target = EditorBringIntoViewTarget.CurrentSelectionHead,
+              version = state.version,
+            )
+          },
+          admit = { isSessionCurrent(session) },
+          mapEvents = { events ->
+            val matches =
+              events.filterIsInstance<EditorEvent.AttachmentPlaceholdersInserted>().filter {
+                it.requestId == requestId
+              }
+            check(matches.size == 1) {
+              "Expected exactly one attachment placeholder result for $requestId, got ${matches.size}"
+            }
+            matches.single().nodeIds
+          },
+        ) {
+          if (editor.ime?.composing != null) {
+            enqueue(Message.TextInput(listOf(FlatImeOp.CommitAsIs)))
+          }
+          enqueue(Message.Insertion(InsertionOp.AttachmentPlaceholders(requestId, requestKinds)))
+        } ?: return emptyList()
+      check(remaining.size == nodeIds.size) {
+        "Expected ${remaining.size} attachment placeholders, got ${nodeIds.size}"
+      }
+      targets += nodeIds.zip(remaining)
+    }
+
+    return targets.map { (nodeId, preparedItem) ->
+      Target(nodeId, preparedItem.item, preparedItem.pending)
+    }
+  }
+
+  private suspend fun uploadTarget(
+    session: DocumentEditingSession,
+    editor: Editor,
+    target: Target,
+  ): Boolean {
+    if (!isCurrent(session, editor, target)) return false
+    var committed = false
+    return try {
+      val completed =
+        completeAttachmentOperation(
+          persist = {
+            when (target.item.kind) {
+              IncomingContentItem.Kind.Image -> persistence.persistImage(target.item.file)
+              IncomingContentItem.Kind.File -> persistence.persistFile(target.item.file)
+            }
+          },
+          isCurrent = { isCurrent(session, editor, target) },
+          cache = externalElementState::put,
+          commit = { uploaded -> committed = commit(editor, session, target, uploaded) },
+          clearPending = { clearPending(target) },
+        ) != null
+      completed && committed
+    } finally {
+      clearPending(target)
+    }
+  }
+
+  private suspend fun commit(
+    editor: Editor,
+    session: DocumentEditingSession,
+    target: Target,
+    asset: EditorExternalAsset,
+  ): Boolean {
+    val operation =
+      session.submit { _, context ->
+        editor.scope.async(context) {
+          editor.await(
+            admit = { isCurrent(session, editor, target) },
+            beforeCommit = { state ->
+              bringIntoViewRequests.requestForVersion(
+                target = EditorBringIntoViewTarget.CurrentSelectionHead,
+                version = state.version,
+              )
+            },
+          ) {
+            enqueue(
+              when (target.item.kind) {
+                IncomingContentItem.Kind.Image ->
+                  Message.Node(
+                    NodeOp.SetAttr(
+                      id = target.nodeId,
+                      attr = NodeAttr.Image(ImageNodeAttr.Id(asset.id)),
+                    )
+                  )
+                IncomingContentItem.Kind.File ->
+                  Message.Node(
+                    NodeOp.SetAttrs(id = target.nodeId, attrs = PlainNode.File(id = asset.id))
+                  )
+              }
+            )
+          }
+        }
+      } ?: return false
+    return operation.await()
+  }
+
+  private fun IncomingContentItem.pendingTokenOrNull(): Any? =
+    when (kind) {
+      IncomingContentItem.Kind.Image -> {
+        val width = file.imageWidth ?: return null
+        val height = file.imageHeight ?: return null
+        if (width <= 0 || height <= 0) return null
+        EditorImageUpload(
+          previewModel = file.previewModel,
+          name = file.filename,
+          width = width,
+          height = height,
+        )
+      }
+      IncomingContentItem.Kind.File -> EditorFileUpload(name = file.filename, size = file.size)
+    }
+
+  private fun setPending(target: Target) {
+    when (target.item.kind) {
+      IncomingContentItem.Kind.Image ->
+        externalElementState.images.uploads[target.nodeId] = target.pending as EditorImageUpload
+      IncomingContentItem.Kind.File ->
+        externalElementState.files.uploads[target.nodeId] = target.pending as EditorFileUpload
+    }
+  }
+
+  private fun clearPending(target: Target) {
+    when (target.item.kind) {
+      IncomingContentItem.Kind.Image -> {
+        if (externalElementState.images.uploads[target.nodeId] === target.pending) {
+          externalElementState.images.uploads.remove(target.nodeId)
+        }
+      }
+      IncomingContentItem.Kind.File -> {
+        if (externalElementState.files.uploads[target.nodeId] === target.pending) {
+          externalElementState.files.uploads.remove(target.nodeId)
+        }
+      }
+    }
+  }
+
+  private fun isCurrent(session: DocumentEditingSession, editor: Editor, target: Target): Boolean =
+    isSessionCurrent(session) &&
+      pendingMatches(target) &&
+      isEmptyPlaceholder(editor, target.nodeId, target.item.kind)
+
+  private fun pendingMatches(target: Target): Boolean =
+    when (target.item.kind) {
+      IncomingContentItem.Kind.Image ->
+        externalElementState.images.uploads[target.nodeId] === target.pending
+      IncomingContentItem.Kind.File ->
+        externalElementState.files.uploads[target.nodeId] === target.pending
+    }
+
+  private fun isAvailablePlaceholder(
+    editor: Editor,
+    nodeId: String,
+    kind: IncomingContentItem.Kind,
+  ): Boolean =
+    isEmptyPlaceholder(editor, nodeId, kind) &&
+      when (kind) {
+        IncomingContentItem.Kind.Image -> !externalElementState.images.uploads.containsKey(nodeId)
+        IncomingContentItem.Kind.File -> !externalElementState.files.uploads.containsKey(nodeId)
+      }
+
+  private fun isEmptyPlaceholder(
+    editor: Editor,
+    nodeId: String,
+    kind: IncomingContentItem.Kind,
+  ): Boolean {
+    val data = editor.externalElements.firstOrNull { it.node == nodeId }?.data ?: return false
+    return when (kind) {
+      IncomingContentItem.Kind.Image -> data is ExternalElementData.Image && data.id == null
+      IncomingContentItem.Kind.File -> data is ExternalElementData.File && data.id == null
+    }
+  }
+}
+
+private fun IncomingContentItem.Kind.toPlaceholderKind(): AttachmentPlaceholderKind =
+  when (this) {
+    IncomingContentItem.Kind.Image -> AttachmentPlaceholderKind.Image
+    IncomingContentItem.Kind.File -> AttachmentPlaceholderKind.File
+  }
+
+private fun IncomingContentItem.Kind.toAttachmentKind(): AttachmentKind =
+  when (this) {
+    IncomingContentItem.Kind.Image -> AttachmentKind.Image
+    IncomingContentItem.Kind.File -> AttachmentKind.File
+  }
+
+private fun List<IncomingContentItem>.closeAll() {
+  forEach { it.file.close() }
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/attachment/EditorAttachmentPersistence.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/attachment/EditorAttachmentPersistence.kt
@@ -1,0 +1,40 @@
+package co.typie.screen.editor.editor.attachment
+
+import co.typie.domain.blob.BlobService
+import co.typie.editor.external.EditorFileAsset
+import co.typie.editor.external.EditorImageAsset
+import co.typie.graphql.Apollo
+import co.typie.graphql.EditorScreen_PersistBlobAsFile_Mutation
+import co.typie.graphql.EditorScreen_PersistBlobAsImage_Mutation
+import co.typie.graphql.executeMutation
+import co.typie.graphql.type.PersistBlobAsFileInput
+import co.typie.graphql.type.PersistBlobAsImageInput
+import co.typie.platform.PickedFile
+import co.typie.screen.editor.editor.toEditorFileAsset
+import co.typie.screen.editor.editor.toEditorImageAsset
+
+internal interface EditorAttachmentPersistence {
+  suspend fun persistImage(file: PickedFile): EditorImageAsset
+
+  suspend fun persistFile(file: PickedFile): EditorFileAsset
+}
+
+internal object GraphqlEditorAttachmentPersistence : EditorAttachmentPersistence {
+  override suspend fun persistImage(file: PickedFile): EditorImageAsset {
+    val path = BlobService.upload(file)
+    return Apollo.executeMutation(
+        EditorScreen_PersistBlobAsImage_Mutation(input = PersistBlobAsImageInput(path = path))
+      )
+      .persistBlobAsImage
+      .toEditorImageAsset()
+  }
+
+  override suspend fun persistFile(file: PickedFile): EditorFileAsset {
+    val path = BlobService.upload(file)
+    return Apollo.executeMutation(
+        EditorScreen_PersistBlobAsFile_Mutation(input = PersistBlobAsFileInput(path = path))
+      )
+      .persistBlobAsFile
+      .toEditorFileAsset()
+  }
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/attachment/SessionEditorIncomingContentHandler.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/attachment/SessionEditorIncomingContentHandler.kt
@@ -1,0 +1,117 @@
+package co.typie.screen.editor.editor.attachment
+
+import co.typie.editor.DocumentEditingSession
+import co.typie.editor.ffi.ClipboardOp
+import co.typie.editor.ffi.FlatImeOp
+import co.typie.editor.ffi.Message
+import co.typie.editor.input.EditorIncomingContentHandler
+import co.typie.editor.scroll.EditorBringIntoViewRequests
+import co.typie.editor.scroll.EditorBringIntoViewTarget
+import co.typie.platform.Clipboard
+import co.typie.platform.IncomingContentCandidates
+import co.typie.platform.IncomingContentItem
+import co.typie.platform.IncomingContentMode
+import co.typie.platform.SelectedIncomingContent
+import kotlinx.coroutines.async
+
+internal class SessionEditorIncomingContentHandler(
+  private val importer: EditorAttachmentImporter,
+  private val bringIntoViewRequests: EditorBringIntoViewRequests,
+  private val isSessionCurrent: (DocumentEditingSession) -> Boolean,
+  private val onAttachmentError: (String) -> Unit,
+) : EditorIncomingContentHandler {
+  override suspend fun handleClipboard(
+    session: DocumentEditingSession,
+    clipboard: Clipboard,
+    mode: IncomingContentMode,
+  ): Boolean {
+    if (!isSessionCurrent(session)) return false
+    val candidates = clipboard.paste() ?: return false
+    return handleCandidates(session, candidates, mode)
+  }
+
+  override suspend fun handleCandidates(
+    session: DocumentEditingSession,
+    candidates: IncomingContentCandidates,
+    mode: IncomingContentMode,
+  ): Boolean {
+    if (!isSessionCurrent(session)) {
+      candidates.close()
+      return false
+    }
+
+    return when (val selected = candidates.select(mode)) {
+      is SelectedIncomingContent.RichText -> pasteRichText(session, selected)
+      is SelectedIncomingContent.Attachments -> {
+        val requestedCount = selected.items.size + selected.unreadableItemCount
+        val hasImages = selected.items.any { it.kind == IncomingContentItem.Kind.Image }
+        val hasFiles = selected.items.any { it.kind == IncomingContentItem.Kind.File }
+        val onCompleted: (Int) -> Unit = { importedCount ->
+          if (importedCount < requestedCount) {
+            onAttachmentError(
+              when {
+                selected.unreadableItemCount > 0 ->
+                  if (importedCount == 0) {
+                    "첨부 파일을 삽입하지 못했어요."
+                  } else {
+                    "일부 첨부 파일을 삽입하지 못했어요."
+                  }
+                hasImages && !hasFiles ->
+                  if (importedCount == 0) {
+                    "이미지를 삽입하지 못했어요."
+                  } else {
+                    "일부 이미지를 삽입하지 못했어요."
+                  }
+                hasFiles && !hasImages ->
+                  if (importedCount == 0) {
+                    "파일을 삽입하지 못했어요."
+                  } else {
+                    "일부 파일을 삽입하지 못했어요."
+                  }
+                else ->
+                  if (importedCount == 0) {
+                    "첨부 파일을 삽입하지 못했어요."
+                  } else {
+                    "일부 첨부 파일을 삽입하지 못했어요."
+                  }
+              }
+            )
+          }
+        }
+        importer.import(
+          session = session,
+          items = selected.items,
+          destination = EditorAttachmentDestination.CurrentSelection,
+          onCompleted = onCompleted,
+        )
+      }
+      SelectedIncomingContent.None -> false
+    }
+  }
+
+  private suspend fun pasteRichText(
+    session: DocumentEditingSession,
+    content: SelectedIncomingContent.RichText,
+  ): Boolean {
+    val operation =
+      session.submit { editor, context ->
+        editor.scope.async(context) {
+          editor.await(
+            admit = { isSessionCurrent(session) },
+            beforeCommit = { state ->
+              bringIntoViewRequests.requestForVersion(
+                target = EditorBringIntoViewTarget.CurrentSelectionHead,
+                version = state.version,
+              )
+            },
+          ) {
+            if (editor.ime?.composing != null) {
+              enqueue(Message.TextInput(listOf(FlatImeOp.CommitAsIs)))
+            }
+            enqueue(Message.Clipboard(ClipboardOp.Paste(html = content.html, text = content.text)))
+          }
+        }
+      } ?: return false
+    return operation.await()
+  }
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorContextMenuActions.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorContextMenuActions.kt
@@ -8,11 +8,14 @@ import co.typie.editor.ffi.ClipboardOp
 import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.SelectionExpansionUnit
 import co.typie.editor.ffi.SelectionOp
+import co.typie.editor.input.LocalEditorIncomingContentHandler
 import co.typie.editor.runtime.EditorContextMenuState
+import co.typie.editor.runtime.LocalEditorRuntime
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.EditorBringIntoViewTarget
 import co.typie.editor.scroll.awaitWithBringIntoView
 import co.typie.platform.Clipboard
+import co.typie.platform.IncomingContentMode
 import co.typie.platform.PlatformModule
 import kotlinx.coroutines.launch
 
@@ -38,6 +41,8 @@ internal fun rememberEditorContextMenuActions(
   clipboard: Clipboard = PlatformModule.clipboard,
 ): EditorContextMenuActions {
   val selection = editor.selection
+  val runtime = LocalEditorRuntime.current
+  val incomingContentHandler = LocalEditorIncomingContentHandler.current
   return remember(
     editor,
     selection,
@@ -45,6 +50,8 @@ internal fun rememberEditorContextMenuActions(
     bringIntoViewRequests,
     contextMenu,
     clipboard,
+    runtime,
+    incomingContentHandler,
   ) {
     val expandSelection =
       { unit: SelectionExpansionUnit, bringIntoViewTarget: EditorBringIntoViewTarget? ->
@@ -81,11 +88,10 @@ internal fun rememberEditorContextMenuActions(
         }
       },
       onPaste = {
-        editor.scope.launch {
-          val read = clipboard.paste() ?: return@launch
-          editor.awaitWithBringIntoView(bringIntoViewRequests) {
-            enqueue(Message.Clipboard(ClipboardOp.Paste(html = read.html, text = read.text)))
-            beforeCommit { bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead) }
+        val session = runtime.session?.takeIf { it.editor === editor }
+        if (session != null) {
+          editor.scope.launch {
+            incomingContentHandler.handleClipboard(session, clipboard, IncomingContentMode.Rich)
           }
         }
       },

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarHost.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarHost.kt
@@ -108,8 +108,8 @@ internal fun EditorToolbarHost(
       commentEnabled = commentEnabled,
       onCommentRequest = onCommentRequest,
     )
-  val pickImage = rememberEditorImagePicker(commandScope)
-  val pickFile = rememberEditorFilePicker(commandScope)
+  val pickImage = rememberEditorImagePicker()
+  val pickFile = rememberEditorFilePicker()
   val pages =
     rememberEditorToolbarPages(
       toolbarContext = toolbarContext,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/FileToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/FileToolbar.kt
@@ -3,43 +3,29 @@ package co.typie.screen.editor.editor.toolbar.contextual
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
-import co.typie.domain.blob.BlobService
-import co.typie.editor.Editor
-import co.typie.editor.external.EditorFileAsset
-import co.typie.editor.external.EditorFileUpload
+import co.typie.editor.DocumentEditingSession
 import co.typie.editor.external.LocalEditorExternalElementState
-import co.typie.editor.ffi.ExternalElementData
-import co.typie.editor.ffi.FlatImeOp
-import co.typie.editor.ffi.Fragment
-import co.typie.editor.ffi.InsertionOp
 import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.NodeOp
 import co.typie.editor.ffi.PlainNode
 import co.typie.editor.runtime.LocalEditorRuntime
-import co.typie.editor.scroll.EditorBringIntoViewRequests
-import co.typie.editor.scroll.EditorBringIntoViewTarget
-import co.typie.editor.scroll.LocalEditorBringIntoViewRequests
-import co.typie.editor.scroll.awaitWithBringIntoView
-import co.typie.graphql.Apollo
-import co.typie.graphql.EditorScreen_PersistBlobAsFile_Mutation
-import co.typie.graphql.executeMutation
-import co.typie.graphql.type.PersistBlobAsFileInput
 import co.typie.icons.Lucide
 import co.typie.platform.FilePickerResult
 import co.typie.platform.FilePickerSelectionMode
-import co.typie.platform.PickedFile
+import co.typie.platform.IncomingContentItem
 import co.typie.platform.rememberFilePicker
-import co.typie.screen.editor.editor.toEditorFileAsset
+import co.typie.screen.editor.editor.attachment.EditorAttachmentDestination
+import co.typie.screen.editor.editor.attachment.LocalEditorAttachmentImporter
 import co.typie.screen.editor.editor.toolbar.EditorToolbarButton
 import co.typie.screen.editor.editor.toolbar.EditorToolbarPage
 import co.typie.screen.editor.editor.toolbar.EditorToolbarPageKey
 import co.typie.screen.editor.editor.toolbar.EditorToolbarPageScope
 import co.typie.screen.editor.editor.toolbar.EditorToolbarRow
 import co.typie.ui.component.toast.LocalToast
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.launch
 
 internal fun editorFileToolbarPage(
@@ -61,18 +47,17 @@ internal fun editorFileToolbarPage(
 // the IME, which unmounts the toolbar pages, and an ActivityResult launcher registered there
 // would be unregistered before the result arrives.
 @Composable
-internal fun rememberEditorFilePicker(commandScope: CoroutineScope): (nodeId: String) -> Unit {
+internal fun rememberEditorFilePicker(): (nodeId: String) -> Unit {
   val toast = LocalToast.current
   val runtime = LocalEditorRuntime.current
-  val bringIntoViewRequests = LocalEditorBringIntoViewRequests.current
-  val externalElementState = LocalEditorExternalElementState.current
-  val fileState = externalElementState.files
-  val pendingNodeId = remember { mutableStateOf<String?>(null) }
+  val importer = LocalEditorAttachmentImporter.current
+  val scope = rememberCoroutineScope()
+  val pendingRequest = remember { mutableStateOf<Pair<DocumentEditingSession, String>?>(null) }
 
   val picker =
     rememberFilePicker(selectionMode = FilePickerSelectionMode.Multiple) { result ->
-      val selectedNodeId = pendingNodeId.value
-      pendingNodeId.value = null
+      val request = pendingRequest.value
+      pendingRequest.value = null
       val files =
         when (result) {
           FilePickerResult.Cancelled -> return@rememberFilePicker
@@ -87,98 +72,55 @@ internal fun rememberEditorFilePicker(commandScope: CoroutineScope): (nodeId: St
             result.files
           }
         }
-      if (selectedNodeId == null) {
+      if (request == null) {
         files.forEach { it.close() }
         return@rememberFilePicker
       }
-      val selectedFile = files.first()
-      val selectedUpload = selectedFile.toFileUpload()
-      val restUploads = files.drop(1).map { file -> file to file.toFileUpload() }
-
-      val uploadJob = commandScope.launch {
-        fileState.uploads[selectedNodeId] = selectedUpload
-
-        val restNodeIds =
-          try {
-            insertFilePlaceholders(
-              editor = runtime.editor,
-              bringIntoViewRequests = bringIntoViewRequests,
-              count = restUploads.size,
-            )
-          } catch (error: CancellationException) {
-            throw error
-          } catch (_: Throwable) {
-            toast.error("파일 업로드에 실패했어요.")
-            emptyList()
-          }
-
-        if (restNodeIds.size < restUploads.size) {
-          toast.error("일부 파일을 삽입하지 못했어요.")
-        }
-
-        restNodeIds.zip(restUploads).forEach { (newNodeId, pending) ->
-          fileState.uploads[newNodeId] = pending.second
-        }
-
-        fun launchUpload(targetNodeId: String, file: PickedFile, upload: EditorFileUpload) {
-          val job = launch {
-            try {
-              // TODO(TR-38): Check restrictedBlob before starting file uploads and
-              // surface the
-              // plan upgrade flow instead of letting the upload proceed.
-              completeAttachmentOperation(
-                persist = { uploadFileAsset(file) },
-                isCurrent = { fileState.uploads[targetNodeId] === upload },
-                cache = externalElementState::put,
-                commit = { uploaded ->
-                  val editor = checkNotNull(runtime.editor) { "No active editor is available" }
-                  val committedState =
-                    editor.awaitWithBringIntoView(bringIntoViewRequests) {
-                      if (editor.ime?.composing != null) {
-                        enqueue(Message.TextInput(listOf(FlatImeOp.CommitAsIs)))
-                      }
-                      enqueue(
-                        Message.Node(
-                          NodeOp.SetAttrs(
-                            id = targetNodeId,
-                            attrs = PlainNode.File(id = uploaded.id),
-                          )
-                        )
-                      )
-                      beforeCommit {
-                        bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
-                      }
-                    }
-                  checkNotNull(committedState) { "Editor file attrs did not commit" }
-                },
-                clearPending = {
-                  if (fileState.uploads[targetNodeId] === upload) {
-                    fileState.uploads.remove(targetNodeId)
-                  }
-                },
-              )
-            } catch (error: CancellationException) {
-              throw error
-            } catch (error: Throwable) {
-              reportAttachmentFailure(AttachmentKind.File, error)
-              toast.error("파일 업로드에 실패했어요.")
+      val (session, selectedNodeId) = request
+      val requestedCount = files.size
+      val items = files.map { file ->
+        IncomingContentItem(kind = IncomingContentItem.Kind.File, file = file)
+      }
+      val onCompleted: (Int) -> Unit = { importedCount ->
+        if (importedCount < requestedCount) {
+          toast.error(
+            if (importedCount == 0) {
+              "파일을 삽입하지 못했어요."
+            } else {
+              "일부 파일을 삽입하지 못했어요."
             }
-          }
-          job.invokeOnCompletion { file.close() }
-        }
-
-        launchUpload(targetNodeId = selectedNodeId, file = selectedFile, upload = selectedUpload)
-        restNodeIds.zip(restUploads).forEach { (newNodeId, pending) ->
-          launchUpload(targetNodeId = newNodeId, file = pending.first, upload = pending.second)
+          )
         }
       }
-      uploadJob.invokeOnCompletion { files.forEach { it.close() } }
+      var importStarted = false
+      scope
+        .launch(start = CoroutineStart.UNDISPATCHED) {
+          importStarted = true
+          importer.import(
+            session = session,
+            items = items,
+            destination =
+              EditorAttachmentDestination.ExistingPlaceholder(
+                nodeId = selectedNodeId,
+                expectedKind = IncomingContentItem.Kind.File,
+              ),
+            onCompleted = onCompleted,
+          )
+        }
+        .invokeOnCompletion {
+          if (!importStarted) {
+            items.forEach { item -> item.file.close() }
+          }
+        }
     }
 
-  return remember(picker) {
+  return remember(picker, runtime) {
     { nodeId ->
-      pendingNodeId.value = nodeId
-      picker("*/*")
+      val session = runtime.session
+      if (session != null) {
+        pendingRequest.value = session to nodeId
+        picker("*/*")
+      }
     }
   }
 }
@@ -226,44 +168,4 @@ private fun EditorFileToolbar(
       },
     )
   }
-}
-
-private fun PickedFile.toFileUpload(): EditorFileUpload =
-  EditorFileUpload(name = filename, size = size)
-
-private suspend fun insertFilePlaceholders(
-  editor: Editor?,
-  bringIntoViewRequests: EditorBringIntoViewRequests,
-  count: Int,
-): List<String> {
-  if (editor == null || count <= 0) {
-    return emptyList()
-  }
-
-  val beforeNodeIds = editor.fileExternalNodeIds().toSet()
-  editor.awaitWithBringIntoView(bringIntoViewRequests) {
-    repeat(count) {
-      enqueue(Message.Insertion(InsertionOp.Fragment(Fragment(node = PlainNode.File(id = null)))))
-    }
-    beforeCommit { bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead) }
-  }
-
-  return editor.fileExternalNodeIds().filterNot(beforeNodeIds::contains)
-}
-
-private fun Editor.fileExternalNodeIds(): List<String> = externalElements.mapNotNull { element ->
-  when (element.data) {
-    is ExternalElementData.File -> element.node
-    else -> null
-  }
-}
-
-private suspend fun uploadFileAsset(file: PickedFile): EditorFileAsset {
-  val path = BlobService.upload(file)
-  val uploaded =
-    Apollo.executeMutation(
-        EditorScreen_PersistBlobAsFile_Mutation(input = PersistBlobAsFileInput(path = path))
-      )
-      .persistBlobAsFile
-  return uploaded.toEditorFileAsset()
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/ImageToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/ImageToolbar.kt
@@ -3,37 +3,21 @@ package co.typie.screen.editor.editor.toolbar.contextual
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
-import co.touchlab.kermit.Logger
-import co.typie.domain.blob.BlobService
-import co.typie.editor.Editor
-import co.typie.editor.external.EditorImageAsset
-import co.typie.editor.external.EditorImageUpload
+import co.typie.editor.DocumentEditingSession
 import co.typie.editor.external.LocalEditorExternalElementState
-import co.typie.editor.ffi.ExternalElementData
-import co.typie.editor.ffi.FlatImeOp
-import co.typie.editor.ffi.Fragment
-import co.typie.editor.ffi.ImageNodeAttr
-import co.typie.editor.ffi.InsertionOp
 import co.typie.editor.ffi.Message
-import co.typie.editor.ffi.NodeAttr
 import co.typie.editor.ffi.NodeOp
 import co.typie.editor.ffi.PlainNode
 import co.typie.editor.runtime.LocalEditorRuntime
-import co.typie.editor.scroll.EditorBringIntoViewRequests
-import co.typie.editor.scroll.EditorBringIntoViewTarget
-import co.typie.editor.scroll.LocalEditorBringIntoViewRequests
-import co.typie.editor.scroll.awaitWithBringIntoView
-import co.typie.graphql.Apollo
-import co.typie.graphql.EditorScreen_PersistBlobAsImage_Mutation
-import co.typie.graphql.executeMutation
-import co.typie.graphql.type.PersistBlobAsImageInput
 import co.typie.icons.Lucide
 import co.typie.platform.FilePickerResult
 import co.typie.platform.FilePickerSelectionMode
-import co.typie.platform.PickedFile
+import co.typie.platform.IncomingContentItem
 import co.typie.platform.rememberFilePicker
-import co.typie.screen.editor.editor.toEditorImageAsset
+import co.typie.screen.editor.editor.attachment.EditorAttachmentDestination
+import co.typie.screen.editor.editor.attachment.LocalEditorAttachmentImporter
 import co.typie.screen.editor.editor.toolbar.EditorToolbarButton
 import co.typie.screen.editor.editor.toolbar.EditorToolbarPage
 import co.typie.screen.editor.editor.toolbar.EditorToolbarPageKey
@@ -41,8 +25,7 @@ import co.typie.screen.editor.editor.toolbar.EditorToolbarPageScope
 import co.typie.screen.editor.editor.toolbar.EditorToolbarRow
 import co.typie.screen.editor.editor.toolbar.EditorToolbarSecondary
 import co.typie.ui.component.toast.LocalToast
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.launch
 
 internal fun editorImageToolbarPage(
@@ -64,18 +47,17 @@ internal fun editorImageToolbarPage(
 // the IME, which unmounts the toolbar pages, and an ActivityResult launcher registered there
 // would be unregistered before the result arrives.
 @Composable
-internal fun rememberEditorImagePicker(commandScope: CoroutineScope): (nodeId: String) -> Unit {
+internal fun rememberEditorImagePicker(): (nodeId: String) -> Unit {
   val toast = LocalToast.current
   val runtime = LocalEditorRuntime.current
-  val bringIntoViewRequests = LocalEditorBringIntoViewRequests.current
-  val externalElementState = LocalEditorExternalElementState.current
-  val imageState = externalElementState.images
-  val pendingNodeId = remember { mutableStateOf<String?>(null) }
+  val importer = LocalEditorAttachmentImporter.current
+  val scope = rememberCoroutineScope()
+  val pendingRequest = remember { mutableStateOf<Pair<DocumentEditingSession, String>?>(null) }
 
   val picker =
     rememberFilePicker(selectionMode = FilePickerSelectionMode.Multiple) { result ->
-      val selectedNodeId = pendingNodeId.value
-      pendingNodeId.value = null
+      val request = pendingRequest.value
+      pendingRequest.value = null
       val files =
         when (result) {
           FilePickerResult.Cancelled -> return@rememberFilePicker
@@ -90,115 +72,55 @@ internal fun rememberEditorImagePicker(commandScope: CoroutineScope): (nodeId: S
             result.files
           }
         }
-      if (selectedNodeId == null) {
+      if (request == null) {
         files.forEach { it.close() }
         return@rememberFilePicker
       }
-      val imageUploads = files.mapNotNull { file ->
-        val upload =
-          file.toImageUploadOrNull()
-            ?: run {
-              Logger.w {
-                "Picked file is not usable as an image: " +
-                  "mimeType=${file.mimeType}, width=${file.imageWidth}, height=${file.imageHeight}"
-              }
-              file.close()
-              return@mapNotNull null
+      val (session, selectedNodeId) = request
+      val requestedCount = files.size
+      val items = files.map { file ->
+        IncomingContentItem(kind = IncomingContentItem.Kind.Image, file = file)
+      }
+      val onCompleted: (Int) -> Unit = { importedCount ->
+        if (importedCount < requestedCount) {
+          toast.error(
+            if (importedCount == 0) {
+              "이미지를 삽입하지 못했어요."
+            } else {
+              "일부 이미지를 삽입하지 못했어요."
             }
-        file to upload
+          )
+        }
       }
-      if (imageUploads.isEmpty()) {
-        toast.error("이미지를 불러올 수 없어요.")
-        return@rememberFilePicker
-      }
-      val skippedImageCount = files.size - imageUploads.size
-      val (selectedImage, selectedUpload) = imageUploads.first()
-      val restUploads = imageUploads.drop(1)
-
-      val uploadJob = commandScope.launch {
-        imageState.uploads[selectedNodeId] = selectedUpload
-
-        val restNodeIds =
-          try {
-            insertImagePlaceholders(
-              editor = runtime.editor,
-              bringIntoViewRequests = bringIntoViewRequests,
-              count = restUploads.size,
-            )
-          } catch (error: CancellationException) {
-            throw error
-          } catch (_: Throwable) {
-            toast.error("이미지 업로드에 실패했어요.")
-            emptyList()
+      var importStarted = false
+      scope
+        .launch(start = CoroutineStart.UNDISPATCHED) {
+          importStarted = true
+          importer.import(
+            session = session,
+            items = items,
+            destination =
+              EditorAttachmentDestination.ExistingPlaceholder(
+                nodeId = selectedNodeId,
+                expectedKind = IncomingContentItem.Kind.Image,
+              ),
+            onCompleted = onCompleted,
+          )
+        }
+        .invokeOnCompletion {
+          if (!importStarted) {
+            items.forEach { item -> item.file.close() }
           }
-
-        if (skippedImageCount > 0 || restNodeIds.size < restUploads.size) {
-          toast.error("일부 이미지를 삽입하지 못했어요.")
         }
-
-        restNodeIds.zip(restUploads).forEach { (newNodeId, pending) ->
-          imageState.uploads[newNodeId] = pending.second
-        }
-
-        fun launchUpload(targetNodeId: String, file: PickedFile, upload: EditorImageUpload) {
-          val job = launch {
-            try {
-              // TODO(TR-38): Check restrictedBlob before starting image uploads and
-              // surface the
-              // plan upgrade flow instead of letting the upload proceed.
-              completeAttachmentOperation(
-                persist = { uploadImageAsset(file) },
-                isCurrent = { imageState.uploads[targetNodeId] === upload },
-                cache = externalElementState::put,
-                commit = { uploaded ->
-                  val editor = checkNotNull(runtime.editor) { "No active editor is available" }
-                  val committedState =
-                    editor.awaitWithBringIntoView(bringIntoViewRequests) {
-                      if (editor.ime?.composing != null) {
-                        enqueue(Message.TextInput(listOf(FlatImeOp.CommitAsIs)))
-                      }
-                      enqueue(
-                        Message.Node(
-                          NodeOp.SetAttr(
-                            id = targetNodeId,
-                            attr = NodeAttr.Image(ImageNodeAttr.Id(uploaded.id)),
-                          )
-                        )
-                      )
-                      beforeCommit {
-                        bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
-                      }
-                    }
-                  checkNotNull(committedState) { "Editor image attrs did not commit" }
-                },
-                clearPending = {
-                  if (imageState.uploads[targetNodeId] === upload) {
-                    imageState.uploads.remove(targetNodeId)
-                  }
-                },
-              )
-            } catch (error: CancellationException) {
-              throw error
-            } catch (error: Throwable) {
-              reportAttachmentFailure(AttachmentKind.Image, error)
-              toast.error("이미지 업로드에 실패했어요.")
-            }
-          }
-          job.invokeOnCompletion { file.close() }
-        }
-
-        launchUpload(targetNodeId = selectedNodeId, file = selectedImage, upload = selectedUpload)
-        restNodeIds.zip(restUploads).forEach { (newNodeId, pending) ->
-          launchUpload(targetNodeId = newNodeId, file = pending.first, upload = pending.second)
-        }
-      }
-      uploadJob.invokeOnCompletion { imageUploads.forEach { (file) -> file.close() } }
     }
 
-  return remember(picker) {
+  return remember(picker, runtime) {
     { nodeId ->
-      pendingNodeId.value = nodeId
-      picker("image/*")
+      val session = runtime.session
+      if (session != null) {
+        pendingRequest.value = session to nodeId
+        picker("image/*")
+      }
     }
   }
 }
@@ -248,56 +170,4 @@ private fun EditorImageToolbar(
       },
     )
   }
-}
-
-private fun PickedFile.toImageUploadOrNull(): EditorImageUpload? {
-  val width = imageWidth
-  val height = imageHeight
-  if (width == null || height == null || width <= 0 || height <= 0) {
-    return null
-  }
-
-  return EditorImageUpload(
-    previewModel = previewModel,
-    name = filename,
-    width = width,
-    height = height,
-  )
-}
-
-private suspend fun insertImagePlaceholders(
-  editor: Editor?,
-  bringIntoViewRequests: EditorBringIntoViewRequests,
-  count: Int,
-): List<String> {
-  if (editor == null || count <= 0) {
-    return emptyList()
-  }
-
-  val beforeNodeIds = editor.imageExternalNodeIds().toSet()
-  editor.awaitWithBringIntoView(bringIntoViewRequests) {
-    repeat(count) {
-      enqueue(Message.Insertion(InsertionOp.Fragment(Fragment(node = PlainNode.Image(id = null)))))
-    }
-    beforeCommit { bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead) }
-  }
-
-  return editor.imageExternalNodeIds().filterNot(beforeNodeIds::contains)
-}
-
-private fun Editor.imageExternalNodeIds(): List<String> = externalElements.mapNotNull { element ->
-  when (element.data) {
-    is ExternalElementData.Image -> element.node
-    else -> null
-  }
-}
-
-private suspend fun uploadImageAsset(file: PickedFile): EditorImageAsset {
-  val path = BlobService.upload(file)
-  val uploaded =
-    Apollo.executeMutation(
-        EditorScreen_PersistBlobAsImage_Mutation(input = PersistBlobAsImageInput(path = path))
-      )
-      .persistBlobAsImage
-  return uploaded.toEditorImageAsset()
 }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/KeyboardTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/KeyboardTest.kt
@@ -11,10 +11,12 @@ import co.typie.editor.ffi.Movement
 import co.typie.editor.ffi.NavigationOp
 import co.typie.editor.scroll.EditorBringIntoViewTarget
 import co.typie.platform.Clipboard
-import co.typie.platform.ClipboardReadPayload
+import co.typie.platform.IncomingContentCandidates
+import co.typie.platform.IncomingContentMode
 import co.typie.platform.Platform
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.TestScope
@@ -93,9 +95,9 @@ class KeyboardTest {
   fun navigationBindingsRevealCurrentSelectionHead() = runTest {
     val editor = Editor(FakeFfiEditor(), this, Dispatchers.Unconfined)
     val navigationBindings =
-      createBindings(Platform.Desktop).filter { binding ->
-        with(binding) { editor.action(NoopClipboard) }.singleOrNull() is Message.Navigation
-      }
+      createBindings(Platform.Desktop)
+        .filter { binding -> binding.action is EditorKeyBindingAction.Messages }
+        .filter { binding -> binding.resolveMessages(editor).singleOrNull() is Message.Navigation }
 
     assertTrue(navigationBindings.isNotEmpty())
     navigationBindings.forEach { binding ->
@@ -115,7 +117,7 @@ class KeyboardTest {
       }
     val editor = Editor(FakeFfiEditor(), this, Dispatchers.Unconfined)
 
-    val messages = with(binding) { editor.action(NoopClipboard) }
+    val messages = binding.resolveMessages(editor)
 
     assertEquals(
       listOf(Message.Key(FfiKeyEvent(FfiKey.Enter, InputModifiers(shift = true)))),
@@ -129,10 +131,7 @@ class KeyboardTest {
       createBindings(Platform.Desktop).single { it.key == ComposeKey.Tab && it.modifiers.isEmpty() }
     val editor = Editor(FakeFfiEditor(), this, Dispatchers.Unconfined)
 
-    assertEquals(
-      listOf(Message.Key(FfiKeyEvent(FfiKey.Tab))),
-      with(binding) { editor.action(NoopClipboard) },
-    )
+    assertEquals(listOf(Message.Key(FfiKeyEvent(FfiKey.Tab))), binding.resolveMessages(editor))
   }
 
   @Test
@@ -145,7 +144,21 @@ class KeyboardTest {
 
     assertEquals(
       listOf(Message.Key(FfiKeyEvent(FfiKey.Tab, InputModifiers(shift = true)))),
-      with(binding) { editor.action(NoopClipboard) },
+      binding.resolveMessages(editor),
+    )
+  }
+
+  @Test
+  fun pasteBindingsDeclarePasteActions() {
+    val pasteBindings = createBindings(Platform.Desktop).filter { it.key == ComposeKey.V }
+
+    assertEquals(
+      EditorKeyBindingAction.Paste(IncomingContentMode.Rich),
+      pasteBindings.single { it.modifiers == setOf(KeyModifier.Mod) }.action,
+    )
+    assertEquals(
+      EditorKeyBindingAction.Paste(IncomingContentMode.PlainTextOnly),
+      pasteBindings.single { it.modifiers == setOf(KeyModifier.Mod, KeyModifier.Shift) }.action,
     )
   }
 
@@ -158,9 +171,14 @@ class KeyboardTest {
       createBindings(Platform.Desktop).single { it.key == key && it.modifiers == modifiers }
     val editor = Editor(FakeFfiEditor(), this, Dispatchers.Unconfined)
 
-    val messages = with(binding) { editor.action(NoopClipboard) }
+    val messages = binding.resolveMessages(editor)
 
     assertEquals(listOf(Message.Navigation(NavigationOp.Move(expected, extend = true))), messages)
+  }
+
+  private suspend fun KeyBinding.resolveMessages(editor: Editor): List<Message> {
+    val action = assertIs<EditorKeyBindingAction.Messages>(action)
+    return action.messages(editor, NoopClipboard)
   }
 
   private object NoopClipboard : Clipboard {
@@ -170,6 +188,6 @@ class KeyboardTest {
 
     override suspend fun copyRichText(html: String, text: String): Boolean = true
 
-    override suspend fun paste(): ClipboardReadPayload? = null
+    override suspend fun paste(): IncomingContentCandidates? = null
   }
 }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/input/EditorKeyBindingCoalescerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/input/EditorKeyBindingCoalescerTest.kt
@@ -1,6 +1,7 @@
 package co.typie.editor.input
 
 import androidx.compose.ui.input.key.Key as ComposeKey
+import co.typie.editor.EditorKeyBindingAction
 import co.typie.editor.EditorLocalEditCoordinator
 import co.typie.editor.KeyBinding
 import co.typie.editor.ffi.Direction
@@ -9,7 +10,7 @@ import co.typie.editor.ffi.Movement
 import co.typie.editor.ffi.NavigationOp
 import co.typie.editor.scroll.EditorBringIntoViewTarget
 import co.typie.platform.Clipboard
-import co.typie.platform.ClipboardReadPayload
+import co.typie.platform.IncomingContentCandidates
 import kotlin.coroutines.CoroutineContext
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -34,7 +35,7 @@ class EditorKeyBindingCoalescerTest {
 
     override suspend fun copyRichText(html: String, text: String): Boolean = false
 
-    override suspend fun paste(): ClipboardReadPayload? = null
+    override suspend fun paste(): IncomingContentCandidates? = null
   }
 
   private data class Dispatched(val messages: List<Message>, val target: EditorBringIntoViewTarget?)
@@ -47,11 +48,11 @@ class EditorKeyBindingCoalescerTest {
     var dispatchGate: CompletableDeferred<Unit>? = null
     var dispatchFailure: Throwable? = null
     private val clipboard = FakeClipboard()
-    private val messagesByBinding = mutableMapOf<KeyBinding, List<Message>>()
+    private val messagesByAction = mutableMapOf<EditorKeyBindingAction.Messages, List<Message>>()
     private val coalescer =
       EditorKeyBindingCoalescer(
         scope = scope,
-        resolveMessages = { binding, _ -> messagesByBinding.getValue(binding) },
+        resolveMessages = { action, _ -> messagesByAction.getValue(action) },
         dispatch = { messages, target ->
           onDispatch()
           dispatched += Dispatched(messages, target)
@@ -86,9 +87,11 @@ class EditorKeyBindingCoalescerTest {
           coalescible = coalescible,
           action = { emptyList() },
         )
-      messagesByBinding[binding] = messages
+      messagesByAction[binding.action as EditorKeyBindingAction.Messages] = messages
       return coalescer.submit(binding, clipboard, localEditContext)
     }
+
+    fun submitOrdered(action: suspend () -> Unit): Deferred<Unit> = coalescer.submitOrdered(action)
 
     fun cancel() {
       scope.cancel()
@@ -111,6 +114,42 @@ class EditorKeyBindingCoalescerTest {
       workerScope.cancel()
     }
   }
+
+  @Test
+  fun `ordered actions wait in FIFO before a later binding dispatches`() =
+    runCoalescerTest { harness ->
+      val firstPasteRead = CompletableDeferred<Unit>()
+      val commandOrder = mutableListOf<String>()
+
+      val firstPaste = harness.submitOrdered {
+        firstPasteRead.await()
+        commandOrder += "paste-a"
+      }
+      val secondPaste = harness.submitOrdered { commandOrder += "paste-b" }
+      val backspace = harness.submit(moveMessage(1), coalescible = false)
+
+      testScheduler.runCurrent()
+
+      assertEquals(emptyList(), commandOrder)
+      assertEquals(emptyList(), harness.dispatched)
+
+      firstPasteRead.complete(Unit)
+      testScheduler.advanceUntilIdle()
+
+      assertEquals(listOf("paste-a", "paste-b"), commandOrder)
+      assertEquals(
+        listOf(
+          Dispatched(
+            messages = listOf(moveMessage(1)),
+            target = EditorBringIntoViewTarget.CurrentSelectionHead,
+          )
+        ),
+        harness.dispatched,
+      )
+      assertTrue(firstPaste.isCompleted)
+      assertTrue(secondPaste.isCompleted)
+      assertTrue(backspace.isCompleted)
+    }
 
   @Test
   fun `queued coalescible bindings drain into a single dispatch`() = runCoalescerTest { harness ->

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/input/EditorSelectionInputIntentTrackerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/input/EditorSelectionInputIntentTrackerTest.kt
@@ -308,6 +308,44 @@ class EditorSelectionInputIntentTrackerTest {
     )
   }
 
+  @Test
+  fun `late non navigation dispatch cannot clear newer in flight intent`() {
+    val tracker = EditorSelectionInputIntentTracker(staleTimeoutMillis = 1_000L)
+    val messages = listOf(move(direction = Direction.Forward, extend = false))
+    val preState = state(version = 1L, selection = ImeRange(18, 18))
+
+    val token =
+      tracker.recordAppOwnedDispatch(messages = messages, preState = preState, nowMillis = 0L)
+        ?: error("expected selection dispatch token")
+    tracker.recordAppOwnedDispatch(messages = emptyList(), preState = preState, nowMillis = 1L)
+
+    assertEquals(
+      EditorSelectionInputDecision.DropNativeSelectionCommand,
+      tracker.classifyNativeSelectionCommands(
+        commands = listOf(SetSelectionCommand(19, 19)),
+        state = preState,
+        nowMillis = 2L,
+      ),
+    )
+
+    tracker.recordAppOwnedCommit(
+      token = token,
+      messages = messages,
+      preState = preState,
+      postState = state(version = 2L, selection = ImeRange(19, 19)),
+      nowMillis = 3L,
+    )
+
+    assertEquals(
+      EditorSelectionInputDecision.DropNativeSelectionCommand,
+      tracker.classifyNativeSelectionCommands(
+        commands = listOf(SetSelectionCommand(19, 19)),
+        state = state(version = 2L, selection = ImeRange(19, 19)),
+        nowMillis = 4L,
+      ),
+    )
+  }
+
   private fun move(direction: Direction, extend: Boolean): Message =
     Message.Navigation(NavigationOp.Move(Movement.Grapheme(direction), extend))
 

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/platform/IncomingContentTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/platform/IncomingContentTest.kt
@@ -1,0 +1,254 @@
+package co.typie.platform
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.io.Buffer
+
+class IncomingContentTest {
+  @Test
+  fun nonemptyHtmlSkipsAttachmentMaterialization() = runTest {
+    var materializations = 0
+
+    val candidates =
+      materializeIncomingContentCandidates(html = "<p>rich</p>", text = "rich") {
+        materializations += 1
+        LoadedIncomingContentItems(listOf(trackedItem(IncomingContentItem.Kind.Image).item))
+      }
+
+    assertEquals(0, materializations)
+    assertEquals("<p>rich</p>", candidates?.html)
+    candidates?.close()
+  }
+
+  @Test
+  fun cancellationClosesPartiallyLoadedItemsExactlyOnce() = runTest {
+    val item = trackedItem(IncomingContentItem.Kind.Image)
+    val firstLoaded = CompletableDeferred<Unit>()
+    val never = CompletableDeferred<Unit>()
+    val loading = async {
+      loadOwnedIncomingContentItems(
+        listOf(
+          { item.item.also { firstLoaded.complete(Unit) } },
+          {
+            never.await()
+            null
+          },
+        )
+      )
+    }
+    firstLoaded.await()
+
+    loading.cancelAndJoin()
+
+    assertEquals(1, item.releaseCount)
+  }
+
+  @Test
+  fun cancellationBeforeCrossDispatcherDeliveryClosesLoadedCandidatesExactlyOnce() = runTest {
+    val item = trackedItem(IncomingContentItem.Kind.Image)
+    val loaded = CompletableDeferred<Unit>()
+    val loading = async {
+      loadOwnedIncomingContentCandidates(StandardTestDispatcher(testScheduler)) {
+        IncomingContentCandidates(items = listOf(item.item)).also { loaded.complete(Unit) }
+      }
+    }
+    loaded.await()
+
+    loading.cancelAndJoin()
+
+    assertEquals(1, item.releaseCount)
+  }
+
+  @Test
+  fun siblingFailurePreservesLoadedItemsAndCountsUnreadable() = runTest {
+    val item = trackedItem(IncomingContentItem.Kind.Image)
+    val firstLoaded = CompletableDeferred<Unit>()
+
+    val loaded =
+      loadOwnedIncomingContentItems(
+        listOf(
+          { item.item.also { firstLoaded.complete(Unit) } },
+          {
+            firstLoaded.await()
+            error("provider failed")
+          },
+        )
+      )
+
+    assertEquals(1, loaded.unreadableItemCount)
+    assertEquals(listOf(item.item), loaded.items)
+    loaded.items.forEach { it.file.close() }
+    assertEquals(1, item.releaseCount)
+  }
+
+  @Test
+  fun anyNonemptyHtmlWinsOverNativeAttachments() {
+    val image = trackedItem(IncomingContentItem.Kind.Image)
+    val file = trackedItem(IncomingContentItem.Kind.File)
+    val candidates =
+      IncomingContentCandidates(
+        html = "<meta data-slice-v2=\"valid\"><p>mixed</p>",
+        text = "mixed",
+        items = listOf(image.item, file.item),
+      )
+
+    val selected = candidates.select(IncomingContentMode.Rich)
+
+    assertEquals(SelectedIncomingContent.RichText(candidates.html, "mixed"), selected)
+    assertEquals(1, image.releaseCount)
+    assertEquals(1, file.releaseCount)
+  }
+
+  @Test
+  fun closingUnselectedCandidatesReleasesItemsExactlyOnce() {
+    val image = trackedItem(IncomingContentItem.Kind.Image)
+    val candidates = IncomingContentCandidates(items = listOf(image.item))
+
+    candidates.close()
+    candidates.close()
+
+    assertEquals(1, image.releaseCount)
+    assertFailsWith<IllegalStateException> { candidates.select(IncomingContentMode.Rich) }
+  }
+
+  @Test
+  fun externalHtmlWinsOverNativeAttachmentsWithoutLosingItsSupportedContent() {
+    val file = trackedItem(IncomingContentItem.Kind.File, "first.pdf")
+    val image = trackedItem(IncomingContentItem.Kind.Image, "second.png")
+    val candidates =
+      IncomingContentCandidates(
+        html = "<p>caption<img src=\"cid:image\"></p>",
+        text = "caption",
+        items = listOf(file.item, image.item),
+      )
+
+    val selected = candidates.select(IncomingContentMode.Rich)
+
+    assertEquals(SelectedIncomingContent.RichText(candidates.html, "caption"), selected)
+    assertEquals(1, file.releaseCount)
+    assertEquals(1, image.releaseCount)
+  }
+
+  @Test
+  fun ordinaryHtmlWithoutAttachmentsRemainsRichText() {
+    val candidates = IncomingContentCandidates(html = "<p>linked file</p>", text = "linked file")
+
+    val selected = candidates.select(IncomingContentMode.Rich)
+
+    assertEquals(SelectedIncomingContent.RichText("<p>linked file</p>", "linked file"), selected)
+  }
+
+  @Test
+  fun externalHtmlWithEmbeddedImageKeepsTheExistingRichTextPastePath() {
+    val candidates =
+      IncomingContentCandidates(
+        html = "<p>before<img src=\"https://example.com/image.png\">after</p>",
+        text = "before after",
+      )
+
+    val selected = candidates.select(IncomingContentMode.Rich)
+
+    assertEquals(SelectedIncomingContent.RichText(candidates.html, "before after"), selected)
+  }
+
+  @Test
+  fun attachmentOnlyPayloadTransfersItemsInProviderOrder() {
+    val file = trackedItem(IncomingContentItem.Kind.File, "first.pdf")
+    val image = trackedItem(IncomingContentItem.Kind.Image, "second.png")
+    val candidates = IncomingContentCandidates(items = listOf(file.item, image.item))
+
+    val selected = candidates.select(IncomingContentMode.Rich)
+
+    val attachments = assertIs<SelectedIncomingContent.Attachments>(selected)
+    assertEquals(listOf(file.item, image.item), attachments.items)
+    assertEquals(0, file.releaseCount)
+    assertEquals(0, image.releaseCount)
+
+    attachments.close()
+    attachments.close()
+    assertEquals(1, file.releaseCount)
+    assertEquals(1, image.releaseCount)
+  }
+
+  @Test
+  fun attachmentSelectionPreservesUnreadableItemCount() {
+    val image = trackedItem(IncomingContentItem.Kind.Image)
+    val candidates = IncomingContentCandidates(items = listOf(image.item), unreadableItemCount = 1)
+
+    val selected = candidates.select(IncomingContentMode.Rich)
+
+    val attachments = assertIs<SelectedIncomingContent.Attachments>(selected)
+    assertEquals(1, attachments.unreadableItemCount)
+    attachments.close()
+  }
+
+  @Test
+  fun unreadableOnlyPayloadStillSelectsAttachmentsForFailureReporting() {
+    val candidates = IncomingContentCandidates(unreadableItemCount = 2)
+
+    val selected = candidates.select(IncomingContentMode.Rich)
+
+    val attachments = assertIs<SelectedIncomingContent.Attachments>(selected)
+    assertEquals(emptyList(), attachments.items)
+    assertEquals(2, attachments.unreadableItemCount)
+  }
+
+  @Test
+  fun plainTextModeIgnoresHtmlAndReleasesAttachments() {
+    val image = trackedItem(IncomingContentItem.Kind.Image)
+    val candidates =
+      IncomingContentCandidates(
+        html = "<meta data-slice-v2=\"valid\"><p>rich</p>",
+        text = "plain",
+        items = listOf(image.item),
+      )
+
+    val selected = candidates.select(IncomingContentMode.PlainTextOnly)
+
+    assertEquals(SelectedIncomingContent.RichText(html = null, text = "plain"), selected)
+    assertEquals(1, image.releaseCount)
+  }
+
+  @Test
+  fun emptyCandidatesSelectNoneAndSelectionIsSingleUse() {
+    val candidates = IncomingContentCandidates(html = "", text = "")
+
+    assertEquals(SelectedIncomingContent.None, candidates.select(IncomingContentMode.Rich))
+    assertFailsWith<IllegalStateException> { candidates.select(IncomingContentMode.Rich) }
+  }
+
+  private fun trackedItem(
+    kind: IncomingContentItem.Kind,
+    filename: String = if (kind == IncomingContentItem.Kind.Image) "image.png" else "file.pdf",
+  ): TrackedItem {
+    var releaseCount = 0
+    val pickedFile =
+      PickedFile(
+        filename = filename,
+        mimeType = if (kind == IncomingContentItem.Kind.Image) "image/png" else "application/pdf",
+        size = 1,
+        previewModel = Unit,
+        openSource = { Buffer() },
+        release = { releaseCount += 1 },
+      )
+    return TrackedItem(
+      item = IncomingContentItem(kind = kind, file = pickedFile),
+      releaseCountProvider = { releaseCount },
+    )
+  }
+
+  private class TrackedItem(
+    val item: IncomingContentItem,
+    private val releaseCountProvider: () -> Int,
+  ) {
+    val releaseCount: Int
+      get() = releaseCountProvider()
+  }
+}

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/platform/NoopClipboard.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/platform/NoopClipboard.kt
@@ -7,5 +7,5 @@ internal object NoopClipboard : Clipboard {
 
   override suspend fun copyRichText(html: String, text: String): Boolean = false
 
-  override suspend fun paste(): ClipboardReadPayload? = null
+  override suspend fun paste(): IncomingContentCandidates? = null
 }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/attachment/DefaultEditorAttachmentImporterTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/attachment/DefaultEditorAttachmentImporterTest.kt
@@ -1,0 +1,1040 @@
+package co.typie.screen.editor.editor.attachment
+
+import co.typie.editor.Editor
+import co.typie.editor.FakeFfiEditor
+import co.typie.editor.external.EditorExternalElementState
+import co.typie.editor.external.EditorFileAsset
+import co.typie.editor.external.EditorFileUpload
+import co.typie.editor.external.EditorImageAsset
+import co.typie.editor.external.EditorImageUpload
+import co.typie.editor.ffi.AttachmentPlaceholderKind
+import co.typie.editor.ffi.EditorEvent
+import co.typie.editor.ffi.ExternalElement
+import co.typie.editor.ffi.ExternalElementData
+import co.typie.editor.ffi.FlatImeOp
+import co.typie.editor.ffi.ImageNodeAttr
+import co.typie.editor.ffi.Ime
+import co.typie.editor.ffi.ImeRange
+import co.typie.editor.ffi.InsertionOp
+import co.typie.editor.ffi.Message
+import co.typie.editor.ffi.NodeAttr
+import co.typie.editor.ffi.NodeOp
+import co.typie.editor.ffi.PlainNode
+import co.typie.editor.ffi.Rect
+import co.typie.editor.ffi.StateField
+import co.typie.editor.scroll.EditorBringIntoViewRequests
+import co.typie.editor.scroll.EditorBringIntoViewTarget
+import co.typie.editor.sync.createTestDocumentEditingSession
+import co.typie.platform.IncomingContentItem
+import co.typie.platform.PickedFile
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.io.Buffer
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DefaultEditorAttachmentImporterTest {
+  @Test
+  fun cancellationBeforeBackgroundCompletionCleansPendingAndFile() = runTest {
+    var released = false
+    val nodeId = "image-node"
+    lateinit var fake: FakeFfiEditor
+    fake =
+      FakeFfiEditor(
+        onTick = {
+          listOf(
+            EditorEvent.AttachmentPlaceholdersInserted(
+              requestId = requestedPlaceholderId(fake),
+              nodeIds = listOf(nodeId),
+            )
+          )
+        },
+        externalElementsProvider = { listOf(emptyImageElement(nodeId)) },
+      )
+    val dispatcher = StandardTestDispatcher(testScheduler)
+    val editor = Editor(fake, this, dispatcher)
+    val session = createTestDocumentEditingSession(editor, this)
+    val state = EditorExternalElementState()
+    val backgroundJob = Job()
+    val importer =
+      DefaultEditorAttachmentImporter(
+        externalElementState = state,
+        bringIntoViewRequests = EditorBringIntoViewRequests(),
+        persistence = FakePersistence,
+        isSessionCurrent = { it === session },
+        backgroundScope = CoroutineScope(backgroundJob + dispatcher),
+      )
+
+    val accepted =
+      importer.import(
+        session = session,
+        items = listOf(imageItem { released = true }),
+        destination = EditorAttachmentDestination.CurrentSelection,
+        onCompleted = {},
+      )
+
+    assertTrue(accepted)
+    assertTrue(state.images.uploads.containsKey(nodeId))
+    assertFalse(released)
+
+    backgroundJob.cancel()
+    advanceUntilIdle()
+
+    assertNull(state.images.uploads[nodeId])
+    assertTrue(released)
+  }
+
+  @Test
+  fun commitsActiveCompositionBeforePlaceholderInsertionThroughImporter() = runTest {
+    val nodeId = "image-node"
+    lateinit var fake: FakeFfiEditor
+    fake =
+      FakeFfiEditor(
+        onTick = {
+          if (fake.placeholderRequests().isNotEmpty()) {
+            listOf(
+              EditorEvent.StateChanged(fields = listOf(StateField.Ime)),
+              EditorEvent.AttachmentPlaceholdersInserted(
+                requestId = requestedPlaceholderId(fake),
+                nodeIds = listOf(nodeId),
+              ),
+            )
+          } else {
+            listOf(EditorEvent.StateChanged(fields = listOf(StateField.Ime)))
+          }
+        },
+        imeProvider = { _, _ ->
+          Ime(text = "가", windowStart = 0, selection = ImeRange(1, 1), composing = ImeRange(0, 1))
+        },
+        externalElementsProvider = { listOf(emptyImageElement(nodeId)) },
+      )
+    val editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
+    editor.setImeSessionActive(true)
+    editor.refreshImeSnapshot()
+    fake.enqueued.clear()
+    val session = createTestDocumentEditingSession(editor, this)
+    val importer =
+      DefaultEditorAttachmentImporter(
+        externalElementState = EditorExternalElementState(),
+        bringIntoViewRequests = EditorBringIntoViewRequests(),
+        persistence = FakePersistence,
+        isSessionCurrent = { it === session },
+        backgroundScope = this,
+      )
+
+    val accepted =
+      importer.import(
+        session = session,
+        items = listOf(imageItem {}),
+        destination = EditorAttachmentDestination.CurrentSelection,
+        onCompleted = {},
+      )
+
+    assertTrue(accepted)
+    assertEquals(Message.TextInput(listOf(FlatImeOp.CommitAsIs)), fake.enqueued[0])
+    val insertion = (fake.enqueued[1] as Message.Insertion).op as InsertionOp.AttachmentPlaceholders
+    assertEquals(listOf(AttachmentPlaceholderKind.Image), insertion.kinds)
+    advanceUntilIdle()
+  }
+
+  @Test
+  fun commandStageReturnsAfterPendingInstallationWithoutWaitingForUpload() = runTest {
+    var released = false
+    val persistenceStarted = CompletableDeferred<Unit>()
+    val persistenceGate = CompletableDeferred<Unit>()
+    val nodeId = "image-node"
+    lateinit var fake: FakeFfiEditor
+    fake =
+      FakeFfiEditor(
+        onTick = {
+          if (fake.placeholderRequests().isNotEmpty()) {
+            listOf(
+              EditorEvent.AttachmentPlaceholdersInserted(
+                requestId = requestedPlaceholderId(fake),
+                nodeIds = listOf(nodeId),
+              )
+            )
+          } else {
+            emptyList()
+          }
+        },
+        externalElementsProvider = { listOf(emptyImageElement(nodeId)) },
+      )
+    val editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
+    val session = createTestDocumentEditingSession(editor, this)
+    val state = EditorExternalElementState()
+    val bringIntoViewRequests = EditorBringIntoViewRequests()
+    val importer =
+      DefaultEditorAttachmentImporter(
+        externalElementState = state,
+        bringIntoViewRequests = bringIntoViewRequests,
+        persistence =
+          object : EditorAttachmentPersistence by FakePersistence {
+            override suspend fun persistImage(file: PickedFile): EditorImageAsset {
+              persistenceStarted.complete(Unit)
+              persistenceGate.await()
+              return FakePersistence.persistImage(file)
+            }
+          },
+        isSessionCurrent = { it === session },
+        backgroundScope = this,
+      )
+
+    val callbackInvocations = mutableListOf<Int>()
+    val accepted =
+      importer.import(
+        session = session,
+        items = listOf(imageItem { released = true }),
+        destination = EditorAttachmentDestination.CurrentSelection,
+        onCompleted = { importedCount -> callbackInvocations += importedCount },
+      )
+
+    assertFalse(persistenceStarted.isCompleted)
+    assertTrue(accepted)
+    assertTrue(callbackInvocations.isEmpty())
+    assertTrue(state.images.uploads.containsKey(nodeId))
+    assertFalse(released)
+    assertEquals(
+      EditorBringIntoViewRequests.Request(EditorBringIntoViewTarget.CurrentSelectionHead),
+      bringIntoViewRequests.activateForVersion(editor.state.version),
+    )
+
+    persistenceStarted.await()
+    assertFalse(released)
+    persistenceGate.complete(Unit)
+    advanceUntilIdle()
+
+    assertEquals(listOf(1), callbackInvocations)
+    assertTrue(released)
+  }
+
+  @Test
+  fun mapsPlaceholderUploadsAndCommitsAssetId() = runTest {
+    var released = false
+    var tick = 0
+    val nodeId = "image-node"
+    lateinit var fake: FakeFfiEditor
+    fake =
+      FakeFfiEditor(
+        onTick = {
+          tick += 1
+          if (tick == 1) {
+            listOf(
+              EditorEvent.AttachmentPlaceholdersInserted(
+                requestId = "other-request",
+                nodeIds = emptyList(),
+              ),
+              EditorEvent.AttachmentPlaceholdersInserted(
+                requestId = requestedPlaceholderId(fake),
+                nodeIds = listOf(nodeId),
+              ),
+            )
+          } else {
+            emptyList()
+          }
+        },
+        externalElementsProvider = { listOf(emptyImageElement(nodeId)) },
+      )
+    val editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
+    val session = createTestDocumentEditingSession(editor, this)
+    val state = EditorExternalElementState()
+    val importer =
+      DefaultEditorAttachmentImporter(
+        externalElementState = state,
+        bringIntoViewRequests = EditorBringIntoViewRequests(),
+        persistence = FakePersistence,
+        isSessionCurrent = { it === session },
+        backgroundScope = this,
+      )
+
+    val callbackInvocations = mutableListOf<Int>()
+    val accepted =
+      importer.import(
+        session = session,
+        items = listOf(imageItem { released = true }),
+        destination = EditorAttachmentDestination.CurrentSelection,
+        onCompleted = { importedCount -> callbackInvocations += importedCount },
+      )
+
+    assertTrue(accepted)
+    assertTrue(state.images.uploads.containsKey(nodeId))
+    advanceUntilIdle()
+    assertEquals(listOf(1), callbackInvocations)
+    assertTrue(released)
+    assertNull(state.images.uploads[nodeId])
+    assertEquals("asset-image", state.images.assets["asset-image"]?.id)
+    val committed =
+      fake.enqueued
+        .filterIsInstance<Message.Node>()
+        .map(Message.Node::op)
+        .filterIsInstance<NodeOp.SetAttr>()
+        .single()
+    assertEquals(nodeId, committed.id)
+    assertEquals(NodeAttr.Image(ImageNodeAttr.Id("asset-image")), committed.attr)
+  }
+
+  @Test
+  fun existingImagePlaceholderUsesFirstItemAndInsertsOnlyRemainingPlaceholders() = runTest {
+    var firstReleased = false
+    var secondReleased = false
+    var placeholderRequestHandled = false
+    val existingNodeId = "existing-image-node"
+    val insertedNodeId = "inserted-image-node"
+    lateinit var fake: FakeFfiEditor
+    fake =
+      FakeFfiEditor(
+        onTick = {
+          if (!placeholderRequestHandled && fake.placeholderRequests().isNotEmpty()) {
+            placeholderRequestHandled = true
+            listOf(
+              EditorEvent.AttachmentPlaceholdersInserted(
+                requestId = requestedPlaceholderId(fake),
+                nodeIds = listOf(insertedNodeId),
+              )
+            )
+          } else {
+            emptyList()
+          }
+        },
+        externalElementsProvider = {
+          listOf(emptyImageElement(existingNodeId), emptyImageElement(insertedNodeId))
+        },
+      )
+    val editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
+    editor.sync {}
+    val session = createTestDocumentEditingSession(editor, this)
+    val state = EditorExternalElementState()
+    val importer =
+      DefaultEditorAttachmentImporter(
+        externalElementState = state,
+        bringIntoViewRequests = EditorBringIntoViewRequests(),
+        persistence =
+          object : EditorAttachmentPersistence by FakePersistence {
+            override suspend fun persistImage(file: PickedFile): EditorImageAsset =
+              EditorImageAsset(
+                id = "asset-${file.filename.removeSuffix(".png")}",
+                url = "https://example.com/${file.filename}",
+                width = 10,
+                height = 5,
+                ratio = 2.0,
+                placeholder = null,
+              )
+          },
+        isSessionCurrent = { it === session },
+        backgroundScope = this,
+      )
+    val callbackInvocations = mutableListOf<Int>()
+
+    val accepted =
+      importer.import(
+        session = session,
+        items =
+          listOf(
+            imageItem(filename = "first.png") { firstReleased = true },
+            imageItem(filename = "second.png") { secondReleased = true },
+          ),
+        destination =
+          EditorAttachmentDestination.ExistingPlaceholder(
+            nodeId = existingNodeId,
+            expectedKind = IncomingContentItem.Kind.Image,
+          ),
+        onCompleted = { importedCount -> callbackInvocations += importedCount },
+      )
+
+    assertTrue(accepted)
+    assertTrue(state.images.uploads.containsKey(existingNodeId))
+    assertTrue(state.images.uploads.containsKey(insertedNodeId))
+    val placeholderRequests = fake.placeholderRequests()
+    assertEquals(1, placeholderRequests.size)
+    assertEquals(listOf(AttachmentPlaceholderKind.Image), placeholderRequests.single().kinds)
+
+    advanceUntilIdle()
+
+    assertEquals(listOf(2), callbackInvocations)
+    assertTrue(firstReleased)
+    assertTrue(secondReleased)
+    assertNull(state.images.uploads[existingNodeId])
+    assertNull(state.images.uploads[insertedNodeId])
+    val commits =
+      fake.enqueued
+        .filterIsInstance<Message.Node>()
+        .map(Message.Node::op)
+        .filterIsInstance<NodeOp.SetAttr>()
+    assertEquals(
+      listOf(
+        NodeOp.SetAttr(id = existingNodeId, attr = NodeAttr.Image(ImageNodeAttr.Id("asset-first"))),
+        NodeOp.SetAttr(id = insertedNodeId, attr = NodeAttr.Image(ImageNodeAttr.Id("asset-second"))),
+      ),
+      commits,
+    )
+  }
+
+  @Test
+  fun mixedBatchZipsOrderedKindsAndNodeIds() = runTest {
+    val nodeIds = listOf("first-image", "file", "second-image")
+    var placeholderRequestHandled = false
+    var releasedCount = 0
+    lateinit var fake: FakeFfiEditor
+    fake =
+      FakeFfiEditor(
+        onTick = {
+          if (!placeholderRequestHandled && fake.placeholderRequests().isNotEmpty()) {
+            placeholderRequestHandled = true
+            listOf(
+              EditorEvent.AttachmentPlaceholdersInserted(
+                requestId = requestedPlaceholderId(fake),
+                nodeIds = nodeIds,
+              )
+            )
+          } else {
+            emptyList()
+          }
+        },
+        externalElementsProvider = {
+          listOf(
+            emptyImageElement(nodeIds[0]),
+            emptyFileElement(nodeIds[1]),
+            emptyImageElement(nodeIds[2]),
+          )
+        },
+      )
+    val editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
+    val session = createTestDocumentEditingSession(editor, this)
+    val importer =
+      DefaultEditorAttachmentImporter(
+        externalElementState = EditorExternalElementState(),
+        bringIntoViewRequests = EditorBringIntoViewRequests(),
+        persistence =
+          object : EditorAttachmentPersistence by FakePersistence {
+            override suspend fun persistImage(file: PickedFile): EditorImageAsset =
+              EditorImageAsset(
+                id = "asset-${file.filename.removeSuffix(".png")}",
+                url = "https://example.com/${file.filename}",
+                width = 10,
+                height = 5,
+                ratio = 2.0,
+                placeholder = null,
+              )
+
+            override suspend fun persistFile(file: PickedFile): EditorFileAsset =
+              EditorFileAsset(
+                id = "asset-file",
+                name = file.filename,
+                url = "https://example.com/file.pdf",
+                size = file.size,
+              )
+          },
+        isSessionCurrent = { it === session },
+        backgroundScope = this,
+      )
+
+    val callbackInvocations = mutableListOf<Int>()
+    val accepted =
+      importer.import(
+        session = session,
+        items =
+          listOf(
+            imageItem(filename = "first.png") { releasedCount += 1 },
+            fileItem { releasedCount += 1 },
+            imageItem(filename = "second.png") { releasedCount += 1 },
+          ),
+        destination = EditorAttachmentDestination.CurrentSelection,
+        onCompleted = { importedCount -> callbackInvocations += importedCount },
+      )
+
+    assertTrue(accepted)
+    assertEquals(
+      listOf(
+        AttachmentPlaceholderKind.Image,
+        AttachmentPlaceholderKind.File,
+        AttachmentPlaceholderKind.Image,
+      ),
+      fake.placeholderRequests().single().kinds,
+    )
+
+    advanceUntilIdle()
+
+    assertEquals(listOf(3), callbackInvocations)
+    assertEquals(3, releasedCount)
+    val committedAssetsByNode =
+      fake.enqueued.filterIsInstance<Message.Node>().associate { message ->
+        when (val op = message.op) {
+          is NodeOp.SetAttr -> op.id to ((op.attr as NodeAttr.Image).attr as ImageNodeAttr.Id).value
+          is NodeOp.SetAttrs -> op.id to (op.attrs as PlainNode.File).id
+          else -> error("Unexpected node operation: $op")
+        }
+      }
+    assertEquals(
+      mapOf(nodeIds[0] to "asset-first", nodeIds[1] to "asset-file", nodeIds[2] to "asset-second"),
+      committedAssetsByNode,
+    )
+  }
+
+  @Test
+  fun existingFilePlaceholderPersistsAndCommitsFileAsset() = runTest {
+    var released = false
+    var persistFileCount = 0
+    val nodeId = "file-node"
+    val fake = FakeFfiEditor(externalElementsProvider = { listOf(emptyFileElement(nodeId)) })
+    val editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
+    editor.sync {}
+    val session = createTestDocumentEditingSession(editor, this)
+    val state = EditorExternalElementState()
+    val importer =
+      DefaultEditorAttachmentImporter(
+        externalElementState = state,
+        bringIntoViewRequests = EditorBringIntoViewRequests(),
+        persistence =
+          object : EditorAttachmentPersistence {
+            override suspend fun persistImage(file: PickedFile): EditorImageAsset =
+              error("unexpected image persistence")
+
+            override suspend fun persistFile(file: PickedFile): EditorFileAsset {
+              persistFileCount += 1
+              return EditorFileAsset(
+                id = "asset-file",
+                name = file.filename,
+                url = "https://example.com/file.pdf",
+                size = file.size,
+              )
+            }
+          },
+        isSessionCurrent = { it === session },
+        backgroundScope = this,
+      )
+    val callbackInvocations = mutableListOf<Int>()
+
+    val accepted =
+      importer.import(
+        session = session,
+        items = listOf(fileItem { released = true }),
+        destination =
+          EditorAttachmentDestination.ExistingPlaceholder(
+            nodeId = nodeId,
+            expectedKind = IncomingContentItem.Kind.File,
+          ),
+        onCompleted = { importedCount -> callbackInvocations += importedCount },
+      )
+
+    assertTrue(accepted)
+    val pending = state.files.uploads[nodeId]
+    assertTrue(pending is EditorFileUpload)
+    assertEquals("file.pdf", pending.name)
+    assertEquals(42, pending.size)
+    assertTrue(fake.placeholderRequests().isEmpty())
+
+    advanceUntilIdle()
+
+    assertEquals(1, persistFileCount)
+    assertEquals(listOf(1), callbackInvocations)
+    assertTrue(released)
+    assertNull(state.files.uploads[nodeId])
+    assertEquals("asset-file", state.files.assets["asset-file"]?.id)
+    val committed =
+      fake.enqueued
+        .filterIsInstance<Message.Node>()
+        .map(Message.Node::op)
+        .filterIsInstance<NodeOp.SetAttrs>()
+        .single()
+    assertEquals(NodeOp.SetAttrs(id = nodeId, attrs = PlainNode.File(id = "asset-file")), committed)
+  }
+
+  @Test
+  fun replacingPendingImageDuringPersistenceKeepsReplacementAndSkipsCommit() = runTest {
+    var released = false
+    val nodeId = "image-node"
+    val fake = FakeFfiEditor(externalElementsProvider = { listOf(emptyImageElement(nodeId)) })
+    val editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
+    editor.sync {}
+    val session = createTestDocumentEditingSession(editor, this)
+    val state = EditorExternalElementState()
+    val replacement =
+      EditorImageUpload(previewModel = Unit, name = "replacement.png", width = 20, height = 10)
+    val importer =
+      DefaultEditorAttachmentImporter(
+        externalElementState = state,
+        bringIntoViewRequests = EditorBringIntoViewRequests(),
+        persistence =
+          object : EditorAttachmentPersistence by FakePersistence {
+            override suspend fun persistImage(file: PickedFile): EditorImageAsset {
+              val original = state.images.uploads[nodeId]
+              assertTrue(original is EditorImageUpload)
+              assertTrue(original !== replacement)
+              state.images.uploads[nodeId] = replacement
+              return FakePersistence.persistImage(file)
+            }
+          },
+        isSessionCurrent = { it === session },
+        backgroundScope = this,
+      )
+    val callbackInvocations = mutableListOf<Int>()
+
+    val accepted =
+      importer.import(
+        session = session,
+        items = listOf(imageItem { released = true }),
+        destination =
+          EditorAttachmentDestination.ExistingPlaceholder(
+            nodeId = nodeId,
+            expectedKind = IncomingContentItem.Kind.Image,
+          ),
+        onCompleted = { importedCount -> callbackInvocations += importedCount },
+      )
+
+    assertTrue(accepted)
+    assertTrue(state.images.uploads[nodeId] !== replacement)
+
+    advanceUntilIdle()
+
+    assertEquals(listOf(0), callbackInvocations)
+    assertTrue(released)
+    assertTrue(state.images.uploads[nodeId] === replacement)
+    assertFalse(fake.enqueued.any { it is Message.Node })
+  }
+
+  @Test
+  fun persistenceFailureCompletesOnceAndClearsPendingOwnership() = runTest {
+    var released = false
+    var tick = 0
+    val nodeId = "image-node"
+    lateinit var fake: FakeFfiEditor
+    fake =
+      FakeFfiEditor(
+        onTick = {
+          tick += 1
+          if (tick == 1) {
+            listOf(
+              EditorEvent.AttachmentPlaceholdersInserted(
+                requestId = requestedPlaceholderId(fake),
+                nodeIds = listOf(nodeId),
+              )
+            )
+          } else {
+            emptyList()
+          }
+        },
+        externalElementsProvider = { listOf(emptyImageElement(nodeId)) },
+      )
+    val editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
+    val session = createTestDocumentEditingSession(editor, this)
+    val state = EditorExternalElementState()
+    val importer =
+      DefaultEditorAttachmentImporter(
+        externalElementState = state,
+        bringIntoViewRequests = EditorBringIntoViewRequests(),
+        persistence =
+          object : EditorAttachmentPersistence by FakePersistence {
+            override suspend fun persistImage(file: PickedFile): EditorImageAsset =
+              error("persistence failed")
+          },
+        isSessionCurrent = { it === session },
+        backgroundScope = this,
+      )
+    val callbackInvocations = mutableListOf<Int>()
+
+    val accepted =
+      importer.import(
+        session = session,
+        items = listOf(imageItem { released = true }),
+        destination = EditorAttachmentDestination.CurrentSelection,
+        onCompleted = { importedCount -> callbackInvocations += importedCount },
+      )
+
+    assertTrue(accepted)
+    assertTrue(state.images.uploads.containsKey(nodeId))
+    advanceUntilIdle()
+    assertEquals(listOf(0), callbackInvocations)
+    assertTrue(released)
+    assertNull(state.images.uploads[nodeId])
+    assertFalse(fake.enqueued.any { it is Message.Node })
+  }
+
+  @Test
+  fun oneOfTwoPersistenceFailuresCompletesOnceWithOneSuccessAndClosesBothFiles() = runTest {
+    var successReleased = false
+    var failureReleased = false
+    var tick = 0
+    val nodeIds = listOf("successful-image-node", "failed-image-node")
+    lateinit var fake: FakeFfiEditor
+    fake =
+      FakeFfiEditor(
+        onTick = {
+          tick += 1
+          if (tick == 1) {
+            listOf(
+              EditorEvent.AttachmentPlaceholdersInserted(
+                requestId = requestedPlaceholderId(fake),
+                nodeIds = nodeIds,
+              )
+            )
+          } else {
+            emptyList()
+          }
+        },
+        externalElementsProvider = { nodeIds.map(::emptyImageElement) },
+      )
+    val editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
+    val session = createTestDocumentEditingSession(editor, this)
+    val state = EditorExternalElementState()
+    val persistedFilenames = mutableListOf<String>()
+    val importer =
+      DefaultEditorAttachmentImporter(
+        externalElementState = state,
+        bringIntoViewRequests = EditorBringIntoViewRequests(),
+        persistence =
+          object : EditorAttachmentPersistence by FakePersistence {
+            override suspend fun persistImage(file: PickedFile): EditorImageAsset {
+              persistedFilenames += file.filename
+              if (file.filename == "failed.png") error("persistence failed")
+              return FakePersistence.persistImage(file)
+            }
+          },
+        isSessionCurrent = { it === session },
+        backgroundScope = this,
+      )
+    val callbackInvocations = mutableListOf<Int>()
+
+    val accepted =
+      importer.import(
+        session = session,
+        items =
+          listOf(
+            imageItem(filename = "successful.png") { successReleased = true },
+            imageItem(filename = "failed.png") { failureReleased = true },
+          ),
+        destination = EditorAttachmentDestination.CurrentSelection,
+        onCompleted = { importedCount -> callbackInvocations += importedCount },
+      )
+
+    assertTrue(accepted)
+    assertTrue(nodeIds.all(state.images.uploads::containsKey))
+    advanceUntilIdle()
+    assertEquals(listOf(1), callbackInvocations)
+    assertEquals(setOf("successful.png", "failed.png"), persistedFilenames.toSet())
+    assertEquals(2, persistedFilenames.size)
+    assertTrue(successReleased)
+    assertTrue(failureReleased)
+    assertTrue(nodeIds.none(state.images.uploads::containsKey))
+  }
+
+  @Test
+  fun sessionBecomingStaleAfterUploadPreventsCommitAndClearsOwnership() = runTest {
+    var current = true
+    var released = false
+    val nodeId = "image-node"
+    lateinit var fake: FakeFfiEditor
+    fake =
+      FakeFfiEditor(
+        onTick = {
+          listOf(
+            EditorEvent.AttachmentPlaceholdersInserted(
+              requestId = requestedPlaceholderId(fake),
+              nodeIds = listOf(nodeId),
+            )
+          )
+        },
+        externalElementsProvider = { listOf(emptyImageElement(nodeId)) },
+      )
+    val editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
+    val session = createTestDocumentEditingSession(editor, this)
+    val state = EditorExternalElementState()
+    val importer =
+      DefaultEditorAttachmentImporter(
+        externalElementState = state,
+        bringIntoViewRequests = EditorBringIntoViewRequests(),
+        persistence =
+          object : EditorAttachmentPersistence by FakePersistence {
+            override suspend fun persistImage(file: PickedFile): EditorImageAsset {
+              current = false
+              return FakePersistence.persistImage(file)
+            }
+          },
+        isSessionCurrent = { current && it === session },
+        backgroundScope = this,
+      )
+
+    val callbackInvocations = mutableListOf<Int>()
+    val accepted =
+      importer.import(
+        session = session,
+        items = listOf(imageItem { released = true }),
+        destination = EditorAttachmentDestination.CurrentSelection,
+        onCompleted = { importedCount -> callbackInvocations += importedCount },
+      )
+
+    assertTrue(accepted)
+    advanceUntilIdle()
+    assertEquals(listOf(0), callbackInvocations)
+    assertTrue(released)
+    assertNull(state.images.uploads[nodeId])
+    assertFalse(fake.enqueued.any { it is Message.Node })
+  }
+
+  @Test
+  fun placeholderRemovedDuringUploadPreventsCommitAndClosesFile() = runTest {
+    var placeholderExists = true
+    var placeholderRequestHandled = false
+    var released = false
+    val nodeId = "image-node"
+    lateinit var fake: FakeFfiEditor
+    fake =
+      FakeFfiEditor(
+        onTick = {
+          if (!placeholderRequestHandled && fake.placeholderRequests().isNotEmpty()) {
+            placeholderRequestHandled = true
+            listOf(
+              EditorEvent.AttachmentPlaceholdersInserted(
+                requestId = requestedPlaceholderId(fake),
+                nodeIds = listOf(nodeId),
+              )
+            )
+          } else {
+            emptyList()
+          }
+        },
+        externalElementsProvider = {
+          if (placeholderExists) listOf(emptyImageElement(nodeId)) else emptyList()
+        },
+      )
+    lateinit var editor: Editor
+    editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
+    val session = createTestDocumentEditingSession(editor, this)
+    val state = EditorExternalElementState()
+    val importer =
+      DefaultEditorAttachmentImporter(
+        externalElementState = state,
+        bringIntoViewRequests = EditorBringIntoViewRequests(),
+        persistence =
+          object : EditorAttachmentPersistence by FakePersistence {
+            override suspend fun persistImage(file: PickedFile): EditorImageAsset {
+              placeholderExists = false
+              editor.sync {}
+              return FakePersistence.persistImage(file)
+            }
+          },
+        isSessionCurrent = { it === session },
+        backgroundScope = this,
+      )
+
+    val callbackInvocations = mutableListOf<Int>()
+    val accepted =
+      importer.import(
+        session = session,
+        items = listOf(imageItem { released = true }),
+        destination = EditorAttachmentDestination.CurrentSelection,
+        onCompleted = { importedCount -> callbackInvocations += importedCount },
+      )
+
+    assertTrue(accepted)
+    advanceUntilIdle()
+
+    assertEquals(listOf(0), callbackInvocations)
+    assertTrue(released)
+    assertNull(state.images.uploads[nodeId])
+    assertFalse(fake.enqueued.any { it is Message.Node })
+  }
+
+  @Test
+  fun invalidImageIsRejectedBeforeAPlaceholderIsInserted() = runTest {
+    var released = false
+    val fake = FakeFfiEditor()
+    val editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
+    val session = createTestDocumentEditingSession(editor, this)
+    val importer =
+      DefaultEditorAttachmentImporter(
+        externalElementState = EditorExternalElementState(),
+        bringIntoViewRequests = EditorBringIntoViewRequests(),
+        persistence = FakePersistence,
+        isSessionCurrent = { it === session },
+        backgroundScope = this,
+      )
+    val invalidImage =
+      IncomingContentItem(
+        kind = IncomingContentItem.Kind.Image,
+        file =
+          PickedFile(
+            filename = "broken.png",
+            mimeType = "image/png",
+            size = 1,
+            previewModel = Unit,
+            openSource = { Buffer() },
+            release = { released = true },
+          ),
+      )
+
+    val callbackInvocations = mutableListOf<Int>()
+    val accepted =
+      importer.import(
+        session = session,
+        items = listOf(invalidImage),
+        destination = EditorAttachmentDestination.CurrentSelection,
+        onCompleted = { importedCount -> callbackInvocations += importedCount },
+      )
+
+    assertFalse(accepted)
+    advanceUntilIdle()
+    assertEquals(listOf(0), callbackInvocations)
+    assertTrue(released)
+    assertTrue(fake.placeholderRequests().isEmpty())
+  }
+
+  @Test
+  fun missingPlaceholderResultDoesNotStartUploadsAndClosesFiles() = runTest {
+    assertInvalidPlaceholderResultDoesNotStartUploads(nodeIds = null)
+  }
+
+  @Test
+  fun placeholderCountMismatchDoesNotStartUploadsAndClosesFiles() = runTest {
+    assertInvalidPlaceholderResultDoesNotStartUploads(nodeIds = listOf("only-one-node"))
+  }
+
+  private suspend fun TestScope.assertInvalidPlaceholderResultDoesNotStartUploads(
+    nodeIds: List<String>?
+  ) {
+    var releasedCount = 0
+    var persistenceCount = 0
+    lateinit var fake: FakeFfiEditor
+    fake =
+      FakeFfiEditor(
+        onTick = {
+          if (fake.placeholderRequests().isEmpty() || nodeIds == null) {
+            emptyList()
+          } else {
+            listOf(
+              EditorEvent.AttachmentPlaceholdersInserted(
+                requestId = requestedPlaceholderId(fake),
+                nodeIds = nodeIds,
+              )
+            )
+          }
+        }
+      )
+    val dispatcher = StandardTestDispatcher(testScheduler)
+    val editorScope = CoroutineScope(SupervisorJob() + dispatcher)
+    val editor = Editor(fake, editorScope, dispatcher)
+    val session = createTestDocumentEditingSession(editor, this)
+    val importer =
+      DefaultEditorAttachmentImporter(
+        externalElementState = EditorExternalElementState(),
+        bringIntoViewRequests = EditorBringIntoViewRequests(),
+        persistence =
+          object : EditorAttachmentPersistence by FakePersistence {
+            override suspend fun persistImage(file: PickedFile): EditorImageAsset {
+              persistenceCount += 1
+              return FakePersistence.persistImage(file)
+            }
+          },
+        isSessionCurrent = { it === session },
+        backgroundScope = this,
+      )
+
+    try {
+      assertFailsWith<IllegalStateException> {
+        importer.import(
+          session = session,
+          items =
+            listOf(
+              imageItem(filename = "first.png") { releasedCount += 1 },
+              imageItem(filename = "second.png") { releasedCount += 1 },
+            ),
+          destination = EditorAttachmentDestination.CurrentSelection,
+          onCompleted = {},
+        )
+      }
+    } finally {
+      editorScope.cancel()
+    }
+
+    assertEquals(0, persistenceCount)
+    assertEquals(2, releasedCount)
+  }
+
+  private fun requestedPlaceholderId(fake: FakeFfiEditor?): String {
+    return fake?.placeholderRequests()?.lastOrNull()?.requestId
+      ?: error("Placeholder request was not enqueued")
+  }
+
+  private fun FakeFfiEditor.placeholderRequests(): List<InsertionOp.AttachmentPlaceholders> =
+    enqueued
+      .filterIsInstance<Message.Insertion>()
+      .map(Message.Insertion::op)
+      .filterIsInstance<InsertionOp.AttachmentPlaceholders>()
+
+  private fun emptyImageElement(nodeId: String): ExternalElement =
+    ExternalElement(
+      pageIdx = 0,
+      node = nodeId,
+      bounds = Rect(0f, 0f, 1f, 1f),
+      isSelected = false,
+      data = ExternalElementData.Image(id = null, proportion = 100),
+    )
+
+  private fun emptyFileElement(nodeId: String): ExternalElement =
+    ExternalElement(
+      pageIdx = 0,
+      node = nodeId,
+      bounds = Rect(0f, 0f, 1f, 1f),
+      isSelected = false,
+      data = ExternalElementData.File(id = null),
+    )
+
+  private fun imageItem(
+    filename: String = "image.png",
+    onRelease: () -> Unit,
+  ): IncomingContentItem =
+    IncomingContentItem(
+      kind = IncomingContentItem.Kind.Image,
+      file =
+        PickedFile(
+          filename = filename,
+          mimeType = "image/png",
+          size = 1,
+          previewModel = Unit,
+          imageWidth = 10,
+          imageHeight = 5,
+          openSource = { Buffer() },
+          release = onRelease,
+        ),
+    )
+
+  private fun fileItem(onRelease: () -> Unit): IncomingContentItem =
+    IncomingContentItem(
+      kind = IncomingContentItem.Kind.File,
+      file =
+        PickedFile(
+          filename = "file.pdf",
+          mimeType = "application/pdf",
+          size = 42,
+          previewModel = Unit,
+          openSource = { Buffer() },
+          release = onRelease,
+        ),
+    )
+
+  private object FakePersistence : EditorAttachmentPersistence {
+    override suspend fun persistImage(file: PickedFile): EditorImageAsset =
+      EditorImageAsset(
+        id = "asset-image",
+        url = "https://example.com/image.png",
+        width = 10,
+        height = 5,
+        ratio = 2.0,
+        placeholder = null,
+      )
+
+    override suspend fun persistFile(file: PickedFile): EditorFileAsset = error("unexpected file")
+  }
+}

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/attachment/SessionEditorIncomingContentHandlerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/attachment/SessionEditorIncomingContentHandlerTest.kt
@@ -1,0 +1,346 @@
+package co.typie.screen.editor.editor.attachment
+
+import co.typie.editor.Editor
+import co.typie.editor.FakeFfiEditor
+import co.typie.editor.ffi.ClipboardOp
+import co.typie.editor.ffi.Message
+import co.typie.editor.scroll.EditorBringIntoViewRequests
+import co.typie.editor.sync.createTestDocumentEditingSession
+import co.typie.platform.Clipboard
+import co.typie.platform.IncomingContentCandidates
+import co.typie.platform.IncomingContentItem
+import co.typie.platform.IncomingContentMode
+import co.typie.platform.PickedFile
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import kotlinx.io.Buffer
+
+class SessionEditorIncomingContentHandlerTest {
+  @Test
+  fun htmlWinsWithoutAlsoImportingNativeAttachmentCandidates() = runTest {
+    var released = false
+    var importCalls = 0
+    val fake = FakeFfiEditor()
+    val editor = Editor(fake, this)
+    val session = createTestDocumentEditingSession(editor, this)
+    val handler =
+      SessionEditorIncomingContentHandler(
+        importer =
+          EditorAttachmentImporter { _, _, _, _ ->
+            importCalls += 1
+            true
+          },
+        bringIntoViewRequests = EditorBringIntoViewRequests(),
+        isSessionCurrent = { it === session },
+        onAttachmentError = {},
+      )
+
+    val handled =
+      handler.handleCandidates(
+        session = session,
+        candidates =
+          IncomingContentCandidates(
+            html = "<p>before<img src=\"https://example.com/image.png\">after</p>",
+            text = "before after",
+            items = listOf(imageItem { released = true }),
+          ),
+        mode = IncomingContentMode.Rich,
+      )
+
+    assertTrue(handled)
+    assertEquals(0, importCalls)
+    assertTrue(released)
+    assertTrue(
+      fake.enqueued.contains(
+        Message.Clipboard(
+          ClipboardOp.Paste(
+            html = "<p>before<img src=\"https://example.com/image.png\">after</p>",
+            text = "before after",
+          )
+        )
+      )
+    )
+  }
+
+  @Test
+  fun attachmentOnlyContentTransfersOwnershipAtCurrentSelectionAndReturnsImporterBoolean() =
+    runTest {
+      for (importerResult in listOf(false, true)) {
+        var released = false
+        var importedItems = emptyList<IncomingContentItem>()
+        lateinit var completeImport: (Int) -> Unit
+        val editor = Editor(FakeFfiEditor(), this)
+        val session = createTestDocumentEditingSession(editor, this)
+        val handler =
+          SessionEditorIncomingContentHandler(
+            importer =
+              EditorAttachmentImporter { importedSession, items, destination, onCompleted ->
+                assertTrue(importedSession === session)
+                assertEquals(EditorAttachmentDestination.CurrentSelection, destination)
+                importedItems = items
+                completeImport = onCompleted
+                items.forEach { it.file.close() }
+                importerResult
+              },
+            bringIntoViewRequests = EditorBringIntoViewRequests(),
+            isSessionCurrent = { it === session },
+            onAttachmentError = {},
+          )
+
+        val handled =
+          handler.handleCandidates(
+            session,
+            IncomingContentCandidates(items = listOf(imageItem { released = true })),
+          )
+
+        assertEquals(importerResult, handled)
+        assertEquals(1, importedItems.size)
+        assertTrue(released)
+        completeImport(if (importerResult) 1 else 0)
+      }
+    }
+
+  @Test
+  fun imageOnlyTotalFailureUsesImageErrorCopy() = runTest {
+    assertCompletionError(
+      items = mutableListOf(imageItem(), imageItem()),
+      accepted = false,
+      importedCount = 0,
+      expectedError = "이미지를 삽입하지 못했어요.",
+    )
+  }
+
+  @Test
+  fun imageOnlyPartialFailureUsesPartialImageErrorCopy() = runTest {
+    assertCompletionError(
+      items = mutableListOf(imageItem(), imageItem()),
+      accepted = true,
+      importedCount = 1,
+      expectedError = "일부 이미지를 삽입하지 못했어요.",
+    )
+  }
+
+  @Test
+  fun fileOnlyTotalFailureUsesFileErrorCopy() = runTest {
+    assertCompletionError(
+      items = mutableListOf(fileItem(), fileItem()),
+      accepted = true,
+      importedCount = 0,
+      expectedError = "파일을 삽입하지 못했어요.",
+    )
+  }
+
+  @Test
+  fun fileOnlyPartialFailureUsesPartialFileErrorCopy() = runTest {
+    assertCompletionError(
+      items = mutableListOf(fileItem(), fileItem()),
+      accepted = true,
+      importedCount = 1,
+      expectedError = "일부 파일을 삽입하지 못했어요.",
+    )
+  }
+
+  @Test
+  fun mixedFailuresUseAttachmentErrorCopy() = runTest {
+    assertCompletionError(
+      items = mutableListOf(imageItem(), fileItem()),
+      accepted = true,
+      importedCount = 0,
+      expectedError = "첨부 파일을 삽입하지 못했어요.",
+    )
+    assertCompletionError(
+      items = mutableListOf(imageItem(), fileItem()),
+      accepted = true,
+      importedCount = 1,
+      expectedError = "일부 첨부 파일을 삽입하지 못했어요.",
+    )
+  }
+
+  @Test
+  fun unreadableItemsCountAsGenericAttachmentFailures() = runTest {
+    assertCompletionError(
+      items = mutableListOf(imageItem()),
+      unreadableItemCount = 1,
+      accepted = true,
+      importedCount = 1,
+      expectedError = "일부 첨부 파일을 삽입하지 못했어요.",
+    )
+  }
+
+  @Test
+  fun completeSuccessDoesNotEmitAnAttachmentError() = runTest {
+    assertCompletionError(
+      items = mutableListOf(imageItem(), fileItem()),
+      accepted = true,
+      importedCount = 2,
+      expectedError = null,
+    )
+  }
+
+  @Test
+  fun staleSessionRejectsAndReleasesCandidates() = runTest {
+    var released = false
+    val editor = Editor(FakeFfiEditor(), this)
+    val session = createTestDocumentEditingSession(editor, this)
+    val handler =
+      SessionEditorIncomingContentHandler(
+        importer = EditorAttachmentImporter { _, _, _, _ -> error("must not import") },
+        bringIntoViewRequests = EditorBringIntoViewRequests(),
+        isSessionCurrent = { false },
+        onAttachmentError = {},
+      )
+
+    val handled =
+      handler.handleCandidates(
+        session,
+        IncomingContentCandidates(items = listOf(imageItem { released = true })),
+      )
+
+    assertFalse(handled)
+    assertTrue(released)
+  }
+
+  @Test
+  fun staleSessionDoesNotReadClipboard() = runTest {
+    var pasteCalls = 0
+    val editor = Editor(FakeFfiEditor(), this)
+    val session = createTestDocumentEditingSession(editor, this)
+    val handler =
+      SessionEditorIncomingContentHandler(
+        importer = EditorAttachmentImporter { _, _, _, _ -> error("must not import") },
+        bringIntoViewRequests = EditorBringIntoViewRequests(),
+        isSessionCurrent = { false },
+        onAttachmentError = {},
+      )
+    val clipboard =
+      object : Clipboard {
+        override suspend fun copy(bytes: ByteArray, mimeType: String): Boolean = false
+
+        override suspend fun copy(text: String, mimeType: String): Boolean = false
+
+        override suspend fun copyRichText(html: String, text: String): Boolean = false
+
+        override suspend fun paste(): IncomingContentCandidates? {
+          pasteCalls += 1
+          return null
+        }
+      }
+
+    val handled = handler.handleClipboard(session, clipboard, IncomingContentMode.Rich)
+
+    assertFalse(handled)
+    assertEquals(0, pasteCalls)
+  }
+
+  @Test
+  fun sessionReplacementDuringClipboardReadRejectsAndReleasesResult() = runTest {
+    var current = true
+    var released = false
+    val editor = Editor(FakeFfiEditor(), this)
+    val session = createTestDocumentEditingSession(editor, this)
+    val handler =
+      SessionEditorIncomingContentHandler(
+        importer = EditorAttachmentImporter { _, _, _, _ -> error("must not import") },
+        bringIntoViewRequests = EditorBringIntoViewRequests(),
+        isSessionCurrent = { current && it === session },
+        onAttachmentError = {},
+      )
+    val clipboard =
+      object : Clipboard {
+        override suspend fun copy(bytes: ByteArray, mimeType: String): Boolean = false
+
+        override suspend fun copy(text: String, mimeType: String): Boolean = false
+
+        override suspend fun copyRichText(html: String, text: String): Boolean = false
+
+        override suspend fun paste(): IncomingContentCandidates {
+          current = false
+          return IncomingContentCandidates(items = listOf(imageItem { released = true }))
+        }
+      }
+
+    val handled = handler.handleClipboard(session, clipboard, IncomingContentMode.Rich)
+
+    assertFalse(handled)
+    assertTrue(released)
+  }
+
+  private suspend fun TestScope.assertCompletionError(
+    items: MutableList<IncomingContentItem>,
+    unreadableItemCount: Int = 0,
+    accepted: Boolean,
+    importedCount: Int,
+    expectedError: String?,
+  ) {
+    val requestedCount = items.size
+    val errors = mutableListOf<String>()
+    var transferredCount = 0
+    lateinit var completeImport: (Int) -> Unit
+    val editor = Editor(FakeFfiEditor(), this)
+    val session = createTestDocumentEditingSession(editor, this)
+    val handler =
+      SessionEditorIncomingContentHandler(
+        importer =
+          EditorAttachmentImporter { importedSession, transferredItems, destination, onCompleted ->
+            assertTrue(importedSession === session)
+            assertEquals(EditorAttachmentDestination.CurrentSelection, destination)
+            transferredCount = transferredItems.size
+            completeImport = onCompleted
+            transferredItems.forEach { it.file.close() }
+            items.clear()
+            accepted
+          },
+        bringIntoViewRequests = EditorBringIntoViewRequests(),
+        isSessionCurrent = { it === session },
+        onAttachmentError = { error -> errors += error },
+      )
+
+    val handled =
+      handler.handleCandidates(
+        session,
+        IncomingContentCandidates(items = items, unreadableItemCount = unreadableItemCount),
+      )
+
+    assertEquals(accepted, handled)
+    assertEquals(requestedCount, transferredCount)
+    assertTrue(errors.isEmpty())
+
+    completeImport(importedCount)
+
+    assertEquals(listOfNotNull(expectedError), errors)
+  }
+
+  private fun imageItem(onRelease: () -> Unit = {}): IncomingContentItem =
+    IncomingContentItem(
+      kind = IncomingContentItem.Kind.Image,
+      file =
+        PickedFile(
+          filename = "image.png",
+          mimeType = "image/png",
+          size = 1,
+          previewModel = Unit,
+          imageWidth = 1,
+          imageHeight = 1,
+          openSource = { Buffer() },
+          release = onRelease,
+        ),
+    )
+
+  private fun fileItem(onRelease: () -> Unit = {}): IncomingContentItem =
+    IncomingContentItem(
+      kind = IncomingContentItem.Kind.File,
+      file =
+        PickedFile(
+          filename = "document.pdf",
+          mimeType = "application/pdf",
+          size = 1,
+          previewModel = Unit,
+          openSource = { Buffer() },
+          release = onRelease,
+        ),
+    )
+}

--- a/apps/mobile/compose/src/desktopMain/kotlin/co/typie/editor/input/EditorInput.desktop.kt
+++ b/apps/mobile/compose/src/desktopMain/kotlin/co/typie/editor/input/EditorInput.desktop.kt
@@ -23,6 +23,7 @@ import co.typie.editor.ffi.Message
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.EditorBringIntoViewTarget
 import co.typie.editor.scroll.syncWithBringIntoView
+import co.typie.platform.IncomingContentCandidates
 
 @OptIn(ExperimentalComposeUiApi::class)
 internal actual suspend fun PlatformTextInputSessionScope.createEditorInputRequest(
@@ -34,6 +35,7 @@ internal actual suspend fun PlatformTextInputSessionScope.createEditorInputReque
   textClippingRectInRoot: () -> Rect?,
   suppressSoftwareKeyboard: Boolean,
   isSessionCurrent: () -> Boolean,
+  onIncomingContent: (IncomingContentCandidates) -> Boolean,
 ): PlatformTextInputMethodRequest {
   return object : PlatformTextInputMethodRequest {
     override val value: () -> TextFieldValue = {

--- a/apps/mobile/compose/src/desktopMain/kotlin/co/typie/editor/input/EditorPlatformInputBridge.desktop.kt
+++ b/apps/mobile/compose/src/desktopMain/kotlin/co/typie/editor/input/EditorPlatformInputBridge.desktop.kt
@@ -13,11 +13,17 @@ internal actual class EditorPlatformInputBridge actual constructor() {
 
   actual fun onPreKeyEvent(
     event: KeyEvent,
-    editorState: () -> EditorState,
     inputCoroutineScope: CoroutineScope,
-    bindingMessages: suspend () -> List<Message>,
-    commit: suspend (List<Message>) -> EditorState?,
+    onAccepted: () -> Unit,
   ): Boolean = false
+
+  actual suspend fun dispatchAppOwnedKeyMessages(
+    messages: List<Message>,
+    preState: EditorState,
+    dispatch: suspend () -> EditorState?,
+  ) {
+    dispatch()
+  }
 
   actual fun shouldConsumeKeyEvent(event: KeyEvent): Boolean = false
 

--- a/apps/mobile/compose/src/desktopMain/kotlin/co/typie/platform/FilePicker.desktop.kt
+++ b/apps/mobile/compose/src/desktopMain/kotlin/co/typie/platform/FilePicker.desktop.kt
@@ -75,9 +75,9 @@ actual fun rememberFilePicker(
   }
 }
 
-private fun File.probeContentType(): String? {
+internal fun File.probeContentType(): String? {
   return runCatching { Files.probeContentType(toPath()) }.getOrNull()
 }
 
-private fun File.decodeImageOrNull(): BufferedImage? =
+internal fun File.decodeImageOrNull(): BufferedImage? =
   runCatching { ImageIO.read(this) }.getOrNull()

--- a/apps/mobile/compose/src/desktopMain/kotlin/co/typie/platform/PlatformServiceModule.desktop.kt
+++ b/apps/mobile/compose/src/desktopMain/kotlin/co/typie/platform/PlatformServiceModule.desktop.kt
@@ -5,11 +5,15 @@ import java.awt.Toolkit
 import java.awt.datatransfer.DataFlavor
 import java.awt.datatransfer.StringSelection
 import java.awt.datatransfer.Transferable
+import java.awt.image.BufferedImage
 import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 import java.io.File
 import javax.imageio.ImageIO
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.io.asSource
+import kotlinx.io.buffered
 
 internal class DesktopDeviceInfo : DeviceInfo {
   override fun retrieve(): DeviceInfoData {
@@ -62,31 +66,132 @@ internal class DesktopClipboard : Clipboard {
         .getOrDefault(false)
     }
 
-  override suspend fun paste(): ClipboardReadPayload? =
+  override suspend fun paste(): IncomingContentCandidates? =
     withContext(Dispatchers.IO) {
       runCatching {
-        val contents = Toolkit.getDefaultToolkit().systemClipboard.getContents(null)
-        val text =
-          if (contents.isDataFlavorSupported(DataFlavor.stringFlavor)) {
-            contents.getTransferData(DataFlavor.stringFlavor) as? String
-          } else {
-            null
-          } ?: return@runCatching null
-
-        val html =
-          if (contents.isDataFlavorSupported(DataFlavor.allHtmlFlavor)) {
-            when (val data = contents.getTransferData(DataFlavor.allHtmlFlavor)) {
-              is String -> data
-              is java.io.Reader -> data.readText()
-              else -> null
-            }
-          } else {
-            null
-          }
-        ClipboardReadPayload(html = html, text = text)
-      }
+          val contents =
+            Toolkit.getDefaultToolkit().systemClipboard.getContents(null) ?: return@runCatching null
+          contents.readIncomingContentCandidates()
+        }
         .getOrNull()
     }
+}
+
+internal fun Transferable.readString(flavor: DataFlavor): String? {
+  if (!isDataFlavorSupported(flavor)) return null
+  return runCatching {
+      when (val data = getTransferData(flavor)) {
+        is String -> data
+        is java.io.Reader -> data.use(java.io.Reader::readText)
+        else -> null
+      }
+    }
+    .getOrNull()
+}
+
+internal fun Transferable.readHtml(): String? =
+  listOf(DataFlavor.allHtmlFlavor, DataFlavor.fragmentHtmlFlavor, DataFlavor.selectionHtmlFlavor)
+    .firstNotNullOfOrNull { flavor -> readString(flavor)?.takeIf(String::isNotEmpty) }
+
+internal suspend fun Transferable.readIncomingContentCandidates(): IncomingContentCandidates? =
+  materializeIncomingContentCandidates(
+    html = readHtml(),
+    text = readString(DataFlavor.stringFlavor),
+    loadItems = ::readAttachmentItems,
+  )
+
+internal fun Transferable.readAttachmentItems(): LoadedIncomingContentItems {
+  if (isDataFlavorSupported(DataFlavor.javaFileListFlavor)) {
+    val transferred = runCatching { getTransferData(DataFlavor.javaFileListFlavor) as? List<*> }
+    if (transferred.isFailure) {
+      return LoadedIncomingContentItems(emptyList(), unreadableItemCount = 1)
+    }
+    val transferredFiles =
+      transferred.getOrNull()
+        ?: return LoadedIncomingContentItems(emptyList(), unreadableItemCount = 1)
+    val files = transferredFiles.filterIsInstance<File>()
+    if (transferredFiles.isNotEmpty()) {
+      val outcomes = files.map { file ->
+        runCatching {
+          check(file.isFile && file.canRead()) { "Clipboard file is unreadable" }
+          val mimeType = file.probeContentType()
+          val image =
+            if (mimeType?.substringBefore('/') == "image") {
+              checkNotNull(file.decodeImageOrNull()) { "Clipboard image is unreadable" }
+            } else {
+              null
+            }
+          IncomingContentItem(
+            kind =
+              if (mimeType?.substringBefore('/') == "image") {
+                IncomingContentItem.Kind.Image
+              } else {
+                IncomingContentItem.Kind.File
+              },
+            file =
+              PickedFile(
+                filename = file.name,
+                mimeType = mimeType,
+                size = file.length(),
+                previewModel = file,
+                imageWidth = image?.width,
+                imageHeight = image?.height,
+                openSource = { file.inputStream().asSource().buffered() },
+              ),
+          )
+        }
+      }
+      return LoadedIncomingContentItems(
+        items = outcomes.mapNotNull(Result<IncomingContentItem>::getOrNull),
+        unreadableItemCount =
+          transferredFiles.size - files.size +
+            outcomes.count(Result<IncomingContentItem>::isFailure),
+      )
+    }
+  }
+
+  if (!isDataFlavorSupported(DataFlavor.imageFlavor)) return LoadedIncomingContentItems(emptyList())
+  return runCatching {
+      val image = checkNotNull(getTransferData(DataFlavor.imageFlavor) as? Image)
+      val buffered = checkNotNull(image.toBufferedImageOrNull())
+      val bytes =
+        ByteArrayOutputStream().use { output ->
+          check(ImageIO.write(buffered, "png", output))
+          output.toByteArray()
+        }
+      IncomingContentItem(
+        kind = IncomingContentItem.Kind.Image,
+        file =
+          PickedFile(
+            filename = "image.png",
+            mimeType = "image/png",
+            size = bytes.size.toLong(),
+            previewModel = buffered,
+            imageWidth = buffered.width,
+            imageHeight = buffered.height,
+            openSource = { ByteArrayInputStream(bytes).asSource().buffered() },
+          ),
+      )
+    }
+    .fold(
+      onSuccess = { item -> LoadedIncomingContentItems(listOf(item)) },
+      onFailure = { LoadedIncomingContentItems(emptyList(), unreadableItemCount = 1) },
+    )
+}
+
+private fun Image.toBufferedImageOrNull(): BufferedImage? {
+  if (this is BufferedImage) return this
+  val width = getWidth(null)
+  val height = getHeight(null)
+  if (width <= 0 || height <= 0) return null
+  return BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB).also { buffered ->
+    val graphics = buffered.createGraphics()
+    try {
+      graphics.drawImage(this, 0, 0, null)
+    } finally {
+      graphics.dispose()
+    }
+  }
 }
 
 internal class ImageTransferable(private val image: Image) : Transferable {
@@ -124,17 +229,17 @@ internal class DesktopFileSystem : FileSystem {
   ): FileSystemSaveResult =
     withContext(Dispatchers.IO) {
       runCatching {
-        val directory =
-          when (location) {
-            FileSystemSaveLocation.Gallery -> File(System.getProperty("user.home"), "Pictures")
-            FileSystemSaveLocation.Files -> File(System.getProperty("user.home"), "Downloads")
-          }
-        directory.mkdirs()
+          val directory =
+            when (location) {
+              FileSystemSaveLocation.Gallery -> File(System.getProperty("user.home"), "Pictures")
+              FileSystemSaveLocation.Files -> File(System.getProperty("user.home"), "Downloads")
+            }
+          directory.mkdirs()
 
-        val file = uniqueFile(directory, name)
-        file.writeBytes(bytes)
-        FileSystemSaveResult.Success
-      }
+          val file = uniqueFile(directory, name)
+          file.writeBytes(bytes)
+          FileSystemSaveResult.Success
+        }
         .getOrElse { FileSystemSaveResult.Error }
     }
 }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/input/EditorInputEnabledDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/input/EditorInputEnabledDesktopTest.kt
@@ -17,14 +17,22 @@ import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.dp
 import co.typie.editor.Editor
 import co.typie.editor.FakeFfiEditor
+import co.typie.editor.ffi.Key as FfiKey
+import co.typie.editor.ffi.KeyEvent as FfiKeyEvent
+import co.typie.editor.ffi.Message
 import co.typie.editor.runtime.EditorUiState
 import co.typie.editor.scroll.LocalEditorBringIntoViewRequests
 import co.typie.editor.scroll.rememberEditorBringIntoViewRequests
 import co.typie.editor.sync.createTestDocumentEditingSession
+import co.typie.platform.Clipboard
+import co.typie.platform.IncomingContentCandidates
+import co.typie.platform.IncomingContentMode
 import co.typie.platform.NoopClipboard
 import co.typie.platform.Platform
 import kotlin.test.Test
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -32,6 +40,152 @@ import kotlinx.coroutines.cancel
 
 @OptIn(ExperimentalTestApi::class)
 class EditorInputEnabledDesktopTest {
+  @Test
+  fun laterKeyWaitsForPasteReadQueuedFromTheSameInputCallback() = runComposeUiTest {
+    val fake = FakeFfiEditor()
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val editor = Editor(fake, scope)
+    val session = createTestDocumentEditingSession(editor, scope)
+    val pasteStarted = CompletableDeferred<Unit>()
+    val finishPaste = CompletableDeferred<Unit>()
+    val handler =
+      object : EditorIncomingContentHandler {
+        override suspend fun handleClipboard(
+          session: co.typie.editor.DocumentEditingSession,
+          clipboard: Clipboard,
+          mode: IncomingContentMode,
+        ): Boolean {
+          pasteStarted.complete(Unit)
+          finishPaste.await()
+          return false
+        }
+
+        override suspend fun handleCandidates(
+          session: co.typie.editor.DocumentEditingSession,
+          candidates: IncomingContentCandidates,
+          mode: IncomingContentMode,
+        ): Boolean = false
+      }
+
+    try {
+      setContent {
+        val focusRequester = remember { FocusRequester() }
+        val bringIntoViewRequests = rememberEditorBringIntoViewRequests()
+        Box(
+          Modifier.size(200.dp)
+            .testTag(InputTag)
+            .focusRequester(focusRequester)
+            .editorInput(
+              session = session,
+              uiState = EditorUiState(),
+              platform = Platform.Desktop,
+              bringIntoViewRequests = bringIntoViewRequests,
+              enabled = true,
+              suppressSoftwareKeyboard = true,
+              clipboard = NoopClipboard,
+              incomingContentHandler = handler,
+            )
+            .focusable()
+        )
+        LaunchedEffect(Unit) { focusRequester.requestFocus() }
+      }
+      waitForIdle()
+
+      onNodeWithTag(InputTag).performKeyInput {
+        keyDown(Key.MetaLeft)
+        keyDown(Key.V)
+        keyUp(Key.V)
+        keyUp(Key.MetaLeft)
+        keyDown(Key.Backspace)
+        keyUp(Key.Backspace)
+      }
+      waitUntil(timeoutMillis = 5_000) { pasteStarted.isCompleted }
+
+      val backspace = Message.Key(FfiKeyEvent(FfiKey.Backspace))
+      assertFalse(fake.enqueued.contains(backspace))
+
+      finishPaste.complete(Unit)
+      waitUntil(timeoutMillis = 5_000) { fake.enqueued.contains(backspace) }
+    } finally {
+      finishPaste.complete(Unit)
+      session.stop()
+      scope.cancel()
+    }
+  }
+
+  @Test
+  fun platformEnumDoesNotReplaceDesktopKeyEventRouting() = runComposeUiTest {
+    val fake = FakeFfiEditor()
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val editor = Editor(fake, scope)
+    val recorder = EditorInputRecorder()
+    editor.inputRecorder = recorder
+    val session = createTestDocumentEditingSession(editor, scope)
+    val pasteHandled = CompletableDeferred<Unit>()
+    val handler =
+      object : EditorIncomingContentHandler {
+        override suspend fun handleClipboard(
+          session: co.typie.editor.DocumentEditingSession,
+          clipboard: Clipboard,
+          mode: IncomingContentMode,
+        ): Boolean {
+          pasteHandled.complete(Unit)
+          return true
+        }
+
+        override suspend fun handleCandidates(
+          session: co.typie.editor.DocumentEditingSession,
+          candidates: IncomingContentCandidates,
+          mode: IncomingContentMode,
+        ): Boolean = false
+      }
+
+    try {
+      setContent {
+        val focusRequester = remember { FocusRequester() }
+        val bringIntoViewRequests = rememberEditorBringIntoViewRequests()
+        Box(
+          Modifier.size(200.dp)
+            .testTag(InputTag)
+            .focusRequester(focusRequester)
+            .editorInput(
+              session = session,
+              uiState = EditorUiState(),
+              platform = Platform.iOS,
+              bringIntoViewRequests = bringIntoViewRequests,
+              enabled = true,
+              suppressSoftwareKeyboard = true,
+              clipboard = NoopClipboard,
+              incomingContentHandler = handler,
+            )
+            .focusable()
+        )
+        LaunchedEffect(Unit) { focusRequester.requestFocus() }
+      }
+      waitForIdle()
+
+      onNodeWithTag(InputTag).performKeyInput {
+        keyDown(Key.MetaLeft)
+        keyDown(Key.V)
+        keyUp(Key.V)
+        keyUp(Key.MetaLeft)
+      }
+      waitUntil(timeoutMillis = 5_000) { pasteHandled.isCompleted }
+
+      val hardwareKeys = recorder.snapshot().filterIsInstance<RecordedInputEntry.HardwareKey>()
+      assertTrue(
+        hardwareKeys.any { it.stage == "onPreKeyEvent" && it.matchedBinding && !it.consumed }
+      )
+      assertTrue(hardwareKeys.any { it.stage == "onKeyEvent" && it.matchedBinding && it.consumed })
+      assertFalse(
+        hardwareKeys.any { it.stage == "onPreKeyEvent" && it.matchedBinding && it.consumed }
+      )
+    } finally {
+      session.stop()
+      scope.cancel()
+    }
+  }
+
   @Test
   fun disabledEditorInputDoesNotDispatchHardwareKeys() = runComposeUiTest {
     val fake = FakeFfiEditor()

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/platform/DesktopIncomingContentTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/platform/DesktopIncomingContentTest.kt
@@ -1,0 +1,144 @@
+package co.typie.platform
+
+import java.awt.datatransfer.DataFlavor
+import java.awt.datatransfer.Transferable
+import java.awt.image.BufferedImage
+import java.io.File
+import java.nio.file.Files
+import javax.imageio.ImageIO
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+
+class DesktopIncomingContentTest {
+  @Test
+  fun nonemptyHtmlDoesNotRequestAttachmentFlavors() = runTest {
+    var attachmentReads = 0
+    val transferable =
+      FakeTransferable(
+        values =
+          linkedMapOf(
+            DataFlavor.allHtmlFlavor to "<p>rich</p>",
+            DataFlavor.stringFlavor to "rich",
+            DataFlavor.imageFlavor to BufferedImage(2, 2, BufferedImage.TYPE_INT_ARGB),
+          ),
+        onRead = { flavor ->
+          if (flavor == DataFlavor.imageFlavor || flavor == DataFlavor.javaFileListFlavor) {
+            attachmentReads += 1
+          }
+        },
+      )
+
+    val candidates = transferable.readIncomingContentCandidates()
+
+    assertEquals(0, attachmentReads)
+    assertEquals("<p>rich</p>", candidates?.html)
+    candidates?.close()
+  }
+
+  @Test
+  fun orderedFileListWinsOverDuplicateImageFlavor() {
+    val directory = Files.createTempDirectory("typie-clipboard-").toFile()
+    try {
+      val imageFile = File(directory, "first.png")
+      ImageIO.write(BufferedImage(2, 3, BufferedImage.TYPE_INT_ARGB), "png", imageFile)
+      val textFile = File(directory, "second.txt").apply { writeText("file") }
+      val transferable =
+        FakeTransferable(
+          linkedMapOf(
+            DataFlavor.javaFileListFlavor to listOf(imageFile, textFile),
+            DataFlavor.imageFlavor to BufferedImage(9, 9, BufferedImage.TYPE_INT_ARGB),
+          )
+        )
+
+      val items = transferable.readAttachmentItems().items
+
+      assertEquals(
+        listOf(IncomingContentItem.Kind.Image, IncomingContentItem.Kind.File),
+        items.map(IncomingContentItem::kind),
+      )
+      assertEquals(listOf("first.png", "second.txt"), items.map { it.file.filename })
+      assertEquals(2, items.first().file.imageWidth)
+      assertEquals(3, items.first().file.imageHeight)
+      items.forEach { it.file.close() }
+    } finally {
+      directory.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun imageFlavorMaterializesOnePngCandidate() {
+    val image = BufferedImage(4, 5, BufferedImage.TYPE_INT_ARGB)
+
+    val items = FakeTransferable(mapOf(DataFlavor.imageFlavor to image)).readAttachmentItems().items
+
+    assertEquals(1, items.size)
+    val file = items.single().file
+    assertEquals(IncomingContentItem.Kind.Image, items.single().kind)
+    assertEquals("image/png", file.mimeType)
+    assertEquals(4, file.imageWidth)
+    assertEquals(5, file.imageHeight)
+    assertTrue(requireNotNull(file.size) > 0)
+    file.close()
+  }
+
+  @Test
+  fun unreadableAdvertisedImageIsReported() {
+    val loaded = FakeTransferable(mapOf(DataFlavor.imageFlavor to Unit)).readAttachmentItems()
+
+    assertEquals(emptyList(), loaded.items)
+    assertEquals(1, loaded.unreadableItemCount)
+  }
+
+  @Test
+  fun unreadableFileListItemDoesNotDiscardReadableSibling() {
+    val file = Files.createTempFile("typie-clipboard-", ".txt").toFile()
+    try {
+      val loaded =
+        FakeTransferable(mapOf(DataFlavor.javaFileListFlavor to listOf(file, "not-a-file")))
+          .readAttachmentItems()
+
+      assertEquals(listOf(file.name), loaded.items.map { it.file.filename })
+      assertEquals(1, loaded.unreadableItemCount)
+      loaded.items.forEach { it.file.close() }
+    } finally {
+      file.delete()
+    }
+  }
+
+  @Test
+  fun htmlAndStringFlavorsRemainAvailable() {
+    val transferable =
+      FakeTransferable(
+        mapOf(DataFlavor.allHtmlFlavor to "<p>rich</p>", DataFlavor.stringFlavor to "rich")
+      )
+
+    assertEquals("<p>rich</p>", transferable.readHtml())
+    assertEquals("rich", transferable.readString(DataFlavor.stringFlavor))
+    assertNotNull(transferable.transferDataFlavors)
+  }
+
+  @Test
+  fun fragmentHtmlFlavorIsAcceptedWhenAllHtmlIsAbsent() {
+    val transferable =
+      FakeTransferable(mapOf(DataFlavor.fragmentHtmlFlavor to "<strong>fragment</strong>"))
+
+    assertEquals("<strong>fragment</strong>", transferable.readHtml())
+  }
+
+  private class FakeTransferable(
+    private val values: Map<DataFlavor, Any>,
+    private val onRead: (DataFlavor) -> Unit = {},
+  ) : Transferable {
+    override fun getTransferDataFlavors(): Array<DataFlavor> = values.keys.toTypedArray()
+
+    override fun isDataFlavorSupported(flavor: DataFlavor): Boolean = values.containsKey(flavor)
+
+    override fun getTransferData(flavor: DataFlavor): Any {
+      onRead(flavor)
+      return values[flavor] ?: error("Unsupported flavor: $flavor")
+    }
+  }
+}

--- a/apps/mobile/compose/src/iosMain/kotlin/co/typie/editor/input/EditorInput.ios.kt
+++ b/apps/mobile/compose/src/iosMain/kotlin/co/typie/editor/input/EditorInput.ios.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.text.input.TextEditorState
 import androidx.compose.ui.text.input.TextFieldValue
 import co.typie.editor.Editor
 import co.typie.editor.scroll.EditorBringIntoViewRequests
+import co.typie.platform.IncomingContentCandidates
 import kotlinx.cinterop.ExperimentalForeignApi
 import platform.CoreGraphics.CGRectMake
 import platform.UIKit.UIView
@@ -33,6 +34,7 @@ internal actual suspend fun PlatformTextInputSessionScope.createEditorInputReque
   textClippingRectInRoot: () -> Rect?,
   suppressSoftwareKeyboard: Boolean,
   isSessionCurrent: () -> Boolean,
+  onIncomingContent: (IncomingContentCandidates) -> Boolean,
 ): PlatformTextInputMethodRequest {
   return object : PlatformTextInputMethodRequest {
     private var lastPulledValue: TextFieldValue? = null

--- a/apps/mobile/compose/src/iosMain/kotlin/co/typie/editor/input/EditorPlatformInputBridge.ios.kt
+++ b/apps/mobile/compose/src/iosMain/kotlin/co/typie/editor/input/EditorPlatformInputBridge.ios.kt
@@ -19,7 +19,6 @@ import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.launch
 import swiftPMImport.co.typie.compose.EditorFloatingCursorBridge
 import swiftPMImport.co.typie.compose.EditorTextInputTraitsBridge
@@ -37,10 +36,8 @@ internal actual class EditorPlatformInputBridge actual constructor() {
 
   actual fun onPreKeyEvent(
     event: KeyEvent,
-    editorState: () -> EditorState,
     inputCoroutineScope: CoroutineScope,
-    bindingMessages: suspend () -> List<Message>,
-    commit: suspend (List<Message>) -> EditorState?,
+    onAccepted: () -> Unit,
   ): Boolean {
     val stroke = event.toPhysicalKeyStroke()
     if (!physicalKeyGate.accept(stroke)) {
@@ -51,26 +48,29 @@ internal actual class EditorPlatformInputBridge actual constructor() {
       physicalKeyGate.clear(stroke)
     }
 
-    val preState = editorState()
-    inputCoroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
-      val messages = bindingMessages()
-      if (messages.isEmpty()) {
-        selectionIntentTracker.reset()
-        return@launch
-      }
-      val dispatchToken =
-        selectionIntentTracker.recordAppOwnedDispatch(
-          messages = messages,
-          preState = preState,
-          nowMillis = nowMillis(),
-        )
-      val postState =
-        commit(messages)
-          ?: run {
-            dispatchToken?.let(selectionIntentTracker::cancelAppOwnedDispatch)
-            return@launch
-          }
-      if (dispatchToken != null) {
+    onAccepted()
+
+    return true
+  }
+
+  actual suspend fun dispatchAppOwnedKeyMessages(
+    messages: List<Message>,
+    preState: EditorState,
+    dispatch: suspend () -> EditorState?,
+  ) {
+    val dispatchToken =
+      selectionIntentTracker.recordAppOwnedDispatch(
+        messages = messages,
+        preState = preState,
+        nowMillis = nowMillis(),
+      )
+    if (messages.isEmpty()) return
+
+    try {
+      val postState = dispatch()
+      if (postState == null) {
+        dispatchToken?.let(selectionIntentTracker::cancelAppOwnedDispatch)
+      } else if (dispatchToken != null) {
         selectionIntentTracker.recordAppOwnedCommit(
           token = dispatchToken,
           messages = messages,
@@ -79,9 +79,10 @@ internal actual class EditorPlatformInputBridge actual constructor() {
           nowMillis = nowMillis(),
         )
       }
+    } catch (error: Throwable) {
+      dispatchToken?.let(selectionIntentTracker::cancelAppOwnedDispatch)
+      throw error
     }
-
-    return true
   }
 
   actual fun shouldConsumeKeyEvent(event: KeyEvent): Boolean = true

--- a/apps/mobile/compose/src/iosMain/kotlin/co/typie/platform/FilePicker.ios.kt
+++ b/apps/mobile/compose/src/iosMain/kotlin/co/typie/platform/FilePicker.ios.kt
@@ -208,7 +208,7 @@ private suspend fun NSItemProvider.loadSelectedImage(): Result<PickedFile> {
       )
   val type = UTType.typeWithIdentifier(typeIdentifier)
   val mimeType = type?.preferredMIMEType
-  val filename = imageFilename(suggestedName, type?.preferredFilenameExtension, mimeType)
+  val filename = providerFilename(suggestedName, type?.preferredFilenameExtension, mimeType)
 
   return suspendCancellableCoroutine { continuation ->
     var progress: NSProgress? = null
@@ -243,7 +243,7 @@ private suspend fun NSItemProvider.loadSelectedImage(): Result<PickedFile> {
   }
 }
 
-private fun NSURL.toPickedImage(filename: String, mimeType: String?): PickedFile {
+internal fun NSURL.toPickedImage(filename: String, mimeType: String?): PickedFile {
   val path = requireNotNull(path) { "Selected image path is unavailable" }
   val image = UIImage.imageWithContentsOfFile(path) ?: error("Unable to decode the selected image")
   return toPickedFile(
@@ -255,7 +255,7 @@ private fun NSURL.toPickedImage(filename: String, mimeType: String?): PickedFile
   )
 }
 
-private fun NSURL.toPickedFile(owned: Boolean): PickedFile {
+internal fun NSURL.toPickedFile(owned: Boolean): PickedFile {
   val inferredType =
     pathExtension?.takeIf(String::isNotBlank)?.let(UTType::typeWithFilenameExtension)
   return toPickedFile(
@@ -265,7 +265,7 @@ private fun NSURL.toPickedFile(owned: Boolean): PickedFile {
   )
 }
 
-private fun NSURL.toPickedFile(
+internal fun NSURL.toPickedFile(
   filename: String,
   mimeType: String?,
   imageWidth: Int? = null,
@@ -286,7 +286,7 @@ private fun NSURL.toPickedFile(
   )
 }
 
-private fun imageFilename(
+internal fun providerFilename(
   suggestedName: String?,
   preferredExtension: String?,
   mimeType: String?,
@@ -302,7 +302,7 @@ private fun imageFilename(
   return pickedFilename(withExtension, mimeType)
 }
 
-private fun copyToTemporaryFile(sourceURL: NSURL, filename: String): NSURL {
+internal fun copyToTemporaryFile(sourceURL: NSURL, filename: String): NSURL {
   val safeFilename = filename.replace('/', '_').replace('\\', '_')
   val destinationPath = "${NSTemporaryDirectory()}${NSUUID().UUIDString}-$safeFilename"
   val destinationURL = NSURL.fileURLWithPath(destinationPath)
@@ -322,7 +322,7 @@ private fun fileSize(path: String): Long? =
       as? NSNumber)
     ?.longLongValue
 
-private fun removeOwnedFile(url: NSURL) {
+internal fun removeOwnedFile(url: NSURL) {
   NSFileManager.defaultManager.removeItemAtURL(url, error = null)
 }
 

--- a/apps/mobile/compose/src/iosMain/kotlin/co/typie/platform/PlatformServiceModule.ios.kt
+++ b/apps/mobile/compose/src/iosMain/kotlin/co/typie/platform/PlatformServiceModule.ios.kt
@@ -3,12 +3,14 @@
 package co.typie.platform
 
 import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.readBytes
 import kotlinx.cinterop.useContents
 import kotlinx.cinterop.usePinned
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
@@ -16,7 +18,12 @@ import platform.CoreGraphics.CGRectMake
 import platform.Foundation.NSBundle
 import platform.Foundation.NSData
 import platform.Foundation.NSDocumentDirectory
+import platform.Foundation.NSItemProvider
+import platform.Foundation.NSProgress
 import platform.Foundation.NSSearchPathForDirectoriesInDomains
+import platform.Foundation.NSTemporaryDirectory
+import platform.Foundation.NSURL
+import platform.Foundation.NSUUID
 import platform.Foundation.NSUserDomainMask
 import platform.Foundation.create
 import platform.Foundation.writeToFile
@@ -30,10 +37,16 @@ import platform.UIKit.UIActivityViewController
 import platform.UIKit.UIApplication
 import platform.UIKit.UIDevice
 import platform.UIKit.UIImage
+import platform.UIKit.UIImagePNGRepresentation
 import platform.UIKit.UIImageWriteToSavedPhotosAlbum
 import platform.UIKit.UIPasteboard
 import platform.UIKit.UIViewController
 import platform.UIKit.popoverPresentationController
+import platform.UniformTypeIdentifiers.UTType
+import platform.UniformTypeIdentifiers.UTTypeData
+import platform.UniformTypeIdentifiers.UTTypeImage
+import platform.UniformTypeIdentifiers.UTTypeText
+import platform.UniformTypeIdentifiers.conformsToType
 
 private fun NSBundle.infoString(key: String): String =
   (objectForInfoDictionaryKey(key) as? String)?.takeIf(String::isNotBlank) ?: "unknown"
@@ -89,25 +102,240 @@ internal class IOSClipboard : Clipboard {
         .getOrDefault(false)
     }
 
-  override suspend fun paste(): ClipboardReadPayload? =
-    withContext(Dispatchers.Default) {
-      runCatching {
-        val pasteboard = UIPasteboard.generalPasteboard
-        val html =
-          (pasteboard.valueForPasteboardType(UTI_HTML) as? String)
-            ?: pasteboard.dataForPasteboardType(UTI_HTML)?.decodeUtf8()
-        val text =
-          (pasteboard.valueForPasteboardType(UTI_PLAIN_TEXT) as? String)
-            ?: pasteboard.string
-            ?: return@runCatching null
-        ClipboardReadPayload(html = html, text = text)
+  override suspend fun paste(): IncomingContentCandidates? {
+    val snapshot =
+      withContext(Dispatchers.Main) {
+        runCatching {
+            val pasteboard = UIPasteboard.generalPasteboard
+            val html =
+              pasteboard
+                .valueForPasteboardType(UTI_HTML)
+                .asPasteboardString()
+                ?.takeIf(String::isNotEmpty)
+                ?: pasteboard
+                  .dataForPasteboardType(UTI_HTML)
+                  ?.decodeUtf8()
+                  ?.takeIf(String::isNotEmpty)
+            if (html != null) {
+              return@runCatching IOSPasteboardSnapshot(
+                html = html,
+                text = pasteboard.string,
+                items = emptyList(),
+                providers = emptyList(),
+              )
+            }
+
+            val pasteboardItems =
+              pasteboard.items.mapNotNull { it as? Map<*, *> }.map { it.toMap() }
+            IOSPasteboardSnapshot(
+              html = null,
+              text =
+                pasteboardItems.firstNotNullOfOrNull { item ->
+                  item[UTI_PLAIN_TEXT].asPasteboardString()
+                } ?: pasteboard.string,
+              items = pasteboardItems,
+              providers =
+                pasteboard.itemProviders
+                  .filterIsInstance<NSItemProvider>()
+                  .takeIf { it.size == pasteboardItems.size }
+                  .orEmpty(),
+            )
+          }
+          .getOrNull()
+      } ?: return null
+
+    return try {
+      materializeIncomingContentCandidates(html = snapshot.html, text = snapshot.text) {
+        loadOwnedIncomingContentItems(
+          loaders =
+            snapshot.items.mapIndexed { index, item ->
+              suspend {
+                val provider = snapshot.providers.getOrNull(index)
+                if (provider == null) {
+                  readPasteboardAttachment(item)
+                } else {
+                  try {
+                    provider.loadPasteboardAttachment() ?: readPasteboardAttachment(item)
+                  } catch (error: CancellationException) {
+                    throw error
+                  } catch (error: Throwable) {
+                    runCatching { readPasteboardAttachment(item) }.getOrNull() ?: throw error
+                  }
+                }
+              }
+            },
+          loaderContext = Dispatchers.Default,
+        )
       }
-        .getOrNull()
+    } catch (error: CancellationException) {
+      throw error
+    } catch (_: Throwable) {
+      null
     }
+  }
 }
 
 private const val UTI_HTML = "public.html"
 private const val UTI_PLAIN_TEXT = "public.utf8-plain-text"
+private const val UTI_FILE_URL = "public.file-url"
+private const val UTI_URL = "public.url"
+
+private data class IOSPasteboardSnapshot(
+  val html: String?,
+  val text: String?,
+  val items: List<Map<*, *>>,
+  val providers: List<NSItemProvider>,
+)
+
+private suspend fun NSItemProvider.loadPasteboardAttachment(): IncomingContentItem? {
+  val representation =
+    registeredTypeIdentifiers
+      .filterIsInstance<String>()
+      .mapNotNull { identifier ->
+        val type = UTType.typeWithIdentifier(identifier) ?: return@mapNotNull null
+        when {
+          type.conformsToType(UTTypeImage) ->
+            PasteboardProviderRepresentation(
+              identifier = identifier,
+              type = type,
+              kind = IncomingContentItem.Kind.Image,
+            )
+          identifier == UTI_FILE_URL || identifier == UTI_URL || type.conformsToType(UTTypeText) ->
+            null
+          type.conformsToType(UTTypeData) ->
+            PasteboardProviderRepresentation(
+              identifier = identifier,
+              type = type,
+              kind = IncomingContentItem.Kind.File,
+            )
+          else -> null
+        }
+      }
+      .minByOrNull { if (it.kind == IncomingContentItem.Kind.Image) 0 else 1 } ?: return null
+  val mimeType = representation.type.preferredMIMEType
+  val filename =
+    providerFilename(
+      suggestedName = suggestedName,
+      preferredExtension = representation.type.preferredFilenameExtension,
+      mimeType = mimeType,
+    )
+
+  return suspendCancellableCoroutine { continuation ->
+    var progress: NSProgress? = null
+    continuation.invokeOnCancellation { progress?.cancel() }
+    progress =
+      loadFileRepresentationForTypeIdentifier(representation.identifier) { url, providerError ->
+        runCatching {
+            val sourceURL =
+              url
+                ?: error(
+                  providerError?.localizedDescription
+                    ?: "Clipboard file representation is unavailable"
+                )
+            val ownedURL = copyToTemporaryFile(sourceURL, filename)
+            try {
+              IncomingContentItem(
+                kind = representation.kind,
+                file =
+                  when (representation.kind) {
+                    IncomingContentItem.Kind.Image -> ownedURL.toPickedImage(filename, mimeType)
+                    IncomingContentItem.Kind.File ->
+                      ownedURL.toPickedFile(filename = filename, mimeType = mimeType, owned = true)
+                  },
+              )
+            } catch (error: Throwable) {
+              removeOwnedFile(ownedURL)
+              throw error
+            }
+          }
+          .onSuccess { item ->
+            continuation.resume(item) { _, undeliveredItem, _ -> undeliveredItem.file.close() }
+          }
+          .onFailure(continuation::resumeWithException)
+      }
+    if (!continuation.isActive) progress.cancel()
+  }
+}
+
+private data class PasteboardProviderRepresentation(
+  val identifier: String,
+  val type: UTType,
+  val kind: IncomingContentItem.Kind,
+)
+
+private fun readPasteboardAttachment(item: Map<*, *>): IncomingContentItem? {
+  val fileURL = item[UTI_FILE_URL].asPasteboardFileURL()?.takeIf { it.scheme == "file" }
+  if (fileURL != null) {
+    val inferredType =
+      fileURL.pathExtension?.takeIf(String::isNotBlank)?.let(UTType::typeWithFilenameExtension)
+    val filename = pickedFilename(fileURL.lastPathComponent, inferredType?.preferredMIMEType)
+    val ownedURL = copyToTemporaryFile(fileURL, filename)
+    return try {
+      val isImage = inferredType?.conformsToType(UTTypeImage) == true
+      IncomingContentItem(
+        kind = if (isImage) IncomingContentItem.Kind.Image else IncomingContentItem.Kind.File,
+        file =
+          if (isImage) {
+            ownedURL.toPickedImage(filename, inferredType.preferredMIMEType)
+          } else {
+            ownedURL.toPickedFile(
+              filename = filename,
+              mimeType = inferredType?.preferredMIMEType,
+              owned = true,
+            )
+          },
+      )
+    } catch (error: Throwable) {
+      removeOwnedFile(ownedURL)
+      throw error
+    }
+  }
+
+  val imageValue =
+    item.entries.firstNotNullOfOrNull { (rawType, value) ->
+      val type = rawType as? String ?: return@firstNotNullOfOrNull null
+      val uniformType = UTType.typeWithIdentifier(type) ?: return@firstNotNullOfOrNull null
+      value.takeIf { uniformType.conformsToType(UTTypeImage) }
+    } ?: return null
+  val image =
+    when (imageValue) {
+      is UIImage -> imageValue
+      is NSData -> UIImage(data = imageValue)
+      else -> null
+    } ?: error("Clipboard image representation is unreadable")
+  return IncomingContentItem(
+    kind = IncomingContentItem.Kind.Image,
+    file = image.toClipboardPickedFile(),
+  )
+}
+
+private fun Any?.asPasteboardString(): String? =
+  when (this) {
+    is String -> this
+    is NSData -> decodeUtf8()
+    else -> null
+  }
+
+private fun Any?.asPasteboardFileURL(): NSURL? =
+  when (this) {
+    is NSURL -> this
+    is String -> NSURL(string = this)
+    is NSData -> decodeUtf8()?.let { NSURL(string = it) }
+    else -> null
+  }
+
+private fun UIImage.toClipboardPickedFile(): PickedFile {
+  val data = UIImagePNGRepresentation(this) ?: error("Unable to encode clipboard image")
+  val path = "${NSTemporaryDirectory()}${NSUUID().UUIDString}-image.png"
+  check(data.writeToFile(path, atomically = true)) { "Unable to copy clipboard image" }
+  val url = NSURL.fileURLWithPath(path)
+  return try {
+    url.toPickedImage(filename = "image.png", mimeType = "image/png")
+  } catch (error: Throwable) {
+    removeOwnedFile(url)
+    throw error
+  }
+}
 
 internal class IOSFileSystem : FileSystem {
   override suspend fun save(

--- a/crates/editor-core/src/event.rs
+++ b/crates/editor-core/src/event.rs
@@ -1,3 +1,4 @@
+use editor_crdt::Dot;
 use editor_macros::ffi;
 use serde::{Deserialize, Serialize};
 
@@ -55,5 +56,9 @@ pub enum EditorEvent {
     },
     ProseRangeInstallResult {
         outcome: ProseRangeInstallOutcome,
+    },
+    AttachmentPlaceholdersInserted {
+        request_id: String,
+        node_ids: Vec<Dot>,
     },
 }

--- a/crates/editor-core/src/handle/clipboard.rs
+++ b/crates/editor-core/src/handle/clipboard.rs
@@ -1141,6 +1141,28 @@ mod tests {
     }
 
     #[test]
+    fn paste_mixed_external_html_preserves_text_and_omits_image() {
+        let (state, ..) = state! {
+            doc { root { p: paragraph {} } }
+            selection: (p, 0)
+        };
+        let mut editor = Editor::new_test(state);
+
+        editor.apply(Message::Clipboard {
+            op: ClipboardOp::Paste {
+                html: Some(r#"<p>before<img src="https://example.com/image.png">after</p>"#.into()),
+                text: "before after".into(),
+            },
+        });
+
+        let (expected, ..) = state! {
+            doc { root { p: paragraph { text("beforeafter") } } }
+            selection: (p, 11)
+        };
+        assert_state_eq!(editor.state(), &expected);
+    }
+
+    #[test]
     fn repaste_as_text_replaces_paste_region_with_plain() {
         let (s_source, ..) = state! {
             doc { root { p1: paragraph { text("hello") [bold] } } }

--- a/crates/editor-core/src/handle/insertion.rs
+++ b/crates/editor-core/src/handle/insertion.rs
@@ -1,11 +1,15 @@
+use editor_clipboard::Slice;
 use editor_commands::{self as commands};
+use editor_crdt::Dot;
 use editor_model::{
-    Fragment, PlainNode, PlainParagraphNode, PlainTableCellNode, PlainTableNode, PlainTableRowNode,
-    TableBorderStyle,
+    ChildView, DocView, Fragment, NodeType, NodeView, PlainFileNode, PlainImageNode, PlainNode,
+    PlainParagraphNode, PlainTableCellNode, PlainTableNode, PlainTableRowNode, TableBorderStyle,
 };
+use editor_state::{ResolvedSelection, Selection, is_unit_node_selection};
 
 use crate::editor::Editor;
 use crate::error::EditorError;
+use crate::event::EditorEvent;
 use crate::message::*;
 
 pub fn handle_insertion_op(editor: &mut Editor, op: InsertionOp) -> Result<(), EditorError> {
@@ -26,6 +30,7 @@ pub fn handle_insertion_op(editor: &mut Editor, op: InsertionOp) -> Result<(), E
         }
     }
 
+    let mut placeholder_node_ids = None;
     editor.transact(|tr| {
         match &op {
             InsertionOp::Text { text } => {
@@ -135,11 +140,72 @@ pub fn handle_insertion_op(editor: &mut Editor, op: InsertionOp) -> Result<(), E
                     commands::insert_fragment(table_fragment(*rows, *cols)),
                 )?;
             }
+            InsertionOp::AttachmentPlaceholders { kinds, .. } => {
+                if kinds.is_empty() {
+                    return Ok(());
+                }
+                let sp = tr.savepoint();
+                let slice = placeholder_slice(kinds);
+                let prepared = commands::first!(
+                    tr,
+                    commands::materialize_gap_paragraph(),
+                    commands::insert_paragraph_after_unit_selection(),
+                    |tr| commands::chain!(
+                        tr,
+                        commands::optional!(commands::ensure_paragraph()),
+                        commands::optional!(commands::delete_selection()),
+                    ),
+                )?;
+                if !prepared {
+                    return Ok(());
+                }
+                let Some(selection) = tr.selection().filter(Selection::is_collapsed) else {
+                    tr.rollback(sp);
+                    return Ok(());
+                };
+                let Some(inserted) = commands::insert_slice_at(
+                    tr,
+                    selection.head,
+                    slice,
+                    commands::types::SliceProvenance::Formatted,
+                )?
+                else {
+                    tr.rollback(sp);
+                    return Ok(());
+                };
+
+                let view = tr.view();
+                let Some(inserted_nodes) = placeholder_nodes_in_selection(&view, inserted) else {
+                    return Err(commands::CommandError::Corrupted(
+                        "placeholder insertion returned an unresolvable selection".into(),
+                    )
+                    .into());
+                };
+                let inserted_kinds = inserted_nodes
+                    .iter()
+                    .map(|(_, kind)| *kind)
+                    .collect::<Vec<_>>();
+                if inserted_kinds != *kinds {
+                    return Err(commands::CommandError::Corrupted(format!(
+                        "placeholder insertion mismatch: requested {kinds:?}, inserted {inserted_kinds:?}"
+                    ))
+                    .into());
+                }
+                if is_unit_node_selection(&inserted, &view) {
+                    tr.set_selection(Some(inserted))?;
+                }
+                placeholder_node_ids = Some(
+                    inserted_nodes
+                        .into_iter()
+                        .map(|(node_id, _)| node_id)
+                        .collect(),
+                );
+            }
         }
         Ok(())
     })?;
 
-    if matches!(op, InsertionOp::Text { .. }) {
+    if matches!(&op, InsertionOp::Text { .. }) {
         let resource = std::sync::Arc::clone(&editor.resource);
         let resource = resource.lock().unwrap();
         editor.transact(|tr| {
@@ -147,7 +213,71 @@ pub fn handle_insertion_op(editor: &mut Editor, op: InsertionOp) -> Result<(), E
             Ok(())
         })?;
     }
+
+    if let InsertionOp::AttachmentPlaceholders { request_id, .. } = op
+        && let Some(node_ids) = placeholder_node_ids
+    {
+        editor.push_event(EditorEvent::AttachmentPlaceholdersInserted {
+            request_id,
+            node_ids,
+        });
+    }
     Ok(())
+}
+
+fn placeholder_slice(kinds: &[AttachmentPlaceholderKind]) -> Slice {
+    Slice::new(
+        kinds
+            .iter()
+            .map(|kind| match kind {
+                AttachmentPlaceholderKind::Image => {
+                    Fragment::leaf(PlainNode::Image(PlainImageNode::default()))
+                }
+                AttachmentPlaceholderKind::File => {
+                    Fragment::leaf(PlainNode::File(PlainFileNode { id: None }))
+                }
+            })
+            .collect(),
+        0,
+        0,
+    )
+}
+
+fn placeholder_nodes_in_selection(
+    view: &DocView,
+    selection: Selection,
+) -> Option<Vec<(Dot, AttachmentPlaceholderKind)>> {
+    let (Some(root), Some(resolved)) = (view.root(), selection.resolve(view)) else {
+        return None;
+    };
+    let mut placeholders = Vec::new();
+    collect_placeholder_nodes(&root, &resolved, &mut placeholders);
+    Some(placeholders)
+}
+
+fn collect_placeholder_nodes(
+    node: &NodeView,
+    selection: &ResolvedSelection,
+    placeholders: &mut Vec<(Dot, AttachmentPlaceholderKind)>,
+) {
+    if !selection.intersects_subtree(node) {
+        return;
+    }
+
+    for (index, child) in node.children().enumerate() {
+        match child {
+            ChildView::Block(block) => collect_placeholder_nodes(&block, selection, placeholders),
+            ChildView::Leaf(leaf) if selection.contains_leaf_slot(node, index) => {
+                let kind = match leaf.node_type() {
+                    NodeType::Image => AttachmentPlaceholderKind::Image,
+                    NodeType::File => AttachmentPlaceholderKind::File,
+                    _ => continue,
+                };
+                placeholders.push((leaf.dot(), kind));
+            }
+            ChildView::Leaf(_) => {}
+        }
+    }
 }
 
 fn table_fragment(rows: usize, cols: usize) -> Fragment {
@@ -185,6 +315,223 @@ mod tests {
 
     use super::*;
     use crate::test_utils::assert_apply_changes_state;
+
+    #[test]
+    fn placeholder_batch_inserts_mixed_kinds_and_returns_ordered_node_ids() {
+        let (state, _p) = state! {
+            doc { root { p: paragraph } }
+            selection: (p, 0)
+        };
+        let mut editor = Editor::new_test(state);
+
+        let events = editor.apply(Message::Insertion {
+            op: InsertionOp::AttachmentPlaceholders {
+                request_id: "request-1".into(),
+                kinds: vec![
+                    AttachmentPlaceholderKind::Image,
+                    AttachmentPlaceholderKind::File,
+                    AttachmentPlaceholderKind::Image,
+                ],
+            },
+        });
+
+        let node_ids = events
+            .iter()
+            .find_map(|event| match event {
+                EditorEvent::AttachmentPlaceholdersInserted {
+                    request_id,
+                    node_ids,
+                } if request_id == "request-1" => Some(node_ids),
+                _ => None,
+            })
+            .expect("matching placeholder result");
+
+        let view = editor.state().view();
+        let inserted = view
+            .root()
+            .expect("root")
+            .children()
+            .filter_map(|child| match child {
+                ChildView::Block(block) => Some((block.id(), block.node_type())),
+                ChildView::Leaf(leaf) => Some((leaf.dot(), leaf.node_type())),
+            })
+            .filter(|(_, kind)| matches!(kind, NodeType::Image | NodeType::File))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            inserted.iter().map(|(_, kind)| *kind).collect::<Vec<_>>(),
+            vec![NodeType::Image, NodeType::File, NodeType::Image]
+        );
+        assert_eq!(
+            node_ids,
+            &inserted
+                .iter()
+                .map(|(node_id, _)| *node_id)
+                .collect::<Vec<_>>()
+        );
+
+        editor.apply(Message::History {
+            op: HistoryOp::Undo,
+        });
+        assert!(
+            editor
+                .state()
+                .view()
+                .root()
+                .expect("root")
+                .children()
+                .all(|child| match child {
+                    ChildView::Block(block) => {
+                        !matches!(block.node_type(), NodeType::Image | NodeType::File)
+                    }
+                    ChildView::Leaf(leaf) => {
+                        !matches!(leaf.node_type(), NodeType::Image | NodeType::File)
+                    }
+                })
+        );
+    }
+
+    #[test]
+    fn placeholder_batch_inserts_after_selected_existing_placeholder() {
+        let (state, root, existing_image) = state! {
+            doc { root: root {
+                existing_image: image
+            } }
+            selection: (root, 0, >) -> (root, 1, <)
+        };
+        let mut editor = Editor::new_test(state);
+
+        let events = editor.apply(Message::Insertion {
+            op: InsertionOp::AttachmentPlaceholders {
+                request_id: "after-existing".into(),
+                kinds: vec![AttachmentPlaceholderKind::Image],
+            },
+        });
+
+        let node_ids = events
+            .iter()
+            .find_map(|event| match event {
+                EditorEvent::AttachmentPlaceholdersInserted {
+                    request_id,
+                    node_ids,
+                } if request_id == "after-existing" => Some(node_ids),
+                _ => None,
+            })
+            .expect("matching placeholder result");
+        let children = editor
+            .state()
+            .view()
+            .node(root)
+            .expect("root")
+            .children()
+            .map(|child| match child {
+                ChildView::Block(block) => (block.id(), block.node_type()),
+                ChildView::Leaf(leaf) => (leaf.dot(), leaf.node_type()),
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(children.len(), 3);
+        assert_eq!(children[0], (existing_image, NodeType::Image));
+        assert_eq!(children[1].1, NodeType::Image);
+        assert_eq!(children[2].1, NodeType::Paragraph);
+        assert_eq!(node_ids, &vec![children[1].0]);
+    }
+
+    #[test]
+    fn empty_or_rejected_placeholder_batch_emits_no_success_result() {
+        let (mut state, _p) = state! {
+            doc { root { p: paragraph } }
+            selection: (p, 0)
+        };
+        state.selection = None;
+        let mut editor = Editor::new_test(state);
+
+        let empty = editor.apply(Message::Insertion {
+            op: InsertionOp::AttachmentPlaceholders {
+                request_id: "empty".into(),
+                kinds: vec![],
+            },
+        });
+        let rejected = editor.apply(Message::Insertion {
+            op: InsertionOp::AttachmentPlaceholders {
+                request_id: "rejected".into(),
+                kinds: vec![AttachmentPlaceholderKind::Image],
+            },
+        });
+
+        assert!(
+            !empty
+                .iter()
+                .any(|event| matches!(event, EditorEvent::AttachmentPlaceholdersInserted { .. }))
+        );
+        assert!(
+            !rejected
+                .iter()
+                .any(|event| matches!(event, EditorEvent::AttachmentPlaceholdersInserted { .. }))
+        );
+    }
+
+    #[test]
+    fn placeholder_batch_result_excludes_existing_nodes_in_nested_container() {
+        let (state, content, existing_image, existing_file, _p) = state! {
+            doc { root {
+                fold {
+                    fold_title { text("Title") }
+                    content: fold_content {
+                        existing_image: image
+                        existing_file: file
+                        p: paragraph
+                    }
+                }
+                paragraph
+            } }
+            selection: (p, 0)
+        };
+        let mut editor = Editor::new_test(state);
+
+        let events = editor.apply(Message::Insertion {
+            op: InsertionOp::AttachmentPlaceholders {
+                request_id: "request-with-existing".into(),
+                kinds: vec![
+                    AttachmentPlaceholderKind::File,
+                    AttachmentPlaceholderKind::Image,
+                ],
+            },
+        });
+
+        let node_ids = events
+            .iter()
+            .find_map(|event| match event {
+                EditorEvent::AttachmentPlaceholdersInserted {
+                    request_id,
+                    node_ids,
+                } if request_id == "request-with-existing" => Some(node_ids),
+                _ => None,
+            })
+            .expect("matching placeholder result");
+        assert!(
+            node_ids
+                .iter()
+                .all(|node_id| *node_id != existing_image && *node_id != existing_file)
+        );
+
+        let view = editor.state().view();
+        let inserted_node_ids = view
+            .node(content)
+            .expect("fold content")
+            .children()
+            .filter_map(|child| match child {
+                ChildView::Block(block) => Some((block.id(), block.node_type())),
+                ChildView::Leaf(leaf) => Some((leaf.dot(), leaf.node_type())),
+            })
+            .filter(|(node_id, node_type)| {
+                *node_id != existing_image
+                    && *node_id != existing_file
+                    && matches!(node_type, NodeType::Image | NodeType::File)
+            })
+            .map(|(node_id, _)| node_id)
+            .collect::<Vec<_>>();
+        assert_eq!(node_ids, &inserted_node_ids);
+    }
 
     #[test]
     fn insert_text_into_paragraph_changes_state() {

--- a/crates/editor-core/src/message.rs
+++ b/crates/editor-core/src/message.rs
@@ -101,10 +101,23 @@ pub enum Break {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum InsertionOp {
-    Text { text: String },
-    Break { kind: Break },
-    Fragment { fragment: Fragment },
-    Table { rows: usize, cols: usize },
+    Text {
+        text: String,
+    },
+    Break {
+        kind: Break,
+    },
+    Fragment {
+        fragment: Fragment,
+    },
+    Table {
+        rows: usize,
+        cols: usize,
+    },
+    AttachmentPlaceholders {
+        request_id: String,
+        kinds: Vec<AttachmentPlaceholderKind>,
+    },
 }
 
 #[ffi]
@@ -290,6 +303,14 @@ pub enum ClipboardOp {
     Paste { html: Option<String>, text: String },
     RepasteAsText,
     Cut,
+}
+
+#[ffi]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AttachmentPlaceholderKind {
+    Image,
+    File,
 }
 
 #[ffi]

--- a/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
@@ -536,6 +536,8 @@ export type Alignment = "left" | "center" | "right" | "justify";
 
 export type ArchivedNodeAttr = { type: "id"; value: string | undefined };
 
+export type AttachmentPlaceholderKind = "image" | "file";
+
 export type Axis = "horizontal" | "vertical";
 
 export type BlockOp = { type: "toggle_blockquote"; variant: BlockquoteVariant } | { type: "toggle_callout" } | { type: "wrap_fold" };
@@ -564,7 +566,7 @@ export type DndOp = { type: "start_internal_selection" } | { type: "enter_extern
 
 export type Dot = string;
 
-export type EditorEvent = { type: "state_changed"; fields: StateField[] } | { type: "render_invalidated" } | { type: "font_data_missing"; family: string; weight: number; required: FontData[]; prefetch: FontData[] } | { type: "cursor_exited_document_start" } | { type: "ime_resync_required" } | { type: "tracked_range_replace_result"; id: string; outcome: TrackedRangeReplaceOutcome } | { type: "prose_range_install_result"; outcome: ProseRangeInstallOutcome };
+export type EditorEvent = { type: "state_changed"; fields: StateField[] } | { type: "render_invalidated" } | { type: "font_data_missing"; family: string; weight: number; required: FontData[]; prefetch: FontData[] } | { type: "cursor_exited_document_start" } | { type: "ime_resync_required" } | { type: "tracked_range_replace_result"; id: string; outcome: TrackedRangeReplaceOutcome } | { type: "prose_range_install_result"; outcome: ProseRangeInstallOutcome } | { type: "attachment_placeholders_inserted"; request_id: string; node_ids: Dot[] };
 
 export type Effect = { load_font: { family: string; weight: number; codepoints: number[] } };
 
@@ -602,7 +604,7 @@ export type HorizontalRuleVariant = "line" | "dashed_line" | "circle_line" | "di
 
 export type ImageNodeAttr = { type: "id"; value: string | undefined } | { type: "proportion"; value: number };
 
-export type InsertionOp = { type: "text"; text: string } | { type: "break"; kind: Break } | { type: "fragment"; fragment: Fragment } | { type: "table"; rows: number; cols: number };
+export type InsertionOp = { type: "text"; text: string } | { type: "break"; kind: Break } | { type: "fragment"; fragment: Fragment } | { type: "table"; rows: number; cols: number } | { type: "attachment_placeholders"; request_id: string; kinds: AttachmentPlaceholderKind[] };
 
 export type InteractiveHit = { type: "fold_title"; id: Dot; text_rect: Rect | undefined } | { type: "callout_icon"; id: Dot; next_variant: CalloutVariant };
 

--- a/crates/editor-ffi/pkg/server/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/server/editor_ffi.d.ts
@@ -601,6 +601,8 @@ export type Alignment = "left" | "center" | "right" | "justify";
 
 export type ArchivedNodeAttr = { type: "id"; value: string | undefined };
 
+export type AttachmentPlaceholderKind = "image" | "file";
+
 export type Axis = "horizontal" | "vertical";
 
 export type BlockOp = { type: "toggle_blockquote"; variant: BlockquoteVariant } | { type: "toggle_callout" } | { type: "wrap_fold" };
@@ -631,7 +633,7 @@ export type DndOp = { type: "start_internal_selection" } | { type: "enter_extern
 
 export type Dot = string;
 
-export type EditorEvent = { type: "state_changed"; fields: StateField[] } | { type: "render_invalidated" } | { type: "font_data_missing"; family: string; weight: number; required: FontData[]; prefetch: FontData[] } | { type: "cursor_exited_document_start" } | { type: "ime_resync_required" } | { type: "tracked_range_replace_result"; id: string; outcome: TrackedRangeReplaceOutcome } | { type: "prose_range_install_result"; outcome: ProseRangeInstallOutcome };
+export type EditorEvent = { type: "state_changed"; fields: StateField[] } | { type: "render_invalidated" } | { type: "font_data_missing"; family: string; weight: number; required: FontData[]; prefetch: FontData[] } | { type: "cursor_exited_document_start" } | { type: "ime_resync_required" } | { type: "tracked_range_replace_result"; id: string; outcome: TrackedRangeReplaceOutcome } | { type: "prose_range_install_result"; outcome: ProseRangeInstallOutcome } | { type: "attachment_placeholders_inserted"; request_id: string; node_ids: Dot[] };
 
 export type Effect = { load_font: { family: string; weight: number; codepoints: number[] } };
 
@@ -669,7 +671,7 @@ export type HorizontalRuleVariant = "line" | "dashed_line" | "circle_line" | "di
 
 export type ImageNodeAttr = { type: "id"; value: string | undefined } | { type: "proportion"; value: number };
 
-export type InsertionOp = { type: "text"; text: string } | { type: "break"; kind: Break } | { type: "fragment"; fragment: Fragment } | { type: "table"; rows: number; cols: number };
+export type InsertionOp = { type: "text"; text: string } | { type: "break"; kind: Break } | { type: "fragment"; fragment: Fragment } | { type: "table"; rows: number; cols: number } | { type: "attachment_placeholders"; request_id: string; kinds: AttachmentPlaceholderKind[] };
 
 export type InteractiveHit = { type: "fold_title"; id: Dot; text_rect: Rect | undefined } | { type: "callout_icon"; id: Dot; next_variant: CalloutVariant };
 


### PR DESCRIPTION
## 배경

- KMP 앱의 에디터 clipboard 붙여넣기는 HTML과 일반 텍스트만 처리해 이미지·파일 payload를 삽입할 수 없었음
- Android IME의 `commitContent`도 지원하지 않아 키보드에서 전달되는 이미지·파일을 받을 수 없었음
- 기존 이미지·파일 picker에는 placeholder 삽입, 업로드, asset 저장과 commit 흐름이 각각 중복되어 있었음

## 변경

- Android, iOS와 Desktop clipboard에서 단일·다중 이미지/파일을 읽고 플랫폼이 제공하는 item 순서를 보존해 삽입
- 키보드 붙여넣기, 컨텍스트 메뉴와 Android IME content를 같은 incoming-content 경로로 통합
  - non-empty HTML은 기존 rich-text 붙여넣기를 우선
  - HTML이 없으면 ordered 이미지·파일을 첨부
  - 일반 텍스트를 마지막 fallback으로 사용
  - HTML과 함께 제공된 별도 binary 표현은 중복 삽입하지 않음
- 기존 이미지·파일 picker의 placeholder, pending, upload, persist, commit과 cleanup을 공용 attachment importer로 이동
  - 기존 빈 placeholder에는 첫 항목을 재사용하고 나머지만 새로 삽입
  - command 시작 시점의 editing session이 교체되거나 read-only가 된 경우 결과를 새 문서에 commit하지 않음
  - placeholder 삭제·undo, kind 변경이나 pending owner 교체 후 끝난 upload도 commit하지 않음
  - 일부 항목 실패가 나머지 항목을 취소하지 않으며 실제 blob upload는 기존 전역 동시성 제한을 사용
- 에디터 엔진에 ordered placeholder batch 삽입 계약 추가
  - 이미지·파일 placeholder 전체를 하나의 `Slice`와 하나의 트랜잭션으로 삽입
  - 해당 삽입이 반환한 selection에서만 node ID를 추출하고 요청한 개수·종류·순서와 일치하는지 검증
  - Kotlin은 `requestId`에 대응하는 ordered node ID를 입력과 zip해 upload 대상으로 사용
  - 기존 노드 전후 차집합이나 후속 global state scan은 사용하지 않음
- iOS provider 임시 파일과 Android clipboard URI를 app-owned 파일로 보존하고, 성공·실패·취소·stale session에서 모든 `PickedFile`과 native permission을 정리
- clipboard read와 후속 key action을 같은 FIFO에서 처리해 느린 clipboard read 중 입력된 키가 붙여넣기를 추월하지 않도록 함
- 폐기된 무료 플랜 제한 관련 TR-38 TODO 제거

## 검증

- editor-core placeholder batch 테스트 및 전체 library 테스트 통과
- KMP attachment importer, incoming-content arbitration, keyboard ordering과 session safety 테스트 통과
- Android clipboard host 테스트 통과
- Android, Desktop과 iOS Simulator compilation 확인
- 성공·실패·취소, session 교체, placeholder 삭제와 pending 교체 시 resource cleanup 회귀 테스트 추가

## 후속

- 일반 HTML에 포함된 외부 이미지를 원래 HTML 위치에 삽입하는 기능은 별도 PR로 구현
- 앱 internal/external native DnD는 이번 PR에 포함하지 않고, 후속 PR에서 같은 ordered placeholder receipt와 attachment importer를 재사용