### PR TITLE
앱 하단 버튼이 키보드 재포커스 중 위로 튀는 문제 수정

### DIFF
--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/ext/ImeInsets.android.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/ext/ImeInsets.android.kt
@@ -1,0 +1,20 @@
+package co.typie.ext
+
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.imeAnimationTarget
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+internal actual fun rememberTrustedImeBottomInset() =
+  with(LocalDensity.current) {
+    val rawImeBottom = WindowInsets.ime.getBottom(this).toDp()
+    val animationTargetBottom = WindowInsets.imeAnimationTarget.getBottom(this).toDp()
+    trustedImeBottomInset(
+      rawImeBottom = rawImeBottom,
+      settledImeBottom = animationTargetBottom.takeIf { it > 0.dp },
+    )
+  }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ext/ImeInsets.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ext/ImeInsets.kt
@@ -1,0 +1,13 @@
+package co.typie.ext
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.Dp
+
+@Composable internal expect fun rememberTrustedImeBottomInset(): Dp
+
+internal fun trustedImeBottomInset(rawImeBottom: Dp, settledImeBottom: Dp?): Dp =
+  if (settledImeBottom != null && rawImeBottom > settledImeBottom) {
+    settledImeBottom
+  } else {
+    rawImeBottom
+  }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ext/WindowInsets.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ext/WindowInsets.kt
@@ -51,7 +51,7 @@ fun Modifier.navigationBarsPadding(): Modifier = windowInsetsPadding(WindowInset
 @Composable
 fun Modifier.navigationBarsOrImePadding(): Modifier {
   val navigationBarsBottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
-  val imeBottom = WindowInsets.ime.asPaddingValues().calculateBottomPadding()
+  val imeBottom = rememberTrustedImeBottomInset()
   return windowInsetsPadding(WindowInsets(bottom = maxOf(navigationBarsBottom, imeBottom)))
 }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.kt
@@ -3,6 +3,7 @@ package co.typie.screen.editor.editor.toolbar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import co.typie.ext.trustedImeBottomInset as trustedSettledImeBottomInset
 
 internal enum class EditorKeyboardType {
   Software,
@@ -93,12 +94,10 @@ internal fun trustedImeBottomInset(rawImeBottom: Dp, keyboardState: EditorKeyboa
     return 0.dp
   }
 
-  val settledImeInset = keyboardState.settledImeBottom
-  return if (settledImeInset != null && rawImeBottom > settledImeInset) {
-    settledImeInset
-  } else {
-    rawImeBottom
-  }
+  return trustedSettledImeBottomInset(
+    rawImeBottom = rawImeBottom,
+    settledImeBottom = keyboardState.settledImeBottom,
+  )
 }
 
 internal fun resolveKeyboardPresentation(

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/ext/ImeInsetsTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/ext/ImeInsetsTest.kt
@@ -1,0 +1,17 @@
+package co.typie.ext
+
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ImeInsetsTest {
+  @Test
+  fun trustedInsetBoundsRefocusOvershootToSettledInset() {
+    assertEquals(350.dp, trustedImeBottomInset(rawImeBottom = 806.dp, settledImeBottom = 350.dp))
+  }
+
+  @Test
+  fun trustedInsetPreservesImeAnimationBeforeItReachesTarget() {
+    assertEquals(120.dp, trustedImeBottomInset(rawImeBottom = 120.dp, settledImeBottom = 350.dp))
+  }
+}

--- a/apps/mobile/compose/src/desktopMain/kotlin/co/typie/ext/ImeInsets.desktop.kt
+++ b/apps/mobile/compose/src/desktopMain/kotlin/co/typie/ext/ImeInsets.desktop.kt
@@ -1,0 +1,9 @@
+package co.typie.ext
+
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalDensity
+
+@Composable
+internal actual fun rememberTrustedImeBottomInset() =
+  with(LocalDensity.current) { WindowInsets.ime.getBottom(this).toDp() }

--- a/apps/mobile/compose/src/iosMain/kotlin/co/typie/ext/ImeInsets.ios.kt
+++ b/apps/mobile/compose/src/iosMain/kotlin/co/typie/ext/ImeInsets.ios.kt
@@ -1,0 +1,91 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+package co.typie.ext
+
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import platform.Foundation.NSNotification
+import platform.Foundation.NSNotificationCenter
+import platform.Foundation.NSOperationQueue
+import platform.UIKit.UIKeyboardDidChangeFrameNotification
+import platform.UIKit.UIKeyboardDidHideNotification
+import platform.UIKit.UIKeyboardDidShowNotification
+import platform.UIKit.UIKeyboardWillChangeFrameNotification
+import platform.UIKit.UIKeyboardWillHideNotification
+import swiftPMImport.co.typie.compose.EditorKeyboardBridge
+
+@Composable
+internal actual fun rememberTrustedImeBottomInset(): Dp {
+  val density = LocalDensity.current
+  val rawImeBottom = with(density) { WindowInsets.ime.getBottom(this).toDp() }
+  var settledImeBottom by remember { mutableStateOf<Dp?>(null) }
+
+  DisposableEffect(Unit) {
+    fun updateSettledImeBottom(notification: NSNotification?) {
+      settledImeBottom =
+        notification?.let(EditorKeyboardBridge::imeVisibleHeightWithNotification)?.dp?.takeIf {
+          it > 0.dp
+        }
+    }
+
+    val center = NSNotificationCenter.defaultCenter
+    val willChangeFrameObserver =
+      center.addObserverForName(
+        name = UIKeyboardWillChangeFrameNotification,
+        `object` = null,
+        queue = NSOperationQueue.mainQueue,
+      ) {
+        updateSettledImeBottom(it)
+      }
+    val didChangeFrameObserver =
+      center.addObserverForName(
+        name = UIKeyboardDidChangeFrameNotification,
+        `object` = null,
+        queue = NSOperationQueue.mainQueue,
+      ) {
+        updateSettledImeBottom(it)
+      }
+    val didShowObserver =
+      center.addObserverForName(
+        name = UIKeyboardDidShowNotification,
+        `object` = null,
+        queue = NSOperationQueue.mainQueue,
+      ) {
+        updateSettledImeBottom(it)
+      }
+    val willHideObserver =
+      center.addObserverForName(
+        name = UIKeyboardWillHideNotification,
+        `object` = null,
+        queue = NSOperationQueue.mainQueue,
+      ) {
+        settledImeBottom = null
+      }
+    val didHideObserver =
+      center.addObserverForName(
+        name = UIKeyboardDidHideNotification,
+        `object` = null,
+        queue = NSOperationQueue.mainQueue,
+      ) {
+        settledImeBottom = null
+      }
+
+    onDispose {
+      center.removeObserver(willChangeFrameObserver)
+      center.removeObserver(didChangeFrameObserver)
+      center.removeObserver(didShowObserver)
+      center.removeObserver(willHideObserver)
+      center.removeObserver(didHideObserver)
+    }
+  }
+
+  return trustedImeBottomInset(rawImeBottom = rawImeBottom, settledImeBottom = settledImeBottom)
+}


### PR DESCRIPTION
- iOS에서 종종 footer button이 화면 상단에서 내려오는 문제를 해결 (IME inset overshoot)
- 에디터 툴바는 이미 해결한 문제를 footer button에서도 수정함
- 보정 로직을 공용화함