### PR TITLE
앱 sheet에서 focused field를 자동 reveal

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/entity/icon/EntityIconPickerSheet.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/entity/icon/EntityIconPickerSheet.kt
@@ -7,8 +7,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -33,7 +31,6 @@ import androidx.compose.ui.unit.dp
 import co.typie.ext.InteractionScope
 import co.typie.ext.clickable
 import co.typie.ext.pressScale
-import co.typie.ext.safeDrawing
 import co.typie.form.FormState
 import co.typie.icons.Lucide
 import co.typie.result.Result
@@ -210,8 +207,6 @@ internal fun EntityIconPickerSheet(
             .weight(1f)
             .scrollFog(padding = gridFogInsets, color = AppTheme.colors.surfaceCanvas)
       ) {
-        val safeBottom = WindowInsets.safeDrawing.asPaddingValues().calculateBottomPadding()
-
         LazyVerticalGrid(
           columns = GridCells.Fixed(7),
           state = iconGridState,
@@ -219,7 +214,7 @@ internal fun EntityIconPickerSheet(
           contentPadding =
             PaddingValues(
               top = gridFogInsets.calculateTopPadding(),
-              bottom = EntityIconPickerGridBottomInset + safeBottom,
+              bottom = EntityIconPickerGridBottomInset,
             ),
           horizontalArrangement = Arrangement.spacedBy(EntityIconPickerCellSpacing),
           verticalArrangement = Arrangement.spacedBy(EntityIconPickerCellSpacing),

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/EditorTableAxisActionsPane.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/EditorTableAxisActionsPane.kt
@@ -102,7 +102,6 @@ private fun EditorTableAxisActionsSheet(
 
   SheetLayout(
     bodyScroll = false,
-    includeImeBottomInset = false,
     padding = SheetPadding.None,
     verticalSpacing = 0.dp,
     header = {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/comments/CommentsSheet.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/comments/CommentsSheet.kt
@@ -418,7 +418,7 @@ private fun CommentsSheetContent(
     fillHeight = true,
     bodyScroll = false,
     handleModifier = sheetDragHandleModifier,
-    includeImeBottomInset = false,
+    includeBottomInset = false,
     padding = SheetPadding(header = PaddingValues(horizontal = 16.dp), body = PaddingValues(0.dp)),
     header = {
       CommentsSheetBar(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/relatednotes/RelatedNotesSheet.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/relatednotes/RelatedNotesSheet.kt
@@ -439,7 +439,7 @@ private fun RelatedNotesSheetContent(
     fillHeight = true,
     bodyScroll = false,
     handleModifier = sheetDragHandleModifier,
-    includeImeBottomInset = false,
+    includeBottomInset = false,
     padding = SheetPadding(header = PaddingValues(horizontal = 16.dp), body = PaddingValues(0.dp)),
     header = {
       RelatedNotesSheetBar(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/shell/MainDrawer.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/shell/MainDrawer.kt
@@ -342,7 +342,6 @@ internal fun CreateSpaceSheet(model: MainDrawerViewModel) {
   val toast = LocalToast.current
 
   SheetLayout(
-    bodyScroll = false,
     header = {
       SheetBar(
         center = {
@@ -355,7 +354,7 @@ internal fun CreateSpaceSheet(model: MainDrawerViewModel) {
           )
         }
       )
-    },
+    }
   ) {
     Text(
       text = "스페이스는 독립된 글쓰기 공간이에요.\n주제나 목적에 따라 글을 나누어 관리해보세요.",

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/sheet/SheetLayout.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/sheet/SheetLayout.kt
@@ -54,7 +54,7 @@ fun SheetLayout(
   bodyScroll: Boolean = true,
   handle: Boolean = true,
   handleModifier: Modifier = Modifier,
-  includeImeBottomInset: Boolean = true,
+  includeBottomInset: Boolean = true,
   padding: SheetPadding = SheetPadding(),
   verticalSpacing: Dp = 12.dp,
   backgroundColor: Color = AppTheme.colors.surfaceCanvas,
@@ -65,11 +65,7 @@ fun SheetLayout(
 ) {
   val scrollState = rememberScrollState()
   val bottomInsets =
-    if (includeImeBottomInset) {
-      WindowInsets.navigationBars.union(WindowInsets.ime)
-    } else {
-      WindowInsets.navigationBars
-    }
+    if (includeBottomInset) WindowInsets.navigationBars.union(WindowInsets.ime) else null
 
   Column(modifier = modifier.fillMaxWidth().thenIf(fillHeight) { fillMaxHeight() }) {
     if (handle) SheetHandle(modifier = handleModifier.background(headerBackgroundColor))
@@ -98,23 +94,23 @@ fun SheetLayout(
           verticalArrangement = Arrangement.spacedBy(verticalSpacing),
         ) {
           body()
-
-          if (footer == null) {
-            Spacer(modifier = Modifier.windowInsetsBottomHeight(bottomInsets))
-          }
         }
       }
 
-      if (footer != null) {
+      if (footer != null || bottomInsets != null) {
         Spacer(Modifier.height(verticalSpacing))
 
-        Column(
-          modifier = Modifier.fillMaxWidth().padding(padding.footer),
-          verticalArrangement = Arrangement.spacedBy(verticalSpacing),
-          content = footer,
-        )
+        if (footer != null) {
+          Column(
+            modifier = Modifier.fillMaxWidth().padding(padding.footer),
+            verticalArrangement = Arrangement.spacedBy(verticalSpacing),
+            content = footer,
+          )
+        }
 
-        Spacer(Modifier.windowInsetsBottomHeight(bottomInsets))
+        if (bottomInsets != null) {
+          Spacer(Modifier.windowInsetsBottomHeight(bottomInsets))
+        }
       }
     }
   }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/sheet/SheetLayoutDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/sheet/SheetLayoutDesktopTest.kt
@@ -1,0 +1,518 @@
+package co.typie.ui.component.sheet
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasScrollAction
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import co.typie.dev.DesktopDebugKeyboard
+import co.typie.ext.ime
+import co.typie.ext.rememberTextInputBinding
+import co.typie.ext.textInputFocusable
+import co.typie.ui.theme.LightAppShadows
+import co.typie.ui.theme.LightColors
+import co.typie.ui.theme.LocalAppColors
+import co.typie.ui.theme.LocalAppShadows
+import co.typie.ui.theme.LocalThemeMode
+import co.typie.ui.theme.ResolvedThemeMode
+import dev.chrisbanes.haze.blur.HazeBlurStyle
+import dev.chrisbanes.haze.blur.LocalHazeBlurStyle
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class SheetLayoutDesktopTest {
+  @Test
+  fun nonScrollingBodyExcludesImeWhileSurfaceContinuesBehindIt() = runComposeUiTest {
+    val sheet = Sheet()
+    val requestFocus = mutableStateOf(false)
+    val wasHardwareKeyboardConnected = DesktopDebugKeyboard.hardwareKeyboardConnected
+    var clearFocus: (() -> Unit)? = null
+    var imeBottomPx = 0f
+
+    try {
+      setContent {
+        SheetLayoutTestTheme {
+          val density = LocalDensity.current
+          val imeInsets = WindowInsets.ime
+          SideEffect { imeBottomPx = imeInsets.getBottom(density).toFloat() }
+
+          Box(Modifier.testTag(NonScrollingRootTag).size(width = 400.dp, height = 700.dp)) {
+            LaunchedEffect(Unit) {
+              sheet.present<Unit> {
+                NonScrollingSheet(
+                  requestFocus = requestFocus.value,
+                  onClearFocusChanged = { clearFocus = it },
+                )
+              }
+            }
+            SheetOverlay(sheet)
+          }
+        }
+      }
+
+      waitUntil(timeoutMillis = 5_000) { sheet.entries.isNotEmpty() }
+      runOnIdle {
+        DesktopDebugKeyboard.updateHardwareKeyboardConnected(true)
+        DesktopDebugKeyboard.hideKeyboardSurface()
+        requestFocus.value = true
+      }
+      waitForIdle()
+      onNodeWithTag(NonScrollingFieldTag).assertIsFocused()
+
+      runOnIdle { DesktopDebugKeyboard.updateHardwareKeyboardConnected(false) }
+      mainClock.advanceTimeBy(300)
+      waitForIdle()
+
+      val rootBounds = onNodeWithTag(NonScrollingRootTag).fetchSemanticsNode().boundsInRoot
+      val layoutBounds = onNodeWithTag(NonScrollingLayoutTag).fetchSemanticsNode().boundsInRoot
+      val bodyBounds = onNodeWithTag(NonScrollingBodyTag).fetchSemanticsNode().boundsInRoot
+      val imeTop = rootBounds.bottom - imeBottomPx
+
+      assertTrue(imeBottomPx > 0f)
+      assertTrue(
+        layoutBounds.bottom > imeTop + 0.5f,
+        "Sheet surface must continue behind the software keyboard",
+      )
+      assertTrue(
+        bodyBounds.bottom <= imeTop + 0.5f,
+        "Sheet-owned IME inset must be excluded from the body viewport",
+      )
+    } finally {
+      runOnIdle {
+        clearFocus?.invoke()
+        DesktopDebugKeyboard.updateHardwareKeyboardConnected(wasHardwareKeyboardConnected)
+        DesktopDebugKeyboard.hideKeyboardSurface()
+      }
+    }
+  }
+
+  @Test
+  fun bottomInsetCanBeDelegatedToCaller() = runComposeUiTest {
+    val sheet = Sheet()
+    val includeBottomInset = mutableStateOf(false)
+    val requestFocus = mutableStateOf(false)
+    val wasHardwareKeyboardConnected = DesktopDebugKeyboard.hardwareKeyboardConnected
+    var clearFocus: (() -> Unit)? = null
+    var imeBottomPx = 0f
+
+    try {
+      setContent {
+        SheetLayoutTestTheme {
+          val density = LocalDensity.current
+          val imeInsets = WindowInsets.ime
+          SideEffect { imeBottomPx = imeInsets.getBottom(density).toFloat() }
+
+          Box(Modifier.testTag(BottomInsetRootTag).size(width = 400.dp, height = 700.dp)) {
+            LaunchedEffect(Unit) {
+              sheet.present<Unit> {
+                InsetOwnershipSheet(
+                  includeBottomInset = includeBottomInset.value,
+                  requestFocus = requestFocus.value,
+                  onClearFocusChanged = { clearFocus = it },
+                )
+              }
+            }
+            SheetOverlay(sheet)
+          }
+        }
+      }
+
+      waitUntil(timeoutMillis = 5_000) { sheet.entries.isNotEmpty() }
+      runOnIdle {
+        DesktopDebugKeyboard.updateHardwareKeyboardConnected(true)
+        DesktopDebugKeyboard.hideKeyboardSurface()
+        requestFocus.value = true
+      }
+      waitForIdle()
+      onNodeWithTag(BottomInsetFieldTag).assertIsFocused()
+
+      val noneLayoutBounds = onNodeWithTag(BottomInsetLayoutTag).fetchSemanticsNode().boundsInRoot
+      val noneBodyBounds = onNodeWithTag(BottomInsetBodyTag).fetchSemanticsNode().boundsInRoot
+      assertEquals(noneLayoutBounds.bottom, noneBodyBounds.bottom, absoluteTolerance = 0.5f)
+
+      runOnIdle { DesktopDebugKeyboard.updateHardwareKeyboardConnected(false) }
+      mainClock.advanceTimeBy(300)
+      waitForIdle()
+
+      val rootBounds = onNodeWithTag(BottomInsetRootTag).fetchSemanticsNode().boundsInRoot
+      val noneImeLayoutBounds =
+        onNodeWithTag(BottomInsetLayoutTag).fetchSemanticsNode().boundsInRoot
+      val noneImeBodyBounds = onNodeWithTag(BottomInsetBodyTag).fetchSemanticsNode().boundsInRoot
+      val imeTop = rootBounds.bottom - imeBottomPx
+      assertTrue(imeBottomPx > 0f)
+      assertEquals(noneLayoutBounds.bottom, noneImeLayoutBounds.bottom, absoluteTolerance = 0.5f)
+      assertEquals(noneBodyBounds.bottom, noneImeBodyBounds.bottom, absoluteTolerance = 0.5f)
+      assertTrue(noneImeLayoutBounds.bottom > imeTop + 0.5f)
+
+      runOnIdle { includeBottomInset.value = true }
+      waitForIdle()
+
+      val ownedInsetLayoutBounds =
+        onNodeWithTag(BottomInsetLayoutTag).fetchSemanticsNode().boundsInRoot
+      val ownedInsetBodyBounds = onNodeWithTag(BottomInsetBodyTag).fetchSemanticsNode().boundsInRoot
+      assertEquals(
+        noneImeLayoutBounds.bottom,
+        ownedInsetLayoutBounds.bottom,
+        absoluteTolerance = 0.5f,
+      )
+      assertTrue(
+        ownedInsetBodyBounds.bottom <= imeTop + 0.5f,
+        "Sheet-owned bottom inset must reserve the IME height",
+      )
+    } finally {
+      runOnIdle {
+        clearFocus?.invoke()
+        DesktopDebugKeyboard.updateHardwareKeyboardConnected(wasHardwareKeyboardConnected)
+        DesktopDebugKeyboard.hideKeyboardSurface()
+      }
+    }
+  }
+
+  @Test
+  fun focusedFieldIsRevealedWhenImeAppearsAfterFocus() = runComposeUiTest {
+    val sheet = Sheet()
+    val requestFocus = mutableStateOf(false)
+    val wasHardwareKeyboardConnected = DesktopDebugKeyboard.hardwareKeyboardConnected
+    var clearFocus: (() -> Unit)? = null
+    var imeBottomPx = 0f
+
+    try {
+      setContent {
+        SheetLayoutTestTheme {
+          val density = LocalDensity.current
+          val imeInsets = WindowInsets.ime
+          SideEffect { imeBottomPx = imeInsets.getBottom(density).toFloat() }
+
+          Box(Modifier.testTag(RootTag).size(width = 400.dp, height = 700.dp)) {
+            LaunchedEffect(Unit) {
+              sheet.present<Unit> {
+                DelayedImeSheet(
+                  requestFocus = requestFocus.value,
+                  onClearFocusChanged = { clearFocus = it },
+                )
+              }
+            }
+            SheetOverlay(sheet)
+          }
+        }
+      }
+
+      waitUntil(timeoutMillis = 5_000) { sheet.entries.isNotEmpty() }
+      runOnIdle {
+        DesktopDebugKeyboard.updateHardwareKeyboardConnected(true)
+        DesktopDebugKeyboard.hideKeyboardSurface()
+        requestFocus.value = true
+      }
+      waitForIdle()
+      onNodeWithTag(FieldTag).assertIsFocused()
+
+      val initialFieldBounds = onNodeWithTag(FieldTag).fetchSemanticsNode().boundsInRoot
+      val initialHeaderBounds = onNodeWithTag(HeaderTag).fetchSemanticsNode().boundsInRoot
+      val scrollNode =
+        onNode(hasScrollAction() and hasAnyAncestor(hasTestTag(LayoutTag)), useUnmergedTree = true)
+      assertEquals(0f, scrollNode.verticalScrollValue(), absoluteTolerance = 0.5f)
+
+      runOnIdle { DesktopDebugKeyboard.updateHardwareKeyboardConnected(false) }
+      mainClock.advanceTimeBy(300)
+      waitForIdle()
+
+      val rootBounds = onNodeWithTag(RootTag).fetchSemanticsNode().boundsInRoot
+      val fieldBounds = onNodeWithTag(FieldTag).fetchSemanticsNode().boundsInRoot
+      val headerBounds = onNodeWithTag(HeaderTag).fetchSemanticsNode().boundsInRoot
+      val imeTop = rootBounds.bottom - imeBottomPx
+      val wholeSheetShift = headerBounds.top - initialHeaderBounds.top
+      val fieldShift = fieldBounds.top - initialFieldBounds.top
+
+      assertTrue(imeBottomPx > 0f)
+      assertTrue(
+        initialFieldBounds.bottom > imeTop,
+        "fixture must place the initially visible field inside the final IME area",
+      )
+      assertTrue(fieldBounds.bottom <= imeTop + 0.5f)
+      assertTrue(fieldShift < wholeSheetShift - 0.5f)
+      assertTrue(scrollNode.verticalScrollValue() > 0f)
+    } finally {
+      runOnIdle {
+        clearFocus?.invoke()
+        DesktopDebugKeyboard.updateHardwareKeyboardConnected(wasHardwareKeyboardConnected)
+        DesktopDebugKeyboard.hideKeyboardSurface()
+      }
+    }
+  }
+
+  @Test
+  fun manualScrollMovesOnlyBodyWithFixedHeaderAndFooter() = runComposeUiTest {
+    val sheet = Sheet()
+
+    setContent {
+      SheetLayoutTestTheme {
+        Box(Modifier.size(width = 400.dp, height = 700.dp)) {
+          LaunchedEffect(Unit) { sheet.present<Unit> { FixedSlotsSheet() } }
+          SheetOverlay(sheet)
+        }
+      }
+    }
+
+    waitUntil(timeoutMillis = 5_000) { sheet.entries.isNotEmpty() }
+    waitForIdle()
+
+    val scrollNode =
+      onNode(
+        hasScrollAction() and hasAnyAncestor(hasTestTag(FixedSlotsLayoutTag)),
+        useUnmergedTree = true,
+      )
+    val headerBounds = onNodeWithTag(FixedHeaderTag).fetchSemanticsNode().boundsInRoot
+    val footerBounds = onNodeWithTag(FixedFooterTag).fetchSemanticsNode().boundsInRoot
+    val bodyBounds = onNodeWithTag(BodyMarkerTag).fetchSemanticsNode().boundsInRoot
+
+    scrollNode.performSemanticsAction(SemanticsActions.ScrollBy) { action ->
+      assertTrue(action(0f, 120f))
+    }
+    waitUntil(timeoutMillis = 5_000) { scrollNode.verticalScrollValue() > 0f }
+
+    assertEquals(
+      headerBounds.top,
+      onNodeWithTag(FixedHeaderTag).fetchSemanticsNode().boundsInRoot.top,
+      absoluteTolerance = 0.5f,
+    )
+    assertEquals(
+      footerBounds.top,
+      onNodeWithTag(FixedFooterTag).fetchSemanticsNode().boundsInRoot.top,
+      absoluteTolerance = 0.5f,
+    )
+    assertTrue(onNodeWithTag(BodyMarkerTag).fetchSemanticsNode().boundsInRoot.top < bodyBounds.top)
+  }
+
+  @Test
+  fun shortSheetDoesNotScrollWhenFocusedFieldRemainsVisible() = runComposeUiTest {
+    val sheet = Sheet()
+    val requestFocus = mutableStateOf(false)
+    val wasHardwareKeyboardConnected = DesktopDebugKeyboard.hardwareKeyboardConnected
+    var clearFocus: (() -> Unit)? = null
+    var imeBottomPx = 0f
+
+    try {
+      setContent {
+        SheetLayoutTestTheme {
+          val density = LocalDensity.current
+          val imeInsets = WindowInsets.ime
+          SideEffect { imeBottomPx = imeInsets.getBottom(density).toFloat() }
+
+          Box(Modifier.testTag(ShortRootTag).size(width = 400.dp, height = 700.dp)) {
+            LaunchedEffect(Unit) {
+              sheet.present<Unit> {
+                ShortSheet(
+                  requestFocus = requestFocus.value,
+                  onClearFocusChanged = { clearFocus = it },
+                )
+              }
+            }
+            SheetOverlay(sheet)
+          }
+        }
+      }
+
+      waitUntil(timeoutMillis = 5_000) { sheet.entries.isNotEmpty() }
+      runOnIdle {
+        DesktopDebugKeyboard.updateHardwareKeyboardConnected(true)
+        DesktopDebugKeyboard.hideKeyboardSurface()
+        requestFocus.value = true
+      }
+      waitForIdle()
+      onNodeWithTag(ShortFieldTag).assertIsFocused()
+
+      val scrollNode =
+        onNode(
+          hasScrollAction() and hasAnyAncestor(hasTestTag(ShortLayoutTag)),
+          useUnmergedTree = true,
+        )
+
+      runOnIdle { DesktopDebugKeyboard.updateHardwareKeyboardConnected(false) }
+      mainClock.advanceTimeBy(300)
+      waitForIdle()
+
+      val rootBounds = onNodeWithTag(ShortRootTag).fetchSemanticsNode().boundsInRoot
+      val fieldBounds = onNodeWithTag(ShortFieldTag).fetchSemanticsNode().boundsInRoot
+      val imeTop = rootBounds.bottom - imeBottomPx
+
+      assertTrue(imeBottomPx > 0f)
+      assertTrue(fieldBounds.bottom <= imeTop + 0.5f)
+      assertEquals(0f, scrollNode.verticalScrollValue(), absoluteTolerance = 0.5f)
+    } finally {
+      runOnIdle {
+        clearFocus?.invoke()
+        DesktopDebugKeyboard.updateHardwareKeyboardConnected(wasHardwareKeyboardConnected)
+        DesktopDebugKeyboard.hideKeyboardSurface()
+      }
+    }
+  }
+
+  @Composable
+  context(_: SheetScope<Unit>)
+  private fun NonScrollingSheet(requestFocus: Boolean, onClearFocusChanged: (() -> Unit) -> Unit) {
+    SheetLayout(
+      modifier = Modifier.testTag(NonScrollingLayoutTag),
+      fillHeight = true,
+      bodyScroll = false,
+    ) {
+      Box(Modifier.testTag(NonScrollingBodyTag).fillMaxSize()) {
+        TestInput(
+          tag = NonScrollingFieldTag,
+          requestFocus = requestFocus,
+          onClearFocusChanged = onClearFocusChanged,
+        )
+      }
+    }
+  }
+
+  @Composable
+  context(_: SheetScope<Unit>)
+  private fun InsetOwnershipSheet(
+    includeBottomInset: Boolean,
+    requestFocus: Boolean,
+    onClearFocusChanged: (() -> Unit) -> Unit,
+  ) {
+    SheetLayout(
+      modifier = Modifier.testTag(BottomInsetLayoutTag),
+      fillHeight = true,
+      bodyScroll = false,
+      includeBottomInset = includeBottomInset,
+    ) {
+      Box(Modifier.testTag(BottomInsetBodyTag).fillMaxSize()) {
+        TestInput(
+          tag = BottomInsetFieldTag,
+          requestFocus = requestFocus,
+          onClearFocusChanged = onClearFocusChanged,
+        )
+      }
+    }
+  }
+
+  @Composable
+  context(_: SheetScope<Unit>)
+  private fun DelayedImeSheet(requestFocus: Boolean, onClearFocusChanged: (() -> Unit) -> Unit) {
+    SheetLayout(
+      modifier = Modifier.testTag(LayoutTag),
+      header = { Box(Modifier.testTag(HeaderTag).fillMaxWidth().height(48.dp)) },
+    ) {
+      Spacer(Modifier.fillMaxWidth().height(240.dp))
+      TestInput(
+        tag = FieldTag,
+        requestFocus = requestFocus,
+        onClearFocusChanged = onClearFocusChanged,
+      )
+    }
+  }
+
+  @Composable
+  context(_: SheetScope<Unit>)
+  private fun FixedSlotsSheet() {
+    SheetLayout(
+      modifier = Modifier.testTag(FixedSlotsLayoutTag),
+      header = { Box(Modifier.testTag(FixedHeaderTag).fillMaxWidth().height(48.dp)) },
+      footer = { Box(Modifier.testTag(FixedFooterTag).fillMaxWidth().height(48.dp)) },
+    ) {
+      Box(Modifier.testTag(BodyMarkerTag).fillMaxWidth().height(48.dp))
+      Spacer(Modifier.fillMaxWidth().height(800.dp))
+    }
+  }
+
+  @Composable
+  context(_: SheetScope<Unit>)
+  private fun ShortSheet(requestFocus: Boolean, onClearFocusChanged: (() -> Unit) -> Unit) {
+    SheetLayout(
+      modifier = Modifier.testTag(ShortLayoutTag),
+      header = { Box(Modifier.fillMaxWidth().height(48.dp)) },
+    ) {
+      TestInput(
+        tag = ShortFieldTag,
+        requestFocus = requestFocus,
+        onClearFocusChanged = onClearFocusChanged,
+      )
+    }
+  }
+
+  @Composable
+  private fun TestInput(
+    tag: String,
+    requestFocus: Boolean,
+    onClearFocusChanged: (() -> Unit) -> Unit,
+  ) {
+    var value by remember { mutableStateOf("") }
+    val focusManager = LocalFocusManager.current
+    val binding = rememberTextInputBinding(onDismiss = { focusManager.clearFocus() })
+    SideEffect { onClearFocusChanged { focusManager.clearFocus() } }
+    LaunchedEffect(requestFocus) { if (requestFocus) binding.requestFocus() }
+
+    BasicTextField(
+      value = value,
+      onValueChange = { value = it },
+      modifier = Modifier.testTag(tag).fillMaxWidth().height(44.dp).textInputFocusable(binding),
+    )
+  }
+
+  private fun androidx.compose.ui.test.SemanticsNodeInteraction.verticalScrollValue(): Float =
+    fetchSemanticsNode().config[SemanticsProperties.VerticalScrollAxisRange].value()
+
+  @Composable
+  private fun SheetLayoutTestTheme(content: @Composable () -> Unit) {
+    CompositionLocalProvider(
+      LocalAppColors provides LightColors,
+      LocalAppShadows provides LightAppShadows,
+      LocalThemeMode provides ResolvedThemeMode.Light,
+      LocalHazeBlurStyle provides
+        HazeBlurStyle(blurRadius = 20.dp, noiseFactor = 0f, colorEffects = listOf()),
+      content = content,
+    )
+  }
+
+  private companion object {
+    const val NonScrollingRootTag = "non-scrolling-sheet-root"
+    const val NonScrollingLayoutTag = "non-scrolling-sheet-layout"
+    const val NonScrollingBodyTag = "non-scrolling-sheet-body"
+    const val NonScrollingFieldTag = "non-scrolling-sheet-field"
+    const val BottomInsetRootTag = "bottom-inset-sheet-root"
+    const val BottomInsetLayoutTag = "bottom-inset-sheet-layout"
+    const val BottomInsetBodyTag = "bottom-inset-sheet-body"
+    const val BottomInsetFieldTag = "bottom-inset-sheet-field"
+    const val RootTag = "sheet-layout-root"
+    const val LayoutTag = "sheet-layout"
+    const val HeaderTag = "sheet-layout-header"
+    const val FieldTag = "sheet-layout-field"
+    const val FixedSlotsLayoutTag = "fixed-slots-sheet-layout"
+    const val FixedHeaderTag = "fixed-slots-sheet-header"
+    const val FixedFooterTag = "fixed-slots-sheet-footer"
+    const val BodyMarkerTag = "fixed-slots-sheet-body-marker"
+    const val ShortRootTag = "short-sheet-root"
+    const val ShortLayoutTag = "short-sheet-layout"
+    const val ShortFieldTag = "short-sheet-field"
+  }
+}


### PR DESCRIPTION
## 배경

- footer가 없는 `SheetLayout`은 navigation bar와 IME inset을 body scroll content의 마지막 요소로 넣고 있었음
- 이 구조에서는 IME가 나타날 때 body viewport가 줄어들지 않고 scroll content만 길어져, wheel scroll은 가능하지만 focused field가 자동으로 reveal되지 않았음
- 반투명한 키보드 뒤까지 sheet surface가 이어지는 시각적 구조는 유지하면서, 실제 body viewport에서는 IME 영역을 제외할 필요가 있었음

## 변경

- 공통 bottom inset을 body scroll content 밖으로 이동
    - sheet surface는 기존처럼 IME 뒤까지 이어짐
    - body viewport는 `max(navigationBars, IME)`만큼 줄어들어 focused field가 자동으로 reveal됨
    - header와 footer는 고정하고 body만 scroll
- 공통 bottom inset을 직접 관리하는지 나타내도록 `includeImeBottomInset`을 `includeBottomInset`으로 정리
    - 일반 sheet는 기본값을 사용
    - Comments와 Related Notes는 자체 safe area 및 keyboard occlusion 계산을 사용하므로 공통 inset을 제외
    - 인풋과 IME가 없는 Table Axis Actions의 별도 설정은 제거
- Create Space sheet가 기본 body scroll 동작을 사용하도록 변경
- Icon Picker의 중복 safe drawing bottom padding 제거
- 다음 동작을 검증하는 Desktop Compose 테스트 추가
    - IME 뒤까지 이어지는 sheet surface와 IME를 제외하는 body viewport
    - callsite가 bottom inset을 직접 관리하는 경우
    - IME가 늦게 나타나도 focused field 자동 reveal
    - 고정 header/footer와 body scroll
    - 이미 보이는 짧은 sheet에서는 불필요하게 scroll하지 않음