### PR TITLE
앱 sheet의 IME inset 반영 지연 수정

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/sheet/SheetLayout.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/sheet/SheetLayout.kt
@@ -8,12 +8,13 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.union
+import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Alignment
@@ -63,9 +64,12 @@ fun SheetLayout(
   body: @Composable ColumnScope.() -> Unit,
 ) {
   val scrollState = rememberScrollState()
-  val imeBottom = WindowInsets.ime.asPaddingValues().calculateBottomPadding()
-  val navigationBarsBottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
-  val bottomInset = maxOf(if (includeImeBottomInset) imeBottom else 0.dp, navigationBarsBottom)
+  val bottomInsets =
+    if (includeImeBottomInset) {
+      WindowInsets.navigationBars.union(WindowInsets.ime)
+    } else {
+      WindowInsets.navigationBars
+    }
 
   Column(modifier = modifier.fillMaxWidth().thenIf(fillHeight) { fillMaxHeight() }) {
     if (handle) SheetHandle(modifier = handleModifier.background(headerBackgroundColor))
@@ -95,8 +99,8 @@ fun SheetLayout(
         ) {
           body()
 
-          if (footer == null && bottomInset > 0.dp) {
-            Spacer(modifier = Modifier.height(bottomInset))
+          if (footer == null) {
+            Spacer(modifier = Modifier.windowInsetsBottomHeight(bottomInsets))
           }
         }
       }
@@ -110,7 +114,7 @@ fun SheetLayout(
           content = footer,
         )
 
-        Spacer(Modifier.height(bottomInset))
+        Spacer(Modifier.windowInsetsBottomHeight(bottomInsets))
       }
     }
   }


### PR DESCRIPTION
## 배경

- `SheetLayout`이 IME와 navigation bar inset을 composition 중 `Dp` 값으로 읽어 `Spacer` 높이에 적용하고 있었음
- Compose의 window inset 값은 composition 이후 layout 전에 갱신될 수 있어, 키보드가 열리고 닫히는 동안 composition에서 읽은 값이 한 frame 늦게 반영될 수 있었음
- 앱의 `adjustNothing` 정책과 `max(IME, navigationBars)` 정책은 유지하면서 inset 적용 시점만 layout 단계로 옮길 필요가 있었음

## 변경

- IME를 포함하는 sheet는 `navigationBars.union(ime)`로 기존 최대 높이 정책을 유지
- `includeImeBottomInset = false`인 sheet는 기존처럼 navigation bar inset만 적용
- 계산된 `Dp` 높이 대신 `windowInsetsBottomHeight`를 사용해 body 또는 고정 footer 아래의 inset을 layout 단계에서 반영
- 기존 body/footer 배치와 sheet별 IME 포함 여부는 변경하지 않음