### PR TITLE
안드로이드 bundle 직렬화 오류 수정

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/entity/container/EntityContainerList.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/entity/container/EntityContainerList.kt
@@ -183,11 +183,11 @@ private fun EntityContainerNormalRow(
   }
 }
 
-private object EntityContainerHeaderKey
+private const val EntityContainerHeaderKey = "entity-container-header"
 
-private object EntityContainerEmptyKey
+private const val EntityContainerEmptyKey = "entity-container-empty"
 
-private object EntityContainerBottomSpacerKey
+private const val EntityContainerBottomSpacerKey = "entity-container-bottom-spacer"
 
 @Composable
 private fun EntityContainerReorderRow(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteList.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteList.kt
@@ -213,10 +213,10 @@ internal fun NoteList(
               LaunchedEffect(item.note.id, noteIsEntering) {
                 if (!noteIsEntering) return@LaunchedEffect
                 snapshotFlow {
-                    visibilityState.isIdle &&
-                      visibilityState.currentState &&
-                      visibilityState.targetState
-                  }
+                  visibilityState.isIdle &&
+                    visibilityState.currentState &&
+                    visibilityState.targetState
+                }
                   .first { it }
                 onEnterAnimationFinished(item.note.id)
               }
@@ -224,10 +224,10 @@ internal fun NoteList(
               LaunchedEffect(item.note.id, noteIsExitVisible) {
                 if (!noteIsExitVisible) return@LaunchedEffect
                 snapshotFlow {
-                    visibilityState.isIdle &&
-                      !visibilityState.currentState &&
-                      !visibilityState.targetState
-                  }
+                  visibilityState.isIdle &&
+                    !visibilityState.currentState &&
+                    !visibilityState.targetState
+                }
                   .first { it }
                 onExitAnimationFinished(item.note.id)
               }
@@ -359,11 +359,11 @@ internal fun NoteList(
   }
 }
 
-private object NoteListHeaderKey
+private const val NoteListHeaderKey = "note-list-header"
 
-private object NoteListBodyStateKey
+private const val NoteListBodyStateKey = "note-list-body-state"
 
-private object NoteListFooterKey
+private const val NoteListFooterKey = "note-list-footer"
 
 @Composable
 private fun NoteQueryError(onRetry: suspend () -> Unit) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/textreplacements/TextReplacementsScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/textreplacements/TextReplacementsScreen.kt
@@ -56,15 +56,15 @@ import co.typie.ui.theme.AppTheme
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
-private object TextReplacementsTitleKey
+private const val TextReplacementsTitleKey = "text-replacements-title"
 
-private object TextReplacementsDescriptionKey
+private const val TextReplacementsDescriptionKey = "text-replacements-description"
 
-private object TextReplacementsPresetKey
+private const val TextReplacementsPresetKey = "text-replacements-preset"
 
-private object TextReplacementsCustomHeaderKey
+private const val TextReplacementsCustomHeaderKey = "text-replacements-custom-header"
 
-private object TextReplacementsEmptyKey
+private const val TextReplacementsEmptyKey = "text-replacements-empty"
 
 @Composable
 fun TextReplacementsScreen() {


### PR DESCRIPTION
top bar/bottom bar 키는 무조건 문자열이어야 한다 (object 안됨. 안드로이드에서 bundle 직렬화에 실패한다)
