### PR TITLE
앱 본문 설정 미리보기 publication 디버그

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/preview/EditorPreview.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/preview/EditorPreview.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Constraints
@@ -278,7 +279,6 @@ private fun EditorPreviewContent(
 
   val publishedBundle = editor?.publishedBundle
   val publishedState = publishedBundle?.snapshot ?: EditorState.Initial
-  val pageSizes = publishedState.pageSizes
   val pageSpacing =
     when (layoutSpec) {
       is EditorDocumentLayoutSpec.Continuous -> 0.dp
@@ -294,25 +294,37 @@ private fun EditorPreviewContent(
     modifier = Modifier.fillMaxSize().clipToBounds().background(pageBackground),
   ) {
     val publishedVersion = publishedState.version
-    pageSizes.forEachIndexed { index, size ->
+    val publishedPageCount = publishedState.pageSizes.size
+    val preparingPage = editor?.preparingPage
+    val presentedPageCount = maxOf(publishedPageCount, (preparingPage ?: -1) + 1)
+    repeat(presentedPageCount) { index ->
+      val preparing = index >= publishedPageCount
+      val size =
+        publishedState.pageSizes.getOrNull(index)
+          ?: editor?.appliedState?.pageSizes?.getOrNull(index)?.takeIf { preparingPage == index }
+          ?: return@repeat
       EditorPageSurface(
         page = index,
         width = size.width,
         height = size.height,
         publishedVersion = publishedVersion,
         publishedFrame = publishedBundle?.frames?.get(index),
-        showChrome = layoutSpec is EditorDocumentLayoutSpec.Paginated,
+        showChrome = layoutSpec is EditorDocumentLayoutSpec.Paginated && !preparing,
         debugBottomMarginHeight =
           when (layoutSpec) {
             is EditorDocumentLayoutSpec.Paginated -> layoutSpec.pageMarginBottom
             is EditorDocumentLayoutSpec.Continuous -> 0f
           },
         modifier =
-          Modifier.editorPagePositionTracker(
-            uiState = uiState,
-            page = index,
-            density = density.density,
-          ),
+          if (preparing) {
+            Modifier.graphicsLayer(alpha = 0f)
+          } else {
+            Modifier.editorPagePositionTracker(
+              uiState = uiState,
+              page = index,
+              density = density.density,
+            )
+          },
       )
     }
   }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/preview/EditorPreviewDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/preview/EditorPreviewDesktopTest.kt
@@ -17,15 +17,19 @@ import co.typie.editor.EditorRootId
 import co.typie.editor.FakeFfiEditor
 import co.typie.editor.ffi.LayoutMode
 import co.typie.editor.ffi.Message
+import co.typie.editor.ffi.Modifier as EditorModifier
 import co.typie.editor.ffi.NodeOp
 import co.typie.editor.ffi.PlainNode
 import co.typie.editor.ffi.PlainRootNode
 import co.typie.editor.runtime.EditorRuntime
 import co.typie.ui.theme.LocalThemeMode
 import co.typie.ui.theme.ResolvedThemeMode
+import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 import kotlin.test.assertSame
+import kotlin.test.assertTrue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -33,6 +37,61 @@ import kotlinx.coroutines.cancel
 
 @OptIn(ExperimentalTestApi::class)
 class EditorPreviewDesktopTest {
+  @Test
+  fun pageSizeAndBodySizeChangesPublishCoherentPreviewFrames() = runComposeUiTest {
+    configureRenderBufferLibrary()
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+    val runtime = EditorRuntime(scope)
+    var layout by mutableStateOf<LayoutMode>(A5Layout)
+    var modifiers by mutableStateOf(listOf<EditorModifier>(EditorModifier.FontSize(1200)))
+
+    try {
+      setContent {
+        CompositionLocalProvider(
+          LocalDensity provides Density(1f),
+          LocalThemeMode provides ResolvedThemeMode.Light,
+        ) {
+          EditorPreview(
+            layoutMode = layout,
+            runtime = runtime,
+            modifier = Modifier.size(width = 320.dp, height = 220.dp),
+            shape = RoundedCornerShape(0.dp),
+            modifiers = modifiers,
+          )
+        }
+      }
+      waitUntil(timeoutMillis = 10_000) {
+        runtime.editor?.hasPublishedFrameFor(layout = A5Layout, fontSize = 1200) == true
+      }
+      val a5FrameSize = runtime.editor!!.publishedBundle!!.frames.getValue(0).pixelSize
+
+      runOnIdle { layout = B6Layout }
+      waitUntil(timeoutMillis = 10_000) {
+        runtime.editor?.hasPublishedFrameFor(layout = B6Layout, fontSize = 1200) == true
+      }
+      waitForIdle()
+      val b6Bundle = runtime.editor!!.publishedBundle!!
+
+      assertNotEquals(a5FrameSize, b6Bundle.frames.getValue(0).pixelSize)
+
+      runOnIdle { modifiers = listOf(EditorModifier.FontSize(1800)) }
+      waitUntil(timeoutMillis = 10_000) {
+        runtime.editor?.hasPublishedFrameFor(layout = B6Layout, fontSize = 1800) == true
+      }
+      waitForIdle()
+      val bodySizeBundle = runtime.editor!!.publishedBundle!!
+
+      assertTrue(bodySizeBundle.snapshot.version > b6Bundle.snapshot.version)
+      assertNotEquals(
+        b6Bundle.frames.getValue(0).proof.frameKey,
+        bodySizeBundle.frames.getValue(0).proof.frameKey,
+      )
+    } finally {
+      runtime.clear()
+      scope.cancel()
+    }
+  }
+
   @Test
   fun generatedPreviewKeepsItsEditorWhenPageSizeChanges() = runComposeUiTest {
     val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
@@ -121,12 +180,54 @@ class EditorPreviewDesktopTest {
 
     val B6Layout =
       LayoutMode.Paginated(
-        pageWidth = 484,
-        pageHeight = 686,
-        pageMarginTop = 57,
-        pageMarginBottom = 57,
-        pageMarginLeft = 57,
-        pageMarginRight = 57,
+        pageWidth = 472,
+        pageHeight = 665,
+        pageMarginTop = 38,
+        pageMarginBottom = 38,
+        pageMarginLeft = 38,
+        pageMarginRight = 38,
+      )
+
+    val A5Layout =
+      LayoutMode.Paginated(
+        pageWidth = 559,
+        pageHeight = 794,
+        pageMarginTop = 76,
+        pageMarginBottom = 76,
+        pageMarginLeft = 76,
+        pageMarginRight = 76,
       )
   }
+}
+
+private fun Editor.hasPublishedFrameFor(layout: LayoutMode, fontSize: Int): Boolean {
+  val bundle = publishedBundle ?: return false
+  val presentedFontSize =
+    bundle.snapshot.rootModifiers
+      .orEmpty()
+      .filterIsInstance<EditorModifier.FontSize>()
+      .firstOrNull()
+  return bundle.snapshot.rootAttrs?.layoutMode == layout &&
+    presentedFontSize?.value == fontSize &&
+    bundle.frames.size == bundle.snapshot.pageSizes.size &&
+    bundle.frames.values.all { frame -> frame.proof.editorRevision == bundle.snapshot.version }
+}
+
+private fun configureRenderBufferLibrary() {
+  if (System.getProperty("jna.library.path") != null) return
+
+  val repository =
+    generateSequence(File(System.getProperty("user.dir"))) { it.parentFile }
+      .firstOrNull { File(it, "Cargo.toml").isFile } ?: error("Typie repository root not found")
+  val host =
+    when (System.getProperty("os.arch")) {
+      "aarch64" -> "aarch64-apple-darwin"
+      "x86_64" -> "x86_64-apple-darwin"
+      else -> error("Unsupported desktop test architecture: ${System.getProperty("os.arch")}")
+    }
+  val directory = File(repository, "target/$host/release-uniffi")
+  check(File(directory, "libeditor_ffi.dylib").isFile) {
+    "Desktop editor FFI is not built; run `just -f crates/editor-ffi/justfile desktop`"
+  }
+  System.setProperty("jna.library.path", directory.absolutePath)
 }


### PR DESCRIPTION
## 문제

#5122 에서 메인 에디터에는 새 페이지를 준비하는 `preparingPage` 처리가 추가됐지만, 본문 설정 프리뷰에는 반영되지 않았음.

이 때문에 페이지 크기, 여백, 텍스트 크기 등의 변경 후 프리뷰 갱신이 멈출 수 있었음.

## 변경

- 프리뷰에도 `preparingPage` surface를 연결함
- 준비 중인 페이지는 보이지 않게 렌더링한 뒤 프레임이 준비되면 공개함
- 설정 변경이 최신 프레임까지 반영되는 회귀 테스트를 추가함