### PR TITLE
앱 이미지 폭 조정 슬라이더 동작 수정

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/external/EditorImageResizePolicy.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/external/EditorImageResizePolicy.kt
@@ -39,6 +39,21 @@ internal fun imageResizeWidthForProportion(
     originalWidth = originalWidth,
   )
 
+internal fun imageResizeDisplayPercent(
+  proportion: Float,
+  boundsWidth: Float,
+  originalWidth: Float,
+): Int {
+  val maxWidth = imageResizeWidthBounds(boundsWidth, originalWidth).max
+  if (maxWidth <= 0f) {
+    return IMAGE_MAX_PROPORTION
+  }
+  val width = imageResizeWidthForProportion(proportion, boundsWidth, originalWidth)
+  return ((width / maxWidth) * 100)
+    .roundToInt()
+    .coerceIn(IMAGE_MIN_PROPORTION, IMAGE_MAX_PROPORTION)
+}
+
 internal fun imageResizeProportionRange(boundsWidth: Float, originalWidth: Float): IntRange {
   val bounds = imageResizeWidthBounds(boundsWidth = boundsWidth, originalWidth = originalWidth)
   return imageResizeProportionForWidth(bounds.min, boundsWidth)..imageResizeProportionForWidth(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/ImageResizeSecondaryToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/ImageResizeSecondaryToolbar.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.unit.dp
 import co.typie.editor.external.IMAGE_MAX_PROPORTION
 import co.typie.editor.external.IMAGE_MIN_PROPORTION
 import co.typie.editor.external.LocalEditorExternalElementState
+import co.typie.editor.external.imageResizeDisplayPercent
 import co.typie.editor.external.imageResizeProportionRange
 import co.typie.editor.ffi.ExternalElementData
 import co.typie.editor.ffi.ImageNodeAttr
@@ -62,25 +63,21 @@ internal fun ImageResizeSecondaryToolbar(
     return
   }
 
-  val range =
-    imageResizeProportionRange(boundsWidth = boundsWidth, originalWidth = asset.width.toFloat())
+  val originalWidth = asset.width.toFloat()
+  val range = imageResizeProportionRange(boundsWidth = boundsWidth, originalWidth = originalWidth)
   val nodeProportion = image.proportion.coerceIn(IMAGE_MIN_PROPORTION, IMAGE_MAX_PROPORTION)
   val currentProportion =
     (imageState.resizeDraftProportions[nodeId] ?: nodeProportion.toFloat()).coerceIn(
       range.first.toFloat(),
       range.last.toFloat(),
     )
-  val currentPercent = currentProportion.roundToInt()
+  val currentPercent = imageResizeDisplayPercent(currentProportion, boundsWidth, originalWidth)
 
   DisposableEffect(nodeId) { onDispose { imageState.resizeDraftProportions.remove(nodeId) } }
 
   fun updateDraft(value: Float) {
     val next = value.coerceIn(range.first.toFloat(), range.last.toFloat())
     imageState.resizeDraftProportions[nodeId] = next
-  }
-
-  fun startDraft() {
-    imageState.resizeDraftProportions[nodeId] = currentProportion
   }
 
   fun commit(value: Float) {
@@ -105,7 +102,7 @@ internal fun ImageResizeSecondaryToolbar(
     Slider(
       value = currentProportion,
       range = range.first.toFloat()..range.last.toFloat(),
-      onDragStart = ::startDraft,
+      onDragStart = ::updateDraft,
       onDrag = ::updateDraft,
       onDragEnd = ::commit,
       onDragCancel = ::cancelDraft,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/Slider.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/Slider.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.changedToUp
+import androidx.compose.ui.input.pointer.changedToUpIgnoreConsumed
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.platform.LocalDensity
@@ -56,7 +57,7 @@ internal fun sliderHapticFeedbackType(
 internal class SliderGestureSession(
   initialValue: Float,
   private val valueFromX: (Float) -> Float,
-  private val onDragStart: () -> Unit,
+  private val onDragStart: (Float) -> Unit,
   private val onDrag: (Float) -> Unit,
 ) {
   private var current = initialValue
@@ -67,7 +68,7 @@ internal class SliderGestureSession(
       return
     }
     started = true
-    onDragStart()
+    onDragStart(current)
   }
 
   fun updateAt(x: Float) {
@@ -96,7 +97,7 @@ internal class SliderGestureSession(
 internal fun Slider(
   value: Float,
   range: ClosedFloatingPointRange<Float>,
-  onDragStart: () -> Unit,
+  onDragStart: (Float) -> Unit,
   onDrag: (Float) -> Unit,
   onDragEnd: (Float) -> Unit,
   modifier: Modifier = Modifier,
@@ -167,7 +168,7 @@ internal fun Slider(
               SliderGestureSession(
                 initialValue = currentValue,
                 valueFromX = ::valueFromX,
-                onDragStart = { currentOnDragStart() },
+                onDragStart = { initialValue -> currentOnDragStart(initialValue) },
                 onDrag = { next ->
                   sliderHapticFeedbackType(range, normalizedStep, next)
                     ?.let(currentHapticFeedback::performHapticFeedback)
@@ -179,7 +180,7 @@ internal fun Slider(
               val event = awaitPointerEvent()
               val change = event.changes.firstOrNull { it.id == down.id } ?: break
 
-              if (change.changedToUp()) {
+              if (change.changedToUp() || (dragging && change.changedToUpIgnoreConsumed())) {
                 if (!dragging) {
                   gesture.start()
                 }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/external/EditorImageResizePolicyTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/external/EditorImageResizePolicyTest.kt
@@ -40,4 +40,20 @@ class EditorImageResizePolicyTest {
   fun proportion_for_width_rounds_to_nearest_percent() {
     assertEquals(38, imageResizeProportionForWidth(width = 300.8f, boundsWidth = 800f))
   }
+
+  @Test
+  fun display_percent_treats_original_width_as_hundred_percent() {
+    assertEquals(
+      100,
+      imageResizeDisplayPercent(proportion = 40f, boundsWidth = 800f, originalWidth = 320f),
+    )
+  }
+
+  @Test
+  fun display_percent_matches_bounds_proportion_when_original_is_larger() {
+    assertEquals(
+      50,
+      imageResizeDisplayPercent(proportion = 50f, boundsWidth = 800f, originalWidth = 1200f),
+    )
+  }
 }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/SliderDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/SliderDesktopTest.kt
@@ -5,6 +5,10 @@ import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerEventPass
@@ -14,12 +18,14 @@ import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performMouseInput
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalTestApi::class)
 class SliderDesktopTest {
@@ -108,8 +114,133 @@ class SliderDesktopTest {
     assertEquals(70f, committedValue)
   }
 
+  @Test
+  fun activeDragCommitsWhenAncestorConsumesReleaseOutsideTrack() = runComposeUiTest {
+    var committedValue: Float? = null
+    var canceled = false
+
+    setContent {
+      Box(Modifier.size(width = 280.dp, height = 32.dp).consumeReleaseAtInitialPass()) {
+        Slider(
+          value = 10f,
+          range = 0f..100f,
+          onDragStart = {},
+          onDrag = {},
+          onDragEnd = { committedValue = it },
+          onDragCancel = { canceled = true },
+          thumbSize = 0.dp,
+          modifier = Modifier.testTag(ConsumedReleaseSliderTag).size(width = 200.dp, height = 32.dp),
+        )
+      }
+    }
+    waitForIdle()
+
+    onNodeWithTag(ConsumedReleaseSliderTag).performTouchInput {
+      val y = center.y
+      down(Offset(x = width * 0.1f, y = y))
+      moveTo(Offset(x = width * 0.7f, y = y))
+      moveTo(Offset(x = width + 48f, y = y))
+      up()
+    }
+    waitForIdle()
+
+    assertFalse(canceled)
+    assertEquals(100f, committedValue)
+  }
+
+  @Test
+  fun consumedReleaseWithoutDragCancelsInsteadOfCommittingTap() = runComposeUiTest {
+    var committedValue: Float? = null
+    var canceled = false
+
+    setContent {
+      Box(Modifier.size(width = 200.dp, height = 32.dp).consumeReleaseAtInitialPass()) {
+        Slider(
+          value = 10f,
+          range = 0f..100f,
+          onDragStart = {},
+          onDrag = {},
+          onDragEnd = { committedValue = it },
+          onDragCancel = { canceled = true },
+          thumbSize = 0.dp,
+          modifier = Modifier.testTag(ConsumedTapReleaseSliderTag).fillMaxSize(),
+        )
+      }
+    }
+    waitForIdle()
+
+    onNodeWithTag(ConsumedTapReleaseSliderTag).performTouchInput {
+      down(Offset(x = width * 0.1f, y = center.y))
+      up()
+    }
+    waitForIdle()
+
+    assertEquals(null, committedValue)
+    assertTrue(canceled)
+  }
+
+  @Test
+  fun dragStartProvidesLatestDisplayedValueWhenDraftDiffersFromNodeValue() = runComposeUiTest {
+    var nodeValue by mutableFloatStateOf(85f)
+    var draftValue by mutableStateOf<Float?>(null)
+
+    setContent {
+      val currentValue = draftValue ?: nodeValue
+      Slider(
+        value = currentValue,
+        range = 0f..100f,
+        onDragStart = { initialValue -> draftValue = initialValue },
+        onDrag = { draftValue = it },
+        onDragEnd = {
+          nodeValue = it
+          draftValue = null
+        },
+        onDragCancel = { draftValue = null },
+        thumbSize = 20.dp,
+        modifier = Modifier.testTag(LatestDraftSliderTag).size(width = 200.dp, height = 32.dp),
+      )
+    }
+    waitForIdle()
+    runOnIdle { draftValue = 100f }
+    waitForIdle()
+
+    val slider = onNodeWithTag(LatestDraftSliderTag)
+    slider.performMouseInput {
+      moveTo(Offset(x = 190f, y = center.y))
+      press()
+      moveTo(Offset(x = 248f, y = center.y))
+    }
+    runOnIdle { assertEquals(100f, draftValue) }
+
+    slider.performMouseInput { release() }
+    runOnIdle {
+      assertEquals(100f, nodeValue)
+      assertEquals(null, draftValue)
+    }
+  }
+
   private companion object {
     const val SliderTag = "slider-track"
     const val ConsumedSliderTag = "consumed-slider-track"
+    const val ConsumedReleaseSliderTag = "consumed-release-slider-track"
+    const val ConsumedTapReleaseSliderTag = "consumed-tap-release-slider-track"
+    const val LatestDraftSliderTag = "latest-draft-slider-track"
   }
 }
+
+private fun Modifier.consumeReleaseAtInitialPass(): Modifier =
+  pointerInput(Unit) {
+    awaitEachGesture {
+      awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
+
+      while (true) {
+        val event = awaitPointerEvent(PointerEventPass.Initial)
+        val change = event.changes.first()
+
+        if (!change.pressed) {
+          change.consume()
+          break
+        }
+      }
+    }
+  }


### PR DESCRIPTION
- 원본보다 확대하지 않는 기존 이미지 resize 정책을 유지하면서 조정 가능한 최대 크기를 100%로 표시
- track 밖으로 드래그해도 처음 값으로 돌아가지 않고, release한 마지막 값을 반영
- 100% 표시와 track 밖 drag/release 동작에 대한 회귀 테스트 추가