### PR TITLE
앱 화면 전환 중 불필요한 recomposition 제거

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationRoutePresentation.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationRoutePresentation.kt
@@ -10,22 +10,24 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.drawscope.clipPath
 import androidx.compose.ui.graphics.graphicsLayer
 
-internal data class NavigationRoutePresentation(
-  val translationX: Float = 0f,
-  val translationY: Float = 0f,
-  val alpha: Float = 1f,
-  val clipShape: Shape? = null,
+/** Keeps per-frame animation state reads inside layer and draw callbacks. */
+internal class NavigationRoutePresentation(
+  val translationX: () -> Float = { 0f },
+  val translationY: () -> Float = { 0f },
+  val alpha: () -> Float = { 1f },
+  val clipShape: (() -> Shape?)? = null,
 )
 
 internal fun Modifier.navigationRoutePresentation(
   presentation: NavigationRoutePresentation
 ): Modifier = graphicsLayer {
-  translationX = presentation.translationX
-  translationY = presentation.translationY
-  alpha = presentation.alpha
-  presentation.clipShape?.let {
-    shape = it
-    clip = true
+  translationX = presentation.translationX()
+  translationY = presentation.translationY()
+  alpha = presentation.alpha()
+  val resolvedClipShape = presentation.clipShape?.invoke()
+  clip = resolvedClipShape != null
+  if (resolvedClipShape != null) {
+    shape = resolvedClipShape
   }
 }
 
@@ -34,14 +36,19 @@ internal fun Modifier.excludeNavigationRouteCoverage(
 ): Modifier {
   val clipShape = presentation.clipShape ?: return this
   return drawWithContent {
-    val outline = clipShape.createOutline(size, layoutDirection, this)
+    val resolvedClipShape = clipShape()
+    if (resolvedClipShape == null) {
+      drawContent()
+      return@drawWithContent
+    }
+    val outline = resolvedClipShape.createOutline(size, layoutDirection, this)
     val coveragePath =
       when (outline) {
         is Outline.Generic -> Path().apply { addPath(outline.path) }
         is Outline.Rectangle -> Path().apply { addRect(outline.rect) }
         is Outline.Rounded -> Path().apply { addRoundRect(outline.roundRect) }
       }
-    coveragePath.translate(Offset(x = presentation.translationX, y = presentation.translationY))
+    coveragePath.translate(Offset(x = presentation.translationX(), y = presentation.translationY()))
     clipPath(coveragePath, clipOp = ClipOp.Difference) { this@drawWithContent.drawContent() }
   }
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationStack.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationStack.kt
@@ -816,66 +816,85 @@ fun NavigationStack(
             bottomBarState
           }
 
-        val p = progress.value
+        val presentationAnimState = animState
+        val presentationPopRequested = navigator.popRequested
         val mainPresentation =
           when {
-            animState == AnimState.Idle -> NavigationRoutePresentation()
+            presentationAnimState == AnimState.Idle -> NavigationRoutePresentation()
             useFadeTransition ->
               NavigationRoutePresentation(
-                alpha =
-                  when (animState) {
+                alpha = {
+                  val p = progress.value
+                  when (presentationAnimState) {
                     AnimState.Push -> p
                     AnimState.Pop -> 1f - p
                     AnimState.PopGestureCommitted -> 1f
-                    AnimState.Dragging -> if (navigator.popRequested) 1f - p else 1f
+                    AnimState.Dragging -> if (presentationPopRequested) 1f - p else 1f
                     AnimState.Idle -> 1f
                   }
+                }
               )
             useVerticalTransition ->
               NavigationRoutePresentation(
-                translationY =
-                  when (animState) {
+                translationY = {
+                  val p = progress.value
+                  when (presentationAnimState) {
                     AnimState.Push -> containerHeight * (1f - p)
                     AnimState.Pop,
                     AnimState.PopGestureCommitted,
                     AnimState.Dragging -> containerHeight * p
                     AnimState.Idle -> 0f
-                  },
-                clipShape =
-                  AppShapes.rounded(cornerRadius(if (animState == AnimState.Push) p else 1f - p)),
+                  }
+                },
+                clipShape = {
+                  val p = progress.value
+                  AppShapes.rounded(
+                    cornerRadius(if (presentationAnimState == AnimState.Push) p else 1f - p)
+                  )
+                },
               )
             else ->
               NavigationRoutePresentation(
-                translationX =
-                  when (animState) {
+                translationX = {
+                  val p = progress.value
+                  when (presentationAnimState) {
                     AnimState.Push -> containerWidth * (1f - p)
                     else -> containerWidth * p
-                  },
-                clipShape =
-                  AppShapes.rounded(cornerRadius(if (animState == AnimState.Push) p else 1f - p)),
+                  }
+                },
+                clipShape = {
+                  val p = progress.value
+                  AppShapes.rounded(
+                    cornerRadius(if (presentationAnimState == AnimState.Push) p else 1f - p)
+                  )
+                },
               )
           }
         val behindPresentation =
           when {
             useFadeTransition ->
               NavigationRoutePresentation(
-                alpha =
-                  when (animState) {
+                alpha = {
+                  val p = progress.value
+                  when (presentationAnimState) {
                     AnimState.Push -> 1f - p
                     AnimState.Pop -> p
                     AnimState.PopGestureCommitted -> 0f
-                    AnimState.Dragging -> if (navigator.popRequested) p else 0f
+                    AnimState.Dragging -> if (presentationPopRequested) p else 0f
                     AnimState.Idle -> 1f
                   }
+                }
               )
             useVerticalTransition -> NavigationRoutePresentation()
             else ->
               NavigationRoutePresentation(
-                translationX =
-                  when (animState) {
+                translationX = {
+                  val p = progress.value
+                  when (presentationAnimState) {
                     AnimState.Push -> -containerWidth / 6f * p
                     else -> -containerWidth / 6f * (1f - p)
                   }
+                }
               )
           }
         val behindDimPresentation =
@@ -883,19 +902,24 @@ fun NavigationStack(
             useFadeTransition -> null
             useVerticalTransition ->
               NavigationRoutePresentation(
-                alpha =
-                  when (animState) {
+                alpha = {
+                  val p = progress.value
+                  when (presentationAnimState) {
                     AnimState.Push -> p
                     AnimState.Pop,
                     AnimState.PopGestureCommitted,
                     AnimState.Dragging -> 1f - p
                     AnimState.Idle -> 0f
                   }
+                }
               )
             else ->
               NavigationRoutePresentation(
                 translationX = behindPresentation.translationX,
-                alpha = if (animState == AnimState.Push) p else 1f - p,
+                alpha = {
+                  val p = progress.value
+                  if (presentationAnimState == AnimState.Push) p else 1f - p
+                },
               )
           }
 
@@ -924,32 +948,41 @@ fun NavigationStack(
           }
         }
 
-        val mainBackdropWeight =
-          when {
-            behindRoute == null -> 1f
-            animState == AnimState.Push -> p
-            animState == AnimState.Pop ||
-              animState == AnimState.PopGestureCommitted ||
-              animState == AnimState.Dragging -> 1f - p
-            else -> 1f
-          }
-        val backdropStyle =
-          resolveNavigationTopBarBackdropStyle(
-            behindBackground =
-              behindRoute?.let { route ->
-                routeSceneFor(route).foregroundRegistry.topBarBackdropBackground
-              },
-            behindPresence = if (behindTopBar.hasTopBarBackdrop()) 1f else 0f,
-            mainBackground = routeSceneFor(mainRoute).foregroundRegistry.topBarBackdropBackground,
-            mainPresence = if (mainTopBar.hasTopBarBackdrop()) 1f else 0f,
-            mainWeight = mainBackdropWeight,
-            fallbackBackground = AppTheme.colors.surfaceCanvas,
+        val behindBackdropBackground = behindRoute?.let { route ->
+          routeSceneFor(route).foregroundRegistry.topBarBackdropBackground
+        }
+        val behindBackdropPresence = if (behindTopBar.hasTopBarBackdrop()) 1f else 0f
+        val mainBackdropBackground =
+          routeSceneFor(mainRoute).foregroundRegistry.topBarBackdropBackground
+        val mainBackdropPresence = if (mainTopBar.hasTopBarBackdrop()) 1f else 0f
+        val fallbackBackdropBackground = AppTheme.colors.surfaceCanvas
+        val hasBehindRoute = behindRoute != null
+        if (behindBackdropPresence > 0f || mainBackdropPresence > 0f) {
+          NavigationTopBarBackdrop(
+            hazeState = topBarBackdropHazeState,
+            style = {
+              val p = progress.value
+              val mainWeight =
+                when {
+                  !hasBehindRoute -> 1f
+                  presentationAnimState == AnimState.Push -> p
+                  presentationAnimState == AnimState.Pop ||
+                    presentationAnimState == AnimState.PopGestureCommitted ||
+                    presentationAnimState == AnimState.Dragging -> 1f - p
+                  else -> 1f
+                }
+              resolveNavigationTopBarBackdropStyle(
+                behindBackground = behindBackdropBackground,
+                behindPresence = behindBackdropPresence,
+                mainBackground = mainBackdropBackground,
+                mainPresence = mainBackdropPresence,
+                mainWeight = mainWeight,
+                fallbackBackground = fallbackBackdropBackground,
+              )
+            },
+            modifier = Modifier.align(Alignment.TopCenter),
           )
-        NavigationTopBarBackdrop(
-          hazeState = topBarBackdropHazeState,
-          style = backdropStyle,
-          modifier = Modifier.align(Alignment.TopCenter),
-        )
+        }
 
         // Scene foregrounds use the matching presentation. Behind foreground is excluded from the
         // transformed main-route coverage so it cannot leak over an opaque front surface.

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationTopBarBackdrop.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationTopBarBackdrop.kt
@@ -1,6 +1,5 @@
 package co.typie.navigation
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -8,7 +7,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
@@ -52,34 +53,33 @@ internal fun resolveNavigationTopBarBackdropStyle(
 @OptIn(ExperimentalHazeApi::class)
 internal fun NavigationTopBarBackdrop(
   hazeState: HazeState,
-  style: NavigationTopBarBackdropStyle,
+  style: () -> NavigationTopBarBackdropStyle,
   modifier: Modifier = Modifier,
 ) {
   val animationSource = LocalTopBarAnimationSource.current
-  val alpha = (animationSource?.animatedAlpha ?: 0f) * style.presence
-  if (alpha <= 0f) return
+  val animatedAlpha = animationSource?.animatedAlpha ?: 0f
+  if (animatedAlpha <= 0f) return
+  val styleState = rememberUpdatedState(style)
 
   val topPadding = TopBarDefaults.topPadding()
+  val blurEffect = remember {
+    TypieTopBarProgressiveBlurEffect(
+      blurRadius = TopBarDefaults.BlurRadius,
+      progressiveBrush = navigationTopBarProgressiveBrush(Color.Black),
+      fallbackProgressive = TopBarDefaults.hazeProgressive(),
+      backgroundColor = { styleState.value().background },
+    )
+  }
   val backdropModifier =
     modifier
       .fillMaxWidth()
       .height(topPadding + TopBarDefaults.Height + TopBarDefaults.BlurFadeHeight)
       .testTag(NavigationTopBarBackdropTestTag)
       .graphicsLayer {
-        this.alpha = alpha
+        val resolvedStyle = styleState.value()
+        alpha = animatedAlpha * resolvedStyle.presence
         translationY = (animationSource?.animatedTranslationY ?: 0f) * size.height
       }
-
-  val fadeColor = style.background.copy(alpha = TopBarDefaults.FadeOpacity)
-  val blurEffect = remember {
-    TypieTopBarProgressiveBlurEffect(
-      blurRadius = TopBarDefaults.BlurRadius,
-      progressiveBrush = navigationTopBarProgressiveBrush(Color.Black),
-      fallbackProgressive = TopBarDefaults.hazeProgressive(),
-      backgroundColor = style.background,
-    )
-  }
-  blurEffect.backgroundColor = style.background
 
   Box(modifier = backdropModifier) {
     Column(modifier = Modifier.fillMaxWidth().hazeEffect(hazeState) { visualEffect = blurEffect }) {
@@ -87,11 +87,18 @@ internal fun NavigationTopBarBackdrop(
       Spacer(Modifier.height(TopBarDefaults.BlurFadeHeight))
     }
     Column(modifier = Modifier.fillMaxWidth()) {
-      Spacer(Modifier.fillMaxWidth().height(topPadding).background(fadeColor))
+      Spacer(
+        Modifier.fillMaxWidth().height(topPadding).drawBehind {
+          drawRect(styleState.value().background.copy(alpha = TopBarDefaults.FadeOpacity))
+        }
+      )
       Spacer(
         Modifier.fillMaxWidth()
           .height(TopBarDefaults.Height + TopBarDefaults.BlurFadeHeight)
-          .background(navigationTopBarProgressiveBrush(fadeColor))
+          .drawBehind {
+            val fadeColor = styleState.value().background.copy(alpha = TopBarDefaults.FadeOpacity)
+            drawRect(navigationTopBarProgressiveBrush(fadeColor))
+          }
       )
     }
   }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/TypieTopBarProgressiveBlurEffect.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/TypieTopBarProgressiveBlurEffect.kt
@@ -1,9 +1,6 @@
 package co.typie.navigation
 
 import androidx.compose.runtime.Stable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
@@ -52,15 +49,13 @@ internal class TypieTopBarProgressiveBlurEffect(
   private val blurRadius: Dp,
   private val progressiveBrush: Brush,
   fallbackProgressive: HazeProgressive,
-  backgroundColor: Color,
+  private val backgroundColor: () -> Color,
 ) : VisualEffect {
-  var backgroundColor: Color by mutableStateOf(backgroundColor)
-
-  private var resolvedBackgroundColor: Color = backgroundColor
+  private var resolvedBackgroundColor: Color = Color.Unspecified
   private val fallbackEffect =
     BlurVisualEffect().apply {
       this.blurRadius = blurRadius
-      this.backgroundColor = backgroundColor
+      this.backgroundColor = Color.Unspecified
       progressive = fallbackProgressive
     }
 
@@ -75,7 +70,7 @@ internal class TypieTopBarProgressiveBlurEffect(
   }
 
   override fun update(context: VisualEffectContext) {
-    val currentBackgroundColor = backgroundColor
+    val currentBackgroundColor = backgroundColor()
     if (currentBackgroundColor != resolvedBackgroundColor) {
       resolvedBackgroundColor = currentBackgroundColor
       fallbackEffect.backgroundColor = currentBackgroundColor

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/NavigationStackDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/NavigationStackDesktopTest.kt
@@ -15,10 +15,17 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.ExperimentalComposeRuntimeApi
+import androidx.compose.runtime.InternalComposeApi
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.RecomposeScope
+import androidx.compose.runtime.currentComposer
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.runtime.tooling.CompositionObserver
+import androidx.compose.runtime.tooling.ObservableComposition
+import androidx.compose.runtime.tooling.setObserver
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
@@ -239,6 +246,57 @@ class NavigationStackDesktopTest {
     )
 
     foreground.performTouchInput { up() }
+    waitUntil { !navigator.isTransitioning }
+  }
+
+  @Test
+  @OptIn(ExperimentalComposeRuntimeApi::class, InternalComposeApi::class)
+  fun directBackDragMotionDoesNotRecomposeNavigationScene() = runComposeUiTest {
+    val navigator = Navigator(Route.Home)
+    val editorRoute = Route.Editor("document-id")
+    val compositionObserver = CountingCompositionObserver()
+    val topBarState = TopBarState().apply { animatedAlpha = 1f }
+    var platformTouchSlop = 0f
+
+    setContent {
+      val composition = currentComposer.composition
+      DisposableEffect(composition) {
+        val observerHandle = composition.setObserver(compositionObserver)
+        onDispose { observerHandle?.dispose() }
+      }
+      platformTouchSlop = LocalViewConfiguration.current.touchSlop
+      NavigationStack(
+        navigator = navigator,
+        topBarState = topBarState,
+        modifier = Modifier.size(width = 320.dp, height = 640.dp),
+      ) { route ->
+        PublishNavigationTopBarBackdropStyle(
+          background = if (route == editorRoute) Color.Blue else Color.Red
+        )
+        ProvideTopBar()
+        Box(
+          Modifier.fillMaxSize().testTag(if (route == editorRoute) EditorRouteTag else HomeRouteTag)
+        )
+      }
+      LaunchedEffect(Unit) { navigator.navigate(editorRoute) }
+    }
+    waitUntil { navigator.current == editorRoute && !navigator.isTransitioning }
+
+    val routeNode = onNodeWithTag(EditorRouteTag)
+    routeNode.performTouchInput {
+      down(center)
+      moveBy(Offset(x = platformTouchSlop * 4f, y = 0f), delayMillis = 100L)
+    }
+    waitUntil { routeNode.fetchSemanticsNode().boundsInRoot.left > 1f }
+    waitForIdle()
+    val settledCompositionCount = compositionObserver.compositionCount
+
+    routeNode.performTouchInput { repeat(5) { moveBy(Offset(x = 8f, y = 0f), delayMillis = 16L) } }
+    waitForIdle()
+
+    assertEquals(settledCompositionCount, compositionObserver.compositionCount)
+
+    routeNode.performTouchInput { up() }
     waitUntil { !navigator.isTransitioning }
   }
 
@@ -782,3 +840,25 @@ class NavigationStackDesktopTest {
 }
 
 private val LocalForegroundTestValue = staticCompositionLocalOf { "missing" }
+
+@OptIn(ExperimentalComposeRuntimeApi::class)
+private class CountingCompositionObserver : CompositionObserver {
+  var compositionCount = 0
+    private set
+
+  override fun onBeginComposition(composition: ObservableComposition) {
+    compositionCount += 1
+  }
+
+  override fun onScopeEnter(scope: RecomposeScope) = Unit
+
+  override fun onReadInScope(scope: RecomposeScope, value: Any) = Unit
+
+  override fun onScopeExit(scope: RecomposeScope) = Unit
+
+  override fun onEndComposition(composition: ObservableComposition) = Unit
+
+  override fun onScopeInvalidated(scope: RecomposeScope, value: Any?) = Unit
+
+  override fun onScopeDisposed(scope: RecomposeScope) = Unit
+}

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/TypieTopBarProgressiveBlurEffectDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/TypieTopBarProgressiveBlurEffectDesktopTest.kt
@@ -30,6 +30,24 @@ private const val MaximumContinuousLuminanceStep = 0.08f
 @OptIn(ExperimentalTestApi::class)
 class TypieTopBarProgressiveBlurEffectDesktopTest {
   @Test
+  fun hiddenTopBarDoesNotKeepBackdropEffectComposed() = runComposeUiTest {
+    setContent {
+      val hazeState = rememberHazeState()
+      val topBarState = remember { TopBarState().apply { animatedAlpha = 0f } }
+
+      CompositionLocalProvider(LocalTopBarAnimationSource provides topBarState) {
+        NavigationTopBarBackdrop(
+          hazeState = hazeState,
+          style = { NavigationTopBarBackdropStyle(background = Color.Black, presence = 1f) },
+        )
+      }
+    }
+    waitForIdle()
+
+    onNodeWithTag(NavigationTopBarBackdropTestTag).assertDoesNotExist()
+  }
+
+  @Test
   fun navigationTopBarBlurChangesContinuouslyThroughFade() = runComposeUiTest {
     setContent {
       val hazeState = rememberHazeState()
@@ -49,7 +67,9 @@ class TypieTopBarProgressiveBlurEffectDesktopTest {
           }
           NavigationTopBarBackdrop(
             hazeState = hazeState,
-            style = NavigationTopBarBackdropStyle(background = Color.Transparent, presence = 1f),
+            style = {
+              NavigationTopBarBackdropStyle(background = Color.Transparent, presence = 1f)
+            },
             modifier = Modifier,
           )
         }


### PR DESCRIPTION
이제 일부 화면을 swipe back 할 때 버벅이지 않습니다.

## 변경 사항

- navigation progress를 `graphicsLayer`와 draw callback에서 읽도록 변경했습니다.
- route translation, alpha, clip shape 계산이 navigation scene을 매 프레임 recompose하지 않도록 정리했습니다.
- top bar backdrop의 스타일과 배경색도 layer/draw/effect 단계에서 갱신하도록 변경했습니다.
- top bar가 숨겨진 경우 backdrop effect를 composition에 유지하지 않도록 했습니다.
- swipe back 중 navigation scene이 recompose되지 않는 회귀 테스트를 추가했습니다.