### PR TITLE
앱 subpane에서 새 노트/코멘트 생성 시 오토포커스

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteEditState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteEditState.kt
@@ -35,7 +35,15 @@ internal class NoteEditState(private val scope: CoroutineScope) {
 
   private var activeForm: ActiveNoteFormState? by mutableStateOf(null)
 
-  fun open(note: NoteCard_note, autoFocusContent: Boolean = false) {
+  fun open(note: NoteCard_note) {
+    open(note = note, autoFocusContent = false)
+  }
+
+  fun openNew(note: NoteCard_note) {
+    open(note = note, autoFocusContent = true)
+  }
+
+  private fun open(note: NoteCard_note, autoFocusContent: Boolean) {
     val currentForm = activeForm
     if (currentForm?.noteId == note.id && currentForm.siteId == note.site.id) {
       currentForm.commitServerSnapshot(note)

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/EditorResizableSheetSurface.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/EditorResizableSheetSurface.kt
@@ -89,6 +89,8 @@ internal fun resolveKeyboardAwareSheetMinHeight(
 internal interface EditorResizableSheetSurfaceScope {
   val keyboardOcclusion: Dp
 
+  fun requestFocus()
+
   fun dismiss()
 
   fun Modifier.sheetDragHandle(): Modifier
@@ -336,6 +338,10 @@ internal fun EditorResizableSheetSurface(
       object : EditorResizableSheetSurfaceScope {
         override val keyboardOcclusion: Dp
           get() = effectiveKeyboardOcclusion
+
+        override fun requestFocus() {
+          sheetFocusRequester.requestFocus()
+        }
 
         override fun dismiss() {
           requestDismiss()

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/comments/CommentTextInputs.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/comments/CommentTextInputs.kt
@@ -66,6 +66,7 @@ internal fun CommentComposer(
   onValueChange: (String) -> Unit,
   placeholder: String,
   submitting: Boolean,
+  autoFocus: Boolean = false,
   onFocusChange: (Boolean) -> Unit,
   onSubmit: (String) -> Unit,
 ) {
@@ -80,7 +81,7 @@ internal fun CommentComposer(
       shape = RoundedCornerShape(20.dp),
       maxLines = 5,
       contentPadding = PaddingValues(start = 14.dp, end = 44.dp, top = 10.dp, bottom = 10.dp),
-      autoFocus = false,
+      autoFocus = autoFocus,
       onFocusChange = onFocusChange,
     )
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/comments/CommentThreadComponents.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/comments/CommentThreadComponents.kt
@@ -198,6 +198,7 @@ internal fun VirtualCommentThreadRow(
       onValueChange = onValueChange,
       placeholder = "코멘트 추가...",
       submitting = submitting,
+      autoFocus = true,
       onFocusChange = onFocusChange,
       onSubmit = onSubmit,
     )

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/comments/CommentsSheet.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/comments/CommentsSheet.kt
@@ -145,6 +145,7 @@ internal fun CommentsSheet(
       onFreezeCurrentSelection = onFreezeCurrentSelection,
       ensureMutationSubscription = ensureMutationSubscription,
       onInputFocusChanged = onInputFocusChanged,
+      onRequestSheetFocus = { requestFocus() },
       onDismiss = ::dismiss,
       sheetDragHandleModifier = Modifier.sheetDragHandle(),
       model = model,
@@ -167,6 +168,7 @@ private fun CommentsSheetContent(
   onFreezeCurrentSelection: suspend () -> StableSelection?,
   ensureMutationSubscription: suspend () -> Boolean,
   onInputFocusChanged: (Boolean) -> Unit,
+  onRequestSheetFocus: () -> Unit,
   onDismiss: () -> Unit,
   sheetDragHandleModifier: Modifier,
   model: CommentsViewModel,
@@ -439,7 +441,10 @@ private fun CommentsSheetContent(
         createEnabled = createEnabled,
         onDismiss = onDismiss,
         onFilterSelect = { filter -> scope.launch { selectFilter(filter) } },
-        onCreate = { scope.launch { createVirtualThread(onFreezeCurrentSelection()) } },
+        onCreate = {
+          onRequestSheetFocus()
+          scope.launch { createVirtualThread(onFreezeCurrentSelection()) }
+        },
         modifier = sheetDragHandleModifier,
       )
     },

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/relatednotes/RelatedNotesSheet.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/relatednotes/RelatedNotesSheet.kt
@@ -194,6 +194,7 @@ internal fun RelatedNotesSheet(
       entityId = entityId,
       safeBottomInset = safeBottomInset,
       keyboardOcclusion = keyboardOcclusion,
+      onRequestSheetFocus = { requestFocus() },
       onDismiss = ::dismiss,
       sheetDragHandleModifier = Modifier.sheetDragHandle(),
       model = model,
@@ -210,6 +211,7 @@ private fun RelatedNotesSheetContent(
   entityId: String,
   safeBottomInset: Dp,
   keyboardOcclusion: Dp,
+  onRequestSheetFocus: () -> Unit,
   onDismiss: () -> Unit,
   sheetDragHandleModifier: Modifier,
   model: RelatedNotesViewModel,
@@ -265,7 +267,7 @@ private fun RelatedNotesSheetContent(
     model.updateFilterStatus(nextStatus)
   }
 
-  suspend fun handleCreateNote(request: NoteActionRequest, autoFocusContent: Boolean = false) {
+  suspend fun handleCreateNote(request: NoteActionRequest) {
     if (!noteActions.isCurrent(request)) return
     if (!SubscriptionService.gate(sheet, GatedAction.CreateNote)) {
       return
@@ -288,7 +290,7 @@ private fun RelatedNotesSheetContent(
           model.updateFilterStatus(NoteStatus.OPEN)
         }
         model.listState(NoteStatus.OPEN).markEntering(outcome.value)
-        noteEditState.open(note = outcome.value, autoFocusContent = autoFocusContent)
+        noteEditState.openNew(outcome.value)
         scrollStateFor(NoteStatus.OPEN).animateScrollToItem(0)
       }
 
@@ -304,7 +306,7 @@ private fun RelatedNotesSheetContent(
 
   fun handleShortcutCreateNote() {
     val request = noteActions.captureRequest() ?: return
-    scope.launch { handleCreateNote(request = request, autoFocusContent = true) }
+    scope.launch { handleCreateNote(request) }
   }
 
   suspend fun handleDeleteNote(note: NoteCard_note) {
@@ -538,6 +540,7 @@ private fun RelatedNotesSheetContent(
           }
         },
         onCreate = {
+          onRequestSheetFocus()
           noteActions.captureRequest()?.let { request ->
             scope.launch { handleCreateNote(request = request) }
           }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/notes/NotesScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/notes/NotesScreen.kt
@@ -236,7 +236,7 @@ fun NotesScreen() {
     model.updateFilterStatus(nextStatus)
   }
 
-  suspend fun handleCreateNote(request: NoteActionRequest, autoFocusContent: Boolean = false) {
+  suspend fun handleCreateNote(request: NoteActionRequest) {
     if (!noteActions.isCurrent(request)) return
     if (!SubscriptionService.gate(sheet, GatedAction.CreateNote)) {
       return
@@ -262,7 +262,7 @@ fun NotesScreen() {
           model.updateFilterStatus(NoteStatus.OPEN)
         }
         model.listState(NoteStatus.OPEN).markEntering(outcome.value)
-        noteEditState.open(note = outcome.value, autoFocusContent = autoFocusContent)
+        noteEditState.openNew(outcome.value)
         scrollStateFor(NoteStatus.OPEN).animateScrollToItem(0)
       }
 
@@ -278,7 +278,7 @@ fun NotesScreen() {
 
   fun handleShortcutCreateNote() {
     val request = noteActions.captureRequest() ?: return
-    scope.launch { handleCreateNote(request = request, autoFocusContent = true) }
+    scope.launch { handleCreateNote(request) }
   }
 
   suspend fun handleDeleteNote(note: NoteCard_note) {

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/domain/note/NoteEditStateTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/domain/note/NoteEditStateTest.kt
@@ -30,6 +30,26 @@ class NoteEditStateTest {
   }
 
   @Test
+  fun `opening an existing note does not request content autofocus`() = runTest {
+    val state = createNoteEditState()
+    val note = notesNote(id = "existing")
+
+    state.open(note)
+
+    assertFalse(state.shouldAutoFocusContent(siteId = note.site.id, noteId = note.id))
+  }
+
+  @Test
+  fun `opening a newly created note requests content autofocus`() = runTest {
+    val state = createNoteEditState()
+    val note = notesNote(id = "new")
+
+    state.openNew(note)
+
+    assertTrue(state.shouldAutoFocusContent(siteId = note.site.id, noteId = note.id))
+  }
+
+  @Test
   fun `debounced content save runs after delay`() = runTest {
     val state = createNoteEditState()
     val saved = mutableListOf<Pair<String, String>>()

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/EditorAuxiliaryFocusBoundaryDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/EditorAuxiliaryFocusBoundaryDesktopTest.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.v2.runComposeUiTest
 import co.typie.editor.runtime.EditorUiState
 import co.typie.screen.editor.editor.subpane.comments.CommentComposer
+import co.typie.screen.editor.editor.subpane.comments.VirtualCommentThreadRow
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
@@ -37,6 +38,19 @@ class EditorAuxiliaryFocusBoundaryDesktopTest {
     advanceUntil(fixture, BlurBoundaryExpired)
 
     fixture.assertAuxiliaryFocusPrecedesBlurBoundary()
+  }
+
+  @Test
+  fun virtualCommentComposerTakesFocusWhenMounted() = runComposeUiTest {
+    val fixture = FocusBoundaryFixture()
+    var showVirtualComment by mutableStateOf(false)
+    mainClock.autoAdvance = false
+
+    setContent { FocusBoundaryContent(fixture, showVirtualComment = showVirtualComment) }
+    advanceUntil(fixture, "observed:true")
+
+    runOnIdle { showVirtualComment = true }
+    advanceUntil(fixture, "auxiliary:true")
   }
 
   private fun androidx.compose.ui.test.ComposeUiTest.advanceUntil(
@@ -68,7 +82,10 @@ private class FocusBoundaryFixture {
 }
 
 @Composable
-private fun FocusBoundaryContent(fixture: FocusBoundaryFixture) {
+private fun FocusBoundaryContent(
+  fixture: FocusBoundaryFixture,
+  showVirtualComment: Boolean = false,
+) {
   val uiState = remember { EditorUiState() }
   var observedEditorFocusOnce by remember { mutableStateOf(false) }
 
@@ -95,14 +112,25 @@ private fun FocusBoundaryContent(fixture: FocusBoundaryFixture) {
     }
   }
 
-  CommentComposer(
-    value = "",
-    onValueChange = {},
-    placeholder = "코멘트 작성...",
-    submitting = false,
-    onFocusChange = { focused -> fixture.events += "auxiliary:$focused" },
-    onSubmit = {},
-  )
+  if (showVirtualComment) {
+    VirtualCommentThreadRow(
+      location = null,
+      value = "",
+      submitting = false,
+      onValueChange = {},
+      onFocusChange = { focused -> fixture.events += "auxiliary:$focused" },
+      onSubmit = {},
+    )
+  } else {
+    CommentComposer(
+      value = "",
+      onValueChange = {},
+      placeholder = "코멘트 작성...",
+      submitting = false,
+      onFocusChange = { focused -> fixture.events += "auxiliary:$focused" },
+      onSubmit = {},
+    )
+  }
 
   LaunchedEffect(Unit) { fixture.editorFocusRequester.requestFocus() }
 }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/subpane/EditorResizableSheetSurfaceDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/subpane/EditorResizableSheetSurfaceDesktopTest.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
@@ -32,6 +33,7 @@ import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.test.swipeWithVelocity
 import androidx.compose.ui.unit.dp
 import co.typie.ext.ScrollGestureLockScope
+import co.typie.ext.clickable as typieClickable
 import co.typie.ext.verticalScroll
 import co.typie.ui.theme.LocalHazeState
 import dev.chrisbanes.haze.HazeState
@@ -246,12 +248,71 @@ class EditorResizableSheetSurfaceDesktopTest {
   }
 
   @Test
-  fun dragHandleTapObserverPreservesChildClick() = runComposeUiTest {
-    var childClicks = 0
+  fun blankDragHandleTapFocusesSheetOnlyAfterPointerUp() = runComposeUiTest {
+    var backgroundFocused = false
 
     setContent {
       ScrollGestureLockScope {
+        val backgroundFocusRequester = remember { FocusRequester() }
         Box(Modifier.size(width = 400.dp, height = 800.dp)) {
+          Box(
+            Modifier.fillMaxSize()
+              .focusRequester(backgroundFocusRequester)
+              .onFocusChanged { backgroundFocused = it.isFocused }
+              .focusable()
+          )
+          EditorResizableSheetSurface(
+            initialHeight = 360.dp,
+            minHeight = 240.dp,
+            dismissThreshold = 128.dp,
+            maxTopInset = 0.dp,
+            trustedImeBottomInset = 0.dp,
+            safeBottomInset = 0.dp,
+            editorFocused = false,
+            minKeyboardVisibleHeight = 0.dp,
+            onDismissed = {},
+            onGeometryChanged = {},
+          ) {
+            Box(
+              Modifier.testTag(BlankDragHandleTag)
+                .fillMaxWidth()
+                .height(EditorSubPaneHeaderRevealHeight)
+                .sheetDragHandle()
+            )
+          }
+        }
+        LaunchedEffect(Unit) { backgroundFocusRequester.requestFocus() }
+      }
+    }
+    waitForIdle()
+    assertTrue(backgroundFocused)
+
+    val handle = onNodeWithTag(BlankDragHandleTag)
+    handle.performTouchInput { down(center) }
+    waitForIdle()
+    assertTrue(backgroundFocused, "pointer down alone must not focus the sheet")
+
+    handle.performTouchInput { up() }
+    waitForIdle()
+    assertEquals(false, backgroundFocused)
+  }
+
+  @Test
+  fun dragHandleChildCanRequestSheetFocusWithoutLosingClick() = runComposeUiTest {
+    var childClicks = 0
+    var backgroundFocused = false
+    var backgroundFocusedAtChildClick: Boolean? = null
+
+    setContent {
+      ScrollGestureLockScope {
+        val backgroundFocusRequester = remember { FocusRequester() }
+        Box(Modifier.size(width = 400.dp, height = 800.dp)) {
+          Box(
+            Modifier.fillMaxSize()
+              .focusRequester(backgroundFocusRequester)
+              .onFocusChanged { backgroundFocused = it.isFocused }
+              .focusable()
+          )
           EditorResizableSheetSurface(
             initialHeight = 360.dp,
             minHeight = 240.dp,
@@ -266,30 +327,44 @@ class EditorResizableSheetSurfaceDesktopTest {
           ) {
             Box(Modifier.fillMaxWidth().height(EditorSubPaneHeaderRevealHeight).sheetDragHandle()) {
               Box(
-                Modifier.testTag(DragHandleChildButtonTag).size(44.dp).clickable {
+                Modifier.testTag(DragHandleChildButtonTag).size(44.dp).typieClickable {
+                  requestFocus()
+                  backgroundFocusedAtChildClick = backgroundFocused
                   childClicks += 1
                 }
               )
             }
           }
         }
+        LaunchedEffect(Unit) { backgroundFocusRequester.requestFocus() }
       }
     }
     waitForIdle()
+    assertTrue(backgroundFocused)
 
     onNodeWithTag(DragHandleChildButtonTag).performTouchInput { click(center) }
     waitForIdle()
 
     assertEquals(1, childClicks)
+    assertEquals(false, backgroundFocusedAtChildClick)
   }
 
   @Test
   fun draggingBottomPanelRevealResizesFromTemporaryHeight() = runComposeUiTest {
     var geometry: EditorResizableSheetGeometry? = null
+    var backgroundFocused = false
+    var childClicks = 0
 
     setContent {
       ScrollGestureLockScope {
+        val backgroundFocusRequester = remember { FocusRequester() }
         Box(Modifier.size(width = 400.dp, height = 800.dp)) {
+          Box(
+            Modifier.fillMaxSize()
+              .focusRequester(backgroundFocusRequester)
+              .onFocusChanged { backgroundFocused = it.isFocused }
+              .focusable()
+          )
           EditorResizableSheetSurface(
             initialHeight = 600.dp,
             minHeight = 240.dp,
@@ -307,24 +382,31 @@ class EditorResizableSheetSurfaceDesktopTest {
             onDismissed = {},
             onGeometryChanged = { geometry = it },
           ) {
-            Box(
-              Modifier.testTag(BottomPanelRevealDragHandleTag)
-                .fillMaxWidth()
-                .height(72.dp)
-                .sheetDragHandle()
-            )
+            Box(Modifier.fillMaxWidth().height(72.dp).sheetDragHandle()) {
+              Box(
+                Modifier.testTag(BottomPanelRevealDragHandleTag).fillMaxSize().typieClickable {
+                  childClicks += 1
+                }
+              )
+            }
           }
         }
+        LaunchedEffect(Unit) { backgroundFocusRequester.requestFocus() }
       }
     }
     waitForIdle()
     assertEquals(398f, checkNotNull(geometry).sheetHeight)
+    assertTrue(backgroundFocused)
 
     val handle = onNodeWithTag(BottomPanelRevealDragHandleTag)
     handle.performTouchInput { down(center) }
     try {
+      waitForIdle()
+      assertTrue(backgroundFocused, "pointer down alone must not focus the sheet")
+
       handle.performTouchInput { moveBy(Offset(x = 0f, y = -64f)) }
       waitForIdle()
+      assertEquals(false, backgroundFocused)
       val heightAfterDragStarted = checkNotNull(geometry).sheetHeight
       assertTrue(
         heightAfterDragStarted in 398f..490f,
@@ -340,6 +422,7 @@ class EditorResizableSheetSurfaceDesktopTest {
     }
 
     waitForIdle()
+    assertEquals(0, childClicks)
     assertTrue(checkNotNull(geometry).sheetHeight in 406f..510f)
   }
 
@@ -720,6 +803,7 @@ class EditorResizableSheetSurfaceDesktopTest {
 
   private companion object {
     const val BackgroundTag = "background"
+    const val BlankDragHandleTag = "blank-drag-handle"
     const val BottomPanelRevealDragHandleTag = "bottom-panel-reveal-drag-handle"
     const val BottomPanelRevealTag = "bottom-panel-reveal"
     const val DismissButtonTag = "dismiss-button"


### PR DESCRIPTION
- 새 코멘트 생성 후 인풋에 자동으로 포커스
- 메인 노트 화면과 관련 노트 subpane에서 새 노트 생성 시 인풋에 자동으로 포커스
- 추가 버튼은 확정된 클릭에서 subpane으로 포커스를 전환
- 추가 버튼 위치에서 드래그하면 클릭을 취소하고, 임시로 노출된 높이부터 resize
- 기존 노트 열기와 일반 코멘트 답글 작성창의 포커스 정책은 유지