### PR TITLE
stable selection의 컨테이너 시작점 복원 개선

### DIFF
--- a/crates/editor-core/src/tests/tracked_range_integration.rs
+++ b/crates/editor-core/src/tests/tracked_range_integration.rs
@@ -219,6 +219,692 @@ fn frozen_range_does_not_expand_when_text_inserted_at_left_boundary_at_paragraph
 }
 
 #[test]
+fn frozen_range_includes_preceding_paragraph_end_typing_but_excludes_paragraph_start_typing() {
+    let (initial, p1, p2) = state! {
+        doc {
+            root {
+                p1: paragraph { text("ab") }
+                p2: paragraph { text("cd") }
+            }
+        }
+        selection: (p1, 1) -> (p2, 0)
+    };
+    let selection = initial.selection.unwrap();
+    let frozen = editor_state::StableSelection::capture(&selection, &initial.view());
+    {
+        let view = initial.view();
+        let ctx =
+            editor_state::StableResolveCtx::from_live(&view, initial.projected.seq_checkout());
+        assert_eq!(
+            frozen.resolve(&ctx),
+            Some(selection),
+            "capture must preserve the exact endpoint while the document is unchanged"
+        );
+    }
+    let mut editor = Editor::new_test(initial);
+    editor.apply(Message::TrackedRange {
+        op: TrackedRangeOp::AddFrozen {
+            id: "r".into(),
+            group: "comment".into(),
+            selection: frozen,
+            metadata: String::new(),
+        },
+    });
+    assert_eq!(located_text(&editor, "r").as_deref(), Some("b"));
+
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::collapsed(editor_state::Position::new(p1, 2)),
+        },
+    });
+    editor.apply(Message::Insertion {
+        op: InsertionOp::Text { text: "X".into() },
+    });
+    assert_eq!(
+        located_text(&editor, "r").as_deref(),
+        Some("bX"),
+        "typing at the preceding paragraph end is inside a range ending at the next paragraph start"
+    );
+
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::collapsed(editor_state::Position::new(p2, 0)),
+        },
+    });
+    editor.apply(Message::Insertion {
+        op: InsertionOp::Text { text: "Y".into() },
+    });
+
+    assert_eq!(
+        located_text(&editor, "r").as_deref(),
+        Some("bX"),
+        "typing at a paragraph-start right boundary must stay outside a frozen comment range"
+    );
+}
+
+#[test]
+fn upstream_lower_endpoint_is_not_confused_with_paragraph_start_upper_endpoint() {
+    let (initial, p1, p2) = state! {
+        doc {
+            root {
+                p1: paragraph { text("ab") }
+                p2: paragraph { text("cd") }
+            }
+        }
+        selection: (p1, 0)
+    };
+    let selection = Selection::new(
+        editor_state::Position {
+            node: p1,
+            offset: 1,
+            affinity: editor_state::Affinity::Upstream,
+        },
+        editor_state::Position::new(p2, 0),
+    );
+    let frozen = editor_state::StableSelection::capture(&selection, &initial.view());
+    let mut editor = Editor::new_test(initial);
+    editor.apply(Message::TrackedRange {
+        op: TrackedRangeOp::AddFrozen {
+            id: "r".into(),
+            group: "comment".into(),
+            selection: frozen,
+            metadata: String::new(),
+        },
+    });
+
+    assert_eq!(
+        located_text(&editor, "r").as_deref(),
+        Some("b"),
+        "endpoint role must come from the selection, not an affinity/binding marker"
+    );
+}
+
+#[test]
+fn paragraph_start_upper_endpoint_follows_live_host_when_next_block_reorders() {
+    let (initial, _p1, p2) = state! {
+        doc {
+            root {
+                p1: paragraph { text("ab") }
+                p2: paragraph { text("cd") }
+            }
+        }
+        selection: (p1, 1) -> (p2, 0)
+    };
+    let root = initial.view().root().unwrap().id();
+    let frozen =
+        editor_state::StableSelection::capture(&initial.selection.unwrap(), &initial.view());
+    let mut editor = Editor::new_test(initial);
+    editor.apply(Message::TrackedRange {
+        op: TrackedRangeOp::AddFrozen {
+            id: "r".into(),
+            group: "comment".into(),
+            selection: frozen,
+            metadata: String::new(),
+        },
+    });
+
+    editor
+        .transact(|tr| {
+            tr.move_node(p2, root, 0)?;
+            Ok(())
+        })
+        .unwrap();
+
+    assert_eq!(
+        located_text(&editor, "r").as_deref(),
+        Some("cda"),
+        "a live primary endpoint must follow its paragraph instead of activating the join fallback"
+    );
+}
+
+#[test]
+fn frozen_range_ending_at_paragraph_start_does_not_expand_when_paragraph_joins_backward() {
+    let (initial, _p1, _p2, p3) = state! {
+        doc {
+            root {
+                p1: paragraph { text("ab") }
+                p2: paragraph { text("cd") }
+                p3: paragraph { text("ef") }
+            }
+        }
+        selection: (p1, 1) -> (p3, 0)
+    };
+    let frozen =
+        editor_state::StableSelection::capture(&initial.selection.unwrap(), &initial.view());
+    let mut editor = Editor::new_test(initial);
+    editor.apply(Message::TrackedRange {
+        op: TrackedRangeOp::AddFrozen {
+            id: "r".into(),
+            group: "comment".into(),
+            selection: frozen,
+            metadata: String::new(),
+        },
+    });
+    assert_eq!(located_text(&editor, "r").as_deref(), Some("bcd"));
+
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::collapsed(editor_state::Position::new(p3, 0)),
+        },
+    });
+    editor.apply(Message::Key {
+        event: KeyEvent {
+            key: Key::Backspace,
+            modifiers: InputModifiers::default(),
+        },
+    });
+    assert_eq!(
+        located_text(&editor, "r").as_deref(),
+        Some("bcd"),
+        "joining the endpoint paragraph backward must not pull that paragraph into the comment range"
+    );
+
+    editor.apply(Message::Insertion {
+        op: InsertionOp::Text { text: "X".into() },
+    });
+    assert_eq!(
+        located_text(&editor, "r").as_deref(),
+        Some("bcd"),
+        "typing at the join seam must stay outside the range"
+    );
+}
+
+#[test]
+fn reversed_frozen_range_stays_located_when_final_paragraph_joins_backward() {
+    let (initial, _p1, p2) = state! {
+        doc {
+            root {
+                p1: paragraph { text("abcd") }
+                p2: paragraph { text("ef") }
+            }
+        }
+        selection: (p2, 0) -> (p1, 1)
+    };
+    let frozen =
+        editor_state::StableSelection::capture(&initial.selection.unwrap(), &initial.view());
+    let mut editor = Editor::new_test(initial);
+    editor.apply(Message::TrackedRange {
+        op: TrackedRangeOp::AddFrozen {
+            id: "r".into(),
+            group: "comment".into(),
+            selection: frozen,
+            metadata: String::new(),
+        },
+    });
+    assert_eq!(located_text(&editor, "r").as_deref(), Some("bcd"));
+
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::collapsed(editor_state::Position::new(p2, 0)),
+        },
+    });
+    editor.apply(Message::Key {
+        event: KeyEvent {
+            key: Key::Backspace,
+            modifiers: InputModifiers::default(),
+        },
+    });
+    assert_eq!(
+        located_text(&editor, "r").as_deref(),
+        Some("bcd"),
+        "joining the final paragraph backward must not make a reversed comment range unlocatable"
+    );
+}
+
+#[test]
+fn frozen_range_ending_at_empty_paragraph_survives_backward_join() {
+    let (initial, _p1, p2) = state! {
+        doc {
+            root {
+                p1: paragraph { text("ab") }
+                p2: paragraph {}
+            }
+        }
+        selection: (p1, 1) -> (p2, 0)
+    };
+    let frozen =
+        editor_state::StableSelection::capture(&initial.selection.unwrap(), &initial.view());
+    let mut editor = Editor::new_test(initial);
+    editor.apply(Message::TrackedRange {
+        op: TrackedRangeOp::AddFrozen {
+            id: "r".into(),
+            group: "comment".into(),
+            selection: frozen,
+            metadata: String::new(),
+        },
+    });
+    assert_eq!(located_text(&editor, "r").as_deref(), Some("b"));
+
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::collapsed(editor_state::Position::new(p2, 0)),
+        },
+    });
+    editor.apply(Message::Key {
+        event: KeyEvent {
+            key: Key::Backspace,
+            modifiers: InputModifiers::default(),
+        },
+    });
+    assert_eq!(
+        located_text(&editor, "r").as_deref(),
+        Some("b"),
+        "removing an empty endpoint paragraph must not make the range disappear"
+    );
+
+    editor.apply(Message::Insertion {
+        op: InsertionOp::Text { text: "X".into() },
+    });
+    assert_eq!(
+        located_text(&editor, "r").as_deref(),
+        Some("b"),
+        "typing at the join seam must stay outside the range"
+    );
+}
+
+#[test]
+fn frozen_range_keeps_pre_join_empty_paragraph_typing_but_excludes_join_seam_typing() {
+    let (initial, _p0, p1, p2) = state! {
+        doc {
+            root {
+                p0: paragraph { text("ab") }
+                p1: paragraph {}
+                p2: paragraph { text("cd") }
+            }
+        }
+        selection: (p0, 1) -> (p2, 0)
+    };
+    let frozen =
+        editor_state::StableSelection::capture(&initial.selection.unwrap(), &initial.view());
+    let mut editor = Editor::new_test(initial);
+    editor.apply(Message::TrackedRange {
+        op: TrackedRangeOp::AddFrozen {
+            id: "r".into(),
+            group: "comment".into(),
+            selection: frozen,
+            metadata: String::new(),
+        },
+    });
+    assert_eq!(located_text(&editor, "r").as_deref(), Some("b"));
+
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::collapsed(editor_state::Position::new(p1, 0)),
+        },
+    });
+    editor.apply(Message::Insertion {
+        op: InsertionOp::Text { text: "Z".into() },
+    });
+    assert_eq!(
+        located_text(&editor, "r").as_deref(),
+        Some("bZ"),
+        "typing before the join is already inside the range"
+    );
+
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::collapsed(editor_state::Position::new(p2, 0)),
+        },
+    });
+    editor.apply(Message::Key {
+        event: KeyEvent {
+            key: Key::Backspace,
+            modifiers: InputModifiers::default(),
+        },
+    });
+    assert_eq!(
+        located_text(&editor, "r").as_deref(),
+        Some("bZ"),
+        "joining must preserve text that the delete observed inside the range"
+    );
+
+    editor.apply(Message::Insertion {
+        op: InsertionOp::Text { text: "X".into() },
+    });
+
+    assert_eq!(
+        located_text(&editor, "r").as_deref(),
+        Some("bZ"),
+        "typing at the join seam after the delete must stay outside the range"
+    );
+}
+
+#[test]
+fn reversed_frozen_range_keeps_pre_join_typing_but_excludes_join_seam_typing() {
+    let (initial, _p0, p1, p2) = state! {
+        doc {
+            root {
+                p0: paragraph { text("ab") }
+                p1: paragraph {}
+                p2: paragraph { text("cd") }
+            }
+        }
+        selection: (p2, 0) -> (p0, 1)
+    };
+    let frozen =
+        editor_state::StableSelection::capture(&initial.selection.unwrap(), &initial.view());
+    let mut editor = Editor::new_test(initial);
+    editor.apply(Message::TrackedRange {
+        op: TrackedRangeOp::AddFrozen {
+            id: "r".into(),
+            group: "comment".into(),
+            selection: frozen,
+            metadata: String::new(),
+        },
+    });
+
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::collapsed(editor_state::Position::new(p1, 0)),
+        },
+    });
+    editor.apply(Message::Insertion {
+        op: InsertionOp::Text { text: "Z".into() },
+    });
+    assert_eq!(located_text(&editor, "r").as_deref(), Some("bZ"));
+
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::collapsed(editor_state::Position::new(p2, 0)),
+        },
+    });
+    editor.apply(Message::Key {
+        event: KeyEvent {
+            key: Key::Backspace,
+            modifiers: InputModifiers::default(),
+        },
+    });
+    assert_eq!(located_text(&editor, "r").as_deref(), Some("bZ"));
+
+    editor.apply(Message::Insertion {
+        op: InsertionOp::Text { text: "X".into() },
+    });
+    assert_eq!(
+        located_text(&editor, "r").as_deref(),
+        Some("bZ"),
+        "reversed ranges must use the same physical delete-observed boundary"
+    );
+}
+
+#[test]
+fn frozen_range_follows_origin_past_removed_trailing_page_break() {
+    let (initial, _p1, p2) = state! {
+        doc {
+            root {
+                p1: paragraph { text("ab") page_break }
+                p2: paragraph { text("cd") }
+            }
+        }
+        selection: (p1, 1) -> (p2, 0)
+    };
+    let frozen =
+        editor_state::StableSelection::capture(&initial.selection.unwrap(), &initial.view());
+    let mut editor = Editor::new_test(initial);
+    editor.apply(Message::TrackedRange {
+        op: TrackedRangeOp::AddFrozen {
+            id: "r".into(),
+            group: "comment".into(),
+            selection: frozen,
+            metadata: String::new(),
+        },
+    });
+    assert_eq!(located_text(&editor, "r").as_deref(), Some("b"));
+
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::collapsed(editor_state::Position::new(p2, 0)),
+        },
+    });
+    editor.apply(Message::Key {
+        event: KeyEvent {
+            key: Key::Backspace,
+            modifiers: InputModifiers::default(),
+        },
+    });
+    editor.apply(Message::Insertion {
+        op: InsertionOp::Text { text: "X".into() },
+    });
+
+    assert_eq!(
+        located_text(&editor, "r").as_deref(),
+        Some("b"),
+        "origin lookup must cross the removed page-break marker and exclude seam typing"
+    );
+}
+
+#[test]
+fn empty_paragraph_start_lower_endpoint_excludes_later_seam_typing() {
+    let (initial, _p1, p2, _p3) = state! {
+        doc {
+            root {
+                p1: paragraph { text("ab") }
+                p2: paragraph {}
+                p3: paragraph { text("ef") }
+            }
+        }
+        selection: (p2, 0) -> (p3, 1)
+    };
+    let frozen =
+        editor_state::StableSelection::capture(&initial.selection.unwrap(), &initial.view());
+    let mut editor = Editor::new_test(initial);
+    editor.apply(Message::TrackedRange {
+        op: TrackedRangeOp::AddFrozen {
+            id: "r".into(),
+            group: "comment".into(),
+            selection: frozen,
+            metadata: String::new(),
+        },
+    });
+    assert_eq!(located_text(&editor, "r").as_deref(), Some("e"));
+
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::collapsed(editor_state::Position::new(p2, 0)),
+        },
+    });
+    editor.apply(Message::Key {
+        event: KeyEvent {
+            key: Key::Backspace,
+            modifiers: InputModifiers::default(),
+        },
+    });
+    editor.apply(Message::Insertion {
+        op: InsertionOp::Text { text: "X".into() },
+    });
+
+    assert_eq!(
+        located_text(&editor, "r").as_deref(),
+        Some("e"),
+        "an empty lower endpoint must remain right-associated when text is inserted at its deleted seam"
+    );
+}
+
+#[test]
+fn frozen_range_ending_at_empty_paragraph_survives_deleted_seam_child_before_backward_join() {
+    let (initial, p1, p2) = state! {
+        doc {
+            root {
+                p1: paragraph { text("abc") }
+                p2: paragraph {}
+            }
+        }
+        selection: (p1, 1) -> (p2, 0)
+    };
+    let frozen =
+        editor_state::StableSelection::capture(&initial.selection.unwrap(), &initial.view());
+    let mut editor = Editor::new_test(initial);
+    editor.apply(Message::TrackedRange {
+        op: TrackedRangeOp::AddFrozen {
+            id: "r".into(),
+            group: "comment".into(),
+            selection: frozen,
+            metadata: String::new(),
+        },
+    });
+    assert_eq!(located_text(&editor, "r").as_deref(), Some("bc"));
+
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::new(
+                editor_state::Position::new(p1, 2),
+                editor_state::Position::new(p1, 3),
+            ),
+        },
+    });
+    editor.apply(Message::Deletion {
+        op: DeletionOp::Selection,
+    });
+    assert_eq!(located_text(&editor, "r").as_deref(), Some("b"));
+
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::collapsed(editor_state::Position::new(p2, 0)),
+        },
+    });
+    editor.apply(Message::Key {
+        event: KeyEvent {
+            key: Key::Backspace,
+            modifiers: InputModifiers::default(),
+        },
+    });
+    editor.apply(Message::Insertion {
+        op: InsertionOp::Text { text: "X".into() },
+    });
+
+    assert_eq!(
+        located_text(&editor, "r").as_deref(),
+        Some("b"),
+        "later typing at the join seam must stay outside the range even if the old seam child was deleted"
+    );
+}
+
+#[test]
+fn frozen_range_follows_a_join_survivor_deleted_after_the_join() {
+    let (initial, p1, p2) = state! {
+        doc {
+            root {
+                p1: paragraph { text("abc") }
+                p2: paragraph {}
+            }
+        }
+        selection: (p1, 1) -> (p2, 0)
+    };
+    let frozen =
+        editor_state::StableSelection::capture(&initial.selection.unwrap(), &initial.view());
+    let mut editor = Editor::new_test(initial);
+    editor.apply(Message::TrackedRange {
+        op: TrackedRangeOp::AddFrozen {
+            id: "r".into(),
+            group: "comment".into(),
+            selection: frozen,
+            metadata: String::new(),
+        },
+    });
+    assert_eq!(located_text(&editor, "r").as_deref(), Some("bc"));
+
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::collapsed(editor_state::Position::new(p2, 0)),
+        },
+    });
+    editor.apply(Message::Key {
+        event: KeyEvent {
+            key: Key::Backspace,
+            modifiers: InputModifiers::default(),
+        },
+    });
+    assert_eq!(located_text(&editor, "r").as_deref(), Some("bc"));
+
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::new(
+                editor_state::Position::new(p1, 2),
+                editor_state::Position::new(p1, 3),
+            ),
+        },
+    });
+    editor.apply(Message::Deletion {
+        op: DeletionOp::Selection,
+    });
+    assert_eq!(located_text(&editor, "r").as_deref(), Some("b"));
+
+    editor.apply(Message::Insertion {
+        op: InsertionOp::Text { text: "X".into() },
+    });
+    assert_eq!(
+        located_text(&editor, "r").as_deref(),
+        Some("b"),
+        "the boundary must follow the deleted join survivor without including later typing"
+    );
+}
+
+#[test]
+fn frozen_range_survives_remote_pre_join_typing_join_and_seam_typing_in_one_tick() {
+    let (initial, _p0, p1, p2) = state! {
+        doc {
+            root {
+                p0: paragraph { text("ab") }
+                p1: paragraph {}
+                p2: paragraph { text("cd") }
+            }
+        }
+        selection: (p0, 1) -> (p2, 0)
+    };
+    let frozen =
+        editor_state::StableSelection::capture(&initial.selection.unwrap(), &initial.view());
+    let mut peer = Editor::new_test(initial.clone());
+    let mut receiver = Editor::new_test(initial);
+    receiver.apply(Message::TrackedRange {
+        op: TrackedRangeOp::AddFrozen {
+            id: "r".into(),
+            group: "comment".into(),
+            selection: frozen,
+            metadata: String::new(),
+        },
+    });
+
+    peer.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::collapsed(editor_state::Position::new(p1, 0)),
+        },
+    });
+    peer.apply(Message::Insertion {
+        op: InsertionOp::Text { text: "Z".into() },
+    });
+    peer.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::collapsed(editor_state::Position::new(p2, 0)),
+        },
+    });
+    peer.apply(Message::Key {
+        event: KeyEvent {
+            key: Key::Backspace,
+            modifiers: InputModifiers::default(),
+        },
+    });
+    peer.apply(Message::Insertion {
+        op: InsertionOp::Text { text: "X".into() },
+    });
+
+    let receiver_heads = receiver.current_heads().into_iter().collect();
+    let changesets = peer.missing_changesets_tolerant(&receiver_heads);
+    assert!(
+        changesets.len() >= 3,
+        "pre-join typing, join, and seam typing must arrive as a batch"
+    );
+    for changeset in changesets {
+        receiver.receive_remote_changeset(changeset);
+    }
+    receiver.tick().unwrap();
+
+    assert_eq!(
+        located_text(&receiver, "r").as_deref(),
+        Some("bZ"),
+        "the receiver must use delete-observed history without an intermediate recapture"
+    );
+}
+
+#[test]
 fn range_shrinks_at_right_edge_after_covering_delete_and_undo() {
     let (initial, p1) = state! {
         doc { root { p1: paragraph { text("ㅁㄴㅇㅁㅁㅁㅁㄴㅁㅇ") } } }

--- a/crates/editor-crdt/src/sequence/mod.rs
+++ b/crates/editor-crdt/src/sequence/mod.rs
@@ -1,5 +1,5 @@
-use crate::Dot;
 use crate::oplog::{ListOp, NYI, OpLog, item_width, lv_cmp};
+use crate::{Dot, FastMap, FastSet};
 use editor_common::content_tree::{ContentTree, Cursor, Leaf, Sum};
 use hashbrown::HashMap;
 use std::collections::BinaryHeap;
@@ -8,6 +8,68 @@ use std::collections::BinaryHeap;
 pub enum Bias {
     Before,
     After,
+}
+
+/// The visible insertions immediately outside a delete's target span in the
+/// delete's parent version. These dots are historical observations and may
+/// themselves be tombstones in the current checkout.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DeletionGap {
+    /// The insertion immediately before the deleted span, if any.
+    pub left: Option<Dot>,
+    /// The insertion immediately after the deleted span, if any.
+    pub right: Option<Dot>,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct DeleteRecord {
+    id: Dot,
+    gap: DeletionGap,
+}
+
+type DeleteRefs = smallvec::SmallVec<[usize; 1]>;
+
+#[derive(Clone, Debug, Default)]
+struct DeletionIndex {
+    records: FastMap<usize, DeleteRecord>,
+    by_target: FastMap<usize, DeleteRefs>,
+    inactive: FastSet<usize>,
+}
+
+impl DeletionIndex {
+    fn record_delete(&mut self, delete_lv: usize, id: Dot, gap: DeletionGap, targets: &[usize]) {
+        self.records.insert(delete_lv, DeleteRecord { id, gap });
+        for &target in targets {
+            let mut deletes = self.by_target.get(&target).cloned().unwrap_or_default();
+            deletes.push(delete_lv);
+            self.by_target.insert(target, deletes);
+        }
+    }
+
+    fn deactivate_delete(&mut self, delete_lv: usize) {
+        self.inactive.insert(delete_lv);
+    }
+
+    fn gap_for_target(
+        &self,
+        tree: &ContentTree<Run>,
+        lv_of: &crate::DotMap<usize>,
+        target: Dot,
+    ) -> Option<DeletionGap> {
+        let target_lv = *lv_of.get(&target)?;
+        tree.doc_index_of_lv_checked(target_lv)?;
+        self.by_target
+            .get(&target_lv)?
+            .iter()
+            .filter(|&&delete_lv| !self.inactive.contains(&delete_lv))
+            .filter_map(|&delete_lv| self.records.get(&delete_lv))
+            .min_by(|a, b| {
+                a.id.actor
+                    .cmp(&b.id.actor)
+                    .then(a.id.clock.cmp(&b.id.clock))
+            })
+            .map(|record| record.gap)
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -110,6 +172,7 @@ struct Ctx {
     // path) shares the per-op delete-target lists by pointer instead of
     // deep-copying ~one (usually empty) allocation per op.
     del_targets: imbl::Vector<Vec<usize>>,
+    deletions: DeletionIndex,
     cur_version: Vec<usize>,
 }
 
@@ -238,6 +301,13 @@ fn batch_update_targets(tree: &mut ContentTree<Run>, targets: &[usize], f: impl 
     }
 }
 
+fn dot_at_cur_position(tree: &ContentTree<Run>, pos: usize) -> Option<Dot> {
+    let cursor = tree.cursor_at_cur_pos(pos + 1);
+    let (run, offset) = tree.prev_slot(&cursor)?;
+    debug_assert_eq!(run.cur, 0, "previous cur-position slot must be visible");
+    Some(Dot::new(run.start.actor, run.start.clock + offset as u64))
+}
+
 fn apply1<P: Clone>(ctx: &mut Ctx, log: &OpLog<P>, lv: usize, op: &ListOp<P>, dot: Dot) {
     match op {
         ListOp::Del { pos, len } => {
@@ -249,6 +319,14 @@ fn apply1<P: Clone>(ctx: &mut Ctx, log: &OpLog<P>, lv: usize, op: &ListOp<P>, do
             );
             let mut targets = Vec::with_capacity(len);
             if len > 0 {
+                let gap = DeletionGap {
+                    left: pos
+                        .checked_sub(1)
+                        .and_then(|position| dot_at_cur_position(&ctx.tree, position)),
+                    right: (pos + len < visible)
+                        .then(|| dot_at_cur_position(&ctx.tree, pos + len))
+                        .flatten(),
+                };
                 let mut c = ctx.tree.cursor_at_cur_pos(pos);
                 for _ in 0..len {
                     loop {
@@ -268,6 +346,7 @@ fn apply1<P: Clone>(ctx: &mut Ctx, log: &OpLog<P>, lv: usize, op: &ListOp<P>, do
                     targets.push(target_lv);
                     ctx.tree.step(&mut c);
                 }
+                ctx.deletions.record_delete(lv, dot, gap, &targets);
                 batch_update_targets(&mut ctx.tree, &targets, |it| {
                     it.cur += 1;
                     it.end += 1;
@@ -278,6 +357,7 @@ fn apply1<P: Clone>(ctx: &mut Ctx, log: &OpLog<P>, lv: usize, op: &ListOp<P>, do
         ListOp::Undel { del } => {
             let del = *del;
             let del_lv = *log.lv_of.get(&del).expect("undel references unknown del");
+            ctx.deletions.deactivate_delete(del_lv);
             let targets = ctx.del_targets[del_lv].clone();
             batch_update_targets(&mut ctx.tree, &targets, |it| {
                 assert!(it.cur >= 1 && it.end >= 1, "undel underflow");
@@ -432,6 +512,7 @@ impl Default for SeqCheckout {
             ctx: Ctx {
                 tree: ContentTree::new(),
                 del_targets: imbl::Vector::new(),
+                deletions: DeletionIndex::default(),
                 cur_version: Vec::new(),
             },
             lv_of: crate::DotMap::new(),
@@ -549,6 +630,16 @@ impl SeqCheckout {
         resolve_boundary_checked_in(&self.ctx.tree, &self.lv_of, id, bias)
     }
 
+    /// Returns the canonical active delete's parent-version gap for `target`.
+    ///
+    /// Returns `None` when `target` is not a sequence insertion or has no
+    /// active delete.
+    pub fn deletion_gap(&self, target: Dot) -> Option<DeletionGap> {
+        self.ctx
+            .deletions
+            .gap_for_target(&self.ctx.tree, &self.lv_of, target)
+    }
+
     pub fn doc_index_of(&self, dot: Dot) -> Option<usize> {
         let lv = *self.lv_of.get(&dot)?;
         self.ctx.tree.doc_index_of_lv_checked(lv)
@@ -611,6 +702,7 @@ impl SeqCheckout {
                 tree: self.ctx.tree,
                 lv_of: self.lv_of,
                 del_targets: self.ctx.del_targets,
+                deletions: self.ctx.deletions,
             },
         }
     }
@@ -635,6 +727,7 @@ pub(crate) fn checkout_with_index<P: Clone>(log: &OpLog<P>) -> (Vec<(Dot, P)>, R
         tree: c.ctx.tree,
         lv_of: c.lv_of,
         del_targets: c.ctx.del_targets,
+        deletions: c.ctx.deletions,
     };
     (snap, index)
 }
@@ -643,6 +736,7 @@ pub(crate) struct ResolveIndex {
     tree: ContentTree<Run>,
     lv_of: crate::DotMap<usize>,
     del_targets: imbl::Vector<Vec<usize>>,
+    deletions: DeletionIndex,
 }
 
 fn resolve_boundary_in(
@@ -731,6 +825,16 @@ impl BoundaryResolver {
 
     pub fn resolve_boundary_checked(&self, id: Dot, bias: Bias) -> Option<Boundary> {
         resolve_boundary_checked_in(&self.index.tree, &self.index.lv_of, id, bias)
+    }
+
+    /// Returns the canonical active delete's parent-version gap for `target`.
+    ///
+    /// Returns `None` when `target` is not a sequence insertion or has no
+    /// active delete.
+    pub fn deletion_gap(&self, target: Dot) -> Option<DeletionGap> {
+        self.index
+            .deletions
+            .gap_for_target(&self.index.tree, &self.index.lv_of, target)
     }
 
     /// Descending current visible positions of `del`'s still-visible targets,
@@ -879,6 +983,257 @@ mod tests {
     fn boundary_missing_dot_is_none() {
         let (r, _a, _b, _c) = abc_del_b_resolver();
         assert!(r.resolve_boundary(Dot::new(9, 9), Bias::After).is_none());
+    }
+
+    #[test]
+    fn deletion_gap_records_the_delete_parent_version_for_every_target() {
+        let a = Dot::new(1, 0);
+        let z = Dot::new(1, 1);
+        let b = Dot::new(1, 2);
+        let c = Dot::new(1, 3);
+        let d = Dot::new(1, 4);
+        let del_bc = Dot::new(1, 5);
+        let later = Dot::new(1, 6);
+        let ev = vec![
+            ins(1, 0, &[], 0, 'a'),
+            ins(1, 1, &[a], 1, 'Z'),
+            ins(1, 2, &[z], 2, 'b'),
+            ins(1, 3, &[b], 3, 'c'),
+            ins(1, 4, &[c], 4, 'd'),
+            del_range(1, 5, &[d], 2, 2),
+            ins(1, 6, &[del_bc], 2, 'X'),
+        ];
+        let log = build_oplog(&ev);
+        let expected = Some(DeletionGap {
+            left: Some(z),
+            right: Some(d),
+        });
+        let (_elems, cold) = checkout_with_resolver(&log);
+        let mut warm = SeqCheckout::new();
+        warm.apply_tail(&log);
+
+        assert_eq!(warm.deletion_gap(b), expected);
+        assert_eq!(warm.deletion_gap(c), expected);
+        assert_eq!(cold.deletion_gap(b), expected);
+        assert_eq!(cold.deletion_gap(c), expected);
+        assert_ne!(warm.deletion_gap(b).unwrap().left, Some(later));
+        assert_eq!(warm.deletion_gap(a), None);
+        assert_eq!(cold.deletion_gap(del_bc), None);
+    }
+
+    #[derive(Clone, Copy)]
+    struct OverlapDots {
+        target: Dot,
+        base_left: Dot,
+        base_right: Dot,
+        a_insert: Dot,
+        a_delete: Dot,
+        b_delete: Dot,
+        a_undel: Dot,
+        a_insert_2: Dot,
+        a_redo: Dot,
+    }
+
+    fn overlapping_delete_log(a_branch_first: bool) -> (OpLog<char>, OverlapDots) {
+        let mut log = OpLog::new();
+        let chars = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'];
+        for (clock, ch) in chars.into_iter().enumerate() {
+            let parents = if clock == 0 {
+                Vec::new()
+            } else {
+                vec![Dot::new(0, clock as u64 - 1)]
+            };
+            log.push(ins(0, clock as u64, &parents, clock, ch));
+        }
+
+        let base_head = Dot::new(0, 8);
+        let dots = OverlapDots {
+            target: Dot::new(0, 4),
+            base_left: Dot::new(0, 3),
+            base_right: Dot::new(0, 5),
+            a_insert: Dot::new(1, 9),
+            a_delete: Dot::new(1, 10),
+            b_delete: Dot::new(2, 9),
+            a_undel: Dot::new(1, 11),
+            a_insert_2: Dot::new(1, 12),
+            a_redo: Dot::new(1, 13),
+        };
+        let a_insert = ins(1, 9, &[base_head], 4, 'Z');
+        let a_delete = del_at(1, 10, &[dots.a_insert], 5);
+        let b_delete = del_at(2, 9, &[base_head], 4);
+        if a_branch_first {
+            log.push(a_insert);
+            log.push(a_delete);
+            log.push(b_delete);
+        } else {
+            log.push(b_delete);
+            log.push(a_insert);
+            log.push(a_delete);
+        }
+        (log, dots)
+    }
+
+    fn append_a_undel(log: &mut OpLog<char>, dots: OverlapDots) {
+        log.push(undel(
+            dots.a_undel.actor,
+            dots.a_undel.clock,
+            &[dots.a_delete],
+            dots.a_delete,
+        ));
+    }
+
+    fn append_a_redo(log: &mut OpLog<char>, dots: OverlapDots) {
+        log.push(ins(
+            dots.a_insert_2.actor,
+            dots.a_insert_2.clock,
+            &[dots.a_undel],
+            5,
+            'W',
+        ));
+        log.push(del_at(
+            dots.a_redo.actor,
+            dots.a_redo.clock,
+            &[dots.a_insert_2],
+            6,
+        ));
+    }
+
+    #[test]
+    fn deletion_gap_uses_actor_first_active_delete_across_local_lv_orders() {
+        let (mut log_a_first, dots) = overlapping_delete_log(true);
+        let (mut log_b_first, other_dots) = overlapping_delete_log(false);
+        assert_eq!(dots.target, other_dots.target);
+        assert!(
+            dots.a_delete > dots.b_delete,
+            "Dot::Ord must prefer B so this fixture catches clock-first comparison"
+        );
+
+        let a_gap = Some(DeletionGap {
+            left: Some(dots.a_insert),
+            right: Some(dots.base_right),
+        });
+        let b_gap = Some(DeletionGap {
+            left: Some(dots.base_left),
+            right: Some(dots.base_right),
+        });
+        let redo_gap = Some(DeletionGap {
+            left: Some(dots.a_insert_2),
+            right: Some(dots.base_right),
+        });
+
+        let mut warm_a_first = SeqCheckout::new();
+        warm_a_first.apply_tail(&log_a_first);
+        let mut warm_b_first = SeqCheckout::new();
+        warm_b_first.apply_tail(&log_b_first);
+        assert_eq!(warm_a_first.deletion_gap(dots.target), a_gap);
+        assert_eq!(warm_b_first.deletion_gap(dots.target), a_gap);
+        assert_eq!(
+            checkout_with_resolver(&log_a_first)
+                .1
+                .deletion_gap(dots.target),
+            a_gap
+        );
+        assert_eq!(
+            checkout_with_resolver(&log_b_first)
+                .1
+                .deletion_gap(dots.target),
+            a_gap
+        );
+
+        append_a_undel(&mut log_a_first, dots);
+        append_a_undel(&mut log_b_first, dots);
+        warm_a_first.apply_tail(&log_a_first);
+        warm_b_first.apply_tail(&log_b_first);
+        assert_eq!(warm_a_first.deletion_gap(dots.target), b_gap);
+        assert_eq!(warm_b_first.deletion_gap(dots.target), b_gap);
+        assert_eq!(
+            checkout_with_resolver(&log_a_first)
+                .1
+                .deletion_gap(dots.target),
+            b_gap
+        );
+        assert_eq!(
+            checkout_with_resolver(&log_b_first)
+                .1
+                .deletion_gap(dots.target),
+            b_gap
+        );
+
+        append_a_redo(&mut log_a_first, dots);
+        append_a_redo(&mut log_b_first, dots);
+        warm_a_first.apply_tail(&log_a_first);
+        warm_b_first.apply_tail(&log_b_first);
+        assert_eq!(warm_a_first.deletion_gap(dots.target), redo_gap);
+        assert_eq!(warm_b_first.deletion_gap(dots.target), redo_gap);
+        assert_eq!(
+            checkout_with_resolver(&log_a_first)
+                .1
+                .deletion_gap(dots.target),
+            redo_gap
+        );
+        assert_eq!(
+            checkout_with_resolver(&log_b_first)
+                .1
+                .deletion_gap(dots.target),
+            redo_gap
+        );
+        assert_eq!(warm_a_first.deletion_gap(dots.a_delete), None);
+        assert_eq!(warm_a_first.deletion_gap(dots.a_undel), None);
+    }
+
+    #[test]
+    fn deletion_gap_handles_document_edges_zero_length_and_deleted_survivors() {
+        let a = Dot::new(1, 0);
+        let b = Dot::new(1, 1);
+        let c = Dot::new(1, 2);
+        let d = Dot::new(1, 3);
+        let del_d = Dot::new(1, 4);
+        let del_c = Dot::new(1, 5);
+        let del_a = Dot::new(1, 6);
+        let zero = Dot::new(1, 7);
+        let ev = vec![
+            ins(1, 0, &[], 0, 'a'),
+            ins(1, 1, &[a], 1, 'b'),
+            ins(1, 2, &[b], 2, 'c'),
+            ins(1, 3, &[c], 3, 'd'),
+            del_at(1, 4, &[d], 3),
+            del_at(1, 5, &[del_d], 2),
+            del_at(1, 6, &[del_c], 0),
+            del_range(1, 7, &[del_a], 0, 0),
+        ];
+        let log = build_oplog(&ev);
+        let mut warm = SeqCheckout::new();
+        warm.apply_tail(&log);
+        let cold = checkout_with_resolver(&log).1;
+
+        assert_eq!(
+            warm.deletion_gap(d),
+            Some(DeletionGap {
+                left: Some(c),
+                right: None,
+            })
+        );
+        assert_eq!(
+            warm.deletion_gap(c),
+            Some(DeletionGap {
+                left: Some(b),
+                right: None,
+            })
+        );
+        assert_eq!(
+            warm.deletion_gap(a),
+            Some(DeletionGap {
+                left: None,
+                right: Some(b),
+            })
+        );
+        assert_eq!(cold.deletion_gap(d), warm.deletion_gap(d));
+        assert_eq!(cold.deletion_gap(c), warm.deletion_gap(c));
+        assert_eq!(cold.deletion_gap(a), warm.deletion_gap(a));
+        assert_eq!(warm.deletion_gap(b), None);
+        assert_eq!(warm.deletion_gap(zero), None);
+        assert_eq!(warm.deletion_gap(Dot::new(9, 9)), None);
+        assert_eq!(warm.deletion_gap(Dot::synthetic(1)), None);
     }
 
     #[test]

--- a/crates/editor-state/src/stable_position.rs
+++ b/crates/editor-state/src/stable_position.rs
@@ -1,9 +1,10 @@
 use editor_crdt::sequence::{
-    Bias, Boundary, BoundaryResolver, SeqCheckout, checkout_with_resolver,
+    Bias, Boundary, BoundaryResolver, DeletionGap, SeqCheckout, checkout_with_resolver,
 };
 use editor_crdt::{Dot, OpLog};
 use editor_macros::ffi;
 use editor_model::{ChildView, DocView, NodeType, NodeView, SeqItem};
+use hashbrown::HashSet;
 use serde::{Deserialize, Serialize};
 
 use crate::Position;
@@ -251,6 +252,32 @@ impl StableResolver<'_> {
         }
     }
 
+    fn deletion_gap(&self, d: Dot) -> Option<DeletionGap> {
+        match self {
+            StableResolver::Owned(r) => r.deletion_gap(d),
+            StableResolver::Live(c) => c.deletion_gap(d),
+        }
+    }
+
+    fn visible_deletion_survivor(&self, target: Dot, bias: Bias) -> Option<Dot> {
+        let mut seen = HashSet::new();
+        let mut current = target;
+        loop {
+            if !seen.insert(current) {
+                return None;
+            }
+            let gap = self.deletion_gap(current)?;
+            let survivor = match bias {
+                Bias::Before => gap.left,
+                Bias::After => gap.right,
+            }?;
+            if self.boundary(survivor)?.visible {
+                return Some(survivor);
+            }
+            current = survivor;
+        }
+    }
+
     /// Sequence position for any dot, visible or deleted — the ordering key used
     /// for a target anchor whose element may have been concurrently removed.
     fn position(&self, d: Dot) -> Option<usize> {
@@ -301,6 +328,10 @@ impl<'a> StableResolveCtx<'a> {
         self.view.alias_classes().resolve_with(d, |m| {
             self.view.node(m).is_some() || self.view.block_of(m).is_some()
         })
+    }
+
+    pub(crate) fn view(&self) -> &'a DocView<'a> {
+        self.view
     }
 }
 
@@ -456,6 +487,87 @@ impl StablePosition {
             return Some(pos);
         }
         Some(self.resolve_in_host(ctx, host, next_child))
+    }
+
+    fn authored_host_at_offset_zero(&self) -> Option<Dot> {
+        if self.child.is_some() {
+            return None;
+        }
+        match self.chain.last()? {
+            ChainSegment::Real { dot } => Some(*dot),
+            ChainSegment::Synthetic { .. } => None,
+        }
+    }
+
+    pub(crate) fn range_start_position(
+        &self,
+        ctx: &StableResolveCtx,
+        primary: Position,
+    ) -> Position {
+        self.range_start_after_deleted_empty_host_candidate(ctx, primary)
+            .unwrap_or(primary)
+    }
+
+    pub(crate) fn range_end_position(&self, ctx: &StableResolveCtx, primary: Position) -> Position {
+        self.range_end_after_deleted_host_candidate(ctx, primary)
+            .unwrap_or(primary)
+    }
+
+    fn range_end_after_deleted_host_candidate(
+        &self,
+        ctx: &StableResolveCtx,
+        primary: Position,
+    ) -> Option<Position> {
+        let terminal = self.authored_host_at_offset_zero()?;
+        if ctx.view.node(ctx.alias(terminal)).is_some() {
+            return None;
+        }
+
+        let survivor = ctx
+            .resolver
+            .visible_deletion_survivor(terminal, Bias::Before)?;
+        let survivor_position = self.position_at_deletion_survivor(ctx, survivor, Bind::Right)?;
+
+        let gap_host = ctx.view.node(primary.node)?;
+        let previous_index = primary.offset.checked_sub(1)?;
+        let containing = direct_child_containing(&gap_host, survivor_position.node, ctx)?;
+        (containing == previous_index).then_some(survivor_position)
+    }
+
+    fn range_start_after_deleted_empty_host_candidate(
+        &self,
+        ctx: &StableResolveCtx,
+        primary: Position,
+    ) -> Option<Position> {
+        let terminal = self.authored_host_at_offset_zero()?;
+        if ctx.view.node(ctx.alias(terminal)).is_some() {
+            return None;
+        }
+
+        let survivor = ctx
+            .resolver
+            .visible_deletion_survivor(terminal, Bias::After)?;
+        let survivor_position = self.position_at_deletion_survivor(ctx, survivor, Bind::Left)?;
+        let gap_host = ctx.view.node(primary.node)?;
+        let containing = direct_child_containing(&gap_host, survivor_position.node, ctx)?;
+        (containing == primary.offset).then_some(survivor_position)
+    }
+
+    fn position_at_deletion_survivor(
+        &self,
+        ctx: &StableResolveCtx,
+        survivor: Dot,
+        bind: Bind,
+    ) -> Option<Position> {
+        let survivor = ctx.alias(survivor);
+        if let Some(node) = ctx.view.node(survivor) {
+            return (node.node_type() == NodeType::Paragraph).then_some(Position {
+                node: node.id(),
+                offset: 0,
+                affinity: self.affinity,
+            });
+        }
+        self.resolve_child_parent_boundary(ctx, survivor, bind)
     }
 
     fn resolve_child_parent_boundary(

--- a/crates/editor-state/src/stable_selection.rs
+++ b/crates/editor-state/src/stable_selection.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::sync::Arc;
 
 use editor_macros::ffi;
@@ -62,9 +63,28 @@ impl StableSelection {
     }
 
     pub fn resolve(&self, ctx: &StableResolveCtx) -> Option<Selection> {
-        let anchor = self.anchor.resolve(ctx)?;
-        let head = self.head.resolve(ctx)?;
-        Some(Selection { anchor, head })
+        let primary = Selection {
+            anchor: self.anchor.resolve(ctx)?,
+            head: self.head.resolve(ctx)?,
+        };
+        if self.anchor == self.head {
+            return Some(primary);
+        }
+
+        let Some(resolved) = primary.resolve(ctx.view()) else {
+            return Some(primary);
+        };
+        Some(match resolved.anchor().cmp(resolved.head()) {
+            Ordering::Less => Selection {
+                anchor: self.anchor.range_start_position(ctx, primary.anchor),
+                head: self.head.range_end_position(ctx, primary.head),
+            },
+            Ordering::Greater => Selection {
+                anchor: self.anchor.range_end_position(ctx, primary.anchor),
+                head: self.head.range_start_position(ctx, primary.head),
+            },
+            Ordering::Equal => primary,
+        })
     }
 }
 


### PR DESCRIPTION
## 문제

`StablePosition`은 position을 ancestor `chain`과 선택적인 `child` dot로 저장합니다.

Range의 시작이나 끝이 문단의 offset 0에 있으면 bind할 child가 없을 수 있습니다. 이 상태에서 문단 시작에서 Backspace를 눌러 앞 문단과 합치면 해당 문단 dot가 삭제되고, stable selection이 원래 범위와 다르게 복원되는 문제가 있었습니다.

- range의 끝이 있던 문단을 합치면 해당 문단의 내용까지 range가 확장됨
- range의 시작이나 끝이 빈 문단에 있으면 문단을 합친 뒤 range가 사라질 수 있음
- 역방향 selection에서도 같은 문제가 발생함

특히 문단을 합치기 전에 range 안에 입력한 텍스트는 계속 포함해야 하지만, 문단을 합친 뒤 같은 자리에 입력한 텍스트는 range에서 제외해야 합니다.

Tracked range가 `StableSelection`을 저장하기 때문에 코멘트 범위에서도 동일한 문제가 재현됐습니다.

## 원인

Range의 시작이나 끝이 문단의 offset 0에 저장되면 해당 문단의 dot가 위치를 식별하는 기준이 됩니다.

문단을 합치면서 이 dot가 삭제되면 최종 문서의 구조만으로는 다음 두 경우를 구분할 수 없습니다.

1. 문단을 합치기 전에 이미 range 안에 있던 텍스트
2. 문단을 합친 뒤 같은 자리에 새로 입력한 텍스트

이 차이는 문단 dot를 삭제한 delete가 실행될 때 관찰한 sequence에 남아 있습니다. 따라서 삭제된 dot를 복원할 때는 현재 보이는 이웃이 아니라, delete가 자신의 `parents`에서 관찰한 삭제 범위 앞뒤의 insertion dot이 필요합니다.

## 변경

- `ListOp::Del`을 적용할 때 delete가 자신의 `parents`에서 관찰한 삭제 범위 바로 앞과 뒤의 insertion dot을 `DeletionGap`으로 파생합니다.
- `DeletionIndex`가 다음 정보를 checkout 상태로 관리합니다.
  - delete별 `DeletionGap`
  - 삭제된 insertion dot에서 관련 delete를 찾기 위한 역방향 index
  - `Undel`로 비활성화된 delete
- 같은 insertion을 지운 active delete가 여러 개면 sequence integration과 같은 actor-first 순서로 하나를 결정적으로 선택합니다.
- incremental checkout과 cold checkout이 op log에서 동일한 `DeletionIndex`를 재구성합니다.
- non-collapsed `StableSelection`을 복원할 때 문서 순서를 기준으로 range의 시작과 끝을 구분합니다.
- 문단 dot가 살아 있으면 일반 `StablePosition::resolve` 결과를 그대로 사용합니다.
- range의 끝이 문단의 offset 0에 저장돼 있고 해당 문단 dot가 삭제됐다면 `DeletionGap.left`를 따라 delete가 관찰한 앞쪽 내용 뒤로 복원합니다.
- range의 시작이 빈 문단의 offset 0에 저장돼 있고 해당 문단 dot가 삭제됐다면 `DeletionGap.right`를 따라 뒤쪽 내용 앞으로 복원합니다.
- 기록된 left/right dot도 나중에 삭제됐다면 해당 dot의 `DeletionGap`을 같은 방향으로 계속 따라갑니다.
- 계산한 위치가 현재 문서에서 일반 resolve 결과와 같은 문맥에 있을 때만 보정값을 사용합니다.
- collapsed selection과 문단 dot가 살아 있는 일반적인 복원 동작은 변경하지 않습니다.
- stable selection wire v2, `ListOp`, 직렬화 형식, FFI 및 DB 형식은 변경하지 않습니다. 별도의 fallback position도 저장하지 않습니다.

## 테스트

다음 동작에 대한 회귀 테스트를 추가하거나 보강했습니다.

- 문단 합치기 전에 range 안에 입력한 텍스트는 계속 포함
- 문단 합치기 후 같은 자리에 입력한 텍스트는 제외
- forward 및 reversed selection
- 빈 문단에 저장된 range 시작과 끝
- 기록된 left dot이 다시 삭제되는 경우
- page break와 문단 이동
- remote changeset을 한 번에 적용하는 경우
- multi-target delete
- `Undel` 및 redo
- 겹친 concurrent delete의 결정적 선택
- incremental/cold checkout 동등성
- 문서 처음과 끝에서의 delete