### PR TITLE
타임라인 패널 닫을 때 svelte tick 후에 에디터 destroy

### DIFF
--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanelTimeline.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanelTimeline.svelte
@@ -9,7 +9,7 @@
   import { clamp, debounce, throttle } from '@typie/ui/utils';
   import dayjs from 'dayjs';
   import mixpanel from 'mixpanel-browser';
-  import { onMount } from 'svelte';
+  import { onMount, tick } from 'svelte';
   import { fly } from 'svelte/transition';
   import ClockRewindIcon from '~icons/lucide/clock-arrow-up';
   import IconClockFading from '~icons/lucide/clock-fading';
@@ -129,14 +129,13 @@
   const shownHead = $derived(headsAsc.find((h) => h.id === shownHeadId) ?? null);
 
   const exitTimeline = (): void => {
+    const exitingEditor = timelineEditor;
+    timelineEditor = undefined;
     ctx.editor = ctx.liveEditor;
     creatingTimeline = false;
     pendingHeadId = null;
-    try {
-      timelineEditor?.destroy();
-    } finally {
-      timelineEditor = undefined;
-    }
+    // The keyed editor subtree still references the previous editor until the next render.
+    void tick().then(() => exitingEditor?.destroy());
   };
 
   onMount(() => {


### PR DESCRIPTION
타임라인 패널을 닫을 때 기존 Svelte Input 컴포넌트가 아직 참조 중인 에디터를 너무 일찍 destroy해 null pointer 에러가 발생하고 있었음