### PR TITLE
앱 일반 화면의 top bar 아래 콘텐츠 간격 복구

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -1024,6 +1024,7 @@ fun EditorScreen(entityId: String) {
     loadable = model.query,
     background = background,
     contentPadding = PaddingValues(),
+    topBarContentPadding = 0.dp,
     overlay = {
       EditorSubscriptionBanner(
         documentId = documentId,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/textreplacements/TextReplacementsScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/textreplacements/TextReplacementsScreen.kt
@@ -87,10 +87,7 @@ fun TextReplacementsScreen() {
     Box(
       modifier =
         Modifier.fillMaxSize()
-          .reorderableViewport(
-            state = reorderState,
-            viewportTopInset = contentPadding.calculateTopPadding(),
-          )
+          .reorderableViewport(state = reorderState, viewportTopInset = topBarOcclusion)
     ) {
       Column(
         modifier =

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/folder/FolderScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/folder/FolderScreen.kt
@@ -423,7 +423,6 @@ fun FolderScreen(entityId: String) {
       )
     },
   ) { contentPadding ->
-    val reorderViewportTopInset = contentPadding.calculateTopPadding()
     val reorderViewportBottomInset =
       WindowInsets.safeDrawing.asPaddingValues().calculateBottomPadding() + overlayBaseBottomInset
 
@@ -432,7 +431,7 @@ fun FolderScreen(entityId: String) {
         Modifier.fillMaxSize()
           .reorderableViewport(
             state = reorderState,
-            viewportTopInset = reorderViewportTopInset,
+            viewportTopInset = topBarOcclusion,
             viewportBottomInset = reorderViewportBottomInset,
           )
     ) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/notes/NotesScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/notes/NotesScreen.kt
@@ -410,7 +410,6 @@ fun NotesScreen() {
           },
         )
       val reorderState = rememberNoteListReorderState(items = listItems, scrollState = scrollState)
-      val reorderViewportTopInset = contentPadding.calculateTopPadding()
       val reorderViewportBottomInset =
         WindowInsets.safeDrawing.asPaddingValues().calculateBottomPadding() + 72.dp
 
@@ -419,7 +418,7 @@ fun NotesScreen() {
           Modifier.fillMaxSize()
             .reorderableViewport(
               state = reorderState,
-              viewportTopInset = reorderViewportTopInset,
+              viewportTopInset = topBarOcclusion,
               viewportBottomInset = reorderViewportBottomInset,
             )
             .imePadding()

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/space/SpaceScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/space/SpaceScreen.kt
@@ -388,7 +388,6 @@ fun SpaceScreen() {
       )
     },
   ) { contentPadding ->
-    val reorderViewportTopInset = contentPadding.calculateTopPadding()
     val reorderViewportBottomInset =
       WindowInsets.safeDrawing.asPaddingValues().calculateBottomPadding() + overlayBaseBottomInset
 
@@ -397,7 +396,7 @@ fun SpaceScreen() {
         Modifier.fillMaxSize()
           .reorderableViewport(
             state = reorderState,
-            viewportTopInset = reorderViewportTopInset,
+            viewportTopInset = topBarOcclusion,
             viewportBottomInset = reorderViewportBottomInset,
           )
     ) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/Screen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/Screen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import co.typie.contract.Loadable
 import co.typie.contract.LoadableState
@@ -48,15 +49,23 @@ import co.typie.ui.theme.AppTheme
 private val MaxContentWidth = 600.dp
 private const val OverlayFadeSamples = 48
 
+interface ScreenScope : BoxScope {
+  val topBarOcclusion: Dp
+}
+
+private class ScreenScopeImpl(boxScope: BoxScope, override val topBarOcclusion: Dp) :
+  ScreenScope, BoxScope by boxScope
+
 @Composable
 fun Screen(
   loadable: Loadable<*>? = null,
   refetchOnMount: Boolean = true,
   background: Color = AppTheme.colors.surfaceCanvas,
   contentPadding: PaddingValues = PaddingValues(horizontal = 16.dp),
+  topBarContentPadding: Dp = TopBarDefaults.BlurFadeHeight + TopBarDefaults.ContentTopSpacing,
   dismissFocusOnTapOutsideInput: Boolean = true,
   overlay: (@Composable BoxScope.() -> Unit)? = null,
-  content: @Composable BoxScope.(contentPadding: PaddingValues) -> Unit,
+  content: @Composable ScreenScope.(contentPadding: PaddingValues) -> Unit,
 ) {
   PublishNavigationTopBarBackdropStyle(background)
 
@@ -71,11 +80,16 @@ fun Screen(
   val horizontalSafePadding = WindowInsets.safeDrawingHorizontal.asPaddingValues()
   val navigationBarPadding =
     PaddingValues(bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding())
+  val topBarOcclusion =
+    if (hasTopBar) {
+      topBarPadding.calculateTopPadding() + TopBarDefaults.Height
+    } else {
+      0.dp
+    }
   val contentPadding =
     if (hasTopBar) {
-      PaddingValues(top = TopBarDefaults.Height) +
+      PaddingValues(top = topBarOcclusion + topBarContentPadding) +
         contentPadding +
-        topBarPadding +
         horizontalSafePadding +
         navigationBarPadding
     } else {
@@ -111,7 +125,9 @@ fun Screen(
       contentAlignment = Alignment.TopCenter,
     ) {
       Skeleton(enabled = loadable != null && loadable.state !is LoadableState.Success) {
-        Box(modifier = Modifier.fillMaxSize()) { content(contentPadding) }
+        Box(modifier = Modifier.fillMaxSize()) {
+          content.invoke(ScreenScopeImpl(this, topBarOcclusion), contentPadding)
+        }
       }
     }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/topbar/TopBarDefaults.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/topbar/TopBarDefaults.kt
@@ -28,6 +28,7 @@ object TopBarDefaults {
   val BlurRadius: Dp = 6.dp
   val BlurFadeHeight: Dp = 16.dp
   val FadeOpacity: Float = 0.8f
+  val ContentTopSpacing: Dp = 8.dp
   val BlurFadeEasing: Easing = SmootherstepEasing
 
   val RevealAnimationDuration: Int = 200

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/ScreenDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/ScreenDesktopTest.kt
@@ -63,7 +63,38 @@ class ScreenDesktopTest {
   }
 
   @Test
-  fun topContentPaddingEndsAtPhysicalTopBarBoundary() = runComposeUiTest {
+  fun topContentPaddingIncludesBackdropFadeAndSpacing() = runComposeUiTest {
+    val topBarState =
+      TopBarState().apply {
+        enabled = true
+        visible = true
+      }
+    var actualTopPadding = Dp.Unspecified
+    var expectedTopPadding = Dp.Unspecified
+
+    setContent {
+      expectedTopPadding =
+        TopBarDefaults.topPadding() +
+          TopBarDefaults.Height +
+          TopBarDefaults.BlurFadeHeight +
+          TopBarDefaults.ContentTopSpacing
+      CompositionLocalProvider(
+        LocalDialog provides Dialog(),
+        LocalTopBarState provides topBarState,
+      ) {
+        Screen { contentPadding ->
+          actualTopPadding = contentPadding.calculateTopPadding()
+          Box(Modifier.fillMaxSize().testTag(ContentTag))
+        }
+      }
+    }
+    waitForIdle()
+
+    assertEquals(expectedTopPadding, actualTopPadding)
+  }
+
+  @Test
+  fun topContentPaddingCanEndAtPhysicalTopBarBoundary() = runComposeUiTest {
     val topBarState =
       TopBarState().apply {
         enabled = true
@@ -78,7 +109,7 @@ class ScreenDesktopTest {
         LocalDialog provides Dialog(),
         LocalTopBarState provides topBarState,
       ) {
-        Screen { contentPadding ->
+        Screen(topBarContentPadding = 0.dp) { contentPadding ->
           actualTopPadding = contentPadding.calculateTopPadding()
           Box(Modifier.fillMaxSize().testTag(ContentTag))
         }
@@ -87,6 +118,38 @@ class ScreenDesktopTest {
     waitForIdle()
 
     assertEquals(expectedTopPadding, actualTopPadding)
+  }
+
+  @Test
+  fun screenScopeTopBarOcclusionTracksPhysicalTopBarVisibility() = runComposeUiTest {
+    val topBarState =
+      TopBarState().apply {
+        enabled = true
+        visible = true
+      }
+    var actualTopBarOcclusion = Dp.Unspecified
+    var expectedTopBarOcclusion = Dp.Unspecified
+
+    setContent {
+      expectedTopBarOcclusion = TopBarDefaults.topPadding() + TopBarDefaults.Height
+      CompositionLocalProvider(
+        LocalDialog provides Dialog(),
+        LocalTopBarState provides topBarState,
+      ) {
+        Screen {
+          actualTopBarOcclusion = topBarOcclusion
+          Box(Modifier.fillMaxSize().testTag(ContentTag))
+        }
+      }
+    }
+    waitForIdle()
+
+    assertEquals(expectedTopBarOcclusion, actualTopBarOcclusion)
+
+    runOnUiThread { topBarState.visible = false }
+    waitForIdle()
+
+    assertEquals(0.dp, actualTopBarOcclusion)
   }
 
   @Test


### PR DESCRIPTION
- 에디터 visible area를 조정하는 과정에서 공통 Screen의 메인 콘텐츠 시작 지점이 실제 top bar 경계까지 올라가버림 (top padding이 24dp만큼 사라짐)
- 이것을 다시 원래대로 복구함
- ScreenScope가 실제 top bar 영역인 topBarOcclusion을 제공함
- ~별도 후속 PR에서 contentPadding과 topBarOcclusion을 같은 방식으로 제공하도록 API를 통일하는 전면적인 Screen 호출부 리팩토링을 할 예정~ -> 공식 Compose 패턴에 따르면 현재처럼 서로 다르게 전달하는 것이 더 적절함