### PR TITLE
앱 스켈레톤 활성화 시 placeholder 데이터 노출 방지

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/skeleton/Skeleton.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/skeleton/Skeleton.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.State
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -27,12 +28,18 @@ data class SkeletonColors(val bone: Color, val highlight: Color)
 
 private const val SkeletonAnimationFractionEpsilon = 0.001f
 
-class SkeletonState(val enabled: Boolean, val fraction: State<Float>, val boneColor: State<Color>) {
+class SkeletonState(
+  val enabled: Boolean,
+  animatedFraction: State<Float>,
+  val boneColor: State<Color>,
+) {
+  val fraction: State<Float> = derivedStateOf { if (enabled) 1f else animatedFraction.value }
+
   companion object {
     val Disabled: SkeletonState =
       SkeletonState(
         enabled = false,
-        fraction = mutableStateOf(0f),
+        animatedFraction = mutableStateOf(0f),
         boneColor = mutableStateOf(Color.Transparent),
       )
   }
@@ -85,7 +92,7 @@ private fun rememberSkeletonState(enabled: Boolean, colors: SkeletonColors): Ske
     } else {
       rememberUpdatedState(colors.bone)
     }
-  return SkeletonState(enabled = enabled, fraction = fraction, boneColor = boneColor)
+  return SkeletonState(enabled = enabled, animatedFraction = fraction, boneColor = boneColor)
 }
 
 object Skeleton {

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/ui/skeleton/SkeletonTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/ui/skeleton/SkeletonTest.kt
@@ -1,10 +1,37 @@
 package co.typie.ui.skeleton
 
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.graphics.Color
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class SkeletonTest {
+  @Test
+  fun `enabled skeleton fully covers content before animation catches up`() {
+    val state =
+      SkeletonState(
+        enabled = true,
+        animatedFraction = mutableStateOf(0f),
+        boneColor = mutableStateOf(Color.Transparent),
+      )
+
+    assertEquals(1f, state.fraction.value)
+  }
+
+  @Test
+  fun `disabled skeleton follows animation fraction during fade out`() {
+    val state =
+      SkeletonState(
+        enabled = false,
+        animatedFraction = mutableStateOf(0.5f),
+        boneColor = mutableStateOf(Color.Transparent),
+      )
+
+    assertEquals(0.5f, state.fraction.value)
+  }
+
   @Test
   fun `skeleton animation stays active while enabled`() {
     assertTrue(shouldAnimateSkeleton(enabled = true, fraction = 0f))


### PR DESCRIPTION
## 배경

쿼리가 성공 상태에서 다시 로딩 또는 오류 상태로 전환되면 화면 데이터가 즉시 placeholder data로 교체됩니다.

이때 스켈레톤 애니메이션 값이 이전 상태인 `0`으로 한 프레임 남아 있을 수 있어, 이어쓰기 카드 등에 placeholder 텍스트가 잠시 노출될 수 있었습니다.

## 변경 사항

- 스켈레톤이 활성화된 동안 콘텐츠를 동기적으로 완전히 가리도록 수정
- 스켈레톤이 비활성화될 때의 기존 fade-out 동작 유지
- 활성화 직후 콘텐츠 차단과 비활성화 전환을 검증하는 테스트 추가