### PR TITLE
앱 Dialog를 IME 제외 영역에 배치

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/dialog/DialogOverlay.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/dialog/DialogOverlay.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
 import co.typie.ext.clickable
+import co.typie.ext.imePadding
 import co.typie.navigation.PlatformBackHandler
 import co.typie.ui.theme.AppTheme
 
@@ -89,19 +90,21 @@ fun DialogOverlay(state: Dialog) {
         )
     )
 
-    Box(
-      modifier =
-        Modifier.align(Alignment.Center)
-          .width(280.dp)
-          .onFocusChanged { dialogHasFocus = it.hasFocus }
-          .pointerInput(Unit) {}
-          .graphicsLayer {
-            alpha = progress
-            translationY = (1f - progress) * offsetPx
-          }
-    ) {
-      @Suppress("UNCHECKED_CAST") val typedEntry = entry as DialogEntry<Any?>
-      context(scope) { typedEntry.content() }
+    Box(Modifier.fillMaxSize().imePadding()) {
+      Box(
+        modifier =
+          Modifier.align(Alignment.Center)
+            .width(280.dp)
+            .onFocusChanged { dialogHasFocus = it.hasFocus }
+            .pointerInput(Unit) {}
+            .graphicsLayer {
+              alpha = progress
+              translationY = (1f - progress) * offsetPx
+            }
+      ) {
+        @Suppress("UNCHECKED_CAST") val typedEntry = entry as DialogEntry<Any?>
+        context(scope) { typedEntry.content() }
+      }
     }
   }
 }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/dialog/DialogOverlayDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/dialog/DialogOverlayDesktopTest.kt
@@ -3,6 +3,7 @@ package co.typie.ui.component.dialog
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -12,6 +13,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsFocused
@@ -20,7 +22,9 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.dp
+import co.typie.dev.DesktopDebugKeyboard
 import co.typie.ext.clickable
+import co.typie.ext.ime
 import co.typie.ui.theme.LightAppShadows
 import co.typie.ui.theme.LightColors
 import co.typie.ui.theme.LocalAppColors
@@ -30,11 +34,69 @@ import co.typie.ui.theme.ResolvedThemeMode
 import dev.chrisbanes.haze.blur.HazeBlurStyle
 import dev.chrisbanes.haze.blur.LocalHazeBlurStyle
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalTestApi::class)
 class DialogOverlayDesktopTest {
+  @Test
+  fun contentIsCenteredInAreaAboveIme() = runComposeUiTest {
+    val dialog = Dialog()
+    val keyboardOwner = Any()
+    val wasHardwareKeyboardConnected = DesktopDebugKeyboard.hardwareKeyboardConnected
+    var imeBottomPx = 0f
+
+    try {
+      setContent {
+        DialogTestTheme {
+          val density = LocalDensity.current
+          val imeInsets = WindowInsets.ime
+          SideEffect { imeBottomPx = imeInsets.getBottom(density).toFloat() }
+
+          Box(Modifier.testTag(RootTag).size(width = 400.dp, height = 700.dp)) {
+            LaunchedEffect(Unit) {
+              dialog.present<Unit> { Box(Modifier.testTag(DialogContentTag).size(80.dp)) }
+            }
+
+            DialogOverlay(dialog)
+          }
+        }
+      }
+
+      waitUntil(timeoutMillis = 5_000) { dialog.current != null }
+      runOnIdle {
+        DesktopDebugKeyboard.updateHardwareKeyboardConnected(false)
+        DesktopDebugKeyboard.hideKeyboardSurface()
+      }
+      mainClock.advanceTimeBy(300)
+      waitForIdle()
+
+      val rootBounds = onNodeWithTag(RootTag).fetchSemanticsNode().boundsInRoot
+      val initialContentBounds = onNodeWithTag(DialogContentTag).fetchSemanticsNode().boundsInRoot
+      assertEquals(0f, imeBottomPx, absoluteTolerance = 0.5f)
+      assertEquals(rootBounds.center.y, initialContentBounds.center.y, absoluteTolerance = 0.5f)
+
+      runOnIdle { DesktopDebugKeyboard.notifyFocusChanged(keyboardOwner, isFocused = true) }
+      mainClock.advanceTimeBy(300)
+      waitForIdle()
+
+      val contentBounds = onNodeWithTag(DialogContentTag).fetchSemanticsNode().boundsInRoot
+      val visibleBottom = rootBounds.bottom - imeBottomPx
+      val visibleAreaCenterY = (rootBounds.top + visibleBottom) / 2f
+      assertTrue(imeBottomPx > 0f)
+      assertEquals(visibleAreaCenterY, contentBounds.center.y, absoluteTolerance = 0.5f)
+      assertTrue(contentBounds.bottom <= visibleBottom + 0.5f)
+    } finally {
+      runOnIdle {
+        DesktopDebugKeyboard.notifyFocusChanged(keyboardOwner, isFocused = false)
+        DesktopDebugKeyboard.updateHardwareKeyboardConnected(wasHardwareKeyboardConnected)
+        DesktopDebugKeyboard.hideKeyboardSurface()
+      }
+    }
+  }
+
   @Test
   fun dismissalDoesNotClearFocusOutsideDialog() = runComposeUiTest {
     val dialog = Dialog()
@@ -141,6 +203,8 @@ class DialogOverlayDesktopTest {
   }
 
   private companion object {
+    const val RootTag = "root"
+    const val DialogContentTag = "dialog-content"
     const val OutsideFocusTag = "outside-focus"
     const val DialogFocusTag = "dialog-focus"
     const val DismissTag = "dialog-dismiss"


### PR DESCRIPTION
## 배경

- `DialogOverlay`가 콘텐츠를 전체 root의 중앙에 배치하고 IME inset을 반영하지 않고 있었음
- 앱의 `adjustNothing` 정책에서는 키보드가 열려도 root가 resize되지 않아, 입력 필드에 focus가 생기면 Dialog 하단이 IME에 가려질 수 있었음
- 전체 화면 scrim, 바깥 탭 dismiss, 기존 focus-home lifecycle은 유지하면서 Dialog 콘텐츠의 배치 영역만 IME에 맞출 필요가 있었음

## 변경

- 전체 화면 scrim과 바깥 탭 영역은 기존 크기를 유지
- Dialog 콘텐츠 전용 host에 공용 `imePadding()`을 적용
- 키보드가 열리면 Dialog 콘텐츠를 IME 위 가시 영역의 중앙에 배치
- Desktop debug keyboard와 실제 `WindowInsets.ime`을 사용하는 회귀 테스트를 추가해 다음을 검증
    - 키보드가 닫혀 있을 때 기존처럼 root 중앙에 배치
    - 키보드가 열려 있을 때 IME 위 가시 영역 중앙에 배치
    - Dialog 하단이 가시 영역을 벗어나지 않음
- focus, dismiss, Android window policy는 변경하지 않음

IME 위 가시 영역보다 긴 Dialog의 body scrolling은 별도 후속 PR에서 다룸