### PR TITLE
앱 목록 reorder 및 edge autoscroll 안정화

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/entity/container/EntityContainerList.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/entity/container/EntityContainerList.kt
@@ -85,7 +85,8 @@ fun EntityContainerListContent(
     }
 
     if (isReordering) {
-      itemsIndexed(items = items, key = { _, entity -> entity.id }) { index, entity ->
+      itemsIndexed(items = items, key = { _, entity -> entity.id }) { _, entity ->
+        val projectedIndex = reorderState.keys.indexOf(entity.id)
         val isDragging = reorderState.isDragging(entity.id)
         EntityContainerReorderRow(
           modifier =
@@ -93,8 +94,8 @@ fun EntityContainerListContent(
               .reorderableItem(state = reorderState, key = entity.id),
           item = entity,
           isDragging = isDragging,
-          isFirst = index == 0,
-          isLast = index == items.lastIndex,
+          isFirst = projectedIndex == 0,
+          isLast = projectedIndex == reorderState.keys.lastIndex,
           dragHandleModifier =
             Modifier.reorderableDragHandle(
               state = reorderState,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteList.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteList.kt
@@ -158,7 +158,7 @@ internal fun NoteList(
   val isLoading = queryState is QueryState.Loading
   val showErrorState = queryState is QueryState.Error
   val showEmptyState = queryState is QueryState.Success<*> && items.isEmpty()
-  val displayedItems = displayOrderedNoteItems(items, reorderState.keys)
+  val displayedItems = displayOrderedNoteItems(items, reorderState.layoutKeys)
 
   SideEffect { noteReorderState.sync(identity = identity, notes = authoritativeNotes) }
   DisposableEffect(noteReorderState) { onDispose(noteReorderState::dispose) }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/relatednotes/RelatedNotesSheet.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/relatednotes/RelatedNotesSheet.kt
@@ -610,7 +610,15 @@ private fun RelatedNotesSheetContent(
         rememberNoteListReorderState(items = listItems, scrollState = sceneScrollState)
 
       NoteEditorBringIntoViewScope {
-        Box(modifier = Modifier.fillMaxSize().reorderableViewport(state = reorderState)) {
+        Box(
+          modifier =
+            Modifier.fillMaxSize()
+              .reorderableViewport(
+                state = reorderState,
+                viewportTopInset = EditorSubPaneContentTopPadding,
+                viewportBottomInset = safeBottomInset + keyboardOcclusion,
+              )
+        ) {
           NoteList(
             identity =
               NoteListIdentity(siteId = model.siteId, status = status, entityId = entityId),

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/textreplacements/TextReplacementsScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/textreplacements/TextReplacementsScreen.kt
@@ -95,7 +95,7 @@ fun TextReplacementsScreen() {
     val keys = displayed.map { it.textReplacementId }
     val reorderState = rememberReorderableLazyColumnState(keys = keys, lazyListState = scrollState)
     val byId = remember(displayed) { displayed.associateBy { it.textReplacementId } }
-    val ordered = reorderState.keys.mapNotNull(byId::get)
+    val ordered = reorderState.layoutKeys.mapNotNull(byId::get)
     val toast = LocalToast.current
     val reorderEnabled = SubscriptionService.entitlement.grantsAccess()
 
@@ -139,15 +139,16 @@ fun TextReplacementsScreen() {
           CardSurface(modifier = Modifier.fillMaxWidth()) { EmptyStateMessage() }
         }
       } else {
-        itemsIndexed(items = ordered, key = { _, entry -> entry.textReplacementId }) { index, entry
-          ->
+        itemsIndexed(items = ordered, key = { _, entry -> entry.textReplacementId }) { _, entry ->
           val id = entry.textReplacementId
+          val projectedIndex = reorderState.keys.indexOf(id)
           val shape =
             RoundedCornerShape(
-              topStart = if (index == 0) AppShapes.md else 0.dp,
-              topEnd = if (index == 0) AppShapes.md else 0.dp,
-              bottomStart = if (index == ordered.lastIndex) AppShapes.md else 0.dp,
-              bottomEnd = if (index == ordered.lastIndex) AppShapes.md else 0.dp,
+              topStart = if (projectedIndex == 0) AppShapes.md else 0.dp,
+              topEnd = if (projectedIndex == 0) AppShapes.md else 0.dp,
+              bottomStart =
+                if (projectedIndex == reorderState.keys.lastIndex) AppShapes.md else 0.dp,
+              bottomEnd = if (projectedIndex == reorderState.keys.lastIndex) AppShapes.md else 0.dp,
             )
           CardSurface(
             modifier =
@@ -156,10 +157,10 @@ fun TextReplacementsScreen() {
             shape = shape,
           ) {
             Column(modifier = Modifier.fillMaxWidth()) {
-              if (index > 0) CardDivider(inset = 20.dp)
+              if (projectedIndex > 0) CardDivider(inset = 20.dp)
               CustomRow(
                 entry = entry,
-                order = index + 1,
+                order = projectedIndex + 1,
                 reorderState = reorderState,
                 reorderEnabled = reorderEnabled,
                 onEdit = {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/folder/FolderScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/folder/FolderScreen.kt
@@ -151,8 +151,8 @@ fun FolderScreen(entityId: String) {
   val reorderState =
     rememberReorderableLazyColumnState(keys = serverChildIds, lazyListState = scrollState)
   val displayChildren =
-    remember(serverChildren, reorderState.keys) {
-      displayEntityRows(serverChildren, reorderState.keys)
+    remember(serverChildren, reorderState.layoutKeys) {
+      displayEntityRows(serverChildren, reorderState.layoutKeys)
     }
   val selection = rememberEntityContainerSelection(displayChildren)
   val selectionState = selection.state

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/space/SpaceScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/space/space/SpaceScreen.kt
@@ -163,8 +163,8 @@ fun SpaceScreen() {
   val reorderState =
     rememberReorderableLazyColumnState(keys = serverEntityIds, lazyListState = scrollState)
   val displayEntities =
-    remember(serverEntities, reorderState.keys) {
-      displayEntityRows(serverEntities, reorderState.keys)
+    remember(serverEntities, reorderState.layoutKeys) {
+      displayEntityRows(serverEntities, reorderState.layoutKeys)
     }
   val selection = rememberEntityContainerSelection(displayEntities)
   val selectionState = selection.state

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/reorder/ReorderInteraction.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/reorder/ReorderInteraction.kt
@@ -1,5 +1,7 @@
 package co.typie.ui.component.reorder
 
+import kotlin.math.abs
+
 internal data class ReorderTargetProposal<K : Any>(
   val draggedKey: K,
   val sourceOrderRevision: Long,
@@ -13,6 +15,7 @@ internal class ReorderInteraction<K : Any>(val orderState: ReorderState<K>) {
   private var pointerY: Float? = null
   private var pointerOffsetInItemY = 0f
   private var draggedHeight: Float? = null
+  private var draggedSlotTopY: Float? = null
   private var direction = 0
 
   fun beginDrag(key: K, pointerY: Float, pointerOffsetInItemY: Float): Boolean {
@@ -26,6 +29,7 @@ internal class ReorderInteraction<K : Any>(val orderState: ReorderState<K>) {
     this.pointerY = pointerY
     this.pointerOffsetInItemY = pointerOffsetInItemY
     draggedHeight = null
+    draggedSlotTopY = layoutSnapshot?.items?.firstOrNull { it.key == key }?.top
     direction = 0
     return true
   }
@@ -57,23 +61,43 @@ internal class ReorderInteraction<K : Any>(val orderState: ReorderState<K>) {
     if (!orderState.isDragging) {
       layoutSnapshot = snapshot
       sourceSnapshot = snapshot
+      draggedSlotTopY = null
       blockOffset = discoverReorderBlockOffset(orderState.keys, snapshot)
       return null
     }
 
     val currentBlockOffset = blockOffset ?: return null
+    val previousSourceSnapshot = sourceSnapshot
+    val projection = projectSnapshot(snapshot, currentBlockOffset)
     sourceSnapshot = snapshot
-    layoutSnapshot =
-      projectReorderSnapshotOntoDisplayedSlots(
-        displayedKeys = orderState.keys,
-        blockOffset = currentBlockOffset,
-        snapshot = snapshot,
-      )
+    layoutSnapshot = projection.snapshot
+    updateDraggedSlotTop(
+      projectedSlotTop = projection.draggedSlotTop,
+      previousSourceSnapshot = previousSourceSnapshot,
+      currentSourceSnapshot = snapshot,
+    )
     return proposeTarget(scrollDirection)
   }
 
-  fun draggedItemInPublishedLayout(): ReorderLayoutItem<K>? =
-    layoutSnapshot?.items?.firstOrNull { it.key == orderState.draggingKey }
+  fun draggedItemInCurrentSourceLayout(): ReorderLayoutItem<K>? {
+    val draggedKey = orderState.draggingKey ?: return null
+    val layoutIndex = orderState.layoutKeys.indexOf(draggedKey)
+    val currentBlockOffset = blockOffset
+    if (layoutIndex == -1 || currentBlockOffset == null) return null
+    val expectedLazyIndex = currentBlockOffset + layoutIndex
+    return sourceSnapshot?.items?.firstOrNull { item ->
+      item.key == draggedKey && item.lazyIndex == expectedLazyIndex
+    }
+  }
+
+  fun draggedDestinationTopY(): Float? = draggedSlotTopY.takeIf { orderState.isDragging }
+
+  fun projectedViewportAnchor(): ReorderLayoutItem<K>? {
+    val snapshot = layoutSnapshot ?: return null
+    return snapshot.items
+      .filter { item -> item.bottom > snapshot.viewportTop && item.top < snapshot.viewportBottom }
+      .minByOrNull(ReorderLayoutItem<K>::top)
+  }
 
   fun commitTarget(proposal: ReorderTargetProposal<K>): Boolean {
     if (orderState.draggingKey != proposal.draggedKey) return false
@@ -81,18 +105,14 @@ internal class ReorderInteraction<K : Any>(val orderState: ReorderState<K>) {
     val changed = orderState.moveDraggedTo(proposal.targetIndex)
     if (changed) {
       val currentBlockOffset = blockOffset
-      layoutSnapshot =
+      val projection =
         if (currentBlockOffset == null) {
           null
         } else {
-          sourceSnapshot?.let { snapshot ->
-            projectReorderSnapshotOntoDisplayedSlots(
-              displayedKeys = orderState.keys,
-              blockOffset = currentBlockOffset,
-              snapshot = snapshot,
-            )
-          }
+          sourceSnapshot?.let { snapshot -> projectSnapshot(snapshot, currentBlockOffset) }
         }
+      layoutSnapshot = projection?.snapshot
+      projection?.draggedSlotTop?.let { draggedSlotTopY = it }
     }
     return changed
   }
@@ -153,9 +173,66 @@ internal class ReorderInteraction<K : Any>(val orderState: ReorderState<K>) {
     )
   }
 
+  private fun projectSnapshot(
+    snapshot: ReorderLayoutSnapshot<K>,
+    blockOffset: Int,
+  ): ReorderLayoutProjection<K> {
+    val draggedKey =
+      orderState.draggingKey
+        ?: return ReorderLayoutProjection(snapshot = snapshot, draggedSlotTop = null)
+    val currentHeight =
+      draggedHeight ?: return ReorderLayoutProjection(snapshot = snapshot, draggedSlotTop = null)
+    return projectReorderLayoutFromStableSource(
+      layoutKeys = orderState.layoutKeys,
+      projectedKeys = orderState.keys,
+      draggedKey = draggedKey,
+      draggedHeight = currentHeight,
+      itemSpacing = snapshot.itemSpacing,
+      blockOffset = blockOffset,
+      snapshot = snapshot,
+    )
+  }
+
+  private fun updateDraggedSlotTop(
+    projectedSlotTop: Float?,
+    previousSourceSnapshot: ReorderLayoutSnapshot<K>?,
+    currentSourceSnapshot: ReorderLayoutSnapshot<K>,
+  ) {
+    draggedSlotTopY =
+      projectedSlotTop
+        ?: draggedSlotTopY?.let { previousSlotTop ->
+          sourceLayoutTranslation(
+              previousSnapshot = previousSourceSnapshot,
+              currentSnapshot = currentSourceSnapshot,
+              referenceY = previousSlotTop,
+            )
+            ?.let(previousSlotTop::plus) ?: previousSlotTop
+        }
+  }
+
+  private fun sourceLayoutTranslation(
+    previousSnapshot: ReorderLayoutSnapshot<K>?,
+    currentSnapshot: ReorderLayoutSnapshot<K>,
+    referenceY: Float,
+  ): Float? =
+    previousSnapshot
+      ?.items
+      ?.mapNotNull { previousItem ->
+        currentSnapshot.items
+          .firstOrNull { currentItem ->
+            currentItem.key == previousItem.key && currentItem.lazyIndex == previousItem.lazyIndex
+          }
+          ?.let { currentItem ->
+            abs(previousItem.top - referenceY) to (currentItem.top - previousItem.top)
+          }
+      }
+      ?.minByOrNull { (distanceFromSlot) -> distanceFromSlot }
+      ?.second
+
   private fun clearDragInputs() {
     pointerY = null
     draggedHeight = null
+    draggedSlotTopY = null
     direction = 0
     layoutSnapshot = null
     sourceSnapshot = null

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/reorder/ReorderLayout.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/reorder/ReorderLayout.kt
@@ -14,6 +14,12 @@ internal data class ReorderLayoutSnapshot<K : Any>(
   val viewportTop: Float,
   val viewportBottom: Float,
   val items: List<ReorderLayoutItem<K>>,
+  val itemSpacing: Float = 0f,
+)
+
+internal data class ReorderLayoutProjection<K : Any>(
+  val snapshot: ReorderLayoutSnapshot<K>,
+  val draggedSlotTop: Float?,
 )
 
 internal fun <K : Any> discoverReorderBlockOffset(
@@ -42,28 +48,103 @@ internal fun <K : Any> isCompatibleReorderSnapshot(
     displayedIndex != -1 && item.lazyIndex == blockOffset + displayedIndex
   }
 
-internal fun <K : Any> projectReorderSnapshotOntoDisplayedSlots(
-  displayedKeys: List<K>,
+internal fun <K : Any> reorderItemDisplacement(
+  layoutKeys: List<K>,
+  projectedKeys: List<K>,
+  draggedKey: K,
+  itemKey: K,
+  draggedHeight: Float,
+  itemSpacing: Float,
+): Float {
+  if (itemKey == draggedKey || draggedHeight <= 0f) return 0f
+  val startIndex = layoutKeys.indexOf(draggedKey)
+  val targetIndex = projectedKeys.indexOf(draggedKey)
+  val itemIndex = layoutKeys.indexOf(itemKey)
+  if (startIndex == -1 || targetIndex == -1 || itemIndex == -1) return 0f
+  val slotHeight = draggedHeight + itemSpacing
+  return when {
+    targetIndex < startIndex && itemIndex in targetIndex until startIndex -> slotHeight
+    targetIndex > startIndex && itemIndex in (startIndex + 1)..targetIndex -> -slotHeight
+    else -> 0f
+  }
+}
+
+internal fun <K : Any> projectReorderLayoutFromStableSource(
+  layoutKeys: List<K>,
+  projectedKeys: List<K>,
+  draggedKey: K,
+  draggedHeight: Float,
+  itemSpacing: Float,
   blockOffset: Int,
   snapshot: ReorderLayoutSnapshot<K>,
-): ReorderLayoutSnapshot<K> =
-  snapshot.copy(
-    items =
-      snapshot.items
-        .mapNotNull { item ->
-          val displayedIndex = item.lazyIndex - blockOffset
-          val displayedKey = displayedKeys.getOrNull(displayedIndex) ?: return@mapNotNull null
-          item.copy(key = displayedKey)
+): ReorderLayoutProjection<K> {
+  val startIndex = layoutKeys.indexOf(draggedKey)
+  val targetIndex = projectedKeys.indexOf(draggedKey)
+  if (startIndex == -1 || targetIndex == -1 || draggedHeight <= 0f) {
+    return ReorderLayoutProjection(snapshot = snapshot, draggedSlotTop = null)
+  }
+
+  val sourceItems =
+    snapshot.items
+      .filter { item ->
+        val sourceIndex = layoutKeys.indexOf(item.key)
+        sourceIndex != -1 && item.lazyIndex == blockOffset + sourceIndex
+      }
+      .groupBy(ReorderLayoutItem<K>::key)
+      .values
+      .map { candidates ->
+        candidates.maxBy { item ->
+          verticalOverlap(item.top, item.bottom, snapshot.viewportTop, snapshot.viewportBottom)
         }
-        .groupBy(ReorderLayoutItem<K>::lazyIndex)
-        .values
-        .map { candidates ->
-          candidates.maxBy { item ->
-            verticalOverlap(item.top, item.bottom, snapshot.viewportTop, snapshot.viewportBottom)
+      }
+  val sourceItemsByKey = sourceItems.associateBy(ReorderLayoutItem<K>::key)
+  val sourceItemsByIndex = sourceItems.associateBy { item -> layoutKeys.indexOf(item.key) }
+  val draggedDestinationTop =
+    when {
+      targetIndex < startIndex ->
+        sourceItemsByKey[layoutKeys[targetIndex]]?.top
+          ?: sourceItemsByIndex[targetIndex - 1]?.bottom?.plus(itemSpacing)
+      targetIndex > startIndex ->
+        sourceItemsByKey[layoutKeys[targetIndex]]?.bottom?.minus(draggedHeight)
+          ?: sourceItemsByIndex[targetIndex + 1]?.top?.minus(itemSpacing + draggedHeight)
+      else -> sourceItemsByKey[draggedKey]?.top
+    }
+
+  return ReorderLayoutProjection(
+    snapshot =
+      snapshot.copy(
+        items =
+          sourceItems.mapNotNull { item ->
+            val projectedIndex = projectedKeys.indexOf(item.key)
+            if (projectedIndex == -1) return@mapNotNull null
+            if (item.key == draggedKey) {
+              val slotTop = draggedDestinationTop ?: return@mapNotNull null
+              item.copy(
+                lazyIndex = blockOffset + projectedIndex,
+                top = slotTop,
+                bottom = slotTop + draggedHeight,
+              )
+            } else {
+              val displacement =
+                reorderItemDisplacement(
+                  layoutKeys = layoutKeys,
+                  projectedKeys = projectedKeys,
+                  draggedKey = draggedKey,
+                  itemKey = item.key,
+                  draggedHeight = draggedHeight,
+                  itemSpacing = itemSpacing,
+                )
+              item.copy(
+                lazyIndex = blockOffset + projectedIndex,
+                top = item.top + displacement,
+                bottom = item.bottom + displacement,
+              )
+            }
           }
-        }
-        .sortedBy(ReorderLayoutItem<K>::lazyIndex)
+      ),
+    draggedSlotTop = draggedDestinationTop,
   )
+}
 
 internal fun <K : Any> targetIndexForDrag(
   displayedKeys: List<K>,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/reorder/ReorderState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/reorder/ReorderState.kt
@@ -43,6 +43,9 @@ internal class ReorderState<K : Any>(initialKeys: List<K> = emptyList()) {
   val keys: List<K>
     get() = _keys
 
+  val layoutKeys: List<K>
+    get() = activeDrag?.startKeys ?: _keys
+
   val draggingKey: K?
     get() = activeDrag?.key
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/reorder/ReorderableLazyColumn.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/reorder/ReorderableLazyColumn.kt
@@ -52,6 +52,7 @@ import co.typie.ext.LocalScrollGestureLockState
 import co.typie.ext.ScrollGestureLockHandle
 import co.typie.ext.edgeAutoScroll
 import co.typie.ext.rememberEdgeAutoScrollController
+import kotlin.math.roundToInt
 import kotlin.time.TimeSource
 import kotlinx.coroutines.launch
 
@@ -60,6 +61,11 @@ private data class LazyLayoutObservation(
   val verticalScrollDirection: Int,
   val viewport: Rect?,
   val layoutInfo: LazyListLayoutInfo,
+)
+
+private data class ReorderReleasePresentation<K : Any>(
+  val siblingTargetOffsets: Map<K, Float>,
+  val layoutCommitPending: Boolean,
 )
 
 @Stable
@@ -80,6 +86,10 @@ internal constructor(
   private var observedDragging = orderState.isDragging
   private var endingDrag = false
   private var draggedVisualOffsetY by mutableFloatStateOf(0f)
+  private var draggedHeight by mutableFloatStateOf(0f)
+  private var itemSpacing by mutableFloatStateOf(0f)
+  private var dragSessionRevision by mutableLongStateOf(0L)
+  private var releasePresentation by mutableStateOf<ReorderReleasePresentation<K>?>(null)
   private val placedItemTops = mutableMapOf<K, Float>()
   private var draggedPlacedTopY: Float? = null
   private var draggedVisualOriginY: Float? = null
@@ -104,6 +114,12 @@ internal constructor(
     get() {
       orderEpoch
       return orderState.keys
+    }
+
+  val layoutKeys: List<K>
+    get() {
+      orderEpoch
+      return orderState.layoutKeys
     }
 
   val draggingKey: K?
@@ -137,8 +153,36 @@ internal constructor(
   internal fun draggedOffsetY(key: K): Float =
     if (orderState.isDragging(key)) draggedVisualOffsetY else 0f
 
+  internal val currentDragSessionRevision: Long
+    get() = dragSessionRevision
+
+  internal val suppressLazyPlacementAnimation: Boolean
+    get() = isDragging || releasePresentation?.layoutCommitPending == true
+
+  internal val isReleaseCommitPending: Boolean
+    get() = releasePresentation?.layoutCommitPending == true
+
+  internal fun releaseSiblingTargetOffsetY(key: K): Float =
+    releasePresentation?.siblingTargetOffsets?.get(key) ?: 0f
+
+  internal fun siblingTargetOffsetY(key: K): Float {
+    orderEpoch
+    val draggedKey = orderState.draggingKey ?: return 0f
+    return reorderItemDisplacement(
+      layoutKeys = orderState.layoutKeys,
+      projectedKeys = orderState.keys,
+      draggedKey = draggedKey,
+      itemKey = key,
+      draggedHeight = draggedHeight,
+      itemSpacing = itemSpacing,
+    )
+  }
+
   internal fun updateInputKeys(keys: List<K>) {
-    if (orderState.inputKeys != keys) placedItemTops.keys.retainAll(keys.toSet())
+    if (orderState.inputKeys != keys) {
+      val retainedKeys = keys.toSet()
+      placedItemTops.keys.retainAll(retainedKeys)
+    }
     val wasDragging = orderState.isDragging
     endingDrag = true
     try {
@@ -150,32 +194,44 @@ internal constructor(
   }
 
   internal fun publishLayout(layoutInfo: LazyListLayoutInfo, viewport: Rect, scrollDirection: Int) {
-    val displayedKeys = orderState.keys
+    val displayedKeys = orderState.layoutKeys
     val displayedKeyByValue = displayedKeys.associateBy { it as Any }
     val snapshot =
       ReorderLayoutSnapshot(
         viewportTop = viewport.top + layoutInfo.viewportStartOffset,
         viewportBottom = viewport.top + layoutInfo.viewportEndOffset,
+        itemSpacing = layoutInfo.mainAxisItemSpacing.toFloat(),
         items =
           layoutInfo.visibleItemsInfo.mapNotNull { item ->
             val key = displayedKeyByValue[item.key] ?: return@mapNotNull null
+            val top = viewport.top + item.offset
             ReorderLayoutItem(
               key = key,
               lazyIndex = item.index,
-              top = viewport.top + item.offset,
-              bottom = viewport.top + item.offset + item.size,
+              top = top,
+              bottom = top + item.size,
             )
           },
       )
     if (!orderState.isDragging) {
       latestIdleLayout = snapshot
       interaction.publishLayout(snapshot)
+      val currentReleasePresentation = releasePresentation
+      if (
+        currentReleasePresentation?.layoutCommitPending == true &&
+          discoverReorderBlockOffset(orderState.layoutKeys, snapshot) != null
+      ) {
+        releasePresentation = currentReleasePresentation.copy(layoutCommitPending = false)
+      }
       return
     }
 
+    itemSpacing = snapshot.itemSpacing
+
     val layoutProposal = interaction.publishLayout(snapshot, scrollDirection)
     val placementProposal =
-      interaction.draggedItemInPublishedLayout()?.let { draggedItem ->
+      interaction.draggedItemInCurrentSourceLayout()?.let { draggedItem ->
+        draggedHeight = draggedItem.height
         val placementOrderRevision = orderState.orderRevision
         interaction
           .updateDraggedSize(height = draggedItem.height, scrollDirection = scrollDirection)
@@ -203,6 +259,10 @@ internal constructor(
     ) {
       return false
     }
+    dragSessionRevision += 1
+    releasePresentation = null
+    draggedHeight = item.height
+    itemSpacing = latestIdleLayout?.itemSpacing ?: 0f
     draggedPlacementOrderRevision = orderState.orderRevision
     interaction.updateDraggedSize(height = item.height)
     draggedPlacedTopY = placedItemTops[key]
@@ -249,10 +309,21 @@ internal constructor(
 
   internal fun release() {
     if (!orderState.isDragging) return
+    val moved = orderState.keys != orderState.layoutKeys
+    val releaseOffsetY = releaseSettlingOffsetY(moved)
+    if (releaseOffsetY == null) {
+      cancel()
+      return
+    }
+    if (moved) {
+      prepareReleaseCommit()
+    } else {
+      releasePresentation = null
+    }
     val drop =
       try {
         endingDrag = true
-        interaction.release(releaseOffsetY = draggedVisualOffsetY)
+        interaction.release(releaseOffsetY = releaseOffsetY)
       } finally {
         endingDrag = false
       }
@@ -267,6 +338,7 @@ internal constructor(
     } finally {
       endingDrag = false
     }
+    releasePresentation = null
     finishDrag(drop = null)
   }
 
@@ -280,27 +352,54 @@ internal constructor(
     if (orderState.draggingKey != proposal.draggedKey) return
     if (orderState.orderRevision != proposal.sourceOrderRevision) return
 
-    val firstVisibleItem =
-      lazyListState.layoutInfo.visibleItemsInfo.firstOrNull {
-        it.index == lazyListState.firstVisibleItemIndex
-      }
-    if (firstVisibleItem != null) {
-      lazyListState.requestScrollToItem(
-        index = lazyListState.firstVisibleItemIndex,
-        scrollOffset = lazyListState.firstVisibleItemScrollOffset,
-      )
-    }
-
     if (!interaction.commitTarget(proposal)) return
     refreshDraggedVisualOffset()
     onTargetChanged?.invoke()
     if (hapticPolicy.shouldEmit(proposal.targetIndex, nowMillis())) onTargetHaptic?.invoke()
   }
 
+  private fun releaseSettlingOffsetY(moved: Boolean): Float? {
+    if (!moved) return draggedVisualOffsetY
+    val currentVisualTop =
+      interaction.draggedTopY(orderState.draggingKey)
+        ?: draggedPlacedTopY?.plus(draggedVisualOffsetY)
+    val destinationTop = interaction.draggedDestinationTopY()
+    if (currentVisualTop == null || destinationTop == null) return null
+    return currentVisualTop - destinationTop
+  }
+
+  private fun prepareReleaseCommit() {
+    val draggedKey = checkNotNull(orderState.draggingKey)
+    releasePresentation =
+      ReorderReleasePresentation(
+        siblingTargetOffsets =
+          orderState.layoutKeys.associateWith { key ->
+            reorderItemDisplacement(
+              layoutKeys = orderState.layoutKeys,
+              projectedKeys = orderState.keys,
+              draggedKey = draggedKey,
+              itemKey = key,
+              draggedHeight = draggedHeight,
+              itemSpacing = itemSpacing,
+            )
+          },
+        layoutCommitPending = true,
+      )
+    val viewportTop = viewport?.top
+    val projectedAnchor = interaction.projectedViewportAnchor()
+    if (viewportTop != null && projectedAnchor != null) {
+      lazyListState.requestScrollToItem(
+        index = projectedAnchor.lazyIndex,
+        scrollOffset = -(projectedAnchor.top - viewportTop).roundToInt(),
+      )
+    }
+  }
+
   private fun finishDrag(drop: ReorderDrop<K>?) {
     edgeAutoScrollController.pointer = null
     latestIdleLayout = null
     draggedVisualOffsetY = 0f
+    draggedHeight = 0f
     draggedPlacedTopY = null
     draggedVisualOriginY = null
     draggedPlacementOrderRevision = null
@@ -397,14 +496,55 @@ fun <K : Any> ReorderableLazyColumn(
 @Composable
 fun <K : Any> Modifier.reorderableItem(state: ReorderableLazyColumnState<K>, key: K): Modifier {
   val isDragging = state.isDragging(key)
+  val isAnyDragging = state.isDragging
   val settlingOffsetY = state.settlingOffsetY(key)
   val isSettling = settlingOffsetY != null
   val settlingAnim = remember(key, isSettling) { Animatable(settlingOffsetY ?: 0f) }
+  val dragSessionRevision = state.currentDragSessionRevision
+  val siblingTargetOffsetY = state.siblingTargetOffsetY(key)
+  val siblingAnim = remember(key, dragSessionRevision) { Animatable(0f) }
+  var siblingHandoffBaseOffsetY by
+    remember(key, dragSessionRevision) { mutableStateOf<Float?>(null) }
+  var siblingHandoffPending by remember(key, dragSessionRevision) { mutableStateOf(false) }
+  val isReleaseCommitPending = state.isReleaseCommitPending
+  val releaseSiblingTargetOffsetY = state.releaseSiblingTargetOffsetY(key)
+  val siblingHandoffBase = siblingHandoffBaseOffsetY
+  val siblingOffsetY =
+    when {
+      isAnyDragging && !isDragging -> siblingAnim.value
+      isReleaseCommitPending -> siblingAnim.value - releaseSiblingTargetOffsetY
+      siblingHandoffBase != null -> siblingAnim.value - siblingHandoffBase
+      siblingHandoffPending -> siblingAnim.value
+      else -> 0f
+    }
   val pinnableContainer = LocalPinnableContainer.current
+  val shouldPin = isDragging || isSettling
 
-  DisposableEffect(pinnableContainer, isDragging || isSettling) {
-    val pinnedHandle = if (isDragging || isSettling) pinnableContainer?.pin() else null
+  SideEffect {
+    if (isAnyDragging) {
+      siblingHandoffPending = true
+    }
+  }
+
+  DisposableEffect(pinnableContainer, shouldPin) {
+    val pinnedHandle = if (shouldPin) pinnableContainer?.pin() else null
     onDispose { pinnedHandle?.release() }
+  }
+
+  LaunchedEffect(key, dragSessionRevision, isAnyDragging, siblingTargetOffsetY) {
+    if (isAnyDragging) {
+      siblingHandoffBaseOffsetY = null
+      siblingAnim.animateTo(
+        targetValue = siblingTargetOffsetY,
+        animationSpec = ReorderSiblingSpring,
+      )
+      return@LaunchedEffect
+    }
+    val handoffBaseOffsetY = if (isReleaseCommitPending) releaseSiblingTargetOffsetY else 0f
+    siblingHandoffBaseOffsetY = handoffBaseOffsetY
+    siblingHandoffPending = false
+    siblingAnim.animateTo(targetValue = handoffBaseOffsetY, animationSpec = ReorderSiblingSpring)
+    siblingHandoffBaseOffsetY = null
   }
 
   LaunchedEffect(key, isSettling) {
@@ -416,7 +556,7 @@ fun <K : Any> Modifier.reorderableItem(state: ReorderableLazyColumnState<K>, key
     state.clearSettling(key)
   }
 
-  return this.zIndex(if (isDragging) 2f else 0f)
+  return this.zIndex(if (isDragging || isSettling) 2f else 0f)
     .onPlaced { coordinates ->
       state.updateItemPlacement(key = key, placedTop = coordinates.positionInWindow().y)
     }
@@ -424,7 +564,7 @@ fun <K : Any> Modifier.reorderableItem(state: ReorderableLazyColumnState<K>, key
       val placeable = measurable.measure(constraints)
       layout(placeable.width, placeable.height) {
         placeable.placeWithLayer(0, 0) {
-          translationY = settlingAnim.value + state.draggedOffsetY(key)
+          translationY = settlingAnim.value + state.draggedOffsetY(key) + siblingOffsetY
         }
       }
     }
@@ -437,7 +577,11 @@ fun <K : Any> LazyItemScope.reorderableAnimatedItem(
   modifier: Modifier = Modifier,
 ): Modifier {
   val placementSpec =
-    if (state.isDragging(key) || state.isSettling(key)) null else ReorderPlacementSpring
+    if (state.suppressLazyPlacementAnimation || state.isSettling(key)) {
+      null
+    } else {
+      ReorderPlacementSpring
+    }
   return modifier.animateItem(fadeInSpec = null, placementSpec = placementSpec, fadeOutSpec = null)
 }
 
@@ -542,6 +686,9 @@ fun <K : Any> Modifier.reorderableDragHandle(
 }
 
 private val ReorderReleaseSpring =
+  spring<Float>(dampingRatio = 0.9f, stiffness = Spring.StiffnessMedium)
+
+private val ReorderSiblingSpring =
   spring<Float>(dampingRatio = 0.9f, stiffness = Spring.StiffnessMedium)
 
 private val ReorderPlacementSpring =

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/ui/component/reorder/ReorderInteractionTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/ui/component/reorder/ReorderInteractionTest.kt
@@ -20,30 +20,62 @@ class ReorderInteractionTest {
     assertEquals(listOf("b", "a", "c", "d"), interaction.orderState.keys)
 
     val secondProposal =
-      interaction.publishLayout(layoutSnapshot(item("b", 0, 0f, 50f), item("c", 2, 100f, 150f)))
+      interaction.publishLayout(
+        layoutSnapshot(item("a", 0, -50f, 0f), item("b", 1, 0f, 50f), item("c", 2, 50f, 100f))
+      )
     assertEquals(2, secondProposal?.targetIndex)
     assertTrue(interaction.commitTarget(requireNotNull(secondProposal)))
     assertEquals(listOf("b", "c", "a", "d"), interaction.orderState.keys)
+    assertEquals(listOf("a", "b", "c", "d"), interaction.orderState.layoutKeys)
   }
 
   @Test
-  fun `stale layout after order revision is ignored until matching layout arrives`() {
+  fun `stable source layout remains usable after order revision`() {
     val interaction = interaction(listOf("a", "b", "c"))
     val initial =
       layoutSnapshot(item("a", 1, 0f, 50f), item("b", 2, 50f, 100f), item("c", 3, 100f, 150f))
     interaction.publishLayout(initial)
     assertTrue(interaction.beginDrag("a", pointerY = 25f, pointerOffsetInItemY = 25f))
     interaction.updateDraggedSize(height = 50f)
-    val proposal = requireNotNull(interaction.updatePointer(pointerY = 130f))
+    val proposal = requireNotNull(interaction.updatePointer(pointerY = 80f))
     assertTrue(interaction.commitTarget(proposal))
 
-    assertNull(interaction.publishLayout(initial))
-    assertNull(interaction.updatePointer(pointerY = 131f))
+    interaction.publishLayout(initial)
 
-    val matching =
-      layoutSnapshot(item("b", 1, 0f, 50f), item("c", 2, 50f, 100f), item("a", 3, 100f, 150f))
-    interaction.publishLayout(matching)
+    assertEquals(50f, interaction.draggedItemInCurrentSourceLayout()?.height)
     assertTrue(interaction.orderState.isDragging)
+  }
+
+  @Test
+  fun `destination anchor follows scroll after its boundary item leaves the published layout`() {
+    val interaction = interaction(listOf("a", "b", "c", "d", "e"))
+    interaction.publishLayout(
+      layoutSnapshot(item("a", 0, 0f, 80f), item("b", 1, 80f, 120f), item("c", 2, 120f, 220f))
+    )
+    assertTrue(interaction.beginDrag("a", pointerY = 40f, pointerOffsetInItemY = 40f))
+    interaction.updateDraggedSize(height = 80f)
+    interaction.publishLayout(
+      layoutSnapshot(
+        item("a", 0, -100f, -20f),
+        item("b", 1, -20f, 20f),
+        item("c", 2, 20f, 120f),
+        item("d", 3, 120f, 160f),
+      )
+    )
+    val proposal = requireNotNull(interaction.updatePointer(pointerY = 110f))
+    assertEquals(3, proposal.targetIndex)
+    assertTrue(interaction.commitTarget(proposal))
+    assertEquals(80f, interaction.draggedDestinationTopY())
+
+    interaction.publishLayout(
+      layoutSnapshot(item("a", 0, -100f, -20f), item("b", 1, -20f, 20f), item("c", 2, 20f, 120f))
+    )
+    assertEquals(80f, interaction.draggedDestinationTopY())
+
+    interaction.publishLayout(
+      layoutSnapshot(item("a", 0, -110f, -30f), item("b", 1, -30f, 10f), item("c", 2, 10f, 110f))
+    )
+    assertEquals(70f, interaction.draggedDestinationTopY())
   }
 
   @Test

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/ui/component/reorder/ReorderLayoutTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/ui/component/reorder/ReorderLayoutTest.kt
@@ -53,26 +53,161 @@ class ReorderLayoutTest {
   }
 
   @Test
-  fun `stale item keys are projected onto the current lazy slots`() {
-    val stale =
+  fun `stable source is projected downward with variable heights and spacing`() {
+    val source =
       layoutSnapshot(
-        item("a", lazyIndex = 1, top = -40f, bottom = 10f),
-        item("b", lazyIndex = 2, top = 10f, bottom = 60f),
-        item("c", lazyIndex = 3, top = 60f, bottom = 110f),
+        item("a", lazyIndex = 1, top = 0f, bottom = 40f),
+        item("b", lazyIndex = 2, top = 50f, bottom = 130f),
+        item("c", lazyIndex = 3, top = 140f, bottom = 170f),
       )
 
     assertEquals(
       layoutSnapshot(
-        item("b", lazyIndex = 1, top = -40f, bottom = 10f),
-        item("c", lazyIndex = 2, top = 10f, bottom = 60f),
-        item("a", lazyIndex = 3, top = 60f, bottom = 110f),
+        item("a", lazyIndex = 3, top = 130f, bottom = 170f),
+        item("b", lazyIndex = 1, top = 0f, bottom = 80f),
+        item("c", lazyIndex = 2, top = 90f, bottom = 120f),
       ),
-      projectReorderSnapshotOntoDisplayedSlots(
-        displayedKeys = listOf("b", "c", "a", "d"),
-        blockOffset = 1,
-        snapshot = stale,
+      projectReorderLayoutFromStableSource(
+          layoutKeys = listOf("a", "b", "c"),
+          projectedKeys = listOf("b", "c", "a"),
+          draggedKey = "a",
+          draggedHeight = 40f,
+          itemSpacing = 10f,
+          blockOffset = 1,
+          snapshot = source,
+        )
+        .snapshot,
+    )
+  }
+
+  @Test
+  fun `stable source is projected upward with variable heights and spacing`() {
+    val source =
+      layoutSnapshot(
+        item("a", lazyIndex = 0, top = 0f, bottom = 30f),
+        item("b", lazyIndex = 1, top = 40f, bottom = 100f),
+        item("c", lazyIndex = 2, top = 110f, bottom = 150f),
+        item("d", lazyIndex = 3, top = 160f, bottom = 230f),
+      )
+
+    assertEquals(
+      layoutSnapshot(
+        item("a", lazyIndex = 0, top = 0f, bottom = 30f),
+        item("b", lazyIndex = 2, top = 120f, bottom = 180f),
+        item("c", lazyIndex = 3, top = 190f, bottom = 230f),
+        item("d", lazyIndex = 1, top = 40f, bottom = 110f),
+      ),
+      projectReorderLayoutFromStableSource(
+          layoutKeys = listOf("a", "b", "c", "d"),
+          projectedKeys = listOf("a", "d", "b", "c"),
+          draggedKey = "d",
+          draggedHeight = 70f,
+          itemSpacing = 10f,
+          blockOffset = 0,
+          snapshot = source,
+        )
+        .snapshot,
+    )
+  }
+
+  @Test
+  fun `reversing to the source index clears sibling displacement`() {
+    assertEquals(
+      0f,
+      reorderItemDisplacement(
+        layoutKeys = listOf("a", "b", "c"),
+        projectedKeys = listOf("a", "b", "c"),
+        draggedKey = "c",
+        itemKey = "b",
+        draggedHeight = 80f,
+        itemSpacing = 12f,
       ),
     )
+  }
+
+  @Test
+  fun `dragged destination top follows the actual target slot height`() {
+    val source =
+      layoutSnapshot(
+        item("a", lazyIndex = 0, top = 0f, bottom = 40f),
+        item("b", lazyIndex = 1, top = 50f, bottom = 150f),
+      )
+
+    val projected =
+      projectReorderLayoutFromStableSource(
+          layoutKeys = listOf("a", "b"),
+          projectedKeys = listOf("b", "a"),
+          draggedKey = "a",
+          draggedHeight = 40f,
+          itemSpacing = 10f,
+          blockOffset = 0,
+          snapshot = source,
+        )
+        .snapshot
+
+    assertEquals(110f, projected.items.single { it.key == "a" }.top)
+  }
+
+  @Test
+  fun `upward destination just below the published range is extrapolated from its boundary`() {
+    val source =
+      ReorderLayoutSnapshot(
+        viewportTop = 0f,
+        viewportBottom = 160f,
+        itemSpacing = 10f,
+        items =
+          listOf(
+            item("a", lazyIndex = 0, top = 0f, bottom = 40f),
+            item("b", lazyIndex = 1, top = 50f, bottom = 90f),
+            item("c", lazyIndex = 2, top = 100f, bottom = 150f),
+            item("e", lazyIndex = 4, top = 300f, bottom = 350f),
+          ),
+      )
+
+    val projected =
+      projectReorderLayoutFromStableSource(
+          layoutKeys = listOf("a", "b", "c", "d", "e"),
+          projectedKeys = listOf("a", "b", "c", "e", "d"),
+          draggedKey = "e",
+          draggedHeight = 50f,
+          itemSpacing = 10f,
+          blockOffset = 0,
+          snapshot = source,
+        )
+        .snapshot
+
+    assertEquals(160f, projected.items.single { it.key == "e" }.top)
+  }
+
+  @Test
+  fun `downward destination just above the published range is extrapolated from its boundary`() {
+    val source =
+      ReorderLayoutSnapshot(
+        viewportTop = 100f,
+        viewportBottom = 260f,
+        itemSpacing = 10f,
+        items =
+          listOf(
+            item("a", lazyIndex = 0, top = -100f, bottom = -50f),
+            item("c", lazyIndex = 2, top = 100f, bottom = 140f),
+            item("d", lazyIndex = 3, top = 150f, bottom = 190f),
+            item("e", lazyIndex = 4, top = 200f, bottom = 240f),
+          ),
+      )
+
+    val projected =
+      projectReorderLayoutFromStableSource(
+          layoutKeys = listOf("a", "b", "c", "d", "e"),
+          projectedKeys = listOf("b", "a", "c", "d", "e"),
+          draggedKey = "a",
+          draggedHeight = 50f,
+          itemSpacing = 10f,
+          blockOffset = 0,
+          snapshot = source,
+        )
+        .snapshot
+
+    assertEquals(40f, projected.items.single { it.key == "a" }.top)
   }
 
   @Test

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/ui/component/reorder/ReorderStateTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/ui/component/reorder/ReorderStateTest.kt
@@ -8,6 +8,20 @@ import kotlin.test.assertTrue
 
 class ReorderStateTest {
   @Test
+  fun `layout order stays at drag start until a moved release`() {
+    val state = ReorderState(listOf("a", "b", "c"))
+
+    assertTrue(state.beginDrag("c"))
+    assertTrue(state.moveDraggedTo(0))
+
+    assertEquals(listOf("c", "a", "b"), state.keys)
+    assertEquals(listOf("a", "b", "c"), state.layoutKeys)
+
+    assertEquals(0, state.endDrag(releaseOffsetY = 0f)?.toIndex)
+    assertEquals(listOf("c", "a", "b"), state.layoutKeys)
+  }
+
+  @Test
   fun `moving a drag to a different target returns one drop`() {
     val state = ReorderState(listOf("a", "b", "c"))
 

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/domain/note/NoteListDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/domain/note/NoteListDesktopTest.kt
@@ -30,6 +30,7 @@ import co.typie.graphql.type.NoteStatus
 import co.typie.result.Result
 import co.typie.ui.component.popover.LocalPopoverOverlayState
 import co.typie.ui.component.popover.PopoverOverlayState
+import co.typie.ui.component.reorder.ReorderableLazyColumnState
 import co.typie.ui.component.toast.LocalToast
 import co.typie.ui.component.toast.Toast
 import co.typie.ui.theme.LightAppShadows
@@ -41,10 +42,83 @@ import co.typie.ui.theme.ResolvedThemeMode
 import dev.chrisbanes.haze.blur.HazeBlurStyle
 import dev.chrisbanes.haze.blur.LocalHazeBlurStyle
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalTestApi::class)
 class NoteListDesktopTest {
+  @Test
+  fun projectedNoteOrderDoesNotChangeThePhysicalListDuringDrag() = runComposeUiTest {
+    val first = notesNote(id = "first", content = "first-content", order = "100")
+    val second = notesNote(id = "second", content = "second-content", order = "200")
+    val items =
+      listOf(first, second).map { note ->
+        NoteListItem(
+          note = note,
+          isDeleting = false,
+          isChangingStatus = false,
+          isEntering = false,
+          isExiting = false,
+          isExitVisible = false,
+        )
+      }
+    lateinit var reorderState: ReorderableLazyColumnState<String>
+
+    setContent {
+      CompositionLocalProvider(
+        LocalAppColors provides LightColors,
+        LocalAppShadows provides LightAppShadows,
+        LocalThemeMode provides ResolvedThemeMode.Light,
+        LocalHazeBlurStyle provides
+          HazeBlurStyle(blurRadius = 20.dp, noiseFactor = 0f, colorEffects = listOf()),
+        LocalToast provides Toast(),
+      ) {
+        val scope = rememberCoroutineScope()
+        val editState = remember(scope) { NoteEditState(scope) }
+        reorderState =
+          rememberNoteListReorderState(items = items, scrollState = rememberLazyListState())
+        NoteList(
+          identity = NoteListIdentity(siteId = "site", status = NoteStatus.OPEN),
+          emptyMessage = "",
+          queryState = QueryState.Success(Unit),
+          items = items,
+          authoritativeNotes = listOf(first, second),
+          editState = editState,
+          onEnterAnimationFinished = {},
+          onExitAnimationFinished = {},
+          reorderState = reorderState,
+          noteColorOptions =
+            listOf(NoteColorOption(value = "gray", label = "그레이", stroke = Color.Gray)),
+          interactive = false,
+          onRetry = {},
+          actions = idleActions(),
+          modifier = Modifier.size(width = 400.dp, height = 500.dp),
+        )
+      }
+    }
+    waitForIdle()
+
+    runOnUiThread {
+      assertTrue(reorderState.orderState.beginDrag("first"))
+      assertTrue(reorderState.orderState.moveDraggedTo(1))
+    }
+    waitForIdle()
+
+    assertEquals(listOf("second", "first"), reorderState.keys)
+    assertEquals(listOf("first", "second"), reorderState.layoutKeys)
+    assertTrue(
+      onNodeWithText("first-content", useUnmergedTree = true)
+        .fetchSemanticsNode()
+        .boundsInRoot
+        .top <
+        onNodeWithText("second-content", useUnmergedTree = true)
+          .fetchSemanticsNode()
+          .boundsInRoot
+          .top
+    )
+    runOnUiThread { reorderState.orderState.cancelDrag() }
+  }
+
   @Test
   fun collapsedMetadataFitsWithinANarrowCard() = runComposeUiTest {
     val note =
@@ -333,4 +407,19 @@ class NoteListDesktopTest {
       )
     }
   }
+
+  private fun idleActions() =
+    NoteListActions(
+      onExpand = {},
+      onCollapse = {},
+      onCreateNote = {},
+      onContentChange = { _, _ -> },
+      onBlur = {},
+      onToggleStatus = {},
+      onColorChange = { _, _ -> },
+      onAddEntity = {},
+      onEntityClick = { _, _ -> },
+      onDelete = {},
+      onMoveNote = { _, _, _ -> Result.Ok("") },
+    )
 }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/reorder/ReorderableLazyColumnDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/reorder/ReorderableLazyColumnDesktopTest.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTouchInput
@@ -45,7 +46,7 @@ class ReorderableLazyColumnDesktopTest {
           contentPadding = PaddingValues(top = 20.dp),
         ) {
           item(key = "header") { Box(Modifier.fillMaxWidth().height(40.dp)) }
-          items(state.keys, key = { it }) { itemKey ->
+          items(state.layoutKeys, key = { it }) { itemKey ->
             Box(
               reorderableAnimatedItem(
                   state = state,
@@ -99,9 +100,13 @@ class ReorderableLazyColumnDesktopTest {
       state = rememberReorderableLazyColumnState(keys = keys)
       ReorderableLazyColumn(
         state = state,
-        modifier = Modifier.size(width = 100.dp, height = 120.dp).reorderableViewport(state = state),
+        modifier =
+          Modifier.size(width = 100.dp, height = 120.dp)
+            .background(Color.White)
+            .testTag("edge-autoscroll-list")
+            .reorderableViewport(state = state),
       ) {
-        items(state.keys, key = { it }) { itemKey ->
+        items(state.layoutKeys, key = { it }) { itemKey ->
           Box(
             reorderableAnimatedItem(
                 state = state,
@@ -109,6 +114,7 @@ class ReorderableLazyColumnDesktopTest {
                 modifier = Modifier.fillMaxWidth().height(40.dp),
               )
               .reorderableItem(state = state, key = itemKey)
+              .background(if (itemKey == "0") Color.Red else Color.Blue)
               .testTag(itemKey)
           ) {
             Box(
@@ -126,9 +132,9 @@ class ReorderableLazyColumnDesktopTest {
     val handle = onNodeWithTag("handle-0")
     handle.performTouchInput { down(center) }
     mainClock.advanceTimeByFrame()
-    handle.performTouchInput { moveBy(Offset(x = 0f, y = 200f)) }
+    handle.performTouchInput { moveBy(Offset(x = 0f, y = 75f)) }
     val targetIndices = buildList {
-      repeat(6) {
+      repeat(4) {
         repeat(12) { mainClock.advanceTimeByFrame() }
         add(state.keys.indexOf("0"))
       }
@@ -143,8 +149,28 @@ class ReorderableLazyColumnDesktopTest {
       "Dragged slot stalled during edge auto-scroll: $targetIndices",
     )
 
+    val list = onNodeWithTag("edge-autoscroll-list")
+    val redRowsBeforeRelease = list.capturedColorRows(Color.Red)
+    assertTrue(redRowsBeforeRelease.isNotEmpty())
     handle.performTouchInput { up() }
-    repeat(3) { mainClock.advanceTimeByFrame() }
+    var redRowsAfterFirstReleaseFrame = emptyList<Int>()
+    repeat(4) {
+      mainClock.advanceTimeByFrame()
+      if (!state.isDragging && redRowsAfterFirstReleaseFrame.isEmpty()) {
+        redRowsAfterFirstReleaseFrame = list.capturedColorRows(Color.Red)
+      }
+    }
+    repeat(90) { mainClock.advanceTimeByFrame() }
+    val redRowsAfterSettling = list.capturedColorRows(Color.Red)
+    val expectedFirstRowRange =
+      minOf(redRowsBeforeRelease.first(), redRowsAfterSettling.first()) - 1..maxOf(
+          redRowsBeforeRelease.first(),
+          redRowsAfterSettling.first(),
+        ) + 1
+    assertTrue(
+      redRowsAfterFirstReleaseFrame.firstOrNull()?.let { it in expectedFirstRowRange } == true,
+      "Dragged pixels jumped on far release: before=$redRowsBeforeRelease, first=$redRowsAfterFirstReleaseFrame, settled=$redRowsAfterSettling",
+    )
     mainClock.autoAdvance = true
   }
 
@@ -158,7 +184,7 @@ class ReorderableLazyColumnDesktopTest {
         state = state,
         modifier = Modifier.size(width = 100.dp, height = 120.dp),
       ) {
-        items(state.keys, key = { it }) { itemKey ->
+        items(state.layoutKeys, key = { it }) { itemKey ->
           Box(
             reorderableAnimatedItem(
                 state = state,
@@ -213,7 +239,7 @@ class ReorderableLazyColumnDesktopTest {
         state = state,
         modifier = Modifier.size(width = 100.dp, height = 120.dp),
       ) {
-        items(state.keys, key = { it }) { itemKey ->
+        items(state.layoutKeys, key = { it }) { itemKey ->
           Box(
             reorderableAnimatedItem(
                 state = state,
@@ -266,7 +292,7 @@ class ReorderableLazyColumnDesktopTest {
         modifier =
           Modifier.size(width = 100.dp, height = 120.dp).background(Color.White).testTag("list"),
       ) {
-        items(state.keys, key = { it }) { itemKey ->
+        items(state.layoutKeys, key = { it }) { itemKey ->
           Box(
             modifier =
               Modifier.fillMaxWidth()
@@ -340,7 +366,7 @@ class ReorderableLazyColumnDesktopTest {
         state = state,
         modifier = Modifier.size(width = 100.dp, height = 120.dp),
       ) {
-        items(state.keys, key = { it }) { itemKey ->
+        items(state.layoutKeys, key = { it }) { itemKey ->
           Box(
             reorderableAnimatedItem(
                 state = state,
@@ -358,6 +384,7 @@ class ReorderableLazyColumnDesktopTest {
                     bottom = origin.y + coordinates.size.height,
                   )
               }
+              .testTag(itemKey)
           )
         }
       }
@@ -390,32 +417,373 @@ class ReorderableLazyColumnDesktopTest {
   }
 
   @Test
-  fun movingAnItemAboveTheFirstVisibleKeyKeepsTheVisibleSlotAnchored() = runComposeUiTest {
+  fun upwardReorderInsideContentPaddingKeepsTheContentCoordinate() = runComposeUiTest {
     lateinit var state: ReorderableLazyColumnState<String>
     val itemBounds = mutableMapOf<String, Rect>()
+    val keys = (0 until 10).map(Int::toString)
+    val draggedKey = "6"
 
     setContent {
       val lazyListState =
         rememberLazyListState(
-          initialFirstVisibleItemIndex = 2,
-          initialFirstVisibleItemScrollOffset = 10,
+          initialFirstVisibleItemIndex = 5,
+          initialFirstVisibleItemScrollOffset = 50,
         )
-      state =
-        rememberReorderableLazyColumnState(
-          keys = listOf("a", "b", "c", "d", "e", "f"),
-          lazyListState = lazyListState,
-        )
+      state = rememberReorderableLazyColumnState(keys = keys, lazyListState = lazyListState)
 
       ReorderableLazyColumn(
         state = state,
-        modifier = Modifier.size(width = 100.dp, height = 120.dp),
+        modifier = Modifier.size(width = 100.dp, height = 240.dp),
+        contentPadding = PaddingValues(top = 40.dp),
       ) {
-        items(state.keys, key = { it }) { itemKey ->
+        items(state.layoutKeys, key = { it }) { itemKey ->
           Box(
             reorderableAnimatedItem(
                 state = state,
                 key = itemKey,
-                modifier = Modifier.fillMaxWidth().height(40.dp),
+                modifier =
+                  Modifier.fillMaxWidth().height(if (itemKey == draggedKey) 120.dp else 40.dp),
+              )
+              .reorderableItem(state = state, key = itemKey)
+              .onGloballyPositioned { coordinates ->
+                val origin = coordinates.positionInWindow()
+                itemBounds[itemKey] =
+                  Rect(
+                    left = origin.x,
+                    top = origin.y,
+                    right = origin.x + coordinates.size.width,
+                    bottom = origin.y + coordinates.size.height,
+                  )
+              }
+              .testTag("padding-$itemKey")
+          )
+        }
+      }
+    }
+    waitForIdle()
+
+    val layoutBefore = state.lazyListState.layoutInfo
+    assertEquals(6, state.lazyListState.firstVisibleItemIndex)
+    val paddingItem = assertNotNull(layoutBefore.visibleItemsInfo.firstOrNull { it.key == "5" })
+    assertTrue(paddingItem.offset < 0)
+    assertTrue(paddingItem.offset + paddingItem.size <= 0)
+    val unaffectedOffsetBefore =
+      assertNotNull(layoutBefore.visibleItemsInfo.firstOrNull { it.key == "7" }).offset
+    val crossedSiblingTopBefore = onNodeWithTag("padding-5").fetchSemanticsNode().boundsInRoot.top
+    val draggedBounds = assertNotNull(itemBounds[draggedKey])
+    val viewport = assertNotNull(state.viewport)
+    val pointer = Offset(x = draggedBounds.center.x, y = draggedBounds.top + 60f)
+    val paddingPointer = Offset(x = pointer.x, y = viewport.top + 29f)
+    mainClock.autoAdvance = false
+
+    runOnUiThread {
+      assertTrue(
+        state.beginDrag(
+          key = draggedKey,
+          pointer = pointer,
+          onTargetChanged = {},
+          onTargetHaptic = {},
+          onDragStopped = {},
+        )
+      )
+      state.updatePointer(paddingPointer)
+      assertEquals(listOf("0", "1", "2", "3", "4", "6", "5", "7", "8", "9"), state.keys)
+      assertEquals(keys, state.layoutKeys)
+    }
+    mainClock.advanceTimeByFrame()
+
+    val layoutAfter = state.lazyListState.layoutInfo
+    assertEquals("5", layoutAfter.visibleItemsInfo.firstOrNull { it.index == 5 }?.key)
+    assertEquals("6", layoutAfter.visibleItemsInfo.firstOrNull { it.index == 6 }?.key)
+    val unaffectedOffsetAfter =
+      assertNotNull(layoutAfter.visibleItemsInfo.firstOrNull { it.key == "7" }).offset
+    assertEquals(unaffectedOffsetBefore, unaffectedOffsetAfter)
+    assertTrue(
+      onNodeWithTag("padding-5").fetchSemanticsNode().boundsInRoot.top <
+        crossedSiblingTopBefore + 100f,
+      "Crossed sibling snapped to the 120px destination on the first frame",
+    )
+    val draggedVisualTopBeforeRelease = assertNotNull(itemBounds[draggedKey]).top
+    runOnUiThread { state.release() }
+    val initialReleaseOffset = assertNotNull(state.settlingOffsetY(draggedKey))
+    assertEquals(
+      draggedVisualTopBeforeRelease,
+      viewport.top + layoutBefore.beforeContentPadding + paddingItem.offset + initialReleaseOffset,
+      1f,
+    )
+    mainClock.advanceTimeByFrame()
+
+    assertEquals(listOf("0", "1", "2", "3", "4", "6", "5", "7", "8", "9"), state.layoutKeys)
+    val draggedOffsetAfterRelease =
+      assertNotNull(
+          state.lazyListState.layoutInfo.visibleItemsInfo.firstOrNull { it.key == draggedKey }
+        )
+        .offset
+    val unaffectedOffsetAfterRelease =
+      assertNotNull(state.lazyListState.layoutInfo.visibleItemsInfo.firstOrNull { it.key == "7" })
+        .offset
+    assertEquals(paddingItem.offset, draggedOffsetAfterRelease)
+    assertEquals(unaffectedOffsetBefore, unaffectedOffsetAfterRelease)
+    repeat(90) { mainClock.advanceTimeByFrame() }
+    mainClock.autoAdvance = true
+  }
+
+  @Test
+  fun movedReleaseKeepsTallDraggedItemContinuousThenSettlesIntoItsSlot() = runComposeUiTest {
+    lateinit var state: ReorderableLazyColumnState<String>
+
+    setContent {
+      state = rememberReorderableLazyColumnState(keys = listOf("a", "b", "c"))
+      ReorderableLazyColumn(
+        state = state,
+        modifier = Modifier.size(width = 100.dp, height = 200.dp),
+      ) {
+        items(state.layoutKeys, key = { it }) { itemKey ->
+          Box(
+            reorderableAnimatedItem(
+                state = state,
+                key = itemKey,
+                modifier = Modifier.fillMaxWidth().height(if (itemKey == "a") 80.dp else 40.dp),
+              )
+              .reorderableItem(state = state, key = itemKey)
+              .testTag(itemKey)
+          )
+        }
+      }
+    }
+    waitForIdle()
+    val initialTop = onNodeWithTag("a").fetchSemanticsNode().boundsInRoot.top
+    val pointer = Offset(x = 50f, y = initialTop + 40f)
+    mainClock.autoAdvance = false
+
+    runOnUiThread {
+      assertTrue(
+        state.beginDrag(
+          key = "a",
+          pointer = pointer,
+          onTargetChanged = {},
+          onTargetHaptic = {},
+          onDragStopped = {},
+        )
+      )
+      state.updatePointer(pointer + Offset(x = 0f, y = 45f))
+      assertEquals(listOf("b", "a", "c"), state.keys)
+      assertEquals(listOf("a", "b", "c"), state.layoutKeys)
+    }
+    mainClock.advanceTimeByFrame()
+    val topBeforeRelease = onNodeWithTag("a").fetchSemanticsNode().boundsInRoot.top
+    val siblingTopBeforeRelease = onNodeWithTag("b").fetchSemanticsNode().boundsInRoot.top
+
+    runOnUiThread { state.release() }
+    mainClock.advanceTimeByFrame()
+
+    assertEquals(listOf("b", "a", "c"), state.layoutKeys)
+    assertEquals("b", state.lazyListState.layoutInfo.visibleItemsInfo.first { it.index == 0 }.key)
+    assertEquals(topBeforeRelease, onNodeWithTag("a").fetchSemanticsNode().boundsInRoot.top, 1f)
+    assertEquals(
+      siblingTopBeforeRelease,
+      onNodeWithTag("b").fetchSemanticsNode().boundsInRoot.top,
+      1f,
+    )
+
+    repeat(90) { mainClock.advanceTimeByFrame() }
+    assertEquals(initialTop + 40f, onNodeWithTag("a").fetchSemanticsNode().boundsInRoot.top, 1f)
+    mainClock.autoAdvance = true
+  }
+
+  @Test
+  fun movedReleaseCapturesTheFinalTargetBeforeTheNextCompositionFrame() = runComposeUiTest {
+    lateinit var state: ReorderableLazyColumnState<String>
+
+    setContent {
+      state = rememberReorderableLazyColumnState(keys = listOf("a", "b", "c"))
+      ReorderableLazyColumn(
+        state = state,
+        modifier = Modifier.size(width = 100.dp, height = 200.dp),
+      ) {
+        items(state.layoutKeys, key = { it }) { itemKey ->
+          Box(
+            reorderableAnimatedItem(
+                state = state,
+                key = itemKey,
+                modifier = Modifier.fillMaxWidth().height(if (itemKey == "a") 80.dp else 40.dp),
+              )
+              .reorderableItem(state = state, key = itemKey)
+              .testTag("immediate-$itemKey")
+          )
+        }
+      }
+    }
+    waitForIdle()
+    val draggedInitialTop = onNodeWithTag("immediate-a").fetchSemanticsNode().boundsInRoot.top
+    val siblingInitialTop = onNodeWithTag("immediate-b").fetchSemanticsNode().boundsInRoot.top
+    val pointer = Offset(x = 50f, y = draggedInitialTop + 40f)
+    mainClock.autoAdvance = false
+
+    runOnUiThread {
+      assertTrue(
+        state.beginDrag(
+          key = "a",
+          pointer = pointer,
+          onTargetChanged = {},
+          onTargetHaptic = {},
+          onDragStopped = {},
+        )
+      )
+      state.updatePointer(pointer + Offset(x = 0f, y = 45f))
+      assertEquals(listOf("b", "a", "c"), state.keys)
+      state.release()
+    }
+    mainClock.advanceTimeByFrame()
+
+    assertEquals(listOf("b", "a", "c"), state.layoutKeys)
+    assertEquals(
+      draggedInitialTop + 45f,
+      onNodeWithTag("immediate-a").fetchSemanticsNode().boundsInRoot.top,
+      1f,
+    )
+    assertEquals(
+      siblingInitialTop,
+      onNodeWithTag("immediate-b").fetchSemanticsNode().boundsInRoot.top,
+      1f,
+    )
+
+    repeat(90) { mainClock.advanceTimeByFrame() }
+    assertEquals(
+      draggedInitialTop + 40f,
+      onNodeWithTag("immediate-a").fetchSemanticsNode().boundsInRoot.top,
+      1f,
+    )
+    mainClock.autoAdvance = true
+  }
+
+  @Test
+  fun movedReleaseAnchorsTheProjectedSlotWithVariableHeights() = runComposeUiTest {
+    lateinit var state: ReorderableLazyColumnState<String>
+    val itemBounds = mutableMapOf<String, Rect>()
+    val keys = listOf("a", "b", "c", "d", "e")
+    val draggedKey = "a"
+
+    setContent {
+      val lazyListState = rememberLazyListState()
+      state = rememberReorderableLazyColumnState(keys = keys, lazyListState = lazyListState)
+      ReorderableLazyColumn(
+        state = state,
+        modifier =
+          Modifier.size(width = 100.dp, height = 160.dp)
+            .background(Color.White)
+            .testTag("projected-anchor-list"),
+      ) {
+        items(state.layoutKeys, key = { it }) { itemKey ->
+          val itemHeight =
+            when (itemKey) {
+              draggedKey -> 80.dp
+              "c" -> 100.dp
+              else -> 40.dp
+            }
+          Box(
+            reorderableAnimatedItem(
+                state = state,
+                key = itemKey,
+                modifier = Modifier.fillMaxWidth().height(itemHeight),
+              )
+              .reorderableItem(state = state, key = itemKey)
+              .onGloballyPositioned { coordinates ->
+                val origin = coordinates.positionInWindow()
+                itemBounds[itemKey] =
+                  Rect(
+                    left = origin.x,
+                    top = origin.y,
+                    right = origin.x + coordinates.size.width,
+                    bottom = origin.y + coordinates.size.height,
+                  )
+              }
+              .background(if (itemKey == draggedKey) Color.Red else Color.Blue)
+          )
+        }
+      }
+    }
+    waitForIdle()
+    val draggedBounds = assertNotNull(itemBounds[draggedKey])
+    val viewport = assertNotNull(state.viewport)
+    val pointer = Offset(x = draggedBounds.center.x, y = draggedBounds.top + 40f)
+    mainClock.autoAdvance = false
+
+    runOnUiThread {
+      assertTrue(
+        state.beginDrag(
+          key = draggedKey,
+          pointer = pointer,
+          onTargetChanged = {},
+          onTargetHaptic = {},
+          onDragStopped = {},
+        )
+      )
+      state.lazyListState.requestScrollToItem(index = 1, scrollOffset = 20)
+    }
+    repeat(2) { mainClock.advanceTimeByFrame() }
+    runOnUiThread { state.updatePointer(Offset(x = pointer.x, y = viewport.top + 110f)) }
+    assertEquals(listOf("b", "c", "d", "a", "e"), state.keys)
+    mainClock.advanceTimeByFrame()
+    val sourceCOffset =
+      assertNotNull(state.lazyListState.layoutInfo.visibleItemsInfo.firstOrNull { it.key == "c" })
+        .offset
+    val expectedProjectedCOffset = sourceCOffset - 80
+    val redRowsBeforeRelease = onNodeWithTag("projected-anchor-list").capturedColorRows(Color.Red)
+
+    runOnUiThread { state.release() }
+    assertEquals(-10f, assertNotNull(state.settlingOffsetY(draggedKey)), 1f)
+    mainClock.advanceTimeByFrame()
+    val redRowsAfterFirstReleaseFrame =
+      onNodeWithTag("projected-anchor-list").capturedColorRows(Color.Red)
+    val committedCOffset =
+      assertNotNull(state.lazyListState.layoutInfo.visibleItemsInfo.firstOrNull { it.key == "c" })
+        .offset
+    val committedDraggedOffsets =
+      state.lazyListState.layoutInfo.visibleItemsInfo
+        .filter { it.key == draggedKey }
+        .map { it.offset }
+
+    assertEquals(expectedProjectedCOffset, committedCOffset)
+    assertEquals(listOf(80), committedDraggedOffsets)
+    repeat(90) { mainClock.advanceTimeByFrame() }
+    val redRowsAfterSettling = onNodeWithTag("projected-anchor-list").capturedColorRows(Color.Red)
+    val expectedFirstRowRange =
+      minOf(redRowsBeforeRelease.first(), redRowsAfterSettling.first()) - 1..maxOf(
+          redRowsBeforeRelease.first(),
+          redRowsAfterSettling.first(),
+        ) + 1
+    assertTrue(
+      redRowsAfterFirstReleaseFrame.firstOrNull()?.let { it in expectedFirstRowRange } == true,
+      "Dragged pixels moved away from the slot: before=$redRowsBeforeRelease, first=$redRowsAfterFirstReleaseFrame, settled=$redRowsAfterSettling",
+    )
+    mainClock.autoAdvance = true
+  }
+
+  @Test
+  fun upwardReorderTargetsAnOverlappedItemInsideTheEdgeInset() = runComposeUiTest {
+    lateinit var state: ReorderableLazyColumnState<String>
+    val itemBounds = mutableMapOf<String, Rect>()
+    val keys = (0 until 10).map(Int::toString)
+    val draggedKey = "6"
+
+    setContent {
+      val lazyListState = rememberLazyListState(initialFirstVisibleItemIndex = 5)
+      state = rememberReorderableLazyColumnState(keys = keys, lazyListState = lazyListState)
+
+      ReorderableLazyColumn(
+        state = state,
+        modifier =
+          Modifier.size(width = 100.dp, height = 240.dp)
+            .reorderableViewport(state = state, viewportTopInset = 40.dp),
+      ) {
+        items(state.layoutKeys, key = { it }) { itemKey ->
+          Box(
+            reorderableAnimatedItem(
+                state = state,
+                key = itemKey,
+                modifier =
+                  Modifier.fillMaxWidth().height(if (itemKey == draggedKey) 120.dp else 40.dp),
               )
               .reorderableItem(state = state, key = itemKey)
               .onGloballyPositioned { coordinates ->
@@ -434,26 +802,107 @@ class ReorderableLazyColumnDesktopTest {
     }
     waitForIdle()
 
-    val draggedBounds = assertNotNull(itemBounds["e"])
-    val pointer = draggedBounds.center
+    val draggedBounds = assertNotNull(itemBounds[draggedKey])
+    val viewport = assertNotNull(state.viewport)
+    val pointer = Offset(x = draggedBounds.center.x, y = draggedBounds.top + 60f)
+    val edgePointer = Offset(x = pointer.x, y = viewport.top + 69f)
+
     runOnUiThread {
       assertTrue(
         state.beginDrag(
-          key = "e",
+          key = draggedKey,
           pointer = pointer,
           onTargetChanged = {},
           onTargetHaptic = {},
           onDragStopped = {},
         )
       )
-      state.updatePointer(pointer + Offset(x = 0f, y = -90f))
-      assertEquals(listOf("a", "b", "e", "c", "d", "f"), state.keys)
+      state.updatePointer(edgePointer)
+      assertEquals(listOf("0", "1", "2", "3", "4", "6", "5", "7", "8", "9"), state.keys)
+      state.cancel()
+    }
+  }
+
+  @Test
+  fun upwardEdgeReorderKeepsThePhysicalOrderStable() = runComposeUiTest {
+    lateinit var state: ReorderableLazyColumnState<String>
+    val itemBounds = mutableMapOf<String, Rect>()
+    val keys = (0 until 10).map(Int::toString)
+
+    setContent {
+      val lazyListState =
+        rememberLazyListState(
+          initialFirstVisibleItemIndex = 4,
+          initialFirstVisibleItemScrollOffset = 10,
+        )
+      state = rememberReorderableLazyColumnState(keys = keys, lazyListState = lazyListState)
+
+      ReorderableLazyColumn(
+        state = state,
+        modifier = Modifier.size(width = 100.dp, height = 160.dp).reorderableViewport(state = state),
+      ) {
+        items(state.layoutKeys, key = { it }) { itemKey ->
+          val itemHeight =
+            when (itemKey) {
+              "5" -> 80.dp
+              "6" -> 60.dp
+              else -> 40.dp
+            }
+          Box(
+            reorderableAnimatedItem(
+                state = state,
+                key = itemKey,
+                modifier = Modifier.fillMaxWidth().height(itemHeight),
+              )
+              .reorderableItem(state = state, key = itemKey)
+              .onGloballyPositioned { coordinates ->
+                val origin = coordinates.positionInWindow()
+                itemBounds[itemKey] =
+                  Rect(
+                    left = origin.x,
+                    top = origin.y,
+                    right = origin.x + coordinates.size.width,
+                    bottom = origin.y + coordinates.size.height,
+                  )
+              }
+          )
+        }
+      }
     }
     waitForIdle()
 
-    assertEquals(2, state.lazyListState.firstVisibleItemIndex)
-    assertEquals(10, state.lazyListState.firstVisibleItemScrollOffset)
-    assertEquals("e", state.lazyListState.layoutInfo.visibleItemsInfo.first().key)
+    assertEquals("4", state.lazyListState.layoutInfo.visibleItemsInfo.first().key)
+    val draggedBounds = assertNotNull(itemBounds["6"])
+    val viewport = assertNotNull(state.viewport)
+    val pointer = Offset(x = draggedBounds.center.x, y = draggedBounds.top + 10f)
+    val edgePointer = Offset(x = pointer.x, y = viewport.top + 15f)
+    mainClock.autoAdvance = false
+
+    runOnUiThread {
+      assertTrue(
+        state.beginDrag(
+          key = "6",
+          pointer = pointer,
+          onTargetChanged = {},
+          onTargetHaptic = {},
+          onDragStopped = {},
+        )
+      )
+      state.updatePointer(edgePointer)
+      assertEquals(listOf("0", "1", "2", "3", "6", "4", "5", "7", "8", "9"), state.keys)
+    }
+    mainClock.advanceTimeByFrame()
+
+    assertEquals("4", state.lazyListState.layoutInfo.visibleItemsInfo.first().key)
+    assertEquals(keys, state.layoutKeys)
     runOnUiThread { state.cancel() }
+    mainClock.advanceTimeByFrame()
+    mainClock.autoAdvance = true
   }
+}
+
+private fun SemanticsNodeInteraction.capturedColorRows(color: Color): List<Int> {
+  val pixels = captureToImage().toPixelMap()
+  val x = pixels.width / 2
+  return (0 until pixels.height).filter { y -> pixels[x, y] == color }
 }


### PR DESCRIPTION
## 문제

- 위쪽 edge autoscroll 중 높이가 다른 노트와 swap하면 주변 항목이 일관된 방향으로 움직이지 않고 목록 전체가 흔들리는 문제가 있었습니다.
- 천천히 위쪽으로 reorder할 때 주변 항목이 잠시 반대 방향으로 움직이거나 스크롤 속도가 갑자기 빨라 보이는 현상이 있었습니다.
- 관련 노트 subpane의 edge autoscroll 영역이 실제 상단·하단 가림 영역을 반영하지 않아 사용 가능한 영역이 짧았습니다.

## 변경

- drag 중에는 LazyColumn의 물리 순서를 고정하고, 논리적인 reorder 결과를 별도로 관리하도록 변경했습니다.
- 주변 항목은 물리적인 item 재배치 대신 projected slot을 향해 애니메이션하도록 변경했습니다.
- 대상 slot이 뷰포트를 벗어나도 이전 slot 위치에 실제 스크롤 변화만 반영해 계속 추적하도록 했습니다.
- dragged item의 실제 높이와 item 간격을 기준으로 slot과 주변 항목의 이동량을 계산하도록 했습니다.
- release 시 최종 순서를 한 번만 물리 목록에 반영하고 projected viewport 위치를 유지하도록 했습니다.
- 공용 reorder 목록을 동일한 물리 순서 유지 방식으로 전환했습니다.
- 관련 노트 subpane의 실제 상단·하단 가림 영역을 edge autoscroll 계산에 반영했습니다.

## 해결

- 위쪽 edge autoscroll 중 주변 항목이 위아래로 왕복하거나 목록 전체가 흔들리는 현상을 방지했습니다.
- 높이가 다른 노트와 swap할 때 스크롤이 갑자기 빨라 보이는 현상을 방지했습니다.
- 메인 노트 화면과 관련 노트 subpane에서 동일한 reorder 동작을 사용하도록 했습니다.
- subpane의 edge autoscroll 영역이 실제 사용 가능한 뷰포트와 일치하도록 했습니다.