### PR TITLE
웹 휠 줌/스크롤 전환을 막는 휴리스틱 가드 제거

### DIFF
--- a/apps/website/src/lib/editor-ffi/components/editor-zoom.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/components/editor-zoom.svelte.ts
@@ -29,19 +29,12 @@ type EditorZoomControllerOptions = {
 };
 
 export class EditorZoomController {
-  static readonly WHEEL_SESSION_RESET_MS = 150;
-  static readonly WHEEL_BURST_GAP_MS = 56;
-  static readonly WHEEL_TAIL_DELTA_PX = 0.8;
-  static readonly WHEEL_TAIL_STREAK_TO_RESET = 3;
-  static readonly WHEEL_MODE_SWITCH_MIN_DELTA_PX = 1.5;
+  static readonly WHEEL_RAW_ZOOM_RESET_MS = 150;
   static readonly KEYBOARD_ZOOM_STEP = 0.1;
 
   #initializedPaginatedPageWidth: number | null = null;
   #renderZoomTimer: ReturnType<typeof setTimeout> | null = null;
-  #wheelSessionTimer: ReturnType<typeof setTimeout> | null = null;
-  #wheelSessionMode: 'scroll' | 'zoom' | null = null;
-  #wheelLastEventTs: number | null = null;
-  #wheelLowDeltaStreak = 0;
+  #wheelRawZoomResetTimer: ReturnType<typeof setTimeout> | null = null;
   #wheelRawZoom: number | null = null;
   #options: EditorZoomControllerOptions;
 
@@ -100,30 +93,22 @@ export class EditorZoomController {
     await this.#syncZoomAnchor(anchor, this.displayZoom);
   }
 
-  #scheduleWheelSessionReset(): void {
-    if (this.#wheelSessionTimer) {
-      clearTimeout(this.#wheelSessionTimer);
+  #scheduleWheelRawZoomReset(): void {
+    if (this.#wheelRawZoomResetTimer) {
+      clearTimeout(this.#wheelRawZoomResetTimer);
     }
-    this.#wheelSessionTimer = setTimeout(() => {
-      this.#wheelSessionTimer = null;
-      this.#wheelLastEventTs = null;
-      this.#clearWheelSessionModeState();
-    }, EditorZoomController.WHEEL_SESSION_RESET_MS);
+    this.#wheelRawZoomResetTimer = setTimeout(() => {
+      this.#wheelRawZoomResetTimer = null;
+      this.#wheelRawZoom = null;
+    }, EditorZoomController.WHEEL_RAW_ZOOM_RESET_MS);
   }
 
-  #clearWheelSessionModeState(): void {
-    this.#wheelSessionMode = null;
+  #resetWheelRawZoom(): void {
+    if (this.#wheelRawZoomResetTimer) {
+      clearTimeout(this.#wheelRawZoomResetTimer);
+      this.#wheelRawZoomResetTimer = null;
+    }
     this.#wheelRawZoom = null;
-    this.#wheelLowDeltaStreak = 0;
-  }
-
-  #resetWheelSession(): void {
-    if (this.#wheelSessionTimer) {
-      clearTimeout(this.#wheelSessionTimer);
-      this.#wheelSessionTimer = null;
-    }
-    this.#wheelLastEventTs = null;
-    this.#clearWheelSessionModeState();
   }
 
   async #syncZoomAnchor(anchor: ZoomAnchor, zoom: number): Promise<void> {
@@ -165,12 +150,12 @@ export class EditorZoomController {
       clearTimeout(this.#renderZoomTimer);
       this.#renderZoomTimer = null;
     }
-    this.#resetWheelSession();
+    this.#resetWheelRawZoom();
   }
 
   setZoom(nextZoom: number, { commitRender = false, source = 'programmatic' as 'wheel' | 'programmatic' } = {}): void {
     if (source !== 'wheel') {
-      this.#wheelRawZoom = null;
+      this.#resetWheelRawZoom();
     }
 
     const isPaginated = this.#options.isPaginated();
@@ -276,52 +261,18 @@ export class EditorZoomController {
     }
 
     const zoomDelta = Math.abs(event.deltaY) >= Math.abs(event.deltaX) ? event.deltaY : event.deltaX;
-    const deltaMagnitude = Math.abs(zoomDelta);
-
-    const hasZoomModifier = event.metaKey || event.ctrlKey;
-
-    if (hasZoomModifier && this.#wheelSessionMode === 'scroll' && deltaMagnitude >= EditorZoomController.WHEEL_MODE_SWITCH_MIN_DELTA_PX) {
-      this.#clearWheelSessionModeState();
+    if (zoomDelta === 0) {
+      return;
     }
 
-    const shouldPreventBrowserZoom = hasZoomModifier && this.#wheelSessionMode !== 'scroll';
-    if (shouldPreventBrowserZoom && event.cancelable) {
+    if (!event.metaKey && !event.ctrlKey) {
+      return;
+    }
+
+    if (event.cancelable) {
       event.preventDefault();
     }
-
-    if (deltaMagnitude === 0) {
-      return;
-    }
-
-    const elapsedSinceLastEvent = this.#wheelLastEventTs === null ? Infinity : event.timeStamp - this.#wheelLastEventTs;
-    this.#wheelLastEventTs = event.timeStamp;
-
-    if (elapsedSinceLastEvent > EditorZoomController.WHEEL_BURST_GAP_MS) {
-      this.#clearWheelSessionModeState();
-    }
-
-    if (deltaMagnitude <= EditorZoomController.WHEEL_TAIL_DELTA_PX) {
-      this.#wheelLowDeltaStreak += 1;
-      if (this.#wheelLowDeltaStreak >= EditorZoomController.WHEEL_TAIL_STREAK_TO_RESET) {
-        this.#resetWheelSession();
-        return;
-      }
-    } else {
-      this.#wheelLowDeltaStreak = 0;
-    }
-
-    if (!this.#wheelSessionMode) {
-      if (deltaMagnitude < EditorZoomController.WHEEL_MODE_SWITCH_MIN_DELTA_PX) {
-        this.#scheduleWheelSessionReset();
-        return;
-      }
-      this.#wheelSessionMode = hasZoomModifier ? 'zoom' : 'scroll';
-    }
-    this.#scheduleWheelSessionReset();
-
-    if (this.#wheelSessionMode !== 'zoom') {
-      return;
-    }
+    this.#scheduleWheelRawZoomReset();
 
     const bounds = computePaginatedZoomBounds(pageWidth);
     const wheelBaseZoom = this.#wheelRawZoom ?? this.displayZoom;

--- a/apps/website/src/lib/editor-ffi/components/editor-zoom.test.ts
+++ b/apps/website/src/lib/editor-ffi/components/editor-zoom.test.ts
@@ -1,0 +1,198 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { EditorZoomController } from './editor-zoom.svelte';
+import type { Editor } from '$lib/editor-ffi/editor.svelte';
+
+type WheelEventDouble = WheelEvent & {
+  preventDefault: ReturnType<typeof vi.fn>;
+};
+
+const controllers: EditorZoomController[] = [];
+
+const createController = (): EditorZoomController => {
+  const editor = {
+    clientToLocal: vi.fn(() => null),
+    pageSizes: [],
+    pageEls: [],
+  } as unknown as Editor;
+  const controller = new EditorZoomController({
+    editor,
+    isPaginated: () => true,
+    pageWidth: () => 1000,
+    viewportWidth: () => 1000,
+    getScrollViewport: () => null,
+  });
+  controllers.push(controller);
+  return controller;
+};
+
+const wheelEvent = ({
+  metaKey = false,
+  ctrlKey = false,
+  deltaX = 0,
+  deltaY = -20,
+  timeStamp = 0,
+  cancelable = true,
+}: {
+  metaKey?: boolean;
+  ctrlKey?: boolean;
+  deltaX?: number;
+  deltaY?: number;
+  timeStamp?: number;
+  cancelable?: boolean;
+} = {}): WheelEventDouble =>
+  ({
+    metaKey,
+    ctrlKey,
+    deltaX,
+    deltaY,
+    timeStamp,
+    cancelable,
+    clientX: 0,
+    clientY: 0,
+    preventDefault: vi.fn(),
+  }) as unknown as WheelEventDouble;
+
+afterEach(() => {
+  for (const controller of controllers) {
+    controller.destroy();
+  }
+  controllers.length = 0;
+  vi.useRealTimers();
+});
+
+describe('EditorZoomController.handleWheel', () => {
+  it.each([
+    ['Meta', { metaKey: true }],
+    ['Control', { ctrlKey: true }],
+  ])('zooms from the current event when %s is pressed', async (_, modifiers) => {
+    const controller = createController();
+    const event = wheelEvent(modifiers);
+
+    await controller.handleWheel(event);
+
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+    expect(controller.displayZoom).toBeGreaterThan(1);
+  });
+
+  it('leaves an unmodified wheel event to native scrolling', async () => {
+    const controller = createController();
+    const event = wheelEvent();
+
+    await controller.handleWheel(event);
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(controller.displayZoom).toBe(1);
+  });
+
+  it.each([
+    ['short gap and tiny delta', 8, -1],
+    ['short gap and large delta', 8, -20],
+    ['long gap and tiny delta', 1000, -1],
+    ['long gap and large delta', 1000, -20],
+  ])('leaves an unmodified event to scrolling after modified wheel input with a %s', async (_, timeStamp, deltaY) => {
+    const controller = createController();
+    await controller.handleWheel(wheelEvent({ metaKey: true, deltaY: -20 }));
+    const zoomBeforeUnmodifiedEvent = controller.displayZoom;
+    const event = wheelEvent({ deltaY, timeStamp });
+
+    await controller.handleWheel(event);
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(controller.displayZoom).toBe(zoomBeforeUnmodifiedEvent);
+  });
+
+  it.each([
+    ['short gap and tiny delta', 8, -1],
+    ['short gap and large delta', 8, -20],
+    ['long gap and tiny delta', 1000, -1],
+    ['long gap and large delta', 1000, -20],
+  ])('routes a modified event to zoom after unmodified wheel input with a %s', async (_, timeStamp, deltaY) => {
+    const controller = createController();
+    await controller.handleWheel(wheelEvent({ deltaY: 20 }));
+    const event = wheelEvent({ metaKey: true, deltaY, timeStamp });
+
+    await controller.handleWheel(event);
+
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+    if (Math.abs(deltaY) > 1) {
+      expect(controller.displayZoom).toBeGreaterThan(1);
+    }
+  });
+
+  it('accumulates tiny modified wheel deltas before the quiet timeout', async () => {
+    vi.useFakeTimers();
+    const controller = createController();
+
+    for (let index = 0; index < 5; index += 1) {
+      await controller.handleWheel(wheelEvent({ metaKey: true, deltaY: -1, timeStamp: index * 8 }));
+    }
+
+    expect(controller.displayZoom).toBeGreaterThan(1);
+  });
+
+  it('rebases tiny wheel zoom after the quiet timeout', async () => {
+    vi.useFakeTimers();
+    const controller = createController();
+
+    await controller.handleWheel(wheelEvent({ metaKey: true, deltaY: -3 }));
+    vi.advanceTimersByTime(EditorZoomController.WHEEL_RAW_ZOOM_RESET_MS);
+    await controller.handleWheel(wheelEvent({ metaKey: true, deltaY: -3, timeStamp: EditorZoomController.WHEEL_RAW_ZOOM_RESET_MS }));
+
+    expect(controller.displayZoom).toBe(1);
+  });
+
+  it('cancels the raw wheel zoom reset when zoom is set programmatically', async () => {
+    vi.useFakeTimers();
+    const controller = createController();
+    await controller.handleWheel(wheelEvent({ metaKey: true, deltaY: -3 }));
+    expect(vi.getTimerCount()).toBe(1);
+
+    controller.setZoom(1, { commitRender: true });
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('cancels the raw wheel zoom reset when destroyed', async () => {
+    vi.useFakeTimers();
+    const controller = createController();
+    await controller.handleWheel(wheelEvent({ metaKey: true, deltaY: -3 }));
+    expect(vi.getTimerCount()).toBe(1);
+
+    controller.destroy();
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('ignores a zero-delta modified event', async () => {
+    vi.useFakeTimers();
+    const controller = createController();
+    const event = wheelEvent({ metaKey: true, deltaY: 0 });
+
+    await controller.handleWheel(event);
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(controller.displayZoom).toBe(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('consumes a modified event at the maximum zoom bound', async () => {
+    const controller = createController();
+    controller.setZoom(2, { commitRender: true });
+    const event = wheelEvent({ metaKey: true });
+
+    await controller.handleWheel(event);
+
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+    expect(controller.displayZoom).toBe(2);
+  });
+
+  it('zooms from a non-cancelable modified event without preventing default', async () => {
+    const controller = createController();
+    const event = wheelEvent({ ctrlKey: true, cancelable: false });
+
+    await controller.handleWheel(event);
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(controller.displayZoom).toBeGreaterThan(1);
+  });
+});


### PR DESCRIPTION
브라우저 `WheelEvent`만으로는 momentum과 새 입력을 확실히 구분할 수 없어, 정상적인 줌·스크롤을 오판하던 세션 기반 휴리스틱 가드를 제거했습니다.