### PR TITLE
앱 편집 잠금 문서의 인터랙션 개선

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionEffects.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionEffects.kt
@@ -22,7 +22,7 @@ internal interface EditorInteractionEffects {
 
   fun requestEditing(editor: Editor): Boolean
 
-  fun showReadingEditHint()
+  fun showReadingTapHint()
 
   fun requestFocus(editor: Editor): Boolean
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionScope.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionScope.kt
@@ -45,7 +45,7 @@ internal class EditorInteractionScope(
   private var doubleTapToEditEnabled: () -> Boolean = { true }
   private var editingSnapshot: Boolean? = null
   private var onRequestEditing: ((Editor) -> Boolean)? = null
-  private var onShowReadingEditHint: (() -> Unit)? = null
+  private var onShowReadingTapHint: (() -> Unit)? = null
   private var tapDispatchJob: Job? = null
   private var tapSequenceConfirmationJob: Job? = null
   private var longPressDispatchJob: Job? = null
@@ -88,7 +88,7 @@ internal class EditorInteractionScope(
     editing: () -> Boolean = { true },
     doubleTapToEditEnabled: () -> Boolean = { true },
     onRequestEditing: (Editor) -> Boolean = { false },
-    onShowReadingEditHint: () -> Unit = {},
+    onShowReadingTapHint: () -> Unit = {},
     onSelectionHaptic: () -> Unit,
     onRequestSoftwareKeyboard: () -> Unit,
   ) {
@@ -122,7 +122,7 @@ internal class EditorInteractionScope(
     this.doubleTapToEditEnabled = doubleTapToEditEnabled
     this.editingSnapshot = nextEditing
     this.onRequestEditing = onRequestEditing
-    this.onShowReadingEditHint = onShowReadingEditHint
+    this.onShowReadingTapHint = onShowReadingTapHint
     outsidePageTapEnabled = layoutSpec == null || layoutSpec is EditorDocumentLayoutSpec.Continuous
     semantics.viewportZoom.configure(viewportZoomConfig)
   }
@@ -153,7 +153,7 @@ internal class EditorInteractionScope(
     doubleTapToEditEnabled = { true }
     editingSnapshot = null
     onRequestEditing = null
-    onShowReadingEditHint = null
+    onShowReadingTapHint = null
     outsidePageTapEnabled = true
     scrollGestureLockState = null
   }
@@ -303,8 +303,8 @@ internal class EditorInteractionScope(
 
   override fun requestEditing(editor: Editor): Boolean = onRequestEditing?.invoke(editor) == true
 
-  override fun showReadingEditHint() {
-    onShowReadingEditHint?.invoke()
+  override fun showReadingTapHint() {
+    onShowReadingTapHint?.invoke()
   }
 
   override fun requestFocus(editor: Editor): Boolean = editor.focus()

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorTapGesture.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorTapGesture.kt
@@ -262,8 +262,8 @@ internal class EditorTapGesture(
       return
     }
     pendingPresentation = null
-    if (pending.showReadingHint && !context.readOnly) {
-      context.effects.showReadingEditHint()
+    if (pending.showReadingHint) {
+      context.effects.showReadingTapHint()
     }
     if (pending.showContextMenu) {
       context.semantics.contextMenu.show(pending.editor.state)
@@ -338,7 +338,24 @@ internal fun EditorTapGesture.handlePointerDown(
   )
   cancelPendingPresentation(context = context)
   context.semantics.contextMenu.hide()
-  if (!context.editing) {
+  val directEditingEnabled = context.editing && !context.readOnly
+  if (tapCountForActivePointer == 2 && (directEditingEnabled || context.readOnly)) {
+    markTapDispatched()
+    context.effects.cancelTapDispatch()
+    dispatchSelectionTap(
+      position = position,
+      clickCount = 2,
+      inputModifiers = inputModifiers,
+      shouldOpenContextMenu = shouldOpenContextMenuForActivePointer,
+      doubleTapDrag = doubleTapDrag,
+      context = context,
+      expectedEditing = directEditingEnabled,
+    ) {
+      doubleTapDrag.prepareForDrag(position = position, tap = this, context = context)
+    }
+    return true
+  }
+  if (!directEditingEnabled) {
     if (tapCountForActivePointer == 2 && context.doubleTapToEditEnabled) {
       prepareActiveTapForEditingPromotion()
       context.effects.cancelTapDispatch()
@@ -354,21 +371,6 @@ internal fun EditorTapGesture.handlePointerDown(
       return handled
     }
     return false
-  }
-  if (tapCountForActivePointer == 2) {
-    markTapDispatched()
-    context.effects.cancelTapDispatch()
-    dispatchEditableTap(
-      position = position,
-      clickCount = 2,
-      inputModifiers = inputModifiers,
-      shouldOpenContextMenu = shouldOpenContextMenuForActivePointer,
-      doubleTapDrag = doubleTapDrag,
-      context = context,
-    ) {
-      doubleTapDrag.prepareForDrag(position = position, tap = this, context = context)
-    }
-    return true
   }
 
   context.effects.scheduleTapDispatch(dispatchAtMillis = nowMillis + EditorTapDispatchDelayMillis)
@@ -408,7 +410,8 @@ internal fun EditorTapGesture.handlePointerUp(
   if (!canFinishTap) {
     context.effects.cancelTapDispatch()
   }
-  if (!context.editing) {
+  val directEditingEnabled = context.editing && !context.readOnly
+  if (!directEditingEnabled) {
     completedTap?.let { completed ->
       if (completed.contentAlreadyDispatched) {
         confirmPendingPresentationAfterPointerUp(completedTap = completed, context = context)
@@ -428,7 +431,7 @@ internal fun EditorTapGesture.handlePointerUp(
   }
   completedTap?.let { completed ->
     if (!completed.contentAlreadyDispatched) {
-      dispatchEditableTap(
+      dispatchSelectionTap(
         position = position,
         clickCount = completed.count,
         inputModifiers = inputModifiers,
@@ -448,7 +451,8 @@ internal fun EditorTapGesture.handleTapTimer(
   doubleTapDrag: EditorDoubleTapDragSession,
   context: EditorGestureContext,
 ) {
-  if (!context.editing) {
+  val directEditingEnabled = context.editing && !context.readOnly
+  if (!directEditingEnabled) {
     return
   }
   val position = activePosition ?: return
@@ -485,7 +489,7 @@ internal fun EditorTapGesture.handleTapTimer(
     return
   }
   markTapDispatched()
-  dispatchEditableTap(
+  dispatchSelectionTap(
     position = position,
     clickCount = clickCount,
     inputModifiers = inputModifiers,
@@ -535,7 +539,7 @@ private fun EditorTapGesture.dispatchReadingTap(
     clearTapHistory()
     return false
   }
-  if (!context.doubleTapToEditEnabled) {
+  if (!context.readOnly && !context.doubleTapToEditEnabled) {
     return dispatchReadingActivation(
       position = position,
       inputModifiers = inputModifiers,
@@ -614,7 +618,7 @@ private fun EditorTapGesture.dispatchReadingActivation(
     return false
   }
   val dispatched =
-    dispatchEditableTap(
+    dispatchSelectionTap(
       position = position,
       clickCount = 1,
       inputModifiers = inputModifiers.copy(shift = false),
@@ -630,13 +634,14 @@ private fun EditorTapGesture.dispatchReadingActivation(
   return dispatched
 }
 
-private fun EditorTapGesture.dispatchEditableTap(
+private fun EditorTapGesture.dispatchSelectionTap(
   position: Offset,
   clickCount: Int,
   inputModifiers: InputModifiers,
   shouldOpenContextMenu: Boolean,
   doubleTapDrag: EditorDoubleTapDragSession,
   context: EditorGestureContext,
+  expectedEditing: Boolean = true,
   preserveExistingSelectionOnSingleTap: Boolean = true,
   beforeLaunch: () -> Unit,
 ): Boolean {
@@ -670,15 +675,17 @@ private fun EditorTapGesture.dispatchEditableTap(
   val generation =
     beginPendingPresentation(
       editor = editor,
-      expectedEditing = true,
+      expectedEditing = expectedEditing,
       tapCount = clickCount,
       showReadingHint = false,
       context = context,
     )
   val wasFocused = context.isFocused
-  context.effects.requestFocus(editor)
-  if (wasFocused) {
-    context.effects.requestSoftwareKeyboard()
+  if (expectedEditing) {
+    context.effects.requestFocus(editor)
+    if (wasFocused) {
+      context.effects.requestSoftwareKeyboard()
+    }
   }
   val hitExistingSelectionAtTap =
     editor.selectionHitTest(page = point.page, x = point.x, y = point.y)

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -245,7 +246,7 @@ fun EditorScreen(entityId: String) {
   val focusReturnSession = remember(entityId) { EditorFocusReturnSession(scope = scope) }
   val runtime = remember(entityId) { EditorRuntime(uiScope = scope) }
   val interactionScope = remember(entityId) { EditorInteractionScope(coroutineScope = scope) }
-  val readingHintEvents = remember(entityId) { MutableSharedFlow<Unit>(extraBufferCapacity = 1) }
+  val readingTapHintEvents = remember(entityId) { MutableSharedFlow<Unit>(extraBufferCapacity = 1) }
   val uiState = remember(entityId) { EditorUiState() }
   val externalElementState = remember(entityId) { EditorExternalElementState() }
   val assetHydrator =
@@ -371,6 +372,7 @@ fun EditorScreen(entityId: String) {
   }
   val editorState = editor?.state ?: EditorState.Initial
   val doubleTapToEditEnabled = Preference.doubleTapToEditEnabled && editorState.placeholder == null
+  val headerReadingTapIdentity = remember(editor, editorReadOnly, documentLocked) { Any() }
   val externalAssetIds =
     remember(editorState.externalElements) {
       editorState.externalElements
@@ -1433,6 +1435,10 @@ fun EditorScreen(entityId: String) {
           ),
       )
     val visibleArea = visibleAreas.editor
+    LaunchedEffect(editorReadOnly, documentLocked) {
+      if (editor == null) return@LaunchedEffect
+      interactionScope.controller.cancel()
+    }
     LaunchedEffect(editorReadOnly) {
       if (!editorReadOnly) return@LaunchedEffect
       editingState.enterReading()
@@ -1610,7 +1616,7 @@ fun EditorScreen(entityId: String) {
         editing = { isEditing },
         doubleTapToEditEnabled = { doubleTapToEditEnabled },
         onRequestEditing = ::requestEditing,
-        onShowReadingEditHint = { readingHintEvents.tryEmit(Unit) },
+        onShowReadingTapHint = { readingTapHintEvents.tryEmit(Unit) },
         onSelectionHaptic = { haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove) },
         onRequestSoftwareKeyboard = {
           if (
@@ -1710,10 +1716,11 @@ fun EditorScreen(entityId: String) {
               title = model.titleDraft,
               subtitle = model.subtitleDraft,
               loading = false,
-              enabled = editorReady && !editorReadOnly && screenState.sceneInForeground,
-              editing = isEditing,
+              enabled = editorReady && screenState.sceneInForeground,
+              editing = directEditingEnabled,
               doubleTapToEditEnabled = doubleTapToEditEnabled,
-              readingTapIdentity = editor,
+              editingActivationEnabled = !editorReadOnly,
+              readingTapIdentity = headerReadingTapIdentity,
               readingModeCleanupRequest = readingModeCleanupRequest,
               showBottomDivider = layoutSpec is EditorDocumentLayoutSpec.Continuous,
               topInset = topInset,
@@ -1733,7 +1740,7 @@ fun EditorScreen(entityId: String) {
                 val activeEditor = editor
                 activeEditor != null && requestEditing(activeEditor)
               },
-              onReadingEditHint = { readingHintEvents.tryEmit(Unit) },
+              onReadingTapHint = { readingTapHintEvents.tryEmit(Unit) },
               onEnterDocument = {
                 model.flushDraftsAsync()
                 enterDocumentStartFromHeader(
@@ -1756,15 +1763,23 @@ fun EditorScreen(entityId: String) {
           }
         },
         viewportOverlay = {
-          if (
-            screenState.sceneInForeground && !isEditing && !editorReadOnly && doubleTapToEditEnabled
-          ) {
-            EditorTapHintOverlay(
-              events = readingHintEvents,
-              text = "편집하려면 더블 탭",
-              hazeState = LocalHazeState.current,
-              visibleArea = visibleArea,
-            )
+          val tapHintText =
+            when {
+              isEditing -> null
+              documentLocked -> "편집이 잠겨 있어요"
+              editorReadOnly -> null
+              doubleTapToEditEnabled -> "편집하려면 더블 탭"
+              else -> null
+            }
+          if (screenState.sceneInForeground && tapHintText != null) {
+            key(tapHintText) {
+              EditorTapHintOverlay(
+                events = readingTapHintEvents,
+                text = tapHintText,
+                hazeState = LocalHazeState.current,
+                visibleArea = visibleArea,
+              )
+            }
           }
           if (editorReady) {
             EditorZoomOverlay(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/header/EditorHeader.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/header/EditorHeader.kt
@@ -171,6 +171,7 @@ internal fun EditorHeader(
   enabled: Boolean = true,
   editing: Boolean = true,
   doubleTapToEditEnabled: Boolean = true,
+  editingActivationEnabled: Boolean = true,
   readingTapIdentity: Any? = Unit,
   readingModeCleanupRequest: Int = 0,
   showBottomDivider: Boolean = true,
@@ -184,7 +185,7 @@ internal fun EditorHeader(
   onHeightChanged: (Float) -> Unit,
   onEnterDocument: () -> Unit,
   onRequestEditing: () -> Boolean = { false },
-  onReadingEditHint: () -> Unit = {},
+  onReadingTapHint: () -> Unit = {},
 ) {
   val density = LocalDensity.current
   val showSkeleton = LocalSkeleton.current.enabled || loading
@@ -250,6 +251,7 @@ internal fun EditorHeader(
         enabled = enabled,
         editing = editing,
         doubleTapToEditEnabled = doubleTapToEditEnabled,
+        editingActivationEnabled = editingActivationEnabled,
         readingTapIdentity = readingTapIdentity,
         readingModeCleanupRequest = readingModeCleanupRequest,
         imeAction = ImeAction.Next,
@@ -260,7 +262,7 @@ internal fun EditorHeader(
         modifier = Modifier.fillMaxWidth(),
         textInputState = titleInputState,
         onRequestEditing = onRequestEditing,
-        onReadingEditHint = onReadingEditHint,
+        onReadingTapHint = onReadingTapHint,
       )
 
       Spacer(Modifier.height(TitleBetweenSpacing))
@@ -291,6 +293,7 @@ internal fun EditorHeader(
         enabled = enabled,
         editing = editing,
         doubleTapToEditEnabled = doubleTapToEditEnabled,
+        editingActivationEnabled = editingActivationEnabled,
         readingTapIdentity = readingTapIdentity,
         readingModeCleanupRequest = readingModeCleanupRequest,
         imeAction = ImeAction.Done,
@@ -306,7 +309,7 @@ internal fun EditorHeader(
         modifier = Modifier.fillMaxWidth(),
         textInputState = subtitleInputState,
         onRequestEditing = onRequestEditing,
-        onReadingEditHint = onReadingEditHint,
+        onReadingTapHint = onReadingTapHint,
       )
 
       Spacer(Modifier.height(TitleBlockSpacing))
@@ -331,6 +334,7 @@ private fun EditorHeaderField(
   enabled: Boolean,
   editing: Boolean,
   doubleTapToEditEnabled: Boolean,
+  editingActivationEnabled: Boolean,
   readingTapIdentity: Any?,
   readingModeCleanupRequest: Int,
   imeAction: ImeAction,
@@ -342,7 +346,7 @@ private fun EditorHeaderField(
   modifier: Modifier = Modifier,
   textInputState: TextInputState,
   onRequestEditing: () -> Boolean,
-  onReadingEditHint: () -> Unit,
+  onReadingTapHint: () -> Unit,
 ) {
   val verticalExitScope = rememberCoroutineScope()
   val keyboardController = LocalSoftwareKeyboardController.current
@@ -352,7 +356,7 @@ private fun EditorHeaderField(
   val currentInputEnabled by rememberUpdatedState(inputEnabled)
   val currentReadingTapEnabled by rememberUpdatedState(enabled && !editing)
   val currentOnRequestEditing by rememberUpdatedState(onRequestEditing)
-  val currentOnReadingEditHint by rememberUpdatedState(onReadingEditHint)
+  val currentOnReadingTapHint by rememberUpdatedState(onReadingTapHint)
   var latestTextLayout by remember { mutableStateOf<TextLayoutResult?>(null) }
   var pendingActivationOffset by remember { mutableStateOf<Int?>(null) }
   val readingTapTracker =
@@ -360,12 +364,14 @@ private fun EditorHeaderField(
       viewConfiguration.touchSlop,
       density.density,
       doubleTapToEditEnabled,
+      editingActivationEnabled,
       readingTapIdentity,
     ) {
       EditorHeaderReadingTapTracker(
         touchSlopPx = viewConfiguration.touchSlop,
         maxTapDistancePx = with(density) { 20.dp.toPx() },
         doubleTapToEditEnabled = doubleTapToEditEnabled,
+        editingActivationEnabled = editingActivationEnabled,
       )
     }
   val verticalNavigation =
@@ -411,7 +417,7 @@ private fun EditorHeaderField(
         }
         .invalidateHeaderVerticalNavigationOnPointerDown(verticalNavigation)
         .then(
-          if (enabled && !editing) {
+          if (enabled && !editing && editingActivationEnabled) {
             Modifier.semantics {
               customActions =
                 listOf(
@@ -444,7 +450,7 @@ private fun EditorHeaderField(
               pendingActivationOffset = offset
             }
           },
-          onShowHint = { currentOnReadingEditHint() },
+          onShowHint = { currentOnReadingTapHint() },
         )
         .onPreviewKeyEvent {
           if (!currentInputEnabled) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/header/EditorHeaderReadingTapGesture.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/header/EditorHeaderReadingTapGesture.kt
@@ -24,6 +24,7 @@ internal class EditorHeaderReadingTapTracker(
   private val touchSlopPx: Float,
   private val maxTapDistancePx: Float,
   private val doubleTapToEditEnabled: Boolean,
+  private val editingActivationEnabled: Boolean = true,
   private val consecutiveTapMaxIntervalMillis: Long = EditorConsecutiveTapMaxIntervalMillis,
 ) {
   private data class ActiveTap(val position: Offset, val suppressHint: Boolean)
@@ -48,17 +49,20 @@ internal class EditorHeaderReadingTapTracker(
   ): EditorHeaderReadingTapResult {
     val pending = pendingTap
     pendingTap = null
-    if (
-      doubleTapToEditEnabled &&
-        pending != null &&
+    val isConsecutiveTap =
+      pending != null &&
         timeMillis <= pending.confirmationAtMillis &&
         (position - pending.position).getDistance() <= maxTapDistancePx
-    ) {
+    if (editingActivationEnabled && doubleTapToEditEnabled && isConsecutiveTap) {
       activeTap = null
       return EditorHeaderReadingTapResult.Activate(offset)
     }
 
-    activeTap = ActiveTap(position = position, suppressHint = suppressHint)
+    activeTap =
+      ActiveTap(
+        position = position,
+        suppressHint = suppressHint || (isConsecutiveTap && !editingActivationEnabled),
+      )
     return EditorHeaderReadingTapResult.None
   }
 
@@ -77,7 +81,7 @@ internal class EditorHeaderReadingTapTracker(
   ): EditorHeaderReadingTapResult {
     val active = activeTap ?: return EditorHeaderReadingTapResult.None
     activeTap = null
-    if (!doubleTapToEditEnabled) {
+    if (editingActivationEnabled && !doubleTapToEditEnabled) {
       pendingTap = null
       return EditorHeaderReadingTapResult.Activate(offset)
     }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
@@ -4065,7 +4065,7 @@ class EditorInteractionControllerTest {
 
     override fun requestEditing(editor: Editor): Boolean = false
 
-    override fun showReadingEditHint() = Unit
+    override fun showReadingTapHint() = Unit
 
     override fun requestFocus(editor: Editor): Boolean {
       focused = true

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorReadingModeInteractionTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorReadingModeInteractionTest.kt
@@ -16,6 +16,7 @@ import co.typie.editor.ffi.Position
 import co.typie.editor.ffi.Rect
 import co.typie.editor.ffi.Selection
 import co.typie.editor.ffi.SelectionOp
+import co.typie.editor.ffi.SelectionPointUnit
 import co.typie.editor.interaction.gestures.EditorConsecutiveTapMaxIntervalMillis
 import co.typie.editor.runtime.EditorUiState
 import co.typie.platform.Platform
@@ -107,6 +108,95 @@ class EditorReadingModeInteractionTest {
           (message as? Message.Selection)?.op is SelectionOp.SelectUnitAt
         }
       )
+    }
+
+  @Test
+  fun `read only single tap selects without editing regardless of the edit preference`() =
+    runTest(StandardTestDispatcher()) {
+      val fixture = fixture(readOnly = true, doubleTapToEditEnabled = false)
+      fixture.editor.sync {}
+
+      fixture.controller.down(pointerId = 1L, nowMillis = 0L)
+      fixture.controller.up(pointerId = 1L, nowMillis = 40L)
+      runCurrent()
+
+      assertFalse(fixture.editing)
+      assertEquals(0, fixture.effects.editingRequestCount)
+      assertEquals(0, fixture.effects.focusRequestCount)
+      assertEquals(0, fixture.effects.softwareKeyboardRequestCount)
+      assertEquals(
+        listOf<Message>(Message.Selection(SelectionOp.SetAt(page = 0, x = 10f, y = 20f))),
+        fixture.fake.enqueued,
+      )
+
+      advanceTimeBy(EditorConsecutiveTapMaxIntervalMillis)
+      runCurrent()
+      assertEquals(1, fixture.effects.hintCount)
+    }
+
+  @Test
+  fun `read only tap stays selection only while editing cleanup is pending`() =
+    runTest(StandardTestDispatcher()) {
+      val fixture = fixture(editing = true, readOnly = true)
+      fixture.editor.sync {}
+
+      fixture.controller.down(pointerId = 1L, nowMillis = 0L)
+      fixture.controller.up(pointerId = 1L, nowMillis = 40L)
+      runCurrent()
+
+      assertTrue(fixture.editing)
+      assertEquals(0, fixture.effects.editingRequestCount)
+      assertEquals(0, fixture.effects.focusRequestCount)
+      assertEquals(0, fixture.effects.softwareKeyboardRequestCount)
+      assertEquals(
+        listOf<Message>(Message.Selection(SelectionOp.SetAt(page = 0, x = 10f, y = 20f))),
+        fixture.fake.enqueued,
+      )
+    }
+
+  @Test
+  fun `read only double tap selects a word and starts selection drag without editing`() =
+    runTest(StandardTestDispatcher()) {
+      val selectedWord =
+        Selection(
+          anchor = Position("text", 0, Affinity.Downstream),
+          head = Position("text", 5, Affinity.Downstream),
+        )
+      val fixture = fixture(readOnly = true, unitSelectionResult = selectedWord)
+      fixture.editor.sync {}
+
+      fixture.controller.down(pointerId = 1L, nowMillis = 0L)
+      fixture.controller.up(pointerId = 1L, nowMillis = 40L)
+      runCurrent()
+
+      fixture.controller.down(pointerId = 2L, nowMillis = 140L)
+      runCurrent()
+
+      assertFalse(fixture.editing)
+      assertEquals(0, fixture.effects.editingRequestCount)
+      assertEquals(0, fixture.effects.focusRequestCount)
+      assertEquals(0, fixture.effects.softwareKeyboardRequestCount)
+      assertTrue(
+        fixture.fake.enqueued.any { message ->
+          ((message as? Message.Selection)?.op as? SelectionOp.SelectUnitAt)?.unit ==
+            SelectionPointUnit.Word
+        }
+      )
+
+      fixture.controller.move(pointerId = 2L, position = Offset(20f, 20f), nowMillis = 160L)
+      runCurrent()
+
+      assertEquals(EditorInteractionMode.DoubleTapSelecting, fixture.controller.interactionMode)
+      assertTrue(
+        fixture.fake.enqueued.any { message ->
+          (message as? Message.Selection)?.op is SelectionOp.ExtendTo
+        }
+      )
+
+      fixture.controller.up(pointerId = 2L, nowMillis = 180L, position = Offset(20f, 20f))
+      advanceUntilIdle()
+      assertEquals(EditorInteractionMode.Idle, fixture.controller.interactionMode)
+      assertEquals(0, fixture.effects.hintCount)
     }
 
   @Test
@@ -344,11 +434,13 @@ class EditorReadingModeInteractionTest {
 
   private fun TestScope.fixture(
     editing: Boolean = false,
+    readOnly: Boolean = false,
     doubleTapToEditEnabled: Boolean = true,
     interactiveHit: InteractiveHit? = null,
     expandedSelection: Boolean = false,
     tapHitsSelection: Boolean = false,
     pointSelectionResult: Selection? = null,
+    unitSelectionResult: Selection? = null,
     platform: Platform = Platform.Desktop,
   ): Fixture {
     var currentSelection =
@@ -366,8 +458,14 @@ class EditorReadingModeInteractionTest {
         selectionProvider = { currentSelection },
         onTick = {
           val latestSelection = fake.enqueued.lastOrNull() as? Message.Selection
-          if (latestSelection?.op is SelectionOp.SetAt) {
-            currentSelection = pointSelectionResult ?: FakeFfiEditor.EmptySelection
+          when (latestSelection?.op) {
+            is SelectionOp.SetAt ->
+              currentSelection = pointSelectionResult ?: FakeFfiEditor.EmptySelection
+            is SelectionOp.SelectUnitAt ->
+              if (unitSelectionResult != null) {
+                currentSelection = unitSelectionResult
+              }
+            else -> Unit
           }
           emptyList()
         },
@@ -403,6 +501,7 @@ class EditorReadingModeInteractionTest {
         geometry = effects,
         uiStateProvider = { effects.uiState },
         platformProvider = { platform },
+        readOnlyProvider = { readOnly },
         editingProvider = { fixture.editing },
         doubleTapToEditEnabledProvider = { doubleTapToEditEnabled },
       )
@@ -487,7 +586,7 @@ class EditorReadingModeInteractionTest {
       return onRequestEditing(editor)
     }
 
-    override fun showReadingEditHint() {
+    override fun showReadingTapHint() {
       hintCount += 1
     }
 

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/semantics/EditorPointSelectionSemanticTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/semantics/EditorPointSelectionSemanticTest.kt
@@ -185,7 +185,7 @@ class EditorPointSelectionSemanticTest {
     override fun requestEditing(editor: Editor): Boolean =
       error("Unused in direct cursor semantic dispatch tests")
 
-    override fun showReadingEditHint() = error("Unused in direct cursor semantic dispatch tests")
+    override fun showReadingTapHint() = error("Unused in direct cursor semantic dispatch tests")
 
     override fun requestFocus(editor: Editor): Boolean =
       error("Unused in direct cursor semantic dispatch tests")

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/header/EditorHeaderReadingTapGestureTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/header/EditorHeaderReadingTapGestureTest.kt
@@ -89,6 +89,36 @@ class EditorHeaderReadingTapGestureTest {
   }
 
   @Test
+  fun activationDisabledKeepsSingleTapAsSelectionWhenEditPreferenceIsDisabled() {
+    val tracker = tracker(doubleTapToEditEnabled = false, editingActivationEnabled = false)
+    tracker.onDown(position = Offset.Zero, offset = 0, timeMillis = 0)
+
+    assertEquals(
+      EditorHeaderReadingTapResult.None,
+      tracker.onUp(position = Offset.Zero, offset = 3, timeMillis = 10),
+    )
+    assertEquals(EditorHeaderReadingTapResult.ShowHint, tracker.confirm(timeMillis = 310))
+  }
+
+  @Test
+  fun activationDisabledLeavesConsecutiveTapNativeAndSuppressesTheHint() {
+    val tracker = tracker(editingActivationEnabled = false)
+    tracker.onDown(position = Offset.Zero, offset = 0, timeMillis = 0)
+    tracker.onUp(position = Offset.Zero, offset = 0, timeMillis = 10)
+
+    assertEquals(
+      EditorHeaderReadingTapResult.None,
+      tracker.onDown(position = Offset(8f, 0f), offset = 4, timeMillis = 250),
+    )
+    assertEquals(
+      EditorHeaderReadingTapResult.None,
+      tracker.onUp(position = Offset(8f, 0f), offset = 4, timeMillis = 260),
+    )
+    assertEquals(EditorHeaderReadingTapResult.None, tracker.confirm(timeMillis = 560))
+    assertNull(tracker.pendingConfirmationAtMillis)
+  }
+
+  @Test
   fun confirmedSingleTapSkipsHintWhenItHandledExistingSelectionUi() {
     val tracker = tracker()
     tracker.onDown(position = Offset.Zero, offset = 0, timeMillis = 0)
@@ -98,11 +128,15 @@ class EditorHeaderReadingTapGestureTest {
     assertNull(tracker.pendingConfirmationAtMillis)
   }
 
-  private fun tracker(doubleTapToEditEnabled: Boolean = true): EditorHeaderReadingTapTracker =
+  private fun tracker(
+    doubleTapToEditEnabled: Boolean = true,
+    editingActivationEnabled: Boolean = true,
+  ): EditorHeaderReadingTapTracker =
     EditorHeaderReadingTapTracker(
       touchSlopPx = 8f,
       maxTapDistancePx = 20f,
       doubleTapToEditEnabled = doubleTapToEditEnabled,
+      editingActivationEnabled = editingActivationEnabled,
     )
 
   private fun scheduleFirstTap(tracker: EditorHeaderReadingTapTracker, startMillis: Long) {

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/interaction/EditorInteractionsDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/interaction/EditorInteractionsDesktopTest.kt
@@ -1975,7 +1975,7 @@ class EditorInteractionsDesktopTest {
 
     override fun requestEditing(editor: Editor): Boolean = false
 
-    override fun showReadingEditHint() = Unit
+    override fun showReadingTapHint() = Unit
 
     override fun requestFocus(editor: Editor): Boolean = false
 

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/header/EditorHeaderDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/header/EditorHeaderDesktopTest.kt
@@ -175,6 +175,64 @@ class EditorHeaderDesktopTest {
   }
 
   @Test
+  fun readOnlyTitleDoubleTapKeepsNativeSelectionWithoutEditingActivation() = runComposeUiTest {
+    var promotionCount = 0
+    var hintCount = 0
+    setContent {
+      CompositionLocalProvider(
+        LocalDensity provides Density(1f),
+        LocalThemeMode provides ResolvedThemeMode.Light,
+      ) {
+        Box(Modifier.width(240.dp)) {
+          EditorHeader(
+            title = Title,
+            subtitle = "",
+            loading = false,
+            editing = false,
+            editingActivationEnabled = false,
+            topInset = 0.dp,
+            onTitleChange = {},
+            onSubtitleChange = {},
+            onTitleFocused = {},
+            onSubtitleFocused = {},
+            onHeightChanged = {},
+            onEnterDocument = {},
+            onRequestEditing = {
+              promotionCount += 1
+              true
+            },
+            onReadingTapHint = { hintCount += 1 },
+          )
+        }
+      }
+    }
+    waitForIdle()
+
+    val title = onNode(hasText(Title), useUnmergedTree = true)
+    val bounds = title.fetchSemanticsNode().boundsInRoot
+    title.performTouchInput {
+      val position = Offset(x = bounds.width * 0.4f, y = bounds.height / 2f)
+      down(position)
+      advanceEventTime(10)
+      up()
+      advanceEventTime(100)
+      down(position)
+      advanceEventTime(10)
+      up()
+    }
+    waitForIdle()
+
+    val selection =
+      onAllNodes(hasText(Title), useUnmergedTree = true)
+        .fetchSemanticsNodes()
+        .single { SemanticsProperties.TextSelectionRange in it.config }
+        .config[SemanticsProperties.TextSelectionRange]
+    assertFalse(selection.collapsed)
+    assertEquals(0, promotionCount)
+    assertEquals(0, hintCount)
+  }
+
+  @Test
   fun readingTitleSingleTapPromotesWhenDoubleTapSettingIsDisabled() = runComposeUiTest {
     val editing = mutableStateOf(false)
     var promotionCount = 0


### PR DESCRIPTION
- 편집 잠금 문서에서 싱글 탭은 '편집이 잠겨 있어요' 힌트를 표시
- 더블 탭 드래그 등 나머지 모든 읽기 전용 제스처 가능