### PR TITLE
에디터 이동이 최신 레이아웃을 사용하도록 함

### DIFF
--- a/crates/editor-core/src/editor.rs
+++ b/crates/editor-core/src/editor.rs
@@ -10,7 +10,6 @@ use editor_resource::{CharacterCount, Resource, count_text};
 use editor_state::{
     LayoutDirty, Position, ResolvedPosition, ResolvedPositionFlatExt, Selection, StableSelection,
     State, closest_empty_paragraph_break_end_between, farther_endpoint, is_unit_node_selection,
-    remap_selection,
 };
 use editor_transaction::{Effect, HistoryMeta, MergeKind, StepError, Transaction};
 use editor_view::{GapPhantom, PageRect, PendingOverlay, View, Viewport};
@@ -218,6 +217,39 @@ fn typing_run(kind: MergeKind, before: &State, after: &State) -> RecordMerge {
 type SelectionMarkRectsCache = Mutex<Option<(Selection, u64, Arc<Vec<PageRect>>)>>;
 type TrackedDecorationMarksCache = Mutex<Option<(u64, Arc<Vec<Mark>>)>>;
 
+#[derive(Default)]
+struct TickChanges {
+    // Pending ops stay on Editor until the tick succeeds; this count records
+    // which prefix has already contributed to an earlier layout phase.
+    reconciled_op_count: usize,
+    view_changed: bool,
+    // Layout may be reconciled more than once for geometry-dependent commands,
+    // but text-sensitive ranges are verified only against the final tick state.
+    tracked_text_dirty: Option<LayoutDirty>,
+}
+
+impl TickChanges {
+    fn record_layout_dirty(&mut self, dirty: &LayoutDirty) {
+        let accumulated = self
+            .tracked_text_dirty
+            .get_or_insert_with(LayoutDirty::empty);
+        match dirty {
+            LayoutDirty::Full => accumulated.mark_full(),
+            LayoutDirty::Incremental {
+                content,
+                structural,
+            } => {
+                for &dot in content {
+                    accumulated.mark_content(dot);
+                }
+                for &dot in structural {
+                    accumulated.mark_structural(dot);
+                }
+            }
+        }
+    }
+}
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ManifestRequestClass {
     Prefetch,
@@ -249,6 +281,10 @@ pub struct Editor {
     resource_apply_count: usize,
     pending_events: Vec<EditorEvent>,
     pub(crate) pending_ops: Vec<Op<EditOp>>,
+    // A mid-tick layout reconciliation drains projected layout dirtiness. If a
+    // later message fails unexpectedly, retain its bookkeeping alongside
+    // `pending_ops` until a successful tick can finish publication.
+    pending_tick_changes: TickChanges,
     pending_effects: HashSet<Effect>,
     pub(crate) pending_fonts: HashMap<(String, u16), HashMap<Dot, HashSet<u32>>>,
     pub(crate) pending_font_index: Option<crate::font::PendingFontIndex>,
@@ -299,6 +335,7 @@ impl Editor {
             resource_apply_count: 0,
             pending_events: Vec::new(),
             pending_ops: Vec::new(),
+            pending_tick_changes: TickChanges::default(),
             pending_effects: HashSet::new(),
             pending_fonts: HashMap::new(),
             pending_font_index: None,
@@ -856,51 +893,15 @@ impl Editor {
         let old_composition_paint = self.composition_paint.clone();
         let old_last_history_tag_revision = self.undo_history.last_tag_revision();
 
-        let mut ime_failed = false;
-        let mut applied = false;
-        while let Some(entry) = entries.pop_front() {
-            match entry {
-                QueueEntry::Request { id, messages } => {
-                    applied = true;
-                    let mut command_outcomes = Vec::with_capacity(messages.len());
-                    self.process_request_messages(
-                        messages,
-                        &mut command_outcomes,
-                        &mut ime_failed,
-                    )?;
-                    request_outcomes.push(RequestOutcome {
-                        request_id: id,
-                        command_outcomes,
-                    });
+        let mut changes = std::mem::take(&mut self.pending_tick_changes);
+        let (ime_failed, applied) =
+            match self.apply_tick_entries(entries, request_outcomes, &mut changes) {
+                Ok(result) => result,
+                Err(error) => {
+                    self.pending_tick_changes = changes;
+                    return Err(error);
                 }
-                QueueEntry::Resource(update) => {
-                    self.ime_delete_paint = None;
-                    applied |= self.apply_resource_update(update)?;
-                }
-                QueueEntry::Remote(changeset) => {
-                    self.ime_delete_paint = None;
-                    let mut batch = vec![changeset];
-                    while matches!(entries.front(), Some(QueueEntry::Remote(_))) {
-                        if let QueueEntry::Remote(changeset) =
-                            entries.pop_front().expect("matched remote queue entry")
-                        {
-                            batch.push(changeset);
-                        }
-                    }
-                    applied |= self.apply_remote_changesets(batch)?;
-                }
-                QueueEntry::SetDocument(plain) => {
-                    applied = true;
-                    self.ime_delete_paint = None;
-                    self.apply_set_doc(plain)?;
-                }
-                QueueEntry::InsertTemplate(template) => {
-                    applied = true;
-                    self.ime_delete_paint = None;
-                    self.apply_template_fragment(template)?;
-                }
-            }
-        }
+            };
         // Defense-in-depth: every op-applying path seals its own changeset
         // (`Transaction::commit`, `apply_undo_result`). If a future path leaks
         // unsealed ops past this boundary, the sync layer snapshots
@@ -926,32 +927,24 @@ impl Editor {
             self.push_event(EditorEvent::ImeResyncRequired);
         }
 
-        crate::font::flush_font_loads(self);
-
-        let layout_dirty = self.view.take_layout_dirty(&mut self.state);
-
-        if !self.pending_ops.is_empty() {
-            self.augment_font_state_from_ops(&layout_dirty);
-        }
-
-        let tracked_ranges_went_stale = self.reverify_tracked_text(&layout_dirty);
+        self.reconcile_pending_layout(&mut changes);
+        let tracked_ranges_went_stale = changes
+            .tracked_text_dirty
+            .take()
+            .is_some_and(|dirty| self.reverify_tracked_text(&dirty));
 
         let effects = std::mem::take(&mut self.pending_effects);
         if !effects.is_empty() {
             self.process_effects(effects);
         }
-
         crate::font::emit_prefetch_if_quiescent(self);
 
         let ops = std::mem::take(&mut self.pending_ops);
-        let pending_overlay = normalize_pending_overlay(&self.state);
-        let gap_phantom = normalize_gap_phantom(&self.state);
-        // `reconcile` reports view-level change sources (pending overlay, gap phantom,
-        // layout fingerprint); applied doc ops also dirty the rendered layout.
-        let dirty = self
-            .view
-            .reconcile(&self.state, layout_dirty, pending_overlay, gap_phantom)
-            || !ops.is_empty();
+        let TickChanges {
+            reconciled_op_count: _,
+            view_changed: dirty,
+            tracked_text_dirty: _,
+        } = changes;
 
         let mut fields: HashSet<StateField> = HashSet::new();
 
@@ -1045,11 +1038,69 @@ impl Editor {
         Ok((std::mem::take(&mut self.pending_events), applied))
     }
 
+    /// Applies queued entries before tick-final publication. If an entry fails,
+    /// the caller retains `changes` with the state mutations that remain applied.
+    fn apply_tick_entries(
+        &mut self,
+        entries: &mut VecDeque<QueueEntry>,
+        request_outcomes: &mut Vec<RequestOutcome>,
+        changes: &mut TickChanges,
+    ) -> Result<(bool, bool), EditorError> {
+        let mut ime_failed = false;
+        let mut applied = false;
+        while let Some(entry) = entries.pop_front() {
+            match entry {
+                QueueEntry::Request { id, messages } => {
+                    applied = true;
+                    let mut command_outcomes = Vec::with_capacity(messages.len());
+                    self.process_request_messages(
+                        messages,
+                        &mut command_outcomes,
+                        &mut ime_failed,
+                        changes,
+                    )?;
+                    request_outcomes.push(RequestOutcome {
+                        request_id: id,
+                        command_outcomes,
+                    });
+                }
+                QueueEntry::Resource(update) => {
+                    self.ime_delete_paint = None;
+                    applied |= self.apply_resource_update(update)?;
+                }
+                QueueEntry::Remote(changeset) => {
+                    self.ime_delete_paint = None;
+                    let mut batch = vec![changeset];
+                    while matches!(entries.front(), Some(QueueEntry::Remote(_))) {
+                        if let QueueEntry::Remote(changeset) =
+                            entries.pop_front().expect("matched remote queue entry")
+                        {
+                            batch.push(changeset);
+                        }
+                    }
+                    applied |= self.apply_remote_changesets(batch)?;
+                }
+                QueueEntry::SetDocument(plain) => {
+                    applied = true;
+                    self.ime_delete_paint = None;
+                    self.apply_set_doc(plain)?;
+                }
+                QueueEntry::InsertTemplate(template) => {
+                    applied = true;
+                    self.ime_delete_paint = None;
+                    self.apply_template_fragment(template)?;
+                }
+            }
+        }
+        Ok((ime_failed, applied))
+    }
+
     fn process_request_messages(
         &mut self,
         messages: Vec<Message>,
         command_outcomes: &mut Vec<CommandOutcome>,
         ime_failed: &mut bool,
+        changes: &mut TickChanges,
     ) -> Result<(), EditorError> {
         let mut messages: VecDeque<_> = messages.into();
         while let Some(message) = messages.pop_front() {
@@ -1082,7 +1133,9 @@ impl Editor {
                         outcome = CommandOutcome::Rejected {
                             reason: CommandRejection::InvalidArgument,
                         };
-                    } else if let Err(e) = self.process_message(Message::TextInput { ops: batch }) {
+                    } else if let Err(e) =
+                        self.process_message(Message::TextInput { ops: batch }, changes)
+                    {
                         if is_illegal_slot(&e) {
                             log::warn!(
                                 "text input rejected by insert-slot guard; requesting ime resync: {e}"
@@ -1105,7 +1158,8 @@ impl Editor {
                         outcome = CommandOutcome::Rejected {
                             reason: CommandRejection::InvalidArgument,
                         };
-                    } else if let Err(e) = self.process_message(Message::Insertion { op }) {
+                    } else if let Err(e) = self.process_message(Message::Insertion { op }, changes)
+                    {
                         if is_illegal_slot(&e) {
                             log::warn!(
                                 "insertion rejected by insert-slot guard; requesting ime resync: {e}"
@@ -1123,7 +1177,7 @@ impl Editor {
                 }
                 other => {
                     self.ime_delete_paint = None;
-                    self.process_message(other)
+                    self.process_message(other, changes)
                 }
             };
             if let Err(e) = &result
@@ -1141,6 +1195,44 @@ impl Editor {
             command_outcomes.extend(std::iter::repeat_n(outcome, consumed));
         }
         Ok(())
+    }
+
+    /// Reconciles the retained layout with the current state. This may run before
+    /// geometry-dependent commands, so irreversible tick-final work stays out.
+    fn reconcile_pending_layout(&mut self, changes: &mut TickChanges) {
+        crate::font::flush_font_loads(self);
+
+        let layout_dirty = self.view.take_layout_dirty(&mut self.state);
+        let has_new_ops = self.pending_ops.len() > changes.reconciled_op_count;
+        if has_new_ops {
+            self.augment_font_state_from_ops(&layout_dirty);
+        }
+        changes.record_layout_dirty(&layout_dirty);
+
+        let pending_overlay = normalize_pending_overlay(&self.state);
+        let gap_phantom = normalize_gap_phantom(&self.state);
+        // `reconcile` reports view-level change sources (pending overlay, gap phantom,
+        // layout fingerprint); applied doc ops also dirty the rendered layout.
+        changes.view_changed |=
+            self.view
+                .reconcile(&self.state, layout_dirty, pending_overlay, gap_phantom)
+                || has_new_ops;
+        changes.reconciled_op_count = self.pending_ops.len();
+    }
+
+    /// Establishes the dispatcher invariant for handlers that query retained geometry.
+    fn synchronize_layout_for_command(&mut self, changes: &mut TickChanges) {
+        let pending_overlay = normalize_pending_overlay(&self.state);
+        let gap_phantom = normalize_gap_phantom(&self.state);
+        if !self.pending_font_loads.is_empty()
+            || !self.view.retained_layout_matches(
+                &self.state,
+                pending_overlay.as_ref(),
+                gap_phantom.as_ref(),
+            )
+        {
+            self.reconcile_pending_layout(changes);
+        }
     }
 
     #[cfg(any(test, feature = "test-utils"))]
@@ -1383,11 +1475,24 @@ impl Editor {
             .export_page_vector(&doc, &self.view, page_idx as usize, scale_factor)
     }
 
-    fn process_message(&mut self, msg: Message) -> Result<(), EditorError> {
+    fn process_message(
+        &mut self,
+        msg: Message,
+        changes: &mut TickChanges,
+    ) -> Result<(), EditorError> {
         match msg {
             Message::Key { event } => handle::handle_key_event(self, event)?,
             Message::Insertion { op } => handle::handle_insertion_op(self, op)?,
-            Message::Deletion { op } => handle::handle_deletion_op(self, op)?,
+            Message::Deletion { op } => {
+                if matches!(
+                    &op,
+                    DeletionOp::Move { movement }
+                        if !matches!(movement, Movement::Grapheme { .. })
+                ) {
+                    self.synchronize_layout_for_command(changes);
+                }
+                handle::handle_deletion_op(self, op)?;
+            }
             Message::Modifier { op } => handle::handle_modifier_op(self, op)?,
             Message::Selection { op } => handle::handle_selection_op(self, op)?,
             Message::Node { op } => handle::handle_node_op(self, op)?,
@@ -1397,7 +1502,10 @@ impl Editor {
             Message::Clipboard { op } => handle::handle_clipboard_op(self, op)?,
             Message::TextInput { ops } => handle::handle_flat_ime_ops(self, ops)?,
             Message::Dnd { op } => handle::handle_dnd_op(self, op)?,
-            Message::Navigation { op } => handle::handle_navigation_op(self, op)?,
+            Message::Navigation { op } => {
+                self.synchronize_layout_for_command(changes);
+                handle::handle_navigation_op(self, op)?;
+            }
             Message::History { op } => handle::handle_history_op(self, op)?,
             Message::System { event } => handle::handle_system_event(self, event)?,
             Message::TrackedRange { op } => handle::handle_tracked_range_op(self, op)?,
@@ -1719,17 +1827,6 @@ impl Editor {
             let resource = self.resource.lock().unwrap();
             self.view.resolve_movement(pos, movement, &resource)
         }
-    }
-
-    /// Rebinds the latest live selection by identity into the document snapshot
-    /// that produced the current layout.
-    pub(crate) fn layout_input_state(&self) -> Option<State> {
-        let mut state = self.view.layout_state()?.clone();
-        state.selection = self
-            .state
-            .selection
-            .and_then(|selection| remap_selection(selection, &self.state, &state));
-        Some(state)
     }
 
     pub(crate) fn resolve_extend_movement(
@@ -2167,6 +2264,7 @@ impl Editor {
             resource_apply_count: 0,
             pending_events: Vec::new(),
             pending_ops: Vec::new(),
+            pending_tick_changes: TickChanges::default(),
             pending_effects: HashSet::new(),
             pending_fonts: HashMap::new(),
             pending_font_index: None,

--- a/crates/editor-core/src/handle/deletion.rs
+++ b/crates/editor-core/src/handle/deletion.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use editor_commands::{self as commands, CommandError, CommandResult};
 use editor_state::{
     Position, ResolvedPosition, ResolvedPositionFlatExt, Selection, flat_size, flat_text,
-    remap_selection,
 };
 use editor_transaction::Transaction;
 
@@ -59,9 +58,7 @@ pub fn handle_deletion_op(editor: &mut Editor, op: DeletionOp) -> Result<(), Edi
             })?;
         }
         DeletionOp::Move { movement } => {
-            let Some(input_state) = editor.layout_input_state() else {
-                return Ok(());
-            };
+            let input_state = editor.state.clone();
             let Some(selection) = input_state.selection else {
                 return Ok(());
             };
@@ -74,10 +71,6 @@ pub fn handle_deletion_op(editor: &mut Editor, op: DeletionOp) -> Result<(), Edi
 
             if let Some(target) = target {
                 let selection = Selection::new(head, target.head);
-                let Some(selection) = remap_selection(selection, &input_state, &editor.state)
-                else {
-                    return Ok(());
-                };
                 editor.transact(|tr| {
                     commands::set_selection(tr, selection)?;
                     commands::delete_selection(tr)?;

--- a/crates/editor-core/src/handle/navigation.rs
+++ b/crates/editor-core/src/handle/navigation.rs
@@ -3,7 +3,7 @@ use editor_model::{ChildView, DocView, Schema};
 use editor_state::{
     Affinity, GapCursor, Position, Selection, as_gap_cursor, cell_rect_selection, enclosing_table,
     enclosing_table_cell, first_cursor_position, gap_cursor_selection_at, is_unit_node_selection,
-    last_cursor_position, remap_selection,
+    last_cursor_position,
 };
 use editor_transaction::HistoryMeta;
 
@@ -15,9 +15,7 @@ use crate::message::*;
 pub fn handle_navigation_op(editor: &mut Editor, op: NavigationOp) -> Result<(), EditorError> {
     match op {
         NavigationOp::Move { movement, extend } => {
-            let Some(input_state) = editor.layout_input_state() else {
-                return Ok(());
-            };
+            let input_state = editor.state.clone();
             let Some(selection) = input_state.selection else {
                 if !extend && let Movement::Document { .. } = movement {
                     let probe_pos = Position {
@@ -26,7 +24,7 @@ pub fn handle_navigation_op(editor: &mut Editor, op: NavigationOp) -> Result<(),
                         affinity: Affinity::Upstream,
                     };
                     if let Some(target) = editor.resolve_movement(&probe_pos, &movement) {
-                        set_navigation_selection(editor, &input_state, target)?;
+                        set_navigation_selection(editor, target)?;
                     }
                 }
                 return Ok(());
@@ -184,7 +182,7 @@ pub fn handle_navigation_op(editor: &mut Editor, op: NavigationOp) -> Result<(),
                 };
                 if let Some(exit) = gap_exit {
                     if let Some(sel) = exit {
-                        set_navigation_selection(editor, &input_state, sel)?;
+                        set_navigation_selection(editor, sel)?;
                     }
                     return Ok(());
                 }
@@ -205,7 +203,7 @@ pub fn handle_navigation_op(editor: &mut Editor, op: NavigationOp) -> Result<(),
                         gap_cursor_selection_at(parent, idx + 1, &input_state.view())
                     };
                     if let Some(sel) = entry {
-                        set_navigation_selection(editor, &input_state, sel)?;
+                        set_navigation_selection(editor, sel)?;
                         return Ok(());
                     }
                 }
@@ -305,7 +303,7 @@ pub fn handle_navigation_op(editor: &mut Editor, op: NavigationOp) -> Result<(),
                         })
                     };
 
-                    set_navigation_selection(editor, &input_state, target)?;
+                    set_navigation_selection(editor, target)?;
                     return Ok(());
                 }
 
@@ -335,7 +333,7 @@ pub fn handle_navigation_op(editor: &mut Editor, op: NavigationOp) -> Result<(),
                     if matches!(movement, Movement::Line { .. }) {
                         editor.ensure_preferred_x_at(&selection.head);
                     }
-                    set_navigation_selection(editor, &input_state, sel)?;
+                    set_navigation_selection(editor, sel)?;
                     return Ok(());
                 }
             }
@@ -369,7 +367,7 @@ pub fn handle_navigation_op(editor: &mut Editor, op: NavigationOp) -> Result<(),
                                 new_head_cell_id,
                                 &input_state.view(),
                             ) {
-                                set_navigation_selection(editor, &input_state, new_selection)?;
+                                set_navigation_selection(editor, new_selection)?;
                             }
                             return Ok(());
                         }
@@ -409,7 +407,7 @@ pub fn handle_navigation_op(editor: &mut Editor, op: NavigationOp) -> Result<(),
                             Some(extended)
                         };
                         if let Some(new_selection) = new_selection {
-                            set_navigation_selection(editor, &input_state, new_selection)?;
+                            set_navigation_selection(editor, new_selection)?;
                         }
                         return Ok(());
                     }
@@ -449,28 +447,21 @@ pub fn handle_navigation_op(editor: &mut Editor, op: NavigationOp) -> Result<(),
                                 None
                             };
                             if let Some(cell_sel) = cell_sel {
-                                set_navigation_selection(editor, &input_state, cell_sel)?;
+                                set_navigation_selection(editor, cell_sel)?;
                                 return Ok(());
                             }
                         }
                     }
                 }
 
-                set_navigation_selection(editor, &input_state, new_selection)?;
+                set_navigation_selection(editor, new_selection)?;
             }
         }
     }
     Ok(())
 }
 
-fn set_navigation_selection(
-    editor: &mut Editor,
-    input_state: &editor_state::State,
-    selection: Selection,
-) -> Result<(), EditorError> {
-    let Some(selection) = remap_selection(selection, input_state, &editor.state) else {
-        return Ok(());
-    };
+fn set_navigation_selection(editor: &mut Editor, selection: Selection) -> Result<(), EditorError> {
     editor.transact(|tr| {
         tr.update_meta(|meta| meta.history = HistoryMeta::Skip);
         if tr.selection() != Some(selection) {

--- a/crates/editor-core/src/handle/selection.rs
+++ b/crates/editor-core/src/handle/selection.rs
@@ -259,7 +259,11 @@ fn resolve_extend_to_selection(
     base_selection: Option<Selection>,
     allow_collapse: bool,
 ) -> Option<Selection> {
-    let input_state = editor.layout_input_state()?;
+    let mut input_state = editor.view.layout_state()?.clone();
+    input_state.selection = editor
+        .state
+        .selection
+        .and_then(|selection| remap_selection(selection, &editor.state, &input_state));
     let view = input_state.view();
     let head_hit =
         editor

--- a/crates/editor-core/src/tests/tracked_range_stale.rs
+++ b/crates/editor-core/src/tests/tracked_range_stale.rs
@@ -1,3 +1,4 @@
+use editor_common::{Direction, Movement};
 use editor_macros::state;
 use editor_state::{Position, Selection};
 
@@ -167,6 +168,38 @@ fn undo_does_not_resurrect_stale_range() {
     assert!(
         !editor.tracked_ranges().contains("r1"),
         "undo restores text but never resurrects a removed range"
+    );
+    assert!(stale_ids(&events).is_empty());
+}
+
+#[test]
+fn transient_text_change_before_navigation_is_verified_at_tick_end() {
+    let (mut editor, p1) = hello_world_editor();
+    set_cursor(&mut editor, p1, 2);
+
+    let request_id = editor
+        .enqueue_request(vec![
+            Message::Insertion {
+                op: InsertionOp::Text { text: "X".into() },
+            },
+            Message::Navigation {
+                op: NavigationOp::Move {
+                    movement: Movement::Grapheme {
+                        direction: Direction::Forward,
+                    },
+                    extend: false,
+                },
+            },
+            Message::History {
+                op: HistoryOp::Undo,
+            },
+        ])
+        .unwrap();
+    let events = editor.tick_through(request_id).unwrap().events;
+
+    assert!(
+        editor.tracked_ranges().contains("r1"),
+        "a range whose captured text matches the final state must survive the tick"
     );
     assert!(stale_ids(&events).is_empty());
 }

--- a/crates/editor-core/src/text_replacement_tests.rs
+++ b/crates/editor-core/src/text_replacement_tests.rs
@@ -637,6 +637,42 @@ fn replacement_fires_on_commit_as_is() {
 }
 
 #[test]
+fn movement_after_replacement_uses_the_replaced_document_layout() {
+    let (s, ..) = state! {
+        doc { root { p1: paragraph { text("가가") } } }
+        selection: (p1, 2)
+    };
+    let mut editor = editor_with_rules(s, vec![rule("ㅠㅠ", "하하하", false)]);
+
+    type_text(&mut editor, "ㅠ");
+    editor.apply(Message::TextInput {
+        ops: vec![FlatImeOp::Compose { text: "ㅠ".into() }],
+    });
+    editor
+        .enqueue_request(vec![
+            Message::TextInput {
+                ops: vec![FlatImeOp::CommitAsIs],
+            },
+            Message::Navigation {
+                op: NavigationOp::Move {
+                    movement: Movement::Grapheme {
+                        direction: Direction::Forward,
+                    },
+                    extend: false,
+                },
+            },
+        ])
+        .unwrap();
+    editor.tick().unwrap();
+
+    let (expected, ..) = state! {
+        doc { root { p1: paragraph { text("가가하하하") } } }
+        selection: (p1, 5)
+    };
+    assert_state_eq!(editor.state(), &expected);
+}
+
+#[test]
 fn flat_text_input_message_commits_preedit() {
     let (s, ..) = state! {
         doc { root { p1: paragraph { text("") } } }

--- a/crates/editor-core/src/tick.rs
+++ b/crates/editor-core/src/tick.rs
@@ -140,6 +140,7 @@ mod tests {
     use std::collections::BTreeMap;
     use std::sync::{Arc, Mutex};
 
+    use editor_common::{Direction, Movement};
     use editor_crdt::Dot;
     use editor_macros::state;
     use editor_model::{
@@ -150,7 +151,11 @@ mod tests {
         prepare_text_replacement_rules,
     };
 
-    use crate::{CommandOutcome, Editor, EditorError, InsertionOp, Message, NodeOp, Revision};
+    use crate::{
+        CommandOutcome, Editor, EditorError, EditorEvent, InsertionOp, Message, NavigationOp,
+        NodeOp, Revision, SelectionOp, StateField, TrackedRangeOp,
+    };
+    use editor_state::{Position, Selection};
 
     fn editor_with_empty_paragraph() -> Editor {
         let (state, ..) = state! {
@@ -530,6 +535,94 @@ mod tests {
         assert!(editor.tick().is_err());
         assert_eq!(editor.revision(), Revision::INITIAL);
         assert_eq!(text(&editor), "unversioned");
+    }
+
+    #[test]
+    fn unexpected_failure_after_layout_phase_keeps_applied_ops_pending() {
+        let mut editor = editor_with_empty_paragraph();
+        editor
+            .enqueue_request(vec![
+                insert("unversioned"),
+                Message::Navigation {
+                    op: NavigationOp::Move {
+                        movement: Movement::Grapheme {
+                            direction: Direction::Forward,
+                        },
+                        extend: false,
+                    },
+                },
+                unexpected_failure(),
+            ])
+            .unwrap();
+
+        assert!(editor.tick().is_err());
+        assert_eq!(text(&editor), "unversioned");
+        assert!(!editor.pending_ops.is_empty());
+    }
+
+    #[test]
+    fn unexpected_failure_after_layout_phase_preserves_tracked_text_verification() {
+        let (state, p) = state! {
+            doc { root { p: paragraph { text("hello") } } }
+            selection: (p, 0) -> (p, 5)
+        };
+        let sensitive_range = state.selection.unwrap();
+        let mut editor = Editor::new_test(state);
+        editor.apply(Message::TrackedRange {
+            op: TrackedRangeOp::Add {
+                id: "r1".into(),
+                group: "spellcheck".into(),
+                selection: sensitive_range,
+                metadata: String::new(),
+                invalidate_on_text_change: true,
+            },
+        });
+        editor.apply(Message::Selection {
+            op: SelectionOp::Set {
+                selection: Selection::collapsed(Position::new(p, 2)),
+            },
+        });
+        editor
+            .enqueue_request(vec![
+                insert("X"),
+                Message::Navigation {
+                    op: NavigationOp::Move {
+                        movement: Movement::Grapheme {
+                            direction: Direction::Forward,
+                        },
+                        extend: false,
+                    },
+                },
+                unexpected_failure(),
+            ])
+            .unwrap();
+
+        assert!(editor.tick().is_err());
+        assert!(editor.tracked_ranges().contains("r1"));
+
+        editor
+            .enqueue_request(vec![Message::Navigation {
+                op: NavigationOp::Move {
+                    movement: Movement::Grapheme {
+                        direction: Direction::Backward,
+                    },
+                    extend: false,
+                },
+            }])
+            .unwrap();
+        let result = editor.tick().unwrap().unwrap();
+
+        assert!(!editor.tracked_ranges().contains("r1"));
+        assert!(result.events.iter().any(
+            |event| matches!(event, EditorEvent::TrackedRangesStale { ids } if ids == &["r1"])
+        ));
+        assert!(result.events.iter().any(|event| {
+            matches!(
+                event,
+                EditorEvent::StateChanged { fields }
+                    if fields.contains(&StateField::TrackedRanges)
+            )
+        }));
     }
 
     #[test]

--- a/crates/editor-view/src/view.rs
+++ b/crates/editor-view/src/view.rs
@@ -412,6 +412,25 @@ impl View {
         self.layout_state.as_ref()
     }
 
+    /// Returns whether the retained geometry was built from the current document
+    /// and its layout-affecting transient state. Selection differences are
+    /// intentionally excluded; their layout effects are represented by the
+    /// pending overlay and gap phantom passed separately.
+    pub fn retained_layout_matches(
+        &self,
+        state: &State,
+        pending_overlay: Option<&PendingOverlay>,
+        gap_phantom: Option<&GapPhantom>,
+    ) -> bool {
+        self.layout.is_some()
+            && self
+                .layout_state
+                .as_ref()
+                .is_some_and(|layout_state| Arc::ptr_eq(&layout_state.projected, &state.projected))
+            && self.view_state.pending_overlay.as_ref() == pending_overlay
+            && self.view_state.gap_phantom.as_ref() == gap_phantom
+    }
+
     /// Consumes projected layout dirtiness without making the retained layout
     /// snapshot force a copy-on-write clone of an otherwise unchanged document.
     pub fn take_layout_dirty(&mut self, state: &mut State) -> LayoutDirty {


### PR DESCRIPTION
## 배경

에디터는 하나의 tick에서 여러 메시지를 순서대로 처리할 수 있습니다. 이때 앞선 메시지가 문서를 변경한 뒤 `Navigation` 같은 geometry-dependent 커맨드가 이어지면, editor state는 최신 문서를 가리키지만 retained layout은 변경 전 문서를 기준으로 만들어진 상태일 수 있습니다.

텍스트 대치 전후의 길이가 다른 경우 이 불일치가 특히 잘 드러납니다. 예를 들어 문단 끝에서 조합 중인 텍스트가 더 긴 문자열로 대치된 직후 오른쪽 방향키 입력까지 같은 tick에서 처리되면, 이동 위치가 대치 전 레이아웃에서 계산될 수 있습니다. 그 결과 커서가 대치된 텍스트 다음이 아니라 문단 앞쪽의 다른 위치로 이동했습니다.

기존 구현은 현재 selection을 retained layout이 만들어진 과거 state로 remap하고, 그 상태에서 이동 위치를 계산한 뒤 결과를 다시 현재 state로 remap했습니다. 하지만 이 방식은 문서 식별 관계를 복원할 수는 있어도, 텍스트 대치나 reflow 이후의 시각적 이동 의미까지 보존하지는 못합니다.

## 변경 사항

- `Navigation`과 layout-dependent deletion을 실행하기 전에 retained layout이 현재 editor state와 일치하는지 확인합니다.
- 현재 문서나 layout-affecting transient state가 달라졌을 때만 pending layout을 reconcile합니다.
- Navigation과 deletion은 과거 layout state를 거치지 않고 동일한 최신 state에서 이동 위치를 계산하고 적용합니다.
- 이를 위해 사용하던 `layout_input_state`와 이동 결과의 selection remap을 제거합니다.
- Selection hit-test처럼 실제 retained layout 좌표를 해석해야 하는 경로에는 layout state 기준 remap을 유지합니다.

## Tick 처리

geometry-dependent 커맨드 앞에서 layout이 갱신되더라도 tick-final 처리가 중간 상태에서 확정되지 않도록 layout reconcile과 최종 처리를 분리했습니다.

- `TickChanges`가 여러 layout phase에서 처리한 op 범위와 layout dirty 범위를 누적합니다.
- view change 여부도 tick 전체에 걸쳐 누적합니다.
- text-sensitive tracked range는 중간 상태가 아니라 모든 메시지가 처리된 최종 state에서 한 번만 검증합니다.
- font effect와 나머지 tick-final 처리도 최종 layout reconcile 이후에 수행합니다.

따라서 한 tick에서 텍스트가 잠시 변경된 뒤 undo로 원복되는 경우에도, 중간 layout phase만 보고 tracked range를 영구적으로 stale 처리하지 않습니다.

## 성능 영향

추가 layout은 모든 이동 입력에서 무조건 수행되지 않습니다.

`retained_layout_matches`가 다음 항목을 확인하고, 기존 layout이 그대로 유효하면 reconcile을 건너뜁니다.

- 현재 projected document와 layout snapshot의 일치 여부
- pending overlay
- gap phantom
- pending font load

Selection 자체의 차이는 layout validity 판단에서 제외합니다. Selection으로 인해 필요한 layout 차이는 pending overlay와 gap phantom을 통해 별도로 비교합니다.

## 검증

- 길이가 달라지는 텍스트 대치 직후 오른쪽 이동이 대치된 문서의 레이아웃을 사용하는지 검증했습니다.
- 같은 tick에서 remote structure 변경 후 navigation/deletion이 최신 문서 기준으로 동작하는지 검증했습니다.
- 중간 layout reconcile 후 undo로 최종 텍스트가 원복되면 tracked range가 유지되는지 검증했습니다.
- 중간 layout phase 이후 tick이 실패해도 이미 적용된 pending op가 보존되는지 검증했습니다.
- `cargo test -p editor-core`
- `cargo fmt --all -- --check`