### PR TITLE
앱 텍스트 대치 규칙 수정 시트 복원

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/textreplacements/TextReplacementEditSheet.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/textreplacements/TextReplacementEditSheet.kt
@@ -47,14 +47,11 @@ import co.typie.ui.theme.AppTheme
 
 @Composable
 context(_: SheetScope<Unit>)
-internal fun TextReplacementEditSheet(
-  model: TextReplacementsViewModel,
-  editing: CustomTextReplacement?,
-) {
+internal fun TextReplacementEditSheet(model: TextReplacementsViewModel, editing: TextReplacement?) {
   val scope = rememberCoroutineScope()
   val toast = LocalToast.current
   val dialog = LocalDialog.current
-  val form = remember(editing?.id) { TextReplacementForm(scope, editing) }
+  val form = remember(editing?.textReplacementId) { TextReplacementForm(scope, editing) }
   var isSaving by remember { mutableStateOf(false) }
   var isDeleting by remember { mutableStateOf(false) }
 
@@ -75,7 +72,7 @@ internal fun TextReplacementEditSheet(
     } else {
       model
         .updateTextReplacement(
-          id = editing.id,
+          id = editing.textReplacementId,
           match = form.match.value,
           substitute = form.substitute.value,
           regex = form.regex.value,
@@ -162,9 +159,10 @@ internal fun TextReplacementEditSheet(
               )
             if (result is DialogResult.Resolved) {
               isDeleting = true
-              model.deleteTextReplacement(editing.id).withDefaultExceptionHandler(toast).onOk {
-                complete(Unit)
-              }
+              model
+                .deleteTextReplacement(editing.textReplacementId)
+                .withDefaultExceptionHandler(toast)
+                .onOk { complete(Unit) }
               isDeleting = false
             }
           },

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/textreplacements/TextReplacementsModel.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/textreplacements/TextReplacementsModel.kt
@@ -7,8 +7,6 @@ import co.typie.graphql.type.TextReplacementState
 
 internal typealias TextReplacement = TextReplacementsScreen_Query.TextReplacement
 
-internal typealias CustomTextReplacement = TextReplacementsScreen_Query.OnTextReplacement
-
 internal val SMART_QUOTE_IDS =
   listOf("TXR0SQUOTEOPEN", "TXR0SQUOTECLOSE", "TXR0DQUOTEOPEN", "TXR0DQUOTECLOSE")
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/textreplacements/TextReplacementsScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/textreplacements/TextReplacementsScreen.kt
@@ -216,9 +216,7 @@ private fun CustomSection(
                 reorderEnabled = reorderEnabled,
                 onEdit = {
                   if (SubscriptionService.gate(sheet, GatedAction.TextReplacement)) {
-                    sheet.present {
-                      TextReplacementEditSheet(model = model, editing = entry.onTextReplacement)
-                    }
+                    sheet.present { TextReplacementEditSheet(model = model, editing = entry) }
                   }
                 },
                 onToggle = {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/textreplacements/TextReplacementsViewModel.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/textreplacements/TextReplacementsViewModel.kt
@@ -28,8 +28,8 @@ import co.typie.result.result
 import com.apollographql.apollo.api.Optional
 import kotlinx.coroutines.CoroutineScope
 
-class TextReplacementForm(scope: CoroutineScope, textReplacement: CustomTextReplacement?) :
-  FormState(scope) {
+class TextReplacementForm(scope: CoroutineScope, textReplacement: TextReplacement?) :
+  FormState(scope, autoFocusFirstField = textReplacement == null) {
   val match = field(textReplacement?.match.orEmpty()) { required("찾을 텍스트를 입력해주세요.") }
   val substitute = field(textReplacement?.substitute.orEmpty()) { required("삽입할 텍스트를 입력해주세요.") }
   val note = field(textReplacement?.note.orEmpty())


### PR DESCRIPTION
- 사용자 대치 규칙을 탭하면 수정 시트를 열도록 함
- 추가 시트만 첫 인풋에 자동 포커스하고 수정 시트는 포커스 없이 열도록 함