### PR TITLE
앱 에디터 typewriter 모드 + IME 열린 경우 스크롤 더 할 수 없는 문제 디버그

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/body/EditorBody.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/body/EditorBody.kt
@@ -130,11 +130,11 @@ internal fun EditorBody(
               )
             }
 
-            if (autoScrollPolicy.bottomSpacerHeight > 0f) {
+            if (autoScrollPolicy.bottomPadding > 0f) {
               Spacer(
                 modifier =
                   Modifier.fillMaxWidth()
-                    .height(autoScrollPolicy.bottomSpacerHeight.dp)
+                    .height(autoScrollPolicy.bottomPadding.dp)
                     .debugBackground(
                       enabled = showDebugBodyOverlay,
                       color = DebugBottomPaddingColor,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorAutoScrollPolicy.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorAutoScrollPolicy.kt
@@ -2,7 +2,6 @@ package co.typie.editor.scroll
 
 import co.typie.editor.VerticalSpan
 import kotlin.math.abs
-import kotlin.math.max
 
 internal const val CursorVisibleMargin = 60f
 private const val TypewriterMinBottomPadding = 48f
@@ -18,7 +17,7 @@ internal data class EditorAutoScrollPolicy(
   val keepVisibleRange: VerticalSpan,
   val targetTop: Float?,
   val targetLineHeight: Float,
-  val bottomSpacerHeight: Float,
+  val bottomPadding: Float,
 ) {
   val targetBottom: Float?
     get() = targetTop?.plus(targetLineHeight)
@@ -26,10 +25,10 @@ internal data class EditorAutoScrollPolicy(
 
 internal fun resolveEditorAutoScrollPolicy(
   visibleArea: EditorVisibleArea,
-  bottomSpacerVisibleArea: EditorVisibleArea = visibleArea,
+  bottomScrollReserveArea: EditorVisibleArea = visibleArea,
   baseBottomSpace: Float = 0f,
   distanceToPagesBottom: Float? = null,
-  pageBottomRevealSpacerHeight: Float = 0f,
+  pageBottomRevealPadding: Float = 0f,
   typewriterEnabled: Boolean = false,
   typewriterPosition: Float = 0.5f,
   targetLineHeight: Float = 0f,
@@ -43,22 +42,22 @@ internal fun resolveEditorAutoScrollPolicy(
       position = resolvedTypewriterPosition,
       targetHeight = resolvedTargetLineHeight,
     )
-  val keepVisibleBottomSpacerHeight =
-    resolveKeepVisibleBottomSpacerHeight(
-      visibleArea = bottomSpacerVisibleArea,
+  val keepVisibleBottomPadding =
+    resolveKeepVisibleBottomPadding(
+      visibleArea = bottomScrollReserveArea,
       baseBottomSpace = baseBottomSpace,
     )
-  val autoScrollPolicyBottomSpacerHeight =
+  val modeBottomPadding =
     if (typewriterEnabled) {
-      resolveTypewriterBottomSpacerHeight(
-        visibleArea = bottomSpacerVisibleArea,
+      resolveTypewriterBottomPadding(
+        visibleArea = bottomScrollReserveArea,
         baseBottomSpace = baseBottomSpace,
         distanceToPagesBottom = distanceToPagesBottom,
         position = resolvedTypewriterPosition,
         targetLineHeight = resolvedTargetLineHeight,
       )
     } else {
-      keepVisibleBottomSpacerHeight
+      keepVisibleBottomPadding
     }
 
   return EditorAutoScrollPolicy(
@@ -69,8 +68,8 @@ internal fun resolveEditorAutoScrollPolicy(
     keepVisibleRange = keepVisibleRange,
     targetTop = targetTop,
     targetLineHeight = resolvedTargetLineHeight,
-    bottomSpacerHeight =
-      max(autoScrollPolicyBottomSpacerHeight, pageBottomRevealSpacerHeight.coerceAtLeast(0f)),
+    bottomPadding =
+      maxOf(keepVisibleBottomPadding, modeBottomPadding, pageBottomRevealPadding.coerceAtLeast(0f)),
   )
 }
 
@@ -178,7 +177,7 @@ private fun resolveKeepVisibleRange(visibleArea: EditorVisibleArea): VerticalSpa
   }
 }
 
-private fun resolveKeepVisibleBottomSpacerHeight(
+private fun resolveKeepVisibleBottomPadding(
   visibleArea: EditorVisibleArea,
   baseBottomSpace: Float,
 ): Float {
@@ -201,7 +200,7 @@ internal fun resolveScrollTargetTop(
   return visibleArea.visibleViewportTop + availableRange * clampedPosition
 }
 
-private fun resolveTypewriterBottomSpacerHeight(
+private fun resolveTypewriterBottomPadding(
   visibleArea: EditorVisibleArea,
   baseBottomSpace: Float,
   distanceToPagesBottom: Float?,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -1301,7 +1301,7 @@ fun EditorScreen(entityId: String) {
       )
     }
     SideEffect { uiState.updateDisplayZoom(displayZoom) }
-    val pageBottomRevealSpacerHeight =
+    val pageBottomRevealPadding =
       when (layoutSpec) {
         is EditorDocumentLayoutSpec.Paginated -> visibleArea.bottomOcclusion
         is EditorDocumentLayoutSpec.Continuous -> 0f
@@ -1332,10 +1332,10 @@ fun EditorScreen(entityId: String) {
     val autoScrollPolicy =
       resolveEditorAutoScrollPolicy(
         visibleArea = visibleArea,
-        bottomSpacerVisibleArea = visibleAreas.bottomSpacer,
+        bottomScrollReserveArea = visibleAreas.bottomScrollReserveArea,
         baseBottomSpace = layoutSpec.resolveBaseBottomSpace(displayZoom),
         distanceToPagesBottom = distanceToPagesBottom,
-        pageBottomRevealSpacerHeight = pageBottomRevealSpacerHeight,
+        pageBottomRevealPadding = pageBottomRevealPadding,
         typewriterEnabled = typewriterEnabled,
         typewriterPosition = typewriterPosition,
         targetLineHeight = typewriterTargetLineHeight,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/state/EditorVisibleAreas.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/state/EditorVisibleAreas.kt
@@ -17,7 +17,7 @@ internal data class EditorVisibleAreas(
   val editor: EditorVisibleArea,
   // 문서 끝까지 스크롤할 때 필요한 하단 여유 공간 계산에 사용하는 영역입니다.
   // 화면에 보이는 오버레이 높이와 스크롤 여유로 확보해야 하는 높이가 다를 수 있습니다.
-  val bottomSpacer: EditorVisibleArea,
+  val bottomScrollReserveArea: EditorVisibleArea,
 )
 
 internal fun EditorScreenState.resolveEditorVisibleAreas(
@@ -41,7 +41,7 @@ internal fun EditorScreenState.resolveEditorVisibleAreas(
       rawEditorInputBottomInset = rawEditorInputBottomInset + overlayOcclusion.bottom,
       rawSubPaneBottomInset = rawSubPaneBottomInset,
     )
-  val bottomSpacer =
+  val bottomScrollReserveArea =
     resolveVisibleArea(
       topInset = topInset + overlayOcclusion.top,
       rawBottomSafeInset = rawBottomSafeInset,
@@ -49,5 +49,9 @@ internal fun EditorScreenState.resolveEditorVisibleAreas(
       rawSubPaneBottomInset = rawSubPaneBottomInset,
     )
 
-  return EditorVisibleAreas(base = base, editor = editor, bottomSpacer = bottomSpacer)
+  return EditorVisibleAreas(
+    base = base,
+    editor = editor,
+    bottomScrollReserveArea = bottomScrollReserveArea,
+  )
 }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorAutoScrollPolicyTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorAutoScrollPolicyTest.kt
@@ -99,7 +99,7 @@ class EditorAutoScrollPolicyTest {
     assertEquals(VerticalSpan(top = 180f, bottom = 740f), policy.keepVisibleRange)
     assertEquals(450f, requireNotNull(policy.targetTop), FloatTolerance)
     assertEquals(470f, requireNotNull(policy.targetBottom), FloatTolerance)
-    assertEquals(140f, policy.bottomSpacerHeight, FloatTolerance)
+    assertEquals(140f, policy.bottomPadding, FloatTolerance)
   }
 
   @Test
@@ -131,7 +131,7 @@ class EditorAutoScrollPolicyTest {
     assertEquals(0.25f, policy.typewriterPosition, FloatTolerance)
     assertEquals(252f, requireNotNull(policy.targetTop), FloatTolerance)
     assertEquals(284f, requireNotNull(policy.targetBottom), FloatTolerance)
-    assertEquals(596f, policy.bottomSpacerHeight, FloatTolerance)
+    assertEquals(596f, policy.bottomPadding, FloatTolerance)
   }
 
   @Test
@@ -140,14 +140,35 @@ class EditorAutoScrollPolicyTest {
       resolveEditorAutoScrollPolicy(
         visibleArea = testVisibleArea(),
         baseBottomSpace = 20f,
-        distanceToPagesBottom = 520f,
+        distanceToPagesBottom = 500f,
         typewriterEnabled = true,
         typewriterPosition = 0.25f,
         targetLineHeight = 32f,
       )
 
     assertEquals(EditorAutoScrollMode.Typewriter, policy.mode)
-    assertEquals(128f, policy.bottomSpacerHeight, FloatTolerance)
+    assertEquals(148f, policy.bottomPadding, FloatTolerance)
+  }
+
+  @Test
+  fun `typewriter bottom padding preserves keep-visible floor above bottom occlusion`() {
+    val policy =
+      resolveEditorAutoScrollPolicy(
+        visibleArea =
+          EditorVisibleArea(
+            viewport = Size(width = 720f, height = 900f),
+            topInset = 80f,
+            bottomOcclusionInset = 400f,
+          ),
+        baseBottomSpace = 20f,
+        distanceToPagesBottom = 1000f,
+        typewriterEnabled = true,
+        typewriterPosition = 0.5f,
+        targetLineHeight = 32f,
+      )
+
+    assertEquals(EditorAutoScrollMode.Typewriter, policy.mode)
+    assertEquals(440f, policy.bottomPadding, FloatTolerance)
   }
 
   @Test
@@ -160,7 +181,7 @@ class EditorAutoScrollPolicyTest {
       )
 
     assertEquals(EditorAutoScrollMode.KeepCursorVisible, policy.mode)
-    assertEquals(20f, policy.bottomSpacerHeight, FloatTolerance)
+    assertEquals(20f, policy.bottomPadding, FloatTolerance)
   }
 
   @Test
@@ -169,15 +190,15 @@ class EditorAutoScrollPolicyTest {
       resolveEditorAutoScrollPolicy(
         visibleArea = testVisibleArea(),
         baseBottomSpace = 180f,
-        pageBottomRevealSpacerHeight = 100f,
+        pageBottomRevealPadding = 100f,
       )
 
     assertEquals(EditorAutoScrollMode.KeepCursorVisible, policy.mode)
-    assertEquals(100f, policy.bottomSpacerHeight, FloatTolerance)
+    assertEquals(100f, policy.bottomPadding, FloatTolerance)
   }
 
   @Test
-  fun `bottom spacer can reserve more space than the currently visible editor area`() {
+  fun `bottom scroll reserve can increase padding beyond the editor visible area`() {
     val policy =
       resolveEditorAutoScrollPolicy(
         visibleArea =
@@ -186,7 +207,7 @@ class EditorAutoScrollPolicyTest {
             topInset = 80f,
             bottomOcclusionInset = 180f,
           ),
-        bottomSpacerVisibleArea =
+        bottomScrollReserveArea =
           EditorVisibleArea(
             viewport = Size(width = 720f, height = 900f),
             topInset = 80f,
@@ -196,7 +217,7 @@ class EditorAutoScrollPolicyTest {
       )
 
     assertEquals(VerticalSpan(top = 140f, bottom = 660f), policy.keepVisibleRange)
-    assertEquals(300f, policy.bottomSpacerHeight, FloatTolerance)
+    assertEquals(300f, policy.bottomPadding, FloatTolerance)
   }
 
   private fun testVisibleArea(): EditorVisibleArea =

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/state/EditorVisibleAreasTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/state/EditorVisibleAreasTest.kt
@@ -31,7 +31,7 @@ class EditorVisibleAreasTest {
     assertEquals(50f, areas.editor.visibleViewportTop)
     assertEquals(180f, areas.editor.bottomOcclusion)
 
-    assertEquals(50f, areas.bottomSpacer.visibleViewportTop)
-    assertEquals(260f, areas.bottomSpacer.bottomOcclusion)
+    assertEquals(50f, areas.bottomScrollReserveArea.visibleViewportTop)
+    assertEquals(260f, areas.bottomScrollReserveArea.bottomOcclusion)
   }
 }


### PR DESCRIPTION
## 배경

- typewriter 모드에서는 선택 위치에 따라 계산한 동적 bottom padding만 최종 스크롤 범위에 반영하고 있었음
- 선택 위치가 문서 끝에서 멀면 padding이 최소값까지 줄어들어, 문서 끝이 IME 뒤에 있어도 더 이상 스크롤할 수 없었음
- typewriter 모드가 꺼진 경우에는 keep-visible padding이 적용되어 재현되지 않았음

## 변경

- 최종 bottom padding을 keep-visible, typewriter, page-bottom reveal padding의 최댓값으로 계산
- 선택 위치에 따른 typewriter padding의 동적 동작은 유지하면서, IME 가림 영역을 반영한 keep-visible 하한을 보장
- `bottomSpacerHeight` 계열 이름을 실제 의미에 맞게 `bottomPadding`, `bottomScrollReserveArea`로 정리
- typewriter 모드에서도 IME 위로 문서 끝을 스크롤할 수 있는지 확인하는 회귀 테스트 추가