### PR TITLE
앱 로그아웃시 웹소켓 연결 정리되지 않는 문제 해결

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/auth/AuthService.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/auth/AuthService.kt
@@ -8,7 +8,9 @@ import co.typie.domain.subscription.shouldDiscardEntitlementCache
 import co.typie.editor.sync.ActiveDocumentEditingSessions
 import co.typie.editor.sync.catchingNonCancellation
 import co.typie.editor.sync.orphanSweeper
+import co.typie.editor.sync.ws.SyncWs
 import co.typie.graphql.Apollo
+import co.typie.graphql.closeApolloSubscriptionConnection
 import co.typie.network.Http
 import co.typie.storage.Preference
 import co.typie.storage.Vault
@@ -99,12 +101,19 @@ object AuthService {
   private suspend fun authenticate(sessionToken: String) {
     val accessToken = exchangeToken(sessionToken)
 
-    if (shouldDiscardEntitlementCache(Vault.authTokens?.sessionToken, sessionToken)) {
+    val previousSessionToken = Vault.authTokens?.sessionToken
+    if (shouldDiscardEntitlementCache(previousSessionToken, sessionToken)) {
       Preference.entitlementCache = null
     }
 
     Vault.authTokens = AuthTokens(sessionToken = sessionToken, accessToken = accessToken)
     state = AuthState.Authenticated(Vault.authTokens!!)
+
+    // 로그아웃을 거치지 않고 세션이 바뀌는 경로 방어. state 갱신 후에 끊어야 재연결이 새 유저 티켓을 받는다.
+    if (previousSessionToken != null && previousSessionToken != sessionToken) {
+      closeApolloSubscriptionConnection()
+      SyncWs.onSessionChanged()
+    }
   }
 
   private suspend fun exchangeToken(sessionToken: String): String {
@@ -172,6 +181,9 @@ object AuthService {
     state = AuthState.Unauthenticated
 
     Apollo.apolloStore.clearAll()
+    // 두 WS 모두 hello/connectionPayload 시점 유저로 인증이 고정된다 — 신원이 끝나면 즉시 끊는다.
+    closeApolloSubscriptionConnection()
+    SyncWs.onSessionChanged()
   }
 
   @Serializable

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/sync/OrphanSweeper.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/sync/OrphanSweeper.kt
@@ -1,6 +1,8 @@
 package co.typie.editor.sync
 
 import co.touchlab.kermit.Logger
+import co.typie.domain.auth.AuthService
+import co.typie.domain.auth.AuthState
 import co.typie.domain.subscription.SubscriptionService
 import co.typie.domain.subscription.shouldAttemptPush
 import co.typie.editor.sync.ws.SyncWs
@@ -22,7 +24,7 @@ class OrphanSweeper(
   }
 
   suspend fun sweep(includeOpenDocuments: Boolean = false, deleteOnSuccess: Boolean = false) {
-    // Expired면 push를 시도하지 않는다. 로컬 스태시는 그대로 유지.
+    // 비로그인·Expired면 push를 시도하지 않는다. 로컬 스태시는 그대로 유지.
     if (!canPush()) return
     if (!mutex.tryLock()) return
     try {
@@ -62,6 +64,9 @@ val orphanSweeper: OrphanSweeper by lazy {
     store = ChangesetDeltaStore,
     pushFn = { documentId, payload -> SyncWs.connection.push(documentId, payload) },
     openDocumentIds = { ActiveDocumentEditingSessions.openDocumentIds() },
-    canPush = { shouldAttemptPush(SubscriptionService.entitlement) },
+    canPush = {
+      AuthService.state is AuthState.Authenticated &&
+        shouldAttemptPush(SubscriptionService.entitlement)
+    },
   )
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/sync/ws/SyncWs.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/sync/ws/SyncWs.kt
@@ -140,6 +140,16 @@ object SyncWs {
     channels.values.toList().forEach { it.resetPermanentFailure() }
   }
 
+  /** 계정 전환/로그아웃 시 호출된다. 소켓 인증은 hello 시점 유저로 고정되므로 즉시 끊는다 — 다음 사용 시 새 티켓으로 재연결된다. */
+  fun onSessionChanged() {
+    if (!connectionDelegate.isInitialized()) return
+    scope.launch {
+      connection.resetTerminal()
+      connection.disconnect()
+      channels.values.toList().forEach { it.resetPermanentFailure() }
+    }
+  }
+
   fun onAppForeground() {
     if (connectionDelegate.isInitialized()) connection.onAppForeground()
   }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/sync/ws/SyncWsConnection.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/sync/ws/SyncWsConnection.kt
@@ -149,6 +149,10 @@ class SyncWsConnection(
     return { reconnectedCallbacks.remove(callback) }
   }
 
+  fun disconnect() {
+    socket?.terminate()
+  }
+
   fun dispose() {
     if (disposed) return
     disposed = true

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/graphql/ApolloClient.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/graphql/ApolloClient.kt
@@ -5,6 +5,7 @@ import co.typie.network.Http
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.annotations.ApolloExperimental
 import com.apollographql.apollo.api.Subscription
+import com.apollographql.apollo.exception.ApolloNetworkException
 import com.apollographql.apollo.network.websocket.GraphQLWsProtocol
 import com.apollographql.apollo.network.websocket.WebSocketNetworkTransport
 import com.apollographql.cache.normalized.api.CacheKey
@@ -15,22 +16,28 @@ import com.apollographql.cache.normalized.normalizedCache
 import com.apollographql.ktor.http.KtorHttpEngine
 import kotlin.time.Duration.Companion.seconds
 
+private val subscriptionTransport: WebSocketNetworkTransport =
+  WebSocketNetworkTransport.Builder()
+    .serverUrl("${Konfig.WS_URL}/graphql")
+    .webSocketEngine(KtorWebSocketEngine)
+    .wsProtocol(
+      GraphQLWsProtocol(connectionPayload = { mapOf("session" to WebSocketSession.create()) })
+    )
+    .pingInterval(30.seconds)
+    .build()
+
+/** 구독 WS는 연결 시점 세션 티켓으로 인증이 고정된다. 계정 전환 시 끊으면 retryOnError 구독들이 새 티켓으로 재연결한다. */
+fun closeApolloSubscriptionConnection() {
+  subscriptionTransport.closeConnection(ApolloNetworkException("session changed"))
+}
+
 @OptIn(ApolloExperimental::class)
 val Apollo: ApolloClient =
   ApolloClient.Builder()
     .serverUrl("${Konfig.API_URL}/graphql")
     .httpEngine(KtorHttpEngine(Http))
     .retryOnError { request -> request.operation is Subscription<*> }
-    .subscriptionNetworkTransport(
-      WebSocketNetworkTransport.Builder()
-        .serverUrl("${Konfig.WS_URL}/graphql")
-        .webSocketEngine(KtorWebSocketEngine)
-        .wsProtocol(
-          GraphQLWsProtocol(connectionPayload = { mapOf("session" to WebSocketSession.create()) })
-        )
-        .pingInterval(30.seconds)
-        .build()
-    )
+    .subscriptionNetworkTransport(subscriptionTransport)
     .normalizedCache(
       MemoryCacheFactory(maxSizeBytes = 10 * 1024 * 1024),
       cacheKeyGenerator = IdCacheKeyGenerator(keyScope = CacheKey.Scope.SERVICE),

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/sync/ws/SyncWsConnectionTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/sync/ws/SyncWsConnectionTest.kt
@@ -139,6 +139,43 @@ class SyncWsConnectionTest {
   }
 
   @Test
+  fun disconnectTerminatesSocketAndNextRequestFetchesNewTicket() = runTest {
+    val (connection, sockets) = harness()
+    connection.disconnect()
+    runCurrent()
+    assertEquals(0, sockets.size)
+
+    val pushDeferred = async { connection.push("D1", byteArrayOf(1)) }
+    runCurrent()
+    val socket0 = sockets[0]
+    handshake(socket0)
+    val push0 = assertIs<WsClientMessage.Push>(socket0.lastOf("push"))
+    socket0.serverSend(
+      WsServerMessage.PushAck(id = push0.id, heads = ByteArray(0), durableHeads = ByteArray(0))
+    )
+    pushDeferred.await()
+
+    connection.disconnect()
+    runCurrent()
+    assertEquals(1, socket0.terminateCalls)
+
+    val pushDeferred2 = async { connection.push("D1", byteArrayOf(2)) }
+    runCurrent()
+    assertEquals(2, sockets.size)
+    val socket1 = sockets[1]
+    val hello = assertIs<WsClientMessage.Hello>(socket1.lastOf("hello"))
+    assertEquals("TK-2", hello.ticket)
+
+    handshake(socket1)
+    val push1 = assertIs<WsClientMessage.Push>(socket1.lastOf("push"))
+    socket1.serverSend(
+      WsServerMessage.PushAck(id = push1.id, heads = ByteArray(0), durableHeads = ByteArray(0))
+    )
+    pushDeferred2.await()
+    connection.dispose()
+  }
+
+  @Test
   fun registerChannelRoutesByDocumentIdAndUnregisters() = runTest {
     val (connection, sockets) = harness()
     val received = mutableListOf<String>()


### PR DESCRIPTION
로그아웃시 Apollo 캐시만 정리하고 SyncWs와 Apollo subscription 정리를 안 해서 로그아웃 후 타 계정 로그인시 에디터 동기화 채널과 실시간 GraphQL 구독이 앱 강제 재시작 전까지 모두 권한 오류로 고장나는 문제 해결함
