### PR TITLE
앱 top bar progressive blur에서 가로 경계가 보이는 문제 수정

### DIFF
--- a/apps/mobile/compose/build.gradle.kts
+++ b/apps/mobile/compose/build.gradle.kts
@@ -223,6 +223,7 @@ kotlin {
     implementation(libs.ksafe)
     implementation(libs.haze)
     implementation(libs.haze.blur)
+    implementation(libs.haze.utils)
     implementation(libs.compottie)
 
     testImplementation(libs.kotlin.test)

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationTopBarBackdrop.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationTopBarBackdrop.kt
@@ -7,17 +7,17 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.platform.testTag
-import co.typie.ui.component.SmootherstepEasing
 import co.typie.ui.component.topbar.LocalTopBarAnimationSource
 import co.typie.ui.component.topbar.TopBarDefaults
+import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeState
-import dev.chrisbanes.haze.blur.blurEffect
 import dev.chrisbanes.haze.hazeEffect
 
 internal const val NavigationTopBarBackdropTestTag = "navigation-top-bar-backdrop"
@@ -49,6 +49,7 @@ internal fun resolveNavigationTopBarBackdropStyle(
 }
 
 @Composable
+@OptIn(ExperimentalHazeApi::class)
 internal fun NavigationTopBarBackdrop(
   hazeState: HazeState,
   style: NavigationTopBarBackdropStyle,
@@ -70,17 +71,18 @@ internal fun NavigationTopBarBackdrop(
       }
 
   val fadeColor = style.background.copy(alpha = TopBarDefaults.FadeOpacity)
+  val blurEffect = remember {
+    TypieTopBarProgressiveBlurEffect(
+      blurRadius = TopBarDefaults.BlurRadius,
+      progressiveBrush = navigationTopBarProgressiveBrush(Color.Black),
+      fallbackProgressive = TopBarDefaults.hazeProgressive(),
+      backgroundColor = style.background,
+    )
+  }
+  blurEffect.backgroundColor = style.background
+
   Box(modifier = backdropModifier) {
-    Column(
-      modifier =
-        Modifier.fillMaxWidth().hazeEffect(hazeState) {
-          blurEffect {
-            backgroundColor = style.background
-            blurRadius = TopBarDefaults.BlurRadius
-            progressive = TopBarDefaults.hazeProgressive()
-          }
-        }
-    ) {
+    Column(modifier = Modifier.fillMaxWidth().hazeEffect(hazeState) { visualEffect = blurEffect }) {
       Spacer(Modifier.fillMaxWidth().height(topPadding + TopBarDefaults.Height))
       Spacer(Modifier.height(TopBarDefaults.BlurFadeHeight))
     }
@@ -89,17 +91,17 @@ internal fun NavigationTopBarBackdrop(
       Spacer(
         Modifier.fillMaxWidth()
           .height(TopBarDefaults.Height + TopBarDefaults.BlurFadeHeight)
-          .background(navigationTopBarFadeBrush(fadeColor))
+          .background(navigationTopBarProgressiveBrush(fadeColor))
       )
     }
   }
 }
 
-private fun navigationTopBarFadeBrush(color: Color): Brush {
+private fun navigationTopBarProgressiveBrush(color: Color): Brush {
   val stops =
     Array(NavigationTopBarFadeSamples + 1) { index ->
       val t = index / NavigationTopBarFadeSamples.toFloat()
-      val alpha = color.alpha * (1f - SmootherstepEasing.transform(t))
+      val alpha = color.alpha * (1f - TopBarDefaults.BlurFadeEasing.transform(t))
       t to color.copy(alpha = alpha)
     }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/TypieTopBarProgressiveBlurEffect.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/TypieTopBarProgressiveBlurEffect.kt
@@ -1,0 +1,326 @@
+package co.typie.navigation
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.Snapshot
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.isSpecified
+import androidx.compose.ui.geometry.takeOrElse
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.GraphicsContext
+import androidx.compose.ui.graphics.RenderEffect
+import androidx.compose.ui.graphics.Shader
+import androidx.compose.ui.graphics.ShaderBrush
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.clipRect
+import androidx.compose.ui.graphics.drawscope.translate
+import androidx.compose.ui.graphics.isSpecified
+import androidx.compose.ui.graphics.layer.GraphicsLayer
+import androidx.compose.ui.graphics.layer.drawLayer
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.roundToIntSize
+import dev.chrisbanes.haze.ExperimentalHazeApi
+import dev.chrisbanes.haze.InternalHazeApi
+import dev.chrisbanes.haze.PlatformRenderEffect
+import dev.chrisbanes.haze.TrimMemoryLevel
+import dev.chrisbanes.haze.VisualEffect
+import dev.chrisbanes.haze.VisualEffectContext
+import dev.chrisbanes.haze.asComposeRenderEffect
+import dev.chrisbanes.haze.blur.BlurVisualEffect
+import dev.chrisbanes.haze.blur.HazeProgressive
+import dev.chrisbanes.haze.createRuntimeEffect
+import dev.chrisbanes.haze.createRuntimeShaderRenderEffect
+import dev.chrisbanes.haze.isRuntimeShaderRenderEffectSupported
+import dev.chrisbanes.haze.then
+
+/**
+ * Top-bar-only workaround for Haze's quantized progressive blur radius.
+ *
+ * Remove this effect when the adopted Haze version provides continuous fractional-radius
+ * progressive blur and the Desktop regression passes with its built-in effect.
+ */
+@Stable
+@OptIn(ExperimentalHazeApi::class, InternalHazeApi::class)
+internal class TypieTopBarProgressiveBlurEffect(
+  private val blurRadius: Dp,
+  private val progressiveBrush: Brush,
+  fallbackProgressive: HazeProgressive,
+  backgroundColor: Color,
+) : VisualEffect {
+  var backgroundColor: Color by mutableStateOf(backgroundColor)
+
+  private var resolvedBackgroundColor: Color = backgroundColor
+  private val fallbackEffect =
+    BlurVisualEffect().apply {
+      this.blurRadius = blurRadius
+      this.backgroundColor = backgroundColor
+      progressive = fallbackProgressive
+    }
+
+  private var graphicsContext: GraphicsContext? = null
+  private var contentLayer: GraphicsLayer? = null
+  private var contentLayerSize: IntSize? = null
+  private var renderEffect: RenderEffect? = null
+  private var renderEffectKey: RenderEffectKey? = null
+
+  override fun attach(context: VisualEffectContext) {
+    fallbackEffect.attach(context)
+  }
+
+  override fun update(context: VisualEffectContext) {
+    val currentBackgroundColor = backgroundColor
+    if (currentBackgroundColor != resolvedBackgroundColor) {
+      resolvedBackgroundColor = currentBackgroundColor
+      fallbackEffect.backgroundColor = currentBackgroundColor
+      context.invalidateDraw()
+    }
+    fallbackEffect.update(context)
+  }
+
+  override fun DrawScope.draw(context: VisualEffectContext) {
+    if (!isRuntimeShaderRenderEffectSupported()) {
+      with(fallbackEffect) { draw(context) }
+      return
+    }
+
+    drawRuntimeEffect(context)
+  }
+
+  override fun detach(context: VisualEffectContext) {
+    releaseRuntimeResources()
+    fallbackEffect.detach(context)
+  }
+
+  override fun onTrimMemory(context: VisualEffectContext, level: TrimMemoryLevel) {
+    releaseRuntimeResources()
+    fallbackEffect.onTrimMemory(context, level)
+    context.invalidateDraw()
+  }
+
+  override fun shouldDrawContentBehind(context: VisualEffectContext): Boolean =
+    fallbackEffect.shouldDrawContentBehind(context)
+
+  override fun shouldClipToNodeBounds(): Boolean = true
+
+  override fun shouldPreferClipToAreaBounds(): Boolean =
+    resolvedBackgroundColor.isSpecified && resolvedBackgroundColor.alpha < 0.9f
+
+  override fun calculateLayerBounds(rect: Rect, density: Density): Rect {
+    val blurRadiusPx = with(density) { blurRadius.toPx() }
+    return if (blurRadiusPx >= 1f) rect.inflate(blurRadiusPx) else rect
+  }
+
+  private fun DrawScope.drawRuntimeEffect(context: VisualEffectContext) {
+    val layerSize = context.layerSize.roundToIntSize()
+    if (layerSize.width <= 0 || layerSize.height <= 0) return
+
+    val layer = requireContentLayer(context, layerSize)
+    layer.record(size = layerSize) {
+      if (resolvedBackgroundColor.isSpecified) {
+        drawRect(resolvedBackgroundColor)
+      }
+
+      val sourceOffset = context.layerOffset - context.position
+      translate(sourceOffset.x, sourceOffset.y) {
+        for (area in context.areas) {
+          val areaPosition = Snapshot.withoutReadObservation {
+            area.position.takeOrElse { Offset.Zero }
+          }
+          val areaLayer = Snapshot.withoutReadObservation {
+            area.contentLayer
+              ?.takeUnless { it.isReleased }
+              ?.takeUnless { it.size.width <= 0 || it.size.height <= 0 }
+          }
+
+          if (areaLayer != null) {
+            translate(areaPosition.x, areaPosition.y) { drawLayer(areaLayer) }
+          }
+        }
+      }
+    }
+
+    layer.clip = true
+    layer.renderEffect = getOrCreateRenderEffect(context)
+
+    clipRect {
+      val drawOffset = -context.layerOffset
+      translate(drawOffset.x, drawOffset.y) { drawLayer(layer) }
+    }
+  }
+
+  private fun requireContentLayer(context: VisualEffectContext, size: IntSize): GraphicsLayer {
+    val current = contentLayer
+    if (current != null && !current.isReleased && contentLayerSize == size) {
+      return current
+    }
+
+    releaseContentLayer()
+    val currentGraphicsContext = context.requireGraphicsContext()
+    return currentGraphicsContext.createGraphicsLayer().also {
+      graphicsContext = currentGraphicsContext
+      contentLayer = it
+      contentLayerSize = size
+    }
+  }
+
+  private fun getOrCreateRenderEffect(context: VisualEffectContext): RenderEffect {
+    val blurRadiusPx = with(context.requireDensity()) { blurRadius.toPx() }
+    val renderSize = context.size.takeIf { it.isSpecified } ?: Size.Zero
+    val key =
+      RenderEffectKey(
+        blurRadiusPx = blurRadiusPx,
+        layerSize = context.layerSize,
+        layerOffset = context.layerOffset,
+        renderSize = renderSize,
+      )
+    renderEffect
+      ?.takeIf { renderEffectKey == key }
+      ?.let {
+        return it
+      }
+
+    val mask = progressiveBrush.toShader(renderSize)
+    return createProgressiveBlurRenderEffect(
+        blurRadiusPx = blurRadiusPx,
+        size = renderSize,
+        offset = context.layerOffset,
+        mask = mask,
+      )
+      .asComposeRenderEffect()
+      .also {
+        renderEffect = it
+        renderEffectKey = key
+      }
+  }
+
+  private fun releaseRuntimeResources() {
+    releaseContentLayer()
+    renderEffect = null
+    renderEffectKey = null
+  }
+
+  private fun releaseContentLayer() {
+    val layer = contentLayer
+    val context = graphicsContext
+    if (layer != null && context != null && !layer.isReleased) {
+      context.releaseGraphicsLayer(layer)
+    }
+    contentLayer = null
+    contentLayerSize = null
+    graphicsContext = null
+  }
+}
+
+private data class RenderEffectKey(
+  val blurRadiusPx: Float,
+  val layerSize: Size,
+  val layerOffset: Offset,
+  val renderSize: Size,
+)
+
+@OptIn(InternalHazeApi::class)
+private fun createProgressiveBlurRenderEffect(
+  blurRadiusPx: Float,
+  size: Size,
+  offset: Offset,
+  mask: Shader,
+): PlatformRenderEffect {
+  fun shader(vertical: Boolean): PlatformRenderEffect =
+    createRuntimeShaderRenderEffect(
+      effect =
+        if (vertical) {
+          VerticalProgressiveBlurRuntimeEffect
+        } else {
+          HorizontalProgressiveBlurRuntimeEffect
+        },
+      shaderNames = arrayOf("content"),
+      inputs = arrayOf<PlatformRenderEffect?>(null),
+    ) {
+      setFloatUniform("blurRadius", blurRadiusPx)
+      setFloatUniform("crop", offset.x, offset.y, offset.x + size.width, offset.y + size.height)
+      setChildShader("mask", mask)
+    }
+
+  return shader(vertical = false).then(shader(vertical = true))
+}
+
+private fun Brush.toShader(size: Size): Shader =
+  requireNotNull((this as? ShaderBrush)?.createShader(size)) {
+    "Top bar progressive blur requires a ShaderBrush"
+  }
+
+// Adapted from Haze 2.0.0-alpha03's HazeBlurShaders under Apache-2.0.
+// Copyright 2024, Christopher Banes and the Haze project contributors.
+@OptIn(InternalHazeApi::class)
+private val VerticalProgressiveBlurRuntimeEffect by
+  lazy(LazyThreadSafetyMode.NONE) {
+    createRuntimeEffect(progressiveBlurShaderSource(vertical = true))
+  }
+
+@OptIn(InternalHazeApi::class)
+private val HorizontalProgressiveBlurRuntimeEffect by
+  lazy(LazyThreadSafetyMode.NONE) {
+    createRuntimeEffect(progressiveBlurShaderSource(vertical = false))
+  }
+
+private fun progressiveBlurShaderSource(vertical: Boolean): String =
+  """
+  uniform shader content;
+  uniform float blurRadius;
+  uniform vec4 crop;
+  uniform shader mask;
+
+  const half maxRadius = 150.0;
+
+  float gaussian(float x, float sigma) {
+    return exp(-(x * x) / (2.0 * sigma * sigma));
+  }
+
+  float tapCoverage(float sampleOffset, float radius) {
+    return clamp(radius - sampleOffset + 1.0, 0.0, 1.0);
+  }
+
+  vec4 blur(vec2 coord, float radius) {
+    float sigma = max(radius / 2.0, 1.0);
+    float weightSum = 1.0;
+    vec4 result = content.eval(coord);
+
+    for (half i = 1.0; i < maxRadius; i += 2.0) {
+      float weightL = gaussian(i, sigma) * tapCoverage(i, radius);
+      float weightH = gaussian(i + 1.0, sigma) * tapCoverage(i + 1.0, radius);
+      float weight = weightL + weightH;
+      if (weight <= 0.0) { break; }
+
+      vec2 sampleOffset =
+        ${if (vertical) "vec2(0.0, i + weightH / weight)" else "vec2(i + weightH / weight, 0.0)"};
+
+      vec2 newCoord = coord - sampleOffset;
+      if (newCoord.x >= crop[0] && newCoord.y >= crop[1]) {
+        result += weight * content.eval(newCoord);
+        weightSum += weight;
+      }
+
+      newCoord = coord + sampleOffset;
+      if (newCoord.x <= crop[2] && newCoord.y <= crop[3]) {
+        result += weight * content.eval(newCoord);
+        weightSum += weight;
+      }
+    }
+
+    return result / weightSum;
+  }
+
+  vec4 main(vec2 coord) {
+    vec2 maskCoord = max(coord - crop.xy, vec2(0.0, 0.0));
+    float intensity = mask.eval(maskCoord).a;
+
+    return blur(coord, mix(0.0, blurRadius, intensity));
+  }
+  """

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/TypieTopBarProgressiveBlurEffectDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/TypieTopBarProgressiveBlurEffectDesktopTest.kt
@@ -1,0 +1,79 @@
+package co.typie.navigation
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import co.typie.ui.component.topbar.LocalTopBarAnimationSource
+import co.typie.ui.component.topbar.TopBarState
+import dev.chrisbanes.haze.hazeSource
+import dev.chrisbanes.haze.rememberHazeState
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+private const val MaximumContinuousLuminanceStep = 0.08f
+
+@OptIn(ExperimentalTestApi::class)
+class TypieTopBarProgressiveBlurEffectDesktopTest {
+  @Test
+  fun navigationTopBarBlurChangesContinuouslyThroughFade() = runComposeUiTest {
+    setContent {
+      val hazeState = rememberHazeState()
+      val topBarState = remember { TopBarState().apply { animatedAlpha = 1f } }
+
+      CompositionLocalProvider(LocalTopBarAnimationSource provides topBarState) {
+        Box(Modifier.size(width = 160.dp, height = 120.dp)) {
+          Canvas(Modifier.fillMaxSize().hazeSource(hazeState)) {
+            drawRect(Color.Black)
+            for (x in 0 until size.width.toInt() step 2) {
+              drawRect(
+                color = Color.White,
+                topLeft = Offset(x = x.toFloat(), y = 0f),
+                size = Size(width = 1f, height = size.height),
+              )
+            }
+          }
+          NavigationTopBarBackdrop(
+            hazeState = hazeState,
+            style = NavigationTopBarBackdropStyle(background = Color.Transparent, presence = 1f),
+            modifier = Modifier,
+          )
+        }
+      }
+    }
+    waitForIdle()
+
+    val pixels = onNodeWithTag(NavigationTopBarBackdropTestTag).captureToImage().toPixelMap()
+    val sampleX = pixels.width / 2
+    val luminance = (2 until pixels.height - 2).map { y -> pixels[sampleX, y].luminance() }
+    val steps = luminance.zipWithNext { first, second -> abs(second - first) }
+    val maximumStep = steps.maxOrNull() ?: 0f
+    val maximumRow = steps.indexOf(maximumStep) + 2
+    val largestSteps =
+      steps
+        .withIndex()
+        .sortedByDescending { it.value }
+        .take(8)
+        .joinToString { (index, value) -> "${index + 2}:$value" }
+
+    assertTrue(
+      maximumStep <= MaximumContinuousLuminanceStep,
+      "progressive blur has a luminance step of $maximumStep at row $maximumRow " +
+        "(height=${pixels.height}, largest=[$largestSteps])",
+    )
+  }
+}

--- a/apps/mobile/gradle/libs.versions.toml
+++ b/apps/mobile/gradle/libs.versions.toml
@@ -65,6 +65,7 @@ firebase-messaging = { module = "com.google.firebase:firebase-messaging" }
 googleid = { module = "com.google.android.libraries.identity.googleid:googleid", version.ref = "googleid" }
 haze = { module = "dev.chrisbanes.haze:haze", version.ref = "haze" }
 haze-blur = { module = "dev.chrisbanes.haze:haze-blur", version.ref = "haze" }
+haze-utils = { module = "dev.chrisbanes.haze:haze-utils", version.ref = "haze" }
 jna = { module = "net.java.dev.jna:jna", version.ref = "jna" }
 kakao-user = { module = "com.kakao.sdk:v2-user", version.ref = "kakao" }
 kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }


### PR DESCRIPTION
## 문제

Haze 2.0.0-alpha03의 progressive blur shader는 gradient로 계산된 blur radius를 `floor(radius + 0.5)`로 반올림합니다.

이 때문에 blur 강도 자체는 연속적으로 변하더라도 특정 radius 경계에서 sample tap 구성이 갑자기 바뀌며, top bar 아래 blur gradient에 가로 띠가 보였습니다.

## 변경 사항

- top bar 전용 `TypieTopBarProgressiveBlurEffect`를 추가했습니다.
- runtime shader에서 fractional radius에 따라 각 sample tap의 기여도를 연속적으로 반영하도록 수정했습니다.
    - 정수 radius에서는 기존 Gaussian sampling 결과를 유지합니다.
    - 정수 사이에서는 새 tap의 weight가 점진적으로 증가합니다.
- 기존 top bar의 smootherstep gradient brush를 blur mask와 color fade가 함께 사용하도록 정리했습니다.
- runtime shader를 지원하지 않는 환경에서는 기존 `TopBarDefaults.hazeProgressive()`를 그대로 사용합니다.
- Haze 전체를 포크하지 않고, shader/runtime effect API 사용을 위해 동일 Haze 버전의 `haze-utils`를 직접 의존성으로 추가했습니다.
- 향후 Haze에서 fractional-radius 문제가 해결되면 workaround를 제거할 수 있도록 제거 조건을 명시했습니다.