### PR TITLE
앱 노트 컬러 팔레트 UX 개선

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteCard.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteCard.kt
@@ -37,6 +37,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
@@ -90,6 +91,7 @@ import co.typie.ui.theme.AppTheme
 import co.typie.ui.utils.ShortcutModifier
 import co.typie.ui.utils.onShortcut
 import kotlin.math.abs
+import kotlinx.coroutines.withTimeoutOrNull
 
 private val NoteCardShape = AppShapes.rounded(AppShapes.md)
 private val NoteActionButtonSize = 24.dp
@@ -638,6 +640,7 @@ internal fun NoteColorPalette(
   val selectedColorState = rememberUpdatedState(selectedColor)
   val onColorChangeState = rememberUpdatedState(onColorChange)
   val hapticState = rememberUpdatedState(haptic)
+  val armedColorState = remember { mutableStateOf<String?>(null) }
   val optionWidthPx = with(density) { NoteColorDotHitTargetWidth.roundToPx().toFloat() }
 
   Row(
@@ -645,8 +648,12 @@ internal fun NoteColorPalette(
       modifier.height(NoteColorDotHitTargetHeight).pointerInput(noteColorOptions, optionWidthPx) {
         awaitEachGesture {
           val down = awaitFirstDown(requireUnconsumed = false)
+          armedColorState.value = null
           val touchSlop = viewConfiguration.touchSlop
           var lastSelectedColor = selectedColorState.value
+          var currentPosition = down.position
+          var elapsedMillis = 0L
+          var armed = false
           var scrubbing = false
 
           fun selectColorAt(x: Float) {
@@ -657,13 +664,41 @@ internal fun NoteColorPalette(
             }
 
             lastSelectedColor = nextColor
-            hapticState.value.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+            hapticState.value.performHapticFeedback(HapticFeedbackType.SegmentFrequentTick)
             onColorChangeState.value(nextColor)
           }
 
+          fun arm() {
+            armed = true
+            val previousColor = lastSelectedColor
+            selectColorAt(currentPosition.x)
+            armedColorState.value = lastSelectedColor.takeIf { it != previousColor }
+          }
+
           while (true) {
-            val event = awaitPointerEvent()
+            val event =
+              if (armed) {
+                awaitPointerEvent()
+              } else {
+                withTimeoutOrNull(
+                  (NoteColorPaletteScrubArmDelayMillis - elapsedMillis).coerceAtLeast(0L)
+                ) {
+                  awaitPointerEvent()
+                }
+              }
+
+            if (event == null) {
+              arm()
+              continue
+            }
+
             val change = event.changes.firstOrNull { it.id == down.id } ?: break
+            currentPosition = change.position
+            elapsedMillis = change.uptimeMillis - down.uptimeMillis
+            if (!armed && elapsedMillis >= NoteColorPaletteScrubArmDelayMillis) {
+              arm()
+            }
+
             if (!change.pressed) {
               break
             }
@@ -678,11 +713,7 @@ internal fun NoteColorPalette(
                 continue
               }
 
-              val elapsedMillis = change.uptimeMillis - down.uptimeMillis
-              if (
-                elapsedMillis < NoteColorPaletteScrubArmDelayMillis ||
-                  abs(offset.y) >= abs(offset.x)
-              ) {
+              if (!armed || abs(offset.y) >= abs(offset.x)) {
                 break
               }
 
@@ -700,7 +731,12 @@ internal fun NoteColorPalette(
       NoteColorDot(
         option = option,
         selected = option.value == selectedColor,
-        onClick = { onColorChange(option.value) },
+        onClick = {
+          if (armedColorState.value != option.value) {
+            onColorChange(option.value)
+          }
+          armedColorState.value = null
+        },
       )
     }
   }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/domain/note/NoteColorPaletteDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/domain/note/NoteColorPaletteDesktopTest.kt
@@ -10,10 +10,14 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.hapticfeedback.HapticFeedback
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.click
@@ -102,7 +106,61 @@ class NoteColorPaletteDesktopTest {
   }
 
   @Test
-  fun holdThenVerticalDragScrollsParentWithoutChangingColor() = runComposeUiTest {
+  fun armSelectsCurrentColorExactlyOnce() = runComposeUiTest {
+    val colors = mutableListOf<String>()
+
+    setContent { TestPalette(onColorChange = colors::add) }
+    waitForIdle()
+
+    val palette = onNodeWithTag(PaletteTag)
+    palette.performTouchInput { down(Offset(x = width / 2f, y = center.y)) }
+    runOnIdle { assertTrue(colors.isEmpty()) }
+
+    mainClock.advanceTimeBy(NoteColorPaletteScrubArmDelayMillis + 1L)
+    runOnIdle { assertContentEquals(listOf("red"), colors) }
+
+    palette.performTouchInput { up() }
+    waitForIdle()
+
+    assertContentEquals(listOf("red"), colors)
+  }
+
+  @Test
+  fun armAndScrubUseFrequentSegmentTickForEachColorChange() = runComposeUiTest {
+    val colors = mutableListOf<String>()
+    val haptics = mutableListOf<HapticFeedbackType>()
+    val hapticFeedback =
+      object : HapticFeedback {
+        override fun performHapticFeedback(hapticFeedbackType: HapticFeedbackType) {
+          haptics += hapticFeedbackType
+        }
+      }
+
+    setContent {
+      CompositionLocalProvider(LocalHapticFeedback provides hapticFeedback) {
+        TestPalette(onColorChange = colors::add)
+      }
+    }
+    waitForIdle()
+
+    onNodeWithTag(PaletteTag).performTouchInput {
+      down(Offset(x = width / 2f, y = center.y))
+      advanceEventTime(NoteColorPaletteScrubArmDelayMillis)
+      moveTo(Offset(x = width * 5f / 6f, y = center.y), delayMillis = 16L)
+      moveBy(Offset(x = 1f, y = 0f), delayMillis = 16L)
+      up()
+    }
+    waitForIdle()
+
+    assertContentEquals(listOf("red", "blue"), colors)
+    assertContentEquals(
+      listOf(HapticFeedbackType.SegmentFrequentTick, HapticFeedbackType.SegmentFrequentTick),
+      haptics,
+    )
+  }
+
+  @Test
+  fun holdThenVerticalDragSelectsArmColorAndScrollsParent() = runComposeUiTest {
     val colors = mutableListOf<String>()
     var scrollValue = 0
 
@@ -127,7 +185,7 @@ class NoteColorPaletteDesktopTest {
     waitForIdle()
 
     assertTrue(scrollValue > 0)
-    assertTrue(colors.isEmpty())
+    assertContentEquals(listOf("red"), colors)
   }
 
   @Test


### PR DESCRIPTION
- scrub 제스처가 arm될 때도 색상 변경
- scrub 제스처가 arm되었을 때 및 scrub으로 값이 바뀔 때 SegmentFrequentTick 햅틱 피드백 발생 (ActivityGrid와 동일. 기존에 사용하던 TextHandleMove 햅틱 타입은 iOS에서 no-op)