### PR TITLE
앱 타자기 모드 bottom padding을 웹처럼 커서 위치와 무관하게 수정

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorAutoScrollPolicy.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorAutoScrollPolicy.kt
@@ -27,7 +27,6 @@ internal fun resolveEditorAutoScrollPolicy(
   visibleArea: EditorVisibleArea,
   bottomScrollReserveArea: EditorVisibleArea = visibleArea,
   baseBottomSpace: Float = 0f,
-  distanceToPagesBottom: Float? = null,
   pageBottomRevealPadding: Float = 0f,
   typewriterEnabled: Boolean = false,
   typewriterPosition: Float = 0.5f,
@@ -52,7 +51,6 @@ internal fun resolveEditorAutoScrollPolicy(
       resolveTypewriterBottomPadding(
         visibleArea = bottomScrollReserveArea,
         baseBottomSpace = baseBottomSpace,
-        distanceToPagesBottom = distanceToPagesBottom,
         position = resolvedTypewriterPosition,
         targetLineHeight = resolvedTargetLineHeight,
       )
@@ -203,7 +201,6 @@ internal fun resolveScrollTargetTop(
 private fun resolveTypewriterBottomPadding(
   visibleArea: EditorVisibleArea,
   baseBottomSpace: Float,
-  distanceToPagesBottom: Float?,
   position: Float,
   targetLineHeight: Float,
 ): Float {
@@ -213,8 +210,7 @@ private fun resolveTypewriterBottomPadding(
   val availableRange = (usableViewportHeight - clampedTargetLineHeight).coerceAtLeast(0f)
   val spaceNeededBelowTargetTop =
     visibleArea.bottomOcclusion + (1f - position) * availableRange + clampedTargetLineHeight
-  val resolvedDistanceToPagesBottom =
-    distanceToPagesBottom?.coerceAtLeast(0f) ?: (baseBottomSpace + clampedTargetLineHeight)
-  val requiredPadding = spaceNeededBelowTargetTop - resolvedDistanceToPagesBottom
+  val intrinsicSpaceBelowTargetTop = baseBottomSpace + clampedTargetLineHeight
+  val requiredPadding = spaceNeededBelowTargetTop - intrinsicSpaceBelowTargetTop
   return requiredPadding.coerceAtLeast(TypewriterMinBottomPadding)
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorScrollIntent.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorScrollIntent.kt
@@ -6,7 +6,6 @@ import co.typie.editor.body.EditorDocumentLayoutSpec
 import co.typie.editor.ffi.PageRect
 import co.typie.editor.pageRectsToContentRect
 import co.typie.editor.runtime.EditorBoundsInContainer
-import co.typie.editor.runtime.EditorUiState
 
 internal data class EditorScrollFrame(
   val state: EditorState,
@@ -70,33 +69,6 @@ internal fun resolveEditorScrollIntent(
   }
 
   return EditorScrollIntentResult.ScrollTo(targetScroll.coerceAtLeast(0f))
-}
-
-internal fun resolveDistanceToPagesBottom(
-  state: EditorState,
-  layoutSpec: EditorDocumentLayoutSpec,
-  uiState: EditorUiState,
-  headerHeight: Float,
-  pagesContentHeight: Float,
-  target: EditorBringIntoViewTarget,
-  density: Float = 0f,
-): Float? {
-  val editorBounds = uiState.editorBoundsInContainer
-  if (!editorBounds.isValid) {
-    return null
-  }
-  val rect =
-    resolveBringIntoViewTargetRect(
-      state = state,
-      layoutSpec = layoutSpec,
-      headerHeight = headerHeight,
-      editorTopInContainer = editorBounds.y,
-      displayZoom = uiState.displayZoom,
-      density = density,
-      target = target,
-    ) ?: return null
-  val contentBottomInContent = headerHeight + editorBounds.y + pagesContentHeight
-  return (contentBottomInContent - rect.top).coerceAtLeast(0f)
 }
 
 internal fun isEditorScrollTargetVisible(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -58,7 +58,6 @@ import co.typie.editor.body.EditorDocumentLayoutSpec
 import co.typie.editor.body.resolveBaseBottomSpace
 import co.typie.editor.body.resolveEditorBodyGeometry
 import co.typie.editor.body.resolveEditorPageWidth
-import co.typie.editor.body.resolvePagesContentHeight
 import co.typie.editor.body.toEditorDocumentLayoutSpec
 import co.typie.editor.external.EditorExternalElementState
 import co.typie.editor.external.LocalEditorExternalElementState
@@ -91,7 +90,6 @@ import co.typie.editor.scroll.LocalEditorBringIntoViewRequests
 import co.typie.editor.scroll.awaitWithBringIntoView
 import co.typie.editor.scroll.rememberEditorBringIntoViewRequests
 import co.typie.editor.scroll.resolveBringIntoViewTargetHeight
-import co.typie.editor.scroll.resolveDistanceToPagesBottom
 import co.typie.editor.scroll.resolveEditorAutoScrollPolicy
 import co.typie.editor.sync.ActiveDocumentEditingSessions
 import co.typie.editor.sync.ChangesetDeltaStore
@@ -1306,8 +1304,6 @@ fun EditorScreen(entityId: String) {
         is EditorDocumentLayoutSpec.Paginated -> visibleArea.bottomOcclusion
         is EditorDocumentLayoutSpec.Continuous -> 0f
       }
-    val pagesContentHeight =
-      layoutSpec.resolvePagesContentHeight(layoutPageSizes, displayZoom, density = density)
     val bodyGeometry =
       resolveEditorBodyGeometry(
         visibleArea = visibleArea,
@@ -1315,26 +1311,11 @@ fun EditorScreen(entityId: String) {
         pageSizes = layoutPageSizes,
         displayZoom = displayZoom,
       )
-    val distanceToPagesBottom =
-      if (typewriterEnabled && editor != null) {
-        resolveDistanceToPagesBottom(
-          state = editorState,
-          layoutSpec = layoutSpec,
-          uiState = uiState,
-          headerHeight = screenState.headerHeight,
-          pagesContentHeight = pagesContentHeight,
-          target = EditorBringIntoViewTarget.CurrentSelectionHead,
-          density = density,
-        )
-      } else {
-        null
-      }
     val autoScrollPolicy =
       resolveEditorAutoScrollPolicy(
         visibleArea = visibleArea,
         bottomScrollReserveArea = visibleAreas.bottomScrollReserveArea,
         baseBottomSpace = layoutSpec.resolveBaseBottomSpace(displayZoom),
-        distanceToPagesBottom = distanceToPagesBottom,
         pageBottomRevealPadding = pageBottomRevealPadding,
         typewriterEnabled = typewriterEnabled,
         typewriterPosition = typewriterPosition,

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionScopeTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionScopeTest.kt
@@ -100,4 +100,61 @@ class EditorInteractionScopeTest {
       assertEquals(Offset(x = 40f, y = -100f), headerMapped)
       assertTrue(headerMapped.y < 0f, "mapping above the body must stay valid and negative")
     }
+
+  @Test
+  fun `outside-page tap eligibility follows document layout mode`() =
+    runTest(StandardTestDispatcher()) {
+      val uiState =
+        EditorUiState().apply {
+          updateInteractionSurfaceBounds(
+            boundsInRoot = Rect(left = 0f, top = 120f, right = 400f, bottom = 920f),
+            density = 1f,
+          )
+          updateEditorBounds(
+            boundsInRoot = Rect(left = 40f, top = 200f, right = 360f, bottom = 680f),
+            density = 1f,
+          )
+        }
+      val editor = Editor(FakeFfiEditor(), this, StandardTestDispatcher(testScheduler))
+      val scope = EditorInteractionScope(coroutineScope = this)
+      val outsidePagePosition = Offset(x = 80f, y = 800f)
+
+      scope.update(
+        editor = editor,
+        bringIntoViewRequests = EditorBringIntoViewRequests(),
+        uiState = uiState,
+        density = 1f,
+        visibleArea = EditorVisibleArea(),
+        viewportState = EditorViewportState(),
+        scrollGestureLockState = ScrollGestureLockState(),
+        viewportZoomConfig = null,
+        layoutSpec = EditorDocumentLayoutSpec.Continuous(maxWidth = 320f),
+        onSelectionHaptic = {},
+        onRequestSoftwareKeyboard = {},
+      )
+      assertTrue(scope.isTapEligible(outsidePagePosition))
+
+      scope.update(
+        editor = editor,
+        bringIntoViewRequests = EditorBringIntoViewRequests(),
+        uiState = uiState,
+        density = 1f,
+        visibleArea = EditorVisibleArea(),
+        viewportState = EditorViewportState(),
+        scrollGestureLockState = ScrollGestureLockState(),
+        viewportZoomConfig = null,
+        layoutSpec =
+          EditorDocumentLayoutSpec.Paginated(
+            pageWidth = 320f,
+            pageHeight = 480f,
+            pageMarginTop = 20f,
+            pageMarginBottom = 20f,
+            pageMarginLeft = 20f,
+            pageMarginRight = 20f,
+          ),
+        onSelectionHaptic = {},
+        onRequestSoftwareKeyboard = {},
+      )
+      assertFalse(scope.isTapEligible(outsidePagePosition))
+    }
 }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorAutoScrollPolicyTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorAutoScrollPolicyTest.kt
@@ -135,19 +135,18 @@ class EditorAutoScrollPolicyTest {
   }
 
   @Test
-  fun `typewriter bottom padding can use actual space available below the target line top`() {
+  fun `typewriter bottom padding uses intrinsic layout bottom space`() {
     val policy =
       resolveEditorAutoScrollPolicy(
         visibleArea = testVisibleArea(),
         baseBottomSpace = 20f,
-        distanceToPagesBottom = 500f,
         typewriterEnabled = true,
         typewriterPosition = 0.25f,
         targetLineHeight = 32f,
       )
 
     assertEquals(EditorAutoScrollMode.Typewriter, policy.mode)
-    assertEquals(148f, policy.bottomPadding, FloatTolerance)
+    assertEquals(596f, policy.bottomPadding, FloatTolerance)
   }
 
   @Test
@@ -161,14 +160,28 @@ class EditorAutoScrollPolicyTest {
             bottomOcclusionInset = 400f,
           ),
         baseBottomSpace = 20f,
-        distanceToPagesBottom = 1000f,
         typewriterEnabled = true,
-        typewriterPosition = 0.5f,
+        typewriterPosition = 0.9f,
         targetLineHeight = 32f,
       )
 
     assertEquals(EditorAutoScrollMode.Typewriter, policy.mode)
     assertEquals(440f, policy.bottomPadding, FloatTolerance)
+  }
+
+  @Test
+  fun `typewriter bottom padding keeps minimum when intrinsic space is sufficient`() {
+    val policy =
+      resolveEditorAutoScrollPolicy(
+        visibleArea = testVisibleArea(),
+        baseBottomSpace = 1000f,
+        typewriterEnabled = true,
+        typewriterPosition = 1f,
+        targetLineHeight = 32f,
+      )
+
+    assertEquals(EditorAutoScrollMode.Typewriter, policy.mode)
+    assertEquals(48f, policy.bottomPadding, FloatTolerance)
   }
 
   @Test

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorScrollResolverTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorScrollResolverTest.kt
@@ -1,6 +1,5 @@
 package co.typie.editor.scroll
 
-import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import co.typie.editor.EditorState
 import co.typie.editor.body.EditorDocumentLayoutSpec
@@ -13,7 +12,6 @@ import co.typie.editor.ffi.Selection
 import co.typie.editor.ffi.SelectionEndpoints
 import co.typie.editor.ffi.Size as PageSize
 import co.typie.editor.runtime.EditorBoundsInContainer
-import co.typie.editor.runtime.EditorUiState
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -275,43 +273,6 @@ class EditorScrollResolverTest {
       )
 
     assertEquals(184f, requireNotNull(height), 0.0001f)
-  }
-
-  @Test
-  fun `distance to pages bottom excludes bottom occlusion so typewriter padding can add it`() {
-    val uiState =
-      EditorUiState().apply {
-        updateInteractionSurfaceBounds(
-          boundsInRoot = Rect(left = 0f, top = 0f, right = 300f, bottom = 1000f),
-          density = 1f,
-        )
-        updateEditorBounds(
-          boundsInRoot = Rect(left = 0f, top = 0f, right = 300f, bottom = 620f),
-          density = 1f,
-        )
-      }
-
-    val distance =
-      resolveDistanceToPagesBottom(
-        state =
-          state(
-            cursor =
-              CursorMetrics(
-                pageIdx = 0,
-                caret = FfiRect(0f, 580f, 0f, 20f),
-                line = FfiRect(0f, 580f, 0f, 20f),
-              ),
-            pageSizes = listOf(PageSize(width = 300f, height = 620f)),
-          ),
-        layoutSpec = EditorDocumentLayoutSpec.Continuous(maxWidth = 300f),
-        uiState = uiState,
-        headerHeight = 0f,
-        pagesContentHeight = 620f,
-        target = EditorBringIntoViewTarget.CurrentSelectionHead,
-        density = 1f,
-      )
-
-    assertEquals(40f, requireNotNull(distance))
   }
 
   private fun assertScrollTo(intent: EditorScrollIntentResult, y: Float) {


### PR DESCRIPTION
문서 끝에서 위 방향으로 셀렉션 핸들로 선택 확장할 때 빠르게 스크롤 점프하는 문제를 해결함