### PR TITLE
앱 툴바에 세로 방향 제스처 추가

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractions.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractions.kt
@@ -61,7 +61,6 @@ internal fun Modifier.editorInteractions(
   maximumFlingVelocity: Float = Float.MAX_VALUE,
   density: Float,
   enabled: Boolean = true,
-  onEditorPointerInput: () -> Unit = {},
   onViewportIndirectInput: () -> Unit = {},
   onNestedScrollCancel: () -> Unit = {},
 ): Modifier =
@@ -79,7 +78,6 @@ internal fun Modifier.editorInteractions(
       maximumFlingVelocity = maximumFlingVelocity,
       density = density,
       enabled = enabled,
-      onEditorPointerInput = onEditorPointerInput,
       onViewportIndirectInput = onViewportIndirectInput,
       onNestedScrollCancel = onNestedScrollCancel,
     )
@@ -97,7 +95,6 @@ private data class EditorInteractionsElement(
   private val maximumFlingVelocity: Float,
   private val density: Float,
   private val enabled: Boolean,
-  private val onEditorPointerInput: () -> Unit,
   private val onViewportIndirectInput: () -> Unit,
   private val onNestedScrollCancel: () -> Unit,
 ) : ModifierNodeElement<EditorInteractionsNode>() {
@@ -115,7 +112,6 @@ private data class EditorInteractionsElement(
       maximumFlingVelocity = maximumFlingVelocity,
       density = density,
       enabled = enabled,
-      onEditorPointerInput = onEditorPointerInput,
       onViewportIndirectInput = onViewportIndirectInput,
       onNestedScrollCancel = onNestedScrollCancel,
     )
@@ -134,7 +130,6 @@ private data class EditorInteractionsElement(
       maximumFlingVelocity = maximumFlingVelocity,
       density = density,
       enabled = enabled,
-      onEditorPointerInput = onEditorPointerInput,
       onViewportIndirectInput = onViewportIndirectInput,
       onNestedScrollCancel = onNestedScrollCancel,
     )
@@ -154,7 +149,6 @@ private class EditorInteractionsNode(
   var maximumFlingVelocity: Float,
   var density: Float,
   var enabled: Boolean,
-  var onEditorPointerInput: () -> Unit,
   var onViewportIndirectInput: () -> Unit,
   var onNestedScrollCancel: () -> Unit,
 ) :
@@ -202,7 +196,6 @@ private class EditorInteractionsNode(
     maximumFlingVelocity: Float,
     density: Float,
     enabled: Boolean,
-    onEditorPointerInput: () -> Unit,
     onViewportIndirectInput: () -> Unit,
     onNestedScrollCancel: () -> Unit,
   ) {
@@ -238,7 +231,6 @@ private class EditorInteractionsNode(
     this.maximumFlingVelocity = maximumFlingVelocity
     this.density = density
     this.enabled = enabled
-    this.onEditorPointerInput = onEditorPointerInput
     this.onViewportIndirectInput = onViewportIndirectInput
     this.onNestedScrollCancel = onNestedScrollCancel
   }
@@ -251,14 +243,6 @@ private class EditorInteractionsNode(
       cancelInteraction(clearSuppression = true)
       return
     }
-    if (
-      pointerEvent.changes.any { change ->
-        change.isDirectDown(pointerEvent) && change.id.value in pointers
-      }
-    ) {
-      onEditorPointerInput()
-    }
-
     interactionController.updateTapSlop(tapSlopPx = EditorTapSlopDp * density)
     interactionController.updateColumnResizeSlop(
       dragSlopPx = min(touchSlop, EditorTapSlopDp * density)
@@ -667,7 +651,6 @@ private class EditorInteractionsNode(
     if (!zoomModified) {
       finishWheelZoom()
       if (scrollDriver.launchPointerSignalScroll(scrollDelta = scrollDelta, density = density)) {
-        onEditorPointerInput()
         onViewportIndirectInput()
         pointerEvent.changes.forEach(PointerInputChange::consume)
       }
@@ -707,7 +690,6 @@ private class EditorInteractionsNode(
       return
     }
     keepWheelZoomAlive()
-    onEditorPointerInput()
     onViewportIndirectInput()
     pointerEvent.changes.forEach(PointerInputChange::consume)
   }
@@ -744,7 +726,6 @@ private class EditorInteractionsNode(
           change.panOffset.takeIf { offset -> !change.isConsumed && offset.isUsablePanOffset() }
         }
       if (panOffset != null && scrollDriver.launchTrackpadPan(panOffset)) {
-        onEditorPointerInput()
         onViewportIndirectInput()
       }
     }
@@ -818,7 +799,6 @@ private class EditorInteractionsNode(
       finishScaleZoom()
       return false
     }
-    onEditorPointerInput()
     onViewportIndirectInput()
     return true
   }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -1714,7 +1714,6 @@ fun EditorScreen(entityId: String) {
         platformIndirectScaleEnabled = platformIndirectScaleEnabled,
         viewportContentWidth = bodyTrackWidth,
         viewportScrollReconcileMode = viewportScrollReconcileMode,
-        onEditorPointerInput = { toolbarPagerState.dismissIndicator() },
         onViewportIndirectInput = { uiState.contextMenu.hide() },
         onRequestEditing =
           if (!isEditing && !editorReadOnly) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayout.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayout.kt
@@ -185,7 +185,6 @@ internal fun EditorScreenLayout(
   editorInteractionEnabled: Boolean = true,
   platformIndirectScaleEnabled: Boolean = editorInteractionEnabled,
   viewportScrollReconcileMode: EditorViewportScrollReconcileMode,
-  onEditorPointerInput: () -> Unit = {},
   onViewportIndirectInput: () -> Unit = {},
   onRequestEditing: (() -> Boolean)? = null,
   onMeasuredViewportSizeChange: (Size) -> Unit,
@@ -266,7 +265,6 @@ internal fun EditorScreenLayout(
         maximumFlingVelocity = viewConfiguration.maximumFlingVelocity,
         density = density.density,
         enabled = editorInteractionEnabled,
-        onEditorPointerInput = onEditorPointerInput,
         onViewportIndirectInput = onViewportIndirectInput,
         onNestedScrollCancel = { navigationPopNestedScroll?.cancel() },
       )

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarControls.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarControls.kt
@@ -24,11 +24,13 @@ import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.input.pointer.PointerEventPass
@@ -49,6 +51,7 @@ import co.typie.ui.icon.Icon
 import co.typie.ui.icon.IconData
 import co.typie.ui.theme.AppShapes
 import co.typie.ui.theme.AppTheme
+import kotlin.math.abs
 
 internal val ToolbarCapsuleShape = AppShapes.rounded(AppShapes.full)
 internal val ToolbarButtonShape = AppShapes.circle
@@ -296,6 +299,100 @@ internal fun Modifier.emitPressInteractions(interactionSource: MutableInteractio
       interactionSource.tryEmit(release)
     }
   }
+
+@Composable
+internal fun Modifier.toolbarVerticalSwipeGestures(
+  onPointerSessionStart: () -> Unit,
+  onSwipeUp: () -> Unit,
+  onSwipeDown: () -> Unit,
+  onSwipeDownProgress: (ToolbarDismissSwipeProgress) -> Unit,
+  onSwipeDownCancelled: () -> Unit,
+): Modifier {
+  val latestOnPointerSessionStart = rememberUpdatedState(onPointerSessionStart)
+  val latestOnSwipeUp = rememberUpdatedState(onSwipeUp)
+  val latestOnSwipeDown = rememberUpdatedState(onSwipeDown)
+  val latestOnSwipeDownProgress = rememberUpdatedState(onSwipeDownProgress)
+  val latestOnSwipeDownCancelled = rememberUpdatedState(onSwipeDownCancelled)
+
+  return pointerInput(Unit) {
+    awaitEachGesture {
+      val down = awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
+      latestOnPointerSessionStart.value()
+      var lastPosition = down.position
+      var totalDelta = Offset.Zero
+      var direction = 0
+      var dismissSwipeArmed = false
+
+      fun updateDismissSwipe(distance: Float) {
+        val nextArmed =
+          if (dismissSwipeArmed) {
+            distance > ToolbarDismissSwipeDisarmThreshold.toPx()
+          } else {
+            distance >= ToolbarDismissSwipeThreshold.toPx()
+          }
+        dismissSwipeArmed = nextArmed
+        latestOnSwipeDownProgress.value(
+          ToolbarDismissSwipeProgress(distancePx = distance, armed = nextArmed)
+        )
+      }
+
+      while (true) {
+        val event = awaitPointerEvent(PointerEventPass.Initial)
+        val change = event.changes.firstOrNull { it.id == down.id }
+        if (change == null || change.isConsumed) {
+          if (direction > 0) {
+            latestOnSwipeDownCancelled.value()
+          }
+          break
+        }
+
+        totalDelta += change.position - lastPosition
+        lastPosition = change.position
+
+        if (!change.pressed) {
+          if (direction > 0) {
+            change.consume()
+            if (dismissSwipeArmed) {
+              latestOnSwipeDown.value()
+            } else {
+              latestOnSwipeDownCancelled.value()
+            }
+          }
+          break
+        }
+
+        if (direction < 0) {
+          change.consume()
+          continue
+        }
+
+        if (direction > 0) {
+          change.consume()
+          updateDismissSwipe(totalDelta.y.coerceAtLeast(0f))
+          continue
+        }
+
+        val horizontalDistance = abs(totalDelta.x)
+        val verticalDistance = abs(totalDelta.y)
+        if (maxOf(horizontalDistance, verticalDistance) <= viewConfiguration.touchSlop) {
+          continue
+        }
+        if (verticalDistance < horizontalDistance * ToolbarDismissSwipeDirectionRatio) break
+
+        change.consume()
+        if (totalDelta.y < 0f) {
+          direction = -1
+          latestOnSwipeUp.value()
+        } else {
+          direction = 1
+          updateDismissSwipe(totalDelta.y)
+        }
+      }
+    }
+  }
+}
+
+internal data class ToolbarDismissSwipeProgress(val distancePx: Float, val armed: Boolean)
 
 internal fun Modifier.trackToolbarScrollGestureStart(
   onStart: () -> Unit,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarDefaults.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarDefaults.kt
@@ -1,5 +1,7 @@
 package co.typie.screen.editor.editor.toolbar
 
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.ScrollState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.dp
@@ -45,11 +47,18 @@ internal val ToolbarIndicatorPadding = 2.dp
 internal val ToolbarIndicatorItemGap = 2.dp
 internal val ToolbarOverscrollLimit = ToolbarPageIndicatorSlotWidth
 internal val ToolbarHardStopActivationEpsilon = 10.dp
+internal val ToolbarDismissSwipeThreshold = 36.dp
+internal val ToolbarDismissSwipeDisarmThreshold = 32.dp
+internal val ToolbarDismissSwipeArmedOffset = 16.dp
 
 internal const val ToolbarCapsulePressedScale = 1.015f
 internal const val ToolbarFixedActionPressedScale = 1.1f
 internal const val ToolbarOverscrollResistance = 0.45f
+internal const val ToolbarDismissSwipeDirectionRatio = 1.5f
+internal const val ToolbarDismissSwipeFollowFraction = 0.2f
 internal val ToolbarSwipeVelocityThreshold = 400.dp
+internal val ToolbarDismissSwipeThresholdSpring =
+  spring<Float>(dampingRatio = Spring.DampingRatioNoBouncy, stiffness = Spring.StiffnessHigh)
 internal const val ToolbarVisibilityEnterMillis = 200
 internal const val ToolbarVisibilityExitMillis = 160
 internal const val ToolbarFixedActionIconCrossfadeMillis = 150

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarHost.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarHost.kt
@@ -307,6 +307,10 @@ internal fun EditorToolbarHost(
             sessionState.clearSecondaryToolbar()
             onInputEffects(inputState.dispatch(ToolbarIntent.DismissInput, environment))
           },
+          onToolbarDismissRequest = {
+            sessionState.clearSecondaryToolbar()
+            onInputEffects(inputState.dispatch(ToolbarIntent.HideInput, environment))
+          },
           onBottomPanelToggle = ::toggleBottomPanel,
           onEditorMessage = { message -> sendEditorMessages(listOf(message)) },
           onToolAction = onToolAction,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarInputState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarInputState.kt
@@ -264,7 +264,7 @@ internal class EditorToolbarInputState {
       is ToolbarIntent.OpenPanel -> openPanel(intent.panel, intent.scope, environment)
       ToolbarIntent.RestoreEditorInput -> restoreEditorInput(environment)
       ToolbarIntent.DismissInput -> dismissInput(environment)
-      ToolbarIntent.HideInput -> hideInput()
+      ToolbarIntent.HideInput -> hideInput(environment)
       ToolbarIntent.Reset -> reset()
     }
 
@@ -374,16 +374,20 @@ internal class EditorToolbarInputState {
     if (environment.focused) {
       effects += EditorInputEffect.ClearFocus
     }
-    if (fixedAction == ToolbarFixedAction.DismissInput) {
-      effects += EditorInputEffect.EnterReadingMode
-    }
+    effects += EditorInputEffect.EnterReadingMode
     return effects
   }
 
-  private fun hideInput(): List<EditorInputEffect> {
+  private fun hideInput(environment: ToolbarInputEnvironment): List<EditorInputEffect> {
     resetInputState()
     lastPanelSnapshot = null
-    return listOf(EditorInputEffect.HideKeyboard)
+    return buildList {
+      add(EditorInputEffect.HideKeyboard)
+      if (environment.focused) {
+        add(EditorInputEffect.ClearFocus)
+      }
+      add(EditorInputEffect.EnterReadingMode)
+    }
   }
 
   private fun resetInputState() {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarPagerState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarPagerState.kt
@@ -28,7 +28,6 @@ internal class ToolbarPagerState {
   var indicatorInteracting by mutableStateOf(false)
   var indicatorDragging by mutableStateOf(false)
   var indicatorPulse by mutableIntStateOf(0)
-  private var indicatorDismissedAtPulse by mutableStateOf<Int?>(null)
   var indicatorDragProgress by mutableStateOf<Float?>(null)
   var indicatorPageTransitioning by mutableStateOf(false)
   var activeHardStop by mutableStateOf<ToolbarHardStop?>(null)
@@ -41,14 +40,6 @@ internal class ToolbarPagerState {
   var previousPageKeys by mutableStateOf<List<EditorToolbarPageKey>?>(null)
   var previousPageScrollRanges by mutableStateOf<List<Int>?>(null)
   var lastAppliedAutoTargetKey by mutableStateOf<Any?>(null)
-
-  val indicatorDismissed: Boolean
-    get() = indicatorDismissedAtPulse == indicatorPulse
-
-  fun dismissIndicator() {
-    indicatorDismissedAtPulse = indicatorPulse
-    indicatorVisible = false
-  }
 
   fun recordManualPageKey(pageKey: EditorToolbarPageKey) {
     recentManualPageKeys = listOf(pageKey) + recentManualPageKeys.filterNot { it == pageKey }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarPages.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarPages.kt
@@ -1,6 +1,7 @@
 package co.typie.screen.editor.editor.toolbar
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
@@ -42,7 +43,9 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import co.typie.editor.ffi.Message
@@ -69,6 +72,7 @@ import dev.chrisbanes.haze.hazeEffect
 import kotlin.math.abs
 import kotlin.math.roundToInt
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
@@ -130,6 +134,7 @@ internal fun EditorToolbarPages(
   fixedAction: ToolbarFixedAction,
   onEditorInputRequest: () -> Unit,
   onKeyboardDismissRequest: () -> Unit,
+  onToolbarDismissRequest: () -> Unit,
   onBottomPanelToggle: (EditorToolbarBottomPanel, EditorToolbarScope) -> Unit,
   onEditorMessage: (Message) -> Unit = {},
   onToolAction: (EditorToolbarToolAction) -> Unit = {},
@@ -144,6 +149,7 @@ internal fun EditorToolbarPages(
 ) {
   val scope = rememberCoroutineScope()
   val density = LocalDensity.current
+  val hapticFeedback = LocalHapticFeedback.current
   val hazeState = LocalHazeState.current
   val secondaryToolbarTransition = remember { MutableTransitionState(false) }
   secondaryToolbarTransition.targetState = secondaryToolbarVisible
@@ -164,9 +170,24 @@ internal fun EditorToolbarPages(
     val lastPageIndex = pageCount - 1
     val pageDistance = with(density) { maxWidth.roundToPx().coerceAtLeast(0) }.toFloat()
     val overscrollLimitPx = with(density) { ToolbarOverscrollLimit.toPx() }
+    val dismissSwipeArmedOffsetPx = with(density) { ToolbarDismissSwipeArmedOffset.toPx() }
     val hardStopActivationEpsilonPx = with(density) { ToolbarHardStopActivationEpsilon.toPx() }
     val swipeVelocityThresholdPx = with(density) { ToolbarSwipeVelocityThreshold.toPx() }
     var outerEdgeDrag by remember { mutableStateOf(ToolbarOuterEdgeDrag()) }
+    var dismissSwipeProgress by remember { mutableStateOf<ToolbarDismissSwipeProgress?>(null) }
+    var dismissSwipeArmedProgress by remember { mutableStateOf(Animatable(0f)) }
+    val dismissSwipeArmedAnimationJob = remember { mutableStateOf<Job?>(null) }
+    val dismissSwipeFollowOffset =
+      dismissSwipeProgress?.distancePx?.times(ToolbarDismissSwipeFollowFraction) ?: 0f
+    val dismissSwipeDragOffset =
+      dismissSwipeFollowOffset +
+        (dismissSwipeArmedOffsetPx - dismissSwipeFollowOffset) * dismissSwipeArmedProgress.value
+    val dismissSwipeVisualOffset by
+      animateFloatAsState(
+        targetValue = if (dismissSwipeProgress != null) dismissSwipeDragOffset else 0f,
+        animationSpec = if (dismissSwipeProgress != null) snap() else ToolbarOverscrollSpring,
+        label = "EditorToolbarDismissSwipeOffset",
+      )
     val outerEdgeVisualOffset =
       animateFloatAsState(
         targetValue = if (pagerState.pointerScrollGestureActive) outerEdgeDrag.offset else 0f,
@@ -381,12 +402,9 @@ internal fun EditorToolbarPages(
     }
 
     val indicatorHeldVisible =
-      !pagerState.indicatorDismissed &&
-        (pagerState.indicatorInteracting || pagerState.indicatorPageTransitioning)
-    LaunchedEffect(pagerState.indicatorPulse, pagerState.indicatorDismissed, indicatorHeldVisible) {
-      if (
-        pagerState.indicatorDismissed || (pagerState.indicatorPulse == 0 && !indicatorHeldVisible)
-      ) {
+      pagerState.indicatorInteracting || pagerState.indicatorPageTransitioning
+    LaunchedEffect(pagerState.indicatorPulse, indicatorHeldVisible) {
+      if (pagerState.indicatorPulse == 0 && !indicatorHeldVisible) {
         pagerState.indicatorVisible = false
         return@LaunchedEffect
       }
@@ -577,14 +595,7 @@ internal fun EditorToolbarPages(
 
     val indicatorAlpha by
       animateFloatAsState(
-        targetValue =
-          if (
-            !pagerState.indicatorDismissed && (pagerState.indicatorVisible || indicatorHeldVisible)
-          ) {
-            1f
-          } else {
-            0f
-          },
+        targetValue = if (pagerState.indicatorVisible || indicatorHeldVisible) 1f else 0f,
         animationSpec = tween(ToolbarIndicatorFadeMillis),
         label = "editor-toolbar-indicator-alpha",
       )
@@ -655,6 +666,44 @@ internal fun EditorToolbarPages(
           Modifier.align(Alignment.BottomCenter)
             .fillMaxWidth()
             .height(ToolbarHeight)
+            .toolbarVerticalSwipeGestures(
+              onPointerSessionStart = {
+                dismissSwipeArmedAnimationJob.value?.cancel()
+                dismissSwipeArmedAnimationJob.value = null
+                dismissSwipeProgress = null
+                dismissSwipeArmedProgress = Animatable(0f)
+              },
+              onSwipeUp = {
+                if (pageCount > 1) {
+                  pagerState.indicatorPulse++
+                }
+              },
+              onSwipeDown = {
+                dismissSwipeProgress = null
+                onToolbarDismissRequest()
+              },
+              onSwipeDownProgress = { progress ->
+                val armedChanged = (dismissSwipeProgress?.armed == true) != progress.armed
+                dismissSwipeProgress = progress
+                if (armedChanged) {
+                  dismissSwipeArmedAnimationJob.value?.cancel()
+                  val armedProgress = dismissSwipeArmedProgress
+                  dismissSwipeArmedAnimationJob.value = scope.launch {
+                    armedProgress.animateTo(
+                      targetValue = if (progress.armed) 1f else 0f,
+                      animationSpec = ToolbarDismissSwipeThresholdSpring,
+                    )
+                  }
+                  if (progress.armed) {
+                    hapticFeedback.performHapticFeedback(
+                      HapticFeedbackType.GestureThresholdActivate
+                    )
+                  }
+                }
+              },
+              onSwipeDownCancelled = { dismissSwipeProgress = null },
+            )
+            .graphicsLayer { translationY = dismissSwipeVisualOffset }
             .shadow(AppTheme.shadows.sm, ToolbarCapsuleShape)
             .pressScale(ToolbarCapsulePressedScale)
             .clip(ToolbarCapsuleShape)

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarInputStateTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarInputStateTest.kt
@@ -25,7 +25,7 @@ class ToolbarInputStateTest {
   }
 
   @Test
-  fun hide_input_closes_panel_and_keyboard_without_restoring_or_clearing_focus() {
+  fun hide_input_closes_panel_and_enters_reading_mode_without_restoring_keyboard() {
     val state = EditorToolbarInputState()
     val keyboardVisible = toolbarInputEnvironment(imeBottom = 320.dp)
 
@@ -37,7 +37,14 @@ class ToolbarInputStateTest {
     assertEquals(null, state.panel)
     assertEquals(null, state.keyboardRestoreInset)
     assertEquals(0.dp, state.rememberedKeyboardInset)
-    assertEquals(listOf(EditorInputEffect.HideKeyboard), effects)
+    assertEquals(
+      listOf(
+        EditorInputEffect.HideKeyboard,
+        EditorInputEffect.ClearFocus,
+        EditorInputEffect.EnterReadingMode,
+      ),
+      effects,
+    )
   }
 
   @Test
@@ -51,7 +58,41 @@ class ToolbarInputStateTest {
     val effects = state.dispatch(ToolbarIntent.HideInput, keyboardVisible)
     state.onEnvironmentChanged(keyboardVisible.copy(visible = false))
 
-    assertEquals(listOf(EditorInputEffect.HideKeyboard), effects)
+    assertEquals(
+      listOf(
+        EditorInputEffect.HideKeyboard,
+        EditorInputEffect.ClearFocus,
+        EditorInputEffect.EnterReadingMode,
+      ),
+      effects,
+    )
+  }
+
+  @Test
+  fun hardware_keyboard_toolbar_hide_action_enters_reading_mode() {
+    val state = EditorToolbarInputState()
+    val hardwareKeyboard =
+      toolbarInputEnvironment(
+        keyboardState = EditorKeyboardState(EditorKeyboardType.Hardware),
+        imeBottom = 0.dp,
+      )
+
+    val effects = state.dispatch(ToolbarIntent.DismissInput, hardwareKeyboard)
+
+    assertEquals(listOf(EditorInputEffect.ClearFocus, EditorInputEffect.EnterReadingMode), effects)
+  }
+
+  @Test
+  fun panel_close_action_restores_editor_input_without_entering_reading_mode() {
+    val state = EditorToolbarInputState()
+    val keyboardVisible = toolbarInputEnvironment(imeBottom = 320.dp)
+
+    state.onEnvironmentChanged(keyboardVisible)
+    state.dispatch(ToolbarIntent.OpenPanel(EditorToolbarBottomPanel.Tools), keyboardVisible)
+
+    val effects = state.dispatch(ToolbarIntent.DismissInput, keyboardVisible)
+
+    assertEquals(listOf(EditorInputEffect.RequestFocus, EditorInputEffect.ShowKeyboard), effects)
   }
 
   @Test

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/interaction/EditorInteractionsDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/interaction/EditorInteractionsDesktopTest.kt
@@ -377,13 +377,11 @@ class EditorInteractionsDesktopTest {
   }
 
   @Test
-  fun `platform indirect scale reports editor and viewport indirect input`() = runComposeUiTest {
+  fun `platform indirect scale reports viewport indirect input`() = runComposeUiTest {
     val fixture = Fixture()
-    var pointerInputCount = 0
     var viewportIndirectInputCount = 0
     setEditorContent(
       fixture = fixture,
-      onEditorPointerInput = { pointerInputCount += 1 },
       onViewportIndirectInput = { viewportIndirectInputCount += 1 },
     )
 
@@ -398,30 +396,8 @@ class EditorInteractionsDesktopTest {
       fixture.platformIndirectScaleBridge.end()
     }
 
-    assertEquals(1, pointerInputCount)
     assertEquals(1, viewportIndirectInputCount)
   }
-
-  @Test
-  fun `direct pointer down reports editor input without viewport indirect input`() =
-    runComposeUiTest {
-      val fixture = Fixture()
-      var pointerInputCount = 0
-      var viewportIndirectInputCount = 0
-      setEditorContent(
-        fixture = fixture,
-        onEditorPointerInput = { pointerInputCount += 1 },
-        onViewportIndirectInput = { viewportIndirectInputCount += 1 },
-      )
-
-      onNodeWithTag(EditorTag).performTouchInput { down(center) }
-      waitForIdle()
-
-      assertEquals(1, pointerInputCount)
-      assertEquals(0, viewportIndirectInputCount)
-
-      onNodeWithTag(EditorTag).performTouchInput { up() }
-    }
 
   @Test
   fun `platform indirect scale takes over a pending physical pan candidate`() = runComposeUiTest {
@@ -1777,7 +1753,6 @@ class EditorInteractionsDesktopTest {
     includeInteractionBoundary: () -> Boolean = { true },
     editorWidth: androidx.compose.ui.unit.Dp = 400.dp,
     consumeIndirectInputAtChild: Boolean = false,
-    onEditorPointerInput: () -> Unit = {},
     onViewportIndirectInput: () -> Unit = {},
     onCoroutineScope: (CoroutineScope) -> Unit = {},
   ) {
@@ -1808,7 +1783,6 @@ class EditorInteractionsDesktopTest {
                   flingBehavior = fixture.flingBehavior,
                   touchSlop = 8f,
                   density = 1f,
-                  onEditorPointerInput = onEditorPointerInput,
                   onViewportIndirectInput = onViewportIndirectInput,
                 )
               } else {

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayoutDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayoutDesktopTest.kt
@@ -193,7 +193,6 @@ class EditorScreenLayoutDesktopTest {
 
       assertEquals(1, controlDownCount)
       assertTrue(fixture.scrollDeltas.isEmpty())
-      assertEquals(0, fixture.editorPointerInputCount)
       assertEquals(EditorInteractionMode.Idle, fixture.interactionScope.controller.interactionMode)
     } finally {
       fixture.close()
@@ -223,12 +222,8 @@ class EditorScreenLayoutDesktopTest {
       }
       waitForIdle()
       assertTrue(fixture.scrollDeltas.isEmpty())
-      assertEquals(0, fixture.editorPointerInputCount)
 
-      runOnIdle {
-        fixture.scrollDeltas.clear()
-        fixture.editorPointerInputCount = 0
-      }
+      runOnIdle { fixture.scrollDeltas.clear() }
       onNodeWithTag(LayoutTag).performTouchInput {
         down(pointerId = 0, position = Offset(x = 280f, y = 40f))
         moveTo(pointerId = 0, position = Offset(x = 282f, y = HeaderHeightPx + 100f))
@@ -237,7 +232,6 @@ class EditorScreenLayoutDesktopTest {
       waitForIdle()
 
       assertTrue(fixture.scrollDeltas.isNotEmpty())
-      assertTrue(fixture.editorPointerInputCount > 0)
       assertEquals(EditorInteractionMode.Idle, fixture.interactionScope.controller.interactionMode)
     } finally {
       fixture.close()
@@ -650,7 +644,6 @@ class EditorScreenLayoutDesktopTest {
     }
     waitForIdle()
 
-    assertEquals(0, fixture.editorPointerInputCount)
     assertEquals(EditorInteractionMode.Idle, fixture.interactionScope.controller.interactionMode)
   }
 
@@ -679,7 +672,7 @@ class EditorScreenLayoutDesktopTest {
       up()
     }
     waitForIdle()
-    assertEquals(0, fixture.editorPointerInputCount, "scrollbar down reached editor")
+    assertEquals(EditorInteractionMode.Idle, fixture.interactionScope.controller.interactionMode)
 
     onNodeWithTag(LayoutTag).performMouseInput {
       moveTo(center)
@@ -1102,7 +1095,6 @@ class EditorScreenLayoutDesktopTest {
           viewportScrollableState = viewportScrollableState,
           viewportContentWidth = HeaderFixtureContentWidth,
           viewportScrollReconcileMode = EditorViewportScrollReconcileMode.Disabled,
-          onEditorPointerInput = { fixture.editorPointerInputCount += 1 },
           onMeasuredViewportSizeChange = {},
           header = {
             EditorHeaderFrame(
@@ -1175,7 +1167,6 @@ class EditorScreenLayoutDesktopTest {
             },
           viewportContentWidth = TestViewportSize.width,
           viewportScrollReconcileMode = EditorViewportScrollReconcileMode.Disabled,
-          onEditorPointerInput = { fixture.editorPointerInputCount += 1 },
           onRequestEditing = onRequestEditing,
           onMeasuredViewportSizeChange = {},
           header = {},
@@ -1273,7 +1264,6 @@ class EditorScreenLayoutDesktopTest {
     val uiState = EditorUiState()
     lateinit var interactionScope: EditorInteractionScope
     val scrollDeltas = mutableListOf<Offset>()
-    var editorPointerInputCount = 0
 
     val layoutSpec =
       EditorDocumentLayoutSpec.Paginated(
@@ -1385,7 +1375,6 @@ class EditorScreenLayoutDesktopTest {
     var headerFocused = false
     var headerPositionInRoot: Offset? = null
     var bodyPositionInRoot: Offset? = null
-    var editorPointerInputCount = 0
 
     fun close() {
       coroutineScope.cancel()

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/toolbar/EditorToolbarPagesDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/toolbar/EditorToolbarPagesDesktopTest.kt
@@ -18,11 +18,18 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.hapticfeedback.HapticFeedback
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
 import androidx.compose.ui.test.click
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performMouseInput
 import androidx.compose.ui.test.performTouchInput
@@ -1294,60 +1301,285 @@ class EditorToolbarPagesDesktopTest {
   }
 
   @Test
-  fun dismissIndicatorHidesCurrentPulseUntilNextPulse() = runComposeUiTest {
-    lateinit var pagerState: ToolbarPagerState
-    setContent {
-      pagerState = rememberToolbarPagerState()
-      val textScrollState = rememberScrollState()
-      ToolbarTestContent(textScrollState = textScrollState, pagerState = pagerState)
-    }
-    waitForIdle()
-    mainClock.autoAdvance = false
-    runOnIdle {
-      pagerState.indicatorPageTransitioning = true
-      pagerState.indicatorPulse++
-    }
-    mainClock.advanceTimeByFrame()
-    runOnIdle { assertTrue(pagerState.indicatorVisible) }
+  fun swipeUpFromFixedActionRevealsIndicatorAndRestartsTimeoutWithoutClickingButton() =
+    runComposeUiTest {
+      lateinit var pagerState: ToolbarPagerState
+      var fixedActionClicks = 0
+      mainClock.autoAdvance = false
+      setContent {
+        pagerState = rememberToolbarPagerState()
+        ToolbarTestContent(
+          textScrollState = rememberScrollState(),
+          pagerState = pagerState,
+          onToolbarDismissRequest = {},
+          onKeyboardDismissRequest = { fixedActionClicks++ },
+        )
+      }
+      mainClock.advanceTimeByFrame()
+      mainClock.advanceTimeBy(ToolbarIndicatorVisibleMillis + 1)
+      mainClock.advanceTimeByFrame()
+      runOnIdle { assertFalse(pagerState.indicatorVisible) }
 
-    runOnIdle { pagerState.dismissIndicator() }
-    mainClock.advanceTimeByFrame()
+      swipeToolbarVerticallyFromFixedAction(up = true)
+      mainClock.advanceTimeByFrame()
 
-    runOnIdle {
-      assertFalse(pagerState.indicatorVisible)
-      pagerState.indicatorPageTransitioning = false
-      pagerState.indicatorPulse++
+      runOnIdle {
+        assertTrue(pagerState.indicatorVisible)
+        assertEquals(0, fixedActionClicks)
+        assertEquals(EditorToolbarPageKey.Main, pagerState.settledPageKey)
+      }
+
+      mainClock.advanceTimeBy(ToolbarIndicatorVisibleMillis / 2)
+      swipeToolbarVerticallyFromFixedAction(up = true)
+      mainClock.advanceTimeByFrame()
+      mainClock.advanceTimeBy(ToolbarIndicatorVisibleMillis - 100)
+
+      runOnIdle { assertTrue(pagerState.indicatorVisible) }
+
+      mainClock.advanceTimeBy(101)
+      mainClock.advanceTimeByFrame()
+      runOnIdle { assertFalse(pagerState.indicatorVisible) }
     }
-    mainClock.advanceTimeByFrame()
-    runOnIdle { assertTrue(pagerState.indicatorVisible) }
+
+  @Test
+  fun swipeDownFromFixedActionDismissesToolbarOnceWithoutClickingButton() = runComposeUiTest {
+    var toolbarDismissals = 0
+    var fixedActionClicks = 0
+    setToolbarContent(
+      onToolbarDismissRequest = { toolbarDismissals++ },
+      onKeyboardDismissRequest = { fixedActionClicks++ },
+    )
+
+    swipeToolbarVerticallyFromFixedAction(up = false)
+
+    assertEquals(1, toolbarDismissals)
+    assertEquals(0, fixedActionClicks)
   }
 
   @Test
-  fun dismissedIndicatorInteractionDuringFadeStartsNewPulse() = runComposeUiTest {
+  fun swipeDownBelowActivationThresholdDoesNotDismissToolbar() = runComposeUiTest {
+    var toolbarDismissals = 0
+    setToolbarContent(onToolbarDismissRequest = { toolbarDismissals++ })
+
+    swipeToolbarVerticallyFromFixedAction(up = false, downDistance = 35.dp)
+
+    assertEquals(0, toolbarDismissals)
+  }
+
+  @Test
+  fun swipeDownAboveActivationThresholdDismissesOnlyOnRelease() = runComposeUiTest {
+    var toolbarDismissals = 0
+    setToolbarContent(onToolbarDismissRequest = { toolbarDismissals++ })
+
+    startToolbarVerticalDrag(37.dp)
+
+    assertEquals(0, toolbarDismissals)
+
+    releaseToolbarVerticalDrag()
+
+    assertEquals(1, toolbarDismissals)
+  }
+
+  @Test
+  fun swipeDownUsesHysteresisForReleaseDecision() = runComposeUiTest {
+    var toolbarDismissals = 0
+    setToolbarContent(onToolbarDismissRequest = { toolbarDismissals++ })
+
+    startToolbarVerticalDrag(37.dp)
+    moveToolbarVerticalDragTo(33.dp)
+    releaseToolbarVerticalDrag()
+
+    assertEquals(1, toolbarDismissals, "33dp should remain armed after crossing 36dp")
+
+    startToolbarVerticalDrag(37.dp)
+    moveToolbarVerticalDragTo(32.dp)
+    releaseToolbarVerticalDrag()
+
+    assertEquals(1, toolbarDismissals, "32dp should disarm before release")
+  }
+
+  @Test
+  fun swipeDownHapticRepeatsAfterDisarmingAndRearming() = runComposeUiTest {
+    val haptics = mutableListOf<HapticFeedbackType>()
+    val hapticFeedback =
+      object : HapticFeedback {
+        override fun performHapticFeedback(hapticFeedbackType: HapticFeedbackType) {
+          haptics += hapticFeedbackType
+        }
+      }
+    setContent {
+      ToolbarTestContent(textScrollState = rememberScrollState(), hapticFeedback = hapticFeedback)
+    }
+    waitForIdle()
+
+    startToolbarVerticalDrag(37.dp)
+    moveToolbarVerticalDragTo(33.dp)
+    moveToolbarVerticalDragTo(32.dp)
+    moveToolbarVerticalDragTo(37.dp)
+    releaseToolbarVerticalDrag()
+
+    assertEquals(
+      listOf(
+        HapticFeedbackType.GestureThresholdActivate,
+        HapticFeedbackType.GestureThresholdActivate,
+      ),
+      haptics,
+    )
+  }
+
+  @Test
+  fun dismissSwipeVisualFeedbackUsesStableOriginAcrossThreshold() = runComposeUiTest {
+    mainClock.autoAdvance = false
+    var density = 0f
+    setContent {
+      density = LocalDensity.current.density
+      ToolbarTestContent(textScrollState = rememberScrollState())
+    }
+    mainClock.advanceTimeByFrame()
+    val initialTop = pageTop(MainPageTag)
+
+    startToolbarVerticalDrag(20.dp)
+    mainClock.advanceTimeByFrame()
+    assertNear(initialTop + 4f * density, pageTop(MainPageTag), "unarmed drag should follow 20%")
+
+    moveToolbarVerticalDragTo(37.dp)
+    mainClock.advanceTimeBy(500)
+    assertNear(initialTop + 16f * density, pageTop(MainPageTag), "armed drag should shift 16dp")
+
+    moveToolbarVerticalDragTo(33.dp)
+    mainClock.advanceTimeByFrame()
+    assertNear(initialTop + 16f * density, pageTop(MainPageTag), "33dp should remain armed")
+
+    moveToolbarVerticalDragTo(32.dp)
+    mainClock.advanceTimeBy(500)
+    assertNear(initialTop + 6.4f * density, pageTop(MainPageTag), "32dp should return to 20%")
+
+    releaseToolbarVerticalDrag()
+    mainClock.autoAdvance = true
+    waitForIdle()
+  }
+
+  @Test
+  fun swipeUpFromToolbarButtonRevealsIndicatorWithoutClickingButton() = runComposeUiTest {
+    lateinit var pagerState: ToolbarPagerState
+    var toolbarButtonClicks = 0
+    setContent {
+      pagerState = rememberToolbarPagerState()
+      ToolbarTestContent(
+        textScrollState = rememberScrollState(),
+        pagerState = pagerState,
+        onToolbarDismissRequest = {},
+        onMainButtonClick = { toolbarButtonClicks++ },
+      )
+    }
+    waitForIdle()
+    val pulseBeforeSwipe = pagerState.indicatorPulse
+
+    swipeToolbarVerticallyFromMainButton(up = true)
+
+    assertTrue(pagerState.indicatorPulse > pulseBeforeSwipe)
+    assertEquals(0, toolbarButtonClicks)
+    assertPageActive(MainPageTag)
+  }
+
+  @Test
+  fun swipeDownFromToolbarButtonDismissesToolbarOnceWithoutClickingButton() = runComposeUiTest {
+    var toolbarDismissals = 0
+    var toolbarButtonClicks = 0
+    setToolbarContent(
+      onToolbarDismissRequest = { toolbarDismissals++ },
+      onMainButtonClick = { toolbarButtonClicks++ },
+    )
+
+    swipeToolbarVerticallyFromMainButton(up = false)
+
+    assertEquals(1, toolbarDismissals)
+    assertEquals(0, toolbarButtonClicks)
+  }
+
+  @Test
+  fun toolbarButtonsStillClickWithoutVerticalSwipe() = runComposeUiTest {
+    var fixedActionClicks = 0
+    var toolbarButtonClicks = 0
+    setToolbarContent(
+      onToolbarDismissRequest = {},
+      onKeyboardDismissRequest = { fixedActionClicks++ },
+      onMainButtonClick = { toolbarButtonClicks++ },
+    )
+
+    onNodeWithTag(MainButtonTag).performTouchInput { click(center) }
+    onNodeWithContentDescription("에디터 포커스 해제").performTouchInput { click(center) }
+    waitForIdle()
+
+    assertEquals(1, toolbarButtonClicks)
+    assertEquals(1, fixedActionClicks)
+  }
+
+  @Test
+  fun horizontalToolbarSwipeDoesNotDismissToolbar() = runComposeUiTest {
+    var toolbarDismissals = 0
+    setToolbarContent(onToolbarDismissRequest = { toolbarDismissals++ })
+
+    swipeToolbarLeft(distanceFraction = 0.7f)
+
+    assertEquals(0, toolbarDismissals)
+    assertPageActive(TextPageTag)
+  }
+
+  @Test
+  fun swipeUpWithOnePageDoesNotPulseIndicator() = runComposeUiTest {
     lateinit var pagerState: ToolbarPagerState
     setContent {
       pagerState = rememberToolbarPagerState()
-      val textScrollState = rememberScrollState()
-      ToolbarTestContent(textScrollState = textScrollState, pagerState = pagerState)
+      ToolbarTestContent(
+        textScrollState = rememberScrollState(),
+        pageKeys = listOf(EditorToolbarPageKey.Main),
+        pagerState = pagerState,
+        onToolbarDismissRequest = {},
+      )
     }
     waitForIdle()
-    mainClock.autoAdvance = false
-    runOnIdle { pagerState.indicatorPulse++ }
-    mainClock.advanceTimeByFrame()
-    val dismissedPulse = runOnIdle {
-      pagerState.dismissIndicator()
-      pagerState.indicatorPulse
-    }
-    mainClock.advanceTimeByFrame()
+    val pulseBeforeSwipe = pagerState.indicatorPulse
 
-    tapToolbarIndicatorPage(pageIndex = 1, pageCount = DefaultPageKeys.size)
-    mainClock.advanceTimeByFrame()
+    swipeToolbarVerticallyFromFixedAction(up = true)
 
-    runOnIdle {
-      assertTrue(pagerState.indicatorPulse > dismissedPulse)
-      assertFalse(pagerState.indicatorDismissed)
-      assertTrue(pagerState.indicatorVisible)
+    assertEquals(pulseBeforeSwipe, pagerState.indicatorPulse)
+  }
+
+  @Test
+  fun ancestorConsumedVerticalMovementDoesNotTriggerToolbarSwipe() = runComposeUiTest {
+    lateinit var pagerState: ToolbarPagerState
+    var toolbarDismissals = 0
+    val consumingAncestor =
+      Modifier.pointerInput(Unit) {
+        awaitPointerEventScope {
+          while (true) {
+            val event = awaitPointerEvent(PointerEventPass.Initial)
+            event.changes.forEach { change ->
+              if (change.pressed && change.previousPressed) {
+                change.consume()
+              }
+            }
+          }
+        }
+      }
+    setContent {
+      pagerState = rememberToolbarPagerState()
+      ToolbarTestContent(
+        textScrollState = rememberScrollState(),
+        pagerState = pagerState,
+        onToolbarDismissRequest = { toolbarDismissals++ },
+        ancestorModifier = consumingAncestor,
+      )
     }
+    waitForIdle()
+    val pulseBeforeSwipe = pagerState.indicatorPulse
+
+    swipeToolbarVerticallyFromFixedAction(up = true)
+    swipeToolbarVerticallyFromFixedAction(up = false)
+
+    assertEquals(pulseBeforeSwipe, pagerState.indicatorPulse)
+    assertEquals(0, toolbarDismissals)
   }
 
   @Test
@@ -1364,11 +1596,20 @@ class EditorToolbarPagesDesktopTest {
     )
   }
 
-  private fun ComposeUiTest.setToolbarContent(): ScrollState {
+  private fun ComposeUiTest.setToolbarContent(
+    onToolbarDismissRequest: () -> Unit = {},
+    onKeyboardDismissRequest: () -> Unit = {},
+    onMainButtonClick: () -> Unit = {},
+  ): ScrollState {
     lateinit var textScrollState: ScrollState
     setContent {
       textScrollState = rememberScrollState()
-      ToolbarTestContent(textScrollState = textScrollState)
+      ToolbarTestContent(
+        textScrollState = textScrollState,
+        onToolbarDismissRequest = onToolbarDismissRequest,
+        onKeyboardDismissRequest = onKeyboardDismissRequest,
+        onMainButtonClick = onMainButtonClick,
+      )
     }
     waitForIdle()
     assertPageActive(MainPageTag)
@@ -1508,6 +1749,59 @@ class EditorToolbarPagesDesktopTest {
     waitForIdle()
   }
 
+  private fun ComposeUiTest.swipeToolbarVerticallyFromFixedAction(
+    up: Boolean,
+    downDistance: Dp = 40.dp,
+  ) {
+    onNodeWithTag(ToolbarTag).performTouchInput {
+      val x = width - ToolbarFixedActionWidth.toPx() / 2f
+      val startY = height - ToolbarHeight.toPx() / 2f
+      val distance = (if (up) 20.dp else downDistance).toPx()
+      swipe(
+        start = Offset(x = x, y = startY),
+        end = Offset(x = x, y = startY + if (up) -distance else distance),
+        durationMillis = 120,
+      )
+    }
+    waitForIdle()
+  }
+
+  private fun ComposeUiTest.swipeToolbarVerticallyFromMainButton(up: Boolean) {
+    onNodeWithTag(MainButtonTag).performTouchInput {
+      val distance = (if (up) 20.dp else 40.dp).toPx()
+      swipe(
+        start = center,
+        end = center + Offset(x = 0f, y = if (up) -distance else distance),
+        durationMillis = 120,
+      )
+    }
+    waitForIdle()
+  }
+
+  private fun ComposeUiTest.startToolbarVerticalDrag(distance: Dp) {
+    onNodeWithTag(ToolbarTag).performTouchInput {
+      val x = width - ToolbarFixedActionWidth.toPx() / 2f
+      val startY = height - ToolbarHeight.toPx() / 2f
+      down(Offset(x = x, y = startY))
+      moveTo(Offset(x = x, y = startY + distance.toPx()))
+    }
+    waitForIdle()
+  }
+
+  private fun ComposeUiTest.moveToolbarVerticalDragTo(distance: Dp) {
+    onNodeWithTag(ToolbarTag).performTouchInput {
+      val x = width - ToolbarFixedActionWidth.toPx() / 2f
+      val startY = height - ToolbarHeight.toPx() / 2f
+      moveTo(Offset(x = x, y = startY + distance.toPx()))
+    }
+    waitForIdle()
+  }
+
+  private fun ComposeUiTest.releaseToolbarVerticalDrag() {
+    onNodeWithTag(ToolbarTag).performTouchInput { up() }
+    waitForIdle()
+  }
+
   private fun ComposeUiTest.tapToolbarIndicatorPage(pageIndex: Int, pageCount: Int) {
     onNodeWithTag(ToolbarTag).performTouchInput {
       val itemPx = ToolbarIndicatorItemSize.toPx()
@@ -1606,6 +1900,9 @@ class EditorToolbarPagesDesktopTest {
   private fun SemanticsNodeInteractionsProvider.pageRight(tag: String): Float =
     onNodeWithTag(tag).fetchSemanticsNode().boundsInRoot.right
 
+  private fun SemanticsNodeInteractionsProvider.pageTop(tag: String): Float =
+    onNodeWithTag(tag).fetchSemanticsNode().boundsInRoot.top
+
   private fun assertNear(expected: Float, actual: Float, message: String) {
     assertTrue(abs(expected - actual) <= 2f, "$message. expected=$expected actual=$actual")
   }
@@ -1619,46 +1916,63 @@ class EditorToolbarPagesDesktopTest {
     visible: Boolean = true,
     pagerState: ToolbarPagerState = rememberToolbarPagerState(),
     textItemWidth: Dp = 80.dp,
+    onToolbarDismissRequest: () -> Unit = {},
+    onKeyboardDismissRequest: () -> Unit = {},
+    onMainButtonClick: () -> Unit = {},
+    ancestorModifier: Modifier = Modifier,
+    hapticFeedback: HapticFeedback? = null,
   ) {
     val pages =
       rememberToolbarTestPages(
         textScrollState = textScrollState,
         pageKeys = pageKeys,
         textItemWidth = textItemWidth,
+        onMainButtonClick = onMainButtonClick,
       )
     val commandScope = rememberCoroutineScope()
-    ToolbarTestTheme {
-      Box(Modifier.width(360.dp).height(ToolbarStackHeight).testTag(ToolbarTag)) {
-        if (visible) {
-          EditorToolbarPages(
-            pages = pages,
-            commandScope = commandScope,
-            pagerState = pagerState,
-            autoTargetPageKey = autoTargetPageKey,
-            autoTargetKey = autoTargetRevision,
-            editorFocused = true,
-            activeBottomPanel = null,
-            fixedAction = ToolbarFixedAction.DismissInput,
-            onEditorInputRequest = {},
-            onKeyboardDismissRequest = {},
-            onBottomPanelToggle = { _, _ -> },
-            modifier = Modifier.fillMaxSize(),
-          )
+    ToolbarTestTheme(hapticFeedback = hapticFeedback) {
+      Box(ancestorModifier) {
+        Box(Modifier.width(360.dp).height(ToolbarStackHeight).testTag(ToolbarTag)) {
+          if (visible) {
+            EditorToolbarPages(
+              pages = pages,
+              commandScope = commandScope,
+              pagerState = pagerState,
+              autoTargetPageKey = autoTargetPageKey,
+              autoTargetKey = autoTargetRevision,
+              editorFocused = true,
+              activeBottomPanel = null,
+              fixedAction = ToolbarFixedAction.DismissInput,
+              onEditorInputRequest = {},
+              onKeyboardDismissRequest = onKeyboardDismissRequest,
+              onToolbarDismissRequest = onToolbarDismissRequest,
+              onBottomPanelToggle = { _, _ -> },
+              modifier = Modifier.fillMaxSize(),
+            )
+          }
         }
       }
     }
   }
 
   @Composable
-  private fun ToolbarTestTheme(content: @Composable () -> Unit) {
+  private fun ToolbarTestTheme(
+    hapticFeedback: HapticFeedback? = null,
+    content: @Composable () -> Unit,
+  ) {
     CompositionLocalProvider(
       LocalAppColors provides LightColors,
       LocalAppShadows provides LightAppShadows,
       LocalThemeMode provides ResolvedThemeMode.Light,
       LocalHazeBlurStyle provides
         HazeBlurStyle(blurRadius = 20.dp, noiseFactor = 0f, colorEffects = listOf()),
-      content = content,
-    )
+    ) {
+      if (hapticFeedback == null) {
+        content()
+      } else {
+        CompositionLocalProvider(LocalHapticFeedback provides hapticFeedback, content = content)
+      }
+    }
   }
 
   @Composable
@@ -1666,8 +1980,9 @@ class EditorToolbarPagesDesktopTest {
     textScrollState: ScrollState,
     pageKeys: List<EditorToolbarPageKey>,
     textItemWidth: Dp,
+    onMainButtonClick: () -> Unit,
   ): List<EditorToolbarPage> =
-    remember(textScrollState, pageKeys, textItemWidth) {
+    remember(textScrollState, pageKeys, textItemWidth, onMainButtonClick) {
       pageKeys.map { key ->
         when (key) {
           EditorToolbarPageKey.Main ->
@@ -1675,7 +1990,16 @@ class EditorToolbarPagesDesktopTest {
               key = EditorToolbarPageKey.Main,
               icon = Lucide.CircleSmall,
               contentDescription = "메인 툴바",
-              content = { Box(Modifier.fillMaxSize().testTag(MainPageTag)) },
+              content = {
+                Box(Modifier.fillMaxSize().testTag(MainPageTag)) {
+                  EditorToolbarButton(
+                    icon = Lucide.CircleSmall,
+                    contentDescription = "테스트 툴바 버튼",
+                    onClick = onMainButtonClick,
+                    modifier = Modifier.align(Alignment.CenterStart).testTag(MainButtonTag),
+                  )
+                }
+              },
             )
           EditorToolbarPageKey.Text ->
             EditorToolbarPage(
@@ -1745,6 +2069,7 @@ class EditorToolbarPagesDesktopTest {
 
   private companion object {
     const val ToolbarTag = "editor-toolbar"
+    const val MainButtonTag = "main-toolbar-button"
     const val MainPageTag = "main-page"
     const val TextPageTag = "text-page"
     const val ImagePageTag = "image-page"


### PR DESCRIPTION
- 앱 에디터 본문 터치 시 툴바 인디케이터 꺼지는 기능 제거
- 앱 툴바 위로 스와이프하면 툴바 인디케이터 표시
- 앱 툴바 아래로 스와이프하면 읽기 모드 전환
- 하드웨어 키보드 모드에서도 툴바 숨길 시 읽기 모드로 전환