### PR TITLE
text replacement 윈도 버그 수정

### DIFF
--- a/crates/editor-commands/src/commands/try_text_replacement.rs
+++ b/crates/editor-commands/src/commands/try_text_replacement.rs
@@ -33,11 +33,7 @@ pub fn try_text_replacement(tr: &mut Transaction, resource: &Resource) -> Comman
         if search_start_byte >= text_before.len() {
             break;
         }
-        while search_start_byte < text_before.len()
-            && !text_before.is_char_boundary(search_start_byte)
-        {
-            search_start_byte += 1;
-        }
+        search_start_byte = char_boundary_at_or_after(&text_before, search_start_byte);
 
         let matched = match_rule(rules, &text_before, search_start_byte);
         let Some((matched_start_byte, matched_text, substitute, suffix)) = matched else {
@@ -105,16 +101,18 @@ pub fn try_text_replacement(tr: &mut Transaction, resource: &Resource) -> Comman
     Ok(replaced)
 }
 
-// Only matches ending exactly at the cursor are ever accepted, so a regex only
-// needs to see a bounded tail of the paragraph text instead of the whole
-// prefix — matches longer than this window are not recognized.
-const REGEX_TAIL_WINDOW: usize = 256;
+// Patterns that need the backtracking engine cost more than linear time, so how
+// far back a match may start is bounded. Lookaround still reads the whole
+// paragraph prefix — only the start of the match itself is limited.
+const BACKTRACKING_START_WINDOW: usize = 256;
 
 fn match_rule(
     rules: &[TextReplacementRule],
     text_before: &str,
     search_start_byte: usize,
 ) -> Option<(usize, String, String, String)> {
+    let last_char = text_before.chars().next_back();
+
     for rule in rules {
         match &rule.pattern {
             CompiledPattern::Plain(pattern) => {
@@ -125,31 +123,43 @@ fn match_rule(
                     return Some((pos, pattern.clone(), rule.substitute.clone(), String::new()));
                 }
             }
-            CompiledPattern::Regex(regex) => {
-                let mut window_start = text_before.len().saturating_sub(REGEX_TAIL_WINDOW);
-                while !text_before.is_char_boundary(window_start) {
-                    window_start += 1;
+            CompiledPattern::Regex {
+                regex,
+                required_last_char,
+                backtracks,
+            } => {
+                if let Some(required) = required_last_char
+                    && last_char != Some(*required)
+                {
+                    continue;
                 }
-                let window = &text_before[window_start..];
-                for caps in regex.captures_iter(window).flatten() {
-                    if let Some(m) = caps.get(0)
-                        && window_start + m.end() == text_before.len()
-                        && window_start + m.start() >= search_start_byte
-                    {
-                        let matched_str = m.as_str().to_string();
-                        let expanded = expand_substitute(&caps, &rule.substitute);
-                        return Some((
-                            window_start + m.start(),
-                            matched_str,
-                            expanded,
-                            String::new(),
-                        ));
-                    }
+
+                let start = if *backtracks {
+                    search_start_byte
+                        .max(text_before.len().saturating_sub(BACKTRACKING_START_WINDOW))
+                } else {
+                    search_start_byte
+                };
+                let start = char_boundary_at_or_after(text_before, start);
+
+                if let Ok(Some(caps)) = regex.captures_from_pos(text_before, start)
+                    && let Some(m) = caps.get(0)
+                {
+                    let matched_str = m.as_str().to_string();
+                    let expanded = expand_substitute(&caps, &rule.substitute);
+                    return Some((m.start(), matched_str, expanded, String::new()));
                 }
             }
         }
     }
     None
+}
+
+fn char_boundary_at_or_after(text: &str, mut byte: usize) -> usize {
+    while byte < text.len() && !text.is_char_boundary(byte) {
+        byte += 1;
+    }
+    byte
 }
 
 fn expand_substitute(caps: &fancy_regex::Captures<'_>, template: &str) -> String {

--- a/crates/editor-core/src/text_replacement_tests.rs
+++ b/crates/editor-core/src/text_replacement_tests.rs
@@ -885,3 +885,49 @@ fn auto_replacement_undo_restores_matched_text_in_one_step() {
     );
     let _ = p1;
 }
+
+#[test]
+fn lookbehind_sees_text_beyond_the_start_window() {
+    let (s, ..) = state! {
+        doc { root { p1: paragraph { text("") } } }
+        selection: (p1, 0)
+    };
+    let mut editor = Editor::new_test(s);
+    set_rules(
+        &editor,
+        vec![
+            rule("(?<!\u{201C}[^\u{201D}]*)\"", "\u{201C}", true),
+            rule("(?<=\u{201C}[^\u{201D}]*)\"", "\u{201D}", true),
+        ],
+    );
+
+    let body = "가".repeat(100);
+    type_text(&mut editor, "\"");
+    type_text(&mut editor, &body);
+    type_text(&mut editor, "\"");
+
+    let text = flat_text(&editor);
+    assert!(
+        text.contains(&format!("\u{201C}{body}\u{201D}")),
+        "quote longer than the start window must still close, got {text:?}"
+    );
+}
+
+#[test]
+fn linear_rule_matches_longer_than_the_start_window() {
+    let (s, ..) = state! {
+        doc { root { p1: paragraph { text("") } } }
+        selection: (p1, 0)
+    };
+    let mut editor = Editor::new_test(s);
+    set_rules(&editor, vec![rule(REGEX_PATTERN, REGEX_SUBSTITUTE, true)]);
+
+    type_text(&mut editor, &"7".repeat(300));
+    type_text(&mut editor, "#");
+
+    let text = flat_text(&editor);
+    assert!(
+        text.contains(REGEX_SUBSTITUTE) && !text.contains('7'),
+        "the whole match must be replaced, not just its tail, got {text:?}"
+    );
+}

--- a/crates/editor-resource/src/text_replacement.rs
+++ b/crates/editor-resource/src/text_replacement.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use editor_macros::ffi;
+use fancy_regex::{Assertion, Expr};
 use serde::{Deserialize, Serialize};
 
 #[ffi]
@@ -15,7 +16,12 @@ pub struct RawTextReplacementRule {
 
 pub enum CompiledPattern {
     Plain(String),
-    Regex(Arc<fancy_regex::Regex>),
+    Regex {
+        regex: Arc<fancy_regex::Regex>,
+        required_last_char: Option<char>,
+        /// Needs the backtracking engine, so matching is not linear in the input.
+        backtracks: bool,
+    },
 }
 
 pub struct TextReplacementRule {
@@ -29,10 +35,7 @@ pub fn compile_rules(raw_rules: Vec<RawTextReplacementRule>) -> Vec<TextReplacem
         .into_iter()
         .filter_map(|r| {
             let pattern = if r.regex {
-                match fancy_regex::Regex::new(&r.match_pattern) {
-                    Ok(re) => CompiledPattern::Regex(Arc::new(re)),
-                    Err(_) => return None,
-                }
+                compile_regex(&r.match_pattern)?
             } else {
                 CompiledPattern::Plain(r.match_pattern)
             };
@@ -43,4 +46,129 @@ pub fn compile_rules(raw_rules: Vec<RawTextReplacementRule>) -> Vec<TextReplacem
             })
         })
         .collect()
+}
+
+/// Only a match ending at the caret is ever accepted, so the anchor belongs in
+/// the pattern rather than in a filter over candidate matches.
+fn compile_regex(pattern: &str) -> Option<CompiledPattern> {
+    let anchored = format!("(?:{pattern})\\z");
+    let regex = fancy_regex::Regex::new(&anchored).ok()?;
+    let expr = Expr::parse_tree(&anchored).ok().map(|tree| tree.expr);
+
+    Some(CompiledPattern::Regex {
+        regex: Arc::new(regex),
+        required_last_char: expr.as_ref().and_then(required_last_char),
+        backtracks: expr.as_ref().is_none_or(backtracks),
+    })
+}
+
+fn backtracks(expr: &Expr) -> bool {
+    match expr {
+        Expr::Empty | Expr::Any { .. } | Expr::Literal { .. } | Expr::Delegate { .. } => false,
+        Expr::Assertion(assertion) => !matches!(
+            assertion,
+            Assertion::StartText
+                | Assertion::EndText
+                | Assertion::StartLine { .. }
+                | Assertion::EndLine { .. }
+        ),
+        Expr::Concat(children) | Expr::Alt(children) => children.iter().any(backtracks),
+        Expr::Group(child) => backtracks(child),
+        Expr::Repeat { child, .. } => backtracks(child),
+        _ => true,
+    }
+}
+
+fn required_last_char(expr: &Expr) -> Option<char> {
+    match expr {
+        Expr::Literal { val, casei: false } => val.chars().next_back(),
+        Expr::Concat(children) => {
+            let last = children.iter().rev().find(|child| !is_zero_width(child))?;
+            if matches_empty(last) {
+                None
+            } else {
+                required_last_char(last)
+            }
+        }
+        Expr::Alt(children) => {
+            let mut candidates = children.iter().map(required_last_char);
+            let first = candidates.next()??;
+            candidates.all(|c| c == Some(first)).then_some(first)
+        }
+        Expr::Group(child) => required_last_char(child),
+        Expr::Repeat { child, lo, .. } if *lo > 0 => required_last_char(child),
+        _ => None,
+    }
+}
+
+fn is_zero_width(expr: &Expr) -> bool {
+    matches!(
+        expr,
+        Expr::Empty
+            | Expr::Assertion(_)
+            | Expr::LookAround(..)
+            | Expr::KeepOut
+            | Expr::ContinueFromPreviousMatchEnd
+    )
+}
+
+fn matches_empty(expr: &Expr) -> bool {
+    match expr {
+        Expr::Any { .. } | Expr::Delegate { .. } | Expr::GeneralNewline { .. } => false,
+        Expr::Literal { val, .. } => val.is_empty(),
+        Expr::Concat(children) => children.iter().all(matches_empty),
+        Expr::Alt(children) => children.iter().any(matches_empty),
+        Expr::Group(child) => matches_empty(child),
+        Expr::Repeat { child, lo, .. } => *lo == 0 || matches_empty(child),
+        _ => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn compiled(pattern: &str) -> (Option<char>, bool) {
+        match compile_regex(pattern).expect("pattern must compile") {
+            CompiledPattern::Regex {
+                required_last_char,
+                backtracks,
+                ..
+            } => (required_last_char, backtracks),
+            CompiledPattern::Plain(_) => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn derives_required_last_char() {
+        assert_eq!(compiled("(?<=\u{201C}[^\u{201D}]*)\"").0, Some('"'));
+        assert_eq!(compiled(r"\d+#").0, Some('#'));
+        assert_eq!(compiled("ab(?=c)").0, Some('b'));
+        assert_eq!(compiled("x{2,3}").0, Some('x'));
+        assert_eq!(compiled("ab|cb").0, Some('b'));
+    }
+
+    #[test]
+    fn omits_required_last_char_when_not_guaranteed() {
+        assert_eq!(compiled("(?i)abc").0, None);
+        assert_eq!(compiled("a|b").0, None);
+        assert_eq!(compiled(r"^-\s").0, None);
+        assert_eq!(compiled(r"ab\d*").0, None);
+    }
+
+    #[test]
+    fn detects_backtracking_patterns() {
+        assert!(compiled("(?<=\u{201C}[^\u{201D}]*)\"").1);
+        assert!(compiled("ab(?=c)").1);
+        assert!(compiled(r"(a)\1").1);
+        assert!(compiled(r"\bword").1);
+    }
+
+    #[test]
+    fn detects_linear_patterns() {
+        assert!(!compiled(r"\d+#").1);
+        assert!(!compiled("(?i)abc").1);
+        assert!(!compiled(r"^-\s").1);
+        assert!(!compiled("(ab|cd)e").1);
+    }
 }


### PR DESCRIPTION
정규식 매칭에 윈도가 있어 앞 내용이 길어지면 닫는 따옴표 등이 트리거되지 않는 문제 수정
