### PR TITLE
앱 에디터 스크롤바 히트 영역이 가로 여백을 차지하도록 확장

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorScrollbars.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorScrollbars.kt
@@ -69,10 +69,11 @@ import kotlinx.coroutines.withTimeoutOrNull
 private const val ScrollbarOpacityAnimationMs = 300
 private const val ScrollbarThumbAnimationMs = 250
 private const val ScrollbarMinThumbSize = 30f
-private const val ScrollbarTrackPadding = 2f
-private const val ScrollbarTrackWidth = 12f
+private const val ScrollbarEdgePadding = 2f
+private const val ScrollbarHitWidth = 20f
 private const val ScrollbarThumbWidth = 6f
 private const val ScrollbarActiveThumbWidth = 10f
+private const val ScrollbarThumbLaneWidth = ScrollbarActiveThumbWidth + ScrollbarEdgePadding
 private const val ScrollbarHideDelayMs = 1500L
 private const val ScrollbarIndicatorHideDelayMs = 300L
 private const val ScrollbarIndicatorHeight = 24f
@@ -142,7 +143,7 @@ private fun resolveEditorScrollbarLayoutMetrics(
   scrollOffset: Offset,
   visibleArea: EditorVisibleArea,
 ): EditorScrollbarLayoutMetrics {
-  fun vertical(reserveHorizontalTrack: Boolean): EditorViewportScrollbarMetrics =
+  fun vertical(reserveHorizontalScrollbar: Boolean): EditorViewportScrollbarMetrics =
     resolveEditorViewportScrollbarMetrics(
       viewportLength = viewportSize.height,
       contentLength = contentSize.height,
@@ -150,50 +151,52 @@ private fun resolveEditorScrollbarLayoutMetrics(
       minThumbSize = ScrollbarMinThumbSize,
       leadingInset = visibleArea.topOcclusion,
       trailingInset = visibleArea.bottomOcclusion,
-      leadingPadding = ScrollbarTrackPadding,
+      leadingPadding = ScrollbarEdgePadding,
       trailingPadding =
-        ScrollbarTrackPadding + if (reserveHorizontalTrack) ScrollbarTrackWidth else 0f,
+        ScrollbarEdgePadding + if (reserveHorizontalScrollbar) ScrollbarThumbLaneWidth else 0f,
     )
 
-  fun horizontal(reserveVerticalTrack: Boolean): EditorViewportScrollbarMetrics =
+  fun horizontal(reserveVerticalScrollbar: Boolean): EditorViewportScrollbarMetrics =
     resolveEditorViewportScrollbarMetrics(
       viewportLength = viewportSize.width,
       contentLength = contentSize.width,
       scrollPosition = scrollOffset.x,
       minThumbSize = ScrollbarMinThumbSize,
-      leadingPadding = ScrollbarTrackPadding,
+      leadingPadding = ScrollbarEdgePadding,
       trailingPadding =
-        ScrollbarTrackPadding + if (reserveVerticalTrack) ScrollbarTrackWidth else 0f,
+        ScrollbarEdgePadding + if (reserveVerticalScrollbar) ScrollbarThumbLaneWidth else 0f,
     )
 
-  val verticalWithoutCrossTrack = vertical(reserveHorizontalTrack = false)
-  val horizontalWithoutCrossTrack = horizontal(reserveVerticalTrack = false)
+  val verticalWithoutHorizontalScrollbar = vertical(reserveHorizontalScrollbar = false)
+  val horizontalWithoutVerticalScrollbar = horizontal(reserveVerticalScrollbar = false)
   val (vertical, horizontal) =
     when {
-      !verticalWithoutCrossTrack.isVisible && !horizontalWithoutCrossTrack.isVisible ->
-        verticalWithoutCrossTrack to horizontalWithoutCrossTrack
+      !verticalWithoutHorizontalScrollbar.isVisible &&
+        !horizontalWithoutVerticalScrollbar.isVisible ->
+        verticalWithoutHorizontalScrollbar to horizontalWithoutVerticalScrollbar
 
-      !verticalWithoutCrossTrack.isVisible ->
-        vertical(reserveHorizontalTrack = true) to horizontalWithoutCrossTrack
+      !verticalWithoutHorizontalScrollbar.isVisible ->
+        vertical(reserveHorizontalScrollbar = true) to horizontalWithoutVerticalScrollbar
 
-      !horizontalWithoutCrossTrack.isVisible ->
-        verticalWithoutCrossTrack to horizontal(reserveVerticalTrack = true)
+      !horizontalWithoutVerticalScrollbar.isVisible ->
+        verticalWithoutHorizontalScrollbar to horizontal(reserveVerticalScrollbar = true)
 
       else -> {
-        val verticalWithCrossTrack = vertical(reserveHorizontalTrack = true)
-        val horizontalWithCrossTrack = horizontal(reserveVerticalTrack = true)
+        val verticalWithHorizontalScrollbar = vertical(reserveHorizontalScrollbar = true)
+        val horizontalWithVerticalScrollbar = horizontal(reserveVerticalScrollbar = true)
         when {
-          verticalWithCrossTrack.isVisible && horizontalWithCrossTrack.isVisible ->
-            verticalWithCrossTrack to horizontalWithCrossTrack
+          verticalWithHorizontalScrollbar.isVisible && horizontalWithVerticalScrollbar.isVisible ->
+            verticalWithHorizontalScrollbar to horizontalWithVerticalScrollbar
 
-          verticalWithCrossTrack.isVisible -> verticalWithoutCrossTrack to horizontalWithCrossTrack
+          verticalWithHorizontalScrollbar.isVisible ->
+            verticalWithoutHorizontalScrollbar to horizontalWithVerticalScrollbar
 
-          horizontalWithCrossTrack.isVisible ->
-            verticalWithCrossTrack to horizontalWithoutCrossTrack
+          horizontalWithVerticalScrollbar.isVisible ->
+            verticalWithHorizontalScrollbar to horizontalWithoutVerticalScrollbar
 
-          // Both axes cannot fit while reserving each other. Keep the vertical track, which is the
-          // primary document-scrolling axis, and hide the horizontal one.
-          else -> verticalWithoutCrossTrack to horizontalWithCrossTrack
+          // Both axes cannot fit while reserving each other. Keep the vertical scrollbar, which is
+          // the primary document-scrolling axis, and hide the horizontal one.
+          else -> verticalWithoutHorizontalScrollbar to horizontalWithVerticalScrollbar
         }
       }
     }
@@ -499,10 +502,10 @@ internal fun EditorScrollbarIndicatorLayout(
       if (verticalMetrics.isVisible) {
         val top =
           visibleArea.topOcclusion +
-            ScrollbarTrackPadding +
+            ScrollbarEdgePadding +
             verticalMetrics.thumbOffset +
             verticalMetrics.thumbSize / 2f - ScrollbarIndicatorHeight / 2f
-        val right = ScrollbarTrackPadding + ScrollbarActiveThumbWidth + ScrollbarIndicatorGap
+        val right = ScrollbarThumbLaneWidth + ScrollbarIndicatorGap
         val x =
           (Dp(layoutMetrics.viewportSize.width - right).roundToPx() - placeable.width)
             .coerceAtLeast(0)
@@ -530,8 +533,8 @@ private fun EditorScrollbarThumb(
   val latestVisibleArea = rememberUpdatedState(visibleArea)
   val latestTryClaimDirectDrag = rememberUpdatedState(tryClaimDirectDrag)
   val latestOnDragChanged = rememberUpdatedState(onDragChanged)
-  val trackWidth = ScrollbarTrackWidth.dp
-  val trackPadding = ScrollbarTrackPadding.dp
+  val thumbLaneWidth = ScrollbarThumbLaneWidth.dp
+  val edgePadding = ScrollbarEdgePadding.dp
   val animatedThumbThickness by
     animateDpAsState(
       targetValue = Dp(resolveEditorScrollbarThumbThickness(isDragging)),
@@ -586,9 +589,9 @@ private fun EditorScrollbarThumb(
         Box(
           modifier =
             Modifier.align(Alignment.CenterEnd)
-              .width(trackWidth)
+              .width(thumbLaneWidth)
               .fillMaxHeight()
-              .padding(end = trackPadding),
+              .padding(end = edgePadding),
           contentAlignment = Alignment.CenterEnd,
         ) {
           EditorScrollbarThumbBody(
@@ -601,8 +604,8 @@ private fun EditorScrollbarThumb(
           modifier =
             Modifier.align(Alignment.BottomCenter)
               .fillMaxWidth()
-              .height(trackWidth)
-              .padding(bottom = trackPadding),
+              .height(thumbLaneWidth)
+              .padding(bottom = edgePadding),
           contentAlignment = Alignment.BottomCenter,
         ) {
           EditorScrollbarThumbBody(
@@ -626,7 +629,7 @@ internal fun EditorScrollbarThumbLayout(
   Layout(modifier = modifier, content = content) { measurables, constraints ->
     val layoutMetrics = resolveEditorScrollbarLayoutMetrics(viewportState, visibleArea)
     val axisMetrics = if (!horizontal) layoutMetrics.vertical else layoutMetrics.horizontal
-    val hitThickness = Dp(ScrollbarTrackWidth).roundToPx()
+    val hitThickness = Dp(ScrollbarHitWidth).roundToPx()
     val thumbLength = Dp(axisMetrics.thumbSize).roundToPx()
     val childConstraints =
       if (!horizontal) {
@@ -640,21 +643,17 @@ internal fun EditorScrollbarThumbLayout(
       if (axisMetrics.isVisible) {
         val x =
           if (!horizontal) {
-            Dp(layoutMetrics.viewportSize.width - ScrollbarTrackWidth).roundToPx().coerceAtLeast(0)
+            Dp(layoutMetrics.viewportSize.width - ScrollbarHitWidth).roundToPx().coerceAtLeast(0)
           } else {
-            Dp(ScrollbarTrackPadding + axisMetrics.thumbOffset).roundToPx().coerceAtLeast(0)
+            Dp(ScrollbarEdgePadding + axisMetrics.thumbOffset).roundToPx().coerceAtLeast(0)
           }
         val y =
           if (!horizontal) {
-            Dp(visibleArea.topOcclusion + ScrollbarTrackPadding + axisMetrics.thumbOffset)
+            Dp(visibleArea.topOcclusion + ScrollbarEdgePadding + axisMetrics.thumbOffset)
               .roundToPx()
               .coerceAtLeast(0)
           } else {
-            Dp(
-                layoutMetrics.viewportSize.height -
-                  visibleArea.bottomOcclusion -
-                  ScrollbarTrackWidth
-              )
+            Dp(layoutMetrics.viewportSize.height - visibleArea.bottomOcclusion - ScrollbarHitWidth)
               .roundToPx()
               .coerceAtLeast(0)
           }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayoutDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayoutDesktopTest.kt
@@ -841,7 +841,7 @@ class EditorScreenLayoutDesktopTest {
     waitForIdle()
 
     onNodeWithTag(LayoutTag).performMouseInput {
-      moveTo(Offset(x = TestViewportSize.width - 20f, y = 32f))
+      moveTo(Offset(x = TestViewportSize.width - ExpectedScrollbarHitWidth - 1f, y = 32f))
       press()
       release()
     }
@@ -852,7 +852,7 @@ class EditorScreenLayoutDesktopTest {
   }
 
   @Test
-  fun scrollbarCoreTouchAxisDragClaimsAfterSlop() = runComposeUiTest {
+  fun scrollbarHitAreaTouchAxisDragClaimsAfterSlop() = runComposeUiTest {
     val fixture = ViewportOverlayFixture()
     setViewportOverlayContent(
       fixture = fixture,
@@ -872,8 +872,8 @@ class EditorScreenLayoutDesktopTest {
         minThumbSize = ExpectedScrollbarMinThumbSize,
         leadingInset = fixture.visibleArea.topOcclusion,
         trailingInset = fixture.visibleArea.bottomOcclusion,
-        leadingPadding = ExpectedScrollbarTrackPadding,
-        trailingPadding = ExpectedScrollbarTrackPadding,
+        leadingPadding = ExpectedScrollbarEdgePadding,
+        trailingPadding = ExpectedScrollbarEdgePadding,
       )
     val expectedScroll =
       resolveEditorViewportScrollbarScrollPositionFromDrag(
@@ -885,9 +885,11 @@ class EditorScreenLayoutDesktopTest {
         contentLength = fixture.viewportState.contentSize.height,
       )
     onNodeWithTag(LayoutTag).performTouchInput {
-      down(Offset(x = TestViewportSize.width - 6f, y = 32f))
+      down(Offset(x = TestViewportSize.width - ExpectedScrollbarHitWidth + 1f, y = 32f))
       advanceEventTime(16L)
-      moveTo(Offset(x = TestViewportSize.width - 6f, y = 32f + dragDelta))
+      moveTo(
+        Offset(x = TestViewportSize.width - ExpectedScrollbarHitWidth + 1f, y = 32f + dragDelta)
+      )
       up()
     }
     waitForIdle()
@@ -910,9 +912,9 @@ class EditorScreenLayoutDesktopTest {
 
     val initialScroll = fixture.viewportState.scrollOffset.y
     onNodeWithTag(LayoutTag).performTouchInput {
-      down(Offset(x = TestViewportSize.width - 20f, y = 32f))
+      down(Offset(x = TestViewportSize.width - ExpectedScrollbarHitWidth - 1f, y = 32f))
       advanceEventTime(16L)
-      moveTo(Offset(x = TestViewportSize.width - 20f, y = 72f))
+      moveTo(Offset(x = TestViewportSize.width - ExpectedScrollbarHitWidth - 1f, y = 72f))
       up()
     }
     waitForIdle()
@@ -935,9 +937,9 @@ class EditorScreenLayoutDesktopTest {
 
     val initialScroll = fixture.viewportState.scrollOffset.y
     onNodeWithTag(LayoutTag).performTouchInput {
-      down(Offset(x = TestViewportSize.width - 20f, y = 32f))
+      down(Offset(x = TestViewportSize.width - ExpectedScrollbarHitWidth - 1f, y = 32f))
       advanceEventTime(EditorScrollbarPressAndHoldDurationMillis)
-      moveTo(Offset(x = TestViewportSize.width - 20f, y = 72f))
+      moveTo(Offset(x = TestViewportSize.width - ExpectedScrollbarHitWidth - 1f, y = 72f))
       up()
     }
     waitForIdle()
@@ -1017,9 +1019,9 @@ class EditorScreenLayoutDesktopTest {
 
     val initialScroll = fixture.viewportState.scrollOffset.y
     onNodeWithTag(LayoutTag).performMouseInput {
-      moveTo(Offset(x = TestViewportSize.width - 20f, y = 32f))
+      moveTo(Offset(x = TestViewportSize.width - ExpectedScrollbarHitWidth - 1f, y = 32f))
       press()
-      moveTo(Offset(x = TestViewportSize.width - 20f, y = 72f))
+      moveTo(Offset(x = TestViewportSize.width - ExpectedScrollbarHitWidth - 1f, y = 72f))
       release()
     }
     waitForIdle()
@@ -1042,10 +1044,10 @@ class EditorScreenLayoutDesktopTest {
 
     val initialScroll = fixture.viewportState.scrollOffset.y
     onNodeWithTag(LayoutTag).performMouseInput {
-      moveTo(Offset(x = TestViewportSize.width - 20f, y = 32f))
+      moveTo(Offset(x = TestViewportSize.width - ExpectedScrollbarHitWidth - 1f, y = 32f))
       press()
       advanceEventTime(EditorScrollbarPressAndHoldDurationMillis)
-      moveTo(Offset(x = TestViewportSize.width - 20f, y = 72f))
+      moveTo(Offset(x = TestViewportSize.width - ExpectedScrollbarHitWidth - 1f, y = 72f))
       release()
     }
     waitForIdle()
@@ -1870,7 +1872,8 @@ class EditorScreenLayoutDesktopTest {
     const val HeaderHeightPx = 96f
     const val HeaderText = "Header title"
     const val ExpectedScrollbarMinThumbSize = 30f
-    const val ExpectedScrollbarTrackPadding = 2f
+    const val ExpectedScrollbarEdgePadding = 2f
+    const val ExpectedScrollbarHitWidth = 20f
     val ControlPointerMove = Offset(x = 40f, y = 40f)
     val ControlPointerStart = Offset(x = 80f, y = 40f)
     val EditorPointerMove = Offset(x = 300f, y = HeaderHeightPx + 140f)

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorScrollbarsDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorScrollbarsDesktopTest.kt
@@ -74,7 +74,9 @@ class EditorScrollbarsDesktopTest {
 
     assertTrue(zoomedPlacements.isNotEmpty())
     zoomedPlacements.forEach { placement ->
+      assertEquals(80f, placement.left, absoluteTolerance = 0.01f)
       assertEquals(34f, placement.top, absoluteTolerance = 0.01f)
+      assertEquals(20f, placement.width, absoluteTolerance = 0.01f)
       assertEquals(32f, placement.height, absoluteTolerance = 0.01f)
     }
   }
@@ -134,12 +136,16 @@ class EditorScrollbarsDesktopTest {
     assertTrue(verticalPlacements.isNotEmpty())
     assertTrue(horizontalPlacements.isNotEmpty())
     verticalPlacements.forEach { placement ->
+      assertEquals(80f, placement.left, absoluteTolerance = 0.01f)
       assertEquals(2f, placement.top, absoluteTolerance = 0.01f)
+      assertEquals(20f, placement.width, absoluteTolerance = 0.01f)
       assertEquals(42f, placement.height, absoluteTolerance = 0.01f)
     }
     horizontalPlacements.forEach { placement ->
       assertEquals(2f, placement.left, absoluteTolerance = 0.01f)
+      assertEquals(80f, placement.top, absoluteTolerance = 0.01f)
       assertEquals(42f, placement.width, absoluteTolerance = 0.01f)
+      assertEquals(20f, placement.height, absoluteTolerance = 0.01f)
     }
 
     runOnIdle { contentSize.value = Size(width = 100f, height = 100f) }


### PR DESCRIPTION
- 스크롤바의 직접 조작 히트 영역을 12dp에서 20dp로 확장
- continuous 모드의 기본 가로 여백(20dp)에 들어가고, 여전히 셀렉션 핸들 등 오버레이 제스처가 우선하고 일반 탭은 에디터가 우선함
- #5146 을 되돌리는 것은 아님