### PR TITLE
Slice 삽입을 replacement-aware fitter로 통합

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "ar_archive_writer"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4087686b4b0a3427190bae57a1d9a478dbb2d40c5dc1bd6e2b6d797913bdd348"
+dependencies = [
+ "object 0.37.3",
+]
+
+[[package]]
 name = "archery"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -679,7 +688,7 @@ dependencies = [
  "bitcode",
  "env_logger",
  "heck",
- "object",
+ "object 0.39.1",
  "quote",
  "syn",
  "uniffi",
@@ -706,6 +715,7 @@ dependencies = [
  "selectors",
  "serde",
  "serde_json",
+ "serde_stacker",
  "tsify",
  "uniffi",
  "wasm-bindgen",
@@ -2063,6 +2073,15 @@ dependencies = [
 
 [[package]]
 name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "object"
 version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
@@ -2346,6 +2365,16 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
 ]
 
 [[package]]
@@ -2858,6 +2887,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_stacker"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4936375d50c4be7eff22293a9344f8e46f323ed2b3c243e52f89138d9bb0f4a"
+dependencies = [
+ "serde",
+ "serde_core",
+ "stacker",
+]
+
+[[package]]
 name = "servo_arc"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2932,6 +2972,19 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stacker"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "static_assertions"
@@ -3884,6 +3937,7 @@ dependencies = [
  "read-fonts",
  "serde",
  "serde_core",
+ "serde_json",
  "smallvec",
  "stable_deref_trait",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,8 @@ resize = { version = "0.8", default-features = false }
 ruzstd = "0.8"
 rstar = "0.13"
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde_json = { version = "1", features = ["unbounded_depth"] }
+serde_stacker = "0.1"
 serde-wasm-bindgen = "0.6"
 serde_bytes = "0.11"
 skrifa = "0.43"

--- a/crates/editor-clipboard/Cargo.toml
+++ b/crates/editor-clipboard/Cargo.toml
@@ -35,6 +35,7 @@ scraper = { workspace = true }
 selectors = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_stacker = { workspace = true }
 tsify = { workspace = true, optional = true }
 uniffi = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }

--- a/crates/editor-clipboard/src/html/parse/mod.rs
+++ b/crates/editor-clipboard/src/html/parse/mod.rs
@@ -13,6 +13,7 @@ use base64::Engine;
 use base64::engine::general_purpose::STANDARD;
 use editor_resource::Resource;
 use scraper::{Html, Selector};
+use serde::Deserialize;
 use std::sync::OnceLock;
 
 fn body_selector() -> &'static Selector {
@@ -49,10 +50,24 @@ pub fn from_html(html: &str, resource: &Resource) -> Slice {
 
 fn extract_meta_slice(doc: &Html) -> Option<Slice> {
     let meta = doc.select(meta_data_slice_selector()).next()?;
+    if meta.value().attr("data-version") != Some("1") {
+        return None;
+    }
     let b64 = meta.value().attr("data-slice-v2")?;
     let bytes = STANDARD.decode(b64.as_bytes()).ok()?;
     let s = std::str::from_utf8(&bytes).ok()?;
-    serde_json::from_str(s).ok()
+    let mut json = serde_json::Deserializer::from_str(s);
+    json.disable_recursion_limit();
+    let slice = Slice::deserialize(serde_stacker::Deserializer::new(&mut json)).ok()?;
+    if json.end().is_err() {
+        drop(slice);
+        return None;
+    }
+    if !slice.is_empty() && slice.has_valid_structure() {
+        return Some(slice);
+    }
+    drop(slice);
+    None
 }
 
 fn fallback_body_parse(doc: &Html, resource: &Resource) -> Slice {
@@ -79,7 +94,8 @@ mod tests {
     use editor_crdt::Dot;
     use editor_macros::state;
     use editor_model::{
-        AtomLeaf, Fragment, Modifier, NodeType, PlainNode, PlainParagraphNode, PlainTextNode,
+        AtomLeaf, Fragment, Modifier, NodeType, PlainBlockquoteNode, PlainNode, PlainParagraphNode,
+        PlainTextNode,
     };
     use editor_resource::{
         FontFamily, FontFamilySource, FontWeight, Resource, ResourceSource, ThemeVariant,
@@ -101,6 +117,48 @@ mod tests {
         let resource = Resource::new_test();
         let parsed = Slice::from_html(&html, &resource);
         assert_eq!(parsed, original);
+    }
+
+    #[test]
+    fn deeply_nested_slice_metadata_and_fallback_formats_are_stack_safe() {
+        const DEPTH: usize = 256;
+        std::thread::Builder::new()
+            .stack_size(64 * 1024)
+            .spawn(|| {
+                let mut fragment = Fragment::leaf(PlainNode::Text(PlainTextNode {
+                    text: "deep".into(),
+                }));
+                fragment = Fragment::leaf(PlainNode::Paragraph(PlainParagraphNode::default()))
+                    .with_children(vec![fragment]);
+                for _ in 0..DEPTH {
+                    fragment =
+                        Fragment::leaf(PlainNode::Blockquote(PlainBlockquoteNode::default()))
+                            .with_children(vec![fragment]);
+                }
+                let slice = Slice::new(vec![fragment], 0, 0);
+                let resource = Resource::new_test();
+
+                let html = slice.to_html(&resource);
+                assert_eq!(html.matches("<blockquote ").count(), DEPTH);
+                assert_eq!(slice.to_text(), "deep");
+
+                let parsed = Slice::from_html(&html, &resource);
+                let mut node_count = 0;
+                let mut stack: Vec<_> = parsed.content.iter().collect();
+                while let Some(fragment) = stack.pop() {
+                    node_count += 1;
+                    stack.extend(fragment.children.iter());
+                }
+                assert_eq!(node_count, DEPTH + 2);
+                assert_eq!(parsed.open_start, 0);
+                assert_eq!(parsed.open_end, 0);
+
+                drop(parsed);
+                drop(slice);
+            })
+            .expect("spawn deep Slice test")
+            .join()
+            .expect("deep Slice round trip");
     }
 
     #[test]
@@ -272,6 +330,49 @@ mod tests {
         let slice = Slice::from_html(html, &Resource::new_test());
         assert_eq!(slice.content.len(), 1);
         assert!(matches!(slice.content[0].node, PlainNode::Paragraph(_)));
+    }
+
+    #[test]
+    fn invalid_version_or_open_depth_metadata_falls_back_to_body() {
+        let metadata_slice = Slice {
+            content: vec![
+                Fragment::leaf(PlainNode::Paragraph(PlainParagraphNode::default())).with_children(
+                    vec![Fragment::leaf(PlainNode::Text(PlainTextNode {
+                        text: "metadata".into(),
+                    }))],
+                ),
+            ],
+            open_start: u32::MAX,
+            open_end: u32::MAX,
+        };
+        let encoded = STANDARD.encode(serde_json::to_vec(&metadata_slice).unwrap());
+
+        for version in ["999", "1"] {
+            let html = format!(
+                r#"<meta data-slice-v2="{encoded}" data-version="{version}"><div data-root><p>body</p></div>"#
+            );
+            let slice = Slice::from_html(&html, &Resource::new_test());
+            assert_eq!(slice.to_text(), "body");
+            assert_eq!((slice.open_start, slice.open_end), (0, 0));
+        }
+    }
+
+    #[test]
+    fn structurally_invalid_metadata_falls_back_to_body() {
+        let metadata_slice = Slice {
+            content: vec![Fragment::leaf(PlainNode::Unknown)],
+            open_start: 0,
+            open_end: 0,
+        };
+        let encoded = STANDARD.encode(serde_json::to_vec(&metadata_slice).unwrap());
+        let html = format!(
+            r#"<meta data-slice-v2="{encoded}" data-version="1"><div data-root><p>body</p></div>"#
+        );
+
+        let slice = Slice::from_html(&html, &Resource::new_test());
+
+        assert_eq!(slice.to_text(), "body");
+        assert_eq!((slice.open_start, slice.open_end), (0, 0));
     }
 
     #[test]

--- a/crates/editor-clipboard/src/html/serialize.rs
+++ b/crates/editor-clipboard/src/html/serialize.rs
@@ -3,118 +3,137 @@ use base64::Engine;
 use base64::engine::general_purpose::STANDARD;
 use editor_model::{Fragment, Modifier, PlainNode};
 use editor_resource::Resource;
+use serde::Serialize;
 
 pub fn to_html(slice: &Slice, resource: &Resource) -> String {
     let mut out = String::new();
     out.push_str(r#"<meta charset="utf-8">"#);
-    let meta_json = serde_json::to_string(slice).expect("Slice serde");
-    let meta_b64 = STANDARD.encode(meta_json.as_bytes());
+    let mut meta_json = Vec::new();
+    let mut serializer = serde_json::Serializer::new(&mut meta_json);
+    slice
+        .serialize(serde_stacker::Serializer::new(&mut serializer))
+        .expect("Slice serde");
+    let meta_b64 = STANDARD.encode(meta_json);
     out.push_str(&format!(
         r#"<meta data-slice-v2="{meta_b64}" data-version="1">"#,
     ));
     out.push_str("<div data-root>");
-    for fragment in &slice.content {
-        serialize_node(fragment, resource, &mut out);
-    }
+    serialize_forest(&slice.content, resource, &mut out);
     out.push_str("</div>");
     out
 }
 
-fn serialize_node(fragment: &Fragment, resource: &Resource, out: &mut String) {
-    match &fragment.node {
-        PlainNode::Text(t) => serialize_text(&t.text, &fragment.modifiers, resource, out),
-        PlainNode::HardBreak(_) => out.push_str("<br>"),
-        PlainNode::Tab(_) => out.push('\t'),
-        PlainNode::Paragraph(_) => wrap("p", fragment, resource, out, None),
-        PlainNode::BulletList(_) => wrap("ul", fragment, resource, out, None),
-        PlainNode::OrderedList(_) => wrap("ol", fragment, resource, out, None),
-        PlainNode::ListItem(_) => wrap("li", fragment, resource, out, None),
-        PlainNode::Blockquote(b) => wrap(
-            "blockquote",
-            fragment,
-            resource,
-            out,
-            Some(format!(r#"data-variant="{}""#, variant_str(&b.variant))),
-        ),
-        PlainNode::Callout(c) => wrap(
-            "aside",
-            fragment,
-            resource,
-            out,
-            Some(format!(
-                r#"data-callout data-variant="{}""#,
-                variant_str(&c.variant)
-            )),
-        ),
-        PlainNode::Fold(_) => wrap("details", fragment, resource, out, None),
-        PlainNode::FoldTitle(_) => wrap("summary", fragment, resource, out, None),
-        PlainNode::FoldContent(_) => {
-            for child in &fragment.children {
-                serialize_node(child, resource, out);
+enum SerializeTask<'a> {
+    Node(&'a Fragment),
+    Close(&'static str),
+}
+
+fn serialize_forest(fragments: &[Fragment], resource: &Resource, out: &mut String) {
+    let mut tasks = Vec::new();
+    push_children(&mut tasks, fragments);
+    while let Some(task) = tasks.pop() {
+        let fragment = match task {
+            SerializeTask::Node(fragment) => fragment,
+            SerializeTask::Close(tag) => {
+                out.push_str(tag);
+                continue;
             }
-        }
-        PlainNode::Table(t) => wrap(
-            "table",
-            fragment,
-            resource,
-            out,
-            Some(format!(
-                r#"data-border-style="{}" data-proportion="{}""#,
-                variant_str(&t.border_style),
-                t.proportion,
-            )),
-        ),
-        PlainNode::TableRow(_) => wrap("tr", fragment, resource, out, None),
-        PlainNode::TableCell(c) => {
-            let attrs = c.col_width.map(|w| format!(r#"data-col-width="{w}""#));
-            wrap("td", fragment, resource, out, attrs);
-        }
-        PlainNode::Image(i) => {
-            out.push_str(&format!(
-                r#"<img data-id="{}" data-proportion="{}">"#,
-                html_escape(i.id.as_deref().unwrap_or("")),
-                i.proportion,
-            ));
-        }
-        PlainNode::Embed(e) => {
-            out.push_str(&format!(
-                r#"<a data-embed data-id="{}"></a>"#,
-                html_escape(e.id.as_deref().unwrap_or("")),
-            ));
-        }
-        PlainNode::File(f) => {
-            out.push_str(&format!(
-                r#"<a data-file data-id="{}"></a>"#,
-                html_escape(f.id.as_deref().unwrap_or("")),
-            ));
-        }
-        PlainNode::Archived(_) => {}
-        PlainNode::PageBreak(_) => out.push_str(r#"<div style="page-break-after:always"></div>"#),
-        PlainNode::HorizontalRule(_) => out.push_str("<hr>"),
-        PlainNode::Root(_) => {
-            for child in &fragment.children {
-                serialize_node(child, resource, out);
+        };
+        match &fragment.node {
+            PlainNode::Text(t) => serialize_text(&t.text, &fragment.modifiers, resource, out),
+            PlainNode::HardBreak(_) => out.push_str("<br>"),
+            PlainNode::Tab(_) => out.push('\t'),
+            PlainNode::Paragraph(_) => open_container("<p>", "</p>", fragment, &mut tasks, out),
+            PlainNode::BulletList(_) => open_container("<ul>", "</ul>", fragment, &mut tasks, out),
+            PlainNode::OrderedList(_) => open_container("<ol>", "</ol>", fragment, &mut tasks, out),
+            PlainNode::ListItem(_) => open_container("<li>", "</li>", fragment, &mut tasks, out),
+            PlainNode::Blockquote(b) => open_container(
+                &format!(r#"<blockquote data-variant="{}">"#, variant_str(&b.variant)),
+                "</blockquote>",
+                fragment,
+                &mut tasks,
+                out,
+            ),
+            PlainNode::Callout(c) => open_container(
+                &format!(
+                    r#"<aside data-callout data-variant="{}">"#,
+                    variant_str(&c.variant)
+                ),
+                "</aside>",
+                fragment,
+                &mut tasks,
+                out,
+            ),
+            PlainNode::Fold(_) => {
+                open_container("<details>", "</details>", fragment, &mut tasks, out)
             }
+            PlainNode::FoldTitle(_) => {
+                open_container("<summary>", "</summary>", fragment, &mut tasks, out)
+            }
+            PlainNode::FoldContent(_) => push_children(&mut tasks, &fragment.children),
+            PlainNode::Table(t) => open_container(
+                &format!(
+                    r#"<table data-border-style="{}" data-proportion="{}">"#,
+                    variant_str(&t.border_style),
+                    t.proportion,
+                ),
+                "</table>",
+                fragment,
+                &mut tasks,
+                out,
+            ),
+            PlainNode::TableRow(_) => open_container("<tr>", "</tr>", fragment, &mut tasks, out),
+            PlainNode::TableCell(c) => {
+                let open = match c.col_width {
+                    Some(width) => format!(r#"<td data-col-width="{width}">"#),
+                    None => "<td>".to_string(),
+                };
+                open_container(&open, "</td>", fragment, &mut tasks, out);
+            }
+            PlainNode::Image(i) => {
+                out.push_str(&format!(
+                    r#"<img data-id="{}" data-proportion="{}">"#,
+                    html_escape(i.id.as_deref().unwrap_or("")),
+                    i.proportion,
+                ));
+            }
+            PlainNode::Embed(e) => {
+                out.push_str(&format!(
+                    r#"<a data-embed data-id="{}"></a>"#,
+                    html_escape(e.id.as_deref().unwrap_or("")),
+                ));
+            }
+            PlainNode::File(f) => {
+                out.push_str(&format!(
+                    r#"<a data-file data-id="{}"></a>"#,
+                    html_escape(f.id.as_deref().unwrap_or("")),
+                ));
+            }
+            PlainNode::Archived(_) => {}
+            PlainNode::PageBreak(_) => {
+                out.push_str(r#"<div style="page-break-after:always"></div>"#)
+            }
+            PlainNode::HorizontalRule(_) => out.push_str("<hr>"),
+            PlainNode::Root(_) => push_children(&mut tasks, &fragment.children),
+            PlainNode::Unknown => {}
         }
-        PlainNode::Unknown => {}
     }
 }
 
-fn wrap(
-    tag: &str,
-    fragment: &Fragment,
-    resource: &Resource,
+fn open_container<'a>(
+    open: &str,
+    close: &'static str,
+    fragment: &'a Fragment,
+    tasks: &mut Vec<SerializeTask<'a>>,
     out: &mut String,
-    attrs: Option<String>,
 ) {
-    match attrs {
-        Some(a) => out.push_str(&format!("<{tag} {a}>")),
-        None => out.push_str(&format!("<{tag}>")),
-    }
-    for c in &fragment.children {
-        serialize_node(c, resource, out);
-    }
-    out.push_str(&format!("</{tag}>"));
+    out.push_str(open);
+    tasks.push(SerializeTask::Close(close));
+    push_children(tasks, &fragment.children);
+}
+
+fn push_children<'a>(tasks: &mut Vec<SerializeTask<'a>>, children: &'a [Fragment]) {
+    tasks.extend(children.iter().rev().map(SerializeTask::Node));
 }
 
 // 변형 enum 들은 #[serde(rename_all = "snake_case")] 의 plain string 직렬화를 가정

--- a/crates/editor-clipboard/src/lib.rs
+++ b/crates/editor-clipboard/src/lib.rs
@@ -9,4 +9,4 @@ pub mod text;
 pub(crate) mod test_doc;
 
 pub use payload::ClipboardPayload;
-pub use slice::{PayloadSource, Slice};
+pub use slice::{PayloadSource, Slice, SlicePreflight};

--- a/crates/editor-clipboard/src/slice.rs
+++ b/crates/editor-clipboard/src/slice.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use editor_crdt::Dot;
 use editor_model::{
     ChildView, DocView, Fragment, LeafView, Modifier, ModifierType, NodeType, NodeView,
-    OwnModifier, PlainNode, PlainTextNode,
+    OwnModifier, PlainNode, PlainTextNode, Schema,
 };
 use editor_resource::Resource;
 use editor_state::State;
@@ -15,6 +15,12 @@ use crate::html::serialize as html_serialize;
 use crate::payload::ClipboardPayload;
 use crate::text::parse as text_parse;
 use crate::text::serialize as text_serialize;
+
+/// Upper bounds on decoded Fragment work admitted to command-side fitting.
+/// The node budget bounds iterative validation work, while the depth budget
+/// keeps later recursive fitting and projection within the tested stack.
+const SLICE_PREFLIGHT_NODE_BUDGET: usize = 1_000_000;
+const MAX_SLICE_STRUCTURE_DEPTH: usize = 32;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -28,6 +34,21 @@ pub struct Slice {
 pub enum PayloadSource {
     Html,
     Text,
+}
+
+pub struct SlicePreflight {
+    pub contains_table: bool,
+    max_depth: usize,
+}
+
+impl SlicePreflight {
+    /// Keep recursive fitting and projection work within a bounded structural
+    /// depth. `destination_depth` excludes the document root.
+    pub fn fits_at_destination_depth(&self, destination_depth: usize) -> bool {
+        destination_depth
+            .checked_add(self.max_depth)
+            .is_some_and(|depth| depth <= MAX_SLICE_STRUCTURE_DEPTH)
+    }
 }
 
 impl Slice {
@@ -57,11 +78,11 @@ impl Slice {
         let open_end =
             (to_block_depth.saturating_sub(common_depth)) as u32 + to.is_inline_position() as u32;
 
-        let fragment = build_fragment(state, &common_nv, &rs);
+        let mut fragment = build_fragment(state, &common_nv, &rs);
 
         let mut slice = if can_use_as_slice_roots(&fragment.children) {
             Slice::new(
-                fragment.children,
+                std::mem::take(&mut fragment.children),
                 open_start.saturating_sub(1),
                 open_end.saturating_sub(1),
             )
@@ -126,11 +147,95 @@ impl Slice {
         self.content.is_empty()
     }
 
+    /// Whether both declared open edges exist in the Fragment forest and
+    /// contain only wrappers that can actually be opened.
+    ///
+    /// The walk is bounded by the decoded forest rather than the advertised
+    /// `u32` depth, so malformed clipboard metadata cannot request an
+    /// allocation or loop proportional to that value.
+    fn has_valid_open_edges(&self) -> bool {
+        if self.content.is_empty() {
+            return self.open_start == 0 && self.open_end == 0;
+        }
+        fragment_has_open_edge(self.content.first(), self.open_start, true)
+            && fragment_has_open_edge(self.content.last(), self.open_end, false)
+    }
+
+    /// Validate the decoded forest before routing or fitting it.
+    ///
+    /// The scan is iterative so malformed metadata cannot turn advertised or
+    /// decoded Fragment depth into recursive validation work.
+    pub fn preflight(&self) -> Option<SlicePreflight> {
+        self.inspect_structure(Some(MAX_SLICE_STRUCTURE_DEPTH))
+    }
+
+    pub(crate) fn has_valid_structure(&self) -> bool {
+        self.inspect_structure(None).is_some()
+    }
+
+    fn inspect_structure(&self, depth_limit: Option<usize>) -> Option<SlicePreflight> {
+        if depth_limit.is_some_and(|limit| {
+            u64::from(self.open_start) > limit as u64 || u64::from(self.open_end) > limit as u64
+        }) {
+            return None;
+        }
+        if !self.has_valid_open_edges() {
+            return None;
+        }
+        let mut contains_table = false;
+        let mut max_depth = 0;
+        let mut remaining = SLICE_PREFLIGHT_NODE_BUDGET;
+        let mut stack: Vec<_> = self.content.iter().map(|fragment| (fragment, 1)).collect();
+        while let Some((fragment, depth)) = stack.pop() {
+            if remaining == 0
+                || depth_limit.is_some_and(|limit| depth > limit)
+                || fragment.node.as_type() == NodeType::Unknown
+            {
+                return None;
+            }
+            remaining -= 1;
+            max_depth = max_depth.max(depth);
+            contains_table |= fragment.node.as_type() == NodeType::Table;
+            stack.extend(fragment.children.iter().map(|child| (child, depth + 1)));
+        }
+        Some(SlicePreflight {
+            contains_table,
+            max_depth,
+        })
+    }
+
     pub fn to_payload(&self, resource: &Resource) -> ClipboardPayload {
         ClipboardPayload {
             html: self.to_html(resource),
             text: self.to_text(),
         }
+    }
+}
+
+fn fragment_has_open_edge(root: Option<&Fragment>, mut depth: u32, first: bool) -> bool {
+    if depth == 0 {
+        return true;
+    }
+    let Some(mut current) = root else {
+        return false;
+    };
+    loop {
+        if Schema::node_spec(current.node.as_type()).inline {
+            return false;
+        }
+        depth -= 1;
+        if depth == 0 {
+            return true;
+        }
+        let next = if first {
+            current.children.first()
+        } else {
+            current.children.last()
+        };
+        let Some(next) = next else {
+            return false;
+        };
+        current = next;
     }
 }
 
@@ -1053,6 +1158,107 @@ mod tests {
         );
         assert_eq!(source, PayloadSource::Text);
         assert_eq!(parsed.to_text(), "plain");
+    }
+
+    #[test]
+    fn empty_metadata_falls_back_to_non_empty_html_body() {
+        use base64::Engine;
+
+        let empty = Slice::new(vec![], 0, 0);
+        let encoded =
+            base64::engine::general_purpose::STANDARD.encode(serde_json::to_vec(&empty).unwrap());
+        let html = format!(
+            r#"<meta data-slice-v2="{encoded}" data-version="1"><div data-root><p>body</p></div>"#
+        );
+
+        let (parsed, source) = Slice::from_payload(Some(&html), "plain", &Resource::new_test());
+
+        assert_eq!(source, PayloadSource::Html);
+        assert_eq!(parsed.to_text(), "body");
+    }
+
+    #[test]
+    fn invalid_open_metadata_with_empty_body_falls_back_to_plain_text() {
+        use base64::Engine;
+
+        let invalid = Slice {
+            content: vec![
+                Fragment::leaf(PlainNode::Paragraph(PlainParagraphNode::default())).with_children(
+                    vec![Fragment::leaf(PlainNode::Text(PlainTextNode {
+                        text: "metadata".into(),
+                    }))],
+                ),
+            ],
+            open_start: u32::MAX,
+            open_end: 0,
+        };
+        let encoded =
+            base64::engine::general_purpose::STANDARD.encode(serde_json::to_vec(&invalid).unwrap());
+        let html = format!(r#"<meta data-slice-v2="{encoded}" data-version="1">"#);
+
+        let (parsed, source) = Slice::from_payload(Some(&html), "plain", &Resource::new_test());
+
+        assert_eq!(source, PayloadSource::Text);
+        assert_eq!(parsed.to_text(), "plain");
+    }
+
+    #[test]
+    fn structurally_invalid_metadata_with_empty_body_falls_back_to_plain_text() {
+        use base64::Engine;
+
+        let invalid = Slice {
+            content: vec![Fragment::leaf(PlainNode::Unknown)],
+            open_start: 0,
+            open_end: 0,
+        };
+        let encoded =
+            base64::engine::general_purpose::STANDARD.encode(serde_json::to_vec(&invalid).unwrap());
+        let html = format!(r#"<meta data-slice-v2="{encoded}" data-version="1">"#);
+
+        let (parsed, source) = Slice::from_payload(Some(&html), "plain", &Resource::new_test());
+
+        assert_eq!(source, PayloadSource::Text);
+        assert_eq!(parsed.to_text(), "plain");
+    }
+
+    #[test]
+    fn slice_open_edges_must_exist_and_remain_non_inline() {
+        let paragraph = Fragment::leaf(PlainNode::Paragraph(PlainParagraphNode::default()))
+            .with_children(vec![Fragment::leaf(PlainNode::Text(PlainTextNode {
+                text: "x".into(),
+            }))]);
+
+        assert!(Slice::new(vec![paragraph.clone()], 1, 1).has_valid_open_edges());
+        assert!(!Slice::new(vec![paragraph.clone()], 2, 1).has_valid_open_edges());
+        assert!(!Slice::new(vec![paragraph], u32::MAX, 0).has_valid_open_edges());
+        assert!(
+            !Slice {
+                content: vec![],
+                open_start: 1,
+                open_end: 0,
+            }
+            .has_valid_open_edges()
+        );
+    }
+
+    #[test]
+    fn slice_preflight_bounds_source_and_resulting_structure_depth() {
+        let nested = |depth: usize| {
+            let mut fragment = Fragment::leaf(PlainNode::Text(PlainTextNode { text: "x".into() }));
+            for _ in 1..depth {
+                fragment = Fragment::leaf(PlainNode::Blockquote(
+                    editor_model::PlainBlockquoteNode::default(),
+                ))
+                .with_children(vec![fragment]);
+            }
+            Slice::new(vec![fragment], 0, 0)
+        };
+
+        let at_limit = nested(MAX_SLICE_STRUCTURE_DEPTH);
+        let preflight = at_limit.preflight().expect("source at the limit");
+        assert!(preflight.fits_at_destination_depth(0));
+        assert!(!preflight.fits_at_destination_depth(1));
+        assert!(nested(MAX_SLICE_STRUCTURE_DEPTH + 1).preflight().is_none());
     }
 
     #[test]

--- a/crates/editor-clipboard/src/text/serialize.rs
+++ b/crates/editor-clipboard/src/text/serialize.rs
@@ -4,8 +4,20 @@ use editor_model::{Fragment, PlainNode, Schema};
 pub fn to_text(slice: &Slice) -> String {
     let mut out = String::new();
     let mut context = TextContext::default();
-    for fragment in &slice.content {
-        walk(fragment, &mut out, &mut context);
+    let mut stack: Vec<_> = slice.content.iter().rev().collect();
+    while let Some(fragment) = stack.pop() {
+        match &fragment.node {
+            PlainNode::Text(t) => out.push_str(&t.text),
+            PlainNode::HardBreak(_) => out.push('\n'),
+            PlainNode::Tab(_) => out.push('\t'),
+            PlainNode::Table(_) => walk_table(fragment, &mut out, &mut context),
+            _ => {
+                if is_textblock_node(&fragment.node) {
+                    separate_textblock(&mut out, &mut context);
+                }
+                stack.extend(fragment.children.iter().rev());
+            }
+        }
     }
     out
 }
@@ -13,23 +25,6 @@ pub fn to_text(slice: &Slice) -> String {
 #[derive(Default)]
 struct TextContext {
     seen_textblock: bool,
-}
-
-fn walk(fragment: &Fragment, out: &mut String, context: &mut TextContext) {
-    match &fragment.node {
-        PlainNode::Text(t) => out.push_str(&t.text),
-        PlainNode::HardBreak(_) => out.push('\n'),
-        PlainNode::Tab(_) => out.push('\t'),
-        PlainNode::Table(_) => walk_table(fragment, out, context),
-        _ => {
-            if is_textblock_node(&fragment.node) {
-                separate_textblock(out, context);
-            }
-            for child in &fragment.children {
-                walk(child, out, context);
-            }
-        }
-    }
 }
 
 fn is_textblock_node(n: &PlainNode) -> bool {
@@ -71,14 +66,12 @@ fn walk_table(table: &Fragment, out: &mut String, context: &mut TextContext) {
 }
 
 fn collect_cell_text(node: &Fragment, out: &mut String) {
-    match &node.node {
-        PlainNode::Text(t) => out.push_str(&t.text),
-        PlainNode::HardBreak(_) => out.push(' '),
-        PlainNode::Tab(_) => out.push(' '),
-        _ => {
-            for c in &node.children {
-                collect_cell_text(c, out);
-            }
+    let mut stack = vec![node];
+    while let Some(fragment) = stack.pop() {
+        match &fragment.node {
+            PlainNode::Text(t) => out.push_str(&t.text),
+            PlainNode::HardBreak(_) | PlainNode::Tab(_) => out.push(' '),
+            _ => stack.extend(fragment.children.iter().rev()),
         }
     }
 }

--- a/crates/editor-commands/src/commands/delete_selection.rs
+++ b/crates/editor-commands/src/commands/delete_selection.rs
@@ -1086,6 +1086,20 @@ mod tests {
             }
             selection: (p2, 1) -> (p3, 0)
         };
+        let planned = crate::helpers::plan_linear_deletion(
+            &initial.view(),
+            initial.selection.expect("selection"),
+        )
+        .unwrap()
+        .expect("linear deletion");
+        let join = crate::helpers::plan_linear_join(&initial.view(), &planned)
+            .unwrap()
+            .expect("joined deletion");
+        assert_eq!(
+            join.container_merges.len(),
+            2,
+            "the nested-list seam and its two outer list items must both be planned"
+        );
         let (actual, ..) = transact!(initial, |tr| delete_selection(&mut tr));
         let (expected, ..) = state! {
             doc {

--- a/crates/editor-commands/src/commands/fill_cell_rect_with_slice.rs
+++ b/crates/editor-commands/src/commands/fill_cell_rect_with_slice.rs
@@ -1,51 +1,69 @@
 use std::collections::BTreeMap;
 
+#[cfg(test)]
 use editor_clipboard::Slice;
 use editor_crdt::Dot;
-use editor_model::{Fragment, Modifier, PlainNode, PlainParagraphNode};
+use editor_model::{Modifier, NodeType};
 use editor_state::{PendingModifiers, Position, Selection, apply_pending};
 use editor_transaction::Transaction;
 
 use crate::helpers::{
     cell_first_charlike_block, consume_pending_modifiers, find_first_text_position,
-    paint_block_uniformly, repair_slice_fragments, replace_cell_children,
+    materialize_planned_endpoint, paint_block_uniformly, replace_cell_children,
     resolve_effective_modifiers,
 };
+use crate::judgments::{CellFillPlan, TableFinalSelection};
 use crate::types::SliceProvenance;
 use crate::{CommandError, CommandResult};
 
 /// Replace every cell in a cell-rect selection with the same slice content.
 /// Inline-only slices are wrapped in a single paragraph so the cell stays
 /// schema-valid; block slices are inserted verbatim.
-pub fn fill_cell_rect_with_slice(
+#[cfg(test)]
+fn fill_cell_rect_with_slice(
     tr: &mut Transaction,
-    mut slice: Slice,
+    slice: Slice,
     provenance: SliceProvenance,
 ) -> CommandResult {
-    repair_slice_fragments(&mut slice.content);
-    let blocks = slice_to_cell_blocks(&slice);
-    if blocks.is_empty() {
-        return Ok(false);
-    }
+    crate::insert_slice(tr, slice, provenance)
+}
 
-    let (anchor_cell_id, cell_ids) = {
-        let Some(sel) = tr.selection() else {
-            return Ok(false);
-        };
+pub(crate) fn apply_cell_fill_plan(
+    tr: &mut Transaction,
+    plan: CellFillPlan,
+    provenance: SliceProvenance,
+) -> CommandResult {
+    let cell_ids = plan
+        .cells
+        .iter()
+        .map(|cell| materialize_planned_endpoint(tr, cell).map(|position| position.node))
+        .collect::<Result<Vec<_>, _>>()?;
+    let anchor_cell_id = *cell_ids
+        .first()
+        .ok_or_else(|| CommandError::Corrupted("cell-fill Slice plan has no anchor cell".into()))?;
+    let structure_matches = {
         let view = tr.view();
-        let Some(rs) = sel.resolve(&view) else {
-            return Ok(false);
-        };
-        let Some(rect) = rs.as_cell_rect() else {
-            return Ok(false);
-        };
-        let ids: Vec<Dot> = rect.cells().into_iter().map(|c| c.id()).collect();
-        if ids.is_empty() {
-            return Ok(false);
-        }
-        (ids[0], ids)
+        cell_ids
+            .iter()
+            .zip(&plan.original_child_types)
+            .all(|(cell_id, expected)| {
+                view.node(*cell_id).is_some_and(|cell| {
+                    cell.node_type() == NodeType::TableCell
+                        && cell
+                            .children()
+                            .map(|child| match child {
+                                editor_model::ChildView::Block(block) => block.node_type(),
+                                editor_model::ChildView::Leaf(leaf) => leaf.node_type(),
+                            })
+                            .eq(expected.iter().copied())
+                })
+            })
     };
-
+    if !structure_matches {
+        return Err(CommandError::Corrupted(
+            "cell-fill Slice target changed after planning".into(),
+        ));
+    }
     let pending = if provenance.is_plain() {
         let pending = tr.pending_modifiers().clone();
         consume_pending_modifiers(tr)?;
@@ -59,7 +77,7 @@ pub fn fill_cell_rect_with_slice(
             let paint = pending
                 .as_ref()
                 .map(|pending| cell_plain_paint(tr, *cell_id, pending));
-            replace_cell_children(tr, *cell_id, &blocks)?;
+            replace_cell_children(tr, *cell_id, &plan.blocks)?;
             if let Some(paint) = &paint {
                 let block_ids: Vec<Dot> = {
                     let view = tr.view();
@@ -72,12 +90,16 @@ pub fn fill_cell_rect_with_slice(
                 }
             }
         }
+        let cursor = match plan.final_selection {
+            TableFinalSelection::FirstTextInAnchorCell => {
+                find_first_text_position(&tr.view(), anchor_cell_id)
+                    .unwrap_or_else(|| Position::new(anchor_cell_id, 0))
+            }
+        };
+        tr.set_selection(Some(Selection::collapsed(cursor)))?;
         Ok(())
     })?;
 
-    let cursor = find_first_text_position(&tr.view(), anchor_cell_id)
-        .unwrap_or_else(|| Position::new(anchor_cell_id, 0));
-    tr.set_selection(Some(Selection::collapsed(cursor)))?;
     Ok(true)
 }
 
@@ -96,36 +118,6 @@ fn cell_plain_paint(tr: &Transaction, cell_id: Dot, pending: &PendingModifiers) 
             map.into_values().collect()
         }
     }
-}
-
-fn slice_to_cell_blocks(slice: &Slice) -> Vec<Fragment> {
-    let top_children: Vec<&Fragment> = slice.content.iter().collect();
-
-    let mut out: Vec<Fragment> = Vec::new();
-    let mut inline_run: Vec<Fragment> = Vec::new();
-    let flush = |run: &mut Vec<Fragment>, out: &mut Vec<Fragment>| {
-        if !run.is_empty() {
-            out.push(Fragment {
-                node: PlainNode::Paragraph(PlainParagraphNode::default()),
-                modifiers: vec![],
-                carry: vec![],
-                children: std::mem::take(run),
-            });
-        }
-    };
-    for child in top_children {
-        match &child.node {
-            PlainNode::Text(_) | PlainNode::HardBreak(_) | PlainNode::Tab(_) => {
-                inline_run.push(child.clone())
-            }
-            _ => {
-                flush(&mut inline_run, &mut out);
-                out.push(child.clone());
-            }
-        }
-    }
-    flush(&mut inline_run, &mut out);
-    out
 }
 
 #[cfg(test)]
@@ -195,19 +187,6 @@ mod tests {
             .carry_modifiers(block)
             .into_values()
             .collect()
-    }
-
-    #[test]
-    fn returns_false_when_selection_is_not_cell_rect() {
-        let (initial, ..) = state! {
-            doc { root { p1: paragraph { text("hello") } } }
-            selection: (p1, 0) -> (p1, 5)
-        };
-        transact_fail!(initial, |tr| fill_cell_rect_with_slice(
-            &mut tr,
-            Slice::from_text("hi"),
-            SliceProvenance::Formatted
-        ));
     }
 
     #[test]

--- a/crates/editor-commands/src/commands/insert_slice.rs
+++ b/crates/editor-commands/src/commands/insert_slice.rs
@@ -1,9 +1,23 @@
+use std::collections::HashMap;
+
 use editor_clipboard::Slice;
-use editor_state::is_unit_node_selection;
+use editor_state::{Position, Selection, is_unit_node_selection};
 use editor_transaction::Transaction;
 
 use crate::CommandResult;
-use crate::judgments::insert_slice_at_position;
+use crate::commands::{apply_cell_fill_plan, apply_table_grid_plan};
+use crate::helpers::{
+    LinearJoinExecution, SliceInsertionTarget, SliceOutputPositionSpec, SliceOutputRelation,
+    apply_cross_range_removal_without_join, apply_linear_deletion_plan, block_parent_and_index,
+    install_planned_selection, materialize_planned_endpoint, materialize_planned_selection,
+    remap_linear_deletion_plan, split_block_wrapper_before_child,
+};
+use crate::judgments::{
+    AppliedSliceInsertion, FitOutcome, JoinedReplacementPlan, LinearFinalSelection, LinearFitPlan,
+    LinearMutation, PlannedBoundaryInsertion, PlannedBranchInsertion, PlannedBranchNode,
+    PlannedBranchSplit, PlannedJoin, PlannedOutputKey, RangePlacement, SliceFitPlan,
+    SliceFitPlanKind, apply_slice_insertion_plan, fit_slice,
+};
 use crate::types::SliceProvenance;
 
 pub fn insert_slice(
@@ -14,13 +28,11 @@ pub fn insert_slice(
     let Some(selection) = tr.selection() else {
         return Ok(false);
     };
-    if selection.anchor != selection.head {
-        return Ok(false);
-    }
-
-    let Some(inserted) = insert_slice_at_position(tr, selection.head, slice, provenance)? else {
-        return Ok(false);
+    let plan = match fit_slice(tr.state(), selection, slice)? {
+        FitOutcome::Plan(plan) => plan,
+        FitOutcome::NoOp | FitOutcome::NoFit => return Ok(false),
     };
+    let inserted = apply_fitted_slice(tr, plan, provenance)?;
     let unit = is_unit_node_selection(&inserted, &tr.view());
     if unit {
         tr.set_selection(Some(inserted))?;
@@ -28,20 +40,651 @@ pub fn insert_slice(
     Ok(true)
 }
 
+pub(crate) fn apply_fitted_slice(
+    tr: &mut Transaction,
+    plan: SliceFitPlan,
+    provenance: SliceProvenance,
+) -> Result<editor_state::Selection, crate::CommandError> {
+    let mut inserted = None;
+    tr.batch::<_, crate::CommandError>(|tr| {
+        inserted = match plan.kind {
+            SliceFitPlanKind::Linear(plan) => apply_linear_fit_plan(tr, plan, provenance)?,
+            SliceFitPlanKind::TableGrid(plan) => {
+                apply_table_grid_plan(tr, plan)?;
+                tr.selection()
+            }
+            SliceFitPlanKind::CellFill(plan) => {
+                apply_cell_fill_plan(tr, plan, provenance)?;
+                tr.selection()
+            }
+        };
+        if inserted.is_none() {
+            return Err(crate::CommandError::Corrupted(
+                "fitted Slice plan produced no observable change".into(),
+            ));
+        }
+        Ok(())
+    })?;
+    inserted.ok_or_else(|| {
+        crate::CommandError::Corrupted("fitted Slice plan produced no observable change".into())
+    })
+}
+
+fn apply_linear_fit_plan(
+    tr: &mut Transaction,
+    plan: LinearFitPlan,
+    provenance: SliceProvenance,
+) -> Result<Option<editor_state::Selection>, crate::CommandError> {
+    let LinearFitPlan {
+        selection: planned_selection,
+        mutation,
+        final_selection,
+    } = plan;
+    let mut applied_insertion = None;
+    let mut deletion_boundary = None;
+    match mutation {
+        LinearMutation::PointInsertion { insertion } => {
+            let planned = install_planned_selection(tr, &planned_selection)?;
+            let applied = apply_slice_insertion_plan(tr, planned.head, insertion, provenance)?;
+            bind_insertion_result(&mut applied_insertion, applied)?;
+        }
+        LinearMutation::RangeReplacement {
+            deletion,
+            placement,
+        } => match placement {
+            RangePlacement::Joined(JoinedReplacementPlan {
+                destination,
+                join,
+                insertion,
+            }) => {
+                materialize_planned_selection(tr, &planned_selection)?;
+                let destination = materialize_planned_endpoint(tr, &destination)?;
+                let join = join
+                    .map(|join| materialize_planned_join(tr, join))
+                    .transpose()?;
+                let actual = current_materialized_selection(tr)?;
+                let deletion = remap_linear_deletion_plan(&tr.view(), &deletion, actual)?;
+                let deleted = apply_linear_deletion_plan(tr, &deletion, join.as_ref(), true)?;
+                if !deleted {
+                    return Err(crate::CommandError::Corrupted(
+                        "fitted Slice replacement did not delete its range".into(),
+                    ));
+                }
+                if tr.view().node(destination.node).is_none() {
+                    return Err(crate::CommandError::Corrupted(
+                        "fitted Slice replacement lost its target survivor".into(),
+                    ));
+                }
+                let applied = apply_slice_insertion_plan(tr, destination, insertion, provenance)?;
+                bind_insertion_result(&mut applied_insertion, applied)?;
+            }
+            RangePlacement::PreservedBoundary(insertion) => {
+                materialize_planned_selection(tr, &planned_selection)?;
+                let insertion = materialize_boundary_insertion(tr, insertion)?;
+                let actual = current_materialized_selection(tr)?;
+                let deletion = remap_linear_deletion_plan(&tr.view(), &deletion, actual)?;
+                if !apply_cross_range_removal_without_join(tr, &deletion)? {
+                    return Err(crate::CommandError::Corrupted(
+                        "fitted Slice did not remove its preserved-boundary range".into(),
+                    ));
+                }
+                let applied = apply_boundary_insertion(tr, insertion, provenance)?;
+                bind_insertion_result(&mut applied_insertion, applied)?;
+            }
+            RangePlacement::SeparatedBranches { boundary } => {
+                materialize_planned_selection(tr, &planned_selection)?;
+                let boundary = materialize_branch_insertion(tr, boundary)?;
+                let actual = current_materialized_selection(tr)?;
+                let deletion = remap_linear_deletion_plan(&tr.view(), &deletion, actual)?;
+                if !apply_cross_range_removal_without_join(tr, &deletion)? {
+                    return Err(crate::CommandError::Corrupted(
+                        "fitted Slice did not remove its separated range".into(),
+                    ));
+                }
+                let applied = apply_branch_insertion(tr, boundary, provenance)?;
+                bind_insertion_result(&mut applied_insertion, applied)?;
+            }
+            RangePlacement::SeparatedOpenEdges {
+                left,
+                middle,
+                right,
+            } => {
+                materialize_planned_selection(tr, &planned_selection)?;
+                let left = materialize_boundary_insertion(tr, left)?;
+                let middle = materialize_branch_insertion(tr, middle)?;
+                let right = materialize_boundary_insertion(tr, right)?;
+                let actual = current_materialized_selection(tr)?;
+                let deletion = remap_linear_deletion_plan(&tr.view(), &deletion, actual)?;
+                if !apply_cross_range_removal_without_join(tr, &deletion)? {
+                    return Err(crate::CommandError::Corrupted(
+                        "fitted Slice did not remove its open-edge range".into(),
+                    ));
+                }
+                let left = apply_boundary_insertion(tr, left, provenance)?;
+                validate_applied_insertion(tr, &left)?;
+                let right = apply_boundary_insertion(tr, right, provenance)?;
+                validate_applied_insertion(tr, &right)?;
+                let middle = apply_branch_insertion(tr, middle, provenance)?;
+                validate_applied_insertion(tr, &middle)?;
+                if applied_insertion
+                    .replace(AppliedLinearInsertion::SeparatedOpenEdges { left, right })
+                    .is_some()
+                {
+                    return Err(crate::CommandError::Corrupted(
+                        "Slice insertion result was bound more than once".into(),
+                    ));
+                }
+            }
+            RangePlacement::DeletionOnly { join } => {
+                materialize_planned_selection(tr, &planned_selection)?;
+                let join = join
+                    .map(|join| materialize_planned_join(tr, join))
+                    .transpose()?;
+                let actual = current_materialized_selection(tr)?;
+                let deletion = remap_linear_deletion_plan(&tr.view(), &deletion, actual)?;
+                if !apply_linear_deletion_plan(tr, &deletion, join.as_ref(), true)? {
+                    return Err(crate::CommandError::Corrupted(
+                        "fitted Slice deletion-only replacement did not delete its range".into(),
+                    ));
+                }
+                deletion_boundary = Some(
+                    tr.selection()
+                        .filter(|selection| selection.is_collapsed())
+                        .map(|selection| selection.head)
+                        .ok_or_else(|| {
+                            crate::CommandError::Corrupted(
+                                "Slice deletion-only plan produced no final boundary".into(),
+                            )
+                        })?,
+                );
+            }
+        },
+    }
+    let (caret, inserted) = match final_selection {
+        LinearFinalSelection::InsertedContent => {
+            let applied = applied_insertion.ok_or_else(|| {
+                crate::CommandError::Corrupted(
+                    "Slice plan produced no declared insertion result".into(),
+                )
+            })?;
+            match applied {
+                AppliedLinearInsertion::Single(applied) => {
+                    let caret =
+                        resolve_planned_output_position(tr, &applied, applied.output.caret)?;
+                    let inserted = Selection::new(
+                        resolve_planned_output_position(tr, &applied, applied.output.anchor)?,
+                        resolve_planned_output_position(tr, &applied, applied.output.head)?,
+                    );
+                    validate_observed_insertion_selection(tr, &applied, caret, inserted)?;
+                    (caret, inserted)
+                }
+                AppliedLinearInsertion::SeparatedOpenEdges { left, right } => {
+                    let caret = resolve_planned_output_position(tr, &right, right.output.caret)?;
+                    let inserted = Selection::new(
+                        resolve_planned_output_position(tr, &left, left.output.anchor)?,
+                        resolve_planned_output_position(tr, &right, right.output.head)?,
+                    );
+                    (caret, inserted)
+                }
+            }
+        }
+        LinearFinalSelection::DeletionBoundary => {
+            if applied_insertion.is_some() {
+                return Err(crate::CommandError::Corrupted(
+                    "deletion-only Slice plan unexpectedly inserted content".into(),
+                ));
+            }
+            let boundary = deletion_boundary.ok_or_else(|| {
+                crate::CommandError::Corrupted(
+                    "Slice deletion-only plan produced no final boundary".into(),
+                )
+            })?;
+            let boundary = resolve_final_position(tr, boundary)?;
+            (boundary, Selection::collapsed(boundary))
+        }
+    };
+    let caret = canonicalize_downstream_block_boundary(&tr.view(), caret);
+    tr.set_selection(Some(Selection::collapsed(caret)))?;
+    Ok(Some(inserted))
+}
+
+enum AppliedLinearInsertion {
+    Single(AppliedSliceInsertion),
+    SeparatedOpenEdges {
+        left: AppliedSliceInsertion,
+        right: AppliedSliceInsertion,
+    },
+}
+
+fn current_materialized_selection(tr: &Transaction) -> Result<Selection, crate::CommandError> {
+    let selection = tr.selection().ok_or_else(|| {
+        crate::CommandError::Corrupted(
+            "fitted Slice lost its materialized replacement selection".into(),
+        )
+    })?;
+    selection.normalize(&tr.view()).ok_or_else(|| {
+        crate::CommandError::Corrupted(
+            "fitted Slice materialized replacement no longer resolves".into(),
+        )
+    })
+}
+
+fn canonicalize_downstream_block_boundary(
+    view: &editor_model::DocView,
+    position: Position,
+) -> Position {
+    if position.affinity != editor_state::Affinity::Downstream {
+        return position;
+    }
+    let Some(parent) = view.node(position.node) else {
+        return position;
+    };
+    let Some(editor_model::ChildView::Block(next)) = parent.child_at(position.offset) else {
+        return position;
+    };
+    editor_state::first_cursor_position(&next).unwrap_or(position)
+}
+
+fn bind_insertion_result(
+    slot: &mut Option<AppliedLinearInsertion>,
+    applied: AppliedSliceInsertion,
+) -> Result<(), crate::CommandError> {
+    if slot
+        .replace(AppliedLinearInsertion::Single(applied))
+        .is_some()
+    {
+        return Err(crate::CommandError::Corrupted(
+            "Slice insertion result was bound more than once".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn resolve_final_position(
+    tr: &Transaction,
+    position: Position,
+) -> Result<Position, crate::CommandError> {
+    position
+        .resolve(&tr.view())
+        .map(|resolved| resolved.position())
+        .ok_or_else(|| {
+            crate::CommandError::Corrupted("Slice final selection output no longer resolves".into())
+        })
+}
+
+fn validate_observed_insertion_selection(
+    tr: &Transaction,
+    applied: &AppliedSliceInsertion,
+    caret: Position,
+    inserted: Selection,
+) -> Result<(), crate::CommandError> {
+    validate_observed_selection(
+        tr,
+        caret,
+        inserted,
+        applied.observed_caret,
+        applied.observed_inserted,
+    )
+}
+
+fn validate_applied_insertion(
+    tr: &Transaction,
+    applied: &AppliedSliceInsertion,
+) -> Result<(), crate::CommandError> {
+    let caret = resolve_planned_output_position(tr, applied, applied.output.caret)?;
+    let inserted = Selection::new(
+        resolve_planned_output_position(tr, applied, applied.output.anchor)?,
+        resolve_planned_output_position(tr, applied, applied.output.head)?,
+    );
+    validate_observed_insertion_selection(tr, applied, caret, inserted)
+}
+
+fn validate_observed_selection(
+    tr: &Transaction,
+    caret: Position,
+    inserted: Selection,
+    observed_caret: Position,
+    observed_inserted: Selection,
+) -> Result<(), crate::CommandError> {
+    let view = tr.view();
+    let normalize = |selection: Selection| selection.normalize(&view).unwrap_or(selection);
+    let planned_caret = normalize(Selection::collapsed(caret));
+    let observed_caret = normalize(Selection::collapsed(resolve_final_position(
+        tr,
+        observed_caret,
+    )?));
+    if planned_caret != observed_caret {
+        return Err(crate::CommandError::Corrupted(format!(
+            "Slice executor produced a different caret than the planned output: planned={planned_caret:?}, observed={observed_caret:?}"
+        )));
+    }
+    let planned_inserted = normalize(inserted);
+    let observed_inserted = normalize(Selection::new(
+        resolve_final_position(tr, observed_inserted.anchor)?,
+        resolve_final_position(tr, observed_inserted.head)?,
+    ));
+    if planned_inserted != observed_inserted {
+        return Err(crate::CommandError::Corrupted(format!(
+            "Slice executor produced a different inserted range than the planned output: planned={planned_inserted:?}, observed={observed_inserted:?}"
+        )));
+    }
+    Ok(())
+}
+
+fn resolve_planned_output_position(
+    tr: &Transaction,
+    applied: &AppliedSliceInsertion,
+    planned: SliceOutputPositionSpec,
+) -> Result<Position, crate::CommandError> {
+    let dot = applied.nodes.get(planned.node).copied().ok_or_else(|| {
+        crate::CommandError::Corrupted(
+            "Slice final selection referenced an unavailable planned output node".into(),
+        )
+    })?;
+    let dot = resolve_live_output_dot(tr, dot).ok_or_else(|| {
+        crate::CommandError::Corrupted(
+            "Slice final selection output node no longer resolves".into(),
+        )
+    })?;
+    let view = tr.view();
+    let mut position = match planned.relation {
+        SliceOutputRelation::Before | SliceOutputRelation::After => {
+            let (parent, index) = output_parent_and_index(&view, dot).ok_or_else(|| {
+                crate::CommandError::Corrupted(
+                    "Slice output node has no structural boundary".into(),
+                )
+            })?;
+            Position::new(
+                parent,
+                index + usize::from(matches!(planned.relation, SliceOutputRelation::After)),
+            )
+        }
+        SliceOutputRelation::AfterTerminalPageBreak => {
+            let paragraph = if view
+                .node(dot)
+                .is_some_and(|node| node.node_type() == editor_model::NodeType::Paragraph)
+            {
+                dot
+            } else {
+                view.block_of(dot).ok_or_else(|| {
+                    crate::CommandError::Corrupted(
+                        "terminal PageBreak output has no paragraph".into(),
+                    )
+                })?
+            };
+            let paragraph = view.node(paragraph).ok_or_else(|| {
+                crate::CommandError::Corrupted(
+                    "terminal PageBreak output paragraph no longer resolves".into(),
+                )
+            })?;
+            let parent = paragraph.parent().ok_or_else(|| {
+                crate::CommandError::Corrupted(
+                    "terminal PageBreak output paragraph has no parent".into(),
+                )
+            })?;
+            let index = paragraph.index().ok_or_else(|| {
+                crate::CommandError::Corrupted(
+                    "terminal PageBreak output paragraph has no parent slot".into(),
+                )
+            })?;
+            parent
+                .child_at(index + 1)
+                .and_then(|child| match child {
+                    editor_model::ChildView::Block(block) => {
+                        editor_state::first_cursor_position(&block)
+                    }
+                    editor_model::ChildView::Leaf(_) => None,
+                })
+                .unwrap_or(Position::new(parent.id(), index + 1))
+        }
+        SliceOutputRelation::Start => {
+            if let Some(node) = view.node(dot) {
+                editor_state::first_cursor_position(&node).unwrap_or(Position::new(dot, 0))
+            } else {
+                let (parent, index) = output_parent_and_index(&view, dot).ok_or_else(|| {
+                    crate::CommandError::Corrupted("Slice leaf output has no start boundary".into())
+                })?;
+                Position::new(parent, index)
+            }
+        }
+        SliceOutputRelation::End => {
+            if let Some(node) = view.node(dot) {
+                Position::new(dot, node.children().count())
+            } else {
+                let (parent, index) = output_parent_and_index(&view, dot).ok_or_else(|| {
+                    crate::CommandError::Corrupted("Slice leaf output has no end boundary".into())
+                })?;
+                Position::new(parent, index + 1)
+            }
+        }
+    };
+    position.affinity = planned.affinity;
+    Ok(position)
+}
+
+fn resolve_live_output_dot(tr: &Transaction, dot: editor_crdt::Dot) -> Option<editor_crdt::Dot> {
+    let view = tr.view();
+    if view.node(dot).is_some() || view.block_of(dot).is_some() {
+        return Some(dot);
+    }
+    let resolved = view.alias_classes().resolve_with(dot, |candidate| {
+        view.node(candidate).is_some() || view.block_of(candidate).is_some()
+    });
+    (view.node(resolved).is_some() || view.block_of(resolved).is_some()).then_some(resolved)
+}
+
+fn output_parent_and_index(
+    view: &editor_model::DocView,
+    dot: editor_crdt::Dot,
+) -> Option<(editor_crdt::Dot, usize)> {
+    if let Some(node) = view.node(dot) {
+        let parent = node.parent()?;
+        return Some((parent.id(), node.index()?));
+    }
+    let parent = view.block_of(dot)?;
+    let index = view.node(parent)?.children().position(
+        |child| matches!(child, editor_model::ChildView::Leaf(leaf) if leaf.dot() == dot),
+    )?;
+    Some((parent, index))
+}
+
+fn materialize_planned_join(
+    tr: &mut Transaction,
+    join: PlannedJoin,
+) -> Result<LinearJoinExecution, crate::CommandError> {
+    let from_textblock = materialize_planned_endpoint(tr, &join.from_textblock)?.node;
+    let to_textblock = materialize_planned_endpoint(tr, &join.to_textblock)?.node;
+    let prune = join
+        .prune
+        .iter()
+        .map(|endpoint| materialize_planned_endpoint(tr, endpoint).map(|position| position.node))
+        .collect::<Result<Vec<_>, _>>()?;
+    let container_merges = join
+        .container_merges
+        .iter()
+        .map(|merge| {
+            Ok((
+                materialize_planned_endpoint(tr, &merge.target)?.node,
+                materialize_planned_endpoint(tr, &merge.source)?.node,
+            ))
+        })
+        .collect::<Result<Vec<_>, crate::CommandError>>()?;
+    let affected = join
+        .affected
+        .iter()
+        .map(|endpoint| materialize_planned_endpoint(tr, endpoint).map(|position| position.node))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(LinearJoinExecution {
+        from_textblock,
+        to_textblock,
+        trailing_page_break: None,
+        prune,
+        container_merges,
+        affected,
+    })
+}
+
+struct MaterializedBoundaryInsertion {
+    destination: Position,
+    target: crate::helpers::SliceInsertionTargetShape,
+    insertion: crate::judgments::SliceInsertionPlan,
+}
+
+fn materialize_boundary_insertion(
+    tr: &mut Transaction,
+    insertion: PlannedBoundaryInsertion,
+) -> Result<MaterializedBoundaryInsertion, crate::CommandError> {
+    Ok(MaterializedBoundaryInsertion {
+        destination: materialize_planned_endpoint(tr, &insertion.destination)?,
+        target: insertion.target,
+        insertion: insertion.insertion,
+    })
+}
+
+fn apply_boundary_insertion(
+    tr: &mut Transaction,
+    insertion: MaterializedBoundaryInsertion,
+    provenance: SliceProvenance,
+) -> Result<AppliedSliceInsertion, crate::CommandError> {
+    let actual_target = SliceInsertionTarget::from_view(&tr.view(), insertion.destination)
+        .ok_or_else(|| {
+            crate::CommandError::Corrupted("fitted Slice lost its preserved boundary".into())
+        })?;
+    if !insertion.target.matches(&actual_target) {
+        return Err(crate::CommandError::Corrupted(
+            "fitted Slice changed its preserved boundary".into(),
+        ));
+    }
+    apply_slice_insertion_plan(tr, insertion.destination, insertion.insertion, provenance)
+}
+
+struct MaterializedBranchInsertion {
+    parent: editor_crdt::Dot,
+    splits: Vec<ResolvedBranchSplit>,
+    right_boundary: ResolvedBranchNode,
+    insertion: crate::judgments::SliceInsertionPlan,
+}
+
+fn materialize_branch_insertion(
+    tr: &mut Transaction,
+    insertion: PlannedBranchInsertion,
+) -> Result<MaterializedBranchInsertion, crate::CommandError> {
+    let parent = materialize_planned_endpoint(tr, &insertion.parent)?.node;
+    let (splits, right_boundary) =
+        materialize_branch_boundary(tr, insertion.splits, insertion.right_boundary)?;
+    Ok(MaterializedBranchInsertion {
+        parent,
+        splits,
+        right_boundary,
+        insertion: insertion.insertion,
+    })
+}
+
+fn apply_branch_insertion(
+    tr: &mut Transaction,
+    insertion: MaterializedBranchInsertion,
+    provenance: SliceProvenance,
+) -> Result<AppliedSliceInsertion, crate::CommandError> {
+    apply_planned_branch_boundary(
+        tr,
+        insertion.parent,
+        insertion.splits,
+        insertion.right_boundary,
+        insertion.insertion,
+        provenance,
+    )
+}
+
+enum ResolvedBranchNode {
+    Existing(editor_crdt::Dot),
+    Output(PlannedOutputKey),
+}
+
+struct ResolvedBranchSplit {
+    wrapper: editor_crdt::Dot,
+    first_right: ResolvedBranchNode,
+    output: PlannedOutputKey,
+}
+
+fn materialize_branch_boundary(
+    tr: &mut Transaction,
+    splits: Vec<PlannedBranchSplit>,
+    right_boundary: PlannedBranchNode,
+) -> Result<(Vec<ResolvedBranchSplit>, ResolvedBranchNode), crate::CommandError> {
+    let materialize_node =
+        |tr: &mut Transaction, node: PlannedBranchNode| -> Result<_, crate::CommandError> {
+            Ok(match node {
+                PlannedBranchNode::Existing(endpoint) => {
+                    ResolvedBranchNode::Existing(materialize_planned_endpoint(tr, &endpoint)?.node)
+                }
+                PlannedBranchNode::Output(output) => ResolvedBranchNode::Output(output),
+            })
+        };
+    let mut resolved = Vec::with_capacity(splits.len());
+    for split in splits {
+        resolved.push(ResolvedBranchSplit {
+            wrapper: materialize_planned_endpoint(tr, &split.wrapper)?.node,
+            first_right: materialize_node(tr, split.first_right)?,
+            output: split.output,
+        });
+    }
+    let right_boundary = materialize_node(tr, right_boundary)?;
+    Ok((resolved, right_boundary))
+}
+
+fn apply_planned_branch_boundary(
+    tr: &mut Transaction,
+    parent: editor_crdt::Dot,
+    splits: Vec<ResolvedBranchSplit>,
+    right_boundary: ResolvedBranchNode,
+    insertion: crate::judgments::SliceInsertionPlan,
+    provenance: SliceProvenance,
+) -> Result<AppliedSliceInsertion, crate::CommandError> {
+    let mut outputs = HashMap::with_capacity(splits.len());
+    let resolve_node = |node: ResolvedBranchNode,
+                        outputs: &HashMap<PlannedOutputKey, editor_crdt::Dot>|
+     -> Result<editor_crdt::Dot, crate::CommandError> {
+        match node {
+            ResolvedBranchNode::Existing(node) => Ok(node),
+            ResolvedBranchNode::Output(key) => outputs.get(&key).copied().ok_or_else(|| {
+                crate::CommandError::Corrupted(
+                    "fitted Slice boundary referenced an unavailable planned output".into(),
+                )
+            }),
+        }
+    };
+    for split in splits {
+        let first_right = resolve_node(split.first_right, &outputs)?;
+        let (right_wrapper, _) = split_block_wrapper_before_child(tr, split.wrapper, first_right)?;
+        outputs.insert(split.output, right_wrapper);
+    }
+    let right_boundary = resolve_node(right_boundary, &outputs)?;
+    let (actual_parent, index) = block_parent_and_index(&tr.view(), right_boundary)
+        .ok_or(crate::CommandError::NodeNotFound(right_boundary))?;
+    if actual_parent != parent {
+        return Err(crate::CommandError::Corrupted(
+            "fitted Slice right boundary did not reach its planned parent".into(),
+        ));
+    }
+    apply_slice_insertion_plan(tr, Position::new(parent, index), insertion, provenance)
+}
+
 #[cfg(test)]
 mod tests {
     use editor_clipboard::Slice;
-    use editor_crdt::Dot;
+    use editor_crdt::{Dot, ListOp, sequence::Bias as SeqBias};
     use editor_macros::state;
     use editor_model::{
-        Alignment, ChildView, Fragment, Modifier, NodeType, PlainNode, PlainParagraphNode,
-        PlainTextNode,
+        Alignment, ChildView, EditOp, Fragment, Modifier, NodeType, PlainBlockquoteNode,
+        PlainHorizontalRuleNode, PlainListItemNode, PlainNode, PlainOrderedListNode,
+        PlainPageBreakNode, PlainParagraphNode, PlainTextNode, SeqItem,
     };
     use editor_resource::Resource;
     use editor_state::{Position, Selection, State};
     use editor_transaction::Step;
 
     use super::*;
+    use crate::helpers::PlannedEndpoint;
     use crate::test_utils::*;
 
     fn root_child_dots(state: &State) -> Vec<Dot> {
@@ -69,6 +712,23 @@ mod tests {
             .collect()
     }
 
+    fn invert_recorded_ops(
+        state: &mut State,
+        ops: &[editor_state::undo::RecordedOp],
+    ) -> Vec<editor_state::undo::RecordedOp> {
+        use editor_state::undo::{RecordedOp, capture_prior, invert};
+
+        let mut out = Vec::new();
+        for recorded in ops.iter().rev() {
+            for payload in invert(&state.projected, recorded) {
+                let prior = capture_prior(&state.projected, &payload);
+                let op = state.projected_mut().apply(payload).unwrap();
+                out.push(RecordedOp { op, prior });
+            }
+        }
+        out
+    }
+
     fn root_with_paragraph(text: &str) -> Slice {
         Slice {
             content: vec![Fragment {
@@ -82,6 +742,36 @@ mod tests {
             open_start: 1,
             open_end: 1,
         }
+    }
+
+    #[test]
+    fn non_empty_lossless_empty_slice_deletes_the_selected_text() {
+        let (initial, _p) = state! {
+            doc { root { p: paragraph { text("abc") } } }
+            selection: (p, 1) -> (p, 2)
+        };
+        let mut tr = Transaction::new(&initial);
+        assert!(
+            insert_slice(
+                &mut tr,
+                Slice::new(
+                    vec![Fragment::leaf(PlainNode::Text(PlainTextNode {
+                        text: String::new(),
+                    }))],
+                    0,
+                    0,
+                ),
+                SliceProvenance::Formatted,
+            )
+            .unwrap()
+        );
+        let (actual, ..) = tr.commit();
+
+        let (expected, ..) = state! {
+            doc { root { p: paragraph { text("ac") } } }
+            selection: (p, 1)
+        };
+        editor_state::assert_state_eq!(&actual, &expected);
     }
 
     fn paragraph_fragment(text: &str) -> Fragment {
@@ -142,6 +832,194 @@ mod tests {
             SliceProvenance::Formatted
         ));
         assert_state_eq!(&actual, &initial);
+    }
+
+    #[test]
+    fn fitted_replacement_rolls_back_if_execution_diverges() {
+        let (initial, p) = state! {
+            doc { root { p: paragraph { text("abc") } } }
+            selection: (p, 1) -> (p, 2)
+        };
+        let selection = initial.selection.expect("selection");
+        let target = PlannedEndpoint::capture(&initial.view(), Position::new(p, 0)).unwrap();
+        let FitOutcome::Plan(mut plan) =
+            fit_slice(&initial, selection, root_with_paragraph("X")).unwrap()
+        else {
+            panic!("replacement must fit");
+        };
+        let SliceFitPlanKind::Linear(LinearFitPlan {
+            mutation:
+                LinearMutation::RangeReplacement {
+                    placement: RangePlacement::Joined(JoinedReplacementPlan { destination, .. }),
+                    ..
+                },
+            ..
+        }) = &mut plan.kind
+        else {
+            panic!("expected joined replacement");
+        };
+        *destination = target;
+        let mut tr = Transaction::new(&initial);
+
+        assert!(
+            apply_fitted_slice(&mut tr, plan, SliceProvenance::Formatted).is_err(),
+            "the deliberately stale plan must fail"
+        );
+        let (actual, steps, ..) = tr.commit();
+
+        assert_state_eq!(&actual, &initial);
+        assert!(steps.is_empty(), "the failed plan must be atomic");
+    }
+
+    #[test]
+    fn fitted_insertion_rolls_back_if_final_selection_contract_is_corrupted() {
+        let (initial, _p) = state! {
+            doc { root { p: paragraph { text("abc") } } }
+            selection: (p, 1)
+        };
+        let FitOutcome::Plan(mut plan) = fit_slice(
+            &initial,
+            initial.selection.expect("selection"),
+            Slice::new(
+                vec![Fragment::leaf(PlainNode::Text(PlainTextNode {
+                    text: "X".into(),
+                }))],
+                0,
+                0,
+            ),
+        )
+        .unwrap() else {
+            panic!("inline insertion must fit");
+        };
+        let SliceFitPlanKind::Linear(LinearFitPlan {
+            final_selection, ..
+        }) = &mut plan.kind
+        else {
+            panic!("expected a linear plan");
+        };
+        *final_selection = LinearFinalSelection::DeletionBoundary;
+
+        let mut tr = Transaction::new(&initial);
+        assert!(
+            apply_fitted_slice(&mut tr, plan, SliceProvenance::Formatted).is_err(),
+            "an inconsistent planned selection contract must reject the whole execution"
+        );
+        let (actual, steps, ..) = tr.commit();
+        assert_state_eq!(&actual, &initial);
+        assert!(
+            steps.is_empty(),
+            "the failed output resolution must be atomic"
+        );
+    }
+
+    #[test]
+    fn fitted_insertion_rejects_a_corrupted_output_source_path_before_mutation() {
+        let (initial, _p) = state! {
+            doc { root { p: paragraph { text("abc") } } }
+            selection: (p, 1)
+        };
+        let FitOutcome::Plan(mut plan) = fit_slice(
+            &initial,
+            initial.selection.expect("selection"),
+            Slice::new(
+                vec![Fragment::leaf(PlainNode::Text(PlainTextNode {
+                    text: "X".into(),
+                }))],
+                0,
+                0,
+            ),
+        )
+        .unwrap() else {
+            panic!("inline insertion must fit");
+        };
+        let SliceFitPlanKind::Linear(LinearFitPlan {
+            mutation: LinearMutation::PointInsertion { insertion },
+            ..
+        }) = &mut plan.kind
+        else {
+            panic!("expected a point insertion plan");
+        };
+        let crate::judgments::SliceInsertionPlan::DirectInline { output, .. } = insertion else {
+            panic!("expected direct inline insertion");
+        };
+        output.nodes[0].source = crate::helpers::SliceOutputSource::InlineSlot { index: 99 };
+
+        let mut tr = Transaction::new(&initial);
+        assert!(
+            apply_fitted_slice(&mut tr, plan, SliceProvenance::Formatted).is_err(),
+            "a planned output key detached from its source slot must be rejected"
+        );
+        let (actual, steps, ..) = tr.commit();
+        assert_state_eq!(&actual, &initial);
+        assert!(steps.is_empty(), "the stale output plan must be atomic");
+    }
+
+    #[test]
+    fn replacement_aware_closed_block_keeps_different_list_boundaries_in_both_directions() {
+        for reversed in [false, true] {
+            let (mut initial, ordered, left, bullet, right) = state! {
+                doc { root {
+                    ordered: ordered_list {
+                        list_item { left: paragraph { text("AB") } }
+                    }
+                    bullet: bullet_list {
+                        list_item { right: paragraph { text("CD") } }
+                    }
+                    paragraph {}
+                } }
+                selection: (left, 1) -> (right, 1)
+            };
+            if reversed {
+                initial.selection = Some(Selection::new(
+                    Position::new(right, 1),
+                    Position::new(left, 1),
+                ));
+            }
+            let slice = Slice::new(
+                vec![Fragment::leaf(PlainNode::HorizontalRule(
+                    PlainHorizontalRuleNode::default(),
+                ))],
+                0,
+                0,
+            );
+
+            let (actual, ..) = transact!(initial, |tr| insert_slice(
+                &mut tr,
+                slice,
+                SliceProvenance::Formatted
+            ));
+            let view = actual.view();
+            let root = view.root().unwrap();
+            let types = root
+                .children()
+                .map(|child| match child {
+                    ChildView::Block(block) => block.node_type(),
+                    ChildView::Leaf(leaf) => leaf.node_type(),
+                })
+                .collect::<Vec<_>>();
+
+            assert_eq!(
+                types,
+                vec![
+                    NodeType::OrderedList,
+                    NodeType::HorizontalRule,
+                    NodeType::BulletList,
+                    NodeType::Paragraph,
+                ]
+            );
+            assert_eq!(
+                view.node(ordered).unwrap().node_type(),
+                NodeType::OrderedList
+            );
+            assert_eq!(view.node(bullet).unwrap().node_type(), NodeType::BulletList);
+            assert_eq!(view.node(left).unwrap().inline_text(), "A");
+            assert_eq!(view.node(right).unwrap().inline_text(), "D");
+            assert!(editor_state::is_unit_node_selection(
+                &actual.selection.unwrap(),
+                &view
+            ));
+            assert_projection_integrity(&actual);
+        }
     }
 
     #[test]
@@ -498,17 +1376,22 @@ mod tests {
     }
 
     #[test]
-    fn non_collapsed_selection_returns_false() {
+    fn non_collapsed_selection_is_replaced_atomically() {
         let (initial, ..) = state! {
             doc { root { p1: paragraph { text("Hello") } } }
             selection: (p1, 1) -> (p1, 4)
         };
         let slice = Slice::from_text("X");
-        transact_fail!(initial, |tr| insert_slice(
+        let (actual, ..) = transact!(initial, |tr| insert_slice(
             &mut tr,
             slice,
             SliceProvenance::Formatted
         ));
+        let (expected, ..) = state! {
+            doc { root { p1: paragraph { text("HXo") } } }
+            selection: (p1, 2)
+        };
+        assert_state_eq!(&actual, &expected);
     }
 
     #[test]
@@ -679,6 +1562,161 @@ mod tests {
     }
 
     #[test]
+    fn open_table_slice_at_cell_caret_is_a_whole_no_fit() {
+        let wrap = |node_type: NodeType, children| Fragment {
+            node: node_type.into_node().to_plain(),
+            modifiers: vec![],
+            carry: vec![],
+            children,
+        };
+        let slice = Slice {
+            content: vec![wrap(
+                NodeType::Table,
+                vec![
+                    wrap(
+                        NodeType::TableRow,
+                        vec![wrap(NodeType::TableCell, vec![paragraph_fragment("A")])],
+                    ),
+                    wrap(
+                        NodeType::TableRow,
+                        vec![wrap(NodeType::TableCell, vec![paragraph_fragment("B")])],
+                    ),
+                ],
+            )],
+            open_start: 4,
+            open_end: 4,
+        };
+        let (initial, ..) = state! {
+            doc { root {
+                table {
+                    table_row {
+                        table_cell {
+                            target: paragraph { text("xy") }
+                        }
+                    }
+                }
+                paragraph {}
+            } }
+            selection: (target, 1)
+            pending_modifiers: [bold]
+        };
+
+        let (actual, ..) = transact_fail!(initial.clone(), |tr| insert_slice(
+            &mut tr,
+            slice,
+            SliceProvenance::Formatted
+        ));
+        assert_state_eq!(&actual, &initial);
+    }
+
+    #[test]
+    fn empty_open_wrapper_is_noop_and_preserves_pending_format() {
+        let (initial, ..) = state! {
+            doc { root {
+                blockquote {
+                    target: paragraph { text("xy") }
+                }
+                paragraph {}
+            } }
+            selection: (target, 1)
+            pending_modifiers: [bold]
+        };
+        let slice = Slice {
+            content: vec![Fragment {
+                node: NodeType::Blockquote.into_node().to_plain(),
+                modifiers: vec![],
+                carry: vec![],
+                children: vec![paragraph_fragment("")],
+            }],
+            open_start: 2,
+            open_end: 2,
+        };
+
+        let (actual, ..) = transact_fail!(initial.clone(), |tr| insert_slice(
+            &mut tr,
+            slice,
+            SliceProvenance::Plain
+        ));
+        assert_state_eq!(&actual, &initial);
+    }
+
+    #[test]
+    fn open_page_break_that_cannot_cross_isolation_is_whole_no_fit() {
+        let fixtures = [
+            {
+                let (state, target) = state! {
+                    doc { root {
+                        fold {
+                            fold_title { text("title") }
+                            fold_content {
+                                blockquote {
+                                    target: paragraph { text("ab") }
+                                }
+                            }
+                        }
+                        paragraph {}
+                    } }
+                    selection: (target, 0)
+                    pending_modifiers: [bold]
+                };
+                (state, target)
+            },
+            {
+                let (state, target) = state! {
+                    doc { root {
+                        table {
+                            table_row {
+                                table_cell {
+                                    blockquote {
+                                        target: paragraph { text("ab") }
+                                    }
+                                }
+                            }
+                        }
+                        paragraph {}
+                    } }
+                    selection: (target, 0)
+                    pending_modifiers: [bold]
+                };
+                (state, target)
+            },
+        ];
+        let slice = Slice::new(
+            vec![
+                Fragment::leaf(PlainNode::Blockquote(PlainBlockquoteNode::default()))
+                    .with_children(vec![
+                        Fragment::leaf(PlainNode::Paragraph(PlainParagraphNode::default()))
+                            .with_children(vec![Fragment::leaf(PlainNode::PageBreak(
+                                PlainPageBreakNode::default(),
+                            ))]),
+                    ]),
+            ],
+            2,
+            2,
+        );
+
+        for (base, target) in fixtures {
+            for selection in [
+                Selection::collapsed(Position::new(target, 0)),
+                Selection::new(Position::new(target, 0), Position::new(target, 1)),
+                Selection::new(Position::new(target, 1), Position::new(target, 0)),
+            ] {
+                let mut initial = base.clone();
+                initial.selection = Some(selection);
+                assert!(matches!(
+                    fit_slice(&initial, selection, slice.clone()).unwrap(),
+                    FitOutcome::NoFit
+                ));
+
+                let mut tr = Transaction::new(&initial);
+                assert!(!insert_slice(&mut tr, slice.clone(), SliceProvenance::Formatted).unwrap());
+                let (actual, ..) = tr.commit();
+                assert_state_eq!(&actual, &initial);
+            }
+        }
+    }
+
+    #[test]
     fn insert_open_list_slice_into_list_item_preserves_sibling_items() {
         let (source, ..) = state! {
             doc { root {
@@ -694,7 +1732,7 @@ mod tests {
 
         let (initial, ..) = state! {
             doc { root {
-                bullet_list {
+                ordered_list {
                     list_item {
                         target: paragraph { text("xy") }
                         paragraph { text("tail") }
@@ -712,7 +1750,7 @@ mod tests {
 
         let (expected, ..) = state! {
             doc { root {
-                bullet_list {
+                ordered_list {
                     list_item { paragraph { text("xrst") } }
                     list_item {
                         p2: paragraph { text("secy") }
@@ -722,6 +1760,1039 @@ mod tests {
                 paragraph {}
             } }
             selection: (p2, 3)
+        };
+        assert_state_eq!(&actual, &expected);
+        assert_projection_integrity(&actual);
+    }
+
+    #[test]
+    fn replace_across_list_items_with_open_list_slice_joins_both_destination_edges() {
+        let (source, ..) = state! {
+            doc { root {
+                bullet_list {
+                    list_item { first: paragraph { text("first") } }
+                    list_item { second: paragraph { text("second") } }
+                }
+                paragraph {}
+            } }
+            selection: (first, 2) -> (second, 3)
+        };
+        let slice = Slice::extract(&source).expect("open list slice");
+
+        let (initial, ..) = state! {
+            doc { root {
+                ordered_list {
+                    list_item { left: paragraph { text("AB") } }
+                    list_item { right: paragraph { text("CD") } }
+                }
+                paragraph {}
+            } }
+            selection: (left, 1) -> (right, 1)
+        };
+        let (actual, ..) = transact!(initial, |tr| insert_slice(
+            &mut tr,
+            slice,
+            SliceProvenance::Formatted
+        ));
+
+        let (expected, ..) = state! {
+            doc { root {
+                ordered_list {
+                    list_item { paragraph { text("Arst") } }
+                    list_item { caret: paragraph { text("secD") } }
+                }
+                paragraph {}
+            } }
+            selection: (caret, 3)
+        };
+        assert_state_eq!(&actual, &expected);
+        assert_projection_integrity(&actual);
+    }
+
+    #[test]
+    fn ranged_page_break_replacement_hoists_without_losing_list_survivors() {
+        let (source, ..) = state! {
+            doc { source_root: root {
+                paragraph { page_break }
+            } }
+            selection: (source_root, 0, >) -> (source_root, 1, <)
+        };
+        let slice = Slice::extract(&source).expect("closed page-break paragraph slice");
+
+        let (initial, left, right) = state! {
+            doc { root {
+                bullet_list {
+                    list_item {
+                        left: paragraph { text("a") }
+                        right: paragraph { text("bd") }
+                    }
+                }
+                paragraph {}
+            } }
+            selection: (left, 1) -> (right, 1)
+            pending_modifiers: [bold]
+        };
+        let mut tr = Transaction::new(&initial);
+        assert!(
+            insert_slice(&mut tr, slice, SliceProvenance::Formatted).unwrap(),
+            "the ranged replacement must climb to the Root frontier"
+        );
+        let (actual, ..) = tr.commit();
+
+        let view = actual.view();
+        assert_eq!(view.node(left).expect("left survivor").inline_text(), "a");
+        let right = view
+            .alias_classes()
+            .members_of(right)
+            .into_iter()
+            .flatten()
+            .copied()
+            .find(|dot| {
+                view.node(*dot)
+                    .is_some_and(|node| node.inline_text() == "d")
+            })
+            .expect("right survivor alias");
+        assert_eq!(view.node(right).expect("right survivor").inline_text(), "d");
+        let page_breaks = view
+            .root()
+            .expect("root")
+            .descendants()
+            .filter(|child| {
+                matches!(child, ChildView::Leaf(leaf) if leaf.node_type() == NodeType::PageBreak)
+            })
+            .count();
+        assert_eq!(page_breaks, 1, "the admitted PageBreak is preserved once");
+        assert_projection_integrity(&actual);
+    }
+
+    #[test]
+    fn destination_page_break_outside_range_blocks_join_and_survives() {
+        let (initial, left, right) = state! {
+            doc { root {
+                left: paragraph { text("a") page_break }
+                right: paragraph { text("b") }
+            } }
+            selection: (left, 2) -> (right, 0)
+        };
+        let page_break = initial
+            .view()
+            .node(left)
+            .expect("left")
+            .children()
+            .find_map(|child| match child {
+                ChildView::Leaf(leaf) if leaf.node_type() == NodeType::PageBreak => {
+                    Some(leaf.dot())
+                }
+                _ => None,
+            })
+            .expect("page break");
+
+        let mut tr = Transaction::new(&initial);
+        assert!(insert_slice(&mut tr, Slice::from_text("X"), SliceProvenance::Formatted,).unwrap());
+        let (actual, ..) = tr.commit();
+
+        let view = actual.view();
+        assert!(
+            view.leaf(page_break).is_some(),
+            "the PageBreak dot survives"
+        );
+        assert_eq!(view.node(left).expect("left survives").inline_text(), "a");
+        assert_eq!(
+            view.node(right).expect("right survives").inline_text(),
+            "Xb"
+        );
+        assert_projection_integrity(&actual);
+    }
+
+    #[test]
+    fn asymmetric_closed_start_keeps_left_boundary_and_opens_into_right_boundary() {
+        let (source, ..) = state! {
+            doc { source_root: root {
+                image
+                source_paragraph: paragraph { text("X") }
+            } }
+            selection: (source_root, 0, >) -> (source_paragraph, 1, <)
+        };
+        let slice = Slice::extract(&source).expect("asymmetric Slice");
+        assert_eq!((slice.open_start, slice.open_end), (0, 1));
+        assert_eq!(
+            slice
+                .content
+                .iter()
+                .map(|fragment| fragment.node.as_type())
+                .collect::<Vec<_>>(),
+            [NodeType::Image, NodeType::Paragraph]
+        );
+
+        let (initial, left, right) = state! {
+            doc { root {
+                left: paragraph { text("ab") }
+                right: paragraph { text("cd") }
+                paragraph {}
+            } }
+            selection: (left, 1) -> (right, 1)
+        };
+        let mut tr = Transaction::new(&initial);
+        assert!(insert_slice(&mut tr, slice, SliceProvenance::Formatted).unwrap());
+        let (actual, ..) = tr.commit();
+
+        let view = actual.view();
+        let child_types = view
+            .root()
+            .expect("root")
+            .children()
+            .map(|child| match child {
+                ChildView::Block(block) => block.node_type(),
+                ChildView::Leaf(leaf) => leaf.node_type(),
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            child_types,
+            [
+                NodeType::Paragraph,
+                NodeType::Image,
+                NodeType::Paragraph,
+                NodeType::Paragraph,
+            ]
+        );
+        assert_eq!(view.node(left).expect("left survivor").inline_text(), "a");
+        let right_members = view
+            .alias_classes()
+            .members_of(right)
+            .into_iter()
+            .flatten()
+            .copied()
+            .collect::<Vec<_>>();
+        let right = right_members
+            .iter()
+            .copied()
+            .find(|dot| view.node(*dot).is_some())
+            .unwrap_or(right);
+        assert_eq!(
+            view.node(right)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "right survivor missing; aliases={right_members:?}, root={child_types:?}"
+                    )
+                })
+                .inline_text(),
+            "Xd"
+        );
+        assert_projection_integrity(&actual);
+    }
+
+    #[test]
+    fn asymmetric_open_start_opens_into_left_boundary_and_keeps_right_boundary() {
+        let (source, ..) = state! {
+            doc { source_root: root {
+                source_paragraph: paragraph { text("X") }
+                image
+            } }
+            selection: (source_paragraph, 0, >) -> (source_root, 2, <)
+        };
+        let slice = Slice::extract(&source).expect("asymmetric Slice");
+        assert_eq!((slice.open_start, slice.open_end), (1, 0));
+        assert_eq!(
+            slice
+                .content
+                .iter()
+                .map(|fragment| fragment.node.as_type())
+                .collect::<Vec<_>>(),
+            [NodeType::Paragraph, NodeType::Image]
+        );
+
+        let (initial, left, right) = state! {
+            doc { root {
+                left: paragraph { text("ab") }
+                right: paragraph { text("cd") }
+                paragraph {}
+            } }
+            selection: (left, 1) -> (right, 1)
+        };
+        let mut tr = Transaction::new(&initial);
+        assert!(insert_slice(&mut tr, slice, SliceProvenance::Formatted).unwrap());
+        let (actual, ..) = tr.commit();
+
+        let view = actual.view();
+        let child_types = view
+            .root()
+            .expect("root")
+            .children()
+            .map(|child| match child {
+                ChildView::Block(block) => block.node_type(),
+                ChildView::Leaf(leaf) => leaf.node_type(),
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            child_types,
+            [
+                NodeType::Paragraph,
+                NodeType::Image,
+                NodeType::Paragraph,
+                NodeType::Paragraph,
+            ]
+        );
+        assert_eq!(view.node(left).expect("left survivor").inline_text(), "aX");
+        let right_members = view
+            .alias_classes()
+            .members_of(right)
+            .into_iter()
+            .flatten()
+            .copied()
+            .collect::<Vec<_>>();
+        let right = right_members
+            .iter()
+            .copied()
+            .find(|dot| view.node(*dot).is_some())
+            .unwrap_or(right);
+        assert_eq!(
+            view.node(right)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "right survivor missing; aliases={right_members:?}, root={child_types:?}"
+                    )
+                })
+                .inline_text(),
+            "d"
+        );
+        assert_projection_integrity(&actual);
+    }
+
+    #[test]
+    fn open_edges_with_a_closed_middle_block_keep_distinct_list_kinds() {
+        let (initial, ordered, left, bullet, right) = state! {
+            doc { root {
+                ordered: ordered_list {
+                    list_item { left: paragraph { text("AB") } }
+                }
+                bullet: bullet_list {
+                    list_item { right: paragraph { text("CD") } }
+                }
+                paragraph {}
+            } }
+            selection: (left, 1) -> (right, 1)
+        };
+        let slice = Slice::new(
+            vec![
+                paragraph_fragment("x"),
+                Fragment::leaf(PlainNode::HorizontalRule(PlainHorizontalRuleNode::default())),
+                paragraph_fragment("y"),
+            ],
+            1,
+            1,
+        );
+
+        let mut tr = Transaction::new(&initial);
+        assert!(insert_slice(&mut tr, slice, SliceProvenance::Formatted).unwrap());
+        let (actual, ..) = tr.commit();
+
+        let view = actual.view();
+        let types = view
+            .root()
+            .expect("root")
+            .children()
+            .map(|child| match child {
+                ChildView::Block(block) => block.node_type(),
+                ChildView::Leaf(leaf) => leaf.node_type(),
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            types,
+            [
+                NodeType::OrderedList,
+                NodeType::HorizontalRule,
+                NodeType::BulletList,
+                NodeType::Paragraph,
+            ]
+        );
+        assert_eq!(
+            view.node(ordered).expect("ordered survivor").node_type(),
+            NodeType::OrderedList
+        );
+        assert_eq!(view.node(left).expect("left survivor").inline_text(), "Ax");
+        assert_eq!(
+            view.node(bullet).expect("bullet survivor").node_type(),
+            NodeType::BulletList
+        );
+        let right = view
+            .alias_classes()
+            .members_of(right)
+            .into_iter()
+            .flatten()
+            .copied()
+            .find(|dot| view.node(*dot).is_some())
+            .unwrap_or(right);
+        assert_eq!(
+            view.node(right).expect("right survivor").inline_text(),
+            "yD"
+        );
+        assert_projection_integrity(&actual);
+    }
+
+    #[test]
+    fn open_edges_are_inserted_before_a_middle_list_merges_their_containers() {
+        let (initial, _left, _right) = state! {
+            doc { root {
+                ordered_list {
+                    list_item { left: paragraph { text("AB") } }
+                }
+                bullet_list {
+                    list_item { right: paragraph { text("CD") } }
+                }
+                paragraph {}
+            } }
+            selection: (left, 1) -> (right, 1)
+        };
+        let middle = Fragment::leaf(PlainNode::OrderedList(PlainOrderedListNode::default()))
+            .with_children(vec![
+                Fragment::leaf(PlainNode::ListItem(PlainListItemNode::default()))
+                    .with_children(vec![paragraph_fragment("M")]),
+            ]);
+        let slice = Slice::new(
+            vec![paragraph_fragment("x"), middle, paragraph_fragment("y")],
+            1,
+            1,
+        );
+
+        let mut tr = Transaction::new(&initial);
+        assert!(insert_slice(&mut tr, slice, SliceProvenance::Formatted).unwrap());
+        let (actual, _, recorded, ..) = tr.commit();
+
+        {
+            let view = actual.view();
+            let list = view
+                .root()
+                .expect("root")
+                .child_blocks()
+                .next()
+                .expect("merged list");
+            assert_eq!(list.node_type(), NodeType::OrderedList);
+            let mut texts = Vec::new();
+            for item in list.child_blocks() {
+                texts.extend(item.child_blocks().map(|paragraph| paragraph.inline_text()));
+            }
+            assert_eq!(texts, ["Ax", "M", "yD"]);
+        }
+        assert_projection_integrity(&actual);
+
+        let mut restored = actual.clone();
+        let redo = invert_recorded_ops(&mut restored, &recorded);
+        assert_eq!(restored.to_plain(), initial.to_plain());
+        assert_projection_integrity(&restored);
+
+        invert_recorded_ops(&mut restored, &redo);
+        assert_eq!(restored.to_plain(), actual.to_plain());
+        assert_projection_integrity(&restored);
+    }
+
+    #[test]
+    fn over_budget_programmatic_slice_is_whole_no_fit() {
+        let (initial, ..) = state! {
+            doc { root { target: paragraph {} } }
+            selection: (target, 0)
+            pending_modifiers: [bold]
+        };
+        let mut inner = paragraph_fragment("deep");
+        for _ in 0..31 {
+            inner = Fragment::leaf(PlainNode::Blockquote(PlainBlockquoteNode::default()))
+                .with_children(vec![inner]);
+        }
+
+        let mut tr = Transaction::new(&initial);
+        assert!(
+            !insert_slice(
+                &mut tr,
+                Slice::new(vec![inner], 0, 0),
+                SliceProvenance::Formatted,
+            )
+            .unwrap()
+        );
+        let (actual, ..) = tr.commit();
+        assert_state_eq!(&actual, &initial);
+    }
+
+    fn inject_root_list_item(state: &mut State, before: Dot, text: &str) -> (Dot, Dot, Dot) {
+        let pos = state
+            .projected
+            .seq_boundary_pos(before, SeqBias::Before)
+            .expect("root insertion boundary");
+        let raw_item = state
+            .projected_mut()
+            .apply(EditOp::Seq(ListOp::Ins {
+                pos,
+                item: SeqItem::Block {
+                    node_type: NodeType::ListItem,
+                    parents: vec![Dot::ROOT],
+                    attrs: vec![],
+                },
+            }))
+            .unwrap()
+            .id;
+        let raw_paragraph = state
+            .projected_mut()
+            .apply(EditOp::Seq(ListOp::Ins {
+                pos: pos + 1,
+                item: SeqItem::Block {
+                    node_type: NodeType::Paragraph,
+                    parents: vec![Dot::ROOT, raw_item],
+                    attrs: vec![],
+                },
+            }))
+            .unwrap()
+            .id;
+        for (index, ch) in text.chars().enumerate() {
+            state
+                .projected_mut()
+                .apply(EditOp::Seq(ListOp::Ins {
+                    pos: pos + 2 + index,
+                    item: SeqItem::Char(ch),
+                }))
+                .unwrap();
+        }
+        let synthetic_list = state
+            .view()
+            .root()
+            .expect("root")
+            .child_blocks()
+            .find(|node| node.node_type() == NodeType::BulletList)
+            .expect("projected list")
+            .id();
+        assert!(synthetic_list.is_synthetic());
+        (raw_item, raw_paragraph, synthetic_list)
+    }
+
+    fn insert_raw_block(
+        state: &mut State,
+        pos: usize,
+        node_type: NodeType,
+        parents: Vec<Dot>,
+    ) -> Dot {
+        state
+            .projected_mut()
+            .apply(EditOp::Seq(ListOp::Ins {
+                pos,
+                item: SeqItem::Block {
+                    node_type,
+                    parents,
+                    attrs: vec![],
+                },
+            }))
+            .unwrap()
+            .id
+    }
+
+    fn insert_raw_text(state: &mut State, mut pos: usize, text: &str) -> usize {
+        for ch in text.chars() {
+            state
+                .projected_mut()
+                .apply(EditOp::Seq(ListOp::Ins {
+                    pos,
+                    item: SeqItem::Char(ch),
+                }))
+                .unwrap();
+            pos += 1;
+        }
+        pos
+    }
+
+    fn inject_list_with_direct_paragraphs(state: &mut State, before: Dot) -> (Dot, Dot, Dot) {
+        let mut pos = state
+            .projected
+            .seq_boundary_pos(before, SeqBias::Before)
+            .expect("root insertion boundary");
+        let list = insert_raw_block(state, pos, NodeType::BulletList, vec![Dot::ROOT]);
+        pos += 1;
+        let right = insert_raw_block(state, pos, NodeType::Paragraph, vec![Dot::ROOT, list]);
+        pos = insert_raw_text(state, pos + 1, "CD");
+        let tail = insert_raw_block(state, pos, NodeType::Paragraph, vec![Dot::ROOT, list]);
+        insert_raw_text(state, pos + 1, "TAIL");
+        (list, right, tail)
+    }
+
+    fn closed_page_break_slice() -> Slice {
+        let (source, _source_root) = state! {
+            doc { source_root: root {
+                paragraph { page_break }
+            } }
+            selection: (source_root, 0, >) -> (source_root, 1, <)
+        };
+        Slice::extract(&source).expect("closed page-break paragraph slice")
+    }
+
+    #[test]
+    fn joined_replacement_preserves_all_content_owned_by_synthetic_list_items() {
+        for reversed in [false, true] {
+            let (mut initial, left, trailing) = state! {
+                doc { root {
+                    ordered_list {
+                        list_item { left: paragraph { text("AB") } }
+                    }
+                    trailing: paragraph {}
+                } }
+                selection: none
+            };
+            let (_later, right, tail) = inject_list_with_direct_paragraphs(&mut initial, trailing);
+            initial.selection = Some(if reversed {
+                Selection::new(Position::new(right, 1), Position::new(left, 1))
+            } else {
+                Selection::new(Position::new(left, 1), Position::new(right, 1))
+            });
+
+            let mut tr = Transaction::new(&initial);
+            assert!(
+                insert_slice(&mut tr, Slice::from_text("X"), SliceProvenance::Formatted,).unwrap(),
+                "the accepted joined replacement must execute"
+            );
+            let (actual, _, recorded, ..) = tr.commit();
+
+            let view = actual.view();
+            let list = view
+                .root()
+                .expect("root")
+                .child_blocks()
+                .next()
+                .expect("earlier list survives");
+            assert_eq!(list.node_type(), NodeType::OrderedList);
+            let texts = list
+                .child_blocks()
+                .flat_map(|item| {
+                    item.child_blocks()
+                        .map(|paragraph| paragraph.inline_text())
+                        .collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(texts, ["AXD", "TAIL"]);
+            let tail = view
+                .alias_classes()
+                .resolve_with(tail, |dot| view.node(dot).is_some());
+            assert!(
+                view.node(tail).is_some(),
+                "the untouched authored tail remains reachable through its alias"
+            );
+            assert_projection_integrity(&actual);
+
+            let mut restored = actual.clone();
+            let redo = invert_recorded_ops(&mut restored, &recorded);
+            assert_eq!(restored.to_plain(), initial.to_plain());
+            assert_projection_integrity(&restored);
+            invert_recorded_ops(&mut restored, &redo);
+            assert_eq!(restored.to_plain(), actual.to_plain());
+            assert_projection_integrity(&restored);
+        }
+    }
+
+    #[test]
+    fn page_break_hoist_keeps_content_owning_synthetic_suffix_on_the_right() {
+        let (mut initial, quote, paragraph, trailing) = state! {
+            doc { root {
+                quote: blockquote {
+                    paragraph: paragraph { text("AB") }
+                }
+                trailing: paragraph {}
+            } }
+            selection: none
+        };
+        let mut pos = initial
+            .projected
+            .seq_boundary_pos(trailing, SeqBias::Before)
+            .expect("blockquote insertion boundary");
+        let item = insert_raw_block(
+            &mut initial,
+            pos,
+            NodeType::ListItem,
+            vec![Dot::ROOT, quote],
+        );
+        pos += 1;
+        let tail = insert_raw_block(
+            &mut initial,
+            pos,
+            NodeType::Paragraph,
+            vec![Dot::ROOT, quote, item],
+        );
+        insert_raw_text(&mut initial, pos + 1, "TAIL");
+        let paragraph = {
+            let view = initial.view();
+            view.alias_classes()
+                .resolve_with(paragraph, |dot| view.node(dot).is_some())
+        };
+        initial.selection = Some(Selection::collapsed(Position::new(paragraph, 1)));
+        assert!(
+            initial
+                .selection
+                .expect("selection")
+                .resolve(&initial.view())
+                .is_some(),
+            "the repaired fixture caret must resolve before fitting"
+        );
+
+        let mut tr = Transaction::new(&initial);
+        assert!(
+            insert_slice(
+                &mut tr,
+                closed_page_break_slice(),
+                SliceProvenance::Formatted,
+            )
+            .unwrap()
+        );
+        let (actual, _, recorded, ..) = tr.commit();
+
+        let view = actual.view();
+        let root_blocks = view
+            .root()
+            .expect("root")
+            .child_blocks()
+            .collect::<Vec<_>>();
+        assert_eq!(
+            root_blocks
+                .iter()
+                .map(|block| block.node_type())
+                .collect::<Vec<_>>(),
+            [
+                NodeType::Blockquote,
+                NodeType::Paragraph,
+                NodeType::Blockquote,
+                NodeType::Paragraph,
+            ]
+        );
+        let descendant_text = |block: &editor_model::NodeView<'_>| {
+            block
+                .descendants()
+                .filter_map(|child| match child {
+                    ChildView::Leaf(leaf) => leaf.as_char(),
+                    ChildView::Block(_) => None,
+                })
+                .collect::<String>()
+        };
+        assert_eq!(descendant_text(&root_blocks[0]), "A");
+        assert_eq!(descendant_text(&root_blocks[2]), "BTAIL");
+        let tail = view
+            .alias_classes()
+            .resolve_with(tail, |dot| view.node(dot).is_some());
+        let tail_ancestor = view
+            .node(tail)
+            .expect("tail survives")
+            .ancestors()
+            .find(|ancestor| ancestor.node_type() == NodeType::Blockquote)
+            .expect("tail remains under a blockquote");
+        assert_eq!(tail_ancestor.id(), root_blocks[2].id());
+        assert_projection_integrity(&actual);
+
+        let mut restored = actual.clone();
+        let redo = invert_recorded_ops(&mut restored, &recorded);
+        assert_eq!(restored.to_plain(), initial.to_plain());
+        assert_projection_integrity(&restored);
+        invert_recorded_ops(&mut restored, &redo);
+        assert_eq!(restored.to_plain(), actual.to_plain());
+        assert_projection_integrity(&restored);
+    }
+
+    #[test]
+    fn mixed_empty_and_non_empty_inline_fragments_ignore_zero_output_text() {
+        for (reversed, empty_first) in [(false, true), (false, false), (true, true), (true, false)]
+        {
+            let (mut initial, paragraph) = state! {
+                doc { root {
+                    paragraph: paragraph { text("ab") }
+                } }
+                selection: none
+            };
+            initial.selection = Some(if reversed {
+                Selection::new(Position::new(paragraph, 2), Position::new(paragraph, 1))
+            } else {
+                Selection::new(Position::new(paragraph, 1), Position::new(paragraph, 2))
+            });
+            let empty = Fragment::leaf(PlainNode::Text(PlainTextNode {
+                text: String::new(),
+            }));
+            let text = Fragment::leaf(PlainNode::Text(PlainTextNode { text: "X".into() }));
+            let content = if empty_first {
+                vec![empty, text]
+            } else {
+                vec![text, empty]
+            };
+
+            let mut tr = Transaction::new(&initial);
+            assert!(
+                insert_slice(
+                    &mut tr,
+                    Slice::new(content, 0, 0),
+                    SliceProvenance::Formatted,
+                )
+                .unwrap()
+            );
+            let (actual, ..) = tr.commit();
+            assert_eq!(
+                actual
+                    .view()
+                    .node(paragraph)
+                    .expect("paragraph")
+                    .inline_text(),
+                "aX"
+            );
+            assert_projection_integrity(&actual);
+        }
+    }
+
+    #[test]
+    fn projected_content_owning_list_slot_materializes_before_slice_insertion() {
+        let (mut initial, tail) = state! {
+            doc { root { tail: paragraph {} } }
+            selection: none
+        };
+        let (raw_item, raw_paragraph, synthetic_list) =
+            inject_root_list_item(&mut initial, tail, "A");
+        initial.selection = Some(Selection::collapsed(Position::new(synthetic_list, 1)));
+        let slice = Slice::new(
+            vec![
+                Fragment::leaf(PlainNode::ListItem(PlainListItemNode::default()))
+                    .with_children(vec![paragraph_fragment("B")]),
+            ],
+            0,
+            0,
+        );
+
+        let mut tr = Transaction::new(&initial);
+        assert!(
+            insert_slice(&mut tr, slice, SliceProvenance::Formatted).unwrap(),
+            "the accepted projected-slot plan must execute"
+        );
+        let (actual, ..) = tr.commit();
+
+        let view = actual.view();
+        let remapped_item = view
+            .alias_classes()
+            .resolve_with(raw_item, |dot| view.node(dot).is_some());
+        let remapped_paragraph = view
+            .alias_classes()
+            .resolve_with(raw_paragraph, |dot| view.node(dot).is_some());
+        assert!(
+            view.node(remapped_item).is_some() && view.node(remapped_paragraph).is_some(),
+            "the original authored list content survives through explicit aliases"
+        );
+        let list = view
+            .root()
+            .expect("root")
+            .child_blocks()
+            .find(|node| node.node_type() == NodeType::BulletList)
+            .expect("materialized list");
+        assert!(!list.id().is_synthetic());
+        let mut texts = Vec::new();
+        for item in list.child_blocks() {
+            texts.extend(item.child_blocks().map(|paragraph| paragraph.inline_text()));
+        }
+        assert_eq!(texts, ["A", "B"]);
+        assert_projection_integrity(&actual);
+    }
+
+    #[test]
+    fn adjacent_synthetic_list_participant_is_whole_no_fit() {
+        for insertion_offset in [0, 1] {
+            let (mut initial, root, tail) = state! {
+                doc { root: root {
+                    tail: paragraph {}
+                } }
+                selection: none
+                pending_modifiers: [bold]
+            };
+            let (_, _, synthetic_list) = inject_root_list_item(&mut initial, tail, "A");
+            assert!(synthetic_list.is_synthetic());
+            let selection = Selection::collapsed(Position::new(root, insertion_offset));
+            initial.selection = Some(selection);
+            let slice = Slice::new(
+                vec![
+                    Fragment::leaf(PlainNode::OrderedList(PlainOrderedListNode::default()))
+                        .with_children(vec![
+                            Fragment::leaf(PlainNode::ListItem(PlainListItemNode::default()))
+                                .with_children(vec![paragraph_fragment("B")]),
+                        ]),
+                ],
+                0,
+                0,
+            );
+
+            assert!(matches!(
+                fit_slice(&initial, selection, slice.clone()).unwrap(),
+                FitOutcome::NoFit
+            ));
+            let mut tr = Transaction::new(&initial);
+            assert!(!insert_slice(&mut tr, slice, SliceProvenance::Formatted).unwrap());
+            let (actual, ..) = tr.commit();
+            assert_state_eq!(&actual, &initial);
+        }
+    }
+
+    #[test]
+    fn structure_budget_boundary_executes_and_cold_projects_on_a_small_stack() {
+        std::thread::Builder::new()
+            .stack_size(256 * 1024)
+            .spawn(|| {
+                let (initial, _root) = state! {
+                    doc { root: root {
+                        paragraph {}
+                    } }
+                    selection: (root, 0)
+                };
+                let mut inner = paragraph_fragment("deep");
+                for _ in 0..15 {
+                    inner = Fragment::leaf(PlainNode::OrderedList(PlainOrderedListNode::default()))
+                        .with_children(vec![
+                            Fragment::leaf(PlainNode::ListItem(PlainListItemNode::default()))
+                                .with_children(vec![paragraph_fragment("level"), inner]),
+                        ]);
+                }
+                let slice = Slice::new(vec![inner], 0, 0);
+                assert!(slice.preflight().is_some(), "fixture must be admitted");
+
+                let mut tr = Transaction::new(&initial);
+                assert!(
+                    insert_slice(&mut tr, slice, SliceProvenance::Formatted).unwrap(),
+                    "a Slice at the structure budget must execute"
+                );
+                let (actual, ..) = tr.commit();
+                assert_projection_integrity(&actual);
+            })
+            .expect("spawn structure-budget test")
+            .join()
+            .expect("admitted Slice must remain stack-safe");
+    }
+
+    #[test]
+    fn range_in_authored_content_under_a_synthetic_wrapper_materializes_losslessly() {
+        let (mut initial, tail) = state! {
+            doc { root { tail: paragraph {} } }
+            selection: none
+        };
+        let (_raw_item, raw_paragraph, synthetic_list) =
+            inject_root_list_item(&mut initial, tail, "AB");
+        initial.selection = Some(Selection::new(
+            Position::new(raw_paragraph, 0),
+            Position::new(raw_paragraph, 1),
+        ));
+
+        let mut tr = Transaction::new(&initial);
+        assert!(
+            insert_slice(&mut tr, Slice::from_text("X"), SliceProvenance::Formatted,).unwrap(),
+            "the replacement must bind its remapped authored endpoints"
+        );
+        let (actual, ..) = tr.commit();
+
+        let view = actual.view();
+        assert!(
+            view.node(synthetic_list).is_none(),
+            "the projection scaffold is replaced by authored structure"
+        );
+        let paragraph = view
+            .alias_classes()
+            .members_of(raw_paragraph)
+            .into_iter()
+            .flatten()
+            .copied()
+            .find_map(|dot| view.node(dot).filter(|node| node.inline_text() == "XB"))
+            .expect("the authored paragraph survives through its alias");
+        assert_eq!(paragraph.inline_text(), "XB");
+        assert_projection_integrity(&actual);
+    }
+
+    #[test]
+    fn closed_block_replacement_materializes_synthetic_endpoint_before_planning() {
+        let (mut initial, _root, left) = state! {
+            doc { root: root {
+                left: paragraph { text("A") }
+                image
+            } }
+            selection: none
+        };
+        let trailing = {
+            let view = initial.view();
+            view.root()
+                .unwrap()
+                .child_blocks()
+                .find(|block| block.node_type() == NodeType::Paragraph && block.id().is_synthetic())
+                .map(|block| block.id())
+                .expect("synthetic trailing paragraph")
+        };
+        initial.selection = Some(Selection::new(
+            Position::new(left, 1),
+            Position::new(trailing, 0),
+        ));
+        let slice = Slice::new(vec![paragraph_fragment("X")], 0, 0);
+        let FitOutcome::Plan(planned) = fit_slice(
+            &initial,
+            initial.selection.expect("selection"),
+            slice.clone(),
+        )
+        .unwrap() else {
+            panic!("closed block replacement must fit");
+        };
+        let SliceFitPlanKind::Linear(LinearFitPlan {
+            final_selection, ..
+        }) = planned.kind
+        else {
+            panic!("replacement must declare a linear final selection");
+        };
+        assert!(matches!(
+            final_selection,
+            LinearFinalSelection::InsertedContent
+        ));
+
+        let (actual, ..) = transact!(initial, |tr| insert_slice(
+            &mut tr,
+            slice,
+            SliceProvenance::Formatted
+        ));
+
+        let (expected, ..) = state! {
+            doc { root {
+                paragraph { text("A") }
+                inserted: paragraph { text("X") }
+                paragraph {}
+            } }
+            selection: (inserted, 1)
+        };
+        assert_state_eq!(&actual, &expected);
+        assert_projection_integrity(&actual);
+    }
+
+    #[test]
+    fn architecture_a_inline_range_ending_at_projected_slot_is_replaced() {
+        let (mut initial, _root, left) = state! {
+            doc { root: root {
+                left: paragraph { text("A") }
+                image
+            } }
+            selection: none
+        };
+        let trailing = {
+            let view = initial.view();
+            view.root()
+                .unwrap()
+                .child_blocks()
+                .find(|block| block.node_type() == NodeType::Paragraph && block.id().is_synthetic())
+                .map(|block| block.id())
+                .expect("synthetic trailing paragraph")
+        };
+        initial.selection = Some(Selection::new(
+            Position::new(left, 1),
+            Position::new(trailing, 0),
+        ));
+
+        let (actual, ..) = transact!(initial, |tr| insert_slice(
+            &mut tr,
+            Slice::new(
+                vec![Fragment::leaf(PlainNode::Text(PlainTextNode {
+                    text: "X".into(),
+                }))],
+                0,
+                0,
+            ),
+            SliceProvenance::Formatted
+        ));
+
+        let (expected, ..) = state! {
+            doc { root {
+                inserted: paragraph { text("AX") }
+            } }
+            selection: (inserted, 2)
         };
         assert_state_eq!(&actual, &expected);
         assert_projection_integrity(&actual);

--- a/crates/editor-commands/src/commands/insert_slice_at.rs
+++ b/crates/editor-commands/src/commands/insert_slice_at.rs
@@ -3,7 +3,8 @@ use editor_state::{Position, Selection};
 use editor_transaction::Transaction;
 
 use crate::CommandError;
-use crate::judgments::insert_slice_at_position;
+use crate::commands::insert_slice::apply_fitted_slice;
+use crate::judgments::{FitOutcome, fit_slice};
 use crate::types::SliceProvenance;
 
 pub fn insert_slice_at(
@@ -12,7 +13,17 @@ pub fn insert_slice_at(
     slice: Slice,
     provenance: SliceProvenance,
 ) -> Result<Option<Selection>, CommandError> {
-    insert_slice_at_position(tr, position, slice, provenance)
+    if slice.is_empty() {
+        return Ok(None);
+    }
+    if tr.view().node(position.node).is_none() {
+        return Err(CommandError::NodeNotFound(position.node));
+    }
+    let plan = match fit_slice(tr.state(), Selection::collapsed(position), slice)? {
+        FitOutcome::Plan(plan) => plan,
+        FitOutcome::NoOp | FitOutcome::NoFit => return Ok(None),
+    };
+    apply_fitted_slice(tr, plan, provenance).map(Some)
 }
 
 #[cfg(test)]
@@ -67,6 +78,22 @@ mod tests {
             open_start: 0,
             open_end: 0,
         }
+    }
+
+    fn text_and_page_break_signature(state: &editor_state::State) -> String {
+        state
+            .view()
+            .root()
+            .expect("root")
+            .descendants()
+            .filter_map(|child| match child {
+                ChildView::Leaf(leaf) => leaf
+                    .as_char()
+                    .map(|ch| ch.to_string())
+                    .or_else(|| (leaf.node_type() == NodeType::PageBreak).then(|| "|".to_string())),
+                ChildView::Block(_) => None,
+            })
+            .collect()
     }
 
     fn text_and_page_break_slice(text: &str) -> Slice {
@@ -538,6 +565,120 @@ mod tests {
     }
 
     #[test]
+    fn closed_list_between_adjacent_lists_uses_the_planned_earlier_kind_merges() {
+        let (initial, root, earlier) = state! {
+            doc { root: root {
+                earlier: ordered_list {
+                    list_item { paragraph { text("A") } }
+                }
+                bullet_list {
+                    list_item { paragraph { text("C") } }
+                }
+                paragraph {}
+            } }
+            selection: none
+        };
+
+        let mut tr = Transaction::new(&initial);
+        let inserted = insert_slice_at(
+            &mut tr,
+            Position::new(root, 1),
+            open_bullet_list_slice("B", 0, 0),
+            SliceProvenance::Formatted,
+        )
+        .expect("command succeeds");
+        assert_eq!(
+            inserted,
+            Some(Selection::new(
+                Position {
+                    node: earlier,
+                    offset: 1,
+                    affinity: Affinity::Downstream,
+                },
+                Position {
+                    node: earlier,
+                    offset: 2,
+                    affinity: Affinity::Upstream,
+                },
+            ))
+        );
+        let (actual, ..) = tr.commit();
+
+        let view = actual.view();
+        let lists = view
+            .node(root)
+            .unwrap()
+            .child_blocks()
+            .filter(|child| {
+                matches!(
+                    child.node_type(),
+                    NodeType::BulletList | NodeType::OrderedList
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(lists.len(), 1);
+        assert_eq!(lists[0].id(), earlier);
+        assert_eq!(lists[0].node_type(), NodeType::OrderedList);
+        assert_eq!(list_item_texts(&view, earlier), ["A", "B", "C"]);
+    }
+
+    #[test]
+    fn closed_list_replacing_empty_paragraph_merges_with_the_earlier_list() {
+        let (initial, earlier, empty) = state! {
+            doc { root {
+                earlier: ordered_list {
+                    list_item { paragraph { text("A") } }
+                }
+                empty: paragraph {}
+            } }
+            selection: none
+        };
+
+        let mut tr = Transaction::new(&initial);
+        let inserted = insert_slice_at(
+            &mut tr,
+            Position::new(empty, 0),
+            open_bullet_list_slice("B", 0, 0),
+            SliceProvenance::Formatted,
+        )
+        .expect("command succeeds")
+        .expect("closed list is inserted");
+        assert_eq!(
+            inserted,
+            Selection::new(
+                Position {
+                    node: earlier,
+                    offset: 1,
+                    affinity: Affinity::Downstream,
+                },
+                Position {
+                    node: earlier,
+                    offset: 2,
+                    affinity: Affinity::Upstream,
+                },
+            )
+        );
+        let (actual, ..) = tr.commit();
+
+        let view = actual.view();
+        let lists = view
+            .root()
+            .unwrap()
+            .child_blocks()
+            .filter(|child| {
+                matches!(
+                    child.node_type(),
+                    NodeType::BulletList | NodeType::OrderedList
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(lists.len(), 1);
+        assert_eq!(lists[0].id(), earlier);
+        assert_eq!(lists[0].node_type(), NodeType::OrderedList);
+        assert_eq!(list_item_texts(&view, earlier), ["A", "B"]);
+    }
+
+    #[test]
     fn insert_open_list_context_with_only_start_edge_open_merges_item() {
         let (initial, list) = state! {
             doc { root {
@@ -622,7 +763,7 @@ mod tests {
     }
 
     #[test]
-    fn rejected_slice_does_not_materialize_or_split_synthetic_textblock() {
+    fn hoisted_slice_does_not_materialize_synthetic_textblock() {
         let (initial, ..) = state! {
             doc { root { blockquote paragraph {} } }
             selection: none
@@ -639,7 +780,27 @@ mod tests {
                 .unwrap()
                 .id()
         };
-        assert_rejected_slice_preserves_synthetic_target(initial, target, horizontal_rule_slice());
+        let mut tr = Transaction::new(&initial);
+        let inserted = insert_slice_at(
+            &mut tr,
+            Position::new(target, 0),
+            horizontal_rule_slice(),
+            SliceProvenance::Formatted,
+        )
+        .expect("HorizontalRule hoists through Blockquote");
+        let (actual, ..) = tr.commit();
+
+        assert!(inserted.is_some());
+        assert!(target.is_synthetic());
+        assert!(
+            actual.view().node(target).is_some(),
+            "edge hoist must preserve the synthetic target paragraph"
+        );
+        let (expected, ..) = state! {
+            doc { root { horizontal_rule blockquote paragraph {} } }
+            selection: none
+        };
+        editor_state::assert_doc_eq!(&actual, &expected);
     }
 
     #[test]
@@ -947,6 +1108,36 @@ mod tests {
     }
 
     #[test]
+    fn task3_bare_text_and_page_break_at_root_paragraph_end_is_lossless() {
+        let (initial, p1) = state! {
+            doc { root { p1: paragraph { text("World") } } }
+            selection: none
+        };
+
+        let mut tr = Transaction::new(&initial);
+        let inserted = insert_slice_at(
+            &mut tr,
+            Position::new(p1, 5),
+            text_and_page_break_slice("X"),
+            SliceProvenance::Formatted,
+        )
+        .expect("insert succeeds")
+        .expect("text and page break inserted");
+        let (actual, ..) = tr.commit();
+
+        let (expected, ..) = state! {
+            doc { root {
+                paragraph { text("WorldX") page_break }
+                p2: paragraph {}
+            } }
+            selection: (p2, 0)
+        };
+        assert_state_eq!(&actual, &expected);
+        assert_trailing_paragraph_is_synthetic(&actual);
+        assert!(!inserted.is_collapsed());
+    }
+
+    #[test]
     fn open_textblock_after_terminal_inline_stays_in_its_wrapper() {
         let (initial, p1) = state! {
             doc { root {
@@ -1015,7 +1206,7 @@ mod tests {
     }
 
     #[test]
-    fn insert_page_break_only_in_nested_paragraph_is_atomic_no_op() {
+    fn insert_page_break_only_in_nested_paragraph_hoists_without_loss() {
         let (initial, p1) = state! {
             doc { root { blockquote { p1: paragraph { text("Nested") } } paragraph {} } }
             selection: none
@@ -1028,15 +1219,16 @@ mod tests {
             page_break_slice(),
             SliceProvenance::Formatted,
         )
-        .expect("invalid page break is a no-op");
-        assert!(inserted.is_none());
+        .expect("PageBreak hoists through Blockquote");
+        assert!(inserted.is_some());
         let (actual, ..) = tr.commit();
 
-        assert_state_eq!(&actual, &initial);
+        assert_eq!(text_and_page_break_signature(&actual), "Nes|ted");
+        assert_projection_integrity(&actual);
     }
 
     #[test]
-    fn insert_page_break_only_paragraph_nested_is_atomic_no_op() {
+    fn insert_page_break_only_paragraph_nested_hoists_without_loss() {
         let (initial, p1) = state! {
             doc { root { blockquote { p1: paragraph { text("Nested") } } paragraph {} } }
             selection: none
@@ -1049,10 +1241,60 @@ mod tests {
             paragraph_with_page_break_slice("", 0, 0),
             SliceProvenance::Formatted,
         )
-        .expect("invalid page break is a no-op");
-        assert!(inserted.is_none());
+        .expect("PageBreak paragraph hoists through Blockquote");
+        assert!(inserted.is_some());
         let (actual, ..) = tr.commit();
 
+        assert_eq!(text_and_page_break_signature(&actual), "Nes|ted");
+        assert_projection_integrity(&actual);
+    }
+
+    #[test]
+    fn insert_page_break_does_not_cross_table_cell_isolation() {
+        let (initial, p) = state! {
+            doc { root {
+                table { table_row { table_cell { p: paragraph { text("Nested") } } } }
+                paragraph {}
+            } }
+            selection: none
+        };
+        let mut tr = Transaction::new(&initial);
+        let inserted = insert_slice_at(
+            &mut tr,
+            Position::new(p, 3),
+            page_break_slice(),
+            SliceProvenance::Formatted,
+        )
+        .expect("isolating rejection is a normal NoFit");
+        let (actual, ..) = tr.commit();
+
+        assert!(inserted.is_none());
+        assert_state_eq!(&actual, &initial);
+    }
+
+    #[test]
+    fn insert_page_break_does_not_cross_fold_content_isolation() {
+        let (initial, p) = state! {
+            doc { root {
+                fold {
+                    fold_title { text("title") }
+                    fold_content { p: paragraph { text("Nested") } }
+                }
+                paragraph {}
+            } }
+            selection: none
+        };
+        let mut tr = Transaction::new(&initial);
+        let inserted = insert_slice_at(
+            &mut tr,
+            Position::new(p, 3),
+            page_break_slice(),
+            SliceProvenance::Formatted,
+        )
+        .expect("isolating rejection is a normal NoFit");
+        let (actual, ..) = tr.commit();
+
+        assert!(inserted.is_none());
         assert_state_eq!(&actual, &initial);
     }
 
@@ -1098,7 +1340,7 @@ mod tests {
     }
 
     #[test]
-    fn insert_non_terminal_page_break_drops_it_and_keeps_following_text() {
+    fn insert_non_terminal_page_break_preserves_following_text_by_splitting() {
         let (initial, p1) = state! {
             doc { root { p1: paragraph { text("ab") } } }
             selection: none
@@ -1119,16 +1361,18 @@ mod tests {
             slice,
             SliceProvenance::Formatted,
         )
-        .expect("insert succeeds")
-        .expect("text inserted");
+        .expect("lossless PageBreak fitting succeeds");
         let (actual, ..) = tr.commit();
 
+        assert!(inserted.is_some());
         let (expected, ..) = state! {
-            doc { root { p1: paragraph { text("axb") } } }
-            selection: (p1, 2)
+            doc { root {
+                paragraph { text("a") page_break }
+                p2: paragraph { text("xb") }
+            } }
+            selection: (p2, 1)
         };
         assert_state_eq!(&actual, &expected);
-        assert!(!inserted.is_collapsed());
     }
 
     #[test]
@@ -1165,6 +1409,190 @@ mod tests {
     }
 
     #[test]
+    fn insert_page_break_through_non_isolating_blockquote_splits_without_loss() {
+        let (initial, p) = state! {
+            doc { root {
+                blockquote { p: paragraph { text("target") } }
+                paragraph {}
+            } }
+            selection: none
+        };
+        let mut tr = Transaction::new(&initial);
+        let inserted = insert_slice_at(
+            &mut tr,
+            Position::new(p, 3),
+            paragraph_with_page_break_slice("lo", 0, 0),
+            SliceProvenance::Formatted,
+        )
+        .expect("PageBreak hoists through a non-isolating wrapper");
+        let (actual, ..) = tr.commit();
+
+        assert!(inserted.is_some());
+        let (expected, ..) = state! {
+            doc { root {
+                blockquote { paragraph { text("tar") } }
+                paragraph { text("lo") page_break }
+                blockquote { q: paragraph { text("get") } }
+                paragraph {}
+            } }
+            selection: (q, 0)
+        };
+        editor_state::assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn hoisted_page_break_at_wrapper_start_places_caret_in_following_textblock() {
+        let (initial, p) = state! {
+            doc { root {
+                blockquote { p: paragraph { text("target") } }
+                paragraph {}
+            } }
+            selection: none
+        };
+        let mut tr = Transaction::new(&initial);
+        insert_slice_at(
+            &mut tr,
+            Position::new(p, 0),
+            page_break_slice(),
+            SliceProvenance::Formatted,
+        )
+        .expect("PageBreak hoists through a non-isolating wrapper")
+        .expect("PageBreak is inserted");
+        let (actual, ..) = tr.commit();
+
+        let (expected, ..) = state! {
+            doc { root {
+                paragraph { page_break }
+                blockquote { q: paragraph { text("target") } }
+                paragraph {}
+            } }
+            selection: (q, 0)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn hoisted_page_break_before_fold_places_caret_in_fold_title() {
+        let (initial, p) = state! {
+            doc { root {
+                blockquote { p: paragraph { text("target") } }
+                fold {
+                    fold_title { text("title") }
+                    fold_content { paragraph { text("content") } }
+                }
+                paragraph {}
+            } }
+            selection: none
+        };
+        let mut tr = Transaction::new(&initial);
+        insert_slice_at(
+            &mut tr,
+            Position::new(p, 6),
+            page_break_slice(),
+            SliceProvenance::Formatted,
+        )
+        .expect("PageBreak hoists through a non-isolating wrapper")
+        .expect("PageBreak is inserted");
+        let (actual, ..) = tr.commit();
+
+        let (expected, ..) = state! {
+            doc { root {
+                blockquote { paragraph { text("target") } }
+                paragraph { page_break }
+                fold {
+                    title: fold_title { text("title") }
+                    fold_content { paragraph { text("content") } }
+                }
+                paragraph {}
+            } }
+            selection: (title, 0)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn hoisted_page_break_before_block_atom_places_caret_at_the_gap() {
+        let (initial, p) = state! {
+            doc { root {
+                blockquote { p: paragraph { text("target") } }
+                horizontal_rule
+                paragraph {}
+            } }
+            selection: none
+        };
+        let mut tr = Transaction::new(&initial);
+        insert_slice_at(
+            &mut tr,
+            Position::new(p, 6),
+            page_break_slice(),
+            SliceProvenance::Formatted,
+        )
+        .expect("PageBreak hoists through a non-isolating wrapper")
+        .expect("PageBreak is inserted");
+        let (actual, ..) = tr.commit();
+
+        let (expected, ..) = state! {
+            doc { root: root {
+                blockquote { paragraph { text("target") } }
+                paragraph { page_break }
+                horizontal_rule
+                paragraph {}
+            } }
+            selection: (root, 2, >)
+        };
+        assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn hoisting_page_break_authors_required_completion_in_split_list_item() {
+        let (initial, p) = state! {
+            doc { root {
+                bullet_list {
+                    list_item {
+                        p: paragraph { text("a") }
+                        bullet_list { list_item { paragraph { text("x") } } }
+                    }
+                }
+                paragraph {}
+            } }
+            selection: none
+        };
+        let mut tr = Transaction::new(&initial);
+        let inserted = insert_slice_at(
+            &mut tr,
+            Position::new(p, 1),
+            page_break_slice(),
+            SliceProvenance::Formatted,
+        )
+        .expect("PageBreak hoists through list wrappers");
+        let (actual, ..) = tr.commit();
+
+        assert!(inserted.is_some());
+        assert_eq!(text_and_page_break_signature(&actual), "a|x");
+        let right_first_paragraph = {
+            let view = actual.view();
+            view.root()
+                .expect("root")
+                .child_blocks()
+                .filter(|node| node.node_type() == NodeType::BulletList)
+                .nth(1)
+                .expect("right list")
+                .child_blocks()
+                .next()
+                .expect("right item")
+                .child_blocks()
+                .next()
+                .expect("required paragraph")
+                .id()
+        };
+        assert!(
+            right_first_paragraph.as_op_dot().is_some(),
+            "accepted plan must author required split-wrapper completion"
+        );
+        assert_projection_integrity(&actual);
+    }
+
+    #[test]
     fn insert_open_page_break_paragraph_keeps_page_break_terminal() {
         let (initial, p1) = state! {
             doc { root { p1: paragraph { text("World") } } }
@@ -1194,7 +1622,7 @@ mod tests {
     }
 
     #[test]
-    fn insert_closed_page_break_paragraph_nested_drops_only_page_break() {
+    fn insert_closed_page_break_paragraph_nested_hoists_without_loss() {
         let (initial, p1) = state! {
             doc { root { blockquote { p1: paragraph { text("Nested") } } paragraph {} } }
             selection: none
@@ -1207,27 +1635,16 @@ mod tests {
             paragraph_with_page_break_slice("lo", 0, 0),
             SliceProvenance::Formatted,
         )
-        .expect("insert succeeds")
-        .expect("paragraph inserted");
+        .expect("PageBreak paragraph hoists through Blockquote");
         let (actual, ..) = tr.commit();
 
-        let (expected, ..) = state! {
-            doc { root {
-                blockquote {
-                    paragraph { text("Nes") }
-                    paragraph { text("lo") }
-                    paragraph { text("ted") }
-                }
-                paragraph {}
-            } }
-            selection: none
-        };
-        editor_state::assert_doc_eq!(&actual, &expected);
-        assert!(!inserted.is_collapsed());
+        assert!(inserted.is_some());
+        assert_eq!(text_and_page_break_signature(&actual), "Neslo|ted");
+        assert_projection_integrity(&actual);
     }
 
     #[test]
-    fn removing_first_page_break_only_block_does_not_transfer_its_openness() {
+    fn leading_page_break_only_block_hoists_in_order() {
         let (initial, p1) = state! {
             doc { root { blockquote { p1: paragraph { text("Nested") } } paragraph {} } }
             selection: none
@@ -1248,26 +1665,16 @@ mod tests {
             slice,
             SliceProvenance::Formatted,
         )
-        .expect("insert succeeds")
-        .expect("text inserted");
+        .expect("PageBreak blocks hoist through Blockquote");
         let (actual, ..) = tr.commit();
 
-        let (expected, ..) = state! {
-            doc { root {
-                blockquote {
-                    paragraph { text("Nes") }
-                    paragraph { text("xted") }
-                }
-                paragraph {}
-            } }
-            selection: none
-        };
-        editor_state::assert_doc_eq!(&actual, &expected);
-        assert!(!inserted.is_collapsed());
+        assert!(inserted.is_some());
+        assert_eq!(text_and_page_break_signature(&actual), "Nes|xted");
+        assert_projection_integrity(&actual);
     }
 
     #[test]
-    fn removing_last_page_break_only_block_does_not_transfer_its_openness() {
+    fn trailing_page_break_only_block_hoists_in_order() {
         let (initial, p1) = state! {
             doc { root { blockquote { p1: paragraph { text("Nested") } } paragraph {} } }
             selection: none
@@ -1288,21 +1695,11 @@ mod tests {
             slice,
             SliceProvenance::Formatted,
         )
-        .expect("insert succeeds")
-        .expect("text inserted");
+        .expect("PageBreak blocks hoist through Blockquote");
         let (actual, ..) = tr.commit();
 
-        let (expected, ..) = state! {
-            doc { root {
-                blockquote {
-                    paragraph { text("Nesx") }
-                    paragraph { text("ted") }
-                }
-                paragraph {}
-            } }
-            selection: none
-        };
-        editor_state::assert_doc_eq!(&actual, &expected);
-        assert!(!inserted.is_collapsed());
+        assert!(inserted.is_some());
+        assert_eq!(text_and_page_break_signature(&actual), "Nesx|ted");
+        assert_projection_integrity(&actual);
     }
 }

--- a/crates/editor-commands/src/commands/merge_adjacent_list_backward.rs
+++ b/crates/editor-commands/src/commands/merge_adjacent_list_backward.rs
@@ -1,8 +1,11 @@
-use editor_model::{ChildView, NodeType};
-use editor_state::{StableResolveCtx, StableSelection};
+use editor_model::NodeType;
+use editor_state::StableSelection;
 use editor_transaction::Transaction;
 
-use crate::helpers::{find_enclosing_list_item_id, is_list_type, prev_sibling};
+use crate::helpers::{
+    find_enclosing_list_item_id, is_list_type, merge_adjacent_list_pair, prev_sibling,
+    restore_selection_after_adjacent_list_merge,
+};
 use crate::{CommandError, CommandResult};
 
 pub fn merge_adjacent_list_backward(tr: &mut Transaction) -> CommandResult {
@@ -13,7 +16,7 @@ pub fn merge_adjacent_list_backward(tr: &mut Transaction) -> CommandResult {
         return Ok(false);
     }
 
-    let (earlier_list_id, later_list_id, earlier_len, items) = {
+    let (earlier_list_id, later_list_id) = {
         let view = tr.view();
         let paragraph = view
             .node(selection.head.node)
@@ -41,47 +44,12 @@ pub fn merge_adjacent_list_backward(tr: &mut Transaction) -> CommandResult {
         if !is_list_type(earlier_list.node_type()) {
             return Ok(false);
         }
-        if earlier_list
-            .children()
-            .chain(later_list.children())
-            .any(|child| matches!(child, ChildView::Leaf(_)))
-        {
-            return Err(CommandError::Corrupted(
-                "list contains an unsupported direct child".into(),
-            ));
-        }
-        let items = later_list
-            .child_blocks()
-            .map(|item| item.id())
-            .collect::<Vec<_>>();
-        if items.is_empty() {
-            return Err(CommandError::Corrupted(
-                "later list contains no list items".into(),
-            ));
-        }
-        (
-            earlier_list.id(),
-            later_list.id(),
-            earlier_list.child_blocks().count(),
-            items,
-        )
+        (earlier_list.id(), later_list.id())
     };
 
-    let stable_selection = StableSelection::capture(&selection, &tr.view());
-    tr.batch::<_, CommandError>(|tr| {
-        tr.move_nodes_consecutive(&items, earlier_list_id, earlier_len)?;
-        tr.remove_subtree(later_list_id)?;
-        let resolved = {
-            let view = tr.view();
-            let ctx = StableResolveCtx::from_live(&view, tr.state().projected.seq_checkout());
-            stable_selection.resolve(&ctx)
-        }
-        .ok_or_else(|| {
-            CommandError::Corrupted("cannot restore selection after list merge".into())
-        })?;
-        tr.set_selection(Some(resolved))?;
-        Ok(())
-    })?;
+    let stable = StableSelection::capture(&selection, &tr.view());
+    let merged = merge_adjacent_list_pair(tr, earlier_list_id, later_list_id)?;
+    restore_selection_after_adjacent_list_merge(tr, selection, stable, &merged)?;
 
     Ok(true)
 }

--- a/crates/editor-commands/src/commands/merge_adjacent_list_forward.rs
+++ b/crates/editor-commands/src/commands/merge_adjacent_list_forward.rs
@@ -1,8 +1,10 @@
-use editor_model::ChildView;
-use editor_state::{StableResolveCtx, StableSelection};
+use editor_state::StableSelection;
 use editor_transaction::Transaction;
 
-use crate::helpers::{ForwardListBoundary, find_forward_list_boundary, is_list_type};
+use crate::helpers::{
+    ForwardListBoundary, find_forward_list_boundary, is_list_type, merge_adjacent_list_pair,
+    restore_selection_after_adjacent_list_merge,
+};
 use crate::{CommandError, CommandResult};
 
 pub fn merge_adjacent_list_forward(tr: &mut Transaction) -> CommandResult {
@@ -13,7 +15,7 @@ pub fn merge_adjacent_list_forward(tr: &mut Transaction) -> CommandResult {
         return Ok(false);
     }
 
-    let (earlier_list_id, later_list_id, earlier_len, items) = {
+    let (earlier_list_id, later_list_id) = {
         let view = tr.view();
         let Some(ForwardListBoundary::NextBlock { list_id, next_id }) =
             find_forward_list_boundary(&view, selection.head)?
@@ -29,47 +31,12 @@ pub fn merge_adjacent_list_forward(tr: &mut Transaction) -> CommandResult {
         if !is_list_type(later_list.node_type()) {
             return Ok(false);
         }
-        if earlier_list
-            .children()
-            .chain(later_list.children())
-            .any(|child| matches!(child, ChildView::Leaf(_)))
-        {
-            return Err(CommandError::Corrupted(
-                "list contains an unsupported direct child".into(),
-            ));
-        }
-        let items = later_list
-            .child_blocks()
-            .map(|item| item.id())
-            .collect::<Vec<_>>();
-        if items.is_empty() {
-            return Err(CommandError::Corrupted(
-                "later list contains no list items".into(),
-            ));
-        }
-        (
-            earlier_list.id(),
-            later_list.id(),
-            earlier_list.child_blocks().count(),
-            items,
-        )
+        (earlier_list.id(), later_list.id())
     };
 
-    let stable_selection = StableSelection::capture(&selection, &tr.view());
-    tr.batch::<_, CommandError>(|tr| {
-        tr.move_nodes_consecutive(&items, earlier_list_id, earlier_len)?;
-        tr.remove_subtree(later_list_id)?;
-        let resolved = {
-            let view = tr.view();
-            let ctx = StableResolveCtx::from_live(&view, tr.state().projected.seq_checkout());
-            stable_selection.resolve(&ctx)
-        }
-        .ok_or_else(|| {
-            CommandError::Corrupted("cannot restore selection after list merge".into())
-        })?;
-        tr.set_selection(Some(resolved))?;
-        Ok(())
-    })?;
+    let stable = StableSelection::capture(&selection, &tr.view());
+    let merged = merge_adjacent_list_pair(tr, earlier_list_id, later_list_id)?;
+    restore_selection_after_adjacent_list_merge(tr, selection, stable, &merged)?;
 
     Ok(true)
 }

--- a/crates/editor-commands/src/commands/mod.rs
+++ b/crates/editor-commands/src/commands/mod.rs
@@ -114,7 +114,7 @@ pub use delete_text_forward::delete_text_forward;
 pub use edit_modifier::edit_modifier;
 pub use edit_modifier_in_selection::edit_modifier_in_selection;
 pub use ensure_paragraph::ensure_paragraph;
-pub use fill_cell_rect_with_slice::fill_cell_rect_with_slice;
+pub(crate) use fill_cell_rect_with_slice::apply_cell_fill_plan;
 pub use insert_fragment::insert_fragment;
 pub use insert_hard_break::insert_hard_break;
 pub use insert_page_break_into_prev_paragraph::insert_page_break_into_prev_paragraph;
@@ -152,7 +152,7 @@ pub use move_paragraph_backward_into_prev_list::move_paragraph_backward_into_pre
 pub use move_table_axis::move_table_axis;
 pub use normalize_selected_blocks_in_blockquote::normalize_selected_blocks_in_blockquote;
 pub use normalize_selected_blocks_in_callout::normalize_selected_blocks_in_callout;
-pub use paste_cells_into_cell_rect::paste_cells_into_cell_rect;
+pub(crate) use paste_cells_into_cell_rect::apply_table_grid_plan;
 pub use replace_range_with_text::replace_range_with_text;
 pub use replace_selection_with_text::replace_selection_with_text;
 pub use replace_tracked_range::replace_tracked_range;

--- a/crates/editor-commands/src/commands/paste_cells_into_cell_rect.rs
+++ b/crates/editor-commands/src/commands/paste_cells_into_cell_rect.rs
@@ -1,139 +1,92 @@
+#[cfg(test)]
 use editor_clipboard::Slice;
-use editor_model::{Fragment, PlainNode};
-use editor_state::enclosing_table_cell;
 use editor_state::{Position, Selection};
 use editor_transaction::Transaction;
 
 use crate::helpers::{
-    find_first_text_position, insert_empty_table_column, insert_empty_table_row, nth_table_cell,
-    repair_slice_fragments, replace_cell_children, table_col_count, table_row_count,
+    find_first_text_position, insert_empty_table_column, insert_empty_table_row,
+    materialize_planned_endpoint, nth_table_cell, replace_cell_children, table_col_count,
+    table_row_count,
 };
+use crate::judgments::{TableFinalSelection, TableGridPlan};
+#[cfg(test)]
+use crate::types::SliceProvenance;
 use crate::{CommandError, CommandResult};
 
 /// Cell-wise paste of a table slice. Anchor is the top-left of the target
 /// cell-rect, or — for a collapsed caret inside a cell — that cell as a 1×1
 /// rect. Missing rows/columns are appended (never inserted in the middle) so
 /// cells outside the source rectangle keep their content and position.
-pub fn paste_cells_into_cell_rect(tr: &mut Transaction, mut slice: Slice) -> CommandResult {
-    repair_slice_fragments(&mut slice.content);
-    let Some(source_rows) = extract_source_rows(&slice) else {
-        return Ok(false);
-    };
-    let sr = source_rows.len();
-    let sc = source_rows.iter().map(|r| r.len()).max().unwrap_or(0);
-    if sr == 0 || sc == 0 {
-        return Ok(false);
-    }
+#[cfg(test)]
+fn paste_cells_into_cell_rect(tr: &mut Transaction, slice: Slice) -> CommandResult {
+    crate::insert_slice(tr, slice, SliceProvenance::Formatted)
+}
 
-    let (table_id, anchor_row, anchor_col, total_r, total_c) = {
-        let Some(sel) = tr.selection() else {
-            return Ok(false);
-        };
-        let view = tr.view();
-        let Some(rs) = sel.resolve(&view) else {
-            return Ok(false);
-        };
-        let (table_id, anchor_row, anchor_col) = if let Some(rect) = rs.as_cell_rect() {
-            (rect.table.id(), *rect.rows.start(), *rect.cols.start())
-        } else {
-            let head_id = rs.head().node();
-            let Some(cell_id) = enclosing_table_cell(&view, head_id) else {
-                return Ok(false);
-            };
-            let cell = view
-                .node(cell_id)
-                .ok_or(CommandError::NodeNotFound(cell_id))?;
-            let row = cell.parent().ok_or(CommandError::NoParent(cell_id))?;
-            let table = row
-                .parent()
-                .ok_or_else(|| CommandError::NoParent(row.id()))?;
-            let row_idx = row
-                .index()
-                .ok_or_else(|| CommandError::orphan_child(row.id(), table.id()))?;
-            let col_idx = cell
-                .index()
-                .ok_or_else(|| CommandError::orphan_child(cell_id, row.id()))?;
-            (table.id(), row_idx, col_idx)
-        };
-        let table = view
-            .node(table_id)
-            .ok_or(CommandError::NodeNotFound(table_id))?;
-        let total_r = table.child_blocks().count();
-        let total_c = table
-            .child_blocks()
-            .next()
-            .map(|row| row.child_blocks().count())
-            .unwrap_or(0);
-        if total_r == 0 || total_c == 0 {
-            return Ok(false);
+pub(crate) fn apply_table_grid_plan(tr: &mut Transaction, plan: TableGridPlan) -> CommandResult {
+    let table_id = materialize_planned_endpoint(tr, &plan.table)?.node;
+    let mut materialized_cells = Vec::with_capacity(plan.target_cells.len());
+    for row in &plan.target_cells {
+        let mut materialized_row = Vec::with_capacity(row.len());
+        for cell in row {
+            materialized_row.push(materialize_planned_endpoint(tr, cell)?.node);
         }
-        (table_id, anchor_row, anchor_col, total_r, total_c)
-    };
-
-    let extra_r = (anchor_row + sr).saturating_sub(total_r);
-    let extra_c = (anchor_col + sc).saturating_sub(total_c);
-
+        materialized_cells.push(materialized_row);
+    }
+    let current_rows = table_row_count(tr, table_id)?;
+    let current_cols = table_col_count(tr, table_id)?;
+    if current_rows != plan.original_rows || current_cols != plan.original_cols {
+        return Err(CommandError::Corrupted(
+            "table-grid Slice target changed after planning".into(),
+        ));
+    }
+    for (row_offset, row) in materialized_cells.iter().enumerate() {
+        for (col_offset, cell) in row.iter().enumerate() {
+            if nth_table_cell(
+                tr,
+                table_id,
+                plan.anchor_row + row_offset,
+                plan.anchor_col + col_offset,
+            )? != *cell
+            {
+                return Err(CommandError::Corrupted(
+                    "table-grid Slice target changed after materialization".into(),
+                ));
+            }
+        }
+    }
+    let source_row_count = plan.source_rows.len();
+    let source_col_count = plan.source_rows.first().map(Vec::len).unwrap_or(0);
     tr.batch::<_, CommandError>(|tr| {
         // Columns first so subsequent row insertions inherit the new width.
-        for _ in 0..extra_c {
+        for _ in 0..plan.append_cols {
             let col_count = table_col_count(tr, table_id)?;
             insert_empty_table_column(tr, table_id, col_count)?;
         }
-        for _ in 0..extra_r {
+        for _ in 0..plan.append_rows {
             let row_count = table_row_count(tr, table_id)?;
             insert_empty_table_row(tr, table_id, row_count)?;
         }
 
-        for sr_i in 0..sr {
-            for sc_i in 0..sc {
-                let Some(source_cell) = source_rows.get(sr_i).and_then(|r| r.get(sc_i)) else {
-                    continue;
-                };
+        for sr_i in 0..source_row_count {
+            for sc_i in 0..source_col_count {
+                let source_cell = &plan.source_rows[sr_i][sc_i];
                 let target_cell_id =
-                    nth_table_cell(tr, table_id, anchor_row + sr_i, anchor_col + sc_i)?;
+                    nth_table_cell(tr, table_id, plan.anchor_row + sr_i, plan.anchor_col + sc_i)?;
                 replace_cell_children(tr, target_cell_id, &source_cell.children)?;
             }
         }
+        let anchor_cell_id = nth_table_cell(tr, table_id, plan.anchor_row, plan.anchor_col)?;
+        let cursor = match plan.final_selection {
+            TableFinalSelection::FirstTextInAnchorCell => {
+                find_first_text_position(&tr.view(), anchor_cell_id)
+                    .unwrap_or_else(|| Position::new(anchor_cell_id, 0))
+            }
+        };
+        tr.set_selection(Some(Selection::collapsed(cursor)))?;
         Ok(())
     })?;
 
-    let anchor_cell_id = nth_table_cell(tr, table_id, anchor_row, anchor_col)?;
-    let cursor = find_first_text_position(&tr.view(), anchor_cell_id)
-        .unwrap_or_else(|| Position::new(anchor_cell_id, 0));
-    tr.set_selection(Some(Selection::collapsed(cursor)))?;
     Ok(true)
-}
-
-fn extract_source_rows(slice: &Slice) -> Option<Vec<Vec<Fragment>>> {
-    let table = slice.content.iter().find_map(find_table_fragment)?;
-    let mut rows: Vec<Vec<Fragment>> = Vec::new();
-    for r in &table.children {
-        if !matches!(r.node, PlainNode::TableRow(_)) {
-            continue;
-        }
-        let cells: Vec<Fragment> = r
-            .children
-            .iter()
-            .filter(|c| matches!(c.node, PlainNode::TableCell(_)))
-            .cloned()
-            .collect();
-        if !cells.is_empty() {
-            rows.push(cells);
-        }
-    }
-    (!rows.is_empty()).then_some(rows)
-}
-
-fn find_table_fragment(frag: &Fragment) -> Option<&Fragment> {
-    if matches!(frag.node, PlainNode::Table(_)) {
-        return Some(frag);
-    }
-    for c in &frag.children {
-        if let Some(t) = find_table_fragment(c) {
-            return Some(t);
-        }
-    }
-    None
 }
 
 #[cfg(test)]
@@ -190,27 +143,178 @@ mod tests {
         (rows, cols)
     }
 
-    #[test]
-    fn returns_false_when_slice_has_no_table() {
-        let (state, _, c00) = state! {
-            doc { root { table { tr0: table_row {
-                c00: table_cell { paragraph { text("x") } }
-            } } } }
-            selection: (c00, 0)
-        };
-        let initial = with_cell_rect(state, c00, c00);
-        let slice = Slice::from_text("plain");
-        transact_fail!(initial, |tr| paste_cells_into_cell_rect(&mut tr, slice));
+    fn invert_recorded_ops(
+        state: &mut editor_state::State,
+        ops: &[editor_state::undo::RecordedOp],
+    ) -> Vec<editor_state::undo::RecordedOp> {
+        use editor_state::undo::{RecordedOp, capture_prior, invert};
+
+        let mut out = Vec::new();
+        for recorded in ops.iter().rev() {
+            for payload in invert(&state.projected, recorded) {
+                let prior = capture_prior(&state.projected, &payload);
+                let op = state.projected_mut().apply(payload).unwrap();
+                out.push(RecordedOp { op, prior });
+            }
+        }
+        out
     }
 
     #[test]
-    fn returns_false_when_selection_is_not_cell_rect() {
-        let (initial, _) = state! {
-            doc { root { p1: paragraph { text("hello") } } }
-            selection: (p1, 0) -> (p1, 5)
+    fn architecture_a_table_grid_accepts_same_cell_range() {
+        let (initial, table, _p) = state! {
+            doc { root { table: table {
+                table_row {
+                    table_cell { p: paragraph { text("ab") } }
+                    table_cell { paragraph { text("untouched") } }
+                }
+            } } }
+            selection: (p, 0) -> (p, 2)
         };
         let source = source_slice_2x2();
-        transact_fail!(initial, |tr| paste_cells_into_cell_rect(&mut tr, source));
+
+        let (after, ..) = transact!(initial, |tr| paste_cells_into_cell_rect(&mut tr, source));
+
+        let view = after.view();
+        assert_eq!(table_dims(&view, table), (2, 2));
+        assert_eq!(cell_text_at(&view, table, 0, 0), "X");
+        assert_eq!(cell_text_at(&view, table, 0, 1), "Y");
+        assert_eq!(cell_text_at(&view, table, 1, 0), "Z");
+        assert_eq!(cell_text_at(&view, table, 1, 1), "W");
+    }
+
+    #[test]
+    fn table_grid_materializes_a_projected_row_cell_and_paragraph() {
+        let (mut initial, table) = state! {
+            doc { root {
+                table: table {}
+                paragraph {}
+            } }
+            selection: none
+        };
+        let synthetic_paragraph = {
+            let view = initial.view();
+            let table = view.node(table).expect("table");
+            let row = table.child_blocks().next().expect("projected row");
+            let cell = row.child_blocks().next().expect("projected cell");
+            let paragraph = cell.child_blocks().next().expect("projected paragraph");
+            assert!(row.id().is_synthetic());
+            assert!(cell.id().is_synthetic());
+            assert!(paragraph.id().is_synthetic());
+            paragraph.id()
+        };
+        initial.selection = Some(Selection::collapsed(Position::new(synthetic_paragraph, 0)));
+
+        let mut tr = Transaction::new(&initial);
+        assert!(
+            paste_cells_into_cell_rect(&mut tr, source_slice_2x2()).unwrap(),
+            "a planned synthetic grid target must execute"
+        );
+        let (after, ..) = tr.commit();
+
+        let view = after.view();
+        assert_eq!(table_dims(&view, table), (2, 2));
+        assert_eq!(cell_text_at(&view, table, 0, 0), "X");
+        assert_eq!(cell_text_at(&view, table, 0, 1), "Y");
+        assert_eq!(cell_text_at(&view, table, 1, 0), "Z");
+        assert_eq!(cell_text_at(&view, table, 1, 1), "W");
+        let selection = after.selection.expect("final caret");
+        assert!(!selection.head.node.is_synthetic());
+        assert_projection_integrity(&after);
+    }
+
+    #[test]
+    fn table_grid_materializes_non_anchor_synthetic_completion_cells() {
+        let (initial, table, _paragraph) = state! {
+            doc { root {
+                table: table {
+                    table_row {
+                        table_cell { paragraph: paragraph { text("a") } }
+                        table_cell { paragraph { text("b") } }
+                        table_cell { paragraph { text("c") } }
+                    }
+                    table_row {
+                        table_cell { paragraph { text("d") } }
+                    }
+                }
+                paragraph {}
+            } }
+            selection: (paragraph, 0)
+        };
+        {
+            let view = initial.view();
+            let second_row = view
+                .node(table)
+                .expect("table")
+                .child_blocks()
+                .nth(1)
+                .expect("second row");
+            let completions = second_row
+                .child_blocks()
+                .skip(1)
+                .map(|cell| cell.id())
+                .collect::<Vec<_>>();
+            assert_eq!(completions.len(), 2);
+            assert!(completions.iter().all(|cell| cell.is_synthetic()));
+        }
+
+        let mut tr = Transaction::new(&initial);
+        assert!(
+            paste_cells_into_cell_rect(&mut tr, source_slice_2x3()).unwrap(),
+            "the accepted grid plan must materialize every target cell slot"
+        );
+        let (after, _, recorded, ..) = tr.commit();
+
+        let view = after.view();
+        assert_eq!(table_dims(&view, table), (2, 3));
+        assert_eq!(cell_text_at(&view, table, 0, 0), "X");
+        assert_eq!(cell_text_at(&view, table, 0, 1), "Y");
+        assert_eq!(cell_text_at(&view, table, 0, 2), "Z");
+        assert_eq!(cell_text_at(&view, table, 1, 0), "P");
+        assert_eq!(cell_text_at(&view, table, 1, 1), "Q");
+        assert_eq!(cell_text_at(&view, table, 1, 2), "R");
+        assert_projection_integrity(&after);
+
+        let mut restored = after.clone();
+        let redo = invert_recorded_ops(&mut restored, &recorded);
+        assert_eq!(restored.to_plain(), initial.to_plain());
+        assert_projection_integrity(&restored);
+        invert_recorded_ops(&mut restored, &redo);
+        assert_eq!(restored.to_plain(), after.to_plain());
+        assert_projection_integrity(&restored);
+    }
+
+    #[test]
+    fn full_table_cell_rect_is_canonicalized_to_linear_replacement() {
+        let (initial, old_table, cell) = state! {
+            doc { root { old_table: table {
+                table_row {
+                    cell: table_cell { paragraph { text("old") } }
+                }
+            } } }
+            selection: (cell, 0)
+        };
+        let initial = with_cell_rect(initial, cell, cell);
+
+        let (after, ..) = transact!(initial, |tr| paste_cells_into_cell_rect(
+            &mut tr,
+            source_slice_2x2(),
+        ));
+
+        let view = after.view();
+        assert!(
+            view.node(old_table).is_none(),
+            "a canonical full-table replacement must not mutate the old grid in place"
+        );
+        let table = view
+            .root()
+            .unwrap()
+            .child_blocks()
+            .find(|block| block.node_type() == editor_model::NodeType::Table)
+            .expect("replacement table");
+        assert_eq!(table_dims(&view, table.id()), (2, 2));
+        assert_eq!(cell_text_at(&view, table.id(), 0, 0), "X");
+        assert_eq!(cell_text_at(&view, table.id(), 1, 1), "W");
     }
 
     fn source_slice_2x2() -> Slice {
@@ -233,6 +337,33 @@ mod tests {
         };
         let s = editor_state::State {
             selection: Some(sel),
+            ..s
+        };
+        Slice::extract(&s).unwrap()
+    }
+
+    fn source_slice_2x3() -> Slice {
+        let (s, c00, c12) = state! {
+            doc { root { table {
+                table_row {
+                    c00: table_cell { paragraph { text("X") } }
+                    table_cell { paragraph { text("Y") } }
+                    table_cell { paragraph { text("Z") } }
+                }
+                table_row {
+                    table_cell { paragraph { text("P") } }
+                    table_cell { paragraph { text("Q") } }
+                    c12: table_cell { paragraph { text("R") } }
+                }
+            } } }
+            selection: (c00, 0)
+        };
+        let selection = {
+            let view = s.view();
+            cell_rect_selection(c00, c12, &view).unwrap()
+        };
+        let s = editor_state::State {
+            selection: Some(selection),
             ..s
         };
         Slice::extract(&s).unwrap()

--- a/crates/editor-commands/src/helpers/deletion.rs
+++ b/crates/editor-commands/src/helpers/deletion.rs
@@ -9,11 +9,14 @@ use editor_transaction::{Step, Transaction, first_child_type, fulfill, minimal_s
 
 use super::{
     apply_carry_from_selection, apply_carry_on_emptied, capture_first_charlike_paint,
-    cell_first_charlike_block, child_elem_id, find_ancestor_textblock, find_lowest_common_ancestor,
-    is_block_container, is_list_type, materialize_selection_endpoints, merge_element_cross_parent,
-    next_sibling, path_from_ancestor,
+    cell_first_charlike_block, find_ancestor_textblock, find_lowest_common_ancestor,
+    is_block_container, materialize_selection_endpoints, merge_block_container_into,
+    merge_element_cross_parent, path_from_ancestor,
 };
 use crate::{CommandError, CommandResult};
+
+mod plan;
+pub(crate) use plan::*;
 
 enum SlotKind {
     Char,
@@ -447,6 +450,25 @@ pub(crate) fn delete_selection_range_no_carry(
     delete_selection_range_carry(tr, selection, false)
 }
 
+/// Apply only the removal geometry of a planned cross-node range.
+///
+/// Replacement planning owns any subsequent joins or branch splits. This
+/// primitive deliberately performs neither.
+pub(crate) fn apply_cross_range_removal_without_join(
+    tr: &mut Transaction,
+    plan: &LinearDeletionPlan,
+) -> CommandResult {
+    let LinearDeletionKind::Cross { geometry, .. } = &plan.kind else {
+        return Err(CommandError::Corrupted(
+            "cross-range removal requires a cross-node plan".into(),
+        ));
+    };
+    tr.batch::<_, CommandError>(|tr| {
+        delete_range(tr, &geometry.from_path, &geometry.to_path, geometry.lca_id)
+    })?;
+    Ok(true)
+}
+
 fn delete_selection_range_carry(
     tr: &mut Transaction,
     selection: Selection,
@@ -479,9 +501,11 @@ fn delete_selection_range_carry(
                 anchor_id,
             }
         } else {
-            let from = resolved.from().position();
-            let to = resolved.to().position();
-            Plan::Range { from, to }
+            let plan = plan_linear_deletion(&view, selection)?.ok_or_else(|| {
+                CommandError::Corrupted("non-cell deletion has no linear range".into())
+            })?;
+            let join = plan_linear_join(&view, &plan)?;
+            Plan::Linear { plan, join }
         }
     };
 
@@ -524,36 +548,203 @@ fn delete_selection_range_carry(
             tr.set_selection(Some(Selection::collapsed(cursor)))?;
             Ok(true)
         }
-        Plan::Range { from, to } => delete_resolved_range(tr, from, to, write_carry),
+        Plan::Linear { plan, join } => {
+            apply_linear_deletion_plan(tr, &plan, join.as_ref(), write_carry)
+        }
     }
 }
 
 enum Plan {
-    CellRect { cell_ids: Vec<Dot>, anchor_id: Dot },
-    Range { from: Position, to: Position },
+    CellRect {
+        cell_ids: Vec<Dot>,
+        anchor_id: Dot,
+    },
+    Linear {
+        plan: LinearDeletionPlan,
+        join: Option<LinearJoinExecution>,
+    },
 }
 
-fn delete_resolved_range(
+#[derive(Clone)]
+pub(crate) struct LinearDeletionPlan {
+    pub from: Position,
+    pub to: Position,
+    pub from_path: Vec<usize>,
+    pub to_path: Vec<usize>,
+    pub kind: LinearDeletionKind,
+}
+
+#[derive(Clone)]
+pub(crate) enum LinearDeletionKind {
+    SameNode {
+        is_container: bool,
+    },
+    Cross {
+        geometry: CrossRangeGeometry,
+        from_textblock: Option<Dot>,
+        to_textblock: Option<Dot>,
+        merge_textblocks: bool,
+    },
+}
+
+#[derive(Clone)]
+pub(crate) enum LinearDeletionSemantics {
+    SameNode { is_container: bool },
+    Cross { merge_textblocks: bool },
+}
+
+#[derive(Clone)]
+pub(crate) struct LinearJoinExecution {
+    pub(crate) from_textblock: Dot,
+    pub(crate) to_textblock: Dot,
+    pub(crate) trailing_page_break: Option<Dot>,
+    pub(crate) prune: Vec<Dot>,
+    pub(crate) container_merges: Vec<(Dot, Dot)>,
+    pub(crate) affected: Vec<Dot>,
+}
+
+impl LinearDeletionPlan {
+    pub(crate) fn semantics(&self) -> LinearDeletionSemantics {
+        match &self.kind {
+            LinearDeletionKind::SameNode { is_container } => LinearDeletionSemantics::SameNode {
+                is_container: *is_container,
+            },
+            LinearDeletionKind::Cross {
+                merge_textblocks, ..
+            } => LinearDeletionSemantics::Cross {
+                merge_textblocks: *merge_textblocks,
+            },
+        }
+    }
+}
+
+pub(crate) fn plan_linear_deletion(
+    view: &DocView,
+    selection: Selection,
+) -> Result<Option<LinearDeletionPlan>, CommandError> {
+    let resolved = selection
+        .resolve(view)
+        .ok_or_else(|| CommandError::Corrupted("cannot resolve deletion selection".into()))?;
+    if resolved.as_cell_rect().is_some() || selection.is_collapsed() {
+        return Ok(None);
+    }
+    let from = resolved.from().position();
+    let to = resolved.to().position();
+    let from_path = resolved.from().path().to_vec();
+    let to_path = resolved.to().path().to_vec();
+    let kind = if from.node == to.node {
+        LinearDeletionKind::SameNode {
+            is_container: view
+                .node(from.node)
+                .is_some_and(|node| is_block_container(&node)),
+        }
+    } else {
+        let geometry = cross_range_geometry(view, from, to)?;
+        let from_textblock = find_ancestor_textblock(view, from.node);
+        let to_textblock = find_ancestor_textblock(view, to.node);
+        let merge_textblocks = matches!(
+            (from_textblock, to_textblock),
+            (Some(from), Some(to))
+                if from != to && structural_region(view, from) == structural_region(view, to)
+        );
+        LinearDeletionKind::Cross {
+            geometry,
+            from_textblock,
+            to_textblock,
+            merge_textblocks,
+        }
+    };
+    Ok(Some(LinearDeletionPlan {
+        from,
+        to,
+        from_path,
+        to_path,
+        kind,
+    }))
+}
+
+/// Rebuild endpoint geometry after projection-only endpoints have been
+/// materialized, while requiring the accepted deletion semantics to remain
+/// unchanged. This is an identity remap for an existing plan, not a second
+/// replacement judgment.
+pub(crate) fn remap_linear_deletion_plan(
+    view: &DocView,
+    planned: &LinearDeletionSemantics,
+    selection: Selection,
+) -> Result<LinearDeletionPlan, CommandError> {
+    let resolved = selection.resolve(view).ok_or_else(|| {
+        CommandError::Corrupted("materialized Slice replacement no longer resolves".into())
+    })?;
+    if resolved.as_cell_rect().is_some() || selection.is_collapsed() {
+        return Err(CommandError::Corrupted(
+            "materialized Slice replacement is no longer a linear range".into(),
+        ));
+    }
+    let from = resolved.from().position();
+    let to = resolved.to().position();
+    let from_path = resolved.from().path().to_vec();
+    let to_path = resolved.to().path().to_vec();
+    let kind = match planned {
+        LinearDeletionSemantics::SameNode { is_container } => {
+            if from.node != to.node
+                || view
+                    .node(from.node)
+                    .is_some_and(|node| is_block_container(&node))
+                    != *is_container
+            {
+                return Err(CommandError::Corrupted(
+                    "materialized Slice replacement changed its same-node boundary".into(),
+                ));
+            }
+            LinearDeletionKind::SameNode {
+                is_container: *is_container,
+            }
+        }
+        LinearDeletionSemantics::Cross { merge_textblocks } => {
+            if from.node == to.node {
+                return Err(CommandError::Corrupted(
+                    "materialized Slice replacement collapsed its cross-node boundary".into(),
+                ));
+            }
+            let geometry = cross_range_geometry(view, from, to)?;
+            let from_textblock = find_ancestor_textblock(view, from.node);
+            let to_textblock = find_ancestor_textblock(view, to.node);
+            LinearDeletionKind::Cross {
+                geometry,
+                from_textblock,
+                to_textblock,
+                merge_textblocks: *merge_textblocks,
+            }
+        }
+    };
+    Ok(LinearDeletionPlan {
+        from,
+        to,
+        from_path,
+        to_path,
+        kind,
+    })
+}
+
+pub(crate) fn apply_linear_deletion_plan(
     tr: &mut Transaction,
-    from: Position,
-    to: Position,
+    plan: &LinearDeletionPlan,
+    join: Option<&LinearJoinExecution>,
     write_carry: bool,
 ) -> CommandResult {
-    let captured = write_carry
-        .then(|| {
-            let state = tr.state();
-            let view = state.view();
-            first_textblock_in_range(&view, &from)
-                .map(|block| capture_first_charlike_paint(state, block))
-        })
-        .flatten();
+    let from = plan.from;
+    let to = plan.to;
 
-    if from.node == to.node {
-        let is_container = {
-            let view = tr.state().view();
-            view.node(from.node).is_some_and(|n| is_block_container(&n))
-        };
-        if is_container {
+    if let LinearDeletionKind::SameNode { is_container } = &plan.kind {
+        let captured = write_carry
+            .then(|| {
+                let state = tr.state();
+                let view = state.view();
+                first_textblock_in_range(&view, &from)
+                    .map(|block| capture_first_charlike_paint(state, block))
+            })
+            .flatten();
+        if *is_container {
             tr.batch::<_, CommandError>(|tr| {
                 delete_child_slots(tr, from.node, from.offset, to.offset)?;
                 let steps = {
@@ -581,21 +772,37 @@ fn delete_resolved_range(
         return Ok(true);
     }
 
-    // Cross-node range.
-    let (lca_id, from_tb, to_tb, from_path, to_path) = {
-        let view = tr.state().view();
-        let lca_id = find_lowest_common_ancestor(&view, from.node, to.node)
-            .ok_or_else(|| CommandError::Corrupted("no common ancestor".into()))?;
-        let from_tb = find_ancestor_textblock(&view, from.node);
-        let to_tb = find_ancestor_textblock(&view, to.node);
-        let mut from_path = path_from_ancestor(&view, from.node, lca_id)
-            .ok_or_else(|| CommandError::Corrupted("from is not descendant of LCA".into()))?;
-        from_path.push(from.offset);
-        let mut to_path = path_from_ancestor(&view, to.node, lca_id)
-            .ok_or_else(|| CommandError::Corrupted("to is not descendant of LCA".into()))?;
-        to_path.push(to.offset);
-        (lca_id, from_tb, to_tb, from_path, to_path)
+    apply_cross_linear_deletion(tr, plan, join, write_carry)
+}
+
+fn apply_cross_linear_deletion(
+    tr: &mut Transaction,
+    plan: &LinearDeletionPlan,
+    join: Option<&LinearJoinExecution>,
+    write_carry: bool,
+) -> CommandResult {
+    let from = plan.from;
+    let to = plan.to;
+    let captured = write_carry
+        .then(|| {
+            let state = tr.state();
+            let view = state.view();
+            first_textblock_in_range(&view, &from)
+                .map(|block| capture_first_charlike_paint(state, block))
+        })
+        .flatten();
+    let LinearDeletionKind::Cross {
+        geometry,
+        from_textblock: _,
+        to_textblock: to_tb,
+        merge_textblocks,
+    } = &plan.kind
+    else {
+        return Err(CommandError::Corrupted(
+            "linear deletion plan kind does not match its endpoints".into(),
+        ));
     };
+    let lca_id = geometry.lca_id;
 
     let to_captured = write_carry
         .then(|| to_tb.map(|tb| capture_first_charlike_paint(tr.state(), tb)))
@@ -604,10 +811,24 @@ fn delete_resolved_range(
     let from_node_id = from.node;
     let to_node_id = to.node;
     tr.batch::<_, CommandError>(|tr| {
-        delete_range(tr, &from_path, &to_path, lca_id)?;
-        merge_after_delete(tr, from_tb, to_tb, lca_id)?;
-        fulfill_ancestors(tr, from_node_id, lca_id)?;
-        fulfill_ancestors(tr, to_node_id, lca_id)?;
+        delete_range(tr, &geometry.from_path, &geometry.to_path, geometry.lca_id)?;
+        match (*merge_textblocks, join) {
+            (true, Some(join)) => apply_planned_join(tr, join)?,
+            (false, None) => {
+                fulfill_ancestors(tr, from_node_id, lca_id)?;
+                fulfill_ancestors(tr, to_node_id, lca_id)?;
+            }
+            (true, None) => {
+                return Err(CommandError::Corrupted(
+                    "linear deletion has no planned join".into(),
+                ));
+            }
+            (false, Some(_)) => {
+                return Err(CommandError::Corrupted(
+                    "linear deletion received an unexpected join".into(),
+                ));
+            }
+        }
         Ok(())
     })?;
 
@@ -628,10 +849,86 @@ fn delete_resolved_range(
     if let Some(captured) = &captured {
         apply_carry_from_selection(tr, captured)?;
     }
-    if let (Some(to_tb), Some(to_captured)) = (to_tb, &to_captured) {
+    if let (Some(to_tb), Some(to_captured)) = (*to_tb, &to_captured) {
         apply_carry_on_emptied(tr, to_tb, to_captured)?;
     }
     Ok(true)
+}
+
+fn apply_planned_join(
+    tr: &mut Transaction,
+    join: &LinearJoinExecution,
+) -> Result<(), CommandError> {
+    if let Some(page_break) = join.trailing_page_break
+        && tr.view().leaf(page_break).is_some()
+    {
+        remove_subtree_full(tr, page_break)?;
+    }
+    merge_element_cross_parent(tr, join.to_textblock, join.from_textblock)?;
+
+    for &node in &join.prune {
+        let valid = {
+            let view = tr.view();
+            view.node(node).is_some_and(|node| {
+                is_structurally_empty(&node)
+                    && node.spec().content.min_required() > 0
+                    && !node.spec().structural
+            })
+        };
+        if !valid {
+            return Err(CommandError::Corrupted(
+                "planned Slice join prune no longer matches its empty container".into(),
+            ));
+        }
+        remove_subtree_full(tr, node)?;
+    }
+
+    for &(target, source) in &join.container_merges {
+        if tr.view().node(source).is_none() {
+            return Err(CommandError::Corrupted(
+                "planned Slice join lost its source container".into(),
+            ));
+        }
+        merge_block_container_into(tr, target, source)?;
+    }
+
+    for &node in &join.affected {
+        let steps = {
+            let view = tr.view();
+            view.node(node)
+                .map(|node| fulfill(&node))
+                .unwrap_or_default()
+        };
+        tr.apply_steps(steps)?;
+    }
+    Ok(())
+}
+
+#[derive(Clone)]
+pub(crate) struct CrossRangeGeometry {
+    pub lca_id: Dot,
+    pub from_path: Vec<usize>,
+    pub to_path: Vec<usize>,
+}
+
+fn cross_range_geometry(
+    view: &DocView,
+    from: Position,
+    to: Position,
+) -> Result<CrossRangeGeometry, CommandError> {
+    let lca_id = find_lowest_common_ancestor(view, from.node, to.node)
+        .ok_or_else(|| CommandError::Corrupted("no common ancestor".into()))?;
+    let mut from_path = path_from_ancestor(view, from.node, lca_id)
+        .ok_or_else(|| CommandError::Corrupted("from is not descendant of LCA".into()))?;
+    from_path.push(from.offset);
+    let mut to_path = path_from_ancestor(view, to.node, lca_id)
+        .ok_or_else(|| CommandError::Corrupted("to is not descendant of LCA".into()))?;
+    to_path.push(to.offset);
+    Ok(CrossRangeGeometry {
+        lca_id,
+        from_path,
+        to_path,
+    })
 }
 
 fn materialize_cell_textblock(
@@ -1084,255 +1381,6 @@ fn structural_region(view: &DocView, node_id: Dot) -> Option<Dot> {
         }
         current = current.parent()?;
     }
-}
-
-/// Merges `source` (a block container) into `target` by re-parenting each of
-/// source's child blocks to the end of `target`, then removing the emptied
-/// source. Unlike `merge_node` (which only flows up loose char/atom leaves),
-/// this correctly relocates block children whose parents chain would otherwise
-/// dangle to the deleted container.
-fn merge_containers(tr: &mut Transaction, target: Dot, source: Dot) -> Result<(), CommandError> {
-    loop {
-        // Only real children move; the projection synthesizes a Derived
-        // placeholder for an empty required container, so stop when only
-        // placeholders remain (otherwise this loops forever).
-        let child = {
-            let view = tr.state().view();
-            match view.node(source) {
-                Some(s) => s
-                    .child_blocks()
-                    .find(|c| c.id().as_op_dot().is_some())
-                    .map(|c| c.id()),
-                None => return Ok(()),
-            }
-        };
-        let Some(child) = child else { break };
-        let target_len = {
-            let view = tr.state().view();
-            view.node(target)
-                .map(|n| {
-                    n.children()
-                        .filter(|c| child_elem_id(c).as_op_dot().is_some())
-                        .count()
-                })
-                .unwrap_or(0)
-        };
-        tr.move_node(child, target, target_len)?;
-    }
-    remove_subtree_full(tr, source)
-}
-
-/// Merges `block`'s next same-parent sibling into it via `merge_containers`
-/// (re-resolving the sibling, whose dot may be fresh after a prior move).
-fn merge_with_next_sibling(tr: &mut Transaction, block: Dot) -> Result<(), CommandError> {
-    let next = {
-        let view = tr.state().view();
-        view.node(block)
-            .and_then(|n| next_sibling(&n))
-            .and_then(|c| match c {
-                ChildView::Block(b) => Some(b.id()),
-                ChildView::Leaf(_) => None,
-            })
-    };
-    match next {
-        Some(next_id) => merge_containers(tr, block, next_id),
-        None => Ok(()),
-    }
-}
-
-fn merge_after_delete(
-    tr: &mut Transaction,
-    from_tb: Option<Dot>,
-    to_tb: Option<Dot>,
-    lca_id: Dot,
-) -> Result<(), CommandError> {
-    let (from_tb, to_tb) = match (from_tb, to_tb) {
-        (Some(a), Some(b)) if a != b => (a, b),
-        _ => return Ok(()),
-    };
-
-    {
-        let view = tr.state().view();
-        if view.node(from_tb).is_none() || view.node(to_tb).is_none() {
-            return Ok(());
-        }
-        if structural_region(&view, from_tb) != structural_region(&view, to_tb) {
-            return Ok(());
-        }
-    }
-
-    let to_tb_parent = {
-        let view = tr.state().view();
-        view.node(to_tb).and_then(|n| n.parent()).map(|p| p.id())
-    };
-
-    // Trailing PageBreak guard: drop it before merging so it does not end up mid-list.
-    let trailing_page_break = {
-        let view = tr.state().view();
-        view.node(from_tb)
-            .and_then(|target| match target.last_child() {
-                Some(ChildView::Leaf(l)) if l.node_type() == NodeType::PageBreak => Some(l.dot()),
-                _ => None,
-            })
-    };
-    if let Some(pb) = trailing_page_break {
-        remove_subtree_full(tr, pb)?;
-    }
-
-    merge_element_cross_parent(tr, to_tb, from_tb)?;
-
-    // The to-side container that held to_tb is now emptied (its content merged
-    // into from_tb); drop it before the container walk so it is not carried into
-    // the merged container as an empty item.
-    if let Some(parent_id) = to_tb_parent {
-        let empty = {
-            let view = tr.state().view();
-            view.node(parent_id)
-                .map(|p| is_structurally_empty(&p))
-                .unwrap_or(false)
-        };
-        if empty {
-            prune_empty_full(tr, parent_id)?;
-        }
-    }
-
-    // Container-level merge: walk up through the boundary removed by the
-    // selection. Same-type containers merge normally; adjacent lists also
-    // merge across kinds, preserving the earlier list's type.
-    let mut from_current = {
-        let view = tr.state().view();
-        view.node(from_tb).and_then(|n| n.parent()).map(|p| p.id())
-    };
-
-    while let Some(from_id) = from_current {
-        if from_id == lca_id {
-            break;
-        }
-
-        let (next_id, next_mergeable, parent_id, seam_lists) = {
-            let view = tr.state().view();
-            let Some(from_node) = view.node(from_id) else {
-                break;
-            };
-            match next_sibling(&from_node) {
-                Some(ChildView::Block(next)) => {
-                    let same_type = next.node_type() == from_node.node_type();
-                    let list_pair =
-                        is_list_type(from_node.node_type()) && is_list_type(next.node_type());
-                    let seam_lists = if from_node.node_type() == NodeType::ListItem && same_type {
-                        let left = from_node
-                            .child_blocks()
-                            .filter(|child| child.id().as_op_dot().is_some())
-                            .last();
-                        let right = next
-                            .child_blocks()
-                            .find(|child| child.id().as_op_dot().is_some());
-                        match (left, right) {
-                            (Some(left), Some(right))
-                                if is_list_type(left.node_type())
-                                    && is_list_type(right.node_type()) =>
-                            {
-                                Some((left.id(), right.id()))
-                            }
-                            _ => None,
-                        }
-                    } else {
-                        None
-                    };
-                    (
-                        Some(next.id()),
-                        same_type || list_pair,
-                        from_node.parent().map(|p| p.id()),
-                        seam_lists,
-                    )
-                }
-                Some(ChildView::Leaf(_)) => (None, false, from_node.parent().map(|p| p.id()), None),
-                None => (None, false, from_node.parent().map(|p| p.id()), None),
-            }
-        };
-
-        match next_id {
-            Some(_) if next_mergeable => {
-                if let Some((target_list, source_list)) = seam_lists {
-                    merge_containers(tr, target_list, source_list)?;
-                }
-
-                merge_with_next_sibling(tr, from_id)?;
-                from_current = parent_id;
-            }
-            _ => {
-                if next_id.is_none() {
-                    from_current = parent_id;
-                } else {
-                    break;
-                }
-            }
-        }
-    }
-
-    // Repair structural ancestors and prune empties.
-    let ancestor_chain: Vec<Dot> = {
-        let view = tr.state().view();
-        let mut chain = Vec::new();
-        if let Some(start_id) = to_tb_parent {
-            let mut current = start_id;
-            loop {
-                chain.push(current);
-                if current == lca_id {
-                    break;
-                }
-                match view.node(current).and_then(|n| n.parent()).map(|p| p.id()) {
-                    Some(parent_id) => current = parent_id,
-                    None => break,
-                }
-            }
-        }
-        chain
-    };
-
-    if let Some(parent_id) = to_tb_parent {
-        let (empty, structural) = {
-            let view = tr.state().view();
-            match view.node(parent_id) {
-                Some(parent) => (is_structurally_empty(&parent), parent.spec().structural),
-                None => (false, false),
-            }
-        };
-        if empty {
-            if structural {
-                let steps = {
-                    let view = tr.state().view();
-                    view.node(parent_id)
-                        .map(|parent| fulfill(&parent))
-                        .unwrap_or_default()
-                };
-                tr.apply_steps(steps)?;
-            } else {
-                prune_empty_full(tr, parent_id)?;
-            }
-        }
-    }
-
-    for id in &ancestor_chain {
-        let steps = {
-            let view = tr.state().view();
-            match view.node(*id) {
-                Some(node) if node.spec().structural => fulfill(&node),
-                _ => Vec::new(),
-            }
-        };
-        tr.apply_steps(steps)?;
-    }
-
-    let lca_steps = {
-        let view = tr.state().view();
-        view.node(lca_id)
-            .map(|lca| fulfill(&lca))
-            .unwrap_or_default()
-    };
-    tr.apply_steps(lca_steps)?;
-
-    Ok(())
 }
 
 fn fulfill_ancestors(tr: &mut Transaction, start_id: Dot, lca_id: Dot) -> Result<(), CommandError> {

--- a/crates/editor-commands/src/helpers/deletion/plan.rs
+++ b/crates/editor-commands/src/helpers/deletion/plan.rs
@@ -1,0 +1,649 @@
+use std::collections::HashSet;
+
+use editor_crdt::Dot;
+use editor_model::{ChildView, DocView, NodeType, Schema, content_placement};
+use editor_state::Position;
+
+use super::{LinearDeletionKind, LinearDeletionPlan, LinearJoinExecution};
+use crate::CommandError;
+use crate::helpers::{SliceInsertionTarget, SliceInsertionTargetNode, is_list_type};
+
+pub(crate) struct JoinedReplacementFrontier {
+    pub(crate) target: SliceInsertionTarget,
+    pub(crate) join: Option<LinearJoinExecution>,
+}
+
+pub(crate) struct UnjoinedReplacementFrontiers {
+    pub(crate) left: SliceInsertionTarget,
+    pub(crate) right: SliceInsertionTarget,
+}
+
+#[derive(Clone)]
+struct VirtualChild {
+    id: Option<Dot>,
+    node_type: NodeType,
+    node: Option<Box<VirtualNode>>,
+}
+
+#[derive(Clone)]
+struct VirtualNode {
+    id: Dot,
+    node_type: NodeType,
+    children: Vec<VirtualChild>,
+}
+
+impl VirtualChild {
+    fn contributes_authored_content(&self) -> bool {
+        self.id.is_some_and(|id| id.as_op_dot().is_some())
+            || self.node.as_deref().is_some_and(|node| {
+                node.children
+                    .iter()
+                    .any(VirtualChild::contributes_authored_content)
+            })
+    }
+}
+
+impl VirtualNode {
+    fn capture(view: &DocView, id: Dot, expanded: &HashSet<Dot>) -> Option<Self> {
+        let node = view.node(id)?;
+        let children = node
+            .children()
+            .map(|child| match child {
+                ChildView::Block(block) => VirtualChild {
+                    id: Some(block.id()),
+                    node_type: block.node_type(),
+                    node: expanded
+                        .contains(&block.id())
+                        .then(|| Self::capture(view, block.id(), expanded))
+                        .flatten()
+                        .map(Box::new),
+                },
+                ChildView::Leaf(leaf) => VirtualChild {
+                    id: Some(leaf.dot()),
+                    node_type: leaf.node_type(),
+                    node: None,
+                },
+            })
+            .collect();
+        Some(Self {
+            id,
+            node_type: node.node_type(),
+            children,
+        })
+    }
+
+    fn find(&self, id: Dot) -> Option<&Self> {
+        if self.id == id {
+            return Some(self);
+        }
+        self.children
+            .iter()
+            .filter_map(|child| child.node.as_deref())
+            .find_map(|child| child.find(id))
+    }
+
+    fn find_mut(&mut self, id: Dot) -> Option<&mut Self> {
+        if self.id == id {
+            return Some(self);
+        }
+        self.children
+            .iter_mut()
+            .filter_map(|child| child.node.as_deref_mut())
+            .find_map(|child| child.find_mut(id))
+    }
+
+    fn parent_and_index(&self, id: Dot) -> Option<(Dot, usize)> {
+        for (index, child) in self.children.iter().enumerate() {
+            if child.id == Some(id) {
+                return Some((self.id, index));
+            }
+            if let Some(found) = child
+                .node
+                .as_deref()
+                .and_then(|node| node.parent_and_index(id))
+            {
+                return Some(found);
+            }
+        }
+        None
+    }
+
+    fn remove_child(&mut self, id: Dot) -> Option<VirtualChild> {
+        if let Some(index) = self.children.iter().position(|child| child.id == Some(id)) {
+            return Some(self.children.remove(index));
+        }
+        self.children
+            .iter_mut()
+            .filter_map(|child| child.node.as_deref_mut())
+            .find_map(|node| node.remove_child(id))
+    }
+
+    fn path_to(&self, id: Dot, out: &mut Vec<SliceInsertionTargetNode>) -> bool {
+        out.push(SliceInsertionTargetNode {
+            id: self.id,
+            node_type: self.node_type,
+            child_types: self.children.iter().map(|child| child.node_type).collect(),
+            child_ids: self.children.iter().map(|child| child.id).collect(),
+            index: None,
+        });
+        if self.id == id {
+            return true;
+        }
+        for (index, child) in self.children.iter().enumerate() {
+            let Some(node) = child.node.as_deref() else {
+                continue;
+            };
+            let before = out.len();
+            if node.path_to(id, out) {
+                if let Some(path_node) = out.get_mut(before) {
+                    path_node.index = Some(index);
+                }
+                return true;
+            }
+            out.truncate(before);
+        }
+        out.pop();
+        false
+    }
+
+    fn complete_expanded(&mut self) -> bool {
+        for child in &mut self.children {
+            if let Some(node) = child.node.as_deref_mut()
+                && !node.complete_expanded()
+            {
+                return false;
+            }
+        }
+        let types = self
+            .children
+            .iter()
+            .map(|child| child.node_type)
+            .collect::<Vec<_>>();
+        let placement = content_placement(self.node_type, &types);
+        let Some(completion) = placement.completion_insertions else {
+            return false;
+        };
+        if placement.first_residue.is_some() {
+            return false;
+        }
+        for insertion in completion {
+            self.children.insert(
+                insertion.index,
+                VirtualChild {
+                    id: None,
+                    node_type: insertion.node_type,
+                    node: None,
+                },
+            );
+        }
+        true
+    }
+}
+
+pub(crate) fn plan_joined_replacement_frontier(
+    view: &DocView,
+    deletion: &LinearDeletionPlan,
+) -> Result<Option<JoinedReplacementFrontier>, CommandError> {
+    let Some((mut virtual_root, join)) = simulate_linear_deletion(view, deletion)? else {
+        return Ok(None);
+    };
+    if join
+        .as_ref()
+        .is_some_and(|join| join.trailing_page_break.is_some())
+    {
+        return Ok(None);
+    }
+    if !virtual_root.complete_expanded() {
+        return Ok(None);
+    }
+
+    let target_id = deletion.from.node;
+    if virtual_root.find(target_id).is_none() {
+        return Ok(None);
+    }
+    let mut path = Vec::new();
+    if !virtual_root.path_to(target_id, &mut path) {
+        return Ok(None);
+    }
+    let position = Position {
+        node: target_id,
+        offset: deletion.from.offset,
+        affinity: deletion.from.affinity,
+    };
+    Ok(SliceInsertionTarget::from_path(position, path)
+        .map(|target| JoinedReplacementFrontier { target, join }))
+}
+
+pub(crate) fn plan_unjoined_replacement_frontiers(
+    view: &DocView,
+    deletion: &LinearDeletionPlan,
+) -> Result<Option<UnjoinedReplacementFrontiers>, CommandError> {
+    let Some(mut virtual_root) = simulate_unjoined_deletion(view, deletion)? else {
+        return Ok(None);
+    };
+    if !virtual_root.complete_expanded() {
+        return Ok(None);
+    }
+
+    let Some(left) = target_in_virtual_tree(&virtual_root, deletion.from) else {
+        return Ok(None);
+    };
+    let right_position = if deletion.from.node == deletion.to.node {
+        deletion.from
+    } else {
+        Position {
+            node: deletion.to.node,
+            offset: 0,
+            affinity: deletion.to.affinity,
+        }
+    };
+    let Some(right) = target_in_virtual_tree(&virtual_root, right_position) else {
+        return Ok(None);
+    };
+    Ok(Some(UnjoinedReplacementFrontiers { left, right }))
+}
+
+fn target_in_virtual_tree(
+    virtual_root: &VirtualNode,
+    position: Position,
+) -> Option<SliceInsertionTarget> {
+    let target = virtual_root.find(position.node)?;
+    if position.offset > target.children.len() {
+        return None;
+    }
+    let mut path = Vec::new();
+    if !virtual_root.path_to(position.node, &mut path) {
+        return None;
+    }
+    SliceInsertionTarget::from_path(position, path)
+}
+
+pub(crate) fn plan_linear_join(
+    view: &DocView,
+    deletion: &LinearDeletionPlan,
+) -> Result<Option<LinearJoinExecution>, CommandError> {
+    if !matches!(
+        deletion.kind,
+        LinearDeletionKind::Cross {
+            merge_textblocks: true,
+            ..
+        }
+    ) {
+        return Ok(None);
+    }
+    let Some((_, join)) = simulate_linear_deletion(view, deletion)? else {
+        return Err(CommandError::Corrupted(
+            "linear deletion could not simulate its planned join".into(),
+        ));
+    };
+    Ok(Some(join.ok_or_else(|| {
+        CommandError::Corrupted("linear deletion lost its planned join".into())
+    })?))
+}
+
+fn simulate_linear_deletion(
+    view: &DocView,
+    deletion: &LinearDeletionPlan,
+) -> Result<Option<(VirtualNode, Option<LinearJoinExecution>)>, CommandError> {
+    let Some(mut virtual_root) = simulate_unjoined_deletion(view, deletion)? else {
+        return Ok(None);
+    };
+    let join = if let LinearDeletionKind::Cross {
+        geometry,
+        from_textblock: Some(from_textblock),
+        to_textblock: Some(to_textblock),
+        merge_textblocks: true,
+    } = &deletion.kind
+    {
+        Some(virtual_merge_after_delete(
+            &mut virtual_root,
+            *from_textblock,
+            *to_textblock,
+            geometry.lca_id,
+            affected_nodes(view, deletion),
+        )?)
+    } else {
+        None
+    };
+    Ok(Some((virtual_root, join)))
+}
+
+fn simulate_unjoined_deletion(
+    view: &DocView,
+    deletion: &LinearDeletionPlan,
+) -> Result<Option<VirtualNode>, CommandError> {
+    let root = view
+        .root()
+        .ok_or_else(|| CommandError::Corrupted("linear deletion has no root".into()))?;
+    let mut expanded = HashSet::new();
+    for endpoint in [deletion.from.node, deletion.to.node] {
+        let node = view
+            .node(endpoint)
+            .ok_or(CommandError::NodeNotFound(endpoint))?;
+        let ancestors = node.ancestors().collect::<Vec<_>>();
+        expanded.extend(ancestors.iter().map(|ancestor| ancestor.id()));
+        // A container join can consume the first or last surviving sibling at
+        // the splice seam even when that sibling is not itself an endpoint
+        // ancestor (notably trailing/leading nested lists in ListItems).
+        // Expand those direct children so the planner can preserve and move
+        // their real children without capturing the whole document.
+        expanded.extend(ancestors.iter().flat_map(|ancestor| {
+            ancestor.children().filter_map(|child| match child {
+                ChildView::Block(block) => Some(block.id()),
+                ChildView::Leaf(_) => None,
+            })
+        }));
+    }
+    let mut virtual_root = VirtualNode::capture(view, root.id(), &expanded)
+        .ok_or_else(|| CommandError::Corrupted("cannot capture linear deletion target".into()))?;
+    if !virtual_delete_range(&mut virtual_root, &deletion.from_path, &deletion.to_path) {
+        return Ok(None);
+    }
+    Ok(Some(virtual_root))
+}
+
+fn affected_nodes(view: &DocView, deletion: &LinearDeletionPlan) -> Vec<Dot> {
+    let mut affected = Vec::new();
+    for endpoint in [deletion.from.node, deletion.to.node] {
+        let mut current = view.node(endpoint);
+        while let Some(node) = current {
+            if !affected.contains(&node.id()) {
+                affected.push(node.id());
+            }
+            current = node.parent();
+        }
+    }
+    affected
+}
+
+fn virtual_delete_range(node: &mut VirtualNode, from: &[usize], to: &[usize]) -> bool {
+    let Some((&from_index, from_rest)) = from.split_first() else {
+        return false;
+    };
+    let Some((&to_index, to_rest)) = to.split_first() else {
+        return false;
+    };
+
+    if from_index == to_index {
+        return match (from_rest.is_empty(), to_rest.is_empty()) {
+            (true, true) => virtual_remove_slots(node, from_index, to_index),
+            (true, false) => node
+                .children
+                .get_mut(from_index)
+                .and_then(|child| child.node.as_deref_mut())
+                .is_some_and(|child| virtual_delete_to(child, to_rest)),
+            (false, true) => node
+                .children
+                .get_mut(from_index)
+                .and_then(|child| child.node.as_deref_mut())
+                .is_some_and(|child| virtual_delete_from(child, from_rest)),
+            (false, false) => node
+                .children
+                .get_mut(from_index)
+                .and_then(|child| child.node.as_deref_mut())
+                .is_some_and(|child| virtual_delete_range(child, from_rest, to_rest)),
+        };
+    }
+
+    let from_child_id = (!from_rest.is_empty())
+        .then(|| node.children.get(from_index)?.id)
+        .flatten();
+    let to_child_id = (!to_rest.is_empty())
+        .then(|| node.children.get(to_index)?.id)
+        .flatten();
+
+    if let Some(from_child_id) = from_child_id {
+        let Some(from_child) = node
+            .children
+            .iter_mut()
+            .find(|child| child.id == Some(from_child_id))
+            .and_then(|child| child.node.as_deref_mut())
+        else {
+            return false;
+        };
+        if !virtual_delete_from(from_child, from_rest) {
+            return false;
+        }
+    }
+
+    let fully_from = if from_rest.is_empty() {
+        from_index
+    } else {
+        from_index + 1
+    };
+    if !virtual_remove_slots(node, fully_from, to_index) {
+        return false;
+    }
+
+    if let Some(to_child_id) = to_child_id {
+        let Some(to_child) = node
+            .children
+            .iter_mut()
+            .find(|child| child.id == Some(to_child_id))
+            .and_then(|child| child.node.as_deref_mut())
+        else {
+            return false;
+        };
+        if !virtual_delete_to(to_child, to_rest) {
+            return false;
+        }
+    }
+    true
+}
+
+fn virtual_delete_from(node: &mut VirtualNode, path: &[usize]) -> bool {
+    let Some((&index, rest)) = path.split_first() else {
+        return false;
+    };
+    if rest.is_empty() {
+        return virtual_remove_slots(node, index, node.children.len());
+    }
+    let Some(child_id) = node.children.get(index).and_then(|child| child.id) else {
+        return false;
+    };
+    if !virtual_remove_slots(node, index + 1, node.children.len()) {
+        return false;
+    }
+    node.children
+        .iter_mut()
+        .find(|child| child.id == Some(child_id))
+        .and_then(|child| child.node.as_deref_mut())
+        .is_some_and(|child| virtual_delete_from(child, rest))
+}
+
+fn virtual_delete_to(node: &mut VirtualNode, path: &[usize]) -> bool {
+    let Some((&index, rest)) = path.split_first() else {
+        return false;
+    };
+    if rest.is_empty() {
+        return virtual_remove_slots(node, 0, index);
+    }
+    let Some(child_id) = node.children.get(index).and_then(|child| child.id) else {
+        return false;
+    };
+    if !virtual_remove_slots(node, 0, index) {
+        return false;
+    }
+    node.children
+        .iter_mut()
+        .find(|child| child.id == Some(child_id))
+        .and_then(|child| child.node.as_deref_mut())
+        .is_some_and(|child| virtual_delete_to(child, rest))
+}
+
+fn virtual_remove_slots(node: &mut VirtualNode, from: usize, to: usize) -> bool {
+    if from > to || to > node.children.len() {
+        return false;
+    }
+    if node.children[from..to]
+        .iter()
+        .any(|child| Schema::node_spec(child.node_type).structural)
+    {
+        return false;
+    }
+    node.children.drain(from..to);
+    true
+}
+
+fn virtual_merge_after_delete(
+    root: &mut VirtualNode,
+    from_textblock: Dot,
+    to_textblock: Dot,
+    lca: Dot,
+    affected: Vec<Dot>,
+) -> Result<LinearJoinExecution, CommandError> {
+    let to_parent = root
+        .parent_and_index(to_textblock)
+        .map(|(parent, _)| parent);
+    let mut moved = {
+        let to = root.find_mut(to_textblock).ok_or_else(|| {
+            CommandError::Corrupted("virtual deletion lost its right textblock".into())
+        })?;
+        std::mem::take(&mut to.children)
+            .into_iter()
+            .filter(VirtualChild::contributes_authored_content)
+            .collect::<Vec<_>>()
+    };
+    let trailing_page_break = {
+        let from = root.find_mut(from_textblock).ok_or_else(|| {
+            CommandError::Corrupted("virtual deletion lost its left textblock".into())
+        })?;
+        let trailing = from
+            .children
+            .last()
+            .is_some_and(|child| child.node_type == NodeType::PageBreak)
+            .then(|| from.children.last().and_then(|child| child.id))
+            .flatten();
+        if trailing.is_some() {
+            from.children.pop();
+        }
+        from.children.append(&mut moved);
+        trailing
+    };
+    root.remove_child(to_textblock).ok_or_else(|| {
+        CommandError::Corrupted("virtual deletion could not remove right textblock".into())
+    })?;
+
+    let mut prune = Vec::new();
+    if let Some(mut current) = to_parent {
+        loop {
+            if current == lca {
+                break;
+            }
+            let Some(node) = root.find(current) else {
+                break;
+            };
+            let real_children = node
+                .children
+                .iter()
+                .filter(|child| child.contributes_authored_content())
+                .count();
+            let spec = Schema::node_spec(node.node_type);
+            if real_children != 0 || spec.content.min_required() == 0 || spec.structural {
+                break;
+            }
+            let Some((parent, _)) = root.parent_and_index(current) else {
+                break;
+            };
+            root.remove_child(current);
+            prune.push(current);
+            current = parent;
+        }
+    }
+
+    let mut container_merges = Vec::new();
+    let mut current = root
+        .parent_and_index(from_textblock)
+        .map(|(parent, _)| parent);
+    while let Some(current_id) = current {
+        if current_id == lca {
+            break;
+        }
+        let Some((parent_id, current_index)) = root.parent_and_index(current_id) else {
+            break;
+        };
+        let next = root
+            .find(parent_id)
+            .and_then(|parent| parent.children.get(current_index + 1))
+            .and_then(|child| child.id)
+            .filter(|id| root.find(*id).is_some());
+        if let Some(next_id) = next {
+            let current_type = root
+                .find(current_id)
+                .map(|node| node.node_type)
+                .ok_or_else(|| {
+                    CommandError::Corrupted("virtual deletion lost its left container".into())
+                })?;
+            let next_type = root
+                .find(next_id)
+                .map(|node| node.node_type)
+                .ok_or_else(|| {
+                    CommandError::Corrupted("virtual deletion lost its right container".into())
+                })?;
+            if current_type == next_type || (is_list_type(current_type) && is_list_type(next_type))
+            {
+                if current_type == NodeType::ListItem && next_type == NodeType::ListItem {
+                    let seam = {
+                        let left = root.find(current_id).and_then(|node| {
+                            node.children
+                                .iter()
+                                .rev()
+                                .find(|child| child.contributes_authored_content())
+                                .and_then(|child| child.id)
+                        });
+                        let right = root.find(next_id).and_then(|node| {
+                            node.children
+                                .iter()
+                                .find(|child| child.contributes_authored_content())
+                                .and_then(|child| child.id)
+                        });
+                        left.zip(right).filter(|(left, right)| {
+                            root.find(*left)
+                                .is_some_and(|node| is_list_type(node.node_type))
+                                && root
+                                    .find(*right)
+                                    .is_some_and(|node| is_list_type(node.node_type))
+                        })
+                    };
+                    if let Some((left, right)) = seam {
+                        container_merges.push((left, right));
+                        virtual_merge_containers(root, left, right)?;
+                    }
+                }
+                container_merges.push((current_id, next_id));
+                virtual_merge_containers(root, current_id, next_id)?;
+            }
+        }
+        current = Some(parent_id);
+    }
+    Ok(LinearJoinExecution {
+        from_textblock,
+        to_textblock,
+        trailing_page_break,
+        prune,
+        container_merges,
+        affected,
+    })
+}
+
+fn virtual_merge_containers(
+    root: &mut VirtualNode,
+    target: Dot,
+    source: Dot,
+) -> Result<(), CommandError> {
+    let source = root
+        .remove_child(source)
+        .ok_or_else(|| CommandError::Corrupted("virtual deletion lost merge source".into()))?;
+    let mut moving = source
+        .node
+        .map(|node| node.children)
+        .unwrap_or_default()
+        .into_iter()
+        .filter(VirtualChild::contributes_authored_content)
+        .collect::<Vec<_>>();
+    root.find_mut(target)
+        .ok_or_else(|| CommandError::Corrupted("virtual deletion lost merge target".into()))?
+        .children
+        .append(&mut moving);
+    Ok(())
+}

--- a/crates/editor-commands/src/helpers/list.rs
+++ b/crates/editor-commands/src/helpers/list.rs
@@ -7,10 +7,150 @@ use editor_state::{
 };
 use editor_transaction::{Step, StepError, Transaction, fulfill, minimal_subtree};
 
+use crate::helpers::merge_block_container_into;
 use crate::{CommandError, CommandResult};
 
 pub(crate) fn is_list_type(ty: NodeType) -> bool {
     matches!(ty, NodeType::BulletList | NodeType::OrderedList)
+}
+
+/// Merge two adjacent sibling lists by moving the later list's items into the
+/// earlier list. The earlier container owns the resulting list kind.
+pub(crate) struct AdjacentListMerge {
+    pub survivor: Dot,
+    pub removed: Dot,
+    pub parent: Dot,
+    pub removed_index: usize,
+    pub appended_at: usize,
+    pub appended_count: usize,
+}
+
+pub(crate) fn merge_adjacent_list_pair(
+    tr: &mut Transaction,
+    earlier_list_id: Dot,
+    later_list_id: Dot,
+) -> Result<AdjacentListMerge, CommandError> {
+    {
+        let view = tr.view();
+        let earlier_list = view
+            .node(earlier_list_id)
+            .ok_or(CommandError::NodeNotFound(earlier_list_id))?;
+        let later_list = view
+            .node(later_list_id)
+            .ok_or(CommandError::NodeNotFound(later_list_id))?;
+        if !is_list_type(earlier_list.node_type()) || !is_list_type(later_list.node_type()) {
+            return Err(CommandError::Corrupted(
+                "adjacent-list merge received a non-list node".into(),
+            ));
+        }
+        if earlier_list.parent().map(|parent| parent.id())
+            != later_list.parent().map(|parent| parent.id())
+            || earlier_list.index().and_then(|index| index.checked_add(1)) != later_list.index()
+        {
+            return Err(CommandError::Corrupted(
+                "list merge requires adjacent siblings".into(),
+            ));
+        }
+        if earlier_list
+            .children()
+            .chain(later_list.children())
+            .any(|child| matches!(child, ChildView::Leaf(_)))
+        {
+            return Err(CommandError::Corrupted(
+                "list contains an unsupported direct child".into(),
+            ));
+        }
+        let items = later_list
+            .child_blocks()
+            .map(|item| item.id())
+            .collect::<Vec<_>>();
+        if items.is_empty() {
+            return Err(CommandError::Corrupted(
+                "later list contains no list items".into(),
+            ));
+        }
+    }
+    let (parent, removed_index, appended_count) = {
+        let view = tr.view();
+        let later = view
+            .node(later_list_id)
+            .ok_or(CommandError::NodeNotFound(later_list_id))?;
+        let parent = later
+            .parent()
+            .ok_or(CommandError::NoParent(later_list_id))?;
+        (
+            parent.id(),
+            later
+                .index()
+                .ok_or_else(|| CommandError::orphan_child(later_list_id, parent.id()))?,
+            later.child_blocks().count(),
+        )
+    };
+    let merged = merge_block_container_into(tr, earlier_list_id, later_list_id)?;
+    Ok(AdjacentListMerge {
+        survivor: earlier_list_id,
+        removed: later_list_id,
+        parent,
+        removed_index,
+        appended_at: merged.appended_at,
+        appended_count,
+    })
+}
+
+pub(crate) fn resolve_selection_after_adjacent_list_merge(
+    tr: &Transaction,
+    before: Selection,
+    stable: StableSelection,
+    merged: &AdjacentListMerge,
+) -> Result<Selection, CommandError> {
+    let mut resolved = {
+        let view = tr.view();
+        let ctx = StableResolveCtx::from_live(&view, tr.state().projected.seq_checkout());
+        stable.resolve(&ctx)
+    }
+    .ok_or_else(|| CommandError::Corrupted("cannot restore selection after list merge".into()))?;
+    let remap_boundary = |position: Position, fallback: Position| {
+        if position.node == merged.removed {
+            Position {
+                node: merged.survivor,
+                offset: merged.appended_at + position.offset,
+                affinity: position.affinity,
+            }
+        } else if position.node == merged.parent && position.offset == merged.removed_index {
+            Position {
+                node: merged.survivor,
+                offset: merged.appended_at,
+                affinity: position.affinity,
+            }
+        } else if position.node == merged.parent && position.offset == merged.removed_index + 1 {
+            Position {
+                node: merged.survivor,
+                offset: merged.appended_at + merged.appended_count,
+                affinity: position.affinity,
+            }
+        } else {
+            fallback
+        }
+    };
+    resolved = Selection::new(
+        remap_boundary(before.anchor, resolved.anchor),
+        remap_boundary(before.head, resolved.head),
+    );
+    let resolved = resolved.normalize(&tr.view()).ok_or_else(|| {
+        CommandError::Corrupted("cannot normalize selection after list merge".into())
+    })?;
+    Ok(resolved)
+}
+
+pub(crate) fn restore_selection_after_adjacent_list_merge(
+    tr: &mut Transaction,
+    before: Selection,
+    stable: StableSelection,
+    merged: &AdjacentListMerge,
+) -> Result<(), CommandError> {
+    let resolved = resolve_selection_after_adjacent_list_merge(tr, before, stable, merged)?;
+    tr.set_selection(Some(resolved))?;
+    Ok(())
 }
 
 pub(crate) enum ForwardListBoundary {
@@ -815,4 +955,41 @@ fn capture_anchor(view: &DocView, items: &[Dot], pos: &Position) -> Option<Selec
             affinity: pos.affinity,
         })
     })
+}
+
+#[cfg(test)]
+mod adjacent_merge_tests {
+    use editor_macros::state;
+
+    use super::*;
+
+    #[test]
+    fn adjacent_list_merge_is_selection_free_and_keeps_the_earlier_container() {
+        let (initial, earlier, later, _p) = state! {
+            doc { root {
+                earlier: ordered_list {
+                    list_item { paragraph { text("A") } }
+                }
+                later: bullet_list {
+                    list_item { p: paragraph { text("B") } }
+                }
+            } }
+            selection: (p, 1)
+        };
+        let mut tr = Transaction::new(&initial);
+        let merged =
+            merge_adjacent_list_pair(&mut tr, earlier, later).expect("adjacent lists merge");
+        let (actual, steps, ..) = tr.commit();
+
+        assert_eq!(merged.survivor, earlier);
+        assert_eq!(merged.removed, later);
+        assert!(actual.view().node(earlier).is_some());
+        assert!(actual.view().node(later).is_none());
+        assert!(
+            steps
+                .iter()
+                .all(|record| !matches!(record.step, Step::SetSelection { .. })),
+            "the mutation primitive must not own selection restoration"
+        );
+    }
 }

--- a/crates/editor-commands/src/helpers/materialize.rs
+++ b/crates/editor-commands/src/helpers/materialize.rs
@@ -1,5 +1,6 @@
 use editor_crdt::Dot;
-use editor_state::{Position, Selection};
+use editor_model::{ChildView, DocView, NodeType};
+use editor_state::{Affinity, Position, Selection};
 use editor_transaction::Transaction;
 
 use super::materialize_position_block;
@@ -10,6 +11,302 @@ use crate::CommandError;
 /// permanent implicit anchor, never a materializable scaffold.
 pub(crate) fn is_materializable_synthetic(node: Dot) -> bool {
     node != Dot::ROOT && node.as_op_dot().is_none()
+}
+
+#[derive(Clone)]
+pub(crate) struct PlannedSelection {
+    anchor: PlannedEndpoint,
+    head: PlannedEndpoint,
+}
+
+#[derive(Clone)]
+pub(crate) enum PlannedEndpoint {
+    Authored {
+        position: Position,
+        node_type: NodeType,
+        child_types: Vec<NodeType>,
+        ancestry: Vec<PlannedAncestorSlot>,
+    },
+    ProjectedSlot {
+        authored_ancestor: Dot,
+        ancestor_type: NodeType,
+        ancestor_ancestry: Vec<PlannedAncestorSlot>,
+        path: Vec<PlannedChildSlot>,
+        offset: usize,
+        affinity: Affinity,
+    },
+}
+
+#[derive(Clone)]
+pub(crate) struct PlannedChildSlot {
+    index: usize,
+    node_type: NodeType,
+}
+
+#[derive(Clone)]
+pub(crate) struct PlannedAncestorSlot {
+    authored_parent: Option<Dot>,
+    parent_type: NodeType,
+    index: usize,
+}
+
+impl PlannedSelection {
+    pub(crate) fn capture(view: &DocView, selection: Selection) -> Option<Self> {
+        Some(Self {
+            anchor: PlannedEndpoint::capture(view, selection.anchor)?,
+            head: PlannedEndpoint::capture(view, selection.head)?,
+        })
+    }
+
+    pub(crate) fn resolve(&self, view: &DocView) -> Option<Selection> {
+        Some(Selection::new(
+            self.anchor.resolve(view)?,
+            self.head.resolve(view)?,
+        ))
+    }
+}
+
+impl PlannedEndpoint {
+    pub(crate) fn capture(view: &DocView, position: Position) -> Option<Self> {
+        let node = view.node(position.node)?;
+        if position.offset > node.children().count() {
+            return None;
+        }
+        if position.node.as_op_dot().is_some() || position.node == Dot::ROOT {
+            return Some(Self::Authored {
+                position,
+                node_type: node.node_type(),
+                child_types: node
+                    .children()
+                    .map(|child| child_node_type(&child))
+                    .collect(),
+                ancestry: capture_ancestry(&node)?,
+            });
+        }
+
+        let mut current = node;
+        let mut path = Vec::new();
+        while current.id().as_op_dot().is_none() && current.id() != Dot::ROOT {
+            path.push(PlannedChildSlot {
+                index: current.index()?,
+                node_type: current.node_type(),
+            });
+            current = current.parent()?;
+        }
+        path.reverse();
+        Some(Self::ProjectedSlot {
+            authored_ancestor: current.id(),
+            ancestor_type: current.node_type(),
+            ancestor_ancestry: capture_ancestry(&current)?,
+            path,
+            offset: position.offset,
+            affinity: position.affinity,
+        })
+    }
+
+    pub(crate) fn resolve(&self, view: &DocView) -> Option<Position> {
+        match self {
+            Self::Authored {
+                position,
+                node_type,
+                child_types,
+                ancestry,
+            } => {
+                let live = resolve_planned_node(view, position.node)?;
+                let node = view.node(live)?;
+                (node.node_type() == *node_type
+                    && position.offset <= node.children().count()
+                    && ancestry_matches(view, &node, ancestry)
+                    && node
+                        .children()
+                        .map(|child| child_node_type(&child))
+                        .eq(child_types.iter().copied()))
+                .then_some(Position {
+                    node: live,
+                    ..*position
+                })
+            }
+            Self::ProjectedSlot {
+                authored_ancestor,
+                ancestor_type,
+                ancestor_ancestry,
+                path,
+                offset,
+                affinity,
+            } => {
+                let mut current = view.node(resolve_planned_node(view, *authored_ancestor)?)?;
+                if current.node_type() != *ancestor_type
+                    || !ancestry_matches(view, &current, ancestor_ancestry)
+                {
+                    return None;
+                }
+                for slot in path {
+                    let ChildView::Block(child) = current.child_at(slot.index)? else {
+                        return None;
+                    };
+                    if child.node_type() != slot.node_type {
+                        return None;
+                    }
+                    current = view.node(child.id())?;
+                }
+                (*offset <= current.children().count()).then_some(Position {
+                    node: current.id(),
+                    offset: *offset,
+                    affinity: *affinity,
+                })
+            }
+        }
+    }
+}
+
+fn capture_ancestry(node: &editor_model::NodeView<'_>) -> Option<Vec<PlannedAncestorSlot>> {
+    let mut current = node.clone();
+    let mut ancestry = Vec::new();
+    while let Some(parent) = current.parent() {
+        let parent_id = parent.id();
+        ancestry.push(PlannedAncestorSlot {
+            authored_parent: (parent_id == Dot::ROOT || parent_id.as_op_dot().is_some())
+                .then_some(parent_id),
+            parent_type: parent.node_type(),
+            index: current.index()?,
+        });
+        current = parent;
+    }
+    Some(ancestry)
+}
+
+fn resolve_planned_node(view: &DocView, planned: Dot) -> Option<Dot> {
+    if view.node(planned).is_some() {
+        return Some(planned);
+    }
+    view.alias_classes()
+        .members_of(planned)
+        .into_iter()
+        .flatten()
+        .copied()
+        .find(|candidate| view.node(*candidate).is_some())
+}
+
+fn ancestry_matches(
+    view: &DocView,
+    node: &editor_model::NodeView<'_>,
+    ancestry: &[PlannedAncestorSlot],
+) -> bool {
+    let mut current = node.clone();
+    for slot in ancestry {
+        let Some(parent) = current.parent() else {
+            return false;
+        };
+        let same_parent = slot
+            .authored_parent
+            .is_none_or(|planned| resolve_planned_node(view, planned) == Some(parent.id()));
+        if !same_parent
+            || parent.node_type() != slot.parent_type
+            || current.index() != Some(slot.index)
+        {
+            return false;
+        }
+        current = parent;
+    }
+    current.parent().is_none()
+}
+
+pub(crate) fn resolve_planned_selection(
+    tr: &Transaction,
+    selection: &PlannedSelection,
+) -> Result<Selection, CommandError> {
+    selection.resolve(&tr.view()).ok_or_else(|| {
+        CommandError::Corrupted("fitted Slice endpoints changed before execution".into())
+    })
+}
+
+pub(crate) fn materialize_planned_selection(
+    tr: &mut Transaction,
+    selection: &PlannedSelection,
+) -> Result<Selection, CommandError> {
+    let projected = install_planned_selection(tr, selection)?;
+    let anchor_precedes_head = projected
+        .resolve(&tr.view())
+        .is_some_and(|resolved| resolved.anchor() <= resolved.head());
+    for anchor in if anchor_precedes_head {
+        [true, false]
+    } else {
+        [false, true]
+    } {
+        let current = tr.selection().ok_or_else(|| {
+            CommandError::Corrupted("fitted Slice lost its selection while materializing".into())
+        })?;
+        let target = if anchor {
+            current.anchor.node
+        } else {
+            current.head.node
+        };
+        materialize_target(tr, target)?;
+    }
+    let materialized = tr.selection().ok_or_else(|| {
+        CommandError::Corrupted("fitted Slice produced no materialized selection".into())
+    })?;
+    let expected = selection.resolve(&tr.view()).ok_or_else(|| {
+        CommandError::Corrupted(
+            "fitted Slice endpoints changed while materializing their repair scaffold".into(),
+        )
+    })?;
+    if materialized != expected {
+        return Err(CommandError::Corrupted(
+            "fitted Slice endpoint remap does not match its planned structural slots".into(),
+        ));
+    }
+    Ok(materialized)
+}
+
+pub(crate) fn install_planned_selection(
+    tr: &mut Transaction,
+    selection: &PlannedSelection,
+) -> Result<Selection, CommandError> {
+    let projected = resolve_planned_selection(tr, selection)?;
+    if tr.selection() != Some(projected) {
+        tr.set_selection(Some(projected))?;
+    }
+    Ok(projected)
+}
+
+pub(crate) fn materialize_planned_endpoint(
+    tr: &mut Transaction,
+    endpoint: &PlannedEndpoint,
+) -> Result<Position, CommandError> {
+    let projected = endpoint.resolve(&tr.view()).ok_or_else(|| {
+        CommandError::Corrupted("fitted Slice structural endpoint changed before execution".into())
+    })?;
+    let materialized = materialize_repair_position(tr, projected)?;
+    let expected = endpoint.resolve(&tr.view()).ok_or_else(|| {
+        CommandError::Corrupted(
+            "fitted Slice structural endpoint changed while materializing".into(),
+        )
+    })?;
+    if materialized != expected {
+        return Err(CommandError::Corrupted(
+            "fitted Slice structural endpoint remap changed its planned slot".into(),
+        ));
+    }
+    Ok(materialized)
+}
+
+/// Materialize the complete projection-repair scaffold that owns `position`.
+/// Unlike the filler-specific `materialize_position_block`, this preserves and
+/// aliases authored descendants already owned by a synthetic wrapper.
+pub(crate) fn materialize_repair_position(
+    tr: &mut Transaction,
+    position: Position,
+) -> Result<Position, CommandError> {
+    let node = materialize_target(tr, position.node)?;
+    Ok(Position { node, ..position })
+}
+
+fn child_node_type(child: &ChildView<'_>) -> NodeType {
+    match child {
+        ChildView::Block(block) => block.node_type(),
+        ChildView::Leaf(leaf) => leaf.node_type(),
+    }
 }
 
 /// Materialize any synthetic scaffold block holding a selection endpoint so

--- a/crates/editor-commands/src/helpers/merge.rs
+++ b/crates/editor-commands/src/helpers/merge.rs
@@ -1,9 +1,98 @@
 use editor_crdt::Dot;
-use editor_model::NodeView;
+use editor_model::{ChildView, NodeView};
 use editor_transaction::Transaction;
 
 use crate::CommandError;
 use crate::helpers::{capture_charlike_slots, insert_charlike_slots};
+
+pub(crate) struct ContainerMerge {
+    pub appended_at: usize,
+}
+
+/// Selection-free authority for moving every real block child from `source`
+/// to the end of `target`, then removing the emptied source container.
+pub(crate) fn merge_block_container_into(
+    tr: &mut Transaction,
+    target: Dot,
+    source: Dot,
+) -> Result<ContainerMerge, CommandError> {
+    let mut merged = None;
+    tr.batch::<_, CommandError>(|tr| {
+        materialize_content_owning_direct_scaffolds(tr, target)?;
+        materialize_content_owning_direct_scaffolds(tr, source)?;
+        let (appended_at, items) = {
+            let view = tr.view();
+            let target_node = view
+                .node(target)
+                .ok_or(CommandError::NodeNotFound(target))?;
+            let source_node = view
+                .node(source)
+                .ok_or(CommandError::NodeNotFound(source))?;
+            if source_node.children().any(
+                |child| matches!(child, ChildView::Leaf(leaf) if leaf.dot().as_op_dot().is_some()),
+            ) {
+                return Err(CommandError::Corrupted(
+                    "block-container merge received a real direct leaf".into(),
+                ));
+            }
+            let appended_at = target_node
+                .child_blocks()
+                .filter(|child| child.id().as_op_dot().is_some())
+                .count();
+            let items = source_node
+                .child_blocks()
+                .filter(|child| child.id().as_op_dot().is_some())
+                .map(|child| child.id())
+                .collect::<Vec<_>>();
+            (appended_at, items)
+        };
+        if !items.is_empty() {
+            tr.move_nodes_consecutive(&items, target, appended_at)?;
+        }
+        let authored_residue = tr
+            .view()
+            .node(source)
+            .is_some_and(|source| has_authored_descendant(&source));
+        if authored_residue {
+            return Err(CommandError::Corrupted(
+                "block-container merge would discard authored descendants".into(),
+            ));
+        }
+        crate::helpers::remove_subtree_full(tr, source)?;
+        merged = Some(ContainerMerge { appended_at });
+        Ok(())
+    })?;
+    merged.ok_or_else(|| CommandError::Corrupted("block-container merge produced no result".into()))
+}
+
+fn materialize_content_owning_direct_scaffolds(
+    tr: &mut Transaction,
+    container: Dot,
+) -> Result<(), CommandError> {
+    loop {
+        let scaffold = {
+            let view = tr.view();
+            let container = view
+                .node(container)
+                .ok_or(CommandError::NodeNotFound(container))?;
+            container
+                .child_blocks()
+                .find(|child| child.id().is_synthetic() && has_authored_descendant(child))
+                .map(|child| child.id())
+        };
+        let Some(scaffold) = scaffold else {
+            return Ok(());
+        };
+        editor_transaction::materialize_repair_target(tr, scaffold)?;
+    }
+}
+
+fn has_authored_descendant(node: &NodeView<'_>) -> bool {
+    node.descendants().any(|child| match child {
+        ChildView::Block(block) => block.id().as_op_dot().is_some(),
+        ChildView::Leaf(leaf) => leaf.dot().as_op_dot().is_some(),
+    })
+}
 
 fn next_block_sibling_id(parent: &NodeView, target_id: Dot) -> Option<Dot> {
     let idx = parent.child_blocks().position(|b| b.id() == target_id)?;
@@ -64,6 +153,14 @@ pub(crate) fn merge_element_cross_parent(
             .node(source_id)
             .ok_or(CommandError::NodeNotFound(source_id))?;
         let source_len = source.children().count();
+        if source
+            .children()
+            .any(|child| !matches!(child, ChildView::Leaf(leaf) if leaf.is_charlike()))
+        {
+            return Err(CommandError::Corrupted(
+                "cross-parent merge cannot preserve non-charlike source content".into(),
+            ));
+        }
         let slots = capture_charlike_slots(&state.projected, &source, 0, source_len)?;
         let target_len = view
             .node(target_id)
@@ -78,13 +175,14 @@ pub(crate) fn merge_element_cross_parent(
 
 #[cfg(test)]
 mod tests {
+    use editor_crdt::{ListOp, sequence::Bias as SeqBias};
     use editor_macros::state;
-    use editor_model::{ChildView, NodeType};
+    use editor_model::{EditOp, NodeType, SeqItem};
 
     use super::*;
 
     #[test]
-    fn cross_parent_fallback_drops_page_break() {
+    fn cross_parent_merge_preserves_a_source_page_break_when_the_move_is_valid() {
         let (initial, t1, src) = state! {
             doc {
                 root {
@@ -97,23 +195,132 @@ mod tests {
             }
             selection: (t1, 0)
         };
+        let page_break = initial
+            .view()
+            .node(src)
+            .expect("source paragraph")
+            .children()
+            .find_map(|child| match child {
+                ChildView::Leaf(leaf) if leaf.node_type() == NodeType::PageBreak => {
+                    Some(leaf.dot())
+                }
+                _ => None,
+            })
+            .expect("source PageBreak");
         let mut tr = Transaction::new(&initial);
         merge_element_cross_parent(&mut tr, src, t1).unwrap();
         let (actual, ..) = tr.commit();
 
         let view = actual.view();
-        let para = view.node(t1).unwrap();
-        assert_eq!(para.inline_text(), "AB");
+        let paragraph = view.node(t1).expect("target paragraph survives");
+        assert_eq!(paragraph.inline_text(), "AB");
+        let page_break = view
+            .alias_classes()
+            .members_of(page_break)
+            .into_iter()
+            .flatten()
+            .copied()
+            .find(|dot| view.leaf(*dot).is_some())
+            .unwrap_or(page_break);
         assert!(
-            para.children().all(|c| !matches!(
-                c,
-                ChildView::Leaf(l) if l.node_type() == NodeType::PageBreak
-            )),
-            "the merge fallback drops the source PageBreak instead of pulling it into a list item"
+            view.leaf(page_break)
+                .is_some_and(|leaf| leaf.node_type() == NodeType::PageBreak),
+            "the source PageBreak stays reachable while projection places it schema-validly"
         );
+        assert!(view.node(src).is_none(), "the source paragraph is merged");
+    }
+
+    #[test]
+    fn cross_parent_merge_rejects_page_break_before_a_lossy_fallback() {
+        let (initial, title, source) = state! {
+            doc { root {
+                fold {
+                    title: fold_title { text("A") }
+                    fold_content { paragraph { text("inside") } }
+                }
+                source: paragraph { text("B") page_break }
+                paragraph {}
+            } }
+            selection: (title, 0)
+        };
+        let mut tr = Transaction::new(&initial);
         assert!(
-            actual.view().node(src).is_none(),
-            "the source paragraph is removed after merging"
+            merge_element_cross_parent(&mut tr, source, title).is_err(),
+            "an incompatible PageBreak must block the copy-and-delete fallback"
         );
+        let (actual, steps, ..) = tr.commit();
+
+        editor_state::assert_state_eq!(&actual, &initial);
+        assert!(steps.is_empty(), "the rejected merge is atomic");
+    }
+
+    #[test]
+    fn block_container_merge_preserves_content_owned_by_a_synthetic_wrapper() {
+        let (mut initial, earlier, tail) = state! {
+            doc { root {
+                earlier: ordered_list {
+                    list_item { paragraph { text("A") } }
+                }
+                tail: paragraph {}
+            } }
+            selection: none
+        };
+        let pos = initial
+            .projected
+            .seq_boundary_pos(tail, SeqBias::Before)
+            .expect("root insertion boundary");
+        let later = initial
+            .projected_mut()
+            .apply(EditOp::Seq(ListOp::Ins {
+                pos,
+                item: SeqItem::Block {
+                    node_type: NodeType::BulletList,
+                    parents: vec![Dot::ROOT],
+                    attrs: vec![],
+                },
+            }))
+            .unwrap()
+            .id;
+        initial
+            .projected_mut()
+            .apply(EditOp::Seq(ListOp::Ins {
+                pos: pos + 1,
+                item: SeqItem::Block {
+                    node_type: NodeType::Paragraph,
+                    parents: vec![Dot::ROOT, later],
+                    attrs: vec![],
+                },
+            }))
+            .unwrap();
+        initial
+            .projected_mut()
+            .apply(EditOp::Seq(ListOp::Ins {
+                pos: pos + 2,
+                item: SeqItem::Char('B'),
+            }))
+            .unwrap();
+        {
+            let view = initial.view();
+            let later = view.node(later).expect("later list");
+            let item = later.child_blocks().next().expect("projected list item");
+            assert_eq!(item.node_type(), NodeType::ListItem);
+            assert!(
+                item.id().is_synthetic(),
+                "the raw Paragraph is owned by a synthetic ListItem repair wrapper"
+            );
+        }
+
+        let mut tr = Transaction::new(&initial);
+        merge_block_container_into(&mut tr, earlier, later).unwrap();
+        let (actual, ..) = tr.commit();
+
+        let view = actual.view();
+        let earlier = view.node(earlier).expect("earlier list survives");
+        let mut texts = Vec::new();
+        for item in earlier.child_blocks() {
+            texts.extend(item.child_blocks().map(|paragraph| paragraph.inline_text()));
+        }
+        assert_eq!(texts, ["A", "B"]);
+        assert!(view.node(later).is_none(), "the later container is merged");
     }
 }

--- a/crates/editor-commands/src/helpers/slice.rs
+++ b/crates/editor-commands/src/helpers/slice.rs
@@ -1,23 +1,23 @@
 use editor_clipboard::Slice;
 use editor_crdt::Dot;
 use editor_model::{
-    ChildView, ContentExpr, DocView, Fragment, Modifier, NodeType, NodeView, PlainNode,
-    PlainParagraphNode, Schema, Subtree, context_allows, wrap_chain,
+    ChildView, DocView, Fragment, Modifier, NodeType, PlainNode, PlainParagraphNode, Schema,
+    Subtree, content_placement,
 };
-use editor_state::{Affinity, Position, Selection};
-use editor_transaction::{Transaction, fulfill};
+use editor_state::{Affinity, Position, Selection, StableSelection, first_cursor_position};
+use editor_transaction::{Transaction, fulfill, minimal_subtree};
 
 use super::{
-    apply_inline_modifiers, child_node_type, consume_pending_modifiers, find_ancestor_textblock,
-    insert_hard_break_at_caret, insert_tab_at_caret, insert_text_at_caret,
-    resolve_effective_modifiers,
+    apply_inline_modifiers, child_node_type, consume_pending_modifiers, insert_hard_break_at_caret,
+    insert_tab_at_caret, insert_text_at_caret, is_list_type, merge_adjacent_list_pair,
+    next_sibling, resolve_effective_modifiers, resolve_selection_after_adjacent_list_merge,
+    restore_selection_after_adjacent_list_merge,
 };
 use crate::types::SliceProvenance;
 use crate::{CommandError, CommandResult};
 
 mod page_break;
 
-pub(crate) use page_break::prepare_page_breaks_for_position;
 use page_break::{insert_terminal_page_break_from_edge, paragraph_ends_with_page_break};
 
 pub(crate) enum InlineMode {
@@ -47,6 +47,16 @@ fn carry_from_paint(paint: &[Modifier]) -> Vec<Modifier> {
         .filter(|m| m.as_type().is_carry_kind())
         .cloned()
         .collect()
+}
+
+pub(crate) fn subtree_to_fragment(subtree: Subtree) -> Fragment {
+    let (node, modifiers, carry, children, _) = subtree.into_parts();
+    Fragment {
+        node,
+        modifiers,
+        carry,
+        children: children.into_iter().map(subtree_to_fragment).collect(),
+    }
 }
 
 pub(crate) fn build_inline_mode(
@@ -99,10 +109,164 @@ pub(crate) fn paint_block_uniformly(
     Ok(())
 }
 
-pub(crate) fn position_in_textblock(view: &DocView, position: &Position) -> bool {
-    position
-        .resolve(view)
-        .is_some_and(|resolved| resolved.is_inline_position())
+#[derive(Clone)]
+pub(crate) struct SliceInsertionTarget {
+    position: Position,
+    path: Vec<SliceInsertionTargetNode>,
+}
+
+#[derive(Clone)]
+pub(crate) struct SliceInsertionTargetShape {
+    offset: usize,
+    path: Vec<SliceInsertionTargetNodeShape>,
+}
+
+#[derive(Clone)]
+struct SliceInsertionTargetNodeShape {
+    node_type: NodeType,
+    child_types: Vec<NodeType>,
+    index: Option<usize>,
+}
+
+#[derive(Clone)]
+pub(crate) struct SliceInsertionTargetNode {
+    pub id: Dot,
+    pub node_type: NodeType,
+    pub child_types: Vec<NodeType>,
+    pub child_ids: Vec<Option<Dot>>,
+    pub index: Option<usize>,
+}
+
+impl SliceInsertionTarget {
+    pub(crate) fn from_view(view: &DocView, position: Position) -> Option<Self> {
+        position.resolve(view)?;
+        let target = view.node(position.node)?;
+        let mut nodes: Vec<_> = target.ancestors().collect();
+        nodes.reverse();
+        let path = nodes
+            .into_iter()
+            .map(|node| SliceInsertionTargetNode {
+                id: node.id(),
+                node_type: node.node_type(),
+                child_types: node
+                    .children()
+                    .map(|child| child_node_type(&child))
+                    .collect(),
+                child_ids: node
+                    .children()
+                    .map(|child| {
+                        Some(match child {
+                            ChildView::Block(block) => block.id(),
+                            ChildView::Leaf(leaf) => leaf.dot(),
+                        })
+                    })
+                    .collect(),
+                index: node.index(),
+            })
+            .collect();
+        Some(Self { position, path })
+    }
+
+    pub(crate) fn from_path(
+        position: Position,
+        path: Vec<SliceInsertionTargetNode>,
+    ) -> Option<Self> {
+        let target = path.last()?;
+        if target.id != position.node || position.offset > target.child_types.len() {
+            return None;
+        }
+        Some(Self { position, path })
+    }
+
+    pub(crate) fn path(&self) -> &[SliceInsertionTargetNode] {
+        &self.path
+    }
+
+    pub(crate) fn position(&self) -> Position {
+        self.position
+    }
+
+    fn node_index(&self, id: Dot) -> Option<usize> {
+        self.path.iter().position(|node| node.id == id)
+    }
+
+    fn node(&self, id: Dot) -> Option<&SliceInsertionTargetNode> {
+        self.node_index(id).and_then(|index| self.path.get(index))
+    }
+
+    fn parent(&self, id: Dot) -> Option<&SliceInsertionTargetNode> {
+        let index = self.node_index(id)?;
+        index.checked_sub(1).and_then(|index| self.path.get(index))
+    }
+
+    fn textblock(&self) -> Option<&SliceInsertionTargetNode> {
+        self.path
+            .iter()
+            .rev()
+            .find(|node| Schema::node_spec(node.node_type).is_textblock())
+    }
+
+    fn can_duplicate(&self, id: Dot) -> bool {
+        let Some(node) = self.node(id) else {
+            return false;
+        };
+        if Schema::node_spec(node.node_type).isolating {
+            return false;
+        }
+        let Some(parent) = self.parent(id) else {
+            return false;
+        };
+        let Some(index) = node.index else {
+            return false;
+        };
+        let mut child_types = parent.child_types.clone();
+        if index > child_types.len() {
+            return false;
+        }
+        child_types.insert(index + 1, node.node_type);
+        content_placement(parent.node_type, &child_types).is_valid()
+    }
+}
+
+impl SliceInsertionTargetShape {
+    pub(crate) fn capture(target: &SliceInsertionTarget) -> Self {
+        Self {
+            offset: target.position.offset,
+            path: target
+                .path
+                .iter()
+                .map(|node| SliceInsertionTargetNodeShape {
+                    node_type: node.node_type,
+                    child_types: node.child_types.clone(),
+                    index: node.index,
+                })
+                .collect(),
+        }
+    }
+
+    pub(crate) fn matches(&self, actual: &SliceInsertionTarget) -> bool {
+        self.offset == actual.position.offset
+            && self.path.len() == actual.path.len()
+            && self
+                .path
+                .iter()
+                .zip(&actual.path)
+                .all(|(expected, actual)| {
+                    expected.node_type == actual.node_type
+                        && expected.child_types == actual.child_types
+                        && expected.index == actual.index
+                })
+    }
+}
+
+pub(crate) fn node_type_path(view: &DocView, node_id: Dot) -> Option<Vec<NodeType>> {
+    let node = view.node(node_id)?;
+    let mut path: Vec<NodeType> = node
+        .ancestors()
+        .map(|ancestor| ancestor.node_type())
+        .collect();
+    path.reverse();
+    Some(path)
 }
 
 pub(crate) fn top_level_fragments(slice: &Slice) -> Vec<&Fragment> {
@@ -110,10 +274,14 @@ pub(crate) fn top_level_fragments(slice: &Slice) -> Vec<&Fragment> {
 }
 
 pub(crate) fn fragments_fit_parent(parent_type: NodeType, fragments: &[&Fragment]) -> bool {
-    let content = &Schema::node_spec(parent_type).content;
-    fragments
-        .iter()
-        .all(|fragment| content.matches(fragment.node.as_type()))
+    content_placement(
+        parent_type,
+        &fragments
+            .iter()
+            .map(|fragment| fragment.node.as_type())
+            .collect::<Vec<_>>(),
+    )
+    .is_completable()
 }
 
 pub(crate) fn fragments_are_inline(fragments: &[&Fragment]) -> bool {
@@ -123,29 +291,37 @@ pub(crate) fn fragments_are_inline(fragments: &[&Fragment]) -> bool {
             .all(|fragment| Schema::node_spec(fragment.node.as_type()).inline)
 }
 
-fn can_split_textblock_for_structural_insert(view: &DocView, textblock_id: Dot) -> bool {
-    let Some(textblock) = view.node(textblock_id) else {
+pub(crate) fn inline_fragments_fit_target(
+    target: &SliceInsertionTarget,
+    fragments: &[Fragment],
+) -> bool {
+    let Some(textblock) = target.textblock() else {
         return false;
     };
-    let Some(parent) = textblock.parent() else {
+    let mut types = textblock.child_types.clone();
+    if target.position.offset > types.len() {
         return false;
-    };
-    let Some(index) = textblock.index() else {
-        return false;
-    };
-
-    let mut child_types: Vec<NodeType> = parent.children().map(|c| child_node_type(&c)).collect();
-    child_types.insert(index + 1, textblock.node_type());
-    parent.spec().content.matches_sequence(&child_types)
+    }
+    types.splice(
+        target.position.offset..target.position.offset,
+        fragments.iter().map(|fragment| fragment.node.as_type()),
+    );
+    content_placement(textblock.node_type, &types).is_valid()
 }
 
-pub(crate) fn fit_slice_for_textblock_parent(
-    view: &DocView,
-    position: &Position,
+fn can_split_textblock_for_structural_insert(
+    target: &SliceInsertionTarget,
+    textblock_id: Dot,
+) -> bool {
+    target.can_duplicate(textblock_id)
+}
+
+pub(crate) fn fit_slice_for_textblock_target_parent(
+    target: &SliceInsertionTarget,
     slice: &Slice,
 ) -> Option<Slice> {
-    let textblock_id = find_ancestor_textblock(view, position.node)?;
-    let parent_type = view.node(textblock_id)?.parent()?.node_type();
+    let textblock = target.textblock()?;
+    let parent_type = target.parent(textblock.id)?.node_type;
     let (content, open_start, open_end) = open_fragments_for_parent(
         top_level_fragments(slice),
         slice.open_start,
@@ -159,65 +335,569 @@ pub(crate) fn fit_slice_for_textblock_parent(
     ))
 }
 
-/// A text-range copied across sibling list items carries `List > ListItem >
-/// Paragraph` as open edge context. Inserting that range in a direct list-item
-/// paragraph must splice at the surrounding list, not nest the copied list in
-/// the current item merely because the expanded schema permits it.
-pub(crate) fn open_list_items_for_textblock_insert(
-    view: &DocView,
-    position: &Position,
-    slice: &Slice,
-) -> Option<Vec<Fragment>> {
-    if slice.open_start < 3 || slice.open_end < 3 || slice.content.len() != 1 {
-        return None;
-    }
-    let textblock_id = find_ancestor_textblock(view, position.node)?;
-    let textblock = view.node(textblock_id)?;
-    if textblock.node_type() != NodeType::Paragraph {
-        return None;
-    }
-    let list_item = textblock.parent()?;
-    if list_item.node_type() != NodeType::ListItem {
-        return None;
-    }
-    let list = list_item.parent()?;
-    if !matches!(
-        list.node_type(),
-        NodeType::BulletList | NodeType::OrderedList
-    ) {
-        return None;
-    }
-
-    let outer = &slice.content[0];
-    if !matches!(
-        outer.node.as_type(),
-        NodeType::BulletList | NodeType::OrderedList
-    ) || outer.children.len() < 2
-        || !outer
-            .children
-            .iter()
-            .all(|item| item.node.as_type() == NodeType::ListItem)
-    {
-        return None;
-    }
-    let first_paragraph = outer.children.first()?.children.first()?;
-    let last_paragraph = outer.children.last()?.children.last()?;
-    if first_paragraph.node.as_type() != NodeType::Paragraph
-        || last_paragraph.node.as_type() != NodeType::Paragraph
-    {
-        return None;
-    }
-    Some(outer.children.clone())
+#[derive(Clone)]
+pub(crate) struct OpenAncestorSplice {
+    pub destination: Vec<Dot>,
+    pub source: Fragment,
 }
 
-pub(crate) fn open_inline_content_for_textblock_insert<'a>(
-    view: &DocView,
-    position: &Position,
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct SliceInsertionOutputPlan {
+    pub(crate) nodes: Vec<SliceOutputNodeSpec>,
+    pub(crate) caret: SliceOutputPositionSpec,
+    pub(crate) anchor: SliceOutputPositionSpec,
+    pub(crate) head: SliceOutputPositionSpec,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct SliceOutputNodeSpec {
+    pub(crate) source: SliceOutputSource,
+    pub(crate) node_type: NodeType,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) enum SliceOutputSource {
+    InlineSlot {
+        index: usize,
+    },
+    OpenSpliceUnit {
+        index: usize,
+    },
+    TextblockStartInline {
+        index: usize,
+    },
+    TextblockBlockPath {
+        block_index: usize,
+        child_path: Vec<usize>,
+    },
+    TextblockEndInline {
+        index: usize,
+    },
+    BlockPath {
+        block_index: usize,
+        child_path: Vec<usize>,
+    },
+    SplitLeft,
+    SplitRight,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SliceOutputPositionSpec {
+    pub(crate) node: usize,
+    pub(crate) relation: SliceOutputRelation,
+    pub(crate) affinity: Affinity,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SliceOutputRelation {
+    Before,
+    After,
+    AfterTerminalPageBreak,
+    Start,
+    End,
+}
+
+pub(crate) fn planned_inline_output(
+    fragments: &[Fragment],
+    anchor_affinity: Affinity,
+) -> Option<SliceInsertionOutputPlan> {
+    let node_types = inline_output_node_types(fragments);
+    let nodes = node_types
+        .into_iter()
+        .enumerate()
+        .map(|(index, node_type)| SliceOutputNodeSpec {
+            source: SliceOutputSource::InlineSlot { index },
+            node_type,
+        })
+        .collect::<Vec<_>>();
+    output_plan_for_units(
+        nodes,
+        SliceOutputRelation::After,
+        Affinity::Downstream,
+        anchor_affinity,
+        Affinity::Downstream,
+    )
+}
+
+pub(crate) fn planned_open_splice_output(
+    splice: &OpenAncestorSplice,
+) -> Option<SliceInsertionOutputPlan> {
+    let mut node_types = Vec::new();
+    collect_open_splice_output_types(
+        &splice.source,
+        splice.destination.len().checked_sub(1)?,
+        &mut node_types,
+    )?;
+    let nodes = node_types
+        .into_iter()
+        .enumerate()
+        .map(|(index, node_type)| SliceOutputNodeSpec {
+            source: SliceOutputSource::OpenSpliceUnit { index },
+            node_type,
+        })
+        .collect::<Vec<_>>();
+    output_plan_for_units(
+        nodes,
+        SliceOutputRelation::After,
+        Affinity::Downstream,
+        Affinity::Upstream,
+        Affinity::Downstream,
+    )
+}
+
+#[derive(Clone)]
+pub(crate) struct HoistedBlockInsertionPlan {
+    pub target: SliceInsertionTargetShape,
+    pub parent_depth: usize,
+    pub initial_boundary: HoistInitialBoundary,
+    pub boundary_steps: Vec<HoistBoundaryStep>,
+    pub blocks: Vec<Fragment>,
+    pub list_merges: Vec<PlannedListMerge>,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum HoistInitialBoundary {
+    Before,
+    After,
+    Split,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum HoistBoundaryStep {
+    LiftBefore,
+    LiftAfter,
+    SplitBefore,
+    SplitAfter,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum PlannedListMember {
+    Left(NodeType),
+    Inserted { index: usize, node_type: NodeType },
+    Right(NodeType),
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct ExistingBlock {
+    pub(crate) id: Option<Dot>,
+    pub(crate) node_type: NodeType,
+}
+
+impl PlannedListMember {
+    fn node_type(self) -> NodeType {
+        match self {
+            Self::Left(node_type) | Self::Right(node_type) | Self::Inserted { node_type, .. } => {
+                node_type
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct PlannedListMerge {
+    pub(crate) earlier: PlannedListMember,
+    pub(crate) later: PlannedListMember,
+}
+
+pub(crate) fn planned_block_output(
+    blocks: &[Fragment],
+    list_merges: &[PlannedListMerge],
+) -> Option<SliceInsertionOutputPlan> {
+    let nodes = planned_block_output_nodes(blocks, list_merges, false);
+    let terminal_page_break = blocks.last().is_some_and(paragraph_ends_with_page_break);
+    let last_merged = blocks
+        .len()
+        .checked_sub(1)
+        .is_some_and(|index| inserted_member_is_merged(list_merges, index));
+    let caret_relation = if terminal_page_break {
+        SliceOutputRelation::AfterTerminalPageBreak
+    } else if last_merged {
+        SliceOutputRelation::After
+    } else {
+        SliceOutputRelation::End
+    };
+    output_plan_for_units(
+        nodes,
+        caret_relation,
+        Affinity::Downstream,
+        Affinity::Downstream,
+        Affinity::Upstream,
+    )
+}
+
+fn output_plan_for_units(
+    nodes: Vec<SliceOutputNodeSpec>,
+    caret_relation: SliceOutputRelation,
+    caret_affinity: Affinity,
+    anchor_affinity: Affinity,
+    head_affinity: Affinity,
+) -> Option<SliceInsertionOutputPlan> {
+    let last = nodes.len().checked_sub(1)?;
+    Some(SliceInsertionOutputPlan {
+        nodes,
+        caret: SliceOutputPositionSpec {
+            node: last,
+            relation: caret_relation,
+            affinity: caret_affinity,
+        },
+        anchor: SliceOutputPositionSpec {
+            node: 0,
+            relation: SliceOutputRelation::Before,
+            affinity: anchor_affinity,
+        },
+        head: SliceOutputPositionSpec {
+            node: last,
+            relation: SliceOutputRelation::After,
+            affinity: head_affinity,
+        },
+    })
+}
+
+fn inline_output_node_types(fragments: &[Fragment]) -> Vec<NodeType> {
+    let mut output = Vec::new();
+    for fragment in fragments {
+        match &fragment.node {
+            PlainNode::Text(text) => {
+                output.extend(std::iter::repeat_n(
+                    NodeType::Text,
+                    text.text.chars().count(),
+                ));
+            }
+            PlainNode::HardBreak(_) => output.push(NodeType::HardBreak),
+            PlainNode::Tab(_) => output.push(NodeType::Tab),
+            PlainNode::PageBreak(_) => output.push(NodeType::PageBreak),
+            _ => {}
+        }
+    }
+    output
+}
+
+fn planned_block_output_nodes(
+    blocks: &[Fragment],
+    list_merges: &[PlannedListMerge],
+    textblock: bool,
+) -> Vec<SliceOutputNodeSpec> {
+    let mut output = Vec::new();
+    for (block_index, block) in blocks.iter().enumerate() {
+        let source = |child_path| {
+            if textblock {
+                SliceOutputSource::TextblockBlockPath {
+                    block_index,
+                    child_path,
+                }
+            } else {
+                SliceOutputSource::BlockPath {
+                    block_index,
+                    child_path,
+                }
+            }
+        };
+        if inserted_member_is_merged(list_merges, block_index) && is_list_type(block.node.as_type())
+        {
+            output.extend(block.children.iter().enumerate().map(|(index, child)| {
+                SliceOutputNodeSpec {
+                    source: source(vec![index]),
+                    node_type: child.node.as_type(),
+                }
+            }));
+        } else {
+            output.push(SliceOutputNodeSpec {
+                source: source(Vec::new()),
+                node_type: block.node.as_type(),
+            });
+        }
+    }
+    output
+}
+
+fn inserted_member_is_merged(merges: &[PlannedListMerge], index: usize) -> bool {
+    merges.iter().any(|merge| {
+        [merge.earlier, merge.later].into_iter().any(|member| {
+            matches!(
+                member,
+                PlannedListMember::Inserted {
+                    index: member_index,
+                    ..
+                } if member_index == index
+            )
+        })
+    })
+}
+
+fn collect_open_splice_output_types(
+    source: &Fragment,
+    depth: usize,
+    output: &mut Vec<NodeType>,
+) -> Option<()> {
+    if depth == 0 {
+        return None;
+    }
+    match source.children.as_slice() {
+        [] => None,
+        [only] => collect_open_join_output_types(only, depth, output),
+        [first, middle @ .., last] => {
+            collect_open_append_output_types(first, depth, output)?;
+            output.extend(middle.iter().map(|fragment| fragment.node.as_type()));
+            collect_open_prepend_output_types(last, depth, output)
+        }
+    }
+}
+
+fn collect_open_join_output_types(
+    source: &Fragment,
+    depth: usize,
+    output: &mut Vec<NodeType>,
+) -> Option<()> {
+    if depth == 0 {
+        return None;
+    }
+    if depth == 1 {
+        output.extend(inline_output_node_types(&source.children));
+        return Some(());
+    }
+    match source.children.as_slice() {
+        [] => None,
+        [only] => collect_open_join_output_types(only, depth - 1, output),
+        [first, middle @ .., last] => {
+            collect_open_append_output_types(first, depth - 1, output)?;
+            output.extend(middle.iter().map(|fragment| fragment.node.as_type()));
+            collect_open_prepend_output_types(last, depth - 1, output)
+        }
+    }
+}
+
+fn collect_open_append_output_types(
+    source: &Fragment,
+    depth: usize,
+    output: &mut Vec<NodeType>,
+) -> Option<()> {
+    if depth == 0 {
+        return None;
+    }
+    if depth == 1 {
+        output.extend(inline_output_node_types(&source.children));
+        return Some(());
+    }
+    let first = source.children.first()?;
+    collect_open_append_output_types(first, depth - 1, output)?;
+    output.extend(
+        source
+            .children
+            .iter()
+            .skip(1)
+            .map(|fragment| fragment.node.as_type()),
+    );
+    Some(())
+}
+
+fn collect_open_prepend_output_types(
+    source: &Fragment,
+    depth: usize,
+    output: &mut Vec<NodeType>,
+) -> Option<()> {
+    if depth == 0 {
+        return None;
+    }
+    if depth == 1 {
+        output.extend(inline_output_node_types(&source.children));
+        return Some(());
+    }
+    let last = source.children.last()?;
+    output.extend(
+        source
+            .children
+            .iter()
+            .take(source.children.len() - 1)
+            .map(|fragment| fragment.node.as_type()),
+    );
+    collect_open_prepend_output_types(last, depth - 1, output)
+}
+
+pub(crate) fn plan_adjacent_list_merges(
+    left: Option<ExistingBlock>,
+    blocks: &[Fragment],
+    right: Option<ExistingBlock>,
+) -> Option<Vec<PlannedListMerge>> {
+    let mut members = Vec::with_capacity(
+        blocks.len() + usize::from(left.is_some()) + usize::from(right.is_some()),
+    );
+    members.extend(left.map(|block| PlannedListMember::Left(block.node_type)));
+    let insertion_start = members.len();
+    members.extend(
+        blocks
+            .iter()
+            .enumerate()
+            .map(|(index, block)| PlannedListMember::Inserted {
+                index,
+                node_type: block.node.as_type(),
+            }),
+    );
+    members.extend(right.map(|block| PlannedListMember::Right(block.node_type)));
+
+    let mut planned = Vec::new();
+    let mut index = insertion_start.saturating_sub(1);
+    let mut scan_end = insertion_start.saturating_add(blocks.len());
+    while index < scan_end && index + 1 < members.len() {
+        if is_list_type(members[index].node_type()) && is_list_type(members[index + 1].node_type())
+        {
+            planned.push(PlannedListMerge {
+                earlier: members[index],
+                later: members[index + 1],
+            });
+            members.remove(index + 1);
+            scan_end = scan_end.saturating_sub(1).max(index + 1);
+        } else {
+            index += 1;
+        }
+    }
+    let existing_participant_is_synthetic = planned.iter().any(|merge_plan| {
+        [merge_plan.earlier, merge_plan.later]
+            .into_iter()
+            .any(|member| match member {
+                PlannedListMember::Left(_) => left
+                    .and_then(|block| block.id)
+                    .is_some_and(|id| id.is_synthetic()),
+                PlannedListMember::Right(_) => right
+                    .and_then(|block| block.id)
+                    .is_some_and(|id| id.is_synthetic()),
+                PlannedListMember::Inserted { .. } => false,
+            })
+    });
+    (!existing_participant_is_synthetic).then_some(planned)
+}
+
+/// Match a symmetrically open Slice edge to the destination ancestor chain.
+///
+/// The matched source wrappers are context, not inserted nodes. Their children
+/// are spliced through the surviving destination wrappers. This is the generic
+/// form of list-item and blockquote open-edge insertion.
+pub(crate) fn open_ancestor_splice_for_target(
+    target: &SliceInsertionTarget,
+    slice: &Slice,
+) -> Option<OpenAncestorSplice> {
+    let (splice, emits_change) = open_ancestor_splice_match_for_target(target, slice)?;
+    emits_change.then_some(splice)
+}
+
+pub(crate) fn open_ancestor_splice_is_complete_no_output(
+    target: &SliceInsertionTarget,
+    slice: &Slice,
+) -> bool {
+    open_ancestor_splice_match_for_target(target, slice).is_some_and(|(splice, _)| {
+        open_splice_is_complete_no_output(&splice.source, splice.destination.len())
+    })
+}
+
+fn open_ancestor_splice_match_for_target(
+    target: &SliceInsertionTarget,
+    slice: &Slice,
+) -> Option<(OpenAncestorSplice, bool)> {
+    if slice.open_start != slice.open_end || slice.open_start < 2 || slice.content.len() != 1 {
+        return None;
+    }
+    let depth = usize::try_from(slice.open_start).ok()?;
+    let source = slice.content.first()?;
+    let source_left = fragment_edge_types(source, depth, true)?;
+    let source_right = fragment_edge_types(source, depth, false)?;
+
+    let textblock_index = target.node_index(target.textblock()?.id)?;
+    let destination_start = textblock_index.checked_add(1)?.checked_sub(depth)?;
+    let destination: Vec<Dot> = target.path[destination_start..=textblock_index]
+        .iter()
+        .map(|node| node.id)
+        .collect();
+    if destination
+        .iter()
+        .any(|node| node.as_op_dot().is_none() && *node != Dot::ROOT)
+    {
+        return None;
+    }
+
+    for ((destination, left), right) in destination.iter().zip(source_left).zip(source_right) {
+        let destination_type = target.node(*destination)?.node_type;
+        if !open_wrapper_compatible(destination_type, left)
+            || !open_wrapper_compatible(destination_type, right)
+        {
+            return None;
+        }
+    }
+    if !destination[1..]
+        .iter()
+        .all(|node| target.can_duplicate(*node))
+    {
+        return None;
+    }
+
+    Some((
+        OpenAncestorSplice {
+            destination,
+            source: source.clone(),
+        },
+        open_splice_emits_change(source, depth),
+    ))
+}
+
+fn fragment_edge_types(fragment: &Fragment, depth: usize, first: bool) -> Option<Vec<NodeType>> {
+    let mut current = fragment;
+    let mut types = Vec::with_capacity(depth);
+    for level in 0..depth {
+        types.push(current.node.as_type());
+        if level + 1 < depth {
+            current = if first {
+                current.children.first()?
+            } else {
+                current.children.last()?
+            };
+        }
+    }
+    Some(types)
+}
+
+fn open_wrapper_compatible(destination: NodeType, source: NodeType) -> bool {
+    destination == source
+        || matches!(
+            (destination, source),
+            (
+                NodeType::BulletList | NodeType::OrderedList,
+                NodeType::BulletList | NodeType::OrderedList
+            )
+        )
+}
+
+fn open_splice_emits_change(source: &Fragment, depth: usize) -> bool {
+    let mut current = source;
+    for level in 0..depth {
+        if level + 1 == depth {
+            return current.children.iter().any(is_insertable_inline_fragment);
+        }
+        if current.children.len() != 1 {
+            return !current.children.is_empty();
+        }
+        current = &current.children[0];
+    }
+    false
+}
+
+fn open_splice_is_complete_no_output(source: &Fragment, depth: usize) -> bool {
+    let mut current = source;
+    for level in 0..depth {
+        if level + 1 == depth {
+            return current.children.iter().all(is_supported_inline_fragment)
+                && !current.children.iter().any(is_insertable_inline_fragment);
+        }
+        let [only] = current.children.as_slice() else {
+            return false;
+        };
+        current = only;
+    }
+    false
+}
+
+pub(crate) fn open_inline_content_for_target<'a>(
+    target: &SliceInsertionTarget,
     slice: &'a Slice,
 ) -> Option<Vec<&'a Fragment>> {
-    let textblock_id = find_ancestor_textblock(view, position.node)?;
-    let textblock = view.node(textblock_id)?;
-    let textblock_type = textblock.node_type();
+    let textblock_type = target.textblock()?.node_type;
 
     let top_level = top_level_fragments(slice);
     if slice.open_start == 0 && slice.open_end == 0 {
@@ -241,7 +921,7 @@ pub(crate) fn insert_content_as_inline_at_position(
     position: Position,
     fragments: Vec<Fragment>,
     mode: &InlineMode,
-) -> Result<Option<Selection>, CommandError> {
+) -> Result<Option<SliceInsertionExecution>, CommandError> {
     if fragments.is_empty() {
         return Ok(None);
     }
@@ -261,165 +941,575 @@ pub(crate) fn insert_content_as_inline_at_position(
         .head;
     end.affinity = Affinity::Downstream;
     tr.set_selection(Some(Selection::collapsed(end)))?;
-    Ok(Some(Selection::new(start, end)))
+    let units = output_units_between(tr, start, end)?;
+    Ok(Some(SliceInsertionExecution {
+        inserted: Selection::new(start, end),
+        units,
+        split_left: None,
+        split_right: None,
+    }))
 }
 
 pub(crate) fn insert_blocks_in_textblock_at_position(
     tr: &mut Transaction,
     position: Position,
-    slice: &Slice,
+    plan: &TextblockSplicePlan,
     mode: &InlineMode,
-) -> Result<Option<Selection>, CommandError> {
+) -> Result<Option<SliceInsertionExecution>, CommandError> {
     tr.set_selection(Some(Selection::collapsed(position)))?;
-    insert_blocks_in_textblock(tr, slice, mode)
+    insert_blocks_in_textblock(tr, plan, mode)
 }
 
-/// Splice an open multi-item list range around a caret: the first and last
-/// source paragraphs join the split destination edges, while source item
-/// boundaries remain sibling items in the destination list.
-pub(crate) fn insert_open_list_items_in_textblock_at_position(
+pub(crate) fn insert_open_ancestor_splice_at_position(
     tr: &mut Transaction,
     position: Position,
-    items: &[Fragment],
+    splice: OpenAncestorSplice,
     mode: &InlineMode,
-) -> Result<Option<Selection>, CommandError> {
-    if items.len() < 2 {
+) -> Result<Option<SliceInsertionExecution>, CommandError> {
+    let depth = splice.destination.len();
+    if depth < 2 {
+        return Ok(None);
+    }
+
+    let start = Position {
+        node: *splice.destination.last().unwrap(),
+        offset: position.offset,
+        affinity: Affinity::Upstream,
+    };
+    let left = splice.destination;
+    let mut right = left.clone();
+    let mut output_units = Vec::new();
+    tr.batch::<_, CommandError>(|tr| {
+        let deepest = depth - 1;
+        tr.split_node(left[deepest], position.offset)?;
+        right[deepest] = next_block_sibling_id(tr, left[deepest])?;
+
+        for level in (1..deepest).rev() {
+            let (wrapper, aliases) =
+                split_block_wrapper_before_child(tr, left[level], right[level + 1])?;
+            right[level] = wrapper;
+            for descendant in &mut right[level + 1..] {
+                if let Some((_, remapped)) = aliases.iter().find(|(old, _)| old == descendant) {
+                    *descendant = *remapped;
+                }
+            }
+        }
+
+        let mut inserted = InsertedRange::default();
+        let source_children = &splice.source.children;
+        match source_children.as_slice() {
+            [] => {
+                return Err(CommandError::Corrupted(
+                    "open Slice wrapper has no edge child".into(),
+                ));
+            }
+            [only] => {
+                join_open_fragment_both(tr, &left[1..], &right[1..], only, mode, &mut inserted)?;
+            }
+            [first, middle @ .., last] => {
+                append_open_fragment(tr, &left[1..], first, mode, &mut inserted)?;
+                insert_fragments_after(tr, left[0], left[1], middle, mode, &mut inserted)?;
+                prepend_open_fragment(tr, &right[1..], last, mode, &mut inserted)?;
+            }
+        }
+
+        let mut end = inserted
+            .end
+            .clone()
+            .and_then(|endpoint| resolve_inserted_range_endpoint(tr, endpoint))
+            .ok_or_else(|| {
+                CommandError::Corrupted(
+                    "open-ancestor Slice plan produced no inserted endpoint".into(),
+                )
+            })?;
+        end.affinity = Affinity::Downstream;
+        output_units = inserted.units.clone();
+        tr.set_selection(Some(Selection::collapsed(end)))?;
+        Ok(())
+    })?;
+
+    let end = tr
+        .selection()
+        .map(|selection| selection.head)
+        .ok_or_else(|| {
+            CommandError::Corrupted("open-ancestor Slice plan produced no final caret".into())
+        })?;
+    Ok(Some(SliceInsertionExecution {
+        inserted: Selection::new(start, end),
+        units: output_units,
+        split_left: None,
+        split_right: None,
+    }))
+}
+
+pub(crate) fn split_block_wrapper_before_child(
+    tr: &mut Transaction,
+    wrapper: Dot,
+    first_right: Dot,
+) -> Result<(Dot, Vec<(Dot, Dot)>), CommandError> {
+    let wrapper = super::materialize_target(tr, wrapper)?;
+    let first_right = super::materialize_target(tr, first_right)?;
+    loop {
+        let scaffold = {
+            let view = tr.view();
+            let wrapper_view = view
+                .node(wrapper)
+                .ok_or(CommandError::NodeNotFound(wrapper))?;
+            let first_right_index = wrapper_view
+                .children()
+                .position(|child| match child {
+                    ChildView::Block(block) => block.id() == first_right,
+                    ChildView::Leaf(leaf) => leaf.dot() == first_right,
+                })
+                .ok_or_else(|| CommandError::orphan_child(first_right, wrapper))?;
+            wrapper_view
+                .children()
+                .skip(first_right_index)
+                .filter_map(|child| match child {
+                    ChildView::Block(block) => Some(block),
+                    ChildView::Leaf(_) => None,
+                })
+                .find(|child| {
+                    child.id().is_synthetic()
+                        && child.descendants().any(|descendant| match descendant {
+                            ChildView::Block(block) => block.id().as_op_dot().is_some(),
+                            ChildView::Leaf(leaf) => leaf.dot().as_op_dot().is_some(),
+                        })
+                })
+                .map(|child| child.id())
+        };
+        let Some(scaffold) = scaffold else {
+            break;
+        };
+        super::materialize_target(tr, scaffold)?;
+    }
+    let (parent, insert_at, container, moving) = {
+        let state = tr.state();
+        let view = state.view();
+        let wrapper_view = view
+            .node(wrapper)
+            .ok_or(CommandError::NodeNotFound(wrapper))?;
+        let parent = wrapper_view
+            .parent()
+            .ok_or(CommandError::NoParent(wrapper))?;
+        let wrapper_index = wrapper_view
+            .index()
+            .ok_or_else(|| CommandError::orphan_child(wrapper, parent.id()))?;
+        let first_right_index = wrapper_view
+            .children()
+            .position(|child| match child {
+                ChildView::Block(block) => block.id() == first_right,
+                ChildView::Leaf(leaf) => leaf.dot() == first_right,
+            })
+            .ok_or_else(|| CommandError::orphan_child(first_right, wrapper))?;
+        let moving: Vec<Dot> = wrapper_view
+            .children()
+            .skip(first_right_index)
+            .filter_map(|child| match child {
+                ChildView::Block(block) => Some(block.id()),
+                ChildView::Leaf(leaf) => Some(leaf.dot()),
+            })
+            .filter(|dot| dot.as_op_dot().is_some())
+            .collect();
+        let container = Subtree {
+            node: wrapper_view.node().to_plain(),
+            modifiers: state
+                .projected
+                .block_modifiers()
+                .modifiers_of(wrapper)
+                .into_values()
+                .collect(),
+            carry: state
+                .projected
+                .carry_modifiers(wrapper)
+                .into_values()
+                .collect(),
+            children: Vec::new(),
+            source_dots: Vec::new(),
+        };
+        (parent.id(), wrapper_index + 1, container, moving)
+    };
+    if moving.is_empty() {
         return Err(CommandError::Corrupted(
-            "open list splice requires at least two items".into(),
+            "open splice wrapper has no right contribution".into(),
         ));
     }
-    let (
-        textblock_id,
-        list_item_id,
-        list_id,
-        list_item_index,
-        paragraph_index,
-        first_inline,
-        first_tail,
-        middle_items,
-        last_prefix,
-        last_inline,
-    ) = {
-        let view = tr.state().view();
-        let textblock_id = find_ancestor_textblock(&view, position.node)
-            .ok_or(CommandError::NodeNotFound(position.node))?;
-        let textblock = view
-            .node(textblock_id)
-            .ok_or(CommandError::NodeNotFound(textblock_id))?;
-        let list_item = textblock
-            .parent()
-            .ok_or(CommandError::NoParent(textblock_id))?;
-        let list = list_item
-            .parent()
-            .ok_or(CommandError::NoParent(list_item.id()))?;
-        let list_item_index = list_item
-            .index()
-            .ok_or_else(|| CommandError::orphan_child(list_item.id(), list.id()))?;
-        let paragraph_index = textblock
-            .index()
-            .ok_or_else(|| CommandError::orphan_child(textblock_id, list_item.id()))?;
+    let (right, moved) = tr.insert_subtree_with_moved(parent, insert_at, container, &moving)?;
+    Ok((
+        right,
+        moved.into_iter().flat_map(|moved| moved.pairs).collect(),
+    ))
+}
 
-        let first = items
-            .first()
-            .ok_or_else(|| CommandError::Corrupted("open list slice has no first item".into()))?;
-        let last = items
-            .last()
-            .ok_or_else(|| CommandError::Corrupted("open list slice has no last item".into()))?;
-        let first_paragraph = first.children.first().ok_or_else(|| {
-            CommandError::Corrupted("open list slice first item has no paragraph".into())
-        })?;
-        let last_paragraph = last.children.last().ok_or_else(|| {
-            CommandError::Corrupted("open list slice last item has no paragraph".into())
-        })?;
+pub(crate) fn insert_hoisted_blocks_at_position(
+    tr: &mut Transaction,
+    position: Position,
+    plan: HoistedBlockInsertionPlan,
+) -> Result<Option<SliceInsertionExecution>, CommandError> {
+    let actual_target = SliceInsertionTarget::from_view(&tr.view(), position).ok_or_else(|| {
+        CommandError::Corrupted("hoisted Slice insertion lost its target structure".into())
+    })?;
+    if !plan.target.matches(&actual_target) {
+        return Err(CommandError::Corrupted(
+            "hoisted Slice insertion target changed after planning".into(),
+        ));
+    }
 
-        (
-            textblock_id,
-            list_item.id(),
-            list.id(),
-            list_item_index,
-            paragraph_index,
-            first_paragraph.children.clone(),
-            first.children[1..].to_vec(),
-            items[1..items.len() - 1].to_vec(),
-            last.children[..last.children.len() - 1].to_vec(),
-            last_paragraph.children.clone(),
-        )
+    #[derive(Clone, Copy)]
+    enum LiftedBoundary {
+        Before(Dot),
+        After(Dot),
+    }
+
+    let child_count = actual_target
+        .path()
+        .last()
+        .map(|node| node.child_types.len())
+        .ok_or_else(|| CommandError::Corrupted("hoisted Slice target has no path".into()))?;
+    let mut boundary = match plan.initial_boundary {
+        HoistInitialBoundary::Before if position.offset == 0 => {
+            LiftedBoundary::Before(position.node)
+        }
+        HoistInitialBoundary::After if position.offset == child_count => {
+            LiftedBoundary::After(position.node)
+        }
+        HoistInitialBoundary::Split if position.offset > 0 && position.offset < child_count => {
+            tr.split_node(position.node, position.offset)?;
+            tr.projected_clean()
+                .map_err(editor_transaction::StepError::from)?;
+            LiftedBoundary::Before(next_block_sibling_id(tr, position.node)?)
+        }
+        _ => {
+            return Err(CommandError::Corrupted(
+                "hoisted Slice initial boundary changed after planning".into(),
+            ));
+        }
     };
 
-    let mut inserted = None;
-    tr.batch::<_, CommandError>(|tr| {
-        tr.split_node(textblock_id, position.offset)?;
-
-        let moving = {
+    for step in &plan.boundary_steps {
+        let child = match boundary {
+            LiftedBoundary::Before(child) | LiftedBoundary::After(child) => child,
+        };
+        let (parent, index, sibling_count, next_right) = {
             let view = tr
                 .view_clean()
                 .map_err(editor_transaction::StepError::from)?;
-            let item = view
-                .node(list_item_id)
-                .ok_or(CommandError::NodeNotFound(list_item_id))?;
-            item.child_blocks()
-                .skip(paragraph_index + 1)
-                .map(|child| child.id())
-                .collect::<Vec<_>>()
+            let node = view.node(child).ok_or(CommandError::NodeNotFound(child))?;
+            let parent = node.parent().ok_or(CommandError::NoParent(child))?;
+            let index = node
+                .index()
+                .ok_or_else(|| CommandError::orphan_child(child, parent.id()))?;
+            let sibling_count = parent.children().count();
+            let next_right = parent.child_at(index + 1).and_then(|child| match child {
+                ChildView::Block(block) => Some(block.id()),
+                ChildView::Leaf(_) => None,
+            });
+            (parent.id(), index, sibling_count, next_right)
         };
-        let (right_item_id, moved) = tr.insert_subtree_with_moved(
-            list_id,
-            list_item_index + 1,
-            Subtree::leaf(NodeType::ListItem.into_node().to_plain()),
-            &moving,
-        )?;
-        let right_paragraph_id =
-            moved
-                .first()
-                .map(|moved| moved.root)
-                .ok_or(CommandError::Corrupted(
-                    "open list splice produced no right paragraph".into(),
-                ))?;
 
-        let start = position_at_end_of_block(tr, textblock_id)?;
-        tr.set_selection(Some(Selection::collapsed(start)))?;
-        insert_inline_fragments(tr, &first_inline, mode)?;
-
-        for fragment in first_tail {
-            let index = tr
-                .state()
-                .view()
-                .node(list_item_id)
-                .map(|item| item.child_blocks().count())
-                .ok_or(CommandError::NodeNotFound(list_item_id))?;
-            tr.insert_subtree(list_item_id, index, fragment.into_subtree())?;
-        }
-
-        let mut insert_at = {
-            let view = tr.state().view();
-            view.node(right_item_id)
-                .and_then(|item| item.index())
-                .ok_or_else(|| CommandError::orphan_child(right_item_id, list_id))?
+        boundary = match (step, boundary) {
+            (HoistBoundaryStep::LiftBefore, LiftedBoundary::Before(_)) if index == 0 => {
+                LiftedBoundary::Before(parent)
+            }
+            (HoistBoundaryStep::LiftAfter, LiftedBoundary::After(_))
+                if index + 1 == sibling_count =>
+            {
+                LiftedBoundary::After(parent)
+            }
+            (HoistBoundaryStep::SplitBefore, LiftedBoundary::Before(first_right)) if index > 0 => {
+                let (right_wrapper, _) = split_block_wrapper_before_child(tr, parent, first_right)?;
+                LiftedBoundary::Before(right_wrapper)
+            }
+            (HoistBoundaryStep::SplitAfter, LiftedBoundary::After(_))
+                if index + 1 < sibling_count =>
+            {
+                let first_right = next_right.ok_or_else(|| {
+                    CommandError::Corrupted("hoisted Slice boundary lost its right sibling".into())
+                })?;
+                let (right_wrapper, _) = split_block_wrapper_before_child(tr, parent, first_right)?;
+                LiftedBoundary::Before(right_wrapper)
+            }
+            _ => {
+                return Err(CommandError::Corrupted(
+                    "hoisted Slice boundary step changed after planning".into(),
+                ));
+            }
         };
-        for item in middle_items {
-            tr.insert_subtree(list_id, insert_at, item.into_subtree())?;
-            insert_at += 1;
-        }
+    }
 
-        for (index, fragment) in last_prefix.into_iter().enumerate() {
-            tr.insert_subtree(right_item_id, index, fragment.into_subtree())?;
-        }
+    let child = match boundary {
+        LiftedBoundary::Before(child) | LiftedBoundary::After(child) => child,
+    };
+    let (parent, index) = {
+        let view = tr
+            .view_clean()
+            .map_err(editor_transaction::StepError::from)?;
+        let node = view.node(child).ok_or(CommandError::NodeNotFound(child))?;
+        let parent = node.parent().ok_or(CommandError::NoParent(child))?;
+        let index = node
+            .index()
+            .ok_or_else(|| CommandError::orphan_child(child, parent.id()))?;
+        (parent.id(), index)
+    };
+    let planned_parent = actual_target
+        .path()
+        .get(plan.parent_depth)
+        .map(|node| node.id)
+        .ok_or_else(|| {
+            CommandError::Corrupted("hoisted Slice parent depth changed after planning".into())
+        })?;
+    if parent != planned_parent {
+        return Err(CommandError::Corrupted(
+            "hoisted Slice boundary did not reach its planned parent".into(),
+        ));
+    }
+    let insertion = Position::new(
+        parent,
+        match boundary {
+            LiftedBoundary::Before(_) => index,
+            LiftedBoundary::After(_) => index + 1,
+        },
+    );
 
-        tr.set_selection(Some(Selection::collapsed(position_at_start_of_block(
-            tr,
-            right_paragraph_id,
-        )?)))?;
-        insert_inline_fragments(tr, &last_inline, mode)?;
-        let mut end = tr
-            .selection()
-            .expect("selection preserved through open list splice")
-            .head;
-        end.affinity = Affinity::Downstream;
-        tr.set_selection(Some(Selection::collapsed(end)))?;
-        inserted = Some(Selection::new(start, end));
-        Ok(())
-    })?;
-    Ok(inserted)
+    tr.projected_clean()
+        .map_err(editor_transaction::StepError::from)?;
+    insert_blocks_at_block_boundary(tr, insertion, plan.blocks, plan.list_merges)
+}
+
+fn next_block_sibling_id(tr: &Transaction, node: Dot) -> Result<Dot, CommandError> {
+    let view = tr.state().view();
+    view.node(node)
+        .and_then(|node| next_sibling(&node))
+        .and_then(|sibling| match sibling {
+            ChildView::Block(block) => Some(block.id()),
+            ChildView::Leaf(_) => None,
+        })
+        .ok_or_else(|| CommandError::Corrupted("split produced no right wrapper".into()))
+}
+
+fn join_open_fragment_both(
+    tr: &mut Transaction,
+    left: &[Dot],
+    right: &[Dot],
+    source: &Fragment,
+    mode: &InlineMode,
+    inserted: &mut InsertedRange,
+) -> Result<(), CommandError> {
+    let (&left_node, &right_node) = left
+        .first()
+        .zip(right.first())
+        .ok_or_else(|| CommandError::Corrupted("open splice exhausted destination edge".into()))?;
+    if left.len() == 1 {
+        insert_inline_at_edge(tr, left_node, &source.children, false, mode, inserted)?;
+        tr.merge_node(left_node)?;
+        return Ok(());
+    }
+
+    match source.children.as_slice() {
+        [] => {
+            return Err(CommandError::Corrupted(
+                "open Slice wrapper has no edge child".into(),
+            ));
+        }
+        [only] => {
+            join_open_fragment_both(tr, &left[1..], &right[1..], only, mode, inserted)?;
+        }
+        [first, middle @ .., last] => {
+            append_open_fragment(tr, &left[1..], first, mode, inserted)?;
+            insert_fragments_after(tr, left_node, left[1], middle, mode, inserted)?;
+            prepend_open_fragment(tr, &right[1..], last, mode, inserted)?;
+        }
+    }
+    tr.merge_node(left_node)?;
+    let _ = right_node;
+    Ok(())
+}
+
+fn append_open_fragment(
+    tr: &mut Transaction,
+    destination: &[Dot],
+    source: &Fragment,
+    mode: &InlineMode,
+    inserted: &mut InsertedRange,
+) -> Result<(), CommandError> {
+    let &node = destination
+        .first()
+        .ok_or_else(|| CommandError::Corrupted("open splice exhausted left edge".into()))?;
+    if destination.len() == 1 {
+        return insert_inline_at_edge(tr, node, &source.children, false, mode, inserted);
+    }
+    let first = source
+        .children
+        .first()
+        .ok_or_else(|| CommandError::Corrupted("open Slice left edge is empty".into()))?;
+    append_open_fragment(tr, &destination[1..], first, mode, inserted)?;
+    insert_fragments_at_end(tr, node, &source.children[1..], mode, inserted)
+}
+
+fn prepend_open_fragment(
+    tr: &mut Transaction,
+    destination: &[Dot],
+    source: &Fragment,
+    mode: &InlineMode,
+    inserted: &mut InsertedRange,
+) -> Result<(), CommandError> {
+    let &node = destination
+        .first()
+        .ok_or_else(|| CommandError::Corrupted("open splice exhausted right edge".into()))?;
+    if destination.len() == 1 {
+        return insert_inline_at_edge(tr, node, &source.children, true, mode, inserted);
+    }
+    let last = source
+        .children
+        .last()
+        .ok_or_else(|| CommandError::Corrupted("open Slice right edge is empty".into()))?;
+    insert_fragments_before(
+        tr,
+        node,
+        destination[1],
+        &source.children[..source.children.len() - 1],
+        mode,
+        inserted,
+    )?;
+    prepend_open_fragment(tr, &destination[1..], last, mode, inserted)
+}
+
+fn insert_inline_at_edge(
+    tr: &mut Transaction,
+    block: Dot,
+    fragments: &[Fragment],
+    at_start: bool,
+    mode: &InlineMode,
+    inserted: &mut InsertedRange,
+) -> Result<(), CommandError> {
+    let position = if at_start {
+        position_at_start_of_block(tr, block)?
+    } else {
+        position_at_end_of_block(tr, block)?
+    };
+    if let Some(execution) =
+        insert_content_as_inline_at_position(tr, position, fragments.to_vec(), mode)?
+    {
+        inserted.include_position_range(execution.inserted.anchor, execution.inserted.head);
+        inserted.units.extend(execution.units);
+    }
+    Ok(())
+}
+
+fn insert_fragments_after(
+    tr: &mut Transaction,
+    parent: Dot,
+    child: Dot,
+    fragments: &[Fragment],
+    mode: &InlineMode,
+    inserted: &mut InsertedRange,
+) -> Result<(), CommandError> {
+    if fragments.is_empty() {
+        return Ok(());
+    }
+    let index = {
+        let view = tr.state().view();
+        let (actual_parent, index) =
+            block_parent_and_index(&view, child).ok_or(CommandError::NodeNotFound(child))?;
+        if actual_parent != parent {
+            return Err(CommandError::Corrupted(
+                "open splice child escaped its destination wrapper".into(),
+            ));
+        }
+        index + 1
+    };
+    insert_closed_fragments(tr, parent, index, fragments, mode, inserted)
+}
+
+fn insert_fragments_before(
+    tr: &mut Transaction,
+    parent: Dot,
+    child: Dot,
+    fragments: &[Fragment],
+    mode: &InlineMode,
+    inserted: &mut InsertedRange,
+) -> Result<(), CommandError> {
+    if fragments.is_empty() {
+        return Ok(());
+    }
+    let index = {
+        let view = tr.state().view();
+        let (actual_parent, index) =
+            block_parent_and_index(&view, child).ok_or(CommandError::NodeNotFound(child))?;
+        if actual_parent != parent {
+            return Err(CommandError::Corrupted(
+                "open splice child escaped its destination wrapper".into(),
+            ));
+        }
+        index
+    };
+    insert_closed_fragments(tr, parent, index, fragments, mode, inserted)
+}
+
+fn insert_fragments_at_end(
+    tr: &mut Transaction,
+    parent: Dot,
+    fragments: &[Fragment],
+    mode: &InlineMode,
+    inserted: &mut InsertedRange,
+) -> Result<(), CommandError> {
+    if fragments.is_empty() {
+        return Ok(());
+    }
+    let index = tr
+        .state()
+        .view()
+        .node(parent)
+        .map(|node| node.children().count())
+        .ok_or(CommandError::NodeNotFound(parent))?;
+    insert_closed_fragments(tr, parent, index, fragments, mode, inserted)
+}
+
+fn insert_closed_fragments(
+    tr: &mut Transaction,
+    parent: Dot,
+    index: usize,
+    fragments: &[Fragment],
+    mode: &InlineMode,
+    inserted: &mut InsertedRange,
+) -> Result<(), CommandError> {
+    for (offset, fragment) in fragments.iter().enumerate() {
+        let inserted_id =
+            tr.insert_subtree(parent, index + offset, fragment.clone().into_subtree())?;
+        if let Some(inserted_id) = inserted_id {
+            inserted.include_block(inserted_id);
+            paint_inserted_subtree(tr, inserted_id, mode)?;
+        }
+    }
+    Ok(())
+}
+
+fn paint_inserted_subtree(
+    tr: &mut Transaction,
+    root: Dot,
+    mode: &InlineMode,
+) -> Result<(), CommandError> {
+    let Some(paint) = mode.plain_paint().map(ToOwned::to_owned) else {
+        return Ok(());
+    };
+    let textblocks: Vec<Dot> = {
+        let view = tr.state().view();
+        let Some(root) = view.node(root) else {
+            return Ok(());
+        };
+        std::iter::once(root.clone())
+            .chain(root.descendants().filter_map(|child| match child {
+                ChildView::Block(block) => Some(block),
+                ChildView::Leaf(_) => None,
+            }))
+            .filter(|node| node.spec().is_textblock())
+            .map(|node| node.id())
+            .collect()
+    };
+    for textblock in textblocks {
+        paint_block_uniformly(tr, textblock, &paint)?;
+    }
+    Ok(())
 }
 
 fn insert_inline_fragments(
@@ -430,6 +1520,7 @@ fn insert_inline_fragments(
     let mut any_change = false;
     for f in fragments {
         match &f.node {
+            PlainNode::Text(t) if t.text.is_empty() => {}
             PlainNode::Text(t) if !t.text.is_empty() => {
                 insert_text_at_caret(tr, &t.text, Some(mode.paint_for(f)))?;
                 any_change = true;
@@ -442,10 +1533,22 @@ fn insert_inline_fragments(
                 insert_tab_at_caret(tr, Some(mode.paint_for(f)))?;
                 any_change = true;
             }
-            _ => {}
+            _ => {
+                return Err(CommandError::Corrupted(format!(
+                    "non-inline fragment reached inline Slice executor: {:?}",
+                    f.node.as_type()
+                )));
+            }
         }
     }
     Ok(any_change)
+}
+
+pub(crate) fn is_supported_inline_fragment(fragment: &Fragment) -> bool {
+    matches!(
+        &fragment.node,
+        PlainNode::Text(_) | PlainNode::HardBreak(_) | PlainNode::Tab(_)
+    )
 }
 
 pub(crate) fn is_insertable_inline_fragment(fragment: &Fragment) -> bool {
@@ -463,10 +1566,19 @@ enum InsertedRangeEndpoint {
     AfterBlock(Dot),
 }
 
+pub(crate) struct SliceInsertionExecution {
+    pub(crate) inserted: Selection,
+    pub(crate) units: Vec<Dot>,
+    pub(crate) split_left: Option<Dot>,
+    pub(crate) split_right: Option<Dot>,
+}
+
 #[derive(Default)]
 struct InsertedRange {
     start: Option<InsertedRangeEndpoint>,
     end: Option<InsertedRangeEndpoint>,
+    blocks: Vec<Dot>,
+    units: Vec<Dot>,
 }
 
 impl InsertedRange {
@@ -484,13 +1596,95 @@ impl InsertedRange {
         self.start
             .get_or_insert(InsertedRangeEndpoint::BeforeBlock(block_id));
         self.end = Some(InsertedRangeEndpoint::AfterBlock(block_id));
+        self.blocks.push(block_id);
+        self.units.push(block_id);
     }
 
-    fn selection(&self, tr: &Transaction) -> Option<Selection> {
-        let start = resolve_inserted_range_endpoint(tr, self.start.clone()?)?;
-        let end = resolve_inserted_range_endpoint(tr, self.end.clone()?)?;
-        Some(Selection::new(start, end))
+    fn selection(&self, tr: &Transaction) -> Result<Option<Selection>, CommandError> {
+        let mut endpoints = Vec::new();
+        if let Some(start) = self.start.clone() {
+            endpoints.push(resolve_inserted_range_endpoint(tr, start).ok_or_else(|| {
+                CommandError::Corrupted("planned Slice start output no longer resolves".into())
+            })?);
+        }
+        if let Some(end) = self.end.clone() {
+            endpoints.push(resolve_inserted_range_endpoint(tr, end).ok_or_else(|| {
+                CommandError::Corrupted("planned Slice end output no longer resolves".into())
+            })?);
+        }
+        for block in &self.blocks {
+            endpoints.push(
+                resolve_inserted_range_endpoint(tr, InsertedRangeEndpoint::BeforeBlock(*block))
+                    .ok_or_else(|| {
+                        CommandError::Corrupted(
+                            "planned Slice block-start output no longer resolves".into(),
+                        )
+                    })?,
+            );
+            endpoints.push(
+                resolve_inserted_range_endpoint(tr, InsertedRangeEndpoint::AfterBlock(*block))
+                    .ok_or_else(|| {
+                        CommandError::Corrupted(
+                            "planned Slice block-end output no longer resolves".into(),
+                        )
+                    })?,
+            );
+        }
+
+        let view = tr.state().view();
+        let resolved = endpoints
+            .iter()
+            .map(|position| {
+                position.resolve(&view).ok_or_else(|| {
+                    CommandError::Corrupted(
+                        "planned Slice output position no longer resolves".into(),
+                    )
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let Some(start) = resolved.iter().min().map(|position| position.position()) else {
+            return Ok(None);
+        };
+        let end = resolved
+            .iter()
+            .max()
+            .map(|position| position.position())
+            .ok_or_else(|| {
+                CommandError::Corrupted("planned Slice output range has no end".into())
+            })?;
+        Ok(Some(Selection::new(start, end)))
     }
+}
+
+fn output_units_between(
+    tr: &Transaction,
+    start: Position,
+    end: Position,
+) -> Result<Vec<Dot>, CommandError> {
+    if start.node != end.node || start.offset > end.offset {
+        return Err(CommandError::Corrupted(
+            "inline Slice output escaped its planned textblock".into(),
+        ));
+    }
+    let view = tr.view();
+    let node = view
+        .node(start.node)
+        .ok_or(CommandError::NodeNotFound(start.node))?;
+    let units = node
+        .children()
+        .skip(start.offset)
+        .take(end.offset - start.offset)
+        .map(|child| match child {
+            ChildView::Block(block) => block.id(),
+            ChildView::Leaf(leaf) => leaf.dot(),
+        })
+        .collect::<Vec<_>>();
+    if units.len() != end.offset - start.offset {
+        return Err(CommandError::Corrupted(
+            "inline Slice output produced a different child span".into(),
+        ));
+    }
+    Ok(units)
 }
 
 /// Elem id at child slot `index` of `container` when it is an addressable block
@@ -504,34 +1698,35 @@ fn block_child_id(tr: &Transaction, container: Dot, index: usize) -> Option<Dot>
     }
 }
 
-fn textblock_edge_joins(textblock: &NodeView, offset: usize, slice: &Slice) -> (bool, bool) {
-    let destination_type = textblock.node_type();
-    let destination_children: Vec<NodeType> = textblock
-        .children()
-        .map(|child| child_node_type(&child))
-        .collect();
+fn textblock_edge_joins(
+    destination_type: NodeType,
+    destination_children: &[NodeType],
+    offset: usize,
+    slice: &Slice,
+) -> (bool, bool) {
     if offset > destination_children.len() {
         return (false, false);
     }
-    let content = &textblock.spec().content;
-
     let join_start = offset > 0
         && slice.open_start > 0
         && slice.content.first().is_some_and(|source| {
             source.node.as_type() == destination_type
-                && content.matches_sequence(
+                && content_placement(
+                    destination_type,
                     &destination_children[..offset]
                         .iter()
                         .copied()
                         .chain(source.children.iter().map(|child| child.node.as_type()))
                         .collect::<Vec<_>>(),
                 )
+                .is_valid()
         });
     let mut join_end = offset < destination_children.len()
         && slice.open_end > 0
         && slice.content.last().is_some_and(|source| {
             source.node.as_type() == destination_type
-                && content.matches_sequence(
+                && content_placement(
+                    destination_type,
                     &source
                         .children
                         .iter()
@@ -539,49 +1734,198 @@ fn textblock_edge_joins(textblock: &NodeView, offset: usize, slice: &Slice) -> (
                         .chain(destination_children[offset..].iter().copied())
                         .collect::<Vec<_>>(),
                 )
+                .is_valid()
         });
 
     if join_start && join_end && slice.content.len() == 1 {
         // Pairwise-valid joins may still form an invalid three-part sequence.
         // Preserve the start join and leave the end in its destination wrapper.
         let source = &slice.content[0];
-        join_end = content.matches_sequence(
+        join_end = content_placement(
+            destination_type,
             &destination_children[..offset]
                 .iter()
                 .copied()
                 .chain(source.children.iter().map(|child| child.node.as_type()))
                 .chain(destination_children[offset..].iter().copied())
                 .collect::<Vec<_>>(),
-        );
+        )
+        .is_valid();
     }
 
     (join_start, join_end)
 }
 
-pub(crate) fn can_splice_textblock(view: &DocView, position: &Position, slice: &Slice) -> bool {
-    let Some(textblock_id) = find_ancestor_textblock(view, position.node) else {
-        return false;
-    };
-    let Some(textblock) = view.node(textblock_id) else {
-        return false;
-    };
-    let Some(container) = textblock.parent() else {
-        return false;
-    };
-    let Some(textblock_index) = textblock.index() else {
-        return false;
-    };
-    let child_count = textblock.children().count();
-    if position.offset > child_count {
-        return false;
+#[derive(Clone)]
+pub(crate) struct TextblockSplicePlan {
+    blocks: Vec<Fragment>,
+    inserted_blocks: Vec<Fragment>,
+    textblock_type: NodeType,
+    container_type: NodeType,
+    textblock_index: usize,
+    child_count: usize,
+    split_index: usize,
+    has_left: bool,
+    has_right: bool,
+    join_start: bool,
+    merge_destinations: bool,
+    merge_end: bool,
+    unjoined_ends_with_page_break: bool,
+    final_caret_at_right_boundary: bool,
+    insert_at: usize,
+    list_merges: Vec<PlannedListMerge>,
+}
+
+impl TextblockSplicePlan {
+    pub(crate) fn planned_output(&self) -> Option<SliceInsertionOutputPlan> {
+        let mut nodes = Vec::new();
+        if self.join_start {
+            nodes.extend(
+                inline_output_node_types(&self.blocks.first()?.children)
+                    .into_iter()
+                    .enumerate()
+                    .map(|(index, node_type)| SliceOutputNodeSpec {
+                        source: SliceOutputSource::TextblockStartInline { index },
+                        node_type,
+                    }),
+            );
+        }
+        nodes.extend(planned_block_output_nodes(
+            &self.inserted_blocks,
+            &self.list_merges,
+            true,
+        ));
+        if self.merge_end {
+            nodes.extend(
+                inline_output_node_types(&self.blocks.last()?.children)
+                    .into_iter()
+                    .enumerate()
+                    .map(|(index, node_type)| SliceOutputNodeSpec {
+                        source: SliceOutputSource::TextblockEndInline { index },
+                        node_type,
+                    }),
+            );
+        }
+
+        if nodes.is_empty() {
+            if !self.final_caret_at_right_boundary {
+                return None;
+            }
+            return Some(SliceInsertionOutputPlan {
+                nodes: vec![
+                    SliceOutputNodeSpec {
+                        source: SliceOutputSource::SplitLeft,
+                        node_type: self.textblock_type,
+                    },
+                    SliceOutputNodeSpec {
+                        source: SliceOutputSource::SplitRight,
+                        node_type: self.textblock_type,
+                    },
+                ],
+                caret: SliceOutputPositionSpec {
+                    node: 1,
+                    relation: SliceOutputRelation::Start,
+                    affinity: Affinity::Downstream,
+                },
+                anchor: SliceOutputPositionSpec {
+                    node: 0,
+                    relation: SliceOutputRelation::End,
+                    affinity: Affinity::Upstream,
+                },
+                head: SliceOutputPositionSpec {
+                    node: 1,
+                    relation: SliceOutputRelation::Start,
+                    affinity: Affinity::Downstream,
+                },
+            });
+        }
+
+        let last_inserted_merged = self
+            .inserted_blocks
+            .len()
+            .checked_sub(1)
+            .is_some_and(|index| inserted_member_is_merged(&self.list_merges, index));
+        let caret_relation = if self.merge_end {
+            SliceOutputRelation::After
+        } else if !self.inserted_blocks.is_empty() {
+            if self.unjoined_ends_with_page_break {
+                SliceOutputRelation::AfterTerminalPageBreak
+            } else if last_inserted_merged {
+                SliceOutputRelation::After
+            } else {
+                SliceOutputRelation::End
+            }
+        } else if nodes
+            .last()
+            .is_some_and(|node| node.node_type == NodeType::PageBreak)
+        {
+            SliceOutputRelation::AfterTerminalPageBreak
+        } else {
+            SliceOutputRelation::After
+        };
+        let head_affinity = if self.merge_end {
+            inline_output_end_affinity(&self.blocks.last()?.children)
+        } else if !self.inserted_blocks.is_empty() {
+            Affinity::Upstream
+        } else {
+            inline_output_end_affinity(&self.blocks.first()?.children)
+        };
+        let mut output = output_plan_for_units(
+            nodes,
+            caret_relation,
+            Affinity::Downstream,
+            if self.join_start {
+                Affinity::Upstream
+            } else {
+                Affinity::Downstream
+            },
+            head_affinity,
+        )?;
+        if self.join_start
+            && self.inserted_blocks.is_empty()
+            && !self.merge_end
+            && self
+                .blocks
+                .first()
+                .is_some_and(|block| paragraph_ends_with_page_break(block))
+        {
+            output.head.relation = SliceOutputRelation::AfterTerminalPageBreak;
+        }
+        Some(output)
+    }
+}
+
+fn inline_output_end_affinity(fragments: &[Fragment]) -> Affinity {
+    fragments
+        .iter()
+        .rev()
+        .find_map(|fragment| match &fragment.node {
+            PlainNode::Text(text) if !text.text.is_empty() => Some(Affinity::Upstream),
+            PlainNode::HardBreak(_) | PlainNode::Tab(_) => Some(Affinity::Downstream),
+            PlainNode::PageBreak(_) => Some(Affinity::Upstream),
+            _ => None,
+        })
+        .unwrap_or(Affinity::Downstream)
+}
+
+pub(crate) fn plan_textblock_splice_target(
+    target: &SliceInsertionTarget,
+    slice: &Slice,
+) -> Option<TextblockSplicePlan> {
+    let textblock = target.textblock()?;
+    let container = target.parent(textblock.id)?;
+    let textblock_index = textblock.index?;
+    let child_count = textblock.child_types.len();
+    if target.position.offset > child_count {
+        return None;
     }
 
     let blocks: Vec<&Fragment> = slice.content.iter().collect();
     if blocks.is_empty() {
-        return false;
+        return None;
     }
 
-    let textblock_type = textblock.node_type();
+    let textblock_type = textblock.node_type;
     let incompatible_textblock = |fragment: &&Fragment| {
         let source_type = fragment.node.as_type();
         Schema::node_spec(source_type).is_textblock() && source_type != textblock_type
@@ -589,16 +1933,21 @@ pub(crate) fn can_splice_textblock(view: &DocView, position: &Position, slice: &
     if blocks.first().is_some_and(incompatible_textblock)
         || blocks.last().is_some_and(incompatible_textblock)
     {
-        return false;
+        return None;
     }
 
-    let has_left = position.offset > 0;
-    let has_right = position.offset < child_count;
-    if has_left && has_right && !can_split_textblock_for_structural_insert(view, textblock_id) {
-        return false;
+    let has_left = target.position.offset > 0;
+    let has_right = target.position.offset < child_count;
+    if has_left && has_right && !can_split_textblock_for_structural_insert(target, textblock.id) {
+        return None;
     }
 
-    let (join_start, join_end) = textblock_edge_joins(&textblock, position.offset, slice);
+    let (join_start, join_end) = textblock_edge_joins(
+        textblock_type,
+        &textblock.child_types,
+        target.position.offset,
+        slice,
+    );
     let merge_destinations = join_start && join_end && blocks.len() == 1;
     let unjoined_start = usize::from(join_start);
     let unjoined_end = if join_end {
@@ -622,89 +1971,126 @@ pub(crate) fn can_splice_textblock(view: &DocView, position: &Position, slice: &
         replacement.push(textblock_type);
     }
 
-    let mut final_types: Vec<NodeType> = container
-        .children()
-        .map(|child| child_node_type(&child))
-        .collect();
+    let mut final_types = container.child_types.clone();
     final_types.splice(textblock_index..=textblock_index, replacement);
-    container
-        .spec()
-        .content
-        .completion_insertions(&final_types)
-        .is_some()
-}
-
-/// `can_splice_textblock`이 통과시킨 splice가 실제로 관측 가능한 op를 방출하는지 —
-/// `insert_blocks_in_textblock`이 `Ok(Some)`을 돌리는 조건의 정확한 미러. 구조 유효성만
-/// 보는 `can_splice_textblock`은 콘텐츠 없는 슬라이스(예: 빈 문단)가 edge join으로 소진돼
-/// 아무 op도 내지 않는(`Ok(None)`) 경우를 통과시키므로, resolve가 그런 슬라이스에
-/// SpliceBlocks Plan을 내지 않도록 이 술어로 걸러 `resolve_slice_insertion`의 계약
-/// (`Some(plan)` ⇒ 삽입 op 방출)을 유지한다. 모든 입력은 (view, position, slice)의 순수
-/// 함수다.
-pub(crate) fn splice_emits_change(view: &DocView, position: &Position, slice: &Slice) -> bool {
-    let Some(textblock_id) = find_ancestor_textblock(view, position.node) else {
-        return false;
-    };
-    let Some(textblock) = view.node(textblock_id) else {
-        return false;
-    };
-    let offset = position.offset;
-    let child_count = textblock.children().count();
-    let has_left = offset > 0;
-    let has_right = offset < child_count;
-
-    let blocks: Vec<&Fragment> = slice.content.iter().collect();
-    if blocks.is_empty() {
-        return false;
+    let placement = content_placement(container.node_type, &final_types);
+    if placement.first_residue.is_some() {
+        return None;
     }
-    let (join_start, join_end) = textblock_edge_joins(&textblock, offset, slice);
-    let merge_destinations = join_start && join_end && blocks.len() == 1;
-    let unjoined_start = usize::from(join_start);
-    let unjoined_end = if join_end {
-        blocks.len().saturating_sub(1)
-    } else {
-        blocks.len()
-    };
+    let completion = placement.completion_insertions?;
+    let mut inserted_blocks = blocks
+        .iter()
+        .take(unjoined_end)
+        .skip(unjoined_start)
+        .map(|fragment| (*fragment).clone())
+        .collect::<Vec<_>>();
+    let mut completed_len = final_types.len();
+    for insertion in completion {
+        // Root's trailing editable paragraph is derived projection state. Other
+        // required children belong to the accepted authored replacement and
+        // must be inserted by this plan before projection observes the result.
+        let projection_owned_trailing_paragraph = container.node_type == NodeType::Root
+            && insertion.node_type == NodeType::Paragraph
+            && insertion.index == completed_len;
+        completed_len += 1;
+        if projection_owned_trailing_paragraph {
+            continue;
+        }
 
-    // 소진되지 않은 블록은 그대로 insert_subtree 된다. 빈 텍스트블록 제거 케이스도 포함:
-    // !has_left && !has_right ⇒ join 불가 ⇒ unjoined_count == blocks.len() > 0.
-    if unjoined_end > unjoined_start {
-        return true;
+        let relative = insertion.index.checked_sub(textblock_index)?;
+        let inserted_index = relative.checked_sub(usize::from(has_left))?;
+        // The original container was valid, so a new required child must fall
+        // inside the one textblock replacement. A completion outside that span
+        // would alter an unrelated destination survivor and is not this plan's
+        // content to author.
+        if inserted_index > inserted_blocks.len() {
+            return None;
+        }
+        inserted_blocks.insert(
+            inserted_index,
+            subtree_to_fragment(minimal_subtree(insertion.node_type)),
+        );
     }
-    // 인접 위치의 미병합 split은 두 반쪽을 남긴다(구조 변경).
-    if has_left && has_right && !merge_destinations {
-        return true;
-    }
-    // start join: blocks[0]의 인라인 병합, 또는 말미 페이지브레이크 삽입.
-    // 페이지브레이크 절은 실행의 into_root_paragraph 성공 여부를 직접 보지 않는다 —
-    // 상류 prepare_page_breaks_for_position이 비-root 문맥의 말미 페이지브레이크를
-    // 이미 제거하므로, 여기 도달한 말미 PageBreak는 root-terminal 허용 문맥이 보장된다.
-    if join_start
+
+    let merge_end = join_end && !merge_destinations;
+    let join_start_emits = join_start
         && (blocks[0].children.iter().any(is_insertable_inline_fragment)
             || blocks[0]
                 .children
                 .last()
-                .is_some_and(|child| child.node.as_type() == NodeType::PageBreak))
-    {
-        return true;
-    }
-    // end join: blocks.last()의 인라인 병합.
-    let merge_end = join_end && !merge_destinations;
-    if merge_end
+                .is_some_and(|child| child.node.as_type() == NodeType::PageBreak));
+    let merge_end_emits = merge_end
         && blocks
             .last()
-            .is_some_and(|block| block.children.iter().any(is_insertable_inline_fragment))
-    {
-        return true;
+            .is_some_and(|block| block.children.iter().any(is_insertable_inline_fragment));
+    let split_emits = has_left && has_right && !merge_destinations;
+    let emits_change =
+        !inserted_blocks.is_empty() || split_emits || join_start_emits || merge_end_emits;
+    if !emits_change {
+        return None;
     }
-    false
+
+    let unjoined_ends_with_page_break = inserted_blocks
+        .last()
+        .is_some_and(|fragment| paragraph_ends_with_page_break(fragment));
+    let final_caret_at_right_boundary =
+        split_emits && inserted_blocks.is_empty() && !join_start_emits && !merge_end_emits;
+    let insert_at = textblock_index + usize::from(has_left);
+    let left = if has_left {
+        Some(ExistingBlock {
+            id: Some(textblock.id),
+            node_type: textblock_type,
+        })
+    } else {
+        textblock_index.checked_sub(1).and_then(|index| {
+            Some(ExistingBlock {
+                id: container.child_ids.get(index).copied().flatten(),
+                node_type: *container.child_types.get(index)?,
+            })
+        })
+    };
+    let right = if has_right && !merge_destinations {
+        Some(ExistingBlock {
+            id: None,
+            node_type: textblock_type,
+        })
+    } else {
+        let index = textblock_index + 1;
+        container
+            .child_types
+            .get(index)
+            .map(|node_type| ExistingBlock {
+                id: container.child_ids.get(index).copied().flatten(),
+                node_type: *node_type,
+            })
+    };
+    let list_merges = plan_adjacent_list_merges(left, &inserted_blocks, right)?;
+
+    Some(TextblockSplicePlan {
+        blocks: slice.content.clone(),
+        inserted_blocks,
+        textblock_type,
+        container_type: container.node_type,
+        textblock_index,
+        child_count,
+        split_index: target.position.offset,
+        has_left,
+        has_right,
+        join_start,
+        merge_destinations,
+        merge_end,
+        unjoined_ends_with_page_break,
+        final_caret_at_right_boundary,
+        insert_at,
+        list_merges,
+    })
 }
 
 fn insert_blocks_in_textblock(
     tr: &mut Transaction,
-    slice: &Slice,
+    plan: &TextblockSplicePlan,
     mode: &InlineMode,
-) -> Result<Option<Selection>, CommandError> {
+) -> Result<Option<SliceInsertionExecution>, CommandError> {
     let head = tr
         .selection()
         .expect("entry caller guaranteed selection")
@@ -713,9 +2099,14 @@ fn insert_blocks_in_textblock(
     // In the projected model the caret already addresses the textblock + child
     // offset, so no inner text-node split is needed.
     let textblock_id = head.node;
-    let split_index_in_textblock = head.offset;
+    if head.offset != plan.split_index {
+        return Err(CommandError::Corrupted(
+            "textblock splice position changed after planning".into(),
+        ));
+    }
+    let split_index_in_textblock = plan.split_index;
 
-    let (container_id, textblock_index, child_count, join_start, join_end) = {
+    let container_id = {
         let view = tr.state().view();
         let tb = view
             .node(textblock_id)
@@ -725,47 +2116,34 @@ fn insert_blocks_in_textblock(
             .index()
             .ok_or_else(|| CommandError::orphan_child(textblock_id, parent.id()))?;
         let child_count = tb.children().count();
-        let (join_start, join_end) = textblock_edge_joins(&tb, split_index_in_textblock, slice);
-        (
-            parent.id(),
-            textblock_index,
-            child_count,
-            join_start,
-            join_end,
-        )
+        if tb.node_type() != plan.textblock_type
+            || parent.node_type() != plan.container_type
+            || textblock_index != plan.textblock_index
+            || child_count != plan.child_count
+        {
+            return Err(CommandError::Corrupted(
+                "textblock splice destination changed after planning".into(),
+            ));
+        }
+        parent.id()
     };
 
-    let blocks: Vec<&Fragment> = slice.content.iter().collect();
-    let has_left = split_index_in_textblock > 0;
-    let has_right = split_index_in_textblock < child_count;
-    let merge_destinations = join_start && join_end && blocks.len() == 1;
-    let unjoined_start = usize::from(join_start);
-    let unjoined_end = if join_end {
-        blocks.len().saturating_sub(1)
-    } else {
-        blocks.len()
-    };
-    let merge_end = join_end && !merge_destinations && unjoined_end >= unjoined_start;
-    let unjoined_count = unjoined_end.saturating_sub(unjoined_start);
-    let unjoined_ends_with_page_break = unjoined_count > 0
-        && blocks
-            .get(unjoined_end - 1)
-            .is_some_and(|fragment| paragraph_ends_with_page_break(fragment));
-    let insert_at = textblock_index + usize::from(has_left);
+    let blocks: Vec<&Fragment> = plan.blocks.iter().collect();
+    let unjoined_count = plan.inserted_blocks.len();
 
-    let left_id = has_left.then_some(textblock_id);
-    let right_id = if has_left && has_right {
+    let left_id = plan.has_left.then_some(textblock_id);
+    let right_id = if plan.has_left && plan.has_right {
         tr.split_node(textblock_id, split_index_in_textblock)?;
         Some(
-            block_child_id(tr, container_id, textblock_index + 1)
+            block_child_id(tr, container_id, plan.textblock_index + 1)
                 .ok_or_else(|| CommandError::Corrupted("split produced no right half".into()))?,
         )
-    } else if has_right {
+    } else if plan.has_right {
         Some(textblock_id)
     } else {
         None
     };
-    if !has_left && !has_right {
+    if !plan.has_left && !plan.has_right {
         tr.remove_subtree(textblock_id)?;
     }
 
@@ -773,10 +2151,15 @@ fn insert_blocks_in_textblock(
     let mut inserted_range = InsertedRange::default();
     let mut terminal_page_break_start: Option<Position> = None;
 
-    if join_start {
+    if plan.join_start {
         let left_id = left_id.expect("merge start requires left destination content");
         let first = blocks[0];
         let inline = first.children.to_vec();
+        let insertable_inline = inline
+            .last()
+            .is_some_and(|fragment| fragment.node.as_type() == NodeType::PageBreak)
+            .then(|| &inline[..inline.len() - 1])
+            .unwrap_or(&inline);
         tr.set_selection(Some(Selection::collapsed(position_at_end_of_block(
             tr, left_id,
         )?)))?;
@@ -784,13 +2167,34 @@ fn insert_blocks_in_textblock(
             .selection()
             .expect("selection preserved through mutations")
             .head;
-        let inserted = insert_inline_fragments(tr, &inline, mode)?;
+        let inserted = insert_inline_fragments(tr, insertable_inline, mode)?;
         let inserted_page_break = insert_terminal_page_break_from_edge(tr, left_id, &inline)?;
         let end = tr
             .selection()
             .expect("selection preserved through mutations")
             .head;
+        if start.offset < end.offset {
+            inserted_range
+                .units
+                .extend(output_units_between(tr, start, end)?);
+        }
         if inserted_page_break {
+            let page_break = tr
+                .view()
+                .node(left_id)
+                .and_then(|paragraph| paragraph.last_child())
+                .and_then(|child| match child {
+                    ChildView::Leaf(leaf) if leaf.node_type() == NodeType::PageBreak => {
+                        Some(leaf.dot())
+                    }
+                    _ => None,
+                })
+                .ok_or_else(|| {
+                    CommandError::Corrupted(
+                        "planned terminal PageBreak output was not authored".into(),
+                    )
+                })?;
+            inserted_range.units.push(page_break);
             terminal_page_break_start = Some(start);
             last_caret = Some(end);
         } else if inserted {
@@ -799,34 +2203,38 @@ fn insert_blocks_in_textblock(
         }
     }
 
-    if merge_destinations {
+    if plan.merge_destinations {
         let left_id = left_id.expect("destination merge requires left content");
         tr.merge_node(left_id)?;
         last_caret = tr.selection().map(|s| s.head);
     }
 
-    for (offset, fragment) in blocks
-        .iter()
-        .take(unjoined_end)
-        .skip(unjoined_start)
-        .copied()
-        .enumerate()
-    {
-        let block_index = insert_at + offset;
-        tr.insert_subtree(container_id, block_index, fragment.clone().into_subtree())?;
-        if let Some(inserted_id) = block_child_id(tr, container_id, block_index) {
+    let mut inserted_blocks = Vec::with_capacity(unjoined_count);
+    for fragment in &plan.inserted_blocks {
+        let block_index = sequential_insert_index(
+            tr,
+            container_id,
+            plan.insert_at,
+            inserted_blocks.last().copied(),
+        );
+        if let Some(inserted_id) =
+            tr.insert_subtree(container_id, block_index, fragment.clone().into_subtree())?
+        {
+            inserted_blocks.push(inserted_id);
             inserted_range.include_block(inserted_id);
             if let Some(paint) = mode.plain_paint() {
                 paint_block_uniformly(tr, inserted_id, paint)?;
             }
-            // Block-level atoms are selectable as a range but have no inner caret.
-            if let Ok(position) = position_at_end_of_block(tr, inserted_id) {
-                last_caret = Some(position);
-            }
+            // Block-level atoms have no inner caret. Their planned end slot is
+            // the boundary immediately after the authored atom.
+            last_caret = Some(position_at_end_of_block(tr, inserted_id).or_else(|_| {
+                resolve_inserted_range_endpoint(tr, InsertedRangeEndpoint::AfterBlock(inserted_id))
+                    .ok_or(CommandError::NodeNotFound(inserted_id))
+            })?);
         }
     }
 
-    if merge_end {
+    if plan.merge_end {
         let right_id = right_id.expect("merge end requires right destination content");
         let last = blocks.last().unwrap();
         let inline = last.children.to_vec();
@@ -844,6 +2252,9 @@ fn insert_blocks_in_textblock(
             .head;
         if inserted {
             inserted_range.include_position_range(start, end);
+            inserted_range
+                .units
+                .extend(output_units_between(tr, start, end)?);
         }
         last_caret = Some(end);
         if let Some(paint) = mode.plain_paint() {
@@ -859,8 +2270,8 @@ fn insert_blocks_in_textblock(
     };
     tr.apply_steps(steps)?;
 
-    if !merge_end && unjoined_ends_with_page_break {
-        let following_id = block_child_id(tr, container_id, insert_at + unjoined_count)
+    if !plan.merge_end && plan.unjoined_ends_with_page_break {
+        let following_id = block_child_id(tr, container_id, plan.insert_at + unjoined_count)
             .ok_or_else(|| CommandError::Corrupted("PageBreak has no following block".into()))?;
         last_caret = Some(position_at_start_of_block(tr, following_id)?);
     }
@@ -869,48 +2280,77 @@ fn insert_blocks_in_textblock(
         if inserted_range.end.is_some() {
             inserted_range.prepend_position(start);
         } else {
-            let following_id = block_child_id(tr, container_id, insert_at).ok_or_else(|| {
-                CommandError::Corrupted("PageBreak has no following block".into())
-            })?;
+            let following_id =
+                block_child_id(tr, container_id, plan.insert_at).ok_or_else(|| {
+                    CommandError::Corrupted("PageBreak has no following block".into())
+                })?;
             let end = position_at_start_of_block(tr, following_id)?;
             inserted_range.include_position_range(start, end);
             last_caret = Some(end);
         }
     }
 
-    let live_right = right_id.filter(|id| tr.state().view().node(*id).is_some());
-    let live_left = left_id.filter(|id| tr.state().view().node(*id).is_some());
-    let mut final_pos = if let Some(position) = last_caret {
-        position
-    } else if let Some(right_id) = live_right {
-        position_at_start_of_block(tr, right_id)?
-    } else if let Some(left_id) = live_left {
-        position_at_end_of_block(tr, left_id)?
-    } else {
-        Position {
-            node: container_id,
-            offset: insert_at + unjoined_count,
-            affinity: Affinity::Upstream,
+    let mut final_pos = match (last_caret, plan.final_caret_at_right_boundary) {
+        (_, true) => position_at_start_of_block(
+            tr,
+            right_id.ok_or_else(|| {
+                CommandError::Corrupted(
+                    "planned textblock split lost its right caret boundary".into(),
+                )
+            })?,
+        )?,
+        (Some(position), false) => position,
+        (None, false) => {
+            return Err(CommandError::Corrupted(
+                "textblock Slice plan produced a different final caret".into(),
+            ));
         }
     };
     final_pos.affinity = Affinity::Downstream;
-    let explicit_inserted_selection = inserted_range.selection(tr);
-    let split_boundary_selection = if has_left && has_right && explicit_inserted_selection.is_none()
-    {
-        match (live_left, live_right) {
-            (Some(left_id), Some(right_id)) => Some(Selection::new(
-                position_at_end_of_block(tr, left_id)?,
-                position_at_start_of_block(tr, right_id)?,
-            )),
-            _ => None,
-        }
-    } else {
-        None
-    };
-    let inserted_selection = explicit_inserted_selection.or(split_boundary_selection);
+    let explicit_inserted_selection = inserted_range.selection(tr)?;
+    let split_boundary_selection =
+        if plan.has_left && plan.has_right && explicit_inserted_selection.is_none() {
+            match (left_id, right_id) {
+                (Some(left_id), Some(right_id)) => Some(Selection::new(
+                    position_at_end_of_block(tr, left_id)?,
+                    position_at_start_of_block(tr, right_id)?,
+                )),
+                _ => {
+                    return Err(CommandError::Corrupted(
+                        "planned textblock split lost a surviving boundary".into(),
+                    ));
+                }
+            }
+        } else {
+            None
+        };
+    let inserted_selection = explicit_inserted_selection
+        .or(split_boundary_selection)
+        .ok_or_else(|| {
+            CommandError::Corrupted("textblock Slice plan produced no inserted selection".into())
+        })?;
+    let output_units = expand_planned_list_output_units(
+        tr,
+        &inserted_range.units,
+        &inserted_blocks,
+        &plan.list_merges,
+    )?;
     tr.set_selection(Some(Selection::collapsed(final_pos)))?;
+    let inserted_selection = apply_planned_list_merges(
+        tr,
+        container_id,
+        plan.insert_at,
+        &inserted_blocks,
+        &plan.list_merges,
+        inserted_selection,
+    )?;
 
-    Ok(inserted_selection)
+    Ok(Some(SliceInsertionExecution {
+        inserted: inserted_selection,
+        units: output_units,
+        split_left: left_id,
+        split_right: right_id,
+    }))
 }
 
 fn position_at_end_of_block(tr: &Transaction, block_id: Dot) -> Result<Position, CommandError> {
@@ -927,21 +2367,21 @@ fn position_at_end_of_block(tr: &Transaction, block_id: Dot) -> Result<Position,
 
 fn position_at_start_of_block(tr: &Transaction, block_id: Dot) -> Result<Position, CommandError> {
     let view = tr.state().view();
-    if view.node(block_id).is_none() {
-        return Err(CommandError::NodeNotFound(block_id));
+    if let Some(block) = view.node(block_id) {
+        return first_cursor_position(&block)
+            .ok_or_else(|| CommandError::Corrupted("block has no position at its start".into()));
     }
-    Ok(Position {
-        node: block_id,
-        offset: 0,
-        affinity: Affinity::Downstream,
-    })
+    let (parent, index) =
+        block_parent_and_index(&view, block_id).ok_or(CommandError::NodeNotFound(block_id))?;
+    Ok(Position::new(parent, index))
 }
 
 pub(crate) fn insert_blocks_at_block_boundary(
     tr: &mut Transaction,
     position: Position,
     blocks: Vec<Fragment>,
-) -> Result<Option<Selection>, CommandError> {
+    list_merges: Vec<PlannedListMerge>,
+) -> Result<Option<SliceInsertionExecution>, CommandError> {
     let container_id = position.node;
     let base_index = position.offset;
     let block_count = blocks.len();
@@ -954,29 +2394,18 @@ pub(crate) fn insert_blocks_at_block_boundary(
         // of trusting `base_index + offset` arithmetic — that arithmetic is
         // what used to anchor an insert on a synthetic scaffold (no CRDT
         // identity) and fail with NodeNotFound.
-        let mut known = {
-            let view = tr.state().view();
-            real_child_ids(&view, container_id)
-        };
         for block in blocks.iter() {
             let subtree = block.clone().into_subtree();
-            let index = {
-                let view = tr.state().view();
-                inserted
-                    .last()
-                    .and_then(|prev| block_parent_and_index(&view, *prev))
-                    .and_then(|(parent, index)| (parent == container_id).then_some(index + 1))
-                    .unwrap_or(base_index)
-            };
-            tr.insert_subtree(container_id, index, subtree)?;
-            let view = tr.state().view();
-            if let Some(new_id) = real_child_ids(&view, container_id)
-                .into_iter()
-                .find(|id| !known.contains(id))
-            {
-                known.push(new_id);
-                inserted.push(new_id);
-            }
+            let index =
+                sequential_insert_index(tr, container_id, base_index, inserted.last().copied());
+            let new_id = tr
+                .insert_subtree(container_id, index, subtree)?
+                .ok_or_else(|| {
+                    CommandError::Corrupted(
+                        "planned block Slice insertion produced no authored node".into(),
+                    )
+                })?;
+            inserted.push(new_id);
         }
         let steps = {
             let view = tr.state().view();
@@ -988,56 +2417,204 @@ pub(crate) fn insert_blocks_at_block_boundary(
         Ok::<(), CommandError>(())
     })?;
 
-    let last_inserted_index = inserted.last().copied().and_then(|id| {
-        let view = tr.state().view();
-        let (parent, index) = block_parent_and_index(&view, id)?;
-        (parent == container_id).then_some(index)
-    });
-    let trailing_synthetic = terminal_page_break
-        .then(|| block_child_id(tr, container_id, last_inserted_index? + 1))
-        .flatten()
-        .filter(|id| id.is_synthetic());
-    let final_position = trailing_synthetic
-        .and_then(|id| position_at_start_of_block(tr, id).ok())
-        .or_else(|| {
-            inserted
-                .last()
-                .and_then(|id| position_at_end_of_block(tr, *id).ok())
-        });
-    if let Some(mut final_pos) = final_position {
-        final_pos.affinity = Affinity::Downstream;
-        tr.set_selection(Some(Selection::collapsed(final_pos)))?;
+    if inserted.len() != block_count {
+        return Err(CommandError::Corrupted(
+            "planned block Slice insertion produced an incomplete output forest".into(),
+        ));
     }
+    let first_inserted_index = inserted
+        .first()
+        .copied()
+        .and_then(|id| {
+            let view = tr.state().view();
+            let (parent, index) = block_parent_and_index(&view, id)?;
+            (parent == container_id).then_some(index)
+        })
+        .ok_or_else(|| {
+            CommandError::Corrupted("planned block Slice start output no longer resolves".into())
+        })?;
+    let last_inserted_index = inserted
+        .last()
+        .copied()
+        .and_then(|id| {
+            let view = tr.state().view();
+            let (parent, index) = block_parent_and_index(&view, id)?;
+            (parent == container_id).then_some(index)
+        })
+        .ok_or_else(|| {
+            CommandError::Corrupted("planned block Slice end output no longer resolves".into())
+        })?;
+    let span = last_inserted_index
+        .checked_sub(first_inserted_index)
+        .and_then(|distance| distance.checked_add(1))
+        .filter(|span| *span == inserted.len())
+        .ok_or_else(|| {
+            CommandError::Corrupted(
+                "planned block Slice outputs are no longer one contiguous range".into(),
+            )
+        })?;
+    let start_index = first_inserted_index;
 
-    let first_inserted_index = inserted.first().copied().and_then(|id| {
-        let view = tr.state().view();
-        let (parent, index) = block_parent_and_index(&view, id)?;
-        (parent == container_id).then_some(index)
-    });
-    let (start_index, span) = match (first_inserted_index, last_inserted_index) {
-        (Some(first), Some(last)) => (first, last - first + 1),
-        _ => (base_index, block_count),
+    let mut final_pos = if terminal_page_break {
+        let following =
+            block_child_id(tr, container_id, last_inserted_index + 1).ok_or_else(|| {
+                CommandError::Corrupted("planned PageBreak output has no following block".into())
+            })?;
+        position_at_start_of_block(tr, following)?
+    } else {
+        let last = *inserted
+            .last()
+            .ok_or_else(|| CommandError::Corrupted("planned block Slice output is empty".into()))?;
+        position_at_end_of_block(tr, last).or_else(|_| {
+            resolve_inserted_range_endpoint(tr, InsertedRangeEndpoint::AfterBlock(last))
+                .ok_or(CommandError::NodeNotFound(last))
+        })?
     };
-    Ok(Some(selection_over_inserted_blocks(
+    final_pos.affinity = Affinity::Downstream;
+    tr.set_selection(Some(Selection::collapsed(final_pos)))?;
+
+    let inserted_selection = selection_over_inserted_blocks(container_id, start_index, span);
+    let output_units = expand_planned_list_output_units(tr, &inserted, &inserted, &list_merges)?;
+    let inserted_selection = apply_planned_list_merges(
+        tr,
         container_id,
         start_index,
-        span,
-    )))
+        &inserted,
+        &list_merges,
+        inserted_selection,
+    )?;
+    Ok(Some(SliceInsertionExecution {
+        inserted: inserted_selection,
+        units: output_units,
+        split_left: None,
+        split_right: None,
+    }))
 }
 
-fn real_child_ids(view: &DocView, container_id: Dot) -> Vec<Dot> {
-    view.node(container_id)
-        .map(|container| {
-            container
-                .children()
-                .map(|child| match child {
-                    ChildView::Block(block) => block.id(),
-                    ChildView::Leaf(leaf) => leaf.dot(),
-                })
-                .filter(|id| id.as_op_dot().is_some())
-                .collect()
-        })
-        .unwrap_or_default()
+fn apply_planned_list_merges(
+    tr: &mut Transaction,
+    container_id: Dot,
+    start_index: usize,
+    inserted: &[Dot],
+    merges: &[PlannedListMerge],
+    mut inserted_selection: Selection,
+) -> Result<Selection, CommandError> {
+    let left = start_index
+        .checked_sub(1)
+        .and_then(|index| block_child_id(tr, container_id, index));
+    let right = block_child_id(tr, container_id, start_index + inserted.len());
+    let resolve_member = |member: PlannedListMember| match member {
+        PlannedListMember::Left(_) => left,
+        PlannedListMember::Inserted { index, .. } => inserted.get(index).copied(),
+        PlannedListMember::Right(_) => right,
+    };
+
+    for planned in merges {
+        let pair = {
+            let view = tr.state().view();
+            let earlier_id = resolve_member(planned.earlier).ok_or_else(|| {
+                CommandError::Corrupted("planned earlier list output is unavailable".into())
+            })?;
+            let later_id = resolve_member(planned.later).ok_or_else(|| {
+                CommandError::Corrupted("planned later list output is unavailable".into())
+            })?;
+            let earlier = view
+                .node(earlier_id)
+                .ok_or(CommandError::NodeNotFound(earlier_id))?;
+            let later = view
+                .node(later_id)
+                .ok_or(CommandError::NodeNotFound(later_id))?;
+            if earlier.node_type() != planned.earlier.node_type()
+                || later.node_type() != planned.later.node_type()
+                || earlier.parent().map(|parent| parent.id()) != Some(container_id)
+                || later.parent().map(|parent| parent.id()) != Some(container_id)
+                || earlier.index().and_then(|index| index.checked_add(1)) != later.index()
+            {
+                return Err(CommandError::Corrupted(
+                    "planned adjacent-list merge no longer matches its bound outputs".into(),
+                ));
+            }
+            (earlier_id, later_id)
+        };
+        let selection = tr.selection();
+        let stable = selection.map(|selection| StableSelection::capture(&selection, &tr.view()));
+        let inserted_stable = StableSelection::capture(&inserted_selection, &tr.view());
+        let merged_lists = merge_adjacent_list_pair(tr, pair.0, pair.1)?;
+        if let Some((selection, stable)) = selection.zip(stable) {
+            restore_selection_after_adjacent_list_merge(tr, selection, stable, &merged_lists)?;
+        }
+        inserted_selection = resolve_selection_after_adjacent_list_merge(
+            tr,
+            inserted_selection,
+            inserted_stable,
+            &merged_lists,
+        )?;
+    }
+    Ok(inserted_selection)
+}
+
+fn expand_planned_list_output_units(
+    tr: &Transaction,
+    units: &[Dot],
+    inserted: &[Dot],
+    merges: &[PlannedListMerge],
+) -> Result<Vec<Dot>, CommandError> {
+    let mut merged_inserted = vec![false; inserted.len()];
+    for planned in merges {
+        for member in [planned.earlier, planned.later] {
+            if let PlannedListMember::Inserted { index, .. } = member {
+                let merged = merged_inserted.get_mut(index).ok_or_else(|| {
+                    CommandError::Corrupted(
+                        "planned list merge referenced an unavailable inserted block".into(),
+                    )
+                })?;
+                *merged = true;
+            }
+        }
+    }
+
+    let view = tr.view();
+    let mut output = Vec::new();
+    for unit in units {
+        let Some(index) = inserted.iter().position(|inserted| inserted == unit) else {
+            output.push(*unit);
+            continue;
+        };
+        if !merged_inserted[index] {
+            output.push(*unit);
+            continue;
+        }
+        let list = view.node(*unit).ok_or(CommandError::NodeNotFound(*unit))?;
+        if !is_list_type(list.node_type()) {
+            return Err(CommandError::Corrupted(
+                "planned list merge output is not a list".into(),
+            ));
+        }
+        let items = list
+            .child_blocks()
+            .map(|item| item.id())
+            .collect::<Vec<_>>();
+        if items.is_empty() {
+            return Err(CommandError::Corrupted(
+                "planned list merge output contains no list item".into(),
+            ));
+        }
+        output.extend(items);
+    }
+    Ok(output)
+}
+
+fn sequential_insert_index(
+    tr: &Transaction,
+    container_id: Dot,
+    base_index: usize,
+    previous: Option<Dot>,
+) -> usize {
+    let view = tr.state().view();
+    previous
+        .and_then(|previous| block_parent_and_index(&view, previous))
+        .and_then(|(parent, index)| (parent == container_id).then_some(index + 1))
+        .unwrap_or(base_index)
 }
 
 pub(crate) fn block_boundary_fragments(
@@ -1172,7 +2749,7 @@ fn resolve_inserted_range_endpoint(
 
 /// Parent id and full child-slot index of `id`, which may be a real block or a
 /// block-level atom leaf (which projects as a `Child::Leaf`, not a node).
-fn block_parent_and_index(view: &DocView, id: Dot) -> Option<(Dot, usize)> {
+pub(crate) fn block_parent_and_index(view: &DocView, id: Dot) -> Option<(Dot, usize)> {
     if let Some(node) = view.node(id) {
         let parent = node.parent()?;
         let index = node.index()?;
@@ -1189,328 +2766,4 @@ fn block_parent_and_index(view: &DocView, id: Dot) -> Option<(Dot, usize)> {
         return Some((parent.id(), index));
     }
     None
-}
-
-/// Recursion-depth ceiling and WRAP/SPLIT operation budget for one repair
-/// invocation. Clipboard HTML is external input, so — like the projection repair's
-/// `RepairCtx` — the pass is bounded: past either limit it stops restructuring and
-/// leaves the (partially repaired) fragments for the projection layer to absorb.
-/// Both are far above any real paste; they exist only to cap pathological input.
-const REPAIR_DEPTH_LIMIT: usize = 128;
-const REPAIR_OP_BUDGET: usize = 4096;
-
-/// Restructure each top-level slice fragment's subtree so every node satisfies its
-/// schema content model before the insert-shape decision, applying the same
-/// WRAP / SPLIT-HOIST algebra the projection repair uses — on the dot-less
-/// `Fragment` tree. A misfit child is either wrapped in the minimal scaffold chain
-/// (`wrap_chain`) that makes it legal in place, or split out: the container keeps
-/// the fitting prefix and the residue is promoted to the container's parent level
-/// (a trailing scaffold of the container's own type carries any following
-/// children) to be re-examined and re-placed. Ancestors above the top-level
-/// fragments are unknown at this point; `Root` is assumed so that Root-anchored
-/// contexts (e.g. `PageBreak`) stay legal. One pass, proportional to slice size;
-/// nothing is dropped.
-pub(crate) fn repair_slice_fragments(fragments: &mut [Fragment]) {
-    let mut budget = REPAIR_OP_BUDGET;
-    for fragment in fragments.iter_mut() {
-        repair_fragment_subtree(fragment, &[NodeType::Root], &mut budget);
-    }
-}
-
-fn repair_fragment_subtree(fragment: &mut Fragment, ancestors: &[NodeType], budget: &mut usize) {
-    let container = fragment.node.as_type();
-    let mut path: Vec<NodeType> = ancestors.to_vec();
-    path.push(container);
-    let hoist = repair_fragment_children(container, &mut fragment.children, &mut path, budget);
-    fragment.children.extend(hoist);
-}
-
-/// Repair `children` against `container`'s content model (`path` ends with
-/// `container`), recursing into each fitting child. Returns the forest to hoist to
-/// `container`'s parent level (empty when self-contained). Stops early once the
-/// depth ceiling or op budget is reached.
-fn repair_fragment_children(
-    container: NodeType,
-    children: &mut Vec<Fragment>,
-    path: &mut Vec<NodeType>,
-    budget: &mut usize,
-) -> Vec<Fragment> {
-    if path.len() > REPAIR_DEPTH_LIMIT {
-        return Vec::new();
-    }
-    let mut i = 0;
-    while i < children.len() {
-        if *budget == 0 {
-            break;
-        }
-        if fragment_is_misfit(container, children, i, path) {
-            match scaffold_chain_for(path, children[i].node.as_type()) {
-                Some(chain) => {
-                    *budget -= 1;
-                    wrap_fragment(children, i, &chain);
-                    continue;
-                }
-                None => {
-                    *budget -= 1;
-                    return split_hoist_fragment(container, children, i);
-                }
-            }
-        }
-        let child = children[i].node.as_type();
-        path.push(child);
-        let hoist = repair_fragment_children(child, &mut children[i].children, path, budget);
-        path.pop();
-        if !hoist.is_empty() {
-            children.splice(i + 1..i + 1, hoist);
-        }
-        i += 1;
-    }
-    Vec::new()
-}
-
-fn fragment_is_misfit(
-    container: NodeType,
-    children: &[Fragment],
-    i: usize,
-    path: &[NodeType],
-) -> bool {
-    if container == NodeType::Unknown {
-        return false;
-    }
-    let child = children[i].node.as_type();
-    if child != NodeType::Unknown && !context_allows(path, child) {
-        return true;
-    }
-    fragment_content_residue(container, children) == Some(i)
-}
-
-/// Index of the first child `container`'s content model cannot admit in sequence
-/// order (the first child past the greedily consumable prefix). `Unknown` children
-/// are transparent. `None` when the children form a completable prefix — missing
-/// required trailing slots are a completion concern, not a residue.
-fn fragment_content_residue(container: NodeType, children: &[Fragment]) -> Option<usize> {
-    if container == NodeType::Unknown {
-        return None;
-    }
-    let reals: Vec<(usize, NodeType)> = children
-        .iter()
-        .enumerate()
-        .filter_map(|(i, c)| {
-            let t = c.node.as_type();
-            (t != NodeType::Unknown).then_some((i, t))
-        })
-        .collect();
-    let types: Vec<NodeType> = reals.iter().map(|(_, t)| *t).collect();
-    let consumed = greedy_consume(&Schema::node_spec(container).content, &types);
-    (consumed < reals.len()).then(|| reals[consumed].0)
-}
-
-/// How many of `types` the content expr consumes from the front, greedily — the
-/// dot-less mirror of the projection repair's consume walk.
-fn greedy_consume(expr: &ContentExpr, types: &[NodeType]) -> usize {
-    fn matches_at(e: &ContentExpr, types: &[NodeType], idx: usize) -> bool {
-        types.get(idx).is_some_and(|t| e.matches(*t))
-    }
-    fn walk(expr: &ContentExpr, types: &[NodeType], idx: &mut usize) {
-        match expr {
-            ContentExpr::Empty => {}
-            ContentExpr::Any => *idx = types.len(),
-            ContentExpr::Single(t) => {
-                if types.get(*idx) == Some(t) {
-                    *idx += 1;
-                }
-            }
-            ContentExpr::Optional(inner) => {
-                if matches_at(inner, types, *idx) {
-                    walk(inner, types, idx);
-                }
-            }
-            ContentExpr::ZeroOrMore(inner) | ContentExpr::OneOrMore(inner) => {
-                while matches_at(inner, types, *idx) {
-                    walk(inner, types, idx);
-                }
-            }
-            ContentExpr::Choice(cs) => {
-                if let Some(c) = cs.iter().find(|c| matches_at(c, types, *idx)) {
-                    walk(c, types, idx);
-                }
-            }
-            ContentExpr::Seq(es) => {
-                for e in es {
-                    walk(e, types, idx);
-                }
-            }
-        }
-    }
-    let mut idx = 0;
-    walk(expr, types, &mut idx);
-    idx
-}
-
-fn scaffold_chain_for(path: &[NodeType], child: NodeType) -> Option<Vec<NodeType>> {
-    let chain = wrap_chain(path, child)?;
-    (!chain.is_empty()).then_some(chain)
-}
-
-fn wrap_fragment(children: &mut Vec<Fragment>, i: usize, chain: &[NodeType]) {
-    let mut current = children.remove(i);
-    for &role in chain.iter().rev() {
-        current = Fragment::leaf(role.into_node().to_plain()).with_children(vec![current]);
-    }
-    children.insert(i, current);
-}
-
-fn split_hoist_fragment(
-    container: NodeType,
-    children: &mut Vec<Fragment>,
-    k: usize,
-) -> Vec<Fragment> {
-    let tail = children.split_off(k + 1);
-    let promoted = children.pop().expect("k is a valid child index");
-    let mut out = vec![promoted];
-    if !tail.is_empty() {
-        out.push(Fragment::leaf(container.into_node().to_plain()).with_children(tail));
-    }
-    out
-}
-
-#[cfg(test)]
-mod repair_tests {
-    use super::*;
-    use editor_model::{PlainBulletListNode, PlainListItemNode, PlainPageBreakNode, PlainTextNode};
-
-    fn text(t: &str) -> Fragment {
-        Fragment::leaf(PlainNode::Text(PlainTextNode { text: t.into() }))
-    }
-
-    fn page_break() -> Fragment {
-        Fragment::leaf(PlainNode::PageBreak(PlainPageBreakNode::default()))
-    }
-
-    fn para(children: Vec<Fragment>) -> Fragment {
-        Fragment::leaf(PlainNode::Paragraph(PlainParagraphNode::default())).with_children(children)
-    }
-
-    fn list_item(children: Vec<Fragment>) -> Fragment {
-        Fragment::leaf(PlainNode::ListItem(PlainListItemNode::default())).with_children(children)
-    }
-
-    fn bullet_list(children: Vec<Fragment>) -> Fragment {
-        Fragment::leaf(PlainNode::BulletList(PlainBulletListNode::default()))
-            .with_children(children)
-    }
-
-    fn types(fragments: &[Fragment]) -> Vec<NodeType> {
-        fragments.iter().map(|f| f.node.as_type()).collect()
-    }
-
-    #[test]
-    fn keeps_list_item_with_two_paragraphs() {
-        let mut content = vec![bullet_list(vec![list_item(vec![
-            para(vec![text("a")]),
-            para(vec![text("b")]),
-        ])])];
-
-        repair_slice_fragments(&mut content);
-
-        assert_eq!(types(&content), vec![NodeType::BulletList]);
-        let items = &content[0].children;
-        assert_eq!(types(items), vec![NodeType::ListItem]);
-        assert_eq!(
-            items[0].children,
-            vec![para(vec![text("a")]), para(vec![text("b")])]
-        );
-    }
-
-    #[test]
-    fn keeps_list_item_with_three_paragraphs() {
-        let mut content = vec![bullet_list(vec![list_item(vec![
-            para(vec![text("a")]),
-            para(vec![text("b")]),
-            para(vec![text("c")]),
-        ])])];
-
-        repair_slice_fragments(&mut content);
-
-        let items = &content[0].children;
-        assert_eq!(types(items), vec![NodeType::ListItem]);
-        assert_eq!(
-            items[0].children,
-            vec![
-                para(vec![text("a")]),
-                para(vec![text("b")]),
-                para(vec![text("c")]),
-            ]
-        );
-    }
-
-    #[test]
-    fn keeps_trailing_paragraph_after_nested_list_in_same_item() {
-        let mut content = vec![bullet_list(vec![list_item(vec![
-            para(vec![text("a")]),
-            bullet_list(vec![list_item(vec![para(vec![text("x")])])]),
-            para(vec![text("b")]),
-        ])])];
-
-        repair_slice_fragments(&mut content);
-
-        let items = &content[0].children;
-        assert_eq!(types(items), vec![NodeType::ListItem]);
-        assert_eq!(
-            types(&items[0].children),
-            vec![
-                NodeType::Paragraph,
-                NodeType::BulletList,
-                NodeType::Paragraph,
-            ]
-        );
-        assert_eq!(items[0].children[2], para(vec![text("b")]));
-    }
-
-    #[test]
-    fn leaves_valid_list_unchanged() {
-        let mut content = vec![bullet_list(vec![
-            list_item(vec![para(vec![text("a")])]),
-            list_item(vec![para(vec![text("b")])]),
-        ])];
-        let before = content.clone();
-
-        repair_slice_fragments(&mut content);
-
-        assert_eq!(content, before);
-    }
-
-    #[test]
-    fn leaves_bare_inline_fragments_unchanged() {
-        let mut content = vec![text("a"), text("b")];
-        let before = content.clone();
-
-        repair_slice_fragments(&mut content);
-
-        assert_eq!(content, before);
-    }
-
-    #[test]
-    fn keeps_page_break_in_top_level_paragraph() {
-        // PageBreak's context is `Root > Paragraph > &`; assuming `Root` above the
-        // top-level fragments keeps it legal so the repair does not hoist it out.
-        let mut content = vec![para(vec![text("a"), page_break()])];
-        let before = content.clone();
-
-        repair_slice_fragments(&mut content);
-
-        assert_eq!(content, before);
-    }
-
-    #[test]
-    fn deeply_nested_input_terminates() {
-        // Clipboard HTML is external; nesting far past the depth ceiling must return
-        // (the cap stops descent) rather than overflow the stack.
-        let mut inner = para(vec![text("x")]);
-        for _ in 0..(REPAIR_DEPTH_LIMIT * 4) {
-            inner = bullet_list(vec![list_item(vec![inner])]);
-        }
-        let mut content = vec![inner];
-        repair_slice_fragments(&mut content);
-    }
 }

--- a/crates/editor-commands/src/helpers/slice/page_break.rs
+++ b/crates/editor-commands/src/helpers/slice/page_break.rs
@@ -1,55 +1,9 @@
-use editor_clipboard::Slice;
 use editor_crdt::Dot;
-use editor_model::{DocView, Fragment, NodeType, PlainNode, PlainParagraphNode};
-use editor_state::Position;
+use editor_model::{Fragment, NodeType};
 use editor_transaction::Transaction;
 
-use super::{fragments_are_inline, position_in_textblock, top_level_fragments};
 use crate::CommandResult;
-use crate::helpers::{find_ancestor_textblock, insert_terminal_page_break_into_root_paragraph};
-
-pub(crate) fn prepare_page_breaks_for_position(
-    view: &DocView,
-    position: &Position,
-    slice: Slice,
-) -> Slice {
-    if !contains_page_break(&slice.content) {
-        return slice;
-    }
-
-    let in_textblock = position_in_textblock(view, position);
-    let root_textblock = in_textblock && position_is_in_root_paragraph(view, position);
-    let root_boundary = !in_textblock && position.node == Dot::ROOT;
-    let inserts_root_paragraph = root_textblock || root_boundary;
-    let top_level_inline = fragments_are_inline(&top_level_fragments(&slice));
-
-    let sanitized = if top_level_inline {
-        sanitize_page_break_siblings(slice.content, inserts_root_paragraph)
-    } else {
-        sanitize_structural_page_break_roots(slice.content, inserts_root_paragraph)
-    };
-    let content = sanitized.fragments;
-
-    if content.is_empty() {
-        return Slice::new(vec![], 0, 0);
-    }
-
-    let terminal_bare_page_break =
-        top_level_inline && content.last().is_some_and(is_page_break_fragment);
-    if root_textblock && terminal_bare_page_break {
-        return Slice::new(vec![paragraph_with_children(content)], 1, 1);
-    }
-
-    if root_boundary && top_level_inline {
-        Slice::new(vec![paragraph_with_children(content)], 0, 0)
-    } else {
-        Slice::new(
-            content,
-            slice.open_start.min(sanitized.open_start),
-            slice.open_end.min(sanitized.open_end),
-        )
-    }
-}
+use crate::helpers::insert_terminal_page_break_into_root_paragraph;
 
 pub(super) fn insert_terminal_page_break_from_edge(
     tr: &mut Transaction,
@@ -62,135 +16,11 @@ pub(super) fn insert_terminal_page_break_from_edge(
     insert_terminal_page_break_into_root_paragraph(tr, paragraph_id)
 }
 
-struct SanitizedPageBreaks {
-    fragments: Vec<Fragment>,
-    open_start: u32,
-    open_end: u32,
-}
-
-struct SanitizedPageBreakFragment {
-    fragment: Fragment,
-    open_start: u32,
-    open_end: u32,
-}
-
-fn sanitize_page_break_fragment(
-    mut fragment: Fragment,
-    root_paragraph: bool,
-) -> Option<SanitizedPageBreakFragment> {
-    let allow_terminal_page_break =
-        root_paragraph && fragment.node.as_type() == NodeType::Paragraph;
-    let had_children = !fragment.children.is_empty();
-    let sanitized = sanitize_page_break_siblings(fragment.children, allow_terminal_page_break);
-    fragment.children = sanitized.fragments;
-    (!had_children || !fragment.children.is_empty()).then_some(SanitizedPageBreakFragment {
-        fragment,
-        open_start: sanitized.open_start.saturating_add(1),
-        open_end: sanitized.open_end.saturating_add(1),
-    })
-}
-
-fn sanitize_page_break_siblings(
-    fragments: Vec<Fragment>,
-    allow_terminal_page_break: bool,
-) -> SanitizedPageBreaks {
-    let original_len = fragments.len();
-    let terminal_page_break = fragments
-        .len()
-        .checked_sub(1)
-        .filter(|&index| allow_terminal_page_break && is_page_break_fragment(&fragments[index]));
-
-    let retained: Vec<_> = fragments
-        .into_iter()
-        .enumerate()
-        .filter_map(|(index, fragment)| {
-            if is_page_break_fragment(&fragment) {
-                return (Some(index) == terminal_page_break).then_some((
-                    index,
-                    SanitizedPageBreakFragment {
-                        fragment,
-                        open_start: 1,
-                        open_end: 1,
-                    },
-                ));
-            }
-            sanitize_page_break_fragment(fragment, false).map(|fragment| (index, fragment))
-        })
-        .collect();
-    finish_page_break_sanitization(retained, original_len)
-}
-
-fn sanitize_structural_page_break_roots(
-    fragments: Vec<Fragment>,
-    allow_root_paragraph: bool,
-) -> SanitizedPageBreaks {
-    let original_len = fragments.len();
-    let retained = fragments
-        .into_iter()
-        .enumerate()
-        .filter_map(|(index, fragment)| {
-            if is_page_break_fragment(&fragment) {
-                return None;
-            }
-            let root_paragraph =
-                allow_root_paragraph && fragment.node.as_type() == NodeType::Paragraph;
-            sanitize_page_break_fragment(fragment, root_paragraph).map(|fragment| (index, fragment))
-        })
-        .collect();
-    finish_page_break_sanitization(retained, original_len)
-}
-
-fn finish_page_break_sanitization(
-    retained: Vec<(usize, SanitizedPageBreakFragment)>,
-    original_len: usize,
-) -> SanitizedPageBreaks {
-    let open_start = retained
-        .first()
-        .filter(|(index, _)| *index == 0)
-        .map_or(0, |(_, fragment)| fragment.open_start);
-    let open_end = retained
-        .last()
-        .filter(|(index, _)| *index + 1 == original_len)
-        .map_or(0, |(_, fragment)| fragment.open_end);
-    SanitizedPageBreaks {
-        fragments: retained
-            .into_iter()
-            .map(|(_, fragment)| fragment.fragment)
-            .collect(),
-        open_start,
-        open_end,
-    }
-}
-
-fn is_page_break_fragment(fragment: &Fragment) -> bool {
-    fragment.node.as_type() == NodeType::PageBreak
-}
-
-fn contains_page_break(fragments: &[Fragment]) -> bool {
-    fragments
-        .iter()
-        .any(|fragment| is_page_break_fragment(fragment) || contains_page_break(&fragment.children))
-}
-
 pub(super) fn paragraph_ends_with_page_break(fragment: &Fragment) -> bool {
     fragment.node.as_type() == NodeType::Paragraph
         && fragment.children.last().is_some_and(is_page_break_fragment)
 }
 
-fn paragraph_with_children(children: Vec<Fragment>) -> Fragment {
-    Fragment {
-        node: PlainNode::Paragraph(PlainParagraphNode::default()),
-        modifiers: vec![],
-        carry: vec![],
-        children,
-    }
-}
-
-fn position_is_in_root_paragraph(view: &DocView, position: &Position) -> bool {
-    find_ancestor_textblock(view, position.node).is_some_and(|id| {
-        view.node(id).is_some_and(|node| {
-            node.node_type() == NodeType::Paragraph
-                && node.parent().is_some_and(|parent| parent.id() == Dot::ROOT)
-        })
-    })
+fn is_page_break_fragment(fragment: &Fragment) -> bool {
+    fragment.node.as_type() == NodeType::PageBreak
 }

--- a/crates/editor-commands/src/judgments/mod.rs
+++ b/crates/editor-commands/src/judgments/mod.rs
@@ -8,8 +8,14 @@ pub use list_kind::judge_toggle_list_kind;
 pub use selection::{
     judge_expand_all, judge_expand_paragraph, judge_expand_sentence, judge_expand_word,
 };
-pub use slice::{SliceInsertionPlan, resolve_slice_insertion};
+pub use slice::{FitOutcome, SliceFitPlan, fit_slice};
 
 pub(crate) use list::{lift_selected_list_items, sink_selected_list_items};
 pub(crate) use list_kind::{judge_lift_list_items_of_kind, judge_set_list_kind};
-pub(crate) use slice::insert_slice_at_position;
+pub(crate) use slice::{
+    AppliedSliceInsertion, CellFillPlan, JoinedReplacementPlan, LinearFinalSelection,
+    LinearFitPlan, LinearMutation, PlannedBoundaryInsertion, PlannedBranchInsertion,
+    PlannedBranchNode, PlannedBranchSplit, PlannedJoin, PlannedOutputKey, RangePlacement,
+    SliceFitPlanKind, SliceInsertionPlan, TableFinalSelection, TableGridPlan,
+    apply_slice_insertion_plan,
+};

--- a/crates/editor-commands/src/judgments/slice.rs
+++ b/crates/editor-commands/src/judgments/slice.rs
@@ -5,187 +5,652 @@ use editor_transaction::Transaction;
 
 use crate::CommandError;
 use crate::helpers::{
-    block_boundary_fragments, build_inline_mode, can_splice_textblock, find_ancestor_textblock,
-    fit_slice_for_textblock_parent, fragments_are_inline, fragments_fit_parent,
-    insert_blocks_at_block_boundary, insert_blocks_in_textblock_at_position,
-    insert_content_as_inline_at_position, insert_open_list_items_in_textblock_at_position,
-    is_insertable_inline_fragment, materialize_position_block,
-    open_inline_content_for_textblock_insert, open_list_items_for_textblock_insert,
-    position_in_textblock, prepare_page_breaks_for_position, repair_slice_fragments,
-    splice_emits_change, top_level_fragments,
+    ExistingBlock, HoistBoundaryStep, HoistInitialBoundary, HoistedBlockInsertionPlan,
+    OpenAncestorSplice, SliceInsertionExecution, SliceInsertionOutputPlan, SliceInsertionTarget,
+    SliceInsertionTargetShape, SliceOutputSource, TextblockSplicePlan, block_boundary_fragments,
+    build_inline_mode, fit_slice_for_textblock_target_parent, fragments_are_inline,
+    fragments_fit_parent, inline_fragments_fit_target, insert_blocks_at_block_boundary,
+    insert_blocks_in_textblock_at_position, insert_content_as_inline_at_position,
+    insert_hoisted_blocks_at_position, insert_open_ancestor_splice_at_position,
+    is_insertable_inline_fragment, is_supported_inline_fragment, materialize_repair_position,
+    open_ancestor_splice_for_target, open_ancestor_splice_is_complete_no_output,
+    open_inline_content_for_target, plan_textblock_splice_target, planned_block_output,
+    planned_inline_output, planned_open_splice_output, top_level_fragments,
 };
 use crate::types::SliceProvenance;
 
-pub enum SliceInsertionPlan {
-    DirectInline { fragments: Vec<Fragment> },
-    SpliceOpenListItems { items: Vec<Fragment> },
-    SpliceBlocks { candidate: Slice },
-    OpenInline { fragments: Vec<Fragment> },
-    BlockBoundary { blocks: Vec<Fragment> },
+mod fitter;
+mod fragment_fitter;
+mod linear_fitter;
+mod table_fitter;
+pub(crate) use fitter::SliceFitPlanKind;
+pub use fitter::{FitOutcome, SliceFitPlan, fit_slice};
+pub(crate) use fragment_fitter::fit_fragment_forest;
+pub(crate) use linear_fitter::{
+    JoinedReplacementPlan, LinearFinalSelection, LinearFitPlan, LinearMutation,
+    PlannedBoundaryInsertion, PlannedBranchInsertion, PlannedBranchNode, PlannedBranchSplit,
+    PlannedJoin, PlannedOutputKey, RangePlacement,
+};
+pub(crate) use table_fitter::{CellFillPlan, TableFinalSelection, TableGridPlan};
+
+pub(crate) enum SliceInsertionPlan {
+    DirectInline {
+        fragments: Vec<Fragment>,
+        output: SliceInsertionOutputPlan,
+    },
+    SpliceOpenAncestors {
+        destination: Vec<editor_crdt::Dot>,
+        source: Fragment,
+        output: SliceInsertionOutputPlan,
+    },
+    SpliceBlocks {
+        plan: TextblockSplicePlan,
+        output: SliceInsertionOutputPlan,
+    },
+    HoistBlocks {
+        plan: HoistedBlockInsertionPlan,
+        output: SliceInsertionOutputPlan,
+    },
+    OpenInline {
+        fragments: Vec<Fragment>,
+        output: SliceInsertionOutputPlan,
+    },
+    BlockBoundary {
+        blocks: Vec<Fragment>,
+        list_merges: Vec<crate::helpers::PlannedListMerge>,
+        output: SliceInsertionOutputPlan,
+    },
 }
 
-/// 삽입 후보 판정의 3-state 결과. 카스케이드의 "실패"에는 두 가지 서로 다른
-/// 원인이 있어 이를 구별한다: 슬라이스 자체가 비어 콘텐츠가 없는 경우(`Empty`)와,
-/// 슬라이스는 비어있지 않지만 이 위치에 들어맞는 삽입 형태가 없는 경우(`NoFit`).
-/// 호출부(`insert_slice_at_position`)는 `NoFit`에서만 노드 소멸 여부를 확인해
-/// `NodeNotFound`를 방출할 수 있다 — `Empty`는 노드 상태와 무관하게 항상 no-op.
-pub(crate) enum SliceInsertionOutcome {
-    Plan(SliceInsertionPlan),
-    Empty,
+pub(super) enum PlacementOutcome {
+    Placed(SliceInsertionPlan),
+    CompleteNoOutput,
     NoFit,
 }
 
-pub(crate) fn resolve_slice_insertion_outcome(
+pub(super) fn place_slice_at_position(
     view: &DocView,
     position: Position,
     slice: Slice,
-) -> SliceInsertionOutcome {
-    if slice.is_empty() {
-        return SliceInsertionOutcome::Empty;
-    }
-    let mut slice = prepare_page_breaks_for_position(view, &position, slice);
-    if slice.is_empty() {
-        return SliceInsertionOutcome::Empty;
-    }
-    repair_slice_fragments(&mut slice.content);
+) -> PlacementOutcome {
+    let Some(target) = SliceInsertionTarget::from_view(view, position) else {
+        return PlacementOutcome::NoFit;
+    };
+    place_slice_at_frontier(&target, slice)
+}
 
-    if position_in_textblock(view, &position) {
+pub(super) fn place_slice_at_frontier(
+    target: &SliceInsertionTarget,
+    slice: Slice,
+) -> PlacementOutcome {
+    if placement_is_complete_no_output(target, &slice) {
+        return PlacementOutcome::CompleteNoOutput;
+    }
+    try_place_slice_at_frontier(target, slice)
+        .map(PlacementOutcome::Placed)
+        .unwrap_or(PlacementOutcome::NoFit)
+}
+
+fn try_place_slice_at_frontier(
+    target: &SliceInsertionTarget,
+    slice: Slice,
+) -> Option<SliceInsertionPlan> {
+    if let Some(textblock) = target
+        .path()
+        .iter()
+        .rev()
+        .find(|node| editor_model::Schema::node_spec(node.node_type).is_textblock())
+    {
+        let textblock_id = textblock.id;
+        let textblock_path = target
+            .path()
+            .iter()
+            .take_while(|node| node.id != textblock_id)
+            .chain(std::iter::once(textblock))
+            .map(|node| node.node_type)
+            .collect::<Vec<_>>();
         let top_level = top_level_fragments(&slice);
-        let direct_inline = find_ancestor_textblock(view, position.node)
-            .and_then(|id| view.node(id))
-            .is_some_and(|textblock| {
-                fragments_are_inline(&top_level)
-                    && fragments_fit_parent(textblock.node_type(), &top_level)
-            });
+        let direct_inline = fragments_are_inline(&top_level)
+            && top_level
+                .iter()
+                .all(|fragment| is_supported_inline_fragment(fragment))
+            && fragments_fit_parent(textblock.node_type, &top_level)
+            && top_level
+                .iter()
+                .any(|fragment| is_insertable_inline_fragment(fragment));
         if direct_inline {
-            let fragments: Vec<Fragment> = top_level.into_iter().cloned().collect();
-            if !fragments.iter().any(is_insertable_inline_fragment) {
-                return SliceInsertionOutcome::NoFit;
+            if let Some(fragments) = fit_fragment_forest(slice.content.clone(), &textblock_path)
+                && inline_fragments_fit_target(target, &fragments)
+                && fragments.iter().any(is_insertable_inline_fragment)
+            {
+                let output = planned_inline_output(&fragments, target.position().affinity)?;
+                return Some(SliceInsertionPlan::DirectInline { fragments, output });
             }
-            return SliceInsertionOutcome::Plan(SliceInsertionPlan::DirectInline { fragments });
         }
 
-        if let Some(items) = open_list_items_for_textblock_insert(view, &position, &slice) {
-            return SliceInsertionOutcome::Plan(SliceInsertionPlan::SpliceOpenListItems { items });
-        }
-
-        let parent_fitted = fit_slice_for_textblock_parent(view, &position, &slice);
-        if let Some(candidate) = parent_fitted.as_ref()
-            && can_splice_textblock(view, &position, candidate)
-            && splice_emits_change(view, &position, candidate)
-        {
-            return SliceInsertionOutcome::Plan(SliceInsertionPlan::SpliceBlocks {
-                candidate: candidate.clone(),
+        if let Some(mut splice) = open_ancestor_splice_for_target(target, &slice) {
+            let Some(outer_index) = target
+                .path()
+                .iter()
+                .position(|node| node.id == splice.destination[0])
+            else {
+                return None;
+            };
+            let Some(parent_path) = outer_index.checked_sub(1).map(|parent_index| {
+                target.path()[..=parent_index]
+                    .iter()
+                    .map(|node| node.node_type)
+                    .collect::<Vec<_>>()
+            }) else {
+                return None;
+            };
+            let Some(mut fitted) = fit_fragment_forest(vec![splice.source.clone()], &parent_path)
+            else {
+                return None;
+            };
+            if fitted.len() != 1 {
+                return None;
+            }
+            splice.source = fitted.pop().expect("cardinality checked");
+            let output = planned_open_splice_output(&splice)?;
+            return Some(SliceInsertionPlan::SpliceOpenAncestors {
+                destination: splice.destination,
+                source: splice.source,
+                output,
             });
+        }
+
+        let textblock_index = target
+            .path()
+            .iter()
+            .position(|node| node.id == textblock_id)?;
+        let parent = textblock_index
+            .checked_sub(1)
+            .and_then(|index| target.path().get(index));
+        let parent_path = textblock_index.checked_sub(1).map(|index| {
+            target.path()[..=index]
+                .iter()
+                .map(|node| node.node_type)
+                .collect::<Vec<_>>()
+        });
+        let parent_fitted = parent_path.as_ref().and_then(|parent_path| {
+            fit_slice_for_textblock_target_parent(target, &slice)
+                .and_then(|candidate| {
+                    let content = fit_fragment_forest(candidate.content, &parent_path)?;
+                    Some(Slice::new(
+                        content,
+                        candidate.open_start,
+                        candidate.open_end,
+                    ))
+                })
+                .or_else(|| {
+                    let has_meaningful_top_level = slice.content.iter().any(|fragment| {
+                        is_insertable_inline_fragment(fragment)
+                            || fragment.node.as_type() == editor_model::NodeType::PageBreak
+                            || !editor_model::Schema::node_spec(fragment.node.as_type()).inline
+                    });
+                    if !has_meaningful_top_level {
+                        return None;
+                    }
+                    let parent_type = parent?.node_type;
+                    let blocks = block_boundary_fragments(&slice, parent_type)?;
+                    let content = fit_fragment_forest(blocks, parent_path)?;
+                    Some(Slice::new(content, 1, 1))
+                })
+        });
+        if let Some(plan) = parent_fitted
+            .as_ref()
+            .and_then(|candidate| plan_textblock_splice_target(target, candidate))
+        {
+            let output = plan.planned_output()?;
+            return Some(SliceInsertionPlan::SpliceBlocks { plan, output });
+        }
+        if let Some(plan) = plan_hoisted_block_insertion(target, &slice) {
+            let output = planned_block_output(&plan.blocks, &plan.list_merges)?;
+            return Some(SliceInsertionPlan::HoistBlocks { plan, output });
         }
 
         let candidate = parent_fitted.as_ref().unwrap_or(&slice);
-        if let Some(fragments) =
-            open_inline_content_for_textblock_insert(view, &position, candidate)
-        {
-            let fragments: Vec<Fragment> = fragments.into_iter().cloned().collect();
-            if !fragments.iter().any(is_insertable_inline_fragment) {
-                return SliceInsertionOutcome::NoFit;
+        if let Some(fragments) = open_inline_content_for_target(target, candidate) {
+            let Some(fragments) =
+                fit_fragment_forest(fragments.into_iter().cloned().collect(), &textblock_path)
+            else {
+                return None;
+            };
+            if !inline_fragments_fit_target(target, &fragments) {
+                return None;
             }
-            return SliceInsertionOutcome::Plan(SliceInsertionPlan::OpenInline { fragments });
+            if !fragments.iter().all(is_supported_inline_fragment) {
+                return None;
+            }
+            if !fragments.iter().any(is_insertable_inline_fragment) {
+                return None;
+            }
+            let output = planned_inline_output(&fragments, target.position().affinity)?;
+            return Some(SliceInsertionPlan::OpenInline { fragments, output });
         }
-        SliceInsertionOutcome::NoFit
+        None
     } else {
-        let Some(container) = view.node(position.node) else {
-            return SliceInsertionOutcome::NoFit;
-        };
+        let container = target.path().last()?;
         // A fixed-arity container (e.g. Fold) can never absorb an extra child:
         // the inserted blocks would stay permanent, projection-suppressed
         // misfits, so the insertion can't produce an observable change.
-        if !container.spec().content.admits_additional_child() {
-            return SliceInsertionOutcome::NoFit;
+        if !editor_model::Schema::node_spec(container.node_type)
+            .content
+            .admits_additional_child()
+        {
+            return None;
         }
-        let Some(blocks) = block_boundary_fragments(&slice, container.node_type()) else {
-            return SliceInsertionOutcome::NoFit;
+        let Some(blocks) = block_boundary_fragments(&slice, container.node_type) else {
+            return None;
         };
-        SliceInsertionOutcome::Plan(SliceInsertionPlan::BlockBoundary { blocks })
+        let container_path = target
+            .path()
+            .iter()
+            .map(|node| node.node_type)
+            .collect::<Vec<_>>();
+        let Some(blocks) = fit_fragment_forest(blocks, &container_path) else {
+            return None;
+        };
+        let position = target.position();
+        let left = position.offset.checked_sub(1).and_then(|index| {
+            Some(ExistingBlock {
+                id: container.child_ids.get(index).copied().flatten(),
+                node_type: *container.child_types.get(index)?,
+            })
+        });
+        let right = container
+            .child_types
+            .get(position.offset)
+            .map(|node_type| ExistingBlock {
+                id: container.child_ids.get(position.offset).copied().flatten(),
+                node_type: *node_type,
+            });
+        let list_merges = crate::helpers::plan_adjacent_list_merges(left, &blocks, right)?;
+        let output = planned_block_output(&blocks, &list_merges)?;
+        Some(SliceInsertionPlan::BlockBoundary {
+            blocks,
+            list_merges,
+            output,
+        })
     }
 }
 
-/// `Some(plan)` ⇒ `insert_slice_at_position`이 이 plan으로 삽입 op를 방출하는
-/// 관측 가능한 변화 보장. plan은 변환(페이지브레이크 정리·수선) 완료된 콘텐츠를
-/// 소유한다.
-pub fn resolve_slice_insertion(
-    view: &DocView,
-    position: Position,
-    slice: Slice,
-) -> Option<SliceInsertionPlan> {
-    match resolve_slice_insertion_outcome(view, position, slice) {
-        SliceInsertionOutcome::Plan(plan) => Some(plan),
-        SliceInsertionOutcome::Empty | SliceInsertionOutcome::NoFit => None,
+fn plan_hoisted_block_insertion(
+    target: &SliceInsertionTarget,
+    slice: &Slice,
+) -> Option<HoistedBlockInsertionPlan> {
+    let has_meaningful_content = slice.content.iter().any(|fragment| {
+        is_insertable_inline_fragment(fragment)
+            || fragment.node.as_type() == editor_model::NodeType::PageBreak
+            || !editor_model::Schema::node_spec(fragment.node.as_type()).inline
+    });
+    if !has_meaningful_content {
+        return None;
     }
+    let textblock_index = target
+        .path()
+        .iter()
+        .rposition(|node| editor_model::Schema::node_spec(node.node_type).is_textblock())?;
+    let mut current_index = textblock_index;
+    let target_offset = target.position().offset;
+    let textblock_child_count = target.path()[textblock_index].child_types.len();
+    let initial_boundary = if target_offset == 0 {
+        HoistInitialBoundary::Before
+    } else if target_offset == textblock_child_count {
+        HoistInitialBoundary::After
+    } else {
+        HoistInitialBoundary::Split
+    };
+    let textblock_child_index = target.path()[textblock_index].index?;
+    let (mut boundary_before, mut boundary_index, mut current_was_split) = match initial_boundary {
+        HoistInitialBoundary::Before => (true, textblock_child_index, false),
+        HoistInitialBoundary::After => (false, textblock_child_index, false),
+        HoistInitialBoundary::Split => (true, textblock_child_index + 1, true),
+    };
+    let mut boundary_steps = Vec::new();
+
+    while let Some(parent_index) = current_index.checked_sub(1) {
+        let current = &target.path()[current_index];
+        let parent = &target.path()[parent_index];
+        let current_child_index = current.index?;
+        let mut destination_types = parent.child_types.clone();
+        let mut destination_ids = parent.child_ids.clone();
+        if current_was_split {
+            if editor_model::Schema::node_spec(current.node_type).isolating {
+                return None;
+            }
+            destination_types.insert(current_child_index + 1, current.node_type);
+            destination_ids.insert(current_child_index + 1, None);
+            if !editor_model::content_placement(parent.node_type, &destination_types).is_valid() {
+                return None;
+            }
+        }
+        let parent_boundary = boundary_index + usize::from(!boundary_before);
+        if parent_boundary > destination_types.len() {
+            return None;
+        }
+
+        if editor_model::Schema::node_spec(parent.node_type)
+            .content
+            .admits_additional_child()
+            && let Some(blocks) = block_boundary_fragments(slice, parent.node_type)
+        {
+            let parent_path = target.path()[..=parent_index]
+                .iter()
+                .map(|node| node.node_type)
+                .collect::<Vec<_>>();
+            if let Some(blocks) = fit_fragment_forest(blocks, &parent_path) {
+                let left = parent_boundary.checked_sub(1).and_then(|index| {
+                    Some(ExistingBlock {
+                        id: destination_ids.get(index).copied().flatten(),
+                        node_type: *destination_types.get(index)?,
+                    })
+                });
+                let right = destination_types
+                    .get(parent_boundary)
+                    .map(|node_type| ExistingBlock {
+                        id: destination_ids.get(parent_boundary).copied().flatten(),
+                        node_type: *node_type,
+                    });
+                let list_merges = crate::helpers::plan_adjacent_list_merges(left, &blocks, right)?;
+                let mut final_types = destination_types.clone();
+                final_types.splice(
+                    parent_boundary..parent_boundary,
+                    blocks.iter().map(|fragment| fragment.node.as_type()),
+                );
+                if editor_model::content_placement(parent.node_type, &final_types).is_valid() {
+                    return Some(HoistedBlockInsertionPlan {
+                        target: SliceInsertionTargetShape::capture(target),
+                        parent_depth: parent_index,
+                        initial_boundary,
+                        boundary_steps,
+                        blocks,
+                        list_merges,
+                    });
+                }
+            }
+        }
+
+        // Reaching the next frontier would move Slice content outside this
+        // destination ancestor, which an isolating node forbids even at an edge.
+        if editor_model::Schema::node_spec(parent.node_type).isolating {
+            return None;
+        }
+        let step = if boundary_before {
+            if boundary_index == 0 {
+                HoistBoundaryStep::LiftBefore
+            } else {
+                HoistBoundaryStep::SplitBefore
+            }
+        } else if boundary_index + 1 == destination_types.len() {
+            HoistBoundaryStep::LiftAfter
+        } else {
+            HoistBoundaryStep::SplitAfter
+        };
+        let parent_child_index = parent.index?;
+        match step {
+            HoistBoundaryStep::LiftBefore => {
+                boundary_before = true;
+                boundary_index = parent_child_index;
+                current_was_split = false;
+            }
+            HoistBoundaryStep::LiftAfter => {
+                boundary_before = false;
+                boundary_index = parent_child_index;
+                current_was_split = false;
+            }
+            HoistBoundaryStep::SplitBefore | HoistBoundaryStep::SplitAfter => {
+                boundary_before = true;
+                boundary_index = parent_child_index + 1;
+                current_was_split = true;
+            }
+        }
+        boundary_steps.push(step);
+        current_index = parent_index;
+    }
+    None
 }
 
-pub(crate) fn insert_slice_at_position(
+fn placement_is_complete_no_output(target: &SliceInsertionTarget, slice: &Slice) -> bool {
+    if slice.is_empty() {
+        return true;
+    }
+    let Some(textblock) = target
+        .path()
+        .iter()
+        .rev()
+        .find(|node| editor_model::Schema::node_spec(node.node_type).is_textblock())
+    else {
+        return false;
+    };
+    let textblock_path = target
+        .path()
+        .iter()
+        .take_while(|node| node.id != textblock.id)
+        .chain(std::iter::once(textblock))
+        .map(|node| node.node_type)
+        .collect::<Vec<_>>();
+    let top_level = top_level_fragments(slice);
+    let empty_inline = fragments_are_inline(&top_level)
+        && top_level
+            .iter()
+            .all(|fragment| is_supported_inline_fragment(fragment))
+        && !top_level
+            .iter()
+            .any(|fragment| is_insertable_inline_fragment(fragment))
+        && fit_fragment_forest(slice.content.clone(), &textblock_path)
+            .is_some_and(|fragments| inline_fragments_fit_target(target, &fragments));
+    if empty_inline || open_ancestor_splice_is_complete_no_output(target, slice) {
+        return true;
+    }
+    open_inline_content_for_target(target, slice).is_some_and(|fragments| {
+        let fragments = fragments.into_iter().cloned().collect::<Vec<_>>();
+        fit_fragment_forest(fragments, &textblock_path).is_some_and(|fragments| {
+            fragments.iter().all(is_supported_inline_fragment)
+                && !fragments.iter().any(is_insertable_inline_fragment)
+                && inline_fragments_fit_target(target, &fragments)
+        })
+    })
+}
+
+pub(crate) struct AppliedSliceInsertion {
+    pub(crate) nodes: Vec<editor_crdt::Dot>,
+    pub(crate) output: SliceInsertionOutputPlan,
+    pub(crate) observed_caret: Position,
+    pub(crate) observed_inserted: Selection,
+}
+
+pub(crate) fn apply_slice_insertion_plan(
     tr: &mut Transaction,
     position: Position,
-    slice: Slice,
+    plan: SliceInsertionPlan,
     provenance: SliceProvenance,
-) -> Result<Option<Selection>, CommandError> {
-    let outcome = {
-        let view = tr.state().view();
-        resolve_slice_insertion_outcome(&view, position, slice)
-    };
-    let plan = match outcome {
-        SliceInsertionOutcome::Plan(plan) => plan,
-        SliceInsertionOutcome::Empty => return Ok(None),
-        SliceInsertionOutcome::NoFit => {
-            let view = tr.state().view();
-            if !position_in_textblock(&view, &position) && view.node(position.node).is_none() {
-                return Err(CommandError::NodeNotFound(position.node));
-            }
-            return Ok(None);
-        }
-    };
-    match plan {
-        SliceInsertionPlan::DirectInline { fragments } => {
-            let position = materialize_position_block(tr, position)?;
+) -> Result<AppliedSliceInsertion, CommandError> {
+    let (output, execution) = match plan {
+        SliceInsertionPlan::DirectInline { fragments, output } => {
+            ensure_output_plan(
+                &output,
+                planned_inline_output(&fragments, position.affinity),
+            )?;
+            let position = materialize_repair_position(tr, position)?;
             let mode = build_inline_mode(tr, &position, provenance)?;
-            insert_content_as_inline_at_position(tr, position, fragments, &mode)
+            let execution = insert_content_as_inline_at_position(tr, position, fragments, &mode)?;
+            (output, execution)
         }
-        SliceInsertionPlan::SpliceOpenListItems { items } => {
+        SliceInsertionPlan::SpliceOpenAncestors {
+            destination,
+            source,
+            output,
+        } => {
+            ensure_output_plan(
+                &output,
+                planned_open_splice_output(&OpenAncestorSplice {
+                    destination: destination.clone(),
+                    source: source.clone(),
+                }),
+            )?;
             let mut inserted = None;
             tr.batch::<_, CommandError>(|tr| {
-                let position = materialize_position_block(tr, position)?;
+                let position = materialize_repair_position(tr, position)?;
                 let mode = build_inline_mode(tr, &position, provenance)?;
-                inserted =
-                    insert_open_list_items_in_textblock_at_position(tr, position, &items, &mode)?;
+                inserted = insert_open_ancestor_splice_at_position(
+                    tr,
+                    position,
+                    OpenAncestorSplice {
+                        destination: destination.clone(),
+                        source: source.clone(),
+                    },
+                    &mode,
+                )?;
                 Ok(())
             })?;
-            Ok(inserted)
+            (output, inserted)
         }
-        SliceInsertionPlan::SpliceBlocks { candidate } => {
+        SliceInsertionPlan::SpliceBlocks { plan, output } => {
+            ensure_output_plan(&output, plan.planned_output())?;
             let mut inserted = None;
             tr.batch::<_, CommandError>(|tr| {
-                let position = materialize_position_block(tr, position)?;
+                let position = materialize_repair_position(tr, position)?;
                 let mode = build_inline_mode(tr, &position, provenance)?;
-                inserted = insert_blocks_in_textblock_at_position(tr, position, &candidate, &mode)?;
+                inserted = insert_blocks_in_textblock_at_position(tr, position, &plan, &mode)?;
                 Ok(())
             })?;
-            Ok(inserted)
+            (output, inserted)
         }
-        SliceInsertionPlan::OpenInline { fragments } => {
-            let position = materialize_position_block(tr, position)?;
+        SliceInsertionPlan::HoistBlocks { plan, output } => {
+            ensure_output_plan(
+                &output,
+                planned_block_output(&plan.blocks, &plan.list_merges),
+            )?;
+            let execution = insert_hoisted_blocks_at_position(tr, position, plan)?;
+            (output, execution)
+        }
+        SliceInsertionPlan::OpenInline { fragments, output } => {
+            ensure_output_plan(
+                &output,
+                planned_inline_output(&fragments, position.affinity),
+            )?;
+            let position = materialize_repair_position(tr, position)?;
             let mode = build_inline_mode(tr, &position, provenance)?;
-            insert_content_as_inline_at_position(tr, position, fragments, &mode)
+            let execution = insert_content_as_inline_at_position(tr, position, fragments, &mode)?;
+            (output, execution)
         }
-        SliceInsertionPlan::BlockBoundary { blocks } => {
-            let position = materialize_position_block(tr, position)?;
-            insert_blocks_at_block_boundary(tr, position, blocks)
+        SliceInsertionPlan::BlockBoundary {
+            blocks,
+            list_merges,
+            output,
+        } => {
+            ensure_output_plan(&output, planned_block_output(&blocks, &list_merges))?;
+            let position = materialize_repair_position(tr, position)?;
+            let execution = insert_blocks_at_block_boundary(tr, position, blocks, list_merges)?;
+            (output, execution)
         }
+    };
+    let execution = execution.ok_or_else(|| {
+        CommandError::Corrupted("planned Slice insertion produced no inserted selection".into())
+    })?;
+    bind_planned_output_nodes(tr, &output, execution)
+}
+
+fn ensure_output_plan(
+    actual: &SliceInsertionOutputPlan,
+    expected: Option<SliceInsertionOutputPlan>,
+) -> Result<(), CommandError> {
+    if expected.as_ref() != Some(actual) {
+        return Err(CommandError::Corrupted(
+            "Slice insertion output no longer matches its planned source path".into(),
+        ));
     }
+    Ok(())
+}
+
+fn bind_planned_output_nodes(
+    tr: &Transaction,
+    output: &SliceInsertionOutputPlan,
+    execution: SliceInsertionExecution,
+) -> Result<AppliedSliceInsertion, CommandError> {
+    let observed_caret = tr
+        .selection()
+        .filter(|selection| selection.is_collapsed())
+        .map(|selection| selection.head)
+        .ok_or_else(|| {
+            CommandError::Corrupted("planned Slice insertion produced no final caret".into())
+        })?;
+    let observed_inserted = execution.inserted;
+    let mut units = execution.units.into_iter();
+    let mut nodes = Vec::with_capacity(output.nodes.len());
+    for spec in &output.nodes {
+        let dot = match &spec.source {
+            SliceOutputSource::SplitLeft => execution.split_left,
+            SliceOutputSource::SplitRight => execution.split_right,
+            _ => units.next(),
+        }
+        .ok_or_else(|| {
+            CommandError::Corrupted(
+                "planned Slice output node was not bound by its insertion action".into(),
+            )
+        })?;
+        let (dot, actual_type) =
+            resolve_output_node(tr, dot).ok_or(CommandError::NodeNotFound(dot))?;
+        if actual_type != spec.node_type {
+            return Err(CommandError::Corrupted(
+                "planned Slice output node has a different type".into(),
+            ));
+        }
+        nodes.push(dot);
+    }
+    if units.next().is_some() {
+        return Err(CommandError::Corrupted(
+            "Slice insertion authored an undeclared output node".into(),
+        ));
+    }
+    Ok(AppliedSliceInsertion {
+        nodes,
+        output: output.clone(),
+        observed_caret,
+        observed_inserted,
+    })
+}
+
+fn resolve_output_node(
+    tr: &Transaction,
+    dot: editor_crdt::Dot,
+) -> Option<(editor_crdt::Dot, editor_model::NodeType)> {
+    let view = tr.view();
+    if let Some(node) = view.node(dot) {
+        return Some((dot, node.node_type()));
+    }
+    let live = view
+        .alias_classes()
+        .members_of(dot)
+        .into_iter()
+        .flatten()
+        .copied()
+        .find(|member| view.node(*member).is_some() || view.block_of(*member).is_some())
+        .unwrap_or(dot);
+    if let Some(node) = view.node(live) {
+        return Some((live, node.node_type()));
+    }
+    let parent = view.block_of(live)?;
+    let node_type = view
+        .node(parent)?
+        .children()
+        .find_map(|child| match child {
+            editor_model::ChildView::Leaf(leaf) if leaf.dot() == live => Some(leaf.node_type()),
+            _ => None,
+        })?;
+    Some((live, node_type))
 }
 
 #[cfg(test)]
 mod tests {
     use editor_clipboard::Slice;
     use editor_macros::state;
-    use editor_model::{Fragment, PlainNode, PlainParagraphNode, PlainTextNode};
+    use editor_model::{
+        Fragment, PlainBulletListNode, PlainHorizontalRuleNode, PlainListItemNode, PlainNode,
+        PlainParagraphNode, PlainTextNode,
+    };
     use editor_state::{Affinity, Position};
 
     use super::*;
@@ -221,12 +686,18 @@ mod tests {
             doc { root { p1: paragraph { text("hello") } } }
             selection: (p1, 2)
         };
-        let view = state.view();
         let position = Position::new(p1, 2);
-        let plan = resolve_slice_insertion(&view, position, text_slice("x"));
+        let outcome = fit_slice(&state, Selection::collapsed(position), text_slice("x")).unwrap();
         assert!(matches!(
-            plan,
-            Some(SliceInsertionPlan::DirectInline { .. })
+            outcome,
+            FitOutcome::Plan(SliceFitPlan {
+                kind: SliceFitPlanKind::Linear(LinearFitPlan {
+                    mutation: LinearMutation::PointInsertion {
+                        insertion: SliceInsertionPlan::DirectInline { .. },
+                    },
+                    ..
+                })
+            })
         ));
     }
 
@@ -236,35 +707,37 @@ mod tests {
             doc { root { p1: paragraph { text("hello") } } }
             selection: (p1, 2)
         };
-        let view = state.view();
-        let plan = resolve_slice_insertion(
-            &view,
-            Position::new(p1, 2),
+        let outcome = fit_slice(
+            &state,
+            Selection::collapsed(Position::new(p1, 2)),
             Slice {
                 content: vec![],
                 open_start: 0,
                 open_end: 0,
             },
-        );
-        assert!(plan.is_none());
+        )
+        .unwrap();
+        assert!(matches!(outcome, FitOutcome::NoOp));
     }
 
     #[test]
-    fn block_slice_at_root_boundary_is_block_boundary() {
+    fn block_slice_at_root_boundary_has_a_linear_plan() {
         let (state, r, ..) = state! {
             doc { r: root { paragraph { text("a") } paragraph { text("b") } } }
             selection: none
         };
-        let view = state.view();
         let position = Position {
             node: r,
             offset: 1,
             affinity: Affinity::Downstream,
         };
-        let plan = resolve_slice_insertion(&view, position, paragraph_slice("x"));
+        let outcome =
+            fit_slice(&state, Selection::collapsed(position), paragraph_slice("x")).unwrap();
         assert!(matches!(
-            plan,
-            Some(SliceInsertionPlan::BlockBoundary { .. })
+            outcome,
+            FitOutcome::Plan(SliceFitPlan {
+                kind: SliceFitPlanKind::Linear(_)
+            })
         ));
     }
 
@@ -280,13 +753,21 @@ mod tests {
             } }
             selection: (t, 1)
         };
-        let view = state.view();
-        let inline = resolve_slice_insertion(&view, Position::new(t, 1), text_slice("x"));
-        let block = resolve_slice_insertion(&view, Position::new(t, 1), paragraph_slice("x"));
-        assert!(inline.is_some());
+        let selection = Selection::collapsed(Position::new(t, 1));
+        let inline = fit_slice(&state, selection, text_slice("x")).unwrap();
+        let block = fit_slice(&state, selection, paragraph_slice("x")).unwrap();
+        assert!(matches!(inline, FitOutcome::Plan(_)));
         assert!(matches!(
             block,
-            None | Some(SliceInsertionPlan::OpenInline { .. })
+            FitOutcome::NoFit
+                | FitOutcome::Plan(SliceFitPlan {
+                    kind: SliceFitPlanKind::Linear(LinearFitPlan {
+                        mutation: LinearMutation::PointInsertion {
+                            insertion: SliceInsertionPlan::OpenInline { .. },
+                        },
+                        ..
+                    })
+                })
         ));
     }
 
@@ -309,7 +790,7 @@ mod tests {
         let state = state_under_distinct_actor(&state_actor1, 2);
 
         let mut tr = editor_transaction::Transaction::new(&state);
-        let result = insert_slice_at_position(
+        let result = crate::insert_slice_at(
             &mut tr,
             Position::new(f1, 0),
             Slice {
@@ -335,12 +816,50 @@ mod tests {
         let state = state_under_distinct_actor(&state_actor1, 2);
 
         let mut tr = editor_transaction::Transaction::new(&state);
-        let result = insert_slice_at_position(
+        let result = crate::insert_slice_at(
             &mut tr,
             Position::new(f1, 0),
             paragraph_slice("x"),
             crate::types::SliceProvenance::Plain,
         );
         assert!(matches!(result, Err(crate::CommandError::NodeNotFound(_))));
+    }
+
+    #[test]
+    fn task3_open_ancestor_fit_rejects_a_multi_root_repair_result() {
+        let (state, p) = state! {
+            doc { root {
+                bullet_list { list_item { p: paragraph { text("target") } } }
+                paragraph {}
+            } }
+            selection: (p, 3)
+        };
+        let paragraph = |text: &str| {
+            Fragment::leaf(PlainNode::Paragraph(PlainParagraphNode::default())).with_children(vec![
+                Fragment::leaf(PlainNode::Text(PlainTextNode { text: text.into() })),
+            ])
+        };
+        let source = Fragment::leaf(PlainNode::BulletList(PlainBulletListNode::default()))
+            .with_children(vec![
+                Fragment::leaf(PlainNode::ListItem(PlainListItemNode::default())).with_children(
+                    vec![
+                        paragraph("left"),
+                        Fragment::leaf(PlainNode::HorizontalRule(
+                            PlainHorizontalRuleNode::default(),
+                        )),
+                        paragraph("right"),
+                    ],
+                ),
+            ]);
+        let slice = Slice {
+            content: vec![source],
+            open_start: 3,
+            open_end: 3,
+        };
+
+        assert!(matches!(
+            place_slice_at_position(&state.view(), Position::new(p, 3), slice),
+            PlacementOutcome::NoFit
+        ));
     }
 }

--- a/crates/editor-commands/src/judgments/slice/fitter.rs
+++ b/crates/editor-commands/src/judgments/slice/fitter.rs
@@ -1,0 +1,136 @@
+//! Selection-aware routing for Slice replacement.
+
+use editor_clipboard::Slice;
+use editor_state::{Selection, State};
+
+use super::linear_fitter::{LinearFitOutcome, LinearFitPlan, fit_linear_slice};
+use super::table_fitter::{
+    CellFillPlan, TableGridPlan, fit_cell_fill, fit_table_grid, is_pure_table_grid_slice,
+    selection_is_wholly_in_one_cell,
+};
+use crate::CommandError;
+
+pub enum FitOutcome {
+    Plan(SliceFitPlan),
+    NoOp,
+    NoFit,
+}
+
+pub struct SliceFitPlan {
+    pub(crate) kind: SliceFitPlanKind,
+}
+
+pub(crate) enum SliceFitPlanKind {
+    Linear(LinearFitPlan),
+    TableGrid(TableGridPlan),
+    CellFill(CellFillPlan),
+}
+
+pub fn fit_slice(
+    state: &State,
+    selection: Selection,
+    slice: Slice,
+) -> Result<FitOutcome, CommandError> {
+    if slice.is_empty() {
+        return Ok(FitOutcome::NoOp);
+    }
+
+    let Some(preflight) = slice.preflight() else {
+        drop_slice_iteratively(slice);
+        return Ok(FitOutcome::NoFit);
+    };
+
+    let view = state.view();
+    let selection = if selection.is_collapsed() {
+        selection.resolve(&view).ok_or_else(|| {
+            CommandError::Corrupted("cannot resolve Slice insertion position".into())
+        })?;
+        selection
+    } else {
+        selection.normalize(&view).ok_or_else(|| {
+            CommandError::Corrupted("cannot resolve Slice replacement selection".into())
+        })?
+    };
+    let destination_depth = {
+        let resolved = selection.resolve(&view).ok_or_else(|| {
+            CommandError::Corrupted("cannot resolve normalized Slice selection".into())
+        })?;
+        resolved
+            .from()
+            .path()
+            .len()
+            .max(resolved.to().path().len())
+            .saturating_sub(1)
+    };
+    if !preflight.fits_at_destination_depth(destination_depth) {
+        drop_slice_iteratively(slice);
+        return Ok(FitOutcome::NoFit);
+    }
+
+    if is_pure_table_grid_slice(&slice) {
+        if selection
+            .resolve(&view)
+            .is_some_and(|resolved| resolved.as_cell_rect().is_some())
+            || selection_is_wholly_in_one_cell(&view, selection)
+        {
+            return Ok(match fit_table_grid(&view, selection, &slice)? {
+                Some(plan) => FitOutcome::Plan(SliceFitPlan {
+                    kind: SliceFitPlanKind::TableGrid(plan),
+                }),
+                None => FitOutcome::NoFit,
+            });
+        }
+    }
+
+    if selection
+        .resolve(&view)
+        .is_some_and(|resolved| resolved.as_cell_rect().is_some())
+    {
+        if preflight.contains_table {
+            return Ok(FitOutcome::NoFit);
+        }
+        return Ok(match fit_cell_fill(&view, selection, &slice) {
+            Some(plan) => FitOutcome::Plan(SliceFitPlan {
+                kind: SliceFitPlanKind::CellFill(plan),
+            }),
+            None => FitOutcome::NoFit,
+        });
+    }
+
+    if preflight.contains_table && surviving_table_destination(&view, selection) {
+        return Ok(FitOutcome::NoFit);
+    }
+
+    match fit_linear_slice(&view, selection, slice)? {
+        LinearFitOutcome::Plan(plan) => Ok(FitOutcome::Plan(SliceFitPlan {
+            kind: SliceFitPlanKind::Linear(plan),
+        })),
+        LinearFitOutcome::NoOp => Ok(FitOutcome::NoOp),
+        LinearFitOutcome::NoFit => Ok(FitOutcome::NoFit),
+    }
+}
+
+fn drop_slice_iteratively(mut slice: Slice) {
+    let mut stack = std::mem::take(&mut slice.content);
+    while let Some(mut fragment) = stack.pop() {
+        stack.append(&mut fragment.children);
+    }
+}
+
+fn surviving_table_destination(view: &editor_model::DocView, selection: Selection) -> bool {
+    let Some(resolved) = selection.resolve(view) else {
+        return false;
+    };
+    for endpoint in [resolved.from().node(), resolved.to().node()] {
+        let Some(node) = view.node(endpoint) else {
+            continue;
+        };
+        if node.ancestors().any(|ancestor| {
+            ancestor.node_type() == editor_model::NodeType::Table
+                && !resolved.contains_subtree(&ancestor)
+        }) {
+            return true;
+        }
+    }
+    false
+}

--- a/crates/editor-commands/src/judgments/slice/fragment_fitter.rs
+++ b/crates/editor-commands/src/judgments/slice/fragment_fitter.rs
@@ -1,0 +1,534 @@
+use editor_model::{
+    CompletionInsertion, Fragment, NodeType, RepairTransition, content_placement, repair_transition,
+};
+use editor_transaction::minimal_subtree;
+
+use crate::helpers::subtree_to_fragment;
+
+/// Restructuring limit for one untrusted Slice fit. A fit either completes
+/// within the work limit or returns `None`; valid ancestry depth is not itself
+/// a semantic rejection reason.
+const FIT_OP_BUDGET: usize = 4096;
+
+enum DirectFit {
+    Ready,
+    Hoist(Vec<Fragment>),
+}
+
+/// Fit an owned fragment forest to its actual destination parent.
+///
+/// `parent_path` includes the destination parent. The same shared
+/// `content_placement` / `misfit_action` decisions used by projection and
+/// fulfillment drive this dot-less executor. An outer SPLIT-HOIST would cross
+/// the destination boundary, so it rejects the whole forest. Internal hoists
+/// remain lossless and are re-examined by the parent fragment.
+pub(crate) fn fit_fragment_forest(
+    fragments: Vec<Fragment>,
+    parent_path: &[NodeType],
+) -> Option<Vec<Fragment>> {
+    if parent_path.is_empty() {
+        return None;
+    }
+    let mut budget = FIT_OP_BUDGET;
+    let mut path = parent_path.to_vec();
+    let mut stack = vec![FragmentFitFrame {
+        owner: None,
+        children: fragments,
+        complete: false,
+        next_child: 0,
+        entered: false,
+    }];
+
+    loop {
+        let action = {
+            let frame = stack.last_mut()?;
+            let container = *path.last()?;
+            if !frame.entered {
+                if frame
+                    .children
+                    .iter()
+                    .any(|child| child.node.as_type() == NodeType::Unknown)
+                {
+                    return None;
+                }
+                match fit_direct_children(
+                    &mut frame.children,
+                    &path,
+                    &mut budget,
+                    frame.complete,
+                    container,
+                    frame.owner.as_ref(),
+                )? {
+                    DirectFit::Ready => {
+                        frame.entered = true;
+                        FrameAction::Continue
+                    }
+                    DirectFit::Hoist(hoist) => FrameAction::Finish(hoist),
+                }
+            } else if frame.next_child < frame.children.len() {
+                let child = frame.children.remove(frame.next_child);
+                FrameAction::Descend(child)
+            } else {
+                let placement = content_placement(container, &fragment_types(&frame.children));
+                let valid = if frame.complete {
+                    placement.is_valid()
+                } else {
+                    placement.is_completable()
+                };
+                if !valid {
+                    return None;
+                }
+                FrameAction::Finish(Vec::new())
+            }
+        };
+
+        match action {
+            FrameAction::Continue => {}
+            FrameAction::Descend(mut child) => {
+                let owner = fragment_shell(&child);
+                path.push(owner.node.as_type());
+                stack.push(FragmentFitFrame {
+                    owner: Some(owner),
+                    children: std::mem::take(&mut child.children),
+                    complete: true,
+                    next_child: 0,
+                    entered: false,
+                });
+            }
+            FrameAction::Finish(mut hoist) => loop {
+                let mut completed = stack.pop()?;
+                let Some(parent) = stack.last_mut() else {
+                    return hoist.is_empty().then_some(completed.children);
+                };
+                path.pop()?;
+                let mut owner = completed.owner.take()?;
+                owner.children = completed.children;
+                let index = parent.next_child;
+                parent.children.insert(index, owner);
+                if hoist.is_empty() {
+                    parent.next_child += 1;
+                    break;
+                }
+                parent.children.splice(index + 1..index + 1, hoist);
+                let container = *path.last()?;
+                match fit_direct_children(
+                    &mut parent.children,
+                    &path,
+                    &mut budget,
+                    parent.complete,
+                    container,
+                    parent.owner.as_ref(),
+                )? {
+                    DirectFit::Ready => {
+                        // The retained child is already fitted. Any wrapper
+                        // introduced around hoisted content starts after it.
+                        parent.next_child += 1;
+                        break;
+                    }
+                    DirectFit::Hoist(next) => hoist = next,
+                }
+            },
+        }
+    }
+}
+
+struct FragmentFitFrame {
+    owner: Option<Fragment>,
+    children: Vec<Fragment>,
+    complete: bool,
+    next_child: usize,
+    entered: bool,
+}
+
+enum FrameAction {
+    Continue,
+    Descend(Fragment),
+    Finish(Vec<Fragment>),
+}
+
+fn fit_direct_children(
+    children: &mut Vec<Fragment>,
+    path: &[NodeType],
+    budget: &mut usize,
+    complete: bool,
+    container: NodeType,
+    container_template: Option<&Fragment>,
+) -> Option<DirectFit> {
+    loop {
+        let types = fragment_types(children);
+        match repair_transition(path, &types, |_| true)? {
+            RepairTransition::Ready { completion: needed } => {
+                if complete {
+                    insert_completion_fragments(children, &needed, budget)?;
+                }
+                return Some(DirectFit::Ready);
+            }
+            RepairTransition::Wrap { index, chain } => {
+                spend(budget)?;
+                wrap_fragment(children, index, &chain);
+            }
+            RepairTransition::SplitHoist {
+                index,
+                retained_completion,
+            } => {
+                if editor_model::Schema::node_spec(container).isolating {
+                    return None;
+                }
+                spend(budget)?;
+                return Some(DirectFit::Hoist(split_hoist_fragment(
+                    container,
+                    container_template,
+                    children,
+                    index,
+                    &retained_completion,
+                    budget,
+                )?));
+            }
+        }
+    }
+}
+
+fn spend(budget: &mut usize) -> Option<()> {
+    if *budget == 0 {
+        return None;
+    }
+    *budget -= 1;
+    Some(())
+}
+
+fn insert_completion_fragments(
+    children: &mut Vec<Fragment>,
+    insertions: &[CompletionInsertion],
+    budget: &mut usize,
+) -> Option<()> {
+    for insertion in insertions {
+        spend(budget)?;
+        children.insert(
+            insertion.index,
+            subtree_to_fragment(minimal_subtree(insertion.node_type)),
+        );
+    }
+    Some(())
+}
+
+fn fragment_types(fragments: &[Fragment]) -> Vec<NodeType> {
+    fragments
+        .iter()
+        .map(|fragment| fragment.node.as_type())
+        .collect()
+}
+
+fn fragment_shell(fragment: &Fragment) -> Fragment {
+    Fragment {
+        node: fragment.node.clone(),
+        modifiers: fragment.modifiers.clone(),
+        carry: fragment.carry.clone(),
+        children: Vec::new(),
+    }
+}
+
+fn wrap_fragment(children: &mut Vec<Fragment>, i: usize, chain: &[NodeType]) {
+    let mut current = children.remove(i);
+    for &role in chain.iter().rev() {
+        current = Fragment::leaf(role.into_node().to_plain()).with_children(vec![current]);
+    }
+    children.insert(i, current);
+}
+
+fn split_hoist_fragment(
+    container: NodeType,
+    container_template: Option<&Fragment>,
+    children: &mut Vec<Fragment>,
+    k: usize,
+    retained_completion: &[CompletionInsertion],
+    budget: &mut usize,
+) -> Option<Vec<Fragment>> {
+    let tail = children.split_off(k + 1);
+    let promoted = children.pop().expect("k is a valid child index");
+    insert_completion_fragments(children, retained_completion, budget)?;
+    let mut out = vec![promoted];
+    if !tail.is_empty() {
+        let mut tail_container = container_template
+            .cloned()
+            .unwrap_or_else(|| Fragment::leaf(container.into_node().to_plain()));
+        tail_container.children = tail;
+        out.push(tail_container);
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use editor_model::{
+        Alignment, BlockquoteVariant, Modifier, PlainBlockquoteNode, PlainBulletListNode,
+        PlainFoldContentNode, PlainHorizontalRuleNode, PlainImageNode, PlainListItemNode,
+        PlainNode, PlainPageBreakNode, PlainParagraphNode, PlainTableCellNode, PlainTextNode,
+    };
+
+    fn text(t: &str) -> Fragment {
+        Fragment::leaf(PlainNode::Text(PlainTextNode { text: t.into() }))
+    }
+
+    fn page_break() -> Fragment {
+        Fragment::leaf(PlainNode::PageBreak(PlainPageBreakNode::default()))
+    }
+
+    fn para(children: Vec<Fragment>) -> Fragment {
+        Fragment::leaf(PlainNode::Paragraph(PlainParagraphNode::default())).with_children(children)
+    }
+
+    fn list_item(children: Vec<Fragment>) -> Fragment {
+        Fragment::leaf(PlainNode::ListItem(PlainListItemNode::default())).with_children(children)
+    }
+
+    fn bullet_list(children: Vec<Fragment>) -> Fragment {
+        Fragment::leaf(PlainNode::BulletList(PlainBulletListNode::default()))
+            .with_children(children)
+    }
+
+    fn horizontal_rule() -> Fragment {
+        Fragment::leaf(PlainNode::HorizontalRule(PlainHorizontalRuleNode::default()))
+    }
+
+    fn table_cell(children: Vec<Fragment>) -> Fragment {
+        Fragment::leaf(PlainNode::TableCell(PlainTableCellNode::default())).with_children(children)
+    }
+
+    fn fold_content(children: Vec<Fragment>) -> Fragment {
+        Fragment::leaf(PlainNode::FoldContent(PlainFoldContentNode::default()))
+            .with_children(children)
+    }
+
+    fn blockquote(variant: BlockquoteVariant, children: Vec<Fragment>) -> Fragment {
+        Fragment::leaf(PlainNode::Blockquote(PlainBlockquoteNode { variant }))
+            .with_children(children)
+    }
+
+    fn types(fragments: &[Fragment]) -> Vec<NodeType> {
+        fragments.iter().map(|f| f.node.as_type()).collect()
+    }
+
+    #[test]
+    fn keeps_list_item_with_two_paragraphs() {
+        let content = vec![bullet_list(vec![list_item(vec![
+            para(vec![text("a")]),
+            para(vec![text("b")]),
+        ])])];
+
+        let content = fit_fragment_forest(content, &[NodeType::Root]).expect("fits");
+
+        assert_eq!(types(&content), vec![NodeType::BulletList]);
+        let items = &content[0].children;
+        assert_eq!(types(items), vec![NodeType::ListItem]);
+        assert_eq!(
+            items[0].children,
+            vec![para(vec![text("a")]), para(vec![text("b")])]
+        );
+    }
+
+    #[test]
+    fn keeps_list_item_with_three_paragraphs() {
+        let content = vec![bullet_list(vec![list_item(vec![
+            para(vec![text("a")]),
+            para(vec![text("b")]),
+            para(vec![text("c")]),
+        ])])];
+
+        let content = fit_fragment_forest(content, &[NodeType::Root]).expect("fits");
+
+        let items = &content[0].children;
+        assert_eq!(types(items), vec![NodeType::ListItem]);
+        assert_eq!(
+            items[0].children,
+            vec![
+                para(vec![text("a")]),
+                para(vec![text("b")]),
+                para(vec![text("c")]),
+            ]
+        );
+    }
+
+    #[test]
+    fn keeps_trailing_paragraph_after_nested_list_in_same_item() {
+        let content = vec![bullet_list(vec![list_item(vec![
+            para(vec![text("a")]),
+            bullet_list(vec![list_item(vec![para(vec![text("x")])])]),
+            para(vec![text("b")]),
+        ])])];
+
+        let content = fit_fragment_forest(content, &[NodeType::Root]).expect("fits");
+
+        let items = &content[0].children;
+        assert_eq!(types(items), vec![NodeType::ListItem]);
+        assert_eq!(
+            types(&items[0].children),
+            vec![
+                NodeType::Paragraph,
+                NodeType::BulletList,
+                NodeType::Paragraph,
+            ]
+        );
+        assert_eq!(items[0].children[2], para(vec![text("b")]));
+    }
+
+    #[test]
+    fn leaves_valid_list_unchanged() {
+        let content = vec![bullet_list(vec![
+            list_item(vec![para(vec![text("a")])]),
+            list_item(vec![para(vec![text("b")])]),
+        ])];
+        let before = content.clone();
+
+        let content = fit_fragment_forest(content, &[NodeType::Root]).expect("fits");
+
+        assert_eq!(content, before);
+    }
+
+    #[test]
+    fn repairs_the_earliest_content_or_context_misfit() {
+        let children = vec![
+            Fragment::leaf(PlainNode::Image(PlainImageNode::default())),
+            page_break(),
+        ];
+        let path = [NodeType::Root, NodeType::Blockquote, NodeType::Paragraph];
+        let transition =
+            repair_transition(&path, &fragment_types(&children), |_| true).expect("repair");
+
+        assert!(matches!(
+            transition,
+            RepairTransition::SplitHoist { index: 0, .. }
+        ));
+    }
+
+    #[test]
+    fn wraps_bare_inline_fragments_for_a_root_destination_without_loss() {
+        let content = vec![text("a"), text("b")];
+
+        let content = fit_fragment_forest(content, &[NodeType::Root]).expect("fits");
+
+        assert_eq!(content, vec![para(vec![text("a")]), para(vec![text("b")])]);
+    }
+
+    #[test]
+    fn keeps_page_break_in_top_level_paragraph() {
+        let content = vec![para(vec![text("a"), page_break()])];
+        let before = content.clone();
+
+        let content = fit_fragment_forest(content, &[NodeType::Root]).expect("fits");
+
+        assert_eq!(content, before);
+    }
+
+    #[test]
+    fn task2_split_hoist_completes_the_retained_list_item() {
+        let fitted = fit_fragment_forest(
+            vec![bullet_list(vec![list_item(vec![horizontal_rule()])])],
+            &[NodeType::Root],
+        )
+        .expect("horizontal rule can hoist without invalidating its retained wrappers");
+
+        assert_eq!(
+            types(&fitted),
+            vec![NodeType::BulletList, NodeType::HorizontalRule]
+        );
+        assert_eq!(
+            types(&fitted[0].children[0].children),
+            vec![NodeType::Paragraph]
+        );
+        assert!(fitted[0].children[0].children[0].children.is_empty());
+    }
+
+    #[test]
+    fn split_hoist_preserves_source_wrapper_metadata_on_the_tail() {
+        let alignment = Modifier::Alignment {
+            value: Alignment::Center,
+        };
+        let carry = Modifier::Bold;
+        let mut source_paragraph = para(vec![text("a"), page_break(), text("b")]);
+        source_paragraph.modifiers.push(alignment.clone());
+        source_paragraph.carry.push(carry.clone());
+        let source_blockquote = blockquote(
+            BlockquoteVariant::MessageSent,
+            vec![source_paragraph.clone()],
+        );
+
+        let fitted = fit_fragment_forest(vec![source_blockquote.clone()], &[NodeType::Root])
+            .expect("the PageBreak can be admitted by splitting its wrappers at Root");
+
+        assert_eq!(fitted.len(), 3);
+        assert_eq!(fitted[0].node, source_blockquote.node);
+        assert_eq!(fitted[2].node, source_blockquote.node);
+        assert_eq!(fitted[0].children[0].modifiers, vec![alignment.clone()]);
+        assert_eq!(fitted[0].children[0].carry, vec![carry.clone()]);
+        assert_eq!(fitted[2].children[0].modifiers, vec![alignment]);
+        assert_eq!(fitted[2].children[0].carry, vec![carry]);
+    }
+
+    #[test]
+    fn split_hoist_does_not_cross_table_cell_isolation() {
+        let content = vec![table_cell(vec![para(vec![
+            text("a"),
+            page_break(),
+            text("b"),
+        ])])];
+
+        assert!(fit_fragment_forest(content, &[NodeType::Root]).is_none());
+    }
+
+    #[test]
+    fn split_hoist_does_not_cross_fold_content_isolation() {
+        let content = vec![fold_content(vec![para(vec![
+            text("a"),
+            page_break(),
+            text("b"),
+        ])])];
+
+        assert!(fit_fragment_forest(content, &[NodeType::Root]).is_none());
+    }
+
+    #[test]
+    fn wide_split_hoists_do_not_accumulate_same_level_stack_frames() {
+        let content = (0..256)
+            .map(|_| {
+                blockquote(
+                    BlockquoteVariant::LeftLine,
+                    vec![para(vec![text("a")]), page_break()],
+                )
+            })
+            .collect();
+        let fitted = std::thread::Builder::new()
+            .stack_size(64 * 1024)
+            .spawn(move || fit_fragment_forest(content, &[NodeType::Root]))
+            .expect("small-stack fitter thread")
+            .join()
+            .expect("wide fitting must not overflow its thread stack");
+
+        assert!(fitted.is_some());
+    }
+
+    #[test]
+    fn deeply_nested_valid_input_is_not_rejected_by_ancestry_depth() {
+        let mut inner = para(vec![text("x")]);
+        for _ in 0..512 {
+            inner = bullet_list(vec![list_item(vec![inner])]);
+        }
+        let content = vec![inner];
+        let fitted = std::thread::Builder::new()
+            .stack_size(64 * 1024)
+            .spawn(move || {
+                let Some(mut fitted) = fit_fragment_forest(content, &[NodeType::Root]) else {
+                    return false;
+                };
+                while let Some(mut fragment) = fitted.pop() {
+                    fitted.append(&mut fragment.children);
+                }
+                true
+            })
+            .expect("small-stack fitter thread")
+            .join()
+            .expect("deep fitting must not overflow its thread stack");
+
+        assert!(fitted);
+    }
+}

--- a/crates/editor-commands/src/judgments/slice/linear_fitter.rs
+++ b/crates/editor-commands/src/judgments/slice/linear_fitter.rs
@@ -1,0 +1,786 @@
+//! Pure planning for ordinary linear Slice insertion and replacement.
+
+use editor_clipboard::Slice;
+use editor_crdt::Dot;
+use editor_model::{ChildView, DocView, Fragment, content_placement};
+use editor_state::{Position, Selection};
+
+use super::{
+    PlacementOutcome, SliceInsertionPlan, place_slice_at_frontier, place_slice_at_position,
+};
+use crate::CommandError;
+use crate::helpers::{
+    ExistingBlock, LinearDeletionPlan, LinearDeletionSemantics, PlannedEndpoint, PlannedSelection,
+    SliceInsertionTarget, SliceInsertionTargetShape, block_boundary_fragments,
+    find_lowest_common_ancestor, path_from_ancestor, plan_joined_replacement_frontier,
+    plan_linear_deletion, plan_unjoined_replacement_frontiers,
+};
+
+pub(super) enum LinearFitOutcome {
+    Plan(LinearFitPlan),
+    NoOp,
+    NoFit,
+}
+
+pub(crate) struct LinearFitPlan {
+    pub(crate) selection: PlannedSelection,
+    pub(crate) mutation: LinearMutation,
+    pub(crate) final_selection: LinearFinalSelection,
+}
+
+pub(crate) enum LinearFinalSelection {
+    InsertedContent,
+    DeletionBoundary,
+}
+
+pub(crate) enum LinearMutation {
+    PointInsertion {
+        insertion: SliceInsertionPlan,
+    },
+    RangeReplacement {
+        deletion: LinearDeletionSemantics,
+        placement: RangePlacement,
+    },
+}
+
+pub(crate) enum RangePlacement {
+    Joined(JoinedReplacementPlan),
+    PreservedBoundary(PlannedBoundaryInsertion),
+    SeparatedBranches {
+        boundary: PlannedBranchInsertion,
+    },
+    SeparatedOpenEdges {
+        left: PlannedBoundaryInsertion,
+        middle: PlannedBranchInsertion,
+        right: PlannedBoundaryInsertion,
+    },
+    DeletionOnly {
+        join: Option<PlannedJoin>,
+    },
+}
+
+pub(crate) struct JoinedReplacementPlan {
+    /// The authored or materializable left survivor that owns the replacement
+    /// seam. The executor binds this endpoint before mutation and never
+    /// reconstructs an insertion frontier from the mutated document.
+    pub(crate) destination: PlannedEndpoint,
+    /// Complete right-boundary reattachment and container-survivor decisions
+    /// made from the original selection.
+    pub(crate) join: Option<PlannedJoin>,
+    /// Already-fitted Slice output, including its semantic output identities.
+    pub(crate) insertion: SliceInsertionPlan,
+}
+
+pub(crate) struct PlannedBoundaryInsertion {
+    pub(crate) destination: PlannedEndpoint,
+    pub(crate) target: SliceInsertionTargetShape,
+    pub(crate) insertion: SliceInsertionPlan,
+}
+
+pub(crate) struct PlannedBranchInsertion {
+    pub(crate) parent: PlannedEndpoint,
+    pub(crate) splits: Vec<PlannedBranchSplit>,
+    pub(crate) right_boundary: PlannedBranchNode,
+    pub(crate) insertion: SliceInsertionPlan,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct PlannedOutputKey(u32);
+
+#[derive(Clone)]
+pub(crate) enum PlannedBranchNode {
+    Existing(PlannedEndpoint),
+    Output(PlannedOutputKey),
+}
+
+pub(crate) struct PlannedBranchSplit {
+    pub(crate) wrapper: PlannedEndpoint,
+    pub(crate) first_right: PlannedBranchNode,
+    pub(crate) output: PlannedOutputKey,
+}
+
+pub(crate) struct PlannedJoin {
+    pub(crate) from_textblock: PlannedEndpoint,
+    pub(crate) to_textblock: PlannedEndpoint,
+    pub(crate) prune: Vec<PlannedEndpoint>,
+    pub(crate) container_merges: Vec<PlannedContainerMerge>,
+    pub(crate) affected: Vec<PlannedEndpoint>,
+}
+
+pub(crate) struct PlannedContainerMerge {
+    pub(crate) target: PlannedEndpoint,
+    pub(crate) source: PlannedEndpoint,
+}
+
+pub(super) fn fit_linear_slice(
+    view: &DocView,
+    selection: Selection,
+    slice: Slice,
+) -> Result<LinearFitOutcome, CommandError> {
+    let planned_selection = PlannedSelection::capture(view, selection).ok_or_else(|| {
+        CommandError::Corrupted("cannot capture Slice replacement endpoints".into())
+    })?;
+    if selection.is_collapsed() {
+        let target = SliceInsertionTarget::from_view(view, selection.head).ok_or_else(|| {
+            CommandError::Corrupted("cannot capture Slice insertion target".into())
+        })?;
+        return Ok(match place_slice_at_frontier(&target, slice) {
+            PlacementOutcome::Placed(insertion) => LinearFitOutcome::Plan(LinearFitPlan {
+                selection: planned_selection,
+                mutation: LinearMutation::PointInsertion { insertion },
+                final_selection: LinearFinalSelection::InsertedContent,
+            }),
+            PlacementOutcome::CompleteNoOutput => LinearFitOutcome::NoOp,
+            PlacementOutcome::NoFit => LinearFitOutcome::NoFit,
+        });
+    }
+
+    let Some(deletion) = plan_linear_deletion(view, selection)? else {
+        return Ok(LinearFitOutcome::NoFit);
+    };
+    let fit = fit_range_replacement(view, selection, &deletion, &slice)?;
+    Ok(match fit {
+        RangeFit::Placed(placement) => LinearFitOutcome::Plan(LinearFitPlan {
+            selection: planned_selection,
+            mutation: LinearMutation::RangeReplacement {
+                deletion: deletion.semantics(),
+                placement,
+            },
+            final_selection: LinearFinalSelection::InsertedContent,
+        }),
+        RangeFit::DeletionOnly(join) => LinearFitOutcome::Plan(LinearFitPlan {
+            selection: planned_selection,
+            mutation: LinearMutation::RangeReplacement {
+                deletion: deletion.semantics(),
+                placement: RangePlacement::DeletionOnly { join },
+            },
+            final_selection: LinearFinalSelection::DeletionBoundary,
+        }),
+        RangeFit::NoFit => LinearFitOutcome::NoFit,
+    })
+}
+
+enum RangeFit {
+    Placed(RangePlacement),
+    DeletionOnly(Option<PlannedJoin>),
+    NoFit,
+}
+
+fn fit_range_replacement(
+    view: &DocView,
+    selection: Selection,
+    deletion: &LinearDeletionPlan,
+    slice: &Slice,
+) -> Result<RangeFit, CommandError> {
+    OriginalRangeFrontiers::capture(view, selection, deletion)?.fit(slice)
+}
+
+struct OriginalRangeFrontiers<'a, 'doc> {
+    view: &'a DocView<'doc>,
+    selection: Selection,
+    deletion: &'a LinearDeletionPlan,
+    separated_lca: Option<Dot>,
+    unjoined: Option<crate::helpers::UnjoinedReplacementFrontiers>,
+}
+
+impl<'a, 'doc> OriginalRangeFrontiers<'a, 'doc> {
+    fn capture(
+        view: &'a DocView<'doc>,
+        selection: Selection,
+        deletion: &'a LinearDeletionPlan,
+    ) -> Result<Self, CommandError> {
+        Ok(Self {
+            view,
+            selection,
+            deletion,
+            separated_lca: separated_branch_lca(view, selection),
+            unjoined: plan_unjoined_replacement_frontiers(view, deletion)?,
+        })
+    }
+
+    fn fit(&self, slice: &Slice) -> Result<RangeFit, CommandError> {
+        if self.separated_lca.is_none() {
+            return Ok(self.fit_joined(slice)?.unwrap_or(RangeFit::NoFit));
+        }
+        match slice_boundary_contribution(slice) {
+            SliceBoundaryContribution::Both => {
+                if let Some(placement) = self.fit_separated_open_edges(slice)? {
+                    return Ok(RangeFit::Placed(placement));
+                }
+                if let Some(placed) = self.fit_joined(slice)? {
+                    return Ok(placed);
+                }
+                if let Some(placement) = self.fit_unjoined_boundary(false, slice) {
+                    return Ok(RangeFit::Placed(placement));
+                }
+                if let Some(placement) = self.fit_unjoined_boundary(true, slice) {
+                    return Ok(RangeFit::Placed(placement));
+                }
+            }
+            SliceBoundaryContribution::Start => {
+                if let Some(placement) = self.fit_unjoined_boundary(true, slice) {
+                    return Ok(RangeFit::Placed(placement));
+                }
+            }
+            SliceBoundaryContribution::End => {
+                if let Some(placement) = self.fit_unjoined_boundary(false, slice) {
+                    return Ok(RangeFit::Placed(placement));
+                }
+            }
+            SliceBoundaryContribution::Neither => {}
+        }
+        Ok(self
+            .fit_separated_branches(slice)?
+            .map(|boundary| RangeFit::Placed(RangePlacement::SeparatedBranches { boundary }))
+            .unwrap_or(RangeFit::NoFit))
+    }
+
+    fn fit_joined(&self, slice: &Slice) -> Result<Option<RangeFit>, CommandError> {
+        // The virtual tree is a pure planning workspace for the original
+        // selection's survivors. It is not an independently executable delete
+        // plan: the accepted result below owns the survivor endpoint, join,
+        // fitted Slice output, and final output selection before any mutation.
+        let Some(preview) = plan_joined_replacement_frontier(self.view, self.deletion)? else {
+            return Ok(None);
+        };
+        let join = preview
+            .join
+            .map(|join| capture_planned_join(self.view, join))
+            .transpose()?;
+        let target = preview.target;
+        Ok(match place_slice_at_frontier(&target, slice.clone()) {
+            PlacementOutcome::Placed(insertion) => Some(RangeFit::Placed(RangePlacement::Joined(
+                JoinedReplacementPlan {
+                    destination: PlannedEndpoint::capture(self.view, target.position())
+                        .ok_or_else(|| {
+                            CommandError::Corrupted(
+                                "cannot capture joined Slice replacement destination".into(),
+                            )
+                        })?,
+                    join,
+                    insertion,
+                },
+            ))),
+            PlacementOutcome::CompleteNoOutput => Some(RangeFit::DeletionOnly(join)),
+            PlacementOutcome::NoFit => None,
+        })
+    }
+
+    fn fit_separated_branches(
+        &self,
+        slice: &Slice,
+    ) -> Result<Option<PlannedBranchInsertion>, CommandError> {
+        let Some(lca) = self.separated_lca else {
+            return Ok(None);
+        };
+        let Some((parent, splits, right_boundary, blocks, list_merges)) =
+            fit_at_preserved_branch_boundary(self.view, self.selection, lca, slice)?
+        else {
+            return Ok(None);
+        };
+        let output =
+            crate::helpers::planned_block_output(&blocks, &list_merges).ok_or_else(|| {
+                CommandError::Corrupted(
+                    "fitted separated Slice boundary produced no planned output".into(),
+                )
+            })?;
+        Ok(Some(PlannedBranchInsertion {
+            parent,
+            splits,
+            right_boundary,
+            insertion: SliceInsertionPlan::BlockBoundary {
+                blocks,
+                list_merges,
+                output,
+            },
+        }))
+    }
+
+    fn fit_separated_open_edges(
+        &self,
+        slice: &Slice,
+    ) -> Result<Option<RangePlacement>, CommandError> {
+        if slice.open_start == 0 || slice.open_end == 0 || slice.content.len() < 3 {
+            return Ok(None);
+        }
+        let left_slice = Slice::new(vec![slice.content[0].clone()], slice.open_start, 0);
+        let middle_slice = Slice::new(slice.content[1..slice.content.len() - 1].to_vec(), 0, 0);
+        let right_slice = Slice::new(
+            vec![slice.content[slice.content.len() - 1].clone()],
+            0,
+            slice.open_end,
+        );
+        let Some(left) = self.fit_unjoined_insertion(true, &left_slice) else {
+            return Ok(None);
+        };
+        let Some(middle) = self.fit_separated_branches(&middle_slice)? else {
+            return Ok(None);
+        };
+        let Some(right) = self.fit_unjoined_insertion(false, &right_slice) else {
+            return Ok(None);
+        };
+        Ok(Some(RangePlacement::SeparatedOpenEdges {
+            left,
+            middle,
+            right,
+        }))
+    }
+
+    fn fit_unjoined_boundary(&self, use_left: bool, slice: &Slice) -> Option<RangePlacement> {
+        self.fit_unjoined_insertion(use_left, slice)
+            .map(RangePlacement::PreservedBoundary)
+    }
+
+    fn fit_unjoined_insertion(
+        &self,
+        use_left: bool,
+        slice: &Slice,
+    ) -> Option<PlannedBoundaryInsertion> {
+        let unjoined = self.unjoined.as_ref()?;
+        let resolved = self.selection.resolve(self.view)?;
+        let target = if use_left {
+            &unjoined.left
+        } else {
+            &unjoined.right
+        };
+        let position = if use_left {
+            resolved.from().position()
+        } else {
+            Position {
+                node: resolved.to().position().node,
+                offset: 0,
+                affinity: resolved.to().position().affinity,
+            }
+        };
+        let PlacementOutcome::Placed(insertion) = place_slice_at_frontier(&target, slice.clone())
+        else {
+            return None;
+        };
+        Some(PlannedBoundaryInsertion {
+            destination: PlannedEndpoint::capture(self.view, position)?,
+            target: SliceInsertionTargetShape::capture(&target),
+            insertion,
+        })
+    }
+}
+
+enum SliceBoundaryContribution {
+    Both,
+    Start,
+    End,
+    Neither,
+}
+
+/// Which original destination edges the Slice can contribute into. Bare inline
+/// content lives directly in a textblock and therefore contributes at both
+/// edges without an open wrapper. Structural roots contribute only through
+/// the edges advertised by Slice openness.
+fn slice_boundary_contribution(slice: &Slice) -> SliceBoundaryContribution {
+    if slice
+        .content
+        .iter()
+        .all(|fragment| editor_model::Schema::node_spec(fragment.node.as_type()).inline)
+    {
+        return SliceBoundaryContribution::Both;
+    }
+    match (slice.open_start > 0, slice.open_end > 0) {
+        (true, true) => SliceBoundaryContribution::Both,
+        (true, false) => SliceBoundaryContribution::Start,
+        (false, true) => SliceBoundaryContribution::End,
+        (false, false) => SliceBoundaryContribution::Neither,
+    }
+}
+
+fn capture_planned_join(
+    view: &DocView,
+    topology: crate::helpers::LinearJoinExecution,
+) -> Result<PlannedJoin, CommandError> {
+    if topology.trailing_page_break.is_some() {
+        return Err(CommandError::Corrupted(
+            "Slice replacement join cannot consume a surviving PageBreak".into(),
+        ));
+    }
+    let capture = |node| {
+        PlannedEndpoint::capture(view, Position::new(node, 0))
+            .ok_or_else(|| CommandError::Corrupted("cannot capture planned Slice join node".into()))
+    };
+    let container_merges = topology
+        .container_merges
+        .into_iter()
+        .map(|(target, source)| {
+            Ok(PlannedContainerMerge {
+                target: capture(target)?,
+                source: capture(source)?,
+            })
+        })
+        .collect::<Result<Vec<_>, CommandError>>()?;
+    let affected = topology
+        .affected
+        .into_iter()
+        .map(capture)
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(PlannedJoin {
+        from_textblock: capture(topology.from_textblock)?,
+        to_textblock: capture(topology.to_textblock)?,
+        prune: topology
+            .prune
+            .into_iter()
+            .map(capture)
+            .collect::<Result<Vec<_>, _>>()?,
+        container_merges,
+        affected,
+    })
+}
+
+/// Lowest common branch frontier retained from the original range. The Slice
+/// is deliberately not consulted here: source placement chooses among the
+/// joined and separated candidates after both destination boundaries exist.
+fn separated_branch_lca(view: &DocView, selection: Selection) -> Option<Dot> {
+    let Some(resolved) = selection.resolve(view) else {
+        return None;
+    };
+    let from = resolved.from().position();
+    let to = resolved.to().position();
+    if from.node == to.node {
+        return None;
+    }
+
+    let Some(lca) = find_lowest_common_ancestor(view, from.node, to.node) else {
+        return None;
+    };
+    let Some(from_path) = path_from_ancestor(view, from.node, lca) else {
+        return None;
+    };
+    let Some(to_path) = path_from_ancestor(view, to.node, lca) else {
+        return None;
+    };
+    let Some((&from_branch, &to_branch)) = from_path.first().zip(to_path.first()) else {
+        return None;
+    };
+    (from_branch < to_branch).then_some(lca)
+}
+
+/// Fit a closed structural source at the first schema-valid frontier that
+/// retains both original destination branches.
+fn fit_at_preserved_branch_boundary(
+    view: &DocView,
+    selection: Selection,
+    lca: Dot,
+    slice: &Slice,
+) -> Result<
+    Option<(
+        PlannedEndpoint,
+        Vec<PlannedBranchSplit>,
+        PlannedBranchNode,
+        Vec<Fragment>,
+        Vec<crate::helpers::PlannedListMerge>,
+    )>,
+    CommandError,
+> {
+    let (parent, blocks) = {
+        let mut candidate = lca;
+        loop {
+            let Some(node) = view.node(candidate) else {
+                return Ok(None);
+            };
+            if block_boundary_fragments(slice, node.node_type()).is_some()
+                && can_split_from_lca_to(view, lca, candidate)
+                && let PlacementOutcome::Placed(SliceInsertionPlan::BlockBoundary {
+                    blocks, ..
+                }) = place_slice_at_position(view, Position::new(candidate, 0), slice.clone())
+            {
+                break (candidate, blocks);
+            }
+            if node.spec().isolating {
+                return Ok(None);
+            }
+            let Some(parent) = node.parent() else {
+                return Ok(None);
+            };
+            candidate = parent.id();
+        }
+    };
+    let resolved = selection
+        .resolve(view)
+        .ok_or_else(|| CommandError::Corrupted("cannot resolve Slice replacement range".into()))?;
+    let from = resolved.from().node();
+    let to = resolved.to().node();
+    let left = dot_path_from_ancestor(view, parent, from).ok_or_else(|| {
+        CommandError::Corrupted("left Slice boundary escaped its fitted parent".into())
+    })?;
+    let right = dot_path_from_ancestor(view, parent, to).ok_or_else(|| {
+        CommandError::Corrupted("right Slice boundary escaped its fitted parent".into())
+    })?;
+    let common = left
+        .iter()
+        .zip(&right)
+        .take_while(|(left, right)| left == right)
+        .count();
+    if common == left.len() || common == right.len() {
+        return Ok(None);
+    }
+    let left_block = view.node(left[0]).map(|node| ExistingBlock {
+        id: Some(node.id()),
+        node_type: node.node_type(),
+    });
+    let right_block = view.node(right[0]).map(|node| ExistingBlock {
+        id: Some(node.id()),
+        node_type: node.node_type(),
+    });
+    let Some(list_merges) =
+        crate::helpers::plan_adjacent_list_merges(left_block, &blocks, right_block)
+    else {
+        return Ok(None);
+    };
+
+    let capture = |node| {
+        PlannedEndpoint::capture(view, Position::new(node, 0)).ok_or_else(|| {
+            CommandError::Corrupted("cannot capture planned Slice boundary node".into())
+        })
+    };
+    let mut right_boundary = PlannedBranchNode::Existing(capture(right[common])?);
+    let mut splits = Vec::with_capacity(common);
+    for (index, wrapper) in left[..common].iter().rev().enumerate() {
+        let output = PlannedOutputKey(index as u32);
+        splits.push(PlannedBranchSplit {
+            wrapper: capture(*wrapper)?,
+            first_right: right_boundary,
+            output,
+        });
+        right_boundary = PlannedBranchNode::Output(output);
+    }
+    let parent = capture(parent)?;
+    Ok(Some((parent, splits, right_boundary, blocks, list_merges)))
+}
+
+fn dot_path_from_ancestor(view: &DocView, ancestor: Dot, node: Dot) -> Option<Vec<Dot>> {
+    let mut path = Vec::new();
+    let mut current = node;
+    while current != ancestor {
+        path.push(current);
+        current = view.node(current)?.parent()?.id();
+    }
+    path.reverse();
+    Some(path)
+}
+
+fn can_split_from_lca_to(view: &DocView, lca: Dot, candidate: Dot) -> bool {
+    let mut split = lca;
+    while split != candidate {
+        let Some(split_node) = view.node(split) else {
+            return false;
+        };
+        if split_node.spec().isolating || !can_duplicate_under_parent(&split_node) {
+            return false;
+        }
+        let Some(parent) = split_node.parent() else {
+            return false;
+        };
+        split = parent.id();
+    }
+    true
+}
+
+fn can_duplicate_under_parent(node: &editor_model::NodeView<'_>) -> bool {
+    let Some(parent) = node.parent() else {
+        return false;
+    };
+    let Some(index) = node.index() else {
+        return false;
+    };
+    let mut child_types: Vec<_> = parent
+        .children()
+        .map(|child| match child {
+            ChildView::Block(block) => block.node_type(),
+            ChildView::Leaf(leaf) => leaf.node_type(),
+        })
+        .collect();
+    child_types.insert(index + 1, node.node_type());
+    content_placement(parent.node_type(), &child_types).is_valid()
+}
+
+#[cfg(test)]
+mod tests {
+    use editor_macros::state;
+    use editor_model::{
+        Fragment, PlainNode, PlainPageBreakNode, PlainParagraphNode, PlainTextNode,
+    };
+
+    use super::super::{FitOutcome, SliceFitPlan, SliceFitPlanKind, fit_slice};
+    use super::*;
+
+    #[test]
+    fn empty_slice_is_no_op() {
+        let (state, p) = state! {
+            doc { root { p: paragraph { text("x") } } }
+            selection: (p, 0)
+        };
+        assert!(matches!(
+            fit_slice(
+                &state,
+                Selection::collapsed(Position::new(p, 0)),
+                Slice::new(vec![], 0, 0),
+            )
+            .unwrap(),
+            FitOutcome::NoOp
+        ));
+    }
+
+    #[test]
+    fn page_break_in_non_isolating_nested_paragraph_has_a_plan() {
+        let (state, p) = state! {
+            doc { root {
+                blockquote { p: paragraph { text("target") } }
+                paragraph {}
+            } }
+            selection: (p, 3)
+        };
+        let slice = Slice::new(
+            vec![Fragment {
+                node: PlainNode::Paragraph(PlainParagraphNode::default()),
+                modifiers: vec![],
+                carry: vec![],
+                children: vec![
+                    Fragment::leaf(PlainNode::Text(PlainTextNode { text: "lo".into() })),
+                    Fragment::leaf(PlainNode::PageBreak(PlainPageBreakNode::default())),
+                ],
+            }],
+            0,
+            0,
+        );
+
+        assert!(matches!(
+            fit_slice(&state, Selection::collapsed(Position::new(p, 3)), slice,).unwrap(),
+            FitOutcome::Plan(_)
+        ));
+    }
+
+    #[test]
+    fn task3_programmatic_slice_with_invalid_open_edge_is_no_fit() {
+        let (state, p) = state! {
+            doc { root { p: paragraph { text("target") } } }
+            selection: (p, 3)
+        };
+        let slice = Slice {
+            content: vec![Fragment {
+                node: PlainNode::Paragraph(PlainParagraphNode::default()),
+                modifiers: vec![],
+                carry: vec![],
+                children: vec![Fragment::leaf(PlainNode::Text(PlainTextNode {
+                    text: "x".into(),
+                }))],
+            }],
+            open_start: u32::MAX,
+            open_end: 0,
+        };
+
+        assert!(matches!(
+            fit_slice(&state, Selection::collapsed(Position::new(p, 3)), slice).unwrap(),
+            FitOutcome::NoFit
+        ));
+    }
+
+    #[test]
+    fn non_empty_but_lossless_empty_inline_slice_is_no_op() {
+        let (state, p) = state! {
+            doc { root { p: paragraph { text("target") } } }
+            selection: (p, 3)
+        };
+        let slice = Slice::new(
+            vec![Fragment::leaf(PlainNode::Text(PlainTextNode {
+                text: String::new(),
+            }))],
+            0,
+            0,
+        );
+
+        assert!(matches!(
+            fit_slice(&state, Selection::collapsed(Position::new(p, 3)), slice).unwrap(),
+            FitOutcome::NoOp
+        ));
+    }
+
+    #[test]
+    fn non_empty_lossless_empty_slice_replaces_a_range_with_deletion() {
+        let (state, _p) = state! {
+            doc { root { p: paragraph { text("abc") } } }
+            selection: (p, 1) -> (p, 2)
+        };
+        let slice = Slice::new(
+            vec![Fragment::leaf(PlainNode::Text(PlainTextNode {
+                text: String::new(),
+            }))],
+            0,
+            0,
+        );
+
+        assert!(matches!(
+            fit_slice(&state, state.selection.unwrap(), slice).unwrap(),
+            FitOutcome::Plan(SliceFitPlan {
+                kind: SliceFitPlanKind::Linear(LinearFitPlan {
+                    mutation: LinearMutation::RangeReplacement {
+                        placement: RangePlacement::DeletionOnly { .. },
+                        ..
+                    },
+                    ..
+                }),
+            })
+        ));
+    }
+
+    #[test]
+    fn structurally_valid_programmatic_slice_within_the_structure_budget_has_a_plan() {
+        let (state, p) = state! {
+            doc { root { p: paragraph { text("x") } } }
+            selection: (p, 0)
+        };
+        let mut nested = Fragment::leaf(PlainNode::Paragraph(PlainParagraphNode::default()))
+            .with_children(vec![Fragment::leaf(PlainNode::Text(PlainTextNode {
+                text: "deep".into(),
+            }))]);
+        for _ in 0..14 {
+            nested = Fragment::leaf(PlainNode::BulletList(
+                editor_model::PlainBulletListNode::default(),
+            ))
+            .with_children(vec![
+                Fragment::leaf(PlainNode::ListItem(
+                    editor_model::PlainListItemNode::default(),
+                ))
+                .with_children(vec![
+                    Fragment::leaf(PlainNode::Paragraph(PlainParagraphNode::default())),
+                    nested,
+                ]),
+            ]);
+        }
+        let slice = Slice::new(vec![nested], 0, 0);
+
+        assert!(matches!(
+            fit_slice(&state, Selection::collapsed(Position::new(p, 0)), slice).unwrap(),
+            FitOutcome::Plan(_)
+        ));
+    }
+
+    #[test]
+    fn programmatic_slice_beyond_the_structure_budget_is_no_fit() {
+        let (state, p) = state! {
+            doc { root { p: paragraph { text("x") } } }
+            selection: (p, 0)
+        };
+        let mut inner = Fragment::leaf(PlainNode::Paragraph(PlainParagraphNode::default()));
+        for _ in 0..16 {
+            inner = Fragment::leaf(editor_model::PlainNode::BulletList(
+                editor_model::PlainBulletListNode::default(),
+            ))
+            .with_children(vec![
+                Fragment::leaf(editor_model::PlainNode::ListItem(
+                    editor_model::PlainListItemNode::default(),
+                ))
+                .with_children(vec![inner]),
+            ]);
+        }
+        let slice = Slice::new(vec![inner], 0, 0);
+
+        let outcome = fit_slice(&state, Selection::collapsed(Position::new(p, 0)), slice).unwrap();
+        assert!(matches!(outcome, FitOutcome::NoFit));
+    }
+}

--- a/crates/editor-commands/src/judgments/slice/table_fitter.rs
+++ b/crates/editor-commands/src/judgments/slice/table_fitter.rs
@@ -1,0 +1,288 @@
+//! Pure planning for two-dimensional table Slice semantics.
+
+use editor_clipboard::Slice;
+use editor_model::{DocView, Fragment, NodeType, PlainNode};
+use editor_state::{Position, Selection, enclosing_table_cell};
+
+use super::fit_fragment_forest;
+use crate::CommandError;
+use crate::helpers::{PlannedEndpoint, node_type_path};
+
+pub(crate) struct TableGridPlan {
+    pub(crate) source_rows: Vec<Vec<Fragment>>,
+    pub(crate) table: PlannedEndpoint,
+    pub(crate) target_cells: Vec<Vec<PlannedEndpoint>>,
+    pub(crate) anchor_row: usize,
+    pub(crate) anchor_col: usize,
+    pub(crate) original_rows: usize,
+    pub(crate) original_cols: usize,
+    pub(crate) append_rows: usize,
+    pub(crate) append_cols: usize,
+    pub(crate) final_selection: TableFinalSelection,
+}
+
+pub(crate) struct CellFillPlan {
+    pub(crate) cells: Vec<PlannedEndpoint>,
+    pub(crate) original_child_types: Vec<Vec<NodeType>>,
+    pub(crate) blocks: Vec<Fragment>,
+    pub(crate) final_selection: TableFinalSelection,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum TableFinalSelection {
+    /// Resolve after cell replacement so newly authored paragraph ids need not
+    /// be guessed during planning.
+    FirstTextInAnchorCell,
+}
+
+pub(super) fn selection_is_wholly_in_one_cell(view: &DocView, selection: Selection) -> bool {
+    let Some(resolved) = selection.resolve(view) else {
+        return false;
+    };
+    let anchor = enclosing_table_cell(view, resolved.anchor().node());
+    let head = enclosing_table_cell(view, resolved.head().node());
+    anchor.is_some() && anchor == head
+}
+
+pub(super) fn fit_table_grid(
+    view: &DocView,
+    selection: Selection,
+    slice: &Slice,
+) -> Result<Option<TableGridPlan>, CommandError> {
+    let Some(source_rows) = source_grid(slice) else {
+        return Ok(None);
+    };
+    let source_row_count = source_rows.len();
+    let source_col_count = source_rows.first().map(Vec::len).unwrap_or(0);
+    if source_row_count == 0 || source_col_count == 0 {
+        return Ok(None);
+    }
+    let Some(resolved) = selection.resolve(view) else {
+        return Ok(None);
+    };
+    let (table_id, anchor_row, anchor_col) = if let Some(rect) = resolved.as_cell_rect() {
+        if rect.cells().is_empty() {
+            return Err(CommandError::Corrupted(
+                "table-grid selection has no anchor cell".into(),
+            ));
+        }
+        (rect.table.id(), *rect.rows.start(), *rect.cols.start())
+    } else {
+        let Some(cell_id) = enclosing_table_cell(view, resolved.head().node()) else {
+            return Ok(None);
+        };
+        if enclosing_table_cell(view, resolved.anchor().node()) != Some(cell_id) {
+            return Ok(None);
+        }
+        let cell = view
+            .node(cell_id)
+            .ok_or(CommandError::NodeNotFound(cell_id))?;
+        let row = cell.parent().ok_or(CommandError::NoParent(cell_id))?;
+        let table = row.parent().ok_or(CommandError::NoParent(row.id()))?;
+        let row_index = row
+            .index()
+            .ok_or_else(|| CommandError::orphan_child(row.id(), table.id()))?;
+        let col_index = cell
+            .index()
+            .ok_or_else(|| CommandError::orphan_child(cell_id, row.id()))?;
+        (table.id(), row_index, col_index)
+    };
+
+    let table = PlannedEndpoint::capture(view, Position::new(table_id, 0))
+        .ok_or_else(|| CommandError::Corrupted("cannot capture table-grid Slice target".into()))?;
+    let table_node = view
+        .node(table_id)
+        .ok_or(CommandError::NodeNotFound(table_id))?;
+    let original_rows = table_node.child_blocks().count();
+    let original_cols = table_node
+        .child_blocks()
+        .next()
+        .map(|row| row.child_blocks().count())
+        .unwrap_or(0);
+    if original_rows == 0 || original_cols == 0 {
+        return Ok(None);
+    }
+    let target_row_count = source_row_count.min(original_rows.saturating_sub(anchor_row));
+    let target_col_count = source_col_count.min(original_cols.saturating_sub(anchor_col));
+    let target_cells = (0..target_row_count)
+        .map(|row_offset| {
+            (0..target_col_count)
+                .map(|col_offset| {
+                    let cell_id = table_node
+                        .child_blocks()
+                        .nth(anchor_row + row_offset)
+                        .and_then(|row| row.child_blocks().nth(anchor_col + col_offset))
+                        .map(|cell| cell.id())
+                        .ok_or_else(|| {
+                            CommandError::Corrupted("cannot capture table-grid target cell".into())
+                        })?;
+                    PlannedEndpoint::capture(view, Position::new(cell_id, 0)).ok_or_else(|| {
+                        CommandError::Corrupted("cannot capture table-grid target cell slot".into())
+                    })
+                })
+                .collect::<Result<Vec<_>, CommandError>>()
+        })
+        .collect::<Result<Vec<_>, CommandError>>()?;
+    if target_cells.first().and_then(|row| row.first()).is_none() {
+        return Err(CommandError::Corrupted(
+            "table-grid plan has no target anchor slot".into(),
+        ));
+    }
+    let append_rows = (anchor_row + source_row_count).saturating_sub(original_rows);
+    let append_cols = (anchor_col + source_col_count).saturating_sub(original_cols);
+    Ok(Some(TableGridPlan {
+        source_rows,
+        table,
+        target_cells,
+        anchor_row,
+        anchor_col,
+        original_rows,
+        original_cols,
+        append_rows,
+        append_cols,
+        final_selection: TableFinalSelection::FirstTextInAnchorCell,
+    }))
+}
+
+pub(super) fn is_pure_table_grid_slice(slice: &Slice) -> bool {
+    slice.open_start == 0
+        && slice.open_end == 0
+        && slice.content.len() == 1
+        && slice
+            .content
+            .first()
+            .is_some_and(|table| rectangular_table_width(table).is_some())
+}
+
+pub(super) fn fit_cell_fill(
+    view: &DocView,
+    selection: Selection,
+    slice: &Slice,
+) -> Option<CellFillPlan> {
+    let resolved = selection.resolve(view)?;
+    let rect = resolved.as_cell_rect()?;
+    let cell_ids: Vec<_> = rect.cells().iter().map(|cell| cell.id()).collect();
+    let anchor_cell_id = *cell_ids.first()?;
+    let cell_path = node_type_path(view, anchor_cell_id)?;
+    let blocks = slice_to_cell_blocks(slice);
+    if blocks.is_empty() {
+        return None;
+    }
+    let blocks = fit_fragment_forest(blocks, &cell_path)?;
+    let original_child_types = cell_ids
+        .iter()
+        .map(|cell_id| {
+            view.node(*cell_id).map(|cell| {
+                cell.children()
+                    .map(|child| match child {
+                        editor_model::ChildView::Block(block) => block.node_type(),
+                        editor_model::ChildView::Leaf(leaf) => leaf.node_type(),
+                    })
+                    .collect::<Vec<_>>()
+            })
+        })
+        .collect::<Option<Vec<_>>>()?;
+    let cells = cell_ids
+        .iter()
+        .map(|cell_id| PlannedEndpoint::capture(view, Position::new(*cell_id, 0)))
+        .collect::<Option<Vec<_>>>()?;
+    Some(CellFillPlan {
+        cells,
+        original_child_types,
+        blocks,
+        final_selection: TableFinalSelection::FirstTextInAnchorCell,
+    })
+}
+
+fn source_grid(slice: &Slice) -> Option<Vec<Vec<Fragment>>> {
+    if slice.open_start != 0 || slice.open_end != 0 || slice.content.len() != 1 {
+        return None;
+    }
+    rectangular_table_width(slice.content.first()?)?;
+    let mut fitted = fit_fragment_forest(slice.content.clone(), &[NodeType::Root])?;
+    if fitted.len() != 1 {
+        return None;
+    }
+    let table = fitted.pop()?;
+    rectangular_table_width(&table)?;
+    let (_, _, _, rows) = table.into_parts();
+    Some(
+        rows.into_iter()
+            .map(|row| {
+                let (_, _, _, cells) = row.into_parts();
+                cells
+            })
+            .collect(),
+    )
+}
+
+fn rectangular_table_width(table: &Fragment) -> Option<usize> {
+    if !matches!(table.node, PlainNode::Table(_)) || table.children.is_empty() {
+        return None;
+    }
+    let mut width = None;
+    for row in &table.children {
+        if !matches!(row.node, PlainNode::TableRow(_))
+            || row.children.is_empty()
+            || row
+                .children
+                .iter()
+                .any(|cell| !matches!(cell.node, PlainNode::TableCell(_)))
+        {
+            return None;
+        }
+        match width {
+            Some(width) if width != row.children.len() => return None,
+            None => width = Some(row.children.len()),
+            _ => {}
+        }
+    }
+    width
+}
+
+fn slice_to_cell_blocks(slice: &Slice) -> Vec<Fragment> {
+    let mut out = Vec::new();
+    let mut inline_run = Vec::new();
+    let flush = |run: &mut Vec<Fragment>, out: &mut Vec<Fragment>| {
+        if !run.is_empty() {
+            out.push(Fragment {
+                node: PlainNode::Paragraph(editor_model::PlainParagraphNode::default()),
+                modifiers: vec![],
+                carry: vec![],
+                children: std::mem::take(run),
+            });
+        }
+    };
+    for child in &slice.content {
+        match &child.node {
+            PlainNode::Text(_) | PlainNode::HardBreak(_) | PlainNode::Tab(_) => {
+                inline_run.push(child.clone());
+            }
+            _ => {
+                flush(&mut inline_run, &mut out);
+                out.push(child.clone());
+            }
+        }
+    }
+    flush(&mut inline_run, &mut out);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn orphan_table_row_is_not_a_pure_table_grid_slice() {
+        let row = Fragment::leaf(PlainNode::TableRow(
+            editor_model::PlainTableRowNode::default(),
+        ))
+        .with_children(vec![Fragment::leaf(PlainNode::TableCell(
+            editor_model::PlainTableCellNode::default(),
+        ))]);
+        let slice = Slice::new(vec![row], 0, 0);
+
+        assert!(!is_pure_table_grid_slice(&slice));
+        assert!(source_grid(&slice).is_none());
+    }
+}

--- a/crates/editor-commands/src/lib.rs
+++ b/crates/editor-commands/src/lib.rs
@@ -17,8 +17,8 @@ pub use commands::*;
 pub use compose::*;
 pub use error::*;
 pub use judgments::{
-    SliceInsertionPlan, judge_expand_all, judge_expand_paragraph, judge_expand_sentence,
-    judge_expand_word, judge_indent_list, judge_outdent_list, judge_toggle_list_kind,
-    resolve_slice_insertion,
+    FitOutcome, SliceFitPlan, fit_slice, judge_expand_all, judge_expand_paragraph,
+    judge_expand_sentence, judge_expand_word, judge_indent_list, judge_outdent_list,
+    judge_toggle_list_kind,
 };
 pub use types::Verdict;

--- a/crates/editor-core/proptest-regressions/tests/dnd_judgment_parity.txt
+++ b/crates/editor-core/proptest-regressions/tests/dnd_judgment_parity.txt
@@ -7,3 +7,6 @@
 cc 08b774ad10f1bf065e049681ef236e49df944641f9c291b5b7546f3dd1f55db9 # shrinks to fixture_idx = 3, pos_off = 13, src_a = 12, src_b = 3, payload_idx = 4
 cc 51ac090bc459461da9cf50928acfedf0367e6b5d7688f545cea25d8c5bf45def # shrinks to fixture_idx = 1, pos_off = 16, src_a = 25, src_b = 26, payload_idx = 4
 cc 8af8c293ea40d3571b0d93e69a1973000b2c351f7b574cbee30ce693b4870d80 # shrinks to fixture_idx = 3, pos_off = 21, src_a = 3, src_b = 20, payload_idx = 4
+cc db34f687835797c4fe7ceb563b3e7ab83f1eb64a33b1f6ca2450ebc71e3b870c # shrinks to fixture_idx = 3, pos_off = 0, src_a = 3, src_b = 21, payload_idx = 5
+cc 5eaaf1f13546411d2be1ae9b643b4d99d2a86e4fe09bddf9a2905c6d9acbd555 # shrinks to fixture_idx = 1, pos_off = 0, src_a = 0, src_b = 0, payload_idx = 0
+cc 847764786e22bf7292aea39a9ae7a46ee7eeb39d0f4d004ad8cac962d8dd821b # shrinks to fixture_idx = 3, pos_off = 4, src_a = 0, src_b = 0, payload_idx = 2

--- a/crates/editor-core/src/editor.rs
+++ b/crates/editor-core/src/editor.rs
@@ -2249,6 +2249,28 @@ mod tests {
     use super::*;
     use crate::test_utils::{EditorSnapshot, apply_and_report_change};
 
+    fn text_and_page_break_signature(state: &State) -> String {
+        state
+            .view()
+            .root()
+            .expect("root")
+            .descendants()
+            .filter_map(|child| match child {
+                ChildView::Leaf(leaf) => leaf
+                    .as_char()
+                    .map(|ch| ch.to_string())
+                    .or_else(|| (leaf.node_type() == NodeType::PageBreak).then(|| "|".to_string())),
+                ChildView::Block(_) => None,
+            })
+            .collect()
+    }
+
+    fn assert_warm_matches_cold(state: &State) {
+        let cold = editor_state::ProjectedState::from_graph(state.projected.graph().clone())
+            .expect("cold projection");
+        assert_eq!(state.projected.projected(), cold.projected());
+    }
+
     // A frame's worth of IME composition traffic arrives as several consecutive
     // `TextInput` messages; `tick` coalesces them into batched reduces. The
     // coalesced drain must land on the same document, composition, and selection
@@ -2469,11 +2491,12 @@ mod tests {
             .expect("document-start position resolves")
             .position();
         drop(view);
-        editor.apply(Message::Selection {
-            op: SelectionOp::Set {
-                selection: Selection::collapsed(caret),
-            },
-        });
+        editor
+            .transact(|tr| {
+                tr.set_selection(Some(Selection::collapsed(caret)))?;
+                Ok(())
+            })
+            .unwrap();
         editor
     }
 
@@ -4338,7 +4361,7 @@ mod tests {
     }
 
     #[test]
-    fn internal_dnd_page_break_source_rejects_nested_inline_drop_indicator() {
+    fn internal_dnd_page_break_source_allows_nested_hoisted_drop_indicator() {
         let (initial, _p1, p2) = state! {
             doc { root {
                 p1: paragraph { text("a") page_break }
@@ -4370,11 +4393,11 @@ mod tests {
             },
         });
 
-        assert!(editor.drop_indicator_for_test().is_none());
+        assert!(editor.drop_indicator_for_test().is_some());
     }
 
     #[test]
-    fn internal_dnd_text_and_page_break_source_allows_nested_inline_drop_indicator() {
+    fn internal_dnd_text_and_page_break_source_allows_nested_hoisted_drop_indicator() {
         let (initial, _p1, p2) = state! {
             doc { root {
                 p1: paragraph { text("a") page_break }
@@ -4947,7 +4970,7 @@ mod tests {
     }
 
     #[test]
-    fn internal_drop_moves_text_and_discards_page_break_at_nested_destination() {
+    fn internal_drop_text_and_page_break_nested_moves_without_loss() {
         let (initial, _p1, p2) = state! {
             doc { root {
                 p1: paragraph { text("a") page_break }
@@ -4957,7 +4980,7 @@ mod tests {
             selection: (p1, 0) -> (p1, 2)
         };
         let source = initial.selection.expect("source selection");
-        let mut editor = Editor::new_test(initial);
+        let mut editor = Editor::new_test(initial.clone());
 
         crate::handle::apply_drop_for_test(
             &mut editor,
@@ -4966,21 +4989,14 @@ mod tests {
             InputModifiers::default(),
             Some(source),
         )
-        .expect("drop succeeds");
+        .expect("drop succeeds through non-isolating Blockquote");
 
-        let (expected, ..) = state! {
-            doc { root {
-                paragraph {}
-                blockquote { p2: paragraph { text("inaside") } }
-                paragraph {}
-            } }
-            selection: (p2, 2) -> (p2, 3)
-        };
-        editor_state::assert_state_eq!(editor.state(), &expected);
+        assert_eq!(text_and_page_break_signature(editor.state()), "ina|side");
+        assert_warm_matches_cold(editor.state());
     }
 
     #[test]
-    fn internal_drop_page_break_only_nested_preserves_source() {
+    fn internal_drop_page_break_only_nested_moves_without_loss() {
         let (initial, _p1, p2) = state! {
             doc { root {
                 p1: paragraph { text("a") page_break }
@@ -4999,13 +5015,14 @@ mod tests {
             InputModifiers::default(),
             Some(source),
         )
-        .expect("drop is a no-op");
+        .expect("drop succeeds through non-isolating Blockquote");
 
-        editor_state::assert_state_eq!(editor.state(), &initial);
+        assert_eq!(text_and_page_break_signature(editor.state()), "ain|side");
+        assert_warm_matches_cold(editor.state());
     }
 
     #[test]
-    fn external_drop_inserts_text_and_discards_page_break_at_nested_destination() {
+    fn external_drop_text_and_page_break_nested_hoists_without_loss() {
         let (source, ..) = state! {
             doc { root { p1: paragraph { text("a") page_break } } }
             selection: (p1, 0) -> (p1, 2)
@@ -5020,7 +5037,12 @@ mod tests {
             } }
             selection: (p2, 0)
         };
-        let mut editor = Editor::new_test(target);
+        let mut editor = Editor::new_test(target.clone());
+        let previous_tag = HistoryTag::PasteHtml {
+            plain_text: "previous".into(),
+            start: None,
+        };
+        editor.undo_history.set_last_tag(Some(previous_tag.clone()));
 
         crate::handle::apply_drop_for_test(
             &mut editor,
@@ -5032,16 +5054,11 @@ mod tests {
             InputModifiers::default(),
             None,
         )
-        .expect("drop succeeds");
+        .expect("drop succeeds through non-isolating Blockquote");
 
-        let (expected, ..) = state! {
-            doc { root {
-                blockquote { p2: paragraph { text("inaside") } }
-                paragraph {}
-            } }
-            selection: (p2, 2) -> (p2, 3)
-        };
-        editor_state::assert_state_eq!(editor.state(), &expected);
+        assert_eq!(text_and_page_break_signature(editor.state()), "ina|side");
+        assert_warm_matches_cold(editor.state());
+        assert_ne!(editor.last_history_tag(), Some(previous_tag));
     }
 
     #[test]
@@ -6000,7 +6017,7 @@ mod tests {
     }
 
     #[test]
-    fn dnd_hover_guard_rejection_leaves_no_telemetry_or_side_effect() {
+    fn dnd_hover_fitting_only_publishes_the_drop_indicator() {
         let (initial, _p1, p2) = state! {
             doc { root {
                 p1: paragraph { text("a") page_break }
@@ -6023,15 +6040,13 @@ mod tests {
             op: DndOp::StartInternalSelection,
         });
 
-        // Snapshot every observable side channel before the rejected hover.
+        // Snapshot the engine-side channels before the pure fitting judgment.
         let repair_before = editor.state().projected.projected().repair_stats;
         let epoch_before = editor.render_epoch;
         assert!(editor.pending_ops.is_empty());
         assert!(editor.pending_effects.is_empty());
 
-        // First hover targets a position the schema guard rejects (a page-break
-        // source dropping into a nested inline slot), decided by a side-effect-free
-        // judgment rather than a committed transaction.
+        // A PageBreak can hoist through Blockquote, so the hover is applicable.
         let events = editor.apply(Message::Dnd {
             op: DndOp::Over {
                 page: 0,
@@ -6042,18 +6057,18 @@ mod tests {
             },
         });
 
-        // The guard rejected and the judgment left no trace: no drop indicator, no
-        // repair telemetry, no queued ops/effects, no render invalidation.
-        assert!(editor.drop_indicator_for_test().is_none());
+        // Fitting itself leaves the document engine untouched; only the
+        // drop-indicator UI is published and invalidated for rendering.
+        assert!(editor.drop_indicator_for_test().is_some());
         assert_eq!(
             editor.state().projected.projected().repair_stats,
             repair_before
         );
-        assert_eq!(editor.render_epoch, epoch_before);
+        assert_eq!(editor.render_epoch, epoch_before.wrapping_add(1));
         assert!(editor.pending_ops.is_empty());
         assert!(editor.pending_effects.is_empty());
         assert!(
-            !events
+            events
                 .iter()
                 .any(|e| matches!(e, EditorEvent::RenderInvalidated))
         );

--- a/crates/editor-core/src/handle/clipboard.rs
+++ b/crates/editor-core/src/handle/clipboard.rs
@@ -1,10 +1,7 @@
 use editor_clipboard::{PayloadSource, Slice};
 use editor_commands::{self as commands};
 use editor_common::HistoryTag;
-use editor_model::{Fragment, PlainNode};
-use editor_state::{
-    ResolvedPosition, ResolvedPositionFlatExt, Selection, StableSelection, enclosing_table_cell,
-};
+use editor_state::{ResolvedPosition, ResolvedPositionFlatExt, Selection, StableSelection};
 use editor_transaction::HistoryMeta;
 
 use crate::editor::Editor;
@@ -41,7 +38,15 @@ pub fn handle_clipboard_op(editor: &mut Editor, op: ClipboardOp) -> Result<(), E
             } else {
                 (None, None)
             };
-            editor.transact(|tr| {
+            let mut paste_applied = false;
+            editor.transact_observable(|tr| {
+                let savepoint = tr.savepoint();
+                let applied = commands::insert_slice(tr, slice.clone(), provenance)?;
+                if !applied {
+                    tr.rollback(savepoint);
+                    return Ok(());
+                }
+                paste_applied = true;
                 if let Some(plain_text) = plain_text.clone() {
                     tr.update_meta(|m| {
                         m.history = HistoryMeta::Tagged {
@@ -52,25 +57,11 @@ pub fn handle_clipboard_op(editor: &mut Editor, op: ClipboardOp) -> Result<(), E
                         };
                     });
                 }
-                let in_cell_context = is_cell_rect_selection(tr) || caret_in_table_cell(tr);
-                if in_cell_context && slice_has_table(&slice) {
-                    commands::paste_cells_into_cell_rect(tr, slice.clone())?;
-                    return Ok(());
-                }
-                if is_cell_rect_selection(tr) {
-                    commands::fill_cell_rect_with_slice(tr, slice.clone(), provenance)?;
-                    return Ok(());
-                }
-                commands::chain!(
-                    tr,
-                    commands::optional!(commands::materialize_gap_paragraph()),
-                    commands::optional!(commands::ensure_paragraph()),
-                    commands::optional!(commands::delete_selection()),
-                    |tr| commands::insert_slice(tr, slice.clone(), provenance),
-                )?;
                 Ok(())
             })?;
-            if let (Some(start), Some(pre), Some(plain_text)) = (start_flat, pre_block, plain_text)
+            if paste_applied
+                && let (Some(start), Some(pre), Some(plain_text)) =
+                    (start_flat, pre_block, plain_text)
                 && matches!(
                     editor.last_history_tag(),
                     Some(HistoryTag::PasteHtml { .. })
@@ -122,17 +113,21 @@ pub fn handle_clipboard_op(editor: &mut Editor, op: ClipboardOp) -> Result<(), E
                         })
                         .collect()
                 };
-                editor.transact(|tr| {
+                editor.transact_observable(|tr| {
+                    let savepoint = tr.savepoint();
                     tr.set_selection(Some(range))?;
-                    commands::chain!(
-                        tr,
-                        commands::optional!(commands::delete_selection()),
-                        |tr| commands::insert_slice(
+                    let applied = if plain_slice.is_empty() {
+                        commands::delete_selection(tr)?
+                    } else {
+                        commands::insert_slice(
                             tr,
                             plain_slice.clone(),
-                            commands::types::SliceProvenance::Plain
-                        ),
-                    )?;
+                            commands::types::SliceProvenance::Plain,
+                        )?
+                    };
+                    if !applied {
+                        tr.rollback(savepoint);
+                    }
                     Ok(())
                 })?;
                 let mut changed = false;
@@ -174,54 +169,26 @@ pub fn handle_clipboard_op(editor: &mut Editor, op: ClipboardOp) -> Result<(), E
                 return Ok(());
             }
 
-            if !editor.try_undo() {
-                return Ok(());
-            }
-            editor.transact(|tr| {
-                commands::chain!(
-                    tr,
-                    commands::optional!(commands::materialize_gap_paragraph()),
-                    commands::optional!(commands::ensure_paragraph()),
-                    commands::optional!(commands::delete_selection()),
-                    |tr| commands::insert_slice(
-                        tr,
-                        plain_slice.clone(),
-                        commands::types::SliceProvenance::Plain
-                    ),
-                )?;
-                Ok(())
-            })
+            repaste_structural_as_text(editor, plain_slice)
         }
     }
 }
 
-fn is_cell_rect_selection(tr: &editor_transaction::Transaction) -> bool {
-    let Some(sel) = tr.selection() else {
-        return false;
+fn repaste_structural_as_text(editor: &mut Editor, plain_slice: Slice) -> Result<(), EditorError> {
+    let Some(paste_entry) = editor.undo_history.last_entry().cloned() else {
+        return Ok(());
     };
-    let doc = tr.view();
-    sel.resolve(&doc).and_then(|rs| rs.as_cell_rect()).is_some()
-}
 
-fn caret_in_table_cell(tr: &editor_transaction::Transaction) -> bool {
-    let Some(sel) = tr.selection() else {
-        return false;
-    };
-    if !sel.is_collapsed() {
-        return false;
-    }
-    let doc = tr.view();
-    enclosing_table_cell(&doc, sel.head.node).is_some()
-}
-
-fn slice_has_table(slice: &Slice) -> bool {
-    fn walk(f: &Fragment) -> bool {
-        if matches!(f.node, PlainNode::Table(_)) {
-            return true;
+    editor.transact_observable(|tr| {
+        let savepoint = tr.savepoint();
+        tr.apply_undo_entry_inverse(&paste_entry)?;
+        if !plain_slice.is_empty()
+            && !commands::insert_slice(tr, plain_slice, commands::types::SliceProvenance::Plain)?
+        {
+            tr.rollback(savepoint);
         }
-        f.children.iter().any(walk)
-    }
-    slice.content.iter().any(walk)
+        Ok(())
+    })
 }
 
 #[cfg(test)]
@@ -230,7 +197,10 @@ mod tests {
     use crate::state_field::StateField;
     use editor_common::HistoryTag;
     use editor_macros::state;
-    use editor_model::ModifierType;
+    use editor_model::{
+        ChildView, Fragment, ModifierType, NodeType, PlainNode, PlainParagraphNode,
+        PlainTableCellNode, PlainTextNode,
+    };
     use editor_resource::Resource;
     use editor_state::{
         Position, ResolvedPositionFlatExt, Selection, assert_doc_eq, assert_state_eq,
@@ -243,6 +213,22 @@ mod tests {
         events.iter().any(|event| {
             matches!(event, EditorEvent::StateChanged { fields } if fields.contains(&field))
         })
+    }
+
+    fn text_and_page_break_signature(state: &editor_state::State) -> String {
+        state
+            .view()
+            .root()
+            .expect("root")
+            .descendants()
+            .filter_map(|child| match child {
+                ChildView::Leaf(leaf) => leaf
+                    .as_char()
+                    .map(|ch| ch.to_string())
+                    .or_else(|| (leaf.node_type() == NodeType::PageBreak).then(|| "|".to_string())),
+                ChildView::Block(_) => None,
+            })
+            .collect()
     }
 
     #[test]
@@ -277,6 +263,63 @@ mod tests {
     }
 
     #[test]
+    fn deeply_nested_proprietary_metadata_reaches_no_fit_without_stack_overflow() {
+        const CHILD_ENV: &str = "TYPIE_DEEP_SLICE_CLIPBOARD_CHILD";
+        if std::env::var_os(CHILD_ENV).is_some() {
+            std::thread::Builder::new()
+                .stack_size(256 * 1024)
+                .spawn(|| {
+                    let mut fragment =
+                        Fragment::leaf(PlainNode::Paragraph(PlainParagraphNode::default()))
+                            .with_children(vec![Fragment::leaf(PlainNode::Text(PlainTextNode {
+                                text: "deep".into(),
+                            }))]);
+                    for _ in 0..4096 {
+                        fragment =
+                            Fragment::leaf(PlainNode::TableCell(PlainTableCellNode::default()))
+                                .with_children(vec![fragment]);
+                    }
+                    drop(fragment.clone().into_subtree());
+                    let payload =
+                        Slice::new(vec![fragment], 0, 0).to_payload(&Resource::new_test());
+                    let (state, ..) = state! {
+                        doc { root {
+                            target: paragraph { text("unchanged") }
+                        } }
+                        selection: (target, 0)
+                    };
+                    let before = state.clone();
+                    let mut editor = Editor::new_test(state);
+                    editor.apply(Message::Clipboard {
+                        op: ClipboardOp::Paste {
+                            html: Some(payload.html),
+                            text: payload.text,
+                        },
+                    });
+                    assert_state_eq!(editor.state(), &before);
+                })
+                .expect("spawn bounded-stack clipboard worker")
+                .join()
+                .expect("deep metadata paste remains stack-safe");
+            return;
+        }
+
+        let status = std::process::Command::new(std::env::current_exe().expect("test executable"))
+            .args([
+                "--exact",
+                "handle::clipboard::tests::deeply_nested_proprietary_metadata_reaches_no_fit_without_stack_overflow",
+                "--nocapture",
+            ])
+            .env(CHILD_ENV, "1")
+            .status()
+            .expect("spawn isolated deep metadata test");
+        assert!(
+            status.success(),
+            "deep metadata clipboard path crashed in the isolated test process"
+        );
+    }
+
+    #[test]
     fn paste_text_replaces_node_selection() {
         let (s, ..) = state! {
             doc { r: root {
@@ -300,6 +343,369 @@ mod tests {
                 paragraph { text("c") }
             } }
             selection: (p1, 1)
+        };
+        assert_state_eq!(editor.state(), &expected);
+    }
+
+    #[test]
+    fn paste_plain_text_at_cell_caret_uses_linear_fitting() {
+        let (initial, ..) = state! {
+            doc { root {
+                table {
+                    table_row {
+                        table_cell { p: paragraph { text("ab") } }
+                    }
+                }
+                paragraph {}
+            } }
+            selection: (p, 1)
+        };
+        let mut editor = Editor::new_test(initial);
+
+        editor.apply(Message::Clipboard {
+            op: ClipboardOp::Paste {
+                html: None,
+                text: "X".into(),
+            },
+        });
+
+        let (expected, ..) = state! {
+            doc { root {
+                table {
+                    table_row {
+                        table_cell { p: paragraph { text("aXb") } }
+                    }
+                }
+                paragraph {}
+            } }
+            selection: (p, 2)
+        };
+        assert_state_eq!(editor.state(), &expected);
+    }
+
+    #[test]
+    fn paste_closed_block_across_distinct_lists_preserves_both_list_boundaries() {
+        let (source, ..) = state! {
+            doc { root: root {
+                paragraph { text("before") }
+                horizontal_rule
+                paragraph { text("after") }
+            } }
+            selection: (root, 1, >) -> (root, 2, <)
+        };
+        let payload = Slice::extract(&source)
+            .expect("horizontal-rule selection extracts")
+            .to_payload(&Resource::new_test());
+
+        let (target, left_list, left_item, left, right_list, right_item, right) = state! {
+            doc { root {
+                left_list: bullet_list {
+                    left_item: list_item { left: paragraph { text("ab") } }
+                }
+                right_list: ordered_list {
+                    right_item: list_item { right: paragraph { text("cd") } }
+                }
+                paragraph {}
+            } }
+            selection: (left, 1) -> (right, 1)
+        };
+        let before_paste = target.clone();
+        let mut editor = Editor::new_test(target);
+
+        editor.apply(Message::Clipboard {
+            op: ClipboardOp::Paste {
+                html: Some(payload.html),
+                text: payload.text,
+            },
+        });
+
+        let (expected, ..) = state! {
+            doc { root: root {
+                bullet_list {
+                    list_item { paragraph { text("a") } }
+                }
+                horizontal_rule
+                ordered_list {
+                    list_item { paragraph { text("d") } }
+                }
+                paragraph {}
+            } }
+            selection: (root, 1, >) -> (root, 2, <)
+        };
+        assert_state_eq!(editor.state(), &expected);
+
+        {
+            let view = editor.state().view();
+            assert_eq!(
+                view.node(left_list).unwrap().node_type(),
+                NodeType::BulletList
+            );
+            assert_eq!(
+                view.node(left_item).unwrap().node_type(),
+                NodeType::ListItem
+            );
+            assert_eq!(view.node(left).unwrap().inline_text(), "a");
+            assert_eq!(
+                view.node(right_list).unwrap().node_type(),
+                NodeType::OrderedList
+            );
+            assert_eq!(
+                view.node(right_item).unwrap().node_type(),
+                NodeType::ListItem
+            );
+            assert_eq!(view.node(right).unwrap().inline_text(), "d");
+        }
+        let cold =
+            editor_state::ProjectedState::from_graph(editor.state().projected.graph().clone())
+                .expect("cold rebuild projects");
+        assert_eq!(editor.state().projected.projected(), cold.projected());
+
+        editor.apply(Message::History {
+            op: HistoryOp::Undo,
+        });
+        assert_state_eq!(editor.state(), &before_paste);
+        editor.apply(Message::History {
+            op: HistoryOp::Redo,
+        });
+        assert_state_eq!(editor.state(), &expected);
+        let view = editor.state().view();
+        for survivor in [left_list, left_item, left, right_list, right_item, right] {
+            assert!(
+                view.node(survivor).is_some(),
+                "replacement survivor {survivor:?} lost identity after redo"
+            );
+        }
+    }
+
+    #[test]
+    fn paste_closed_block_across_items_splits_the_shared_list() {
+        let (source, ..) = state! {
+            doc { root: root {
+                paragraph { text("before") }
+                horizontal_rule
+                paragraph { text("after") }
+            } }
+            selection: (root, 1, >) -> (root, 2, <)
+        };
+        let payload = Slice::extract(&source)
+            .expect("horizontal-rule selection extracts")
+            .to_payload(&Resource::new_test());
+
+        let (target, ..) = state! {
+            doc { root {
+                bullet_list {
+                    list_item { left: paragraph { text("ab") } }
+                    list_item { right: paragraph { text("cd") } }
+                }
+                paragraph {}
+            } }
+            selection: (left, 1) -> (right, 1)
+        };
+        let mut editor = Editor::new_test(target);
+
+        editor.apply(Message::Clipboard {
+            op: ClipboardOp::Paste {
+                html: Some(payload.html),
+                text: payload.text,
+            },
+        });
+
+        let (expected, ..) = state! {
+            doc { root: root {
+                bullet_list {
+                    list_item { paragraph { text("a") } }
+                }
+                horizontal_rule
+                bullet_list {
+                    list_item { paragraph { text("d") } }
+                }
+                paragraph {}
+            } }
+            selection: (root, 1, >) -> (root, 2, <)
+        };
+        assert_state_eq!(editor.state(), &expected);
+    }
+
+    #[test]
+    fn paste_closed_list_across_lists_merges_into_the_earlier_list_kind() {
+        let (source, ..) = state! {
+            doc { source_root: root {
+                bullet_list {
+                    list_item { paragraph { text("X") } }
+                }
+                paragraph {}
+            } }
+            selection: (source_root, 0, >) -> (source_root, 1, <)
+        };
+        let payload = Slice::extract(&source)
+            .expect("closed list selection extracts")
+            .to_payload(&Resource::new_test());
+
+        let (target, ..) = state! {
+            doc { root {
+                ordered_list {
+                    list_item { left: paragraph { text("ab") } }
+                }
+                bullet_list {
+                    list_item { right: paragraph { text("cd") } }
+                }
+                paragraph {}
+            } }
+            selection: (left, 1) -> (right, 1)
+        };
+        let before_paste = target.clone();
+        let mut editor = Editor::new_test(target);
+
+        editor.apply(Message::Clipboard {
+            op: ClipboardOp::Paste {
+                html: Some(payload.html),
+                text: payload.text,
+            },
+        });
+
+        let (expected, ..) = state! {
+            doc { root {
+                ordered_list {
+                    list_item { paragraph { text("a") } }
+                    list_item { paragraph { text("X") } }
+                    list_item { right_tail: paragraph { text("d") } }
+                }
+                paragraph {}
+            } }
+            selection: (right_tail, 0)
+        };
+        assert_state_eq!(editor.state(), &expected);
+
+        let cold =
+            editor_state::ProjectedState::from_graph(editor.state().projected.graph().clone())
+                .expect("cold rebuild projects");
+        assert_eq!(
+            editor.state().projected.projected(),
+            cold.projected(),
+            "warm/cold projection diverged after list replacement"
+        );
+
+        editor.apply(Message::History {
+            op: HistoryOp::Undo,
+        });
+        assert_state_eq!(editor.state(), &before_paste);
+        editor.apply(Message::History {
+            op: HistoryOp::Redo,
+        });
+        assert_state_eq!(editor.state(), &expected);
+        let cold =
+            editor_state::ProjectedState::from_graph(editor.state().projected.graph().clone())
+                .expect("redo cold rebuild projects");
+        assert_eq!(editor.state().projected.projected(), cold.projected());
+    }
+
+    #[test]
+    fn paste_open_list_slice_round_trips_history_and_projection() {
+        let (source, ..) = state! {
+            doc { root {
+                bullet_list {
+                    list_item { first: paragraph { text("first") } }
+                    list_item { second: paragraph { text("second") } }
+                }
+                paragraph {}
+            } }
+            selection: (first, 2) -> (second, 3)
+        };
+        let payload = Slice::extract(&source)
+            .expect("open list selection extracts")
+            .to_payload(&Resource::new_test());
+
+        let (target, ..) = state! {
+            doc { root {
+                ordered_list {
+                    list_item { left: paragraph { text("AB") } }
+                    list_item { right: paragraph { text("CD") } }
+                }
+                paragraph {}
+            } }
+            selection: (left, 1) -> (right, 1)
+        };
+        let before_paste = target.clone();
+        let mut editor = Editor::new_test(target);
+
+        editor.apply(Message::Clipboard {
+            op: ClipboardOp::Paste {
+                html: Some(payload.html),
+                text: payload.text,
+            },
+        });
+
+        let (expected, ..) = state! {
+            doc { root {
+                ordered_list {
+                    list_item { paragraph { text("Arst") } }
+                    list_item { caret: paragraph { text("secD") } }
+                }
+                paragraph {}
+            } }
+            selection: (caret, 3)
+        };
+        assert_state_eq!(editor.state(), &expected);
+        let cold =
+            editor_state::ProjectedState::from_graph(editor.state().projected.graph().clone())
+                .expect("cold rebuild projects");
+        assert_eq!(editor.state().projected.projected(), cold.projected());
+
+        editor.apply(Message::History {
+            op: HistoryOp::Undo,
+        });
+        assert_state_eq!(editor.state(), &before_paste);
+        editor.apply(Message::History {
+            op: HistoryOp::Redo,
+        });
+        assert_state_eq!(editor.state(), &expected);
+        let cold =
+            editor_state::ProjectedState::from_graph(editor.state().projected.graph().clone())
+                .expect("redo cold rebuild projects");
+        assert_eq!(editor.state().projected.projected(), cold.projected());
+    }
+
+    #[test]
+    fn paste_inline_across_distinct_lists_uses_the_earlier_list_join() {
+        let (source, ..) = state! {
+            doc { root {
+                text: paragraph { text("X") }
+            } }
+            selection: (text, 0) -> (text, 1)
+        };
+        let payload = Slice::extract(&source)
+            .expect("inline selection extracts")
+            .to_payload(&Resource::new_test());
+
+        let (target, ..) = state! {
+            doc { root {
+                bullet_list {
+                    list_item { left: paragraph { text("ab") } }
+                }
+                ordered_list {
+                    list_item { right: paragraph { text("cd") } }
+                }
+                paragraph {}
+            } }
+            selection: (left, 1) -> (right, 1)
+        };
+        let mut editor = Editor::new_test(target);
+
+        editor.apply(Message::Clipboard {
+            op: ClipboardOp::Paste {
+                html: Some(payload.html),
+                text: payload.text,
+            },
+        });
+
+        let (expected, ..) = state! {
+            doc { root {
+                bullet_list {
+                    list_item { caret: paragraph { text("aXd") } }
+                }
+                paragraph {}
+            } }
+            selection: (caret, 2)
         };
         assert_state_eq!(editor.state(), &expected);
     }
@@ -875,6 +1281,98 @@ mod tests {
     }
 
     #[test]
+    fn paste_mixed_table_slice_at_cell_caret_is_a_whole_no_fit() {
+        let (source, _source_root, ..) = state! {
+            doc { source_root: root {
+                paragraph { text("before") }
+                table {
+                    table_row {
+                        table_cell { paragraph { text("grid") } }
+                    }
+                }
+                paragraph { text("after") }
+            } }
+            selection: (source_root, 0, >) -> (source_root, 3, <)
+        };
+        let payload = Slice::extract(&source)
+            .expect("closed mixed slice")
+            .to_payload(&Resource::new_test());
+
+        let (target, ..) = state! {
+            doc { root {
+                table {
+                    table_row {
+                        table_cell { p: paragraph { text("target") } }
+                    }
+                }
+                paragraph {}
+            } }
+            selection: (p, 3)
+            pending_modifiers: [bold]
+        };
+        let mut editor = Editor::new_test(target.clone());
+        let previous_tag = HistoryTag::PasteHtml {
+            plain_text: "previous".into(),
+            start: None,
+        };
+        editor.undo_history.set_last_tag(Some(previous_tag.clone()));
+
+        editor.apply(Message::Clipboard {
+            op: ClipboardOp::Paste {
+                html: Some(payload.html),
+                text: payload.text,
+            },
+        });
+
+        assert_state_eq!(editor.state(), &target);
+        assert_eq!(editor.last_history_tag(), Some(previous_tag));
+    }
+
+    #[test]
+    fn paste_text_and_page_break_into_list_paragraph_hoists_without_loss() {
+        let (source, ..) = state! {
+            doc { root {
+                source: paragraph { text("X") page_break }
+            } }
+            selection: (source, 0) -> (source, 2)
+        };
+        let payload = Slice::extract(&source)
+            .expect("open inline slice with a page break")
+            .to_payload(&Resource::new_test());
+
+        let (target, ..) = state! {
+            doc { root {
+                bullet_list {
+                    list_item { p: paragraph { text("target") } }
+                }
+                paragraph {}
+            } }
+            selection: (p, 0)
+            pending_modifiers: [bold]
+        };
+        let mut editor = Editor::new_test(target.clone());
+        let previous_tag = HistoryTag::PasteHtml {
+            plain_text: "previous".into(),
+            start: None,
+        };
+        editor.undo_history.set_last_tag(Some(previous_tag.clone()));
+
+        editor.apply(Message::Clipboard {
+            op: ClipboardOp::Paste {
+                html: Some(payload.html),
+                text: payload.text,
+            },
+        });
+
+        assert_eq!(text_and_page_break_signature(editor.state()), "X|target");
+        assert!(matches!(
+            editor.last_history_tag(),
+            Some(HistoryTag::PasteHtml { .. })
+        ));
+        assert_ne!(editor.last_history_tag(), Some(previous_tag));
+    }
+
+    #[test]
     fn paste_plain_text_into_cell_rect_fills_every_cell() {
         let (s, c00, c01, c10, c11) = state! {
             doc { root { table {
@@ -1043,7 +1541,7 @@ mod tests {
     }
 
     #[test]
-    fn paste_page_break_only_into_nested_selection_preserves_selection() {
+    fn paste_page_break_only_into_nested_selection_replaces_and_hoists() {
         let (source, ..) = state! {
             doc { root { p1: paragraph { text("a") page_break } } }
             selection: (p1, 1) -> (p1, 2)
@@ -1067,7 +1565,17 @@ mod tests {
             },
         });
 
+        assert_eq!(text_and_page_break_signature(editor.state()), "N|ed");
+        let after_paste = editor.state().clone();
+
+        editor.apply(Message::History {
+            op: HistoryOp::Undo,
+        });
         assert_state_eq!(editor.state(), &target);
+        editor.apply(Message::History {
+            op: HistoryOp::Redo,
+        });
+        assert_state_eq!(editor.state(), &after_paste);
     }
 
     #[test]
@@ -1207,6 +1715,194 @@ mod tests {
             selection: (p3, 6)
         };
         editor_state::assert_state_eq!(editor.state(), &expected);
+    }
+
+    #[test]
+    fn repaste_empty_plain_text_removes_inline_html_and_is_undoable() {
+        let (initial, ..) = state! {
+            doc { root { p: paragraph { text("ab") } } }
+            selection: (p, 1)
+        };
+        let mut editor = Editor::new_test(initial.clone());
+        editor.apply(Message::Clipboard {
+            op: ClipboardOp::Paste {
+                html: Some("<br>".into()),
+                text: String::new(),
+            },
+        });
+        let html_state = editor.state().clone();
+        assert!(matches!(
+            editor.last_history_tag(),
+            Some(HistoryTag::PasteHtml { .. })
+        ));
+
+        editor.apply(Message::Clipboard {
+            op: ClipboardOp::RepasteAsText,
+        });
+        assert_state_eq!(editor.state(), &initial);
+
+        editor.apply(Message::History {
+            op: HistoryOp::Undo,
+        });
+        assert_state_eq!(editor.state(), &html_state);
+    }
+
+    #[test]
+    fn repaste_empty_plain_text_removes_structural_html_as_one_undo_unit() {
+        let (initial, ..) = state! {
+            doc { root { p: paragraph { text("ab") } } }
+            selection: (p, 1)
+        };
+        let mut editor = Editor::new_test(initial.clone());
+        editor.apply(Message::Clipboard {
+            op: ClipboardOp::Paste {
+                html: Some("<hr>".into()),
+                text: String::new(),
+            },
+        });
+        let html_state = editor.state().clone();
+        assert!(matches!(
+            editor.last_history_tag(),
+            Some(HistoryTag::PasteHtml { .. })
+        ));
+
+        editor.apply(Message::Clipboard {
+            op: ClipboardOp::RepasteAsText,
+        });
+        assert_state_eq!(editor.state(), &initial);
+
+        editor.apply(Message::History {
+            op: HistoryOp::Undo,
+        });
+        assert_state_eq!(editor.state(), &html_state);
+        editor.apply(Message::History {
+            op: HistoryOp::Redo,
+        });
+        assert_state_eq!(editor.state(), &initial);
+        editor.apply(Message::History {
+            op: HistoryOp::Undo,
+        });
+        assert_state_eq!(editor.state(), &html_state);
+        editor.apply(Message::History {
+            op: HistoryOp::Undo,
+        });
+        assert_state_eq!(editor.state(), &initial);
+    }
+
+    #[test]
+    fn repaste_structural_html_with_text_is_one_reversible_replacement() {
+        let (initial, ..) = state! {
+            doc { root { p: paragraph { text("ab") } } }
+            selection: (p, 1)
+        };
+        let mut editor = Editor::new_test(initial.clone());
+        editor.apply(Message::Clipboard {
+            op: ClipboardOp::Paste {
+                html: Some("<hr>".into()),
+                text: "plain".into(),
+            },
+        });
+        let html_state = editor.state().clone();
+
+        editor.apply(Message::Clipboard {
+            op: ClipboardOp::RepasteAsText,
+        });
+        let plain_state = editor.state().clone();
+        assert_eq!(text_and_page_break_signature(&plain_state), "aplainb");
+        assert_eq!(editor.last_history_tag(), None);
+
+        editor.apply(Message::History {
+            op: HistoryOp::Undo,
+        });
+        assert_state_eq!(editor.state(), &html_state);
+        assert_eq!(editor.last_history_tag(), None);
+        editor.apply(Message::History {
+            op: HistoryOp::Redo,
+        });
+        assert_state_eq!(editor.state(), &plain_state);
+        editor.apply(Message::History {
+            op: HistoryOp::Undo,
+        });
+        assert_state_eq!(editor.state(), &html_state);
+        editor.apply(Message::History {
+            op: HistoryOp::Undo,
+        });
+        assert_state_eq!(editor.state(), &initial);
+    }
+
+    #[test]
+    fn structural_paste_and_repaste_in_one_request_record_two_history_entries() {
+        let (initial, ..) = state! {
+            doc { root { p: paragraph { text("ab") } } }
+            selection: (p, 1)
+        };
+        let mut editor = Editor::new_test(initial.clone());
+        let request = editor
+            .enqueue_request(vec![
+                Message::Clipboard {
+                    op: ClipboardOp::Paste {
+                        html: Some("<hr>".into()),
+                        text: "plain".into(),
+                    },
+                },
+                Message::Clipboard {
+                    op: ClipboardOp::RepasteAsText,
+                },
+            ])
+            .unwrap();
+        editor.tick_through(request).unwrap();
+
+        assert_eq!(text_and_page_break_signature(editor.state()), "aplainb");
+        assert_eq!(editor.history_undos_len(), 2);
+        editor.apply(Message::History {
+            op: HistoryOp::Undo,
+        });
+        let (html_expected, ..) = state! {
+            doc { root {
+                paragraph { text("a") }
+                horizontal_rule
+                paragraph { text("b") }
+            } }
+            selection: none
+        };
+        assert_doc_eq!(editor.state(), &html_expected);
+        editor.apply(Message::History {
+            op: HistoryOp::Undo,
+        });
+        assert_state_eq!(editor.state(), &initial);
+    }
+
+    #[test]
+    fn structural_repaste_no_fit_preserves_state_history_and_pending_ops() {
+        let (initial, ..) = state! {
+            doc { root { p: paragraph { text("ab") } } }
+            selection: (p, 1)
+        };
+        let mut editor = Editor::new_test(initial);
+        editor.apply(Message::Clipboard {
+            op: ClipboardOp::Paste {
+                html: Some("<hr>".into()),
+                text: "plain".into(),
+            },
+        });
+        let html_state = editor.state().clone();
+        let history_undos = editor.history_undos_len();
+        let history_redos = editor.history_redos_len();
+        let history_tag = editor.last_history_tag();
+        let pending_ops = editor.pending_ops.len();
+        let malformed = Slice {
+            content: vec![Fragment::leaf(PlainNode::Unknown)],
+            open_start: 0,
+            open_end: 0,
+        };
+
+        repaste_structural_as_text(&mut editor, malformed).unwrap();
+
+        assert_state_eq!(editor.state(), &html_state);
+        assert_eq!(editor.history_undos_len(), history_undos);
+        assert_eq!(editor.history_redos_len(), history_redos);
+        assert_eq!(editor.last_history_tag(), history_tag);
+        assert_eq!(editor.pending_ops.len(), pending_ops);
     }
 
     #[test]

--- a/crates/editor-core/src/handle/dnd.rs
+++ b/crates/editor-core/src/handle/dnd.rs
@@ -267,12 +267,19 @@ pub(crate) fn judge_apply_drop(
     match payload {
         DndDropPayload::Text { text, html } => {
             let (slice, _) = Slice::from_payload(html.as_deref(), text, resource);
-            commands::resolve_slice_insertion(&state.view(), position, slice).is_some()
+            matches!(
+                commands::fit_slice(state, Selection::collapsed(position), slice),
+                Ok(commands::FitOutcome::Plan(_))
+            )
         }
-        DndDropPayload::Files { kinds, .. } => {
-            commands::resolve_slice_insertion(&state.view(), position, placeholder_slice(kinds))
-                .is_some()
-        }
+        DndDropPayload::Files { kinds, .. } => matches!(
+            commands::fit_slice(
+                state,
+                Selection::collapsed(position),
+                placeholder_slice(kinds),
+            ),
+            Ok(commands::FitOutcome::Plan(_))
+        ),
         DndDropPayload::InternalSelection => {
             let Some(source) = source else {
                 return false;
@@ -287,7 +294,10 @@ pub(crate) fn judge_apply_drop(
             };
             if modifiers.alt {
                 // copy: 소스를 삭제하지 않으므로 드롭 전 원시 위치가 곧 실제 삽입 지점이다.
-                return commands::resolve_slice_insertion(&state.view(), position, slice).is_some();
+                return matches!(
+                    commands::fit_slice(state, Selection::collapsed(position), slice),
+                    Ok(commands::FitOutcome::Plan(_))
+                );
             }
             move_insertion_fits_after_delete(state, position, *source, slice)
         }
@@ -301,10 +311,9 @@ pub(crate) fn judge_apply_drop(
 /// 커밋하지 않으므로 관측 부작용이 없다. 재앵커 실패는 실행의 rollback no-op과 정확히
 /// 합치해 false를 돌린다.
 ///
-/// 마지막 삽입 가능성은 `resolve_slice_insertion`으로 판정한다 — 그 계약("Some(plan) ⇒
-/// 관측 가능한 삽입 op 방출")이 `insert_slice_at`과 정확히 대응하므로(빈 슬라이스가 splice
-/// edge join으로 소진돼 no-op이 되는 경우까지 `splice_emits_change`로 흡수됨) 이 근사는
-/// 실행과 합치한다.
+/// 마지막 삽입 가능성은 공통 `fit_slice`로 판정한다. 실행도 같은 Fitter를 거치는
+/// `insert_slice_at`을 사용하므로, source 삭제 뒤의 실제 destination을 기준으로
+/// indicator와 drop 실행이 같은 결론을 낸다.
 fn move_insertion_fits_after_delete(
     state: &State,
     position: Position,
@@ -324,7 +333,10 @@ fn move_insertion_fits_after_delete(
     let Some(target) = stable_target.resolve(&ctx).map(|sel| sel.head) else {
         return false;
     };
-    commands::resolve_slice_insertion(&view, target, slice).is_some()
+    matches!(
+        commands::fit_slice(tr.state(), Selection::collapsed(target), slice),
+        Ok(commands::FitOutcome::Plan(_))
+    )
 }
 
 fn representative_external_payload(payload: ExternalDndPayloadKind) -> DndDropPayload {
@@ -544,7 +556,7 @@ fn drop_slice_at(
     slice: Slice,
     provenance: commands::types::SliceProvenance,
 ) -> Result<(), EditorError> {
-    editor.transact(|tr| {
+    editor.transact_observable(|tr| {
         let inserted_selection =
             commands::insert_slice_at(tr, position, slice.clone(), provenance)?;
         if let Some(inserted_selection) = inserted_selection
@@ -590,7 +602,7 @@ fn drop_internal_selection_at(
 
     let stable_target =
         StableSelection::capture(&Selection::collapsed(position), &editor.state.view());
-    editor.transact(|tr| {
+    editor.transact_observable(|tr| {
         let savepoint = tr.savepoint();
         commands::set_selection(tr, source)?;
         commands::delete_selection(tr)?;

--- a/crates/editor-core/src/handle/selection.rs
+++ b/crates/editor-core/src/handle/selection.rs
@@ -14,6 +14,50 @@ use crate::editor::Editor;
 use crate::error::EditorError;
 use crate::message::*;
 
+fn canonicalize_set_selection(
+    view: &DocView,
+    current: Option<Selection>,
+    selection: Selection,
+) -> Option<Selection> {
+    selection.resolve(view)?;
+
+    let selection = if let (Some(anchor_cell), Some(head_cell)) = (
+        enclosing_table_cell(view, selection.anchor.node),
+        enclosing_table_cell(view, selection.head.node),
+    ) && anchor_cell != head_cell
+        && enclosing_table(view, anchor_cell)
+            .zip(enclosing_table(view, head_cell))
+            .is_some_and(|(anchor_table, head_table)| anchor_table == head_table)
+    {
+        cell_rect_selection(anchor_cell, head_cell, view)?
+    } else {
+        selection.normalize(view)?
+    };
+
+    Some(match current {
+        Some(current) if same_cell_rect(view, current, selection) => current,
+        _ => selection,
+    })
+}
+
+fn same_cell_rect(view: &DocView, left: Selection, right: Selection) -> bool {
+    let Some(left) = left
+        .resolve(view)
+        .and_then(|selection| selection.as_cell_rect())
+    else {
+        return false;
+    };
+    let Some(right) = right
+        .resolve(view)
+        .and_then(|selection| selection.as_cell_rect())
+    else {
+        return false;
+    };
+    left.table_id() == right.table_id()
+        && left.rows() == right.rows()
+        && left.cols() == right.cols()
+}
+
 pub fn handle_selection_op(editor: &mut Editor, op: SelectionOp) -> Result<(), EditorError> {
     if matches!(op, SelectionOp::Unset) {
         editor.clear_preferred_x();
@@ -29,7 +73,12 @@ pub fn handle_selection_op(editor: &mut Editor, op: SelectionOp) -> Result<(), E
     match op {
         SelectionOp::Set { selection } => editor.transact(|tr| {
             tr.update_meta(|m| m.history = HistoryMeta::Skip);
-            if selection.resolve(&tr.view()).is_some() {
+            let selection = {
+                let current = tr.selection();
+                let view = tr.view();
+                canonicalize_set_selection(&view, current, selection)
+            };
+            if let Some(selection) = selection {
                 if tr.selection() != Some(selection) {
                     tr.clear_pending_format()?;
                 }
@@ -40,9 +89,12 @@ pub fn handle_selection_op(editor: &mut Editor, op: SelectionOp) -> Result<(), E
         SelectionOp::SetFrozen { selection } => editor.transact(|tr| {
             tr.update_meta(|m| m.history = HistoryMeta::Skip);
             let live = {
+                let current = tr.selection();
                 let view = tr.view();
                 let ctx = StableResolveCtx::from_live(&view, tr.state().projected.seq_checkout());
-                selection.resolve(&ctx)
+                selection
+                    .resolve(&ctx)
+                    .and_then(|live| canonicalize_set_selection(&view, current, live))
             };
             if let Some(live) = live {
                 if tr.selection() != Some(live) {
@@ -80,7 +132,13 @@ pub fn handle_selection_op(editor: &mut Editor, op: SelectionOp) -> Result<(), E
                     Some(p) => p,
                     None => return Ok(()),
                 };
-                Selection::new(Position::from(&start_pos), Position::from(&end_pos))
+                let selection =
+                    Selection::new(Position::from(&start_pos), Position::from(&end_pos));
+                let Some(selection) = canonicalize_set_selection(&view, tr.selection(), selection)
+                else {
+                    return Ok(());
+                };
+                selection
             };
             if tr.selection() != Some(selection) {
                 tr.clear_pending_format()?;
@@ -471,6 +529,131 @@ mod tests {
         });
         assert_eq!(editor.state().selection, Some(target));
         assert!(!editor.undo_history.can_undo());
+    }
+
+    #[test]
+    fn select_set_across_table_cells_canonicalizes_to_cell_rect() {
+        let (state, c00, p00, c01, p01) = state! {
+            doc { root {
+                table {
+                    table_row {
+                        c00: table_cell { p00: paragraph { text("hello") } }
+                        c01: table_cell { p01: paragraph { text("world") } }
+                        table_cell { paragraph { text("tail") } }
+                    }
+                }
+                paragraph {}
+            } }
+            selection: (p00, 0)
+        };
+        let mut editor = Editor::new_test(state);
+
+        editor.apply(Message::Selection {
+            op: SelectionOp::Set {
+                selection: Selection::new(Position::new(p00, 2), Position::new(p01, 3)),
+            },
+        });
+
+        let view = editor.state().view();
+        let rect = editor
+            .state()
+            .selection
+            .and_then(|selection| selection.resolve(&view))
+            .and_then(|selection| selection.as_cell_rect())
+            .expect("cross-cell Set must canonicalize to a cell rect");
+        assert_eq!(rect.anchor_cell.id(), c00);
+        assert_eq!(rect.head_cell.id(), c01);
+    }
+
+    #[test]
+    fn task1_set_set_flat_and_set_frozen_share_table_boundary_canonicalization() {
+        let (state, inside, outside) = state! {
+            doc { root {
+                table {
+                    table_row {
+                        table_cell { inside: paragraph { text("inside") } }
+                    }
+                }
+                outside: paragraph { text("outside") }
+            } }
+            selection: (outside, 0)
+        };
+        let requested = Selection::new(Position::new(inside, 2), Position::new(outside, 3));
+        let (start, end, frozen, expected) = {
+            let view = state.view();
+            let resolved = requested
+                .resolve(&view)
+                .expect("requested selection resolves");
+            (
+                resolved.anchor().to_flat(),
+                resolved.head().to_flat(),
+                StableSelection::capture(&requested, &view),
+                requested
+                    .normalize(&view)
+                    .expect("table boundary selection normalizes"),
+            )
+        };
+        assert_ne!(requested, expected);
+
+        for op in [
+            SelectionOp::Set {
+                selection: requested,
+            },
+            SelectionOp::SetFlat { start, end },
+            SelectionOp::SetFrozen { selection: frozen },
+        ] {
+            let mut editor = Editor::new_test(state.clone());
+            editor.apply(Message::Selection { op });
+            assert_eq!(editor.state().selection, Some(expected));
+        }
+    }
+
+    #[test]
+    fn select_set_flat_round_trips_cell_rect_without_losing_direction_or_pending_format() {
+        let (mut state, c00, c11, _tail) = state! {
+            doc { root {
+                table {
+                    table_row {
+                        c00: table_cell { paragraph { text("00") } }
+                        table_cell { paragraph { text("01") } }
+                        table_cell { paragraph { text("02") } }
+                    }
+                    table_row {
+                        table_cell { paragraph { text("10") } }
+                        c11: table_cell { paragraph { text("11") } }
+                        table_cell { paragraph { text("12") } }
+                    }
+                }
+                tail: paragraph {}
+            } }
+            selection: (tail, 0)
+        };
+        let expected = {
+            let view = state.view();
+            cell_rect_selection(c11, c00, &view).expect("partial reverse cell rect")
+        };
+        state.selection = Some(expected);
+        let mut editor = Editor::new_test(state);
+        let pending_modifiers = vec![PendingModifier::Set {
+            modifier: Modifier::Bold,
+        }];
+        editor
+            .transact(|tr| {
+                tr.set_pending_modifiers(pending_modifiers.clone())?;
+                Ok(())
+            })
+            .unwrap();
+
+        let ime_selection = editor.ime(64, 64).unwrap().unwrap().selection;
+        editor.apply(Message::Selection {
+            op: SelectionOp::SetFlat {
+                start: ime_selection.start,
+                end: ime_selection.end,
+            },
+        });
+
+        assert_eq!(editor.state().selection, Some(expected));
+        assert_eq!(editor.state().pending_modifiers, pending_modifiers);
     }
 
     #[test]

--- a/crates/editor-core/src/tests/dnd_judgment_parity.rs
+++ b/crates/editor-core/src/tests/dnd_judgment_parity.rs
@@ -229,7 +229,7 @@ proptest::proptest! {
 
 // Pins the input that `assert_drop_parity`'s 4096-case sweep once surfaced as a
 // `judge_apply_drop` under-prediction (fixture 3, InternalSelection move,
-// pos_off=13/src_a=12/src_b=3): `resolve_slice_insertion` against the raw
+// pos_off=13/src_a=12/src_b=3): `fit_slice` against the raw
 // pre-delete position gets `NoFit`, yet the real drop execution changes state
 // because the move's delete-then-remap (`drop_internal_selection_at`) re-anchors
 // the drop through a `StableSelection` captured before the delete and resolved
@@ -295,42 +295,19 @@ fn move_bullet_list_child_range_drop_judge_follows_delete_then_remap() {
     );
 }
 
-// Pins the seed-51ac09 input (fixture 1, InternalSelection move,
-// pos_off=16/src_a=25/src_b=26) that surfaced the "plan-then-no-op" class. The
-// drop position (flat 16, inside the fold) lies outside the source (flat 25..26,
-// the document tail) and off its boundary, so neither `position_inside_selection`
-// nor the move boundary no-op filters it — production-reachable. The judge routes
-// this move through `move_insertion_fits_after_delete`, which deletes the source
-// and re-anchors to the SAME target the execution reaches (Dot{1,17}@6). The
-// extracted slice there is a single EMPTY paragraph; at the textblock's end that
-// splice is structurally valid (`can_splice_textblock` = true) but emits zero ops
-// (the block is consumed by the start-edge join and contributes no inline), so the
-// execution's `insert_slice_at` returns `Ok(None)` — a clean no-op. Previously
-// `resolve_slice_insertion` still reported `Some(SpliceBlocks)` there, violating
-// its own contract ("Some(plan) ⇒ observable change") and over-predicting. The
-// contract is now upheld at the source: `resolve_slice_insertion_outcome`'s
-// SpliceBlocks branch is guarded by `splice_emits_change` (an exact mirror of
-// `insert_blocks_in_textblock`'s Ok(Some) condition), so resolve returns NoFit and
-// the move simulation reports `false`. judge and execution now agree exactly (both
-// no-op); the fix benefits every `resolve_slice_insertion` consumer, not just DnD.
+// Empty external HTML exercises the same no-observable-plan contract without
+// relying on a non-canonical affinity-only range. Both the drop indicator and
+// execution must use the shared Fitter and leave state untouched.
 #[test]
-fn move_empty_splice_judged_as_noop_matching_execution() {
+fn empty_html_drop_is_judged_as_noop_matching_execution() {
     let state = fixtures().swap_remove(1);
     let mut editor = Editor::new_test(state);
-    let source = source_range(&mut editor, 25, 26).expect("document-tail source");
     let position = position_at_flat(&mut editor, 16).expect("position inside the fold");
-    editor.apply(Message::Selection {
-        op: SelectionOp::SetFlat { start: 25, end: 26 },
-    });
     let modifiers = InputModifiers::default();
-
-    {
-        let view = editor.state().view();
-        assert!(
-            !position_inside_selection(&view, position, &source),
-            "the drop position lies outside the moved selection; production does not filter it"
-        );
-    }
+    let payload = DndDropPayload::Text {
+        text: String::new(),
+        html: Some(String::new()),
+    };
 
     let judged = {
         let resource = editor.resource().clone();
@@ -339,32 +316,26 @@ fn move_empty_splice_judged_as_noop_matching_execution() {
             editor.state(),
             &resource,
             position,
-            &DndDropPayload::InternalSelection,
+            &payload,
             modifiers,
-            Some(&source),
+            None,
         )
     };
     assert!(
         !judged,
-        "resolve now returns NoFit for the empty splice, so the move simulation predicts the no-op"
+        "the shared Fitter must not advertise an empty drop"
     );
 
     let (run_result, run_changed) = {
         let mut scratch = Editor::new_test(editor.state().clone());
         let before = crate::test_utils::EditorSnapshot::capture(&scratch);
-        let result = apply_drop_for_test(
-            &mut scratch,
-            position,
-            DndDropPayload::InternalSelection,
-            modifiers,
-            Some(source),
-        );
+        let result = apply_drop_for_test(&mut scratch, position, payload, modifiers, None);
         let after = crate::test_utils::EditorSnapshot::capture(&scratch);
         (result, before != after)
     };
     assert!(
         matches!(run_result, Ok(())) && !run_changed,
-        "the move's actual insert_slice_at at the same target returns Ok(None), rolling back to a clean no-op: {run_result:?}"
+        "empty drop execution must remain a clean no-op: {run_result:?}"
     );
 }
 
@@ -504,7 +475,14 @@ fn copy_drop_at_list_item_source_boundary_succeeds_observably() {
     let state = fixtures().swap_remove(3);
     let mut editor = Editor::new_test(state);
     let source = source_range(&mut editor, 2, 20).expect("boundary-touching source");
-    let position = position_at_flat(&mut editor, 2).expect("position at the source from-boundary");
+    let position = {
+        let view = editor.state().view();
+        source
+            .resolve(&view)
+            .expect("source resolves")
+            .from()
+            .position()
+    };
     let modifiers = InputModifiers {
         alt: true,
         ..InputModifiers::default()
@@ -555,10 +533,79 @@ fn copy_drop_at_list_item_source_boundary_succeeds_observably() {
     );
 }
 
+// Copying the structural tail from the end of a list into the start of another
+// item inserts an open list wrapper followed by a paragraph. The fitted final
+// sequence also requires a leading paragraph in the destination ListItem. That
+// completion must be authored by the plan before the source blocks, rather than
+// appearing later as a projection repair scaffold.
+#[test]
+fn copy_open_list_tail_authors_required_completion_before_execution() {
+    let (state, _root, p1, _p2) = state! {
+        doc { root: root {
+            bullet_list {
+                list_item { p1: paragraph { text("alpha") } }
+                list_item { p2: paragraph { text("beta") } }
+            }
+            paragraph {}
+        } }
+        selection: (p2, 4, >) -> (root, 2, <)
+    };
+    let source = state.selection.expect("structural list-tail source");
+    let mut editor = Editor::new_test(state);
+    let position = Position::new(p1, 0);
+    let modifiers = InputModifiers {
+        alt: true,
+        ..InputModifiers::default()
+    };
+
+    let judged = {
+        let resource = editor.resource().clone();
+        let resource = resource.lock().unwrap();
+        judge_apply_drop(
+            editor.state(),
+            &resource,
+            position,
+            &DndDropPayload::InternalSelection,
+            modifiers,
+            Some(&source),
+        )
+    };
+    assert!(judged, "the structural Slice has an observable fit");
+
+    assert_drop_parity(
+        &mut editor,
+        position,
+        &DndDropPayload::InternalSelection,
+        modifiers,
+        Some(source),
+    );
+
+    apply_drop_for_test(
+        &mut editor,
+        position,
+        DndDropPayload::InternalSelection,
+        modifiers,
+        Some(source),
+    )
+    .expect("fitted copy executes");
+    let view = editor.state().view();
+    let item = view
+        .node(p1)
+        .and_then(|paragraph| paragraph.parent())
+        .expect("destination paragraph stays in its list item");
+    assert!(
+        item.children().all(|child| match child {
+            editor_model::ChildView::Block(block) => block.id().as_op_dot().is_some(),
+            editor_model::ChildView::Leaf(leaf) => leaf.dot().as_op_dot().is_some(),
+        }),
+        "the accepted plan must author required completion instead of relying on projection scaffolds"
+    );
+}
+
 // Copying a fold-spanning selection into the gap past the fold's fixed slots
 // (title, content). A fixed-arity container can never absorb an extra child —
 // the fragments would stay projection-suppressed misfits — so
-// `resolve_slice_insertion` refuses (NoFit) and the execution, consuming the
+// `fit_slice` refuses (NoFit) and the execution, consuming the
 // same resolve, is a clean no-op: judgment and execution agree at `false`.
 // (This used to over-predict and then die on IndexOutOfBounds once mid-batch
 // normalization suppressed the first inserted child.)

--- a/crates/editor-model/src/fragment.rs
+++ b/crates/editor-model/src/fragment.rs
@@ -5,7 +5,7 @@ use editor_macros::ffi;
 use serde::{Deserialize, Serialize};
 
 #[ffi]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Fragment {
     pub node: PlainNode,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
@@ -37,16 +37,109 @@ impl Fragment {
     }
 
     pub fn into_subtree(self) -> Subtree {
-        Subtree {
-            node: self.node,
-            modifiers: self.modifiers,
-            carry: self.carry,
-            children: self
-                .children
-                .into_iter()
-                .map(|f| f.into_subtree())
-                .collect(),
-            source_dots: Vec::new(),
+        struct Frame {
+            node: PlainNode,
+            modifiers: Vec<Modifier>,
+            carry: Vec<Modifier>,
+            children: std::vec::IntoIter<Fragment>,
+            converted: Vec<Subtree>,
+        }
+
+        impl Frame {
+            fn new(fragment: Fragment) -> Self {
+                let (node, modifiers, carry, children) = fragment.into_parts();
+                Self {
+                    node,
+                    modifiers,
+                    carry,
+                    converted: Vec::with_capacity(children.len()),
+                    children: children.into_iter(),
+                }
+            }
+
+            fn finish(self) -> Subtree {
+                Subtree {
+                    node: self.node,
+                    modifiers: self.modifiers,
+                    carry: self.carry,
+                    children: self.converted,
+                    source_dots: Vec::new(),
+                }
+            }
+        }
+
+        let mut stack = vec![Frame::new(self)];
+        loop {
+            if let Some(child) = stack.last_mut().and_then(|frame| frame.children.next()) {
+                stack.push(Frame::new(child));
+                continue;
+            }
+            let converted = stack.pop().expect("root conversion frame").finish();
+            let Some(parent) = stack.last_mut() else {
+                return converted;
+            };
+            parent.converted.push(converted);
+        }
+    }
+
+    pub fn into_parts(mut self) -> (PlainNode, Vec<Modifier>, Vec<Modifier>, Vec<Fragment>) {
+        (
+            std::mem::replace(&mut self.node, PlainNode::Unknown),
+            std::mem::take(&mut self.modifiers),
+            std::mem::take(&mut self.carry),
+            std::mem::take(&mut self.children),
+        )
+    }
+}
+
+impl Clone for Fragment {
+    fn clone(&self) -> Self {
+        struct Frame<'a> {
+            source: &'a Fragment,
+            next_child: usize,
+            children: Vec<Fragment>,
+        }
+
+        let mut stack = vec![Frame {
+            source: self,
+            next_child: 0,
+            children: Vec::with_capacity(self.children.len()),
+        }];
+        loop {
+            let next = {
+                let frame = stack.last_mut().expect("root clone frame");
+                let child = frame.source.children.get(frame.next_child);
+                frame.next_child += usize::from(child.is_some());
+                child
+            };
+            if let Some(child) = next {
+                stack.push(Frame {
+                    source: child,
+                    next_child: 0,
+                    children: Vec::with_capacity(child.children.len()),
+                });
+                continue;
+            }
+            let frame = stack.pop().expect("root clone frame");
+            let cloned = Fragment {
+                node: frame.source.node.clone(),
+                modifiers: frame.source.modifiers.clone(),
+                carry: frame.source.carry.clone(),
+                children: frame.children,
+            };
+            let Some(parent) = stack.last_mut() else {
+                return cloned;
+            };
+            parent.children.push(cloned);
+        }
+    }
+}
+
+impl Drop for Fragment {
+    fn drop(&mut self) {
+        let mut stack = std::mem::take(&mut self.children);
+        while let Some(mut fragment) = stack.pop() {
+            stack.append(&mut fragment.children);
         }
     }
 }

--- a/crates/editor-model/src/schema/placement.rs
+++ b/crates/editor-model/src/schema/placement.rs
@@ -4,6 +4,72 @@ use crate::NodeType;
 
 use super::{ContentExpr, ContextExpr, Schema};
 
+/// Schema decisions for an ordered direct-child sequence.
+///
+/// `consumed` counts schema-known (non-`Unknown`) children in the greedily
+/// accepted prefix. `first_residue` indexes the original `children` slice, so
+/// callers can retain their own representation-specific child indexing.
+/// `completion_insertions` uses sequential physical child indices: each index
+/// addresses the sequence after the preceding insertions have been applied;
+/// `None` means insertion alone cannot complete the supplied sequence.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ContentPlacement {
+    pub consumed: usize,
+    pub first_residue: Option<usize>,
+    pub completion_insertions: Option<Vec<CompletionInsertion>>,
+}
+
+impl ContentPlacement {
+    /// Whether the supplied children are a schema-valid complete sequence.
+    pub fn is_valid(&self) -> bool {
+        self.first_residue.is_none()
+            && self
+                .completion_insertions
+                .as_ref()
+                .is_some_and(Vec::is_empty)
+    }
+
+    /// Whether the supplied children can become valid by inserting only
+    /// schema-required scaffolds.
+    pub fn is_completable(&self) -> bool {
+        self.first_residue.is_none() && self.completion_insertions.is_some()
+    }
+}
+
+/// A required direct child and its sequential physical insertion index.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CompletionInsertion {
+    pub index: usize,
+    pub node_type: NodeType,
+}
+
+/// The schema action for a child already known to be a placement misfit.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum MisfitAction {
+    /// Wrap the child in the declaration-order minimal schema chain. The first
+    /// role is the outermost wrapper.
+    Wrap { chain: Vec<NodeType> },
+    /// Split the current container at the child and hoist it one level.
+    SplitHoist,
+}
+
+/// The next representation-neutral repair transition for one ordered child
+/// sequence. Callers own the actual tree mutation and identity policy.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RepairTransition {
+    Ready {
+        completion: Vec<CompletionInsertion>,
+    },
+    Wrap {
+        index: usize,
+        chain: Vec<NodeType>,
+    },
+    SplitHoist {
+        index: usize,
+        retained_completion: Vec<CompletionInsertion>,
+    },
+}
+
 pub fn context_allows(path: &[NodeType], t: NodeType) -> bool {
     let ctx = &Schema::node_spec(t).context;
     if *ctx == ContextExpr::Any {
@@ -11,6 +77,87 @@ pub fn context_allows(path: &[NodeType], t: NodeType) -> bool {
     }
     let full: Vec<NodeType> = path.iter().copied().chain(std::iter::once(t)).collect();
     ctx.matches(&full)
+}
+
+/// Analyze `children` against `parent`'s ordered content expression.
+///
+/// `Unknown` is transparent: it consumes no slot and can never be residue.
+/// Matching is deliberately greedy, mirroring projection repair. A sequence
+/// that is already valid reports no completion even when a repeatable group
+/// could greedily consume a trailing required role.
+pub fn content_placement(parent: NodeType, children: &[NodeType]) -> ContentPlacement {
+    let known: Vec<(usize, NodeType)> = children
+        .iter()
+        .copied()
+        .enumerate()
+        .filter(|(_, child)| *child != NodeType::Unknown)
+        .collect();
+    let types: Vec<NodeType> = known.iter().map(|(_, child)| *child).collect();
+    let content = &Schema::node_spec(parent).content;
+    let mut consumed = 0;
+    consume_content(content, &types, &mut consumed);
+    let completion_insertions = content.completion_insertions(&types).map(|insertions| {
+        insertions
+            .into_iter()
+            .enumerate()
+            .map(|(inserted, (filtered_index, node_type))| {
+                let original_known_index = filtered_index - inserted;
+                let physical_index = known
+                    .get(original_known_index)
+                    .map(|(index, _)| *index)
+                    .unwrap_or(children.len())
+                    + inserted;
+                CompletionInsertion {
+                    index: physical_index,
+                    node_type,
+                }
+            })
+            .collect()
+    });
+
+    ContentPlacement {
+        consumed,
+        first_residue: known.get(consumed).map(|(index, _)| *index),
+        completion_insertions,
+    }
+}
+
+fn consume_content(content: &ContentExpr, children: &[NodeType], consumed: &mut usize) {
+    let matches_at = |content: &ContentExpr, index: usize| {
+        children
+            .get(index)
+            .is_some_and(|child| content.matches(*child))
+    };
+
+    match content {
+        ContentExpr::Empty => {}
+        ContentExpr::Any => *consumed = children.len(),
+        ContentExpr::Single(expected) => {
+            if children.get(*consumed) == Some(expected) {
+                *consumed += 1;
+            }
+        }
+        ContentExpr::Optional(inner) => {
+            if matches_at(inner, *consumed) {
+                consume_content(inner, children, consumed);
+            }
+        }
+        ContentExpr::ZeroOrMore(inner) | ContentExpr::OneOrMore(inner) => {
+            while matches_at(inner, *consumed) {
+                consume_content(inner, children, consumed);
+            }
+        }
+        ContentExpr::Choice(choices) => {
+            if let Some(choice) = choices.iter().find(|choice| matches_at(choice, *consumed)) {
+                consume_content(choice, children, consumed);
+            }
+        }
+        ContentExpr::Seq(exprs) => {
+            for expr in exprs {
+                consume_content(expr, children, consumed);
+            }
+        }
+    }
 }
 
 // Declared content-expr order, not enum order: the chain tie-break is defined by
@@ -70,6 +217,59 @@ pub fn wrap_chain(path: &[NodeType], child: NodeType) -> Option<Vec<NodeType>> {
     None
 }
 
+/// Choose the next lossless schema action for a child already identified as a
+/// direct-child misfit at `path`.
+pub fn misfit_action(path: &[NodeType], child: NodeType) -> MisfitAction {
+    match wrap_chain(path, child) {
+        Some(chain) if !chain.is_empty() => MisfitAction::Wrap { chain },
+        Some(_) | None => MisfitAction::SplitHoist,
+    }
+}
+
+/// Choose the next lossless repair transition for `children` under `path`.
+///
+/// `path` includes the destination parent. `can_wrap` lets a representation
+/// block a schema-valid WRAP for identity/cycle reasons while leaving the final
+/// WRAP-versus-SPLIT decision in this shared policy.
+pub fn repair_transition(
+    path: &[NodeType],
+    children: &[NodeType],
+    mut can_wrap: impl FnMut(usize) -> bool,
+) -> Option<RepairTransition> {
+    let parent = *path.last()?;
+    let placement = content_placement(parent, children);
+    let context_misfit = (parent != NodeType::Unknown)
+        .then(|| {
+            children
+                .iter()
+                .position(|child| *child != NodeType::Unknown && !context_allows(path, *child))
+        })
+        .flatten();
+    let first_misfit = match (context_misfit, placement.first_residue) {
+        (Some(context), Some(content)) => Some(context.min(content)),
+        (context, content) => context.or(content),
+    };
+    let Some(index) = first_misfit else {
+        return Some(RepairTransition::Ready {
+            completion: placement.completion_insertions?,
+        });
+    };
+
+    let child = *children.get(index)?;
+    if let MisfitAction::Wrap { chain } = misfit_action(path, child)
+        && !chain.is_empty()
+        && can_wrap(index)
+    {
+        return Some(RepairTransition::Wrap { index, chain });
+    }
+
+    let retained_completion = content_placement(parent, &children[..index]).completion_insertions?;
+    Some(RepairTransition::SplitHoist {
+        index,
+        retained_completion,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -122,6 +322,164 @@ mod tests {
         assert_eq!(
             wrap_chain(root, NodeType::PageBreak),
             Some(vec![NodeType::Paragraph])
+        );
+    }
+
+    #[test]
+    fn list_item_consumes_multiple_paragraphs_and_nested_list() {
+        assert_eq!(
+            content_placement(
+                NodeType::ListItem,
+                &[
+                    NodeType::Paragraph,
+                    NodeType::Paragraph,
+                    NodeType::BulletList,
+                ],
+            ),
+            ContentPlacement {
+                consumed: 3,
+                first_residue: None,
+                completion_insertions: Some(vec![]),
+            }
+        );
+    }
+
+    #[test]
+    fn text_under_list_wraps_in_declaration_order_minimal_chain() {
+        assert_eq!(
+            misfit_action(&[NodeType::Root, NodeType::BulletList], NodeType::Text),
+            MisfitAction::Wrap {
+                chain: vec![NodeType::ListItem, NodeType::Paragraph],
+            }
+        );
+    }
+
+    #[test]
+    fn page_break_under_root_requires_paragraph_wrapper() {
+        assert_eq!(
+            misfit_action(&[NodeType::Root], NodeType::PageBreak),
+            MisfitAction::Wrap {
+                chain: vec![NodeType::Paragraph],
+            }
+        );
+    }
+
+    #[test]
+    fn page_break_inside_blockquote_split_hoists() {
+        assert_eq!(
+            misfit_action(
+                &[NodeType::Root, NodeType::Blockquote, NodeType::Paragraph,],
+                NodeType::PageBreak,
+            ),
+            MisfitAction::SplitHoist
+        );
+    }
+
+    #[test]
+    fn task2_split_hoist_reports_required_completion_for_retained_prefix() {
+        assert_eq!(
+            repair_transition(
+                &[NodeType::Root, NodeType::BulletList, NodeType::ListItem],
+                &[NodeType::HorizontalRule],
+                |_| true,
+            ),
+            Some(RepairTransition::SplitHoist {
+                index: 0,
+                retained_completion: vec![CompletionInsertion {
+                    index: 0,
+                    node_type: NodeType::Paragraph,
+                }],
+            })
+        );
+    }
+
+    #[test]
+    fn empty_table_requires_direct_row() {
+        assert_eq!(
+            content_placement(NodeType::Table, &[]),
+            ContentPlacement {
+                consumed: 0,
+                first_residue: None,
+                completion_insertions: Some(vec![CompletionInsertion {
+                    index: 0,
+                    node_type: NodeType::TableRow,
+                }]),
+            }
+        );
+    }
+
+    #[test]
+    fn valid_sequence_with_unknowns_has_no_residue_or_completion() {
+        assert_eq!(
+            content_placement(
+                NodeType::ListItem,
+                &[
+                    NodeType::Unknown,
+                    NodeType::Paragraph,
+                    NodeType::Unknown,
+                    NodeType::OrderedList,
+                    NodeType::Unknown,
+                ],
+            ),
+            ContentPlacement {
+                consumed: 2,
+                first_residue: None,
+                completion_insertions: Some(vec![]),
+            }
+        );
+    }
+
+    #[test]
+    fn fold_completion_maps_filtered_index_around_unknown() {
+        assert_eq!(
+            content_placement(NodeType::Fold, &[NodeType::Unknown, NodeType::FoldContent],)
+                .completion_insertions,
+            Some(vec![CompletionInsertion {
+                index: 1,
+                node_type: NodeType::FoldTitle,
+            }])
+        );
+    }
+
+    #[test]
+    fn fold_completion_orders_multiple_insertions_after_unknowns() {
+        assert_eq!(
+            content_placement(NodeType::Fold, &[]).completion_insertions,
+            Some(vec![
+                CompletionInsertion {
+                    index: 0,
+                    node_type: NodeType::FoldTitle,
+                },
+                CompletionInsertion {
+                    index: 1,
+                    node_type: NodeType::FoldContent,
+                },
+            ])
+        );
+        assert_eq!(
+            content_placement(NodeType::Fold, &[NodeType::Unknown]).completion_insertions,
+            Some(vec![
+                CompletionInsertion {
+                    index: 1,
+                    node_type: NodeType::FoldTitle,
+                },
+                CompletionInsertion {
+                    index: 2,
+                    node_type: NodeType::FoldContent,
+                },
+            ])
+        );
+    }
+
+    #[test]
+    fn valid_root_repeatable_content_and_trailing_paragraph_needs_no_completion() {
+        assert_eq!(
+            content_placement(NodeType::Root, &[NodeType::Image, NodeType::Paragraph]),
+            ContentPlacement {
+                consumed: 2,
+                first_residue: None,
+                completion_insertions: Some(vec![]),
+            }
         );
     }
 

--- a/crates/editor-model/src/seq/normalize.rs
+++ b/crates/editor-model/src/seq/normalize.rs
@@ -1,11 +1,11 @@
-use std::collections::VecDeque;
-
 use editor_crdt::Dot;
 use hashbrown::HashSet;
 
 use super::project::{RawChild, RawNode, RawTree, synthetic_id};
 use crate::nodes::NodeType;
-use crate::schema::{ContentExpr, context_allows, wrap_chain};
+use crate::schema::{
+    CompletionInsertion, ContentExpr, RepairTransition, content_placement, repair_transition,
+};
 
 /// Counters for the deterministic repair pass. `drops` and `totality_violations`
 /// record real (authored) content loss — `drops` should always be zero under the
@@ -143,222 +143,25 @@ pub fn is_fixed_slot(t: NodeType) -> bool {
     fixed_slot_roles(&t.spec().content).is_some()
 }
 
-/// Move any leading `Unknown` children (opaque preserved ops) verbatim from
-/// `kids` to `out` without consuming a content slot — they belong with the
-/// preceding real sibling and are invisible to content matching.
-fn skip_unknowns(kids: &mut VecDeque<RawChild>, out: &mut Vec<RawChild>) {
-    while kids
-        .front()
-        .and_then(|c| c.as_child_type())
-        .is_some_and(|t| t == NodeType::Unknown)
-    {
-        out.push(kids.pop_front().unwrap());
-    }
-}
-
-/// Greedily consume `kids` against `expr`, appending matched real children and
-/// deterministic fillers for missing required slots to `out`, leaving any residue
-/// in `kids`. `Unknown` children pass through transparently. Returns the number
-/// of real (non-`Unknown`) children consumed. This is the container-completion
-/// engine: it never removes or reorders existing real children.
-fn match_content(
-    expr: &ContentExpr,
-    kids: &mut VecDeque<RawChild>,
-    parent: Dot,
-    out: &mut Vec<RawChild>,
-) -> usize {
-    let front = |k: &VecDeque<RawChild>, e: &ContentExpr| {
-        k.front()
-            .and_then(|c| c.as_child_type())
-            .is_some_and(|t| t != NodeType::Unknown && e.matches(t))
-    };
-    match expr {
-        ContentExpr::Empty | ContentExpr::Any => 0,
-        ContentExpr::Single(t) => {
-            skip_unknowns(kids, out);
-            if kids
-                .front()
-                .and_then(|c| c.as_child_type())
-                .is_some_and(|ct| ct == *t)
-            {
-                out.push(kids.pop_front().unwrap());
-                1
-            } else {
-                out.push(RawChild::Block(scaffold_block(*t, 0, parent)));
-                0
-            }
-        }
-        ContentExpr::Optional(inner) => {
-            skip_unknowns(kids, out);
-            if front(kids, inner) {
-                out.push(kids.pop_front().unwrap());
-                1
-            } else {
-                0
-            }
-        }
-        ContentExpr::ZeroOrMore(inner) => {
-            let mut n = 0;
-            loop {
-                skip_unknowns(kids, out);
-                if front(kids, inner) {
-                    out.push(kids.pop_front().unwrap());
-                    n += 1;
-                } else {
-                    break;
-                }
-            }
-            n
-        }
-        ContentExpr::OneOrMore(inner) => {
-            let mut n = 0;
-            loop {
-                skip_unknowns(kids, out);
-                if front(kids, inner) {
-                    out.push(kids.pop_front().unwrap());
-                    n += 1;
-                } else {
-                    break;
-                }
-            }
-            if n == 0 {
-                out.push(RawChild::Block(scaffold_block(
-                    first_type(inner),
-                    0,
-                    parent,
-                )));
-            }
-            n
-        }
-        ContentExpr::Choice(cs) => {
-            skip_unknowns(kids, out);
-            match cs.iter().find(|c| front(kids, c)) {
-                Some(c) => match_content(c, kids, parent, out),
-                None => {
-                    out.push(RawChild::Block(scaffold_block(
-                        first_type(&cs[0]),
-                        0,
-                        parent,
-                    )));
-                    0
-                }
-            }
-        }
-        ContentExpr::Seq(exprs) => {
-            let mut n = 0;
-            for e in exprs {
-                n += match_content(e, kids, parent, out);
-            }
-            n
-        }
-    }
-}
-
-/// Greedily consume `types` (real child types only) against `expr` and return how
-/// many were consumed — the mirror of [`match_content`] without scaffolding. A
-/// residue exists exactly when the returned count is short of `types.len()`.
-fn greedy_consume(expr: &ContentExpr, types: &[NodeType]) -> usize {
-    fn matches_at(e: &ContentExpr, types: &[NodeType], idx: usize) -> bool {
-        types.get(idx).is_some_and(|t| e.matches(*t))
-    }
-    fn walk(expr: &ContentExpr, types: &[NodeType], idx: &mut usize) {
-        match expr {
-            ContentExpr::Empty => {}
-            ContentExpr::Any => *idx = types.len(),
-            ContentExpr::Single(t) => {
-                if types.get(*idx) == Some(t) {
-                    *idx += 1;
-                }
-            }
-            ContentExpr::Optional(inner) => {
-                if matches_at(inner, types, *idx) {
-                    walk(inner, types, idx);
-                }
-            }
-            ContentExpr::ZeroOrMore(inner) | ContentExpr::OneOrMore(inner) => {
-                while matches_at(inner, types, *idx) {
-                    walk(inner, types, idx);
-                }
-            }
-            ContentExpr::Choice(cs) => {
-                if let Some(c) = cs.iter().find(|c| matches_at(c, types, *idx)) {
-                    walk(c, types, idx);
-                }
-            }
-            ContentExpr::Seq(es) => {
-                for e in es {
-                    walk(e, types, idx);
-                }
-            }
-        }
-    }
-    let mut idx = 0;
-    walk(expr, types, &mut idx);
-    idx
-}
-
-/// The index of the first content residue among `node`'s children (the first real
-/// child greedy matching cannot consume), treating `Unknown` as transparent.
-/// `None` when the content is a completable prefix (missing required slots are a
-/// completion concern, not a residue).
-fn content_residue_index(node: &RawNode) -> Option<usize> {
-    if node.node_type == NodeType::Unknown {
-        return None;
-    }
-    let reals: Vec<(usize, NodeType)> = node
-        .children
+fn raw_child_types(node: &RawNode) -> Vec<NodeType> {
+    node.children
         .iter()
-        .enumerate()
-        .filter_map(|(i, c)| {
-            c.as_child_type()
-                .filter(|t| *t != NodeType::Unknown)
-                .map(|t| (i, t))
-        })
-        .collect();
-    let types: Vec<NodeType> = reals.iter().map(|(_, t)| *t).collect();
-    let consumed = greedy_consume(&node.node_type.spec().content, &types);
-    (consumed < reals.len()).then(|| reals[consumed].0)
+        .map(|child| child.as_child_type().unwrap_or(NodeType::Unknown))
+        .collect()
 }
 
-fn min_opt(a: Option<usize>, b: Option<usize>) -> Option<usize> {
-    match (a, b) {
-        (Some(x), Some(y)) => Some(x.min(y)),
-        (Some(x), None) | (None, Some(x)) => Some(x),
-        (None, None) => None,
-    }
-}
-
-/// The index of the first child that cannot legally stay a direct child here — a
-/// content residue or an actual-path context violation — in document order.
-fn first_misfit(node: &RawNode, path: &[NodeType]) -> Option<usize> {
-    let ctx_viol = (node.node_type != NodeType::Unknown)
-        .then(|| {
-            node.children.iter().position(|c| {
-                c.as_child_type()
-                    .is_some_and(|ct| ct != NodeType::Unknown && !context_allows(path, ct))
-            })
-        })
-        .flatten();
-    min_opt(ctx_viol, content_residue_index(node))
-}
-
-/// Whether the child at `i` is a misfit here (context violation or the first
-/// content residue). Correct when every child before `i` already fits and
-/// `residue` equals `content_residue_index(node)` for the node's current
-/// children — callers cache it across loop iterations and must recompute it
-/// after any mutation of `node.children`.
-fn is_misfit_at(node: &RawNode, i: usize, path: &[NodeType], residue: Option<usize>) -> bool {
-    debug_assert_eq!(residue, content_residue_index(node));
-    let Some(ct) = node.children[i].as_child_type() else {
-        return false;
-    };
-    if ct == NodeType::Unknown {
-        return false;
-    }
-    if node.node_type != NodeType::Unknown && !context_allows(path, ct) {
-        return true;
-    }
-    residue == Some(i)
+fn raw_repair_transition(
+    node: &RawNode,
+    path: &[NodeType],
+    ctx: &RepairCtx,
+) -> Option<RepairTransition> {
+    repair_transition(path, &raw_child_types(node), |index| {
+        !matches!(
+            node.children.get(index),
+            Some(RawChild::Block(block))
+                if ctx.wrap_created.contains(&(block.id, path.len()))
+        )
+    })
 }
 
 fn child_own_dot(c: &RawChild) -> Dot {
@@ -421,56 +224,27 @@ fn empty_scaffold(
 }
 
 /// Insert deterministic fillers for `node`'s missing required content slots,
-/// preserving every existing child (including `Unknown`s) in place. Assumes the
-/// node is residue-free (misfits already resolved).
+/// preserving every existing child (including `Unknown`s) in place. If insertion
+/// alone cannot complete the current sequence, leave it for the subsequent
+/// WRAP/SPLIT repair pass.
 fn complete_required(node: &mut RawNode) {
     if node.node_type == NodeType::Unknown {
         return;
     }
-    let content = node.node_type.spec().content.clone();
-    // Already valid — do not run the greedy filler, whose repeatable groups would
-    // absorb an existing trailing required slot and re-scaffold it (non-idempotent).
-    let real_types: Vec<NodeType> = node
-        .children
-        .iter()
-        .filter_map(|c| c.as_child_type())
-        .filter(|t| *t != NodeType::Unknown)
-        .collect();
-    if content.matches_sequence(&real_types) {
+    let placement = content_placement(node.node_type, &raw_child_types(node));
+    let Some(insertions) = placement.completion_insertions else {
         return;
-    }
-    let mut kids: VecDeque<RawChild> = std::mem::take(&mut node.children).into_iter().collect();
-    let mut out = Vec::new();
-    match_content(&content, &mut kids, node.id, &mut out);
-    skip_unknowns(&mut kids, &mut out);
-    out.extend(kids);
-    node.children = out;
+    };
+    apply_completion(node, &insertions);
 }
 
-/// The WRAP plan for the misfit child at `i`: the scaffold chain to wrap it in, or
-/// `None` when it must SPLIT-HOIST instead — the type fits directly (an
-/// empty chain, i.e. a count/position overflow), no chain exists, the context is
-/// unsatisfiable, or the child is a wrap scaffold already created at this level.
-fn wrap_plan(
-    node: &RawNode,
-    i: usize,
-    path: &[NodeType],
-    ctx: &RepairCtx,
-) -> Option<Vec<NodeType>> {
-    let ct = node.children[i].as_child_type()?;
-    if ct == NodeType::Unknown {
-        return None;
+fn apply_completion(node: &mut RawNode, insertions: &[CompletionInsertion]) {
+    for insertion in insertions {
+        node.children.insert(
+            insertion.index,
+            RawChild::Block(scaffold_block(insertion.node_type, 0, node.id)),
+        );
     }
-    let chain = wrap_chain(path, ct)?;
-    if chain.is_empty() {
-        return None;
-    }
-    if let RawChild::Block(b) = &node.children[i]
-        && ctx.wrap_created.contains(&(b.id, path.len()))
-    {
-        return None;
-    }
-    Some(chain)
 }
 
 /// Replace the child at `i` with a scaffold chain (`chain[0]` outermost) that
@@ -513,6 +287,7 @@ fn wrap_child(
 fn split_out(
     node: &mut RawNode,
     k: usize,
+    retained_completion: &[CompletionInsertion],
     path: &[NodeType],
     ctx: &mut RepairCtx,
 ) -> Vec<RawChild> {
@@ -521,7 +296,7 @@ fn split_out(
     }
     let tail: Vec<RawChild> = node.children.split_off(k + 1);
     let promoted = node.children.pop().expect("k is a valid child index");
-    complete_required(node);
+    apply_completion(node, retained_completion);
     let mut out = vec![promoted];
     if !tail.is_empty() {
         let cause = tail
@@ -554,12 +329,17 @@ fn resolve_own_misfits(
         if ctx.capped {
             return Vec::new();
         }
-        let Some(k) = first_misfit(node, path) else {
-            return Vec::new();
-        };
-        match wrap_plan(node, k, path, ctx) {
-            Some(chain) => wrap_child(node, k, &chain, path, ctx),
-            None => return split_out(node, k, path, ctx),
+        match raw_repair_transition(node, path, ctx) {
+            Some(RepairTransition::Ready { .. }) | None => return Vec::new(),
+            Some(RepairTransition::Wrap { index, chain }) => {
+                wrap_child(node, index, &chain, path, ctx)
+            }
+            Some(RepairTransition::SplitHoist {
+                index,
+                retained_completion,
+            }) => {
+                return split_out(node, index, &retained_completion, path, ctx);
+            }
         }
     }
 }
@@ -605,26 +385,14 @@ fn normalize_grid(table: &mut RawNode) {
 
 fn scaffold_block(role: NodeType, slot: usize, parent: Dot) -> RawNode {
     let id = synthetic_id(parent, slot, role);
-    let mut out = Vec::new();
-    match_content(&role.spec().content, &mut VecDeque::new(), id, &mut out);
-    RawNode {
+    let mut node = RawNode {
         id,
         node_type: role,
         attrs: vec![],
-        children: out,
-    }
-}
-
-fn first_type(e: &ContentExpr) -> NodeType {
-    match e {
-        ContentExpr::Single(t) => *t,
-        ContentExpr::Choice(cs) => first_type(&cs[0]),
-        ContentExpr::OneOrMore(i) | ContentExpr::ZeroOrMore(i) | ContentExpr::Optional(i) => {
-            first_type(i)
-        }
-        ContentExpr::Seq(es) => first_type(&es[0]),
-        ContentExpr::Empty | ContentExpr::Any => unreachable!(),
-    }
+        children: Vec::new(),
+    };
+    complete_required(&mut node);
+    node
 }
 
 fn last_known_child(children: &[RawChild]) -> Option<&RawChild> {
@@ -728,31 +496,30 @@ pub fn normalize_window_forest_with_stats(
     // Mirror `process_children` for the Root node WITHOUT its terminal
     // `complete_required` (Root completion is applied document-globally elsewhere).
     let mut path = vec![NodeType::Root];
-    let mut residue = content_residue_index(&root);
     let mut i = 0;
     while i < root.children.len() {
         if ctx.capped {
             break;
         }
-        if is_misfit_at(&root, i, &path, residue) {
-            match wrap_plan(&root, i, &path, &ctx) {
-                Some(chain) => {
-                    wrap_child(&mut root, i, &chain, &path, &mut ctx);
-                    residue = content_residue_index(&root);
-                    // The scaffold now fits here; re-examine slot i (recursed next pass).
-                    continue;
-                }
-                None => {
-                    // Root accepts every block type through WRAP, so a terminating
-                    // SPLIT here is unreachable; keep the promoted forest as Root
-                    // children rather than lose it (total).
-                    let hoist = split_out(&mut root, i, &path, &mut ctx);
-                    root.children.splice(i + 1..i + 1, hoist);
-                    residue = content_residue_index(&root);
-                    i += 1;
-                    continue;
-                }
+        match raw_repair_transition(&root, &path, &ctx) {
+            Some(RepairTransition::Wrap { index, chain }) if index == i => {
+                wrap_child(&mut root, i, &chain, &path, &mut ctx);
+                // The scaffold now fits here; re-examine slot i (recursed next pass).
+                continue;
             }
+            Some(RepairTransition::SplitHoist {
+                index,
+                retained_completion,
+            }) if index == i => {
+                // Root accepts every block type through WRAP, so a terminating
+                // SPLIT here is unreachable; keep the promoted forest as Root
+                // children rather than lose it (total).
+                let hoist = split_out(&mut root, i, &retained_completion, &path, &mut ctx);
+                root.children.splice(i + 1..i + 1, hoist);
+                i += 1;
+                continue;
+            }
+            _ => {}
         }
         let child_hoist = if let RawChild::Block(b) = &mut root.children[i] {
             normalize_node(b, &mut path, &mut ctx)
@@ -764,11 +531,9 @@ pub fn normalize_window_forest_with_stats(
                 matches!(&root.children[i], RawChild::Block(b) if first_real_dot_node(b).is_none());
             if husk_emptied {
                 root.children.splice(i..i + 1, child_hoist);
-                residue = content_residue_index(&root);
                 continue;
             }
             root.children.splice(i + 1..i + 1, child_hoist);
-            residue = content_residue_index(&root);
         }
         i += 1;
     }
@@ -795,24 +560,24 @@ pub fn normalize_window_forest_for(
     let mut path = ancestors.to_vec();
     path.push(container_type);
     let mut hoisted: Vec<RawChild> = Vec::new();
-    let mut residue = content_residue_index(&root);
     let mut i = 0;
     while i < root.children.len() {
         if ctx.capped {
             break;
         }
-        if is_misfit_at(&root, i, &path, residue) {
-            match wrap_plan(&root, i, &path, &ctx) {
-                Some(chain) => {
-                    wrap_child(&mut root, i, &chain, &path, &mut ctx);
-                    residue = content_residue_index(&root);
-                    continue;
-                }
-                None => {
-                    hoisted = split_out(&mut root, i, &path, &mut ctx);
-                    break;
-                }
+        match raw_repair_transition(&root, &path, &ctx) {
+            Some(RepairTransition::Wrap { index, chain }) if index == i => {
+                wrap_child(&mut root, i, &chain, &path, &mut ctx);
+                continue;
             }
+            Some(RepairTransition::SplitHoist {
+                index,
+                retained_completion,
+            }) if index == i => {
+                hoisted = split_out(&mut root, i, &retained_completion, &path, &mut ctx);
+                break;
+            }
+            _ => {}
         }
         let child_hoist = if let RawChild::Block(b) = &mut root.children[i] {
             normalize_node(b, &mut path, &mut ctx)
@@ -824,11 +589,9 @@ pub fn normalize_window_forest_for(
                 matches!(&root.children[i], RawChild::Block(b) if first_real_dot_node(b).is_none());
             if husk_emptied {
                 root.children.splice(i..i + 1, child_hoist);
-                residue = content_residue_index(&root);
                 continue;
             }
             root.children.splice(i + 1..i + 1, child_hoist);
-            residue = content_residue_index(&root);
         }
         i += 1;
     }
@@ -867,8 +630,8 @@ pub fn normalize_subtree_with_stats(
 /// assuming its children are already individually normalized — no deep recursion.
 /// Lets a caller re-establish a container's content invariant (e.g. the Root's
 /// required trailing paragraph) by deferring to the schema rather than hardcoding
-/// it. Newly scaffolded children are themselves shaped by `match_content`, so they
-/// need no further normalization here.
+/// it. Newly scaffolded children are themselves completed from the shared
+/// schema-placement decision, so they need no further normalization here.
 pub fn normalize_content_shallow(node: &mut RawNode, ancestors: &[NodeType]) {
     let mut stats = RepairStats::default();
     normalize_content_shallow_with_stats(node, ancestors, &mut stats);
@@ -920,23 +683,25 @@ fn process_children(
     path: &mut Vec<NodeType>,
     ctx: &mut RepairCtx,
 ) -> Vec<RawChild> {
-    let mut residue = content_residue_index(node);
     let mut i = 0;
     while i < node.children.len() {
         if ctx.capped {
             return Vec::new();
         }
-        if is_misfit_at(node, i, path, residue) {
-            match wrap_plan(node, i, path, ctx) {
-                Some(chain) => {
-                    wrap_child(node, i, &chain, path, ctx);
-                    residue = content_residue_index(node);
-                    // The scaffold now fits here; re-examine slot i (it will be
-                    // recursed on the next pass).
-                    continue;
-                }
-                None => return split_out(node, i, path, ctx),
+        match raw_repair_transition(node, path, ctx) {
+            Some(RepairTransition::Wrap { index, chain }) if index == i => {
+                wrap_child(node, i, &chain, path, ctx);
+                // The scaffold now fits here; re-examine slot i (it will be
+                // recursed on the next pass).
+                continue;
             }
+            Some(RepairTransition::SplitHoist {
+                index,
+                retained_completion,
+            }) if index == i => {
+                return split_out(node, i, &retained_completion, path, ctx);
+            }
+            _ => {}
         }
         let child_hoist = match &mut node.children[i] {
             RawChild::Block(b) => normalize_node(b, path, ctx),
@@ -947,15 +712,15 @@ fn process_children(
                 matches!(&node.children[i], RawChild::Block(b) if first_real_dot_node(b).is_none());
             if husk_emptied {
                 node.children.splice(i..i + 1, child_hoist);
-                residue = content_residue_index(node);
                 continue;
             }
             node.children.splice(i + 1..i + 1, child_hoist);
-            residue = content_residue_index(node);
         }
         i += 1;
     }
-    complete_required(node);
+    if let Some(RepairTransition::Ready { completion }) = raw_repair_transition(node, path, ctx) {
+        apply_completion(node, &completion);
+    }
     Vec::new()
 }
 
@@ -1111,6 +876,23 @@ mod tests {
             flat.get(promoted_para).is_some(),
             "its Paragraph survives inside the ListItem"
         );
+        assert!(valid(&out).is_ok());
+    }
+
+    #[test]
+    fn normalize_repairs_children_of_malformed_leaf_block() {
+        let tree = RawTree {
+            roots: vec![raw_block(
+                0,
+                NodeType::Text,
+                vec![raw_char(1, 'A'), raw_char(2, ' ')],
+            )],
+        };
+        let expected_dots = raw_real_dots(&tree);
+
+        let out = normalize(tree);
+
+        assert_eq!(raw_real_dots(&out), expected_dots);
         assert!(valid(&out).is_ok());
     }
 
@@ -1426,6 +1208,40 @@ mod tests {
             ],
             "the Unknown stays first and the typed roles follow in order"
         );
+        assert!(valid(&out).is_ok());
+    }
+
+    #[test]
+    fn fold_completion_inserts_title_after_leading_unknown() {
+        let tree = raw_root(vec![raw_block_child(
+            1,
+            NodeType::Fold,
+            vec![
+                raw_block_child(2, NodeType::Unknown, vec![]),
+                raw_block_child(
+                    3,
+                    NodeType::FoldContent,
+                    vec![raw_block_child(4, NodeType::Paragraph, vec![])],
+                ),
+            ],
+        )]);
+
+        let out = normalize(tree);
+        let RawChild::Block(fold) = &out.roots[0].children[0] else {
+            panic!("fold");
+        };
+        assert_eq!(
+            fold.children
+                .iter()
+                .filter_map(RawChild::as_child_type)
+                .collect::<Vec<_>>(),
+            vec![
+                NodeType::Unknown,
+                NodeType::FoldTitle,
+                NodeType::FoldContent,
+            ]
+        );
+        assert!(matches!(&fold.children[1], RawChild::Block(title) if title.id.is_synthetic()));
         assert!(valid(&out).is_ok());
     }
 

--- a/crates/editor-model/src/subtree.rs
+++ b/crates/editor-model/src/subtree.rs
@@ -3,7 +3,7 @@ use editor_crdt::Dot;
 use crate::modifier::Modifier;
 use crate::nodes::PlainNode;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Subtree {
     pub node: PlainNode,
     pub modifiers: Vec<Modifier>,
@@ -36,5 +36,76 @@ impl Subtree {
     pub fn with_modifiers(mut self, modifiers: Vec<Modifier>) -> Self {
         self.modifiers = modifiers;
         self
+    }
+
+    pub fn into_parts(
+        mut self,
+    ) -> (
+        PlainNode,
+        Vec<Modifier>,
+        Vec<Modifier>,
+        Vec<Subtree>,
+        Vec<Dot>,
+    ) {
+        (
+            std::mem::replace(&mut self.node, PlainNode::Unknown),
+            std::mem::take(&mut self.modifiers),
+            std::mem::take(&mut self.carry),
+            std::mem::take(&mut self.children),
+            std::mem::take(&mut self.source_dots),
+        )
+    }
+}
+
+impl Clone for Subtree {
+    fn clone(&self) -> Self {
+        struct Frame<'a> {
+            source: &'a Subtree,
+            next_child: usize,
+            children: Vec<Subtree>,
+        }
+
+        let mut stack = vec![Frame {
+            source: self,
+            next_child: 0,
+            children: Vec::with_capacity(self.children.len()),
+        }];
+        loop {
+            let next = {
+                let frame = stack.last_mut().expect("root clone frame");
+                let child = frame.source.children.get(frame.next_child);
+                frame.next_child += usize::from(child.is_some());
+                child
+            };
+            if let Some(child) = next {
+                stack.push(Frame {
+                    source: child,
+                    next_child: 0,
+                    children: Vec::with_capacity(child.children.len()),
+                });
+                continue;
+            }
+            let frame = stack.pop().expect("root clone frame");
+            let cloned = Subtree {
+                node: frame.source.node.clone(),
+                modifiers: frame.source.modifiers.clone(),
+                carry: frame.source.carry.clone(),
+                children: frame.children,
+                source_dots: frame.source.source_dots.clone(),
+            };
+            let Some(parent) = stack.last_mut() else {
+                return cloned;
+            };
+            parent.children.push(cloned);
+        }
+    }
+}
+
+impl Drop for Subtree {
+    fn drop(&mut self) {
+        let mut stack = std::mem::take(&mut self.children);
+        while let Some(mut subtree) = stack.pop() {
+            stack.append(&mut subtree.children);
+        }
     }
 }

--- a/crates/editor-state/src/undo.rs
+++ b/crates/editor-state/src/undo.rs
@@ -28,14 +28,14 @@ pub struct TransientState {
     pub selection: Option<StableSelection>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct SpanRun {
     pub start: Anchor,
     pub end: Anchor,
     pub modifier: Modifier,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum PriorValue {
     BlockModifier(Option<Modifier>),
     NodeAttr(NodeAttr),
@@ -46,7 +46,7 @@ pub enum PriorValue {
     },
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct RecordedOp {
     pub op: Op<EditOp>,
     pub prior: Option<PriorValue>,
@@ -63,6 +63,7 @@ pub enum RecordMerge {
     },
 }
 
+#[derive(Clone)]
 pub struct UndoEntry {
     pub ops: Vec<RecordedOp>,
     pub tag: Option<HistoryTag>,
@@ -114,11 +115,9 @@ impl UndoHistory {
         self.last_tag.as_ref()
     }
 
-    /// The transient state recorded with the most recent undo entry (e.g. the
-    /// caret before the last edit). Used by repaste to recover the pre-paste
-    /// caret without popping the entry.
-    pub fn last_transient(&self) -> Option<&TransientState> {
-        self.undos.last().map(|e| &e.transient)
+    /// The latest applied history entry, without changing either stack.
+    pub fn last_entry(&self) -> Option<&UndoEntry> {
+        self.undos.last()
     }
 
     pub fn last_tag_revision(&self) -> u64 {
@@ -231,41 +230,11 @@ impl UndoHistory {
         let entry = self.undos.pop()?;
         let tag = entry.tag.clone();
         let restore_transient = entry.transient.clone();
-        let mut redo_ops: Vec<RecordedOp> = Vec::new();
-        let mut applied: Vec<Op<EditOp>> = Vec::new();
-        // Sequence inverses read only the checkout, so a run of them can be applied
-        // without projecting each — deferred into one `reproject_all` — collapsing the
-        // per-op window reprojections that make undoing a large multi-block delete
-        // quadratic-ish. A non-sequence inverse's `capture_prior` reads the projection,
-        // so flush any deferred run before it.
-        let mut warm_pending = false;
-        'entry: for ro in entry.ops.into_iter().rev() {
-            for inv_payload in invert(state, &ro) {
-                let is_seq = matches!(inv_payload, EditOp::Seq(_));
-                if !is_seq && warm_pending {
-                    let _ = state.reproject_all();
-                    warm_pending = false;
-                }
-                let prior_for_redo = capture_prior(state, &inv_payload);
-                let res = if is_seq {
-                    state.apply_warm_only(inv_payload)
-                } else {
-                    state.apply(inv_payload)
-                };
-                let Ok(inv_op) = res else {
-                    break 'entry;
-                };
-                warm_pending |= is_seq;
-                applied.push(inv_op.clone());
-                redo_ops.push(RecordedOp {
-                    op: inv_op,
-                    prior: prior_for_redo,
-                });
-            }
-        }
-        if warm_pending {
-            let _ = state.reproject_all();
-        }
+        let (redo_ops, _) = apply_inverse(state, &entry.ops);
+        let applied = redo_ops
+            .iter()
+            .map(|recorded| recorded.op.clone())
+            .collect();
         self.redos.push(UndoEntry {
             ops: redo_ops,
             tag,
@@ -285,38 +254,11 @@ impl UndoHistory {
         let entry = self.redos.pop()?;
         let tag = entry.tag.clone();
         let restore_transient = entry.transient.clone();
-        let mut undo_ops: Vec<RecordedOp> = Vec::new();
-        let mut applied: Vec<Op<EditOp>> = Vec::new();
-        // See `undo`: defer a run of sequence inverses into one reproject, flushing
-        // before any non-sequence inverse (whose `capture_prior` reads the projection).
-        let mut warm_pending = false;
-        'entry: for ro in entry.ops.into_iter().rev() {
-            for inv_payload in invert(state, &ro) {
-                let is_seq = matches!(inv_payload, EditOp::Seq(_));
-                if !is_seq && warm_pending {
-                    let _ = state.reproject_all();
-                    warm_pending = false;
-                }
-                let prior_for_undo = capture_prior(state, &inv_payload);
-                let res = if is_seq {
-                    state.apply_warm_only(inv_payload)
-                } else {
-                    state.apply(inv_payload)
-                };
-                let Ok(inv_op) = res else {
-                    break 'entry;
-                };
-                warm_pending |= is_seq;
-                applied.push(inv_op.clone());
-                undo_ops.push(RecordedOp {
-                    op: inv_op,
-                    prior: prior_for_undo,
-                });
-            }
-        }
-        if warm_pending {
-            let _ = state.reproject_all();
-        }
+        let (undo_ops, _) = apply_inverse(state, &entry.ops);
+        let applied = undo_ops
+            .iter()
+            .map(|recorded| recorded.op.clone())
+            .collect();
         self.undos.push(UndoEntry {
             ops: undo_ops,
             tag,
@@ -327,6 +269,56 @@ impl UndoHistory {
         self.sync_last_tag_from_top();
         Some((applied, restore_transient))
     }
+}
+
+/// Apply the inverse of `ops` and capture the emitted CRDT ops with their prior
+/// values for a later inverse. Normal undo keeps its historical best-effort
+/// behavior when `failure` is present; transactional callers can reject the
+/// isolated transaction instead.
+pub fn apply_inverse(
+    state: &mut ProjectedState,
+    ops: &[RecordedOp],
+) -> (Vec<RecordedOp>, Option<crate::StateError>) {
+    let mut recorded = Vec::new();
+    let mut failure = None;
+    // Sequence inverses read only the checkout, so a run of them can be applied
+    // without projecting each — deferred into one `reproject_all` — collapsing the
+    // per-op window reprojections that make undoing a large multi-block delete
+    // quadratic-ish. A non-sequence inverse's `capture_prior` reads the projection,
+    // so flush any deferred run before it.
+    let mut warm_pending = false;
+    'entry: for ro in ops.iter().rev() {
+        for inv_payload in invert(state, ro) {
+            let is_seq = matches!(inv_payload, EditOp::Seq(_));
+            if !is_seq && warm_pending {
+                if let Err(error) = state.reproject_all() {
+                    failure = Some(error.into());
+                    warm_pending = false;
+                    break 'entry;
+                }
+                warm_pending = false;
+            }
+            let prior = capture_prior(state, &inv_payload);
+            let result = if is_seq {
+                state.apply_warm_only(inv_payload)
+            } else {
+                state.apply(inv_payload)
+            };
+            let op = match result {
+                Ok(op) => op,
+                Err(error) => {
+                    failure = Some(error.into());
+                    break 'entry;
+                }
+            };
+            warm_pending |= is_seq;
+            recorded.push(RecordedOp { op, prior });
+        }
+    }
+    if warm_pending && let Err(error) = state.reproject_all() {
+        failure.get_or_insert_with(|| error.into());
+    }
+    (recorded, failure)
 }
 
 fn mergeable(last_merge: Option<&RecordMerge>, entry: &UndoEntry) -> bool {

--- a/crates/editor-transaction/src/fulfill.rs
+++ b/crates/editor-transaction/src/fulfill.rs
@@ -1,35 +1,20 @@
-use editor_model::{ChildView, ContentExpr, NodeType, NodeView, Subtree};
+use editor_model::{ChildView, ContentExpr, NodeType, NodeView, Subtree, content_placement};
 
 use crate::Step;
 
 /// Analyzes a node's content expression and returns InsertSubtree steps
 /// needed to make it valid. Returns empty vec if already valid.
 pub fn fulfill(node: &NodeView) -> Vec<Step> {
-    let spec = node.spec();
-    let (child_types, real_indices) = known_child_types(node);
-
-    if spec.content.matches_sequence(&child_types) {
-        return vec![];
-    }
-
-    let insertions = spec
-        .content
-        .completion_insertions(&child_types)
+    let insertions = content_placement(node.node_type(), &child_types(node))
+        .completion_insertions
         .unwrap_or_default();
-    let total_children = node.child_count();
     insertions
         .into_iter()
-        .enumerate()
-        .map(|(k, (filtered_index, node_type))| {
-            let unshifted = filtered_index - k;
-            let real_index = real_indices
-                .get(unshifted)
-                .copied()
-                .unwrap_or(total_children);
-            let subtree = scaffold(node_type);
+        .map(|insertion| {
+            let subtree = scaffold(insertion.node_type);
             Step::InsertSubtree {
                 parent: node.id(),
-                index: real_index + k,
+                index: insertion.index,
                 subtree,
             }
         })
@@ -50,21 +35,13 @@ pub fn minimal_subtree(node_type: NodeType) -> Subtree {
     scaffold(node_type)
 }
 
-fn known_child_types(node: &NodeView) -> (Vec<NodeType>, Vec<usize>) {
-    let mut types = Vec::new();
-    let mut real_indices = Vec::new();
-    for (i, c) in node.children().enumerate() {
-        let node_type = match c {
-            ChildView::Block(b) => b.node_type(),
-            ChildView::Leaf(l) => l.node_type(),
-        };
-        if node_type == NodeType::Unknown {
-            continue;
-        }
-        types.push(node_type);
-        real_indices.push(i);
-    }
-    (types, real_indices)
+fn child_types(node: &NodeView) -> Vec<NodeType> {
+    node.children()
+        .map(|child| match child {
+            ChildView::Block(block) => block.node_type(),
+            ChildView::Leaf(leaf) => leaf.node_type(),
+        })
+        .collect()
 }
 
 fn first_type(expr: &ContentExpr) -> NodeType {
@@ -182,15 +159,10 @@ mod tests {
         );
     }
 
-    /// The append-fallback case above hits `real_indices.get(unshifted) == None`
-    /// (the missing type sorts after every known child, so the repair index
-    /// falls back to `total_children`). This oracle instead hits `Some(_)`: an
-    /// interior real_indices lookup succeeds because the missing child must be
-    /// inserted *before* an already-present known child. Physical order here
-    /// is [FoldContent, Unknown], so `fulfill` must insert the missing FoldTitle
-    /// at real index 0, not append it after the Unknown.
+    /// Physical order is [FoldContent, Unknown], so the shared placement result
+    /// inserts the missing FoldTitle at index 0, not after the Unknown.
     #[test]
-    fn fulfill_remaps_insertion_index_via_real_indices_hit_before_unknown() {
+    fn fulfill_inserts_missing_role_before_trailing_unknown() {
         use editor_crdt::Dot;
         use editor_model::{BlockTree, DocView, ProjectedDoc, RawChild, RawNode, RawTree};
 
@@ -243,17 +215,10 @@ mod tests {
         );
     }
 
-    /// The two oracles above both land on `real_index == unshifted` (0 in both
-    /// cases) because their Unknown sits *after* the insertion point — a
-    /// regression that dropped the `real_indices` remap entirely (using the
-    /// filtered index directly as the real index) would slip through both
-    /// unnoticed. This oracle puts the Unknown *before* the insertion point
-    /// (`[Unknown, FoldContent]`), so the real index (1, past the
-    /// Unknown) diverges from the filtered index (0, Unknown excluded) —
-    /// only the `real_indices` lookup, not the raw filtered index, produces
-    /// the expected step.
+    /// Physical order is [Unknown, FoldContent], so the shared placement result
+    /// keeps the Unknown transparent while inserting FoldTitle after it.
     #[test]
-    fn fulfill_remaps_insertion_index_when_real_and_filtered_indices_diverge() {
+    fn fulfill_inserts_missing_role_after_leading_unknown() {
         use editor_crdt::Dot;
         use editor_model::{BlockTree, DocView, ProjectedDoc, RawChild, RawNode, RawTree};
 

--- a/crates/editor-transaction/src/steps/move_nodes_into.rs
+++ b/crates/editor-transaction/src/steps/move_nodes_into.rs
@@ -63,9 +63,10 @@ pub(crate) fn capture_items(
 }
 
 fn collect_source_dots(subtree: &Subtree, out: &mut Vec<Dot>) {
-    out.extend(subtree.source_dots.iter().copied());
-    for child in &subtree.children {
-        collect_source_dots(child, out);
+    let mut stack = vec![subtree];
+    while let Some(subtree) = stack.pop() {
+        out.extend(subtree.source_dots.iter().copied());
+        stack.extend(subtree.children.iter().rev());
     }
 }
 

--- a/crates/editor-transaction/src/steps/support.rs
+++ b/crates/editor-transaction/src/steps/support.rs
@@ -175,15 +175,22 @@ pub(crate) fn validate_ins_slot(
 /// any state — a rejection aborts before the first op, leaving the state
 /// untouched.
 fn validate_subtree_shape(sub: &Subtree, host: NodeType) -> Result<(), StepError> {
-    let t = sub.node.as_type();
-    if !Schema::node_spec(host).content.matches(t) {
-        return Err(StepError::IllegalInsertSlot {
-            block: Dot::ROOT,
-            pos: 0,
-        });
-    }
-    for child in &sub.children {
-        validate_subtree_shape(child, t)?;
+    let mut stack = vec![(sub, host)];
+    while let Some((subtree, parent_type)) = stack.pop() {
+        let node_type = subtree.node.as_type();
+        if !Schema::node_spec(parent_type).content.matches(node_type) {
+            return Err(StepError::IllegalInsertSlot {
+                block: Dot::ROOT,
+                pos: 0,
+            });
+        }
+        stack.extend(
+            subtree
+                .children
+                .iter()
+                .rev()
+                .map(|child| (child, node_type)),
+        );
     }
     Ok(())
 }
@@ -539,115 +546,151 @@ pub(crate) fn node_carry_clear(target: Dot, key: ModifierType) -> EditOp {
 /// Builds a `Subtree` snapshot of the projected block at `block`. Consecutive
 /// char leaves that share the same own paint collapse into one `Text` subtree
 /// carrying that run's own modifiers; a paint change starts a new run. Atom
-/// leaves keep their own modifiers. Nested blocks recurse.
+/// leaves keep their own modifiers.
 pub fn capture_subtree(ps: &ProjectedState, block: Dot) -> Option<Subtree> {
     if let Some(leaf) = ps.view().leaf(block)
         && let Some(atom) = leaf.as_atom()
     {
         return Some(atom_leaf_subtree(ps, block, atom.clone()));
     }
-    let node = ps.block_node(block)?.to_plain();
-    let dot = editor_model::anchor_dot(block);
-    let modifiers: Vec<Modifier> = dot
-        .map(|d| {
-            ps.block_modifiers()
-                .modifiers_of(d)
-                .values()
-                .cloned()
-                .collect()
-        })
-        .unwrap_or_default();
-    let carry: Vec<Modifier> = dot
-        .map(|d| ps.node_carries().modifiers_of(d).into_values().collect())
-        .unwrap_or_default();
+    struct CaptureFrame {
+        block: Dot,
+        node: PlainNode,
+        modifiers: Vec<Modifier>,
+        carry: Vec<Modifier>,
+        children: std::vec::IntoIter<Child>,
+        leaf_own: Vec<Vec<Modifier>>,
+        leaf_index: usize,
+        captured: Vec<Subtree>,
+        pending_text: String,
+        pending_dots: Vec<Dot>,
+        pending_modifiers: Vec<Modifier>,
+    }
 
-    let leaf_own: Vec<Vec<Modifier>> = {
-        let view = ps.view();
-        match view.node(block) {
-            Some(nv) => nv
-                .inline()
-                .iter()
-                .map(|it| it.own_modifiers.values().map(|o| o.value.clone()).collect())
-                .collect(),
-            None => Vec::new(),
+    impl CaptureFrame {
+        fn new(ps: &ProjectedState, block: Dot) -> Option<Self> {
+            let node = ps.block_node(block)?.to_plain();
+            let dot = editor_model::anchor_dot(block);
+            let modifiers = dot
+                .map(|dot| {
+                    ps.block_modifiers()
+                        .modifiers_of(dot)
+                        .values()
+                        .cloned()
+                        .collect()
+                })
+                .unwrap_or_default();
+            let carry = dot
+                .map(|dot| ps.node_carries().modifiers_of(dot).into_values().collect())
+                .unwrap_or_default();
+            let leaf_own = {
+                let view = ps.view();
+                view.node(block)
+                    .map(|node| {
+                        node.inline()
+                            .iter()
+                            .map(|item| {
+                                item.own_modifiers
+                                    .values()
+                                    .map(|modifier| modifier.value.clone())
+                                    .collect()
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default()
+            };
+            Some(Self {
+                block,
+                node,
+                modifiers,
+                carry,
+                children: ps.block_children(block)?.into_iter(),
+                leaf_own,
+                leaf_index: 0,
+                captured: Vec::new(),
+                pending_text: String::new(),
+                pending_dots: Vec::new(),
+                pending_modifiers: Vec::new(),
+            })
         }
-    };
 
-    let mut children: Vec<Subtree> = Vec::new();
-    let mut pending_text = String::new();
-    let mut pending_dots: Vec<Dot> = Vec::new();
-    let mut pending_mods: Vec<Modifier> = Vec::new();
-    let mut leaf_idx = 0usize;
-    for c in ps.block_children(block)? {
-        match c {
-            Child::Leaf { id, item } => {
-                let own = leaf_own.get(leaf_idx).cloned().unwrap_or_default();
-                leaf_idx += 1;
+        fn flush_text(&mut self) {
+            if !self.pending_text.is_empty() {
+                self.captured.push(text_subtree(
+                    std::mem::take(&mut self.pending_text),
+                    std::mem::take(&mut self.pending_dots),
+                    std::mem::take(&mut self.pending_modifiers),
+                ));
+            }
+        }
+
+        fn finish(mut self) -> Subtree {
+            self.flush_text();
+            Subtree {
+                node: self.node,
+                modifiers: self.modifiers,
+                carry: self.carry,
+                children: self.captured,
+                source_dots: if self.block.is_synthetic() {
+                    Vec::new()
+                } else {
+                    vec![self.block]
+                },
+            }
+        }
+    }
+
+    let mut stack = vec![CaptureFrame::new(ps, block)?];
+    loop {
+        let child = stack
+            .last_mut()
+            .expect("root capture frame")
+            .children
+            .next();
+        match child {
+            Some(Child::Leaf { id, item }) => {
+                let frame = stack.last_mut().expect("root capture frame");
+                let own = frame
+                    .leaf_own
+                    .get(frame.leaf_index)
+                    .cloned()
+                    .unwrap_or_default();
+                frame.leaf_index += 1;
                 match item {
                     SeqItem::Char(ch) => {
-                        if !pending_text.is_empty() && own != pending_mods {
-                            children.push(text_subtree(
-                                std::mem::take(&mut pending_text),
-                                std::mem::take(&mut pending_dots),
-                                std::mem::take(&mut pending_mods),
-                            ));
+                        if !frame.pending_text.is_empty() && own != frame.pending_modifiers {
+                            frame.flush_text();
                         }
-                        pending_text.push(ch);
-                        pending_dots.push(id);
-                        pending_mods = own;
+                        frame.pending_text.push(ch);
+                        frame.pending_dots.push(id);
+                        frame.pending_modifiers = own;
                     }
                     SeqItem::Atom(atom) => {
-                        if !pending_text.is_empty() {
-                            children.push(text_subtree(
-                                std::mem::take(&mut pending_text),
-                                std::mem::take(&mut pending_dots),
-                                std::mem::take(&mut pending_mods),
-                            ));
-                        }
-                        children.push(atom_leaf_subtree(ps, id, atom));
+                        frame.flush_text();
+                        frame.captured.push(atom_leaf_subtree(ps, id, atom));
                     }
                     SeqItem::BlockAtom { leaf, .. } => {
-                        if !pending_text.is_empty() {
-                            children.push(text_subtree(
-                                std::mem::take(&mut pending_text),
-                                std::mem::take(&mut pending_dots),
-                                std::mem::take(&mut pending_mods),
-                            ));
-                        }
-                        children.push(atom_leaf_subtree(ps, id, leaf));
+                        frame.flush_text();
+                        frame.captured.push(atom_leaf_subtree(ps, id, leaf));
                     }
                     _ => {}
                 }
             }
-            Child::Block(d) => {
-                if !pending_text.is_empty() {
-                    children.push(text_subtree(
-                        std::mem::take(&mut pending_text),
-                        std::mem::take(&mut pending_dots),
-                        std::mem::take(&mut pending_mods),
-                    ));
+            Some(Child::Block(child)) => {
+                stack.last_mut().expect("root capture frame").flush_text();
+                if let Some(frame) = CaptureFrame::new(ps, child) {
+                    stack.push(frame);
                 }
-                if let Some(sub) = capture_subtree(ps, d) {
-                    children.push(sub);
-                }
+            }
+            None => {
+                let subtree = stack.pop().expect("root capture frame").finish();
+                let Some(parent) = stack.last_mut() else {
+                    return Some(subtree);
+                };
+                parent.captured.push(subtree);
             }
         }
     }
-    if !pending_text.is_empty() {
-        children.push(text_subtree(pending_text, pending_dots, pending_mods));
-    }
-
-    Some(Subtree {
-        node,
-        modifiers,
-        carry,
-        children,
-        source_dots: if block.is_synthetic() {
-            Vec::new()
-        } else {
-            vec![block]
-        },
-    })
 }
 
 fn text_subtree(text: String, dots: Vec<Dot>, modifiers: Vec<Modifier>) -> Subtree {
@@ -682,26 +725,35 @@ fn atom_leaf_subtree(ps: &ProjectedState, dot: Dot, atom: AtomLeaf) -> Subtree {
     }
 }
 
-/// Recursively scans the *projected* subtree rooted at `block` for any of the
+/// Scans the *projected* subtree rooted at `block` for any of the
 /// lossy shapes `remove_child_slots_steps` routes to `Step::DeleteOpaque`: an
 /// unknown-bearing leaf, or a `NodeType::Unknown` placeholder block (its whole
 /// subtree, since the block's children are only structurally attached). Must
 /// run against the live projection, not a captured `Subtree` — capture already
 /// drops unknown content, so by then it's undetectable.
 pub(crate) fn subtree_has_unknown(ps: &ProjectedState, block: Dot) -> bool {
-    if let Some(leaf) = ps.view().leaf(block) {
-        return leaf.item().is_unknown_bearing();
+    let mut stack = vec![block];
+    while let Some(block) = stack.pop() {
+        if let Some(leaf) = ps.view().leaf(block)
+            && leaf.item().is_unknown_bearing()
+        {
+            return true;
+        }
+        if block_node_type(ps, block) == Some(NodeType::Unknown) {
+            return true;
+        }
+        let Some(children) = ps.block_children(block) else {
+            continue;
+        };
+        for child in children {
+            match child {
+                Child::Leaf { item, .. } if item.is_unknown_bearing() => return true,
+                Child::Block(child) => stack.push(child),
+                Child::Leaf { .. } => {}
+            }
+        }
     }
-    if block_node_type(ps, block) == Some(NodeType::Unknown) {
-        return true;
-    }
-    let Some(children) = ps.block_children(block) else {
-        return false;
-    };
-    children.iter().any(|c| match c {
-        Child::Leaf { item, .. } => item.is_unknown_bearing(),
-        Child::Block(d) => subtree_has_unknown(ps, *d),
-    })
+    false
 }
 
 /// Coalesces `(old, new)` dot pairs from an `emit_subtree` walk into maximal
@@ -763,115 +815,126 @@ pub(crate) fn emit_subtree(
     if let Some(host) = host {
         validate_subtree_shape(subtree, host)?;
     }
-    let node_type = subtree.node.as_type();
-    match classify(node_type) {
-        SeqClass::Block => {
-            if node_type == NodeType::Root {
-                return Err(StepError::RootSubtree);
-            }
-            let dot = batched
-                .apply(EditOp::Seq(ListOp::Ins {
-                    pos: *seq_pos,
-                    item: SeqItem::Block {
-                        node_type,
-                        parents: parents.to_vec(),
-                        attrs: subtree.node.to_attrs(),
-                    },
-                }))?
-                .id;
-            *seq_pos += 1;
-            if let Some(&old) = subtree.source_dots.first() {
-                pairs.push((old, dot));
-            }
-            for modifier in &subtree.modifiers {
-                batched.apply(block_modifier_set(dot, modifier.clone()))?;
-            }
-            let mut carry_by_type: BTreeMap<ModifierType, Modifier> = BTreeMap::new();
-            for m in &subtree.carry {
-                if m.as_type().is_carry_kind() {
-                    carry_by_type.insert(m.as_type(), m.clone());
-                }
-            }
-            for (_ty, m) in carry_by_type {
-                batched.apply(node_carry_set(dot, m))?;
-            }
-            let mut child_parents = parents.to_vec();
-            child_parents.push(dot);
-            for child in &subtree.children {
-                emit_subtree(
-                    batched,
-                    child,
-                    &child_parents,
-                    Some(node_type),
-                    seq_pos,
-                    pairs,
-                )?;
-            }
-            Ok(Some(dot))
+    let mut stack = vec![(subtree, parents.to_vec())];
+    let mut root = None;
+    let mut first = true;
+    while let Some((subtree, parents)) = stack.pop() {
+        if subtree.node == PlainNode::Unknown {
+            return Err(StepError::UnknownSubtree);
         }
-        SeqClass::Text => {
-            if let PlainNode::Text(PlainTextNode { text }) = &subtree.node {
-                let mut char_dots = Vec::with_capacity(text.chars().count());
-                for ch in text.chars() {
-                    let d = batched
-                        .apply(EditOp::Seq(ListOp::Ins {
-                            pos: *seq_pos,
-                            item: SeqItem::Char(ch),
-                        }))?
-                        .id;
-                    *seq_pos += 1;
-                    char_dots.push(d);
+        let node_type = subtree.node.as_type();
+        let emitted = match classify(node_type) {
+            SeqClass::Block => {
+                if node_type == NodeType::Root {
+                    return Err(StepError::RootSubtree);
                 }
-                if subtree.source_dots.len() == char_dots.len() {
-                    for (&old, &new) in subtree.source_dots.iter().zip(char_dots.iter()) {
-                        pairs.push((old, new));
+                let dot = batched
+                    .apply(EditOp::Seq(ListOp::Ins {
+                        pos: *seq_pos,
+                        item: SeqItem::Block {
+                            node_type,
+                            parents: parents.clone(),
+                            attrs: subtree.node.to_attrs(),
+                        },
+                    }))?
+                    .id;
+                *seq_pos += 1;
+                if let Some(&old) = subtree.source_dots.first() {
+                    pairs.push((old, dot));
+                }
+                for modifier in &subtree.modifiers {
+                    batched.apply(block_modifier_set(dot, modifier.clone()))?;
+                }
+                let mut carry_by_type: BTreeMap<ModifierType, Modifier> = BTreeMap::new();
+                for modifier in &subtree.carry {
+                    if modifier.as_type().is_carry_kind() {
+                        carry_by_type.insert(modifier.as_type(), modifier.clone());
                     }
                 }
-                if let (Some(&first), Some(&last)) = (char_dots.first(), char_dots.last()) {
-                    for modifier in &subtree.modifiers {
-                        if modifier.as_type().is_text_applicable() {
-                            batched.apply(span_add(first, last, modifier.clone()))?;
+                for modifier in carry_by_type.into_values() {
+                    batched.apply(node_carry_set(dot, modifier))?;
+                }
+                let mut child_parents = parents;
+                child_parents.push(dot);
+                stack.extend(
+                    subtree
+                        .children
+                        .iter()
+                        .rev()
+                        .map(|child| (child, child_parents.clone())),
+                );
+                Some(dot)
+            }
+            SeqClass::Text => {
+                if let PlainNode::Text(PlainTextNode { text }) = &subtree.node {
+                    let mut char_dots = Vec::with_capacity(text.chars().count());
+                    for ch in text.chars() {
+                        let dot = batched
+                            .apply(EditOp::Seq(ListOp::Ins {
+                                pos: *seq_pos,
+                                item: SeqItem::Char(ch),
+                            }))?
+                            .id;
+                        *seq_pos += 1;
+                        char_dots.push(dot);
+                    }
+                    if subtree.source_dots.len() == char_dots.len() {
+                        pairs.extend(
+                            subtree
+                                .source_dots
+                                .iter()
+                                .copied()
+                                .zip(char_dots.iter().copied()),
+                        );
+                    }
+                    if let (Some(&first), Some(&last)) = (char_dots.first(), char_dots.last()) {
+                        for modifier in &subtree.modifiers {
+                            if modifier.as_type().is_text_applicable() {
+                                batched.apply(span_add(first, last, modifier.clone()))?;
+                            }
                         }
                     }
                 }
+                None
             }
-            Ok(None)
-        }
-        SeqClass::Atom => {
-            let leaf = AtomLeaf::from_plain_node(&subtree.node)
-                .ok_or(StepError::NodeNotFound(Dot::ROOT))?;
-            let is_block_level = leaf.is_block_level();
-            let item = if is_block_level {
-                SeqItem::BlockAtom {
-                    leaf,
-                    parents: parents.to_vec(),
+            SeqClass::Atom => {
+                let leaf = AtomLeaf::from_plain_node(&subtree.node)
+                    .ok_or(StepError::NodeNotFound(Dot::ROOT))?;
+                let is_block_level = leaf.is_block_level();
+                let item = if is_block_level {
+                    SeqItem::BlockAtom { leaf, parents }
+                } else {
+                    SeqItem::Atom(leaf)
+                };
+                let dot = batched
+                    .apply(EditOp::Seq(ListOp::Ins {
+                        pos: *seq_pos,
+                        item,
+                    }))?
+                    .id;
+                *seq_pos += 1;
+                if let Some(&old) = subtree.source_dots.first() {
+                    pairs.push((old, dot));
                 }
-            } else {
-                SeqItem::Atom(leaf)
-            };
-            let dot = batched
-                .apply(EditOp::Seq(ListOp::Ins {
-                    pos: *seq_pos,
-                    item,
-                }))?
-                .id;
-            *seq_pos += 1;
-            if let Some(&old) = subtree.source_dots.first() {
-                pairs.push((old, dot));
-            }
-            for modifier in &subtree.modifiers {
-                let ty = modifier.as_type();
-                if is_block_level {
-                    batched.apply(block_modifier_set(dot, modifier.clone()))?;
-                } else if ty.is_text_applicable()
-                    && !matches!(ty, ModifierType::Link | ModifierType::Ruby)
-                {
-                    batched.apply(span_add(dot, dot, modifier.clone()))?;
+                for modifier in &subtree.modifiers {
+                    let modifier_type = modifier.as_type();
+                    if is_block_level {
+                        batched.apply(block_modifier_set(dot, modifier.clone()))?;
+                    } else if modifier_type.is_text_applicable()
+                        && !matches!(modifier_type, ModifierType::Link | ModifierType::Ruby)
+                    {
+                        batched.apply(span_add(dot, dot, modifier.clone()))?;
+                    }
                 }
+                Some(dot)
             }
-            Ok(Some(dot))
+        };
+        if first {
+            root = emitted;
+            first = false;
         }
     }
+    Ok(root)
 }
 
 #[cfg(test)]

--- a/crates/editor-transaction/src/transaction.rs
+++ b/crates/editor-transaction/src/transaction.rs
@@ -2,10 +2,10 @@ use std::collections::BTreeMap;
 
 use editor_crdt::Dot;
 use editor_model::{DocView, Modifier, ModifierType, NodeAttr, NodeType, PlainNode, Subtree};
-use editor_state::Selection;
-use editor_state::undo::RecordedOp;
+use editor_state::undo::{RecordedOp, UndoEntry, apply_inverse};
 use editor_state::{
-    BatchedState, Composition, PendingModifiers, ProjectedState, State, StateError,
+    BatchedState, Composition, PendingModifiers, ProjectedState, Selection, StableResolveCtx,
+    State, StateError,
 };
 use strum::IntoEnumIterator;
 
@@ -31,6 +31,8 @@ pub struct Savepoint {
     step_records_len: usize,
     recorded_len: usize,
     effects_len: usize,
+    meta: TransactionMeta,
+    keep_pending: bool,
 }
 
 /// `Step::DeleteOpaque`'s `emitted` field does not exist at construction (the
@@ -98,7 +100,7 @@ impl Transaction {
     }
 
     pub fn doc_changed(&self) -> bool {
-        self.steps.iter().any(|s| s.is_doc_step())
+        !self.recorded.is_empty() || self.steps.iter().any(|s| s.is_doc_step())
     }
 
     pub fn selection_changed(&self) -> bool {
@@ -185,6 +187,8 @@ impl Transaction {
             step_records_len: self.step_records.len(),
             recorded_len: self.recorded.len(),
             effects_len: self.effects.len(),
+            meta: self.meta.clone(),
+            keep_pending: self.keep_pending,
         }
     }
 
@@ -194,6 +198,38 @@ impl Transaction {
         self.step_records.truncate(sp.step_records_len);
         self.recorded.truncate(sp.recorded_len);
         self.effects.truncate(sp.effects_len);
+        self.meta = sp.meta;
+        self.keep_pending = sp.keep_pending;
+    }
+
+    /// Apply the inverse of an undo entry inside this transaction without
+    /// consuming the history entry itself. This lets a replacement compose
+    /// "remove the previous edit" and its new content into one CRDT commit and
+    /// one undo entry.
+    pub fn apply_undo_entry_inverse(&mut self, entry: &UndoEntry) -> Result<(), StepError> {
+        let savepoint = self.savepoint();
+        let result = (|| {
+            let (recorded, failure) = apply_inverse(self.state.projected_mut(), &entry.ops);
+            if let Some(error) = failure {
+                return Err(error.into());
+            }
+            self.recorded.extend(recorded);
+
+            let selection = entry.transient.selection.as_ref().and_then(|stable| {
+                let view = self.state.view();
+                let ctx = StableResolveCtx::from_live(&view, self.state.projected.seq_checkout());
+                let resolved = stable.resolve(&ctx)?;
+                Some(resolved.normalize(&view).unwrap_or(resolved))
+            });
+            self.set_selection(selection)?;
+            self.set_composition(None)?;
+            self.clear_pending_format()?;
+            Ok(())
+        })();
+        if result.is_err() {
+            self.rollback(savepoint);
+        }
+        result
     }
 
     pub fn insert_text(&mut self, block: Dot, offset: usize, text: &str) -> Result<(), StepError> {
@@ -816,10 +852,15 @@ mod tests {
 
     use super::*;
     use crate::HistoryMeta;
+    use editor_common::{
+        HistoryTag,
+        time::{Duration, Instant},
+    };
     use editor_crdt::ListOp;
     use editor_macros::state;
     use editor_model::{AtomLeaf, Child, EditOp, NodeType, SeqItem, UnknownNode};
-    use editor_state::{Position, ProjectedState, Selection};
+    use editor_state::undo::{RecordMerge, RecordedOp, TransientState, UndoEntry, UndoHistory};
+    use editor_state::{Position, ProjectedState, Selection, assert_state_eq};
 
     fn block_text(state: &State, elem: &Dot) -> String {
         state
@@ -855,6 +896,102 @@ mod tests {
         let (_, steps, _, _, _) = tr.commit();
         assert_eq!(steps.len(), 1);
         assert!(matches!(&steps[0].step, Step::InsertText { .. }));
+    }
+
+    #[test]
+    fn transaction_history_inverse_matches_normal_undo() {
+        let (initial, p) = state! {
+            doc { root { p: paragraph { text("ab") } } }
+            selection: none
+        };
+        let mut forward = Transaction::new(&initial);
+        forward.insert_text(p, 1, "x").unwrap();
+        let (after, _, recorded, _, _) = forward.commit();
+        let entry = UndoEntry {
+            ops: recorded,
+            tag: Some(HistoryTag::PasteHtml {
+                plain_text: "x".into(),
+                start: None,
+            }),
+            transient: TransientState::default(),
+            merge: RecordMerge::Isolated,
+        };
+
+        let mut expected = after.clone();
+        let mut history = UndoHistory::new(Duration::from_secs(0));
+        history.record(entry.clone(), Instant::now());
+        let (normal_ops, _) = history
+            .undo(expected.projected_mut(), TransientState::default())
+            .expect("normal undo applies");
+
+        let mut tr = Transaction::new(&after);
+        tr.apply_undo_entry_inverse(&entry)
+            .expect("transaction inverse applies");
+        assert!(tr.doc_changed());
+        let (actual, _, transaction_recorded, _, _) = tr.commit();
+
+        assert_state_eq!(&actual, &expected);
+        assert_eq!(
+            transaction_recorded
+                .into_iter()
+                .map(|recorded| recorded.op)
+                .collect::<Vec<_>>(),
+            normal_ops
+        );
+    }
+
+    #[test]
+    fn transaction_history_inverse_rolls_back_a_partial_failure() {
+        let (initial, p) = state! {
+            doc { root { p: paragraph { text("ab") } } }
+            selection: none
+        };
+        let mut forward = Transaction::new(&initial);
+        forward.insert_text(p, 1, "x").unwrap();
+        let (mut after, _, recorded, _, _) = forward.commit();
+        let invalid_insert = after
+            .projected_mut()
+            .apply_warm_only(EditOp::Seq(ListOp::Ins {
+                pos: 0,
+                item: SeqItem::Block {
+                    node_type: NodeType::Root,
+                    parents: vec![Dot::ROOT],
+                    attrs: Vec::new(),
+                },
+            }))
+            .unwrap();
+        let invalid_pos = after
+            .projected
+            .seq_visible_pos(invalid_insert.id)
+            .expect("warm insertion is visible in the sequence");
+        let invalid_delete = after
+            .projected_mut()
+            .apply_warm_only(EditOp::Seq(ListOp::Del {
+                pos: invalid_pos,
+                len: 1,
+            }))
+            .unwrap();
+        after.projected_mut().reproject_all().unwrap();
+        after.projected_mut().commit();
+        let invalid_delete = RecordedOp {
+            op: invalid_delete,
+            prior: None,
+        };
+        let entry = UndoEntry {
+            // Inverse order is reversed: the real insertion is removed first,
+            // then undeleting the hidden Root-typed block fails projection.
+            ops: vec![invalid_delete, recorded[0].clone()],
+            tag: None,
+            transient: TransientState::default(),
+            merge: RecordMerge::Isolated,
+        };
+
+        let mut tr = Transaction::new(&after);
+        let before = tr.state().clone();
+        assert!(tr.apply_undo_entry_inverse(&entry).is_err());
+        assert_state_eq!(tr.state(), &before);
+        assert!(tr.ops_for_test().is_empty());
+        assert!(!tr.doc_changed());
     }
 
     #[test]
@@ -1090,6 +1227,23 @@ mod tests {
         let after_two = tr.ops_for_test().len();
         tr.rollback(sp);
         assert!(after_two > tr.ops_for_test().len());
+    }
+
+    #[test]
+    fn savepoint_rollback_restores_meta_and_keep_pending() {
+        let (state, ..) = state! {
+            doc { root { p: paragraph { text("Hi") } } }
+            selection: (p, 0)
+        };
+        let mut tr = Transaction::new(&state);
+        let sp = tr.savepoint();
+        tr.update_meta(|meta| meta.history = HistoryMeta::Skip);
+        tr.keep_pending_modifiers();
+
+        tr.rollback(sp);
+
+        assert!(matches!(tr.meta().history, HistoryMeta::Record));
+        assert!(!tr.keeps_pending_modifiers());
     }
 
     #[test]

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -20,6 +20,7 @@ phf_shared = { version = "0.14", default-features = false, features = ["std"] }
 read-fonts = { version = "0.40", features = ["experimental_font_api"] }
 serde = { version = "1", features = ["alloc", "derive"] }
 serde_core = { version = "1", features = ["alloc"] }
+serde_json = { version = "1", features = ["unbounded_depth"] }
 smallvec = { version = "1", default-features = false, features = ["const_new", "serde"] }
 stable_deref_trait = { version = "1" }
 thiserror = { version = "2" }
@@ -43,6 +44,7 @@ phf_shared = { version = "0.14", default-features = false, features = ["std"] }
 read-fonts = { version = "0.40", features = ["experimental_font_api"] }
 serde = { version = "1", features = ["alloc", "derive"] }
 serde_core = { version = "1", features = ["alloc"] }
+serde_json = { version = "1", features = ["unbounded_depth"] }
 smallvec = { version = "1", default-features = false, features = ["const_new", "serde"] }
 stable_deref_trait = { version = "1" }
 syn = { version = "2", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }


### PR DESCRIPTION
## 배경

#5101에서 하나의 `ListItem`이 여러 Paragraph를 가질 수 있게 되면서, 붙여넣기와 DnD는 단순 삽입이 아니라 원본 selection의 양쪽 boundary, wrapper ownership, Slice openness를 함께 고려해야 하게 됐습니다.

기존 구현은 selection을 먼저 삭제한 뒤 삽입 가능성을 판단하거나, 리스트·PageBreak·테이블 사례를 개별 경로에서 수선했습니다. 이 과정에서 원본 boundary가 사라져 리스트 종류나 surviving content가 잘못 합쳐질 수 있었고, planner와 executor가 서로 다른 구조를 기대하거나 Slice 일부만 삽입할 가능성도 있었습니다.

## 변경 사항

### Replacement-aware Slice fitter

- `fit_slice`를 clipboard와 DnD의 selection-aware 판단 진입점으로 통합했습니다.
  - `Plan`
  - `NoOp`
  - `NoFit`
- linear replacement는 원본 document와 selection에서 양쪽 survivor를 보존한 채 insertion, deletion, split, join, hoist, list merge와 최종 selection을 함께 계획합니다.
- closed block 전용 예외를 제거하고, collapsed insertion과 ranged replacement가 동일한 planner/executor 계약을 사용하도록 정리했습니다.
- fitting 결과를 `Placed`, `CompleteNoOutput`, `NoFit`으로 구분하여, 실제 fitting 실패가 zero-output 성공으로 잘못 해석되지 않도록 했습니다.
  - 구조적으로 빈 Slice는 `NoOp`입니다.
  - 완전히 fitting되지만 authored output이 없는 명시적 zero-length Text 등은 ranged replacement에서 deletion-only plan이 될 수 있습니다.
  - PageBreak나 배치되지 않은 content는 zero-output으로 간주하지 않습니다.
- executor는 구조를 다시 판단하지 않고 계획된 endpoint, output path와 ancestry fingerprint를 검증하며 하나의 rollback 가능한 transaction으로 실행합니다.
- 삽입 결과의 caret과 selection은 executor가 사후 추측하지 않고, planner가 지정한 semantic output node/path를 실제 authored Dot에 binding하여 복원합니다.

### 무손실 구조 처리

- 허용된 Slice의 모든 fragment를 순서대로 배치할 수 있을 때만 적용합니다.
- PageBreak는 일반 schema fitting으로 split/hoist하며, 일부 content만 삽입하지 않습니다.
- selection 밖에 남아 있는 destination PageBreak는 join을 위해 삭제하지 않습니다.
- lossless placement가 불가능하거나 `isolating` 경계를 넘어야 하면 Slice 전체를 `NoFit`으로 처리합니다.
- 인접한 리스트는 앞 리스트에 뒤 리스트의 item을 합치며 앞 리스트 종류를 유지합니다.
- 여러 list container가 연속으로 인접하는 경우에도 계획된 순서대로 병합하고, container나 item identity가 reissue되면 alias를 따라 삽입 범위와 최종 caret을 복원합니다.
- 리스트 병합 뒤의 downstream boundary는 다음 `ListItem` 내부의 첫 cursor position으로 정규화됩니다.
- content-owning synthetic list가 기존 adjacent-list merge participant가 되어야 하는 repaired topology는 이번 범위에서 성공 경로로 확장하지 않습니다.
  - planner가 mutation 전에 전체 operation을 `NoFit`으로 처리합니다.
  - document, selection, pending format과 history는 변경되지 않습니다.

### Projection 및 synthetic scaffold

- projection과 Slice fitting이 동일한 schema placement/repair 결정을 사용하도록 공통화했습니다.
- content를 소유한 synthetic List/ListItem 등의 scaffold는 빈 wrapper로 대체하지 않고 transaction의 content-preserving materialization을 사용합니다.
- authored descendant를 새 real wrapper 아래로 보존·reissue한 뒤 planned endpoint와 selection을 remap합니다.
- endpoint plan은 synthetic Dot 자체를 identity로 저장하지 않고, authored ancestor와 structural path 및 예상 node type을 저장합니다.
- split이나 hoist의 affected suffix에 content-owning synthetic scaffold가 포함된 경우에도 먼저 materialize하여 surviving content의 순서와 ownership을 보존합니다.
- accepted plan을 losslessly 실행할 수 없는 repaired projection topology는 executor corruption까지 진행하지 않고 planning 단계에서 `NoFit`으로 거부합니다.

### Table paste

- 실제 `CellRect`와 셀 내부의 pure Table paste는 별도의 2차원 `TableGridPlan`으로 처리합니다.
- 일반 caret에서의 table grid paste도 기존 셀 기반 UX를 유지하며 필요한 row/column을 확장합니다.
- synthetic row, cell, paragraph로 완성된 empty/ragged Table은 target rectangle의 모든 기존 cell slot을 계획하고 실행 전에 materialize합니다.
- `CellRect`에 일반 Slice를 붙여넣는 경우에는 fitted block을 각 cell에 적용하는 `CellFillPlan`을 사용합니다.
- Table을 포함하지만 pure grid가 아닌 mixed Slice는 일부만 삽입하지 않고 전체를 `NoFit`으로 처리합니다.
- table-grid parser와 fragment fitting은 plan 생성 중 한 번만 수행하며 executor는 Slice를 다시 파싱하거나 fitting하지 않습니다.

### Clipboard metadata, resource admission과 transaction 안전성

- 잘못된 `data-slice-v2` metadata는 HTML body, 이후 plain text 순서로 조용히 fallback합니다.
- empty proprietary Slice metadata는 authoritative `NoOp`으로 사용하지 않고 metadata가 없는 것처럼 HTML/plain-text fallback을 사용합니다.
- advertised `open_start`/`open_end`는 decoded forest의 실제 edge를 반복형으로 검증하며, advertised 값에 비례해 allocation하거나 순회하지 않습니다.
- command-side admission에는 다음 resource budget을 적용합니다.
  - decoded Fragment node budget: `1,000,000`
  - destination structural depth와 Slice maximum depth의 합: `32` 이하
- resource budget을 넘는 Slice는 semantic content를 일부 삽입하지 않고 whole-operation `NoFit`으로 처리합니다.
- JSON metadata, HTML body와 plain-text 직렬화, Fragment/Subtree clone·conversion·drop은 깊은 Slice에서도 stack-safe하게 순회합니다.
- `Transaction::Savepoint`가 document state뿐 아니라 `meta`와 `keep_pending`도 복원하도록 보강했습니다.
- `NoOp`/`NoFit` 및 실행 중 corruption rollback은 document, selection, pending format, carry와 기존 paste history tag를 보존합니다.

## 일관 정책

Slice fitting은 mutation 전에 원본 selection을 기준으로 전체 결과를 결정합니다.

- 허용된 Slice는 모든 fragment와 보존 대상 destination content를 유지합니다.
- 일부 fragment만 배치하거나 surviving content를 버려야 하는 경우 전체 operation을 거부합니다.
- 계획과 실제 endpoint, ancestry, output 구조가 달라지면 corruption으로 처리하고 transaction 전체를 rollback합니다.
- collapsed insertion, ranged replacement, clipboard paste와 external/copy DnD는 같은 fitter 계약을 사용합니다.
- internal move DnD는 source removal 후의 실제 destination state에서 동일한 fitter를 다시 실행합니다.
- 테이블의 2차원 UX가 필요한 경우에만 specialized grid route를 사용합니다.
- projection repair는 안전망이며, accepted plan의 visible result를 사후 결정하는 fitting 수단으로 사용하지 않습니다.
- repaired synthetic topology나 resource budget을 지원 범위 밖으로 정한 경우에는 mutation 전에 `NoFit`으로 종료합니다.
- `NoFit`은 operation의 안전한 거부이며 executor failure나 partial insertion으로 처리하지 않습니다.

## 참고한 선례

정책과 테스트 시나리오는 다음 에디터들의 동작을 대조했습니다.

- ProseMirror의 open Slice, replacement frontier 및 fitting
- CKEditor와 Lexical의 리스트 split/join 및 boundary 처리
- Lexical 계열의 셀 내부 table/grid paste

구조를 그대로 복제하기보다는 Typie의 CRDT identity, projection repair, alias와 transaction rollback 모델에 맞게 planner와 executor의 책임을 분리했습니다.

## 검증

- Rust 영향 범위 테스트: **3,234 passed, 18 ignored**
  - `editor-clipboard`
  - `editor-model`
  - `editor-transaction`
  - `editor-state`
  - `editor-commands`
  - `editor-core`
- iOS, Android, WASM 대상 `editor-clipboard` cross-check
- `cargo fmt --all -- --check`
- `git diff --check`
- ranged PageBreak SPLIT-HOIST와 destination PageBreak 보존
- Fold/TableCell isolation을 넘어야 하는 open PageBreak의 whole-operation `NoFit`
  - collapsed insertion
  - forward ranged replacement
  - reverse ranged replacement
- 서로 다른 리스트 종류 사이의 closed/open Slice replacement
- 여러 인접 리스트의 연속 merge와 최종 caret/selection remap
- content-owning synthetic list scaffold materialization
- adjacent synthetic list participant의 사전 `NoFit`과 state 불변성
- content-owning synthetic suffix를 포함한 split/hoist
- synthetic table row/cell/paragraph grid paste
- ragged table의 non-anchor synthetic cell materialization
- zero-length Text와 non-empty inline fragment가 섞인 Slice
- structure budget 초과 Slice의 whole-operation `NoFit`
- structure budget 경계의 schema-valid nested Slice를 작은 thread stack에서 실제 삽입
- Undo/Redo, warm/cold projection과 reachable-dot 정합성
- malformed metadata의 HTML/plain-text fallback
- `NoOp`/`NoFit`의 pending format 및 paste history 보존