### PR TITLE
앱 전역 노트 오버레이 노트 사이에 포인터 있을 때 스크롤 안 되는 문제 디버그

### DIFF
--- a/apps/website/src/routes/website/(dashboard)/@notes/Notes.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@notes/Notes.svelte
@@ -429,7 +429,6 @@
       paddingTop: '[15dvh]',
       paddingX: '20px',
       flexDirection: 'column',
-      gap: '20px',
       width: 'full',
       height: 'full',
       overflowY: 'auto',
@@ -442,14 +441,12 @@
         handleCollapse();
         return;
       }
-      if (target === e.currentTarget || target.closest('[data-notes-backdrop]')) {
+      if (target === e.currentTarget) {
         close();
       }
     }}
     role="presentation"
   >
-    <div class={css({ position: 'fixed', inset: '0' })} data-notes-backdrop role="none"></div>
-
     <!-- Input Area -->
     <div
       bind:this={composer}
@@ -521,9 +518,10 @@
     <!-- Notes List -->
     <div
       class={css({
-        paddingBottom: '50px',
+        marginTop: '20px',
+        marginBottom: '50px',
         maxWidth: '480px',
-        flexGrow: '1',
+        flexShrink: '0',
         width: 'full',
       })}
     >

--- a/apps/website/src/routes/website/(dashboard)/@notes/notes-overlay.browser.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/@notes/notes-overlay.browser.test.ts
@@ -81,7 +81,7 @@ afterEach(async () => {
 });
 
 describe('global notes overlay', () => {
-  it('closes when the notes-list wrapper fills the scrolled viewport', async () => {
+  it('keeps the empty scrim on the native scroll surface after scrolling', async () => {
     const target = document.createElement('div');
     document.body.append(target);
     component = mount(Notes, { target, intro: false });
@@ -91,23 +91,24 @@ describe('global notes overlay', () => {
 
     const scrollSurface = document.querySelector<HTMLElement>('[role="presentation"]');
     const noteList = document.querySelector<HTMLElement>('[data-note-list]');
-    const notesArea = noteList?.parentElement;
+    const notesContent = noteList?.parentElement;
     expect(scrollSurface).not.toBeNull();
-    expect(notesArea).toBeInstanceOf(HTMLElement);
-    if (!scrollSurface || !notesArea) throw new Error('Expected the notes overlay scroll surface and list area');
-    expect(notesArea.contains(noteList)).toBe(true);
+    expect(notesContent).toBeInstanceOf(HTMLElement);
+    if (!scrollSurface || !notesContent) return;
+    expect(notesContent.contains(noteList)).toBe(true);
     expect(scrollSurface.scrollHeight).toBeGreaterThan(scrollSurface.clientHeight);
+
+    const contentRect = notesContent.getBoundingClientRect();
+    expect(document.elementFromPoint(Math.max(1, contentRect.left - 8), contentRect.top + 8)).toBe(scrollSurface);
 
     scrollSurface.scrollTop = scrollSurface.scrollHeight;
     await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
 
     const scrollRect = scrollSurface.getBoundingClientRect();
-    const notesRect = notesArea.getBoundingClientRect();
-    const clientX = notesRect.left + notesRect.width / 2;
-    const clientY = Math.min(notesRect.bottom, scrollRect.bottom) - 8;
+    const clientX = scrollRect.left + scrollRect.width / 2;
+    const clientY = scrollRect.bottom - 8;
     const hit = document.elementFromPoint(clientX, clientY);
-    expect(hit).not.toBeNull();
-    expect(hit === scrollSurface || hit?.closest('[data-notes-backdrop]') !== null).toBe(true);
+    expect(hit).toBe(scrollSurface);
     expect(app.state.notesOpen).toBe(true);
     hit?.dispatchEvent(new MouseEvent('click', { bubbles: true, clientX, clientY }));
 


### PR DESCRIPTION
- scrim 단순화함
- 노트 사이를 클릭해도 오버레이가 닫히지 않도록 함
- 노트 사이에 포인터 있을 때 스크롤이 되도록 함
- 포인터가 완전히 목록 외부에 있어도 스크롤이 되도록 함