### PR TITLE
앱 MainTabPager가 활성화되어있을 때만 nested scroll을 처리하도록 함

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/shell/MainTabPager.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/shell/MainTabPager.kt
@@ -1,6 +1,8 @@
 package co.typie.shell
 
+import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerDefaults
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -25,10 +27,18 @@ internal fun MainTabPager(
   content: @Composable (Tab) -> Unit,
 ) {
   val deferredUserScrollEnabled = rememberMainTabPagerUserScrollEnabled(userScrollEnabled)
+  val defaultPageNestedScrollConnection =
+    PagerDefaults.pageNestedScrollConnection(state, Orientation.Horizontal)
   HorizontalPager(
     state = state,
     modifier = modifier,
     userScrollEnabled = deferredUserScrollEnabled,
+    pageNestedScrollConnection =
+      if (deferredUserScrollEnabled) {
+        defaultPageNestedScrollConnection
+      } else {
+        DisabledMainTabPagerNestedScrollConnection
+      },
     overscrollEffect = null,
   ) { page ->
     content(Tab.entries[page])
@@ -54,6 +64,8 @@ private fun rememberMainTabPagerUserScrollEnabled(requested: Boolean): Boolean {
 
   return requested && enabledAfterFrame
 }
+
+private data object DisabledMainTabPagerNestedScrollConnection : NestedScrollConnection
 
 internal fun mainTabActivationWeights(position: Float): Map<Tab, Float> =
   Tab.entries.associateWith { tab -> (1f - abs(position - tab.ordinal)).coerceIn(0f, 1f) }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/shell/MainTabPagerDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/shell/MainTabPagerDesktopTest.kt
@@ -8,8 +8,13 @@ import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollDispatcher
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.testTag
@@ -17,10 +22,12 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
 
 @OptIn(ExperimentalTestApi::class)
 class MainTabPagerDesktopTest {
@@ -94,6 +101,55 @@ class MainTabPagerDesktopTest {
   }
 
   @Test
+  fun `disabled pager is transparent to descendant side effects`() = runComposeUiTest {
+    lateinit var pagerState: PagerState
+    lateinit var nestedScrollDispatcher: NestedScrollDispatcher
+
+    setContent {
+      pagerState = rememberPagerState(pageCount = { Tab.entries.size })
+      nestedScrollDispatcher = remember { NestedScrollDispatcher() }
+      MainTabPager(
+        state = pagerState,
+        userScrollEnabled = false,
+        modifier = Modifier.size(width = 320.dp, height = 640.dp),
+      ) { tab ->
+        Box(
+          Modifier.fillMaxSize()
+            .then(
+              if (tab == Tab.Home) {
+                Modifier.nestedScroll(NoOpNestedScrollConnection, nestedScrollDispatcher)
+              } else {
+                Modifier
+              }
+            )
+        )
+      }
+    }
+    waitForIdle()
+
+    var postScrollConsumed = Offset.Unspecified
+    var postFlingConsumed = Velocity(Float.NaN, Float.NaN)
+    runOnIdle {
+      postScrollConsumed =
+        nestedScrollDispatcher.dispatchPostScroll(
+          consumed = Offset(x = 0f, y = -12f),
+          available = Offset(x = -8f, y = 0f),
+          source = NestedScrollSource.SideEffect,
+        )
+      postFlingConsumed = runBlocking {
+        nestedScrollDispatcher.dispatchPostFling(
+          consumed = Velocity(x = 0f, y = -200f),
+          available = Velocity(x = -100f, y = 0f),
+        )
+      }
+    }
+
+    assertEquals(Offset.Zero, postScrollConsumed)
+    assertEquals(Velocity.Zero, postFlingConsumed)
+    assertEquals(0f, pagerState.currentPageOffsetFraction)
+  }
+
+  @Test
   fun `child pager keeps an outward edge drag from the main pager`() = runComposeUiTest {
     lateinit var mainPagerState: PagerState
     lateinit var childPagerState: PagerState
@@ -136,5 +192,6 @@ class MainTabPagerDesktopTest {
     const val ChromeTag = "main-tab-fixed-chrome"
     const val ChildPagerTag = "main-tab-child-pager"
     const val PagerTag = "main-tab-pager"
+    val NoOpNestedScrollConnection = object : NestedScrollConnection {}
   }
 }


### PR DESCRIPTION
## 문제

메인 탭 `HorizontalPager`는 `userScrollEnabled=false`인 화면에서도 기본
`pageNestedScrollConnection`이 계속 활성화되어 있었습니다.

그 결과 에디터나 텍스트 툴바처럼 하위 요소가 fling하는 동안 수평 잔여 델타가 발생하면
바깥 pager가 `CancellationException("Scroll cancelled")`을 발생시켰습니다. iOS에서는 이
예외가 fling 종료처럼 처리되어, 드래그는 동작하지만 손을 놓은 뒤 관성이 사라졌습니다.

## 변경

- 메인 탭 스와이프가 활성화된 경우에는 기존 pager nested-scroll 정책을 유지합니다.
- 스와이프가 비활성화된 경우에는 no-op connection을 사용해 하위 scroll과 fling에
개입하지 않도록 했습니다.
- 에디터나 툴바에 개별 예외 처리를 추가하지 않고, 문제를 만든 바깥 pager의 정책만
수정했습니다.
- 기존 툴바 hard-stop, overscroll 및 메인 탭 직접 스와이프 동작은 변경하지 않았습니다.