### PR TITLE
웹 트리플 클릭으로 문단 선택 디버그

### DIFF
--- a/apps/website/src/lib/editor-ffi/handlers/pointer.test.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/pointer.test.ts
@@ -196,6 +196,57 @@ describe('pointer native drag admission', () => {
     expect(editor.scrollIntoView).toHaveBeenCalledWith({ target: { type: 'current_selection_head' }, mode: 'nearest' });
   });
 
+  it('promotes a rapid third click inside the selected word to paragraph selection', () => {
+    const editor = createEditor();
+    const target = createPointerTarget({ captured: true });
+
+    handlePointerDown(editor, createPointerEvent({ target, timeStamp: 1000 }));
+    handlePointerUp(editor, createPointerEvent({ target, timeStamp: 1050 }));
+    handlePointerDown(editor, createPointerEvent({ target, timeStamp: 1100 }));
+    expect(editor.enqueue).toHaveBeenCalledWith({
+      type: 'selection',
+      op: { type: 'select_unit_at', page: 0, x: 10, y: 20, unit: 'word' },
+    });
+    handlePointerUp(editor, createPointerEvent({ target, timeStamp: 1150 }));
+
+    Object.assign(editor, { isSelectionCollapsed: false, selection: rangeSelection });
+    editor.selectionHitTest.mockReturnValue(true);
+    editor.enqueue.mockClear();
+
+    handlePointerDown(editor, createPointerEvent({ target, timeStamp: 1200 }));
+
+    expect(editor.enqueue).toHaveBeenCalledWith({
+      type: 'selection',
+      op: { type: 'select_unit_at', page: 0, x: 10, y: 20, unit: 'paragraph' },
+    });
+    expect(editor.beginNativeDragAdmission).not.toHaveBeenCalled();
+
+    editor.enqueue.mockClear();
+    handlePointerUp(editor, createPointerEvent({ target, timeStamp: 1250 }));
+    expect(editor.enqueue).not.toHaveBeenCalled();
+  });
+
+  it('extends a selected range on shift-click instead of admitting a native drag', () => {
+    const editor = createEditor({ selectionHit: true, isSelectionCollapsed: false, selection: rangeSelection });
+    const target = createPointerTarget({ captured: true });
+
+    handlePointerDown(editor, createPointerEvent({ target, shiftKey: true }));
+
+    expect(editor.enqueue).toHaveBeenCalledWith({
+      type: 'selection',
+      op: {
+        type: 'extend_to',
+        anchor: rangeSelection.anchor,
+        head_page: 0,
+        head_x: 10,
+        head_y: 20,
+        base_selection: undefined,
+        allow_collapse: true,
+      },
+    });
+    expect(editor.beginNativeDragAdmission).not.toHaveBeenCalled();
+  });
+
   it('ignores a non-primary pointer without replacing the active selection interaction', () => {
     const editor = createEditor();
     const target = createPointerTarget({ captured: true });

--- a/apps/website/src/lib/editor-ffi/handlers/pointer.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/pointer.ts
@@ -69,8 +69,7 @@ export const handlePointerDown: EditorEventHandler<HTMLElement, PointerEvent> = 
   const count = PointerState.of(editor).resolveClickCount(e);
   const modifiers: InputModifiers = { shift: e.shiftKey, ctrl: e.ctrlKey, alt: e.altKey, meta: e.metaKey };
 
-  const selectionHit = !editor.isSelectionCollapsed && editor.selectionHitTest(page, x, y);
-  const nativeDragCandidate = !editor.isSelectionCollapsed && selectionHit;
+  const nativeDragCandidate = count === 1 && !modifiers.shift && !editor.isSelectionCollapsed && editor.selectionHitTest(page, x, y);
   if (nativeDragCandidate) {
     const target = e.currentTarget;
     editor.beginNativeDragAdmission();


### PR DESCRIPTION
### 문제

더블 클릭으로 단어가 선택된 뒤 세 번째 클릭이 선택 영역 안에 들어오면, 이를 트리플 클릭이 아니라 네이티브 드래그 후보로 판정했습니다. 이 때문에 문단 선택 명령이 생략되고, 실제 드래그가 아니면 pointer up에서 선택이 커서로 접혔습니다. 클릭 위치의 selection hit-test 결과에 따라 간헐적으로 보였습니다.

### 변경

네이티브 선택 드래그는 Shift가 없는 단일 클릭(`count === 1`)에서만 시작하도록 제한했습니다. 따라서 더블 클릭은 단어 선택, 트리플 클릭은 문단 선택으로 정상 확장되며 Shift-click도 선택 확장 경로를 유지합니다.

기존 엔진이 갖고 있던 조건이 포인터 처리를 웹 호스트로 옮기는 과정에서 누락된 퇴행을 복원한 변경입니다. 실제 `1 → 2 → 3` 클릭 시퀀스와 Shift-click 회귀 테스트도 추가했습니다.