### PR TITLE
앱 SVG 이미지 업로드 지원

### DIFF
--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/input/EditorInput.android.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/input/EditorInput.android.kt
@@ -50,6 +50,7 @@ internal actual suspend fun PlatformTextInputSessionScope.createEditorInputReque
       EditorInputConnection(
         editor = editor,
         view = androidView,
+        inputSessionScope = this,
         bringIntoViewRequests = bringIntoViewRequests,
         extractMonitor = extractMonitor,
         isSessionCurrent = isSessionCurrent,

--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/input/EditorInputConnection.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/input/EditorInputConnection.kt
@@ -25,10 +25,15 @@ import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.EditorBringIntoViewTarget
 import co.typie.editor.scroll.syncWithBringIntoView
 import co.typie.platform.IncomingContentCandidates
-import co.typie.platform.IncomingContentItem
-import co.typie.platform.readPlatformFile
+import co.typie.platform.copyIncomingContentItem
+import co.typie.platform.loadOwnedIncomingContentCandidates
 import java.util.concurrent.Executor
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.function.IntConsumer
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 // Reads are bounded by the ime window itself, and keyboards derive absolute
 // positions from read lengths (e.g. getTextBeforeCursor(Int.MAX_VALUE)), so
@@ -65,9 +70,10 @@ private val ImeExtract.isSelecting: Boolean
 internal class EditorInputConnection(
   private val editor: Editor,
   private val view: View,
+  private val inputSessionScope: CoroutineScope,
   private val bringIntoViewRequests: EditorBringIntoViewRequests,
   private val extractMonitor: ImeExtractMonitor,
-  isSessionCurrent: () -> Boolean,
+  private val isSessionCurrent: () -> Boolean,
   private val onIncomingContent: (IncomingContentCandidates) -> Boolean,
 ) : InputConnection {
   private val batch =
@@ -303,58 +309,58 @@ internal class EditorInputConnection(
     flags: Int,
     opts: Bundle?,
   ): Boolean {
+    if (!isSessionCurrent()) return false
+
     val permissionRequested = flags and InputConnection.INPUT_CONTENT_GRANT_READ_URI_PERMISSION != 0
-    var permissionOwned = false
-    return try {
+    val permissionOwned = AtomicBoolean(false)
+    fun releasePermission() {
+      if (permissionOwned.compareAndSet(true, false)) {
+        runCatching(inputContentInfo::releasePermission)
+      }
+    }
+
+    try {
       if (permissionRequested) {
         inputContentInfo.requestPermission()
-        permissionOwned = true
+        permissionOwned.set(true)
       }
-      val fallbackMimeType =
-        inputContentInfo.description.let { description ->
-          (0 until description.mimeTypeCount).firstNotNullOfOrNull { index ->
-            description.getMimeType(index)?.takeIf { it != "*/*" }
-          }
+    } catch (_: Throwable) {
+      releasePermission()
+      return false
+    }
+
+    val fallbackMimeType =
+      inputContentInfo.description.let { description ->
+        (0 until description.mimeTypeCount).firstNotNullOfOrNull { index ->
+          description.getMimeType(index)?.takeIf { it != "*/*" }
         }
-      val file =
-        view.context.readPlatformFile(
-          uri = inputContentInfo.contentUri,
-          fallbackMimeType = fallbackMimeType,
-          release = {
-            if (permissionOwned) {
-              permissionOwned = false
-              runCatching(inputContentInfo::releasePermission)
-            }
-          },
-        )
+      }
+    val job = inputSessionScope.launch {
       val candidates =
-        IncomingContentCandidates(
-          items =
-            listOf(
-              IncomingContentItem(
-                kind =
-                  if (file.mimeType?.substringBefore('/') == "image") {
-                    IncomingContentItem.Kind.Image
-                  } else {
-                    IncomingContentItem.Kind.File
-                  },
-                file = file,
+        try {
+          loadOwnedIncomingContentCandidates(Dispatchers.IO) {
+            val item =
+              view.context.copyIncomingContentItem(
+                uri = inputContentInfo.contentUri,
+                fallbackMimeType = fallbackMimeType,
               )
-            )
-        )
+            IncomingContentCandidates(items = listOf(item))
+          } ?: return@launch
+        } catch (error: CancellationException) {
+          throw error
+        } catch (_: Throwable) {
+          IncomingContentCandidates(unreadableItemCount = 1)
+        }
+
       try {
-        onIncomingContent(candidates).also { accepted -> if (!accepted) candidates.close() }
+        if (!onIncomingContent(candidates)) candidates.close()
       } catch (error: Throwable) {
         candidates.close()
         throw error
       }
-    } catch (_: Throwable) {
-      if (permissionOwned) {
-        permissionOwned = false
-        runCatching(inputContentInfo::releasePermission)
-      }
-      false
     }
+    job.invokeOnCompletion { releasePermission() }
+    return !job.isCancelled
   }
 
   override fun commitCompletion(text: CompletionInfo?): Boolean = false

--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/platform/FilePicker.android.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/platform/FilePicker.android.kt
@@ -8,9 +8,13 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.platform.LocalContext
 import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.io.asSource
 import kotlinx.io.buffered
 
@@ -20,27 +24,24 @@ actual fun rememberFilePicker(
   onResult: (FilePickerResult) -> Unit,
 ): (mimeType: String) -> Unit {
   val context = LocalContext.current
+  val scope = rememberCoroutineScope()
   val currentOnResult = rememberUpdatedState(onResult)
   val singleLauncher =
     rememberLauncherForActivityResult(contract = ActivityResultContracts.GetContent()) { uri ->
-      currentOnResult.value(
-        if (uri == null) {
-          FilePickerResult.Cancelled
-        } else {
-          aggregateSelectedFiles(listOf(runCatching { context.readPlatformFile(uri) }))
-        }
-      )
+      if (uri == null) {
+        currentOnResult.value(FilePickerResult.Cancelled)
+      } else {
+        scope.launch { currentOnResult.value(context.readSelectedFiles(listOf(uri))) }
+      }
     }
   val multipleLauncher =
     rememberLauncherForActivityResult(contract = ActivityResultContracts.GetMultipleContents()) {
       uris ->
-      currentOnResult.value(
-        if (uris.isEmpty()) {
-          FilePickerResult.Cancelled
-        } else {
-          aggregateSelectedFiles(uris.map { uri -> runCatching { context.readPlatformFile(uri) } })
-        }
-      )
+      if (uris.isEmpty()) {
+        currentOnResult.value(FilePickerResult.Cancelled)
+      } else {
+        scope.launch { currentOnResult.value(context.readSelectedFiles(uris)) }
+      }
     }
 
   return remember(singleLauncher, multipleLauncher, selectionMode) {
@@ -53,14 +54,29 @@ actual fun rememberFilePicker(
   }
 }
 
+private suspend fun Context.readSelectedFiles(uris: List<Uri>): FilePickerResult =
+  withContext(Dispatchers.IO) {
+    aggregateSelectedFiles(uris.map { uri -> runCatching { readPlatformFile(uri) } })
+  }
+
 internal fun Context.readPlatformFile(
   uri: Uri,
   fallbackMimeType: String? = null,
   release: () -> Unit = {},
 ): PickedFile {
-  val mimeType = contentResolver.getType(uri) ?: fallbackMimeType
   val metadata = queryMetadata(uri)
-  val imageSize = decodeImageSizeIfNeeded(uri, mimeType)
+  val providerMimeType = contentResolver.getType(uri) ?: fallbackMimeType
+  val svgMimeType = svgMimeTypeOrNull(metadata.filename, providerMimeType)
+  val mimeType = svgMimeType ?: providerMimeType
+  val imageSize =
+    if (svgMimeType != null) {
+      val bytes =
+        contentResolver.openInputStream(uri)?.use { it.readBytes() }
+          ?: error("Unable to open selected image")
+      decodeSvgImageSize(bytes)
+    } else {
+      decodeImageSizeIfNeeded(uri, mimeType)
+    }
 
   if (mimeType?.substringBefore('/') != "image") {
     contentResolver.openInputStream(uri)?.close() ?: error("Unable to open selected file")
@@ -81,36 +97,54 @@ internal fun Context.readPlatformFile(
   )
 }
 
-internal fun Context.copyClipboardFile(uri: Uri, fallbackMimeType: String? = null): PickedFile {
-  val mimeType = contentResolver.getType(uri) ?: fallbackMimeType
+internal fun Context.copyIncomingContentItem(
+  uri: Uri,
+  fallbackMimeType: String? = null,
+): IncomingContentItem {
   val metadata = queryMetadata(uri)
-  val directory = File(cacheDir, "incoming-clipboard").apply { mkdirs() }
-  val ownedFile = File.createTempFile("clipboard-", ".tmp", directory)
+  val providerMimeType = contentResolver.getType(uri) ?: fallbackMimeType
+  val svgMimeType = svgMimeTypeOrNull(metadata.filename, providerMimeType)
+  val mimeType = svgMimeType ?: providerMimeType
+  val directory = File(cacheDir, "incoming-content").apply { mkdirs() }
+  val ownedFile = File.createTempFile("incoming-", ".tmp", directory)
 
   try {
     contentResolver.openInputStream(uri)?.use { input ->
       ownedFile.outputStream().use { output -> input.copyTo(output) }
-    } ?: error("Unable to open clipboard file")
+    } ?: error("Unable to open incoming file")
     val imageSize =
-      if (mimeType?.substringBefore('/') == "image") {
-        val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
-        BitmapFactory.decodeFile(ownedFile.path, options)
-        options.outWidth
-          .takeIf { it > 0 }
-          ?.let { width -> options.outHeight.takeIf { it > 0 }?.let { height -> width to height } }
-      } else {
-        null
+      when {
+        svgMimeType != null -> decodeSvgImageSize(ownedFile.readBytes())
+        mimeType?.substringBefore('/') == "image" -> {
+          val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+          BitmapFactory.decodeFile(ownedFile.path, options)
+          options.outWidth
+            .takeIf { it > 0 }
+            ?.let { width ->
+              options.outHeight.takeIf { it > 0 }?.let { height -> width to height }
+            }
+        }
+        else -> null
       }
 
-    return PickedFile(
-      filename = pickedFilename(metadata.filename, mimeType),
-      mimeType = mimeType,
-      size = metadata.size ?: ownedFile.length(),
-      previewModel = ownedFile,
-      imageWidth = imageSize?.first,
-      imageHeight = imageSize?.second,
-      openSource = { ownedFile.inputStream().asSource().buffered() },
-      release = { ownedFile.delete() },
+    return IncomingContentItem(
+      kind =
+        if (mimeType?.substringBefore('/') == "image") {
+          IncomingContentItem.Kind.Image
+        } else {
+          IncomingContentItem.Kind.File
+        },
+      file =
+        PickedFile(
+          filename = pickedFilename(metadata.filename, mimeType),
+          mimeType = mimeType,
+          size = metadata.size ?: ownedFile.length(),
+          previewModel = ownedFile,
+          imageWidth = imageSize?.first,
+          imageHeight = imageSize?.second,
+          openSource = { ownedFile.inputStream().asSource().buffered() },
+          release = { ownedFile.delete() },
+        ),
     )
   } catch (error: Throwable) {
     ownedFile.delete()

--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/platform/PlatformServiceModule.android.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/platform/PlatformServiceModule.android.kt
@@ -92,16 +92,7 @@ internal class AndroidClipboard(private val context: Context) : Clipboard {
             if (uri == null) {
               null
             } else {
-              val file = context.copyClipboardFile(uri)
-              IncomingContentItem(
-                kind =
-                  if (file.mimeType?.substringBefore('/') == "image") {
-                    IncomingContentItem.Kind.Image
-                  } else {
-                    IncomingContentItem.Kind.File
-                  },
-                file = file,
-              )
+              context.copyIncomingContentItem(uri)
             }
           },
         )

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/platform/FilePicker.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/platform/FilePicker.kt
@@ -2,7 +2,14 @@ package co.typie.platform
 
 import androidx.compose.runtime.Composable
 import co.touchlab.kermit.Logger
+import com.hashsequence.coilresvg.SvgRenderer
+import com.hashsequence.coilresvg.use
+import kotlin.math.roundToInt
 import kotlinx.io.Source
+
+internal const val SVG_MIME_TYPE = "image/svg+xml"
+private val SVG_EXTENSION_FALLBACK_MIME_TYPES =
+  setOf("application/octet-stream", "image/*", "text/xml", "application/xml")
 
 class PickedFile
 internal constructor(
@@ -87,6 +94,29 @@ internal fun pickedFilename(originalFilename: String?, mimeType: String?): Strin
     "image/webp" -> "image.webp"
     "image/heic" -> "image.heic"
     "image/heif" -> "image.heif"
+    SVG_MIME_TYPE -> "image.svg"
     else -> "file"
   }
+}
+
+internal fun svgMimeTypeOrNull(filename: String?, mimeType: String?): String? {
+  val normalizedMimeType =
+    mimeType?.substringBefore(';')?.trim()?.lowercase()?.takeIf(String::isNotEmpty)
+  if (normalizedMimeType == SVG_MIME_TYPE) return SVG_MIME_TYPE
+  if (filename?.trim()?.endsWith(".svg", ignoreCase = true) != true) return null
+  return SVG_MIME_TYPE.takeIf {
+    normalizedMimeType == null || normalizedMimeType in SVG_EXTENSION_FALLBACK_MIME_TYPES
+  }
+}
+
+internal fun decodeSvgImageSize(bytes: ByteArray): Pair<Int, Int> {
+  val size = SvgRenderer.fromData(bytes).use { renderer -> renderer.getSize() }
+  return size.width.toImageDimension() to size.height.toImageDimension()
+}
+
+private fun Float.toImageDimension(): Int {
+  require(isFinite() && this > 0f && toDouble() <= Int.MAX_VALUE.toDouble()) {
+    "SVG image dimension is not a positive Int: $this"
+  }
+  return roundToInt().coerceAtLeast(1)
 }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/platform/FilePickerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/platform/FilePickerTest.kt
@@ -2,8 +2,10 @@ package co.typie.platform
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFails
 import kotlin.test.assertIs
 import kotlin.test.assertSame
+import kotlin.test.assertTrue
 import kotlinx.io.Buffer
 
 class FilePickerTest {
@@ -78,6 +80,62 @@ class FilePickerTest {
     assertEquals(1, releaseCount)
   }
 
+  @Test
+  fun svgMimeRecognitionNormalizesStandardMimeAndConservativeExtensionFallbacks() {
+    assertEquals(
+      "image/svg+xml",
+      svgMimeTypeOrNull(filename = "drawing", mimeType = " IMAGE/SVG+XML ; charset=utf-8"),
+    )
+
+    for (mimeType in
+      listOf(null, "application/octet-stream", "image/*", "text/xml", "application/xml")) {
+      assertEquals(
+        "image/svg+xml",
+        svgMimeTypeOrNull(filename = " drawing.SvG ", mimeType = mimeType),
+      )
+    }
+
+    assertEquals(null, svgMimeTypeOrNull(filename = "drawing.svg", mimeType = "image/png"))
+    assertEquals(null, svgMimeTypeOrNull(filename = "drawing.xml", mimeType = "text/xml"))
+  }
+
+  @Test
+  fun svgMimeUsesImageFilenameFallbackWithoutReplacingProvidedName() {
+    assertEquals("image.svg", pickedFilename(originalFilename = null, mimeType = "image/svg+xml"))
+    assertEquals(
+      "drawing.svg",
+      pickedFilename(originalFilename = " drawing.svg ", mimeType = "image/svg+xml"),
+    )
+  }
+
+  @Test
+  fun svgImageSizeUsesIntrinsicDimensionsAndRoundsPositiveFractions() {
+    assertEquals(24 to 12, decodeSvgImageSize(svg("width=\"24\" height=\"12\"")))
+    assertEquals(3 to 1, decodeSvgImageSize(svg("width=\"2.6\" height=\"0.4\"")))
+  }
+
+  @Test
+  fun svgImageSizePreservesViewBoxAspectRatio() {
+    val (width, height) = decodeSvgImageSize(svg("viewBox=\"0 0 48 32\""))
+
+    assertTrue(width > 0)
+    assertTrue(height > 0)
+    assertEquals(width * 2, height * 3)
+  }
+
+  @Test
+  fun svgImageSizeRejectsInvalidOrUnrepresentableDimensions() {
+    for (bytes in
+      listOf(
+        "<svg".encodeToByteArray(),
+        svg("width=\"0\" height=\"10\""),
+        svg("width=\"-1\" height=\"10\""),
+        svg("width=\"3000000000\" height=\"1\""),
+      )) {
+      assertFails { decodeSvgImageSize(bytes) }
+    }
+  }
+
   private fun pickedFile(filename: String): PickedFile =
     PickedFile(
       filename = filename,
@@ -86,4 +144,7 @@ class FilePickerTest {
       previewModel = Unit,
       openSource = { Buffer() },
     )
+
+  private fun svg(attributes: String): ByteArray =
+    """<svg xmlns="http://www.w3.org/2000/svg" $attributes></svg>""".encodeToByteArray()
 }

--- a/apps/mobile/compose/src/desktopMain/kotlin/co/typie/platform/FilePicker.desktop.kt
+++ b/apps/mobile/compose/src/desktopMain/kotlin/co/typie/platform/FilePicker.desktop.kt
@@ -2,6 +2,7 @@ package co.typie.platform
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import java.awt.FileDialog
 import java.awt.Frame
@@ -9,6 +10,9 @@ import java.awt.image.BufferedImage
 import java.io.File
 import java.nio.file.Files
 import javax.imageio.ImageIO
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.io.asSource
 import kotlinx.io.buffered
 
@@ -17,9 +21,10 @@ actual fun rememberFilePicker(
   selectionMode: FilePickerSelectionMode,
   onResult: (FilePickerResult) -> Unit,
 ): (mimeType: String) -> Unit {
+  val scope = rememberCoroutineScope()
   val currentOnResult = rememberUpdatedState(onResult)
 
-  return remember(selectionMode) {
+  return remember(selectionMode, scope) {
     { mimeType: String ->
       val contentType = mimeType.substringBefore('/')
       val title =
@@ -37,7 +42,8 @@ actual fun rememberFilePicker(
                   lower.endsWith(".jpg") ||
                   lower.endsWith(".jpeg") ||
                   lower.endsWith(".webp") ||
-                  lower.endsWith(".heic")
+                  lower.endsWith(".heic") ||
+                  lower.endsWith(".svg")
               }
             }
           }
@@ -45,32 +51,40 @@ actual fun rememberFilePicker(
           isVisible = true
         }
       val selectedFiles = dialog.files
-      currentOnResult.value(
-        if (selectedFiles.isEmpty()) {
-          FilePickerResult.Cancelled
-        } else {
-          aggregateSelectedFiles(
-            selectedFiles.map { file ->
-              runCatching {
-                val image =
-                  when (contentType) {
-                    "image" -> file.decodeImageOrNull()
-                    else -> null
+      if (selectedFiles.isEmpty()) {
+        currentOnResult.value(FilePickerResult.Cancelled)
+      } else {
+        scope.launch {
+          val result =
+            withContext(Dispatchers.IO) {
+              aggregateSelectedFiles(
+                selectedFiles.map { file ->
+                  runCatching {
+                    val providerMimeType = file.probeContentType()
+                    val svgMimeType = svgMimeTypeOrNull(file.name, providerMimeType)
+                    val imageSize =
+                      when {
+                        svgMimeType != null -> decodeSvgImageSize(file.readBytes())
+                        contentType == "image" ->
+                          file.decodeImageOrNull()?.let { it.width to it.height }
+                        else -> null
+                      }
+                    PickedFile(
+                      filename = file.name,
+                      mimeType = svgMimeType ?: providerMimeType,
+                      size = file.length(),
+                      previewModel = file,
+                      imageWidth = imageSize?.first,
+                      imageHeight = imageSize?.second,
+                      openSource = { file.inputStream().asSource().buffered() },
+                    )
                   }
-                PickedFile(
-                  filename = file.name,
-                  mimeType = file.probeContentType(),
-                  size = file.length(),
-                  previewModel = file,
-                  imageWidth = image?.width,
-                  imageHeight = image?.height,
-                  openSource = { file.inputStream().asSource().buffered() },
-                )
-              }
+                }
+              )
             }
-          )
+          currentOnResult.value(result)
         }
-      )
+      }
     }
   }
 }

--- a/apps/mobile/compose/src/desktopMain/kotlin/co/typie/platform/PlatformServiceModule.desktop.kt
+++ b/apps/mobile/compose/src/desktopMain/kotlin/co/typie/platform/PlatformServiceModule.desktop.kt
@@ -114,12 +114,16 @@ internal fun Transferable.readAttachmentItems(): LoadedIncomingContentItems {
       val outcomes = files.map { file ->
         runCatching {
           check(file.isFile && file.canRead()) { "Clipboard file is unreadable" }
-          val mimeType = file.probeContentType()
-          val image =
-            if (mimeType?.substringBefore('/') == "image") {
-              checkNotNull(file.decodeImageOrNull()) { "Clipboard image is unreadable" }
-            } else {
-              null
+          val providerMimeType = file.probeContentType()
+          val svgMimeType = svgMimeTypeOrNull(file.name, providerMimeType)
+          val mimeType = svgMimeType ?: providerMimeType
+          val imageSize =
+            when {
+              svgMimeType != null -> decodeSvgImageSize(file.readBytes())
+              mimeType?.substringBefore('/') == "image" ->
+                checkNotNull(file.decodeImageOrNull()) { "Clipboard image is unreadable" }
+                  .let { it.width to it.height }
+              else -> null
             }
           IncomingContentItem(
             kind =
@@ -134,8 +138,8 @@ internal fun Transferable.readAttachmentItems(): LoadedIncomingContentItems {
                 mimeType = mimeType,
                 size = file.length(),
                 previewModel = file,
-                imageWidth = image?.width,
-                imageHeight = image?.height,
+                imageWidth = imageSize?.first,
+                imageHeight = imageSize?.second,
                 openSource = { file.inputStream().asSource().buffered() },
               ),
           )

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/platform/DesktopIncomingContentTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/platform/DesktopIncomingContentTest.kt
@@ -7,10 +7,12 @@ import java.io.File
 import java.nio.file.Files
 import javax.imageio.ImageIO
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
+import kotlinx.io.readByteArray
 
 class DesktopIncomingContentTest {
   @Test
@@ -62,6 +64,40 @@ class DesktopIncomingContentTest {
       assertEquals(listOf("first.png", "second.txt"), items.map { it.file.filename })
       assertEquals(2, items.first().file.imageWidth)
       assertEquals(3, items.first().file.imageHeight)
+      items.forEach { it.file.close() }
+    } finally {
+      directory.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun orderedFileListMaterializesSvgAsOriginalImageWithoutDuplicateImageFlavor() {
+    val directory = Files.createTempDirectory("typie-svg-clipboard-").toFile()
+    try {
+      val svgBytes =
+        """<svg xmlns="http://www.w3.org/2000/svg" width="12" height="8"></svg>"""
+          .encodeToByteArray()
+      val imageFile = File(directory, "first.svg").apply { writeBytes(svgBytes) }
+      val textFile = File(directory, "second.txt").apply { writeText("file") }
+      val transferable =
+        FakeTransferable(
+          linkedMapOf(
+            DataFlavor.javaFileListFlavor to listOf(imageFile, textFile),
+            DataFlavor.imageFlavor to BufferedImage(9, 9, BufferedImage.TYPE_INT_ARGB),
+          )
+        )
+
+      val items = transferable.readAttachmentItems().items
+
+      assertEquals(
+        listOf(IncomingContentItem.Kind.Image, IncomingContentItem.Kind.File),
+        items.map(IncomingContentItem::kind),
+      )
+      assertEquals(listOf("first.svg", "second.txt"), items.map { it.file.filename })
+      assertEquals("image/svg+xml", items.first().file.mimeType)
+      assertEquals(12, items.first().file.imageWidth)
+      assertEquals(8, items.first().file.imageHeight)
+      assertContentEquals(svgBytes, items.first().file.openSource().use { it.readByteArray() })
       items.forEach { it.file.close() }
     } finally {
       directory.deleteRecursively()

--- a/apps/mobile/compose/src/iosMain/kotlin/co/typie/platform/FilePicker.ios.kt
+++ b/apps/mobile/compose/src/iosMain/kotlin/co/typie/platform/FilePicker.ios.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.io.buffered
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.readByteArray
 import platform.Foundation.NSError
 import platform.Foundation.NSFileManager
 import platform.Foundation.NSFileSize
@@ -245,6 +246,18 @@ private suspend fun NSItemProvider.loadSelectedImage(): Result<PickedFile> {
 
 internal fun NSURL.toPickedImage(filename: String, mimeType: String?): PickedFile {
   val path = requireNotNull(path) { "Selected image path is unavailable" }
+  if (mimeType == SVG_MIME_TYPE) {
+    val bytes = SystemFileSystem.source(Path(path)).buffered().use { it.readByteArray() }
+    val (width, height) = decodeSvgImageSize(bytes)
+    return toPickedFile(
+      filename = filename,
+      mimeType = mimeType,
+      imageWidth = width,
+      imageHeight = height,
+      owned = true,
+    )
+  }
+
   val image = UIImage.imageWithContentsOfFile(path) ?: error("Unable to decode the selected image")
   return toPickedFile(
     filename = filename,

--- a/apps/mobile/compose/src/iosMain/kotlin/co/typie/platform/PlatformServiceModule.ios.kt
+++ b/apps/mobile/compose/src/iosMain/kotlin/co/typie/platform/PlatformServiceModule.ios.kt
@@ -150,18 +150,10 @@ internal class IOSClipboard : Clipboard {
           loaders =
             snapshot.items.mapIndexed { index, item ->
               suspend {
-                val provider = snapshot.providers.getOrNull(index)
-                if (provider == null) {
-                  readPasteboardAttachment(item)
-                } else {
-                  try {
-                    provider.loadPasteboardAttachment() ?: readPasteboardAttachment(item)
-                  } catch (error: CancellationException) {
-                    throw error
-                  } catch (error: Throwable) {
-                    runCatching { readPasteboardAttachment(item) }.getOrNull() ?: throw error
-                  }
-                }
+                readPasteboardAttachment(
+                  item = item,
+                  provider = snapshot.providers.getOrNull(index),
+                )
               }
             },
           loaderContext = Dispatchers.Default,
@@ -187,39 +179,9 @@ private data class IOSPasteboardSnapshot(
   val providers: List<NSItemProvider>,
 )
 
-private suspend fun NSItemProvider.loadPasteboardAttachment(): IncomingContentItem? {
-  val representation =
-    registeredTypeIdentifiers
-      .filterIsInstance<String>()
-      .mapNotNull { identifier ->
-        val type = UTType.typeWithIdentifier(identifier) ?: return@mapNotNull null
-        when {
-          type.conformsToType(UTTypeImage) ->
-            PasteboardProviderRepresentation(
-              identifier = identifier,
-              type = type,
-              kind = IncomingContentItem.Kind.Image,
-            )
-          identifier == UTI_FILE_URL || identifier == UTI_URL || type.conformsToType(UTTypeText) ->
-            null
-          type.conformsToType(UTTypeData) ->
-            PasteboardProviderRepresentation(
-              identifier = identifier,
-              type = type,
-              kind = IncomingContentItem.Kind.File,
-            )
-          else -> null
-        }
-      }
-      .minByOrNull { if (it.kind == IncomingContentItem.Kind.Image) 0 else 1 } ?: return null
-  val mimeType = representation.type.preferredMIMEType
-  val filename =
-    providerFilename(
-      suggestedName = suggestedName,
-      preferredExtension = representation.type.preferredFilenameExtension,
-      mimeType = mimeType,
-    )
-
+private suspend fun NSItemProvider.loadPasteboardAttachment(
+  representation: PasteboardProviderRepresentation
+): IncomingContentItem {
   return suspendCancellableCoroutine { continuation ->
     var progress: NSProgress? = null
     continuation.invokeOnCancellation { progress?.cancel() }
@@ -232,15 +194,20 @@ private suspend fun NSItemProvider.loadPasteboardAttachment(): IncomingContentIt
                   providerError?.localizedDescription
                     ?: "Clipboard file representation is unavailable"
                 )
-            val ownedURL = copyToTemporaryFile(sourceURL, filename)
+            val ownedURL = copyToTemporaryFile(sourceURL, representation.filename)
             try {
               IncomingContentItem(
                 kind = representation.kind,
                 file =
                   when (representation.kind) {
-                    IncomingContentItem.Kind.Image -> ownedURL.toPickedImage(filename, mimeType)
+                    IncomingContentItem.Kind.Image ->
+                      ownedURL.toPickedImage(representation.filename, representation.mimeType)
                     IncomingContentItem.Kind.File ->
-                      ownedURL.toPickedFile(filename = filename, mimeType = mimeType, owned = true)
+                      ownedURL.toPickedFile(
+                        filename = representation.filename,
+                        mimeType = representation.mimeType,
+                        owned = true,
+                      )
                   },
               )
             } catch (error: Throwable) {
@@ -257,32 +224,115 @@ private suspend fun NSItemProvider.loadPasteboardAttachment(): IncomingContentIt
   }
 }
 
-private data class PasteboardProviderRepresentation(
+private suspend fun readPasteboardAttachment(
+  item: Map<*, *>,
+  provider: NSItemProvider?,
+): IncomingContentItem? {
+  if (provider == null) return readDirectPasteboardAttachment(item)
+  val representation =
+    provider.selectPasteboardProviderRepresentation() ?: return readDirectPasteboardAttachment(item)
+
+  return try {
+    provider.loadPasteboardAttachment(representation)
+  } catch (error: CancellationException) {
+    throw error
+  } catch (error: Throwable) {
+    val fallback = runCatching { readDirectPasteboardAttachment(item) }.getOrNull()
+    if (representation.mimeType == SVG_MIME_TYPE && fallback?.file?.mimeType != SVG_MIME_TYPE) {
+      fallback?.file?.close()
+      throw error
+    }
+    fallback ?: throw error
+  }
+}
+
+internal data class PasteboardProviderRepresentation(
   val identifier: String,
-  val type: UTType,
   val kind: IncomingContentItem.Kind,
+  val filename: String,
+  val mimeType: String?,
 )
 
-private fun readPasteboardAttachment(item: Map<*, *>): IncomingContentItem? {
+private fun pasteboardProviderRepresentation(
+  identifier: String,
+  suggestedName: String?,
+): PasteboardProviderRepresentation? {
+  val type = UTType.typeWithIdentifier(identifier) ?: return null
+  if (identifier == UTI_FILE_URL || identifier == UTI_URL) return null
+  val providerMimeType = type.preferredMIMEType
+  val filename =
+    providerFilename(
+      suggestedName = suggestedName,
+      preferredExtension = type.preferredFilenameExtension,
+      mimeType = providerMimeType,
+    )
+  val svgMimeType = svgMimeTypeOrNull(filename, providerMimeType)
+  val kind =
+    when {
+      svgMimeType != null || type.conformsToType(UTTypeImage) -> IncomingContentItem.Kind.Image
+      type.conformsToType(UTTypeText) -> return null
+      type.conformsToType(UTTypeData) -> IncomingContentItem.Kind.File
+      else -> return null
+    }
+  return PasteboardProviderRepresentation(
+    identifier = identifier,
+    kind = kind,
+    filename = filename,
+    mimeType = svgMimeType ?: providerMimeType,
+  )
+}
+
+private fun NSItemProvider.selectPasteboardProviderRepresentation():
+  PasteboardProviderRepresentation? =
+  selectPasteboardProviderRepresentation(
+    registeredTypeIdentifiers.filterIsInstance<String>().mapNotNull { identifier ->
+      pasteboardProviderRepresentation(identifier, suggestedName)
+    }
+  )
+
+internal fun selectPasteboardProviderRepresentation(
+  representations: List<PasteboardProviderRepresentation>
+): PasteboardProviderRepresentation? =
+  representations.firstOrNull { it.mimeType == SVG_MIME_TYPE }
+    ?: representations.firstOrNull { it.kind == IncomingContentItem.Kind.Image }
+    ?: representations.firstOrNull()
+
+internal fun readDirectPasteboardAttachment(item: Map<*, *>): IncomingContentItem? {
+  val rawSvg =
+    item.entries.firstNotNullOfOrNull { (rawType, value) ->
+      if (value !is NSData) return@firstNotNullOfOrNull null
+      val identifier = rawType as? String ?: return@firstNotNullOfOrNull null
+      val representation =
+        pasteboardProviderRepresentation(identifier, suggestedName = null)
+          ?: return@firstNotNullOfOrNull null
+      Pair(representation, value).takeIf { representation.mimeType == SVG_MIME_TYPE }
+    }
+  if (rawSvg != null) {
+    val (representation, data) = rawSvg
+    return IncomingContentItem(
+      kind = IncomingContentItem.Kind.Image,
+      file = data.toClipboardPickedImage(representation.filename, representation.mimeType),
+    )
+  }
+
   val fileURL = item[UTI_FILE_URL].asPasteboardFileURL()?.takeIf { it.scheme == "file" }
   if (fileURL != null) {
     val inferredType =
       fileURL.pathExtension?.takeIf(String::isNotBlank)?.let(UTType::typeWithFilenameExtension)
-    val filename = pickedFilename(fileURL.lastPathComponent, inferredType?.preferredMIMEType)
+    val providerMimeType = inferredType?.preferredMIMEType
+    val filename = pickedFilename(fileURL.lastPathComponent, providerMimeType)
+    val svgMimeType = svgMimeTypeOrNull(filename, providerMimeType)
+    val mimeType = svgMimeType ?: providerMimeType
     val ownedURL = copyToTemporaryFile(fileURL, filename)
     return try {
-      val isImage = inferredType?.conformsToType(UTTypeImage) == true
+      val isImage = svgMimeType != null || inferredType?.conformsToType(UTTypeImage) == true
       IncomingContentItem(
         kind = if (isImage) IncomingContentItem.Kind.Image else IncomingContentItem.Kind.File,
         file =
           if (isImage) {
-            ownedURL.toPickedImage(filename, inferredType.preferredMIMEType)
+            ownedURL.toPickedImage(filename, mimeType)
           } else {
-            ownedURL.toPickedFile(
-              filename = filename,
-              mimeType = inferredType?.preferredMIMEType,
-              owned = true,
-            )
+            ownedURL.toPickedFile(filename = filename, mimeType = mimeType, owned = true)
           },
       )
     } catch (error: Throwable) {
@@ -291,21 +341,24 @@ private fun readPasteboardAttachment(item: Map<*, *>): IncomingContentItem? {
     }
   }
 
-  val imageValue =
+  val imageEntry =
     item.entries.firstNotNullOfOrNull { (rawType, value) ->
-      val type = rawType as? String ?: return@firstNotNullOfOrNull null
-      val uniformType = UTType.typeWithIdentifier(type) ?: return@firstNotNullOfOrNull null
-      value.takeIf { uniformType.conformsToType(UTTypeImage) }
+      val identifier = rawType as? String ?: return@firstNotNullOfOrNull null
+      val representation =
+        pasteboardProviderRepresentation(identifier, suggestedName = null)
+          ?: return@firstNotNullOfOrNull null
+      Pair(representation, value).takeIf { representation.kind == IncomingContentItem.Kind.Image }
     } ?: return null
-  val image =
-    when (imageValue) {
-      is UIImage -> imageValue
-      is NSData -> UIImage(data = imageValue)
-      else -> null
-    } ?: error("Clipboard image representation is unreadable")
+  val (representation, imageValue) = imageEntry
   return IncomingContentItem(
     kind = IncomingContentItem.Kind.Image,
-    file = image.toClipboardPickedFile(),
+    file =
+      when (imageValue) {
+        is UIImage -> imageValue.toClipboardPickedFile()
+        is NSData ->
+          imageValue.toClipboardPickedImage(representation.filename, representation.mimeType)
+        else -> error("Clipboard image representation is unreadable")
+      },
   )
 }
 
@@ -331,6 +384,24 @@ private fun UIImage.toClipboardPickedFile(): PickedFile {
   val url = NSURL.fileURLWithPath(path)
   return try {
     url.toPickedImage(filename = "image.png", mimeType = "image/png")
+  } catch (error: Throwable) {
+    removeOwnedFile(url)
+    throw error
+  }
+}
+
+private fun NSData.toClipboardPickedImage(filename: String, mimeType: String?): PickedFile {
+  if (mimeType != SVG_MIME_TYPE) {
+    return UIImage(data = this).toClipboardPickedFile()
+  }
+
+  val safeFilename = filename.replace('/', '_').replace('\\', '_')
+  val url = NSURL.fileURLWithPath("${NSTemporaryDirectory()}${NSUUID().UUIDString}-$safeFilename")
+  return try {
+    check(writeToFile(requireNotNull(url.path), atomically = true)) {
+      "Unable to copy clipboard image"
+    }
+    url.toPickedImage(filename = filename, mimeType = mimeType)
   } catch (error: Throwable) {
     removeOwnedFile(url)
     throw error

--- a/apps/mobile/compose/src/iosTest/kotlin/co/typie/platform/IOSFilePickerTest.kt
+++ b/apps/mobile/compose/src/iosTest/kotlin/co/typie/platform/IOSFilePickerTest.kt
@@ -1,0 +1,183 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+package co.typie.platform
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import kotlinx.io.readByteArray
+import platform.CoreGraphics.CGSizeMake
+import platform.Foundation.NSData
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSTemporaryDirectory
+import platform.Foundation.NSURL
+import platform.Foundation.NSUUID
+import platform.Foundation.create
+import platform.Foundation.writeToFile
+import platform.UIKit.UIGraphicsBeginImageContextWithOptions
+import platform.UIKit.UIGraphicsEndImageContext
+import platform.UIKit.UIGraphicsGetImageFromCurrentImageContext
+import platform.UIKit.UIImagePNGRepresentation
+import platform.UniformTypeIdentifiers.UTTypeSVG
+
+class IOSFilePickerTest {
+  @Test
+  fun ownedSvgFilePreservesBytesDimensionsAndDeletesOnClose() {
+    val bytes = svgBytes(width = 18, height = 12)
+    val url = temporaryFile("owned.svg", bytes)
+    try {
+      val file = url.toPickedImage(filename = "owned.svg", mimeType = "image/svg+xml")
+
+      assertEquals(18, file.imageWidth)
+      assertEquals(12, file.imageHeight)
+      assertContentEquals(bytes, file.openSource().use { it.readByteArray() })
+      assertTrue(NSFileManager.defaultManager.fileExistsAtPath(requireNotNull(url.path)))
+
+      file.close()
+
+      assertFalse(NSFileManager.defaultManager.fileExistsAtPath(requireNotNull(url.path)))
+    } finally {
+      NSFileManager.defaultManager.removeItemAtURL(url, error = null)
+    }
+  }
+
+  @Test
+  fun rawSvgDataPreservesBytesAndDeletesItsOwnedFileOnClose() {
+    val bytes = svgBytes(width = 15, height = 10)
+
+    val imported =
+      assertNotNull(readDirectPasteboardAttachment(mapOf(UTTypeSVG.identifier to bytes.toNSData())))
+    assertEquals(IncomingContentItem.Kind.Image, imported.kind)
+    val file = imported.file
+    val url = file.previewModel as NSURL
+    try {
+      assertEquals("image.svg", file.filename)
+      assertEquals("image/svg+xml", file.mimeType)
+      assertEquals(15, file.imageWidth)
+      assertEquals(10, file.imageHeight)
+      assertContentEquals(bytes, file.openSource().use { it.readByteArray() })
+      assertTrue(NSFileManager.defaultManager.fileExistsAtPath(requireNotNull(url.path)))
+
+      file.close()
+
+      assertFalse(NSFileManager.defaultManager.fileExistsAtPath(requireNotNull(url.path)))
+    } finally {
+      file.close()
+    }
+  }
+
+  @Test
+  fun malformedRawSvgDataRemovesItsTemporaryFile() {
+    val existingFiles = temporaryFilesEndingWith("image.svg")
+
+    assertFails {
+      readDirectPasteboardAttachment(
+        mapOf(UTTypeSVG.identifier to "<svg".encodeToByteArray().toNSData())
+      )
+    }
+
+    assertEquals(existingFiles, temporaryFilesEndingWith("image.svg"))
+  }
+
+  @Test
+  fun providerSelectionPrefersRawSvgAndPreservesOrderWithinRank() {
+    val raster =
+      PasteboardProviderRepresentation(
+        identifier = "public.png",
+        kind = IncomingContentItem.Kind.Image,
+        filename = "image.png",
+        mimeType = "image/png",
+      )
+    val secondRaster = raster.copy(identifier = "public.jpeg", filename = "image.jpg")
+    val svg =
+      PasteboardProviderRepresentation(
+        identifier = UTTypeSVG.identifier,
+        kind = IncomingContentItem.Kind.Image,
+        filename = "image.svg",
+        mimeType = "image/svg+xml",
+      )
+    val file =
+      PasteboardProviderRepresentation(
+        identifier = "public.data",
+        kind = IncomingContentItem.Kind.File,
+        filename = "file",
+        mimeType = "application/octet-stream",
+      )
+
+    assertSame(svg, selectPasteboardProviderRepresentation(listOf(raster, svg, file)))
+    assertSame(raster, selectPasteboardProviderRepresentation(listOf(raster, secondRaster)))
+  }
+
+  @Test
+  fun directPasteboardItemPrefersRawSvgOverRasterFileUrlWithoutFallbackOnFailure() {
+    val rasterUrl = temporaryPngFile()
+    try {
+      val svgBytes = svgBytes(width = 21, height = 14)
+      val item =
+        mapOf<Any, Any>("public.file-url" to rasterUrl, UTTypeSVG.identifier to svgBytes.toNSData())
+
+      val imported = assertNotNull(readDirectPasteboardAttachment(item))
+      try {
+        assertEquals(IncomingContentItem.Kind.Image, imported.kind)
+        assertEquals("image/svg+xml", imported.file.mimeType)
+        assertContentEquals(svgBytes, imported.file.openSource().use { it.readByteArray() })
+      } finally {
+        imported.file.close()
+      }
+
+      assertFails {
+        readDirectPasteboardAttachment(
+          mapOf<Any, Any>(
+            "public.file-url" to rasterUrl,
+            UTTypeSVG.identifier to "<svg".encodeToByteArray().toNSData(),
+          )
+        )
+      }
+    } finally {
+      NSFileManager.defaultManager.removeItemAtURL(rasterUrl, error = null)
+    }
+  }
+
+  private fun svgBytes(width: Int, height: Int): ByteArray =
+    """<svg xmlns="http://www.w3.org/2000/svg" width="$width" height="$height"></svg>"""
+      .encodeToByteArray()
+
+  private fun temporaryFile(filename: String, bytes: ByteArray): NSURL {
+    val path = "${NSTemporaryDirectory()}${NSUUID().UUIDString}-$filename"
+    check(bytes.toNSData().writeToFile(path, atomically = true))
+    return NSURL.fileURLWithPath(path)
+  }
+
+  private fun temporaryPngFile(): NSURL {
+    UIGraphicsBeginImageContextWithOptions(CGSizeMake(2.0, 3.0), false, 1.0)
+    val image =
+      try {
+        requireNotNull(UIGraphicsGetImageFromCurrentImageContext())
+      } finally {
+        UIGraphicsEndImageContext()
+      }
+    val data = requireNotNull(UIImagePNGRepresentation(image))
+    val path = "${NSTemporaryDirectory()}${NSUUID().UUIDString}-image.png"
+    check(data.writeToFile(path, atomically = true))
+    return NSURL.fileURLWithPath(path)
+  }
+
+  private fun temporaryFilesEndingWith(suffix: String): Set<String> =
+    NSFileManager.defaultManager
+      .contentsOfDirectoryAtPath(NSTemporaryDirectory(), error = null)
+      ?.filterIsInstance<String>()
+      ?.filter { it.endsWith(suffix) }
+      ?.toSet()
+      .orEmpty()
+
+  private fun ByteArray.toNSData(): NSData = usePinned { pinned ->
+    NSData.create(bytes = pinned.addressOf(0), length = size.toULong())
+  }
+}


### PR DESCRIPTION
## 작업 내용

- 공통 `SvgRenderer`를 사용해 SVG의 크기를 추출하고 `image/svg+xml` MIME을 보수적으로 정규화합니다.
- Android 이미지 picker, clipboard, IME `commitContent`에서 SVG를 이미지로 가져옵니다.
- Desktop 이미지 picker와 clipboard 파일 목록에서 SVG를 이미지로 가져옵니다.
- iOS clipboard와 `NSItemProvider`의 raw SVG representation을 이미지로 가져옵니다.
- SVG는 rasterize하지 않고 원본 bytes를 그대로 업로드하며, 기존 raster decoder와 attachment importer 계약은 유지합니다.
- Android/Desktop 파일 읽기를 IO dispatcher로 이동하고, Android IME 입력은 URI 권한을 해제하기 전에 app-owned 임시 파일로 복사합니다.

iOS 이미지 picker는 기존 Photos 기반 `PHPicker`를 유지하며, Files에서 SVG를 선택하는 별도 진입점은 추가하지 않습니다.