### PR TITLE
ctrl-s to inspect_slice_as_macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,6 +884,7 @@ dependencies = [
 name = "editor-introspection"
 version = "0.0.1"
 dependencies = [
+ "editor-clipboard",
  "editor-crdt",
  "editor-macros",
  "editor-model",

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Editor.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Editor.kt
@@ -1064,6 +1064,12 @@ internal constructor(
       inner.inspectStateAsMacro()
     }
 
+  fun inspectSelectionAsSliceMacro(): String? =
+    withFailureNotification(defaultValue = { null }) {
+      ensureActive()
+      inner.inspectSelectionAsSliceMacro()
+    }
+
   // Snapshot-based on purpose: these run synchronously inside touch dispatch on the
   // main thread, where a direct FFI call would contend on the Rust editor mutex and
   // stall input for as long as a background tick holds it (APP2-7P).

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/FakeFfiEditor.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/FakeFfiEditor.kt
@@ -375,6 +375,8 @@ internal class FakeFfiEditor(
 
   override fun inspectStateAsMacro(): String = ""
 
+  override fun inspectSelectionAsSliceMacro(): String? = null
+
   override fun receiveRemoteChangeset(payload: ByteArray) {
     pendingEntries += PendingNativeWork
     receiveRemoteChangesetProvider(payload)

--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -2389,12 +2389,13 @@ export class Editor {
     }
   }
 
-  inspect(mode: 'state' | 'state-with-node-id' | 'state-as-macro') {
+  inspect(mode: 'state' | 'state-with-node-id' | 'state-as-macro' | 'selection-as-slice-macro') {
     const output = this.#invokeCore((core) =>
       match(mode)
         .with('state', () => core.inspect_state())
         .with('state-with-node-id', () => core.inspect_state({ show_node_ids: true }))
         .with('state-as-macro', () => core.inspect_state_as_macro())
+        .with('selection-as-slice-macro', () => core.inspect_selection_as_slice_macro())
         .exhaustive(),
     );
 

--- a/apps/website/src/lib/editor-ffi/handlers/keyboard.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/keyboard.ts
@@ -235,6 +235,12 @@ const bindings: KeyBinding[] = [
 
   { key: ['q', 'ㅂ'], modifiers: ['ctrl'], predicate: macOnly, action: (ed) => ed.inspect('state') },
   { key: ['w', 'ㅈ'], modifiers: ['ctrl'], predicate: macOnly, action: (ed) => ed.inspect('state-as-macro') },
+  {
+    key: ['s', 'ㄴ'],
+    modifiers: ['ctrl'],
+    predicate: macOnly,
+    action: (ed) => ed.inspect('selection-as-slice-macro'),
+  },
 ];
 
 const move = (movement: Movement, extend: boolean): Message => ({

--- a/crates/editor-clipboard/src/slice.rs
+++ b/crates/editor-clipboard/src/slice.rs
@@ -375,8 +375,10 @@ fn extract_cell_rect(state: &State, view: &DocView, rect: &CellRect) -> Slice {
 mod tests {
     use super::*;
     use crate::test_doc::DocBuilder;
-    use editor_macros::state;
-    use editor_model::{AtomLeaf, CalloutVariant, Modifier, NodeType};
+    use editor_macros::{slice, state};
+    use editor_model::{
+        Alignment, AtomLeaf, CalloutVariant, Modifier, NodeType, PlainParagraphNode,
+    };
     use editor_resource::Resource;
     use editor_state::{Affinity, Position, Selection};
 
@@ -392,6 +394,96 @@ mod tests {
         let lo = a_col.min(h_col);
         let hi = a_col.max(h_col);
         Selection::new(Position::new(a_row, lo), Position::new(h_row, hi + 1))
+    }
+
+    #[test]
+    fn slice_macro_constructs_nested_multi_root_content() {
+        let actual = slice! {
+            content {
+                paragraph [alignment(Alignment::Center)] carry([bold]) {
+                    text("Hello") [italic]
+                }
+                paragraph {
+                    text("World")
+                }
+            }
+            open_start: 1
+            open_end: 2
+        };
+
+        let expected = Slice {
+            content: vec![
+                Fragment {
+                    node: PlainNode::Paragraph(PlainParagraphNode::default()),
+                    modifiers: vec![Modifier::Alignment {
+                        value: Alignment::Center,
+                    }],
+                    carry: vec![Modifier::Bold],
+                    children: vec![Fragment {
+                        node: PlainNode::Text(PlainTextNode {
+                            text: "Hello".into(),
+                        }),
+                        modifiers: vec![Modifier::Italic],
+                        carry: vec![],
+                        children: vec![],
+                    }],
+                },
+                Fragment {
+                    node: PlainNode::Paragraph(PlainParagraphNode::default()),
+                    modifiers: vec![],
+                    carry: vec![],
+                    children: vec![Fragment {
+                        node: PlainNode::Text(PlainTextNode {
+                            text: "World".into(),
+                        }),
+                        modifiers: vec![],
+                        carry: vec![],
+                        children: vec![],
+                    }],
+                },
+            ],
+            open_start: 1,
+            open_end: 2,
+        };
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn slice_macro_normalizes_empty_content_open_depths() {
+        let actual = slice! {
+            content {}
+            open_start: 3
+            open_end: 4
+        };
+
+        assert_eq!(actual, Slice::new(vec![], 3, 4));
+        assert_eq!((actual.open_start, actual.open_end), (0, 0));
+    }
+
+    #[test]
+    fn slice_macro_constructs_unknown_unit_variant() {
+        let actual = slice! {
+            content {
+                unknown {}
+            }
+            open_start: 0
+            open_end: 0
+        };
+
+        assert_eq!(
+            actual,
+            Slice::new(
+                vec![Fragment {
+                    node: PlainNode::Unknown,
+                    modifiers: vec![],
+                    carry: vec![],
+                    children: vec![],
+                }],
+                0,
+                0,
+            )
+        );
     }
 
     #[test]

--- a/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
@@ -748,6 +748,7 @@ declare class Editor {
     freeze_selection(selection: Selection): StableSelection | undefined;
     ime(before_limit: number, after_limit: number): Ime | undefined;
     insert_template_fragment(changesets: Uint8Array): void;
+    inspect_selection_as_slice_macro(): string | undefined;
     inspect_state(options?: InspectStateOptions | null): string;
     inspect_state_as_macro(): string;
     interactive_hit_test(page: number, x: number, y: number): InteractiveHit | undefined;

--- a/crates/editor-ffi/pkg/server/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/server/editor_ffi.d.ts
@@ -813,6 +813,7 @@ declare class Editor {
     freeze_selection(selection: Selection): StableSelection | undefined;
     ime(before_limit: number, after_limit: number): Ime | undefined;
     insert_template_fragment(changesets: Uint8Array): void;
+    inspect_selection_as_slice_macro(): string | undefined;
     inspect_state(options?: InspectStateOptions | null): string;
     inspect_state_as_macro(): string;
     interactive_hit_test(page: number, x: number, y: number): InteractiveHit | undefined;

--- a/crates/editor-ffi/src/editor.rs
+++ b/crates/editor-ffi/src/editor.rs
@@ -523,6 +523,14 @@ impl Editor {
         })
     }
 
+    pub fn inspect_selection_as_slice_macro(&self) -> EditorResult<Option<String>> {
+        self.with_inner(|inner| {
+            Ok(editor_introspection::inspect_selection_as_slice_macro(
+                inner.editor.state(),
+            ))
+        })
+    }
+
     pub fn page_sizes(&self) -> EditorResult<Vec<Complex<editor_common::Size>>> {
         self.with_inner(|inner| {
             Ok(inner

--- a/crates/editor-introspection/Cargo.toml
+++ b/crates/editor-introspection/Cargo.toml
@@ -11,6 +11,7 @@ uniffi = ["dep:uniffi", "editor-model/uniffi", "editor-state/uniffi"]
 wasm = ["dep:tsify", "dep:wasm-bindgen", "editor-model/wasm", "editor-state/wasm"]
 
 [dependencies]
+editor-clipboard = { path = "../editor-clipboard" }
 editor-crdt = { path = "../editor-crdt" }
 editor-macros = { path = "../editor-macros" }
 editor-model = { path = "../editor-model", features = ["test-utils"] }

--- a/crates/editor-introspection/src/inspect_slice_as_macro.rs
+++ b/crates/editor-introspection/src/inspect_slice_as_macro.rs
@@ -1,0 +1,264 @@
+use std::fmt::Write;
+
+use editor_clipboard::Slice;
+use editor_model::{Fragment, PlainNode};
+use editor_state::State;
+
+use crate::macro_format::{
+    escape_str, write_carry_macro, write_indent, write_modifiers_macro, write_node_attrs_macro,
+};
+
+pub fn inspect_selection_as_slice_macro(state: &State) -> Option<String> {
+    let slice = Slice::extract(state)?;
+    Some(inspect_slice_as_macro(&slice))
+}
+
+pub fn inspect_slice_as_macro(slice: &Slice) -> String {
+    let mut output = String::new();
+
+    output.push_str("slice! {\n");
+    write_indent(&mut output, 1);
+    if slice.content.is_empty() {
+        output.push_str("content {}\n");
+    } else {
+        output.push_str("content {\n");
+        for fragment in &slice.content {
+            write_fragment(fragment, 2, &mut output);
+        }
+        write_indent(&mut output, 1);
+        output.push_str("}\n");
+    }
+    write_indent(&mut output, 1);
+    writeln!(output, "open_start: {}", slice.open_start).unwrap();
+    write_indent(&mut output, 1);
+    writeln!(output, "open_end: {}", slice.open_end).unwrap();
+    output.push_str("}\n");
+
+    output
+}
+
+fn write_fragment(fragment: &Fragment, indent_level: usize, output: &mut String) {
+    write_indent(output, indent_level);
+
+    if let PlainNode::Text(text) = &fragment.node {
+        write!(output, "text(\"{}\")", escape_str(&text.text)).unwrap();
+        write_modifiers_macro(&fragment.modifiers, output);
+        write_carry_macro(&fragment.carry, output);
+        output.push('\n');
+        return;
+    }
+
+    let type_name: &str = fragment.node.as_type().into();
+    output.push_str(type_name);
+    write_node_attrs_macro(&fragment.node, output);
+    write_modifiers_macro(&fragment.modifiers, output);
+    write_carry_macro(&fragment.carry, output);
+
+    if fragment.children.is_empty() {
+        if fragment.node.as_type().spec().is_leaf() {
+            output.push('\n');
+        } else {
+            output.push_str(" {}\n");
+        }
+        return;
+    }
+
+    output.push_str(" {\n");
+    for child in &fragment.children {
+        write_fragment(child, indent_level + 1, output);
+    }
+    write_indent(output, indent_level);
+    output.push_str("}\n");
+}
+
+#[cfg(test)]
+mod tests {
+    use editor_macros::{slice, state};
+
+    use crate::{inspect_selection_as_slice_macro, inspect_slice_as_macro};
+
+    #[test]
+    fn collapsed_selection_has_no_slice_macro() {
+        let (state, ..) = state! {
+            doc { root { p1: paragraph { text("Hello") } } }
+            selection: (p1, 2)
+        };
+
+        assert_eq!(inspect_selection_as_slice_macro(&state), None);
+    }
+
+    #[test]
+    fn selected_range_is_extracted_as_slice_macro() {
+        let (state, ..) = state! {
+            doc { root { p1: paragraph { text("Hello") } } }
+            selection: (p1, 1) -> (p1, 4)
+        };
+
+        assert_eq!(
+            inspect_selection_as_slice_macro(&state),
+            Some(
+                "\
+slice! {
+    content {
+        text(\"ell\")
+    }
+    open_start: 0
+    open_end: 0
+}
+"
+                .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn nested_multi_root_slice() {
+        let slice = slice! {
+            content {
+                paragraph [alignment(Alignment::Center)] carry([bold]) {
+                    text("He said \"hi\"\n") [italic]
+                }
+                image(id: Some("asset-id".to_string()), proportion: 80)
+            }
+            open_start: 1
+            open_end: 2
+        };
+
+        let output = inspect_slice_as_macro(&slice);
+        let expected = r#"slice! {
+    content {
+        paragraph [alignment(Alignment::Center)] carry([bold]) {
+            text("He said \"hi\"\n") [italic]
+        }
+        image(id: Some("asset-id".to_string()), proportion: 80)
+    }
+    open_start: 1
+    open_end: 2
+}
+"#;
+
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn empty_slice_uses_normalized_open_depths() {
+        let slice = slice! {
+            content {}
+            open_start: 3
+            open_end: 4
+        };
+
+        let output = inspect_slice_as_macro(&slice);
+        let expected = "\
+slice! {
+    content {}
+    open_start: 0
+    open_end: 0
+}
+";
+
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn escapes_all_rust_string_literals() {
+        let slice = slice! {
+            content {
+                paragraph {
+                    text("styles") [
+                        font_family("Font\"Family".to_string()),
+                        text_color("red\\blue".to_string()),
+                        background_color("line\nbreak".to_string()),
+                        link(href: "tab\tlink".to_string()),
+                        ruby(text: "ruby\r\u{2}".to_string()),
+                    ]
+                }
+                image(id: Some("asset\"\\\n\r\t\u{1}".to_string()))
+                file(id: Some("file\"id".to_string()))
+                embed(id: Some("embed\\id".to_string()))
+                archived(id: Some("archived\nid".to_string()))
+            }
+            open_start: 0
+            open_end: 0
+        };
+
+        let output = inspect_slice_as_macro(&slice);
+        let expected = r#"slice! {
+    content {
+        paragraph {
+            text("styles") [font_family("Font\"Family".to_string()), text_color("red\\blue".to_string()), background_color("line\nbreak".to_string()), link(href: "tab\tlink".to_string()), ruby(text: "ruby\r\u{2}".to_string())]
+        }
+        image(id: Some("asset\"\\\n\r\t\u{1}".to_string()))
+        file(id: Some("file\"id".to_string()))
+        embed(id: Some("embed\\id".to_string()))
+        archived(id: Some("archived\nid".to_string()))
+    }
+    open_start: 0
+    open_end: 0
+}
+"#;
+
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn emits_all_non_default_plain_node_attributes() {
+        let slice = slice! {
+            content {
+                root(
+                    layout_mode: LayoutMode::Paginated {
+                        page_width: 800,
+                        page_height: 1200,
+                        page_margin_top: 10,
+                        page_margin_bottom: 20,
+                        page_margin_left: 30,
+                        page_margin_right: 40,
+                    },
+                ) {}
+                table_cell(
+                    col_width: Some(320),
+                    background_color: Some("blue\"gray".to_string()),
+                ) {}
+            }
+            open_start: 0
+            open_end: 0
+        };
+
+        let output = inspect_slice_as_macro(&slice);
+        let expected = r#"slice! {
+    content {
+        root(layout_mode: LayoutMode::Paginated { page_width: 800, page_height: 1200, page_margin_top: 10, page_margin_bottom: 20, page_margin_left: 30, page_margin_right: 40 }) {}
+        table_cell(col_width: Some(320), background_color: Some("blue\"gray".to_string())) {}
+    }
+    open_start: 0
+    open_end: 0
+}
+"#;
+
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn formats_unknown_unit_variant() {
+        let slice = slice! {
+            content {
+                unknown {}
+            }
+            open_start: 0
+            open_end: 0
+        };
+
+        let output = inspect_slice_as_macro(&slice);
+        let expected = "\
+slice! {
+    content {
+        unknown {}
+    }
+    open_start: 0
+    open_end: 0
+}
+";
+
+        assert_eq!(output, expected);
+    }
+}

--- a/crates/editor-introspection/src/inspect_state_as_macro.rs
+++ b/crates/editor-introspection/src/inspect_state_as_macro.rs
@@ -4,6 +4,10 @@ use std::collections::BTreeMap;
 use std::fmt::Write;
 
 use crate::labeler::Labeler;
+use crate::macro_format::{
+    escape_str, write_carry_macro, write_indent, write_modifier_macro, write_modifiers_macro,
+    write_node_attrs_macro,
+};
 
 enum Disp<'a> {
     Block(NodeView<'a>),
@@ -130,13 +134,6 @@ pub fn inspect_state_as_macro(state: &State) -> String {
     output
 }
 
-fn write_indent(output: &mut String, level: usize) {
-    const INDENT: &str = "    ";
-    for _ in 0..level {
-        output.push_str(INDENT);
-    }
-}
-
 fn write_macro_node(
     item: &Disp,
     indent_level: usize,
@@ -159,7 +156,7 @@ fn write_macro_node(
             let type_name: &str = node.node_type().into();
             write!(output, "{type_name}").unwrap();
 
-            write_node_attrs_macro(&node.node(), output);
+            write_node_attrs_macro(&node.node().to_plain(), output);
             write_modifiers_macro(&explicit_block_mods(pd, node.id()), output);
             write_node_carry_macro(node, pd, output);
 
@@ -189,7 +186,7 @@ fn write_macro_node(
             let type_name: &str = leaf.node_type().into();
             write!(output, "{type_name}").unwrap();
 
-            write_node_attrs_macro(&atom_node(leaf, pd), output);
+            write_node_attrs_macro(&atom_node(leaf, pd).to_plain(), output);
             write_modifiers_macro(modifiers, output);
             output.push('\n');
         }
@@ -201,20 +198,8 @@ fn is_synthetic_scaffold(id: editor_crdt::Dot) -> bool {
 }
 
 fn write_node_carry_macro(node: &NodeView, pd: &ProjectedDoc, output: &mut String) {
-    let carry = pd.carry_modifiers(node.id());
-    if carry.is_empty() {
-        return;
-    }
-    output.push_str(" carry(");
-    output.push('[');
-    for (i, m) in carry.values().enumerate() {
-        if i > 0 {
-            output.push_str(", ");
-        }
-        write_modifier_macro(m, output);
-    }
-    output.push(']');
-    output.push(')');
+    let carry: Vec<_> = pd.carry_modifiers(node.id()).into_values().collect();
+    write_carry_macro(&carry, output);
 }
 
 fn write_selection_macro(
@@ -283,129 +268,6 @@ fn write_pending_modifiers(pending: &editor_state::PendingModifiers, output: &mu
         }
     }
     output.push_str("]\n");
-}
-
-fn write_node_attrs_macro(node: &Node, output: &mut String) {
-    let mut attrs = Vec::new();
-    match node {
-        Node::Blockquote(bq) if *bq.variant.get() != BlockquoteVariant::default() => {
-            attrs.push(format!(
-                "variant: BlockquoteVariant::{:?}",
-                bq.variant.get()
-            ));
-        }
-        Node::Callout(c) if *c.variant.get() != CalloutVariant::default() => {
-            attrs.push(format!("variant: CalloutVariant::{:?}", c.variant.get()));
-        }
-        Node::HorizontalRule(hr) if *hr.variant.get() != HorizontalRuleVariant::default() => {
-            attrs.push(format!(
-                "variant: HorizontalRuleVariant::{:?}",
-                hr.variant.get()
-            ));
-        }
-        Node::Table(t) => {
-            if *t.border_style.get() != TableBorderStyle::default() {
-                attrs.push(format!(
-                    "border_style: TableBorderStyle::{:?}",
-                    t.border_style.get()
-                ));
-            }
-            if *t.proportion.get() != 100 {
-                attrs.push(format!("proportion: {}", *t.proportion.get()));
-            }
-        }
-        Node::TableCell(tc) => {
-            if let Some(w) = tc.col_width.get() {
-                attrs.push(format!("col_width: Some({w})"));
-            }
-        }
-        Node::Image(img) => {
-            if let Some(id) = img.id.get() {
-                attrs.push(format!("id: Some(\"{id}\".to_string())"));
-            }
-            if *img.proportion.get() != 100 {
-                attrs.push(format!("proportion: {}", *img.proportion.get()));
-            }
-        }
-        Node::File(f) => {
-            if let Some(id) = f.id.get() {
-                attrs.push(format!("id: Some(\"{id}\".to_string())"));
-            }
-        }
-        Node::Embed(e) => {
-            if let Some(id) = e.id.get() {
-                attrs.push(format!("id: Some(\"{id}\".to_string())"));
-            }
-        }
-        Node::Archived(a) => {
-            if let Some(id) = a.id.get() {
-                attrs.push(format!("id: Some(\"{id}\".to_string())"));
-            }
-        }
-        _ => {}
-    }
-    if !attrs.is_empty() {
-        write!(output, "({})", attrs.join(", ")).unwrap();
-    }
-}
-
-fn write_modifier_macro(m: &Modifier, output: &mut String) {
-    let name: &str = m.as_type().into();
-    match m {
-        Modifier::Bold | Modifier::Italic | Modifier::Underline | Modifier::Strikethrough => {
-            output.push_str(name);
-        }
-        Modifier::FontSize { value }
-        | Modifier::LineHeight { value }
-        | Modifier::BlockGap { value }
-        | Modifier::ParagraphIndent { value } => write!(output, "{name}({value})").unwrap(),
-        Modifier::FontWeight { value } => write!(output, "{name}({value})").unwrap(),
-        Modifier::LetterSpacing { value } => write!(output, "{name}({value})").unwrap(),
-        Modifier::FontFamily { value }
-        | Modifier::TextColor { value }
-        | Modifier::BackgroundColor { value } => {
-            write!(output, "{name}(\"{value}\".to_string())").unwrap();
-        }
-        Modifier::Link { href } => {
-            write!(output, "{name}(href: \"{href}\".to_string())").unwrap();
-        }
-        Modifier::Ruby { text } => {
-            write!(output, "{name}(text: \"{text}\".to_string())").unwrap();
-        }
-        Modifier::Alignment { value } => {
-            write!(output, "{name}(Alignment::{value:?})").unwrap();
-        }
-    }
-}
-
-fn write_modifiers_macro(modifiers: &[Modifier], output: &mut String) {
-    if modifiers.is_empty() {
-        return;
-    }
-    output.push_str(" [");
-    for (i, m) in modifiers.iter().enumerate() {
-        if i > 0 {
-            output.push_str(", ");
-        }
-        write_modifier_macro(m, output);
-    }
-    output.push(']');
-}
-
-fn escape_str(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for c in s.chars() {
-        match c {
-            '\\' => out.push_str("\\\\"),
-            '"' => out.push_str("\\\""),
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\t' => out.push_str("\\t"),
-            c if c.is_control() => write!(out, "\\u{{{:x}}}", c as u32).unwrap(),
-            c => out.push(c),
-        }
-    }
-    out
 }
 
 fn non_default_root_modifiers(modifiers: &[Modifier]) -> Vec<Modifier> {

--- a/crates/editor-introspection/src/lib.rs
+++ b/crates/editor-introspection/src/lib.rs
@@ -1,8 +1,11 @@
 editor_macros::preamble!();
 
+mod inspect_slice_as_macro;
 mod inspect_state;
 mod inspect_state_as_macro;
 mod labeler;
+mod macro_format;
 
+pub use inspect_slice_as_macro::*;
 pub use inspect_state::*;
 pub use inspect_state_as_macro::*;

--- a/crates/editor-introspection/src/macro_format.rs
+++ b/crates/editor-introspection/src/macro_format.rs
@@ -1,0 +1,197 @@
+use std::fmt::Write;
+
+use editor_model::*;
+
+pub(crate) fn write_indent(output: &mut String, level: usize) {
+    const INDENT: &str = "    ";
+    for _ in 0..level {
+        output.push_str(INDENT);
+    }
+}
+
+pub(crate) fn write_node_attrs_macro(node: &PlainNode, output: &mut String) {
+    let mut attrs = Vec::new();
+    match node {
+        PlainNode::Root(root) => {
+            if root.layout_mode != LayoutMode::default() {
+                attrs.push(format!(
+                    "layout_mode: {}",
+                    layout_mode_expr(root.layout_mode)
+                ));
+            }
+        }
+        PlainNode::Blockquote(bq) => {
+            if bq.variant != BlockquoteVariant::default() {
+                attrs.push(format!("variant: BlockquoteVariant::{:?}", bq.variant));
+            }
+        }
+        PlainNode::Callout(c) => {
+            if c.variant != CalloutVariant::default() {
+                attrs.push(format!("variant: CalloutVariant::{:?}", c.variant));
+            }
+        }
+        PlainNode::HorizontalRule(hr) => {
+            if hr.variant != HorizontalRuleVariant::default() {
+                attrs.push(format!("variant: HorizontalRuleVariant::{:?}", hr.variant));
+            }
+        }
+        PlainNode::Table(t) => {
+            if t.border_style != TableBorderStyle::default() {
+                attrs.push(format!(
+                    "border_style: TableBorderStyle::{:?}",
+                    t.border_style
+                ));
+            }
+            if t.proportion != 100 {
+                attrs.push(format!("proportion: {}", t.proportion));
+            }
+        }
+        PlainNode::TableCell(tc) => {
+            if let Some(w) = tc.col_width {
+                attrs.push(format!("col_width: Some({w})"));
+            }
+            if let Some(background_color) = &tc.background_color {
+                attrs.push(format!(
+                    "background_color: Some({})",
+                    owned_string_expr(background_color)
+                ));
+            }
+        }
+        PlainNode::Image(img) => {
+            if let Some(id) = &img.id {
+                attrs.push(format!("id: Some({})", owned_string_expr(id)));
+            }
+            if img.proportion != 100 {
+                attrs.push(format!("proportion: {}", img.proportion));
+            }
+        }
+        PlainNode::File(f) => {
+            if let Some(id) = &f.id {
+                attrs.push(format!("id: Some({})", owned_string_expr(id)));
+            }
+        }
+        PlainNode::Embed(e) => {
+            if let Some(id) = &e.id {
+                attrs.push(format!("id: Some({})", owned_string_expr(id)));
+            }
+        }
+        PlainNode::Archived(a) => {
+            if let Some(id) = &a.id {
+                attrs.push(format!("id: Some({})", owned_string_expr(id)));
+            }
+        }
+        PlainNode::Paragraph(_)
+        | PlainNode::Text(_)
+        | PlainNode::BulletList(_)
+        | PlainNode::OrderedList(_)
+        | PlainNode::ListItem(_)
+        | PlainNode::Fold(_)
+        | PlainNode::FoldTitle(_)
+        | PlainNode::FoldContent(_)
+        | PlainNode::TableRow(_)
+        | PlainNode::HardBreak(_)
+        | PlainNode::PageBreak(_)
+        | PlainNode::Tab(_)
+        | PlainNode::Unknown => {}
+    }
+    if !attrs.is_empty() {
+        write!(output, "({})", attrs.join(", ")).unwrap();
+    }
+}
+
+pub(crate) fn write_modifier_macro(m: &Modifier, output: &mut String) {
+    let name: &str = m.as_type().into();
+    match m {
+        Modifier::Bold | Modifier::Italic | Modifier::Underline | Modifier::Strikethrough => {
+            output.push_str(name);
+        }
+        Modifier::FontSize { value }
+        | Modifier::LineHeight { value }
+        | Modifier::BlockGap { value }
+        | Modifier::ParagraphIndent { value } => write!(output, "{name}({value})").unwrap(),
+        Modifier::FontWeight { value } => write!(output, "{name}({value})").unwrap(),
+        Modifier::LetterSpacing { value } => write!(output, "{name}({value})").unwrap(),
+        Modifier::FontFamily { value }
+        | Modifier::TextColor { value }
+        | Modifier::BackgroundColor { value } => {
+            write!(output, "{name}({})", owned_string_expr(value)).unwrap();
+        }
+        Modifier::Link { href } => {
+            write!(output, "{name}(href: {})", owned_string_expr(href)).unwrap();
+        }
+        Modifier::Ruby { text } => {
+            write!(output, "{name}(text: {})", owned_string_expr(text)).unwrap();
+        }
+        Modifier::Alignment { value } => {
+            write!(output, "{name}(Alignment::{value:?})").unwrap();
+        }
+    }
+}
+
+pub(crate) fn write_modifiers_macro(modifiers: &[Modifier], output: &mut String) {
+    if modifiers.is_empty() {
+        return;
+    }
+    output.push_str(" [");
+    for (i, m) in modifiers.iter().enumerate() {
+        if i > 0 {
+            output.push_str(", ");
+        }
+        write_modifier_macro(m, output);
+    }
+    output.push(']');
+}
+
+pub(crate) fn write_carry_macro(carry: &[Modifier], output: &mut String) {
+    if carry.is_empty() {
+        return;
+    }
+    output.push_str(" carry([");
+    for (i, modifier) in carry.iter().enumerate() {
+        if i > 0 {
+            output.push_str(", ");
+        }
+        write_modifier_macro(modifier, output);
+    }
+    output.push_str("])");
+}
+
+pub(crate) fn escape_str(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if c.is_control() => write!(out, "\\u{{{:x}}}", c as u32).unwrap(),
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+fn owned_string_expr(value: &str) -> String {
+    format!("\"{}\".to_string()", escape_str(value))
+}
+
+fn layout_mode_expr(layout_mode: LayoutMode) -> String {
+    match layout_mode {
+        LayoutMode::Paginated {
+            page_width,
+            page_height,
+            page_margin_top,
+            page_margin_bottom,
+            page_margin_left,
+            page_margin_right,
+        } => format!(
+            "LayoutMode::Paginated {{ page_width: {page_width}, page_height: {page_height}, \
+             page_margin_top: {page_margin_top}, page_margin_bottom: {page_margin_bottom}, \
+             page_margin_left: {page_margin_left}, page_margin_right: {page_margin_right} }}"
+        ),
+        LayoutMode::Continuous { max_width } => {
+            format!("LayoutMode::Continuous {{ max_width: {max_width} }}")
+        }
+    }
+}

--- a/crates/editor-macros/src/doc_macro/codegen.rs
+++ b/crates/editor-macros/src/doc_macro/codegen.rs
@@ -157,7 +157,11 @@ fn collect_synthetic_node(
 }
 
 // Produces the PlainNode variant expression (excluding Text, which is inlined in collect_node).
-fn build_plain_node_expr(node: &NodeDef) -> TokenStream {
+pub(crate) fn build_plain_node_expr(node: &NodeDef) -> TokenStream {
+    if node.node_type == "unknown" && node.params.is_empty() {
+        return quote! { PlainNode::Unknown };
+    }
+
     let type_str = node.node_type.to_string();
 
     let variant = Ident::new(&type_str.to_pascal_case(), Span::call_site());

--- a/crates/editor-macros/src/doc_macro/parse.rs
+++ b/crates/editor-macros/src/doc_macro/parse.rs
@@ -61,7 +61,7 @@ impl Parse for DocTree {
     }
 }
 
-fn parse_node_list(input: ParseStream) -> Result<Vec<NodeDef>> {
+pub(crate) fn parse_node_list(input: ParseStream) -> Result<Vec<NodeDef>> {
     let mut nodes = Vec::new();
     while !input.is_empty() {
         nodes.push(parse_node_def(input)?);

--- a/crates/editor-macros/src/lib.rs
+++ b/crates/editor-macros/src/lib.rs
@@ -8,6 +8,7 @@ mod modifier_state_macro;
 mod node_attr_macro;
 mod node_companion_macro;
 mod preamble_macro;
+mod slice_macro;
 mod state_macro;
 
 use proc_macro::TokenStream;
@@ -33,6 +34,12 @@ pub fn context_expr(input: TokenStream) -> TokenStream {
 pub fn state(input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input as state_macro::parse::StateInput);
     state_macro::codegen::generate(&input).into()
+}
+
+#[proc_macro]
+pub fn slice(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as slice_macro::parse::SliceInput);
+    slice_macro::codegen::generate(&input).into()
 }
 
 #[proc_macro_derive(FromDiscriminant, attributes(from_discriminant))]

--- a/crates/editor-macros/src/slice_macro/codegen.rs
+++ b/crates/editor-macros/src/slice_macro/codegen.rs
@@ -1,0 +1,71 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+
+use crate::doc_macro::codegen::{build_modifier_expr, build_plain_node_expr};
+use crate::doc_macro::parse::{CarryDef, DecorationDef, NodeContent, NodeDef};
+use crate::slice_macro::parse::SliceInput;
+
+pub fn generate(input: &SliceInput) -> TokenStream {
+    let content = input.content.iter().map(generate_fragment);
+    let open_start = &input.open_start;
+    let open_end = &input.open_end;
+
+    quote! {
+        {
+            use ::editor_model::*;
+
+            ::editor_clipboard::Slice::new(
+                vec![#(#content),*],
+                #open_start,
+                #open_end,
+            )
+        }
+    }
+}
+
+fn generate_fragment(node: &NodeDef) -> TokenStream {
+    let node_expr = match &node.content {
+        NodeContent::Text(text) => {
+            quote! { PlainNode::Text(PlainTextNode { text: #text.to_string() }) }
+        }
+        NodeContent::Children(_) | NodeContent::Leaf => build_plain_node_expr(node),
+    };
+    let modifiers = generate_modifiers(node.modifiers.as_deref());
+    let carry = generate_carry(node.carry.as_ref());
+    let children = match &node.content {
+        NodeContent::Children(children) => {
+            let children = children.iter().map(generate_fragment);
+            quote! { vec![#(#children),*] }
+        }
+        NodeContent::Text(_) | NodeContent::Leaf => quote! { Vec::new() },
+    };
+
+    quote! {
+        ::editor_model::Fragment {
+            node: #node_expr,
+            modifiers: #modifiers,
+            carry: #carry,
+            children: #children,
+        }
+    }
+}
+
+fn generate_modifiers(modifiers: Option<&[DecorationDef]>) -> TokenStream {
+    match modifiers {
+        Some(modifiers) if !modifiers.is_empty() => {
+            let modifiers = modifiers.iter().map(build_modifier_expr);
+            quote! { vec![#(#modifiers),*] }
+        }
+        Some(_) | None => quote! { Vec::new() },
+    }
+}
+
+fn generate_carry(carry: Option<&CarryDef>) -> TokenStream {
+    match carry {
+        Some(carry) => {
+            let modifiers = carry.modifiers.iter().map(build_modifier_expr);
+            quote! { vec![#(#modifiers),*] }
+        }
+        None => quote! { Vec::new() },
+    }
+}

--- a/crates/editor-macros/src/slice_macro/mod.rs
+++ b/crates/editor-macros/src/slice_macro/mod.rs
@@ -1,0 +1,2 @@
+pub mod codegen;
+pub mod parse;

--- a/crates/editor-macros/src/slice_macro/parse.rs
+++ b/crates/editor-macros/src/slice_macro/parse.rs
@@ -1,0 +1,163 @@
+use syn::braced;
+use syn::parse::{Parse, ParseStream};
+use syn::{LitInt, Result, Token};
+
+use crate::doc_macro::parse::{
+    DecorationDef, DecorationParams, NodeContent, NodeDef, parse_node_list,
+};
+
+mod kw {
+    syn::custom_keyword!(content);
+    syn::custom_keyword!(open_start);
+    syn::custom_keyword!(open_end);
+}
+
+pub struct SliceInput {
+    pub content: Vec<NodeDef>,
+    pub open_start: LitInt,
+    pub open_end: LitInt,
+}
+
+impl Parse for SliceInput {
+    fn parse(input: ParseStream) -> Result<Self> {
+        input.parse::<kw::content>()?;
+
+        let content;
+        braced!(content in input);
+        let content = parse_node_list(&content)?;
+        validate_slice_nodes(&content)?;
+
+        input.parse::<kw::open_start>()?;
+        input.parse::<Token![:]>()?;
+        let open_start = input.parse()?;
+
+        input.parse::<kw::open_end>()?;
+        input.parse::<Token![:]>()?;
+        let open_end = input.parse()?;
+
+        Ok(Self {
+            content,
+            open_start,
+            open_end,
+        })
+    }
+}
+
+fn validate_slice_nodes(nodes: &[NodeDef]) -> Result<()> {
+    for node in nodes {
+        if let Some(binding) = &node.binding {
+            return Err(syn::Error::new(
+                binding.span(),
+                "slice nodes cannot be labeled because slices contain plain fragments without projected identities",
+            ));
+        }
+        if node.synthetic {
+            return Err(syn::Error::new(
+                node.node_type.span(),
+                "slice nodes cannot be synthetic because slices contain plain fragments without projected identities",
+            ));
+        }
+        validate_modifiers(node.modifiers.as_deref())?;
+        validate_modifiers(node.carry.as_ref().map(|carry| carry.modifiers.as_slice()))?;
+        if let NodeContent::Children(children) = &node.content {
+            validate_slice_nodes(children)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_modifiers(modifiers: Option<&[DecorationDef]>) -> Result<()> {
+    for modifier in modifiers.into_iter().flatten() {
+        if let DecorationParams::Positional(params) = &modifier.params
+            && params.len() != 1
+        {
+            return Err(syn::Error::new(
+                modifier.name.span(),
+                "positional modifier shorthand expects exactly one argument",
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SliceInput;
+
+    fn assert_parse_error(input: &str, expected_message: &str) {
+        let error = syn::parse_str::<SliceInput>(input)
+            .err()
+            .expect("slice input must be rejected");
+        assert!(
+            error.to_string().contains(expected_message),
+            "expected error containing {expected_message:?}, got {error}"
+        );
+    }
+
+    #[test]
+    fn positional_modifier_requires_exactly_one_argument() {
+        let input = r#"
+            content {
+                paragraph [font_size(1, 2)] {}
+            }
+            open_start: 0
+            open_end: 0
+        "#;
+
+        assert_parse_error(
+            input,
+            "positional modifier shorthand expects exactly one argument",
+        );
+    }
+
+    #[test]
+    fn nested_block_labels_are_rejected() {
+        let input = r#"
+            content {
+                paragraph {
+                    child: paragraph {}
+                }
+            }
+            open_start: 0
+            open_end: 0
+        "#;
+
+        assert_parse_error(input, "slice nodes cannot be labeled");
+    }
+
+    #[test]
+    fn nested_synthetic_nodes_are_rejected() {
+        let input = r#"
+            content {
+                paragraph {
+                    synthetic paragraph {}
+                }
+            }
+            open_start: 0
+            open_end: 0
+        "#;
+
+        assert_parse_error(input, "slice nodes cannot be synthetic");
+    }
+
+    #[test]
+    fn slice_fields_must_follow_the_required_order() {
+        let input = r#"
+            content {}
+            open_end: 0
+            open_start: 0
+        "#;
+
+        assert_parse_error(input, "expected `open_start`");
+    }
+
+    #[test]
+    fn slice_requires_open_end() {
+        let input = r#"
+            content {}
+            open_start: 0
+        "#;
+
+        assert_parse_error(input, "expected `open_end`");
+    }
+}


### PR DESCRIPTION
- 웹 v1의 ctrl-f (selection을 fragment로 콘솔에 출력) 와 대응되는 기능
- 웹에서 ctrl-s로 현재 selection을 slice로 콘솔에 출력함