### PR TITLE
크래시 workaround 주석 업데이트

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/shell/MainTabPager.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/shell/MainTabPager.kt
@@ -55,8 +55,9 @@ private fun rememberMainTabPagerUserScrollEnabled(requested: Boolean): Boolean {
     } else if (!enabledAfterFrame) {
       // Re-enabling the pager while a root pop disposes movable route content can invalidate the
       // pager subcomposition in the same frame and crash Compose Runtime with a missing endGroup.
-      // TODO: Remove this one-frame workaround after updating to Compose Multiplatform 1.12 or
-      // later and verifying the root-pop flows without it on iOS and JVM Desktop.
+      // TODO: Remove this one-frame workaround after upgrading to a Compose Multiplatform release
+      // where the root-pop flows no longer crash without it on iOS and JVM Desktop. The crash still
+      // reproduces on Compose Multiplatform 1.12.0-beta03.
       withFrameNanos {}
       enabledAfterFrame = true
     }


### PR DESCRIPTION
#5164 픽스는 Compose 1.12 에서도 재현되므로 주석을 업데이트하고 workaround는 계속 남겨둠