### PR TITLE
웹 에디터가 실제 viewport frame을 준비한 뒤 표시

### DIFF
--- a/apps/website/src/lib/editor-ffi/components/View.svelte
+++ b/apps/website/src/lib/editor-ffi/components/View.svelte
@@ -169,6 +169,7 @@
   });
 
   let readyFired = false;
+  let viewportEditor: (typeof ctx)['editor'];
 
   $effect(() => {
     const editor = ctx.editor;
@@ -180,14 +181,21 @@
     const effectiveWidth = isContinuous ? Math.max(CONTINUOUS_MIN_WIDTH, width) : width;
 
     untrack(() => {
-      editor.resizeViewport(effectiveWidth, height, viewportScaleFactor);
-
-      if (!readyFired && editor.viewportResized) {
-        readyFired = true;
-        loadFonts(document.data.editorFontFamilies);
-        onReady?.();
+      if (viewportEditor === editor) {
+        editor.resizeViewport(effectiveWidth, height, viewportScaleFactor);
+      } else {
+        viewportEditor = editor;
+        editor.resizeViewportNow(effectiveWidth, height, viewportScaleFactor);
       }
     });
+
+    if (!readyFired && editor.isPublished(editor.appliedRevision, { requireFrame: true })) {
+      readyFired = true;
+      untrack(() => {
+        loadFonts(document.data.editorFontFamilies);
+        onReady?.();
+      });
+    }
   });
 
   $effect(() => {

--- a/apps/website/src/lib/editor-ffi/editor-host-failure.test.ts
+++ b/apps/website/src/lib/editor-ffi/editor-host-failure.test.ts
@@ -944,6 +944,105 @@ describe('Editor guarded core invocation', () => {
     editor.destroy();
   });
 
+  it('publishes the immediately applied viewport only after its replacement frame', async () => {
+    const core = createCore();
+    core.page_sizes.mockReturnValue([{ width: 40, height: 1064 }]);
+    core.page_backing_sizes.mockReturnValue([{ width: 40, height: 1064 }]);
+    core.tick_through.mockImplementation((requestId) => ({
+      revision: { value: 1 },
+      events: [{ type: 'state_changed', fields: ['page_sizes'] }],
+      request_outcomes: [{ request_id: requestId, command_outcomes: [{ type: 'applied' }] }],
+    }));
+    const { editor } = await createEditor(core);
+    const releaseHost = editor.activateVisualHost();
+    const displayed = document.createElement('canvas');
+    const candidate = document.createElement('canvas');
+    core.render_surface.mockReset().mockReturnValueOnce({ value: 1 }).mockReturnValue(undefined);
+    const replace = vi.fn(() => {
+      editor.attachSurface(0, candidate, 320, 1064, replace);
+    });
+    editor.attachSurface(0, displayed, 40, 1064, replace);
+
+    core.page_sizes.mockReturnValue([{ width: 320, height: 1064 }]);
+    core.page_backing_sizes.mockReturnValue([{ width: 320, height: 1064 }]);
+    core.tick_through.mockImplementation((requestId) => ({
+      revision: { value: 2 },
+      events: [{ type: 'state_changed', fields: ['page_sizes'] }, { type: 'render_invalidated' }],
+      request_outcomes: [{ request_id: requestId, command_outcomes: [{ type: 'applied' }] }],
+    }));
+
+    editor.resizeViewportNow(320, 800, 1);
+    expect(editor.appliedRevision).toBe(2);
+    expect(editor.publishedRevision).toBe(1);
+    expect(editor.isPublished(editor.appliedRevision, { requireFrame: true })).toBe(false);
+
+    core.render_surface.mockReturnValue({ value: 2 });
+    editor.invalidateSurface(0);
+
+    expect(editor.publishedRevision).toBe(2);
+    expect(editor.publishedSurfaceCanvas(0)).toBe(candidate);
+    expect(editor.isPublished(editor.appliedRevision, { requireFrame: true })).toBe(true);
+
+    releaseHost();
+    editor.destroy();
+  });
+
+  it('publishes an already matching viewport when its first frame arrives', async () => {
+    const core = createCore();
+    core.page_sizes.mockReturnValue([{ width: 320, height: 1064 }]);
+    core.page_backing_sizes.mockReturnValue([{ width: 320, height: 1064 }]);
+    core.tick_through.mockImplementation((requestId) => ({
+      revision: { value: 1 },
+      events: [{ type: 'state_changed', fields: ['page_sizes'] }],
+      request_outcomes: [{ request_id: requestId, command_outcomes: [{ type: 'applied' }] }],
+    }));
+    wasmHarness.createEditor.mockReturnValue(core);
+    const editor = await Editor.createFromDoc({} as never, { width: 320, height: 800, scale_factor: 1 });
+    const releaseHost = editor.activateVisualHost();
+
+    editor.resizeViewportNow(320, 800, 1);
+    expect(editor.isPublished(editor.appliedRevision, { requireFrame: true })).toBe(false);
+
+    editor.attachSurface(0, document.createElement('canvas'), 320, 1064);
+
+    expect(editor.isPublished(editor.appliedRevision, { requireFrame: true })).toBe(true);
+
+    releaseHost();
+    editor.destroy();
+  });
+
+  it('requires a frame from the current visual host after reactivation', async () => {
+    const core = createCore();
+    core.page_sizes.mockReturnValue([{ width: 320, height: 1064 }]);
+    core.page_backing_sizes.mockReturnValue([{ width: 320, height: 1064 }]);
+    core.tick_through.mockImplementation((requestId) => ({
+      revision: { value: 1 },
+      events: [{ type: 'state_changed', fields: ['page_sizes'] }],
+      request_outcomes: [{ request_id: requestId, command_outcomes: [{ type: 'applied' }] }],
+    }));
+    wasmHarness.createEditor.mockReturnValue(core);
+    const editor = await Editor.createFromDoc({} as never, { width: 320, height: 800, scale_factor: 1 });
+    const releaseFirstHost = editor.activateVisualHost();
+
+    editor.resizeViewportNow(320, 800, 1);
+    editor.attachSurface(0, document.createElement('canvas'), 320, 1064);
+    expect(editor.isPublished(editor.appliedRevision, { requireFrame: true })).toBe(true);
+
+    releaseFirstHost();
+    const releaseSecondHost = editor.activateVisualHost();
+
+    expect(editor.isPublished(editor.appliedRevision, { requireFrame: true })).toBe(false);
+
+    const secondCanvas = document.createElement('canvas');
+    editor.attachSurface(0, secondCanvas, 320, 1064);
+
+    expect(editor.publishedSurfaceCanvas(0)).toBe(secondCanvas);
+    expect(editor.isPublished(editor.appliedRevision, { requireFrame: true })).toBe(true);
+
+    releaseSecondHost();
+    editor.destroy();
+  });
+
   it('requests a preparing surface when page shrink removes every active target', async () => {
     const core = createCore();
     core.page_sizes.mockReturnValue([

--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -350,7 +350,6 @@ export class Editor {
 
   #viewport = $state<Viewport>({ width: 0, height: 0, scale_factor: 1 });
   #appliedViewport: Viewport = { width: 0, height: 0, scale_factor: 1 };
-  #firstResizeApplied = false;
   #applyViewportResize = debounce(() => {
     if (this.#destroyed || sameViewport(this.#appliedViewport, this.#viewport)) return;
 
@@ -771,9 +770,7 @@ export class Editor {
       const published = this.published;
       if (!published) return;
       for (const waiter of this.#publicationWaiters) {
-        if (!satisfiesWaiter(waiter.revision, published.snapshot.revision, published.frames, this.#visualHost, waiter.requireFrame)) {
-          continue;
-        }
+        if (!this.isPublished(waiter.revision, { requireFrame: waiter.requireFrame })) continue;
         this.#publicationWaiters.delete(waiter);
         if (waiter.signal && waiter.onAbort) waiter.signal.removeEventListener('abort', waiter.onAbort);
         waiter.resolve({ type: 'published', revision: published.snapshot.revision });
@@ -798,7 +795,7 @@ export class Editor {
     if (this.#failed) return Promise.reject(this.#failure);
     if (!this.#visualHost) return Promise.resolve({ type: 'no_host' });
     const published = this.published;
-    if (published && satisfiesWaiter(revision, published.snapshot.revision, published.frames, this.#visualHost, requireFrame)) {
+    if (published && this.isPublished(revision, { requireFrame })) {
       return Promise.resolve({ type: 'published', revision: published.snapshot.revision });
     }
     for (const target of this.#visualHost.targets.values()) {
@@ -1289,8 +1286,12 @@ export class Editor {
     return this.#viewport.scale_factor * this.renderZoom;
   }
 
-  get viewportResized(): boolean {
-    return this.#firstResizeApplied;
+  isPublished(revision: number, options?: { requireFrame?: boolean }): boolean {
+    const published = this.published;
+    return (
+      published !== undefined &&
+      satisfiesWaiter(revision, published.snapshot.revision, published.frames, this.#visualHost, options?.requireFrame)
+    );
   }
 
   resizeViewport(width: number, height: number, scaleFactor: number): void {
@@ -1303,13 +1304,25 @@ export class Editor {
     this.#viewport = viewport;
     if (sameViewport(this.#appliedViewport, viewport)) return;
 
-    if (!this.#firstResizeApplied) {
-      this.#firstResizeApplied = true;
-      this.#applyViewport(viewport);
-      return;
-    }
-
     this.#applyViewportResize.call();
+  }
+
+  resizeViewportNow(width: number, height: number, scaleFactor: number): void {
+    if (!Number.isFinite(width) || !Number.isFinite(height) || !Number.isFinite(scaleFactor)) return;
+    if (width <= 0 || height <= 0 || scaleFactor <= 0) return;
+
+    const viewport = { width, height, scale_factor: scaleFactor };
+    this.#viewport = viewport;
+    this.#applyViewportResize.cancel();
+    if (sameViewport(this.#appliedViewport, viewport)) return;
+
+    this.#appliedViewport = viewport;
+    this.updateNow((request) => {
+      request.enqueue({
+        type: 'system',
+        event: { type: 'resize', width: viewport.width, height: viewport.height, scale_factor: viewport.scale_factor },
+      });
+    });
   }
 
   setRenderZoom(renderZoom: number): void {


### PR DESCRIPTION
웹 에디터는 실제 크기를 알기 전에 1px viewport로 엔진을 생성합니다. 첫 viewport resize를 enqueue한 시점에 ready 처리하면서, 실제 viewport용 frame이 준비되기 전에 너비 80px인 bootstrap canvas가 노출될 수 있었습니다.

첫 실제 viewport는 `updateNow`로 applied까지 동기 반영하고, 현재 visual host와 일치하는 frame이 publish된 뒤에만 ready 처리합니다. 이후 viewport 변경은 기존처럼 debounce하며, visual host가 교체되면 새 host의 frame을 다시 요구합니다.

앱에는 문제가 업습니다.