### PR TITLE
JVM Desktop에서 위젯 드래그가 viewport pan보다 우선하도록 함

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayout.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayout.kt
@@ -30,11 +30,15 @@ import androidx.compose.ui.input.nestedscroll.NestedScrollDispatcher
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.PointerEvent
 import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.input.pointer.changedToUpIgnoreConsumed
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
 import androidx.compose.ui.node.ModifierNodeElement
 import androidx.compose.ui.node.PointerInputModifierNode
+import androidx.compose.ui.node.currentValueOf
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.unit.Constraints
@@ -59,9 +63,11 @@ import co.typie.editor.scroll.isEditorScrollTargetVisible
 import co.typie.editor.scroll.resolveEditorScrollIntent
 import co.typie.editor.viewport.EditorViewportState
 import co.typie.ext.LocalScrollGestureLockState
+import co.typie.ext.ScrollGestureLockHandle
 import co.typie.navigation.LocalNavigationPopNestedScroll
 import co.typie.navigation.NavigationForeground
 import co.typie.navigation.navigationPopNestedScroll
+import co.typie.platform.isTouchDragPointer
 import co.typie.screen.editor.editor.overlay.EditorMagnifierPlacement
 import co.typie.screen.editor.editor.overlay.editorNativeMagnifier
 import co.typie.screen.editor.editor.overlay.editorSoftwareMagnifierLens
@@ -114,19 +120,43 @@ private data object ViewportDirectControlElement :
   override fun update(node: ViewportDirectControlNode) = Unit
 }
 
-private class ViewportDirectControlNode : Modifier.Node(), PointerInputModifierNode {
+private class ViewportDirectControlNode :
+  Modifier.Node(), PointerInputModifierNode, CompositionLocalConsumerModifierNode {
+  private var scrollGestureLockHandle: ScrollGestureLockHandle? = null
+
   override fun onPointerEvent(pointerEvent: PointerEvent, pass: PointerEventPass, bounds: IntSize) {
     if (pass != PointerEventPass.Initial) {
       return
     }
     pointerEvent.changes.forEach { change ->
       if (change.isDirectDown(pointerEvent)) {
+        if (
+          scrollGestureLockHandle == null &&
+            change.type == PointerType.Mouse &&
+            change.type.isTouchDragPointer()
+        ) {
+          scrollGestureLockHandle = currentValueOf(LocalScrollGestureLockState).acquire()
+        }
         change.consume()
+      } else if (change.changedToUpIgnoreConsumed()) {
+        releaseScrollGestureLock()
       }
     }
   }
 
-  override fun onCancelPointerInput() = Unit
+  override fun onCancelPointerInput() {
+    releaseScrollGestureLock()
+  }
+
+  override fun onDetach() {
+    releaseScrollGestureLock()
+    super.onDetach()
+  }
+
+  private fun releaseScrollGestureLock() {
+    scrollGestureLockHandle?.release()
+    scrollGestureLockHandle = null
+  }
 }
 
 private fun Modifier.sharePointerInputWithSiblings(): Modifier =

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorCharacterCountOverlayDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorCharacterCountOverlayDesktopTest.kt
@@ -3,21 +3,47 @@ package co.typie.screen.editor.editor.overlay
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performMouseInput
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.dp
+import co.typie.ext.LocalScrollGestureLockState
+import co.typie.ext.ScrollGestureLockState
 import co.typie.screen.editor.editor.layout.viewportDirectControl
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalTestApi::class)
 class EditorCharacterCountOverlayDesktopTest {
+  @Test
+  fun directControlHoldsDesktopScrollTranslationLockUntilRelease() = runComposeUiTest {
+    val scrollGestureLockState = ScrollGestureLockState()
+    setContent {
+      CompositionLocalProvider(LocalScrollGestureLockState provides scrollGestureLockState) {
+        Box(Modifier.size(120.dp).testTag(OverlayTag).viewportDirectControl())
+      }
+    }
+
+    onNodeWithTag(OverlayTag).performMouseInput { press() }
+    waitForIdle()
+
+    assertTrue(scrollGestureLockState.isLocked)
+
+    onNodeWithTag(OverlayTag).performMouseInput { release() }
+    waitForIdle()
+
+    assertFalse(scrollGestureLockState.isLocked)
+  }
+
   @Test
   fun tapDetectorAcceptsDownConsumedByDirectControlMarker() = runComposeUiTest {
     var tapCount = 0


### PR DESCRIPTION
JVM Desktop에서 viewport 직접 조작 컨트롤의 마우스 드래그가 에디터 pan scroll로 변환되지 않도록 입력 소유권을 보장