### PR TITLE
앱 에디터 스크롤바 hit area 및 admission 정책 개선

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionController.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionController.kt
@@ -236,6 +236,14 @@ internal class EditorInteractionController(
     gestures.cancel(context = this)
   }
 
+  fun tryClaimScrollbarDirectDrag(): Boolean {
+    if (mode != EditorInteractionMode.Idle || gestures.hasPendingHandleGesture) {
+      return false
+    }
+    cancel()
+    return true
+  }
+
   fun consumeActiveTapAfterEditingPromotion() {
     gestures.consumeActiveTapAfterEditingPromotion(context = this)
   }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionGestures.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionGestures.kt
@@ -45,6 +45,9 @@ internal class EditorInteractionGestures(
       onHandoffToSelectionHandle = ::handoffTableDragToSelectionHandle,
     )
 
+  val hasPendingHandleGesture: Boolean
+    get() = tableColumnResize.pending || tableHandle.pendingDrag || selectionHandle.pendingDrag
+
   fun updateTapSlop(tapSlopPx: Float) {
     tap.updateTapSlop(tapSlopPx)
     selectionHandle.updateDragSlop(tapSlopPx)

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -1840,6 +1840,7 @@ fun EditorScreen(entityId: String) {
               pageSizes = layoutPageSizes,
               displayZoom = displayZoom,
               modifier = Modifier.fillMaxSize(),
+              tryClaimDirectDrag = interactionScope.controller::tryClaimScrollbarDirectDrag,
             )
           }
         },

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorScrollbars.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorScrollbars.kt
@@ -32,7 +32,9 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.AwaitPointerEventScope
 import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.layout.Layout
@@ -40,6 +42,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -51,10 +54,12 @@ import co.typie.editor.viewport.EditorViewportScrollbarMetrics
 import co.typie.editor.viewport.EditorViewportState
 import co.typie.editor.viewport.resolveEditorViewportScrollbarMetrics
 import co.typie.editor.viewport.resolveEditorViewportScrollbarScrollPositionFromDrag
-import co.typie.screen.editor.editor.layout.viewportDirectControl
+import co.typie.ext.LocalScrollGestureLockState
+import co.typie.ext.ScrollGestureLockState
 import co.typie.ui.component.Text
 import co.typie.ui.theme.AppShapes
 import co.typie.ui.theme.AppTheme
+import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
@@ -63,18 +68,58 @@ import kotlinx.coroutines.withTimeoutOrNull
 
 private const val ScrollbarOpacityAnimationMs = 300
 private const val ScrollbarThumbAnimationMs = 250
-private const val ScrollbarLongPressDurationMs = 100L
 private const val ScrollbarMinThumbSize = 30f
 private const val ScrollbarTrackPadding = 2f
 private const val ScrollbarTrackWidth = 12f
 private const val ScrollbarThumbWidth = 6f
 private const val ScrollbarActiveThumbWidth = 10f
-private const val ScrollbarLongPressHitExpansion = 16f
 private const val ScrollbarHideDelayMs = 1500L
 private const val ScrollbarIndicatorHideDelayMs = 300L
 private const val ScrollbarIndicatorHeight = 24f
 private const val ScrollbarIndicatorGap = 8f
 private val ScrollbarShape = AppShapes.rounded(4.dp)
+
+internal const val EditorScrollbarPressAndHoldDurationMillis = 300L
+
+internal enum class EditorScrollbarDragDecision {
+  Pending,
+  Claim,
+  Yield,
+}
+
+internal fun resolveEditorScrollbarDragDecision(
+  horizontal: Boolean,
+  directDragEnabled: Boolean,
+  displacement: Offset,
+  touchSlop: Float,
+  elapsedMillis: Long,
+): EditorScrollbarDragDecision {
+  val effectiveTouchSlop = touchSlop.coerceAtLeast(0f)
+  val movedPastSlop = displacement.getDistanceSquared() > effectiveTouchSlop * effectiveTouchSlop
+  if (movedPastSlop) {
+    val axisDelta = abs(if (horizontal) displacement.x else displacement.y)
+    val crossAxisDelta = abs(if (horizontal) displacement.y else displacement.x)
+    if (axisDelta <= crossAxisDelta) {
+      return EditorScrollbarDragDecision.Yield
+    }
+
+    return if (directDragEnabled) {
+      EditorScrollbarDragDecision.Claim
+    } else {
+      EditorScrollbarDragDecision.Yield
+    }
+  }
+
+  if (elapsedMillis >= EditorScrollbarPressAndHoldDurationMillis) {
+    return if (directDragEnabled) {
+      EditorScrollbarDragDecision.Claim
+    } else {
+      EditorScrollbarDragDecision.Yield
+    }
+  }
+
+  return EditorScrollbarDragDecision.Pending
+}
 
 private data class EditorScrollbarLayoutMetrics(
   val viewportSize: Size,
@@ -170,6 +215,7 @@ internal fun EditorScrollbars(
   pageSizes: List<PageSize>,
   displayZoom: Float,
   modifier: Modifier = Modifier,
+  tryClaimDirectDrag: () -> Boolean = { true },
 ) {
   val haptic = LocalHapticFeedback.current
   var overlayVisible by remember { mutableStateOf(false) }
@@ -258,6 +304,7 @@ internal fun EditorScrollbars(
         isAutoScroll = lastScrollWasAuto,
         directDragEnabled = directDragEnabled,
         isDragging = isVerticalThumbDragged,
+        tryClaimDirectDrag = tryClaimDirectDrag,
         onDragChanged = { dragging ->
           if (isVerticalThumbDragged != dragging) {
             haptic.performHapticFeedback(
@@ -284,6 +331,7 @@ internal fun EditorScrollbars(
         isAutoScroll = lastScrollWasAuto,
         directDragEnabled = directDragEnabled,
         isDragging = isHorizontalThumbDragged,
+        tryClaimDirectDrag = tryClaimDirectDrag,
         onDragChanged = { dragging ->
           if (isHorizontalThumbDragged != dragging) {
             haptic.performHapticFeedback(
@@ -473,11 +521,14 @@ private fun EditorScrollbarThumb(
   isAutoScroll: Boolean,
   directDragEnabled: Boolean,
   isDragging: Boolean,
+  tryClaimDirectDrag: () -> Boolean,
   onDragChanged: (Boolean) -> Unit,
 ) {
   val density = LocalDensity.current
+  val scrollGestureLockState = LocalScrollGestureLockState.current
   val latestDirectDragEnabled = rememberUpdatedState(directDragEnabled)
   val latestVisibleArea = rememberUpdatedState(visibleArea)
+  val latestTryClaimDirectDrag = rememberUpdatedState(tryClaimDirectDrag)
   val latestOnDragChanged = rememberUpdatedState(onDragChanged)
   val trackWidth = ScrollbarTrackWidth.dp
   val trackPadding = ScrollbarTrackPadding.dp
@@ -503,112 +554,31 @@ private fun EditorScrollbarThumb(
   ) {
     Box(
       modifier =
-        Modifier.fillMaxSize().viewportDirectControl().pointerInput(
+        Modifier.fillMaxSize().pointerInput(
           horizontal,
           viewportState,
           density,
+          scrollGestureLockState,
         ) {
-          val touchSlop = viewConfiguration.touchSlop
-          val touchSlopSquared = touchSlop * touchSlop
-
-          fun currentLayoutMetrics(): EditorScrollbarLayoutMetrics =
-            resolveEditorScrollbarLayoutMetrics(viewportState, latestVisibleArea.value)
-
           awaitEachGesture {
-            val down = awaitFirstDown(requireUnconsumed = false)
-            down.consume()
-            if (!latestDirectDragEnabled.value) {
-              var cancelled = false
-              val longPressed =
-                withTimeoutOrNull(ScrollbarLongPressDurationMs) {
-                  while (true) {
-                    val event = awaitPointerEvent(PointerEventPass.Main)
-                    val change =
-                      event.changes.firstOrNull { it.id == down.id }
-                        ?: run {
-                          cancelled = true
-                          return@withTimeoutOrNull
-                        }
-                    val offset = change.position - down.position
-                    val movedPastSlop = offset.x * offset.x + offset.y * offset.y > touchSlopSquared
-
-                    if (!change.pressed || change.isConsumed || movedPastSlop) {
-                      cancelled = true
-                      return@withTimeoutOrNull
-                    }
-
-                    val finalEvent = awaitPointerEvent(PointerEventPass.Final)
-                    if (finalEvent.changes.any { it.id == down.id && it.isConsumed }) {
-                      cancelled = true
-                      return@withTimeoutOrNull
-                    }
-                  }
-                } == null
-
-              if (!longPressed || cancelled) {
-                return@awaitEachGesture
-              }
-            }
-            val dragStartLayoutMetrics = currentLayoutMetrics()
-            var dragMetrics = dragStartLayoutMetrics.dragMetrics(horizontal)
-            var dragStartScroll = dragStartLayoutMetrics.scrollPosition(horizontal)
-            var accumulatedDrag = 0f
-
-            latestOnDragChanged.value(true)
-            try {
-              while (true) {
-                val event = awaitPointerEvent(PointerEventPass.Main)
-                val change = event.changes.firstOrNull { it.id == down.id } ?: break
-
-                if (!change.pressed) {
-                  change.consume()
-                  break
-                }
-
-                val dragAmount = change.positionChange()
-                val dragDelta =
-                  with(density) {
-                    if (!horizontal) {
-                      dragAmount.y.toDp().value
-                    } else {
-                      dragAmount.x.toDp().value
-                    }
-                  }
-
-                if (dragDelta != 0f) {
-                  val currentLayoutMetrics = currentLayoutMetrics()
-                  val currentDragMetrics = currentLayoutMetrics.dragMetrics(horizontal)
-                  if (currentDragMetrics != dragMetrics) {
-                    dragMetrics = currentDragMetrics
-                    dragStartScroll = currentLayoutMetrics.scrollPosition(horizontal)
-                    accumulatedDrag = 0f
-                  }
-                  val nextScrollPosition =
-                    resolveEditorViewportScrollbarScrollPositionFromDrag(
-                      startScrollPosition = dragStartScroll,
-                      dragDelta = accumulatedDrag + dragDelta,
-                      trackLength = dragMetrics.trackLength,
-                      thumbSize = dragMetrics.thumbSize,
-                      viewportLength = dragMetrics.viewportLength,
-                      contentLength = dragMetrics.contentLength,
-                    )
-
-                  change.consume()
-                  accumulatedDrag += dragDelta
-                  if (!horizontal) {
-                    viewportState.scrollTo(
-                      offset = Offset(x = viewportState.scrollOffset.x, y = nextScrollPosition)
-                    )
-                  } else {
-                    viewportState.scrollTo(
-                      offset = Offset(x = nextScrollPosition, y = viewportState.scrollOffset.y)
-                    )
-                  }
-                }
-              }
-            } finally {
-              latestOnDragChanged.value(false)
-            }
+            val admission =
+              awaitEditorScrollbarDragAdmission(
+                horizontal = horizontal,
+                directDragEnabled = { latestDirectDragEnabled.value },
+                tryClaimDirectDrag = { latestTryClaimDirectDrag.value() },
+                touchSlop = viewConfiguration.touchSlop,
+              ) ?: return@awaitEachGesture
+            dragEditorScrollbar(
+              admission = admission,
+              horizontal = horizontal,
+              density = density,
+              viewportState = viewportState,
+              scrollGestureLockState = scrollGestureLockState,
+              currentLayoutMetrics = {
+                resolveEditorScrollbarLayoutMetrics(viewportState, latestVisibleArea.value)
+              },
+              onDragChanged = { latestOnDragChanged.value(it) },
+            )
           }
         }
     ) {
@@ -656,7 +626,7 @@ internal fun EditorScrollbarThumbLayout(
   Layout(modifier = modifier, content = content) { measurables, constraints ->
     val layoutMetrics = resolveEditorScrollbarLayoutMetrics(viewportState, visibleArea)
     val axisMetrics = if (!horizontal) layoutMetrics.vertical else layoutMetrics.horizontal
-    val hitThickness = Dp(ScrollbarTrackWidth + ScrollbarLongPressHitExpansion).roundToPx()
+    val hitThickness = Dp(ScrollbarTrackWidth).roundToPx()
     val thumbLength = Dp(axisMetrics.thumbSize).roundToPx()
     val childConstraints =
       if (!horizontal) {
@@ -670,13 +640,7 @@ internal fun EditorScrollbarThumbLayout(
       if (axisMetrics.isVisible) {
         val x =
           if (!horizontal) {
-            Dp(
-                layoutMetrics.viewportSize.width -
-                  ScrollbarTrackWidth -
-                  ScrollbarLongPressHitExpansion
-              )
-              .roundToPx()
-              .coerceAtLeast(0)
+            Dp(layoutMetrics.viewportSize.width - ScrollbarTrackWidth).roundToPx().coerceAtLeast(0)
           } else {
             Dp(ScrollbarTrackPadding + axisMetrics.thumbOffset).roundToPx().coerceAtLeast(0)
           }
@@ -689,14 +653,199 @@ internal fun EditorScrollbarThumbLayout(
             Dp(
                 layoutMetrics.viewportSize.height -
                   visibleArea.bottomOcclusion -
-                  ScrollbarTrackWidth -
-                  ScrollbarLongPressHitExpansion
+                  ScrollbarTrackWidth
               )
               .roundToPx()
               .coerceAtLeast(0)
           }
         placeable.place(x = x, y = y)
       }
+    }
+  }
+}
+
+private data class EditorScrollbarDragAdmission(
+  val down: PointerInputChange,
+  val initialDragAmount: Offset,
+)
+
+private sealed interface EditorScrollbarPendingResult {
+  data class Claim(val change: PointerInputChange) : EditorScrollbarPendingResult
+
+  data object Yield : EditorScrollbarPendingResult
+}
+
+private suspend fun AwaitPointerEventScope.awaitEditorScrollbarDragAdmission(
+  horizontal: Boolean,
+  directDragEnabled: () -> Boolean,
+  tryClaimDirectDrag: () -> Boolean,
+  touchSlop: Float,
+): EditorScrollbarDragAdmission? {
+  val down = awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
+  val downInActualBounds =
+    down.position.x >= 0f &&
+      down.position.x < size.width.toFloat() &&
+      down.position.y >= 0f &&
+      down.position.y < size.height.toFloat()
+  if (down.isConsumed || !downInActualBounds) {
+    return null
+  }
+
+  var latestDisplacement = Offset.Zero
+  val pendingResult =
+    withTimeoutOrNull<EditorScrollbarPendingResult>(
+      timeMillis = EditorScrollbarPressAndHoldDurationMillis
+    ) {
+      while (true) {
+        val event = awaitPointerEvent(PointerEventPass.Initial)
+        val change =
+          event.changes.firstOrNull { it.id == down.id }
+            ?: return@withTimeoutOrNull EditorScrollbarPendingResult.Yield
+        if (!change.pressed || change.isConsumed) {
+          return@withTimeoutOrNull EditorScrollbarPendingResult.Yield
+        }
+
+        latestDisplacement = change.position - down.position
+        when (
+          resolveEditorScrollbarDragDecision(
+            horizontal = horizontal,
+            directDragEnabled = directDragEnabled(),
+            displacement = latestDisplacement,
+            touchSlop = touchSlop,
+            elapsedMillis = (change.uptimeMillis - down.uptimeMillis).coerceAtLeast(0L),
+          )
+        ) {
+          EditorScrollbarDragDecision.Pending -> {
+            val finalEvent = awaitPointerEvent(PointerEventPass.Final)
+            val finalChange =
+              finalEvent.changes.firstOrNull { it.id == down.id }
+                ?: return@withTimeoutOrNull EditorScrollbarPendingResult.Yield
+            if (!finalChange.pressed || finalChange.isConsumed) {
+              return@withTimeoutOrNull EditorScrollbarPendingResult.Yield
+            }
+          }
+
+          EditorScrollbarDragDecision.Claim ->
+            return@withTimeoutOrNull EditorScrollbarPendingResult.Claim(change)
+
+          EditorScrollbarDragDecision.Yield ->
+            return@withTimeoutOrNull EditorScrollbarPendingResult.Yield
+        }
+      }
+      error("Unreachable scrollbar admission state")
+    }
+
+  val claimedChange =
+    when (pendingResult) {
+      null -> {
+        val timeoutDecision =
+          resolveEditorScrollbarDragDecision(
+            horizontal = horizontal,
+            directDragEnabled = directDragEnabled(),
+            displacement = latestDisplacement,
+            touchSlop = touchSlop,
+            elapsedMillis = EditorScrollbarPressAndHoldDurationMillis,
+          )
+        if (timeoutDecision != EditorScrollbarDragDecision.Claim) {
+          return null
+        }
+        null
+      }
+
+      is EditorScrollbarPendingResult.Claim -> pendingResult.change
+      EditorScrollbarPendingResult.Yield -> return null
+    }
+  val initialDragAmount = claimedChange?.positionChange() ?: Offset.Zero
+  if (!tryClaimDirectDrag()) {
+    return null
+  }
+  claimedChange?.consume()
+  return EditorScrollbarDragAdmission(down = down, initialDragAmount = initialDragAmount)
+}
+
+private suspend fun AwaitPointerEventScope.dragEditorScrollbar(
+  admission: EditorScrollbarDragAdmission,
+  horizontal: Boolean,
+  density: Density,
+  viewportState: EditorViewportState,
+  scrollGestureLockState: ScrollGestureLockState,
+  currentLayoutMetrics: () -> EditorScrollbarLayoutMetrics,
+  onDragChanged: (Boolean) -> Unit,
+) {
+  val dragLock = scrollGestureLockState.acquire()
+  var dragActivated = false
+  try {
+    val dragStartLayoutMetrics = currentLayoutMetrics()
+    var dragMetrics = dragStartLayoutMetrics.dragMetrics(horizontal)
+    var dragStartScroll = dragStartLayoutMetrics.scrollPosition(horizontal)
+    var accumulatedDrag = 0f
+
+    fun applyDragAmount(dragAmount: Offset) {
+      val dragDelta =
+        with(density) {
+          if (!horizontal) {
+            dragAmount.y.toDp().value
+          } else {
+            dragAmount.x.toDp().value
+          }
+        }
+      if (dragDelta == 0f) {
+        return
+      }
+
+      val latestLayoutMetrics = currentLayoutMetrics()
+      val latestDragMetrics = latestLayoutMetrics.dragMetrics(horizontal)
+      if (latestDragMetrics != dragMetrics) {
+        dragMetrics = latestDragMetrics
+        dragStartScroll = latestLayoutMetrics.scrollPosition(horizontal)
+        accumulatedDrag = 0f
+      }
+      val nextScrollPosition =
+        resolveEditorViewportScrollbarScrollPositionFromDrag(
+          startScrollPosition = dragStartScroll,
+          dragDelta = accumulatedDrag + dragDelta,
+          trackLength = dragMetrics.trackLength,
+          thumbSize = dragMetrics.thumbSize,
+          viewportLength = dragMetrics.viewportLength,
+          contentLength = dragMetrics.contentLength,
+        )
+
+      accumulatedDrag += dragDelta
+      val currentScrollOffset = viewportState.scrollOffset
+      viewportState.scrollTo(
+        offset =
+          if (!horizontal) {
+            Offset(x = currentScrollOffset.x, y = nextScrollPosition)
+          } else {
+            Offset(x = nextScrollPosition, y = currentScrollOffset.y)
+          }
+      )
+    }
+
+    onDragChanged(true)
+    dragActivated = true
+    applyDragAmount(admission.initialDragAmount)
+    while (true) {
+      val event = awaitPointerEvent(PointerEventPass.Initial)
+      val change = event.changes.firstOrNull { it.id == admission.down.id } ?: break
+      if (!change.pressed) {
+        change.consume()
+        break
+      }
+
+      val dragAmount = change.positionChange()
+      if (dragAmount != Offset.Zero) {
+        change.consume()
+        applyDragAmount(dragAmount)
+      }
+    }
+  } finally {
+    try {
+      if (dragActivated) {
+        onDragChanged(false)
+      }
+    } finally {
+      dragLock.release()
     }
   }
 }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
@@ -1423,6 +1423,7 @@ class EditorInteractionControllerTest {
 
       assertTrue(controller.pointerDownOnSelectionHandle(down))
       assertEquals(EditorInteractionMode.Idle, controller.interactionMode)
+      assertFalse(controller.tryClaimScrollbarDirectDrag())
       assertTrue(host.scrollGestureLockActive)
       assertFalse(host.uiState.contextMenu.isVisibleFor(editor.publishedState))
 
@@ -1440,6 +1441,7 @@ class EditorInteractionControllerTest {
 
       assertTrue(controller.upSelectionHandlePointer())
       assertEquals(EditorInteractionMode.Idle, controller.interactionMode)
+      assertTrue(controller.tryClaimScrollbarDirectDrag())
       assertFalse(host.scrollGestureLockActive)
       assertNull(controller.magnifierPosition)
     }
@@ -1996,6 +1998,7 @@ class EditorInteractionControllerTest {
 
       assertTrue(controller.pointerDownOnSelectionHandle(down))
       assertEquals(EditorInteractionMode.Idle, controller.interactionMode)
+      assertFalse(controller.tryClaimScrollbarDirectDrag())
       assertTrue(host.scrollGestureLockActive)
 
       assertTrue(controller.moveSelectionHandlePointer(down))
@@ -2005,6 +2008,7 @@ class EditorInteractionControllerTest {
       assertTrue(controller.upSelectionHandlePointer())
 
       assertEquals(EditorInteractionMode.Idle, controller.interactionMode)
+      assertTrue(controller.tryClaimScrollbarDirectDrag())
       assertFalse(host.scrollGestureLockActive)
       assertFalse(host.uiState.contextMenu.visible)
     }
@@ -2297,9 +2301,11 @@ class EditorInteractionControllerTest {
       val down = Offset(60f, 60f)
 
       assertTrue(controller.onPointerDown(pointerId = 1L, position = down, nowMillis = 0L))
+      assertFalse(controller.tryClaimScrollbarDirectDrag())
       assertTrue(
         controller.onPointerMove(pointerId = 1L, position = Offset(100f, 90f), nowMillis = 20L)
       )
+      assertFalse(controller.tryClaimScrollbarDirectDrag())
 
       val extend =
         fake.enqueued.filterIsInstance<Message.Selection>().single().op as SelectionOp.ExtendTo
@@ -2316,6 +2322,7 @@ class EditorInteractionControllerTest {
         controller.onPointerUp(pointerId = 1L, position = Offset(100f, 90f), nowMillis = 40L)
       )
       assertEquals(EditorInteractionMode.Idle, controller.interactionMode)
+      assertTrue(controller.tryClaimScrollbarDirectDrag())
       assertFalse(host.scrollGestureLockActive)
     }
 
@@ -2897,19 +2904,23 @@ class EditorInteractionControllerTest {
       val down = Offset(60f, 30f)
 
       assertTrue(controller.onPointerDown(pointerId = 1L, position = down, nowMillis = 0L))
+      assertFalse(controller.tryClaimScrollbarDirectDrag())
       assertFalse(host.scrollGestureLockActive)
 
       assertTrue(
         controller.onPointerMove(pointerId = 1L, position = Offset(70f, 30f), nowMillis = 20L)
       )
+      assertFalse(controller.tryClaimScrollbarDirectDrag())
       assertTrue(host.scrollGestureLockActive)
 
       assertTrue(
         controller.onPointerUp(pointerId = 1L, position = Offset(70f, 30f), nowMillis = 40L)
       )
+      assertTrue(controller.tryClaimScrollbarDirectDrag())
       assertFalse(host.scrollGestureLockActive)
 
       assertTrue(controller.onPointerDown(pointerId = 2L, position = down, nowMillis = 60L))
+      assertFalse(controller.tryClaimScrollbarDirectDrag())
       assertTrue(
         controller.onPointerMove(pointerId = 2L, position = Offset(70f, 30f), nowMillis = 80L)
       )
@@ -2917,6 +2928,7 @@ class EditorInteractionControllerTest {
 
       controller.cancel()
 
+      assertTrue(controller.tryClaimScrollbarDirectDrag())
       assertFalse(host.scrollGestureLockActive)
     }
 

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/overlay/EditorScrollbarGesturePolicyTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/overlay/EditorScrollbarGesturePolicyTest.kt
@@ -1,0 +1,147 @@
+package co.typie.screen.editor.editor.overlay
+
+import androidx.compose.ui.geometry.Offset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class EditorScrollbarGesturePolicyTest {
+  @Test
+  fun `stationary vertical press stays pending before hold duration`() {
+    assertEquals(
+      EditorScrollbarDragDecision.Pending,
+      resolveEditorScrollbarDragDecision(
+        horizontal = false,
+        directDragEnabled = true,
+        displacement = Offset.Zero,
+        touchSlop = 8f,
+        elapsedMillis = 299L,
+      ),
+    )
+  }
+
+  @Test
+  fun `horizontal movement within touch slop stays pending before hold duration`() {
+    assertEquals(
+      EditorScrollbarDragDecision.Pending,
+      resolveEditorScrollbarDragDecision(
+        horizontal = true,
+        directDragEnabled = true,
+        displacement = Offset(x = 4f, y = 2f),
+        touchSlop = 8f,
+        elapsedMillis = 299L,
+      ),
+    )
+  }
+
+  @Test
+  fun `movement exactly at touch slop stays pending before hold duration`() {
+    assertEquals(
+      EditorScrollbarDragDecision.Pending,
+      resolveEditorScrollbarDragDecision(
+        horizontal = false,
+        directDragEnabled = true,
+        displacement = Offset(x = 0f, y = 8f),
+        touchSlop = 8f,
+        elapsedMillis = 299L,
+      ),
+    )
+  }
+
+  @Test
+  fun `stationary vertical press claims at hold duration when direct drag is enabled`() {
+    assertEquals(
+      EditorScrollbarDragDecision.Claim,
+      resolveEditorScrollbarDragDecision(
+        horizontal = false,
+        directDragEnabled = true,
+        displacement = Offset.Zero,
+        touchSlop = 8f,
+        elapsedMillis = 300L,
+      ),
+    )
+  }
+
+  @Test
+  fun `horizontal movement within touch slop claims at hold duration`() {
+    assertEquals(
+      EditorScrollbarDragDecision.Claim,
+      resolveEditorScrollbarDragDecision(
+        horizontal = true,
+        directDragEnabled = true,
+        displacement = Offset(x = 4f, y = 2f),
+        touchSlop = 8f,
+        elapsedMillis = 300L,
+      ),
+    )
+  }
+
+  @Test
+  fun `vertical axis drag claims after slop before hold duration`() {
+    assertEquals(
+      EditorScrollbarDragDecision.Claim,
+      resolveEditorScrollbarDragDecision(
+        horizontal = false,
+        directDragEnabled = true,
+        displacement = Offset(x = 2f, y = 12f),
+        touchSlop = 8f,
+        elapsedMillis = 0L,
+      ),
+    )
+  }
+
+  @Test
+  fun `horizontal cross axis drag yields after slop before hold duration`() {
+    assertEquals(
+      EditorScrollbarDragDecision.Yield,
+      resolveEditorScrollbarDragDecision(
+        horizontal = true,
+        directDragEnabled = true,
+        displacement = Offset(x = 2f, y = 12f),
+        touchSlop = 8f,
+        elapsedMillis = 0L,
+      ),
+    )
+  }
+
+  @Test
+  fun `cross axis drag yields after slop at hold duration`() {
+    assertEquals(
+      EditorScrollbarDragDecision.Yield,
+      resolveEditorScrollbarDragDecision(
+        horizontal = true,
+        directDragEnabled = true,
+        displacement = Offset(x = 2f, y = 12f),
+        touchSlop = 8f,
+        elapsedMillis = 300L,
+      ),
+    )
+  }
+
+  @Test
+  fun `equal axis and cross axis movement past Euclidean slop yields`() {
+    assertEquals(
+      EditorScrollbarDragDecision.Yield,
+      resolveEditorScrollbarDragDecision(
+        horizontal = false,
+        directDragEnabled = true,
+        displacement = Offset(x = 8f, y = 8f),
+        touchSlop = 8f,
+        elapsedMillis = 0L,
+      ),
+    )
+  }
+
+  @Test
+  fun `stationary horizontal press yields at hold duration when direct drag is disabled`() {
+    assertEquals(
+      EditorScrollbarDragDecision.Yield,
+      resolveEditorScrollbarDragDecision(
+        horizontal = true,
+        directDragEnabled = false,
+        displacement = Offset.Zero,
+        touchSlop = 8f,
+        elapsedMillis = 300L,
+      ),
+    )
+  }
+}

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayoutDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayoutDesktopTest.kt
@@ -80,11 +80,14 @@ import co.typie.editor.scroll.LocalEditorBringIntoViewRequests
 import co.typie.editor.scroll.rememberEditorBringIntoViewRequests
 import co.typie.editor.scroll.resolveEditorAutoScrollPolicy
 import co.typie.editor.viewport.EditorViewportState
+import co.typie.editor.viewport.resolveEditorViewportScrollbarMetrics
+import co.typie.editor.viewport.resolveEditorViewportScrollbarScrollPositionFromDrag
 import co.typie.ext.ScrollGestureLockState
 import co.typie.navigation.LocalNavigationPopNestedScroll
 import co.typie.navigation.NavigationPopNestedScroll
 import co.typie.screen.editor.editor.header.EditorHeaderFrame
 import co.typie.screen.editor.editor.header.resolveEditorHeaderGeometry
+import co.typie.screen.editor.editor.overlay.EditorScrollbarPressAndHoldDurationMillis
 import co.typie.screen.editor.editor.overlay.EditorScrollbars
 import co.typie.screen.editor.editor.state.EditorScreenState
 import co.typie.ui.theme.LightColors
@@ -648,30 +651,33 @@ class EditorScreenLayoutDesktopTest {
   }
 
   @Test
-  fun scrollbarOwnsDownAndSharesWheelWithViewport() = runComposeUiTest {
+  fun scrollbarShortTouchAndMouseInputsFallThroughAndShareWheelWithViewport() = runComposeUiTest {
     val fixture = ViewportOverlayFixture()
     setViewportOverlayContent(
       fixture = fixture,
-      viewportOverlay = {
-        CompositionLocalProvider(LocalAppColors provides LightColors) {
-          EditorScrollbars(
-            viewportState = fixture.viewportState,
-            visibleArea = fixture.visibleArea,
-            layoutSpec = fixture.layoutSpec,
-            pageSizes = fixture.pageSizes,
-            displayZoom = 1f,
-          )
-        }
-      },
+      viewportOverlay = { ScrollbarViewportOverlay(fixture) },
+      bodyTapEnabled = true,
     )
     runOnIdle { fixture.viewportState.scrollToY(1f) }
     waitForIdle()
 
     onNodeWithTag(LayoutTag).performTouchInput {
-      down(Offset(x = TestViewportSize.width - 20f, y = 32f))
+      down(Offset(x = TestViewportSize.width - 6f, y = 32f))
+      advanceEventTime(EditorScrollbarPressAndHoldDurationMillis - 1L)
       up()
     }
     waitForIdle()
+    assertEquals(1, fixture.bodyTapCount)
+    assertEquals(EditorInteractionMode.Idle, fixture.interactionScope.controller.interactionMode)
+
+    onNodeWithTag(LayoutTag).performMouseInput {
+      moveTo(Offset(x = TestViewportSize.width - 6f, y = 32f))
+      press()
+      advanceEventTime(EditorScrollbarPressAndHoldDurationMillis - 1L)
+      release()
+    }
+    waitForIdle()
+    assertEquals(2, fixture.bodyTapCount)
     assertEquals(EditorInteractionMode.Idle, fixture.interactionScope.controller.interactionMode)
 
     onNodeWithTag(LayoutTag).performMouseInput {
@@ -683,12 +689,370 @@ class EditorScreenLayoutDesktopTest {
     runOnIdle { fixture.scrollDeltas.clear() }
 
     onNodeWithTag(LayoutTag).performMouseInput {
-      moveTo(Offset(x = TestViewportSize.width - 20f, y = 32f))
+      moveTo(Offset(x = TestViewportSize.width - 6f, y = 32f))
       scroll(Offset(x = 0f, y = 120f))
     }
     waitForIdle()
 
     assertTrue(fixture.scrollDeltas.isNotEmpty(), "wheel over the thumb did not reach viewport")
+  }
+
+  @Test
+  fun scrollbarCoreTouchPressAndHoldClaimsWithoutMovement() = runComposeUiTest {
+    val fixture = ViewportOverlayFixture()
+    setViewportOverlayContent(
+      fixture = fixture,
+      viewportOverlay = { ScrollbarViewportOverlay(fixture) },
+      bodyTapEnabled = true,
+    )
+    runOnIdle { fixture.viewportState.scrollToY(1f) }
+    waitForIdle()
+
+    val layout = onNodeWithTag(LayoutTag)
+    layout.performTouchInput {
+      down(Offset(x = TestViewportSize.width - 6f, y = 32f))
+      advanceEventTime(EditorScrollbarPressAndHoldDurationMillis)
+      // Compose Desktop's test clock does not drive pointer-node timeouts deterministically.
+      // A stationary event at the deadline verifies the same policy and routing path by uptime.
+      move(delayMillis = 0L)
+    }
+
+    assertEquals(1, fixture.directDragClaimCount)
+    layout.performTouchInput { up() }
+    assertEquals(0, fixture.bodyTapCount)
+  }
+
+  @Test
+  fun scrollbarCoreTouchPressAndHoldThenDrags() = runComposeUiTest {
+    val fixture = ViewportOverlayFixture()
+    setViewportOverlayContent(
+      fixture = fixture,
+      viewportOverlay = { ScrollbarViewportOverlay(fixture) },
+    )
+    runOnIdle { fixture.viewportState.scrollToY(1f) }
+    waitForIdle()
+    runOnIdle { fixture.scrollDeltas.clear() }
+
+    val initialScroll = fixture.viewportState.scrollOffset.y
+    val layout = onNodeWithTag(LayoutTag)
+    layout.performTouchInput {
+      down(Offset(x = TestViewportSize.width - 6f, y = 32f))
+      advanceEventTime(EditorScrollbarPressAndHoldDurationMillis)
+      move(delayMillis = 0L)
+    }
+
+    assertEquals(1, fixture.directDragClaimCount)
+    layout.performTouchInput {
+      moveTo(Offset(x = TestViewportSize.width - 6f, y = 72f))
+      up()
+    }
+
+    assertEquals(1, fixture.directDragClaimCount)
+    assertTrue(fixture.viewportState.scrollOffset.y > initialScroll)
+    assertTrue(fixture.scrollDeltas.isEmpty())
+  }
+
+  @Test
+  fun scrollbarCoreTouchMicroMovementDoesNotRestartPressAndHoldDeadline() = runComposeUiTest {
+    val fixture = ViewportOverlayFixture()
+    setViewportOverlayContent(
+      fixture = fixture,
+      viewportOverlay = { ScrollbarViewportOverlay(fixture) },
+    )
+    runOnIdle { fixture.viewportState.scrollToY(1f) }
+    waitForIdle()
+
+    val layout = onNodeWithTag(LayoutTag)
+    val firstInterval = EditorScrollbarPressAndHoldDurationMillis / 2L
+    layout.performTouchInput {
+      down(Offset(x = TestViewportSize.width - 6f, y = 32f))
+      advanceEventTime(firstInterval)
+      moveBy(Offset(x = 0f, y = 1f), delayMillis = 0L)
+      advanceEventTime(EditorScrollbarPressAndHoldDurationMillis - firstInterval)
+      move(delayMillis = 0L)
+    }
+
+    assertEquals(1, fixture.directDragClaimCount)
+    layout.performTouchInput { up() }
+  }
+
+  @Test
+  fun scrollbarCoreMousePressAndHoldClaimsWithoutMovement() = runComposeUiTest {
+    val fixture = ViewportOverlayFixture()
+    setViewportOverlayContent(
+      fixture = fixture,
+      viewportOverlay = { ScrollbarViewportOverlay(fixture) },
+      bodyTapEnabled = true,
+    )
+    runOnIdle { fixture.viewportState.scrollToY(1f) }
+    waitForIdle()
+
+    val layout = onNodeWithTag(LayoutTag)
+    layout.performMouseInput {
+      moveTo(Offset(x = TestViewportSize.width - 6f, y = 32f))
+      press()
+      advanceEventTime(EditorScrollbarPressAndHoldDurationMillis)
+      moveTo(currentPosition, delayMillis = 0L)
+    }
+
+    assertEquals(1, fixture.directDragClaimCount)
+    layout.performMouseInput { release() }
+    assertEquals(0, fixture.bodyTapCount)
+  }
+
+  @Test
+  fun scrollbarCorePressAndHoldYieldsWhenEditorHandleIsPending() = runComposeUiTest {
+    val fixture = ViewportOverlayFixture()
+    setViewportOverlayContent(
+      fixture = fixture,
+      viewportOverlay = {
+        ScrollbarViewportOverlay(fixture = fixture, allowDirectDragClaim = { false })
+      },
+      bodyTapEnabled = true,
+    )
+    runOnIdle { fixture.viewportState.scrollToY(1f) }
+    waitForIdle()
+    runOnIdle { fixture.scrollDeltas.clear() }
+
+    val initialScroll = fixture.viewportState.scrollOffset.y
+    val layout = onNodeWithTag(LayoutTag)
+    layout.performTouchInput {
+      down(Offset(x = TestViewportSize.width - 6f, y = 32f))
+      advanceEventTime(EditorScrollbarPressAndHoldDurationMillis)
+      move(delayMillis = 0L)
+    }
+
+    assertEquals(0, fixture.directDragClaimCount)
+    assertEquals(initialScroll, fixture.viewportState.scrollOffset.y)
+    assertTrue(fixture.scrollDeltas.isEmpty())
+    layout.performTouchInput { up() }
+    assertEquals(1, fixture.bodyTapCount)
+  }
+
+  @Test
+  fun areaOutsideScrollbarMouseClickFallsThrough() = runComposeUiTest {
+    val fixture = ViewportOverlayFixture()
+    setViewportOverlayContent(
+      fixture = fixture,
+      viewportOverlay = { ScrollbarViewportOverlay(fixture) },
+      bodyTapEnabled = true,
+    )
+    runOnIdle { fixture.viewportState.scrollToY(1f) }
+    waitForIdle()
+
+    onNodeWithTag(LayoutTag).performMouseInput {
+      moveTo(Offset(x = TestViewportSize.width - 20f, y = 32f))
+      press()
+      release()
+    }
+    waitForIdle()
+
+    assertEquals(1, fixture.bodyTapCount)
+    assertEquals(0, fixture.directDragClaimCount)
+  }
+
+  @Test
+  fun scrollbarCoreTouchAxisDragClaimsAfterSlop() = runComposeUiTest {
+    val fixture = ViewportOverlayFixture()
+    setViewportOverlayContent(
+      fixture = fixture,
+      viewportOverlay = { ScrollbarViewportOverlay(fixture) },
+    )
+    runOnIdle { fixture.viewportState.scrollToY(1f) }
+    waitForIdle()
+    runOnIdle { fixture.scrollDeltas.clear() }
+
+    val initialScroll = fixture.viewportState.scrollOffset.y
+    val dragDelta = 40f
+    val scrollbarMetrics =
+      resolveEditorViewportScrollbarMetrics(
+        viewportLength = fixture.viewportState.viewportSize.height,
+        contentLength = fixture.viewportState.contentSize.height,
+        scrollPosition = initialScroll,
+        minThumbSize = ExpectedScrollbarMinThumbSize,
+        leadingInset = fixture.visibleArea.topOcclusion,
+        trailingInset = fixture.visibleArea.bottomOcclusion,
+        leadingPadding = ExpectedScrollbarTrackPadding,
+        trailingPadding = ExpectedScrollbarTrackPadding,
+      )
+    val expectedScroll =
+      resolveEditorViewportScrollbarScrollPositionFromDrag(
+        startScrollPosition = initialScroll,
+        dragDelta = dragDelta,
+        trackLength = scrollbarMetrics.trackLength,
+        thumbSize = scrollbarMetrics.thumbSize,
+        viewportLength = fixture.viewportState.viewportSize.height,
+        contentLength = fixture.viewportState.contentSize.height,
+      )
+    onNodeWithTag(LayoutTag).performTouchInput {
+      down(Offset(x = TestViewportSize.width - 6f, y = 32f))
+      advanceEventTime(16L)
+      moveTo(Offset(x = TestViewportSize.width - 6f, y = 32f + dragDelta))
+      up()
+    }
+    waitForIdle()
+
+    assertEquals(1, fixture.directDragClaimCount)
+    assertEquals(expectedScroll, fixture.viewportState.scrollOffset.y)
+    assertTrue(fixture.scrollDeltas.isEmpty())
+  }
+
+  @Test
+  fun areaOutsideScrollbarQuickTouchDragGoesToViewportPan() = runComposeUiTest {
+    val fixture = ViewportOverlayFixture()
+    setViewportOverlayContent(
+      fixture = fixture,
+      viewportOverlay = { ScrollbarViewportOverlay(fixture) },
+    )
+    runOnIdle { fixture.viewportState.scrollToY(1f) }
+    waitForIdle()
+    runOnIdle { fixture.scrollDeltas.clear() }
+
+    val initialScroll = fixture.viewportState.scrollOffset.y
+    onNodeWithTag(LayoutTag).performTouchInput {
+      down(Offset(x = TestViewportSize.width - 20f, y = 32f))
+      advanceEventTime(16L)
+      moveTo(Offset(x = TestViewportSize.width - 20f, y = 72f))
+      up()
+    }
+    waitForIdle()
+
+    assertEquals(0, fixture.directDragClaimCount)
+    assertEquals(initialScroll, fixture.viewportState.scrollOffset.y)
+    assertTrue(fixture.scrollDeltas.isNotEmpty())
+  }
+
+  @Test
+  fun areaOutsideScrollbarHeldTouchDragStaysWithViewportPan() = runComposeUiTest {
+    val fixture = ViewportOverlayFixture()
+    setViewportOverlayContent(
+      fixture = fixture,
+      viewportOverlay = { ScrollbarViewportOverlay(fixture) },
+    )
+    runOnIdle { fixture.viewportState.scrollToY(1f) }
+    waitForIdle()
+    runOnIdle { fixture.scrollDeltas.clear() }
+
+    val initialScroll = fixture.viewportState.scrollOffset.y
+    onNodeWithTag(LayoutTag).performTouchInput {
+      down(Offset(x = TestViewportSize.width - 20f, y = 32f))
+      advanceEventTime(EditorScrollbarPressAndHoldDurationMillis)
+      moveTo(Offset(x = TestViewportSize.width - 20f, y = 72f))
+      up()
+    }
+    waitForIdle()
+
+    assertEquals(0, fixture.directDragClaimCount)
+    assertEquals(initialScroll, fixture.viewportState.scrollOffset.y)
+    assertTrue(fixture.scrollDeltas.isNotEmpty())
+  }
+
+  @Test
+  fun scrollbarCoreTouchDragYieldsWhenEditorHandleIsPending() = runComposeUiTest {
+    val fixture = ViewportOverlayFixture()
+    setViewportOverlayContent(
+      fixture = fixture,
+      viewportOverlay = {
+        ScrollbarViewportOverlay(fixture = fixture, allowDirectDragClaim = { false })
+      },
+    )
+    runOnIdle { fixture.viewportState.scrollToY(1f) }
+    waitForIdle()
+    runOnIdle { fixture.scrollDeltas.clear() }
+
+    val initialScroll = fixture.viewportState.scrollOffset.y
+    onNodeWithTag(LayoutTag).performTouchInput {
+      down(Offset(x = TestViewportSize.width - 6f, y = 32f))
+      advanceEventTime(16L)
+      moveTo(Offset(x = TestViewportSize.width - 6f, y = 72f))
+      up()
+    }
+    waitForIdle()
+
+    assertEquals(initialScroll, fixture.viewportState.scrollOffset.y)
+    assertTrue(fixture.scrollDeltas.isNotEmpty())
+    assertEquals(0, fixture.directDragClaimCount)
+  }
+
+  @Test
+  fun scrollbarMouseDragInCoreClaimsWithoutDelay() = runComposeUiTest {
+    val fixture = ViewportOverlayFixture()
+    setViewportOverlayContent(
+      fixture = fixture,
+      viewportOverlay = { ScrollbarViewportOverlay(fixture) },
+    )
+    runOnIdle { fixture.viewportState.scrollToY(1f) }
+    waitForIdle()
+    runOnIdle { fixture.scrollDeltas.clear() }
+
+    val initialScroll = fixture.viewportState.scrollOffset.y
+    onNodeWithTag(LayoutTag).performMouseInput {
+      moveTo(Offset(x = TestViewportSize.width - 6f, y = 32f))
+      press()
+      moveTo(Offset(x = TestViewportSize.width - 6f, y = 72f))
+      release()
+    }
+    waitForIdle()
+
+    assertEquals(1, fixture.directDragClaimCount)
+    assertTrue(
+      fixture.viewportState.scrollOffset.y > initialScroll,
+      "scrollbar claimed but did not move: initial=$initialScroll " +
+        "actual=${fixture.viewportState.scrollOffset.y} " +
+        "viewportDeltas=${fixture.scrollDeltas}",
+    )
+    assertTrue(fixture.scrollDeltas.isEmpty())
+  }
+
+  @Test
+  fun areaOutsideScrollbarQuickMouseDragGoesToViewportPan() = runComposeUiTest {
+    val fixture = ViewportOverlayFixture()
+    setViewportOverlayContent(
+      fixture = fixture,
+      viewportOverlay = { ScrollbarViewportOverlay(fixture) },
+    )
+    runOnIdle { fixture.viewportState.scrollToY(1f) }
+    waitForIdle()
+    runOnIdle { fixture.scrollDeltas.clear() }
+
+    val initialScroll = fixture.viewportState.scrollOffset.y
+    onNodeWithTag(LayoutTag).performMouseInput {
+      moveTo(Offset(x = TestViewportSize.width - 20f, y = 32f))
+      press()
+      moveTo(Offset(x = TestViewportSize.width - 20f, y = 72f))
+      release()
+    }
+    waitForIdle()
+
+    assertEquals(initialScroll, fixture.viewportState.scrollOffset.y)
+    assertTrue(fixture.scrollDeltas.isNotEmpty())
+    assertEquals(0, fixture.directDragClaimCount)
+  }
+
+  @Test
+  fun areaOutsideScrollbarHeldMouseDragStaysWithViewportPan() = runComposeUiTest {
+    val fixture = ViewportOverlayFixture()
+    setViewportOverlayContent(
+      fixture = fixture,
+      viewportOverlay = { ScrollbarViewportOverlay(fixture) },
+    )
+    runOnIdle { fixture.viewportState.scrollToY(1f) }
+    waitForIdle()
+    runOnIdle { fixture.scrollDeltas.clear() }
+
+    val initialScroll = fixture.viewportState.scrollOffset.y
+    onNodeWithTag(LayoutTag).performMouseInput {
+      moveTo(Offset(x = TestViewportSize.width - 20f, y = 32f))
+      press()
+      advanceEventTime(EditorScrollbarPressAndHoldDurationMillis)
+      moveTo(Offset(x = TestViewportSize.width - 20f, y = 72f))
+      release()
+    }
+    waitForIdle()
+
+    assertEquals(initialScroll, fixture.viewportState.scrollOffset.y)
+    assertTrue(fixture.scrollDeltas.isNotEmpty())
+    assertEquals(0, fixture.directDragClaimCount)
   }
 
   @Test
@@ -1146,6 +1510,7 @@ class EditorScreenLayoutDesktopTest {
     viewportOverlay: @Composable BoxScope.() -> Unit = {},
     overlay: @Composable () -> Unit = {},
     onRequestEditing: (() -> Boolean)? = null,
+    bodyTapEnabled: Boolean = false,
   ) {
     setContent {
       val coroutineScope = rememberCoroutineScope()
@@ -1170,7 +1535,19 @@ class EditorScreenLayoutDesktopTest {
           onRequestEditing = onRequestEditing,
           onMeasuredViewportSizeChange = {},
           header = {},
-          body = { Box(Modifier.fillMaxWidth().height(800.dp)) },
+          body = {
+            Box(
+              Modifier.fillMaxWidth()
+                .height(800.dp)
+                .then(
+                  if (bodyTapEnabled) {
+                    Modifier.pointerInput(Unit) { detectTapGestures { fixture.bodyTapCount += 1 } }
+                  } else {
+                    Modifier
+                  }
+                )
+            )
+          },
           viewportOverlay = viewportOverlay,
           overlay = overlay,
           toolbar = {},
@@ -1258,12 +1635,38 @@ class EditorScreenLayoutDesktopTest {
     )
   }
 
+  @Composable
+  private fun ScrollbarViewportOverlay(
+    fixture: ViewportOverlayFixture,
+    allowDirectDragClaim: () -> Boolean = { true },
+  ) {
+    CompositionLocalProvider(LocalAppColors provides LightColors) {
+      EditorScrollbars(
+        viewportState = fixture.viewportState,
+        visibleArea = fixture.visibleArea,
+        layoutSpec = fixture.layoutSpec,
+        pageSizes = fixture.pageSizes,
+        displayZoom = 1f,
+        tryClaimDirectDrag = {
+          if (!allowDirectDragClaim()) {
+            false
+          } else {
+            fixture.directDragClaimCount += 1
+            true
+          }
+        },
+      )
+    }
+  }
+
   private class ViewportOverlayFixture {
     val viewportState = EditorViewportState()
     val visibleArea = EditorVisibleArea(viewport = TestViewportSize)
     val uiState = EditorUiState()
     lateinit var interactionScope: EditorInteractionScope
     val scrollDeltas = mutableListOf<Offset>()
+    var bodyTapCount = 0
+    var directDragClaimCount = 0
 
     val layoutSpec =
       EditorDocumentLayoutSpec.Paginated(
@@ -1397,6 +1800,8 @@ class EditorScreenLayoutDesktopTest {
     const val HeaderFixtureContentWidth = 640f
     const val HeaderHeightPx = 96f
     const val HeaderText = "Header title"
+    const val ExpectedScrollbarMinThumbSize = 30f
+    const val ExpectedScrollbarTrackPadding = 2f
     val ControlPointerMove = Offset(x = 40f, y = 40f)
     val ControlPointerStart = Offset(x = 80f, y = 40f)
     val EditorPointerMove = Offset(x = 300f, y = HeaderHeightPx + 140f)

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorScrollbarsDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorScrollbarsDesktopTest.kt
@@ -218,10 +218,10 @@ class EditorScrollbarsDesktopTest {
 
     onRoot().performTouchInput {
       down(Offset(x = 90f, y = 20f))
-      moveBy(Offset(x = 0f, y = 10f))
+      moveBy(Offset(x = 0f, y = 20f))
     }
     waitForIdle()
-    assertEquals(21.833334f, viewportState.scrollOffset.y, absoluteTolerance = 0.01f)
+    assertEquals(42.666668f, viewportState.scrollOffset.y, absoluteTolerance = 0.01f)
 
     runOnIdle { contentSize.value = Size(width = 100f, height = 300f) }
     waitForIdle()
@@ -232,7 +232,7 @@ class EditorScrollbarsDesktopTest {
     }
     waitForIdle()
 
-    assertEquals(53.083336f, viewportState.scrollOffset.y, absoluteTolerance = 0.01f)
+    assertEquals(73.91667f, viewportState.scrollOffset.y, absoluteTolerance = 0.01f)
   }
 
   @Test


### PR DESCRIPTION
## 요약

앱 에디터의 스크롤바가 일반 탭이나 드래그를 너무 일찍 가져가지 않도록 직접 조작 제스처의 소유권 정책을 변경합니다.

기존에는 Compose가 작은 컴포넌트의 최소 터치 영역을 암묵적으로 확장하면서, 스크롤바 바깥에서 시작한 입력까지 스크롤바에 전달될 수 있었습니다. 이제 스크롤바는 실제 thumb layout 영역 안에서 시작하고, 드래그 또는 press-and-hold 의도가 확인된 경우에만 제스처를 가져갑니다.

터치와 마우스에 동일한 정책을 적용하며, wheel/trackpad 스크롤 경로는 변경하지 않습니다.

## 동작

스크롤바의 직접 조작 대상은 현재 thumb가 배치된 영역으로 제한합니다.

- 세로 스크롤바: 가로 12dp × 현재 thumb 높이
- 가로 스크롤바: 현재 thumb 너비 × 세로 12dp
- 나머지 track과 Compose가 암묵적으로 확장한 터치 영역은 직접 조작 대상이 아님

해당 영역에서 시작한 입력은 다음과 같이 처리합니다.

- 300ms 전에 끝나는 일반 탭/클릭은 소비하지 않고 에디터에 전달
- 스크롤바 축 방향 움직임이 pointer slop을 넘으면 즉시 thumb drag로 전환
- pointer slop 안에서 300ms 동안 누르고 있으면 thumb를 잡은 것으로 처리
- 반대 축 움직임이 우세한 상태로 slop을 넘으면 에디터에 양보
- 정확히 대각선처럼 두 축의 움직임이 같으면 에디터에 양보
- 실제 thumb 영역 밖에서 시작한 입력은 누르고 있어도 스크롤바가 가져가지 않음
- 숨겨진 스크롤바는 모든 직접 조작 입력을 에디터에 양보

Selection handle, table selection handle, column resize handle처럼 더 우선순위가 높은 에디터 제스처가 pending 상태이거나 다른 에디터 interaction이 이미 진행 중이면 스크롤바 drag를 시작하지 않습니다.

따라서 일반적인 에디터 탭과 viewport pan은 유지하면서도, 사용자는 thumb를 축 방향으로 바로 끌거나 300ms 동안 눌러 안정적으로 잡을 수 있습니다.