### PR TITLE
앱 렌더 싱크 오류 전수 수정

### DIFF
--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/input/EditorInputConnection.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/input/EditorInputConnection.kt
@@ -232,7 +232,7 @@ internal class EditorInputConnection(
 
   override fun finishComposingText(): Boolean {
     recordCall("finishComposingText", "")
-    batch.finishComposingText(hasActiveComposition = editor.ime?.composing != null)
+    batch.finishComposingText(hasActiveComposition = editor.tickIme?.composing != null)
     return true
   }
 
@@ -301,7 +301,7 @@ internal class EditorInputConnection(
   override fun closeConnection() {
     recordCall("closeConnection", "")
     extractMonitor.token = null
-    batch.closeConnection(hasActiveComposition = editor.ime?.composing != null)
+    batch.closeConnection(hasActiveComposition = editor.tickIme?.composing != null)
   }
 
   override fun commitContent(

--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/render/RenderCanvas.android.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/render/RenderCanvas.android.kt
@@ -32,6 +32,7 @@ internal actual fun RenderCanvas(
   onDetach: (releaseBuffer: () -> Unit) -> Unit,
   onResize: () -> Unit,
   onFrame: (bitmap: ImageBitmap, pixelSize: IntSize, version: Long) -> Unit,
+  onFrameSkipped: (version: Long) -> Unit,
 ) {
   var bufferHandle by remember { mutableLongStateOf(0L) }
 
@@ -39,6 +40,7 @@ internal actual fun RenderCanvas(
   val currentOnDetach by rememberUpdatedState(onDetach)
   val currentOnResize by rememberUpdatedState(onResize)
   val currentOnFrame by rememberUpdatedState(onFrame)
+  val currentOnFrameSkipped by rememberUpdatedState(onFrameSkipped)
 
   LaunchedEffect(desiredPixelSize, configuration) {
     if (desiredPixelSize.width <= 0 || desiredPixelSize.height <= 0) return@LaunchedEffect
@@ -71,16 +73,29 @@ internal actual fun RenderCanvas(
 
     var cachedWidth = 0
     var cachedHeight = 0
-    var cachedAndroidBitmap: Bitmap? = null
+    // Ping-pong across three backings: a delivered frame's pixels must stay immutable
+    // for as long as the presentation gate can still show it (the pending store keeps
+    // up to two frames per size, plus the currently applied one). Reusing a single
+    // bitmap would overwrite on-screen pixels in place, moving content ahead of the
+    // publish invisibly to the gate.
+    val cachedBitmaps = arrayOfNulls<Bitmap>(3)
+    var cachedIndex = 0
 
     trigger.conflate().collect { version ->
-      if (!RenderBuffer.beginRead(handle)) return@collect
+      if (!RenderBuffer.beginRead(handle)) {
+        // An earlier read already consumed the commit behind this present — its pixels
+        // were in the slot that read pinned — so no frame will arrive for this version.
+        // It must still settle, or a publish parked on it would sit until the watchdog.
+        currentOnFrameSkipped(version)
+        return@collect
+      }
 
       val w = RenderBuffer.getPixelWidth(handle)
       val h = RenderBuffer.getPixelHeight(handle)
       val dataAddr = RenderBuffer.getDataPointer(handle)
       if (w <= 0 || h <= 0 || dataAddr == 0L) {
         RenderBuffer.endRead(handle)
+        currentOnFrameSkipped(version)
         return@collect
       }
 
@@ -88,16 +103,19 @@ internal actual fun RenderCanvas(
       // premultiplied by default. This matches CpuSink::read_back_rect_absolute's
       // premultiplied RGBA8 output, so copyPixelsFromBuffer is a direct memcpy with
       // no channel swap or un-premultiplication.
+      if (cachedWidth != w || cachedHeight != h) {
+        cachedBitmaps.fill(null)
+        cachedIndex = 0
+        cachedWidth = w
+        cachedHeight = h
+      }
       val androidBitmap =
-        cachedAndroidBitmap?.takeIf { cachedWidth == w && cachedHeight == h }
-          ?: createBitmap(w, h).also {
-            cachedAndroidBitmap = it
-            cachedWidth = w
-            cachedHeight = h
-          }
+        cachedBitmaps[cachedIndex] ?: createBitmap(w, h).also { cachedBitmaps[cachedIndex] = it }
+      cachedIndex = (cachedIndex + 1) % cachedBitmaps.size
       val byteCount = androidBitmap.byteCount.toLong()
       if (byteCount != w.toLong() * h * 4) {
         RenderBuffer.endRead(handle)
+        currentOnFrameSkipped(version)
         return@collect
       }
       androidBitmap.copyPixelsFromBuffer(Pointer(dataAddr).getByteBuffer(0, byteCount))

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Editor.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Editor.kt
@@ -44,6 +44,7 @@ import co.typie.editor.sync.SplitChangeset
 import co.typie.editor.sync.encodeLengthPrefixedBlobs
 import co.typie.editor.sync.toChangesetBytes
 import co.typie.platform.PlatformModule
+import io.sentry.kotlin.multiplatform.Sentry
 import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.concurrent.atomics.AtomicLong
 import kotlin.concurrent.atomics.AtomicReference
@@ -62,6 +63,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -70,6 +72,8 @@ import kotlinx.coroutines.withContext
 // state; consumers resolve absolute offsets through Ime.windowStart, so a bounded
 // window only limits how much surrounding text the IME can observe.
 private const val IME_SNAPSHOT_WINDOW = 4096
+
+private const val PARKED_PUBLISH_WATCHDOG_MS = 1000L
 
 private data class EditorAwaitTick<T>(
   val events: List<EditorEvent>,
@@ -104,6 +108,7 @@ internal constructor(
   val placeholder: PlaceholderMetrics? by derivedStateOf { state.placeholder }
   val selection: Selection? by derivedStateOf { state.selection }
   val tickIme: Ime? by derivedStateOf { tickSnapshot.ime }
+  val tickSelection: Selection? by derivedStateOf { tickSnapshot.selection }
   val tickSelectionEndpoints: SelectionEndpoints? by derivedStateOf {
     tickSnapshot.selectionEndpoints
   }
@@ -119,6 +124,7 @@ internal constructor(
 
   private val mutex = PriorityMutex()
   private val versionCounter: AtomicLong = AtomicLong(0L)
+  private val tickStateRef: AtomicReference<EditorState> = AtomicReference(EditorState.Initial)
   private val disposed: AtomicBoolean = AtomicBoolean(false)
   private val imeSessionActive: AtomicBoolean = AtomicBoolean(false)
   private val syncInProgress: AtomicBoolean = AtomicBoolean(false)
@@ -135,7 +141,7 @@ internal constructor(
       inner = inner,
       scope = scope,
       dispatcher = dispatcher,
-      versionCounter = versionCounter,
+      tickState = { tickStateRef.load() },
       disposed = disposed,
       markPageAttached = { page -> attachedPages.updatePersistent { it.adding(page) } },
       markPageDetached = { page -> markSurfacePageDetached(page) },
@@ -329,31 +335,53 @@ internal constructor(
       return
     }
     if (events.any { it is EditorEvent.RenderInvalidated }) {
-      pendingSettles.updatePersistent { list ->
-        list.add(PendingSettle(pages, requiredVersion = snapshot.version, snapshot = snapshot))
-      }
+      parkPublish(PendingSettle(pages, requiredVersion = snapshot.version, snapshot = snapshot))
       return
     }
-    val outstanding = pendingSettles.load().maxOfOrNull { it.requiredVersion }
-    if (outstanding == null) {
+    val ridden = pendingSettles.load().maxByOrNull { it.requiredVersion }
+    if (ridden == null) {
       commit(snapshot)
       return
     }
-    val piggyback = PendingSettle(pages, requiredVersion = outstanding, snapshot = snapshot)
-    pendingSettles.updatePersistent { it.add(piggyback) }
-    val owed = pendingSettles.load().any { it !== piggyback && it.requiredVersion <= outstanding }
-    if (!owed) {
-      // The settle being ridden completed between the read and the add; reclaim and
-      // publish inline. If the settle did catch the piggyback, commit is a stale no-op.
-      var reclaimed = false
-      pendingSettles.updatePersistent { list ->
-        val next = list.remove(piggyback)
-        reclaimed = next !== list
-        next
+    // Attached to the ridden pending instead of parked as its own: a no-render tick has
+    // no frame to wait for, and requiring pages again would orphan it whenever a page
+    // already settled at this version and never renders again.
+    ridden.attachPiggyback(snapshot)
+    if (pendingSettles.load().none { it === ridden }) {
+      // The ridden settle completed between the read and the attach; its release may
+      // have missed the piggyback. Publishing inline is safe — commit is monotonic.
+      commit(snapshot)
+    }
+  }
+
+  // Parks an awaiter-less snapshot on the settle, with a liveness fallback: a settle
+  // can be lost (a frame copy that never lands, a dropped present), and a parked
+  // publish has no owner to notice — without a watchdog the published state would be
+  // locked behind the missing settle forever.
+  private fun parkPublish(pending: PendingSettle) {
+    pendingSettles.updatePersistent { it.add(pending) }
+    scope.launch(dispatcher) {
+      delay(PARKED_PUBLISH_WATCHDOG_MS)
+      if (pendingSettles.load().none { it === pending }) return@launch
+      // Telemetry only — the force publish below recovers the editor, so this must not
+      // go through notifyFailure, which fails the runtime and tears the session down.
+      val error =
+        IllegalStateException(
+          "parked publish watchdog: settle for version ${pending.requiredVersion} never arrived"
+        )
+      Logger.e(error) {
+        "parked publish watchdog v=${pending.requiredVersion}" +
+          " remaining=${pending.remainingPages()}" +
+          " counter=${versionCounter.load()} state=${state.version}" +
+          " attached=${attachedPages.load()}" +
+          " pendings=${
+            pendingSettles.load().map {
+              "${it.requiredVersion}:${it.remainingPages()}:effective=${it.effectiveVersion()}"
+            }
+          }"
       }
-      if (reclaimed) {
-        commit(snapshot)
-      }
+      Sentry.captureException(error)
+      releaseCompletedSettles(listOf(pending))
     }
   }
 
@@ -581,15 +609,17 @@ internal constructor(
   private fun releaseCompletedSettles(completed: List<PendingSettle>) {
     if (completed.isEmpty()) return
     pendingSettles.updatePersistent { list -> list.removeAll(completed) }
-    // Piggybacked snapshots share a requiredVersion with the settle they ride, so the
-    // newest is decided by the snapshot version they would publish.
-    val newest = completed.maxBy { it.snapshot?.version ?: it.requiredVersion }
+    // The newest is decided by the snapshot each settle would publish, which includes
+    // any piggybacked no-render snapshot riding it.
+    val newest = completed.maxBy { it.effectiveVersion() }
     completed.forEach { pending ->
       pending.supersededByNewerSettle = pending !== newest
       pending.release()
     }
-    // Awaiter-less pendings (deferred sync publishes) have no coroutine to commit them.
-    val deferred = newest.snapshot ?: return
+    // Awaiter-less snapshots (deferred sync publishes and piggybacks) have no coroutine
+    // to commit them. An awaiter pending still commits its own snapshot on resume;
+    // commit is monotonic, so the pair cannot regress the published state.
+    val deferred = newest.effectiveSnapshot() ?: return
     scope.launch(dispatcher) {
       mutex.withLock {
         if (!disposed.load()) {
@@ -879,6 +909,10 @@ internal constructor(
         interactiveRegions = interactiveRegions,
       )
     tickSnapshot = snapshot
+    // Plain atomic mirror for non-composition readers: the surface scheduler runs on its
+    // own thread, where a Compose snapshot-state read is not a sound publication
+    // primitive (visibility rides the global snapshot's apply cadence).
+    tickStateRef.store(snapshot)
     return snapshot
   }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorSurfaceScheduler.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorSurfaceScheduler.kt
@@ -90,7 +90,7 @@ internal class EditorSurfaceScheduler(
   private val inner: FfiEditor,
   private val scope: CoroutineScope,
   private val dispatcher: CoroutineDispatcher,
-  private val versionCounter: AtomicLong,
+  private val tickState: () -> EditorState,
   private val disposed: AtomicBoolean,
   private val markPageAttached: (Int) -> Unit,
   private val markPageDetached: (Int) -> Unit,
@@ -360,7 +360,13 @@ internal class EditorSurfaceScheduler(
     // Logical page geometry is owned by the engine and can advance ahead of any requested
     // configuration; the surface must match it before a frame is produced, or a presented
     // frame would be laid out for a different target size. The UI only owns scaleFactor.
-    val pageSize = inner.pageSizes().getOrNull(command.page)
+    // The stamp and the geometry come from the tick snapshot — a single immutable object
+    // published atomically per tick — because reading the counter and the live geometry
+    // separately can never agree under concurrent ticks (the engine state advances before
+    // the counter does).
+    val tick = tickState()
+    val version = tick.version
+    val pageSize = tick.pageSizes.getOrNull(command.page)
     val target =
       if (pageSize == null) {
         requested
@@ -378,9 +384,9 @@ internal class EditorSurfaceScheduler(
       }
     }
 
-    // Reading the version before rendering under-reports what the frame may contain,
-    // which only delays a settle until the follow-up render command.
-    val version = versionCounter.load()
+    // The stamp was read together with the geometry above. The render below may contain
+    // a newer tick than the stamp — under-reporting only delays a settle until the
+    // follow-up render command, while the frame stays sized for the stamped version.
     val presented = inner.renderSurface(command.page)
 
     if (!isActive(command.page, command.sessionId)) return
@@ -433,7 +439,7 @@ internal class EditorSurfaceScheduler(
           markPageDetached(command.page)
         }
       }
-      is SurfaceRenderCommand -> onPageSettled(command.page, versionCounter.load())
+      is SurfaceRenderCommand -> onPageSettled(command.page, tickState().version)
       is SurfaceDetachCommand -> Unit
     }
   }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorView.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorView.kt
@@ -206,6 +206,7 @@ internal fun EditorView(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(pageSpacing),
       ) {
+        val publishedVersion = editor.state.version
         editor.pageSizes.forEachIndexed { index, size ->
           val pageCursor = editor.cursor?.takeIf { sessionActive && it.pageIdx == index }
           val pageExternalElements =
@@ -215,6 +216,7 @@ internal fun EditorView(
             page = index,
             width = size.width,
             height = size.height,
+            publishedVersion = publishedVersion,
             showChrome = showPageChrome,
             debugBottomMarginHeight =
               when (layoutSpec) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/PendingSettle.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/PendingSettle.kt
@@ -16,8 +16,37 @@ internal class PendingSettle(
     AtomicReference(pages.toPersistentSet())
   private val signal: CompletableDeferred<Unit> = CompletableDeferred()
 
+  // A newer snapshot from a tick that did not invalidate rendering, riding this settle
+  // instead of demanding its own: such a tick has no frame of its own to wait for, and
+  // requiring pages again would orphan it whenever a page already settled at this
+  // version and never renders again.
+  private val piggyback: AtomicReference<EditorState?> = AtomicReference(null)
+
   // Must be assigned before release(); read by the awaiter only after await() resumes.
   var supersededByNewerSettle: Boolean = false
+
+  fun remainingPages(): Set<Int> = remaining.load()
+
+  fun attachPiggyback(snapshot: EditorState) {
+    while (true) {
+      val current = piggyback.load()
+      if (current != null && current.version >= snapshot.version) return
+      if (piggyback.compareAndSet(current, snapshot)) return
+    }
+  }
+
+  fun effectiveSnapshot(): EditorState? {
+    val ridden = piggyback.load()
+    val own = snapshot
+    return when {
+      ridden == null -> own
+      own == null -> ridden
+      ridden.version >= own.version -> ridden
+      else -> own
+    }
+  }
+
+  fun effectiveVersion(): Long = effectiveSnapshot()?.version ?: requiredVersion
 
   fun markCommitted(page: Int, version: Long): Boolean {
     if (version < requiredVersion) return false

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/body/EditorBody.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/body/EditorBody.kt
@@ -71,12 +71,13 @@ internal fun EditorBody(
       .trackEditorInteractionSurfaceBounds(uiState = uiState, density = density.density)
       .run {
         if (layoutSpec is EditorDocumentLayoutSpec.Continuous) {
+          val pageSizes = editor?.pageSizes.orEmpty()
           editorExtensionAreaLineHighlight(
-            cursor = { editor?.cursor },
-            focused = { uiState.focused },
+            cursor = editor?.cursor,
+            focused = uiState.focused,
             editorBounds = { uiState.editorBoundsInContainer },
-            viewportTransform = { uiState.resolveViewportTransform(editor?.pageSizes.orEmpty()) },
-            enabled = { Preference.lineHighlightEnabled },
+            viewportTransform = { uiState.resolveViewportTransform(pageSizes) },
+            enabled = Preference.lineHighlightEnabled,
             color = AppTheme.colors.surfaceInset.copy(alpha = 0.55f),
           )
         } else {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorInput.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorInput.kt
@@ -385,7 +385,7 @@ internal class EditorInputNode(
   private val textInputClient =
     object : TextInputClient {
       override val hasActiveComposition: Boolean
-        get() = editor.ime?.composing != null
+        get() = editor.tickIme?.composing != null
 
       override fun requestFocus() {
         editor.focus()
@@ -393,7 +393,7 @@ internal class EditorInputNode(
 
       override fun insertText(text: String): Boolean {
         recordToolbarInput("insertText", text)
-        dispatch(toolbarInsertTextMessages(text, editor.ime?.composing != null))
+        dispatch(toolbarInsertTextMessages(text, editor.tickIme?.composing != null))
         return true
       }
 
@@ -464,7 +464,7 @@ internal class EditorInputNode(
     if (!enabled || event.type != KeyEventType.KeyDown) return false
     val binding = bindings.find { matchesKeyBinding(it, platform, event) }
     if (binding != null) {
-      val composing = editor.ime?.composing != null
+      val composing = editor.tickIme?.composing != null
       if (composing && !commitsCompositionBeforeKeyBinding(platform, event.key)) {
         recordHardwareKey(
           event = event,
@@ -513,7 +513,7 @@ internal class EditorInputNode(
             (((cp - 0x10000) and 0x3FF) + 0xDC00).toChar(),
           )
           .concatToString()
-      if (editor.ime?.composing != null) {
+      if (editor.tickIme?.composing != null) {
         recordHardwareKey(
           event = event,
           stage = "onKeyEvent",
@@ -539,7 +539,7 @@ internal class EditorInputNode(
     val ch = cp.toChar()
     if (!ch.isDefined() || ch.isISOControl() || ch.isSurrogate()) return false
 
-    if (editor.ime?.composing != null) {
+    if (editor.tickIme?.composing != null) {
       recordHardwareKey(
         event = event,
         stage = "onKeyEvent",
@@ -565,7 +565,9 @@ internal class EditorInputNode(
   override fun onPreKeyEvent(event: KeyEvent): Boolean {
     if (!enabled || event.type != KeyEventType.KeyDown) return false
     val binding = bindings.find { matchesKeyBinding(it, platform, event) } ?: return false
-    if (editor.ime?.composing != null && !commitsCompositionBeforeKeyBinding(platform, event.key)) {
+    if (
+      editor.tickIme?.composing != null && !commitsCompositionBeforeKeyBinding(platform, event.key)
+    ) {
       recordHardwareKey(
         event = event,
         stage = "onPreKeyEvent",
@@ -699,7 +701,13 @@ internal class EditorInputNode(
                 // emission is already handled above.
                 snapshotFlow {
                   EditorImeNotifyKey(
+                    // Both selection views on purpose: tickSelection fires the
+                    // notification the moment a tick moves the selection (push-based
+                    // IMEs must see the latest state regardless of the render cycle),
+                    // while the published selection re-fires after a parked publish
+                    // lands so pull-based sessions re-read the committed state.
                     selection = editor.selection,
+                    tickSelection = editor.tickSelection,
                     cursor = editor.cursor,
                     ime = editor.tickIme,
                     paused = editor.imeNotificationsPaused,
@@ -740,6 +748,7 @@ internal class EditorInputNode(
 
 internal data class EditorImeNotifyKey(
   val selection: Selection?,
+  val tickSelection: Selection?,
   val cursor: CursorMetrics?,
   val ime: Ime?,
   val paused: Boolean,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/overlay/LineHighlight.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/overlay/LineHighlight.kt
@@ -65,16 +65,22 @@ internal fun EditorLineHighlightOverlay(
   Box(Modifier.editorOverlayRect(rect).background(AppTheme.colors.surfaceInset.copy(alpha = 0.55f)))
 }
 
+// Mixed read timing on purpose. The cursor is a composition-captured value so the
+// highlight moves in the same recomposition wave as the page frames and overlays — a
+// draw-phase read would observe a background-thread publish one frame ahead of them and
+// flash one line off. The bounds and the viewport transform stay draw-phase reads: they
+// come from post-layout position trackers, and capturing them in composition would lag
+// layout-driven movement (zoom, relayout) by a frame.
 internal fun Modifier.editorExtensionAreaLineHighlight(
-  cursor: () -> CursorMetrics?,
-  focused: () -> Boolean,
+  cursor: CursorMetrics?,
+  focused: Boolean,
   editorBounds: () -> EditorBoundsInContainer,
   viewportTransform: () -> EditorViewportTransform,
-  enabled: () -> Boolean,
+  enabled: Boolean,
   color: Color,
 ): Modifier = drawBehind {
-  if (!enabled() || !focused()) return@drawBehind
-  val currentCursor = cursor() ?: return@drawBehind
+  if (!enabled || !focused) return@drawBehind
+  val currentCursor = cursor ?: return@drawBehind
   val band =
     resolveEditorExtensionAreaLineHighlightBand(
       cursor = currentCursor,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/preview/EditorPreview.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/preview/EditorPreview.kt
@@ -308,11 +308,13 @@ private fun EditorPreviewContent(
     pageSpacing = pageSpacing,
     modifier = Modifier.fillMaxSize().clipToBounds().background(pageBackground),
   ) {
+    val publishedVersion = editor?.state?.version ?: 0L
     pageSizes.forEachIndexed { index, size ->
       EditorPageSurface(
         page = index,
         width = size.width,
         height = size.height,
+        publishedVersion = publishedVersion,
         showChrome = layoutSpec is EditorDocumentLayoutSpec.Paginated,
         debugBottomMarginHeight =
           when (layoutSpec) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/render/RenderCanvas.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/render/RenderCanvas.kt
@@ -18,6 +18,7 @@ internal expect fun RenderCanvas(
   onDetach: (releaseBuffer: () -> Unit) -> Unit,
   onResize: () -> Unit,
   onFrame: (bitmap: ImageBitmap, pixelSize: IntSize, version: Long) -> Unit,
+  onFrameSkipped: (version: Long) -> Unit,
 )
 
 internal expect fun readNativeInts(srcAddr: Long, count: Int): IntArray

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/surface/EditorPageSurface.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/surface/EditorPageSurface.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -28,6 +27,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import co.touchlab.kermit.Logger
 import co.typie.editor.LocalEditorZoomController
 import co.typie.editor.SurfaceConfiguration
 import co.typie.editor.SurfaceSessionHandle
@@ -46,6 +46,7 @@ private val DebugPageBoundaryTint = Color(0xE6FF3B30)
 private val DebugPageBoundaryThickness = 2.dp
 private val DebugFrameSizeMismatchTint = Color(0x99FF9500)
 private val DebugMissingFrameTint = Color(0x990066FF)
+private val DebugFrameAheadTint = Color(0x9930D158)
 
 private data class PresentedFrame(
   val bitmap: ImageBitmap,
@@ -58,11 +59,16 @@ private class AppliedFrameHolder {
   var frame: PresentedFrame? = null
 }
 
+private class DebugMismatchLogHolder {
+  var lastKey: String? = null
+}
+
 @Composable
 internal fun EditorPageSurface(
   page: Int,
   width: Float,
   height: Float,
+  publishedVersion: Long,
   showChrome: Boolean,
   debugBottomMarginHeight: Float = 0f,
   showDebugOverlay: Boolean = false,
@@ -99,18 +105,26 @@ internal fun EditorPageSurface(
       width = round(configuration.width * configuration.scaleFactor).toInt().coerceAtLeast(1),
       height = round(configuration.height * configuration.scaleFactor).toInt().coerceAtLeast(1),
     )
-  val pendingFrameState = remember(editor, page) { mutableStateOf<PresentedFrame?>(null) }
+  val pendingFramesState = remember(editor, page) { mutableStateOf(emptyList<PresentedFrame>()) }
   val appliedFrameHolder = remember(editor, page) { AppliedFrameHolder() }
-  // A committed frame becomes visible only once the editor state containing its tick has
-  // been published, so the page box, overlays, and pixels always change in the same
-  // composition. Until then the previously applied frame keeps being shown.
+  val debugMismatchLog = remember(editor, page) { DebugMismatchLogHolder() }
+  val debugAheadLog = remember(editor, page) { DebugMismatchLogHolder() }
+  // A committed frame becomes visible only once the page box and the published state
+  // agree with it. Both conditions compare against values derived from this
+  // composition's own parameters — the geometry from width/height and the version from
+  // publishedVersion — so pixels, box, overlays, and the caret-reveal scroll can only
+  // ever change together. Reading the editor state directly here instead would race:
+  // the publish lands on a background thread, and a frame-delivery recomposition can
+  // observe the new version before the parent's parameter propagation. Without the
+  // version condition, a same-size frame would apply at delivery and move its content
+  // one edit ahead of the publish (and of the reveal scroll that lands with it).
+  // The last frame of each recent size is retained: under rapid edits the next frame can
+  // arrive before the composition for the previous publish runs, and a single slot would
+  // lose the frame the current box needs.
   val frame =
-    remember(editor, page) {
-        derivedStateOf {
-          pendingFrameState.value?.takeIf { it.version <= editor.state.version }
-        }
-      }
-      .value ?: appliedFrameHolder.frame
+    pendingFramesState.value.firstOrNull {
+      it.pixelSize == desiredPixelSize && it.version <= publishedVersion
+    } ?: appliedFrameHolder.frame
   appliedFrameHolder.frame = frame
   val committedPixelSize = frame?.pixelSize ?: desiredPixelSize
   val committedRenderZoom = frame?.renderZoom ?: renderZoom
@@ -158,12 +172,43 @@ internal fun EditorPageSurface(
         }
         // Composition-consistency probes: a frame where the shown pixels do not match the
         // published page geometry flashes orange; a frame with no pixels at all flashes
-        // magenta. If the user-visible flicker happens with neither, the composition is
-        // consistent and the presented pixel content itself is wrong.
-        if (frame == null) {
+        // magenta. Render-gated pages draw no canvas at all, so their retained frame
+        // reference is not a visible mismatch.
+        if (!renderActive) {
+          debugMismatchLog.lastKey = null
+        } else if (frame == null) {
           drawRect(DebugMissingFrameTint)
         } else if (frame.pixelSize != desiredPixelSize) {
+          val key = "${frame.version}:${frame.pixelSize}:$desiredPixelSize"
+          if (debugMismatchLog.lastKey != key) {
+            debugMismatchLog.lastKey = key
+            Logger.i {
+              "[settle-trace] ORANGE page=$page frame=${frame.pixelSize} frameV=${frame.version}" +
+                " desired=$desiredPixelSize stateV=${editor.state.version}" +
+                " param=${width}x$height sf=$scaleFactor renderZoom=$renderZoom"
+            }
+          }
           drawRect(DebugFrameSizeMismatchTint)
+        } else if (debugMismatchLog.lastKey != null) {
+          debugMismatchLog.lastKey = null
+          Logger.i { "[settle-trace] ORANGE-CLEAR page=$page frameV=${frame.version}" }
+        }
+        // Content-ahead probe: the applied frame's tick is newer than the published
+        // version this composition was built with — structurally impossible with the
+        // version condition in the gate; kept as a tripwire.
+        if (renderActive && frame != null && frame.version > publishedVersion) {
+          val key = "${frame.version}:$publishedVersion"
+          if (debugAheadLog.lastKey != key) {
+            debugAheadLog.lastKey = key
+            Logger.i {
+              "[settle-trace] EARLY page=$page frameV=${frame.version}" +
+                " publishedV=$publishedVersion size=${frame.pixelSize}"
+            }
+          }
+          drawRect(DebugFrameAheadTint)
+        } else if (debugAheadLog.lastKey != null) {
+          debugAheadLog.lastKey = null
+          Logger.i { "[settle-trace] EARLY-CLEAR page=$page" }
         }
         val boundaryPx = DebugPageBoundaryThickness.toPx()
         drawRect(
@@ -216,15 +261,24 @@ internal fun EditorPageSurface(
             },
             onResize = { surfaceSession?.requestResize(configuration, onPresented) },
             onFrame = { bitmap, size, version ->
-              pendingFrameState.value =
+              val next =
                 PresentedFrame(
                   bitmap = bitmap,
                   pixelSize = size,
                   renderZoom = currentRenderZoom,
                   version = version,
                 )
+              // Two frames per size: at publish time the qualifying frame is the one
+              // whose version the publish covers, which a newest-only rule would have
+              // already replaced when the next same-size frame landed first.
+              val existing = pendingFramesState.value
+              pendingFramesState.value =
+                listOf(next) +
+                  existing.filter { it.pixelSize == size }.take(1) +
+                  existing.filter { it.pixelSize != size }.take(2)
               editor.onPageSettled(page, version)
             },
+            onFrameSkipped = { version -> editor.onPageSettled(page, version) },
           )
         }
       ) { measurables, _ ->

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorAwaitTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorAwaitTest.kt
@@ -984,7 +984,7 @@ class EditorAwaitTest {
       editor.attachSurface(page = 0, handle = 0L, width = 0.0, height = 0.0, scaleFactor = 1.0)
 
       editor.sync { enqueue(sampleMessage) }
-      dispatcher.scheduler.advanceUntilIdle()
+      dispatcher.scheduler.runCurrent()
       assertEquals(0L, editor.state.version)
 
       editor.onPageSettled(page = 0, version = 1L)
@@ -1001,7 +1001,7 @@ class EditorAwaitTest {
 
       editor.sync { enqueue(sampleMessage) }
       val job = launch(dispatcher) { editor.await { enqueue(sampleMessage) } }
-      dispatcher.scheduler.advanceUntilIdle()
+      dispatcher.scheduler.runCurrent()
       assertEquals(0L, editor.state.version)
 
       editor.onPageSettled(page = 0, version = 2L)
@@ -1018,7 +1018,7 @@ class EditorAwaitTest {
       editor.attachSurface(page = 0, handle = 0L, width = 0.0, height = 0.0, scaleFactor = 1.0)
 
       editor.enqueue(sampleMessage)
-      dispatcher.scheduler.advanceUntilIdle()
+      dispatcher.scheduler.runCurrent()
       assertEquals(1, fake.tickCount)
       assertEquals(0L, editor.state.version)
 
@@ -1058,13 +1058,62 @@ class EditorAwaitTest {
 
       editor.sync { enqueue(sampleMessage) }
       editor.sync { enqueue(sampleMessage) }
-      dispatcher.scheduler.advanceUntilIdle()
+      dispatcher.scheduler.runCurrent()
       assertEquals(0L, editor.state.version)
 
       // The settle owed for version 1 also publishes the ridden version 2 snapshot.
       editor.onPageSettled(page = 0, version = 1L)
       dispatcher.scheduler.advanceUntilIdle()
       assertEquals(2L, editor.state.version)
+    }
+
+  @Test
+  fun no_render_tick_rides_a_partially_settled_outstanding_settle() =
+    runTest(dispatcher) {
+      val events =
+        ArrayDeque(
+          listOf(
+            listOf(renderInvalidated()),
+            listOf(EditorEvent.StateChanged(listOf(StateField.Cursor))),
+          )
+        )
+      val fake = FakeFfiEditor(onTick = { events.removeFirst() })
+      val editor = Editor(fake, this, dispatcher)
+      editor.attachSurface(page = 0, handle = 0L, width = 0.0, height = 0.0, scaleFactor = 1.0)
+      editor.attachSurface(page = 1, handle = 1L, width = 0.0, height = 0.0, scaleFactor = 1.0)
+
+      editor.sync { enqueue(sampleMessage) }
+      // Page 0 settles before the no-render tick arrives; it will never settle again.
+      editor.onPageSettled(page = 0, version = 1L)
+      dispatcher.scheduler.runCurrent()
+      editor.sync { enqueue(sampleMessage) }
+      dispatcher.scheduler.runCurrent()
+      assertEquals(0L, editor.state.version)
+
+      // Completing the ridden settle must publish the piggybacked snapshot without
+      // demanding another settle from page 0 (and without the watchdog).
+      editor.onPageSettled(page = 1, version = 1L)
+      dispatcher.scheduler.runCurrent()
+      assertEquals(2L, editor.state.version)
+    }
+
+  @Test
+  fun parked_publish_watchdog_force_publishes_when_settle_is_lost() =
+    runTest(dispatcher) {
+      val fake = FakeFfiEditor(onTick = { listOf(renderInvalidated()) })
+      val reported = mutableListOf<Throwable>()
+      val editor = Editor(fake, this, dispatcher, onError = { _, error -> reported += error })
+      editor.attachSurface(page = 0, handle = 0L, width = 0.0, height = 0.0, scaleFactor = 1.0)
+
+      editor.sync { enqueue(sampleMessage) }
+      dispatcher.scheduler.runCurrent()
+      assertEquals(0L, editor.state.version)
+
+      // No settle ever arrives; the watchdog must force the parked publish without
+      // failing the editor (telemetry only, no onError).
+      dispatcher.scheduler.advanceUntilIdle()
+      assertEquals(1L, editor.state.version)
+      assertEquals(emptyList(), reported)
     }
 
   @Test
@@ -1185,7 +1234,7 @@ class EditorAwaitTest {
 
       // The settle for version 1 publishes the awaited snapshot only.
       editor.onPageSettled(0, version = 1L)
-      dispatcher.scheduler.advanceUntilIdle()
+      dispatcher.scheduler.runCurrent()
       assertEquals(cursorA, editor.cursor)
       assertEquals(1L, editor.state.version)
 

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/input/EditorImeNotificationFlowTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/input/EditorImeNotificationFlowTest.kt
@@ -14,6 +14,7 @@ class EditorImeNotificationFlowTest {
     val position = Position(node = "n", offset = offset, affinity = Affinity.Downstream)
     return EditorImeNotifyKey(
       selection = Selection(anchor = position, head = position),
+      tickSelection = Selection(anchor = position, head = position),
       cursor = null,
       ime = null,
       paused = paused,

--- a/apps/mobile/compose/src/desktopMain/kotlin/co/typie/editor/input/EditorInput.desktop.kt
+++ b/apps/mobile/compose/src/desktopMain/kotlin/co/typie/editor/input/EditorInput.desktop.kt
@@ -87,7 +87,9 @@ internal actual suspend fun PlatformTextInputSessionScope.createEditorInputReque
     override val editText: (block: TextEditingScope.() -> Unit) -> Unit = { block ->
       editor.syncWithBringIntoView(bringIntoViewRequests) {
         val batch =
-          EditorDesktopTextEditingBatch(initialHasActiveComposition = editor.ime?.composing != null)
+          EditorDesktopTextEditingBatch(
+            initialHasActiveComposition = editor.tickIme?.composing != null
+          )
         batch.block()
         for (message in batch.drainMessages()) {
           enqueue(message)

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/overlay/LineHighlightDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/overlay/LineHighlightDesktopTest.kt
@@ -41,11 +41,11 @@ class LineHighlightDesktopTest {
                 Modifier.fillMaxWidth()
                   .trackEditorInteractionSurfaceBounds(uiState = uiState, density = 1f)
                   .editorExtensionAreaLineHighlight(
-                    cursor = { cursor },
-                    focused = { true },
+                    cursor = cursor,
+                    focused = true,
                     editorBounds = { uiState.editorBoundsInContainer },
                     viewportTransform = { uiState.resolveViewportTransform() },
-                    enabled = { true },
+                    enabled = true,
                     color = Color.Black,
                   )
             ) {

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorOverlayLayoutSynchronizationDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorOverlayLayoutSynchronizationDesktopTest.kt
@@ -227,11 +227,11 @@ class EditorOverlayLayoutSynchronizationDesktopTest {
             .testTag(RootTag)
             .trackEditorInteractionSurfaceBounds(uiState = uiState, density = 1f)
             .editorExtensionAreaLineHighlight(
-              cursor = { cursor },
-              focused = { true },
+              cursor = cursor,
+              focused = true,
               editorBounds = { uiState.editorBoundsInContainer },
               viewportTransform = { uiState.resolveViewportTransform() },
-              enabled = { true },
+              enabled = true,
               color = LightColors.surfaceInset.copy(alpha = 0.55f),
             )
         ) {

--- a/apps/mobile/compose/src/skikoMain/kotlin/co/typie/editor/render/RenderCanvas.skiko.kt
+++ b/apps/mobile/compose/src/skikoMain/kotlin/co/typie/editor/render/RenderCanvas.skiko.kt
@@ -34,6 +34,7 @@ internal actual fun RenderCanvas(
   onDetach: (releaseBuffer: () -> Unit) -> Unit,
   onResize: () -> Unit,
   onFrame: (bitmap: ImageBitmap, pixelSize: IntSize, version: Long) -> Unit,
+  onFrameSkipped: (version: Long) -> Unit,
 ) {
   var bufferHandle by remember { mutableStateOf(0L) }
 
@@ -41,6 +42,7 @@ internal actual fun RenderCanvas(
   val currentOnDetach by rememberUpdatedState(onDetach)
   val currentOnResize by rememberUpdatedState(onResize)
   val currentOnFrame by rememberUpdatedState(onFrame)
+  val currentOnFrameSkipped by rememberUpdatedState(onFrameSkipped)
 
   LaunchedEffect(desiredPixelSize, configuration) {
     if (desiredPixelSize.width <= 0 || desiredPixelSize.height <= 0) return@LaunchedEffect
@@ -78,12 +80,19 @@ internal actual fun RenderCanvas(
     var readerLastVersion = 0L
 
     trigger.conflate().collect { version ->
-      if (!RenderBuffer.beginRead(handle)) return@collect
+      if (!RenderBuffer.beginRead(handle)) {
+        // An earlier read already consumed the commit behind this present — its pixels
+        // were in the slot that read pinned — so no frame will arrive for this version.
+        // It must still settle, or a publish parked on it would sit until the watchdog.
+        currentOnFrameSkipped(version)
+        return@collect
+      }
 
       val w = RenderBuffer.getPixelWidth(handle)
       val h = RenderBuffer.getPixelHeight(handle)
       if (w <= 0 || h <= 0) {
         RenderBuffer.endRead(handle)
+        currentOnFrameSkipped(version)
         return@collect
       }
 
@@ -97,12 +106,14 @@ internal actual fun RenderCanvas(
             if (!fresh.allocPixels(ImageInfo(w, h, ColorType.RGBA_8888, ColorAlphaType.PREMUL))) {
               fresh.close()
               RenderBuffer.endRead(handle)
+              currentOnFrameSkipped(version)
               return@collect
             }
             val addr = fresh.peekPixels()?.use { it.addr.toLong() } ?: 0L
             if (addr == 0L) {
               fresh.close()
               RenderBuffer.endRead(handle)
+              currentOnFrameSkipped(version)
               return@collect
             }
             cachedSkBitmap = fresh
@@ -141,7 +152,10 @@ internal actual fun RenderCanvas(
       val ok =
         RenderBuffer.readPinnedInto(handle, cachedPixelsAddr, w.toLong() * h * 4, rowFrom, rowTo)
       RenderBuffer.endRead(handle)
-      if (!ok) return@collect
+      if (!ok) {
+        currentOnFrameSkipped(version)
+        return@collect
+      }
 
       skBitmap.notifyPixelsChanged()
       // asComposeImageBitmap() is zero-copy, so Compose may still draw this Bitmap after


### PR DESCRIPTION
- iOS 빌드 383→384 사이에 발생한 "높이 변화 편집(엔터/백스페이스) 시 화면 밀림+깜빡임" 회귀를 규명하는 과정에서, 에디터 렌더 파이프라인 전반의 발행/픽셀 원자성 결함들을 발견하여 함께 봉인함. 최종적으로 iOS·Android 전 시나리오(단발 편집, 백스페이스 홀드, 페이지 경계 통과) 무깜빡임·무회귀 검증 완료.
- 회귀의 발단은 `flushRender`의 "지오메트리 불일치 시 렌더 포기+settle" 가드(#4898)로, 이를 **라이브 지오메트리 reconcile**로 교체: 렌더 직전 엔진의 `pageSizes()` 기준으로 `resizeSurface`를 적용한 뒤 렌더하여, present되는 모든 프레임이 지오메트리 일관성을 갖도록 함.
- 프레임 표시 구조 재설계: `RenderCanvas`는 픽셀 수송(`onFrame`/`onFrameSkipped`)만 담당하고, 표시 정책은 `EditorPageSurface`가 소유. 블릿된 프레임은 pending 슬롯에 대기하다가 게이트 통과 시에만 화면에 적용됨.
- 발행(publish) 게이팅 도입 — `commitOrPark` 단일 관문:
  - `RenderInvalidated`를 유발한 틱의 스냅샷은 settle 완료까지 파킹 후 발행 (박스·오버레이·픽셀이 같은 컴포지션에서 변경).
  - 렌더를 유발하지 않은 틱은 미결 settle에 스냅샷을 편승(`PendingSettle.attachPiggyback`)시켜 추월 발행을 방지.
  - 하나의 settle이 여러 틱을 커버하면(`releaseCompletedSettles`) 최신 스냅샷만 발행하고 중간 버전은 superseded 처리.
  - 의도적 예외: `refreshImeSnapshot`(IME 세션 시작 전 정렬 발행 필수), `EditorPreview`(layout-first 설계, `publishBeforeSettle = true`).
- settle 유실 대비 워치독: 파킹된 발행이 1초 내 settle되지 않으면 강제 발행으로 자가 복구하고 `Sentry`에 `parked publish watchdog` 이슈로 보고 (세션은 유지, 텔레메트리 전용).
- IME 경로 정합: 소프트 키보드 디스패치(`dispatchSync`, Android `EditorInputConnection`)도 파킹 대상에 포함하되, IME 계약("상태는 렌더 사이클과 무관하게 무조건 최신")을 위해 조합 판정·notify 트리거를 `tickIme`/`tickSelection`(tick-즉시 스냅샷) 기반으로 이관. notify 키는 tick·published를 병기하여 push형(Android)과 pull형(iOS) 계약을 모두 충족.
- 스케줄러의 버전 스탬프·지오메트리 원자화: `versionCounter`와 라이브 상태를 따로 읽던 방식(경합 존재)을 폐기하고, 틱이 원자적으로 발행하는 `tickStateRef: AtomicReference<EditorState>` 단일 읽기로 교체. Compose snapshot state는 스레드 간 발행 프리미티브로 사용하지 않음.
- 프레임 적용 게이트를 파라미터 정합 방식으로 확정: 부모(`EditorView`)가 전달하는 `publishedVersion`·`width`/`height`에서 유도한 조건(`pixelSize == desired && version <= publishedVersion`)만 비교하고, 컴포지션에서 전역 state 직접 읽기를 금지 (백그라운드 commit과 파라미터 전파 사이의 1프레임 경합 제거).
- 프레임 슬롯을 크기당 최신 2개(총 4)로 유지하여, 발행 컴포지션 전에 다음 프레임이 도착해도 해당 발행이 요구하는 프레임이 보존되도록 함.
- Android 블릿의 same-size 비트맵 in-place 재사용 제거: 3-버퍼 핑퐁으로 전달된 프레임의 픽셀 불변성을 보장 (표시 중인 backing이 다음 블릿에 덮여 게이트를 우회하던 무색 떨림의 원인). skiko(iOS)는 부분 업로드 최적화 유지.
- 현재 줄 강조(`editorExtensionAreaLineHighlight`) 1줄 깜빡임 수정: `cursor` 등 발행 상태 계열은 컴포지션 캡처로 전환하고, 포지션 트래커 계열(`editorBounds`/`viewportTransform`)은 draw-시점 읽기를 유지 (#4905 줌/리레이아웃 동기화 계약 보존).
- 디버그 도구 추가("페이지 표면 켜기" 게이트): 페이지 경계선·짝/홀 교대 틴트, 합성 일관성 프로브(주황=크기 불일치, 파랑=프레임 부재, 초록=버전 선행) — 향후 동류 회귀의 조기 경보.
- 웹(`apps/website/src/lib/editor-ffi`): 동류 감사에서 발견된 1프레임 창 수정 — `requestSurfaceResize`를 `resizeSurfaceNow`(호출 즉시 동기 resize+render, paint 전 같은 프레임 합류)로 교체, 신규 페이지는 IntersectionObserver 시드를 기다리지 않고 동기 가시성 판정+`flush()`로 첫 페인트부터 콘텐츠 표시.
- 테스트: settle/발행 계약 회귀 테스트 다수 추가 (`EditorAwaitTest` — 파킹·편승·부분 settle·코얼레싱·워치독, `PendingSettleTest` 계약 갱신, LineHighlight·오버레이 동기화 테스트 시그니처 반영).
