### PR TITLE
웹 에디터 예외를 terminal failure 경로로 연결

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorView.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorView.kt
@@ -121,7 +121,7 @@ internal fun EditorView(
         throw e
       } catch (e: Throwable) {
         if (currentLoad === load && !load.isClosed) {
-          runtime.reportError(e)
+          runtime.fail(e)
         }
       }
     }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/preview/EditorPreview.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/preview/EditorPreview.kt
@@ -269,7 +269,7 @@ private fun EditorPreviewContent(
     EditorSurfaceHost(
       editor = editor,
       scaleFactor = density.density.toDouble() * renderZoom.toDouble(),
-      onFailure = { error -> runtime.reportError(editor, error) },
+      onFailure = { error -> runtime.fail(editor, error) },
     )
   }
 
@@ -298,7 +298,7 @@ private fun EditorPreviewContent(
               viewport = viewport,
               themeVariant = themeVariant,
               scope = editorScope,
-              onError = { activeEditor, error -> runtime.reportError(activeEditor, error) },
+              onError = { activeEditor, error -> runtime.fail(activeEditor, error) },
             )
           EditorPreviewSource.Generated ->
             Editor.createFromDoc(
@@ -306,7 +306,7 @@ private fun EditorPreviewContent(
               viewport = viewport,
               themeVariant = themeVariant,
               scope = editorScope,
-              onError = { activeEditor, error -> runtime.reportError(activeEditor, error) },
+              onError = { activeEditor, error -> runtime.fail(activeEditor, error) },
             )
           EditorPreviewSource.AttachedEditor -> return@LaunchedEffect
         }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/runtime/EditorRuntime.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/runtime/EditorRuntime.kt
@@ -29,7 +29,7 @@ class EditorRuntime(private val uiScope: CoroutineScope) {
   }
 
   private var attachment by mutableStateOf<Attachment?>(null)
-  private var failure by mutableStateOf<Failure?>(null)
+  private var failureState by mutableStateOf<Failure?>(null)
 
   val editor: Editor?
     get() = attachment?.editor
@@ -37,19 +37,19 @@ class EditorRuntime(private val uiScope: CoroutineScope) {
   internal val session: DocumentEditingSession?
     get() = (attachment as? DocumentSession)?.session
 
-  val error: Throwable?
-    get() = failure?.error
+  val failure: Throwable?
+    get() = failureState?.error
 
   // The editor is already disposed; retain it only to keep its last committed surfaces composed
-  // until the error is cleared.
+  // until the failure is cleared.
   internal val failedEditor: Editor?
-    get() = failure?.editor
+    get() = failureState?.editor
 
   val canCreateEditor: Boolean
-    get() = editor == null && error == null
+    get() = editor == null && failure == null
 
   fun attach(editor: Editor) {
-    if (error != null) {
+    if (failure != null) {
       editor.dispose()
       return
     }
@@ -61,7 +61,7 @@ class EditorRuntime(private val uiScope: CoroutineScope) {
   }
 
   internal fun attach(session: DocumentEditingSession) {
-    if (error != null) {
+    if (failure != null) {
       session.stop()
       session.editor.dispose()
       return
@@ -93,14 +93,14 @@ class EditorRuntime(private val uiScope: CoroutineScope) {
     dispose(current)
   }
 
-  fun reportError(error: Throwable) {
+  fun fail(error: Throwable) {
     if (error is CancellationException) {
       throw error
     }
-    uiScope.launch { fail(error) }
+    uiScope.launch { setFailed(error) }
   }
 
-  fun reportError(editor: Editor, error: Throwable) {
+  fun fail(editor: Editor, error: Throwable) {
     if (error is CancellationException) {
       throw error
     }
@@ -108,11 +108,11 @@ class EditorRuntime(private val uiScope: CoroutineScope) {
       if (this@EditorRuntime.editor !== editor) {
         return@launch
       }
-      fail(error)
+      setFailed(error)
     }
   }
 
-  internal fun reportError(session: DocumentEditingSession, error: Throwable) {
+  internal fun fail(session: DocumentEditingSession, error: Throwable) {
     if (error is CancellationException) {
       throw error
     }
@@ -120,19 +120,19 @@ class EditorRuntime(private val uiScope: CoroutineScope) {
       if (this@EditorRuntime.session !== session) {
         return@launch
       }
-      fail(error)
+      setFailed(error)
     }
   }
 
-  private fun fail(error: Throwable) {
-    if (this.error != null) {
+  private fun setFailed(error: Throwable) {
+    if (failure != null) {
       return
     }
 
     val detail = error.cause?.let { "$error; cause=$it" } ?: error.toString()
     Logger.e(error) { "Editor failed: $detail" }
     Sentry.captureException(error)
-    failure = Failure(error = error, editor = editor)
+    failureState = Failure(error = error, editor = editor)
     clear()
   }
 
@@ -141,8 +141,8 @@ class EditorRuntime(private val uiScope: CoroutineScope) {
     attachment?.editor?.dispose()
   }
 
-  fun clearError() {
-    failure = null
+  fun clearFailure() {
+    failureState = null
   }
 
   fun focus(): Boolean = editor?.focus() == true

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/document/bodysettings/DocumentBodySettingsScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/document/bodysettings/DocumentBodySettingsScreen.kt
@@ -263,7 +263,7 @@ fun DocumentBodySettingsScreen(entityId: String) {
           } catch (e: Throwable) {
             if (reloadRequest === request && settingsRuntime.session === request.session) {
               finishReloadRequest(request)
-              settingsRuntime.reportError(request.session, e)
+              settingsRuntime.fail(request.session, e)
             }
           }
         }
@@ -360,10 +360,10 @@ fun DocumentBodySettingsScreen(entityId: String) {
       }
     }
 
-    LaunchedEffect(settingsRuntime.error) {
-      settingsRuntime.error ?: return@LaunchedEffect
+    LaunchedEffect(settingsRuntime.failure) {
+      settingsRuntime.failure ?: return@LaunchedEffect
       dialog.error(nav) {
-        settingsRuntime.clearError()
+        settingsRuntime.clearFailure()
         load = null
         SyncWs.retryDocument(document.id)
       }
@@ -391,7 +391,7 @@ fun DocumentBodySettingsScreen(entityId: String) {
             themeVariant = editorThemeVariant,
             onError = { activeEditor, error ->
               if (settingsRuntime.editor === activeEditor) {
-                settingsRuntime.reportError(activeEditor, error)
+                settingsRuntime.fail(activeEditor, error)
               } else {
                 bootstrapFailure.compareAndSet(expectedValue = null, newValue = error)
               }
@@ -474,7 +474,7 @@ fun DocumentBodySettingsScreen(entityId: String) {
       } catch (e: CancellationException) {
         throw e
       } catch (e: Throwable) {
-        if (load === readyLoad) settingsRuntime.reportError(e)
+        if (load === readyLoad) settingsRuntime.fail(e)
       } finally {
         if (liveLoad === readyLoad) liveLoad = null
         val closingSession = session

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -333,11 +333,11 @@ fun EditorScreen(entityId: String) {
       assetHydrator.onQueryRefresh(generation = assetQueryGeneration, assets = assets)
     }
   }
-  LaunchedEffect(runtime.error) {
-    runtime.error ?: return@LaunchedEffect
+  LaunchedEffect(runtime.failure) {
+    runtime.failure ?: return@LaunchedEffect
     dialog.error(nav) {
       val failedLoad = editorLoadState
-      runtime.clearError()
+      runtime.clearFailure()
       editorLoadState = null
       if (syncActiveLoadState === failedLoad) syncActiveLoadState = null
       pendingChangesets.clear()
@@ -740,7 +740,7 @@ fun EditorScreen(entityId: String) {
         } catch (e: Throwable) {
           if (reloadRequest === request && runtime.session === request.session) {
             finishReloadRequest(request)
-            runtime.reportError(request.session, e)
+            runtime.fail(request.session, e)
           }
         }
       }
@@ -906,7 +906,7 @@ fun EditorScreen(entityId: String) {
                   pending = pending,
                   parentScope = scope,
                   onEditorError = { _, error ->
-                    scope.launch { if (editorLoadState === nextLoad) runtime.reportError(error) }
+                    scope.launch { if (editorLoadState === nextLoad) runtime.fail(error) }
                   },
                 )
 
@@ -924,7 +924,7 @@ fun EditorScreen(entityId: String) {
             } catch (e: CancellationException) {
               throw e
             } catch (e: Throwable) {
-              runtime.reportError(e)
+              runtime.fail(e)
             } finally {
               if (!installed) {
                 nextLoad?.close() ?: runCatching { outcome.handle.abort() }
@@ -933,7 +933,7 @@ fun EditorScreen(entityId: String) {
           }
           is DocumentGraphLoaderEvent.Failed -> {
             if (editorLoadState != null) {
-              runtime.reportError(SyncWsException(outcome.code, permanent = true))
+              runtime.fail(SyncWsException(outcome.code, permanent = true))
             } else {
               loaderFailedCode = outcome.code
             }
@@ -1617,10 +1617,7 @@ fun EditorScreen(entityId: String) {
     LaunchedEffect(editor, publishedRevision, editorGeometryValid) {
       val attachedEditor = editor ?: return@LaunchedEffect
       if (editorGeometryInvalid && runtime.editor === attachedEditor) {
-        runtime.reportError(
-          attachedEditor,
-          IllegalStateException("Attached editor has invalid geometry"),
-        )
+        runtime.fail(attachedEditor, IllegalStateException("Attached editor has invalid geometry"))
       }
     }
     LaunchedEffect(editor, editorReady) {
@@ -1759,7 +1756,7 @@ fun EditorScreen(entityId: String) {
           scaleFactor = density.toDouble() * zoomController.renderZoom.toDouble(),
           onDeactivate = bringIntoViewRequests::cancel,
           onPublicationFailure = bringIntoViewRequests::discardFailedForVersion,
-          onFailure = { error -> runtime.reportError(activeEditor, error) },
+          onFailure = { error -> runtime.fail(activeEditor, error) },
         )
       }
       EditorScreenLayout(
@@ -1854,7 +1851,7 @@ fun EditorScreen(entityId: String) {
           }
         },
         viewportSurfaceOverlay = {
-          if (!editorReady && runtime.error == null) {
+          if (!editorReady && runtime.failure == null) {
             EditorLoadingSkeleton(
               layoutSpec = layoutSpec,
               topInset = topInset,

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/runtime/EditorRuntimeTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/runtime/EditorRuntimeTest.kt
@@ -93,40 +93,40 @@ class EditorRuntimeTest {
   }
 
   @Test
-  fun staleSessionErrorCannotClearReplacement() = runTest {
+  fun staleSessionFailureCannotClearReplacement() = runTest {
     val first = createSession(Editor(FakeFfiEditor(), this, StandardTestDispatcher(testScheduler)))
     val second = createSession(Editor(FakeFfiEditor(), this, StandardTestDispatcher(testScheduler)))
     val runtime = EditorRuntime(uiScope = this)
 
     runtime.attach(first)
-    runtime.reportError(first, IllegalStateException("stale reload failure"))
+    runtime.fail(first, IllegalStateException("stale reload failure"))
     runtime.attach(second)
     runCurrent()
 
     assertSame(second.editor, runtime.editor)
     assertSame(second, runtime.session)
-    assertNull(runtime.error)
+    assertNull(runtime.failure)
   }
 
   @Test
-  fun fatalErrorRetainsEditorWithoutKeepingItActive() = runTest {
+  fun fatalFailureRetainsEditorWithoutKeepingItActive() = runTest {
     val editor = Editor(FakeFfiEditor(), this, StandardTestDispatcher(testScheduler))
     val session = createSession(editor)
     val runtime = EditorRuntime(uiScope = this)
     val failure = IllegalStateException("fatal editor failure")
 
     runtime.attach(session)
-    runtime.reportError(session, failure)
+    runtime.fail(session, failure)
     runCurrent()
 
-    assertSame(failure, runtime.error)
+    assertSame(failure, runtime.failure)
     assertNull(runtime.editor)
     assertNull(runtime.session)
     assertSame(editor, runtime.failedEditor)
 
-    runtime.clearError()
+    runtime.clearFailure()
 
-    assertNull(runtime.error)
+    assertNull(runtime.failure)
     assertNull(runtime.failedEditor)
   }
 }

--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -231,7 +231,6 @@ export class EditorContext {
   attachmentDropTargetNodeId = $state<string | null>(null);
   findReplaceOpen = $state(false);
   linkEditorOpen = $state(false);
-  reportEditorFailure: ((error: unknown) => void) | undefined;
 }
 
 const [getEditorContext, setEditorContext] = createContext<EditorContext>();
@@ -423,7 +422,7 @@ export class Editor {
       const result = this.#invokeCore((core) => core.tick());
       if (result) publicEvents = this.#installTick(result);
     } catch (err) {
-      this.#fail(err);
+      this.fail(err);
     } finally {
       this.#transitionActive = false;
     }
@@ -519,7 +518,7 @@ export class Editor {
     try {
       return operation(this.#wasm);
     } catch (err) {
-      if (!this.#creationActive) this.#fail(err);
+      if (!this.#creationActive) this.fail(err);
       throw err;
     }
   }
@@ -824,36 +823,6 @@ export class Editor {
       waiter.reject(new DOMException('The editor surface target must be replaced.', 'OperationError'));
     }
     this.#publicationWaiters.clear();
-  }
-
-  #fail(error: unknown): void {
-    if (this.terminal) return;
-    const reason = error ?? new Error('Editor operation failed');
-    this.#failure = reason;
-    this.#failed = true;
-    // eslint-disable-next-line svelte/prefer-svelte-reactivity -- immutable empty snapshot
-    this.surfacePageRequirements = new Set();
-    this.#stopRuntime();
-    unregister(this);
-    for (const receipt of this.#receipts.values()) {
-      try {
-        receipt.request.discard();
-        receipt.reject(reason);
-      } catch {
-        // Failure cleanup must continue even if an internal receipt hook throws.
-      }
-    }
-    this.#receipts.clear();
-    for (const waiter of this.#appliedWaiters) waiter.reject(reason);
-    this.#appliedWaiters.clear();
-    for (const waiter of this.#publicationWaiters) {
-      if (waiter.signal && waiter.onAbort) waiter.signal.removeEventListener('abort', waiter.onAbort);
-      waiter.reject(reason);
-    }
-    this.#publicationWaiters.clear();
-    this.#listeners.clear();
-    this.#contextMenuContributors.clear();
-    this.#discardCore();
   }
 
   #applyViewport(viewport: Viewport): void {
@@ -1729,7 +1698,7 @@ export class Editor {
       if (!update) throw new Error(`tickThrough omitted request outcome ${requestId.value}`);
     } catch (err) {
       request?.discard();
-      if (admitted && !this.#creationActive) this.#fail(err);
+      if (admitted && !this.#creationActive) this.fail(err);
       throw err;
     } finally {
       this.#transitionActive = false;
@@ -1973,8 +1942,38 @@ export class Editor {
     });
   }
 
+  fail(error: unknown): void {
+    if (this.terminal) return;
+    const reason = error ?? new Error('Editor operation failed');
+    this.#failure = reason;
+    this.#failed = true;
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity -- immutable empty snapshot
+    this.surfacePageRequirements = new Set();
+    this.#stopRuntime();
+    unregister(this);
+    for (const receipt of this.#receipts.values()) {
+      try {
+        receipt.request.discard();
+        receipt.reject(reason);
+      } catch {
+        // Failure cleanup must continue even if an internal receipt hook throws.
+      }
+    }
+    this.#receipts.clear();
+    for (const waiter of this.#appliedWaiters) waiter.reject(reason);
+    this.#appliedWaiters.clear();
+    for (const waiter of this.#publicationWaiters) {
+      if (waiter.signal && waiter.onAbort) waiter.signal.removeEventListener('abort', waiter.onAbort);
+      waiter.reject(reason);
+    }
+    this.#publicationWaiters.clear();
+    this.#listeners.clear();
+    this.#contextMenuContributors.clear();
+    this.#discardCore();
+  }
+
   surfaceReplacementFailed(page: number): void {
-    this.#fail(new Error(`Editor surface replacement failed for page ${page}`));
+    this.fail(new Error(`Editor surface replacement failed for page ${page}`));
   }
 
   publishedSurfaceCanvas(page: number): HTMLCanvasElement | undefined {

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanelTimeline.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanelTimeline.svelte
@@ -147,7 +147,7 @@
     void applyHead(selectedHeadId);
   };
 
-  const reportTimelineFailure = (editor?: Editor): void => {
+  const failTimeline = (editor?: Editor): void => {
     if (destroyed) return;
     if (editor) {
       if (unusableTimelineEditors.has(editor)) return;
@@ -163,7 +163,7 @@
     onPreviewEditorRecovered?.();
   };
 
-  const reportTimelineRecovery = (): void => {
+  const handleTimelineRecovery = (): void => {
     if (previewFailed) sliderElement?.focus({ preventScroll: true });
     clearTimelineFailure();
   };
@@ -176,15 +176,15 @@
       .then((publication) => {
         if (destroyed || pendingTimelinePublication !== pending || timelineEditor !== editor) return;
         if (publication.type !== 'published') {
-          reportTimelineFailure(editor);
+          failTimeline(editor);
           return;
         }
         pendingTimelinePublication = undefined;
         shownHeadId = headId;
-        reportTimelineRecovery();
+        handleTimelineRecovery();
       })
       .catch(() => {
-        if (pendingTimelinePublication === pending && timelineEditor === editor) reportTimelineFailure(editor);
+        if (pendingTimelinePublication === pending && timelineEditor === editor) failTimeline(editor);
       });
   };
 
@@ -243,9 +243,7 @@
       plain = liveEditor.materializeAt(Uint8Array.fromBase64(head.heads), [...(query.data?.document.sweepTombstones ?? [])]);
     } catch {
       if (liveEditor.failure === undefined) {
-        reportTimelineFailure(currentTimelineEditor);
-      } else {
-        ctx.reportEditorFailure?.(liveEditor.failure);
+        failTimeline(currentTimelineEditor);
       }
       return;
     }
@@ -255,7 +253,7 @@
       try {
         currentTimelineEditor.setDoc(plain);
       } catch {
-        reportTimelineFailure(currentTimelineEditor);
+        failTimeline(currentTimelineEditor);
         return;
       }
       awaitTimelinePublication(currentTimelineEditor, headId, afterRevision);
@@ -268,7 +266,7 @@
       try {
         created = await Editor.createFromDoc(plain, liveEditor.viewport, theme.currentThemeVariant);
       } catch {
-        reportTimelineFailure();
+        failTimeline();
         return;
       }
       created.readOnly = true;
@@ -289,19 +287,19 @@
         const publication = await created.awaitPublishedRevision(publicationRevision, { requireFrame: true });
         if (destroyed || timelineEditor !== created) return;
         if (publication.type !== 'published') {
-          reportTimelineFailure(created);
+          failTimeline(created);
           return;
         }
       } catch {
         if (destroyed || timelineEditor !== created) return;
-        reportTimelineFailure(created);
+        failTimeline(created);
         return;
       }
 
       if (pendingHeadId === null || pendingHeadId === headId) {
         if (pendingHeadId === headId) pendingHeadId = null;
         shownHeadId = headId;
-        reportTimelineRecovery();
+        handleTimelineRecovery();
       }
     } finally {
       creatingTimeline = false;
@@ -316,7 +314,7 @@
 
   $effect(() => {
     const editor = timelineEditor;
-    if (editor?.failure !== undefined) reportTimelineFailure(editor);
+    if (editor?.failure !== undefined) failTimeline(editor);
   });
 
   $effect(() => {

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditor.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditor.svelte
@@ -339,7 +339,7 @@
   let pendingRemoteEvents: RemoteChangesetEvent[] = [];
   let remoteChangesetPipeline: RemoteChangesetPipeline | undefined;
 
-  const reportEditorFailure = (error: unknown) => {
+  const failLiveEditor = (error: unknown) => {
     if (editorFailureReported) return;
     editorFailureReported = true;
     liveEditorFailed = true;
@@ -348,7 +348,15 @@
     pusher?.stop();
     onEditorFailed?.(error);
   };
-  ctx.reportEditorFailure = reportEditorFailure;
+
+  const handleEditorBoundaryError = (editor: Editor | undefined, error: unknown) => {
+    console.error(error);
+    if (editor) {
+      editor.fail(error);
+    } else {
+      failLiveEditor(error);
+    }
+  };
 
   const retryLiveEditor = () => {
     onEditorRetry?.();
@@ -358,7 +366,7 @@
     if (editor.destroyed) return;
     const failure = editor.failure;
     if (failure !== undefined) {
-      reportEditorFailure(failure);
+      failLiveEditor(failure);
       return;
     }
     if (!destroyed) console.error(error);
@@ -366,7 +374,7 @@
 
   $effect(() => {
     const failure = ctx.liveEditor?.failure;
-    if (failure !== undefined) reportEditorFailure(failure);
+    if (failure !== undefined) failLiveEditor(failure);
   });
 
   let resyncPrep: Promise<void> = Promise.resolve();
@@ -434,7 +442,7 @@
               createdEditor = liveEditor;
             } catch (err) {
               store.destroy();
-              reportEditorFailure(err);
+              failLiveEditor(err);
               return;
             }
 
@@ -475,7 +483,7 @@
             if (createdEditor?.failure === undefined) {
               console.error(err);
             } else {
-              reportEditorFailure(createdEditor.failure);
+              failLiveEditor(createdEditor.failure);
             }
             createdEditor?.destroy();
             createdStore?.destroy();
@@ -956,7 +964,6 @@
     const currentEditor = ctx.editor;
     const currentLiveEditor = ctx.liveEditor;
     const currentEditorStore = editorStore;
-    if (ctx.reportEditorFailure === reportEditorFailure) ctx.reportEditorFailure = undefined;
     channelUnsubscribe?.();
     channelUnsubscribe = null;
     pusher?.stop();
@@ -1266,114 +1273,117 @@
                   inert={editorSurfaceFailed}
                 >
                   {#key ctx.editor}
-                    <EditorComponent active={focused} document$key={document} onReady={handleEditorReady}>
-                      {#snippet header()}
-                        <div
-                          class={flex({
-                            flexDirection: 'column',
-                            alignItems: 'center',
-                            paddingTop: '60px',
-                            width: 'full',
-                            ...(ctx.editor?.rootAttrs?.layout_mode.type === 'paginated' && { paddingBottom: '20px' }),
-                          })}
-                        >
-                          <div class={flex({ flexDirection: 'column', flexShrink: '0', width: 'full' })}>
-                            <textarea
-                              bind:this={titleEl}
-                              class={css({ width: 'full', fontSize: '28px', fontWeight: 'bold', resize: 'none' })}
-                              autocapitalize="off"
-                              autocomplete="off"
-                              maxlength={100}
-                              onblur={() => {
-                                titleFocused = false;
-                                flushTitleUpdate();
-                              }}
-                              onfocus={() => {
-                                clearBodySelectionForHeaderFocus();
-                                titleFocused = true;
-                                if (documentId) {
-                                  selectionsStore.current = {
-                                    ...selectionsStore.current,
-                                    [documentId]: { type: 'element', element: 'title', timestamp: dayjs().valueOf() },
-                                  };
-                                }
-                              }}
-                              oninput={handleTitleChanged}
-                              onkeydown={(e) => {
-                                if (e.isComposing) {
-                                  return;
-                                }
+                    {@const editor = ctx.editor}
+                    <svelte:boundary onerror={(error) => handleEditorBoundaryError(editor, error)}>
+                      <EditorComponent active={focused} document$key={document} onReady={handleEditorReady}>
+                        {#snippet header()}
+                          <div
+                            class={flex({
+                              flexDirection: 'column',
+                              alignItems: 'center',
+                              paddingTop: '60px',
+                              width: 'full',
+                              ...(ctx.editor?.rootAttrs?.layout_mode.type === 'paginated' && { paddingBottom: '20px' }),
+                            })}
+                          >
+                            <div class={flex({ flexDirection: 'column', flexShrink: '0', width: 'full' })}>
+                              <textarea
+                                bind:this={titleEl}
+                                class={css({ width: 'full', fontSize: '28px', fontWeight: 'bold', resize: 'none' })}
+                                autocapitalize="off"
+                                autocomplete="off"
+                                maxlength={100}
+                                onblur={() => {
+                                  titleFocused = false;
+                                  flushTitleUpdate();
+                                }}
+                                onfocus={() => {
+                                  clearBodySelectionForHeaderFocus();
+                                  titleFocused = true;
+                                  if (documentId) {
+                                    selectionsStore.current = {
+                                      ...selectionsStore.current,
+                                      [documentId]: { type: 'element', element: 'title', timestamp: dayjs().valueOf() },
+                                    };
+                                  }
+                                }}
+                                oninput={handleTitleChanged}
+                                onkeydown={(e) => {
+                                  if (e.isComposing) {
+                                    return;
+                                  }
 
-                                if (e.key === 'Enter') {
-                                  e.preventDefault();
-                                  subtitleEl?.focus();
-                                }
-                              }}
-                              placeholder="제목을 입력하세요"
-                              rows={1}
-                              spellcheck="false"
-                              bind:value={localTitle}
-                              use:autosize
-                              use:headerVerticalNavigation={{ down: () => subtitleEl?.focus() }}></textarea>
+                                  if (e.key === 'Enter') {
+                                    e.preventDefault();
+                                    subtitleEl?.focus();
+                                  }
+                                }}
+                                placeholder="제목을 입력하세요"
+                                rows={1}
+                                spellcheck="false"
+                                bind:value={localTitle}
+                                use:autosize
+                                use:headerVerticalNavigation={{ down: () => subtitleEl?.focus() }}></textarea>
 
-                            <textarea
-                              bind:this={subtitleEl}
-                              class={css({
-                                marginTop: '4px',
-                                width: 'full',
-                                fontSize: '16px',
-                                fontWeight: 'medium',
-                                overflow: 'hidden',
-                                resize: 'none',
-                              })}
-                              autocapitalize="off"
-                              autocomplete="off"
-                              maxlength={100}
-                              onblur={() => {
-                                subtitleFocused = false;
-                                flushSubtitleUpdate();
-                              }}
-                              onfocus={() => {
-                                clearBodySelectionForHeaderFocus();
-                                subtitleFocused = true;
-                                if (documentId) {
-                                  selectionsStore.current = {
-                                    ...selectionsStore.current,
-                                    [documentId]: { type: 'element', element: 'subtitle', timestamp: dayjs().valueOf() },
-                                  };
-                                }
-                              }}
-                              oninput={handleSubtitleChanged}
-                              onkeydown={(e) => {
-                                if (e.isComposing) {
-                                  return;
-                                }
+                              <textarea
+                                bind:this={subtitleEl}
+                                class={css({
+                                  marginTop: '4px',
+                                  width: 'full',
+                                  fontSize: '16px',
+                                  fontWeight: 'medium',
+                                  overflow: 'hidden',
+                                  resize: 'none',
+                                })}
+                                autocapitalize="off"
+                                autocomplete="off"
+                                maxlength={100}
+                                onblur={() => {
+                                  subtitleFocused = false;
+                                  flushSubtitleUpdate();
+                                }}
+                                onfocus={() => {
+                                  clearBodySelectionForHeaderFocus();
+                                  subtitleFocused = true;
+                                  if (documentId) {
+                                    selectionsStore.current = {
+                                      ...selectionsStore.current,
+                                      [documentId]: { type: 'element', element: 'subtitle', timestamp: dayjs().valueOf() },
+                                    };
+                                  }
+                                }}
+                                oninput={handleSubtitleChanged}
+                                onkeydown={(e) => {
+                                  if (e.isComposing) {
+                                    return;
+                                  }
 
-                                if (!localSubtitle && e.key === 'Backspace') {
-                                  e.preventDefault();
-                                  titleEl?.focus();
-                                }
+                                  if (!localSubtitle && e.key === 'Backspace') {
+                                    e.preventDefault();
+                                    titleEl?.focus();
+                                  }
 
-                                if (e.key === 'Enter' || (e.key === 'Tab' && !e.shiftKey)) {
-                                  e.preventDefault();
-                                  enterDocumentFromHeader();
-                                }
-                              }}
-                              placeholder="부제목을 입력하세요"
-                              rows={1}
-                              spellcheck="false"
-                              bind:value={localSubtitle}
-                              use:autosize
-                              use:headerVerticalNavigation={{ up: () => titleEl?.focus(), down: enterDocumentFromHeader }}></textarea>
+                                  if (e.key === 'Enter' || (e.key === 'Tab' && !e.shiftKey)) {
+                                    e.preventDefault();
+                                    enterDocumentFromHeader();
+                                  }
+                                }}
+                                placeholder="부제목을 입력하세요"
+                                rows={1}
+                                spellcheck="false"
+                                bind:value={localSubtitle}
+                                use:autosize
+                                use:headerVerticalNavigation={{ up: () => titleEl?.focus(), down: enterDocumentFromHeader }}></textarea>
 
-                            {#if ctx.editor?.rootAttrs?.layout_mode.type !== 'paginated'}
-                              <HorizontalDivider style={css.raw({ marginTop: '10px' })} />
-                            {/if}
+                              {#if ctx.editor?.rootAttrs?.layout_mode.type !== 'paginated'}
+                                <HorizontalDivider style={css.raw({ marginTop: '10px' })} />
+                              {/if}
+                            </div>
                           </div>
-                        </div>
-                      {/snippet}
-                      <CommentPopover />
-                    </EditorComponent>
+                        {/snippet}
+                        <CommentPopover />
+                      </EditorComponent>
+                    </svelte:boundary>
                   {/key}
                 </div>
                 {#if showFindReplace}


### PR DESCRIPTION
웹 에디터 내부에서 예외가 throw되면 기존 terminal failure 경로를 거치지 않아, 에디터가 멈춰도 failure overlay가 표시되지 않았습니다. (엔진 에러 이외의 에러)

- Svelte error boundary에서 예외를 해당 에디터의 terminal failure로 전환합니다.
- live editor와 timeline preview가 각자의 failure overlay를 표시하도록 실패를 소유한 runtime에서 처리합니다.
- preview failure는 preview에만 격리합니다.
- 웹과 앱의 실패 진입 API와 책임을 `fail`/`failure` 기준으로 정리합니다.