### PR TITLE
앱 노트/코멘트 subpane 헤더와 safe area 개선

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationTopBarBackdrop.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationTopBarBackdrop.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.platform.testTag
+import co.typie.ui.component.TypieProgressiveBlurEffect
 import co.typie.ui.component.topbar.LocalTopBarAnimationSource
 import co.typie.ui.component.topbar.TopBarDefaults
 import dev.chrisbanes.haze.ExperimentalHazeApi
@@ -63,7 +64,7 @@ internal fun NavigationTopBarBackdrop(
 
   val topPadding = TopBarDefaults.topPadding()
   val blurEffect = remember {
-    TypieTopBarProgressiveBlurEffect(
+    TypieProgressiveBlurEffect(
       blurRadius = TopBarDefaults.BlurRadius,
       progressiveBrush = navigationTopBarProgressiveBrush(Color.Black),
       fallbackProgressive = TopBarDefaults.hazeProgressive(),

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/EditorResizableSheetSurface.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/EditorResizableSheetSurface.kt
@@ -58,6 +58,9 @@ internal data class EditorResizableSheetGeometry(
 
 private const val EditorSubPaneHazeZIndex = 1f
 internal val EditorSubPaneBarHeight = SheetBarDefaults.SlotWidth
+private val EditorSubPaneBodyTopSpacing = 12.dp
+internal val EditorSubPaneContentTopPadding =
+  SheetHandleContainerHeight + EditorSubPaneBarHeight + EditorSubPaneBodyTopSpacing
 private val EditorSubPaneHeaderBottomClearance = 4.dp
 internal val EditorSubPaneHeaderRevealHeight =
   SheetHandleContainerHeight + EditorSubPaneBarHeight + EditorSubPaneHeaderBottomClearance

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/comments/CommentsSheet.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/comments/CommentsSheet.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -42,6 +41,7 @@ import co.typie.result.Result
 import co.typie.screen.editor.editor.subpane.EditorResizableSheetSurface
 import co.typie.screen.editor.editor.subpane.EditorSubPane
 import co.typie.screen.editor.editor.subpane.EditorSubPaneBarHeight
+import co.typie.screen.editor.editor.subpane.EditorSubPaneContentTopPadding
 import co.typie.screen.editor.editor.subpane.EditorSubPaneForegroundOcclusion
 import co.typie.screen.editor.editor.subpane.EditorSubPaneLayoutInfo
 import co.typie.screen.editor.editor.subpane.resolveResizableSubPaneVisibleAreaMode
@@ -433,6 +433,7 @@ private fun CommentsSheetContent(
     bodyScroll = false,
     handleModifier = sheetDragHandleModifier,
     includeBottomInset = false,
+    overlayHeader = true,
     padding = SheetPadding(header = PaddingValues(horizontal = 16.dp), body = PaddingValues(0.dp)),
     header = {
       CommentsSheetBar(
@@ -451,12 +452,20 @@ private fun CommentsSheetContent(
   ) {
     Crossfade(
       targetState = state.filter,
-      modifier = Modifier.fillMaxSize().padding(bottom = safeBottomInset + keyboardOcclusion),
+      modifier = Modifier.fillMaxSize(),
       animationSpec = tween(durationMillis = 200),
     ) { filter ->
       val threads = model.threads(filter)
       Column(
-        modifier = Modifier.fillMaxSize().verticalScroll(scrollState).padding(horizontal = 16.dp),
+        modifier =
+          Modifier.fillMaxSize()
+            .verticalScroll(scrollState)
+            .padding(
+              start = 16.dp,
+              top = EditorSubPaneContentTopPadding,
+              end = 16.dp,
+              bottom = safeBottomInset + keyboardOcclusion + CommentsListBottomContentPadding,
+            ),
         verticalArrangement = Arrangement.spacedBy(10.dp),
       ) {
         when (val queryState = model.queryState(filter)) {
@@ -530,8 +539,6 @@ private fun CommentsSheetContent(
             )
           }
         }
-
-        Spacer(Modifier.height(CommentsListBottomContentPadding))
       }
     }
   }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/relatednotes/RelatedNotesSheet.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/relatednotes/RelatedNotesSheet.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -62,6 +61,7 @@ import co.typie.route.Route
 import co.typie.screen.editor.editor.subpane.EditorResizableSheetSurface
 import co.typie.screen.editor.editor.subpane.EditorSubPane
 import co.typie.screen.editor.editor.subpane.EditorSubPaneBarHeight
+import co.typie.screen.editor.editor.subpane.EditorSubPaneContentTopPadding
 import co.typie.screen.editor.editor.subpane.EditorSubPaneForegroundOcclusion
 import co.typie.screen.editor.editor.subpane.EditorSubPaneLayoutInfo
 import co.typie.screen.editor.editor.subpane.resolveResizableSubPaneVisibleAreaMode
@@ -529,6 +529,7 @@ private fun RelatedNotesSheetContent(
     bodyScroll = false,
     handleModifier = sheetDragHandleModifier,
     includeBottomInset = false,
+    overlayHeader = true,
     padding = SheetPadding(header = PaddingValues(horizontal = 16.dp), body = PaddingValues(0.dp)),
     header = {
       RelatedNotesSheetBar(
@@ -551,7 +552,7 @@ private fun RelatedNotesSheetContent(
   ) {
     Crossfade(
       targetState = model.filterStatus,
-      modifier = Modifier.fillMaxSize().padding(bottom = safeBottomInset + keyboardOcclusion),
+      modifier = Modifier.fillMaxSize(),
       animationSpec = tween(durationMillis = 200),
     ) { status ->
       val sceneScrollState = scrollStateFor(status)
@@ -628,8 +629,13 @@ private fun RelatedNotesSheetContent(
             contentEditable = SubscriptionService.entitlement.grantsAccess(),
             actions = listActions,
             modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(horizontal = 16.dp),
-            footer = { Spacer(Modifier.height(RelatedNotesListBottomContentPadding)) },
+            contentPadding =
+              PaddingValues(
+                start = 16.dp,
+                top = EditorSubPaneContentTopPadding,
+                end = 16.dp,
+                bottom = safeBottomInset + keyboardOcclusion + RelatedNotesListBottomContentPadding,
+              ),
           )
         }
       }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/TypieProgressiveBlurEffect.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/TypieProgressiveBlurEffect.kt
@@ -1,4 +1,4 @@
-package co.typie.navigation
+package co.typie.ui.component
 
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.snapshots.Snapshot
@@ -38,14 +38,14 @@ import dev.chrisbanes.haze.isRuntimeShaderRenderEffectSupported
 import dev.chrisbanes.haze.then
 
 /**
- * Top-bar-only workaround for Haze's quantized progressive blur radius.
+ * Workaround for Haze's quantized progressive blur radius.
  *
  * Remove this effect when the adopted Haze version provides continuous fractional-radius
- * progressive blur and the Desktop regression passes with its built-in effect.
+ * progressive blur and the focused pixel regressions pass with its built-in effect.
  */
 @Stable
 @OptIn(ExperimentalHazeApi::class, InternalHazeApi::class)
-internal class TypieTopBarProgressiveBlurEffect(
+internal class TypieProgressiveBlurEffect(
   private val blurRadius: Dp,
   private val progressiveBrush: Brush,
   fallbackProgressive: HazeProgressive,
@@ -248,7 +248,7 @@ private fun createProgressiveBlurRenderEffect(
 
 private fun Brush.toShader(size: Size): Shader =
   requireNotNull((this as? ShaderBrush)?.createShader(size)) {
-    "Top bar progressive blur requires a ShaderBrush"
+    "Progressive blur requires a ShaderBrush"
   }
 
 // Adapted from Haze 2.0.0-alpha03's HazeBlurShaders under Apache-2.0.

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/sheet/SheetLayout.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/sheet/SheetLayout.kt
@@ -17,19 +17,36 @@ import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import co.typie.ext.ime
 import co.typie.ext.navigationBars
 import co.typie.ext.thenIf
 import co.typie.ext.verticalScroll
+import co.typie.ui.component.SmootherstepEasing
+import co.typie.ui.component.TypieProgressiveBlurEffect
 import co.typie.ui.state.rememberScrollState
 import co.typie.ui.theme.AppShapes
 import co.typie.ui.theme.AppTheme
+import dev.chrisbanes.haze.ExperimentalHazeApi
+import dev.chrisbanes.haze.blur.HazeProgressive
+import dev.chrisbanes.haze.hazeEffect
+import dev.chrisbanes.haze.hazeSource
+import dev.chrisbanes.haze.rememberHazeState
+
+private const val SheetOverlayHeaderFadeSamples = 48
+private val SheetOverlayHeaderBlurRadius = 4.dp
+private val SheetOverlayHeaderFadeHeight = 12.dp
+private const val SheetOverlayHeaderTintOpacity = 0.84f
 
 @Immutable
 data class SheetPadding(
@@ -48,6 +65,7 @@ data class SheetPadding(
 }
 
 @Composable
+@OptIn(ExperimentalHazeApi::class)
 fun SheetLayout(
   modifier: Modifier = Modifier,
   fillHeight: Boolean = false,
@@ -55,6 +73,7 @@ fun SheetLayout(
   handle: Boolean = true,
   handleModifier: Modifier = Modifier,
   includeBottomInset: Boolean = true,
+  overlayHeader: Boolean = false,
   padding: SheetPadding = SheetPadding(),
   verticalSpacing: Dp = 12.dp,
   backgroundColor: Color = AppTheme.colors.surfaceCanvas,
@@ -67,20 +86,12 @@ fun SheetLayout(
   val bottomInsets =
     if (includeBottomInset) WindowInsets.navigationBars.union(WindowInsets.ime) else null
 
-  Column(modifier = modifier.fillMaxWidth().thenIf(fillHeight) { fillMaxHeight() }) {
-    if (handle) SheetHandle(modifier = handleModifier.background(headerBackgroundColor))
+  val layoutModifier = modifier.fillMaxWidth().thenIf(fillHeight) { fillMaxHeight() }
 
-    if (header != null) {
-      Column(
-        modifier =
-          Modifier.fillMaxWidth().background(headerBackgroundColor).padding(padding.header),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
-        content = header,
-      )
-    }
-
-    Column(modifier = Modifier.background(backgroundColor)) {
-      Spacer(Modifier.height(verticalSpacing))
+  @Composable
+  fun SheetBody(modifier: Modifier, includeTopSpacing: Boolean) {
+    Column(modifier = modifier) {
+      if (includeTopSpacing) Spacer(Modifier.height(verticalSpacing))
 
       Box(
         modifier =
@@ -92,9 +103,8 @@ fun SheetLayout(
         Column(
           modifier = Modifier.fillMaxWidth().thenIf(fillHeight && !bodyScroll) { fillMaxHeight() },
           verticalArrangement = Arrangement.spacedBy(verticalSpacing),
-        ) {
-          body()
-        }
+          content = body,
+        )
       }
 
       if (footer != null || bottomInsets != null) {
@@ -114,6 +124,88 @@ fun SheetLayout(
       }
     }
   }
+
+  if (overlayHeader) {
+    val headerHazeState = rememberHazeState()
+    val headerBackgroundColorState = rememberUpdatedState(headerBackgroundColor)
+    val blurEffect = remember {
+      TypieProgressiveBlurEffect(
+        blurRadius = SheetOverlayHeaderBlurRadius,
+        progressiveBrush = sheetOverlayHeaderProgressiveBrush(Color.Black),
+        fallbackProgressive =
+          HazeProgressive.verticalGradient(
+            easing = SmootherstepEasing,
+            startIntensity = 1f,
+            endIntensity = 0f,
+          ),
+        backgroundColor = { headerBackgroundColorState.value },
+      )
+    }
+    val tintBrush =
+      remember(headerBackgroundColor) {
+        sheetOverlayHeaderProgressiveBrush(
+          headerBackgroundColor.copy(alpha = SheetOverlayHeaderTintOpacity)
+        )
+      }
+
+    Box(modifier = layoutModifier.background(backgroundColor)) {
+      SheetBody(
+        modifier =
+          Modifier.fillMaxWidth()
+            .thenIf(fillHeight) { fillMaxHeight() }
+            .background(backgroundColor)
+            .hazeSource(headerHazeState),
+        includeTopSpacing = false,
+      )
+
+      Column(
+        modifier =
+          Modifier.fillMaxWidth()
+            .hazeEffect(headerHazeState) { visualEffect = blurEffect }
+            .drawBehind { drawRect(tintBrush) }
+            .pointerInput(Unit) {}
+      ) {
+        if (handle) SheetHandle(modifier = handleModifier)
+
+        if (header != null) {
+          Column(
+            modifier = Modifier.fillMaxWidth().padding(padding.header),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            content = header,
+          )
+        }
+
+        Spacer(Modifier.height(SheetOverlayHeaderFadeHeight))
+      }
+    }
+    return
+  }
+
+  Column(modifier = layoutModifier) {
+    if (handle) SheetHandle(modifier = handleModifier.background(headerBackgroundColor))
+
+    if (header != null) {
+      Column(
+        modifier =
+          Modifier.fillMaxWidth().background(headerBackgroundColor).padding(padding.header),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        content = header,
+      )
+    }
+
+    SheetBody(modifier = Modifier.background(backgroundColor), includeTopSpacing = true)
+  }
+}
+
+private fun sheetOverlayHeaderProgressiveBrush(color: Color): Brush {
+  val stops =
+    Array(SheetOverlayHeaderFadeSamples + 1) { index ->
+      val t = index / SheetOverlayHeaderFadeSamples.toFloat()
+      val alpha = color.alpha * (1f - SmootherstepEasing.transform(t))
+      t to color.copy(alpha = alpha)
+    }
+
+  return Brush.verticalGradient(colorStops = stops)
 }
 
 private val HandleTopPadding = 8.dp

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/sheet/SheetLayoutDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/sheet/SheetLayoutDesktopTest.kt
@@ -1,13 +1,22 @@
 package co.typie.ui.component.sheet
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.draggable
+import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -17,6 +26,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
@@ -24,11 +34,14 @@ import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.click
 import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.hasScrollAction
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.dp
 import co.typie.dev.DesktopDebugKeyboard
@@ -312,6 +325,73 @@ class SheetLayoutDesktopTest {
   }
 
   @Test
+  fun overlayHeaderKeepsFullBodyViewportWhileContentScrollsBehindIt() = runComposeUiTest {
+    setContent {
+      SheetLayoutTestTheme {
+        Box(Modifier.size(width = 400.dp, height = 320.dp)) { OverlayHeaderSheet() }
+      }
+    }
+    waitForIdle()
+
+    val layoutBounds = onNodeWithTag(OverlayLayoutTag).fetchSemanticsNode().boundsInRoot
+    val viewportBounds = onNodeWithTag(OverlayViewportTag).fetchSemanticsNode().boundsInRoot
+    val initialHeaderBounds = onNodeWithTag(OverlayHeaderTag).fetchSemanticsNode().boundsInRoot
+    val initialMarkerBounds =
+      onNodeWithTag(OverlayMarkerTag, useUnmergedTree = true).fetchSemanticsNode().boundsInRoot
+
+    assertEquals(layoutBounds.top, viewportBounds.top, absoluteTolerance = 0.5f)
+    assertEquals(layoutBounds.bottom, viewportBounds.bottom, absoluteTolerance = 0.5f)
+    assertTrue(initialMarkerBounds.top >= initialHeaderBounds.bottom)
+
+    val scrollNode = onNodeWithTag(OverlayViewportTag)
+    scrollNode.performSemanticsAction(SemanticsActions.ScrollBy) { action ->
+      assertTrue(action(0f, 120f))
+    }
+    waitUntil(timeoutMillis = 5_000) { scrollNode.verticalScrollValue() > 0f }
+
+    val currentHeaderBounds = onNodeWithTag(OverlayHeaderTag).fetchSemanticsNode().boundsInRoot
+    val currentMarkerBounds =
+      onNodeWithTag(OverlayMarkerTag, useUnmergedTree = true).fetchSemanticsNode().boundsInRoot
+    assertEquals(initialHeaderBounds.top, currentHeaderBounds.top, absoluteTolerance = 0.5f)
+    assertTrue(currentMarkerBounds.top < currentHeaderBounds.bottom)
+  }
+
+  @Test
+  fun overlayHeaderBlocksBodyClicksWhilePreservingControlsAndDrag() = runComposeUiTest {
+    var bodyClicks = 0
+    var headerClicks = 0
+    var draggedBy = 0f
+
+    setContent {
+      SheetLayoutTestTheme {
+        Box(Modifier.size(width = 400.dp, height = 320.dp)) {
+          OverlayHeaderSheet(
+            onBodyClick = { bodyClicks += 1 },
+            onHeaderClick = { headerClicks += 1 },
+            onDrag = { draggedBy += it },
+          )
+        }
+      }
+    }
+    waitForIdle()
+
+    onNodeWithTag(OverlayHeaderTag).performTouchInput {
+      click(Offset(x = width - 20f, y = center.y))
+    }
+    onNodeWithTag(OverlayHeaderControlTag).performClick()
+    onNodeWithTag(OverlayHandleTag).performTouchInput {
+      down(center)
+      moveBy(Offset(x = 0f, y = 48f))
+      up()
+    }
+    waitForIdle()
+
+    assertEquals(0, bodyClicks)
+    assertEquals(1, headerClicks)
+    assertTrue(draggedBy > 0f)
+  }
+
+  @Test
   fun shortSheetDoesNotScrollWhenFocusedFieldRemainsVisible() = runComposeUiTest {
     val sheet = Sheet()
     val requestFocus = mutableStateOf(false)
@@ -446,6 +526,47 @@ class SheetLayoutDesktopTest {
   }
 
   @Composable
+  private fun OverlayHeaderSheet(
+    onBodyClick: () -> Unit = {},
+    onHeaderClick: () -> Unit = {},
+    onDrag: (Float) -> Unit = {},
+  ) {
+    val scrollState = rememberScrollState()
+    val dragState = rememberDraggableState(onDelta = onDrag)
+
+    SheetLayout(
+      modifier = Modifier.testTag(OverlayLayoutTag).fillMaxSize(),
+      fillHeight = true,
+      bodyScroll = false,
+      includeBottomInset = false,
+      overlayHeader = true,
+      handleModifier =
+        Modifier.testTag(OverlayHandleTag)
+          .draggable(state = dragState, orientation = Orientation.Vertical),
+      padding =
+        SheetPadding(header = PaddingValues(horizontal = 16.dp), body = PaddingValues(0.dp)),
+      header = {
+        Box(Modifier.testTag(OverlayHeaderTag).fillMaxWidth().height(44.dp)) {
+          Box(
+            Modifier.testTag(OverlayHeaderControlTag).size(44.dp).clickable(onClick = onHeaderClick)
+          )
+        }
+      },
+    ) {
+      Column(
+        Modifier.testTag(OverlayViewportTag)
+          .fillMaxSize()
+          .verticalScroll(scrollState)
+          .clickable(onClick = onBodyClick)
+          .padding(top = 76.dp)
+      ) {
+        Box(Modifier.testTag(OverlayMarkerTag).fillMaxWidth().height(44.dp))
+        Spacer(Modifier.fillMaxWidth().height(800.dp))
+      }
+    }
+  }
+
+  @Composable
   context(_: SheetScope<Unit>)
   private fun ShortSheet(requestFocus: Boolean, onClearFocusChanged: (() -> Unit) -> Unit) {
     SheetLayout(
@@ -511,6 +632,12 @@ class SheetLayoutDesktopTest {
     const val FixedHeaderTag = "fixed-slots-sheet-header"
     const val FixedFooterTag = "fixed-slots-sheet-footer"
     const val BodyMarkerTag = "fixed-slots-sheet-body-marker"
+    const val OverlayLayoutTag = "overlay-header-sheet-layout"
+    const val OverlayViewportTag = "overlay-header-sheet-viewport"
+    const val OverlayHeaderTag = "overlay-header-sheet-header"
+    const val OverlayHeaderControlTag = "overlay-header-sheet-control"
+    const val OverlayHandleTag = "overlay-header-sheet-handle"
+    const val OverlayMarkerTag = "overlay-header-sheet-marker"
     const val ShortRootTag = "short-sheet-root"
     const val ShortLayoutTag = "short-sheet-layout"
     const val ShortFieldTag = "short-sheet-field"


### PR DESCRIPTION
- 노트/코멘트 subpane에서 하단 safe area만큼 시트 뷰포트가 줄어들어서 내용 하단이 clip된 것처럼 보이고 있었음. safe area padding을 콘텐츠 내부로 옮김
- SheetLayout에 overlayHeader 모드를 추가하고 subpane에 적용함