### PR TITLE
앱 에디터가 published selection 대신 applied selection을 저장

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/entry/EditorEntryStateSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/entry/EditorEntryStateSession.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshotFlow
 import co.typie.editor.Editor
 import co.typie.editor.ffi.Message
-import co.typie.editor.ffi.Selection
 import co.typie.editor.ffi.SelectionOp
 import co.typie.editor.ffi.StableSelection
 import co.typie.editor.scroll.EditorBringIntoViewRequests
@@ -62,18 +61,14 @@ internal fun rememberEditorEntryStateSession(
     val activeDocumentId = documentId ?: return@LaunchedEffect
     val activeEditor = editor ?: return@LaunchedEffect
 
-    snapshotFlow { activeEditor.publishedState.selection }
+    snapshotFlow { activeEditor.appliedState.selection }
       .filterNotNull()
-      .collect { selection ->
+      .collect {
         if (!currentEditorFocused.value) {
           return@collect
         }
 
-        controller.saveBodySelection(
-          documentId = activeDocumentId,
-          editor = activeEditor,
-          selection = selection,
-        )
+        controller.saveBodySelection(documentId = activeDocumentId, editor = activeEditor)
       }
   }
 
@@ -91,8 +86,10 @@ private class EditorEntryStateSessionController(private val store: EditorEntrySt
     save(documentId = documentId, target = target, bodySelection = null)
   }
 
-  suspend fun saveBodySelection(documentId: String, editor: Editor, selection: Selection) {
+  suspend fun saveBodySelection(documentId: String, editor: Editor) {
+    val selection = editor.appliedState.selection ?: return
     val frozen = editor.freezeSelection(selection) ?: return
+
     save(documentId = documentId, target = EditorEntryTarget.Body, bodySelection = frozen)
   }
 

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/entry/EditorEntryStateSessionDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/entry/EditorEntryStateSessionDesktopTest.kt
@@ -1,0 +1,69 @@
+package co.typie.screen.editor.editor.entry
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runComposeUiTest
+import co.typie.editor.Editor
+import co.typie.editor.FakeFfiEditor
+import co.typie.editor.scroll.EditorBringIntoViewRequests
+import java.io.File
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+
+@OptIn(ExperimentalTestApi::class)
+class EditorEntryStateSessionDesktopTest {
+  @Test
+  fun savesAppliedSelectionBeforeItIsPublished() = runComposeUiTest {
+    configureRenderBufferLibrary()
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+    val fake = FakeFfiEditor()
+    val editor = Editor(fake, scope, Dispatchers.Unconfined)
+    val documentId = "entry-state-test-${UUID.randomUUID()}"
+
+    try {
+      fake.applySnapshot(editor)
+      assertNotNull(editor.appliedState.selection)
+      assertNull(editor.publishedState.selection)
+
+      setContent {
+        rememberEditorEntryStateSession(
+          documentId = documentId,
+          editor = editor,
+          editorFocused = true,
+          bringIntoViewRequests = EditorBringIntoViewRequests(),
+        )
+      }
+      waitForIdle()
+
+      val saved = EditorEntryStateStore().load(documentId)
+      assertNotNull(saved?.bodySelection)
+    } finally {
+      editor.dispose()
+      scope.cancel()
+    }
+  }
+}
+
+private fun configureRenderBufferLibrary() {
+  if (System.getProperty("jna.library.path") != null) return
+
+  val repository =
+    generateSequence(File(System.getProperty("user.dir"))) { it.parentFile }
+      .firstOrNull { File(it, "Cargo.toml").isFile } ?: error("Typie repository root not found")
+  val host =
+    when (System.getProperty("os.arch")) {
+      "aarch64" -> "aarch64-apple-darwin"
+      "x86_64" -> "x86_64-apple-darwin"
+      else -> error("Unsupported desktop test architecture: ${System.getProperty("os.arch")}")
+    }
+  val directory = File(repository, "target/$host/release-uniffi")
+  check(File(directory, "libeditor_ffi.dylib").isFile) {
+    "Desktop editor FFI is not built; run `just -f crates/editor-ffi/justfile desktop`"
+  }
+  System.setProperty("jna.library.path", directory.absolutePath)
+}


### PR DESCRIPTION
웹과 동일하게 문서별 마지막 본문 셀렉션으로 applied state의 selection을 저장함