### PR TITLE
앱 크래시 workaround

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/shell/MainTabPager.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/shell/MainTabPager.kt
@@ -3,6 +3,12 @@ package co.typie.shell
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
@@ -18,14 +24,35 @@ internal fun MainTabPager(
   modifier: Modifier = Modifier,
   content: @Composable (Tab) -> Unit,
 ) {
+  val deferredUserScrollEnabled = rememberMainTabPagerUserScrollEnabled(userScrollEnabled)
   HorizontalPager(
     state = state,
     modifier = modifier,
-    userScrollEnabled = userScrollEnabled,
+    userScrollEnabled = deferredUserScrollEnabled,
     overscrollEffect = null,
   ) { page ->
     content(Tab.entries[page])
   }
+}
+
+@Composable
+private fun rememberMainTabPagerUserScrollEnabled(requested: Boolean): Boolean {
+  var enabledAfterFrame by remember { mutableStateOf(requested) }
+
+  LaunchedEffect(requested) {
+    if (!requested) {
+      enabledAfterFrame = false
+    } else if (!enabledAfterFrame) {
+      // Re-enabling the pager while a root pop disposes movable route content can invalidate the
+      // pager subcomposition in the same frame and crash Compose Runtime with a missing endGroup.
+      // TODO: Remove this one-frame workaround after updating to Compose Multiplatform 1.12 or
+      // later and verifying the root-pop flows without it on iOS and JVM Desktop.
+      withFrameNanos {}
+      enabledAfterFrame = true
+    }
+  }
+
+  return requested && enabledAfterFrame
 }
 
 internal fun mainTabActivationWeights(position: Float): Map<Tab, Float> =


### PR DESCRIPTION
## 문제

현재 탭의 navigation stack이 마지막 하위 route에서 root로 pop될 때 iOS와 JVM Desktop에서 Compose Runtime이 크래시

재현 경로:

- Space 삭제 후 자동 pop
- EditorScreen → DocumentScreen → 두 번 pop

공통 조건은 최종 pop에서 route의 movable content가 제거되는 동시에 `HorizontalPager.userScrollEnabled`가 다시 활성화되는 것. 이때 pager subcomposition과 route 정리가 같은 프레임에 겹치며 `Missed recording an endGroup` 오류가 발생

## 변경

- pager 비활성화는 즉시 반영하되, 다시 활성화할 때만 한 프레임 지연
- 이를 통해 route content 정리와 pager 재활성화가 같은 프레임에 겹치지 않도록 함

Compose Multiplatform 1.12 이상으로 업데이트한 뒤, workaround를 제거한 상태로 iOS와 JVM Desktop의 root-pop 경로를 재검증하고 제거해야 함