### PR TITLE
IME 조합 확정 시 텍스트 대치가 적용되도록 함

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorImeCommandNormalizer.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorImeCommandNormalizer.kt
@@ -31,15 +31,17 @@ internal object EditorImeCommandNormalizer {
     val messages = mutableListOf<Message>()
     val ops = mutableListOf<FlatImeOp>()
     var hasActiveComposition = ime?.composing != null
+    fun flushOps() {
+      if (ops.isEmpty()) return
+      messages += Message.TextInput(ops.toList())
+      ops.clear()
+    }
 
     for (command in commands) {
       if (command is CommitTextCommand) {
         val text = command.text.replace("\r\n", "\n").replace('\r', '\n')
         if (text == "\n") {
-          if (ops.isNotEmpty()) {
-            messages += Message.TextInput(ops.toList())
-            ops.clear()
-          }
+          flushOps()
 
           messages += Message.Key(KeyEvent(Key.Enter))
           continue
@@ -48,10 +50,7 @@ internal object EditorImeCommandNormalizer {
         // paragraph splits via the enter key path.
         text.split("\n").forEachIndexed { index, segment ->
           if (index > 0) {
-            if (ops.isNotEmpty()) {
-              messages += Message.TextInput(ops.toList())
-              ops.clear()
-            }
+            flushOps()
             messages += Message.Key(KeyEvent(Key.Enter))
           }
           if (segment.isNotEmpty() || index == 0) {
@@ -84,9 +83,7 @@ internal object EditorImeCommandNormalizer {
         }
     }
 
-    if (ops.isNotEmpty()) {
-      messages += Message.TextInput(ops)
-    }
+    flushOps()
 
     return messages
   }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/input/EditorImeCommandNormalizerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/input/EditorImeCommandNormalizerTest.kt
@@ -149,6 +149,26 @@ class EditorImeCommandNormalizerTest {
   }
 
   @Test
+  fun `finish composition stays ordered before following committed text`() {
+    val ime =
+      Ime(text = "ㅜㅜ", windowStart = 0, selection = ImeRange(2, 2), composing = ImeRange(1, 2))
+    val messages =
+      EditorImeCommandNormalizer.normalize(
+        listOf(FinishComposingTextCommand(), CommitTextCommand(" ", 1)),
+        ime = ime,
+      )
+
+    assertEquals(
+      listOf(
+        Message.TextInput(
+          listOf(FlatImeOp.CommitAsIs, FlatImeOp.Compose(" "), FlatImeOp.CommitAsIs)
+        )
+      ),
+      messages,
+    )
+  }
+
+  @Test
   fun `finish composing command commits preedit started in same command batch`() {
     val messages =
       EditorImeCommandNormalizer.normalize(

--- a/apps/website/src/lib/editor-ffi/components/Input.svelte
+++ b/apps/website/src/lib/editor-ffi/components/Input.svelte
@@ -126,12 +126,13 @@
         pendingCompositionDispatch = undefined;
         return;
       }
-      const committed = inputAdapter.handleCompositionEnd();
       const action = pendingCompositionDispatch;
       pendingCompositionDispatch = undefined;
-      if (committed) {
-        action?.();
-      }
+      let committed = false;
+      editor.updateNow(() => {
+        committed = inputAdapter.handleCompositionEnd();
+      });
+      if (committed) action?.();
     }}
     oncompositionstart={(e) => {
       if (editor.readOnly) return;
@@ -160,6 +161,7 @@
         editor.editBlockedHandler?.();
       }
       editor.updateNow(() => {
+        inputAdapter.handleKeyDown(e);
         pendingCompositionDispatch =
           deferPasteShortcutDuringComposition(
             e,

--- a/apps/website/src/lib/editor-ffi/input/composition-tail-resolver.test.ts
+++ b/apps/website/src/lib/editor-ffi/input/composition-tail-resolver.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { initialCompositionTailState, resolveCompositionTail } from './composition-tail-resolver';
+
+describe('resolveCompositionTail', () => {
+  it('commits the active composition before inserting an appended Korean final key', () => {
+    const keyed = resolveCompositionTail(initialCompositionTailState, { type: 'key_down', key: ' ' });
+    const updated = resolveCompositionTail(keyed.state, { type: 'composition_continues' });
+    const deferred = resolveCompositionTail(updated.state, {
+      type: 'composition_edit',
+      currentText: 'ㅠ',
+      editText: 'ㅠ ',
+      targetsCurrentComposition: true,
+    });
+    expect(deferred.effects).toEqual([{ type: 'defer_current_edit', generation: 1 }]);
+
+    const ended = resolveCompositionTail(deferred.state, { type: 'composition_end' });
+    expect(ended.effects).toEqual([{ type: 'commit_then_insert', generation: 1, text: ' ' }]);
+  });
+
+  it('applies a deferred Japanese continuation as a composition edit', () => {
+    const keyed = resolveCompositionTail(initialCompositionTailState, { type: 'key_down', key: 'n' });
+    const deferred = resolveCompositionTail(keyed.state, {
+      type: 'composition_edit',
+      currentText: 'にほ',
+      editText: 'にほn',
+      targetsCurrentComposition: true,
+    });
+
+    const continued = resolveCompositionTail(deferred.state, { type: 'composition_continues' });
+    expect(continued.effects).toEqual([{ type: 'apply_deferred_edit', generation: 1 }]);
+  });
+
+  it('applies a deferred edit when no composition-end observation arrives', () => {
+    const keyed = resolveCompositionTail(initialCompositionTailState, { type: 'key_down', key: 'n' });
+    const deferred = resolveCompositionTail(keyed.state, {
+      type: 'composition_edit',
+      currentText: 'にほ',
+      editText: 'にほn',
+      targetsCurrentComposition: true,
+    });
+
+    const timedOut = resolveCompositionTail(deferred.state, { type: 'timeout', generation: 1 });
+    expect(timedOut.effects).toEqual([{ type: 'apply_deferred_edit', generation: 1 }]);
+  });
+
+  it('ignores a stale timeout after reset discarded the deferred edit', () => {
+    const keyed = resolveCompositionTail(initialCompositionTailState, { type: 'key_down', key: ' ' });
+    const deferred = resolveCompositionTail(keyed.state, {
+      type: 'composition_edit',
+      currentText: 'ㅠ',
+      editText: 'ㅠ ',
+      targetsCurrentComposition: true,
+    });
+    const reset = resolveCompositionTail(deferred.state, { type: 'reset' });
+    expect(reset.effects).toEqual([{ type: 'discard_deferred_edit', generation: 1 }]);
+
+    const staleTimeout = resolveCompositionTail(reset.state, { type: 'timeout', generation: 1 });
+    expect(staleTimeout.effects).toEqual([]);
+  });
+});

--- a/apps/website/src/lib/editor-ffi/input/composition-tail-resolver.ts
+++ b/apps/website/src/lib/editor-ffi/input/composition-tail-resolver.ts
@@ -1,0 +1,86 @@
+export type CompositionTailState =
+  | { type: 'idle'; generation: number }
+  | { type: 'key_observed'; generation: number; key: string }
+  | { type: 'edit_deferred'; generation: number; appendedText: string };
+
+export type CompositionTailObservation =
+  | { type: 'key_down'; key: string | null }
+  | { type: 'composition_edit'; currentText: string | null; editText: string; targetsCurrentComposition: boolean }
+  | { type: 'composition_continues' }
+  | { type: 'composition_end' }
+  | { type: 'timeout'; generation: number }
+  | { type: 'reset' };
+
+export type CompositionTailEffect =
+  | { type: 'apply_current_edit' }
+  | { type: 'defer_current_edit'; generation: number }
+  | { type: 'apply_deferred_edit'; generation: number }
+  | { type: 'commit_then_insert'; generation: number; text: string }
+  | { type: 'discard_deferred_edit'; generation: number };
+
+export type CompositionTailResolution = {
+  state: CompositionTailState;
+  effects: CompositionTailEffect[];
+};
+
+export const initialCompositionTailState: CompositionTailState = { type: 'idle', generation: 0 };
+
+const idle = (generation: number): CompositionTailState => ({ type: 'idle', generation });
+
+export const resolveCompositionTail = (state: CompositionTailState, observation: CompositionTailObservation): CompositionTailResolution => {
+  switch (observation.type) {
+    case 'key_down': {
+      const effects: CompositionTailEffect[] =
+        state.type === 'edit_deferred' ? [{ type: 'apply_deferred_edit', generation: state.generation }] : [];
+      return {
+        state:
+          observation.key == null ? idle(state.generation) : { type: 'key_observed', generation: state.generation, key: observation.key },
+        effects,
+      };
+    }
+    case 'composition_edit': {
+      if (
+        state.type === 'key_observed' &&
+        observation.currentText != null &&
+        observation.targetsCurrentComposition &&
+        observation.editText === `${observation.currentText}${state.key}`
+      ) {
+        const generation = state.generation + 1;
+        return {
+          state: { type: 'edit_deferred', generation, appendedText: state.key },
+          effects: [{ type: 'defer_current_edit', generation }],
+        };
+      }
+
+      const effects: CompositionTailEffect[] = [];
+      if (state.type === 'edit_deferred') {
+        effects.push({ type: 'apply_deferred_edit', generation: state.generation });
+      }
+      effects.push({ type: 'apply_current_edit' });
+      return { state: idle(state.generation), effects };
+    }
+    case 'composition_continues': {
+      return state.type === 'edit_deferred'
+        ? { state: idle(state.generation), effects: [{ type: 'apply_deferred_edit', generation: state.generation }] }
+        : { state, effects: [] };
+    }
+    case 'composition_end': {
+      return state.type === 'edit_deferred'
+        ? {
+            state: idle(state.generation),
+            effects: [{ type: 'commit_then_insert', generation: state.generation, text: state.appendedText }],
+          }
+        : { state: idle(state.generation), effects: [] };
+    }
+    case 'timeout': {
+      return state.type === 'edit_deferred' && state.generation === observation.generation
+        ? { state: idle(state.generation), effects: [{ type: 'apply_deferred_edit', generation: state.generation }] }
+        : { state, effects: [] };
+    }
+    case 'reset': {
+      const effects: CompositionTailEffect[] =
+        state.type === 'edit_deferred' ? [{ type: 'discard_deferred_edit', generation: state.generation }] : [];
+      return { state: idle(state.generation + 1), effects };
+    }
+  }
+};

--- a/apps/website/src/lib/editor-ffi/input/ime-input-adapter.test.ts
+++ b/apps/website/src/lib/editor-ffi/input/ime-input-adapter.test.ts
@@ -30,6 +30,8 @@ const createImeHarness = (initialContext: ImeContext) => {
     compositionStart: (data = '') => adapter.handleCompositionStart(compositionEvent(input, data)),
     compositionUpdate: (data: string) => adapter.handleCompositionUpdate(compositionEvent(input, data)),
     compositionEnd: () => adapter.handleCompositionEnd(),
+    composingKeyDown: (key: string) =>
+      adapter.handleKeyDown({ key, isComposing: true, ctrlKey: false, metaKey: false, altKey: false } as KeyboardEvent),
     beforeCompositionInput: (text: string) => adapter.handleBeforeInput(beforeInputEvent(input, 'insertCompositionText', text)),
     beforeTextInput: (text: string) => {
       const event = beforeInputEvent(input, 'insertText', text);
@@ -1165,6 +1167,93 @@ describe('ImeInputAdapter', () => {
         ops: [
           { type: 'set_selection', start: 21, end: 21 },
           { type: 'replace_selection', text: ' ' },
+        ],
+      },
+    ]);
+  });
+
+  it('commits preedit before a non-composition text insertion delivered before compositionend', () => {
+    const ime = createImeHarness(context('ㅜ'));
+
+    ime.syncFromEditor();
+    ime.compositionStart();
+    ime.beforeCompositionInput('ㅜ');
+    ime.applyNativeInput('ㅜㅜ', 2);
+
+    const spaceEvent = ime.beforeTextInput(' ');
+    expect(spaceEvent.preventDefault).toHaveBeenCalledOnce();
+    expect(ime.compositionEnd()).toBe(false);
+    const duplicateCommittedPreedit = ime.beforeTextInput('ㅜ');
+    expect(duplicateCommittedPreedit.preventDefault).toHaveBeenCalledOnce();
+
+    expect(ime.messages).toEqual([
+      {
+        type: 'text_input',
+        ops: [
+          { type: 'set_composition', start: 21, end: 21 },
+          { type: 'compose', text: 'ㅜ' },
+        ],
+      },
+      { type: 'text_input', ops: [{ type: 'commit_as_is' }] },
+      { type: 'text_input', ops: [{ type: 'replace_selection', text: ' ' }] },
+    ]);
+  });
+
+  it('inserts an appended composition key at the caret produced by commit', () => {
+    const ime = createImeHarness(context('ㅠ'));
+
+    ime.syncFromEditor();
+    ime.compositionStart();
+    ime.beforeCompositionInput('ㅠ');
+    ime.applyNativeInput('ㅠㅠ', 2);
+
+    ime.composingKeyDown(' ');
+    ime.compositionUpdate('ㅠ ');
+    ime.beforeCompositionInput('ㅠ ');
+    ime.applyNativeInput('ㅠㅠ ', 3);
+    expect(ime.compositionEnd()).toBe(true);
+
+    expect(ime.messages).toEqual([
+      {
+        type: 'text_input',
+        ops: [
+          { type: 'set_composition', start: 21, end: 21 },
+          { type: 'compose', text: 'ㅠ' },
+        ],
+      },
+      { type: 'text_input', ops: [{ type: 'commit_as_is' }] },
+      { type: 'text_input', ops: [{ type: 'replace_selection', text: ' ' }] },
+    ]);
+  });
+
+  it('applies an appended composition key when the composition continues', async () => {
+    const ime = createImeHarness(context(''));
+
+    ime.syncFromEditor();
+    ime.compositionStart();
+    ime.beforeCompositionInput('にほ');
+    ime.applyNativeInput('にほ', 2);
+
+    ime.composingKeyDown('n');
+    ime.compositionUpdate('にほn');
+    ime.beforeCompositionInput('にほn');
+    ime.applyNativeInput('にほn', 3);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(ime.messages).toEqual([
+      {
+        type: 'text_input',
+        ops: [
+          { type: 'set_composition', start: 20, end: 20 },
+          { type: 'compose', text: 'にほ' },
+        ],
+      },
+      {
+        type: 'text_input',
+        ops: [
+          { type: 'set_composition', start: 20, end: 22 },
+          { type: 'compose', text: 'にほn' },
         ],
       },
     ]);

--- a/apps/website/src/lib/editor-ffi/input/ime-input-adapter.ts
+++ b/apps/website/src/lib/editor-ffi/input/ime-input-adapter.ts
@@ -1,3 +1,4 @@
+import { initialCompositionTailState, resolveCompositionTail } from './composition-tail-resolver';
 import {
   canPreserveNativeInputOnEditorSync,
   codePointLength,
@@ -11,6 +12,7 @@ import {
 } from './ime-context';
 import { normalizeLineBreakBeforeInput, readDomComposingReplacement, readDomInputDiff, textInputMessage } from './ime-normalizer';
 import type { Message } from '@typie/editor-ffi/browser';
+import type { CompositionTailEffect, CompositionTailObservation, CompositionTailState } from './composition-tail-resolver';
 import type { ImeContext, ImeRange, ImeTextInput } from './ime-context';
 import type { DomInputDiff } from './ime-normalizer';
 
@@ -28,6 +30,14 @@ type ImeEditIntent = {
 type ImeCompositionEdit = {
   target: ImeRange;
   text: string;
+};
+
+type DeferredCompositionEdit = {
+  generation: number;
+  context: ImeContext;
+  input: ImeTextInput;
+  edit: ImeCompositionEdit;
+  timer: ReturnType<typeof setTimeout>;
 };
 
 const isCollapsedRange = (range: ImeRange): boolean => range.start === range.end;
@@ -136,12 +146,89 @@ export class ImeInputAdapter {
   #pendingEditIntent: ImeEditIntent | null = null;
   #pendingCompositionText: string | null = null;
   #pendingCompositionTarget: ImeRange | null = null;
+  #compositionTailState: CompositionTailState = initialCompositionTailState;
+  #deferredCompositionEdit: DeferredCompositionEdit | null = null;
   #compositionActive = false;
   #commitPendingText: string | null = null;
   #resyncInProgress = false;
 
   constructor(deps: ImeInputAdapterDeps) {
     this.#deps = deps;
+  }
+
+  #takeDeferredCompositionEdit(generation: number): DeferredCompositionEdit | null {
+    const deferred = this.#deferredCompositionEdit;
+    if (deferred && deferred.generation !== generation) {
+      return null;
+    }
+    this.#deferredCompositionEdit = null;
+    if (deferred) {
+      clearTimeout(deferred.timer);
+    }
+    return deferred;
+  }
+
+  #applyDeferredCompositionEdit(generation: number): void {
+    const deferred = this.#takeDeferredCompositionEdit(generation);
+    if (!deferred) {
+      return;
+    }
+    this.#applyCompositionEdit(deferred.context, deferred.input, deferred.edit);
+  }
+
+  #observeCompositionTail(observation: CompositionTailObservation): CompositionTailEffect[] {
+    const resolution = resolveCompositionTail(this.#compositionTailState, observation);
+    this.#compositionTailState = resolution.state;
+    return resolution.effects;
+  }
+
+  #applyCompositionTailEffects(
+    effects: CompositionTailEffect[],
+    currentEdit?: { context: ImeContext; input: ImeTextInput; edit: ImeCompositionEdit },
+  ): Extract<CompositionTailEffect, { type: 'commit_then_insert' }> | null {
+    let commit: Extract<CompositionTailEffect, { type: 'commit_then_insert' }> | null = null;
+    for (const effect of effects) {
+      switch (effect.type) {
+        case 'apply_current_edit': {
+          if (!currentEdit) {
+            throw new Error('Composition-tail resolution requires the current edit');
+          }
+          this.#applyCompositionEdit(currentEdit.context, currentEdit.input, currentEdit.edit);
+          break;
+        }
+        case 'defer_current_edit': {
+          if (!currentEdit) {
+            throw new Error('Composition-tail resolution requires the current edit');
+          }
+          this.#deferCompositionEdit(effect.generation, currentEdit.context, currentEdit.input, currentEdit.edit);
+          break;
+        }
+        case 'apply_deferred_edit': {
+          this.#applyDeferredCompositionEdit(effect.generation);
+          break;
+        }
+        case 'discard_deferred_edit': {
+          this.#takeDeferredCompositionEdit(effect.generation);
+          break;
+        }
+        case 'commit_then_insert': {
+          commit = effect;
+          break;
+        }
+      }
+    }
+    return commit;
+  }
+
+  #continueCompositionTail(): void {
+    this.#applyCompositionTailEffects(this.#observeCompositionTail({ type: 'composition_continues' }));
+  }
+
+  #deferCompositionEdit(generation: number, context: ImeContext, input: ImeTextInput, edit: ImeCompositionEdit): void {
+    const timer = setTimeout(() => {
+      this.#applyCompositionTailEffects(this.#observeCompositionTail({ type: 'timeout', generation }));
+    }, 0);
+    this.#deferredCompositionEdit = { generation, context, input, edit, timer };
   }
 
   #handleInputWithoutDiff(context: ImeContext, input: ImeTextInput): void {
@@ -155,6 +242,7 @@ export class ImeInputAdapter {
       this.#pendingCompositionText = null;
       const target = pendingTarget ?? context.composing;
       if (target && text != null) {
+        this.#applyCompositionTailEffects(this.#observeCompositionTail({ type: 'key_down', key: null }));
         this.#applyCompositionEdit(context, input, { target, text });
         return;
       }
@@ -190,7 +278,16 @@ export class ImeInputAdapter {
     }
     const edit = this.#compositionEdit(context, replacement);
     this.#pendingCompositionText = null;
-    this.#applyCompositionEdit(context, input, edit);
+    const currentText = readContextCompositionText(context);
+    const targetsCurrentComposition =
+      !!context.composing && edit.target.start === context.composing.start && edit.target.end === context.composing.end;
+    const effects = this.#observeCompositionTail({
+      type: 'composition_edit',
+      currentText,
+      editText: edit.text,
+      targetsCurrentComposition,
+    });
+    this.#applyCompositionTailEffects(effects, { context, input, edit });
   }
 
   #handleTextInputWithDiff(context: ImeContext, input: ImeTextInput, diff: DomInputDiff): void {
@@ -292,6 +389,7 @@ export class ImeInputAdapter {
       this.#pendingEditIntent = null;
       this.#pendingCompositionText = null;
       this.#pendingCompositionTarget = null;
+      this.#applyCompositionTailEffects(this.#observeCompositionTail({ type: 'reset' }));
       this.#compositionActive = false;
       this.#commitPendingText = null;
 
@@ -346,6 +444,8 @@ export class ImeInputAdapter {
       return;
     }
 
+    this.#continueCompositionTail();
+
     if (
       this.#commitPendingText != null &&
       (e.inputType === 'insertText' || e.inputType === 'insertCompositionText') &&
@@ -386,6 +486,29 @@ export class ImeInputAdapter {
         context && !context.composing
           ? utf16SelectionToFlatRange(context.text, context.windowStart, readInputUtf16Selection(e.currentTarget))
           : null;
+    }
+
+    if (this.#compositionActive && e.inputType === 'insertText' && e.data != null && context?.composing) {
+      const committedText = readContextCompositionText(context);
+      if (committedText != null) {
+        e.preventDefault();
+        this.#compositionActive = false;
+        this.#pendingEditIntent = null;
+        this.#pendingCompositionText = null;
+        this.#pendingCompositionTarget = null;
+        this.#applyCompositionTailEffects(this.#observeCompositionTail({ type: 'key_down', key: null }));
+        this.#context = {
+          ...context,
+          selection: { start: context.composing.end, end: context.composing.end },
+          composing: null,
+        };
+        this.#deps.enqueue([
+          { type: 'text_input', ops: [{ type: 'commit_as_is' }] },
+          ...textInputMessage([{ type: 'replace_selection', text: e.data }]),
+        ]);
+        this.#setCommitPending(committedText);
+        return;
+      }
     }
 
     this.#pendingEditIntent =
@@ -429,6 +552,9 @@ export class ImeInputAdapter {
       return;
     }
 
+    this.#continueCompositionTail();
+    this.#applyCompositionTailEffects(this.#observeCompositionTail({ type: 'key_down', key: null }));
+
     this.#clearCommitPending();
     const wasCompositionActive = this.#compositionActive;
     const pendingTarget = this.#pendingCompositionTarget;
@@ -444,12 +570,40 @@ export class ImeInputAdapter {
       return;
     }
 
+    this.#continueCompositionTail();
+
     this.#pendingCompositionText = e.data;
+  }
+
+  handleKeyDown(e: KeyboardEvent): void {
+    const key =
+      this.#compositionActive && e.isComposing && !e.ctrlKey && !e.metaKey && !e.altKey && codePointLength(e.key) === 1 ? e.key : null;
+    this.#applyCompositionTailEffects(this.#observeCompositionTail({ type: 'key_down', key }));
   }
 
   handleCompositionEnd(): boolean {
     if (this.#resyncInProgress) {
       return false;
+    }
+
+    const commitTail = this.#applyCompositionTailEffects(this.#observeCompositionTail({ type: 'composition_end' }));
+    if (commitTail) {
+      const deferred = this.#takeDeferredCompositionEdit(commitTail.generation);
+      if (deferred) {
+        const committedText = readContextCompositionText(deferred.context);
+        this.#compositionActive = false;
+        this.#pendingCompositionText = null;
+        this.#pendingCompositionTarget = null;
+        this.#context = updateContextFromInputElement(deferred.context, deferred.input, null);
+        if (committedText != null) {
+          this.#deps.enqueue([
+            { type: 'text_input', ops: [{ type: 'commit_as_is' }] },
+            ...textInputMessage([{ type: 'replace_selection', text: commitTail.text }]),
+          ]);
+          this.#setCommitPending(committedText);
+          return true;
+        }
+      }
     }
 
     this.#compositionActive = false;

--- a/apps/website/src/lib/editor-ffi/input/ime-text-replacement.browser.test.ts
+++ b/apps/website/src/lib/editor-ffi/input/ime-text-replacement.browser.test.ts
@@ -1,0 +1,152 @@
+import '../../../app.css';
+
+import { mount, tick, unmount } from 'svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { initWasm } from '$lib/wasm-ffi.svelte';
+import { Editor } from '../editor.svelte';
+import EditorFrameSyncTestHost from '../editor-frame-sync-test-host.svelte';
+import type { PlainDoc, PlainNode, PlainNodeEntry } from '@typie/editor-ffi/browser';
+
+vi.mock('$env/dynamic/public', () => ({ env: {} }));
+
+const entry = (node: PlainNode, children: PlainNodeEntry[] = []): PlainNodeEntry => ({
+  node,
+  modifiers: {} as never,
+  carry: [],
+  children,
+});
+
+const doc = (text: string): PlainDoc => ({
+  root: entry(
+    {
+      type: 'root',
+      layout_mode: { type: 'continuous', max_width: 320 },
+    },
+    [entry({ type: 'paragraph' }, [entry({ type: 'text', text })])],
+  ),
+});
+
+describe('web IME text replacement', () => {
+  let editor: Editor | undefined;
+  let mounted: Record<string, unknown> | undefined;
+
+  const mountEditor = async (): Promise<{ editor: Editor; input: HTMLTextAreaElement }> => {
+    const host = await initWasm();
+    host.set_text_replacement_rules([{ id: 'cry-to-laugh', matchPattern: 'ㅠㅠ', substitute: '하하하', regex: false }]);
+    const mountedEditor = await Editor.createFromDoc(doc(''), { width: 320, height: 180, scale_factor: 1 });
+    editor = mountedEditor;
+
+    const target = document.createElement('div');
+    document.body.append(target);
+    mounted = mount(EditorFrameSyncTestHost, {
+      target,
+      props: { editor: mountedEditor, userId: `ime-text-replacement-${crypto.randomUUID()}` },
+    });
+    await tick();
+    mountedEditor.updateNow(() => {
+      mountedEditor.enqueue({ type: 'selection', op: { type: 'set_flat', start: 1, end: 1 } });
+      mountedEditor.enqueue({ type: 'system', event: { type: 'set_focused', focused: true } });
+    });
+    await tick();
+
+    const input = mountedEditor.inputEl;
+    if (!input) throw new Error('Production editor input is not mounted');
+    input.focus();
+    return { editor: mountedEditor, input };
+  };
+
+  const imeEvents = (input: HTMLTextAreaElement) => ({
+    composition: (type: 'compositionstart' | 'compositionupdate' | 'compositionend', data: string) =>
+      input.dispatchEvent(new CompositionEvent(type, { data, bubbles: true })),
+    beforeCompositionInput: (data: string) =>
+      input.dispatchEvent(
+        new InputEvent('beforeinput', {
+          inputType: 'insertCompositionText',
+          data,
+          isComposing: true,
+          bubbles: true,
+          cancelable: true,
+        }),
+      ),
+    beforeTextInput: (data: string) =>
+      input.dispatchEvent(
+        new InputEvent('beforeinput', {
+          inputType: 'insertText',
+          data,
+          isComposing: true,
+          bubbles: true,
+          cancelable: true,
+        }),
+      ),
+    applyNativeInput: (value: string, selection: number, inputType: string, data: string) => {
+      input.value = value;
+      input.setSelectionRange(selection, selection);
+      input.dispatchEvent(new InputEvent('input', { inputType, data, isComposing: true, bubbles: true }));
+    },
+    composingKeyDown: (key: string) =>
+      input.dispatchEvent(new KeyboardEvent('keydown', { key, isComposing: true, bubbles: true, cancelable: true })),
+  });
+
+  afterEach(async () => {
+    if (mounted) await unmount(mounted);
+    mounted = undefined;
+    editor?.destroy();
+    editor = undefined;
+    const host = await initWasm();
+    host.set_text_replacement_rules([]);
+    document.body.replaceChildren();
+  });
+
+  it('replaces a Korean match when macOS appends Space to the final composition update', async () => {
+    const { editor, input } = await mountEditor();
+    const events = imeEvents(input);
+
+    events.composition('compositionstart', '');
+    events.composition('compositionupdate', 'ㅠ');
+    events.beforeCompositionInput('ㅠ');
+    events.applyNativeInput('\u{2028}ㅠ\u{2029}', 2, 'insertCompositionText', 'ㅠ');
+
+    events.composingKeyDown('ㅠ');
+    events.composition('compositionupdate', 'ㅠ');
+    events.beforeCompositionInput('ㅠ');
+    events.applyNativeInput('\u{2028}ㅠ\u{2029}', 2, 'insertCompositionText', 'ㅠ');
+    events.composition('compositionend', 'ㅠ');
+    events.composition('compositionstart', '');
+    events.composition('compositionupdate', 'ㅠ');
+    events.beforeCompositionInput('ㅠ');
+    events.applyNativeInput('\u{2028}ㅠㅠ\u{2029}', 3, 'insertCompositionText', 'ㅠ');
+
+    events.composingKeyDown(' ');
+    events.composition('compositionupdate', 'ㅠ ');
+    events.beforeCompositionInput('ㅠ ');
+    events.applyNativeInput('\u{2028}ㅠㅠ \u{2029}', 4, 'insertCompositionText', 'ㅠ ');
+    events.composition('compositionend', 'ㅠ ');
+
+    await new Promise(requestAnimationFrame);
+    expect(editor.proseText()).toBe('하하하 ');
+  });
+
+  it('inserts text after a replacement when insertText arrives before compositionend', async () => {
+    const { editor, input } = await mountEditor();
+    const events = imeEvents(input);
+
+    events.composition('compositionstart', '');
+    events.composition('compositionupdate', 'ㅠ');
+    events.beforeCompositionInput('ㅠ');
+    events.applyNativeInput('\u{2028}ㅠ\u{2029}', 2, 'insertCompositionText', 'ㅠ');
+    events.composition('compositionend', 'ㅠ');
+
+    events.composition('compositionstart', '');
+    events.composition('compositionupdate', 'ㅠ');
+    events.beforeCompositionInput('ㅠ');
+    events.applyNativeInput('\u{2028}ㅠㅠ\u{2029}', 3, 'insertCompositionText', 'ㅠ');
+
+    if (events.beforeTextInput(' ')) {
+      events.applyNativeInput('\u{2028}ㅠㅠ \u{2029}', 4, 'insertText', ' ');
+    }
+    events.composition('compositionend', 'ㅠ');
+
+    await new Promise(requestAnimationFrame);
+    expect(editor.proseText()).toBe('하하하 ');
+  });
+});

--- a/crates/editor-core/src/editor.rs
+++ b/crates/editor-core/src/editor.rs
@@ -1107,13 +1107,9 @@ impl Editor {
             let mut consumed = 1;
             let mut outcome = CommandOutcome::Applied;
             let result: Result<(), EditorError> = match message {
-                // Coalesce a consecutive run of text-input batches into one reduce +
-                // transact: an IME composition update enqueues several `TextInput`
-                // messages per frame, and each separately rebuilds the flat window
-                // and re-derives the edit. A batch containing `CommitAsIs` ends the
-                // run — the commit's text replacement must see the committed text
-                // before a following batch reopens a composition (it no-ops while
-                // one is active).
+                // Coalesce composition updates until a committed message boundary.
+                // `handle_flat_ime_ops` still preserves barriers inside one message,
+                // while stopping here keeps per-message failure outcomes truthful.
                 Message::TextInput { ops } => {
                     let mut batch = ops;
                     while matches!(messages.front(), Some(Message::TextInput { .. }))
@@ -2372,8 +2368,8 @@ mod tests {
     // A frame's worth of IME composition traffic arrives as several consecutive
     // `TextInput` messages; `tick` coalesces them into batched reduces. The
     // coalesced drain must land on the same document, composition, and selection
-    // as ticking each message separately (the run splits after `CommitAsIs` so
-    // the commit's text replacement still sees the committed text).
+    // as ticking each message separately. `CommitAsIs` remains an execution
+    // barrier inside the combined flat-op vector.
     #[test]
     fn tick_coalesces_consecutive_text_input_messages() {
         let (state, ..) = state! {
@@ -2708,6 +2704,44 @@ mod tests {
             vec![rejected.clone()]
         );
         assert_eq!(result.request_outcomes[3].command_outcomes, vec![rejected]);
+    }
+
+    #[test]
+    fn tick_does_not_coalesce_a_committed_input_with_a_later_failure() {
+        let mut editor = zombie_fixture_editor();
+        let request = editor
+            .enqueue_request(vec![
+                Message::TextInput {
+                    ops: vec![
+                        FlatImeOp::SetSelection { start: 1, end: 1 },
+                        FlatImeOp::ReplaceSelection { text: "a".into() },
+                        FlatImeOp::CommitAsIs,
+                    ],
+                },
+                Message::TextInput {
+                    ops: vec![
+                        FlatImeOp::SetSelection { start: 0, end: 0 },
+                        FlatImeOp::ReplaceSelection { text: "X".into() },
+                    ],
+                },
+            ])
+            .unwrap();
+
+        let result = editor.tick().unwrap().unwrap();
+
+        assert_eq!(
+            result.request_outcomes[0],
+            RequestOutcome {
+                request_id: request,
+                command_outcomes: vec![
+                    CommandOutcome::Applied,
+                    CommandOutcome::Rejected {
+                        reason: CommandRejection::InvalidArgument,
+                    },
+                ],
+            }
+        );
+        assert_eq!(text_and_page_break_signature(editor.state()), "aaz");
     }
 
     #[test]

--- a/crates/editor-core/src/handle/text_input.rs
+++ b/crates/editor-core/src/handle/text_input.rs
@@ -217,6 +217,7 @@ struct FlatImeReduction {
     // must see the full replacement — trimming swallows a leading trigger
     // char that matches the selection's first character.
     untrimmed_text_change: Option<FlatImeTextChange>,
+    committed_composition: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -402,6 +403,15 @@ impl FlatImeAnchoredChangeTracker {
 }
 
 impl FlatImeState {
+    fn has_valid_composition(&self) -> bool {
+        self.comp.is_some_and(|(start, end)| {
+            start < end
+                && start >= self.text.base
+                && end <= self.text.base + self.text.chars.len()
+                && self.text.slice(start..end).iter().all(|c| !is_token(*c))
+        })
+    }
+
     fn from_editor(editor: &Editor, ops: &[FlatImeOp]) -> Option<Self> {
         let state = editor.state();
         let doc = state.view();
@@ -615,8 +625,12 @@ impl FlatImeState {
         let initial_sel_start = self.sel_start;
         let mut anchored_change: Option<FlatImeAnchoredChangeTracker> = None;
         let mut can_track_anchored_change = true;
+        let mut committed_composition = false;
 
         for op in ops {
+            if matches!(op, FlatImeOp::CommitAsIs) && self.has_valid_composition() {
+                committed_composition = true;
+            }
             if let Some(change) = self.apply(op) {
                 if !can_track_anchored_change {
                     continue;
@@ -662,6 +676,7 @@ impl FlatImeState {
             state: self,
             text_change,
             untrimmed_text_change,
+            committed_composition,
         }
     }
 }
@@ -829,11 +844,17 @@ fn flat_ime_ops_form_plain_backspace(editor: &Editor, ops: &[FlatImeOp]) -> bool
 }
 
 pub fn handle_flat_ime_ops(editor: &mut Editor, ops: Vec<FlatImeOp>) -> Result<(), EditorError> {
+    for segment in ops.split_inclusive(|op| matches!(op, FlatImeOp::CommitAsIs)) {
+        handle_flat_ime_segment(editor, segment)?;
+    }
+    Ok(())
+}
+
+fn handle_flat_ime_segment(editor: &mut Editor, ops: &[FlatImeOp]) -> Result<(), EditorError> {
     let mut delete_paint = editor.ime_delete_paint.take();
-    let commit_as_is = ops.iter().any(|op| matches!(op, FlatImeOp::CommitAsIs));
 
     if matches!(editor.last_history_tag(), Some(HistoryTag::AutoReplacement))
-        && flat_ime_ops_form_plain_backspace(editor, &ops)
+        && flat_ime_ops_form_plain_backspace(editor, ops)
         && editor.try_undo_auto_replacement()
     {
         if !editor.state().pending_modifiers.is_empty() {
@@ -846,13 +867,14 @@ pub fn handle_flat_ime_ops(editor: &mut Editor, ops: Vec<FlatImeOp>) -> Result<(
         return Ok(());
     }
 
+    let mut committed_composition = false;
     let committed_insert = (|| -> Result<bool, EditorError> {
-        let initial = match FlatImeState::from_editor(editor, &ops) {
+        let initial = match FlatImeState::from_editor(editor, ops) {
             Some(s) => s,
             None => return Ok(false),
         };
 
-        let reduced = initial.clone().reduce_flat_ime_ops(&ops);
+        let reduced = initial.clone().reduce_flat_ime_ops(ops);
 
         if reduced.text_change.is_none() {
             return Ok(false);
@@ -889,6 +911,7 @@ pub fn handle_flat_ime_ops(editor: &mut Editor, ops: Vec<FlatImeOp>) -> Result<(
             (initial, reduced)
         };
 
+        let reduced_committed_composition = reduced.committed_composition;
         let result = reduced.state;
         let untrimmed_text_change = reduced.untrimmed_text_change;
         let Some(text_change) = reduced.text_change else {
@@ -1181,11 +1204,12 @@ pub fn handle_flat_ime_ops(editor: &mut Editor, ops: Vec<FlatImeOp>) -> Result<(
         }
 
         editor.ime_delete_paint = next_delete_paint;
+        committed_composition = reduced_committed_composition;
 
         Ok(!text_change.insert.is_empty() && result.comp.is_none())
     })()?;
 
-    if commit_as_is || committed_insert {
+    if committed_composition || committed_insert {
         let resource = Arc::clone(&editor.resource);
         let resource = resource.lock().unwrap();
         editor.transact(|tr| {

--- a/crates/editor-core/src/text_replacement_tests.rs
+++ b/crates/editor-core/src/text_replacement_tests.rs
@@ -637,6 +637,170 @@ fn replacement_fires_on_commit_as_is() {
 }
 
 #[test]
+fn commit_barrier_replaces_before_later_op_in_same_text_input() {
+    let (s, ..) = state! {
+        doc { root { p1: paragraph { text("") } } }
+        selection: (p1, 0)
+    };
+    let mut editor = editor_with_rules(s, vec![rule("ㅠㅠ", "하하하", false)]);
+
+    type_text(&mut editor, "ㅠ");
+    editor.apply(Message::TextInput {
+        ops: vec![FlatImeOp::Compose { text: "ㅠ".into() }],
+    });
+    editor.apply(Message::TextInput {
+        ops: vec![
+            FlatImeOp::CommitAsIs,
+            FlatImeOp::ReplaceSelection { text: " ".into() },
+        ],
+    });
+
+    let (expected, ..) = state! {
+        doc { root { p1: paragraph { text("하하하 ") } } }
+        selection: (p1, 4)
+    };
+    assert_state_eq!(editor.state(), &expected);
+}
+
+#[test]
+fn commit_barrier_matches_split_delivery_including_undo() {
+    let (s, ..) = state! {
+        doc { root { p1: paragraph { text("") } } }
+        selection: (p1, 0)
+    };
+    let rules = vec![rule("ㅠㅠ", "하하하", false)];
+    let mut batched = editor_with_rules(s.clone(), rules.clone());
+    let mut split = editor_with_rules(s, rules);
+
+    for editor in [&mut batched, &mut split] {
+        type_text(editor, "ㅠ");
+        editor.apply(Message::TextInput {
+            ops: vec![FlatImeOp::Compose { text: "ㅠ".into() }],
+        });
+    }
+    batched.apply(Message::TextInput {
+        ops: vec![
+            FlatImeOp::CommitAsIs,
+            FlatImeOp::ReplaceSelection { text: " ".into() },
+        ],
+    });
+    split.apply(Message::TextInput {
+        ops: vec![FlatImeOp::CommitAsIs],
+    });
+    split.apply(Message::TextInput {
+        ops: vec![FlatImeOp::ReplaceSelection { text: " ".into() }],
+    });
+
+    assert_state_eq!(batched.state(), split.state());
+    for editor in [&mut batched, &mut split] {
+        editor.apply(Message::History {
+            op: HistoryOp::Undo,
+        });
+    }
+    assert_state_eq!(batched.state(), split.state());
+}
+
+#[test]
+fn commit_as_is_without_active_composition_does_not_trigger_replacement() {
+    let (s, ..) = state! {
+        doc { root { p1: paragraph { text("abc") } } }
+        selection: (p1, 3)
+    };
+    let mut editor = editor_with_rules(s, vec![rule("abc", "X", false)]);
+
+    editor.apply(Message::TextInput {
+        ops: vec![FlatImeOp::CommitAsIs],
+    });
+
+    let (expected, ..) = state! {
+        doc { root { p1: paragraph { text("abc") } } }
+        selection: (p1, 3)
+    };
+    assert_state_eq!(editor.state(), &expected);
+}
+
+#[test]
+fn empty_compose_commit_without_active_composition_does_not_trigger_replacement() {
+    let (s, ..) = state! {
+        doc { root { p1: paragraph { text("abc") } } }
+        selection: (p1, 3)
+    };
+    let mut editor = editor_with_rules(s, vec![rule("abc", "X", false)]);
+
+    editor.apply(Message::TextInput {
+        ops: vec![
+            FlatImeOp::Compose {
+                text: String::new(),
+            },
+            FlatImeOp::CommitAsIs,
+        ],
+    });
+
+    let (expected, ..) = state! {
+        doc { root { p1: paragraph { text("abc") } } }
+        selection: (p1, 3)
+    };
+    assert_state_eq!(editor.state(), &expected);
+}
+
+#[test]
+fn commit_after_clear_composition_does_not_trigger_replacement() {
+    let (s, ..) = state! {
+        doc { root { p1: paragraph { text("abc") } } }
+        selection: (p1, 3)
+    };
+    let mut editor = editor_with_rules(s, vec![rule("abc", "X", false)]);
+    editor.apply(Message::TextInput {
+        ops: vec![FlatImeOp::SetComposition { start: 1, end: 4 }],
+    });
+
+    editor.apply(Message::TextInput {
+        ops: vec![FlatImeOp::ClearComposition, FlatImeOp::CommitAsIs],
+    });
+
+    let (expected, ..) = state! {
+        doc { root { p1: paragraph { text("abc") } } }
+        selection: (p1, 3)
+    };
+    assert_state_eq!(editor.state(), &expected);
+    assert!(editor.state().composition.is_none());
+}
+
+#[test]
+fn replacement_fires_before_following_text_input_in_same_request() {
+    let (s, ..) = state! {
+        doc { root { p1: paragraph { text("") } } }
+        selection: (p1, 0)
+    };
+    let mut editor = editor_with_rules(s, vec![rule("ㅜㅜ", "ㅋㅋ", false)]);
+
+    type_text(&mut editor, "ㅜ");
+    editor.apply(Message::TextInput {
+        ops: vec![FlatImeOp::Compose { text: "ㅜ".into() }],
+    });
+    editor
+        .enqueue_request(vec![
+            Message::TextInput {
+                ops: vec![FlatImeOp::CommitAsIs],
+            },
+            Message::TextInput {
+                ops: vec![
+                    FlatImeOp::Compose { text: " ".into() },
+                    FlatImeOp::CommitAsIs,
+                ],
+            },
+        ])
+        .unwrap();
+    editor.tick().unwrap();
+
+    let (expected, ..) = state! {
+        doc { root { p1: paragraph { text("ㅋㅋ ") } } }
+        selection: (p1, 3)
+    };
+    assert_state_eq!(editor.state(), &expected);
+}
+
+#[test]
 fn movement_after_replacement_uses_the_replaced_document_layout() {
     let (s, ..) = state! {
         doc { root { p1: paragraph { text("가가") } } }


### PR DESCRIPTION
## 배경

`"ㅠㅠ" → "하하하"` 같은 텍스트 대치 룰이 있을 때, 마지막 한글 글자가 조합 중인 상태에서 Space를 누르면 대치가 누락되는 문제가 있었습니다.

기대 결과:

- `ㅠㅠ`가 조합 중인 상태에서 Space 입력
- 결과: `하하하 `

기존 결과는 플랫폼의 IME 이벤트 순서에 따라 달랐습니다.

- 조합 중인 원문이 그대로 남아 `ㅠㅠ `가 됨
- 길이가 다른 대치에서는 후속 공백이 잘못된 위치에 적용되어 `하하 하`가 됨

이 문제는 Web과 App 모두에서 발생할 수 있지만, 플랫폼별 입력 이벤트 모양은 서로 다릅니다.

- Compose는 `FinishComposingTextCommand`와 뒤따르는 `CommitTextCommand(" ")`를 하나의 command batch로 전달할 수 있습니다.
- Web에서는 Space가 마지막 `compositionupdate`에 포함되거나, `insertText(" ")`가 `compositionend`보다 먼저 전달될 수 있습니다.

## 원인

에디터는 연속된 IME 입력을 처리 비용을 줄이기 위해 하나의 `TextInput` 배치로 합칠 수 있습니다.

기존 코어 로직은 배치 전체를 한 번 축약한 뒤 텍스트 대치를 시도했습니다. 이 때문에 배치 중간에 `CommitAsIs`가 있어도 그 뒤의 공백 입력이 composition을 다시 만들면, 텍스트 대치를 검사하는 시점에는 아직 조합 중인 것으로 판단되어 대치가 실행되지 않았습니다.

즉, 텍스트 대치의 의미가 IME의 조합 확정 시점이 아니라 우연한 transport message 경계에 의존하고 있었습니다.

Web에서는 조합을 확정해 대치를 수행한 뒤에도 브라우저가 native input mutation을 계속 적용할 수 있었습니다. 이때 생성되는 DOM diff와 selection은 대치 전 텍스트 길이를 기준으로 하므로, 대치 문자열의 길이가 달라지면 후속 문자가 잘못된 위치에 삽입될 수 있었습니다.

## 변경 사항

### Editor core

- `CommitAsIs`를 하나의 `TextInput` 내부에서도 의미적 실행 경계로 처리합니다.
- 각 확정 경계까지의 IME 연산을 먼저 반영하고 텍스트 대치를 수행한 뒤, 나머지 연산을 변경된 문서와 selection에서 처리합니다.
- 실제로 유효한 활성 composition을 확정한 경우에만 텍스트 대치를 시도합니다.
- 다음 입력들은 텍스트 대치를 유발하지 않습니다.
    - 활성 composition이 없는 단독 `CommitAsIs`
    - 빈 `Compose` 뒤의 `CommitAsIs`
    - `ClearComposition` 뒤의 `CommitAsIs`
- 하나로 합쳐진 입력과 여러 message로 분리된 입력이 최종 문서 상태와 undo 결과까지 동일한지 검증합니다.
- 확정된 첫 번째 message와 실패하는 후속 message의 command outcome이 서로 섞이지 않는 기존 coalescing 경계도 테스트로 고정합니다.

이제 다음 두 입력은 같은 의미를 갖습니다.

- 한 배치: `CommitAsIs → ReplaceSelection(" ")`
- 분리된 배치: `CommitAsIs`, 이후 `ReplaceSelection(" ")`

두 경우 모두 조합 확정과 텍스트 대치가 먼저 끝난 뒤, 대치된 selection에 공백이 삽입됩니다.

### Compose app

Compose normalizer는 이미 `FinishComposingTextCommand`와 뒤따르는 `CommitTextCommand(" ")`를 다음 순서로 보존하고 있었습니다.

- `CommitAsIs`
- `Compose(" ")`
- `CommitAsIs`

이 순서를 회귀 테스트로 고정했습니다. 반복되던 message flush 코드는 작은 helper로 정리했습니다.

App에 텍스트 대치 전용 조건이나 “공백 직전 committed text” 같은 휴리스틱은 추가하지 않습니다. 합쳐진 IME 연산의 의미는 공통 editor core가 처리합니다.

### Web

브라우저가 조합 확정과 후속 입력을 전달하는 두 가지 순서를 공통 editor contract로 변환합니다.

1. `insertText`가 `compositionend`보다 먼저 도착하는 경우
    - 활성 composition의 committed text를 확인합니다.
    - native input mutation을 `preventDefault`로 막습니다.
    - `CommitAsIs`와 후속 `ReplaceSelection`을 순서대로 editor에 전달합니다.
    - 브라우저가 이후 같은 committed preedit을 다시 전달하면 중복 입력으로 무시합니다.
2. 마지막 `compositionupdate`에 Space 같은 후속 키가 붙는 경우
    - 조합 중 `keydown`과 이어지는 composition edit을 비교합니다.
    - 현재 composition 뒤에 해당 키가 붙은 모호한 edit만 잠시 보류합니다.
    - 바로 `compositionend`가 오면 `CommitAsIs`와 후속 입력으로 분리합니다.
    - composition이 계속되거나 다음 입력이 도착하면 보류한 edit을 정상 composition update로 적용합니다.

`compositionend` 처리는 editor update 안에서 동기적으로 반영하여, 이후 keyboard action이 확정 및 텍스트 대치가 끝난 selection을 사용하도록 합니다.

## 동작 계약

이번 변경은 다음 계약을 명시합니다.

- IME transport가 여러 연산을 하나의 `TextInput`으로 합쳐도 의미가 달라지지 않습니다.
- `CommitAsIs`는 활성 composition을 확정하는 의미적 실행 경계입니다.
- 텍스트 대치는 실제 composition 확정 직후에 실행됩니다.
- 공백과 같은 후속 입력은 텍스트 대치가 만든 문서와 selection에서 처리됩니다.
- 플랫폼 adapter는 native 이벤트를 공통 IME 연산으로 변환하고, 텍스트 대치 판단은 editor core가 소유합니다.

## PR 범위

이 PR은 IME 조합 확정과 텍스트 대치 순서를 수정합니다.

아래 stack의 이전 PR은 텍스트 대치 후 이동 명령이 최신 레이아웃을 사용하도록 수정하며, 이 PR의 Web/App 입력 정규화와는 별도 책임입니다.

## 검증

- `cargo test -p editor-core`
    - 1005 passed
    - 17 ignored
- Web IME adapter 및 composition-tail resolver unit tests
    - 36 passed
- Chromium production editor regression tests
    - 2 passed
    - 마지막 `compositionupdate`에 Space가 포함되는 흐름
    - `insertText`가 `compositionend`보다 먼저 오는 흐름
- Compose normalizer에 조합 확정과 후속 committed text의 순서를 검증하는 테스트를 추가했습니다.
    - 현재 로컬 desktop test 실행은 이 변경과 무관한 `ToolbarControls.kt` 컴파일 오류로 차단되어 있습니다.