### PR TITLE
앱 홈 이어쓰기 캐러셀 초기화 퇴행 수정

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/state/RememberPersistedState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/state/RememberPersistedState.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.currentCompositeKeyHashCode
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key as compositionKey
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -33,10 +34,10 @@ private inline fun <S, reified T> rememberPersistedState(
 ): S {
   val resolvedKey = key ?: currentCompositeKeyHashCode.toString(36)
   val holder = viewModel<PositionHolder<T>>(key = resolvedKey) { PositionHolder(initial) }
-  val restoredInitial = remember { holder.position }
-  val state = factory(restoredInitial)
+  val restoredInitial = remember(resolvedKey) { holder.position }
+  val state = compositionKey(resolvedKey) { factory(restoredInitial) }
 
-  LaunchedEffect(state) { snapshotFlow { read(state) }.collect { holder.position = it } }
+  LaunchedEffect(state, holder) { snapshotFlow { read(state) }.collect { holder.position = it } }
 
   return state
 }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/state/RememberPersistedStateDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/state/RememberPersistedStateDesktopTest.kt
@@ -1,0 +1,42 @@
+package co.typie.ui.state
+
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+class RememberPersistedStateDesktopTest {
+  @Test
+  fun `changing an explicit key recreates pager state at its initial page`() = runComposeUiTest {
+    val owner =
+      object : ViewModelStoreOwner {
+        override val viewModelStore = ViewModelStore()
+      }
+    var pagerKey by mutableStateOf("first|second|third")
+    lateinit var pagerState: PagerState
+
+    setContent {
+      CompositionLocalProvider(LocalViewModelStoreOwner provides owner) {
+        pagerState = rememberPagerState(key = pagerKey, pageCount = { 3 })
+      }
+    }
+    waitForIdle()
+
+    runOnIdle { pagerState.requestScrollToPage(1) }
+    runOnIdle { assertEquals(1, pagerState.currentPage) }
+
+    runOnIdle { pagerKey = "second|first|third" }
+    runOnIdle { assertEquals(0, pagerState.currentPage) }
+
+    owner.viewModelStore.clear()
+  }
+}


### PR DESCRIPTION
홈 이어쓰기 캐러셀에서 두 번째 이후 문서를 열었다가 back하면, 캐러셀이 첫 번째 항목으로 돌아가지 않는 문제 수정