### PR TITLE
앱 column resize handle의 조기 tap 처리 디버그

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorTableColumnResizeGesture.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorTableColumnResizeGesture.kt
@@ -51,6 +51,8 @@ internal class EditorTableColumnResizeGesture {
     downPosition = position
     currentPosition = position
     dragging = false
+    context.effects.cancelTapDispatch()
+    context.effects.cancelLongPressDispatch()
     context.semantics.tableColumnResize.press(editor = context.editor, placement = placement)
     context.uiState.contextMenu.hide()
     return true

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
@@ -2501,6 +2501,47 @@ class EditorInteractionControllerTest {
     }
 
   @Test
+  fun `column resize handle tap waits for pointer up`() =
+    runTest(StandardTestDispatcher()) {
+      val selection =
+        Selection(
+          anchor = Position("cell-text", 0, Affinity.Downstream),
+          head = Position("cell-text", 0, Affinity.Downstream),
+        )
+      val fake =
+        FakeFfiEditor(
+          selectionProvider = { selection },
+          tableOverlaysProvider = {
+            listOf(tableOverlay(isFocused = true, focusedRowIndex = 0, focusedColIndex = 0))
+          },
+        )
+      val editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
+      editor.sync {}
+      val host = TestHost(this)
+      val controller =
+        EditorInteractionController(
+          editorProvider = { editor },
+          effects = host,
+          geometry = host,
+          uiStateProvider = { host.uiState },
+        )
+      val down = Offset(60f, 90f)
+
+      assertTrue(controller.onPointerDown(pointerId = 1L, position = down, nowMillis = 0L))
+      assertNull(host.scheduledTapDispatchAtMillis)
+      assertNull(host.scheduledLongPressDispatchAtMillis)
+      assertEquals(emptyList(), fake.enqueued.filterIsInstance<Message.Selection>())
+
+      assertTrue(controller.onPointerUp(pointerId = 1L, position = down, nowMillis = 300L))
+      runCurrent()
+
+      assertEquals(
+        listOf(Message.Selection(SelectionOp.SetAt(page = 0, x = 60f, y = 90f))),
+        fake.enqueued.filterIsInstance<Message.Selection>(),
+      )
+    }
+
+  @Test
   fun `column resize drag locks scroll only while active`() =
     runTest(StandardTestDispatcher()) {
       val selection =


### PR DESCRIPTION
- column resize가 PointerDown을 수락하면 예약된 tap과 long-press
dispatch를 취소
- 드래그하지 않은 경우 PointerUp의 일반 editor tap fallback은 유지
- 셀 셀렉션 핸들과 동일하게 수정함