### PR TITLE
마우스 버튼 해제 후 lostpointercapture를 드롭으로 처리

### DIFF
--- a/apps/website/src/lib/pointer-capture.test.ts
+++ b/apps/website/src/lib/pointer-capture.test.ts
@@ -2,11 +2,12 @@ import { pointerCapture } from '@typie/ui/actions';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { PointerCaptureParameters } from '@typie/ui/actions';
 
-const pointerEvent = (type: string, pointerId = 1) => {
+const pointerEvent = (type: string, pointerId = 1, properties: { buttons?: number; pointerType?: string } = {}) => {
   const event = new MouseEvent(type, { bubbles: true, button: 0 });
   Object.defineProperties(event, {
     pointerId: { value: pointerId },
     isPrimary: { value: true },
+    ...Object.fromEntries(Object.entries(properties).map(([key, value]) => [key, { value }])),
   });
   return event as PointerEvent;
 };
@@ -25,9 +26,9 @@ const installPointerCapture = (element: HTMLElement) => {
   });
 
   return {
-    lose(pointerId: number) {
+    lose(pointerId: number, event = pointerEvent('lostpointercapture', pointerId)) {
       capturedPointerId = null;
-      element.dispatchEvent(pointerEvent('lostpointercapture', pointerId));
+      element.dispatchEvent(event);
     },
   };
 };
@@ -130,12 +131,30 @@ describe('pointerCapture', () => {
     const action = pointerCapture(element, { start: () => session, cancel });
 
     element.dispatchEvent(pointerEvent('pointerdown'));
-    capture.lose(1);
+    capture.lose(1, pointerEvent('lostpointercapture', 1, { pointerType: 'mouse', buttons: 1 }));
 
     expect(cancel).toHaveBeenCalledOnce();
     expect(cancel).toHaveBeenCalledWith(session, 'lostpointercapture', expect.any(MouseEvent));
     action.destroy?.();
     expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it('ends when mouse capture is lost after all buttons are released', () => {
+    const element = createElement();
+    const capture = installPointerCapture(element);
+    const session = { id: 'owner' };
+    const end = vi.fn();
+    const cancel = vi.fn();
+    const action = pointerCapture(element, { start: () => session, end, cancel });
+
+    element.dispatchEvent(pointerEvent('pointerdown'));
+    const event = pointerEvent('lostpointercapture', 1, { pointerType: 'mouse', buttons: 0 });
+    capture.lose(1, event);
+
+    expect(end).toHaveBeenCalledOnce();
+    expect(end).toHaveBeenCalledWith(session, event);
+    expect(cancel).not.toHaveBeenCalled();
+    action.destroy?.();
   });
 
   it('cancels on destroy and removes its listeners', () => {

--- a/packages/ui/src/actions/pointer-capture.svelte.ts
+++ b/packages/ui/src/actions/pointer-capture.svelte.ts
@@ -92,7 +92,13 @@ export const pointerCapture = <Session>(
   };
 
   const handlePointerCancel = (event: PointerEvent) => cancel('pointercancel', event);
-  const handleLostPointerCapture = (event: PointerEvent) => cancel('lostpointercapture', event);
+  const handleLostPointerCapture = (event: PointerEvent) => {
+    if (event.pointerType === 'mouse' && event.buttons === 0) {
+      handlePointerUp(event);
+      return;
+    }
+    cancel('lostpointercapture', event);
+  };
 
   element.addEventListener('pointerdown', handlePointerDown);
 


### PR DESCRIPTION
## 문제

웹에서 노트를 빠르게 드래그한 뒤 놓으면, 이동한 순서가 적용되지 않고
노트가 원래 위치로 돌아가는 경우가 있었습니다.

실패한 입력 흐름에서는 활성화된 drag 이후 `pointerup`이나
`pointercancel` 없이 `lostpointercapture`만 전달됐습니다. 기존 구현은
모든 `lostpointercapture`를 취소로 처리했기 때문에 reorder preview를
rollback했습니다.

## 원인

`lostpointercapture`는 제스처가 취소되었다는 뜻이 아니라 해당 pointer의
capture가 해제되었다는 뜻입니다.

또한 Pointer Events에서 `buttons === 0`은 현재 눌린 버튼이 없음을
나타냅니다. Chromium은 마우스가 페이지 밖에서 놓인 것으로 판단한 경우
`buttons === 0`인 move를 처리하면서 pointer capture를 해제하고,
후속 move보다 먼저 `lostpointercapture`를 전달합니다.

기존 구현은 `lostpointercapture`를 받자마자 drag listener를 제거했기
때문에 이 경로를 실제 취소와 구분하지 못했습니다.

## Fallback 정책

이번 정책은 Pointer Events 표준이 직접 규정하는 종료 방식이 아니라,
표준의 이벤트 의미와 Chromium의 입력 복구 동작에 근거한
애플리케이션 수준의 fallback입니다.

- `pointerType === 'mouse' && buttons === 0`
    - 마우스 버튼은 이미 해제된 상태로 판단
    - `pointerup`과 동일한 정상 종료 경로를 사용해 drop을 commit
- `pointercancel`
    - 명시적인 입력 취소이므로 기존처럼 cancel 및 rollback
- 마우스 버튼이 남아 있는 `lostpointercapture`
    - 실제 capture 손실일 수 있으므로 기존처럼 cancel 및 rollback
- touch 및 pen의 `lostpointercapture`
    - 이번 휴리스틱을 적용하지 않고 기존 취소 정책 유지

시간, 이동 속도 또는 마지막 좌표를 이용한 추측은 추가하지 않습니다.

## 근거

- Pointer Events: `lostpointercapture`는 capture가 해제된 후 발생
    - https://www.w3.org/TR/pointerevents/#the-lostpointercapture-event
- Pointer Events: `buttons === 0`은 활성 버튼이 없음을 의미
    - https://www.w3.org/TR/pointerevents/#the-buttons-property
- Chromium: 페이지 밖 mouse release를 `buttons === 0` move로 감지하고
capture를 해제한 뒤 `lostpointercapture`를 즉시 처리
    - https://chromium.googlesource.com/chromium/src/+/a6c1687b03092871b0486030ccc18f2fbb27dad0/third_party/blink/renderer/core/input/pointer_event_manager.cc#668

## 변경 사항

- mouse zero-button `lostpointercapture`를 정상 종료 경로로 전달
- 버튼이 남아 있는 capture loss가 계속 취소되는 회귀 테스트 추가
- zero-button capture loss가 정확히 한 번 종료되고 취소되지 않는 테스트 추가