### PR TITLE
웹/앱 노트 저장과 상태 전환 문제 수정

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteActions.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteActions.kt
@@ -165,6 +165,22 @@ internal class NoteActions {
     return owns(request)
   }
 
+  suspend fun flushOnFocusLoss(
+    request: NoteActionRequest,
+    noteId: String,
+    saveContent: suspend (noteId: String, content: String) -> NoteSaveOutcome,
+    saveColor: suspend (noteId: String, color: String) -> NoteSaveOutcome,
+  ) {
+    if (!owns(request)) return
+    val currentEditState = editState ?: return
+    currentEditState.flushOnFocusLoss(
+      siteId = request.siteId,
+      noteId = noteId,
+      saveContent = saveContent,
+      saveColor = saveColor,
+    )
+  }
+
   fun updateContent(
     request: NoteActionRequest,
     noteId: String,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteEditState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteEditState.kt
@@ -4,9 +4,10 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import co.typie.form.FieldState
 import co.typie.form.FormState
 import co.typie.graphql.fragment.NoteCard_note
-import kotlin.coroutines.coroutineContext
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
@@ -41,6 +42,7 @@ internal class NoteEditState(private val scope: CoroutineScope) {
       return
     }
 
+    currentForm?.cancelPendingSaves()
     activeForm =
       ActiveNoteFormState(
         scope = scope,
@@ -51,10 +53,8 @@ internal class NoteEditState(private val scope: CoroutineScope) {
   }
 
   fun clearExpanded(siteId: String, noteId: String? = expandedNoteId) {
-    if (noteId == null || activeFormFor(siteId = siteId, noteId = noteId) == null) {
-      return
-    }
-
+    val currentForm = noteId?.let { activeFormFor(siteId = siteId, noteId = it) } ?: return
+    currentForm.cancelPendingSaves()
     activeForm = null
   }
 
@@ -91,8 +91,17 @@ internal class NoteEditState(private val scope: CoroutineScope) {
     saveColor: suspend (noteId: String, color: String) -> NoteSaveOutcome,
   ): Boolean {
     val currentForm = activeFormFor(siteId = siteId, noteId = noteId) ?: return true
-
     return currentForm.flush(saveContent = saveContent, saveColor = saveColor)
+  }
+
+  suspend fun flushOnFocusLoss(
+    siteId: String,
+    noteId: String,
+    saveContent: suspend (noteId: String, content: String) -> NoteSaveOutcome,
+    saveColor: suspend (noteId: String, color: String) -> NoteSaveOutcome,
+  ) {
+    activeFormFor(siteId = siteId, noteId = noteId)
+      ?.flushOnFocusLoss(saveContent = saveContent, saveColor = saveColor)
   }
 
   suspend fun collapse(
@@ -101,13 +110,10 @@ internal class NoteEditState(private val scope: CoroutineScope) {
     saveColor: suspend (noteId: String, color: String) -> NoteSaveOutcome,
   ): Boolean {
     val currentForm = activeForm ?: return true
-    if (currentForm.siteId != siteId) {
-      return true
-    }
-    if (!currentForm.flush(saveContent = saveContent, saveColor = saveColor)) {
-      return false
-    }
+    if (currentForm.siteId != siteId) return true
+    if (!currentForm.flush(saveContent = saveContent, saveColor = saveColor)) return false
 
+    currentForm.cancelPendingSaves()
     activeForm = null
     return true
   }
@@ -152,18 +158,6 @@ internal class NoteEditState(private val scope: CoroutineScope) {
     activeForm = null
   }
 
-  fun dispose(
-    savePendingContent:
-      suspend (siteId: String, noteId: String, content: String) -> NoteSaveOutcome,
-    savePendingColor: suspend (siteId: String, noteId: String, color: String) -> NoteSaveOutcome,
-  ) {
-    val currentForm = activeForm ?: return
-    currentForm.dispose(
-      savePendingContent = savePendingContent,
-      savePendingColor = savePendingColor,
-    )
-  }
-
   private fun activeFormFor(siteId: String, noteId: String): ActiveNoteFormState? =
     activeForm?.takeIf {
       it.siteId == siteId && it.noteId == noteId
@@ -202,15 +196,17 @@ private class ActiveNoteFormState(
   var isColorSaving by mutableStateOf(false)
     private set
 
+  private val form = NoteEditorForm(scope = scope, note = note)
+  private val contentEdit = FieldEditState()
+  private val colorEdit = FieldEditState()
+  private val contentSaveController =
+    NotesDebouncedSaveController(scope = scope, debounceMillis = CONTENT_SAVE_DEBOUNCE_MILLIS)
+  private val colorSaveController =
+    NotesDebouncedSaveController(scope = scope, debounceMillis = COLOR_SAVE_DEBOUNCE_MILLIS)
+  private val attemptAdmissionMutex = Mutex()
+  private val saveMutex = Mutex()
+
   private var showSaving by mutableStateOf(false)
-  private var contentSaveFailed by mutableStateOf(false)
-  private var colorSaveFailed by mutableStateOf(false)
-  private var contentRevision = 0
-  private var colorRevision = 0
-  private var blockedContentRevision: Int? = null
-  private var blockedColorRevision: Int? = null
-  private var inFlightContentRevision: Int? = null
-  private var inFlightColorRevision: Int? = null
   private var activeSaveCount = 0
   private var savingGeneration = 0L
   private var savingIntervalActive = false
@@ -219,24 +215,19 @@ private class ActiveNoteFormState(
   val saveStatus: NoteSaveStatus
     get() =
       when {
-        contentSaveFailed || colorSaveFailed -> NoteSaveStatus.FAILED
+        hasSaveFailure -> NoteSaveStatus.FAILED
         showSaving -> NoteSaveStatus.SAVING
         else -> NoteSaveStatus.NONE
       }
 
   val isContentDirty: Boolean
-    get() = form.content.isDirty
+    get() = contentEdit.desired != null
 
   val isColorDirty: Boolean
-    get() = form.color.isDirty
+    get() = colorEdit.desired != null
 
-  private val form = NoteEditorForm(scope = scope, note = note)
-
-  private val contentSaveController =
-    NotesDebouncedSaveController(scope = scope, debounceMillis = CONTENT_SAVE_DEBOUNCE_MILLIS)
-  private val colorSaveController =
-    NotesDebouncedSaveController(scope = scope, debounceMillis = COLOR_SAVE_DEBOUNCE_MILLIS)
-  private val saveMutex = Mutex()
+  private val hasSaveFailure: Boolean
+    get() = contentEdit.hasCurrentFailure || colorEdit.hasCurrentFailure
 
   fun overlay(note: NoteCard_note): NoteCard_note =
     if (note.id == noteId && note.site.id == siteId) {
@@ -246,37 +237,11 @@ private class ActiveNoteFormState(
     }
 
   fun commitServerSnapshot(note: NoteCard_note): NoteCard_note {
-    if (note.id != noteId || note.site.id != siteId) {
-      return note
-    }
-
-    val desiredContent = form.content.value
-    val desiredColor = form.color.value
-    val preserveContent = contentSaveController.hasWork()
-    val preserveColor = colorSaveController.hasWork()
+    if (note.id != noteId || note.site.id != siteId) return note
 
     serverSnapshot = note
-    form.syncFromSnapshot(note)
-    if (preserveContent) form.content.setValue(desiredContent)
-    if (preserveColor) form.color.setValue(desiredColor)
-    if (!form.content.isDirty) {
-      blockedContentRevision = null
-      updateContentSaveFailed(false)
-      if (contentSaveController.hasWork() && !contentSaveController.hasExecutingSave()) {
-        contentSaveController.cancel()
-        isContentSaving = false
-        endSavingIntervalIfIdle()
-      }
-    }
-    if (!form.color.isDirty) {
-      blockedColorRevision = null
-      updateColorSaveFailed(false)
-      if (colorSaveController.hasWork() && !colorSaveController.hasExecutingSave()) {
-        colorSaveController.cancel()
-        isColorSaving = false
-        endSavingIntervalIfIdle()
-      }
-    }
+    syncFieldFromSource(field = form.content, edit = contentEdit, sourceValue = note.content)
+    syncFieldFromSource(field = form.color, edit = colorEdit, sourceValue = note.color)
     return overlay(note)
   }
 
@@ -284,75 +249,80 @@ private class ActiveNoteFormState(
     value: String,
     save: suspend (noteId: String, content: String) -> NoteSaveOutcome,
   ) {
-    if (form.content.value != value) {
-      contentRevision += 1
-      blockedContentRevision = null
-    }
+    if (form.content.value == value) return
+
+    val desired = contentEdit.recordEdit(value)
     form.content.setValue(value)
-
-    val mustCompensateForInFlightSave = inFlightContentRevision != null
-    if (!form.content.isDirty && !mustCompensateForInFlightSave) {
-      contentSaveController.cancel()
-      isContentSaving = false
-      endSavingIntervalIfIdle()
-      blockedContentRevision = null
-      updateContentSaveFailed(false)
-      return
-    }
-    if (blockedContentRevision == contentRevision) return
-
-    updateContentSaveFailed(false)
-    contentSaveController.submit { generation ->
-      saveContentNow(save = save, generation = generation, force = mustCompensateForInFlightSave)
-    }
+    contentSaveController.submit { attemptContent(desired = desired, save = save) }
   }
 
   fun updateColor(value: String, save: suspend (noteId: String, color: String) -> NoteSaveOutcome) {
-    if (form.color.value != value) {
-      colorRevision += 1
-      blockedColorRevision = null
-    }
+    if (form.color.value == value) return
+
+    val desired = colorEdit.recordEdit(value)
     form.color.setValue(value)
-
-    val mustCompensateForInFlightSave = inFlightColorRevision != null
-    if (!form.color.isDirty && !mustCompensateForInFlightSave) {
-      colorSaveController.cancel()
-      isColorSaving = false
-      endSavingIntervalIfIdle()
-      blockedColorRevision = null
-      updateColorSaveFailed(false)
-      return
-    }
-    if (blockedColorRevision == colorRevision) return
-
-    updateColorSaveFailed(false)
-    colorSaveController.submit { generation ->
-      saveColorNow(save = save, generation = generation, force = mustCompensateForInFlightSave)
-    }
+    colorSaveController.submit { attemptColor(desired = desired, save = save) }
   }
 
   suspend fun flush(
     saveContent: suspend (noteId: String, content: String) -> NoteSaveOutcome,
     saveColor: suspend (noteId: String, color: String) -> NoteSaveOutcome,
   ): Boolean {
-    val mustCompensateContent = inFlightContentRevision != null
-    val mustCompensateColor = inFlightColorRevision != null
-    if (
-      !colorSaveController.runNow { generation ->
-        saveColorNow(save = saveColor, generation = generation, force = mustCompensateColor)
+    contentSaveController.cancel()
+    colorSaveController.cancel()
+    val attemptedContent = mutableSetOf<Long>()
+    val attemptedColor = mutableSetOf<Long>()
+
+    while (true) {
+      if (!flushColorGenerations(attempted = attemptedColor, save = saveColor)) return false
+      if (!flushContentGenerations(attempted = attemptedContent, save = saveContent)) return false
+      if (contentEdit.desired == null && colorEdit.desired == null) return true
+    }
+  }
+
+  suspend fun flushOnFocusLoss(
+    saveContent: suspend (noteId: String, content: String) -> NoteSaveOutcome,
+    saveColor: suspend (noteId: String, color: String) -> NoteSaveOutcome,
+  ) {
+    val contentTarget = contentEdit.desired
+    val colorTarget = colorEdit.desired
+    val contentAttemptAtEntry =
+      contentEdit.attempt?.takeIf { it.generation == contentTarget?.generation }
+    val colorAttemptAtEntry = colorEdit.attempt?.takeIf { it.generation == colorTarget?.generation }
+
+    colorSaveController.cancel()
+    contentSaveController.cancel()
+    if (colorTarget != null) {
+      if (colorAttemptAtEntry != null) {
+        colorAttemptAtEntry.result.await()
+      } else {
+        attemptColor(desired = colorTarget, save = saveColor)
       }
-    ) {
-      return false
     }
 
-    return contentSaveController.runNow { generation ->
-      saveContentNow(save = saveContent, generation = generation, force = mustCompensateContent)
+    if (contentTarget != null) {
+      if (contentAttemptAtEntry != null) {
+        contentAttemptAtEntry.result.await()
+      } else {
+        attemptContent(desired = contentTarget, save = saveContent)
+      }
     }
   }
 
   fun cancelPendingSaves() {
     contentSaveController.cancel()
     colorSaveController.cancel()
+
+    val contentAttempt = contentEdit.attempt
+    val colorAttempt = colorEdit.attempt
+    contentEdit.attempt = null
+    colorEdit.attempt = null
+    contentAttempt?.job?.cancel()
+    colorAttempt?.job?.cancel()
+
+    contentEdit.failedGeneration = null
+    colorEdit.failedGeneration = null
+
     savingGeneration += 1
     savingIndicatorJob?.cancel()
     savingIndicatorJob = null
@@ -361,184 +331,227 @@ private class ActiveNoteFormState(
     isContentSaving = false
     isColorSaving = false
     showSaving = false
-    updateContentSaveFailed(false)
-    updateColorSaveFailed(false)
   }
 
-  fun dispose(
-    savePendingContent:
-      suspend (siteId: String, noteId: String, content: String) -> NoteSaveOutcome,
-    savePendingColor: suspend (siteId: String, noteId: String, color: String) -> NoteSaveOutcome,
-  ) {
-    val mustCompensateContent = inFlightContentRevision != null
-    val shouldFlushContent =
-      blockedContentRevision != contentRevision &&
-        inFlightContentRevision != contentRevision &&
-        (form.content.isDirty || inFlightContentRevision != null)
-    if (shouldFlushContent) {
-      contentSaveController.launchNow { generation ->
-        saveContentNow(
-          save = { pendingNoteId, content -> savePendingContent(siteId, pendingNoteId, content) },
-          generation = generation,
-          force = mustCompensateContent,
-        )
-      }
-    } else {
-      contentSaveController.cancelScheduled()
-    }
-
-    val mustCompensateColor = inFlightColorRevision != null
-    val shouldFlushColor =
-      blockedColorRevision != colorRevision &&
-        inFlightColorRevision != colorRevision &&
-        (form.color.isDirty || inFlightColorRevision != null)
-    if (shouldFlushColor) {
-      colorSaveController.launchNow { generation ->
-        saveColorNow(
-          save = { pendingNoteId, color -> savePendingColor(siteId, pendingNoteId, color) },
-          generation = generation,
-          force = mustCompensateColor,
-        )
-      }
-    } else {
-      colorSaveController.cancelScheduled()
-    }
-  }
-
-  private suspend fun saveContentNow(
+  private suspend fun flushContentGenerations(
+    attempted: MutableSet<Long>,
     save: suspend (noteId: String, content: String) -> NoteSaveOutcome,
-    generation: Long,
-    force: Boolean,
   ): Boolean {
-    if (!form.content.isDirty && !force) {
-      isContentSaving = false
-      endSavingIntervalIfIdle()
-      return true
+    while (true) {
+      val desired = contentEdit.desired ?: return true
+      if (!attempted.add(desired.generation)) return false
+      attemptContent(desired = desired, save = save)
+      val remaining = contentEdit.desired ?: return true
+      if (remaining.generation == desired.generation) return false
     }
-    if (blockedContentRevision == contentRevision) {
-      isContentSaving = false
-      endSavingIntervalIfIdle()
-      return false
-    }
-
-    val currentContent = form.content.value
-    val revision = contentRevision
-    updateContentSaveFailed(false)
-    isContentSaving = true
-    val savingGeneration = beginSaving()
-    val outcome: NoteSaveOutcome?
-    try {
-      outcome = saveMutex.withLock {
-        if (!contentSaveController.isCurrent(generation)) {
-          return@withLock null
-        }
-        inFlightContentRevision = revision
-        val result = save(noteId, currentContent)
-        val isCurrent = contentSaveController.isCurrent(generation)
-        if (result == NoteSaveOutcome.SubscriptionGated) {
-          contentSaveController.cancel()
-          colorSaveController.cancel()
-          blockDirtyRevisions()
-        } else if (isCurrent && result == NoteSaveOutcome.Superseded) {
-          contentSaveController.cancel()
-          colorSaveController.cancel()
-        }
-        result.takeIf { isCurrent }
-      }
-    } finally {
-      inFlightContentRevision = null
-      val hasQueuedSave = contentSaveController.hasPendingAfter(generation)
-      isContentSaving = hasQueuedSave
-      finishSaving(generation = savingGeneration, keepInterval = hasQueuedSave)
-    }
-    if (outcome == null) {
-      return false
-    }
-
-    when (outcome) {
-      NoteSaveOutcome.Saved -> {
-        blockedContentRevision = null
-        form.content.syncFromSource(currentContent)
-      }
-      NoteSaveOutcome.Failed -> {
-        if (revision == contentRevision) {
-          blockedContentRevision = revision
-          updateContentSaveFailed(true)
-        }
-      }
-      NoteSaveOutcome.SubscriptionGated,
-      NoteSaveOutcome.Superseded -> Unit
-    }
-
-    return outcome == NoteSaveOutcome.Saved || outcome == NoteSaveOutcome.Superseded
   }
 
-  private suspend fun saveColorNow(
+  private suspend fun flushColorGenerations(
+    attempted: MutableSet<Long>,
     save: suspend (noteId: String, color: String) -> NoteSaveOutcome,
-    generation: Long,
-    force: Boolean,
   ): Boolean {
-    if (!form.color.isDirty && !force) {
-      isColorSaving = false
-      endSavingIntervalIfIdle()
-      return true
+    while (true) {
+      val desired = colorEdit.desired ?: return true
+      if (!attempted.add(desired.generation)) return false
+      attemptColor(desired = desired, save = save)
+      val remaining = colorEdit.desired ?: return true
+      if (remaining.generation == desired.generation) return false
     }
-    if (blockedColorRevision == colorRevision) {
-      isColorSaving = false
-      endSavingIntervalIfIdle()
-      return false
-    }
+  }
 
-    val currentColor = form.color.value
-    val revision = colorRevision
-    updateColorSaveFailed(false)
-    isColorSaving = true
-    val savingGeneration = beginSaving()
-    val outcome: NoteSaveOutcome?
-    try {
-      outcome = saveMutex.withLock {
-        if (!colorSaveController.isCurrent(generation)) {
-          return@withLock null
-        }
-        inFlightColorRevision = revision
-        val result = save(noteId, currentColor)
-        val isCurrent = colorSaveController.isCurrent(generation)
-        if (result == NoteSaveOutcome.SubscriptionGated) {
-          contentSaveController.cancel()
-          colorSaveController.cancel()
-          blockDirtyRevisions()
-        } else if (isCurrent && result == NoteSaveOutcome.Superseded) {
-          contentSaveController.cancel()
-          colorSaveController.cancel()
-        }
-        result.takeIf { isCurrent }
+  private suspend fun attemptContent(
+    desired: DesiredValue,
+    save: suspend (noteId: String, content: String) -> NoteSaveOutcome,
+  ) {
+    attemptField(
+      edit = contentEdit,
+      controller = contentSaveController,
+      desired = desired,
+      setSaving = { isContentSaving = it },
+      save = { value -> save(noteId, value) },
+      applyOutcome = { outcome -> applyContentOutcome(outcome = outcome, saved = desired) },
+    )
+  }
+
+  private suspend fun attemptColor(
+    desired: DesiredValue,
+    save: suspend (noteId: String, color: String) -> NoteSaveOutcome,
+  ) {
+    attemptField(
+      edit = colorEdit,
+      controller = colorSaveController,
+      desired = desired,
+      setSaving = { isColorSaving = it },
+      save = { value -> save(noteId, value) },
+      applyOutcome = { outcome -> applyColorOutcome(outcome = outcome, saved = desired) },
+    )
+  }
+
+  private suspend fun attemptField(
+    edit: FieldEditState,
+    controller: NotesDebouncedSaveController,
+    desired: DesiredValue,
+    setSaving: (Boolean) -> Unit,
+    save: suspend (value: String) -> NoteSaveOutcome,
+    applyOutcome: (NoteSaveOutcome) -> Unit,
+  ) {
+    while (true) {
+      var created = false
+      val attempt =
+        attemptAdmissionMutex.withLock {
+          if (edit.desired?.generation != desired.generation) return@withLock null
+
+          edit.attempt
+            ?: FieldSaveAttempt(generation = desired.generation, value = desired.value).also {
+              edit.attempt = it
+              created = true
+              setSaving(true)
+            }
+        } ?: return
+
+      if (created) {
+        startFieldAttempt(
+          edit = edit,
+          controller = controller,
+          attempt = attempt,
+          setSaving = setSaving,
+          save = save,
+          applyOutcome = applyOutcome,
+        )
       }
-    } finally {
-      inFlightColorRevision = null
-      val hasQueuedSave = colorSaveController.hasPendingAfter(generation)
-      isColorSaving = hasQueuedSave
-      finishSaving(generation = savingGeneration, keepInterval = hasQueuedSave)
-    }
-    if (outcome == null) {
-      return false
-    }
 
+      val outcome = attempt.result.await()
+      if (
+        attempt.generation == desired.generation || outcome == NoteSaveOutcome.SubscriptionGated
+      ) {
+        return
+      }
+    }
+  }
+
+  private fun startFieldAttempt(
+    edit: FieldEditState,
+    controller: NotesDebouncedSaveController,
+    attempt: FieldSaveAttempt,
+    setSaving: (Boolean) -> Unit,
+    save: suspend (value: String) -> NoteSaveOutcome,
+    applyOutcome: (NoteSaveOutcome) -> Unit,
+  ) {
+    val job =
+      scope.launch(start = CoroutineStart.LAZY) {
+        try {
+          val outcome = saveMutex.withLock {
+            if (edit.desired?.generation != attempt.generation) return@withLock null
+
+            clearFailureForAttempt(edit = edit, generation = attempt.generation)
+            val intervalGeneration = beginSaving()
+            try {
+              save(attempt.value)
+            } finally {
+              finishSaving(
+                generation = intervalGeneration,
+                keepInterval = hasSaveWork(excluding = attempt),
+              )
+            }
+          }
+
+          if (outcome != null) applyOutcome(outcome)
+          attempt.result.complete(outcome)
+        } catch (error: Throwable) {
+          if (!attempt.result.isCompleted) attempt.result.completeExceptionally(error)
+          throw error
+        } finally {
+          finishFieldAttempt(
+            edit = edit,
+            controller = controller,
+            attempt = attempt,
+            setSaving = setSaving,
+          )
+        }
+      }
+    attempt.job = job
+    job.invokeOnCompletion { error ->
+      if (error != null && !attempt.result.isCompleted) {
+        attempt.result.completeExceptionally(error)
+      }
+      finishFieldAttempt(
+        edit = edit,
+        controller = controller,
+        attempt = attempt,
+        setSaving = setSaving,
+      )
+    }
+    job.start()
+  }
+
+  private fun finishFieldAttempt(
+    edit: FieldEditState,
+    controller: NotesDebouncedSaveController,
+    attempt: FieldSaveAttempt,
+    setSaving: (Boolean) -> Unit,
+  ) {
+    if (edit.attempt === attempt) edit.attempt = null
+    setSaving(edit.attempt != null || controller.hasWork())
+    settleSavingInterval()
+  }
+
+  private fun applyContentOutcome(outcome: NoteSaveOutcome, saved: DesiredValue) {
     when (outcome) {
-      NoteSaveOutcome.Saved -> {
-        blockedColorRevision = null
-        form.color.syncFromSource(currentColor)
-      }
-      NoteSaveOutcome.Failed -> {
-        if (revision == colorRevision) {
-          blockedColorRevision = revision
-          updateColorSaveFailed(true)
-        }
-      }
-      NoteSaveOutcome.SubscriptionGated,
+      NoteSaveOutcome.Saved -> applySaved(field = form.content, edit = contentEdit, saved = saved)
+      NoteSaveOutcome.Failed -> applyFailed(edit = contentEdit, generation = saved.generation)
+      NoteSaveOutcome.SubscriptionGated -> cancelDebouncedSaves()
       NoteSaveOutcome.Superseded -> Unit
     }
+  }
 
-    return outcome == NoteSaveOutcome.Saved || outcome == NoteSaveOutcome.Superseded
+  private fun applyColorOutcome(outcome: NoteSaveOutcome, saved: DesiredValue) {
+    when (outcome) {
+      NoteSaveOutcome.Saved -> applySaved(field = form.color, edit = colorEdit, saved = saved)
+      NoteSaveOutcome.Failed -> applyFailed(edit = colorEdit, generation = saved.generation)
+      NoteSaveOutcome.SubscriptionGated -> cancelDebouncedSaves()
+      NoteSaveOutcome.Superseded -> Unit
+    }
+  }
+
+  private fun applySaved(field: FieldState<String>, edit: FieldEditState, saved: DesiredValue) {
+    if (edit.desired?.generation == saved.generation) {
+      edit.desired = null
+      edit.failedGeneration = null
+      field.syncFromSource(saved.value, preserveDirty = false)
+      return
+    }
+
+    field.syncFromSource(saved.value, preserveDirty = false)
+    edit.desired?.let { field.setValue(it.value) }
+  }
+
+  private fun applyFailed(edit: FieldEditState, generation: Long) {
+    if (edit.desired?.generation != generation) return
+
+    val wasFailed = hasSaveFailure
+    edit.failedGeneration = generation
+    if (!wasFailed && hasSaveFailure) onSaveFailed()
+  }
+
+  private fun clearFailureForAttempt(edit: FieldEditState, generation: Long) {
+    if (edit.failedGeneration == generation) edit.failedGeneration = null
+  }
+
+  private fun cancelDebouncedSaves() {
+    contentSaveController.cancel()
+    colorSaveController.cancel()
+    isContentSaving = contentEdit.attempt != null
+    isColorSaving = colorEdit.attempt != null
+    settleSavingInterval()
+  }
+
+  private fun syncFieldFromSource(
+    field: FieldState<String>,
+    edit: FieldEditState,
+    sourceValue: String,
+  ) {
+    field.syncFromSource(sourceValue, preserveDirty = false)
+    edit.desired?.let { field.setValue(it.value) }
   }
 
   private fun beginSaving(): Long {
@@ -549,9 +562,7 @@ private class ActiveNoteFormState(
     savingIndicatorJob?.cancel()
     savingIndicatorJob = scope.launch {
       delay(SAVING_INDICATOR_DELAY_MILLIS)
-      if (activeSaveCount > 0) {
-        showSaving = true
-      }
+      if (activeSaveCount > 0 || hasSaveWork()) showSaving = true
     }
     return savingGeneration
   }
@@ -561,130 +572,77 @@ private class ActiveNoteFormState(
 
     activeSaveCount = (activeSaveCount - 1).coerceAtLeast(0)
     if (activeSaveCount != 0 || keepInterval) return
-
-    endSavingIntervalIfIdle()
+    endSavingInterval()
   }
 
-  private fun endSavingIntervalIfIdle() {
-    if (activeSaveCount != 0) return
+  private fun settleSavingInterval() {
+    if (activeSaveCount == 0 && !hasSaveWork()) endSavingInterval()
+  }
 
+  private fun endSavingInterval() {
     savingIntervalActive = false
     savingIndicatorJob?.cancel()
     savingIndicatorJob = null
     showSaving = false
   }
 
-  private fun updateContentSaveFailed(value: Boolean) {
-    val wasFailed = contentSaveFailed || colorSaveFailed
-    contentSaveFailed = value
-    if (!wasFailed && (contentSaveFailed || colorSaveFailed)) {
-      onSaveFailed()
-    }
-  }
+  private fun hasSaveWork(excluding: FieldSaveAttempt? = null): Boolean =
+    contentSaveController.hasWork() ||
+      colorSaveController.hasWork() ||
+      (contentEdit.attempt != null && contentEdit.attempt !== excluding) ||
+      (colorEdit.attempt != null && colorEdit.attempt !== excluding)
+}
 
-  private fun updateColorSaveFailed(value: Boolean) {
-    val wasFailed = contentSaveFailed || colorSaveFailed
-    colorSaveFailed = value
-    if (!wasFailed && (contentSaveFailed || colorSaveFailed)) {
-      onSaveFailed()
-    }
-  }
+private data class DesiredValue(val generation: Long, val value: String)
 
-  private fun blockDirtyRevisions() {
-    if (form.content.isDirty) blockedContentRevision = contentRevision
-    if (form.color.isDirty) blockedColorRevision = colorRevision
+private class FieldEditState {
+  var desired: DesiredValue? by mutableStateOf(null)
+  var failedGeneration: Long? by mutableStateOf(null)
+  var attempt: FieldSaveAttempt? = null
+  private var nextGeneration = 0L
+
+  val hasCurrentFailure: Boolean
+    get() = failedGeneration != null && failedGeneration == desired?.generation
+
+  fun recordEdit(value: String): DesiredValue {
+    val next = DesiredValue(generation = ++nextGeneration, value = value)
+    desired = next
+    failedGeneration = null
+    return next
   }
+}
+
+private class FieldSaveAttempt(val generation: Long, val value: String) {
+  val result = CompletableDeferred<NoteSaveOutcome?>()
+  var job: Job? = null
 }
 
 private class NoteEditorForm(scope: CoroutineScope, note: NoteCard_note) : FormState(scope) {
   val content = field(note.content)
   val color = field(note.color) { focusable = false }
-
-  fun syncFromSnapshot(note: NoteCard_note) {
-    content.syncFromSource(note.content)
-    color.syncFromSource(note.color)
-  }
 }
 
 private class NotesDebouncedSaveController(
   private val scope: CoroutineScope,
   private val debounceMillis: Long,
 ) {
-  private var debounceJob: Job? = null
-  private val saveMutex = Mutex()
-  private val executingGenerations = mutableSetOf<Long>()
-  private var generation = 0L
+  private var job: Job? = null
 
-  fun submit(action: suspend (generation: Long) -> Unit) {
-    debounceJob?.cancel()
-    val generation = advanceGeneration()
-
-    var nextDebounceJob: Job? = null
-    nextDebounceJob = scope.launch {
+  fun submit(action: suspend () -> Unit) {
+    job?.cancel()
+    var nextJob: Job? = null
+    nextJob = scope.launch {
       delay(debounceMillis)
-      if (debounceJob === nextDebounceJob) {
-        debounceJob = null
-      }
-      runNow(generation) {
-        action(generation)
-        true
-      }
+      if (job === nextJob) job = null
+      action()
     }
-
-    debounceJob = nextDebounceJob
+    job = nextJob
   }
-
-  suspend fun runNow(action: suspend (generation: Long) -> Boolean): Boolean {
-    val generation = advanceGeneration()
-    val currentJob = debounceJob
-    debounceJob = null
-    if (currentJob != coroutineContext[Job]) {
-      currentJob?.cancel()
-    }
-
-    return runNow(generation) { action(generation) }
-  }
-
-  private suspend fun runNow(generation: Long, action: suspend () -> Boolean): Boolean {
-    executingGenerations.add(generation)
-    return try {
-      saveMutex.withLock {
-        if (this.generation != generation) {
-          false
-        } else {
-          action()
-        }
-      }
-    } finally {
-      executingGenerations.remove(generation)
-    }
-  }
-
-  fun hasPendingAfter(generation: Long): Boolean =
-    debounceJob != null || executingGenerations.any { it != generation && it == this.generation }
-
-  fun hasWork(): Boolean = debounceJob != null || executingGenerations.isNotEmpty()
-
-  fun hasExecutingSave(): Boolean = executingGenerations.isNotEmpty()
-
-  fun isCurrent(generation: Long): Boolean = this.generation == generation
 
   fun cancel() {
-    advanceGeneration()
-    debounceJob?.cancel()
-    debounceJob = null
+    job?.cancel()
+    job = null
   }
 
-  fun cancelScheduled() {
-    debounceJob?.cancel()
-    debounceJob = null
-  }
-
-  fun launchNow(action: suspend (generation: Long) -> Boolean) {
-    val generation = advanceGeneration()
-    cancelScheduled()
-    scope.launch(start = CoroutineStart.UNDISPATCHED) { runNow(generation) { action(generation) } }
-  }
-
-  private fun advanceGeneration(): Long = ++generation
+  fun hasWork(): Boolean = job != null
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteListState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteListState.kt
@@ -22,7 +22,6 @@ internal class NoteListState(private val status: NoteStatus) {
   fun sync(serverNotes: List<NoteCard_note>) {
     val wasSettled = hasSettled
     val previousServerNotesById = serverNotesById
-    val latestServerNotesById = serverNotes.associateBy { it.id }
     val nextServerNotesById = serverNotes.filter { it.status == status }.associateBy { it.id }
     val locallyEnteringIds = enteringNotesById.keys.toSet()
     val expectedEntryIds = expectedEntryNotesById.keys.toSet()
@@ -44,16 +43,19 @@ internal class NoteListState(private val status: NoteStatus) {
       nextServerNotesById.forEach { (noteId, _) ->
         if (noteId in previousServerNotesById) return@forEach
 
-        if (exitingNotesById.remove(noteId) != null) {
+        val exitingSnapshot = exitingNotesById.remove(noteId)
+        if (exitingSnapshot?.isVisible == false) {
           enteringAnimationIds[noteId] = true
-        } else if (noteId !in locallyEnteringIds && noteId !in expectedEntryIds) {
+        } else if (
+          exitingSnapshot == null && noteId !in locallyEnteringIds && noteId !in expectedEntryIds
+        ) {
           enteringAnimationIds[noteId] = true
         }
       }
 
       previousServerNotesById.forEach { (noteId, note) ->
         if (noteId !in nextServerNotesById && noteId !in exitingNotesById) {
-          markExiting(latestServerNotesById[noteId] ?: note)
+          markExiting(note)
         }
       }
     }
@@ -66,6 +68,15 @@ internal class NoteListState(private val status: NoteStatus) {
     }
 
     serverNotesById = nextServerNotesById
+  }
+
+  fun settle(serverNotes: List<NoteCard_note>) {
+    hasSettled = true
+    enteringNotesById.clear()
+    enteringAnimationIds.clear()
+    expectedEntryNotesById.clear()
+    exitingNotesById.clear()
+    serverNotesById = serverNotes.filter { it.status == status }.associateBy { it.id }
   }
 
   fun merge(serverNotes: List<NoteCard_note>): List<NoteCard_note> {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteStatusListStates.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteStatusListStates.kt
@@ -1,0 +1,66 @@
+package co.typie.domain.note
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import co.typie.graphql.fragment.NoteCard_note
+import co.typie.graphql.type.NoteStatus
+
+@Stable
+internal class NoteStatusListStates(initialVisibleStatus: NoteStatus = NoteStatus.OPEN) {
+  var visibleStatus by mutableStateOf(initialVisibleStatus.asListStatus())
+    private set
+
+  private val states =
+    mapOf(
+      NoteStatus.OPEN to NoteListState(NoteStatus.OPEN),
+      NoteStatus.RESOLVED to NoteListState(NoteStatus.RESOLVED),
+    )
+  private var serverNotes: List<NoteCard_note>? = null
+
+  fun state(status: NoteStatus): NoteListState = states.getValue(status.asListStatus())
+
+  fun sync(notes: List<NoteCard_note>) {
+    serverNotes = notes
+    states.forEach { (status, state) ->
+      if (status == visibleStatus) {
+        state.sync(notes)
+      } else {
+        state.settle(notes)
+      }
+    }
+  }
+
+  fun updateVisibleStatus(status: NoteStatus) {
+    val nextStatus = status.asListStatus()
+    if (visibleStatus == nextStatus) return
+
+    visibleStatus = nextStatus
+    serverNotes?.let { notes -> states.values.forEach { it.settle(notes) } }
+  }
+
+  fun convergeDeletedNote(noteId: String, fallbackNote: (status: NoteStatus) -> NoteCard_note?) {
+    val currentNotes = serverNotes
+    val remainingNotes = currentNotes?.filterNot { it.id == noteId }
+    states.forEach { (status, state) ->
+      if (status == visibleStatus) {
+        state.markDeleted(
+          noteId = noteId,
+          fallbackNote =
+            currentNotes?.firstOrNull { it.id == noteId && it.status == status }
+              ?: fallbackNote(status),
+        )
+      } else if (remainingNotes != null) {
+        state.settle(remainingNotes)
+      }
+    }
+    serverNotes = remainingNotes
+  }
+}
+
+private fun NoteStatus.asListStatus(): NoteStatus =
+  when (this) {
+    NoteStatus.RESOLVED -> NoteStatus.RESOLVED
+    else -> NoteStatus.OPEN
+  }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/EditorSubPaneHost.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/EditorSubPaneHost.kt
@@ -58,9 +58,7 @@ internal fun EditorSubPaneHost(
         onDismiss = state::dismiss,
         onLayoutInfoChanged = state::updateLayoutInfo,
         onLayoutInfoCleared = state::clearLayoutInfo,
-        registerRouteRemovalPreparation = { prepare ->
-          state.registerRouteRemovalPreparation(EditorSubPane.RelatedNotes, prepare)
-        },
+        registerRouteRemovalPreparation = state::registerRouteRemovalPreparation,
         modifier = modifier,
       )
     EditorSubPane.Comments ->

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/EditorSubPaneState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/EditorSubPaneState.kt
@@ -53,11 +53,6 @@ internal data class EditorSubPaneLayoutInfo(
 
 @Stable
 internal class EditorSubPaneState {
-  private data class RouteRemovalPreparationRegistration(
-    val pane: EditorSubPane,
-    val prepare: suspend () -> Boolean,
-  )
-
   var active by mutableStateOf<EditorSubPane?>(null)
     private set
 
@@ -68,7 +63,7 @@ internal class EditorSubPaneState {
     private set
 
   private var dismissalInProgress by mutableStateOf(false)
-  private var routeRemovalPreparation: RouteRemovalPreparationRegistration? = null
+  private var routeRemovalPreparation: (suspend () -> Boolean)? = null
 
   val editorInputBlocked: Boolean
     get() = active != null && !dismissalInProgress
@@ -141,23 +136,12 @@ internal class EditorSubPaneState {
     }
   }
 
-  fun registerRouteRemovalPreparation(
-    pane: EditorSubPane,
-    prepare: suspend () -> Boolean,
-  ): () -> Unit {
-    val registration = RouteRemovalPreparationRegistration(pane = pane, prepare = prepare)
-    routeRemovalPreparation = registration
-    return {
-      if (routeRemovalPreparation === registration) {
-        routeRemovalPreparation = null
-      }
-    }
+  fun registerRouteRemovalPreparation(prepare: suspend () -> Boolean) {
+    routeRemovalPreparation = prepare
   }
 
   suspend fun prepareForRouteRemoval(): Boolean {
-    val registration = routeRemovalPreparation ?: return true
-    if (active != registration.pane) return true
-
-    return registration.prepare()
+    val prepare = routeRemovalPreparation ?: return true
+    return prepare()
   }
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/relatednotes/RelatedNotesSheet.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/relatednotes/RelatedNotesSheet.kt
@@ -98,7 +98,7 @@ internal fun RelatedNotesSheet(
   onDismiss: () -> Unit,
   onLayoutInfoChanged: (EditorSubPaneLayoutInfo) -> Unit,
   onLayoutInfoCleared: (EditorSubPane) -> Unit,
-  registerRouteRemovalPreparation: (suspend () -> Boolean) -> (() -> Unit),
+  registerRouteRemovalPreparation: (suspend () -> Boolean) -> Unit,
   modifier: Modifier = Modifier,
 ) {
   val keyboardOcclusion = (trustedImeBottomInset - safeBottomInset).coerceAtLeast(0.dp)
@@ -117,28 +117,19 @@ internal fun RelatedNotesSheet(
     )
   }
 
-  DisposableEffect(noteEditState, model, registerRouteRemovalPreparation) {
-    val unregister = registerRouteRemovalPreparation {
+  SideEffect {
+    registerRouteRemovalPreparation {
       noteEditState.flushPendingEdits(
         savePendingContent = model::savePendingNoteContent,
         savePendingColor = model::savePendingNoteColor,
       )
     }
-    onDispose { unregister() }
   }
 
   DisposableEffect(onLayoutInfoCleared) {
     onDispose { onLayoutInfoCleared(EditorSubPane.RelatedNotes) }
   }
-  DisposableEffect(noteEditState, model) {
-    onDispose {
-      noteActions.dispose()
-      noteEditState.dispose(
-        savePendingContent = model::savePendingNoteContent,
-        savePendingColor = model::savePendingNoteColor,
-      )
-    }
-  }
+  DisposableEffect(noteActions) { onDispose { noteActions.dispose() } }
 
   suspend fun saveNoteContent(noteId: String, content: String): NoteSaveOutcome {
     val request =
@@ -584,7 +575,7 @@ private fun RelatedNotesSheetContent(
           onBlur = { note ->
             noteActions.captureRequest(siteId = note.site.id, entityId = entityId)?.let { request ->
               scope.launch {
-                noteActions.flush(
+                noteActions.flushOnFocusLoss(
                   request = request,
                   noteId = note.id,
                   saveContent = saveNoteContent,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/relatednotes/RelatedNotesViewModel.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/relatednotes/RelatedNotesViewModel.kt
@@ -1,9 +1,6 @@
 package co.typie.screen.editor.editor.subpane.relatednotes
 
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -11,6 +8,7 @@ import co.typie.domain.note.DEFAULT_NOTE_COLOR
 import co.typie.domain.note.NoteEditState
 import co.typie.domain.note.NoteListState
 import co.typie.domain.note.NoteSaveOutcome
+import co.typie.domain.note.NoteStatusListStates
 import co.typie.domain.note.NoteSync
 import co.typie.domain.note.addNoteEntity as addNoteEntityMutation
 import co.typie.domain.note.createNote as createNoteMutation
@@ -40,12 +38,11 @@ internal class RelatedNotesViewModel(private val entityId: String, val siteId: S
   ViewModel() {
   val noteEditState = NoteEditState(scope = viewModelScope)
 
-  var filterStatus by mutableStateOf(NoteStatus.OPEN)
-    private set
+  val filterStatus: NoteStatus
+    get() = statusLists.visibleStatus
 
   private val settledNotesByStatus = mutableStateMapOf<NoteStatus, List<NoteCard_note>>()
-  private val openListState = NoteListState(NoteStatus.OPEN)
-  private val resolvedListState = NoteListState(NoteStatus.RESOLVED)
+  private val statusLists = NoteStatusListStates()
 
   val query =
     Apollo.watchQuery(scope = viewModelScope, resetOnChange = false) {
@@ -60,8 +57,8 @@ internal class RelatedNotesViewModel(private val entityId: String, val siteId: S
             val notes = state.data.notes().filterNot { NoteSync.isTerminallyDeleted(siteId, it.id) }
             listOf(NoteStatus.OPEN, NoteStatus.RESOLVED).forEach { status ->
               settledNotesByStatus[status] = notes.filter { it.status == status }
-              listState(status).sync(notes)
             }
+            statusLists.sync(notes)
 
             val activeNoteId = noteEditState.expandedNoteId ?: return@collect
             notes.firstOrNull { it.id == activeNoteId }?.let(noteEditState::commitServerSnapshot)
@@ -80,18 +77,14 @@ internal class RelatedNotesViewModel(private val entityId: String, val siteId: S
     }
   }
 
-  fun listState(status: NoteStatus): NoteListState =
-    when (status) {
-      NoteStatus.RESOLVED -> resolvedListState
-      else -> openListState
-    }
+  fun listState(status: NoteStatus): NoteListState = statusLists.state(status)
 
   fun updateFilterStatus(status: NoteStatus) {
     if (status == NoteStatus.UNKNOWN__ || filterStatus == status) {
       return
     }
 
-    filterStatus = status
+    statusLists.updateVisibleStatus(status)
   }
 
   fun notes(status: NoteStatus): List<NoteCard_note> {
@@ -175,11 +168,13 @@ internal class RelatedNotesViewModel(private val entityId: String, val siteId: S
       } else {
         null
       }
-    listOf(NoteStatus.OPEN, NoteStatus.RESOLVED).forEach { status ->
-      val note =
-        settledNotesByStatus[status]?.firstOrNull { it.id == noteId }
-          ?: liveNotes?.takeIf { it.status == status }
-      listState(status).markDeleted(noteId = noteId, fallbackNote = note)
+    statusLists.convergeDeletedNote(noteId) { status ->
+      settledNotesByStatus[status]?.firstOrNull { it.id == noteId }
+        ?: liveNotes?.takeIf { it.status == status }
+    }
+    settledNotesByStatus.keys.toList().forEach { status ->
+      settledNotesByStatus[status] =
+        settledNotesByStatus.getValue(status).filterNot { it.id == noteId }
     }
   }
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/notes/NotesScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/notes/NotesScreen.kt
@@ -163,26 +163,14 @@ fun NotesScreen() {
   }
 
   LaunchedEffect(siteId, noteEditState, model) {
-    val activeNoteId = noteEditState.expandedNoteId ?: return@LaunchedEffect
     val activeSiteId = noteEditState.expandedNoteSiteId ?: return@LaunchedEffect
+    val activeNoteId = noteEditState.expandedNoteId ?: return@LaunchedEffect
     if (activeSiteId != siteId) {
-      noteEditState.dispose(
-        savePendingContent = model::savePendingNoteContent,
-        savePendingColor = model::savePendingNoteColor,
-      )
       noteEditState.remove(siteId = activeSiteId, noteId = activeNoteId)
     }
   }
 
-  DisposableEffect(noteEditState, model) {
-    onDispose {
-      noteActions.dispose()
-      noteEditState.dispose(
-        savePendingContent = model::savePendingNoteContent,
-        savePendingColor = model::savePendingNoteColor,
-      )
-    }
-  }
+  DisposableEffect(noteActions) { onDispose { noteActions.dispose() } }
 
   suspend fun saveNoteContent(noteId: String, content: String): NoteSaveOutcome {
     val activeSiteId = siteId ?: return NoteSaveOutcome.Superseded
@@ -552,7 +540,7 @@ fun NotesScreen() {
           onBlur = { note ->
             noteActions.captureRequest(siteId = note.site.id, entityId = null)?.let { request ->
               scope.launch {
-                noteActions.flush(
+                noteActions.flushOnFocusLoss(
                   request = request,
                   noteId = note.id,
                   saveContent = ::saveNoteContent,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/notes/NotesViewModel.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/notes/NotesViewModel.kt
@@ -1,9 +1,6 @@
 package co.typie.screen.space.notes
 
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -11,6 +8,7 @@ import co.typie.domain.note.DEFAULT_NOTE_COLOR
 import co.typie.domain.note.NoteEditState
 import co.typie.domain.note.NoteListState
 import co.typie.domain.note.NoteSaveOutcome
+import co.typie.domain.note.NoteStatusListStates
 import co.typie.domain.note.NoteSync
 import co.typie.domain.note.addNoteEntity as addNoteEntityMutation
 import co.typie.domain.note.createNote as createNoteMutation
@@ -43,8 +41,8 @@ internal class NotesViewModel : ViewModel() {
   val siteId: String?
     get() = Preference.siteId
 
-  var filterStatus by mutableStateOf(NoteStatus.OPEN)
-    private set
+  val filterStatus: NoteStatus
+    get() = sceneCache.visibleStatus
 
   private val sceneCache = NotesSceneCache()
 
@@ -97,7 +95,7 @@ internal class NotesViewModel : ViewModel() {
       return
     }
 
-    filterStatus = status
+    sceneCache.updateVisibleStatus(status)
   }
 
   fun notes(status: NoteStatus): List<NoteCard_note> =
@@ -220,7 +218,7 @@ internal data class NotesSceneKey(val siteId: String, val status: NoteStatus)
 
 internal class NotesSceneCache {
   private val settledNotesByKey = mutableStateMapOf<NotesSceneKey, List<NoteCard_note>>()
-  private val listStatesByKey = mutableMapOf<NotesSceneKey, NoteListState>()
+  private var statusLists = NoteStatusListStates()
   private val fallbackListStates = mutableMapOf<NoteStatus, NoteListState>()
   private var activeSiteId: String? = null
   private var hasActiveSite = false
@@ -231,8 +229,15 @@ internal class NotesSceneCache {
     activeSiteId = siteId
     hasActiveSite = true
     settledNotesByKey.clear()
-    listStatesByKey.clear()
+    statusLists = NoteStatusListStates(initialVisibleStatus = statusLists.visibleStatus)
     fallbackListStates.clear()
+  }
+
+  val visibleStatus: NoteStatus
+    get() = statusLists.visibleStatus
+
+  fun updateVisibleStatus(status: NoteStatus) {
+    statusLists.updateVisibleStatus(status)
   }
 
   fun commitSuccess(siteId: String, notes: List<NoteCard_note>) {
@@ -243,13 +248,13 @@ internal class NotesSceneCache {
     listOf(NoteStatus.OPEN, NoteStatus.RESOLVED).forEach { status ->
       val key = NotesSceneKey(siteId = siteId, status = status)
       settledNotesByKey[key] = currentNotes.filter { it.status == status }
-      listState(key).sync(currentNotes)
     }
+    statusLists.sync(currentNotes)
   }
 
   fun listState(key: NotesSceneKey): NoteListState {
     activateSite(key.siteId)
-    return listStatesByKey.getOrPut(key) { NoteListState(key.status.normalizedListStatus()) }
+    return statusLists.state(key.status)
   }
 
   fun fallbackListState(status: NoteStatus): NoteListState =
@@ -258,15 +263,17 @@ internal class NotesSceneCache {
     }
 
   fun convergeDeletedNote(noteId: String, querySiteId: String?, queryNotes: List<NoteCard_note>?) {
-    listStatesByKey.forEach { (key, state) ->
-      val note =
-        settledNotesByKey[key]?.firstOrNull { it.id == noteId }
-          ?: if (key.siteId == querySiteId) {
-            queryNotes?.firstOrNull { it.id == noteId && it.status == key.status }
-          } else {
-            null
-          }
-      state.markDeleted(noteId = noteId, fallbackNote = note)
+    statusLists.convergeDeletedNote(noteId) { status ->
+      val key = activeSiteId?.let { NotesSceneKey(siteId = it, status = status) }
+      key?.let(settledNotesByKey::get)?.firstOrNull { it.id == noteId }
+        ?: if (activeSiteId == querySiteId) {
+          queryNotes?.firstOrNull { it.id == noteId && it.status == status }
+        } else {
+          null
+        }
+    }
+    settledNotesByKey.keys.toList().forEach { key ->
+      settledNotesByKey[key] = settledNotesByKey.getValue(key).filterNot { it.id == noteId }
     }
     fallbackListStates.values.forEach { it.markDeleted(noteId) }
   }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/domain/note/NoteActionsTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/domain/note/NoteActionsTest.kt
@@ -27,7 +27,7 @@ class NoteActionsTest {
     actions.activate(
       siteId = siteId,
       entityId = null,
-      editState = NoteEditState(scope = this),
+      editState = createNoteEditState(),
       onTerminal = { converged += it },
     )
     NoteSync.publish(NoteUpdate(NoteUpdateKind.DELETED, noteId = note.id, siteId = siteId))
@@ -47,13 +47,13 @@ class NoteActionsTest {
     actions.activate(
       siteId = oldSiteId,
       entityId = null,
-      editState = NoteEditState(scope = this),
+      editState = createNoteEditState(),
       onTerminal = { converged += "old:$it" },
     )
     actions.activate(
       siteId = newSiteId,
       entityId = null,
-      editState = NoteEditState(scope = this),
+      editState = createNoteEditState(),
       onTerminal = { converged += "new:$it" },
     )
 
@@ -81,7 +81,7 @@ class NoteActionsTest {
     actions.activate(
       siteId = siteId,
       entityId = null,
-      editState = NoteEditState(scope = this),
+      editState = createNoteEditState(),
       onTerminal = { converged += it },
     )
 
@@ -118,8 +118,8 @@ class NoteActionsTest {
   @Test
   fun `completion from a replaced surface is ignored`() = runTest {
     val actions = NoteActions()
-    val oldEditState = NoteEditState(scope = this)
-    val newEditState = NoteEditState(scope = this)
+    val oldEditState = createNoteEditState()
+    val newEditState = createNoteEditState()
     val oldNote = notesNote(id = "old-note", siteId = "site")
     val mutationStarted = CompletableDeferred<Unit>()
     val finishMutation = CompletableDeferred<Unit>()
@@ -167,7 +167,7 @@ class NoteActionsTest {
     actions.activate(
       siteId = "old-site",
       entityId = null,
-      editState = NoteEditState(scope = this),
+      editState = createNoteEditState(),
       onTerminal = {},
     )
     val oldRequest = actions.captureRequest()!!
@@ -184,7 +184,7 @@ class NoteActionsTest {
     actions.activate(
       siteId = "new-site",
       entityId = null,
-      editState = NoteEditState(scope = this),
+      editState = createNoteEditState(),
       onTerminal = {},
     )
     val newRequest = actions.captureRequest()!!
@@ -219,7 +219,7 @@ class NoteActionsTest {
     actions.activate(
       siteId = siteId,
       entityId = null,
-      editState = NoteEditState(scope = this),
+      editState = createNoteEditState(),
       onTerminal = { converged += it },
     )
 
@@ -255,7 +255,7 @@ class NoteActionsTest {
     actions.activate(
       siteId = "old-delete-site",
       entityId = null,
-      editState = NoteEditState(scope = this),
+      editState = createNoteEditState(),
       onTerminal = {},
     )
     val oldRequest = actions.captureRequest()!!
@@ -271,7 +271,7 @@ class NoteActionsTest {
     actions.activate(
       siteId = "new-delete-site",
       entityId = null,
-      editState = NoteEditState(scope = this),
+      editState = createNoteEditState(),
       onTerminal = {},
     )
     val newRequest = actions.captureRequest()!!
@@ -306,7 +306,7 @@ class NoteActionsTest {
     actions.activate(
       siteId = siteId,
       entityId = null,
-      editState = NoteEditState(scope = this),
+      editState = createNoteEditState(),
       onTerminal = {},
     )
 
@@ -357,7 +357,7 @@ class NoteActionsTest {
       actions.activate(
         siteId = siteId,
         entityId = null,
-        editState = NoteEditState(scope = this),
+        editState = createNoteEditState(),
         onTerminal = {},
       )
 

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/domain/note/NoteEditStateTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/domain/note/NoteEditStateTest.kt
@@ -7,7 +7,9 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.time.Instant
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -19,7 +21,7 @@ import kotlinx.coroutines.test.runTest
 class NoteEditStateTest {
   @Test
   fun `open tracks expanded note`() = runTest {
-    val state = NoteEditState(scope = this)
+    val state = createNoteEditState()
     val note = notesNote(id = "existing")
 
     state.open(note = note)
@@ -29,7 +31,7 @@ class NoteEditStateTest {
 
   @Test
   fun `debounced content save runs after delay`() = runTest {
-    val state = NoteEditState(scope = this)
+    val state = createNoteEditState()
     val saved = mutableListOf<Pair<String, String>>()
     state.open(note = notesNote(id = "note"))
 
@@ -54,7 +56,7 @@ class NoteEditStateTest {
 
   @Test
   fun `debounced color save runs after delay`() = runTest {
-    val state = NoteEditState(scope = this)
+    val state = createNoteEditState()
     val saved = mutableListOf<Pair<String, String>>()
     state.open(note = notesNote(id = "note", color = "gray"))
 
@@ -79,7 +81,7 @@ class NoteEditStateTest {
 
   @Test
   fun `overlay preserves latest server snapshot fields while applying local drafts`() = runTest {
-    val state = NoteEditState(scope = this)
+    val state = createNoteEditState()
     val linkedEntity = notesDocumentEntity(id = "entity-1")
     state.open(note = notesNote(id = "note", content = "server", color = "gray"))
     state.updateContent(siteId = "site", noteId = "note", value = "draft content") { _, _ ->
@@ -116,7 +118,7 @@ class NoteEditStateTest {
 
   @Test
   fun `unrelated note snapshot does not clear active draft`() = runTest {
-    val state = NoteEditState(scope = this)
+    val state = createNoteEditState()
     state.open(note = notesNote(id = "open", color = "gray"))
     state.updateColor(siteId = "site", noteId = "open", value = "red") { _, _ ->
       NoteSaveOutcome.Saved
@@ -132,7 +134,7 @@ class NoteEditStateTest {
 
   @Test
   fun `the same note id in another site cannot reuse or overwrite the active draft`() = runTest {
-    val state = NoteEditState(scope = this)
+    val state = createNoteEditState()
     state.open(notesNote(id = "shared", siteId = "site-a", content = "site a"))
     state.updateContent(siteId = "site-a", noteId = "shared", value = "site a draft") { _, _ ->
       NoteSaveOutcome.Saved
@@ -154,7 +156,7 @@ class NoteEditStateTest {
 
   @Test
   fun `flush persists both content and color before collapse`() = runTest {
-    val state = NoteEditState(scope = this)
+    val state = createNoteEditState()
     val contentSaves = mutableListOf<Pair<String, String>>()
     val colorSaves = mutableListOf<Pair<String, String>>()
     state.open(note = notesNote(id = "note", content = "server", color = "gray"))
@@ -189,45 +191,8 @@ class NoteEditStateTest {
   }
 
   @Test
-  fun `dispose saves pending drafts and keeps expanded note`() = runTest {
-    val state = NoteEditState(scope = this)
-    val contentSaves = mutableListOf<Pair<String, String>>()
-    val colorSaves = mutableListOf<Pair<String, String>>()
-    state.open(note = notesNote(id = "note", content = "server", color = "gray"))
-    state.updateContent(siteId = "site", noteId = "note", value = "local content") { noteId, content
-      ->
-      contentSaves += noteId to content
-      NoteSaveOutcome.Saved
-    }
-    state.updateColor(siteId = "site", noteId = "note", value = "red") { noteId, color ->
-      colorSaves += noteId to color
-      NoteSaveOutcome.Saved
-    }
-
-    state.dispose(
-      savePendingContent = { _, noteId, content ->
-        contentSaves += noteId to content
-        NoteSaveOutcome.Saved
-      },
-      savePendingColor = { _, noteId, color ->
-        colorSaves += noteId to color
-        NoteSaveOutcome.Saved
-      },
-    )
-    runCurrent()
-
-    assertEquals(listOf("note" to "local content"), contentSaves)
-    assertEquals(listOf("note" to "red"), colorSaves)
-    assertEquals("note", state.expandedNoteId)
-    assertEquals(
-      notesNote(id = "note", content = "local content", color = "red"),
-      state.overlay(notesNote(id = "note", content = "server", color = "gray")),
-    )
-  }
-
-  @Test
   fun `route removal flushes pending drafts with their site identity`() = runTest {
-    val state = NoteEditState(scope = this)
+    val state = createNoteEditState()
     val saved = mutableListOf<Triple<String, String, String>>()
     state.open(note = notesNote(id = "note", siteId = "site", content = "server", color = "gray"))
     state.updateContent(siteId = "site", noteId = "note", value = "local content") { _, _ ->
@@ -258,7 +223,7 @@ class NoteEditStateTest {
 
   @Test
   fun `older content save completion does not clear newer draft before snapshot`() = runTest {
-    val state = NoteEditState(scope = this)
+    val state = createNoteEditState()
     val firstSaveStarted = CompletableDeferred<Unit>()
     val finishFirstSave = CompletableDeferred<Unit>()
     val saved = mutableListOf<String>()
@@ -295,8 +260,39 @@ class NoteEditStateTest {
   }
 
   @Test
+  fun `superseded older save does not cancel a newer field debounce`() = runTest {
+    val state = createNoteEditState()
+    val contentSaveStarted = CompletableDeferred<Unit>()
+    val finishContentSave = CompletableDeferred<Unit>()
+    val savedColors = mutableListOf<String>()
+    state.open(note = notesNote(id = "note", content = "server", color = "gray"))
+
+    state.updateContent(siteId = "site", noteId = "note", value = "draft") { _, _ ->
+      contentSaveStarted.complete(Unit)
+      finishContentSave.await()
+      NoteSaveOutcome.Superseded
+    }
+    advanceTimeBy(300)
+    runCurrent()
+    contentSaveStarted.await()
+
+    state.updateColor(siteId = "site", noteId = "note", value = "red") { _, color ->
+      savedColors += color
+      NoteSaveOutcome.Saved
+    }
+    finishContentSave.complete(Unit)
+    runCurrent()
+    advanceTimeBy(180)
+    runCurrent()
+
+    assertEquals(listOf("red"), savedColors)
+    assertFalse(state.hasPendingColor(siteId = "site", noteId = "note"))
+    assertTrue(state.isDirty(siteId = "site", noteId = "note"))
+  }
+
+  @Test
   fun `same field saves are serialized so the latest draft is written last`() = runTest {
-    val state = NoteEditState(scope = this)
+    val state = createNoteEditState()
     val firstSaveStarted = CompletableDeferred<Unit>()
     val finishFirstSave = CompletableDeferred<Unit>()
     val saved = mutableListOf<String>()
@@ -331,7 +327,7 @@ class NoteEditStateTest {
   @Test
   fun `content and color saves are serialized so full snapshots cannot arrive out of order`() =
     runTest {
-      val state = NoteEditState(scope = this)
+      val state = createNoteEditState()
       val contentStarted = CompletableDeferred<Unit>()
       val finishContent = CompletableDeferred<Unit>()
       val colorStarted = CompletableDeferred<Unit>()
@@ -372,7 +368,7 @@ class NoteEditStateTest {
 
   @Test
   fun `saving status stays hidden until the request has lasted 500ms`() = runTest {
-    val state = NoteEditState(scope = this)
+    val state = createNoteEditState()
     val saveStarted = CompletableDeferred<Unit>()
     val finishSave = CompletableDeferred<Unit>()
     state.open(note = notesNote(id = "note", content = "server"))
@@ -405,7 +401,7 @@ class NoteEditStateTest {
 
   @Test
   fun `saving status uses one interval across serialized content and color requests`() = runTest {
-    val state = NoteEditState(scope = this)
+    val state = createNoteEditState()
     val contentStarted = CompletableDeferred<Unit>()
     val finishContent = CompletableDeferred<Unit>()
     val colorStarted = CompletableDeferred<Unit>()
@@ -447,7 +443,7 @@ class NoteEditStateTest {
   @Test
   fun `saving status stays visible while a newer content save waits for the active request`() =
     runTest {
-      val state = NoteEditState(scope = this)
+      val state = createNoteEditState()
       val firstSaveStarted = CompletableDeferred<Unit>()
       val finishFirstSave = CompletableDeferred<Unit>()
       val secondSaveStarted = CompletableDeferred<Unit>()
@@ -486,42 +482,51 @@ class NoteEditStateTest {
     }
 
   @Test
-  fun `authoritative content matching a queued save ends the retained saving interval`() = runTest {
-    val state = NoteEditState(scope = this)
-    val firstSaveStarted = CompletableDeferred<Unit>()
-    val finishFirstSave = CompletableDeferred<Unit>()
-    state.open(note = notesNote(id = "note", content = "server"))
+  fun `authoritative content matching desired does not clear the local save obligation`() =
+    runTest {
+      val state = createNoteEditState()
+      val firstSaveStarted = CompletableDeferred<Unit>()
+      val finishFirstSave = CompletableDeferred<Unit>()
+      val saved = mutableListOf<String>()
+      state.open(note = notesNote(id = "note", content = "server"))
 
-    state.updateContent(siteId = "site", noteId = "note", value = "draft A") { _, content ->
-      firstSaveStarted.complete(Unit)
-      finishFirstSave.await()
-      state.commitServerSnapshot(notesNote(id = "note", content = content))
-      NoteSaveOutcome.Saved
+      state.updateContent(siteId = "site", noteId = "note", value = "draft A") { _, content ->
+        saved += content
+        firstSaveStarted.complete(Unit)
+        finishFirstSave.await()
+        state.commitServerSnapshot(notesNote(id = "note", content = content))
+        NoteSaveOutcome.Saved
+      }
+      advanceTimeBy(300)
+      runCurrent()
+      firstSaveStarted.await()
+      advanceTimeBy(500)
+      runCurrent()
+
+      state.updateContent(siteId = "site", noteId = "note", value = "draft B") { _, _ ->
+        saved += "draft B"
+        NoteSaveOutcome.Saved
+      }
+      finishFirstSave.complete(Unit)
+      runCurrent()
+      assertEquals(NoteSaveStatus.SAVING, state.saveStatus(siteId = "site", noteId = "note"))
+
+      state.commitServerSnapshot(notesNote(id = "note", content = "draft B"))
+      runCurrent()
+
+      assertTrue(state.isDirty(siteId = "site", noteId = "note"))
+
+      advanceTimeBy(300)
+      runCurrent()
+
+      assertEquals(listOf("draft A", "draft B"), saved)
+      assertFalse(state.isDirty(siteId = "site", noteId = "note"))
+      assertEquals(NoteSaveStatus.NONE, state.saveStatus(siteId = "site", noteId = "note"))
     }
-    advanceTimeBy(300)
-    runCurrent()
-    firstSaveStarted.await()
-    advanceTimeBy(500)
-    runCurrent()
-
-    state.updateContent(siteId = "site", noteId = "note", value = "draft B") { _, _ ->
-      NoteSaveOutcome.Saved
-    }
-    finishFirstSave.complete(Unit)
-    runCurrent()
-    assertEquals(NoteSaveStatus.SAVING, state.saveStatus(siteId = "site", noteId = "note"))
-
-    state.commitServerSnapshot(notesNote(id = "note", content = "draft B"))
-    runCurrent()
-
-    assertFalse(state.isSaving(siteId = "site", noteId = "note"))
-    assertEquals(NoteSaveStatus.NONE, state.saveStatus(siteId = "site", noteId = "note"))
-    assertFalse(state.isDirty(siteId = "site", noteId = "note"))
-  }
 
   @Test
   fun `reverting content while a save is in flight persists the reverted value`() = runTest {
-    val state = NoteEditState(scope = this)
+    val state = createNoteEditState()
     val firstSaveStarted = CompletableDeferred<Unit>()
     val finishFirstSave = CompletableDeferred<Unit>()
     val saved = mutableListOf<String>()
@@ -555,7 +560,7 @@ class NoteEditStateTest {
 
   @Test
   fun `reverting content compensates for an ambiguous in flight failure`() = runTest {
-    val state = NoteEditState(scope = this)
+    val state = createNoteEditState()
     val firstSaveStarted = CompletableDeferred<Unit>()
     val finishFirstSave = CompletableDeferred<Unit>()
     val saved = mutableListOf<String>()
@@ -589,8 +594,49 @@ class NoteEditStateTest {
   }
 
   @Test
+  fun `flush saves a reverted color after the older color save fails`() = runTest {
+    val state = createNoteEditState()
+    val firstSaveStarted = CompletableDeferred<Unit>()
+    val finishFirstSave = CompletableDeferred<Unit>()
+    val saved = mutableListOf<String>()
+    state.open(note = notesNote(id = "note", color = "gray"))
+
+    state.updateColor(siteId = "site", noteId = "note", value = "red") { _, color ->
+      saved += color
+      firstSaveStarted.complete(Unit)
+      finishFirstSave.await()
+      NoteSaveOutcome.Failed
+    }
+    advanceTimeBy(180)
+    runCurrent()
+    firstSaveStarted.await()
+
+    state.updateColor(siteId = "site", noteId = "note", value = "gray") { _, _ ->
+      error("flush must own the reverted save")
+    }
+    finishFirstSave.complete(Unit)
+    runCurrent()
+
+    val flushed =
+      state.flush(
+        siteId = "site",
+        noteId = "note",
+        saveContent = { _, _ -> NoteSaveOutcome.Saved },
+        saveColor = { _, color ->
+          saved += color
+          NoteSaveOutcome.Saved
+        },
+      )
+
+    assertTrue(flushed)
+    assertEquals(listOf("red", "gray"), saved)
+    assertFalse(state.hasPendingColor(siteId = "site", noteId = "note"))
+    assertEquals(NoteSaveStatus.NONE, state.saveStatus(siteId = "site", noteId = "note"))
+  }
+
+  @Test
   fun `failed save keeps the draft and the next edit saves the latest value`() = runTest {
-    val state = NoteEditState(scope = this)
+    val state = createNoteEditState()
     val saved = mutableListOf<String>()
     state.open(note = notesNote(id = "note", content = "server"))
 
@@ -619,8 +665,26 @@ class NoteEditStateTest {
   }
 
   @Test
+  fun `reopening the same live session keeps a failed desired value`() = runTest {
+    val state = createNoteEditState()
+    val serverNote = notesNote(id = "note", content = "server")
+    state.open(note = serverNote)
+    state.updateContent(siteId = "site", noteId = "note", value = "draft") { _, _ ->
+      NoteSaveOutcome.Failed
+    }
+    advanceTimeBy(300)
+    runCurrent()
+
+    state.open(note = serverNote)
+
+    assertEquals("draft", state.overlay(serverNote).content)
+    assertTrue(state.isDirty(siteId = "site", noteId = "note"))
+    assertEquals(NoteSaveStatus.FAILED, state.saveStatus(siteId = "site", noteId = "note"))
+  }
+
+  @Test
   fun `content and color failures emit once per aggregate failure episode`() = runTest {
-    val state = NoteEditState(scope = this)
+    val state = createNoteEditState()
     val failures = mutableListOf<Unit>()
     backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
       state.saveFailures.collect { failures += it }
@@ -678,7 +742,7 @@ class NoteEditStateTest {
 
   @Test
   fun `older failed save does not report failure for a newer queued draft`() = runTest {
-    val state = NoteEditState(scope = this)
+    val state = createNoteEditState()
     val failures = mutableListOf<Unit>()
     backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
       state.saveFailures.collect { failures += it }
@@ -721,7 +785,7 @@ class NoteEditStateTest {
 
   @Test
   fun `subscription gated save keeps the draft without reporting a failure`() = runTest {
-    val state = NoteEditState(scope = this)
+    val state = createNoteEditState()
     val failures = mutableListOf<Unit>()
     backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
       state.saveFailures.collect { failures += it }
@@ -741,13 +805,13 @@ class NoteEditStateTest {
   }
 
   @Test
-  fun `focus loss does not retry an unchanged failed or gated revision`() = runTest {
+  fun `a later flush retries an unchanged failed or gated revision`() = runTest {
     listOf(NoteSaveOutcome.Failed, NoteSaveOutcome.SubscriptionGated).forEach { outcome ->
-      val state = NoteEditState(scope = this)
+      val state = createNoteEditState()
       var saveCount = 0
       val saveContent: suspend (String, String) -> NoteSaveOutcome = { _, _ ->
         saveCount += 1
-        outcome
+        if (saveCount == 1) outcome else NoteSaveOutcome.Saved
       }
       state.open(note = notesNote(id = "note-$outcome", content = "server"))
 
@@ -757,7 +821,14 @@ class NoteEditStateTest {
         value = "draft",
         save = saveContent,
       )
+      advanceTimeBy(300)
       runCurrent()
+      assertEquals(1, saveCount)
+      assertTrue(state.isDirty(siteId = "site", noteId = "note-$outcome"))
+
+      advanceTimeBy(1_000)
+      runCurrent()
+      assertEquals(1, saveCount)
 
       val flushed =
         state.flush(
@@ -767,15 +838,192 @@ class NoteEditStateTest {
           saveColor = { _, _ -> NoteSaveOutcome.Saved },
         )
 
-      assertFalse(flushed)
-      assertEquals(1, saveCount)
-      assertTrue(state.isDirty(siteId = "site", noteId = "note-$outcome"))
+      assertTrue(flushed)
+      assertEquals(2, saveCount)
+      assertFalse(state.isDirty(siteId = "site", noteId = "note-$outcome"))
     }
   }
 
   @Test
+  fun `a later focus loss retries desired fields after a subscription gate`() = runTest {
+    val state = createNoteEditState()
+    var contentSaveCount = 0
+    var colorSaveCount = 0
+    state.open(note = notesNote(id = "note", content = "server", color = "gray"))
+    state.updateContent(siteId = "site", noteId = "note", value = "draft") { _, _ ->
+      contentSaveCount += 1
+      NoteSaveOutcome.Saved
+    }
+    state.updateColor(siteId = "site", noteId = "note", value = "red") { _, _ ->
+      colorSaveCount += 1
+      NoteSaveOutcome.SubscriptionGated
+    }
+    advanceTimeBy(180)
+    runCurrent()
+
+    state.flushOnFocusLoss(
+      siteId = "site",
+      noteId = "note",
+      saveContent = { _, _ ->
+        contentSaveCount += 1
+        NoteSaveOutcome.Saved
+      },
+      saveColor = { _, _ ->
+        colorSaveCount += 1
+        NoteSaveOutcome.Saved
+      },
+    )
+
+    assertEquals(1, contentSaveCount)
+    assertEquals(2, colorSaveCount)
+    assertFalse(state.isDirty(siteId = "site", noteId = "note"))
+    assertFalse(state.hasPendingColor(siteId = "site", noteId = "note"))
+  }
+
+  @Test
+  fun `focus loss does not duplicate a matching in flight save`() = runTest {
+    val state = createNoteEditState()
+    val finishSave = CompletableDeferred<Unit>()
+    var saveCount = 0
+    val saveContent: suspend (String, String) -> NoteSaveOutcome = { _, _ ->
+      saveCount += 1
+      finishSave.await()
+      NoteSaveOutcome.Saved
+    }
+    state.open(note = notesNote(id = "note", content = "server"))
+    state.updateContent(siteId = "site", noteId = "note", value = "draft", save = saveContent)
+    advanceTimeBy(300)
+    runCurrent()
+
+    backgroundScope.launch {
+      state.flushOnFocusLoss(
+        siteId = "site",
+        noteId = "note",
+        saveContent = saveContent,
+        saveColor = { _, _ -> NoteSaveOutcome.Saved },
+      )
+    }
+    runCurrent()
+    assertEquals(1, saveCount)
+
+    finishSave.complete(Unit)
+    runCurrent()
+
+    assertEquals(1, saveCount)
+    assertFalse(state.isDirty(siteId = "site", noteId = "note"))
+  }
+
+  @Test
+  fun `focus loss does not retry content that fails while waiting for color`() = runTest {
+    val state = createNoteEditState()
+    val contentSaveStarted = CompletableDeferred<Unit>()
+    val finishContentSave = CompletableDeferred<Unit>()
+    var contentSaveCount = 0
+    var colorSaveCount = 0
+    val saveColor: suspend (String, String) -> NoteSaveOutcome = { _, _ ->
+      colorSaveCount += 1
+      NoteSaveOutcome.Saved
+    }
+    state.open(note = notesNote(id = "note", content = "server", color = "gray"))
+    state.updateContent(siteId = "site", noteId = "note", value = "draft") { _, _ ->
+      contentSaveCount += 1
+      contentSaveStarted.complete(Unit)
+      finishContentSave.await()
+      NoteSaveOutcome.Failed
+    }
+    advanceTimeBy(300)
+    runCurrent()
+    contentSaveStarted.await()
+
+    state.updateColor(siteId = "site", noteId = "note", value = "red", save = saveColor)
+    val firstBlur = backgroundScope.launch {
+      state.flushOnFocusLoss(
+        siteId = "site",
+        noteId = "note",
+        saveContent = { _, _ ->
+          contentSaveCount += 1
+          NoteSaveOutcome.Saved
+        },
+        saveColor = saveColor,
+      )
+    }
+    runCurrent()
+
+    finishContentSave.complete(Unit)
+    runCurrent()
+
+    assertTrue(firstBlur.isCompleted)
+    assertEquals(1, contentSaveCount)
+    assertEquals(1, colorSaveCount)
+    assertTrue(state.isDirty(siteId = "site", noteId = "note"))
+
+    state.flushOnFocusLoss(
+      siteId = "site",
+      noteId = "note",
+      saveContent = { _, _ ->
+        contentSaveCount += 1
+        NoteSaveOutcome.Saved
+      },
+      saveColor = { _, _ -> NoteSaveOutcome.Saved },
+    )
+
+    assertEquals(2, contentSaveCount)
+    assertFalse(state.isDirty(siteId = "site", noteId = "note"))
+  }
+
+  @Test
+  fun `focus loss cancels pending content debounce before waiting for color`() = runTest {
+    val state = createNoteEditState()
+    val colorSaveStarted = CompletableDeferred<Unit>()
+    val finishColorSave = CompletableDeferred<Unit>()
+    var automaticContentSaveCount = 0
+    var focusLossContentSaveCount = 0
+    var colorSaveCount = 0
+    val saveColor: suspend (String, String) -> NoteSaveOutcome = { _, _ ->
+      colorSaveCount += 1
+      colorSaveStarted.complete(Unit)
+      finishColorSave.await()
+      NoteSaveOutcome.Saved
+    }
+    state.open(note = notesNote(id = "note", content = "server", color = "gray"))
+
+    state.updateColor(siteId = "site", noteId = "note", value = "red", save = saveColor)
+    advanceTimeBy(180)
+    runCurrent()
+    colorSaveStarted.await()
+
+    state.updateContent(siteId = "site", noteId = "note", value = "draft") { _, _ ->
+      automaticContentSaveCount += 1
+      NoteSaveOutcome.Superseded
+    }
+    val blurJob = backgroundScope.launch {
+      state.flushOnFocusLoss(
+        siteId = "site",
+        noteId = "note",
+        saveContent = { _, _ ->
+          focusLossContentSaveCount += 1
+          NoteSaveOutcome.Saved
+        },
+        saveColor = saveColor,
+      )
+    }
+    runCurrent()
+
+    advanceTimeBy(300)
+    runCurrent()
+    finishColorSave.complete(Unit)
+    runCurrent()
+
+    assertTrue(blurJob.isCompleted)
+    assertEquals(0, automaticContentSaveCount)
+    assertEquals(1, focusLossContentSaveCount)
+    assertEquals(1, colorSaveCount)
+    assertFalse(state.isDirty(siteId = "site", noteId = "note"))
+  }
+
+  @Test
   fun `subscription gated save does not automatically run a queued newer draft`() = runTest {
-    val state = NoteEditState(scope = this)
+    val state = createNoteEditState()
     val firstSaveStarted = CompletableDeferred<Unit>()
     val finishFirstSave = CompletableDeferred<Unit>()
     val saved = mutableListOf<String>()
@@ -806,39 +1054,224 @@ class NoteEditStateTest {
   }
 
   @Test
-  fun `subscription gated save discards a queued save for the other field`() = runTest {
-    val state = NoteEditState(scope = this)
-    val contentStarted = CompletableDeferred<Unit>()
-    val finishContent = CompletableDeferred<Unit>()
+  fun `concurrent triggers share content queued behind an active color save`() = runTest {
+    val state = createNoteEditState()
+    val colorSaveStarted = CompletableDeferred<Unit>()
+    val finishColorSave = CompletableDeferred<Unit>()
+    val contentSaveStarted = CompletableDeferred<Unit>()
+    val finishContentSave = CompletableDeferred<Unit>()
+    var contentSaveCount = 0
     var colorSaveCount = 0
-    state.open(note = notesNote(id = "note", content = "server", color = "gray"))
-
-    state.updateContent(siteId = "site", noteId = "note", value = "draft") { _, _ ->
-      contentStarted.complete(Unit)
-      finishContent.await()
-      NoteSaveOutcome.SubscriptionGated
-    }
-    advanceTimeBy(300)
-    runCurrent()
-    contentStarted.await()
-
-    state.updateColor(siteId = "site", noteId = "note", value = "red") { _, _ ->
+    val saveColor: suspend (String, String) -> NoteSaveOutcome = { _, _ ->
       colorSaveCount += 1
+      colorSaveStarted.complete(Unit)
+      finishColorSave.await()
       NoteSaveOutcome.Saved
     }
+    val saveContent: suspend (String, String) -> NoteSaveOutcome = { _, _ ->
+      contentSaveCount += 1
+      contentSaveStarted.complete(Unit)
+      finishContentSave.await()
+      NoteSaveOutcome.Saved
+    }
+    state.open(note = notesNote(id = "note", content = "server", color = "gray"))
+
+    state.updateColor(siteId = "site", noteId = "note", value = "red", save = saveColor)
+    advanceTimeBy(180)
+    runCurrent()
+    colorSaveStarted.await()
+
+    state.updateContent(siteId = "site", noteId = "note", value = "draft", save = saveContent)
+    advanceTimeBy(300)
+    runCurrent()
+    assertEquals(0, contentSaveCount)
+
+    val blurJob = backgroundScope.launch {
+      state.flushOnFocusLoss(
+        siteId = "site",
+        noteId = "note",
+        saveContent = saveContent,
+        saveColor = saveColor,
+      )
+    }
+    var flushResult: Boolean? = null
+    val flushJob = backgroundScope.launch {
+      flushResult =
+        state.flush(
+          siteId = "site",
+          noteId = "note",
+          saveContent = saveContent,
+          saveColor = saveColor,
+        )
+    }
     runCurrent()
 
+    finishColorSave.complete(Unit)
+    runCurrent()
+    contentSaveStarted.await()
+    assertEquals(1, contentSaveCount)
+    assertFalse(flushJob.isCompleted)
+
+    finishContentSave.complete(Unit)
+    runCurrent()
+
+    assertTrue(blurJob.isCompleted)
+    assertTrue(flushJob.isCompleted)
+    assertEquals(true, flushResult)
+    assertEquals(1, contentSaveCount)
+    assertEquals(1, colorSaveCount)
+    assertFalse(state.isDirty(siteId = "site", noteId = "note"))
+  }
+
+  @Test
+  fun `caller cancellation does not strand an owner scoped field attempt`() = runTest {
+    val state = createNoteEditState()
+    val saveStarted = CompletableDeferred<Unit>()
+    val finishSave = CompletableDeferred<Unit>()
+    var saveCount = 0
+    val saveContent: suspend (String, String) -> NoteSaveOutcome = { _, _ ->
+      saveCount += 1
+      saveStarted.complete(Unit)
+      finishSave.await()
+      NoteSaveOutcome.Saved
+    }
+    state.open(note = notesNote(id = "note", content = "server"))
+    state.updateContent(siteId = "site", noteId = "note", value = "draft", save = saveContent)
+
+    val firstFlush = backgroundScope.launch {
+      state.flush(
+        siteId = "site",
+        noteId = "note",
+        saveContent = saveContent,
+        saveColor = { _, _ -> NoteSaveOutcome.Saved },
+      )
+    }
+    runCurrent()
+    saveStarted.await()
+
+    firstFlush.cancel()
+    runCurrent()
+    assertTrue(firstFlush.isCancelled)
+
+    var secondResult: Boolean? = null
+    val secondFlush = backgroundScope.launch {
+      secondResult =
+        state.flush(
+          siteId = "site",
+          noteId = "note",
+          saveContent = saveContent,
+          saveColor = { _, _ -> NoteSaveOutcome.Saved },
+        )
+    }
+    runCurrent()
+    assertFalse(secondFlush.isCompleted)
+    assertEquals(1, saveCount)
+
+    finishSave.complete(Unit)
+    runCurrent()
+
+    assertTrue(secondFlush.isCompleted)
+    assertEquals(true, secondResult)
+    assertEquals(1, saveCount)
+    assertFalse(state.isDirty(siteId = "site", noteId = "note"))
+  }
+
+  @Test
+  fun `owner cancellation completes a waiting field attempt`() = runTest {
+    val ownerJob = Job()
+    val ownerScope = CoroutineScope(coroutineContext + ownerJob)
+    val state = NoteEditState(scope = ownerScope)
+    val saveStarted = CompletableDeferred<Unit>()
+    val finishSave = CompletableDeferred<Unit>()
+    state.open(note = notesNote(id = "note", content = "server"))
+    state.updateContent(siteId = "site", noteId = "note", value = "draft") { _, _ ->
+      error("flush must replace the pending debounce callback")
+    }
+
+    val flushJob = backgroundScope.launch {
+      state.flush(
+        siteId = "site",
+        noteId = "note",
+        saveContent = { _, _ ->
+          saveStarted.complete(Unit)
+          finishSave.await()
+          NoteSaveOutcome.Saved
+        },
+        saveColor = { _, _ -> NoteSaveOutcome.Saved },
+      )
+    }
+    runCurrent()
+    saveStarted.await()
+
+    ownerJob.cancel()
+    runCurrent()
+
+    assertTrue(flushJob.isCompleted)
+    assertTrue(flushJob.isCancelled)
+  }
+
+  @Test
+  fun `flush rechecks color after content wait creates a newer color generation`() = runTest {
+    val state = createNoteEditState()
+    val contentStarted = CompletableDeferred<Unit>()
+    val finishContent = CompletableDeferred<Unit>()
+    val secondColorStarted = CompletableDeferred<Unit>()
+    val finishSecondColor = CompletableDeferred<Unit>()
+    val colorSaves = mutableListOf<String>()
+    state.open(note = notesNote(id = "note", content = "server", color = "gray"))
+    state.updateContent(siteId = "site", noteId = "note", value = "draft") { _, _ ->
+      error("flush must own the content save")
+    }
+    state.updateColor(siteId = "site", noteId = "note", value = "red") { _, _ ->
+      error("flush must own the color save")
+    }
+
+    var flushResult: Boolean? = null
+    val flushJob = backgroundScope.launch {
+      flushResult =
+        state.flush(
+          siteId = "site",
+          noteId = "note",
+          saveContent = { _, _ ->
+            contentStarted.complete(Unit)
+            finishContent.await()
+            NoteSaveOutcome.Saved
+          },
+          saveColor = { _, color ->
+            colorSaves += color
+            if (colorSaves.size == 2) {
+              secondColorStarted.complete(Unit)
+              finishSecondColor.await()
+            }
+            NoteSaveOutcome.Saved
+          },
+        )
+    }
+    runCurrent()
+    contentStarted.await()
+    assertEquals(listOf("red"), colorSaves)
+
+    state.updateColor(siteId = "site", noteId = "note", value = "blue") { _, _ ->
+      error("the same flush must own the newer color")
+    }
     finishContent.complete(Unit)
     runCurrent()
+    secondColorStarted.await()
 
-    assertEquals(0, colorSaveCount)
-    assertTrue(state.hasPendingColor(siteId = "site", noteId = "note"))
-    assertEquals("red", state.overlay(notesNote(id = "note", color = "gray")).color)
+    assertFalse(flushJob.isCompleted)
+    assertEquals(listOf("red", "blue"), colorSaves)
+
+    finishSecondColor.complete(Unit)
+    runCurrent()
+
+    assertTrue(flushJob.isCompleted)
+    assertEquals(true, flushResult)
+    assertFalse(state.hasPendingColor(siteId = "site", noteId = "note"))
   }
 
   @Test
   fun `cancelled active save ignores its late failure`() = runTest {
-    val state = NoteEditState(scope = this)
+    val state = createNoteEditState()
     val saveStarted = CompletableDeferred<Unit>()
     val finishSave = CompletableDeferred<Unit>()
     val failures = mutableListOf<Unit>()
@@ -865,8 +1298,8 @@ class NoteEditStateTest {
   }
 
   @Test
-  fun `cancelled save completion cannot end a newer saving interval`() = runTest {
-    val state = NoteEditState(scope = this)
+  fun `cancelling an active save lets a newer save own its saving interval`() = runTest {
+    val state = createNoteEditState()
     val contentSaveStarted = CompletableDeferred<Unit>()
     val finishContentSave = CompletableDeferred<Unit>()
     val colorSaveStarted = CompletableDeferred<Unit>()
@@ -888,150 +1321,18 @@ class NoteEditStateTest {
       finishColorSave.await()
       NoteSaveOutcome.Saved
     }
-    advanceTimeBy(680)
+    advanceTimeBy(300)
     runCurrent()
 
-    assertEquals(NoteSaveStatus.SAVING, state.saveStatus(siteId = "site", noteId = "note"))
-    assertFalse(colorSaveStarted.isCompleted)
+    assertTrue(colorSaveStarted.isCompleted)
+    assertEquals(NoteSaveStatus.NONE, state.saveStatus(siteId = "site", noteId = "note"))
 
-    finishContentSave.complete(Unit)
+    advanceTimeBy(500)
     runCurrent()
-    colorSaveStarted.await()
-
     assertEquals(NoteSaveStatus.SAVING, state.saveStatus(siteId = "site", noteId = "note"))
 
     finishColorSave.complete(Unit)
     runCurrent()
     assertEquals(NoteSaveStatus.NONE, state.saveStatus(siteId = "site", noteId = "note"))
-  }
-
-  @Test
-  fun `dispose does not retry an unchanged failed draft`() = runTest {
-    val state = NoteEditState(scope = this)
-    var disposeSaveCount = 0
-    state.open(note = notesNote(id = "note", content = "server"))
-    state.updateContent(siteId = "site", noteId = "note", value = "draft") { _, _ ->
-      NoteSaveOutcome.Failed
-    }
-    advanceTimeBy(300)
-    runCurrent()
-
-    repeat(2) {
-      state.dispose(
-        savePendingContent = { _, _, _ ->
-          disposeSaveCount += 1
-          NoteSaveOutcome.Saved
-        },
-        savePendingColor = { _, _, _ -> NoteSaveOutcome.Saved },
-      )
-      runCurrent()
-    }
-
-    assertEquals(0, disposeSaveCount)
-    assertEquals(NoteSaveStatus.FAILED, state.saveStatus(siteId = "site", noteId = "note"))
-  }
-
-  @Test
-  fun `dispose does not duplicate an active save`() = runTest {
-    val state = NoteEditState(scope = this)
-    val saveStarted = CompletableDeferred<Unit>()
-    val finishSave = CompletableDeferred<Unit>()
-    var disposeSaveCount = 0
-    state.open(note = notesNote(id = "note", content = "server"))
-    state.updateContent(siteId = "site", noteId = "note", value = "draft") { _, _ ->
-      saveStarted.complete(Unit)
-      finishSave.await()
-      NoteSaveOutcome.Saved
-    }
-    advanceTimeBy(300)
-    runCurrent()
-    saveStarted.await()
-
-    state.dispose(
-      savePendingContent = { _, _, _ ->
-        disposeSaveCount += 1
-        NoteSaveOutcome.Saved
-      },
-      savePendingColor = { _, _, _ -> NoteSaveOutcome.Saved },
-    )
-    finishSave.complete(Unit)
-    runCurrent()
-
-    assertEquals(0, disposeSaveCount)
-  }
-
-  @Test
-  fun `dispose persists a newer draft behind a superseded active save`() = runTest {
-    val state = NoteEditState(scope = this)
-    val activeSaveStarted = CompletableDeferred<Unit>()
-    val finishActiveSave = CompletableDeferred<Unit>()
-    val activeSaves = mutableListOf<String>()
-    val pendingSaves = mutableListOf<String>()
-    state.open(note = notesNote(id = "note", content = "server"))
-    state.updateContent(siteId = "site", noteId = "note", value = "draft A") { _, content ->
-      activeSaves += content
-      activeSaveStarted.complete(Unit)
-      finishActiveSave.await()
-      NoteSaveOutcome.Superseded
-    }
-    advanceTimeBy(300)
-    runCurrent()
-    activeSaveStarted.await()
-
-    state.updateContent(siteId = "site", noteId = "note", value = "draft B") { _, _ ->
-      error("the disposed surface callback must not save the newer draft")
-    }
-    state.dispose(
-      savePendingContent = { _, _, content ->
-        pendingSaves += content
-        NoteSaveOutcome.Saved
-      },
-      savePendingColor = { _, _, _ -> NoteSaveOutcome.Saved },
-    )
-    finishActiveSave.complete(Unit)
-    runCurrent()
-
-    assertEquals(listOf("draft A"), activeSaves)
-    assertEquals(listOf("draft B"), pendingSaves)
-    assertFalse(state.isDirty(siteId = "site", noteId = "note"))
-  }
-
-  @Test
-  fun `dispose replaces a content save that has not reached the network`() = runTest {
-    val state = NoteEditState(scope = this)
-    val colorSaveStarted = CompletableDeferred<Unit>()
-    val finishColorSave = CompletableDeferred<Unit>()
-    var disposedSurfaceSaveCount = 0
-    val pendingSaves = mutableListOf<String>()
-    state.open(note = notesNote(id = "note", content = "server", color = "gray"))
-    state.updateColor(siteId = "site", noteId = "note", value = "red") { _, _ ->
-      colorSaveStarted.complete(Unit)
-      finishColorSave.await()
-      NoteSaveOutcome.Saved
-    }
-    advanceTimeBy(180)
-    runCurrent()
-    colorSaveStarted.await()
-
-    state.updateContent(siteId = "site", noteId = "note", value = "draft") { _, _ ->
-      disposedSurfaceSaveCount += 1
-      NoteSaveOutcome.Saved
-    }
-    advanceTimeBy(300)
-    runCurrent()
-
-    state.dispose(
-      savePendingContent = { _, _, content ->
-        pendingSaves += content
-        NoteSaveOutcome.Saved
-      },
-      savePendingColor = { _, _, _ -> NoteSaveOutcome.Saved },
-    )
-    finishColorSave.complete(Unit)
-    runCurrent()
-
-    assertEquals(0, disposedSurfaceSaveCount)
-    assertEquals(listOf("draft"), pendingSaves)
-    assertFalse(state.isDirty(siteId = "site", noteId = "note"))
   }
 }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/domain/note/NoteListStateTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/domain/note/NoteListStateTest.kt
@@ -92,7 +92,7 @@ class NoteListStateTest {
   }
 
   @Test
-  fun `remote status change keeps the destination style while exiting the source list`() {
+  fun `remote status change keeps the source snapshot while exiting its list`() {
     val state = NoteListState(NoteStatus.OPEN)
     val openNote = notesNote(id = "a", order = "100", status = NoteStatus.OPEN)
     val resolvedNote = openNote.copy(status = NoteStatus.RESOLVED)
@@ -101,12 +101,26 @@ class NoteListStateTest {
     state.sync(serverNotes = listOf(resolvedNote))
 
     assertTrue(state.isExiting(openNote.id))
-    assertEquals(NoteStatus.RESOLVED, state.merge(serverNotes = emptyList()).single().status)
+    assertEquals(NoteStatus.OPEN, state.merge(serverNotes = emptyList()).single().status)
 
     state.finishExiting(openNote.id)
     state.sync(serverNotes = emptyList())
 
     assertFalse(state.isExiting(openNote.id))
+  }
+
+  @Test
+  fun `authoritative reversal restores a visible source without reentering`() {
+    val state = NoteListState(NoteStatus.OPEN)
+    val openNote = notesNote(id = "a", order = "100", status = NoteStatus.OPEN)
+    state.sync(serverNotes = listOf(openNote))
+    state.sync(serverNotes = listOf(openNote.copy(status = NoteStatus.RESOLVED)))
+
+    state.sync(serverNotes = listOf(openNote))
+
+    assertFalse(state.isExiting(openNote.id))
+    assertFalse(state.isEntering(openNote.id))
+    assertEquals(listOf(openNote), state.merge(serverNotes = listOf(openNote)))
   }
 
   @Test

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/domain/note/NoteTestFixtures.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/domain/note/NoteTestFixtures.kt
@@ -10,6 +10,9 @@ import co.typie.graphql.fragment.NoteCard_note
 import co.typie.graphql.fragment.NoteLinkedEntity_entity
 import co.typie.graphql.type.NoteStatus
 import kotlin.time.Instant
+import kotlinx.coroutines.test.TestScope
+
+internal fun TestScope.createNoteEditState() = NoteEditState(scope = backgroundScope)
 
 internal fun notesNote(
   id: String,

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/subpane/EditorSubPaneStateTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/subpane/EditorSubPaneStateTest.kt
@@ -17,7 +17,7 @@ class EditorSubPaneStateTest {
     val state = EditorSubPaneState()
     state.open(EditorSubPane.RelatedNotes)
     var preparations = 0
-    state.registerRouteRemovalPreparation(EditorSubPane.RelatedNotes) {
+    state.registerRouteRemovalPreparation {
       preparations += 1
       false
     }
@@ -27,23 +27,41 @@ class EditorSubPaneStateTest {
   }
 
   @Test
-  fun `inactive or unregistered sub pane does not participate in route removal`() = runTest {
+  fun `registered preparation remains available after its sub pane is dismissed`() = runTest {
     val state = EditorSubPaneState()
-    state.open(EditorSubPane.RelatedNotes)
     var preparations = 0
-    val unregister =
-      state.registerRouteRemovalPreparation(EditorSubPane.RelatedNotes) {
-        preparations += 1
-        false
-      }
 
-    state.dismiss()
     assertTrue(state.prepareForRouteRemoval())
 
     state.open(EditorSubPane.RelatedNotes)
-    unregister()
+    state.registerRouteRemovalPreparation {
+      preparations += 1
+      false
+    }
+    state.dismiss()
+
+    assertFalse(state.prepareForRouteRemoval())
+    assertEquals(1, preparations)
+  }
+
+  @Test
+  fun `later route removal preparation replaces the previous registration`() = runTest {
+    val state = EditorSubPaneState()
+    var firstPreparations = 0
+    var secondPreparations = 0
+
+    state.registerRouteRemovalPreparation {
+      firstPreparations += 1
+      false
+    }
+    state.registerRouteRemovalPreparation {
+      secondPreparations += 1
+      true
+    }
+
     assertTrue(state.prepareForRouteRemoval())
-    assertEquals(0, preparations)
+    assertEquals(0, firstPreparations)
+    assertEquals(1, secondPreparations)
   }
 
   @Test

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/space/notes/NotesViewModelTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/space/notes/NotesViewModelTest.kt
@@ -223,7 +223,7 @@ class NotesViewModelTest {
   }
 
   @Test
-  fun `one authoritative snapshot drives both sides of a remote status change`() {
+  fun `one authoritative snapshot animates only the visible side of a remote status change`() {
     val cache = NotesSceneCache()
     val siteId = "site-a"
     val openKey = NotesSceneKey(siteId = siteId, status = NoteStatus.OPEN)
@@ -236,9 +236,84 @@ class NotesViewModelTest {
 
     assertEquals(true, cache.listState(openKey).isExiting(openNote.id))
     assertEquals(
-      NoteStatus.RESOLVED,
+      NoteStatus.OPEN,
       cache.listState(openKey).merge(serverNotes = emptyList()).single().status,
     )
-    assertEquals(true, cache.listState(resolvedKey).isEntering(openNote.id))
+    assertFalse(cache.listState(resolvedKey).isEntering(openNote.id))
+    assertEquals(
+      listOf(resolvedNote),
+      cache.listState(resolvedKey).merge(serverNotes = listOf(resolvedNote)),
+    )
+  }
+
+  @Test
+  fun `switching the visible status settles both sides and transfers ownership`() {
+    val cache = NotesSceneCache()
+    val siteId = "site-a"
+    val openKey = NotesSceneKey(siteId = siteId, status = NoteStatus.OPEN)
+    val resolvedKey = NotesSceneKey(siteId = siteId, status = NoteStatus.RESOLVED)
+    val resolvedNote = notesNote(id = "a", siteId = siteId, status = NoteStatus.RESOLVED)
+    val reopenedNote = resolvedNote.copy(status = NoteStatus.OPEN)
+
+    cache.commitSuccess(siteId = siteId, notes = listOf(resolvedNote))
+    cache.updateVisibleStatus(NoteStatus.RESOLVED)
+
+    assertFalse(cache.listState(openKey).isEntering(resolvedNote.id))
+    assertFalse(cache.listState(resolvedKey).isEntering(resolvedNote.id))
+
+    cache.commitSuccess(siteId = siteId, notes = listOf(reopenedNote))
+
+    assertFalse(cache.listState(openKey).isEntering(reopenedNote.id))
+    assertEquals(true, cache.listState(resolvedKey).isExiting(resolvedNote.id))
+
+    cache.updateVisibleStatus(NoteStatus.OPEN)
+
+    assertFalse(cache.listState(openKey).isEntering(reopenedNote.id))
+    assertFalse(cache.listState(resolvedKey).isExiting(resolvedNote.id))
+    assertEquals(
+      listOf(reopenedNote),
+      cache.listState(openKey).merge(serverNotes = listOf(reopenedNote)),
+    )
+  }
+
+  @Test
+  fun `switching status before the first success does not animate initial notes`() {
+    val cache = NotesSceneCache()
+    val siteId = "site-a"
+    val resolvedKey = NotesSceneKey(siteId = siteId, status = NoteStatus.RESOLVED)
+    val resolvedNote = notesNote(id = "a", siteId = siteId, status = NoteStatus.RESOLVED)
+
+    cache.activateSite(siteId)
+    cache.updateVisibleStatus(NoteStatus.RESOLVED)
+    cache.commitSuccess(siteId = siteId, notes = listOf(resolvedNote))
+
+    assertFalse(cache.listState(resolvedKey).isEntering(resolvedNote.id))
+  }
+
+  @Test
+  fun `terminal deletion does not retain an exit in the hidden status`() {
+    val cache = NotesSceneCache()
+    val siteId = "site-a"
+    val resolvedKey = NotesSceneKey(siteId = siteId, status = NoteStatus.RESOLVED)
+    val resolvedNote = notesNote(id = "a", siteId = siteId, status = NoteStatus.RESOLVED)
+
+    cache.commitSuccess(siteId = siteId, notes = listOf(resolvedNote))
+    cache.convergeDeletedNote(
+      noteId = resolvedNote.id,
+      querySiteId = siteId,
+      queryNotes = listOf(resolvedNote),
+    )
+
+    assertFalse(cache.listState(resolvedKey).isExiting(resolvedNote.id))
+    assertEquals(emptyList(), cache.listState(resolvedKey).merge(serverNotes = emptyList()))
+    assertEquals(
+      emptyList(),
+      cache.notes(
+        key = resolvedKey,
+        querySiteId = null,
+        queryState = QueryState.Loading,
+        placeholderNotes = emptyList(),
+      ),
+    )
   }
 }

--- a/apps/website/src/lib/note/NoteList.svelte
+++ b/apps/website/src/lib/note/NoteList.svelte
@@ -48,6 +48,7 @@
     identity: NoteListIdentity;
     authoritativeNotes: readonly T[];
     children: Snippet<[NoteListRenderProps<T>]>;
+    presentationActive?: boolean;
     reorderEnabled?: boolean;
     onMoveSuccess?: (note: T) => void;
     onexitcomplete?: (item: T) => void;
@@ -60,6 +61,7 @@
     identity,
     authoritativeNotes,
     children,
+    presentationActive = true,
     reorderEnabled = true,
     onMoveSuccess,
     onexitcomplete,
@@ -77,6 +79,7 @@
   } | null>(null);
   let activeIdentityKey: string | null = null;
   let ownedListState: NoteListState<T> | null = null;
+  let ownedPresentationActive: boolean | null = null;
   let latestSyncGeneration = 0;
   let visibleSyncGeneration = 0;
   let suppressedFlipGeneration: number | null = null;
@@ -86,6 +89,7 @@
   let preferredMove: { noteId: string } | null = null;
   let reconcileTask: Promise<void> | null = null;
   let lastAuthoritativeMembership: readonly string[] | null = null;
+  let latestAuthoritativeNotes: readonly T[] = [];
 
   $effect.pre(() => {
     const nextIdentityKey = JSON.stringify([identity.siteId, identity.entityId, identity.status]);
@@ -93,13 +97,14 @@
     const suppressFlip = activeIdentityKey !== nextIdentityKey;
     const identityChanged = activeIdentityKey !== null && activeIdentityKey !== nextIdentityKey;
     const stateChanged = ownedListState !== null && ownedListState !== listState;
+    const presentationChanged = ownedPresentationActive !== null && ownedPresentationActive !== presentationActive;
     const membershipChanged =
       !identityChanged &&
       !stateChanged &&
       lastAuthoritativeMembership !== null &&
       (nextAuthoritativeMembership.length !== lastAuthoritativeMembership.length ||
         nextAuthoritativeMembership.some((noteId, index) => noteId !== lastAuthoritativeMembership?.[index]));
-    if (identityChanged || stateChanged || (membershipChanged && (dragging !== null || reconcileTask !== null))) {
+    if (identityChanged || stateChanged || presentationChanged || (membershipChanged && (dragging !== null || reconcileTask !== null))) {
       operationOwner += 1;
       preferredMove = null;
       reconcileTask = null;
@@ -109,20 +114,29 @@
     }
     activeIdentityKey = nextIdentityKey;
     ownedListState = listState;
+    ownedPresentationActive = presentationActive;
+    latestAuthoritativeNotes = authoritativeNotes;
     lastAuthoritativeMembership = nextAuthoritativeMembership;
     visibleSyncGeneration = ++latestSyncGeneration;
-    if (suppressFlip) suppressedFlipGeneration = visibleSyncGeneration;
-    listState.sync(identity, authoritativeNotes);
+    if (suppressFlip || !presentationActive) suppressedFlipGeneration = visibleSyncGeneration;
+    if (presentationActive) listState.sync(identity, authoritativeNotes);
+    else listState.settle(identity, authoritativeNotes);
   });
 
   $effect(() => {
     const activeState = listState;
-    const siteId = identity.siteId;
-    const entityId = identity.entityId;
+    const activeIdentity = { ...identity };
+    const activePresentationActive = presentationActive;
+    const siteId = activeIdentity.siteId;
+    const entityId = activeIdentity.entityId;
     if (entityId) noteSync.retainRelatedEntity({ siteId, entityId });
     const unregisterDelete = noteSync.onTerminalDelete({
       siteId,
       listener: (noteId) => {
+        if (!activePresentationActive) {
+          activeState.settle(activeIdentity, latestAuthoritativeNotes);
+          return;
+        }
         const item = activeState.visibleNotes().find(({ note }) => note.id === noteId);
         if (!item) return;
 
@@ -172,7 +186,7 @@
 
   const beginDrag = (noteId: string): boolean => {
     const item = visibleNotes.find(({ note }) => note.id === noteId);
-    if (item === undefined || dragging !== null || item.deleting || item.presence === 'exiting' || !reorderEnabled) {
+    if (item === undefined || dragging !== null || item.deleting || item.presence === 'exiting' || !presentationActive || !reorderEnabled) {
       return false;
     }
 
@@ -321,7 +335,12 @@
   };
 
   const reorderFor = (item: VisibleNote<T>): NoteListItemReorder => ({
-    enabled: reorderEnabled && item.presence !== 'exiting' && !item.deleting && (dragging === null || dragging.noteId === item.note.id),
+    enabled:
+      presentationActive &&
+      reorderEnabled &&
+      item.presence !== 'exiting' &&
+      !item.deleting &&
+      (dragging === null || dragging.noteId === item.note.id),
     dragging: dragging?.noteId === item.note.id,
     ondragstart: () => beginDrag(item.note.id),
     ondragmove: (position) => updateDrag(item.note.id, position),

--- a/apps/website/src/lib/note/note-actions.svelte.ts
+++ b/apps/website/src/lib/note/note-actions.svelte.ts
@@ -150,10 +150,11 @@ export class NoteActions<T extends ActionNote> {
     return request?.source !== status && this.#statusTransfers.get(noteId)?.target !== status;
   }
 
-  finishStatusTransfer(noteId: string, source: NoteStatus): void {
-    if (this.#statusTransfers.get(noteId)?.source === source) {
-      this.#statusTransfers.delete(noteId);
-    }
+  finishStatusTransfer(noteId: string, source: NoteStatus): boolean {
+    if (this.#statusTransfers.get(noteId)?.source !== source) return false;
+
+    this.#statusTransfers.delete(noteId);
+    return true;
   }
 
   activate({ siteId, entityId, onTerminal }: { siteId: string; entityId?: string; onTerminal?: (noteId: string) => void }): () => void {

--- a/apps/website/src/lib/note/note-actions.test.ts
+++ b/apps/website/src/lib/note/note-actions.test.ts
@@ -612,10 +612,10 @@ describe('NoteActions status transfer admission', () => {
     syncStatus(actions, [note()]);
     syncStatus(actions, [note({ status: 'RESOLVED' })]);
 
-    actions.finishStatusTransfer('note-1', 'RESOLVED');
+    expect(actions.finishStatusTransfer('note-1', 'RESOLVED')).toBe(false);
     expect(actions.isStatusAdmitted('note-1', 'RESOLVED')).toBe(false);
 
-    actions.finishStatusTransfer('note-1', 'OPEN');
+    expect(actions.finishStatusTransfer('note-1', 'OPEN')).toBe(true);
     expect(actions.isStatusAdmitted('note-1', 'RESOLVED')).toBe(true);
   });
 

--- a/apps/website/src/lib/note/note-edit-state.svelte.ts
+++ b/apps/website/src/lib/note/note-edit-state.svelte.ts
@@ -329,6 +329,7 @@ export class NoteEditState {
     for (const field of ['content', 'color'] as const) {
       const fieldState = this.#fieldState(field);
       if (!fieldState.dirty) continue;
+      if (fieldState.blockedRevision === fieldState.revision) fieldState.blockedRevision = null;
       this.#clearDebounce(fieldState);
       const pending = { revision: fieldState.revision, value: this.#draft(field), onSaved: fieldState.onSaved };
       if (this.#activeSave) this.#queueSave(field, pending);

--- a/apps/website/src/lib/note/note-edit-state.test.ts
+++ b/apps/website/src/lib/note/note-edit-state.test.ts
@@ -658,24 +658,48 @@ describe('NoteEditState delayed save display and failures', () => {
   });
 
   it.each([{ kind: 'failed' as const }, { kind: 'subscription_gated' as const }])(
-    'does not retry an unchanged $kind revision when focus loss flushes the draft',
+    'retries an unchanged $kind revision on a later flush without automatic replay',
     async (outcome) => {
-      const save = vi.fn().mockResolvedValue(outcome);
+      const save = vi
+        .fn()
+        .mockResolvedValueOnce(outcome)
+        .mockResolvedValue(saved(snapshot({ content: 'content draft' })));
       const { state } = createState(save);
       state.setContent('content draft');
       await vi.advanceTimersByTimeAsync(300);
       await settle();
 
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(save).toHaveBeenCalledOnce();
+
       state.flush();
       await settle();
 
-      expect(save).toHaveBeenCalledOnce();
-
-      state.setContent('edited after failure');
-      await vi.advanceTimersByTimeAsync(300);
       expect(save).toHaveBeenCalledTimes(2);
+      expect(state.content).toBe('content draft');
+      expect(state.saveDisplay).toBe('none');
     },
   );
+
+  it('retries dirty content after an unrelated color save is gated', async () => {
+    const save = vi
+      .fn<(request: NoteFieldSave) => Promise<NoteSaveOutcome>>()
+      .mockResolvedValueOnce({ kind: 'subscription_gated' })
+      .mockResolvedValue(saved(snapshot({ content: 'content draft', color: 'blue' })));
+    const { state } = createState(save);
+    state.setContent('content draft');
+    state.setColor('blue');
+    await vi.advanceTimersByTimeAsync(180);
+    await settle();
+
+    state.flush();
+    await settle();
+
+    expect(save).toHaveBeenCalledTimes(3);
+    expect(save).toHaveBeenNthCalledWith(1, { field: 'color', value: 'blue' });
+    expect(save).toHaveBeenNthCalledWith(2, { field: 'content', value: 'content draft' });
+    expect(save).toHaveBeenNthCalledWith(3, { field: 'color', value: 'blue' });
+  });
 
   it.each([{ kind: 'failed' as const }, { kind: 'subscription_gated' as const }])(
     'treats a matching authoritative snapshot as confirmation after $kind',

--- a/apps/website/src/lib/note/note-list-state.svelte.ts
+++ b/apps/website/src/lib/note/note-list-state.svelte.ts
@@ -198,6 +198,10 @@ export class NoteListState<T extends ListNote> {
     this.#rebuildVisible();
   }
 
+  settle(identity: NoteListIdentity, authoritativeNotes: readonly T[]): void {
+    this.#reset(identity, authoritativeNotes);
+  }
+
   authoritativeNote(noteId: string): T | undefined {
     return this.#authoritativeNotesById.get(noteId);
   }

--- a/apps/website/src/routes/website/(dashboard)/@notes/Notes.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@notes/Notes.svelte
@@ -353,8 +353,8 @@
   };
 
   const handleStatusExitComplete = (noteId: string, sourceStatus: 'OPEN' | 'RESOLVED') => {
+    if (!noteActions.finishStatusTransfer(noteId, sourceStatus)) return;
     if (expandedNoteId === noteId) expandedNoteId = null;
-    noteActions.finishStatusTransfer(noteId, sourceStatus);
   };
 
   const handleAddEntity = (noteId: string) => {
@@ -566,6 +566,7 @@
             identity={{ siteId: currentSiteId, status: 'OPEN' }}
             onMoveSuccess={() => mixpanel.track('move_note')}
             onexitcomplete={(note) => handleStatusExitComplete(note.id, 'OPEN')}
+            presentationActive={app.state.notesOpen}
             state={openListState}
           >
             {#snippet children({ item, reorder })}
@@ -643,6 +644,7 @@
                 identity={{ siteId: currentSiteId, status: 'RESOLVED' }}
                 onMoveSuccess={() => mixpanel.track('move_note')}
                 onexitcomplete={(note) => handleStatusExitComplete(note.id, 'RESOLVED')}
+                presentationActive={app.state.notesOpen && resolvedOpen}
                 state={resolvedListState}
               >
                 {#snippet children({ item, reorder })}

--- a/apps/website/src/routes/website/(dashboard)/@notes/notes-error.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/@notes/notes-error.test.ts
@@ -4,18 +4,28 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { NoteListState } from '$lib/note/note-list-state.svelte';
 import Notes from './Notes.svelte';
 
-const { app, createNote, createQuery, noteSync, toastError } = vi.hoisted(() => ({
+const { app, createNote, createQuery, noteEdits, noteSync, terminalNoteIds, terminalListeners, toastError } = vi.hoisted(() => ({
   app: {
     preference: undefined as unknown as { readonly current: { currentSiteId: string | undefined } },
     state: { notesOpen: true },
   },
   createNote: vi.fn(),
   createQuery: vi.fn(),
+  noteEdits: {
+    get: vi.fn(),
+    remove: vi.fn(),
+    sync: vi.fn(),
+  },
   noteSync: {
-    isTerminallyDeleted: vi.fn(() => false),
-    onTerminalDelete: vi.fn(() => vi.fn()),
+    isTerminallyDeleted: vi.fn((_siteId: string, noteId: string) => terminalNoteIds.has(noteId)),
+    onTerminalDelete: vi.fn(({ listener }: { listener: (noteId: string) => void }) => {
+      terminalListeners.add(listener);
+      return () => terminalListeners.delete(listener);
+    }),
     retainRelatedEntity: vi.fn(),
   },
+  terminalNoteIds: new Set<string>(),
+  terminalListeners: new Set<(noteId: string) => void>(),
   toastError: vi.fn(),
 }));
 
@@ -32,7 +42,7 @@ vi.mock('@typie/ui/context', async (importOriginal) => ({
 }));
 vi.mock('@typie/ui/notification', () => ({ Toast: { error: toastError } }));
 vi.mock('mixpanel-browser', () => ({ default: { track: vi.fn() } }));
-vi.mock('$app/navigation', () => ({ beforeNavigate: vi.fn() }));
+vi.mock('$app/navigation', () => ({ afterNavigate: vi.fn(), beforeNavigate: vi.fn() }));
 vi.mock('$lib/graphql', () => ({ cache: { invalidate: vi.fn() } }));
 vi.mock('$lib/note/note-mutation', async (importOriginal) => ({
   ...(await importOriginal<typeof import('$lib/note/note-mutation')>()),
@@ -45,17 +55,45 @@ vi.mock('$lib/note/note-mutation', async (importOriginal) => ({
     update: vi.fn(),
   }),
 }));
+vi.mock('$lib/note/note-edit-state.svelte', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('$lib/note/note-edit-state.svelte')>()),
+  getNoteEditsContext: () => noteEdits,
+}));
 vi.mock('$lib/note/note-sync.svelte', async (importOriginal) => ({
   ...(await importOriginal<typeof import('$lib/note/note-sync.svelte')>()),
   getNoteSyncContext: () => noteSync,
 }));
 
+type SiteNote = {
+  id: string;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+  order: string;
+  color: string;
+  status: 'OPEN' | 'RESOLVED';
+  site: { id: string };
+  entities: [];
+};
+
 type SiteQuery = {
-  data?: { notes: [] };
+  data?: { notes: SiteNote[] };
   loading: boolean;
   error?: Error;
   refetch: ReturnType<typeof vi.fn>;
 };
+
+const siteNote = (status: SiteNote['status']): SiteNote => ({
+  id: 'note-1',
+  content: 'note content',
+  createdAt: '2026-07-29T00:00:00.000Z',
+  updatedAt: status === 'OPEN' ? '2026-07-29T00:00:01.000Z' : '2026-07-29T00:00:00.000Z',
+  order: '100',
+  color: 'gray',
+  status,
+  site: { id: 'site-1' },
+  entities: [],
+});
 
 const createSiteQueryController = (initial: SiteQuery) => {
   const state = new SvelteMap([['snapshot', initial]]);
@@ -106,6 +144,14 @@ const mountNotes = async (siteQuery: SiteQuery | ReturnType<typeof createSiteQue
 
 describe('global notes error UX', () => {
   beforeEach(() => {
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe = vi.fn();
+        unobserve = vi.fn();
+        disconnect = vi.fn();
+      },
+    );
     Object.defineProperty(Element.prototype, 'animate', {
       configurable: true,
       value: vi.fn(() => ({
@@ -128,10 +174,14 @@ describe('global notes error UX', () => {
     noteSync.isTerminallyDeleted.mockClear();
     noteSync.onTerminalDelete.mockClear();
     noteSync.retainRelatedEntity.mockClear();
+    terminalNoteIds.clear();
+    terminalListeners.clear();
     toastError.mockReset();
   });
 
   afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
     Reflect.deleteProperty(Element.prototype, 'animate');
     document.body.replaceChildren();
   });
@@ -187,6 +237,60 @@ describe('global notes error UX', () => {
       expect(region).not.toBeNull();
       expect(region?.inert).toBe(true);
       expect(region?.getAttribute('aria-hidden')).toBe('true');
+    } finally {
+      await unmount(component);
+    }
+  });
+
+  it('does not retain a hidden completed exit or let its completion collapse the reopened note', async () => {
+    vi.useFakeTimers();
+    const controller = createSiteQueryController({
+      data: { notes: [siteNote('RESOLVED')] },
+      loading: false,
+      refetch: vi.fn(),
+    });
+    const { component } = await mountNotes(controller);
+
+    try {
+      controller.publish({
+        data: { notes: [siteNote('OPEN')] },
+        loading: false,
+        refetch: vi.fn(),
+      });
+      await tick();
+
+      const ownedCards = () => [...document.body.querySelectorAll<HTMLElement>('[data-note-list-owned-item][data-note-id="note-1"]')];
+      expect(ownedCards()).toHaveLength(1);
+
+      const openCard = ownedCards()[0]?.querySelector<HTMLElement>('[role="button"][data-note-id="note-1"]');
+      openCard?.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'Enter' }));
+      await tick();
+      expect(openCard?.querySelector('textarea')).not.toBeNull();
+
+      await vi.advanceTimersByTimeAsync(500);
+      await tick();
+
+      expect(ownedCards()).toHaveLength(1);
+      expect(openCard?.querySelector('textarea')).not.toBeNull();
+    } finally {
+      await unmount(component);
+    }
+  });
+
+  it('does not retain a terminally deleted card in the hidden completed list', async () => {
+    const controller = createSiteQueryController({
+      data: { notes: [siteNote('RESOLVED')] },
+      loading: false,
+      refetch: vi.fn(),
+    });
+    const { component } = await mountNotes(controller);
+
+    try {
+      terminalNoteIds.add('note-1');
+      for (const listener of terminalListeners) listener('note-1');
+      await tick();
+
+      expect(document.body.querySelector('[data-note-list-owned-item][data-note-id="note-1"]')).toBeNull();
     } finally {
       await unmount(component);
     }

--- a/apps/website/src/routes/website/(dashboard)/@widgets/widgets/DocumentRelatedNoteWidget.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@widgets/widgets/DocumentRelatedNoteWidget.svelte
@@ -271,31 +271,28 @@
 <Widget collapsed={isCollapsed} icon={StickyNoteIcon} noPadding title="노트">
   {#snippet headerActions()}
     {#if !palette && !isCollapsed}
-      <button
-        class={center({
-          height: '26px',
-          borderRadius: '6px',
-          paddingX: '6px',
-          color: 'text.subtle',
-          transition: 'common',
-          _hover: { backgroundColor: 'surface.muted', color: 'text.default' },
-          cursor: hasActiveDocument ? 'pointer' : 'default',
-          opacity: hasActiveDocument ? '100' : '40',
-        })}
-        disabled={!hasActiveDocument}
-        onclick={(event) => {
-          event.stopPropagation();
-          void handleAddNote('button');
-        }}
-        onpointerdown={(event) => event.stopPropagation()}
-        type="button"
-        use:tooltip={{
-          message: hasActiveDocument ? '노트 추가' : '문서를 열어야 노트를 추가할 수 있어요',
-          placement: 'top',
-        }}
-      >
-        <Icon icon={PlusIcon} size={14} />
-      </button>
+      {#if hasActiveDocument}
+        <button
+          class={center({
+            height: '26px',
+            borderRadius: '6px',
+            paddingX: '6px',
+            color: 'text.subtle',
+            transition: 'common',
+            _hover: { backgroundColor: 'surface.muted', color: 'text.default' },
+            cursor: 'pointer',
+          })}
+          onclick={(event) => {
+            event.stopPropagation();
+            void handleAddNote('button');
+          }}
+          onpointerdown={(event) => event.stopPropagation()}
+          type="button"
+          use:tooltip={{ message: '노트 추가', placement: 'top' }}
+        >
+          <Icon icon={PlusIcon} size={14} />
+        </button>
+      {/if}
       <button
         class={center({
           height: '26px',
@@ -369,11 +366,7 @@
         >
           <Icon icon={StickyNoteIcon} size={20} />
         </div>
-        <p class={css({ fontSize: '12px', color: 'text.faint', textAlign: 'center' })}>
-          문서를 열면 관련 노트를
-          <br />
-          사용할 수 있어요
-        </p>
+        <p class={css({ fontSize: '12px', color: 'text.faint', textAlign: 'center' })}>문서를 열면 연결된 노트를 볼 수 있어요</p>
       </div>
     {:else if siteId && entityId}
       <NoteList


### PR DESCRIPTION
#5102, #5106 후속 수정

- 앱에서 노트 패널을 닫았다 다시 열어도 편집 중인 draft와 저장 실패 상태가 유지되도록 함
- 앱에서 화면을 실제로 떠날 때 남은 변경사항 저장을 시도하고, 실패하면 그대로 나갈지 확인하도록 함
- 저장 중 새 draft가 생기거나 기존 값으로 되돌린 경우에도 최신 입력이 마지막에 저장되도록 함
- 저장 실패 또는 구독 제한 뒤 다음 blur, collapse, flush에서 같은 draft를 다시 저장하도록 함
- 앱에서 현재 보이는 상태 목록만 enter/exit transition을 소유하도록 함
- 웹에서 접힌 완료 목록의 늦은 exit가 새로 열린 노트를 닫지 않도록 함
- 활성 문서가 없을 때 관련 노트 추가 버튼을 숨기고 안내 문구 수정