### PR TITLE
iOS 에디터 입력 디버그

### DIFF
--- a/apps/mobile/compose/src/iosMain/kotlin/co/typie/editor/input/EditorInput.ios.kt
+++ b/apps/mobile/compose/src/iosMain/kotlin/co/typie/editor/input/EditorInput.ios.kt
@@ -9,12 +9,18 @@ import androidx.compose.ui.platform.PlatformTextInputMethodRequest
 import androidx.compose.ui.platform.PlatformTextInputSessionScope
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.CommitTextCommand
+import androidx.compose.ui.text.input.DeleteSurroundingTextInCodePointsCommand
 import androidx.compose.ui.text.input.EditCommand
+import androidx.compose.ui.text.input.FinishComposingTextCommand
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.ImeOptions
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PlatformImeOptions
+import androidx.compose.ui.text.input.SetComposingRegionCommand
+import androidx.compose.ui.text.input.SetComposingTextCommand
+import androidx.compose.ui.text.input.SetSelectionCommand
 import androidx.compose.ui.text.input.TextEditingScope
 import androidx.compose.ui.text.input.TextEditorState
 import androidx.compose.ui.text.input.TextFieldValue
@@ -121,7 +127,41 @@ internal actual suspend fun PlatformTextInputSessionScope.createEditorInputReque
           value().text.subSequence(startIndex, endIndex)
       }
 
-    override val editText: (block: TextEditingScope.() -> Unit) -> Unit = { _ -> }
+    override val editText: (block: TextEditingScope.() -> Unit) -> Unit = { block ->
+      val commands = mutableListOf<EditCommand>()
+      val scope =
+        object : TextEditingScope {
+          override fun deleteSurroundingTextInCodePoints(
+            lengthBeforeCursor: Int,
+            lengthAfterCursor: Int,
+          ) {
+            commands +=
+              DeleteSurroundingTextInCodePointsCommand(lengthBeforeCursor, lengthAfterCursor)
+          }
+
+          override fun setSelection(start: Int, end: Int) {
+            commands += SetSelectionCommand(start, end)
+          }
+
+          override fun commitText(text: CharSequence, newCursorPosition: Int) {
+            commands += CommitTextCommand(text.toString(), newCursorPosition)
+          }
+
+          override fun setComposingRegion(start: Int, end: Int) {
+            commands += SetComposingRegionCommand(start, end)
+          }
+
+          override fun setComposingText(text: CharSequence, newCursorPosition: Int) {
+            commands += SetComposingTextCommand(text.toString(), newCursorPosition)
+          }
+
+          override fun finishComposingText() {
+            commands += FinishComposingTextCommand()
+          }
+        }
+      scope.block()
+      onEditCommand(commands)
+    }
   }
 }
 

--- a/apps/mobile/compose/src/iosTest/kotlin/co/typie/editor/input/EditorInputRequestIosTest.kt
+++ b/apps/mobile/compose/src/iosTest/kotlin/co/typie/editor/input/EditorInputRequestIosTest.kt
@@ -1,0 +1,55 @@
+@file:OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
+
+package co.typie.editor.input
+
+import androidx.compose.ui.platform.PlatformTextInputMethodRequest
+import androidx.compose.ui.platform.PlatformTextInputSessionScope
+import androidx.compose.ui.text.input.CommitTextCommand
+import androidx.compose.ui.text.input.EditCommand
+import co.typie.editor.Editor
+import co.typie.editor.FakeFfiEditor
+import co.typie.editor.scroll.EditorBringIntoViewRequests
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
+
+class EditorInputRequestIosTest {
+  @Test
+  fun nativeEditBlockDispatchesEditCommands() {
+    val editorScope = CoroutineScope(EmptyCoroutineContext)
+    val editor = Editor(FakeFfiEditor(), editorScope)
+    val dispatched = mutableListOf<List<EditCommand>>()
+    try {
+      val request =
+        kotlinx.coroutines.runBlocking {
+          TestTextInputSessionScope.createEditorInputRequest(
+            editor = editor,
+            bringIntoViewRequests = EditorBringIntoViewRequests(),
+            onEditCommand = dispatched::add,
+            focusedRectInRoot = { null },
+            textFieldRectInRoot = { null },
+            textClippingRectInRoot = { null },
+            suppressSoftwareKeyboard = false,
+            isSessionCurrent = { true },
+            onIncomingContent = { false },
+          )
+        }
+
+      request.editText { commitText("typed", 1) }
+
+      val expected: List<List<EditCommand>> = listOf(listOf(CommitTextCommand("typed", 1)))
+      assertEquals(expected, dispatched)
+    } finally {
+      editorScope.cancel()
+    }
+  }
+}
+
+private object TestTextInputSessionScope : PlatformTextInputSessionScope {
+  override val coroutineContext = EmptyCoroutineContext
+
+  override suspend fun startInputMethod(request: PlatformTextInputMethodRequest): Nothing =
+    error("not used")
+}


### PR DESCRIPTION
Compose 1.12의 iOS `TextInputConnection` 소스는 모든 UIKit 편집을 `request.editText { ... }`로 전달합니다.