### PR TITLE
zero-target publication 교착 디버그

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Editor.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Editor.kt
@@ -117,6 +117,9 @@ internal constructor(
   val publishedRevision: Long?
     get() = published?.snapshot?.version
 
+  internal var preparingPage: Int? by mutableStateOf(null)
+    private set
+
   internal var inputRecorder: EditorInputRecorder? = null
 
   // Selection-handle drags pause per-tick IME notifications: each one ships the
@@ -675,6 +678,7 @@ internal constructor(
       mutex.withPriorityLock(escalationMillis = 0) {
         if (visualHost?.token !== token) return@withPriorityLock
         visualHost = null
+        preparingPage = null
         refreshRetainedFrames()
         publicationWaiters.exchange(persistentListOf()).forEach { it.completion.complete(NoHost) }
       }
@@ -982,6 +986,7 @@ internal constructor(
   private fun publishIfReady() {
     val host = visualHost
     if (host == null) {
+      preparingPage = null
       refreshRetainedFrames()
       return
     }
@@ -996,7 +1001,19 @@ internal constructor(
           available = page.available,
         )
       }
-    val publishedRevision = published?.snapshot?.version ?: 0L
+    val currentPublishedRevision = published?.snapshot?.version
+    if (preparingPage == null) {
+      preparingPage =
+        Publication.preparingPage(
+          hasVisualHost = true,
+          hasPublishedFrames = published?.frames?.isNotEmpty() == true,
+          appliedRevision = appliedState.version,
+          publishedRevision = currentPublishedRevision,
+          appliedPageCount = appliedState.pageSizes.size,
+          targetCount = host.pages.size,
+        )
+    }
+    val publishedRevision = currentPublishedRevision ?: 0L
     if (
       !Publication.canPublish(
         hasVisualHost = true,
@@ -1015,6 +1032,7 @@ internal constructor(
       host.pages.mapNotNull { (page, record) -> record.frame?.let { page to it } }.toMap()
     val bundle = PublishedBundle(snapshot = appliedState, frames = frames)
     published = bundle
+    preparingPage = null
     host.pages.values.forEach {
       it.requiredRevision = null
       it.failedRevision = null
@@ -1213,6 +1231,7 @@ internal constructor(
         waiters = publicationWaiters.exchange(persistentListOf())
         edits = queuedLocalEdits.exchange(persistentListOf())
         visualHost = null
+        preparingPage = null
         retainedFrameBitmaps.store(persistentMapOf())
       }
       receipts.forEach { it.completeExceptionally(error) }
@@ -1375,6 +1394,7 @@ internal constructor(
         receipts = requestReceipts.exchange(persistentMapOf()).values
         waiters = publicationWaiters.exchange(persistentListOf())
         edits = queuedLocalEdits.exchange(persistentListOf())
+        preparingPage = null
       }
       receipts.forEach { it.completeExceptionally(error) }
       waiters.forEach { it.completion.completeExceptionally(error) }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Publication.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Publication.kt
@@ -47,6 +47,27 @@ internal object Publication {
       proof.surfaceKey == target.key &&
       (requiredRevision == null || proof.editorRevision >= requiredRevision)
 
+  fun preparingPage(
+    hasVisualHost: Boolean,
+    hasPublishedFrames: Boolean,
+    appliedRevision: Long,
+    publishedRevision: Long?,
+    appliedPageCount: Int,
+    targetCount: Int,
+  ): Int? =
+    if (
+      hasVisualHost &&
+        hasPublishedFrames &&
+        publishedRevision != null &&
+        appliedRevision > publishedRevision &&
+        appliedPageCount > 0 &&
+        targetCount == 0
+    ) {
+      0
+    } else {
+      null
+    }
+
   fun canPublish(
     hasVisualHost: Boolean,
     hasPublishedFrames: Boolean,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/surface/EditorPageSurface.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/surface/EditorPageSurface.kt
@@ -119,7 +119,8 @@ internal fun EditorPageSurface(
   val display = resolveFrameDisplay(publishedFrame, desiredPixelSize)
   val frame = display.frame
   val committedPixelSize = display.pixelSize
-  var renderActive by remember(editor, page) { mutableStateOf(false) }
+  var gateActive by remember(editor, page) { mutableStateOf(false) }
+  val renderActive = gateActive || editor.preparingPage == page
 
   val displayedWidthPxInt =
     round(widthDouble * density.density.toDouble() * displayZoom.toDouble())
@@ -203,7 +204,7 @@ internal fun EditorPageSurface(
       modifier
         .width(displayedWidthDp)
         .height(displayedHeightDp)
-        .editorPageRenderGate { renderActive = it }
+        .editorPageRenderGate { gateActive = it }
         .then(chromeModifier)
         .then(debugOverlayModifier)
   ) {

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorPublicationHostTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorPublicationHostTest.kt
@@ -321,6 +321,79 @@ class EditorPublicationHostTest {
     }
 
   @Test
+  fun pageShrinkPreparesPageZeroWhenItRemovesEveryTarget() =
+    runTest(dispatcher) {
+      var pageSizes = listOf(Size(width = 100f, height = 100f), Size(width = 100f, height = 100f))
+      val fake =
+        FakeFfiEditor(
+          onTick = { listOf(EditorEvent.RenderInvalidated) },
+          pageSizesProvider = { pageSizes },
+        )
+      val editor = Editor(fake, this, dispatcher)
+      editor.activateVisualHost(Any())
+      val stale = editor.attachSurface(1, 10L, 100.0, 100.0, 1.0, wakeDelivery = {})
+      advanceUntilIdle()
+      editor.deliverFrame(stale, editorRevision = 0L, frameKey = 1L)
+      advanceUntilIdle()
+      assertEquals(0L, editor.publishedRevision)
+
+      pageSizes = listOf(Size(width = 200f, height = 300f))
+      val update = requireNotNull(editor.update { enqueue(message) })
+      advanceUntilIdle()
+
+      assertEquals(update.revision, editor.appliedRevision)
+      assertEquals(0L, editor.publishedRevision)
+      assertEquals(0, editor.preparingPage)
+
+      var replacementFrameKey: FrameKey? = null
+      val replacement =
+        editor.attachSurface(0, 11L, 100.0, 100.0, 1.0) { frameKey ->
+          replacementFrameKey = frameKey
+        }
+      advanceUntilIdle()
+      assertEquals(FakeFfiEditor.SurfaceAttachCall(0, 200.0, 300.0, 1.0), fake.attachCalls.last())
+      assertEquals(0, editor.preparingPage)
+      editor.deliverFrame(
+        replacement,
+        editorRevision = update.revision,
+        frameKey = requireNotNull(replacementFrameKey).value,
+      )
+      advanceUntilIdle()
+
+      assertEquals(update.revision, editor.publishedRevision)
+      assertNull(editor.preparingPage)
+    }
+
+  @Test
+  fun terminalFailureCancelsPreparationWithoutDroppingThePublishedBundle() =
+    runTest(dispatcher) {
+      var pageSizes = listOf(Size(width = 100f, height = 100f), Size(width = 100f, height = 100f))
+      val fake =
+        FakeFfiEditor(
+          onTick = { listOf(EditorEvent.RenderInvalidated) },
+          pageSizesProvider = { pageSizes },
+        )
+      val editor = Editor(fake, this, dispatcher)
+      editor.activateVisualHost(Any())
+      val stale = editor.attachSurface(1, 10L, 100.0, 100.0, 1.0, wakeDelivery = {})
+      advanceUntilIdle()
+      editor.deliverFrame(stale, editorRevision = 0L, frameKey = 1L)
+      advanceUntilIdle()
+      val publishedBeforeFailure = requireNotNull(editor.publishedBundle)
+
+      pageSizes = listOf(Size(width = 200f, height = 300f))
+      requireNotNull(editor.update { enqueue(message) })
+      advanceUntilIdle()
+      assertEquals(0, editor.preparingPage)
+
+      editor.fail(IllegalStateException("test failure"))
+      advanceUntilIdle()
+
+      assertNull(editor.preparingPage)
+      assertSame(publishedBeforeFailure, editor.publishedBundle)
+    }
+
+  @Test
   fun stalePublishedSizeCallbackDoesNotReplaceLatestAppliedTarget() =
     runTest(dispatcher) {
       var pageHeight = 100f

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/FakeFfiEditor.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/FakeFfiEditor.kt
@@ -106,6 +106,13 @@ internal class FakeFfiEditor(
 ) : co.typie.editor.ffi.Editor {
   data class EnqueuedRequest(val id: RequestId, val messages: List<Message>)
 
+  data class SurfaceAttachCall(
+    val page: Int,
+    val width: Double,
+    val height: Double,
+    val scaleFactor: Double,
+  )
+
   data class SurfaceResizeCall(
     val page: Int,
     val width: Double,
@@ -140,6 +147,7 @@ internal class FakeFfiEditor(
   var tickCount: Int = 0
   var renderCount: Int = 0
   var lastRenderedPage: Int? = null
+  val attachCalls = mutableListOf<SurfaceAttachCall>()
   val resizeCalls = mutableListOf<SurfaceResizeCall>()
   val surfaceEvents = mutableListOf<String>()
   var trackedRangesCallCount: Int = 0
@@ -316,6 +324,7 @@ internal class FakeFfiEditor(
     scaleFactor: Double,
   ) {
     surfaceEvents += "attach:$page:$handle"
+    attachCalls += SurfaceAttachCall(page, width, height, scaleFactor)
     attached += page
   }
 

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/PublicationTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/PublicationTest.kt
@@ -2,6 +2,7 @@ package co.typie.editor
 
 import co.typie.editor.ffi.FrameKey
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -70,6 +71,71 @@ class PublicationTest {
         appliedRevision = 2,
         publishedRevision = 1,
         pages = emptyList(),
+      )
+    )
+  }
+
+  @Test
+  fun pageZeroIsPreparedOnlyWhenANewerAppliedLayoutStrandsAFramedPublication() {
+    assertEquals(
+      0,
+      Publication.preparingPage(
+        hasVisualHost = true,
+        hasPublishedFrames = true,
+        appliedRevision = 10,
+        publishedRevision = 9,
+        appliedPageCount = 1,
+        targetCount = 0,
+      ),
+    )
+    assertNull(
+      Publication.preparingPage(
+        hasVisualHost = true,
+        hasPublishedFrames = false,
+        appliedRevision = 10,
+        publishedRevision = 9,
+        appliedPageCount = 1,
+        targetCount = 0,
+      )
+    )
+    assertNull(
+      Publication.preparingPage(
+        hasVisualHost = true,
+        hasPublishedFrames = true,
+        appliedRevision = 9,
+        publishedRevision = 9,
+        appliedPageCount = 1,
+        targetCount = 0,
+      )
+    )
+    assertNull(
+      Publication.preparingPage(
+        hasVisualHost = true,
+        hasPublishedFrames = true,
+        appliedRevision = 10,
+        publishedRevision = 9,
+        appliedPageCount = 0,
+        targetCount = 0,
+      )
+    )
+    assertNull(
+      Publication.preparingPage(
+        hasVisualHost = true,
+        hasPublishedFrames = true,
+        appliedRevision = 10,
+        publishedRevision = 9,
+        appliedPageCount = 1,
+        targetCount = 1,
+      )
+    )
+    assertNull(
+      Publication.preparingPage(
+        hasVisualHost = false,
+        hasPublishedFrames = true,
+        appliedRevision = 10,
+        publishedRevision = 9,
+        appliedPageCount = 1,
+        targetCount = 0,
       )
     )
   }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/surface/EditorPageSurfaceLifecycleDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/surface/EditorPageSurfaceLifecycleDesktopTest.kt
@@ -1,0 +1,118 @@
+package co.typie.editor.surface
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import co.typie.editor.Editor
+import co.typie.editor.EditorZoomController
+import co.typie.editor.FakeFfiEditor
+import co.typie.editor.LocalEditorZoomController
+import co.typie.editor.ffi.EditorEvent
+import co.typie.editor.ffi.Size
+import co.typie.editor.runtime.EditorRuntime
+import co.typie.editor.runtime.LocalEditorRuntime
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+
+@OptIn(ExperimentalTestApi::class)
+class EditorPageSurfaceLifecycleDesktopTest {
+  @Test
+  fun offscreenPageAttachesWhileTheHostIsPreparingItsReplacementSurface() = runComposeUiTest {
+    configureRenderBufferLibrary()
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+    var pageSizes = listOf(Size(width = 100f, height = 100f), Size(width = 100f, height = 100f))
+    val fake =
+      FakeFfiEditor(
+        onTick = { listOf(EditorEvent.RenderInvalidated) },
+        pageSizesProvider = { pageSizes },
+      )
+    val editor = Editor(fake, scope, Dispatchers.Unconfined)
+    val runtime = EditorRuntime(scope).apply { attach(editor) }
+    val host = Any()
+
+    try {
+      fake.applySnapshot(editor)
+      editor.activateVisualHost(host)
+      var frameKey = 0L
+      val stale = editor.attachSurface(1, 10L, 100.0, 100.0, 1.0) { frameKey = it.value }
+      editor.deliverFrame(
+        session = stale,
+        bitmap = ImageBitmap(width = 100, height = 100),
+        pixelSize = IntSize(width = 100, height = 100),
+        editorRevision = editor.appliedRevision,
+        frameKey = frameKey,
+      )
+      stale.detach()
+
+      pageSizes = listOf(Size(width = 200f, height = 300f))
+      fake.applySnapshot(editor)
+      assertEquals(0, editor.preparingPage)
+      fake.attachCalls.clear()
+
+      setContent {
+        CompositionLocalProvider(
+          LocalDensity provides Density(1f),
+          LocalEditorRuntime provides runtime,
+          LocalEditorZoomController provides EditorZoomController(),
+        ) {
+          Box(Modifier.size(100.dp)) {
+            EditorPageSurface(
+              page = 0,
+              width = 200f,
+              height = 300f,
+              publishedVersion = editor.publishedRevision ?: 0L,
+              publishedFrame = editor.publishedBundle?.frames?.get(0),
+              showChrome = false,
+              modifier = Modifier.offset(y = 5_000.dp),
+            )
+          }
+        }
+      }
+
+      waitUntil { fake.attachCalls.any { it.page == 0 } }
+
+      assertEquals(0, editor.preparingPage)
+      assertEquals(
+        FakeFfiEditor.SurfaceAttachCall(page = 0, width = 200.0, height = 300.0, scaleFactor = 1.0),
+        fake.attachCalls.last(),
+      )
+    } finally {
+      runtime.clear()
+      waitForIdle()
+      scope.cancel()
+    }
+  }
+}
+
+private fun configureRenderBufferLibrary() {
+  if (System.getProperty("jna.library.path") != null) return
+
+  val repository =
+    generateSequence(File(System.getProperty("user.dir"))) { it.parentFile }
+      .firstOrNull { File(it, "Cargo.toml").isFile } ?: error("Typie repository root not found")
+  val host =
+    when (System.getProperty("os.arch")) {
+      "aarch64" -> "aarch64-apple-darwin"
+      "x86_64" -> "x86_64-apple-darwin"
+      else -> error("Unsupported desktop test architecture: ${System.getProperty("os.arch")}")
+    }
+  val directory = File(repository, "target/$host/release-uniffi")
+  check(File(directory, "libeditor_ffi.dylib").isFile) {
+    "Desktop editor FFI is not built; run `just -f crates/editor-ffi/justfile desktop`"
+  }
+  System.setProperty("jna.library.path", directory.absolutePath)
+}

--- a/apps/website/src/lib/editor-ffi/components/Page.svelte
+++ b/apps/website/src/lib/editor-ffi/components/Page.svelte
@@ -95,7 +95,7 @@
       {@attach (wrapper) => {
         if (!editor) return;
 
-        let manager: ReturnType<typeof createSurfaceDriver<HTMLCanvasElement>>;
+        let driver: ReturnType<typeof createSurfaceDriver<HTMLCanvasElement>>;
         let isVisible = false;
         let syncSeeded = false;
 
@@ -110,7 +110,7 @@
             canvas.style.height = `${cssBackingHeight}px`;
           },
           attach: (canvas) => {
-            const backend = editor.attachSurface(page, canvas, width, backingHeight, () => manager.replace());
+            const backend = editor.attachSurface(page, canvas, width, backingHeight, () => driver.replace());
             probeAttach(editor, page, canvas);
             if (backend === 'cpu') return 'cpu';
             return backend === 'cpu-oversized' ? 'cpu-oversized' : 'none';
@@ -147,19 +147,19 @@
           replacementFailed: () => editor.surfaceReplacementFailed(page),
         };
 
-        manager = createSurfaceDriver(effects);
+        driver = createSurfaceDriver(effects);
         const stopPublishedSync = $effect.root(() => {
           $effect(() => {
-            manager.syncPublished(editor.publishedSurfaceCanvas(page));
+            driver.syncPublished(editor.publishedSurfaceCanvas(page));
           });
         });
 
         // A detached target has no editor-owned requirement. Visibility recovery
         // only recreates the target; attachSurface establishes its fresh requirement.
         const onVisible = () => {
-          if (document.visibilityState === 'visible') manager.resume();
+          if (document.visibilityState === 'visible') driver.resume();
         };
-        const onPageShow = () => manager.resume();
+        const onPageShow = () => driver.resume();
         document.addEventListener('visibilitychange', onVisible);
         window.addEventListener('pageshow', onPageShow);
 
@@ -171,9 +171,39 @@
           let observers: IntersectionObserver[] = [];
           let seeded = 0;
           const state = { inAcquire: false, inRelease: false };
+          const measureVisibility = () => {
+            const rect = wrapper.getBoundingClientRect();
+            const rootRect = root === null ? { top: 0, bottom: window.innerHeight } : root.getBoundingClientRect();
+            const viewportHeight = rootRect.bottom - rootRect.top;
+            state.inAcquire = rect.bottom > rootRect.top - viewportHeight && rect.top < rootRect.bottom + viewportHeight;
+            state.inRelease = rect.bottom > rootRect.top - 1.5 * viewportHeight && rect.top < rootRect.bottom + 1.5 * viewportHeight;
+            return { rect, rootRect };
+          };
+          const updateDriverActive = () => {
+            if (editor.terminal) return;
+            const withinActiveRange = driver.hasSurface() ? state.inRelease : state.inAcquire;
+            driver.setActive(editor.preparingPage === page || withinActiveRange);
+          };
+          const stopHostSync = $effect.root(() => {
+            let wasPreparing = false;
+            $effect(() => {
+              if (editor.terminal) return;
+              const preparing = editor.preparingPage === page;
+              if (preparing === wasPreparing) return;
+              wasPreparing = preparing;
+              if (!preparing) {
+                // Publication and preparation settle in the same Host turn. Promote
+                // the exact published canvas before normal visibility may park it.
+                driver.syncPublished(editor.publishedSurfaceCanvas(page));
+                measureVisibility();
+              }
+              updateDriverActive();
+            });
+          });
 
           let buildEpoch = 0;
           const build = () => {
+            if (disposed) return;
             const epoch = ++buildEpoch;
             for (const observer of observers) observer.disconnect();
             observers = [];
@@ -183,14 +213,14 @@
               let seededSelf = false;
               const observer = new IntersectionObserver(
                 (entries) => {
-                  if (epoch !== buildEpoch) return;
+                  if (disposed || epoch !== buildEpoch) return;
                   apply(entries.at(-1)?.isIntersecting ?? false);
                   if (seed && !seededSelf) {
                     seededSelf = true;
                     seeded += 1;
                   }
                   if (seeded >= 3 && !disposed) {
-                    manager.reconcile({ ...state });
+                    updateDriverActive();
                   }
                 },
                 { root, rootMargin: margin, threshold: 0 },
@@ -219,16 +249,12 @@
           // page born under the caret presents in its first frame.
           if (!syncSeeded) {
             syncSeeded = true;
-            const rect = wrapper.getBoundingClientRect();
-            const rootRect = root === null ? { top: 0, bottom: window.innerHeight } : root.getBoundingClientRect();
-            const viewportHeight = rootRect.bottom - rootRect.top;
-            const inAcquire = rect.bottom > rootRect.top - viewportHeight && rect.top < rootRect.bottom + viewportHeight;
-            if (inAcquire) {
-              state.inAcquire = true;
+            const { rect, rootRect } = measureVisibility();
+            if (state.inAcquire) {
               state.inRelease = true;
               isVisible = rect.bottom > rootRect.top && rect.top < rootRect.bottom;
               overlaysVisible = isVisible;
-              manager.reconcile({ ...state });
+              updateDriverActive();
             }
           }
           let resize: ResizeObserver | null = null;
@@ -244,6 +270,7 @@
 
           return () => {
             disposed = true;
+            stopHostSync();
             resize?.disconnect();
             if (root === null) {
               window.removeEventListener('resize', rebuild);
@@ -254,22 +281,27 @@
         });
 
         $effect.pre(() => {
+          if (editor.terminal) {
+            driver.syncPublished(editor.publishedSurfaceCanvas(page));
+            driver.freeze();
+            return;
+          }
           void editor.surfaceScaleFactor;
           void width;
           void backingHeight;
-          if (!manager.isAttached()) {
-            manager.replace();
+          if (!driver.isAttached()) {
+            driver.replace();
             return;
           }
-          if (editor.surfaceConfigMatches(page, width, backingHeight)) manager.restyle();
-          else manager.replace();
+          if (editor.surfaceConfigMatches(page, width, backingHeight)) driver.restyle();
+          else driver.replace();
         });
 
         return () => {
           document.removeEventListener('visibilitychange', onVisible);
           window.removeEventListener('pageshow', onPageShow);
           stopPublishedSync();
-          manager.destroy();
+          driver.destroy();
         };
       }}
     ></div>

--- a/apps/website/src/lib/editor-ffi/editor-host-failure.test.ts
+++ b/apps/website/src/lib/editor-ffi/editor-host-failure.test.ts
@@ -1,7 +1,8 @@
-import { tick } from 'svelte';
+import { mount, tick, unmount } from 'svelte';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Editor } from './editor.svelte';
 import { createTrackedEffect } from './editor-effect-harness.svelte';
+import PageLifecycleTestHost from './page-lifecycle-test-host.svelte';
 import { snapshot } from './registry';
 import type { Size, TickResult, TrackedRange } from '@typie/editor-ffi/browser';
 
@@ -30,6 +31,24 @@ vi.mock('./gesture.svelte', () => ({
 
 vi.mock('./fonts', () => ({
   fontDataMissingHandler: vi.fn(),
+}));
+
+vi.mock('./components/ExternalElement.svelte', () => ({
+  default: () => {
+    // Surface lifecycle coverage does not render external-element content.
+  },
+}));
+
+vi.mock('./components/LinkOverlay.svelte', () => ({
+  default: () => {
+    // Surface lifecycle coverage does not render link content.
+  },
+}));
+
+vi.mock('./components/TableOverlay.svelte', () => ({
+  default: () => {
+    // Surface lifecycle coverage does not render table content.
+  },
 }));
 
 type FakeCore = ReturnType<typeof createCore>;
@@ -96,6 +115,44 @@ async function expectPending(promise: Promise<unknown> | undefined): Promise<voi
   );
   await Promise.resolve();
   expect(settled).toBe(false);
+}
+
+class OffscreenIntersectionObserver {
+  private readonly callback: IntersectionObserverCallback;
+
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback;
+  }
+
+  observe(target: Element): void {
+    this.callback([{ isIntersecting: false, target } as IntersectionObserverEntry], this as never);
+  }
+
+  unobserve(): void {
+    // Each test observer delivers its only entry synchronously.
+  }
+
+  disconnect(): void {
+    // Each test observer delivers its only entry synchronously.
+  }
+
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+}
+
+class PassiveResizeObserver {
+  observe(): void {
+    // Root geometry is fixed for this lifecycle test.
+  }
+
+  unobserve(): void {
+    // Root geometry is fixed for this lifecycle test.
+  }
+
+  disconnect(): void {
+    // Root geometry is fixed for this lifecycle test.
+  }
 }
 
 describe('Editor guarded core invocation', () => {
@@ -860,6 +917,138 @@ describe('Editor guarded core invocation', () => {
 
     releaseHost();
     editor.destroy();
+  });
+
+  it('requests a preparing surface when page shrink removes every active target', async () => {
+    const core = createCore();
+    core.page_sizes.mockReturnValue([
+      { width: 100, height: 100 },
+      { width: 100, height: 100 },
+    ]);
+    core.page_backing_sizes.mockReturnValue([
+      { width: 100, height: 100 },
+      { width: 100, height: 100 },
+    ]);
+    const { editor } = await createEditor(core);
+    const releaseHost = editor.activateVisualHost();
+    editor.attachSurface(1, document.createElement('canvas'), 100, 100);
+    expect(editor.publishedRevision).toBe(1);
+
+    core.page_sizes.mockReturnValue([{ width: 200, height: 300 }]);
+    core.page_backing_sizes.mockReturnValue([{ width: 200, height: 400 }]);
+    core.tick.mockReturnValue({
+      revision: { value: 2 },
+      events: [{ type: 'state_changed', fields: ['page_sizes'] }, { type: 'render_invalidated' }],
+      request_outcomes: [],
+    });
+
+    editor.enqueue({ type: 'history', op: { type: 'undo' } });
+    frames.at(-1)?.(0);
+
+    expect(editor.appliedRevision).toBe(2);
+    expect(editor.publishedRevision).toBe(1);
+    expect(editor.preparingPage).toBe(0);
+
+    editor.attachSurface(0, document.createElement('canvas'), 200, 400);
+
+    expect(editor.publishedRevision).toBe(2);
+    expect(editor.preparingPage).toBeUndefined();
+
+    releaseHost();
+    editor.destroy();
+  });
+
+  it('keeps page preparation latched until proof and cancels it on terminal failure without dropping the published frame', async () => {
+    const core = createCore();
+    core.page_sizes.mockReturnValue([{ width: 100, height: 100 }]);
+    core.page_backing_sizes.mockReturnValue([{ width: 100, height: 100 }]);
+    const { editor } = await createEditor(core);
+    const releaseHost = editor.activateVisualHost();
+    const publishedCanvas = document.createElement('canvas');
+    editor.attachSurface(0, publishedCanvas, 100, 100);
+
+    editor.detachSurface(0);
+    core.page_sizes.mockReturnValue([{ width: 200, height: 300 }]);
+    core.page_backing_sizes.mockReturnValue([{ width: 200, height: 400 }]);
+    core.tick.mockReturnValue({
+      revision: { value: 2 },
+      events: [{ type: 'state_changed', fields: ['page_sizes'] }, { type: 'render_invalidated' }],
+      request_outcomes: [],
+    });
+    editor.enqueue({ type: 'history', op: { type: 'undo' } });
+    frames.at(-1)?.(0);
+    expect(editor.preparingPage).toBe(0);
+
+    core.render_surface.mockReturnValueOnce(undefined);
+    const preparingCanvas = document.createElement('canvas');
+    editor.attachSurface(0, preparingCanvas, 100, 100);
+    expect(core.attach_surface).toHaveBeenLastCalledWith(0, preparingCanvas, 200, 400, 1);
+    expect(editor.preparingPage).toBe(0);
+    expect(editor.publishedSurfaceCanvas(0)).toBe(publishedCanvas);
+
+    editor.surfaceReplacementFailed(0);
+    expect(editor.preparingPage).toBeUndefined();
+    expect(editor.publishedSurfaceCanvas(0)).toBe(publishedCanvas);
+
+    releaseHost();
+    editor.destroy();
+  });
+
+  it('activates an offscreen page while the Host is preparing its replacement surface', async () => {
+    const core = createCore();
+    core.page_sizes.mockReturnValue([{ width: 100, height: 100 }]);
+    core.page_backing_sizes.mockReturnValue([{ width: 100, height: 100 }]);
+    const { editor } = await createEditor(core);
+    const releaseHost = editor.activateVisualHost();
+    const initialCanvas = document.createElement('canvas');
+    editor.attachSurface(0, initialCanvas, 100, 100);
+    editor.detachSurface(0);
+    core.attach_surface.mockClear();
+    core.detach_surface.mockClear();
+    core.render_surface.mockReset().mockReturnValue(undefined);
+
+    vi.stubGlobal('IntersectionObserver', OffscreenIntersectionObserver);
+    vi.stubGlobal('ResizeObserver', PassiveResizeObserver);
+    const rectSpy = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (this: HTMLElement) {
+      return this.dataset.pageLifecycleScrollRoot === undefined ? new DOMRect(0, 300, 200, 100) : new DOMRect(0, 0, 100, 100);
+    });
+    const target = document.createElement('div');
+    document.body.append(target);
+    const component = mount(PageLifecycleTestHost, { target, props: { editor } });
+
+    try {
+      await tick();
+      expect(core.attach_surface).not.toHaveBeenCalled();
+
+      core.page_sizes.mockReturnValue([{ width: 200, height: 300 }]);
+      core.page_backing_sizes.mockReturnValue([{ width: 200, height: 400 }]);
+      core.tick.mockReturnValue({
+        revision: { value: 2 },
+        events: [{ type: 'state_changed', fields: ['page_sizes'] }, { type: 'render_invalidated' }],
+        request_outcomes: [],
+      });
+      editor.enqueue({ type: 'history', op: { type: 'undo' } });
+      frames.at(-1)?.(0);
+      await tick();
+
+      expect(editor.preparingPage).toBe(0);
+      expect(core.attach_surface).toHaveBeenCalledExactlyOnceWith(0, expect.any(HTMLCanvasElement), 200, 400, 1);
+
+      core.render_surface.mockReturnValue({ value: 2 });
+      editor.invalidateSurface(0);
+      await tick();
+
+      expect(editor.publishedRevision).toBe(2);
+      expect(editor.preparingPage).toBeUndefined();
+      expect(core.detach_surface).toHaveBeenCalledExactlyOnceWith(0);
+    } finally {
+      await unmount(component);
+      target.remove();
+      rectSpy.mockRestore();
+      releaseHost();
+      editor.destroy();
+      vi.unstubAllGlobals();
+    }
   });
 
   it('materializes table and link geometry only for active page targets', async () => {

--- a/apps/website/src/lib/editor-ffi/editor-publication.test.ts
+++ b/apps/website/src/lib/editor-ffi/editor-publication.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { canPublish, proofSatisfies } from './publication';
+import { canPublish, preparingPage, proofSatisfies } from './publication';
 import type { PublicationTarget } from './publication';
 
 describe('editor publication', () => {
@@ -59,6 +59,15 @@ describe('editor publication', () => {
   it('keeps a prior framed publication when the active host temporarily has zero targets', () => {
     expect(canPublish(10, 9, { targets: new Map() }, true, true)).toBe(false);
     expect(canPublish(10, undefined, { targets: new Map() }, true, false)).toBe(true);
+  });
+
+  it('requests page zero only when a newer applied layout strands a framed publication without targets', () => {
+    expect(preparingPage(true, true, 10, 9, 1, 0)).toBe(0);
+    expect(preparingPage(true, false, 10, 9, 1, 0)).toBeUndefined();
+    expect(preparingPage(true, true, 9, 9, 1, 0)).toBeUndefined();
+    expect(preparingPage(true, true, 10, 9, 0, 0)).toBeUndefined();
+    expect(preparingPage(true, true, 10, 9, 1, 1)).toBeUndefined();
+    expect(preparingPage(false, true, 10, 9, 1, 0)).toBeUndefined();
   });
 
   it('republishes a replacement target at the same revision but not a no-change reevaluation', () => {

--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -12,7 +12,7 @@ import { TouchGestureController } from './gesture.svelte';
 import { readClipboardRich, writeClipboardPayload } from './handlers/clipboard';
 import { encodeLengthPrefixedBlobs } from './length-prefix';
 import { isMutatingMessage } from './message-gate';
-import { canPublish, proofSatisfies } from './publication';
+import { canPublish, preparingPage, proofSatisfies } from './publication';
 import { fanOutResourceUpdate, register, snapshot, unregister } from './registry';
 import { probeEvent, probeRendered } from './surface-probe';
 import { zoomDiffers } from './zoom';
@@ -318,6 +318,7 @@ export class Editor {
   #admission: EditorRequest | undefined;
   #surfaceKey = 0;
   #visualHost: VisualHost | undefined;
+  #preparingPage = $state<number | undefined>(undefined);
   // eslint-disable-next-line svelte/prefer-svelte-reactivity
   #receipts = new Map<number, UpdateReceipt>();
   // eslint-disable-next-line svelte/prefer-svelte-reactivity
@@ -717,6 +718,15 @@ export class Editor {
           }
         }
       }
+      const publishedRevision = this.published?.snapshot.revision;
+      this.#preparingPage ??= preparingPage(
+        this.#visualHost !== undefined,
+        (this.published?.frames.size ?? 0) > 0,
+        this.#applied.revision,
+        publishedRevision,
+        this.#applied.pageSizes.length,
+        this.#visualHost?.targets.size ?? 0,
+      );
       if (
         !canPublish(
           this.#applied.revision,
@@ -743,6 +753,7 @@ export class Editor {
 
       const bundle: PublishedBundle = { snapshot: this.#applied, frames };
       this.published = bundle;
+      this.#preparingPage = undefined;
       this.#pullToolbarStateIfReady();
 
       for (const target of this.#visualHost?.targets.values() ?? []) {
@@ -840,6 +851,7 @@ export class Editor {
     const reason = error ?? new Error('Editor operation failed');
     this.#failure = reason;
     this.#failed = true;
+    this.#preparingPage = undefined;
     this.#stopRuntime();
     unregister(this);
     for (const receipt of this.#receipts.values()) {
@@ -1459,6 +1471,10 @@ export class Editor {
     return this.published?.snapshot.revision;
   }
 
+  get preparingPage(): number | undefined {
+    return this.#preparingPage;
+  }
+
   awaitPublishedRevision(revision: number, options?: { requireFrame?: boolean }): Promise<EditorPublicationResult> {
     return this.#awaitPublished(revision, undefined, options?.requireFrame);
   }
@@ -1722,6 +1738,7 @@ export class Editor {
           }
           this.#removeAppliedPageData(this.#visualHost.targets.keys());
           this.#visualHost = undefined;
+          this.#preparingPage = undefined;
           for (const waiter of this.#publicationWaiters) {
             if (waiter.signal && waiter.onAbort) waiter.signal.removeEventListener('abort', waiter.onAbort);
             waiter.resolve({ type: 'no_host' });
@@ -2421,6 +2438,7 @@ export class Editor {
     }
     this.#publicationWaiters.clear();
     this.#visualHost = undefined;
+    this.#preparingPage = undefined;
     this.#listeners.clear();
     this.#contextMenuContributors.clear();
 

--- a/apps/website/src/lib/editor-ffi/page-lifecycle-test-host.svelte
+++ b/apps/website/src/lib/editor-ffi/page-lifecycle-test-host.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import Page from './components/Page.svelte';
+  import { setupEditorContext } from './editor.svelte';
+  import type { Editor } from './editor.svelte';
+
+  type Props = {
+    editor: Editor;
+  };
+
+  let { editor }: Props = $props();
+
+  const ctx = setupEditorContext();
+  ctx.editor = editor;
+</script>
+
+<div
+  {@attach (root) => {
+    editor.scrollRootEl = root;
+
+    return () => {
+      if (editor.scrollRootEl === root) editor.scrollRootEl = undefined;
+    };
+  }}
+  data-page-lifecycle-scroll-root
+>
+  <Page backingHeight={400} height={300} page={0} width={200} />
+</div>

--- a/apps/website/src/lib/editor-ffi/publication.ts
+++ b/apps/website/src/lib/editor-ffi/publication.ts
@@ -20,6 +20,27 @@ export function proofSatisfies(target: PublicationTarget): boolean {
   return target.proof !== undefined && target.proof.revision >= target.requiredRevision && target.proof.surfaceKey === target.key;
 }
 
+export function preparingPage(
+  hasVisualHost: boolean,
+  hasPublishedFrames: boolean,
+  appliedRevision: number,
+  publishedRevision: number | undefined,
+  appliedPageCount: number,
+  targetCount: number,
+): number | undefined {
+  if (
+    hasVisualHost &&
+    hasPublishedFrames &&
+    publishedRevision !== undefined &&
+    appliedRevision > publishedRevision &&
+    appliedPageCount > 0 &&
+    targetCount === 0
+  ) {
+    return 0;
+  }
+  return undefined;
+}
+
 export function canPublish(
   appliedRevision: number,
   publishedRevision: number | undefined,

--- a/apps/website/src/lib/editor-ffi/surface-driver.test.ts
+++ b/apps/website/src/lib/editor-ffi/surface-driver.test.ts
@@ -60,9 +60,9 @@ function harness(attachResult: AttachResult | AttachResult[] = 'cpu') {
       replacementFailureCount += 1;
     },
   };
-  const manager = createSurfaceDriver(effects);
+  const driver = createSurfaceDriver(effects);
   return {
-    manager,
+    driver,
     canvases,
     isAttached: () => attached,
     recoverCount: () => recoverCount,
@@ -74,72 +74,72 @@ function harness(attachResult: AttachResult | AttachResult[] = 'cpu') {
   };
 }
 
-const inView = { inAcquire: true, inRelease: true };
-const outOfView = { inAcquire: false, inRelease: false };
-
 describe('surface-driver', () => {
   it('does not expose a target canvas before Editor publishes its delivered frame', () => {
     const h = harness();
-    h.manager.reconcile(inView);
+    expect(h.driver.hasSurface()).toBe(false);
 
-    expect(h.manager.debug().target).toBe(h.canvases[0]);
-    expect(h.manager.debug().displayed).toBeUndefined();
+    h.driver.setActive(true);
 
-    h.manager.syncPublished(h.canvases[0]);
-    expect(h.manager.debug().displayed).toBe(h.canvases[0]);
+    expect(h.driver.debug().target).toBe(h.canvases[0]);
+    expect(h.driver.debug().displayed).toBeUndefined();
+    expect(h.driver.hasSurface()).toBe(true);
+
+    h.driver.syncPublished(h.canvases[0]);
+    expect(h.driver.debug().displayed).toBe(h.canvases[0]);
   });
 
   it('ignores stale delivery for a canvas that is not the current target', () => {
     const h = harness();
-    h.manager.reconcile(inView);
+    h.driver.setActive(true);
     const stale = { id: 99, pixels: '', disposed: false, removed: false, listeners: 0 };
 
-    h.manager.syncPublished(stale);
+    h.driver.syncPublished(stale);
 
-    expect(h.manager.debug().displayed).toBeUndefined();
+    expect(h.driver.debug().displayed).toBeUndefined();
   });
 
   it('has no timeout or retry scheduler and retries only on a real resume signal', () => {
     const h = harness('cpu-oversized');
-    h.manager.reconcile(inView);
+    h.driver.setActive(true);
     expect(h.canvases).toHaveLength(1);
-    expect(h.manager.debug().target).toBeUndefined();
+    expect(h.driver.debug().target).toBeUndefined();
     expect(h.isAttached()).toBe(false);
     expect(h.detachCount()).toBe(1);
 
-    h.manager.resume();
+    h.driver.resume();
     expect(h.canvases).toHaveLength(2);
     expect(h.replacementFailureCount()).toBe(1);
   });
 
   it('starts a fresh replacement attempt after the surface is parked', () => {
     const h = harness(['cpu-oversized', 'cpu-oversized']);
-    h.manager.reconcile(inView);
+    h.driver.setActive(true);
 
-    h.manager.reconcile(outOfView);
-    h.manager.reconcile(inView);
+    h.driver.setActive(false);
+    h.driver.setActive(true);
 
     expect(h.replacementFailureCount()).toBe(0);
   });
 
   it('allows another replacement after a target publishes successfully', () => {
     const h = harness(['cpu-oversized', 'cpu', 'cpu-oversized', 'cpu-oversized']);
-    h.manager.reconcile(inView);
+    h.driver.setActive(true);
     expect(h.replacementFailureCount()).toBe(0);
 
-    h.manager.resume();
-    h.manager.syncPublished(h.canvases[1]);
-    h.manager.replace();
+    h.driver.resume();
+    h.driver.syncPublished(h.canvases[1]);
+    h.driver.replace();
     expect(h.replacementFailureCount()).toBe(0);
 
-    h.manager.resume();
+    h.driver.resume();
     expect(h.replacementFailureCount()).toBe(1);
   });
 
   it('forwards recovery for the current target without creating another canvas', () => {
     const h = harness();
-    h.manager.reconcile(inView);
-    h.manager.resume();
+    h.driver.setActive(true);
+    h.driver.resume();
 
     expect(h.canvases).toHaveLength(1);
     expect(h.recoverCount()).toBe(1);
@@ -147,11 +147,11 @@ describe('surface-driver', () => {
 
   it('re-promotes the same canvas after an in-place backing replacement publishes', () => {
     const h = harness();
-    h.manager.reconcile(inView);
-    h.manager.syncPublished(h.canvases[0]);
+    h.driver.setActive(true);
+    h.driver.syncPublished(h.canvases[0]);
     h.canvases[0].removed = true;
 
-    h.manager.syncPublished(h.canvases[0]);
+    h.driver.syncPublished(h.canvases[0]);
 
     expect(h.canvases[0].removed).toBe(false);
     expect(h.promoteCount()).toBe(2);
@@ -159,82 +159,82 @@ describe('surface-driver', () => {
 
   it('keeps the published canvas visible until its replacement is published', () => {
     const h = harness();
-    h.manager.reconcile(inView);
+    h.driver.setActive(true);
     h.canvases[0].pixels = 'published pixels';
-    h.manager.syncPublished(h.canvases[0]);
+    h.driver.syncPublished(h.canvases[0]);
 
-    h.manager.replace();
+    h.driver.replace();
 
     expect(h.canvases).toHaveLength(2);
     expect(h.canvases[0]).toMatchObject({ pixels: 'published pixels', disposed: false, removed: false, listeners: 0 });
-    expect(h.manager.debug()).toMatchObject({ target: h.canvases[1], displayed: h.canvases[0] });
+    expect(h.driver.debug()).toMatchObject({ target: h.canvases[1], displayed: h.canvases[0] });
     expect(h.detachCount()).toBe(0);
 
-    h.manager.syncPublished(h.canvases[1]);
+    h.driver.syncPublished(h.canvases[1]);
     expect(h.canvases[0]).toMatchObject({ disposed: true, removed: true });
-    expect(h.manager.debug().displayed).toBe(h.canvases[1]);
+    expect(h.driver.debug().displayed).toBe(h.canvases[1]);
   });
 
   it('keeps repeated missing-target attempts outside replacement-failure escalation', () => {
     const h = harness(['cpu', 'none', 'none']);
-    h.manager.reconcile(inView);
+    h.driver.setActive(true);
     h.canvases[0].pixels = 'published pixels';
-    h.manager.syncPublished(h.canvases[0]);
+    h.driver.syncPublished(h.canvases[0]);
 
-    h.manager.replace();
-    h.manager.resume();
+    h.driver.replace();
+    h.driver.resume();
 
-    expect(h.manager.debug()).toMatchObject({ target: undefined, displayed: h.canvases[0] });
+    expect(h.driver.debug()).toMatchObject({ target: undefined, displayed: h.canvases[0] });
     expect(h.canvases[0]).toMatchObject({ pixels: 'published pixels', disposed: false, removed: false });
     expect(h.canvases[1]).toMatchObject({ pixels: '', disposed: true, removed: true });
     expect(h.canvases[2]).toMatchObject({ pixels: '', disposed: true, removed: true });
     expect(h.isAttached()).toBe(false);
     expect(h.replacementFailureCount()).toBe(0);
 
-    h.manager.destroy();
+    h.driver.destroy();
     expect(h.detachCount()).toBe(0);
   });
 
   it('promotes a proven replacement before releasing the displayed backing', () => {
     const h = harness();
-    h.manager.reconcile(inView);
-    h.manager.syncPublished(h.canvases[0]);
-    h.manager.replace();
+    h.driver.setActive(true);
+    h.driver.syncPublished(h.canvases[0]);
+    h.driver.replace();
     h.lifecycle.length = 0;
 
-    h.manager.syncPublished(h.canvases[1]);
+    h.driver.syncPublished(h.canvases[1]);
 
     expect(h.lifecycle).toEqual(['promote:1:0', 'release:0', 'remove:0']);
   });
 
   it('converges repeated replacement requests to the latest candidate while retaining only the displayed frame', () => {
     const h = harness();
-    h.manager.reconcile(inView);
-    h.manager.syncPublished(h.canvases[0]);
+    h.driver.setActive(true);
+    h.driver.syncPublished(h.canvases[0]);
 
-    h.manager.replace();
-    h.manager.replace();
+    h.driver.replace();
+    h.driver.replace();
 
     expect(h.maxLiveCanvasCount()).toBe(2);
     expect(h.canvases[1]).toMatchObject({ disposed: true, removed: true });
-    expect(h.manager.debug()).toMatchObject({ target: h.canvases[2], displayed: h.canvases[0] });
+    expect(h.driver.debug()).toMatchObject({ target: h.canvases[2], displayed: h.canvases[0] });
 
-    h.manager.syncPublished(h.canvases[1]);
-    expect(h.manager.debug().displayed).toBe(h.canvases[0]);
+    h.driver.syncPublished(h.canvases[1]);
+    expect(h.driver.debug().displayed).toBe(h.canvases[0]);
 
-    h.manager.syncPublished(h.canvases[2]);
-    expect(h.manager.debug().displayed).toBe(h.canvases[2]);
+    h.driver.syncPublished(h.canvases[2]);
+    expect(h.driver.debug().displayed).toBe(h.canvases[2]);
     expect(h.canvases.filter((canvas) => !canvas.disposed)).toEqual([h.canvases[2]]);
   });
 
   it('keeps the published canvas when a replacement is oversized', () => {
     const h = harness(['cpu', 'cpu-oversized']);
-    h.manager.reconcile(inView);
-    h.manager.syncPublished(h.canvases[0]);
+    h.driver.setActive(true);
+    h.driver.syncPublished(h.canvases[0]);
 
-    h.manager.replace();
+    h.driver.replace();
 
-    expect(h.manager.debug()).toMatchObject({ target: undefined, displayed: h.canvases[0] });
+    expect(h.driver.debug()).toMatchObject({ target: undefined, displayed: h.canvases[0] });
     expect(h.canvases[0]).toMatchObject({ disposed: false, removed: false });
     expect(h.canvases[1]).toMatchObject({ disposed: true, removed: true });
     expect(h.isAttached()).toBe(false);
@@ -242,12 +242,27 @@ describe('surface-driver', () => {
 
   it('releases the target, listeners, and displayed canvas when parked', () => {
     const h = harness();
-    h.manager.reconcile(inView);
-    h.manager.syncPublished(h.canvases[0]);
-    h.manager.reconcile(outOfView);
+    h.driver.setActive(true);
+    h.driver.syncPublished(h.canvases[0]);
+    h.driver.setActive(false);
 
     expect(h.isAttached()).toBe(false);
+    expect(h.driver.hasSurface()).toBe(false);
     expect(h.canvases[0]).toMatchObject({ disposed: true, removed: true, listeners: 0 });
-    expect(h.manager.debug()).toMatchObject({ target: undefined, displayed: undefined, wantsLive: false });
+    expect(h.driver.debug()).toMatchObject({ target: undefined, displayed: undefined, wantsLive: false });
+  });
+
+  it('freezes the published canvas on terminal failure and discards only an unpublished replacement', () => {
+    const h = harness();
+    h.driver.setActive(true);
+    h.canvases[0].pixels = 'published pixels';
+    h.driver.syncPublished(h.canvases[0]);
+    h.driver.replace();
+
+    h.driver.freeze();
+
+    expect(h.canvases[0]).toMatchObject({ pixels: 'published pixels', disposed: false, removed: false });
+    expect(h.canvases[1]).toMatchObject({ disposed: true, removed: true, listeners: 0 });
+    expect(h.driver.debug()).toMatchObject({ target: undefined, displayed: h.canvases[0], wantsLive: false });
   });
 });

--- a/apps/website/src/lib/editor-ffi/surface-driver.ts
+++ b/apps/website/src/lib/editor-ffi/surface-driver.ts
@@ -13,15 +13,13 @@ export type SurfaceDriverEffects<C> = {
   replacementFailed: () => void;
 };
 
-export type VisibilityState = { inAcquire: boolean; inRelease: boolean };
-
 type Slot<C> = {
   canvas: C;
   removeListeners: () => void;
 };
 
-// Owns canvas lifetime, visibility, and delivery only. Editor owns publication facts,
-// requirements, proofs, waiters, and scheduling.
+// Web surface effect boundary: owns canvas activation/lifetime, attach/recovery,
+// and published-canvas promotion. Editor owns publication policy and proof acceptance.
 export function createSurfaceDriver<C>(effects: SurfaceDriverEffects<C>) {
   let target: Slot<C> | undefined;
   let displayed: C | undefined;
@@ -84,10 +82,9 @@ export function createSurfaceDriver<C>(effects: SurfaceDriverEffects<C>) {
   };
 
   return {
-    reconcile(state: VisibilityState): void {
-      const shouldBeLive = target || displayed ? state.inRelease : state.inAcquire;
-      wantsLive = shouldBeLive;
-      if (!shouldBeLive) {
+    setActive(active: boolean): void {
+      wantsLive = active;
+      if (!active) {
         park();
       } else if (!target) {
         mount();
@@ -121,8 +118,26 @@ export function createSurfaceDriver<C>(effects: SurfaceDriverEffects<C>) {
       if (!wantsLive) return;
       mount(true);
     },
+    freeze(): void {
+      // Terminal cleanup must not park the last published canvas. The Host has
+      // already stopped surface work, so only the unpublished target is released.
+      wantsLive = false;
+      replacingUnavailableTarget = false;
+      ownsHostTarget = false;
+      const current = target;
+      if (!current) return;
+      current.removeListeners();
+      target = undefined;
+      if (current.canvas !== displayed) {
+        effects.releaseCpuBacking(current.canvas);
+        effects.removeNode(current.canvas);
+      }
+    },
     isAttached(): boolean {
       return target !== undefined;
+    },
+    hasSurface(): boolean {
+      return target !== undefined || displayed !== undefined;
     },
     destroy(): void {
       wantsLive = false;

--- a/apps/website/src/vitest-setup.ts
+++ b/apps/website/src/vitest-setup.ts
@@ -1,0 +1,20 @@
+import { beforeEach } from 'vitest';
+
+if (typeof window !== 'undefined') {
+  const values = new Map<string, string>();
+  const localStorage: Storage = {
+    get length() {
+      return values.size;
+    },
+    clear: () => values.clear(),
+    getItem: (key) => values.get(key) ?? null,
+    key: (index) => [...values.keys()][index] ?? null,
+    removeItem: (key) => values.delete(key),
+    setItem: (key, value) => values.set(key, value),
+  };
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: localStorage,
+  });
+  beforeEach(() => values.clear());
+}

--- a/apps/website/vite.config.ts
+++ b/apps/website/vite.config.ts
@@ -7,8 +7,8 @@ import { svg } from '@typie/lib/vite';
 import mearie from 'mearie/vite';
 import { FileSystemIconLoader } from 'unplugin-icons/loaders';
 import icons from 'unplugin-icons/vite';
-import { defineConfig } from 'vite';
-import type { Plugin, UserConfig } from 'vite';
+import { defaultClientConditions, defineConfig } from 'vite';
+import type { ConfigEnv, Plugin, UserConfig } from 'vite';
 
 const currentDir = fileURLToPath(new URL('.', import.meta.url));
 const editorPkgDir = path.resolve(currentDir, '../../crates/editor/pkg');
@@ -50,7 +50,7 @@ const wasmReloadPlugin = (): Plugin => {
   };
 };
 
-const config = {
+const config = ({ mode }: ConfigEnv) => ({
   clearScreen: false,
   plugins: [
     svg(),
@@ -68,6 +68,7 @@ const config = {
   optimizeDeps: {
     exclude: ['@typie/editor', '@typie/editor-ffi'],
   },
+  ...(mode === 'test' && { resolve: { conditions: [...defaultClientConditions] } }),
   server: {
     port: 4000,
     strictPort: true,
@@ -78,7 +79,8 @@ const config = {
   test: {
     environment: 'jsdom',
     include: ['src/**/*.test.ts'],
+    setupFiles: ['./src/vitest-setup.ts'],
   },
-};
+});
 
-export default defineConfig(config as UserConfig);
+export default defineConfig((env) => config(env) as UserConfig);


### PR DESCRIPTION
## 문제

새로운 applied layout에서 활성 surface target이 0개가 되면 publication이 멈출 수 있었습니다.

이때 이전 published frame은 남아 있지만, 새로운 layout을 publish하려면 그 layout에 대응하는 `FrameProof`가 필요합니다. 그런데 화면에 보이는 target이 하나도 없으면 새 frame을 준비할 surface도 없어져 proof를 만들 수 없었습니다.

대표적으로 page break가 많은 문서를 전체 선택 후 삭제하면 다음 상태가 만들어질 수 있었습니다.

- 새 applied layout의 target 수는 0
- 이전 published frame은 계속 표시 중
- 새 publication에 필요한 surface와 proof는 생성되지 않음
- 프레임 업데이트가 멈추며, 스크롤로 target이 다시 활성화되어야 우연히 복구됨

## 변경 사항

- visual host가 살아 있지만 target만 0개인 상태를 `NoHost`와 구분합니다.
- 다음 조건에서 page 0을 일시적인 preparation target으로 활성화합니다.
    - 이전 published frame이 존재함
    - applied revision이 published revision보다 새로움
    - applied document에 page가 존재함
    - 현재 활성 target은 0개임
- page 0에서 새 frame과 `FrameProof`가 준비될 때까지 preparation 상태를 유지합니다.
- proof가 도착하면 pixels와 geometry를 함께 publish하고 정상 visibility 정책으로 돌아갑니다.
- timeout이나 강제 publish를 추가하지 않았습니다. 이전 pixels와 새로운 geometry를 섞어 보여주지 않습니다.

## 호스트 구조

KMP와 Web에서 같은 publication 계약을 적용했습니다.

- visibility와 preparation 대상 결정은 각 호스트의 page 계층이 담당합니다.
- `SurfaceDriver`는 결정된 활성 상태에 따라 surface 작업만 수행합니다.
- KMP는 visibility gate 또는 preparation 대상인 page를 활성화합니다.
- Web은 `Page`가 visibility를 결정하고 `SurfaceDriver`에 명시적으로 활성 상태를 전달합니다.

구현은 각 렌더링 모델에 맞게 다르지만 책임과 상태 전이는 동일합니다.

## 마지막 published surface 보존

terminal failure가 발생하면 진행 중인 preparation은 중단하지만 마지막으로 성공한 published frame은 유지합니다.

Web canvas는 render target이면서 표시 중인 pixel backing이기도 하므로, terminal failure에서 canvas를 제거하거나 초기화하지 않는 `freeze()` 경로를 사용합니다.

KMP는 표시 중인 `PublishedBundle.ImageBitmap`과 native render target의 소유권이 이미 분리되어 있어 별도의 `freeze()` API 없이 같은 동작을 보장합니다.

## 보장되는 동작

- target이 0개가 되어도 publication이 영구적으로 멈추지 않음
- 새 frame이 준비되기 전에 새로운 geometry만 먼저 노출하지 않음
- offscreen page가 우연히 다시 활성화되어야 복구되는 의존성 제거
- terminal failure에서도 마지막으로 성공한 surface 유지
- 정상적인 visibility 및 virtualization 경로에는 변화 없음
- 필요한 경우에만 page 0 하나를 일시적으로 준비하므로 전역 materialization을 유발하지 않음