### PR TITLE
stable selection의 삭제된 inline 경계 복원

### DIFF
--- a/crates/editor-core/src/handle/tracked_range.rs
+++ b/crates/editor-core/src/handle/tracked_range.rs
@@ -74,30 +74,11 @@ pub fn handle_tracked_range_op(editor: &mut Editor, op: TrackedRangeOp) -> Resul
             });
         }
         TrackedRangeOp::SetGroup { id, group } => {
-            // Re-anchor the range to its current resolved extent so a stale
-            // binding to a since-deleted boundary character is dropped; without
-            // this, a later insert at the collapsed boundary would be recaptured.
-            let recaptured = editor.tracked_ranges().get(&id).and_then(|range| {
-                let state = editor.state();
-                let located = range.locate(state)?;
-                let view = state.view();
-                let resolved = located.resolve(&view)?;
-                let blocks: Vec<editor_crdt::Dot> = editor_state::blocks_in_range(&resolved)
-                    .iter()
-                    .map(|b| b.id())
-                    .collect();
-                Some((StableSelection::capture(&located, &view), blocks))
-            });
-            let would_change = editor.tracked_ranges().get(&id).is_some_and(|range| {
-                range.group != group
-                    || recaptured
-                        .as_ref()
-                        .is_some_and(|(s, _)| s != &range.selection)
-            });
+            let would_change = editor
+                .tracked_ranges()
+                .get(&id)
+                .is_some_and(|range| range.group != group);
             commit_if_changed(editor, would_change, |reg| {
-                if let Some((selection, blocks)) = recaptured {
-                    reg.set_selection(&id, selection, blocks);
-                }
                 reg.set_group(&id, group);
             });
         }
@@ -721,6 +702,23 @@ mod tests {
             state,
             Message::TrackedRange {
                 op: TrackedRangeOp::Remove { id: "x".into() },
+            },
+        );
+    }
+
+    #[test]
+    fn set_group_nonexistent_preserves_state() {
+        let (state, ..) = state! {
+            doc { root { p1: paragraph { text("hello") } } }
+            selection: (p1, 1) -> (p1, 4)
+        };
+        assert_apply_preserves_state(
+            state,
+            Message::TrackedRange {
+                op: TrackedRangeOp::SetGroup {
+                    id: "missing".into(),
+                    group: "g2".into(),
+                },
             },
         );
     }

--- a/crates/editor-core/src/tests/tracked_range_integration.rs
+++ b/crates/editor-core/src/tests/tracked_range_integration.rs
@@ -41,6 +41,74 @@ fn located_text(editor: &Editor, id: &str) -> Option<String> {
     Some(resolved.collect_text())
 }
 
+fn directed_selection(
+    node: editor_crdt::Dot,
+    start: usize,
+    end: usize,
+    reversed: bool,
+) -> Selection {
+    let start = editor_state::Position::new(node, start);
+    let end = editor_state::Position::new(node, end);
+    if reversed {
+        Selection::new(end, start)
+    } else {
+        Selection::new(start, end)
+    }
+}
+
+fn set_selection(editor: &mut Editor, selection: Selection) {
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set { selection },
+    });
+}
+
+fn insert_text(editor: &mut Editor, node: editor_crdt::Dot, offset: usize, text: &str) {
+    set_selection(
+        editor,
+        Selection::collapsed(editor_state::Position::new(node, offset)),
+    );
+    editor.apply(Message::Insertion {
+        op: InsertionOp::Text { text: text.into() },
+    });
+}
+
+fn delete_range(editor: &mut Editor, node: editor_crdt::Dot, start: usize, end: usize) {
+    set_selection(editor, directed_selection(node, start, end, false));
+    editor.apply(Message::Deletion {
+        op: DeletionOp::Selection,
+    });
+}
+
+fn run_deleted_end_history_with_group_transitions(
+    groups: &[&str],
+) -> (crate::tracked_range::TrackedRange, Option<String>) {
+    let (initial, p1) = state! {
+        doc { root { p1: paragraph { text("abcdef") } } }
+        selection: (p1, 0)
+    };
+    let mut editor = Editor::new_test(initial);
+    editor.apply(add_message(
+        "r",
+        "comment",
+        directed_selection(p1, 1, 4, false),
+    ));
+    insert_text(&mut editor, p1, 3, "Y");
+    delete_range(&mut editor, p1, 4, 6);
+    for group in groups {
+        editor.apply(Message::TrackedRange {
+            op: TrackedRangeOp::SetGroup {
+                id: "r".into(),
+                group: (*group).into(),
+            },
+        });
+    }
+    insert_text(&mut editor, p1, 4, "X");
+    (
+        editor.tracked_ranges().get("r").unwrap().clone(),
+        located_text(&editor, "r"),
+    )
+}
+
 #[test]
 fn range_position_shifts_when_text_inserted_before_it() {
     let (initial, p1) = state! {
@@ -905,6 +973,56 @@ fn frozen_range_survives_remote_pre_join_typing_join_and_seam_typing_in_one_tick
 }
 
 #[test]
+fn deleted_inline_boundary_has_the_same_result_when_history_arrives_in_one_remote_tick() {
+    for upper in [false, true] {
+        for reversed in [false, true] {
+            let (initial, p1) = state! {
+                doc { root { p1: paragraph { text("abcdef") } } }
+                selection: (p1, 0)
+            };
+            let stable = editor_state::StableSelection::capture(
+                &directed_selection(p1, 1, 4, reversed),
+                &initial.view(),
+            );
+            let mut peer = Editor::new_test(initial.clone());
+            let mut receiver = Editor::new_test(initial);
+            receiver.apply(Message::TrackedRange {
+                op: TrackedRangeOp::AddFrozen {
+                    id: "r".into(),
+                    group: "comment".into(),
+                    selection: stable,
+                    metadata: String::new(),
+                },
+            });
+
+            if upper {
+                insert_text(&mut peer, p1, 3, "Y");
+                delete_range(&mut peer, p1, 4, 6);
+                insert_text(&mut peer, p1, 4, "X");
+            } else {
+                insert_text(&mut peer, p1, 2, "Y");
+                delete_range(&mut peer, p1, 1, 2);
+                insert_text(&mut peer, p1, 1, "X");
+            }
+
+            let receiver_heads = receiver.current_heads().into_iter().collect();
+            let changesets = peer.missing_changesets_tolerant(&receiver_heads);
+            assert!(changesets.len() >= 3);
+            for changeset in changesets {
+                receiver.receive_remote_changeset(changeset);
+            }
+            receiver.tick().unwrap();
+
+            assert_eq!(
+                located_text(&receiver, "r").as_deref(),
+                Some(if upper { "bcY" } else { "Ycd" }),
+                "remote boundary result diverged (upper={upper}, reversed={reversed})"
+            );
+        }
+    }
+}
+
+#[test]
 fn range_shrinks_at_right_edge_after_covering_delete_and_undo() {
     let (initial, p1) = state! {
         doc { root { p1: paragraph { text("ㅁㄴㅇㅁㅁㅁㅁㄴㅁㅇ") } } }
@@ -1698,6 +1816,150 @@ fn redo_restores_inserted_text() {
         op: HistoryOp::Redo,
     });
     assert_eq!(editor.state().view().node(p1).unwrap().inline_text(), "ax");
+}
+
+#[test]
+fn deleted_inline_end_keeps_observed_interior_insert_and_excludes_later_gap_insert() {
+    for reversed in [false, true] {
+        let (initial, p1) = state! {
+            doc { root { p1: paragraph { text("abcdef") } } }
+            selection: (p1, 0)
+        };
+        let mut editor = Editor::new_test(initial);
+        editor.apply(add_message(
+            "r",
+            "comment",
+            directed_selection(p1, 1, 4, reversed),
+        ));
+
+        insert_text(&mut editor, p1, 3, "Y");
+        delete_range(&mut editor, p1, 4, 6);
+        assert_eq!(located_text(&editor, "r").as_deref(), Some("bcY"));
+
+        insert_text(&mut editor, p1, 4, "X");
+        assert_eq!(
+            located_text(&editor, "r").as_deref(),
+            Some("bcY"),
+            "later typing at a deleted upper boundary must stay outside (reversed={reversed})"
+        );
+    }
+}
+
+#[test]
+fn deleted_inline_start_keeps_observed_interior_insert_and_excludes_later_gap_insert() {
+    for reversed in [false, true] {
+        let (initial, p1) = state! {
+            doc { root { p1: paragraph { text("abcdef") } } }
+            selection: (p1, 0)
+        };
+        let mut editor = Editor::new_test(initial);
+        editor.apply(add_message(
+            "r",
+            "comment",
+            directed_selection(p1, 1, 4, reversed),
+        ));
+
+        insert_text(&mut editor, p1, 2, "Y");
+        delete_range(&mut editor, p1, 1, 2);
+        assert_eq!(located_text(&editor, "r").as_deref(), Some("Ycd"));
+
+        insert_text(&mut editor, p1, 1, "X");
+        assert_eq!(
+            located_text(&editor, "r").as_deref(),
+            Some("Ycd"),
+            "later typing at a deleted lower boundary must stay outside (reversed={reversed})"
+        );
+    }
+}
+
+#[test]
+fn fully_deleted_inline_range_stays_at_canonical_end_gap_through_typing_and_history() {
+    for reversed in [false, true] {
+        let (initial, p1) = state! {
+            doc { root { p1: paragraph { text("abcdef") } } }
+            selection: (p1, 0)
+        };
+        let mut editor = Editor::new_test(initial);
+        editor.undo_history =
+            editor_state::undo::UndoHistory::new(editor_common::time::Duration::from_millis(0));
+        editor.apply(add_message(
+            "r",
+            "comment",
+            directed_selection(p1, 1, 4, reversed),
+        ));
+
+        delete_range(&mut editor, p1, 1, 4);
+        assert_eq!(restored_offsets(&editor, "r"), (1, 1));
+        assert!(is_unlocated(&editor, "r"));
+
+        insert_text(&mut editor, p1, 1, "X");
+        assert_eq!(restored_offsets(&editor, "r"), (1, 1));
+        assert!(is_unlocated(&editor, "r"));
+
+        insert_text(&mut editor, p1, 1, "Y");
+        assert_eq!(restored_offsets(&editor, "r"), (1, 1));
+        assert!(is_unlocated(&editor, "r"));
+
+        editor.apply(Message::History {
+            op: HistoryOp::Undo,
+        });
+        assert_eq!(restored_offsets(&editor, "r"), (1, 1));
+        assert!(is_unlocated(&editor, "r"));
+
+        editor.apply(Message::History {
+            op: HistoryOp::Redo,
+        });
+        assert_eq!(restored_offsets(&editor, "r"), (1, 1));
+        assert!(is_unlocated(&editor, "r"));
+    }
+}
+
+#[test]
+fn set_group_only_changes_group_during_deleted_boundary_history() {
+    let (mut baseline, baseline_text) = run_deleted_end_history_with_group_transitions(&[]);
+    baseline.group = "normalized".into();
+    assert_eq!(baseline_text.as_deref(), Some("bcY"));
+
+    for groups in [&["active"][..], &["active", "hover", "selected"][..]] {
+        let (mut actual, actual_text) = run_deleted_end_history_with_group_transitions(groups);
+        actual.group = "normalized".into();
+        assert_eq!(
+            actual, baseline,
+            "0/1/multiple group transitions must preserve the tracked range payload"
+        );
+        assert_eq!(actual_text, baseline_text);
+    }
+}
+
+#[test]
+fn setting_the_same_group_does_not_recapture_a_deleted_boundary() {
+    let (initial, p1) = state! {
+        doc { root { p1: paragraph { text("abcdef") } } }
+        selection: (p1, 0)
+    };
+    let mut editor = Editor::new_test(initial);
+    editor.apply(add_message(
+        "r",
+        "comment",
+        directed_selection(p1, 1, 4, false),
+    ));
+    insert_text(&mut editor, p1, 3, "Y");
+    delete_range(&mut editor, p1, 4, 6);
+    let before = editor.tracked_ranges().get("r").unwrap().clone();
+
+    let events = editor.apply(Message::TrackedRange {
+        op: TrackedRangeOp::SetGroup {
+            id: "r".into(),
+            group: "comment".into(),
+        },
+    });
+
+    assert_eq!(editor.tracked_ranges().get("r"), Some(&before));
+    assert!(!events.iter().any(|event| matches!(
+        event,
+        crate::event::EditorEvent::StateChanged { fields }
+            if fields.contains(&crate::state_field::StateField::TrackedRanges)
+    )));
 }
 
 #[test]

--- a/crates/editor-core/src/tests/tracked_range_stale.rs
+++ b/crates/editor-core/src/tests/tracked_range_stale.rs
@@ -112,6 +112,37 @@ fn typing_at_range_boundaries_keeps_it() {
 }
 
 #[test]
+fn group_transitions_do_not_change_text_staleness() {
+    for groups in [
+        &[][..],
+        &["active"][..],
+        &["active", "hover", "selected"][..],
+    ] {
+        let (mut editor, p1) = hello_world_editor();
+        for group in groups {
+            editor.apply(Message::TrackedRange {
+                op: TrackedRangeOp::SetGroup {
+                    id: "r1".into(),
+                    group: (*group).into(),
+                },
+            });
+        }
+
+        set_cursor(&mut editor, p1, 2);
+        let events = editor.apply(Message::Insertion {
+            op: InsertionOp::Text { text: "X".into() },
+        });
+
+        assert!(!editor.tracked_ranges().contains("r1"));
+        assert_eq!(
+            stale_ids(&events),
+            vec!["r1".to_string()],
+            "0/1/multiple group transitions must preserve staleness (groups={groups:?})"
+        );
+    }
+}
+
+#[test]
 fn paragraph_split_outside_range_keeps_it() {
     let (mut editor, p1) = hello_world_editor();
     set_cursor(&mut editor, p1, 8);

--- a/crates/editor-crdt/src/sequence/mod.rs
+++ b/crates/editor-crdt/src/sequence/mod.rs
@@ -837,6 +837,15 @@ impl BoundaryResolver {
             .gap_for_target(&self.index.tree, &self.index.lv_of, target)
     }
 
+    /// Tombstone-inclusive document index of a sequence insertion.
+    ///
+    /// Unlike a visible rank, this remains stable while the insertion is
+    /// deleted and therefore can order two persisted boundary anchors.
+    pub fn doc_index_of(&self, dot: Dot) -> Option<usize> {
+        let lv = *self.index.lv_of.get(&dot)?;
+        self.index.tree.doc_index_of_lv_checked(lv)
+    }
+
     /// Descending current visible positions of `del`'s still-visible targets,
     /// for redoing a deletion. See [`ResolveIndex::del_target_positions`].
     pub fn del_target_positions(&self, del: Dot) -> Vec<usize> {

--- a/crates/editor-state/src/stable_position.rs
+++ b/crates/editor-state/src/stable_position.rs
@@ -259,6 +259,13 @@ impl StableResolver<'_> {
         }
     }
 
+    fn doc_index_of(&self, d: Dot) -> Option<usize> {
+        match self {
+            StableResolver::Owned(r) => r.doc_index_of(d),
+            StableResolver::Live(c) => c.doc_index_of(d),
+        }
+    }
+
     fn visible_deletion_survivor(&self, target: Dot, bias: Bias) -> Option<Dot> {
         let mut seen = HashSet::new();
         let mut current = target;
@@ -489,6 +496,23 @@ impl StablePosition {
         Some(self.resolve_in_host(ctx, host, next_child))
     }
 
+    pub(crate) fn has_live_inline_child(&self, ctx: &StableResolveCtx) -> bool {
+        let Some(child) = self.child.as_ref() else {
+            return false;
+        };
+        let is_live_inline = |dot| {
+            ctx.view
+                .block_of(dot)
+                .and_then(|host| ctx.view.node(host))
+                .is_some_and(|host| host.spec().is_textblock())
+        };
+        if is_live_inline(child.dot) {
+            return true;
+        }
+        let alias = ctx.alias(child.dot);
+        alias != child.dot && is_live_inline(alias)
+    }
+
     fn authored_host_at_offset_zero(&self) -> Option<Dot> {
         if self.child.is_some() {
             return None;
@@ -504,13 +528,67 @@ impl StablePosition {
         ctx: &StableResolveCtx,
         primary: Position,
     ) -> Position {
-        self.range_start_after_deleted_empty_host_candidate(ctx, primary)
+        self.inline_range_boundary_position(ctx, primary, Bind::Left)
+            .or_else(|| self.range_start_after_deleted_empty_host_candidate(ctx, primary))
             .unwrap_or(primary)
     }
 
     pub(crate) fn range_end_position(&self, ctx: &StableResolveCtx, primary: Position) -> Position {
-        self.range_end_after_deleted_host_candidate(ctx, primary)
+        self.inline_range_boundary_position(ctx, primary, Bind::Right)
+            .or_else(|| self.range_end_after_deleted_host_candidate(ctx, primary))
             .unwrap_or(primary)
+    }
+
+    /// Preserves `primary` when no inline correction is needed. `None` leaves
+    /// structural or whole-selection fallback policy to the caller.
+    pub(crate) fn inline_range_boundary_position(
+        &self,
+        ctx: &StableResolveCtx,
+        primary: Position,
+        expected_bind: Bind,
+    ) -> Option<Position> {
+        let child = self.child.as_ref()?;
+        if child.bind != expected_bind {
+            return Some(primary);
+        }
+        let dot = ctx.alias(child.dot);
+        if ctx.resolver.boundary(dot)?.visible {
+            return Some(primary);
+        }
+        let (host, _, _) = self.inline_boundary_key(ctx)?;
+        let bias = match expected_bind {
+            Bind::Left => Bias::After,
+            Bind::Right => Bias::Before,
+        };
+        let survivor = ctx.resolver.visible_deletion_survivor(dot, bias)?;
+        let candidate = self.resolve_child_parent_boundary(ctx, survivor, expected_bind)?;
+        (candidate.node == host && candidate.node == primary.node).then_some(candidate)
+    }
+
+    pub(crate) fn cmp_inline_boundary(
+        &self,
+        other: &StablePosition,
+        ctx: &StableResolveCtx,
+    ) -> Option<std::cmp::Ordering> {
+        let (host, index, side) = self.inline_boundary_key(ctx)?;
+        let (other_host, other_index, other_side) = other.inline_boundary_key(ctx)?;
+        (host == other_host).then(|| (index, side).cmp(&(other_index, other_side)))
+    }
+
+    fn inline_boundary_key(&self, ctx: &StableResolveCtx) -> Option<(Dot, usize, u8)> {
+        let child = self.child.as_ref()?;
+        let dot = ctx.alias(child.dot);
+        let host = ctx
+            .view
+            .block_of(dot)
+            .or_else(|| self.resolve_chain_host(ctx).map(|(host, _)| host.id()))?;
+        let host_view = ctx.view.node(host)?;
+        if !host_view.spec().is_textblock() {
+            return None;
+        }
+        let index = ctx.resolver.doc_index_of(dot)?;
+        let side = u8::from(child.bind == Bind::Right);
+        Some((host, index, side))
     }
 
     fn range_end_after_deleted_host_candidate(

--- a/crates/editor-state/src/stable_selection.rs
+++ b/crates/editor-state/src/stable_selection.rs
@@ -5,6 +5,7 @@ use editor_macros::ffi;
 use editor_model::DocView;
 use serde::{Deserialize, Serialize};
 
+use crate::bind::Bind;
 use crate::selection::Selection;
 use crate::stable_position::{StablePosition, StableResolveCtx};
 use crate::state::State;
@@ -70,6 +71,15 @@ impl StableSelection {
         if self.anchor == self.head {
             return Some(primary);
         }
+        if self.anchor.has_live_inline_child(ctx) && self.head.has_live_inline_child(ctx) {
+            return Some(primary);
+        }
+
+        if let Some(order) = self.anchor.cmp_inline_boundary(&self.head, ctx)
+            && order != Ordering::Equal
+        {
+            return Some(self.resolve_inline_range(ctx, primary, order));
+        }
 
         let Some(resolved) = primary.resolve(ctx.view()) else {
             return Some(primary);
@@ -85,6 +95,46 @@ impl StableSelection {
             },
             Ordering::Equal => primary,
         })
+    }
+
+    fn resolve_inline_range(
+        &self,
+        ctx: &StableResolveCtx,
+        primary: Selection,
+        order: Ordering,
+    ) -> Selection {
+        let (start, end, reversed) = match order {
+            Ordering::Less => (
+                self.anchor
+                    .inline_range_boundary_position(ctx, primary.anchor, Bind::Left),
+                self.head
+                    .inline_range_boundary_position(ctx, primary.head, Bind::Right),
+                false,
+            ),
+            Ordering::Greater => (
+                self.head
+                    .inline_range_boundary_position(ctx, primary.head, Bind::Left),
+                self.anchor
+                    .inline_range_boundary_position(ctx, primary.anchor, Bind::Right),
+                true,
+            ),
+            Ordering::Equal => return primary,
+        };
+        let (Some(start), Some(end)) = (start, end) else {
+            return primary;
+        };
+
+        let crosses = Selection::new(start, end)
+            .resolve(ctx.view())
+            .is_some_and(|resolved| resolved.anchor() > resolved.head());
+        if crosses {
+            return Selection::collapsed(end);
+        }
+        if reversed {
+            Selection::new(end, start)
+        } else {
+            Selection::new(start, end)
+        }
     }
 }
 
@@ -112,10 +162,10 @@ pub fn remap_selection(selection: Selection, source: &State, target: &State) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use editor_crdt::{Dot, InputEvent, ListOp, build_oplog};
+    use editor_crdt::{Changeset, Dot, InputEvent, ListOp, OpGraph, build_oplog};
     use editor_model::{
-        AliasLog, DocLogs, ModifierAttrLog, NodeAttrLog, NodeType, ProjectedDoc, SeqItem, SpanLog,
-        project_document,
+        AliasLog, DocLogs, EditOp, ModifierAttrLog, NodeAttrLog, NodeType, ProjectedDoc, SeqItem,
+        SpanLog, project_document,
     };
 
     use crate::Position;
@@ -396,6 +446,270 @@ mod tests {
             let restored = ss.resolve(&undel_ctx).expect("resolve after undel");
             proptest::prop_assert_eq!(restored.anchor, anchor);
             proptest::prop_assert_eq!(restored.head, head);
+        }
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    enum DeletedInlineBoundaryCase {
+        Start,
+        End,
+        Full,
+    }
+
+    fn inline_state(text: &str) -> (crate::ProjectedState, Dot) {
+        let mut state = crate::ProjectedState::empty();
+        let paragraph = state.seq().entries[0].dot;
+        for (offset, ch) in text.chars().enumerate() {
+            state
+                .apply(EditOp::Seq(ListOp::Ins {
+                    pos: 1 + offset,
+                    item: SeqItem::Char(ch),
+                }))
+                .unwrap();
+        }
+        (state, paragraph)
+    }
+
+    fn directed_inline_selection(
+        paragraph: Dot,
+        start: usize,
+        end: usize,
+        reversed: bool,
+    ) -> Selection {
+        let start = Position::new(paragraph, start);
+        let end = Position::new(paragraph, end);
+        if reversed {
+            Selection::new(end, start)
+        } else {
+            Selection::new(start, end)
+        }
+    }
+
+    fn assert_owned_live_resolution(
+        stable: &StableSelection,
+        state: &crate::ProjectedState,
+        expected: Selection,
+    ) {
+        let view = state.view();
+        let owned = StableResolveCtx::new(&view, state.seq());
+        let live = StableResolveCtx::from_live(&view, state.seq_checkout());
+        assert_eq!(stable.resolve(&owned), Some(expected));
+        assert_eq!(stable.resolve(&live), Some(expected));
+    }
+
+    fn projected_client(actor: u64, base: &[Changeset<EditOp>]) -> crate::ProjectedState {
+        let mut graph = OpGraph::with_actor(actor);
+        for changeset in base {
+            graph
+                .receive_changeset_mut(changeset.clone())
+                .expect("shared base applies");
+        }
+        crate::ProjectedState::from_graph(graph).expect("shared base projects")
+    }
+
+    #[test]
+    fn deleted_inline_boundary_resolution_matches_owned_and_live() {
+        for case in [
+            DeletedInlineBoundaryCase::Start,
+            DeletedInlineBoundaryCase::End,
+            DeletedInlineBoundaryCase::Full,
+        ] {
+            for reversed in [false, true] {
+                let (mut state, paragraph) = inline_state("abcdef");
+                let stable = StableSelection::capture(
+                    &directed_inline_selection(paragraph, 1, 4, reversed),
+                    &state.view(),
+                );
+
+                let (expected_start, expected_end) = match case {
+                    DeletedInlineBoundaryCase::Start => {
+                        state
+                            .apply(EditOp::Seq(ListOp::Ins {
+                                pos: 3,
+                                item: SeqItem::Char('Y'),
+                            }))
+                            .unwrap();
+                        state
+                            .apply(EditOp::Seq(ListOp::Del { pos: 2, len: 1 }))
+                            .unwrap();
+                        state
+                            .apply(EditOp::Seq(ListOp::Ins {
+                                pos: 2,
+                                item: SeqItem::Char('X'),
+                            }))
+                            .unwrap();
+                        (2, 5)
+                    }
+                    DeletedInlineBoundaryCase::End => {
+                        state
+                            .apply(EditOp::Seq(ListOp::Ins {
+                                pos: 4,
+                                item: SeqItem::Char('Y'),
+                            }))
+                            .unwrap();
+                        state
+                            .apply(EditOp::Seq(ListOp::Del { pos: 5, len: 2 }))
+                            .unwrap();
+                        state
+                            .apply(EditOp::Seq(ListOp::Ins {
+                                pos: 5,
+                                item: SeqItem::Char('X'),
+                            }))
+                            .unwrap();
+                        (1, 4)
+                    }
+                    DeletedInlineBoundaryCase::Full => {
+                        state
+                            .apply(EditOp::Seq(ListOp::Del { pos: 2, len: 3 }))
+                            .unwrap();
+                        state
+                            .apply(EditOp::Seq(ListOp::Ins {
+                                pos: 2,
+                                item: SeqItem::Char('X'),
+                            }))
+                            .unwrap();
+                        (1, 1)
+                    }
+                };
+                let expected = directed_inline_selection(
+                    paragraph,
+                    expected_start,
+                    expected_end,
+                    reversed && expected_start != expected_end,
+                );
+                assert_owned_live_resolution(&stable, &state, expected);
+            }
+        }
+    }
+
+    #[test]
+    fn collapsed_selection_keeps_primary_resolution_after_its_child_is_deleted() {
+        let (mut state, paragraph) = inline_state("abcdef");
+        let stable = StableSelection::capture(
+            &Selection::collapsed(Position::new(paragraph, 2)),
+            &state.view(),
+        );
+        state
+            .apply(EditOp::Seq(ListOp::Del { pos: 2, len: 2 }))
+            .unwrap();
+        state
+            .apply(EditOp::Seq(ListOp::Ins {
+                pos: 2,
+                item: SeqItem::Char('X'),
+            }))
+            .unwrap();
+
+        let view = state.view();
+        for ctx in [
+            StableResolveCtx::new(&view, state.seq()),
+            StableResolveCtx::from_live(&view, state.seq_checkout()),
+        ] {
+            let primary = stable.anchor.resolve(&ctx).unwrap();
+            assert_eq!(stable.resolve(&ctx), Some(Selection::collapsed(primary)));
+        }
+    }
+
+    #[test]
+    fn missing_canonical_inline_end_candidate_preserves_primary_selection() {
+        let (mut state, paragraph) = inline_state("abcdef");
+        let stable = StableSelection::capture(
+            &directed_inline_selection(paragraph, 0, 3, false),
+            &state.view(),
+        );
+        state
+            .apply(EditOp::Seq(ListOp::Del { pos: 1, len: 3 }))
+            .unwrap();
+        state
+            .apply(EditOp::Seq(ListOp::Ins {
+                pos: 1,
+                item: SeqItem::Char('X'),
+            }))
+            .unwrap();
+
+        let view = state.view();
+        for ctx in [
+            StableResolveCtx::new(&view, state.seq()),
+            StableResolveCtx::from_live(&view, state.seq_checkout()),
+        ] {
+            let primary = Selection {
+                anchor: stable.anchor.resolve(&ctx).unwrap(),
+                head: stable.head.resolve(&ctx).unwrap(),
+            };
+            let end = stable
+                .head
+                .inline_range_boundary_position(&ctx, primary.head, Bind::Right);
+            assert_eq!(end, None);
+            assert_eq!(stable.resolve(&ctx), Some(primary));
+        }
+    }
+
+    #[test]
+    fn deletion_gap_excludes_an_insertion_the_delete_did_not_observe() {
+        let mut base_graph = OpGraph::with_actor(0);
+        base_graph
+            .add_mut(EditOp::Seq(ListOp::Ins {
+                pos: 0,
+                item: block(NodeType::Paragraph, vec![Dot::ROOT]),
+            }))
+            .unwrap();
+        for (offset, ch) in "abcdef".chars().enumerate() {
+            base_graph
+                .add_mut(EditOp::Seq(ListOp::Ins {
+                    pos: 1 + offset,
+                    item: SeqItem::Char(ch),
+                }))
+                .unwrap();
+        }
+        base_graph.commit_mut();
+        let base = base_graph.changesets_as_vec();
+        let paragraph = base[0].ops[0].id;
+
+        for reversed in [false, true] {
+            let base_state = projected_client(3, &base);
+            let stable = StableSelection::capture(
+                &directed_inline_selection(paragraph, 1, 4, reversed),
+                &base_state.view(),
+            );
+
+            let mut inserter = projected_client(1, &base);
+            inserter
+                .apply(EditOp::Seq(ListOp::Ins {
+                    pos: 4,
+                    item: SeqItem::Char('Z'),
+                }))
+                .unwrap();
+            inserter.commit();
+
+            let mut deleter = projected_client(2, &base);
+            deleter
+                .apply(EditOp::Seq(ListOp::Del { pos: 4, len: 2 }))
+                .unwrap();
+            deleter.commit();
+
+            let mut merged = projected_client(4, &base);
+            for changeset in inserter
+                .graph()
+                .changesets_as_vec()
+                .into_iter()
+                .chain(deleter.graph().changesets_as_vec())
+                .filter(|changeset| changeset.ops[0].id.actor != 0)
+            {
+                merged = merged.receive_changeset(changeset).unwrap();
+            }
+
+            assert!(
+                merged
+                    .view()
+                    .node(paragraph)
+                    .unwrap()
+                    .inline_text()
+                    .contains('Z')
+            );
+            assert_owned_live_resolution(
+                &stable,
+                &merged,
+                directed_inline_selection(paragraph, 1, 3, reversed),
+            );
         }
     }
 }


### PR DESCRIPTION
## 문제

tracked range의 inline 시작점이나 끝점이 삭제되면 일반 stable position 복원만으로는 삭제 전부터 범위 안에 있던 입력과 삭제 후 같은 gap에 들어온 입력을 구분하기 어렵습니다.

예를 들어 `bcd` 범위 안에 `Y`를 입력하고 끝 경계를 삭제한 뒤 같은 위치에 `X`를 입력하면, 범위는 `bcY`를 유지해야 하지만 `bcYX`로 다시 확장될 수 있었습니다.

또한 `SetGroup`이 stable selection을 다시 capture하면서 group 변경이 range membership 결과에도 영향을 줄 수 있었습니다.

## 변경 사항

- tombstone을 포함한 sequence 순서와 bind 방향을 이용해 삭제된 inline 시작점과 끝점을 복원합니다.
- 삭제 전에 범위 안에 들어온 입력은 유지하고, 삭제 후 또는 concurrent하게 같은 gap에 들어온 입력은 제외합니다.
- 범위가 전부 삭제된 경우 canonical end gap에 접어서 후속 입력이나 undo/redo로 범위가 되살아나지 않게 합니다.
- `SetGroup`은 stable selection과 payload를 변경하지 않고 group만 갱신하도록 단순화합니다.
- live inline range의 기존 빠른 복원 경로는 유지합니다.