### PR TITLE
툴바에서 uniform하지 않은 글자색, 배경색을 - 로 보여주기

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/TextOptionMode.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/TextOptionMode.kt
@@ -141,7 +141,7 @@ internal fun TextToolbarSwatchButton(
   modifier: Modifier = Modifier,
   selected: Boolean = false,
   swatchShape: Shape = ToolbarButtonShape,
-  showSlash: Boolean = false,
+  markIcon: IconData? = null,
 ) {
   val interactionSource = remember { MutableInteractionSource() }
   val bringIntoViewRequester = remember { BringIntoViewRequester() }
@@ -181,9 +181,9 @@ internal fun TextToolbarSwatchButton(
             .border(ToolbarBorderWidth, AppTheme.colors.borderDefault, swatchShape),
         contentAlignment = Alignment.Center,
       ) {
-        if (showSlash) {
+        markIcon?.let {
           Icon(
-            icon = Lucide.Slash,
+            icon = it,
             contentDescription = null,
             modifier = Modifier.size(14.dp),
             tint = AppTheme.colors.textMuted,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/TextOptionsToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/TextOptionsToolbar.kt
@@ -268,7 +268,7 @@ private fun ColorOptions(
       onClick = { onSelect(option.value) },
       selected = currentValue == option.value,
       swatchShape = swatchShape,
-      showSlash = showSlashForNullTheme && option.themeKey == null,
+      markIcon = if (showSlashForNullTheme && option.themeKey == null) Lucide.Slash else null,
     )
   }
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/TextToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/TextToolbar.kt
@@ -113,6 +113,8 @@ private fun EditorTextToolbar(
   val editorTheme = remember(variant) { EditorTheme.resolve(variant) }
   val textColor = modifierState?.textColor.textColorCurrentValue()
   val backgroundColor = modifierState?.backgroundColor.backgroundColorCurrentValue()
+  val textColorMixed = modifierState?.textColor is Tri.Mixed
+  val backgroundColorMixed = modifierState?.backgroundColor is Tri.Mixed
   val fontFamily = modifierState?.fontFamily.uniformValue { it.value }
   val fontWeight = modifierState?.fontWeight.uniformValue { it.value }
   val fontSize = modifierState?.fontSize.uniformValue { it.value }
@@ -162,17 +164,23 @@ private fun EditorTextToolbar(
   EditorToolbarRow(scope = scope, modifier = modifier, scrollState = scrollState) {
     TextToolbarSwatchButton(
       color = editorTheme.colorFor(EditorValues.textColor, textColor),
-      contentDescription = "글자색",
+      contentDescription = if (textColorMixed) "글자색: 여러 색" else "글자색",
       onClick = { toggleMode(TextOptionMode.TextColor) },
       selected = activeTextOptionMode == TextOptionMode.TextColor,
+      markIcon = if (textColorMixed) Lucide.Minus else null,
     )
     TextToolbarSwatchButton(
       color = editorTheme.colorFor(EditorValues.textBackgroundColor, backgroundColor),
-      contentDescription = "배경색",
+      contentDescription = if (backgroundColorMixed) "배경색: 여러 색" else "배경색",
       onClick = { toggleMode(TextOptionMode.BackgroundColor) },
       selected = activeTextOptionMode == TextOptionMode.BackgroundColor,
       swatchShape = TextBackgroundSwatchShape,
-      showSlash = backgroundColor == "none",
+      markIcon =
+        when {
+          backgroundColorMixed -> Lucide.Minus
+          backgroundColor == "none" -> Lucide.Slash
+          else -> null
+        },
     )
     EditorToolbarLabelButton(
       text = fontFamilyLabel(fontFamily, fontFamilies),

--- a/apps/website/src/lib/editor-ffi/components/toolbar/BottomToolbar.svelte
+++ b/apps/website/src/lib/editor-ffi/components/toolbar/BottomToolbar.svelte
@@ -1,15 +1,17 @@
 <script lang="ts">
   import { css } from '@typie/styled-system/css';
   import { center, flex } from '@typie/styled-system/patterns';
-  import { DropdownMenu, DropdownMenuItem, VerticalDivider } from '@typie/ui/components';
+  import { DropdownMenu, DropdownMenuItem, Icon, VerticalDivider } from '@typie/ui/components';
   import { getAppContext, getThemeContext } from '@typie/ui/context';
   import BoldIcon from '~icons/lucide/bold';
   import ItalicIcon from '~icons/lucide/italic';
   import LinkIcon from '~icons/lucide/link';
   import MessageSquarePlusIcon from '~icons/lucide/message-square-plus';
+  import MinusIcon from '~icons/lucide/minus';
   import RedoIcon from '~icons/lucide/redo';
   import RemoveFormattingIcon from '~icons/lucide/remove-formatting';
   import SearchIcon from '~icons/lucide/search';
+  import SlashIcon from '~icons/lucide/slash';
   import StrikethroughIcon from '~icons/lucide/strikethrough';
   import UnderlineIcon from '~icons/lucide/underline';
   import UndoIcon from '~icons/lucide/undo';
@@ -75,6 +77,7 @@
         ? 'black'
         : undefined,
   );
+  const isTextColorMixed = $derived(ctx.editor?.modifierState?.text_color?.type === 'mixed');
 
   const currentTextBackgroundColor = $derived(
     ctx.editor?.modifierState?.background_color?.type === 'uniform'
@@ -83,6 +86,7 @@
         ? 'none'
         : undefined,
   );
+  const isTextBackgroundColorMixed = $derived(ctx.editor?.modifierState?.background_color?.type === 'mixed');
 
   const currentLineHeight = $derived(
     ctx.editor?.modifierState?.line_height?.type === 'uniform' ? ctx.editor.modifierState.line_height.value.value : undefined,
@@ -182,13 +186,34 @@
 
   <VerticalDivider style={css.raw({ height: '12px' })} />
   <div class={flex({ alignItems: 'center', gap: '4px' })}>
-    <ToolbarDropdownButton chevron label="글씨 색" onEscape={() => ctx.editor?.focus()} placement="bottom-start" size="small">
+    <ToolbarDropdownButton
+      chevron
+      label={isTextColorMixed ? '글씨 색: 여러 색' : '글씨 색'}
+      onEscape={() => ctx.editor?.focus()}
+      placement="bottom-start"
+      size="small"
+    >
       {#snippet anchor()}
         <div class={center({ size: '20px' })}>
-          <div
-            style:background-color={textColors.find(({ value }) => value === currentTextColor)?.color}
-            class={css({ borderWidth: '1px', borderRadius: 'full', size: '16px' })}
-          ></div>
+          {#if isTextColorMixed}
+            <div
+              class={css({
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                borderWidth: '1px',
+                borderRadius: 'full',
+                size: '16px',
+              })}
+            >
+              <Icon style={css.raw({ color: 'text.subtle' })} icon={MinusIcon} size={14} />
+            </div>
+          {:else}
+            <div
+              style:background-color={textColors.find(({ value }) => value === currentTextColor)?.color}
+              class={css({ borderWidth: '1px', borderRadius: 'full', size: '16px' })}
+            ></div>
+          {/if}
         </div>
       {/snippet}
 
@@ -206,7 +231,13 @@
       {/snippet}
     </ToolbarDropdownButton>
 
-    <ToolbarDropdownButton chevron label="배경색" onEscape={() => ctx.editor?.focus()} placement="bottom-start" size="small">
+    <ToolbarDropdownButton
+      chevron
+      label={isTextBackgroundColorMixed ? '배경색: 여러 색' : '배경색'}
+      onEscape={() => ctx.editor?.focus()}
+      placement="bottom-start"
+      size="small"
+    >
       {#snippet anchor()}
         {@const selectedValue = currentTextBackgroundColor}
         {@const selectedItem = textBackgroundColors.find(({ value }) => value === selectedValue)}
@@ -218,20 +249,15 @@
               borderRadius: '4px',
               size: '16px',
               position: 'relative',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
             })}
           >
-            {#if selectedValue === 'none'}
-              <div
-                class={css({
-                  position: 'absolute',
-                  inset: '0',
-                  margin: 'auto',
-                  width: '1px',
-                  height: '12px',
-                  backgroundColor: 'text.disabled',
-                  transform: 'rotate(45deg)',
-                })}
-              ></div>
+            {#if isTextBackgroundColorMixed}
+              <Icon style={css.raw({ color: 'text.subtle' })} icon={MinusIcon} size={14} />
+            {:else if selectedValue === 'none'}
+              <Icon style={css.raw({ color: 'text.disabled' })} icon={SlashIcon} size={10} />
             {/if}
           </div>
         </div>

--- a/apps/website/src/lib/editor-ffi/components/toolbar/ToolbarColorGrid.svelte
+++ b/apps/website/src/lib/editor-ffi/components/toolbar/ToolbarColorGrid.svelte
@@ -124,9 +124,9 @@
         outlineOffset: '1px',
         size: '20px',
         position: 'relative',
-        _focus: {
-          outlineWidth: '2px',
-        },
+        // Keyboard focus outlines are intentionally omitted for now because
+        // reusing the selection outline makes the first auto-focused swatch look
+        // selected. Restore them with a consistent toolbar-wide focus treatment.
       })}
       aria-label={label}
       data-active={currentValue === value}


### PR DESCRIPTION
기존에 focus된 옵션을 active 옵션처럼 보여주고 있었는데 이제 더 이상 그렇게 보여주지 않습니다. 나중에 포커스 ring 같은 것 제대로 지원하면 그 때 관행에 맞는 일관된 색깔로 도입하는 것이 나을듯.