### PR TITLE
선택된 블록 내부 break selection rect 억제

### DIFF
--- a/crates/editor-view/src/query/common.rs
+++ b/crates/editor-view/src/query/common.rs
@@ -1,6 +1,3 @@
-use editor_crdt::Dot;
-use editor_state::Affinity;
-
 use crate::page::LayoutPage;
 use crate::paginate::types::LayoutLine;
 
@@ -9,13 +6,6 @@ pub enum Phase {
     Before,
     Inside,
     After,
-}
-
-pub type SelectionKey = ((Dot, usize, Affinity), (Dot, usize, Affinity));
-
-pub fn selection_key(selection: &editor_state::Selection) -> SelectionKey {
-    let key = |pos: &editor_state::Position| (pos.node, pos.offset, pos.affinity);
-    (key(&selection.anchor), key(&selection.head))
 }
 
 pub fn page_for_y(pages: &[LayoutPage], y: f32) -> Option<usize> {

--- a/crates/editor-view/src/query/hard_break.rs
+++ b/crates/editor-view/src/query/hard_break.rs
@@ -6,7 +6,7 @@ pub(crate) struct HardBreakGeometry {
 use editor_common::Rect;
 use editor_model::{AtomLeaf, ChildView, DocView};
 use editor_state::Affinity;
-use editor_state::{Position, ResolvedSelection, Selection};
+use editor_state::{Position, Selection};
 
 use crate::page::{LayoutPage, PageRect};
 use crate::paginate::types::{LayoutContent, LayoutLine};
@@ -14,36 +14,20 @@ use crate::paginate::types::{LayoutContent, LayoutLine};
 use super::common::page_for_y;
 use super::layout_index::{LayoutEntry, LayoutIndex, LayoutPoint};
 
-pub(crate) struct SelectedHardBreak {
-    pub(crate) selection: Selection,
+pub(crate) struct HardBreakOccurrence {
+    pub(crate) range: Selection,
     pub(crate) geometry: HardBreakGeometry,
 }
 
-pub(crate) fn included_in_selection(
-    layout_index: &LayoutIndex,
-    selection: &ResolvedSelection<'_>,
-    y_bounds: Option<(f32, f32)>,
-) -> Vec<SelectedHardBreak> {
-    let mut hard_breaks = Vec::new();
-    let mut seen = hashbrown::HashSet::new();
-    for entry in layout_index.entries() {
-        if let Some((y_start, y_end)) = y_bounds
-            && !entry.overlaps_y_range(y_start, y_end)
-        {
-            continue;
-        }
-        let Some(hard_break) = hard_break_for_entry(layout_index, selection.view(), entry) else {
-            continue;
-        };
-        if !selection.contains_range(hard_break.selection) {
-            continue;
-        }
-        if !seen.insert(super::common::selection_key(&hard_break.selection)) {
-            continue;
-        }
-        hard_breaks.push(hard_break);
-    }
-    hard_breaks
+pub(crate) fn hard_break_occurrence_for_line(
+    view: &DocView,
+    line: &LayoutLine,
+    line_rect: Rect,
+    pages: &[LayoutPage],
+) -> Option<HardBreakOccurrence> {
+    let range = hard_break_range_for_line(view, line)?;
+    let geometry = geometry_for_line_rect(line_rect, line, range, pages)?;
+    Some(HardBreakOccurrence { range, geometry })
 }
 
 pub(crate) fn drag_selection_for_entry(
@@ -52,7 +36,7 @@ pub(crate) fn drag_selection_for_entry(
     entry: &LayoutEntry,
     point: LayoutPoint,
 ) -> Option<Selection> {
-    let hard_break = hard_break_for_entry(layout_index, view, entry)?;
+    let hard_break = hard_break_occurrence_for_entry(layout_index, view, entry)?;
     let rect = hard_break.geometry.rect.rect;
     let page_y = point.y - point.page_y_start;
     let x_mid = rect.x + rect.width / 2.0;
@@ -62,29 +46,24 @@ pub(crate) fn drag_selection_for_entry(
         && point.x >= x_mid
         && point.x <= hard_break.geometry.line_right
     {
-        Some(hard_break.selection)
+        Some(hard_break.range)
     } else {
         None
     }
 }
 
-fn hard_break_for_entry(
+fn hard_break_occurrence_for_entry(
     layout_index: &LayoutIndex,
     view: &DocView,
     entry: &LayoutEntry,
-) -> Option<SelectedHardBreak> {
+) -> Option<HardBreakOccurrence> {
     let LayoutContent::Line(line) = entry.content(layout_index)? else {
         return None;
     };
-    let selection = hard_break_for_line(view, line)?;
-    let geometry = geometry_for_line_entry(entry, line, selection, layout_index.pages())?;
-    Some(SelectedHardBreak {
-        selection,
-        geometry,
-    })
+    hard_break_occurrence_for_line(view, line, entry.rect, layout_index.pages())
 }
 
-fn hard_break_for_line(view: &DocView, line: &LayoutLine) -> Option<Selection> {
+fn hard_break_range_for_line(view: &DocView, line: &LayoutLine) -> Option<Selection> {
     let range = line.offset_range.as_ref()?;
     let index = range.end;
     let paragraph = view.node(line.node)?;
@@ -107,26 +86,26 @@ fn hard_break_for_line(view: &DocView, line: &LayoutLine) -> Option<Selection> {
     ))
 }
 
-fn geometry_for_line_entry(
-    entry: &LayoutEntry,
+fn geometry_for_line_rect(
+    line_rect: Rect,
     line: &LayoutLine,
-    hard_break: Selection,
+    hard_break_range: Selection,
     pages: &[LayoutPage],
 ) -> Option<HardBreakGeometry> {
-    let page_idx = page_for_y(pages, entry.rect.y)?;
-    let x = entry.rect.x + super::grapheme::x_at_offset(line, &hard_break.anchor);
-    let width = entry.rect.height * 0.15;
+    let page_idx = page_for_y(pages, line_rect.y)?;
+    let x = line_rect.x + super::grapheme::x_at_offset(line, &hard_break_range.anchor);
+    let width = line_rect.height * 0.15;
     Some(HardBreakGeometry {
         rect: PageRect::new(
             page_idx,
             Rect::from_xywh(
                 x,
-                entry.rect.y - pages[page_idx].y_start,
+                line_rect.y - pages[page_idx].y_start,
                 width,
-                entry.rect.height,
+                line_rect.height,
             ),
         ),
-        line_right: entry.rect.right(),
+        line_right: line_rect.right(),
     })
 }
 
@@ -252,14 +231,14 @@ mod tests {
     }
 
     #[test]
-    fn hard_break_for_line_detects_and_rejects() {
+    fn hard_break_range_for_line_detects_and_rejects() {
         let (pd, para_id, index) = para_with_hard_break("Hi", 400.0);
         let view = DocView::new(&pd);
 
         let (entry, line) = first_line_for_para(&index, &para_id)
             .expect("must find line with offset_range for para with hard break");
 
-        let sel = hard_break_for_line(&view, line).expect("must detect trailing hard break");
+        let sel = hard_break_range_for_line(&view, line).expect("must detect trailing hard break");
         assert_eq!(sel.anchor.node, para_id);
         assert_eq!(sel.head.node, para_id);
         let expected_index = line.offset_range.as_ref().unwrap().end;
@@ -272,55 +251,9 @@ mod tests {
         let view2 = DocView::new(&pd2);
         let (_, line2) = first_line_for_para(&index2, &para_id2)
             .expect("must find line for para without hard break");
-        assert!(hard_break_for_line(&view2, line2).is_none());
+        assert!(hard_break_range_for_line(&view2, line2).is_none());
 
         let _ = entry;
-    }
-
-    #[test]
-    fn included_in_selection_covered_and_dedup() {
-        let (pd, para_id, index) = para_with_hard_break("Hi", 400.0);
-        let view = DocView::new(&pd);
-
-        let (_, line) = first_line_for_para(&index, &para_id).expect("must find line");
-        let hb_index = line.offset_range.as_ref().unwrap().end;
-
-        let covering = Selection::new(
-            Position {
-                node: para_id,
-                offset: 0,
-                affinity: Affinity::Downstream,
-            },
-            Position {
-                node: para_id,
-                offset: hb_index + 1,
-                affinity: Affinity::Upstream,
-            },
-        );
-        let rsel = covering
-            .resolve(&view)
-            .expect("must resolve covering selection");
-        let results = included_in_selection(&index, &rsel, None);
-        assert_eq!(results.len(), 1);
-        assert_eq!(results[0].selection.anchor.node, para_id);
-
-        let not_covering = Selection::new(
-            Position {
-                node: para_id,
-                offset: 0,
-                affinity: Affinity::Downstream,
-            },
-            Position {
-                node: para_id,
-                offset: 0,
-                affinity: Affinity::Downstream,
-            },
-        );
-        let rsel2 = not_covering
-            .resolve(&view)
-            .expect("must resolve collapsed selection");
-        let results2 = included_in_selection(&index, &rsel2, None);
-        assert!(results2.is_empty());
     }
 
     #[test]
@@ -344,7 +277,7 @@ mod tests {
             },
         );
 
-        let geom = geometry_for_line_entry(entry, line, sel, index.pages())
+        let geom = geometry_for_line_rect(entry.rect, line, sel, index.pages())
             .expect("must produce geometry");
 
         assert!(
@@ -377,7 +310,7 @@ mod tests {
                 affinity: Affinity::Upstream,
             },
         );
-        let geom = geometry_for_line_entry(entry, line, sel, index.pages())
+        let geom = geometry_for_line_rect(entry.rect, line, sel, index.pages())
             .expect("must produce geometry");
 
         let rect = &geom.rect.rect;

--- a/crates/editor-view/src/query/layout_index.rs
+++ b/crates/editor-view/src/query/layout_index.rs
@@ -481,10 +481,6 @@ impl LayoutEntry {
     pub(crate) fn ancestors(&self) -> &[Dot] {
         &self.ancestors
     }
-
-    pub(crate) fn overlaps_y_range(&self, y_start: f32, y_end: f32) -> bool {
-        rect_overlaps_y_range(&self.rect, y_start, y_end)
-    }
 }
 
 impl LayoutIndexBuilder<'_> {

--- a/crates/editor-view/src/query/paragraph_break.rs
+++ b/crates/editor-view/src/query/paragraph_break.rs
@@ -4,10 +4,11 @@ pub(crate) struct ParagraphBreakGeometry {
 }
 
 use editor_common::Rect;
+use editor_crdt::Dot;
 use editor_model::{ChildView, DocView, NodeType};
 use editor_state::Affinity;
 use editor_state::{
-    Position, ResolvedPosition, ResolvedSelection, Selection, before_or_same, last_cursor_position,
+    Position, ResolvedPosition, Selection, before_or_same, last_cursor_position,
     paragraph_break_at_end,
 };
 
@@ -17,51 +18,36 @@ use crate::paginate::types::{LayoutContent, LayoutLine, SpacingKind};
 use super::common::page_for_y;
 use super::layout_index::{LayoutEntry, LayoutIndex, LayoutPoint};
 
-pub(crate) struct SelectedParagraphBreak {
-    pub(crate) selection: Selection,
+pub(crate) struct ParagraphBreakOccurrence {
+    pub(crate) range: Selection,
     pub(crate) geometry: ParagraphBreakGeometry,
 }
 
-pub(crate) fn included_in_selection(
+pub(crate) fn paragraph_break_occurrence_for_node(
     layout_index: &LayoutIndex,
-    selection: &ResolvedSelection<'_>,
-    y_bounds: Option<(f32, f32)>,
-) -> Vec<SelectedParagraphBreak> {
-    let mut paragraph_breaks = Vec::new();
-    let mut seen = hashbrown::HashSet::new();
-    for entry in layout_index.entries() {
-        if let Some((y_start, y_end)) = y_bounds
-            && !entry.overlaps_y_range(y_start, y_end)
-        {
-            continue;
-        }
-        let Some(paragraph_break) =
-            paragraph_break_for_entry(layout_index, selection.view(), entry)
-        else {
-            continue;
-        };
-        if !selection.contains_range(paragraph_break.selection) {
-            continue;
-        }
-        if !seen.insert(super::common::selection_key(&paragraph_break.selection)) {
-            continue;
-        }
-        paragraph_breaks.push(paragraph_break);
+    view: &DocView,
+    node: Dot,
+) -> Option<ParagraphBreakOccurrence> {
+    let paragraph = view.node(node)?;
+    if paragraph.node_type() != NodeType::Paragraph {
+        return None;
     }
-    paragraph_breaks
+    let range = paragraph_break_at_end(&last_cursor_position(&paragraph)?, view)?;
+    let geometry = geometry(layout_index, range, layout_index.pages())?;
+    Some(ParagraphBreakOccurrence { range, geometry })
 }
 
 fn geometry(
     layout_index: &LayoutIndex,
-    paragraph_break: Selection,
+    paragraph_break_range: Selection,
     pages: &[LayoutPage],
 ) -> Option<ParagraphBreakGeometry> {
-    let pos = paragraph_break.anchor;
+    let pos = paragraph_break_range.anchor;
     let entry = layout_index.entry_for_position(&pos)?;
     let LayoutContent::Line(line) = entry.content(layout_index)? else {
         return None;
     };
-    geometry_for_line_entry(entry, line, paragraph_break, pages)
+    geometry_for_line_entry(entry, line, paragraph_break_range, pages)
 }
 
 pub(crate) fn drag_selection_for_entry(
@@ -71,7 +57,7 @@ pub(crate) fn drag_selection_for_entry(
     entry: &LayoutEntry,
     point: LayoutPoint,
 ) -> Option<Selection> {
-    let paragraph_break = paragraph_break_for_entry(layout_index, view, entry)?;
+    let paragraph_break = paragraph_break_occurrence_for_entry(layout_index, view, entry)?;
     match entry.content(layout_index)? {
         LayoutContent::Line(_) => {
             let rect = paragraph_break.geometry.rect.rect;
@@ -83,50 +69,44 @@ pub(crate) fn drag_selection_for_entry(
                 && point.x >= x_mid
                 && point.x <= paragraph_break.geometry.line_right
             {
-                Some(paragraph_break.selection)
+                Some(paragraph_break.range)
             } else {
                 None
             }
         }
         LayoutContent::Spacing(SpacingKind::Gap { .. }) => {
-            let resolved = paragraph_break.selection.resolve(view)?;
+            let resolved = paragraph_break.range.resolve(view)?;
             if before_or_same(&anchor.position(), &resolved.from().position(), view) {
-                Some(paragraph_break.selection)
+                Some(paragraph_break.range)
             } else {
-                Some(Selection::collapsed(paragraph_break.selection.head))
+                Some(Selection::collapsed(paragraph_break.range.head))
             }
         }
         LayoutContent::Box(_) | LayoutContent::Atom(_) | LayoutContent::Spacing(_) => None,
     }
 }
 
-fn paragraph_break_for_entry(
+fn paragraph_break_occurrence_for_entry(
     layout_index: &LayoutIndex,
     view: &DocView,
     entry: &LayoutEntry,
-) -> Option<SelectedParagraphBreak> {
+) -> Option<ParagraphBreakOccurrence> {
     match entry.content(layout_index)? {
         LayoutContent::Line(line) => {
-            let selection = paragraph_break_for_line(view, line)?;
-            let geometry = geometry_for_line_entry(entry, line, selection, layout_index.pages())?;
-            Some(SelectedParagraphBreak {
-                selection,
-                geometry,
-            })
+            let range = paragraph_break_range_for_line(view, line)?;
+            let geometry = geometry_for_line_entry(entry, line, range, layout_index.pages())?;
+            Some(ParagraphBreakOccurrence { range, geometry })
         }
         LayoutContent::Spacing(SpacingKind::Gap { position }) => {
-            let selection = paragraph_break_before_gap_boundary(view, *position)?;
-            let geometry = geometry(layout_index, selection, layout_index.pages())?;
-            Some(SelectedParagraphBreak {
-                selection,
-                geometry,
-            })
+            let range = paragraph_break_range_before_gap_boundary(view, *position)?;
+            let geometry = geometry(layout_index, range, layout_index.pages())?;
+            Some(ParagraphBreakOccurrence { range, geometry })
         }
         LayoutContent::Box(_) | LayoutContent::Atom(_) | LayoutContent::Spacing(_) => None,
     }
 }
 
-fn paragraph_break_for_line(view: &DocView, line: &LayoutLine) -> Option<Selection> {
+fn paragraph_break_range_for_line(view: &DocView, line: &LayoutLine) -> Option<Selection> {
     if !line_can_host_visual_paragraph_break(line) {
         return None;
     }
@@ -144,7 +124,10 @@ fn line_can_host_visual_paragraph_break(line: &LayoutLine) -> bool {
     !strut_line_represents_inline_child
 }
 
-fn paragraph_break_before_gap_boundary(view: &DocView, position: Position) -> Option<Selection> {
+fn paragraph_break_range_before_gap_boundary(
+    view: &DocView,
+    position: Position,
+) -> Option<Selection> {
     let parent = view.node(position.node)?;
     let previous = position
         .offset
@@ -168,10 +151,10 @@ fn paragraph_break_before_gap_boundary(view: &DocView, position: Position) -> Op
 fn geometry_for_line_entry(
     entry: &LayoutEntry,
     line: &LayoutLine,
-    paragraph_break: Selection,
+    paragraph_break_range: Selection,
     pages: &[LayoutPage],
 ) -> Option<ParagraphBreakGeometry> {
-    let pos = paragraph_break.anchor;
+    let pos = paragraph_break_range.anchor;
     let page_idx = page_for_y(pages, entry.rect.y)?;
     let x = entry.rect.x + super::grapheme::x_at_offset(line, &pos);
     let width = entry.rect.height * 0.15;
@@ -198,7 +181,7 @@ mod tests {
         NodeType, ProjectedDoc, SeqItem, SpanLog, project_document,
     };
     use editor_state::Affinity;
-    use editor_state::{Position, Selection};
+    use editor_state::Position;
 
     use crate::measure::context::MeasureContext;
     use crate::measure::nodes::dispatch::measure_node;
@@ -348,7 +331,7 @@ mod tests {
     }
 
     #[test]
-    fn paragraph_break_for_line_detects_and_rejects() {
+    fn paragraph_break_range_for_line_detects_and_rejects() {
         let doc = two_para_doc();
         let (pd, index) = build_index(&doc, 400.0);
         let view = DocView::new(&pd);
@@ -359,7 +342,7 @@ mod tests {
 
         let (_, line) = first_line_for_para(&index, &para_a_id).expect("must find line for para A");
 
-        let sel = paragraph_break_for_line(&view, line)
+        let sel = paragraph_break_range_for_line(&view, line)
             .expect("must detect paragraph break at end of para A");
         assert_eq!(sel.anchor.node, para_a_id);
 
@@ -377,56 +360,7 @@ mod tests {
         let (_, line2) =
             first_line_for_para(&index2, &para_id2).expect("must find line for single para");
 
-        assert!(paragraph_break_for_line(&view2, line2).is_none());
-    }
-
-    #[test]
-    fn included_in_selection_covered() {
-        let doc = two_para_doc();
-        let (pd, index) = build_index(&doc, 400.0);
-        let view = DocView::new(&pd);
-
-        let root = view.root().unwrap();
-        let mut blocks = root.child_blocks();
-        let para_a_id = blocks.next().expect("first para must exist").id();
-        let para_b_id = blocks.next().expect("second para must exist").id();
-
-        let covering = Selection::new(
-            Position {
-                node: para_a_id,
-                offset: 0,
-                affinity: Affinity::Downstream,
-            },
-            Position {
-                node: para_b_id,
-                offset: 1,
-                affinity: Affinity::Upstream,
-            },
-        );
-        let rsel = covering
-            .resolve(&view)
-            .expect("must resolve covering selection");
-        let results = included_in_selection(&index, &rsel, None);
-        assert_eq!(results.len(), 1);
-        assert_eq!(results[0].selection.anchor.node, para_a_id);
-
-        let not_covering = Selection::new(
-            Position {
-                node: para_a_id,
-                offset: 0,
-                affinity: Affinity::Downstream,
-            },
-            Position {
-                node: para_a_id,
-                offset: 0,
-                affinity: Affinity::Downstream,
-            },
-        );
-        let rsel2 = not_covering
-            .resolve(&view)
-            .expect("must resolve collapsed selection");
-        let results2 = included_in_selection(&index, &rsel2, None);
-        assert!(results2.is_empty());
+        assert!(paragraph_break_range_for_line(&view2, line2).is_none());
     }
 
     #[test]
@@ -450,12 +384,12 @@ mod tests {
             };
             let gap_pos = *position;
 
-            let result = paragraph_break_before_gap_boundary(&view, gap_pos);
+            let result = paragraph_break_range_before_gap_boundary(&view, gap_pos);
             assert!(result.is_some(), "gap after paragraph must produce a break");
 
             let root = view.root().unwrap();
             let root_id = root.id();
-            let none_result = paragraph_break_before_gap_boundary(
+            let none_result = paragraph_break_range_before_gap_boundary(
                 &view,
                 Position {
                     node: root_id,
@@ -483,7 +417,7 @@ mod tests {
         let (entry, line) =
             first_line_for_para(&index, &para_a_id).expect("must find line for para A");
 
-        let sel = paragraph_break_for_line(&view, line).expect("must detect paragraph break");
+        let sel = paragraph_break_range_for_line(&view, line).expect("must detect paragraph break");
 
         let geom = geometry_for_line_entry(entry, line, sel, index.pages())
             .expect("must produce geometry");
@@ -519,7 +453,7 @@ mod tests {
             };
             let gap_pos = *position;
 
-            let pb = paragraph_break_before_gap_boundary(&view, gap_pos);
+            let pb = paragraph_break_range_before_gap_boundary(&view, gap_pos);
             if pb.is_none() {
                 return;
             }

--- a/crates/editor-view/src/query/selection.rs
+++ b/crates/editor-view/src/query/selection.rs
@@ -145,16 +145,6 @@ fn selection_rect_sets(
     let from_entry = layout_index.entry_for_position(&from);
     let to_entry = layout_index.entry_for_position(&to);
 
-    let break_y_bounds = match (from_entry, to_entry) {
-        (Some(f), Some(t)) => Some((f.rect.y.min(t.rect.y), f.rect.bottom().max(t.rect.bottom()))),
-        _ => None,
-    };
-
-    let hard_breaks =
-        super::hard_break::included_in_selection(layout_index, selection, break_y_bounds);
-    let paragraph_breaks =
-        super::paragraph_break::included_in_selection(layout_index, selection, break_y_bounds);
-
     let from_owner = from_entry.filter(|entry| attached(layout_index, entry, &from));
     let to_owner = to_entry.filter(|entry| attached(layout_index, entry, &to));
 
@@ -171,17 +161,9 @@ fn selection_rect_sets(
         &mut phase,
         &mut rects,
         pages,
-        selection.view(),
+        selection,
     );
 
-    for hard_break in hard_breaks {
-        let rect = hard_break_rect(hard_break.geometry);
-        rects.push_same(rect);
-    }
-    for paragraph_break in paragraph_breaks {
-        let rect = paragraph_break_rect(paragraph_break.geometry);
-        rects.push_same(rect);
-    }
     rects.sort_by_position();
 
     rects
@@ -564,7 +546,7 @@ fn visit_node(
     phase: &mut Phase,
     rects: &mut SelectionRectSets,
     pages: &[LayoutPage],
-    doc: &DocView,
+    selection: &ResolvedSelection<'_>,
 ) {
     match &node.content {
         LayoutContent::Box(b) => visit_box(
@@ -578,7 +560,7 @@ fn visit_node(
             phase,
             rects,
             pages,
-            doc,
+            selection,
         ),
         LayoutContent::Line(l) => visit_line(
             node,
@@ -591,8 +573,11 @@ fn visit_node(
             phase,
             rects,
             pages,
+            selection,
         ),
-        LayoutContent::Atom(a) => visit_atom(node, a, from, to, phase, rects, pages, doc),
+        LayoutContent::Atom(a) => {
+            visit_atom(node, a, from, to, phase, rects, pages, selection.view())
+        }
         LayoutContent::Spacing(_) => {}
     }
 }
@@ -608,9 +593,14 @@ fn visit_line(
     phase: &mut Phase,
     rects: &mut SelectionRectSets,
     pages: &[LayoutPage],
+    selection: &ResolvedSelection<'_>,
 ) {
     let contains_from = from_owner.is_some_and(|entry| entry.is_node(layout_index, node));
     let contains_to = to_owner.is_some_and(|entry| entry.is_node(layout_index, node));
+
+    if *phase == Phase::Inside || (*phase == Phase::Before && contains_from) {
+        push_selected_hard_break_rect(node, line, selection, rects, pages);
+    }
 
     let placeholder_width = node.rect.height * 0.15;
 
@@ -671,6 +661,21 @@ fn visit_line(
     }
 }
 
+fn push_selected_hard_break_rect(
+    node: &LayoutNode,
+    line: &LayoutLine,
+    selection: &ResolvedSelection<'_>,
+    rects: &mut SelectionRectSets,
+    pages: &[LayoutPage],
+) {
+    if let Some(hard_break) =
+        super::hard_break::hard_break_occurrence_for_line(selection.view(), line, node.rect, pages)
+        && selection.contains_range(hard_break.range)
+    {
+        rects.push_same(hard_break_rect(hard_break.geometry));
+    }
+}
+
 fn visit_atom(
     node: &LayoutNode,
     atom: &LayoutAtom,
@@ -713,7 +718,7 @@ fn visit_box(
     phase: &mut Phase,
     rects: &mut SelectionRectSets,
     pages: &[LayoutPage],
-    doc: &DocView,
+    selection: &ResolvedSelection<'_>,
 ) {
     let from_at_box_level = from.node == bx.node && from_owner.is_none();
     let to_at_box_level = to.node == bx.node && to_owner.is_none();
@@ -745,7 +750,7 @@ fn visit_box(
             phase,
             rects,
             pages,
-            doc,
+            selection,
         );
 
         if !is_spacing {
@@ -758,6 +763,17 @@ fn visit_box(
                 *phase = Phase::After;
             }
         }
+    }
+
+    if *phase == Phase::Inside
+        && let Some(paragraph_break) = super::paragraph_break::paragraph_break_occurrence_for_node(
+            layout_index,
+            selection.view(),
+            bx.node,
+        )
+        && selection.contains_range(paragraph_break.range)
+    {
+        rects.push_same(paragraph_break_rect(paragraph_break.geometry));
     }
 
     let fully = has_content_child && entry_phase == Phase::Inside && *phase == Phase::Inside;
@@ -912,6 +928,71 @@ mod tests {
             items.push((Dot::new(12, 2 + i as u64), child));
         }
         (logs(&items), root, para)
+    }
+
+    fn monolithic_table_doc() -> (DocLogs, Dot, Dot, Dot) {
+        let root = Dot::ROOT;
+        let table = Dot::new(30, 1);
+        let row = Dot::new(30, 2);
+        let cell = Dot::new(30, 3);
+        let first_para = Dot::new(30, 4);
+        let second_para = Dot::new(30, 7);
+        let trailing_para = Dot::new(30, 9);
+        let items = vec![
+            (
+                table,
+                SeqItem::Block {
+                    node_type: NodeType::Table,
+                    parents: vec![root],
+                    attrs: vec![],
+                },
+            ),
+            (
+                row,
+                SeqItem::Block {
+                    node_type: NodeType::TableRow,
+                    parents: vec![root, table],
+                    attrs: vec![],
+                },
+            ),
+            (
+                cell,
+                SeqItem::Block {
+                    node_type: NodeType::TableCell,
+                    parents: vec![root, table, row],
+                    attrs: vec![],
+                },
+            ),
+            (
+                first_para,
+                SeqItem::Block {
+                    node_type: NodeType::Paragraph,
+                    parents: vec![root, table, row, cell],
+                    attrs: vec![],
+                },
+            ),
+            (Dot::new(30, 5), SeqItem::Char('A')),
+            (Dot::new(30, 6), SeqItem::Atom(AtomLeaf::HardBreak)),
+            (
+                second_para,
+                SeqItem::Block {
+                    node_type: NodeType::Paragraph,
+                    parents: vec![root, table, row, cell],
+                    attrs: vec![],
+                },
+            ),
+            (Dot::new(30, 8), SeqItem::Char('B')),
+            (
+                trailing_para,
+                SeqItem::Block {
+                    node_type: NodeType::Paragraph,
+                    parents: vec![root],
+                    attrs: vec![],
+                },
+            ),
+            (Dot::new(30, 10), SeqItem::Char('C')),
+        ];
+        (logs(&items), root, first_para, second_para)
     }
 
     fn first_line_for_para<'a>(
@@ -1729,5 +1810,108 @@ mod tests {
             ),
             "point inside rect on wrong page must not hit"
         );
+    }
+
+    #[test]
+    fn fully_selected_monolithic_suppresses_descendant_break_rects() {
+        let (doc, root, _first_para, _second_para) = monolithic_table_doc();
+        let (pd, index) = build_index(&doc, 400.0);
+        let view = DocView::new(&pd);
+        let selection = Selection::new(
+            Position {
+                node: root,
+                offset: 0,
+                affinity: Affinity::Downstream,
+            },
+            Position {
+                node: root,
+                offset: 1,
+                affinity: Affinity::Upstream,
+            },
+        );
+        let resolved = selection
+            .resolve(&view)
+            .expect("must resolve table selection");
+
+        for rects in [
+            selection_rects(&index, &resolved),
+            selection_mark_rects(&index, &resolved),
+            selection_text_rects(&index, &resolved),
+        ] {
+            assert!(!rects.is_empty(), "table selection must produce rects");
+            assert!(
+                rects
+                    .iter()
+                    .all(|rect| rect.meta == SelectionRectKind::Block),
+                "fully selected monolithic table must produce only Block rects, got {rects:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn paragraph_break_inside_partially_selected_monolithic_remains_visible() {
+        let (doc, _root, first_para, second_para) = monolithic_table_doc();
+        let (pd, index) = build_index(&doc, 400.0);
+        let view = DocView::new(&pd);
+        let selection = Selection::new(
+            Position {
+                node: first_para,
+                offset: 2,
+                affinity: Affinity::Downstream,
+            },
+            Position {
+                node: second_para,
+                offset: 0,
+                affinity: Affinity::Upstream,
+            },
+        );
+        let resolved = selection
+            .resolve(&view)
+            .expect("must resolve paragraph-break selection");
+        let rects = selection_rects(&index, &resolved);
+
+        assert!(
+            rects
+                .iter()
+                .any(|rect| rect.meta == SelectionRectKind::ParagraphBreak),
+            "selected paragraph break must remain visible, got {rects:?}"
+        );
+        assert!(
+            rects
+                .iter()
+                .all(|rect| rect.meta != SelectionRectKind::Block),
+            "partially selected table must not be promoted to a Block rect, got {rects:?}"
+        );
+    }
+
+    #[test]
+    fn hard_break_inside_partially_selected_monolithic_remains_visible() {
+        let (doc, _root, first_para, _second_para) = monolithic_table_doc();
+        let (pd, index) = build_index(&doc, 400.0);
+        let view = DocView::new(&pd);
+        let selection = Selection::new(
+            Position {
+                node: first_para,
+                offset: 1,
+                affinity: Affinity::Downstream,
+            },
+            Position {
+                node: first_para,
+                offset: 2,
+                affinity: Affinity::Upstream,
+            },
+        );
+        let resolved = selection
+            .resolve(&view)
+            .expect("must resolve hard-break selection");
+        let rects = selection_rects(&index, &resolved);
+
+        assert_eq!(
+            rects.len(),
+            1,
+            "selected hard break must produce exactly its affordance rect, got {rects:?}"
+        );
+        assert_eq!(rects[0].meta, SelectionRectKind::Text);
+        assert!(rects[0].rect.width > 0.0);
     }
 }


### PR DESCRIPTION
## 변경 사항

- hard break는 line, paragraph break는 paragraph box의 selection traversal 중 생성하도록 변경했습니다.
- 완전히 선택된 monolithic box의 기존 descendant rect 교체 흐름에 break rect도 포함해 Block rect 위에 다시 그려지지 않도록 했습니다.
- 별도 LayoutIndex 스캔과 SelectionKey 기반 중복 제거를 없애고, Phase와 endpoint owner로 후보를 좁힌 뒤 `contains_range`로 실제 포함 여부를 판단합니다.
- monolithic box의 전체 선택에서는 하위 break rect가 억제되고 부분 선택에서는 유지되는 회귀 테스트를 추가했습니다.

## 성능

1,000개 hard-break 문단을 사용한 로컬 release benchmark를 기존 HEAD와 현재 구현에 동일하게 적용했습니다. 각 범위를 5회 측정한 중앙값입니다.

| 선택 범위 | HEAD | 현재 | 개선 |
| --- | ---:| ---:| ---:|
| 한 글자 | 37\.300µs | 26\.399µs | 29\.2% |
| 중간 100개 문단 | 1\.705ms | 1\.325ms | 22\.3% |
| 전체 1,000개 문단 | 21\.584ms | 16\.923ms | 21\.6% |

별도 LayoutIndex 스캔과 임시 Vec/HashSet 할당을 제거하면서 측정한 세 범위 모두 빨라졌습니다.

Fixes TR-347