### PR TITLE
luminance-adaptive top bar

### DIFF
--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/navigation/NavigationStatusBarAppearance.android.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/navigation/NavigationStatusBarAppearance.android.kt
@@ -1,0 +1,25 @@
+package co.typie.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
+import co.typie.platform.activityContext
+
+@Composable
+internal actual fun ApplyPlatformNavigationStatusBarAppearance(
+  useLightForeground: Boolean,
+  defaultUseLightForeground: Boolean,
+) {
+  val activity = activityContext()
+  val view = LocalView.current
+  val insetsController =
+    remember(activity, view) { WindowCompat.getInsetsController(activity.window, view) }
+
+  SideEffect { insetsController.isAppearanceLightStatusBars = !useLightForeground }
+  DisposableEffect(insetsController, defaultUseLightForeground) {
+    onDispose { insetsController.isAppearanceLightStatusBars = !defaultUseLightForeground }
+  }
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationScaffold.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationScaffold.kt
@@ -5,11 +5,32 @@ import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import co.typie.ui.component.bottombar.BottomBar
 import co.typie.ui.component.bottombar.BottomBarState
 import co.typie.ui.component.topbar.TopBar
 import co.typie.ui.component.topbar.TopBarState
+import co.typie.ui.theme.AppTheme
+
+private const val STATUS_BAR_PRESENTED_ENTER_ALPHA = 0.65f
+private const val STATUS_BAR_PRESENTED_EXIT_ALPHA = 0.35f
+
+internal fun resolveAdaptiveStatusBarPresented(
+  previous: Boolean,
+  enabled: Boolean,
+  alpha: Float,
+): Boolean =
+  when {
+    !enabled -> false
+    alpha >= STATUS_BAR_PRESENTED_ENTER_ALPHA -> true
+    alpha <= STATUS_BAR_PRESENTED_EXIT_ALPHA -> false
+    else -> previous
+  }
 
 @Composable
 fun NavigationScaffold(
@@ -20,6 +41,24 @@ fun NavigationScaffold(
   overlay: @Composable BoxScope.() -> Unit = {},
   content: @Composable () -> Unit,
 ) {
+  val defaultForegroundStyle =
+    defaultNavigationTopBarLuminanceStyle(AppTheme.themeMode).foregroundStyle
+  var previousAdaptiveStatusBarPresented by remember { mutableStateOf(false) }
+  val adaptiveStatusBarPresented =
+    resolveAdaptiveStatusBarPresented(
+      previous = previousAdaptiveStatusBarPresented,
+      enabled = topBarState.enabled,
+      alpha = topBarState.animatedAlpha,
+    )
+  SideEffect { previousAdaptiveStatusBarPresented = adaptiveStatusBarPresented }
+  val statusBarForegroundStyle =
+    if (adaptiveStatusBarPresented) {
+      topBarState.adaptiveForegroundStyle ?: defaultForegroundStyle
+    } else {
+      defaultForegroundStyle
+    }
+  PublishNavigationStatusBarAppearance(statusBarForegroundStyle)
+
   Box(modifier.fillMaxSize()) {
     Box(Modifier.fillMaxSize()) { content() }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationStack.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationStack.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.ProvidedValue
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.movableContentOf
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -206,6 +207,7 @@ fun NavigationStack(
   foregroundInteractive: Boolean = true,
   content: @Composable (Route) -> Unit,
 ) {
+  val themeMode = AppTheme.themeMode
   val exitTopBarState = remember { TopBarState() }
   val exitBottomBarState = remember { bottomBarState?.let { BottomBarState() } }
 
@@ -280,6 +282,9 @@ fun NavigationStack(
 
   val progress = remember { Animatable(0f) }
   val topBarBackdropHazeState = remember { HazeState() }
+  val topBarSampleRequests = remember { NavigationTopBarSampleRequests() }
+  val topBarLuminanceCache =
+    remember(themeMode) { mutableStateMapOf<Route, NavigationTopBarContentLuminance>() }
 
   val popNestedScroll = remember { NavigationPopNestedScroll() }
   val navigationPopActivationDistance =
@@ -304,6 +309,7 @@ fun NavigationStack(
       exitTopBarState.clearRoute(removedRoute)
       bottomBarState?.clearRoute(removedRoute)
       exitBottomBarState?.clearRoute(removedRoute)
+      topBarLuminanceCache.remove(removedRoute)
     }
   }
 
@@ -647,6 +653,52 @@ fun NavigationStack(
     }
   }
 
+  val transitionCommitted =
+    when (animState) {
+      AnimState.Push,
+      AnimState.Pop,
+      AnimState.PopGestureCommitted -> true
+      AnimState.Dragging -> navigator.popRequested
+      AnimState.Idle -> false
+    }
+  val destinationRoute =
+    when (animState) {
+      AnimState.Push -> navigator.current
+      AnimState.Pop,
+      AnimState.PopGestureCommitted -> behindRoute ?: navigator.current
+      AnimState.Dragging -> behindRoute.takeIf { transitionCommitted }
+      AnimState.Idle -> null
+    }
+  val sourceContentLuminance =
+    topBarLuminanceCache[visibleRoute] ?: defaultNavigationTopBarContentLuminance(themeMode)
+  val topBarTransitionAppearance =
+    if (animState == AnimState.Idle) {
+      NavigationTopBarTransitionAppearance(
+        blurEnabled = topBarState.backdropBlurEnabled,
+        contentLuminance = sourceContentLuminance,
+      )
+    } else {
+      resolveNavigationTopBarTransitionAppearance(
+        themeMode = themeMode,
+        committed = transitionCommitted,
+        sourceBlurEnabled =
+          if (transitionCommitted) {
+            exitTopBarState.backdropBlurEnabled
+          } else {
+            topBarState.backdropBlurEnabled
+          },
+        sourceContentLuminance = sourceContentLuminance,
+        destinationBlurEnabled = topBarState.backdropBlurEnabled,
+        destinationContentLuminance = destinationRoute?.let { topBarLuminanceCache[it] },
+      )
+    }
+  val topBarLuminanceStyle =
+    navigationTopBarLuminanceStyle(
+      themeMode = themeMode,
+      contentLuminance = topBarTransitionAppearance.contentLuminance,
+    )
+  topBarState.adaptiveForegroundStyle = topBarLuminanceStyle.foregroundStyle
+
   val animationProviders =
     buildList<ProvidedValue<*>> {
       add(Nav provides navigator)
@@ -655,6 +707,7 @@ fun NavigationStack(
       )
       add(LocalNavigationForegroundInteractive provides foregroundInteractive)
       add(LocalTopBarAnimationSource provides topBarState)
+      add(LocalNavigationTopBarSampleRequester provides topBarSampleRequests)
       bottomBarState?.let { add(LocalBottomBarAnimationSource provides it) }
     }
   CompositionLocalProvider(*animationProviders.toTypedArray()) {
@@ -985,6 +1038,25 @@ fun NavigationStack(
         if (behindBackdropPresence > 0f || mainBackdropPresence > 0f) {
           NavigationTopBarBackdrop(
             hazeState = topBarBackdropHazeState,
+            blurEnabled = topBarTransitionAppearance.blurEnabled,
+            sampleRequests = topBarSampleRequests.flow,
+            luminanceMode =
+              if (presentationAnimState == AnimState.Idle && foregroundInteractive) {
+                NavigationTopBarLuminanceMode.Live(mainRoute)
+              } else {
+                NavigationTopBarLuminanceMode.Frozen(topBarTransitionAppearance.contentLuminance)
+              },
+            onMeasuredContentLuminance = { measurement ->
+              if (
+                presentationAnimState == AnimState.Idle &&
+                  foregroundInteractive &&
+                  measurement.token.owner == mainRoute &&
+                  measurement.token.themeMode == themeMode
+              ) {
+                topBarLuminanceCache[mainRoute] = measurement.contentLuminance
+              }
+            },
+            themeMode = themeMode,
             style = {
               val p = progress.value
               val mainWeight =

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationStatusBarAppearanceState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationStatusBarAppearanceState.kt
@@ -1,0 +1,76 @@
+package co.typie.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.staticCompositionLocalOf
+import co.typie.ui.component.topbar.TopBarForegroundStyle
+import co.typie.ui.theme.ResolvedThemeMode
+
+@Stable
+internal class NavigationStatusBarAppearanceState {
+  private val appearances = mutableStateMapOf<Any, TopBarForegroundStyle>()
+
+  operator fun get(owner: Any): TopBarForegroundStyle? = appearances[owner]
+
+  fun publish(owner: Any, style: TopBarForegroundStyle) {
+    appearances[owner] = style
+  }
+
+  fun remove(owner: Any) {
+    appearances.remove(owner)
+  }
+}
+
+@Composable
+internal fun ProvideNavigationStatusBarAppearanceOwner(
+  owner: Any,
+  state: NavigationStatusBarAppearanceState,
+  content: @Composable () -> Unit,
+) {
+  val publisher =
+    remember(owner, state) {
+      NavigationStatusBarAppearancePublisher { style -> state.publish(owner, style) }
+    }
+  DisposableEffect(owner, state) { onDispose { state.remove(owner) } }
+  CompositionLocalProvider(LocalNavigationStatusBarAppearancePublisher provides publisher) {
+    content()
+  }
+}
+
+@Composable
+internal fun PublishNavigationStatusBarAppearance(style: TopBarForegroundStyle) {
+  val publisher = LocalNavigationStatusBarAppearancePublisher.current ?: return
+  SideEffect { publisher.publish(style) }
+}
+
+@Composable
+internal fun ApplyActiveNavigationStatusBarAppearance(
+  activeOwner: Any,
+  state: NavigationStatusBarAppearanceState,
+  themeMode: ResolvedThemeMode,
+) {
+  val defaultStyle = defaultNavigationTopBarLuminanceStyle(themeMode).foregroundStyle
+  val style = state[activeOwner] ?: defaultStyle
+  ApplyPlatformNavigationStatusBarAppearance(
+    useLightForeground = style == TopBarForegroundStyle.Light,
+    defaultUseLightForeground = defaultStyle == TopBarForegroundStyle.Light,
+  )
+}
+
+private fun interface NavigationStatusBarAppearancePublisher {
+  fun publish(style: TopBarForegroundStyle)
+}
+
+private val LocalNavigationStatusBarAppearancePublisher =
+  staticCompositionLocalOf<NavigationStatusBarAppearancePublisher?> { null }
+
+@Composable
+internal expect fun ApplyPlatformNavigationStatusBarAppearance(
+  useLightForeground: Boolean,
+  defaultUseLightForeground: Boolean,
+)

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationTopBarBackdrop.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationTopBarBackdrop.kt
@@ -1,13 +1,20 @@
 package co.typie.navigation
 
+import androidx.compose.animation.core.EaseOutQuint
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Brush
@@ -18,16 +25,61 @@ import androidx.compose.ui.platform.testTag
 import co.typie.ui.component.TypieProgressiveBlurEffect
 import co.typie.ui.component.topbar.LocalTopBarAnimationSource
 import co.typie.ui.component.topbar.TopBarDefaults
+import co.typie.ui.theme.ResolvedThemeMode
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.hazeEffect
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
 
 internal const val NavigationTopBarBackdropTestTag = "navigation-top-bar-backdrop"
 internal const val NavigationSceneSurfaceCompositeTestTag = "navigation-scene-surface-composite"
 
-private const val NavigationTopBarFadeSamples = 48
+private const val NAVIGATION_TOP_BAR_FADE_SAMPLES = 48
+private const val NAVIGATION_TOP_BAR_LUMINANCE_ANIMATION_DURATION_MILLIS = 900
+private const val NAVIGATION_TOP_BAR_LUMINANCE_SAMPLE_DELAY_MILLIS = 100L
+private const val NAVIGATION_TOP_BAR_BLUR_ANIMATION_DURATION_MILLIS = 250
 
 internal data class NavigationTopBarBackdropStyle(val background: Color, val presence: Float)
+
+internal sealed interface NavigationTopBarLuminanceMode {
+  data class Live(val key: Any) : NavigationTopBarLuminanceMode
+
+  data class Frozen(val contentLuminance: NavigationTopBarContentLuminance) :
+    NavigationTopBarLuminanceMode
+}
+
+internal data class NavigationTopBarMeasuredContentLuminance(
+  val token: NavigationTopBarSampleToken,
+  val contentLuminance: NavigationTopBarContentLuminance,
+)
+
+internal data class NavigationTopBarTransitionAppearance(
+  val blurEnabled: Boolean,
+  val contentLuminance: NavigationTopBarContentLuminance,
+)
+
+internal fun resolveNavigationTopBarTransitionAppearance(
+  themeMode: ResolvedThemeMode,
+  committed: Boolean,
+  sourceBlurEnabled: Boolean,
+  sourceContentLuminance: NavigationTopBarContentLuminance,
+  destinationBlurEnabled: Boolean,
+  destinationContentLuminance: NavigationTopBarContentLuminance?,
+): NavigationTopBarTransitionAppearance =
+  if (committed) {
+    NavigationTopBarTransitionAppearance(
+      blurEnabled = destinationBlurEnabled,
+      contentLuminance =
+        destinationContentLuminance ?: defaultNavigationTopBarContentLuminance(themeMode),
+    )
+  } else {
+    NavigationTopBarTransitionAppearance(
+      blurEnabled = sourceBlurEnabled,
+      contentLuminance = sourceContentLuminance,
+    )
+  }
 
 internal fun resolveNavigationTopBarBackdropStyle(
   behindBackground: Color?,
@@ -55,7 +107,12 @@ internal fun resolveNavigationTopBarBackdropStyle(
 internal fun NavigationTopBarBackdrop(
   hazeState: HazeState,
   style: () -> NavigationTopBarBackdropStyle,
+  luminanceMode: NavigationTopBarLuminanceMode,
+  themeMode: ResolvedThemeMode,
   modifier: Modifier = Modifier,
+  blurEnabled: Boolean = true,
+  sampleRequests: Flow<Unit> = emptyFlow(),
+  onMeasuredContentLuminance: (NavigationTopBarMeasuredContentLuminance) -> Unit = {},
 ) {
   val animationSource = LocalTopBarAnimationSource.current
   val animatedAlpha = animationSource?.animatedAlpha ?: 0f
@@ -63,6 +120,98 @@ internal fun NavigationTopBarBackdrop(
   val styleState = rememberUpdatedState(style)
 
   val topPadding = TopBarDefaults.topPadding()
+  val activeSampleToken =
+    remember(themeMode, luminanceMode) {
+      (luminanceMode as? NavigationTopBarLuminanceMode.Live)?.let {
+        NavigationTopBarSampleToken(it.key, themeMode)
+      }
+    }
+  val activeSampleTokenState = rememberUpdatedState(activeSampleToken)
+  var resolvedContentLuminance by
+    remember(themeMode) { mutableStateOf(defaultNavigationTopBarContentLuminance(themeMode)) }
+  var pendingMeasurement by
+    remember(themeMode) { mutableStateOf<NavigationTopBarMeasuredContentLuminance?>(null) }
+  val onMeasuredContentLuminanceState = rememberUpdatedState(onMeasuredContentLuminance)
+  LaunchedEffect(themeMode, luminanceMode) {
+    val frozenMode = luminanceMode as? NavigationTopBarLuminanceMode.Frozen ?: return@LaunchedEffect
+    pendingMeasurement = null
+    resolvedContentLuminance = frozenMode.contentLuminance
+  }
+  LaunchedEffect(pendingMeasurement, activeSampleToken) {
+    val measurement = pendingMeasurement ?: return@LaunchedEffect
+    if (measurement.token != activeSampleToken) return@LaunchedEffect
+    val delayMillis =
+      navigationTopBarLuminanceTransitionDelayMillis(
+        from = resolvedContentLuminance,
+        to = measurement.contentLuminance,
+      )
+    if (delayMillis > 0L) delay(delayMillis)
+    if (pendingMeasurement != measurement || measurement.token != activeSampleToken) {
+      return@LaunchedEffect
+    }
+    resolvedContentLuminance = measurement.contentLuminance
+    onMeasuredContentLuminanceState.value(measurement)
+  }
+
+  val resolvedLuminanceStyle =
+    navigationTopBarLuminanceStyle(
+      themeMode = themeMode,
+      contentLuminance = resolvedContentLuminance,
+    )
+
+  val backdropOpacity by
+    animateFloatAsState(
+      targetValue = resolvedLuminanceStyle.backdropOpacity,
+      animationSpec =
+        tween(
+          durationMillis = NAVIGATION_TOP_BAR_LUMINANCE_ANIMATION_DURATION_MILLIS,
+          easing = EaseOutQuint,
+        ),
+      label = "navigation-top-bar-backdrop-opacity",
+    )
+  val darkTintOpacity by
+    animateFloatAsState(
+      targetValue = resolvedLuminanceStyle.darkTintOpacity,
+      animationSpec =
+        tween(
+          durationMillis = NAVIGATION_TOP_BAR_LUMINANCE_ANIMATION_DURATION_MILLIS,
+          easing = EaseOutQuint,
+        ),
+      label = "navigation-top-bar-dark-tint-opacity",
+    )
+
+  val onLuminancePixels =
+    rememberUpdatedState<(NavigationTopBarSampleToken, IntArray, Int) -> Unit> {
+      token,
+      pixels,
+      width ->
+      if (token != activeSampleTokenState.value) {
+        return@rememberUpdatedState
+      }
+      val contentLuminance =
+        classifyNavigationTopBarContentLuminance(
+          themeMode = token.themeMode,
+          sample = analyzeNavigationTopBarPixels(pixels = pixels, width = width),
+          current = resolvedContentLuminance,
+        )
+      pendingMeasurement = NavigationTopBarMeasuredContentLuminance(token, contentLuminance)
+    }
+  val samplingEffect =
+    remember(topPadding) {
+      NavigationTopBarSamplingEffect(
+        sampleTopInset = topPadding,
+        sampleHeight = TopBarDefaults.Height,
+        backgroundColor = { styleState.value().background },
+        samplingEnabled = { activeSampleTokenState.value != null },
+        sampleToken = { activeSampleTokenState.value },
+        onPixels = { token, pixels, width -> onLuminancePixels.value(token, pixels, width) },
+      )
+    }
+  LaunchedEffect(themeMode, samplingEffect, luminanceMode) {
+    if (luminanceMode is NavigationTopBarLuminanceMode.Live) {
+      samplingEffect.requestSample()
+    }
+  }
   val blurEffect = remember {
     TypieProgressiveBlurEffect(
       blurRadius = TopBarDefaults.BlurRadius,
@@ -71,10 +220,27 @@ internal fun NavigationTopBarBackdrop(
       backgroundColor = { styleState.value().background },
     )
   }
+  LaunchedEffect(samplingEffect, sampleRequests, luminanceMode) {
+    if (luminanceMode !is NavigationTopBarLuminanceMode.Live) return@LaunchedEffect
+    sampleRequests.collect {
+      delay(NAVIGATION_TOP_BAR_LUMINANCE_SAMPLE_DELAY_MILLIS)
+      samplingEffect.requestSample()
+    }
+  }
+  val blurAlpha by
+    animateFloatAsState(
+      targetValue = if (blurEnabled) 1f else 0f,
+      animationSpec =
+        tween(
+          durationMillis = NAVIGATION_TOP_BAR_BLUR_ANIMATION_DURATION_MILLIS,
+          easing = EaseOutQuint,
+        ),
+      label = "navigation-top-bar-blur-alpha",
+    )
   val backdropModifier =
     modifier
       .fillMaxWidth()
-      .height(topPadding + TopBarDefaults.Height + TopBarDefaults.BlurFadeHeight)
+      .height(topPadding + TopBarDefaults.Height + TopBarDefaults.BackdropFadeHeight)
       .testTag(NavigationTopBarBackdropTestTag)
       .graphicsLayer {
         val resolvedStyle = styleState.value()
@@ -83,22 +249,44 @@ internal fun NavigationTopBarBackdrop(
       }
 
   Box(modifier = backdropModifier) {
-    Column(modifier = Modifier.fillMaxWidth().hazeEffect(hazeState) { visualEffect = blurEffect }) {
+    Column(
+      modifier =
+        Modifier.fillMaxWidth().hazeEffect(hazeState) {
+          visualEffect = samplingEffect
+          forceInvalidateOnPreDraw = true
+        }
+    ) {
       Spacer(Modifier.fillMaxWidth().height(topPadding + TopBarDefaults.Height))
-      Spacer(Modifier.height(TopBarDefaults.BlurFadeHeight))
+      Spacer(Modifier.height(TopBarDefaults.BackdropFadeHeight))
+    }
+    if (blurAlpha > 0f) {
+      Column(
+        modifier =
+          Modifier.fillMaxWidth()
+            .graphicsLayer { alpha = blurAlpha }
+            .hazeEffect(hazeState) { visualEffect = blurEffect }
+      ) {
+        Spacer(Modifier.fillMaxWidth().height(topPadding + TopBarDefaults.Height))
+        Spacer(Modifier.height(TopBarDefaults.BackdropFadeHeight))
+      }
     }
     Column(modifier = Modifier.fillMaxWidth()) {
       Spacer(
         Modifier.fillMaxWidth().height(topPadding).drawBehind {
-          drawRect(styleState.value().background.copy(alpha = TopBarDefaults.FadeOpacity))
+          drawRect(styleState.value().background.copy(alpha = backdropOpacity))
+          drawRect(Color.Black.copy(alpha = darkTintOpacity))
         }
       )
       Spacer(
         Modifier.fillMaxWidth()
-          .height(TopBarDefaults.Height + TopBarDefaults.BlurFadeHeight)
+          .height(TopBarDefaults.Height + TopBarDefaults.BackdropFadeHeight)
           .drawBehind {
-            val fadeColor = styleState.value().background.copy(alpha = TopBarDefaults.FadeOpacity)
-            drawRect(navigationTopBarProgressiveBrush(fadeColor))
+            drawRect(
+              navigationTopBarProgressiveBrush(
+                styleState.value().background.copy(alpha = backdropOpacity)
+              )
+            )
+            drawRect(navigationTopBarProgressiveBrush(Color.Black.copy(alpha = darkTintOpacity)))
           }
       )
     }
@@ -107,9 +295,9 @@ internal fun NavigationTopBarBackdrop(
 
 private fun navigationTopBarProgressiveBrush(color: Color): Brush {
   val stops =
-    Array(NavigationTopBarFadeSamples + 1) { index ->
-      val t = index / NavigationTopBarFadeSamples.toFloat()
-      val alpha = color.alpha * (1f - TopBarDefaults.BlurFadeEasing.transform(t))
+    Array(NAVIGATION_TOP_BAR_FADE_SAMPLES + 1) { index ->
+      val t = index / NAVIGATION_TOP_BAR_FADE_SAMPLES.toFloat()
+      val alpha = color.alpha * (1f - TopBarDefaults.BackdropFadeEasing.transform(t))
       t to color.copy(alpha = alpha)
     }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationTopBarLuminance.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationTopBarLuminance.kt
@@ -1,0 +1,211 @@
+package co.typie.navigation
+
+import co.typie.ui.component.topbar.TopBarForegroundStyle
+import co.typie.ui.theme.ResolvedThemeMode
+import kotlin.math.abs
+import kotlin.math.pow
+
+private const val LIGHT_PIXEL_LUMINANCE_THRESHOLD = 0.421f
+private const val LIGHT_BRIGHT_COVERAGE_THRESHOLD = 0.703f
+private const val LIGHT_BRIGHT_COVERAGE_HYSTERESIS = 0.04f
+private const val HORIZONTAL_CENTER_WEIGHT_BOOST = 0.85f
+private const val SPATIAL_LUMINANCE_BLOCK_WIDTH = 4
+private const val SPATIAL_LUMINANCE_BLOCK_HEIGHT = 16
+
+private const val LIGHT_BACKDROP_OPACITY = 0.85f
+private const val LIGHT_DARK_TINT_OPACITY = 0.25f
+
+private const val DARK_LOW_BACKDROP_OPACITY = 0.85f
+private const val DARK_MIDDLE_BACKDROP_OPACITY = 0.60f
+private const val STYLE_STABILITY_MILLIS = 180L
+
+private val DARK_LOW_LUMINANCE_THRESHOLD = encodedGrayRelativeLuminance(77)
+private val DARK_LOW_LUMINANCE_ENTER_THRESHOLD = encodedGrayRelativeLuminance(85)
+private val DARK_LOW_LUMINANCE_EXIT_THRESHOLD = encodedGrayRelativeLuminance(69)
+
+internal data class NavigationTopBarLuminanceSample(
+  val weightedMeanRelativeLuminance: Float,
+  val weightedBrightCoverage: Float,
+)
+
+internal enum class NavigationTopBarContentLuminance {
+  Dark,
+  Bright,
+}
+
+internal data class NavigationTopBarLuminanceStyle(
+  val backdropOpacity: Float,
+  val darkTintOpacity: Float,
+  val foregroundStyle: TopBarForegroundStyle,
+)
+
+internal fun analyzeNavigationTopBarPixels(
+  pixels: IntArray,
+  width: Int,
+): NavigationTopBarLuminanceSample {
+  require(width > 0) { "width must be positive" }
+  require(pixels.isNotEmpty() && pixels.size % width == 0) {
+    "pixels must contain complete non-empty rows"
+  }
+
+  val height = pixels.size / width
+  val useSpatialBlocks =
+    width >= SPATIAL_LUMINANCE_BLOCK_WIDTH && height >= SPATIAL_LUMINANCE_BLOCK_HEIGHT
+  val blockWidth =
+    if (useSpatialBlocks) {
+      SPATIAL_LUMINANCE_BLOCK_WIDTH
+    } else {
+      1
+    }
+  val blockHeight =
+    if (useSpatialBlocks) {
+      SPATIAL_LUMINANCE_BLOCK_HEIGHT
+    } else {
+      1
+    }
+  val blockLuminances = FloatArray(blockWidth * blockHeight)
+  var weightedLuminance = 0f
+  var weightedBrightPixels = 0f
+  var totalWeight = 0f
+
+  for (blockTop in 0 until height step blockHeight) {
+    for (blockLeft in 0 until width step blockWidth) {
+      val blockRight = (blockLeft + blockWidth).coerceAtMost(width)
+      val blockBottom = (blockTop + blockHeight).coerceAtMost(height)
+      var count = 0
+      for (y in blockTop until blockBottom) {
+        for (x in blockLeft until blockRight) {
+          blockLuminances[count++] = relativeLuminance(pixels[y * width + x])
+        }
+      }
+      blockLuminances.sort(fromIndex = 0, toIndex = count)
+      val luminance =
+        if (count % 2 == 0) {
+          (blockLuminances[count / 2 - 1] + blockLuminances[count / 2]) / 2f
+        } else {
+          blockLuminances[count / 2]
+        }
+      val weight =
+        horizontalSampleWeight(normalizedX = (blockLeft + (blockRight - blockLeft) / 2f) / width)
+      weightedLuminance += luminance * weight
+      if (luminance >= LIGHT_PIXEL_LUMINANCE_THRESHOLD) {
+        weightedBrightPixels += weight
+      }
+      totalWeight += weight
+    }
+  }
+
+  return NavigationTopBarLuminanceSample(
+    weightedMeanRelativeLuminance = weightedLuminance / totalWeight,
+    weightedBrightCoverage = weightedBrightPixels / totalWeight,
+  )
+}
+
+internal fun classifyNavigationTopBarContentLuminance(
+  themeMode: ResolvedThemeMode,
+  sample: NavigationTopBarLuminanceSample,
+  current: NavigationTopBarContentLuminance? = null,
+): NavigationTopBarContentLuminance =
+  when (themeMode) {
+    ResolvedThemeMode.Light -> {
+      val brightCoverageThreshold =
+        when {
+          current == null -> LIGHT_BRIGHT_COVERAGE_THRESHOLD
+          current == NavigationTopBarContentLuminance.Dark ->
+            LIGHT_BRIGHT_COVERAGE_THRESHOLD + LIGHT_BRIGHT_COVERAGE_HYSTERESIS
+          else -> LIGHT_BRIGHT_COVERAGE_THRESHOLD - LIGHT_BRIGHT_COVERAGE_HYSTERESIS
+        }
+      if (sample.weightedBrightCoverage >= brightCoverageThreshold) {
+        NavigationTopBarContentLuminance.Bright
+      } else {
+        NavigationTopBarContentLuminance.Dark
+      }
+    }
+    ResolvedThemeMode.Dark -> {
+      val lowLuminanceThreshold =
+        when {
+          current == null -> DARK_LOW_LUMINANCE_THRESHOLD
+          current == NavigationTopBarContentLuminance.Dark -> DARK_LOW_LUMINANCE_ENTER_THRESHOLD
+          else -> DARK_LOW_LUMINANCE_EXIT_THRESHOLD
+        }
+      if (sample.weightedMeanRelativeLuminance <= lowLuminanceThreshold) {
+        NavigationTopBarContentLuminance.Dark
+      } else {
+        NavigationTopBarContentLuminance.Bright
+      }
+    }
+  }
+
+internal fun navigationTopBarLuminanceStyle(
+  themeMode: ResolvedThemeMode,
+  contentLuminance: NavigationTopBarContentLuminance,
+): NavigationTopBarLuminanceStyle =
+  when (themeMode) {
+    ResolvedThemeMode.Light ->
+      if (contentLuminance == NavigationTopBarContentLuminance.Bright) {
+        NavigationTopBarLuminanceStyle(
+          backdropOpacity = LIGHT_BACKDROP_OPACITY,
+          darkTintOpacity = 0f,
+          foregroundStyle = TopBarForegroundStyle.Dark,
+        )
+      } else {
+        NavigationTopBarLuminanceStyle(
+          backdropOpacity = 0f,
+          darkTintOpacity = LIGHT_DARK_TINT_OPACITY,
+          foregroundStyle = TopBarForegroundStyle.Light,
+        )
+      }
+    ResolvedThemeMode.Dark ->
+      NavigationTopBarLuminanceStyle(
+        backdropOpacity =
+          if (contentLuminance == NavigationTopBarContentLuminance.Dark) {
+            DARK_LOW_BACKDROP_OPACITY
+          } else {
+            DARK_MIDDLE_BACKDROP_OPACITY
+          },
+        darkTintOpacity = 0f,
+        foregroundStyle = TopBarForegroundStyle.Light,
+      )
+  }
+
+internal fun defaultNavigationTopBarContentLuminance(
+  themeMode: ResolvedThemeMode
+): NavigationTopBarContentLuminance =
+  when (themeMode) {
+    ResolvedThemeMode.Light -> NavigationTopBarContentLuminance.Bright
+    ResolvedThemeMode.Dark -> NavigationTopBarContentLuminance.Dark
+  }
+
+internal fun defaultNavigationTopBarLuminanceStyle(
+  themeMode: ResolvedThemeMode
+): NavigationTopBarLuminanceStyle =
+  navigationTopBarLuminanceStyle(
+    themeMode = themeMode,
+    contentLuminance = defaultNavigationTopBarContentLuminance(themeMode),
+  )
+
+internal fun navigationTopBarLuminanceTransitionDelayMillis(
+  from: NavigationTopBarContentLuminance,
+  to: NavigationTopBarContentLuminance,
+): Long = if (from == to) 0L else STYLE_STABILITY_MILLIS
+
+private fun horizontalSampleWeight(normalizedX: Float): Float {
+  val centerProximity = 1f - abs(2f * normalizedX - 1f)
+  return 1f + HORIZONTAL_CENTER_WEIGHT_BOOST * centerProximity
+}
+
+private fun relativeLuminance(argb: Int): Float {
+  val red = srgbToLinear((argb ushr 16 and 0xFF) / 255f)
+  val green = srgbToLinear((argb ushr 8 and 0xFF) / 255f)
+  val blue = srgbToLinear((argb and 0xFF) / 255f)
+  return 0.2126f * red + 0.7152f * green + 0.0722f * blue
+}
+
+private fun encodedGrayRelativeLuminance(gray: Int): Float = srgbToLinear(gray / 255f)
+
+private fun srgbToLinear(value: Float): Float =
+  if (value <= 0.04045f) {
+    value / 12.92f
+  } else {
+    ((value + 0.055f) / 1.055f).pow(2.4f)
+  }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationTopBarSampling.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationTopBarSampling.kt
@@ -1,0 +1,344 @@
+package co.typie.navigation
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.snapshots.Snapshot
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.isSpecified
+import androidx.compose.ui.geometry.takeOrElse
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.GraphicsContext
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.clipRect
+import androidx.compose.ui.graphics.drawscope.scale
+import androidx.compose.ui.graphics.drawscope.translate
+import androidx.compose.ui.graphics.isSpecified
+import androidx.compose.ui.graphics.layer.GraphicsLayer
+import androidx.compose.ui.graphics.layer.drawLayer
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.roundToIntSize
+import co.typie.ui.theme.ResolvedThemeMode
+import dev.chrisbanes.haze.ExperimentalHazeApi
+import dev.chrisbanes.haze.InternalHazeApi
+import dev.chrisbanes.haze.TrimMemoryLevel
+import dev.chrisbanes.haze.VisualEffect
+import dev.chrisbanes.haze.VisualEffectContext
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.TimeMark
+import kotlin.time.TimeSource
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.yield
+
+private const val LUMINANCE_ANALYSIS_WIDTH = 64
+private const val LUMINANCE_ANALYSIS_HEIGHT = 16
+private val MINIMUM_LUMINANCE_SAMPLE_INTERVAL = 100.milliseconds
+
+private data class LuminanceSampleRegion(val renderWidth: Float, val top: Float, val height: Float)
+
+internal class NavigationTopBarSampleToken(val owner: Any, val themeMode: ResolvedThemeMode)
+
+private val DefaultNavigationTopBarSampleToken =
+  NavigationTopBarSampleToken(Unit, ResolvedThemeMode.Light)
+
+internal data class NavigationTopBarPixelSample(val pixels: IntArray, val width: Int)
+
+@Stable
+internal class NavigationTopBarSampleRequests : NavigationTopBarSampleRequester {
+  private val mutableRequests =
+    MutableSharedFlow<Unit>(extraBufferCapacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+
+  val flow: Flow<Unit> = mutableRequests.asSharedFlow()
+
+  override fun requestSample() {
+    mutableRequests.tryEmit(Unit)
+  }
+}
+
+internal fun interface NavigationTopBarSampleRequester {
+  fun requestSample()
+}
+
+internal val LocalNavigationTopBarSampleRequester =
+  staticCompositionLocalOf<NavigationTopBarSampleRequester?> { null }
+
+/**
+ * Draws the Haze source unchanged and samples a tiny downscaled control-row image for luminance
+ * policy. Only the 64 x 16 analysis layer crosses back to the CPU; the full scene never does.
+ */
+@Stable
+@OptIn(ExperimentalHazeApi::class, InternalHazeApi::class)
+internal class NavigationTopBarSamplingEffect(
+  private val sampleTopInset: Dp,
+  private val sampleHeight: Dp,
+  private val backgroundColor: () -> Color,
+  private val samplingEnabled: () -> Boolean = { true },
+  private val sampleToken: () -> NavigationTopBarSampleToken? = {
+    DefaultNavigationTopBarSampleToken
+  },
+  private val readPixels: (suspend (GraphicsLayer) -> NavigationTopBarPixelSample?)? = null,
+  private val onPixels: (token: NavigationTopBarSampleToken, pixels: IntArray, width: Int) -> Unit,
+) : VisualEffect {
+  private var resolvedBackgroundColor = Color.Unspecified
+
+  private var graphicsContext: GraphicsContext? = null
+  private var contentLayer: GraphicsLayer? = null
+  private var contentLayerSize: IntSize? = null
+  private var analysisLayer: GraphicsLayer? = null
+  private var sampleJob: Job? = null
+  private var trailingSampleJob: Job? = null
+  private var sampleRequestedWhileActive = false
+  private var lastSampleStartedAt: TimeMark? = null
+  private var visualEffectContext: VisualEffectContext? = null
+
+  override fun attach(context: VisualEffectContext) {
+    visualEffectContext = context
+  }
+
+  override fun update(context: VisualEffectContext) {
+    visualEffectContext = context
+    val currentBackgroundColor = backgroundColor()
+    if (currentBackgroundColor != resolvedBackgroundColor) {
+      resolvedBackgroundColor = currentBackgroundColor
+      context.invalidateDraw()
+    }
+  }
+
+  override fun DrawScope.draw(context: VisualEffectContext) {
+    visualEffectContext = context
+    val layerSize = context.layerSize.roundToIntSize()
+    if (layerSize.width <= 0 || layerSize.height <= 0) return
+
+    val layer = requireContentLayer(context, layerSize)
+    layer.record(size = layerSize) {
+      if (resolvedBackgroundColor.isSpecified) {
+        drawRect(resolvedBackgroundColor)
+      }
+
+      val sourceOffset = context.layerOffset - context.position
+      translate(sourceOffset.x, sourceOffset.y) {
+        for (area in context.areas) {
+          val areaPosition = Snapshot.withoutReadObservation {
+            area.position.takeOrElse { Offset.Zero }
+          }
+          val areaLayer = Snapshot.withoutReadObservation {
+            area.contentLayer
+              ?.takeUnless { it.isReleased }
+              ?.takeUnless { it.size.width <= 0 || it.size.height <= 0 }
+          }
+
+          if (areaLayer != null) {
+            translate(areaPosition.x, areaPosition.y) { drawLayer(areaLayer) }
+          }
+        }
+      }
+    }
+
+    if (samplingEnabled()) {
+      scheduleSample(context = context, content = layer)
+    }
+
+    clipRect {
+      val drawOffset = -context.layerOffset
+      translate(drawOffset.x, drawOffset.y) { drawLayer(layer) }
+    }
+  }
+
+  override fun detach(context: VisualEffectContext) {
+    if (visualEffectContext === context) {
+      visualEffectContext = null
+    }
+    releaseResources()
+  }
+
+  override fun onTrimMemory(context: VisualEffectContext, level: TrimMemoryLevel) {
+    releaseResources()
+    context.invalidateDraw()
+  }
+
+  override fun shouldClipToNodeBounds(): Boolean = true
+
+  override fun shouldPreferClipToAreaBounds(): Boolean =
+    resolvedBackgroundColor.isSpecified && resolvedBackgroundColor.alpha < 0.9f
+
+  override fun calculateLayerBounds(rect: Rect, density: Density): Rect = rect
+
+  internal fun requestSample() {
+    visualEffectContext?.invalidateDraw()
+  }
+
+  private fun DrawScope.scheduleSample(context: VisualEffectContext, content: GraphicsLayer) {
+    if (sampleJob?.isActive == true) {
+      sampleRequestedWhileActive = true
+      return
+    }
+    val previousStart = lastSampleStartedAt
+    if (previousStart != null) {
+      val elapsed = previousStart.elapsedNow()
+      if (elapsed < MINIMUM_LUMINANCE_SAMPLE_INTERVAL) {
+        scheduleTrailingSample(context, MINIMUM_LUMINANCE_SAMPLE_INTERVAL - elapsed)
+        return
+      }
+    }
+    trailingSampleJob?.cancel()
+    trailingSampleJob = null
+
+    val region = resolveSampleRegion(context) ?: return
+    val token = sampleToken() ?: return
+
+    val analysis = requireAnalysisLayer(context)
+    analysis.record(size = IntSize(LUMINANCE_ANALYSIS_WIDTH, LUMINANCE_ANALYSIS_HEIGHT)) {
+      val scaleX = LUMINANCE_ANALYSIS_WIDTH / region.renderWidth
+      val scaleY = LUMINANCE_ANALYSIS_HEIGHT / region.height
+      scale(scaleX = scaleX, scaleY = scaleY, pivot = Offset.Zero) {
+        translate(left = -context.layerOffset.x, top = -(context.layerOffset.y + region.top)) {
+          drawLayer(content)
+        }
+      }
+    }
+
+    lastSampleStartedAt = TimeSource.Monotonic.markNow()
+    sampleJob =
+      context.coroutineScope.launch {
+        try {
+          val sample =
+            if (readPixels != null) {
+              readPixels.invoke(analysis)
+            } else {
+              readAnalysisPixels(analysis)
+            } ?: return@launch
+          if (sampleToken() == token) {
+            onPixels(token, sample.pixels, sample.width)
+          }
+        } finally {
+          sampleJob = null
+          if (sampleRequestedWhileActive && visualEffectContext === context) {
+            sampleRequestedWhileActive = false
+            scheduleTrailingSample(context)
+          }
+        }
+      }
+  }
+
+  private fun resolveSampleRegion(context: VisualEffectContext): LuminanceSampleRegion? {
+    val density = context.requireDensity()
+    val renderWidth = context.size.width.takeIf { it.isFinite() && it > 0f } ?: return null
+    val renderHeight = context.size.height.takeIf { it.isFinite() && it > 0f } ?: return null
+    val topInsetPx = with(density) { sampleTopInset.toPx() }.coerceAtLeast(0f)
+    val requestedHeightPx = with(density) { sampleHeight.toPx() }.coerceAtLeast(0f)
+    val top = topInsetPx.coerceAtMost(renderHeight)
+    val height = (top + requestedHeightPx).coerceAtMost(renderHeight) - top
+    if (height <= 0f) return null
+    return LuminanceSampleRegion(renderWidth = renderWidth, top = top, height = height)
+  }
+
+  private suspend fun readAnalysisPixels(analysis: GraphicsLayer): NavigationTopBarPixelSample? {
+    // Leave the draw pass before snapshotting the recorded analysis layer.
+    yield()
+    val image =
+      try {
+        analysis.toImageBitmap()
+      } catch (cancellation: CancellationException) {
+        throw cancellation
+      } catch (_: Exception) {
+        return null
+      }
+    val pixels =
+      try {
+        IntArray(image.width * image.height).also { image.readPixels(it) }
+      } catch (cancellation: CancellationException) {
+        throw cancellation
+      } catch (_: Exception) {
+        return null
+      }
+    return NavigationTopBarPixelSample(pixels = pixels, width = image.width)
+  }
+
+  private fun scheduleTrailingSample(
+    context: VisualEffectContext,
+    delayDuration: Duration = remainingSampleInterval(),
+  ) {
+    if (trailingSampleJob?.isActive == true) return
+    trailingSampleJob =
+      context.coroutineScope.launch {
+        if (delayDuration.isPositive()) delay(delayDuration)
+        trailingSampleJob = null
+        if (visualEffectContext === context) {
+          context.invalidateDraw()
+        }
+      }
+  }
+
+  private fun remainingSampleInterval(): Duration {
+    val previousStart = lastSampleStartedAt ?: return Duration.ZERO
+    return (MINIMUM_LUMINANCE_SAMPLE_INTERVAL - previousStart.elapsedNow()).coerceAtLeast(
+      Duration.ZERO
+    )
+  }
+
+  private fun requireContentLayer(context: VisualEffectContext, size: IntSize): GraphicsLayer {
+    val current = contentLayer
+    if (current != null && !current.isReleased && contentLayerSize == size) {
+      return current
+    }
+
+    releaseContentLayer()
+    val currentGraphicsContext = context.requireGraphicsContext()
+    return currentGraphicsContext.createGraphicsLayer().also {
+      graphicsContext = currentGraphicsContext
+      contentLayer = it
+      contentLayerSize = size
+    }
+  }
+
+  private fun requireAnalysisLayer(context: VisualEffectContext): GraphicsLayer {
+    analysisLayer
+      ?.takeUnless { it.isReleased }
+      ?.let {
+        return it
+      }
+    val currentGraphicsContext = graphicsContext ?: context.requireGraphicsContext()
+    return currentGraphicsContext.createGraphicsLayer().also {
+      graphicsContext = currentGraphicsContext
+      analysisLayer = it
+    }
+  }
+
+  private fun releaseResources() {
+    sampleRequestedWhileActive = false
+    sampleJob?.cancel()
+    sampleJob = null
+    trailingSampleJob?.cancel()
+    trailingSampleJob = null
+    lastSampleStartedAt = null
+    releaseLayer(analysisLayer)
+    analysisLayer = null
+    releaseContentLayer()
+  }
+
+  private fun releaseContentLayer() {
+    releaseLayer(contentLayer)
+    contentLayer = null
+    contentLayerSize = null
+    if (analysisLayer == null) {
+      graphicsContext = null
+    }
+  }
+
+  private fun releaseLayer(layer: GraphicsLayer?) {
+    val context = graphicsContext
+    if (layer != null && context != null && !layer.isReleased) {
+      context.releaseGraphicsLayer(layer)
+    }
+  }
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -118,6 +118,7 @@ import co.typie.editor.viewport.consumeEditorViewportTouchPan
 import co.typie.ext.LocalScrollGestureLockState
 import co.typie.ext.ime
 import co.typie.graphql.QueryState
+import co.typie.navigation.LocalNavigationTopBarSampleRequester
 import co.typie.navigation.Nav
 import co.typie.navigation.NavigationResult
 import co.typie.navigation.PlatformBackHandler
@@ -207,6 +208,7 @@ import co.typie.ui.component.sheet.LocalSheet
 import co.typie.ui.component.toast.LocalToast
 import co.typie.ui.component.toast.ToastType
 import co.typie.ui.component.topbar.ProvideTopBar
+import co.typie.ui.component.topbar.TopBarCenterAppearance
 import co.typie.ui.theme.AppTheme
 import co.typie.ui.theme.LocalHazeState
 import dev.chrisbanes.haze.HazeState
@@ -1241,10 +1243,12 @@ fun EditorScreen(entityId: String) {
     when {
       findReplace.active -> {
         ProvideTopBar(
+          backdropBlurEnabled = false,
           leading = { FindReplaceTopBarLeading(session = findReplace) },
           leadingKey = FindReplaceTopBarLeadingKey,
           center = { FindReplaceTopBarCenter(session = findReplace) },
           centerKey = FindReplaceTopBarCenterKey,
+          centerAppearance = TopBarCenterAppearance.ThemeSurface,
           trailing = { FindReplaceTopBarTrailing(session = findReplace) },
           trailingKey = FindReplaceTopBarTrailingKey,
           scrollOffset = null,
@@ -1252,10 +1256,12 @@ fun EditorScreen(entityId: String) {
       }
       spellcheck.active -> {
         ProvideTopBar(
+          backdropBlurEnabled = false,
           leading = { SpellcheckTopBarLeading(session = spellcheck) },
           leadingKey = SpellcheckTopBarLeadingKey,
           center = { SpellcheckTopBarCenter(session = spellcheck) },
           centerKey = SpellcheckTopBarCenterKey,
+          centerAppearance = TopBarCenterAppearance.ThemeSurface,
           trailing = { SpellcheckTopBarTrailing(session = spellcheck) },
           trailingKey = SpellcheckTopBarTrailingKey,
           scrollOffset = null,
@@ -1263,10 +1269,12 @@ fun EditorScreen(entityId: String) {
       }
       aiFeedback.active -> {
         ProvideTopBar(
+          backdropBlurEnabled = false,
           leading = { AiFeedbackTopBarLeading(session = aiFeedback) },
           leadingKey = AiFeedbackTopBarLeadingKey,
           center = { AiFeedbackTopBarCenter(session = aiFeedback) },
           centerKey = AiFeedbackTopBarCenterKey,
+          centerAppearance = TopBarCenterAppearance.ThemeSurface,
           trailing = { AiFeedbackTopBarTrailing(session = aiFeedback) },
           trailingKey = AiFeedbackTopBarTrailingKey,
           scrollOffset = null,
@@ -1708,6 +1716,13 @@ fun EditorScreen(entityId: String) {
         },
       )
       interactionScope.onEditorStateChanged()
+    }
+    val topBarSampleRequester = LocalNavigationTopBarSampleRequester.current
+    LaunchedEffect(screenState.viewportState, topBarSampleRequester) {
+      val sampleRequester = topBarSampleRequester ?: return@LaunchedEffect
+      snapshotFlow { screenState.viewportState.scrollOffset }
+        .drop(1)
+        .collect { sampleRequester.requestSample() }
     }
     LaunchedEffect(screenState.viewportState, viewportScrollableState) {
       snapshotFlow { viewportScrollableState.isScrollInProgress }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/topbar/EditorScreenTopBar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/topbar/EditorScreenTopBar.kt
@@ -32,6 +32,7 @@ internal fun EditorScreenTopBar(
 ) {
   if (editing) {
     ProvideTopBar(
+      backdropBlurEnabled = false,
       center = { documentButton(Modifier.fillMaxWidth()) },
       trailing = { EditorEditingTopBarTrailing(onEnterReadingMode) },
       trailingKey = EditingTopBarTrailingKey,
@@ -39,6 +40,7 @@ internal fun EditorScreenTopBar(
     )
   } else {
     ProvideTopBar(
+      backdropBlurEnabled = false,
       center = {
         documentButton(Modifier.fillMaxWidth().padding(end = ReadingTopBarExtraEndClearance))
       },

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/shell/RootShell.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/shell/RootShell.kt
@@ -34,6 +34,9 @@ import co.typie.domain.subscription.SubscriptionService
 import co.typie.editor.sync.ActiveDocumentEditingSessions
 import co.typie.editor.sync.orphanSweeper
 import co.typie.editor.sync.ws.SyncWs
+import co.typie.navigation.ApplyActiveNavigationStatusBarAppearance
+import co.typie.navigation.NavigationStatusBarAppearanceState
+import co.typie.navigation.ProvideNavigationStatusBarAppearanceOwner
 import co.typie.platform.appLifecycleService
 import co.typie.platform.connectivityService
 import co.typie.route.AuthRoutes
@@ -154,6 +157,7 @@ fun RootShell() {
   val sheet = remember { Sheet() }
   val dialog = remember { Dialog() }
   val popover = remember { PopoverOverlayState() }
+  val statusBarAppearanceState = remember { NavigationStatusBarAppearanceState() }
 
   // 등록 실패 안내는 루트에서 수집한다 — 미완료 트랜잭션 재시도는 화면 밖(앱 실행 시 복구)에서도 일어나므로
   // 구매 화면에서만 들으면 조용히 버려진다.
@@ -180,6 +184,11 @@ fun RootShell() {
       OnboardingService.state == OnboardingGateState.Show -> RootScreen.Onboarding
       else -> RootScreen.Main
     }
+  ApplyActiveNavigationStatusBarAppearance(
+    activeOwner = screen,
+    state = statusBarAppearanceState,
+    themeMode = AppTheme.themeMode,
+  )
 
   CompositionLocalProvider(
     LocalSheet provides sheet,
@@ -198,14 +207,16 @@ fun RootShell() {
         modifier =
           Modifier.background(AppTheme.colors.surfaceDefault).hazeSource(LocalHazeState.current),
       ) { target ->
-        when (target) {
-          RootScreen.Splash -> SplashScreen()
-          RootScreen.Maintenance -> MaintenanceScreen()
-          RootScreen.UpdateRequired -> UpdateRequiredScreen()
-          RootScreen.Auth -> AuthShell { route -> AuthRoutes(route) }
-          RootScreen.Onboarding ->
-            OnboardingShell { OnboardingScreen(onComplete = { OnboardingService.complete() }) }
-          RootScreen.Main -> MainShell { route -> MainRoutes(route) }
+        ProvideNavigationStatusBarAppearanceOwner(target, statusBarAppearanceState) {
+          when (target) {
+            RootScreen.Splash -> SplashScreen()
+            RootScreen.Maintenance -> MaintenanceScreen()
+            RootScreen.UpdateRequired -> UpdateRequiredScreen()
+            RootScreen.Auth -> AuthShell { route -> AuthRoutes(route) }
+            RootScreen.Onboarding ->
+              OnboardingShell { OnboardingScreen(onComplete = { OnboardingService.complete() }) }
+            RootScreen.Main -> MainShell { route -> MainRoutes(route) }
+          }
         }
       }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/Screen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/Screen.kt
@@ -62,7 +62,7 @@ fun Screen(
   refetchOnMount: Boolean = true,
   background: Color = AppTheme.colors.surfaceCanvas,
   contentPadding: PaddingValues = PaddingValues(horizontal = 16.dp),
-  topBarContentPadding: Dp = TopBarDefaults.BlurFadeHeight + TopBarDefaults.ContentTopSpacing,
+  topBarContentPadding: Dp = TopBarDefaults.BackdropFadeHeight + TopBarDefaults.ContentTopSpacing,
   dismissFocusOnTapOutsideInput: Boolean = true,
   overlay: (@Composable BoxScope.() -> Unit)? = null,
   content: @Composable ScreenScope.(innerPadding: PaddingValues) -> Unit,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/topbar/TopBar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/topbar/TopBar.kt
@@ -3,8 +3,10 @@ package co.typie.ui.component.topbar
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.SizeTransform
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.EaseOut
 import androidx.compose.animation.core.EaseOutCubic
+import androidx.compose.animation.core.EaseOutQuint
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.tween
@@ -24,6 +26,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -40,6 +43,12 @@ import androidx.compose.ui.unit.dp
 import co.typie.ext.safeDrawingHorizontalPadding
 import co.typie.ext.toDp
 import co.typie.ext.toPx
+import co.typie.ui.theme.DarkColors
+import co.typie.ui.theme.LocalAppColors
+import co.typie.ui.theme.LocalThemeMode
+import co.typie.ui.theme.ResolvedThemeMode
+
+private const val TOP_BAR_CENTER_PALETTE_ANIMATION_DURATION_MILLIS = 900
 
 @Composable
 fun TopBar(state: TopBarState, modifier: Modifier = Modifier, onTap: (() -> Unit)? = null) {
@@ -141,7 +150,18 @@ fun TopBar(state: TopBarState, modifier: Modifier = Modifier, onTap: (() -> Unit
                   revealed = !hasScrollReveal || centerRevealed
                 }
 
-                TopBarCenterReveal(visible = revealed) { state.centerEntries[entryKey]?.invoke() }
+                TopBarCenterReveal(visible = revealed) {
+                  val content = state.centerEntries[entryKey]
+                  if (
+                    state.centerAppearances[entryKey] == TopBarCenterAppearance.AdaptiveTransparent
+                  ) {
+                    ProvideTopBarCenterPalette(foregroundStyle = state.adaptiveForegroundStyle) {
+                      content?.invoke()
+                    }
+                  } else {
+                    content?.invoke()
+                  }
+                }
               }
             }
           }
@@ -205,6 +225,52 @@ fun TopBar(state: TopBarState, modifier: Modifier = Modifier, onTap: (() -> Unit
       }
     }
   }
+}
+
+@Composable
+private fun ProvideTopBarCenterPalette(
+  foregroundStyle: TopBarForegroundStyle?,
+  content: @Composable () -> Unit,
+) {
+  val baseColors = LocalAppColors.current
+  val inverted =
+    LocalThemeMode.current == ResolvedThemeMode.Light &&
+      foregroundStyle == TopBarForegroundStyle.Light
+  val targetColors = if (inverted) DarkColors else baseColors
+  val textDefault by
+    animateColorAsState(
+      targetValue = targetColors.textDefault,
+      animationSpec =
+        tween(
+          durationMillis = TOP_BAR_CENTER_PALETTE_ANIMATION_DURATION_MILLIS,
+          easing = EaseOutQuint,
+        ),
+      label = "top-bar-center-text-default",
+    )
+  val textMuted by
+    animateColorAsState(
+      targetValue = targetColors.textMuted,
+      animationSpec =
+        tween(
+          durationMillis = TOP_BAR_CENTER_PALETTE_ANIMATION_DURATION_MILLIS,
+          easing = EaseOutQuint,
+        ),
+      label = "top-bar-center-text-muted",
+    )
+  val textHint by
+    animateColorAsState(
+      targetValue = targetColors.textHint,
+      animationSpec =
+        tween(
+          durationMillis = TOP_BAR_CENTER_PALETTE_ANIMATION_DURATION_MILLIS,
+          easing = EaseOutQuint,
+        ),
+      label = "top-bar-center-text-hint",
+    )
+  val centerColors =
+    baseColors.copy(textDefault = textDefault, textMuted = textMuted, textHint = textHint)
+
+  CompositionLocalProvider(LocalAppColors provides centerColors, content = content)
 }
 
 @Composable

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/topbar/TopBarDefaults.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/topbar/TopBarDefaults.kt
@@ -26,10 +26,9 @@ object TopBarDefaults {
   val RevealOffset: Dp = 44.dp
 
   val BlurRadius: Dp = 6.dp
-  val BlurFadeHeight: Dp = 16.dp
-  val FadeOpacity: Float = 0.8f
+  val BackdropFadeHeight: Dp = 16.dp
   val ContentTopSpacing: Dp = 8.dp
-  val BlurFadeEasing: Easing = SmootherstepEasing
+  val BackdropFadeEasing: Easing = SmootherstepEasing
 
   val RevealAnimationDuration: Int = 200
   val RevealFadeDuration: Int = 150
@@ -47,7 +46,7 @@ object TopBarDefaults {
 
   fun hazeProgressive(): HazeProgressive =
     HazeProgressive.verticalGradient(
-      easing = BlurFadeEasing,
+      easing = BackdropFadeEasing,
       startIntensity = 1f,
       endIntensity = 0f,
     )

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/topbar/TopBarState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/topbar/TopBarState.kt
@@ -16,10 +16,21 @@ enum class NavDirection {
   Switch,
 }
 
+internal enum class TopBarForegroundStyle {
+  Dark,
+  Light,
+}
+
+enum class TopBarCenterAppearance {
+  ThemeSurface,
+  AdaptiveTransparent,
+}
+
 @Stable
 class TopBarState {
   internal val leadingEntries = mutableStateMapOf<Any, @Composable () -> Unit>()
   internal val centerEntries = mutableStateMapOf<Any, @Composable () -> Unit>()
+  internal val centerAppearances = mutableStateMapOf<Any, TopBarCenterAppearance>()
   internal val trailingEntries = mutableStateMapOf<Any, @Composable () -> Unit>()
   internal val customEntries = mutableStateMapOf<Any, @Composable () -> Unit>()
   internal val leadingOwners = mutableMapOf<Any, Any>()
@@ -49,6 +60,8 @@ class TopBarState {
   var scrollOffset: (() -> Int)? by mutableStateOf(null)
   var visible: Boolean by mutableStateOf(true)
   var enabled: Boolean by mutableStateOf(false)
+  var backdropBlurEnabled: Boolean by mutableStateOf(true)
+  internal var adaptiveForegroundStyle: TopBarForegroundStyle? by mutableStateOf(null)
   var navDirection: NavDirection by mutableStateOf(NavDirection.Switch)
   var animatedAlpha: Float by mutableStateOf(0f)
   var animatedTranslationY: Float by mutableStateOf(0f)
@@ -66,10 +79,16 @@ class TopBarState {
   fun setCenter(
     key: Any,
     content: (@Composable () -> Unit)?,
+    appearance: TopBarCenterAppearance = TopBarCenterAppearance.AdaptiveTransparent,
     owner: Any? = null,
     instance: Any? = null,
   ) {
     setEntry(centerEntries, centerOwners, centerInstances, key, content, owner, instance)
+    if (content != null) {
+      centerAppearances[key] = appearance
+    } else {
+      centerAppearances.remove(key)
+    }
     centerKey = key
   }
 
@@ -86,6 +105,8 @@ class TopBarState {
   fun reset() {
     visible = false
     scrollOffset = null
+    backdropBlurEnabled = true
+    adaptiveForegroundStyle = null
   }
 
   fun clearRoute(key: Any) {
@@ -104,6 +125,7 @@ class TopBarState {
       owners = centerOwners,
       instances = centerInstances,
       onCurrentKeyCleared = { centerKey = it },
+      onEntryRemoved = centerAppearances::remove,
     )
     clearOwnedEntries(
       route = key,
@@ -158,6 +180,7 @@ class TopBarState {
     owners: MutableMap<Any, Any>,
     instances: MutableMap<Any, Any>,
     onCurrentKeyCleared: (Any) -> Unit,
+    onEntryRemoved: (Any) -> Unit = {},
   ) {
     val keysToRemove = linkedSetOf(route)
     owners.entries
@@ -168,6 +191,7 @@ class TopBarState {
       entries.remove(entryKey)
       owners.remove(entryKey)
       instances.remove(entryKey)
+      onEntryRemoved(entryKey)
     }
 
     if (currentKey in keysToRemove) {
@@ -208,10 +232,12 @@ internal fun resolveTopBarEntryKey(explicitKey: Any?, routeKey: Any?, fallbackKe
 @Composable
 fun ProvideTopBar(
   enabled: Boolean = true,
+  backdropBlurEnabled: Boolean = true,
   leading: (@Composable () -> Unit)? = { TopBarBackButton() },
   leadingKey: Any = TopBarState.DefaultLeadingKey,
   center: (@Composable () -> Unit)? = null,
   centerKey: Any? = null,
+  centerAppearance: TopBarCenterAppearance = TopBarCenterAppearance.AdaptiveTransparent,
   trailing: (@Composable () -> Unit)? = null,
   trailingKey: Any? = null,
   scrollOffset: (() -> Int)? = null,
@@ -231,6 +257,7 @@ fun ProvideTopBar(
   @Suppress("UNUSED_EXPRESSION") state.centerKey
 
   state.enabled = enabled
+  state.backdropBlurEnabled = backdropBlurEnabled
   if (enabled) {
     val entryInstance = remember { Any() }
     val routeKey =
@@ -251,7 +278,7 @@ fun ProvideTopBar(
     val resolvedCustomKey = resolveTopBarEntryKey(customKey, routeKey, fallbackEntryKey)
 
     state.setLeading(resolvedLeadingKey, leading, owner, entryInstance)
-    state.setCenter(resolvedCenterKey, center, owner, entryInstance)
+    state.setCenter(resolvedCenterKey, center, centerAppearance, owner, entryInstance)
     state.setTrailing(resolvedTrailingKey, trailing, owner, entryInstance)
     state.scrollOffset = scrollOffset
     state.visible = visible

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/navigation/NavigationTopBarBackdropTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/navigation/NavigationTopBarBackdropTest.kt
@@ -2,8 +2,11 @@ package co.typie.navigation
 
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.lerp
+import co.typie.ui.theme.ResolvedThemeMode
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class NavigationTopBarBackdropTest {
   @Test
@@ -90,5 +93,70 @@ class NavigationTopBarBackdropTest {
       )
 
     assertEquals(Color.Green, style.background)
+  }
+
+  @Test
+  fun interactiveTransitionKeepsTheSourceAppearance() {
+    val sourceLuminance = NavigationTopBarContentLuminance.Dark
+    val destinationLuminance = NavigationTopBarContentLuminance.Bright
+
+    val appearance =
+      resolveNavigationTopBarTransitionAppearance(
+        themeMode = ResolvedThemeMode.Light,
+        committed = false,
+        sourceBlurEnabled = false,
+        sourceContentLuminance = sourceLuminance,
+        destinationBlurEnabled = true,
+        destinationContentLuminance = destinationLuminance,
+      )
+
+    assertFalse(appearance.blurEnabled)
+    assertEquals(sourceLuminance, appearance.contentLuminance)
+  }
+
+  @Test
+  fun committedTransitionUsesDestinationBlurAndVerifiedFade() {
+    val sourceLuminance = NavigationTopBarContentLuminance.Dark
+    val destinationLuminance = NavigationTopBarContentLuminance.Bright
+
+    val appearance =
+      resolveNavigationTopBarTransitionAppearance(
+        themeMode = ResolvedThemeMode.Light,
+        committed = true,
+        sourceBlurEnabled = false,
+        sourceContentLuminance = sourceLuminance,
+        destinationBlurEnabled = true,
+        destinationContentLuminance = destinationLuminance,
+      )
+
+    assertTrue(appearance.blurEnabled)
+    assertEquals(destinationLuminance, appearance.contentLuminance)
+  }
+
+  @Test
+  fun committedTransitionUsesTheThemeSafeFallbackForAnUnmeasuredDestination() {
+    val lightAppearance =
+      resolveNavigationTopBarTransitionAppearance(
+        themeMode = ResolvedThemeMode.Light,
+        committed = true,
+        sourceBlurEnabled = false,
+        sourceContentLuminance = NavigationTopBarContentLuminance.Dark,
+        destinationBlurEnabled = true,
+        destinationContentLuminance = null,
+      )
+    val darkAppearance =
+      resolveNavigationTopBarTransitionAppearance(
+        themeMode = ResolvedThemeMode.Dark,
+        committed = true,
+        sourceBlurEnabled = false,
+        sourceContentLuminance = NavigationTopBarContentLuminance.Bright,
+        destinationBlurEnabled = true,
+        destinationContentLuminance = null,
+      )
+
+    assertTrue(lightAppearance.blurEnabled)
+    assertEquals(NavigationTopBarContentLuminance.Bright, lightAppearance.contentLuminance)
+    assertTrue(darkAppearance.blurEnabled)
+    assertEquals(NavigationTopBarContentLuminance.Dark, darkAppearance.contentLuminance)
   }
 }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/navigation/NavigationTopBarLuminanceTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/navigation/NavigationTopBarLuminanceTest.kt
@@ -1,0 +1,207 @@
+package co.typie.navigation
+
+import co.typie.ui.component.topbar.TopBarForegroundStyle
+import co.typie.ui.theme.ResolvedThemeMode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class NavigationTopBarLuminanceTest {
+  @Test
+  fun lightUniformGraySwitchesBetween173And174() {
+    val low =
+      resolvedStyle(
+        themeMode = ResolvedThemeMode.Light,
+        sample = analyzeNavigationTopBarPixels(uniformPixels(gray = 173), width = 1),
+      )
+    val high =
+      resolvedStyle(
+        themeMode = ResolvedThemeMode.Light,
+        sample = analyzeNavigationTopBarPixels(uniformPixels(gray = 174), width = 1),
+      )
+
+    assertEquals(0f, low.backdropOpacity)
+    assertEquals(0.25f, low.darkTintOpacity)
+    assertEquals(TopBarForegroundStyle.Light, low.foregroundStyle)
+    assertEquals(0.85f, high.backdropOpacity)
+    assertEquals(0f, high.darkTintOpacity)
+    assertEquals(TopBarForegroundStyle.Dark, high.foregroundStyle)
+  }
+
+  @Test
+  fun lightMixedCoverageUsesBroadCenterWeightedSampling() {
+    val leadingLow = styleForWhiteRun(start = 0, width = 269)
+    val leadingHigh = styleForWhiteRun(start = 0, width = 270)
+    val centerLow = styleForWhiteRun(start = (ContentWidth - 254) / 2, width = 254)
+    val centerHigh = styleForWhiteRun(start = (ContentWidth - 255) / 2, width = 255)
+
+    assertEquals(0.25f, leadingLow.darkTintOpacity)
+    assertEquals(0f, leadingHigh.darkTintOpacity)
+    assertEquals(0.25f, centerLow.darkTintOpacity)
+    assertEquals(0f, centerHigh.darkTintOpacity)
+  }
+
+  @Test
+  fun darkUniformGrayUsesTwoBackdropOpacities() {
+    assertEquals(0.85f, darkStyle(gray = 77).backdropOpacity)
+    assertEquals(0.60f, darkStyle(gray = 78).backdropOpacity)
+    assertEquals(0.60f, darkStyle(gray = 221).backdropOpacity)
+    assertEquals(0.60f, darkStyle(gray = 222).backdropOpacity)
+  }
+
+  @Test
+  fun luminanceBoundariesUseTheCurrentClassificationAsHysteresis() {
+    val lightDark = contentLuminanceForWhiteRun(start = 0, width = 269)
+    val lightBright = contentLuminanceForWhiteRun(start = 0, width = 270)
+    val darkDark = darkContentLuminance(gray = 77)
+    val darkBright = darkContentLuminance(gray = 78)
+
+    assertEquals(
+      lightDark,
+      contentLuminanceForWhiteRun(start = 0, width = 270, current = lightDark),
+    )
+    assertEquals(
+      lightBright,
+      contentLuminanceForWhiteRun(start = 0, width = 269, current = lightBright),
+    )
+    assertEquals(darkDark, darkContentLuminance(gray = 78, current = darkDark))
+    assertEquals(darkBright, darkContentLuminance(gray = 77, current = darkBright))
+  }
+
+  @Test
+  fun thinDarkTextDoesNotChangeTheUnderlyingBrightImageTone() {
+    val sample =
+      analyzeNavigationTopBarPixels(
+        pixels = thinTextPatternPixels(background = White, foreground = Black),
+        width = SampleWidth,
+      )
+
+    val lightStyle = resolvedStyle(themeMode = ResolvedThemeMode.Light, sample = sample)
+    val darkStyle = resolvedStyle(themeMode = ResolvedThemeMode.Dark, sample = sample)
+
+    assertEquals(0f, lightStyle.darkTintOpacity)
+    assertEquals(0.60f, darkStyle.backdropOpacity)
+  }
+
+  @Test
+  fun narrowHorizontalStripesAreTreatedAsTextureInsteadOfDarkRegions() {
+    val horizontalSample =
+      analyzeNavigationTopBarPixels(pixels = horizontalStripePatternPixels(), width = SampleWidth)
+
+    assertEquals(
+      0f,
+      resolvedStyle(themeMode = ResolvedThemeMode.Light, sample = horizontalSample).darkTintOpacity,
+    )
+  }
+
+  @Test
+  fun denseDarkPatternStillChangesTheUnderlyingBrightImageTone() {
+    val sample =
+      analyzeNavigationTopBarPixels(
+        pixels = denseTextPatternPixels(background = White, foreground = Black),
+        width = SampleWidth,
+      )
+
+    val lightStyle = resolvedStyle(themeMode = ResolvedThemeMode.Light, sample = sample)
+    val darkStyle = resolvedStyle(themeMode = ResolvedThemeMode.Dark, sample = sample)
+
+    assertEquals(0.25f, lightStyle.darkTintOpacity)
+    assertEquals(0.85f, darkStyle.backdropOpacity)
+  }
+
+  @Test
+  fun everyStyleChangeWaitsForAStableCandidate() {
+    val dark = NavigationTopBarContentLuminance.Dark
+    val bright = NavigationTopBarContentLuminance.Bright
+
+    assertEquals(180L, navigationTopBarLuminanceTransitionDelayMillis(from = dark, to = bright))
+    assertEquals(180L, navigationTopBarLuminanceTransitionDelayMillis(from = bright, to = dark))
+    assertEquals(0L, navigationTopBarLuminanceTransitionDelayMillis(from = dark, to = dark))
+  }
+
+  private fun styleForWhiteRun(
+    start: Int,
+    width: Int,
+    current: NavigationTopBarContentLuminance? = null,
+  ): NavigationTopBarLuminanceStyle {
+    val contentLuminance = contentLuminanceForWhiteRun(start, width, current)
+    return navigationTopBarLuminanceStyle(ResolvedThemeMode.Light, contentLuminance)
+  }
+
+  private fun contentLuminanceForWhiteRun(
+    start: Int,
+    width: Int,
+    current: NavigationTopBarContentLuminance? = null,
+  ): NavigationTopBarContentLuminance {
+    val pixels = IntArray(ContentWidth) { Black }
+    for (x in start until start + width) {
+      pixels[x] = White
+    }
+    return classifyNavigationTopBarContentLuminance(
+      themeMode = ResolvedThemeMode.Light,
+      sample = analyzeNavigationTopBarPixels(pixels = pixels, width = ContentWidth),
+      current = current,
+    )
+  }
+
+  private fun darkStyle(
+    gray: Int,
+    current: NavigationTopBarContentLuminance? = null,
+  ): NavigationTopBarLuminanceStyle =
+    navigationTopBarLuminanceStyle(
+      themeMode = ResolvedThemeMode.Dark,
+      contentLuminance = darkContentLuminance(gray, current),
+    )
+
+  private fun darkContentLuminance(
+    gray: Int,
+    current: NavigationTopBarContentLuminance? = null,
+  ): NavigationTopBarContentLuminance =
+    classifyNavigationTopBarContentLuminance(
+      themeMode = ResolvedThemeMode.Dark,
+      sample = analyzeNavigationTopBarPixels(uniformPixels(gray), width = 1),
+      current = current,
+    )
+
+  private fun resolvedStyle(
+    themeMode: ResolvedThemeMode,
+    sample: NavigationTopBarLuminanceSample,
+  ): NavigationTopBarLuminanceStyle =
+    navigationTopBarLuminanceStyle(
+      themeMode = themeMode,
+      contentLuminance =
+        classifyNavigationTopBarContentLuminance(themeMode = themeMode, sample = sample),
+    )
+
+  private fun uniformPixels(gray: Int): IntArray = intArrayOf(argb(gray, gray, gray))
+
+  private fun thinTextPatternPixels(background: Int, foreground: Int): IntArray =
+    IntArray(SampleWidth * SampleHeight) { index ->
+      val x = index % SampleWidth
+      val y = index / SampleWidth
+      val isGlyphStroke = x % 4 == 1 || (y % 8 == 3 && x % 8 in 1..5)
+      if (isGlyphStroke) foreground else background
+    }
+
+  private fun denseTextPatternPixels(background: Int, foreground: Int): IntArray =
+    IntArray(SampleWidth * SampleHeight) { index ->
+      val x = index % SampleWidth
+      if (x % 4 < 3) foreground else background
+    }
+
+  private fun horizontalStripePatternPixels(): IntArray =
+    IntArray(SampleWidth * SampleHeight) { index ->
+      val y = index / SampleWidth
+      if (y % 8 < 4) Black else White
+    }
+
+  private companion object {
+    const val ContentWidth = 402
+    const val SampleWidth = 64
+    const val SampleHeight = 16
+    val Black = argb(0, 0, 0)
+    val White = argb(255, 255, 255)
+
+    fun argb(red: Int, green: Int, blue: Int): Int =
+      (0xFF shl 24) or (red shl 16) or (green shl 8) or blue
+  }
+}

--- a/apps/mobile/compose/src/desktopMain/kotlin/co/typie/dev/SystemChrome.kt
+++ b/apps/mobile/compose/src/desktopMain/kotlin/co/typie/dev/SystemChrome.kt
@@ -44,6 +44,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import co.typie.datetime.format
+import co.typie.navigation.LocalNavigationStatusBarAppearanceController
+import co.typie.navigation.NavigationStatusBarAppearanceController
 import co.typie.ui.theme.AppTheme
 import java.awt.MouseInfo
 import java.awt.Point
@@ -73,6 +75,7 @@ private val BezelScreenEdge = Color(0xFF000000) // screen-to-frame seam
 @Composable
 actual fun SystemChrome(content: @Composable () -> Unit) {
   val r = ScreenCornerRadius
+  val statusBarAppearanceController = remember { NavigationStatusBarAppearanceController() }
   val keyboardController = remember {
     object : SoftwareKeyboardController {
       override fun show() {
@@ -85,7 +88,10 @@ actual fun SystemChrome(content: @Composable () -> Unit) {
     }
   }
 
-  CompositionLocalProvider(LocalSoftwareKeyboardController provides keyboardController) {
+  CompositionLocalProvider(
+    LocalSoftwareKeyboardController provides keyboardController,
+    LocalNavigationStatusBarAppearanceController provides statusBarAppearanceController,
+  ) {
     Box(Modifier.fillMaxSize()) {
       // Content fills the full window so the Compose root lines up with the window
       // origin, matching iOS/Android. The bezel is a decorative overlay drawn on top
@@ -97,9 +103,11 @@ actual fun SystemChrome(content: @Composable () -> Unit) {
             .padding(start = BezelThickness, end = BezelThickness, bottom = BezelThickness)
         )
         StatusBar(
-          Modifier.fillMaxWidth()
-            .align(Alignment.TopStart)
-            .padding(start = BezelThickness, top = BezelThickness, end = BezelThickness)
+          useLightForeground = statusBarAppearanceController.useLightForeground,
+          modifier =
+            Modifier.fillMaxWidth()
+              .align(Alignment.TopStart)
+              .padding(start = BezelThickness, top = BezelThickness, end = BezelThickness),
         )
         HomeIndicator(Modifier.align(Alignment.BottomCenter).padding(bottom = BezelThickness))
       }
@@ -152,8 +160,13 @@ actual fun SystemChrome(content: @Composable () -> Unit) {
 }
 
 @Composable
-private fun StatusBar(modifier: Modifier = Modifier) {
-  val contentColor = AppTheme.colors.textDefault
+private fun StatusBar(useLightForeground: Boolean?, modifier: Modifier = Modifier) {
+  val contentColor =
+    when (useLightForeground) {
+      true -> Color.White
+      false -> Color.Black
+      null -> AppTheme.colors.textDefault
+    }
   var time by remember { mutableStateOf(Clock.System.now().format("HH:mm")) }
 
   LaunchedEffect(Unit) {

--- a/apps/mobile/compose/src/desktopMain/kotlin/co/typie/navigation/NavigationStatusBarAppearance.desktop.kt
+++ b/apps/mobile/compose/src/desktopMain/kotlin/co/typie/navigation/NavigationStatusBarAppearance.desktop.kt
@@ -1,0 +1,34 @@
+package co.typie.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
+
+internal class NavigationStatusBarAppearanceController {
+  var useLightForeground: Boolean? by mutableStateOf(null)
+    private set
+
+  fun update(useLightForeground: Boolean) {
+    this.useLightForeground = useLightForeground
+  }
+}
+
+internal val LocalNavigationStatusBarAppearanceController =
+  staticCompositionLocalOf<NavigationStatusBarAppearanceController?> { null }
+
+@Composable
+internal actual fun ApplyPlatformNavigationStatusBarAppearance(
+  useLightForeground: Boolean,
+  defaultUseLightForeground: Boolean,
+) {
+  val controller = LocalNavigationStatusBarAppearanceController.current ?: return
+
+  SideEffect { controller.update(useLightForeground) }
+  DisposableEffect(controller, defaultUseLightForeground) {
+    onDispose { controller.update(defaultUseLightForeground) }
+  }
+}

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/interaction/EditorInteractionsDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/interaction/EditorInteractionsDesktopTest.kt
@@ -57,7 +57,7 @@ import co.typie.editor.viewport.EditorViewportState
 import co.typie.editor.viewport.consumeEditorViewportTouchPan
 import co.typie.ext.ScrollGestureLockState
 import co.typie.navigation.LocalNavigationPopNestedScroll
-import co.typie.navigation.NavigationStack
+import co.typie.navigation.NavigationStackTestHost
 import co.typie.navigation.Navigator
 import co.typie.navigation.navigationPopNestedScroll
 import co.typie.route.Route
@@ -1831,7 +1831,7 @@ class EditorInteractionsDesktopTest {
     setContent {
       effectiveTouchSlop =
         if (usePlatformTouchSlop) LocalViewConfiguration.current.touchSlop else 8f
-      NavigationStack(
+      NavigationStackTestHost(
         navigator = navigator,
         topBarState = remember { TopBarState() },
         modifier = Modifier.size(width = 320.dp, height = 640.dp),

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/EditorRouteRemovalNavigationStackDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/EditorRouteRemovalNavigationStackDesktopTest.kt
@@ -66,7 +66,7 @@ class EditorRouteRemovalNavigationStackDesktopTest {
     )
 
     setContent {
-      NavigationStack(
+      NavigationStackTestHost(
         navigator = navigator,
         topBarState = remember { TopBarState() },
         modifier = Modifier.size(width = 320.dp, height = 640.dp),

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/NavigationStackDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/NavigationStackDesktopTest.kt
@@ -71,7 +71,7 @@ class NavigationStackDesktopTest {
     val navigator = Navigator(Route.Home)
 
     setContent {
-      NavigationStack(
+      NavigationStackTestHost(
         navigator = navigator,
         topBarState = remember { TopBarState() },
         modifier = Modifier.size(width = 320.dp, height = 640.dp),
@@ -97,7 +97,7 @@ class NavigationStackDesktopTest {
     var surfaceDownCount = 0
 
     setContent {
-      NavigationStack(
+      NavigationStackTestHost(
         navigator = navigator,
         topBarState = remember { TopBarState() },
         modifier = Modifier.size(width = 320.dp, height = 640.dp),
@@ -154,7 +154,7 @@ class NavigationStackDesktopTest {
     val observedBottomBars = mutableMapOf<Route, BottomBarState?>()
 
     setContent {
-      NavigationStack(
+      NavigationStackTestHost(
         navigator = navigator,
         topBarState = topBarState,
         bottomBarState = bottomBarState,
@@ -221,7 +221,7 @@ class NavigationStackDesktopTest {
 
     setContent {
       platformTouchSlop = LocalViewConfiguration.current.touchSlop
-      NavigationStack(
+      NavigationStackTestHost(
         navigator = navigator,
         topBarState = remember { TopBarState() },
         modifier = Modifier.size(width = 320.dp, height = 640.dp),
@@ -270,7 +270,7 @@ class NavigationStackDesktopTest {
         onDispose { observerHandle?.dispose() }
       }
       platformTouchSlop = LocalViewConfiguration.current.touchSlop
-      NavigationStack(
+      NavigationStackTestHost(
         navigator = navigator,
         topBarState = topBarState,
         modifier = Modifier.size(width = 320.dp, height = 640.dp),
@@ -314,7 +314,7 @@ class NavigationStackDesktopTest {
     var routeDownCount = 0
 
     setContent {
-      NavigationStack(
+      NavigationStackTestHost(
         navigator = navigator,
         topBarState = remember { TopBarState() },
         foregroundInteractive = foregroundInteractive,
@@ -359,7 +359,7 @@ class NavigationStackDesktopTest {
 
     setContent {
       platformTouchSlop = LocalViewConfiguration.current.touchSlop
-      NavigationStack(
+      NavigationStackTestHost(
         navigator = navigator,
         topBarState = topBarState,
         modifier = Modifier.size(width = 320.dp, height = 640.dp),
@@ -413,7 +413,7 @@ class NavigationStackDesktopTest {
 
     setContent {
       platformTouchSlop = LocalViewConfiguration.current.touchSlop
-      NavigationStack(
+      NavigationStackTestHost(
         navigator = navigator,
         topBarState = remember { TopBarState() },
         modifier = Modifier.size(width = 320.dp, height = 640.dp),
@@ -513,7 +513,7 @@ class NavigationStackDesktopTest {
 
     setContent {
       platformTouchSlop = LocalViewConfiguration.current.touchSlop
-      NavigationStack(
+      NavigationStackTestHost(
         navigator = navigator,
         topBarState = remember { TopBarState() },
         modifier = Modifier.size(width = 320.dp, height = 640.dp),
@@ -559,7 +559,7 @@ class NavigationStackDesktopTest {
 
     setContent {
       platformTouchSlop = LocalViewConfiguration.current.touchSlop
-      NavigationStack(
+      NavigationStackTestHost(
         navigator = navigator,
         topBarState = remember { TopBarState() },
         modifier = Modifier.size(width = 320.dp, height = 640.dp),
@@ -680,7 +680,7 @@ class NavigationStackDesktopTest {
     lateinit var compositionScope: CoroutineScope
 
     setContent {
-      NavigationStack(
+      NavigationStackTestHost(
         navigator = navigator,
         topBarState = remember { TopBarState() },
         modifier = Modifier.size(width = 320.dp, height = 640.dp),
@@ -755,7 +755,7 @@ class NavigationStackDesktopTest {
 
     setContent {
       activationDistancePx = LocalViewConfiguration.current.touchSlop * 3f
-      NavigationStack(
+      NavigationStackTestHost(
         navigator = navigator,
         topBarState = remember { TopBarState() },
         modifier = Modifier.size(width = 320.dp, height = 640.dp),
@@ -811,7 +811,7 @@ class NavigationStackDesktopTest {
     val editorRoute = Route.Editor("document-id")
 
     setContent {
-      NavigationStack(
+      NavigationStackTestHost(
         navigator = navigator,
         topBarState = remember { TopBarState() },
         modifier = Modifier.size(width = 320.dp, height = 640.dp),
@@ -857,7 +857,7 @@ class NavigationStackDesktopTest {
     val editorRoute = Route.Editor("document-id")
 
     setContent {
-      NavigationStack(
+      NavigationStackTestHost(
         navigator = navigator,
         topBarState = remember { TopBarState() },
         modifier = Modifier.size(width = 320.dp, height = 640.dp),

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/NavigationStackTestHost.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/NavigationStackTestHost.kt
@@ -1,0 +1,31 @@
+package co.typie.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import co.typie.route.Route
+import co.typie.ui.component.bottombar.BottomBarState
+import co.typie.ui.component.topbar.TopBarState
+import co.typie.ui.theme.LocalThemeMode
+import co.typie.ui.theme.ResolvedThemeMode
+
+@Composable
+internal fun NavigationStackTestHost(
+  navigator: Navigator,
+  topBarState: TopBarState,
+  bottomBarState: BottomBarState? = null,
+  modifier: Modifier = Modifier,
+  foregroundInteractive: Boolean = true,
+  content: @Composable (Route) -> Unit,
+) {
+  CompositionLocalProvider(LocalThemeMode provides ResolvedThemeMode.Light) {
+    NavigationStack(
+      navigator = navigator,
+      topBarState = topBarState,
+      bottomBarState = bottomBarState,
+      modifier = modifier,
+      foregroundInteractive = foregroundInteractive,
+      content = content,
+    )
+  }
+}

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/NavigationTopBarSamplingEffectDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/NavigationTopBarSamplingEffectDesktopTest.kt
@@ -1,0 +1,300 @@
+package co.typie.navigation
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import co.typie.ui.theme.ResolvedThemeMode
+import dev.chrisbanes.haze.ExperimentalHazeApi
+import dev.chrisbanes.haze.hazeEffect
+import dev.chrisbanes.haze.hazeSource
+import dev.chrisbanes.haze.rememberHazeState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
+
+private const val SamplingEffectTag = "sampling-effect"
+
+@OptIn(ExperimentalTestApi::class, ExperimentalHazeApi::class)
+class NavigationTopBarSamplingEffectDesktopTest {
+  @Test
+  fun inFlightReadbackIsDiscardedWhenSampleSessionChanges() = runComposeUiTest {
+    val tokenA = NavigationTopBarSampleToken(owner = "A", themeMode = ResolvedThemeMode.Light)
+    val tokenB = NavigationTopBarSampleToken(owner = "B", themeMode = ResolvedThemeMode.Dark)
+    val sampleToken = mutableStateOf(tokenA)
+    val firstReadStarted = CompletableDeferred<Unit>()
+    val releaseFirstRead = CompletableDeferred<Unit>()
+    val secondReadStarted = CompletableDeferred<Unit>()
+    val releaseSecondRead = CompletableDeferred<Unit>()
+    val accepted = mutableListOf<NavigationTopBarSampleToken>()
+    var readCount = 0
+    lateinit var samplingEffect: NavigationTopBarSamplingEffect
+
+    setContent {
+      val hazeState = rememberHazeState()
+      val effect = remember {
+        NavigationTopBarSamplingEffect(
+          sampleTopInset = 0.dp,
+          sampleHeight = 40.dp,
+          backgroundColor = { Color.Black },
+          sampleToken = { sampleToken.value },
+          readPixels = {
+            when (readCount++) {
+              0 -> {
+                firstReadStarted.complete(Unit)
+                releaseFirstRead.await()
+              }
+              1 -> {
+                secondReadStarted.complete(Unit)
+                releaseSecondRead.await()
+              }
+            }
+            NavigationTopBarPixelSample(IntArray(64 * 16), width = 64)
+          },
+          onPixels = { token, _, _ -> accepted += token },
+        )
+      }
+      samplingEffect = effect
+
+      Box(Modifier.size(width = 160.dp, height = 40.dp)) {
+        Box(Modifier.fillMaxSize().background(Color.White).hazeSource(hazeState))
+        Box(Modifier.fillMaxSize().hazeEffect(hazeState) { visualEffect = effect })
+      }
+    }
+
+    waitUntil(timeoutMillis = 5_000) { firstReadStarted.isCompleted }
+    sampleToken.value = tokenB
+    samplingEffect.requestSample()
+    releaseFirstRead.complete(Unit)
+
+    waitUntil(timeoutMillis = 5_000) { secondReadStarted.isCompleted }
+    assertTrue(accepted.isEmpty(), "stale result was accepted: $accepted")
+
+    releaseSecondRead.complete(Unit)
+    waitUntil(timeoutMillis = 5_000) { accepted.isNotEmpty() }
+    assertEquals(tokenB, accepted.first())
+  }
+
+  @Test
+  fun disabledSamplingSkipsReadbackUntilReenabled() = runComposeUiTest {
+    val samplingEnabled = mutableStateOf(false)
+    var sampleCount = 0
+    lateinit var samplingEffect: NavigationTopBarSamplingEffect
+
+    setContent {
+      val hazeState = rememberHazeState()
+      val effect = remember {
+        NavigationTopBarSamplingEffect(
+          sampleTopInset = 0.dp,
+          sampleHeight = 40.dp,
+          backgroundColor = { Color.Black },
+          samplingEnabled = { samplingEnabled.value },
+          onPixels = { _, _, _ -> sampleCount++ },
+        )
+      }
+      samplingEffect = effect
+
+      Box(Modifier.size(width = 160.dp, height = 40.dp)) {
+        Box(Modifier.fillMaxSize().background(Color.White).hazeSource(hazeState))
+        Box(Modifier.fillMaxSize().hazeEffect(hazeState) { visualEffect = effect })
+      }
+    }
+    waitForIdle()
+    samplingEffect.requestSample()
+    waitForIdle()
+    assertTrue(sampleCount == 0, "disabled sample count=$sampleCount")
+
+    samplingEnabled.value = true
+    samplingEffect.requestSample()
+    waitUntil(timeoutMillis = 5_000) { sampleCount > 0 }
+  }
+
+  @Test
+  fun requestedReadbackRefreshesWhenHazeSourceMovesDuringPlacement() = runComposeUiTest {
+    val sourceOffsetY = mutableIntStateOf(60)
+    var sample: PixelSample? = null
+    lateinit var samplingEffect: NavigationTopBarSamplingEffect
+
+    setContent {
+      val hazeState = rememberHazeState()
+      val effect = remember {
+        NavigationTopBarSamplingEffect(
+          sampleTopInset = 0.dp,
+          sampleHeight = 40.dp,
+          backgroundColor = { Color.White },
+          onPixels = { _, pixels, width -> sample = PixelSample(pixels, width) },
+        )
+      }
+      samplingEffect = effect
+
+      Box(Modifier.size(width = 160.dp, height = 100.dp)) {
+        Box(Modifier.fillMaxSize().hazeSource(hazeState)) {
+          Box(
+            Modifier.offset { IntOffset(x = 0, y = sourceOffsetY.intValue) }
+              .width(160.dp)
+              .height(40.dp)
+              .background(Color.Black)
+          )
+        }
+        Box(Modifier.fillMaxSize().hazeEffect(hazeState) { visualEffect = effect })
+      }
+    }
+
+    waitUntil(timeoutMillis = 5_000) {
+      sample?.averageEncodedBrightness()?.let { it > 0.92f } == true
+    }
+    sourceOffsetY.intValue = 0
+    waitForIdle()
+    samplingEffect.requestSample()
+    waitUntil(timeoutMillis = 5_000) {
+      sample?.averageEncodedBrightness()?.let { it < 0.08f } == true
+    }
+  }
+
+  @Test
+  fun readbackRefreshesWhenHazeSourceChanges() = runComposeUiTest {
+    val sourceColor = mutableStateOf(Color.Black)
+    var sample: PixelSample? = null
+
+    setContent {
+      val hazeState = rememberHazeState()
+      val effect = remember {
+        NavigationTopBarSamplingEffect(
+          sampleTopInset = 0.dp,
+          sampleHeight = 40.dp,
+          backgroundColor = { Color.Magenta },
+          onPixels = { _, pixels, width -> sample = PixelSample(pixels, width) },
+        )
+      }
+
+      Box(Modifier.size(width = 160.dp, height = 40.dp)) {
+        Canvas(Modifier.fillMaxSize().hazeSource(hazeState)) { drawRect(sourceColor.value) }
+        Box(Modifier.fillMaxSize().hazeEffect(hazeState) { visualEffect = effect })
+      }
+    }
+
+    waitUntil(timeoutMillis = 5_000) {
+      sample?.averageEncodedBrightness()?.let { it < 0.08f } == true
+    }
+    sourceColor.value = Color.White
+    waitUntil(timeoutMillis = 5_000) {
+      sample?.averageEncodedBrightness()?.let { it > 0.92f } == true
+    }
+  }
+
+  @Test
+  fun readbackDownsamplesOnlyConfiguredControlRow() = runComposeUiTest {
+    var sample: PixelSample? = null
+
+    setContent {
+      val hazeState = rememberHazeState()
+      val effect = remember {
+        NavigationTopBarSamplingEffect(
+          sampleTopInset = 20.dp,
+          sampleHeight = 40.dp,
+          backgroundColor = { Color.Magenta },
+          onPixels = { _, pixels, width -> sample = PixelSample(pixels, width) },
+        )
+      }
+
+      Box(Modifier.size(width = 160.dp, height = 100.dp)) {
+        Canvas(Modifier.fillMaxSize().hazeSource(hazeState)) {
+          drawRect(Color.Red, size = Size(size.width, 20.dp.toPx()))
+          drawRect(
+            Color.Black,
+            topLeft = Offset(0f, 20.dp.toPx()),
+            size = Size(size.width / 2f, 40.dp.toPx()),
+          )
+          drawRect(
+            Color.White,
+            topLeft = Offset(size.width / 2f, 20.dp.toPx()),
+            size = Size(size.width / 2f, 40.dp.toPx()),
+          )
+          drawRect(
+            Color.Blue,
+            topLeft = Offset(0f, 60.dp.toPx()),
+            size = Size(size.width, size.height - 60.dp.toPx()),
+          )
+        }
+        Box(
+          Modifier.fillMaxSize().testTag(SamplingEffectTag).hazeEffect(hazeState) {
+            visualEffect = effect
+          }
+        )
+      }
+    }
+
+    waitUntil(timeoutMillis = 5_000) { sample != null }
+    val resolved = requireNotNull(sample)
+    val height = resolved.pixels.size / resolved.width
+    assertEquals(64, resolved.width)
+    assertEquals(16, height)
+    val left = averageRgb(resolved, xRange = 0 until resolved.width / 2, height = height)
+    val right =
+      averageRgb(resolved, xRange = resolved.width / 2 until resolved.width, height = height)
+
+    assertTrue(left.red < 0.08f && left.green < 0.08f && left.blue < 0.08f, "left=$left")
+    assertTrue(right.red > 0.92f && right.green > 0.92f && right.blue > 0.92f, "right=$right")
+
+    val rendered = onNodeWithTag(SamplingEffectTag).captureToImage().toPixelMap()
+    val boundaryY = rendered.height / 2
+    val leftBoundaryLuminance = rendered[rendered.width / 2 - 1, boundaryY].luminance()
+    val rightBoundaryLuminance = rendered[rendered.width / 2, boundaryY].luminance()
+    assertTrue(leftBoundaryLuminance < 0.08f, "left boundary=$leftBoundaryLuminance")
+    assertTrue(rightBoundaryLuminance > 0.92f, "right boundary=$rightBoundaryLuminance")
+  }
+
+  private fun averageRgb(sample: PixelSample, xRange: IntRange, height: Int): Rgb {
+    var red = 0L
+    var green = 0L
+    var blue = 0L
+    var count = 0
+    for (y in 0 until height) {
+      for (x in xRange) {
+        val argb = sample.pixels[y * sample.width + x]
+        red += argb ushr 16 and 0xFF
+        green += argb ushr 8 and 0xFF
+        blue += argb and 0xFF
+        count += 1
+      }
+    }
+    return Rgb(
+      red = red / count.toFloat() / 255f,
+      green = green / count.toFloat() / 255f,
+      blue = blue / count.toFloat() / 255f,
+    )
+  }
+
+  private fun PixelSample.averageEncodedBrightness(): Float {
+    var total = 0L
+    pixels.forEach { argb ->
+      total += (argb ushr 16 and 0xFF) + (argb ushr 8 and 0xFF) + (argb and 0xFF)
+    }
+    return total / pixels.size.toFloat() / (3f * 255f)
+  }
+
+  private data class PixelSample(val pixels: IntArray, val width: Int)
+
+  private data class Rgb(val red: Float, val green: Float, val blue: Float)
+}

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/RouteRemovalNavigationStackDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/RouteRemovalNavigationStackDesktopTest.kt
@@ -59,7 +59,7 @@ class RouteRemovalNavigationStackDesktopTest {
     )
 
     setContent {
-      NavigationStack(
+      NavigationStackTestHost(
         navigator = navigator,
         topBarState = remember { TopBarState() },
         modifier = Modifier.size(width = 320.dp, height = 640.dp),
@@ -114,7 +114,7 @@ class RouteRemovalNavigationStackDesktopTest {
     )
 
     setContent {
-      NavigationStack(
+      NavigationStackTestHost(
         navigator = navigator,
         topBarState = remember { TopBarState() },
         modifier = Modifier.size(width = 320.dp, height = 640.dp),
@@ -176,7 +176,7 @@ class RouteRemovalNavigationStackDesktopTest {
     )
 
     setContent {
-      NavigationStack(
+      NavigationStackTestHost(
         navigator = navigator,
         topBarState = remember { TopBarState() },
         modifier = Modifier.size(width = 320.dp, height = 640.dp),
@@ -215,7 +215,7 @@ class RouteRemovalNavigationStackDesktopTest {
     val route = Route.Folder("unguarded")
 
     setContent {
-      NavigationStack(
+      NavigationStackTestHost(
         navigator = navigator,
         topBarState = remember { TopBarState() },
         modifier = Modifier.size(width = 320.dp, height = 640.dp),
@@ -258,7 +258,7 @@ class RouteRemovalNavigationStackDesktopTest {
     val navigator = Navigator(Route.Home)
 
     setContent {
-      NavigationStack(
+      NavigationStackTestHost(
         navigator = navigator,
         topBarState = remember { TopBarState() },
         modifier = Modifier.size(width = 320.dp, height = 640.dp),
@@ -322,7 +322,7 @@ class RouteRemovalNavigationStackDesktopTest {
     )
 
     setContent {
-      NavigationStack(
+      NavigationStackTestHost(
         navigator = navigator,
         topBarState = remember { TopBarState() },
         modifier = Modifier.size(width = 320.dp, height = 640.dp),
@@ -390,7 +390,7 @@ class RouteRemovalNavigationStackDesktopTest {
     )
 
     setContent {
-      NavigationStack(
+      NavigationStackTestHost(
         navigator = navigator,
         topBarState = remember { TopBarState() },
         modifier = Modifier.size(width = 320.dp, height = 640.dp),
@@ -448,7 +448,7 @@ class RouteRemovalNavigationStackDesktopTest {
     )
 
     setContent {
-      NavigationStack(
+      NavigationStackTestHost(
         navigator = navigator,
         topBarState = remember { TopBarState() },
         modifier = Modifier.size(width = 320.dp, height = 640.dp),
@@ -505,7 +505,7 @@ class RouteRemovalNavigationStackDesktopTest {
     )
 
     setContent {
-      NavigationStack(
+      NavigationStackTestHost(
         navigator = navigator,
         topBarState = remember { TopBarState() },
         modifier = Modifier.size(width = 320.dp, height = 640.dp),
@@ -562,7 +562,7 @@ class RouteRemovalNavigationStackDesktopTest {
     var removalResult: Result<NavigationResult>? = null
 
     setContent {
-      NavigationStack(
+      NavigationStackTestHost(
         navigator = navigator,
         topBarState = remember { TopBarState() },
         modifier = Modifier.size(width = 320.dp, height = 640.dp),
@@ -627,7 +627,7 @@ class RouteRemovalNavigationStackDesktopTest {
       )
 
       setContent {
-        NavigationStack(
+        NavigationStackTestHost(
           navigator = navigator,
           topBarState = remember { TopBarState() },
           modifier = Modifier.size(width = 320.dp, height = 640.dp),
@@ -680,7 +680,7 @@ class RouteRemovalNavigationStackDesktopTest {
       )
 
       setContent {
-        NavigationStack(
+        NavigationStackTestHost(
           navigator = navigator,
           topBarState = remember { TopBarState() },
           modifier = Modifier.size(width = 320.dp, height = 640.dp),

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/TypieTopBarProgressiveBlurEffectDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/TypieTopBarProgressiveBlurEffectDesktopTest.kt
@@ -1,28 +1,41 @@
 package co.typie.navigation
 
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import co.typie.ui.component.topbar.LocalTopBarAnimationSource
+import co.typie.ui.component.topbar.TopBarDefaults
 import co.typie.ui.component.topbar.TopBarState
+import co.typie.ui.theme.LocalThemeMode
+import co.typie.ui.theme.ResolvedThemeMode
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 import kotlin.math.abs
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 private const val MaximumContinuousLuminanceStep = 0.08f
@@ -30,15 +43,106 @@ private const val MaximumContinuousLuminanceStep = 0.08f
 @OptIn(ExperimentalTestApi::class)
 class TypieTopBarProgressiveBlurEffectDesktopTest {
   @Test
+  fun nestedBlurLayerRedrawRefreshesMeasuredLuminance() = runComposeUiTest {
+    val sourceColor = mutableStateOf(Color.White)
+    val measurements = mutableListOf<NavigationTopBarMeasuredContentLuminance>()
+
+    setContent {
+      val hazeState = rememberHazeState()
+      val topBarState = remember { TopBarState().apply { animatedAlpha = 1f } }
+
+      CompositionLocalProvider(
+        LocalThemeMode provides ResolvedThemeMode.Light,
+        LocalTopBarAnimationSource provides topBarState,
+      ) {
+        Box(Modifier.size(width = 160.dp, height = 120.dp)) {
+          Box(Modifier.fillMaxSize().hazeSource(hazeState)) {
+            Canvas(Modifier.fillMaxSize().blur(16.dp)) { drawRect(sourceColor.value) }
+          }
+          NavigationTopBarBackdrop(
+            hazeState = hazeState,
+            style = {
+              NavigationTopBarBackdropStyle(background = Color.Transparent, presence = 1f)
+            },
+            blurEnabled = false,
+            luminanceMode = NavigationTopBarLuminanceMode.Live(Unit),
+            themeMode = ResolvedThemeMode.Light,
+            onMeasuredContentLuminance = measurements::add,
+          )
+        }
+      }
+    }
+
+    waitUntil(timeoutMillis = 5_000) {
+      measurements.any { it.contentLuminance == NavigationTopBarContentLuminance.Bright }
+    }
+    runOnIdle {
+      measurements.clear()
+      sourceColor.value = Color.Black
+    }
+    waitUntil(timeoutMillis = 5_000) {
+      measurements.any { it.contentLuminance == NavigationTopBarContentLuminance.Dark }
+    }
+  }
+
+  @Test
+  fun frozenSeedIsNotPublishedUntilDestinationPixelsAreMeasured() = runComposeUiTest {
+    val luminanceMode =
+      mutableStateOf<NavigationTopBarLuminanceMode>(
+        NavigationTopBarLuminanceMode.Frozen(NavigationTopBarContentLuminance.Dark)
+      )
+    val measurements = mutableListOf<NavigationTopBarMeasuredContentLuminance>()
+
+    setContent {
+      val hazeState = rememberHazeState()
+      val topBarState = remember { TopBarState().apply { animatedAlpha = 1f } }
+
+      CompositionLocalProvider(
+        LocalThemeMode provides ResolvedThemeMode.Light,
+        LocalTopBarAnimationSource provides topBarState,
+      ) {
+        Box(Modifier.size(width = 160.dp, height = 120.dp)) {
+          Box(Modifier.fillMaxSize().background(Color.Black).hazeSource(hazeState))
+          NavigationTopBarBackdrop(
+            hazeState = hazeState,
+            style = {
+              NavigationTopBarBackdropStyle(background = Color.Transparent, presence = 1f)
+            },
+            blurEnabled = false,
+            luminanceMode = luminanceMode.value,
+            themeMode = ResolvedThemeMode.Light,
+            onMeasuredContentLuminance = measurements::add,
+          )
+        }
+      }
+    }
+    waitForIdle()
+    assertTrue(measurements.isEmpty(), "frozen seed was published: $measurements")
+
+    luminanceMode.value = NavigationTopBarLuminanceMode.Live("destination")
+    waitUntil(timeoutMillis = 5_000) { measurements.isNotEmpty() }
+
+    val measured = measurements.first()
+    assertEquals("destination", measured.token.owner)
+    assertEquals(ResolvedThemeMode.Light, measured.token.themeMode)
+    assertEquals(NavigationTopBarContentLuminance.Dark, measured.contentLuminance)
+  }
+
+  @Test
   fun hiddenTopBarDoesNotKeepBackdropEffectComposed() = runComposeUiTest {
     setContent {
       val hazeState = rememberHazeState()
       val topBarState = remember { TopBarState().apply { animatedAlpha = 0f } }
 
-      CompositionLocalProvider(LocalTopBarAnimationSource provides topBarState) {
+      CompositionLocalProvider(
+        LocalThemeMode provides ResolvedThemeMode.Light,
+        LocalTopBarAnimationSource provides topBarState,
+      ) {
         NavigationTopBarBackdrop(
           hazeState = hazeState,
           style = { NavigationTopBarBackdropStyle(background = Color.Black, presence = 1f) },
+          luminanceMode = NavigationTopBarLuminanceMode.Live(Unit),
+          themeMode = ResolvedThemeMode.Light,
         )
       }
     }
@@ -48,12 +152,15 @@ class TypieTopBarProgressiveBlurEffectDesktopTest {
   }
 
   @Test
-  fun navigationTopBarBlurChangesContinuouslyThroughFade() = runComposeUiTest {
+  fun navigationTopBarOpacityChangesContinuouslyThroughFade() = runComposeUiTest {
     setContent {
       val hazeState = rememberHazeState()
       val topBarState = remember { TopBarState().apply { animatedAlpha = 1f } }
 
-      CompositionLocalProvider(LocalTopBarAnimationSource provides topBarState) {
+      CompositionLocalProvider(
+        LocalThemeMode provides ResolvedThemeMode.Light,
+        LocalTopBarAnimationSource provides topBarState,
+      ) {
         Box(Modifier.size(width = 160.dp, height = 120.dp)) {
           Canvas(Modifier.fillMaxSize().hazeSource(hazeState)) {
             drawRect(Color.Black)
@@ -70,6 +177,8 @@ class TypieTopBarProgressiveBlurEffectDesktopTest {
             style = {
               NavigationTopBarBackdropStyle(background = Color.Transparent, presence = 1f)
             },
+            luminanceMode = NavigationTopBarLuminanceMode.Live(Unit),
+            themeMode = ResolvedThemeMode.Light,
             modifier = Modifier,
           )
         }
@@ -92,8 +201,185 @@ class TypieTopBarProgressiveBlurEffectDesktopTest {
 
     assertTrue(
       maximumStep <= MaximumContinuousLuminanceStep,
-      "progressive blur has a luminance step of $maximumStep at row $maximumRow " +
+      "progressive fade has a luminance step of $maximumStep at row $maximumRow " +
         "(height=${pixels.height}, largest=[$largestSteps])",
     )
   }
+
+  @Test
+  fun navigationTopBarBlurCrossfadesOverTheLiveBackdrop() = runComposeUiTest {
+    val blurEnabled = mutableStateOf(false)
+
+    setContent {
+      val hazeState = rememberHazeState()
+      val topBarState = remember { TopBarState().apply { animatedAlpha = 1f } }
+
+      CompositionLocalProvider(
+        LocalThemeMode provides ResolvedThemeMode.Light,
+        LocalTopBarAnimationSource provides topBarState,
+      ) {
+        Box(Modifier.size(width = 160.dp, height = 120.dp)) {
+          Canvas(Modifier.fillMaxSize().hazeSource(hazeState)) {
+            drawRect(Color.Black)
+            for (x in 0 until size.width.toInt() step 2) {
+              drawRect(
+                color = Color.White,
+                topLeft = Offset(x = x.toFloat(), y = 0f),
+                size = Size(width = 1f, height = size.height),
+              )
+            }
+          }
+          NavigationTopBarBackdrop(
+            hazeState = hazeState,
+            style = {
+              NavigationTopBarBackdropStyle(background = Color.Transparent, presence = 1f)
+            },
+            blurEnabled = blurEnabled.value,
+            luminanceMode =
+              NavigationTopBarLuminanceMode.Frozen(NavigationTopBarContentLuminance.Bright),
+            themeMode = ResolvedThemeMode.Light,
+          )
+        }
+      }
+    }
+    waitForIdle()
+
+    val clearPixels = onNodeWithTag(NavigationTopBarBackdropTestTag).captureToImage().toPixelMap()
+    val clearContrast = clearPixels.averageHorizontalLuminanceDelta(y = 4)
+
+    mainClock.autoAdvance = false
+    blurEnabled.value = true
+    mainClock.advanceTimeByFrame()
+    mainClock.advanceTimeBy(32)
+    waitForIdle()
+
+    val midpointPixels =
+      onNodeWithTag(NavigationTopBarBackdropTestTag).captureToImage().toPixelMap()
+    val midpointContrast = midpointPixels.averageHorizontalLuminanceDelta(y = 4)
+
+    mainClock.advanceTimeBy(250)
+    waitForIdle()
+
+    val blurredPixels = onNodeWithTag(NavigationTopBarBackdropTestTag).captureToImage().toPixelMap()
+    val blurredContrast = blurredPixels.averageHorizontalLuminanceDelta(y = 4)
+
+    assertTrue(
+      midpointContrast < clearContrast * 0.9f && midpointContrast > blurredContrast * 1.1f,
+      "midpoint contrast=$midpointContrast, blurred contrast=$blurredContrast, " +
+        "clear contrast=$clearContrast",
+    )
+    assertTrue(
+      blurredContrast < clearContrast * 0.5f,
+      "blurred contrast=$blurredContrast, clear contrast=$clearContrast",
+    )
+  }
+
+  @Test
+  fun darkTopBarFadeBecomesLighterOverBrightContent() = runComposeUiTest {
+    val blackOffsetY = mutableIntStateOf(0)
+    val sampleRequests = NavigationTopBarSampleRequests()
+    var controlHeightPx = 0
+
+    setContent {
+      val hazeState = rememberHazeState()
+      val topBarState = remember { TopBarState().apply { animatedAlpha = 1f } }
+
+      CompositionLocalProvider(
+        LocalThemeMode provides ResolvedThemeMode.Dark,
+        LocalTopBarAnimationSource provides topBarState,
+      ) {
+        val topPadding = TopBarDefaults.topPadding()
+        val density = LocalDensity.current
+        val sampleTopPx = with(density) { topPadding.roundToPx() }
+        controlHeightPx = with(density) { TopBarDefaults.Height.roundToPx() }
+        Box(Modifier.size(width = 160.dp, height = 120.dp)) {
+          Box(Modifier.fillMaxSize().hazeSource(hazeState)) {
+            Box(Modifier.fillMaxSize().background(Color.White))
+            Box(
+              Modifier.offset { IntOffset(x = 0, y = sampleTopPx + blackOffsetY.intValue) }
+                .fillMaxWidth()
+                .height(TopBarDefaults.Height)
+                .background(Color.Black)
+            )
+          }
+          NavigationTopBarBackdrop(
+            hazeState = hazeState,
+            style = { NavigationTopBarBackdropStyle(background = Color.Black, presence = 1f) },
+            blurEnabled = false,
+            luminanceMode = NavigationTopBarLuminanceMode.Live(Unit),
+            themeMode = ResolvedThemeMode.Dark,
+            sampleRequests = sampleRequests.flow,
+          )
+        }
+      }
+    }
+    waitForIdle()
+
+    val darkPixels = onNodeWithTag(NavigationTopBarBackdropTestTag).captureToImage().toPixelMap()
+    val sampleY = (darkPixels.height - 14).coerceAtLeast(0)
+    val darkFadeLuminance = darkPixels[darkPixels.width / 2, sampleY].luminance()
+
+    blackOffsetY.intValue = -controlHeightPx
+    waitForIdle()
+    sampleRequests.requestSample()
+    waitUntil(timeoutMillis = 5_000) {
+      val pixels = onNodeWithTag(NavigationTopBarBackdropTestTag).captureToImage().toPixelMap()
+      pixels[pixels.width / 2, sampleY].luminance() > darkFadeLuminance + 0.2f
+    }
+  }
+
+  @Test
+  fun adaptiveFadeResamplesAfterThemeChange() = runComposeUiTest {
+    val themeMode = mutableStateOf(ResolvedThemeMode.Dark)
+    val sourceColor = mutableStateOf(Color.White)
+    val sampleRequests = NavigationTopBarSampleRequests()
+
+    setContent {
+      val hazeState = rememberHazeState()
+      val topBarState = remember { TopBarState().apply { animatedAlpha = 1f } }
+
+      CompositionLocalProvider(
+        LocalThemeMode provides themeMode.value,
+        LocalTopBarAnimationSource provides topBarState,
+      ) {
+        Box(Modifier.size(width = 160.dp, height = 120.dp)) {
+          Box(Modifier.fillMaxSize().hazeSource(hazeState)) {
+            Box(Modifier.fillMaxSize().background(sourceColor.value))
+          }
+          NavigationTopBarBackdrop(
+            hazeState = hazeState,
+            style = {
+              NavigationTopBarBackdropStyle(
+                background =
+                  if (themeMode.value == ResolvedThemeMode.Light) Color.White else Color.Black,
+                presence = 1f,
+              )
+            },
+            blurEnabled = false,
+            luminanceMode = NavigationTopBarLuminanceMode.Live(Unit),
+            themeMode = themeMode.value,
+            sampleRequests = sampleRequests.flow,
+          )
+        }
+      }
+    }
+    waitForIdle()
+
+    runOnIdle {
+      themeMode.value = ResolvedThemeMode.Light
+      sourceColor.value = Color.Black
+    }
+    sampleRequests.requestSample()
+
+    waitUntil(timeoutMillis = 5_000) {
+      val pixels = onNodeWithTag(NavigationTopBarBackdropTestTag).captureToImage().toPixelMap()
+      pixels[pixels.width / 2, 4].luminance() < 0.2f
+    }
+  }
+}
+
+private fun androidx.compose.ui.graphics.PixelMap.averageHorizontalLuminanceDelta(y: Int): Float {
+  val deltas =
+    (0 until width - 1).map { x -> abs(this[x, y].luminance() - this[x + 1, y].luminance()) }
+  return deltas.average().toFloat()
 }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/topbar/EditorScreenTopBarDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/topbar/EditorScreenTopBarDesktopTest.kt
@@ -99,6 +99,13 @@ class EditorScreenTopBarDesktopTest {
   }
 
   @Test
+  fun editorTopBarDisablesBackdropBlur() = runComposeUiTest {
+    val topBarState = setTopBarContent(editing = false)
+
+    assertFalse(topBarState.backdropBlurEnabled)
+  }
+
+  @Test
   fun debugToolsAppearOnlyWhenDebugMetadataIsSupplied() = runComposeUiTest {
     val actions = mutableStateListOf<EditorToolbarToolAction>()
     val overlayState = PopoverOverlayState()
@@ -161,10 +168,12 @@ class EditorScreenTopBarDesktopTest {
     debugOverlays: EditorToolbarDebugOverlays? = null,
     onToolAction: (EditorToolbarToolAction) -> Unit = {},
     onEnterReadingMode: suspend () -> Unit = {},
-  ) {
+  ): TopBarState {
+    lateinit var capturedTopBarState: TopBarState
     setContent {
       TopBarTestTheme {
         val topBarState = remember { TopBarState() }
+        capturedTopBarState = topBarState
         CompositionLocalProvider(
           Nav provides Navigator(Route.Home),
           LocalRoute provides Route.Editor("document-id"),
@@ -188,6 +197,7 @@ class EditorScreenTopBarDesktopTest {
       }
     }
     waitForIdle()
+    return capturedTopBarState
   }
 
   @Composable

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/ScreenDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/ScreenDesktopTest.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import co.typie.navigation.NavigationStack
+import co.typie.navigation.NavigationStackTestHost
 import co.typie.navigation.Navigator
 import co.typie.route.Route
 import co.typie.ui.component.dialog.Dialog
@@ -76,7 +76,7 @@ class ScreenDesktopTest {
       expectedTopPadding =
         TopBarDefaults.topPadding() +
           TopBarDefaults.Height +
-          TopBarDefaults.BlurFadeHeight +
+          TopBarDefaults.BackdropFadeHeight +
           TopBarDefaults.ContentTopSpacing
       CompositionLocalProvider(
         LocalDialog provides Dialog(),
@@ -161,7 +161,7 @@ class ScreenDesktopTest {
 
     setContent {
       CompositionLocalProvider(LocalDialog provides Dialog()) {
-        NavigationStack(
+        NavigationStackTestHost(
           navigator = navigator,
           topBarState = TopBarState(),
           modifier = Modifier.size(width = 320.dp, height = 640.dp),

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/topbar/TopBarCenterPaletteDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/topbar/TopBarCenterPaletteDesktopTest.kt
@@ -1,0 +1,142 @@
+package co.typie.ui.component.topbar
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import co.typie.navigation.NavigationScaffold
+import co.typie.navigation.NavigationStack
+import co.typie.navigation.Navigator
+import co.typie.navigation.PublishNavigationTopBarBackdropStyle
+import co.typie.route.Route
+import co.typie.ui.theme.AppTheme
+import co.typie.ui.theme.DarkColors
+import co.typie.ui.theme.LightColors
+import co.typie.ui.theme.LocalAppColors
+import co.typie.ui.theme.LocalThemeMode
+import co.typie.ui.theme.ResolvedThemeMode
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class TopBarCenterPaletteDesktopTest {
+  @Test
+  fun navigationStackUsesTheAmbientDarkThemeForBrightContent() = runComposeUiTest {
+    val navigator = Navigator(Route.Home)
+    val topBarState = TopBarState()
+
+    setContent {
+      CompositionLocalProvider(
+        LocalAppColors provides DarkColors,
+        LocalThemeMode provides ResolvedThemeMode.Dark,
+      ) {
+        NavigationScaffold(navigator = navigator, topBarState = topBarState) {
+          NavigationStack(navigator = navigator, topBarState = topBarState) {
+            Box(Modifier.fillMaxSize().background(Color.White))
+            PublishNavigationTopBarBackdropStyle(Color.White)
+            ProvideTopBar(center = { PaletteSample("dark-theme-center") })
+          }
+        }
+      }
+    }
+
+    waitUntil(timeoutMillis = 5_000) {
+      topBarState.adaptiveForegroundStyle == TopBarForegroundStyle.Light
+    }
+  }
+
+  @Test
+  fun lightThemeDarkNavigationSurfaceInvertsTheScaffoldCenterSlot() = runComposeUiTest {
+    val navigator = Navigator(Route.Home)
+    val sourceColor = mutableStateOf(Color.Black)
+    val topBarState = TopBarState()
+
+    setContent {
+      CompositionLocalProvider(
+        LocalAppColors provides LightColors,
+        LocalThemeMode provides ResolvedThemeMode.Light,
+      ) {
+        NavigationScaffold(navigator = navigator, topBarState = topBarState) {
+          NavigationStack(navigator = navigator, topBarState = topBarState) {
+            Box(Modifier.fillMaxSize().background(sourceColor.value))
+            PublishNavigationTopBarBackdropStyle(sourceColor.value)
+            ProvideTopBar(
+              leading = { PaletteSample("integrated-leading") },
+              center = { PaletteSample("integrated-center") },
+              trailing = { PaletteSample("integrated-trailing") },
+            )
+          }
+        }
+      }
+    }
+
+    waitUntil(timeoutMillis = 5_000) { onNodeWithTag("integrated-center").centerLuminance() > 0.8f }
+    assertTrue(onNodeWithTag("integrated-leading").centerLuminance() < 0.2f)
+    assertTrue(onNodeWithTag("integrated-trailing").centerLuminance() < 0.2f)
+
+    sourceColor.value = Color.White
+    waitUntil(timeoutMillis = 5_000) {
+      topBarState.adaptiveForegroundStyle == TopBarForegroundStyle.Dark
+    }
+    waitUntil(timeoutMillis = 5_000) { onNodeWithTag("integrated-center").centerLuminance() < 0.2f }
+    assertTrue(onNodeWithTag("integrated-leading").centerLuminance() < 0.2f)
+    assertTrue(onNodeWithTag("integrated-trailing").centerLuminance() < 0.2f)
+  }
+
+  @Test
+  fun themeSurfaceCenterKeepsTheAmbientPalette() = runComposeUiTest {
+    setContent {
+      val state = remember {
+        TopBarState().apply {
+          adaptiveForegroundStyle = TopBarForegroundStyle.Light
+          setLeading("leading", { PaletteSample("leading") })
+          setCenter(
+            "center",
+            { PaletteSample("center") },
+            appearance = TopBarCenterAppearance.ThemeSurface,
+          )
+          setTrailing("trailing", { PaletteSample("trailing") })
+        }
+      }
+
+      CompositionLocalProvider(
+        LocalAppColors provides LightColors,
+        LocalThemeMode provides ResolvedThemeMode.Light,
+      ) {
+        Box(Modifier.size(width = 320.dp, height = 100.dp)) { TopBar(state) }
+      }
+    }
+    waitForIdle()
+
+    val leadingLuminance = onNodeWithTag("leading").centerLuminance()
+    val centerLuminance = onNodeWithTag("center").centerLuminance()
+    val trailingLuminance = onNodeWithTag("trailing").centerLuminance()
+
+    assertTrue(centerLuminance < 0.2f, "center luminance=$centerLuminance")
+    assertTrue(leadingLuminance < 0.2f, "leading luminance=$leadingLuminance")
+    assertTrue(trailingLuminance < 0.2f, "trailing luminance=$trailingLuminance")
+  }
+}
+
+@androidx.compose.runtime.Composable
+private fun PaletteSample(tag: String) {
+  Box(Modifier.size(16.dp).testTag(tag).background(AppTheme.colors.textDefault))
+}
+
+private fun androidx.compose.ui.test.SemanticsNodeInteraction.centerLuminance(): Float {
+  val pixels = captureToImage().toPixelMap()
+  return pixels[pixels.width / 2, pixels.height / 2].luminance()
+}

--- a/apps/mobile/compose/src/iosMain/kotlin/co/typie/MainViewController.kt
+++ b/apps/mobile/compose/src/iosMain/kotlin/co/typie/MainViewController.kt
@@ -3,10 +3,20 @@ package co.typie
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.uikit.OnFocusBehavior
 import androidx.compose.ui.window.ComposeUIViewController
+import co.typie.navigation.LocalNavigationStatusBarAppearanceController
+import co.typie.navigation.NavigationStatusBarAppearanceController
 import co.typie.ui.utils.LocalNativeShortcutRegistry
 import co.typie.ui.utils.NativeShortcutRegistry
 
-fun MainViewController(shortcutRegistry: NativeShortcutRegistry) =
+fun MainViewController(
+  shortcutRegistry: NativeShortcutRegistry,
+  statusBarAppearanceController: NavigationStatusBarAppearanceController,
+) =
   ComposeUIViewController(configure = { onFocusBehavior = OnFocusBehavior.DoNothing }) {
-    CompositionLocalProvider(LocalNativeShortcutRegistry provides shortcutRegistry) { App() }
+    CompositionLocalProvider(
+      LocalNativeShortcutRegistry provides shortcutRegistry,
+      LocalNavigationStatusBarAppearanceController provides statusBarAppearanceController,
+    ) {
+      App()
+    }
   }

--- a/apps/mobile/compose/src/iosMain/kotlin/co/typie/navigation/NavigationStatusBarAppearance.ios.kt
+++ b/apps/mobile/compose/src/iosMain/kotlin/co/typie/navigation/NavigationStatusBarAppearance.ios.kt
@@ -1,0 +1,41 @@
+package co.typie.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.uikit.LocalUIViewController
+
+class NavigationStatusBarAppearanceController {
+  private var lightForeground = false
+
+  val useLightForeground: Boolean
+    get() = lightForeground
+
+  internal fun update(useLightForeground: Boolean) {
+    lightForeground = useLightForeground
+  }
+}
+
+internal val LocalNavigationStatusBarAppearanceController =
+  staticCompositionLocalOf<NavigationStatusBarAppearanceController?> { null }
+
+@Composable
+internal actual fun ApplyPlatformNavigationStatusBarAppearance(
+  useLightForeground: Boolean,
+  defaultUseLightForeground: Boolean,
+) {
+  val controller = LocalNavigationStatusBarAppearanceController.current ?: return
+  val viewController = LocalUIViewController.current
+
+  SideEffect {
+    controller.update(useLightForeground)
+    (viewController.parentViewController ?: viewController).setNeedsStatusBarAppearanceUpdate()
+  }
+  DisposableEffect(controller, viewController, defaultUseLightForeground) {
+    onDispose {
+      controller.update(defaultUseLightForeground)
+      (viewController.parentViewController ?: viewController).setNeedsStatusBarAppearanceUpdate()
+    }
+  }
+}

--- a/apps/mobile/ios/App/SceneDelegate.swift
+++ b/apps/mobile/ios/App/SceneDelegate.swift
@@ -18,13 +18,16 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     let window = UIWindow(windowScene: windowScene)
     let shortcutRegistry = NativeShortcutRegistry()
+    let statusBarAppearanceController = NavigationStatusBarAppearanceController()
     let composeController = MainViewControllerKt.MainViewController(
-      shortcutRegistry: shortcutRegistry
+      shortcutRegistry: shortcutRegistry,
+      statusBarAppearanceController: statusBarAppearanceController
     )
     composeController.view.backgroundColor = .systemBackground
     let controller = ShortcutHostingViewController(
       content: composeController,
-      shortcutRegistry: shortcutRegistry
+      shortcutRegistry: shortcutRegistry,
+      statusBarAppearanceController: statusBarAppearanceController
     )
     window.backgroundColor = .systemBackground
     window.rootViewController = controller

--- a/apps/mobile/ios/App/ShortcutHostingViewController.swift
+++ b/apps/mobile/ios/App/ShortcutHostingViewController.swift
@@ -4,10 +4,16 @@ import UIKit
 final class ShortcutHostingViewController: UIViewController {
   private let content: UIViewController
   private let shortcutRegistry: NativeShortcutRegistry
+  private let statusBarAppearanceController: NavigationStatusBarAppearanceController
 
-  init(content: UIViewController, shortcutRegistry: NativeShortcutRegistry) {
+  init(
+    content: UIViewController,
+    shortcutRegistry: NativeShortcutRegistry,
+    statusBarAppearanceController: NavigationStatusBarAppearanceController
+  ) {
     self.content = content
     self.shortcutRegistry = shortcutRegistry
+    self.statusBarAppearanceController = statusBarAppearanceController
     super.init(nibName: nil, bundle: nil)
   }
 
@@ -25,8 +31,8 @@ final class ShortcutHostingViewController: UIViewController {
     content.didMove(toParent: self)
   }
 
-  override var childForStatusBarStyle: UIViewController? {
-    content
+  override var preferredStatusBarStyle: UIStatusBarStyle {
+    statusBarAppearanceController.useLightForeground ? .lightContent : .darkContent
   }
 
   override var childForStatusBarHidden: UIViewController? {


### PR DESCRIPTION
## 변경 사항

- 상단 바 아래의 실제 콘텐츠 밝기를 분석해 기존 gradient 형태는 유지하면서 페이드 농도를 자동으로 조정합니다.
- 라이트 모드에서 어두운 콘텐츠가 지나가면 어두운 페이드와 밝은 상단 바 center foreground·status bar를 사용합니다.
- 다크 모드에서는 콘텐츠 밝기에 따라 페이드 농도를 두 단계로 조정합니다.
- 배경이 없는 center title은 adaptive foreground를 따르고, 검색창·맞춤법 검사·AI 피드백처럼 자체 surface가 있는 control은 기존 테마 palette를 유지합니다.
- 상단 바의 leading/trailing 버튼 색상은 기존 테마를 유지합니다.
- 에디터에서만 상단 바 blur를 제거하고, 다른 화면에서는 기존 blur를 유지합니다. 화면 전환에 따른 blur 변화도 애니메이션합니다.
- 테마 변경 시 기존 밝기 판정을 초기화하고 새 테마를 기준으로 다시 분석합니다.
- JVM Desktop의 status bar도 동일한 adaptive appearance를 표시합니다.

## 밝기 분석

- 전체 화면 대신 GPU에서 64×16으로 축소한 분석 버퍼만 CPU로 읽습니다.
- 4×16 공간 중앙값과 가로 중앙 영역 가중치를 사용해 텍스트·스트라이프 같은 고주파 패턴의 영향을 줄였습니다.
- 밝기 판정에는 hysteresis와 180ms 안정화 시간을 적용해 경계 영역에서 반복적으로 전환되는 현상을 줄였습니다.
- 샘플링은 최대 10Hz로 제한하며, 스크롤뿐 아니라 콘텐츠가 다시 그려지는 경우에도 갱신합니다. 별도의 상시 polling은 사용하지 않습니다.

## 화면 전환 및 상태 관리

- 화면별로 실제 측정이 완료된 밝기 결과만 cache합니다.
- 화면 전환이 확정되면 대상 화면의 측정된 appearance를 사용하고, 아직 측정되지 않은 화면은 현재 테마에 안전한 기본값으로 시작한 뒤 실제 pixel 결과로 갱신합니다.
- route나 테마가 바뀐 뒤 늦게 도착한 GPU readback은 세션 token으로 폐기해 이전 화면의 결과가 새 화면을 덮지 않도록 했습니다.
- frozen transition 상태는 화면 표시 용도로만 사용하며 대상 화면의 실측 결과로 cache하지 않습니다.

## Status bar

- status bar foreground는 확정된 adaptive luminance 상태를 별도 지연 없이 반영합니다.
- 상단 바가 나타나거나 사라지는 중에는 alpha 0.65/0.35 hysteresis를 적용해 foreground가 경계에서 반복 전환되지 않도록 했습니다.
- Android와 iOS의 status bar appearance는 navigation root에서 관리합니다.
- iOS에서는 deprecated Compose delegate 대신 scene별 부모 view controller가 status bar appearance를 소유합니다.
- JVM Desktop 구현은 공용 navigation 정책과 분리된 desktop 전용 controller를 통해 status bar 모형에 appearance를 전달합니다.