### PR TITLE
Screen contentPadding -> innerPadding으로 rename

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/auth/login/LoginScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/auth/login/LoginScreen.kt
@@ -67,8 +67,8 @@ fun LoginScreen() {
 
   ProvideTopBar(enabled = false)
 
-  Screen { contentPadding ->
-    Column(modifier = Modifier.fillMaxSize().padding(contentPadding)) {
+  Screen { innerPadding ->
+    Column(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
       Column(
         modifier = Modifier.weight(1f).fillMaxWidth(),
         verticalArrangement = Arrangement.Center,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/document/bodysettings/DocumentBodySettingsScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/document/bodysettings/DocumentBodySettingsScreen.kt
@@ -126,7 +126,7 @@ fun DocumentBodySettingsScreen(entityId: String) {
     loadable = model.query,
     background = AppTheme.colors.surfaceInset,
     contentPadding = PaddingValues.Zero,
-  ) { contentPadding ->
+  ) { innerPadding ->
     val data = (model.query.state as? QueryState.Success)?.data ?: return@Screen
     val document = data.entity.node.onDocument ?: return@Screen
     val settingsRuntime = remember(document.id) { EditorRuntime(uiScope = scope) }
@@ -142,7 +142,7 @@ fun DocumentBodySettingsScreen(entityId: String) {
 
     val colors = AppTheme.colors
     val layoutDirection = LocalLayoutDirection.current
-    val topBarClearance = contentPadding.calculateTopPadding()
+    val topBarClearance = innerPadding.calculateTopPadding()
     val previewHeight = 200.dp
     val previewContainerHeight = topBarClearance + previewHeight
     val previewShape = RoundedCornerShape(bottomStart = AppShapes.xl, bottomEnd = AppShapes.xl)
@@ -633,8 +633,8 @@ fun DocumentBodySettingsScreen(entityId: String) {
         Modifier.fillMaxSize()
           .imePadding()
           .padding(
-            start = contentPadding.calculateStartPadding(layoutDirection),
-            end = contentPadding.calculateEndPadding(layoutDirection),
+            start = innerPadding.calculateStartPadding(layoutDirection),
+            end = innerPadding.calculateEndPadding(layoutDirection),
           )
     ) {
       Skeleton(enabled = !controlsEnabled, modifier = Modifier.matchParentSize()) {
@@ -645,7 +645,7 @@ fun DocumentBodySettingsScreen(entityId: String) {
               .background(colors.surfaceDefault)
               .padding(
                 top = previewContainerHeight + 12.dp,
-                bottom = contentPadding.calculateBottomPadding(),
+                bottom = innerPadding.calculateBottomPadding(),
               )
               .padding(AppTheme.spacings.scrollBottomPadding)
         ) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/document/document/DocumentScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/document/document/DocumentScreen.kt
@@ -220,7 +220,7 @@ fun DocumentScreen(entityId: String) {
     scrollOffset = scrollState.topBarScrollOffset(),
   )
 
-  Screen(loadable = model.query, background = AppTheme.colors.surfaceCanvas) { contentPadding ->
+  Screen(loadable = model.query, background = AppTheme.colors.surfaceCanvas) { innerPadding ->
     val document = document ?: return@Screen
     val subtitle = document.subtitle?.takeIf(String::isNotBlank)
     val createdAt =
@@ -377,7 +377,7 @@ fun DocumentScreen(entityId: String) {
       modifier =
         Modifier.fillMaxSize()
           .verticalScroll(scrollState)
-          .padding(contentPadding)
+          .padding(innerPadding)
           .padding(horizontal = 16.dp)
           .padding(bottom = 12.dp)
     ) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -1032,7 +1032,7 @@ fun EditorScreen(entityId: String) {
         backdropColor = background,
       )
     },
-  ) { contentPadding ->
+  ) { innerPadding ->
     val comments =
       rememberEditorCommentsSession(
         entityId = entityId,
@@ -1052,10 +1052,10 @@ fun EditorScreen(entityId: String) {
     val keyboardController = LocalSoftwareKeyboardController.current
     val scrollGestureLockState = LocalScrollGestureLockState.current
     val layoutDirection = LocalLayoutDirection.current
-    val topInset = contentPadding.calculateTopPadding()
-    val startInset = contentPadding.calculateStartPadding(layoutDirection)
-    val endInset = contentPadding.calculateEndPadding(layoutDirection)
-    val bottomSafeInset = contentPadding.calculateBottomPadding()
+    val topInset = innerPadding.calculateTopPadding()
+    val startInset = innerPadding.calculateStartPadding(layoutDirection)
+    val endInset = innerPadding.calculateEndPadding(layoutDirection)
+    val bottomSafeInset = innerPadding.calculateBottomPadding()
     val imeBottom = WindowInsets.ime.asPaddingValues().calculateBottomPadding()
     val toolbarInputState = rememberEditorToolbarInputState()
     val keyboardState =

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/home/home/HomeScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/home/home/HomeScreen.kt
@@ -203,12 +203,12 @@ fun HomeScreen() {
           }
         }
       },
-  ) { contentPadding ->
+  ) { innerPadding ->
     if (recentDocs.isEmpty()) {
       EmptyHome(
         modifier =
           Modifier.fillMaxSize()
-            .padding(contentPadding)
+            .padding(innerPadding)
             .padding(bottom = BottomBarDefaults.BarAreaHeight),
         userName = model.query.data.me.name,
         onCreate = createDocument,
@@ -220,7 +220,7 @@ fun HomeScreen() {
         recentDocs = recentDocs,
         siteName = model.query.data.site.name,
         contentPadding =
-          contentPadding +
+          innerPadding +
             PaddingValues(
               bottom =
                 if (continueWritingDoc != null) ContinueWritingPinHeight + ContinueWritingPinGap
@@ -339,11 +339,7 @@ private fun EmptyHome(
 
         Spacer(Modifier.width(8.dp))
 
-        Text(
-          "새 문서 쓰기",
-          style = AppTheme.typography.action,
-          color = AppTheme.colors.surfaceDefault,
-        )
+        Text("새 문서 쓰기", style = AppTheme.typography.action, color = AppTheme.colors.surfaceDefault)
       }
     }
   }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/home/search/SearchScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/home/search/SearchScreen.kt
@@ -66,12 +66,12 @@ fun SearchScreen() {
 
   ProvideTopBar()
 
-  Screen(contentPadding = PaddingValues.Zero) { contentPadding ->
+  Screen(contentPadding = PaddingValues.Zero) { innerPadding ->
     Column(
       modifier =
         Modifier.fillMaxSize()
           .imePadding()
-          .padding(contentPadding.excludeBottom())
+          .padding(innerPadding.excludeBottom())
           .padding(horizontal = 16.dp)
     ) {
       SearchInputField(
@@ -95,7 +95,7 @@ fun SearchScreen() {
             Modifier.fillMaxSize()
               .verticalScroll(scrollState)
               .padding(FogInsets)
-              .padding(bottom = contentPadding.calculateBottomPadding())
+              .padding(bottom = innerPadding.calculateBottomPadding())
               .padding(AppTheme.spacings.scrollBottomPadding)
         ) {
           if (model.inputKeyword.isBlank()) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/more/feedback/FeedbackScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/more/feedback/FeedbackScreen.kt
@@ -72,14 +72,14 @@ fun FeedbackScreen() {
 
   ProvideTopBar(center = { Text("의견 보내기", style = AppTheme.typography.title) })
 
-  Screen { contentPadding ->
-    Column(modifier = Modifier.fillMaxSize().imePadding().padding(contentPadding.excludeTop())) {
+  Screen { innerPadding ->
+    Column(modifier = Modifier.fillMaxSize().imePadding().padding(innerPadding.excludeTop())) {
       Box(modifier = Modifier.weight(1f)) {
         Column(
           modifier =
             Modifier.fillMaxSize()
               .verticalScroll(scrollState)
-              .padding(contentPadding.onlyTop())
+              .padding(innerPadding.onlyTop())
               .padding(AppTheme.spacings.scrollBottomPadding),
           verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/more/more/MoreScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/more/more/MoreScreen.kt
@@ -63,12 +63,12 @@ fun MoreScreen() {
     scrollOffset = scrollState.topBarScrollOffset(),
   )
 
-  Screen(loadable = model.query) { contentPadding ->
+  Screen(loadable = model.query) { innerPadding ->
     Column(
       modifier =
         Modifier.fillMaxSize()
           .verticalScroll(scrollState)
-          .padding(contentPadding)
+          .padding(innerPadding)
           .padding(bottom = BottomBarDefaults.BarAreaHeight)
           .padding(AppTheme.spacings.scrollBottomPadding),
       verticalArrangement = Arrangement.spacedBy(16.dp),

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/more/stats/StatsScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/more/stats/StatsScreen.kt
@@ -56,12 +56,12 @@ fun StatsScreen() {
     scrollOffset = scrollState.topBarScrollOffset(),
   )
 
-  Screen(loadable = model.query) { contentPadding ->
+  Screen(loadable = model.query) { innerPadding ->
     Column(
       modifier =
         Modifier.fillMaxSize()
           .verticalScroll(scrollState)
-          .padding(contentPadding)
+          .padding(innerPadding)
           .padding(AppTheme.spacings.scrollBottomPadding),
       verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/aisettings/AiSettingsScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/aisettings/AiSettingsScreen.kt
@@ -74,12 +74,12 @@ fun AiSettingsScreen() {
     center = { Text("AI", style = AppTheme.typography.title) },
   )
 
-  Screen(loadable = model.query) { contentPadding ->
+  Screen(loadable = model.query) { innerPadding ->
     Column(
       modifier =
         Modifier.fillMaxSize()
           .verticalScroll(scrollState)
-          .padding(contentPadding)
+          .padding(innerPadding)
           .padding(AppTheme.spacings.scrollBottomPadding),
       verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/deleteuser/DeleteUserScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/deleteuser/DeleteUserScreen.kt
@@ -55,14 +55,14 @@ fun DeleteUserScreen() {
 
   ProvideTopBar(center = { Text("회원 탈퇴", style = AppTheme.typography.title) })
 
-  Screen { contentPadding ->
-    Column(modifier = Modifier.fillMaxSize().padding(contentPadding.excludeTop())) {
+  Screen { innerPadding ->
+    Column(modifier = Modifier.fillMaxSize().padding(innerPadding.excludeTop())) {
       Box(modifier = Modifier.weight(1f)) {
         Column(
           modifier =
             Modifier.fillMaxSize()
               .verticalScroll(scrollState)
-              .padding(contentPadding.onlyTop())
+              .padding(innerPadding.onlyTop())
               .padding(AppTheme.spacings.scrollBottomPadding),
           verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/editorsettings/EditorSettingsScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/editorsettings/EditorSettingsScreen.kt
@@ -37,12 +37,12 @@ fun EditorSettingsScreen() {
     scrollOffset = scrollState.topBarScrollOffset(),
   )
 
-  Screen { contentPadding ->
+  Screen { innerPadding ->
     Column(
       modifier =
         Modifier.fillMaxSize()
           .verticalScroll(scrollState)
-          .padding(contentPadding)
+          .padding(innerPadding)
           .padding(AppTheme.spacings.scrollBottomPadding),
       verticalArrangement = Arrangement.spacedBy(20.dp),
     ) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/fontsettings/FontSettingsScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/fontsettings/FontSettingsScreen.kt
@@ -132,12 +132,12 @@ fun FontSettingsScreen() {
     scrollOffset = scrollState.topBarScrollOffset(),
   )
 
-  Screen(loadable = model.query) { contentPadding ->
+  Screen(loadable = model.query) { innerPadding ->
     Column(
       modifier =
         Modifier.fillMaxSize()
           .verticalScroll(scrollState)
-          .padding(contentPadding)
+          .padding(innerPadding)
           .padding(AppTheme.spacings.scrollBottomPadding),
       verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/osslicenses/OssLicensesScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/osslicenses/OssLicensesScreen.kt
@@ -51,12 +51,12 @@ fun OssLicensesScreen() {
     scrollOffset = scrollState.topBarScrollOffset(),
   )
 
-  Screen(loadable = model) { contentPadding ->
+  Screen(loadable = model) { innerPadding ->
     Column(
       modifier =
         Modifier.fillMaxSize()
           .verticalScroll(scrollState)
-          .padding(contentPadding)
+          .padding(innerPadding)
           .padding(AppTheme.spacings.scrollBottomPadding),
       verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/presetsettings/PresetSettingsScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/presetsettings/PresetSettingsScreen.kt
@@ -101,10 +101,10 @@ fun PresetSettingsScreen() {
     loadable = model.query,
     background = screenBackground,
     contentPadding = PaddingValues.Zero,
-  ) { contentPadding ->
+  ) { innerPadding ->
     val colors = AppTheme.colors
     val layoutDirection = LocalLayoutDirection.current
-    val topBarClearance = contentPadding.calculateTopPadding()
+    val topBarClearance = innerPadding.calculateTopPadding()
     val previewHeight = 200.dp
     val previewContainerHeight = topBarClearance + previewHeight
     val previewShape = RoundedCornerShape(bottomStart = AppShapes.xl, bottomEnd = AppShapes.xl)
@@ -116,8 +116,8 @@ fun PresetSettingsScreen() {
         Modifier.fillMaxSize()
           .imePadding()
           .padding(
-            start = contentPadding.calculateStartPadding(layoutDirection),
-            end = contentPadding.calculateEndPadding(layoutDirection),
+            start = innerPadding.calculateStartPadding(layoutDirection),
+            end = innerPadding.calculateEndPadding(layoutDirection),
           )
     ) {
       Column(
@@ -127,7 +127,7 @@ fun PresetSettingsScreen() {
             .background(colors.surfaceDefault)
             .padding(
               top = previewContainerHeight + 12.dp,
-              bottom = contentPadding.calculateBottomPadding(),
+              bottom = innerPadding.calculateBottomPadding(),
             )
             .padding(AppTheme.spacings.scrollBottomPadding)
       ) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/profilesettings/ProfileSettingsScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/profilesettings/ProfileSettingsScreen.kt
@@ -77,12 +77,12 @@ fun ProfileSettingsScreen() {
     scrollOffset = scrollState.topBarScrollOffset(),
   )
 
-  Screen(loadable = model.query) { contentPadding ->
+  Screen(loadable = model.query) { innerPadding ->
     Column(
       modifier =
         Modifier.fillMaxSize()
           .verticalScroll(scrollState)
-          .padding(contentPadding)
+          .padding(innerPadding)
           .padding(AppTheme.spacings.scrollBottomPadding),
       verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/securitysettings/SecuritySettingsScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/securitysettings/SecuritySettingsScreen.kt
@@ -35,12 +35,12 @@ fun SecuritySettingsScreen() {
     scrollOffset = scrollState.topBarScrollOffset(),
   )
 
-  Screen(loadable = model.query) { contentPadding ->
+  Screen(loadable = model.query) { innerPadding ->
     Column(
       modifier =
         Modifier.fillMaxSize()
           .verticalScroll(scrollState)
-          .padding(contentPadding)
+          .padding(innerPadding)
           .padding(AppTheme.spacings.scrollBottomPadding),
       verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/settings/SettingsScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/settings/SettingsScreen.kt
@@ -75,12 +75,12 @@ fun SettingsScreen() {
     scrollOffset = scrollState.topBarScrollOffset(),
   )
 
-  Screen(loadable = model.query) { contentPadding ->
+  Screen(loadable = model.query) { innerPadding ->
     Column(
       modifier =
         Modifier.fillMaxSize()
           .verticalScroll(scrollState)
-          .padding(contentPadding)
+          .padding(innerPadding)
           .padding(AppTheme.spacings.scrollBottomPadding),
       verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/socialaccounts/SocialAccountsScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/socialaccounts/SocialAccountsScreen.kt
@@ -44,12 +44,12 @@ fun SocialAccountsScreen() {
 
   ProvideTopBar(center = { Text("연결된 SNS 계정", style = AppTheme.typography.title) })
 
-  Screen(loadable = model.query) { contentPadding ->
+  Screen(loadable = model.query) { innerPadding ->
     Column(
       modifier =
         Modifier.fillMaxSize()
           .verticalScroll(scrollState)
-          .padding(contentPadding)
+          .padding(innerPadding)
           .padding(AppTheme.spacings.scrollBottomPadding),
       verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/textreplacements/TextReplacementsScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/textreplacements/TextReplacementsScreen.kt
@@ -78,7 +78,7 @@ fun TextReplacementsScreen() {
     scrollOffset = scrollState.topBarScrollOffset(),
   )
 
-  Screen(loadable = model.query) { contentPadding ->
+  Screen(loadable = model.query) { innerPadding ->
     val displayed = model.customs
     val keys = displayed.map { it.textReplacementId }
     val reorderState =
@@ -93,7 +93,7 @@ fun TextReplacementsScreen() {
         modifier =
           Modifier.fillMaxSize()
             .verticalScroll(scrollState)
-            .padding(contentPadding)
+            .padding(innerPadding)
             .padding(AppTheme.spacings.scrollBottomPadding),
         verticalArrangement = Arrangement.spacedBy(16.dp),
       ) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/updateemail/UpdateEmailScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/updateemail/UpdateEmailScreen.kt
@@ -56,14 +56,14 @@ fun UpdateEmailScreen() {
 
   ProvideTopBar(center = { Text("이메일 변경", style = AppTheme.typography.title) })
 
-  Screen(loadable = model.query) { contentPadding ->
-    Column(modifier = Modifier.fillMaxSize().imePadding().padding(contentPadding.excludeTop())) {
+  Screen(loadable = model.query) { innerPadding ->
+    Column(modifier = Modifier.fillMaxSize().imePadding().padding(innerPadding.excludeTop())) {
       Box(modifier = Modifier.weight(1f)) {
         Column(
           modifier =
             Modifier.fillMaxSize()
               .verticalScroll(scrollState)
-              .padding(contentPadding.onlyTop())
+              .padding(innerPadding.onlyTop())
               .padding(AppTheme.spacings.scrollBottomPadding)
         ) {
           Text("현재 이메일 주소", style = AppTheme.typography.caption, color = AppTheme.colors.textMuted)

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/updatepassword/UpdatePasswordScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/updatepassword/UpdatePasswordScreen.kt
@@ -67,13 +67,13 @@ fun UpdatePasswordScreen() {
         Spacer(Modifier.height(12.dp))
       }
     },
-  ) { contentPadding ->
+  ) { innerPadding ->
     Column(
       modifier =
         Modifier.fillMaxSize()
           .verticalScroll(scrollState)
           .imePadding()
-          .padding(contentPadding)
+          .padding(innerPadding)
           .padding(AppTheme.spacings.scrollBottomPadding),
       verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/updateprofile/UpdateProfileScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/updateprofile/UpdateProfileScreen.kt
@@ -109,13 +109,13 @@ fun UpdateProfileScreen() {
         Spacer(Modifier.height(12.dp))
       }
     },
-  ) { contentPadding ->
+  ) { innerPadding ->
     Column(
       modifier =
         Modifier.fillMaxSize()
           .verticalScroll(scrollState)
           .imePadding()
-          .padding(contentPadding)
+          .padding(innerPadding)
           .padding(AppTheme.spacings.scrollBottomPadding)
     ) {
       Column(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/widgetsettings/WidgetSettingsScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/widgetsettings/WidgetSettingsScreen.kt
@@ -33,12 +33,12 @@ fun WidgetSettingsScreen() {
     scrollOffset = scrollState.topBarScrollOffset(),
   )
 
-  Screen { contentPadding ->
+  Screen { innerPadding ->
     Column(
       modifier =
         Modifier.fillMaxSize()
           .verticalScroll(scrollState)
-          .padding(contentPadding)
+          .padding(innerPadding)
           .padding(AppTheme.spacings.scrollBottomPadding),
       verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/folder/FolderDetailsScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/folder/FolderDetailsScreen.kt
@@ -180,7 +180,7 @@ fun FolderDetailsScreen(entityId: String) {
     scrollOffset = scrollState.topBarScrollOffset(),
   )
 
-  Screen(loadable = model.query, background = AppTheme.colors.surfaceCanvas) { contentPadding ->
+  Screen(loadable = model.query, background = AppTheme.colors.surfaceCanvas) { innerPadding ->
     val resolvedFolder = folder ?: return@Screen
     val characterCount = folderDetails?.characterCount ?: 0
 
@@ -280,7 +280,7 @@ fun FolderDetailsScreen(entityId: String) {
       modifier =
         Modifier.fillMaxSize()
           .verticalScroll(scrollState)
-          .padding(contentPadding)
+          .padding(innerPadding)
           .padding(horizontal = 16.dp)
           .padding(bottom = 12.dp)
     ) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/folder/FolderScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/folder/FolderScreen.kt
@@ -422,7 +422,7 @@ fun FolderScreen(entityId: String) {
         onMetricsChanged = overlayState::onMetricsChanged,
       )
     },
-  ) { contentPadding ->
+  ) { innerPadding ->
     val reorderViewportBottomInset =
       WindowInsets.safeDrawing.asPaddingValues().calculateBottomPadding() + overlayBaseBottomInset
 
@@ -443,7 +443,7 @@ fun FolderScreen(entityId: String) {
         selectionState = selectionState,
         dimmedItemIds = cutDimmedItemIds,
         bottomSpacerHeight = overlayState.reservedBottomSpacerHeight,
-        modifier = Modifier.fillMaxSize().verticalScroll(scrollState).padding(contentPadding),
+        modifier = Modifier.fillMaxSize().verticalScroll(scrollState).padding(innerPadding),
         header = {},
         onDocumentClick = { childEntityId -> nav.navigate(Route.Editor(childEntityId)) },
         onDocumentLongPress = onDocumentLongPress@{ entity ->

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/notes/NotesScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/notes/NotesScreen.kt
@@ -372,7 +372,7 @@ fun NotesScreen() {
       ),
   )
 
-  Screen(loadable = model.query, background = AppTheme.colors.surfaceCanvas) { contentPadding ->
+  Screen(loadable = model.query, background = AppTheme.colors.surfaceCanvas) { innerPadding ->
     Crossfade(
       targetState = model.filterStatus,
       modifier = Modifier,
@@ -424,7 +424,7 @@ fun NotesScreen() {
             .imePadding()
       ) {
         Column(
-          modifier = Modifier.fillMaxSize().verticalScroll(scrollState).padding(contentPadding),
+          modifier = Modifier.fillMaxSize().verticalScroll(scrollState).padding(innerPadding),
           verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
           Skeleton.Keep { Text(text = "노트", style = AppTheme.typography.display) }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/space/SpaceScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/space/SpaceScreen.kt
@@ -387,7 +387,7 @@ fun SpaceScreen() {
         onMetricsChanged = overlayState::onMetricsChanged,
       )
     },
-  ) { contentPadding ->
+  ) { innerPadding ->
     val reorderViewportBottomInset =
       WindowInsets.safeDrawing.asPaddingValues().calculateBottomPadding() + overlayBaseBottomInset
 
@@ -408,7 +408,7 @@ fun SpaceScreen() {
         selectionState = selectionState,
         dimmedItemIds = cutDimmedItemIds,
         bottomSpacerHeight = overlayState.reservedBottomSpacerHeight,
-        modifier = Modifier.fillMaxSize().verticalScroll(scrollState).padding(contentPadding),
+        modifier = Modifier.fillMaxSize().verticalScroll(scrollState).padding(innerPadding),
         header = {
           SpaceHeader(
             title = site?.name.orEmpty(),

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/spacesettings/SpaceSettingsScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/spacesettings/SpaceSettingsScreen.kt
@@ -156,7 +156,7 @@ fun SpaceSettingsScreen() {
         Spacer(Modifier.height(12.dp))
       }
     },
-  ) { contentPadding ->
+  ) { innerPadding ->
     Column(
       modifier =
         Modifier.fillMaxSize()
@@ -174,7 +174,7 @@ fun SpaceSettingsScreen() {
             }
           }
         },
-        topInset = contentPadding.calculateTopPadding(),
+        topInset = innerPadding.calculateTopPadding(),
       )
 
       PaperPane(modifier = Modifier.offset(y = (-28).dp)) {
@@ -349,7 +349,9 @@ private fun DeleteSiteSheet(
   documentCount: Int,
   folderCount: Int,
   isDeleting: Boolean,
-  onDelete: suspend context(SheetScope<Unit>) () -> Unit,
+  onDelete:
+    suspend context(SheetScope<Unit>)
+    () -> Unit,
 ) {
   var inputValue by remember { mutableStateOf("") }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/trash/TrashScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/trash/TrashScreen.kt
@@ -310,13 +310,12 @@ fun TrashScreen(entityId: String? = null) {
     scrollOffset = scrollState.topBarScrollOffset(),
   )
 
-  Screen(loadable = if (entityId == null) model.siteQuery else model.entityQuery) { contentPadding
-    ->
+  Screen(loadable = if (entityId == null) model.siteQuery else model.entityQuery) { innerPadding ->
     Column(
       modifier =
         Modifier.fillMaxSize()
           .verticalScroll(scrollState)
-          .padding(contentPadding)
+          .padding(innerPadding)
           .padding(bottom = 16.dp)
           .padding(AppTheme.spacings.scrollBottomPadding),
       verticalArrangement = Arrangement.spacedBy(16.dp),

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/subscription/cancelplan/CancelPlanScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/subscription/cancelplan/CancelPlanScreen.kt
@@ -50,12 +50,12 @@ fun CancelPlanScreen() {
     scrollOffset = scrollState.topBarScrollOffset(),
   )
 
-  Screen(loadable = model.query) { contentPadding ->
+  Screen(loadable = model.query) { innerPadding ->
     Column(
       modifier =
         Modifier.fillMaxSize()
           .verticalScroll(scrollState)
-          .padding(contentPadding)
+          .padding(innerPadding)
           .padding(AppTheme.spacings.scrollBottomPadding),
       verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/subscription/currentplan/CurrentPlanScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/subscription/currentplan/CurrentPlanScreen.kt
@@ -56,12 +56,12 @@ fun CurrentPlanScreen() {
     }
   }
 
-  Screen(loadable = model.query) { contentPadding ->
+  Screen(loadable = model.query) { innerPadding ->
     Column(
       modifier =
         Modifier.fillMaxSize()
           .verticalScroll(scrollState)
-          .padding(contentPadding)
+          .padding(innerPadding)
           .padding(AppTheme.spacings.scrollBottomPadding),
       verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/subscription/enrollplan/EnrollPlanScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/subscription/enrollplan/EnrollPlanScreen.kt
@@ -107,12 +107,12 @@ fun EnrollPlanScreen() {
 
   LaunchedEffect(Unit) { SubscriptionPurchaseService.ensureProductsLoaded() }
 
-  Screen(loadable = model.query) { contentPadding ->
+  Screen(loadable = model.query) { innerPadding ->
     Column(
       modifier =
         Modifier.fillMaxSize()
           .verticalScroll(scrollState)
-          .padding(contentPadding)
+          .padding(innerPadding)
           .padding(AppTheme.spacings.scrollBottomPadding),
       verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/subscription/referral/ReferralScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/subscription/referral/ReferralScreen.kt
@@ -80,14 +80,14 @@ fun ReferralScreen() {
     scrollOffset = scrollState.topBarScrollOffset(),
   )
 
-  Screen(loadable = model.query) { contentPadding ->
-    Column(modifier = Modifier.fillMaxSize().padding(contentPadding.excludeTop())) {
+  Screen(loadable = model.query) { innerPadding ->
+    Column(modifier = Modifier.fillMaxSize().padding(innerPadding.excludeTop())) {
       Box(modifier = Modifier.weight(1f)) {
         Column(
           modifier =
             Modifier.fillMaxSize()
               .verticalScroll(scrollState)
-              .padding(contentPadding.onlyTop())
+              .padding(innerPadding.onlyTop())
               .padding(AppTheme.spacings.scrollBottomPadding),
           verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/system/maintenance/MaintenanceScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/system/maintenance/MaintenanceScreen.kt
@@ -43,8 +43,8 @@ fun MaintenanceScreen() {
 
   ProvideTopBar(enabled = false)
 
-  Screen(background = AppTheme.colors.surfaceDefault) { contentPadding ->
-    Column(modifier = Modifier.fillMaxSize().padding(contentPadding)) {
+  Screen(background = AppTheme.colors.surfaceDefault) { innerPadding ->
+    Column(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
       Column(
         modifier = Modifier.weight(1f).fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/system/onboarding/OnboardingScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/system/onboarding/OnboardingScreen.kt
@@ -145,8 +145,8 @@ fun OnboardingScreen(onComplete: () -> Unit) {
       },
   )
 
-  Screen(background = AppTheme.colors.surfaceDefault) { contentPadding ->
-    Column(modifier = Modifier.fillMaxSize().padding(contentPadding)) {
+  Screen(background = AppTheme.colors.surfaceDefault) { innerPadding ->
+    Column(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
       HorizontalPager(
         state = pagerState,
         beyondViewportPageCount = pages.size - 1,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/system/updaterequired/UpdateRequiredScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/system/updaterequired/UpdateRequiredScreen.kt
@@ -44,8 +44,8 @@ fun UpdateRequiredScreen() {
 
   ProvideTopBar(enabled = false)
 
-  Screen(background = AppTheme.colors.surfaceDefault) { contentPadding ->
-    Column(modifier = Modifier.fillMaxSize().padding(contentPadding)) {
+  Screen(background = AppTheme.colors.surfaceDefault) { innerPadding ->
+    Column(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
       Column(
         modifier = Modifier.weight(1f).fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/Screen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/Screen.kt
@@ -65,7 +65,7 @@ fun Screen(
   topBarContentPadding: Dp = TopBarDefaults.BlurFadeHeight + TopBarDefaults.ContentTopSpacing,
   dismissFocusOnTapOutsideInput: Boolean = true,
   overlay: (@Composable BoxScope.() -> Unit)? = null,
-  content: @Composable ScreenScope.(contentPadding: PaddingValues) -> Unit,
+  content: @Composable ScreenScope.(innerPadding: PaddingValues) -> Unit,
 ) {
   PublishNavigationTopBarBackdropStyle(background)
 
@@ -86,7 +86,7 @@ fun Screen(
     } else {
       0.dp
     }
-  val contentPadding =
+  val innerPadding =
     if (hasTopBar) {
       PaddingValues(top = topBarOcclusion + topBarContentPadding) +
         contentPadding +
@@ -126,7 +126,7 @@ fun Screen(
     ) {
       Skeleton(enabled = loadable != null && loadable.state !is LoadableState.Success) {
         Box(modifier = Modifier.fillMaxSize()) {
-          content.invoke(ScreenScopeImpl(this, topBarOcclusion), contentPadding)
+          content.invoke(ScreenScopeImpl(this, topBarOcclusion), innerPadding)
         }
       }
     }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/ScreenDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/ScreenDesktopTest.kt
@@ -82,8 +82,8 @@ class ScreenDesktopTest {
         LocalDialog provides Dialog(),
         LocalTopBarState provides topBarState,
       ) {
-        Screen { contentPadding ->
-          actualTopPadding = contentPadding.calculateTopPadding()
+        Screen { innerPadding ->
+          actualTopPadding = innerPadding.calculateTopPadding()
           Box(Modifier.fillMaxSize().testTag(ContentTag))
         }
       }
@@ -109,8 +109,8 @@ class ScreenDesktopTest {
         LocalDialog provides Dialog(),
         LocalTopBarState provides topBarState,
       ) {
-        Screen(topBarContentPadding = 0.dp) { contentPadding ->
-          actualTopPadding = contentPadding.calculateTopPadding()
+        Screen(topBarContentPadding = 0.dp) { innerPadding ->
+          actualTopPadding = innerPadding.calculateTopPadding()
           Box(Modifier.fillMaxSize().testTag(ContentTag))
         }
       }


### PR DESCRIPTION
## 변경 사항

- `Screen`에 전달하는 입력값은 기존처럼 `contentPadding`으로 유지했습니다.
- top bar와 safe area 등을 합산해 콘텐츠에 전달하는 최종 padding은 `innerPadding`으로 이름을 변경했습니다.
- 각 Screen의 content 람다에서도 `innerPadding`을 사용하도록 통일했습니다.

## 변경 이유

입력으로 받은 padding과 `Screen`이 계산한 최종 padding이 모두 `contentPadding`으로 불려 두 단계의 역할을 구분하기 어려웠습니다. `contentPadding`은 입력, `innerPadding`은 실제 콘텐츠가 적용할 최종 padding이라는 의미가 드러나도록 정리했습니다.

동작과 padding 계산 방식은 변경하지 않았습니다.