### PR TITLE
노트 컬러 팔레트가 pan scroll을 흡수하지 않음

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteCard.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteCard.kt
@@ -97,6 +97,7 @@ private val NoteStatusHitTargetSize = 28.dp
 private val NoteGripHitTargetSize = 28.dp
 private val NoteColorDotHitTargetWidth = 20.dp
 private val NoteColorDotHitTargetHeight = 24.dp
+internal const val NoteColorPaletteScrubArmDelayMillis = 180L
 private const val NoteExpandAnimationDurationMillis = 220
 
 private data class NoteCardVisualState(val expanded: Boolean, val dragging: Boolean)
@@ -626,10 +627,11 @@ private fun NoteActionIconAnchor(icon: IconData, tint: Color = AppTheme.colors.t
 }
 
 @Composable
-private fun NoteColorPalette(
+internal fun NoteColorPalette(
   noteColorOptions: List<NoteColorOption>,
   selectedColor: String,
   onColorChange: (String) -> Unit,
+  modifier: Modifier = Modifier,
 ) {
   val density = LocalDensity.current
   val haptic = LocalHapticFeedback.current
@@ -640,13 +642,14 @@ private fun NoteColorPalette(
 
   Row(
     modifier =
-      Modifier.height(NoteColorDotHitTargetHeight).pointerInput(noteColorOptions, optionWidthPx) {
+      modifier.height(NoteColorDotHitTargetHeight).pointerInput(noteColorOptions, optionWidthPx) {
         awaitEachGesture {
           val down = awaitFirstDown(requireUnconsumed = false)
-          var lastPointerX = down.position.x
+          val touchSlop = viewConfiguration.touchSlop
           var lastSelectedColor = selectedColorState.value
+          var scrubbing = false
 
-          fun selectColorAt(x: Float, fromPan: Boolean) {
+          fun selectColorAt(x: Float) {
             val index = (x / optionWidthPx).toInt().coerceIn(0, noteColorOptions.lastIndex)
             val nextColor = noteColorOptions[index].value
             if (nextColor == lastSelectedColor) {
@@ -654,13 +657,9 @@ private fun NoteColorPalette(
             }
 
             lastSelectedColor = nextColor
-            if (fromPan) {
-              hapticState.value.performHapticFeedback(HapticFeedbackType.TextHandleMove)
-            }
+            hapticState.value.performHapticFeedback(HapticFeedbackType.TextHandleMove)
             onColorChangeState.value(nextColor)
           }
-
-          selectColorAt(down.position.x, fromPan = false)
 
           while (true) {
             val event = awaitPointerEvent()
@@ -669,10 +668,28 @@ private fun NoteColorPalette(
               break
             }
 
-            if (change.position.x != lastPointerX) {
-              selectColorAt(change.position.x, fromPan = true)
-              lastPointerX = change.position.x
+            if (!scrubbing) {
+              if (change.isConsumed) {
+                break
+              }
+
+              val offset = change.position - down.position
+              if (offset.getDistance() < touchSlop) {
+                continue
+              }
+
+              val elapsedMillis = change.uptimeMillis - down.uptimeMillis
+              if (
+                elapsedMillis < NoteColorPaletteScrubArmDelayMillis ||
+                  abs(offset.y) >= abs(offset.x)
+              ) {
+                break
+              }
+
+              scrubbing = true
             }
+
+            selectColorAt(change.position.x)
             change.consume()
           }
         }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/domain/note/NoteColorPaletteDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/domain/note/NoteColorPaletteDesktopTest.kt
@@ -1,0 +1,168 @@
+package co.typie.domain.note
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class NoteColorPaletteDesktopTest {
+  @Test
+  fun verticalDragBeforeArmDelayScrollsParentWithoutChangingColor() = runComposeUiTest {
+    val colors = mutableListOf<String>()
+    var scrollValue = 0
+
+    setContent {
+      val scrollState = rememberScrollState()
+      scrollValue = scrollState.value
+      Column(
+        Modifier.size(width = PaletteWidth, height = PaletteHeight).verticalScroll(scrollState)
+      ) {
+        TestPalette(onColorChange = colors::add)
+        Spacer(Modifier.height(200.dp))
+      }
+    }
+    waitForIdle()
+
+    onNodeWithTag(PaletteTag).performTouchInput {
+      down(center)
+      moveBy(Offset(x = 0f, y = -100f), delayMillis = 16L)
+      up()
+    }
+    waitForIdle()
+
+    assertTrue(scrollValue > 0)
+    assertTrue(colors.isEmpty())
+  }
+
+  @Test
+  fun horizontalDragBeforeArmDelayScrollsParentWithoutChangingColor() = runComposeUiTest {
+    val colors = mutableListOf<String>()
+    var scrollValue = 0
+
+    setContent {
+      val scrollState = rememberScrollState()
+      scrollValue = scrollState.value
+      Row(
+        Modifier.size(width = PaletteWidth, height = PaletteHeight).horizontalScroll(scrollState)
+      ) {
+        TestPalette(onColorChange = colors::add)
+        Spacer(Modifier.width(200.dp))
+      }
+    }
+    waitForIdle()
+
+    onNodeWithTag(PaletteTag).performTouchInput {
+      down(center)
+      moveBy(Offset(x = -100f, y = 0f), delayMillis = 16L)
+      up()
+    }
+    waitForIdle()
+
+    assertTrue(scrollValue > 0)
+    assertTrue(colors.isEmpty())
+  }
+
+  @Test
+  fun holdThenHorizontalDragScrubsToPointerColor() = runComposeUiTest {
+    val colors = mutableListOf<String>()
+
+    setContent { TestPalette(onColorChange = colors::add) }
+    waitForIdle()
+
+    onNodeWithTag(PaletteTag).performTouchInput {
+      down(Offset(x = width / 6f, y = center.y))
+      advanceEventTime(NoteColorPaletteScrubArmDelayMillis)
+      moveTo(Offset(x = width * 5f / 6f, y = center.y), delayMillis = 16L)
+      up()
+    }
+    waitForIdle()
+
+    assertContentEquals(listOf("blue"), colors)
+  }
+
+  @Test
+  fun holdThenVerticalDragScrollsParentWithoutChangingColor() = runComposeUiTest {
+    val colors = mutableListOf<String>()
+    var scrollValue = 0
+
+    setContent {
+      val scrollState = rememberScrollState()
+      scrollValue = scrollState.value
+      Column(
+        Modifier.size(width = PaletteWidth, height = PaletteHeight).verticalScroll(scrollState)
+      ) {
+        TestPalette(onColorChange = colors::add)
+        Spacer(Modifier.height(200.dp))
+      }
+    }
+    waitForIdle()
+
+    onNodeWithTag(PaletteTag).performTouchInput {
+      down(center)
+      advanceEventTime(NoteColorPaletteScrubArmDelayMillis)
+      moveBy(Offset(x = 0f, y = -100f), delayMillis = 16L)
+      up()
+    }
+    waitForIdle()
+
+    assertTrue(scrollValue > 0)
+    assertTrue(colors.isEmpty())
+  }
+
+  @Test
+  fun tapSelectsColorExactlyOnce() = runComposeUiTest {
+    val colors = mutableListOf<String>()
+
+    setContent { TestPalette(onColorChange = colors::add) }
+    waitForIdle()
+
+    onNodeWithTag(PaletteTag).performTouchInput { click(Offset(x = width / 2f, y = center.y)) }
+    waitForIdle()
+
+    assertContentEquals(listOf("red"), colors)
+  }
+
+  @Composable
+  private fun TestPalette(onColorChange: (String) -> Unit) {
+    val options = remember {
+      listOf(
+        NoteColorOption(value = "gray", label = "그레이", stroke = Color.Gray),
+        NoteColorOption(value = "red", label = "레드", stroke = Color.Red),
+        NoteColorOption(value = "blue", label = "블루", stroke = Color.Blue),
+      )
+    }
+    NoteColorPalette(
+      noteColorOptions = options,
+      selectedColor = "gray",
+      onColorChange = onColorChange,
+      modifier = Modifier.testTag(PaletteTag),
+    )
+  }
+
+  private companion object {
+    const val PaletteTag = "note-color-palette"
+    val PaletteWidth = 60.dp
+    val PaletteHeight = 24.dp
+  }
+}


### PR DESCRIPTION
1. 팝오버와 동일한 `180ms` press delay 적용
2. 지연 전에 움직이면 팔레트가 제스처를 포기
3. 지연 후 가로 우세 드래그만 scrub으로 전환
4. 세로 또는 동률 방향은 상위 스크롤에 양보
5. 탭 선택과 색상 변경 시 햅틱은 그대로 유지