### PR TITLE
publication 완료 후 target이 해제된 경우의 교착 수정

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Editor.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Editor.kt
@@ -630,16 +630,18 @@ internal constructor(
             NoHost
           } else {
             val current = published
-            val pages = host.pages.values
-            val targets = pages.map { it.target }
             if (
               current != null &&
-                current.snapshot.version >= revision &&
-                Publication.matchesTargets(current.frames, targets)
+                Publication.satisfiesWaiter(
+                  requestedRevision = revision,
+                  publishedRevision = current.snapshot.version,
+                  frames = current.frames,
+                  targets = host.pages.values.map { it.target },
+                )
             ) {
               Published(current.snapshot.version)
             } else {
-              pages
+              host.pages.values
                 .firstOrNull { page -> (page.failedRevision ?: -1L) >= revision }
                 ?.let { page -> throw EditorSurfaceUnavailableException(page.target.page) }
               publicationWaiters.updatePersistent { it.adding(waiter) }
@@ -1015,7 +1017,7 @@ internal constructor(
     }
     val publishedRevision = currentPublishedRevision ?: 0L
     if (
-      !Publication.canPublish(
+      Publication.canPublish(
         hasVisualHost = true,
         hasPublishedFrames = published?.frames?.isNotEmpty() == true,
         appliedRevision = appliedState.version,
@@ -1024,24 +1026,29 @@ internal constructor(
         targetsChanged = targetsChanged,
       )
     ) {
-      refreshRetainedFrames()
-      return
-    }
-
-    val frames =
-      host.pages.mapNotNull { (page, record) -> record.frame?.let { page to it } }.toMap()
-    val bundle = PublishedBundle(snapshot = appliedState, frames = frames)
-    published = bundle
-    preparingPage = null
-    host.pages.values.forEach {
-      it.requiredRevision = null
-      it.failedRevision = null
+      val frames =
+        host.pages.mapNotNull { (page, record) -> record.frame?.let { page to it } }.toMap()
+      published = PublishedBundle(snapshot = appliedState, frames = frames)
+      preparingPage = null
+      host.pages.values.forEach {
+        it.requiredRevision = null
+        it.failedRevision = null
+      }
     }
     refreshRetainedFrames()
 
-    val completed = publicationWaiters.load().filter { it.revision <= bundle.snapshot.version }
+    val current = published ?: return
+    val completed =
+      publicationWaiters.load().filter {
+        Publication.satisfiesWaiter(
+          requestedRevision = it.revision,
+          publishedRevision = current.snapshot.version,
+          frames = current.frames,
+          targets = targets,
+        )
+      }
     publicationWaiters.updatePersistent { it.removingAll(completed) }
-    val result = Published(bundle.snapshot.version)
+    val result = Published(current.snapshot.version)
     completed.forEach { it.completion.complete(result) }
   }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Publication.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Publication.kt
@@ -37,6 +37,16 @@ internal object Publication {
     frames.size == targets.size &&
       targets.all { target -> frames[target.page]?.proof?.surfaceKey == target.key }
 
+  fun satisfiesWaiter(
+    requestedRevision: Long,
+    publishedRevision: Long?,
+    frames: Map<Int, PresentedFrame>,
+    targets: Collection<SurfaceTarget>,
+  ): Boolean =
+    publishedRevision != null &&
+      publishedRevision >= requestedRevision &&
+      (matchesTargets(frames, targets) || (targets.isEmpty() && frames.isNotEmpty()))
+
   fun accepts(
     proof: FrameProof,
     target: SurfaceTarget,

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorPublicationHostTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorPublicationHostTest.kt
@@ -270,6 +270,37 @@ class EditorPublicationHostTest {
     }
 
   @Test
+  fun pendingWaitCompletesWhenTheLastReplacementTargetDetaches() =
+    runTest(dispatcher) {
+      val fake = FakeFfiEditor(pageSizesProvider = { listOf(Size(width = 100f, height = 100f)) })
+      val editor = Editor(fake, this, dispatcher)
+      editor.activateVisualHost(Any())
+      val session = editor.attachSurface(0, 10L, 100.0, 100.0, 1.0, wakeDelivery = {})
+      advanceUntilIdle()
+      editor.deliverFrame(session, editorRevision = 0L, frameKey = 1L)
+      advanceUntilIdle()
+
+      val update = requireNotNull(editor.update { enqueue(message) })
+      assertEquals(Published(update.revision), update.awaitPublished())
+
+      session.requestResize(SurfaceConfiguration(width = 100.0, height = 100.0, scaleFactor = 2.0))
+      advanceUntilIdle()
+      val publication = async(start = CoroutineStart.UNDISPATCHED) { update.awaitPublished() }
+      assertFalse(publication.isCompleted)
+
+      session.detach()
+      advanceUntilIdle()
+
+      try {
+        assertTrue(publication.isCompleted)
+        assertEquals(Published(update.revision), publication.await())
+      } finally {
+        publication.cancel()
+        advanceUntilIdle()
+      }
+    }
+
+  @Test
   fun detachingTheLastTargetRetainsPublishedBundleUntilReplacementProofArrives() =
     runTest(dispatcher) {
       val fake =
@@ -321,7 +352,7 @@ class EditorPublicationHostTest {
     }
 
   @Test
-  fun pageShrinkPreparesPageZeroWhenItRemovesEveryTarget() =
+  fun pageShrinkPreparationCompletesLateWaitAfterReplacementDetaches() =
     runTest(dispatcher) {
       var pageSizes = listOf(Size(width = 100f, height = 100f), Size(width = 100f, height = 100f))
       val fake =
@@ -362,6 +393,18 @@ class EditorPublicationHostTest {
 
       assertEquals(update.revision, editor.publishedRevision)
       assertNull(editor.preparingPage)
+
+      replacement.detach()
+      advanceUntilIdle()
+      val latePublication = async(start = CoroutineStart.UNDISPATCHED) { update.awaitPublished() }
+      try {
+        advanceUntilIdle()
+        assertTrue(latePublication.isCompleted)
+        assertEquals(Published(update.revision), latePublication.await())
+      } finally {
+        latePublication.cancel()
+        advanceUntilIdle()
+      }
     }
 
   @Test

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/PublicationTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/PublicationTest.kt
@@ -1,5 +1,7 @@
 package co.typie.editor
 
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.unit.IntSize
 import co.typie.editor.ffi.FrameKey
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -71,6 +73,31 @@ class PublicationTest {
         appliedRevision = 2,
         publishedRevision = 1,
         pages = emptyList(),
+      )
+    )
+  }
+
+  @Test
+  fun retainedFramedPublicationSatisfiesWaiterWhenNoTargetsRemain() {
+    assertTrue(
+      Publication.satisfiesWaiter(
+        requestedRevision = 10,
+        publishedRevision = 10,
+        frames = mapOf(0 to frame(surfaceKey = 1)),
+        targets = emptyList(),
+      )
+    )
+  }
+
+  @Test
+  fun replacementTargetMustMatchBeforeItSatisfiesWaiter() {
+    assertFalse(
+      Publication.satisfiesWaiter(
+        requestedRevision = 10,
+        publishedRevision = 10,
+        frames = mapOf(0 to frame(surfaceKey = 1)),
+        targets =
+          listOf(SurfaceTarget(page = 0, key = SurfaceKey(2), configuration = configuration)),
       )
     )
   }
@@ -244,4 +271,12 @@ class PublicationTest {
     assertTrue(Publication.workRevision(appliedRevision = 11, requiredRevision = 10) == 11L)
     assertNull(Publication.workRevision(appliedRevision = 11, requiredRevision = null))
   }
+
+  private fun frame(surfaceKey: Long): PresentedFrame =
+    PresentedFrame(
+      bitmap = ImageBitmap(width = 1, height = 1),
+      pixelSize = IntSize(width = 1, height = 1),
+      proof =
+        FrameProof(editorRevision = 10, surfaceKey = SurfaceKey(surfaceKey), frameKey = FrameKey(1)),
+    )
 }

--- a/apps/website/src/lib/editor-ffi/editor-host-failure.test.ts
+++ b/apps/website/src/lib/editor-ffi/editor-host-failure.test.ts
@@ -525,6 +525,30 @@ describe('Editor guarded core invocation', () => {
     editor.destroy();
   });
 
+  it('settles an existing ordinary waiter when the last mismatching target detaches', async () => {
+    const { editor, core } = await createEditor();
+    const releaseHost = editor.activateVisualHost();
+
+    try {
+      editor.attachSurface(0, document.createElement('canvas'), 100, 100);
+
+      core.surface_backend.mockReturnValue('none');
+      editor.attachSurface(0, document.createElement('canvas'), 100, 100);
+      const publication = editor.awaitPublishedRevision(1);
+      const framedPublication = editor.awaitPublishedRevision(1, { requireFrame: true });
+
+      editor.detachSurface(0);
+
+      const pending = Symbol('pending');
+      const result = await Promise.race([publication, new Promise<typeof pending>((resolve) => queueMicrotask(() => resolve(pending)))]);
+      expect(result).toEqual({ type: 'published', revision: 1 });
+      await expectPending(framedPublication);
+    } finally {
+      releaseHost();
+      editor.destroy();
+    }
+  });
+
   it('rejects a failed render revision once and retries only after applied advances', async () => {
     const { editor, core } = await createEditor();
     const releaseHost = editor.activateVisualHost();
@@ -994,7 +1018,7 @@ describe('Editor guarded core invocation', () => {
     editor.destroy();
   });
 
-  it('activates an offscreen page while the Host is preparing its replacement surface', async () => {
+  it('completes a late publication wait after an offscreen prepared page publishes and detaches', async () => {
     const core = createCore();
     core.page_sizes.mockReturnValue([{ width: 100, height: 100 }]);
     core.page_backing_sizes.mockReturnValue([{ width: 100, height: 100 }]);
@@ -1041,6 +1065,14 @@ describe('Editor guarded core invocation', () => {
       expect(editor.publishedRevision).toBe(2);
       expect(editor.preparingPage).toBeUndefined();
       expect(core.detach_surface).toHaveBeenCalledExactlyOnceWith(0);
+
+      const pending = Symbol('pending');
+      const latePublication = await Promise.race([
+        editor.awaitPublishedRevision(2),
+        new Promise<typeof pending>((resolve) => queueMicrotask(() => resolve(pending))),
+      ]);
+      expect(latePublication).toEqual({ type: 'published', revision: 2 });
+      await expectPending(editor.awaitPublishedRevision(2, { requireFrame: true }));
     } finally {
       await unmount(component);
       target.remove();

--- a/apps/website/src/lib/editor-ffi/editor-publication.test.ts
+++ b/apps/website/src/lib/editor-ffi/editor-publication.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { canPublish, preparingPage, proofSatisfies } from './publication';
+import { canPublish, preparingPage, proofSatisfies, satisfiesWaiter } from './publication';
 import type { PublicationTarget } from './publication';
 
 describe('editor publication', () => {
@@ -59,6 +59,25 @@ describe('editor publication', () => {
   it('keeps a prior framed publication when the active host temporarily has zero targets', () => {
     expect(canPublish(10, 9, { targets: new Map() }, true, true)).toBe(false);
     expect(canPublish(10, undefined, { targets: new Map() }, true, false)).toBe(true);
+  });
+
+  it('lets an ordinary waiter use a retained framed publication when no targets remain', () => {
+    expect(satisfiesWaiter(10, 10, new Map([[0, { surfaceKey: 1 }]]), { targets: new Map() })).toBe(true);
+  });
+
+  it('keeps frame-required waiters pending without a matching current target', () => {
+    expect(satisfiesWaiter(10, 10, new Map([[0, { surfaceKey: 1 }]]), { targets: new Map() }, true)).toBe(false);
+  });
+
+  it('requires an exact match while the current target set is non-empty', () => {
+    const replacement: PublicationTarget = {
+      key: 2,
+      requiredRevision: 10,
+      proof: undefined,
+      available: true,
+    };
+
+    expect(satisfiesWaiter(10, 10, new Map([[0, { surfaceKey: 1 }]]), { targets: new Map([[0, replacement]]) })).toBe(false);
   });
 
   it('requests page zero only when a newer applied layout strands a framed publication without targets', () => {

--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -12,7 +12,7 @@ import { TouchGestureController } from './gesture.svelte';
 import { readClipboardRich, writeClipboardPayload } from './handlers/clipboard';
 import { encodeLengthPrefixedBlobs } from './length-prefix';
 import { isMutatingMessage } from './message-gate';
-import { canPublish, preparingPage, proofSatisfies } from './publication';
+import { canPublish, preparingPage, proofSatisfies, satisfiesWaiter } from './publication';
 import { fanOutResourceUpdate, register, snapshot, unregister } from './registry';
 import { probeEvent, probeRendered } from './surface-probe';
 import { zoomDiffers } from './zoom';
@@ -728,7 +728,7 @@ export class Editor {
         this.#visualHost?.targets.size ?? 0,
       );
       if (
-        !canPublish(
+        canPublish(
           this.#applied.revision,
           this.published?.snapshot.revision,
           this.#visualHost,
@@ -736,41 +736,37 @@ export class Editor {
           (this.published?.frames.size ?? 0) > 0,
         )
       ) {
-        return;
-      }
+        // eslint-disable-next-line svelte/prefer-svelte-reactivity
+        const frames = new Map<number, PublishedFrame>();
+        for (const target of this.#visualHost?.targets.values() ?? []) {
+          if (target.proof) {
+            frames.set(target.page, {
+              surfaceKey: target.key,
+              frameKey: target.proof.frameKey,
+              canvas: target.canvas,
+            });
+          }
+        }
 
-      // eslint-disable-next-line svelte/prefer-svelte-reactivity
-      const frames = new Map<number, PublishedFrame>();
-      for (const target of this.#visualHost?.targets.values() ?? []) {
-        if (target.proof) {
-          frames.set(target.page, {
-            surfaceKey: target.key,
-            frameKey: target.proof.frameKey,
-            canvas: target.canvas,
-          });
+        this.published = { snapshot: this.#applied, frames };
+        this.#preparingPage = undefined;
+        this.#pullToolbarStateIfReady();
+
+        for (const target of this.#visualHost?.targets.values() ?? []) {
+          target.requiredRevision = undefined;
+          target.failedRevision = undefined;
         }
       }
 
-      const bundle: PublishedBundle = { snapshot: this.#applied, frames };
-      this.published = bundle;
-      this.#preparingPage = undefined;
-      this.#pullToolbarStateIfReady();
-
-      for (const target of this.#visualHost?.targets.values() ?? []) {
-        target.requiredRevision = undefined;
-        target.failedRevision = undefined;
-      }
-
+      const published = this.published;
+      if (!published) return;
       for (const waiter of this.#publicationWaiters) {
-        if (
-          bundle.snapshot.revision < waiter.revision ||
-          (waiter.requireFrame && (bundle.frames.size === 0 || !this.#publishedMatchesCurrentTargets()))
-        ) {
+        if (!satisfiesWaiter(waiter.revision, published.snapshot.revision, published.frames, this.#visualHost, waiter.requireFrame)) {
           continue;
         }
         this.#publicationWaiters.delete(waiter);
         if (waiter.signal && waiter.onAbort) waiter.signal.removeEventListener('abort', waiter.onAbort);
-        waiter.resolve({ type: 'published', revision: bundle.snapshot.revision });
+        waiter.resolve({ type: 'published', revision: published.snapshot.revision });
       }
     });
   }
@@ -786,29 +782,14 @@ export class Editor {
     this.#toolbarSyncDirty = false;
   }
 
-  #publishedMatchesCurrentTargets(): boolean {
-    const host = this.#visualHost;
-    const frames = this.published?.frames;
-    if (!host || !frames || frames.size !== host.targets.size) return false;
-    for (const [page, target] of host.targets) {
-      if (!target.available || frames.get(page)?.surfaceKey !== target.key) return false;
-    }
-    return true;
-  }
-
   #awaitPublished(revision: number, signal?: AbortSignal, requireFrame = false): Promise<EditorPublicationResult> {
     if (signal?.aborted) return Promise.reject(signal.reason ?? new DOMException('Cancelled', 'AbortError'));
     if (this.#destroyed) return Promise.reject(new Error('Editor is disposed'));
     if (this.#failed) return Promise.reject(this.#failure);
     if (!this.#visualHost) return Promise.resolve({ type: 'no_host' });
-    const publishedRevision = this.published?.snapshot.revision;
-    if (
-      publishedRevision !== undefined &&
-      publishedRevision >= revision &&
-      this.#publishedMatchesCurrentTargets() &&
-      (!requireFrame || (this.published?.frames.size ?? 0) > 0)
-    ) {
-      return Promise.resolve({ type: 'published', revision: publishedRevision });
+    const published = this.published;
+    if (published && satisfiesWaiter(revision, published.snapshot.revision, published.frames, this.#visualHost, requireFrame)) {
+      return Promise.resolve({ type: 'published', revision: published.snapshot.revision });
     }
     for (const target of this.#visualHost.targets.values()) {
       if ((target.failedRevision ?? -1) >= revision) {

--- a/apps/website/src/lib/editor-ffi/publication.ts
+++ b/apps/website/src/lib/editor-ffi/publication.ts
@@ -15,9 +15,34 @@ export type VisualHostFacts = {
   targets: ReadonlyMap<number, PublicationTarget>;
 };
 
+type PublishedFrameFacts = {
+  surfaceKey: number;
+};
+
+function matchesTargets(frames: ReadonlyMap<number, PublishedFrameFacts>, targets: ReadonlyMap<number, PublicationTarget>): boolean {
+  if (frames.size !== targets.size) return false;
+  for (const [page, target] of targets) {
+    if (!target.available || frames.get(page)?.surfaceKey !== target.key) return false;
+  }
+  return true;
+}
+
 export function proofSatisfies(target: PublicationTarget): boolean {
   if (!target.available || target.requiredRevision === undefined) return false;
   return target.proof !== undefined && target.proof.revision >= target.requiredRevision && target.proof.surfaceKey === target.key;
+}
+
+export function satisfiesWaiter(
+  requestedRevision: number,
+  publishedRevision: number | undefined,
+  frames: ReadonlyMap<number, PublishedFrameFacts>,
+  host: VisualHostFacts | undefined,
+  requireFrame = false,
+): boolean {
+  if (!host || publishedRevision === undefined || publishedRevision < requestedRevision) return false;
+  if (requireFrame && frames.size === 0) return false;
+
+  return matchesTargets(frames, host.targets) || (!requireFrame && host.targets.size === 0 && frames.size > 0);
 }
 
 export function preparingPage(

--- a/apps/website/src/vitest-setup.ts
+++ b/apps/website/src/vitest-setup.ts
@@ -1,20 +1,8 @@
-import { beforeEach } from 'vitest';
+import { vi } from 'vitest';
 
-if (typeof window !== 'undefined') {
-  const values = new Map<string, string>();
-  const localStorage: Storage = {
-    get length() {
-      return values.size;
-    },
-    clear: () => values.clear(),
-    getItem: (key) => values.get(key) ?? null,
-    key: (index) => [...values.keys()][index] ?? null,
-    removeItem: (key) => values.delete(key),
-    setItem: (key, value) => values.set(key, value),
-  };
-  Object.defineProperty(globalThis, 'localStorage', {
-    configurable: true,
-    value: localStorage,
-  });
-  beforeEach(() => values.clear());
-}
+vi.mock('$lib/editor-ffi/surface-probe', () => ({
+  probeAttach: vi.fn(),
+  probeDetach: vi.fn(),
+  probeEvent: vi.fn(),
+  probeRendered: vi.fn(),
+}));


### PR DESCRIPTION
- publication 완료 후 페이지의 surface target이 해제(park)되면 같은 revision의 publication wait가 끝나지 않는 문제 수정
- target이 없더라도 이미 publish된 frame이 보존되어 있으면 일반 wait를 완료