### PR TITLE
앱 top bar blur와 에디터 visible area 동작 수정

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationForeground.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationForeground.kt
@@ -1,0 +1,177 @@
+package co.typie.navigation
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalContext
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.currentCompositionLocalContext
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.movableContentOf
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerEvent
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.PointerInputModifierNode
+import androidx.compose.ui.unit.IntSize
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import co.typie.route.Route
+import co.typie.ui.component.bottombar.BottomBarState
+import co.typie.ui.component.bottombar.LocalBottomBarState
+import co.typie.ui.component.topbar.LocalTopBarState
+import co.typie.ui.component.topbar.TopBarState
+
+internal class NavigationForegroundRegistry {
+  private val entries = mutableStateListOf<NavigationForegroundEntry>()
+  private val backdropEntries = mutableStateListOf<NavigationTopBarBackdropEntry>()
+
+  val topBarBackdropBackground: Color?
+    get() = backdropEntries.lastOrNull()?.background
+
+  fun register(entry: NavigationForegroundEntry) {
+    if (entries.none { it.owner === entry.owner }) {
+      entries += entry
+    }
+  }
+
+  fun unregister(entry: NavigationForegroundEntry) {
+    entries.removeAll { it.owner === entry.owner }
+  }
+
+  fun register(entry: NavigationTopBarBackdropEntry) {
+    if (backdropEntries.none { it.owner === entry.owner }) {
+      backdropEntries += entry
+    }
+  }
+
+  fun unregister(entry: NavigationTopBarBackdropEntry) {
+    backdropEntries.removeAll { it.owner === entry.owner }
+  }
+
+  @Composable
+  fun Content(
+    route: Route,
+    viewModelStoreOwner: ViewModelStoreOwner,
+    topBarState: TopBarState?,
+    bottomBarState: BottomBarState?,
+    modifier: Modifier,
+  ) {
+    entries.forEach { entry ->
+      Box(
+        modifier =
+          modifier.then(
+            if (entry.sharePointerInputWithSiblings) {
+              ShareNavigationForegroundPointerInputElement
+            } else {
+              Modifier
+            }
+          )
+      ) {
+        CompositionLocalProvider(entry.context) {
+          CompositionLocalProvider(
+            LocalViewModelStoreOwner provides viewModelStoreOwner,
+            LocalRoute provides route,
+            LocalTopBarState provides topBarState,
+            LocalBottomBarState provides bottomBarState,
+          ) {
+            entry.content()
+          }
+        }
+      }
+    }
+  }
+}
+
+internal class NavigationForegroundEntry(
+  val owner: Any,
+  val content: @Composable () -> Unit,
+  context: CompositionLocalContext,
+  sharePointerInputWithSiblings: Boolean,
+) {
+  var context by mutableStateOf(context)
+  var sharePointerInputWithSiblings by mutableStateOf(sharePointerInputWithSiblings)
+}
+
+internal class NavigationTopBarBackdropEntry(val owner: Any, background: Color) {
+  var background by mutableStateOf(background)
+}
+
+private val LocalNavigationForegroundRegistry =
+  staticCompositionLocalOf<NavigationForegroundRegistry?> { null }
+
+@Composable
+internal fun NavigationForeground(
+  sharePointerInputWithSiblings: Boolean = false,
+  content: @Composable () -> Unit,
+) {
+  val registry = LocalNavigationForegroundRegistry.current
+  if (registry == null) {
+    content()
+    return
+  }
+
+  val currentContent = rememberUpdatedState(content)
+  val movableContent = remember { movableContentOf { currentContent.value() } }
+  val context = currentCompositionLocalContext
+  val entry =
+    remember(registry) {
+      NavigationForegroundEntry(
+        owner = Any(),
+        content = movableContent,
+        context = context,
+        sharePointerInputWithSiblings = sharePointerInputWithSiblings,
+      )
+    }
+  if (entry.context != context) {
+    entry.context = context
+  }
+  entry.sharePointerInputWithSiblings = sharePointerInputWithSiblings
+  registry.register(entry)
+
+  DisposableEffect(registry, entry) { onDispose { registry.unregister(entry) } }
+}
+
+@Composable
+internal fun PublishNavigationTopBarBackdropStyle(background: Color) {
+  val registry = LocalNavigationForegroundRegistry.current ?: return
+  val entry =
+    remember(registry) { NavigationTopBarBackdropEntry(owner = Any(), background = background) }
+  entry.background = background
+  registry.register(entry)
+
+  DisposableEffect(registry, entry) { onDispose { registry.unregister(entry) } }
+}
+
+@Composable
+internal fun ProvideNavigationForegroundRegistry(
+  registry: NavigationForegroundRegistry,
+  content: @Composable () -> Unit,
+) {
+  CompositionLocalProvider(LocalNavigationForegroundRegistry provides registry, content = content)
+}
+
+private data object ShareNavigationForegroundPointerInputElement :
+  ModifierNodeElement<ShareNavigationForegroundPointerInputNode>() {
+  override fun create(): ShareNavigationForegroundPointerInputNode =
+    ShareNavigationForegroundPointerInputNode()
+
+  override fun update(node: ShareNavigationForegroundPointerInputNode) = Unit
+}
+
+private class ShareNavigationForegroundPointerInputNode :
+  Modifier.Node(), PointerInputModifierNode {
+  override fun sharePointerInputWithSiblings(): Boolean = true
+
+  override fun onPointerEvent(pointerEvent: PointerEvent, pass: PointerEventPass, bounds: IntSize) =
+    Unit
+
+  override fun onCancelPointerInput() = Unit
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationRoutePresentation.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationRoutePresentation.kt
@@ -1,0 +1,47 @@
+package co.typie.navigation
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.ClipOp
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.drawscope.clipPath
+import androidx.compose.ui.graphics.graphicsLayer
+
+internal data class NavigationRoutePresentation(
+  val translationX: Float = 0f,
+  val translationY: Float = 0f,
+  val alpha: Float = 1f,
+  val clipShape: Shape? = null,
+)
+
+internal fun Modifier.navigationRoutePresentation(
+  presentation: NavigationRoutePresentation
+): Modifier = graphicsLayer {
+  translationX = presentation.translationX
+  translationY = presentation.translationY
+  alpha = presentation.alpha
+  presentation.clipShape?.let {
+    shape = it
+    clip = true
+  }
+}
+
+internal fun Modifier.excludeNavigationRouteCoverage(
+  presentation: NavigationRoutePresentation
+): Modifier {
+  val clipShape = presentation.clipShape ?: return this
+  return drawWithContent {
+    val outline = clipShape.createOutline(size, layoutDirection, this)
+    val coveragePath =
+      when (outline) {
+        is Outline.Generic -> Path().apply { addPath(outline.path) }
+        is Outline.Rectangle -> Path().apply { addRect(outline.rect) }
+        is Outline.Rounded -> Path().apply { addRoundRect(outline.roundRect) }
+      }
+    coveragePath.translate(Offset(x = presentation.translationX, y = presentation.translationY))
+    clipPath(coveragePath, clipOp = ClipOp.Difference) { this@drawWithContent.drawContent() }
+  }
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationStack.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationStack.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.input.pointer.util.VelocityTracker
 import androidx.compose.ui.input.pointer.util.addPointerInputChange
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalViewConfiguration
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
@@ -45,7 +46,6 @@ import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import co.touchlab.kermit.Logger
 import co.typie.ext.pointerIgnore
-import co.typie.ext.thenIf
 import co.typie.platform.isTouchDragPointer
 import co.typie.route.Route
 import co.typie.route.RouteTransitionStyle
@@ -62,6 +62,8 @@ import co.typie.ui.component.topbar.NavDirection
 import co.typie.ui.component.topbar.TopBarState
 import co.typie.ui.theme.AppShapes
 import co.typie.ui.theme.AppTheme
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.hazeSource
 import kotlin.math.abs
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineStart
@@ -79,6 +81,12 @@ private enum class AnimState {
   Dragging,
   PopGestureCommitted,
 }
+
+private class NavigationRouteScene(
+  val owner: ViewModelStoreOwner,
+  val foregroundRegistry: NavigationForegroundRegistry,
+  val content: @Composable (TopBarState?, BottomBarState?) -> Unit,
+)
 
 private const val NavigationPopActivationSlopMultiplier = 3f
 
@@ -203,36 +211,56 @@ fun NavigationStack(
   // 안정적으로 유지된다. (같은 스크린을 두 call site에서 composition하면
   // compound key가 달라져 viewModel/rememberSaveable 키가 꼬인다.)
   val latestContent by rememberUpdatedState(content)
-  val routeContents = remember {
-    mutableMapOf<Route, @Composable (TopBarState?, BottomBarState?) -> Unit>()
-  }
-  val routeContentFor: (Route) -> @Composable (TopBarState?, BottomBarState?) -> Unit = { route ->
-    routeContents.getOrPut(route) {
-      movableContentOf<TopBarState?, BottomBarState?> { topBar, bottomBar ->
-        val owner = remember {
-          object : ViewModelStoreOwner {
-            override val viewModelStore = navigator.viewModelStoreFor(route)
+  val routeScenes = remember { mutableMapOf<Route, NavigationRouteScene>() }
+  val routeSceneFor: (Route) -> NavigationRouteScene = { route ->
+    routeScenes.getOrPut(route) {
+      val owner =
+        object : ViewModelStoreOwner {
+          override val viewModelStore = navigator.viewModelStoreFor(route)
+        }
+      val foregroundRegistry = NavigationForegroundRegistry()
+      val routeContent =
+        movableContentOf<TopBarState?, BottomBarState?> { topBar, bottomBar ->
+          val providers =
+            buildList<ProvidedValue<*>> {
+              add(LocalViewModelStoreOwner provides owner)
+              add(LocalRoute provides route)
+              add(LocalTopBarState provides topBar)
+              if (bottomBar != null) add(LocalBottomBarState provides bottomBar)
+            }
+          CompositionLocalProvider(*providers.toTypedArray()) {
+            ProvideBottomBar(enabled = false)
+            ProvideNavigationForegroundRegistry(foregroundRegistry) { latestContent(route) }
           }
         }
-        val providers =
-          buildList<ProvidedValue<*>> {
-            add(LocalViewModelStoreOwner provides owner)
-            add(LocalRoute provides route)
-            add(LocalTopBarState provides topBar)
-            if (bottomBar != null) add(LocalBottomBarState provides bottomBar)
-          }
-        CompositionLocalProvider(*providers.toTypedArray()) {
-          ProvideBottomBar(enabled = false)
-          latestContent(route)
-        }
-      }
+      NavigationRouteScene(
+        owner = owner,
+        foregroundRegistry = foregroundRegistry,
+        content = routeContent,
+      )
     }
   }
+  val presentRouteSurface: @Composable (Route, TopBarState?, BottomBarState?) -> Unit =
+    { route, topBar, bottomBar ->
+      val scene = routeSceneFor(route)
+      scene.content(topBar, bottomBar)
+    }
+  val presentRouteForeground: @Composable (Route, TopBarState?, BottomBarState?, Modifier) -> Unit =
+    { route, topBar, bottomBar, foregroundModifier ->
+      val scene = routeSceneFor(route)
+      scene.foregroundRegistry.Content(
+        route = route,
+        viewModelStoreOwner = scene.owner,
+        topBarState = topBar,
+        bottomBarState = bottomBar,
+        modifier = foregroundModifier,
+      )
+    }
 
   // 백스택에서 제거된 라우트의 movable 캐시 정리
   LaunchedEffect(Unit) {
     snapshotFlow { navigator.stack.toSet() }
-      .collect { active -> routeContents.keys.retainAll(active) }
+      .collect { active -> routeScenes.keys.retainAll(active) }
   }
 
   val scope = rememberCoroutineScope()
@@ -247,6 +275,7 @@ fun NavigationStack(
   var transitionStyle by remember { mutableStateOf(RouteTransitionStyle.Slide) }
 
   val progress = remember { Animatable(0f) }
+  val topBarBackdropHazeState = remember { HazeState() }
 
   val popNestedScroll = remember { NavigationPopNestedScroll() }
   val navigationPopActivationDistance =
@@ -664,7 +693,8 @@ fun NavigationStack(
                 } else {
                   null
                 }
-              // Compose excludes the UP position from velocity samples, but still uses the event to
+              // Compose excludes the UP position from velocity samples, but still uses the
+              // event to
               // apply its platform-specific pointer-stop timeout.
               val pointerSample = activePointer ?: releasedPointer
               popPointerVelocity.update(pressedDragPointerCount, pointerSample)
@@ -724,12 +754,27 @@ fun NavigationStack(
         navigator.stack.forEach { route ->
           if (route == mainRoute || route == behindRoute) return@forEach
           if (!route.keepAlive) return@forEach
-          Box(Modifier.fillMaxSize()) { routeContentFor(route).invoke(null, null) }
+          Box(Modifier.fillMaxSize()) {
+            presentRouteSurface(route, null, null)
+            presentRouteForeground(route, null, null, Modifier.fillMaxSize())
+          }
         }
       }
 
-      // Behind layer (애니메이션 중 뒤에 깔리는 화면)
-      if (behindRoute != null) {
+      Box(
+        Modifier.fillMaxSize().pointerInput(navigationPopActivationDistance) {
+          detectNavigationPopDrag(
+            activationDistance = navigationPopActivationDistance,
+            pointerVelocity = popPointerVelocity,
+            canStart = ::canStartPopGesture,
+            isSequenceRejected = { popNestedScroll.isCurrentSequenceRejected },
+            onStart = ::startPopDrag,
+            onDrag = ::updatePopDrag,
+            onRelease = popNestedScroll::finishDirectGesture,
+            onCancel = popNestedScroll::cancelDirectGesture,
+          )
+        }
+      ) {
         val behindTopBar =
           when (animState) {
             AnimState.Push -> exitTopBarState
@@ -748,106 +793,193 @@ fun NavigationStack(
           } else {
             bottomBarState
           }
-
-        if (useFadeTransition) {
-          Box(
-            Modifier.fillMaxSize().graphicsLayer {
-              alpha =
-                when (animState) {
-                  AnimState.Push -> 1f - progress.value
-                  AnimState.Pop -> progress.value
-                  AnimState.PopGestureCommitted -> 0f
-                  AnimState.Dragging -> if (navigator.popRequested) progress.value else 0f
-                  AnimState.Idle -> 1f
-                }
+        val mainTopBar =
+          when (animState) {
+            // Pop: 나가는 화면은 exitTopBarState
+            AnimState.Pop,
+            AnimState.PopGestureCommitted -> exitTopBarState
+            AnimState.Dragging -> if (navigator.popRequested) exitTopBarState else topBarState
+            else -> topBarState
+          }
+        val mainBottomBar =
+          if (bottomBarState != null && exitBottomBarState != null) {
+            when (animState) {
+              AnimState.Pop,
+              AnimState.PopGestureCommitted -> exitBottomBarState
+              AnimState.Dragging ->
+                if (navigator.popRequested) exitBottomBarState else bottomBarState
+              else -> bottomBarState
             }
-          ) {
-            routeContentFor(behindRoute!!).invoke(behindTopBar, behindBottomBar)
+          } else {
+            bottomBarState
           }
-          // 전환 중 behind 화면 터치 차단 (fade는 dim overlay가 없으므로 별도 pointerIgnore)
-          Box(Modifier.fillMaxSize().pointerIgnore())
-        } else if (useVerticalTransition) {
-          Box(Modifier.fillMaxSize()) {
-            routeContentFor(behindRoute!!).invoke(behindTopBar, behindBottomBar)
-          }
-          // Dim overlay — 전환 중 behind 화면 터치 차단
-          Box(
-            Modifier.fillMaxSize()
-              .graphicsLayer {
+
+        val p = progress.value
+        val mainPresentation =
+          when {
+            animState == AnimState.Idle -> NavigationRoutePresentation()
+            useFadeTransition ->
+              NavigationRoutePresentation(
                 alpha =
                   when (animState) {
-                    AnimState.Push -> progress.value
-                    AnimState.Pop,
-                    AnimState.PopGestureCommitted -> 1f - progress.value
-                    AnimState.Dragging -> 1f - progress.value
-                    AnimState.Idle -> 0f
+                    AnimState.Push -> p
+                    AnimState.Pop -> 1f - p
+                    AnimState.PopGestureCommitted -> 1f
+                    AnimState.Dragging -> if (navigator.popRequested) 1f - p else 1f
+                    AnimState.Idle -> 1f
                   }
-              }
-              .background(AppTheme.colors.scrim.copy(alpha = 0.5f))
-              .pointerIgnore()
-          )
-        } else {
-          Box(
-            Modifier.fillMaxSize().graphicsLayer {
-              translationX =
-                when (animState) {
-                  // Push: 이전 화면이 왼쪽으로 밀림
-                  AnimState.Push -> -containerWidth / 6f * progress.value
-                  // Pop/Dragging: 돌아갈 화면이 왼쪽에서 복귀
-                  else -> -containerWidth / 6f * (1f - progress.value)
-                }
-            }
-          ) {
-            routeContentFor(behindRoute!!).invoke(behindTopBar, behindBottomBar)
+              )
+            useVerticalTransition ->
+              NavigationRoutePresentation(
+                translationY =
+                  when (animState) {
+                    AnimState.Push -> containerHeight * (1f - p)
+                    AnimState.Pop,
+                    AnimState.PopGestureCommitted,
+                    AnimState.Dragging -> containerHeight * p
+                    AnimState.Idle -> 0f
+                  },
+                clipShape =
+                  AppShapes.rounded(cornerRadius(if (animState == AnimState.Push) p else 1f - p)),
+              )
+            else ->
+              NavigationRoutePresentation(
+                translationX =
+                  when (animState) {
+                    AnimState.Push -> containerWidth * (1f - p)
+                    else -> containerWidth * p
+                  },
+                clipShape =
+                  AppShapes.rounded(cornerRadius(if (animState == AnimState.Push) p else 1f - p)),
+              )
           }
-          // Dim overlay — 전환 중 behind 화면 터치 차단
-          Box(
-            Modifier.fillMaxSize()
-              .graphicsLayer {
-                val p = progress.value
+        val behindPresentation =
+          when {
+            useFadeTransition ->
+              NavigationRoutePresentation(
+                alpha =
+                  when (animState) {
+                    AnimState.Push -> 1f - p
+                    AnimState.Pop -> p
+                    AnimState.PopGestureCommitted -> 0f
+                    AnimState.Dragging -> if (navigator.popRequested) p else 0f
+                    AnimState.Idle -> 1f
+                  }
+              )
+            useVerticalTransition -> NavigationRoutePresentation()
+            else ->
+              NavigationRoutePresentation(
                 translationX =
                   when (animState) {
                     AnimState.Push -> -containerWidth / 6f * p
                     else -> -containerWidth / 6f * (1f - p)
                   }
+              )
+          }
+        val behindDimPresentation =
+          when {
+            useFadeTransition -> null
+            useVerticalTransition ->
+              NavigationRoutePresentation(
                 alpha =
                   when (animState) {
                     AnimState.Push -> p
-                    else -> 1f - p
+                    AnimState.Pop,
+                    AnimState.PopGestureCommitted,
+                    AnimState.Dragging -> 1f - p
+                    AnimState.Idle -> 0f
                   }
-              }
-              .background(AppTheme.colors.scrim.copy(alpha = 0.5f))
-              .pointerIgnore()
+              )
+            else ->
+              NavigationRoutePresentation(
+                translationX = behindPresentation.translationX,
+                alpha = if (animState == AnimState.Push) p else 1f - p,
+              )
+          }
+
+        // Scene surfaces retain the current behind/main route order and are captured as one live
+        // composite for the fixed top bar backdrop.
+        Box(
+          Modifier.fillMaxSize()
+            .testTag(NavigationSceneSurfaceCompositeTestTag)
+            .hazeSource(topBarBackdropHazeState)
+        ) {
+          behindRoute?.let { route ->
+            Box(Modifier.fillMaxSize().navigationRoutePresentation(behindPresentation)) {
+              presentRouteSurface(route, behindTopBar, behindBottomBar)
+            }
+            behindDimPresentation?.let { presentation ->
+              Box(
+                Modifier.fillMaxSize()
+                  .navigationRoutePresentation(presentation)
+                  .background(AppTheme.colors.scrim.copy(alpha = 0.5f))
+                  .pointerIgnore()
+              )
+            }
+          }
+          Box(Modifier.fillMaxSize().navigationRoutePresentation(mainPresentation)) {
+            presentRouteSurface(mainRoute, mainTopBar, mainBottomBar)
+          }
+        }
+
+        val mainBackdropWeight =
+          when {
+            behindRoute == null -> 1f
+            animState == AnimState.Push -> p
+            animState == AnimState.Pop ||
+              animState == AnimState.PopGestureCommitted ||
+              animState == AnimState.Dragging -> 1f - p
+            else -> 1f
+          }
+        val backdropStyle =
+          resolveNavigationTopBarBackdropStyle(
+            behindBackground =
+              behindRoute?.let { route ->
+                routeSceneFor(route).foregroundRegistry.topBarBackdropBackground
+              },
+            behindPresence = if (behindTopBar.hasTopBarBackdrop()) 1f else 0f,
+            mainBackground = routeSceneFor(mainRoute).foregroundRegistry.topBarBackdropBackground,
+            mainPresence = if (mainTopBar.hasTopBarBackdrop()) 1f else 0f,
+            mainWeight = mainBackdropWeight,
+            fallbackBackground = AppTheme.colors.surfaceCanvas,
+          )
+        NavigationTopBarBackdrop(
+          hazeState = topBarBackdropHazeState,
+          style = backdropStyle,
+          modifier = Modifier.align(Alignment.TopCenter),
+        )
+
+        // Scene foregrounds use the matching presentation. Behind foreground is excluded from the
+        // transformed main-route coverage so it cannot leak over an opaque front surface.
+        behindRoute?.let { route ->
+          presentRouteForeground(
+            route,
+            behindTopBar,
+            behindBottomBar,
+            Modifier.fillMaxSize()
+              .excludeNavigationRouteCoverage(mainPresentation)
+              .navigationRoutePresentation(behindPresentation),
           )
         }
-      }
+        presentRouteForeground(
+          mainRoute,
+          mainTopBar,
+          mainBottomBar,
+          Modifier.fillMaxSize().navigationRoutePresentation(mainPresentation),
+        )
 
-      // Main layer (현재 화면 — 항상 같은 composition slot을 유지하여
-      // Push→Idle 전환 시 remember 등 composition 상태가 보존됨)
-      val mainTopBar =
-        when (animState) {
-          // Pop: 나가는 화면은 exitTopBarState
-          AnimState.Pop,
-          AnimState.PopGestureCommitted -> exitTopBarState
-          AnimState.Dragging -> if (navigator.popRequested) exitTopBarState else topBarState
-          else -> topBarState
-        }
-      val mainBottomBar =
-        if (bottomBarState != null && exitBottomBarState != null) {
-          when (animState) {
-            AnimState.Pop,
-            AnimState.PopGestureCommitted -> exitBottomBarState
-            AnimState.Dragging -> if (navigator.popRequested) exitBottomBarState else bottomBarState
-            else -> bottomBarState
-          }
-        } else {
-          bottomBarState
+        // 전환/드래그 중 route foreground까지 포함한 전체 presented scene의 터치를 차단한다.
+        // 이미 시작된 direct drag의 hit path에는 이 노드가 없으므로 제스처 추적은 계속된다.
+        if (animState != AnimState.Idle) {
+          Box(Modifier.fillMaxSize().pointerIgnore())
         }
 
-      Box(
-        Modifier.fillMaxSize()
-          .thenIf(navigator.canPop) {
-            pointerInput(navigationPopActivationDistance) {
+        // 엣지 제스처 감지 영역 (platform touch slop의 3배를 넘긴 dominant-right drag만 claim)
+        if (navigator.canPop && (animState == AnimState.Idle || animState == AnimState.Dragging)) {
+          Box(
+            Modifier.fillMaxHeight().width(20.dp).align(Alignment.CenterStart).pointerInput(
+              navigationPopActivationDistance
+            ) {
               detectNavigationPopDrag(
                 activationDistance = navigationPopActivationDistance,
                 pointerVelocity = popPointerVelocity,
@@ -859,87 +991,8 @@ fun NavigationStack(
                 onCancel = popNestedScroll::cancelDirectGesture,
               )
             }
-          }
-          .graphicsLayer {
-            if (animState != AnimState.Idle) {
-              val p = progress.value
-              if (useFadeTransition) {
-                alpha =
-                  when (animState) {
-                    AnimState.Push -> p
-                    AnimState.Pop -> 1f - p
-                    AnimState.PopGestureCommitted -> 1f
-                    AnimState.Dragging -> if (navigator.popRequested) 1f - p else 1f
-                    AnimState.Idle -> 1f
-                  }
-              } else if (useVerticalTransition) {
-                translationY =
-                  when (animState) {
-                    AnimState.Push -> containerHeight * (1f - p)
-                    AnimState.Pop,
-                    AnimState.PopGestureCommitted -> containerHeight * p
-                    AnimState.Dragging -> containerHeight * p
-                    AnimState.Idle -> 0f
-                  }
-                shape =
-                  AppShapes.rounded(
-                    cornerRadius(
-                      when (animState) {
-                        AnimState.Push -> p
-                        else -> 1f - p
-                      }
-                    )
-                  )
-                clip = true
-              } else {
-                translationX =
-                  when (animState) {
-                    // Push: 오른쪽에서 왼쪽으로 슬라이드 in
-                    AnimState.Push -> containerWidth * (1f - p)
-                    // Pop/Dragging: 오른쪽으로 슬라이드 out
-                    else -> containerWidth * p
-                  }
-                shape =
-                  AppShapes.rounded(
-                    cornerRadius(
-                      when (animState) {
-                        AnimState.Push -> p
-                        else -> 1f - p
-                      }
-                    )
-                  )
-                clip = true
-              }
-            }
-          }
-      ) {
-        routeContentFor(mainRoute).invoke(mainTopBar, mainBottomBar)
-        // 전환/드래그 중 front 화면 내부로 터치가 흘러가지 않도록 consume.
-        // Main pass 기준 overlay가 sibling routeContent보다 나중에 composed → 먼저 처리되어 consume.
-        // Drag 로직은 Main pass에서 positionChangeIgnoreConsumed로 계속 추적하므로 영향받지 않는다.
-        if (animState != AnimState.Idle) {
-          Box(Modifier.fillMaxSize().pointerIgnore())
+          )
         }
-      }
-
-      // 엣지 제스처 감지 영역 (platform touch slop의 3배를 넘긴 dominant-right drag만 claim)
-      if (navigator.canPop && (animState == AnimState.Idle || animState == AnimState.Dragging)) {
-        Box(
-          Modifier.fillMaxHeight().width(20.dp).align(Alignment.CenterStart).pointerInput(
-            navigationPopActivationDistance
-          ) {
-            detectNavigationPopDrag(
-              activationDistance = navigationPopActivationDistance,
-              pointerVelocity = popPointerVelocity,
-              canStart = ::canStartPopGesture,
-              isSequenceRejected = { popNestedScroll.isCurrentSequenceRejected },
-              onStart = ::startPopDrag,
-              onDrag = ::updatePopDrag,
-              onRelease = popNestedScroll::finishDirectGesture,
-              onCancel = popNestedScroll::cancelDirectGesture,
-            )
-          }
-        )
       }
     }
   }
@@ -954,3 +1007,5 @@ private fun cornerRadius(progress: Float): Dp {
     }
   return maxRadius * factor.coerceIn(0f, 1f)
 }
+
+private fun TopBarState?.hasTopBarBackdrop(): Boolean = this != null && enabled

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationTopBarBackdrop.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationTopBarBackdrop.kt
@@ -1,0 +1,107 @@
+package co.typie.navigation
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.platform.testTag
+import co.typie.ui.component.SmootherstepEasing
+import co.typie.ui.component.topbar.LocalTopBarAnimationSource
+import co.typie.ui.component.topbar.TopBarDefaults
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.blur.blurEffect
+import dev.chrisbanes.haze.hazeEffect
+
+internal const val NavigationTopBarBackdropTestTag = "navigation-top-bar-backdrop"
+internal const val NavigationSceneSurfaceCompositeTestTag = "navigation-scene-surface-composite"
+
+private const val NavigationTopBarFadeSamples = 48
+
+internal data class NavigationTopBarBackdropStyle(val background: Color, val presence: Float)
+
+internal fun resolveNavigationTopBarBackdropStyle(
+  behindBackground: Color?,
+  behindPresence: Float,
+  mainBackground: Color?,
+  mainPresence: Float,
+  mainWeight: Float,
+  fallbackBackground: Color,
+): NavigationTopBarBackdropStyle {
+  val resolvedMainWeight = mainWeight.coerceIn(0f, 1f)
+  val behind = behindBackground ?: fallbackBackground
+  val main = mainBackground ?: fallbackBackground
+
+  return NavigationTopBarBackdropStyle(
+    background = lerp(behind, main, resolvedMainWeight),
+    presence =
+      (behindPresence.coerceIn(0f, 1f) * (1f - resolvedMainWeight) +
+          mainPresence.coerceIn(0f, 1f) * resolvedMainWeight)
+        .coerceIn(0f, 1f),
+  )
+}
+
+@Composable
+internal fun NavigationTopBarBackdrop(
+  hazeState: HazeState,
+  style: NavigationTopBarBackdropStyle,
+  modifier: Modifier = Modifier,
+) {
+  val animationSource = LocalTopBarAnimationSource.current
+  val alpha = (animationSource?.animatedAlpha ?: 0f) * style.presence
+  if (alpha <= 0f) return
+
+  val topPadding = TopBarDefaults.topPadding()
+  val backdropModifier =
+    modifier
+      .fillMaxWidth()
+      .height(topPadding + TopBarDefaults.Height + TopBarDefaults.BlurFadeHeight)
+      .testTag(NavigationTopBarBackdropTestTag)
+      .graphicsLayer {
+        this.alpha = alpha
+        translationY = (animationSource?.animatedTranslationY ?: 0f) * size.height
+      }
+
+  val fadeColor = style.background.copy(alpha = TopBarDefaults.FadeOpacity)
+  Box(modifier = backdropModifier) {
+    Column(
+      modifier =
+        Modifier.fillMaxWidth().hazeEffect(hazeState) {
+          blurEffect {
+            backgroundColor = style.background
+            blurRadius = TopBarDefaults.BlurRadius
+            progressive = TopBarDefaults.hazeProgressive()
+          }
+        }
+    ) {
+      Spacer(Modifier.fillMaxWidth().height(topPadding + TopBarDefaults.Height))
+      Spacer(Modifier.height(TopBarDefaults.BlurFadeHeight))
+    }
+    Column(modifier = Modifier.fillMaxWidth()) {
+      Spacer(Modifier.fillMaxWidth().height(topPadding).background(fadeColor))
+      Spacer(
+        Modifier.fillMaxWidth()
+          .height(TopBarDefaults.Height + TopBarDefaults.BlurFadeHeight)
+          .background(navigationTopBarFadeBrush(fadeColor))
+      )
+    }
+  }
+}
+
+private fun navigationTopBarFadeBrush(color: Color): Brush {
+  val stops =
+    Array(NavigationTopBarFadeSamples + 1) { index ->
+      val t = index / NavigationTopBarFadeSamples.toFloat()
+      val alpha = color.alpha * (1f - SmootherstepEasing.transform(t))
+      t to color.copy(alpha = alpha)
+    }
+
+  return Brush.verticalGradient(colorStops = stops)
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -1523,6 +1523,16 @@ fun EditorScreen(entityId: String) {
             },
           )
         },
+        viewportSurfaceOverlay = {
+          if (!editorReady && runtime.error == null) {
+            EditorLoadingSkeleton(
+              layoutSpec = layoutSpec,
+              topInset = topInset,
+              background = background,
+              modifier = Modifier.fillMaxSize(),
+            )
+          }
+        },
         viewportOverlay = {
           if (editorReady) {
             EditorZoomOverlay(
@@ -1541,13 +1551,6 @@ fun EditorScreen(entityId: String) {
               layoutSpec = layoutSpec,
               pageSizes = layoutPageSizes,
               displayZoom = displayZoom,
-              modifier = Modifier.fillMaxSize(),
-            )
-          } else if (runtime.error == null) {
-            EditorLoadingSkeleton(
-              layoutSpec = layoutSpec,
-              topInset = topInset,
-              background = background,
               modifier = Modifier.fillMaxSize(),
             )
           }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayout.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayout.kt
@@ -23,6 +23,8 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.layer.GraphicsLayer
+import androidx.compose.ui.graphics.rememberGraphicsLayer
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollDispatcher
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -58,8 +60,12 @@ import co.typie.editor.scroll.resolveEditorScrollIntent
 import co.typie.editor.viewport.EditorViewportState
 import co.typie.ext.LocalScrollGestureLockState
 import co.typie.navigation.LocalNavigationPopNestedScroll
+import co.typie.navigation.NavigationForeground
 import co.typie.navigation.navigationPopNestedScroll
-import co.typie.screen.editor.editor.overlay.editorMagnifier
+import co.typie.screen.editor.editor.overlay.EditorMagnifierPlacement
+import co.typie.screen.editor.editor.overlay.editorNativeMagnifier
+import co.typie.screen.editor.editor.overlay.editorSoftwareMagnifierLens
+import co.typie.screen.editor.editor.overlay.editorSoftwareMagnifierSource
 import co.typie.screen.editor.editor.overlay.resolveEditorMagnifierPlacement
 import co.typie.screen.editor.editor.state.EditorScreenState
 import co.typie.ui.theme.LocalHazeState
@@ -74,6 +80,7 @@ import kotlinx.coroutines.launch
 
 private enum class EditorScreenLayoutSlot {
   ViewportContent,
+  ViewportSurfaceOverlay,
   ViewportOverlay,
   Overlay,
   Toolbar,
@@ -150,6 +157,7 @@ internal fun EditorScreenLayout(
   onMeasuredViewportSizeChange: (Size) -> Unit,
   header: @Composable () -> Unit,
   body: @Composable () -> Unit,
+  viewportSurfaceOverlay: @Composable BoxScope.() -> Unit = {},
   viewportOverlay: @Composable BoxScope.() -> Unit = {},
   overlay: @Composable () -> Unit = {},
   toolbar: @Composable () -> Unit,
@@ -209,213 +217,270 @@ internal fun EditorScreenLayout(
     remember(density) {
       { width, height -> Size(width = width / density.density, height = height / density.density) }
     }
+  val softwareMagnifierSource = rememberGraphicsLayer()
+  val editorInteractionModifier =
+    Modifier.editorInteractions(
+        interactionController = interactionScope.controller,
+        geometry = interactionScope,
+        screenPointerSequence = screenPointerSequence,
+        platformIndirectScaleBridge = platformIndirectScaleBridge,
+        scrollGestureLockState = scrollGestureLockState,
+        scrollableState = viewportScrollableState,
+        nestedScrollDispatcher = viewportNestedScrollDispatcher,
+        flingBehavior = viewportFlingBehavior,
+        touchSlop = viewConfiguration.touchSlop,
+        maximumFlingVelocity = viewConfiguration.maximumFlingVelocity,
+        density = density.density,
+        enabled = editorInteractionEnabled,
+        onEditorPointerInput = onEditorPointerInput,
+        onViewportIndirectInput = onViewportIndirectInput,
+        onNestedScrollCancel = { navigationPopNestedScroll?.cancel() },
+      )
+      .editorPlatformIndirectScale(
+        bridge = platformIndirectScaleBridge,
+        enabled = platformIndirectScaleEnabled,
+        density = density.density,
+      )
 
-  SubcomposeLayout(
+  Box(
     modifier =
       modifier
         .fillMaxSize()
         .observeEditorScreenPointerSequence(screenPointerSequence)
-        .editorMagnifier(magnifierPlacement)
+        .editorNativeMagnifier(magnifierPlacement)
         .onGloballyPositioned { coordinates ->
           layoutBoundsInRoot = coordinates.unclippedBoundsInRoot()
         }
-  ) { constraints ->
-    val editorInteractionModifier =
-      Modifier.editorInteractions(
-          interactionController = interactionScope.controller,
-          geometry = interactionScope,
-          screenPointerSequence = screenPointerSequence,
-          platformIndirectScaleBridge = platformIndirectScaleBridge,
-          scrollGestureLockState = scrollGestureLockState,
-          scrollableState = viewportScrollableState,
-          nestedScrollDispatcher = viewportNestedScrollDispatcher,
-          flingBehavior = viewportFlingBehavior,
-          touchSlop = viewConfiguration.touchSlop,
-          maximumFlingVelocity = viewConfiguration.maximumFlingVelocity,
-          density = density.density,
-          enabled = editorInteractionEnabled,
-          onEditorPointerInput = onEditorPointerInput,
-          onViewportIndirectInput = onViewportIndirectInput,
-          onNestedScrollCancel = { navigationPopNestedScroll?.cancel() },
+  ) {
+    SubcomposeLayout(
+      modifier =
+        Modifier.fillMaxSize()
+          .editorSoftwareMagnifierSource(
+            sourceLayer = softwareMagnifierSource,
+            active = magnifierPlacement != null,
+          )
+    ) { constraints ->
+      val viewportWidth = constraints.maxWidth / density.density
+      val resolvedContentWidth =
+        resolveEditorViewportContentWidth(
+          viewportWidth = viewportWidth,
+          contentTrackWidth = viewportContentWidth,
         )
-        .editorPlatformIndirectScale(
-          bridge = platformIndirectScaleBridge,
-          enabled = platformIndirectScaleEnabled,
-          density = density.density,
+      val viewportHeight = constraints.maxHeight
+      val viewportConstraints =
+        constraints.copy(
+          minWidth = constraints.maxWidth,
+          maxWidth = constraints.maxWidth,
+          minHeight = viewportHeight,
+          maxHeight = viewportHeight,
         )
-    val viewportWidth = constraints.maxWidth / density.density
-    val resolvedContentWidth =
-      resolveEditorViewportContentWidth(
-        viewportWidth = viewportWidth,
-        contentTrackWidth = viewportContentWidth,
-      )
-    val toolbarPlaceables =
-      subcompose(EditorScreenLayoutSlot.Toolbar, toolbar).map {
-        it.measure(constraints.copy(minWidth = 0, minHeight = 0))
-      }
-    val viewportHeight = constraints.maxHeight
-    val viewportConstraints =
-      constraints.copy(
-        minWidth = constraints.maxWidth,
-        maxWidth = constraints.maxWidth,
-        minHeight = viewportHeight,
-        maxHeight = viewportHeight,
-      )
-    val viewportContentPlaceables =
-      subcompose(EditorScreenLayoutSlot.ViewportContent) {
-          Layout(
-            modifier =
-              Modifier.fillMaxSize()
-                .clipToBounds()
-                .hazeSource(toolbarBackdropHazeState)
-                .navigationPopNestedScroll()
-                .nestedScroll(EditorViewportNestedScrollConnection, viewportNestedScrollDispatcher)
-                .then(editorInteractionModifier),
-            content = {
-              Column {
-                Box(modifier = Modifier.width(viewportWidth.dp)) { header() }
-                Box(
-                  modifier =
-                    Modifier.fillMaxWidth().graphicsLayer {
-                      translationX = -state.viewportState.scrollOffset.x * density.density
-                    }
-                ) {
-                  body()
-                }
-              }
-            },
-          ) { measurables, viewportConstraints ->
-            val contentConstraints =
-              resolveEditorViewportContentConstraints(
-                viewportWidthPx = viewportConstraints.maxWidth,
-                contentWidthPx = resolvedContentWidth.dp.roundToPx(),
-              )
-            val placeable = measurables.single().measure(contentConstraints)
-            val measuredViewportSize =
-              resolveSize(viewportConstraints.maxWidth, viewportConstraints.maxHeight)
-            val viewportSizeChanged =
-              state.viewportState.updateMeasuredBounds(
-                viewportSize = measuredViewportSize,
-                contentSize = resolveSize(placeable.width, placeable.height),
-              )
-            if (viewportSizeChanged) {
-              onMeasuredViewportSizeChange(measuredViewportSize)
-            }
-            val scrollFrameVersion = scrollFrame.state.version
-            val bringIntoViewRequest =
-              bringIntoViewRequests.activateForVersion(version = scrollFrameVersion)
-            if (bringIntoViewRequest != null) {
-              val bringIntoViewTarget = bringIntoViewRequest.target
-              if (
-                state.viewportState.isTransforming ||
-                  state.viewportState.isDirectManipulationInProgress
-              ) {
-                bringIntoViewRequests.cancel()
-              } else {
-                when (
-                  val scrollIntentResult =
-                    resolveEditorScrollIntent(
-                      frame = scrollFrame,
-                      target = bringIntoViewTarget,
-                      currentScroll = state.viewportState.scrollOffset.y,
-                    )
-                ) {
-                  EditorScrollIntentResult.Unresolved -> Unit
-                  EditorScrollIntentResult.ConsumedWithoutScroll -> {
-                    bringIntoViewRequests.markApplied(
-                      version = scrollFrameVersion,
-                      request = bringIntoViewRequest,
-                    )
+      val viewportContentPlaceables =
+        subcompose(EditorScreenLayoutSlot.ViewportContent) {
+            Layout(
+              modifier =
+                Modifier.fillMaxSize()
+                  .clipToBounds()
+                  .hazeSource(toolbarBackdropHazeState)
+                  .navigationPopNestedScroll()
+                  .nestedScroll(
+                    EditorViewportNestedScrollConnection,
+                    viewportNestedScrollDispatcher,
+                  )
+                  .then(editorInteractionModifier),
+              content = {
+                Column {
+                  Box(modifier = Modifier.width(viewportWidth.dp)) { header() }
+                  Box(
+                    modifier =
+                      Modifier.fillMaxWidth().graphicsLayer {
+                        translationX = -state.viewportState.scrollOffset.x * density.density
+                      }
+                  ) {
+                    body()
                   }
-                  is EditorScrollIntentResult.ScrollTo -> {
-                    if (
+                }
+              },
+            ) { measurables, viewportConstraints ->
+              val contentConstraints =
+                resolveEditorViewportContentConstraints(
+                  viewportWidthPx = viewportConstraints.maxWidth,
+                  contentWidthPx = resolvedContentWidth.dp.roundToPx(),
+                )
+              val placeable = measurables.single().measure(contentConstraints)
+              val measuredViewportSize =
+                resolveSize(viewportConstraints.maxWidth, viewportConstraints.maxHeight)
+              val viewportSizeChanged =
+                state.viewportState.updateMeasuredBounds(
+                  viewportSize = measuredViewportSize,
+                  contentSize = resolveSize(placeable.width, placeable.height),
+                )
+              if (viewportSizeChanged) {
+                onMeasuredViewportSizeChange(measuredViewportSize)
+              }
+              val scrollFrameVersion = scrollFrame.state.version
+              val bringIntoViewRequest =
+                bringIntoViewRequests.activateForVersion(version = scrollFrameVersion)
+              if (bringIntoViewRequest != null) {
+                val bringIntoViewTarget = bringIntoViewRequest.target
+                if (
+                  state.viewportState.isTransforming ||
+                    state.viewportState.isDirectManipulationInProgress
+                ) {
+                  bringIntoViewRequests.cancel()
+                } else {
+                  when (
+                    val scrollIntentResult =
+                      resolveEditorScrollIntent(
+                        frame = scrollFrame,
+                        target = bringIntoViewTarget,
+                        currentScroll = state.viewportState.scrollOffset.y,
+                      )
+                  ) {
+                    EditorScrollIntentResult.Unresolved -> Unit
+                    EditorScrollIntentResult.ConsumedWithoutScroll -> {
                       bringIntoViewRequests.markApplied(
                         version = scrollFrameVersion,
                         request = bringIntoViewRequest,
                       )
-                    ) {
-                      smoothScrollJob?.cancel()
-                      smoothScrollJob =
-                        when (bringIntoViewRequest.behavior) {
-                          EditorBringIntoViewBehavior.Instant -> {
-                            state.viewportState.scrollToY(
-                              targetY = scrollIntentResult.y,
-                              isAutoScroll = true,
-                            )
-                            null
-                          }
+                    }
+                    is EditorScrollIntentResult.ScrollTo -> {
+                      if (
+                        bringIntoViewRequests.markApplied(
+                          version = scrollFrameVersion,
+                          request = bringIntoViewRequest,
+                        )
+                      ) {
+                        smoothScrollJob?.cancel()
+                        smoothScrollJob =
+                          when (bringIntoViewRequest.behavior) {
+                            EditorBringIntoViewBehavior.Instant -> {
+                              state.viewportState.scrollToY(
+                                targetY = scrollIntentResult.y,
+                                isAutoScroll = true,
+                              )
+                              null
+                            }
 
-                          EditorBringIntoViewBehavior.Smooth ->
-                            coroutineScope.launch {
-                              try {
-                                state.viewportState.animateScrollToY(
-                                  targetY = scrollIntentResult.y,
-                                  isAutoScroll = true,
-                                )
-                              } finally {
-                                if (smoothScrollJob == coroutineContext[Job]) {
-                                  smoothScrollJob = null
+                            EditorBringIntoViewBehavior.Smooth ->
+                              coroutineScope.launch {
+                                try {
+                                  state.viewportState.animateScrollToY(
+                                    targetY = scrollIntentResult.y,
+                                    isAutoScroll = true,
+                                  )
+                                } finally {
+                                  if (smoothScrollJob == coroutineContext[Job]) {
+                                    smoothScrollJob = null
+                                  }
                                 }
                               }
-                            }
-                        }
+                          }
+                      }
                     }
                   }
                 }
+              } else {
+                scrollReconcileState.reconcile(
+                  mode = viewportScrollReconcileMode,
+                  viewportState = state.viewportState,
+                  scrollFrame = scrollFrame,
+                  visibleArea = visibleArea,
+                )
               }
-            } else {
-              scrollReconcileState.reconcile(
-                mode = viewportScrollReconcileMode,
-                viewportState = state.viewportState,
-                scrollFrame = scrollFrame,
-                visibleArea = visibleArea,
-              )
-            }
 
-            layout(width = viewportConstraints.maxWidth, height = viewportConstraints.maxHeight) {
-              val scrollY = (state.viewportState.scrollOffset.y * density.density).roundToInt()
-              placeable.place(x = 0, y = -scrollY)
+              layout(width = viewportConstraints.maxWidth, height = viewportConstraints.maxHeight) {
+                val scrollY = (state.viewportState.scrollOffset.y * density.density).roundToInt()
+                placeable.place(x = 0, y = -scrollY)
+              }
             }
           }
-        }
-        .map { it.measure(viewportConstraints) }
+          .map { it.measure(viewportConstraints) }
+      val viewportSurfaceOverlayPlaceables =
+        subcompose(EditorScreenLayoutSlot.ViewportSurfaceOverlay) {
+            Box(modifier = Modifier.fillMaxSize().clipToBounds(), content = viewportSurfaceOverlay)
+          }
+          .map { it.measure(viewportConstraints) }
+
+      layout(width = constraints.maxWidth, height = constraints.maxHeight) {
+        viewportContentPlaceables.forEach { it.place(x = 0, y = 0) }
+        viewportSurfaceOverlayPlaceables.forEach { it.place(x = 0, y = 0) }
+      }
+    }
+
+    NavigationForeground(sharePointerInputWithSiblings = true) {
+      EditorViewportOverlayLayout(viewportOverlay)
+    }
+    NavigationForeground {
+      EditorScreenForegroundLayout(
+        overlay = overlay,
+        toolbar = toolbar,
+        subPane = subPane,
+        softwareMagnifierSource = softwareMagnifierSource,
+        magnifierPlacement = magnifierPlacement,
+      )
+    }
+  }
+}
+
+@Composable
+private fun EditorViewportOverlayLayout(viewportOverlay: @Composable BoxScope.() -> Unit) {
+  SubcomposeLayout(modifier = Modifier.fillMaxSize().sharePointerInputWithSiblings()) { constraints
+    ->
+    val viewportConstraints =
+      constraints.copy(
+        minWidth = constraints.maxWidth,
+        maxWidth = constraints.maxWidth,
+        minHeight = constraints.maxHeight,
+        maxHeight = constraints.maxHeight,
+      )
     val viewportOverlayPlaceables =
       subcompose(EditorScreenLayoutSlot.ViewportOverlay) {
-          Box(
-            modifier = Modifier.fillMaxSize().clipToBounds().sharePointerInputWithSiblings(),
-            content = viewportOverlay,
-          )
+          Box(modifier = Modifier.fillMaxSize().clipToBounds(), content = viewportOverlay)
         }
         .map { it.measure(viewportConstraints) }
-    val overlayPlaceables =
-      subcompose(EditorScreenLayoutSlot.Overlay, overlay).map {
-        it.measure(
-          constraints.copy(
-            minWidth = constraints.maxWidth,
-            maxWidth = constraints.maxWidth,
-            minHeight = constraints.maxHeight,
-            maxHeight = constraints.maxHeight,
-          )
+
+    layout(width = constraints.maxWidth, height = constraints.maxHeight) {
+      viewportOverlayPlaceables.forEach { it.place(x = 0, y = 0) }
+    }
+  }
+}
+
+@Composable
+private fun EditorScreenForegroundLayout(
+  overlay: @Composable () -> Unit,
+  toolbar: @Composable () -> Unit,
+  subPane: @Composable BoxScope.() -> Unit,
+  softwareMagnifierSource: GraphicsLayer,
+  magnifierPlacement: EditorMagnifierPlacement?,
+) {
+  SubcomposeLayout(
+    modifier =
+      Modifier.fillMaxSize()
+        .editorSoftwareMagnifierLens(
+          sourceLayer = softwareMagnifierSource,
+          placement = magnifierPlacement,
         )
+  ) { constraints ->
+    val fullConstraints =
+      constraints.copy(
+        minWidth = constraints.maxWidth,
+        maxWidth = constraints.maxWidth,
+        minHeight = constraints.maxHeight,
+        maxHeight = constraints.maxHeight,
+      )
+    val overlayPlaceables =
+      subcompose(EditorScreenLayoutSlot.Overlay, overlay).map { it.measure(fullConstraints) }
+    val toolbarPlaceables =
+      subcompose(EditorScreenLayoutSlot.Toolbar, toolbar).map {
+        it.measure(constraints.copy(minWidth = 0, minHeight = 0))
       }
     val subPanePlaceables =
       subcompose(EditorScreenLayoutSlot.SubPane) {
           Box(modifier = Modifier.fillMaxSize(), content = subPane)
         }
-        .map {
-          it.measure(
-            constraints.copy(
-              minWidth = constraints.maxWidth,
-              maxWidth = constraints.maxWidth,
-              minHeight = constraints.maxHeight,
-              maxHeight = constraints.maxHeight,
-            )
-          )
-        }
+        .map { it.measure(fullConstraints) }
 
     layout(width = constraints.maxWidth, height = constraints.maxHeight) {
-      viewportContentPlaceables.forEach { it.place(x = 0, y = 0) }
-      viewportOverlayPlaceables.forEach { it.place(x = 0, y = 0) }
       overlayPlaceables.forEach { it.place(x = 0, y = 0) }
       toolbarPlaceables.forEach { it.place(x = 0, y = constraints.maxHeight - it.height) }
       subPanePlaceables.forEach { it.place(x = 0, y = 0) }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorNativeMagnifier.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorNativeMagnifier.kt
@@ -14,6 +14,8 @@ import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.clipPath
 import androidx.compose.ui.graphics.drawscope.withTransform
+import androidx.compose.ui.graphics.layer.GraphicsLayer
+import androidx.compose.ui.graphics.layer.drawLayer
 import androidx.compose.ui.unit.dp
 import co.typie.editor.scroll.EditorVisibleArea
 import co.typie.ui.theme.AppTheme
@@ -80,11 +82,15 @@ internal expect val EditorNativeMagnifierAvailable: Boolean
 internal expect fun Modifier.editorNativeMagnifier(placement: EditorMagnifierPlacement?): Modifier
 
 @Composable
-internal fun Modifier.editorMagnifier(placement: EditorMagnifierPlacement?): Modifier =
+internal fun Modifier.editorSoftwareMagnifierLens(
+  sourceLayer: GraphicsLayer,
+  placement: EditorMagnifierPlacement?,
+): Modifier =
   if (EditorNativeMagnifierAvailable) {
-    editorNativeMagnifier(placement)
+    this
   } else {
     editorSoftwareMagnifier(
+      sourceLayer = sourceLayer,
       placement = placement,
       borderColor = AppTheme.colors.borderDefault,
       shadowColor = Color.Black.copy(alpha = EditorSoftwareMagnifierShadowAlpha),
@@ -92,7 +98,21 @@ internal fun Modifier.editorMagnifier(placement: EditorMagnifierPlacement?): Mod
     )
   }
 
+internal fun Modifier.editorSoftwareMagnifierSource(
+  sourceLayer: GraphicsLayer,
+  active: Boolean,
+): Modifier =
+  if (EditorNativeMagnifierAvailable || !active) {
+    this
+  } else {
+    drawWithContent {
+      sourceLayer.record { this@drawWithContent.drawContent() }
+      drawLayer(sourceLayer)
+    }
+  }
+
 private fun Modifier.editorSoftwareMagnifier(
+  sourceLayer: GraphicsLayer,
   placement: EditorMagnifierPlacement?,
   borderColor: Color,
   shadowColor: Color,
@@ -156,7 +176,7 @@ private fun Modifier.editorSoftwareMagnifier(
       scale(scaleX = EditorMagnifierZoom, scaleY = EditorMagnifierZoom, pivot = Offset.Zero)
       translate(left = -placement.sourceCenter.x, top = -placement.sourceCenter.y)
     }) {
-      this@drawWithContent.drawContent()
+      drawLayer(sourceLayer)
     }
   }
   drawRoundRect(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/textreplacements/TextReplacementsScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/textreplacements/TextReplacementsScreen.kt
@@ -46,7 +46,6 @@ import co.typie.ui.component.sheet.LocalSheet
 import co.typie.ui.component.toast.LocalToast
 import co.typie.ui.component.topbar.ProvideTopBar
 import co.typie.ui.component.topbar.TopBarButton
-import co.typie.ui.component.topbar.TopBarDefaults
 import co.typie.ui.component.topbar.topBarScrollOffset
 import co.typie.ui.icon.Icon
 import co.typie.ui.state.rememberScrollState
@@ -90,13 +89,7 @@ fun TextReplacementsScreen() {
         Modifier.fillMaxSize()
           .reorderableViewport(
             state = reorderState,
-            viewportTopInset =
-              maxOf(
-                0.dp,
-                contentPadding.calculateTopPadding() -
-                  TopBarDefaults.BlurFadeHeight -
-                  TopBarDefaults.ContentTopSpacing,
-              ),
+            viewportTopInset = contentPadding.calculateTopPadding(),
           )
     ) {
       Column(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/folder/FolderScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/folder/FolderScreen.kt
@@ -423,13 +423,7 @@ fun FolderScreen(entityId: String) {
       )
     },
   ) { contentPadding ->
-    val reorderViewportTopInset =
-      maxOf(
-        0.dp,
-        contentPadding.calculateTopPadding() -
-          TopBarDefaults.BlurFadeHeight -
-          TopBarDefaults.ContentTopSpacing,
-      )
+    val reorderViewportTopInset = contentPadding.calculateTopPadding()
     val reorderViewportBottomInset =
       WindowInsets.safeDrawing.asPaddingValues().calculateBottomPadding() + overlayBaseBottomInset
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/notes/NotesScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/notes/NotesScreen.kt
@@ -69,7 +69,6 @@ import co.typie.ui.component.toast.ToastAnchor
 import co.typie.ui.component.toast.ToastType
 import co.typie.ui.component.topbar.ProvideTopBar
 import co.typie.ui.component.topbar.TopBarButton
-import co.typie.ui.component.topbar.TopBarDefaults
 import co.typie.ui.component.topbar.topBarScrollOffset
 import co.typie.ui.icon.Icon
 import co.typie.ui.skeleton.Skeleton
@@ -411,13 +410,7 @@ fun NotesScreen() {
           },
         )
       val reorderState = rememberNoteListReorderState(items = listItems, scrollState = scrollState)
-      val reorderViewportTopInset =
-        maxOf(
-          0.dp,
-          contentPadding.calculateTopPadding() -
-            TopBarDefaults.BlurFadeHeight -
-            TopBarDefaults.ContentTopSpacing,
-        )
+      val reorderViewportTopInset = contentPadding.calculateTopPadding()
       val reorderViewportBottomInset =
         WindowInsets.safeDrawing.asPaddingValues().calculateBottomPadding() + 72.dp
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/space/SpaceScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/space/SpaceScreen.kt
@@ -95,7 +95,6 @@ import co.typie.ui.component.toast.LocalToast
 import co.typie.ui.component.toast.ToastAnchor
 import co.typie.ui.component.toast.ToastType
 import co.typie.ui.component.topbar.ProvideTopBar
-import co.typie.ui.component.topbar.TopBarDefaults
 import co.typie.ui.state.rememberScrollState
 import co.typie.ui.theme.AppTheme
 import kotlin.time.Duration
@@ -389,13 +388,7 @@ fun SpaceScreen() {
       )
     },
   ) { contentPadding ->
-    val reorderViewportTopInset =
-      maxOf(
-        0.dp,
-        contentPadding.calculateTopPadding() -
-          TopBarDefaults.BlurFadeHeight -
-          TopBarDefaults.ContentTopSpacing,
-      )
+    val reorderViewportTopInset = contentPadding.calculateTopPadding()
     val reorderViewportBottomInset =
       WindowInsets.safeDrawing.asPaddingValues().calculateBottomPadding() + overlayBaseBottomInset
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/Screen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/Screen.kt
@@ -34,19 +34,16 @@ import co.typie.ext.navigationBarsPadding
 import co.typie.ext.plus
 import co.typie.ext.safeDrawingHorizontal
 import co.typie.navigation.Nav
+import co.typie.navigation.NavigationForeground
+import co.typie.navigation.PublishNavigationTopBarBackdropStyle
 import co.typie.ui.component.bottombar.BottomBarDefaults
 import co.typie.ui.component.bottombar.LocalBottomBarAnimationSource
 import co.typie.ui.component.dialog.LocalDialog
 import co.typie.ui.component.dialog.error
-import co.typie.ui.component.topbar.LocalTopBarAnimationSource
 import co.typie.ui.component.topbar.LocalTopBarState
 import co.typie.ui.component.topbar.TopBarDefaults
 import co.typie.ui.skeleton.Skeleton
 import co.typie.ui.theme.AppTheme
-import dev.chrisbanes.haze.HazeState
-import dev.chrisbanes.haze.blur.blurEffect
-import dev.chrisbanes.haze.hazeEffect
-import dev.chrisbanes.haze.hazeSource
 
 private val MaxContentWidth = 600.dp
 private const val OverlayFadeSamples = 48
@@ -61,7 +58,7 @@ fun Screen(
   overlay: (@Composable BoxScope.() -> Unit)? = null,
   content: @Composable BoxScope.(contentPadding: PaddingValues) -> Unit,
 ) {
-  val hazeState = remember { HazeState() }
+  PublishNavigationTopBarBackdropStyle(background)
 
   val topBarState = LocalTopBarState.current
   val hasTopBar = topBarState != null && topBarState.enabled && topBarState.visible
@@ -76,10 +73,11 @@ fun Screen(
     PaddingValues(bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding())
   val contentPadding =
     if (hasTopBar) {
-      PaddingValues(
-        top =
-          TopBarDefaults.Height + TopBarDefaults.BlurFadeHeight + TopBarDefaults.ContentTopSpacing
-      ) + contentPadding + topBarPadding + horizontalSafePadding + navigationBarPadding
+      PaddingValues(top = TopBarDefaults.Height) +
+        contentPadding +
+        topBarPadding +
+        horizontalSafePadding +
+        navigationBarPadding
     } else {
       contentPadding + horizontalSafePadding + navigationBarPadding
     }
@@ -109,51 +107,11 @@ fun Screen(
       )
   ) {
     Box(
-      modifier = Modifier.fillMaxSize().hazeSource(hazeState).widthIn(max = MaxContentWidth),
+      modifier = Modifier.fillMaxSize().widthIn(max = MaxContentWidth),
       contentAlignment = Alignment.TopCenter,
     ) {
       Skeleton(enabled = loadable != null && loadable.state !is LoadableState.Success) {
         Box(modifier = Modifier.fillMaxSize()) { content(contentPadding) }
-      }
-    }
-
-    val topBarAlpha = LocalTopBarAnimationSource.current?.animatedAlpha ?: 0f
-    val topBarTranslationY = LocalTopBarAnimationSource.current?.animatedTranslationY ?: 0f
-    if (topBarState?.enabled == true && topBarAlpha > 0f) {
-      val topBarSolidHeight = 0.dp
-      val topBarFadeHeight = TopBarDefaults.Height + TopBarDefaults.BlurFadeHeight
-      val topBarOverlayModifier =
-        Modifier.fillMaxWidth().align(Alignment.TopCenter).graphicsLayer {
-          alpha = topBarAlpha
-          translationY = topBarTranslationY * size.height
-        }
-
-      Column(
-        modifier =
-          topBarOverlayModifier.hazeEffect(hazeState) {
-            blurEffect {
-              backgroundColor = background
-              blurRadius = TopBarDefaults.BlurRadius
-              progressive = TopBarDefaults.hazeProgressive()
-            }
-          }
-      ) {
-        Spacer(Modifier.fillMaxWidth().height(TopBarDefaults.topPadding() + TopBarDefaults.Height))
-        Spacer(Modifier.height(TopBarDefaults.BlurFadeHeight))
-      }
-
-      val fadeColor = background.copy(alpha = TopBarDefaults.FadeOpacity)
-      Column(modifier = topBarOverlayModifier) {
-        Spacer(
-          Modifier.fillMaxWidth()
-            .background(fadeColor)
-            .height(TopBarDefaults.topPadding() + topBarSolidHeight)
-        )
-        Spacer(
-          Modifier.fillMaxWidth()
-            .height(topBarFadeHeight)
-            .background(overlayFadeBrush(color = fadeColor, reverse = false))
-        )
       }
     }
 
@@ -184,7 +142,9 @@ fun Screen(
       }
     }
 
-    overlay?.invoke(this)
+    overlay?.let { overlayContent ->
+      NavigationForeground { Box(Modifier.fillMaxSize(), content = overlayContent) }
+    }
   }
 }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/topbar/TopBarDefaults.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/topbar/TopBarDefaults.kt
@@ -28,7 +28,6 @@ object TopBarDefaults {
   val BlurRadius: Dp = 6.dp
   val BlurFadeHeight: Dp = 16.dp
   val FadeOpacity: Float = 0.8f
-  val ContentTopSpacing: Dp = 8.dp
   val BlurFadeEasing: Easing = SmootherstepEasing
 
   val RevealAnimationDuration: Int = 200
@@ -61,7 +60,7 @@ object TopBarDefaults {
       horizontalSafeArea.calculateLeftPadding(direction) > 0.dp ||
         horizontalSafeArea.calculateRightPadding(direction) > 0.dp
 
-    return if (statusTop == 0.dp && hasHorizontalSafeArea) LandscapeTopPadding else statusTop
+    return resolveTopBarTopPadding(statusTop, hasHorizontalSafeArea)
   }
 
   @Composable fun topPaddingValues(): PaddingValues = PaddingValues(top = topPadding())
@@ -70,3 +69,10 @@ object TopBarDefaults {
 
   @Composable fun controlBorderColor(): Color = AppTheme.colors.borderEmphasis
 }
+
+internal fun resolveTopBarTopPadding(statusTop: Dp, hasHorizontalSafeArea: Boolean): Dp =
+  if (statusTop == 0.dp && hasHorizontalSafeArea) {
+    TopBarDefaults.LandscapeTopPadding
+  } else {
+    statusTop
+  }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/navigation/NavigationTopBarBackdropTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/navigation/NavigationTopBarBackdropTest.kt
@@ -1,0 +1,94 @@
+package co.typie.navigation
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class NavigationTopBarBackdropTest {
+  @Test
+  fun visibleMainRouteUsesPublishedBackgroundAndPresence() {
+    val style =
+      resolveNavigationTopBarBackdropStyle(
+        behindBackground = null,
+        behindPresence = 0f,
+        mainBackground = Color.Red,
+        mainPresence = 1f,
+        mainWeight = 1f,
+        fallbackBackground = Color.Black,
+      )
+
+    assertEquals(Color.Red, style.background)
+    assertEquals(1f, style.presence)
+  }
+
+  @Test
+  fun routeWithoutTopBarContributesZeroPresence() {
+    val style =
+      resolveNavigationTopBarBackdropStyle(
+        behindBackground = Color.Red,
+        behindPresence = 1f,
+        mainBackground = Color.Blue,
+        mainPresence = 0f,
+        mainWeight = 0.25f,
+        fallbackBackground = Color.Black,
+      )
+
+    assertEquals(0.75f, style.presence)
+  }
+
+  @Test
+  fun transitionInterpolatesBackgroundAndPresenceContinuously() {
+    val midpoint =
+      resolveNavigationTopBarBackdropStyle(
+        behindBackground = Color.Red,
+        behindPresence = 0f,
+        mainBackground = Color.Blue,
+        mainPresence = 1f,
+        mainWeight = 0.5f,
+        fallbackBackground = Color.Black,
+      )
+
+    assertEquals(lerp(Color.Red, Color.Blue, 0.5f), midpoint.background)
+    assertEquals(0.5f, midpoint.presence)
+  }
+
+  @Test
+  fun completedPopMatchesDestinationIdleStyle() {
+    val beforeRoleSwitch =
+      resolveNavigationTopBarBackdropStyle(
+        behindBackground = Color.Red,
+        behindPresence = 1f,
+        mainBackground = Color.Blue,
+        mainPresence = 0f,
+        mainWeight = 0f,
+        fallbackBackground = Color.Black,
+      )
+    val afterRoleSwitch =
+      resolveNavigationTopBarBackdropStyle(
+        behindBackground = null,
+        behindPresence = 0f,
+        mainBackground = Color.Red,
+        mainPresence = 1f,
+        mainWeight = 1f,
+        fallbackBackground = Color.Black,
+      )
+
+    assertEquals(afterRoleSwitch, beforeRoleSwitch)
+  }
+
+  @Test
+  fun missingPublicationUsesFallbackBackground() {
+    val style =
+      resolveNavigationTopBarBackdropStyle(
+        behindBackground = null,
+        behindPresence = 1f,
+        mainBackground = null,
+        mainPresence = 1f,
+        mainWeight = 0.4f,
+        fallbackBackground = Color.Green,
+      )
+
+    assertEquals(Color.Green, style.background)
+  }
+}

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/ui/component/topbar/TopBarDefaultsTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/ui/component/topbar/TopBarDefaultsTest.kt
@@ -1,0 +1,25 @@
+package co.typie.ui.component.topbar
+
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TopBarDefaultsTest {
+  @Test
+  fun statusBarInsetIsTheTopPadding() {
+    assertEquals(24.dp, resolveTopBarTopPadding(statusTop = 24.dp, hasHorizontalSafeArea = true))
+  }
+
+  @Test
+  fun zeroInsetsHaveNoTopPadding() {
+    assertEquals(0.dp, resolveTopBarTopPadding(statusTop = 0.dp, hasHorizontalSafeArea = false))
+  }
+
+  @Test
+  fun horizontalSafeAreaUsesLandscapeTopPaddingWithoutStatusBar() {
+    assertEquals(
+      TopBarDefaults.LandscapeTopPadding,
+      resolveTopBarTopPadding(statusTop = 0.dp, hasHorizontalSafeArea = true),
+    )
+  }
+}

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/NavigationStackDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/NavigationStackDesktopTest.kt
@@ -12,12 +12,15 @@ import androidx.compose.foundation.gestures.scrollable2D
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChange
@@ -33,6 +36,10 @@ import androidx.compose.ui.test.performTrackpadInput
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.dp
 import co.typie.route.Route
+import co.typie.ui.component.bottombar.BottomBarState
+import co.typie.ui.component.bottombar.LocalBottomBarState
+import co.typie.ui.component.topbar.LocalTopBarState
+import co.typie.ui.component.topbar.ProvideTopBar
 import co.typie.ui.component.topbar.TopBarState
 import kotlin.math.abs
 import kotlin.test.Test
@@ -46,6 +53,271 @@ import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalTestApi::class)
 class NavigationStackDesktopTest {
+  @Test
+  fun navigationForegroundCanSharePointerInputWithRouteSurface() = runComposeUiTest {
+    val navigator = Navigator(Route.Home)
+    val editorRoute = Route.Editor("document-id")
+    var surfaceDownCount = 0
+
+    setContent {
+      NavigationStack(
+        navigator = navigator,
+        topBarState = remember { TopBarState() },
+        modifier = Modifier.size(width = 320.dp, height = 640.dp),
+      ) { route ->
+        Box(
+          Modifier.fillMaxSize()
+            .pointerInput(Unit) {
+              awaitEachGesture {
+                awaitFirstDown(requireUnconsumed = false)
+                surfaceDownCount += 1
+              }
+            }
+            .testTag("surface-$route")
+        )
+        NavigationForeground(sharePointerInputWithSiblings = true) {
+          Box(Modifier.fillMaxSize().testTag("foreground-$route"))
+        }
+      }
+      LaunchedEffect(Unit) { navigator.navigate(editorRoute) }
+    }
+    waitUntil { navigator.current == editorRoute && !navigator.isTransitioning }
+
+    onNodeWithTag("foreground-$editorRoute").performTouchInput {
+      down(center)
+      up()
+    }
+    waitForIdle()
+
+    assertEquals(1, surfaceDownCount)
+  }
+
+  @Test
+  fun navigationForegroundRendersLocallyWithoutHost() = runComposeUiTest {
+    setContent { NavigationForeground { Box(Modifier.size(20.dp).testTag(ForegroundFallbackTag)) } }
+
+    onNodeWithTag(ForegroundFallbackTag).assertExists()
+  }
+
+  @Test
+  fun navigationForegroundPreservesRouteIdentityAndDeclarationContext() = runComposeUiTest {
+    val navigator = Navigator(Route.Home)
+    val editorRoute = Route.Editor("document-id")
+    val coveringRoute = Route.Document("covering-document-id")
+    val topBarState = TopBarState()
+    val bottomBarState = BottomBarState()
+    val navigateAway = CompletableDeferred<Unit>()
+    val returnToEditor = CompletableDeferred<Unit>()
+    val foregroundIdentities = mutableMapOf<Route, Any>()
+    val foregroundAttachCounts = mutableMapOf<Route, Int>()
+    val foregroundDisposeCounts = mutableMapOf<Route, Int>()
+    val observedRoutes = mutableMapOf<Route, Route?>()
+    val observedContexts = mutableMapOf<Route, String>()
+    val observedTopBars = mutableMapOf<Route, TopBarState?>()
+    val observedBottomBars = mutableMapOf<Route, BottomBarState?>()
+
+    setContent {
+      NavigationStack(
+        navigator = navigator,
+        topBarState = topBarState,
+        bottomBarState = bottomBarState,
+        modifier = Modifier.size(width = 320.dp, height = 640.dp),
+      ) { route ->
+        CompositionLocalProvider(LocalForegroundTestValue provides "context-$route") {
+          Box(Modifier.fillMaxSize().testTag("surface-$route"))
+          NavigationForeground {
+            val identity = remember { Any() }
+            foregroundIdentities.putIfAbsent(route, identity)
+            observedRoutes[route] = LocalRoute.current
+            observedContexts[route] = LocalForegroundTestValue.current
+            observedTopBars[route] = LocalTopBarState.current
+            observedBottomBars[route] = LocalBottomBarState.current
+            DisposableEffect(identity) {
+              foregroundAttachCounts[route] = foregroundAttachCounts.getOrElse(route) { 0 } + 1
+              onDispose {
+                foregroundDisposeCounts[route] = foregroundDisposeCounts.getOrElse(route) { 0 } + 1
+              }
+            }
+            Box(Modifier.fillMaxSize().testTag("foreground-$route"))
+          }
+        }
+      }
+      LaunchedEffect(Unit) {
+        navigator.navigate(editorRoute)
+        navigateAway.await()
+        navigator.navigate(coveringRoute)
+        returnToEditor.await()
+        navigator.pop()
+      }
+    }
+
+    waitUntil { navigator.current == editorRoute && !navigator.isTransitioning }
+    onAllNodes(hasTestTag("foreground-$editorRoute")).assertCountEquals(1)
+    val editorForegroundIdentity = foregroundIdentities.getValue(editorRoute)
+    assertEquals(editorRoute, observedRoutes[editorRoute])
+    assertEquals("context-$editorRoute", observedContexts[editorRoute])
+    assertTrue(observedTopBars[editorRoute] === topBarState)
+    assertTrue(observedBottomBars[editorRoute] === bottomBarState)
+
+    navigateAway.complete(Unit)
+    waitUntil { navigator.current == coveringRoute && !navigator.isTransitioning }
+    assertEquals(1, foregroundAttachCounts[editorRoute])
+    assertEquals(0, foregroundDisposeCounts[editorRoute] ?: 0)
+    assertEquals(null, observedTopBars[editorRoute])
+    assertEquals(null, observedBottomBars[editorRoute])
+
+    returnToEditor.complete(Unit)
+    waitUntil { navigator.current == editorRoute && !navigator.isTransitioning }
+    onAllNodes(hasTestTag("foreground-$editorRoute")).assertCountEquals(1)
+    assertTrue(foregroundIdentities[editorRoute] === editorForegroundIdentity)
+    assertEquals(1, foregroundAttachCounts[editorRoute])
+    assertEquals(0, foregroundDisposeCounts[editorRoute] ?: 0)
+    assertTrue(observedTopBars[editorRoute] === topBarState)
+    assertTrue(observedBottomBars[editorRoute] === bottomBarState)
+  }
+
+  @Test
+  fun navigationForegroundMatchesSurfaceDuringDirectBackDrag() = runComposeUiTest {
+    val navigator = Navigator(Route.Home)
+    val editorRoute = Route.Editor("document-id")
+    var platformTouchSlop = 0f
+
+    setContent {
+      platformTouchSlop = LocalViewConfiguration.current.touchSlop
+      NavigationStack(
+        navigator = navigator,
+        topBarState = remember { TopBarState() },
+        modifier = Modifier.size(width = 320.dp, height = 640.dp),
+      ) { route ->
+        Box(Modifier.fillMaxSize().testTag("surface-$route"))
+        NavigationForeground { Box(Modifier.fillMaxSize().testTag("foreground-$route")) }
+      }
+      LaunchedEffect(Unit) { navigator.navigate(editorRoute) }
+    }
+    waitUntil { navigator.current == editorRoute && !navigator.isTransitioning }
+
+    val surface = onNodeWithTag("surface-$editorRoute")
+    val foreground = onNodeWithTag("foreground-$editorRoute")
+    foreground.performTouchInput {
+      down(center)
+      moveBy(Offset(x = platformTouchSlop * 4f, y = 0f), delayMillis = 100L)
+    }
+    waitUntil { surface.fetchSemanticsNode().boundsInRoot.left > 1f }
+
+    assertEquals(
+      surface.fetchSemanticsNode().boundsInRoot.left,
+      foreground.fetchSemanticsNode().boundsInRoot.left,
+      absoluteTolerance = 0.5f,
+    )
+
+    foreground.performTouchInput { up() }
+    waitUntil { !navigator.isTransitioning }
+  }
+
+  @Test
+  fun topBarBackdropStaysFixedOverLiveTransitionSurfaceComposite() = runComposeUiTest {
+    val navigator = Navigator(Route.Home)
+    val editorRoute = Route.Editor("document-id")
+    val topBarState = TopBarState().apply { animatedAlpha = 1f }
+    var platformTouchSlop = 0f
+
+    setContent {
+      platformTouchSlop = LocalViewConfiguration.current.touchSlop
+      NavigationStack(
+        navigator = navigator,
+        topBarState = topBarState,
+        modifier = Modifier.size(width = 320.dp, height = 640.dp),
+      ) { route ->
+        PublishNavigationTopBarBackdropStyle(
+          background = if (route == editorRoute) Color.Blue else Color.Red
+        )
+        ProvideTopBar()
+        Box(Modifier.fillMaxSize().testTag("surface-$route"))
+        NavigationForeground { Box(Modifier.fillMaxSize().testTag("foreground-$route")) }
+      }
+      LaunchedEffect(Unit) { navigator.navigate(editorRoute) }
+    }
+    waitUntil { navigator.current == editorRoute && !navigator.isTransitioning }
+
+    val surface = onNodeWithTag("surface-$editorRoute")
+    val foreground = onNodeWithTag("foreground-$editorRoute")
+    foreground.performTouchInput {
+      down(center)
+      moveBy(Offset(x = platformTouchSlop * 4f, y = 0f), delayMillis = 100L)
+    }
+    waitUntil { surface.fetchSemanticsNode().boundsInRoot.left > 1f }
+
+    assertEquals(
+      0f,
+      onNodeWithTag(NavigationTopBarBackdropTestTag).fetchSemanticsNode().boundsInRoot.left,
+      absoluteTolerance = 0.5f,
+    )
+    assertEquals(
+      0f,
+      onNodeWithTag(NavigationSceneSurfaceCompositeTestTag).fetchSemanticsNode().boundsInRoot.left,
+      absoluteTolerance = 0.5f,
+    )
+    onNodeWithTag("surface-${Route.Home}").assertExists()
+    assertEquals(
+      surface.fetchSemanticsNode().boundsInRoot.left,
+      foreground.fetchSemanticsNode().boundsInRoot.left,
+      absoluteTolerance = 0.5f,
+    )
+
+    foreground.performTouchInput { up() }
+    waitUntil { !navigator.isTransitioning }
+  }
+
+  @Test
+  fun foregroundScrollableChildOwnsDragBeforeFullAreaBackSwipe() = runComposeUiTest {
+    val navigator = Navigator(Route.Home)
+    val editorRoute = Route.Editor("document-id")
+    var platformTouchSlop = 0f
+    var childConsumed = 0f
+
+    setContent {
+      platformTouchSlop = LocalViewConfiguration.current.touchSlop
+      NavigationStack(
+        navigator = navigator,
+        topBarState = remember { TopBarState() },
+        modifier = Modifier.size(width = 320.dp, height = 640.dp),
+      ) { route ->
+        Box(Modifier.fillMaxSize().testTag("surface-$route"))
+        NavigationForeground {
+          val scrollableState = rememberScrollableState { delta ->
+            childConsumed += delta
+            delta
+          }
+          Box(
+            Modifier.fillMaxSize()
+              .testTag("foreground-$route")
+              .scrollable(scrollableState, Orientation.Horizontal)
+          )
+        }
+      }
+      LaunchedEffect(Unit) { navigator.navigate(editorRoute) }
+    }
+    waitUntil { navigator.current == editorRoute && !navigator.isTransitioning }
+    val foreground = onNodeWithTag("foreground-$editorRoute")
+
+    foreground.performTouchInput {
+      down(center)
+      moveBy(Offset(x = platformTouchSlop * 4f, y = 0f))
+    }
+    waitForIdle()
+
+    assertTrue(abs(childConsumed) > 0.5f)
+    assertEquals(
+      0f,
+      onNodeWithTag("surface-$editorRoute").fetchSemanticsNode().boundsInRoot.left,
+      absoluteTolerance = 0.5f,
+    )
+
+    foreground.performTouchInput { up() }
+    waitForIdle()
+    assertEquals(editorRoute, navigator.current)
+  }
+
   @Test
   fun mainAreaTrackpadClickDragPopsOnDesktop() = assertTrackpadClickDragPops(startAtEdge = false)
 
@@ -476,6 +748,9 @@ class NavigationStackDesktopTest {
 
   private companion object {
     const val EditorRouteTag = "editor-route"
+    const val ForegroundFallbackTag = "foreground-fallback"
     const val HomeRouteTag = "home-route"
   }
 }
+
+private val LocalForegroundTestValue = staticCompositionLocalOf { "missing" }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/RouteRemovalNavigationStackDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/RouteRemovalNavigationStackDesktopTest.kt
@@ -1,8 +1,6 @@
 package co.typie.navigation
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.rememberScrollable2DState
-import androidx.compose.foundation.gestures.scrollable2D
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
@@ -179,12 +177,9 @@ class RouteRemovalNavigationStackDesktopTest {
         topBarState = remember { TopBarState() },
         modifier = Modifier.size(width = 320.dp, height = 640.dp),
       ) { route ->
-        val scrollableState = rememberScrollable2DState { Offset.Zero }
         Box(
           Modifier.fillMaxSize()
             .testTag(if (route == guardedRoute) GuardedRouteTag else HomeRouteTag)
-            .navigationPopNestedScroll()
-            .scrollable2D(scrollableState)
         )
       }
       LaunchedEffect(Unit) { navigator.navigate(guardedRoute) }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorSoftwareMagnifierDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorSoftwareMagnifierDesktopTest.kt
@@ -1,0 +1,65 @@
+package co.typie.screen.editor.editor.overlay
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.rememberGraphicsLayer
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import co.typie.ui.theme.LightColors
+import co.typie.ui.theme.LocalAppColors
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private const val SoftwareMagnifierRootTag = "software-magnifier-root"
+
+@OptIn(ExperimentalTestApi::class)
+class EditorSoftwareMagnifierDesktopTest {
+  @Test
+  fun lensSamplesSurfaceWithoutCapturingForeground() = runComposeUiTest {
+    setContent {
+      CompositionLocalProvider(LocalAppColors provides LightColors) {
+        val sourceLayer = rememberGraphicsLayer()
+        Box(Modifier.size(320.dp).testTag(SoftwareMagnifierRootTag)) {
+          Box(
+            Modifier.fillMaxSize()
+              .editorSoftwareMagnifierSource(sourceLayer = sourceLayer, active = true)
+              .background(Color.Red)
+          )
+          Box(
+            Modifier.fillMaxSize()
+              .background(Color.Blue)
+              .editorSoftwareMagnifierLens(
+                sourceLayer = sourceLayer,
+                placement =
+                  EditorMagnifierPlacement(
+                    sourceCenter = Offset(x = 160f, y = 200f),
+                    magnifierCenter = Offset(x = 160f, y = 100f),
+                    topLeft = Offset(x = 88f, y = 60f),
+                  ),
+              )
+          )
+        }
+      }
+    }
+    waitForIdle()
+
+    val pixels = onNodeWithTag(SoftwareMagnifierRootTag).captureToImage().toPixelMap()
+    assertEquals(
+      Color.Red,
+      pixels[160, 100],
+      "lens center should sample only the red editor surface",
+    )
+    assertEquals(Color.Blue, pixels[160, 200], "foreground outside the lens should remain blue")
+  }
+}

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/ScreenDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/ScreenDesktopTest.kt
@@ -1,17 +1,36 @@
 package co.typie.ui.component
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import co.typie.navigation.NavigationStack
+import co.typie.navigation.Navigator
+import co.typie.route.Route
 import co.typie.ui.component.dialog.Dialog
 import co.typie.ui.component.dialog.LocalDialog
+import co.typie.ui.component.topbar.LocalTopBarState
+import co.typie.ui.component.topbar.TopBarDefaults
+import co.typie.ui.component.topbar.TopBarState
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 private const val ContentTag = "screen-content"
+private const val OverlayTag = "screen-overlay"
+private val LocalScreenOverlayTestValue = staticCompositionLocalOf { "default" }
 
 @OptIn(ExperimentalTestApi::class)
 class ScreenDesktopTest {
@@ -25,5 +44,94 @@ class ScreenDesktopTest {
     waitForIdle()
 
     onNodeWithTag(ContentTag).assertExists()
+  }
+
+  @Test
+  fun overlayRendersLocallyAtScreenCoordinatesWithoutNavigationHost() = runComposeUiTest {
+    setContent {
+      CompositionLocalProvider(LocalDialog provides Dialog()) {
+        Screen(
+          overlay = { Box(Modifier.fillMaxSize().testTag(OverlayTag)) },
+          content = { Box(Modifier.fillMaxSize().testTag(ContentTag)) },
+        )
+      }
+    }
+    waitForIdle()
+
+    assertEquals(Offset.Zero, onNodeWithTag(ContentTag).fetchSemanticsNode().boundsInRoot.topLeft)
+    assertEquals(Offset.Zero, onNodeWithTag(OverlayTag).fetchSemanticsNode().boundsInRoot.topLeft)
+  }
+
+  @Test
+  fun topContentPaddingEndsAtPhysicalTopBarBoundary() = runComposeUiTest {
+    val topBarState =
+      TopBarState().apply {
+        enabled = true
+        visible = true
+      }
+    var actualTopPadding = Dp.Unspecified
+    var expectedTopPadding = Dp.Unspecified
+
+    setContent {
+      expectedTopPadding = TopBarDefaults.topPadding() + TopBarDefaults.Height
+      CompositionLocalProvider(
+        LocalDialog provides Dialog(),
+        LocalTopBarState provides topBarState,
+      ) {
+        Screen { contentPadding ->
+          actualTopPadding = contentPadding.calculateTopPadding()
+          Box(Modifier.fillMaxSize().testTag(ContentTag))
+        }
+      }
+    }
+    waitForIdle()
+
+    assertEquals(expectedTopPadding, actualTopPadding)
+  }
+
+  @Test
+  fun navigationHostsScreenOverlayOnceWithDeclarationContext() = runComposeUiTest {
+    val navigator = Navigator(Route.Home)
+    val editorRoute = Route.Editor("document-id")
+    var attachCount = 0
+    var observedContext = ""
+
+    setContent {
+      CompositionLocalProvider(LocalDialog provides Dialog()) {
+        NavigationStack(
+          navigator = navigator,
+          topBarState = TopBarState(),
+          modifier = Modifier.size(width = 320.dp, height = 640.dp),
+        ) { route ->
+          if (route == editorRoute) {
+            CompositionLocalProvider(LocalScreenOverlayTestValue provides "context-$route") {
+              Screen(
+                overlay = {
+                  observedContext = LocalScreenOverlayTestValue.current
+                  DisposableEffect(Unit) {
+                    attachCount += 1
+                    onDispose {}
+                  }
+                  Box(Modifier.fillMaxSize().testTag("$OverlayTag-$route"))
+                },
+                content = { Box(Modifier.fillMaxSize().testTag("$ContentTag-$route")) },
+              )
+            }
+          } else {
+            Box(Modifier.fillMaxSize().testTag("$ContentTag-$route"))
+          }
+        }
+        LaunchedEffect(Unit) { navigator.navigate(editorRoute) }
+      }
+    }
+    waitUntil { navigator.current == editorRoute && !navigator.isTransitioning }
+
+    onAllNodes(hasTestTag("$OverlayTag-$editorRoute")).assertCountEquals(1)
+    assertEquals(1, attachCount)
+    assertEquals("context-$editorRoute", observedContext)
+    assertEquals(
+      onNodeWithTag("$ContentTag-$editorRoute").fetchSemanticsNode().boundsInRoot.topLeft,
+      onNodeWithTag("$OverlayTag-$editorRoute").fetchSemanticsNode().boundsInRoot.topLeft,
+    )
   }
 }


### PR DESCRIPTION
## 요약

- top bar blur/fade가 screen 레벨이 아니라 navigation 레벨에서 그려짐. DocumentScreen을 pop할 때 자연스러워짐
- 에디터 오버레이들이 top bar blur/haze에 영향받지 않게 함
- 에디터 visible area의 top occlusion을 줄임

## 변경사항

- 화면별 `Screen`이 그리던 top bar haze/fade를 navigation-owned backdrop으로 통합했습니다.
    - push, pop, back swipe 중 backdrop은 화면 상단에 고정됩니다.
    - 이동 중인 route surface composite를 매 프레임 샘플링해 blur가 현재 전환 위치를 반영합니다.
    - 화면별 background와 top bar 표시 상태도 전환 진행률에 따라 보간합니다.
- route surface와 foreground를 분리하고 동일한 transition presentation을 적용했습니다.
    - editor overlay, toolbar, subpane, magnifier는 route와 함께 이동하지만 top bar haze에는 포함되지 않습니다.
    - software magnifier는 foreground를 재귀적으로 캡처하지 않고 editor surface만 확대합니다.
    - 전환 중 clipping, route coverage, pointer 차단과 back gesture 소유권을 기존 동작과 맞췄습니다.
- top bar가 차지하는 visible area를 실제 top bar 박스까지만 계산하도록 수정했습니다.
    - top content padding은 system top inset과 실제 top bar 높이까지만 포함합니다.
    - 16dp blur/fade 영역과 기존 8dp 추가 spacing은 visible-area occlusion에서 제외했습니다.
    - Folder, Notes, Space, Text Replacements의 reorder viewport inset도 같은 경계에 맞췄습니다.