### PR TITLE
IME 조합을 커밋한 뒤 키 바인딩 실행

### DIFF
--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/input/EditorPlatformInputBridge.android.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/input/EditorPlatformInputBridge.android.kt
@@ -1,15 +1,52 @@
+// cspell:ignore Gboard reentrantly
+
 package co.typie.editor.input
 
+import android.content.Context
+import android.view.View
+import android.view.inputmethod.InputMethodManager
+import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.platform.PlatformTextInputSessionScope
 import androidx.compose.ui.text.input.EditCommand
 import co.typie.editor.EditorState
 import co.typie.editor.EditorViewportTransform
+import co.typie.editor.KeyModifier
 import co.typie.editor.ffi.CursorMetrics
 import co.typie.editor.ffi.Message
+import java.lang.ref.WeakReference
 import kotlinx.coroutines.CoroutineScope
 
 internal actual class EditorPlatformInputBridge actual constructor() {
+  private var inputView = WeakReference<View>(null)
+
   actual fun reset() = Unit
+
+  actual fun setInputSessionActive(active: Boolean) {
+    if (!active) inputView.clear()
+  }
+
+  actual fun bindInputSession(session: PlatformTextInputSessionScope) {
+    inputView = WeakReference(session.view)
+  }
+
+  actual fun resetPlatformInputBeforeBindingDispatch() {
+    val view = inputView.get() ?: return
+
+    // Gboard's Korean physical-keyboard path can retain a private composing syllable while
+    // exposing every update as commitText plus selection replacement. In that path the editor
+    // correctly has no composing range, so updateSelection cannot express the remaining state.
+    // Reset only at bindings that explicitly require a composition commit.
+    //
+    // Post until the current InputConnection key dispatch returns so the connection is not
+    // invalidated reentrantly.
+    view.post {
+      if (inputView.get() !== view) return@post
+      val inputMethodManager =
+        view.context.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
+      inputMethodManager?.restartInput(view)
+    }
+  }
 
   actual fun onPreKeyEvent(
     event: KeyEvent,
@@ -32,7 +69,7 @@ internal actual class EditorPlatformInputBridge actual constructor() {
     state: EditorState,
   ): List<Message>? = null
 
-  actual fun onImeMessagesCommitted(
+  actual fun onImeMessagesApplied(
     messages: List<Message>,
     preState: EditorState,
     postState: EditorState,
@@ -42,5 +79,6 @@ internal actual class EditorPlatformInputBridge actual constructor() {
     cursor: () -> CursorMetrics?,
     viewportTransform: () -> EditorViewportTransform,
     dispatch: (List<Message>) -> Unit,
+    dispatchBindingOnUnmatchedKeyUp: (Key, Set<KeyModifier>) -> Boolean,
   ): () -> Unit = {}
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Keyboard.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Keyboard.kt
@@ -53,6 +53,13 @@ internal data class KeyBinding(
   val predicate: (() -> Boolean)? = null,
   val bringIntoViewTarget: EditorBringIntoViewTarget? =
     EditorBringIntoViewTarget.CurrentSelectionHead,
+  // Unmarked bindings stay owned by platform text input while composing. Replaying them could
+  // steal an IME command or duplicate work the platform already handled.
+  val commitCompositionBeforeDispatch: Boolean = false,
+  // Command shortcuts establish a stronger platform boundary than navigation. Some IMEs can
+  // retain private composition state after reporting committed text, so Android may need to
+  // restart its input connection before dispatching these commands.
+  val resetPlatformInputBeforeDispatch: Boolean = false,
   val action: EditorKeyBindingAction,
 ) {
   constructor(
@@ -61,6 +68,8 @@ internal data class KeyBinding(
     predicate: (() -> Boolean)? = null,
     bringIntoViewTarget: EditorBringIntoViewTarget? =
       EditorBringIntoViewTarget.CurrentSelectionHead,
+    commitCompositionBeforeDispatch: Boolean = false,
+    resetPlatformInputBeforeDispatch: Boolean = false,
     coalescible: Boolean = true,
     action: suspend Editor.(Clipboard) -> List<Message>,
   ) : this(
@@ -68,6 +77,8 @@ internal data class KeyBinding(
     modifiers = modifiers,
     predicate = predicate,
     bringIntoViewTarget = bringIntoViewTarget,
+    commitCompositionBeforeDispatch = commitCompositionBeforeDispatch,
+    resetPlatformInputBeforeDispatch = resetPlatformInputBeforeDispatch,
     action = EditorKeyBindingAction.Messages(coalescible = coalescible, messages = action),
   )
 }
@@ -79,153 +90,165 @@ private fun toggleModifier(type: ModifierType): Message = Message.Modifier(Modif
 
 private fun delete(movement: Movement): Message = Message.Deletion(DeletionOp.Move(movement))
 
+private fun withCompositionCommitBeforeDispatch(vararg bindings: KeyBinding): Array<KeyBinding> =
+  bindings.map { it.copy(commitCompositionBeforeDispatch = true) }.toTypedArray()
+
+private fun withPlatformInputResetBeforeDispatch(vararg bindings: KeyBinding): Array<KeyBinding> =
+  bindings
+    .map {
+      it.copy(commitCompositionBeforeDispatch = true, resetPlatformInputBeforeDispatch = true)
+    }
+    .toTypedArray()
+
 internal fun createBindings(platform: Platform): List<KeyBinding> {
   val isMac = platform != Platform.Android
 
   return listOf(
-    KeyBinding(
-      ComposeKey.DirectionLeft,
-      action = { listOf(move(Movement.Grapheme(Direction.Backward), false)) },
-    ),
-    KeyBinding(
-      ComposeKey.DirectionLeft,
-      setOf(KeyModifier.Shift),
-      action = { listOf(move(Movement.Grapheme(Direction.Backward), true)) },
-    ),
-    KeyBinding(
-      ComposeKey.DirectionRight,
-      action = { listOf(move(Movement.Grapheme(Direction.Forward), false)) },
-    ),
-    KeyBinding(
-      ComposeKey.DirectionRight,
-      setOf(KeyModifier.Shift),
-      action = { listOf(move(Movement.Grapheme(Direction.Forward), true)) },
-    ),
-    KeyBinding(
-      ComposeKey.DirectionLeft,
-      setOf(KeyModifier.Alt),
-      action = { listOf(move(Movement.Word(Direction.Backward), false)) },
-    ),
-    KeyBinding(
-      ComposeKey.DirectionRight,
-      setOf(KeyModifier.Alt),
-      action = { listOf(move(Movement.Word(Direction.Forward), false)) },
-    ),
-    KeyBinding(
-      ComposeKey.DirectionLeft,
-      setOf(KeyModifier.Alt, KeyModifier.Shift),
-      action = { listOf(move(Movement.Word(Direction.Backward), true)) },
-    ),
-    KeyBinding(
-      ComposeKey.DirectionRight,
-      setOf(KeyModifier.Alt, KeyModifier.Shift),
-      action = { listOf(move(Movement.Word(Direction.Forward), true)) },
-    ),
-    KeyBinding(
-      ComposeKey.DirectionLeft,
-      setOf(KeyModifier.Ctrl),
-      action = { listOf(move(Movement.Word(Direction.Backward), false)) },
-    ),
-    KeyBinding(
-      ComposeKey.DirectionRight,
-      setOf(KeyModifier.Ctrl),
-      action = { listOf(move(Movement.Word(Direction.Forward), false)) },
-    ),
-    KeyBinding(
-      ComposeKey.DirectionLeft,
-      setOf(KeyModifier.Ctrl, KeyModifier.Shift),
-      action = { listOf(move(Movement.Word(Direction.Backward), true)) },
-    ),
-    KeyBinding(
-      ComposeKey.DirectionRight,
-      setOf(KeyModifier.Ctrl, KeyModifier.Shift),
-      action = { listOf(move(Movement.Word(Direction.Forward), true)) },
-    ),
-    KeyBinding(
-      ComposeKey.DirectionLeft,
-      setOf(KeyModifier.Mod),
-      predicate = { isMac },
-      action = { listOf(move(Movement.Line(Direction.Backward, Axis.Horizontal), false)) },
-    ),
-    KeyBinding(
-      ComposeKey.DirectionRight,
-      setOf(KeyModifier.Mod),
-      predicate = { isMac },
-      action = { listOf(move(Movement.Line(Direction.Forward, Axis.Horizontal), false)) },
-    ),
-    KeyBinding(
-      ComposeKey.DirectionLeft,
-      setOf(KeyModifier.Mod, KeyModifier.Shift),
-      predicate = { isMac },
-      action = { listOf(move(Movement.Line(Direction.Backward, Axis.Horizontal), true)) },
-    ),
-    KeyBinding(
-      ComposeKey.DirectionRight,
-      setOf(KeyModifier.Mod, KeyModifier.Shift),
-      predicate = { isMac },
-      action = { listOf(move(Movement.Line(Direction.Forward, Axis.Horizontal), true)) },
-    ),
-    KeyBinding(
-      ComposeKey.DirectionUp,
-      action = { listOf(move(Movement.Line(Direction.Backward, Axis.Vertical), false)) },
-    ),
-    KeyBinding(
-      ComposeKey.DirectionUp,
-      setOf(KeyModifier.Shift),
-      action = { listOf(move(Movement.Line(Direction.Backward, Axis.Vertical), true)) },
-    ),
-    KeyBinding(
-      ComposeKey.DirectionDown,
-      action = { listOf(move(Movement.Line(Direction.Forward, Axis.Vertical), false)) },
-    ),
-    KeyBinding(
-      ComposeKey.DirectionDown,
-      setOf(KeyModifier.Shift),
-      action = { listOf(move(Movement.Line(Direction.Forward, Axis.Vertical), true)) },
-    ),
-    KeyBinding(
-      ComposeKey.DirectionUp,
-      setOf(KeyModifier.Mod),
-      predicate = { isMac },
-      action = { listOf(move(Movement.Document(Direction.Backward), false)) },
-    ),
-    KeyBinding(
-      ComposeKey.DirectionDown,
-      setOf(KeyModifier.Mod),
-      predicate = { isMac },
-      action = { listOf(move(Movement.Document(Direction.Forward), false)) },
-    ),
-    KeyBinding(
-      ComposeKey.DirectionUp,
-      setOf(KeyModifier.Mod, KeyModifier.Shift),
-      predicate = { isMac },
-      action = { listOf(move(Movement.Document(Direction.Backward), true)) },
-    ),
-    KeyBinding(
-      ComposeKey.DirectionDown,
-      setOf(KeyModifier.Mod, KeyModifier.Shift),
-      predicate = { isMac },
-      action = { listOf(move(Movement.Document(Direction.Forward), true)) },
-    ),
-    KeyBinding(
-      ComposeKey.DirectionUp,
-      setOf(KeyModifier.Alt),
-      action = { listOf(move(Movement.Sentence(Direction.Backward), false)) },
-    ),
-    KeyBinding(
-      ComposeKey.DirectionDown,
-      setOf(KeyModifier.Alt),
-      action = { listOf(move(Movement.Sentence(Direction.Forward), false)) },
-    ),
-    KeyBinding(
-      ComposeKey.DirectionUp,
-      setOf(KeyModifier.Alt, KeyModifier.Shift),
-      action = { listOf(move(Movement.Sentence(Direction.Backward), true)) },
-    ),
-    KeyBinding(
-      ComposeKey.DirectionDown,
-      setOf(KeyModifier.Alt, KeyModifier.Shift),
-      action = { listOf(move(Movement.Sentence(Direction.Forward), true)) },
+    *withCompositionCommitBeforeDispatch(
+      KeyBinding(
+        ComposeKey.DirectionLeft,
+        action = { listOf(move(Movement.Grapheme(Direction.Backward), false)) },
+      ),
+      KeyBinding(
+        ComposeKey.DirectionLeft,
+        setOf(KeyModifier.Shift),
+        action = { listOf(move(Movement.Grapheme(Direction.Backward), true)) },
+      ),
+      KeyBinding(
+        ComposeKey.DirectionRight,
+        action = { listOf(move(Movement.Grapheme(Direction.Forward), false)) },
+      ),
+      KeyBinding(
+        ComposeKey.DirectionRight,
+        setOf(KeyModifier.Shift),
+        action = { listOf(move(Movement.Grapheme(Direction.Forward), true)) },
+      ),
+      KeyBinding(
+        ComposeKey.DirectionLeft,
+        setOf(KeyModifier.Alt),
+        action = { listOf(move(Movement.Word(Direction.Backward), false)) },
+      ),
+      KeyBinding(
+        ComposeKey.DirectionRight,
+        setOf(KeyModifier.Alt),
+        action = { listOf(move(Movement.Word(Direction.Forward), false)) },
+      ),
+      KeyBinding(
+        ComposeKey.DirectionLeft,
+        setOf(KeyModifier.Alt, KeyModifier.Shift),
+        action = { listOf(move(Movement.Word(Direction.Backward), true)) },
+      ),
+      KeyBinding(
+        ComposeKey.DirectionRight,
+        setOf(KeyModifier.Alt, KeyModifier.Shift),
+        action = { listOf(move(Movement.Word(Direction.Forward), true)) },
+      ),
+      KeyBinding(
+        ComposeKey.DirectionLeft,
+        setOf(KeyModifier.Ctrl),
+        action = { listOf(move(Movement.Word(Direction.Backward), false)) },
+      ),
+      KeyBinding(
+        ComposeKey.DirectionRight,
+        setOf(KeyModifier.Ctrl),
+        action = { listOf(move(Movement.Word(Direction.Forward), false)) },
+      ),
+      KeyBinding(
+        ComposeKey.DirectionLeft,
+        setOf(KeyModifier.Ctrl, KeyModifier.Shift),
+        action = { listOf(move(Movement.Word(Direction.Backward), true)) },
+      ),
+      KeyBinding(
+        ComposeKey.DirectionRight,
+        setOf(KeyModifier.Ctrl, KeyModifier.Shift),
+        action = { listOf(move(Movement.Word(Direction.Forward), true)) },
+      ),
+      KeyBinding(
+        ComposeKey.DirectionLeft,
+        setOf(KeyModifier.Mod),
+        predicate = { isMac },
+        action = { listOf(move(Movement.Line(Direction.Backward, Axis.Horizontal), false)) },
+      ),
+      KeyBinding(
+        ComposeKey.DirectionRight,
+        setOf(KeyModifier.Mod),
+        predicate = { isMac },
+        action = { listOf(move(Movement.Line(Direction.Forward, Axis.Horizontal), false)) },
+      ),
+      KeyBinding(
+        ComposeKey.DirectionLeft,
+        setOf(KeyModifier.Mod, KeyModifier.Shift),
+        predicate = { isMac },
+        action = { listOf(move(Movement.Line(Direction.Backward, Axis.Horizontal), true)) },
+      ),
+      KeyBinding(
+        ComposeKey.DirectionRight,
+        setOf(KeyModifier.Mod, KeyModifier.Shift),
+        predicate = { isMac },
+        action = { listOf(move(Movement.Line(Direction.Forward, Axis.Horizontal), true)) },
+      ),
+      KeyBinding(
+        ComposeKey.DirectionUp,
+        action = { listOf(move(Movement.Line(Direction.Backward, Axis.Vertical), false)) },
+      ),
+      KeyBinding(
+        ComposeKey.DirectionUp,
+        setOf(KeyModifier.Shift),
+        action = { listOf(move(Movement.Line(Direction.Backward, Axis.Vertical), true)) },
+      ),
+      KeyBinding(
+        ComposeKey.DirectionDown,
+        action = { listOf(move(Movement.Line(Direction.Forward, Axis.Vertical), false)) },
+      ),
+      KeyBinding(
+        ComposeKey.DirectionDown,
+        setOf(KeyModifier.Shift),
+        action = { listOf(move(Movement.Line(Direction.Forward, Axis.Vertical), true)) },
+      ),
+      KeyBinding(
+        ComposeKey.DirectionUp,
+        setOf(KeyModifier.Mod),
+        predicate = { isMac },
+        action = { listOf(move(Movement.Document(Direction.Backward), false)) },
+      ),
+      KeyBinding(
+        ComposeKey.DirectionDown,
+        setOf(KeyModifier.Mod),
+        predicate = { isMac },
+        action = { listOf(move(Movement.Document(Direction.Forward), false)) },
+      ),
+      KeyBinding(
+        ComposeKey.DirectionUp,
+        setOf(KeyModifier.Mod, KeyModifier.Shift),
+        predicate = { isMac },
+        action = { listOf(move(Movement.Document(Direction.Backward), true)) },
+      ),
+      KeyBinding(
+        ComposeKey.DirectionDown,
+        setOf(KeyModifier.Mod, KeyModifier.Shift),
+        predicate = { isMac },
+        action = { listOf(move(Movement.Document(Direction.Forward), true)) },
+      ),
+      KeyBinding(
+        ComposeKey.DirectionUp,
+        setOf(KeyModifier.Alt),
+        action = { listOf(move(Movement.Sentence(Direction.Backward), false)) },
+      ),
+      KeyBinding(
+        ComposeKey.DirectionDown,
+        setOf(KeyModifier.Alt),
+        action = { listOf(move(Movement.Sentence(Direction.Forward), false)) },
+      ),
+      KeyBinding(
+        ComposeKey.DirectionUp,
+        setOf(KeyModifier.Alt, KeyModifier.Shift),
+        action = { listOf(move(Movement.Sentence(Direction.Backward), true)) },
+      ),
+      KeyBinding(
+        ComposeKey.DirectionDown,
+        setOf(KeyModifier.Alt, KeyModifier.Shift),
+        action = { listOf(move(Movement.Sentence(Direction.Forward), true)) },
+      ),
     ),
     KeyBinding(ComposeKey.Enter, action = { listOf(Message.Key(FfiKeyEvent(FfiKey.Enter))) }),
     KeyBinding(
@@ -236,6 +259,8 @@ internal fun createBindings(platform: Platform): List<KeyBinding> {
     KeyBinding(
       ComposeKey.Enter,
       setOf(KeyModifier.Mod),
+      commitCompositionBeforeDispatch = true,
+      resetPlatformInputBeforeDispatch = true,
       action = { listOf(Message.Insertion(InsertionOp.Break(Break.Page))) },
     ),
     KeyBinding(
@@ -280,156 +305,160 @@ internal fun createBindings(platform: Platform): List<KeyBinding> {
       bringIntoViewTarget = null,
       action = { listOf(Message.Key(FfiKeyEvent(FfiKey.Escape))) },
     ),
-    KeyBinding(
-      ComposeKey.MoveHome,
-      action = { listOf(move(Movement.Line(Direction.Backward, Axis.Horizontal), false)) },
+    *withCompositionCommitBeforeDispatch(
+      KeyBinding(
+        ComposeKey.MoveHome,
+        action = { listOf(move(Movement.Line(Direction.Backward, Axis.Horizontal), false)) },
+      ),
+      KeyBinding(
+        ComposeKey.MoveHome,
+        setOf(KeyModifier.Shift),
+        action = { listOf(move(Movement.Line(Direction.Backward, Axis.Horizontal), true)) },
+      ),
+      KeyBinding(
+        ComposeKey.MoveHome,
+        setOf(KeyModifier.Ctrl),
+        action = { listOf(move(Movement.Document(Direction.Backward), false)) },
+      ),
+      KeyBinding(
+        ComposeKey.MoveHome,
+        setOf(KeyModifier.Ctrl, KeyModifier.Shift),
+        action = { listOf(move(Movement.Document(Direction.Backward), true)) },
+      ),
+      KeyBinding(
+        ComposeKey.MoveEnd,
+        action = { listOf(move(Movement.Line(Direction.Forward, Axis.Horizontal), false)) },
+      ),
+      KeyBinding(
+        ComposeKey.MoveEnd,
+        setOf(KeyModifier.Shift),
+        action = { listOf(move(Movement.Line(Direction.Forward, Axis.Horizontal), true)) },
+      ),
+      KeyBinding(
+        ComposeKey.MoveEnd,
+        setOf(KeyModifier.Ctrl),
+        action = { listOf(move(Movement.Document(Direction.Forward), false)) },
+      ),
+      KeyBinding(
+        ComposeKey.MoveEnd,
+        setOf(KeyModifier.Ctrl, KeyModifier.Shift),
+        action = { listOf(move(Movement.Document(Direction.Forward), true)) },
+      ),
+      KeyBinding(
+        ComposeKey.PageUp,
+        action = { listOf(move(Movement.Page(Direction.Backward), false)) },
+      ),
+      KeyBinding(
+        ComposeKey.PageUp,
+        setOf(KeyModifier.Shift),
+        action = { listOf(move(Movement.Page(Direction.Backward), true)) },
+      ),
+      KeyBinding(
+        ComposeKey.PageDown,
+        action = { listOf(move(Movement.Page(Direction.Forward), false)) },
+      ),
+      KeyBinding(
+        ComposeKey.PageDown,
+        setOf(KeyModifier.Shift),
+        action = { listOf(move(Movement.Page(Direction.Forward), true)) },
+      ),
     ),
-    KeyBinding(
-      ComposeKey.MoveHome,
-      setOf(KeyModifier.Shift),
-      action = { listOf(move(Movement.Line(Direction.Backward, Axis.Horizontal), true)) },
-    ),
-    KeyBinding(
-      ComposeKey.MoveHome,
-      setOf(KeyModifier.Ctrl),
-      action = { listOf(move(Movement.Document(Direction.Backward), false)) },
-    ),
-    KeyBinding(
-      ComposeKey.MoveHome,
-      setOf(KeyModifier.Ctrl, KeyModifier.Shift),
-      action = { listOf(move(Movement.Document(Direction.Backward), true)) },
-    ),
-    KeyBinding(
-      ComposeKey.MoveEnd,
-      action = { listOf(move(Movement.Line(Direction.Forward, Axis.Horizontal), false)) },
-    ),
-    KeyBinding(
-      ComposeKey.MoveEnd,
-      setOf(KeyModifier.Shift),
-      action = { listOf(move(Movement.Line(Direction.Forward, Axis.Horizontal), true)) },
-    ),
-    KeyBinding(
-      ComposeKey.MoveEnd,
-      setOf(KeyModifier.Ctrl),
-      action = { listOf(move(Movement.Document(Direction.Forward), false)) },
-    ),
-    KeyBinding(
-      ComposeKey.MoveEnd,
-      setOf(KeyModifier.Ctrl, KeyModifier.Shift),
-      action = { listOf(move(Movement.Document(Direction.Forward), true)) },
-    ),
-    KeyBinding(
-      ComposeKey.PageUp,
-      action = { listOf(move(Movement.Page(Direction.Backward), false)) },
-    ),
-    KeyBinding(
-      ComposeKey.PageUp,
-      setOf(KeyModifier.Shift),
-      action = { listOf(move(Movement.Page(Direction.Backward), true)) },
-    ),
-    KeyBinding(
-      ComposeKey.PageDown,
-      action = { listOf(move(Movement.Page(Direction.Forward), false)) },
-    ),
-    KeyBinding(
-      ComposeKey.PageDown,
-      setOf(KeyModifier.Shift),
-      action = { listOf(move(Movement.Page(Direction.Forward), true)) },
-    ),
-    KeyBinding(
-      ComposeKey.B,
-      setOf(KeyModifier.Mod),
-      action = { listOf(toggleModifier(ModifierType.Bold)) },
-    ),
-    KeyBinding(
-      ComposeKey.I,
-      setOf(KeyModifier.Mod),
-      action = { listOf(toggleModifier(ModifierType.Italic)) },
-    ),
-    KeyBinding(
-      ComposeKey.S,
-      setOf(KeyModifier.Mod, KeyModifier.Shift),
-      action = { listOf(toggleModifier(ModifierType.Strikethrough)) },
-    ),
-    KeyBinding(
-      ComposeKey.U,
-      setOf(KeyModifier.Mod),
-      action = { listOf(toggleModifier(ModifierType.Underline)) },
-    ),
-    KeyBinding(
-      ComposeKey.Backslash,
-      setOf(KeyModifier.Mod),
-      action = { listOf(Message.Modifier(ModifierOp.ClearAll)) },
-    ),
-    KeyBinding(
-      ComposeKey.Z,
-      setOf(KeyModifier.Mod),
-      action = { listOf(Message.History(HistoryOp.Undo)) },
-    ),
-    KeyBinding(
-      ComposeKey.Z,
-      setOf(KeyModifier.Mod, KeyModifier.Shift),
-      action = { listOf(Message.History(HistoryOp.Redo)) },
-    ),
-    KeyBinding(
-      ComposeKey.C,
-      setOf(KeyModifier.Mod),
-      bringIntoViewTarget = null,
-      coalescible = false,
-      action = { clipboard ->
-        copySelection()?.let { clipboard.copyRichText(html = it.html, text = it.text) }
+    *withPlatformInputResetBeforeDispatch(
+      KeyBinding(
+        ComposeKey.B,
+        setOf(KeyModifier.Mod),
+        action = { listOf(toggleModifier(ModifierType.Bold)) },
+      ),
+      KeyBinding(
+        ComposeKey.I,
+        setOf(KeyModifier.Mod),
+        action = { listOf(toggleModifier(ModifierType.Italic)) },
+      ),
+      KeyBinding(
+        ComposeKey.S,
+        setOf(KeyModifier.Mod, KeyModifier.Shift),
+        action = { listOf(toggleModifier(ModifierType.Strikethrough)) },
+      ),
+      KeyBinding(
+        ComposeKey.U,
+        setOf(KeyModifier.Mod),
+        action = { listOf(toggleModifier(ModifierType.Underline)) },
+      ),
+      KeyBinding(
+        ComposeKey.Backslash,
+        setOf(KeyModifier.Mod),
+        action = { listOf(Message.Modifier(ModifierOp.ClearAll)) },
+      ),
+      KeyBinding(
+        ComposeKey.Z,
+        setOf(KeyModifier.Mod),
+        action = { listOf(Message.History(HistoryOp.Undo)) },
+      ),
+      KeyBinding(
+        ComposeKey.Z,
+        setOf(KeyModifier.Mod, KeyModifier.Shift),
+        action = { listOf(Message.History(HistoryOp.Redo)) },
+      ),
+      KeyBinding(
+        ComposeKey.C,
+        setOf(KeyModifier.Mod),
+        bringIntoViewTarget = null,
+        coalescible = false,
+        action = { clipboard ->
+          copySelection()?.let { clipboard.copyRichText(html = it.html, text = it.text) }
+          emptyList()
+        },
+      ),
+      KeyBinding(
+        ComposeKey.X,
+        setOf(KeyModifier.Mod),
+        coalescible = false,
+        action = { clipboard ->
+          val payload = copySelection() ?: return@KeyBinding emptyList()
+          if (clipboard.copyRichText(html = payload.html, text = payload.text)) {
+            listOf(Message.Clipboard(ClipboardOp.Cut))
+          } else {
+            emptyList()
+          }
+        },
+      ),
+      KeyBinding(
+        ComposeKey.V,
+        setOf(KeyModifier.Mod),
+        action = EditorKeyBindingAction.Paste(IncomingContentMode.Rich),
+      ),
+      KeyBinding(
+        ComposeKey.V,
+        setOf(KeyModifier.Mod, KeyModifier.Shift),
+        action = EditorKeyBindingAction.Paste(IncomingContentMode.PlainTextOnly),
+      ),
+      KeyBinding(
+        ComposeKey.A,
+        setOf(KeyModifier.Mod),
+        bringIntoViewTarget = null,
+        action = { listOf(Message.Selection(SelectionOp.Expand(SelectionExpansionUnit.All))) },
+      ),
+      KeyBinding(
+        ComposeKey.Q,
+        setOf(KeyModifier.Ctrl),
+        predicate = { isMac },
+        bringIntoViewTarget = null,
+        coalescible = false,
+      ) {
+        inspectState()
+        emptyList()
+      },
+      KeyBinding(
+        ComposeKey.W,
+        setOf(KeyModifier.Ctrl),
+        predicate = { isMac },
+        bringIntoViewTarget = null,
+        coalescible = false,
+      ) {
+        inspectStateAsMacro()
         emptyList()
       },
     ),
-    KeyBinding(
-      ComposeKey.X,
-      setOf(KeyModifier.Mod),
-      coalescible = false,
-      action = { clipboard ->
-        val payload = copySelection() ?: return@KeyBinding emptyList()
-        if (clipboard.copyRichText(html = payload.html, text = payload.text)) {
-          listOf(Message.Clipboard(ClipboardOp.Cut))
-        } else {
-          emptyList()
-        }
-      },
-    ),
-    KeyBinding(
-      ComposeKey.V,
-      setOf(KeyModifier.Mod),
-      action = EditorKeyBindingAction.Paste(IncomingContentMode.Rich),
-    ),
-    KeyBinding(
-      ComposeKey.V,
-      setOf(KeyModifier.Mod, KeyModifier.Shift),
-      action = EditorKeyBindingAction.Paste(IncomingContentMode.PlainTextOnly),
-    ),
-    KeyBinding(
-      ComposeKey.A,
-      setOf(KeyModifier.Mod),
-      bringIntoViewTarget = null,
-      action = { listOf(Message.Selection(SelectionOp.Expand(SelectionExpansionUnit.All))) },
-    ),
-    KeyBinding(
-      ComposeKey.Q,
-      setOf(KeyModifier.Ctrl),
-      predicate = { isMac },
-      bringIntoViewTarget = null,
-      coalescible = false,
-    ) {
-      inspectState()
-      emptyList()
-    },
-    KeyBinding(
-      ComposeKey.W,
-      setOf(KeyModifier.Ctrl),
-      predicate = { isMac },
-      bringIntoViewTarget = null,
-      coalescible = false,
-    ) {
-      inspectStateAsMacro()
-      emptyList()
-    },
   )
 }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorInput.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorInput.kt
@@ -25,6 +25,7 @@ import co.typie.editor.EditorEventListener
 import co.typie.editor.EditorKeyBindingAction
 import co.typie.editor.EditorState
 import co.typie.editor.KeyBinding
+import co.typie.editor.KeyModifier
 import co.typie.editor.createBindings
 import co.typie.editor.ffi.CursorMetrics
 import co.typie.editor.ffi.EditorEvent
@@ -137,25 +138,6 @@ internal fun toolbarInsertTextMessages(text: String, composing: Boolean): List<M
   } else {
     listOf(Message.Insertion(InsertionOp.Text(text)))
   }
-
-private val COMPOSITION_COMMITTING_NAVIGATION_KEYS =
-  setOf(
-    ComposeKey.DirectionLeft,
-    ComposeKey.DirectionRight,
-    ComposeKey.DirectionUp,
-    ComposeKey.DirectionDown,
-    ComposeKey.MoveHome,
-    ComposeKey.MoveEnd,
-    ComposeKey.PageUp,
-    ComposeKey.PageDown,
-  )
-
-// Android delivers hardware keys to the view only after the IME has declined them, so a
-// blocked navigation key would leave the composition (and every following arrow) stuck.
-// Other platforms deliver raw key events even while the IME is still consuming them
-// (e.g. candidate navigation), so bindings stay blocked during composition there.
-internal fun commitsCompositionBeforeKeyBinding(platform: Platform, key: ComposeKey): Boolean =
-  platform == Platform.Android && key in COMPOSITION_COMMITTING_NAVIGATION_KEYS
 
 internal fun fixedLocalCaretTextFieldRectInRoot(
   focusedRectInRoot: Rect?,
@@ -325,6 +307,24 @@ internal class EditorInputNode(
     }
   }
 
+  private fun dispatchBindingOnUnmatchedKeyUp(
+    key: ComposeKey,
+    modifiers: Set<KeyModifier>,
+  ): Boolean {
+    if (!focused || !enabled || bindingCoalescer == null) return false
+    val binding =
+      bindings.find {
+        it.key == key &&
+          it.modifiers == modifiers &&
+          it.commitCompositionBeforeDispatch &&
+          (it.predicate == null || it.predicate.invoke())
+      } ?: return false
+
+    commitCompositionBeforeBindingDispatch(binding.resetPlatformInputBeforeDispatch)
+    dispatchBinding(binding, clipboard)
+    return true
+  }
+
   private fun dispatchPreKeyBinding(binding: KeyBinding, clipboard: Clipboard) {
     val coalescer = bindingCoalescer ?: return
     when (val action = binding.action) {
@@ -388,6 +388,20 @@ internal class EditorInputNode(
         messages.forEach(::enqueue)
         afterApplied { bringIntoViewTarget?.let { target -> bringIntoView(target) } }
       }
+    }
+  }
+
+  private fun commitCompositionBeforeBindingDispatch(resetPlatformInput: Boolean) {
+    if (editor.appliedState.ime?.composing != null) {
+      dispatchSync(
+        listOf(Message.TextInput(listOf(FlatImeOp.CommitAsIs))),
+        bringIntoViewTarget = null,
+      )
+      if (editor.appliedState.ime?.composing != null) return
+    }
+
+    if (resetPlatformInput) {
+      platformInputBridge.resetPlatformInputBeforeBindingDispatch()
     }
   }
 
@@ -474,7 +488,7 @@ internal class EditorInputNode(
     val binding = bindings.find { matchesKeyBinding(it, platform, event) }
     if (binding != null) {
       val composing = editor.appliedState.ime?.composing != null
-      if (composing && !commitsCompositionBeforeKeyBinding(platform, event.key)) {
+      if (composing && !binding.commitCompositionBeforeDispatch) {
         recordHardwareKey(
           event = event,
           stage = "onKeyEvent",
@@ -484,11 +498,8 @@ internal class EditorInputNode(
         )
         return true
       }
-      if (composing) {
-        dispatchSync(
-          listOf(Message.TextInput(listOf(FlatImeOp.CommitAsIs))),
-          bringIntoViewTarget = null,
-        )
+      if (binding.commitCompositionBeforeDispatch) {
+        commitCompositionBeforeBindingDispatch(binding.resetPlatformInputBeforeDispatch)
       }
       if (platformInputBridge.shouldConsumeKeyEvent(event)) {
         recordHardwareKey(
@@ -574,10 +585,7 @@ internal class EditorInputNode(
   override fun onPreKeyEvent(event: KeyEvent): Boolean {
     if (!enabled || event.type != KeyEventType.KeyDown) return false
     val binding = bindings.find { matchesKeyBinding(it, platform, event) } ?: return false
-    if (
-      editor.appliedState.ime?.composing != null &&
-        !commitsCompositionBeforeKeyBinding(platform, event.key)
-    ) {
+    if (editor.appliedState.ime?.composing != null && !binding.commitCompositionBeforeDispatch) {
       recordHardwareKey(
         event = event,
         stage = "onPreKeyEvent",
@@ -591,7 +599,12 @@ internal class EditorInputNode(
       platformInputBridge.onPreKeyEvent(
         event = event,
         inputCoroutineScope = coroutineScope,
-        onAccepted = { dispatchPreKeyBinding(binding, clipboard) },
+        onAccepted = {
+          if (binding.commitCompositionBeforeDispatch) {
+            commitCompositionBeforeBindingDispatch(binding.resetPlatformInputBeforeDispatch)
+          }
+          dispatchPreKeyBinding(binding, clipboard)
+        },
       )
     recordHardwareKey(
       event = event,
@@ -625,6 +638,7 @@ internal class EditorInputNode(
     } else {
       editor.deactivateImeSession()
     }
+    platformInputBridge.setInputSessionActive(sessionEnabled)
     focusedJob?.cancel()
     focusedJob = null
     platformInputBridge.reset()
@@ -640,6 +654,10 @@ internal class EditorInputNode(
                 uiState.resolveViewportTransform(editor.publishedState.pageSizes)
               },
               dispatch = { messages -> dispatch(messages) },
+              dispatchBindingOnUnmatchedKeyUp = { key, modifiers ->
+                imeSessionGeneration == generationAtStart &&
+                  dispatchBindingOnUnmatchedKeyUp(key, modifiers)
+              },
             )
           val inputSessionUiState = uiState
           val inputSessionOwner = Any()
@@ -649,6 +667,7 @@ internal class EditorInputNode(
             // the session must not start against a pre-activation snapshot.
             editor.refreshImeSnapshot()
             establishTextInputSession {
+              platformInputBridge.bindInputSession(this)
               val request =
                 createEditorInputRequest(
                   editor = editor,
@@ -668,7 +687,7 @@ internal class EditorInputNode(
                         )
                     val postState = dispatchSync(messages)
                     if (postState != null) {
-                      platformInputBridge.onImeMessagesCommitted(
+                      platformInputBridge.onImeMessagesApplied(
                         messages = messages,
                         preState = preState,
                         postState = postState,
@@ -751,6 +770,7 @@ internal class EditorInputNode(
     unsubscribeImeResync = null
     bindingCoalescer = null
     focused = false
+    platformInputBridge.setInputSessionActive(false)
     editor.setImeSessionActive(false)
     platformInputBridge.reset()
     notifyTextInputFocusChanged(this, false)

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorPlatformInputBridge.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorPlatformInputBridge.kt
@@ -1,15 +1,24 @@
 package co.typie.editor.input
 
+import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.platform.PlatformTextInputSessionScope
 import androidx.compose.ui.text.input.EditCommand
 import co.typie.editor.EditorState
 import co.typie.editor.EditorViewportTransform
+import co.typie.editor.KeyModifier
 import co.typie.editor.ffi.CursorMetrics
 import co.typie.editor.ffi.Message
 import kotlinx.coroutines.CoroutineScope
 
 internal expect class EditorPlatformInputBridge() {
   fun reset()
+
+  fun setInputSessionActive(active: Boolean)
+
+  fun bindInputSession(session: PlatformTextInputSessionScope)
+
+  fun resetPlatformInputBeforeBindingDispatch()
 
   fun onPreKeyEvent(
     event: KeyEvent,
@@ -27,11 +36,12 @@ internal expect class EditorPlatformInputBridge() {
 
   fun interceptEditCommands(commands: List<EditCommand>, state: EditorState): List<Message>?
 
-  fun onImeMessagesCommitted(messages: List<Message>, preState: EditorState, postState: EditorState)
+  fun onImeMessagesApplied(messages: List<Message>, preState: EditorState, postState: EditorState)
 
   fun installSessionEffects(
     cursor: () -> CursorMetrics?,
     viewportTransform: () -> EditorViewportTransform,
     dispatch: (List<Message>) -> Unit,
+    dispatchBindingOnUnmatchedKeyUp: (Key, Set<KeyModifier>) -> Boolean,
   ): () -> Unit
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorSelectionInputIntentTracker.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorSelectionInputIntentTracker.kt
@@ -160,7 +160,7 @@ internal class EditorSelectionInputIntentTracker(private val staleTimeoutMillis:
     )
   }
 
-  fun recordImeMessagesCommitted(
+  fun recordImeMessagesApplied(
     messages: List<Message>,
     preState: EditorState,
     postState: EditorState,

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/input/EditorImeCommandNormalizerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/input/EditorImeCommandNormalizerTest.kt
@@ -1,6 +1,7 @@
 package co.typie.editor.input
 
 import androidx.compose.ui.text.input.CommitTextCommand
+import androidx.compose.ui.text.input.DeleteSurroundingTextInCodePointsCommand
 import androidx.compose.ui.text.input.FinishComposingTextCommand
 import androidx.compose.ui.text.input.SetComposingRegionCommand
 import androidx.compose.ui.text.input.SetComposingTextCommand
@@ -162,6 +163,20 @@ class EditorImeCommandNormalizerTest {
   }
 
   @Test
+  fun `delete and composing commands stay in one ordered text input batch`() {
+    val messages =
+      EditorImeCommandNormalizer.normalize(
+        listOf(DeleteSurroundingTextInCodePointsCommand(1, 0), SetComposingTextCommand("하", 1)),
+        ime = null,
+      )
+
+    assertEquals(
+      listOf(Message.TextInput(listOf(FlatImeOp.DeleteSurrounding(1, 0), FlatImeOp.Compose("하")))),
+      messages,
+    )
+  }
+
+  @Test
   fun `collapsed selection command normalizes to navigation delta`() {
     val ime = Ime(text = "hello", windowStart = 10, selection = ImeRange(12, 12), composing = null)
 
@@ -191,12 +206,7 @@ class EditorImeCommandNormalizerTest {
   @Test
   fun `mixed selection and commit batch projects window-relative offsets to absolute`() {
     val ime =
-      Ime(
-        text = "텐데. ㅎㅇ",
-        windowStart = 4559,
-        selection = ImeRange(4565, 4565),
-        composing = null,
-      )
+      Ime(text = "텐데. ㅎㅇ", windowStart = 4559, selection = ImeRange(4565, 4565), composing = null)
 
     val messages =
       EditorImeCommandNormalizer.normalize(
@@ -229,13 +239,7 @@ class EditorImeCommandNormalizerTest {
 
   @Test
   fun `mixed batch selection offsets convert utf16 indices to code point offsets`() {
-    val ime =
-      Ime(
-        text = "a😀b",
-        windowStart = 10,
-        selection = ImeRange(13, 13),
-        composing = null,
-      )
+    val ime = Ime(text = "a😀b", windowStart = 10, selection = ImeRange(13, 13), composing = null)
 
     val messages =
       EditorImeCommandNormalizer.normalize(
@@ -256,12 +260,7 @@ class EditorImeCommandNormalizerTest {
   @Test
   fun `mixed batch composing region projects window-relative offsets to absolute`() {
     val ime =
-      Ime(
-        text = "텐데. ㅎㅇ",
-        windowStart = 4559,
-        selection = ImeRange(4565, 4565),
-        composing = null,
-      )
+      Ime(text = "텐데. ㅎㅇ", windowStart = 4559, selection = ImeRange(4565, 4565), composing = null)
 
     val messages =
       EditorImeCommandNormalizer.normalize(

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/input/EditorInputKeyHandlingTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/input/EditorInputKeyHandlingTest.kt
@@ -2,6 +2,8 @@ package co.typie.editor.input
 
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.input.key.Key
+import co.typie.editor.KeyModifier
+import co.typie.editor.createBindings
 import co.typie.editor.ffi.FlatImeOp
 import co.typie.editor.ffi.InsertionOp
 import co.typie.editor.ffi.Message
@@ -32,41 +34,78 @@ class EditorInputKeyHandlingTest {
   }
 
   @Test
-  fun `Android navigation keys commit composition before running their binding`() {
-    val navigationKeys =
+  fun `navigation bindings commit composition on every platform`() {
+    val navigationBindings =
       listOf(
-        Key.DirectionLeft,
-        Key.DirectionRight,
-        Key.DirectionUp,
-        Key.DirectionDown,
-        Key.MoveHome,
-        Key.MoveEnd,
-        Key.PageUp,
-        Key.PageDown,
+        Key.DirectionLeft to emptySet(),
+        Key.DirectionLeft to setOf(KeyModifier.Shift),
+        Key.DirectionLeft to setOf(KeyModifier.Alt),
+        Key.DirectionLeft to setOf(KeyModifier.Mod),
+        Key.DirectionDown to setOf(KeyModifier.Mod, KeyModifier.Shift),
+        Key.MoveHome to emptySet(),
+        Key.MoveEnd to setOf(KeyModifier.Ctrl),
+        Key.PageUp to setOf(KeyModifier.Shift),
+        Key.PageDown to emptySet(),
       )
 
-    for (key in navigationKeys) {
-      assertTrue(commitsCompositionBeforeKeyBinding(platform = Platform.Android, key = key))
+    for (platform in Platform.entries) {
+      for ((key, modifiers) in navigationBindings) {
+        assertTrue(
+          binding(platform, key, modifiers).commitCompositionBeforeDispatch,
+          "$platform $key $modifiers",
+        )
+      }
     }
   }
 
   @Test
-  fun `Android editing keys stay blocked during composition`() {
-    val blockedKeys = listOf(Key.Backspace, Key.Delete, Key.Enter, Key.Tab, Key.Escape, Key.A)
+  fun `editor shortcuts commit composition on every platform`() {
+    val shortcutBindings =
+      listOf(
+        Key.Enter to setOf(KeyModifier.Mod),
+        Key.A to setOf(KeyModifier.Mod),
+        Key.B to setOf(KeyModifier.Mod),
+        Key.Z to setOf(KeyModifier.Mod),
+        Key.C to setOf(KeyModifier.Mod),
+        Key.V to setOf(KeyModifier.Mod),
+      )
 
-    for (key in blockedKeys) {
-      assertFalse(commitsCompositionBeforeKeyBinding(platform = Platform.Android, key = key))
+    for (platform in Platform.entries) {
+      for ((key, modifiers) in shortcutBindings) {
+        assertTrue(
+          binding(platform, key, modifiers).commitCompositionBeforeDispatch,
+          "$platform $key $modifiers",
+        )
+      }
     }
   }
 
   @Test
-  fun `non-Android platforms keep navigation keys blocked during composition`() {
-    assertFalse(
-      commitsCompositionBeforeKeyBinding(platform = Platform.Desktop, key = Key.DirectionLeft)
-    )
-    assertFalse(
-      commitsCompositionBeforeKeyBinding(platform = Platform.iOS, key = Key.DirectionLeft)
-    )
+  fun `native text input bindings stay blocked during composition`() {
+    val nativeBindings =
+      listOf(
+        Key.Enter to emptySet(),
+        Key.Enter to setOf(KeyModifier.Shift),
+        Key.Backspace to emptySet(),
+        Key.Backspace to setOf(KeyModifier.Alt),
+        Key.Backspace to setOf(KeyModifier.Ctrl),
+        Key.Backspace to setOf(KeyModifier.Mod),
+        Key.Delete to emptySet(),
+        Key.Delete to setOf(KeyModifier.Alt),
+        Key.Delete to setOf(KeyModifier.Ctrl),
+        Key.Tab to emptySet(),
+        Key.Tab to setOf(KeyModifier.Shift),
+        Key.Escape to emptySet(),
+      )
+
+    for (platform in Platform.entries) {
+      for ((key, modifiers) in nativeBindings) {
+        assertFalse(
+          binding(platform, key, modifiers).commitCompositionBeforeDispatch,
+          "$platform $key $modifiers",
+        )
+      }
+    }
   }
 
   @Test
@@ -144,4 +183,7 @@ class EditorInputKeyHandlingTest {
       )
     )
   }
+
+  private fun binding(platform: Platform, key: Key, modifiers: Set<KeyModifier>) =
+    createBindings(platform).first { it.key == key && it.modifiers == modifiers }
 }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/input/EditorSelectionInputIntentTrackerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/input/EditorSelectionInputIntentTrackerTest.kt
@@ -64,7 +64,7 @@ class EditorSelectionInputIntentTrackerTest {
       ),
     )
 
-    tracker.recordImeMessagesCommitted(
+    tracker.recordImeMessagesApplied(
       messages = expected,
       preState = state(version = 2L, selection = ImeRange(17, 18)),
       postState = state(version = 3L, selection = ImeRange(16, 18)),

--- a/apps/mobile/compose/src/desktopMain/kotlin/co/typie/editor/input/EditorInput.desktop.kt
+++ b/apps/mobile/compose/src/desktopMain/kotlin/co/typie/editor/input/EditorInput.desktop.kt
@@ -7,22 +7,20 @@ import androidx.compose.ui.platform.PlatformTextInputMethodRequest
 import androidx.compose.ui.platform.PlatformTextInputSessionScope
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.CommitTextCommand
+import androidx.compose.ui.text.input.DeleteSurroundingTextInCodePointsCommand
 import androidx.compose.ui.text.input.EditCommand
+import androidx.compose.ui.text.input.FinishComposingTextCommand
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.ImeOptions
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.SetComposingTextCommand
 import androidx.compose.ui.text.input.TextEditingScope
 import androidx.compose.ui.text.input.TextEditorState
 import androidx.compose.ui.text.input.TextFieldValue
 import co.typie.editor.Editor
-import co.typie.editor.ffi.FlatImeOp
-import co.typie.editor.ffi.Key
-import co.typie.editor.ffi.KeyEvent
-import co.typie.editor.ffi.Message
 import co.typie.editor.scroll.EditorBringIntoViewRequests
-import co.typie.editor.scroll.EditorBringIntoViewTarget
-import co.typie.editor.scroll.updateNowWithBringIntoView
 import co.typie.platform.IncomingContentCandidates
 
 @OptIn(ExperimentalComposeUiApi::class)
@@ -84,20 +82,13 @@ internal actual suspend fun PlatformTextInputSessionScope.createEditorInputReque
           value().text.subSequence(startIndex, endIndex)
       }
 
-    override val editText: (block: TextEditingScope.() -> Unit) -> Unit = { block ->
-      editor.runInputCallback {
-        editor.updateNowWithBringIntoView(bringIntoViewRequests) {
-          val batch =
-            EditorDesktopTextEditingBatch(
-              initialHasActiveComposition = editor.appliedState.ime?.composing != null
-            )
-          batch.block()
-          for (message in batch.drainMessages()) {
-            enqueue(message)
-          }
-          afterApplied { bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead) }
-        }
-      }
+    // Desktop's AWT IME callback edits through TextEditingScope rather than onEditCommand.
+    // Adapt it to the common onEditCommand normalization and apply pipeline.
+    override val editText: (block: TextEditingScope.() -> Unit) -> Unit = editText@{ block ->
+      val batch = EditorDesktopTextEditingBatch()
+      batch.block()
+      val commands = batch.drainCommands()
+      if (commands.isNotEmpty()) onEditCommand(commands)
     }
   }
 }
@@ -111,52 +102,28 @@ internal actual fun PlatformTextInputSessionScope.notifyImeStateChanged(editor: 
 }
 
 @OptIn(ExperimentalComposeUiApi::class)
-internal class EditorDesktopTextEditingBatch(initialHasActiveComposition: Boolean = false) :
-  TextEditingScope {
-  private val messages = mutableListOf<Message>()
-  private val ops = mutableListOf<FlatImeOp>()
-  private var hasActiveComposition = initialHasActiveComposition
+internal class EditorDesktopTextEditingBatch : TextEditingScope {
+  private val commands = mutableListOf<EditCommand>()
 
   override fun commitText(text: CharSequence, newCursorPosition: Int) {
-    if (text.toString() == "\n") {
-      flushOps()
-      messages += Message.Key(KeyEvent(Key.Enter))
-    } else {
-      ops += FlatImeOp.Compose(text.toString())
-      ops += FlatImeOp.CommitAsIs
-      hasActiveComposition = false
-    }
+    commands += CommitTextCommand(text.toString(), newCursorPosition)
   }
 
   override fun setComposingText(text: CharSequence, newCursorPosition: Int) {
-    ops += FlatImeOp.Compose(text.toString())
-    hasActiveComposition = true
+    commands += SetComposingTextCommand(text.toString(), newCursorPosition)
   }
 
   override fun finishComposingText() {
-    ops +=
-      if (hasActiveComposition) {
-        FlatImeOp.CommitAsIs
-      } else {
-        FlatImeOp.ClearComposition
-      }
-    hasActiveComposition = false
+    commands += FinishComposingTextCommand()
   }
 
   override fun deleteSurroundingTextInCodePoints(lengthBeforeCursor: Int, lengthAfterCursor: Int) {
-    ops += FlatImeOp.DeleteSurrounding(lengthBeforeCursor, lengthAfterCursor)
+    commands += DeleteSurroundingTextInCodePointsCommand(lengthBeforeCursor, lengthAfterCursor)
   }
 
-  fun drainMessages(): List<Message> {
-    flushOps()
-    val drained = messages.toList()
-    messages.clear()
+  fun drainCommands(): List<EditCommand> {
+    val drained = commands.toList()
+    commands.clear()
     return drained
-  }
-
-  private fun flushOps() {
-    if (ops.isEmpty()) return
-    messages += Message.TextInput(ops.toList())
-    ops.clear()
   }
 }

--- a/apps/mobile/compose/src/desktopMain/kotlin/co/typie/editor/input/EditorPlatformInputBridge.desktop.kt
+++ b/apps/mobile/compose/src/desktopMain/kotlin/co/typie/editor/input/EditorPlatformInputBridge.desktop.kt
@@ -1,15 +1,44 @@
 package co.typie.editor.input
 
+import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.platform.PlatformTextInputSessionScope
 import androidx.compose.ui.text.input.EditCommand
 import co.typie.editor.EditorState
 import co.typie.editor.EditorViewportTransform
+import co.typie.editor.KeyModifier
 import co.typie.editor.ffi.CursorMetrics
+import co.typie.editor.ffi.FlatImeOp
 import co.typie.editor.ffi.Message
+import java.awt.KeyEventDispatcher
+import java.awt.KeyboardFocusManager
+import java.awt.event.KeyEvent as AwtKeyEvent
 import kotlinx.coroutines.CoroutineScope
 
 internal actual class EditorPlatformInputBridge actual constructor() {
+  private val pressedKeys = mutableSetOf<DesktopPhysicalKey>()
+  private var observedModifiers = emptySet<KeyModifier>()
+  private var pendingRecoveryModifiers: Set<KeyModifier>? = null
+  private var sessionActive = false
+  private var sessionEffectsGeneration = 0
+
+  // Compose may reinstall an active text-input session while a physical key stroke
+  // is still in flight. Preserve that tracking until the input session actually ends.
   actual fun reset() = Unit
+
+  actual fun setInputSessionActive(active: Boolean) {
+    sessionActive = active
+    if (!active) {
+      sessionEffectsGeneration += 1
+      pressedKeys.clear()
+      observedModifiers = emptySet()
+      pendingRecoveryModifiers = null
+    }
+  }
+
+  actual fun bindInputSession(session: PlatformTextInputSessionScope) = Unit
+
+  actual fun resetPlatformInputBeforeBindingDispatch() = Unit
 
   actual fun onPreKeyEvent(
     event: KeyEvent,
@@ -32,15 +61,89 @@ internal actual class EditorPlatformInputBridge actual constructor() {
     state: EditorState,
   ): List<Message>? = null
 
-  actual fun onImeMessagesCommitted(
+  actual fun onImeMessagesApplied(
     messages: List<Message>,
     preState: EditorState,
     postState: EditorState,
-  ) = Unit
+  ) {
+    if (!sessionActive) return
+
+    val committedComposition =
+      preState.ime?.composing != null &&
+        postState.ime?.composing == null &&
+        messages.any { message ->
+          message is Message.TextInput && message.ops.any { it == FlatImeOp.CommitAsIs }
+        }
+    pendingRecoveryModifiers =
+      if (committedComposition) {
+        observedModifiers
+      } else {
+        null
+      }
+  }
 
   actual fun installSessionEffects(
     cursor: () -> CursorMetrics?,
     viewportTransform: () -> EditorViewportTransform,
     dispatch: (List<Message>) -> Unit,
-  ): () -> Unit = {}
+    dispatchBindingOnUnmatchedKeyUp: (Key, Set<KeyModifier>) -> Boolean,
+  ): () -> Unit {
+    val focusManager = KeyboardFocusManager.getCurrentKeyboardFocusManager()
+    val generation = ++sessionEffectsGeneration
+    val keyEventDispatcher = KeyEventDispatcher { event ->
+      if (!sessionActive || generation != sessionEffectsGeneration) {
+        return@KeyEventDispatcher false
+      }
+
+      val physicalKey = event.toDesktopPhysicalKey()
+      when (event.id) {
+        AwtKeyEvent.KEY_PRESSED -> {
+          pendingRecoveryModifiers = null
+          pressedKeys += physicalKey
+          observedModifiers = event.toKeyModifiers()
+          false
+        }
+        AwtKeyEvent.KEY_RELEASED -> {
+          observedModifiers = event.toKeyModifiers()
+          if (pressedKeys.remove(physicalKey)) {
+            false
+          } else {
+            val recoveryModifiers = pendingRecoveryModifiers ?: return@KeyEventDispatcher false
+            pendingRecoveryModifiers = null
+            // JVM IMEs can commit composition while consuming the triggering KeyDown, then
+            // still deliver KeyUp through AWT. Recover only after that commit was observed,
+            // using its modifier snapshot so modifier-first release order remains valid.
+            dispatchBindingOnUnmatchedKeyUp(
+              Key(physicalKey.code, physicalKey.location),
+              recoveryModifiers,
+            )
+          }
+        }
+        else -> false
+      }
+    }
+
+    focusManager.addKeyEventDispatcher(keyEventDispatcher)
+    return { focusManager.removeKeyEventDispatcher(keyEventDispatcher) }
+  }
+}
+
+private data class DesktopPhysicalKey(val code: Int, val location: Int)
+
+private fun AwtKeyEvent.toDesktopPhysicalKey(): DesktopPhysicalKey =
+  DesktopPhysicalKey(
+    code = keyCode,
+    location =
+      if (keyLocation == AwtKeyEvent.KEY_LOCATION_UNKNOWN) {
+        AwtKeyEvent.KEY_LOCATION_STANDARD
+      } else {
+        keyLocation
+      },
+  )
+
+private fun AwtKeyEvent.toKeyModifiers(): Set<KeyModifier> = buildSet {
+  if (isShiftDown) add(KeyModifier.Shift)
+  if (isMetaDown) add(KeyModifier.Mod)
+  if (isControlDown) add(KeyModifier.Ctrl)
+  if (isAltDown) add(KeyModifier.Alt)
 }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/input/EditorDesktopTextEditingBatchTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/input/EditorDesktopTextEditingBatchTest.kt
@@ -1,82 +1,40 @@
 package co.typie.editor.input
 
-import co.typie.editor.ffi.FlatImeOp
-import co.typie.editor.ffi.Key
-import co.typie.editor.ffi.KeyEvent
-import co.typie.editor.ffi.Message
+import androidx.compose.ui.text.input.CommitTextCommand
+import androidx.compose.ui.text.input.DeleteSurroundingTextInCodePointsCommand
+import androidx.compose.ui.text.input.FinishComposingTextCommand
+import androidx.compose.ui.text.input.SetComposingTextCommand
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class EditorDesktopTextEditingBatchTest {
   @Test
-  fun `delete and compose are batched as one flat ime message`() {
+  fun `text editing scope calls are forwarded as edit commands in order`() {
     val batch = EditorDesktopTextEditingBatch()
 
-    batch.deleteSurroundingTextInCodePoints(1, 0)
-    batch.setComposingText("하", 1)
+    batch.deleteSurroundingTextInCodePoints(1, 2)
+    batch.setComposingText("하", 3)
+    batch.finishComposingText()
+    batch.commitText("foo\r\nbar", 4)
 
     assertEquals(
-      listOf(Message.TextInput(listOf(FlatImeOp.DeleteSurrounding(1, 0), FlatImeOp.Compose("하")))),
-      batch.drainMessages(),
+      listOf(
+        DeleteSurroundingTextInCodePointsCommand(1, 2),
+        SetComposingTextCommand("하", 3),
+        FinishComposingTextCommand(),
+        CommitTextCommand("foo\r\nbar", 4),
+      ),
+      batch.drainCommands(),
     )
   }
 
   @Test
-  fun `newline commit flushes pending flat ops before enter`() {
-    val batch = EditorDesktopTextEditingBatch()
-
-    batch.setComposingText("ㅎ", 1)
-    batch.commitText("\n", 1)
-
-    assertEquals(
-      listOf(Message.TextInput(listOf(FlatImeOp.Compose("ㅎ"))), Message.Key(KeyEvent(Key.Enter))),
-      batch.drainMessages(),
-    )
-  }
-
-  @Test
-  fun `text commit uses composition replacement and commits composition`() {
+  fun `draining commands clears the batch`() {
     val batch = EditorDesktopTextEditingBatch()
 
     batch.commitText("하", 1)
 
-    assertEquals(
-      listOf(Message.TextInput(listOf(FlatImeOp.Compose("하"), FlatImeOp.CommitAsIs))),
-      batch.drainMessages(),
-    )
-  }
-
-  @Test
-  fun `finish composing text clears composition without active preedit`() {
-    val batch = EditorDesktopTextEditingBatch()
-
-    batch.finishComposingText()
-
-    assertEquals(
-      listOf(Message.TextInput(listOf(FlatImeOp.ClearComposition))),
-      batch.drainMessages(),
-    )
-  }
-
-  @Test
-  fun `finish composing text commits initial active preedit as-is`() {
-    val batch = EditorDesktopTextEditingBatch(initialHasActiveComposition = true)
-
-    batch.finishComposingText()
-
-    assertEquals(listOf(Message.TextInput(listOf(FlatImeOp.CommitAsIs))), batch.drainMessages())
-  }
-
-  @Test
-  fun `finish composing text commits preedit started in same batch`() {
-    val batch = EditorDesktopTextEditingBatch()
-
-    batch.setComposingText("ㅎ", 1)
-    batch.finishComposingText()
-
-    assertEquals(
-      listOf(Message.TextInput(listOf(FlatImeOp.Compose("ㅎ"), FlatImeOp.CommitAsIs))),
-      batch.drainMessages(),
-    )
+    assertEquals(listOf(CommitTextCommand("하", 1)), batch.drainCommands())
+    assertEquals(emptyList(), batch.drainCommands())
   }
 }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/input/EditorInputCompositionKeyDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/input/EditorInputCompositionKeyDesktopTest.kt
@@ -61,11 +61,15 @@ class EditorInputCompositionKeyDesktopTest {
   }
 
   @Test
-  fun `desktop navigation key during composition stays blocked`() {
+  fun `desktop navigation key during composition commits preedit then moves`() {
     runCompositionKeyTest(
       platform = Platform.Desktop,
       key = Key.DirectionRight,
-      expectEnqueued = null,
+      expectEnqueued =
+        listOf(
+          Message.TextInput(listOf(FlatImeOp.CommitAsIs)),
+          Message.Navigation(NavigationOp.Move(Movement.Grapheme(Direction.Forward), false)),
+        ),
     )
   }
 

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/input/EditorInputEnabledDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/input/EditorInputEnabledDesktopTest.kt
@@ -17,9 +17,19 @@ import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.dp
 import co.typie.editor.Editor
 import co.typie.editor.FakeFfiEditor
+import co.typie.editor.ffi.Break
+import co.typie.editor.ffi.Direction
+import co.typie.editor.ffi.FlatImeOp
+import co.typie.editor.ffi.Ime
+import co.typie.editor.ffi.ImeRange
+import co.typie.editor.ffi.InsertionOp
 import co.typie.editor.ffi.Key as FfiKey
 import co.typie.editor.ffi.KeyEvent as FfiKeyEvent
 import co.typie.editor.ffi.Message
+import co.typie.editor.ffi.ModifierOp
+import co.typie.editor.ffi.ModifierType
+import co.typie.editor.ffi.Movement
+import co.typie.editor.ffi.NavigationOp
 import co.typie.editor.runtime.EditorUiState
 import co.typie.editor.scroll.LocalEditorBringIntoViewRequests
 import co.typie.editor.scroll.rememberEditorBringIntoViewRequests
@@ -30,6 +40,7 @@ import co.typie.platform.IncomingContentMode
 import co.typie.platform.NoopClipboard
 import co.typie.platform.Platform
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlinx.coroutines.CompletableDeferred
@@ -40,6 +51,96 @@ import kotlinx.coroutines.cancel
 
 @OptIn(ExperimentalTestApi::class)
 class EditorInputEnabledDesktopTest {
+  @Test
+  fun navigationAndShortcutsCommitCompositionBeforeDispatch() = runComposeUiTest {
+    val composingIme =
+      Ime(text = "한", windowStart = 0, selection = ImeRange(1, 1), composing = ImeRange(0, 1))
+    val fake = FakeFfiEditor(imeProvider = { _, _ -> composingIme })
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val editor = Editor(fake, scope)
+    val session = createTestDocumentEditingSession(editor, scope)
+
+    try {
+      editor.setImeSessionActive(true)
+      editor.refreshImeSnapshot()
+
+      setContent {
+        val focusRequester = remember { FocusRequester() }
+        val bringIntoViewRequests = rememberEditorBringIntoViewRequests()
+        Box(
+          Modifier.size(200.dp)
+            .testTag(InputTag)
+            .focusRequester(focusRequester)
+            .editorInput(
+              session = session,
+              uiState = EditorUiState(),
+              platform = Platform.Desktop,
+              bringIntoViewRequests = bringIntoViewRequests,
+              enabled = true,
+              suppressSoftwareKeyboard = true,
+              clipboard = NoopClipboard,
+            )
+            .focusable()
+        )
+        LaunchedEffect(Unit) { focusRequester.requestFocus() }
+      }
+      waitForIdle()
+      fake.enqueued.clear()
+
+      onNodeWithTag(InputTag).performKeyInput {
+        keyDown(Key.MetaLeft)
+        keyDown(Key.Enter)
+        keyUp(Key.Enter)
+        keyUp(Key.MetaLeft)
+      }
+      waitUntil(timeoutMillis = 5_000) {
+        fake.enqueued.any { it == Message.Insertion(InsertionOp.Break(Break.Page)) }
+      }
+
+      assertEquals(
+        listOf(
+          Message.TextInput(listOf(FlatImeOp.CommitAsIs)),
+          Message.Insertion(InsertionOp.Break(Break.Page)),
+        ),
+        fake.enqueued.filter {
+          it is Message.TextInput || it == Message.Insertion(InsertionOp.Break(Break.Page))
+        },
+      )
+
+      editor.refreshImeSnapshot()
+      fake.enqueued.clear()
+      onNodeWithTag(InputTag).performKeyInput {
+        keyDown(Key.DirectionLeft)
+        keyUp(Key.DirectionLeft)
+      }
+      val moveLeft =
+        Message.Navigation(NavigationOp.Move(Movement.Grapheme(Direction.Backward), extend = false))
+      waitUntil(timeoutMillis = 5_000) { fake.enqueued.any { it == moveLeft } }
+      assertEquals(
+        listOf(Message.TextInput(listOf(FlatImeOp.CommitAsIs)), moveLeft),
+        fake.enqueued.filter { it is Message.TextInput || it == moveLeft },
+      )
+
+      editor.refreshImeSnapshot()
+      fake.enqueued.clear()
+      onNodeWithTag(InputTag).performKeyInput {
+        keyDown(Key.MetaLeft)
+        keyDown(Key.B)
+        keyUp(Key.B)
+        keyUp(Key.MetaLeft)
+      }
+      val toggleBold = Message.Modifier(ModifierOp.Toggle(ModifierType.Bold))
+      waitUntil(timeoutMillis = 5_000) { fake.enqueued.any { it == toggleBold } }
+      assertEquals(
+        listOf(Message.TextInput(listOf(FlatImeOp.CommitAsIs)), toggleBold),
+        fake.enqueued.filter { it is Message.TextInput || it == toggleBold },
+      )
+    } finally {
+      session.stop()
+      scope.cancel()
+    }
+  }
+
   @Test
   fun laterKeyWaitsForPasteReadQueuedFromTheSameInputCallback() = runComposeUiTest {
     val fake = FakeFfiEditor()

--- a/apps/mobile/compose/src/iosMain/kotlin/co/typie/editor/input/EditorPlatformInputBridge.ios.kt
+++ b/apps/mobile/compose/src/iosMain/kotlin/co/typie/editor/input/EditorPlatformInputBridge.ios.kt
@@ -10,9 +10,11 @@ import androidx.compose.ui.input.key.isCtrlPressed
 import androidx.compose.ui.input.key.isMetaPressed
 import androidx.compose.ui.input.key.isShiftPressed
 import androidx.compose.ui.input.key.key
+import androidx.compose.ui.platform.PlatformTextInputSessionScope
 import androidx.compose.ui.text.input.EditCommand
 import co.typie.editor.EditorState
 import co.typie.editor.EditorViewportTransform
+import co.typie.editor.KeyModifier
 import co.typie.editor.ffi.CursorMetrics
 import co.typie.editor.ffi.Message
 import kotlin.time.Clock
@@ -33,6 +35,12 @@ internal actual class EditorPlatformInputBridge actual constructor() {
     selectionIntentTracker.reset()
     floatingCursorSession.end()
   }
+
+  actual fun setInputSessionActive(active: Boolean) = Unit
+
+  actual fun bindInputSession(session: PlatformTextInputSessionScope) = Unit
+
+  actual fun resetPlatformInputBeforeBindingDispatch() = Unit
 
   actual fun onPreKeyEvent(
     event: KeyEvent,
@@ -105,12 +113,12 @@ internal actual class EditorPlatformInputBridge actual constructor() {
     }
   }
 
-  actual fun onImeMessagesCommitted(
+  actual fun onImeMessagesApplied(
     messages: List<Message>,
     preState: EditorState,
     postState: EditorState,
   ) {
-    selectionIntentTracker.recordImeMessagesCommitted(
+    selectionIntentTracker.recordImeMessagesApplied(
       messages = messages,
       preState = preState,
       postState = postState,
@@ -122,6 +130,7 @@ internal actual class EditorPlatformInputBridge actual constructor() {
     cursor: () -> CursorMetrics?,
     viewportTransform: () -> EditorViewportTransform,
     dispatch: (List<Message>) -> Unit,
+    dispatchBindingOnUnmatchedKeyUp: (Key, Set<KeyModifier>) -> Boolean,
   ): () -> Unit {
     val traitsGeneration = EditorTextInputTraitsBridge.install()
     val uninstall =

--- a/apps/website/src/lib/editor-ffi/components/Input.svelte
+++ b/apps/website/src/lib/editor-ffi/components/Input.svelte
@@ -4,7 +4,7 @@
   import { getEditorContext } from '$lib/editor-ffi/editor.svelte';
   import { pageRectToClientRect } from '../geometry';
   import { handle } from '../handlers';
-  import { handleCopy, handleCut, handlePaste } from '../handlers/clipboard';
+  import { deferPasteShortcutDuringComposition, handleCopy, handleCut, handlePaste, requestPaste } from '../handlers/clipboard';
   import { handleKeyDown } from '../handlers/keyboard';
   import { IME_CONTEXT_AFTER_LIMIT, IME_CONTEXT_BEFORE_LIMIT, normalizeImeContext } from '../input/ime-context';
   import { ImeInputAdapter } from '../input/ime-input-adapter';
@@ -41,6 +41,10 @@
     readContext: readEditorImeContext,
     enqueue: enqueueMessages,
   });
+  let pendingCompositionDispatch: (() => void) | undefined;
+  const handlePasteFailure = ({ file, kind }: { file: File; kind: 'image' | 'file' }) => {
+    Toast.error(`${file.name} ${kind === 'image' ? '이미지' : '파일'} 업로드에 실패했습니다.`);
+  };
 
   const syncInput = () => {
     if (!editor?.inputEl || editor.terminal) return;
@@ -76,7 +80,20 @@
   $effect(() => {
     if (!editor || editor.terminal) return;
 
-    return wireImeResyncListener(editor, inputAdapter, () => editor.inputEl ?? null);
+    return wireImeResyncListener(
+      editor,
+      inputAdapter,
+      () => editor.inputEl ?? null,
+      () => {
+        pendingCompositionDispatch = undefined;
+      },
+    );
+  });
+
+  $effect(() => {
+    if (editor?.readOnly) {
+      pendingCompositionDispatch = undefined;
+    }
   });
 </script>
 
@@ -101,12 +118,24 @@
       if (editor.readOnly) return;
       editor.updateNow(() => inputAdapter.handleBeforeInput(e as InputEvent & { currentTarget: ImeTextInput }));
     }}
+    onblur={() => {
+      pendingCompositionDispatch = undefined;
+    }}
     oncompositionend={() => {
-      if (editor.readOnly) return;
-      inputAdapter.handleCompositionEnd();
+      if (editor.readOnly) {
+        pendingCompositionDispatch = undefined;
+        return;
+      }
+      const committed = inputAdapter.handleCompositionEnd();
+      const action = pendingCompositionDispatch;
+      pendingCompositionDispatch = undefined;
+      if (committed) {
+        action?.();
+      }
     }}
     oncompositionstart={(e) => {
       if (editor.readOnly) return;
+      pendingCompositionDispatch = undefined;
       inputAdapter.handleCompositionStart(e as CompositionEvent & { currentTarget: ImeTextInput });
     }}
     oncompositionupdate={(e) => {
@@ -130,16 +159,25 @@
       if (editor.readOnly && e.key.length === 1 && !e.ctrlKey && !e.metaKey) {
         editor.editBlockedHandler?.();
       }
-      editor.updateNow(() => handleKeyDown(editor, e));
+      editor.updateNow(() => {
+        pendingCompositionDispatch =
+          deferPasteShortcutDuringComposition(
+            e,
+            () => {
+              void requestPaste(ctx, handlePasteFailure);
+            },
+            () => {
+              void editor.requestPasteTextOnly();
+            },
+          ) ?? handleKeyDown(editor, e);
+      });
     }}
     onpaste={(e) => {
       if (editor.readOnly) {
         editor.editBlockedHandler?.();
         return;
       }
-      handlePaste(ctx, e, ({ file, kind }) => {
-        Toast.error(`${file.name} ${kind === 'image' ? '이미지' : '파일'} 업로드에 실패했습니다.`);
-      });
+      handlePaste(ctx, e, handlePasteFailure);
     }}
     readonly={editor.readOnly}
     spellcheck={false}></textarea>

--- a/apps/website/src/lib/editor-ffi/handlers/clipboard.test.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/clipboard.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { handlePaste, requestPaste } from './clipboard';
+import { deferPasteShortcutDuringComposition, handlePaste, requestPaste } from './clipboard';
 import type { Message } from '@typie/editor-ffi/browser';
 import type { AttachmentImportFailureHandler, AttachmentImportItem } from '../attachment-importer';
 
@@ -184,6 +184,68 @@ describe('native paste arbitration', () => {
     expect(editor.enqueue).not.toHaveBeenCalled();
     expect(event.preventDefault).toHaveBeenCalledOnce();
     expect(editor.scrollIntoView).not.toHaveBeenCalled();
+  });
+});
+
+describe('composition paste fallback', () => {
+  it('defers a composing Mod+V while leaving ordinary paste to the native event', () => {
+    const isMac = navigator.platform.toUpperCase().includes('MAC');
+    const requestPaste = vi.fn();
+    const composing = {
+      key: 'v',
+      code: 'KeyV',
+      isComposing: true,
+      shiftKey: false,
+      altKey: false,
+      ctrlKey: !isMac,
+      metaKey: isMac,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    } as unknown as KeyboardEvent;
+
+    const deferred = deferPasteShortcutDuringComposition(composing, requestPaste, vi.fn());
+
+    expect(deferred).toBeTypeOf('function');
+    expect(requestPaste).not.toHaveBeenCalled();
+    expect(composing.preventDefault).toHaveBeenCalledOnce();
+    expect(composing.stopPropagation).toHaveBeenCalledOnce();
+
+    deferred?.();
+
+    expect(requestPaste).toHaveBeenCalledOnce();
+
+    const ordinary = { ...composing, isComposing: false } as unknown as KeyboardEvent;
+    expect(deferPasteShortcutDuringComposition(ordinary, requestPaste, vi.fn())).toBeUndefined();
+  });
+
+  it('defers a composing Mod+Shift+V as text-only paste', () => {
+    const isMac = navigator.platform.toUpperCase().includes('MAC');
+    const requestPaste = vi.fn();
+    const requestPasteTextOnly = vi.fn();
+    const composing = {
+      key: 'V',
+      code: 'KeyV',
+      isComposing: true,
+      shiftKey: true,
+      altKey: false,
+      ctrlKey: !isMac,
+      metaKey: isMac,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    } as unknown as KeyboardEvent;
+
+    const deferred = deferPasteShortcutDuringComposition(composing, requestPaste, requestPasteTextOnly);
+
+    expect(deferred).toBeTypeOf('function');
+    expect(requestPaste).not.toHaveBeenCalled();
+    expect(requestPasteTextOnly).not.toHaveBeenCalled();
+    expect(composing.preventDefault).toHaveBeenCalledOnce();
+    expect(composing.stopPropagation).toHaveBeenCalledOnce();
+
+    deferred?.();
+
+    expect(requestPaste).not.toHaveBeenCalled();
+    expect(requestPasteTextOnly).toHaveBeenCalledOnce();
   });
 });
 

--- a/apps/website/src/lib/editor-ffi/handlers/clipboard.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/clipboard.ts
@@ -48,6 +48,25 @@ export const handleCut: EditorEventHandler<ImeTextInput, ClipboardEvent> = (edit
   editor.scrollIntoView({ target: { type: 'current_selection_head' }, mode: 'nearest' });
 };
 
+export const deferPasteShortcutDuringComposition = (
+  e: KeyboardEvent,
+  requestPaste: () => void,
+  requestPasteTextOnly: () => void,
+): (() => void) | undefined => {
+  if (!e.isComposing || e.altKey) return;
+
+  const isMac = navigator.platform.toUpperCase().includes('MAC');
+  const hasMod = isMac ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey;
+  if (!hasMod || (e.code !== 'KeyV' && e.key.toLowerCase() !== 'v' && e.key !== 'ㅍ')) return;
+
+  // Some IMEs consume the first paste shortcut to commit preedit without emitting
+  // a ClipboardEvent. Preserve the native paste-event path outside composition,
+  // and recover only this missing event after the composition commit is applied.
+  e.preventDefault();
+  e.stopPropagation();
+  return e.shiftKey ? requestPasteTextOnly : requestPaste;
+};
+
 const toImportItem = (file: File): AttachmentImportItem => ({
   file,
   kind: file.type.startsWith('image/') ? 'image' : 'file',

--- a/apps/website/src/lib/editor-ffi/handlers/keyboard.test.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/keyboard.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest';
+import { handleKeyDown } from './keyboard';
+import type { Message } from '@typie/editor-ffi/browser';
+import type { Editor } from '../editor.svelte';
+
+const createEditor = (messages: Message[]) =>
+  ({
+    enqueue: vi.fn((message: Message) => {
+      messages.push(message);
+    }),
+    scrollIntoView: vi.fn(),
+  }) as unknown as Editor;
+
+type TestKeyboardEvent = KeyboardEvent & { currentTarget: HTMLTextAreaElement };
+
+const composingEvent = (
+  key: string,
+  modifiers: { shift?: boolean; mod?: boolean; ctrl?: boolean; alt?: boolean } = {},
+): TestKeyboardEvent => {
+  const isMac = navigator.platform.toUpperCase().includes('MAC');
+  return {
+    key,
+    isComposing: true,
+    shiftKey: modifiers.shift ?? false,
+    altKey: modifiers.alt ?? false,
+    ctrlKey: modifiers.ctrl ?? (modifiers.mod === true && !isMac),
+    metaKey: modifiers.mod === true && isMac,
+    currentTarget: document.createElement('textarea'),
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+  } as unknown as TestKeyboardEvent;
+};
+
+describe('handleKeyDown', () => {
+  it('leaves composing navigation to the native post-composition keydown', () => {
+    const messages: Message[] = [];
+    const editor = createEditor(messages);
+    const composing = composingEvent('ArrowLeft');
+
+    expect(handleKeyDown(editor, composing)).toBeUndefined();
+    expect(messages).toEqual([]);
+    expect(composing.preventDefault).not.toHaveBeenCalled();
+    expect(composing.stopPropagation).not.toHaveBeenCalled();
+
+    const postComposition = { ...composing, isComposing: false } as TestKeyboardEvent;
+    handleKeyDown(editor, postComposition);
+
+    expect(messages).toEqual([
+      {
+        type: 'navigation',
+        op: {
+          type: 'move',
+          movement: { type: 'grapheme', direction: 'backward' },
+          extend: false,
+        },
+      },
+    ]);
+    expect(postComposition.preventDefault).toHaveBeenCalledOnce();
+    expect(postComposition.stopPropagation).toHaveBeenCalledOnce();
+  });
+
+  it('defers and consumes a composing editor shortcut', () => {
+    const messages: Message[] = [];
+    const editor = createEditor(messages);
+    const event = composingEvent('b', { mod: true });
+
+    const pending = handleKeyDown(editor, event);
+
+    expect(pending).toBeTypeOf('function');
+    expect(messages).toEqual([]);
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+    expect(event.stopPropagation).toHaveBeenCalledOnce();
+
+    messages.push({ type: 'text_input', ops: [{ type: 'commit_as_is' }] });
+    pending?.();
+
+    expect(messages).toEqual([
+      { type: 'text_input', ops: [{ type: 'commit_as_is' }] },
+      { type: 'modifier', op: { type: 'toggle', modifier_type: 'bold' } },
+    ]);
+  });
+
+  it.each(['Tab', 'Escape'])('leaves composing %s to native text input', (key) => {
+    const messages: Message[] = [];
+    const editor = createEditor(messages);
+    const event = composingEvent(key);
+
+    expect(handleKeyDown(editor, event)).toBeUndefined();
+    expect(messages).toEqual([]);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(event.stopPropagation).not.toHaveBeenCalled();
+  });
+
+  it('defers Mod+Enter until after the active composition is committed', () => {
+    const messages: Message[] = [];
+    const editor = createEditor(messages);
+    const event = composingEvent('Enter', { mod: true });
+
+    const pending = handleKeyDown(editor, event);
+
+    expect(pending).toBeTypeOf('function');
+    expect(messages).toEqual([]);
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+    expect(event.stopPropagation).toHaveBeenCalledOnce();
+
+    messages.push({ type: 'text_input', ops: [{ type: 'commit_as_is' }] });
+    pending?.();
+
+    expect(messages).toEqual([
+      { type: 'text_input', ops: [{ type: 'commit_as_is' }] },
+      { type: 'insertion', op: { type: 'break', kind: 'page' } },
+    ]);
+  });
+});

--- a/apps/website/src/lib/editor-ffi/handlers/keyboard.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/keyboard.ts
@@ -3,7 +3,6 @@ import type { Message, Movement } from '@typie/editor-ffi/browser';
 import type { Editor } from '../editor.svelte';
 import type { ImeTextInput } from '../input/ime-context';
 import type { EditorScrollIntoViewOptions } from '../scroll.svelte';
-import type { EditorEventHandler } from '../types';
 
 type KeyBindingModifier = 'shift' | 'mod' | 'ctrl' | 'alt';
 
@@ -11,6 +10,8 @@ type KeyBinding = {
   key: string | string[];
   modifiers?: KeyBindingModifier[];
   predicate?: (e: KeyboardEvent) => boolean;
+  commitCompositionBeforeDispatch?: boolean;
+  consumeKeyDownDuringComposition?: boolean;
   reveal?: () => EditorScrollIntoViewOptions;
   action: (editor: Editor, e: KeyboardEvent) => void;
 };
@@ -29,10 +30,20 @@ const currentSelectionHeadTypewriterReveal = (): EditorScrollIntoViewOptions => 
 const withCurrentSelectionHeadReveal = (bindings: KeyBinding[]): KeyBinding[] =>
   bindings.map((binding) => ({ ...binding, reveal: currentSelectionHeadTypewriterReveal }));
 
+const withCompositionCommitBeforeDispatch = (bindings: KeyBinding[], consumeKeyDownDuringComposition = false): KeyBinding[] =>
+  bindings.map((binding) => ({
+    ...binding,
+    commitCompositionBeforeDispatch: true,
+    consumeKeyDownDuringComposition,
+  }));
+
 // NOTE: Plain Backspace, Delete, and Enter also arrive through beforeinput in Input.svelte
 // as deleteContentBackward, deleteContentForward, insertParagraph, or insertLineBreak.
 // These bindings own the hardware-key path; beforeinput remains the browser input fallback.
 const bindings: KeyBinding[] = [
+  // Browsers may finish a simple-conversion IME and then dispatch a non-composing
+  // keydown for the same navigation key. Replaying the composing keydown here
+  // would move twice, so navigation stays owned by that native follow-up event.
   ...withCurrentSelectionHeadReveal([
     { key: 'ArrowLeft', action: (ed) => ed.enqueue(move({ type: 'grapheme', direction: 'backward' }, false)) },
     { key: 'ArrowLeft', modifiers: ['shift'], action: (ed) => ed.enqueue(move({ type: 'grapheme', direction: 'backward' }, true)) },
@@ -149,7 +160,9 @@ const bindings: KeyBinding[] = [
 
     { key: 'PageDown', action: (ed) => ed.enqueue(move({ type: 'page', direction: 'forward' }, false)) },
     { key: 'PageDown', modifiers: ['shift'], action: (ed) => ed.enqueue(move({ type: 'page', direction: 'forward' }, true)) },
+  ]),
 
+  ...withCurrentSelectionHeadReveal([
     { key: 'Enter', action: (ed) => ed.enqueue({ type: 'key', event: { key: 'enter' } }) },
     {
       key: 'Enter',
@@ -159,6 +172,8 @@ const bindings: KeyBinding[] = [
     {
       key: 'Enter',
       modifiers: ['mod'],
+      commitCompositionBeforeDispatch: true,
+      consumeKeyDownDuringComposition: true,
       action: (ed) => ed.enqueue({ type: 'insertion', op: { type: 'break', kind: 'page' } }),
     },
 
@@ -192,55 +207,60 @@ const bindings: KeyBinding[] = [
     },
   ]),
 
-  {
-    key: 'a',
-    modifiers: ['mod'],
-    action: (ed) => ed.enqueue({ type: 'selection', op: { type: 'expand', unit: 'all' } }),
-  },
+  ...withCompositionCommitBeforeDispatch(
+    [
+      {
+        key: 'a',
+        modifiers: ['mod'],
+        action: (ed) => ed.enqueue({ type: 'selection', op: { type: 'expand', unit: 'all' } }),
+      },
 
-  {
-    key: 'b',
-    modifiers: ['mod'],
-    action: (ed) => ed.enqueue({ type: 'modifier', op: { type: 'toggle', modifier_type: 'bold' } }),
-  },
-  {
-    key: 'i',
-    modifiers: ['mod'],
-    action: (ed) => ed.enqueue({ type: 'modifier', op: { type: 'toggle', modifier_type: 'italic' } }),
-  },
-  {
-    key: 's',
-    modifiers: ['mod', 'shift'],
-    action: (ed) => ed.enqueue({ type: 'modifier', op: { type: 'toggle', modifier_type: 'strikethrough' } }),
-  },
-  {
-    key: 'u',
-    modifiers: ['mod'],
-    action: (ed) => ed.enqueue({ type: 'modifier', op: { type: 'toggle', modifier_type: 'underline' } }),
-  },
-  {
-    key: '\\',
-    modifiers: ['mod'],
-    action: (ed) => ed.enqueue({ type: 'modifier', op: { type: 'clear_all' } }),
-  },
+      {
+        key: 'b',
+        modifiers: ['mod'],
+        action: (ed) => ed.enqueue({ type: 'modifier', op: { type: 'toggle', modifier_type: 'bold' } }),
+      },
+      {
+        key: 'i',
+        modifiers: ['mod'],
+        action: (ed) => ed.enqueue({ type: 'modifier', op: { type: 'toggle', modifier_type: 'italic' } }),
+      },
+      {
+        key: 's',
+        modifiers: ['mod', 'shift'],
+        action: (ed) => ed.enqueue({ type: 'modifier', op: { type: 'toggle', modifier_type: 'strikethrough' } }),
+      },
+      {
+        key: 'u',
+        modifiers: ['mod'],
+        action: (ed) => ed.enqueue({ type: 'modifier', op: { type: 'toggle', modifier_type: 'underline' } }),
+      },
+      {
+        key: '\\',
+        modifiers: ['mod'],
+        action: (ed) => ed.enqueue({ type: 'modifier', op: { type: 'clear_all' } }),
+      },
 
-  { key: 'z', modifiers: ['mod'], action: (ed) => ed.enqueue({ type: 'history', op: { type: 'undo' } }) },
-  { key: 'z', modifiers: ['mod', 'shift'], action: (ed) => ed.enqueue({ type: 'history', op: { type: 'redo' } }) },
-  {
-    key: 'y',
-    modifiers: ['mod'],
-    predicate: () => !isMac,
-    action: (ed) => ed.enqueue({ type: 'history', op: { type: 'redo' } }),
-  },
+      { key: 'z', modifiers: ['mod'], action: (ed) => ed.enqueue({ type: 'history', op: { type: 'undo' } }) },
+      { key: 'z', modifiers: ['mod', 'shift'], action: (ed) => ed.enqueue({ type: 'history', op: { type: 'redo' } }) },
+      {
+        key: 'y',
+        modifiers: ['mod'],
+        predicate: () => !isMac,
+        action: (ed) => ed.enqueue({ type: 'history', op: { type: 'redo' } }),
+      },
 
-  { key: ['q', 'ㅂ'], modifiers: ['ctrl'], predicate: macOnly, action: (ed) => ed.inspect('state') },
-  { key: ['w', 'ㅈ'], modifiers: ['ctrl'], predicate: macOnly, action: (ed) => ed.inspect('state-as-macro') },
-  {
-    key: ['s', 'ㄴ'],
-    modifiers: ['ctrl'],
-    predicate: macOnly,
-    action: (ed) => ed.inspect('selection-as-slice-macro'),
-  },
+      { key: ['q', 'ㅂ'], modifiers: ['ctrl'], predicate: macOnly, action: (ed) => ed.inspect('state') },
+      { key: ['w', 'ㅈ'], modifiers: ['ctrl'], predicate: macOnly, action: (ed) => ed.inspect('state-as-macro') },
+      {
+        key: ['s', 'ㄴ'],
+        modifiers: ['ctrl'],
+        predicate: macOnly,
+        action: (ed) => ed.inspect('selection-as-slice-macro'),
+      },
+    ],
+    true,
+  ),
 ];
 
 const move = (movement: Movement, extend: boolean): Message => ({
@@ -276,8 +296,25 @@ const matchBinding = (binding: KeyBinding, e: KeyboardEvent): boolean => {
   return true;
 };
 
-export const handleKeyDown: EditorEventHandler<ImeTextInput, KeyboardEvent> = (editor, e) => {
-  if (e.isComposing) return;
+const runBinding = (editor: Editor, binding: KeyBinding, e: KeyboardEvent): void => {
+  binding.action(editor, e);
+  const reveal = binding.reveal?.();
+  if (reveal) editor.scrollIntoView(reveal);
+};
+
+export const handleKeyDown = (editor: Editor, e: KeyboardEvent & { currentTarget: ImeTextInput }): (() => void) | undefined => {
+  const binding = bindings.find((candidate) => matchBinding(candidate, e));
+  if (e.isComposing) {
+    // Unmarked bindings, notably Tab and Escape, stay owned by native text input.
+    // Replaying them could steal an IME command or duplicate work the platform already handled.
+    if (!binding?.commitCompositionBeforeDispatch) return;
+
+    if (binding.consumeKeyDownDuringComposition) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+    return () => runBinding(editor, binding, e);
+  }
 
   if (e.key === 'Escape' && runEscapeStack()) {
     e.preventDefault();
@@ -285,12 +322,9 @@ export const handleKeyDown: EditorEventHandler<ImeTextInput, KeyboardEvent> = (e
     return;
   }
 
-  const binding = bindings.find((b) => matchBinding(b, e));
   if (binding) {
     e.preventDefault();
     e.stopPropagation();
-    binding.action(editor, e);
-    const reveal = binding.reveal?.();
-    if (reveal) editor.scrollIntoView(reveal);
+    runBinding(editor, binding, e);
   }
 };

--- a/apps/website/src/lib/editor-ffi/input/ime-input-adapter.test.ts
+++ b/apps/website/src/lib/editor-ffi/input/ime-input-adapter.test.ts
@@ -574,7 +574,7 @@ describe('ImeInputAdapter', () => {
     adapter.handleInput(inputEvent(input));
     expect(input.value).toBe('かな');
 
-    adapter.handleCompositionEnd();
+    expect(adapter.handleCompositionEnd()).toBe(true);
 
     expect(messages).toEqual([
       {
@@ -1284,7 +1284,7 @@ describe('ImeInputAdapter', () => {
       input.value = 'garbage';
       input.setSelectionRange(7, 7);
       adapter.handleInput(inputEvent(input));
-      adapter.handleCompositionEnd();
+      expect(adapter.handleCompositionEnd()).toBe(false);
     });
 
     messages.length = 0;

--- a/apps/website/src/lib/editor-ffi/input/ime-input-adapter.ts
+++ b/apps/website/src/lib/editor-ffi/input/ime-input-adapter.ts
@@ -447,9 +447,9 @@ export class ImeInputAdapter {
     this.#pendingCompositionText = e.data;
   }
 
-  handleCompositionEnd(): void {
+  handleCompositionEnd(): boolean {
     if (this.#resyncInProgress) {
-      return;
+      return false;
     }
 
     this.#compositionActive = false;
@@ -467,7 +467,8 @@ export class ImeInputAdapter {
       const messages: Message[] = [{ type: 'text_input', ops: [{ type: 'commit_as_is' }] }];
       this.#deps.enqueue(messages);
       this.#setCommitPending(committedText);
-      return;
+      return true;
     }
+    return false;
   }
 }

--- a/apps/website/src/lib/editor-ffi/input/ime-resync.test.ts
+++ b/apps/website/src/lib/editor-ffi/input/ime-resync.test.ts
@@ -30,10 +30,12 @@ describe('wireImeResyncListener', () => {
     const editor = createFakeEditor();
     const input = document.createElement('textarea');
     const adapter = { resetForResync: vi.fn() };
+    const onResync = vi.fn();
 
-    const cleanup = wireImeResyncListener(editor as unknown as Editor, adapter as unknown as ImeInputAdapter, () => input);
+    const cleanup = wireImeResyncListener(editor as unknown as Editor, adapter as unknown as ImeInputAdapter, () => input, onResync);
 
     editor.emit('ime_resync_required');
+    expect(onResync).toHaveBeenCalledOnce();
     expect(adapter.resetForResync).not.toHaveBeenCalled();
 
     await Promise.resolve();

--- a/apps/website/src/lib/editor-ffi/input/ime-resync.ts
+++ b/apps/website/src/lib/editor-ffi/input/ime-resync.ts
@@ -5,8 +5,10 @@ export const wireImeResyncListener = (
   editor: Editor,
   adapter: ImeInputAdapter,
   getInput: () => HTMLTextAreaElement | null,
+  onResync?: () => void,
 ): (() => void) => {
   return editor.on('ime_resync_required', () => {
+    onResync?.();
     queueMicrotask(() => {
       adapter.resetForResync(getInput());
     });


### PR DESCRIPTION
## 배경

한글 등 IME 조합 중 내비게이션이나 에디터 단축키를 누르면 첫 키 입력이
조합 커밋에만 사용되고, 같은 키를 다시 눌러야 명령이 실행되는 문제가 있었습니다.

웹과 앱 모두 조합을 먼저 커밋한 뒤 동일한 키 입력의 바인딩까지 이어서
실행하도록 입력 경계를 정리합니다.

## 변경 사항

- 키 바인딩에 composition commit 정책을 선언했습니다.
    - 내비게이션과 에디터 단축키는 조합을 먼저 커밋합니다.
    - Enter, Backspace, Delete, Tab, Escape 등 네이티브 텍스트 입력 키는
기존처럼 플랫폼 입력이 소유합니다.
- 앱의 일반 KeyDown, 플랫폼 pre-key 처리, Desktop KeyUp 복구가 동일한
바인딩 정책을 사용하도록 통합했습니다.
- JVM Desktop에서 IME가 단축키 KeyDown을 소비하더라도 composition commit 뒤
도착한 KeyUp으로 해당 바인딩을 한 번만 복구합니다.
- Desktop `TextEditingScope` 입력을 공통 `EditCommand` 정규화·적용
파이프라인으로 전달합니다.
- Android에서는 명령 단축키 경계에서만 입력 연결을 재시작하여 Gboard가
유지하는 비공개 조합 상태를 종료합니다. 방향키는 입력 연결을 재시작하지 않습니다.
- Web에서는 조합 중 단축키를 보류하고 `compositionend`의 커밋 적용 뒤
실행합니다.
    - 방향키는 브라우저의 post-composition keydown에 맡겨 중복 이동을 방지합니다.
    - 조합 중 `Mod+V`와 `Mod+Shift+V`는 누락된 paste 이벤트를 보완합니다.
    - blur, read-only 전환, IME resync에서는 보류 명령을 폐기합니다.