### PR TITLE
앱 읽기 전용 또는 구독 만료 상태에서의 도구 사용 정책 픽스

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/subscription/GatedAction.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/subscription/GatedAction.kt
@@ -21,6 +21,7 @@ enum class GatedAction {
   TextReplacement,
   PresetSettings,
   AiSettings,
+  Comment,
   Spellcheck,
   AiFeedback,
   Generic,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -429,12 +429,16 @@ fun EditorScreen(entityId: String) {
     val activeEditor = runtime.editor ?: return
     activeEditor.enqueue(Message.Selection(SelectionOp.Unset))
   }
+  suspend fun ensureEditorMutationSubscription(): Boolean {
+    return SubscriptionService.gate(sheet = sheet, action = GatedAction.Generic)
+  }
   val findReplace =
     rememberEditorFindReplaceSession(
-      documentLocked = editorReadOnly,
+      documentLocked = documentLocked,
       editingSession = editingSession,
       editorState = editorState,
       bringIntoViewRequests = bringIntoViewRequests,
+      ensureSubscription = ::ensureEditorMutationSubscription,
       onEditingIntent = ::requestEditing,
       admitMutation = ::canApplyEditorMutation,
     )
@@ -489,7 +493,7 @@ fun EditorScreen(entityId: String) {
   val spellcheck =
     rememberEditorSpellcheckSession(
       documentId = document?.id,
-      documentLocked = editorReadOnly,
+      documentLocked = documentLocked,
       editingSession = editingSession,
       editorState = editorState,
       bringIntoViewRequests = bringIntoViewRequests,
@@ -514,17 +518,20 @@ fun EditorScreen(entityId: String) {
       ensureSubscription = ::ensureAiFeedbackSubscription,
       ensureAiOptIn = ::ensureAiOptIn,
     )
+  suspend fun ensureCommentMutationSubscription(): Boolean {
+    return SubscriptionService.gate(sheet = sheet, action = GatedAction.Comment)
+  }
   val comments =
     rememberEditorCommentsSession(
       entityId = entityId,
       documentId = document?.id,
-      documentLocked = editorReadOnly,
       editor = editor,
       editorState = editorState,
       sheetActive = subPaneState.active == EditorSubPane.Comments,
       bringIntoViewRequests = bringIntoViewRequests,
       hideContextMenu = { uiState.contextMenu.hide() },
       openSheet = { subPaneState.open(EditorSubPane.Comments) },
+      ensureMutationSubscription = ::ensureCommentMutationSubscription,
     )
   suspend fun enterReadingMode() {
     val transition = editingState.beginReadingTransition() ?: return
@@ -1443,33 +1450,33 @@ fun EditorScreen(entityId: String) {
       if (!editorReadOnly) return@LaunchedEffect
       editingState.enterReading()
       readingModeCleanupRequest += 1
-      findReplace.close()
-      spellcheck.close()
-      aiFeedback.close()
-      subPaneState.dismiss()
       uiState.contextMenu.hide()
-      popoverOverlayState.dismissFromOutsideGesture()
     }
-    LaunchedEffect(editor, directEditingEnabled) {
+    LaunchedEffect(editor, directEditingEnabled, editorReadOnly) {
       if (!editingState.shouldRunReadingCleanup(editorReadOnly)) return@LaunchedEffect
+      if (!uiState.focused && !uiState.editorInputSessionActive) return@LaunchedEffect
       val activeEditor = editor ?: return@LaunchedEffect
+      val activeSession = runtime.session
+      val activeDocumentId = model.documentId
+      val expectedEditorReadOnly = editorReadOnly
+      val cleanupCurrent = {
+        runtime.editor === activeEditor &&
+          runtime.session === activeSession &&
+          model.documentId == activeDocumentId &&
+          nav.current == Route.Editor(entityId) &&
+          screenState.sceneInForeground &&
+          currentEditorReadOnly == expectedEditorReadOnly &&
+          !currentDirectEditingEnabled
+      }
       val cleaned =
-        activeEditor.await(
-          admit = {
-            runtime.editor === activeEditor && editingState.shouldRunReadingCleanup(editorReadOnly)
-          }
-        ) {
+        activeEditor.await(admit = cleanupCurrent) {
           if (activeEditor.tickIme?.composing != null) {
             enqueue(Message.TextInput(listOf(FlatImeOp.CommitAsIs)))
           }
           enqueue(Message.System(SystemEvent.SetFocused(false)))
         }
-      if (!cleaned) return@LaunchedEffect
-      if (
-        runtime.editor !== activeEditor || !editingState.shouldRunReadingCleanup(editorReadOnly)
-      ) {
-        return@LaunchedEffect
-      }
+      if (!cleaned || !cleanupCurrent()) return@LaunchedEffect
+      if (!uiState.focused) return@LaunchedEffect
       interactionScope.controller.cancel()
       runtime.blur()
       performInputEffects(toolbarInputState.dispatch(ToolbarIntent.Reset, toolbarInputEnvironment))
@@ -1932,6 +1939,7 @@ fun EditorScreen(entityId: String) {
           EditorSubPaneHost(
             state = subPaneState,
             entityId = entityId,
+            editorMutationEnabled = directEditingEnabled,
             comments =
               CommentsSubPaneEnvironment(
                 session = comments,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/EditorFindReplaceSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/EditorFindReplaceSession.kt
@@ -59,6 +59,7 @@ internal fun rememberEditorFindReplaceSession(
   editingSession: DocumentEditingSession?,
   editorState: EditorState,
   bringIntoViewRequests: EditorBringIntoViewRequests,
+  ensureSubscription: suspend () -> Boolean,
   onEditingIntent: (Editor) -> Boolean,
   admitMutation: (DocumentEditingSession) -> Boolean,
 ): EditorFindReplaceSession {
@@ -119,14 +120,18 @@ internal fun rememberEditorFindReplaceSession(
           toast.show(ToastType.Error, "잠긴 문서는 편집할 수 없어요.")
           return@replace
         }
-        if (!state.canReplaceActive() || !onEditingIntent(activeSession.editor)) return@replace
-        activeSession.submit { activeEditor, context ->
-          activeEditor.scope.launch(context) {
-            state.replaceActive(
-              editor = activeEditor,
-              admitMutation = { admitMutation(activeSession) },
-              bringIntoViewRequests = bringIntoViewRequests,
-            )
+        if (!state.canReplaceActive()) return@replace
+        scope.launch {
+          if (!ensureSubscription()) return@launch
+          if (!state.canReplaceActive() || !onEditingIntent(activeSession.editor)) return@launch
+          activeSession.submit { activeEditor, context ->
+            activeEditor.scope.launch(context) {
+              state.replaceActive(
+                editor = activeEditor,
+                admitMutation = { admitMutation(activeSession) },
+                bringIntoViewRequests = bringIntoViewRequests,
+              )
+            }
           }
         }
       },
@@ -136,14 +141,18 @@ internal fun rememberEditorFindReplaceSession(
           toast.show(ToastType.Error, "잠긴 문서는 편집할 수 없어요.")
           return@replaceAll
         }
-        if (!state.canReplaceAll() || !onEditingIntent(activeSession.editor)) return@replaceAll
-        activeSession.submit { activeEditor, context ->
-          activeEditor.scope.launch(context) {
-            state.replaceAllMatches(
-              editor = activeEditor,
-              admitMutation = { admitMutation(activeSession) },
-              bringIntoViewRequests = bringIntoViewRequests,
-            )
+        if (!state.canReplaceAll()) return@replaceAll
+        scope.launch {
+          if (!ensureSubscription()) return@launch
+          if (!state.canReplaceAll() || !onEditingIntent(activeSession.editor)) return@launch
+          activeSession.submit { activeEditor, context ->
+            activeEditor.scope.launch(context) {
+              state.replaceAllMatches(
+                editor = activeEditor,
+                admitMutation = { admitMutation(activeSession) },
+                bringIntoViewRequests = bringIntoViewRequests,
+              )
+            }
           }
         }
       },

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/spellcheck/EditorSpellcheckSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/spellcheck/EditorSpellcheckSession.kt
@@ -352,6 +352,7 @@ internal fun rememberEditorSpellcheckSession(
 
         scope.launch {
           if (activeSession.editor.trackedRange(id) == null) return@launch
+          if (!ensureSubscription()) return@launch
           if (!onEditingIntent(activeSession.editor)) return@launch
           activeSession.submit { activeEditor, context ->
             activeEditor.scope.launch(context) {
@@ -385,6 +386,7 @@ internal fun rememberEditorSpellcheckSession(
             return@launch
           }
 
+          if (!ensureSubscription()) return@launch
           if (!onEditingIntent(activeEditor)) return@launch
           val selected =
             activeEditor.awaitWithBringIntoView(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/EditorSubPaneHost.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/EditorSubPaneHost.kt
@@ -21,6 +21,7 @@ internal data class CommentsSubPaneEnvironment(
 internal fun EditorSubPaneHost(
   state: EditorSubPaneState,
   entityId: String,
+  editorMutationEnabled: Boolean,
   comments: CommentsSubPaneEnvironment,
   maxTopInset: Dp,
   safeBottomInset: Dp,
@@ -32,6 +33,11 @@ internal fun EditorSubPaneHost(
   val selection = editor?.tickSelection
 
   LaunchedEffect(active, selection) { state.dismissTableAxisActionsIfSelectionChanged(selection) }
+  LaunchedEffect(active, editorMutationEnabled) {
+    if (active is EditorSubPane.TableAxisActions && !editorMutationEnabled) {
+      state.dismiss()
+    }
+  }
 
   LaunchedEffect(active, comments.session.model) {
     if (active == EditorSubPane.Comments && comments.session.model == null) {
@@ -65,6 +71,7 @@ internal fun EditorSubPaneHost(
           composeLocation = comments.session.composeLocation,
           createEnabled = comments.session.topBarCreateEnabled,
           onFreezeCurrentSelection = comments.session.freezeCurrentSelection,
+          ensureMutationSubscription = comments.session.ensureMutationSubscription,
           onInputFocusChanged = comments.session.onInputFocusChanged,
           maxTopInset = maxTopInset,
           safeBottomInset = safeBottomInset,
@@ -81,10 +88,11 @@ internal fun EditorSubPaneHost(
         pane = active,
         currentBackgroundColor = editor?.state?.modifierState?.cellBackgroundColor,
         dismissRequestVersion = state.dismissRequestVersion,
-        onAction = { message ->
-          editor?.sync { enqueue(message) }
-          editor?.focus()
-        },
+        onAction = tableAction@{ message ->
+            if (!editorMutationEnabled) return@tableAction
+            editor?.sync { enqueue(message) }
+            editor?.focus()
+          },
         onDismissStarted = state::beginDismiss,
         onDismissCancelled = state::cancelDismiss,
         onDismiss = state::dismiss,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/comments/CommentsSheet.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/comments/CommentsSheet.kt
@@ -77,6 +77,7 @@ internal fun CommentsSheet(
   composeLocation: CommentThreadLocation?,
   createEnabled: Boolean,
   onFreezeCurrentSelection: suspend () -> StableSelection?,
+  ensureMutationSubscription: suspend () -> Boolean,
   onInputFocusChanged: (Boolean) -> Unit,
   maxTopInset: Dp,
   safeBottomInset: Dp,
@@ -136,6 +137,7 @@ internal fun CommentsSheet(
       composeLocation = composeLocation,
       createEnabled = createEnabled,
       onFreezeCurrentSelection = onFreezeCurrentSelection,
+      ensureMutationSubscription = ensureMutationSubscription,
       onInputFocusChanged = onInputFocusChanged,
       onDismiss = ::dismiss,
       sheetDragHandleModifier = Modifier.sheetDragHandle(),
@@ -157,6 +159,7 @@ private fun CommentsSheetContent(
   composeLocation: CommentThreadLocation?,
   createEnabled: Boolean,
   onFreezeCurrentSelection: suspend () -> StableSelection?,
+  ensureMutationSubscription: suspend () -> Boolean,
   onInputFocusChanged: (Boolean) -> Unit,
   onDismiss: () -> Unit,
   sheetDragHandleModifier: Modifier,
@@ -182,6 +185,7 @@ private fun CommentsSheetContent(
     }
     commentSubmitInProgress = true
     try {
+      if (!ensureMutationSubscription()) return
       block()
     } finally {
       commentSubmitInProgress = false
@@ -290,6 +294,7 @@ private fun CommentsSheetContent(
 
   suspend fun resolveThread(thread: CommentsSheetThread_thread) {
     afterDiscardingCommentInput {
+      if (!ensureMutationSubscription()) return@afterDiscardingCommentInput
       when (model.resolveThread(thread.id)) {
         is Result.Ok -> toast.show(ToastType.Success, "코멘트를 해결했어요.")
         is Result.Err,
@@ -300,6 +305,7 @@ private fun CommentsSheetContent(
 
   suspend fun unresolveThread(thread: CommentsSheetThread_thread) {
     afterDiscardingCommentInput {
+      if (!ensureMutationSubscription()) return@afterDiscardingCommentInput
       when (val result = model.unresolveThread(thread.id)) {
         is Result.Ok -> {
           pendingReopenedThreadId = result.value.id

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/comments/EditorCommentsSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/comments/EditorCommentsSession.kt
@@ -30,6 +30,7 @@ internal class EditorCommentsSession(
   val composeLocation: CommentThreadLocation?,
   val virtualThreadGuardVisible: Boolean,
   val freezeCurrentSelection: suspend () -> StableSelection?,
+  val ensureMutationSubscription: suspend () -> Boolean,
   val onInputFocusChanged: (Boolean) -> Unit,
   val requestFromTextToolbar: () -> Unit,
   val openFromToolPanel: () -> Unit,
@@ -83,13 +84,13 @@ private class CommentSheetRequestQueue {
 internal fun rememberEditorCommentsSession(
   entityId: String,
   documentId: String?,
-  documentLocked: Boolean,
   editor: Editor?,
   editorState: EditorState,
   sheetActive: Boolean,
   bringIntoViewRequests: EditorBringIntoViewRequests,
   hideContextMenu: () -> Unit,
   openSheet: () -> Unit,
+  ensureMutationSubscription: suspend () -> Boolean,
 ): EditorCommentsSession {
   val requestQueue = remember(entityId) { CommentSheetRequestQueue() }
   val scope = rememberCoroutineScope()
@@ -106,8 +107,8 @@ internal fun rememberEditorCommentsSession(
   val selection = editorState.selection
   val selectionCollapsed = selection == null || selection.anchor == selection.head
   val collapsedCommentRanges =
-    remember(editorState.trackedRangesContainingSelectionHead, selectionCollapsed, documentLocked) {
-      if (selection != null && selectionCollapsed && !documentLocked) {
+    remember(editorState.trackedRangesContainingSelectionHead, selectionCollapsed) {
+      if (selection != null && selectionCollapsed) {
         editorState.trackedRangesContainingSelectionHead.commentRangeEndpoints()
       } else {
         emptyList()
@@ -115,11 +116,9 @@ internal fun rememberEditorCommentsSession(
     }
   val collapsedCommentRangeIds = collapsedCommentRanges.mapTo(mutableSetOf()) { it.id }
   val collapsedSelectionHead = selection?.takeIf { selectionCollapsed }?.head
-  val topBarCreateEnabled =
-    model != null && !documentLocked && selection != null && !selectionCollapsed
+  val topBarCreateEnabled = model != null && selection != null && !selectionCollapsed
   val toolbarEnabled =
     model != null &&
-      !documentLocked &&
       selection != null &&
       (!selectionCollapsed || collapsedCommentRanges.isNotEmpty())
 
@@ -239,6 +238,7 @@ internal fun rememberEditorCommentsSession(
     freezeCurrentSelection = {
       editorState.selection?.let { currentSelection -> editor?.freezeSelection(currentSelection) }
     },
+    ensureMutationSubscription = ensureMutationSubscription,
     onInputFocusChanged = { focused -> inputFocused = focused },
     requestFromTextToolbar = {
       hideContextMenu()


### PR DESCRIPTION
## 변경 사항

- 읽기 모드나 구독 만료로 본문 편집이 비활성화될 때 본문·제목 입력만 종료하도록 변경
    - 검색/치환, 맞춤법 검사, AI 피드백, 코멘트 상태와 작성 중인 내용은 유지
    - 비동기 cleanup이 다른 문서나 새 포커스 세션에 적용되지 않도록 현재 세션을 재확인
- 검색/치환과 맞춤법 수정에 문서 잠금 및 구독 gate 적용
    - 실제 변경 직전에 조건을 다시 확인
- 본문 편집이 비활성화되면 테이블 행/열 작업 패널을 닫고, 늦게 전달된 작업도 실행되지 않도록 방어
- 문서가 편집 잠금 상태여도 코멘트를 열람하고 작성할 수 있도록 변경
- 구독이 만료된 경우 코멘트 생성, 답글, 수정, 해결/해결 취소를 제출 시점에 gate
    - 코멘트 및 스레드 삭제는 계속 허용

## 배경

기존에는 읽기 모드, 문서 편집 잠금, 구독 만료가 모두 `editorReadOnly` 흐름에 묶여 있어 본문 편집이 비활성화될 때 보조 도구와 코멘트까지 함께 닫히거나 사용할 수 없었습니다.

본문 편집 가능 여부와 보조 작업의 사용 가능 여부를 분리해, 읽기 전용으로 전환되더라도 진행 중인 검색, 맞춤법 검사, AI 피드백, 코멘트 작업은 유지하면서 실제 문서 변경만 원인에 맞게 제한하도록 수정했습니다.