### PR TITLE
앱 에디터 pan scroll의 간헐적 fling 누락 수정

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionController.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionController.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerInputChange
 import co.typie.editor.Editor
 import co.typie.editor.EditorState
 import co.typie.editor.ffi.InputModifiers
@@ -79,9 +80,8 @@ internal class EditorInteractionController(
   fun canApplyModeEvent(event: EditorInteractionEvent): Boolean = mode.canApply(event)
 
   fun onPointerDown(
-    pointerId: Long,
+    change: PointerInputChange,
     position: Offset?,
-    nowMillis: Long,
     tapEnabled: Boolean = true,
     inputModifiers: InputModifiers = InputModifiers(),
     positionInRoot: Offset = requireNotNull(position),
@@ -89,10 +89,9 @@ internal class EditorInteractionController(
   ): Boolean =
     if (ensurePointerInputEnabled()) {
       gestures.handlePointerDown(
-        pointerId = pointerId,
+        change = change,
         positionInEditor = position,
         positionInRoot = positionInRoot,
-        nowMillis = nowMillis,
         tapEnabled = tapEnabled && position != null,
         inputModifiers = inputModifiers,
         touchPanDriver = touchPanDriver,
@@ -103,21 +102,15 @@ internal class EditorInteractionController(
     }
 
   fun onPointerMove(
-    pointerId: Long,
+    change: PointerInputChange,
     position: Offset?,
-    nowMillis: Long,
     positionInRoot: Offset = requireNotNull(position),
-    pressed: Boolean = true,
-    consumed: Boolean = false,
   ): Boolean =
     if (ensurePointerInputEnabled()) {
       gestures.handlePointerMove(
-        pointerId = pointerId,
+        change = change,
         positionInEditor = position,
         positionInRoot = positionInRoot,
-        nowMillis = nowMillis,
-        pressed = pressed,
-        consumed = consumed,
         context = gestureContext,
       )
     } else {
@@ -125,17 +118,15 @@ internal class EditorInteractionController(
     }
 
   fun onPointerUp(
-    pointerId: Long,
+    change: PointerInputChange,
     position: Offset?,
-    nowMillis: Long,
     positionInRoot: Offset = requireNotNull(position),
   ): Boolean =
     if (ensurePointerInputEnabled()) {
       gestures.handlePointerUp(
-        pointerId = pointerId,
+        change = change,
         positionInEditor = position,
         positionInRoot = positionInRoot,
-        nowMillis = nowMillis,
         context = gestureContext,
       )
     } else {
@@ -152,18 +143,16 @@ internal class EditorInteractionController(
   fun onPinchEnd(): Boolean = gestures.endPinch(context = gestureContext)
 
   fun endPinchAndResumeViewportPan(
-    pointerId: Long,
+    change: PointerInputChange,
     position: Offset,
-    nowMillis: Long,
     driver: EditorPanGestureDriver,
   ): Boolean {
     if (!ensurePointerInputEnabled()) {
       return false
     }
     return gestures.endPinchAndResumeViewportPan(
-      pointerId = pointerId,
+      change = change,
       position = position,
-      nowMillis = nowMillis,
       driver = driver,
       context = gestureContext,
     )

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionGestures.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionGestures.kt
@@ -1,6 +1,7 @@
 package co.typie.editor.interaction
 
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerInputChange
 import co.typie.editor.ffi.InputModifiers
 import co.typie.editor.interaction.gestures.EditorDndGesture
 import co.typie.editor.interaction.gestures.EditorLongPressDispatchDelayMillis
@@ -54,15 +55,16 @@ internal class EditorInteractionGestures(
   }
 
   fun handlePointerDown(
-    pointerId: Long,
+    change: PointerInputChange,
     positionInEditor: Offset?,
     positionInRoot: Offset,
-    nowMillis: Long,
     tapEnabled: Boolean,
     inputModifiers: InputModifiers,
     touchPanDriver: EditorPanGestureDriver? = null,
     context: EditorGestureContext,
   ): Boolean {
+    val pointerId = change.id.value
+    val nowMillis = change.uptimeMillis
     if (tap.hasActivePointer) {
       tap.cancelActivePointerStream()
       context.reduceMode(EditorInteractionEvent.PointerCancel)
@@ -76,24 +78,14 @@ internal class EditorInteractionGestures(
 
     if (
       touchPanDriver != null &&
-        pan.prepareScrollCatch(
-          pointerId = pointerId,
-          position = positionInRoot,
-          nowMillis = nowMillis,
-          driver = touchPanDriver,
-        )
+        pan.prepareScrollCatch(change = change, position = positionInRoot, driver = touchPanDriver)
     ) {
       return true
     }
 
     if (positionInEditor == null) {
       if (touchPanDriver != null) {
-        pan.prepareFresh(
-          pointerId = pointerId,
-          position = positionInRoot,
-          nowMillis = nowMillis,
-          driver = touchPanDriver,
-        )
+        pan.prepareFresh(change = change, position = positionInRoot, driver = touchPanDriver)
       }
       return false
     }
@@ -149,12 +141,7 @@ internal class EditorInteractionGestures(
         !tableHandleHit &&
         selectionHandleType == null &&
         touchPanDriver != null ->
-        pan.prepareFresh(
-          pointerId = pointerId,
-          position = positionInRoot,
-          nowMillis = nowMillis,
-          driver = touchPanDriver,
-        )
+        pan.prepareFresh(change = change, position = positionInRoot, driver = touchPanDriver)
     }
     if (
       tapEnabled &&
@@ -174,29 +161,19 @@ internal class EditorInteractionGestures(
   }
 
   fun handlePointerMove(
-    pointerId: Long,
+    change: PointerInputChange,
     positionInEditor: Offset?,
     positionInRoot: Offset,
-    nowMillis: Long,
-    pressed: Boolean = true,
-    consumed: Boolean = false,
     context: EditorGestureContext,
   ): Boolean {
+    val pointerId = change.id.value
     if (doubleTapDrag.active) {
       val position = positionInEditor ?: return true
       trackTapPointerMove(pointerId = pointerId, position = position, context = context)
       return doubleTapDrag.handlePointerMove(position = position, tap = tap, context = context)
     }
     if (positionInEditor == null) {
-      val panConsumed =
-        pan.update(
-          pointerId = pointerId,
-          position = positionInRoot,
-          nowMillis = nowMillis,
-          pressed = pressed,
-          consumed = consumed,
-          context = context,
-        )
+      val panConsumed = pan.update(change = change, position = positionInRoot, context = context)
       if (panConsumed) {
         cancelTapAndLongPress(context = context)
       }
@@ -250,15 +227,7 @@ internal class EditorInteractionGestures(
       }
       return true
     }
-    val panConsumed =
-      pan.update(
-        pointerId = pointerId,
-        position = positionInRoot,
-        nowMillis = nowMillis,
-        pressed = pressed,
-        consumed = consumed,
-        context = context,
-      )
+    val panConsumed = pan.update(change = change, position = positionInRoot, context = context)
     if (panConsumed) {
       cancelTapAndLongPress(context = context)
       return true
@@ -267,22 +236,15 @@ internal class EditorInteractionGestures(
   }
 
   fun handlePointerUp(
-    pointerId: Long,
+    change: PointerInputChange,
     positionInEditor: Offset?,
     positionInRoot: Offset,
-    nowMillis: Long,
     context: EditorGestureContext,
   ): Boolean {
+    val pointerId = change.id.value
+    val nowMillis = change.uptimeMillis
     if (positionInEditor == null) {
-      val panConsumed =
-        pan.update(
-          pointerId = pointerId,
-          position = positionInRoot,
-          nowMillis = nowMillis,
-          pressed = false,
-          consumed = false,
-          context = context,
-        )
+      val panConsumed = pan.update(change = change, position = positionInRoot, context = context)
       if (panConsumed || tap.hasActivePointer) {
         cancelTapAndLongPress(context = context)
       }
@@ -334,16 +296,7 @@ internal class EditorInteractionGestures(
       return selectionHandle.handleDragEnd(type = type)
     }
 
-    if (
-      pan.update(
-        pointerId = pointerId,
-        position = positionInRoot,
-        nowMillis = nowMillis,
-        pressed = false,
-        consumed = false,
-        context = context,
-      )
-    ) {
+    if (pan.update(change = change, position = positionInRoot, context = context)) {
       cancelTapAndLongPress(context = context)
       return true
     }
@@ -400,9 +353,8 @@ internal class EditorInteractionGestures(
   }
 
   fun endPinchAndResumeViewportPan(
-    pointerId: Long,
+    change: PointerInputChange,
     position: Offset,
-    nowMillis: Long,
     driver: EditorPanGestureDriver,
     context: EditorGestureContext,
   ): Boolean {
@@ -410,7 +362,7 @@ internal class EditorInteractionGestures(
       return false
     }
     endPinch(context = context)
-    pan.resume(pointerId = pointerId, position = position, nowMillis = nowMillis, driver = driver)
+    pan.resume(change = change, position = position, driver = driver)
     return true
   }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractions.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractions.kt
@@ -310,9 +310,8 @@ private class EditorInteractionsNode(
       val rootPosition = positionInRoot(survivor.position)
       if (
         interactionController.endPinchAndResumeViewportPan(
-          pointerId = survivor.id.value,
+          change = survivor,
           position = rootPosition,
-          nowMillis = survivor.uptimeMillis,
           driver = scrollDriver,
         )
       ) {
@@ -485,9 +484,8 @@ private class EditorInteractionsNode(
         singlePointerStreams += change.id.value
         if (
           interactionController.onPointerDown(
-            pointerId = change.id.value,
+            change = change,
             position = editorPosition,
-            nowMillis = change.uptimeMillis,
             tapEnabled = tapEnabled,
             inputModifiers = pointerEvent.inputModifiers(),
             positionInRoot = rootPosition,
@@ -513,11 +511,9 @@ private class EditorInteractionsNode(
         }
         if (
           interactionController.onPointerMove(
-            pointerId = change.id.value,
+            change = change,
             position = editorPosition,
             positionInRoot = rootPosition,
-            nowMillis = change.uptimeMillis,
-            consumed = change.isConsumed,
           )
         ) {
           change.consume()
@@ -539,10 +535,9 @@ private class EditorInteractionsNode(
         }
         if (
           interactionController.onPointerUp(
-            pointerId = change.id.value,
+            change = change,
             position = editorPosition,
             positionInRoot = rootPosition,
-            nowMillis = change.uptimeMillis,
           )
         ) {
           change.consume()

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorPanGesture.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorPanGesture.kt
@@ -1,13 +1,13 @@
 package co.typie.editor.interaction.gestures
 
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.compose.ui.input.pointer.util.VelocityTracker
+import androidx.compose.ui.input.pointer.util.addPointerInputChange
 import androidx.compose.ui.unit.Velocity
 import co.typie.editor.interaction.EditorGestureContext
 import co.typie.editor.interaction.EditorInteractionEvent
 import co.typie.editor.interaction.canApply
-
-private const val PointerMoveStoppedTimeoutMillis = 40L
 
 internal interface EditorPanGestureDriver {
   val shouldCatchTouch: Boolean
@@ -34,37 +34,24 @@ internal class EditorPanGesture {
   val hasPendingPointer: Boolean
     get() = session != null && !active
 
-  fun prepareFresh(
-    pointerId: Long,
-    position: Offset,
-    nowMillis: Long,
-    driver: EditorPanGestureDriver,
-  ) {
+  fun prepareFresh(change: PointerInputChange, position: Offset, driver: EditorPanGestureDriver) {
     if (session != null) {
       return
     }
-    prepare(
-      pointerId = pointerId,
-      position = position,
-      nowMillis = nowMillis,
-      startKind = StartKind.Fresh,
-      driver = driver,
-    )
+    prepare(change = change, position = position, startKind = StartKind.Fresh, driver = driver)
   }
 
   fun prepareScrollCatch(
-    pointerId: Long,
+    change: PointerInputChange,
     position: Offset,
-    nowMillis: Long,
     driver: EditorPanGestureDriver,
   ): Boolean {
     if (session != null || !driver.shouldCatchTouch) {
       return false
     }
     prepare(
-      pointerId = pointerId,
+      change = change,
       position = position,
-      nowMillis = nowMillis,
       startKind = StartKind.ScrollCatch,
       driver = driver,
     )
@@ -76,44 +63,29 @@ internal class EditorPanGesture {
     return true
   }
 
-  fun resume(pointerId: Long, position: Offset, nowMillis: Long, driver: EditorPanGestureDriver) {
+  fun resume(change: PointerInputChange, position: Offset, driver: EditorPanGestureDriver) {
     reset()
-    prepare(
-      pointerId = pointerId,
-      position = position,
-      nowMillis = nowMillis,
-      startKind = StartKind.Resumed,
-      driver = driver,
-    )
+    prepare(change = change, position = position, startKind = StartKind.Resumed, driver = driver)
   }
 
-  fun update(
-    pointerId: Long,
-    position: Offset,
-    nowMillis: Long,
-    pressed: Boolean,
-    consumed: Boolean,
-    context: EditorGestureContext,
-  ): Boolean {
-    val current = session?.takeIf { it.pointerId == pointerId } ?: return false
+  fun update(change: PointerInputChange, position: Offset, context: EditorGestureContext): Boolean {
+    val current = session?.takeIf { it.pointerId == change.id.value } ?: return false
+    val pressed = change.pressed
     val delta = position - current.lastPosition
 
     if (active) {
       if (delta != Offset.Zero) {
         current.driver.update(delta)
       }
-      if (pressed) {
-        velocityTracker.addPosition(nowMillis, position)
-        current.lastVelocitySampleAtMillis = nowMillis
-      }
+      trackVelocity(position = position, change = change)
       current.lastPosition = position
       if (!pressed) {
-        finish(nowMillis = nowMillis, context = context)
+        finish(context = context)
       }
       return true
     }
 
-    if (!pressed || consumed) {
+    if (!pressed || change.isConsumed) {
       val caughtScroll = current.startKind == StartKind.ScrollCatch
       if (current.driverStarted) {
         current.driver.cancel()
@@ -133,15 +105,13 @@ internal class EditorPanGesture {
         clear()
         return false
       }
-      velocityTracker.addPosition(nowMillis, position)
-      current.lastVelocitySampleAtMillis = nowMillis
+      trackVelocity(position = position, change = change)
       current.driver.update(delta)
       current.lastPosition = position
       return true
     }
 
-    velocityTracker.addPosition(nowMillis, position)
-    current.lastVelocitySampleAtMillis = nowMillis
+    trackVelocity(position = position, change = change)
     val fromStart = position - current.startPosition
     val distance = fromStart.getDistance()
     val touchSlop = current.driver.touchSlop.coerceAtLeast(0f)
@@ -183,23 +153,21 @@ internal class EditorPanGesture {
   }
 
   private fun prepare(
-    pointerId: Long,
+    change: PointerInputChange,
     position: Offset,
-    nowMillis: Long,
     startKind: StartKind,
     driver: EditorPanGestureDriver,
   ) {
     session =
       Session(
-        pointerId = pointerId,
+        pointerId = change.id.value,
         startPosition = position,
         lastPosition = position,
-        lastVelocitySampleAtMillis = nowMillis,
         startKind = startKind,
         driver = driver,
       )
     velocityTracker.resetTracking()
-    velocityTracker.addPosition(nowMillis, position)
+    trackVelocity(position = position, change = change)
   }
 
   private fun start(context: EditorGestureContext): Boolean {
@@ -219,16 +187,11 @@ internal class EditorPanGesture {
     return true
   }
 
-  private fun finish(nowMillis: Long, context: EditorGestureContext) {
+  private fun finish(context: EditorGestureContext) {
     val current = session ?: return
     val maximum =
       current.driver.maximumFlingVelocity.takeIf { it.isFinite() && it > 0f } ?: Float.MAX_VALUE
-    val velocity =
-      if (nowMillis - current.lastVelocitySampleAtMillis > PointerMoveStoppedTimeoutMillis) {
-        Velocity.Zero
-      } else {
-        velocityTracker.calculateVelocity(Velocity(maximum, maximum))
-      }
+    val velocity = velocityTracker.calculateVelocity(Velocity(maximum, maximum))
     current.driver.end(velocity)
     context.applyModeEvent(EditorInteractionEvent.PanEnd)
     clear()
@@ -240,11 +203,14 @@ internal class EditorPanGesture {
     velocityTracker.resetTracking()
   }
 
+  private fun trackVelocity(position: Offset, change: PointerInputChange) {
+    velocityTracker.addPointerInputChange(event = change, offset = position - change.position)
+  }
+
   private data class Session(
     val pointerId: Long,
     val startPosition: Offset,
     var lastPosition: Offset,
-    var lastVelocitySampleAtMillis: Long,
     val startKind: StartKind,
     val driver: EditorPanGestureDriver,
     var driverStarted: Boolean = false,

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
@@ -4,6 +4,8 @@ import androidx.compose.runtime.BroadcastFrameClock
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect as ComposeRect
 import androidx.compose.ui.geometry.Size as ComposeSize
+import androidx.compose.ui.input.pointer.PointerId
+import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.compose.ui.unit.Velocity
 import co.typie.editor.Editor
 import co.typie.editor.EditorZoomController
@@ -53,6 +55,77 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+
+private fun EditorInteractionController.onPointerDown(
+  pointerId: Long,
+  position: Offset?,
+  nowMillis: Long,
+  tapEnabled: Boolean = true,
+  inputModifiers: InputModifiers = InputModifiers(),
+  positionInRoot: Offset = requireNotNull(position),
+  touchPanDriver: EditorPanGestureDriver? = null,
+): Boolean =
+  onPointerDown(
+    change = testPointerInputChange(pointerId, nowMillis, pressed = true, previousPressed = false),
+    position = position,
+    tapEnabled = tapEnabled,
+    inputModifiers = inputModifiers,
+    positionInRoot = positionInRoot,
+    touchPanDriver = touchPanDriver,
+  )
+
+private fun EditorInteractionController.onPointerMove(
+  pointerId: Long,
+  position: Offset?,
+  nowMillis: Long,
+  positionInRoot: Offset = requireNotNull(position),
+  pressed: Boolean = true,
+  consumed: Boolean = false,
+): Boolean =
+  onPointerMove(
+    change =
+      testPointerInputChange(
+        pointerId = pointerId,
+        nowMillis = nowMillis,
+        pressed = pressed,
+        previousPressed = true,
+        consumed = consumed,
+      ),
+    position = position,
+    positionInRoot = positionInRoot,
+  )
+
+private fun EditorInteractionController.onPointerUp(
+  pointerId: Long,
+  position: Offset?,
+  nowMillis: Long,
+  positionInRoot: Offset = requireNotNull(position),
+): Boolean =
+  onPointerUp(
+    change = testPointerInputChange(pointerId, nowMillis, pressed = false, previousPressed = true),
+    position = position,
+    positionInRoot = positionInRoot,
+  )
+
+private fun testPointerInputChange(
+  pointerId: Long,
+  nowMillis: Long,
+  pressed: Boolean,
+  previousPressed: Boolean,
+  consumed: Boolean = false,
+): PointerInputChange =
+  // The public test constructor does not expose originalEventPosition. Keeping its local position
+  // at the origin lets the production root-space offset carry the synthetic test position.
+  PointerInputChange(
+    id = PointerId(pointerId),
+    uptimeMillis = nowMillis,
+    position = Offset.Zero,
+    pressed = pressed,
+    previousUptimeMillis = nowMillis,
+    previousPosition = Offset.Zero,
+    previousPressed = previousPressed,
+    isInitiallyConsumed = consumed,
+  )
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class EditorInteractionControllerTest {
@@ -1891,51 +1964,6 @@ class EditorInteractionControllerTest {
       val velocity = driver.endVelocities.single()
       assertTrue(velocity.x > 1_500f, "Expected recent pan velocity, got $velocity")
       assertTrue(velocity.y in -0.01f..0.01f, "Expected horizontal pan velocity, got $velocity")
-    }
-
-  @Test
-  fun `pan release after pointer stops has no velocity`() =
-    runTest(StandardTestDispatcher()) {
-      val editor = Editor(FakeFfiEditor(), this, StandardTestDispatcher(testScheduler))
-      val host = TestHost(this)
-      val controller =
-        EditorInteractionController(
-          editorProvider = { editor },
-          effects = host,
-          geometry = host,
-          uiStateProvider = { host.uiState },
-        )
-      val driver = TestPanGestureDriver(shouldCatchTouch = false)
-      controller.updateTapSlop(8f)
-      val start = Offset(10f, 20f)
-
-      controller.onPointerDown(
-        pointerId = 1L,
-        position = start,
-        positionInRoot = start,
-        nowMillis = 0L,
-        touchPanDriver = driver,
-      )
-      controller.onPointerMove(
-        pointerId = 1L,
-        position = start + Offset(20f, 0f),
-        positionInRoot = start + Offset(20f, 0f),
-        nowMillis = 10L,
-      )
-      controller.onPointerMove(
-        pointerId = 1L,
-        position = start + Offset(40f, 0f),
-        positionInRoot = start + Offset(40f, 0f),
-        nowMillis = 20L,
-      )
-      controller.onPointerUp(
-        pointerId = 1L,
-        position = start + Offset(40f, 0f),
-        positionInRoot = start + Offset(40f, 0f),
-        nowMillis = 61L,
-      )
-
-      assertEquals(Velocity.Zero, driver.endVelocities.single())
     }
 
   @Test


### PR DESCRIPTION
## 배경

- 앱 에디터가 pan velocity를 원본 pointer event 대신 개별 좌표로 추적하고, 마지막 move 후 40ms가 지나 release되면 velocity를 강제로 0으로 만들고 있었음
- Compose의 플랫폼별 velocity tracker는 historical sample과 release timing을 자체적으로 처리하므로, 에디터의 별도 cutoff가 iOS에서 유효한 fling까지 간헐적으로 제거할 수 있었음

## 변경

- 실제 DOWN, MOVE와 UP의 `PointerInputChange`를 Compose `VelocityTracker`에 전달해 historical sample과 플랫폼 release 정책을 사용
- 에디터가 소유하던 40ms timeout과 마지막 velocity sample timestamp 제거
- 기존 pan/pinch gesture ownership, pinch 이후 pan 재개, 최대 velocity 제한과 Compose `FlingBehavior`는 유지