### PR TITLE
iOS 특정 시나리오에서 검색창이 잠시 검게 보이는 문제 workaround

### DIFF
--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/ext/PlatformImeOptions.android.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/ext/PlatformImeOptions.android.kt
@@ -1,0 +1,5 @@
+package co.typie.ext
+
+import androidx.compose.ui.text.input.PlatformImeOptions
+
+internal actual fun nativeTextInputPlatformImeOptions(): PlatformImeOptions? = null

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ext/PlatformImeOptions.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ext/PlatformImeOptions.kt
@@ -1,0 +1,5 @@
+package co.typie.ext
+
+import androidx.compose.ui.text.input.PlatformImeOptions
+
+internal expect fun nativeTextInputPlatformImeOptions(): PlatformImeOptions?

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/home/search/SearchScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/home/search/SearchScreen.kt
@@ -32,6 +32,7 @@ import co.typie.ext.InteractionScope
 import co.typie.ext.clickable
 import co.typie.ext.excludeBottom
 import co.typie.ext.imePadding
+import co.typie.ext.nativeTextInputPlatformImeOptions
 import co.typie.ext.pressScale
 import co.typie.ext.separated
 import co.typie.ext.truncate
@@ -160,6 +161,7 @@ private fun SearchInputField(
     placeholder = placeholder,
     autoFocus = true,
     imeAction = ImeAction.Search,
+    platformImeOptions = nativeTextInputPlatformImeOptions(),
     onImeAction = onSubmit,
     leadingIcon = {
       Icon(icon = Lucide.Search, modifier = Modifier.size(16.dp), tint = AppTheme.colors.textHint)

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/TextField.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/TextField.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.PlatformImeOptions
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
@@ -226,6 +227,7 @@ fun TextField(
   onBlur: (() -> Unit)? = null,
   keyboardType: KeyboardType = KeyboardType.Text,
   imeAction: ImeAction? = null,
+  platformImeOptions: PlatformImeOptions? = null,
   onImeAction: (() -> Unit)? = null,
   onTabAction: (() -> Unit)? = null,
   onShiftTabAction: (() -> Unit)? = null,
@@ -383,7 +385,11 @@ fun TextField(
         ),
       cursorBrush = SolidColor(AppTheme.colors.textDefault),
       keyboardOptions =
-        KeyboardOptions(keyboardType = resolvedKeyboardType, imeAction = resolvedImeAction),
+        KeyboardOptions(
+          keyboardType = resolvedKeyboardType,
+          imeAction = resolvedImeAction,
+          platformImeOptions = platformImeOptions,
+        ),
       keyboardActions =
         KeyboardActions(onNext = { onImeAction?.invoke() }, onDone = { onImeAction?.invoke() }),
       visualTransformation =

--- a/apps/mobile/compose/src/desktopMain/kotlin/co/typie/ext/PlatformImeOptions.desktop.kt
+++ b/apps/mobile/compose/src/desktopMain/kotlin/co/typie/ext/PlatformImeOptions.desktop.kt
@@ -1,0 +1,5 @@
+package co.typie.ext
+
+import androidx.compose.ui.text.input.PlatformImeOptions
+
+internal actual fun nativeTextInputPlatformImeOptions(): PlatformImeOptions? = null

--- a/apps/mobile/compose/src/iosMain/kotlin/co/typie/ext/PlatformImeOptions.ios.kt
+++ b/apps/mobile/compose/src/iosMain/kotlin/co/typie/ext/PlatformImeOptions.ios.kt
@@ -1,0 +1,9 @@
+package co.typie.ext
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.text.input.PlatformImeOptions
+
+@OptIn(ExperimentalComposeUiApi::class)
+internal actual fun nativeTextInputPlatformImeOptions(): PlatformImeOptions? = PlatformImeOptions {
+  usingNativeTextInput(true)
+}


### PR DESCRIPTION
## 문제

다음 조건에서 검색 입력 영역이 포커스되는 순간 검은 사각형으로 잠깐 표시되는 문제가 있었습니다.

1. 검색 화면에 진입했다가 나가기
2. 앱을 백그라운드로 전환한 뒤 복귀
3. 검색 화면에 다시 진입

자동 포커스를 끈 상태에서도 사용자가 직접 검색창을 포커스하는 순간 동일하게 재현됐습니다.

## 원인

검색창의 페이드, `graphicsLayer`, Haze 또는 포커스 요청 시점 문제가 아니라 Compose iOS의 기본 텍스트 입력 경로에서 발생하는 문제로 범위를 좁혔습니다.

- 정적인 UI로 교체하면 재현되지 않음
- `BasicTextField`가 포커스되기 전에는 재현되지 않음
- 자동 포커스를 끄면 진입 시에는 나타나지 않지만, 직접 포커스하는 순간 재현됨
- 네이티브 iOS 텍스트 입력 경로에서는 동일한 재현 절차로 나타나지 않음

따라서 화면이 다시 생성된 후 입력 세션을 시작할 때, Compose iOS의 기본 non-native 텍스트 입력 경로에서 발생하는 렌더링 결함으로 판단했습니다.

정확한 내부 렌더링 원인은 Compose 구현에 있지만, 문제가 발생하는 입력 경로까지는 실기기 비교로 확인했습니다.

## Workaround

검색 입력에서만 `PlatformImeOptions.usingNativeTextInput(true)`를 사용하도록 변경했습니다.