### PR TITLE
앱 에디터 및 본문 설정 진입 성능 개선

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/preview/EditorPreview.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/preview/EditorPreview.kt
@@ -68,6 +68,14 @@ import dev.chrisbanes.haze.hazeSource
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 
+internal sealed interface EditorPreviewSource {
+  data object Generated : EditorPreviewSource
+
+  data class Graph(val bytes: ByteArray) : EditorPreviewSource
+
+  data object AttachedEditor : EditorPreviewSource
+}
+
 @Composable
 internal fun EditorPreview(
   layoutMode: LayoutMode,
@@ -75,14 +83,20 @@ internal fun EditorPreview(
   modifier: Modifier = Modifier,
   shape: RoundedCornerShape,
   contentTopPadding: Dp = 0.dp,
-  graph: ByteArray? = null,
+  source: EditorPreviewSource = EditorPreviewSource.Generated,
   modifiers: List<EditorModifier> = emptyList(),
   hintText: String = "미리보기 텍스트",
 ) {
   val colors = AppTheme.colors
   val scope = rememberCoroutineScope()
   val sourceKey =
-    remember(graph) { graph?.let { it.size to it.contentHashCode() } ?: GeneratedPreviewSourceKey }
+    remember(source) {
+      when (source) {
+        is EditorPreviewSource.Graph -> source.bytes.size to source.bytes.contentHashCode()
+        EditorPreviewSource.AttachedEditor,
+        EditorPreviewSource.Generated -> source
+      }
+    }
   val doc =
     remember(runtime, sourceKey) {
       defaultPreviewDoc(layoutMode).withPreviewRootModifiers(modifiers)
@@ -105,8 +119,11 @@ internal fun EditorPreview(
   val hintHazeState = remember { HazeState() }
   val hintEvents = remember { MutableSharedFlow<Unit>(extraBufferCapacity = 1) }
 
-  DisposableEffect(runtime, sourceKey) { onDispose { runtime.clear() } }
-  LaunchedEffect(runtime.editor, layoutMode, modifiers) {
+  DisposableEffect(runtime, sourceKey) {
+    onDispose { if (source !== EditorPreviewSource.AttachedEditor) runtime.clear() }
+  }
+  LaunchedEffect(runtime.editor, sourceKey, layoutMode, modifiers) {
+    if (source === EditorPreviewSource.AttachedEditor) return@LaunchedEffect
     val editor = runtime.editor ?: return@LaunchedEffect
     val currentModifiers = editor.appliedState.rootModifiers.orEmpty().toPreviewRootModifierMap()
     val changedModifiers = modifiers.filter { modifier ->
@@ -166,7 +183,7 @@ internal fun EditorPreview(
             LocalEditorBringIntoViewRequests provides bringIntoViewRequests,
           ) {
             EditorPreviewContent(
-              graph = graph,
+              source = source,
               doc = doc,
               sourceKey = sourceKey,
               editorScope = scope,
@@ -199,7 +216,7 @@ internal fun EditorPreview(
 
 @Composable
 private fun EditorPreviewContent(
-  graph: ByteArray?,
+  source: EditorPreviewSource,
   doc: PlainDoc,
   sourceKey: Any,
   editorScope: CoroutineScope,
@@ -230,7 +247,15 @@ private fun EditorPreviewContent(
     }
   }
 
-  LaunchedEffect(runtime, sourceKey, viewportWidth, viewportHeight, density.density, themeVariant) {
+  LaunchedEffect(
+    runtime,
+    editor,
+    sourceKey,
+    viewportWidth,
+    viewportHeight,
+    density.density,
+    themeVariant,
+  ) {
     val viewport =
       Viewport(
         width = viewportWidth,
@@ -240,22 +265,24 @@ private fun EditorPreviewContent(
     val activeEditor = runtime.editor
     if (activeEditor == null) {
       val nextEditor =
-        if (graph != null) {
-          Editor.create(
-            graph = graph,
-            viewport = viewport,
-            themeVariant = themeVariant,
-            scope = editorScope,
-            onError = { activeEditor, error -> runtime.reportError(activeEditor, error) },
-          )
-        } else {
-          Editor.createFromDoc(
-            doc = doc,
-            viewport = viewport,
-            themeVariant = themeVariant,
-            scope = editorScope,
-            onError = { activeEditor, error -> runtime.reportError(activeEditor, error) },
-          )
+        when (source) {
+          is EditorPreviewSource.Graph ->
+            Editor.create(
+              graph = source.bytes,
+              viewport = viewport,
+              themeVariant = themeVariant,
+              scope = editorScope,
+              onError = { activeEditor, error -> runtime.reportError(activeEditor, error) },
+            )
+          EditorPreviewSource.Generated ->
+            Editor.createFromDoc(
+              doc = doc,
+              viewport = viewport,
+              themeVariant = themeVariant,
+              scope = editorScope,
+              onError = { activeEditor, error -> runtime.reportError(activeEditor, error) },
+            )
+          EditorPreviewSource.AttachedEditor -> return@LaunchedEffect
         }
       runtime.attach(nextEditor)
     } else {
@@ -407,8 +434,6 @@ private fun EditorModifier.previewRootModifierType(): ModifierType? =
     is EditorModifier.BlockGap -> ModifierType.BlockGap
     else -> null
   }
-
-private data object GeneratedPreviewSourceKey
 
 private val DefaultPreviewRootModifiers =
   mapOf(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/sync/ws/DocumentGraphLoader.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/sync/ws/DocumentGraphLoader.kt
@@ -1,6 +1,9 @@
 package co.typie.editor.sync.ws
 
 import co.typie.editor.ffi.GraphIngest
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 data class DocumentSyncBaseline(val seq: String, val heads: ByteArray, val durableHeads: ByteArray)
 
@@ -11,7 +14,10 @@ sealed interface DocumentGraphLoaderEvent {
   data class Failed(val code: String) : DocumentGraphLoaderEvent
 }
 
-class DocumentGraphLoader(private val beginIngest: () -> GraphIngest) {
+class DocumentGraphLoader(
+  private val ingestDispatcher: CoroutineDispatcher = Dispatchers.Default,
+  private val beginIngest: () -> GraphIngest,
+) {
   private sealed interface State {
     data object Idle : State
 
@@ -24,7 +30,7 @@ class DocumentGraphLoader(private val beginIngest: () -> GraphIngest) {
 
   private var state: State = State.Idle
 
-  fun handle(event: AttachEvent): DocumentGraphLoaderEvent? =
+  suspend fun handle(event: AttachEvent): DocumentGraphLoaderEvent? =
     when (event) {
       is AttachEvent.SnapshotChunkEvent -> onChunk(event.bytes)
       AttachEvent.SnapshotRestart -> onRestart()
@@ -38,7 +44,7 @@ class DocumentGraphLoader(private val beginIngest: () -> GraphIngest) {
     onReload()
   }
 
-  private fun onChunk(bytes: ByteArray): DocumentGraphLoaderEvent? {
+  private suspend fun onChunk(bytes: ByteArray): DocumentGraphLoaderEvent? {
     val receiving = state as? State.Receiving
     val handle: GraphIngest
     if (receiving != null) {
@@ -46,8 +52,8 @@ class DocumentGraphLoader(private val beginIngest: () -> GraphIngest) {
     } else {
       handle = beginIngest()
     }
-    handle.appendChunk(bytes)
     state = State.Receiving(handle)
+    withContext(ingestDispatcher) { handle.appendChunk(bytes) }
     return null
   }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/document/bodysettings/DocumentBodySettingsScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/document/bodysettings/DocumentBodySettingsScreen.kt
@@ -41,6 +41,7 @@ import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.SystemEvent
 import co.typie.editor.ffi.Viewport
 import co.typie.editor.preview.EditorPreview
+import co.typie.editor.preview.EditorPreviewSource
 import co.typie.editor.runProtectedDocumentReload
 import co.typie.editor.runtime.EditorRuntime
 import co.typie.editor.sync.ActiveDocumentEditingSessions
@@ -62,7 +63,6 @@ import co.typie.ext.verticalScroll
 import co.typie.graphql.QueryState
 import co.typie.navigation.Nav
 import co.typie.navigation.RouteRemovalDecision
-import co.typie.platform.PlatformModule
 import co.typie.result.withDefaultExceptionHandler
 import co.typie.route.Route
 import co.typie.screen.editor.editor.EditorRouteLeaveInterceptor
@@ -103,7 +103,6 @@ import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 @OptIn(ExperimentalAtomicApi::class)
 @Composable
@@ -138,7 +137,6 @@ fun DocumentBodySettingsScreen(entityId: String) {
     var loaderFailedCode by remember(document.id) { mutableStateOf<String?>(null) }
     var routeLeaveActive by remember(document.id) { mutableStateOf(false) }
     val channel = remember(document.id) { SyncWs.channel(document.id) }
-    val graph = load?.graph
 
     val colors = AppTheme.colors
     val layoutDirection = LocalLayoutDirection.current
@@ -146,10 +144,16 @@ fun DocumentBodySettingsScreen(entityId: String) {
     val previewHeight = 200.dp
     val previewContainerHeight = topBarClearance + previewHeight
     val previewShape = RoundedCornerShape(bottomStart = AppShapes.xl, bottomEnd = AppShapes.xl)
-    val graphKey = remember(graph) { graph?.let { it.size to it.contentHashCode() } }
     var initial by
-      remember(document.id, graphKey) { mutableStateOf<DocumentBodySettingsInitialState?>(null) }
-    val previewGraph = if (initial?.hasText == true) graph else null
+      remember(document.id, load) { mutableStateOf<DocumentBodySettingsInitialState?>(null) }
+    val previewUsesDocumentEditor = initial?.hasText == true
+    val activePreviewRuntime = if (previewUsesDocumentEditor) settingsRuntime else previewRuntime
+    val previewSource =
+      if (previewUsesDocumentEditor) {
+        EditorPreviewSource.AttachedEditor
+      } else {
+        EditorPreviewSource.Generated
+      }
     var bodyStyle by remember(document.id) { mutableStateOf<EditorStyleSettings?>(null) }
     val editorThemeVariant = currentEditorThemeVariant()
     var layout by remember(document.id) { mutableStateOf<LayoutMode?>(null) }
@@ -365,30 +369,6 @@ fun DocumentBodySettingsScreen(entityId: String) {
       }
     }
 
-    LaunchedEffect(graphKey) {
-      val currentGraph = graph ?: return@LaunchedEffect
-      val nextInitial =
-        withContext(Dispatchers.Default) {
-          DocumentBodySettingsInitialState(
-            hasText =
-              runCatching {
-                  PlatformModule.editorHost.extractTextFromGraph(currentGraph).isNotBlank()
-                }
-                .getOrDefault(true),
-            style =
-              runCatching { PlatformModule.editorHost.rootModifiersFromGraph(currentGraph) }
-                .getOrDefault(emptyList())
-                .toEditorStyleSettings(),
-            layout =
-              runCatching { PlatformModule.editorHost.rootAttrsFromGraph(currentGraph).layoutMode }
-                .getOrDefault(DefaultRootPaginatedLayout),
-          )
-        }
-      initial = nextInitial
-      if (bodyStyle == null) bodyStyle = nextInitial.style
-      if (layout == null) layout = nextInitial.layout
-    }
-
     LaunchedEffect(load, document.id, channel) {
       val readyLoad = load ?: return@LaunchedEffect
       if (!settingsRuntime.canCreateEditor) return@LaunchedEffect
@@ -419,6 +399,12 @@ fun DocumentBodySettingsScreen(entityId: String) {
           )
         readyEditor = createdEditor
         bootstrapFailure.load()?.let { throw it }
+        val nextInitial = createdEditor.readBodySettingsInitialState()
+        bootstrapFailure.load()?.let { throw it }
+        if (load !== readyLoad) return@LaunchedEffect
+        initial = nextInitial
+        if (bodyStyle == null) bodyStyle = nextInitial.style
+        if (layout == null) layout = nextInitial.layout
 
         lateinit var createdSession: DocumentEditingSession
         readyLoad.activate(
@@ -677,11 +663,11 @@ fun DocumentBodySettingsScreen(entityId: String) {
         if (initial != null) {
           EditorPreview(
             layoutMode = resolvedLayout,
-            runtime = previewRuntime,
+            runtime = activePreviewRuntime,
             modifier = Modifier.fillMaxWidth().height(previewContainerHeight).zIndex(1f),
             shape = previewShape,
             contentTopPadding = topBarClearance,
-            graph = previewGraph,
+            source = previewSource,
             modifiers = resolvedBodyStyle.toEditorModifiers(),
           )
         } else {
@@ -712,6 +698,15 @@ private data class DocumentBodySettingsInitialState(
   val style: EditorStyleSettings,
   val layout: LayoutMode,
 )
+
+private suspend fun Editor.readBodySettingsInitialState(): DocumentBodySettingsInitialState {
+  val state = appliedState
+  return DocumentBodySettingsInitialState(
+    hasText = proseText().isNotBlank(),
+    style = state.rootModifiers.orEmpty().toEditorStyleSettings(),
+    layout = state.rootAttrs?.layoutMode ?: DefaultRootPaginatedLayout,
+  )
+}
 
 internal class DocumentBodySettingsLoad(val graph: ByteArray, baseline: DocumentSyncBaseline) {
   private val pending = mutableListOf<AttachEvent.ChangesetsEvent>()

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/sync/ws/DocumentGraphLoaderTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/sync/ws/DocumentGraphLoaderTest.kt
@@ -3,11 +3,14 @@ package co.typie.editor.sync.ws
 import co.typie.editor.ffi.Editor
 import co.typie.editor.ffi.GraphIngest
 import co.typie.editor.ffi.Viewport
+import kotlin.coroutines.CoroutineContext
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertSame
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.test.runTest
 
 private class FakeGraphIngest : GraphIngest {
   val appended = mutableListOf<ByteArray>()
@@ -44,9 +47,37 @@ private fun chunk(bytes: ByteArray = byteArrayOf(1)) =
 private fun end(seq: String = "0-1") =
   AttachEvent.SnapshotEndEvent(seq = seq, heads = ByteArray(0), durableHeads = ByteArray(0))
 
+private class RecordingDispatcher : CoroutineDispatcher() {
+  var dispatchCount = 0
+    private set
+
+  override fun dispatch(context: CoroutineContext, block: Runnable) {
+    dispatchCount += 1
+    block.run()
+  }
+}
+
 class DocumentGraphLoaderTest {
   @Test
-  fun restart_aborts_old_handle_and_begins_new_handle_exactly_once() {
+  fun snapshot_chunk_append_runs_on_ingest_dispatcher_before_transfer() = runTest {
+    val dispatcher = RecordingDispatcher()
+    val handles = mutableListOf<FakeGraphIngest>()
+    val loader =
+      DocumentGraphLoader(
+        beginIngest = { FakeGraphIngest().also(handles::add) },
+        ingestDispatcher = dispatcher,
+      )
+
+    assertNull(loader.handle(chunk(byteArrayOf(1, 2, 3))))
+    val loaded = assertIs<DocumentGraphLoaderEvent.Loaded>(loader.handle(end()))
+
+    assertEquals(1, dispatcher.dispatchCount)
+    assertEquals(byteArrayOf(1, 2, 3).toList(), handles.single().appended.single().toList())
+    assertSame(handles.single(), loaded.handle)
+  }
+
+  @Test
+  fun restart_aborts_old_handle_and_begins_new_handle_exactly_once() = runTest {
     val handles = mutableListOf<FakeGraphIngest>()
     val loader = DocumentGraphLoader { FakeGraphIngest().also(handles::add) }
 
@@ -67,30 +98,31 @@ class DocumentGraphLoaderTest {
   }
 
   @Test
-  fun reload_after_transferred_does_not_abort_handle_and_begins_new_ingest_on_next_chunk() {
-    val handles = mutableListOf<FakeGraphIngest>()
-    val loader = DocumentGraphLoader { FakeGraphIngest().also(handles::add) }
+  fun reload_after_transferred_does_not_abort_handle_and_begins_new_ingest_on_next_chunk() =
+    runTest {
+      val handles = mutableListOf<FakeGraphIngest>()
+      val loader = DocumentGraphLoader { FakeGraphIngest().also(handles::add) }
 
-    assertNull(loader.handle(chunk()))
-    val firstLoaded = loader.handle(end())
-    assertIs<DocumentGraphLoaderEvent.Loaded>(firstLoaded)
-    val firstHandle = handles.single()
+      assertNull(loader.handle(chunk()))
+      val firstLoaded = loader.handle(end())
+      assertIs<DocumentGraphLoaderEvent.Loaded>(firstLoaded)
+      val firstHandle = handles.single()
 
-    assertNull(loader.handle(AttachEvent.ReloadEvent))
-    assertEquals(0, firstHandle.abortCount)
+      assertNull(loader.handle(AttachEvent.ReloadEvent))
+      assertEquals(0, firstHandle.abortCount)
 
-    assertNull(loader.handle(chunk()))
-    assertEquals(2, handles.size)
-    assertEquals(0, firstHandle.abortCount)
+      assertNull(loader.handle(chunk()))
+      assertEquals(2, handles.size)
+      assertEquals(0, firstHandle.abortCount)
 
-    val secondLoaded = loader.handle(end())
-    assertIs<DocumentGraphLoaderEvent.Loaded>(secondLoaded)
-    assertSame(handles[1], secondLoaded.handle)
-    assertEquals(0, firstHandle.abortCount)
-  }
+      val secondLoaded = loader.handle(end())
+      assertIs<DocumentGraphLoaderEvent.Loaded>(secondLoaded)
+      assertSame(handles[1], secondLoaded.handle)
+      assertEquals(0, firstHandle.abortCount)
+    }
 
   @Test
-  fun duplicate_snapshot_end_after_transfer_is_ignored() {
+  fun duplicate_snapshot_end_after_transfer_is_ignored() = runTest {
     val handles = mutableListOf<FakeGraphIngest>()
     val loader = DocumentGraphLoader { FakeGraphIngest().also(handles::add) }
 
@@ -105,7 +137,7 @@ class DocumentGraphLoaderTest {
   }
 
   @Test
-  fun handle_is_delivered_exactly_once_ready_to_finish_after_end() {
+  fun handle_is_delivered_exactly_once_ready_to_finish_after_end() = runTest {
     val handles = mutableListOf<FakeGraphIngest>()
     val loader = DocumentGraphLoader { FakeGraphIngest().also(handles::add) }
 
@@ -126,7 +158,7 @@ class DocumentGraphLoaderTest {
   }
 
   @Test
-  fun restart_after_transferred_is_ignored() {
+  fun restart_after_transferred_is_ignored() = runTest {
     val handles = mutableListOf<FakeGraphIngest>()
     val loader = DocumentGraphLoader { FakeGraphIngest().also(handles::add) }
 
@@ -146,7 +178,7 @@ class DocumentGraphLoaderTest {
   }
 
   @Test
-  fun permanent_error_while_receiving_aborts_handle_once_and_emits_failed() {
+  fun permanent_error_while_receiving_aborts_handle_once_and_emits_failed() = runTest {
     val handles = mutableListOf<FakeGraphIngest>()
     val loader = DocumentGraphLoader { FakeGraphIngest().also(handles::add) }
 
@@ -160,7 +192,7 @@ class DocumentGraphLoaderTest {
   }
 
   @Test
-  fun cancel_while_receiving_aborts_handle_once() {
+  fun cancel_while_receiving_aborts_handle_once() = runTest {
     val handles = mutableListOf<FakeGraphIngest>()
     val loader = DocumentGraphLoader { FakeGraphIngest().also(handles::add) }
 
@@ -173,7 +205,7 @@ class DocumentGraphLoaderTest {
   }
 
   @Test
-  fun cancel_after_transferred_does_not_abort_handle() {
+  fun cancel_after_transferred_does_not_abort_handle() = runTest {
     val handles = mutableListOf<FakeGraphIngest>()
     val loader = DocumentGraphLoader { FakeGraphIngest().also(handles::add) }
 

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/preview/EditorPreviewDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/preview/EditorPreviewDesktopTest.kt
@@ -146,6 +146,60 @@ class EditorPreviewDesktopTest {
     }
   }
 
+  @Test
+  fun attachedDocumentPreviewDoesNotOwnOrRestyleItsEditor() = runComposeUiTest {
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+    val fake =
+      FakeFfiEditor(
+        rootAttrsProvider = { PlainRootNode(layoutMode = A4Layout) },
+        rootModifiersProvider = { listOf(EditorModifier.FontSize(1200)) },
+      )
+    val editor = Editor(fake, scope, Dispatchers.Unconfined)
+    val runtime = EditorRuntime(scope).apply { attach(editor) }
+    var shown by mutableStateOf(true)
+    var layout by mutableStateOf<LayoutMode>(A4Layout)
+    var modifiers by mutableStateOf(listOf<EditorModifier>(EditorModifier.FontSize(1200)))
+    fake.applySnapshot(editor)
+
+    try {
+      setContent {
+        if (shown) {
+          CompositionLocalProvider(
+            LocalDensity provides Density(1f),
+            LocalThemeMode provides ResolvedThemeMode.Light,
+          ) {
+            EditorPreview(
+              layoutMode = layout,
+              runtime = runtime,
+              modifier = Modifier.size(0.dp),
+              shape = RoundedCornerShape(0.dp),
+              source = EditorPreviewSource.AttachedEditor,
+              modifiers = modifiers,
+            )
+          }
+        }
+      }
+      waitForIdle()
+      fake.enqueued.clear()
+
+      runOnIdle {
+        layout = B6Layout
+        modifiers = listOf(EditorModifier.FontSize(1800))
+      }
+      waitForIdle()
+
+      assertTrue(fake.enqueued.none { it is Message.Node || it is Message.Modifier })
+
+      runOnIdle { shown = false }
+      waitForIdle()
+
+      runOnIdle { assertSame(editor, runtime.editor) }
+    } finally {
+      runtime.clear()
+      scope.cancel()
+    }
+  }
+
   private fun androidx.compose.ui.test.ComposeUiTest.setPreviewContent(
     runtime: EditorRuntime,
     graph: ByteArray? = null,
@@ -161,7 +215,7 @@ class EditorPreviewDesktopTest {
           runtime = runtime,
           modifier = Modifier.size(0.dp),
           shape = RoundedCornerShape(0.dp),
-          graph = graph,
+          source = graph?.let(EditorPreviewSource::Graph) ?: EditorPreviewSource.Generated,
         )
       }
     }


### PR DESCRIPTION
## 변경 사항

- 문서 snapshot chunk ingest를 background dispatcher에서 처리해 메인 스레드 작업을 줄였습니다.
- 본문 설정 초기 상태를 이미 초기화된 settings editor에서 읽도록 변경해 중복 graph 처리를 제거했습니다.
- 본문이 있는 문서는 settings editor를 미리보기에 재사용하고, 빈 문서는 기존 생성형 미리보기를 유지합니다.
- 외부에서 연결된 editor를 `EditorPreview`가 초기화하거나 해제하지 않도록 ownership을 구분했습니다.