### PR TITLE
앱 토스트 Notification 타입 아이콘 배경색 수정

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/toast/ToastOverlay.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/toast/ToastOverlay.kt
@@ -183,7 +183,7 @@ private fun AnimatedToast(
                     when (type) {
                       ToastType.Success -> AppTheme.colors.success
                       ToastType.Error -> AppTheme.colors.danger
-                      else -> AppTheme.colors.textDefault
+                      else -> AppTheme.colors.palette.blue
                     },
                     AppShapes.circle,
                   ),


### PR DESCRIPTION
대비가 너무 낮아서 palette.blue로 수정함 (처음에는 brand였다가 textDefault로 대체되었었음)