### PR TITLE
웹/앱 노트 사용성 개선

### DIFF
--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/ui/utils/Shortcut.android.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/ui/utils/Shortcut.android.kt
@@ -1,0 +1,21 @@
+package co.typie.ui.utils
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+
+internal actual val platformModUsesMeta: Boolean = false
+
+internal actual fun Modifier.onShortcut(
+  key: Key,
+  modifiers: Set<ShortcutModifier>,
+  enabled: Boolean,
+  onShortcut: () -> Unit,
+): Modifier = onPreviewKeyEvent { event ->
+  if (!enabled || !matchesShortcut(event = event, key = key, modifiers = modifiers)) {
+    return@onPreviewKeyEvent false
+  }
+
+  onShortcut()
+  true
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteCard.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteCard.kt
@@ -34,10 +34,10 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -45,6 +45,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.platform.LocalDensity
@@ -68,6 +69,8 @@ import co.typie.graphql.fragment.NoteCard_note
 import co.typie.graphql.fragment.NoteLinkedEntity_entity
 import co.typie.graphql.type.NoteStatus
 import co.typie.icons.Lucide
+import co.typie.platform.Platform
+import co.typie.platform.PlatformModule
 import co.typie.ui.component.CardDivider
 import co.typie.ui.component.Text
 import co.typie.ui.component.popover.Popover
@@ -83,6 +86,8 @@ import co.typie.ui.skeleton.Skeleton
 import co.typie.ui.theme.AppShapes
 import co.typie.ui.theme.AppTheme
 import co.typie.ui.theme.shadow
+import co.typie.ui.utils.ShortcutModifier
+import co.typie.ui.utils.onShortcut
 import kotlin.math.abs
 
 private val NoteCardShape = AppShapes.rounded(AppShapes.md)
@@ -112,11 +117,25 @@ private val NoteEditorBringIntoViewSpec =
     }
   }
 
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+internal fun NoteEditorBringIntoViewScope(content: @Composable () -> Unit) {
+  if (PlatformModule.platform == Platform.iOS) {
+    CompositionLocalProvider(
+      LocalBringIntoViewSpec provides NoteEditorBringIntoViewSpec,
+      content = content,
+    )
+  } else {
+    content()
+  }
+}
+
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 internal fun NoteCard(
   note: NoteCard_note,
   expanded: Boolean,
+  autoFocusContent: Boolean,
   isDragging: Boolean,
   content: String,
   isSaving: Boolean,
@@ -126,6 +145,7 @@ internal fun NoteCard(
   modifier: Modifier = Modifier,
   onExpand: () -> Unit,
   onCollapse: () -> Unit,
+  onCreateNote: () -> Unit,
   onContentChange: (String) -> Unit,
   onBlur: () -> Unit,
   onToggleStatus: () -> Unit,
@@ -201,7 +221,6 @@ internal fun NoteCard(
             }
           )
       },
-      label = "note-card-content",
     ) { isExpanded ->
       if (isExpanded) {
         NoteExpandedContent(
@@ -211,8 +230,10 @@ internal fun NoteCard(
           colorOption = colorOption,
           dragHandleModifier = dragHandleModifier,
           contentEditable = contentEditable,
+          autoFocusContent = autoFocusContent,
           noteColorOptions = noteColorOptions,
           onCollapse = onCollapse,
+          onCreateNote = onCreateNote,
           onContentChange = onContentChange,
           onBlur = onBlur,
           onToggleStatus = onToggleStatus,
@@ -243,8 +264,10 @@ private fun NoteExpandedContent(
   colorOption: NoteColorOption,
   dragHandleModifier: Modifier,
   contentEditable: Boolean,
+  autoFocusContent: Boolean,
   noteColorOptions: List<NoteColorOption>,
   onCollapse: () -> Unit,
+  onCreateNote: () -> Unit,
   onContentChange: (String) -> Unit,
   onBlur: () -> Unit,
   onToggleStatus: () -> Unit,
@@ -274,8 +297,11 @@ private fun NoteExpandedContent(
         Column(modifier = Modifier.weight(1f).padding(top = 2.dp)) {
           NoteContentEditor(
             content = content,
+            resolved = note.status == NoteStatus.RESOLVED,
             onValueChange = onContentChange,
             onBlur = onBlur,
+            onCreateNote = onCreateNote,
+            autoFocus = autoFocusContent,
             readOnly = !contentEditable,
           )
         }
@@ -788,8 +814,11 @@ private fun NoteColorDot(option: NoteColorOption, selected: Boolean, onClick: ()
 @Composable
 private fun NoteContentEditor(
   content: String,
+  resolved: Boolean,
   onValueChange: (String) -> Unit,
   onBlur: () -> Unit,
+  onCreateNote: () -> Unit,
+  autoFocus: Boolean,
   readOnly: Boolean,
 ) {
   val focusManager = LocalFocusManager.current
@@ -800,18 +829,32 @@ private fun NoteContentEditor(
       onDismiss = { focusManager.clearFocus() },
     )
 
+  LaunchedEffect(autoFocus) {
+    if (autoFocus) {
+      textInputState.requestFocus()
+    }
+  }
+
   CompositionLocalProvider(LocalBringIntoViewSpec provides NoteEditorBringIntoViewSpec) {
     BasicTextField(
       value = textInputState.value,
       onValueChange = textInputState::onValueChange,
       modifier =
-        Modifier.fillMaxWidth().defaultMinSize(minHeight = 90.dp).textInputFocusable(
-          textInputState
-        ) { state ->
-          if (!state.isFocused) {
-            onBlur()
+        Modifier.fillMaxWidth()
+          .defaultMinSize(minHeight = 90.dp)
+          .textInputFocusable(textInputState) { state ->
+            if (!state.isFocused) {
+              onBlur()
+            }
           }
-        },
+          .onShortcut(
+            key = Key.Enter,
+            modifiers = setOf(ShortcutModifier.Mod),
+            enabled = !readOnly && textInputState.value.text.isNotBlank(),
+          ) {
+            textInputState.finishCompositionAndCollapseSelection()
+            onCreateNote()
+          },
       readOnly = readOnly,
       textStyle = AppTheme.typography.body.copy(color = AppTheme.colors.textDefault),
       keyboardOptions =
@@ -824,7 +867,7 @@ private fun NoteContentEditor(
         Box(modifier = Modifier.fillMaxWidth()) {
           if (textInputState.value.text.isEmpty()) {
             Text(
-              text = "내용을 입력하세요",
+              text = if (resolved) "(내용 없음)" else "떠오르는 생각을 적어보세요",
               style = AppTheme.typography.body,
               color = AppTheme.colors.textHint,
             )

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteEditState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteEditState.kt
@@ -25,7 +25,7 @@ internal class NoteEditState(
 
   private var activeForm: ActiveNoteFormState? by mutableStateOf(null)
 
-  fun open(note: NoteCard_note) {
+  fun open(note: NoteCard_note, autoFocusContent: Boolean = false) {
     val currentForm = activeForm
     if (currentForm?.noteId == note.id) {
       currentForm.commitServerSnapshot(note)
@@ -38,6 +38,7 @@ internal class NoteEditState(
         note = note,
         contentDebounceMillis = contentDebounceMillis,
         colorDebounceMillis = colorDebounceMillis,
+        autoFocusContent = autoFocusContent,
       )
   }
 
@@ -108,6 +109,9 @@ internal class NoteEditState(
   fun isSavingColor(noteId: String): Boolean =
     activeForm?.takeIf { it.noteId == noteId }?.isColorSaving == true
 
+  fun shouldAutoFocusContent(noteId: String): Boolean =
+    activeForm?.takeIf { it.noteId == noteId }?.autoFocusContent == true
+
   fun cancelPendingSaves(noteId: String) {
     activeForm?.takeIf { it.noteId == noteId }?.cancelPendingSaves()
   }
@@ -140,6 +144,7 @@ private class ActiveNoteFormState(
   note: NoteCard_note,
   contentDebounceMillis: Long,
   colorDebounceMillis: Long,
+  val autoFocusContent: Boolean,
 ) {
   val noteId: String = note.id
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteList.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteList.kt
@@ -56,6 +56,7 @@ internal data class NoteListItem(
   val isSaving: Boolean,
   val hasPendingColor: Boolean,
   val isDirty: Boolean,
+  val autoFocusContent: Boolean,
   val isEntering: Boolean,
   val isExiting: Boolean,
   val isExitVisible: Boolean,
@@ -64,6 +65,7 @@ internal data class NoteListItem(
 internal class NoteListActions(
   val onExpand: (NoteCard_note) -> Unit,
   val onCollapse: () -> Unit,
+  val onCreateNote: () -> Unit,
   val onContentChange: (String, String) -> Unit,
   val onBlur: (String) -> Unit,
   val onToggleStatus: (NoteCard_note) -> Unit,
@@ -124,6 +126,7 @@ internal fun NoteList(
             val noteIsEntering = !isLoading && item.isEntering
             val noteIsExiting = !isLoading && item.isExiting
             val noteIsExitVisible = !isLoading && item.isExitVisible
+            val cardExpanded = !isLoading && item.expanded
 
             LaunchedEffect(item.note.id, noteIsEntering) {
               if (noteIsEntering) {
@@ -142,6 +145,7 @@ internal fun NoteList(
             val visibilityState =
               remember(item.note.id) { MutableTransitionState(initialState = !noteIsEntering) }
             visibilityState.targetState = !noteIsExiting
+
             val rowModifier =
               if (reorderState.isDragging && !reorderState.isDragging(item.note.id)) {
                 Modifier.animateBounds(
@@ -193,7 +197,8 @@ internal fun NoteList(
             ) {
               NoteCard(
                 note = note,
-                expanded = !isLoading && item.expanded,
+                expanded = cardExpanded,
+                autoFocusContent = item.autoFocusContent,
                 isDragging = !isLoading && interactive && reorderState.isDragging(note.id),
                 content = noteContent,
                 isSaving = !isLoading && item.isSaving,
@@ -230,6 +235,11 @@ internal fun NoteList(
                   },
                 onExpand = { if (interactive && !isLoading) actions.onExpand(note) },
                 onCollapse = { if (interactive && !isLoading) actions.onCollapse() },
+                onCreateNote = {
+                  if (interactive && !isLoading) {
+                    actions.onCreateNote()
+                  }
+                },
                 onContentChange = { nextValue ->
                   if (interactive && !isLoading) {
                     actions.onContentChange(note.id, nextValue)

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -1289,7 +1289,6 @@ fun EditorScreen(entityId: String) {
     }
     val screenShortcutContext =
       EditorScreenShortcutContext(
-        platform = PlatformModule.platform,
         sceneInForeground = screenState.sceneInForeground,
         subPaneBlocksEditorInput = subPaneBlocksEditorInput,
         editorFocused = uiState.focused,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreenShortcut.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreenShortcut.kt
@@ -13,26 +13,12 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
-import androidx.compose.ui.input.key.KeyEventType
-import androidx.compose.ui.input.key.isAltPressed
-import androidx.compose.ui.input.key.isCtrlPressed
-import androidx.compose.ui.input.key.isMetaPressed
-import androidx.compose.ui.input.key.isShiftPressed
-import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
-import androidx.compose.ui.input.key.type
 import co.typie.editor.ffi.Selection
-import co.typie.platform.Platform
-
-internal enum class EditorScreenShortcutModifier {
-  Shift,
-  Mod,
-  Ctrl,
-  Alt,
-}
+import co.typie.ui.utils.ShortcutModifier
+import co.typie.ui.utils.matchesShortcut
 
 internal data class EditorScreenShortcutContext(
-  val platform: Platform,
   val sceneInForeground: Boolean,
   val subPaneBlocksEditorInput: Boolean,
   val editorFocused: Boolean,
@@ -50,7 +36,7 @@ internal data class EditorScreenShortcutActions(
 
 private data class EditorScreenShortcutBinding(
   val key: Key,
-  val modifiers: Set<EditorScreenShortcutModifier> = emptySet(),
+  val modifiers: Set<ShortcutModifier> = emptySet(),
   val enabled: (EditorScreenShortcutContext) -> Boolean = { true },
   val action: (EditorScreenShortcutContext, EditorScreenShortcutActions) -> Boolean,
 )
@@ -59,7 +45,7 @@ private val EditorScreenShortcutBindings =
   listOf(
     EditorScreenShortcutBinding(
       key = Key.F,
-      modifiers = setOf(EditorScreenShortcutModifier.Mod),
+      modifiers = setOf(ShortcutModifier.Mod),
       enabled = ::isEditorScreenShortcutAvailable,
       action = { _, actions ->
         actions.openFindReplace()
@@ -81,12 +67,7 @@ internal fun handleEditorScreenShortcut(
   val binding =
     EditorScreenShortcutBindings.firstOrNull { binding ->
       binding.enabled(context) &&
-        matchesEditorShortcut(
-          event = event,
-          platform = context.platform,
-          key = binding.key,
-          modifiers = binding.modifiers,
-        )
+        matchesShortcut(event = event, key = binding.key, modifiers = binding.modifiers)
     } ?: return false
 
   return binding.action(context, actions)
@@ -129,27 +110,6 @@ internal fun Modifier.editorScreenShortcutFocusTarget(
   return focusRequester(focusRequester)
     .onPreviewKeyEvent(onPreviewKeyEvent)
     .focusable(enabled = active && enabled)
-}
-
-internal fun matchesEditorShortcut(
-  event: KeyEvent,
-  platform: Platform,
-  key: Key,
-  modifiers: Set<EditorScreenShortcutModifier> = emptySet(),
-): Boolean {
-  if (event.type != KeyEventType.KeyDown) return false
-  if (event.key != key) return false
-
-  val modModifier = EditorScreenShortcutModifier.Mod in modifiers
-  val ctrlModifier = EditorScreenShortcutModifier.Ctrl in modifiers
-  val metaModifier = modModifier && platform != Platform.Android
-  val expectedCtrl = ctrlModifier || (modModifier && platform == Platform.Android)
-  val expectedMeta = metaModifier
-
-  return event.isShiftPressed == (EditorScreenShortcutModifier.Shift in modifiers) &&
-    event.isCtrlPressed == expectedCtrl &&
-    event.isMetaPressed == expectedMeta &&
-    event.isAltPressed == (EditorScreenShortcutModifier.Alt in modifiers)
 }
 
 private fun isEditorScreenShortcutAvailable(context: EditorScreenShortcutContext): Boolean =

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceToolbar.kt
@@ -35,9 +35,6 @@ import androidx.compose.ui.unit.dp
 import co.typie.ext.rememberTextInputState
 import co.typie.ext.textInputFocusable
 import co.typie.icons.Lucide
-import co.typie.platform.PlatformModule
-import co.typie.screen.editor.editor.EditorScreenShortcutModifier
-import co.typie.screen.editor.editor.matchesEditorShortcut
 import co.typie.screen.editor.editor.toolbar.EditorToolbarButton
 import co.typie.screen.editor.editor.toolbar.EditorToolbarSurfaceBackground
 import co.typie.screen.editor.editor.toolbar.ToolbarBorderWidth
@@ -58,6 +55,8 @@ import co.typie.ui.component.Text
 import co.typie.ui.theme.AppShapes
 import co.typie.ui.theme.AppTheme
 import co.typie.ui.theme.shadow
+import co.typie.ui.utils.ShortcutModifier
+import co.typie.ui.utils.matchesShortcut
 
 @Composable
 internal fun FindReplaceToolbar(
@@ -186,20 +185,15 @@ private fun handleReplaceInputShortcut(
   session: EditorFindReplaceSession,
 ): Boolean =
   when {
-    matchesEditorShortcut(event = event, platform = PlatformModule.platform, key = Key.Escape) -> {
+    matchesShortcut(event = event, key = Key.Escape) -> {
       session.close()
       true
     }
-    matchesEditorShortcut(
-      event = event,
-      platform = PlatformModule.platform,
-      key = Key.Enter,
-      modifiers = setOf(EditorScreenShortcutModifier.Mod),
-    ) -> {
+    matchesShortcut(event = event, key = Key.Enter, modifiers = setOf(ShortcutModifier.Mod)) -> {
       session.replaceAll()
       true
     }
-    matchesEditorShortcut(event = event, platform = PlatformModule.platform, key = Key.Enter) -> {
+    matchesShortcut(event = event, key = Key.Enter) -> {
       session.replace()
       true
     }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceTopBar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceTopBar.kt
@@ -33,9 +33,6 @@ import androidx.compose.ui.unit.dp
 import co.typie.ext.rememberTextInputState
 import co.typie.ext.textInputFocusable
 import co.typie.icons.Lucide
-import co.typie.platform.PlatformModule
-import co.typie.screen.editor.editor.EditorScreenShortcutModifier
-import co.typie.screen.editor.editor.matchesEditorShortcut
 import co.typie.ui.component.Text
 import co.typie.ui.component.popover.PopoverMenu
 import co.typie.ui.component.topbar.TopBarButton
@@ -44,6 +41,8 @@ import co.typie.ui.icon.Icon
 import co.typie.ui.theme.AppShapes
 import co.typie.ui.theme.AppTheme
 import co.typie.ui.theme.shadow
+import co.typie.ui.utils.ShortcutModifier
+import co.typie.ui.utils.matchesShortcut
 
 @Composable
 internal fun FindReplaceTopBarLeading(session: EditorFindReplaceSession) {
@@ -126,20 +125,15 @@ internal fun FindReplaceTopBarCenter(session: EditorFindReplaceSession) {
 
 private fun handleFindInputShortcut(event: KeyEvent, session: EditorFindReplaceSession): Boolean =
   when {
-    matchesEditorShortcut(event = event, platform = PlatformModule.platform, key = Key.Escape) -> {
+    matchesShortcut(event = event, key = Key.Escape) -> {
       session.close()
       true
     }
-    matchesEditorShortcut(
-      event = event,
-      platform = PlatformModule.platform,
-      key = Key.Enter,
-      modifiers = setOf(EditorScreenShortcutModifier.Shift),
-    ) -> {
+    matchesShortcut(event = event, key = Key.Enter, modifiers = setOf(ShortcutModifier.Shift)) -> {
       session.findPrevious()
       true
     }
-    matchesEditorShortcut(event = event, platform = PlatformModule.platform, key = Key.Enter) -> {
+    matchesShortcut(event = event, key = Key.Enter) -> {
       session.findNext()
       true
     }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/relatednotes/RelatedNotesSheet.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/relatednotes/RelatedNotesSheet.kt
@@ -16,7 +16,11 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
@@ -25,6 +29,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import co.typie.domain.entity.isFolder
 import co.typie.domain.note.NoteEditState
+import co.typie.domain.note.NoteEditorBringIntoViewScope
 import co.typie.domain.note.NoteEntityPickerSheet
 import co.typie.domain.note.NoteEntityPickerStops
 import co.typie.domain.note.NoteLinkedEntityActionsSheet
@@ -205,6 +210,7 @@ private fun RelatedNotesSheetContent(
   val scope = rememberCoroutineScope()
   val sheet = LocalSheet.current
   val noteColorOptions = rememberNoteColorOptions()
+  var shortcutCreateInFlight by remember { mutableStateOf(false) }
 
   suspend fun flushNoteEdits(noteId: String): Boolean {
     return noteEditState.flush(
@@ -236,7 +242,7 @@ private fun RelatedNotesSheetContent(
     scrollState.scrollTo(0)
   }
 
-  suspend fun handleCreateNote() {
+  suspend fun handleCreateNote(autoFocusContent: Boolean = false) {
     if (!SubscriptionService.gate(sheet, GatedAction.CreateNote)) {
       return
     }
@@ -253,8 +259,9 @@ private fun RelatedNotesSheetContent(
     when (val result = model.createNote()) {
       is Result.Ok -> {
         model.listState(NoteStatus.OPEN).markEntering(result.value)
-        noteEditState.open(note = result.value)
+        noteEditState.open(note = result.value, autoFocusContent = autoFocusContent)
         model.refetch()
+        scrollState.animateScrollTo(0)
       }
 
       is Result.Err,
@@ -264,17 +271,34 @@ private fun RelatedNotesSheetContent(
     }
   }
 
-  suspend fun handleDeleteNote(note: NoteCard_note, sceneStatus: NoteStatus) {
-    val confirmed =
-      dialog.confirm(
-        title = "노트 삭제",
-        message = "이 노트를 삭제하시겠어요?\n복구할 수 없어요.",
-        confirmText = "삭제",
-        confirmIsDestructive = true,
-      )
-
-    if (confirmed !is DialogResult.Resolved) {
+  fun handleShortcutCreateNote() {
+    if (shortcutCreateInFlight) {
       return
+    }
+
+    shortcutCreateInFlight = true
+    scope.launch {
+      try {
+        handleCreateNote(autoFocusContent = true)
+      } finally {
+        shortcutCreateInFlight = false
+      }
+    }
+  }
+
+  suspend fun handleDeleteNote(note: NoteCard_note, sceneStatus: NoteStatus) {
+    if (note.content.isNotBlank()) {
+      val confirmed =
+        dialog.confirm(
+          title = "노트 삭제",
+          message = "이 노트를 삭제하시겠어요?\n복구할 수 없어요.",
+          confirmText = "삭제",
+          confirmIsDestructive = true,
+        )
+
+      if (confirmed !is DialogResult.Resolved) {
+        return
+      }
     }
 
     noteEditState.cancelPendingSaves(note.id)
@@ -465,6 +489,7 @@ private fun RelatedNotesSheetContent(
           isSaving = noteEditState.isSaving(note.id) || noteEditState.isSavingColor(note.id),
           hasPendingColor = noteEditState.hasPendingColor(note.id),
           isDirty = noteEditState.isDirty(note.id),
+          autoFocusContent = noteEditState.shouldAutoFocusContent(note.id),
           isEntering = listState.isEntering(note.id),
           isExiting = listState.isExiting(note.id),
           isExitVisible = listState.isExitVisible(note.id),
@@ -474,6 +499,7 @@ private fun RelatedNotesSheetContent(
         NoteListActions(
           onExpand = { note -> scope.launch { handleExpandNote(note) } },
           onCollapse = { scope.launch { collapseExpandedNote() } },
+          onCreateNote = ::handleShortcutCreateNote,
           onContentChange = { noteId, content ->
             noteEditState.updateContent(noteId = noteId, value = content, save = saveNoteContent)
           },
@@ -489,26 +515,29 @@ private fun RelatedNotesSheetContent(
         )
       val reorderState = rememberNoteListReorderState(items = listItems, scrollState = scrollState)
 
-      Box(modifier = Modifier.fillMaxSize().reorderableViewport(state = reorderState)) {
-        Column(
-          modifier = Modifier.fillMaxSize().verticalScroll(scrollState).padding(horizontal = 16.dp),
-          verticalArrangement = Arrangement.spacedBy(16.dp),
-        ) {
-          NoteList(
-            emptyMessage = status.emptyMessage(),
-            queryState = model.queryState(status),
-            items = listItems,
-            onEnterAnimationFinished = listState::finishEntering,
-            onExitAnimationFinished = listState::finishExiting,
-            reorderState = reorderState,
-            noteColorOptions = noteColorOptions,
-            interactive = status == model.filterStatus,
-            reorderEnabled = SubscriptionService.entitlement !is Entitlement.Expired,
-            contentEditable = SubscriptionService.entitlement !is Entitlement.Expired,
-            actions = listActions,
-          )
+      NoteEditorBringIntoViewScope {
+        Box(modifier = Modifier.fillMaxSize().reorderableViewport(state = reorderState)) {
+          Column(
+            modifier =
+              Modifier.fillMaxSize().verticalScroll(scrollState).padding(horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+          ) {
+            NoteList(
+              emptyMessage = status.emptyMessage(),
+              queryState = model.queryState(status),
+              items = listItems,
+              onEnterAnimationFinished = listState::finishEntering,
+              onExitAnimationFinished = listState::finishExiting,
+              reorderState = reorderState,
+              noteColorOptions = noteColorOptions,
+              interactive = status == model.filterStatus,
+              reorderEnabled = SubscriptionService.entitlement !is Entitlement.Expired,
+              contentEditable = SubscriptionService.entitlement !is Entitlement.Expired,
+              actions = listActions,
+            )
 
-          Spacer(Modifier.height(RelatedNotesListBottomContentPadding))
+            Spacer(Modifier.height(RelatedNotesListBottomContentPadding))
+          }
         }
       }
     }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/notes/NotesScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/notes/NotesScreen.kt
@@ -16,12 +16,17 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import co.typie.domain.entity.isFolder
+import co.typie.domain.note.NoteEditorBringIntoViewScope
 import co.typie.domain.note.NoteEntityPickerSheet
 import co.typie.domain.note.NoteEntityPickerStops
 import co.typie.domain.note.NoteLinkedEntityActionsSheet
@@ -90,6 +95,7 @@ fun NotesScreen() {
   val sheet = LocalSheet.current
   val siteId = model.siteId
   val noteColorOptions = rememberNoteColorOptions()
+  var shortcutCreateInFlight by remember { mutableStateOf(false) }
 
   DisposableEffect(noteEditState, model) {
     onDispose {
@@ -164,7 +170,7 @@ fun NotesScreen() {
     scrollState.scrollTo(0)
   }
 
-  suspend fun handleCreateNote() {
+  suspend fun handleCreateNote(autoFocusContent: Boolean = false) {
     if (siteId == null) {
       return
     }
@@ -185,8 +191,9 @@ fun NotesScreen() {
     when (val result = model.createNote()) {
       is Result.Ok -> {
         model.listState(NoteStatus.OPEN).markEntering(result.value)
-        noteEditState.open(note = result.value)
+        noteEditState.open(note = result.value, autoFocusContent = autoFocusContent)
         model.refetch()
+        scrollState.animateScrollTo(0)
       }
 
       is Result.Err,
@@ -196,17 +203,34 @@ fun NotesScreen() {
     }
   }
 
-  suspend fun handleDeleteNote(note: NoteCard_note, sceneStatus: NoteStatus) {
-    val confirmed =
-      dialog.confirm(
-        title = "노트 삭제",
-        message = "이 노트를 삭제하시겠어요?\n복구할 수 없어요.",
-        confirmText = "삭제",
-        confirmIsDestructive = true,
-      )
-
-    if (confirmed !is DialogResult.Resolved) {
+  fun handleShortcutCreateNote() {
+    if (shortcutCreateInFlight) {
       return
+    }
+
+    shortcutCreateInFlight = true
+    scope.launch {
+      try {
+        handleCreateNote(autoFocusContent = true)
+      } finally {
+        shortcutCreateInFlight = false
+      }
+    }
+  }
+
+  suspend fun handleDeleteNote(note: NoteCard_note, sceneStatus: NoteStatus) {
+    if (note.content.isNotBlank()) {
+      val confirmed =
+        dialog.confirm(
+          title = "노트 삭제",
+          message = "이 노트를 삭제하시겠어요?\n복구할 수 없어요.",
+          confirmText = "삭제",
+          confirmIsDestructive = true,
+        )
+
+      if (confirmed !is DialogResult.Resolved) {
+        return
+      }
     }
 
     noteEditState.cancelPendingSaves(note.id)
@@ -387,6 +411,7 @@ fun NotesScreen() {
           isSaving = noteEditState.isSaving(note.id) || noteEditState.isSavingColor(note.id),
           hasPendingColor = noteEditState.hasPendingColor(note.id),
           isDirty = noteEditState.isDirty(note.id),
+          autoFocusContent = noteEditState.shouldAutoFocusContent(note.id),
           isEntering = listState.isEntering(note.id),
           isExiting = listState.isExiting(note.id),
           isExitVisible = listState.isExitVisible(note.id),
@@ -396,6 +421,7 @@ fun NotesScreen() {
         NoteListActions(
           onExpand = { note -> scope.launch { handleExpandNote(note) } },
           onCollapse = { scope.launch { collapseExpandedNote() } },
+          onCreateNote = ::handleShortcutCreateNote,
           onContentChange = { noteId, content ->
             noteEditState.updateContent(noteId = noteId, value = content, save = ::saveNoteContent)
           },
@@ -413,37 +439,39 @@ fun NotesScreen() {
       val reorderViewportBottomInset =
         WindowInsets.safeDrawing.asPaddingValues().calculateBottomPadding() + 72.dp
 
-      Box(
-        modifier =
-          Modifier.fillMaxSize()
-            .reorderableViewport(
-              state = reorderState,
-              viewportTopInset = topBarOcclusion,
-              viewportBottomInset = reorderViewportBottomInset,
-            )
-            .imePadding()
-      ) {
-        Column(
-          modifier = Modifier.fillMaxSize().verticalScroll(scrollState).padding(innerPadding),
-          verticalArrangement = Arrangement.spacedBy(16.dp),
+      NoteEditorBringIntoViewScope {
+        Box(
+          modifier =
+            Modifier.fillMaxSize()
+              .reorderableViewport(
+                state = reorderState,
+                viewportTopInset = topBarOcclusion,
+                viewportBottomInset = reorderViewportBottomInset,
+              )
+              .imePadding()
         ) {
-          Skeleton.Keep { Text(text = "노트", style = AppTheme.typography.display) }
+          Column(
+            modifier = Modifier.fillMaxSize().verticalScroll(scrollState).padding(innerPadding),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+          ) {
+            Skeleton.Keep { Text(text = "노트", style = AppTheme.typography.display) }
 
-          NoteList(
-            emptyMessage = status.emptyMessage(),
-            queryState = model.queryState(status),
-            items = listItems,
-            onEnterAnimationFinished = listState::finishEntering,
-            onExitAnimationFinished = listState::finishExiting,
-            reorderState = reorderState,
-            noteColorOptions = noteColorOptions,
-            interactive = status == model.filterStatus,
-            reorderEnabled = SubscriptionService.entitlement !is Entitlement.Expired,
-            contentEditable = SubscriptionService.entitlement !is Entitlement.Expired,
-            actions = listActions,
-          )
+            NoteList(
+              emptyMessage = status.emptyMessage(),
+              queryState = model.queryState(status),
+              items = listItems,
+              onEnterAnimationFinished = listState::finishEntering,
+              onExitAnimationFinished = listState::finishExiting,
+              reorderState = reorderState,
+              noteColorOptions = noteColorOptions,
+              interactive = status == model.filterStatus,
+              reorderEnabled = SubscriptionService.entitlement !is Entitlement.Expired,
+              contentEditable = SubscriptionService.entitlement !is Entitlement.Expired,
+              actions = listActions,
+            )
 
-          Spacer(Modifier.height(140.dp))
+            Spacer(Modifier.height(140.dp))
+          }
         }
       }
     }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/utils/Shortcut.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/utils/Shortcut.kt
@@ -1,0 +1,66 @@
+package co.typie.ui.utils
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isAltPressed
+import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.isMetaPressed
+import androidx.compose.ui.input.key.isShiftPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.type
+
+internal enum class ShortcutModifier {
+  Shift,
+  Mod,
+  Ctrl,
+  Alt,
+}
+
+internal expect val platformModUsesMeta: Boolean
+
+// NOTE: 플랫폼 텍스트 입력이 KeyDown을 Compose modifier보다 먼저 소비할 수 있어
+// 일반 onPreviewKeyEvent만으로 처리할 수 없는 shortcut을 플랫폼별 입력 경로에서 통합
+internal expect fun Modifier.onShortcut(
+  key: Key,
+  modifiers: Set<ShortcutModifier> = emptySet(),
+  enabled: Boolean,
+  onShortcut: () -> Unit,
+): Modifier
+
+internal fun matchesShortcut(
+  event: KeyEvent,
+  key: Key,
+  modifiers: Set<ShortcutModifier> = emptySet(),
+  eventType: KeyEventType = KeyEventType.KeyDown,
+): Boolean {
+  if (event.type != eventType || event.key != key) {
+    return false
+  }
+
+  return matchesShortcutModifiers(
+    isShiftPressed = event.isShiftPressed,
+    isCtrlPressed = event.isCtrlPressed,
+    isMetaPressed = event.isMetaPressed,
+    isAltPressed = event.isAltPressed,
+    modifiers = modifiers,
+  )
+}
+
+internal fun matchesShortcutModifiers(
+  isShiftPressed: Boolean,
+  isCtrlPressed: Boolean,
+  isMetaPressed: Boolean,
+  isAltPressed: Boolean,
+  modifiers: Set<ShortcutModifier>,
+): Boolean {
+  val expectsMod = ShortcutModifier.Mod in modifiers
+  val expectedCtrl = ShortcutModifier.Ctrl in modifiers || (expectsMod && !platformModUsesMeta)
+  val expectedMeta = expectsMod && platformModUsesMeta
+
+  return isShiftPressed == (ShortcutModifier.Shift in modifiers) &&
+    isCtrlPressed == expectedCtrl &&
+    isMetaPressed == expectedMeta &&
+    isAltPressed == (ShortcutModifier.Alt in modifiers)
+}

--- a/apps/mobile/compose/src/desktopMain/kotlin/co/typie/ui/utils/Shortcut.desktop.kt
+++ b/apps/mobile/compose/src/desktopMain/kotlin/co/typie/ui/utils/Shortcut.desktop.kt
@@ -1,0 +1,122 @@
+package co.typie.ui.utils
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusEventModifierNode
+import androidx.compose.ui.focus.FocusState
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.nativeKeyCode
+import androidx.compose.ui.input.key.nativeKeyLocation
+import androidx.compose.ui.node.ModifierNodeElement
+import java.awt.KeyEventDispatcher
+import java.awt.KeyboardFocusManager
+import java.awt.event.KeyEvent
+
+internal actual val platformModUsesMeta: Boolean =
+  System.getProperty("os.name").startsWith("Mac", ignoreCase = true)
+
+internal actual fun Modifier.onShortcut(
+  key: Key,
+  modifiers: Set<ShortcutModifier>,
+  enabled: Boolean,
+  onShortcut: () -> Unit,
+): Modifier = this then DesktopShortcutElement(key, modifiers, enabled, onShortcut)
+
+private data class DesktopShortcutElement(
+  private val key: Key,
+  private val modifiers: Set<ShortcutModifier>,
+  private val enabled: Boolean,
+  private val onShortcut: () -> Unit,
+) : ModifierNodeElement<DesktopShortcutNode>() {
+  override fun create(): DesktopShortcutNode =
+    DesktopShortcutNode(key, modifiers, enabled, onShortcut)
+
+  override fun update(node: DesktopShortcutNode) {
+    node.update(key, modifiers, enabled, onShortcut)
+  }
+}
+
+private class DesktopShortcutNode(
+  private var key: Key,
+  private var modifiers: Set<ShortcutModifier>,
+  private var enabled: Boolean,
+  private var onShortcut: () -> Unit,
+) : Modifier.Node(), FocusEventModifierNode {
+  private val focusManager = KeyboardFocusManager.getCurrentKeyboardFocusManager()
+  private val keyEventDispatcher = KeyEventDispatcher(::dispatchKeyEvent)
+  private var focused = false
+  private var sawKeyDown = false
+  private var handledKeyDown = false
+
+  override fun onFocusEvent(focusState: FocusState) {
+    focused = focusState.isFocused
+    if (!focused) {
+      sawKeyDown = false
+      handledKeyDown = false
+    }
+  }
+
+  override fun onAttach() {
+    focusManager.addKeyEventDispatcher(keyEventDispatcher)
+  }
+
+  override fun onDetach() {
+    focusManager.removeKeyEventDispatcher(keyEventDispatcher)
+    super.onDetach()
+  }
+
+  fun update(key: Key, modifiers: Set<ShortcutModifier>, enabled: Boolean, onShortcut: () -> Unit) {
+    this.key = key
+    this.modifiers = modifiers
+    this.enabled = enabled
+    this.onShortcut = onShortcut
+  }
+
+  private fun dispatchKeyEvent(event: KeyEvent): Boolean {
+    if (!matchesKey(event)) {
+      return false
+    }
+
+    if (event.id == KeyEvent.KEY_RELEASED) {
+      val shouldHandle = !sawKeyDown && focused && enabled && modifiersMatch(event)
+      sawKeyDown = false
+      handledKeyDown = false
+      if (shouldHandle) {
+        onShortcut()
+      }
+      return shouldHandle
+    }
+
+    if (event.id != KeyEvent.KEY_PRESSED) {
+      return false
+    }
+
+    if (!sawKeyDown) {
+      sawKeyDown = true
+      handledKeyDown = focused && enabled && modifiersMatch(event)
+      if (handledKeyDown) {
+        onShortcut()
+      }
+    }
+    return handledKeyDown
+  }
+
+  private fun matchesKey(event: KeyEvent): Boolean {
+    val eventKeyLocation =
+      if (event.keyLocation == KeyEvent.KEY_LOCATION_UNKNOWN) {
+        KeyEvent.KEY_LOCATION_STANDARD
+      } else {
+        event.keyLocation
+      }
+
+    return event.keyCode == key.nativeKeyCode && eventKeyLocation == key.nativeKeyLocation
+  }
+
+  private fun modifiersMatch(event: KeyEvent): Boolean =
+    matchesShortcutModifiers(
+      isShiftPressed = event.isShiftDown,
+      isCtrlPressed = event.isControlDown,
+      isMetaPressed = event.isMetaDown,
+      isAltPressed = event.isAltDown,
+      modifiers = modifiers,
+    )
+}

--- a/apps/mobile/compose/src/iosMain/kotlin/co/typie/MainViewController.kt
+++ b/apps/mobile/compose/src/iosMain/kotlin/co/typie/MainViewController.kt
@@ -1,7 +1,12 @@
 package co.typie
 
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.uikit.OnFocusBehavior
 import androidx.compose.ui.window.ComposeUIViewController
+import co.typie.ui.utils.LocalNativeShortcutRegistry
+import co.typie.ui.utils.NativeShortcutRegistry
 
-fun MainViewController() =
-  ComposeUIViewController(configure = { onFocusBehavior = OnFocusBehavior.DoNothing }) { App() }
+fun MainViewController(shortcutRegistry: NativeShortcutRegistry) =
+  ComposeUIViewController(configure = { onFocusBehavior = OnFocusBehavior.DoNothing }) {
+    CompositionLocalProvider(LocalNativeShortcutRegistry provides shortcutRegistry) { App() }
+  }

--- a/apps/mobile/compose/src/iosMain/kotlin/co/typie/ui/utils/NativeShortcutRouter.kt
+++ b/apps/mobile/compose/src/iosMain/kotlin/co/typie/ui/utils/NativeShortcutRouter.kt
@@ -1,0 +1,113 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+package co.typie.ui.utils
+
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusEventModifierNode
+import androidx.compose.ui.focus.FocusState
+import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.currentValueOf
+import platform.UIKit.UIKeyModifierAlternate
+import platform.UIKit.UIKeyModifierCommand
+import platform.UIKit.UIKeyModifierControl
+import platform.UIKit.UIKeyModifierShift
+
+internal fun Modifier.nativeShortcut(
+  input: String,
+  modifierFlags: Long,
+  enabled: Boolean,
+  onShortcut: () -> Unit,
+): Modifier = this then NativeShortcutElement(input, modifierFlags, enabled, onShortcut)
+
+internal fun nativeShortcutModifierFlags(modifiers: Set<ShortcutModifier>): Long {
+  var flags = 0L
+  if (ShortcutModifier.Shift in modifiers) flags = flags or UIKeyModifierShift
+  if (ShortcutModifier.Ctrl in modifiers) flags = flags or UIKeyModifierControl
+  if (ShortcutModifier.Mod in modifiers) flags = flags or UIKeyModifierCommand
+  if (ShortcutModifier.Alt in modifiers) flags = flags or UIKeyModifierAlternate
+  return flags
+}
+
+private data class NativeShortcutElement(
+  private val input: String,
+  private val modifierFlags: Long,
+  private val enabled: Boolean,
+  private val onShortcut: () -> Unit,
+) : ModifierNodeElement<NativeShortcutNode>() {
+  override fun create(): NativeShortcutNode =
+    NativeShortcutNode(input, modifierFlags, enabled, onShortcut)
+
+  override fun update(node: NativeShortcutNode) {
+    node.update(input, modifierFlags, enabled, onShortcut)
+  }
+}
+
+internal class NativeShortcutNode(
+  var input: String,
+  var modifierFlags: Long,
+  private var enabled: Boolean,
+  var onShortcut: () -> Unit,
+) : Modifier.Node(), FocusEventModifierNode, CompositionLocalConsumerModifierNode {
+  private var focused = false
+  private var registry: NativeShortcutRegistry? = null
+
+  override fun onAttach() {
+    registry = currentValueOf(LocalNativeShortcutRegistry)
+    syncRegistration()
+  }
+
+  override fun onFocusEvent(focusState: FocusState) {
+    focused = focusState.isFocused
+    syncRegistration()
+  }
+
+  override fun onDetach() {
+    registry?.deactivate(this)
+    registry = null
+    super.onDetach()
+  }
+
+  fun update(input: String, modifierFlags: Long, enabled: Boolean, onShortcut: () -> Unit) {
+    this.input = input
+    this.modifierFlags = modifierFlags
+    this.enabled = enabled
+    this.onShortcut = onShortcut
+    syncRegistration()
+  }
+
+  private fun syncRegistration() {
+    val registry = registry ?: return
+    if (isAttached && focused && enabled) {
+      registry.activate(this)
+    } else {
+      registry.deactivate(this)
+    }
+  }
+}
+
+class NativeShortcutRegistry {
+  private var active: NativeShortcutNode? = null
+
+  internal fun activate(node: NativeShortcutNode) {
+    active = node
+  }
+
+  internal fun deactivate(node: NativeShortcutNode) {
+    if (active === node) {
+      active = null
+    }
+  }
+
+  fun activeInput(): String? = active?.input
+
+  fun activeModifierFlags(): Long = active?.modifierFlags ?: 0L
+
+  fun dispatch(input: String, modifierFlags: Long) {
+    active?.takeIf { it.input == input && it.modifierFlags == modifierFlags }?.onShortcut?.invoke()
+  }
+}
+
+internal val LocalNativeShortcutRegistry =
+  staticCompositionLocalOf<NativeShortcutRegistry> { error("No NativeShortcutRegistry provided") }

--- a/apps/mobile/compose/src/iosMain/kotlin/co/typie/ui/utils/Shortcut.ios.kt
+++ b/apps/mobile/compose/src/iosMain/kotlin/co/typie/ui/utils/Shortcut.ios.kt
@@ -1,0 +1,32 @@
+package co.typie.ui.utils
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+
+internal actual val platformModUsesMeta: Boolean = true
+
+internal actual fun Modifier.onShortcut(
+  key: Key,
+  modifiers: Set<ShortcutModifier>,
+  enabled: Boolean,
+  onShortcut: () -> Unit,
+): Modifier {
+  if (key == Key.Enter) {
+    return nativeShortcut(
+      input = "\r",
+      modifierFlags = nativeShortcutModifierFlags(modifiers),
+      enabled = enabled,
+      onShortcut = onShortcut,
+    )
+  }
+
+  return onPreviewKeyEvent { event ->
+    if (!enabled || !matchesShortcut(event = event, key = key, modifiers = modifiers)) {
+      return@onPreviewKeyEvent false
+    }
+
+    onShortcut()
+    true
+  }
+}

--- a/apps/mobile/ios/App/SceneDelegate.swift
+++ b/apps/mobile/ios/App/SceneDelegate.swift
@@ -17,8 +17,15 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     let window = UIWindow(windowScene: windowScene)
-    let controller = MainViewControllerKt.MainViewController()
-    controller.view.backgroundColor = .systemBackground
+    let shortcutRegistry = NativeShortcutRegistry()
+    let composeController = MainViewControllerKt.MainViewController(
+      shortcutRegistry: shortcutRegistry
+    )
+    composeController.view.backgroundColor = .systemBackground
+    let controller = ShortcutHostingViewController(
+      content: composeController,
+      shortcutRegistry: shortcutRegistry
+    )
     window.backgroundColor = .systemBackground
     window.rootViewController = controller
     self.window = window

--- a/apps/mobile/ios/App/ShortcutHostingViewController.swift
+++ b/apps/mobile/ios/App/ShortcutHostingViewController.swift
@@ -1,0 +1,58 @@
+import Compose
+import UIKit
+
+final class ShortcutHostingViewController: UIViewController {
+  private let content: UIViewController
+  private let shortcutRegistry: NativeShortcutRegistry
+
+  init(content: UIViewController, shortcutRegistry: NativeShortcutRegistry) {
+    self.content = content
+    self.shortcutRegistry = shortcutRegistry
+    super.init(nibName: nil, bundle: nil)
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    addChild(content)
+    content.view.frame = view.bounds
+    content.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+    view.addSubview(content.view)
+    content.didMove(toParent: self)
+  }
+
+  override var childForStatusBarStyle: UIViewController? {
+    content
+  }
+
+  override var childForStatusBarHidden: UIViewController? {
+    content
+  }
+
+  override var keyCommands: [UIKeyCommand]? {
+    guard let input = shortcutRegistry.activeInput() else {
+      return super.keyCommands
+    }
+
+    let command = UIKeyCommand(
+      input: input,
+      modifierFlags: UIKeyModifierFlags(
+        rawValue: Int(shortcutRegistry.activeModifierFlags())
+      ),
+      action: #selector(handleShortcut(_:))
+    )
+    command.wantsPriorityOverSystemBehavior = true
+    return (super.keyCommands ?? []) + [command]
+  }
+
+  @objc private func handleShortcut(_ command: UIKeyCommand) {
+    shortcutRegistry.dispatch(
+      input: command.input ?? "",
+      modifierFlags: Int64(command.modifierFlags.rawValue)
+    )
+  }
+}

--- a/apps/website/src/lib/note-reorder.test.ts
+++ b/apps/website/src/lib/note-reorder.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+import { reorderedNoteIdsForDrag } from './note-reorder';
+import type { NoteReorderGeometry } from './note-reorder';
+
+const geometry = (entries: Record<string, NoteReorderGeometry>) => new Map(Object.entries(entries));
+
+describe('reorderedNoteIdsForDrag', () => {
+  it('does not swap at exactly half overlap with the next note', () => {
+    const result = reorderedNoteIdsForDrag(
+      ['dragged', 'next', 'tail'],
+      'dragged',
+      1,
+      geometry({
+        dragged: { top: 50, bottom: 150 },
+        next: { top: 100, bottom: 200 },
+        tail: { top: 200, bottom: 300 },
+      }),
+    );
+
+    expect(result).toEqual(['dragged', 'next', 'tail']);
+  });
+
+  it('swaps with the next note once overlap is greater than half the smaller height', () => {
+    const result = reorderedNoteIdsForDrag(
+      ['dragged', 'next', 'tail'],
+      'dragged',
+      1,
+      geometry({
+        dragged: { top: 85, bottom: 145 },
+        next: { top: 100, bottom: 300 },
+        tail: { top: 300, bottom: 360 },
+      }),
+    );
+
+    expect(result).toEqual(['next', 'dragged', 'tail']);
+  });
+
+  it('swaps with the previous note once overlap is greater than half the smaller height', () => {
+    const result = reorderedNoteIdsForDrag(
+      ['head', 'dragged', 'tail'],
+      'dragged',
+      -1,
+      geometry({
+        head: { top: 0, bottom: 100 },
+        dragged: { top: 49, bottom: 149 },
+        tail: { top: 200, bottom: 300 },
+      }),
+    );
+
+    expect(result).toEqual(['dragged', 'head', 'tail']);
+  });
+
+  it('does not swap at exactly half overlap with the previous note', () => {
+    const result = reorderedNoteIdsForDrag(
+      ['head', 'dragged', 'tail'],
+      'dragged',
+      -1,
+      geometry({
+        head: { top: 0, bottom: 100 },
+        dragged: { top: 50, bottom: 150 },
+        tail: { top: 200, bottom: 300 },
+      }),
+    );
+
+    expect(result).toEqual(['head', 'dragged', 'tail']);
+  });
+
+  it('swaps down after fully crossing the next note without overlap', () => {
+    const result = reorderedNoteIdsForDrag(
+      ['dragged', 'next', 'tail'],
+      'dragged',
+      1,
+      geometry({
+        dragged: { top: 200, bottom: 300 },
+        next: { top: 100, bottom: 200 },
+        tail: { top: 300, bottom: 400 },
+      }),
+    );
+
+    expect(result).toEqual(['next', 'dragged', 'tail']);
+  });
+
+  it('swaps up after fully crossing the previous note without overlap', () => {
+    const result = reorderedNoteIdsForDrag(
+      ['head', 'dragged', 'tail'],
+      'dragged',
+      -1,
+      geometry({
+        head: { top: 100, bottom: 200 },
+        dragged: { top: 0, bottom: 100 },
+        tail: { top: 300, bottom: 400 },
+      }),
+    );
+
+    expect(result).toEqual(['dragged', 'head', 'tail']);
+  });
+
+  it('does not reorder while stationary after a prior swap', () => {
+    const result = reorderedNoteIdsForDrag(
+      ['a', 'c', 'b', 'd'],
+      'b',
+      0,
+      geometry({
+        a: { top: 0, bottom: 50 },
+        c: { top: 100, bottom: 150 },
+        b: { top: 50, bottom: 100 },
+        d: { top: 150, bottom: 200 },
+      }),
+    );
+
+    expect(result).toEqual(['a', 'c', 'b', 'd']);
+  });
+
+  it('crosses multiple next notes in one update', () => {
+    const result = reorderedNoteIdsForDrag(
+      ['dragged', 'first', 'second', 'tail'],
+      'dragged',
+      1,
+      geometry({
+        dragged: { top: 175, bottom: 225 },
+        first: { top: 50, bottom: 100 },
+        second: { top: 100, bottom: 150 },
+        tail: { top: 250, bottom: 300 },
+      }),
+    );
+
+    expect(result).toEqual(['first', 'second', 'dragged', 'tail']);
+  });
+
+  it('crosses multiple previous notes in one update', () => {
+    const result = reorderedNoteIdsForDrag(
+      ['head', 'first', 'second', 'dragged', 'tail'],
+      'dragged',
+      -1,
+      geometry({
+        head: { top: 0, bottom: 50 },
+        first: { top: 100, bottom: 150 },
+        second: { top: 200, bottom: 250 },
+        dragged: { top: 40, bottom: 90 },
+        tail: { top: 300, bottom: 350 },
+      }),
+    );
+
+    expect(result).toEqual(['head', 'dragged', 'first', 'second', 'tail']);
+  });
+
+  it('does not mutate the input note IDs', () => {
+    const noteIds = ['dragged', 'next'];
+
+    const result = reorderedNoteIdsForDrag(
+      noteIds,
+      'dragged',
+      1,
+      geometry({
+        dragged: { top: 60, bottom: 160 },
+        next: { top: 100, bottom: 200 },
+      }),
+    );
+
+    expect(result).toEqual(['next', 'dragged']);
+    expect(noteIds).toEqual(['dragged', 'next']);
+  });
+
+  it('returns null when the dragged note geometry is missing', () => {
+    const result = reorderedNoteIdsForDrag(['a', 'b'], 'a', 1, geometry({ b: { top: 50, bottom: 100 } }));
+
+    expect(result).toBeNull();
+  });
+});

--- a/apps/website/src/lib/note-reorder.ts
+++ b/apps/website/src/lib/note-reorder.ts
@@ -1,0 +1,60 @@
+export type NoteReorderGeometry = {
+  top: number;
+  bottom: number;
+};
+
+export type NoteReorderDirection = -1 | 0 | 1;
+
+export const reorderedNoteIdsForDrag = (
+  noteIds: readonly string[],
+  draggedNoteId: string,
+  direction: NoteReorderDirection,
+  noteGeometries: ReadonlyMap<string, NoteReorderGeometry>,
+): string[] | null => {
+  if (noteIds.length < 2) return null;
+
+  const currentIndex = noteIds.indexOf(draggedNoteId);
+  if (currentIndex === -1) return null;
+
+  const draggedGeometry = noteGeometries.get(draggedNoteId);
+  if (!draggedGeometry) return null;
+
+  let insertionIndex = currentIndex;
+
+  if (direction < 0) {
+    while (insertionIndex > 0) {
+      const previousNoteId = noteIds[insertionIndex - 1];
+      const previousGeometry = noteGeometries.get(previousNoteId);
+      if (!previousGeometry || !shouldSwapTowardsPrevious(draggedGeometry, previousGeometry)) break;
+      insertionIndex -= 1;
+    }
+  } else if (direction > 0) {
+    while (insertionIndex < noteIds.length - 1) {
+      const nextNoteId = noteIds[insertionIndex + 1];
+      const nextGeometry = noteGeometries.get(nextNoteId);
+      if (!nextGeometry || !shouldSwapTowardsNext(draggedGeometry, nextGeometry)) break;
+      insertionIndex += 1;
+    }
+  }
+
+  const reorderedNoteIds = [...noteIds];
+  reorderedNoteIds.splice(currentIndex, 1);
+  reorderedNoteIds.splice(insertionIndex, 0, draggedNoteId);
+  return reorderedNoteIds;
+};
+
+const shouldSwapTowardsPrevious = (dragged: NoteReorderGeometry, previous: NoteReorderGeometry): boolean => {
+  return verticalOverlap(dragged, previous) > requiredOverlap(dragged, previous) || dragged.bottom <= previous.top;
+};
+
+const shouldSwapTowardsNext = (dragged: NoteReorderGeometry, next: NoteReorderGeometry): boolean => {
+  return verticalOverlap(dragged, next) > requiredOverlap(dragged, next) || dragged.top >= next.bottom;
+};
+
+const requiredOverlap = (first: NoteReorderGeometry, second: NoteReorderGeometry): number => {
+  return Math.min(first.bottom - first.top, second.bottom - second.top) / 2;
+};
+
+const verticalOverlap = (first: NoteReorderGeometry, second: NoteReorderGeometry): number => {
+  return Math.max(0, Math.min(first.bottom, second.bottom) - Math.max(first.top, second.top));
+};

--- a/apps/website/src/routes/website/(dashboard)/@notes/Note.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@notes/Note.svelte
@@ -5,7 +5,8 @@
   import { autosize, tooltip } from '@typie/ui/actions';
   import { HorizontalDivider, Icon, Menu, MenuItem, Submenu, TimeAgo } from '@typie/ui/components';
   import { Dialog } from '@typie/ui/notification';
-  import { onDestroy } from 'svelte';
+  import { pushEscapeHandler } from '@typie/ui/utils';
+  import { onDestroy, untrack } from 'svelte';
   import CheckIcon from '~icons/lucide/check';
   import CircleIcon from '~icons/lucide/circle';
   import CircleCheckIcon from '~icons/lucide/circle-check';
@@ -16,12 +17,24 @@
   import UnlinkIcon from '~icons/lucide/unlink';
   import EntityIcon from '../@context-menu/EntityIcon.svelte';
   import { getNoteColor, noteColors } from './colors';
+  import type { NoteReorderDirection, NoteReorderGeometry } from '$lib/note-reorder';
   import type { EntityIcon_entity$key } from '$mearie';
+
+  type NoteDragPosition = {
+    clientX: number;
+    clientY: number;
+    direction: NoteReorderDirection;
+    ghost: NoteReorderGeometry;
+  };
 
   type NoteEntity = EntityIcon_entity$key & {
     id: string;
     slug: string;
     node: { __typename: string; id?: string; title?: string; name?: string };
+  };
+
+  type CollapseOptions = {
+    focusComposer?: boolean;
   };
 
   type Props = {
@@ -38,15 +51,15 @@
     resolving: boolean;
     draggingNoteId: string | null;
     onexpand: (id: string) => void;
-    oncollapse: () => void;
+    oncollapse: (options?: CollapseOptions) => void;
     ondelete: (id: string) => void;
     ontogglestatus: (id: string) => void;
     onchangecolor: (id: string, color: string) => void;
     onupdatecontent: (id: string, content: string) => void;
-    ondragstart: () => void;
+    ondragstart: (pointer: { clientX: number; clientY: number }) => boolean;
     ondragend: () => void;
     ondragcancel: () => void;
-    ondragmove: (noteId: string) => void;
+    ondragmove: (position: NoteDragPosition) => void;
     onaddentity: (noteId: string) => void;
     onremoveentity: (noteId: string, entityId: string) => void;
     onendresolve: (noteId: string) => void;
@@ -77,6 +90,7 @@
   let content = $state(note.content);
   let focused = $state(false);
   let dirty = $state(false);
+  let contentUpdatePending = false;
   let contentUpdateTimeout: ReturnType<typeof setTimeout> | null = null;
   let textareaEl = $state<HTMLTextAreaElement>();
 
@@ -93,9 +107,16 @@
   }
 
   const DRAG_THRESHOLD = 5;
-  let cancelDrag: (() => void) | null = null;
+  const DRAG_DIRECTION_EPSILON = 0.5;
+  const RESOLVE_PAUSE_DURATION = 250;
 
-  onDestroy(() => cancelDrag?.());
+  let cancelDrag: (() => void) | null = null;
+  let resolveCollapsing = $state(false);
+  let collapseFinished = $state(false);
+
+  onDestroy(() => {
+    cancelDrag?.();
+  });
 
   $effect(() => {
     const serverContent = note.content;
@@ -108,16 +129,56 @@
   });
 
   function flushContentUpdate() {
-    if (!contentUpdateTimeout) return;
-    clearTimeout(contentUpdateTimeout);
-    contentUpdateTimeout = null;
+    if (contentUpdateTimeout) {
+      clearTimeout(contentUpdateTimeout);
+      contentUpdateTimeout = null;
+    }
+    if (!contentUpdatePending) return;
+
+    contentUpdatePending = false;
     onupdatecontent(note.id, content);
   }
 
   function handleContentChanged() {
     dirty = true;
+    contentUpdatePending = true;
     if (contentUpdateTimeout) clearTimeout(contentUpdateTimeout);
     contentUpdateTimeout = setTimeout(flushContentUpdate, 300);
+  }
+
+  function handleDeleteNote() {
+    if (content.trim() === '') {
+      ondelete(note.id);
+      return;
+    }
+
+    Dialog.confirm({
+      title: '노트를 삭제하시겠어요?',
+      message: '삭제된 노트는 복구할 수 없어요.',
+      action: 'danger',
+      actionLabel: '삭제',
+      actionHandler: () => ondelete(note.id),
+    });
+  }
+
+  function completeShortcut() {
+    textareaEl?.blur();
+    focused = false;
+    flushContentUpdate();
+    oncollapse({ focusComposer: true });
+  }
+
+  function handleEditorShortcut(event: KeyboardEvent) {
+    if (event.key !== 'Enter' || !(event.metaKey || event.ctrlKey)) return;
+
+    event.stopPropagation();
+    if (event.isComposing) {
+      setTimeout(completeShortcut, 0);
+      return;
+    }
+
+    event.preventDefault();
+    completeShortcut();
   }
 
   $effect(() => {
@@ -126,473 +187,589 @@
     }
 
     textareaEl.focus();
-    textareaEl.setSelectionRange(content.length, content.length);
+    const initialCaretPosition = untrack(() => content.length);
+    textareaEl.setSelectionRange(initialCaretPosition, initialCaretPosition);
+  });
+
+  function handleResolveTransitionEnd(event: TransitionEvent) {
+    if (
+      event.target !== event.currentTarget ||
+      event.propertyName !== 'grid-template-rows' ||
+      !resolveCollapsing ||
+      !resolving ||
+      cancelling
+    ) {
+      return;
+    }
+
+    collapseFinished = true;
+  }
+
+  $effect(() => {
+    collapseFinished = false;
+    if (!resolving || cancelling) {
+      resolveCollapsing = false;
+      return;
+    }
+
+    const timeout = setTimeout(() => {
+      resolveCollapsing = true;
+    }, RESOLVE_PAUSE_DURATION);
+
+    return () => clearTimeout(timeout);
+  });
+
+  $effect(() => {
+    if (!collapseFinished || note.status !== 'RESOLVED' || !resolving || cancelling) {
+      return;
+    }
+
+    collapseFinished = false;
+    onendresolve(note.id);
   });
 </script>
 
 <div
-  style:--resolve-duration="500ms"
-  style:opacity={isDragging ? '0.5' : resolving && !cancelling ? '0' : '1'}
-  style:transition={cancelling
-    ? 'none'
-    : 'opacity var(--resolve-duration) ease, background-color 150ms, box-shadow 150ms, border-color 150ms'}
-  class={cx(
-    'group',
-    flex({
-      flexDirection: 'column',
-      position: 'relative',
-      borderRadius: '10px',
-      cursor: expanded ? 'default' : 'grab',
-      backgroundColor: expanded ? 'surface.default' : 'surface.subtle',
-      boxShadow: expanded ? 'large' : 'small',
-      borderWidth: '1px',
-      borderColor: expanded ? 'border.subtle' : 'transparent',
-      _hover: {
-        borderColor: 'border.subtle',
-      },
-    }),
-  )}
-  data-note-id={note.id}
-  onkeydown={(e) => {
-    if (expanded) return;
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      onexpand(note.id);
-    }
-  }}
-  onpointerdown={(e) => {
-    if (expanded || !e.isPrimary || e.button !== 0) return;
-    const target = e.target as HTMLElement;
-    if (target.closest('button, textarea, a')) return;
-
-    e.preventDefault();
-    const el = e.currentTarget as HTMLElement;
-    const rect = el.getBoundingClientRect();
-    const pointerId = e.pointerId;
-
-    const state = {
-      startX: e.clientX,
-      startY: e.clientY,
-      offsetX: e.clientX - rect.left,
-      offsetY: e.clientY - rect.top,
-      started: false,
-      ghost: null as HTMLElement | null,
-      cursorStyle: null as HTMLStyleElement | null,
-      active: true,
-    };
-
-    const cleanup = (cancelled = false) => {
-      if (!state.active) return;
-      const wasStarted = state.started;
-      state.active = false;
-      state.ghost?.remove();
-      state.cursorStyle?.remove();
-      document.removeEventListener('pointermove', handleMove);
-      document.removeEventListener('pointerup', handleUp);
-      document.removeEventListener('pointercancel', handleCancel);
-      cancelDrag = null;
-      if (cancelled && wasStarted) {
-        ondragcancel();
-      }
-    };
-
-    const handleMove = (ev: PointerEvent) => {
-      if (ev.pointerId !== pointerId) return;
-
-      const dist = Math.abs(ev.clientX - state.startX) + Math.abs(ev.clientY - state.startY);
-
-      if (!state.started && dist > DRAG_THRESHOLD) {
-        state.started = true;
-
-        const ghost = document.createElement('div');
-        const cloned = el.cloneNode(true) as HTMLElement;
-        cloned.style.pointerEvents = 'none';
-        cloned.style.transform = 'rotate(1.5deg) scale(1.05)';
-        cloned.style.opacity = '0.8';
-        cloned.style.width = '100%';
-        cloned.style.height = '100%';
-        ghost.append(cloned);
-
-        ghost.style.position = 'fixed';
-        ghost.style.pointerEvents = 'none';
-        ghost.style.zIndex = '9999';
-        ghost.style.width = `${rect.width}px`;
-        ghost.style.left = `${ev.clientX - state.offsetX}px`;
-        ghost.style.top = `${ev.clientY - state.offsetY}px`;
-        document.body.append(ghost);
-
-        state.ghost = ghost;
-        state.cursorStyle = document.createElement('style');
-        state.cursorStyle.textContent = '* { cursor: grabbing !important; }';
-        document.head.append(state.cursorStyle);
-        ondragstart();
-      }
-
-      if (state.started && state.ghost) {
-        state.ghost.style.left = `${ev.clientX - state.offsetX}px`;
-        state.ghost.style.top = `${ev.clientY - state.offsetY}px`;
-
-        const elemBelow = document.elementFromPoint(ev.clientX, ev.clientY);
-        const noteBelow = elemBelow?.closest('[data-note-id]') as HTMLElement | null;
-        if (noteBelow) {
-          const noteId = noteBelow.dataset.noteId;
-          if (noteId && noteId !== note.id) {
-            ondragmove(noteId);
-          }
-        }
-      }
-    };
-
-    const handleUp = (ev: PointerEvent) => {
-      if (ev.pointerId !== pointerId) return;
-
-      const wasStarted = state.started;
-      cleanup();
-      if (wasStarted) {
-        ondragend();
-      } else {
+  style:grid-template-rows={resolveCollapsing ? '0fr' : '1fr'}
+  style:margin-bottom={resolveCollapsing ? '-8px' : '0px'}
+  style:opacity={resolveCollapsing ? '0' : '1'}
+  style:transition={cancelling ? 'none' : 'grid-template-rows 180ms ease, margin-bottom 180ms ease, opacity 180ms ease'}
+  class={css({ display: 'grid', minWidth: '0', width: 'full' })}
+  ontransitionend={handleResolveTransitionEnd}
+>
+  <div
+    style:overflow={resolveCollapsing ? 'hidden' : 'visible'}
+    style:opacity={isDragging ? '0.5' : '1'}
+    style:transition="opacity 180ms ease, background-color 150ms, box-shadow 150ms, border-color 150ms"
+    class={cx(
+      'group',
+      flex({
+        flexDirection: 'column',
+        position: 'relative',
+        minHeight: '0',
+        borderRadius: '10px',
+        cursor: 'grab',
+        backgroundColor: expanded ? 'surface.default' : 'surface.subtle',
+        boxShadow: expanded ? 'large' : 'small',
+        borderWidth: '1px',
+        borderColor: expanded ? 'border.subtle' : 'transparent',
+        _hover: {
+          borderColor: 'border.subtle',
+        },
+      }),
+    )}
+    data-note-id={note.id}
+    onkeydown={(e) => {
+      if (expanded) return;
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
         onexpand(note.id);
       }
-    };
+    }}
+    onpointerdown={(e) => {
+      if (!e.isPrimary || e.button !== 0) return;
+      const target = e.target as HTMLElement;
+      if (target.closest('button, textarea, a')) return;
 
-    const handleCancel = (ev: PointerEvent) => {
-      if (ev.pointerId !== pointerId) return;
-      cleanup(true);
-    };
+      e.preventDefault();
+      const el = e.currentTarget as HTMLElement;
+      const rect = el.getBoundingClientRect();
+      const pointerId = e.pointerId;
+      const pointerCaptureTarget = document.documentElement;
 
-    cancelDrag?.();
-    document.addEventListener('pointermove', handleMove);
-    document.addEventListener('pointerup', handleUp);
-    document.addEventListener('pointercancel', handleCancel);
-    cancelDrag = () => cleanup(true);
-  }}
-  ontransitionend={(e) => {
-    if (e.target === e.currentTarget && e.propertyName === 'opacity' && resolving && !cancelling) {
-      onendresolve(note.id);
-    }
-  }}
-  role="button"
-  tabindex="0"
->
-  <div class={flex({ gap: '10px', padding: '12px', paddingBottom: expanded ? '8px' : '12px' })}>
-    <!-- Color Checkbox -->
-    <button
-      style:background-color={isResolved ? colorHex : 'transparent'}
-      style:border={isResolved ? 'none' : `1.5px solid ${colorHex}`}
-      style:transition={resolving || cancelling ? 'none' : undefined}
-      class={center({
-        width: '16px',
-        height: '16px',
-        padding: '0',
-        borderRadius: 'full',
-        flexShrink: '0',
-        marginTop: '2px',
-        cursor: 'pointer',
-        transition: 'common',
-        ...(isResolved && !resolving ? { _hover: { opacity: '60' } } : { _hover: { opacity: '100' } }),
-      })}
-      onclick={() => ontogglestatus(note.id)}
-      type="button"
-      use:tooltip={{ message: isResolved ? '미완료로 표시' : '완료로 표시', placement: 'top' }}
-    >
-      {#if isResolved}
-        <Icon style={css.raw({ color: 'surface.default', '& *': { strokeWidth: '[3px]' } })} icon={CheckIcon} size={12} />
-      {:else}
-        <div
-          style:background-color={colorHex}
-          class={center({
-            width: 'full',
-            height: 'full',
-            borderRadius: 'full',
-            opacity: '0',
-            transition: 'common!',
-            ':hover > &': { opacity: '100' },
-          })}
-        >
+      const state = {
+        startX: e.clientX,
+        startY: e.clientY,
+        offsetX: e.clientX - rect.left,
+        offsetY: e.clientY - rect.top,
+        started: false,
+        ghost: null as HTMLElement | null,
+        cursorStyle: null as HTMLStyleElement | null,
+        removeEscapeHandler: null as (() => void) | null,
+        moveFrame: null as number | null,
+        pendingMove: null as PointerEvent | null,
+        active: true,
+        previousCenterY: rect.top + rect.height / 2,
+        direction: 0 as NoteReorderDirection,
+      };
+
+      const cleanup = (cancelled = false) => {
+        if (!state.active) return;
+        const wasStarted = state.started;
+        state.active = false;
+        if (state.moveFrame !== null) {
+          cancelAnimationFrame(state.moveFrame);
+          state.moveFrame = null;
+        }
+        state.pendingMove = null;
+        state.ghost?.remove();
+        state.cursorStyle?.remove();
+        state.removeEscapeHandler?.();
+        state.removeEscapeHandler = null;
+        document.removeEventListener('pointermove', handleMove);
+        document.removeEventListener('pointerup', handleUp);
+        document.removeEventListener('pointercancel', handleCancel);
+        pointerCaptureTarget.removeEventListener('lostpointercapture', handleLostPointerCapture);
+        if (pointerCaptureTarget.hasPointerCapture(pointerId)) {
+          pointerCaptureTarget.releasePointerCapture(pointerId);
+        }
+        cancelDrag = null;
+        if (cancelled && wasStarted) {
+          ondragcancel();
+        }
+      };
+
+      const updateGhost = (ev: PointerEvent) => {
+        if (!state.ghost) return;
+
+        const top = ev.clientY - state.offsetY;
+        const centerY = top + rect.height / 2;
+        const centerDeltaY = centerY - state.previousCenterY;
+
+        state.ghost.style.left = `${ev.clientX - state.offsetX}px`;
+        state.ghost.style.top = `${top}px`;
+        state.previousCenterY = centerY;
+
+        if (Math.abs(centerDeltaY) > DRAG_DIRECTION_EPSILON) {
+          state.direction = centerDeltaY < 0 ? -1 : 1;
+        }
+
+        ondragmove({
+          clientX: ev.clientX,
+          clientY: ev.clientY,
+          direction: state.direction,
+          ghost: {
+            top,
+            bottom: top + rect.height,
+          },
+        });
+      };
+
+      const processMove = (ev: PointerEvent) => {
+        const dist = Math.hypot(ev.clientX - state.startX, ev.clientY - state.startY);
+        if (!state.started && dist > DRAG_THRESHOLD) {
+          if (!ondragstart({ clientX: ev.clientX, clientY: ev.clientY })) {
+            cleanup();
+            return;
+          }
+          state.started = true;
+
+          const ghost = document.createElement('div');
+          const cloned = el.cloneNode(true) as HTMLElement;
+          (cloned as unknown as { inert: boolean }).inert = true;
+          cloned.setAttribute('aria-hidden', 'true');
+          cloned.style.pointerEvents = 'none';
+          cloned.style.transform = 'rotate(1.5deg) scale(1.05)';
+          cloned.style.opacity = '0.8';
+          cloned.style.width = '100%';
+          cloned.style.height = '100%';
+          ghost.append(cloned);
+
+          ghost.style.position = 'fixed';
+          ghost.style.pointerEvents = 'none';
+          ghost.style.zIndex = token('zIndex.ghost');
+          ghost.style.width = `${rect.width}px`;
+          ghost.style.height = `${rect.height}px`;
+          ghost.style.left = `${ev.clientX - state.offsetX}px`;
+          ghost.style.top = `${ev.clientY - state.offsetY}px`;
+          document.body.append(ghost);
+
+          state.ghost = ghost;
+          state.cursorStyle = document.createElement('style');
+          state.cursorStyle.textContent = '* { cursor: grabbing !important; }';
+          document.head.append(state.cursorStyle);
+          state.removeEscapeHandler = pushEscapeHandler(() => {
+            cleanup(true);
+            return true;
+          });
+        }
+
+        if (state.started && state.ghost) {
+          updateGhost(ev);
+        }
+      };
+
+      const handleMove = (ev: PointerEvent) => {
+        if (ev.pointerId !== pointerId) return;
+
+        state.pendingMove = ev;
+        if (state.moveFrame !== null) return;
+
+        state.moveFrame = requestAnimationFrame(() => {
+          state.moveFrame = null;
+          const pendingMove = state.pendingMove;
+          state.pendingMove = null;
+          if (pendingMove && state.active) {
+            processMove(pendingMove);
+          }
+        });
+      };
+
+      const flushPendingMove = () => {
+        if (state.moveFrame !== null) {
+          cancelAnimationFrame(state.moveFrame);
+          state.moveFrame = null;
+        }
+        const pendingMove = state.pendingMove;
+        state.pendingMove = null;
+        if (pendingMove && state.active) {
+          processMove(pendingMove);
+        }
+      };
+
+      const handleUp = (ev: PointerEvent) => {
+        if (ev.pointerId !== pointerId) return;
+
+        flushPendingMove();
+        if (!state.active) return;
+        const wasStarted = state.started;
+        if (wasStarted) {
+          updateGhost(ev);
+        }
+        cleanup();
+        if (wasStarted) {
+          ondragend();
+        } else if (!expanded) {
+          onexpand(note.id);
+        }
+      };
+
+      const handleCancel = (ev: PointerEvent) => {
+        if (ev.pointerId !== pointerId) return;
+        cleanup(true);
+      };
+
+      const handleLostPointerCapture = (ev: PointerEvent) => {
+        if (ev.pointerId !== pointerId) return;
+        cleanup(true);
+      };
+
+      cancelDrag?.();
+      document.addEventListener('pointermove', handleMove);
+      document.addEventListener('pointerup', handleUp);
+      document.addEventListener('pointercancel', handleCancel);
+      pointerCaptureTarget.addEventListener('lostpointercapture', handleLostPointerCapture);
+      try {
+        pointerCaptureTarget.setPointerCapture(pointerId);
+      } catch {
+        cleanup();
+        return;
+      }
+      cancelDrag = () => cleanup(true);
+    }}
+    role="button"
+    tabindex="0"
+  >
+    <div class={flex({ gap: '10px', padding: '12px', paddingBottom: expanded ? '8px' : '12px' })}>
+      <!-- Color Checkbox -->
+      <button
+        style:background-color={isResolved ? colorHex : 'transparent'}
+        style:border={isResolved ? 'none' : `1.5px solid ${colorHex}`}
+        style:transition={resolving || cancelling ? 'none' : undefined}
+        class={center({
+          width: '16px',
+          height: '16px',
+          padding: '0',
+          borderRadius: 'full',
+          flexShrink: '0',
+          marginTop: '3px',
+          cursor: 'pointer',
+          transition: 'common',
+          ...(isResolved && !resolving ? { _hover: { opacity: '60' } } : { _hover: { opacity: '100' } }),
+        })}
+        onclick={() => ontogglestatus(note.id)}
+        type="button"
+        use:tooltip={{ message: isResolved ? '미완료로 표시' : '완료로 표시', placement: 'top' }}
+      >
+        {#if isResolved}
           <Icon style={css.raw({ color: 'surface.default', '& *': { strokeWidth: '[3px]' } })} icon={CheckIcon} size={12} />
-        </div>
-      {/if}
-    </button>
-
-    <!-- Content -->
-    <div class={flex({ flexDirection: 'column', gap: '4px', flexGrow: '1', minWidth: '0' })}>
-      {#if expanded}
-        <textarea
-          bind:this={textareaEl}
-          class={css({
-            width: 'full',
-            fontSize: '13px',
-            paddingRight: '22px',
-            color: 'text.default',
-            backgroundColor: 'transparent',
-            resize: 'none',
-            lineHeight: '[1.55]',
-            whiteSpace: 'pre-wrap',
-          })}
-          onblur={() => {
-            focused = false;
-            flushContentUpdate();
-          }}
-          onfocus={() => {
-            focused = true;
-          }}
-          oninput={() => handleContentChanged()}
-          onkeydown={(e) => {
-            if (!(e.key === 'Enter' && (e.metaKey || e.ctrlKey))) {
-              return;
-            }
-
-            e.preventDefault();
-            e.stopPropagation();
-            flushContentUpdate();
-            oncollapse();
-          }}
-          rows={1}
-          bind:value={content}
-          use:autosize={{ cacheKey: `note-${note.id}` }}></textarea>
-      {:else}
-        <p
-          style:transition={cancelling
-            ? 'none'
-            : 'text-decoration-color var(--resolve-duration) ease, opacity var(--resolve-duration) ease'}
-          class={css({
-            fontSize: '13px',
-            lineHeight: '[1.55]',
-            paddingRight: '22px',
-            color: note.content.trim() ? 'text.default' : 'text.faint',
-            whiteSpace: 'pre-wrap',
-            wordBreak: 'break-word',
-            lineClamp: '3',
-            opacity: isResolved && !resolving ? '50' : '100',
-            textDecorationLine: isResolved ? 'line-through' : 'none',
-            textDecorationColor: isResolved ? 'text.faint' : 'transparent',
-          })}
-        >
-          {note.content.trim() || '(내용 없음)'}
-        </p>
-      {/if}
-
-      <!-- Meta -->
-      <div
-        class={css({
-          display: 'grid',
-          gridTemplateRows: expanded ? '0fr' : '1fr',
-          transitionProperty: '[grid-template-rows]',
-          transitionDuration: '150ms',
-        })}
-      >
-        <div class={css({ overflow: 'hidden' })}>
-          <div class={flex({ alignItems: 'center', gap: '6px', flexWrap: 'wrap' })}>
-            {#each note.entities as entity (entity.id)}
-              {#if entity.node.__typename === 'Folder'}
-                <span class={flex({ alignItems: 'center', gap: '4px', fontSize: '12px', fontWeight: 'medium', color: 'text.faint' })}>
-                  <EntityIcon entity$key={entity} fallback={FolderIcon} size={12} />
-                  <span class={css({ lineClamp: '1' })}>{getEntityTitle(entity)}</span>
-                </span>
-              {:else}
-                <a
-                  class={flex({
-                    alignItems: 'center',
-                    gap: '4px',
-                    fontSize: '12px',
-                    fontWeight: 'medium',
-                    color: 'text.faint',
-                    borderRadius: '4px',
-                    paddingX: '2px',
-                    _hover: { color: 'text.subtle', backgroundColor: 'surface.dark/10' },
-                  })}
-                  href={`/${entity.slug}`}
-                  onclick={(e) => e.stopPropagation()}
-                >
-                  <EntityIcon entity$key={entity} size={12} />
-                  <span class={css({ lineClamp: '1' })}>{getEntityTitle(entity)}</span>
-                </a>
-              {/if}
-              <span class={css({ fontSize: '12px', color: 'text.faint' })}>·</span>
-            {/each}
-            <TimeAgo style={css.raw({ fontSize: '12px', color: 'text.faint' })} timestamp={new Date(note.updatedAt).getTime()} />
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <!-- Expanded Toolbar -->
-  <!-- Expanded Toolbar -->
-  <div
-    class={css({
-      display: 'grid',
-      gridTemplateRows: expanded ? '1fr' : '0fr',
-      transitionProperty: '[grid-template-rows]',
-      transitionDuration: '150ms',
-    })}
-  >
-    <div class={css({ overflow: 'hidden' })}>
-      <div
-        class={flex({
-          flexDirection: 'column',
-          gap: '6px',
-          paddingLeft: '38px',
-          paddingRight: '12px',
-          paddingBottom: '10px',
-        })}
-      >
-        <div class={flex({ alignItems: 'center', gap: '8px' })}>
-          <!-- Color dots -->
-          <div class={flex({ alignItems: 'center', gap: '4px' })}>
-            {#each noteColors as c (c.value)}
-              <button
-                style:background-color={c.value === note.color ? c.color : 'transparent'}
-                style:border={c.value === note.color ? 'none' : `1.5px solid ${c.color}`}
-                class={center({
-                  width: '12px',
-                  height: '12px',
-                  borderRadius: 'full',
-                  cursor: 'pointer',
-                  padding: '0',
-                })}
-                aria-label={c.label}
-                onclick={() => onchangecolor(note.id, c.value)}
-                type="button"
-                use:tooltip={{ message: c.label, placement: 'top' }}
-              ></button>
-            {/each}
-          </div>
-
-          <div class={css({ width: '1px', height: '12px', backgroundColor: 'border.subtle' })}></div>
-
-          <button
-            class={flex({
-              alignItems: 'center',
-              gap: '4px',
-              fontSize: '12px',
-              fontWeight: 'medium',
-              color: 'text.subtle',
-              cursor: 'pointer',
-              flexShrink: '0',
-              _hover: { color: 'text.default' },
-            })}
-            onclick={() => onaddentity(note.id)}
-            type="button"
-          >
-            <Icon icon={LinkIcon} size={12} />
-            연결 추가
-          </button>
-        </div>
-
-        {#if note.entities.length > 0}
-          <div class={flex({ alignItems: 'center', gap: '6px', flexWrap: 'wrap' })}>
-            {#each note.entities as entity (entity.id)}
-              <div class={flex({ alignItems: 'center', gap: '2px', fontSize: '12px', color: 'text.faint', minWidth: '0' })}>
-                <EntityIcon
-                  style={css.raw({ flexShrink: '0' })}
-                  entity$key={entity}
-                  fallback={entity.node.__typename === 'Folder' ? FolderIcon : undefined}
-                  size={12}
-                />
-                <span class={css({ lineClamp: '1' })}>{getEntityTitle(entity)}</span>
-                <button
-                  class={center({
-                    size: '14px',
-                    borderRadius: '2px',
-                    color: 'text.faint',
-                    cursor: 'pointer',
-                    flexShrink: '0',
-                    _hover: { color: 'text.default' },
-                  })}
-                  onclick={() => onremoveentity(note.id, entity.id)}
-                  type="button"
-                  use:tooltip={{ message: '연결 해제', placement: 'top' }}
-                >
-                  <Icon icon={UnlinkIcon} size={10} />
-                </button>
-              </div>
-            {/each}
-          </div>
-        {/if}
-      </div>
-    </div>
-  </div>
-
-  <!-- ⋯ More Menu -->
-  <Menu
-    style={center.raw({
-      position: 'absolute',
-      top: '11px',
-      right: '8px',
-      size: '22px',
-      borderRadius: '4px',
-      color: 'text.faint',
-      cursor: 'pointer',
-      transition: 'common!',
-      opacity: '0',
-      _groupHover: {
-        opacity: anyDragging ? '0' : '100',
-      },
-      _hover: {
-        color: 'text.default',
-        backgroundColor: 'surface.dark/10',
-      },
-      _focusVisible: {
-        opacity: '100',
-        color: 'text.default',
-        backgroundColor: 'surface.dark/10',
-      },
-      '&[aria-expanded="true"]': {
-        opacity: '100',
-        color: 'text.default',
-        backgroundColor: 'surface.dark/10',
-      },
-    })}
-    placement="bottom-end"
-  >
-    {#snippet button()}
-      <Icon icon={EllipsisIcon} size={14} />
-    {/snippet}
-    {#snippet children({ close })}
-      <Submenu label="색 바꾸기" listStyle={css.raw({ minWidth: '100px' })}>
-        {#snippet prefix()}
+        {:else}
           <div
             style:background-color={colorHex}
-            class={css({ width: '14px', height: '14px', borderRadius: 'full', flexShrink: '0' })}
-          ></div>
-        {/snippet}
-        {#each noteColors as c (c.value)}
-          <MenuItem onclick={() => onchangecolor(note.id, c.value)}>
-            {#snippet prefix()}
-              <div
-                style:background-color={c.color}
-                class={center({ width: '14px', height: '14px', borderRadius: 'full', flexShrink: '0' })}
-              >
-                {#if c.value === note.color}
-                  <Icon style={css.raw({ color: 'surface.default' })} icon={CheckIcon} size={10} />
+            class={center({
+              width: 'full',
+              height: 'full',
+              borderRadius: 'full',
+              opacity: '0',
+              transition: 'common!',
+              ':hover > &': { opacity: '100' },
+            })}
+          >
+            <Icon style={css.raw({ color: 'surface.default', '& *': { strokeWidth: '[3px]' } })} icon={CheckIcon} size={12} />
+          </div>
+        {/if}
+      </button>
+
+      <!-- Content -->
+      <div class={flex({ flexDirection: 'column', gap: '4px', flexGrow: '1', minWidth: '0' })}>
+        {#if expanded}
+          <textarea
+            bind:this={textareaEl}
+            style:transition={resolving || cancelling ? 'none' : 'text-decoration-color 150ms ease, opacity 150ms ease'}
+            class={css({
+              width: 'full',
+              fontSize: '14px',
+              paddingRight: '22px',
+              color: 'text.default',
+              backgroundColor: 'transparent',
+              resize: 'none',
+              lineHeight: '[1.55]',
+              whiteSpace: 'pre-wrap',
+              textDecorationLine: isResolved ? 'line-through' : 'none',
+              textDecorationColor: isResolved ? 'text.faint' : 'transparent',
+              opacity: isResolved && !resolving ? '50' : '100',
+            })}
+            onblur={() => {
+              focused = false;
+              flushContentUpdate();
+            }}
+            onfocus={() => {
+              focused = true;
+            }}
+            oninput={() => {
+              handleContentChanged();
+            }}
+            onkeydown={handleEditorShortcut}
+            placeholder={isResolved ? '(내용 없음)' : '떠오르는 생각을 적어보세요'}
+            rows={1}
+            bind:value={content}
+            use:autosize={{ cacheKey: `note-${note.id}`, value: content }}></textarea>
+        {:else}
+          <p
+            style:transition={resolving || cancelling ? 'none' : 'text-decoration-color 150ms ease, opacity 150ms ease'}
+            class={css({
+              fontSize: '14px',
+              lineHeight: '[1.55]',
+              paddingRight: '22px',
+              color: note.content.trim() ? 'text.default' : 'text.faint',
+              whiteSpace: 'pre-wrap',
+              wordBreak: 'break-word',
+              lineClamp: '3',
+              opacity: isResolved && !resolving ? '50' : '100',
+              textDecorationLine: isResolved ? 'line-through' : 'none',
+              textDecorationColor: isResolved ? 'text.faint' : 'transparent',
+            })}
+          >
+            {note.content.trim() || '(내용 없음)'}
+          </p>
+        {/if}
+
+        <!-- Meta -->
+        <div
+          class={css({
+            display: 'grid',
+            gridTemplateRows: expanded ? '0fr' : '1fr',
+            transitionProperty: '[grid-template-rows]',
+            transitionDuration: '150ms',
+          })}
+        >
+          <div class={css({ overflow: 'hidden' })}>
+            <div class={flex({ alignItems: 'center', gap: '6px', flexWrap: 'wrap' })}>
+              {#each note.entities as entity (entity.id)}
+                {#if entity.node.__typename === 'Folder'}
+                  <span class={flex({ alignItems: 'center', gap: '4px', fontSize: '12px', fontWeight: 'medium', color: 'text.faint' })}>
+                    <EntityIcon entity$key={entity} fallback={FolderIcon} size={12} />
+                    <span class={css({ lineClamp: '1' })}>{getEntityTitle(entity)}</span>
+                  </span>
+                {:else}
+                  <a
+                    class={flex({
+                      alignItems: 'center',
+                      gap: '4px',
+                      fontSize: '12px',
+                      fontWeight: 'medium',
+                      color: 'text.faint',
+                      borderRadius: '4px',
+                      paddingX: '2px',
+                      _hover: { color: 'text.subtle', backgroundColor: 'surface.dark/10' },
+                    })}
+                    href={`/${entity.slug}`}
+                    onclick={(e) => e.stopPropagation()}
+                  >
+                    <EntityIcon entity$key={entity} size={12} />
+                    <span class={css({ lineClamp: '1' })}>{getEntityTitle(entity)}</span>
+                  </a>
                 {/if}
-              </div>
-            {/snippet}
-            {c.label}
-          </MenuItem>
-        {/each}
-      </Submenu>
-      <MenuItem icon={isResolved ? CircleIcon : CircleCheckIcon} onclick={() => ontogglestatus(note.id)}>
-        {isResolved ? '미완료로 표시' : '완료로 표시'}
-      </MenuItem>
-      <HorizontalDivider />
-      <MenuItem
-        icon={Trash2Icon}
-        onclick={() => {
-          close();
-          Dialog.confirm({
-            title: '노트를 삭제하시겠어요?',
-            message: '삭제된 노트는 복구할 수 없어요.',
-            action: 'danger',
-            actionLabel: '삭제',
-            actionHandler: () => ondelete(note.id),
-          });
-        }}
-        variant="danger"
-      >
-        삭제
-      </MenuItem>
-    {/snippet}
-  </Menu>
+                <span class={css({ fontSize: '12px', color: 'text.faint' })}>·</span>
+              {/each}
+              <TimeAgo style={css.raw({ fontSize: '12px', color: 'text.faint' })} timestamp={new Date(note.updatedAt).getTime()} />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Expanded Toolbar -->
+    <!-- Expanded Toolbar -->
+    <div
+      class={css({
+        display: 'grid',
+        gridTemplateRows: expanded ? '1fr' : '0fr',
+        transitionProperty: '[grid-template-rows]',
+        transitionDuration: '150ms',
+      })}
+    >
+      <div class={css({ overflow: 'hidden' })}>
+        <div
+          class={flex({
+            flexDirection: 'column',
+            gap: '6px',
+            paddingLeft: '38px',
+            paddingRight: '12px',
+            paddingBottom: '10px',
+          })}
+        >
+          <div class={flex({ alignItems: 'center', gap: '8px' })}>
+            <!-- Color dots -->
+            <div class={flex({ alignItems: 'center', gap: '4px' })}>
+              {#each noteColors as c (c.value)}
+                <button
+                  style:background-color={c.value === note.color ? c.color : 'transparent'}
+                  style:border={c.value === note.color ? 'none' : `1.5px solid ${c.color}`}
+                  class={center({
+                    width: '12px',
+                    height: '12px',
+                    borderRadius: 'full',
+                    cursor: 'pointer',
+                    padding: '0',
+                  })}
+                  aria-label={c.label}
+                  onclick={() => onchangecolor(note.id, c.value)}
+                  type="button"
+                  use:tooltip={{ message: c.label, placement: 'top' }}
+                ></button>
+              {/each}
+            </div>
+
+            <div class={css({ width: '1px', height: '12px', backgroundColor: 'border.subtle' })}></div>
+
+            <button
+              class={flex({
+                alignItems: 'center',
+                gap: '4px',
+                fontSize: '12px',
+                fontWeight: 'medium',
+                color: 'text.subtle',
+                cursor: 'pointer',
+                flexShrink: '0',
+                _hover: { color: 'text.default' },
+              })}
+              onclick={() => onaddentity(note.id)}
+              type="button"
+            >
+              <Icon icon={LinkIcon} size={12} />
+              연결 추가
+            </button>
+          </div>
+
+          {#if note.entities.length > 0}
+            <div class={flex({ alignItems: 'center', gap: '6px', flexWrap: 'wrap' })}>
+              {#each note.entities as entity (entity.id)}
+                <div class={flex({ alignItems: 'center', gap: '2px', fontSize: '12px', color: 'text.faint', minWidth: '0' })}>
+                  <EntityIcon
+                    style={css.raw({ flexShrink: '0' })}
+                    entity$key={entity}
+                    fallback={entity.node.__typename === 'Folder' ? FolderIcon : undefined}
+                    size={12}
+                  />
+                  <span class={css({ lineClamp: '1' })}>{getEntityTitle(entity)}</span>
+                  <button
+                    class={center({
+                      size: '14px',
+                      borderRadius: '2px',
+                      color: 'text.faint',
+                      cursor: 'pointer',
+                      flexShrink: '0',
+                      _hover: { color: 'text.default' },
+                    })}
+                    onclick={() => onremoveentity(note.id, entity.id)}
+                    type="button"
+                    use:tooltip={{ message: '연결 해제', placement: 'top' }}
+                  >
+                    <Icon icon={UnlinkIcon} size={10} />
+                  </button>
+                </div>
+              {/each}
+            </div>
+          {/if}
+        </div>
+      </div>
+    </div>
+
+    <!-- ⋯ More Menu -->
+    <Menu
+      style={center.raw({
+        position: 'absolute',
+        top: '11px',
+        right: '8px',
+        size: '22px',
+        borderRadius: '4px',
+        color: 'text.faint',
+        cursor: 'pointer',
+        transition: 'common!',
+        opacity: '0',
+        _groupHover: {
+          opacity: anyDragging ? '0' : '100',
+        },
+        _hover: {
+          color: 'text.default',
+          backgroundColor: 'surface.dark/10',
+        },
+        _focusVisible: {
+          opacity: '100',
+          color: 'text.default',
+          backgroundColor: 'surface.dark/10',
+        },
+        '&[aria-expanded="true"]': {
+          opacity: '100',
+          color: 'text.default',
+          backgroundColor: 'surface.dark/10',
+        },
+      })}
+      placement="bottom-end"
+    >
+      {#snippet button()}
+        <Icon icon={EllipsisIcon} size={14} />
+      {/snippet}
+      {#snippet children({ close })}
+        <Submenu label="색 바꾸기" listStyle={css.raw({ minWidth: '100px' })}>
+          {#snippet prefix()}
+            <div
+              style:background-color={colorHex}
+              class={css({ width: '14px', height: '14px', borderRadius: 'full', flexShrink: '0' })}
+            ></div>
+          {/snippet}
+          {#each noteColors as c (c.value)}
+            <MenuItem onclick={() => onchangecolor(note.id, c.value)}>
+              {#snippet prefix()}
+                <div
+                  style:background-color={c.color}
+                  class={center({ width: '14px', height: '14px', borderRadius: 'full', flexShrink: '0' })}
+                >
+                  {#if c.value === note.color}
+                    <Icon style={css.raw({ color: 'surface.default' })} icon={CheckIcon} size={10} />
+                  {/if}
+                </div>
+              {/snippet}
+              {c.label}
+            </MenuItem>
+          {/each}
+        </Submenu>
+        <MenuItem icon={isResolved ? CircleIcon : CircleCheckIcon} onclick={() => ontogglestatus(note.id)}>
+          {isResolved ? '미완료로 표시' : '완료로 표시'}
+        </MenuItem>
+        <HorizontalDivider />
+        <MenuItem
+          icon={Trash2Icon}
+          onclick={() => {
+            close();
+            handleDeleteNote();
+          }}
+          variant="danger"
+        >
+          삭제
+        </MenuItem>
+      {/snippet}
+    </Menu>
+  </div>
 </div>

--- a/apps/website/src/routes/website/(dashboard)/@notes/Notes.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@notes/Notes.svelte
@@ -6,20 +6,37 @@
   import { Button, Icon, Modal } from '@typie/ui/components';
   import { getAppContext } from '@typie/ui/context';
   import { Toast } from '@typie/ui/notification';
-  import { animateFlip, pushEscapeHandler } from '@typie/ui/utils';
+  import { animateFlip, createDragScroll, elementScrollViewport, pushEscapeHandler } from '@typie/ui/utils';
   import mixpanel from 'mixpanel-browser';
-  import { SvelteSet } from 'svelte/reactivity';
+  import { onDestroy, tick } from 'svelte';
+  import { SvelteMap, SvelteSet } from 'svelte/reactivity';
   import ChevronDownIcon from '~icons/lucide/chevron-down';
   import ChevronRightIcon from '~icons/lucide/chevron-right';
   import CommandIcon from '~icons/lucide/command';
   import CornerDownLeftIcon from '~icons/lucide/corner-down-left';
   import { beforeNavigate } from '$app/navigation';
   import { cache } from '$lib/graphql';
+  import { reorderedNoteIdsForDrag } from '$lib/note-reorder';
   import { graphql } from '$mearie';
   import { SubscribeModal } from '../@subscription/subscribe-modal.svelte';
   import { noteColors } from './colors';
   import NoteComponent from './Note.svelte';
   import NoteEntitySearchModal from './NoteEntitySearchModal.svelte';
+  import type { NoteReorderDirection, NoteReorderGeometry } from '$lib/note-reorder';
+
+  type NoteDragPosition = {
+    clientX: number;
+    clientY: number;
+    direction: NoteReorderDirection;
+    ghost: NoteReorderGeometry;
+  };
+
+  type NoteDragging = {
+    noteId: string;
+    originalOrder: string[];
+    position: NoteDragPosition | null;
+    sectionNoteIds: string[];
+  };
 
   const [createNote] = createMutation(
     graphql(`
@@ -153,17 +170,17 @@
   let inputValue = $state('');
   let inputEl = $state<HTMLTextAreaElement>();
   let selectedColor = $state('gray');
+  let createInFlight = $state(false);
   let expandedNoteId = $state<string | null>(null);
   let entitySearchNoteId = $state<string | null>(null);
   let resolvedOpen = $state(false);
   const resolvingNoteIds = new SvelteSet<string>();
 
-  let dragging = $state<{
-    noteId: string;
-    originalIndex: number;
-    dropTargetNoteId: string | null;
-  } | null>(null);
+  let dragging = $state<NoteDragging | null>(null);
   let localNoteOrder = $state<string[]>([]);
+  let scrollContainer = $state<HTMLElement | null>(null);
+  let composer = $state<HTMLElement | null>(null);
+  let dragScroll: ReturnType<typeof createDragScroll> | null = null;
 
   const sortedNotes = $derived.by(() => {
     if (localNoteOrder.length === 0) return notes;
@@ -185,25 +202,99 @@
     return n?.entities?.map((e) => e.id) ?? [];
   });
 
-  const handleDragEnd = async () => {
+  const resolveDraggingPosition = (position: NoteDragPosition) => {
+    const currentDragging = dragging;
+    if (!currentDragging || !scrollContainer) return;
+
+    const sectionNoteIds = new Set(currentDragging.sectionNoteIds);
+    const currentSectionOrder = localNoteOrder.filter((noteId) => sectionNoteIds.has(noteId));
+    const noteGeometries = new SvelteMap<string, NoteReorderGeometry>();
+
+    for (const noteElement of scrollContainer.querySelectorAll<HTMLElement>('[data-note-id]')) {
+      const noteId = noteElement.dataset.noteId;
+      if (!noteId || !sectionNoteIds.has(noteId)) continue;
+
+      const { top, bottom } = noteElement.getBoundingClientRect();
+      noteGeometries.set(noteId, { top, bottom });
+    }
+    noteGeometries.set(currentDragging.noteId, position.ghost);
+
+    const reorderedSection = reorderedNoteIdsForDrag(currentSectionOrder, currentDragging.noteId, position.direction, noteGeometries);
+    if (!reorderedSection || reorderedSection.every((noteId, index) => noteId === currentSectionOrder[index])) return;
+
+    let sectionIndex = 0;
+    const reorderedNotes = localNoteOrder.map((noteId) => {
+      if (!sectionNoteIds.has(noteId)) return noteId;
+      return reorderedSection[sectionIndex++] ?? noteId;
+    });
+    if (reorderedNotes.some((noteId, index) => noteId !== localNoteOrder[index])) {
+      localNoteOrder = reorderedNotes;
+    }
+  };
+
+  const updateDraggingPosition = (position: NoteDragPosition) => {
     if (!dragging) return;
 
-    const currentIndex = localNoteOrder.indexOf(dragging.noteId);
+    dragging.position = position;
+    dragScroll?.updatePointer(position.clientX, position.clientY);
+    resolveDraggingPosition(position);
+  };
 
-    if (currentIndex !== -1 && dragging.originalIndex !== -1 && currentIndex !== dragging.originalIndex && sortedNotes.length > 1) {
+  const stopDragScroll = () => {
+    dragScroll?.destroy();
+    dragScroll = null;
+  };
+
+  const startDragScroll = (draggingNoteId: string, initialPointer: { clientX: number; clientY: number }) => {
+    stopDragScroll();
+    if (!scrollContainer || !composer) return;
+
+    const baseViewport = elementScrollViewport(scrollContainer);
+    dragScroll = createDragScroll(
+      {
+        ...baseViewport,
+        getRect: () => {
+          const rect = baseViewport.getRect();
+          const bottom = Math.min(rect.bottom, window.innerHeight);
+          return {
+            ...rect,
+            top: Math.min(Math.max(rect.top, composer?.getBoundingClientRect().bottom ?? rect.top), bottom),
+            bottom,
+          };
+        },
+      },
+      {
+        initialPointer,
+        stickyCandidates: [],
+        onScroll: () => {
+          if (dragging?.noteId === draggingNoteId && dragging.position) {
+            resolveDraggingPosition(dragging.position);
+          }
+        },
+      },
+    );
+  };
+
+  const handleDragEnd = async () => {
+    const currentDragging = dragging;
+    if (!currentDragging) return;
+
+    const currentIndex = localNoteOrder.indexOf(currentDragging.noteId);
+    const originalIndex = currentDragging.originalOrder.indexOf(currentDragging.noteId);
+    dragging = null;
+    stopDragScroll();
+
+    if (currentIndex !== -1 && originalIndex !== -1 && currentIndex !== originalIndex && sortedNotes.length > 1) {
       if (!SubscribeModal.gate('notes_move')) {
-        dragging = null;
+        localNoteOrder = [...currentDragging.originalOrder];
         return;
       }
 
-      const notes = sortedNotes;
-      let lowerNote, upperNote;
-
-      lowerNote = notes[currentIndex - 1] ?? null;
-      upperNote = notes[currentIndex + 1] ?? null;
+      const lowerNote = sortedNotes[currentIndex - 1] ?? null;
+      const upperNote = sortedNotes[currentIndex + 1] ?? null;
 
       try {
-        const { noteId } = dragging;
+        const { noteId } = currentDragging;
         await moveNote({
           input: {
             noteId,
@@ -219,32 +310,17 @@
           cache.invalidate({ __typename: 'Entity', id: entity.id, $field: 'notes' });
         }
       } catch {
-        localNoteOrder = notes.map((note) => note.id);
+        localNoteOrder = [...currentDragging.originalOrder];
         Toast.error('노트 순서 변경에 실패했습니다. 잠시 후 다시 시도해주세요.');
-      }
-    }
-
-    dragging = null;
-  };
-
-  const handleNoteDragEnter = (noteId: string) => {
-    if (dragging && dragging.noteId !== noteId) {
-      dragging.dropTargetNoteId = noteId;
-      const draggedIndex = localNoteOrder.indexOf(dragging.noteId);
-      const dropIndex = localNoteOrder.indexOf(noteId);
-
-      if (draggedIndex !== -1 && dropIndex !== -1 && draggedIndex !== dropIndex) {
-        const newOrder = [...localNoteOrder];
-        const [removed] = newOrder.splice(draggedIndex, 1);
-        newOrder.splice(dropIndex, 0, removed);
-        localNoteOrder = newOrder;
       }
     }
   };
 
   let prevNoteIds = $state<string[]>([]);
   $effect(() => {
-    const noteIds = notes.map((n) => n.id);
+    const noteIds = notes.map((note) => note.id);
+    if (dragging) return;
+
     const noteIdsStr = noteIds.join(',');
     const prevNoteIdsStr = prevNoteIds.join(',');
 
@@ -254,35 +330,43 @@
     }
   });
 
-  const handleDragStart = (noteId: string) => {
-    dragging = {
+  const handleDragStart = (noteId: string, initialPointer: { clientX: number; clientY: number }) => {
+    const sectionNotes = openNotes.some((note) => note.id === noteId) ? openNotes : resolvedNotes;
+    const originalOrder = sortedNotes.map((note) => note.id);
+    localNoteOrder = [...originalOrder];
+    const currentDragging: NoteDragging = {
       noteId,
-      originalIndex: localNoteOrder.indexOf(noteId),
-      dropTargetNoteId: null,
+      originalOrder,
+      position: null,
+      sectionNoteIds: sectionNotes.map((note) => note.id),
     };
+    dragging = currentDragging;
+    startDragScroll(noteId, initialPointer);
+    return true;
   };
 
   const handleDragCancel = (noteId: string) => {
-    if (dragging?.noteId !== noteId) return;
+    const currentDragging = dragging;
+    if (currentDragging?.noteId !== noteId) return;
 
-    const { originalIndex } = dragging;
-    const currentIndex = localNoteOrder.indexOf(noteId);
     dragging = null;
-
-    if (currentIndex === -1 || originalIndex === -1 || currentIndex === originalIndex) return;
-
-    const restoredOrder = [...localNoteOrder];
-    const [removed] = restoredOrder.splice(currentIndex, 1);
-    restoredOrder.splice(originalIndex, 0, removed);
-    localNoteOrder = restoredOrder;
+    stopDragScroll();
+    localNoteOrder = [...currentDragging.originalOrder];
   };
 
   const handleExpand = (noteId: string) => {
     expandedNoteId = noteId;
   };
 
-  const handleCollapse = () => {
+  const handleCollapse = (options: { focusComposer?: boolean } = {}) => {
     expandedNoteId = null;
+    if (options.focusComposer) {
+      void tick().then(() => {
+        if (expandedNoteId === null && app.state.notesOpen) {
+          inputEl?.focus();
+        }
+      });
+    }
   };
 
   $effect(() => {
@@ -304,25 +388,35 @@
   };
 
   const handleAddNote = async (via: string) => {
+    if (createInFlight) return;
     if (!inputValue.trim()) return;
 
     if (!SubscribeModal.gate('notes_create')) {
       return;
     }
 
-    await createNote({
-      input: {
-        siteId: app.preference.current.currentSiteId,
-        color: selectedColor,
-        content: inputValue,
-      },
-    });
-    mixpanel.track('create_note', { via });
-    cache.invalidate({ __typename: 'Query', $field: 'notes' });
+    const submittedContent = inputValue;
+    const submittedColor = selectedColor;
+    createInFlight = true;
+    try {
+      await createNote({
+        input: {
+          siteId: app.preference.current.currentSiteId,
+          color: submittedColor,
+          content: submittedContent,
+        },
+      });
+      mixpanel.track('create_note', { via });
+      cache.invalidate({ __typename: 'Query', $field: 'notes' });
 
-    inputValue = '';
-    selectedColor = 'gray';
-    inputEl?.focus();
+      if (inputValue === submittedContent && selectedColor === submittedColor) {
+        inputValue = '';
+        selectedColor = 'gray';
+      }
+      inputEl?.focus();
+    } finally {
+      createInFlight = false;
+    }
   };
 
   const handleDeleteNote = async (noteId: string) => {
@@ -446,6 +540,10 @@
     }
   });
 
+  onDestroy(() => {
+    stopDragScroll();
+  });
+
   $effect.pre(() => {
     void localNoteOrder;
     animateFlip('[data-note-id]', 'noteId');
@@ -470,6 +568,7 @@
   overlayPadding={0}
 >
   <div
+    bind:this={scrollContainer}
     class={flex({
       position: 'relative',
       paddingTop: '[15dvh]',
@@ -504,6 +603,7 @@
 
     <!-- Input Area -->
     <div
+      bind:this={composer}
       class={flex({
         position: 'sticky',
         top: '[calc(16px - 15dvh)]',
@@ -531,14 +631,18 @@
           resize: 'none',
         })}
         onkeydown={(e) => {
-          if (!(e.key === 'Enter' && (e.metaKey || e.ctrlKey)) || e.isComposing) {
+          if (e.key !== 'Enter' || !(e.metaKey || e.ctrlKey)) return;
+
+          e.stopPropagation();
+          if (e.isComposing) {
+            setTimeout(() => void handleAddNote('shortcut'), 0);
             return;
           }
 
           e.preventDefault();
-          handleAddNote('shortcut');
+          void handleAddNote('shortcut');
         }}
-        placeholder="떠오르는 생각을 자유롭게 적어보세요..."
+        placeholder="떠오르는 생각을 적어보세요"
         bind:value={inputValue}></textarea>
 
       <div class={flex({ alignItems: 'center', gap: '8px', paddingX: '12px', paddingY: '6px' })}>
@@ -563,7 +667,13 @@
           {/each}
         </div>
 
-        <Button style={css.raw({ marginLeft: 'auto', gap: '4px' })} onclick={() => handleAddNote('button')} size="sm" variant="primary">
+        <Button
+          style={css.raw({ marginLeft: 'auto', gap: '4px' })}
+          loading={createInFlight}
+          onclick={() => handleAddNote('button')}
+          size="sm"
+          variant="primary"
+        >
           추가
           <div class={flex({ alignItems: 'center', opacity: '70' })}>
             {#if navigator.platform.includes('Mac')}
@@ -600,8 +710,8 @@
               ondelete={handleDeleteNote}
               ondragcancel={() => handleDragCancel(note.id)}
               ondragend={handleDragEnd}
-              ondragmove={handleNoteDragEnter}
-              ondragstart={() => handleDragStart(note.id)}
+              ondragmove={updateDraggingPosition}
+              ondragstart={(pointer) => handleDragStart(note.id, pointer)}
               onendresolve={handleEndResolve}
               onexpand={handleExpand}
               onremoveentity={handleRemoveEntity}
@@ -654,8 +764,8 @@
                 ondelete={handleDeleteNote}
                 ondragcancel={() => handleDragCancel(note.id)}
                 ondragend={handleDragEnd}
-                ondragmove={handleNoteDragEnter}
-                ondragstart={() => handleDragStart(note.id)}
+                ondragmove={updateDraggingPosition}
+                ondragstart={(pointer) => handleDragStart(note.id, pointer)}
                 onendresolve={handleEndResolve}
                 onexpand={handleExpand}
                 onremoveentity={handleRemoveEntity}

--- a/apps/website/src/routes/website/(dashboard)/@widgets/widgets/DocumentRelatedNoteWidget.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@widgets/widgets/DocumentRelatedNoteWidget.svelte
@@ -8,7 +8,7 @@
   import { animateFlip, createDragScroll, elementScrollViewport } from '@typie/ui/utils';
   import mixpanel from 'mixpanel-browser';
   import { tick, untrack } from 'svelte';
-  import { SvelteSet } from 'svelte/reactivity';
+  import { SvelteMap, SvelteSet } from 'svelte/reactivity';
   import ChevronDownIcon from '~icons/lucide/chevron-down';
   import ChevronUpIcon from '~icons/lucide/chevron-up';
   import ExpandIcon from '~icons/lucide/expand';
@@ -16,11 +16,20 @@
   import PlusIcon from '~icons/lucide/plus';
   import StickyNoteIcon from '~icons/lucide/sticky-note';
   import { cache } from '$lib/graphql';
+  import { reorderedNoteIdsForDrag } from '$lib/note-reorder';
   import { graphql } from '$mearie';
   import { SubscribeModal } from '../../@subscription/subscribe-modal.svelte';
   import Widget from '../Widget.svelte';
   import { getWidgetContext } from '../widget-context.svelte';
   import DocumentRelatedNoteWidgetItem from './DocumentRelatedNoteWidgetItem.svelte';
+  import type { NoteReorderDirection, NoteReorderGeometry } from '$lib/note-reorder';
+
+  type NoteDragPosition = {
+    clientX: number;
+    clientY: number;
+    direction: NoteReorderDirection;
+    ghost: NoteReorderGeometry;
+  };
 
   type Props = {
     widgetId: string;
@@ -80,8 +89,9 @@
 
   let dragging = $state<{
     noteId: string;
-    originalIndex: number;
-    pointer: { clientX: number; clientY: number } | null;
+    originalOrder: string[];
+    position: NoteDragPosition | null;
+    sectionNoteIds: string[];
   } | null>(null);
   let localNoteOrder = $state<string[]>([]);
   let scrollContainer = $state<HTMLElement | null>(null);
@@ -156,78 +166,77 @@
   };
 
   const handleDragStart = (noteId: string) => {
+    const originalOrder = sortedNotes.map((note) => note.id);
+    localNoteOrder = [...originalOrder];
     dragging = {
       noteId,
-      originalIndex: localNoteOrder.indexOf(noteId),
-      pointer: null,
+      originalOrder,
+      position: null,
+      sectionNoteIds: openNotes.map((note) => note.id),
     };
+    return true;
   };
 
   const handleDragCancel = (noteId: string) => {
-    if (dragging?.noteId !== noteId) return;
+    const currentDragging = dragging;
+    if (currentDragging?.noteId !== noteId) return;
 
-    const { originalIndex } = dragging;
-    const currentIndex = localNoteOrder.indexOf(noteId);
     dragging = null;
-
-    if (currentIndex === -1 || originalIndex === -1 || currentIndex === originalIndex) return;
-
-    const restoredOrder = [...localNoteOrder];
-    const [removed] = restoredOrder.splice(currentIndex, 1);
-    restoredOrder.splice(originalIndex, 0, removed);
-    localNoteOrder = restoredOrder;
+    localNoteOrder = [...currentDragging.originalOrder];
   };
 
-  const moveDraggingNote = (noteId: string) => {
-    if (dragging && dragging.noteId !== noteId) {
-      const draggedIndex = localNoteOrder.indexOf(dragging.noteId);
-      const dropIndex = localNoteOrder.indexOf(noteId);
+  const resolveDraggingPosition = (position: NoteDragPosition) => {
+    const currentDragging = dragging;
+    if (!currentDragging || !scrollContainer) return;
 
-      if (draggedIndex !== -1 && dropIndex !== -1 && draggedIndex !== dropIndex) {
-        const newOrder = [...localNoteOrder];
-        const [removed] = newOrder.splice(draggedIndex, 1);
-        newOrder.splice(dropIndex, 0, removed);
-        localNoteOrder = newOrder;
-      }
+    const sectionNoteIds = new Set(currentDragging.sectionNoteIds);
+    const currentSectionOrder = localNoteOrder.filter((noteId) => sectionNoteIds.has(noteId));
+    const noteGeometries = new SvelteMap<string, NoteReorderGeometry>();
+
+    for (const noteElement of scrollContainer.querySelectorAll<HTMLElement>('[data-widget-note-id]')) {
+      const noteId = noteElement.dataset.widgetNoteId;
+      if (!noteId || !sectionNoteIds.has(noteId)) continue;
+
+      const { top, bottom } = noteElement.getBoundingClientRect();
+      noteGeometries.set(noteId, { top, bottom });
+    }
+    noteGeometries.set(currentDragging.noteId, position.ghost);
+
+    const reorderedSection = reorderedNoteIdsForDrag(currentSectionOrder, currentDragging.noteId, position.direction, noteGeometries);
+    if (!reorderedSection || reorderedSection.every((noteId, index) => noteId === currentSectionOrder[index])) return;
+
+    let sectionIndex = 0;
+    const reorderedNotes = localNoteOrder.map((noteId) => {
+      if (!sectionNoteIds.has(noteId)) return noteId;
+      return reorderedSection[sectionIndex++] ?? noteId;
+    });
+    if (reorderedNotes.some((noteId, index) => noteId !== localNoteOrder[index])) {
+      localNoteOrder = reorderedNotes;
     }
   };
 
-  const resolveDraggingPosition = (clientX: number, clientY: number) => {
-    if (!dragging || !scrollContainer) return;
-
-    const element = document.elementFromPoint(clientX, clientY);
-    const noteElement = element?.closest('[data-widget-note-id]') as HTMLElement | null;
-    if (!noteElement || !scrollContainer.contains(noteElement)) return;
-
-    const noteId = noteElement.dataset.widgetNoteId;
-    if (noteId) moveDraggingNote(noteId);
-  };
-
-  const updateDraggingPosition = (clientX: number, clientY: number) => {
-    if (!dragging) return;
-    dragging.pointer = { clientX, clientY };
-    dragScroll?.updatePointer(clientX, clientY);
-    resolveDraggingPosition(clientX, clientY);
-  };
-
-  const handleDragEnd = async (clientX: number, clientY: number) => {
+  const updateDraggingPosition = (position: NoteDragPosition) => {
     if (!dragging) return;
 
-    updateDraggingPosition(clientX, clientY);
+    dragging.position = position;
+    dragScroll?.updatePointer(position.clientX, position.clientY);
+    resolveDraggingPosition(position);
+  };
+
+  const handleDragEnd = async () => {
     const currentDragging = dragging;
+    if (!currentDragging) return;
+
     const currentIndex = localNoteOrder.indexOf(currentDragging.noteId);
+    const originalIndex = currentDragging.originalOrder.indexOf(currentDragging.noteId);
     dragging = null;
 
     const currentDocument = relatedDocument.data;
     if (!currentDocument) return;
 
-    if (
-      currentIndex !== -1 &&
-      currentDragging.originalIndex !== -1 &&
-      currentIndex !== currentDragging.originalIndex &&
-      sortedNotes.length > 1
-    ) {
+    if (currentIndex !== -1 && originalIndex !== -1 && currentIndex !== originalIndex && sortedNotes.length > 1) {
       if (!SubscribeModal.gate('notes_move')) {
+        localNoteOrder = [...currentDragging.originalOrder];
         return;
       }
 
@@ -257,7 +266,7 @@
     const noteIdsStr = noteIds.join(',');
     const prevNoteIdsStr = prevNoteIds.join(',');
 
-    if (noteIdsStr !== prevNoteIdsStr) {
+    if (!dragging && noteIdsStr !== prevNoteIdsStr) {
       prevNoteIds = noteIds;
       localNoteOrder = noteIds;
     }
@@ -276,11 +285,16 @@
     const current = dragging;
     if (palette || !scrollContainer || !current) return;
 
-    const initialPointer = untrack(() => current.pointer ?? undefined);
+    const initialPointer = untrack(() => {
+      const position = current.position;
+      return position ? { clientX: position.clientX, clientY: position.clientY } : undefined;
+    });
     const activeDragScroll = createDragScroll(elementScrollViewport(scrollContainer), {
       initialPointer,
-      onScroll: (clientX, clientY) => {
-        if (dragging === current) resolveDraggingPosition(clientX, clientY);
+      onScroll: () => {
+        if (dragging?.noteId === current.noteId && current.position) {
+          resolveDraggingPosition(current.position);
+        }
       },
     });
     dragScroll = activeDragScroll;
@@ -413,7 +427,6 @@
           onBeginResolve={() => handleBeginResolve(note.id)}
           onDragCancel={() => handleDragCancel(note.id)}
           onDragEnd={handleDragEnd}
-          onDragEnter={() => moveDraggingNote(note.id)}
           onDragMove={updateDraggingPosition}
           onDragStart={() => handleDragStart(note.id)}
           onEndResolve={() => handleEndResolve(note.id)}

--- a/apps/website/src/routes/website/(dashboard)/@widgets/widgets/DocumentRelatedNoteWidgetItem.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@widgets/widgets/DocumentRelatedNoteWidgetItem.svelte
@@ -6,6 +6,7 @@
   import { autosize, tooltip } from '@typie/ui/actions';
   import { HorizontalDivider, Icon, Menu, MenuItem, Submenu } from '@typie/ui/components';
   import { Dialog } from '@typie/ui/notification';
+  import { pushEscapeHandler } from '@typie/ui/utils';
   import mixpanel from 'mixpanel-browser';
   import { onDestroy } from 'svelte';
   import CheckIcon from '~icons/lucide/check';
@@ -17,7 +18,15 @@
   import { graphql } from '$mearie';
   import { getNoteColor, noteColors } from '../../@notes/colors';
   import { SubscribeModal } from '../../@subscription/subscribe-modal.svelte';
+  import type { NoteReorderDirection, NoteReorderGeometry } from '$lib/note-reorder';
   import type { DocumentRelatedNoteWidgetItem_note$key } from '$mearie';
+
+  type NoteDragPosition = {
+    clientX: number;
+    clientY: number;
+    direction: NoteReorderDirection;
+    ghost: NoteReorderGeometry;
+  };
 
   type Props = {
     note$key: DocumentRelatedNoteWidgetItem_note$key;
@@ -27,10 +36,9 @@
     onAddNote: () => void;
     onBeginResolve: () => void;
     onDragCancel: () => void;
-    onDragEnd: (clientX: number, clientY: number) => void;
-    onDragEnter: () => void;
-    onDragMove: (clientX: number, clientY: number) => void;
-    onDragStart: () => void;
+    onDragEnd: () => void;
+    onDragMove: (position: NoteDragPosition) => void;
+    onDragStart: () => boolean;
     onEndResolve: () => void;
   };
 
@@ -43,7 +51,6 @@
     onBeginResolve,
     onDragCancel,
     onDragEnd,
-    onDragEnter,
     onDragMove,
     onDragStart,
     onEndResolve,
@@ -98,6 +105,7 @@
   const colorHex = $derived(getNoteColor(note.data.color) ?? token('colors.surface.default'));
 
   const DRAG_THRESHOLD = 5;
+  const DRAG_DIRECTION_EPSILON = 0.5;
   let cancelDrag: (() => void) | null = null;
 
   onDestroy(() => cancelDrag?.());
@@ -194,20 +202,27 @@
     }
   };
 
+  const executeDeleteNote = async () => {
+    const entityId = note.data.entity?.id;
+    await deleteNote({ input: { noteId: note.data.id } });
+    mixpanel.track('delete_related_note');
+    if (entityId) {
+      cache.invalidate({ __typename: 'Entity', id: entityId, $field: 'notes' });
+    }
+  };
+
   const handleDeleteNote = () => {
+    if (content.trim() === '') {
+      void executeDeleteNote();
+      return;
+    }
+
     Dialog.confirm({
       title: '노트를 삭제하시겠어요?',
       message: '삭제된 노트는 복구할 수 없어요.',
       action: 'danger',
       actionLabel: '삭제',
-      actionHandler: async () => {
-        const entityId = note.data.entity?.id;
-        await deleteNote({ input: { noteId: note.data.id } });
-        mixpanel.track('delete_related_note');
-        if (entityId) {
-          cache.invalidate({ __typename: 'Entity', id: entityId, $field: 'notes' });
-        }
-      },
+      actionHandler: executeDeleteNote,
     });
   };
 </script>
@@ -227,19 +242,16 @@
     }),
   )}
   data-widget-note-id={note.data.id}
-  ondragenter={onDragEnter}
-  ondragover={(e) => {
-    e.preventDefault();
-  }}
   onpointerdown={(e) => {
     if (palette || !e.isPrimary || e.button !== 0) return;
     const target = e.target as HTMLElement;
-    if (target.closest('button, textarea')) return;
+    if (target.closest('button, textarea, a')) return;
 
     e.preventDefault();
     const el = e.currentTarget as HTMLElement;
     const rect = el.getBoundingClientRect();
     const pointerId = e.pointerId;
+    const pointerCaptureTarget = document.documentElement;
 
     const state = {
       startX: e.clientX,
@@ -249,34 +261,79 @@
       started: false,
       ghost: null as HTMLElement | null,
       cursorStyle: null as HTMLStyleElement | null,
+      removeEscapeHandler: null as (() => void) | null,
+      moveFrame: null as number | null,
+      pendingMove: null as PointerEvent | null,
       active: true,
+      previousCenterY: rect.top + rect.height / 2,
+      direction: 0 as NoteReorderDirection,
     };
 
     const cleanup = (cancelled = false) => {
       if (!state.active) return;
       const wasStarted = state.started;
       state.active = false;
+      if (state.moveFrame !== null) {
+        cancelAnimationFrame(state.moveFrame);
+        state.moveFrame = null;
+      }
+      state.pendingMove = null;
       state.ghost?.remove();
       state.cursorStyle?.remove();
+      state.removeEscapeHandler?.();
+      state.removeEscapeHandler = null;
       document.removeEventListener('pointermove', handleMove);
       document.removeEventListener('pointerup', handleUp);
       document.removeEventListener('pointercancel', handleCancel);
+      pointerCaptureTarget.removeEventListener('lostpointercapture', handleLostPointerCapture);
+      if (pointerCaptureTarget.hasPointerCapture(pointerId)) {
+        pointerCaptureTarget.releasePointerCapture(pointerId);
+      }
       cancelDrag = null;
       if (cancelled && wasStarted) {
         onDragCancel();
       }
     };
 
-    const handleMove = (ev: PointerEvent) => {
-      if (ev.pointerId !== pointerId) return;
+    const updateGhost = (ev: PointerEvent) => {
+      if (!state.ghost) return;
 
-      const dist = Math.abs(ev.clientX - state.startX) + Math.abs(ev.clientY - state.startY);
+      const top = ev.clientY - state.offsetY;
+      const centerY = top + rect.height / 2;
+      const centerDeltaY = centerY - state.previousCenterY;
 
+      state.ghost.style.left = `${ev.clientX - state.offsetX}px`;
+      state.ghost.style.top = `${top}px`;
+      state.previousCenterY = centerY;
+
+      if (Math.abs(centerDeltaY) > DRAG_DIRECTION_EPSILON) {
+        state.direction = centerDeltaY < 0 ? -1 : 1;
+      }
+
+      onDragMove({
+        clientX: ev.clientX,
+        clientY: ev.clientY,
+        direction: state.direction,
+        ghost: {
+          top,
+          bottom: top + rect.height,
+        },
+      });
+    };
+
+    const processMove = (ev: PointerEvent) => {
+      const dist = Math.hypot(ev.clientX - state.startX, ev.clientY - state.startY);
       if (!state.started && dist > DRAG_THRESHOLD) {
+        if (!onDragStart()) {
+          cleanup();
+          return;
+        }
         state.started = true;
 
         const ghost = document.createElement('div');
         const cloned = el.cloneNode(true) as HTMLElement;
+        (cloned as unknown as { inert: boolean }).inert = true;
+        cloned.setAttribute('aria-hidden', 'true');
         cloned.style.pointerEvents = 'none';
         cloned.style.transform = 'rotate(1.5deg) scale(1.05)';
         cloned.style.opacity = '0.8';
@@ -286,8 +343,9 @@
 
         ghost.style.position = 'fixed';
         ghost.style.pointerEvents = 'none';
-        ghost.style.zIndex = '9999';
+        ghost.style.zIndex = token('zIndex.ghost');
         ghost.style.width = `${rect.width}px`;
+        ghost.style.height = `${rect.height}px`;
         ghost.style.left = `${ev.clientX - state.offsetX}px`;
         ghost.style.top = `${ev.clientY - state.offsetY}px`;
         document.body.append(ghost);
@@ -296,23 +354,57 @@
         state.cursorStyle = document.createElement('style');
         state.cursorStyle.textContent = '* { cursor: grabbing !important; }';
         document.head.append(state.cursorStyle);
-        onDragStart();
+        state.removeEscapeHandler = pushEscapeHandler(() => {
+          cleanup(true);
+          return true;
+        });
       }
 
       if (state.started && state.ghost) {
-        state.ghost.style.left = `${ev.clientX - state.offsetX}px`;
-        state.ghost.style.top = `${ev.clientY - state.offsetY}px`;
-        onDragMove(ev.clientX, ev.clientY);
+        updateGhost(ev);
+      }
+    };
+
+    const handleMove = (ev: PointerEvent) => {
+      if (ev.pointerId !== pointerId) return;
+
+      state.pendingMove = ev;
+      if (state.moveFrame !== null) return;
+
+      state.moveFrame = requestAnimationFrame(() => {
+        state.moveFrame = null;
+        const pendingMove = state.pendingMove;
+        state.pendingMove = null;
+        if (pendingMove && state.active) {
+          processMove(pendingMove);
+        }
+      });
+    };
+
+    const flushPendingMove = () => {
+      if (state.moveFrame !== null) {
+        cancelAnimationFrame(state.moveFrame);
+        state.moveFrame = null;
+      }
+      const pendingMove = state.pendingMove;
+      state.pendingMove = null;
+      if (pendingMove && state.active) {
+        processMove(pendingMove);
       }
     };
 
     const handleUp = (ev: PointerEvent) => {
       if (ev.pointerId !== pointerId) return;
 
+      flushPendingMove();
+      if (!state.active) return;
       const wasStarted = state.started;
+      if (wasStarted) {
+        updateGhost(ev);
+      }
       cleanup();
       if (wasStarted) {
-        onDragEnd(ev.clientX, ev.clientY);
+        onDragEnd();
       }
     };
 
@@ -321,10 +413,22 @@
       cleanup(true);
     };
 
+    const handleLostPointerCapture = (ev: PointerEvent) => {
+      if (ev.pointerId !== pointerId) return;
+      cleanup(true);
+    };
+
     cancelDrag?.();
     document.addEventListener('pointermove', handleMove);
     document.addEventListener('pointerup', handleUp);
     document.addEventListener('pointercancel', handleCancel);
+    pointerCaptureTarget.addEventListener('lostpointercapture', handleLostPointerCapture);
+    try {
+      pointerCaptureTarget.setPointerCapture(pointerId);
+    } catch {
+      cleanup();
+      return;
+    }
     cancelDrag = () => cleanup(true);
   }}
   ontransitionend={(e) => {
@@ -408,17 +512,20 @@
         handleContentChanged();
       }}
       onkeydown={(e) => {
-        if (!(e.key === 'Enter' && (e.metaKey || e.ctrlKey)) || e.isComposing) {
+        if (!(e.key === 'Enter' && (e.metaKey || e.ctrlKey))) return;
+
+        e.stopPropagation();
+        if (e.isComposing) {
+          setTimeout(onAddNote, 0);
           return;
         }
-
         e.preventDefault();
         onAddNote();
       }}
-      placeholder="기억할 내용이나 작성에 도움이 되는 내용을 자유롭게 적어보세요."
+      placeholder={displayStatus === 'RESOLVED' ? '(내용 없음)' : '떠오르는 생각을 적어보세요'}
       rows={1}
       bind:value={content}
-      use:autosize={{ cacheKey: `widget-note-${note.data.id}` }}></textarea>
+      use:autosize={{ cacheKey: `widget-note-${note.data.id}`, value: content }}></textarea>
   </div>
 
   {#if !palette}

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@document-panel/DocumentPanelNoteItem.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@document-panel/DocumentPanelNoteItem.svelte
@@ -173,20 +173,27 @@
     }
   };
 
+  const executeDeleteNote = async () => {
+    const entityId = note.data.entity?.id;
+    await deleteNote({ input: { noteId: note.data.id } });
+    mixpanel.track('delete_related_note');
+    if (entityId) {
+      cache.invalidate({ __typename: 'Entity', id: entityId, $field: 'notes' });
+    }
+  };
+
   const handleDeleteNote = () => {
+    if (content.trim() === '') {
+      void executeDeleteNote();
+      return;
+    }
+
     Dialog.confirm({
       title: '노트를 삭제하시겠어요?',
       message: '삭제된 노트는 복구할 수 없어요.',
       action: 'danger',
       actionLabel: '삭제',
-      actionHandler: async () => {
-        const entityId = note.data.entity?.id;
-        await deleteNote({ input: { noteId: note.data.id } });
-        mixpanel.track('delete_related_note');
-        if (entityId) {
-          cache.invalidate({ __typename: 'Entity', id: entityId, $field: 'notes' });
-        }
-      },
+      actionHandler: executeDeleteNote,
     });
   };
 </script>
@@ -372,19 +379,20 @@
         handleContentChanged();
       }}
       onkeydown={(e) => {
-        if (!(e.key === 'Enter' && (e.metaKey || e.ctrlKey)) || e.isComposing) {
+        if (!(e.key === 'Enter' && (e.metaKey || e.ctrlKey))) return;
+
+        e.stopPropagation();
+        if (e.isComposing) {
+          setTimeout(onAddNote, 0);
           return;
         }
-
         e.preventDefault();
         onAddNote();
       }}
-      placeholder={displayStatus === 'RESOLVED' && !resolving
-        ? '(내용 없음)'
-        : '기억할 내용이나 작성에 도움이 되는 내용을 자유롭게 적어보세요.'}
+      placeholder={displayStatus === 'RESOLVED' ? '(내용 없음)' : '떠오르는 생각을 적어보세요'}
       rows={1}
       bind:value={content}
-      use:autosize={{ cacheKey: `document-panel-note-${note.data.id}` }}></textarea>
+      use:autosize={{ cacheKey: `document-panel-note-${note.data.id}`, value: content }}></textarea>
   </div>
 
   <!-- ⋯ More button with Menu -->

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanelNote.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanelNote.svelte
@@ -8,15 +8,24 @@
   import { animateFlip, createDragScroll, elementScrollViewport } from '@typie/ui/utils';
   import mixpanel from 'mixpanel-browser';
   import { tick, untrack } from 'svelte';
-  import { SvelteSet } from 'svelte/reactivity';
+  import { SvelteMap, SvelteSet } from 'svelte/reactivity';
   import ChevronRightIcon from '~icons/lucide/chevron-right';
   import PlusIcon from '~icons/lucide/plus';
   import StickyNoteIcon from '~icons/lucide/sticky-note';
   import { cache } from '$lib/graphql';
+  import { reorderedNoteIdsForDrag } from '$lib/note-reorder';
   import { graphql } from '$mearie';
   import { SubscribeModal } from '../../../@subscription/subscribe-modal.svelte';
   import DocumentPanelNoteItem from './DocumentPanelNoteItem.svelte';
+  import type { NoteReorderDirection, NoteReorderGeometry } from '$lib/note-reorder';
   import type { DocumentPanelV2_Note_entity$key } from '$mearie';
+
+  type NoteDragPosition = {
+    clientX: number;
+    clientY: number;
+    direction: NoteReorderDirection;
+    ghost: NoteReorderGeometry;
+  };
 
   type Props = {
     entity$key: DocumentPanelV2_Note_entity$key;
@@ -68,12 +77,14 @@
 
   let dragging = $state<{
     noteId: string;
-    originalIndex: number;
-    pointer: { clientX: number; clientY: number } | null;
+    originalOrder: string[];
+    position: NoteDragPosition | null;
+    sectionNoteIds: string[];
   } | null>(null);
   let localNoteOrder = $state<string[]>([]);
   let scrollContainer = $state<HTMLElement | null>(null);
   let dragScroll: ReturnType<typeof createDragScroll> | null = null;
+  let createInFlight = $state(false);
 
   const sortedNotes = $derived.by(() => {
     if (localNoteOrder.length === 0) {
@@ -106,97 +117,104 @@
   let lastAddedNoteId = $state<string>();
 
   const handleAddNote = async (via: string) => {
+    if (createInFlight) return;
+
     if (!SubscribeModal.gate('notes_create')) {
       return;
     }
 
-    const result = await createNote({
-      input: {
-        content: '',
-        color: 'gray',
-        entityId: entity.data.id,
-      },
-    });
-
-    if (result?.createNote?.id) {
-      lastAddedNoteId = result.createNote.id;
-      mixpanel.track('create_related_note', {
-        via,
+    createInFlight = true;
+    try {
+      const result = await createNote({
+        input: {
+          content: '',
+          color: 'gray',
+          entityId: entity.data.id,
+        },
       });
-      cache.invalidate({ __typename: 'Entity', id: entity.data.id, $field: 'notes' });
+
+      if (result?.createNote?.id) {
+        lastAddedNoteId = result.createNote.id;
+        mixpanel.track('create_related_note', {
+          via,
+        });
+        cache.invalidate({ __typename: 'Entity', id: entity.data.id, $field: 'notes' });
+      }
+    } finally {
+      createInFlight = false;
     }
   };
 
   const handleDragStart = (noteId: string) => {
+    const sectionNotes = openNotes.some((note) => note.id === noteId) ? openNotes : resolvedNotes;
+    const originalOrder = sortedNotes.map((note) => note.id);
+    localNoteOrder = [...originalOrder];
     dragging = {
       noteId,
-      originalIndex: localNoteOrder.indexOf(noteId),
-      pointer: null,
+      originalOrder,
+      position: null,
+      sectionNoteIds: sectionNotes.map((note) => note.id),
     };
+    return true;
   };
 
   const handleDragCancel = (noteId: string) => {
-    if (dragging?.noteId !== noteId) return;
+    const currentDragging = dragging;
+    if (currentDragging?.noteId !== noteId) return;
 
-    const { originalIndex } = dragging;
-    const currentIndex = localNoteOrder.indexOf(noteId);
     dragging = null;
-
-    if (currentIndex === -1 || originalIndex === -1 || currentIndex === originalIndex) return;
-
-    const restoredOrder = [...localNoteOrder];
-    const [removed] = restoredOrder.splice(currentIndex, 1);
-    restoredOrder.splice(originalIndex, 0, removed);
-    localNoteOrder = restoredOrder;
+    localNoteOrder = [...currentDragging.originalOrder];
   };
 
-  const moveDraggingNote = (noteId: string) => {
-    if (dragging && dragging.noteId !== noteId) {
-      const draggedIndex = localNoteOrder.indexOf(dragging.noteId);
-      const dropIndex = localNoteOrder.indexOf(noteId);
+  const resolveDraggingPosition = (position: NoteDragPosition) => {
+    const currentDragging = dragging;
+    if (!currentDragging || !scrollContainer) return;
 
-      if (draggedIndex !== -1 && dropIndex !== -1 && draggedIndex !== dropIndex) {
-        const newOrder = [...localNoteOrder];
-        const [removed] = newOrder.splice(draggedIndex, 1);
-        newOrder.splice(dropIndex, 0, removed);
-        localNoteOrder = newOrder;
-      }
+    const sectionNoteIds = new Set(currentDragging.sectionNoteIds);
+    const currentSectionOrder = localNoteOrder.filter((noteId) => sectionNoteIds.has(noteId));
+    const noteGeometries = new SvelteMap<string, NoteReorderGeometry>();
+
+    for (const noteElement of scrollContainer.querySelectorAll<HTMLElement>('[data-related-note-id]')) {
+      const noteId = noteElement.dataset.relatedNoteId;
+      if (!noteId || !sectionNoteIds.has(noteId)) continue;
+
+      const { top, bottom } = noteElement.getBoundingClientRect();
+      noteGeometries.set(noteId, { top, bottom });
+    }
+    noteGeometries.set(currentDragging.noteId, position.ghost);
+
+    const reorderedSection = reorderedNoteIdsForDrag(currentSectionOrder, currentDragging.noteId, position.direction, noteGeometries);
+    if (!reorderedSection || reorderedSection.every((noteId, index) => noteId === currentSectionOrder[index])) return;
+
+    let sectionIndex = 0;
+    const reorderedNotes = localNoteOrder.map((noteId) => {
+      if (!sectionNoteIds.has(noteId)) return noteId;
+      return reorderedSection[sectionIndex++] ?? noteId;
+    });
+    if (reorderedNotes.some((noteId, index) => noteId !== localNoteOrder[index])) {
+      localNoteOrder = reorderedNotes;
     }
   };
 
-  const resolveDraggingPosition = (clientX: number, clientY: number) => {
-    if (!dragging || !scrollContainer) return;
-
-    const element = document.elementFromPoint(clientX, clientY);
-    const noteElement = element?.closest('[data-related-note-id]') as HTMLElement | null;
-    if (!noteElement || !scrollContainer.contains(noteElement)) return;
-
-    const noteId = noteElement.dataset.relatedNoteId;
-    if (noteId) moveDraggingNote(noteId);
-  };
-
-  const updateDraggingPosition = (clientX: number, clientY: number) => {
-    if (!dragging) return;
-    dragging.pointer = { clientX, clientY };
-    dragScroll?.updatePointer(clientX, clientY);
-    resolveDraggingPosition(clientX, clientY);
-  };
-
-  const handleDragEnd = async (clientX: number, clientY: number) => {
+  const updateDraggingPosition = (position: NoteDragPosition) => {
     if (!dragging) return;
 
-    updateDraggingPosition(clientX, clientY);
+    dragging.position = position;
+    dragScroll?.updatePointer(position.clientX, position.clientY);
+    resolveDraggingPosition(position);
+  };
+
+  const handleDragEnd = async () => {
     const currentDragging = dragging;
+    if (!currentDragging) return;
+
     const currentIndex = localNoteOrder.indexOf(currentDragging.noteId);
+    const originalIndex = currentDragging.originalOrder.indexOf(currentDragging.noteId);
     dragging = null;
 
-    if (
-      currentIndex !== -1 &&
-      currentDragging.originalIndex !== -1 &&
-      currentIndex !== currentDragging.originalIndex &&
-      sortedNotes.length > 1
-    ) {
+    if (currentIndex !== -1 && originalIndex !== -1 && currentIndex !== originalIndex && sortedNotes.length > 1) {
       if (!SubscribeModal.gate('notes_move')) {
+        localNoteOrder = [...currentDragging.originalOrder];
         return;
       }
 
@@ -214,7 +232,7 @@
         mixpanel.track('move_related_note');
         cache.invalidate({ __typename: 'Entity', id: entity.data.id, $field: 'notes' });
       } catch {
-        localNoteOrder = entity.data.notes.map((note) => note.id);
+        localNoteOrder = [...currentDragging.originalOrder];
         Toast.error('노트 순서 변경에 실패했습니다. 잠시 후 다시 시도해주세요.');
       }
     }
@@ -222,13 +240,15 @@
 
   let prevNoteIds = $state<string[]>([]);
   $effect(() => {
-    const noteIds = entity.data.notes.map((n) => n.id);
-    const noteIdsStr = noteIds.join(',');
-    const prevNoteIdsStr = prevNoteIds.join(',');
+    const noteIds = entity.data.notes.map((note) => note.id);
+    if (!dragging) {
+      const noteIdsStr = noteIds.join(',');
+      const prevNoteIdsStr = prevNoteIds.join(',');
 
-    if (noteIdsStr !== prevNoteIdsStr) {
-      prevNoteIds = noteIds;
-      localNoteOrder = noteIds;
+      if (noteIdsStr !== prevNoteIdsStr) {
+        prevNoteIds = noteIds;
+        localNoteOrder = noteIds;
+      }
     }
 
     if (lastAddedNoteId && noteIds.includes(lastAddedNoteId)) {
@@ -245,11 +265,16 @@
     const current = dragging;
     if (!scrollContainer || !current) return;
 
-    const initialPointer = untrack(() => current.pointer ?? undefined);
+    const initialPointer = untrack(() => {
+      const position = current.position;
+      return position ? { clientX: position.clientX, clientY: position.clientY } : undefined;
+    });
     const activeDragScroll = createDragScroll(elementScrollViewport(scrollContainer), {
       initialPointer,
-      onScroll: (clientX, clientY) => {
-        if (dragging === current) resolveDraggingPosition(clientX, clientY);
+      onScroll: () => {
+        if (dragging === current && current.position) {
+          resolveDraggingPosition(current.position);
+        }
       },
     });
     dragScroll = activeDragScroll;
@@ -360,7 +385,7 @@
           </p>
         </div>
 
-        <Button onclick={() => handleAddNote('button')} size="sm" variant="secondary">노트 추가</Button>
+        <Button loading={createInFlight} onclick={() => handleAddNote('button')} size="sm" variant="secondary">노트 추가</Button>
       </div>
     {:else}
       {#each openNotes as note (note.id)}
@@ -371,7 +396,6 @@
           onBeginResolve={() => handleBeginResolve(note.id)}
           onDragCancel={() => handleDragCancel(note.id)}
           onDragEnd={handleDragEnd}
-          onDragEnter={() => moveDraggingNote(note.id)}
           onDragMove={updateDraggingPosition}
           onDragStart={() => handleDragStart(note.id)}
           onEndResolve={() => handleEndResolve(note.id)}
@@ -440,7 +464,6 @@
               }}
               onDragCancel={() => handleDragCancel(note.id)}
               onDragEnd={handleDragEnd}
-              onDragEnter={() => moveDraggingNote(note.id)}
               onDragMove={updateDraggingPosition}
               onDragStart={() => handleDragStart(note.id)}
               onEndResolve={() => {

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanelNoteItem.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanelNoteItem.svelte
@@ -6,6 +6,7 @@
   import { autosize, tooltip } from '@typie/ui/actions';
   import { HorizontalDivider, Icon, Menu, MenuItem, Submenu } from '@typie/ui/components';
   import { Dialog } from '@typie/ui/notification';
+  import { pushEscapeHandler } from '@typie/ui/utils';
   import mixpanel from 'mixpanel-browser';
   import { onDestroy } from 'svelte';
   import CheckIcon from '~icons/lucide/check';
@@ -17,7 +18,15 @@
   import { graphql } from '$mearie';
   import { getNoteColor, noteColors } from '../../../@notes/colors';
   import { SubscribeModal } from '../../../@subscription/subscribe-modal.svelte';
+  import type { NoteReorderDirection, NoteReorderGeometry } from '$lib/note-reorder';
   import type { DocumentPanelV2NoteItem_note$key } from '$mearie';
+
+  type NoteDragPosition = {
+    clientX: number;
+    clientY: number;
+    direction: NoteReorderDirection;
+    ghost: NoteReorderGeometry;
+  };
 
   type Props = {
     note$key: DocumentPanelV2NoteItem_note$key;
@@ -26,10 +35,9 @@
     onAddNote: () => void;
     onBeginResolve: () => void;
     onDragCancel: () => void;
-    onDragEnd: (clientX: number, clientY: number) => void;
-    onDragEnter: () => void;
-    onDragMove: (clientX: number, clientY: number) => void;
-    onDragStart: () => void;
+    onDragEnd: () => void;
+    onDragMove: (position: NoteDragPosition) => void;
+    onDragStart: () => boolean;
     onEndResolve: () => void;
   };
 
@@ -41,7 +49,6 @@
     onBeginResolve,
     onDragCancel,
     onDragEnd,
-    onDragEnter,
     onDragMove,
     onDragStart,
     onEndResolve,
@@ -96,9 +103,16 @@
   const colorHex = $derived(getNoteColor(note.data.color) ?? token('colors.surface.default'));
 
   const DRAG_THRESHOLD = 5;
-  let cancelDrag: (() => void) | null = null;
+  const DRAG_DIRECTION_EPSILON = 0.5;
+  const RESOLVE_PAUSE_DURATION = 250;
 
-  onDestroy(() => cancelDrag?.());
+  let cancelDrag: (() => void) | null = null;
+  let resolveCollapsing = $state(false);
+  let collapseFinished = $state(false);
+
+  onDestroy(() => {
+    cancelDrag?.();
+  });
 
   $effect(() => {
     const serverContent = note.data.content;
@@ -192,306 +206,445 @@
     }
   };
 
+  const executeDeleteNote = async () => {
+    const entityId = note.data.entity?.id;
+    await deleteNote({ input: { noteId: note.data.id } });
+    mixpanel.track('delete_related_note');
+    if (entityId) {
+      cache.invalidate({ __typename: 'Entity', id: entityId, $field: 'notes' });
+    }
+  };
+
   const handleDeleteNote = () => {
+    if (content.trim() === '') {
+      void executeDeleteNote();
+      return;
+    }
+
     Dialog.confirm({
       title: '노트를 삭제하시겠어요?',
       message: '삭제된 노트는 복구할 수 없어요.',
       action: 'danger',
       actionLabel: '삭제',
-      actionHandler: async () => {
-        const entityId = note.data.entity?.id;
-        await deleteNote({ input: { noteId: note.data.id } });
-        mixpanel.track('delete_related_note');
-        if (entityId) {
-          cache.invalidate({ __typename: 'Entity', id: entityId, $field: 'notes' });
-        }
-      },
+      actionHandler: executeDeleteNote,
     });
   };
+
+  function handleResolveTransitionEnd(event: TransitionEvent) {
+    if (
+      event.target !== event.currentTarget ||
+      event.propertyName !== 'grid-template-rows' ||
+      !resolveCollapsing ||
+      !resolving ||
+      cancelling
+    ) {
+      return;
+    }
+
+    collapseFinished = true;
+  }
+
+  $effect(() => {
+    collapseFinished = false;
+    if (!resolving || cancelling) {
+      resolveCollapsing = false;
+      return;
+    }
+
+    const timeout = setTimeout(() => {
+      resolveCollapsing = true;
+    }, RESOLVE_PAUSE_DURATION);
+
+    return () => clearTimeout(timeout);
+  });
+
+  $effect(() => {
+    if (!collapseFinished || note.data.status !== 'RESOLVED' || !resolving || cancelling) {
+      return;
+    }
+
+    collapseFinished = false;
+    onEndResolve();
+  });
 </script>
 
 <div
-  style:--resolve-duration="500ms"
-  style:opacity={isDragging ? '0.5' : resolving && !cancelling ? '0' : '1'}
-  style:transition={cancelling ? 'none' : 'opacity var(--resolve-duration) ease'}
-  class={cx(
-    'group',
-    flex({
-      flexDirection: 'column',
-      position: 'relative',
-      backgroundColor: 'surface.subtle',
-      borderRadius: '8px',
-      cursor: 'grab',
-    }),
-  )}
-  data-related-note-id={note.data.id}
-  ondragenter={onDragEnter}
-  ondragover={(e) => {
-    e.preventDefault();
-  }}
-  onpointerdown={(e) => {
-    if (!e.isPrimary || e.button !== 0) return;
-    const target = e.target as HTMLElement;
-    if (target.closest('button, textarea')) return;
-
-    e.preventDefault();
-    const el = e.currentTarget as HTMLElement;
-    const rect = el.getBoundingClientRect();
-    const pointerId = e.pointerId;
-
-    const state = {
-      startX: e.clientX,
-      startY: e.clientY,
-      offsetX: e.clientX - rect.left,
-      offsetY: e.clientY - rect.top,
-      started: false,
-      ghost: null as HTMLElement | null,
-      cursorStyle: null as HTMLStyleElement | null,
-      active: true,
-    };
-
-    const cleanup = (cancelled = false) => {
-      if (!state.active) return;
-      const wasStarted = state.started;
-      state.active = false;
-      state.ghost?.remove();
-      state.cursorStyle?.remove();
-      document.removeEventListener('pointermove', handleMove);
-      document.removeEventListener('pointerup', handleUp);
-      document.removeEventListener('pointercancel', handleCancel);
-      cancelDrag = null;
-      if (cancelled && wasStarted) {
-        onDragCancel();
-      }
-    };
-
-    const handleMove = (ev: PointerEvent) => {
-      if (ev.pointerId !== pointerId) return;
-
-      const dist = Math.abs(ev.clientX - state.startX) + Math.abs(ev.clientY - state.startY);
-
-      if (!state.started && dist > DRAG_THRESHOLD) {
-        state.started = true;
-
-        const ghost = document.createElement('div');
-        const cloned = el.cloneNode(true) as HTMLElement;
-        cloned.style.pointerEvents = 'none';
-        cloned.style.transform = 'rotate(1.5deg) scale(1.05)';
-        cloned.style.opacity = '0.8';
-        cloned.style.width = '100%';
-        cloned.style.height = '100%';
-        ghost.append(cloned);
-
-        ghost.style.position = 'fixed';
-        ghost.style.pointerEvents = 'none';
-        ghost.style.zIndex = '9999';
-        ghost.style.width = `${rect.width}px`;
-        ghost.style.left = `${ev.clientX - state.offsetX}px`;
-        ghost.style.top = `${ev.clientY - state.offsetY}px`;
-        document.body.append(ghost);
-
-        state.ghost = ghost;
-        state.cursorStyle = document.createElement('style');
-        state.cursorStyle.textContent = '* { cursor: grabbing !important; }';
-        document.head.append(state.cursorStyle);
-        onDragStart();
-      }
-
-      if (state.started && state.ghost) {
-        state.ghost.style.left = `${ev.clientX - state.offsetX}px`;
-        state.ghost.style.top = `${ev.clientY - state.offsetY}px`;
-        onDragMove(ev.clientX, ev.clientY);
-      }
-    };
-
-    const handleUp = (ev: PointerEvent) => {
-      if (ev.pointerId !== pointerId) return;
-
-      const wasStarted = state.started;
-      cleanup();
-      if (wasStarted) {
-        onDragEnd(ev.clientX, ev.clientY);
-      }
-    };
-
-    const handleCancel = (ev: PointerEvent) => {
-      if (ev.pointerId !== pointerId) return;
-      cleanup(true);
-    };
-
-    cancelDrag?.();
-    document.addEventListener('pointermove', handleMove);
-    document.addEventListener('pointerup', handleUp);
-    document.addEventListener('pointercancel', handleCancel);
-    cancelDrag = () => cleanup(true);
-  }}
-  ontransitionend={(e) => {
-    if (e.target === e.currentTarget && e.propertyName === 'opacity' && resolving && !cancelling) {
-      onEndResolve();
-    }
-  }}
-  role="listitem"
+  style:grid-template-rows={resolveCollapsing ? '0fr' : '1fr'}
+  style:margin-bottom={resolveCollapsing ? '-6px' : '0px'}
+  style:opacity={resolveCollapsing ? '0' : '1'}
+  style:transition={cancelling ? 'none' : 'grid-template-rows 180ms ease, margin-bottom 180ms ease, opacity 180ms ease'}
+  class={css({ display: 'grid', minWidth: '0', width: 'full' })}
+  ontransitionend={handleResolveTransitionEnd}
 >
-  <div class={flex({ gap: '10px', padding: '12px' })}>
-    <!-- Color Checkbox -->
-    <button
-      style:background-color={displayStatus === 'RESOLVED' ? colorHex : 'transparent'}
-      style:border={displayStatus === 'RESOLVED' ? 'none' : `1.5px solid ${colorHex}`}
-      style:transition={resolving || cancelling ? 'none' : undefined}
-      class={center({
-        width: '16px',
-        height: '16px',
-        padding: '0',
-        borderRadius: 'full',
-        flexShrink: '0',
-        marginTop: '2px',
-        cursor: 'pointer',
-        transition: 'common',
-        ...(displayStatus === 'RESOLVED' && !resolving
-          ? {
-              _hover: { opacity: '60' },
-            }
-          : {
-              _hover: { opacity: '100' },
-            }),
-      })}
-      onclick={handleToggleStatus}
-      type="button"
-      use:tooltip={{ message: displayStatus === 'RESOLVED' ? '미완료로 표시' : '완료로 표시', placement: 'top' }}
-    >
-      {#if displayStatus === 'RESOLVED'}
-        <Icon style={css.raw({ color: 'surface.default', '& *': { strokeWidth: '[3px]' } })} icon={CheckIcon} size={12} />
-      {:else}
-        <div
-          style:background-color={colorHex}
-          class={center({
-            width: 'full',
-            height: 'full',
-            borderRadius: 'full',
-            opacity: '0',
-            transition: 'common',
-            ':hover > &': { opacity: '100' },
-          })}
-        >
-          <Icon style={css.raw({ color: 'surface.default', '& *': { strokeWidth: '[3px]' } })} icon={CheckIcon} size={12} />
-        </div>
-      {/if}
-    </button>
+  <div
+    style:overflow={resolveCollapsing ? 'hidden' : 'visible'}
+    style:opacity={isDragging ? '0.5' : '1'}
+    style:transition="opacity 180ms ease"
+    class={cx(
+      'group',
+      flex({
+        flexDirection: 'column',
+        position: 'relative',
+        minHeight: '0',
+        backgroundColor: 'surface.subtle',
+        borderRadius: '8px',
+        cursor: 'grab',
+      }),
+    )}
+    data-related-note-id={note.data.id}
+    onpointerdown={(e) => {
+      if (!e.isPrimary || e.button !== 0) return;
+      const target = e.target as HTMLElement;
+      if (target.closest('button, textarea, a')) return;
 
-    <!-- Textarea -->
-    <textarea
-      style:transition={cancelling ? 'none' : 'text-decoration-color var(--resolve-duration) ease, opacity var(--resolve-duration) ease'}
-      class={css({
-        width: 'full',
-        fontSize: '13px',
-        paddingRight: '22px',
-        color: 'text.default',
-        backgroundColor: 'transparent',
-        resize: 'none',
-        lineHeight: '[1.65]',
-        textDecorationLine: displayStatus === 'RESOLVED' ? 'line-through' : 'none',
-        textDecorationColor: displayStatus === 'RESOLVED' ? 'text.faint' : 'transparent',
-        opacity: displayStatus === 'RESOLVED' && !resolving ? '55' : '100',
-      })}
-      onblur={() => {
-        focused = false;
-        flushContentUpdate();
-      }}
-      onfocus={() => {
-        focused = true;
-      }}
-      oninput={() => {
-        handleContentChanged();
-      }}
-      onkeydown={(e) => {
-        if (!(e.key === 'Enter' && (e.metaKey || e.ctrlKey)) || e.isComposing) {
-          return;
+      e.preventDefault();
+      const el = e.currentTarget as HTMLElement;
+      const rect = el.getBoundingClientRect();
+      const pointerId = e.pointerId;
+      const pointerCaptureTarget = document.documentElement;
+
+      const state = {
+        startX: e.clientX,
+        startY: e.clientY,
+        offsetX: e.clientX - rect.left,
+        offsetY: e.clientY - rect.top,
+        started: false,
+        ghost: null as HTMLElement | null,
+        cursorStyle: null as HTMLStyleElement | null,
+        removeEscapeHandler: null as (() => void) | null,
+        moveFrame: null as number | null,
+        pendingMove: null as PointerEvent | null,
+        active: true,
+        previousCenterY: rect.top + rect.height / 2,
+        direction: 0 as NoteReorderDirection,
+      };
+
+      const cleanup = (cancelled = false) => {
+        if (!state.active) return;
+        const wasStarted = state.started;
+        state.active = false;
+        if (state.moveFrame !== null) {
+          cancelAnimationFrame(state.moveFrame);
+          state.moveFrame = null;
+        }
+        state.pendingMove = null;
+        state.ghost?.remove();
+        state.cursorStyle?.remove();
+        state.removeEscapeHandler?.();
+        state.removeEscapeHandler = null;
+        document.removeEventListener('pointermove', handleMove);
+        document.removeEventListener('pointerup', handleUp);
+        document.removeEventListener('pointercancel', handleCancel);
+        pointerCaptureTarget.removeEventListener('lostpointercapture', handleLostPointerCapture);
+        if (pointerCaptureTarget.hasPointerCapture(pointerId)) {
+          pointerCaptureTarget.releasePointerCapture(pointerId);
+        }
+        cancelDrag = null;
+        if (cancelled && wasStarted) {
+          onDragCancel();
+        }
+      };
+
+      const updateGhost = (ev: PointerEvent) => {
+        if (!state.ghost) return;
+
+        const top = ev.clientY - state.offsetY;
+        const centerY = top + rect.height / 2;
+        const centerDeltaY = centerY - state.previousCenterY;
+
+        state.ghost.style.left = `${ev.clientX - state.offsetX}px`;
+        state.ghost.style.top = `${top}px`;
+        state.previousCenterY = centerY;
+
+        if (Math.abs(centerDeltaY) > DRAG_DIRECTION_EPSILON) {
+          state.direction = centerDeltaY < 0 ? -1 : 1;
         }
 
-        e.preventDefault();
-        onAddNote();
-      }}
-      placeholder={displayStatus === 'RESOLVED' && !resolving
-        ? '(내용 없음)'
-        : '기억할 내용이나 작성에 도움이 되는 내용을 자유롭게 적어보세요.'}
-      rows={1}
-      bind:value={content}
-      use:autosize={{ cacheKey: `document-panel-note-${note.data.id}` }}></textarea>
-  </div>
+        onDragMove({
+          clientX: ev.clientX,
+          clientY: ev.clientY,
+          direction: state.direction,
+          ghost: {
+            top,
+            bottom: top + rect.height,
+          },
+        });
+      };
 
-  <!-- ⋯ More button with Menu -->
-  <Menu
-    style={center.raw({
-      position: 'absolute',
-      top: '11px',
-      right: '8px',
-      size: '22px',
-      borderRadius: '4px',
-      color: 'text.faint',
-      cursor: 'pointer',
-      transition: 'common',
-      opacity: '0',
-      _groupHover: {
-        opacity: anyDragging ? '0' : '100',
-      },
-      _hover: {
-        color: 'text.default',
-        backgroundColor: 'surface.dark/10',
-      },
-      _focusVisible: {
-        opacity: '100',
-        color: 'text.default',
-        backgroundColor: 'surface.dark/10',
-      },
-      '&[aria-expanded="true"]': {
-        opacity: '100',
-        color: 'text.default',
-        backgroundColor: 'surface.dark/10',
-      },
-    })}
-    placement="bottom-end"
+      const processMove = (ev: PointerEvent) => {
+        const dist = Math.hypot(ev.clientX - state.startX, ev.clientY - state.startY);
+        if (!state.started && dist > DRAG_THRESHOLD) {
+          if (!onDragStart()) {
+            cleanup();
+            return;
+          }
+          state.started = true;
+
+          const ghost = document.createElement('div');
+          const cloned = el.cloneNode(true) as HTMLElement;
+          (cloned as unknown as { inert: boolean }).inert = true;
+          cloned.setAttribute('aria-hidden', 'true');
+          cloned.style.pointerEvents = 'none';
+          cloned.style.transform = 'rotate(1.5deg) scale(1.05)';
+          cloned.style.opacity = '0.8';
+          cloned.style.width = '100%';
+          cloned.style.height = '100%';
+          ghost.append(cloned);
+
+          ghost.style.position = 'fixed';
+          ghost.style.pointerEvents = 'none';
+          ghost.style.zIndex = token('zIndex.ghost');
+          ghost.style.width = `${rect.width}px`;
+          ghost.style.height = `${rect.height}px`;
+          ghost.style.left = `${ev.clientX - state.offsetX}px`;
+          ghost.style.top = `${ev.clientY - state.offsetY}px`;
+          document.body.append(ghost);
+
+          state.ghost = ghost;
+          state.cursorStyle = document.createElement('style');
+          state.cursorStyle.textContent = '* { cursor: grabbing !important; }';
+          document.head.append(state.cursorStyle);
+          state.removeEscapeHandler = pushEscapeHandler(() => {
+            cleanup(true);
+            return true;
+          });
+        }
+
+        if (state.started && state.ghost) {
+          updateGhost(ev);
+        }
+      };
+
+      const handleMove = (ev: PointerEvent) => {
+        if (ev.pointerId !== pointerId) return;
+
+        state.pendingMove = ev;
+        if (state.moveFrame !== null) return;
+
+        state.moveFrame = requestAnimationFrame(() => {
+          state.moveFrame = null;
+          const pendingMove = state.pendingMove;
+          state.pendingMove = null;
+          if (pendingMove && state.active) {
+            processMove(pendingMove);
+          }
+        });
+      };
+
+      const flushPendingMove = () => {
+        if (state.moveFrame !== null) {
+          cancelAnimationFrame(state.moveFrame);
+          state.moveFrame = null;
+        }
+        const pendingMove = state.pendingMove;
+        state.pendingMove = null;
+        if (pendingMove && state.active) {
+          processMove(pendingMove);
+        }
+      };
+
+      const handleUp = (ev: PointerEvent) => {
+        if (ev.pointerId !== pointerId) return;
+
+        flushPendingMove();
+        if (!state.active) return;
+        const wasStarted = state.started;
+        if (wasStarted) {
+          updateGhost(ev);
+        }
+        cleanup();
+        if (wasStarted) {
+          onDragEnd();
+        }
+      };
+
+      const handleCancel = (ev: PointerEvent) => {
+        if (ev.pointerId !== pointerId) return;
+        cleanup(true);
+      };
+
+      const handleLostPointerCapture = (ev: PointerEvent) => {
+        if (ev.pointerId !== pointerId) return;
+        cleanup(true);
+      };
+
+      cancelDrag?.();
+      document.addEventListener('pointermove', handleMove);
+      document.addEventListener('pointerup', handleUp);
+      document.addEventListener('pointercancel', handleCancel);
+      pointerCaptureTarget.addEventListener('lostpointercapture', handleLostPointerCapture);
+      try {
+        pointerCaptureTarget.setPointerCapture(pointerId);
+      } catch {
+        cleanup();
+        return;
+      }
+      cancelDrag = () => cleanup(true);
+    }}
+    role="listitem"
   >
-    {#snippet button()}
-      <Icon icon={EllipsisIcon} size={14} />
-    {/snippet}
-    {#snippet children({ close })}
-      <Submenu label="색 바꾸기" listStyle={css.raw({ minWidth: '100px' })}>
-        {#snippet prefix()}
+    <div class={flex({ gap: '10px', padding: '12px' })}>
+      <!-- Color Checkbox -->
+      <button
+        style:background-color={displayStatus === 'RESOLVED' ? colorHex : 'transparent'}
+        style:border={displayStatus === 'RESOLVED' ? 'none' : `1.5px solid ${colorHex}`}
+        style:transition={resolving || cancelling ? 'none' : undefined}
+        class={center({
+          width: '16px',
+          height: '16px',
+          padding: '0',
+          borderRadius: 'full',
+          flexShrink: '0',
+          marginTop: '4px',
+          cursor: 'pointer',
+          transition: 'common',
+          ...(displayStatus === 'RESOLVED' && !resolving
+            ? {
+                _hover: { opacity: '60' },
+              }
+            : {
+                _hover: { opacity: '100' },
+              }),
+        })}
+        onclick={handleToggleStatus}
+        type="button"
+        use:tooltip={{ message: displayStatus === 'RESOLVED' ? '미완료로 표시' : '완료로 표시', placement: 'top' }}
+      >
+        {#if displayStatus === 'RESOLVED'}
+          <Icon style={css.raw({ color: 'surface.default', '& *': { strokeWidth: '[3px]' } })} icon={CheckIcon} size={12} />
+        {:else}
           <div
             style:background-color={colorHex}
-            class={css({ width: '14px', height: '14px', borderRadius: 'full', flexShrink: '0' })}
-          ></div>
-        {/snippet}
-        {#each noteColors as noteColorOption (noteColorOption.value)}
-          <MenuItem onclick={() => handleChangeColor(noteColorOption.value)}>
-            {#snippet prefix()}
-              <div
-                style:background-color={noteColorOption.color}
-                class={center({ width: '14px', height: '14px', borderRadius: 'full', flexShrink: '0' })}
-              >
-                {#if noteColorOption.value === note.data.color}
-                  <Icon style={css.raw({ color: 'surface.default' })} icon={CheckIcon} size={10} />
-                {/if}
-              </div>
-            {/snippet}
-            {noteColorOption.label}
-          </MenuItem>
-        {/each}
-      </Submenu>
-      <MenuItem icon={displayStatus === 'RESOLVED' ? CircleIcon : CircleCheckIcon} onclick={handleToggleStatus}>
-        {displayStatus === 'RESOLVED' ? '미완료로 표시' : '완료로 표시'}
-      </MenuItem>
-      <HorizontalDivider />
-      <MenuItem
-        icon={Trash2Icon}
-        onclick={() => {
-          close();
-          handleDeleteNote();
+            class={center({
+              width: 'full',
+              height: 'full',
+              borderRadius: 'full',
+              opacity: '0',
+              transition: 'common',
+              ':hover > &': { opacity: '100' },
+            })}
+          >
+            <Icon style={css.raw({ color: 'surface.default', '& *': { strokeWidth: '[3px]' } })} icon={CheckIcon} size={12} />
+          </div>
+        {/if}
+      </button>
+
+      <!-- Textarea -->
+      <textarea
+        style:transition={resolving || cancelling ? 'none' : 'text-decoration-color 150ms ease, opacity 150ms ease'}
+        class={css({
+          width: 'full',
+          fontSize: '14px',
+          paddingRight: '22px',
+          color: 'text.default',
+          backgroundColor: 'transparent',
+          resize: 'none',
+          lineHeight: '[1.65]',
+          textDecorationLine: displayStatus === 'RESOLVED' ? 'line-through' : 'none',
+          textDecorationColor: displayStatus === 'RESOLVED' ? 'text.faint' : 'transparent',
+          opacity: displayStatus === 'RESOLVED' && !resolving ? '55' : '100',
+        })}
+        onblur={() => {
+          focused = false;
+          flushContentUpdate();
         }}
-        variant="danger"
-      >
-        삭제
-      </MenuItem>
-    {/snippet}
-  </Menu>
+        onfocus={() => {
+          focused = true;
+        }}
+        oninput={() => {
+          handleContentChanged();
+        }}
+        onkeydown={(e) => {
+          if (!(e.key === 'Enter' && (e.metaKey || e.ctrlKey))) return;
+
+          e.stopPropagation();
+          if (e.isComposing) {
+            setTimeout(onAddNote, 0);
+            return;
+          }
+          e.preventDefault();
+          onAddNote();
+        }}
+        placeholder={displayStatus === 'RESOLVED' ? '(내용 없음)' : '떠오르는 생각을 적어보세요'}
+        rows={1}
+        bind:value={content}
+        use:autosize={{ cacheKey: `document-panel-note-${note.data.id}`, value: content }}></textarea>
+    </div>
+
+    <!-- ⋯ More button with Menu -->
+    <Menu
+      style={center.raw({
+        position: 'absolute',
+        top: '11px',
+        right: '8px',
+        size: '22px',
+        borderRadius: '4px',
+        color: 'text.faint',
+        cursor: 'pointer',
+        transition: 'common',
+        opacity: '0',
+        _groupHover: {
+          opacity: anyDragging ? '0' : '100',
+        },
+        _hover: {
+          color: 'text.default',
+          backgroundColor: 'surface.dark/10',
+        },
+        _focusVisible: {
+          opacity: '100',
+          color: 'text.default',
+          backgroundColor: 'surface.dark/10',
+        },
+        '&[aria-expanded="true"]': {
+          opacity: '100',
+          color: 'text.default',
+          backgroundColor: 'surface.dark/10',
+        },
+      })}
+      placement="bottom-end"
+    >
+      {#snippet button()}
+        <Icon icon={EllipsisIcon} size={14} />
+      {/snippet}
+      {#snippet children({ close })}
+        <Submenu label="색 바꾸기" listStyle={css.raw({ minWidth: '100px' })}>
+          {#snippet prefix()}
+            <div
+              style:background-color={colorHex}
+              class={css({ width: '14px', height: '14px', borderRadius: 'full', flexShrink: '0' })}
+            ></div>
+          {/snippet}
+          {#each noteColors as noteColorOption (noteColorOption.value)}
+            <MenuItem onclick={() => handleChangeColor(noteColorOption.value)}>
+              {#snippet prefix()}
+                <div
+                  style:background-color={noteColorOption.color}
+                  class={center({ width: '14px', height: '14px', borderRadius: 'full', flexShrink: '0' })}
+                >
+                  {#if noteColorOption.value === note.data.color}
+                    <Icon style={css.raw({ color: 'surface.default' })} icon={CheckIcon} size={10} />
+                  {/if}
+                </div>
+              {/snippet}
+              {noteColorOption.label}
+            </MenuItem>
+          {/each}
+        </Submenu>
+        <MenuItem icon={displayStatus === 'RESOLVED' ? CircleIcon : CircleCheckIcon} onclick={handleToggleStatus}>
+          {displayStatus === 'RESOLVED' ? '미완료로 표시' : '완료로 표시'}
+        </MenuItem>
+        <HorizontalDivider />
+        <MenuItem
+          icon={Trash2Icon}
+          onclick={() => {
+            close();
+            handleDeleteNote();
+          }}
+          variant="danger"
+        >
+          삭제
+        </MenuItem>
+      {/snippet}
+    </Menu>
+  </div>
 </div>

--- a/packages/ui/src/actions/autosize.svelte.ts
+++ b/packages/ui/src/actions/autosize.svelte.ts
@@ -9,10 +9,37 @@ const cleanupTimeouts = new SvelteMap<string, ReturnType<typeof setTimeout>>();
 type AutosizeParams = {
   // NOTE: 높이 캐싱을 위한 stable key
   cacheKey?: string;
+  // NOTE: input event 없이 value가 바뀌는 경우 높이 재계산에 사용
+  value?: string;
 };
 
 export const autosize: Action<HTMLTextAreaElement, AutosizeParams | undefined> = (element, params = {}) => {
   const cacheKey = params.cacheKey;
+  let currentValue = params.value;
+  let resizeFrame: number | null = null;
+
+  const resize = () => {
+    // NOTE: 요소가 숨겨져 있으면 scrollHeight 계산을 건너뜀
+    if (element.offsetParent === null) {
+      return;
+    }
+
+    element.style.height = 'auto';
+    const height = element.scrollHeight;
+    element.style.height = `${height}px`;
+
+    if (cacheKey) {
+      heightCache.set(cacheKey, height);
+    }
+  };
+
+  const scheduleResize = () => {
+    if (resizeFrame !== null) return;
+    resizeFrame = requestAnimationFrame(() => {
+      resizeFrame = null;
+      resize();
+    });
+  };
 
   if (cacheKey) {
     const existingTimeout = cleanupTimeouts.get(cacheKey);
@@ -32,22 +59,7 @@ export const autosize: Action<HTMLTextAreaElement, AutosizeParams | undefined> =
 
     let lastWidth = 0;
 
-    const handler = () => {
-      // NOTE: 요소가 숨겨져 있으면 scrollHeight 계산을 건너뜀
-      if (element.offsetParent === null) {
-        return;
-      }
-
-      element.style.height = 'auto';
-      const height = element.scrollHeight;
-      element.style.height = `${height}px`;
-
-      if (cacheKey) {
-        heightCache.set(cacheKey, height);
-      }
-    };
-
-    const off = on(element, 'input', handler);
+    const off = on(element, 'input', resize);
 
     const resizeObserver = new ResizeObserver((entries) => {
       for (const entry of entries) {
@@ -55,26 +67,32 @@ export const autosize: Action<HTMLTextAreaElement, AutosizeParams | undefined> =
 
         if (newWidth > 0 && newWidth !== lastWidth) {
           lastWidth = newWidth;
-          requestAnimationFrame(() => {
-            handler();
-          });
+          scheduleResize();
         }
       }
     });
 
     resizeObserver.observe(element);
-
-    requestAnimationFrame(() => {
-      handler();
-    });
+    scheduleResize();
 
     return () => {
       off();
       resizeObserver.disconnect();
+      if (resizeFrame !== null) {
+        cancelAnimationFrame(resizeFrame);
+        resizeFrame = null;
+      }
     };
   });
 
   return {
+    update(nextParams = {}) {
+      const valueChanged = nextParams.value !== currentValue;
+      currentValue = nextParams.value;
+      if (valueChanged) {
+        scheduleResize();
+      }
+    },
     destroy() {
       if (cacheKey) {
         // NOTE: animateFlip이 완료될 때까지 캐시를 유지한 후 삭제

--- a/packages/ui/src/utils/dnd-handler.ts
+++ b/packages/ui/src/utils/dnd-handler.ts
@@ -176,7 +176,7 @@ export const createDndHandler = (node: HTMLElement, options: DndHandlerOptions) 
     animationFrameId = requestAnimationFrame(() => {
       if (!dragStartEvent || !dragTarget) return;
 
-      const distance = Math.sqrt(Math.pow(e.clientX - dragStartEvent.clientX, 2) + Math.pow(e.clientY - dragStartEvent.clientY, 2));
+      const distance = Math.hypot(e.clientX - dragStartEvent.clientX, e.clientY - dragStartEvent.clientY);
 
       if (distance > threshold && !isDragActive) {
         isDragActive = true;


### PR DESCRIPTION
- 빈 노트 컨펌 없이 삭제
- 노트 생성 inflight guard
- 웹 전역 노트 edge auto-scroll
- 웹 노트 드래그할 때 위치 swap되는 threshold를 앱과 맞춤
- 웹 전역 노트 작성 중에도 드래그 가능
- 웹 전역 노트와 노트 패널 본문 13px → 14px
- 빈 노트 placeholder를 `"떠오르는 생각을 적어보세요"`로 통일하고, 접혀있거나 완료된 빈 노트는 `"(내용 없음)"`으로 표시
- **웹 전역 노트 오버레이에서 기존 노트의 내용 중간을 편집해도 커서가 끝으로 이동하지 않도록 함**
- 웹 노트 편집 중 한글 조합 중 `Mod+Enter`를 사용해도 마지막 글자가 중복되지 않고 현재 편집을 마치거나 새 노트를 생성
- 웹 노트 resolve 애니메이션을 앱과 맞춤: 취소선이 표시된 뒤 높이가 줄어들고 주변 노트도 함께 부드럽게 이동
- 앱의 노트 화면과 관련 노트 시트에서 노트를 만들면 맨 위로 스크롤
- 앱에서 내용이 있는 노트를 편집 중 `Mod+Enter`를 누르면 composition을 끝내고 현재 노트를 저장한 뒤 새 노트를 생성하고 본문에 포커스
- 앱의 일반 노트 생성은 자동 포커스하지 않고, `Mod+Enter`로 생성한 경우에만 새 노트 본문에 포커스
- 앱의 `Mod+Enter` 생성에 inflight guard를 적용해 중복 생성 방지
- **앱의 shortcut modifier 판별을 공용화하고 기존 에디터와 찾기·바꾸기 단축키에서도 재사용**
- **iOS native shortcut router와 JVM Desktop IME fallback을 추가해 composition 중에도 `Mod+Enter` 처리**
- 앱 노트 내용 포커스 시 input이 reveal될 때 iOS 뷰포트가 세로로 흔들리는 현상 해결
- 웹 노트 내용이 외부 동기화 등으로 `input` 이벤트 없이 바뀌어도 height를 업데이트하도록 autosize 개선