### PR TITLE
앱 에디터 공용 overlay 종료 시 focus 복원 안정화

### DIFF
--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.android.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.android.kt
@@ -44,9 +44,7 @@ internal actual fun rememberEditorKeyboardState(
   val imeHideOwnershipTracker = remember { EditorImeHideOwnershipTracker() }
   val imeHideEventOwner =
     imeHideOwnershipTracker.observe(
-      visible =
-        presentation == EditorKeyboardPresentation.Showing ||
-          presentation is EditorKeyboardPresentation.Shown,
+      presentation = presentation,
       editorInputSessionActive = isEditorInputSessionActive(),
     )
   val hardwareKeyboardVisible =

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -235,6 +235,7 @@ fun EditorScreen(entityId: String) {
   val nav = Nav.current
   val dialog = LocalDialog.current
   val sheet = LocalSheet.current
+  val popoverOverlayState = LocalPopoverOverlayState.current
   val toast = LocalToast.current
   val model = viewModel { EditorViewModel(entityId) }
   val scope = rememberCoroutineScope()
@@ -401,7 +402,10 @@ fun EditorScreen(entityId: String) {
     findReplace.active ||
       (subPaneState.editorInputBlocked &&
         (subPaneState.active == EditorSubPane.RelatedNotes ||
-          subPaneState.active == EditorSubPane.Comments))
+          subPaneState.active == EditorSubPane.Comments)) ||
+      dialog.acceptsInput ||
+      sheet.acceptsInput ||
+      popoverOverlayState.acceptsInput
   SideEffect {
     focusReturnSession.observeEditorContext(
       editor = editor,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/EditorResizableSheetSurface.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/EditorResizableSheetSurface.kt
@@ -25,8 +25,10 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
@@ -91,6 +93,7 @@ internal fun EditorResizableSheetSurface(
 ) {
   BoxWithConstraints(modifier.fillMaxSize()) {
     val density = LocalDensity.current
+    val focusManager = LocalFocusManager.current
     val coroutineScope = rememberCoroutineScope()
     val scrollGestureLockState = LocalScrollGestureLockState.current
     val canDismissState = rememberUpdatedState(canDismiss)
@@ -101,6 +104,7 @@ internal fun EditorResizableSheetSurface(
     val heightAnimation = remember { Animatable(0f) }
     var dismissRequestInProgress by remember { mutableStateOf(false) }
     var dismissing by remember { mutableStateOf(false) }
+    var sheetHasFocus by remember { mutableStateOf(false) }
     var sheetDragScrollLock by remember { mutableStateOf<ScrollGestureLockHandle?>(null) }
 
     fun releaseSheetDragScrollLock() {
@@ -199,6 +203,9 @@ internal fun EditorResizableSheetSurface(
           }
 
           dismissing = true
+          if (sheetHasFocus) {
+            focusManager.clearFocus()
+          }
           onDismissStartedState.value()
           heightAnimation.stop()
           presentationProgress.animateTo(1f, SheetAnimationSpec)
@@ -206,6 +213,12 @@ internal fun EditorResizableSheetSurface(
         } finally {
           dismissRequestInProgress = false
         }
+      }
+    }
+
+    LaunchedEffect(dismissing, sheetHasFocus) {
+      if (dismissing && sheetHasFocus) {
+        focusManager.clearFocus()
       }
     }
 
@@ -256,6 +269,7 @@ internal fun EditorResizableSheetSurface(
           .align(Alignment.BottomCenter)
           .offset { IntOffset(x = 0, y = hiddenOffsetPx.roundToInt()) }
           .clip(RoundedCornerShape(topStart = AppShapes.xl, topEnd = AppShapes.xl))
+          .onFocusChanged { sheetHasFocus = it.hasFocus }
           .blockPointerInputBehind()
     ) {
       scope.content()

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/EditorSubPaneHost.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/EditorSubPaneHost.kt
@@ -83,6 +83,7 @@ internal fun EditorSubPaneHost(
           editor?.focus()
         },
         onDismissStarted = state::beginDismiss,
+        onDismissCancelled = state::cancelDismiss,
         onDismiss = state::dismiss,
         onLayoutInfoChanged = state::updateLayoutInfo,
         onLayoutInfoCleared = state::clearLayoutInfo,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/EditorSubPaneState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/EditorSubPaneState.kt
@@ -95,6 +95,18 @@ internal class EditorSubPaneState {
     }
   }
 
+  fun cancelDismiss() {
+    if (active == null) {
+      return
+    }
+
+    if (dismissRequestVersion == 0) {
+      dismissalInProgress = false
+    } else {
+      dismissRequestVersion += 1
+    }
+  }
+
   fun requestDismiss() {
     if (active != null) {
       beginDismiss()

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/EditorTableAxisActionsPane.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/EditorTableAxisActionsPane.kt
@@ -45,6 +45,7 @@ internal fun EditorTableAxisActionsPane(
   dismissRequestVersion: Int,
   onAction: (Message) -> Unit,
   onDismissStarted: () -> Unit,
+  onDismissCancelled: () -> Unit,
   onDismiss: () -> Unit,
   onLayoutInfoChanged: (EditorSubPaneLayoutInfo) -> Unit,
   onLayoutInfoCleared: (EditorSubPane) -> Unit,
@@ -58,6 +59,7 @@ internal fun EditorTableAxisActionsPane(
     stopPolicy = SheetStop.Policy.KeepAll,
     onDismissed = onDismiss,
     onDismissStarted = onDismissStarted,
+    onDismissCancelled = onDismissCancelled,
     onGeometryChanged = { geometry ->
       onLayoutInfoChanged(
         EditorSubPaneLayoutInfo(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.kt
@@ -46,23 +46,39 @@ internal data class EditorKeyboardState(
 }
 
 internal class EditorImeHideOwnershipTracker {
-  private var previouslyVisible = false
+  private var visibleOwner: EditorImeInputOwner? = null
   private var hideEventOwner: EditorImeInputOwner? = null
 
-  fun observe(visible: Boolean, editorInputSessionActive: Boolean): EditorImeInputOwner? {
-    if (visible) {
-      hideEventOwner = null
-    } else if (previouslyVisible) {
-      hideEventOwner =
-        if (editorInputSessionActive) {
-          EditorImeInputOwner.Editor
-        } else {
-          EditorImeInputOwner.Other
-        }
+  fun observeVisibleOwner(editorInputSessionActive: Boolean) {
+    visibleOwner =
+      if (editorInputSessionActive) {
+        EditorImeInputOwner.Editor
+      } else {
+        EditorImeInputOwner.Other
+      }
+    hideEventOwner = null
+  }
+
+  fun beginHide(): EditorImeInputOwner? {
+    if (hideEventOwner == null) {
+      hideEventOwner = visibleOwner
     }
-    previouslyVisible = visible
     return hideEventOwner
   }
+
+  fun observe(
+    presentation: EditorKeyboardPresentation,
+    editorInputSessionActive: Boolean,
+  ): EditorImeInputOwner? =
+    when (presentation) {
+      EditorKeyboardPresentation.Showing,
+      is EditorKeyboardPresentation.Shown -> {
+        observeVisibleOwner(editorInputSessionActive)
+        null
+      }
+      EditorKeyboardPresentation.Hiding,
+      EditorKeyboardPresentation.Hidden -> beginHide()
+    }
 }
 
 @Composable

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarHost.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarHost.kt
@@ -80,10 +80,6 @@ internal fun EditorToolbarHost(
       try {
         block()
       } finally {
-        val environment = latestEnvironment.value
-        if (environment.visible) {
-          onInputEffects(inputState.dispatch(ToolbarIntent.RestoreEditorInput, environment))
-        }
         sessionState.modalActive = false
       }
     }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/dialog/Dialog.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/dialog/Dialog.kt
@@ -2,7 +2,10 @@ package co.typie.ui.component.dialog
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import kotlin.coroutines.resume
 import kotlinx.coroutines.suspendCancellableCoroutine
 
@@ -14,9 +17,15 @@ class Dialog {
   val current: DialogEntry<*>?
     get() = queue.firstOrNull()
 
+  val acceptsInput: Boolean
+    get() = queue.any { it.acceptsInput }
+
   suspend fun <R> present(
     dismissible: Boolean = true,
-    content: @Composable context(DialogScope<R>) () -> Unit,
+    content:
+      @Composable
+      context(DialogScope<R>)
+      () -> Unit,
   ): DialogResult<R> = suspendCancellableCoroutine { continuation ->
     val entry =
       DialogEntry(
@@ -33,10 +42,20 @@ class Dialog {
     queue.removeAt(0)
     @Suppress("UNCHECKED_CAST") (entry as DialogEntry<Any?>).onResult(result)
   }
+
+  internal fun stopEntryAcceptingInput(entry: DialogEntry<*>) {
+    entry.acceptsInput = false
+  }
 }
 
 class DialogEntry<R>(
   val dismissible: Boolean,
-  val content: @Composable context(DialogScope<R>) () -> Unit,
+  val content:
+    @Composable
+    context(DialogScope<R>)
+    () -> Unit,
   val onResult: (DialogResult<R>) -> Unit,
-)
+) {
+  var acceptsInput by mutableStateOf(true)
+    internal set
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/dialog/DialogOverlay.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/dialog/DialogOverlay.kt
@@ -14,9 +14,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
 import co.typie.ext.clickable
 import co.typie.navigation.PlatformBackHandler
@@ -26,10 +28,12 @@ import co.typie.ui.theme.AppTheme
 fun DialogOverlay(state: Dialog) {
   val entry = state.current ?: return
   val density = LocalDensity.current
+  val focusManager = LocalFocusManager.current
   val offsetPx = with(density) { 20.dp.toPx() }
 
   var pendingResult by remember(entry) { mutableStateOf<DialogResult<Any?>?>(null) }
   var visible by remember(entry) { mutableStateOf(false) }
+  var dialogHasFocus by remember(entry) { mutableStateOf(false) }
   LaunchedEffect(entry) { visible = true }
 
   val progress by
@@ -43,24 +47,35 @@ fun DialogOverlay(state: Dialog) {
       },
     )
 
-  val scope =
-    remember(entry) {
-      object : DialogScope<Any?> {
-        override fun resolve(result: Any?) {
-          pendingResult = DialogResult.Resolved(result)
-          visible = false
-        }
-
-        override fun dismiss() {
-          pendingResult = DialogResult.Dismissed
+  val requestDismissal =
+    remember(entry, state, focusManager) {
+      { result: DialogResult<Any?> ->
+        if (entry.acceptsInput) {
+          if (dialogHasFocus) {
+            focusManager.clearFocus()
+          }
+          pendingResult = result
+          state.stopEntryAcceptingInput(entry)
           visible = false
         }
       }
     }
 
-  PlatformBackHandler(enabled = entry.dismissible) {
-    pendingResult = DialogResult.Dismissed
-    visible = false
+  val scope =
+    remember(entry, requestDismissal) {
+      object : DialogScope<Any?> {
+        override fun resolve(result: Any?) {
+          requestDismissal(DialogResult.Resolved(result))
+        }
+
+        override fun dismiss() {
+          requestDismissal(DialogResult.Dismissed)
+        }
+      }
+    }
+
+  PlatformBackHandler(enabled = entry.dismissible && entry.acceptsInput) {
+    requestDismissal(DialogResult.Dismissed)
   }
 
   Box(Modifier.fillMaxSize()) {
@@ -69,11 +84,7 @@ fun DialogOverlay(state: Dialog) {
         .graphicsLayer { alpha = progress }
         .background(AppTheme.colors.scrim)
         .then(
-          if (entry.dismissible)
-            Modifier.clickable {
-              pendingResult = DialogResult.Dismissed
-              visible = false
-            }
+          if (entry.dismissible) Modifier.clickable { requestDismissal(DialogResult.Dismissed) }
           else Modifier.pointerInput(Unit) {}
         )
     )
@@ -82,6 +93,7 @@ fun DialogOverlay(state: Dialog) {
       modifier =
         Modifier.align(Alignment.Center)
           .width(280.dp)
+          .onFocusChanged { dialogHasFocus = it.hasFocus }
           .pointerInput(Unit) {}
           .graphicsLayer {
             alpha = progress

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/popover/Popover.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/popover/Popover.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.AwaitPointerEventScope
@@ -84,13 +85,26 @@ fun Popover(
   var isOverlayVisible by remember { mutableStateOf(false) }
   var anchorBounds by remember { mutableStateOf(IntRect.Zero) }
   var reverseAnimationCompleted by remember { mutableStateOf(false) }
+  var paneHasFocus by remember { mutableStateOf(false) }
   val progress = remember { Animatable(0f) }
   val scrollGestureLockState = LocalScrollGestureLockState.current
-  val scope = remember { PopoverScope(onClose = { isExpanded = false }) }
+  val scope =
+    remember(overlayState, overlayOwner, focusManager) {
+      PopoverScope(
+        onClose = {
+          if (overlayState.isOwnedBy(overlayOwner)) {
+            if (paneHasFocus) {
+              focusManager.clearFocus()
+            }
+            overlayState.stopAcceptingInput(overlayOwner)
+          }
+          isExpanded = false
+        }
+      )
+    }
   val dismissPopoverFromOutsideGesture by rememberUpdatedState { scope.close() }
   val ownsOverlay = overlayState.isOwnedBy(overlayOwner)
   val latestIsOverlayVisible by rememberUpdatedState(isOverlayVisible)
-  val latestOwnsOverlay by rememberUpdatedState(ownsOverlay)
   val overlayEntry =
     PopoverOverlayEntry(
       owner = overlayOwner,
@@ -99,16 +113,30 @@ fun Popover(
       collapsedCornerRadius = collapsedCornerRadius,
       maxWidth = maxWidth,
       minWidth = minWidth,
-      pane = { PopoverPaneSelectionHost(scope = scope, pane = pane) },
+      pane = {
+        val focusObserver =
+          if (LocalPopoverPaneRenderPhase.current == PopoverPaneRenderPhase.Interactive) {
+            Modifier.onFocusChanged { paneHasFocus = it.hasFocus }
+          } else {
+            Modifier
+          }
+        Box(focusObserver) { PopoverPaneSelectionHost(scope = scope, pane = pane) }
+      },
       anchor = { anchor() },
     )
-
-  LaunchedEffect(isExpanded) {
-    if (isExpanded) {
+  val openPopover = rememberUpdatedState {
+    if (!isOverlayVisible) {
       reverseAnimationCompleted = false
       scope.acceptsInput = true
       isOverlayVisible = true
       overlayState.show(owner = overlayOwner, entry = overlayEntry, anchorBounds = anchorBounds)
+      focusManager.clearFocus()
+      isExpanded = true
+    }
+  }
+
+  LaunchedEffect(isExpanded) {
+    if (isExpanded) {
       progress.stop()
       progress.snapTo(0f)
       progress.animateTo(1f, tween(PopoverDefaults.ForwardDuration, easing = LinearEasing))
@@ -141,9 +169,15 @@ fun Popover(
     }
   }
 
-  DisposableEffect(overlayState, overlayOwner) {
+  DisposableEffect(overlayState, overlayOwner, focusManager) {
     onDispose {
-      if (latestIsOverlayVisible && latestOwnsOverlay) {
+      if (latestIsOverlayVisible && overlayState.isOwnedBy(overlayOwner)) {
+        if (scope.acceptsInput) {
+          if (paneHasFocus) {
+            focusManager.clearFocus()
+          }
+          overlayState.stopAcceptingInput(overlayOwner)
+        }
         overlayState.detach(overlayOwner)
       } else {
         overlayState.clear(overlayOwner)
@@ -175,7 +209,9 @@ fun Popover(
     }
   }
 
-  PlatformBackHandler(enabled = isOverlayVisible && ownsOverlay) { isExpanded = false }
+  PlatformBackHandler(enabled = isOverlayVisible && ownsOverlay && scope.acceptsInput) {
+    scope.close()
+  }
 
   val easedProgress =
     if (isOverlayVisible && ownsOverlay) {
@@ -228,9 +264,8 @@ fun Popover(
             }
             is PopoverOpenTrigger.Tap -> {
               anchorInteractionSource.tryEmit(PressInteraction.Release(pressInteraction))
-              focusManager.clearFocus()
+              openPopover.value()
               openTrigger.upChange.consume()
-              isExpanded = true
               return@awaitEachGesture
             }
             PopoverOpenTrigger.Pressed -> {}
@@ -241,8 +276,7 @@ fun Popover(
 
           try {
             scrollLockHandle = scrollGestureLockState.acquire()
-            focusManager.clearFocus()
-            isExpanded = true
+            openPopover.value()
             released =
               trackPressGestureSession(
                 pointerId = press.id,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/popover/PopoverMenu.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/popover/PopoverMenu.kt
@@ -115,8 +115,11 @@ fun PopoverMenu(
                     PopoverListItem(
                       content = entry.content,
                       onSelected = {
-                        close()
-                        entry.onClick()
+                        try {
+                          entry.onClick()
+                        } finally {
+                          close()
+                        }
                       },
                     )
                   }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/popover/PopoverOverlayState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/popover/PopoverOverlayState.kt
@@ -23,6 +23,9 @@ class PopoverOverlayState {
   internal var entry: PopoverOverlayEntry? by mutableStateOf(null)
     private set
 
+  val acceptsInput: Boolean
+    get() = owner != null && entry != null && interactive
+
   var anchorBounds: IntRect by mutableStateOf(IntRect.Zero)
     private set
 
@@ -81,6 +84,15 @@ class PopoverOverlayState {
     }
 
     this.paneBoundsInWindow = paneBoundsInWindow
+  }
+
+  internal fun stopAcceptingInput(owner: Any) {
+    if (this.owner !== owner) {
+      return
+    }
+
+    onOutsideDismiss = null
+    interactive = false
   }
 
   internal fun isOwnedBy(owner: Any): Boolean = this.owner === owner

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/popover/PopoverScope.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/popover/PopoverScope.kt
@@ -14,6 +14,10 @@ class PopoverScope internal constructor(private val onClose: () -> Unit) {
     internal set
 
   fun close() {
+    if (!acceptsInput) {
+      return
+    }
+
     acceptsInput = false
     onClose()
   }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/sheet/AnchoredSheetSurface.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/sheet/AnchoredSheetSurface.kt
@@ -25,11 +25,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
@@ -69,6 +71,7 @@ internal fun AnchoredSheetSurface(
   modifier: Modifier = Modifier,
   onDismissed: () -> Unit,
   onDismissStarted: () -> Unit = {},
+  onDismissCancelled: () -> Unit = {},
   onGeometryChanged: (AnchoredSheetGeometry) -> Unit = {},
   onSettledStopChanged: (Int?) -> Unit = {},
   scrim: @Composable AnchoredSheetSurfaceScope.(alpha: Float) -> Unit = {},
@@ -87,7 +90,9 @@ internal fun AnchoredSheetSurface(
     var hasSettledVisible by remember { mutableStateOf(false) }
     var dismissing by remember { mutableStateOf(false) }
     var dismissed by remember { mutableStateOf(false) }
+    var sheetHasFocus by remember { mutableStateOf(false) }
     val coroutineScope = rememberCoroutineScope()
+    val focusManager = LocalFocusManager.current
     val dragOverscrollEffect = remember { SheetTopHysteresisOverscrollEffect() }
 
     val baseVisibleAnchors =
@@ -187,6 +192,7 @@ internal fun AnchoredSheetSurface(
     val hapticFeedbackState = rememberUpdatedState(hapticFeedback)
     val onDismissedState = rememberUpdatedState(onDismissed)
     val onDismissStartedState = rememberUpdatedState(onDismissStarted)
+    val onDismissCancelledState = rememberUpdatedState(onDismissCancelled)
     val onGeometryChangedState = rememberUpdatedState(onGeometryChanged)
     val onSettledStopChangedState = rememberUpdatedState(onSettledStopChanged)
 
@@ -205,7 +211,19 @@ internal fun AnchoredSheetSurface(
       }
 
       dismissing = true
+      if (sheetHasFocus) {
+        focusManager.clearFocus()
+      }
       onDismissStartedState.value()
+    }
+
+    fun cancelDismiss() {
+      if (!dismissing || dismissed) {
+        return
+      }
+
+      dismissing = false
+      onDismissCancelledState.value()
     }
 
     fun requestDismiss() {
@@ -220,16 +238,28 @@ internal fun AnchoredSheetSurface(
           finishDismiss()
         } catch (e: CancellationException) {
           if (!isActive) throw e
-          dismissing = false
+          if (anchoredState.targetValue != AnchorHidden) {
+            cancelDismiss()
+          }
         }
+      }
+    }
+
+    LaunchedEffect(dismissing, sheetHasFocus) {
+      if (dismissing && sheetHasFocus) {
+        focusManager.clearFocus()
       }
     }
 
     LaunchedEffect(anchoredState) {
       snapshotFlow { anchoredState.targetValue }
         .collect { targetValue ->
-          if (targetValue == AnchorHidden && hasSettledVisible) {
+          if (!hasSettledVisible) return@collect
+
+          if (targetValue == AnchorHidden) {
             beginDismiss()
+          } else {
+            cancelDismiss()
           }
         }
     }
@@ -333,11 +363,13 @@ internal fun AnchoredSheetSurface(
 
     Column(
       modifier =
-        sheetModifier.anchoredDraggable(
-          state = anchoredState,
-          orientation = Orientation.Vertical,
-          overscrollEffect = dragOverscrollEffect,
-        )
+        sheetModifier
+          .anchoredDraggable(
+            state = anchoredState,
+            orientation = Orientation.Vertical,
+            overscrollEffect = dragOverscrollEffect,
+          )
+          .onFocusChanged { sheetHasFocus = it.hasFocus }
     ) {
       scope.content()
     }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/sheet/Sheet.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/sheet/Sheet.kt
@@ -2,7 +2,10 @@ package co.typie.ui.component.sheet
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import kotlin.coroutines.resume
 import kotlinx.coroutines.suspendCancellableCoroutine
 
@@ -10,6 +13,9 @@ val LocalSheet = compositionLocalOf<Sheet> { error("No Sheet provided") }
 
 class Sheet {
   internal val entries = mutableStateListOf<SheetEntry<*>>()
+
+  val acceptsInput: Boolean
+    get() = entries.any { it.acceptsInput }
 
   suspend fun <R> present(
     stops: List<SheetStop> = emptyList(),
@@ -33,6 +39,14 @@ class Sheet {
     entries.remove(entry)
     @Suppress("UNCHECKED_CAST") (entry as SheetEntry<Any?>).onResult(result)
   }
+
+  internal fun stopEntryAcceptingInput(entry: SheetEntry<*>) {
+    entry.acceptsInput = false
+  }
+
+  internal fun startEntryAcceptingInput(entry: SheetEntry<*>) {
+    entry.acceptsInput = true
+  }
 }
 
 class SheetEntry<R>(
@@ -43,4 +57,7 @@ class SheetEntry<R>(
     context(SheetScope<R>)
     () -> Unit,
   val onResult: (R?) -> Unit,
-)
+) {
+  var acceptsInput by mutableStateOf(true)
+    internal set
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/sheet/SheetOverlay.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/sheet/SheetOverlay.kt
@@ -24,14 +24,12 @@ import co.typie.ui.theme.AppTheme
 @Composable
 fun SheetOverlay(state: Sheet) {
   for (entry in state.entries) {
-    key(entry) {
-      SheetEntryOverlay(entry = entry, onResolve = { result -> state.resolveEntry(entry, result) })
-    }
+    key(entry) { SheetEntryOverlay(state = state, entry = entry) }
   }
 }
 
 @Composable
-private fun SheetEntryOverlay(entry: SheetEntry<*>, onResolve: (Any?) -> Unit) {
+private fun SheetEntryOverlay(state: Sheet, entry: SheetEntry<*>) {
   @Suppress("UNCHECKED_CAST") val typedEntry = entry as SheetEntry<Any?>
 
   val viewModelStore = remember { ViewModelStore() }
@@ -51,13 +49,15 @@ private fun SheetEntryOverlay(entry: SheetEntry<*>, onResolve: (Any?) -> Unit) {
   val handleDismissed: () -> Unit = {
     if (!dismissed) {
       dismissed = true
-      onResolve(if (resolved) pendingResult else null)
+      state.resolveEntry(entry, if (resolved) pendingResult else null)
     }
   }
 
   AnchoredSheetSurface(
     stops = entry.stops,
     stopPolicy = entry.stopPolicy,
+    onDismissStarted = { state.stopEntryAcceptingInput(entry) },
+    onDismissCancelled = { state.startEntryAcceptingInput(entry) },
     onDismissed = handleDismissed,
     onSettledStopChanged = { stop ->
       if (stop != null && resolved && !dismissed) {

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/subpane/EditorSubPaneStateTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/subpane/EditorSubPaneStateTest.kt
@@ -119,6 +119,34 @@ class EditorSubPaneStateTest {
   }
 
   @Test
+  fun `cancelling user dismissal blocks editor input again`() {
+    val state = EditorSubPaneState()
+    val pane = tableAxisPane(tableId = "table", index = 1)
+    state.open(pane)
+    state.beginDismiss()
+
+    state.cancelDismiss()
+
+    assertEquals(pane, state.active)
+    assertTrue(state.editorInputBlocked)
+    assertEquals(0, state.dismissRequestVersion)
+  }
+
+  @Test
+  fun `cancelling requested dismissal keeps input released and requests dismissal again`() {
+    val state = EditorSubPaneState()
+    val pane = tableAxisPane(tableId = "table", index = 1)
+    state.open(pane)
+    state.requestDismiss()
+
+    state.cancelDismiss()
+
+    assertEquals(pane, state.active)
+    assertFalse(state.editorInputBlocked)
+    assertEquals(2, state.dismissRequestVersion)
+  }
+
+  @Test
   fun `opening pane after dismissal starts blocks editor input again`() {
     val state = EditorSubPaneState()
     state.open(tableAxisPane(tableId = "table", index = 0))

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardTypeTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardTypeTest.kt
@@ -70,23 +70,34 @@ class EditorKeyboardTypeTest {
   }
 
   @Test
+  fun auxiliary_visible_ime_keeps_other_ownership_when_editor_refocuses_at_hide() {
+    val tracker = EditorImeHideOwnershipTracker()
+
+    tracker.observeVisibleOwner(editorInputSessionActive = false)
+
+    assertEquals(EditorImeInputOwner.Other, tracker.beginHide())
+  }
+
+  @Test
+  fun visible_ime_transfers_to_editor_before_a_later_hide() {
+    val tracker = EditorImeHideOwnershipTracker()
+
+    tracker.observeVisibleOwner(editorInputSessionActive = false)
+    tracker.observeVisibleOwner(editorInputSessionActive = true)
+
+    assertEquals(EditorImeInputOwner.Editor, tracker.beginHide())
+  }
+
+  @Test
   fun ime_hide_ownership_is_preserved_until_the_keyboard_is_visible_again() {
     val tracker = EditorImeHideOwnershipTracker()
 
-    assertNull(tracker.observe(visible = true, editorInputSessionActive = false))
-    assertEquals(
-      EditorImeInputOwner.Other,
-      tracker.observe(visible = false, editorInputSessionActive = false),
-    )
-    assertEquals(
-      EditorImeInputOwner.Other,
-      tracker.observe(visible = false, editorInputSessionActive = true),
-    )
-    assertNull(tracker.observe(visible = true, editorInputSessionActive = true))
-    assertEquals(
-      EditorImeInputOwner.Editor,
-      tracker.observe(visible = false, editorInputSessionActive = true),
-    )
+    tracker.observeVisibleOwner(editorInputSessionActive = false)
+    assertEquals(EditorImeInputOwner.Other, tracker.beginHide())
+    assertEquals(EditorImeInputOwner.Other, tracker.beginHide())
+
+    tracker.observeVisibleOwner(editorInputSessionActive = true)
+    assertEquals(EditorImeInputOwner.Editor, tracker.beginHide())
   }
 
   @Test

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/ui/component/dialog/DialogTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/ui/component/dialog/DialogTest.kt
@@ -2,8 +2,10 @@ package co.typie.ui.component.dialog
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -11,6 +13,50 @@ import kotlinx.coroutines.test.runTest
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class DialogTest {
+
+  @Test
+  fun acceptsInputUntilTheLastQueuedEntryBeginsDismissal() = runTest {
+    val dialog = Dialog()
+    val first = async { dialog.present<Unit> {} }
+    val second = async { dialog.present<Unit> {} }
+
+    advanceUntilIdle()
+    assertTrue(dialog.acceptsInput)
+
+    dialog.stopEntryAcceptingInput(dialog.queue[0])
+    assertTrue(dialog.acceptsInput)
+
+    dialog.resolveCurrentEntry(DialogResult.Dismissed)
+    advanceUntilIdle()
+    assertTrue(dialog.acceptsInput)
+
+    dialog.stopEntryAcceptingInput(dialog.queue[0])
+    assertFalse(dialog.acceptsInput)
+
+    dialog.resolveCurrentEntry(DialogResult.Dismissed)
+    advanceUntilIdle()
+    assertIs<DialogResult.Dismissed>(first.await())
+    assertIs<DialogResult.Dismissed>(second.await())
+  }
+
+  @Test
+  fun stoppingEntryIsIdempotent() = runTest {
+    val dialog = Dialog()
+
+    assertFalse(dialog.acceptsInput)
+
+    val result = async { dialog.present<Unit> {} }
+    advanceUntilIdle()
+    val entry = dialog.queue.single()
+
+    dialog.stopEntryAcceptingInput(entry)
+    dialog.stopEntryAcceptingInput(entry)
+    assertFalse(dialog.acceptsInput)
+
+    dialog.resolveCurrentEntry(DialogResult.Dismissed)
+    advanceUntilIdle()
+    assertIs<DialogResult.Dismissed>(result.await())
+  }
 
   @Test
   fun presentAndDismiss() = runTest {

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/ui/component/popover/PopoverOverlayStateTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/ui/component/popover/PopoverOverlayStateTest.kt
@@ -5,10 +5,44 @@ import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertSame
+import kotlin.test.assertTrue
 
 class PopoverOverlayStateTest {
+
+  @Test
+  fun acceptsInputOnlyWhileTheCurrentOwnerIsInteractive() {
+    val state = PopoverOverlayState()
+    val owner = Any()
+    val entry = createEntry(owner)
+
+    assertFalse(state.acceptsInput)
+
+    state.show(owner, entry, IntRect.Zero)
+    assertTrue(state.acceptsInput)
+
+    state.stopAcceptingInput(owner)
+    assertFalse(state.acceptsInput)
+    assertSame(entry, state.entry)
+
+    state.clear(owner)
+    assertFalse(state.acceptsInput)
+  }
+
+  @Test
+  fun stopAcceptingInputIgnoresPreviousOwner() {
+    val state = PopoverOverlayState()
+    val firstOwner = Any()
+    val secondOwner = Any()
+
+    state.show(firstOwner, createEntry(firstOwner), IntRect.Zero)
+    state.show(secondOwner, createEntry(secondOwner), IntRect.Zero)
+    state.stopAcceptingInput(firstOwner)
+
+    assertTrue(state.acceptsInput)
+  }
 
   @Test
   fun clearIgnoresRequestsFromPreviousOwner() {

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/ui/component/sheet/SheetTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/ui/component/sheet/SheetTest.kt
@@ -1,0 +1,60 @@
+package co.typie.ui.component.sheet
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SheetTest {
+  @Test
+  fun acceptsInputUntilTheLastEntryBeginsDismissal() = runTest {
+    val sheet = Sheet()
+
+    assertFalse(sheet.acceptsInput)
+
+    val first = async { sheet.present<String> {} }
+    val second = async { sheet.present<String> {} }
+    advanceUntilIdle()
+    val firstEntry = sheet.entries[0]
+    val secondEntry = sheet.entries[1]
+
+    assertTrue(sheet.acceptsInput)
+
+    sheet.stopEntryAcceptingInput(firstEntry)
+    assertTrue(sheet.acceptsInput)
+
+    sheet.stopEntryAcceptingInput(secondEntry)
+    assertFalse(sheet.acceptsInput)
+
+    sheet.resolveEntry(firstEntry, "first")
+    advanceUntilIdle()
+    assertEquals("first", first.await())
+    assertFalse(sheet.acceptsInput)
+
+    sheet.resolveEntry(secondEntry, "second")
+    advanceUntilIdle()
+    assertEquals("second", second.await())
+    assertFalse(sheet.acceptsInput)
+  }
+
+  @Test
+  fun stoppingEntryIsIdempotent() = runTest {
+    val sheet = Sheet()
+    val result = async { sheet.present<Unit> {} }
+    advanceUntilIdle()
+    val entry = sheet.entries.single()
+
+    sheet.stopEntryAcceptingInput(entry)
+    sheet.stopEntryAcceptingInput(entry)
+
+    assertFalse(sheet.acceptsInput)
+    sheet.resolveEntry(entry, Unit)
+    advanceUntilIdle()
+    assertEquals(Unit, result.await())
+  }
+}

--- a/apps/mobile/compose/src/desktopMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.desktop.kt
+++ b/apps/mobile/compose/src/desktopMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.desktop.kt
@@ -16,17 +16,18 @@ internal actual fun rememberEditorKeyboardState(
   val density = LocalDensity.current
   val imeBottom = with(density) { WindowInsets.ime.getBottom(this).toDp() }
   val imeHideOwnershipTracker = remember { EditorImeHideOwnershipTracker() }
-  return resolveDesktopEditorKeyboardState(
+  val state =
+    resolveDesktopEditorKeyboardState(
       hardwareKeyboardConnected = DesktopDebugKeyboard.hardwareKeyboardConnected,
       imeBottom = imeBottom,
     )
-    .copy(
-      imeHideEventOwner =
-        imeHideOwnershipTracker.observe(
-          visible = imeBottom > 0.dp,
-          editorInputSessionActive = isEditorInputSessionActive(),
-        )
-    )
+  return state.copy(
+    imeHideEventOwner =
+      imeHideOwnershipTracker.observe(
+        presentation = state.presentation,
+        editorInputSessionActive = isEditorInputSessionActive(),
+      )
+  )
 }
 
 internal fun resolveDesktopEditorKeyboardState(

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/EditorCommonOverlayFocusReturnDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/EditorCommonOverlayFocusReturnDesktopTest.kt
@@ -1,0 +1,205 @@
+package co.typie.screen.editor.editor
+
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertIsNotFocused
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import co.typie.editor.Editor
+import co.typie.editor.FakeFfiEditor
+import co.typie.editor.ffi.Affinity
+import co.typie.editor.ffi.ChainSegment
+import co.typie.editor.ffi.Position
+import co.typie.editor.ffi.Selection
+import co.typie.editor.ffi.StablePosition
+import co.typie.editor.ffi.StableSelection
+import co.typie.ext.clickable
+import co.typie.ui.component.dialog.Dialog
+import co.typie.ui.component.dialog.DialogOverlay
+import co.typie.ui.component.dialog.DialogScope
+import co.typie.ui.theme.LightAppShadows
+import co.typie.ui.theme.LightColors
+import co.typie.ui.theme.LocalAppColors
+import co.typie.ui.theme.LocalAppShadows
+import co.typie.ui.theme.LocalThemeMode
+import co.typie.ui.theme.ResolvedThemeMode
+import dev.chrisbanes.haze.blur.HazeBlurStyle
+import dev.chrisbanes.haze.blur.LocalHazeBlurStyle
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+
+@OptIn(ExperimentalTestApi::class)
+class EditorCommonOverlayFocusReturnDesktopTest {
+  @Test
+  fun focusedEditorReturnsBeforeDialogRemovalAndRemainsFocused() = runComposeUiTest {
+    val fixture = FocusReturnFixture()
+    setContent { FocusReturnContent(fixture = fixture, initiallyFocused = true) }
+
+    dismissDialog(fixture)
+    onNodeWithTag(EditorFocusTag).assertIsFocused()
+
+    mainClock.advanceTimeBy(250)
+    waitForIdle()
+    onNodeWithTag(EditorFocusTag).assertIsFocused()
+  }
+
+  @Test
+  fun dialogOpenedFromUnfocusedEditorDoesNotFocusItOnDismissal() = runComposeUiTest {
+    val fixture = FocusReturnFixture()
+    setContent { FocusReturnContent(fixture = fixture, initiallyFocused = false) }
+
+    dismissDialog(fixture)
+    onNodeWithTag(EditorFocusTag).assertIsNotFocused()
+  }
+
+  private fun ComposeUiTest.dismissDialog(fixture: FocusReturnFixture) {
+    waitUntil(timeoutMillis = 5_000) { fixture.dialog.current != null }
+    waitForIdle()
+
+    mainClock.autoAdvance = false
+    onNodeWithTag(DialogDismissTag).performTouchInput {
+      down(center)
+      up()
+    }
+    repeat(2) { mainClock.advanceTimeByFrame() }
+    waitForIdle()
+
+    assertNotNull(fixture.dialog.current)
+  }
+}
+
+private class FocusReturnFixture {
+  val dialog = Dialog()
+  private val selection = selection("selected")
+  val editor =
+    Editor(
+      inner = FakeFfiEditor(selectionProvider = { selection }),
+      scope = CoroutineScope(Job()),
+      dispatcher = Dispatchers.Unconfined,
+    )
+
+  init {
+    editor.sync {}
+  }
+}
+
+@Composable
+private fun FocusReturnContent(fixture: FocusReturnFixture, initiallyFocused: Boolean) {
+  FocusReturnTestTheme {
+    val editorFocusRequester = remember { FocusRequester() }
+    val dialogFocusRequester = remember { FocusRequester() }
+    val scope = rememberCoroutineScope()
+    val session =
+      remember(fixture.editor) {
+        EditorFocusReturnSession(
+          scope = scope,
+          freezeSelection = { _, selection -> stableSelection(selection.anchor.node) },
+          applySelection = { _, _ -> },
+          focusEditor = { editorFocusRequester.requestFocus() },
+          awaitFocusBoundary = { withFrameNanos {} },
+        )
+      }
+    var editorFocused by remember { mutableStateOf(false) }
+
+    Box(Modifier.size(400.dp)) {
+      Column {
+        Box(
+          Modifier.testTag(EditorFocusTag)
+            .size(48.dp)
+            .focusRequester(editorFocusRequester)
+            .onFocusChanged { editorFocused = it.isFocused }
+            .focusable()
+        )
+      }
+
+      SideEffect {
+        session.observeEditorContext(
+          editor = fixture.editor,
+          focused = editorFocused,
+          selection = fixture.editor.state.selection,
+          contextActive = true,
+          auxiliaryOwnerActive = fixture.dialog.acceptsInput,
+        )
+      }
+      LaunchedEffect(fixture.dialog.acceptsInput) {
+        if (!fixture.dialog.acceptsInput) {
+          session.restore()
+        }
+      }
+      LaunchedEffect(Unit) {
+        if (initiallyFocused) {
+          editorFocusRequester.requestFocus()
+          withFrameNanos {}
+        }
+        fixture.dialog.present<Unit> { FocusReturnDialogContent(dialogFocusRequester) }
+      }
+
+      DialogOverlay(fixture.dialog)
+    }
+  }
+}
+
+@Composable
+context(scope: DialogScope<Unit>)
+private fun FocusReturnDialogContent(focusRequester: FocusRequester) {
+  Column(Modifier.size(200.dp)) {
+    Box(Modifier.size(48.dp).focusRequester(focusRequester).focusable())
+    Box(Modifier.testTag(DialogDismissTag).size(48.dp).clickable { scope.dismiss() })
+  }
+  LaunchedEffect(Unit) { focusRequester.requestFocus() }
+}
+
+@Composable
+private fun FocusReturnTestTheme(content: @Composable () -> Unit) {
+  CompositionLocalProvider(
+    LocalAppColors provides LightColors,
+    LocalAppShadows provides LightAppShadows,
+    LocalThemeMode provides ResolvedThemeMode.Light,
+    LocalHazeBlurStyle provides
+      HazeBlurStyle(blurRadius = 20.dp, noiseFactor = 0f, colorEffects = listOf()),
+    content = content,
+  )
+}
+
+private fun selection(node: String): Selection {
+  val position = Position(node = node, offset = 0, affinity = Affinity.Downstream)
+  return Selection(anchor = position, head = position)
+}
+
+private fun stableSelection(node: String): StableSelection {
+  val position =
+    StablePosition(
+      chain = listOf(ChainSegment.Real(node)),
+      child = null,
+      affinity = Affinity.Downstream,
+    )
+  return StableSelection(version = 2, anchor = position, head = position)
+}
+
+private const val EditorFocusTag = "editor-focus"
+private const val DialogDismissTag = "dialog-dismiss"

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/subpane/EditorResizableSheetSurfaceDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/subpane/EditorResizableSheetSurfaceDesktopTest.kt
@@ -2,17 +2,23 @@ package co.typie.screen.editor.editor.subpane
 
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertIsNotFocused
 import androidx.compose.ui.test.click
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
@@ -28,6 +34,54 @@ import kotlin.test.assertTrue
 
 @OptIn(ExperimentalTestApi::class)
 class EditorResizableSheetSurfaceDesktopTest {
+  @Test
+  fun closingSheetReleasesFocusAndCannotRegainIt() = runComposeUiTest {
+    val sheetFocusRequester = FocusRequester()
+
+    setContent {
+      ScrollGestureLockScope {
+        Box(Modifier.size(width = 400.dp, height = 800.dp)) {
+          EditorResizableSheetSurface(
+            initialHeight = 360.dp,
+            minHeight = 240.dp,
+            dismissThreshold = 128.dp,
+            maxTopInset = 0.dp,
+            keyboardOcclusion = 0.dp,
+            minKeyboardVisibleHeight = 0.dp,
+            onDismissed = {},
+            onGeometryChanged = {},
+          ) {
+            Column(Modifier.fillMaxSize()) {
+              Box(
+                Modifier.testTag(SheetFocusTag)
+                  .size(48.dp)
+                  .focusRequester(sheetFocusRequester)
+                  .focusable()
+              )
+              Box(Modifier.testTag(DismissButtonTag).size(48.dp).clickable { dismiss() })
+            }
+            LaunchedEffect(Unit) { sheetFocusRequester.requestFocus() }
+          }
+        }
+      }
+    }
+    waitForIdle()
+    onNodeWithTag(SheetFocusTag).assertIsFocused()
+
+    mainClock.autoAdvance = false
+    onNodeWithTag(DismissButtonTag).performTouchInput {
+      down(center)
+      up()
+    }
+    waitForIdle()
+
+    onNodeWithTag(SheetFocusTag).assertIsNotFocused()
+    runOnIdle { sheetFocusRequester.requestFocus() }
+    mainClock.advanceTimeByFrame()
+    waitForIdle()
+    onNodeWithTag(SheetFocusTag).assertIsNotFocused()
+  }
+
   @Test
   fun dismissReportsStartBeforeDismissed() = runComposeUiTest {
     val events = mutableListOf<String>()
@@ -182,5 +236,6 @@ class EditorResizableSheetSurfaceDesktopTest {
     const val IncrementalDragHandleTag = "incremental-drag-handle"
     const val SheetDragHandleTag = "sheet-drag-handle"
     const val SheetSurfaceTag = "sheet-surface"
+    const val SheetFocusTag = "sheet-focus"
   }
 }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardTypeDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardTypeDesktopTest.kt
@@ -25,4 +25,22 @@ class EditorKeyboardTypeDesktopTest {
     assertEquals(false, state.imeFrameVisible)
     assertEquals(EditorKeyboardPresentation.Hidden, state.presentation)
   }
+
+  @Test
+  fun desktop_feed_reuses_visible_auxiliary_owner_when_editor_refocuses_at_hide() {
+    val tracker = EditorImeHideOwnershipTracker()
+    val visible =
+      resolveDesktopEditorKeyboardState(hardwareKeyboardConnected = false, imeBottom = 320.dp)
+    val hidden =
+      resolveDesktopEditorKeyboardState(hardwareKeyboardConnected = false, imeBottom = 0.dp)
+
+    assertEquals(
+      null,
+      tracker.observe(presentation = visible.presentation, editorInputSessionActive = false),
+    )
+    assertEquals(
+      EditorImeInputOwner.Other,
+      tracker.observe(presentation = hidden.presentation, editorInputSessionActive = true),
+    )
+  }
 }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/dialog/DialogOverlayDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/dialog/DialogOverlayDesktopTest.kt
@@ -1,0 +1,148 @@
+package co.typie.ui.component.dialog
+
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertIsNotFocused
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import co.typie.ext.clickable
+import co.typie.ui.theme.LightAppShadows
+import co.typie.ui.theme.LightColors
+import co.typie.ui.theme.LocalAppColors
+import co.typie.ui.theme.LocalAppShadows
+import co.typie.ui.theme.LocalThemeMode
+import co.typie.ui.theme.ResolvedThemeMode
+import dev.chrisbanes.haze.blur.HazeBlurStyle
+import dev.chrisbanes.haze.blur.LocalHazeBlurStyle
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+
+@OptIn(ExperimentalTestApi::class)
+class DialogOverlayDesktopTest {
+  @Test
+  fun dismissalDoesNotClearFocusOutsideDialog() = runComposeUiTest {
+    val dialog = Dialog()
+    val outsideFocusRequester = FocusRequester()
+    var dismissRequest: (() -> Unit)? = null
+
+    setContent {
+      DialogTestTheme {
+        Box(Modifier.size(400.dp)) {
+          Box(
+            Modifier.testTag(OutsideFocusTag)
+              .size(48.dp)
+              .focusRequester(outsideFocusRequester)
+              .focusable()
+          )
+          LaunchedEffect(Unit) {
+            outsideFocusRequester.requestFocus()
+            dialog.present<Unit> {
+              FocuslessDialogContent(onDismissReady = { dismissRequest = it })
+            }
+          }
+
+          DialogOverlay(dialog)
+        }
+      }
+    }
+
+    waitUntil(timeoutMillis = 5_000) { dialog.current != null && dismissRequest != null }
+    waitForIdle()
+    onNodeWithTag(OutsideFocusTag).assertIsFocused()
+
+    mainClock.autoAdvance = false
+    runOnIdle { checkNotNull(dismissRequest).invoke() }
+    waitForIdle()
+
+    assertFalse(dialog.acceptsInput)
+    onNodeWithTag(OutsideFocusTag).assertIsFocused()
+  }
+
+  @Test
+  fun dismissalReleasesFocusBeforeRemoval() = runComposeUiTest {
+    val dialog = Dialog()
+
+    setContent {
+      DialogTestTheme {
+        Box(Modifier.size(400.dp)) {
+          LaunchedEffect(Unit) { dialog.present<Unit> { ClosingDialogContent() } }
+
+          DialogOverlay(dialog)
+        }
+      }
+    }
+
+    waitUntil(timeoutMillis = 5_000) { dialog.current != null }
+    waitForIdle()
+    onNodeWithTag(DialogFocusTag).assertIsFocused()
+
+    mainClock.autoAdvance = false
+    onNodeWithTag(DismissTag).performTouchInput {
+      down(center)
+      up()
+    }
+    waitForIdle()
+
+    assertNotNull(dialog.current)
+    assertFalse(dialog.acceptsInput)
+    onNodeWithTag(DialogFocusTag).assertIsNotFocused()
+  }
+
+  @Composable
+  context(scope: DialogScope<Unit>)
+  private fun FocuslessDialogContent(onDismissReady: (() -> Unit) -> Unit) {
+    SideEffect { onDismissReady(scope::dismiss) }
+    Box(Modifier.size(200.dp))
+  }
+
+  @Composable
+  context(scope: DialogScope<Unit>)
+  private fun ClosingDialogContent() {
+    val dialogFocusRequester = remember { FocusRequester() }
+
+    Column(Modifier.size(200.dp)) {
+      Box(
+        Modifier.testTag(DialogFocusTag)
+          .size(48.dp)
+          .focusRequester(dialogFocusRequester)
+          .focusable()
+      )
+      Box(Modifier.testTag(DismissTag).size(48.dp).clickable { scope.dismiss() })
+    }
+    LaunchedEffect(Unit) { dialogFocusRequester.requestFocus() }
+  }
+
+  @Composable
+  private fun DialogTestTheme(content: @Composable () -> Unit) {
+    CompositionLocalProvider(
+      LocalAppColors provides LightColors,
+      LocalAppShadows provides LightAppShadows,
+      LocalThemeMode provides ResolvedThemeMode.Light,
+      LocalHazeBlurStyle provides
+        HazeBlurStyle(blurRadius = 20.dp, noiseFactor = 0f, colorEffects = listOf()),
+      content = content,
+    )
+  }
+
+  private companion object {
+    const val OutsideFocusTag = "outside-focus"
+    const val DialogFocusTag = "dialog-focus"
+    const val DismissTag = "dialog-dismiss"
+  }
+}

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/popover/PopoverFocusDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/popover/PopoverFocusDesktopTest.kt
@@ -4,33 +4,60 @@ import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.assertIsNotFocused
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.dp
+import co.typie.ui.theme.LightAppShadows
+import co.typie.ui.theme.LightColors
+import co.typie.ui.theme.LocalAppColors
+import co.typie.ui.theme.LocalAppShadows
+import co.typie.ui.theme.LocalThemeMode
+import co.typie.ui.theme.ResolvedThemeMode
+import dev.chrisbanes.haze.blur.HazeBlurStyle
+import dev.chrisbanes.haze.blur.LocalHazeBlurStyle
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalTestApi::class)
 class PopoverFocusDesktopTest {
   @Test
   fun openingPopoverClearsExistingFocus() = runComposeUiTest {
+    val overlayState = PopoverOverlayState()
+    var focusWasAcquired = false
+    var acceptsInputWhenFocusWasLost: Boolean? = null
+
     setContent {
       val focusRequester = remember { FocusRequester() }
-      val overlayState = remember { PopoverOverlayState() }
 
       CompositionLocalProvider(LocalPopoverOverlayState provides overlayState) {
         Column {
           Box(
-            Modifier.testTag(FocusTargetTag).size(48.dp).focusRequester(focusRequester).focusable()
+            Modifier.testTag(FocusTargetTag)
+              .size(48.dp)
+              .focusRequester(focusRequester)
+              .onFocusChanged { state ->
+                if (state.isFocused) {
+                  focusWasAcquired = true
+                } else if (focusWasAcquired) {
+                  acceptsInputWhenFocusWasLost = overlayState.acceptsInput
+                }
+              }
+              .focusable()
           )
           Popover(
             anchor = { Box(Modifier.testTag(PopoverAnchorTag).size(48.dp)) },
@@ -51,10 +78,82 @@ class PopoverFocusDesktopTest {
     waitForIdle()
 
     onNodeWithTag(FocusTargetTag).assertIsNotFocused()
+    assertEquals(true, acceptsInputWhenFocusWasLost)
+  }
+
+  @Test
+  fun menuAdmitsSynchronousDestinationBeforeClosingPopover() = runComposeUiTest {
+    val overlayState = PopoverOverlayState()
+    val destinationAcceptsInput = mutableStateOf(false)
+    val destinationFocusRequester = FocusRequester()
+    var popoverAcceptedInputAtDestinationAdmission: Boolean? = null
+
+    setContent {
+      PopoverTestTheme {
+        CompositionLocalProvider(LocalPopoverOverlayState provides overlayState) {
+          Box(Modifier.size(400.dp)) {
+            Box(
+              Modifier.testTag(DestinationFocusTag)
+                .size(48.dp)
+                .focusRequester(destinationFocusRequester)
+                .focusable()
+            )
+            PopoverMenu(anchor = { Box(Modifier.testTag(PopoverAnchorTag).size(48.dp)) }) {
+              item(
+                content = {
+                  val modifier =
+                    if (LocalPopoverPaneRenderPhase.current == PopoverPaneRenderPhase.Interactive) {
+                      Modifier.testTag(MenuItemTag)
+                    } else {
+                      Modifier
+                    }
+                  Box(modifier.size(48.dp))
+                }
+              ) {
+                popoverAcceptedInputAtDestinationAdmission = overlayState.acceptsInput
+                destinationAcceptsInput.value = true
+                destinationFocusRequester.requestFocus()
+              }
+            }
+            PopoverOverlay(overlayState)
+          }
+        }
+      }
+    }
+
+    onNodeWithTag(PopoverAnchorTag).performTouchInput {
+      down(center)
+      up()
+    }
+    waitForIdle()
+
+    onNodeWithTag(MenuItemTag, useUnmergedTree = true).performTouchInput {
+      down(center)
+      up()
+    }
+    waitForIdle()
+
+    assertEquals(true, popoverAcceptedInputAtDestinationAdmission)
+    assertTrue(destinationAcceptsInput.value)
+    onNodeWithTag(DestinationFocusTag).assertIsFocused()
+  }
+
+  @Composable
+  private fun PopoverTestTheme(content: @Composable () -> Unit) {
+    CompositionLocalProvider(
+      LocalAppColors provides LightColors,
+      LocalAppShadows provides LightAppShadows,
+      LocalThemeMode provides ResolvedThemeMode.Light,
+      LocalHazeBlurStyle provides
+        HazeBlurStyle(blurRadius = 20.dp, noiseFactor = 0f, colorEffects = listOf()),
+      content = content,
+    )
   }
 
   private companion object {
     const val FocusTargetTag = "focus-target"
     const val PopoverAnchorTag = "popover-anchor"
+    const val MenuItemTag = "menu-item"
+    const val DestinationFocusTag = "destination-focus"
   }
 }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/sheet/AnchoredSheetSurfaceDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/sheet/AnchoredSheetSurfaceDesktopTest.kt
@@ -126,8 +126,43 @@ class AnchoredSheetSurfaceDesktopTest {
     assertEquals(listOf("start", "dismissed"), events)
   }
 
+  @Test
+  fun reversingDismissDragReportsCancellation() = runComposeUiTest {
+    val events = mutableListOf<String>()
+
+    setContent {
+      Box(Modifier.size(width = 400.dp, height = 800.dp)) {
+        AnchoredSheetSurface(
+          stops = emptyList(),
+          stopPolicy = SheetStop.Policy.KeepAll,
+          onDismissStarted = { events += "start" },
+          onDismissCancelled = { events += "cancelled" },
+          onDismissed = { events += "dismissed" },
+        ) {
+          Box(Modifier.testTag(SheetTag).fillMaxWidth().height(160.dp))
+        }
+      }
+    }
+    waitForIdle()
+
+    onNodeWithTag(SheetTag).performTouchInput {
+      down(center)
+      moveBy(Offset(0f, 140f), delayMillis = 500)
+    }
+    waitUntil { "start" in events }
+
+    onNodeWithTag(SheetTag).performTouchInput { moveBy(Offset(0f, -140f), delayMillis = 500) }
+    waitUntil { "cancelled" in events }
+
+    onNodeWithTag(SheetTag).performTouchInput { up() }
+    waitForIdle()
+
+    assertEquals(listOf("start", "cancelled"), events)
+  }
+
   private companion object {
     const val ViewportTag = "viewport"
     const val DismissTag = "dismiss"
+    const val SheetTag = "sheet"
   }
 }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/sheet/SheetOverlayDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/sheet/SheetOverlayDesktopTest.kt
@@ -1,14 +1,28 @@
 package co.typie.ui.component.sheet
 
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertIsNotFocused
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.dp
+import co.typie.ext.clickable
 import co.typie.ui.theme.LightAppShadows
 import co.typie.ui.theme.LightColors
 import co.typie.ui.theme.LocalAppColors
@@ -19,9 +33,184 @@ import dev.chrisbanes.haze.blur.HazeBlurStyle
 import dev.chrisbanes.haze.blur.LocalHazeBlurStyle
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalTestApi::class)
 class SheetOverlayDesktopTest {
+  @Test
+  fun dismissalReleasesFocusBeforeRemoval() = runComposeUiTest {
+    val sheet = Sheet()
+
+    setContent {
+      SheetTestTheme {
+        Box(Modifier.size(width = 400.dp, height = 800.dp)) {
+          LaunchedEffect(Unit) { sheet.present<Unit> { ClosingSheetContent() } }
+
+          SheetOverlay(sheet)
+        }
+      }
+    }
+
+    waitUntil(timeoutMillis = 5_000) { sheet.entries.isNotEmpty() }
+    waitForIdle()
+    onNodeWithTag(SheetFocusTag).assertIsFocused()
+
+    mainClock.autoAdvance = false
+    onNodeWithTag(DismissTag).performTouchInput {
+      down(center)
+      up()
+    }
+    waitForIdle()
+
+    assertNotNull(sheet.entries.singleOrNull())
+    assertFalse(sheet.acceptsInput)
+    onNodeWithTag(SheetFocusTag).assertIsNotFocused()
+
+    mainClock.advanceTimeBy(2_000)
+    waitForIdle()
+    assertTrue(sheet.entries.isEmpty())
+  }
+
+  @Test
+  fun closingSheetCannotRegainFocus() = runComposeUiTest {
+    val sheet = Sheet()
+    val returnedFocusRequester = FocusRequester()
+    val refocusRequestVersion = mutableIntStateOf(0)
+
+    setContent {
+      SheetTestTheme {
+        Box(Modifier.size(width = 400.dp, height = 800.dp)) {
+          Box(
+            Modifier.testTag(ReturnedFocusTag)
+              .size(48.dp)
+              .focusRequester(returnedFocusRequester)
+              .focusable()
+          )
+          LaunchedEffect(sheet.acceptsInput) {
+            if (!sheet.acceptsInput) {
+              withFrameNanos {}
+              returnedFocusRequester.requestFocus()
+            }
+          }
+          LaunchedEffect(Unit) {
+            sheet.present<Unit> {
+              ClosingSheetContent(refocusRequestVersion = refocusRequestVersion.intValue)
+            }
+          }
+
+          SheetOverlay(sheet)
+        }
+      }
+    }
+
+    waitUntil(timeoutMillis = 5_000) { sheet.entries.isNotEmpty() }
+    waitForIdle()
+    onNodeWithTag(SheetFocusTag).assertIsFocused()
+
+    mainClock.autoAdvance = false
+    onNodeWithTag(DismissTag).performTouchInput {
+      down(center)
+      up()
+    }
+    waitForIdle()
+    repeat(2) { mainClock.advanceTimeByFrame() }
+    waitForIdle()
+    onNodeWithTag(ReturnedFocusTag).assertIsFocused()
+
+    runOnIdle { refocusRequestVersion.intValue += 1 }
+    waitForIdle()
+
+    onNodeWithTag(SheetFocusTag).assertIsNotFocused()
+    onNodeWithTag(ReturnedFocusTag).assertIsFocused()
+  }
+
+  @Test
+  fun catchingDismissalKeepsReturnedFocusThroughNextDismissal() = runComposeUiTest {
+    val sheet = Sheet()
+    val returnedFocusRequester = FocusRequester()
+
+    setContent {
+      SheetTestTheme {
+        Box(Modifier.size(width = 400.dp, height = 800.dp)) {
+          Box(
+            Modifier.testTag(ReturnedFocusTag)
+              .size(48.dp)
+              .focusRequester(returnedFocusRequester)
+              .focusable()
+          )
+          LaunchedEffect(sheet.acceptsInput) {
+            if (!sheet.acceptsInput) {
+              withFrameNanos {}
+              returnedFocusRequester.requestFocus()
+            }
+          }
+          LaunchedEffect(Unit) { sheet.present<Unit> { ClosingSheetContent() } }
+
+          SheetOverlay(sheet)
+        }
+      }
+    }
+
+    waitUntil(timeoutMillis = 5_000) { sheet.entries.isNotEmpty() }
+    waitForIdle()
+    onNodeWithTag(SheetFocusTag).assertIsFocused()
+
+    mainClock.autoAdvance = false
+    onNodeWithTag(DismissTag).performTouchInput {
+      down(center)
+      up()
+    }
+    waitForIdle()
+
+    assertFalse(sheet.acceptsInput)
+    repeat(2) { mainClock.advanceTimeByFrame() }
+    waitForIdle()
+    onNodeWithTag(ReturnedFocusTag).assertIsFocused()
+
+    onNodeWithTag(SheetContentTag).performTouchInput {
+      down(center)
+      moveBy(Offset(0f, -80f), delayMillis = 500)
+      up()
+    }
+    mainClock.autoAdvance = true
+    waitForIdle()
+
+    assertNotNull(sheet.entries.singleOrNull())
+    assertTrue(sheet.acceptsInput)
+    onNodeWithTag(ReturnedFocusTag).assertIsFocused()
+
+    mainClock.autoAdvance = false
+    onNodeWithTag(DismissTag).performTouchInput {
+      down(center)
+      up()
+    }
+    waitForIdle()
+
+    assertFalse(sheet.acceptsInput)
+    onNodeWithTag(ReturnedFocusTag).assertIsFocused()
+  }
+
+  @Composable
+  context(scope: SheetScope<Unit>)
+  private fun ClosingSheetContent(refocusRequestVersion: Int = 0) {
+    val sheetFocusRequester = remember { FocusRequester() }
+
+    Column(Modifier.testTag(SheetContentTag).size(width = 400.dp, height = 200.dp)) {
+      Box(
+        Modifier.testTag(SheetFocusTag).size(48.dp).focusRequester(sheetFocusRequester).focusable()
+      )
+      Box(Modifier.testTag(DismissTag).size(48.dp).clickable { scope.dismiss() })
+    }
+    LaunchedEffect(Unit) { sheetFocusRequester.requestFocus() }
+    LaunchedEffect(refocusRequestVersion) {
+      if (refocusRequestVersion > 0) {
+        sheetFocusRequester.requestFocus()
+      }
+    }
+  }
+
   @Test
   fun entryCompletingDuringEntranceAnimationIsResolved() = runComposeUiTest {
     val sheet = Sheet()
@@ -58,5 +247,12 @@ class SheetOverlayDesktopTest {
         HazeBlurStyle(blurRadius = 20.dp, noiseFactor = 0f, colorEffects = listOf()),
       content = content,
     )
+  }
+
+  private companion object {
+    const val SheetFocusTag = "sheet-focus"
+    const val SheetContentTag = "sheet-content"
+    const val DismissTag = "sheet-dismiss"
+    const val ReturnedFocusTag = "returned-focus"
   }
 }

--- a/apps/mobile/compose/src/iosMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.ios.kt
+++ b/apps/mobile/compose/src/iosMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.ios.kt
@@ -4,6 +4,7 @@ package co.typie.screen.editor.editor.toolbar
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -26,7 +27,9 @@ import swiftPMImport.co.typie.compose.EditorKeyboardBridge
 internal actual fun rememberEditorKeyboardState(
   isEditorInputSessionActive: () -> Boolean
 ): EditorKeyboardState {
-  val currentEditorInputSessionActive by rememberUpdatedState(isEditorInputSessionActive)
+  val editorInputSessionActive = isEditorInputSessionActive()
+  val currentEditorInputSessionActive by rememberUpdatedState(editorInputSessionActive)
+  val imeHideOwnershipTracker = remember { EditorImeHideOwnershipTracker() }
   var hardwareKeyboardMode by remember { mutableStateOf(isEditorHardwareKeyboardConnected()) }
   var imeFrameVisible by remember { mutableStateOf(false) }
   var imeHideEventVersion by remember { mutableIntStateOf(0) }
@@ -46,17 +49,13 @@ internal actual fun rememberEditorKeyboardState(
     val targetBottom =
       notification?.let(EditorKeyboardBridge::imeVisibleHeightWithNotification)?.dp ?: 0.dp
     if (targetBottom > 0.dp) {
+      imeHideOwnershipTracker.observeVisibleOwner(currentEditorInputSessionActive)
       imeHideEventOwner = null
     } else if (
       presentation != EditorKeyboardPresentation.Hidden &&
         presentation != EditorKeyboardPresentation.Hiding
     ) {
-      imeHideEventOwner =
-        if (currentEditorInputSessionActive()) {
-          EditorImeInputOwner.Editor
-        } else {
-          EditorImeInputOwner.Other
-        }
+      imeHideEventOwner = imeHideOwnershipTracker.beginHide()
     }
     if (settlesImeBottom) {
       presentation =
@@ -85,6 +84,18 @@ internal actual fun rememberEditorKeyboardState(
     }
     imeFrameVisible = targetBottom > 0.dp
     syncKeyboardState()
+  }
+
+  SideEffect {
+    if (
+      presentation == EditorKeyboardPresentation.Showing ||
+        presentation is EditorKeyboardPresentation.Shown
+    ) {
+      imeHideOwnershipTracker.observeVisibleOwner(editorInputSessionActive)
+      if (imeHideEventOwner != null) {
+        imeHideEventOwner = null
+      }
+    }
   }
 
   DisposableEffect(Unit) {
@@ -144,12 +155,7 @@ internal actual fun rememberEditorKeyboardState(
         queue = NSOperationQueue.mainQueue,
       ) {
         if (presentation != EditorKeyboardPresentation.Hiding) {
-          imeHideEventOwner =
-            if (currentEditorInputSessionActive()) {
-              EditorImeInputOwner.Editor
-            } else {
-              EditorImeInputOwner.Other
-            }
+          imeHideEventOwner = imeHideOwnershipTracker.beginHide()
         }
         presentation = EditorKeyboardPresentation.Hiding
         imeFrameVisible = false


### PR DESCRIPTION
- #4959 후속. 이전 PR은 에디터 쪽 focus capture/restore 정책을 정리했고, 이번 PR은 공용 Dialog/Sheet/Popover와 subpane sheet의 dismiss lifecycle을 그 정책에 연결
- 애니메이션 완료가 아니라 dismiss 시작 시 복원하고, 보조 UI가 소유한 focus만 해제
- dismiss 취소와 IME hide ownership을 구분해 복원된 에디터 focus가 다시 풀리지 않도록 함