### PR TITLE
앱 - 내용이 큰 Dialog를 적절히 처리

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/EmbedToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/EmbedToolbar.kt
@@ -1,21 +1,14 @@
 package co.typie.screen.editor.editor.toolbar.contextual
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
@@ -48,13 +41,13 @@ import co.typie.ui.component.TextField
 import co.typie.ui.component.dialog.Dialog
 import co.typie.ui.component.dialog.DialogActionButton
 import co.typie.ui.component.dialog.DialogActionDivider
+import co.typie.ui.component.dialog.DialogLayout
 import co.typie.ui.component.dialog.DialogResult
 import co.typie.ui.component.dialog.DialogScope
 import co.typie.ui.component.dialog.LocalDialog
 import co.typie.ui.component.dialog.dismiss
 import co.typie.ui.component.dialog.resolve
 import co.typie.ui.component.toast.LocalToast
-import co.typie.ui.theme.AppShapes
 import co.typie.ui.theme.AppTheme
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
@@ -180,37 +173,38 @@ private fun EmbedUrlDialog() {
     }
   }
 
-  Column(
-    modifier =
-      Modifier.widthIn(max = 340.dp)
-        .clip(AppShapes.rounded(AppShapes.lg))
-        .background(AppTheme.colors.surfaceDefault)
-  ) {
-    Column(Modifier.padding(start = 20.dp, end = 20.dp, top = 24.dp, bottom = 20.dp)) {
-      Text("임베드 삽입", style = AppTheme.typography.title)
-      Spacer(Modifier.height(16.dp))
-      TextField(
-        value = url,
-        onValueChange = { url = it },
-        label = "URL",
-        placeholder = "https://...",
-        labelPosition = LabelPosition.None,
-        autoFocus = true,
-        keyboardType = KeyboardType.Uri,
-        imeAction = ImeAction.Done,
-        onImeAction = ::submit,
-        modifier = Modifier.fillMaxWidth(),
+  DialogLayout(
+    header = {
+      Text(
+        "임베드 삽입",
+        modifier = Modifier.fillMaxWidth().padding(start = 20.dp, end = 20.dp, top = 24.dp),
+        style = AppTheme.typography.title,
       )
-    }
-
-    Box(Modifier.fillMaxWidth().height(1.dp).background(AppTheme.colors.borderHairline))
-
-    Row(Modifier.fillMaxWidth()) {
+    },
+    body = {
+      Column(
+        Modifier.fillMaxWidth().padding(start = 20.dp, end = 20.dp, top = 16.dp, bottom = 20.dp)
+      ) {
+        TextField(
+          value = url,
+          onValueChange = { url = it },
+          label = "URL",
+          placeholder = "https://...",
+          labelPosition = LabelPosition.None,
+          autoFocus = true,
+          keyboardType = KeyboardType.Uri,
+          imeAction = ImeAction.Done,
+          onImeAction = ::submit,
+          modifier = Modifier.fillMaxWidth(),
+        )
+      }
+    },
+    actions = {
       DialogActionButton(text = "취소") { dismiss() }
       DialogActionDivider()
       DialogActionButton(text = "삽입") { submit() }
-    }
-  }
+    },
+  )
 }
 
 private fun normalizedEmbedUrl(input: String): String {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/TextOptionsToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/TextOptionsToolbar.kt
@@ -16,12 +16,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.relocation.BringIntoViewRequester
 import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.foundation.rememberScrollState
@@ -81,12 +79,12 @@ import co.typie.ui.component.Text
 import co.typie.ui.component.TextField
 import co.typie.ui.component.dialog.DialogActionButton
 import co.typie.ui.component.dialog.DialogActionDivider
+import co.typie.ui.component.dialog.DialogLayout
 import co.typie.ui.component.dialog.DialogResult
 import co.typie.ui.component.dialog.DialogScope
 import co.typie.ui.component.dialog.LocalDialog
 import co.typie.ui.component.dialog.dismiss
 import co.typie.ui.component.dialog.resolve
-import co.typie.ui.theme.AppShapes
 import co.typie.ui.theme.AppTheme
 import kotlin.math.roundToInt
 
@@ -509,43 +507,44 @@ private fun FontSizeInputDialog(initialValue: Int) {
     parsedValue?.let { resolve(it) }
   }
 
-  Column(
-    modifier =
-      Modifier.widthIn(max = 340.dp)
-        .clip(AppShapes.rounded(AppShapes.lg))
-        .background(AppTheme.colors.surfaceDefault)
-  ) {
-    Column(Modifier.padding(start = 20.dp, end = 20.dp, top = 24.dp, bottom = 20.dp)) {
-      Text("폰트 크기", style = AppTheme.typography.title)
-      Spacer(Modifier.height(16.dp))
-      TextField(
-        value = value,
-        onValueChange = { value = it },
-        label = "크기",
-        labelPosition = LabelPosition.None,
-        autoFocus = true,
-        placeholder =
-          "${formatToolbarPointValue(EditorValues.minFontSize)}-" +
-            formatToolbarPointValue(EditorValues.maxFontSize),
-        keyboardType = KeyboardType.Decimal,
-        imeAction = ImeAction.Done,
-        onImeAction = ::submit,
-        error = if (hasError) "1-200 사이 숫자를 입력하세요" else null,
-        suffix = {
-          Text("pt", style = AppTheme.typography.caption, color = AppTheme.colors.textMuted)
-        },
-        modifier = Modifier.fillMaxWidth(),
+  DialogLayout(
+    header = {
+      Text(
+        "폰트 크기",
+        modifier = Modifier.fillMaxWidth().padding(start = 20.dp, end = 20.dp, top = 24.dp),
+        style = AppTheme.typography.title,
       )
-    }
-
-    Box(Modifier.fillMaxWidth().height(1.dp).background(AppTheme.colors.borderHairline))
-
-    Row(Modifier.fillMaxWidth()) {
+    },
+    body = {
+      Column(
+        Modifier.fillMaxWidth().padding(start = 20.dp, end = 20.dp, top = 16.dp, bottom = 20.dp)
+      ) {
+        TextField(
+          value = value,
+          onValueChange = { value = it },
+          label = "크기",
+          labelPosition = LabelPosition.None,
+          autoFocus = true,
+          placeholder =
+            "${formatToolbarPointValue(EditorValues.minFontSize)}-" +
+              formatToolbarPointValue(EditorValues.maxFontSize),
+          keyboardType = KeyboardType.Decimal,
+          imeAction = ImeAction.Done,
+          onImeAction = ::submit,
+          error = if (hasError) "1-200 사이 숫자를 입력하세요" else null,
+          suffix = {
+            Text("pt", style = AppTheme.typography.caption, color = AppTheme.colors.textMuted)
+          },
+          modifier = Modifier.fillMaxWidth(),
+        )
+      }
+    },
+    actions = {
       DialogActionButton(text = "취소") { dismiss() }
       DialogActionDivider()
       DialogActionButton(text = "확인") { submit() }
-    }
-  }
+    },
+  )
 }
 
 private fun sendSet(sendMessages: (List<Message>) -> Unit, modifier: EditorModifier) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/TextToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/TextToolbar.kt
@@ -1,15 +1,9 @@
 package co.typie.screen.editor.editor.toolbar.contextual
 
 import androidx.compose.foundation.ScrollState
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -18,7 +12,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
@@ -51,12 +44,12 @@ import co.typie.ui.component.TextField
 import co.typie.ui.component.dialog.Dialog
 import co.typie.ui.component.dialog.DialogActionButton
 import co.typie.ui.component.dialog.DialogActionDivider
+import co.typie.ui.component.dialog.DialogLayout
 import co.typie.ui.component.dialog.DialogResult
 import co.typie.ui.component.dialog.DialogScope
 import co.typie.ui.component.dialog.LocalDialog
 import co.typie.ui.component.dialog.dismiss
 import co.typie.ui.component.dialog.resolve
-import co.typie.ui.theme.AppShapes
 import co.typie.ui.theme.AppTheme
 
 @Composable
@@ -342,32 +335,33 @@ private fun LinkInputDialog(existingHref: String?) {
     }
   }
 
-  Column(
-    modifier =
-      Modifier.widthIn(max = 340.dp)
-        .clip(AppShapes.rounded(AppShapes.lg))
-        .background(AppTheme.colors.surfaceDefault)
-  ) {
-    Column(Modifier.padding(start = 20.dp, end = 20.dp, top = 24.dp, bottom = 20.dp)) {
-      Text("링크", style = AppTheme.typography.title)
-      Spacer(Modifier.height(16.dp))
-      TextField(
-        value = value,
-        onValueChange = { value = it },
-        label = "URL",
-        labelPosition = LabelPosition.None,
-        autoFocus = true,
-        placeholder = "https://...",
-        keyboardType = KeyboardType.Uri,
-        imeAction = ImeAction.Done,
-        onImeAction = ::submit,
-        modifier = Modifier.fillMaxWidth(),
+  DialogLayout(
+    header = {
+      Text(
+        "링크",
+        modifier = Modifier.fillMaxWidth().padding(start = 20.dp, end = 20.dp, top = 24.dp),
+        style = AppTheme.typography.title,
       )
-    }
-
-    Box(Modifier.fillMaxWidth().height(1.dp).background(AppTheme.colors.borderHairline))
-
-    Row(Modifier.fillMaxWidth()) {
+    },
+    body = {
+      Column(
+        Modifier.fillMaxWidth().padding(start = 20.dp, end = 20.dp, top = 16.dp, bottom = 20.dp)
+      ) {
+        TextField(
+          value = value,
+          onValueChange = { value = it },
+          label = "URL",
+          labelPosition = LabelPosition.None,
+          autoFocus = true,
+          placeholder = "https://...",
+          keyboardType = KeyboardType.Uri,
+          imeAction = ImeAction.Done,
+          onImeAction = ::submit,
+          modifier = Modifier.fillMaxWidth(),
+        )
+      }
+    },
+    actions = {
       DialogActionButton(text = "취소") { dismiss() }
       if (existingHref != null) {
         DialogActionDivider()
@@ -375,8 +369,8 @@ private fun LinkInputDialog(existingHref: String?) {
       }
       DialogActionDivider()
       DialogActionButton(text = if (existingHref != null) "수정" else "삽입") { submit() }
-    }
-  }
+    },
+  )
 }
 
 @Composable
@@ -390,32 +384,33 @@ private fun RubyInputDialog(existingText: String?) {
     }
   }
 
-  Column(
-    modifier =
-      Modifier.widthIn(max = 340.dp)
-        .clip(AppShapes.rounded(AppShapes.lg))
-        .background(AppTheme.colors.surfaceDefault)
-  ) {
-    Column(Modifier.padding(start = 20.dp, end = 20.dp, top = 24.dp, bottom = 20.dp)) {
-      Text("루비", style = AppTheme.typography.title)
-      Spacer(Modifier.height(16.dp))
-      TextField(
-        value = value,
-        onValueChange = { value = it },
-        label = "루비",
-        labelPosition = LabelPosition.None,
-        autoFocus = true,
-        placeholder = "텍스트 위에 들어갈 문구",
-        keyboardType = KeyboardType.Text,
-        imeAction = ImeAction.Done,
-        onImeAction = ::submit,
-        modifier = Modifier.fillMaxWidth(),
+  DialogLayout(
+    header = {
+      Text(
+        "루비",
+        modifier = Modifier.fillMaxWidth().padding(start = 20.dp, end = 20.dp, top = 24.dp),
+        style = AppTheme.typography.title,
       )
-    }
-
-    Box(Modifier.fillMaxWidth().height(1.dp).background(AppTheme.colors.borderHairline))
-
-    Row(Modifier.fillMaxWidth()) {
+    },
+    body = {
+      Column(
+        Modifier.fillMaxWidth().padding(start = 20.dp, end = 20.dp, top = 16.dp, bottom = 20.dp)
+      ) {
+        TextField(
+          value = value,
+          onValueChange = { value = it },
+          label = "루비",
+          labelPosition = LabelPosition.None,
+          autoFocus = true,
+          placeholder = "텍스트 위에 들어갈 문구",
+          keyboardType = KeyboardType.Text,
+          imeAction = ImeAction.Done,
+          onImeAction = ::submit,
+          modifier = Modifier.fillMaxWidth(),
+        )
+      }
+    },
+    actions = {
       DialogActionButton(text = "취소") { dismiss() }
       if (existingText != null) {
         DialogActionDivider()
@@ -423,8 +418,8 @@ private fun RubyInputDialog(existingText: String?) {
       }
       DialogActionDivider()
       DialogActionButton(text = if (existingText != null) "수정" else "삽입") { submit() }
-    }
-  }
+    },
+  )
 }
 
 private fun ResolvedEditorTheme.colorFor(options: List<EditorColorOption>, value: String?) =

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/dialog/DialogLayout.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/dialog/DialogLayout.kt
@@ -3,6 +3,7 @@ package co.typie.ui.component.dialog
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
@@ -10,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -17,6 +19,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import co.typie.ext.clickable
+import co.typie.ext.verticalScroll
 import co.typie.ui.component.Text
 import co.typie.ui.theme.AppShapes
 import co.typie.ui.theme.AppTheme
@@ -28,23 +31,51 @@ internal fun DialogLayout(
   icon: (@Composable () -> Unit)? = null,
   actions: @Composable RowScope.() -> Unit,
 ) {
+  DialogLayout(
+    header = {
+      Column(
+        modifier = Modifier.padding(start = 28.dp, end = 28.dp, top = 32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+      ) {
+        if (icon != null) {
+          icon()
+          Spacer(Modifier.height(16.dp))
+        }
+        Text(title, style = AppTheme.typography.title)
+      }
+    },
+    body = {
+      Text(
+        message,
+        modifier = Modifier.padding(start = 28.dp, end = 28.dp, top = 6.dp, bottom = 28.dp),
+        style = AppTheme.typography.caption,
+        color = AppTheme.colors.textMuted,
+      )
+    },
+    actions = actions,
+  )
+}
+
+@Composable
+internal fun DialogLayout(
+  header: @Composable () -> Unit,
+  body: @Composable ColumnScope.() -> Unit,
+  actions: @Composable RowScope.() -> Unit,
+) {
+  val bodyScrollState = rememberScrollState()
+
   Column(
     modifier =
       Modifier.clip(AppShapes.rounded(AppShapes.lg)).background(AppTheme.colors.surfaceDefault),
     horizontalAlignment = Alignment.CenterHorizontally,
   ) {
+    header()
+
     Column(
-      modifier = Modifier.padding(start = 28.dp, end = 28.dp, top = 32.dp, bottom = 28.dp),
+      modifier = Modifier.fillMaxWidth().weight(1f, fill = false).verticalScroll(bodyScrollState),
       horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-      if (icon != null) {
-        icon()
-        Spacer(Modifier.height(16.dp))
-      }
-      Text(title, style = AppTheme.typography.title)
-      Spacer(Modifier.height(6.dp))
-      Text(message, style = AppTheme.typography.caption, color = AppTheme.colors.textMuted)
-    }
+      content = body,
+    )
 
     Box(Modifier.fillMaxWidth().height(1.dp).background(AppTheme.colors.borderHairline))
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/dialog/DialogOverlay.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/dialog/DialogOverlay.kt
@@ -4,8 +4,12 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.add
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -21,7 +25,8 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
 import co.typie.ext.clickable
-import co.typie.ext.imePadding
+import co.typie.ext.ime
+import co.typie.ext.safeDrawing
 import co.typie.navigation.PlatformBackHandler
 import co.typie.ui.theme.AppTheme
 
@@ -31,6 +36,8 @@ fun DialogOverlay(state: Dialog) {
   val density = LocalDensity.current
   val focusManager = LocalFocusManager.current
   val offsetPx = with(density) { 20.dp.toPx() }
+  val dialogViewportInsets =
+    WindowInsets.safeDrawing.union(WindowInsets.ime.add(WindowInsets(bottom = DialogImeGap)))
 
   var pendingResult by remember(entry) { mutableStateOf<DialogResult<Any?>?>(null) }
   var visible by remember(entry) { mutableStateOf(false) }
@@ -90,7 +97,7 @@ fun DialogOverlay(state: Dialog) {
         )
     )
 
-    Box(Modifier.fillMaxSize().imePadding()) {
+    Box(Modifier.fillMaxSize().windowInsetsPadding(dialogViewportInsets)) {
       Box(
         modifier =
           Modifier.align(Alignment.Center)
@@ -108,3 +115,5 @@ fun DialogOverlay(state: Dialog) {
     }
   }
 }
+
+private val DialogImeGap = 16.dp

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/dialog/DialogLayoutDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/dialog/DialogLayoutDesktopTest.kt
@@ -1,0 +1,109 @@
+package co.typie.ui.component.dialog
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasScrollAction
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeUp
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import co.typie.ui.theme.LightAppShadows
+import co.typie.ui.theme.LightColors
+import co.typie.ui.theme.LocalAppColors
+import co.typie.ui.theme.LocalAppShadows
+import co.typie.ui.theme.LocalThemeMode
+import co.typie.ui.theme.ResolvedThemeMode
+import dev.chrisbanes.haze.blur.HazeBlurStyle
+import dev.chrisbanes.haze.blur.LocalHazeBlurStyle
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class DialogLayoutDesktopTest {
+  @Test
+  fun longMessageScrollsWhileHeaderAndActionsStayFixed() = runComposeUiTest {
+    setContent {
+      DialogLayoutTestTheme {
+        Box(Modifier.testTag(RootTag).size(width = 280.dp, height = 240.dp)) {
+          DialogLayout(
+            title = Title,
+            message = LongMessage,
+            actions = { DialogActionButton(text = ConfirmText, onClick = {}) },
+          )
+        }
+      }
+    }
+
+    val title = onNodeWithText(Title)
+    val message = onNodeWithText(LongMessage)
+    val action = onNodeWithText(ConfirmText)
+    title.assertIsDisplayed()
+    action.assertIsDisplayed()
+
+    val scrollableBody = onNode(hasScrollAction())
+    val titleBoundsBeforeScroll = title.fetchSemanticsNode().boundsInRoot
+    val messageBoundsBeforeScroll = message.fetchSemanticsNode().boundsInRoot
+    val actionBoundsBeforeScroll = action.fetchSemanticsNode().boundsInRoot
+
+    scrollableBody.performTouchInput { swipeUp() }
+    waitForIdle()
+
+    val titleBoundsAfterScroll = title.fetchSemanticsNode().boundsInRoot
+    val messageBoundsAfterScroll = message.fetchSemanticsNode().boundsInRoot
+    val actionBoundsAfterScroll = action.fetchSemanticsNode().boundsInRoot
+    assertEquals(titleBoundsBeforeScroll.top, titleBoundsAfterScroll.top, absoluteTolerance = 0.5f)
+    assertTrue(messageBoundsAfterScroll.top < messageBoundsBeforeScroll.top)
+    assertEquals(
+      actionBoundsBeforeScroll.top,
+      actionBoundsAfterScroll.top,
+      absoluteTolerance = 0.5f,
+    )
+  }
+
+  @Test
+  fun shortMessageKeepsCompactHeight() = runComposeUiTest {
+    setContent {
+      DialogLayoutTestTheme {
+        Box(Modifier.testTag(RootTag).size(width = 280.dp, height = 600.dp)) {
+          DialogLayout(
+            title = Title,
+            message = "짧은 본문",
+            actions = { DialogActionButton(text = ConfirmText, onClick = {}) },
+          )
+        }
+      }
+    }
+
+    val rootBounds = onNodeWithTag(RootTag).fetchSemanticsNode().boundsInRoot
+    val actionBounds = onNodeWithText(ConfirmText).fetchSemanticsNode().boundsInRoot
+    assertTrue(actionBounds.bottom < rootBounds.center.y)
+  }
+
+  @Composable
+  private fun DialogLayoutTestTheme(content: @Composable () -> Unit) {
+    CompositionLocalProvider(
+      LocalAppColors provides LightColors,
+      LocalAppShadows provides LightAppShadows,
+      LocalThemeMode provides ResolvedThemeMode.Light,
+      LocalHazeBlurStyle provides
+        HazeBlurStyle(blurRadius = 20.dp, noiseFactor = 0f, colorEffects = listOf()),
+      content = content,
+    )
+  }
+
+  private companion object {
+    const val RootTag = "root"
+    const val Title = "긴 내용"
+    const val ConfirmText = "확인"
+    val LongMessage = (1..30).joinToString("\n") { "본문 $it" }
+  }
+}

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/dialog/DialogOverlayDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/dialog/DialogOverlayDesktopTest.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.unit.dp
 import co.typie.dev.DesktopDebugKeyboard
 import co.typie.ext.clickable
 import co.typie.ext.ime
+import co.typie.ext.safeDrawing
 import co.typie.ui.theme.LightAppShadows
 import co.typie.ui.theme.LightColors
 import co.typie.ui.theme.LocalAppColors
@@ -42,18 +43,27 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalTestApi::class)
 class DialogOverlayDesktopTest {
   @Test
-  fun contentIsCenteredInAreaAboveIme() = runComposeUiTest {
+  fun contentIsCenteredInSafeAreaWithImeGap() = runComposeUiTest {
     val dialog = Dialog()
     val keyboardOwner = Any()
     val wasHardwareKeyboardConnected = DesktopDebugKeyboard.hardwareKeyboardConnected
+    var safeTopPx = 0f
+    var safeBottomPx = 0f
     var imeBottomPx = 0f
+    var imeGapPx = 0f
 
     try {
       setContent {
         DialogTestTheme {
           val density = LocalDensity.current
+          val safeDrawingInsets = WindowInsets.safeDrawing
           val imeInsets = WindowInsets.ime
-          SideEffect { imeBottomPx = imeInsets.getBottom(density).toFloat() }
+          SideEffect {
+            safeTopPx = safeDrawingInsets.getTop(density).toFloat()
+            safeBottomPx = safeDrawingInsets.getBottom(density).toFloat()
+            imeBottomPx = imeInsets.getBottom(density).toFloat()
+            imeGapPx = with(density) { ImeGap.toPx() }
+          }
 
           Box(Modifier.testTag(RootTag).size(width = 400.dp, height = 700.dp)) {
             LaunchedEffect(Unit) {
@@ -76,17 +86,22 @@ class DialogOverlayDesktopTest {
       val rootBounds = onNodeWithTag(RootTag).fetchSemanticsNode().boundsInRoot
       val initialContentBounds = onNodeWithTag(DialogContentTag).fetchSemanticsNode().boundsInRoot
       assertEquals(0f, imeBottomPx, absoluteTolerance = 0.5f)
-      assertEquals(rootBounds.center.y, initialContentBounds.center.y, absoluteTolerance = 0.5f)
+      assertTrue(safeTopPx > 0f)
+      assertTrue(safeBottomPx > 0f)
+      val safeAreaCenterY = (rootBounds.top + safeTopPx + rootBounds.bottom - safeBottomPx) / 2f
+      assertEquals(safeAreaCenterY, initialContentBounds.center.y, absoluteTolerance = 0.5f)
 
       runOnIdle { DesktopDebugKeyboard.notifyFocusChanged(keyboardOwner, isFocused = true) }
       mainClock.advanceTimeBy(300)
       waitForIdle()
 
       val contentBounds = onNodeWithTag(DialogContentTag).fetchSemanticsNode().boundsInRoot
-      val visibleBottom = rootBounds.bottom - imeBottomPx
-      val visibleAreaCenterY = (rootBounds.top + visibleBottom) / 2f
+      val visibleTop = rootBounds.top + safeTopPx
+      val visibleBottom = rootBounds.bottom - maxOf(safeBottomPx, imeBottomPx + imeGapPx)
+      val visibleAreaCenterY = (visibleTop + visibleBottom) / 2f
       assertTrue(imeBottomPx > 0f)
       assertEquals(visibleAreaCenterY, contentBounds.center.y, absoluteTolerance = 0.5f)
+      assertTrue(contentBounds.top >= visibleTop - 0.5f)
       assertTrue(contentBounds.bottom <= visibleBottom + 0.5f)
     } finally {
       runOnIdle {
@@ -203,6 +218,7 @@ class DialogOverlayDesktopTest {
   }
 
   private companion object {
+    val ImeGap = 16.dp
     const val RootTag = "root"
     const val DialogContentTag = "dialog-content"
     const val OutsideFocusTag = "outside-focus"


### PR DESCRIPTION
- 공용 `DialogLayout`을 header, body, actions 구조로 정리
    - header와 actions는 고정
    - body만 가용 높이에 맞춰 scroll
    - 짧은 Dialog는 기존처럼 콘텐츠 높이만 차지
    - 여러 dialog에 적용함. 하지만 안 쓰고 싶으면 opt-out 가능
- Dialog 콘텐츠 viewport에 safe drawing inset과 하단 여백을 반영
    - 하단은 화면 가장자리 또는 IME와 최소 16dp 간격 유지