### PR TITLE
앱 노트 카드에서 보이지 않는 rounding 제거

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteCard.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteCard.kt
@@ -426,7 +426,6 @@ private fun NoteCollapsedContent(
         modifier =
           Modifier.weight(1f)
             .padding(end = 12.dp, top = 12.dp, bottom = 12.dp)
-            .clip(AppShapes.rounded(AppShapes.md))
             .clickable { onExpand() }
             .pressScale(0.985f),
         horizontalArrangement = Arrangement.spacedBy(12.dp),


### PR DESCRIPTION
수정 시각이 살짝 잘려보이는 시각적 문제를 해결함