### PR TITLE
에디터 내용 변경 시 레이아웃 재측정 범위 수정

### DIFF
--- a/crates/editor-view/src/measure/nodes/dispatch.rs
+++ b/crates/editor-view/src/measure/nodes/dispatch.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use editor_common::EdgeInsets;
-use editor_model::{ChildView, NodeType, NodeView};
+use editor_model::{BlockquoteVariant, ChildView, Node, NodeType, NodeView};
 use editor_resource::Resource;
 
 use crate::measure::PageBreakPolicy;
@@ -18,6 +18,27 @@ use crate::measure::Measurer;
 use crate::measure::container::layout_padded;
 use crate::measure::context::MeasureContext;
 use crate::measure::types::{MeasuredContent, MeasuredNode};
+
+/// Returns the subtree root that must be rebuilt as one unit for a content
+/// edit. Tables own their row and cell layout, while message blockquotes
+/// derive their width from descendant content.
+pub(crate) fn content_remeasurement_target<'a>(node: NodeView<'a>) -> NodeView<'a> {
+    let table = node
+        .ancestors()
+        .find(|candidate| candidate.node_type() == NodeType::Table);
+    let message_blockquote = node.ancestors().find(|candidate| {
+        matches!(
+            candidate.node(),
+            Node::Blockquote(blockquote)
+                if matches!(
+                    *blockquote.variant.get(),
+                    BlockquoteVariant::MessageSent | BlockquoteVariant::MessageReceived
+                )
+        )
+    });
+
+    table.or(message_blockquote).unwrap_or(node)
+}
 
 pub(crate) fn measure_node(
     measurer: &mut Measurer,

--- a/crates/editor-view/src/view.rs
+++ b/crates/editor-view/src/view.rs
@@ -2,12 +2,13 @@ use std::sync::{Arc, Mutex, OnceLock};
 
 use editor_common::{EdgeInsets, Movement};
 use editor_crdt::Dot;
-use editor_model::{LayoutMode, Node, NodeType, NodeView};
+use editor_model::{LayoutMode, Node, NodeView};
 use editor_resource::Resource;
 use editor_state::{LayoutDirty, Position, ResolvedSelection, Selection, StablePosition, State};
 
 use crate::measure::Measurer;
 use crate::measure::context::measure_context;
+use crate::measure::nodes::dispatch::content_remeasurement_target;
 use crate::measure::types::MeasuredTree;
 use crate::page::LayoutPage;
 use crate::page_fragment::{PageFragmentTree, build_page_fragment_tree};
@@ -136,15 +137,12 @@ impl View {
                     else {
                         continue;
                     };
-                    let table = if node.node_type() == NodeType::Table {
-                        Some(node)
-                    } else {
-                        node.ancestors().find(|a| a.node_type() == NodeType::Table)
-                    };
-                    let target = table.as_ref().unwrap_or(&node);
-                    self.measurer.invalidate_subtree(target);
-                    self.measurer.invalidate_with_ancestors(target);
-                    if let Some(t) = targets.as_mut() {
+                    let target = content_remeasurement_target(node);
+                    self.measurer.invalidate_subtree(&node);
+                    self.measurer.invalidate_with_ancestors(&node);
+                    if let Some(t) = targets.as_mut()
+                        && !t.contains(&target.id())
+                    {
                         t.push(target.id());
                     }
                 }
@@ -1408,7 +1406,8 @@ mod incremental_tests {
 
     use editor_crdt::{Dot, ListOp, OpGraph};
     use editor_model::{
-        AtomLeaf, ChildView, EditOp, Node, NodeAttr, NodeAttrOp, NodeType, SeqItem, TableNodeAttr,
+        AtomLeaf, BlockquoteNodeAttr, BlockquoteVariant, ChildView, EditOp, Node, NodeAttr,
+        NodeAttrOp, NodeType, SeqItem, TableNodeAttr,
     };
     use editor_resource::Resource;
     use editor_state::{ProjectedState, State};
@@ -1458,13 +1457,18 @@ mod incremental_tests {
     }
 
     fn cached_arc(view: &mut View, state: &State, node: Dot) -> Arc<MeasuredNode> {
-        let (_, content_width, _) = view.build_pipeline(state);
+        let width = view
+            .node_box_rects(&[node])
+            .into_iter()
+            .next()
+            .expect("laid-out block node")
+            .rect
+            .width;
         let dv = state.view();
         let nv = dv.node(node).expect("block node present");
         let ctx = measure_context(&view.view_state);
         let mut resource = view.resource.lock().unwrap();
-        view.measurer
-            .measure(&nv, content_width, &ctx, &mut resource)
+        view.measurer.measure(&nv, width, &ctx, &mut resource)
     }
 
     fn all_block_dots(state: &State) -> Vec<Dot> {
@@ -1584,6 +1588,114 @@ mod incremental_tests {
         assert_eq!(
             view.node_box_rects(&[table]),
             fresh.node_box_rects(&[table])
+        );
+    }
+
+    #[test]
+    fn reconcile_table_cell_edit_preserves_unaffected_cell_content_measure() {
+        let mut projected = ProjectedState::empty();
+        let root = Dot::ROOT;
+        let table = projected
+            .apply(seq_block(1, NodeType::Table, vec![root]))
+            .unwrap()
+            .id;
+        let row = projected
+            .apply(seq_block(2, NodeType::TableRow, vec![root, table]))
+            .unwrap()
+            .id;
+        let first_cell = projected
+            .apply(seq_block(3, NodeType::TableCell, vec![root, table, row]))
+            .unwrap()
+            .id;
+        projected
+            .apply(seq_block(
+                4,
+                NodeType::Paragraph,
+                vec![root, table, row, first_cell],
+            ))
+            .unwrap();
+        projected.apply(seq_char(5, 'A')).unwrap();
+        let second_cell = projected
+            .apply(seq_block(6, NodeType::TableCell, vec![root, table, row]))
+            .unwrap()
+            .id;
+        let second_paragraph = projected
+            .apply(seq_block(
+                7,
+                NodeType::Paragraph,
+                vec![root, table, row, second_cell],
+            ))
+            .unwrap()
+            .id;
+        projected.apply(seq_char(8, 'B')).unwrap();
+        projected.commit();
+
+        let pre = State::new(projected.clone(), None);
+        let mut view = make_view(800.0);
+        view.layout(&pre);
+        let before = cached_arc(&mut view, &pre, second_paragraph);
+
+        let mut edited = projected;
+        let _ = edited.take_layout_dirty();
+        edited
+            .apply(EditOp::Seq(ListOp::Del { pos: 5, len: 1 }))
+            .unwrap();
+        let dirty = edited.take_layout_dirty();
+        let post = State::new(edited, None);
+
+        view.reconcile(&post, dirty, None, None);
+        let after = cached_arc(&mut view, &post, second_paragraph);
+
+        assert!(
+            Arc::ptr_eq(&before, &after),
+            "editing one table cell must preserve an unaffected cell's content measurement"
+        );
+    }
+
+    #[test]
+    fn reconcile_message_blockquote_content_shrink_matches_full_layout() {
+        let mut graph = OpGraph::<EditOp>::with_actor(1);
+        let root = Dot::ROOT;
+        let blockquote = graph
+            .add_mut(seq_block(0, NodeType::Blockquote, vec![root]))
+            .unwrap()
+            .id;
+        graph
+            .add_mut(seq_block(1, NodeType::Paragraph, vec![root, blockquote]))
+            .unwrap();
+        for (offset, ch) in "Hello".chars().enumerate() {
+            graph.add_mut(seq_char(2 + offset, ch)).unwrap();
+        }
+        graph
+            .add_mut(EditOp::NodeAttr(NodeAttrOp {
+                target: blockquote,
+                attr: NodeAttr::Blockquote {
+                    attr: BlockquoteNodeAttr::Variant(BlockquoteVariant::MessageSent),
+                },
+            }))
+            .unwrap();
+        graph.commit_mut();
+        let projected = ProjectedState::from_graph(graph).unwrap();
+
+        let pre = State::new(projected.clone(), None);
+        let mut view = make_view(800.0);
+        view.layout(&pre);
+
+        let mut edited = projected;
+        let _ = edited.take_layout_dirty();
+        edited
+            .apply(EditOp::Seq(ListOp::Del { pos: 6, len: 1 }))
+            .unwrap();
+        let dirty = edited.take_layout_dirty();
+        let post = State::new(edited, None);
+
+        view.reconcile(&post, dirty, None, None);
+
+        let mut fresh = make_view(800.0);
+        fresh.layout(&post);
+        assert_eq!(
+            view.node_box_rects(&[blockquote]),
+            fresh.node_box_rects(&[blockquote])
         );
     }
 


### PR DESCRIPTION
## 요약

- message blockquote가 내용이 줄어들어도 작아지지 않는 문제를 해결
- #5022 의 후속

## 배경

테이블 proportion 변경 시 리렌더링 문제를 수정하면서, 테이블 내부 내용이 변경되면 `reconcile`의 layout splice 대상을 테이블까지 올리도록 했습니다.

같은 경로를 점검하는 과정에서 기존 로직이 다음 두 역할을 하나의 target으로 처리하고 있음을 확인했습니다.

- 변경 후 어느 subtree까지 layout을 다시 구성해야 하는가
- 기존 측정 캐시 중 어느 범위를 무효화해야 하는가

두 범위는 항상 같지 않습니다.

- 메시지형 인용문은 descendant content의 intrinsic width로 bubble 폭을 결정하므로, 내부 paragraph만 splice하면 상위 bubble geometry가 이전 폭으로 남습니다.
- 테이블은 row와 cell layout을 직접 결정하므로 테이블 전체를 다시 구성해야 하지만, 테이블 subtree의 측정 캐시까지 모두 버릴 필요는 없습니다. 한 셀의 내용만 변경된 경우 다른 셀의 측정 결과는 재사용할 수 있습니다.

## 변경 사항

- 내용 변경 시 다시 구성할 subtree를 `content_remeasurement_target`에서 결정하도록 했습니다.
    - 테이블 내부 변경은 테이블을 다시 구성합니다.
    - `MessageSent`와 `MessageReceived` 인용문 내부 변경은 해당 인용문을 다시 구성합니다.
    - 그 외에는 기존처럼 실제 변경된 노드를 다시 구성합니다.
- 이 판단을 `View::reconcile`의 node-type 분기에서 measurement dispatch로 이동해, 측정 구조를 소유한 쪽에서 재측정 단위를 결정하도록 했습니다.
- layout splice 대상과 cache invalidation 시작점을 분리했습니다.
    - splice에는 위에서 결정한 상위 subtree target을 사용합니다.
    - cache invalidation은 실제 dirty node의 subtree와 ancestor에만 적용합니다.
    - 따라서 상위 container는 올바르게 다시 구성하면서도 변경되지 않은 sibling subtree의 측정 캐시는 유지합니다.
- 여러 dirty node가 같은 table 또는 message blockquote로 승격되는 경우 동일 target을 한 번만 splice하도록 중복을 제거했습니다.

## 테스트

- 메시지형 인용문의 텍스트를 `Hello`에서 `Hell`로 줄인 뒤 incremental reconcile 결과가 전체 layout 결과와 같은 폭을 갖는지 검증했습니다.
- 첫 번째 테이블 셀을 편집해도 두 번째 셀 paragraph의 실제 측정 `Arc`가 유지되는지 검증했습니다.
- 이 검증이 실제 layout cache entry를 관찰하도록 `cached_arc`가 문서 전체 폭 대신 layout된 node의 폭을 사용하게 수정했습니다.
    - 측정 캐시는 node와 width가 모두 일치해야 hit합니다.
    - 테이블 내부 paragraph는 문서 폭이 아니라 셀 내부 폭으로 측정되므로, 기존 helper는 실제 layout에서 사용된 cache entry를 조회하지 못했습니다.