### PR TITLE
tracked range membership 정책을 웹/앱에서 통일

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Editor.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Editor.kt
@@ -1375,13 +1375,12 @@ internal constructor(
         trackedRanges = trackedRanges,
         trackedRangesContainingSelectionHead =
           if (selection != null && selection.anchor == selection.head) {
-            if (
-              selectionChanged ||
-                changed(StateField.TrackedRanges) ||
-                documentChanged ||
-                renderInvalidated
-            ) {
-              inner.trackedRangesContainingPosition(selection.head, null)
+            if (selectionChanged || changed(StateField.TrackedRanges) || documentChanged) {
+              if (trackedRanges.isEmpty()) {
+                emptyList()
+              } else {
+                inner.trackedRangesContainingPosition(selection.head, null)
+              }
             } else {
               previous.trackedRangesContainingSelectionHead
             }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/TrackedRangeMembership.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/TrackedRangeMembership.kt
@@ -1,0 +1,29 @@
+package co.typie.screen.editor.editor
+
+import co.typie.editor.ffi.TrackedRangeEndpoints
+
+private fun List<TrackedRangeEndpoints>.featureCandidates(
+  allowedGroups: Set<String>,
+  ownedIds: Set<String>?,
+): List<TrackedRangeEndpoints> = filter { range ->
+  range.group in allowedGroups && (ownedIds == null || range.id in ownedIds)
+}
+
+internal fun List<TrackedRangeEndpoints>.trackedRangeMembershipIds(
+  allowedGroups: Set<String>,
+  ownedIds: Set<String>? = null,
+): List<String> = featureCandidates(allowedGroups, ownedIds).map { it.id }
+
+/**
+ * Core가 정한 membership fallback 순서를 보존하면서 feature가 사용할 한 범위를 고른다.
+ *
+ * 명시적인 active ID도 현재 cursor의 후보이면서 허용된 group/소유 ID에 속할 때만 우선한다.
+ */
+internal fun List<TrackedRangeEndpoints>.selectTrackedRangeMember(
+  allowedGroups: Set<String>,
+  activeId: String?,
+  ownedIds: Set<String>? = null,
+): TrackedRangeEndpoints? {
+  val candidates = featureCandidates(allowedGroups, ownedIds)
+  return activeId?.let { id -> candidates.firstOrNull { it.id == id } } ?: candidates.firstOrNull()
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/aifeedback/AiFeedbackEditorRanges.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/aifeedback/AiFeedbackEditorRanges.kt
@@ -6,11 +6,12 @@ import co.typie.editor.ffi.DecorationStyle
 import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.Selection
 import co.typie.editor.ffi.TrackedRange
-import co.typie.editor.ffi.TrackedRangeEndpoints
 import co.typie.editor.ffi.TrackedRangeOp
 
 internal const val AI_FEEDBACK_RANGE_GROUP = "ai-feedback"
 internal const val ACTIVE_AI_FEEDBACK_RANGE_GROUP = "ai-feedback-active"
+internal val AI_FEEDBACK_MEMBERSHIP_GROUPS =
+  setOf(AI_FEEDBACK_RANGE_GROUP, ACTIVE_AI_FEEDBACK_RANGE_GROUP)
 
 internal data class AiFeedbackRangeRegistration(val id: String, val selection: Selection)
 
@@ -73,14 +74,6 @@ internal suspend fun Editor.removeAiFeedbackRange(id: String) {
 internal suspend fun Editor.removeAiFeedbackRanges(ids: Iterable<String>) {
   update { ids.forEach { id -> enqueue(Message.TrackedRange(TrackedRangeOp.Remove(id = id))) } }
 }
-
-internal val TrackedRangeEndpoints.isAiFeedbackRange: Boolean
-  get() = group == AI_FEEDBACK_RANGE_GROUP || group == ACTIVE_AI_FEEDBACK_RANGE_GROUP
-
-internal fun List<TrackedRangeEndpoints>.aiFeedbackRangeEndpoints(): List<TrackedRangeEndpoints> =
-  filter {
-    it.isAiFeedbackRange
-  }
 
 internal fun List<TrackedRange>.aiFeedbackRanges(): List<TrackedRange> = filter {
   it.group == AI_FEEDBACK_RANGE_GROUP || it.group == ACTIVE_AI_FEEDBACK_RANGE_GROUP

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/aifeedback/EditorAiFeedbackSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/aifeedback/EditorAiFeedbackSession.kt
@@ -13,13 +13,14 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.viewmodel.compose.viewModel
 import co.typie.editor.Editor
 import co.typie.editor.EditorState
-import co.typie.editor.ffi.Selection
 import co.typie.editor.scroll.EditorBringIntoViewBehavior
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.toPageRectsTarget
 import co.typie.graphql.AiFeedback_LiteraryAnalysisDocumentStream_Subscription
 import co.typie.graphql.Apollo
+import co.typie.screen.editor.editor.selectTrackedRangeMember
 import co.typie.screen.editor.editor.state.EditorOverlayOcclusion
+import co.typie.screen.editor.editor.trackedRangeMembershipIds
 import co.typie.ui.component.toast.LocalToast
 import co.typie.ui.component.toast.ToastType
 import com.apollographql.apollo.api.Optional
@@ -58,7 +59,8 @@ internal fun rememberEditorAiFeedbackSession(
   val scope = rememberCoroutineScope()
   val toast = LocalToast.current
   var bottomOcclusion by remember(documentId) { mutableFloatStateOf(0f) }
-  var lastSelectionMappedToAiFeedback by remember(documentId) { mutableStateOf<Selection?>(null) }
+  var lastMembershipIdsMappedToAiFeedback by
+    remember(documentId) { mutableStateOf<List<String>?>(null) }
   var occlusionReleaseJob by remember(documentId) { mutableStateOf<Job?>(null) }
   var analysisJob by remember(documentId) { mutableStateOf<Job?>(null) }
   val model = documentId?.let { id ->
@@ -113,7 +115,6 @@ internal fun rememberEditorAiFeedbackSession(
       val analysisRunId = activeModel.prepareAnalysis(sourceText)
       activeEditor.installAiFeedbackDecorations()
       activeEditor.clearAiFeedbackRanges()
-      lastSelectionMappedToAiFeedback = activeEditor.appliedState.selection
       if (sourceText.trim().isBlank()) {
         activeModel.complete()
         setOverlayBottomOcclusion(0f)
@@ -151,9 +152,6 @@ internal fun rememberEditorAiFeedbackSession(
                   AiFeedbackRangeRegistration(id = raw.id, selection = selection)
                 )
                 activeModel.appendResult(raw.toAiFeedbackResult())
-                if (wasEmpty) {
-                  lastSelectionMappedToAiFeedback = activeEditor.appliedState.selection
-                }
                 updateCompactOverlayHeightForRange(activeModel.activeRangeId)
                 updateActiveRangeDecoration()
                 if (wasEmpty) {
@@ -227,7 +225,7 @@ internal fun rememberEditorAiFeedbackSession(
     occlusionReleaseJob?.cancel()
     occlusionReleaseJob = null
     bottomOcclusion = 0f
-    lastSelectionMappedToAiFeedback = null
+    lastMembershipIdsMappedToAiFeedback = null
   }
 
   DisposableEffect(editor) { onDispose { disposeEditor(editor) } }
@@ -267,32 +265,50 @@ internal fun rememberEditorAiFeedbackSession(
     updateActiveRangeDecoration()
   }
 
-  LaunchedEffect(active, editorState.selection) {
+  LaunchedEffect(
+    active,
+    editorState.selection,
+    editorState.trackedRanges,
+    editorState.trackedRangesContainingSelectionHead,
+    model?.results,
+  ) {
     val activeModel = model ?: return@LaunchedEffect
     if (!active) {
-      lastSelectionMappedToAiFeedback = null
+      lastMembershipIdsMappedToAiFeedback = null
       return@LaunchedEffect
     }
     val selection =
       editorState.selection
         ?: run {
-          lastSelectionMappedToAiFeedback = null
+          lastMembershipIdsMappedToAiFeedback = null
           return@LaunchedEffect
         }
     if (activeModel.results.isEmpty()) {
-      lastSelectionMappedToAiFeedback = selection
+      lastMembershipIdsMappedToAiFeedback = null
       return@LaunchedEffect
     }
-    if (selection == lastSelectionMappedToAiFeedback) return@LaunchedEffect
-    lastSelectionMappedToAiFeedback = selection
-    if (selection.anchor != selection.head) return@LaunchedEffect
+    if (selection.anchor != selection.head) {
+      lastMembershipIdsMappedToAiFeedback = null
+      return@LaunchedEffect
+    }
+
+    val resultIds = activeModel.results.mapTo(mutableSetOf()) { it.id }
+    val membershipIds =
+      editorState.trackedRangesContainingSelectionHead.trackedRangeMembershipIds(
+        allowedGroups = AI_FEEDBACK_MEMBERSHIP_GROUPS,
+        ownedIds = resultIds,
+      )
+    if (membershipIds == lastMembershipIdsMappedToAiFeedback) return@LaunchedEffect
+    lastMembershipIdsMappedToAiFeedback = membershipIds
 
     val rangeId =
       editorState.trackedRangesContainingSelectionHead
-        .aiFeedbackRangeEndpoints()
-        .firstOrNull()
+        .selectTrackedRangeMember(
+          allowedGroups = AI_FEEDBACK_MEMBERSHIP_GROUPS,
+          activeId = activeModel.activeRangeId,
+          ownedIds = resultIds,
+        )
         ?.id
-        ?.takeIf { id -> activeModel.results.any { it.id == id } }
     val previousActiveRangeId = activeModel.activeRangeId
     if (rangeId == null) {
       activeModel.activate(null)

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/spellcheck/EditorSpellcheckSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/spellcheck/EditorSpellcheckSession.kt
@@ -22,7 +22,9 @@ import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.EditorBringIntoViewTarget
 import co.typie.editor.scroll.toPageRectsTarget
 import co.typie.editor.scroll.updateWithBringIntoView
+import co.typie.screen.editor.editor.selectTrackedRangeMember
 import co.typie.screen.editor.editor.state.EditorOverlayOcclusion
+import co.typie.screen.editor.editor.trackedRangeMembershipIds
 import co.typie.ui.component.toast.LocalToast
 import co.typie.ui.component.toast.ToastType
 import kotlin.math.max
@@ -67,7 +69,8 @@ internal fun rememberEditorSpellcheckSession(
   val scope = rememberCoroutineScope()
   val toast = LocalToast.current
   var bottomOcclusion by remember(documentId) { mutableFloatStateOf(0f) }
-  var lastSelectionMappedToSpellcheck by remember(documentId) { mutableStateOf<Selection?>(null) }
+  var lastMembershipIdsMappedToSpellcheck by
+    remember(documentId) { mutableStateOf<List<String>?>(null) }
   var programmaticSelectionToSkip by remember(documentId) { mutableStateOf<Selection?>(null) }
   var occlusionReleaseJob by remember(documentId) { mutableStateOf<Job?>(null) }
   val model = documentId?.let { id ->
@@ -140,7 +143,6 @@ internal fun rememberEditorSpellcheckSession(
         }
       },
       onReady = { results ->
-        lastSelectionMappedToSpellcheck = activeEditor.appliedState.selection
         if (results.isEmpty()) {
           setOverlayBottomOcclusion(0f)
         } else {
@@ -191,7 +193,7 @@ internal fun rememberEditorSpellcheckSession(
     occlusionReleaseJob?.cancel()
     occlusionReleaseJob = null
     bottomOcclusion = 0f
-    lastSelectionMappedToSpellcheck = null
+    lastMembershipIdsMappedToSpellcheck = null
     programmaticSelectionToSkip = null
   }
 
@@ -235,7 +237,7 @@ internal fun rememberEditorSpellcheckSession(
     val activeModel = model ?: return@LaunchedEffect
     val activeEditor = editor ?: return@LaunchedEffect
     if (!active || activeModel.results.isEmpty()) {
-      lastSelectionMappedToSpellcheck = null
+      lastMembershipIdsMappedToSpellcheck = null
       return@LaunchedEffect
     }
 
@@ -252,30 +254,42 @@ internal fun rememberEditorSpellcheckSession(
     }
 
     if (!active || activeModel.results.isEmpty()) {
-      lastSelectionMappedToSpellcheck = null
+      lastMembershipIdsMappedToSpellcheck = null
       return@LaunchedEffect
     }
     val selection =
       editorState.selection
         ?: run {
-          lastSelectionMappedToSpellcheck = null
+          lastMembershipIdsMappedToSpellcheck = null
           return@LaunchedEffect
         }
-    if (selection == programmaticSelectionToSkip) {
-      programmaticSelectionToSkip = null
-      lastSelectionMappedToSpellcheck = selection
+    if (selection.anchor != selection.head) {
+      lastMembershipIdsMappedToSpellcheck = null
       return@LaunchedEffect
     }
-    if (selection == lastSelectionMappedToSpellcheck) return@LaunchedEffect
-    lastSelectionMappedToSpellcheck = selection
-    if (selection.anchor != selection.head) return@LaunchedEffect
+
+    val resultIds = activeModel.results.mapTo(mutableSetOf()) { it.id }
+    val membershipIds =
+      editorState.trackedRangesContainingSelectionHead.trackedRangeMembershipIds(
+        allowedGroups = SPELLCHECK_MEMBERSHIP_GROUPS,
+        ownedIds = resultIds,
+      )
+    if (selection == programmaticSelectionToSkip) {
+      programmaticSelectionToSkip = null
+      lastMembershipIdsMappedToSpellcheck = membershipIds
+      return@LaunchedEffect
+    }
+    if (membershipIds == lastMembershipIdsMappedToSpellcheck) return@LaunchedEffect
+    lastMembershipIdsMappedToSpellcheck = membershipIds
 
     val rangeId =
       editorState.trackedRangesContainingSelectionHead
-        .spellcheckRangeEndpoints()
-        .firstOrNull()
+        .selectTrackedRangeMember(
+          allowedGroups = SPELLCHECK_MEMBERSHIP_GROUPS,
+          activeId = activeModel.activeRangeId,
+          ownedIds = resultIds,
+        )
         ?.id
-        ?.takeIf { id -> activeModel.results.any { it.id == id } }
     val previousActiveRangeId = activeModel.activeRangeId
     if (rangeId == null) {
       activeModel.activate(null)

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/spellcheck/SpellcheckEditorRanges.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/spellcheck/SpellcheckEditorRanges.kt
@@ -8,13 +8,14 @@ import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.ProseRangeInstallOutcome
 import co.typie.editor.ffi.ProseTrackedRangeRegistration
 import co.typie.editor.ffi.TrackedRange
-import co.typie.editor.ffi.TrackedRangeEndpoints
 import co.typie.editor.ffi.TrackedRangeOp
 import co.typie.editor.ffi.Underline
 import co.typie.editor.ffi.UnderlineStyle
 
 internal const val SPELLCHECK_RANGE_GROUP = "spellcheck"
 internal const val ACTIVE_SPELLCHECK_RANGE_GROUP = "spellcheck-active"
+internal val SPELLCHECK_MEMBERSHIP_GROUPS =
+  setOf(SPELLCHECK_RANGE_GROUP, ACTIVE_SPELLCHECK_RANGE_GROUP)
 
 internal enum class SpellcheckRangeInstallResult {
   Ready,
@@ -148,14 +149,6 @@ internal suspend fun Editor.replaceSpellcheckRangeText(
     }
     ?.commandOutcomes
     ?.none { it is CommandOutcome.Rejected } == true
-
-internal val TrackedRangeEndpoints.isSpellcheckRange: Boolean
-  get() = group == SPELLCHECK_RANGE_GROUP || group == ACTIVE_SPELLCHECK_RANGE_GROUP
-
-internal fun List<TrackedRangeEndpoints>.spellcheckRangeEndpoints(): List<TrackedRangeEndpoints> =
-  filter {
-    it.isSpellcheckRange
-  }
 
 internal fun List<TrackedRange>.spellcheckRanges(): List<TrackedRange> = filter {
   it.group == SPELLCHECK_RANGE_GROUP || it.group == ACTIVE_SPELLCHECK_RANGE_GROUP

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/comments/CommentEditorRanges.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/comments/CommentEditorRanges.kt
@@ -6,7 +6,6 @@ import co.typie.editor.ffi.DecorationStyle
 import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.StableSelection
 import co.typie.editor.ffi.TrackedRange
-import co.typie.editor.ffi.TrackedRangeEndpoints
 import co.typie.editor.ffi.TrackedRangeOp
 import co.typie.editor.ffi.Underline
 import co.typie.editor.ffi.UnderlineStyle
@@ -15,6 +14,7 @@ internal const val COMMENT_RANGE_GROUP = "comment"
 internal const val ACTIVE_COMMENT_RANGE_GROUP = "comment-active"
 internal const val COMMENT_COMPOSE_RANGE_GROUP = "__comment_compose__"
 internal const val COMMENT_COMPOSE_RANGE_ID = "__comment_compose__"
+internal val COMMENT_MEMBERSHIP_GROUPS = setOf(COMMENT_RANGE_GROUP, ACTIVE_COMMENT_RANGE_GROUP)
 
 internal suspend fun Editor.installCommentDecorations() {
   update { installCommentDecorations(this) }
@@ -93,14 +93,6 @@ internal suspend fun Editor.setCommentComposeRange(selection: StableSelection?) 
 internal fun List<TrackedRange>.commentRanges(): List<TrackedRange> = filter {
   it.group == COMMENT_RANGE_GROUP || it.group == ACTIVE_COMMENT_RANGE_GROUP
 }
-
-internal val TrackedRangeEndpoints.isCommentRange: Boolean
-  get() = group == COMMENT_RANGE_GROUP || group == ACTIVE_COMMENT_RANGE_GROUP
-
-internal fun List<TrackedRangeEndpoints>.commentRangeEndpoints(): List<TrackedRangeEndpoints> =
-  filter {
-    it.isCommentRange
-  }
 
 private fun installCommentDecorations(scope: EditorRequestScope) {
   val underline = Underline(color = "text.amber", style = UnderlineStyle.Solid, thickness = 2f)

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/comments/EditorCommentsSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/comments/EditorCommentsSession.kt
@@ -16,6 +16,7 @@ import co.typie.editor.ffi.StableSelection
 import co.typie.editor.scroll.EditorBringIntoViewBehavior
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.toPageRectsTarget
+import co.typie.screen.editor.editor.selectTrackedRangeMember
 import co.typie.ui.component.toast.LocalToast
 import co.typie.ui.component.toast.ToastType
 import kotlinx.coroutines.launch
@@ -101,26 +102,34 @@ internal fun rememberEditorCommentsSession(
       CommentsViewModel(entityId = entityId, documentId = id)
     }
   }
+  val openSelectionsById = model?.openSelectionsById.orEmpty()
 
   LaunchedEffect(editor) { editor?.installCommentDecorations() }
 
+  val activeThreadId = model?.threadState?.activeThreadId
   val selection = editorState.selection
   val selectionCollapsed = selection == null || selection.anchor == selection.head
-  val collapsedCommentRanges =
-    remember(editorState.trackedRangesContainingSelectionHead, selectionCollapsed) {
+  val collapsedCommentRange =
+    remember(
+      editorState.trackedRangesContainingSelectionHead,
+      selectionCollapsed,
+      activeThreadId,
+      openSelectionsById.keys,
+    ) {
       if (selection != null && selectionCollapsed) {
-        editorState.trackedRangesContainingSelectionHead.commentRangeEndpoints()
+        editorState.trackedRangesContainingSelectionHead.selectTrackedRangeMember(
+          allowedGroups = COMMENT_MEMBERSHIP_GROUPS,
+          activeId = activeThreadId,
+          ownedIds = openSelectionsById.keys,
+        )
       } else {
-        emptyList()
+        null
       }
     }
-  val collapsedCommentRangeIds = collapsedCommentRanges.mapTo(mutableSetOf()) { it.id }
   val collapsedSelectionHead = selection?.takeIf { selectionCollapsed }?.head
   val topBarCreateEnabled = model != null && selection != null && !selectionCollapsed
   val toolbarEnabled =
-    model != null &&
-      selection != null &&
-      (!selectionCollapsed || collapsedCommentRanges.isNotEmpty())
+    model != null && selection != null && (!selectionCollapsed || collapsedCommentRange != null)
 
   val trackedCommentRanges =
     remember(editorState.trackedRanges, sheetActive) {
@@ -137,7 +146,6 @@ internal fun rememberEditorCommentsSession(
   val trackedCommentRangeById =
     remember(trackedCommentRanges) { trackedCommentRanges.associateBy { it.id } }
   val visibleFilter = model?.threadState?.filter ?: CommentFilter.Open
-  val activeThreadId = model?.threadState?.activeThreadId
   var lastRequestedActiveThreadId by remember(editor) { mutableStateOf<String?>(null) }
   val activeThreadRange =
     remember(activeThreadId, trackedCommentRanges) {
@@ -171,7 +179,6 @@ internal fun rememberEditorCommentsSession(
       commentThreadLocation(range.text)
     }
   val composeSelection = model?.threadState?.virtualThread?.selection
-  val openSelectionsById = model?.openSelectionsById.orEmpty()
   val openSelectionDecodeFailureIds = model?.openSelectionDecodeFailureIds.orEmpty()
 
   LaunchedEffect(openSelectionDecodeFailureIds) {
@@ -210,7 +217,7 @@ internal fun rememberEditorCommentsSession(
     if (!requested) return@LaunchedEffect
     lastRequestedActiveThreadId = threadId
   }
-  LaunchedEffect(sheetActive, collapsedSelectionHead, collapsedCommentRangeIds) {
+  LaunchedEffect(sheetActive, collapsedSelectionHead, collapsedCommentRange?.id) {
     if (
       !sheetActive ||
         selection == null ||
@@ -221,7 +228,7 @@ internal fun rememberEditorCommentsSession(
       return@LaunchedEffect
     }
 
-    val threadId = collapsedCommentRanges.firstOrNull()?.id ?: return@LaunchedEffect
+    val threadId = collapsedCommentRange?.id ?: return@LaunchedEffect
     if (threadId != activeThreadId) {
       requestQueue.requestActiveThread(threadId)
     }
@@ -258,9 +265,7 @@ internal fun rememberEditorCommentsSession(
           }
         } else {
           openSheet()
-          collapsedCommentRanges.firstOrNull()?.let { range ->
-            requestQueue.requestActiveThread(range.id)
-          }
+          collapsedCommentRange?.let { range -> requestQueue.requestActiveThread(range.id) }
         }
       }
     },
@@ -269,9 +274,7 @@ internal fun rememberEditorCommentsSession(
       if (model != null) {
         openSheet()
         if (selection != null && selectionCollapsed) {
-          collapsedCommentRanges.firstOrNull()?.let { range ->
-            requestQueue.requestActiveThread(range.id)
-          }
+          collapsedCommentRange?.let { range -> requestQueue.requestActiveThread(range.id) }
         }
       }
     },

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorRequestTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorRequestTest.kt
@@ -280,7 +280,7 @@ class EditorRequestTest {
     }
 
   @Test
-  fun snapshot_reads_tracked_ranges_only_when_state_field_changes() =
+  fun snapshot_refreshes_membership_when_ranges_or_document_change_under_stationary_cursor() =
     runTest(dispatcher) {
       val range =
         TrackedRange(
@@ -304,6 +304,7 @@ class EditorRequestTest {
           listOf(
             listOf(EditorEvent.StateChanged(listOf(StateField.TrackedRanges))),
             listOf(EditorEvent.StateChanged(listOf(StateField.Cursor))),
+            listOf(EditorEvent.StateChanged(listOf(StateField.Doc))),
           )
         )
       val fake =
@@ -327,6 +328,28 @@ class EditorRequestTest {
       assertEquals(1, fake.trackedRangesContainingPositionCallCount)
       assertEquals(listOf(range), editor.appliedState.trackedRanges)
       assertEquals(listOf(rangeEndpoints), editor.appliedState.trackedRangesContainingSelectionHead)
+
+      editor.update { enqueue(sampleMessage) }
+
+      assertEquals(1, fake.trackedRangesCallCount)
+      assertEquals(2, fake.trackedRangesContainingPositionCallCount)
+      assertEquals(listOf(rangeEndpoints), editor.appliedState.trackedRangesContainingSelectionHead)
+    }
+
+  @Test
+  fun snapshot_skips_membership_lookup_when_no_tracked_ranges_exist() =
+    runTest(dispatcher) {
+      val fake =
+        FakeFfiEditor(
+          onTick = { listOf(EditorEvent.StateChanged(listOf(StateField.TrackedRanges))) }
+        )
+      val editor = Editor(fake, this, dispatcher)
+
+      editor.update { enqueue(sampleMessage) }
+
+      assertEquals(1, fake.trackedRangesCallCount)
+      assertEquals(0, fake.trackedRangesContainingPositionCallCount)
+      assertEquals(emptyList(), editor.appliedState.trackedRangesContainingSelectionHead)
     }
 
   @Test

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/TrackedRangeMembershipTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/TrackedRangeMembershipTest.kt
@@ -1,0 +1,86 @@
+package co.typie.screen.editor.editor
+
+import co.typie.editor.ffi.Affinity
+import co.typie.editor.ffi.Position
+import co.typie.editor.ffi.TrackedRangeEndpoints
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class TrackedRangeMembershipTest {
+  private val position = Position(node = "paragraph", offset = 1, affinity = Affinity.Downstream)
+
+  private fun range(id: String, group: String) =
+    TrackedRangeEndpoints(id = id, group = group, anchor = position, head = position)
+
+  @Test
+  fun eligibleActiveMemberWinsWithoutChangingCoreFallbackOrder() {
+    val members = listOf(range("before", "comment"), range("after", "comment-active"))
+
+    assertEquals(
+      "after",
+      members
+        .selectTrackedRangeMember(
+          allowedGroups = setOf("comment", "comment-active"),
+          activeId = "after",
+        )
+        ?.id,
+    )
+    assertEquals(
+      "before",
+      members
+        .selectTrackedRangeMember(
+          allowedGroups = setOf("comment", "comment-active"),
+          activeId = null,
+        )
+        ?.id,
+    )
+  }
+
+  @Test
+  fun excludedOrUnownedActiveIdFallsBackToFirstEligibleMember() {
+    val members =
+      listOf(
+        range("temporary", "__comment_compose__"),
+        range("missing-result", "spellcheck-active"),
+        range("owned-result", "spellcheck"),
+      )
+
+    assertEquals(
+      "owned-result",
+      members
+        .selectTrackedRangeMember(
+          allowedGroups = setOf("spellcheck", "spellcheck-active"),
+          activeId = "missing-result",
+          ownedIds = setOf("owned-result"),
+        )
+        ?.id,
+    )
+    assertNull(
+      members.selectTrackedRangeMember(
+        allowedGroups = setOf("comment", "comment-active"),
+        activeId = "temporary",
+      )
+    )
+    assertNull(
+      listOf(range("orphan", "comment"))
+        .selectTrackedRangeMember(
+          allowedGroups = setOf("comment", "comment-active"),
+          activeId = "orphan",
+          ownedIds = emptySet(),
+        )
+    )
+  }
+
+  @Test
+  fun membershipIdsIgnoreNormalActiveGroupProjection() {
+    val groups = setOf("comment", "comment-active")
+
+    val before =
+      listOf(range("a", "comment"), range("b", "comment-active")).trackedRangeMembershipIds(groups)
+    val after =
+      listOf(range("a", "comment-active"), range("b", "comment")).trackedRangeMembershipIds(groups)
+
+    assertEquals(before, after)
+  }
+}

--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -15,6 +15,7 @@ import { isMutatingMessage } from './message-gate';
 import { canPublish, preparingPage, proofSatisfies, satisfiesWaiter } from './publication';
 import { fanOutResourceUpdate, register, snapshot, unregister } from './registry';
 import { probeEvent, probeRendered } from './surface-probe';
+import { selectTrackedRangeMember, semanticMembershipForStateChange, trackedRangeMembershipIds } from './tracked-range-membership';
 import { zoomDiffers } from './zoom';
 import type {
   BlockState,
@@ -46,6 +47,7 @@ import type {
   ThemeVariant,
   TickResult,
   TrackedRange,
+  TrackedRangeEndpoints,
   Viewport,
 } from '@typie/editor-ffi/browser';
 import type { ScrollViewport } from '@typie/ui/utils';
@@ -117,6 +119,11 @@ type PublishedFrame = Readonly<{
 }>;
 
 const HIDDEN_TICK = Symbol('hidden-tick');
+const SPELLCHECK_MEMBERSHIP_GROUPS = new Set(['spellcheck', 'spellcheck-active']);
+const AI_FEEDBACK_MEMBERSHIP_GROUPS = new Set(['ai-feedback', 'ai-feedback-active']);
+const COMMENT_MEMBERSHIP_GROUPS = new Set(['comment', 'comment-active']);
+const sameIds = (a: readonly string[] | null, b: readonly string[]): boolean =>
+  a !== null && a.length === b.length && a.every((id, index) => id === b[index]);
 
 export type PublishedBundle = Readonly<{
   snapshot: EditorSnapshot;
@@ -388,8 +395,10 @@ export class Editor {
   #gesture!: TouchGestureController;
 
   #spellcheckDecorationsInstalled = false;
+  #spellcheckMembershipIds: string[] | null = null;
 
   #aiFeedbackDecorationsInstalled = false;
+  #aiFeedbackMembershipIds: string[] | null = null;
 
   #commentDecorationsInstalled = false;
   // eslint-disable-next-line svelte/prefer-svelte-reactivity
@@ -564,7 +573,7 @@ export class Editor {
         revision,
         cursor: fields.has('cursor') ? core.cursor() : previous.cursor,
         placeholder: fields.has('placeholder') ? (core.placeholder() ?? undefined) : previous.placeholder,
-        selection: fields.has('selection') ? core.selection() : previous.selection,
+        selection: fields.has('selection') || fields.has('doc') ? core.selection() : previous.selection,
         selectionEndpoints:
           fields.has('selection') || fields.has('cursor') || fields.has('doc') || fields.has('page_sizes')
             ? core.selection_endpoints()
@@ -590,13 +599,9 @@ export class Editor {
   #installAppliedSideEffects(fields: ReadonlySet<StateField>): void {
     const snapshot = this.#applied;
 
-    if (fields.has('selection')) {
-      if (snapshot.selection === undefined) {
-        this.inputEl?.blur();
-        this.closeContextMenu();
-      }
-      this.#syncActiveSpellcheckErrorFromSelection();
-      this.#syncActiveAiFeedbackFromSelection();
+    if (fields.has('selection') && snapshot.selection === undefined) {
+      this.inputEl?.blur();
+      this.closeContextMenu();
     }
 
     if (fields.has('doc') || fields.has('selection')) this.characterCountsVersion++;
@@ -613,6 +618,22 @@ export class Editor {
       }
       this.aiFeedbacks = this.aiFeedbacks.filter((feedback) => rangeIds.has(feedback.id));
       if (this.activeAiFeedbackId !== null && !rangeIds.has(this.activeAiFeedbackId)) this.activeAiFeedbackId = null;
+    }
+
+    const hasMembershipConsumers = this.spellcheckErrors.length > 0 || this.aiFeedbacks.length > 0;
+    if (!hasMembershipConsumers || !snapshot.selection || !isSelectionCollapsed(snapshot.selection)) {
+      this.#spellcheckMembershipIds = null;
+      this.#aiFeedbackMembershipIds = null;
+    }
+
+    if (hasMembershipConsumers) {
+      const membership = semanticMembershipForStateChange(fields, snapshot.selection, (position) =>
+        this.#invokeCore((core) => core.tracked_ranges_containing_position(position, null)),
+      );
+      if (membership !== undefined) {
+        this.#syncActiveSpellcheckErrorFromMembership(membership);
+        this.#syncActiveAiFeedbackFromMembership(membership);
+      }
     }
 
     if (fields.has('root_attrs') || fields.has('page_sizes')) {
@@ -967,40 +988,31 @@ export class Editor {
     }
   }
 
-  #syncActiveSpellcheckErrorFromSelection(): void {
-    const cursor = this.#applied.cursor;
-    if (!cursor) return;
+  #syncActiveSpellcheckErrorFromMembership(membership: readonly TrackedRangeEndpoints[]): void {
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity
+    const ownedIds = new Set(this.spellcheckErrors.map((error) => error.id));
+    const membershipIds = trackedRangeMembershipIds(membership, SPELLCHECK_MEMBERSHIP_GROUPS, ownedIds);
+    if (sameIds(this.#spellcheckMembershipIds, membershipIds)) return;
+    this.#spellcheckMembershipIds = membershipIds;
+    const member = selectTrackedRangeMember(membership, SPELLCHECK_MEMBERSHIP_GROUPS, this.activeSpellcheckErrorId, ownedIds);
 
-    const cx = cursor.caret.x;
-    const cy = cursor.line.y + cursor.line.height / 2;
-    const pageIdx = cursor.page_idx;
-
-    const hit = this.#invokeCore(
-      (core) => core.tracked_ranges_at(pageIdx, cx, cy, 'spellcheck-active')[0] ?? core.tracked_ranges_at(pageIdx, cx, cy, 'spellcheck')[0],
-    );
-
-    if (hit) {
-      this.setActiveSpellcheckError(hit.id);
+    if (member) {
+      this.setActiveSpellcheckError(member.id);
     } else if (this.activeSpellcheckErrorId !== null) {
       this.setActiveSpellcheckError(null);
     }
   }
 
-  #syncActiveAiFeedbackFromSelection(): void {
-    const cursor = this.#applied.cursor;
-    if (!cursor) return;
+  #syncActiveAiFeedbackFromMembership(membership: readonly TrackedRangeEndpoints[]): void {
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity
+    const ownedIds = new Set(this.aiFeedbacks.map((feedback) => feedback.id));
+    const membershipIds = trackedRangeMembershipIds(membership, AI_FEEDBACK_MEMBERSHIP_GROUPS, ownedIds);
+    if (sameIds(this.#aiFeedbackMembershipIds, membershipIds)) return;
+    this.#aiFeedbackMembershipIds = membershipIds;
+    const member = selectTrackedRangeMember(membership, AI_FEEDBACK_MEMBERSHIP_GROUPS, this.activeAiFeedbackId, ownedIds);
 
-    const cx = cursor.caret.x;
-    const cy = cursor.line.y + cursor.line.height / 2;
-    const pageIdx = cursor.page_idx;
-
-    const hit = this.#invokeCore(
-      (core) =>
-        core.tracked_ranges_at(pageIdx, cx, cy, 'ai-feedback-active')[0] ?? core.tracked_ranges_at(pageIdx, cx, cy, 'ai-feedback')[0],
-    );
-
-    if (hit) {
-      this.setActiveAiFeedback(hit.id);
+    if (member) {
+      this.setActiveAiFeedback(member.id);
     } else if (this.activeAiFeedbackId !== null) {
       this.setActiveAiFeedback(null);
     }
@@ -2373,10 +2385,16 @@ export class Editor {
     return this.#applied.trackedRanges.some((x) => x.id === id);
   }
 
-  commentIdsAt(page: number, x: number, y: number): string[] {
-    return this.#invokeCore((core) => core.tracked_ranges_at(page, x, y, null))
-      .filter((hit) => this.#registeredCommentIds.has(hit.id))
-      .map((hit) => hit.id);
+  commentIdAt(page: number, x: number, y: number): string | null {
+    const selection = this.#applied.selection;
+    if (!selection || !isSelectionCollapsed(selection)) return null;
+
+    return this.#invokeCore((core) => {
+      // eslint-disable-next-line svelte/prefer-svelte-reactivity
+      const geometryHitIds = new Set(core.tracked_ranges_at(page, x, y, null).map((hit) => hit.id));
+      const membership = core.tracked_ranges_containing_position(selection.head, null).filter((range) => geometryHitIds.has(range.id));
+      return selectTrackedRangeMember(membership, COMMENT_MEMBERSHIP_GROUPS, this.activeCommentId, this.#registeredCommentIds)?.id ?? null;
+    });
   }
 
   setActiveComment(id: string | null): void {

--- a/apps/website/src/lib/editor-ffi/handlers/pointer.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/pointer.ts
@@ -170,10 +170,8 @@ export const handleClick: EditorEventHandler<HTMLElement, MouseEvent> = (editor,
   const local = editor.clientToLocal(e.clientX, e.clientY);
   if (!local) return;
 
-  const ids = editor.commentIdsAt(local.page, local.x, local.y);
-  if (ids.length > 0) {
-    editor.commentClickHandler(ids[0]);
-  }
+  const id = editor.commentIdAt(local.page, local.x, local.y);
+  if (id !== null) editor.commentClickHandler(id);
 };
 
 export const handlePointerCancel: EditorEventHandler<HTMLElement, PointerEvent> = (editor, e) => {

--- a/apps/website/src/lib/editor-ffi/tracked-range-membership.test.ts
+++ b/apps/website/src/lib/editor-ffi/tracked-range-membership.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import { selectTrackedRangeMember, semanticMembershipForStateChange, trackedRangeMembershipIds } from './tracked-range-membership';
+import type { Position, Selection, StateField, TrackedRangeEndpoints } from '@typie/editor-ffi/browser';
+
+const position = (offset: number): Position => ({ node: 'paragraph', offset, affinity: 'downstream' });
+const collapsed = (offset: number): Selection => ({ anchor: position(offset), head: position(offset) });
+const member = (id: string, group: string): TrackedRangeEndpoints => ({
+  id,
+  group,
+  anchor: position(0),
+  head: position(1),
+});
+
+describe('tracked range membership', () => {
+  it.each<StateField>(['selection', 'doc', 'tracked_ranges'])('%s change refreshes membership under a stationary cursor', (field) => {
+    const query = vi.fn(() => [member('a', 'comment')]);
+
+    expect(semanticMembershipForStateChange(new Set([field]), collapsed(3), query)).toEqual([member('a', 'comment')]);
+    expect(query).toHaveBeenCalledWith(position(3));
+  });
+
+  it('does not query for layout-only changes or non-collapsed selections', () => {
+    const query = vi.fn(() => [member('a', 'comment')]);
+    const expanded: Selection = { anchor: position(1), head: position(2) };
+
+    expect(semanticMembershipForStateChange(new Set<StateField>(['page_sizes', 'cursor']), collapsed(1), query)).toBeUndefined();
+    expect(semanticMembershipForStateChange(new Set<StateField>(['selection']), expanded, query)).toBeUndefined();
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('prefers an eligible active ID, otherwise keeps Core fallback order', () => {
+    const members = [member('before', 'comment'), member('after', 'comment-active')];
+    const groups = new Set(['comment', 'comment-active']);
+
+    expect(selectTrackedRangeMember(members, groups, 'after')?.id).toBe('after');
+    expect(selectTrackedRangeMember(members, groups, null)?.id).toBe('before');
+    expect(selectTrackedRangeMember(members, groups, 'outside')?.id).toBe('before');
+  });
+
+  it('filters feature ownership before applying active preference', () => {
+    const members = [member('missing', 'spellcheck-active'), member('owned', 'spellcheck')];
+
+    expect(selectTrackedRangeMember(members, new Set(['spellcheck', 'spellcheck-active']), 'missing', new Set(['owned']))?.id).toBe(
+      'owned',
+    );
+  });
+
+  it('keeps membership identity stable across normal-active group projection', () => {
+    const groups = new Set(['comment', 'comment-active']);
+
+    expect(trackedRangeMembershipIds([member('a', 'comment'), member('b', 'comment-active')], groups)).toEqual(
+      trackedRangeMembershipIds([member('a', 'comment-active'), member('b', 'comment')], groups),
+    );
+  });
+});

--- a/apps/website/src/lib/editor-ffi/tracked-range-membership.ts
+++ b/apps/website/src/lib/editor-ffi/tracked-range-membership.ts
@@ -1,0 +1,41 @@
+import type { Position, Selection, StateField, TrackedRangeEndpoints } from '@typie/editor-ffi/browser';
+
+type MembershipQuery = (position: Position) => TrackedRangeEndpoints[];
+
+const samePosition = (a: Position, b: Position): boolean => a.node === b.node && a.offset === b.offset && a.affinity === b.affinity;
+
+/** 문서 의미가 바뀔 때만 collapsed cursor의 Core membership을 다시 읽는다. */
+export const semanticMembershipForStateChange = (
+  fields: ReadonlySet<StateField>,
+  selection: Selection | undefined,
+  query: MembershipQuery,
+): TrackedRangeEndpoints[] | undefined => {
+  if (!fields.has('selection') && !fields.has('doc') && !fields.has('tracked_ranges')) return undefined;
+  if (!selection || !samePosition(selection.anchor, selection.head)) return undefined;
+  return query(selection.head);
+};
+
+const featureMembers = (
+  members: readonly TrackedRangeEndpoints[],
+  allowedGroups: ReadonlySet<string>,
+  ownedIds?: ReadonlySet<string>,
+): TrackedRangeEndpoints[] =>
+  members.filter((range) => allowedGroups.has(range.group) && (ownedIds === undefined || ownedIds.has(range.id)));
+
+/** normal/active group 투영을 제외한 feature membership의 결정적 identity다. */
+export const trackedRangeMembershipIds = (
+  members: readonly TrackedRangeEndpoints[],
+  allowedGroups: ReadonlySet<string>,
+  ownedIds?: ReadonlySet<string>,
+): string[] => featureMembers(members, allowedGroups, ownedIds).map((range) => range.id);
+
+/** Core fallback 순서를 유지하되 현재 feature의 eligible active ID를 먼저 고른다. */
+export const selectTrackedRangeMember = (
+  members: readonly TrackedRangeEndpoints[],
+  allowedGroups: ReadonlySet<string>,
+  activeId: string | null,
+  ownedIds?: ReadonlySet<string>,
+): TrackedRangeEndpoints | undefined => {
+  const candidates = featureMembers(members, allowedGroups, ownedIds);
+  return (activeId === null ? undefined : candidates.find((range) => range.id === activeId)) ?? candidates[0];
+};

--- a/crates/editor-core/src/editor.rs
+++ b/crates/editor-core/src/editor.rs
@@ -642,16 +642,17 @@ impl Editor {
         scored.into_iter().map(|(_, _, hit)| hit).collect()
     }
 
-    /// Returns located tracked ranges containing `position`, sorted by shortest range first.
+    /// Returns located tracked ranges whose closed interval contains `position`.
     ///
-    /// Containment is start-inclusive and end-exclusive. This lets a cursor at the
-    /// start of a range continue that range while keeping the cursor immediately
-    /// after the range outside it.
+    /// Exact end matches come first so the preceding range wins at a shared
+    /// end/start boundary. Remaining ties are sorted by shortest range, then ID.
+    /// This membership policy is independent of the range's insertion affinity:
+    /// including the end cursor here does not make later text part of the range.
     pub fn tracked_ranges_containing_position(
         &self,
         position: editor_state::Position,
         group: Option<&str>,
-    ) -> Vec<crate::tracked_range::TrackedRange> {
+    ) -> Vec<&crate::tracked_range::TrackedRange> {
         use crate::tracked_range::TrackedRange;
         use editor_state::ResolvedPositionFlatExt;
 
@@ -666,7 +667,7 @@ impl Editor {
             None => Box::new(self.tracked_ranges.iter()),
         };
 
-        let mut scored: Vec<(usize, String, TrackedRange)> = Vec::new();
+        let mut scored: Vec<(bool, usize, &TrackedRange)> = Vec::new();
         for range in iter {
             let Some(sel) = range.locate(&self.state) else {
                 continue;
@@ -679,12 +680,16 @@ impl Editor {
             let head = resolved.head().to_flat();
             let start = anchor.min(head);
             let end = anchor.max(head);
-            if start <= pos && pos < end {
-                scored.push((end - start, range.id.clone(), range.clone()));
+            if start < end && start <= pos && pos <= end {
+                scored.push((end != pos, end - start, range));
             }
         }
 
-        scored.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+        scored.sort_by(|a, b| {
+            a.0.cmp(&b.0)
+                .then_with(|| a.1.cmp(&b.1))
+                .then_with(|| a.2.id.cmp(&b.2.id))
+        });
         scored.into_iter().map(|(_, _, range)| range).collect()
     }
 

--- a/crates/editor-core/src/tests/tracked_range_position_lookup.rs
+++ b/crates/editor-core/src/tests/tracked_range_position_lookup.rs
@@ -4,54 +4,136 @@ use editor_state::{Position, Selection};
 use crate::editor::Editor;
 use crate::message::*;
 
-fn add_msg(id: &str, group: &str, sel: Selection) -> Message {
+fn add_msg(id: &str, group: &str, selection: Selection) -> Message {
     Message::TrackedRange {
         op: TrackedRangeOp::Add {
             id: id.into(),
             group: group.into(),
-            selection: sel,
+            selection,
             metadata: String::new(),
             invalidate_on_text_change: false,
         },
     }
 }
 
+fn ids_at(editor: &Editor, position: Position, group: Option<&str>) -> Vec<String> {
+    editor
+        .tracked_ranges_containing_position(position, group)
+        .into_iter()
+        .map(|range| range.id.clone())
+        .collect()
+}
+
 #[test]
-fn containing_position_is_start_inclusive_and_end_exclusive() {
+fn membership_includes_both_boundaries_and_excludes_outside_positions() {
     let (state, p1) = state! {
         doc { root { p1: paragraph { text("hello") } } }
         selection: (p1, 1) -> (p1, 4)
     };
-    let sel = state.selection.unwrap();
+    let selection = state.selection.unwrap();
     let mut editor = Editor::new_test(state);
-    editor.apply(add_msg("r", "comment", sel));
+    editor.apply(add_msg("r", "comment", selection));
 
-    let at_start = editor.tracked_ranges_containing_position(Position::new(p1, 1), Some("comment"));
+    for offset in [1, 2, 4] {
+        assert_eq!(
+            ids_at(&editor, Position::new(p1, offset), Some("comment")),
+            ["r"]
+        );
+    }
+    assert!(ids_at(&editor, Position::new(p1, 0), Some("comment")).is_empty());
+    assert!(ids_at(&editor, Position::new(p1, 5), Some("comment")).is_empty());
+}
+
+#[test]
+fn membership_prefers_exact_end_over_exact_start_and_interior() {
+    let (state, p1) = state! {
+        doc { root { p1: paragraph { text("abcdef") } } }
+        selection: (p1, 0)
+    };
+    let mut editor = Editor::new_test(state);
+    editor.apply(add_msg(
+        "a",
+        "comment",
+        Selection::new(Position::new(p1, 0), Position::new(p1, 3)),
+    ));
+    editor.apply(add_msg(
+        "b",
+        "comment",
+        Selection::new(Position::new(p1, 3), Position::new(p1, 5)),
+    ));
+    editor.apply(add_msg(
+        "outer",
+        "comment",
+        Selection::new(Position::new(p1, 0), Position::new(p1, 6)),
+    ));
+
     assert_eq!(
-        at_start.iter().map(|r| r.id.as_str()).collect::<Vec<_>>(),
-        ["r"]
-    );
-
-    let at_end = editor.tracked_ranges_containing_position(Position::new(p1, 4), Some("comment"));
-    assert!(
-        at_end.is_empty(),
-        "cursor immediately after the range must not be treated as inside it"
+        ids_at(&editor, Position::new(p1, 3), Some("comment")),
+        ["a", "b", "outer"]
     );
 }
 
 #[test]
-fn containing_position_filters_group_and_sorts_narrowest_first() {
+fn membership_keeps_shortest_first_without_exact_end() {
+    let (state, p1) = state! {
+        doc { root { p1: paragraph { text("abcdefghij") } } }
+        selection: (p1, 0)
+    };
+    let mut editor = Editor::new_test(state);
+    editor.apply(add_msg(
+        "outer",
+        "comment",
+        Selection::new(Position::new(p1, 0), Position::new(p1, 10)),
+    ));
+    editor.apply(add_msg(
+        "inner",
+        "comment",
+        Selection::new(Position::new(p1, 3), Position::new(p1, 5)),
+    ));
+
+    assert_eq!(
+        ids_at(&editor, Position::new(p1, 3), Some("comment")),
+        ["inner", "outer"]
+    );
+}
+
+#[test]
+fn membership_sorts_exact_end_ties_by_length_then_id() {
+    let (state, p1) = state! {
+        doc { root { p1: paragraph { text("abcdef") } } }
+        selection: (p1, 0)
+    };
+    let mut editor = Editor::new_test(state);
+    for (id, start) in [("b", 1), ("c", 2), ("a", 2)] {
+        editor.apply(add_msg(
+            id,
+            "comment",
+            Selection::new(Position::new(p1, start), Position::new(p1, 4)),
+        ));
+    }
+
+    assert_eq!(
+        ids_at(&editor, Position::new(p1, 4), Some("comment")),
+        ["a", "c", "b"]
+    );
+}
+
+#[test]
+fn membership_normalizes_reversed_ranges_and_preserves_group_filter_order() {
     let (state, p1) = state! {
         doc { root { p1: paragraph { text("hello world") } } }
-        selection: (p1, 0) -> (p1, 11)
+        selection: (p1, 0)
     };
-    let outer = state.selection.unwrap();
     let mut editor = Editor::new_test(state);
-    editor.apply(add_msg("outer", "comment", outer));
+    editor.apply(add_msg(
+        "outer",
+        "comment",
+        Selection::new(Position::new(p1, 0), Position::new(p1, 11)),
+    ));
     editor.apply(add_msg(
         "inner",
         "comment-active",
-        Selection::new(Position::new(p1, 1), Position::new(p1, 4)),
+        Selection::new(Position::new(p1, 4), Position::new(p1, 1)),
     ));
     editor.apply(add_msg(
         "spellcheck",
@@ -59,16 +141,88 @@ fn containing_position_filters_group_and_sorts_narrowest_first() {
         Selection::new(Position::new(p1, 1), Position::new(p1, 4)),
     ));
 
-    let all = editor.tracked_ranges_containing_position(Position::new(p1, 2), None);
     assert_eq!(
-        all.iter().map(|r| r.id.as_str()).collect::<Vec<_>>(),
-        ["inner", "spellcheck", "outer"],
-        "all groups should still be sorted by range width, then id"
+        ids_at(&editor, Position::new(p1, 2), None),
+        ["inner", "spellcheck", "outer"]
     );
-
-    let comments = editor.tracked_ranges_containing_position(Position::new(p1, 2), Some("comment"));
     assert_eq!(
-        comments.iter().map(|r| r.id.as_str()).collect::<Vec<_>>(),
+        ids_at(&editor, Position::new(p1, 2), Some("comment")),
         ["outer"]
+    );
+}
+
+#[test]
+fn membership_excludes_invalid_and_collapsed_ranges_after_deletion() {
+    let (state, p1) = state! {
+        doc { root { p1: paragraph { text("hello") } } }
+        selection: (p1, 0)
+    };
+    let mut editor = Editor::new_test(state);
+    editor.apply(add_msg(
+        "invalid",
+        "comment",
+        Selection::new(Position::new(p1, 0), Position::new(p1, 1)),
+    ));
+    editor.apply(Message::TrackedRange {
+        op: TrackedRangeOp::Invalidate {
+            id: "invalid".into(),
+        },
+    });
+    editor.apply(add_msg(
+        "collapsed",
+        "comment",
+        Selection::collapsed(Position::new(p1, 1)),
+    ));
+    editor.apply(add_msg(
+        "deleted",
+        "comment",
+        Selection::new(Position::new(p1, 1), Position::new(p1, 4)),
+    ));
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::new(Position::new(p1, 1), Position::new(p1, 4)),
+        },
+    });
+    editor.apply(Message::Deletion {
+        op: DeletionOp::Selection,
+    });
+
+    assert!(ids_at(&editor, Position::new(p1, 1), None).is_empty());
+}
+
+#[test]
+fn membership_uses_document_positions_across_paragraph_boundaries() {
+    let (state, p1, p2) = state! {
+        doc {
+            root {
+                p1: paragraph { text("ab") }
+                p2: paragraph { text("cd") }
+            }
+        }
+        selection: (p1, 0)
+    };
+    let mut editor = Editor::new_test(state);
+    editor.apply(add_msg(
+        "before",
+        "comment",
+        Selection::new(Position::new(p1, 1), Position::new(p2, 0)),
+    ));
+    editor.apply(add_msg(
+        "after",
+        "comment",
+        Selection::new(Position::new(p2, 0), Position::new(p2, 2)),
+    ));
+
+    assert_eq!(
+        ids_at(&editor, Position::new(p1, 1), Some("comment")),
+        ["before"]
+    );
+    assert_eq!(
+        ids_at(&editor, Position::new(p2, 0), Some("comment")),
+        ["before", "after"]
+    );
+    assert_eq!(
+        ids_at(&editor, Position::new(p2, 2), Some("comment")),
+        ["after"]
     );
 }

--- a/crates/editor-core/src/tracked_range.rs
+++ b/crates/editor-core/src/tracked_range.rs
@@ -237,7 +237,7 @@ impl TrackedRangeRegistry {
         self.by_id.values()
     }
 
-    pub fn iter_group<'a>(&'a self, group: &'a str) -> impl Iterator<Item = &'a TrackedRange> + 'a {
+    pub fn iter_group<'a>(&'a self, group: &str) -> impl Iterator<Item = &'a TrackedRange> + 'a {
         self.by_group
             .get(group)
             .into_iter()

--- a/crates/editor-ffi/src/editor.rs
+++ b/crates/editor-ffi/src/editor.rs
@@ -3213,6 +3213,48 @@ mod tests {
     }
 
     #[test]
+    fn ffi_tracked_ranges_containing_position_preserves_core_membership_order() {
+        let (initial, p1) = state! {
+            doc { root { p1: paragraph { text("abcde") } } }
+            selection: (p1, 0)
+        };
+        let editor = make_ffi_editor(initial);
+
+        for (id, from, to) in [("before", 0, 3), ("after", 3, 5)] {
+            editor
+                .enqueue_for_test(editor_core::Message::TrackedRange {
+                    op: editor_core::TrackedRangeOp::Add {
+                        id: id.into(),
+                        group: "comment".into(),
+                        selection: editor_state::Selection::new(
+                            editor_state::Position::new(p1, from),
+                            editor_state::Position::new(p1, to),
+                        ),
+                        metadata: String::new(),
+                        invalidate_on_text_change: false,
+                    },
+                })
+                .expect("enqueue tracked-range add");
+        }
+        let _ = editor.tick().expect("tick");
+
+        let matches = editor
+            .tracked_ranges_containing_position(
+                editor_state::Position::new(p1, 3),
+                Some("comment".into()),
+            )
+            .expect("ffi ok");
+        assert_eq!(
+            matches
+                .iter()
+                .map(|range| range.id.as_str())
+                .collect::<Vec<_>>(),
+            ["before", "after"],
+            "FFI must preserve Core's exact-end-first membership order"
+        );
+    }
+
+    #[test]
     fn ffi_spellcheck_tracked_range_text_matches_context() {
         let (initial, p1) = state! {
             doc { root { p1: paragraph { text("않녕하세요") } } }


### PR DESCRIPTION
## 배경

tracked range 끝점의 cursor membership이 일관되지 않았고, 맞춤법 검사·AI 피드백·코멘트가 웹과 앱에서 서로 다른 geometry/selection 경로로 활성 항목을 결정하고 있었습니다. 그 결과 범위 끝이나 연속 범위의 경계에서 활성 항목이 사라지거나 플랫폼마다 다르게 선택될 수 있었습니다.

## Membership 정책

Core의 document position lookup을 단일 기준으로 사용합니다.

- 시작점과 끝점을 모두 membership에 포함합니다.
- Core fallback 순서는 `정확한 끝점 → 짧은 범위 → ID`입니다.
    - 따라서 `A.end == B.start`에서는 기본적으로 앞 범위 A가 우선합니다.
- feature의 현재 active ID가 실제 membership 후보이고 해당 feature가 소유한 범위라면 active 항목을 먼저 유지합니다.
- 역방향 범위는 정규화하고, collapsed·삭제·해석 불가능 범위는 제외합니다.
- membership은 insertion affinity와 독립적이며, 끝점을 포함해도 이후 입력이 범위에 편입되는 규칙은 바뀌지 않습니다.

## 웹·앱 적용

- collapsed cursor의 membership을 selection뿐 아니라 document/tracked range 변경 후에도 갱신합니다.
- 맞춤법 검사와 AI 피드백은 geometry hit 대신 semantic membership으로 활성 결과를 동기화합니다.
- normal/active decoration group 전환은 같은 membership identity로 취급해 자체 group 변경으로 인한 반복 활성화를 막습니다.
- 앱 코멘트 선택과 웹 코멘트 클릭도 같은 active/Core fallback 선택기를 사용합니다.
- 웹 코멘트 클릭은 실제 geometry hit과 semantic membership의 교집합 안에서만 항목을 선택합니다.

## 단순화 및 성능

- Core lookup은 `TrackedRange`를 복제하지 않고 borrowed range를 정렬합니다.
- 웹·앱의 선택 로직을 `selectTrackedRangeMember`로 통일했습니다.
- 단일 코멘트만 사용하는 웹 포인터 경로에서 별도 목록 정렬 helper를 제거했습니다.
- 웹은 맞춤법/AI 결과가 없을 때, 앱은 tracked range가 없을 때 membership 조회를 생략합니다.
- FFI는 Core가 정한 membership 순서를 그대로 전달합니다.

## 사용자 동작

범위 끝에서도 해당 맞춤법 결과·AI 피드백·코멘트가 유지됩니다. 연속 범위의 경계에서는 앞 범위가 기본 선택되며, 이미 활성화된 유효 항목은 불필요하게 전환되지 않습니다. 커서를 움직이지 않은 채 문서나 tracked range가 바뀌어도 웹과 앱에서 활성 상태가 동일하게 갱신됩니다.