### PR TITLE
iOS에서 빠른 스와이프가 안 먹는 문제 수정

### DIFF
--- a/apps/mobile/settings.gradle.kts
+++ b/apps/mobile/settings.gradle.kts
@@ -4,6 +4,11 @@ rootProject.name = "typie"
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
+val githubPackagesUser =
+  providers.gradleProperty("gpr.user").orElse(providers.environmentVariable("GITHUB_ACTOR"))
+val githubPackagesToken =
+  providers.gradleProperty("gpr.key").orElse(providers.environmentVariable("GITHUB_TOKEN"))
+
 pluginManagement {
   repositories {
     mavenCentral()
@@ -20,6 +25,23 @@ pluginManagement {
 
 dependencyResolutionManagement {
   repositories {
+    exclusiveContent {
+      forRepository {
+        maven("https://maven.pkg.github.com/penxle/compose-patches") {
+          name = "GitHubPackages"
+          // Local builds read these from ~/.gradle/gradle.properties; CI can provide the
+          // environment fallbacks above.
+          credentials {
+            username = githubPackagesUser.orNull
+            password = githubPackagesToken.orNull
+          }
+        }
+      }
+      filter {
+        includeVersion("org.jetbrains.compose.ui", "ui-iosarm64", "1.12.0-beta03")
+        includeVersion("org.jetbrains.compose.ui", "ui-iossimulatorarm64", "1.12.0-beta03")
+      }
+    }
     mavenCentral()
     google {
       mavenContent {

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -669,6 +669,30 @@ ICU 리소스를 사용한다.
 | Android | Firebase Messaging, Play Billing, Google/Kakao/Naver 로그인 |
 | iOS     | Swift Package bridge, Sentry, push notification             |
 
+#### GitHub Packages 인증
+
+`apps/mobile`의 Gradle 빌드는 GitHub Packages에 배포된 일부 Maven 의존성을
+사용한다. GitHub Packages는 공개 패키지를 내려받을 때도 인증을 요구하므로, 모바일
+빌드 전에 각자 GitHub personal access token (classic)을 준비해야 한다.
+
+1. GitHub에서 `read:packages` 권한이 있는 personal access token (classic)을
+   생성한다.
+2. `~/.gradle/gradle.properties`에 다음 값을 추가한다.
+
+   ```properties
+   gpr.user=<GitHub 사용자명>
+   gpr.key=<personal access token>
+   ```
+
+#### Compose 패치 사용
+
+[`penxle/compose-patches`](https://github.com/penxle/compose-patches)에 게시된 패치를 사용할 때는 `apps/mobile/settings.gradle.kts`의
+`exclusiveContent`에 다음을 반영한다.
+
+- Maven 저장소는 `https://maven.pkg.github.com/penxle/compose-patches`를 사용한다.
+- 패치의 `release.json`에 선언된 각 publication에 대해 최상위 `version`과 `group`, `artifact`를
+  `includeVersion(group, artifact, version)`으로 추가한다.
+
 ### apps/literoom
 
 S3 Object Lambda 핸들러다. Sharp로 원본을 조회하고 리사이즈, WebP/PNG 변환을


### PR DESCRIPTION
## 문제

- Compose의 iOS `PlatformVelocityTracker`가 짧고 빠른 제스처의 릴리스 속도를 0 또는 반대 방향으로 계산할 수 있음
- 이로 인해 메인 탭과 drawer를 충분히 빠르게 스와이프해도 전환되지 않았음

## 변경

- 정지 여부를 마지막 move와 pointer-up 사이의 간격으로 판단합니다.
- 현재 및 historical sample에 원본 이벤트 좌표를 사용합니다.
- 패치와 provenance는 [`penxle/compose-patches`](https://github.com/penxle/compose-patches)에서 관리하고, GitHub Actions로 검증·게시합니다.
- Typie는 패치된 `ui-iosarm64`와 `ui-iossimulatorarm64`만 `compose-patches`의 GitHub Packages에서 해석합니다.
- 나머지 Compose artifact는 기존 upstream 저장소를 계속 사용합니다.
- 로컬 모바일 빌드에 필요한 GitHub Packages 인증과 Compose 패치 사용 방법을 `docs/ONBOARDING.md`에 기록합니다.

## 패치 provenance

- upstream: `https://github.com/JetBrains/compose-multiplatform-core.git`
- upstream commit: `2fbe09679fa51fc3f4a192047dcc7c4484f7adf7`
- source: `compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/input/pointer/util/PlatformVelocityTracker.ios.kt`
- upstream source SHA-256: `fccec5111f5dfd77be9b3611c1a269ac8a970dd1a6ca6e52a06e9b159ed83bdd`
- [release manifest](https://github.com/penxle/compose-patches/blob/0723bb38e9c6d9849d9699dcd1eb7d8ce1fa9c6a/patches/1.12.0-beta03/release.json)
- [patch](https://github.com/penxle/compose-patches/blob/0723bb38e9c6d9849d9699dcd1eb7d8ce1fa9c6a/patches/1.12.0-beta03/ios-velocity-tracker.patch)
- provenance SHA-256: `2affa611ffe415287159806387ec370967d6aa34d585589c66d8cf3c53c81b7c`
- Maven repository: `https://maven.pkg.github.com/penxle/compose-patches`
- publications:
  - `org.jetbrains.compose.ui:ui-iosarm64:1.12.0-beta03`
  - `org.jetbrains.compose.ui:ui-iossimulatorarm64:1.12.0-beta03`

Provenance SHA-256는 canonical `release.json`과 선언된 patch 내용을 순서대로 해시한 값이며, 게시된 POM의 `typie.patch.sha256`에 기록됩니다.

## 제거 조건

동일한 수정이 포함된 Compose 버전으로 업그레이드하면 Typie의 해당 iOS artifact override를 제거합니다. 패치와 provenance는 `compose-patches`에 기록으로 남깁니다.