### PR TITLE
앱 에디터 읽기 모드 지원

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorTapHint.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorTapHint.kt
@@ -1,0 +1,93 @@
+package co.typie.editor
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import co.typie.editor.scroll.EditorVisibleArea
+import co.typie.ui.component.Text
+import co.typie.ui.theme.AppShapes
+import co.typie.ui.theme.AppTheme
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.blur.blurEffect
+import dev.chrisbanes.haze.hazeEffect
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collectLatest
+
+internal const val EditorTapHintVisibleMillis = 850
+internal const val EditorTapHintFadeMillis = 180
+internal const val EditorTapHintTestTag = "editor-tap-hint"
+
+@Composable
+internal fun EditorTapHint(
+  events: Flow<Unit>,
+  text: String,
+  hazeState: HazeState,
+  modifier: Modifier = Modifier,
+) {
+  val colors = AppTheme.colors
+  val shape = AppShapes.rounded(AppShapes.md)
+  val alpha = remember { Animatable(0f) }
+
+  LaunchedEffect(events) {
+    events.collectLatest {
+      alpha.animateTo(1f, tween(EditorTapHintFadeMillis))
+      delay(EditorTapHintVisibleMillis.toLong())
+      alpha.animateTo(0f, tween(EditorTapHintFadeMillis))
+    }
+  }
+
+  if (alpha.value > 0f) {
+    Box(
+      modifier =
+        modifier
+          .graphicsLayer { this.alpha = alpha.value }
+          .clip(shape)
+          .hazeEffect(hazeState) {
+            blurEffect {
+              backgroundColor = colors.surfaceInset
+              blurRadius = 6.dp
+            }
+          }
+          .background(colors.surfaceInset.copy(alpha = 0.36f), shape)
+          .semantics { liveRegion = LiveRegionMode.Polite }
+          .testTag(EditorTapHintTestTag)
+          .padding(horizontal = 14.dp, vertical = 8.dp)
+    ) {
+      Text(text = text, style = AppTheme.typography.body, color = colors.textMuted)
+    }
+  }
+}
+
+@Composable
+internal fun BoxScope.EditorTapHintOverlay(
+  events: Flow<Unit>,
+  text: String,
+  hazeState: HazeState,
+  visibleArea: EditorVisibleArea,
+) {
+  Box(
+    modifier =
+      Modifier.fillMaxSize()
+        .padding(top = visibleArea.visibleViewportTop.dp, bottom = visibleArea.bottomOcclusion.dp),
+    contentAlignment = Alignment.Center,
+  ) {
+    EditorTapHint(events = events, text = text, hazeState = hazeState)
+  }
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorGestureContext.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorGestureContext.kt
@@ -11,6 +11,8 @@ internal interface EditorGestureContext {
   val mode: EditorInteractionMode
   val isFocused: Boolean
   val readOnly: Boolean
+  val editing: Boolean
+  val doubleTapToEditEnabled: Boolean
 
   val platform: Platform
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionController.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionController.kt
@@ -26,6 +26,8 @@ internal class EditorInteractionController(
   private val platformProvider: () -> Platform = { Platform.Desktop },
   private val pointerInputEnabledProvider: () -> Boolean = { true },
   private val readOnlyProvider: () -> Boolean = { false },
+  private val editingProvider: () -> Boolean = { true },
+  private val doubleTapToEditEnabledProvider: () -> Boolean = { true },
 ) : EditorGestureContext {
   override val editor: Editor
     get() = editorProvider()
@@ -38,6 +40,12 @@ internal class EditorInteractionController(
 
   override val readOnly: Boolean
     get() = readOnlyProvider()
+
+  override val editing: Boolean
+    get() = editingProvider()
+
+  override val doubleTapToEditEnabled: Boolean
+    get() = doubleTapToEditEnabledProvider()
 
   override val platform: Platform
     get() = platformProvider()
@@ -220,7 +228,12 @@ internal class EditorInteractionController(
     gestures.cancel(context = this)
   }
 
+  fun consumeActiveTapAfterEditingPromotion() {
+    gestures.consumeActiveTapAfterEditingPromotion(context = this)
+  }
+
   fun reset() {
+    effects.cancelTapSequenceConfirmation()
     effects.setScrollGestureLocked(false)
     mode = EditorInteractionMode.Idle
     gestures.reset()

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionEffects.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionEffects.kt
@@ -10,11 +10,19 @@ internal interface EditorInteractionEffects {
 
   fun cancelTapDispatch()
 
+  fun scheduleTapSequenceConfirmation(onConfirmed: () -> Unit)
+
+  fun cancelTapSequenceConfirmation()
+
   fun scheduleLongPressDispatch(pointerId: Long, position: Offset, dispatchAtMillis: Long)
 
   fun cancelLongPressDispatch()
 
   fun launchInteraction(block: suspend () -> Unit)
+
+  fun requestEditing(editor: Editor): Boolean
+
+  fun showReadingEditHint()
 
   fun requestFocus(editor: Editor): Boolean
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionGestures.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionGestures.kt
@@ -71,9 +71,12 @@ internal class EditorInteractionGestures(
       pinch.reset()
       resetPointerOwnedState(context = context)
       context.effects.cancelTapDispatch()
+      tap.cancelPendingPresentation(context = context)
       context.effects.cancelLongPressDispatch()
       return false
     }
+
+    tap.cancelPendingPresentation(context = context)
 
     if (
       touchPanDriver != null &&
@@ -108,6 +111,7 @@ internal class EditorInteractionGestures(
         (selectionHandleType != null && !tripleTapOnSelectionHandle)
     ) {
       tap.clearTapHistory()
+      tap.cancelPendingPresentation(context = context)
     }
 
     if (
@@ -153,6 +157,7 @@ internal class EditorInteractionGestures(
     if (
       tapEnabled &&
         tap.hasActivePointer &&
+        !consumed &&
         !columnResizeConsumed &&
         !selectionHandleConsumed &&
         !tableHandleConsumed
@@ -435,6 +440,7 @@ internal class EditorInteractionGestures(
     val started = longPress.start(pointerId = pointerId, position = position, context = context)
     if (started) {
       pan.cancel(context = context)
+      tap.cancelPendingPresentation(context = context)
       tap.markTapDispatched()
       if (longPress.isWordSelection) {
         tap.clearTapHistory()
@@ -477,6 +483,16 @@ internal class EditorInteractionGestures(
     cancelActivePointerStream(context = context)
   }
 
+  fun consumeActiveTapAfterEditingPromotion(context: EditorGestureContext) {
+    tap.markTapDispatched()
+    longPress.cancelPending()
+    context.effects.cancelTapDispatch()
+    if (!tap.shouldPreservePresentationAfterEditingPromotion()) {
+      tap.cancelPendingPresentation(context = context)
+    }
+    context.effects.cancelLongPressDispatch()
+  }
+
   fun resetPointerOwnedState(context: EditorGestureContext) {
     tableColumnResize.cancel(context = context)
     tableHandle.resetPointerOwnedState(context = context)
@@ -491,12 +507,14 @@ internal class EditorInteractionGestures(
 
   fun cancelActivePointerStream(context: EditorGestureContext) {
     context.effects.cancelTapDispatch()
+    tap.cancelPendingPresentation(context = context)
     context.effects.cancelLongPressDispatch()
     tap.cancelActivePointerStream()
   }
 
   private fun cancelTapAndLongPress(context: EditorGestureContext) {
     context.effects.cancelTapDispatch()
+    tap.cancelPendingPresentation(context = context)
     context.effects.cancelLongPressDispatch()
     longPress.reset()
     doubleTapDrag.resetPointerOwnedState(context = context)
@@ -509,6 +527,7 @@ internal class EditorInteractionGestures(
     context: EditorGestureContext,
   ) {
     if (tap.trackPointerMove(pointerId = pointerId, position = position, context = context)) {
+      tap.cancelPendingPresentation(context = context)
       longPress.cancelPending(pointerId = pointerId)
       context.effects.cancelLongPressDispatch()
     }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionScope.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionScope.kt
@@ -6,6 +6,7 @@ import co.typie.editor.Editor
 import co.typie.editor.EditorState
 import co.typie.editor.PagePoint
 import co.typie.editor.body.EditorDocumentLayoutSpec
+import co.typie.editor.interaction.gestures.EditorConsecutiveTapMaxIntervalMillis
 import co.typie.editor.interaction.gestures.EditorLongPressDispatchDelayMillis
 import co.typie.editor.interaction.gestures.EditorTapDispatchDelayMillis
 import co.typie.editor.interaction.semantics.EditorViewportZoomSemanticConfig
@@ -40,7 +41,13 @@ internal class EditorInteractionScope(
   private var onRequestSoftwareKeyboard: (() -> Unit)? = null
   private var pointerInputEnabled: () -> Boolean = { true }
   private var readOnly: () -> Boolean = { false }
+  private var editing: () -> Boolean = { true }
+  private var doubleTapToEditEnabled: () -> Boolean = { true }
+  private var editingSnapshot: Boolean? = null
+  private var onRequestEditing: ((Editor) -> Boolean)? = null
+  private var onShowReadingEditHint: (() -> Unit)? = null
   private var tapDispatchJob: Job? = null
+  private var tapSequenceConfirmationJob: Job? = null
   private var longPressDispatchJob: Job? = null
   private var scrollGestureLockState: ScrollGestureLockState? = null
   private var scrollGestureLockHandle: ScrollGestureLockHandle? = null
@@ -62,6 +69,8 @@ internal class EditorInteractionScope(
       uiStateProvider = { checkNotNull(uiState) { "Editor interaction scope has no UI state" } },
       pointerInputEnabledProvider = { pointerInputEnabled() },
       readOnlyProvider = { readOnly() },
+      editingProvider = { editing() },
+      doubleTapToEditEnabledProvider = { doubleTapToEditEnabled() },
     )
 
   fun update(
@@ -76,9 +85,28 @@ internal class EditorInteractionScope(
     layoutSpec: EditorDocumentLayoutSpec? = null,
     pointerInputEnabled: () -> Boolean = { true },
     readOnly: () -> Boolean = { false },
+    editing: () -> Boolean = { true },
+    doubleTapToEditEnabled: () -> Boolean = { true },
+    onRequestEditing: (Editor) -> Boolean = { false },
+    onShowReadingEditHint: () -> Unit = {},
     onSelectionHaptic: () -> Unit,
     onRequestSoftwareKeyboard: () -> Unit,
   ) {
+    val nextEditing = editing()
+    val editorChanged = this.editor != null && this.editor !== editor
+    if (editorChanged) {
+      controller.cancel()
+      controller.reset()
+    } else {
+      when (editingSnapshot) {
+        true -> if (!nextEditing) controller.cancel()
+        false ->
+          if (nextEditing) {
+            controller.consumeActiveTapAfterEditingPromotion()
+          }
+        null -> Unit
+      }
+    }
     this.editor = editor
     this.bringIntoViewRequests = bringIntoViewRequests
     this.uiState = uiState
@@ -90,6 +118,11 @@ internal class EditorInteractionScope(
     this.onRequestSoftwareKeyboard = onRequestSoftwareKeyboard
     this.pointerInputEnabled = pointerInputEnabled
     this.readOnly = readOnly
+    this.editing = editing
+    this.doubleTapToEditEnabled = doubleTapToEditEnabled
+    this.editingSnapshot = nextEditing
+    this.onRequestEditing = onRequestEditing
+    this.onShowReadingEditHint = onShowReadingEditHint
     outsidePageTapEnabled = layoutSpec == null || layoutSpec is EditorDocumentLayoutSpec.Continuous
     semantics.viewportZoom.configure(viewportZoomConfig)
   }
@@ -116,6 +149,11 @@ internal class EditorInteractionScope(
     onRequestSoftwareKeyboard = null
     pointerInputEnabled = { true }
     readOnly = { false }
+    editing = { true }
+    doubleTapToEditEnabled = { true }
+    editingSnapshot = null
+    onRequestEditing = null
+    onShowReadingEditHint = null
     outsidePageTapEnabled = true
     scrollGestureLockState = null
   }
@@ -215,6 +253,25 @@ internal class EditorInteractionScope(
     tapDispatchJob = null
   }
 
+  override fun scheduleTapSequenceConfirmation(onConfirmed: () -> Unit) {
+    tapSequenceConfirmationJob?.cancel()
+    val job = coroutineScope.launch {
+      delay(EditorConsecutiveTapMaxIntervalMillis)
+      onConfirmed()
+    }
+    tapSequenceConfirmationJob = job
+    job.invokeOnCompletion {
+      if (tapSequenceConfirmationJob === job) {
+        tapSequenceConfirmationJob = null
+      }
+    }
+  }
+
+  override fun cancelTapSequenceConfirmation() {
+    tapSequenceConfirmationJob?.cancel()
+    tapSequenceConfirmationJob = null
+  }
+
   override fun scheduleLongPressDispatch(
     pointerId: Long,
     position: Offset,
@@ -242,6 +299,12 @@ internal class EditorInteractionScope(
 
   override fun launchInteraction(block: suspend () -> Unit) {
     coroutineScope.launch { block() }
+  }
+
+  override fun requestEditing(editor: Editor): Boolean = onRequestEditing?.invoke(editor) == true
+
+  override fun showReadingEditHint() {
+    onShowReadingEditHint?.invoke()
   }
 
   override fun requestFocus(editor: Editor): Boolean = editor.focus()

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorLongPressGesture.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorLongPressGesture.kt
@@ -90,6 +90,7 @@ internal fun EditorLongPressGesture.captureSemanticIntentAtPointerDown(
       editor = context.editor,
       point = point,
       platform = context.platform,
+      editing = context.editing,
     )
   )
 }
@@ -109,6 +110,7 @@ internal fun EditorLongPressGesture.start(
         editor = context.editor,
         point = point,
         platform = context.platform,
+        editing = context.editing,
       )
   return startSession(
     pointerId = pointerId,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorTableColumnResizeGesture.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorTableColumnResizeGesture.kt
@@ -29,7 +29,7 @@ internal class EditorTableColumnResizeGesture {
   }
 
   fun hitTest(position: Offset, context: EditorGestureContext): EditorTableColumnResizePlacement? =
-    if (context.readOnly) {
+    if (context.readOnly || !context.editing) {
       null
     } else {
       resolveTableColumnResizePlacement(editor = context.editor, geometry = context.geometry)
@@ -52,6 +52,7 @@ internal class EditorTableColumnResizeGesture {
     currentPosition = position
     dragging = false
     context.effects.cancelTapDispatch()
+    context.effects.cancelTapSequenceConfirmation()
     context.effects.cancelLongPressDispatch()
     context.semantics.tableColumnResize.press(editor = context.editor, placement = placement)
     context.semantics.contextMenu.hide()

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorTapGesture.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorTapGesture.kt
@@ -1,13 +1,16 @@
 package co.typie.editor.interaction.gestures
 
 import androidx.compose.ui.geometry.Offset
+import co.typie.editor.Editor
 import co.typie.editor.EditorState
 import co.typie.editor.ext.isCollapsed
 import co.typie.editor.ffi.CursorMetrics
 import co.typie.editor.ffi.InputModifiers
+import co.typie.editor.ffi.Selection
 import co.typie.editor.ffi.SelectionPointUnit
 import co.typie.editor.interaction.EditorGestureContext
 import co.typie.editor.interaction.isViewportZooming
+import co.typie.editor.interaction.semantics.EditorInteractiveTapResult
 import co.typie.editor.interaction.sessions.EditorDoubleTapDragSession
 import co.typie.platform.Platform
 
@@ -16,16 +19,24 @@ private const val EditorTapTimerDelayMillis = 150L
 internal const val EditorTapDispatchDelayMillis =
   EditorTapDownDelayMillis + EditorTapTimerDelayMillis
 
-private const val ConsecutiveTapMaxIntervalMillis = 300L
+internal const val EditorConsecutiveTapMaxIntervalMillis = 300L
 private const val ConsecutiveTapMaxDistanceDp = 20f
+
+internal data class EditorCompletedTap(
+  val count: Int,
+  val contentAlreadyDispatched: Boolean,
+  val recordInHistory: Boolean,
+)
 
 internal class EditorTapGesture(
   private var tapSlopPx: Float,
   private val densityProvider: () -> Float,
-  private val consecutiveTapMaxIntervalMillis: Long = ConsecutiveTapMaxIntervalMillis,
+  private val consecutiveTapMaxIntervalMillis: Long = EditorConsecutiveTapMaxIntervalMillis,
 ) {
   private var activeTap: ActiveTap? = null
   private var tapHistory: TapHistory? = null
+  private var pendingPresentation: PendingTapPresentation? = null
+  private var nextPresentationGeneration = 0L
 
   val hasActivePointer: Boolean
     get() = activeTap != null
@@ -35,6 +46,9 @@ internal class EditorTapGesture(
 
   val inputModifiersForActivePointer: InputModifiers
     get() = activeTap?.inputModifiers ?: InputModifiers()
+
+  val shouldOpenContextMenuForActivePointer: Boolean
+    get() = activeTap?.contextMenuWasVisibleAtPointerDown == false
 
   val tapCountForActivePointer: Int?
     get() = activeTap?.count
@@ -93,7 +107,7 @@ internal class EditorTapGesture(
     position: Offset,
     nowMillis: Long,
     canFinish: Boolean = true,
-  ): Int? {
+  ): EditorCompletedTap? {
     val tap = activeTap
     if (tap == null || tap.pointerId != pointerId) {
       return null
@@ -103,12 +117,21 @@ internal class EditorTapGesture(
       return null
     }
 
-    val clickCount = if (tap.phase == ActiveTapPhase.Pending) tap.count else null
-    if (tap.phase == ActiveTapPhase.Recorded) {
-      recordTap(nowMillis = nowMillis, position = position, clickCount = tap.count)
+    if (tap.phase == ActiveTapPhase.Moved) {
+      clearActivePointer()
+      return null
+    }
+    val completed =
+      EditorCompletedTap(
+        count = tap.semanticCount,
+        contentAlreadyDispatched = tap.phase == ActiveTapPhase.Dispatched,
+        recordInHistory = tap.recordInHistory,
+      )
+    if (completed.recordInHistory) {
+      recordTap(nowMillis = nowMillis, position = position, clickCount = completed.count)
     }
     clearActivePointer()
-    return clickCount
+    return completed
   }
 
   fun cancelActivePointerStream(): Boolean {
@@ -120,6 +143,7 @@ internal class EditorTapGesture(
   fun reset() {
     clearActivePointer()
     clearTapHistory()
+    pendingPresentation = null
   }
 
   private fun clearActivePointer() {
@@ -127,11 +151,6 @@ internal class EditorTapGesture(
   }
 
   fun recordTap(nowMillis: Long, position: Offset, clickCount: Int) {
-    activeTap?.let { tap ->
-      if (clickCount == tap.count && tap.phase != ActiveTapPhase.Moved) {
-        tap.phase = ActiveTapPhase.Recorded
-      }
-    }
     if (clickCount >= 3) {
       clearTapHistory()
       return
@@ -143,9 +162,112 @@ internal class EditorTapGesture(
     tapHistory = null
   }
 
-  fun shouldOpenContextMenuForCurrentTap(): Boolean {
-    val tap = activeTap ?: return false
-    return !tap.contextMenuWasVisibleAtPointerDown
+  fun prepareActiveTapForEditingPromotion() {
+    activeTap?.let { tap ->
+      tap.semanticCount = 1
+      tap.recordInHistory = false
+      tap.preservePresentationAcrossEditingPromotion = true
+      if (tap.phase == ActiveTapPhase.Pending) {
+        tap.phase = ActiveTapPhase.Dispatched
+      }
+    }
+  }
+
+  fun shouldPreservePresentationAfterEditingPromotion(): Boolean =
+    activeTap?.preservePresentationAcrossEditingPromotion == true
+
+  fun beginPendingPresentation(
+    editor: Editor,
+    expectedEditing: Boolean,
+    tapCount: Int,
+    showReadingHint: Boolean,
+    context: EditorGestureContext,
+  ): Long {
+    cancelPendingPresentation(context = context)
+    val generation = ++nextPresentationGeneration
+    pendingPresentation =
+      PendingTapPresentation(
+        generation = generation,
+        editor = editor,
+        expectedEditing = expectedEditing,
+        tapCount = tapCount,
+        showReadingHint = showReadingHint,
+      )
+    return generation
+  }
+
+  fun markPendingSelectionPublished(
+    generation: Long,
+    snapshot: EditorState,
+    showContextMenu: Boolean,
+    context: EditorGestureContext,
+  ) {
+    val pending = pendingPresentation
+    if (pending == null || pending.generation != generation) {
+      return
+    }
+    if (pending.editor.state.selection != snapshot.selection) {
+      cancelPendingPresentation(context = context)
+      return
+    }
+    pending.selectionPublished = true
+    pending.committedSelection = snapshot.selection
+    pending.showContextMenu = showContextMenu
+    deliverPendingPresentationIfReady(context = context)
+  }
+
+  fun confirmPendingPresentationAfterPointerUp(
+    completedTap: EditorCompletedTap,
+    context: EditorGestureContext,
+  ) {
+    val pending = pendingPresentation ?: return
+    if (pending.tapCount != completedTap.count) {
+      return
+    }
+    val generation = pending.generation
+    if (completedTap.count >= 3) {
+      markPendingSequenceConfirmed(generation = generation, context = context)
+      return
+    }
+    context.effects.scheduleTapSequenceConfirmation {
+      markPendingSequenceConfirmed(generation = generation, context = context)
+    }
+  }
+
+  fun cancelPendingPresentation(context: EditorGestureContext) {
+    pendingPresentation = null
+    context.effects.cancelTapSequenceConfirmation()
+  }
+
+  private fun markPendingSequenceConfirmed(generation: Long, context: EditorGestureContext) {
+    val pending = pendingPresentation
+    if (pending == null || pending.generation != generation) {
+      return
+    }
+    pending.sequenceConfirmed = true
+    deliverPendingPresentationIfReady(context = context)
+  }
+
+  private fun deliverPendingPresentationIfReady(context: EditorGestureContext) {
+    val pending = pendingPresentation ?: return
+    if (!pending.selectionPublished || !pending.sequenceConfirmed) {
+      return
+    }
+    if (
+      context.editor !== pending.editor ||
+        context.editing != pending.expectedEditing ||
+        pending.editor.state.selection != pending.committedSelection
+    ) {
+      cancelPendingPresentation(context = context)
+      return
+    }
+    pendingPresentation = null
+    if (pending.showReadingHint && !context.readOnly) {
+      context.effects.showReadingEditHint()
+    }
+    if (pending.showContextMenu) {
+      context.semantics.contextMenu.show(pending.editor.state)
+    }
   }
 
   fun nextTapCount(position: Offset, nowMillis: Long): Int {
@@ -168,16 +290,30 @@ internal class EditorTapGesture(
     val count: Int,
     val contextMenuWasVisibleAtPointerDown: Boolean,
     var phase: ActiveTapPhase = ActiveTapPhase.Pending,
+    var semanticCount: Int = count,
+    var recordInHistory: Boolean = true,
+    var preservePresentationAcrossEditingPromotion: Boolean = false,
   )
 
   private enum class ActiveTapPhase {
     Pending,
     Dispatched,
-    Recorded,
     Moved,
   }
 
   private data class TapHistory(val completedAtMillis: Long, val position: Offset, val count: Int)
+
+  private data class PendingTapPresentation(
+    val generation: Long,
+    val editor: Editor,
+    val expectedEditing: Boolean,
+    val tapCount: Int,
+    val showReadingHint: Boolean,
+    var selectionPublished: Boolean = false,
+    var committedSelection: Selection? = null,
+    var showContextMenu: Boolean = false,
+    var sequenceConfirmed: Boolean = false,
+  )
 }
 
 internal fun EditorTapGesture.handlePointerDown(
@@ -200,16 +336,33 @@ internal fun EditorTapGesture.handlePointerDown(
     inputModifiers = inputModifiers,
     contextMenuWasVisibleAtPointerDown = context.semantics.contextMenu.visible,
   )
+  cancelPendingPresentation(context = context)
   context.semantics.contextMenu.hide()
+  if (!context.editing) {
+    if (tapCountForActivePointer == 2 && context.doubleTapToEditEnabled) {
+      prepareActiveTapForEditingPromotion()
+      context.effects.cancelTapDispatch()
+      val handled =
+        dispatchReadingActivation(
+          position = position,
+          inputModifiers = inputModifiers,
+          shouldOpenContextMenu = shouldOpenContextMenuForActivePointer,
+          doubleTapDrag = doubleTapDrag,
+          context = context,
+        )
+      clearTapHistory()
+      return handled
+    }
+    return false
+  }
   if (tapCountForActivePointer == 2) {
     markTapDispatched()
     context.effects.cancelTapDispatch()
-    dispatchTap(
+    dispatchEditableTap(
       position = position,
-      nowMillis = nowMillis,
       clickCount = 2,
       inputModifiers = inputModifiers,
-      shouldOpenContextMenu = shouldOpenContextMenuForCurrentTap(),
+      shouldOpenContextMenu = shouldOpenContextMenuForActivePointer,
       doubleTapDrag = doubleTapDrag,
       context = context,
     ) {
@@ -244,8 +397,8 @@ internal fun EditorTapGesture.handlePointerUp(
   val canFinishTap = !context.mode.isViewportZooming && !doubleTapDrag.dragging
   val shouldConsumeTap = shouldConsumePointerUp(pointerId = pointerId, canFinish = canFinishTap)
   val inputModifiers = inputModifiersForActivePointer
-  val shouldOpenContextMenu = shouldOpenContextMenuForCurrentTap()
-  val clickCount =
+  val shouldOpenContextMenu = shouldOpenContextMenuForActivePointer
+  val completedTap =
     onPointerUp(
       pointerId = pointerId,
       position = position,
@@ -255,17 +408,37 @@ internal fun EditorTapGesture.handlePointerUp(
   if (!canFinishTap) {
     context.effects.cancelTapDispatch()
   }
-  clickCount?.let {
-    dispatchTap(
-      position = position,
-      nowMillis = nowMillis,
-      clickCount = it,
-      inputModifiers = inputModifiers,
-      shouldOpenContextMenu = shouldOpenContextMenu,
-      doubleTapDrag = doubleTapDrag,
-      context = context,
-      beforeLaunch = {},
-    )
+  if (!context.editing) {
+    completedTap?.let { completed ->
+      if (completed.contentAlreadyDispatched) {
+        confirmPendingPresentationAfterPointerUp(completedTap = completed, context = context)
+        return@let
+      }
+      dispatchReadingTap(
+        position = position,
+        clickCount = completed.count,
+        inputModifiers = inputModifiers,
+        shouldOpenContextMenu = shouldOpenContextMenu,
+        doubleTapDrag = doubleTapDrag,
+        context = context,
+      )
+      confirmPendingPresentationAfterPointerUp(completedTap = completed, context = context)
+    }
+    return shouldConsumeTap
+  }
+  completedTap?.let { completed ->
+    if (!completed.contentAlreadyDispatched) {
+      dispatchEditableTap(
+        position = position,
+        clickCount = completed.count,
+        inputModifiers = inputModifiers,
+        shouldOpenContextMenu = shouldOpenContextMenu,
+        doubleTapDrag = doubleTapDrag,
+        context = context,
+        beforeLaunch = {},
+      )
+    }
+    confirmPendingPresentationAfterPointerUp(completedTap = completed, context = context)
   }
   return shouldConsumeTap
 }
@@ -275,6 +448,9 @@ internal fun EditorTapGesture.handleTapTimer(
   doubleTapDrag: EditorDoubleTapDragSession,
   context: EditorGestureContext,
 ) {
+  if (!context.editing) {
+    return
+  }
   val position = activePosition ?: return
   val inputModifiers = inputModifiersForActivePointer
   if (!canDispatchTapTimer) {
@@ -288,46 +464,217 @@ internal fun EditorTapGesture.handleTapTimer(
       context.editor.selectionHitTest(page = point.page, x = point.x, y = point.y)
   if (clickCount == 1 && context.platform != Platform.Android && hitSelection) {
     markTapDispatched()
-    if (shouldOpenContextMenuForCurrentTap()) {
-      context.semantics.contextMenu.show(context.editor.state)
-    }
+    val snapshot = context.editor.state
+    val generation =
+      beginPendingPresentation(
+        editor = context.editor,
+        expectedEditing = true,
+        tapCount = clickCount,
+        showReadingHint = false,
+        context = context,
+      )
+    markPendingSelectionPublished(
+      generation = generation,
+      snapshot = snapshot,
+      showContextMenu = shouldOpenContextMenuForActivePointer && !snapshot.selection.isCollapsed(),
+      context = context,
+    )
     return
   }
   if (clickCount == 1 && !context.editor.selection.isCollapsed()) {
     return
   }
   markTapDispatched()
-  dispatchTap(
+  dispatchEditableTap(
     position = position,
-    nowMillis = nowMillis,
     clickCount = clickCount,
     inputModifiers = inputModifiers,
-    shouldOpenContextMenu = shouldOpenContextMenuForCurrentTap(),
+    shouldOpenContextMenu = shouldOpenContextMenuForActivePointer,
     doubleTapDrag = doubleTapDrag,
     context = context,
     beforeLaunch = {},
   )
 }
 
-private fun EditorTapGesture.dispatchTap(
+private fun EditorTapGesture.dispatchReadingTap(
   position: Offset,
-  nowMillis: Long,
   clickCount: Int,
   inputModifiers: InputModifiers,
   shouldOpenContextMenu: Boolean,
   doubleTapDrag: EditorDoubleTapDragSession,
   context: EditorGestureContext,
-  beforeLaunch: () -> Unit,
 ): Boolean {
-  val point = context.geometry.resolvePoint(positionInNode = position) ?: return false
+  val point =
+    context.geometry.resolvePoint(positionInNode = position)
+      ?: run {
+        clearTapHistory()
+        return false
+      }
   if (context.mode.isViewportZooming || point.page < 0) {
+    clearTapHistory()
     return false
   }
   val editor = context.editor
-  if (context.semantics.interactiveHit.handleTap(editor = editor, point = point)) {
-    return true
+  when (
+    context.semantics.interactiveHit.handleTap(
+      editor = editor,
+      point = point,
+      editing = false,
+      readOnly = context.readOnly,
+    )
+  ) {
+    EditorInteractiveTapResult.HandledViewAction,
+    EditorInteractiveTapResult.BlockedMutation -> {
+      clearTapHistory()
+      cancelPendingPresentation(context = context)
+      return true
+    }
+    EditorInteractiveTapResult.None -> Unit
   }
-  recordTap(nowMillis = nowMillis, position = position, clickCount = clickCount)
+  if (clickCount != 1) {
+    clearTapHistory()
+    return false
+  }
+  if (!context.doubleTapToEditEnabled) {
+    return dispatchReadingActivation(
+      position = position,
+      inputModifiers = inputModifiers,
+      shouldOpenContextMenu = shouldOpenContextMenu,
+      doubleTapDrag = doubleTapDrag,
+      context = context,
+    )
+  }
+
+  val generation =
+    beginPendingPresentation(
+      editor = editor,
+      expectedEditing = false,
+      tapCount = clickCount,
+      showReadingHint = true,
+      context = context,
+    )
+  var candidateSnapshot: EditorState? = null
+  context.semantics.pointSelection.launchCursorMove(
+    editor = editor,
+    point = point,
+    beforeCommit = { snapshot -> candidateSnapshot = snapshot },
+    afterDispatch = { dispatched ->
+      val snapshot = candidateSnapshot
+      if (dispatched && snapshot != null) {
+        markPendingSelectionPublished(
+          generation = generation,
+          snapshot = snapshot,
+          showContextMenu = shouldOpenContextMenu && !snapshot.selection.isCollapsed(),
+          context = context,
+        )
+      } else {
+        cancelPendingPresentation(context = context)
+      }
+    },
+  )
+  return true
+}
+
+private fun EditorTapGesture.dispatchReadingActivation(
+  position: Offset,
+  inputModifiers: InputModifiers,
+  shouldOpenContextMenu: Boolean,
+  doubleTapDrag: EditorDoubleTapDragSession,
+  context: EditorGestureContext,
+): Boolean {
+  val point =
+    context.geometry.resolvePoint(positionInNode = position)
+      ?: run {
+        clearTapHistory()
+        return false
+      }
+  if (context.mode.isViewportZooming || point.page < 0) {
+    clearTapHistory()
+    return false
+  }
+  val editor = context.editor
+  when (
+    context.semantics.interactiveHit.handleTap(
+      editor = editor,
+      point = point,
+      editing = false,
+      readOnly = context.readOnly,
+    )
+  ) {
+    EditorInteractiveTapResult.HandledViewAction,
+    EditorInteractiveTapResult.BlockedMutation -> {
+      clearTapHistory()
+      cancelPendingPresentation(context = context)
+      return true
+    }
+    EditorInteractiveTapResult.None -> Unit
+  }
+  if (!context.effects.requestEditing(editor)) {
+    clearTapHistory()
+    return false
+  }
+  val dispatched =
+    dispatchEditableTap(
+      position = position,
+      clickCount = 1,
+      inputModifiers = inputModifiers.copy(shift = false),
+      shouldOpenContextMenu = shouldOpenContextMenu,
+      doubleTapDrag = doubleTapDrag,
+      context = context,
+      preserveExistingSelectionOnSingleTap = false,
+      beforeLaunch = {},
+    )
+  if (dispatched) {
+    context.effects.requestSoftwareKeyboard()
+  }
+  return dispatched
+}
+
+private fun EditorTapGesture.dispatchEditableTap(
+  position: Offset,
+  clickCount: Int,
+  inputModifiers: InputModifiers,
+  shouldOpenContextMenu: Boolean,
+  doubleTapDrag: EditorDoubleTapDragSession,
+  context: EditorGestureContext,
+  preserveExistingSelectionOnSingleTap: Boolean = true,
+  beforeLaunch: () -> Unit,
+): Boolean {
+  val point =
+    context.geometry.resolvePoint(positionInNode = position)
+      ?: run {
+        clearTapHistory()
+        return false
+      }
+  if (context.mode.isViewportZooming || point.page < 0) {
+    clearTapHistory()
+    return false
+  }
+  val editor = context.editor
+  when (
+    context.semantics.interactiveHit.handleTap(
+      editor = editor,
+      point = point,
+      editing = context.editing,
+      readOnly = context.readOnly,
+    )
+  ) {
+    EditorInteractiveTapResult.HandledViewAction,
+    EditorInteractiveTapResult.BlockedMutation -> {
+      clearTapHistory()
+      cancelPendingPresentation(context = context)
+      return true
+    }
+    EditorInteractiveTapResult.None -> Unit
+  }
+  val generation =
+    beginPendingPresentation(
+      editor = editor,
+      expectedEditing = true,
+      tapCount = clickCount,
+      showReadingHint = false,
+      context = context,
+    )
   val wasFocused = context.isFocused
   context.effects.requestFocus(editor)
   if (wasFocused) {
@@ -335,50 +682,62 @@ private fun EditorTapGesture.dispatchTap(
   }
   val hitExistingSelectionAtTap =
     editor.selectionHitTest(page = point.page, x = point.x, y = point.y)
-  if (clickCount == 1 && context.platform != Platform.Android && hitExistingSelectionAtTap) {
-    if (shouldOpenContextMenu) {
-      context.semantics.contextMenu.show(editor.state)
-    }
+  if (
+    clickCount == 1 &&
+      preserveExistingSelectionOnSingleTap &&
+      context.platform != Platform.Android &&
+      hitExistingSelectionAtTap
+  ) {
+    markPendingSelectionPublished(
+      generation = generation,
+      snapshot = editor.state,
+      showContextMenu = shouldOpenContextMenu,
+      context = context,
+    )
     return false
   }
   val previousCursor = editor.cursor
   beforeLaunch()
-  val tap = this
+  var candidateSnapshot: EditorState? = null
+  var candidateShowsContextMenu = false
   val beforeCommit: (EditorState) -> Unit = { snapshot ->
+    candidateSnapshot = snapshot
     if (clickCount == 1) {
       when {
         !snapshot.selection.isCollapsed() -> {
           if (!hitExistingSelectionAtTap) {
-            context.semantics.contextMenu.show(snapshot)
+            candidateShowsContextMenu = true
             context.effects.requestCurrentSelectionHead(version = snapshot.version)
-          } else {
-            context.semantics.contextMenu.hide()
           }
         }
         isSameCursorTap(previousCursor, snapshot) -> {
-          if (wasFocused && shouldOpenContextMenu) {
-            context.semantics.contextMenu.show(snapshot)
-          }
+          candidateShowsContextMenu = wasFocused
         }
         else -> {
-          context.semantics.contextMenu.hide()
           if (snapshot.cursor != null) {
             context.effects.requestCurrentSelectionHead(version = snapshot.version)
           }
         }
       }
+    } else {
+      candidateShowsContextMenu = !snapshot.selection.isCollapsed()
     }
   }
+  val tap = this
   val afterDispatch: (Boolean) -> Unit = { dispatched ->
-    if (dispatched) {
-      when (clickCount) {
-        2 -> doubleTapDrag.onWordSelectionCommitted(tap = tap, context = context)
-        3 -> {
-          if (!editor.selection.isCollapsed()) {
-            context.semantics.contextMenu.show(editor.state)
-          }
-        }
+    val snapshot = candidateSnapshot
+    if (dispatched && snapshot != null) {
+      markPendingSelectionPublished(
+        generation = generation,
+        snapshot = snapshot,
+        showContextMenu = shouldOpenContextMenu && candidateShowsContextMenu,
+        context = context,
+      )
+      if (clickCount == 2) {
+        doubleTapDrag.onWordSelectionCommitted(tap = tap, context = context)
       }
+    } else {
+      cancelPendingPresentation(context = context)
     }
   }
   when {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/semantics/EditorInteractiveHitSemantic.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/semantics/EditorInteractiveHitSemantic.kt
@@ -9,27 +9,42 @@ import co.typie.editor.ffi.PlainNode
 import co.typie.editor.ffi.Rect
 import co.typie.editor.ffi.ViewOp
 
+internal enum class EditorInteractiveTapResult {
+  None,
+  HandledViewAction,
+  BlockedMutation,
+}
+
 internal class EditorInteractiveHitSemantic {
-  fun handleTap(editor: Editor, point: PagePoint): Boolean =
+  fun handleTap(
+    editor: Editor,
+    point: PagePoint,
+    editing: Boolean,
+    readOnly: Boolean,
+  ): EditorInteractiveTapResult =
     when (val hit = editor.interactiveHitTest(page = point.page, x = point.x, y = point.y)) {
       is InteractiveHit.FoldTitle -> {
         val onText = hit.textRect?.contains(point.x, point.y) == true
         if (onText) {
-          false
+          EditorInteractiveTapResult.None
         } else {
           editor.enqueue(Message.View(ViewOp.ToggleFold(id = hit.id)))
-          true
+          EditorInteractiveTapResult.HandledViewAction
         }
       }
       is InteractiveHit.CalloutIcon -> {
-        editor.enqueue(
-          Message.Node(
-            NodeOp.SetAttrs(id = hit.id, attrs = PlainNode.Callout(variant = hit.nextVariant))
+        if (editing && !readOnly) {
+          editor.enqueue(
+            Message.Node(
+              NodeOp.SetAttrs(id = hit.id, attrs = PlainNode.Callout(variant = hit.nextVariant))
+            )
           )
-        )
-        true
+          EditorInteractiveTapResult.HandledViewAction
+        } else {
+          EditorInteractiveTapResult.BlockedMutation
+        }
       }
-      else -> false
+      else -> EditorInteractiveTapResult.None
     }
 }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/semantics/EditorLongPressSemantic.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/semantics/EditorLongPressSemantic.kt
@@ -15,7 +15,11 @@ internal class EditorLongPressSemantic {
     editor: Editor,
     point: PagePoint,
     platform: Platform,
+    editing: Boolean,
   ): EditorLongPressSemanticIntent {
+    if (!editing) {
+      return EditorLongPressSemanticIntent.WordSelection
+    }
     if (platform != Platform.Android) {
       return EditorLongPressSemanticIntent.CursorMove
     }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/sessions/EditorDoubleTapDragSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/sessions/EditorDoubleTapDragSession.kt
@@ -17,6 +17,7 @@ internal class EditorDoubleTapDragSession {
   private var pendingSelectionExtensionPosition: Offset? = null
   private var startPosition: Offset? = null
   private var startThresholdPx = 0f
+  private var terminalDragAwaitingWordCommit = false
 
   val active: Boolean
     get() = phase != EditorDoubleTapDragPhase.Idle
@@ -37,6 +38,7 @@ internal class EditorDoubleTapDragSession {
     }
     context.effects.cancelTapDispatch()
     tap.markTapDispatched()
+    terminalDragAwaitingWordCommit = false
     context.semantics.selectionExpansion.reset()
     context.semantics.selectionExpansion.awaitWordSelectionCommit()
     context.semantics.contextMenu.hide()
@@ -70,7 +72,6 @@ internal class EditorDoubleTapDragSession {
   fun endDrag(context: EditorGestureContext): Boolean {
     val wasActive = active
     val wasDragging = dragging
-    val wasPending = pending
     if (!stop()) {
       return false
     }
@@ -80,11 +81,9 @@ internal class EditorDoubleTapDragSession {
       if (context.mode.canApply(EditorInteractionEvent.DoubleTapDragEnd)) {
         context.reduceMode(EditorInteractionEvent.DoubleTapDragEnd)
       }
-      if (!context.editor.selection.isCollapsed()) {
-        context.semantics.contextMenu.show(context.editor.state)
-      }
-    } else if (wasPending) {
-      if (!context.editor.selection.isCollapsed()) {
+      if (context.semantics.selectionExpansion.isAwaitingWordSelectionCommit) {
+        terminalDragAwaitingWordCommit = true
+      } else if (!context.editor.selection.isCollapsed()) {
         context.semantics.contextMenu.show(context.editor.state)
       }
     }
@@ -96,9 +95,10 @@ internal class EditorDoubleTapDragSession {
     context.semantics.selectionExpansion.markWordSelectionCommitted()
     flushPendingSelectionExtension(context = context)
     if (!tap.hasActivePointer && !active) {
-      if (!context.editor.selection.isCollapsed()) {
+      if (terminalDragAwaitingWordCommit && !context.editor.selection.isCollapsed()) {
         context.semantics.contextMenu.show(context.editor.state)
       }
+      terminalDragAwaitingWordCommit = false
       resetSelectionExtensionState(context = context)
     }
   }
@@ -113,11 +113,13 @@ internal class EditorDoubleTapDragSession {
     context.effects.setScrollGestureLocked(false)
     context.semantics.edgeAutoScroll.stop()
     resetSelectionExtensionState(context = context)
+    terminalDragAwaitingWordCommit = false
     reset()
   }
 
   fun reset() {
     pendingSelectionExtensionPosition = null
+    terminalDragAwaitingWordCommit = false
     stop()
   }
 
@@ -135,6 +137,7 @@ internal class EditorDoubleTapDragSession {
     if (!begin()) {
       return false
     }
+    tap.cancelPendingPresentation(context = context)
     context.reduceMode(EditorInteractionEvent.DoubleTapDragStart)
     if (context.mode != EditorInteractionMode.DoubleTapSelecting) {
       stop()

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/preview/EditorPreview.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/preview/EditorPreview.kt
@@ -1,7 +1,5 @@
 package co.typie.editor.preview
 
-import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -24,7 +22,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Constraints
@@ -32,6 +29,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import co.typie.editor.Editor
 import co.typie.editor.EditorRegistry
+import co.typie.editor.EditorTapHint
 import co.typie.editor.EditorZoomController
 import co.typie.editor.LocalEditorZoomController
 import co.typie.editor.body.EditorDocumentLayoutSpec
@@ -60,20 +58,11 @@ import co.typie.editor.surface.EditorPageSurface
 import co.typie.editor.surface.editorPagePositionTracker
 import co.typie.ext.clickable
 import co.typie.platform.PlatformModule
-import co.typie.ui.component.Text
-import co.typie.ui.theme.AppShapes
 import co.typie.ui.theme.AppTheme
 import dev.chrisbanes.haze.HazeState
-import dev.chrisbanes.haze.blur.blurEffect
-import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.collectLatest
-
-private const val PreviewHintVisibleMillis = 850
-private const val PreviewHintFadeMillis = 180
 
 @Composable
 internal fun EditorPreview(
@@ -106,18 +95,9 @@ internal fun EditorPreview(
   val zoomController = remember(runtime, sourceKey) { EditorZoomController(scope = scope) }
   val bringIntoViewRequests = remember(runtime, sourceKey) { EditorBringIntoViewRequests() }
   val hintHazeState = remember { HazeState() }
-  val hintShape = AppShapes.rounded(AppShapes.sm)
   val hintEvents = remember { MutableSharedFlow<Unit>(extraBufferCapacity = 1) }
-  val hintAlpha = remember { Animatable(0f) }
 
   DisposableEffect(runtime, sourceKey) { onDispose { runtime.clear() } }
-  LaunchedEffect(hintEvents) {
-    hintEvents.collectLatest {
-      hintAlpha.animateTo(1f, tween(PreviewHintFadeMillis))
-      delay(PreviewHintVisibleMillis.toLong())
-      hintAlpha.animateTo(0f, tween(PreviewHintFadeMillis))
-    }
-  }
   LaunchedEffect(runtime.editor, layoutMode, modifiers) {
     val editor = runtime.editor ?: return@LaunchedEffect
     val currentModifiers = editor.rootModifiers.orEmpty().toPreviewRootModifierMap()
@@ -203,23 +183,7 @@ internal fun EditorPreview(
         modifier = Modifier.weight(1f).fillMaxWidth().clickable { hintEvents.tryEmit(Unit) },
         contentAlignment = Alignment.Center,
       ) {
-        if (hintAlpha.value > 0f) {
-          Box(
-            modifier =
-              Modifier.graphicsLayer { alpha = hintAlpha.value }
-                .clip(hintShape)
-                .hazeEffect(hintHazeState) {
-                  blurEffect {
-                    backgroundColor = colors.surfaceInset
-                    blurRadius = 6.dp
-                  }
-                }
-                .background(colors.surfaceInset.copy(alpha = 0.36f), hintShape)
-                .padding(horizontal = 10.dp, vertical = 5.dp)
-          ) {
-            Text(text = hintText, style = AppTheme.typography.caption, color = colors.textMuted)
-          }
-        }
+        EditorTapHint(events = hintEvents, text = hintText, hazeState = hintHazeState)
       }
     }
   }
@@ -394,10 +358,7 @@ private fun PlainDoc.withPreviewRootModifiers(modifiers: List<EditorModifier>): 
 }
 
 private fun List<EditorModifier>.toPreviewRootModifierMap(): Map<ModifierType, EditorModifier> =
-  mapNotNull { modifier ->
-    modifier.previewRootModifierType()?.let { it to modifier }
-  }
-  .toMap()
+  mapNotNull { modifier -> modifier.previewRootModifierType()?.let { it to modifier } }.toMap()
 
 private fun EditorModifier.previewRootModifierType(): ModifierType? =
   when (this) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorAwaitWithBringIntoView.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorAwaitWithBringIntoView.kt
@@ -57,12 +57,14 @@ internal fun Editor.syncWithBringIntoView(
 
 internal suspend fun Editor.awaitWithBringIntoView(
   bringIntoViewRequests: EditorBringIntoViewRequests,
+  admit: () -> Boolean = { true },
   block: EditorBringIntoViewAwaitScope.() -> Unit,
 ): EditorState? {
   val beforeCommitBlocks = mutableListOf<EditorBringIntoViewCommitScope.() -> Unit>()
   var committedState: EditorState? = null
 
   await(
+    admit = admit,
     beforeCommit = { snapshot ->
       committedState = snapshot
       val commitScope =
@@ -73,7 +75,7 @@ internal suspend fun Editor.awaitWithBringIntoView(
         }
 
       beforeCommitBlocks.forEach { block -> block(commitScope) }
-    }
+    },
   ) {
     val editorScope = this
     val awaitScope =

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ext/TextInputState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ext/TextInputState.kt
@@ -65,6 +65,17 @@ internal constructor(private val binding: TextInputBinding, initialValue: TextFi
     applyValueChange(value)
   }
 
+  fun updateSelection(selection: TextRange) {
+    value =
+      value.copy(selection = clampTextInputRange(selection, value.text.length), composition = null)
+  }
+
+  fun finishCompositionAndCollapseSelection() {
+    val next = finishTextInputComposition(value)
+    val cursor = next.selection.start.coerceIn(0, next.text.length)
+    value = next.copy(selection = TextRange(cursor), composition = null)
+  }
+
   override val hasActiveComposition: Boolean
     get() = value.composition != null
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -52,6 +52,7 @@ import co.typie.editor.DocumentReloadFailureDecision
 import co.typie.editor.Editor
 import co.typie.editor.EditorLocalChangesetBus
 import co.typie.editor.EditorState
+import co.typie.editor.EditorTapHintOverlay
 import co.typie.editor.LocalEditorZoomController
 import co.typie.editor.body.EditorBody
 import co.typie.editor.body.EditorDocumentLayoutSpec
@@ -64,6 +65,7 @@ import co.typie.editor.ffi.ClipboardOp
 import co.typie.editor.ffi.Direction
 import co.typie.editor.ffi.EditorEvent
 import co.typie.editor.ffi.ExternalElementData
+import co.typie.editor.ffi.FlatImeOp
 import co.typie.editor.ffi.HistoryTag
 import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.Movement
@@ -184,6 +186,7 @@ import co.typie.screen.editor.editor.toolbar.suppressSoftwareKeyboard
 import co.typie.screen.editor.editor.toolbar.textInputSessionEnabledForBottomPanel
 import co.typie.screen.editor.editor.toolbar.trustedImeBottomInset
 import co.typie.screen.editor.editor.topbar.EditorDocumentButton
+import co.typie.screen.editor.editor.topbar.EditorScreenTopBar
 import co.typie.screen.settings.aisettings.AiPreferences
 import co.typie.serialization.json
 import co.typie.storage.Preference
@@ -212,6 +215,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
@@ -240,6 +244,7 @@ fun EditorScreen(entityId: String) {
   val focusReturnSession = remember(entityId) { EditorFocusReturnSession(scope = scope) }
   val runtime = remember(entityId) { EditorRuntime(uiScope = scope) }
   val interactionScope = remember(entityId) { EditorInteractionScope(coroutineScope = scope) }
+  val readingHintEvents = remember(entityId) { MutableSharedFlow<Unit>(extraBufferCapacity = 1) }
   val uiState = remember(entityId) { EditorUiState() }
   val externalElementState = remember(entityId) { EditorExternalElementState() }
   val assetHydrator =
@@ -255,6 +260,12 @@ fun EditorScreen(entityId: String) {
   val document = entity.node.onDocument
   val documentLocked = document?.locked == true
   val editorReadOnly = editorIsReadOnly(documentLocked, SubscriptionService.entitlement)
+  val editingState = rememberEditorScreenEditingState(entityId)
+  val isEditing = editingState.editing
+  var readingModeCleanupRequest by remember(entityId) { mutableStateOf(0) }
+  val directEditingEnabled = editingState.directEditingEnabled(readOnly = editorReadOnly)
+  val currentEditorReadOnly by rememberUpdatedState(editorReadOnly)
+  val currentDirectEditingEnabled by rememberUpdatedState(directEditingEnabled)
   val documentId = model.documentId
   var editorLoadState by remember(entityId) { mutableStateOf<DocumentEditorLoad?>(null) }
   var syncActiveLoadState by remember(entityId) { mutableStateOf<DocumentEditorLoad?>(null) }
@@ -276,11 +287,15 @@ fun EditorScreen(entityId: String) {
     }
   }
   LaunchedEffect(nav.current, entityId, runtime, screenState) {
+    val isForeground = nav.current == Route.Editor(entityId)
     screenState.updateSceneForeground(
-      isForeground = nav.current == Route.Editor(entityId),
+      isForeground = isForeground,
       runtime = runtime,
       uiState = uiState,
     )
+    if (!isForeground) {
+      interactionScope.controller.cancel()
+    }
   }
   LaunchedEffect(document?.nullableTitle, document?.subtitle, loading) {
     model.syncDocument(
@@ -319,12 +334,34 @@ fun EditorScreen(entityId: String) {
     }
   }
   fun requestEditorFocus() {
-    if (nav.current == Route.Editor(entityId)) {
+    if (
+      editingState.directEditingEnabled(currentEditorReadOnly) &&
+        nav.current == Route.Editor(entityId)
+    ) {
       runtime.focus()
     }
   }
   val editor = runtime.editor
+  fun requestEditing(expectedEditor: Editor): Boolean {
+    if (
+      currentEditorReadOnly ||
+        runtime.editor !== expectedEditor ||
+        nav.current != Route.Editor(entityId) ||
+        !screenState.sceneInForeground
+    ) {
+      return false
+    }
+    editingState.enterEditing()
+    return true
+  }
   val editingSession = runtime.session
+  fun canApplyEditorMutation(expectedSession: DocumentEditingSession): Boolean =
+    editingState.directEditingEnabled(currentEditorReadOnly) &&
+      runtime.session === expectedSession &&
+      model.documentId == expectedSession.documentId &&
+      nav.current == Route.Editor(entityId) &&
+      screenState.sceneInForeground
+
   val editorSessionAttached = editingSession != null
   LaunchedEffect(editor) {
     if (editor != null && editor.inputRecorder == null && Preference.devMode) {
@@ -332,6 +369,7 @@ fun EditorScreen(entityId: String) {
     }
   }
   val editorState = editor?.state ?: EditorState.Initial
+  val doubleTapToEditEnabled = Preference.doubleTapToEditEnabled && editorState.placeholder == null
   val externalAssetIds =
     remember(editorState.externalElements) {
       editorState.externalElements
@@ -355,13 +393,14 @@ fun EditorScreen(entityId: String) {
     assetHydrator.resolve(externalAssetIds)
   }
   val bringIntoViewRequests = rememberEditorBringIntoViewRequests()
-  val currentEditorReadOnly by rememberUpdatedState(editorReadOnly)
   val attachmentImporter =
     remember(runtime, externalElementState, bringIntoViewRequests) {
       DefaultEditorAttachmentImporter(
         externalElementState = externalElementState,
         bringIntoViewRequests = bringIntoViewRequests,
-        isSessionCurrent = { session -> runtime.session === session && !currentEditorReadOnly },
+        isSessionCurrent = { session ->
+          runtime.session === session && currentDirectEditingEnabled
+        },
         backgroundScope = scope,
       )
     }
@@ -370,7 +409,9 @@ fun EditorScreen(entityId: String) {
       SessionEditorIncomingContentHandler(
         importer = attachmentImporter,
         bringIntoViewRequests = bringIntoViewRequests,
-        isSessionCurrent = { session -> runtime.session === session && !currentEditorReadOnly },
+        isSessionCurrent = { session ->
+          runtime.session === session && currentDirectEditingEnabled
+        },
         onAttachmentError = { message -> toast.error(message) },
       )
     }
@@ -387,9 +428,11 @@ fun EditorScreen(entityId: String) {
       editingSession = editingSession,
       editorState = editorState,
       bringIntoViewRequests = bringIntoViewRequests,
+      onEditingIntent = ::requestEditing,
+      admitMutation = ::canApplyEditorMutation,
     )
   fun requestEditorFocusIfSelectionActive() {
-    if (editorState.selection != null) {
+    if (isEditing && editorState.selection != null) {
       requestEditorFocus()
     }
   }
@@ -406,7 +449,7 @@ fun EditorScreen(entityId: String) {
       editor = editor,
       focused = uiState.focused,
       selection = editorState.selection,
-      contextActive = screenState.sceneInForeground && !editorReadOnly,
+      contextActive = screenState.sceneInForeground && directEditingEnabled,
       auxiliaryOwnerActive = focusReturnOwnerActive,
     )
   }
@@ -446,6 +489,8 @@ fun EditorScreen(entityId: String) {
       hideContextMenu = { uiState.contextMenu.hide() },
       closeSubPane = subPaneState::dismiss,
       ensureSubscription = ::ensureSpellcheckSubscription,
+      onEditingIntent = ::requestEditing,
+      admitMutation = ::canApplyEditorMutation,
     )
   val aiFeedback =
     rememberEditorAiFeedbackSession(
@@ -462,6 +507,53 @@ fun EditorScreen(entityId: String) {
       ensureSubscription = ::ensureAiFeedbackSubscription,
       ensureAiOptIn = ::ensureAiOptIn,
     )
+  val comments =
+    rememberEditorCommentsSession(
+      entityId = entityId,
+      documentId = document?.id,
+      documentLocked = editorReadOnly,
+      editor = editor,
+      editorState = editorState,
+      sheetActive = subPaneState.active == EditorSubPane.Comments,
+      bringIntoViewRequests = bringIntoViewRequests,
+      hideContextMenu = { uiState.contextMenu.hide() },
+      openSheet = { subPaneState.open(EditorSubPane.Comments) },
+    )
+  suspend fun enterReadingMode() {
+    val transition = editingState.beginReadingTransition() ?: return
+    val activeEditor = runtime.editor
+    val activeDocumentId = model.documentId
+    try {
+      val transitionCurrent = {
+        editingState.isReadingTransitionCurrent(transition) &&
+          runtime.editor === activeEditor &&
+          model.documentId == activeDocumentId &&
+          nav.current == Route.Editor(entityId) &&
+          screenState.sceneInForeground
+      }
+      val finalized =
+        activeEditor?.await(admit = transitionCurrent) {
+          if (activeEditor.tickIme?.composing != null) {
+            enqueue(Message.TextInput(listOf(FlatImeOp.CommitAsIs)))
+          }
+          enqueue(Message.System(SystemEvent.SetFocused(false)))
+        } ?: true
+      if (!finalized || !transitionCurrent()) return
+      model.flushDrafts()
+
+      if (!transitionCurrent()) return
+
+      subPaneState.dismiss()
+      uiState.contextMenu.hide()
+      popoverOverlayState.dismissFromOutsideGesture()
+      interactionScope.controller.cancel()
+      runtime.blur()
+      readingModeCleanupRequest += 1
+      editingState.completeReadingTransition(transition)
+    } finally {
+      editingState.cancelReadingTransition(transition)
+    }
+  }
   fun closeSpellcheckAndRestoreEditorFocus() {
     spellcheck.close()
     requestEditorFocusIfSelectionActive()
@@ -475,79 +567,6 @@ fun EditorScreen(entityId: String) {
       findReplace.active -> findReplace.close()
       spellcheck.active -> closeSpellcheckAndRestoreEditorFocus()
       aiFeedback.active -> closeAiFeedbackAndRestoreEditorFocus()
-    }
-  }
-
-  when {
-    findReplace.active -> {
-      ProvideTopBar(
-        leading = { FindReplaceTopBarLeading(session = findReplace) },
-        leadingKey = FindReplaceTopBarLeadingKey,
-        center = { FindReplaceTopBarCenter(session = findReplace) },
-        centerKey = FindReplaceTopBarCenterKey,
-        trailing = { FindReplaceTopBarTrailing(session = findReplace) },
-        trailingKey = FindReplaceTopBarTrailingKey,
-        scrollOffset = null,
-      )
-    }
-    spellcheck.active -> {
-      ProvideTopBar(
-        leading = { SpellcheckTopBarLeading(session = spellcheck) },
-        leadingKey = SpellcheckTopBarLeadingKey,
-        center = { SpellcheckTopBarCenter(session = spellcheck) },
-        centerKey = SpellcheckTopBarCenterKey,
-        trailing = { SpellcheckTopBarTrailing(session = spellcheck) },
-        trailingKey = SpellcheckTopBarTrailingKey,
-        scrollOffset = null,
-      )
-    }
-    aiFeedback.active -> {
-      ProvideTopBar(
-        leading = { AiFeedbackTopBarLeading(session = aiFeedback) },
-        leadingKey = AiFeedbackTopBarLeadingKey,
-        center = { AiFeedbackTopBarCenter(session = aiFeedback) },
-        centerKey = AiFeedbackTopBarCenterKey,
-        trailing = { AiFeedbackTopBarTrailing(session = aiFeedback) },
-        trailingKey = AiFeedbackTopBarTrailingKey,
-        scrollOffset = null,
-      )
-    }
-    else -> {
-      ProvideTopBar(
-        center = {
-          document?.let {
-            Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-              EditorDocumentButton(
-                entityIcon = entity.entityIcon_entity,
-                title = model.headingTitle,
-                subtitle = model.headingSubtitle,
-                loading = loading,
-                onClick = {
-                  val activeEditor = runtime.editor
-                  val target = Route.Document(entityId)
-                  var delivered = false
-                  try {
-                    DocumentCharacterCountSnapshots.put(entityId, activeEditor?.characterCounts())
-                    screenState.prepareToLeaveEditorScene(
-                      runtime = runtime,
-                      uiState = uiState,
-                      flushDrafts = { model.flush() },
-                    )
-                    delivered = nav.navigate(target) is NavigationResult.ReachedTarget
-                  } finally {
-                    if (!delivered) {
-                      DocumentCharacterCountSnapshots.remove(entityId)
-                    }
-                  }
-                },
-                modifier =
-                  Modifier.fillMaxWidth().widthIn(max = ResponsiveContainerDefaults.MaxWidth),
-              )
-            }
-          }
-        },
-        scrollOffset = null,
-      )
     }
   }
 
@@ -1030,18 +1049,6 @@ fun EditorScreen(entityId: String) {
       )
     },
   ) { innerPadding ->
-    val comments =
-      rememberEditorCommentsSession(
-        entityId = entityId,
-        documentId = document?.id,
-        documentLocked = editorReadOnly,
-        editor = editor,
-        editorState = editorState,
-        sheetActive = subPaneState.active == EditorSubPane.Comments,
-        bringIntoViewRequests = bringIntoViewRequests,
-        hideContextMenu = { uiState.contextMenu.hide() },
-        openSheet = { subPaneState.open(EditorSubPane.Comments) },
-      )
     val layoutPageSizes = layoutEditor?.pageSizes.orEmpty()
     val density = LocalDensity.current.density
     val focusManager = LocalFocusManager.current
@@ -1072,7 +1079,7 @@ fun EditorScreen(entityId: String) {
         screenState.sceneInForeground &&
         !subPaneBlocksEditorInput &&
         !findReplace.active &&
-        !editorReadOnly
+        directEditingEnabled
     val findReplaceToolbarVisible =
       screenState.sceneInForeground && !subPaneBlocksEditorInput && findReplace.active
     val findReplaceToolbarTransition = remember {
@@ -1091,21 +1098,169 @@ fun EditorScreen(entityId: String) {
         panelTransitionRunning = panelTransitionRunning,
       )
     fun performInputEffects(effects: List<EditorInputEffect>) {
-      effects.forEach { effect ->
-        when (effect) {
-          EditorInputEffect.ShowKeyboard -> keyboardController?.show()
-          EditorInputEffect.HideKeyboard -> keyboardController?.hide()
-          EditorInputEffect.RequestFocus -> requestEditorFocus()
-          EditorInputEffect.ClearFocus -> focusManager.clearFocus(force = true)
-        }
-      }
+      performEditorInputEffects(
+        effects = effects,
+        showKeyboard = { keyboardController?.show() },
+        hideKeyboard = { keyboardController?.hide() },
+        requestFocus = ::requestEditorFocus,
+        clearFocus = { focusManager.clearFocus(force = true) },
+        enterReadingMode = { scope.launch { enterReadingMode() } },
+      )
     }
-    fun openFindReplace() {
+    fun openFindReplace(resetEditorInput: Boolean = true) {
       aiFeedback.close()
       spellcheck.close()
       uiState.contextMenu.hide()
-      performInputEffects(toolbarInputState.dispatch(ToolbarIntent.Reset, toolbarInputEnvironment))
+      if (resetEditorInput) {
+        performInputEffects(
+          toolbarInputState.dispatch(ToolbarIntent.Reset, toolbarInputEnvironment)
+        )
+      }
       findReplace.open()
+    }
+    val devMode = Preference.devMode
+    val debugOverlays =
+      if (devMode) {
+        EditorToolbarDebugOverlays(
+          viewportVisible = model.debugViewportOverlayVisible,
+          bodyVisible = model.debugBodyOverlayVisible,
+          surfaceVisible = model.debugSurfaceOverlayVisible,
+          inputLogAvailable = editor?.inputRecorder != null,
+        )
+      } else {
+        null
+      }
+    fun performToolAction(action: EditorToolbarToolAction, restoreEditorInput: Boolean) {
+      when (action) {
+        EditorToolbarToolAction.Search -> openFindReplace(resetEditorInput = restoreEditorInput)
+        EditorToolbarToolAction.RelatedNotes -> {
+          findReplace.close()
+          aiFeedback.close()
+          spellcheck.close()
+          uiState.contextMenu.hide()
+          subPaneState.open(EditorSubPane.RelatedNotes)
+        }
+        EditorToolbarToolAction.Comment -> {
+          findReplace.close()
+          aiFeedback.close()
+          spellcheck.close()
+          comments.openFromToolPanel()
+        }
+        EditorToolbarToolAction.Spellcheck -> {
+          findReplace.close()
+          aiFeedback.close()
+          spellcheck.openFromToolPanel()
+          if (restoreEditorInput) {
+            performInputEffects(
+              toolbarInputState.dispatch(ToolbarIntent.RestoreEditorInput, toolbarInputEnvironment)
+            )
+          }
+        }
+        EditorToolbarToolAction.AiFeedback -> {
+          aiFeedback.openFromToolPanel()
+        }
+        EditorToolbarToolAction.Timeline -> {
+          toast.show(ToastType.Notification, "타임라인 기능은 아직 준비 중이에요.")
+        }
+        EditorToolbarToolAction.DebugViewportOverlay -> model.toggleDebugViewportOverlay()
+        EditorToolbarToolAction.DebugBodyOverlay -> model.toggleDebugBodyOverlay()
+        EditorToolbarToolAction.DebugSurfaceOverlay -> model.toggleDebugSurfaceOverlay()
+        EditorToolbarToolAction.SendInputLog -> {
+          val recorder = editor?.inputRecorder
+          if (recorder != null) {
+            scope.launch {
+              val name = sheet.present<String> { InputLogSendSheet() } ?: return@launch
+              val payload = buildInputLogPayload(name = name, entries = recorder.snapshot())
+              try {
+                sendInputLog(payload)
+                toast.show(ToastType.Success, "입력 로그를 보냈어요.")
+              } catch (e: CancellationException) {
+                throw e
+              } catch (_: Exception) {
+                toast.show(ToastType.Error, "입력 로그 전송에 실패했어요.")
+              }
+            }
+          }
+        }
+      }
+    }
+
+    when {
+      findReplace.active -> {
+        ProvideTopBar(
+          leading = { FindReplaceTopBarLeading(session = findReplace) },
+          leadingKey = FindReplaceTopBarLeadingKey,
+          center = { FindReplaceTopBarCenter(session = findReplace) },
+          centerKey = FindReplaceTopBarCenterKey,
+          trailing = { FindReplaceTopBarTrailing(session = findReplace) },
+          trailingKey = FindReplaceTopBarTrailingKey,
+          scrollOffset = null,
+        )
+      }
+      spellcheck.active -> {
+        ProvideTopBar(
+          leading = { SpellcheckTopBarLeading(session = spellcheck) },
+          leadingKey = SpellcheckTopBarLeadingKey,
+          center = { SpellcheckTopBarCenter(session = spellcheck) },
+          centerKey = SpellcheckTopBarCenterKey,
+          trailing = { SpellcheckTopBarTrailing(session = spellcheck) },
+          trailingKey = SpellcheckTopBarTrailingKey,
+          scrollOffset = null,
+        )
+      }
+      aiFeedback.active -> {
+        ProvideTopBar(
+          leading = { AiFeedbackTopBarLeading(session = aiFeedback) },
+          leadingKey = AiFeedbackTopBarLeadingKey,
+          center = { AiFeedbackTopBarCenter(session = aiFeedback) },
+          centerKey = AiFeedbackTopBarCenterKey,
+          trailing = { AiFeedbackTopBarTrailing(session = aiFeedback) },
+          trailingKey = AiFeedbackTopBarTrailingKey,
+          scrollOffset = null,
+        )
+      }
+      else -> {
+        EditorScreenTopBar(
+          editing = isEditing,
+          debugOverlays = debugOverlays,
+          documentButton = { modifier ->
+            document?.let {
+              Box(modifier = modifier, contentAlignment = Alignment.Center) {
+                EditorDocumentButton(
+                  entityIcon = entity.entityIcon_entity,
+                  title = model.headingTitle,
+                  subtitle = model.headingSubtitle,
+                  loading = loading,
+                  onClick = {
+                    val activeEditor = runtime.editor
+                    val target = Route.Document(entityId)
+                    var delivered = false
+                    try {
+                      DocumentCharacterCountSnapshots.put(entityId, activeEditor?.characterCounts())
+                      screenState.prepareToLeaveEditorScene(
+                        runtime = runtime,
+                        uiState = uiState,
+                        flushDrafts = { model.flush() },
+                      )
+                      delivered = nav.navigate(target) is NavigationResult.ReachedTarget
+                    } finally {
+                      if (!delivered) {
+                        DocumentCharacterCountSnapshots.remove(entityId)
+                      }
+                    }
+                  },
+                  modifier =
+                    Modifier.fillMaxWidth().widthIn(max = ResponsiveContainerDefaults.MaxWidth),
+                )
+              }
+            }
+          },
+          onToolAction = { action ->
+            performToolAction(action = action, restoreEditorInput = false)
+          },
+          onEnterReadingMode = ::enterReadingMode,
+        )
+      }
     }
     val screenShortcutContext =
       EditorScreenShortcutContext(
@@ -1119,13 +1274,14 @@ fun EditorScreen(entityId: String) {
       )
     val screenShortcutActions =
       EditorScreenShortcutActions(
-        openFindReplace = ::openFindReplace,
+        openFindReplace = { openFindReplace() },
         closeFindReplace = findReplace.close,
         closeSpellcheck = ::closeSpellcheckAndRestoreEditorFocus,
         closeAiFeedback = ::closeAiFeedbackAndRestoreEditorFocus,
       )
     suspend fun openTemplateSheet() {
       val activeEditor = runtime.editor ?: return
+      if (!requestEditing(activeEditor)) return
       runtime.blur()
       focusManager.clearFocus(force = true)
       uiState.contextMenu.hide()
@@ -1140,8 +1296,8 @@ fun EditorScreen(entityId: String) {
         performInputEffects(listOf(EditorInputEffect.HideKeyboard))
       }
     }
-    LaunchedEffect(aiFeedback.active) {
-      if (aiFeedback.active) {
+    LaunchedEffect(aiFeedback.active, isEditing) {
+      if (aiFeedback.active && isEditing) {
         performInputEffects(
           toolbarInputState.dispatch(ToolbarIntent.RestoreEditorInput, toolbarInputEnvironment)
         )
@@ -1168,7 +1324,6 @@ fun EditorScreen(entityId: String) {
     val imeAppearing = !previousImeVisible.value && imeVisible
     val toolbarRetainedKeyboardInset = toolbarInputState.retainedKeyboardInset()
     val toolbarRestoreInset = toolbarInputState.keyboardRestoreInset
-    val popoverOverlayState = LocalPopoverOverlayState.current
     val toolbarPresented =
       isEditorToolbarPresented(
         environment = toolbarInputEnvironment,
@@ -1233,7 +1388,6 @@ fun EditorScreen(entityId: String) {
       }
     val typewriterEnabled = Preference.typewriterEnabled
     val typewriterPosition = Preference.typewriterPosition.toFloat()
-    val devMode = Preference.devMode
     val displayZoom = zoomController.displayZoom
     val typewriterTargetLineHeight =
       resolveBringIntoViewTargetHeight(
@@ -1252,7 +1406,7 @@ fun EditorScreen(entityId: String) {
         maxOf(toolbarBottomOcclusion.value, findReplaceToolbarOcclusion).value.coerceAtLeast(0f)
       }
     val repasteAsTextVisible =
-      !editorReadOnly &&
+      directEditingEnabled &&
         uiState.focused &&
         editorState.selection != null &&
         editorState.lastHistoryTag is HistoryTag.PasteHtml
@@ -1276,18 +1430,41 @@ fun EditorScreen(entityId: String) {
     val visibleArea = visibleAreas.editor
     LaunchedEffect(editorReadOnly) {
       if (!editorReadOnly) return@LaunchedEffect
-      // 세션 중 강등: 열린 보조 모드를 닫고 포커스·키보드를 안전 복구한다.
+      editingState.enterReading()
+      readingModeCleanupRequest += 1
       findReplace.close()
       spellcheck.close()
       aiFeedback.close()
       subPaneState.dismiss()
       uiState.contextMenu.hide()
-      if (uiState.focused) {
-        runtime.blur()
-        uiState.updateFocus(false)
-        runtime.editor?.sync { enqueue(Message.System(SystemEvent.SetFocused(false))) }
+      popoverOverlayState.dismissFromOutsideGesture()
+    }
+    LaunchedEffect(editor, directEditingEnabled) {
+      if (!editingState.shouldRunReadingCleanup(editorReadOnly)) return@LaunchedEffect
+      val activeEditor = editor ?: return@LaunchedEffect
+      val cleaned =
+        activeEditor.await(
+          admit = {
+            runtime.editor === activeEditor && editingState.shouldRunReadingCleanup(editorReadOnly)
+          }
+        ) {
+          if (activeEditor.tickIme?.composing != null) {
+            enqueue(Message.TextInput(listOf(FlatImeOp.CommitAsIs)))
+          }
+          enqueue(Message.System(SystemEvent.SetFocused(false)))
+        }
+      if (!cleaned) return@LaunchedEffect
+      if (
+        runtime.editor !== activeEditor || !editingState.shouldRunReadingCleanup(editorReadOnly)
+      ) {
+        return@LaunchedEffect
       }
+      interactionScope.controller.cancel()
+      runtime.blur()
+      performInputEffects(toolbarInputState.dispatch(ToolbarIntent.Reset, toolbarInputEnvironment))
+      focusManager.clearFocus(force = true)
       keyboardController?.hide()
+      uiState.updateFocus(false)
     }
     LaunchedEffect(imeVisible, bottomPanelOpen) { previousImeVisible.value = imeVisible }
     LaunchedEffect(layoutSpec, visibleArea.visibleBodySize.width) {
@@ -1425,9 +1602,18 @@ fun EditorScreen(entityId: String) {
         layoutSpec = layoutSpec,
         pointerInputEnabled = { editorInteractionEnabled },
         readOnly = { editorReadOnly },
+        editing = { isEditing },
+        doubleTapToEditEnabled = { doubleTapToEditEnabled },
+        onRequestEditing = ::requestEditing,
+        onShowReadingEditHint = { readingHintEvents.tryEmit(Unit) },
         onSelectionHaptic = { haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove) },
         onRequestSoftwareKeyboard = {
-          if (editorReady && editorInputEnabledByToolbar && !editorSuppressesSoftwareKeyboard) {
+          if (
+            editingState.directEditingEnabled(editorReadOnly) &&
+              editorReady &&
+              editorInputEnabledByToolbar &&
+              !editorSuppressesSoftwareKeyboard
+          ) {
             keyboardController?.show()
           }
         },
@@ -1477,6 +1663,21 @@ fun EditorScreen(entityId: String) {
         viewportScrollReconcileMode = viewportScrollReconcileMode,
         onEditorPointerInput = { toolbarPagerState.dismissIndicator() },
         onViewportIndirectInput = { uiState.contextMenu.hide() },
+        onRequestEditing =
+          if (!isEditing && !editorReadOnly) {
+            {
+              val activeEditor = runtime.editor
+              if (activeEditor != null && requestEditing(activeEditor)) {
+                activeEditor.focus()
+                keyboardController?.show()
+                true
+              } else {
+                false
+              }
+            }
+          } else {
+            null
+          },
         onMeasuredViewportSizeChange = { viewport ->
           val editor = runtime.editor
           if (editor != null && viewport.width > 0f && viewport.height > 0f) {
@@ -1504,7 +1705,11 @@ fun EditorScreen(entityId: String) {
               title = model.titleDraft,
               subtitle = model.subtitleDraft,
               loading = false,
-              enabled = editorReady && !editorReadOnly,
+              enabled = editorReady && !editorReadOnly && screenState.sceneInForeground,
+              editing = isEditing,
+              doubleTapToEditEnabled = doubleTapToEditEnabled,
+              readingTapIdentity = editor,
+              readingModeCleanupRequest = readingModeCleanupRequest,
               showBottomDivider = layoutSpec is EditorDocumentLayoutSpec.Continuous,
               topInset = topInset,
               subtitleFocusRequestVersion = subtitleFocusRequestVersion.value,
@@ -1513,6 +1718,11 @@ fun EditorScreen(entityId: String) {
               onTitleFocused = entryState::markTitleFocused,
               onSubtitleFocused = entryState::markSubtitleFocused,
               onHeightChanged = screenState::updateHeaderHeight,
+              onRequestEditing = {
+                val activeEditor = editor
+                activeEditor != null && requestEditing(activeEditor)
+              },
+              onReadingEditHint = { readingHintEvents.tryEmit(Unit) },
               onEnterDocument = {
                 model.flushDraftsAsync()
                 enterDocumentStartFromHeader(
@@ -1535,6 +1745,16 @@ fun EditorScreen(entityId: String) {
           }
         },
         viewportOverlay = {
+          if (
+            screenState.sceneInForeground && !isEditing && !editorReadOnly && doubleTapToEditEnabled
+          ) {
+            EditorTapHintOverlay(
+              events = readingHintEvents,
+              text = "편집하려면 더블 탭",
+              hazeState = LocalHazeState.current,
+              visibleArea = visibleArea,
+            )
+          }
           if (editorReady) {
             EditorZoomOverlay(
               modifier =
@@ -1563,19 +1783,20 @@ fun EditorScreen(entityId: String) {
                 viewportState = screenState.viewportState,
                 visibleArea = visibleArea,
                 autoScrollPolicy = autoScrollPolicy,
-                onTableAxisActionsRequest = { target, openedSelection ->
-                  findReplace.close()
-                  aiFeedback.close()
-                  spellcheck.close()
-                  uiState.contextMenu.hide()
-                  subPaneState.open(
-                    EditorSubPane.TableAxisActions(
-                      target = target,
-                      openedSelection = openedSelection,
+                onTableAxisActionsRequest = tableAxisActions@{ target, openedSelection ->
+                    if (!directEditingEnabled) return@tableAxisActions
+                    findReplace.close()
+                    aiFeedback.close()
+                    spellcheck.close()
+                    uiState.contextMenu.hide()
+                    subPaneState.open(
+                      EditorSubPane.TableAxisActions(
+                        target = target,
+                        openedSelection = openedSelection,
+                      )
                     )
-                  )
-                },
-                editorReadOnly = editorReadOnly,
+                  },
+                editorMutationEnabled = directEditingEnabled,
                 showDebugOverlay = devMode && model.debugViewportOverlayVisible,
                 modifier = Modifier.fillMaxSize(),
               )
@@ -1593,19 +1814,20 @@ fun EditorScreen(entityId: String) {
               EditorRepasteAsTextOverlay(
                 visibleArea = visibleAreas.base,
                 visible = repasteAsTextVisible,
-                onRepasteAsText = {
-                  activeSession.submit { activeEditor, context ->
-                    activeEditor.scope.launch(context) {
-                      activeEditor.awaitWithBringIntoView(bringIntoViewRequests) {
-                        enqueue(Message.Clipboard(ClipboardOp.RepasteAsText))
-                        beforeCommit {
-                          bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+                onRepasteAsText = repasteAsText@{
+                    if (!directEditingEnabled) return@repasteAsText
+                    activeSession.submit { activeEditor, context ->
+                      activeEditor.scope.launch(context) {
+                        activeEditor.awaitWithBringIntoView(bringIntoViewRequests) {
+                          enqueue(Message.Clipboard(ClipboardOp.RepasteAsText))
+                          beforeCommit {
+                            bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+                          }
                         }
                       }
                     }
-                  }
-                  activeSession.editor.focus()
-                },
+                    activeSession.editor.focus()
+                  },
                 modifier = Modifier.fillMaxSize(),
               )
             }
@@ -1620,9 +1842,10 @@ fun EditorScreen(entityId: String) {
               layoutSpec = layoutSpec,
               autoScrollPolicy = autoScrollPolicy,
               modifier = Modifier,
-              editorInputEnabled = editorReady && editorInputEnabledByToolbar && !editorReadOnly,
+              editorInputEnabled =
+                editorReady && editorInputEnabledByToolbar && directEditingEnabled,
               suppressSoftwareKeyboard =
-                !editorReady || editorSuppressesSoftwareKeyboard || editorReadOnly,
+                !editorReady || editorSuppressesSoftwareKeyboard || !directEditingEnabled,
               showDebugBodyOverlay = devMode && model.debugBodyOverlayVisible,
               showDebugSurfaceOverlay = devMode && model.debugSurfaceOverlayVisible,
               overlay = {
@@ -1670,73 +1893,11 @@ fun EditorScreen(entityId: String) {
             fontFamilies = model.toolbarFontFamilies,
             sessionState = toolbarSessionState,
             commentEnabled = comments.toolbarEnabled,
-            debugOverlays =
-              if (devMode) {
-                EditorToolbarDebugOverlays(
-                  viewportVisible = model.debugViewportOverlayVisible,
-                  bodyVisible = model.debugBodyOverlayVisible,
-                  surfaceVisible = model.debugSurfaceOverlayVisible,
-                  inputLogAvailable = editor?.inputRecorder != null,
-                )
-              } else {
-                null
-              },
+            debugOverlays = debugOverlays,
             onCommentRequest = comments.requestFromTextToolbar,
             onInputEffects = ::performInputEffects,
             onToolAction = { action ->
-              when (action) {
-                EditorToolbarToolAction.Search -> openFindReplace()
-                EditorToolbarToolAction.RelatedNotes -> {
-                  findReplace.close()
-                  aiFeedback.close()
-                  spellcheck.close()
-                  uiState.contextMenu.hide()
-                  subPaneState.open(EditorSubPane.RelatedNotes)
-                }
-                EditorToolbarToolAction.Comment -> {
-                  findReplace.close()
-                  aiFeedback.close()
-                  spellcheck.close()
-                  comments.openFromToolPanel()
-                }
-                EditorToolbarToolAction.Spellcheck -> {
-                  findReplace.close()
-                  aiFeedback.close()
-                  spellcheck.openFromToolPanel()
-                  performInputEffects(
-                    toolbarInputState.dispatch(
-                      ToolbarIntent.RestoreEditorInput,
-                      toolbarInputEnvironment,
-                    )
-                  )
-                }
-                EditorToolbarToolAction.AiFeedback -> {
-                  aiFeedback.openFromToolPanel()
-                }
-                EditorToolbarToolAction.Timeline -> {
-                  toast.show(ToastType.Notification, "타임라인 기능은 아직 준비 중이에요.")
-                }
-                EditorToolbarToolAction.DebugViewportOverlay -> model.toggleDebugViewportOverlay()
-                EditorToolbarToolAction.DebugBodyOverlay -> model.toggleDebugBodyOverlay()
-                EditorToolbarToolAction.DebugSurfaceOverlay -> model.toggleDebugSurfaceOverlay()
-                EditorToolbarToolAction.SendInputLog -> {
-                  val recorder = editor?.inputRecorder
-                  if (recorder != null) {
-                    scope.launch {
-                      val name = sheet.present<String> { InputLogSendSheet() } ?: return@launch
-                      val payload = buildInputLogPayload(name = name, entries = recorder.snapshot())
-                      try {
-                        sendInputLog(payload)
-                        toast.show(ToastType.Success, "입력 로그를 보냈어요.")
-                      } catch (e: CancellationException) {
-                        throw e
-                      } catch (_: Exception) {
-                        toast.show(ToastType.Error, "입력 로그 전송에 실패했어요.")
-                      }
-                    }
-                  }
-                }
-              }
+              performToolAction(action = action, restoreEditorInput = true)
             },
             modifier = Modifier,
           )

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreenEditingState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreenEditingState.kt
@@ -1,0 +1,82 @@
+package co.typie.screen.editor.editor
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import co.typie.screen.editor.editor.state.EditorInputEffect
+
+@Stable
+internal class EditorScreenEditingState {
+  var editing by mutableStateOf(false)
+    private set
+
+  private var nextReadingTransition = 0L
+  private var pendingReadingTransition: Long? = null
+
+  fun enterEditing() {
+    pendingReadingTransition = null
+    editing = true
+  }
+
+  fun enterReading() {
+    pendingReadingTransition = null
+    editing = false
+  }
+
+  fun beginReadingTransition(): Long? {
+    if (!editing || pendingReadingTransition != null) {
+      return null
+    }
+    val transition = ++nextReadingTransition
+    pendingReadingTransition = transition
+    return transition
+  }
+
+  fun isReadingTransitionCurrent(transition: Long): Boolean =
+    editing && pendingReadingTransition == transition
+
+  fun completeReadingTransition(transition: Long): Boolean {
+    if (!isReadingTransitionCurrent(transition)) {
+      return false
+    }
+    pendingReadingTransition = null
+    editing = false
+    return true
+  }
+
+  fun cancelReadingTransition(transition: Long) {
+    if (pendingReadingTransition == transition) {
+      pendingReadingTransition = null
+    }
+  }
+
+  fun directEditingEnabled(readOnly: Boolean): Boolean = editing && !readOnly
+
+  fun shouldRunReadingCleanup(readOnly: Boolean): Boolean = !directEditingEnabled(readOnly)
+}
+
+@Composable
+internal fun rememberEditorScreenEditingState(entityId: String): EditorScreenEditingState =
+  remember(entityId) { EditorScreenEditingState() }
+
+internal fun performEditorInputEffects(
+  effects: List<EditorInputEffect>,
+  showKeyboard: () -> Unit,
+  hideKeyboard: () -> Unit,
+  requestFocus: () -> Unit,
+  clearFocus: () -> Unit,
+  enterReadingMode: () -> Unit,
+) {
+  effects.forEach { effect ->
+    when (effect) {
+      EditorInputEffect.ShowKeyboard -> showKeyboard()
+      EditorInputEffect.HideKeyboard -> hideKeyboard()
+      EditorInputEffect.RequestFocus -> requestFocus()
+      EditorInputEffect.ClearFocus -> clearFocus()
+      EditorInputEffect.EnterReadingMode -> enterReadingMode()
+    }
+  }
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/EditorFindReplaceSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/EditorFindReplaceSession.kt
@@ -59,6 +59,8 @@ internal fun rememberEditorFindReplaceSession(
   editingSession: DocumentEditingSession?,
   editorState: EditorState,
   bringIntoViewRequests: EditorBringIntoViewRequests,
+  onEditingIntent: (Editor) -> Boolean,
+  admitMutation: (DocumentEditingSession) -> Boolean,
 ): EditorFindReplaceSession {
   val state = remember { FindReplaceSessionController() }
   val scope = rememberCoroutineScope()
@@ -113,12 +115,16 @@ internal fun rememberEditorFindReplaceSession(
     },
     replace = replace@{
         val activeSession = editingSession ?: return@replace
+        if (documentLocked) {
+          toast.show(ToastType.Error, "잠긴 문서는 편집할 수 없어요.")
+          return@replace
+        }
+        if (!state.canReplaceActive() || !onEditingIntent(activeSession.editor)) return@replace
         activeSession.submit { activeEditor, context ->
           activeEditor.scope.launch(context) {
             state.replaceActive(
               editor = activeEditor,
-              documentLocked = documentLocked,
-              onLocked = { toast.show(ToastType.Error, "잠긴 문서는 편집할 수 없어요.") },
+              admitMutation = { admitMutation(activeSession) },
               bringIntoViewRequests = bringIntoViewRequests,
             )
           }
@@ -126,12 +132,16 @@ internal fun rememberEditorFindReplaceSession(
       },
     replaceAll = replaceAll@{
         val activeSession = editingSession ?: return@replaceAll
+        if (documentLocked) {
+          toast.show(ToastType.Error, "잠긴 문서는 편집할 수 없어요.")
+          return@replaceAll
+        }
+        if (!state.canReplaceAll() || !onEditingIntent(activeSession.editor)) return@replaceAll
         activeSession.submit { activeEditor, context ->
           activeEditor.scope.launch(context) {
             state.replaceAllMatches(
               editor = activeEditor,
-              documentLocked = documentLocked,
-              onLocked = { toast.show(ToastType.Error, "잠긴 문서는 편집할 수 없어요.") },
+              admitMutation = { admitMutation(activeSession) },
               bringIntoViewRequests = bringIntoViewRequests,
             )
           }
@@ -177,6 +187,14 @@ private class FindReplaceSessionController {
   fun updateReplaceText(value: String) {
     replaceText = value.toSingleLineText()
   }
+
+  fun canReplaceActive(): Boolean =
+    findText.isNotEmpty() &&
+      !replaceText.containsLineBreak() &&
+      activeIndex?.let(matches::getOrNull) != null
+
+  fun canReplaceAll(): Boolean =
+    findText.isNotEmpty() && !replaceText.containsLineBreak() && matches.isNotEmpty()
 
   suspend fun runSearch(
     editor: Editor?,
@@ -259,24 +277,24 @@ private class FindReplaceSessionController {
 
   suspend fun replaceActive(
     editor: Editor?,
-    documentLocked: Boolean,
-    onLocked: () -> Unit,
+    admitMutation: () -> Boolean,
     bringIntoViewRequests: EditorBringIntoViewRequests,
   ) = stateLock.withLock {
     val activeEditor = editor ?: return@withLock
     if (findText.isEmpty() || replaceText.containsLineBreak()) return@withLock
-    if (documentLocked) {
-      onLocked()
-      return@withLock
-    }
     val replaceIndex = activeIndex ?: return@withLock
     val match = matches.getOrNull(replaceIndex) ?: return@withLock
 
-    activeEditor.replaceFindReplaceRangeText(
-      id = match.id,
-      expectedText = findText,
-      replacement = replaceText,
-    )
+    if (
+      !activeEditor.replaceFindReplaceRangeText(
+        id = match.id,
+        expectedText = findText,
+        replacement = replaceText,
+        admit = admitMutation,
+      )
+    ) {
+      return@withLock
+    }
     matches = matches.filterIndexed { index, _ -> index != replaceIndex }
     activeIndex =
       when {
@@ -293,22 +311,22 @@ private class FindReplaceSessionController {
 
   suspend fun replaceAllMatches(
     editor: Editor?,
-    documentLocked: Boolean,
-    onLocked: () -> Unit,
+    admitMutation: () -> Boolean,
     bringIntoViewRequests: EditorBringIntoViewRequests,
   ) = stateLock.withLock {
     val activeEditor = editor ?: return@withLock
     if (findText.isEmpty() || replaceText.containsLineBreak() || matches.isEmpty()) return@withLock
-    if (documentLocked) {
-      onLocked()
+
+    if (
+      !activeEditor.replaceAllFindReplaceRanges(
+        matches = matches,
+        expectedText = findText,
+        replacement = replaceText,
+        admit = admitMutation,
+      )
+    ) {
       return@withLock
     }
-
-    activeEditor.replaceAllFindReplaceRanges(
-      matches = matches,
-      expectedText = findText,
-      replacement = replaceText,
-    )
     matches = emptyList()
     activeIndex = null
     runSearchLocked(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceEditorRanges.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceEditorRanges.kt
@@ -115,8 +115,9 @@ internal suspend fun Editor.replaceFindReplaceRangeText(
   id: String,
   expectedText: String,
   replacement: String,
-) {
-  await {
+  admit: () -> Boolean = { true },
+): Boolean =
+  await(admit = admit) {
     enqueue(
       Message.TrackedRange(
         TrackedRangeOp.ReplaceText(id = id, expectedText = expectedText, replacement = replacement)
@@ -124,14 +125,14 @@ internal suspend fun Editor.replaceFindReplaceRangeText(
     )
     enqueue(Message.TrackedRange(TrackedRangeOp.Remove(id = id)))
   }
-}
 
 internal suspend fun Editor.replaceAllFindReplaceRanges(
   matches: List<FindReplaceMatch>,
   expectedText: String,
   replacement: String,
-) {
-  await {
+  admit: () -> Boolean = { true },
+): Boolean =
+  await(admit = admit) {
     matches.forEach { match ->
       enqueue(
         Message.TrackedRange(
@@ -148,7 +149,6 @@ internal suspend fun Editor.replaceAllFindReplaceRanges(
       Message.TrackedRange(TrackedRangeOp.ClearGroup(group = ACTIVE_SEARCH_MATCH_RANGE_GROUP))
     )
   }
-}
 
 internal fun List<TrackedRange>.searchMatchScrollTarget(id: String?): EditorBringIntoViewTarget? {
   if (id == null) return null

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/header/EditorHeader.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/header/EditorHeader.kt
@@ -13,11 +13,15 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.key.Key
@@ -28,6 +32,13 @@ import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.LocalViewConfiguration
+import androidx.compose.ui.semantics.CustomAccessibilityAction
+import androidx.compose.ui.semantics.customActions
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
@@ -158,6 +169,10 @@ internal fun EditorHeader(
   subtitle: String,
   loading: Boolean,
   enabled: Boolean = true,
+  editing: Boolean = true,
+  doubleTapToEditEnabled: Boolean = true,
+  readingTapIdentity: Any? = Unit,
+  readingModeCleanupRequest: Int = 0,
   showBottomDivider: Boolean = true,
   topInset: Dp,
   subtitleFocusRequestVersion: Int = 0,
@@ -168,26 +183,35 @@ internal fun EditorHeader(
   onSubtitleFocused: () -> Unit,
   onHeightChanged: (Float) -> Unit,
   onEnterDocument: () -> Unit,
+  onRequestEditing: () -> Boolean = { false },
+  onReadingEditHint: () -> Unit = {},
 ) {
   val density = LocalDensity.current
   val showSkeleton = LocalSkeleton.current.enabled || loading
+  val inputEnabled = enabled && editing
   val titleInputState =
     rememberTextInputState(
       value = title,
       onValueChange = onTitleChange,
-      enabled = enabled,
+      enabled = inputEnabled,
       onDismiss = onEnterDocument,
     )
   val subtitleInputState =
     rememberTextInputState(
       value = subtitle,
       onValueChange = onSubtitleChange,
-      enabled = enabled,
+      enabled = inputEnabled,
       onDismiss = onEnterDocument,
     )
-  LaunchedEffect(subtitleFocusRequestVersion, enabled) {
-    if (enabled && subtitleFocusRequestVersion > 0) {
+  LaunchedEffect(subtitleFocusRequestVersion, inputEnabled) {
+    if (inputEnabled && subtitleFocusRequestVersion > 0) {
       subtitleInputState.requestFocus()
+    }
+  }
+  LaunchedEffect(editing, readingModeCleanupRequest) {
+    if (!editing) {
+      titleInputState.finishCompositionAndCollapseSelection()
+      subtitleInputState.finishCompositionAndCollapseSelection()
     }
   }
   val resolveHeight: (Int) -> Float = remember(density) { { height -> height / density.density } }
@@ -202,7 +226,13 @@ internal fun EditorHeader(
 
       EditorHeaderField(
         text = titleInputState.value,
-        onValueChange = { titleInputState.onValueChange(sanitizeTitleFieldValue(it)) },
+        onValueChange = {
+          if (editing) {
+            titleInputState.onValueChange(sanitizeTitleFieldValue(it))
+          } else {
+            titleInputState.updateSelection(it.selection)
+          }
+        },
         placeholder = "제목",
         style =
           AppTheme.typography.title.copy(
@@ -218,6 +248,10 @@ internal fun EditorHeader(
           ),
         showSkeleton = showSkeleton,
         enabled = enabled,
+        editing = editing,
+        doubleTapToEditEnabled = doubleTapToEditEnabled,
+        readingTapIdentity = readingTapIdentity,
+        readingModeCleanupRequest = readingModeCleanupRequest,
         imeAction = ImeAction.Next,
         onFocusNext = { subtitleInputState.requestFocus() },
         onEnterDocument = { subtitleInputState.requestFocus() },
@@ -225,13 +259,21 @@ internal fun EditorHeader(
         onFocused = onTitleFocused,
         modifier = Modifier.fillMaxWidth(),
         textInputState = titleInputState,
+        onRequestEditing = onRequestEditing,
+        onReadingEditHint = onReadingEditHint,
       )
 
       Spacer(Modifier.height(TitleBetweenSpacing))
 
       EditorHeaderField(
         text = subtitleInputState.value,
-        onValueChange = { subtitleInputState.onValueChange(sanitizeSubtitleFieldValue(it)) },
+        onValueChange = {
+          if (editing) {
+            subtitleInputState.onValueChange(sanitizeSubtitleFieldValue(it))
+          } else {
+            subtitleInputState.updateSelection(it.selection)
+          }
+        },
         placeholder = "부제목",
         style =
           AppTheme.typography.body.copy(
@@ -247,6 +289,10 @@ internal fun EditorHeader(
           ),
         showSkeleton = showSkeleton,
         enabled = enabled,
+        editing = editing,
+        doubleTapToEditEnabled = doubleTapToEditEnabled,
+        readingTapIdentity = readingTapIdentity,
+        readingModeCleanupRequest = readingModeCleanupRequest,
         imeAction = ImeAction.Done,
         onFocusNext = onEnterDocument,
         onEnterDocument = onEnterDocument,
@@ -259,6 +305,8 @@ internal fun EditorHeader(
         onFocused = onSubtitleFocused,
         modifier = Modifier.fillMaxWidth(),
         textInputState = subtitleInputState,
+        onRequestEditing = onRequestEditing,
+        onReadingEditHint = onReadingEditHint,
       )
 
       Spacer(Modifier.height(TitleBlockSpacing))
@@ -281,6 +329,10 @@ private fun EditorHeaderField(
   placeholderStyle: TextStyle,
   showSkeleton: Boolean,
   enabled: Boolean,
+  editing: Boolean,
+  doubleTapToEditEnabled: Boolean,
+  readingTapIdentity: Any?,
+  readingModeCleanupRequest: Int,
   imeAction: ImeAction,
   onFocusNext: () -> Unit,
   onEnterDocument: () -> Unit,
@@ -289,32 +341,115 @@ private fun EditorHeaderField(
   onFocused: () -> Unit,
   modifier: Modifier = Modifier,
   textInputState: TextInputState,
+  onRequestEditing: () -> Boolean,
+  onReadingEditHint: () -> Unit,
 ) {
   val verticalExitScope = rememberCoroutineScope()
-  val currentEnabled by rememberUpdatedState(enabled)
+  val keyboardController = LocalSoftwareKeyboardController.current
+  val density = LocalDensity.current
+  val viewConfiguration = LocalViewConfiguration.current
+  val inputEnabled = enabled && editing
+  val currentInputEnabled by rememberUpdatedState(inputEnabled)
+  val currentReadingTapEnabled by rememberUpdatedState(enabled && !editing)
+  val currentOnRequestEditing by rememberUpdatedState(onRequestEditing)
+  val currentOnReadingEditHint by rememberUpdatedState(onReadingEditHint)
+  var latestTextLayout by remember { mutableStateOf<TextLayoutResult?>(null) }
+  var pendingActivationOffset by remember { mutableStateOf<Int?>(null) }
+  val readingTapTracker =
+    remember(
+      viewConfiguration.touchSlop,
+      density.density,
+      doubleTapToEditEnabled,
+      readingTapIdentity,
+    ) {
+      EditorHeaderReadingTapTracker(
+        touchSlopPx = viewConfiguration.touchSlop,
+        maxTapDistancePx = with(density) { 20.dp.toPx() },
+        doubleTapToEditEnabled = doubleTapToEditEnabled,
+      )
+    }
   val verticalNavigation =
     remember(verticalExitScope, textInputState) {
       HeaderVerticalNavigationState(
         scope = verticalExitScope,
         currentValue = { textInputState.value },
-        currentEnabled = { currentEnabled },
+        currentEnabled = { currentInputEnabled },
       )
     }
+  LaunchedEffect(inputEnabled, pendingActivationOffset) {
+    val offset = pendingActivationOffset ?: return@LaunchedEffect
+    if (!inputEnabled) return@LaunchedEffect
+    withFrameNanos {}
+    textInputState.updateSelection(TextRange(offset.coerceIn(0, textInputState.value.text.length)))
+    textInputState.requestFocus()
+    keyboardController?.show()
+    pendingActivationOffset = null
+  }
+  LaunchedEffect(readingTapIdentity) {
+    pendingActivationOffset = null
+    readingTapTracker.onModeChanged()
+  }
+  LaunchedEffect(editing, readingModeCleanupRequest) {
+    if (!editing) {
+      pendingActivationOffset = null
+      readingTapTracker.onModeChanged()
+    }
+  }
 
   BasicTextField(
     value = text,
     onValueChange = onValueChange,
     enabled = enabled,
+    readOnly = !editing,
     modifier =
       modifier
-        .textInputFocusable(textInputState, enabled = enabled) {
+        .textInputFocusable(textInputState, enabled = inputEnabled) {
           verticalNavigation.onFocusChanged(it.isFocused)
-          if (it.isFocused) {
+          if (inputEnabled && it.isFocused) {
             onFocused()
           }
         }
         .invalidateHeaderVerticalNavigationOnPointerDown(verticalNavigation)
+        .then(
+          if (enabled && !editing) {
+            Modifier.semantics {
+              customActions =
+                listOf(
+                  CustomAccessibilityAction(label = "편집") {
+                    val offset = textInputState.value.selection.start
+                    if (currentOnRequestEditing()) {
+                      pendingActivationOffset = offset
+                      true
+                    } else {
+                      false
+                    }
+                  }
+                )
+            }
+          } else {
+            Modifier
+          }
+        )
+        .observeEditorHeaderReadingTaps(
+          enabled = { currentReadingTapEnabled },
+          tracker = readingTapTracker,
+          currentSelectionIsExpanded = { !textInputState.value.selection.collapsed },
+          offsetForPosition = { position ->
+            (latestTextLayout?.getOffsetForPosition(position)
+                ?: textInputState.value.selection.start)
+              .coerceIn(0, textInputState.value.text.length)
+          },
+          onActivate = { offset ->
+            if (currentOnRequestEditing()) {
+              pendingActivationOffset = offset
+            }
+          },
+          onShowHint = { currentOnReadingEditHint() },
+        )
         .onPreviewKeyEvent {
+          if (!currentInputEnabled) {
+            return@onPreviewKeyEvent false
+          }
           if (it.type != KeyEventType.KeyDown) {
             return@onPreviewKeyEvent false
           }
@@ -355,10 +490,18 @@ private fun EditorHeaderField(
           }
         },
     textStyle = style.copy(color = AppTheme.colors.textDefault),
-    cursorBrush = SolidColor(AppTheme.colors.textDefault),
+    cursorBrush =
+      if (editing) {
+        SolidColor(AppTheme.colors.textDefault)
+      } else {
+        SolidColor(Color.Transparent)
+      },
     keyboardOptions = KeyboardOptions(imeAction = imeAction),
     keyboardActions = KeyboardActions(onNext = { onFocusNext() }, onDone = { onEnterDocument() }),
-    onTextLayout = verticalNavigation::onTextLayout,
+    onTextLayout = {
+      latestTextLayout = it
+      verticalNavigation.onTextLayout(it)
+    },
     minLines = 1,
     maxLines = Int.MAX_VALUE,
     decorationBox = { innerTextField ->

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/header/EditorHeaderReadingTapGesture.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/header/EditorHeaderReadingTapGesture.kt
@@ -1,0 +1,224 @@
+package co.typie.screen.editor.editor.header
+
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
+import co.typie.editor.interaction.gestures.EditorConsecutiveTapMaxIntervalMillis
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+internal sealed interface EditorHeaderReadingTapResult {
+  data object None : EditorHeaderReadingTapResult
+
+  data object ShowHint : EditorHeaderReadingTapResult
+
+  data class Activate(val offset: Int) : EditorHeaderReadingTapResult
+}
+
+internal class EditorHeaderReadingTapTracker(
+  private val touchSlopPx: Float,
+  private val maxTapDistancePx: Float,
+  private val doubleTapToEditEnabled: Boolean,
+  private val consecutiveTapMaxIntervalMillis: Long = EditorConsecutiveTapMaxIntervalMillis,
+) {
+  private data class ActiveTap(val position: Offset, val suppressHint: Boolean)
+
+  private data class PendingTap(
+    val position: Offset,
+    val confirmationAtMillis: Long,
+    val suppressHint: Boolean,
+  )
+
+  private var activeTap: ActiveTap? = null
+  private var pendingTap: PendingTap? = null
+
+  val pendingConfirmationAtMillis: Long?
+    get() = pendingTap?.confirmationAtMillis
+
+  fun onDown(
+    position: Offset,
+    offset: Int,
+    timeMillis: Long,
+    suppressHint: Boolean = false,
+  ): EditorHeaderReadingTapResult {
+    val pending = pendingTap
+    pendingTap = null
+    if (
+      doubleTapToEditEnabled &&
+        pending != null &&
+        timeMillis <= pending.confirmationAtMillis &&
+        (position - pending.position).getDistance() <= maxTapDistancePx
+    ) {
+      activeTap = null
+      return EditorHeaderReadingTapResult.Activate(offset)
+    }
+
+    activeTap = ActiveTap(position = position, suppressHint = suppressHint)
+    return EditorHeaderReadingTapResult.None
+  }
+
+  fun onMove(position: Offset) {
+    val active = activeTap ?: return
+    if ((position - active.position).getDistance() > touchSlopPx) {
+      cancel()
+    }
+  }
+
+  fun onUp(
+    position: Offset,
+    offset: Int,
+    timeMillis: Long,
+    suppressHint: Boolean = false,
+  ): EditorHeaderReadingTapResult {
+    val active = activeTap ?: return EditorHeaderReadingTapResult.None
+    activeTap = null
+    if (!doubleTapToEditEnabled) {
+      pendingTap = null
+      return EditorHeaderReadingTapResult.Activate(offset)
+    }
+
+    pendingTap =
+      PendingTap(
+        position = position,
+        confirmationAtMillis = timeMillis + consecutiveTapMaxIntervalMillis,
+        suppressHint = active.suppressHint || suppressHint,
+      )
+    return EditorHeaderReadingTapResult.None
+  }
+
+  fun confirm(timeMillis: Long): EditorHeaderReadingTapResult {
+    val pending = pendingTap ?: return EditorHeaderReadingTapResult.None
+    if (timeMillis < pending.confirmationAtMillis) {
+      return EditorHeaderReadingTapResult.None
+    }
+
+    pendingTap = null
+    return if (pending.suppressHint) {
+      EditorHeaderReadingTapResult.None
+    } else {
+      EditorHeaderReadingTapResult.ShowHint
+    }
+  }
+
+  fun onLongPress() {
+    cancel()
+  }
+
+  fun onModeChanged() {
+    cancel()
+  }
+
+  fun cancel() {
+    activeTap = null
+    pendingTap = null
+  }
+}
+
+internal fun Modifier.observeEditorHeaderReadingTaps(
+  enabled: () -> Boolean,
+  tracker: EditorHeaderReadingTapTracker,
+  currentSelectionIsExpanded: () -> Boolean,
+  offsetForPosition: (Offset) -> Int,
+  onActivate: (Int) -> Unit,
+  onShowHint: () -> Unit,
+): Modifier {
+  return pointerInput(tracker) {
+    coroutineScope {
+      var confirmationJob: Job? = null
+      try {
+        awaitEachGesture {
+          val down = awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
+          if (!enabled()) {
+            tracker.cancel()
+            return@awaitEachGesture
+          }
+          confirmationJob?.cancel()
+          confirmationJob = null
+          val downOffset = offsetForPosition(down.position)
+          var activationOwnsPointer = false
+          when (
+            val result =
+              tracker.onDown(
+                position = down.position,
+                offset = downOffset,
+                timeMillis = down.uptimeMillis,
+                suppressHint = currentSelectionIsExpanded(),
+              )
+          ) {
+            is EditorHeaderReadingTapResult.Activate -> {
+              down.consume()
+              onActivate(result.offset)
+              activationOwnsPointer = true
+            }
+            EditorHeaderReadingTapResult.None -> Unit
+            EditorHeaderReadingTapResult.ShowHint -> error("A pointer down cannot confirm a hint")
+          }
+
+          while (true) {
+            val event = awaitPointerEvent(pass = PointerEventPass.Initial)
+            val change = event.changes.find { it.id == down.id }
+            if (change == null) {
+              tracker.cancel()
+              return@awaitEachGesture
+            }
+            if (activationOwnsPointer) {
+              change.consume()
+              if (!change.pressed) {
+                return@awaitEachGesture
+              }
+              continue
+            }
+            if (event.changes.count { it.pressed } > 1) {
+              tracker.cancel()
+              return@awaitEachGesture
+            }
+            if (change.pressed) {
+              tracker.onMove(change.position)
+              continue
+            }
+
+            val elapsedMillis = change.uptimeMillis - down.uptimeMillis
+            if (elapsedMillis >= viewConfiguration.longPressTimeoutMillis) {
+              tracker.onLongPress()
+              return@awaitEachGesture
+            }
+
+            when (
+              val result =
+                tracker.onUp(
+                  position = change.position,
+                  offset = offsetForPosition(change.position),
+                  timeMillis = change.uptimeMillis,
+                )
+            ) {
+              is EditorHeaderReadingTapResult.Activate -> onActivate(result.offset)
+              EditorHeaderReadingTapResult.None -> {
+                val confirmationAtMillis = tracker.pendingConfirmationAtMillis
+                if (confirmationAtMillis != null) {
+                  confirmationJob = launch {
+                    delay((confirmationAtMillis - change.uptimeMillis).coerceAtLeast(0))
+                    if (
+                      tracker.confirm(confirmationAtMillis) == EditorHeaderReadingTapResult.ShowHint
+                    ) {
+                      onShowHint()
+                    }
+                  }
+                }
+              }
+              EditorHeaderReadingTapResult.ShowHint -> onShowHint()
+            }
+            return@awaitEachGesture
+          }
+        }
+      } finally {
+        confirmationJob?.cancel()
+        tracker.cancel()
+      }
+    }
+  }
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayout.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayout.kt
@@ -41,6 +41,9 @@ import androidx.compose.ui.node.PointerInputModifierNode
 import androidx.compose.ui.node.currentValueOf
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalViewConfiguration
+import androidx.compose.ui.semantics.CustomAccessibilityAction
+import androidx.compose.ui.semantics.customActions
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
@@ -184,6 +187,7 @@ internal fun EditorScreenLayout(
   viewportScrollReconcileMode: EditorViewportScrollReconcileMode,
   onEditorPointerInput: () -> Unit = {},
   onViewportIndirectInput: () -> Unit = {},
+  onRequestEditing: (() -> Boolean)? = null,
   onMeasuredViewportSizeChange: (Size) -> Unit,
   header: @Composable () -> Unit,
   body: @Composable () -> Unit,
@@ -271,6 +275,14 @@ internal fun EditorScreenLayout(
         enabled = platformIndirectScaleEnabled,
         density = density.density,
       )
+  val readingEditSemanticsModifier =
+    if (onRequestEditing == null) {
+      Modifier
+    } else {
+      Modifier.semantics {
+        customActions = listOf(CustomAccessibilityAction(label = "편집") { onRequestEditing() })
+      }
+    }
 
   Box(
     modifier =
@@ -316,6 +328,7 @@ internal fun EditorScreenLayout(
                     EditorViewportNestedScrollConnection,
                     viewportNestedScrollDispatcher,
                   )
+                  .then(readingEditSemanticsModifier)
                   .then(editorInteractionModifier),
               content = {
                 Column {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorContextMenuOverlay.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorContextMenuOverlay.kt
@@ -66,7 +66,7 @@ internal fun EditorSelectionContextMenuOverlay(
   overlaySize: Size,
   visibleArea: EditorVisibleArea,
   showCopyCutActions: Boolean,
-  editorReadOnly: Boolean = false,
+  editorMutationEnabled: Boolean = true,
   availableExpansionUnits: Set<SelectionExpansionUnit>,
   onCopy: () -> Unit,
   onCut: () -> Unit,
@@ -154,11 +154,11 @@ internal fun EditorSelectionContextMenuOverlay(
             EditorContextMenuPage.Primary -> {
               if (showCopyCutActions) {
                 EditorContextMenuItem(label = "복사", onClick = onCopy.withDismiss(onDismiss))
-                if (!editorReadOnly) {
+                if (editorMutationEnabled) {
                   EditorContextMenuItem(label = "잘라내기", onClick = onCut.withDismiss(onDismiss))
                 }
               }
-              if (!editorReadOnly) {
+              if (editorMutationEnabled) {
                 EditorContextMenuItem(label = "붙여넣기", onClick = onPaste.withDismiss(onDismiss))
               }
               if (availableExpansionUnits.isNotEmpty()) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorScreenOverlayHost.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorScreenOverlayHost.kt
@@ -37,7 +37,7 @@ internal fun EditorScreenOverlayHost(
   visibleArea: EditorVisibleArea,
   autoScrollPolicy: EditorAutoScrollPolicy,
   onTableAxisActionsRequest: (EditorTableAxisActionsTarget, Selection?) -> Unit,
-  editorReadOnly: Boolean = false,
+  editorMutationEnabled: Boolean = true,
   showDebugOverlay: Boolean = false,
   modifier: Modifier = Modifier,
 ) {
@@ -89,13 +89,15 @@ internal fun EditorScreenOverlayHost(
     if (overlayBounds != null) {
       val editor = runtime.editor
       if (editor != null) {
-        EditorTableAxisSelectionOverlay(
-          editor = editor,
-          uiState = uiState,
-          editorRectInOverlay = editorRectInViewport,
-          density = density.density,
-          onTableAxisActionsRequest = onTableAxisActionsRequest,
-        )
+        if (editorMutationEnabled) {
+          EditorTableAxisSelectionOverlay(
+            editor = editor,
+            uiState = uiState,
+            editorRectInOverlay = editorRectInViewport,
+            density = density.density,
+            onTableAxisActionsRequest = onTableAxisActionsRequest,
+          )
+        }
 
         if (editorRectInOverlay != null && contextMenu.isVisibleFor(editor.state)) {
           val anchor =
@@ -121,7 +123,7 @@ internal fun EditorScreenOverlayHost(
                 overlaySize = overlayBounds.size,
                 visibleArea = visibleArea,
                 showCopyCutActions = actions.showCopyCutActions,
-                editorReadOnly = editorReadOnly,
+                editorMutationEnabled = editorMutationEnabled,
                 availableExpansionUnits = actions.availableExpansionUnits,
                 onCopy = actions.onCopy,
                 onCut = actions.onCut,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorSelectionHandleOverlay.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorSelectionHandleOverlay.kt
@@ -23,7 +23,7 @@ import co.typie.ui.theme.AppTheme
 
 @Composable
 internal fun EditorSelectionHandleOverlay(editor: Editor, uiState: EditorUiState, density: Float) {
-  if (!uiState.focused || editor.selection.isCollapsed() || hasActiveTableCellSelection(editor)) {
+  if (editor.selection.isCollapsed() || hasActiveTableCellSelection(editor)) {
     return
   }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorTableCellSelectionOverlay.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorTableCellSelectionOverlay.kt
@@ -23,10 +23,6 @@ internal fun EditorTableCellSelectionOverlay(
   uiState: EditorUiState,
   density: Float,
 ) {
-  if (!uiState.focused) {
-    return
-  }
-
   if (resolveTableCellSelections(editor).isEmpty()) {
     return
   }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/spellcheck/EditorSpellcheckSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/spellcheck/EditorSpellcheckSession.kt
@@ -61,6 +61,8 @@ internal fun rememberEditorSpellcheckSession(
   hideContextMenu: () -> Unit,
   closeSubPane: () -> Unit,
   ensureSubscription: suspend () -> Boolean,
+  onEditingIntent: (Editor) -> Boolean,
+  admitMutation: (DocumentEditingSession) -> Boolean,
 ): EditorSpellcheckSession {
   val scope = rememberCoroutineScope()
   val toast = LocalToast.current
@@ -348,25 +350,34 @@ internal fun rememberEditorSpellcheckSession(
           return@applySuggestion
         }
 
-        activeSession.submit { activeEditor, context ->
-          activeEditor.scope.launch(context) {
-            activeEditor.replaceSpellcheckRangeText(
-              id = id,
-              expectedText = result.context,
-              replacement = replacement,
-            )
-            programmaticSelectionToSkip = activeEditor.state.selection
-            val nextId = model.remove(id, activateReplacement = true)
-            if (nextId != null) {
-              updateCompactOverlayHeightForRange(nextId)
+        scope.launch {
+          if (activeSession.editor.trackedRange(id) == null) return@launch
+          if (!onEditingIntent(activeSession.editor)) return@launch
+          activeSession.submit { activeEditor, context ->
+            activeEditor.scope.launch(context) {
+              val replaced =
+                activeEditor.replaceSpellcheckRangeText(
+                  id = id,
+                  expectedText = result.context,
+                  replacement = replacement,
+                  admit = { admitMutation(activeSession) },
+                )
+              if (replaced) {
+                programmaticSelectionToSkip = activeEditor.state.selection
+                val nextId = model.remove(id, activateReplacement = true)
+                if (nextId != null) {
+                  updateCompactOverlayHeightForRange(nextId)
+                }
+                updateActiveRangeDecoration()
+                requestRangeIntoView(nextId)
+              }
             }
-            updateActiveRangeDecoration()
-            requestRangeIntoView(nextId)
           }
         }
       },
     directEdit = directEdit@{ id ->
-        val activeEditor = editor ?: return@directEdit
+        val activeSession = editingSession ?: return@directEdit
+        val activeEditor = activeSession.editor
         scope.launch {
           val range = activeEditor.trackedRange(id) ?: return@launch
           if (documentLocked) {
@@ -374,19 +385,27 @@ internal fun rememberEditorSpellcheckSession(
             return@launch
           }
 
+          if (!onEditingIntent(activeEditor)) return@launch
+          val selected =
+            activeEditor.awaitWithBringIntoView(
+              bringIntoViewRequests = bringIntoViewRequests,
+              admit = { admitMutation(activeSession) },
+            ) {
+              enqueue(
+                Message.Selection(
+                  SelectionOp.Set(Selection(anchor = range.anchor, head = range.head))
+                )
+              )
+              beforeCommit { bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead) }
+            }
+          if (selected == null) return@launch
           model?.activate(null)
           updateCompactOverlayHeightForRange(null)
           model?.updateExpanded(false)
           updateActiveRangeDecoration()
-          activeEditor.awaitWithBringIntoView(bringIntoViewRequests) {
-            enqueue(
-              Message.Selection(
-                SelectionOp.Set(Selection(anchor = range.anchor, head = range.head))
-              )
-            )
-            beforeCommit { bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead) }
+          if (admitMutation(activeSession)) {
+            activeEditor.focus()
           }
-          activeEditor.focus()
         }
       },
     ignore = ignore@{ id ->

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/spellcheck/SpellcheckEditorRanges.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/spellcheck/SpellcheckEditorRanges.kt
@@ -131,8 +131,9 @@ internal suspend fun Editor.replaceSpellcheckRangeText(
   id: String,
   expectedText: String,
   replacement: String,
-) {
-  await {
+  admit: () -> Boolean = { true },
+): Boolean =
+  await(admit = admit) {
     enqueue(
       Message.TrackedRange(
         TrackedRangeOp.ReplaceText(id = id, expectedText = expectedText, replacement = replacement)
@@ -140,7 +141,6 @@ internal suspend fun Editor.replaceSpellcheckRangeText(
     )
     enqueue(Message.TrackedRange(TrackedRangeOp.Remove(id = id)))
   }
-}
 
 internal val TrackedRangeEndpoints.isSpellcheckRange: Boolean
   get() = group == SPELLCHECK_RANGE_GROUP || group == ACTIVE_SPELLCHECK_RANGE_GROUP

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/state/EditorInputEffect.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/state/EditorInputEffect.kt
@@ -5,4 +5,5 @@ internal enum class EditorInputEffect {
   HideKeyboard,
   RequestFocus,
   ClearFocus,
+  EnterReadingMode,
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorToolbarToolAction.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorToolbarToolAction.kt
@@ -1,5 +1,8 @@
 package co.typie.screen.editor.editor.toolbar
 
+import co.typie.icons.Lucide
+import co.typie.ui.icon.IconData
+
 internal enum class EditorToolbarToolAction {
   Search,
   RelatedNotes,
@@ -19,3 +22,82 @@ internal data class EditorToolbarDebugOverlays(
   val surfaceVisible: Boolean,
   val inputLogAvailable: Boolean,
 )
+
+internal data class EditorToolbarToolItem(
+  val icon: IconData,
+  val label: String,
+  val action: EditorToolbarToolAction,
+  val key: String = label,
+)
+
+internal val EditorToolbarToolItems =
+  listOf(
+    EditorToolbarToolItem(
+      icon = Lucide.StickyNote,
+      label = "노트",
+      action = EditorToolbarToolAction.RelatedNotes,
+    ),
+    EditorToolbarToolItem(
+      icon = Lucide.MessageSquareText,
+      label = "코멘트",
+      action = EditorToolbarToolAction.Comment,
+    ),
+    EditorToolbarToolItem(
+      icon = Lucide.SpellCheck,
+      label = "맞춤법 검사",
+      action = EditorToolbarToolAction.Spellcheck,
+    ),
+    EditorToolbarToolItem(
+      icon = Lucide.Lightbulb,
+      label = "AI 피드백",
+      action = EditorToolbarToolAction.AiFeedback,
+    ),
+    EditorToolbarToolItem(
+      icon = Lucide.History,
+      label = "타임라인",
+      action = EditorToolbarToolAction.Timeline,
+    ),
+  )
+
+internal fun editorToolbarDebugToolItems(
+  debugOverlays: EditorToolbarDebugOverlays
+): List<EditorToolbarToolItem> {
+  return buildList {
+    add(
+      EditorToolbarToolItem(
+        icon = Lucide.PanelTop,
+        label = debugOverlays.viewportVisible.debugToggleLabel("뷰포트 기준선"),
+        action = EditorToolbarToolAction.DebugViewportOverlay,
+        key = "debug-viewport-overlay",
+      )
+    )
+    add(
+      EditorToolbarToolItem(
+        icon = Lucide.PanelBottom,
+        label = debugOverlays.bodyVisible.debugToggleLabel("바디 영역"),
+        action = EditorToolbarToolAction.DebugBodyOverlay,
+        key = "debug-body-overlay",
+      )
+    )
+    add(
+      EditorToolbarToolItem(
+        icon = Lucide.InspectionPanel,
+        label = debugOverlays.surfaceVisible.debugToggleLabel("페이지 표면"),
+        action = EditorToolbarToolAction.DebugSurfaceOverlay,
+        key = "debug-surface-overlay",
+      )
+    )
+    if (debugOverlays.inputLogAvailable) {
+      add(
+        EditorToolbarToolItem(
+          icon = Lucide.Send,
+          label = "입력 로그 보내기",
+          action = EditorToolbarToolAction.SendInputLog,
+          key = "debug-send-input-log",
+        )
+      )
+    }
+  }
+}
+
+private fun Boolean.debugToggleLabel(label: String): String = "$label ${if (this) "끄기" else "켜기"}"

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarInputState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarInputState.kt
@@ -198,7 +198,7 @@ internal class EditorToolbarInputState {
       keyboardRestoreInset = null
       rememberedKeyboardInset = 0.dp
       previousIme = currentIme
-      return listOf(EditorInputEffect.ClearFocus)
+      return listOf(EditorInputEffect.EnterReadingMode)
     }
 
     var currentPanel = panel
@@ -373,6 +373,9 @@ internal class EditorToolbarInputState {
     }
     if (environment.focused) {
       effects += EditorInputEffect.ClearFocus
+    }
+    if (fixedAction == ToolbarFixedAction.DismissInput) {
+      effects += EditorInputEffect.EnterReadingMode
     }
     return effects
   }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/bottom/Tools.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/bottom/Tools.kt
@@ -31,14 +31,15 @@ import androidx.compose.ui.unit.dp
 import co.typie.ext.InteractionScope
 import co.typie.ext.LocalInteractionSource
 import co.typie.ext.pressScale
-import co.typie.icons.Lucide
 import co.typie.screen.editor.editor.toolbar.EditorToolbarDebugOverlays
 import co.typie.screen.editor.editor.toolbar.EditorToolbarToolAction
+import co.typie.screen.editor.editor.toolbar.EditorToolbarToolItem
+import co.typie.screen.editor.editor.toolbar.EditorToolbarToolItems
 import co.typie.screen.editor.editor.toolbar.ToolbarBottomPanelRadius
+import co.typie.screen.editor.editor.toolbar.editorToolbarDebugToolItems
 import co.typie.ui.component.Text
 import co.typie.ui.component.scrollFog
 import co.typie.ui.icon.Icon
-import co.typie.ui.icon.IconData
 import co.typie.ui.theme.AppShapes
 import co.typie.ui.theme.AppTheme
 
@@ -60,7 +61,7 @@ internal fun BottomToolbarTools(
     horizontalArrangement = Arrangement.spacedBy(6.dp),
     verticalArrangement = Arrangement.spacedBy(8.dp),
   ) {
-    items(ToolItems, key = { it.key }) { item ->
+    items(EditorToolbarToolItems, key = { it.key }) { item ->
       ToolTile(item = item, modifier = Modifier.fillMaxWidth(), onClick = { onAction(item.action) })
     }
 
@@ -73,7 +74,7 @@ internal fun BottomToolbarTools(
           modifier = Modifier.padding(start = 2.dp, top = 8.dp),
         )
       }
-      items(debugToolItems(debugOverlays), key = { it.key }) { item ->
+      items(editorToolbarDebugToolItems(debugOverlays), key = { it.key }) { item ->
         ToolTile(
           item = item,
           modifier = Modifier.fillMaxWidth(),
@@ -84,49 +85,12 @@ internal fun BottomToolbarTools(
   }
 }
 
-private fun debugToolItems(debugOverlays: EditorToolbarDebugOverlays): List<ToolItem> {
-  return buildList {
-    add(
-      ToolItem(
-        icon = Lucide.PanelTop,
-        label = debugOverlays.viewportVisible.debugToggleLabel("뷰포트 기준선"),
-        action = EditorToolbarToolAction.DebugViewportOverlay,
-        key = "debug-viewport-overlay",
-      )
-    )
-    add(
-      ToolItem(
-        icon = Lucide.PanelBottom,
-        label = debugOverlays.bodyVisible.debugToggleLabel("바디 영역"),
-        action = EditorToolbarToolAction.DebugBodyOverlay,
-        key = "debug-body-overlay",
-      )
-    )
-    add(
-      ToolItem(
-        icon = Lucide.InspectionPanel,
-        label = debugOverlays.surfaceVisible.debugToggleLabel("페이지 표면"),
-        action = EditorToolbarToolAction.DebugSurfaceOverlay,
-        key = "debug-surface-overlay",
-      )
-    )
-    if (debugOverlays.inputLogAvailable) {
-      add(
-        ToolItem(
-          icon = Lucide.Send,
-          label = "입력 로그 보내기",
-          action = EditorToolbarToolAction.SendInputLog,
-          key = "debug-send-input-log",
-        )
-      )
-    }
-  }
-}
-
-private fun Boolean.debugToggleLabel(label: String): String = "$label ${if (this) "끄기" else "켜기"}"
-
 @Composable
-private fun ToolTile(item: ToolItem, onClick: () -> Unit, modifier: Modifier = Modifier) {
+private fun ToolTile(
+  item: EditorToolbarToolItem,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
   val shape = ToolTileShape
 
   InteractionScope {
@@ -174,34 +138,6 @@ private fun ToolTile(item: ToolItem, onClick: () -> Unit, modifier: Modifier = M
     }
   }
 }
-
-private data class ToolItem(
-  val icon: IconData,
-  val label: String,
-  val action: EditorToolbarToolAction,
-  val key: String = label,
-)
-
-private val ToolItems =
-  listOf(
-    ToolItem(icon = Lucide.StickyNote, label = "노트", action = EditorToolbarToolAction.RelatedNotes),
-    ToolItem(
-      icon = Lucide.MessageSquareText,
-      label = "코멘트",
-      action = EditorToolbarToolAction.Comment,
-    ),
-    ToolItem(
-      icon = Lucide.SpellCheck,
-      label = "맞춤법 검사",
-      action = EditorToolbarToolAction.Spellcheck,
-    ),
-    ToolItem(
-      icon = Lucide.Lightbulb,
-      label = "AI 피드백",
-      action = EditorToolbarToolAction.AiFeedback,
-    ),
-    ToolItem(icon = Lucide.History, label = "타임라인", action = EditorToolbarToolAction.Timeline),
-  )
 
 private const val DebugSectionTitleKey = "debug-section-title"
 private val ToolPanelPadding = 16.dp

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/topbar/EditorScreenTopBar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/topbar/EditorScreenTopBar.kt
@@ -1,0 +1,113 @@
+package co.typie.screen.editor.editor.topbar
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import co.typie.icons.Lucide
+import co.typie.screen.editor.editor.toolbar.EditorToolbarDebugOverlays
+import co.typie.screen.editor.editor.toolbar.EditorToolbarToolAction
+import co.typie.screen.editor.editor.toolbar.EditorToolbarToolItems
+import co.typie.screen.editor.editor.toolbar.editorToolbarDebugToolItems
+import co.typie.ui.component.popover.PopoverMenu
+import co.typie.ui.component.topbar.ProvideTopBar
+import co.typie.ui.component.topbar.TopBarButton
+import co.typie.ui.component.topbar.TopBarDefaults
+import co.typie.ui.theme.AppTheme
+
+@Composable
+internal fun EditorScreenTopBar(
+  editing: Boolean,
+  debugOverlays: EditorToolbarDebugOverlays?,
+  documentButton: @Composable (Modifier) -> Unit,
+  onToolAction: (EditorToolbarToolAction) -> Unit,
+  onEnterReadingMode: suspend () -> Unit,
+) {
+  if (editing) {
+    ProvideTopBar(
+      center = { documentButton(Modifier.fillMaxWidth()) },
+      trailing = { EditorEditingTopBarTrailing(onEnterReadingMode) },
+      trailingKey = EditingTopBarTrailingKey,
+      scrollOffset = null,
+    )
+  } else {
+    ProvideTopBar(
+      center = {
+        documentButton(Modifier.fillMaxWidth().padding(end = ReadingTopBarExtraEndClearance))
+      },
+      trailing = { EditorReadingTopBarTrailing(debugOverlays, onToolAction) },
+      trailingKey = ReadingTopBarTrailingKey,
+      scrollOffset = null,
+    )
+  }
+}
+
+@Composable
+private fun EditorEditingTopBarTrailing(onEnterReadingMode: suspend () -> Unit) {
+  TopBarButton(
+    icon = Lucide.Check,
+    onClick = onEnterReadingMode,
+    backgroundColor = AppTheme.colors.textDefault,
+    contentColor = AppTheme.colors.surfaceDefault,
+    modifier =
+      Modifier.semantics {
+        contentDescription = EnterReadingModeDescription
+        role = Role.Button
+      },
+  )
+}
+
+@Composable
+private fun EditorReadingTopBarTrailing(
+  debugOverlays: EditorToolbarDebugOverlays?,
+  onToolAction: (EditorToolbarToolAction) -> Unit,
+) {
+  Row(horizontalArrangement = Arrangement.spacedBy(ReadingTopBarActionGap)) {
+    TopBarButton(
+      icon = Lucide.Search,
+      onClick = { onToolAction(EditorToolbarToolAction.Search) },
+      modifier =
+        Modifier.semantics {
+          contentDescription = SearchDescription
+          role = Role.Button
+        },
+    )
+    PopoverMenu(
+      anchor = {
+        TopBarButton(
+          icon = Lucide.Ellipsis,
+          modifier =
+            Modifier.semantics {
+              contentDescription = ToolsDescription
+              role = Role.Button
+            },
+        )
+      }
+    ) {
+      EditorToolbarToolItems.forEach { item ->
+        item(icon = item.icon, label = item.label) { onToolAction(item.action) }
+      }
+      debugOverlays?.let { overlays ->
+        divider()
+        editorToolbarDebugToolItems(overlays).forEach { item ->
+          item(icon = item.icon, label = item.label) { onToolAction(item.action) }
+        }
+      }
+    }
+  }
+}
+
+private val EditingTopBarTrailingKey = Any()
+private val ReadingTopBarTrailingKey = Any()
+private const val SearchDescription = "검색"
+private const val ToolsDescription = "도구"
+private const val EnterReadingModeDescription = "읽기 모드로 전환"
+private val ReadingTopBarActionGap = 8.dp
+private val ReadingTopBarExtraEndClearance = TopBarDefaults.ButtonSize + ReadingTopBarActionGap

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/editorsettings/EditorSettingsScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/editorsettings/EditorSettingsScreen.kt
@@ -117,6 +117,20 @@ fun EditorSettingsScreen() {
 
       EditorSettingsSection(title = "편집 설정") {
         SettingControlRow(
+          label = "편집하려면 더블 탭",
+          description = "읽기 모드에서 더블 탭해야 편집을 시작합니다.",
+          onClick = { Preference.doubleTapToEditEnabled = !Preference.doubleTapToEditEnabled },
+          trailing = {
+            SettingSwitch(
+              checked = Preference.doubleTapToEditEnabled,
+              onCheckedChange = { next -> Preference.doubleTapToEditEnabled = next },
+            )
+          },
+        )
+
+        CardDivider(inset = 20.dp)
+
+        SettingControlRow(
           label = "선택 영역 둘러싸기",
           description = "따옴표나 괄호를 입력하면 선택 영역을 둘러쌉니다.",
           onClick = { Preference.autoSurroundEnabled = !Preference.autoSurroundEnabled },

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/storage/Preference.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/storage/Preference.kt
@@ -30,6 +30,7 @@ object Preference {
   var typewriterEnabled by prefs("typewriter_enabled", false)
   var typewriterPosition by prefs("typewriter_position", 0.5)
   var lineHighlightEnabled by prefs("line_highlight_enabled", true)
+  var doubleTapToEditEnabled by prefs("double_tap_to_edit_enabled", true)
   var autoSurroundEnabled by prefs("auto_surround_enabled", true)
   var searchMatchWholeWord by prefs("search_match_whole_word", false)
   var characterCountFloatingEnabled by prefs("character_count_floating_enabled", false)

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/topbar/TopBarButton.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/topbar/TopBarButton.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import co.typie.ext.InteractionScope
 import co.typie.ext.LocalInteractionSource
@@ -22,12 +23,28 @@ fun TopBarButton(
   icon: IconData,
   onClick: (suspend () -> Unit)? = null,
   modifier: Modifier = Modifier,
+  backgroundColor: Color = TopBarDefaults.controlBackgroundColor(),
+  contentColor: Color = AppTheme.colors.textDefault,
 ) {
   val inheritedInteractionSource = LocalInteractionSource.current
   if (inheritedInteractionSource != null) {
-    TopBarButtonContent(icon = icon, onClick = onClick, modifier = modifier)
+    TopBarButtonContent(
+      icon = icon,
+      onClick = onClick,
+      modifier = modifier,
+      backgroundColor = backgroundColor,
+      contentColor = contentColor,
+    )
   } else {
-    InteractionScope { TopBarButtonContent(icon = icon, onClick = onClick, modifier = modifier) }
+    InteractionScope {
+      TopBarButtonContent(
+        icon = icon,
+        onClick = onClick,
+        modifier = modifier,
+        backgroundColor = backgroundColor,
+        contentColor = contentColor,
+      )
+    }
   }
 }
 
@@ -36,8 +53,9 @@ private fun TopBarButtonContent(
   icon: IconData,
   onClick: (suspend () -> Unit)?,
   modifier: Modifier,
+  backgroundColor: Color,
+  contentColor: Color,
 ) {
-  val bg = TopBarDefaults.controlBackgroundColor()
   val borderColor = TopBarDefaults.controlBorderColor()
 
   Box(
@@ -46,15 +64,13 @@ private fun TopBarButtonContent(
       modifier
         .size(TopBarDefaults.ButtonSize)
         .shadow(AppTheme.shadows.sm, TopBarDefaults.ButtonShape)
-        .pressScale(1.05f)
-        .background(bg, TopBarDefaults.ButtonShape)
+        .pressScale(TopBarButtonPressedScale)
+        .background(backgroundColor, TopBarDefaults.ButtonShape)
         .border(1.dp, borderColor, TopBarDefaults.ButtonShape)
         .then(if (onClick != null) Modifier.clickable(onClick) else Modifier),
   ) {
-    Icon(
-      icon = icon,
-      modifier = Modifier.size(TopBarDefaults.ButtonIconSize),
-      tint = AppTheme.colors.textDefault,
-    )
+    Icon(icon = icon, modifier = Modifier.size(TopBarDefaults.ButtonIconSize), tint = contentColor)
   }
 }
+
+private const val TopBarButtonPressedScale = 1.1f

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
@@ -38,6 +38,7 @@ import co.typie.editor.ffi.TableOverlayCellSelection
 import co.typie.editor.ffi.TableOverlayColumn
 import co.typie.editor.ffi.TableOverlayRow
 import co.typie.editor.ffi.ViewOp
+import co.typie.editor.interaction.gestures.EditorConsecutiveTapMaxIntervalMillis
 import co.typie.editor.interaction.gestures.EditorPanGestureDriver
 import co.typie.editor.interaction.semantics.EditorViewportZoomSemanticConfig
 import co.typie.editor.runtime.EditorContextMenuState
@@ -50,9 +51,12 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
@@ -297,7 +301,7 @@ class EditorInteractionControllerTest {
     }
 
   @Test
-  fun `tap timer selection hit guard does not dispatch primary click`() =
+  fun `tap timer selection hit waits for pointer up and tap confirmation before showing menu`() =
     runTest(StandardTestDispatcher()) {
       val rangeSelection =
         Selection(
@@ -324,10 +328,20 @@ class EditorInteractionControllerTest {
 
       controller.onPointerDown(pointerId = 1L, position = start, nowMillis = 0L)
       controller.onTapTimer(nowMillis = 250L)
+      runCurrent()
+
+      assertFalse(host.uiState.contextMenu.isVisibleFor(editor.state))
+
       controller.onPointerUp(pointerId = 1L, position = start, nowMillis = 300L)
-      advanceUntilIdle()
+      runCurrent()
+
+      assertFalse(host.uiState.contextMenu.isVisibleFor(editor.state))
+
+      advanceTimeBy(EditorConsecutiveTapMaxIntervalMillis)
+      runCurrent()
 
       assertEquals(emptyList(), fake.enqueued)
+      assertTrue(host.uiState.contextMenu.isVisibleFor(editor.state))
       assertEquals(emptyList(), host.requestedBringIntoViewVersions)
     }
 
@@ -368,7 +382,7 @@ class EditorInteractionControllerTest {
     }
 
   @Test
-  fun `single tap on range selection hit toggles context menu without moving cursor`() =
+  fun `confirmed tap on range selection toggles context menu without moving cursor`() =
     runTest(StandardTestDispatcher()) {
       val rangeSelection =
         Selection(
@@ -395,7 +409,12 @@ class EditorInteractionControllerTest {
 
       controller.onPointerDown(pointerId = 1L, position = start, nowMillis = 0L)
       controller.onPointerUp(pointerId = 1L, position = start, nowMillis = 40L)
-      advanceUntilIdle()
+      runCurrent()
+
+      assertFalse(host.uiState.contextMenu.isVisibleFor(editor.state))
+
+      advanceTimeBy(EditorConsecutiveTapMaxIntervalMillis)
+      runCurrent()
 
       assertTrue(host.uiState.contextMenu.isVisibleFor(editor.state))
       assertTrue(host.focused)
@@ -1059,7 +1078,7 @@ class EditorInteractionControllerTest {
     }
 
   @Test
-  fun `three taps separated within the platform timeout select a paragraph`() =
+  fun `single and double tap menus stay hidden while a triple tap remains possible`() =
     runTest(StandardTestDispatcher()) {
       val selection =
         Selection(
@@ -1082,12 +1101,18 @@ class EditorInteractionControllerTest {
 
       controller.onPointerDown(pointerId = 1L, position = start, nowMillis = 0L)
       controller.onPointerUp(pointerId = 1L, position = start, nowMillis = 40L)
-      advanceUntilIdle()
-      controller.onPointerDown(pointerId = 2L, position = start, nowMillis = 280L)
-      controller.onPointerUp(pointerId = 2L, position = start, nowMillis = 360L)
-      advanceUntilIdle()
-      controller.onPointerDown(pointerId = 3L, position = start, nowMillis = 600L)
-      controller.onPointerUp(pointerId = 3L, position = start, nowMillis = 680L)
+      runCurrent()
+      assertFalse(host.uiState.contextMenu.isVisibleFor(editor.state))
+
+      advanceTimeBy(100L)
+      controller.onPointerDown(pointerId = 2L, position = start, nowMillis = 140L)
+      controller.onPointerUp(pointerId = 2L, position = start, nowMillis = 180L)
+      runCurrent()
+      assertFalse(host.uiState.contextMenu.isVisibleFor(editor.state))
+
+      advanceTimeBy(100L)
+      controller.onPointerDown(pointerId = 3L, position = start, nowMillis = 280L)
+      controller.onPointerUp(pointerId = 3L, position = start, nowMillis = 320L)
       advanceUntilIdle()
 
       assertEquals(
@@ -1763,6 +1788,8 @@ class EditorInteractionControllerTest {
           override val mode = EditorInteractionMode.Idle
           override val isFocused = host.uiState.focused
           override val readOnly = false
+          override val editing = true
+          override val doubleTapToEditEnabled = true
           override val platform = Platform.Desktop
 
           override fun applyModeEvent(event: EditorInteractionEvent) = Unit
@@ -3638,7 +3665,7 @@ class EditorInteractionControllerTest {
     }
 
   @Test
-  fun `same cursor single tap toggles context menu state`() =
+  fun `same cursor tap closes an existing context menu`() =
     runTest(StandardTestDispatcher()) {
       var cursor = cursorAt(x = 10f)
       val fake =
@@ -3673,6 +3700,7 @@ class EditorInteractionControllerTest {
       assertTrue(host.uiState.contextMenu.isVisibleFor(editor.state))
 
       controller.onPointerDown(pointerId = 2L, position = start, nowMillis = 700L)
+      assertFalse(host.uiState.contextMenu.isVisibleFor(editor.state))
       controller.onTapTimer(nowMillis = 950L)
       controller.onPointerUp(pointerId = 2L, position = start, nowMillis = 1000L)
       advanceUntilIdle()
@@ -3681,7 +3709,7 @@ class EditorInteractionControllerTest {
     }
 
   @Test
-  fun `delayed same cursor tap keeps its pointer down context menu policy`() =
+  fun `later pointer down cancels the older pending same cursor menu`() =
     runTest(StandardTestDispatcher()) {
       val collapsedSelection =
         Selection(
@@ -3716,7 +3744,13 @@ class EditorInteractionControllerTest {
       assertFalse(host.uiState.contextMenu.isVisibleFor(editor.state))
       runCurrent()
 
-      assertTrue(host.uiState.contextMenu.isVisibleFor(editor.state))
+      assertFalse(host.uiState.contextMenu.isVisibleFor(editor.state))
+
+      controller.onTapTimer(nowMillis = 950L)
+      controller.onPointerUp(pointerId = 2L, position = start, nowMillis = 1000L)
+      advanceUntilIdle()
+
+      assertFalse(host.uiState.contextMenu.isVisibleFor(editor.state))
     }
 
   @Test
@@ -3916,6 +3950,7 @@ class EditorInteractionControllerTest {
     EditorInteractionEffects, EditorInteractionGeometry {
     val frameClock = BroadcastFrameClock()
     private var frameTimeNanos = 0L
+    private var tapSequenceConfirmationJob: Job? = null
 
     fun sendFrame() {
       frameTimeNanos += 16_000_000L
@@ -3926,6 +3961,7 @@ class EditorInteractionControllerTest {
     var scheduledTapDispatchAtMillis: Long? = null
     var scheduledLongPressDispatchAtMillis: Long? = null
     var cancelTapDispatchCount = 0
+    var cancelTapSequenceConfirmationCount = 0
     var launchInteractionCount = 0
     var focused = false
     var softwareKeyboardRequestCount = 0
@@ -3996,6 +4032,20 @@ class EditorInteractionControllerTest {
       scheduledTapDispatchAtMillis = null
     }
 
+    override fun scheduleTapSequenceConfirmation(onConfirmed: () -> Unit) {
+      tapSequenceConfirmationJob?.cancel()
+      tapSequenceConfirmationJob = scope.launch {
+        delay(EditorConsecutiveTapMaxIntervalMillis)
+        onConfirmed()
+      }
+    }
+
+    override fun cancelTapSequenceConfirmation() {
+      cancelTapSequenceConfirmationCount += 1
+      tapSequenceConfirmationJob?.cancel()
+      tapSequenceConfirmationJob = null
+    }
+
     override fun scheduleLongPressDispatch(
       pointerId: Long,
       position: Offset,
@@ -4012,6 +4062,10 @@ class EditorInteractionControllerTest {
       launchInteractionCount += 1
       scope.launch(frameClock) { block() }
     }
+
+    override fun requestEditing(editor: Editor): Boolean = false
+
+    override fun showReadingEditHint() = Unit
 
     override fun requestFocus(editor: Editor): Boolean {
       focused = true

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionScopeTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionScopeTest.kt
@@ -2,15 +2,24 @@ package co.typie.editor.interaction
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.input.pointer.PointerId
+import androidx.compose.ui.input.pointer.PointerInputChange
 import co.typie.editor.Editor
 import co.typie.editor.EditorState
 import co.typie.editor.FakeFfiEditor
 import co.typie.editor.body.EditorDocumentLayoutSpec
+import co.typie.editor.ffi.Affinity
+import co.typie.editor.ffi.Message
+import co.typie.editor.ffi.Position
+import co.typie.editor.ffi.Selection
+import co.typie.editor.ffi.SelectionOp
+import co.typie.editor.ffi.Size
 import co.typie.editor.runtime.EditorUiState
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.EditorVisibleArea
 import co.typie.editor.viewport.EditorViewportState
 import co.typie.ext.ScrollGestureLockState
+import co.typie.platform.Platform
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -18,10 +27,223 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class EditorInteractionScopeTest {
+  @Test
+  fun `reset cancels a pending tap sequence confirmation`() =
+    runTest(StandardTestDispatcher()) {
+      val scope =
+        EditorInteractionScope(coroutineScope = this, platformProvider = { Platform.Desktop })
+      var confirmed = false
+
+      scope.scheduleTapSequenceConfirmation { confirmed = true }
+      scope.reset()
+      advanceUntilIdle()
+
+      assertFalse(confirmed)
+    }
+
+  @Test
+  fun `editing mode change cancels the latest replacement tap confirmation`() =
+    runTest(StandardTestDispatcher()) {
+      val editor = Editor(FakeFfiEditor(), this, StandardTestDispatcher(testScheduler))
+      val scope =
+        EditorInteractionScope(coroutineScope = this, platformProvider = { Platform.Desktop })
+      var editing = false
+      var firstConfirmed = false
+      var replacementConfirmed = false
+
+      updateScope(scope = scope, editor = editor, editing = { editing })
+      scope.scheduleTapSequenceConfirmation { firstConfirmed = true }
+      scope.scheduleTapSequenceConfirmation { replacementConfirmed = true }
+      runCurrent()
+      editing = true
+      updateScope(scope = scope, editor = editor, editing = { editing })
+      advanceUntilIdle()
+
+      assertFalse(firstConfirmed)
+      assertFalse(replacementConfirmed)
+    }
+
+  @Test
+  fun `external editing promotion consumes the active reading pointer without redispatching it`() =
+    runTest(StandardTestDispatcher()) {
+      val fake = FakeFfiEditor(pageSizesProvider = { listOf(Size(width = 400f, height = 700f)) })
+      val editor = Editor(fake, this, StandardTestDispatcher(testScheduler)).also { it.sync {} }
+      val uiState =
+        EditorUiState().apply {
+          updateInteractionSurfaceBounds(
+            boundsInRoot = Rect(left = 0f, top = 0f, right = 400f, bottom = 700f),
+            density = 1f,
+          )
+          updateEditorBounds(
+            boundsInRoot = Rect(left = 0f, top = 0f, right = 400f, bottom = 700f),
+            density = 1f,
+          )
+          updatePageOffset(page = 0, offset = Offset.Zero)
+        }
+      val scope =
+        EditorInteractionScope(coroutineScope = this, platformProvider = { Platform.Desktop })
+      var editing = false
+      updateScope(scope = scope, editor = editor, editing = { editing }, uiState = uiState)
+
+      scope.controller.onPointerDown(
+        change = pointerDown(id = 1L, uptimeMillis = 0L),
+        position = Offset(10f, 20f),
+      )
+
+      editing = true
+      updateScope(scope = scope, editor = editor, editing = { editing }, uiState = uiState)
+
+      assertTrue(
+        scope.controller.onPointerUp(
+          change = pointerUp(id = 1L, uptimeMillis = 40L),
+          position = Offset(10f, 20f),
+        )
+      )
+      advanceUntilIdle()
+      assertTrue(fake.enqueued.isEmpty())
+    }
+
+  @Test
+  fun `accepted double tap promotion preserves its editable node menu through scope update`() =
+    runTest(StandardTestDispatcher()) {
+      val collapsedSelection =
+        Selection(
+          anchor = Position("text", 0, Affinity.Downstream),
+          head = Position("text", 0, Affinity.Downstream),
+        )
+      val nodeSelection =
+        Selection(
+          anchor = Position("node", 0, Affinity.Downstream),
+          head = Position("node", 1, Affinity.Downstream),
+        )
+      var currentSelection = collapsedSelection
+      lateinit var fake: FakeFfiEditor
+      fake =
+        FakeFfiEditor(
+          pageSizesProvider = { listOf(Size(width = 400f, height = 700f)) },
+          selectionProvider = { currentSelection },
+          onTick = {
+            if ((fake.enqueued.lastOrNull() as? Message.Selection)?.op is SelectionOp.SetAt) {
+              currentSelection = nodeSelection
+            }
+            emptyList()
+          },
+        )
+      val editor = Editor(fake, this, StandardTestDispatcher(testScheduler)).also { it.sync {} }
+      val uiState =
+        EditorUiState().apply {
+          updateInteractionSurfaceBounds(
+            boundsInRoot = Rect(left = 0f, top = 0f, right = 400f, bottom = 700f),
+            density = 1f,
+          )
+          updateEditorBounds(
+            boundsInRoot = Rect(left = 0f, top = 0f, right = 400f, bottom = 700f),
+            density = 1f,
+          )
+          updatePageOffset(page = 0, offset = Offset.Zero)
+        }
+      val scope =
+        EditorInteractionScope(coroutineScope = this, platformProvider = { Platform.Desktop })
+      var editing = false
+      val onRequestEditing: (Editor) -> Boolean = {
+        editing = true
+        true
+      }
+      updateScope(
+        scope = scope,
+        editor = editor,
+        editing = { editing },
+        uiState = uiState,
+        onRequestEditing = onRequestEditing,
+      )
+
+      scope.controller.tap(pointerId = 1L, position = Offset(10f, 20f), downAtMillis = 0L)
+      runCurrent()
+      scope.controller.onPointerDown(
+        change = pointerDown(id = 2L, uptimeMillis = 140L),
+        position = Offset(10f, 20f),
+      )
+      updateScope(
+        scope = scope,
+        editor = editor,
+        editing = { editing },
+        uiState = uiState,
+        onRequestEditing = onRequestEditing,
+      )
+      scope.controller.onPointerUp(
+        change = pointerUp(id = 2L, uptimeMillis = 180L),
+        position = Offset(10f, 20f),
+      )
+      advanceUntilIdle()
+
+      assertTrue(editing)
+      assertEquals(
+        2,
+        fake.enqueued.filterIsInstance<Message.Selection>().count { it.op is SelectionOp.SetAt },
+      )
+      assertTrue(uiState.contextMenu.isVisibleFor(editor.state))
+    }
+
+  @Test
+  fun `editor replacement clears the previous editor reading tap history`() =
+    runTest(StandardTestDispatcher()) {
+      fun editor() =
+        Editor(
+            FakeFfiEditor(pageSizesProvider = { listOf(Size(width = 400f, height = 700f)) }),
+            this,
+            StandardTestDispatcher(testScheduler),
+          )
+          .also { it.sync {} }
+
+      val firstEditor = editor()
+      val secondEditor = editor()
+      val uiState =
+        EditorUiState().apply {
+          updateInteractionSurfaceBounds(
+            boundsInRoot = Rect(left = 0f, top = 0f, right = 400f, bottom = 700f),
+            density = 1f,
+          )
+          updateEditorBounds(
+            boundsInRoot = Rect(left = 0f, top = 0f, right = 400f, bottom = 700f),
+            density = 1f,
+          )
+          updatePageOffset(page = 0, offset = Offset.Zero)
+        }
+      val scope =
+        EditorInteractionScope(coroutineScope = this, platformProvider = { Platform.Desktop })
+      var editingRequestCount = 0
+      val onRequestEditing: (Editor) -> Boolean = {
+        editingRequestCount += 1
+        true
+      }
+
+      updateScope(
+        scope = scope,
+        editor = firstEditor,
+        editing = { false },
+        uiState = uiState,
+        onRequestEditing = onRequestEditing,
+      )
+      scope.controller.tap(pointerId = 1L, position = Offset(10f, 20f), downAtMillis = 0L)
+
+      updateScope(
+        scope = scope,
+        editor = secondEditor,
+        editing = { false },
+        uiState = uiState,
+        onRequestEditing = onRequestEditing,
+      )
+      scope.controller.tap(pointerId = 2L, position = Offset(10f, 20f), downAtMillis = 120L)
+
+      assertEquals(0, editingRequestCount)
+    }
+
   @Test
   fun `editor state observation is ignored before editor attaches`() =
     runTest(StandardTestDispatcher()) {
@@ -157,4 +379,62 @@ class EditorInteractionScopeTest {
       )
       assertFalse(scope.isTapEligible(outsidePagePosition))
     }
+
+  private fun updateScope(
+    scope: EditorInteractionScope,
+    editor: Editor,
+    editing: () -> Boolean,
+    uiState: EditorUiState = EditorUiState(),
+    onRequestEditing: (Editor) -> Boolean = { false },
+  ) {
+    scope.update(
+      editor = editor,
+      bringIntoViewRequests = EditorBringIntoViewRequests(),
+      uiState = uiState,
+      density = 1f,
+      visibleArea = EditorVisibleArea(),
+      viewportState = EditorViewportState(),
+      scrollGestureLockState = ScrollGestureLockState(),
+      viewportZoomConfig = null,
+      editing = editing,
+      onRequestEditing = onRequestEditing,
+      onSelectionHaptic = {},
+      onRequestSoftwareKeyboard = {},
+    )
+  }
 }
+
+private fun EditorInteractionController.tap(pointerId: Long, position: Offset, downAtMillis: Long) {
+  onPointerDown(
+    change = pointerDown(id = pointerId, uptimeMillis = downAtMillis),
+    position = position,
+  )
+  onPointerUp(
+    change = pointerUp(id = pointerId, uptimeMillis = downAtMillis + 40L),
+    position = position,
+  )
+}
+
+private fun pointerDown(id: Long, uptimeMillis: Long): PointerInputChange =
+  PointerInputChange(
+    id = PointerId(id),
+    uptimeMillis = uptimeMillis,
+    position = Offset.Zero,
+    pressed = true,
+    previousUptimeMillis = uptimeMillis,
+    previousPosition = Offset.Zero,
+    previousPressed = false,
+    isInitiallyConsumed = false,
+  )
+
+private fun pointerUp(id: Long, uptimeMillis: Long): PointerInputChange =
+  PointerInputChange(
+    id = PointerId(id),
+    uptimeMillis = uptimeMillis,
+    position = Offset.Zero,
+    pressed = false,
+    previousUptimeMillis = uptimeMillis,
+    previousPosition = Offset.Zero,
+    previousPressed = true,
+    isInitiallyConsumed = false,
+  )

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorReadingModeInteractionTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorReadingModeInteractionTest.kt
@@ -1,0 +1,557 @@
+package co.typie.editor.interaction
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerId
+import androidx.compose.ui.input.pointer.PointerInputChange
+import co.typie.editor.Editor
+import co.typie.editor.FakeFfiEditor
+import co.typie.editor.PagePoint
+import co.typie.editor.ffi.Affinity
+import co.typie.editor.ffi.CalloutVariant
+import co.typie.editor.ffi.InputModifiers
+import co.typie.editor.ffi.InteractiveHit
+import co.typie.editor.ffi.Message
+import co.typie.editor.ffi.PageRect
+import co.typie.editor.ffi.Position
+import co.typie.editor.ffi.Rect
+import co.typie.editor.ffi.Selection
+import co.typie.editor.ffi.SelectionOp
+import co.typie.editor.interaction.gestures.EditorConsecutiveTapMaxIntervalMillis
+import co.typie.editor.runtime.EditorUiState
+import co.typie.platform.Platform
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class EditorReadingModeInteractionTest {
+  @Test
+  fun `reading single tap waits through the consecutive tap window before hint`() =
+    runTest(StandardTestDispatcher()) {
+      val fixture = fixture()
+      fixture.editor.sync {}
+
+      fixture.controller.down(pointerId = 1L, nowMillis = 0L)
+      fixture.controller.up(pointerId = 1L, nowMillis = 40L)
+
+      advanceTimeBy(EditorConsecutiveTapMaxIntervalMillis - 1)
+      runCurrent()
+      assertEquals(0, fixture.effects.hintCount)
+      assertEquals(0, fixture.effects.focusRequestCount)
+      assertEquals(
+        listOf<Message>(Message.Selection(SelectionOp.SetAt(page = 0, x = 10f, y = 20f))),
+        fixture.fake.enqueued,
+      )
+
+      advanceTimeBy(1)
+      runCurrent()
+      assertEquals(1, fixture.effects.hintCount)
+      assertEquals(0, fixture.effects.editingRequestCount)
+    }
+
+  @Test
+  fun `editable 250 millisecond tap timer cannot present the reading hint`() =
+    runTest(StandardTestDispatcher()) {
+      val fixture = fixture(editing = true)
+      fixture.editor.sync {}
+
+      fixture.controller.down(pointerId = 1L, nowMillis = 0L)
+      fixture.controller.onTapTimer(nowMillis = 250L)
+      advanceUntilIdle()
+
+      assertEquals(0, fixture.effects.hintCount)
+      assertEquals(
+        listOf<Message>(Message.Selection(SelectionOp.SetAt(page = 0, x = 10f, y = 20f))),
+        fixture.fake.enqueued,
+      )
+    }
+
+  @Test
+  fun `reading double tap applies reading selection then one editable cursor move`() =
+    runTest(StandardTestDispatcher()) {
+      val fixture = fixture()
+      fixture.editor.sync {}
+
+      fixture.controller.down(pointerId = 1L, nowMillis = 0L)
+      fixture.controller.up(pointerId = 1L, nowMillis = 40L)
+      advanceTimeBy(100L)
+      fixture.controller.down(pointerId = 2L, nowMillis = 140L)
+      fixture.controller.up(pointerId = 2L, nowMillis = 180L)
+      advanceUntilIdle()
+
+      assertTrue(fixture.editing)
+      assertEquals(1, fixture.effects.editingRequestCount)
+      assertEquals(1, fixture.effects.focusRequestCount)
+      assertEquals(1, fixture.effects.softwareKeyboardRequestCount)
+      assertEquals(0, fixture.effects.hintCount)
+      assertEquals(
+        listOf<Message>(
+          Message.Selection(SelectionOp.SetAt(page = 0, x = 10f, y = 20f)),
+          Message.Selection(SelectionOp.SetAt(page = 0, x = 10f, y = 20f)),
+        ),
+        fixture.fake.enqueued,
+      )
+      assertTrue(
+        fixture.fake.enqueued.none { message ->
+          (message as? Message.Selection)?.op is SelectionOp.SelectUnitAt
+        }
+      )
+    }
+
+  @Test
+  fun `reading activation ignores Shift and places a collapsed cursor`() =
+    runTest(StandardTestDispatcher()) {
+      val fixture = fixture()
+      fixture.editor.sync {}
+
+      fixture.controller.down(
+        pointerId = 1L,
+        nowMillis = 0L,
+        inputModifiers = InputModifiers(shift = true),
+      )
+      fixture.controller.up(pointerId = 1L, nowMillis = 40L)
+      advanceTimeBy(100L)
+      fixture.controller.down(
+        pointerId = 2L,
+        nowMillis = 140L,
+        inputModifiers = InputModifiers(shift = true),
+      )
+      fixture.controller.up(pointerId = 2L, nowMillis = 180L)
+      advanceUntilIdle()
+
+      assertEquals(
+        listOf<Message>(
+          Message.Selection(SelectionOp.SetAt(page = 0, x = 10f, y = 20f)),
+          Message.Selection(SelectionOp.SetAt(page = 0, x = 10f, y = 20f)),
+        ),
+        fixture.fake.enqueued,
+      )
+    }
+
+  @Test
+  fun `single tap opt out promotes and preserves the first tap for editable double tap`() =
+    runTest(StandardTestDispatcher()) {
+      val fixture = fixture(doubleTapToEditEnabled = false)
+      fixture.editor.sync {}
+
+      fixture.controller.down(pointerId = 1L, nowMillis = 0L)
+      fixture.controller.up(pointerId = 1L, nowMillis = 40L)
+      runCurrent()
+
+      assertTrue(fixture.editing)
+      assertEquals(
+        Message.Selection(SelectionOp.SetAt(page = 0, x = 10f, y = 20f)),
+        fixture.fake.enqueued.single(),
+      )
+
+      fixture.controller.down(pointerId = 2L, nowMillis = 120L)
+      fixture.controller.up(pointerId = 2L, nowMillis = 160L)
+      advanceUntilIdle()
+
+      assertTrue(
+        fixture.fake.enqueued.any { message ->
+          (message as? Message.Selection)?.op is SelectionOp.SelectUnitAt
+        }
+      )
+      assertEquals(1, fixture.effects.editingRequestCount)
+      assertEquals(0, fixture.effects.hintCount)
+    }
+
+  @Test
+  fun `single tap opt out collapses an existing iOS reading selection before editing`() =
+    runTest(StandardTestDispatcher()) {
+      val fixture =
+        fixture(
+          doubleTapToEditEnabled = false,
+          expandedSelection = true,
+          tapHitsSelection = true,
+          platform = Platform.iOS,
+        )
+      fixture.editor.sync {}
+
+      fixture.controller.down(pointerId = 1L, nowMillis = 0L)
+      fixture.controller.up(pointerId = 1L, nowMillis = 40L)
+      advanceUntilIdle()
+
+      assertTrue(fixture.editing)
+      assertEquals(
+        listOf<Message>(Message.Selection(SelectionOp.SetAt(page = 0, x = 10f, y = 20f))),
+        fixture.fake.enqueued,
+      )
+      assertEquals(1, fixture.effects.focusRequestCount)
+      assertEquals(1, fixture.effects.softwareKeyboardRequestCount)
+    }
+
+  @Test
+  fun `movement and pointer cancellation discard a pending reading result`() =
+    runTest(StandardTestDispatcher()) {
+      val moved = fixture()
+      moved.editor.sync {}
+      moved.controller.down(pointerId = 1L, nowMillis = 0L)
+      moved.controller.move(pointerId = 1L, position = Offset(19f, 20f), nowMillis = 20L)
+      moved.controller.up(pointerId = 1L, position = Offset(19f, 20f), nowMillis = 40L)
+      advanceUntilIdle()
+      assertEquals(0, moved.effects.hintCount)
+
+      val cancelled = fixture()
+      cancelled.editor.sync {}
+      cancelled.controller.down(pointerId = 2L, nowMillis = 100L)
+      cancelled.controller.up(pointerId = 2L, nowMillis = 140L)
+      cancelled.controller.cancel()
+      advanceUntilIdle()
+      assertEquals(0, cancelled.effects.hintCount)
+    }
+
+  @Test
+  fun `header down cancels pending reading presentation without undoing the selection`() =
+    runTest(StandardTestDispatcher()) {
+      val fixture = fixture()
+      fixture.editor.sync {}
+
+      fixture.controller.down(pointerId = 1L, nowMillis = 0L)
+      fixture.controller.up(pointerId = 1L, nowMillis = 40L)
+      runCurrent()
+
+      fixture.controller.onPointerDown(
+        change =
+          pointerChange(pointerId = 2L, nowMillis = 100L, pressed = true, previousPressed = false),
+        position = null,
+        positionInRoot = Offset(10f, 20f),
+      )
+      advanceUntilIdle()
+
+      assertEquals(0, fixture.effects.hintCount)
+      assertEquals(
+        listOf<Message>(Message.Selection(SelectionOp.SetAt(page = 0, x = 10f, y = 20f))),
+        fixture.fake.enqueued,
+      )
+    }
+
+  @Test
+  fun `reading fold control performs view action without entering editing or showing hint`() =
+    runTest(StandardTestDispatcher()) {
+      val fixture = fixture(interactiveHit = InteractiveHit.FoldTitle(id = "fold", textRect = null))
+      fixture.editor.sync {}
+
+      fixture.controller.down(pointerId = 1L, nowMillis = 0L)
+      fixture.controller.up(pointerId = 1L, nowMillis = 40L)
+      advanceUntilIdle()
+
+      assertEquals(
+        listOf<Message>(Message.View(co.typie.editor.ffi.ViewOp.ToggleFold("fold"))),
+        fixture.fake.enqueued,
+      )
+      assertFalse(fixture.editing)
+      assertEquals(0, fixture.effects.hintCount)
+    }
+
+  @Test
+  fun `reading callout control blocks node mutation without entering editing or showing hint`() =
+    runTest(StandardTestDispatcher()) {
+      val fixture =
+        fixture(
+          interactiveHit =
+            InteractiveHit.CalloutIcon(id = "callout", nextVariant = CalloutVariant.Warning)
+        )
+      fixture.editor.sync {}
+
+      fixture.controller.down(pointerId = 1L, nowMillis = 0L)
+      fixture.controller.up(pointerId = 1L, nowMillis = 40L)
+      advanceUntilIdle()
+
+      assertTrue(fixture.fake.enqueued.isEmpty())
+      assertFalse(fixture.editing)
+      assertEquals(0, fixture.effects.hintCount)
+    }
+
+  @Test
+  fun `dismissing an existing selection menu still applies the reading tap and shows the hint`() =
+    runTest(StandardTestDispatcher()) {
+      val fixture = fixture()
+      fixture.editor.sync {}
+      fixture.effects.uiState.contextMenu.show(fixture.editor.state)
+
+      fixture.controller.down(pointerId = 1L, nowMillis = 0L)
+      fixture.controller.up(pointerId = 1L, nowMillis = 40L)
+      advanceUntilIdle()
+
+      assertFalse(fixture.effects.uiState.contextMenu.visible)
+      assertEquals(
+        listOf<Message>(Message.Selection(SelectionOp.SetAt(page = 0, x = 10f, y = 20f))),
+        fixture.fake.enqueued,
+      )
+      assertEquals(1, fixture.effects.hintCount)
+      assertFalse(fixture.editing)
+    }
+
+  @Test
+  fun `reading tap replaces an existing range and still shows the edit hint`() =
+    runTest(StandardTestDispatcher()) {
+      val fixture = fixture(expandedSelection = true)
+      fixture.editor.sync {}
+
+      fixture.controller.down(pointerId = 1L, nowMillis = 0L)
+      fixture.controller.up(pointerId = 1L, nowMillis = 40L)
+      advanceUntilIdle()
+
+      assertEquals(
+        listOf<Message>(Message.Selection(SelectionOp.SetAt(page = 0, x = 10f, y = 20f))),
+        fixture.fake.enqueued,
+      )
+      assertEquals(1, fixture.effects.hintCount)
+      assertFalse(fixture.effects.uiState.contextMenu.visible)
+      assertFalse(fixture.editing)
+    }
+
+  @Test
+  fun `reading tap that selects a node shows the hint and copy menu after confirmation`() =
+    runTest(StandardTestDispatcher()) {
+      val nodeSelection =
+        Selection(
+          anchor = Position("node", 0, Affinity.Downstream),
+          head = Position("node", 1, Affinity.Downstream),
+        )
+      val fixture = fixture(pointSelectionResult = nodeSelection)
+      fixture.editor.sync {}
+
+      fixture.controller.down(pointerId = 1L, nowMillis = 0L)
+      fixture.controller.up(pointerId = 1L, nowMillis = 40L)
+      runCurrent()
+
+      assertEquals(0, fixture.effects.hintCount)
+      assertFalse(fixture.effects.uiState.contextMenu.visible)
+      assertEquals(0, fixture.effects.focusRequestCount)
+      assertEquals(0, fixture.effects.softwareKeyboardRequestCount)
+
+      advanceTimeBy(EditorConsecutiveTapMaxIntervalMillis)
+      runCurrent()
+
+      assertEquals(1, fixture.effects.hintCount)
+      assertTrue(fixture.effects.uiState.contextMenu.isVisibleFor(fixture.editor.state))
+      assertFalse(fixture.editing)
+    }
+
+  private fun TestScope.fixture(
+    editing: Boolean = false,
+    doubleTapToEditEnabled: Boolean = true,
+    interactiveHit: InteractiveHit? = null,
+    expandedSelection: Boolean = false,
+    tapHitsSelection: Boolean = false,
+    pointSelectionResult: Selection? = null,
+    platform: Platform = Platform.Desktop,
+  ): Fixture {
+    var currentSelection =
+      if (expandedSelection) {
+        Selection(
+          anchor = Position("text", 0, Affinity.Downstream),
+          head = Position("text", 4, Affinity.Downstream),
+        )
+      } else {
+        FakeFfiEditor.EmptySelection
+      }
+    lateinit var fake: FakeFfiEditor
+    fake =
+      FakeFfiEditor(
+        selectionProvider = { currentSelection },
+        onTick = {
+          val latestSelection = fake.enqueued.lastOrNull() as? Message.Selection
+          if (latestSelection?.op is SelectionOp.SetAt) {
+            currentSelection = pointSelectionResult ?: FakeFfiEditor.EmptySelection
+          }
+          emptyList()
+        },
+        interactiveRegionsProvider = {
+          interactiveHit?.let { listOf(FakeFfiEditor.coveringRegion(it)) } ?: emptyList()
+        },
+        selectionHitRectsProvider = {
+          if (tapHitsSelection) {
+            listOf(PageRect(pageIdx = 0, rect = Rect(x = 0f, y = 0f, width = 100f, height = 100f)))
+          } else {
+            emptyList()
+          }
+        },
+      )
+    val editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
+    lateinit var fixture: Fixture
+    val effects =
+      TestEffects(
+        scope = this,
+        onRequestEditing = { requestedEditor ->
+          if (requestedEditor !== editor) {
+            false
+          } else {
+            fixture.editing = true
+            true
+          }
+        },
+      )
+    val controller =
+      EditorInteractionController(
+        editorProvider = { editor },
+        effects = effects,
+        geometry = effects,
+        uiStateProvider = { effects.uiState },
+        platformProvider = { platform },
+        editingProvider = { fixture.editing },
+        doubleTapToEditEnabledProvider = { doubleTapToEditEnabled },
+      )
+    controller.updateTapSlop(8f)
+    fixture =
+      Fixture(
+        fake = fake,
+        editor = editor,
+        effects = effects,
+        controller = controller,
+        editing = editing,
+      )
+    return fixture
+  }
+
+  private class Fixture(
+    val fake: FakeFfiEditor,
+    val editor: Editor,
+    val effects: TestEffects,
+    val controller: EditorInteractionController,
+    var editing: Boolean,
+  )
+
+  private class TestEffects(
+    private val scope: TestScope,
+    private val onRequestEditing: (Editor) -> Boolean,
+  ) : EditorInteractionEffects, EditorInteractionGeometry {
+    override val density: Float = 1f
+    val uiState = EditorUiState()
+    var hintCount = 0
+    var editingRequestCount = 0
+    var focusRequestCount = 0
+    var softwareKeyboardRequestCount = 0
+    private var tapSequenceConfirmationJob: Job? = null
+
+    override fun containsDocumentInteraction(positionInRoot: Offset): Boolean = true
+
+    override fun resolveInteractionPosition(positionInRoot: Offset): Offset = positionInRoot
+
+    override fun isTapEligible(positionInRoot: Offset): Boolean = true
+
+    override fun resolvePoint(positionInNode: Offset): PagePoint =
+      PagePoint(page = 0, x = positionInNode.x, y = positionInNode.y)
+
+    override fun resolvePagePosition(page: Int, x: Float, y: Float): Offset = Offset(x, y)
+
+    override fun resolveEdgeAutoScrollViewport(): EditorEdgeAutoScrollViewport? = null
+
+    override fun dispatchEdgeAutoScroll(delta: Offset): Offset = Offset.Zero
+
+    override fun scheduleTapDispatch(dispatchAtMillis: Long) = Unit
+
+    override fun cancelTapDispatch() = Unit
+
+    override fun scheduleTapSequenceConfirmation(onConfirmed: () -> Unit) {
+      tapSequenceConfirmationJob?.cancel()
+      tapSequenceConfirmationJob = scope.launch {
+        delay(EditorConsecutiveTapMaxIntervalMillis)
+        onConfirmed()
+      }
+    }
+
+    override fun cancelTapSequenceConfirmation() {
+      tapSequenceConfirmationJob?.cancel()
+      tapSequenceConfirmationJob = null
+    }
+
+    override fun scheduleLongPressDispatch(
+      pointerId: Long,
+      position: Offset,
+      dispatchAtMillis: Long,
+    ) = Unit
+
+    override fun cancelLongPressDispatch() = Unit
+
+    override fun launchInteraction(block: suspend () -> Unit) {
+      scope.launch { block() }
+    }
+
+    override fun requestEditing(editor: Editor): Boolean {
+      editingRequestCount += 1
+      return onRequestEditing(editor)
+    }
+
+    override fun showReadingEditHint() {
+      hintCount += 1
+    }
+
+    override fun requestFocus(editor: Editor): Boolean {
+      focusRequestCount += 1
+      uiState.updateFocus(true)
+      return true
+    }
+
+    override fun requestSoftwareKeyboard() {
+      softwareKeyboardRequestCount += 1
+    }
+
+    override fun setScrollGestureLocked(locked: Boolean) = Unit
+
+    override fun performSelectionHaptic() = Unit
+
+    override fun requestCurrentSelectionHead(version: Long) = Unit
+  }
+}
+
+private fun EditorInteractionController.down(
+  pointerId: Long,
+  nowMillis: Long,
+  inputModifiers: InputModifiers = InputModifiers(),
+) {
+  onPointerDown(
+    change = pointerChange(pointerId, nowMillis, pressed = true, previousPressed = false),
+    position = Offset(10f, 20f),
+    inputModifiers = inputModifiers,
+  )
+}
+
+private fun EditorInteractionController.move(pointerId: Long, position: Offset, nowMillis: Long) {
+  onPointerMove(
+    change = pointerChange(pointerId, nowMillis, pressed = true, previousPressed = true),
+    position = position,
+  )
+}
+
+private fun EditorInteractionController.up(
+  pointerId: Long,
+  nowMillis: Long,
+  position: Offset = Offset(10f, 20f),
+) {
+  onPointerUp(
+    change = pointerChange(pointerId, nowMillis, pressed = false, previousPressed = true),
+    position = position,
+  )
+}
+
+private fun pointerChange(
+  pointerId: Long,
+  nowMillis: Long,
+  pressed: Boolean,
+  previousPressed: Boolean,
+): PointerInputChange =
+  PointerInputChange(
+    id = PointerId(pointerId),
+    uptimeMillis = nowMillis,
+    position = Offset.Zero,
+    pressed = pressed,
+    previousUptimeMillis = nowMillis,
+    previousPosition = Offset.Zero,
+    previousPressed = previousPressed,
+    isInitiallyConsumed = false,
+  )

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/gestures/EditorTapGestureTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/gestures/EditorTapGestureTest.kt
@@ -9,12 +9,7 @@ import kotlin.test.assertTrue
 
 class EditorTapGestureTest {
   @Test
-  fun `tap dispatch delay includes legacy tap down deadline before tap timer`() {
-    assertEquals(250L, EditorTapDispatchDelayMillis)
-  }
-
-  @Test
-  fun `tap timer can dispatch a primary click once`() {
+  fun `tap timer dispatch still completes the tap on pointer up`() {
     val gesture = createTapGesture()
 
     gesture.startPendingTap(pointerId = 1L, position = Offset(10f, 20f))
@@ -22,21 +17,30 @@ class EditorTapGestureTest {
     assertTrue(gesture.canDispatchTapTimer)
     gesture.markTapDispatched()
     assertFalse(gesture.canDispatchTapTimer)
-    assertNull(gesture.onPointerUp(pointerId = 1L, position = Offset(10f, 20f), nowMillis = 160L))
+    assertEquals(
+      EditorCompletedTap(count = 1, contentAlreadyDispatched = true, recordInHistory = true),
+      gesture.onPointerUp(pointerId = 1L, position = Offset(10f, 20f), nowMillis = 160L),
+    )
   }
 
   @Test
-  fun `tap timer selection hit consumes pending tap without advancing click count`() {
+  fun `tap timer selection hit advances click count only after pointer up`() {
     val gesture = createTapGesture()
 
     gesture.startPendingTap(pointerId = 1L, position = Offset.Zero)
     gesture.markTapDispatched()
 
-    assertNull(gesture.onPointerUp(pointerId = 1L, position = Offset.Zero, nowMillis = 160L))
+    assertEquals(
+      1,
+      gesture.onPointerUp(pointerId = 1L, position = Offset.Zero, nowMillis = 160L)?.count,
+    )
 
     gesture.startPendingTap(pointerId = 2L, position = Offset.Zero)
 
-    assertEquals(1, gesture.onPointerUp(pointerId = 2L, position = Offset.Zero, nowMillis = 240L))
+    assertEquals(
+      2,
+      gesture.onPointerUp(pointerId = 2L, position = Offset.Zero, nowMillis = 240L)?.count,
+    )
   }
 
   @Test
@@ -46,7 +50,10 @@ class EditorTapGestureTest {
     gesture.startPendingTap(pointerId = 1L, position = Offset.Zero)
 
     assertTrue(gesture.canDispatchTapTimer)
-    assertEquals(1, gesture.onPointerUp(pointerId = 1L, position = Offset.Zero, nowMillis = 160L))
+    assertEquals(
+      EditorCompletedTap(count = 1, contentAlreadyDispatched = false, recordInHistory = true),
+      gesture.onPointerUp(pointerId = 1L, position = Offset.Zero, nowMillis = 160L),
+    )
   }
 
   @Test
@@ -56,8 +63,7 @@ class EditorTapGestureTest {
     gesture.startPendingTap(pointerId = 1L, position = Offset(10f, 20f))
     val firstClick =
       gesture.onPointerUp(pointerId = 1L, position = Offset(10f, 20f), nowMillis = 40L)
-    assertEquals(1, firstClick)
-    gesture.recordTap(nowMillis = 40L, position = Offset(10f, 20f), clickCount = firstClick!!)
+    assertEquals(1, firstClick?.count)
 
     assertEquals(2, gesture.nextTapCount(position = Offset(18f, 26f), nowMillis = 240L))
   }
@@ -73,7 +79,7 @@ class EditorTapGestureTest {
 
     assertEquals(
       3,
-      gesture.onPointerUp(pointerId = 3L, position = Offset(20f, 28f), nowMillis = 430L),
+      gesture.onPointerUp(pointerId = 3L, position = Offset(20f, 28f), nowMillis = 430L)?.count,
     )
   }
 
@@ -98,7 +104,7 @@ class EditorTapGestureTest {
 
     assertEquals(
       1,
-      gesture.onPointerUp(pointerId = 2L, position = Offset(10f, 20f), nowMillis = 470L),
+      gesture.onPointerUp(pointerId = 2L, position = Offset(10f, 20f), nowMillis = 470L)?.count,
     )
   }
 
@@ -111,7 +117,7 @@ class EditorTapGestureTest {
     assertFalse(gesture.onPointerMove(pointerId = 1L, position = Offset(4f, 0f)))
     assertEquals(
       1,
-      gesture.onPointerUp(pointerId = 1L, position = Offset(4f, 0f), nowMillis = 160L),
+      gesture.onPointerUp(pointerId = 1L, position = Offset(4f, 0f), nowMillis = 160L)?.count,
     )
   }
 
@@ -138,7 +144,10 @@ class EditorTapGestureTest {
     gesture.onPointerUp(pointerId = 2L, position = Offset(9f, 0f), nowMillis = 560L)
     gesture.startPendingTap(pointerId = 3L, position = Offset.Zero, nowMillis = 660L)
 
-    assertEquals(1, gesture.onPointerUp(pointerId = 3L, position = Offset.Zero, nowMillis = 700L))
+    assertEquals(
+      1,
+      gesture.onPointerUp(pointerId = 3L, position = Offset.Zero, nowMillis = 700L)?.count,
+    )
   }
 
   @Test
@@ -150,6 +159,24 @@ class EditorTapGestureTest {
 
     assertFalse(gesture.canDispatchTapTimer)
     assertFalse(gesture.cancelActivePointerStream())
+  }
+
+  @Test
+  fun `editing promotion completes as a fresh tap without entering tap history`() {
+    val gesture = createTapGesture()
+
+    gesture.recordTap(nowMillis = 40L, position = Offset.Zero, clickCount = 1)
+    gesture.startPendingTap(pointerId = 2L, position = Offset.Zero, nowMillis = 120L)
+    gesture.prepareActiveTapForEditingPromotion()
+
+    assertEquals(
+      EditorCompletedTap(count = 1, contentAlreadyDispatched = true, recordInHistory = false),
+      gesture.onPointerUp(pointerId = 2L, position = Offset.Zero, nowMillis = 160L),
+    )
+    assertEquals(2, gesture.nextTapCount(position = Offset.Zero, nowMillis = 200L))
+
+    gesture.clearTapHistory()
+    assertEquals(1, gesture.nextTapCount(position = Offset.Zero, nowMillis = 200L))
   }
 
   private fun EditorTapGesture.startPendingTap(

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/semantics/EditorLongPressSemanticTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/semantics/EditorLongPressSemanticTest.kt
@@ -1,0 +1,93 @@
+package co.typie.editor.interaction.semantics
+
+import co.typie.editor.Editor
+import co.typie.editor.FakeFfiEditor
+import co.typie.editor.PagePoint
+import co.typie.platform.Platform
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+
+class EditorLongPressSemanticTest {
+  @Test
+  fun `reading resolves word selection on every shared platform`() = runTest {
+    val editor = editor()
+
+    Platform.entries.forEach { platform ->
+      assertEquals(
+        EditorLongPressSemanticIntent.WordSelection,
+        EditorLongPressSemantic()
+          .resolveIntent(editor = editor, point = Point, platform = platform, editing = false),
+        platform.name,
+      )
+    }
+  }
+
+  @Test
+  fun `editing preserves the native platform matrix`() = runTest {
+    val ordinaryEditor = editor()
+
+    assertEquals(
+      EditorLongPressSemanticIntent.WordSelection,
+      EditorLongPressSemantic()
+        .resolveIntent(
+          editor = ordinaryEditor,
+          point = Point,
+          platform = Platform.Android,
+          editing = true,
+        ),
+    )
+    assertEquals(
+      EditorLongPressSemanticIntent.CursorMove,
+      EditorLongPressSemantic()
+        .resolveIntent(
+          editor = ordinaryEditor,
+          point = Point,
+          platform = Platform.iOS,
+          editing = true,
+        ),
+    )
+    assertEquals(
+      EditorLongPressSemanticIntent.CursorMove,
+      EditorLongPressSemantic()
+        .resolveIntent(
+          editor = ordinaryEditor,
+          point = Point,
+          platform = Platform.Desktop,
+          editing = true,
+        ),
+    )
+
+    val androidCursorEditor = editor(cursorHit = true)
+    assertEquals(
+      EditorLongPressSemanticIntent.CursorMove,
+      EditorLongPressSemantic()
+        .resolveIntent(
+          editor = androidCursorEditor,
+          point = Point,
+          platform = Platform.Android,
+          editing = true,
+        ),
+    )
+  }
+
+  private suspend fun kotlinx.coroutines.test.TestScope.editor(cursorHit: Boolean = false): Editor {
+    val editor =
+      Editor(
+        FakeFfiEditor(
+          cursorHitRectsProvider = {
+            if (cursorHit) FakeFfiEditor.coveringHitRects(0) else emptyList()
+          }
+        ),
+        this,
+        StandardTestDispatcher(testScheduler),
+      )
+    editor.sync {}
+    return editor
+  }
+
+  private companion object {
+    val Point = PagePoint(page = 0, x = 10f, y = 20f)
+  }
+}

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/semantics/EditorPointSelectionSemanticTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/semantics/EditorPointSelectionSemanticTest.kt
@@ -164,6 +164,12 @@ class EditorPointSelectionSemanticTest {
 
     override fun cancelTapDispatch() = error("Unused in direct cursor semantic dispatch tests")
 
+    override fun scheduleTapSequenceConfirmation(onConfirmed: () -> Unit) =
+      error("Unused in direct cursor semantic dispatch tests")
+
+    override fun cancelTapSequenceConfirmation() =
+      error("Unused in direct cursor semantic dispatch tests")
+
     override fun scheduleLongPressDispatch(
       pointerId: Long,
       position: Offset,
@@ -175,6 +181,11 @@ class EditorPointSelectionSemanticTest {
 
     override fun launchInteraction(block: suspend () -> Unit) =
       error("Unused in direct cursor semantic dispatch tests")
+
+    override fun requestEditing(editor: Editor): Boolean =
+      error("Unused in direct cursor semantic dispatch tests")
+
+    override fun showReadingEditHint() = error("Unused in direct cursor semantic dispatch tests")
 
     override fun requestFocus(editor: Editor): Boolean =
       error("Unused in direct cursor semantic dispatch tests")

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/ext/TextInputStateTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/ext/TextInputStateTest.kt
@@ -2,6 +2,7 @@ package co.typie.ext
 
 // cspell:ignore heyo
 
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import kotlin.test.Test
@@ -10,6 +11,68 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class TextInputStateTest {
+  @Test
+  fun update_selection_changes_only_local_selection() {
+    var externalValue = "hello"
+    var externalChangeCount = 0
+    val state =
+      TextInputState(
+        binding = TextInputBinding(focusRequester = FocusRequester(), owner = Any()),
+        initialValue =
+          TextFieldValue(
+            text = externalValue,
+            selection = TextRange(0, 5),
+            composition = TextRange(1, 4),
+          ),
+      )
+    state.update(
+      value = externalValue,
+      onValueChange = {
+        externalValue = it
+        externalChangeCount += 1
+      },
+      onDismiss = {},
+    )
+
+    state.updateSelection(TextRange(1, 4))
+
+    assertEquals(
+      TextFieldValue(text = "hello", selection = TextRange(1, 4), composition = null),
+      state.value,
+    )
+    assertEquals("hello", externalValue)
+    assertEquals(0, externalChangeCount)
+  }
+
+  @Test
+  fun finish_composition_and_collapse_selection_keeps_external_text() {
+    var externalValue = "hello"
+    var externalChangeCount = 0
+    val state =
+      TextInputState(
+        binding = TextInputBinding(focusRequester = FocusRequester(), owner = Any()),
+        initialValue =
+          TextFieldValue(
+            text = externalValue,
+            selection = TextRange(4, 1),
+            composition = TextRange(1, 4),
+          ),
+      )
+    state.update(
+      value = externalValue,
+      onValueChange = {
+        externalValue = it
+        externalChangeCount += 1
+      },
+      onDismiss = {},
+    )
+
+    state.finishCompositionAndCollapseSelection()
+
+    assertEquals(TextFieldValue(text = "hello", selection = TextRange(4)), state.value)
+    assertEquals("hello", externalValue)
+    assertEquals(0, externalChangeCount)
+  }
 
   @Test
   fun resolve_text_input_change_ignores_selection_only_updates() {

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/header/EditorHeaderReadingTapGestureTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/header/EditorHeaderReadingTapGestureTest.kt
@@ -1,0 +1,112 @@
+package co.typie.screen.editor.editor.header
+
+import androidx.compose.ui.geometry.Offset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class EditorHeaderReadingTapGestureTest {
+  @Test
+  fun firstTapSchedulesHintAfterConsecutiveTapWindow() {
+    val tracker = tracker()
+
+    assertEquals(
+      EditorHeaderReadingTapResult.None,
+      tracker.onDown(position = Offset(10f, 10f), offset = 2, timeMillis = 0),
+    )
+    assertEquals(
+      EditorHeaderReadingTapResult.None,
+      tracker.onUp(position = Offset(10f, 10f), offset = 2, timeMillis = 20),
+    )
+
+    assertEquals(320, tracker.pendingConfirmationAtMillis)
+    assertEquals(EditorHeaderReadingTapResult.None, tracker.confirm(timeMillis = 319))
+    assertEquals(EditorHeaderReadingTapResult.ShowHint, tracker.confirm(timeMillis = 320))
+    assertNull(tracker.pendingConfirmationAtMillis)
+  }
+
+  @Test
+  fun secondTapWithinTimeAndDistanceActivatesTouchedOffset() {
+    val tracker = tracker()
+    tracker.onDown(position = Offset.Zero, offset = 0, timeMillis = 0)
+    tracker.onUp(position = Offset.Zero, offset = 0, timeMillis = 10)
+
+    assertEquals(
+      EditorHeaderReadingTapResult.Activate(offset = 4),
+      tracker.onDown(position = Offset(8f, 0f), offset = 4, timeMillis = 250),
+    )
+    assertNull(tracker.pendingConfirmationAtMillis)
+  }
+
+  @Test
+  fun secondTapOutsideWindowStartsNewFirstTap() {
+    val tracker = tracker()
+    tracker.onDown(position = Offset.Zero, offset = 0, timeMillis = 0)
+    tracker.onUp(position = Offset.Zero, offset = 0, timeMillis = 10)
+
+    assertEquals(
+      EditorHeaderReadingTapResult.None,
+      tracker.onDown(position = Offset.Zero, offset = 4, timeMillis = 311),
+    )
+    assertNull(tracker.pendingConfirmationAtMillis)
+    tracker.onUp(position = Offset.Zero, offset = 4, timeMillis = 320)
+    assertEquals(620, tracker.pendingConfirmationAtMillis)
+  }
+
+  @Test
+  fun movementLongPressCancelAndModeChangeClearPendingState() {
+    val tracker = tracker()
+
+    tracker.onDown(position = Offset.Zero, offset = 0, timeMillis = 0)
+    tracker.onMove(position = Offset(9f, 0f))
+    tracker.onUp(position = Offset(9f, 0f), offset = 1, timeMillis = 10)
+    assertNull(tracker.pendingConfirmationAtMillis)
+
+    tracker.onDown(position = Offset.Zero, offset = 0, timeMillis = 20)
+    tracker.onLongPress()
+    tracker.onUp(position = Offset.Zero, offset = 0, timeMillis = 30)
+    assertNull(tracker.pendingConfirmationAtMillis)
+
+    scheduleFirstTap(tracker, startMillis = 40)
+    tracker.cancel()
+    assertNull(tracker.pendingConfirmationAtMillis)
+
+    scheduleFirstTap(tracker, startMillis = 80)
+    tracker.onModeChanged()
+    assertNull(tracker.pendingConfirmationAtMillis)
+  }
+
+  @Test
+  fun settingDisabledFirstCompletedTapActivates() {
+    val tracker = tracker(doubleTapToEditEnabled = false)
+    tracker.onDown(position = Offset.Zero, offset = 0, timeMillis = 0)
+
+    assertEquals(
+      EditorHeaderReadingTapResult.Activate(offset = 3),
+      tracker.onUp(position = Offset.Zero, offset = 3, timeMillis = 10),
+    )
+    assertNull(tracker.pendingConfirmationAtMillis)
+  }
+
+  @Test
+  fun confirmedSingleTapSkipsHintWhenItHandledExistingSelectionUi() {
+    val tracker = tracker()
+    tracker.onDown(position = Offset.Zero, offset = 0, timeMillis = 0)
+    tracker.onUp(position = Offset.Zero, offset = 0, timeMillis = 10, suppressHint = true)
+
+    assertEquals(EditorHeaderReadingTapResult.None, tracker.confirm(timeMillis = 310))
+    assertNull(tracker.pendingConfirmationAtMillis)
+  }
+
+  private fun tracker(doubleTapToEditEnabled: Boolean = true): EditorHeaderReadingTapTracker =
+    EditorHeaderReadingTapTracker(
+      touchSlopPx = 8f,
+      maxTapDistancePx = 20f,
+      doubleTapToEditEnabled = doubleTapToEditEnabled,
+    )
+
+  private fun scheduleFirstTap(tracker: EditorHeaderReadingTapTracker, startMillis: Long) {
+    tracker.onDown(position = Offset.Zero, offset = 0, timeMillis = startMillis)
+    tracker.onUp(position = Offset.Zero, offset = 0, timeMillis = startMillis + 10)
+  }
+}

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarInputStateTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarInputStateTest.kt
@@ -7,6 +7,24 @@ import kotlin.test.assertEquals
 
 class ToolbarInputStateTest {
   @Test
+  fun keyboard_dismiss_action_enters_reading_mode() {
+    val state = EditorToolbarInputState()
+    val keyboardVisible = toolbarInputEnvironment(imeBottom = 320.dp)
+    state.onEnvironmentChanged(keyboardVisible)
+
+    val effects = state.dispatch(ToolbarIntent.DismissInput, keyboardVisible)
+
+    assertEquals(
+      listOf(
+        EditorInputEffect.HideKeyboard,
+        EditorInputEffect.ClearFocus,
+        EditorInputEffect.EnterReadingMode,
+      ),
+      effects,
+    )
+  }
+
+  @Test
   fun hide_input_closes_panel_and_keyboard_without_restoring_or_clearing_focus() {
     val state = EditorToolbarInputState()
     val keyboardVisible = toolbarInputEnvironment(imeBottom = 320.dp)
@@ -202,7 +220,7 @@ class ToolbarInputStateTest {
   }
 
   @Test
-  fun system_ime_dismiss_while_editor_focused_clears_focus() {
+  fun system_ime_dismiss_while_editor_focused_enters_reading_mode() {
     val state = EditorToolbarInputState()
     val keyboardVisible = toolbarInputEnvironment(imeBottom = 320.dp)
 
@@ -219,15 +237,15 @@ class ToolbarInputStateTest {
         )
       )
 
-    assertEquals(listOf(EditorInputEffect.ClearFocus), effects)
+    assertEquals(listOf(EditorInputEffect.EnterReadingMode), effects)
     assertEquals(null, state.keyboardRestoreInset)
     assertEquals(0.dp, state.rememberedKeyboardInset)
     assertEquals(0.dp, state.retainedKeyboardInset())
 
-    val focusCleared =
+    val focusLost =
       state.onEnvironmentChanged(toolbarInputEnvironment(focused = false, imeBottom = 0.dp))
 
-    assertEquals(emptyList(), focusCleared)
+    assertEquals(emptyList(), focusLost)
   }
 
   @Test
@@ -321,7 +339,7 @@ class ToolbarInputStateTest {
   }
 
   @Test
-  fun system_ime_dismiss_during_keyboard_restore_clears_focus_and_restore() {
+  fun system_ime_dismiss_after_keyboard_restore_enters_reading_mode() {
     val state = EditorToolbarInputState()
     val keyboardVisible = toolbarInputEnvironment(imeBottom = 320.dp)
 
@@ -343,7 +361,7 @@ class ToolbarInputStateTest {
 
     val effects = state.onEnvironmentChanged(keyboardHidden)
 
-    assertEquals(listOf(EditorInputEffect.ClearFocus), effects)
+    assertEquals(listOf(EditorInputEffect.EnterReadingMode), effects)
     assertEquals(null, state.keyboardRestoreInset)
     assertEquals(0.dp, state.rememberedKeyboardInset)
   }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/EditorTapHintDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/EditorTapHintDesktopTest.kt
@@ -1,0 +1,108 @@
+package co.typie.editor
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import co.typie.editor.scroll.EditorVisibleArea
+import co.typie.ui.theme.LocalThemeMode
+import co.typie.ui.theme.ResolvedThemeMode
+import dev.chrisbanes.haze.HazeState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.flow.MutableSharedFlow
+
+@OptIn(ExperimentalTestApi::class)
+class EditorTapHintDesktopTest {
+  @Test
+  fun hintFadesInStaysVisibleAndFadesOutWithPreviewTimings() = runComposeUiTest {
+    mainClock.autoAdvance = false
+    val events = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    setHintContent(events)
+
+    onNodeWithTag(EditorTapHintTestTag).assertDoesNotExist()
+    runOnIdle { assertTrue(events.tryEmit(Unit)) }
+
+    mainClock.advanceTimeBy(EditorTapHintFadeMillis / 2L)
+    onNodeWithTag(EditorTapHintTestTag)
+      .assertExists()
+      .assert(SemanticsMatcher.expectValue(SemanticsProperties.LiveRegion, LiveRegionMode.Polite))
+
+    mainClock.advanceTimeBy(EditorTapHintFadeMillis / 2L + EditorTapHintVisibleMillis)
+    onNodeWithTag(EditorTapHintTestTag).assertExists()
+
+    mainClock.advanceTimeBy(EditorTapHintFadeMillis + 32L)
+    onNodeWithTag(EditorTapHintTestTag).assertDoesNotExist()
+  }
+
+  @Test
+  fun repeatedEventExtendsDwellWithoutDisappearingAndRestarting() = runComposeUiTest {
+    mainClock.autoAdvance = false
+    val events = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    setHintContent(events)
+
+    runOnIdle { assertTrue(events.tryEmit(Unit)) }
+    mainClock.advanceTimeBy(EditorTapHintFadeMillis + 800L)
+    runOnIdle { assertTrue(events.tryEmit(Unit)) }
+
+    mainClock.advanceTimeBy(400L)
+    onNodeWithTag(EditorTapHintTestTag).assertExists()
+
+    mainClock.advanceTimeBy(EditorTapHintVisibleMillis + EditorTapHintFadeMillis + 1L)
+    onNodeWithTag(EditorTapHintTestTag).assertDoesNotExist()
+  }
+
+  @Test
+  fun readingHintIsCenteredInsideEditorVisibleAreaNotTheFullViewport() = runComposeUiTest {
+    mainClock.autoAdvance = false
+    val events = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    setHintContent(
+      events = events,
+      visibleArea =
+        EditorVisibleArea(
+          viewport = Size(width = 400f, height = 700f),
+          topInset = 100f,
+          bottomOcclusionInset = 200f,
+        ),
+    )
+
+    runOnIdle { assertTrue(events.tryEmit(Unit)) }
+    mainClock.advanceTimeBy(EditorTapHintFadeMillis.toLong())
+
+    val centerY = onNodeWithTag(EditorTapHintTestTag).fetchSemanticsNode().boundsInRoot.center.y
+    assertEquals(300f, centerY, absoluteTolerance = 0.5f)
+  }
+
+  private fun androidx.compose.ui.test.ComposeUiTest.setHintContent(
+    events: MutableSharedFlow<Unit>,
+    visibleArea: EditorVisibleArea = EditorVisibleArea(viewport = Size(width = 400f, height = 700f)),
+  ) {
+    setContent {
+      CompositionLocalProvider(
+        LocalDensity provides Density(1f),
+        LocalThemeMode provides ResolvedThemeMode.Light,
+      ) {
+        Box(Modifier.size(width = 400.dp, height = 700.dp)) {
+          EditorTapHintOverlay(
+            events = events,
+            text = "편집하려면 더블 탭",
+            hazeState = HazeState(),
+            visibleArea = visibleArea,
+          )
+        }
+      }
+    }
+  }
+}

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/interaction/EditorInteractionsDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/interaction/EditorInteractionsDesktopTest.kt
@@ -1955,6 +1955,10 @@ class EditorInteractionsDesktopTest {
       pointerStreamCancelCount += 1
     }
 
+    override fun scheduleTapSequenceConfirmation(onConfirmed: () -> Unit) = Unit
+
+    override fun cancelTapSequenceConfirmation() = Unit
+
     override fun scheduleLongPressDispatch(
       pointerId: Long,
       position: Offset,
@@ -1968,6 +1972,10 @@ class EditorInteractionsDesktopTest {
     }
 
     override fun launchInteraction(block: suspend () -> Unit) = Unit
+
+    override fun requestEditing(editor: Editor): Boolean = false
+
+    override fun showReadingEditHint() = Unit
 
     override fun requestFocus(editor: Editor): Boolean = false
 

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/EditorScreenReadingModeDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/EditorScreenReadingModeDesktopTest.kt
@@ -1,0 +1,111 @@
+package co.typie.screen.editor.editor
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runComposeUiTest
+import co.typie.screen.editor.editor.state.EditorInputEffect
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNotSame
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class EditorScreenReadingModeDesktopTest {
+  @Test
+  fun newEntityStartsInReadingModeAfterThePreviousEntityWasEditing() = runComposeUiTest {
+    val entityId = mutableStateOf("A")
+    lateinit var state: EditorScreenEditingState
+
+    setContent { state = rememberEditorScreenEditingState(entityId.value) }
+    runOnIdle { state.enterEditing() }
+    waitForIdle()
+
+    lateinit var previousState: EditorScreenEditingState
+    runOnIdle {
+      assertTrue(state.editing)
+      previousState = state
+      entityId.value = "B"
+    }
+    waitForIdle()
+
+    runOnIdle {
+      assertNotSame(previousState, state)
+      assertFalse(state.editing)
+    }
+  }
+
+  @Test
+  fun hideKeyboardAndClearFocusDoNotEnterReadingMode() {
+    val state = EditorScreenEditingState().apply { enterEditing() }
+    var keyboardHidden = false
+    var focusCleared = false
+    var readingModeRequested = false
+
+    performEditorInputEffects(
+      effects = listOf(EditorInputEffect.HideKeyboard, EditorInputEffect.ClearFocus),
+      showKeyboard = {},
+      hideKeyboard = { keyboardHidden = true },
+      requestFocus = {},
+      clearFocus = { focusCleared = true },
+      enterReadingMode = { readingModeRequested = true },
+    )
+
+    assertTrue(keyboardHidden)
+    assertTrue(focusCleared)
+    assertFalse(readingModeRequested)
+    assertTrue(state.editing)
+  }
+
+  @Test
+  fun explicitInputEffectRequestsTheCoordinatedReadingModeTransition() {
+    var readingModeRequested = false
+
+    performEditorInputEffects(
+      effects = listOf(EditorInputEffect.EnterReadingMode),
+      showKeyboard = {},
+      hideKeyboard = {},
+      requestFocus = {},
+      clearFocus = {},
+      enterReadingMode = { readingModeRequested = true },
+    )
+
+    assertTrue(readingModeRequested)
+  }
+
+  @Test
+  fun editingPromotionInvalidatesAnInFlightReadingTransition() {
+    val state = EditorScreenEditingState().apply { enterEditing() }
+    val transition = assertNotNull(state.beginReadingTransition())
+
+    state.enterEditing()
+
+    assertFalse(state.completeReadingTransition(transition))
+    assertTrue(state.editing)
+  }
+
+  @Test
+  fun readingTransitionDeduplicatesAndCompletesOnlyTheCurrentToken() {
+    val state = EditorScreenEditingState().apply { enterEditing() }
+    val transition = assertNotNull(state.beginReadingTransition())
+
+    assertNull(state.beginReadingTransition())
+    assertTrue(state.isReadingTransitionCurrent(transition))
+    assertTrue(state.completeReadingTransition(transition))
+    assertFalse(state.editing)
+    assertFalse(state.completeReadingTransition(transition))
+  }
+
+  @Test
+  fun capabilityDowngradeClosesDirectEditingBeforeReadingCleanupRuns() {
+    val state = EditorScreenEditingState().apply { enterEditing() }
+
+    assertTrue(state.directEditingEnabled(readOnly = false))
+    assertFalse(state.directEditingEnabled(readOnly = true))
+    assertTrue(state.editing)
+
+    state.enterReading()
+    assertFalse(state.editing)
+  }
+}

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/header/EditorHeaderDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/header/EditorHeaderDesktopTest.kt
@@ -5,17 +5,21 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.click
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performKeyInput
 import androidx.compose.ui.test.performTextInputSelection
+import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.unit.Density
@@ -25,10 +29,263 @@ import co.typie.ui.theme.LocalThemeMode
 import co.typie.ui.theme.ResolvedThemeMode
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalTestApi::class)
 class EditorHeaderDesktopTest {
+  @Test
+  fun readingHeaderKeepsSelectionSemanticsWithoutTextMutation() = runComposeUiTest {
+    setContent {
+      CompositionLocalProvider(
+        LocalDensity provides Density(1f),
+        LocalThemeMode provides ResolvedThemeMode.Light,
+      ) {
+        EditorHeader(
+          title = Title,
+          subtitle = "",
+          loading = false,
+          editing = false,
+          topInset = 0.dp,
+          onTitleChange = {},
+          onSubtitleChange = {},
+          onTitleFocused = {},
+          onSubtitleFocused = {},
+          onHeightChanged = {},
+          onEnterDocument = {},
+        )
+      }
+    }
+    waitForIdle()
+
+    val field =
+      onAllNodes(hasText(Title), useUnmergedTree = true).fetchSemanticsNodes().single {
+        SemanticsProperties.TextSelectionRange in it.config
+      }
+
+    assertTrue(SemanticsActions.SetSelection in field.config)
+    assertFalse(SemanticsActions.SetText in field.config)
+    assertTrue(SemanticsActions.CustomActions in field.config)
+  }
+
+  @Test
+  fun readingTitleAccessibilityEditActionPromotesAndFocusesTheField() = runComposeUiTest {
+    val editing = mutableStateOf(false)
+    var promotionCount = 0
+    setContent {
+      CompositionLocalProvider(
+        LocalDensity provides Density(1f),
+        LocalThemeMode provides ResolvedThemeMode.Light,
+      ) {
+        EditorHeader(
+          title = Title,
+          subtitle = "",
+          loading = false,
+          editing = editing.value,
+          topInset = 0.dp,
+          onTitleChange = {},
+          onSubtitleChange = {},
+          onTitleFocused = {},
+          onSubtitleFocused = {},
+          onHeightChanged = {},
+          onEnterDocument = {},
+          onRequestEditing = {
+            promotionCount += 1
+            editing.value = true
+            true
+          },
+        )
+      }
+    }
+    waitForIdle()
+
+    val readingTitle =
+      onAllNodes(hasText(Title), useUnmergedTree = true).fetchSemanticsNodes().single {
+        SemanticsProperties.TextSelectionRange in it.config
+      }
+    runOnIdle { assertTrue(readingTitle.config[SemanticsActions.CustomActions].single().action()) }
+    waitForIdle()
+
+    assertEquals(1, promotionCount)
+    onNode(hasText(Title) and hasSetTextAction(), useUnmergedTree = true).assertIsFocused()
+  }
+
+  @Test
+  fun readingTitleDoubleTapPromotesOnceAndPlacesCollapsedSelection() = runComposeUiTest {
+    val editing = mutableStateOf(false)
+    var promotionCount = 0
+    setContent {
+      CompositionLocalProvider(
+        LocalDensity provides Density(1f),
+        LocalThemeMode provides ResolvedThemeMode.Light,
+      ) {
+        Box(Modifier.width(240.dp)) {
+          EditorHeader(
+            title = Title,
+            subtitle = "",
+            loading = false,
+            editing = editing.value,
+            topInset = 0.dp,
+            onTitleChange = {},
+            onSubtitleChange = {},
+            onTitleFocused = {},
+            onSubtitleFocused = {},
+            onHeightChanged = {},
+            onEnterDocument = {},
+            onRequestEditing = {
+              promotionCount += 1
+              editing.value = true
+              true
+            },
+          )
+        }
+      }
+    }
+    waitForIdle()
+
+    val readingTitle = onNode(hasText(Title), useUnmergedTree = true)
+    val readingTitleBounds = readingTitle.fetchSemanticsNode().boundsInRoot
+    readingTitle.performTouchInput {
+      val position = Offset(x = readingTitleBounds.width * 0.4f, y = readingTitleBounds.height / 2f)
+      down(position)
+      advanceEventTime(10)
+      up()
+      advanceEventTime(100)
+      down(position)
+      advanceEventTime(10)
+      up()
+    }
+    waitForIdle()
+
+    val editableTitle =
+      onNode(hasText(Title) and hasSetTextAction(), useUnmergedTree = true).assertIsFocused()
+    val selection =
+      editableTitle.fetchSemanticsNode().config[SemanticsProperties.TextSelectionRange]
+    assertEquals(1, promotionCount)
+    assertTrue(selection.collapsed)
+    assertTrue(selection.start in 1 until Title.length)
+  }
+
+  @Test
+  fun readingTitleSingleTapPromotesWhenDoubleTapSettingIsDisabled() = runComposeUiTest {
+    val editing = mutableStateOf(false)
+    var promotionCount = 0
+    setContent {
+      CompositionLocalProvider(
+        LocalDensity provides Density(1f),
+        LocalThemeMode provides ResolvedThemeMode.Light,
+      ) {
+        EditorHeader(
+          title = Title,
+          subtitle = "",
+          loading = false,
+          editing = editing.value,
+          doubleTapToEditEnabled = false,
+          topInset = 0.dp,
+          onTitleChange = {},
+          onSubtitleChange = {},
+          onTitleFocused = {},
+          onSubtitleFocused = {},
+          onHeightChanged = {},
+          onEnterDocument = {},
+          onRequestEditing = {
+            promotionCount += 1
+            editing.value = true
+            true
+          },
+        )
+      }
+    }
+    waitForIdle()
+
+    onNode(hasText(Title), useUnmergedTree = true).performTouchInput { click(center) }
+    waitForIdle()
+
+    assertEquals(1, promotionCount)
+    onNode(hasText(Title) and hasSetTextAction(), useUnmergedTree = true).assertIsFocused()
+  }
+
+  @Test
+  fun editorReplacementClearsThePreviousHeaderReadingTap() = runComposeUiTest {
+    val readingTapIdentity = mutableStateOf<Any>(Any())
+    var promotionCount = 0
+    setContent {
+      CompositionLocalProvider(
+        LocalDensity provides Density(1f),
+        LocalThemeMode provides ResolvedThemeMode.Light,
+      ) {
+        EditorHeader(
+          title = Title,
+          subtitle = "",
+          loading = false,
+          editing = false,
+          readingTapIdentity = readingTapIdentity.value,
+          topInset = 0.dp,
+          onTitleChange = {},
+          onSubtitleChange = {},
+          onTitleFocused = {},
+          onSubtitleFocused = {},
+          onHeightChanged = {},
+          onEnterDocument = {},
+          onRequestEditing = {
+            promotionCount += 1
+            true
+          },
+        )
+      }
+    }
+    waitForIdle()
+
+    onNode(hasText(Title), useUnmergedTree = true).performTouchInput { click(center) }
+    runOnIdle { readingTapIdentity.value = Any() }
+    waitForIdle()
+    onNode(hasText(Title), useUnmergedTree = true).performTouchInput { click(center) }
+    waitForIdle()
+
+    assertEquals(0, promotionCount)
+  }
+
+  @Test
+  fun readingCleanupCollapsesExistingHeaderSelection() = runComposeUiTest {
+    val editing = mutableStateOf(true)
+    val cleanupRequest = mutableStateOf(0)
+    setContent {
+      CompositionLocalProvider(
+        LocalDensity provides Density(1f),
+        LocalThemeMode provides ResolvedThemeMode.Light,
+      ) {
+        EditorHeader(
+          title = Title,
+          subtitle = SubtitleWrappedText,
+          loading = false,
+          editing = editing.value,
+          readingModeCleanupRequest = cleanupRequest.value,
+          topInset = 0.dp,
+          onTitleChange = {},
+          onSubtitleChange = {},
+          onTitleFocused = {},
+          onSubtitleFocused = {},
+          onHeightChanged = {},
+          onEnterDocument = {},
+        )
+      }
+    }
+    waitForIdle()
+
+    onNode(hasText(Title) and hasSetTextAction(), useUnmergedTree = true)
+      .performTextInputSelection(TextRange(1, 5))
+    editing.value = false
+    cleanupRequest.value += 1
+    waitForIdle()
+
+    val field =
+      onAllNodes(hasText(Title), useUnmergedTree = true).fetchSemanticsNodes().single {
+        SemanticsProperties.TextSelectionRange in it.config
+      }
+    assertTrue(field.config[SemanticsProperties.TextSelectionRange].collapsed)
+  }
+
   @Test
   fun verticalArrowsExitOnlyWhenNativeMovementStaysOnVisualLine() = runComposeUiTest {
     val bodyEntries = mutableStateOf(0)

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayoutDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayoutDesktopTest.kt
@@ -615,6 +615,31 @@ class EditorScreenLayoutDesktopTest {
   }
 
   @Test
+  fun readingViewportExposesAnAccessibilityEditAction() = runComposeUiTest {
+    val fixture = ViewportOverlayFixture()
+    var requestCount = 0
+    setViewportOverlayContent(
+      fixture = fixture,
+      onRequestEditing = {
+        requestCount += 1
+        true
+      },
+    )
+
+    val node =
+      onAllNodes(
+          SemanticsMatcher("has an edit custom action") {
+            SemanticsActions.CustomActions in it.config
+          }
+        )
+        .fetchSemanticsNodes()
+        .single()
+    runOnIdle { assertTrue(node.config[SemanticsActions.CustomActions].single().action()) }
+
+    assertEquals(1, requestCount)
+  }
+
+  @Test
   fun viewportOverlayConsumedDownDoesNotStartEditorGesture() = runComposeUiTest {
     val fixture = ViewportOverlayFixture()
     setViewportOverlayContent(fixture = fixture, viewportOverlay = { ViewportOverlayTarget() })
@@ -1128,6 +1153,7 @@ class EditorScreenLayoutDesktopTest {
     fixture: ViewportOverlayFixture,
     viewportOverlay: @Composable BoxScope.() -> Unit = {},
     overlay: @Composable () -> Unit = {},
+    onRequestEditing: (() -> Boolean)? = null,
   ) {
     setContent {
       val coroutineScope = rememberCoroutineScope()
@@ -1150,6 +1176,7 @@ class EditorScreenLayoutDesktopTest {
           viewportContentWidth = TestViewportSize.width,
           viewportScrollReconcileMode = EditorViewportScrollReconcileMode.Disabled,
           onEditorPointerInput = { fixture.editorPointerInputCount += 1 },
+          onRequestEditing = onRequestEditing,
           onMeasuredViewportSizeChange = {},
           header = {},
           body = { Box(Modifier.fillMaxWidth().height(800.dp)) },

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorContextMenuOverlayDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorContextMenuOverlayDesktopTest.kt
@@ -76,14 +76,26 @@ class EditorContextMenuOverlayDesktopTest {
   }
 
   @Test
-  fun readOnlyMenuHidesCutAndPasteButKeepsCopyAndExpansion() = runComposeUiTest {
-    setMenuContent(editorReadOnly = true)
+  fun disabledMutationMenuHidesCutAndPasteButKeepsCopyAndExpansion() = runComposeUiTest {
+    setMenuContent(editorMutationEnabled = false)
 
     waitForIdle()
 
     assertEquals(1, onAllNodesWithText("복사").fetchSemanticsNodes().size)
     assertEquals(0, onAllNodesWithText("잘라내기").fetchSemanticsNodes().size)
     assertEquals(0, onAllNodesWithText("붙여넣기").fetchSemanticsNodes().size)
+    assertEquals(1, onAllNodesWithText("선택 확장").fetchSemanticsNodes().size)
+  }
+
+  @Test
+  fun enabledMutationMenuKeepsCompletePrimaryMenu() = runComposeUiTest {
+    setMenuContent(editorMutationEnabled = true)
+
+    waitForIdle()
+
+    assertEquals(1, onAllNodesWithText("복사").fetchSemanticsNodes().size)
+    assertEquals(1, onAllNodesWithText("잘라내기").fetchSemanticsNodes().size)
+    assertEquals(1, onAllNodesWithText("붙여넣기").fetchSemanticsNodes().size)
     assertEquals(1, onAllNodesWithText("선택 확장").fetchSemanticsNodes().size)
   }
 
@@ -139,7 +151,7 @@ class EditorContextMenuOverlayDesktopTest {
 
   private fun androidx.compose.ui.test.ComposeUiTest.setMenuContent(
     showCopyCutActions: Boolean = true,
-    editorReadOnly: Boolean = false,
+    editorMutationEnabled: Boolean = true,
     onCopy: () -> Unit = {},
     onCut: () -> Unit = {},
     onPaste: () -> Unit = {},
@@ -161,7 +173,7 @@ class EditorContextMenuOverlayDesktopTest {
           overlaySize = Size(width = 400f, height = 700f),
           visibleArea = EditorVisibleArea(viewport = Size(width = 400f, height = 700f)),
           showCopyCutActions = showCopyCutActions,
-          editorReadOnly = editorReadOnly,
+          editorMutationEnabled = editorMutationEnabled,
           availableExpansionUnits = availableExpansionUnits,
           onCopy = onCopy,
           onCut = onCut,

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/topbar/EditorScreenTopBarDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/topbar/EditorScreenTopBarDesktopTest.kt
@@ -1,0 +1,215 @@
+package co.typie.screen.editor.editor.topbar
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.hasAnyDescendant
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import co.typie.navigation.LocalRoute
+import co.typie.navigation.Nav
+import co.typie.navigation.Navigator
+import co.typie.route.Route
+import co.typie.screen.editor.editor.toolbar.EditorToolbarDebugOverlays
+import co.typie.screen.editor.editor.toolbar.EditorToolbarToolAction
+import co.typie.ui.component.popover.LocalPopoverOverlayState
+import co.typie.ui.component.popover.PopoverOverlay
+import co.typie.ui.component.popover.PopoverOverlayState
+import co.typie.ui.component.topbar.LocalTopBarState
+import co.typie.ui.component.topbar.TopBar
+import co.typie.ui.component.topbar.TopBarDefaults
+import co.typie.ui.component.topbar.TopBarState
+import co.typie.ui.theme.LightAppShadows
+import co.typie.ui.theme.LightColors
+import co.typie.ui.theme.LocalAppColors
+import co.typie.ui.theme.LocalAppShadows
+import co.typie.ui.theme.LocalThemeMode
+import co.typie.ui.theme.ResolvedThemeMode
+import dev.chrisbanes.haze.blur.HazeBlurStyle
+import dev.chrisbanes.haze.blur.LocalHazeBlurStyle
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class EditorScreenTopBarDesktopTest {
+  @Test
+  fun readingShowsSearchAndToolsAndDispatchesEveryToolAction() = runComposeUiTest {
+    val actions = mutableStateListOf<EditorToolbarToolAction>()
+    val overlayState = PopoverOverlayState()
+
+    setTopBarContent(editing = false, overlayState = overlayState, onToolAction = actions::add)
+
+    onNodeWithContentDescription(SearchDescription).assertExists()
+    onNodeWithContentDescription(ToolsDescription).assertExists()
+    onNodeWithContentDescription(EnterReadingDescription).assertDoesNotExist()
+
+    onNodeWithContentDescription(SearchDescription).performClick()
+    waitUntil { actions.lastOrNull() == EditorToolbarToolAction.Search }
+
+    val expectedItems =
+      listOf(
+        "노트" to EditorToolbarToolAction.RelatedNotes,
+        "코멘트" to EditorToolbarToolAction.Comment,
+        "맞춤법 검사" to EditorToolbarToolAction.Spellcheck,
+        "AI 피드백" to EditorToolbarToolAction.AiFeedback,
+        "타임라인" to EditorToolbarToolAction.Timeline,
+      )
+    expectedItems.forEach { (label, action) ->
+      openTools(overlayState)
+      onAllNodes(hasClickAction() and hasAnyDescendant(hasText(label)), useUnmergedTree = true)[0]
+        .performClick()
+      waitUntil { actions.lastOrNull() == action }
+    }
+
+    assertEquals(
+      listOf(EditorToolbarToolAction.Search) + expectedItems.map { it.second },
+      actions.toList(),
+    )
+    onNodeWithText("뷰포트 기준선 켜기", useUnmergedTree = true).assertDoesNotExist()
+  }
+
+  @Test
+  fun editingShowsOnlyReadingModeButton() = runComposeUiTest {
+    var enterReadingCount = 0
+
+    setTopBarContent(editing = true, onEnterReadingMode = { enterReadingCount += 1 })
+
+    onNodeWithContentDescription(EnterReadingDescription).assertExists().performClick()
+    waitUntil { enterReadingCount == 1 }
+    onNodeWithContentDescription(SearchDescription).assertDoesNotExist()
+    onNodeWithContentDescription(ToolsDescription).assertDoesNotExist()
+  }
+
+  @Test
+  fun debugToolsAppearOnlyWhenDebugMetadataIsSupplied() = runComposeUiTest {
+    val actions = mutableStateListOf<EditorToolbarToolAction>()
+    val overlayState = PopoverOverlayState()
+
+    setTopBarContent(
+      editing = false,
+      overlayState = overlayState,
+      debugOverlays =
+        EditorToolbarDebugOverlays(
+          viewportVisible = false,
+          bodyVisible = true,
+          surfaceVisible = false,
+          inputLogAvailable = true,
+        ),
+      onToolAction = actions::add,
+    )
+
+    val expectedItems =
+      listOf(
+        "뷰포트 기준선 켜기" to EditorToolbarToolAction.DebugViewportOverlay,
+        "바디 영역 끄기" to EditorToolbarToolAction.DebugBodyOverlay,
+        "페이지 표면 켜기" to EditorToolbarToolAction.DebugSurfaceOverlay,
+        "입력 로그 보내기" to EditorToolbarToolAction.SendInputLog,
+      )
+    expectedItems.forEach { (label, action) ->
+      openTools(overlayState)
+      onAllNodes(hasClickAction() and hasAnyDescendant(hasText(label)), useUnmergedTree = true)[0]
+        .performClick()
+      waitUntil { actions.lastOrNull() == action }
+    }
+
+    assertEquals(expectedItems.map { it.second }, actions.toList())
+  }
+
+  @Test
+  fun readingTitleUsesAvailableSpaceWithoutIntersectingTrailingButtons() = runComposeUiTest {
+    setTopBarContent(editing = false, width = 360.dp)
+
+    val rootBounds = onNodeWithTag(RootTag).fetchSemanticsNode().boundsInRoot
+    val titleBounds = onNodeWithTag(TitleTag).fetchSemanticsNode().boundsInRoot
+    val searchBounds =
+      onNodeWithContentDescription(SearchDescription).fetchSemanticsNode().boundsInRoot
+    val toolsBounds =
+      onNodeWithContentDescription(ToolsDescription).fetchSemanticsNode().boundsInRoot
+
+    assertTrue(titleBounds.center.x < rootBounds.center.x)
+    assertFalse(titleBounds.intersects(searchBounds))
+    assertFalse(titleBounds.intersects(toolsBounds))
+  }
+
+  private fun androidx.compose.ui.test.ComposeUiTest.openTools(overlayState: PopoverOverlayState) {
+    onNodeWithContentDescription(ToolsDescription).performTouchInput { click() }
+    waitUntil { overlayState.acceptsInput }
+  }
+
+  private fun androidx.compose.ui.test.ComposeUiTest.setTopBarContent(
+    editing: Boolean,
+    width: androidx.compose.ui.unit.Dp = 400.dp,
+    overlayState: PopoverOverlayState = PopoverOverlayState(),
+    debugOverlays: EditorToolbarDebugOverlays? = null,
+    onToolAction: (EditorToolbarToolAction) -> Unit = {},
+    onEnterReadingMode: suspend () -> Unit = {},
+  ) {
+    setContent {
+      TopBarTestTheme {
+        val topBarState = remember { TopBarState() }
+        CompositionLocalProvider(
+          Nav provides Navigator(Route.Home),
+          LocalRoute provides Route.Editor("document-id"),
+          LocalTopBarState provides topBarState,
+          LocalPopoverOverlayState provides overlayState,
+        ) {
+          Box(Modifier.size(width = width, height = 700.dp).testTag(RootTag)) {
+            EditorScreenTopBar(
+              editing = editing,
+              debugOverlays = debugOverlays,
+              documentButton = { modifier ->
+                Box(modifier.height(TopBarDefaults.TitleHeight).testTag(TitleTag))
+              },
+              onToolAction = onToolAction,
+              onEnterReadingMode = onEnterReadingMode,
+            )
+            TopBar(state = topBarState)
+            PopoverOverlay(state = overlayState)
+          }
+        }
+      }
+    }
+    waitForIdle()
+  }
+
+  @Composable
+  private fun TopBarTestTheme(content: @Composable () -> Unit) {
+    CompositionLocalProvider(
+      LocalAppColors provides LightColors,
+      LocalAppShadows provides LightAppShadows,
+      LocalThemeMode provides ResolvedThemeMode.Light,
+      LocalHazeBlurStyle provides
+        HazeBlurStyle(blurRadius = 20.dp, noiseFactor = 0f, colorEffects = listOf()),
+      content = content,
+    )
+  }
+
+  private companion object {
+    const val RootTag = "editor-top-bar-root"
+    const val TitleTag = "editor-top-bar-title"
+    const val SearchDescription = "검색"
+    const val ToolsDescription = "도구"
+    const val EnterReadingDescription = "읽기 모드로 전환"
+  }
+}
+
+private fun Rect.intersects(other: Rect): Boolean =
+  left < other.right && right > other.left && top < other.bottom && bottom > other.top


### PR DESCRIPTION
## 주요 동작

| 상황 | 동작 |
| --- | --- |
| 문서 열기 | 읽기 모드로 시작하며 keyboard를 열지 않음 |
| 읽기 모드 일반 싱글 탭 | selection/node 선택을 적용하고 편집 모드나 keyboard는 열지 않음 |
| 읽기 모드 더블 탭 | 두 번째 탭 위치에 cursor를 두고 편집 모드와 keyboard를 활성화 |
| 더블 탭 설정 끔 | 읽기 모드 싱글 탭으로 편집 시작 |
| 빈 문서 | 설정과 관계없이 싱글 탭으로 편집 시작 |
| 읽기 모드 롱프레스 | 플랫폼 공통으로 단어 선택 |
| selection handle | 읽기 모드에서도 표시하고 조작 가능 |
| table cell selection | 읽기 모드에서도 selection과 handle 표시 |
| 읽기 모드 context menu | 복사와 선택 확장은 유지하고 잘라내기/붙여넣기는 숨김 |
| keyboard 닫기 | 현재 도구 세션을 유지하면서 읽기 모드로 전환 |
| 편집 모드 체크 버튼 | composition과 draft를 정리한 뒤 읽기 모드로 전환 |
| 읽기 모드 top bar | 검색 버튼과 기타 도구 popover 표시 |

## 변경 사항

- 문서별 읽기/편집 상태와 취소 가능한 읽기 전환을 추가했습니다.
- 읽기 모드 진입 시 IME composition, focus, toolbar input, pointer interaction을 정리하되 본문 selection은 유지합니다.
- 읽기 모드 싱글 탭은 selection을 적용하고, 더블 탭은 편집 모드의 일반 싱글 탭으로 승격합니다.
- 제목과 부제목을 읽기 모드에서 read-only text field로 유지해 native selection과 롱프레스를 지원합니다.
- context menu와 편집 힌트를 후속 탭 가능성이 끝난 뒤 표시하도록 탭 시퀀스 확정 단계를 추가했습니다.
- 새 pointer down, drag, long press, handle drag, resize, mode/editor 변경 시 오래된 표시 예약을 취소합니다.
- 읽기 모드에서도 text/table selection handle과 copy context menu를 유지합니다.
- table resize, cut/paste, attachment import 등 mutation UI와 작업은 편집 모드에서만 허용합니다.
- 검색 결과 바꾸기와 맞춤법 제안 적용은 편집 모드로 승격한 뒤 최신 editing session인지 다시 확인하고 commit합니다.
- 읽기 모드 top bar에 검색과 도구 popover를 추가하고, 편집 모드에는 반전 색상의 읽기 모드 버튼을 표시합니다.
- 공용 haze tap hint를 추가하고 editor preview와 읽기 모드에서 공유합니다.
- `편집하려면 더블 탭` 설정을 추가했으며 기본값은 켜짐입니다.
- 본문과 제목/부제목에 접근성용 `편집` action을 추가했습니다.