### PR TITLE
특정 화면에서 자동 포커스가 풀리는 문제 수정

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationStack.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationStack.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerInputChange
@@ -37,7 +38,6 @@ import androidx.compose.ui.input.pointer.positionChangeIgnoreConsumed
 import androidx.compose.ui.input.pointer.util.VelocityTracker
 import androidx.compose.ui.input.pointer.util.addPointerInputChange
 import androidx.compose.ui.layout.onSizeChanged
-import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.clearAndSetSemantics
@@ -292,7 +292,6 @@ fun NavigationStack(
   val backGestureZoneWidth by rememberUpdatedState(systemBackGestureZoneWidth())
   val popPointerVelocity = remember { NavigationPopPointerVelocity() }
   var predictiveBackActive by remember { mutableStateOf(false) }
-  val focusManager = LocalFocusManager.current
 
   fun canStartPopGesture(): Boolean =
     foregroundInteractive &&
@@ -550,7 +549,6 @@ fun NavigationStack(
       predictiveBackActive = false
       popNestedScroll.cancel()
       cancelPopDrag()
-      focusManager.clearFocus(force = true)
     }
   }
 
@@ -779,6 +777,7 @@ fun NavigationStack(
     Box(
       modifier
         .fillMaxSize()
+        .focusProperties { canFocus = foregroundInteractive }
         .onSizeChanged {
           containerWidth = it.width.toFloat()
           containerHeight = it.height.toFloat()

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/shell/MainShell.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/shell/MainShell.kt
@@ -1,9 +1,7 @@
 package co.typie.shell
 
-import androidx.compose.foundation.interaction.collectIsDraggedAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.pager.PagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
@@ -11,13 +9,9 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import co.typie.domain.note.NoteSync
 import co.typie.domain.note.NoteUpdate
@@ -39,37 +33,26 @@ import co.typie.ui.component.drawer.DrawerAnchor
 import co.typie.ui.component.drawer.LocalDrawer
 import co.typie.ui.component.topbar.TopBarState
 import kotlin.math.abs
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.launch
 
 @Composable
 fun MainShell(content: @Composable (Route) -> Unit) {
   val navState =
     rememberSaveable(saver = MainNavigationStateSaver) { MainNavigationState.initial() }
   val navigators = navState.navigators
-  val pagerState = remember {
-    PagerState(currentPage = navState.currentTab.ordinal) { Tab.entries.size }
-  }
-  val isDirectDrag by pagerState.interactionSource.collectIsDraggedAsState()
-  val settledTab = Tab.entries[pagerState.settledPage]
-  val targetTab = Tab.entries[pagerState.targetPage]
-  val chromeTab =
-    resolveMainTabChrome(
-      settledTab = settledTab,
-      targetTab = targetTab,
-      isDirectDrag = isDirectDrag,
-    )
+  val mainTabState = rememberMainTabState(initialTab = navState.currentTab)
+  val settledTab = mainTabState.settledTab
+  val motion = mainTabState.motion
+  val chromeTab = mainTabChromeTab(settledTab = settledTab, motion = motion)
   val chromeNavigator = navigators[chromeTab]!!
   val settledNavigator = navigators[settledTab]!!
+  val motionOwnerNavigator = navigators[motion?.origin ?: settledTab]!!
 
   val topBarState = remember { TopBarState() }
   val bottomBarState = remember { BottomBarState() }
   val backgroundTopBarStates = remember { Tab.entries.associateWith { TopBarState() } }
   val backgroundBottomBarStates = remember { Tab.entries.associateWith { BottomBarState() } }
   val drawer = remember { Drawer() }
-  val scope = rememberCoroutineScope()
 
   val drawerAtRest by
     remember(drawer) {
@@ -84,15 +67,13 @@ fun MainShell(content: @Composable (Route) -> Unit) {
           !drawer.isProgrammaticAnimating
       }
     }
-  val pagerAtRest = !pagerState.isScrollInProgress
   val mayAdmitNewPagerGesture =
     canAdmitMainTabPagerGesture(
       navigatorCanPop = settledNavigator.canPop,
       navigatorIsTransitioning = settledNavigator.isTransitioning,
-      pagerAtRest = pagerAtRest,
+      motion = motion,
       drawerAtRest = drawerAtRest,
     )
-  val pagerUserScrollEnabled = mayAdmitNewPagerGesture || pagerState.isScrollInProgress
   val drawerSwipeEnabled =
     settledTab == Tab.Home &&
       chromeTab == Tab.Home &&
@@ -105,39 +86,17 @@ fun MainShell(content: @Composable (Route) -> Unit) {
       canStart = { drawerAtRest },
     )
 
-  var tabSelectionJob by remember { mutableStateOf<Job?>(null) }
-  val latestIsDirectDrag by rememberUpdatedState(isDirectDrag)
   val latestDrawerAtRest by rememberUpdatedState(drawerAtRest)
   val selectTab =
-    remember(pagerState, drawer, scope) {
-      { tab: Tab ->
-        if (!latestIsDirectDrag) {
-          tabSelectionJob?.cancel()
-          tabSelectionJob = scope.launch {
-            if (!latestDrawerAtRest) drawer.close()
-            pagerState.animateScrollToPage(tab.ordinal)
-          }
-        }
-      }
+    remember(mainTabState, drawer) {
+      { tab: Tab -> mainTabState.selectTab(tab) { if (!latestDrawerAtRest) drawer.close() } }
     }
 
   val siteId = Preference.siteId
 
   DisposableEffect(Unit) { onDispose { navigators.values.forEach { it.clear() } } }
 
-  LaunchedEffect(pagerState) {
-    snapshotFlow { pagerState.settledPage }
-      .distinctUntilChanged()
-      .collect { page -> navState.currentTab = Tab.entries[page] }
-  }
-
   LaunchedEffect(chromeTab) { if (chromeTab != Tab.Home && !drawerAtRest) drawer.close() }
-
-  MainTabPagerNavigationGuard(
-    state = pagerState,
-    navigationLocked = settledNavigator.canPop || settledNavigator.isTransitioning,
-    onInterrupt = { tabSelectionJob?.cancel() },
-  )
 
   LaunchedEffect(siteId) {
     if (siteId == null) {
@@ -170,8 +129,8 @@ fun MainShell(content: @Composable (Route) -> Unit) {
     LocalTabState provides
       TabState(
         currentTab = chromeTab,
-        bodyPosition = pagerState.currentPage + pagerState.currentPageOffsetFraction,
-        isBodyMoving = pagerState.isScrollInProgress,
+        bodyPosition = mainTabState.bodyPosition,
+        isBodyMoving = motion != null,
         onSelectTab = selectTab,
       ),
     LocalDrawer provides drawer,
@@ -185,11 +144,13 @@ fun MainShell(content: @Composable (Route) -> Unit) {
         modifier = drawerSwipeModifier,
       ) {
         MainTabPager(
-          state = pagerState,
+          state = mainTabState,
           modifier = Modifier.fillMaxSize(),
-          userScrollEnabled = pagerUserScrollEnabled,
+          gestureAdmissionAllowed = mayAdmitNewPagerGesture,
+          navigationLocked = motionOwnerNavigator.canPop || motionOwnerNavigator.isTransitioning,
+          onSettledTab = { tab -> navState.currentTab = tab },
         ) { tab ->
-          val foregroundInteractive = tab == settledTab && pagerAtRest && drawerAtRest
+          val foregroundInteractive = tab == settledTab && motion == null && drawerAtRest
           NavigationStack(
             navigator = navigators[tab]!!,
             topBarState =
@@ -201,7 +162,7 @@ fun MainShell(content: @Composable (Route) -> Unit) {
           )
         }
       }
-      if (pagerState.isScrollInProgress) {
+      if (motion != null) {
         Box(Modifier.fillMaxSize().pointerIgnore())
       }
       MainDrawerOverlay(drawer)
@@ -210,10 +171,7 @@ fun MainShell(content: @Composable (Route) -> Unit) {
     }
   }
 
-  PlatformBackHandler(enabled = pagerState.isScrollInProgress) {
-    tabSelectionJob?.cancel()
-    scope.launch { pagerState.animateScrollToPage(pagerState.settledPage) }
-  }
+  PlatformBackHandler(enabled = motion != null) { mainTabState.cancelToOrigin() }
 }
 
 enum class Tab(val route: Route) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/shell/MainTabPager.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/shell/MainTabPager.kt
@@ -1,15 +1,21 @@
 package co.typie.shell
 
+import androidx.compose.foundation.MutatePriority
 import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.interaction.collectIsDraggedAsState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerDefaults
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -18,19 +24,261 @@ import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.Velocity
 import kotlin.math.abs
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+
+internal enum class MainTabMotionSource {
+  DirectDrag,
+  Committed,
+}
+
+internal data class MainTabMotion(val origin: Tab, val target: Tab, val source: MainTabMotionSource)
+
+@Stable
+internal class MainTabState(initialTab: Tab, private val scope: CoroutineScope) {
+  internal val pagerState = PagerState(currentPage = initialTab.ordinal) { Tab.entries.size }
+
+  var settledTab by mutableStateOf(initialTab)
+    private set
+
+  var motion by mutableStateOf<MainTabMotion?>(null)
+    private set
+
+  val bodyPosition: Float
+    get() =
+      if (motion == null) {
+        settledTab.ordinal.toFloat()
+      } else {
+        pagerState.currentPage + pagerState.currentPageOffsetFraction
+      }
+
+  private var selectionJob: Job? = null
+  private var neutralizeJob: Job? = null
+  private var selectionRequestId = 0L
+  private var nextMotionSessionId = 0L
+  private var activeMotionSessionId: Long? = null
+  private var activeMotionObservedScroll = false
+  private var returningToOrigin = false
+
+  fun selectTab(tab: Tab, beforeTransition: suspend () -> Unit = {}) {
+    if (motion?.source == MainTabMotionSource.DirectDrag) return
+
+    selectionJob?.cancel()
+    val requestId = ++selectionRequestId
+    selectionJob = scope.launch {
+      beforeTransition()
+      if (requestId != selectionRequestId) return@launch
+
+      val activeMotion = motion
+      val origin = activeMotion?.origin ?: settledTab
+      if (activeMotion == null && tab == origin) return@launch
+
+      beginMotion(
+        origin = origin,
+        target = tab,
+        source = MainTabMotionSource.Committed,
+        observedScroll = pagerState.isScrollInProgress,
+      )
+      pagerState.animateScrollToPage(tab.ordinal)
+    }
+  }
+
+  fun cancelToOrigin() {
+    val activeMotion = motion ?: return
+    val sessionId = activeMotionSessionId ?: return
+    val interruptedSelection = selectionJob
+
+    interruptedSelection?.cancel()
+    selectionRequestId += 1
+    returningToOrigin = true
+    motion = activeMotion.copy(target = activeMotion.origin, source = MainTabMotionSource.Committed)
+    selectionJob = scope.launch {
+      interruptedSelection?.join()
+      pagerState.scroll(MutatePriority.PreventUserInput) {
+        with(pagerState) { updateCurrentPage(activeMotion.origin.ordinal) }
+      }
+      completeMotion(sessionId)
+    }
+  }
+
+  internal fun reconcileRawPager(raw: RawMainTabPagerSnapshot): Tab? {
+    val rawTarget = Tab.entries[raw.targetPage]
+
+    if (raw.isDirectDrag) {
+      if (motion == null) {
+        if (raw.gestureAdmissionAllowed) {
+          beginMotion(
+            origin = settledTab,
+            target = rawTarget,
+            source = MainTabMotionSource.DirectDrag,
+            observedScroll = raw.isScrollInProgress,
+          )
+        } else {
+          requestSettledPage()
+          return null
+        }
+      }
+
+      val activeMotion = motion
+      if (
+        activeMotion?.source == MainTabMotionSource.DirectDrag && activeMotion.target != rawTarget
+      ) {
+        motion = activeMotion.copy(target = rawTarget)
+      }
+    } else {
+      val activeMotion = motion
+      if (activeMotion?.source == MainTabMotionSource.DirectDrag) {
+        motion = activeMotion.copy(target = rawTarget, source = MainTabMotionSource.Committed)
+      }
+    }
+
+    var activeMotion = motion
+    if (activeMotion == null) {
+      if (raw.isScrollInProgress && rawTarget != settledTab && raw.gestureAdmissionAllowed) {
+        beginMotion(
+          origin = settledTab,
+          target = rawTarget,
+          source = MainTabMotionSource.Committed,
+          observedScroll = true,
+        )
+      } else if (raw.isDisplacedFrom(settledTab)) {
+        requestSettledPage()
+      }
+      return null
+    }
+
+    val sessionId = activeMotionSessionId ?: return null
+    if (raw.isScrollInProgress) activeMotionObservedScroll = true
+
+    if (
+      !returningToOrigin &&
+        (raw.isScrollInProgress || activeMotionObservedScroll) &&
+        activeMotion.target != rawTarget
+    ) {
+      motion = activeMotion.copy(target = rawTarget)
+      activeMotion = motion ?: return null
+    }
+
+    if (
+      !raw.isScrollInProgress &&
+        activeMotion.source == MainTabMotionSource.Committed &&
+        !returningToOrigin &&
+        (activeMotionObservedScroll ||
+          (activeMotion.target == activeMotion.origin && !raw.isDisplacedFrom(activeMotion.origin)))
+    ) {
+      return completeMotion(sessionId)
+    }
+
+    return null
+  }
+
+  private fun beginMotion(
+    origin: Tab,
+    target: Tab,
+    source: MainTabMotionSource,
+    observedScroll: Boolean,
+  ) {
+    neutralizeJob?.cancel()
+    neutralizeJob = null
+    activeMotionSessionId = ++nextMotionSessionId
+    activeMotionObservedScroll = observedScroll
+    returningToOrigin = false
+    motion = MainTabMotion(origin = origin, target = target, source = source)
+  }
+
+  private fun completeMotion(sessionId: Long): Tab? {
+    if (activeMotionSessionId != sessionId) return null
+
+    val activeMotion = motion ?: return null
+    val rawSettledTab = Tab.entries[pagerState.settledPage]
+    if (returningToOrigin && rawSettledTab != activeMotion.origin) {
+      requestSettledPage(activeMotion.origin)
+      return null
+    }
+
+    settledTab = if (returningToOrigin) activeMotion.origin else rawSettledTab
+    motion = null
+    activeMotionSessionId = null
+    activeMotionObservedScroll = false
+    returningToOrigin = false
+    return settledTab
+  }
+
+  private fun requestSettledPage(tab: Tab = settledTab) {
+    pagerState.requestScrollToPage(tab.ordinal)
+    if (!pagerState.isScrollInProgress || neutralizeJob?.isActive == true) return
+
+    neutralizeJob = scope.launch {
+      pagerState.scroll(MutatePriority.PreventUserInput) {
+        pagerState.requestScrollToPage(tab.ordinal)
+      }
+    }
+  }
+}
+
+@Composable
+internal fun rememberMainTabState(initialTab: Tab = Tab.Home): MainTabState {
+  val scope = rememberCoroutineScope()
+  return remember { MainTabState(initialTab = initialTab, scope = scope) }
+}
+
+internal data class RawMainTabPagerSnapshot(
+  val isDirectDrag: Boolean,
+  val isScrollInProgress: Boolean,
+  val currentPage: Int,
+  val targetPage: Int,
+  val currentPageOffsetFraction: Float,
+  val gestureAdmissionAllowed: Boolean,
+) {
+  fun isDisplacedFrom(tab: Tab): Boolean =
+    currentPage != tab.ordinal ||
+      targetPage != tab.ordinal ||
+      abs(currentPageOffsetFraction) > PagerPositionEpsilon
+}
 
 @Composable
 internal fun MainTabPager(
-  state: PagerState,
-  userScrollEnabled: Boolean,
+  state: MainTabState,
+  gestureAdmissionAllowed: Boolean,
+  navigationLocked: Boolean = false,
   modifier: Modifier = Modifier,
+  onSettledTab: (Tab) -> Unit = {},
   content: @Composable (Tab) -> Unit,
 ) {
+  val pagerState = state.pagerState
+  val isDirectDrag by pagerState.interactionSource.collectIsDraggedAsState()
+  val latestGestureAdmissionAllowed by rememberUpdatedState(gestureAdmissionAllowed)
+  val latestOnSettledTab by rememberUpdatedState(onSettledTab)
+  val userScrollEnabled = gestureAdmissionAllowed || state.motion != null
   val deferredUserScrollEnabled = rememberMainTabPagerUserScrollEnabled(userScrollEnabled)
   val defaultPageNestedScrollConnection =
-    PagerDefaults.pageNestedScrollConnection(state, Orientation.Horizontal)
+    PagerDefaults.pageNestedScrollConnection(pagerState, Orientation.Horizontal)
+
+  LaunchedEffect(state) {
+    snapshotFlow {
+        state.motion to
+          RawMainTabPagerSnapshot(
+            isDirectDrag = isDirectDrag,
+            isScrollInProgress = pagerState.isScrollInProgress,
+            currentPage = pagerState.currentPage,
+            targetPage = pagerState.targetPage,
+            currentPageOffsetFraction = pagerState.currentPageOffsetFraction,
+            gestureAdmissionAllowed = latestGestureAdmissionAllowed,
+          )
+      }
+      .collect { (_, raw) ->
+        state.reconcileRawPager(raw)?.let { settledTab -> latestOnSettledTab(settledTab) }
+      }
+  }
+
+  LaunchedEffect(navigationLocked, state.motion?.origin, state.motion != null) {
+    if (navigationLocked && state.motion != null) state.cancelToOrigin()
+  }
+
   HorizontalPager(
-    state = state,
+    state = pagerState,
     modifier = modifier,
     userScrollEnabled = deferredUserScrollEnabled,
     pageNestedScrollConnection =
@@ -42,20 +290,6 @@ internal fun MainTabPager(
     overscrollEffect = null,
   ) { page ->
     content(Tab.entries[page])
-  }
-}
-
-@Composable
-internal fun MainTabPagerNavigationGuard(
-  state: PagerState,
-  navigationLocked: Boolean,
-  onInterrupt: () -> Unit,
-) {
-  LaunchedEffect(state.isScrollInProgress, navigationLocked) {
-    if (!state.isScrollInProgress || !navigationLocked) return@LaunchedEffect
-
-    onInterrupt()
-    state.requestScrollToPage(state.settledPage)
   }
 }
 
@@ -85,15 +319,19 @@ private data object DisabledMainTabPagerNestedScrollConnection : NestedScrollCon
 internal fun mainTabActivationWeights(position: Float): Map<Tab, Float> =
   Tab.entries.associateWith { tab -> (1f - abs(position - tab.ordinal)).coerceIn(0f, 1f) }
 
-internal fun resolveMainTabChrome(settledTab: Tab, targetTab: Tab, isDirectDrag: Boolean): Tab =
-  if (isDirectDrag) settledTab else targetTab
+internal fun mainTabChromeTab(settledTab: Tab, motion: MainTabMotion?): Tab =
+  when (motion?.source) {
+    MainTabMotionSource.DirectDrag -> motion.origin
+    MainTabMotionSource.Committed -> motion.target
+    null -> settledTab
+  }
 
 internal fun canAdmitMainTabPagerGesture(
   navigatorCanPop: Boolean,
   navigatorIsTransitioning: Boolean,
-  pagerAtRest: Boolean,
+  motion: MainTabMotion?,
   drawerAtRest: Boolean,
-): Boolean = !navigatorCanPop && !navigatorIsTransitioning && pagerAtRest && drawerAtRest
+): Boolean = !navigatorCanPop && !navigatorIsTransitioning && motion == null && drawerAtRest
 
 internal fun mainTabPillHandoffProgress(
   position: Float,
@@ -119,3 +357,5 @@ private data object MainTabPagerChildHorizontalHandoffBoundary : NestedScrollCon
   override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity =
     Velocity(x = available.x, y = 0f)
 }
+
+private const val PagerPositionEpsilon = 0.001f

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/shell/MainTabPagerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/shell/MainTabPagerTest.kt
@@ -34,16 +34,29 @@ class MainTabPagerTest {
   fun `chrome stays settled during direct drag and follows committed target while settling`() {
     assertEquals(
       Tab.Home,
-      resolveMainTabChrome(settledTab = Tab.Home, targetTab = Tab.Space, isDirectDrag = true),
+      mainTabChromeTab(
+        settledTab = Tab.Home,
+        motion =
+          MainTabMotion(
+            origin = Tab.Home,
+            target = Tab.Space,
+            source = MainTabMotionSource.DirectDrag,
+          ),
+      ),
     )
     assertEquals(
       Tab.Space,
-      resolveMainTabChrome(settledTab = Tab.Home, targetTab = Tab.Space, isDirectDrag = false),
+      mainTabChromeTab(
+        settledTab = Tab.Home,
+        motion =
+          MainTabMotion(
+            origin = Tab.Home,
+            target = Tab.Space,
+            source = MainTabMotionSource.Committed,
+          ),
+      ),
     )
-    assertEquals(
-      Tab.Home,
-      resolveMainTabChrome(settledTab = Tab.Home, targetTab = Tab.Home, isDirectDrag = false),
-    )
+    assertEquals(Tab.Home, mainTabChromeTab(settledTab = Tab.Home, motion = null))
   }
 
   @Test
@@ -52,7 +65,7 @@ class MainTabPagerTest {
       canAdmitMainTabPagerGesture(
         navigatorCanPop = false,
         navigatorIsTransitioning = false,
-        pagerAtRest = true,
+        motion = null,
         drawerAtRest = true,
       )
     )
@@ -60,7 +73,7 @@ class MainTabPagerTest {
       canAdmitMainTabPagerGesture(
         navigatorCanPop = true,
         navigatorIsTransitioning = false,
-        pagerAtRest = true,
+        motion = null,
         drawerAtRest = true,
       )
     )
@@ -68,7 +81,7 @@ class MainTabPagerTest {
       canAdmitMainTabPagerGesture(
         navigatorCanPop = false,
         navigatorIsTransitioning = true,
-        pagerAtRest = true,
+        motion = null,
         drawerAtRest = true,
       )
     )
@@ -76,7 +89,12 @@ class MainTabPagerTest {
       canAdmitMainTabPagerGesture(
         navigatorCanPop = false,
         navigatorIsTransitioning = false,
-        pagerAtRest = false,
+        motion =
+          MainTabMotion(
+            origin = Tab.Home,
+            target = Tab.Space,
+            source = MainTabMotionSource.Committed,
+          ),
         drawerAtRest = true,
       )
     )
@@ -84,7 +102,7 @@ class MainTabPagerTest {
       canAdmitMainTabPagerGesture(
         navigatorCanPop = false,
         navigatorIsTransitioning = false,
-        pagerAtRest = true,
+        motion = null,
         drawerAtRest = false,
       )
     )

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/shell/MainDrawerGestureDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/shell/MainDrawerGestureDesktopTest.kt
@@ -1,7 +1,6 @@
 package co.typie.shell
 
 import androidx.compose.foundation.gestures.DraggableAnchors
-import androidx.compose.foundation.interaction.collectIsDraggedAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
@@ -192,15 +191,15 @@ class MainDrawerGestureDesktopTest {
   @Test
   fun `outward drag on the home main pager opens the drawer`() = runComposeUiTest {
     lateinit var drawer: Drawer
-    lateinit var pagerState: PagerState
+    lateinit var mainTabState: MainTabState
 
     setContent {
       drawer = rememberTestDrawer()
-      pagerState = rememberPagerState(pageCount = { Tab.entries.size })
+      mainTabState = rememberMainTabState()
       DrawerSwipeHost(drawer) {
         MainTabPager(
-          state = pagerState,
-          userScrollEnabled = true,
+          state = mainTabState,
+          gestureAdmissionAllowed = true,
           modifier = Modifier.fillMaxSize().testTag(PagerTag),
         ) {
           Box(Modifier.fillMaxSize())
@@ -214,32 +213,26 @@ class MainDrawerGestureDesktopTest {
       repeat(15) { moveBy(Offset(x = 12f, y = 0f), delayMillis = 16L) }
       up()
     }
-    waitUntil { !pagerState.isScrollInProgress && !drawer.state.isAnimationRunning }
+    waitUntil { !mainTabState.pagerState.isScrollInProgress && !drawer.state.isAnimationRunning }
 
     assertEquals(DrawerAnchor.Open, drawer.state.currentValue)
-    assertEquals(Tab.Home.ordinal, pagerState.settledPage)
+    assertEquals(Tab.Home, mainTabState.settledTab)
   }
 
   @Test
   fun `home to space drag settles after the home drawer becomes unavailable`() = runComposeUiTest {
     lateinit var drawer: Drawer
-    lateinit var pagerState: PagerState
+    lateinit var mainTabState: MainTabState
 
     setContent {
       drawer = rememberTestDrawer()
-      pagerState = rememberPagerState(pageCount = { Tab.entries.size })
-      val isDirectDrag by pagerState.interactionSource.collectIsDraggedAsState()
-      val settledTab = Tab.entries[pagerState.settledPage]
-      val chromeTab =
-        resolveMainTabChrome(
-          settledTab = settledTab,
-          targetTab = Tab.entries[pagerState.targetPage],
-          isDirectDrag = isDirectDrag,
-        )
+      mainTabState = rememberMainTabState()
+      val settledTab = mainTabState.settledTab
+      val chromeTab = mainTabChromeTab(settledTab, mainTabState.motion)
       DrawerSwipeHost(drawer = drawer, enabled = settledTab == Tab.Home && chromeTab == Tab.Home) {
         MainTabPager(
-          state = pagerState,
-          userScrollEnabled = true,
+          state = mainTabState,
+          gestureAdmissionAllowed = true,
           modifier = Modifier.fillMaxSize().testTag(PagerTag),
         ) {
           Box(Modifier.fillMaxSize())
@@ -253,25 +246,25 @@ class MainDrawerGestureDesktopTest {
       repeat(10) { moveBy(Offset(x = -20f, y = 0f), delayMillis = 16L) }
       up()
     }
-    waitUntil(timeoutMillis = 5_000L) { !pagerState.isScrollInProgress }
+    waitUntil(timeoutMillis = 5_000L) { mainTabState.motion == null }
 
-    assertEquals(Tab.Space.ordinal, pagerState.settledPage)
-    assertEquals(0f, pagerState.currentPageOffsetFraction, absoluteTolerance = 0.001f)
+    assertEquals(Tab.Space, mainTabState.settledTab)
+    assertEquals(0f, mainTabState.pagerState.currentPageOffsetFraction, absoluteTolerance = 0.001f)
   }
 
   @Test
   fun `claimed drawer drag never hands the reversed sequence to the main pager`() =
     runComposeUiTest {
       lateinit var drawer: Drawer
-      lateinit var pagerState: PagerState
+      lateinit var mainTabState: MainTabState
 
       setContent {
         drawer = rememberTestDrawer()
-        pagerState = rememberPagerState(pageCount = { Tab.entries.size })
+        mainTabState = rememberMainTabState()
         DrawerSwipeHost(drawer) {
           MainTabPager(
-            state = pagerState,
-            userScrollEnabled = true,
+            state = mainTabState,
+            gestureAdmissionAllowed = true,
             modifier = Modifier.fillMaxSize().testTag(PagerTag),
           ) {
             Box(Modifier.fillMaxSize())
@@ -286,24 +279,24 @@ class MainDrawerGestureDesktopTest {
         repeat(20) { moveBy(Offset(x = -12f, y = 0f), delayMillis = 16L) }
         up()
       }
-      waitUntil { !pagerState.isScrollInProgress && !drawer.state.isAnimationRunning }
+      waitUntil { !mainTabState.pagerState.isScrollInProgress && !drawer.state.isAnimationRunning }
 
       assertEquals(DrawerAnchor.Closed, drawer.state.currentValue)
-      assertEquals(Tab.Home.ordinal, pagerState.settledPage)
+      assertEquals(Tab.Home, mainTabState.settledTab)
     }
 
   @Test
   fun `mouse outward drag on the home main pager never opens the drawer`() = runComposeUiTest {
     lateinit var drawer: Drawer
-    lateinit var pagerState: PagerState
+    lateinit var mainTabState: MainTabState
 
     setContent {
       drawer = rememberTestDrawer()
-      pagerState = rememberPagerState(pageCount = { Tab.entries.size })
+      mainTabState = rememberMainTabState()
       DrawerSwipeHost(drawer) {
         MainTabPager(
-          state = pagerState,
-          userScrollEnabled = true,
+          state = mainTabState,
+          gestureAdmissionAllowed = true,
           modifier = Modifier.fillMaxSize().testTag(PagerTag),
         ) {
           Box(Modifier.fillMaxSize())
@@ -318,10 +311,10 @@ class MainDrawerGestureDesktopTest {
       moveBy(Offset(x = 180f, y = 0f), delayMillis = 16L)
       release()
     }
-    waitUntil { !pagerState.isScrollInProgress && !drawer.state.isAnimationRunning }
+    waitUntil { !mainTabState.pagerState.isScrollInProgress && !drawer.state.isAnimationRunning }
 
     assertEquals(DrawerAnchor.Closed, drawer.state.currentValue)
-    assertEquals(Tab.Home.ordinal, pagerState.settledPage)
+    assertEquals(Tab.Home, mainTabState.settledTab)
   }
 
   @Test

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/shell/MainShellAutofocusDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/shell/MainShellAutofocusDesktopTest.kt
@@ -1,0 +1,221 @@
+package co.typie.shell
+
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import co.typie.dev.DesktopDebugKeyboard
+import co.typie.navigation.LocalNavigationForegroundInteractive
+import co.typie.navigation.Nav
+import co.typie.navigation.Navigator
+import co.typie.route.Route
+import co.typie.screen.more.feedback.FeedbackForm
+import co.typie.screen.settings.updateprofile.UpdateProfileForm
+import co.typie.ui.component.TextArea
+import co.typie.ui.component.TextField
+import co.typie.ui.component.dialog.Dialog
+import co.typie.ui.component.dialog.LocalDialog
+import co.typie.ui.component.sheet.LocalSheet
+import co.typie.ui.component.sheet.Sheet
+import co.typie.ui.theme.LocalThemeMode
+import co.typie.ui.theme.ResolvedThemeMode
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalTestApi::class)
+class MainShellAutofocusDesktopTest {
+  @Test
+  fun `feedback autofocus keeps the software keyboard visible inside main shell`() =
+    assertNestedFormAutofocus(Route.Feedback)
+
+  @Test
+  fun `update profile autofocus keeps the software keyboard visible inside main shell`() =
+    assertNestedFormAutofocus(Route.UpdateProfile)
+
+  private fun assertNestedFormAutofocus(targetRoute: Route) = runComposeUiTest {
+    configureEditorFfiLibrary()
+    val fixture = MainShellAutofocusFixture(targetRoute)
+    val previousHardwareKeyboardConnected = DesktopDebugKeyboard.hardwareKeyboardConnected
+
+    try {
+      runOnIdle {
+        DesktopDebugKeyboard.updateHardwareKeyboardConnected(false)
+        DesktopDebugKeyboard.hideKeyboardSurface()
+      }
+      setContent {
+        val sheet = remember { Sheet() }
+        val dialog = remember { Dialog() }
+        val navigationScope = rememberCoroutineScope()
+        SideEffect { fixture.scope = navigationScope }
+        CompositionLocalProvider(
+          LocalThemeMode provides ResolvedThemeMode.Light,
+          LocalSheet provides sheet,
+          LocalDialog provides dialog,
+        ) {
+          MainShell { route -> fixture.Content(route) }
+        }
+      }
+      waitUntil { fixture.isReady }
+
+      runOnIdle { fixture.scope.launch { fixture.navigator.navigate(Route.More) } }
+      waitUntil(timeoutMillis = 5_000L) {
+        fixture.navigator.current == Route.More && !fixture.navigator.isTransitioning
+      }
+
+      runOnIdle { fixture.scope.launch { fixture.navigator.navigate(targetRoute) } }
+      waitUntil(timeoutMillis = 5_000L) {
+        fixture.navigator.current == targetRoute && !fixture.navigator.isTransitioning
+      }
+      runOnIdle {
+        assertEquals(Tab.Home, fixture.currentTab)
+        assertEquals(Tab.Home.ordinal.toFloat(), fixture.bodyPosition)
+        assertFalse(fixture.isBodyMoving)
+        assertFalse(fixture.everBodyMoving, "Autofocus was misclassified as main-tab motion")
+        assertTrue(fixture.targetForegroundInteractive)
+        assertFalse(
+          fixture.targetWasEverForegroundInactive,
+          "Target route was briefly made foreground-inactive",
+        )
+        assertTrue(
+          fixture.backgroundTabComposedWhileTargetActive,
+          "The regression path did not compose a background tab stack",
+        )
+      }
+      onNode(hasSetTextAction(), useUnmergedTree = true).assertIsFocused()
+      runOnIdle {
+        assertFalse(
+          fixture.backgroundFocusRequester.requestFocus(),
+          "An inactive tab stack accepted focus",
+        )
+      }
+      onNode(hasSetTextAction(), useUnmergedTree = true).assertIsFocused()
+      waitUntil(timeoutMillis = 5_000L) { DesktopDebugKeyboard.visible }
+
+      val stableSince = System.nanoTime()
+      waitUntil(timeoutMillis = 1_000L) {
+        System.nanoTime() - stableSince >= KeyboardStabilityNanos
+      }
+
+      onNode(hasSetTextAction(), useUnmergedTree = true).assertIsFocused()
+      runOnIdle {
+        assertTrue(DesktopDebugKeyboard.visible)
+        assertEquals(targetRoute, fixture.navigator.current)
+        assertEquals(Tab.Home, fixture.currentTab)
+        assertFalse(fixture.isBodyMoving)
+      }
+    } finally {
+      runOnIdle {
+        DesktopDebugKeyboard.updateHardwareKeyboardConnected(previousHardwareKeyboardConnected)
+        DesktopDebugKeyboard.hideKeyboardSurface()
+      }
+    }
+  }
+
+  private fun configureEditorFfiLibrary() {
+    if (System.getProperty("jna.library.path") != null) return
+
+    val repository =
+      generateSequence(File(System.getProperty("user.dir"))) { it.parentFile }
+        .firstOrNull { File(it, "Cargo.toml").isFile } ?: error("Typie repository root not found")
+    val host =
+      when (System.getProperty("os.arch")) {
+        "aarch64" -> "aarch64-apple-darwin"
+        "x86_64" -> "x86_64-apple-darwin"
+        else -> error("Unsupported desktop test architecture: ${System.getProperty("os.arch")}")
+      }
+    val directory = File(repository, "target/$host/release-uniffi")
+    check(File(directory, "libeditor_ffi.dylib").isFile) {
+      "Desktop editor FFI is not built; run `just -f crates/editor-ffi/justfile desktop`"
+    }
+    System.setProperty("jna.library.path", directory.absolutePath)
+  }
+
+  private class MainShellAutofocusFixture(private val targetRoute: Route) {
+    lateinit var navigator: Navigator
+    lateinit var scope: CoroutineScope
+    lateinit var backgroundFocusRequester: FocusRequester
+    var currentTab = Tab.Home
+    var bodyPosition = Tab.Home.ordinal.toFloat()
+    var isBodyMoving = false
+    var everBodyMoving = false
+    var targetForegroundInteractive = false
+    var targetWasEverForegroundInactive = false
+    var backgroundTabComposedWhileTargetActive = false
+    val isReady: Boolean
+      get() = ::navigator.isInitialized && ::scope.isInitialized
+
+    @Composable
+    fun Content(route: Route) {
+      val routeScope = rememberCoroutineScope()
+      val tabState = LocalTabState.current
+      val nav = Nav.current
+      val foregroundInteractive = LocalNavigationForegroundInteractive.current
+      SideEffect {
+        currentTab = tabState.currentTab
+        bodyPosition = tabState.bodyPosition
+        isBodyMoving = tabState.isBodyMoving
+        everBodyMoving = everBodyMoving || tabState.isBodyMoving
+        if (route == targetRoute) {
+          targetForegroundInteractive = foregroundInteractive
+          targetWasEverForegroundInactive =
+            targetWasEverForegroundInactive || !foregroundInteractive
+        }
+        if (
+          isReady && navigator.current == targetRoute && route in setOf(Route.Space, Route.Notes)
+        ) {
+          backgroundTabComposedWhileTargetActive = true
+        }
+        if (route == Route.Home) {
+          navigator = nav
+        }
+      }
+
+      Box(Modifier.fillMaxSize().padding(24.dp)) {
+        when (route) {
+          Route.Feedback -> {
+            check(targetRoute == Route.Feedback)
+            val form = remember { FeedbackForm(routeScope) }
+            TextArea(field = form.content)
+          }
+
+          Route.UpdateProfile -> {
+            check(targetRoute == Route.UpdateProfile)
+            val form = remember { UpdateProfileForm(routeScope) }
+            TextField(field = form.name, label = "닉네임")
+          }
+
+          Route.Space,
+          Route.Notes -> {
+            val focusRequester = remember { FocusRequester() }
+            SideEffect { backgroundFocusRequester = focusRequester }
+            Box(Modifier.focusRequester(focusRequester).focusable())
+          }
+
+          else -> Unit
+        }
+      }
+    }
+  }
+
+  private companion object {
+    const val KeyboardStabilityNanos = 250_000_000L
+  }
+}

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/shell/MainTabPagerDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/shell/MainTabPagerDesktopTest.kt
@@ -8,8 +8,11 @@ import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
@@ -19,15 +22,19 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -39,10 +46,10 @@ class MainTabPagerDesktopTest {
     val composedTabs = mutableSetOf<Tab>()
 
     setContent {
-      val pagerState = rememberPagerState(pageCount = { Tab.entries.size })
+      val state = rememberMainTabState()
       MainTabPager(
-        state = pagerState,
-        userScrollEnabled = true,
+        state = state,
+        gestureAdmissionAllowed = true,
         modifier = Modifier.size(width = 320.dp, height = 640.dp),
       ) { tab ->
         DisposableEffect(tab) {
@@ -58,62 +65,66 @@ class MainTabPagerDesktopTest {
   }
 
   @Test
-  fun `partial drag moves adjacent bodies while fixed chrome stays in place`() = runComposeUiTest {
-    lateinit var pagerState: PagerState
-    val pageLefts = mutableMapOf<Tab, Float>()
+  fun `partial drag moves adjacent bodies while direct motion keeps chrome on its origin`() =
+    runComposeUiTest {
+      lateinit var state: MainTabState
+      val pageLefts = mutableMapOf<Tab, Float>()
 
-    setContent {
-      pagerState = rememberPagerState(pageCount = { Tab.entries.size })
-      Box(Modifier.size(width = 320.dp, height = 640.dp)) {
-        MainTabPager(
-          state = pagerState,
-          userScrollEnabled = true,
-          modifier = Modifier.fillMaxSize().testTag(PagerTag),
-        ) { tab ->
-          Box(
-            Modifier.fillMaxSize()
-              .onGloballyPositioned { pageLefts[tab] = it.positionInRoot().x }
-              .testTag("page-${tab.name}")
-          )
+      setContent {
+        state = rememberMainTabState()
+        Box(Modifier.size(width = 320.dp, height = 640.dp)) {
+          MainTabPager(
+            state = state,
+            gestureAdmissionAllowed = true,
+            modifier = Modifier.fillMaxSize().testTag(PagerTag),
+          ) { tab ->
+            Box(
+              Modifier.fillMaxSize()
+                .onGloballyPositioned { pageLefts[tab] = it.positionInRoot().x }
+                .testTag("page-${tab.name}")
+            )
+          }
+          Box(Modifier.size(width = 320.dp, height = 56.dp).testTag(ChromeTag))
         }
-        Box(Modifier.size(width = 320.dp, height = 56.dp).testTag(ChromeTag))
       }
+      waitForIdle()
+
+      val chromeLeft = onNodeWithTag(ChromeTag).fetchSemanticsNode().boundsInRoot.left
+      onNodeWithTag(PagerTag).performTouchInput {
+        down(center)
+        moveBy(Offset(x = -80f, y = 0f), delayMillis = 100L)
+      }
+
+      waitUntil {
+        (pageLefts[Tab.Home] ?: 0f) < -1f && state.motion?.source == MainTabMotionSource.DirectDrag
+      }
+      val homeLeft = pageLefts.getValue(Tab.Home)
+      val spaceLeft = pageLefts.getValue(Tab.Space)
+      assertTrue(homeLeft < -1f)
+      assertTrue(spaceLeft in 1f..319f)
+      assertEquals(320f, spaceLeft - homeLeft, absoluteTolerance = 1f)
+      assertEquals(Tab.Home, mainTabChromeTab(state.settledTab, state.motion))
+      assertEquals(
+        chromeLeft,
+        onNodeWithTag(ChromeTag).fetchSemanticsNode().boundsInRoot.left,
+        absoluteTolerance = 0.1f,
+      )
+
+      onNodeWithTag(PagerTag).performTouchInput { up() }
+      waitUntil { state.motion == null }
     }
-    waitForIdle()
-
-    val chromeLeft = onNodeWithTag(ChromeTag).fetchSemanticsNode().boundsInRoot.left
-    onNodeWithTag(PagerTag).performTouchInput {
-      down(center)
-      moveBy(Offset(x = -80f, y = 0f), delayMillis = 100L)
-    }
-
-    waitUntil { (pageLefts[Tab.Home] ?: 0f) < -1f }
-    val homeLeft = pageLefts.getValue(Tab.Home)
-    val spaceLeft = pageLefts.getValue(Tab.Space)
-    assertTrue(homeLeft < -1f)
-    assertTrue(spaceLeft in 1f..319f)
-    assertEquals(320f, spaceLeft - homeLeft, absoluteTolerance = 1f)
-    assertEquals(
-      chromeLeft,
-      onNodeWithTag(ChromeTag).fetchSemanticsNode().boundsInRoot.left,
-      absoluteTolerance = 0.1f,
-    )
-
-    onNodeWithTag(PagerTag).performTouchInput { up() }
-    waitUntil { !pagerState.isScrollInProgress }
-  }
 
   @Test
   fun `disabled pager is transparent to descendant side effects`() = runComposeUiTest {
-    lateinit var pagerState: PagerState
+    lateinit var state: MainTabState
     lateinit var nestedScrollDispatcher: NestedScrollDispatcher
 
     setContent {
-      pagerState = rememberPagerState(pageCount = { Tab.entries.size })
+      state = rememberMainTabState()
       nestedScrollDispatcher = remember { NestedScrollDispatcher() }
       MainTabPager(
-        state = pagerState,
-        userScrollEnabled = false,
+        state = state,
+        gestureAdmissionAllowed = false,
         modifier = Modifier.size(width = 320.dp, height = 640.dp),
       ) { tab ->
         Box(
@@ -149,51 +160,228 @@ class MainTabPagerDesktopTest {
 
     assertEquals(Offset.Zero, postScrollConsumed)
     assertEquals(Velocity.Zero, postFlingConsumed)
-    assertEquals(0f, pagerState.currentPageOffsetFraction)
+    assertEquals(0f, state.pagerState.currentPageOffsetFraction)
   }
 
   @Test
-  fun `pager motion that starts after nested navigation is cancelled before another tab settles`() =
-    runComposeUiTest {
-      lateinit var pagerState: PagerState
-      lateinit var scrollJob: Job
-      lateinit var startScroll: () -> Unit
+  fun `raw same page work never creates main tab motion`() = runComposeUiTest {
+    lateinit var state: MainTabState
+    lateinit var releaseScroll: CompletableDeferred<Unit>
+    lateinit var scrollJob: Job
+    lateinit var startScroll: () -> Unit
 
-      setContent {
-        pagerState = rememberPagerState(pageCount = { Tab.entries.size })
-        val scope = rememberCoroutineScope()
-        startScroll = {
-          scrollJob = scope.launch { pagerState.animateScrollToPage(Tab.Space.ordinal) }
-        }
-        MainTabPagerNavigationGuard(state = pagerState, navigationLocked = true, onInterrupt = {})
-        MainTabPager(
-          state = pagerState,
-          userScrollEnabled = true,
-          modifier = Modifier.size(width = 320.dp, height = 640.dp),
-        ) {
-          Box(Modifier.fillMaxSize())
-        }
+    setContent {
+      state = rememberMainTabState()
+      val scope = rememberCoroutineScope()
+      startScroll = {
+        releaseScroll = CompletableDeferred()
+        scrollJob = scope.launch { state.pagerState.scroll { releaseScroll.await() } }
       }
-      waitForIdle()
-
-      runOnIdle { startScroll() }
-      waitUntil { scrollJob.isCompleted }
-
-      assertEquals(Tab.Home.ordinal, pagerState.settledPage)
-      assertEquals(0f, pagerState.currentPageOffsetFraction)
+      MainTabPager(
+        state = state,
+        gestureAdmissionAllowed = false,
+        modifier = Modifier.size(width = 320.dp, height = 640.dp),
+      ) {
+        Box(Modifier.fillMaxSize())
+      }
     }
+    waitForIdle()
+
+    runOnIdle { startScroll() }
+    waitUntil { state.pagerState.isScrollInProgress }
+    runOnIdle {
+      assertNull(state.motion)
+      assertEquals(Tab.Home, state.settledTab)
+      assertEquals(Tab.Home.ordinal.toFloat(), state.bodyPosition)
+      releaseScroll.complete(Unit)
+    }
+    waitUntil { scrollJob.isCompleted && !state.pagerState.isScrollInProgress }
+    assertNull(state.motion)
+  }
+
+  @Test
+  fun `late raw page motion is rejected after nested navigation locks`() = runComposeUiTest {
+    lateinit var state: MainTabState
+    lateinit var scrollJob: Job
+    lateinit var startScroll: () -> Unit
+
+    setContent {
+      state = rememberMainTabState()
+      val scope = rememberCoroutineScope()
+      startScroll = {
+        scrollJob = scope.launch { state.pagerState.animateScrollToPage(Tab.Space.ordinal) }
+      }
+      MainTabPager(
+        state = state,
+        gestureAdmissionAllowed = false,
+        navigationLocked = true,
+        modifier = Modifier.size(width = 320.dp, height = 640.dp),
+      ) {
+        Box(Modifier.fillMaxSize())
+      }
+    }
+    waitForIdle()
+
+    runOnIdle { startScroll() }
+    waitUntil { scrollJob.isCompleted && !state.pagerState.isScrollInProgress }
+
+    assertNull(state.motion)
+    assertEquals(Tab.Home, state.settledTab)
+    assertEquals(Tab.Home.ordinal, state.pagerState.settledPage)
+    assertEquals(0f, state.pagerState.currentPageOffsetFraction)
+  }
+
+  @Test
+  fun `navigation lock cancels a held direct drag to its origin`() = runComposeUiTest {
+    lateinit var state: MainTabState
+    var navigationLocked by mutableStateOf(false)
+
+    setContent {
+      state = rememberMainTabState()
+      MainTabPager(
+        state = state,
+        gestureAdmissionAllowed = !navigationLocked,
+        navigationLocked = navigationLocked,
+        modifier = Modifier.size(width = 320.dp, height = 640.dp).testTag(PagerTag),
+      ) {
+        Box(Modifier.fillMaxSize())
+      }
+    }
+    waitForIdle()
+
+    onNodeWithTag(PagerTag).performTouchInput {
+      down(center)
+      moveBy(Offset(x = -80f, y = 0f), delayMillis = 100L)
+    }
+    waitUntil { state.motion?.source == MainTabMotionSource.DirectDrag }
+
+    runOnIdle { navigationLocked = true }
+    waitUntil(timeoutMillis = 5_000L) { state.motion == null }
+
+    assertEquals(Tab.Home, state.settledTab)
+    assertEquals(Tab.Home.ordinal, state.pagerState.settledPage)
+    assertEquals(0f, state.pagerState.currentPageOffsetFraction)
+    onNodeWithTag(PagerTag).performTouchInput { up() }
+  }
+
+  @Test
+  fun `rapid programmatic selection settles on the latest request`() = runComposeUiTest {
+    lateinit var state: MainTabState
+
+    setContent {
+      state = rememberMainTabState()
+      MainTabPager(
+        state = state,
+        gestureAdmissionAllowed = true,
+        modifier = Modifier.size(width = 320.dp, height = 640.dp),
+      ) {
+        Box(Modifier.fillMaxSize())
+      }
+    }
+    waitForIdle()
+
+    runOnIdle { state.selectTab(Tab.Notes) }
+    waitUntil { state.motion?.target == Tab.Notes }
+    runOnIdle { state.selectTab(Tab.Space) }
+    waitUntil(timeoutMillis = 5_000L) { state.motion == null && state.settledTab == Tab.Space }
+
+    assertEquals(Tab.Space.ordinal, state.pagerState.settledPage)
+  }
+
+  @Test
+  fun `cancel during owned motion returns to its origin`() = runComposeUiTest {
+    lateinit var state: MainTabState
+
+    setContent {
+      state = rememberMainTabState()
+      MainTabPager(
+        state = state,
+        gestureAdmissionAllowed = true,
+        modifier = Modifier.size(width = 320.dp, height = 640.dp),
+      ) {
+        Box(Modifier.fillMaxSize())
+      }
+    }
+    waitForIdle()
+
+    mainClock.autoAdvance = false
+    runOnIdle { state.selectTab(Tab.Notes) }
+    mainClock.advanceTimeByFrame()
+    runOnIdle { assertEquals(Tab.Notes, state.motion?.target) }
+    runOnIdle { state.cancelToOrigin() }
+    mainClock.autoAdvance = true
+    waitUntil(timeoutMillis = 5_000L) { state.motion == null }
+
+    assertEquals(Tab.Home, state.settledTab)
+    assertEquals(Tab.Home.ordinal, state.pagerState.settledPage)
+  }
+
+  @Test
+  fun `pager accessibility scroll creates committed motion and settles`() = runComposeUiTest {
+    lateinit var state: MainTabState
+
+    setContent {
+      state = rememberMainTabState()
+      MainTabPager(
+        state = state,
+        gestureAdmissionAllowed = true,
+        modifier = Modifier.size(width = 320.dp, height = 640.dp).testTag(PagerTag),
+      ) {
+        Box(Modifier.fillMaxSize())
+      }
+    }
+    waitForIdle()
+
+    onNodeWithTag(PagerTag).performSemanticsAction(SemanticsActions.PageRight) { action ->
+      assertTrue(action())
+    }
+    waitUntil(timeoutMillis = 5_000L) { state.motion == null && state.settledTab != Tab.Home }
+
+    assertEquals(Tab.Space, state.settledTab)
+  }
+
+  @Test
+  fun `late pager accessibility scroll is rejected after admission closes`() = runComposeUiTest {
+    lateinit var state: MainTabState
+    lateinit var lateAccessibilityPageRight: () -> Boolean
+    var gestureAdmissionAllowed by mutableStateOf(true)
+
+    setContent {
+      state = rememberMainTabState()
+      MainTabPager(
+        state = state,
+        gestureAdmissionAllowed = gestureAdmissionAllowed,
+        modifier = Modifier.size(width = 320.dp, height = 640.dp).testTag(PagerTag),
+      ) {
+        Box(Modifier.fillMaxSize())
+      }
+    }
+    waitForIdle()
+
+    onNodeWithTag(PagerTag).performSemanticsAction(SemanticsActions.PageRight) { action ->
+      lateAccessibilityPageRight = action
+    }
+    runOnIdle { gestureAdmissionAllowed = false }
+    waitForIdle()
+    runOnIdle { assertTrue(lateAccessibilityPageRight()) }
+    waitUntil { !state.pagerState.isScrollInProgress }
+
+    assertNull(state.motion)
+    assertEquals(Tab.Home, state.settledTab)
+    assertEquals(Tab.Home.ordinal, state.pagerState.settledPage)
+  }
 
   @Test
   fun `child pager keeps an outward edge drag from the main pager`() = runComposeUiTest {
-    lateinit var mainPagerState: PagerState
+    lateinit var mainTabState: MainTabState
     lateinit var childPagerState: PagerState
 
     setContent {
-      mainPagerState = rememberPagerState(pageCount = { Tab.entries.size })
+      mainTabState = rememberMainTabState()
       childPagerState = rememberPagerState(initialPage = 1, pageCount = { 2 })
       MainTabPager(
-        state = mainPagerState,
-        userScrollEnabled = true,
+        state = mainTabState,
+        gestureAdmissionAllowed = true,
         modifier = Modifier.size(width = 320.dp, height = 640.dp).testTag(PagerTag),
       ) { tab ->
         if (tab == Tab.Home) ChildPager(childPagerState) else Box(Modifier.fillMaxSize())
@@ -206,10 +394,10 @@ class MainTabPagerDesktopTest {
       repeat(8) { moveBy(Offset(x = -20f, y = 0f), delayMillis = 16L) }
       up()
     }
-    waitUntil { !childPagerState.isScrollInProgress && !mainPagerState.isScrollInProgress }
+    waitUntil { !childPagerState.isScrollInProgress && !mainTabState.pagerState.isScrollInProgress }
 
     assertEquals(1, childPagerState.settledPage)
-    assertEquals(0, mainPagerState.settledPage)
+    assertEquals(Tab.Home, mainTabState.settledTab)
   }
 
   @Composable


### PR DESCRIPTION
## 문제

메인 탭의 중첩 화면에서 자동 포커스되는 폼에 진입하면 입력창에 포커스가 잡히고 소프트웨어 키보드가 나타났다가 곧바로 닫혔다.

의견 보내기와 프로필 변경 화면에서 재현됐다.

`HorizontalPager`의 raw scroll 상태를 실제 탭 이동 상태로 직접 사용하면서, 탭 이동과 무관한 pager 내부 작업도 메인 화면의 상호작용 상태를 변경했다. 이 과정에서 `NavigationStack`이 전역 포커스를 해제해 새로 진입한 폼의 자동 포커스가 사라졌다.

## 변경 사항

- `MainTabState`가 확정된 탭과 실제 탭 이동을 명시적으로 소유하도록 변경
- `HorizontalPager`의 raw 상태를 메인 화면과 내비게이션 계층에서 격리
- 실제 탭 이동이 아닌 동일 페이지 pager 작업은 화면 전환으로 취급하지 않도록 보정
- 비활성 탭의 포커스를 제한하되 다른 탭의 포커스까지 전역적으로 해제하지 않도록 `NavigationStack`의 포커스 처리를 범위화
- 내비게이션 잠금 중 pager 이동 취소, drawer 및 자식 pager 제스처 정책 유지
- 의견 보내기와 프로필 변경 autofocus를 포함한 Desktop 회귀 테스트 추가