### PR TITLE
fix subpane KeepVisibleAnchor

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -1640,19 +1640,15 @@ fun EditorScreen(entityId: String) {
         editorBounds = uiState.editorBoundsInContainer,
       )
     val viewportScrollReconcileMode =
-      if (
-        editorInteractionFocused &&
-          interactionScope.controller.interactionMode.allowsViewportScrollReconcile
-      ) {
-        if (subPaneLayoutInfo != null) {
-          EditorViewportScrollReconcileMode.KeepVisibleAnchor
-        } else if (imeAppearing) {
-          EditorViewportScrollReconcileMode.RevealSelectionHead
-        } else {
-          EditorViewportScrollReconcileMode.KeepVisibleAnchor
-        }
-      } else {
-        EditorViewportScrollReconcileMode.Disabled
+      when {
+        !editorReady -> EditorViewportScrollReconcileMode.Disabled
+        !screenState.sceneInForeground -> EditorViewportScrollReconcileMode.Disabled
+        !interactionScope.controller.interactionMode.allowsViewportScrollReconcile ->
+          EditorViewportScrollReconcileMode.Disabled
+        subPaneLayoutInfo != null -> EditorViewportScrollReconcileMode.KeepVisibleAnchor
+        !uiState.focused -> EditorViewportScrollReconcileMode.Disabled
+        imeAppearing -> EditorViewportScrollReconcileMode.RevealSelectionHead
+        else -> EditorViewportScrollReconcileMode.KeepVisibleAnchor
       }
     val magnifierFocalPositionInRoot =
       interactionScope.controller.magnifierPosition?.let { position ->


### PR DESCRIPTION
회귀 수정: **에디터 포커스 상태와 상관없이** subpane 리사이즈 시 KeepVisibleAnchor 모드로 viewport reconcile이 일어나도록 함 (resize 전에 보이던 current selection head는 계속 보이도록 유지하고, 그렇지 않은 경우에는 기존 viewport anchor를 보존)
