### PR TITLE
웹 단축키 카탈로그 통합 및 정리

### DIFF
--- a/apps/website/src/lib/editor-ffi/components/toolbar/BottomToolbar.svelte
+++ b/apps/website/src/lib/editor-ffi/components/toolbar/BottomToolbar.svelte
@@ -458,7 +458,7 @@
   <ToolbarButton
     icon={RemoveFormattingIcon}
     keys={['Mod', '\\']}
-    label="기본 서식 적용"
+    label="서식 지우기"
     onclick={() => enqueue({ type: 'modifier', op: { type: 'clear_all' } })}
     size="small"
   />
@@ -468,7 +468,7 @@
   <ToolbarButton
     icon={SearchIcon}
     keys={['Mod', 'F']}
-    label="찾기, 바꾸기"
+    label="찾기 및 바꾸기"
     onclick={() => onSearchClick?.()}
     onpointerdown={(e) => e.preventDefault()}
     size="small"

--- a/apps/website/src/routes/website/(dashboard)/@preference/ShortcutsTab.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@preference/ShortcutsTab.svelte
@@ -4,7 +4,9 @@
   import { flex } from '@typie/styled-system/patterns';
   import { SettingsCard, SettingsDivider, SettingsRow } from '$lib/components';
   import { graphql } from '$mearie';
+  import { shortcutCategories } from '../shortcut-catalog';
   import type { DashboardLayout_PreferenceModal_ShortcutsTab_user$key } from '$mearie';
+  import type { ShortcutKey, ShortcutPlatform, ShortcutSequence } from '../shortcut-catalog';
 
   type Props = {
     user$key: DashboardLayout_PreferenceModal_ShortcutsTab_user$key;
@@ -22,71 +24,18 @@
     () => user$key,
   );
 
-  type ShortcutCategory = {
-    title: string;
-    shortcuts: {
-      keys: string[] | string[][];
-      description: string;
-    }[];
+  const isMac = typeof window !== 'undefined' && /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
+  const platform: ShortcutPlatform = isMac ? 'mac' : 'windows';
+
+  const displayKey = (key: ShortcutKey): string => {
+    if (key === 'mod') return isMac ? 'Cmd' : 'Ctrl';
+    if (key === 'alt') return isMac ? 'Option' : 'Alt';
+    if (key === 'shift') return 'Shift';
+    return key;
   };
 
-  const isMac = typeof window !== 'undefined' && /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
-  const modKey = isMac ? 'Cmd' : 'Ctrl';
-  const altKey = isMac ? 'Option' : 'Alt';
-
-  const shortcutCategories: ShortcutCategory[] = [
-    {
-      title: '텍스트 서식',
-      shortcuts: [
-        { keys: [modKey, 'B'], description: '굵게' },
-        { keys: [modKey, 'I'], description: '기울임' },
-        { keys: [modKey, 'Shift', 'S'], description: '취소선' },
-        { keys: [modKey, 'U'], description: '밑줄' },
-      ],
-    },
-    {
-      title: '편집',
-      shortcuts: [
-        { keys: [modKey, 'Z'], description: '실행 취소' },
-        { keys: [modKey, 'Shift', 'Z'], description: '다시 실행' },
-        { keys: [modKey, 'X'], description: '잘라내기' },
-        { keys: [modKey, 'C'], description: '복사' },
-        { keys: [modKey, 'V'], description: '붙여넣기' },
-        { keys: [modKey, 'A'], description: '전체 선택' },
-        { keys: [modKey, 'F'], description: '찾기, 바꾸기 열기' },
-        { keys: [altKey, '↑'], description: '이전 문장 경계로 이동' },
-        { keys: [altKey, '↓'], description: '다음 문장 경계로 이동' },
-        { keys: ['Shift', altKey, '↑'], description: '이전 문장 경계까지 선택' },
-        { keys: ['Shift', altKey, '↓'], description: '다음 문장 경계까지 선택' },
-      ],
-    },
-    {
-      title: '삽입',
-      shortcuts: [
-        { keys: ['Enter'], description: '문단 나누기' },
-        { keys: ['Shift', 'Enter'], description: '문단 내 줄바꿈' },
-        { keys: [modKey, 'Enter'], description: '페이지 나누기' },
-        { keys: [['드래그 앤 드롭'], [modKey, 'V']], description: '이미지/파일 삽입' },
-        { keys: ['--'], description: '긴 대시 (—)' },
-        { keys: ['...'], description: '말줄임표 (…)' },
-        { keys: ['"'], description: '큰따옴표 (“”)' },
-        { keys: ["'"], description: '작은따옴표 (‘’)' },
-      ],
-    },
-    {
-      title: '메뉴',
-      shortcuts: [
-        { keys: [modKey, 'K'], description: '빠른 검색 열기' },
-        { keys: [modKey, 'J'], description: '노트 열기' },
-        { keys: ['/'], description: '슬래시 메뉴 열기' },
-        { keys: ['Esc'], description: '열린 메뉴 닫기' },
-      ],
-    },
-    {
-      title: '레이아웃',
-      shortcuts: [{ keys: [modKey, 'Shift', 'M'], description: '집중 모드 전환' }],
-    },
-  ];
+  const availableSequences = (sequences: ShortcutSequence[]): ShortcutSequence[] =>
+    sequences.filter((sequence) => sequence.platforms === undefined || sequence.platforms.includes(platform));
 </script>
 
 <div class={flex({ direction: 'column', gap: '40px', maxWidth: '640px' })}>
@@ -101,13 +50,13 @@
       <h2 class={css({ fontSize: '16px', fontWeight: 'semibold', color: 'text.default', marginBottom: '24px' })}>{category.title}</h2>
 
       <SettingsCard>
-        {#each category.shortcuts as shortcut, index (shortcut.description)}
+        {#each category.shortcuts as shortcut, index (shortcut.id)}
           {#if index > 0}
             <SettingsDivider />
           {/if}
           <SettingsRow>
             {#snippet label()}
-              {shortcut.description}
+              {shortcut.label}
             {/snippet}
             {#snippet value()}
               <div
@@ -117,89 +66,54 @@
                   flexShrink: 0,
                 })}
               >
-                {#if Array.isArray(shortcut.keys[0])}
-                  {#each shortcut.keys as keyGroup, groupIndex (groupIndex)}
-                    {#if groupIndex > 0}
-                      <span
-                        class={css({
-                          fontSize: '11px',
-                          color: 'text.subtle',
-                          fontWeight: 'medium',
-                          marginX: '6px',
-                        })}
-                      >
-                        또는
-                      </span>
-                    {/if}
-                    <div class={flex({ align: 'center', gap: '4px' })}>
-                      {#each keyGroup as key, keyIndex (key)}
-                        {#if keyIndex > 0}
-                          <span
-                            class={css({
-                              fontSize: '11px',
-                              color: 'text.disabled',
-                              fontWeight: 'normal',
-                            })}
-                          >
-                            +
-                          </span>
-                        {/if}
-                        <kbd
-                          class={css({
-                            display: 'inline-flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            minWidth: '24px',
-                            height: '24px',
-                            paddingX: '6px',
-                            fontSize: '11px',
-                            fontWeight: 'normal',
-                            fontFamily: 'mono',
-                            color: 'text.subtle',
-                            borderWidth: '1px',
-                            borderColor: 'border.subtle',
-                            borderRadius: '4px',
-                          })}
-                        >
-                          {key}
-                        </kbd>
-                      {/each}
-                    </div>
-                  {/each}
-                {:else}
-                  {#each shortcut.keys as key, keyIndex (key)}
-                    {#if keyIndex > 0}
-                      <span
-                        class={css({
-                          fontSize: '11px',
-                          color: 'text.disabled',
-                          fontWeight: 'medium',
-                        })}
-                      >
-                        +
-                      </span>
-                    {/if}
-                    <kbd
+                {#each availableSequences(shortcut.sequences) as sequence, sequenceIndex (sequenceIndex)}
+                  {#if sequenceIndex > 0}
+                    <span
                       class={css({
-                        display: 'inline-flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        minWidth: '24px',
-                        height: '24px',
-                        paddingX: '6px',
                         fontSize: '11px',
-                        fontWeight: 'normal',
-                        fontFamily: 'mono',
                         color: 'text.subtle',
-                        borderWidth: '1px',
-                        borderColor: 'border.subtle',
-                        borderRadius: '4px',
+                        fontWeight: 'medium',
+                        marginX: '6px',
                       })}
                     >
-                      {key}
-                    </kbd>
-                  {/each}
-                {/if}
+                      또는
+                    </span>
+                  {/if}
+                  <div class={flex({ align: 'center', gap: '4px' })}>
+                    {#each sequence.keys as key, keyIndex (keyIndex)}
+                      {#if keyIndex > 0}
+                        <span
+                          class={css({
+                            fontSize: '11px',
+                            color: 'text.disabled',
+                            fontWeight: 'normal',
+                          })}
+                        >
+                          +
+                        </span>
+                      {/if}
+                      <kbd
+                        class={css({
+                          display: 'inline-flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          minWidth: '24px',
+                          height: '24px',
+                          paddingX: '6px',
+                          fontSize: '11px',
+                          fontWeight: 'normal',
+                          fontFamily: 'mono',
+                          color: 'text.subtle',
+                          borderWidth: '1px',
+                          borderColor: 'border.subtle',
+                          borderRadius: '4px',
+                        })}
+                      >
+                        {displayKey(key)}
+                      </kbd>
+                    {/each}
+                  </div>
+                {/each}
               </div>
             {/snippet}
           </SettingsRow>

--- a/apps/website/src/routes/website/(dashboard)/ShortcutsModal.svelte
+++ b/apps/website/src/routes/website/(dashboard)/ShortcutsModal.svelte
@@ -6,73 +6,77 @@
   import ArrowBigUpIcon from '~icons/lucide/arrow-big-up';
   import CommandIcon from '~icons/lucide/command';
   import OptionIcon from '~icons/lucide/option';
+  import { pushState } from '$app/navigation';
+  import { shortcutCategories } from './shortcut-catalog';
   import type { Component } from 'svelte';
+  import type { ShortcutKey, ShortcutSequence } from './shortcut-catalog';
 
   const app = getAppContext();
 
   const isMac = typeof window !== 'undefined' && /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
+  const platform = isMac ? 'mac' : 'windows';
 
   type Key = string | { icon: Component };
+  type CheatsheetShortcut = { id: string; label: string; sequences: ShortcutSequence[] };
+  type CheatsheetCategory = {
+    id: string;
+    title: string;
+    column: 'left' | 'right';
+    shortcuts: CheatsheetShortcut[];
+  };
 
-  const mod: Key = isMac ? { icon: CommandIcon } : 'Ctrl';
-  const alt: Key = isMac ? { icon: OptionIcon } : 'Alt';
-  const shift: Key = isMac ? { icon: ArrowBigUpIcon } : 'Shift';
+  const availableSequences = (sequences: ShortcutSequence[]): ShortcutSequence[] =>
+    sequences.filter((sequence) => sequence.platforms === undefined || sequence.platforms.includes(platform));
 
-  type Category = { title: string; shortcuts: { keys: Key[]; label: string }[] };
+  const displayKey = (key: ShortcutKey): Key => {
+    if (key === 'mod') return isMac ? { icon: CommandIcon } : 'Ctrl';
+    if (key === 'alt') return isMac ? { icon: OptionIcon } : 'Alt';
+    if (key === 'shift') return isMac ? { icon: ArrowBigUpIcon } : 'Shift';
+    return key;
+  };
 
-  const left: Category[] = [
-    {
-      title: '텍스트 서식',
-      shortcuts: [
-        { keys: [mod, 'B'], label: '굵게' },
-        { keys: [mod, 'I'], label: '기울임' },
-        { keys: [mod, shift, 'S'], label: '취소선' },
-        { keys: [mod, 'U'], label: '밑줄' },
-      ],
-    },
-    {
-      title: '삽입',
-      shortcuts: [
-        { keys: ['Enter'], label: '문단 나누기' },
-        { keys: [shift, 'Enter'], label: '줄바꿈' },
-        { keys: [mod, 'Enter'], label: '페이지 나누기' },
-      ],
-    },
-  ];
+  const cheatsheetCategories: CheatsheetCategory[] = shortcutCategories.flatMap((category) => {
+    const column = category.cheatsheetColumn;
+    if (column === undefined) return [];
 
-  const right: Category[] = [
-    {
-      title: '편집',
-      shortcuts: [
-        { keys: [mod, 'Z'], label: '실행 취소' },
-        { keys: [mod, shift, 'Z'], label: '다시 실행' },
-        { keys: [mod, 'A'], label: '문단/전체 선택' },
-        { keys: [mod, 'F'], label: '찾기/바꾸기' },
-        { keys: [alt, '↑↓'], label: '문장 경계 이동' },
-      ],
-    },
-    {
-      title: '메뉴',
-      shortcuts: [
-        { keys: [mod, 'K'], label: '빠른 검색' },
-        { keys: [mod, 'J'], label: '노트' },
-        { keys: ['/'], label: '슬래시 메뉴' },
-        { keys: ['Esc'], label: '메뉴 닫기' },
-      ],
-    },
-    {
-      title: '레이아웃',
-      shortcuts: [{ keys: [mod, shift, 'M'], label: '집중 모드' }],
-    },
-  ];
+    const shortcuts = category.shortcuts.flatMap((shortcut) => {
+      if (shortcut.cheatsheet === undefined) return [];
+
+      return [
+        {
+          id: shortcut.id,
+          label: shortcut.cheatsheet.label ?? shortcut.label,
+          sequences: availableSequences(shortcut.cheatsheet.sequences ?? shortcut.sequences),
+        },
+      ];
+    });
+
+    return [{ id: category.id, title: category.title, column, shortcuts }];
+  });
+
+  const left = cheatsheetCategories.filter((category) => category.column === 'left');
+  const right = cheatsheetCategories.filter((category) => category.column === 'right');
+
+  let openSettingsAfterClose = false;
+
+  const openShortcutSettings = () => {
+    openSettingsAfterClose = true;
+    app.state.shortcutsOpen = false;
+  };
+
+  const handleTransitionEnd = () => {
+    if (!openSettingsAfterClose) return;
+    openSettingsAfterClose = false;
+    pushState('', { shallowRoute: '/preference/shortcuts' });
+  };
 </script>
 
-{#snippet category(cat: Category)}
+{#snippet category(cat: CheatsheetCategory)}
   <div>
     <h3 class={css({ fontSize: '12px', fontWeight: 'semibold', color: 'text.faint', marginBottom: '8px' })}>{cat.title}</h3>
 
     <div class={flex({ direction: 'column', gap: '2px' })}>
-      {#each cat.shortcuts as shortcut (shortcut.label)}
+      {#each cat.shortcuts as shortcut (shortcut.id)}
         <div
           class={flex({
             alignItems: 'center',
@@ -83,30 +87,38 @@
         >
           <span class={css({ fontSize: '13px', color: 'text.default', whiteSpace: 'nowrap' })}>{shortcut.label}</span>
           <div class={flex({ alignItems: 'center', gap: '3px', flexShrink: '0' })}>
-            {#each shortcut.keys as key, i (i)}
-              <kbd
-                class={css({
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  minWidth: '22px',
-                  paddingX: '5px',
-                  paddingY: '4px',
-                  fontSize: '11px',
-                  lineHeight: '[1]',
-                  color: 'text.subtle',
-                  borderWidth: '1px',
-                  borderColor: 'border.subtle',
-                  borderRadius: '4px',
-                  backgroundColor: 'surface.subtle',
-                })}
-              >
-                {#if typeof key === 'string'}
-                  {key}
-                {:else}
-                  <Icon icon={key.icon} size={12} />
-                {/if}
-              </kbd>
+            {#each shortcut.sequences as sequence, sequenceIndex (sequenceIndex)}
+              {#if sequenceIndex > 0}
+                <span class={css({ paddingX: '2px', fontSize: '11px', color: 'text.faint' })}>/</span>
+              {/if}
+              <div class={flex({ alignItems: 'center', gap: '3px' })}>
+                {#each sequence.keys as key, keyIndex (keyIndex)}
+                  {@const displayedKey = displayKey(key)}
+                  <kbd
+                    class={css({
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      minWidth: '22px',
+                      paddingX: '5px',
+                      paddingY: '4px',
+                      fontSize: '11px',
+                      lineHeight: '[1]',
+                      color: 'text.subtle',
+                      borderWidth: '1px',
+                      borderColor: 'border.subtle',
+                      borderRadius: '4px',
+                      backgroundColor: 'surface.subtle',
+                    })}
+                  >
+                    {#if typeof displayedKey === 'string'}
+                      {displayedKey}
+                    {:else}
+                      <Icon icon={displayedKey.icon} size={12} />
+                    {/if}
+                  </kbd>
+                {/each}
+              </div>
             {/each}
           </div>
         </div>
@@ -120,12 +132,28 @@
   onclose={() => {
     app.state.shortcutsOpen = false;
   }}
+  ontransitionend={handleTransitionEnd}
   open={app.state.shortcutsOpen}
 >
   <div class={css({ padding: '24px' })}>
-    <h2 class={css({ fontSize: '15px', fontWeight: 'bold', letterSpacing: '-0.01em', color: 'text.default', marginBottom: '24px' })}>
-      단축키
-    </h2>
+    <div class={flex({ alignItems: 'center', justifyContent: 'space-between', marginBottom: '24px' })}>
+      <h2 class={css({ fontSize: '15px', fontWeight: 'bold', letterSpacing: '-0.01em', color: 'text.default' })}>단축키</h2>
+      <button
+        class={css({
+          padding: '0',
+          fontSize: '12px',
+          color: 'text.subtle',
+          borderWidth: '0',
+          backgroundColor: 'transparent',
+          cursor: 'pointer',
+          _hover: { color: 'text.default', textDecoration: 'underline', textUnderlineOffset: '2px' },
+        })}
+        onclick={openShortcutSettings}
+        type="button"
+      >
+        더 보기…
+      </button>
+    </div>
 
     <div class={flex({ gap: '32px' })}>
       <div class={flex({ direction: 'column', gap: '20px', flex: '1' })}>

--- a/apps/website/src/routes/website/(dashboard)/shortcut-catalog.ts
+++ b/apps/website/src/routes/website/(dashboard)/shortcut-catalog.ts
@@ -1,0 +1,140 @@
+export type ShortcutKey = 'mod' | 'alt' | 'shift' | string;
+export type ShortcutPlatform = 'mac' | 'windows';
+export type ShortcutSequence = {
+  keys: ShortcutKey[];
+  platforms?: ShortcutPlatform[];
+};
+export type ShortcutEntry = {
+  id: string;
+  label: string;
+  sequences: ShortcutSequence[];
+  cheatsheet?: {
+    label?: string;
+    sequences?: ShortcutSequence[];
+  };
+};
+export type ShortcutCategory = {
+  id: string;
+  title: string;
+  cheatsheetColumn?: 'left' | 'right';
+  shortcuts: ShortcutEntry[];
+};
+
+export const shortcutCategories: ShortcutCategory[] = [
+  {
+    id: 'formatting',
+    title: '텍스트 서식',
+    cheatsheetColumn: 'left',
+    shortcuts: [
+      { id: 'bold', label: '굵게', sequences: [{ keys: ['mod', 'B'] }], cheatsheet: {} },
+      { id: 'italic', label: '기울임', sequences: [{ keys: ['mod', 'I'] }], cheatsheet: {} },
+      { id: 'strikethrough', label: '취소선', sequences: [{ keys: ['mod', 'shift', 'S'] }], cheatsheet: {} },
+      { id: 'underline', label: '밑줄', sequences: [{ keys: ['mod', 'U'] }], cheatsheet: {} },
+      { id: 'clear-formatting', label: '서식 지우기', sequences: [{ keys: ['mod', '\\'] }], cheatsheet: {} },
+    ],
+  },
+  {
+    id: 'editing',
+    title: '편집',
+    cheatsheetColumn: 'left',
+    shortcuts: [
+      { id: 'undo', label: '실행 취소', sequences: [{ keys: ['mod', 'Z'] }], cheatsheet: {} },
+      {
+        id: 'redo',
+        label: '다시 실행',
+        sequences: [{ keys: ['mod', 'shift', 'Z'] }, { keys: ['mod', 'Y'], platforms: ['windows'] }],
+        cheatsheet: {},
+      },
+      { id: 'cut', label: '잘라내기', sequences: [{ keys: ['mod', 'X'] }] },
+      { id: 'copy', label: '복사', sequences: [{ keys: ['mod', 'C'] }] },
+      { id: 'paste', label: '붙여넣기', sequences: [{ keys: ['mod', 'V'] }] },
+      {
+        id: 'paste-without-formatting',
+        label: '서식 없이 붙여넣기',
+        sequences: [{ keys: ['mod', 'shift', 'V'] }],
+        cheatsheet: {},
+      },
+      { id: 'select-all', label: '전체 선택', sequences: [{ keys: ['mod', 'A'] }], cheatsheet: {} },
+      {
+        id: 'find-and-replace',
+        label: '찾기 및 바꾸기 열기',
+        sequences: [{ keys: ['mod', 'F'] }],
+        cheatsheet: { label: '찾기 및 바꾸기' },
+      },
+      {
+        id: 'previous-sentence',
+        label: '이전 문장 경계로 이동',
+        sequences: [{ keys: ['alt', '↑'] }],
+        cheatsheet: {
+          label: '문장 경계 이동',
+          sequences: [{ keys: ['alt', '↑↓'] }],
+        },
+      },
+      { id: 'next-sentence', label: '다음 문장 경계로 이동', sequences: [{ keys: ['alt', '↓'] }] },
+      {
+        id: 'select-previous-sentence',
+        label: '이전 문장 경계까지 선택',
+        sequences: [{ keys: ['shift', 'alt', '↑'] }],
+      },
+      {
+        id: 'select-next-sentence',
+        label: '다음 문장 경계까지 선택',
+        sequences: [{ keys: ['shift', 'alt', '↓'] }],
+      },
+    ],
+  },
+  {
+    id: 'insertion',
+    title: '삽입',
+    cheatsheetColumn: 'right',
+    shortcuts: [
+      { id: 'paragraph-break', label: '문단 나누기', sequences: [{ keys: ['Enter'] }], cheatsheet: {} },
+      {
+        id: 'line-break',
+        label: '문단 내 줄바꿈',
+        sequences: [{ keys: ['shift', 'Enter'] }],
+        cheatsheet: {},
+      },
+      { id: 'page-break', label: '페이지 나누기', sequences: [{ keys: ['mod', 'Enter'] }], cheatsheet: {} },
+      {
+        id: 'insert-image-or-file',
+        label: '이미지/파일 삽입',
+        sequences: [{ keys: ['드래그 앤 드롭'] }, { keys: ['mod', 'V'] }],
+      },
+    ],
+  },
+  {
+    id: 'menu',
+    title: '메뉴',
+    cheatsheetColumn: 'right',
+    shortcuts: [
+      { id: 'quick-search', label: '빠른 검색 열기', sequences: [{ keys: ['mod', 'K'] }], cheatsheet: {} },
+      { id: 'close-ui', label: '열린 UI 닫기', sequences: [{ keys: ['Esc'] }], cheatsheet: {} },
+    ],
+  },
+  {
+    id: 'note',
+    title: '노트',
+    cheatsheetColumn: 'right',
+    shortcuts: [
+      { id: 'open-note', label: '노트 열기', sequences: [{ keys: ['mod', 'J'] }], cheatsheet: {} },
+      { id: 'add-note', label: '노트 추가', sequences: [{ keys: ['mod', 'Enter'] }], cheatsheet: {} },
+    ],
+  },
+  {
+    id: 'layout',
+    title: '레이아웃',
+    cheatsheetColumn: 'right',
+    shortcuts: [
+      {
+        id: 'focus-mode',
+        label: '집중 모드 전환',
+        sequences: [{ keys: ['mod', 'shift', 'M'] }],
+        cheatsheet: {},
+      },
+      { id: 'page-zoom-in', label: '페이지 확대', sequences: [{ keys: ['mod', '+'] }], cheatsheet: {} },
+      { id: 'page-zoom-out', label: '페이지 축소', sequences: [{ keys: ['mod', '-'] }], cheatsheet: {} },
+      { id: 'page-zoom-reset', label: '페이지 배율 100%', sequences: [{ keys: ['mod', '0'] }], cheatsheet: {} },
+    ],
+  },
+];

--- a/packages/ui/src/components/Modal.svelte
+++ b/packages/ui/src/components/Modal.svelte
@@ -16,6 +16,7 @@
     children: Snippet;
     style?: SystemStyleObject;
     onclose?: () => void;
+    ontransitionend?: () => void;
     overlayPadding?: number;
     focusTrapOptions?: FocusTrapOptions;
     showBackdrop?: boolean;
@@ -27,6 +28,7 @@
     children,
     style,
     onclose,
+    ontransitionend,
     loading = false,
     overlayPadding = 20,
     focusTrapOptions = {},
@@ -99,6 +101,7 @@
         },
       )}
       onclick={closable ? close : undefined}
+      onoutroend={ontransitionend}
       role="none"
       in:fade|global={{ duration: 400, easing: cubicOut }}
       out:fade|global={{ duration: 280, easing: cubicOut }}


### PR DESCRIPTION
## 변경 사항

- 설정과 단축키 모달에 중복되어 있던 목록을 중앙 카탈로그로 통합했습니다.
- 설정에서는 전체 단축키를, 작은 모달에서는 주요 단축키만 cheatsheet로 보여줍니다.
- 모달에 `더 보기…`를 추가해 설정의 단축키 탭으로 이동할 수 있게 했습니다.
- 툴바와 카탈로그에서의 기능 명칭을 `서식 지우기`, `문단 내 줄바꿈`, `전체 선택`, `찾기 및 바꾸기`로 통일했습니다.

## 카탈로그

다음 항목을 추가하거나 보완했습니다.

- 서식 지우기
- 서식 없이 붙여넣기
- Windows `Ctrl+Y` 다시 실행
- 노트 추가
- 페이지 확대, 축소, 배율 100%
- 문장 경계 이동 및 선택
- 이미지/파일 삽입

다음 항목은 카탈로그에서 제거했습니다.

- 슬래시 메뉴
- 긴 대시, 말줄임표, 큰따옴표, 작은따옴표 텍스트 대치 예시