### PR TITLE
앱 시트 드래그 중 버벅거리는 현상 수정

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/sheet/AnchoredSheetSurface.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/sheet/AnchoredSheetSurface.kt
@@ -74,7 +74,7 @@ internal fun AnchoredSheetSurface(
   onDismissCancelled: () -> Unit = {},
   onGeometryChanged: (AnchoredSheetGeometry) -> Unit = {},
   onSettledStopChanged: (Int?) -> Unit = {},
-  scrim: @Composable AnchoredSheetSurfaceScope.(alpha: Float) -> Unit = {},
+  scrim: @Composable AnchoredSheetSurfaceScope.(alpha: () -> Float) -> Unit = {},
   content: @Composable AnchoredSheetSurfaceScope.() -> Unit,
 ) {
   BoxWithConstraints(modifier.fillMaxSize()) {
@@ -307,15 +307,12 @@ internal fun AnchoredSheetSurface(
         animationSpec = SheetAnimationSpec,
       )
 
-    val stateOffset = if (anchoredState.offset.isNaN()) containerHeightPx else anchoredState.offset
-    val offset = if (isIntrinsic) stateOffset else stateOffset + offsetCorrection.value
-    val visibleHeight =
-      resolveAnchoredSheetVisibleHeight(
-        containerHeightPx = containerHeightPx,
-        sheetOffsetPx = offset,
-        density = density.density,
-      )
-    val animatedOffsetPx = offset.roundToInt().coerceAtLeast(0)
+    fun currentOffsetPx(): Float {
+      val stateOffset =
+        if (anchoredState.offset.isNaN()) containerHeightPx else anchoredState.offset
+      return if (isIntrinsic) stateOffset else stateOffset + offsetCorrection.value
+    }
+
     val intrinsicTopLimit = intrinsicTopLimitPx.roundToInt()
     val minStopHeightPx =
       (containerHeightPx -
@@ -323,18 +320,37 @@ internal fun AnchoredSheetSurface(
         .roundToInt()
         .coerceAtLeast(0)
     val minVisibleOffset = topVisibleOffset
-    val scrimAlpha =
+
+    LaunchedEffect(
+      anchoredState,
+      offsetCorrection,
+      isIntrinsic,
+      containerHeightPx,
+      density.density,
+    ) {
+      snapshotFlow { currentOffsetPx() }
+        .collect { offset ->
+          onGeometryChangedState.value(
+            AnchoredSheetGeometry(
+              visibleHeight =
+                resolveAnchoredSheetVisibleHeight(
+                  containerHeightPx = containerHeightPx,
+                  sheetOffsetPx = offset,
+                  density = density.density,
+                )
+            )
+          )
+        }
+    }
+
+    scope.scrim {
       if (containerHeightPx > minVisibleOffset) {
-        (1f - (offset - minVisibleOffset) / (containerHeightPx - minVisibleOffset)).coerceIn(0f, 1f)
+        (1f - (currentOffsetPx() - minVisibleOffset) / (containerHeightPx - minVisibleOffset))
+          .coerceIn(0f, 1f)
       } else {
         0f
       }
-
-    LaunchedEffect(visibleHeight) {
-      onGeometryChangedState.value(AnchoredSheetGeometry(visibleHeight = visibleHeight))
     }
-
-    scope.scrim(scrimAlpha)
 
     val sheetModifier =
       Modifier.fillMaxWidth()
@@ -344,12 +360,13 @@ internal fun AnchoredSheetSurface(
             if (isIntrinsic) {
               (constraints.maxHeight - intrinsicTopLimit).coerceAtLeast(0)
             } else {
+              val animatedOffsetPx = currentOffsetPx().roundToInt().coerceAtLeast(0)
               maxOf((constraints.maxHeight - animatedOffsetPx).coerceAtLeast(0), minStopHeightPx)
             }
           val placeable = measurable.measure(constraints.copy(maxHeight = maxH))
           layout(placeable.width, placeable.height) { placeable.place(0, 0) }
         }
-        .offset { IntOffset(x = 0, y = animatedOffsetPx) }
+        .offset { IntOffset(x = 0, y = currentOffsetPx().roundToInt().coerceAtLeast(0)) }
         .thenIf(isIntrinsic) {
           onSizeChanged {
             val measuredHeightPx = it.height.toFloat()

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/sheet/SheetOverlay.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/sheet/SheetOverlay.kt
@@ -67,7 +67,7 @@ private fun SheetEntryOverlay(state: Sheet, entry: SheetEntry<*>) {
     scrim = { scrimAlpha ->
       Box(
         Modifier.fillMaxSize()
-          .graphicsLayer { alpha = scrimAlpha }
+          .graphicsLayer { alpha = scrimAlpha() }
           .background(AppTheme.colors.scrim)
           .clickable { dismiss() }
       )

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/sheet/AnchoredSheetSurfaceDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/sheet/AnchoredSheetSurfaceDesktopTest.kt
@@ -9,8 +9,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.pointerInput
@@ -29,6 +31,39 @@ import kotlin.test.assertTrue
 
 @OptIn(ExperimentalTestApi::class)
 class AnchoredSheetSurfaceDesktopTest {
+  @Test
+  fun dragMotionDoesNotRecomposeStableScrimContent() = runComposeUiTest {
+    var scrimCompositions = 0
+
+    setContent {
+      Box(Modifier.size(width = 400.dp, height = 800.dp)) {
+        AnchoredSheetSurface(
+          stops = listOf(SheetStop.Bottom(240.dp)),
+          stopPolicy = SheetStop.Policy.KeepAll,
+          onDismissed = {},
+          scrim = { alpha ->
+            SideEffect { scrimCompositions += 1 }
+            Box(Modifier.fillMaxSize().graphicsLayer { this.alpha = alpha() })
+          },
+        ) {
+          Box(Modifier.testTag(SheetTag).fillMaxWidth().height(240.dp))
+        }
+      }
+    }
+    waitForIdle()
+    val settledScrimCompositions = scrimCompositions
+
+    onNodeWithTag(SheetTag).performTouchInput {
+      down(center)
+      repeat(5) { moveBy(Offset(0f, 4f), delayMillis = 16) }
+    }
+    waitForIdle()
+
+    assertEquals(settledScrimCompositions, scrimCompositions)
+
+    onNodeWithTag(SheetTag).performTouchInput { up() }
+  }
+
   @Test
   fun intrinsicSheetWithoutScrimAllowsViewportTouchScrollAboveSheet() = runComposeUiTest {
     var viewportScroll = 0f


### PR DESCRIPTION
- 드래그 중 시트 위치를 composition 단계에서 읽어서, 포인터 움직일 때마다 시트 전체가 다시 composition 되고 있었음
- 시트 위치와 높이를 layout/placement 단계에서 갱신
- 배경 scrim 투명도는 draw 단계에서 갱신
- 외부 geometry 알림은 snapshotFlow로 분리