### PR TITLE
앱 노트/코멘트 subpane 열어놓고 에디터 편집 가능

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -165,6 +165,7 @@ import co.typie.screen.editor.editor.subpane.EditorSubPane
 import co.typie.screen.editor.editor.subpane.EditorSubPaneHost
 import co.typie.screen.editor.editor.subpane.EditorSubPaneState
 import co.typie.screen.editor.editor.subpane.comments.rememberEditorCommentsSession
+import co.typie.screen.editor.editor.subpane.computeEditorSubPaneForegroundOcclusion
 import co.typie.screen.editor.editor.subpane.resolveSubPaneBottomOcclusion
 import co.typie.screen.editor.editor.template.EditorTemplateSheet
 import co.typie.screen.editor.editor.toolbar.EditorToolbarDebugOverlays
@@ -233,6 +234,16 @@ private class EditorReloadRequest(
   val completion = CompletableDeferred<Unit>()
   var policyJob: Job? = null
   var snapshotInFlight = snapshotInFlight
+}
+
+internal fun openEditorAuxiliarySubPane(
+  state: EditorSubPaneState,
+  pane: EditorSubPane,
+  blurEditor: () -> Unit,
+) {
+  require(pane == EditorSubPane.RelatedNotes || pane == EditorSubPane.Comments)
+  blurEditor()
+  state.open(pane)
 }
 
 @OptIn(ExperimentalComposeUiApi::class)
@@ -455,9 +466,7 @@ fun EditorScreen(entityId: String) {
   }
   val focusReturnOwnerActive =
     findReplace.active ||
-      (subPaneState.editorInputBlocked &&
-        (subPaneState.active == EditorSubPane.RelatedNotes ||
-          subPaneState.active == EditorSubPane.Comments)) ||
+      subPaneState.auxiliaryFocusOwnerActive ||
       dialog.acceptsInput ||
       sheet.acceptsInput ||
       popoverOverlayState.acceptsInput ||
@@ -537,7 +546,13 @@ fun EditorScreen(entityId: String) {
       sheetActive = subPaneState.active == EditorSubPane.Comments,
       bringIntoViewRequests = bringIntoViewRequests,
       hideContextMenu = { uiState.contextMenu.hide() },
-      openSheet = { subPaneState.open(EditorSubPane.Comments) },
+      openSheet = {
+        openEditorAuxiliarySubPane(
+          state = subPaneState,
+          pane = EditorSubPane.Comments,
+          blurEditor = runtime::blur,
+        )
+      },
       ensureMutationSubscription = ::ensureCommentMutationSubscription,
     )
   suspend fun enterReadingMode() {
@@ -571,11 +586,13 @@ fun EditorScreen(entityId: String) {
 
       if (!transitionCurrent()) return
 
-      subPaneState.dismiss()
       uiState.contextMenu.hide()
       popoverOverlayState.dismissFromOutsideGesture()
       interactionScope.controller.cancel()
-      runtime.blur()
+      subPaneState.dismissTableAxisActions()
+      if (uiState.focused) {
+        runtime.blur()
+      }
       readingModeCleanupRequest += 1
       editingState.completeReadingTransition(transition)
     } finally {
@@ -1169,7 +1186,11 @@ fun EditorScreen(entityId: String) {
           aiFeedback.close()
           spellcheck.close()
           uiState.contextMenu.hide()
-          subPaneState.open(EditorSubPane.RelatedNotes)
+          openEditorAuxiliarySubPane(
+            state = subPaneState,
+            pane = EditorSubPane.RelatedNotes,
+            blurEditor = runtime::blur,
+          )
         }
         EditorToolbarToolAction.Comment -> {
           findReplace.close()
@@ -1388,6 +1409,24 @@ fun EditorScreen(entityId: String) {
         toolbarRestoreInset?.let { maxOf(bottomSafeInset, it) }
           ?: maxOf(bottomSafeInset, toolbarEffectiveImeInset, toolbarRetainedKeyboardInset)
       }
+    val subPaneToolbarControlsOcclusion =
+      if (toolbarPresented || panelTransitionRunning) {
+        ToolbarHeight + ToolbarBottomPadding + textOptionsToolbarOcclusion.value
+      } else {
+        0.dp
+      }
+    val subPaneForegroundOcclusion =
+      computeEditorSubPaneForegroundOcclusion(
+        trustedImeBottomInset = trustedImeBottom,
+        toolbarControlsOcclusion = subPaneToolbarControlsOcclusion,
+        bottomPanelOrKeyboardOcclusion = bottomPanelOrKeyboardOcclusion,
+        lastBottomPanelOcclusion =
+          bottomSafeInset + ToolbarBottomPanelGap + toolbarInputState.lastBottomPanelHeight,
+        bottomPanelOpen = bottomPanelOpen,
+        panelTransitionRunning = panelTransitionRunning,
+        keyboardRestoreInset = toolbarRestoreInset,
+        softwareKeyboardVisible = imeVisible,
+      )
     val toolbarBottomOcclusionTarget = toolbarControlsOcclusion + bottomPanelOrKeyboardOcclusion
     val inputSpaceOwnsOcclusion = !bottomPanelOpen && (imeVisible || !panelTransitionRunning)
     val toolbarBottomOcclusion =
@@ -1985,6 +2024,8 @@ fun EditorScreen(entityId: String) {
             maxTopInset = topInset,
             safeBottomInset = bottomSafeInset,
             trustedImeBottomInset = trustedImeBottom,
+            editorFocused = uiState.focused,
+            foregroundOcclusion = subPaneForegroundOcclusion,
             modifier = Modifier.fillMaxSize(),
           )
         },

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayout.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayout.kt
@@ -523,8 +523,8 @@ private fun EditorScreenForegroundLayout(
 
     layout(width = constraints.maxWidth, height = constraints.maxHeight) {
       overlayPlaceables.forEach { it.place(x = 0, y = 0) }
-      toolbarPlaceables.forEach { it.place(x = 0, y = constraints.maxHeight - it.height) }
       subPanePlaceables.forEach { it.place(x = 0, y = 0) }
+      toolbarPlaceables.forEach { it.place(x = 0, y = constraints.maxHeight - it.height) }
     }
   }
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/EditorResizableSheetSurface.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/EditorResizableSheetSurface.kt
@@ -1,9 +1,13 @@
 package co.typie.screen.editor.editor.subpane
 
 import androidx.compose.animation.core.Animatable
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.draggable
 import androidx.compose.foundation.gestures.rememberDraggableState
+import androidx.compose.foundation.gestures.waitForUpOrCancellation
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -25,6 +29,8 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
@@ -35,7 +41,11 @@ import androidx.compose.ui.unit.dp
 import co.typie.ext.LocalScrollGestureLockState
 import co.typie.ext.ScrollGestureLockHandle
 import co.typie.ui.component.sheet.SheetAnimationSpec
+import co.typie.ui.component.sheet.SheetBarDefaults
+import co.typie.ui.component.sheet.SheetHandleContainerHeight
 import co.typie.ui.theme.AppShapes
+import co.typie.ui.theme.LocalHazeState
+import dev.chrisbanes.haze.hazeSource
 import kotlin.math.max
 import kotlin.math.roundToInt
 import kotlinx.coroutines.launch
@@ -45,6 +55,12 @@ internal data class EditorResizableSheetGeometry(
   val expandedHeight: Float,
   val visibleHeight: Float,
 )
+
+private const val EditorSubPaneHazeZIndex = 1f
+internal val EditorSubPaneBarHeight = SheetBarDefaults.SlotWidth
+private val EditorSubPaneHeaderBottomClearance = 4.dp
+internal val EditorSubPaneHeaderRevealHeight =
+  SheetHandleContainerHeight + EditorSubPaneBarHeight + EditorSubPaneHeaderBottomClearance
 
 internal fun resolveEditorResizableSheetGeometry(
   sheetHeightPx: Float,
@@ -71,6 +87,8 @@ internal fun resolveKeyboardAwareSheetMinHeight(
   max(minHeightPx, keyboardOcclusionPx + minKeyboardVisibleHeightPx).coerceAtMost(expandedHeightPx)
 
 internal interface EditorResizableSheetSurfaceScope {
+  val keyboardOcclusion: Dp
+
   fun dismiss()
 
   fun Modifier.sheetDragHandle(): Modifier
@@ -82,7 +100,11 @@ internal fun EditorResizableSheetSurface(
   minHeight: Dp,
   dismissThreshold: Dp,
   maxTopInset: Dp,
-  keyboardOcclusion: Dp,
+  trustedImeBottomInset: Dp,
+  safeBottomInset: Dp,
+  editorFocused: Boolean,
+  foregroundOcclusion: EditorSubPaneForegroundOcclusion =
+    EditorSubPaneForegroundOcclusion(height = trustedImeBottomInset),
   minKeyboardVisibleHeight: Dp,
   canDismiss: suspend () -> Boolean = { true },
   onDismissStarted: () -> Unit = {},
@@ -94,6 +116,8 @@ internal fun EditorResizableSheetSurface(
   BoxWithConstraints(modifier.fillMaxSize()) {
     val density = LocalDensity.current
     val focusManager = LocalFocusManager.current
+    val sheetFocusRequester = remember { FocusRequester() }
+    val toolbarBackdropHazeState = LocalHazeState.current
     val coroutineScope = rememberCoroutineScope()
     val scrollGestureLockState = LocalScrollGestureLockState.current
     val canDismissState = rememberUpdatedState(canDismiss)
@@ -105,6 +129,8 @@ internal fun EditorResizableSheetSurface(
     var dismissRequestInProgress by remember { mutableStateOf(false) }
     var dismissing by remember { mutableStateOf(false) }
     var sheetHasFocus by remember { mutableStateOf(false) }
+    var sheetSurfaceFocused by remember { mutableStateOf(false) }
+    var sheetDragInProgress by remember { mutableStateOf(false) }
     var sheetDragScrollLock by remember { mutableStateOf<ScrollGestureLockHandle?>(null) }
 
     fun releaseSheetDragScrollLock() {
@@ -119,14 +145,24 @@ internal fun EditorResizableSheetSurface(
     val minHeightPx = with(density) { minHeight.toPx() }
     val dismissThresholdPx = with(density) { dismissThreshold.toPx() }
     val maxTopInsetPx = with(density) { maxTopInset.toPx() }
-    val keyboardOcclusionPx = with(density) { keyboardOcclusion.toPx() }
+    val rawKeyboardOcclusion = (trustedImeBottomInset - safeBottomInset).coerceAtLeast(0.dp)
+    val sheetDescendantHasFocus = sheetHasFocus && !sheetSurfaceFocused
+    val effectiveKeyboardOcclusion = if (sheetDescendantHasFocus) rawKeyboardOcclusion else 0.dp
+    val effectiveKeyboardOcclusionPx = with(density) { effectiveKeyboardOcclusion.toPx() }
+    val foregroundOcclusionHeightPx =
+      with(density) { foregroundOcclusion.height.toPx() }.coerceAtLeast(0f)
+    val foregroundHeaderRevealHeightPx =
+      with(density) { foregroundOcclusion.headerRevealHeight.toPx() }.coerceAtLeast(0f)
+    val rawForegroundOcclusion = (foregroundOcclusion.height - safeBottomInset).coerceAtLeast(0.dp)
+    val renderedHeightOverrideActive =
+      editorFocused && !sheetHasFocus && rawForegroundOcclusion > 0.dp
     val minKeyboardVisibleHeightPx = with(density) { minKeyboardVisibleHeight.toPx() }
     val dismissVelocityThresholdPx = with(density) { 1200.dp.toPx() }
     val expandedHeightPx = (containerHeightPx - maxTopInsetPx).coerceAtLeast(minHeightPx)
     val effectiveMinHeightPx =
       resolveKeyboardAwareSheetMinHeight(
         minHeightPx = minHeightPx,
-        keyboardOcclusionPx = keyboardOcclusionPx,
+        keyboardOcclusionPx = effectiveKeyboardOcclusionPx,
         minKeyboardVisibleHeightPx = minKeyboardVisibleHeightPx,
         expandedHeightPx = expandedHeightPx,
       )
@@ -164,7 +200,71 @@ internal fun EditorResizableSheetSurface(
       }
     }
 
-    val sheetHeight = resolvedSheetHeightPx()
+    val preferredSheetHeight = resolvedSheetHeightPx()
+    val renderedHeightTarget =
+      if (renderedHeightOverrideActive) {
+        if (foregroundHeaderRevealHeightPx > 0f) {
+          (foregroundOcclusionHeightPx + foregroundHeaderRevealHeightPx).coerceAtMost(
+            expandedHeightPx
+          )
+        } else {
+          minOf(preferredSheetHeight, foregroundOcclusionHeightPx)
+        }
+      } else {
+        preferredSheetHeight
+      }
+    val renderedHeightAnimation = remember { Animatable(preferredSheetHeight) }
+    val retainedRenderedHeightVelocity = remember { FloatArray(1) }
+    var renderedHeightTransitionFromOverride by remember {
+      mutableStateOf(renderedHeightOverrideActive)
+    }
+
+    LaunchedEffect(
+      renderedHeightTarget,
+      renderedHeightOverrideActive,
+      preferredSheetHeight,
+      sheetDragInProgress,
+    ) {
+      when {
+        sheetDragInProgress -> {
+          renderedHeightTransitionFromOverride = false
+          retainedRenderedHeightVelocity[0] = 0f
+          renderedHeightAnimation.snapTo(preferredSheetHeight)
+        }
+        renderedHeightOverrideActive -> {
+          renderedHeightTransitionFromOverride = true
+          renderedHeightAnimation.animateTo(
+            targetValue = renderedHeightTarget,
+            animationSpec = SheetAnimationSpec,
+            initialVelocity = retainedRenderedHeightVelocity[0],
+          ) {
+            retainedRenderedHeightVelocity[0] = velocity
+          }
+          retainedRenderedHeightVelocity[0] = 0f
+        }
+        renderedHeightTransitionFromOverride -> {
+          renderedHeightAnimation.animateTo(
+            targetValue = preferredSheetHeight,
+            animationSpec = SheetAnimationSpec,
+            initialVelocity = retainedRenderedHeightVelocity[0],
+          ) {
+            retainedRenderedHeightVelocity[0] = velocity
+          }
+          retainedRenderedHeightVelocity[0] = 0f
+          renderedHeightTransitionFromOverride = false
+        }
+        else -> {
+          retainedRenderedHeightVelocity[0] = 0f
+          renderedHeightAnimation.snapTo(preferredSheetHeight)
+        }
+      }
+    }
+
+    val renderedSheetHeight =
+      (if (sheetDragInProgress) preferredSheetHeight else renderedHeightAnimation.value).coerceIn(
+        0f,
+        expandedHeightPx,
+      )
 
     fun animateSheetHeight(target: Float) {
       coroutineScope.launch { animateSheetHeightTo(target) }
@@ -172,14 +272,19 @@ internal fun EditorResizableSheetSurface(
 
     LaunchedEffect(Unit) { presentationProgress.animateTo(0f, SheetAnimationSpec) }
 
-    LaunchedEffect(sheetHeight, expandedHeightPx, keyboardOcclusionPx, density.density) {
+    LaunchedEffect(
+      renderedSheetHeight,
+      expandedHeightPx,
+      effectiveKeyboardOcclusionPx,
+      density.density,
+    ) {
       snapshotFlow { presentationProgress.value }
         .collect { progress ->
           onGeometryChangedState.value(
             resolveEditorResizableSheetGeometry(
-              sheetHeightPx = sheetHeight,
+              sheetHeightPx = renderedSheetHeight,
               expandedHeightPx = expandedHeightPx,
-              keyboardOcclusionPx = keyboardOcclusionPx,
+              keyboardOcclusionPx = effectiveKeyboardOcclusionPx,
               visibility = 1f - progress,
               density = density.density,
             )
@@ -229,47 +334,84 @@ internal fun EditorResizableSheetSurface(
     }
     val scope =
       object : EditorResizableSheetSurfaceScope {
+        override val keyboardOcclusion: Dp
+          get() = effectiveKeyboardOcclusion
+
         override fun dismiss() {
           requestDismiss()
         }
 
         override fun Modifier.sheetDragHandle(): Modifier =
           draggable(
-            state = dragState,
-            orientation = Orientation.Vertical,
-            enabled = !dismissing && !dismissRequestInProgress,
-            onDragStarted = {
-              heightAnimation.stop()
-              releaseSheetDragScrollLock()
-              sheetDragScrollLock = scrollGestureLockState.acquire()
-            },
-            onDragStopped = { velocity ->
-              try {
-                val shouldDismiss =
-                  resolvedSheetHeightPx() <= dismissThresholdPx ||
-                    velocity > dismissVelocityThresholdPx
-                if (shouldDismiss) {
-                  requestDismiss()
-                } else if (resolvedSheetHeightPx() < effectiveMinHeightPx) {
-                  animateSheetHeight(effectiveMinHeightPx)
+              state = dragState,
+              orientation = Orientation.Vertical,
+              enabled = !dismissing && !dismissRequestInProgress,
+              onDragStarted = {
+                val draggingFromTemporaryReveal =
+                  renderedHeightOverrideActive && foregroundHeaderRevealHeightPx > 0f
+                val dragStartHeight =
+                  if (draggingFromTemporaryReveal) {
+                    renderedHeightAnimation.value.coerceIn(0f, expandedHeightPx)
+                  } else {
+                    resolvedSheetHeightPx()
+                  }
+                if (draggingFromTemporaryReveal) {
+                  updateSheetHeight(dragStartHeight)
                 }
-              } finally {
+                sheetFocusRequester.requestFocus()
+                sheetDragInProgress = true
+                renderedHeightTransitionFromOverride = false
+                retainedRenderedHeightVelocity[0] = 0f
+                renderedHeightAnimation.stop()
+                renderedHeightAnimation.snapTo(dragStartHeight)
+                heightAnimation.stop()
                 releaseSheetDragScrollLock()
+                sheetDragScrollLock = scrollGestureLockState.acquire()
+              },
+              onDragStopped = { velocity ->
+                try {
+                  val shouldDismiss =
+                    resolvedSheetHeightPx() <= dismissThresholdPx ||
+                      velocity > dismissVelocityThresholdPx
+                  if (shouldDismiss) {
+                    requestDismiss()
+                  } else if (resolvedSheetHeightPx() < effectiveMinHeightPx) {
+                    animateSheetHeight(effectiveMinHeightPx)
+                  }
+                } finally {
+                  sheetDragInProgress = false
+                  releaseSheetDragScrollLock()
+                }
+              },
+            )
+            .pointerInput(dismissing, dismissRequestInProgress) {
+              if (!dismissing && !dismissRequestInProgress) {
+                awaitEachGesture {
+                  awaitFirstDown(requireUnconsumed = false)
+                  if (waitForUpOrCancellation() != null) {
+                    sheetFocusRequester.requestFocus()
+                  }
+                }
               }
-            },
-          )
+            }
       }
 
-    val hiddenOffsetPx = sheetHeight * presentationProgress.value
+    val hiddenOffsetPx = renderedSheetHeight * presentationProgress.value
 
     Column(
       modifier =
         Modifier.fillMaxWidth()
-          .height(with(density) { sheetHeight.toDp() })
+          .height(with(density) { renderedSheetHeight.toDp() })
           .align(Alignment.BottomCenter)
           .offset { IntOffset(x = 0, y = hiddenOffsetPx.roundToInt()) }
           .clip(RoundedCornerShape(topStart = AppShapes.xl, topEnd = AppShapes.xl))
-          .onFocusChanged { sheetHasFocus = it.hasFocus }
+          .hazeSource(toolbarBackdropHazeState, zIndex = EditorSubPaneHazeZIndex)
+          .focusRequester(sheetFocusRequester)
+          .onFocusChanged {
+            sheetHasFocus = it.hasFocus
+            sheetSurfaceFocused = it.isFocused
+          }
+          .focusable(enabled = !dismissing)
           .blockPointerInputBehind()
     ) {
       scope.content()

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/EditorSubPaneForegroundOcclusion.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/EditorSubPaneForegroundOcclusion.kt
@@ -1,0 +1,43 @@
+package co.typie.screen.editor.editor.subpane
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+internal data class EditorSubPaneForegroundOcclusion(
+  val height: Dp,
+  val headerRevealHeight: Dp = 0.dp,
+)
+
+internal fun computeEditorSubPaneForegroundOcclusion(
+  trustedImeBottomInset: Dp,
+  toolbarControlsOcclusion: Dp,
+  bottomPanelOrKeyboardOcclusion: Dp,
+  lastBottomPanelOcclusion: Dp,
+  bottomPanelOpen: Boolean,
+  panelTransitionRunning: Boolean,
+  keyboardRestoreInset: Dp?,
+  softwareKeyboardVisible: Boolean,
+): EditorSubPaneForegroundOcclusion {
+  val height =
+    when {
+      bottomPanelOpen -> toolbarControlsOcclusion + bottomPanelOrKeyboardOcclusion
+      panelTransitionRunning ->
+        toolbarControlsOcclusion + maxOf(bottomPanelOrKeyboardOcclusion, lastBottomPanelOcclusion)
+      keyboardRestoreInset != null -> toolbarControlsOcclusion + bottomPanelOrKeyboardOcclusion
+      softwareKeyboardVisible -> toolbarControlsOcclusion + trustedImeBottomInset
+      else -> trustedImeBottomInset
+    }
+  val headerRevealHeight =
+    if (
+      bottomPanelOpen ||
+        panelTransitionRunning ||
+        keyboardRestoreInset != null ||
+        softwareKeyboardVisible
+    ) {
+      EditorSubPaneHeaderRevealHeight
+    } else {
+      0.dp
+    }
+
+  return EditorSubPaneForegroundOcclusion(height = height, headerRevealHeight = headerRevealHeight)
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/EditorSubPaneHost.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/EditorSubPaneHost.kt
@@ -27,6 +27,8 @@ internal fun EditorSubPaneHost(
   maxTopInset: Dp,
   safeBottomInset: Dp,
   trustedImeBottomInset: Dp,
+  editorFocused: Boolean,
+  foregroundOcclusion: EditorSubPaneForegroundOcclusion,
   modifier: Modifier = Modifier,
 ) {
   val editor = LocalEditorRuntime.current.editor
@@ -35,8 +37,8 @@ internal fun EditorSubPaneHost(
 
   LaunchedEffect(active, selection) { state.dismissTableAxisActionsIfSelectionChanged(selection) }
   LaunchedEffect(active, editorMutationEnabled) {
-    if (active is EditorSubPane.TableAxisActions && !editorMutationEnabled) {
-      state.dismiss()
+    if (!editorMutationEnabled) {
+      state.dismissTableAxisActions()
     }
   }
 
@@ -54,6 +56,8 @@ internal fun EditorSubPaneHost(
         maxTopInset = maxTopInset,
         safeBottomInset = safeBottomInset,
         trustedImeBottomInset = trustedImeBottomInset,
+        editorFocused = editorFocused,
+        foregroundOcclusion = foregroundOcclusion,
         onDismissStarted = state::beginDismiss,
         onDismiss = state::dismiss,
         onLayoutInfoChanged = state::updateLayoutInfo,
@@ -79,6 +83,8 @@ internal fun EditorSubPaneHost(
           maxTopInset = maxTopInset,
           safeBottomInset = safeBottomInset,
           trustedImeBottomInset = trustedImeBottomInset,
+          editorFocused = editorFocused,
+          foregroundOcclusion = foregroundOcclusion,
           onDismissStarted = state::beginDismiss,
           onDismiss = state::dismiss,
           onLayoutInfoChanged = state::updateLayoutInfo,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/EditorSubPaneState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/EditorSubPaneState.kt
@@ -66,7 +66,12 @@ internal class EditorSubPaneState {
   private var routeRemovalPreparation: (suspend () -> Boolean)? = null
 
   val editorInputBlocked: Boolean
-    get() = active != null && !dismissalInProgress
+    get() = active is EditorSubPane.TableAxisActions && !dismissalInProgress
+
+  val auxiliaryFocusOwnerActive: Boolean
+    get() =
+      !dismissalInProgress &&
+        (active == EditorSubPane.RelatedNotes || active == EditorSubPane.Comments)
 
   fun open(pane: EditorSubPane) {
     val previous = active
@@ -119,6 +124,12 @@ internal class EditorSubPaneState {
     val pane = active as? EditorSubPane.TableAxisActions ?: return
     if (pane.openedSelection != selection) {
       requestDismiss()
+    }
+  }
+
+  fun dismissTableAxisActions() {
+    if (active is EditorSubPane.TableAxisActions) {
+      dismiss()
     }
   }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/comments/CommentsSheet.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/comments/CommentsSheet.kt
@@ -41,6 +41,8 @@ import co.typie.navigation.PlatformBackHandler
 import co.typie.result.Result
 import co.typie.screen.editor.editor.subpane.EditorResizableSheetSurface
 import co.typie.screen.editor.editor.subpane.EditorSubPane
+import co.typie.screen.editor.editor.subpane.EditorSubPaneBarHeight
+import co.typie.screen.editor.editor.subpane.EditorSubPaneForegroundOcclusion
 import co.typie.screen.editor.editor.subpane.EditorSubPaneLayoutInfo
 import co.typie.screen.editor.editor.subpane.resolveResizableSubPaneVisibleAreaMode
 import co.typie.ui.component.Text
@@ -82,13 +84,14 @@ internal fun CommentsSheet(
   maxTopInset: Dp,
   safeBottomInset: Dp,
   trustedImeBottomInset: Dp,
+  editorFocused: Boolean,
+  foregroundOcclusion: EditorSubPaneForegroundOcclusion,
   onDismissStarted: () -> Unit,
   onDismiss: () -> Unit,
   onLayoutInfoChanged: (EditorSubPaneLayoutInfo) -> Unit,
   onLayoutInfoCleared: (EditorSubPane) -> Unit,
   modifier: Modifier = Modifier,
 ) {
-  val keyboardOcclusion = (trustedImeBottomInset - safeBottomInset).coerceAtLeast(0.dp)
   val state = model.threadState
   val dialog = LocalDialog.current
   val latestOnLayoutInfoCleared = rememberUpdatedState(onLayoutInfoCleared)
@@ -100,7 +103,10 @@ internal fun CommentsSheet(
     minHeight = CommentsMinHeight,
     dismissThreshold = CommentsDismissThreshold,
     maxTopInset = maxTopInset,
-    keyboardOcclusion = keyboardOcclusion,
+    trustedImeBottomInset = trustedImeBottomInset,
+    safeBottomInset = safeBottomInset,
+    editorFocused = editorFocused,
+    foregroundOcclusion = foregroundOcclusion,
     minKeyboardVisibleHeight = CommentsMinKeyboardVisibleHeight,
     canDismiss = { confirmDiscardCommentInput(state = state, dialog = dialog) },
     onDismissStarted = onDismissStarted,
@@ -536,7 +542,7 @@ private fun CommentsSheetBar(
   onCreate: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
-  Box(modifier = modifier.fillMaxWidth().height(44.dp)) {
+  Box(modifier = modifier.fillMaxWidth().height(EditorSubPaneBarHeight)) {
     SheetBarButton(
       icon = Lucide.X,
       onClick = onDismiss,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/relatednotes/RelatedNotesSheet.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/relatednotes/RelatedNotesSheet.kt
@@ -61,6 +61,8 @@ import co.typie.navigation.PlatformBackHandler
 import co.typie.route.Route
 import co.typie.screen.editor.editor.subpane.EditorResizableSheetSurface
 import co.typie.screen.editor.editor.subpane.EditorSubPane
+import co.typie.screen.editor.editor.subpane.EditorSubPaneBarHeight
+import co.typie.screen.editor.editor.subpane.EditorSubPaneForegroundOcclusion
 import co.typie.screen.editor.editor.subpane.EditorSubPaneLayoutInfo
 import co.typie.screen.editor.editor.subpane.resolveResizableSubPaneVisibleAreaMode
 import co.typie.ui.component.Text
@@ -93,6 +95,8 @@ internal fun RelatedNotesSheet(
   maxTopInset: Dp,
   safeBottomInset: Dp,
   trustedImeBottomInset: Dp,
+  editorFocused: Boolean,
+  foregroundOcclusion: EditorSubPaneForegroundOcclusion,
   onDismissStarted: () -> Unit,
   onDismiss: () -> Unit,
   onLayoutInfoChanged: (EditorSubPaneLayoutInfo) -> Unit,
@@ -100,7 +104,6 @@ internal fun RelatedNotesSheet(
   registerRouteRemovalPreparation: (suspend () -> Boolean) -> Unit,
   modifier: Modifier = Modifier,
 ) {
-  val keyboardOcclusion = (trustedImeBottomInset - safeBottomInset).coerceAtLeast(0.dp)
   val model =
     viewModel(key = "$RelatedNotesSheetViewModelKeyPrefix:$siteId:$entityId") {
       RelatedNotesViewModel(entityId = entityId, siteId = siteId)
@@ -163,7 +166,10 @@ internal fun RelatedNotesSheet(
     minHeight = RelatedNotesMinHeight,
     dismissThreshold = RelatedNotesDismissThreshold,
     maxTopInset = maxTopInset,
-    keyboardOcclusion = keyboardOcclusion,
+    trustedImeBottomInset = trustedImeBottomInset,
+    safeBottomInset = safeBottomInset,
+    editorFocused = editorFocused,
+    foregroundOcclusion = foregroundOcclusion,
     minKeyboardVisibleHeight = RelatedNotesMinKeyboardVisibleHeight,
     onDismissStarted = onDismissStarted,
     onDismissed = onDismiss,
@@ -636,7 +642,9 @@ private fun RelatedNotesSheetBar(
   onCreate: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
-  Box(modifier = modifier.fillMaxWidth().height(44.dp).padding(horizontal = 0.dp)) {
+  Box(
+    modifier = modifier.fillMaxWidth().height(EditorSubPaneBarHeight).padding(horizontal = 0.dp)
+  ) {
     SheetBarButton(
       icon = Lucide.X,
       onClick = { onDismiss() },

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/sheet/SheetLayout.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/sheet/SheetLayout.kt
@@ -117,20 +117,21 @@ fun SheetLayout(
 }
 
 private val HandleTopPadding = 8.dp
-private val HandleHeight = 4.dp
+private val HandleIndicatorHeight = 4.dp
 private val HandleBottomPadding = 8.dp
 private val HandleWidth = 36.dp
+internal val SheetHandleContainerHeight =
+  HandleTopPadding + HandleIndicatorHeight + HandleBottomPadding
 
 @Composable
 private fun SheetHandle(modifier: Modifier) {
   Box(
-    modifier =
-      modifier.fillMaxWidth().height(HandleTopPadding + HandleHeight + HandleBottomPadding),
+    modifier = modifier.fillMaxWidth().height(SheetHandleContainerHeight),
     contentAlignment = Alignment.Center,
   ) {
     Box(
       modifier =
-        Modifier.size(width = HandleWidth, height = HandleHeight)
+        Modifier.size(width = HandleWidth, height = HandleIndicatorHeight)
           .clip(AppShapes.rounded(AppShapes.sm))
           .background(AppTheme.colors.borderHairline)
     )

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/subpane/EditorSubPaneForegroundOcclusionTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/subpane/EditorSubPaneForegroundOcclusionTest.kt
@@ -1,0 +1,125 @@
+package co.typie.screen.editor.editor.subpane
+
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class EditorSubPaneForegroundOcclusionTest {
+  @Test
+  fun bottomPanelRevealsHeaderAboveItsFullOcclusion() {
+    assertEquals(
+      EditorSubPaneForegroundOcclusion(
+        height = 330.dp,
+        headerRevealHeight = EditorSubPaneHeaderRevealHeight,
+      ),
+      computeEditorSubPaneForegroundOcclusion(
+        trustedImeBottomInset = 0.dp,
+        toolbarControlsOcclusion = 50.dp,
+        bottomPanelOrKeyboardOcclusion = 280.dp,
+        lastBottomPanelOcclusion = 280.dp,
+        bottomPanelOpen = true,
+        panelTransitionRunning = true,
+        keyboardRestoreInset = null,
+        softwareKeyboardVisible = false,
+      ),
+    )
+  }
+
+  @Test
+  fun panelTransitionRetainsLastPanelOcclusionAndHeaderReveal() {
+    assertEquals(
+      EditorSubPaneForegroundOcclusion(
+        height = 210.dp,
+        headerRevealHeight = EditorSubPaneHeaderRevealHeight,
+      ),
+      computeEditorSubPaneForegroundOcclusion(
+        trustedImeBottomInset = 0.dp,
+        toolbarControlsOcclusion = 50.dp,
+        bottomPanelOrKeyboardOcclusion = 0.dp,
+        lastBottomPanelOcclusion = 160.dp,
+        bottomPanelOpen = false,
+        panelTransitionRunning = true,
+        keyboardRestoreInset = null,
+        softwareKeyboardVisible = false,
+      ),
+    )
+  }
+
+  @Test
+  fun keyboardRestoreRetainsOcclusionAndHeaderReveal() {
+    assertEquals(
+      EditorSubPaneForegroundOcclusion(
+        height = 330.dp,
+        headerRevealHeight = EditorSubPaneHeaderRevealHeight,
+      ),
+      computeEditorSubPaneForegroundOcclusion(
+        trustedImeBottomInset = 0.dp,
+        toolbarControlsOcclusion = 50.dp,
+        bottomPanelOrKeyboardOcclusion = 280.dp,
+        lastBottomPanelOcclusion = 280.dp,
+        bottomPanelOpen = false,
+        panelTransitionRunning = false,
+        keyboardRestoreInset = 280.dp,
+        softwareKeyboardVisible = false,
+      ),
+    )
+    assertEquals(
+      EditorSubPaneForegroundOcclusion(
+        height = 160.dp,
+        headerRevealHeight = EditorSubPaneHeaderRevealHeight,
+      ),
+      computeEditorSubPaneForegroundOcclusion(
+        trustedImeBottomInset = 0.dp,
+        toolbarControlsOcclusion = 0.dp,
+        bottomPanelOrKeyboardOcclusion = 160.dp,
+        lastBottomPanelOcclusion = 160.dp,
+        bottomPanelOpen = false,
+        panelTransitionRunning = false,
+        keyboardRestoreInset = 160.dp,
+        softwareKeyboardVisible = false,
+      ),
+    )
+  }
+
+  @Test
+  fun softwareKeyboardRevealsHeaderAboveImeAndToolbar() {
+    assertEquals(
+      EditorSubPaneForegroundOcclusion(
+        height = 330.dp,
+        headerRevealHeight = EditorSubPaneHeaderRevealHeight,
+      ),
+      computeEditorSubPaneForegroundOcclusion(
+        trustedImeBottomInset = 280.dp,
+        toolbarControlsOcclusion = 50.dp,
+        bottomPanelOrKeyboardOcclusion = 280.dp,
+        lastBottomPanelOcclusion = 280.dp,
+        bottomPanelOpen = false,
+        panelTransitionRunning = false,
+        keyboardRestoreInset = null,
+        softwareKeyboardVisible = true,
+      ),
+    )
+  }
+
+  @Test
+  fun hiddenForegroundUsesTrustedImeWithoutHeaderReveal() {
+    assertEquals(
+      EditorSubPaneForegroundOcclusion(height = 0.dp),
+      computeEditorSubPaneForegroundOcclusion(
+        trustedImeBottomInset = 0.dp,
+        toolbarControlsOcclusion = 0.dp,
+        bottomPanelOrKeyboardOcclusion = 0.dp,
+        lastBottomPanelOcclusion = 0.dp,
+        bottomPanelOpen = false,
+        panelTransitionRunning = false,
+        keyboardRestoreInset = null,
+        softwareKeyboardVisible = false,
+      ),
+    )
+  }
+
+  @Test
+  fun headerRevealIncludesBottomClearance() {
+    assertEquals(68.dp, EditorSubPaneHeaderRevealHeight)
+  }
+}

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/subpane/EditorSubPaneStateTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/subpane/EditorSubPaneStateTest.kt
@@ -95,6 +95,53 @@ class EditorSubPaneStateTest {
   }
 
   @Test
+  fun `related notes keeps editor input available while owning focus return`() {
+    val state = EditorSubPaneState()
+
+    state.open(EditorSubPane.RelatedNotes)
+
+    assertFalse(state.editorInputBlocked)
+    assertTrue(state.auxiliaryFocusOwnerActive)
+  }
+
+  @Test
+  fun `comments keeps editor input available while owning focus return`() {
+    val state = EditorSubPaneState()
+
+    state.open(EditorSubPane.Comments)
+
+    assertFalse(state.editorInputBlocked)
+    assertTrue(state.auxiliaryFocusOwnerActive)
+  }
+
+  @Test
+  fun `beginning auxiliary pane dismissal releases focus return ownership`() {
+    val state = EditorSubPaneState()
+    state.open(EditorSubPane.RelatedNotes)
+
+    state.beginDismiss()
+
+    assertFalse(state.auxiliaryFocusOwnerActive)
+  }
+
+  @Test
+  fun `direct editing loss dismisses only table axis actions`() {
+    val state = EditorSubPaneState()
+
+    state.open(EditorSubPane.RelatedNotes)
+    state.dismissTableAxisActions()
+    assertEquals(EditorSubPane.RelatedNotes, state.active)
+
+    state.open(EditorSubPane.Comments)
+    state.dismissTableAxisActions()
+    assertEquals(EditorSubPane.Comments, state.active)
+
+    state.open(tableAxisPane(tableId = "table"))
+    state.dismissTableAxisActions()
+    assertNull(state.active)
+  }
+
+  @Test
   fun `table axis actions remain valid while selection stays at opening selection`() {
     val openingSelection = selection(offset = 1)
     val pane =

--- a/apps/mobile/compose/src/desktopMain/kotlin/co/typie/dev/DesktopDebugKeyboard.kt
+++ b/apps/mobile/compose/src/desktopMain/kotlin/co/typie/dev/DesktopDebugKeyboard.kt
@@ -253,14 +253,14 @@ internal object DesktopDebugKeyboard {
             endPointerInteraction()
           }
         }
-        .background(DesktopDebugKeyboardBackground.copy(alpha = 0.98f))
+        .background(DesktopDebugKeyboardBackground.copy(alpha = 0.78f))
         .border(1.dp, AppTheme.colors.borderHairline.copy(alpha = 0.95f))
         .padding(horizontal = 10.dp, vertical = 10.dp)
     ) {
       Column(
         modifier =
           Modifier.fillMaxWidth()
-            .background(DesktopDebugKeyboardBody.copy(alpha = 0.92f), RoundedCornerShape(18.dp))
+            .background(DesktopDebugKeyboardBody.copy(alpha = 0.72f), RoundedCornerShape(18.dp))
             .padding(10.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
       ) {

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/EditorScreenReadingModeDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/EditorScreenReadingModeDesktopTest.kt
@@ -4,7 +4,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.v2.runComposeUiTest
 import co.typie.screen.editor.editor.state.EditorInputEffect
+import co.typie.screen.editor.editor.subpane.EditorSubPane
+import co.typie.screen.editor.editor.subpane.EditorSubPaneState
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNotSame
@@ -13,6 +16,23 @@ import kotlin.test.assertTrue
 
 @OptIn(ExperimentalTestApi::class)
 class EditorScreenReadingModeDesktopTest {
+  @Test
+  fun openingAuxiliarySubPaneBlursEditorWithoutBlockingLaterInput() {
+    val subPaneState = EditorSubPaneState()
+    var blurCount = 0
+
+    openEditorAuxiliarySubPane(
+      state = subPaneState,
+      pane = EditorSubPane.Comments,
+      blurEditor = { blurCount += 1 },
+    )
+
+    assertEquals(1, blurCount)
+    assertEquals(EditorSubPane.Comments, subPaneState.active)
+    assertFalse(subPaneState.editorInputBlocked)
+    assertTrue(subPaneState.auxiliaryFocusOwnerActive)
+  }
+
   @Test
   fun newEntityStartsInReadingModeAfterThePreviousEntityWasEditing() = runComposeUiTest {
     val entityId = mutableStateOf("A")

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayoutDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayoutDesktopTest.kt
@@ -1116,6 +1116,74 @@ class EditorScreenLayoutDesktopTest {
   }
 
   @Test
+  fun toolbarReceivesPointerAboveOverlappingSubPane() = runComposeUiTest {
+    var toolbarTaps = 0
+    var subPaneTaps = 0
+
+    setContent {
+      val coroutineScope = rememberCoroutineScope()
+      val interactionScope = remember { EditorInteractionScope(coroutineScope = coroutineScope) }
+      val visibleArea = EditorVisibleArea(viewport = Size(width = 320f, height = 640f))
+      val scrollFrame =
+        EditorScrollFrame(
+          state = EditorState.Initial,
+          layoutSpec = EditorDocumentLayoutSpec.Continuous(maxWidth = 320f),
+          displayZoom = 1f,
+          visibleArea = visibleArea,
+          autoScrollPolicy = resolveEditorAutoScrollPolicy(visibleArea),
+          headerHeight = 0f,
+          density = 1f,
+          editorBounds = EditorBoundsInContainer(),
+        )
+
+      CompositionLocalProvider(
+        LocalEditorBringIntoViewRequests provides rememberEditorBringIntoViewRequests(),
+        LocalEditorInteractionScope provides interactionScope,
+        LocalEditorUiState provides remember { EditorUiState() },
+      ) {
+        EditorScreenLayout(
+          state = remember { EditorScreenState(EditorViewportState()) },
+          scrollFrame = scrollFrame,
+          visibleArea = visibleArea,
+          viewportScrollableState = rememberScrollable2DState { Offset.Zero },
+          viewportContentWidth = 320f,
+          viewportScrollReconcileMode = EditorViewportScrollReconcileMode.Disabled,
+          onMeasuredViewportSizeChange = {},
+          header = {},
+          body = { Box(Modifier.fillMaxWidth().height(800.dp)) },
+          toolbar = {
+            Box(
+              Modifier.fillMaxWidth().height(160.dp).testTag(ToolbarTag).pointerInput(Unit) {
+                detectTapGestures { toolbarTaps += 1 }
+              }
+            )
+          },
+          subPane = {
+            Box(
+              Modifier.align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .height(160.dp)
+                .testTag(SubPaneTag)
+                .pointerInput(Unit) { detectTapGestures { subPaneTaps += 1 } }
+            )
+          },
+          modifier = Modifier.size(width = 320.dp, height = 640.dp).testTag(LayoutTag),
+        )
+      }
+    }
+    waitForIdle()
+
+    onNodeWithTag(LayoutTag).performTouchInput {
+      down(Offset(x = center.x, y = 600f))
+      up()
+    }
+    waitForIdle()
+
+    assertEquals(1, toolbarTaps)
+    assertEquals(0, subPaneTaps)
+  }
+
+  @Test
   fun disabledEditorInteractionDoesNotPanFromTouchOrWheel() = runComposeUiTest {
     var consumed = Offset.Zero
 
@@ -1795,6 +1863,7 @@ class EditorScreenLayoutDesktopTest {
     const val HeaderTag = "editor-screen-layout-header"
     const val LayoutTag = "editor-screen-layout"
     const val SubPaneTag = "editor-screen-layout-subpane"
+    const val ToolbarTag = "editor-screen-layout-toolbar"
     const val ViewportOverlayTag = "editor-screen-layout-viewport-overlay-target"
     const val HeaderFixtureBodyHeight = 800f
     const val HeaderFixtureContentWidth = 640f

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/subpane/EditorResizableSheetSurfaceDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/subpane/EditorResizableSheetSurfaceDesktopTest.kt
@@ -9,8 +9,13 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -28,12 +33,423 @@ import androidx.compose.ui.test.swipeWithVelocity
 import androidx.compose.ui.unit.dp
 import co.typie.ext.ScrollGestureLockScope
 import co.typie.ext.verticalScroll
+import co.typie.ui.theme.LocalHazeState
+import dev.chrisbanes.haze.HazeState
+import kotlin.math.abs
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalTestApi::class)
 class EditorResizableSheetSurfaceDesktopTest {
+  @Test
+  fun editorOwnedKeyboardCapsRenderedHeightWithoutChangingPreferredHeight() = runComposeUiTest {
+    var editorFocused by mutableStateOf(false)
+    var geometry: EditorResizableSheetGeometry? = null
+
+    setContent {
+      ScrollGestureLockScope {
+        Box(Modifier.size(width = 400.dp, height = 800.dp)) {
+          EditorResizableSheetSurface(
+            initialHeight = 360.dp,
+            minHeight = 240.dp,
+            dismissThreshold = 128.dp,
+            maxTopInset = 0.dp,
+            trustedImeBottomInset = 180.dp,
+            safeBottomInset = 0.dp,
+            editorFocused = editorFocused,
+            minKeyboardVisibleHeight = 240.dp,
+            onDismissed = {},
+            onGeometryChanged = { geometry = it },
+          ) {
+            Box(Modifier.fillMaxSize())
+          }
+        }
+      }
+    }
+    waitForIdle()
+
+    assertEquals(360f, checkNotNull(geometry).sheetHeight)
+
+    mainClock.autoAdvance = false
+    runOnIdle { editorFocused = true }
+    repeat(3) { mainClock.advanceTimeByFrame() }
+
+    val limitingHeight = checkNotNull(geometry).sheetHeight
+    assertTrue(
+      limitingHeight in 180f..360f && limitingHeight != 180f && limitingHeight != 360f,
+      "expected a limiting transition height, but was $limitingHeight",
+    )
+
+    mainClock.autoAdvance = true
+    waitForIdle()
+    assertEquals(180f, checkNotNull(geometry).sheetHeight)
+
+    mainClock.autoAdvance = false
+    runOnIdle { editorFocused = false }
+    repeat(3) { mainClock.advanceTimeByFrame() }
+
+    val restoringHeight = checkNotNull(geometry).sheetHeight
+    assertTrue(
+      restoringHeight in 180f..360f && restoringHeight != 180f && restoringHeight != 360f,
+      "expected a restoring transition height, but was $restoringHeight",
+    )
+
+    mainClock.autoAdvance = true
+    waitForIdle()
+
+    assertEquals(360f, checkNotNull(geometry).sheetHeight)
+  }
+
+  @Test
+  fun activeKeyboardCapRetargetsFromCurrentMotionToLatestInset() = runComposeUiTest {
+    var editorFocused by mutableStateOf(false)
+    var trustedImeBottomInset by mutableStateOf(180.dp)
+    var geometry: EditorResizableSheetGeometry? = null
+
+    setContent {
+      ScrollGestureLockScope {
+        Box(Modifier.size(width = 400.dp, height = 800.dp)) {
+          EditorResizableSheetSurface(
+            initialHeight = 360.dp,
+            minHeight = 240.dp,
+            dismissThreshold = 128.dp,
+            maxTopInset = 0.dp,
+            trustedImeBottomInset = trustedImeBottomInset,
+            safeBottomInset = 0.dp,
+            editorFocused = editorFocused,
+            minKeyboardVisibleHeight = 240.dp,
+            onDismissed = {},
+            onGeometryChanged = { geometry = it },
+          ) {
+            Box(Modifier.fillMaxSize())
+          }
+        }
+      }
+    }
+    waitForIdle()
+
+    mainClock.autoAdvance = false
+    runOnIdle { editorFocused = true }
+    repeat(3) { mainClock.advanceTimeByFrame() }
+    val heightBeforeLastPreRetargetFrame = checkNotNull(geometry).sheetHeight
+    mainClock.advanceTimeByFrame()
+    val heightImmediatelyBeforeRetarget = checkNotNull(geometry).sheetHeight
+    val preRetargetDelta = heightImmediatelyBeforeRetarget - heightBeforeLastPreRetargetFrame
+    assertTrue(preRetargetDelta < 0f)
+
+    runOnIdle { trustedImeBottomInset = 220.dp }
+    mainClock.advanceTimeByFrame()
+    val heightImmediatelyAfterRetarget = checkNotNull(geometry).sheetHeight
+    val postRetargetDelta = heightImmediatelyAfterRetarget - heightImmediatelyBeforeRetarget
+
+    assertTrue(postRetargetDelta <= 0f)
+    assertTrue(abs(postRetargetDelta) >= abs(preRetargetDelta) * 0.25f)
+
+    mainClock.autoAdvance = true
+    waitForIdle()
+    assertEquals(220f, checkNotNull(geometry).sheetHeight)
+  }
+
+  @Test
+  fun foregroundOcclusionKeepsHeaderRevealedAcrossPanelToKeyboardHandoff() = runComposeUiTest {
+    var foregroundOcclusion by mutableStateOf(EditorSubPaneForegroundOcclusion(height = 0.dp))
+    var geometry: EditorResizableSheetGeometry? = null
+
+    setContent {
+      ScrollGestureLockScope {
+        Box(Modifier.size(width = 400.dp, height = 800.dp)) {
+          EditorResizableSheetSurface(
+            initialHeight = 300.dp,
+            minHeight = 240.dp,
+            dismissThreshold = 128.dp,
+            maxTopInset = 0.dp,
+            trustedImeBottomInset = 0.dp,
+            safeBottomInset = 0.dp,
+            editorFocused = true,
+            foregroundOcclusion = foregroundOcclusion,
+            minKeyboardVisibleHeight = 240.dp,
+            onDismissed = {},
+            onGeometryChanged = { geometry = it },
+          ) {
+            Box(Modifier.fillMaxSize())
+          }
+        }
+      }
+    }
+    waitForIdle()
+    assertEquals(300f, checkNotNull(geometry).sheetHeight)
+
+    runOnIdle {
+      foregroundOcclusion =
+        EditorSubPaneForegroundOcclusion(
+          height = 330.dp,
+          headerRevealHeight = EditorSubPaneHeaderRevealHeight,
+        )
+    }
+    waitForIdle()
+    assertEquals(398f, checkNotNull(geometry).sheetHeight)
+
+    runOnIdle { foregroundOcclusion = foregroundOcclusion.copy(height = 280.dp) }
+    waitForIdle()
+    assertEquals(348f, checkNotNull(geometry).sheetHeight)
+
+    runOnIdle { foregroundOcclusion = EditorSubPaneForegroundOcclusion(height = 0.dp) }
+    waitForIdle()
+    assertEquals(300f, checkNotNull(geometry).sheetHeight)
+  }
+
+  @Test
+  fun tappingBottomPanelRevealFocusesSheetAndRestoresRememberedHeight() = runComposeUiTest {
+    var geometry: EditorResizableSheetGeometry? = null
+    var exposedKeyboardOcclusion = (-1).dp
+
+    setContent {
+      ScrollGestureLockScope {
+        Box(Modifier.size(width = 400.dp, height = 800.dp)) {
+          EditorResizableSheetSurface(
+            initialHeight = 600.dp,
+            minHeight = 240.dp,
+            dismissThreshold = 128.dp,
+            maxTopInset = 0.dp,
+            trustedImeBottomInset = 320.dp,
+            safeBottomInset = 0.dp,
+            editorFocused = true,
+            foregroundOcclusion =
+              EditorSubPaneForegroundOcclusion(
+                height = 330.dp,
+                headerRevealHeight = EditorSubPaneHeaderRevealHeight,
+              ),
+            minKeyboardVisibleHeight = 240.dp,
+            onDismissed = {},
+            onGeometryChanged = { geometry = it },
+          ) {
+            SideEffect { exposedKeyboardOcclusion = keyboardOcclusion }
+            Box(
+              Modifier.testTag(BottomPanelRevealTag)
+                .fillMaxWidth()
+                .height(EditorSubPaneHeaderRevealHeight)
+                .sheetDragHandle()
+            )
+          }
+        }
+      }
+    }
+    waitForIdle()
+    assertEquals(398f, checkNotNull(geometry).sheetHeight)
+
+    onNodeWithTag(BottomPanelRevealTag).performTouchInput { click(Offset(x = center.x, y = 12f)) }
+    waitForIdle()
+
+    assertEquals(600f, checkNotNull(geometry).sheetHeight)
+    assertEquals(0.dp, exposedKeyboardOcclusion)
+  }
+
+  @Test
+  fun dragHandleTapObserverPreservesChildClick() = runComposeUiTest {
+    var childClicks = 0
+
+    setContent {
+      ScrollGestureLockScope {
+        Box(Modifier.size(width = 400.dp, height = 800.dp)) {
+          EditorResizableSheetSurface(
+            initialHeight = 360.dp,
+            minHeight = 240.dp,
+            dismissThreshold = 128.dp,
+            maxTopInset = 0.dp,
+            trustedImeBottomInset = 0.dp,
+            safeBottomInset = 0.dp,
+            editorFocused = false,
+            minKeyboardVisibleHeight = 0.dp,
+            onDismissed = {},
+            onGeometryChanged = {},
+          ) {
+            Box(Modifier.fillMaxWidth().height(EditorSubPaneHeaderRevealHeight).sheetDragHandle()) {
+              Box(
+                Modifier.testTag(DragHandleChildButtonTag).size(44.dp).clickable {
+                  childClicks += 1
+                }
+              )
+            }
+          }
+        }
+      }
+    }
+    waitForIdle()
+
+    onNodeWithTag(DragHandleChildButtonTag).performTouchInput { click(center) }
+    waitForIdle()
+
+    assertEquals(1, childClicks)
+  }
+
+  @Test
+  fun draggingBottomPanelRevealResizesFromTemporaryHeight() = runComposeUiTest {
+    var geometry: EditorResizableSheetGeometry? = null
+
+    setContent {
+      ScrollGestureLockScope {
+        Box(Modifier.size(width = 400.dp, height = 800.dp)) {
+          EditorResizableSheetSurface(
+            initialHeight = 600.dp,
+            minHeight = 240.dp,
+            dismissThreshold = 128.dp,
+            maxTopInset = 0.dp,
+            trustedImeBottomInset = 0.dp,
+            safeBottomInset = 0.dp,
+            editorFocused = true,
+            foregroundOcclusion =
+              EditorSubPaneForegroundOcclusion(
+                height = 330.dp,
+                headerRevealHeight = EditorSubPaneHeaderRevealHeight,
+              ),
+            minKeyboardVisibleHeight = 240.dp,
+            onDismissed = {},
+            onGeometryChanged = { geometry = it },
+          ) {
+            Box(
+              Modifier.testTag(BottomPanelRevealDragHandleTag)
+                .fillMaxWidth()
+                .height(72.dp)
+                .sheetDragHandle()
+            )
+          }
+        }
+      }
+    }
+    waitForIdle()
+    assertEquals(398f, checkNotNull(geometry).sheetHeight)
+
+    val handle = onNodeWithTag(BottomPanelRevealDragHandleTag)
+    handle.performTouchInput { down(center) }
+    try {
+      handle.performTouchInput { moveBy(Offset(x = 0f, y = -64f)) }
+      waitForIdle()
+      val heightAfterDragStarted = checkNotNull(geometry).sheetHeight
+      assertTrue(
+        heightAfterDragStarted in 398f..490f,
+        "drag should start from the temporary 398dp height, but was $heightAfterDragStarted",
+      )
+
+      handle.performTouchInput { moveBy(Offset(x = 0f, y = -12f)) }
+      waitForIdle()
+      val heightAfterNextMove = checkNotNull(geometry).sheetHeight
+      assertEquals(12f, heightAfterNextMove - heightAfterDragStarted, absoluteTolerance = 1f)
+    } finally {
+      handle.performTouchInput { up() }
+    }
+
+    waitForIdle()
+    assertTrue(checkNotNull(geometry).sheetHeight in 406f..510f)
+  }
+
+  @Test
+  fun resizableSubPaneParticipatesInToolbarBackdropHazeAboveTheEditorViewport() = runComposeUiTest {
+    lateinit var hazeState: HazeState
+
+    setContent {
+      val state = remember { HazeState() }
+      SideEffect { hazeState = state }
+      CompositionLocalProvider(LocalHazeState provides state) {
+        ScrollGestureLockScope {
+          Box(Modifier.size(width = 400.dp, height = 800.dp)) {
+            EditorResizableSheetSurface(
+              initialHeight = 360.dp,
+              minHeight = 240.dp,
+              dismissThreshold = 128.dp,
+              maxTopInset = 0.dp,
+              trustedImeBottomInset = 0.dp,
+              safeBottomInset = 0.dp,
+              editorFocused = false,
+              minKeyboardVisibleHeight = 0.dp,
+              onDismissed = {},
+              onGeometryChanged = {},
+            ) {
+              Box(Modifier.fillMaxSize())
+            }
+          }
+        }
+      }
+    }
+    waitForIdle()
+
+    assertEquals(listOf(1f), hazeState.areas.map { it.zIndex })
+  }
+
+  @Test
+  fun keyboardOcclusionIsExposedOnlyWhileSheetOwnsFocus() = runComposeUiTest {
+    val sheetFocusRequester = FocusRequester()
+    var exposedKeyboardOcclusion = (-1).dp
+
+    setContent {
+      ScrollGestureLockScope {
+        Box(Modifier.size(width = 400.dp, height = 800.dp)) {
+          EditorResizableSheetSurface(
+            initialHeight = 360.dp,
+            minHeight = 240.dp,
+            dismissThreshold = 128.dp,
+            maxTopInset = 0.dp,
+            trustedImeBottomInset = 320.dp,
+            safeBottomInset = 0.dp,
+            editorFocused = false,
+            minKeyboardVisibleHeight = 240.dp,
+            onDismissed = {},
+            onGeometryChanged = {},
+          ) {
+            SideEffect { exposedKeyboardOcclusion = keyboardOcclusion }
+            Box(
+              Modifier.testTag(SheetFocusTag)
+                .size(48.dp)
+                .focusRequester(sheetFocusRequester)
+                .focusable()
+            )
+          }
+        }
+      }
+    }
+    waitForIdle()
+
+    assertEquals(0.dp, exposedKeyboardOcclusion)
+
+    runOnIdle { sheetFocusRequester.requestFocus() }
+    waitForIdle()
+
+    assertEquals(320.dp, exposedKeyboardOcclusion)
+  }
+
+  @Test
+  fun editorOwnedKeyboardCapDoesNotBlockPointerInputAboveRenderedSheet() = runComposeUiTest {
+    var backgroundClicks = 0
+
+    setContent {
+      ScrollGestureLockScope {
+        Box(Modifier.size(width = 400.dp, height = 800.dp)) {
+          Box(Modifier.testTag(BackgroundTag).fillMaxSize().clickable { backgroundClicks += 1 })
+          EditorResizableSheetSurface(
+            initialHeight = 360.dp,
+            minHeight = 240.dp,
+            dismissThreshold = 128.dp,
+            maxTopInset = 0.dp,
+            trustedImeBottomInset = 180.dp,
+            safeBottomInset = 0.dp,
+            editorFocused = true,
+            minKeyboardVisibleHeight = 240.dp,
+            onDismissed = {},
+            onGeometryChanged = {},
+          ) {
+            Box(Modifier.fillMaxSize())
+          }
+        }
+      }
+    }
+    waitForIdle()
+
+    onNodeWithTag(BackgroundTag).performTouchInput { click(Offset(x = center.x, y = 500f)) }
+    waitForIdle()
+
+    assertEquals(1, backgroundClicks)
+  }
+
   @Test
   fun closingSheetReleasesFocusAndCannotRegainIt() = runComposeUiTest {
     val sheetFocusRequester = FocusRequester()
@@ -46,7 +462,9 @@ class EditorResizableSheetSurfaceDesktopTest {
             minHeight = 240.dp,
             dismissThreshold = 128.dp,
             maxTopInset = 0.dp,
-            keyboardOcclusion = 0.dp,
+            trustedImeBottomInset = 0.dp,
+            safeBottomInset = 0.dp,
+            editorFocused = false,
             minKeyboardVisibleHeight = 0.dp,
             onDismissed = {},
             onGeometryChanged = {},
@@ -94,7 +512,9 @@ class EditorResizableSheetSurfaceDesktopTest {
             minHeight = 240.dp,
             dismissThreshold = 128.dp,
             maxTopInset = 0.dp,
-            keyboardOcclusion = 320.dp,
+            trustedImeBottomInset = 320.dp,
+            safeBottomInset = 0.dp,
+            editorFocused = false,
             minKeyboardVisibleHeight = 240.dp,
             onDismissStarted = { events += "start" },
             onDismissed = { events += "dismissed" },
@@ -125,7 +545,9 @@ class EditorResizableSheetSurfaceDesktopTest {
             minHeight = 240.dp,
             dismissThreshold = 128.dp,
             maxTopInset = 0.dp,
-            keyboardOcclusion = 320.dp,
+            trustedImeBottomInset = 320.dp,
+            safeBottomInset = 0.dp,
+            editorFocused = false,
             minKeyboardVisibleHeight = 240.dp,
             onDismissed = {},
             onGeometryChanged = {},
@@ -158,6 +580,67 @@ class EditorResizableSheetSurfaceDesktopTest {
   }
 
   @Test
+  fun dragTakesOverImmediatelyDuringKeyboardCapRestoration() = runComposeUiTest {
+    var editorFocused by mutableStateOf(true)
+    var geometry: EditorResizableSheetGeometry? = null
+
+    setContent {
+      ScrollGestureLockScope {
+        Box(Modifier.size(width = 400.dp, height = 800.dp)) {
+          EditorResizableSheetSurface(
+            initialHeight = 360.dp,
+            minHeight = 240.dp,
+            dismissThreshold = 128.dp,
+            maxTopInset = 0.dp,
+            trustedImeBottomInset = 180.dp,
+            safeBottomInset = 0.dp,
+            editorFocused = editorFocused,
+            minKeyboardVisibleHeight = 240.dp,
+            onDismissed = {},
+            onGeometryChanged = { geometry = it },
+          ) {
+            Box(
+              Modifier.testTag(IncrementalDragHandleTag)
+                .fillMaxWidth()
+                .height(72.dp)
+                .sheetDragHandle()
+            )
+          }
+        }
+      }
+    }
+    waitForIdle()
+    assertEquals(180f, checkNotNull(geometry).sheetHeight)
+
+    mainClock.autoAdvance = false
+    runOnIdle { editorFocused = false }
+    repeat(3) { mainClock.advanceTimeByFrame() }
+    val restoringHeight = checkNotNull(geometry).sheetHeight
+    assertTrue(restoringHeight in 180f..360f && restoringHeight != 180f && restoringHeight != 360f)
+
+    val handle = onNodeWithTag(IncrementalDragHandleTag)
+    handle.performTouchInput { down(center) }
+    try {
+      handle.performTouchInput { moveBy(Offset(x = 0f, y = 64f)) }
+      mainClock.advanceTimeByFrame()
+      waitForIdle()
+      val heightAfterDragStarted = checkNotNull(geometry).sheetHeight
+      assertTrue(
+        heightAfterDragStarted > restoringHeight,
+        "drag should take over from restoration immediately: $restoringHeight -> $heightAfterDragStarted",
+      )
+
+      handle.performTouchInput { moveBy(Offset(x = 0f, y = 12f)) }
+      mainClock.advanceTimeByFrame()
+      waitForIdle()
+      val heightAfterNextMove = checkNotNull(geometry).sheetHeight
+      assertEquals(12f, heightAfterDragStarted - heightAfterNextMove, absoluteTolerance = 1f)
+    } finally {
+      handle.performTouchInput { up() }
+    }
+  }
+
+  @Test
   fun incrementalTouchMovesResizeSheet() = runComposeUiTest {
     var geometry: EditorResizableSheetGeometry? = null
 
@@ -169,7 +652,9 @@ class EditorResizableSheetSurfaceDesktopTest {
             minHeight = 240.dp,
             dismissThreshold = 128.dp,
             maxTopInset = 0.dp,
-            keyboardOcclusion = 0.dp,
+            trustedImeBottomInset = 0.dp,
+            safeBottomInset = 0.dp,
+            editorFocused = false,
             minKeyboardVisibleHeight = 0.dp,
             onDismissed = {},
             onGeometryChanged = { geometry = it },
@@ -213,7 +698,9 @@ class EditorResizableSheetSurfaceDesktopTest {
             minHeight = 240.dp,
             dismissThreshold = 128.dp,
             maxTopInset = 0.dp,
-            keyboardOcclusion = 0.dp,
+            trustedImeBottomInset = 0.dp,
+            safeBottomInset = 0.dp,
+            editorFocused = false,
             minKeyboardVisibleHeight = 0.dp,
             onDismissed = {},
             onGeometryChanged = {},
@@ -232,7 +719,11 @@ class EditorResizableSheetSurfaceDesktopTest {
   }
 
   private companion object {
+    const val BackgroundTag = "background"
+    const val BottomPanelRevealDragHandleTag = "bottom-panel-reveal-drag-handle"
+    const val BottomPanelRevealTag = "bottom-panel-reveal"
     const val DismissButtonTag = "dismiss-button"
+    const val DragHandleChildButtonTag = "drag-handle-child-button"
     const val IncrementalDragHandleTag = "incremental-drag-handle"
     const val SheetDragHandleTag = "sheet-drag-handle"
     const val SheetSurfaceTag = "sheet-surface"

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/subpane/EditorSubPaneInputDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/subpane/EditorSubPaneInputDesktopTest.kt
@@ -1,0 +1,86 @@
+package co.typie.screen.editor.editor.subpane
+
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import co.typie.editor.Editor
+import co.typie.editor.FakeFfiEditor
+import co.typie.editor.ffi.Key as FfiKey
+import co.typie.editor.ffi.KeyEvent as FfiKeyEvent
+import co.typie.editor.ffi.Message
+import co.typie.editor.input.editorInput
+import co.typie.editor.runtime.EditorUiState
+import co.typie.editor.scroll.rememberEditorBringIntoViewRequests
+import co.typie.editor.sync.createTestDocumentEditingSession
+import co.typie.platform.NoopClipboard
+import co.typie.platform.Platform
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+
+@OptIn(ExperimentalTestApi::class)
+class EditorSubPaneInputDesktopTest {
+  @Test
+  fun commentsSubPaneDoesNotBlockFocusedEditorHardwareInput() = runComposeUiTest {
+    val fake = FakeFfiEditor()
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val editor = Editor(fake, scope)
+    val session = createTestDocumentEditingSession(editor, scope)
+    val subPaneState = EditorSubPaneState().apply { open(EditorSubPane.Comments) }
+
+    try {
+      setContent {
+        val focusRequester = remember { FocusRequester() }
+        val bringIntoViewRequests = rememberEditorBringIntoViewRequests()
+        Box(
+          Modifier.size(200.dp)
+            .testTag(EditorInputTag)
+            .focusRequester(focusRequester)
+            .editorInput(
+              session = session,
+              uiState = EditorUiState(),
+              platform = Platform.Desktop,
+              bringIntoViewRequests = bringIntoViewRequests,
+              enabled = !subPaneState.editorInputBlocked,
+              suppressSoftwareKeyboard = true,
+              clipboard = NoopClipboard,
+            )
+            .focusable()
+        )
+        LaunchedEffect(Unit) { focusRequester.requestFocus() }
+      }
+      waitForIdle()
+
+      onNodeWithTag(EditorInputTag).performKeyInput {
+        keyDown(Key.Backspace)
+        keyUp(Key.Backspace)
+      }
+
+      val backspace = Message.Key(FfiKeyEvent(FfiKey.Backspace))
+      waitUntil(timeoutMillis = 5_000) { fake.enqueued.contains(backspace) }
+      assertEquals(EditorSubPane.Comments, subPaneState.active)
+    } finally {
+      session.stop()
+      scope.cancel()
+    }
+  }
+
+  private companion object {
+    const val EditorInputTag = "editor-input-with-comments-subpane"
+  }
+}


### PR DESCRIPTION
- 노트/코멘트 subpane 열어놓고 에디터 편집 가능
- 소프트웨어 키보드나 바텀 패널 떠있을 때는 subpane이 툴바 위쪽으로 살짝 튀어나오는 정도로 사이즈가 임시 조정됨
- 읽기 모드로 전환해도 subpane이 dismiss되지 않도록 함