### PR TITLE
에디터 continuous 모드에서 테이블 overlay 중복 표시 수정

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorTableCellSelectionGeometry.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorTableCellSelectionGeometry.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.geometry.Rect
 import co.typie.editor.Editor
 import co.typie.editor.PagePoint
 import co.typie.editor.ext.isCollapsed
+import co.typie.editor.ffi.LayoutMode
 import co.typie.editor.ffi.TableOverlay
 import kotlin.math.max
 import kotlin.math.min
@@ -53,14 +54,27 @@ internal fun resolveActiveTableCellSelection(editor: Editor): EditorTableCellSel
 internal fun hasActiveTableCellSelection(editor: Editor): Boolean =
   resolveTableCellSelections(editor).isNotEmpty()
 
-internal fun TableOverlay.contains(point: PagePoint): Boolean {
-  if (pageIdx != point.page) {
-    return false
+internal fun TableOverlay.contains(
+  point: PagePoint,
+  layoutMode: LayoutMode?,
+  project: (page: Int, x: Float, y: Float) -> Offset?,
+): Boolean {
+  if (layoutMode !is LayoutMode.Continuous) {
+    return pageIdx == point.page &&
+      point.x >= bounds.x &&
+      point.x <= bounds.x + bounds.width &&
+      point.y >= bounds.y &&
+      point.y <= bounds.y + bounds.height
   }
-  return point.x >= bounds.x &&
-    point.x <= bounds.x + bounds.width &&
-    point.y >= bounds.y &&
-    point.y <= bounds.y + bounds.height
+
+  val topLeft = project(pageIdx, bounds.x, bounds.y) ?: return false
+  val bottomRight =
+    project(pageIdx, bounds.x + bounds.width, bounds.y + bounds.height) ?: return false
+  val candidate = project(point.page, point.x, point.y) ?: return false
+  return candidate.x >= topLeft.x &&
+    candidate.x <= bottomRight.x &&
+    candidate.y >= topLeft.y &&
+    candidate.y <= bottomRight.y
 }
 
 internal fun resolveTableCellSelectionRange(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorTableHandleGesture.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorTableHandleGesture.kt
@@ -258,7 +258,12 @@ internal class EditorTableHandleGesture(
 
     if (
       !context.editor.tableOverlays.any { overlay ->
-        overlay.tableId == drag.tableId && overlay.contains(point)
+        overlay.tableId == drag.tableId &&
+          overlay.contains(
+            point = point,
+            layoutMode = context.editor.rootAttrs?.layoutMode,
+            project = context.geometry::resolvePagePosition,
+          )
       }
     ) {
       return EditorTableHandleDragUpdate.HandoffToSelectionHandle(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/sessions/EditorSelectionHandleDragSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/sessions/EditorSelectionHandleDragSession.kt
@@ -135,7 +135,13 @@ internal class EditorSelectionHandleDragSession {
     ) {
       return null
     }
-    if (!activeSelection.overlay.contains(point)) {
+    if (
+      !activeSelection.overlay.contains(
+        point = point,
+        layoutMode = context.editor.rootAttrs?.layoutMode,
+        project = context.geometry::resolvePagePosition,
+      )
+    ) {
       return null
     }
     val baseSelection = drag.baseSelection ?: context.editor.selection ?: return null

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
@@ -2139,7 +2139,7 @@ class EditorInteractionControllerTest {
     }
 
   @Test
-  fun `table cell handle drag hands off to selection handle after leaving table`() =
+  fun `table cell handle drag stays active across continuous canvas boundary and hands off outside table`() =
     runTest(StandardTestDispatcher()) {
       val selection =
         Selection(
@@ -2155,7 +2155,8 @@ class EditorInteractionControllerTest {
         )
       val editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
       editor.sync {}
-      val host = TestHost(this)
+      val host =
+        TestHost(this).apply { pageOffsets = mapOf(0 to Offset.Zero, 1 to Offset(x = 0f, y = 80f)) }
       val controller =
         EditorInteractionController(
           editorProvider = { editor },
@@ -2167,31 +2168,46 @@ class EditorInteractionControllerTest {
       val down = Offset(70f, 70f)
 
       assertTrue(controller.onPointerDown(pointerId = 1L, position = down, nowMillis = 0L))
+      host.point = PagePoint(page = 1, x = 0f, y = 0f)
       assertTrue(
-        controller.onPointerMove(pointerId = 1L, position = Offset(130f, 120f), nowMillis = 20L)
+        controller.onPointerMove(pointerId = 1L, position = Offset(40f, 100f), nowMillis = 20L)
       )
 
-      val extends =
-        fake.enqueued.filterIsInstance<Message.Selection>().map { it.op as SelectionOp.ExtendTo }
-      assertEquals(1, extends.size)
-      assertTrue(extends.all { extend -> extend.baseSelection == selection })
-      assertTrue(extends.all { extend -> !extend.allowCollapse })
-      assertEquals(selection.anchor, extends.single().anchor)
-      assertEquals(120f, extends.single().headX)
-      assertEquals(110f, extends.single().headY)
-      assertEquals(EditorInteractionMode.SelectionHandleDragging, controller.interactionMode)
-      assertEquals(Offset(120f, 110f), controller.magnifierPosition)
+      val crossCanvasExtend =
+        (fake.enqueued.single() as Message.Selection).op as SelectionOp.ExtendTo
+      assertEquals(selection.anchor, crossCanvasExtend.anchor)
+      assertEquals(1, crossCanvasExtend.headPage)
+      assertEquals(30f, crossCanvasExtend.headX)
+      assertEquals(10f, crossCanvasExtend.headY)
+      assertEquals(selection, crossCanvasExtend.baseSelection)
+      assertFalse(crossCanvasExtend.allowCollapse)
+      assertEquals(EditorInteractionMode.TableCellHandleDragging, controller.interactionMode)
 
       fake.enqueued.clear()
       assertTrue(
-        controller.onPointerMove(pointerId = 1L, position = Offset(131f, 121f), nowMillis = 40L)
+        controller.onPointerMove(pointerId = 1L, position = Offset(40f, 120f), nowMillis = 40L)
+      )
+
+      val outsideExtend = (fake.enqueued.single() as Message.Selection).op as SelectionOp.ExtendTo
+      assertEquals(selection.anchor, outsideExtend.anchor)
+      assertEquals(1, outsideExtend.headPage)
+      assertEquals(30f, outsideExtend.headX)
+      assertEquals(30f, outsideExtend.headY)
+      assertEquals(selection, outsideExtend.baseSelection)
+      assertFalse(outsideExtend.allowCollapse)
+      assertEquals(EditorInteractionMode.SelectionHandleDragging, controller.interactionMode)
+      assertEquals(Offset(30f, 110f), controller.magnifierPosition)
+
+      fake.enqueued.clear()
+      assertTrue(
+        controller.onPointerMove(pointerId = 1L, position = Offset(41f, 121f), nowMillis = 60L)
       )
       val continuedExtend = (fake.enqueued.single() as Message.Selection).op as SelectionOp.ExtendTo
-      assertEquals(121f, continuedExtend.headX)
-      assertEquals(111f, continuedExtend.headY)
+      assertEquals(31f, continuedExtend.headX)
+      assertEquals(31f, continuedExtend.headY)
 
       assertTrue(
-        controller.onPointerUp(pointerId = 1L, position = Offset(131f, 121f), nowMillis = 60L)
+        controller.onPointerUp(pointerId = 1L, position = Offset(41f, 121f), nowMillis = 80L)
       )
       assertEquals(EditorInteractionMode.Idle, controller.interactionMode)
       assertFalse(host.scrollGestureLockActive)
@@ -2290,7 +2306,7 @@ class EditorInteractionControllerTest {
     }
 
   @Test
-  fun `selection handle drag hands off to table cell handle after cell selection appears`() =
+  fun `selection handle drag hands off to table cell handle on later continuous canvas`() =
     runTest(StandardTestDispatcher()) {
       val endpoints =
         SelectionEndpoints(
@@ -2310,7 +2326,8 @@ class EditorInteractionControllerTest {
         )
       val editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
       editor.sync {}
-      val host = TestHost(this)
+      val host =
+        TestHost(this).apply { pageOffsets = mapOf(0 to Offset.Zero, 1 to Offset(x = 0f, y = 80f)) }
       val controller =
         EditorInteractionController(
           editorProvider = { editor },
@@ -2337,29 +2354,32 @@ class EditorInteractionControllerTest {
         )
       editor.sync {}
       fake.enqueued.clear()
+      host.point = PagePoint(page = 1, x = 0f, y = 0f)
 
       assertTrue(
-        controller.onPointerMove(pointerId = 1L, position = Offset(64f, 60f), nowMillis = 40L)
+        controller.onPointerMove(pointerId = 1L, position = Offset(64f, 96f), nowMillis = 40L)
       )
       val handoffExtend = (fake.enqueued.single() as Message.Selection).op as SelectionOp.ExtendTo
       assertEquals(selection.anchor, handoffExtend.anchor)
       assertEquals(selection, handoffExtend.baseSelection)
+      assertEquals(1, handoffExtend.headPage)
       assertEquals(62f, handoffExtend.headX)
-      assertEquals(54f, handoffExtend.headY)
+      assertEquals(10f, handoffExtend.headY)
       assertEquals(EditorInteractionMode.TableCellHandleDragging, controller.interactionMode)
 
       fake.enqueued.clear()
       assertTrue(
-        controller.onPointerMove(pointerId = 1L, position = Offset(72f, 70f), nowMillis = 60L)
+        controller.onPointerMove(pointerId = 1L, position = Offset(72f, 106f), nowMillis = 60L)
       )
       val tableExtend = (fake.enqueued.single() as Message.Selection).op as SelectionOp.ExtendTo
       assertEquals(selection, tableExtend.baseSelection)
+      assertEquals(1, tableExtend.headPage)
       assertEquals(70f, tableExtend.headX)
-      assertEquals(64f, tableExtend.headY)
+      assertEquals(20f, tableExtend.headY)
       assertEquals(EditorInteractionMode.TableCellHandleDragging, controller.interactionMode)
 
       assertTrue(
-        controller.onPointerUp(pointerId = 1L, position = Offset(72f, 70f), nowMillis = 80L)
+        controller.onPointerUp(pointerId = 1L, position = Offset(72f, 106f), nowMillis = 80L)
       )
       assertEquals(EditorInteractionMode.Idle, controller.interactionMode)
     }
@@ -3593,6 +3613,7 @@ class EditorInteractionControllerTest {
     val uiState = EditorUiState()
     var scrollGestureLockActive = false
     var point: PagePoint? = PagePoint(page = 0, x = 10f, y = 20f)
+    var pageOffsets: Map<Int, Offset>? = null
     var edgeAutoScrollViewport: EditorEdgeAutoScrollViewport? = null
     var edgeAutoScrollConsumedDelta = Offset.Zero
     var edgeAutoScrollDispatchCount = 0
@@ -3609,14 +3630,26 @@ class EditorInteractionControllerTest {
       if (density <= 0f) {
         return null
       }
-      return point?.copy(x = positionInNode.x / density, y = positionInNode.y / density)
+      val currentPoint = point ?: return null
+      val configuredPageOffsets = pageOffsets
+      val pageOffset =
+        if (configuredPageOffsets == null) Offset.Zero
+        else configuredPageOffsets[currentPoint.page] ?: return null
+      return currentPoint.copy(
+        x = (positionInNode.x - pageOffset.x) / density,
+        y = (positionInNode.y - pageOffset.y) / density,
+      )
     }
 
     override fun resolvePagePosition(page: Int, x: Float, y: Float): Offset? {
       if (density <= 0f) {
         return null
       }
-      return Offset(x = x * density, y = y * density)
+      val configuredPageOffsets = pageOffsets
+      val pageOffset =
+        if (configuredPageOffsets == null) Offset.Zero
+        else configuredPageOffsets[page] ?: return null
+      return pageOffset + Offset(x = x * density, y = y * density)
     }
 
     override fun resolveEdgeAutoScrollViewport(): EditorEdgeAutoScrollViewport? =

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorTableCellSelectionGeometryTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorTableCellSelectionGeometryTest.kt
@@ -2,7 +2,10 @@ package co.typie.editor.interaction
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect as ComposeRect
+import co.typie.editor.DefaultRootPaginatedLayout
+import co.typie.editor.PagePoint
 import co.typie.editor.ffi.Alignment
+import co.typie.editor.ffi.LayoutMode
 import co.typie.editor.ffi.Rect
 import co.typie.editor.ffi.TableBorderStyle
 import co.typie.editor.ffi.TableOverlay
@@ -11,9 +14,56 @@ import co.typie.editor.ffi.TableOverlayColumn
 import co.typie.editor.ffi.TableOverlayRow
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class EditorTableCellSelectionGeometryTest {
+  @Test
+  fun `table containment projects complete continuous overlay across pages`() {
+    val overlay = tableOverlay()
+    val pageOffsets = mapOf(0 to Offset.Zero, 1 to Offset(x = 0f, y = 80f))
+    val project: (Int, Float, Float) -> Offset? = { page, x, y ->
+      pageOffsets[page]?.plus(Offset(x = x, y = y))
+    }
+
+    assertTrue(
+      overlay.contains(
+        point = PagePoint(page = 1, x = 20f, y = 10f),
+        layoutMode = LayoutMode.Continuous(maxWidth = 600),
+        project = project,
+      )
+    )
+    assertFalse(
+      overlay.contains(
+        point = PagePoint(page = 1, x = 20f, y = 30f),
+        layoutMode = LayoutMode.Continuous(maxWidth = 600),
+        project = project,
+      )
+    )
+    assertFalse(
+      overlay.contains(
+        point = PagePoint(page = 2, x = 20f, y = 10f),
+        layoutMode = LayoutMode.Continuous(maxWidth = 600),
+        project = project,
+      )
+    )
+    assertFalse(
+      overlay.contains(
+        point = PagePoint(page = 1, x = 20f, y = 10f),
+        layoutMode = DefaultRootPaginatedLayout,
+        project = project,
+      )
+    )
+    assertTrue(
+      overlay.contains(
+        point = PagePoint(page = 0, x = 20f, y = 30f),
+        layoutMode = DefaultRootPaginatedLayout,
+        project = project,
+      )
+    )
+  }
+
   @Test
   fun `collapsed focused cell resolves single-cell range and handle`() {
     val overlay = tableOverlay(isFocused = true, focusedRowIndex = 1, focusedColIndex = 0)
@@ -79,6 +129,32 @@ class EditorTableCellSelectionGeometryTest {
   }
 
   @Test
+  fun `complete continuous cell selection spans all rows with one head handle`() {
+    val overlay =
+      tableOverlay(
+        isFocused = true,
+        rows =
+          listOf(
+            TableOverlayRow(index = 0, height = 40f, position = 40f),
+            TableOverlayRow(index = 1, height = 40f, position = 80f),
+            TableOverlayRow(index = 2, height = 40f, position = 120f),
+          ),
+        rowCount = 3,
+        cellSelection = cellSelection(anchorRow = 0, anchorCol = 0, headRow = 2, headCol = 1),
+      )
+
+    val range = resolveTableCellSelectionRange(overlay = overlay, selectionCollapsed = false)
+
+    assertEquals(
+      EditorTableCellSelectionGeometry(
+        outline = ComposeRect(left = 10f, top = 20f, right = 110f, bottom = 140f),
+        handleCenter = Offset(x = 110f, y = 140f),
+      ),
+      resolveTableCellSelectionGeometry(overlay = overlay, range = range!!),
+    )
+  }
+
+  @Test
   fun `non-focused table boundary selection does not keep table handle active`() {
     val overlay =
       tableOverlay(
@@ -99,11 +175,12 @@ class EditorTableCellSelectionGeometryTest {
         TableOverlayRow(index = 0, height = 40f, position = 40f),
         TableOverlayRow(index = 1, height = 40f, position = 80f),
       ),
+    rowCount: Int = 2,
   ): TableOverlay =
     TableOverlay(
       tableId = "table",
       pageIdx = 0,
-      bounds = Rect(x = 10f, y = 20f, width = 100f, height = 80f),
+      bounds = Rect(x = 10f, y = 20f, width = 100f, height = rows.lastOrNull()?.position ?: 0f),
       borderStyle = TableBorderStyle.Solid,
       align = Alignment.Left,
       proportion = 1f,
@@ -116,7 +193,7 @@ class EditorTableCellSelectionGeometryTest {
           TableOverlayColumn(index = 0, widthAsPx = 50f, position = 50f),
           TableOverlayColumn(index = 1, widthAsPx = 50f, position = 100f),
         ),
-      rowCount = 2,
+      rowCount = rowCount,
       isLastRowFragment = true,
       isFocused = isFocused,
       focusedRowIndex = focusedRowIndex,

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/overlay/EditorTableAxisSelectionOverlayTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/overlay/EditorTableAxisSelectionOverlayTest.kt
@@ -83,6 +83,35 @@ class EditorTableAxisSelectionOverlayTest {
   }
 
   @Test
+  fun `later row in complete continuous overlay resolves one row and one column selector`() {
+    val overlay =
+      tableOverlay(
+        isFocused = true,
+        focusedRowIndex = 2,
+        focusedColIndex = 0,
+        rows =
+          listOf(
+            TableOverlayRow(index = 0, height = 40f, position = 40f),
+            TableOverlayRow(index = 1, height = 40f, position = 80f),
+            TableOverlayRow(index = 2, height = 40f, position = 120f),
+          ),
+        rowCount = 3,
+      )
+
+    val selectors = resolveTableAxisSelectors(overlay = overlay, selectionCollapsed = true)
+
+    assertEquals(
+      listOf(Axis.Horizontal to 2, Axis.Vertical to 0),
+      selectors.map { it.axis to it.index },
+    )
+    assertEquals(listOf(3, 2), selectors.map { it.count })
+    assertEquals(
+      listOf(Offset(x = 10f, y = 120f), Offset(x = 35f, y = 20f)),
+      selectors.map { it.center },
+    )
+  }
+
+  @Test
   fun `column selector overlaps table top edge like legacy handle`() {
     val rect =
       resolveSelectorButtonRect(
@@ -124,11 +153,12 @@ class EditorTableAxisSelectionOverlayTest {
         TableOverlayRow(index = 0, height = 40f, position = 40f),
         TableOverlayRow(index = 1, height = 40f, position = 80f),
       ),
+    rowCount: Int = 2,
   ): TableOverlay =
     TableOverlay(
       tableId = "table",
       pageIdx = 0,
-      bounds = FfiRect(x = 10f, y = 20f, width = 100f, height = 80f),
+      bounds = FfiRect(x = 10f, y = 20f, width = 100f, height = rows.lastOrNull()?.position ?: 0f),
       borderStyle = TableBorderStyle.Solid,
       align = Alignment.Left,
       proportion = 1f,
@@ -141,7 +171,7 @@ class EditorTableAxisSelectionOverlayTest {
           TableOverlayColumn(index = 0, widthAsPx = 50f, position = 50f),
           TableOverlayColumn(index = 1, widthAsPx = 50f, position = 100f),
         ),
-      rowCount = 2,
+      rowCount = rowCount,
       isLastRowFragment = true,
       isFocused = isFocused,
       focusedRowIndex = focusedRowIndex,

--- a/apps/website/src/lib/editor-ffi/components/DocumentOverlayLayer.svelte
+++ b/apps/website/src/lib/editor-ffi/components/DocumentOverlayLayer.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  import { css } from '@typie/styled-system/css';
+  import { getEditorContext } from '../editor.svelte';
+  import TableOverlay from './TableOverlay.svelte';
+
+  type PageAnchor = {
+    top: number;
+    width: number;
+    height: number;
+  };
+
+  const ctx = getEditorContext();
+  const scaleFactor = $derived(ctx.editor?.scaleFactor ?? 1);
+  const pageAnchors = $derived.by(() => {
+    const anchors: PageAnchor[] = [];
+    let top = 0;
+    for (const pageSize of ctx.editor?.pageSizes ?? []) {
+      const width = roundToScale(pageSize.width, scaleFactor);
+      const height = roundToScale(pageSize.height, scaleFactor);
+      anchors.push({ top, width, height });
+      top += height;
+    }
+    return anchors;
+  });
+
+  function roundToScale(value: number, scale: number): number {
+    return Math.round(value * scale) / scale;
+  }
+</script>
+
+{#if ctx.editor?.rootAttrs?.layout_mode.type === 'continuous'}
+  <div
+    class={css({
+      position: 'absolute',
+      inset: '0',
+      pointerEvents: 'none',
+    })}
+  >
+    {#each ctx.editor.tableOverlays as overlay (overlay.table_id)}
+      {@const anchor = pageAnchors[overlay.page_idx]}
+      {#if anchor}
+        <div
+          style:top={`${anchor.top}px`}
+          style:width={`${anchor.width}px`}
+          style:height={`${anchor.height}px`}
+          class={css({ position: 'absolute', left: '0', right: '0', marginX: 'auto', overflow: 'visible', pointerEvents: 'none' })}
+        >
+          <TableOverlay {overlay} readOnly={ctx.editor.readOnly} />
+        </div>
+      {/if}
+    {/each}
+  </div>
+{/if}

--- a/apps/website/src/lib/editor-ffi/components/Page.svelte
+++ b/apps/website/src/lib/editor-ffi/components/Page.svelte
@@ -55,7 +55,7 @@
   });
   const tableOverlays = $derived.by(() => {
     void ctx.editor?.tickRevision;
-    return overlaysVisible && ctx.editor ? ctx.editor.pageTableOverlays(page) : [];
+    return isPaginated && overlaysVisible && ctx.editor ? ctx.editor.pageTableOverlays(page) : [];
   });
   const linkRects = $derived.by(() => {
     void ctx.editor?.tickRevision;

--- a/apps/website/src/lib/editor-ffi/components/View.svelte
+++ b/apps/website/src/lib/editor-ffi/components/View.svelte
@@ -30,6 +30,7 @@
   import { touchPanLock } from '../touch-pan-lock';
   import Caret from './Caret.svelte';
   import ContextMenu from './ContextMenu.svelte';
+  import DocumentOverlayLayer from './DocumentOverlayLayer.svelte';
   import Input from './Input.svelte';
   import LineHighlight from './LineHighlight.svelte';
   import LinkTooltip from './LinkTooltip.svelte';
@@ -317,6 +318,8 @@
           {#each ctx.editor.pageSizes as { width, height }, i (i)}
             <Page backingHeight={ctx.editor.pageBackingSizes[i]?.height ?? height} {height} page={i} {width} />
           {/each}
+
+          <DocumentOverlayLayer />
 
           <Caret />
 

--- a/crates/editor-view/src/table_overlay.rs
+++ b/crates/editor-view/src/table_overlay.rs
@@ -5,7 +5,10 @@ use editor_model::{Alignment, DocView, Modifier, ModifierType, Node, NodeType, T
 use editor_state::ResolvedSelection;
 use serde::{Deserialize, Serialize};
 
+use crate::page::LayoutPage;
 use crate::page_fragment::{PageFragmentBox, PageFragmentNode, PageFragmentTree};
+use crate::paginate::types::{LayoutBox, LayoutContent, LayoutNode};
+use crate::query::layout_index::LayoutIndex;
 
 const TABLE_BORDER_WIDTH: f32 = 1.0;
 const MIN_CELL_WIDTH: f32 = 40.0;
@@ -111,9 +114,11 @@ fn collect_table_overlays(
         Some(Node::Table(table_node)) => {
             if let Some(overlay) = build_table_overlay(
                 node.rect,
-                fragment_box,
+                fragment_box.node,
                 &table_node,
+                visible_rows(fragment_box, view),
                 page_idx,
+                0.0,
                 view,
                 selection,
                 content_width,
@@ -131,16 +136,16 @@ fn collect_table_overlays(
 
 fn build_table_overlay(
     table_rect: Rect,
-    table_box: &PageFragmentBox,
+    table_id: Dot,
     table_node: &editor_model::TableNode,
+    mut rows: Vec<OverlayRow>,
     page_idx: usize,
+    page_y_start: f32,
     view: &DocView,
     selection: Option<&ResolvedSelection<'_>>,
     content_width: f32,
 ) -> Option<TableOverlay> {
-    let table_id = table_box.node;
     let doc_node = view.node(table_id)?;
-    let mut rows = visible_rows(table_box, view);
     rows.sort_by_key(|row| row.index);
     for row in &mut rows {
         row.cells.sort_by_key(|cell| cell.index);
@@ -158,7 +163,7 @@ fn build_table_overlay(
 
     let bounds = Rect::from_xywh(
         table_rect.x,
-        fragment_top,
+        fragment_top - page_y_start,
         table_rect.width,
         fragment_bottom - fragment_top,
     );
@@ -315,6 +320,98 @@ fn build_table_overlay(
     })
 }
 
+pub(crate) fn continuous_table_overlays(
+    layout_index: &LayoutIndex,
+    view: &DocView,
+    selection: Option<&ResolvedSelection<'_>>,
+    content_width: f32,
+) -> Vec<TableOverlay> {
+    let mut overlays = Vec::new();
+    let mut page_cursor = 0;
+    collect_continuous_table_overlays(
+        &layout_index.tree().root,
+        layout_index,
+        view,
+        selection,
+        content_width,
+        &mut page_cursor,
+        &mut overlays,
+    );
+    overlays
+}
+
+fn continuous_page_anchor(
+    pages: &[LayoutPage],
+    page_cursor: &mut usize,
+    y: f32,
+) -> Option<(usize, f32)> {
+    while let Some(page) = pages.get(*page_cursor) {
+        if y < page.y_start {
+            return None;
+        }
+        if y <= page.y_end {
+            return Some((*page_cursor, page.y_start));
+        }
+        *page_cursor += 1;
+    }
+    None
+}
+
+fn collect_continuous_table_overlays(
+    node: &LayoutNode,
+    layout_index: &LayoutIndex,
+    view: &DocView,
+    selection: Option<&ResolvedSelection<'_>>,
+    content_width: f32,
+    page_cursor: &mut usize,
+    overlays: &mut Vec<TableOverlay>,
+) {
+    let LayoutContent::Box(layout_box) = &node.content else {
+        return;
+    };
+
+    let node_view = view.node(layout_box.node);
+    match node_view.map(|node_view| node_view.node()) {
+        Some(Node::Table(table_node)) => {
+            let rows = layout_rows(layout_box, view);
+            let Some(fragment_top) = rows.first().map(|row| row.rect.y) else {
+                return;
+            };
+            let Some((page_idx, page_y_start)) =
+                continuous_page_anchor(layout_index.pages(), page_cursor, fragment_top)
+            else {
+                return;
+            };
+            if let Some(overlay) = build_table_overlay(
+                node.rect,
+                layout_box.node,
+                &table_node,
+                rows,
+                page_idx,
+                page_y_start,
+                view,
+                selection,
+                content_width,
+            ) {
+                overlays.push(overlay);
+            }
+        }
+        _ => {
+            for child in &layout_box.children {
+                collect_continuous_table_overlays(
+                    child,
+                    layout_index,
+                    view,
+                    selection,
+                    content_width,
+                    page_cursor,
+                    overlays,
+                );
+            }
+        }
+    }
+}
+
 fn min_table_width(col_count: usize) -> f32 {
     if col_count == 0 {
         return TABLE_BORDER_WIDTH;
@@ -338,6 +435,43 @@ fn visible_rows(table_box: &PageFragmentBox, view: &DocView) -> Vec<OverlayRow> 
                 .iter()
                 .filter_map(|cell_node| {
                     let cell_box = cell_node.as_box()?;
+                    let cell_view = view.node(cell_box.node)?;
+                    (cell_view.node_type() == NodeType::TableCell).then(|| OverlayCell {
+                        index: cell_view.index().unwrap_or(0),
+                        rect: cell_node.rect,
+                    })
+                })
+                .collect();
+
+            Some(OverlayRow {
+                index: row_view.index().unwrap_or(0),
+                rect: row_node.rect,
+                cells,
+            })
+        })
+        .collect()
+}
+
+fn layout_rows(table_box: &LayoutBox, view: &DocView) -> Vec<OverlayRow> {
+    table_box
+        .children
+        .iter()
+        .filter_map(|row_node| {
+            let LayoutContent::Box(row_box) = &row_node.content else {
+                return None;
+            };
+            let row_view = view.node(row_box.node)?;
+            if row_view.node_type() != NodeType::TableRow {
+                return None;
+            }
+
+            let cells = row_box
+                .children
+                .iter()
+                .filter_map(|cell_node| {
+                    let LayoutContent::Box(cell_box) = &cell_node.content else {
+                        return None;
+                    };
                     let cell_view = view.node(cell_box.node)?;
                     (cell_view.node_type() == NodeType::TableCell).then(|| OverlayCell {
                         index: cell_view.index().unwrap_or(0),
@@ -412,6 +546,7 @@ mod tests {
     use crate::page::LayoutPage;
     use crate::page_fragment::build_page_fragment_tree;
     use crate::paginate::types::{LayoutBox, LayoutContent, LayoutLine, LayoutNode, LayoutTree};
+    use crate::query::layout_index::LayoutIndex;
     use crate::style::{Alignment as StyleAlignment, BorderMode, BoxStyle, Direction};
 
     use super::*;
@@ -658,6 +793,117 @@ mod tests {
         (pd, root, table, row0, cell00, cell01, row1, cell10, cell11)
     }
 
+    fn two_table_doc() -> (ProjectedDoc, Dot, Dot, Dot, Dot, Dot, Dot, Dot) {
+        let root = Dot::ROOT;
+        let table0 = elem(3, 1);
+        let row0 = elem(3, 2);
+        let cell0 = elem(3, 3);
+        let para0 = elem(3, 4);
+        let table1 = elem(3, 5);
+        let row1 = elem(3, 6);
+        let cell1 = elem(3, 7);
+        let para1 = elem(3, 8);
+        let items = vec![
+            (
+                table0,
+                SeqItem::Block {
+                    node_type: NodeType::Table,
+                    parents: vec![root],
+                    attrs: vec![],
+                },
+            ),
+            (
+                row0,
+                SeqItem::Block {
+                    node_type: NodeType::TableRow,
+                    parents: vec![root, table0],
+                    attrs: vec![],
+                },
+            ),
+            (
+                cell0,
+                SeqItem::Block {
+                    node_type: NodeType::TableCell,
+                    parents: vec![root, table0, row0],
+                    attrs: vec![],
+                },
+            ),
+            (
+                para0,
+                SeqItem::Block {
+                    node_type: NodeType::Paragraph,
+                    parents: vec![root, table0, row0, cell0],
+                    attrs: vec![],
+                },
+            ),
+            (
+                table1,
+                SeqItem::Block {
+                    node_type: NodeType::Table,
+                    parents: vec![root],
+                    attrs: vec![],
+                },
+            ),
+            (
+                row1,
+                SeqItem::Block {
+                    node_type: NodeType::TableRow,
+                    parents: vec![root, table1],
+                    attrs: vec![],
+                },
+            ),
+            (
+                cell1,
+                SeqItem::Block {
+                    node_type: NodeType::TableCell,
+                    parents: vec![root, table1, row1],
+                    attrs: vec![],
+                },
+            ),
+            (
+                para1,
+                SeqItem::Block {
+                    node_type: NodeType::Paragraph,
+                    parents: vec![root, table1, row1, cell1],
+                    attrs: vec![],
+                },
+            ),
+        ];
+        let mut logs = doc_logs(&items);
+        logs.node_attrs = NodeAttrLog::new()
+            .apply(
+                Dot::ROOT,
+                NodeAttrOp {
+                    target: table0,
+                    attr: NodeAttr::Table {
+                        attr: TableNodeAttr::Proportion(100),
+                    },
+                },
+            )
+            .unwrap()
+            .apply(
+                elem(4, 1),
+                NodeAttrOp {
+                    target: table1,
+                    attr: NodeAttr::Table {
+                        attr: TableNodeAttr::Proportion(100),
+                    },
+                },
+            )
+            .unwrap();
+
+        (
+            project_document(&logs).unwrap(),
+            table0,
+            row0,
+            cell0,
+            para0,
+            table1,
+            row1,
+            cell1,
+        )
+    }
+
     fn resolved_sel<'a>(
         view: &'a DocView<'a>,
         anchor_node: Dot,
@@ -796,6 +1042,222 @@ mod tests {
 
         assert!(!ov.is_focused);
         assert_eq!(ov.cell_selection, None);
+    }
+
+    #[test]
+    fn paginated_table_overlay_keeps_page_fragments() {
+        let (pd, root, table, row0, cell00, cell01, row1, cell10, cell11) = two_by_two_table_doc();
+        let view = DocView::new(&pd);
+        let tree = table_layout_tree(
+            table,
+            row0,
+            cell00,
+            cell01,
+            row1,
+            cell10,
+            cell11,
+            elem(1, 8),
+            elem(1, 9),
+            elem(1, 10),
+            elem(1, 11),
+            root,
+        );
+
+        let pages = [page(0.0, 40.0), page(40.0, 40.0)];
+        let overlays = pages
+            .iter()
+            .enumerate()
+            .flat_map(|(page_idx, page)| {
+                let fragment = build_page_fragment_tree(&tree, page_idx, page);
+                page_table_overlays(&fragment, &view, None, 600.0)
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(overlays.len(), 2);
+        assert_eq!(overlays[0].page_idx, 0);
+        assert_eq!(
+            overlays[0]
+                .rows
+                .iter()
+                .map(|row| row.index)
+                .collect::<Vec<_>>(),
+            [0]
+        );
+        assert!(!overlays[0].is_last_row_fragment);
+        assert_eq!(overlays[1].page_idx, 1);
+        assert_eq!(
+            overlays[1]
+                .rows
+                .iter()
+                .map(|row| row.index)
+                .collect::<Vec<_>>(),
+            [1]
+        );
+        assert!(overlays[1].is_last_row_fragment);
+    }
+
+    #[test]
+    fn continuous_page_cursor_never_rescans_previous_pages() {
+        let pages = [page(0.0, 40.0), page(40.0, 40.0), page(80.0, 40.0)];
+        let mut page_cursor = 0;
+
+        assert_eq!(
+            continuous_page_anchor(&pages, &mut page_cursor, 5.0),
+            Some((0, 0.0))
+        );
+        assert_eq!(
+            continuous_page_anchor(&pages, &mut page_cursor, 45.0),
+            Some((1, 40.0))
+        );
+        assert_eq!(
+            continuous_page_anchor(&pages, &mut page_cursor, 85.0),
+            Some((2, 80.0))
+        );
+        assert_eq!(page_cursor, 2);
+        assert_eq!(continuous_page_anchor(&pages, &mut page_cursor, 5.0), None);
+        assert_eq!(page_cursor, 2);
+    }
+
+    #[test]
+    fn continuous_table_overlay_spanning_pages_is_single_complete_overlay() {
+        let (pd, root, table, row0, cell00, cell01, row1, cell10, cell11) = two_by_two_table_doc();
+        let view = DocView::new(&pd);
+        let tree = table_layout_tree(
+            table,
+            row0,
+            cell00,
+            cell01,
+            row1,
+            cell10,
+            cell11,
+            elem(1, 8),
+            elem(1, 9),
+            elem(1, 10),
+            elem(1, 11),
+            root,
+        );
+        let index = LayoutIndex::new(tree, &[page(0.0, 40.0), page(40.0, 40.0)]);
+
+        let overlays = continuous_table_overlays(&index, &view, None, 600.0);
+
+        assert_eq!(overlays.len(), 1);
+        let overlay = &overlays[0];
+        assert_eq!(overlay.table_id, table);
+        assert_eq!(overlay.page_idx, 0);
+        assert_eq!(
+            overlay.rows.iter().map(|row| row.index).collect::<Vec<_>>(),
+            [0, 1]
+        );
+        assert_eq!(overlay.bounds.height, 80.0);
+        assert!(overlay.is_last_row_fragment);
+    }
+
+    #[test]
+    fn continuous_table_overlay_preserves_later_row_focus_and_cross_row_selection() {
+        let (pd, root, table, row0, cell00, cell01, row1, cell10, cell11) = two_by_two_table_doc();
+        let view = DocView::new(&pd);
+        let para00 = elem(1, 8);
+        let para01 = elem(1, 9);
+        let para10 = elem(1, 10);
+        let para11 = elem(1, 11);
+        let tree = table_layout_tree(
+            table, row0, cell00, cell01, row1, cell10, cell11, para00, para01, para10, para11, root,
+        );
+        let index = LayoutIndex::new(tree, &[page(0.0, 40.0), page(40.0, 40.0)]);
+        let later_cell_focus = resolved_sel(&view, para11, 0, para11, 0);
+
+        let overlays = continuous_table_overlays(&index, &view, Some(&later_cell_focus), 600.0);
+
+        assert_eq!(overlays.len(), 1);
+        let overlay = &overlays[0];
+        assert!(overlay.is_focused);
+        assert_eq!(overlay.focused_row_index, Some(1));
+        assert_eq!(overlay.focused_col_index, Some(1));
+
+        let cross_row_selection = resolved_sel(&view, row1, 2, row0, 0);
+        let overlays = continuous_table_overlays(&index, &view, Some(&cross_row_selection), 600.0);
+
+        assert_eq!(overlays.len(), 1);
+        assert_eq!(
+            overlays[0].cell_selection,
+            Some(TableOverlayCellSelection {
+                anchor_row: 1,
+                anchor_col: 1,
+                head_row: 0,
+                head_col: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn continuous_table_overlays_follow_document_order_without_duplicates() {
+        let (pd, table0, row0, cell0, para0, table1, row1, cell1) = two_table_doc();
+        let view = DocView::new(&pd);
+        let table0_node = box_node(
+            table0,
+            0.0,
+            0.0,
+            600.0,
+            40.0,
+            vec![box_node(
+                row0,
+                0.0,
+                0.0,
+                600.0,
+                40.0,
+                vec![box_node(
+                    cell0,
+                    0.0,
+                    0.0,
+                    600.0,
+                    40.0,
+                    vec![line_node(para0, 0.0, 0.0, 600.0, 40.0)],
+                )],
+            )],
+        );
+        let table1_node = box_node(
+            table1,
+            0.0,
+            40.0,
+            600.0,
+            40.0,
+            vec![box_node(
+                row1,
+                0.0,
+                40.0,
+                600.0,
+                40.0,
+                vec![box_node(
+                    cell1,
+                    0.0,
+                    40.0,
+                    600.0,
+                    40.0,
+                    vec![line_node(elem(3, 8), 0.0, 40.0, 600.0, 40.0)],
+                )],
+            )],
+        );
+        let tree = LayoutTree {
+            root: box_node(
+                Dot::ROOT,
+                0.0,
+                0.0,
+                600.0,
+                80.0,
+                vec![table0_node, table1_node],
+            ),
+        };
+        let index = LayoutIndex::new(tree, &[page(0.0, 40.0), page(40.0, 40.0)]);
+
+        let overlays = continuous_table_overlays(&index, &view, None, 600.0);
+
+        assert_eq!(
+            overlays
+                .iter()
+                .map(|overlay| overlay.table_id)
+                .collect::<Vec<_>>(),
+            [table0, table1]
+        );
     }
 
     #[test]

--- a/crates/editor-view/src/view.rs
+++ b/crates/editor-view/src/view.rs
@@ -690,12 +690,25 @@ impl View {
         state: &State,
         selection: Option<&ResolvedSelection>,
     ) -> Vec<crate::table_overlay::TableOverlay> {
-        let page_count = self.layout.as_ref().map(|r| r.pages.len()).unwrap_or(0);
-        let mut overlays = Vec::new();
-        for page_idx in 0..page_count {
-            overlays.extend(self.page_table_overlays(state, page_idx, selection));
+        let Some(result) = self.layout.as_ref() else {
+            return Vec::new();
+        };
+
+        match Self::doc_layout_mode(state) {
+            LayoutMode::Continuous { .. } => crate::table_overlay::continuous_table_overlays(
+                &result.layout_index,
+                &state.view(),
+                selection,
+                result.content_width,
+            ),
+            LayoutMode::Paginated { .. } => {
+                let mut overlays = Vec::new();
+                for page_idx in 0..result.pages.len() {
+                    overlays.extend(self.page_table_overlays(state, page_idx, selection));
+                }
+                overlays
+            }
         }
-        overlays
     }
 
     pub fn viewport(&self) -> &Viewport {


### PR DESCRIPTION
- 테이블 오버레이가 continuous 모드에서 page별로 분리되는 문제가 있었음
- editor engine의 table overlay query를 레이아웃 모드별로 분리
    - continuous에서는 retained full `LayoutTree`를 순회해 table마다 하나의 완전한 overlay를 생성
    - 전체 row, bounds, focus와 cell selection geometry를 하나의 overlay에 포함
    - document-order page cursor를 사용해 이전 page를 반복 탐색하지 않고 선형 시간으로 anchor page를 결정
    - paginated에서는 기존처럼 page fragment별 overlay를 유지
- 웹 continuous table overlay를 개별 `Page`가 아닌 document-level layer에서 렌더링
    - `page_idx`는 좌표 anchor로만 사용하고 DOM lifecycle은 table 단위로 소유
    - `table_id`를 key로 사용해 reflow로 anchor page가 바뀌어도 resize, menu와 pointer interaction 상태를 유지
    - paginated에서는 기존 visible-page query와 page-local overlay 렌더링을 유지
- 앱의 기존 screen-level overlay host는 유지
    - continuous에서는 table bounds와 pointer를 같은 interaction 좌표계로 projection해 이후 canvas의 point도 같은 table 내부로 판정
    - paginated에서는 기존 page 일치 조건과 page-local bounds 검사를 유지
- continuous split table, 여러 table의 document order, 이후 canvas의 focus·selection, paginated fragment 보존과 cross-canvas gesture handoff 회귀 테스트 추가