### PR TITLE
앱/웹 에디터 프레임 싱크 및 반복 입력 드랍 수정

### DIFF
--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/input/EditorInputConnection.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/input/EditorInputConnection.kt
@@ -80,12 +80,12 @@ internal class EditorInputConnection(
     ImeEditBatch(isSessionCurrent) { messages ->
       val recorder = editor.inputRecorder
       val imeBefore = if (recorder == null) null else editor.appliedState.ime
-      val state = editor.runInputCallback {
+      val update = editor.runInputCallback {
         editor.updateNowWithBringIntoView(bringIntoViewRequests) {
           for (message in messages) {
             enqueue(message)
           }
-          afterApplied { bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead) }
+          bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
         }
       }
       recorder?.record { seq, t ->
@@ -94,7 +94,7 @@ internal class EditorInputConnection(
           t = t,
           messages = messages,
           imeBefore = imeBefore,
-          imeAfter = state?.ime,
+          imeAfter = update?.snapshot?.ime,
         )
       }
     }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Editor.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Editor.kt
@@ -75,6 +75,11 @@ private data class PublicationWaiter(
   val completion: CompletableDeferred<EditorPublicationResult>,
 )
 
+private data class PendingRequest(
+  val completion: CompletableDeferred<EditorUpdate>?,
+  val beforePublish: ((EditorUpdate) -> Unit)?,
+)
+
 internal data class PublishedBundle(val snapshot: EditorState, val frames: Map<Int, PresentedFrame>)
 
 private class SurfacePage(
@@ -146,8 +151,7 @@ internal constructor(
     AtomicReference(persistentMapOf())
   private val queuedLocalEdits: AtomicReference<PersistentList<LocalEdit>> =
     AtomicReference(persistentListOf())
-  private val requestReceipts:
-    AtomicReference<PersistentMap<Long, CompletableDeferred<EditorUpdate>>> =
+  private val pendingRequests: AtomicReference<PersistentMap<Long, PendingRequest>> =
     AtomicReference(persistentMapOf())
   private val publicationWaiters: AtomicReference<PersistentList<PublicationWaiter>> =
     AtomicReference(persistentListOf())
@@ -218,17 +222,11 @@ internal constructor(
   suspend fun update(
     admit: () -> Boolean = { true },
     block: EditorRequestScope.() -> Unit,
-  ): EditorUpdate? = updateInternal(admit = admit, afterApplied = null, block = block)
+  ): EditorUpdate? = update(admit = admit, beforePublish = null, block = block)
 
   internal suspend fun update(
-    admit: () -> Boolean = { true },
-    afterApplied: (EditorUpdate) -> Unit,
-    block: EditorRequestScope.() -> Unit,
-  ): EditorUpdate? = updateInternal(admit = admit, afterApplied = afterApplied, block = block)
-
-  private suspend fun updateInternal(
     admit: () -> Boolean,
-    afterApplied: ((EditorUpdate) -> Unit)?,
+    beforePublish: ((EditorUpdate) -> Unit)?,
     block: EditorRequestScope.() -> Unit,
   ): EditorUpdate? {
     if (terminal) return null
@@ -242,7 +240,6 @@ internal constructor(
     val localEdit = inheritedLocalEdit ?: localEdits.register() ?: return null
     val ownsLocalEdit = inheritedLocalEdit == null
     var admitted = false
-    var afterAppliedCompletion: CompletableDeferred<Unit>? = null
     val update =
       try {
         val accepted =
@@ -252,22 +249,14 @@ internal constructor(
               if (!admit()) return@withLock false
               val requestId = inner.enqueueRequest(messages)
               admitted = true
-              requestReceipts.updatePersistent { it.putting(requestId.value, receipt) }
+              registerPendingRequest(
+                requestId = requestId,
+                completion = receipt,
+                beforePublish = beforePublish,
+              )
               if (ownsLocalEdit) {
                 receipt.invokeOnCompletion { error ->
                   if (error == null) localEdit.complete() else localEdit.fail(error)
-                }
-              }
-              if (afterApplied != null) {
-                val completion = CompletableDeferred<Unit>()
-                afterAppliedCompletion = completion
-                scope.launch(start = CoroutineStart.UNDISPATCHED) {
-                  try {
-                    afterApplied(receipt.await())
-                    completion.complete(Unit)
-                  } catch (error: Throwable) {
-                    completion.completeExceptionally(error)
-                  }
                 }
               }
               scheduleTick()
@@ -288,15 +277,15 @@ internal constructor(
         fail(e)
         throw e
       }
-    afterAppliedCompletion?.await()
     return update
   }
 
   fun updateNow(block: EditorRequestScope.() -> Unit): EditorUpdate? =
-    updateNow(admit = { true }, block = block)
+    updateNow(admit = { true }, beforePublish = null, block = block)
 
   internal fun updateNow(
     admit: () -> Boolean,
+    beforePublish: ((EditorUpdate) -> Unit)? = null,
     block: EditorRequestScope.() -> Unit,
   ): EditorUpdate? {
     if (!syncInProgress.compareAndSet(expectedValue = false, newValue = true)) {
@@ -316,6 +305,11 @@ internal constructor(
               ensureActive()
               if (!admit()) return@withPriorityLock null
               val requestId = inner.enqueueRequest(messages)
+              registerPendingRequest(
+                requestId = requestId,
+                completion = null,
+                beforePublish = beforePublish,
+              )
               val tick = inner.tickThrough(requestId)
               install(tick)
               updateFor(tick, requestId)
@@ -529,13 +523,12 @@ internal constructor(
       renderInvalidated = tick.events.any { it is EditorEvent.RenderInvalidated },
     )
     startSurfaceRenders()
-    publishIfReady()
 
     val events = publicEvents(tick.events)
+    val completions = mutableListOf<Pair<CompletableDeferred<EditorUpdate>, EditorUpdate>>()
     for (request in tick.requestOutcomes) {
-      val receipt = requestReceipts.load()[request.requestId.value] ?: continue
-      requestReceipts.updatePersistent { it.removing(request.requestId.value) }
-      receipt.complete(
+      val pending = pendingRequests.load()[request.requestId.value] ?: continue
+      val update =
         EditorUpdate(
           revision = tick.revision.value,
           snapshot = appliedState,
@@ -543,6 +536,24 @@ internal constructor(
           commandOutcomes = request.commandOutcomes,
           editor = this,
         )
+      pending.beforePublish?.invoke(update)
+      pendingRequests.updatePersistent { it.removing(request.requestId.value) }
+      pending.completion?.let { completion -> completions += completion to update }
+    }
+    publishIfReady()
+    completions.forEach { (completion, update) -> completion.complete(update) }
+  }
+
+  private fun registerPendingRequest(
+    requestId: RequestId,
+    completion: CompletableDeferred<EditorUpdate>?,
+    beforePublish: ((EditorUpdate) -> Unit)?,
+  ) {
+    if (completion == null && beforePublish == null) return
+    pendingRequests.updatePersistent {
+      it.putting(
+        requestId.value,
+        PendingRequest(completion = completion, beforePublish = beforePublish),
       )
     }
   }
@@ -992,6 +1003,10 @@ internal constructor(
       refreshRetainedFrames()
       return
     }
+    val pendingPage = preparingPage
+    if (pendingPage != null && pendingPage >= appliedState.pageSizes.size) {
+      preparingPage = null
+    }
     val targets = host.pages.values.map { it.target }
     val targetsChanged = published?.let { !Publication.matchesTargets(it.frames, targets) } ?: false
     val pages =
@@ -1012,9 +1027,12 @@ internal constructor(
           appliedRevision = appliedState.version,
           publishedRevision = currentPublishedRevision,
           appliedPageCount = appliedState.pageSizes.size,
-          targetCount = host.pages.size,
+          publishedPageCount = published?.snapshot?.pageSizes?.size ?: 0,
+          targetPages = host.pages.keys,
         )
     }
+    val pageBeingPrepared = preparingPage
+    if (pageBeingPrepared != null && pageBeingPrepared !in host.pages) return
     val publishedRevision = currentPublishedRevision ?: 0L
     if (
       Publication.canPublish(
@@ -1234,7 +1252,7 @@ internal constructor(
       var waiters: List<PublicationWaiter> = emptyList()
       var edits: List<LocalEdit> = emptyList()
       mutex.withPriorityLock {
-        receipts = requestReceipts.exchange(persistentMapOf()).values
+        receipts = pendingRequests.exchange(persistentMapOf()).values.mapNotNull { it.completion }
         waiters = publicationWaiters.exchange(persistentListOf())
         edits = queuedLocalEdits.exchange(persistentListOf())
         visualHost = null
@@ -1398,7 +1416,7 @@ internal constructor(
       var waiters: List<PublicationWaiter> = emptyList()
       var edits: List<LocalEdit> = emptyList()
       mutex.withPriorityLock {
-        receipts = requestReceipts.exchange(persistentMapOf()).values
+        receipts = pendingRequests.exchange(persistentMapOf()).values.mapNotNull { it.completion }
         waiters = publicationWaiters.exchange(persistentListOf())
         edits = queuedLocalEdits.exchange(persistentListOf())
         preparingPage = null

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorView.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorView.kt
@@ -1,15 +1,14 @@
 package co.typie.editor
 
 import androidx.compose.foundation.focusable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -19,6 +18,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
@@ -46,6 +47,7 @@ import kotlinx.coroutines.CancellationException
 @Composable
 internal fun EditorView(
   load: DocumentEditorLoad,
+  publishedBundle: PublishedBundle?,
   layoutSpec: EditorDocumentLayoutSpec,
   viewportWidth: Float,
   viewportHeight: Float,
@@ -146,8 +148,7 @@ internal fun EditorView(
         onDispose { if (activated) editor.deactivateVisualHost(visualHostToken) }
       }
       val focusManager = LocalFocusManager.current
-      val publishedSelection by
-        remember(editor) { derivedStateOf { editor.publishedState.selection } }
+      val publishedSelection = publishedBundle?.snapshot?.selection
       var previousSelection by remember(editor) { mutableStateOf(publishedSelection) }
       LaunchedEffect(editor, themeVariant) {
         EditorRegistry.commitResourceUpdate {
@@ -207,72 +208,95 @@ internal fun EditorView(
         // Flutter/Web 기준으로 더 정교하게 맞춰야 한다.
         }
       val showPageChrome = layoutSpec is EditorDocumentLayoutSpec.Paginated
-      Column(
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(pageSpacing),
-      ) {
-        val publishedBundle = editor.publishedBundle
-        val publishedState = publishedBundle?.snapshot ?: EditorState.Initial
-        val publishedVersion = publishedState.version
-        publishedState.pageSizes.forEachIndexed { index, size ->
+      val publishedState = publishedBundle?.snapshot ?: EditorState.Initial
+      val publishedVersion = publishedState.version
+      val publishedPageCount = publishedState.pageSizes.size
+      val preparingPage = editor.preparingPage
+      val presentedPageCount = maxOf(publishedPageCount, (preparingPage ?: -1) + 1)
+      Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        repeat(presentedPageCount) { index ->
+          val preparing = index >= publishedPageCount
+          val size =
+            publishedState.pageSizes.getOrNull(index)
+              ?: editor.appliedState.pageSizes.getOrNull(index)?.takeIf { preparingPage == index }
+              ?: return@repeat
           val pageCursor = publishedState.cursor?.takeIf { sessionActive && it.pageIdx == index }
           val pageExternalElements =
             if (sessionActive) publishedState.externalElements.filter { it.pageIdx == index }
             else emptyList()
-          EditorPageSurface(
-            page = index,
-            width = size.width,
-            height = size.height,
-            publishedVersion = publishedVersion,
-            publishedFrame = publishedBundle?.frames?.get(index),
-            showChrome = showPageChrome,
-            debugBottomMarginHeight =
-              when (layoutSpec) {
-                is EditorDocumentLayoutSpec.Paginated -> layoutSpec.pageMarginBottom
-                is EditorDocumentLayoutSpec.Continuous -> 0f
-              },
-            showDebugOverlay = showDebugSurfaceOverlay,
-            backgroundOverlay = {
-              // Paginated line coordinates are page-local, so keep this in the page background
-              // layer below RenderCanvas content.
-              if (sessionActive && layoutSpec is EditorDocumentLayoutSpec.Paginated) {
-                EditorPageLineHighlightOverlay(
-                  cursor = pageCursor,
-                  focused = uiState.focused,
-                  displayZoom = displayZoom,
-                  pageWidth = size.width,
-                  enabled = Preference.lineHighlightEnabled,
-                )
-              }
-            },
-            foregroundOverlay = {
-              if (sessionActive) {
-                EditorExternalElementOverlay(
-                  elements = pageExternalElements,
-                  displayZoom = displayZoom,
-                )
-                EditorCursorOverlay(
-                  cursor = pageCursor,
-                  focused = uiState.focused,
-                  displayZoom = displayZoom,
-                )
-              }
-            },
+          val pagePositionModifier =
+            if (!preparing && sessionActive) {
+              Modifier.editorPagePositionTracker(
+                uiState = uiState,
+                page = index,
+                density = density.density,
+              )
+            } else {
+              Modifier
+            }
+          Box(
             modifier =
-              if (sessionActive) {
-                Modifier.editorPagePositionTracker(
-                  uiState = uiState,
-                  page = index,
-                  density = density.density,
-                )
-              } else {
-                Modifier
+              when {
+                preparing -> pagePositionModifier.withoutLayoutFootprint()
+                index < publishedPageCount - 1 -> pagePositionModifier.padding(bottom = pageSpacing)
+                else -> pagePositionModifier
+              }
+          ) {
+            EditorPageSurface(
+              page = index,
+              width = size.width,
+              height = size.height,
+              publishedVersion = publishedVersion,
+              publishedFrame = publishedBundle?.frames?.get(index),
+              showChrome = showPageChrome && !preparing,
+              debugBottomMarginHeight =
+                when (layoutSpec) {
+                  is EditorDocumentLayoutSpec.Paginated -> layoutSpec.pageMarginBottom
+                  is EditorDocumentLayoutSpec.Continuous -> 0f
+                },
+              showDebugOverlay = showDebugSurfaceOverlay && !preparing,
+              backgroundOverlay = {
+                // Paginated line coordinates are page-local, so keep this in the page background
+                // layer below RenderCanvas content.
+                if (
+                  !preparing && sessionActive && layoutSpec is EditorDocumentLayoutSpec.Paginated
+                ) {
+                  EditorPageLineHighlightOverlay(
+                    cursor = pageCursor,
+                    focused = uiState.focused,
+                    displayZoom = displayZoom,
+                    pageWidth = size.width,
+                    enabled = Preference.lineHighlightEnabled,
+                  )
+                }
               },
-          )
+              foregroundOverlay = {
+                if (!preparing && sessionActive) {
+                  EditorExternalElementOverlay(
+                    elements = pageExternalElements,
+                    displayZoom = displayZoom,
+                  )
+                  EditorCursorOverlay(
+                    cursor = pageCursor,
+                    focused = uiState.focused,
+                    displayZoom = displayZoom,
+                  )
+                }
+              },
+              modifier = if (preparing) Modifier.graphicsLayer(alpha = 0f) else Modifier,
+            )
+          }
         }
       }
     }
   }
+}
+
+private fun Modifier.withoutLayoutFootprint(): Modifier = layout { measurable, constraints ->
+  // Compose and measure the preparatory surface, but keep it out of document layout just like
+  // the web projection's absolutely positioned hidden page.
+  val placeable = measurable.measure(constraints.copy(minWidth = 0, minHeight = 0))
+  layout(width = 0, height = 0) { placeable.place(x = 0, y = 0) }
 }
 
 private data class EditorAttachEnvironment(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Publication.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Publication.kt
@@ -63,20 +63,21 @@ internal object Publication {
     appliedRevision: Long,
     publishedRevision: Long?,
     appliedPageCount: Int,
-    targetCount: Int,
-  ): Int? =
+    publishedPageCount: Int,
+    targetPages: Set<Int>,
+  ): Int? {
     if (
-      hasVisualHost &&
-        hasPublishedFrames &&
-        publishedRevision != null &&
-        appliedRevision > publishedRevision &&
-        appliedPageCount > 0 &&
-        targetCount == 0
+      !hasVisualHost ||
+        !hasPublishedFrames ||
+        publishedRevision == null ||
+        appliedRevision <= publishedRevision ||
+        appliedPageCount == 0
     ) {
-      0
-    } else {
-      null
+      return null
     }
+    if (targetPages.isEmpty()) return 0
+    return publishedPageCount.takeIf { appliedPageCount > publishedPageCount && it !in targetPages }
+  }
 
   fun canPublish(
     hasVisualHost: Boolean,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/body/EditorBody.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/body/EditorBody.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
@@ -23,7 +22,9 @@ import androidx.compose.ui.layout.onPlaced
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
+import co.typie.editor.EditorState
 import co.typie.editor.EditorView
+import co.typie.editor.PublishedBundle
 import co.typie.editor.ext.unclippedBoundsInRoot
 import co.typie.editor.interaction.LocalEditorInteractionScope
 import co.typie.editor.overlay.editorExtensionAreaLineHighlight
@@ -45,6 +46,7 @@ private val DebugExtensionFillColor = Color(0x2200B8D4)
 @Composable
 internal fun EditorBody(
   load: DocumentEditorLoad,
+  publishedBundle: PublishedBundle?,
   geometry: EditorBodyGeometry,
   layoutSpec: EditorDocumentLayoutSpec,
   autoScrollPolicy: EditorAutoScrollPolicy,
@@ -60,9 +62,9 @@ internal fun EditorBody(
   val uiState = LocalEditorUiState.current
   val interactionScope = LocalEditorInteractionScope.current
   var bodyContentHeight by remember { mutableFloatStateOf(0f) }
-  val pageSizes by
-    remember(editor) { derivedStateOf { editor?.publishedState?.pageSizes.orEmpty() } }
-  val cursor by remember(editor) { derivedStateOf { editor?.publishedState?.cursor } }
+  val publishedState = publishedBundle?.snapshot ?: EditorState.Initial
+  val pageSizes = publishedState.pageSizes
+  val cursor = publishedState.cursor
   val extensionAreaFillSpacerHeight =
     remember(geometry.minimumBodyHeight, bodyContentHeight) {
       resolveExtensionAreaFillSpacerHeight(
@@ -126,6 +128,7 @@ internal fun EditorBody(
             ) {
               EditorView(
                 load = load,
+                publishedBundle = publishedBundle,
                 layoutSpec = layoutSpec,
                 viewportWidth = geometry.visibleBodySize.width,
                 viewportHeight = geometry.visibleBodySize.height,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorInput.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorInput.kt
@@ -263,7 +263,7 @@ internal class EditorInputNode(
       sessionEditor.scope.launch(context) {
         sessionEditor.updateWithBringIntoView(bringIntoViewRequests) {
           messages.forEach(::enqueue)
-          afterApplied { bringIntoViewTarget?.let { target -> bringIntoView(target) } }
+          bringIntoViewTarget?.let { target -> bringIntoView(target) }
         }
       }
     }
@@ -372,10 +372,15 @@ internal class EditorInputNode(
     bringIntoViewTarget: EditorBringIntoViewTarget?,
   ): EditorState? {
     if (messages.isEmpty()) return null
-    return editor.updateWithBringIntoView(bringIntoViewRequests) {
-      messages.forEach(::enqueue)
-      afterApplied { bringIntoViewTarget?.let { target -> bringIntoView(target) } }
-    }
+    val update =
+      editor.updateWithBringIntoView(bringIntoViewRequests) {
+        messages.forEach(::enqueue)
+        bringIntoViewTarget?.let { target -> bringIntoView(target) }
+      } ?: return null
+    // Keep the ordered key consumer behind visual publication so repeated input
+    // coalesces into the next batch instead of outrunning the displayed revision.
+    update.awaitPublished()
+    return update.snapshot
   }
 
   private fun dispatchSync(
@@ -383,12 +388,14 @@ internal class EditorInputNode(
     bringIntoViewTarget: EditorBringIntoViewTarget? = EditorBringIntoViewTarget.CurrentSelectionHead,
   ): EditorState? {
     if (messages.isEmpty()) return null
-    return editor.runInputCallback {
-      editor.updateNowWithBringIntoView(bringIntoViewRequests) {
-        messages.forEach(::enqueue)
-        afterApplied { bringIntoViewTarget?.let { target -> bringIntoView(target) } }
+    return editor
+      .runInputCallback {
+        editor.updateNowWithBringIntoView(bringIntoViewRequests) {
+          messages.forEach(::enqueue)
+          bringIntoViewTarget?.let { target -> bringIntoView(target) }
+        }
       }
-    }
+      ?.snapshot
   }
 
   private fun commitCompositionBeforeBindingDispatch(resetPlatformInput: Boolean) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorUpdateWithBringIntoView.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorUpdateWithBringIntoView.kt
@@ -2,83 +2,63 @@ package co.typie.editor.scroll
 
 import co.typie.editor.Editor
 import co.typie.editor.EditorRequestScope
-import co.typie.editor.EditorState
+import co.typie.editor.EditorUpdate
 import co.typie.editor.ffi.Message
 
 internal interface EditorBringIntoViewUpdateScope : EditorRequestScope {
-  fun afterApplied(block: EditorBringIntoViewAppliedScope.() -> Unit)
+  fun bringIntoView(target: EditorBringIntoViewTarget)
 }
 
-internal interface EditorBringIntoViewAppliedScope {
-  fun bringIntoView(target: EditorBringIntoViewTarget)
+private fun EditorRequestScope.applyBringIntoViewUpdate(
+  block: EditorBringIntoViewUpdateScope.() -> Unit
+): EditorBringIntoViewTarget? {
+  val request = this
+  var selectedTarget: EditorBringIntoViewTarget? = null
+  block(
+    object : EditorBringIntoViewUpdateScope {
+      override fun enqueue(message: Message) {
+        request.enqueue(message)
+      }
+
+      override fun bringIntoView(target: EditorBringIntoViewTarget) {
+        selectedTarget = target
+      }
+    }
+  )
+  return selectedTarget
 }
 
 internal fun Editor.updateNowWithBringIntoView(
   bringIntoViewRequests: EditorBringIntoViewRequests,
   block: EditorBringIntoViewUpdateScope.() -> Unit,
-): EditorState? {
-  val afterAppliedBlocks = mutableListOf<EditorBringIntoViewAppliedScope.() -> Unit>()
-  val update =
-    updateNow {
-      val editorScope = this
-      val updateScope =
-        object : EditorBringIntoViewUpdateScope {
-          override fun enqueue(message: Message) {
-            editorScope.enqueue(message)
-          }
-
-          override fun afterApplied(block: EditorBringIntoViewAppliedScope.() -> Unit) {
-            afterAppliedBlocks += block
-          }
-        }
-
-      updateScope.block()
-    } ?: return null
-
-  val appliedScope =
-    object : EditorBringIntoViewAppliedScope {
-      override fun bringIntoView(target: EditorBringIntoViewTarget) {
-        // EditorView activates this request only from a matching published snapshot, after
-        // Compose has received the matching geometry.
-        bringIntoViewRequests.requestForVersion(target = target, version = update.revision)
+): EditorUpdate? {
+  var selectedTarget: EditorBringIntoViewTarget? = null
+  return updateNow(
+    admit = { true },
+    beforePublish = { applied ->
+      selectedTarget?.let { target ->
+        bringIntoViewRequests.requestForVersion(target = target, version = applied.revision)
       }
-    }
-  afterAppliedBlocks.forEach { block -> block(appliedScope) }
-  return update.snapshot
+    },
+  ) {
+    selectedTarget = applyBringIntoViewUpdate(block)
+  }
 }
 
 internal suspend fun Editor.updateWithBringIntoView(
   bringIntoViewRequests: EditorBringIntoViewRequests,
   admit: () -> Boolean = { true },
   block: EditorBringIntoViewUpdateScope.() -> Unit,
-): EditorState? {
-  val afterAppliedBlocks = mutableListOf<EditorBringIntoViewAppliedScope.() -> Unit>()
-  val update =
-    update(
-      admit = admit,
-      afterApplied = { applied ->
-        val appliedScope =
-          object : EditorBringIntoViewAppliedScope {
-            override fun bringIntoView(target: EditorBringIntoViewTarget) {
-              bringIntoViewRequests.requestForVersion(target = target, version = applied.revision)
-            }
-          }
-        afterAppliedBlocks.forEach { block -> block(appliedScope) }
-      },
-    ) {
-      val editorScope = this
-      val updateScope =
-        object : EditorBringIntoViewUpdateScope {
-          override fun enqueue(message: Message) {
-            editorScope.enqueue(message)
-          }
-
-          override fun afterApplied(block: EditorBringIntoViewAppliedScope.() -> Unit) {
-            afterAppliedBlocks += block
-          }
-        }
-
-      updateScope.block()
-    } ?: return null
-  return update.snapshot
+): EditorUpdate? {
+  var selectedTarget: EditorBringIntoViewTarget? = null
+  return update(
+    admit = admit,
+    beforePublish = { applied ->
+      selectedTarget?.let { target ->
+        bringIntoViewRequests.requestForVersion(target = target, version = applied.revision)
+      }
+    },
+  ) {
+    selectedTarget = applyBringIntoViewUpdate(block)
+  }
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -374,7 +374,8 @@ fun EditorScreen(entityId: String) {
     }
   }
   val appliedEditorState = editor?.appliedState ?: EditorState.Initial
-  val publishedEditorState = editor?.publishedState ?: EditorState.Initial
+  val publishedBundle = editor?.publishedBundle
+  val publishedEditorState = publishedBundle?.snapshot ?: EditorState.Initial
   val doubleTapToEditEnabled =
     Preference.doubleTapToEditEnabled && publishedEditorState.placeholder == null
   val headerReadingTapIdentity = remember(editor, editorReadOnly, documentLocked) { Any() }
@@ -1049,11 +1050,13 @@ fun EditorScreen(entityId: String) {
     }
   }
 
-  val layoutEditor = editor ?: runtime.failedEditor
+  val layoutPublishedBundle =
+    if (editor != null) publishedBundle else runtime.failedEditor?.publishedBundle
+  val layoutPublishedState = layoutPublishedBundle?.snapshot ?: EditorState.Initial
   val preloadedLayoutSpec =
     remember(document?.layoutMode) { decodeDocumentLayoutSpec(document?.layoutMode) }
   val layoutSpec: EditorDocumentLayoutSpec =
-    layoutEditor?.publishedState?.rootAttrs?.layoutMode?.toEditorDocumentLayoutSpec()
+    layoutPublishedState.rootAttrs?.layoutMode?.toEditorDocumentLayoutSpec()
       ?: preloadedLayoutSpec
       ?: EditorDocumentLayoutSpec.Continuous(maxWidth = 600f)
   val background =
@@ -1077,7 +1080,7 @@ fun EditorScreen(entityId: String) {
       )
     },
   ) { innerPadding ->
-    val layoutPageSizes = layoutEditor?.publishedState?.pageSizes.orEmpty()
+    val layoutPageSizes = layoutPublishedState.pageSizes
     val density = LocalDensity.current.density
     val focusManager = LocalFocusManager.current
     val haptic = LocalHapticFeedback.current
@@ -1885,9 +1888,7 @@ fun EditorScreen(entityId: String) {
                       activeEditor.scope.launch(context) {
                         activeEditor.updateWithBringIntoView(bringIntoViewRequests) {
                           enqueue(Message.Clipboard(ClipboardOp.RepasteAsText))
-                          afterApplied {
-                            bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
-                          }
+                          bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
                         }
                       }
                     }
@@ -1903,6 +1904,7 @@ fun EditorScreen(entityId: String) {
           if (editorLoad != null) {
             EditorBody(
               load = editorLoad,
+              publishedBundle = layoutPublishedBundle,
               geometry = bodyGeometry,
               layoutSpec = layoutSpec,
               autoScrollPolicy = autoScrollPolicy,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/entry/EditorEntryStateSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/entry/EditorEntryStateSession.kt
@@ -54,7 +54,7 @@ internal fun rememberEditorEntryStateSession(
 
     activeEditor.updateWithBringIntoView(bringIntoViewRequests) {
       enqueue(Message.Selection(SelectionOp.SetFrozen(selection = selection)))
-      afterApplied { bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead) }
+      bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
     }
   }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorContextMenuActions.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorContextMenuActions.kt
@@ -60,10 +60,12 @@ internal fun rememberEditorContextMenuActions(
             if (bringIntoViewTarget == null) {
               editor.update { enqueue(Message.Selection(SelectionOp.Expand(unit))) }?.snapshot
             } else {
-              editor.updateWithBringIntoView(bringIntoViewRequests) {
-                enqueue(Message.Selection(SelectionOp.Expand(unit)))
-                afterApplied { bringIntoView(bringIntoViewTarget) }
-              }
+              editor
+                .updateWithBringIntoView(bringIntoViewRequests) {
+                  enqueue(Message.Selection(SelectionOp.Expand(unit)))
+                  bringIntoView(bringIntoViewTarget)
+                }
+                ?.snapshot
             }
           appliedState?.let { state ->
             contextMenu.requestShowForAppliedSelection(editor = editor, state = state)
@@ -85,7 +87,7 @@ internal fun rememberEditorContextMenuActions(
           if (clipboard.copyRichText(html = payload.html, text = payload.text)) {
             editor.updateWithBringIntoView(bringIntoViewRequests) {
               enqueue(Message.Clipboard(ClipboardOp.Cut))
-              afterApplied { bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead) }
+              bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
             }
           }
         }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/spellcheck/EditorSpellcheckSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/spellcheck/EditorSpellcheckSession.kt
@@ -390,7 +390,7 @@ internal fun rememberEditorSpellcheckSession(
 
           if (!ensureSubscription()) return@launch
           if (!onEditingIntent(activeEditor)) return@launch
-          val selected =
+          val update =
             activeEditor.updateWithBringIntoView(
               bringIntoViewRequests = bringIntoViewRequests,
               admit = { admitMutation(activeSession) },
@@ -400,9 +400,9 @@ internal fun rememberEditorSpellcheckSession(
                   SelectionOp.Set(Selection(anchor = range.anchor, head = range.head))
                 )
               )
-              afterApplied { bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead) }
+              bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
             }
-          if (selected == null) return@launch
+          if (update == null) return@launch
           model?.activate(null)
           updateCompactOverlayHeightForRange(null)
           model?.updateExpanded(false)

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarHost.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarHost.kt
@@ -246,15 +246,15 @@ internal fun EditorToolbarHost(
     val session = runtime.session ?: return
     session.submit { editor, context ->
       editor.scope.launch(context) {
-        val appliedSnapshot =
+        val update =
           editor.updateWithBringIntoView(bringIntoViewRequests) {
             if (editor.appliedState.ime?.composing != null) {
               enqueue(Message.TextInput(listOf(FlatImeOp.CommitAsIs)))
             }
             messages.forEach(::enqueue)
-            afterApplied { bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead) }
+            bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
           }
-        if (appliedSnapshot == null) {
+        if (update == null) {
           Logger.e { "Editor toolbar messages were not admitted" }
         }
       }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/bottom/Nodes.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/bottom/Nodes.kt
@@ -110,7 +110,7 @@ internal fun BottomToolbarNodes(
                 currentEditor.scope.launch(context) {
                   currentEditor.updateWithBringIntoView(bringIntoViewRequests) {
                     enqueue(action.message)
-                    afterApplied { bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead) }
+                    bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
                   }
                 }
               }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/EmbedToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/EmbedToolbar.kt
@@ -100,7 +100,7 @@ private fun EditorEmbedToolbar(
                 cache = externalElementState::put,
                 commit = { embedded ->
                   val editor = checkNotNull(runtime.editor) { "No active editor is available" }
-                  val appliedSnapshot =
+                  val update =
                     editor.updateWithBringIntoView(bringIntoViewRequests) {
                       if (editor.appliedState.ime?.composing != null) {
                         enqueue(Message.TextInput(listOf(FlatImeOp.CommitAsIs)))
@@ -113,9 +113,9 @@ private fun EditorEmbedToolbar(
                           )
                         )
                       )
-                      afterApplied { bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead) }
+                      bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
                     }
-                  checkNotNull(appliedSnapshot) { "Editor embed attrs were not admitted" }
+                  checkNotNull(update) { "Editor embed attrs were not admitted" }
                 },
                 clearPending = {
                   if (embedState.unfurls[selectedNodeId] === unfurl) {

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorRequestTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorRequestTest.kt
@@ -88,25 +88,6 @@ class EditorRequestTest {
     }
 
   @Test
-  fun update_afterApplied_exception_does_not_fail_editor() =
-    runTest(dispatcher) {
-      val boom = IllegalStateException("boom")
-      val reported = mutableListOf<Throwable>()
-      val editor =
-        Editor(FakeFfiEditor(), this, dispatcher, onError = { _, error -> reported += error })
-
-      val thrown =
-        assertFailsWith<IllegalStateException> {
-          editor.update(afterApplied = { throw boom }) { enqueue(sampleMessage) }
-        }
-
-      assertEquals(boom.message, thrown.message)
-      assertFalse(editor.terminal)
-      assertTrue(reported.isEmpty())
-      assertEquals(1L, editor.appliedState.version)
-    }
-
-  @Test
   fun prose_range_install_returns_the_single_result() =
     runTest(dispatcher) {
       lateinit var fake: FakeFfiEditor

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/PublicationTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/PublicationTest.kt
@@ -112,7 +112,8 @@ class PublicationTest {
         appliedRevision = 10,
         publishedRevision = 9,
         appliedPageCount = 1,
-        targetCount = 0,
+        publishedPageCount = 1,
+        targetPages = emptySet(),
       ),
     )
     assertNull(
@@ -122,7 +123,8 @@ class PublicationTest {
         appliedRevision = 10,
         publishedRevision = 9,
         appliedPageCount = 1,
-        targetCount = 0,
+        publishedPageCount = 1,
+        targetPages = emptySet(),
       )
     )
     assertNull(
@@ -132,7 +134,8 @@ class PublicationTest {
         appliedRevision = 9,
         publishedRevision = 9,
         appliedPageCount = 1,
-        targetCount = 0,
+        publishedPageCount = 1,
+        targetPages = emptySet(),
       )
     )
     assertNull(
@@ -142,7 +145,8 @@ class PublicationTest {
         appliedRevision = 10,
         publishedRevision = 9,
         appliedPageCount = 0,
-        targetCount = 0,
+        publishedPageCount = 1,
+        targetPages = emptySet(),
       )
     )
     assertNull(
@@ -152,7 +156,8 @@ class PublicationTest {
         appliedRevision = 10,
         publishedRevision = 9,
         appliedPageCount = 1,
-        targetCount = 1,
+        publishedPageCount = 1,
+        targetPages = setOf(0),
       )
     )
     assertNull(
@@ -162,7 +167,34 @@ class PublicationTest {
         appliedRevision = 10,
         publishedRevision = 9,
         appliedPageCount = 1,
-        targetCount = 0,
+        publishedPageCount = 1,
+        targetPages = emptySet(),
+      )
+    )
+  }
+
+  @Test
+  fun nextAppendedPageIsPreparedUntilItsTargetIsAttached() {
+    val preparingPage =
+      Publication.preparingPage(
+        hasVisualHost = true,
+        hasPublishedFrames = true,
+        appliedRevision = 10,
+        publishedRevision = 9,
+        appliedPageCount = 2,
+        publishedPageCount = 1,
+        targetPages = setOf(0),
+      )
+    assertEquals(1, preparingPage)
+    assertNull(
+      Publication.preparingPage(
+        hasVisualHost = true,
+        hasPublishedFrames = true,
+        appliedRevision = 10,
+        publishedRevision = 9,
+        appliedPageCount = 2,
+        publishedPageCount = 1,
+        targetPages = setOf(0, 1),
       )
     )
   }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorUpdateWithBringIntoViewTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorUpdateWithBringIntoViewTest.kt
@@ -6,6 +6,7 @@ import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.SystemEvent
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.CoroutineStart
@@ -23,11 +24,16 @@ class EditorUpdateWithBringIntoViewTest {
       val requests = EditorBringIntoViewRequests()
       val editor = Editor(FakeFfiEditor(), this, dispatcher)
 
-      editor.updateWithBringIntoView(requests) {
-        enqueue(Message.System(SystemEvent.Initialize))
-        afterApplied { bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead) }
-      }
+      val update =
+        assertNotNull(
+          editor.updateWithBringIntoView(requests) {
+            enqueue(Message.System(SystemEvent.Initialize))
+            bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+          }
+        )
 
+      assertEquals(1L, update.revision)
+      assertEquals(1L, update.snapshot.version)
       assertNull(requests.activateForVersion(version = 0L))
       assertEquals(
         request(EditorBringIntoViewTarget.CurrentSelectionHead),
@@ -41,11 +47,16 @@ class EditorUpdateWithBringIntoViewTest {
       val requests = EditorBringIntoViewRequests()
       val editor = Editor(FakeFfiEditor(), this, dispatcher)
 
-      editor.updateNowWithBringIntoView(requests) {
-        enqueue(Message.System(SystemEvent.Initialize))
-        afterApplied { bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead) }
-      }
+      val update =
+        assertNotNull(
+          editor.updateNowWithBringIntoView(requests) {
+            enqueue(Message.System(SystemEvent.Initialize))
+            bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+          }
+        )
 
+      assertEquals(1L, update.revision)
+      assertEquals(1L, update.snapshot.version)
       assertNull(requests.activateForVersion(version = 0L))
       assertEquals(
         request(EditorBringIntoViewTarget.CurrentSelectionHead),
@@ -54,22 +65,17 @@ class EditorUpdateWithBringIntoViewTest {
     }
 
   @Test
-  fun `update bringIntoView runs afterApplied once when caller is cancelled after admission`() =
+  fun `update bringIntoView survives caller cancellation after admission`() =
     runTest(dispatcher) {
       val requests = EditorBringIntoViewRequests()
       lateinit var caller: Job
       val fake = FakeFfiEditor(beforeEnqueueRequest = { caller.cancel() })
       val editor = Editor(fake, this, dispatcher)
-      var afterAppliedCalls = 0
-
       caller =
         launch(start = CoroutineStart.LAZY) {
           editor.updateWithBringIntoView(requests) {
             enqueue(Message.System(SystemEvent.Initialize))
-            afterApplied {
-              afterAppliedCalls += 1
-              bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
-            }
+            bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
           }
         }
       caller.start()
@@ -78,7 +84,6 @@ class EditorUpdateWithBringIntoViewTest {
 
       assertTrue(caller.isCancelled)
       assertEquals(1L, editor.appliedState.version)
-      assertEquals(1, afterAppliedCalls)
       assertEquals(
         request(EditorBringIntoViewTarget.CurrentSelectionHead),
         requests.activateForVersion(version = 1L),

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/EditorFrameSyncDesktopFixture.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/EditorFrameSyncDesktopFixture.kt
@@ -1,0 +1,401 @@
+package co.typie.editor
+
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.input.key.Key as ComposeKey
+import androidx.compose.ui.test.ExperimentalTestApi
+import co.typie.editor.body.EditorDocumentLayoutSpec
+import co.typie.editor.ffi.Editor as FfiEditor
+import co.typie.editor.ffi.GraphIngest
+import co.typie.editor.ffi.Key
+import co.typie.editor.ffi.KeyEvent
+import co.typie.editor.ffi.LayoutMode
+import co.typie.editor.ffi.Message
+import co.typie.editor.ffi.Modifier as EditorModifier
+import co.typie.editor.ffi.ModifierType
+import co.typie.editor.ffi.PlainDoc
+import co.typie.editor.ffi.PlainNode
+import co.typie.editor.ffi.PlainNodeEntry
+import co.typie.editor.ffi.SelectionOp
+import co.typie.editor.ffi.Viewport
+import co.typie.editor.runtime.EditorRuntime
+import co.typie.editor.runtime.EditorUiState
+import co.typie.editor.scroll.EditorBringIntoViewRequests
+import co.typie.editor.scroll.EditorBringIntoViewTarget
+import co.typie.editor.scroll.EditorScrollFrame
+import co.typie.editor.scroll.EditorVisibleArea
+import co.typie.editor.scroll.resolveEditorAutoScrollPolicy
+import co.typie.editor.scroll.updateNowWithBringIntoView
+import co.typie.editor.sync.DocumentEditorLoad
+import co.typie.editor.sync.createTestDocumentEditingSession
+import co.typie.editor.sync.ws.DocumentSyncBaseline
+import co.typie.editor.viewport.EditorViewportState
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
+
+@OptIn(ExperimentalTestApi::class)
+internal class FrameSyncFixture(continuous: Boolean = false) {
+  val continuationScheduler = TestCoroutineScheduler()
+  private val continuationDispatcher = StandardTestDispatcher(continuationScheduler)
+  val scope = CoroutineScope(SupervisorJob() + continuationDispatcher)
+  val layoutSpec: EditorDocumentLayoutSpec =
+    if (continuous) {
+      EditorDocumentLayoutSpec.Continuous(maxWidth = PageWidth)
+    } else {
+      EditorDocumentLayoutSpec.Paginated(
+        pageWidth = PageWidth,
+        pageHeight = PageHeight,
+        pageMarginTop = PageMargin,
+        pageMarginBottom = PageMargin,
+        pageMarginLeft = PageMargin,
+        pageMarginRight = PageMargin,
+      )
+    }
+  val visibleArea = EditorVisibleArea(viewport = Size(ViewportWidth, ViewportHeight))
+  val autoScrollPolicy =
+    resolveEditorAutoScrollPolicy(visibleArea = visibleArea, baseBottomSpace = PageMargin)
+  val viewportState = EditorViewportState()
+  val uiState = EditorUiState()
+  val bringIntoViewRequests = EditorBringIntoViewRequests()
+  private var drawSequence = 0L
+  private val drawJournal = mutableListOf<DrawnPresentation>()
+  val forceDrawTick = mutableIntStateOf(0)
+  @Volatile var lastDrawnPresentation: DrawnPresentation? = null
+  val editor: Editor
+  private val session: DocumentEditingSession
+  val runtime: EditorRuntime
+  val load: DocumentEditorLoad
+
+  init {
+    configureRenderBufferLibrary()
+    editor =
+      kotlinx.coroutines.runBlocking {
+        Editor.createFromDoc(
+          doc = if (continuous) emptyContinuousDocument() else emptyPaginatedDocument(),
+          viewport = Viewport(ViewportWidth, ViewportHeight, 1.0),
+          scope = scope,
+          dispatcher = Dispatchers.Default.limitedParallelism(1),
+        )
+      }
+    editor.updateNow {
+      enqueue(Message.Selection(SelectionOp.SetAt(page = 0, x = PageMargin, y = PageMargin)))
+    }
+    session = createTestDocumentEditingSession(editor, scope)
+    runtime = EditorRuntime(scope)
+    runtime.attach(session)
+    load =
+      DocumentEditorLoad(
+        ingest = UnusedGraphIngest,
+        initialBaseline = DocumentSyncBaseline("", ByteArray(0), ByteArray(0)),
+        pending = emptyList(),
+        parentScope = scope,
+        onEditorError = { _, _ -> },
+      )
+  }
+
+  @Synchronized
+  fun recordDraw(
+    snapshot: EditorState,
+    scrollY: Float,
+    cursorNativeFrameRevision: Long?,
+    testDrawTick: Int,
+  ) {
+    val cursorPage = snapshot.cursor?.pageIdx
+    val draw =
+      DrawnPresentation(
+        sequence = ++drawSequence,
+        snapshot = snapshot,
+        scrollY = scrollY,
+        cursorNativeFrameRevision = cursorNativeFrameRevision,
+        editorBoundsY = uiState.editorBoundsInContainer.y,
+        cursorPageOffsetY =
+          cursorPage?.let {
+            uiState.resolveViewportTransform(snapshot.pageSizes).pageOffsets[it]?.y
+          },
+        testDrawTick = testDrawTick,
+      )
+    drawJournal += draw
+    lastDrawnPresentation = draw
+  }
+
+  @Synchronized
+  fun drawsAfter(sequence: Long): List<DrawnPresentation> = drawJournal.filter {
+    it.sequence > sequence
+  }
+
+  @Synchronized fun latestDrawSequence(): Long = drawSequence
+
+  fun forceNextDraw() {
+    forceDrawTick.intValue += 1
+  }
+
+  fun scrollFrame(state: EditorState): EditorScrollFrame =
+    EditorScrollFrame(
+      state = state,
+      layoutSpec = layoutSpec,
+      displayZoom = 1f,
+      visibleArea = visibleArea,
+      autoScrollPolicy = autoScrollPolicy,
+      headerHeight = 0f,
+      density = 1f,
+      editorBounds = uiState.editorBoundsInContainer,
+    )
+
+  fun moveToLastOnePageState(test: androidx.compose.ui.test.ComposeUiTest) {
+    repeat(MaxBoundarySearchSteps) {
+      val update =
+        assertNotNull(
+          editor.updateNowWithBringIntoView(bringIntoViewRequests) {
+            enqueue(Message.Key(KeyEvent(Key.Enter)))
+            bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+          }
+        )
+      test.waitUntil(timeoutMillis = 10_000) {
+        (editor.publishedRevision ?: -1L) >= update.revision
+      }
+      test.waitForIdle()
+      if (editor.publishedState.pageSizes.size > 1) {
+        val onePageUpdate =
+          assertNotNull(
+            editor.updateNowWithBringIntoView(bringIntoViewRequests) {
+              enqueue(Message.Key(KeyEvent(Key.Backspace)))
+              bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+            }
+          )
+        test.waitUntil(timeoutMillis = 10_000) {
+          (editor.publishedRevision ?: -1L) >= onePageUpdate.revision
+        }
+        test.waitForIdle()
+        assertEquals(1, editor.publishedState.pageSizes.size)
+        return
+      }
+    }
+    val state = editor.publishedState
+    error(
+      "page boundary was not reached within $MaxBoundarySearchSteps Enter presses: " +
+        "version=${state.version} pages=${state.pageSizes} cursor=${state.cursor} " +
+        "selection=${state.selection} ime=${state.ime} root=${state.rootAttrs}"
+    )
+  }
+
+  fun prepareLongDocument(test: androidx.compose.ui.test.ComposeUiTest) {
+    repeat(LongDocumentParagraphCount) {
+      val update =
+        assertNotNull(
+          editor.updateNowWithBringIntoView(bringIntoViewRequests) {
+            enqueue(Message.Key(KeyEvent(Key.Enter)))
+            bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+          }
+        )
+      test.waitUntil(timeoutMillis = 10_000) {
+        val bundle = editor.publishedBundle ?: return@waitUntil false
+        val cursorPage = bundle.snapshot.cursor?.pageIdx ?: return@waitUntil false
+        bundle.snapshot.version >= update.revision && bundle.frames.containsKey(cursorPage)
+      }
+      test.waitForIdle()
+    }
+    assertTrue(editor.publishedState.pageSizes.size >= 3)
+
+    val startUpdate =
+      assertNotNull(
+        editor.updateNowWithBringIntoView(bringIntoViewRequests) {
+          enqueue(Message.Selection(SelectionOp.SetAt(page = 0, x = PageMargin, y = PageMargin)))
+          bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+        }
+      )
+    test.waitUntil(timeoutMillis = 10_000) {
+      (editor.publishedRevision ?: -1L) >= startUpdate.revision
+    }
+    test.waitForIdle()
+    viewportState.scrollToY(0f, isAutoScroll = false)
+  }
+
+  fun resetLongDocumentStart(test: androidx.compose.ui.test.ComposeUiTest) {
+    val startUpdate =
+      assertNotNull(
+        editor.updateNowWithBringIntoView(bringIntoViewRequests) {
+          enqueue(Message.Selection(SelectionOp.SetAt(page = 0, x = PageMargin, y = PageMargin)))
+        }
+      )
+    viewportState.scrollToY(0f, isAutoScroll = false)
+    test.mainClock.autoAdvance = true
+    try {
+      test.waitUntil(timeoutMillis = 10_000) {
+        (editor.publishedRevision ?: -1L) >= startUpdate.revision &&
+          editor.publishedState.cursor?.pageIdx == 0
+      }
+      test.waitForIdle()
+    } finally {
+      test.mainClock.autoAdvance = false
+    }
+    viewportState.scrollToY(0f, isAutoScroll = false)
+  }
+
+  fun moveToTwoPageEnd(test: androidx.compose.ui.test.ComposeUiTest) {
+    moveToLastOnePageState(test)
+    val twoPageUpdate =
+      assertNotNull(
+        editor.updateNowWithBringIntoView(bringIntoViewRequests) {
+          enqueue(Message.Key(KeyEvent(Key.Enter)))
+          bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+        }
+      )
+    test.waitUntil(timeoutMillis = 10_000) {
+      (editor.publishedRevision ?: -1L) >= twoPageUpdate.revision &&
+        editor.publishedBundle?.frames?.get(1) != null
+    }
+    test.waitForIdle()
+    assertEquals(2, editor.publishedState.pageSizes.size)
+  }
+
+  fun close() {
+    load.close()
+    runtime.clear()
+    scope.cancel()
+  }
+}
+
+internal enum class RepeatKey(val key: ComposeKey) {
+  Down(ComposeKey.DirectionDown),
+  Up(ComposeKey.DirectionUp),
+  Enter(ComposeKey.Enter),
+  Backspace(ComposeKey.Backspace),
+}
+
+internal data class DrawnPresentation(
+  val sequence: Long,
+  val snapshot: EditorState,
+  val scrollY: Float,
+  val cursorNativeFrameRevision: Long?,
+  val editorBoundsY: Float,
+  val cursorPageOffsetY: Float?,
+  val testDrawTick: Int,
+)
+
+internal data class DesktopFrameSample(
+  val phaseMillis: Long,
+  val displayFrame: Int,
+  val repeatKey: RepeatKey?,
+  val presentation: DrawnPresentation,
+  val drawPassCount: Int,
+  val cursorDocumentY: Float,
+  val highlightDocumentY: Float,
+  val expectedCursorY: Float,
+  val actualCursorY: Float?,
+  val expectedHighlightY: Float,
+  val actualHighlightY: Float?,
+)
+
+internal data class CapturedDesktopFrame(val sample: DesktopFrameSample, val image: ImageBitmap)
+
+internal const val RootTag = "editor-frame-sync-root"
+internal const val ViewportWidth = 240f
+internal const val ViewportHeight = 140f
+internal const val PageWidth = 200f
+internal const val PageHeight = 180f
+internal const val PageMargin = 20f
+internal const val HighlightSampleInset = 8f
+internal const val CursorScanRadius = 4
+internal const val RepeatIntervalMillis = 33L
+internal const val RepeatFramesPerLeg = 8
+internal const val RepeatCyclesPerPhase = 3
+internal const val EnterBackspaceRepeatsPerLeg = 60
+internal const val EnterBackspaceCyclesPerPhase = 3
+internal const val MaximumPublicationStallMillis = 250L
+internal const val CoordinateTolerancePx = 2f
+internal const val PixelBandHeightTolerance = 2
+internal const val ColorChannelTolerance = 2f / 255f
+internal val RepeatStartPhasesMillis = listOf(0L, 16L)
+private const val MaxBoundarySearchSteps = 32
+private const val LongDocumentParagraphCount = 24
+
+private object UnusedGraphIngest : GraphIngest {
+  override fun appendChunk(data: ByteArray) = error("unused")
+
+  override fun totalBytes(): Long = 0L
+
+  override fun abort() = Unit
+
+  override fun finish(viewport: Viewport): FfiEditor = error("unused")
+
+  override fun finishWithPending(pendingEncoded: ByteArray, viewport: Viewport): FfiEditor =
+    error("unused")
+}
+
+private fun emptyPaginatedDocument(): PlainDoc =
+  emptyDocument(
+    LayoutMode.Paginated(
+      pageWidth = PageWidth.toInt(),
+      pageHeight = PageHeight.toInt(),
+      pageMarginTop = PageMargin.toInt(),
+      pageMarginBottom = PageMargin.toInt(),
+      pageMarginLeft = PageMargin.toInt(),
+      pageMarginRight = PageMargin.toInt(),
+    )
+  )
+
+private fun emptyContinuousDocument(): PlainDoc =
+  emptyDocument(LayoutMode.Continuous(maxWidth = PageWidth.toInt()))
+
+private fun emptyDocument(layoutMode: LayoutMode): PlainDoc =
+  PlainDoc(
+    root =
+      PlainNodeEntry(
+        node = PlainNode.Root(layoutMode),
+        modifiers =
+          mapOf(
+            ModifierType.FontFamily to EditorModifier.FontFamily("Pretendard"),
+            ModifierType.FontSize to EditorModifier.FontSize(1200),
+            ModifierType.FontWeight to EditorModifier.FontWeight(400),
+            ModifierType.TextColor to EditorModifier.TextColor("black"),
+            ModifierType.BackgroundColor to EditorModifier.BackgroundColor("none"),
+            ModifierType.LetterSpacing to EditorModifier.LetterSpacing(0),
+            ModifierType.LineHeight to EditorModifier.LineHeight(160),
+            ModifierType.ParagraphIndent to EditorModifier.ParagraphIndent(100),
+            ModifierType.BlockGap to EditorModifier.BlockGap(100),
+          ),
+        children =
+          listOf(
+            PlainNodeEntry(
+              node = PlainNode.Paragraph,
+              modifiers = emptyMap(),
+              children =
+                listOf(
+                  PlainNodeEntry(
+                    node = PlainNode.Text(""),
+                    modifiers = emptyMap(),
+                    children = emptyList(),
+                  )
+                ),
+            )
+          ),
+      )
+  )
+
+private fun configureRenderBufferLibrary() {
+  if (System.getProperty("jna.library.path") != null) return
+
+  val repository =
+    generateSequence(File(System.getProperty("user.dir"))) { it.parentFile }
+      .firstOrNull { File(it, "Cargo.toml").isFile } ?: error("Typie repository root not found")
+  val host =
+    when (System.getProperty("os.arch")) {
+      "aarch64" -> "aarch64-apple-darwin"
+      "x86_64" -> "x86_64-apple-darwin"
+      else -> error("Unsupported desktop test architecture: ${System.getProperty("os.arch")}")
+    }
+  val directory = File(repository, "target/$host/release-uniffi")
+  check(File(directory, "libeditor_ffi.dylib").isFile) {
+    "Desktop editor FFI is not built; run `just -f crates/editor-ffi/justfile desktop`"
+  }
+  System.setProperty("jna.library.path", directory.absolutePath)
+}

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/EditorFrameSyncDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/EditorFrameSyncDesktopTest.kt
@@ -1,0 +1,969 @@
+package co.typie.editor
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.rememberScrollable2DState
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asSkiaBitmap
+import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.input.key.Key as ComposeKey
+import androidx.compose.ui.platform.InterceptPlatformTextInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.PlatformTextInputMethodRequest
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import co.typie.editor.body.EditorBody
+import co.typie.editor.body.resolveEditorBodyGeometry
+import co.typie.editor.body.resolvePageContentTop
+import co.typie.editor.ffi.Key
+import co.typie.editor.ffi.KeyEvent
+import co.typie.editor.ffi.Message
+import co.typie.editor.ffi.SelectionOp
+import co.typie.editor.interaction.EditorInteractionScope
+import co.typie.editor.interaction.LocalEditorInteractionScope
+import co.typie.editor.runtime.LocalEditorRuntime
+import co.typie.editor.runtime.LocalEditorUiState
+import co.typie.editor.scroll.EditorBringIntoViewTarget
+import co.typie.editor.scroll.EditorScrollIntentResult
+import co.typie.editor.scroll.LocalEditorBringIntoViewRequests
+import co.typie.editor.scroll.resolveEditorScrollIntent
+import co.typie.editor.scroll.updateNowWithBringIntoView
+import co.typie.editor.scroll.updateWithBringIntoView
+import co.typie.ext.ScrollGestureLockState
+import co.typie.screen.editor.editor.layout.EditorScreenLayout
+import co.typie.screen.editor.editor.layout.EditorViewportScrollReconcileMode
+import co.typie.screen.editor.editor.state.EditorScreenState
+import co.typie.ui.theme.LightAppShadows
+import co.typie.ui.theme.LightColors
+import co.typie.ui.theme.LocalAppColors
+import co.typie.ui.theme.LocalAppShadows
+import co.typie.ui.theme.LocalThemeMode
+import co.typie.ui.theme.ResolvedThemeMode
+import java.io.File
+import kotlin.math.abs
+import kotlin.math.roundToInt
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.launch
+import org.jetbrains.skia.EncodedImageFormat
+import org.jetbrains.skia.Image
+
+@OptIn(ExperimentalComposeUiApi::class, ExperimentalTestApi::class)
+class EditorFrameSyncDesktopTest {
+  @Test
+  fun frameJournalRejectsTextEditWithoutCursorNativeFrame() {
+    val sample =
+      matchingDesktopFrameSample(repeatKey = RepeatKey.Enter, cursorNativeFrameRevision = null)
+
+    assertTrue(sample.hasPresentationMismatch())
+  }
+
+  @Test
+  fun frameJournalAllowsNavigationWithoutCursorNativeFrameWhenOverlaysStayAligned() {
+    val sample = matchingDesktopFrameSample(cursorNativeFrameRevision = null)
+
+    assertFalse(sample.hasPresentationMismatch())
+  }
+
+  @Test
+  fun frameJournalRejectsTextEditWithStaleCursorNativeFrame() {
+    val sample =
+      matchingDesktopFrameSample(
+        repeatKey = RepeatKey.Enter,
+        revision = 2L,
+        cursorNativeFrameRevision = 1L,
+      )
+
+    assertTrue(sample.hasPresentationMismatch())
+  }
+
+  @Test
+  fun frameJournalAllowsFiveConsecutiveFramesWithoutPublication() {
+    val revisions = listOf(1L, 1L, 1L, 1L, 1L, 2L, 3L, 4L)
+    val samples = RepeatStartPhasesMillis.flatMap { phaseMillis ->
+      revisions.mapIndexed { displayFrame, revision ->
+        matchingDesktopFrameSample(
+          phaseMillis = phaseMillis,
+          displayFrame = displayFrame,
+          revision = revision,
+        )
+      }
+    }
+
+    assertFrameLiveness(samples)
+  }
+
+  @Test
+  fun frameJournalRejectsNineConsecutiveFramesWithoutPublication() {
+    val revisions = listOf(1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 2L, 3L, 4L)
+    val samples = RepeatStartPhasesMillis.flatMap { phaseMillis ->
+      revisions.mapIndexed { displayFrame, revision ->
+        matchingDesktopFrameSample(
+          phaseMillis = phaseMillis,
+          displayFrame = displayFrame,
+          revision = revision,
+        )
+      }
+    }
+
+    assertFailsWith<AssertionError> { assertFrameLiveness(samples) }
+  }
+
+  @Test
+  fun physicalArrowKeyRepeatKeepsEveryRenderedPresentationTogether() = runComposeUiTest {
+    val fixture = FrameSyncFixture()
+
+    try {
+      setFrameSyncContent(fixture)
+      waitUntil(timeoutMillis = 10_000) {
+        fixture.editor.publishedBundle?.frames?.isNotEmpty() == true
+      }
+      fixture.prepareLongDocument(this)
+      fixture.editor.focus()
+      waitUntil(timeoutMillis = 5_000) { fixture.uiState.focused }
+      waitForIdle()
+
+      mainClock.autoAdvance = false
+      val journal = DesktopFrameJournal()
+      var displayFrame = 0
+      for ((phaseIndex, phaseMillis) in RepeatStartPhasesMillis.withIndex()) {
+        val phaseStart = journal.samples.size
+        repeat(RepeatCyclesPerPhase) {
+          repeat(RepeatFramesPerLeg) {
+            journal.record(
+              driveRepeatDisplayFrame(
+                fixture = fixture,
+                repeatKey = RepeatKey.Down,
+                phaseMillis = phaseMillis,
+                displayFrame = displayFrame++,
+              )
+            )
+          }
+          repeat(RepeatFramesPerLeg) {
+            journal.record(
+              driveRepeatDisplayFrame(
+                fixture = fixture,
+                repeatKey = RepeatKey.Up,
+                phaseMillis = phaseMillis,
+                displayFrame = displayFrame++,
+              )
+            )
+          }
+        }
+        journal.record(captureForcedSettleFrame(fixture, phaseMillis, displayFrame++))
+
+        val phaseSamples = journal.samples.subList(phaseStart, journal.samples.size)
+        assertTrue(
+          phaseSamples.any { it.presentation.scrollY > CoordinateTolerancePx },
+          "TEST HARNESS: phase ${phaseMillis}ms never scrolled the long document",
+        )
+        if (phaseIndex < RepeatStartPhasesMillis.lastIndex) {
+          fixture.resetLongDocumentStart(this)
+        }
+      }
+
+      assertFrameLiveness(journal.samples)
+    } finally {
+      mainClock.autoAdvance = true
+      fixture.continuationScheduler.runCurrent()
+      fixture.close()
+    }
+  }
+
+  @Test
+  fun physicalEnterAndBackspaceRepeatKeepsEveryRenderedPresentationTogether() = runComposeUiTest {
+    val fixture = FrameSyncFixture(continuous = true)
+
+    try {
+      setFrameSyncContent(fixture)
+      waitUntil(timeoutMillis = 10_000) {
+        fixture.editor.publishedBundle?.frames?.isNotEmpty() == true
+      }
+      fixture.editor.focus()
+      waitUntil(timeoutMillis = 5_000) { fixture.uiState.focused }
+      waitForIdle()
+
+      mainClock.autoAdvance = false
+      val journal = DesktopFrameJournal()
+      var displayFrame = 0
+      for (phaseMillis in RepeatStartPhasesMillis) {
+        val phaseStart = journal.samples.size
+        repeat(EnterBackspaceCyclesPerPhase) {
+          repeat(EnterBackspaceRepeatsPerLeg) {
+            journal.record(
+              driveRepeatDisplayFrame(
+                fixture = fixture,
+                repeatKey = RepeatKey.Enter,
+                phaseMillis = phaseMillis,
+                displayFrame = displayFrame++,
+              )
+            )
+          }
+          repeat(EnterBackspaceRepeatsPerLeg) {
+            journal.record(
+              driveRepeatDisplayFrame(
+                fixture = fixture,
+                repeatKey = RepeatKey.Backspace,
+                phaseMillis = phaseMillis,
+                displayFrame = displayFrame++,
+              )
+            )
+          }
+        }
+        journal.record(captureForcedSettleFrame(fixture, phaseMillis, displayFrame++))
+
+        val phaseSamples = journal.samples.subList(phaseStart, journal.samples.size)
+        assertTrue(
+          phaseSamples
+            .map { sample -> sample.presentation.snapshot.pageSizes.sumOf { it.height.toDouble() } }
+            .distinct()
+            .size > 1,
+          "TEST HARNESS: phase ${phaseMillis}ms never changed the continuous scroll extent",
+        )
+      }
+
+      assertFrameLiveness(journal.samples)
+    } finally {
+      mainClock.autoAdvance = true
+      fixture.continuationScheduler.runCurrent()
+      fixture.close()
+    }
+  }
+
+  @Test
+  fun commandDocumentNavigationRevealsThePublishedCursor() = runComposeUiTest {
+    val fixture = FrameSyncFixture()
+
+    try {
+      setFrameSyncContent(fixture)
+      waitUntil(timeoutMillis = 10_000) {
+        fixture.editor.publishedBundle?.frames?.isNotEmpty() == true
+      }
+      fixture.moveToTwoPageEnd(this)
+      fixture.editor.updateNow {
+        enqueue(Message.Selection(SelectionOp.SetAt(page = 0, x = PageMargin, y = PageMargin)))
+      }
+      fixture.viewportState.scrollToY(0f, isAutoScroll = false)
+      fixture.editor.focus()
+      waitUntil(timeoutMillis = 5_000) { fixture.uiState.focused }
+      waitForIdle()
+
+      val beforeDown = fixture.viewportState.scrollOffset.y
+      onNodeWithTag(RootTag).performKeyInput {
+        keyDown(ComposeKey.MetaLeft)
+        keyDown(ComposeKey.DirectionDown)
+        keyUp(ComposeKey.DirectionDown)
+        keyUp(ComposeKey.MetaLeft)
+      }
+      fixture.continuationScheduler.runCurrent()
+      waitUntil(timeoutMillis = 10_000) { fixture.editor.publishedState.cursor?.pageIdx == 1 }
+      waitForIdle()
+      val downState = fixture.editor.publishedState
+      val expectedDown =
+        assertNotNull(
+          resolveEditorScrollIntent(
+            frame = fixture.scrollFrame(downState),
+            target = EditorBringIntoViewTarget.CurrentSelectionHead,
+            currentScroll = beforeDown,
+          )
+            as? EditorScrollIntentResult.ScrollTo,
+          "Cmd+Down did not require a viewport reveal",
+        )
+      assertTrue(
+        abs(fixture.viewportState.scrollOffset.y - expectedDown.y) <= 0.5f,
+        "Cmd+Down published cursor=${downState.cursor} at ${downState.version}, " +
+          "but viewport=${fixture.viewportState.scrollOffset.y} expected=${expectedDown.y}",
+      )
+
+      val beforeUp = fixture.viewportState.scrollOffset.y
+      onNodeWithTag(RootTag).performKeyInput {
+        keyDown(ComposeKey.MetaLeft)
+        keyDown(ComposeKey.DirectionUp)
+        keyUp(ComposeKey.DirectionUp)
+        keyUp(ComposeKey.MetaLeft)
+      }
+      fixture.continuationScheduler.runCurrent()
+      waitUntil(timeoutMillis = 10_000) { fixture.editor.publishedState.cursor?.pageIdx == 0 }
+      waitForIdle()
+      val upState = fixture.editor.publishedState
+      val expectedUp =
+        assertNotNull(
+          resolveEditorScrollIntent(
+            frame = fixture.scrollFrame(upState),
+            target = EditorBringIntoViewTarget.CurrentSelectionHead,
+            currentScroll = beforeUp,
+          )
+            as? EditorScrollIntentResult.ScrollTo,
+          "Cmd+Up did not require a viewport reveal",
+        )
+      assertTrue(
+        abs(fixture.viewportState.scrollOffset.y - expectedUp.y) <= 0.5f,
+        "Cmd+Up published cursor=${upState.cursor} at ${upState.version}, " +
+          "but viewport=${fixture.viewportState.scrollOffset.y} expected=${expectedUp.y}",
+      )
+    } finally {
+      fixture.continuationScheduler.runCurrent()
+      fixture.close()
+    }
+  }
+
+  @Test
+  fun enterAcrossPageBoundaryPublishesPixelsAndRevealInOnePresentation() = runComposeUiTest {
+    val fixture = FrameSyncFixture()
+    var inputRequest: PlatformTextInputMethodRequest? = null
+
+    try {
+      setFrameSyncContent(fixture) { inputRequest = it }
+      waitUntil(timeoutMillis = 10_000) {
+        fixture.editor.publishedBundle?.frames?.isNotEmpty() == true
+      }
+
+      fixture.editor.focus()
+      waitUntil(timeoutMillis = 5_000) { fixture.uiState.focused && inputRequest != null }
+      fixture.moveToLastOnePageState(this)
+
+      mainClock.autoAdvance = false
+      val beforeRevision = assertNotNull(fixture.editor.publishedRevision)
+      val beforeScroll = fixture.viewportState.scrollOffset.y
+      val updateJob =
+        fixture.scope.launch {
+          fixture.editor.updateWithBringIntoView(fixture.bringIntoViewRequests) {
+            enqueue(Message.Key(KeyEvent(Key.Enter)))
+            bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+          }
+        }
+      fixture.continuationScheduler.runCurrent()
+
+      waitUntil(timeoutMillis = 10_000) {
+        (fixture.editor.publishedRevision ?: beforeRevision) > beforeRevision
+      }
+      val bundle = assertNotNull(fixture.editor.publishedBundle)
+      val cursor = assertNotNull(bundle.snapshot.cursor)
+      val cursorFrameInFirstPresentation = bundle.frames[cursor.pageIdx]
+
+      mainClock.advanceTimeByFrame()
+      waitForIdle()
+      waitUntil(timeoutMillis = 10_000) {
+        fixture.editor.publishedBundle?.frames?.get(cursor.pageIdx) != null
+      }
+      val materializedBundle = assertNotNull(fixture.editor.publishedBundle)
+      val materializedCursorFrame =
+        assertNotNull(
+          materializedBundle.frames[cursor.pageIdx],
+          "STOP: cursor page ${cursor.pageIdx} is not materialized by the current policy",
+        )
+      assertEquals(
+        materializedBundle.snapshot.version,
+        materializedCursorFrame.proof.editorRevision,
+      )
+
+      val cursorRectInRoot = assertNotNull(fixture.uiState.cursorRectInRoot(cursor))
+      val observedInputRequest = assertNotNull(inputRequest)
+      assertEquals(cursorRectInRoot, observedInputRequest.focusedRectInRoot())
+      val scrollFrame = fixture.scrollFrame(bundle.snapshot)
+      val expectedScroll =
+        assertNotNull(
+          resolveEditorScrollIntent(
+            frame = scrollFrame,
+            target = EditorBringIntoViewTarget.CurrentSelectionHead,
+            currentScroll = beforeScroll,
+          )
+            as? EditorScrollIntentResult.ScrollTo,
+          "page-boundary Enter did not require a viewport reveal",
+        )
+      assertNotNull(
+        cursorFrameInFirstPresentation,
+        "published snapshot ${bundle.snapshot.version} exposed cursor page ${cursor.pageIdx} " +
+          "before that page's native frame was present; the page was materialized afterward " +
+          "with frame ${materializedCursorFrame.proof.editorRevision}",
+      )
+      assertTrue(
+        abs(fixture.viewportState.scrollOffset.y - expectedScroll.y) <= 0.5f,
+        "published=${bundle.snapshot.version} frame=${materializedCursorFrame.proof.editorRevision} " +
+          "page=${cursor.pageIdx} beforeScroll=$beforeScroll " +
+          "actualScroll=${fixture.viewportState.scrollOffset.y} expectedScroll=${expectedScroll.y} " +
+          "cursorRect=$cursorRectInRoot imeRect=${observedInputRequest.focusedRectInRoot()}",
+      )
+
+      fixture.continuationScheduler.runCurrent()
+      updateJob.join()
+      mainClock.autoAdvance = true
+
+      repeat(3) { cycle ->
+        val backspace =
+          assertNotNull(
+            fixture.editor.updateNowWithBringIntoView(fixture.bringIntoViewRequests) {
+              enqueue(Message.Key(KeyEvent(Key.Backspace)))
+              bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+            }
+          )
+        assertEquals(
+          1,
+          backspace.snapshot.pageSizes.size,
+          "cycle $cycle Backspace did not cross 2→1: " +
+            "applied=${backspace.snapshot.pageSizes} cursor=${backspace.snapshot.cursor}",
+        )
+        val shrinking = assertNotNull(fixture.editor.publishedBundle)
+        if (shrinking.snapshot.version >= backspace.revision) {
+          assertEquals(1, shrinking.snapshot.pageSizes.size)
+          assertEquals(0, assertNotNull(shrinking.snapshot.cursor).pageIdx)
+          assertNotNull(
+            shrinking.frames[0],
+            "cycle $cycle published 2→1 geometry without page 0's native frame",
+          )
+        }
+        waitForIdle()
+        waitUntil(timeoutMillis = 10_000) {
+          (fixture.editor.publishedRevision ?: -1L) >= backspace.revision &&
+            fixture.editor.publishedState.pageSizes.size == 1
+        }
+
+        if (cycle == 0) {
+          val burstEnter =
+            assertNotNull(
+              fixture.editor.updateNowWithBringIntoView(fixture.bringIntoViewRequests) {
+                enqueue(Message.Key(KeyEvent(Key.Enter)))
+                bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+              }
+            )
+          assertEquals(2, burstEnter.snapshot.pageSizes.size)
+          val burstBackspace =
+            assertNotNull(
+              fixture.editor.updateNowWithBringIntoView(fixture.bringIntoViewRequests) {
+                enqueue(Message.Key(KeyEvent(Key.Backspace)))
+                bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+              }
+            )
+          assertEquals(1, burstBackspace.snapshot.pageSizes.size)
+          waitForIdle()
+          waitUntil(timeoutMillis = 10_000) {
+            (fixture.editor.publishedRevision ?: -1L) >= burstBackspace.revision &&
+              fixture.editor.publishedState.pageSizes.size == 1
+          }
+          assertNotNull(fixture.editor.publishedBundle?.frames?.get(0))
+        }
+
+        val enter =
+          assertNotNull(
+            fixture.editor.updateNowWithBringIntoView(fixture.bringIntoViewRequests) {
+              enqueue(Message.Key(KeyEvent(Key.Enter)))
+              bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+            }
+          )
+        val growing = assertNotNull(fixture.editor.publishedBundle)
+        val growingCursor = growing.snapshot.cursor
+        assertTrue(
+          growingCursor?.pageIdx != 1 || growing.frames[1] != null,
+          "cycle $cycle published page 1 cursor geometry without its native frame",
+        )
+        waitForIdle()
+        waitUntil(timeoutMillis = 10_000) {
+          (fixture.editor.publishedRevision ?: -1L) >= enter.revision &&
+            fixture.editor.publishedBundle?.frames?.get(1) != null
+        }
+      }
+
+      val finalBundle = assertNotNull(fixture.editor.publishedBundle)
+      val finalCursor = assertNotNull(finalBundle.snapshot.cursor)
+      assertEquals(
+        finalBundle.snapshot.version,
+        assertNotNull(finalBundle.frames[finalCursor.pageIdx]).proof.editorRevision,
+      )
+      assertEquals(
+        fixture.uiState.cursorRectInRoot(finalCursor),
+        observedInputRequest.focusedRectInRoot(),
+      )
+      assertActualCursorAndLinePixels(fixture, finalCursor)
+    } finally {
+      mainClock.autoAdvance = true
+      fixture.continuationScheduler.runCurrent()
+      fixture.close()
+    }
+  }
+
+  private fun androidx.compose.ui.test.ComposeUiTest.assertActualCursorAndLinePixels(
+    fixture: FrameSyncFixture,
+    cursor: co.typie.editor.ffi.CursorMetrics,
+  ) {
+    val root = onNodeWithTag(RootTag)
+    val rootBounds = root.fetchSemanticsNode().boundsInRoot
+    val pixels = root.captureToImage().toPixelMap()
+    val cursorRect = assertNotNull(fixture.uiState.cursorRectInRoot(cursor))
+    val cursorX = (cursorRect.left - rootBounds.left).roundToInt().coerceIn(0, pixels.width - 1)
+    val cursorY = (cursorRect.center.y - rootBounds.top).roundToInt().coerceIn(0, pixels.height - 1)
+    assertEquals(
+      LightColors.textDefault,
+      pixels[cursorX, cursorY],
+      "actual cursor pixels did not move with the published frame",
+    )
+
+    val pageLeft = cursorRect.left - cursor.caret.x
+    val lineTop = cursorRect.top - (cursor.caret.y - cursor.line.y)
+    val lineX = (pageLeft + 8f - rootBounds.left).roundToInt().coerceIn(0, pixels.width - 1)
+    val lineY =
+      (lineTop + cursor.line.height / 2f - rootBounds.top)
+        .roundToInt()
+        .coerceIn(0, pixels.height - 1)
+    assertNotEquals(
+      LightColors.surfaceDefault,
+      pixels[lineX, lineY],
+      "actual current-line highlight pixels did not move with the published frame",
+    )
+  }
+
+  private fun androidx.compose.ui.test.ComposeUiTest.pressPhysicalKeyWithoutPresentationWait(
+    key: ComposeKey,
+    phaseMillis: Long,
+  ) {
+    onNodeWithTag(RootTag).performKeyInput {
+      if (phaseMillis > 0L) advanceEventTime(phaseMillis)
+      keyDown(key)
+      keyUp(key)
+      val trailingMillis = RepeatIntervalMillis - phaseMillis
+      if (trailingMillis > 0L) advanceEventTime(trailingMillis)
+    }
+  }
+
+  private fun androidx.compose.ui.test.ComposeUiTest.driveRepeatDisplayFrame(
+    fixture: FrameSyncFixture,
+    repeatKey: RepeatKey,
+    phaseMillis: Long,
+    displayFrame: Int,
+  ): CapturedDesktopFrame {
+    val beforeDraw = fixture.latestDrawSequence()
+    pressPhysicalKeyWithoutPresentationWait(repeatKey.key, phaseMillis)
+    fixture.continuationScheduler.runCurrent()
+    fixture.forceNextDraw()
+    mainClock.advanceTimeByFrame()
+    waitForIdle()
+    return captureDesktopFrameSample(
+      fixture = fixture,
+      beforeDraw = beforeDraw,
+      phaseMillis = phaseMillis,
+      displayFrame = displayFrame,
+      repeatKey = repeatKey,
+    )
+  }
+
+  private fun androidx.compose.ui.test.ComposeUiTest.captureForcedSettleFrame(
+    fixture: FrameSyncFixture,
+    phaseMillis: Long,
+    displayFrame: Int,
+  ): CapturedDesktopFrame {
+    val beforeDraw = fixture.latestDrawSequence()
+    fixture.forceNextDraw()
+    mainClock.advanceTimeByFrame()
+    waitForIdle()
+    return captureDesktopFrameSample(
+      fixture = fixture,
+      beforeDraw = beforeDraw,
+      phaseMillis = phaseMillis,
+      displayFrame = displayFrame,
+      repeatKey = null,
+    )
+  }
+
+  private fun androidx.compose.ui.test.ComposeUiTest.captureDesktopFrameSample(
+    fixture: FrameSyncFixture,
+    beforeDraw: Long,
+    phaseMillis: Long,
+    displayFrame: Int,
+    repeatKey: RepeatKey?,
+  ): CapturedDesktopFrame {
+    val root = onNodeWithTag(RootTag)
+    val draws = fixture.drawsAfter(beforeDraw)
+    assertTrue(
+      draws.isNotEmpty(),
+      "TEST HARNESS: phase=${phaseMillis}ms displayFrame=$displayFrame had no root draw " +
+        "after sequence $beforeDraw",
+    )
+    val presentation = draws.last()
+    val rootBounds = root.fetchSemanticsNode().boundsInRoot
+    val image = root.captureToImage()
+    val captureDraws = fixture.drawsAfter(presentation.sequence)
+    assertTrue(
+      captureDraws.isEmpty(),
+      "TEST HARNESS: captureToImage produced extra root draws after ${presentation.sequence}: " +
+        captureDraws.map(DrawnPresentation::sequence),
+    )
+
+    val cursor = assertNotNull(presentation.snapshot.cursor)
+    val bodyTop =
+      resolveEditorBodyGeometry(
+          visibleArea = fixture.visibleArea,
+          layoutSpec = fixture.layoutSpec,
+          pageSizes = presentation.snapshot.pageSizes,
+        )
+        .topSpacerHeight
+    val pageTop =
+      assertNotNull(
+        fixture.layoutSpec.resolvePageContentTop(
+          page = cursor.pageIdx,
+          pageSizes = presentation.snapshot.pageSizes,
+          displayZoom = 1f,
+          density = 1f,
+        )
+      )
+    val cursorDocumentY = bodyTop + pageTop + cursor.caret.y
+    val highlightDocumentY = bodyTop + pageTop + cursor.line.y
+    val expectedCursorY = rootBounds.top + cursorDocumentY - presentation.scrollY
+    val expectedHighlightY = rootBounds.top + highlightDocumentY - presentation.scrollY
+    val pixels = image.toPixelMap()
+    val pageLeft = (pixels.width - presentation.snapshot.pageSizes[cursor.pageIdx].width) / 2f
+    val cursorX =
+      (pageLeft + cursor.caret.x + cursor.caret.width / 2f)
+        .roundToInt()
+        .coerceIn(0, pixels.width - 1)
+    val highlightX = (pageLeft + HighlightSampleInset).roundToInt().coerceIn(0, pixels.width - 1)
+    val actualCursorY =
+      ((cursorX - CursorScanRadius).coerceAtLeast(0)..(cursorX + CursorScanRadius).coerceAtMost(
+            pixels.width - 1
+          ))
+        .mapNotNull { x ->
+          findMatchingVerticalBandTop(
+            imageHeight = pixels.height,
+            expectedTop = expectedCursorY - rootBounds.top,
+            expectedHeight = null,
+          ) { y ->
+            colorsApproximatelyEqual(pixels[x, y], LightColors.textDefault)
+          }
+        }
+        .minByOrNull { top -> abs(top - (expectedCursorY - rootBounds.top)) }
+        ?.plus(rootBounds.top)
+    val highlightColor =
+      LightColors.surfaceInverse.copy(alpha = 0.04f).compositeOver(LightColors.surfaceDefault)
+    val actualHighlightY =
+      findMatchingVerticalBandTop(
+          imageHeight = pixels.height,
+          expectedTop = expectedHighlightY - rootBounds.top,
+          expectedHeight = cursor.line.height,
+        ) { y ->
+          colorsApproximatelyEqual(pixels[highlightX, y], highlightColor)
+        }
+        ?.plus(rootBounds.top)
+
+    return CapturedDesktopFrame(
+      sample =
+        DesktopFrameSample(
+          phaseMillis = phaseMillis,
+          displayFrame = displayFrame,
+          repeatKey = repeatKey,
+          presentation = presentation,
+          drawPassCount = draws.size,
+          cursorDocumentY = cursorDocumentY,
+          highlightDocumentY = highlightDocumentY,
+          expectedCursorY = expectedCursorY,
+          actualCursorY = actualCursorY,
+          expectedHighlightY = expectedHighlightY,
+          actualHighlightY = actualHighlightY,
+        ),
+      image = image,
+    )
+  }
+
+  private fun findMatchingVerticalBandTop(
+    imageHeight: Int,
+    expectedTop: Float,
+    expectedHeight: Float?,
+    matches: (Int) -> Boolean,
+  ): Float? {
+    val runs = mutableListOf<IntRange>()
+    var runStart: Int? = null
+    for (y in 0 until imageHeight) {
+      if (matches(y)) {
+        if (runStart == null) runStart = y
+      } else if (runStart != null) {
+        runs += runStart..(y - 1)
+        runStart = null
+      }
+    }
+    if (runStart != null) runs += runStart..(imageHeight - 1)
+
+    return runs
+      .filter { run ->
+        expectedHeight == null ||
+          abs(run.count() - expectedHeight.roundToInt().coerceAtLeast(1)) <=
+            PixelBandHeightTolerance
+      }
+      .minByOrNull { run -> abs(run.first - expectedTop) }
+      ?.first
+      ?.toFloat()
+  }
+
+  private fun colorsApproximatelyEqual(actual: Color, expected: Color): Boolean =
+    abs(actual.red - expected.red) <= ColorChannelTolerance &&
+      abs(actual.green - expected.green) <= ColorChannelTolerance &&
+      abs(actual.blue - expected.blue) <= ColorChannelTolerance &&
+      abs(actual.alpha - expected.alpha) <= ColorChannelTolerance
+
+  private fun matchingDesktopFrameSample(
+    phaseMillis: Long = 0L,
+    displayFrame: Int = 0,
+    repeatKey: RepeatKey = RepeatKey.Down,
+    revision: Long = 1L,
+    cursorNativeFrameRevision: Long? = revision,
+  ): DesktopFrameSample =
+    DesktopFrameSample(
+      phaseMillis = phaseMillis,
+      displayFrame = displayFrame,
+      repeatKey = repeatKey,
+      presentation =
+        DrawnPresentation(
+          sequence = displayFrame.toLong(),
+          snapshot = EditorState.Initial.copy(version = revision),
+          scrollY = 0f,
+          cursorNativeFrameRevision = cursorNativeFrameRevision,
+          editorBoundsY = 0f,
+          cursorPageOffsetY = 0f,
+          testDrawTick = displayFrame,
+        ),
+      drawPassCount = 1,
+      cursorDocumentY = 0f,
+      highlightDocumentY = 0f,
+      expectedCursorY = 0f,
+      actualCursorY = 0f,
+      expectedHighlightY = 0f,
+      actualHighlightY = 0f,
+    )
+
+  private inner class DesktopFrameJournal {
+    val samples = mutableListOf<DesktopFrameSample>()
+    private var previous: CapturedDesktopFrame? = null
+
+    fun record(frame: CapturedDesktopFrame) {
+      val sample = frame.sample
+      if (sample.hasPresentationMismatch()) {
+        val artifactDirectory = writeDesktopFailureArtifacts(listOfNotNull(previous, frame))
+        error(
+          "Key-repeat presentation mismatch; artifacts=${artifactDirectory.absolutePath}\n" +
+            formatDesktopFrameSample(sample, previous?.sample)
+        )
+      }
+      samples += sample
+      previous = frame
+    }
+  }
+
+  private fun DesktopFrameSample.hasPresentationMismatch(): Boolean {
+    val nativeFrameMismatch =
+      when (repeatKey) {
+        RepeatKey.Enter,
+        RepeatKey.Backspace ->
+          presentation.cursorNativeFrameRevision != presentation.snapshot.version
+        RepeatKey.Down,
+        RepeatKey.Up,
+        null -> false
+      }
+    return nativeFrameMismatch ||
+      actualCursorY == null ||
+      abs(actualCursorY - expectedCursorY) > CoordinateTolerancePx ||
+      actualHighlightY == null ||
+      abs(actualHighlightY - expectedHighlightY) > CoordinateTolerancePx
+  }
+
+  private fun assertFrameLiveness(samples: List<DesktopFrameSample>) {
+    for (phaseMillis in RepeatStartPhasesMillis) {
+      val active = samples.filter { it.phaseMillis == phaseMillis && it.repeatKey != null }
+      var previousRevision: Long? = null
+      var sameRevisionFrames = 0
+      var maximumSameRevisionFrames = 0
+      for (sample in active) {
+        val revision = sample.presentation.snapshot.version
+        sameRevisionFrames = if (revision == previousRevision) sameRevisionFrames + 1 else 1
+        previousRevision = revision
+        maximumSameRevisionFrames = maxOf(maximumSameRevisionFrames, sameRevisionFrames)
+      }
+      val maximumPublicationStallMillis =
+        (maximumSameRevisionFrames - 1).coerceAtLeast(0) * RepeatIntervalMillis
+      assertTrue(
+        maximumPublicationStallMillis <= MaximumPublicationStallMillis,
+        "Key-repeat publication stalled at phase ${phaseMillis}ms: " +
+          "maximumPublicationStallMillis=$maximumPublicationStallMillis " +
+          "revisions=${active.map { it.presentation.snapshot.version }}",
+      )
+    }
+  }
+
+  private fun writeDesktopFailureArtifacts(frames: List<CapturedDesktopFrame>): File {
+    val directory =
+      File(
+          System.getProperty("java.io.tmpdir"),
+          "typie-editor-frame-sync/${System.currentTimeMillis()}-${System.nanoTime()}",
+        )
+        .apply { mkdirs() }
+    File(directory, "journal.txt")
+      .writeText(
+        frames
+          .mapIndexed { index, frame ->
+            formatDesktopFrameSample(frame.sample, frames.getOrNull(index - 1)?.sample)
+          }
+          .joinToString(separator = "\n\n")
+      )
+    for ((sample, image) in frames) {
+      val bytes =
+        Image.makeFromBitmap(image.asSkiaBitmap()).encodeToData(EncodedImageFormat.PNG)?.bytes
+          ?: error("Could not encode frame PNG")
+      File(directory, "frame-${sample.displayFrame}.png").writeBytes(bytes)
+    }
+    return directory
+  }
+
+  private fun formatDesktopFrameSample(
+    sample: DesktopFrameSample,
+    previous: DesktopFrameSample?,
+  ): String {
+    val cursor = sample.presentation.snapshot.cursor
+    val cursorDocumentDelta = previous?.let { sample.cursorDocumentY - it.cursorDocumentY }
+    val highlightDocumentDelta = previous?.let { sample.highlightDocumentY - it.highlightDocumentY }
+    val scrollDelta = previous?.let { sample.presentation.scrollY - it.presentation.scrollY }
+    val cursorViewportDelta =
+      previous?.actualCursorY?.let { previousY ->
+        sample.actualCursorY?.let { currentY -> currentY - previousY }
+      }
+    val highlightViewportDelta =
+      previous?.actualHighlightY?.let { previousY ->
+        sample.actualHighlightY?.let { currentY -> currentY - previousY }
+      }
+    return buildString {
+      appendLine(
+        "phase=${sample.phaseMillis}ms displayFrame=${sample.displayFrame} " +
+          "key=${sample.repeatKey} draw=${sample.presentation.sequence} " +
+          "drawPasses=${sample.drawPassCount} revision=${sample.presentation.snapshot.version}"
+      )
+      appendLine(
+        "scrollY=${sample.presentation.scrollY} cursorPage=${cursor?.pageIdx} " +
+          "cursorNativeFrameRevision=${sample.presentation.cursorNativeFrameRevision ?: "missing"}"
+      )
+      appendLine(
+        "editorBoundsY=${sample.presentation.editorBoundsY} " +
+          "cursorPageOffsetY=${sample.presentation.cursorPageOffsetY}"
+      )
+      appendLine(
+        "cursor expected=${sample.expectedCursorY} actual=${sample.actualCursorY} " +
+          "highlight expected=${sample.expectedHighlightY} actual=${sample.actualHighlightY}"
+      )
+      append(
+        "delta cursorDocument=$cursorDocumentDelta highlightDocument=$highlightDocumentDelta " +
+          "scroll=$scrollDelta cursorViewport=$cursorViewportDelta " +
+          "highlightViewport=$highlightViewportDelta"
+      )
+    }
+  }
+
+  private fun androidx.compose.ui.test.ComposeUiTest.setFrameSyncContent(
+    fixture: FrameSyncFixture,
+    onInputRequest: (PlatformTextInputMethodRequest) -> Unit = {},
+  ) {
+    setContent {
+      InterceptPlatformTextInput(
+        interceptor = { request, nextHandler ->
+          onInputRequest(request)
+          nextHandler.startInputMethod(request)
+        }
+      ) {
+        val interactionScope = remember { EditorInteractionScope(fixture.scope) }
+        val scrollGestureLockState = remember { ScrollGestureLockState() }
+        val zoomController = remember { EditorZoomController() }
+        val publishedBundle = fixture.editor.publishedBundle
+        val publishedState = publishedBundle?.snapshot ?: EditorState.Initial
+        val geometry =
+          resolveEditorBodyGeometry(
+            visibleArea = fixture.visibleArea,
+            layoutSpec = fixture.layoutSpec,
+            pageSizes = publishedState.pageSizes,
+          )
+        val forceDrawTick = fixture.forceDrawTick.intValue
+        val scrollFrame = fixture.scrollFrame(publishedState)
+        val viewportScrollableState = rememberScrollable2DState { delta ->
+          val consumed = fixture.viewportState.consumePan(Offset(x = -delta.x, y = -delta.y))
+          Offset(x = -consumed.x, y = -consumed.y)
+        }
+
+        SideEffect {
+          interactionScope.update(
+            editor = fixture.editor,
+            bringIntoViewRequests = fixture.bringIntoViewRequests,
+            uiState = fixture.uiState,
+            visibleArea = fixture.visibleArea,
+            viewportState = fixture.viewportState,
+            density = 1f,
+            scrollGestureLockState = scrollGestureLockState,
+            viewportZoomConfig = null,
+            layoutSpec = fixture.layoutSpec,
+            onSelectionHaptic = {},
+            onRequestSoftwareKeyboard = {},
+          )
+        }
+
+        CompositionLocalProvider(
+          LocalDensity provides Density(1f),
+          LocalAppColors provides LightColors,
+          LocalAppShadows provides LightAppShadows,
+          LocalThemeMode provides ResolvedThemeMode.Light,
+          LocalEditorRuntime provides fixture.runtime,
+          LocalEditorUiState provides fixture.uiState,
+          LocalEditorZoomController provides zoomController,
+          LocalEditorBringIntoViewRequests provides fixture.bringIntoViewRequests,
+          LocalEditorInteractionScope provides interactionScope,
+        ) {
+          EditorScreenLayout(
+            state = remember { EditorScreenState(fixture.viewportState) },
+            scrollFrame = scrollFrame,
+            visibleArea = fixture.visibleArea,
+            viewportScrollableState = viewportScrollableState,
+            viewportContentWidth = geometry.pageColumnWidth,
+            viewportScrollReconcileMode = EditorViewportScrollReconcileMode.Disabled,
+            onMeasuredViewportSizeChange = {},
+            header = {},
+            body = {
+              EditorBody(
+                load = fixture.load,
+                publishedBundle = publishedBundle,
+                geometry = geometry,
+                layoutSpec = fixture.layoutSpec,
+                autoScrollPolicy = fixture.autoScrollPolicy,
+                editorInputEnabled = true,
+                suppressSoftwareKeyboard = true,
+              )
+            },
+            toolbar = {},
+            modifier =
+              Modifier.size(ViewportWidth.dp, ViewportHeight.dp)
+                .background(LightColors.surfaceDefault)
+                .testTag(RootTag)
+                .drawWithContent {
+                  drawContent()
+                  val cursorPage = publishedState.cursor?.pageIdx
+                  fixture.recordDraw(
+                    snapshot = publishedState,
+                    scrollY = fixture.viewportState.scrollOffset.y,
+                    cursorNativeFrameRevision =
+                      cursorPage?.let { publishedBundle?.frames?.get(it)?.proof?.editorRevision },
+                    testDrawTick = forceDrawTick,
+                  )
+                },
+          )
+        }
+      }
+    }
+  }
+}

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/input/EditorInputEnabledDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/input/EditorInputEnabledDesktopTest.kt
@@ -8,17 +8,20 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performKeyInput
 import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import co.typie.editor.Editor
 import co.typie.editor.FakeFfiEditor
 import co.typie.editor.ffi.Break
 import co.typie.editor.ffi.Direction
+import co.typie.editor.ffi.EditorEvent
 import co.typie.editor.ffi.FlatImeOp
 import co.typie.editor.ffi.Ime
 import co.typie.editor.ffi.ImeRange
@@ -30,6 +33,8 @@ import co.typie.editor.ffi.ModifierOp
 import co.typie.editor.ffi.ModifierType
 import co.typie.editor.ffi.Movement
 import co.typie.editor.ffi.NavigationOp
+import co.typie.editor.ffi.Size as EditorSize
+import co.typie.editor.ffi.StateField
 import co.typie.editor.runtime.EditorUiState
 import co.typie.editor.scroll.LocalEditorBringIntoViewRequests
 import co.typie.editor.scroll.rememberEditorBringIntoViewRequests
@@ -39,6 +44,7 @@ import co.typie.platform.IncomingContentCandidates
 import co.typie.platform.IncomingContentMode
 import co.typie.platform.NoopClipboard
 import co.typie.platform.Platform
+import java.util.concurrent.ConcurrentLinkedQueue
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -48,9 +54,131 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
 
 @OptIn(ExperimentalTestApi::class)
 class EditorInputEnabledDesktopTest {
+  @Test
+  fun later33msKeyRepeatsWaitForTheActiveVisualPublication() = runComposeUiTest {
+    val scheduler = TestCoroutineScheduler()
+    val dispatcher = StandardTestDispatcher(scheduler)
+    var pageHeight = 100f
+    val fake =
+      FakeFfiEditor(
+        onTick = {
+          pageHeight += 10f
+          listOf(
+            EditorEvent.StateChanged(listOf(StateField.PageSizes)),
+            EditorEvent.RenderInvalidated,
+          )
+        },
+        pageSizesProvider = { listOf(EditorSize(width = 100f, height = pageHeight)) },
+      )
+    val scope = CoroutineScope(SupervisorJob() + dispatcher)
+    val editor = Editor(fake, scope, dispatcher)
+    fake.applySnapshot(editor)
+    val session = createTestDocumentEditingSession(editor, scope)
+    val readyFrameKeys = ConcurrentLinkedQueue<Long>()
+    val host = Any()
+    editor.activateVisualHost(host)
+    val surface =
+      editor.attachSurface(
+        page = 0,
+        handle = 1L,
+        width = 100.0,
+        height = pageHeight.toDouble(),
+        scaleFactor = 1.0,
+      ) { frameKey ->
+        readyFrameKeys += frameKey.value
+      }
+
+    fun deliverFrame(revision: Long) {
+      scheduler.runCurrent()
+      val frameKey = checkNotNull(readyFrameKeys.poll())
+      editor.deliverFrame(
+        session = surface,
+        bitmap = ImageBitmap(width = 100, height = 100),
+        pixelSize = IntSize(width = 100, height = 100),
+        editorRevision = revision,
+        frameKey = frameKey,
+      )
+      scheduler.runCurrent()
+    }
+
+    try {
+      deliverFrame(editor.appliedRevision)
+      assertEquals(editor.appliedRevision, editor.publishedRevision)
+
+      setContent {
+        val focusRequester = remember { FocusRequester() }
+        val bringIntoViewRequests = rememberEditorBringIntoViewRequests()
+        Box(
+          Modifier.size(200.dp)
+            .testTag(InputTag)
+            .focusRequester(focusRequester)
+            .editorInput(
+              session = session,
+              uiState = EditorUiState(),
+              platform = Platform.Desktop,
+              bringIntoViewRequests = bringIntoViewRequests,
+              enabled = true,
+              suppressSoftwareKeyboard = true,
+              clipboard = NoopClipboard,
+            )
+            .focusable()
+        )
+        LaunchedEffect(Unit) { focusRequester.requestFocus() }
+      }
+      waitForIdle()
+
+      onNodeWithTag(InputTag).performKeyInput {
+        keyDown(Key.Enter)
+        keyUp(Key.Enter)
+        advanceEventTime(RealisticRepeatIntervalMillis)
+      }
+      waitUntil(timeoutMillis = 5_000) {
+        scheduler.runCurrent()
+        fake.enqueuedRequests.size == 1
+      }
+      val firstRevision = editor.appliedRevision
+      assertTrue(firstRevision > requireNotNull(editor.publishedRevision))
+
+      repeat(3) {
+        onNodeWithTag(InputTag).performKeyInput {
+          keyDown(Key.Enter)
+          keyUp(Key.Enter)
+          advanceEventTime(RealisticRepeatIntervalMillis)
+        }
+      }
+      repeat(5) {
+        waitForIdle()
+        scheduler.runCurrent()
+      }
+
+      assertEquals(
+        firstRevision,
+        editor.appliedRevision,
+        "33ms key repeats overtook an extent-changing frame that had not been published",
+      )
+      assertEquals(1, fake.enqueuedRequests.size)
+
+      deliverFrame(firstRevision)
+      waitUntil(timeoutMillis = 5_000) {
+        scheduler.runCurrent()
+        fake.enqueuedRequests.size == 2
+      }
+      assertEquals(3, fake.enqueuedRequests.last().messages.size)
+
+      deliverFrame(editor.appliedRevision)
+      assertEquals(editor.appliedRevision, editor.publishedRevision)
+    } finally {
+      editor.deactivateVisualHost(host)
+      session.stop()
+      scope.cancel()
+    }
+  }
+
   @Test
   fun navigationAndShortcutsCommitCompositionBeforeDispatch() = runComposeUiTest {
     val composingIme =
@@ -336,5 +464,6 @@ class EditorInputEnabledDesktopTest {
 
   private companion object {
     const val InputTag = "editor-input-disabled"
+    const val RealisticRepeatIntervalMillis = 33L
   }
 }

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -10,7 +10,8 @@
     "lint:eslint": "eslint --max-warnings 0 .",
     "lint:svelte": "svelte-check --fail-on-warnings",
     "start": "node dist/index.js",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:browser": "vitest run --config vitest.browser.config.ts"
   },
   "dependencies": {
     "@hono/node-server": "^2.0.8",
@@ -47,6 +48,7 @@
     "@typie/styled-system": "workspace:*",
     "@typie/tsconfig": "workspace:*",
     "@typie/ui": "workspace:*",
+    "@vitest/browser-playwright": "4.1.10",
     "dayjs": "^1.11.21",
     "es-hangul": "^2.3.8",
     "fake-indexeddb": "^6.2.5",

--- a/apps/website/src/lib/editor-ffi/components/Caret.svelte
+++ b/apps/website/src/lib/editor-ffi/components/Caret.svelte
@@ -59,6 +59,7 @@
     animation: 'blink 1s step-end infinite',
     pointerEvents: 'none',
   })}
+  data-editor-caret
 ></div>
 
 <style>

--- a/apps/website/src/lib/editor-ffi/components/EditorPages.svelte
+++ b/apps/website/src/lib/editor-ffi/components/EditorPages.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import Page from './Page.svelte';
+  import type { Editor } from '../editor.svelte';
+
+  type Props = {
+    editor: Editor;
+  };
+
+  let { editor }: Props = $props();
+
+  const presentedPageCount = $derived(Math.max(editor.pageSizes.length, editor.preparingPage === undefined ? 0 : editor.preparingPage + 1));
+</script>
+
+{#each Array.from({ length: presentedPageCount }, (_value, index) => index) as page (page)}
+  {@const publishedPageCount = editor.pageSizes.length}
+  {@const size = editor.pageSizes[page] ?? editor.appliedSnapshot.pageSizes[page]}
+  {#if size}
+    <Page
+      backingHeight={editor.pageBackingSizes[page]?.height ?? editor.appliedSnapshot.pageBackingSizes[page]?.height ?? size.height}
+      height={size.height}
+      {page}
+      preparing={page >= publishedPageCount}
+      width={size.width}
+    />
+  {/if}
+{/each}

--- a/apps/website/src/lib/editor-ffi/components/LineHighlight.svelte
+++ b/apps/website/src/lib/editor-ffi/components/LineHighlight.svelte
@@ -43,5 +43,6 @@
       zIndex: '[-1]',
       pointerEvents: 'none',
     })}
+    data-editor-line-highlight
   ></div>
 {/if}

--- a/apps/website/src/lib/editor-ffi/components/Page.svelte
+++ b/apps/website/src/lib/editor-ffi/components/Page.svelte
@@ -20,9 +20,10 @@
     width: number;
     height: number;
     backingHeight: number;
+    preparing?: boolean;
   };
 
-  let { page, width, height, backingHeight }: Props = $props();
+  let { page, width, height, backingHeight, preparing = false }: Props = $props();
 
   const ctx = getEditorContext();
   const { editor } = ctx;
@@ -61,7 +62,14 @@
   });
 </script>
 
-<div style:width={`${slotWidth}px`} style:height={`${slotHeight}px`} class={css({ position: 'relative', flexShrink: '0' })}>
+<div
+  style:width={`${slotWidth}px`}
+  style:height={`${slotHeight}px`}
+  style:position={preparing ? 'absolute' : undefined}
+  style:visibility={preparing ? 'hidden' : undefined}
+  style:pointer-events={preparing ? 'none' : undefined}
+  class={css({ position: 'relative', flexShrink: '0' })}
+>
   <div
     style:width={`${cssWidth}px`}
     style:height={`${cssHeight}px`}

--- a/apps/website/src/lib/editor-ffi/components/View.svelte
+++ b/apps/website/src/lib/editor-ffi/components/View.svelte
@@ -26,11 +26,11 @@
   import Caret from './Caret.svelte';
   import ContextMenu from './ContextMenu.svelte';
   import DocumentOverlayLayer from './DocumentOverlayLayer.svelte';
+  import EditorPages from './EditorPages.svelte';
   import { resolveHeaderGeometry } from './header-geometry';
   import Input from './Input.svelte';
   import LineHighlight from './LineHighlight.svelte';
   import LinkTooltip from './LinkTooltip.svelte';
-  import Page from './Page.svelte';
   import PlaceholderOverlay from './PlaceholderOverlay.svelte';
   import RepasteAsText from './RepasteAsText.svelte';
   import Scrollbar from './Scrollbar.svelte';
@@ -349,9 +349,7 @@
           tabindex={0}
           use:touchPanLock={ctx.editor.gesture.panLockActive}
         >
-          {#each ctx.editor.pageSizes as { width, height }, i (i)}
-            <Page backingHeight={ctx.editor.pageBackingSizes[i]?.height ?? height} {height} page={i} {width} />
-          {/each}
+          <EditorPages editor={ctx.editor} />
 
           <DocumentOverlayLayer />
 

--- a/apps/website/src/lib/editor-ffi/editor-frame-sync-test-host.svelte
+++ b/apps/website/src/lib/editor-ffi/editor-frame-sync-test-host.svelte
@@ -1,0 +1,100 @@
+<script lang="ts" module>
+  export type EditorFrameSyncTestHarness = {
+    extensionArea: HTMLDivElement;
+    scrollRoot: HTMLDivElement;
+  };
+</script>
+
+<script lang="ts">
+  import { setupAppContext } from '@typie/ui/context';
+  import { elementScrollViewport } from '@typie/ui/utils';
+  import { onDestroy, untrack } from 'svelte';
+  import Caret from './components/Caret.svelte';
+  import DocumentOverlayLayer from './components/DocumentOverlayLayer.svelte';
+  import EditorPages from './components/EditorPages.svelte';
+  import Input from './components/Input.svelte';
+  import LineHighlight from './components/LineHighlight.svelte';
+  import SelectionHandles from './components/SelectionHandles.svelte';
+  import ViewportOverlay from './components/ViewportOverlay.svelte';
+  import { PAGE_GAP } from './constants';
+  import { setupEditorContext } from './editor.svelte';
+  import { setupEditorScroll } from './scroll.svelte';
+  import type { Editor } from './editor.svelte';
+
+  type Props = {
+    editor: Editor;
+    onReady?: (harness: EditorFrameSyncTestHarness) => void;
+    readOnly?: boolean;
+    typewriterEnabled?: boolean;
+    userId: string;
+  };
+
+  let { editor, onReady, readOnly = false, typewriterEnabled = false, userId }: Props = $props();
+
+  const app = setupAppContext(userId);
+  app.preference.current = { ...app.preference.current, lineHighlightEnabled: true, typewriterEnabled };
+
+  const ctx = setupEditorContext();
+  ctx.editor = editor;
+  setupEditorScroll(ctx);
+
+  let extensionArea = $state<HTMLDivElement>();
+  let scrollRoot = $state<HTMLDivElement>();
+  let ready = false;
+
+  $effect(() => {
+    editor.readOnly = readOnly;
+  });
+
+  $effect(() => editor.activateVisualHost());
+
+  $effect(() => {
+    if (!extensionArea || !scrollRoot || ready) return;
+    const currentExtensionArea = extensionArea;
+    const currentScrollRoot = scrollRoot;
+    ready = true;
+    untrack(() => onReady?.({ extensionArea: currentExtensionArea, scrollRoot: currentScrollRoot }));
+  });
+
+  onDestroy(() => {
+    if (editor.extensionAreaEl === extensionArea) editor.extensionAreaEl = undefined;
+    if (editor.scrollContainerEl === scrollRoot) editor.scrollContainerEl = undefined;
+    if (editor.scrollRootEl === scrollRoot) editor.scrollRootEl = undefined;
+    editor.scrollViewport = undefined;
+  });
+</script>
+
+<div
+  bind:this={scrollRoot}
+  style="position: relative; width: 360px; height: 180px; overflow: auto;"
+  {@attach (el) => {
+    editor.scrollContainerEl = el;
+    editor.scrollViewport = elementScrollViewport(el);
+    editor.scrollRootEl = el;
+  }}
+  data-editor-scroll-root
+>
+  <div
+    bind:this={extensionArea}
+    style:padding-bottom={`${ctx.scroll?.bottomPadding ?? 0}px`}
+    style:row-gap={`${PAGE_GAP}px`}
+    style="position: relative; display: flex; flex-direction: column; align-items: center; min-width: max-content;"
+    {@attach (el) => {
+      editor.extensionAreaEl = el;
+    }}
+    data-editor-extension-area
+  >
+    <EditorPages {editor} />
+
+    <DocumentOverlayLayer />
+    <Caret />
+    <LineHighlight />
+
+    <ViewportOverlay>
+      <Input />
+      {#if editor.readOnly}
+        <SelectionHandles />
+      {/if}
+    </ViewportOverlay>
+  </div>
+</div>

--- a/apps/website/src/lib/editor-ffi/editor-frame-sync.browser.test.ts
+++ b/apps/website/src/lib/editor-ffi/editor-frame-sync.browser.test.ts
@@ -1,0 +1,631 @@
+import '../../app.css';
+
+import { mount, tick, unmount } from 'svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import { PAGE_GAP } from './constants';
+import { Editor } from './editor.svelte';
+import EditorFrameSyncTestHost from './editor-frame-sync-test-host.svelte';
+import { pageRectToClientRect } from './geometry';
+import { computeSelectionHandleVisual } from './gesture.svelte';
+import type { PlainDoc, PlainNode, PlainNodeEntry } from '@typie/editor-ffi/browser';
+import type { EditorFrameSyncTestHarness } from './editor-frame-sync-test-host.svelte';
+
+vi.mock('$env/dynamic/public', () => ({ env: {} }));
+
+const PAGE_WIDTH = 320;
+const PAGE_HEIGHT = 220;
+const PAGE_MARGIN = 24;
+const REPEAT_INTERVAL_MS = 33;
+const REPEAT_START_PHASES_MS = [0, 16] as const;
+const REPEAT_EVENTS_PER_LEG = 16;
+const REPEAT_CYCLES_PER_PHASE = 3;
+const EDIT_REPEAT_EVENTS_PER_LEG = 60;
+const MAXIMUM_DISPLAY_FRAME_GAP_MS = 250;
+const MAXIMUM_PUBLICATION_STALL_MS = 250;
+const COORDINATE_TOLERANCE_PX = 1;
+const PERFORMANCE_PARAGRAPH_COUNT = 300;
+const PERFORMANCE_PARAGRAPH_TEXT = '0123456789'.repeat(10);
+
+type RepeatKey = 'ArrowUp' | 'ArrowDown' | 'Enter' | 'Backspace';
+
+type WebFrameSample = {
+  phaseMs: number;
+  frame: number;
+  capturedAtMs: number;
+  direction: RepeatKey | null;
+  revision: number;
+  cursorPage: number;
+  hasNativeFrame: boolean;
+  scrollTop: number;
+  documentHeight: number;
+  cursorDocumentY: number;
+  highlightDocumentY: number;
+  expectedCursorY: number;
+  actualCursorY: number | null;
+  expectedHighlightY: number;
+  actualHighlightY: number | null;
+  caretOnCursorPage: boolean;
+  highlightOnCursorPage: boolean;
+};
+
+function matchingWebFrameSample(overrides: Partial<WebFrameSample> = {}): WebFrameSample {
+  return {
+    phaseMs: 0,
+    frame: 0,
+    capturedAtMs: 0,
+    direction: 'ArrowDown',
+    revision: 1,
+    cursorPage: 0,
+    hasNativeFrame: true,
+    scrollTop: 0,
+    documentHeight: 100,
+    cursorDocumentY: 10,
+    highlightDocumentY: 8,
+    expectedCursorY: 10,
+    actualCursorY: 10,
+    expectedHighlightY: 8,
+    actualHighlightY: 8,
+    caretOnCursorPage: true,
+    highlightOnCursorPage: true,
+    ...overrides,
+  };
+}
+
+let mounted: Record<string, unknown> | undefined;
+let editor: Editor | undefined;
+
+afterEach(async () => {
+  if (mounted) await unmount(mounted);
+  mounted = undefined;
+  editor?.destroy();
+  editor = undefined;
+  document.body.replaceChildren();
+});
+
+function entry(node: PlainNode, children: PlainNodeEntry[] = [], modifiers: PlainNodeEntry['modifiers'] = {} as never): PlainNodeEntry {
+  return { node, modifiers, carry: [], children };
+}
+
+function doc(text = '', href?: string): PlainDoc {
+  const textChildren = text ? [entry({ type: 'text', text }, [], href ? ({ link: { type: 'link', href } } as never) : ({} as never))] : [];
+  return {
+    root: entry(
+      {
+        type: 'root',
+        layout_mode: {
+          type: 'paginated',
+          page_width: PAGE_WIDTH,
+          page_height: PAGE_HEIGHT,
+          page_margin_top: PAGE_MARGIN,
+          page_margin_bottom: PAGE_MARGIN,
+          page_margin_left: PAGE_MARGIN,
+          page_margin_right: PAGE_MARGIN,
+        },
+      },
+      [entry({ type: 'paragraph' }, textChildren)],
+      {
+        block_gap: { type: 'block_gap', value: 120 },
+        font_size: { type: 'font_size', value: 1600 },
+        line_height: { type: 'line_height', value: 160 },
+      } as never,
+    ),
+  };
+}
+
+function longDoc(): PlainDoc {
+  const document = doc();
+  return {
+    ...document,
+    root: {
+      ...document.root,
+      node: {
+        type: 'root',
+        layout_mode: { type: 'continuous', max_width: PAGE_WIDTH },
+      },
+      children: Array.from({ length: PERFORMANCE_PARAGRAPH_COUNT }, () =>
+        entry({ type: 'paragraph' }, [entry({ type: 'text', text: PERFORMANCE_PARAGRAPH_TEXT })]),
+      ),
+      modifiers: {
+        block_gap: { type: 'block_gap', value: 80 },
+        font_size: { type: 'font_size', value: 1000 },
+        line_height: { type: 'line_height', value: 150 },
+      } as never,
+    },
+  };
+}
+
+async function mountEditor(plain: PlainDoc, options: { readOnly?: boolean; typewriterEnabled?: boolean } = {}) {
+  editor = await Editor.createFromDoc(plain, { width: 360, height: 180, scale_factor: 1 });
+  const target = document.createElement('div');
+  document.body.append(target);
+  const harness = Promise.withResolvers<EditorFrameSyncTestHarness>();
+  mounted = mount(EditorFrameSyncTestHost, {
+    target,
+    props: {
+      editor,
+      onReady: harness.resolve,
+      readOnly: options.readOnly,
+      typewriterEnabled: options.typewriterEnabled,
+      userId: `frame-sync-${crypto.randomUUID()}`,
+    },
+  });
+  const result = await harness.promise;
+  await tick();
+  await vi.waitFor(() => expect(editor?.published?.frames.get(0)).toBeDefined());
+  return { editor, ...result };
+}
+
+function dispatchEditorKey(editor: Editor, key: RepeatKey) {
+  const input = editor.inputEl;
+  if (!input) throw new Error('Production editor input is not mounted');
+  const beforeRevision = editor.appliedRevision;
+  input.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }));
+  if (editor.appliedRevision <= beforeRevision) throw new Error(`Expected ${key} to produce an update`);
+}
+
+async function pressEditorKey(editor: Editor, key: 'Enter' | 'Backspace') {
+  dispatchEditorKey(editor, key);
+  await tick();
+}
+
+function readWebFrameSample(
+  editor: Editor,
+  scrollRoot: HTMLElement,
+  phaseMs: number,
+  frame: number,
+  direction: RepeatKey | null,
+): WebFrameSample {
+  const published = editor.published;
+  const cursor = published?.snapshot.cursor;
+  if (!published || !cursor) throw new Error('Expected a published cursor');
+
+  const zoom = published.snapshot.rootAttrs?.layout_mode.type === 'paginated' ? editor.displayZoom : 1;
+  const pageTop = published.snapshot.pageSizes
+    .slice(0, cursor.page_idx)
+    .reduce((sum, pageSize) => sum + pageSize.height * zoom + PAGE_GAP * zoom, 0);
+  const rootTop = scrollRoot.getBoundingClientRect().top;
+  const scrollTop = scrollRoot.scrollTop;
+  const cursorDocumentY = pageTop + cursor.caret.y * zoom;
+  const highlightDocumentY = pageTop + cursor.line.y * zoom;
+  const caret = document.querySelector<HTMLElement>('[data-editor-caret]');
+  const lineHighlight = document.querySelector<HTMLElement>('[data-editor-line-highlight]');
+  const cursorPage = editor.pageEls[cursor.page_idx];
+
+  return {
+    phaseMs,
+    frame,
+    capturedAtMs: performance.now(),
+    direction,
+    revision: published.snapshot.revision,
+    cursorPage: cursor.page_idx,
+    hasNativeFrame: published.frames.has(cursor.page_idx),
+    scrollTop,
+    documentHeight: published.snapshot.pageSizes.reduce((sum, size) => sum + size.height, 0),
+    cursorDocumentY,
+    highlightDocumentY,
+    expectedCursorY: rootTop + cursorDocumentY - scrollTop,
+    actualCursorY: caret?.getBoundingClientRect().top ?? null,
+    expectedHighlightY: rootTop + highlightDocumentY - scrollTop,
+    actualHighlightY: lineHighlight?.getBoundingClientRect().top ?? null,
+    caretOnCursorPage: caret?.parentElement === cursorPage,
+    highlightOnCursorPage: lineHighlight?.parentElement === cursorPage,
+  };
+}
+
+function nextAnimationFrame(): Promise<number> {
+  return new Promise((resolve) => requestAnimationFrame(resolve));
+}
+
+function delayUntil(deadline: number): Promise<void> {
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, Math.max(0, deadline - performance.now()));
+  });
+}
+
+function describeWebFrameMismatch(sample: WebFrameSample, previous?: WebFrameSample): string | undefined {
+  const nativePresentationMismatch = !sample.hasNativeFrame || !sample.caretOnCursorPage || !sample.highlightOnCursorPage;
+  const cursorMismatch = sample.actualCursorY === null || Math.abs(sample.actualCursorY - sample.expectedCursorY) > COORDINATE_TOLERANCE_PX;
+  const highlightMismatch =
+    sample.actualHighlightY === null || Math.abs(sample.actualHighlightY - sample.expectedHighlightY) > COORDINATE_TOLERANCE_PX;
+  if (!nativePresentationMismatch && !cursorMismatch && !highlightMismatch) return;
+
+  const cursorDocumentDelta = previous ? sample.cursorDocumentY - previous.cursorDocumentY : null;
+  const highlightDocumentDelta = previous ? sample.highlightDocumentY - previous.highlightDocumentY : null;
+  const scrollDelta = previous ? sample.scrollTop - previous.scrollTop : null;
+  const cursorViewportDelta =
+    previous?.actualCursorY !== null && previous?.actualCursorY !== undefined && sample.actualCursorY !== null
+      ? sample.actualCursorY - previous.actualCursorY
+      : null;
+  const highlightViewportDelta =
+    previous?.actualHighlightY !== null && previous?.actualHighlightY !== undefined && sample.actualHighlightY !== null
+      ? sample.actualHighlightY - previous.actualHighlightY
+      : null;
+
+  return [
+    `phase=${sample.phaseMs}ms frame=${sample.frame} direction=${sample.direction} revision=${sample.revision}`,
+    `scrollTop=${sample.scrollTop} cursorPage=${sample.cursorPage} hasNativeFrame=${sample.hasNativeFrame}`,
+    `caretOnCursorPage=${sample.caretOnCursorPage} highlightOnCursorPage=${sample.highlightOnCursorPage}`,
+    `cursor expected=${sample.expectedCursorY} actual=${sample.actualCursorY}`,
+    `highlight expected=${sample.expectedHighlightY} actual=${sample.actualHighlightY}`,
+    `delta cursorDocument=${cursorDocumentDelta} highlightDocument=${highlightDocumentDelta} scroll=${scrollDelta} ` +
+      `cursorViewport=${cursorViewportDelta} highlightViewport=${highlightViewportDelta}`,
+  ].join('\n');
+}
+
+function repeatKeys(first: RepeatKey, second: RepeatKey, eventsPerLeg: number, cycles: number): RepeatKey[] {
+  return Array.from({ length: cycles }).flatMap(() => [
+    ...Array.from({ length: eventsPerLeg }, () => first),
+    ...Array.from({ length: eventsPerLeg }, () => second),
+  ]);
+}
+
+async function driveWebRepeatPhase(
+  editor: Editor,
+  scrollRoot: HTMLElement,
+  phaseMs: number,
+  keys: RepeatKey[],
+  scenario: string,
+): Promise<WebFrameSample[]> {
+  await nextAnimationFrame();
+  const startedAt = performance.now();
+  const samples: WebFrameSample[] = [];
+  let currentKey: RepeatKey | null = null;
+  let done = false;
+  let cancelled = false;
+  let inputError: unknown;
+
+  const input = (async () => {
+    try {
+      for (const [index, key] of keys.entries()) {
+        await delayUntil(startedAt + phaseMs + index * REPEAT_INTERVAL_MS);
+        if (cancelled) break;
+        currentKey = key;
+        dispatchEditorKey(editor, key);
+      }
+    } catch (err) {
+      inputError = err;
+    } finally {
+      done = true;
+    }
+  })();
+
+  let settleFrames = 0;
+  while (!done || settleFrames < 1) {
+    await nextAnimationFrame();
+    const sample = readWebFrameSample(editor, scrollRoot, phaseMs, samples.length, done ? null : currentKey);
+    samples.push(sample);
+    const mismatch = describeWebFrameMismatch(sample, samples.at(-2));
+    if (mismatch) {
+      cancelled = true;
+      const screenshot = await page.screenshot({ element: scrollRoot, save: true });
+      await input;
+      throw new Error(`Web ${scenario} presentation mismatch; screenshot=${screenshot}\n${mismatch}`);
+    }
+    if (done) settleFrames += 1;
+  }
+
+  await input;
+  if (inputError) throw inputError;
+  return samples;
+}
+
+function expectWebFrameLiveness(samples: WebFrameSample[], phaseMs: number) {
+  let lastPublishedRevision = samples[0]?.revision;
+  let lastPublicationAtMs = samples[0]?.capturedAtMs ?? 0;
+
+  for (let index = 1; index < samples.length; index += 1) {
+    const previous = samples[index - 1];
+    const current = samples[index];
+    const displayFrameGapMs = current.capturedAtMs - previous.capturedAtMs;
+    expect(
+      previous.direction === null || displayFrameGapMs <= MAXIMUM_DISPLAY_FRAME_GAP_MS,
+      `Repeated input dropped display frames at phase ${phaseMs}ms: ` +
+        `frames=${previous.frame}→${current.frame} gap=${displayFrameGapMs}ms revision=${current.revision}`,
+    ).toBe(true);
+
+    if (current.revision !== lastPublishedRevision) {
+      lastPublishedRevision = current.revision;
+      lastPublicationAtMs = current.capturedAtMs;
+      continue;
+    }
+    const publicationStallMs = current.capturedAtMs - lastPublicationAtMs;
+    expect(
+      current.direction === null || publicationStallMs <= MAXIMUM_PUBLICATION_STALL_MS,
+      `Repeated input stalled publication at phase ${phaseMs}ms: ` +
+        `revision=${current.revision} stall=${publicationStallMs}ms frame=${current.frame}`,
+    ).toBe(true);
+  }
+}
+
+async function resetWebLongDocumentStart(editor: Editor, scrollRoot: HTMLElement) {
+  editor.updateNow((request) => request.enqueue({ type: 'selection', op: { type: 'set_at', page: 0, x: PAGE_MARGIN, y: PAGE_MARGIN } }));
+  scrollRoot.scrollTop = 0;
+  scrollRoot.dispatchEvent(new Event('scroll'));
+  await waitForPresentation(editor);
+}
+
+async function waitForPresentation(editor: Editor, revision = editor.appliedRevision) {
+  await expect.poll(() => editor.isPublished(revision, { requireFrame: true })).toBe(true);
+  await tick();
+  await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+}
+
+function expectActualCanvas(editor: Editor, pageIndex: number, requirePaintedPixels = true) {
+  const frame = editor.published?.frames.get(pageIndex);
+  const canvas = document.querySelector<HTMLCanvasElement>(`canvas[data-page-canvas="${pageIndex}"]`);
+  expect(frame, `page ${pageIndex} must have a frame in the published bundle`).toBeDefined();
+  expect(canvas, `page ${pageIndex} must have a production Page canvas`).toBe(frame?.canvas);
+  if (requirePaintedPixels) {
+    const pixels = canvas?.getContext('2d')?.getImageData(0, 0, canvas.width, canvas.height).data;
+    expect(pixels && pixels.some((channel) => channel !== 0), `page ${pageIndex} canvas must contain rendered pixels`).toBe(true);
+  }
+}
+
+describe('web editor frame synchronization', () => {
+  it('rejects a presentation without the cursor page native frame', () => {
+    expect(describeWebFrameMismatch(matchingWebFrameSample({ hasNativeFrame: false }))).toBeDefined();
+  });
+
+  it('rejects a repeated-input display frame gap over 250ms', () => {
+    const samples = [
+      matchingWebFrameSample({ frame: 0, revision: 1, capturedAtMs: 0 }),
+      matchingWebFrameSample({ frame: 1, revision: 2, capturedAtMs: 16 }),
+      matchingWebFrameSample({ frame: 2, revision: 3, capturedAtMs: 32 }),
+      matchingWebFrameSample({ frame: 3, revision: 4, capturedAtMs: 400 }),
+    ];
+
+    expect(() => expectWebFrameLiveness(samples, 0)).toThrow();
+  });
+
+  it('keeps repeated ArrowUp/ArrowDown navigation on one actual presentation in a long document', async () => {
+    const { editor, scrollRoot } = await mountEditor(longDoc());
+    editor.updateNow((request) => request.enqueue({ type: 'selection', op: { type: 'set_at', page: 0, x: PAGE_MARGIN, y: PAGE_MARGIN } }));
+    await waitForPresentation(editor);
+    editor.focus();
+    await tick();
+
+    for (const [phaseIndex, phaseMs] of REPEAT_START_PHASES_MS.entries()) {
+      const samples = await driveWebRepeatPhase(
+        editor,
+        scrollRoot,
+        phaseMs,
+        repeatKeys('ArrowDown', 'ArrowUp', REPEAT_EVENTS_PER_LEG, REPEAT_CYCLES_PER_PHASE),
+        'Arrow-repeat',
+      );
+      expectWebFrameLiveness(samples, phaseMs);
+      expect(
+        samples.some((sample) => sample.scrollTop > COORDINATE_TOLERANCE_PX),
+        `TEST HARNESS: phase ${phaseMs}ms never scrolled the long document`,
+      ).toBe(true);
+      if (phaseIndex < REPEAT_START_PHASES_MS.length - 1) {
+        await resetWebLongDocumentStart(editor, scrollRoot);
+      }
+    }
+  });
+
+  it('keeps 33ms Enter/Backspace repeats live in a 30000-character document', async () => {
+    const { editor, scrollRoot } = await mountEditor(longDoc());
+    editor.updateNow((request) => request.enqueue({ type: 'selection', op: { type: 'set_at', page: 0, x: PAGE_MARGIN, y: PAGE_MARGIN } }));
+    await waitForPresentation(editor);
+    editor.focus();
+    await tick();
+
+    for (const [phaseIndex, phaseMs] of REPEAT_START_PHASES_MS.entries()) {
+      const samples = await driveWebRepeatPhase(
+        editor,
+        scrollRoot,
+        phaseMs,
+        repeatKeys('Enter', 'Backspace', EDIT_REPEAT_EVENTS_PER_LEG, 1),
+        'Enter/Backspace repeat',
+      );
+      expectWebFrameLiveness(samples, phaseMs);
+      expect(
+        new Set(samples.map((sample) => sample.documentHeight)).size,
+        `TEST HARNESS: phase ${phaseMs}ms never changed the 30000-character document extent`,
+      ).toBeGreaterThan(1);
+      if (phaseIndex < REPEAT_START_PHASES_MS.length - 1) {
+        await resetWebLongDocumentStart(editor, scrollRoot);
+      }
+    }
+  }, 30_000);
+
+  it('keeps empty-document Enter/Backspace page transitions on one actual presentation', async () => {
+    const { editor, scrollRoot } = await mountEditor(doc());
+    editor.updateNow((request) => request.enqueue({ type: 'selection', op: { type: 'set_at', page: 0, x: PAGE_MARGIN, y: PAGE_MARGIN } }));
+    await waitForPresentation(editor);
+    editor.focus();
+    await tick();
+
+    for (let i = 0; i < 32 && editor.appliedSnapshot.pageSizes.length === 1; i += 1) await pressEditorKey(editor, 'Enter');
+
+    expect(editor.appliedSnapshot.pageSizes).toHaveLength(2);
+    const crossing = editor.published;
+    expect(
+      crossing?.snapshot.cursor?.page_idx !== 1 || crossing?.frames.has(1) === true,
+      `published snapshot ${crossing?.snapshot.revision} exposed cursor page 1 before that page's actual canvas frame was present`,
+    ).toBe(true);
+
+    await waitForPresentation(editor);
+    expect(editor.published?.snapshot.cursor?.page_idx).toBe(1);
+    expectActualCanvas(editor, 1, false);
+    expect(
+      scrollRoot.scrollTop,
+      `scrollTop=${scrollRoot.scrollTop} clientHeight=${scrollRoot.clientHeight} scrollHeight=${scrollRoot.scrollHeight} cursor=${JSON.stringify(editor.published?.snapshot.cursor)}`,
+    ).toBeGreaterThan(0);
+
+    for (let cycle = 0; cycle < 3; cycle += 1) {
+      await pressEditorKey(editor, 'Backspace');
+      expect(editor.appliedSnapshot.pageSizes).toHaveLength(1);
+      const shrinking = editor.published;
+      expect(
+        shrinking?.snapshot.pageSizes.length !== 1 || (shrinking.snapshot.cursor?.page_idx === 0 && shrinking.frames.has(0)),
+        `cycle ${cycle} published the 2→1 geometry without page 0's cursor and actual frame`,
+      ).toBe(true);
+      await waitForPresentation(editor);
+      expect(editor.published?.snapshot.pageSizes).toHaveLength(1);
+      expectActualCanvas(editor, 0, false);
+
+      if (cycle === 0) {
+        dispatchEditorKey(editor, 'Enter');
+        dispatchEditorKey(editor, 'Backspace');
+        expect(editor.appliedSnapshot.pageSizes).toHaveLength(1);
+        await waitForPresentation(editor);
+        expect(editor.published?.snapshot.pageSizes).toHaveLength(1);
+        expectActualCanvas(editor, 0, false);
+      }
+
+      await pressEditorKey(editor, 'Enter');
+      expect(editor.appliedSnapshot.pageSizes).toHaveLength(2);
+      const repeated = editor.published;
+      expect(
+        repeated?.snapshot.cursor?.page_idx !== 1 || repeated?.frames.has(1) === true,
+        `cycle ${cycle} published page 1 geometry without its actual frame`,
+      ).toBe(true);
+      await waitForPresentation(editor);
+      expect(editor.published?.snapshot.pageSizes).toHaveLength(2);
+      expectActualCanvas(editor, 1, false);
+    }
+  });
+
+  it('keeps a hidden preparatory page out of the scroll extent until publication', async () => {
+    const { editor, extensionArea, scrollRoot } = await mountEditor(doc());
+    editor.updateNow((request) => request.enqueue({ type: 'selection', op: { type: 'set_at', page: 0, x: PAGE_MARGIN, y: PAGE_MARGIN } }));
+    await waitForPresentation(editor);
+    editor.focus();
+    await tick();
+
+    const initialScrollHeight = scrollRoot.scrollHeight;
+    const initialExtensionRect = extensionArea.getBoundingClientRect();
+    const initialPageRect = editor.pageEls[0]?.getBoundingClientRect();
+    expect(initialPageRect).toBeDefined();
+    if (!initialPageRect) throw new Error('Expected the initial published page');
+
+    const initialPageTop = initialPageRect.top - initialExtensionRect.top;
+    const attachSurface = editor.attachSurface.bind(editor);
+    const attachSurfaceSpy = vi.spyOn(editor, 'attachSurface').mockImplementation((page, canvas, width, height, replace) => {
+      if (page === 1) return 'none';
+      return attachSurface(page, canvas, width, height, replace);
+    });
+
+    try {
+      for (let i = 0; i < 32 && editor.appliedSnapshot.pageSizes.length === 1; i += 1) await pressEditorKey(editor, 'Enter');
+      expect(editor.appliedSnapshot.pageSizes).toHaveLength(2);
+      await vi.waitFor(() => expect(editor.preparingPage).toBe(1));
+      const stalledPublished = editor.published;
+      expect(stalledPublished?.snapshot.pageSizes).toHaveLength(1);
+      if (!stalledPublished) throw new Error('Expected the previous publication during page preparation');
+      await tick();
+      await nextAnimationFrame();
+
+      const preparatoryPage = editor.pageEls[1]?.parentElement;
+      const currentExtensionRect = extensionArea.getBoundingClientRect();
+      const currentPageRect = editor.pageEls[0]?.getBoundingClientRect();
+      expect(preparatoryPage).toBeDefined();
+      expect(currentPageRect).toBeDefined();
+      if (!currentPageRect) throw new Error('Expected the published page to remain mounted during preparation');
+      expect(editor.published?.snapshot.revision).toBe(stalledPublished.snapshot.revision);
+      expect(scrollRoot.scrollHeight).toBe(initialScrollHeight);
+      expect(currentPageRect.top - currentExtensionRect.top).toBeCloseTo(initialPageTop);
+      expect(currentPageRect.width).toBeCloseTo(initialPageRect.width);
+      expect(currentPageRect.height).toBeCloseTo(initialPageRect.height);
+    } finally {
+      attachSurfaceSpy.mockRestore();
+    }
+
+    window.dispatchEvent(new Event('pageshow'));
+    await waitForPresentation(editor);
+    expect(editor.published?.snapshot.pageSizes).toHaveLength(2);
+    expect(scrollRoot.scrollHeight).toBeGreaterThan(initialScrollHeight);
+  });
+
+  it('keeps canvas, cursor, current line, page overlay, and fixed input on the published geometry', async () => {
+    const href = 'https://example.com/frame-sync';
+    const { editor, scrollRoot } = await mountEditor(doc('linked pixels', href));
+    editor.updateNow((request) => request.enqueue({ type: 'selection', op: { type: 'set_at', page: 0, x: PAGE_MARGIN, y: PAGE_MARGIN } }));
+    await waitForPresentation(editor);
+    editor.focus();
+    await tick();
+
+    expectActualCanvas(editor, 0);
+    const pageElement = editor.pageEls[0];
+    const caret = document.querySelector<HTMLElement>('[data-editor-caret]');
+    const lineHighlight = document.querySelector<HTMLElement>('[data-editor-line-highlight]');
+    const input = editor.inputEl;
+    expect(pageElement).toBeDefined();
+    expect(caret?.parentElement).toBe(pageElement);
+    expect(lineHighlight?.parentElement).toBe(pageElement);
+    await expect.poll(() => pageElement?.querySelector<HTMLAnchorElement>(`a[aria-label="${href}"]`) !== null).toBe(true);
+    const linkOverlay = pageElement?.querySelector<HTMLAnchorElement>(`a[aria-label="${href}"]`);
+    expect(getComputedStyle(caret as HTMLElement).visibility).toBe('visible');
+    expect(getComputedStyle(lineHighlight as HTMLElement).display).toBe('block');
+    const linkRect = editor.pageLinkRects(0).find((link) => link.href === href)?.rects[0];
+    expect(linkRect).toBeDefined();
+    expect(Number.parseFloat(linkOverlay?.style.left ?? '')).toBeCloseTo(linkRect?.x ?? NaN);
+    expect(Number.parseFloat(linkOverlay?.style.top ?? '')).toBeCloseTo(linkRect?.y ?? NaN);
+    expect(linkOverlay?.parentElement).toBe(pageElement);
+
+    const cursor = editor.published?.snapshot.cursor;
+    expect(cursor).toBeDefined();
+    await expect
+      .poll(() => {
+        const current = editor.published?.snapshot.cursor;
+        const expected = current && pageRectToClientRect(editor, { page_idx: current.page_idx, rect: current.caret });
+        return expected && input
+          ? Math.abs(Number.parseFloat(input.style.left) - expected.left) <= 0.5 &&
+              Math.abs(Number.parseFloat(input.style.top) - expected.top) <= 0.5
+          : false;
+      })
+      .toBe(true);
+
+    const screenshot = await page.screenshot({ element: scrollRoot, save: false });
+    expect(screenshot.startsWith('iVBOR')).toBe(true);
+  });
+
+  it('keeps non-vacuous fixed selection handles on the published page and scroll geometry', async () => {
+    const href = 'https://example.com/selection-handles';
+    const { editor, scrollRoot } = await mountEditor(doc('select this link', href), { readOnly: true });
+    editor.updateNow((request) => request.enqueue({ type: 'selection', op: { type: 'set_at', page: 0, x: PAGE_MARGIN, y: PAGE_MARGIN } }));
+    await waitForPresentation(editor);
+    const selection = editor.selection;
+    const span = selection && editor.modifierSpanSelection(selection.head, 'link');
+    expect(span).toBeDefined();
+    if (!span) throw new Error('Expected the linked text to produce an expanded selection');
+    editor.updateNow((request) => request.enqueue({ type: 'selection', op: { type: 'set', selection: span } }));
+    await waitForPresentation(editor);
+
+    scrollRoot.scrollTop = 24;
+    scrollRoot.dispatchEvent(new Event('scroll'));
+    editor.scrollIntoView({ target: { type: 'current_selection_head' }, mode: 'nearest', behavior: 'instant' });
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+    const endpoints = editor.selectionEndpoints();
+    const fromHandle = document.querySelector<HTMLButtonElement>('[data-selection-handle="from"]');
+    const toHandle = document.querySelector<HTMLButtonElement>('[data-selection-handle="to"]');
+    expect(endpoints).toBeDefined();
+    expect(fromHandle).toBeDefined();
+    expect(toHandle).toBeDefined();
+    if (!endpoints || !fromHandle || !toHandle) throw new Error('Expected both production selection handles');
+
+    for (const [kind, endpoint, handle] of [
+      ['from', endpoints.from, fromHandle],
+      ['to', endpoints.to, toHandle],
+    ] as const) {
+      const anchorRect = pageRectToClientRect(editor, endpoint);
+      expect(anchorRect).toBeDefined();
+      if (!anchorRect) throw new Error(`Expected the ${kind} endpoint to resolve to client geometry`);
+      const visual = computeSelectionHandleVisual({ kind, anchorRect });
+      expect(getComputedStyle(handle).position).toBe('fixed');
+      expect(Number.parseFloat(handle.style.left)).toBeCloseTo(visual.left);
+      expect(Number.parseFloat(handle.style.top)).toBeCloseTo(visual.top);
+    }
+  });
+
+  it('keeps cursor-guard bottom padding when typewriter mode is disabled', async () => {
+    const { editor, extensionArea } = await mountEditor(doc(), { typewriterEnabled: false });
+    editor.updateNow((request) => request.enqueue({ type: 'selection', op: { type: 'set_at', page: 0, x: PAGE_MARGIN, y: PAGE_HEIGHT } }));
+    await waitForPresentation(editor);
+
+    expect(Number.parseFloat(extensionArea.style.paddingBottom)).toBeGreaterThanOrEqual(60);
+  });
+});

--- a/apps/website/src/lib/editor-ffi/editor-host-failure.test.ts
+++ b/apps/website/src/lib/editor-ffi/editor-host-failure.test.ts
@@ -200,6 +200,24 @@ describe('Editor guarded core invocation', () => {
     expect(frames).toEqual([]);
   });
 
+  it('retires a scheduled RAF when updateNow drains the queued request prefix', async () => {
+    const { editor, core } = await createEditor();
+    editor.enqueue({ type: 'history', op: { type: 'undo' } });
+    const scheduledFrame = frames.at(-1);
+
+    expect(editor.hasQueuedTick).toBe(true);
+    expect(scheduledFrame).toBeDefined();
+
+    editor.updateNow((request) => request.enqueue({ type: 'history', op: { type: 'undo' } }));
+
+    expect(editor.hasQueuedTick).toBe(false);
+    expect(cancelAnimationFrame).toHaveBeenCalledWith(frames.length);
+    scheduledFrame?.(0);
+    expect(core.tick).not.toHaveBeenCalled();
+
+    editor.destroy();
+  });
+
   it.each([
     [
       'request admission',

--- a/apps/website/src/lib/editor-ffi/editor-publication.test.ts
+++ b/apps/website/src/lib/editor-ffi/editor-publication.test.ts
@@ -81,12 +81,34 @@ describe('editor publication', () => {
   });
 
   it('requests page zero only when a newer applied layout strands a framed publication without targets', () => {
-    expect(preparingPage(true, true, 10, 9, 1, 0)).toBe(0);
-    expect(preparingPage(true, false, 10, 9, 1, 0)).toBeUndefined();
-    expect(preparingPage(true, true, 9, 9, 1, 0)).toBeUndefined();
-    expect(preparingPage(true, true, 10, 9, 0, 0)).toBeUndefined();
-    expect(preparingPage(true, true, 10, 9, 1, 1)).toBeUndefined();
-    expect(preparingPage(false, true, 10, 9, 1, 0)).toBeUndefined();
+    const facts = {
+      hasPublishedFrames: true,
+      appliedRevision: 10,
+      publishedRevision: 9,
+      appliedPageCount: 1,
+      publishedPageCount: 1,
+      targets: new Map<number, PublicationTarget>(),
+    };
+    expect(preparingPage(facts)).toBe(0);
+    expect(preparingPage({ ...facts, hasPublishedFrames: false })).toBeUndefined();
+    expect(preparingPage({ ...facts, appliedRevision: 9 })).toBeUndefined();
+    expect(preparingPage({ ...facts, appliedPageCount: 0 })).toBeUndefined();
+    expect(preparingPage({ ...facts, targets: new Map([[0, {} as PublicationTarget]]) })).toBeUndefined();
+    expect(preparingPage({ ...facts, targets: undefined })).toBeUndefined();
+  });
+
+  it('prepares a newly appended page until its target is attached', () => {
+    const pageZero = new Map([[0, {} as PublicationTarget]]);
+    const facts = {
+      hasPublishedFrames: true,
+      appliedRevision: 10,
+      publishedRevision: 9,
+      appliedPageCount: 2,
+      publishedPageCount: 1,
+      targets: pageZero,
+    };
+    expect(preparingPage(facts)).toBe(1);
+    expect(preparingPage({ ...facts, targets: new Map([...pageZero, [1, {} as PublicationTarget]]) })).toBeUndefined();
   });
 
   it('republishes a replacement target at the same revision but not a no-change reevaluation', () => {

--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -519,11 +519,7 @@ export class Editor {
   }
 
   #stopRuntime(): void {
-    this.#tickScheduled = false;
-    if (this.#frameId !== null) {
-      if (typeof this.#frameId === 'number') cancelAnimationFrame(this.#frameId);
-      this.#frameId = null;
-    }
+    this.#clearScheduledTick();
     if (this.#characterCountsDebounceTimer !== null) {
       clearTimeout(this.#characterCountsDebounceTimer);
       this.#characterCountsDebounceTimer = null;
@@ -532,6 +528,14 @@ export class Editor {
     this.#effectCleanup?.();
     this.#effectCleanup = null;
     this.#gesture?.destroy();
+  }
+
+  #clearScheduledTick(): void {
+    this.#tickScheduled = false;
+    if (this.#frameId !== null) {
+      if (typeof this.#frameId === 'number') cancelAnimationFrame(this.#frameId);
+      this.#frameId = null;
+    }
   }
 
   #materializeSnapshot(revision: number, fields: ReadonlySet<StateField>): EditorSnapshot {
@@ -716,6 +720,9 @@ export class Editor {
 
   #publishIfReady(): void {
     untrack(() => {
+      if (this.#preparingPage !== undefined && this.#preparingPage >= this.#applied.pageSizes.length) {
+        this.#preparingPage = undefined;
+      }
       let targetSetChanged = false;
       if (this.published !== undefined && this.#visualHost !== undefined) {
         targetSetChanged = this.published.frames.size !== this.#visualHost.targets.size;
@@ -728,14 +735,15 @@ export class Editor {
         }
       }
       const publishedRevision = this.published?.snapshot.revision;
-      this.#preparingPage ??= preparingPage(
-        this.#visualHost !== undefined,
-        (this.published?.frames.size ?? 0) > 0,
-        this.#applied.revision,
+      this.#preparingPage ??= preparingPage({
+        hasPublishedFrames: (this.published?.frames.size ?? 0) > 0,
+        appliedRevision: this.#applied.revision,
         publishedRevision,
-        this.#applied.pageSizes.length,
-        this.#visualHost?.targets.size ?? 0,
-      );
+        appliedPageCount: this.#applied.pageSizes.length,
+        publishedPageCount: this.published?.snapshot.pageSizes.length ?? 0,
+        targets: this.#visualHost?.targets,
+      });
+      if (this.#preparingPage !== undefined && !this.#visualHost?.targets.has(this.#preparingPage)) return;
       if (
         canPublish(
           this.#applied.revision,
@@ -1709,6 +1717,9 @@ export class Editor {
         },
       });
       const result = this.#invokeCore((core) => core.tick_through(requestId));
+      // tickThrough has consumed every entry through this synchronously admitted request.
+      // Retire an older queued RAF so Host work does not wait for a tick that is already installed.
+      this.#clearScheduledTick();
       publicEvents = this.#installTick(result);
       if (receiptFailure) throw receiptFailure.error;
       if (!update) throw new Error(`tickThrough omitted request outcome ${requestId.value}`);

--- a/apps/website/src/lib/editor-ffi/publication.ts
+++ b/apps/website/src/lib/editor-ffi/publication.ts
@@ -45,25 +45,32 @@ export function satisfiesWaiter(
   return matchesTargets(frames, host.targets) || (!requireFrame && host.targets.size === 0 && frames.size > 0);
 }
 
-export function preparingPage(
-  hasVisualHost: boolean,
-  hasPublishedFrames: boolean,
-  appliedRevision: number,
-  publishedRevision: number | undefined,
-  appliedPageCount: number,
-  targetCount: number,
-): number | undefined {
+export function preparingPage({
+  hasPublishedFrames,
+  appliedRevision,
+  publishedRevision,
+  appliedPageCount,
+  publishedPageCount,
+  targets,
+}: {
+  hasPublishedFrames: boolean;
+  appliedRevision: number;
+  publishedRevision: number | undefined;
+  appliedPageCount: number;
+  publishedPageCount: number;
+  targets: Pick<ReadonlyMap<number, PublicationTarget>, 'size' | 'has'> | undefined;
+}): number | undefined {
   if (
-    hasVisualHost &&
-    hasPublishedFrames &&
-    publishedRevision !== undefined &&
-    appliedRevision > publishedRevision &&
-    appliedPageCount > 0 &&
-    targetCount === 0
+    !targets ||
+    !hasPublishedFrames ||
+    publishedRevision === undefined ||
+    appliedRevision <= publishedRevision ||
+    appliedPageCount === 0
   ) {
-    return 0;
+    return undefined;
   }
-  return undefined;
+  if (targets.size === 0) return 0;
+  return appliedPageCount > publishedPageCount && !targets.has(publishedPageCount) ? publishedPageCount : undefined;
 }
 
 export function canPublish(

--- a/apps/website/src/lib/editor-ffi/scroll.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/scroll.svelte.ts
@@ -109,8 +109,11 @@ export class EditorScrollScope {
   bottomPadding = $derived.by(() => {
     void this.#editor.viewport.height;
     const snapshot = this.#editor.published?.snapshot;
-    const minimumPadding = Math.max(this.visibleArea.bottomInset, this.#keepVisibleBottomPadding(snapshot));
     const rect = selectionHeadRect(snapshot);
+    const needsKeepVisiblePadding = rect !== undefined || this.#hasResolvedKeepVisibleTarget(snapshot);
+    const minimumPadding = needsKeepVisiblePadding
+      ? resolveKeepVisibleBottomPadding({ visibleArea: this.visibleArea })
+      : this.visibleArea.bottomInset;
     if (!rect) {
       return minimumPadding;
     }
@@ -212,20 +215,9 @@ export class EditorScrollScope {
     }
   }
 
-  #keepVisibleBottomPadding(snapshot: EditorSnapshot | undefined): number {
+  #hasResolvedKeepVisibleTarget(snapshot: EditorSnapshot | undefined): boolean {
     const target = this.#keepVisibleTarget;
-    if (!target) {
-      return 0;
-    }
-
-    const rects = this.#resolveTargetRects(target, snapshot);
-    if (!rects) {
-      return 0;
-    }
-
-    return resolveKeepVisibleBottomPadding({
-      visibleArea: this.visibleArea,
-    });
+    return target !== null && this.#resolveTargetRects(target, snapshot) !== null;
   }
 
   #typewriterBottomPaddingForRect(rect: PageRect): number {

--- a/apps/website/vite.config.ts
+++ b/apps/website/vite.config.ts
@@ -50,7 +50,7 @@ const wasmReloadPlugin = (): Plugin => {
   };
 };
 
-const config = ({ mode }: ConfigEnv) => ({
+export const createConfig = ({ mode }: Pick<ConfigEnv, 'mode'>) => ({
   clearScreen: false,
   plugins: [
     svg(),
@@ -78,9 +78,10 @@ const config = ({ mode }: ConfigEnv) => ({
   },
   test: {
     environment: 'jsdom',
+    exclude: ['src/**/*.browser.test.ts'],
     include: ['src/**/*.test.ts'],
     setupFiles: ['./src/vitest-setup.ts'],
   },
 });
 
-export default defineConfig((env) => config(env) as UserConfig);
+export default defineConfig((env) => createConfig(env) as UserConfig);

--- a/apps/website/vitest.browser.config.ts
+++ b/apps/website/vitest.browser.config.ts
@@ -1,0 +1,26 @@
+/// <reference types="vitest/config" />
+
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { playwright } from '@vitest/browser-playwright';
+import { defaultClientConditions, defineConfig } from 'vite';
+import { createConfig } from './vite.config';
+import type { UserConfig } from 'vite';
+
+const base = createConfig({ mode: 'test' }) as UserConfig;
+
+export default defineConfig({
+  ...base,
+  resolve: { ...base.resolve, conditions: [...defaultClientConditions] },
+  test: {
+    browser: {
+      enabled: true,
+      headless: true,
+      provider: playwright({ contextOptions: { hasTouch: true } }),
+      screenshotDirectory: path.join(tmpdir(), 'typie-vitest-screenshots'),
+      instances: [{ browser: 'chromium' }],
+    },
+    include: ['src/**/*.browser.test.ts'],
+    setupFiles: ['./src/vitest-setup.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -419,7 +419,7 @@ importers:
         version: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.4.2)(tsx@4.23.0)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.4.2)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(@vitest/browser-playwright@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.4.2)(tsx@4.23.0)(yaml@2.9.0))
       wrangler:
         specifier: ^4.112.0
         version: 4.112.0(@cloudflare/workers-types@5.20260719.1)
@@ -444,7 +444,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.4.2)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(@vitest/browser-playwright@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.4.2)(tsx@4.23.0)(yaml@2.9.0))
       wrangler:
         specifier: ^4.112.0
         version: 4.112.0(@cloudflare/workers-types@5.20260721.1)
@@ -581,6 +581,9 @@ importers:
       '@typie/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      '@vitest/browser-playwright':
+        specifier: 4.1.10
+        version: 4.1.10(playwright@1.62.1)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.4.2)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.10)
       dayjs:
         specifier: ^1.11.21
         version: 1.11.21
@@ -664,7 +667,7 @@ importers:
         version: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.4.2)(tsx@4.23.0)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.4.2)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(@vitest/browser-playwright@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.4.2)(tsx@4.23.0)(yaml@2.9.0))
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -1212,6 +1215,9 @@ packages:
   '@babel/types@8.0.0':
     resolution: {integrity: sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==}
     engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@blazediff/core@1.9.1':
+    resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
 
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
@@ -4155,6 +4161,17 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vitest/browser-playwright@4.1.10':
+    resolution: {integrity: sha512-nMoXGEiRpT7m3W7NsbvrM2aKNwiNHZf+zEpUCvMteGjZFvfT96Q9fh7QyB98dvDWXiKvrLxA7bJ1mCOOv+JQPw==}
+    peerDependencies:
+      playwright: '*'
+      vitest: 4.1.10
+
+  '@vitest/browser@4.1.10':
+    resolution: {integrity: sha512-UDwuWGwXj646CBx/bQHOaJSX7np0I8JL/UKQYa1e4QrVHH8VdWtx8eaOuf8sy0ShwDgR6NjJAsp5eF6vjF6qng==}
+    peerDependencies:
+      vitest: 4.1.10
+
   '@vitest/expect@4.1.10':
     resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
 
@@ -5607,6 +5624,11 @@ packages:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -7001,9 +7023,23 @@ packages:
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
 
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
 
   postcss-discard-duplicates@7.0.2:
     resolution: {integrity: sha512-eTonaQvPZ/3i1ASDHOKkYwAybiM45zFIc7KXils4mQmHLqIswXD9XNOKEVxtTFnsmwYzF66u4LMgSr0abDlh5w==}
@@ -8870,6 +8906,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 8.0.0
       '@babel/helper-validator-identifier': 8.0.2
+
+  '@blazediff/core@1.9.1': {}
 
   '@bramus/specificity@2.4.2':
     dependencies:
@@ -11516,6 +11554,36 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
+  '@vitest/browser-playwright@4.1.10(playwright@1.62.1)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.4.2)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.10)':
+    dependencies:
+      '@vitest/browser': 4.1.10(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.4.2)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.4.2)(tsx@4.23.0)(yaml@2.9.0))
+      playwright: 1.62.1
+      tinyrainbow: 3.1.0
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(@vitest/browser-playwright@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.4.2)(tsx@4.23.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/browser@4.1.10(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.4.2)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.10)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.4.2)(tsx@4.23.0)(yaml@2.9.0))
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.0
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(@vitest/browser-playwright@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.4.2)(tsx@4.23.0)(yaml@2.9.0))
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
   '@vitest/expect@4.1.10':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -13102,6 +13170,9 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -14645,7 +14716,17 @@ snapshots:
       exsolve: 1.1.0
       pathe: 2.0.3
 
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
   pluralize@8.0.0: {}
+
+  pngjs@7.0.0: {}
 
   postcss-discard-duplicates@7.0.2(postcss@8.5.14):
     dependencies:
@@ -15890,7 +15971,7 @@ snapshots:
     optionalDependencies:
       vite: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.4.2)(tsx@4.23.0)(yaml@2.9.0)
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.4.2)(tsx@4.23.0)(yaml@2.9.0)):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(@vitest/browser-playwright@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.4.2)(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.4.2)(tsx@4.23.0)(yaml@2.9.0))
@@ -15915,6 +15996,7 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 26.1.0
+      '@vitest/browser-playwright': 4.1.10(playwright@1.62.1)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.4.2)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.10)
       jsdom: 29.1.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - msw


### PR DESCRIPTION
## 요약
- 프레임 싱크와 프레임 드랍 문제를 함께 해결함
- 웹/앱 모두 큰 문서에서 체감 속도 빨라짐
- 프레임 싱크 테스트 추가

## 문제

- 긴 문서에서 Enter/Backspace 또는 ArrowUp/ArrowDown을 반복하면 editor state 적용이 화면 publication보다 앞서가면서, 입력 중 화면이 멈췄다가 키를 뗄 때 변경사항이 한꺼번에 표시될 수 있었음
- 이 과정에서 cursor, line highlight, scroll, rendered texture가 서로 다른 revision을 표시해 한 프레임 안의 정합성이 깨질 수 있었음
- 페이지가 새로 생기는 순간에는 아직 해당 페이지의 render surface가 없어 publication이 지연될 수 있었고, Web에서는 이미 처리한 예약 RAF가 남아 긴 문서의 불필요한 frame 지연을 키울 수 있었음

## 변경

- App의 bring-into-view 요청을 해당 mutation의 정확한 revision과 연결하고, 첫 publication 전에 등록하도록 변경함
- 반복 키 입력 consumer가 현재 revision이 실제로 publish될 때까지 기다리게 해 화면보다 앞선 입력 batch가 계속 누적되지 않도록 함
- App의 snapshot, rendered frame, geometry를 하나의 `PublishedBundle`에서 읽게 해 cursor, line highlight, scroll, texture가 같은 published revision을 기준으로 표시되도록 함
- 새 페이지가 추가될 때 App/Web 모두 보이지 않는 preparatory surface를 먼저 준비한 뒤 publish하도록 해 `1→2`, `2→1` 페이지 전환 중에도 표시할 frame이 끊기지 않도록 함
- editor가 실패한 경우 App은 마지막으로 정상 publish된 bundle을 유지해 오류 전 화면이 빈 surface로 교체되지 않도록 함
- Web의 즉시 update가 이미 처리한 예약 RAF를 취소하고, cursor keep-visible bottom padding 정책을 하나의 경로로 정리함

## 개선

- Enter/Backspace를 누르고 있는 동안 화면이 멈췄다가 key-up 시 한꺼번에 갱신되던 현상을 방지함
- 반복 입력 중에도 publication revision이 계속 전진하므로, 화면보다 앞서 처리된 입력이 쌓이지 않아 긴 문서에서의 체감 응답성이 개선됨
- ArrowUp/ArrowDown 이동 중 scroll, cursor, line highlight가 서로 다른 프레임에 표시되는 회귀를 감지하고 방지함
- 페이지 경계를 지나는 Enter/Backspace에서도 이전 texture와 새 cursor/scroll이 섞이지 않고, 새 페이지 surface가 준비된 뒤 한 번에 공개됨
- App과 Web이 같은 publication 계약을 사용하되 새로운 presentation layer나 별도 readiness state machine은 추가하지 않음

## 검증

- Desktop 실제 Compose surface와 native bitmap을 기록해 cursor, line highlight, scroll, rendered frame의 정합성을 검증함
- 33ms 간격과 서로 다른 frame phase에서 ArrowUp/ArrowDown 및 Enter/Backspace 반복 입력을 수행하고, publication이 250ms 이상 정지하면 실패하도록 함
- Web 실제 Chromium의 canvas, DOM overlay, scroll을 매 frame 기록해 같은 조건의 프레임 정합성을 검증함
- Web에서는 100자 문단 300개인 약 3만자 문서에서도 33ms Enter/Backspace 반복 중 250ms 이상의 display gap 또는 publication stall이 발생하면 실패하도록 함
- App/Web 모두 새 페이지 생성·제거와 빠른 `Enter→Backspace` 전환을 회귀 테스트에 포함함