### PR TITLE
에디터 스크롤 reveal 정책 개선

### DIFF
--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/input/EditorInputConnection.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/input/EditorInputConnection.kt
@@ -21,6 +21,7 @@ import co.typie.editor.ffi.FlatImeOp
 import co.typie.editor.ffi.Key
 import co.typie.editor.ffi.KeyEvent as FfiKeyEvent
 import co.typie.editor.ffi.Message
+import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.EditorBringIntoViewTarget
 import co.typie.editor.scroll.updateNowWithBringIntoView
@@ -85,7 +86,10 @@ internal class EditorInputConnection(
           for (message in messages) {
             enqueue(message)
           }
-          bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+          bringIntoView(
+            EditorBringIntoViewTarget.CurrentSelectionHead,
+            policy = EditorBringIntoViewPolicy.Typewriter,
+          )
         }
       }
       recorder?.record { seq, t ->

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorInput.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorInput.kt
@@ -38,6 +38,7 @@ import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.Selection
 import co.typie.editor.matchesKeyBinding
 import co.typie.editor.runtime.EditorUiState
+import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.EditorBringIntoViewTarget
 import co.typie.editor.scroll.updateNowWithBringIntoView
@@ -268,7 +269,9 @@ internal class EditorInputNode(
       sessionEditor.scope.launch(context) {
         sessionEditor.updateWithBringIntoView(bringIntoViewRequests) {
           messages.forEach(::enqueue)
-          bringIntoViewTarget?.let { target -> bringIntoView(target) }
+          bringIntoViewTarget?.let { target ->
+            bringIntoView(target, policy = EditorBringIntoViewPolicy.Typewriter)
+          }
         }
       }
     }
@@ -380,7 +383,9 @@ internal class EditorInputNode(
     val update =
       editor.updateWithBringIntoView(bringIntoViewRequests) {
         messages.forEach(::enqueue)
-        bringIntoViewTarget?.let { target -> bringIntoView(target) }
+        bringIntoViewTarget?.let { target ->
+          bringIntoView(target, policy = EditorBringIntoViewPolicy.Typewriter)
+        }
       } ?: return null
     return update.snapshot
   }
@@ -394,7 +399,9 @@ internal class EditorInputNode(
       .runInputCallback {
         editor.updateNowWithBringIntoView(bringIntoViewRequests) {
           messages.forEach(::enqueue)
-          bringIntoViewTarget?.let { target -> bringIntoView(target) }
+          bringIntoViewTarget?.let { target ->
+            bringIntoView(target, policy = EditorBringIntoViewPolicy.Typewriter)
+          }
         }
       }
       ?.snapshot

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionEffects.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionEffects.kt
@@ -32,5 +32,5 @@ internal interface EditorInteractionEffects {
 
   fun performSelectionHaptic()
 
-  fun requestCurrentSelectionHead(version: Long)
+  fun requestPointerSelectionHead(version: Long)
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionScope.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionScope.kt
@@ -10,6 +10,7 @@ import co.typie.editor.interaction.gestures.EditorLongPressDispatchDelayMillis
 import co.typie.editor.interaction.gestures.EditorTapDispatchDelayMillis
 import co.typie.editor.interaction.semantics.EditorViewportZoomSemanticConfig
 import co.typie.editor.runtime.EditorUiState
+import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.EditorBringIntoViewTarget
 import co.typie.editor.scroll.EditorVisibleArea
@@ -327,10 +328,11 @@ internal class EditorInteractionScope(
     onSelectionHaptic?.invoke()
   }
 
-  override fun requestCurrentSelectionHead(version: Long) {
+  override fun requestPointerSelectionHead(version: Long) {
     bringIntoViewRequests?.requestForVersion(
       target = EditorBringIntoViewTarget.CurrentSelectionHead,
       version = version,
+      policy = EditorBringIntoViewPolicy.PointerCursorGuard,
     )
   }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorTapGesture.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorTapGesture.kt
@@ -737,7 +737,7 @@ private fun EditorTapGesture.dispatchSelectionTap(
         !snapshot.selection.isCollapsed() -> {
           if (!hitExistingSelectionAtTap) {
             showContextMenuAfterPublication = true
-            context.effects.requestCurrentSelectionHead(version = snapshot.version)
+            context.effects.requestPointerSelectionHead(version = snapshot.version)
           }
         }
         isSameCursorTap(previousCursor, snapshot) -> {
@@ -745,7 +745,7 @@ private fun EditorTapGesture.dispatchSelectionTap(
         }
         else -> {
           if (snapshot.cursor != null) {
-            context.effects.requestCurrentSelectionHead(version = snapshot.version)
+            context.effects.requestPointerSelectionHead(version = snapshot.version)
           }
         }
       }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorAutoScrollPolicy.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorAutoScrollPolicy.kt
@@ -6,22 +6,24 @@ import kotlin.math.abs
 internal const val CursorVisibleMargin = 60f
 private const val TypewriterMinBottomPadding = 48f
 
-internal enum class EditorAutoScrollMode {
-  KeepCursorVisible,
-  Typewriter,
-}
-
 internal data class EditorAutoScrollPolicy(
-  val mode: EditorAutoScrollMode,
+  val typewriterActive: Boolean,
   val typewriterPosition: Float,
-  val keepVisibleRange: VerticalSpan,
   val targetTop: Float?,
   val targetLineHeight: Float,
   val bottomPadding: Float,
+  val configuration: EditorAutoScrollPolicyConfiguration,
 ) {
   val targetBottom: Float?
     get() = targetTop?.plus(targetLineHeight)
 }
+
+internal data class EditorAutoScrollPolicyConfiguration(
+  val bottomScrollReserveArea: EditorVisibleArea,
+  val baseBottomSpace: Float,
+  val pageBottomRevealPadding: Float,
+  val typewriterEnabled: Boolean,
+)
 
 internal fun resolveEditorAutoScrollPolicy(
   visibleArea: EditorVisibleArea,
@@ -29,11 +31,12 @@ internal fun resolveEditorAutoScrollPolicy(
   baseBottomSpace: Float = 0f,
   pageBottomRevealPadding: Float = 0f,
   typewriterEnabled: Boolean = false,
+  typewriterActive: Boolean = typewriterEnabled,
   typewriterPosition: Float = 0.5f,
   targetLineHeight: Float = 0f,
 ): EditorAutoScrollPolicy {
+  val useTypewriter = typewriterEnabled && typewriterActive
   val resolvedTypewriterPosition = typewriterPosition.coerceIn(0f, 1f)
-  val keepVisibleRange = resolveKeepVisibleRange(visibleArea)
   val resolvedTargetLineHeight = targetLineHeight.coerceAtLeast(0f)
   val targetTop =
     resolveScrollTargetTop(
@@ -47,7 +50,7 @@ internal fun resolveEditorAutoScrollPolicy(
       baseBottomSpace = baseBottomSpace,
     )
   val modeBottomPadding =
-    if (typewriterEnabled) {
+    if (useTypewriter) {
       resolveTypewriterBottomPadding(
         visibleArea = bottomScrollReserveArea,
         baseBottomSpace = baseBottomSpace,
@@ -59,23 +62,45 @@ internal fun resolveEditorAutoScrollPolicy(
     }
 
   return EditorAutoScrollPolicy(
-    mode =
-      if (typewriterEnabled) EditorAutoScrollMode.Typewriter
-      else EditorAutoScrollMode.KeepCursorVisible,
+    typewriterActive = useTypewriter,
     typewriterPosition = resolvedTypewriterPosition,
-    keepVisibleRange = keepVisibleRange,
     targetTop = targetTop,
     targetLineHeight = resolvedTargetLineHeight,
     bottomPadding =
       maxOf(keepVisibleBottomPadding, modeBottomPadding, pageBottomRevealPadding.coerceAtLeast(0f)),
+    configuration =
+      EditorAutoScrollPolicyConfiguration(
+        bottomScrollReserveArea = bottomScrollReserveArea,
+        baseBottomSpace = baseBottomSpace,
+        pageBottomRevealPadding = pageBottomRevealPadding,
+        typewriterEnabled = typewriterEnabled,
+      ),
   )
 }
+
+internal fun EditorAutoScrollPolicy.resolveForState(
+  visibleArea: EditorVisibleArea,
+  typewriterActive: Boolean,
+  targetLineHeight: Float,
+): EditorAutoScrollPolicy =
+  resolveEditorAutoScrollPolicy(
+    visibleArea = visibleArea,
+    bottomScrollReserveArea = configuration.bottomScrollReserveArea,
+    baseBottomSpace = configuration.baseBottomSpace,
+    pageBottomRevealPadding = configuration.pageBottomRevealPadding,
+    typewriterEnabled = configuration.typewriterEnabled,
+    typewriterActive = typewriterActive,
+    typewriterPosition = typewriterPosition,
+    targetLineHeight = targetLineHeight,
+  )
 
 internal fun resolveEditorScrollOffset(
   currentScroll: Float,
   targetTopInContent: Float,
   targetBottomInContent: Float,
   range: VerticalSpan,
+  maximumScrollY: Float = Float.POSITIVE_INFINITY,
+  oversizedMinimumVisibleHeight: Float? = null,
 ): Float? {
   if (!range.isValid) {
     return null
@@ -85,12 +110,56 @@ internal fun resolveEditorScrollOffset(
   val targetBottomInViewport = targetBottomInContent - currentScroll
   val targetHeight = (targetBottomInContent - targetTopInContent).coerceAtLeast(0f)
 
-  return when {
-    targetHeight > range.height -> targetTopInContent - range.top
-    targetBottomInViewport > range.bottom -> targetBottomInContent - range.bottom
-    targetTopInViewport < range.top -> targetTopInContent - range.top
-    else -> null
+  if (targetHeight > range.height) {
+    if (oversizedMinimumVisibleHeight != null) {
+      val minimumVisibleHeight = oversizedMinimumVisibleHeight.coerceIn(0f, range.height)
+      val visibleHeight =
+        (minOf(targetBottomInViewport, range.bottom) - maxOf(targetTopInViewport, range.top))
+          .coerceAtLeast(0f)
+      if (visibleHeight >= minimumVisibleHeight) {
+        return null
+      }
+
+      val targetScroll =
+        when {
+          targetTopInViewport > range.top ->
+            targetTopInContent - (range.bottom - minimumVisibleHeight)
+          targetBottomInViewport < range.bottom ->
+            targetBottomInContent - (range.top + minimumVisibleHeight)
+          else -> null
+        } ?: return null
+      return resolveFeasibleScrollOffset(
+        targetScroll = targetScroll,
+        currentScroll = currentScroll,
+        maximumScrollY = maximumScrollY,
+      )
+    }
+
+    val targetScroll =
+      when {
+        targetTopInViewport <= range.top && targetBottomInViewport >= range.bottom -> null
+        targetBottomInViewport > range.bottom -> targetBottomInContent - range.bottom
+        targetTopInViewport < range.top -> targetTopInContent - range.top
+        else -> null
+      } ?: return null
+    return resolveFeasibleScrollOffset(
+      targetScroll = targetScroll,
+      currentScroll = currentScroll,
+      maximumScrollY = maximumScrollY,
+    )
   }
+
+  val targetScroll =
+    when {
+      targetBottomInViewport > range.bottom -> targetBottomInContent - range.bottom
+      targetTopInViewport < range.top -> targetTopInContent - range.top
+      else -> null
+    } ?: return null
+  return resolveFeasibleScrollOffset(
+    targetScroll = targetScroll,
+    currentScroll = currentScroll,
+    maximumScrollY = maximumScrollY,
+  )
 }
 
 internal fun resolveKeepVisibleScrollOffset(
@@ -98,6 +167,8 @@ internal fun resolveKeepVisibleScrollOffset(
   targetTopInContent: Float,
   targetBottomInContent: Float,
   visibleArea: EditorVisibleArea,
+  maximumScrollY: Float = Float.POSITIVE_INFINITY,
+  oversizedMinimumVisibleHeight: Float? = null,
 ): Float? {
   val keepVisibleRange = resolveKeepVisibleRange(visibleArea)
   if (!keepVisibleRange.isValid) {
@@ -106,6 +177,7 @@ internal fun resolveKeepVisibleScrollOffset(
       targetTopInContent = targetTopInContent,
       targetBottomInContent = targetBottomInContent,
       visibleArea = visibleArea,
+      maximumScrollY = maximumScrollY,
     )
   }
 
@@ -114,6 +186,44 @@ internal fun resolveKeepVisibleScrollOffset(
     targetTopInContent = targetTopInContent,
     targetBottomInContent = targetBottomInContent,
     range = keepVisibleRange,
+    maximumScrollY = maximumScrollY,
+    oversizedMinimumVisibleHeight = oversizedMinimumVisibleHeight,
+  )
+}
+
+internal fun resolveResultRevealScrollOffset(
+  currentScroll: Float,
+  targetTopInContent: Float,
+  targetBottomInContent: Float,
+  visibleArea: EditorVisibleArea,
+  maximumScrollY: Float = Float.POSITIVE_INFINITY,
+): Float? {
+  val keepVisibleRange = resolveKeepVisibleRange(visibleArea)
+  if (!keepVisibleRange.isValid) {
+    return resolveCenteredVisibleScrollOffset(
+      currentScroll = currentScroll,
+      targetTopInContent = targetTopInContent,
+      targetBottomInContent = targetBottomInContent,
+      visibleArea = visibleArea,
+      maximumScrollY = maximumScrollY,
+    )
+  }
+
+  val targetHeight = (targetBottomInContent - targetTopInContent).coerceAtLeast(0f)
+  if (targetHeight <= keepVisibleRange.height) {
+    return resolveEditorScrollOffset(
+      currentScroll = currentScroll,
+      targetTopInContent = targetTopInContent,
+      targetBottomInContent = targetBottomInContent,
+      range = keepVisibleRange,
+      maximumScrollY = maximumScrollY,
+    )
+  }
+
+  return resolveFeasibleScrollOffset(
+    targetScroll = targetTopInContent - keepVisibleRange.top,
+    currentScroll = currentScroll,
+    maximumScrollY = maximumScrollY,
   )
 }
 
@@ -122,6 +232,7 @@ private fun resolveCenteredVisibleScrollOffset(
   targetTopInContent: Float,
   targetBottomInContent: Float,
   visibleArea: EditorVisibleArea,
+  maximumScrollY: Float,
 ): Float? {
   val visibleTop = visibleArea.visibleViewportTop
   val visibleBottom = visibleArea.visibleViewportBottom
@@ -136,11 +247,11 @@ private fun resolveCenteredVisibleScrollOffset(
   val targetCenter = targetTopInContent + (targetBottomInContent - targetTopInContent) / 2f
   val visibleCenter = visibleTop + (visibleBottom - visibleTop) / 2f
   val targetScroll = targetCenter - visibleCenter
-  return if (abs(targetScroll - currentScroll) <= 1f) {
-    null
-  } else {
-    targetScroll
-  }
+  return resolveFeasibleScrollOffset(
+    targetScroll = targetScroll,
+    currentScroll = currentScroll,
+    maximumScrollY = maximumScrollY,
+  )
 }
 
 internal fun resolveTypewriterScrollOffset(
@@ -149,8 +260,19 @@ internal fun resolveTypewriterScrollOffset(
   targetBottomInContent: Float,
   visibleArea: EditorVisibleArea,
   position: Float,
+  maximumScrollY: Float = Float.POSITIVE_INFINITY,
 ): Float? {
   val targetHeight = (targetBottomInContent - targetTopInContent).coerceAtLeast(0f)
+  val keepVisibleRange = resolveKeepVisibleRange(visibleArea)
+  if (!keepVisibleRange.isValid || targetHeight > keepVisibleRange.height) {
+    return resolveKeepVisibleScrollOffset(
+      currentScroll = currentScroll,
+      targetTopInContent = targetTopInContent,
+      targetBottomInContent = targetBottomInContent,
+      visibleArea = visibleArea,
+      maximumScrollY = maximumScrollY,
+    )
+  }
   val targetTopInViewport =
     resolveScrollTargetTop(
       visibleArea = visibleArea,
@@ -158,11 +280,20 @@ internal fun resolveTypewriterScrollOffset(
       targetHeight = targetHeight,
     ) ?: return null
   val targetScroll = targetTopInContent - targetTopInViewport
-  return if (abs(targetScroll - currentScroll) <= 1f) {
-    null
-  } else {
-    targetScroll
-  }
+  return resolveFeasibleScrollOffset(
+    targetScroll = targetScroll,
+    currentScroll = currentScroll,
+    maximumScrollY = maximumScrollY,
+  )
+}
+
+private fun resolveFeasibleScrollOffset(
+  targetScroll: Float,
+  currentScroll: Float,
+  maximumScrollY: Float,
+): Float? {
+  val feasibleScroll = targetScroll.coerceIn(0f, maximumScrollY)
+  return feasibleScroll.takeUnless { abs(it - currentScroll) <= 1f }
 }
 
 internal fun resolveKeepVisibleRange(visibleArea: EditorVisibleArea): VerticalSpan {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorBringIntoViewRequests.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorBringIntoViewRequests.kt
@@ -13,10 +13,13 @@ import kotlinx.coroutines.CompletableDeferred
 
 @OptIn(ExperimentalAtomicApi::class)
 internal class EditorBringIntoViewRequests(private val requestPresentation: () -> Unit = {}) {
-  data class Request(
-    val target: EditorBringIntoViewTarget,
-    val behavior: EditorBringIntoViewBehavior = EditorBringIntoViewBehavior.Instant,
-  ) {
+  data class Request(val target: EditorBringIntoViewTarget, val policy: EditorBringIntoViewPolicy) {
+    val behavior: EditorBringIntoViewBehavior =
+      if (policy == EditorBringIntoViewPolicy.ResultReveal) {
+        EditorBringIntoViewBehavior.Smooth
+      } else {
+        EditorBringIntoViewBehavior.Instant
+      }
     internal val targetVersion = AtomicLong(UNBOUND_VERSION)
     internal val presentation = CompletableDeferred<Unit>()
   }
@@ -25,13 +28,13 @@ internal class EditorBringIntoViewRequests(private val requestPresentation: () -
 
   fun requestForState(
     state: EditorState,
-    behavior: EditorBringIntoViewBehavior = EditorBringIntoViewBehavior.Instant,
+    policy: EditorBringIntoViewPolicy,
     target: EditorState.() -> EditorBringIntoViewTarget?,
   ): Boolean {
     requestForVersion(
       target = state.target() ?: return false,
       version = state.version,
-      behavior = behavior,
+      policy = policy,
     )
     return true
   }
@@ -39,14 +42,11 @@ internal class EditorBringIntoViewRequests(private val requestPresentation: () -
   fun requestForVersion(
     target: EditorBringIntoViewTarget,
     version: Long,
-    behavior: EditorBringIntoViewBehavior = EditorBringIntoViewBehavior.Instant,
-  ): Request = declare(target, behavior).also { bind(it, version) }
+    policy: EditorBringIntoViewPolicy,
+  ): Request = declare(target = target, policy = policy).also { bind(it, version) }
 
-  fun declare(
-    target: EditorBringIntoViewTarget,
-    behavior: EditorBringIntoViewBehavior = EditorBringIntoViewBehavior.Instant,
-  ): Request {
-    val request = Request(target = target, behavior = behavior)
+  fun declare(target: EditorBringIntoViewTarget, policy: EditorBringIntoViewPolicy): Request {
+    val request = Request(target = target, policy = policy)
     pending.exchange(request)?.presentation?.complete(Unit)
     requestPresentation()
     return request
@@ -81,9 +81,13 @@ internal class EditorBringIntoViewRequests(private val requestPresentation: () -
     val targetVersion =
       request.targetVersion.load().takeUnless { it == UNBOUND_VERSION } ?: return null
     val eligible =
-      when (request.target) {
-        is EditorBringIntoViewTarget.PageRects -> version == targetVersion
-        EditorBringIntoViewTarget.CurrentSelectionHead -> version >= targetVersion
+      if (
+        request.target is EditorBringIntoViewTarget.PageRects ||
+          request.policy == EditorBringIntoViewPolicy.PointerCursorGuard
+      ) {
+        version == targetVersion
+      } else {
+        version >= targetVersion
       }
     return request.takeIf { eligible }
   }
@@ -91,7 +95,10 @@ internal class EditorBringIntoViewRequests(private val requestPresentation: () -
   fun discardObsoleteForVersion(version: Long) {
     val request = pending.load() ?: return
     val targetVersion = request.targetVersion.load().takeUnless { it == UNBOUND_VERSION } ?: return
-    if (request.target is EditorBringIntoViewTarget.PageRects && version > targetVersion) {
+    if (
+      (request.target is EditorBringIntoViewTarget.PageRects ||
+        request.policy == EditorBringIntoViewPolicy.PointerCursorGuard) && version > targetVersion
+    ) {
       discard(request)
     }
   }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorScrollIntent.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorScrollIntent.kt
@@ -17,12 +17,55 @@ internal data class EditorScrollFrame(
   val headerHeight: Float,
   val density: Float,
   val editorBounds: EditorBoundsInContainer,
-)
+) {
+  fun withState(state: EditorState): EditorScrollFrame {
+    return copy(
+      state = state,
+      autoScrollPolicy =
+        autoScrollPolicy.resolveForState(
+          state = state,
+          visibleArea = visibleArea,
+          layoutSpec = layoutSpec,
+          displayZoom = displayZoom,
+          density = density,
+        ),
+    )
+  }
+}
+
+internal fun EditorAutoScrollPolicy.resolveForState(
+  state: EditorState,
+  visibleArea: EditorVisibleArea,
+  layoutSpec: EditorDocumentLayoutSpec,
+  displayZoom: Float,
+  density: Float,
+): EditorAutoScrollPolicy {
+  val targetLineHeight =
+    resolveBringIntoViewTargetHeight(
+      state = state,
+      layoutSpec = layoutSpec,
+      target = EditorBringIntoViewTarget.CurrentSelectionHead,
+      displayZoom = displayZoom,
+      density = density,
+    )
+  return resolveForState(
+    visibleArea = visibleArea,
+    typewriterActive = targetLineHeight != null,
+    targetLineHeight = targetLineHeight ?: 0f,
+  )
+}
 
 internal sealed interface EditorBringIntoViewTarget {
   data object CurrentSelectionHead : EditorBringIntoViewTarget
 
   data class PageRects(val rects: List<PageRect>) : EditorBringIntoViewTarget
+}
+
+internal enum class EditorBringIntoViewPolicy {
+  CursorGuard,
+  PointerCursorGuard,
+  Typewriter,
+  ResultReveal,
 }
 
 internal sealed interface EditorScrollIntentResult {
@@ -36,7 +79,9 @@ internal sealed interface EditorScrollIntentResult {
 internal fun resolveEditorScrollIntent(
   frame: EditorScrollFrame,
   target: EditorBringIntoViewTarget,
+  policy: EditorBringIntoViewPolicy,
   currentScroll: Float,
+  maximumScrollY: Float = Float.POSITIVE_INFINITY,
 ): EditorScrollIntentResult {
   val editorBounds = frame.editorBounds
   if (!editorBounds.isValid) {
@@ -46,16 +91,20 @@ internal fun resolveEditorScrollIntent(
   return resolveEditorScrollIntent(
     frame = frame,
     target = target,
+    policy = policy,
     currentScroll = currentScroll,
     contentOriginY = frame.headerHeight + editorBounds.y,
+    maximumScrollY = maximumScrollY,
   )
 }
 
 internal fun resolveEditorScrollIntent(
   frame: EditorScrollFrame,
   target: EditorBringIntoViewTarget,
+  policy: EditorBringIntoViewPolicy,
   currentScroll: Float,
   contentOriginY: Float,
+  maximumScrollY: Float = Float.POSITIVE_INFINITY,
 ): EditorScrollIntentResult {
   if (!contentOriginY.isFinite()) return EditorScrollIntentResult.Unresolved
 
@@ -74,22 +123,30 @@ internal fun resolveEditorScrollIntent(
 
   val targetScroll =
     resolveBringIntoViewTargetOffset(
-      mode = frame.autoScrollPolicy.mode,
+      policy = frame.resolvePolicy(target = target, requestedPolicy = policy),
       currentScroll = currentScroll,
       rect = rect,
       visibleArea = frame.visibleArea,
       autoScrollPolicy = frame.autoScrollPolicy,
+      maximumScrollY = maximumScrollY,
+      oversizedMinimumVisibleHeight =
+        if (policy == EditorBringIntoViewPolicy.PointerCursorGuard) {
+          CursorVisibleMargin
+        } else {
+          null
+        },
     )
   if (targetScroll == null) {
     return EditorScrollIntentResult.NoScroll
   }
 
-  return EditorScrollIntentResult.ScrollTo(targetScroll.coerceAtLeast(0f))
+  return EditorScrollIntentResult.ScrollTo(targetScroll)
 }
 
 internal fun resolveInstantRevealPreparationViewports(
   frame: EditorScrollFrame,
   target: EditorBringIntoViewTarget,
+  policy: EditorBringIntoViewPolicy,
   currentScroll: Float,
   contentOriginY: Float,
   maximumScrollY: Float,
@@ -110,6 +167,13 @@ internal fun resolveInstantRevealPreparationViewports(
     target = rect,
     visibleArea = frame.visibleArea,
     autoScrollPolicy = frame.autoScrollPolicy,
+    policy = frame.resolvePolicy(target = target, requestedPolicy = policy),
+    oversizedMinimumVisibleHeight =
+      if (policy == EditorBringIntoViewPolicy.PointerCursorGuard) {
+        CursorVisibleMargin
+      } else {
+        null
+      },
   )
 }
 
@@ -120,6 +184,8 @@ internal fun resolveInstantRevealPreparationViewports(
   target: VerticalSpan,
   visibleArea: EditorVisibleArea,
   autoScrollPolicy: EditorAutoScrollPolicy,
+  policy: EditorBringIntoViewPolicy,
+  oversizedMinimumVisibleHeight: Float? = null,
 ): List<VerticalSpan> {
   if (
     !currentScroll.isFinite() ||
@@ -129,14 +195,24 @@ internal fun resolveInstantRevealPreparationViewports(
       maximumScrollY < 0f ||
       !target.top.isFinite() ||
       !target.bottom.isFinite() ||
-      !target.isValid
+      target.bottom < target.top
   ) {
     return emptyList()
   }
 
+  val keepVisibleRange = resolveKeepVisibleRange(visibleArea)
+  val preparationPolicy =
+    if (
+      policy == EditorBringIntoViewPolicy.Typewriter &&
+        (!keepVisibleRange.isValid || target.height > keepVisibleRange.height)
+    ) {
+      EditorBringIntoViewPolicy.CursorGuard
+    } else {
+      policy
+    }
   val destinations =
-    when (autoScrollPolicy.mode) {
-      EditorAutoScrollMode.Typewriter ->
+    when (preparationPolicy) {
+      EditorBringIntoViewPolicy.Typewriter ->
         listOf(
           resolveTypewriterScrollOffset(
             currentScroll = currentScroll,
@@ -144,11 +220,14 @@ internal fun resolveInstantRevealPreparationViewports(
             targetBottomInContent = target.bottom,
             visibleArea = visibleArea,
             position = autoScrollPolicy.typewriterPosition,
+            maximumScrollY = maximumScrollY,
           ) ?: currentScroll
         )
 
-      EditorAutoScrollMode.KeepCursorVisible -> {
-        val range = resolveKeepVisibleRange(visibleArea)
+      EditorBringIntoViewPolicy.CursorGuard,
+      EditorBringIntoViewPolicy.PointerCursorGuard,
+      EditorBringIntoViewPolicy.ResultReveal -> {
+        val range = keepVisibleRange
         if (!range.isValid) {
           listOf(
             resolveKeepVisibleScrollOffset(
@@ -156,22 +235,37 @@ internal fun resolveInstantRevealPreparationViewports(
               targetTopInContent = target.top,
               targetBottomInContent = target.bottom,
               visibleArea = visibleArea,
+              maximumScrollY = maximumScrollY,
             ) ?: currentScroll
           )
         } else {
           buildList {
-            if (
-              resolveKeepVisibleScrollOffset(
-                currentScroll = currentScroll,
-                targetTopInContent = target.top,
-                targetBottomInContent = target.bottom,
-                visibleArea = visibleArea,
-              ) == null
-            ) {
-              add(currentScroll)
+            if (target.height > range.height) {
+              if (oversizedMinimumVisibleHeight == null) {
+                add(currentScroll)
+                add(target.top - range.top)
+                add(target.bottom - range.bottom)
+              } else {
+                val minimumVisibleHeight = oversizedMinimumVisibleHeight.coerceIn(0f, range.height)
+                add(currentScroll)
+                add(target.top - (range.bottom - minimumVisibleHeight))
+                add(target.bottom - (range.top + minimumVisibleHeight))
+              }
+            } else {
+              val targetScroll =
+                resolveKeepVisibleScrollOffset(
+                  currentScroll = currentScroll,
+                  targetTopInContent = target.top,
+                  targetBottomInContent = target.bottom,
+                  visibleArea = visibleArea,
+                  maximumScrollY = maximumScrollY,
+                )
+              if (targetScroll == null) {
+                add(currentScroll)
+              }
+              add(target.top - range.top)
+              add(target.bottom - range.bottom)
             }
-            add(target.top - range.top)
-            if (target.height <= range.height) add(target.bottom - range.bottom)
           }
         }
       }
@@ -262,6 +356,18 @@ private fun resolveBringIntoViewTargetPageRects(
     is EditorBringIntoViewTarget.PageRects -> target.rects.takeIf { it.isNotEmpty() }
   }
 
+private fun EditorScrollFrame.resolvePolicy(
+  target: EditorBringIntoViewTarget,
+  requestedPolicy: EditorBringIntoViewPolicy,
+): EditorBringIntoViewPolicy =
+  when {
+    requestedPolicy == EditorBringIntoViewPolicy.Typewriter &&
+      target == EditorBringIntoViewTarget.CurrentSelectionHead &&
+      autoScrollPolicy.typewriterActive -> EditorBringIntoViewPolicy.Typewriter
+    requestedPolicy == EditorBringIntoViewPolicy.Typewriter -> EditorBringIntoViewPolicy.CursorGuard
+    else -> requestedPolicy
+  }
+
 internal fun List<PageRect>.toPageRectsTarget(): EditorBringIntoViewTarget.PageRects? =
   takeIf { it.isNotEmpty() }?.let(EditorBringIntoViewTarget::PageRects)
 
@@ -286,27 +392,42 @@ private fun resolveCurrentSelectionHeadPageRect(state: EditorState): PageRect? {
 }
 
 private fun resolveBringIntoViewTargetOffset(
-  mode: EditorAutoScrollMode,
+  policy: EditorBringIntoViewPolicy,
   currentScroll: Float,
   rect: VerticalSpan,
   visibleArea: EditorVisibleArea,
   autoScrollPolicy: EditorAutoScrollPolicy,
+  maximumScrollY: Float,
+  oversizedMinimumVisibleHeight: Float?,
 ): Float? =
-  when (mode) {
-    EditorAutoScrollMode.KeepCursorVisible ->
+  when (policy) {
+    EditorBringIntoViewPolicy.CursorGuard,
+    EditorBringIntoViewPolicy.PointerCursorGuard ->
       resolveKeepVisibleScrollOffset(
         currentScroll = currentScroll,
         targetTopInContent = rect.top,
         targetBottomInContent = rect.bottom,
         visibleArea = visibleArea,
+        maximumScrollY = maximumScrollY,
+        oversizedMinimumVisibleHeight = oversizedMinimumVisibleHeight,
       )
 
-    EditorAutoScrollMode.Typewriter ->
+    EditorBringIntoViewPolicy.Typewriter ->
       resolveTypewriterScrollOffset(
         currentScroll = currentScroll,
         targetTopInContent = rect.top,
         targetBottomInContent = rect.bottom,
         visibleArea = visibleArea,
         position = autoScrollPolicy.typewriterPosition,
+        maximumScrollY = maximumScrollY,
+      )
+
+    EditorBringIntoViewPolicy.ResultReveal ->
+      resolveResultRevealScrollOffset(
+        currentScroll = currentScroll,
+        targetTopInContent = rect.top,
+        targetBottomInContent = rect.bottom,
+        visibleArea = visibleArea,
+        maximumScrollY = maximumScrollY,
       )
   }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorUpdateWithBringIntoView.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorUpdateWithBringIntoView.kt
@@ -7,34 +7,42 @@ import co.typie.editor.beforePublish
 import co.typie.editor.ffi.Message
 
 internal interface EditorBringIntoViewUpdateScope : EditorRequestScope {
-  fun bringIntoView(target: EditorBringIntoViewTarget)
+  fun bringIntoView(target: EditorBringIntoViewTarget, policy: EditorBringIntoViewPolicy)
 }
+
+private data class EditorBringIntoViewUpdate(
+  val target: EditorBringIntoViewTarget,
+  val policy: EditorBringIntoViewPolicy,
+)
 
 private fun EditorRequestScope.applyBringIntoViewUpdate(
   block: EditorBringIntoViewUpdateScope.() -> Unit
-): EditorBringIntoViewTarget? {
+): EditorBringIntoViewUpdate? {
   val request = this
-  var selectedTarget: EditorBringIntoViewTarget? = null
+  var selectedUpdate: EditorBringIntoViewUpdate? = null
   block(
     object : EditorBringIntoViewUpdateScope {
       override fun enqueue(message: Message) {
         request.enqueue(message)
       }
 
-      override fun bringIntoView(target: EditorBringIntoViewTarget) {
-        selectedTarget = target
+      override fun bringIntoView(
+        target: EditorBringIntoViewTarget,
+        policy: EditorBringIntoViewPolicy,
+      ) {
+        selectedUpdate = EditorBringIntoViewUpdate(target = target, policy = policy)
       }
     }
   )
-  return selectedTarget
+  return selectedUpdate
 }
 
 internal fun Editor.updateNowWithBringIntoView(
   bringIntoViewRequests: EditorBringIntoViewRequests,
   block: EditorBringIntoViewUpdateScope.() -> Unit,
 ): EditorUpdate? = updateNow {
-  applyBringIntoViewUpdate(block)?.let { target ->
-    val request = bringIntoViewRequests.declare(target)
+  applyBringIntoViewUpdate(block)?.let { reveal ->
+    val request = bringIntoViewRequests.declare(target = reveal.target, policy = reveal.policy)
     beforePublish(
       block = { applied -> bringIntoViewRequests.bind(request, applied.revision) },
       onDiscard = { bringIntoViewRequests.discard(request) },
@@ -50,8 +58,9 @@ internal suspend fun Editor.updateWithBringIntoView(
   var reveal: EditorBringIntoViewRequests.Request? = null
   val update =
     update(admit = admit) {
-      applyBringIntoViewUpdate(block)?.let { target ->
-        val request = bringIntoViewRequests.declare(target)
+      applyBringIntoViewUpdate(block)?.let { requested ->
+        val request =
+          bringIntoViewRequests.declare(target = requested.target, policy = requested.policy)
         reveal = request
         beforePublish(
           block = { applied -> bringIntoViewRequests.bind(request, applied.revision) },

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -89,12 +89,14 @@ import co.typie.editor.runtime.EditorRuntime
 import co.typie.editor.runtime.EditorUiState
 import co.typie.editor.runtime.LocalEditorRuntime
 import co.typie.editor.runtime.LocalEditorUiState
+import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorBringIntoViewTarget
 import co.typie.editor.scroll.EditorScrollFrame
 import co.typie.editor.scroll.LocalEditorBringIntoViewRequests
 import co.typie.editor.scroll.rememberEditorBringIntoViewRequests
 import co.typie.editor.scroll.resolveBringIntoViewTargetHeight
 import co.typie.editor.scroll.resolveEditorAutoScrollPolicy
+import co.typie.editor.scroll.resolveForState
 import co.typie.editor.scroll.updateWithBringIntoView
 import co.typie.editor.surface.EditorSurfaceHost
 import co.typie.editor.sync.ActiveDocumentEditingSessions
@@ -1477,7 +1479,7 @@ fun EditorScreen(entityId: String) {
         target = EditorBringIntoViewTarget.CurrentSelectionHead,
         displayZoom = displayZoom,
         density = density,
-      ) ?: 0f
+      )
     val subPaneLayoutInfo = subPaneState.layoutInfo
     val subPaneBottomOcclusion = resolveSubPaneBottomOcclusion(subPaneLayoutInfo)
     val editorInputBottomOcclusion =
@@ -1581,8 +1583,9 @@ fun EditorScreen(entityId: String) {
         baseBottomSpace = layoutSpec.resolveBaseBottomSpace(displayZoom),
         pageBottomRevealPadding = pageBottomRevealPadding,
         typewriterEnabled = typewriterEnabled,
+        typewriterActive = typewriterTargetLineHeight != null,
         typewriterPosition = typewriterPosition,
-        targetLineHeight = typewriterTargetLineHeight,
+        targetLineHeight = typewriterTargetLineHeight ?: 0f,
       )
     val bodyTrackWidth = bodyGeometry.pageColumnWidth.coerceAtLeast(0f)
     val headerGeometry =
@@ -1945,7 +1948,10 @@ fun EditorScreen(entityId: String) {
                       activeEditor.scope.launch(context) {
                         activeEditor.updateWithBringIntoView(bringIntoViewRequests) {
                           enqueue(Message.Clipboard(ClipboardOp.RepasteAsText))
-                          bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+                          bringIntoView(
+                            EditorBringIntoViewTarget.CurrentSelectionHead,
+                            policy = EditorBringIntoViewPolicy.Typewriter,
+                          )
                         }
                       }
                     }
@@ -1959,12 +1965,20 @@ fun EditorScreen(entityId: String) {
         body = { presentedBundle ->
           val editorLoad = editorLoadState
           if (editorLoad != null) {
+            val presentedAutoScrollPolicy =
+              autoScrollPolicy.resolveForState(
+                state = presentedBundle?.snapshot ?: publishedEditorState,
+                visibleArea = visibleArea,
+                layoutSpec = layoutSpec,
+                displayZoom = displayZoom,
+                density = density,
+              )
             EditorBody(
               load = editorLoad,
               publishedBundle = presentedBundle,
               visibleArea = visibleArea,
               layoutSpec = layoutSpec,
-              autoScrollPolicy = autoScrollPolicy,
+              autoScrollPolicy = presentedAutoScrollPolicy,
               modifier = Modifier,
               editorInputEnabled =
                 editorReady && editorInputEnabledByToolbar && directEditingEnabled,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/aifeedback/EditorAiFeedbackSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/aifeedback/EditorAiFeedbackSession.kt
@@ -13,7 +13,7 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.viewmodel.compose.viewModel
 import co.typie.editor.Editor
 import co.typie.editor.EditorState
-import co.typie.editor.scroll.EditorBringIntoViewBehavior
+import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.toPageRectsTarget
 import co.typie.graphql.AiFeedback_LiteraryAnalysisDocumentStream_Subscription
@@ -77,7 +77,7 @@ internal fun rememberEditorAiFeedbackSession(
     if (id == null) return
     bringIntoViewRequests.requestForState(
       state = activeEditor.appliedState,
-      behavior = EditorBringIntoViewBehavior.Smooth,
+      policy = EditorBringIntoViewPolicy.ResultReveal,
     ) {
       trackedRanges.firstOrNull { it.id == id }?.rects?.toPageRectsTarget()
     }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/attachment/EditorAttachmentImporter.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/attachment/EditorAttachmentImporter.kt
@@ -20,6 +20,7 @@ import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.NodeAttr
 import co.typie.editor.ffi.NodeOp
 import co.typie.editor.ffi.PlainNode
+import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.EditorBringIntoViewTarget
 import co.typie.platform.IncomingContentItem
@@ -199,6 +200,7 @@ internal class DefaultEditorAttachmentImporter(
       bringIntoViewRequests.requestForVersion(
         target = EditorBringIntoViewTarget.CurrentSelectionHead,
         version = update.revision,
+        policy = EditorBringIntoViewPolicy.Typewriter,
       )
       val matches =
         update.events.filterIsInstance<EditorEvent.AttachmentPlaceholdersInserted>().filter {
@@ -289,6 +291,7 @@ internal class DefaultEditorAttachmentImporter(
           bringIntoViewRequests.requestForVersion(
             target = EditorBringIntoViewTarget.CurrentSelectionHead,
             version = update.revision,
+            policy = EditorBringIntoViewPolicy.CursorGuard,
           )
           update.commandOutcomes.none { it is CommandOutcome.Rejected }
         }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/attachment/SessionEditorIncomingContentHandler.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/attachment/SessionEditorIncomingContentHandler.kt
@@ -6,6 +6,7 @@ import co.typie.editor.ffi.CommandOutcome
 import co.typie.editor.ffi.FlatImeOp
 import co.typie.editor.ffi.Message
 import co.typie.editor.input.EditorIncomingContentHandler
+import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.EditorBringIntoViewTarget
 import co.typie.platform.Clipboard
@@ -109,6 +110,7 @@ internal class SessionEditorIncomingContentHandler(
           bringIntoViewRequests.requestForVersion(
             target = EditorBringIntoViewTarget.CurrentSelectionHead,
             version = update.revision,
+            policy = EditorBringIntoViewPolicy.Typewriter,
           )
           update.commandOutcomes.none { it is CommandOutcome.Rejected }
         }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/entry/EditorEntryStateSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/entry/EditorEntryStateSession.kt
@@ -13,6 +13,7 @@ import co.typie.editor.Editor
 import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.SelectionOp
 import co.typie.editor.ffi.StableSelection
+import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.EditorBringIntoViewTarget
 import co.typie.editor.scroll.updateWithBringIntoView
@@ -70,7 +71,10 @@ internal fun rememberEditorEntryStateSession(
 
     activeEditor.updateWithBringIntoView(bringIntoViewRequests) {
       enqueue(Message.Selection(SelectionOp.SetFrozen(selection = selection)))
-      bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+      bringIntoView(
+        EditorBringIntoViewTarget.CurrentSelectionHead,
+        policy = EditorBringIntoViewPolicy.CursorGuard,
+      )
     }
     session.markPresentationReady()
   }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/EditorFindReplaceSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/EditorFindReplaceSession.kt
@@ -14,7 +14,7 @@ import co.typie.editor.DocumentEditingSession
 import co.typie.editor.Editor
 import co.typie.editor.EditorState
 import co.typie.editor.ext.isCollapsed
-import co.typie.editor.scroll.EditorBringIntoViewBehavior
+import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.storage.Preference
 import co.typie.ui.component.toast.LocalToast
@@ -388,7 +388,7 @@ private class FindReplaceSessionController {
   ) {
     bringIntoViewRequests.requestForState(
       state = editor.appliedState,
-      behavior = EditorBringIntoViewBehavior.Smooth,
+      policy = EditorBringIntoViewPolicy.ResultReveal,
     ) {
       trackedRanges.searchMatchScrollTarget(activeMatchId())
     }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayout.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayout.kt
@@ -67,6 +67,7 @@ import co.typie.editor.interaction.observeEditorScreenPointerSequence
 import co.typie.editor.requiredSurfacePages
 import co.typie.editor.runtime.LocalEditorUiState
 import co.typie.editor.scroll.EditorBringIntoViewBehavior
+import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.EditorBringIntoViewTarget
 import co.typie.editor.scroll.EditorScrollFrame
@@ -231,7 +232,7 @@ internal fun EditorScreenLayout(
   val surfacePreparation = editor?.let {
     resolveEditorSurfacePreparation(
       editor = it,
-      scrollFrame = scrollFrame.copy(state = it.appliedState),
+      scrollFrame = scrollFrame.withState(it.appliedState),
       currentScroll = state.viewportState.scrollOffset.y,
       bringIntoViewRequest = bringIntoViewRequest,
     )
@@ -364,7 +365,7 @@ internal fun EditorScreenLayout(
         if (editor != null && currentAppliedState != null) {
           resolveEditorSurfacePreparation(
             editor = editor,
-            scrollFrame = measuredScrollFrame.copy(state = currentAppliedState),
+            scrollFrame = measuredScrollFrame.withState(currentAppliedState),
             currentScroll = state.viewportState.scrollOffset.y,
             bringIntoViewRequest = currentRequest,
           )
@@ -383,7 +384,7 @@ internal fun EditorScreenLayout(
           currentPreparation ==
             resolveEditorSurfacePreparation(
               editor = acceptingEditor,
-              scrollFrame = measuredScrollFrame.copy(state = latestState),
+              scrollFrame = measuredScrollFrame.withState(latestState),
               currentScroll = state.viewportState.scrollOffset.y,
               bringIntoViewRequest = latestRequest,
             ) &&
@@ -438,7 +439,7 @@ internal fun EditorScreenLayout(
               val acceptedPreparation = currentPreparation.takeIf { acceptedBundle != null }
 
               val presentationScrollFrame =
-                measuredScrollFrame.copy(state = placedBundle?.snapshot ?: scrollFrame.state)
+                measuredScrollFrame.withState(placedBundle?.snapshot ?: scrollFrame.state)
               val scrollFrameVersion = presentationScrollFrame.state.version
               val bringIntoViewRequest = acceptedRequest?.takeIf {
                 bringIntoViewRequests.activateForVersion(scrollFrameVersion) === it
@@ -449,7 +450,9 @@ internal fun EditorScreenLayout(
                   ?: resolveEditorScrollIntent(
                     frame = presentationScrollFrame,
                     target = request.target,
+                    policy = request.policy,
                     currentScroll = placementScrollY,
+                    maximumScrollY = state.viewportState.maxScrollY,
                   )
               }
               if (bringIntoViewRequest != null) {
@@ -625,20 +628,23 @@ private fun resolveEditorSurfacePreparation(
       null
     }
   if (currentViewport == null) return null
+  val maximumScrollY = (contentExtent - viewportHeight).coerceAtLeast(0f)
   val scrollIntent = bringIntoViewRequest?.let { request ->
     resolveEditorScrollIntent(
       frame = scrollFrame,
       target = request.target,
+      policy = request.policy,
       currentScroll = currentScroll,
       contentOriginY = resolvedContentOrigin,
+      maximumScrollY = maximumScrollY,
     )
   }
-  val maximumScrollY = (contentExtent - viewportHeight).coerceAtLeast(0f)
   val preparationViewports =
     if (bringIntoViewRequest?.behavior == EditorBringIntoViewBehavior.Instant) {
       resolveInstantRevealPreparationViewports(
         frame = scrollFrame,
         target = bringIntoViewRequest.target,
+        policy = bringIntoViewRequest.policy,
         currentScroll = currentScroll,
         contentOriginY = resolvedContentOrigin,
         maximumScrollY = maximumScrollY,
@@ -850,7 +856,9 @@ internal class EditorViewportScrollReconcileState {
         resolveEditorScrollIntent(
           frame = scrollFrame,
           target = EditorBringIntoViewTarget.CurrentSelectionHead,
+          policy = EditorBringIntoViewPolicy.Typewriter,
           currentScroll = viewportState.scrollOffset.y,
+          maximumScrollY = viewportState.maxScrollY,
         )
     ) {
       EditorScrollIntentResult.Unresolved,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorContextMenuActions.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorContextMenuActions.kt
@@ -11,6 +11,7 @@ import co.typie.editor.ffi.SelectionOp
 import co.typie.editor.input.LocalEditorIncomingContentHandler
 import co.typie.editor.runtime.EditorContextMenuState
 import co.typie.editor.runtime.LocalEditorRuntime
+import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.EditorBringIntoViewTarget
 import co.typie.editor.scroll.updateWithBringIntoView
@@ -63,7 +64,7 @@ internal fun rememberEditorContextMenuActions(
               editor
                 .updateWithBringIntoView(bringIntoViewRequests) {
                   enqueue(Message.Selection(SelectionOp.Expand(unit)))
-                  bringIntoView(bringIntoViewTarget)
+                  bringIntoView(bringIntoViewTarget, policy = EditorBringIntoViewPolicy.CursorGuard)
                 }
                 ?.snapshot
             }
@@ -87,7 +88,10 @@ internal fun rememberEditorContextMenuActions(
           if (clipboard.copyRichText(html = payload.html, text = payload.text)) {
             editor.updateWithBringIntoView(bringIntoViewRequests) {
               enqueue(Message.Clipboard(ClipboardOp.Cut))
-              bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+              bringIntoView(
+                EditorBringIntoViewTarget.CurrentSelectionHead,
+                policy = EditorBringIntoViewPolicy.CursorGuard,
+              )
             }
           }
         }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorScreenOverlayHost.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorScreenOverlayHost.kt
@@ -23,10 +23,10 @@ import co.typie.editor.ffi.Selection
 import co.typie.editor.ffi.SelectionExpansionUnit
 import co.typie.editor.runtime.LocalEditorRuntime
 import co.typie.editor.runtime.LocalEditorUiState
-import co.typie.editor.scroll.EditorAutoScrollMode
 import co.typie.editor.scroll.EditorAutoScrollPolicy
 import co.typie.editor.scroll.EditorVisibleArea
 import co.typie.editor.scroll.LocalEditorBringIntoViewRequests
+import co.typie.editor.scroll.resolveKeepVisibleRange
 import co.typie.editor.viewport.EditorViewportState
 import co.typie.screen.editor.editor.subpane.EditorTableAxisActionsTarget
 import kotlin.math.roundToInt
@@ -71,18 +71,15 @@ internal fun EditorScreenOverlayHost(
       DebugViewportLine(y = visibleArea.visibleViewportTop, color = Color(0xFF00C853))
       DebugViewportLine(y = visibleArea.visibleViewportBottom, color = Color(0xFF00C853))
 
-      when (autoScrollPolicy.mode) {
-        EditorAutoScrollMode.KeepCursorVisible -> {
-          DebugViewportLine(y = autoScrollPolicy.keepVisibleRange.top, color = Color(0xFFFFAB00))
-          DebugViewportLine(y = autoScrollPolicy.keepVisibleRange.bottom, color = Color(0xFFFFAB00))
-        }
-
-        EditorAutoScrollMode.Typewriter -> {
-          autoScrollPolicy.targetTop?.let { DebugViewportLine(y = it, color = Color(0xFFFFAB00)) }
-          autoScrollPolicy.targetBottom
-            ?.takeIf { autoScrollPolicy.targetLineHeight > 0f }
-            ?.let { DebugViewportLine(y = it, color = Color(0xFFFFAB00)) }
-        }
+      if (autoScrollPolicy.typewriterActive) {
+        autoScrollPolicy.targetTop?.let { DebugViewportLine(y = it, color = Color(0xFFFFAB00)) }
+        autoScrollPolicy.targetBottom
+          ?.takeIf { autoScrollPolicy.targetLineHeight > 0f }
+          ?.let { DebugViewportLine(y = it, color = Color(0xFFFFAB00)) }
+      } else {
+        val keepVisibleRange = resolveKeepVisibleRange(visibleArea)
+        DebugViewportLine(y = keepVisibleRange.top, color = Color(0xFFFFAB00))
+        DebugViewportLine(y = keepVisibleRange.bottom, color = Color(0xFFFFAB00))
       }
     }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/spellcheck/EditorSpellcheckSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/spellcheck/EditorSpellcheckSession.kt
@@ -17,7 +17,7 @@ import co.typie.editor.EditorState
 import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.Selection
 import co.typie.editor.ffi.SelectionOp
-import co.typie.editor.scroll.EditorBringIntoViewBehavior
+import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.EditorBringIntoViewTarget
 import co.typie.editor.scroll.toPageRectsTarget
@@ -88,7 +88,7 @@ internal fun rememberEditorSpellcheckSession(
     if (id == null) return
     bringIntoViewRequests.requestForState(
       state = activeEditor.appliedState,
-      behavior = EditorBringIntoViewBehavior.Smooth,
+      policy = EditorBringIntoViewPolicy.ResultReveal,
     ) {
       trackedRanges.firstOrNull { it.id == id }?.rects?.toPageRectsTarget()
     }
@@ -414,7 +414,10 @@ internal fun rememberEditorSpellcheckSession(
                   SelectionOp.Set(Selection(anchor = range.anchor, head = range.head))
                 )
               )
-              bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+              bringIntoView(
+                EditorBringIntoViewTarget.CurrentSelectionHead,
+                policy = EditorBringIntoViewPolicy.CursorGuard,
+              )
             }
           if (update == null) return@launch
           model?.activate(null)

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/comments/EditorCommentsSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/comments/EditorCommentsSession.kt
@@ -13,7 +13,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import co.typie.editor.Editor
 import co.typie.editor.EditorState
 import co.typie.editor.ffi.StableSelection
-import co.typie.editor.scroll.EditorBringIntoViewBehavior
+import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.toPageRectsTarget
 import co.typie.screen.editor.editor.selectTrackedRangeMember
@@ -203,7 +203,7 @@ internal fun rememberEditorCommentsSession(
     val requested =
       bringIntoViewRequests.requestForState(
         state = editorState,
-        behavior = EditorBringIntoViewBehavior.Smooth,
+        policy = EditorBringIntoViewPolicy.ResultReveal,
       ) {
         trackedRanges.firstOrNull { it.id == threadId }?.rects?.toPageRectsTarget()
       }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarHost.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarHost.kt
@@ -37,6 +37,7 @@ import co.typie.editor.EditorState
 import co.typie.editor.ffi.FlatImeOp
 import co.typie.editor.ffi.Message
 import co.typie.editor.runtime.LocalEditorRuntime
+import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorBringIntoViewTarget
 import co.typie.editor.scroll.LocalEditorBringIntoViewRequests
 import co.typie.editor.scroll.updateWithBringIntoView
@@ -253,7 +254,10 @@ internal fun EditorToolbarHost(
               enqueue(Message.TextInput(listOf(FlatImeOp.CommitAsIs)))
             }
             messages.forEach(::enqueue)
-            bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+            bringIntoView(
+              EditorBringIntoViewTarget.CurrentSelectionHead,
+              policy = EditorBringIntoViewPolicy.CursorGuard,
+            )
           }
         if (update == null) {
           Logger.e { "Editor toolbar messages were not admitted" }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/bottom/Nodes.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/bottom/Nodes.kt
@@ -43,6 +43,7 @@ import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.PlainNode
 import co.typie.editor.ffi.Selection
 import co.typie.editor.runtime.LocalEditorRuntime
+import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorBringIntoViewTarget
 import co.typie.editor.scroll.LocalEditorBringIntoViewRequests
 import co.typie.editor.scroll.updateWithBringIntoView
@@ -110,7 +111,10 @@ internal fun BottomToolbarNodes(
                 currentEditor.scope.launch(context) {
                   currentEditor.updateWithBringIntoView(bringIntoViewRequests) {
                     enqueue(action.message)
-                    bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+                    bringIntoView(
+                      EditorBringIntoViewTarget.CurrentSelectionHead,
+                      policy = EditorBringIntoViewPolicy.Typewriter,
+                    )
                   }
                 }
               }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/EmbedToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/EmbedToolbar.kt
@@ -21,6 +21,7 @@ import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.NodeOp
 import co.typie.editor.ffi.PlainNode
 import co.typie.editor.runtime.LocalEditorRuntime
+import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorBringIntoViewTarget
 import co.typie.editor.scroll.LocalEditorBringIntoViewRequests
 import co.typie.editor.scroll.updateWithBringIntoView
@@ -113,7 +114,10 @@ private fun EditorEmbedToolbar(
                           )
                         )
                       )
-                      bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+                      bringIntoView(
+                        EditorBringIntoViewTarget.CurrentSelectionHead,
+                        policy = EditorBringIntoViewPolicy.CursorGuard,
+                      )
                     }
                   checkNotNull(update) { "Editor embed attrs were not admitted" }
                 },

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/RequiredSurfacePagesTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/RequiredSurfacePagesTest.kt
@@ -1,6 +1,7 @@
 package co.typie.editor
 
 import androidx.compose.ui.geometry.Size
+import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorVisibleArea
 import co.typie.editor.scroll.resolveEditorAutoScrollPolicy
 import co.typie.editor.scroll.resolveInstantRevealPreparationViewports
@@ -224,6 +225,7 @@ class RequiredSurfacePagesTest {
         target = target,
         visibleArea = visibleArea,
         autoScrollPolicy = resolveEditorAutoScrollPolicy(visibleArea),
+        policy = EditorBringIntoViewPolicy.CursorGuard,
       )
 
     val exactDestinations =
@@ -253,26 +255,24 @@ class RequiredSurfacePagesTest {
         bottomOcclusionInset = 30f,
       )
     val target = VerticalSpan(top = 600f, bottom = 1_100f)
-    val preparation =
-      resolveInstantRevealPreparationViewports(
-        currentScroll = 0f,
-        viewportHeight = visibleArea.viewport.height,
-        maximumScrollY = 1_600f,
-        target = target,
-        visibleArea = visibleArea,
-        autoScrollPolicy = resolveEditorAutoScrollPolicy(visibleArea),
-      )
-
     for (currentScroll in listOf(0f, 600f, 1_500f)) {
-      val destination =
-        requireNotNull(
-          resolveKeepVisibleScrollOffset(
-            currentScroll = currentScroll,
-            targetTopInContent = target.top,
-            targetBottomInContent = target.bottom,
-            visibleArea = visibleArea,
-          )
+      val preparation =
+        resolveInstantRevealPreparationViewports(
+          currentScroll = currentScroll,
+          viewportHeight = visibleArea.viewport.height,
+          maximumScrollY = 1_600f,
+          target = target,
+          visibleArea = visibleArea,
+          autoScrollPolicy = resolveEditorAutoScrollPolicy(visibleArea),
+          policy = EditorBringIntoViewPolicy.CursorGuard,
         )
+      val destination =
+        resolveKeepVisibleScrollOffset(
+          currentScroll = currentScroll,
+          targetTopInContent = target.top,
+          targetBottomInContent = target.bottom,
+          visibleArea = visibleArea,
+        ) ?: currentScroll
       assertTrue(
         VerticalSpan(destination, destination + visibleArea.viewport.height) in preparation,
         "destination=$destination preparation=$preparation",
@@ -302,6 +302,7 @@ class RequiredSurfacePagesTest {
               bottomOcclusionInset = 20f,
             )
           ),
+        policy = EditorBringIntoViewPolicy.CursorGuard,
       )
     assertEquals(setOf(VerticalSpan(250f, 650f)), clamped.toSet())
 
@@ -320,6 +321,7 @@ class RequiredSurfacePagesTest {
         target = centeredTarget,
         visibleArea = narrowVisibleArea,
         autoScrollPolicy = resolveEditorAutoScrollPolicy(narrowVisibleArea),
+        policy = EditorBringIntoViewPolicy.CursorGuard,
       )
     val centeredDestination =
       requireNotNull(
@@ -347,6 +349,7 @@ class RequiredSurfacePagesTest {
             typewriterEnabled = true,
             typewriterPosition = 0.5f,
           ),
+        policy = EditorBringIntoViewPolicy.Typewriter,
       )
     val typewriterDestination =
       requireNotNull(
@@ -361,6 +364,68 @@ class RequiredSurfacePagesTest {
     assertEquals(
       listOf(VerticalSpan(typewriterDestination, typewriterDestination + 400f)),
       typewriter,
+    )
+
+    val oversizedTypewriterTarget = VerticalSpan(top = 600f, bottom = 1_100f)
+    val oversizedTypewriter =
+      resolveInstantRevealPreparationViewports(
+        currentScroll = 0f,
+        viewportHeight = 400f,
+        maximumScrollY = 1_600f,
+        target = oversizedTypewriterTarget,
+        visibleArea =
+          EditorVisibleArea(
+            viewport = Size(width = 800f, height = 400f),
+            topInset = 20f,
+            bottomOcclusionInset = 30f,
+          ),
+        autoScrollPolicy =
+          resolveEditorAutoScrollPolicy(
+            visibleArea =
+              EditorVisibleArea(
+                viewport = Size(width = 800f, height = 400f),
+                topInset = 20f,
+                bottomOcclusionInset = 30f,
+              ),
+            typewriterEnabled = true,
+            typewriterPosition = 0.5f,
+          ),
+        policy = EditorBringIntoViewPolicy.Typewriter,
+      )
+    assertEquals(
+      listOf(VerticalSpan(0f, 400f), VerticalSpan(520f, 920f), VerticalSpan(790f, 1_190f)),
+      oversizedTypewriter,
+    )
+
+    val documentEdgeTarget = VerticalSpan(top = 10f, bottom = 500f)
+    val documentEdge =
+      resolveInstantRevealPreparationViewports(
+        currentScroll = 800f,
+        viewportHeight = 400f,
+        maximumScrollY = 1_600f,
+        target = documentEdgeTarget,
+        visibleArea =
+          EditorVisibleArea(
+            viewport = Size(width = 800f, height = 400f),
+            topInset = 20f,
+            bottomOcclusionInset = 30f,
+          ),
+        autoScrollPolicy =
+          resolveEditorAutoScrollPolicy(
+            visibleArea =
+              EditorVisibleArea(
+                viewport = Size(width = 800f, height = 400f),
+                topInset = 20f,
+                bottomOcclusionInset = 30f,
+              ),
+            typewriterEnabled = true,
+            typewriterPosition = 0.5f,
+          ),
+        policy = EditorBringIntoViewPolicy.Typewriter,
+      )
+    assertEquals(
+      listOf(VerticalSpan(800f, 1_200f), VerticalSpan(0f, 400f), VerticalSpan(190f, 590f)),
+      documentEdge,
     )
   }
 
@@ -383,6 +448,7 @@ class RequiredSurfacePagesTest {
               typewriterEnabled = true,
               typewriterPosition = 0.5f,
             ),
+          policy = EditorBringIntoViewPolicy.Typewriter,
         )
       }
     val prepared =

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
@@ -661,6 +661,54 @@ class EditorInteractionControllerTest {
     }
 
   @Test
+  fun `single tap requests the interaction anchor for a committed range version`() =
+    runTest(StandardTestDispatcher()) {
+      val collapsedSelection =
+        Selection(
+          anchor = Position("text", 0, Affinity.Downstream),
+          head = Position("text", 0, Affinity.Downstream),
+        )
+      val nodeSelection =
+        Selection(
+          anchor = Position("node", 0, Affinity.Downstream),
+          head = Position("node", 1, Affinity.Downstream),
+        )
+      var currentSelection = collapsedSelection
+      var commitNodeSelection = false
+      val fake =
+        FakeFfiEditor(
+          cursorProvider = { cursorAt(x = 10f) },
+          selectionProvider = { currentSelection },
+          onTick = {
+            if (commitNodeSelection) {
+              currentSelection = nodeSelection
+            }
+            listOf(EditorEvent.StateChanged(listOf(StateField.Selection)))
+          },
+        )
+      val editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
+      fake.publishSnapshot(editor)
+      val host = TestHost(this)
+      val controller =
+        EditorInteractionController(
+          editorProvider = { editor },
+          effects = host,
+          geometry = host,
+          uiStateProvider = { host.uiState },
+          platformProvider = { Platform.Android },
+        )
+      controller.updateTapSlop(8f)
+      val start = Offset(10f, 20f)
+
+      commitNodeSelection = true
+      controller.onPointerDown(pointerId = 1L, position = start, nowMillis = 0L)
+      controller.onTapTimer(nowMillis = 250L)
+      advanceUntilIdle()
+
+      assertEquals(listOf(2L), host.requestedBringIntoViewVersions)
+    }
+
+  @Test
   fun `ios single tap that creates range selection opens context menu after commit`() =
     runTest(StandardTestDispatcher()) {
       val collapsedSelection =
@@ -4547,7 +4595,7 @@ class EditorInteractionControllerTest {
 
     override fun performSelectionHaptic() = Unit
 
-    override fun requestCurrentSelectionHead(version: Long) {
+    override fun requestPointerSelectionHead(version: Long) {
       requestedBringIntoViewVersions += version
     }
   }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorReadingModeInteractionTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorReadingModeInteractionTest.kt
@@ -711,7 +711,7 @@ class EditorReadingModeInteractionTest {
 
     override fun performSelectionHaptic() = Unit
 
-    override fun requestCurrentSelectionHead(version: Long) = Unit
+    override fun requestPointerSelectionHead(version: Long) = Unit
   }
 }
 

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/semantics/EditorPointSelectionSemanticTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/semantics/EditorPointSelectionSemanticTest.kt
@@ -224,7 +224,7 @@ class EditorPointSelectionSemanticTest {
 
     override fun performSelectionHaptic() = error("Unused in direct cursor semantic dispatch tests")
 
-    override fun requestCurrentSelectionHead(version: Long) =
+    override fun requestPointerSelectionHead(version: Long) =
       error("Unused in direct cursor semantic dispatch tests")
   }
 }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorAutoScrollPolicyTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorAutoScrollPolicyTest.kt
@@ -4,6 +4,8 @@ import androidx.compose.ui.geometry.Size
 import co.typie.editor.VerticalSpan
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 private const val FloatTolerance = 0.01f
 
@@ -35,7 +37,7 @@ class EditorAutoScrollPolicyTest {
   }
 
   @Test
-  fun `keep-visible policy scrolls up only after the cursor enters the visible viewport guard`() {
+  fun `keep-visible policy ignores a one-pixel guard correction`() {
     val offset =
       resolveKeepVisibleScrollOffset(
         currentScroll = 240f,
@@ -44,7 +46,7 @@ class EditorAutoScrollPolicyTest {
         visibleArea = testVisibleArea(),
       )
 
-    assertEquals(239f, offset)
+    assertEquals(null, offset)
   }
 
   @Test
@@ -66,7 +68,7 @@ class EditorAutoScrollPolicyTest {
   }
 
   @Test
-  fun `keep-visible policy aligns oversized target top to the guarded visible area`() {
+  fun `keep-visible policy aligns oversized target below viewport bottom to lower guard`() {
     val offset =
       resolveKeepVisibleScrollOffset(
         currentScroll = 300f,
@@ -75,11 +77,87 @@ class EditorAutoScrollPolicyTest {
         visibleArea = testVisibleArea(),
       )
 
-    assertEquals(860f, offset)
+    assertEquals(960f, offset)
   }
 
   @Test
-  fun `resolved policy keeps keep-visible mode active when typewriter is disabled`() {
+  fun `keep-visible policy does not scroll when oversized target covers guarded visible area`() {
+    val offset =
+      resolveKeepVisibleScrollOffset(
+        currentScroll = 300f,
+        targetTopInContent = 200f,
+        targetBottomInContent = 1200f,
+        visibleArea = testVisibleArea(),
+      )
+
+    assertEquals(null, offset)
+  }
+
+  @Test
+  fun `keep-visible policy does not scroll when oversized target meets either guard edge`() {
+    assertEquals(
+      null,
+      resolveKeepVisibleScrollOffset(
+        currentScroll = 300f,
+        targetTopInContent = 440f,
+        targetBottomInContent = 1200f,
+        visibleArea = testVisibleArea(),
+      ),
+    )
+    assertEquals(
+      null,
+      resolveKeepVisibleScrollOffset(
+        currentScroll = 300f,
+        targetTopInContent = 0f,
+        targetBottomInContent = 1040f,
+        visibleArea = testVisibleArea(),
+      ),
+    )
+  }
+
+  @Test
+  fun `keep-visible policy aligns oversized target to violated edge within old slack`() {
+    val offset =
+      resolveKeepVisibleScrollOffset(
+        currentScroll = 300f,
+        targetTopInContent = 460f,
+        targetBottomInContent = 1200f,
+        visibleArea = testVisibleArea(),
+      )
+
+    assertEquals(460f, offset)
+  }
+
+  @Test
+  fun `keep-visible policy clamps oversized target at document edge`() {
+    val offset =
+      resolveKeepVisibleScrollOffset(
+        currentScroll = 10f,
+        targetTopInContent = 0f,
+        targetBottomInContent = 251f,
+        visibleArea =
+          EditorVisibleArea(viewport = Size(width = 720f, height = 400f), topInset = 30f),
+        maximumScrollY = 400f,
+      )
+
+    assertEquals(0f, offset)
+  }
+
+  @Test
+  fun `keep-visible policy aligns oversized target above viewport top to upper guard`() {
+    val offset =
+      resolveKeepVisibleScrollOffset(
+        currentScroll = 1000f,
+        targetTopInContent = 500f,
+        targetBottomInContent = 1200f,
+        visibleArea = testVisibleArea(),
+      )
+
+    assertEquals(360f, offset)
+  }
+
+  @Test
+  fun `resolved policy keeps typewriter inactive when the preference is disabled`() {
     val policy =
       resolveEditorAutoScrollPolicy(
         visibleArea =
@@ -94,9 +172,18 @@ class EditorAutoScrollPolicyTest {
         targetLineHeight = 20f,
       )
 
-    assertEquals(EditorAutoScrollMode.KeepCursorVisible, policy.mode)
+    assertFalse(policy.typewriterActive)
     assertEquals(0.5f, policy.typewriterPosition, FloatTolerance)
-    assertEquals(VerticalSpan(top = 180f, bottom = 740f), policy.keepVisibleRange)
+    assertEquals(
+      VerticalSpan(top = 180f, bottom = 740f),
+      resolveKeepVisibleRange(
+        EditorVisibleArea(
+          viewport = Size(width = 720f, height = 900f),
+          topInset = 120f,
+          imeInset = 100f,
+        )
+      ),
+    )
     assertEquals(450f, requireNotNull(policy.targetTop), FloatTolerance)
     assertEquals(470f, requireNotNull(policy.targetBottom), FloatTolerance)
     assertEquals(140f, policy.bottomPadding, FloatTolerance)
@@ -117,7 +204,35 @@ class EditorAutoScrollPolicyTest {
   }
 
   @Test
-  fun `resolved policy switches to typewriter mode when enabled`() {
+  fun `typewriter policy falls back to lower cursor guard for oversized target below viewport`() {
+    val offset =
+      resolveTypewriterScrollOffset(
+        currentScroll = 300f,
+        targetTopInContent = 1000f,
+        targetBottomInContent = 1700f,
+        visibleArea = testVisibleArea(),
+        position = 0.5f,
+      )
+
+    assertEquals(960f, requireNotNull(offset), FloatTolerance)
+  }
+
+  @Test
+  fun `typewriter policy keeps viewport when oversized target spans both guard edges`() {
+    val offset =
+      resolveTypewriterScrollOffset(
+        currentScroll = 300f,
+        targetTopInContent = 200f,
+        targetBottomInContent = 1200f,
+        visibleArea = testVisibleArea(),
+        position = 0.5f,
+      )
+
+    assertEquals(null, offset)
+  }
+
+  @Test
+  fun `resolved policy activates typewriter when enabled`() {
     val policy =
       resolveEditorAutoScrollPolicy(
         visibleArea = testVisibleArea(),
@@ -127,7 +242,7 @@ class EditorAutoScrollPolicyTest {
         targetLineHeight = 32f,
       )
 
-    assertEquals(EditorAutoScrollMode.Typewriter, policy.mode)
+    assertTrue(policy.typewriterActive)
     assertEquals(0.25f, policy.typewriterPosition, FloatTolerance)
     assertEquals(252f, requireNotNull(policy.targetTop), FloatTolerance)
     assertEquals(284f, requireNotNull(policy.targetBottom), FloatTolerance)
@@ -145,7 +260,7 @@ class EditorAutoScrollPolicyTest {
         targetLineHeight = 32f,
       )
 
-    assertEquals(EditorAutoScrollMode.Typewriter, policy.mode)
+    assertTrue(policy.typewriterActive)
     assertEquals(596f, policy.bottomPadding, FloatTolerance)
   }
 
@@ -165,7 +280,7 @@ class EditorAutoScrollPolicyTest {
         targetLineHeight = 32f,
       )
 
-    assertEquals(EditorAutoScrollMode.Typewriter, policy.mode)
+    assertTrue(policy.typewriterActive)
     assertEquals(440f, policy.bottomPadding, FloatTolerance)
   }
 
@@ -180,7 +295,7 @@ class EditorAutoScrollPolicyTest {
         targetLineHeight = 32f,
       )
 
-    assertEquals(EditorAutoScrollMode.Typewriter, policy.mode)
+    assertTrue(policy.typewriterActive)
     assertEquals(48f, policy.bottomPadding, FloatTolerance)
   }
 
@@ -193,7 +308,7 @@ class EditorAutoScrollPolicyTest {
         baseBottomSpace = 40f,
       )
 
-    assertEquals(EditorAutoScrollMode.KeepCursorVisible, policy.mode)
+    assertFalse(policy.typewriterActive)
     assertEquals(20f, policy.bottomPadding, FloatTolerance)
   }
 
@@ -206,7 +321,7 @@ class EditorAutoScrollPolicyTest {
         pageBottomRevealPadding = 100f,
       )
 
-    assertEquals(EditorAutoScrollMode.KeepCursorVisible, policy.mode)
+    assertFalse(policy.typewriterActive)
     assertEquals(100f, policy.bottomPadding, FloatTolerance)
   }
 
@@ -229,7 +344,16 @@ class EditorAutoScrollPolicyTest {
         baseBottomSpace = 20f,
       )
 
-    assertEquals(VerticalSpan(top = 140f, bottom = 660f), policy.keepVisibleRange)
+    assertEquals(
+      VerticalSpan(top = 140f, bottom = 660f),
+      resolveKeepVisibleRange(
+        EditorVisibleArea(
+          viewport = Size(width = 720f, height = 900f),
+          topInset = 80f,
+          bottomOcclusionInset = 180f,
+        )
+      ),
+    )
     assertEquals(300f, policy.bottomPadding, FloatTolerance)
   }
 

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorBringIntoViewRequestsTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorBringIntoViewRequestsTest.kt
@@ -21,7 +21,7 @@ class EditorBringIntoViewRequestsTest {
     val state = EditorState.Initial.copy(version = 11L, selectionHitRects = pageRectsTarget.rects)
 
     assertTrue(
-      requests.requestForState(state, behavior = EditorBringIntoViewBehavior.Smooth) {
+      requests.requestForState(state, policy = EditorBringIntoViewPolicy.ResultReveal) {
         selectionHitRects.toPageRectsTarget()
       }
     )
@@ -29,6 +29,21 @@ class EditorBringIntoViewRequestsTest {
     assertNull(requests.activateForVersion(version = 10L))
     val request = requests.activateForVersion(version = 11L)
     assertTrue(request?.target == pageRectsTarget)
+    assertTrue(request?.policy == EditorBringIntoViewPolicy.ResultReveal)
+    assertTrue(request?.behavior == EditorBringIntoViewBehavior.Smooth)
+  }
+
+  @Test
+  fun `result reveal derives smooth behavior`() {
+    val requests = EditorBringIntoViewRequests()
+
+    requests.requestForVersion(
+      target = pageRectsTarget,
+      version = 11L,
+      policy = EditorBringIntoViewPolicy.ResultReveal,
+    )
+
+    val request = requests.activateForVersion(version = 11L)
     assertTrue(request?.behavior == EditorBringIntoViewBehavior.Smooth)
   }
 
@@ -37,7 +52,11 @@ class EditorBringIntoViewRequestsTest {
     var wakes = 0
     val requests = EditorBringIntoViewRequests(requestPresentation = { wakes += 1 })
 
-    requests.requestForVersion(EditorBringIntoViewTarget.CurrentSelectionHead, version = 1L)
+    requests.requestForVersion(
+      EditorBringIntoViewTarget.CurrentSelectionHead,
+      version = 1L,
+      policy = EditorBringIntoViewPolicy.CursorGuard,
+    )
 
     assertTrue(wakes > 0)
   }
@@ -46,7 +65,14 @@ class EditorBringIntoViewRequestsTest {
   fun `state-based request reports when state has no target`() {
     val requests = EditorBringIntoViewRequests()
 
-    assertFalse(requests.requestForState(EditorState.Initial) { null })
+    assertFalse(
+      requests.requestForState(
+        EditorState.Initial,
+        policy = EditorBringIntoViewPolicy.CursorGuard,
+      ) {
+        null
+      }
+    )
     assertNull(requests.activateForVersion(version = EditorState.Initial.version))
   }
 
@@ -57,6 +83,7 @@ class EditorBringIntoViewRequestsTest {
       requests.requestForVersion(
         target = EditorBringIntoViewTarget.CurrentSelectionHead,
         version = 11L,
+        policy = EditorBringIntoViewPolicy.CursorGuard,
       )
 
     assertNull(requests.activateForVersion(version = 10L))
@@ -67,8 +94,14 @@ class EditorBringIntoViewRequestsTest {
   @Test
   fun `new declaration immediately supersedes the previous reveal`() {
     val requests = EditorBringIntoViewRequests()
-    val previous = requests.requestForVersion(EditorBringIntoViewTarget.CurrentSelectionHead, 1L)
-    val current = requests.requestForVersion(pageRectsTarget, 2L)
+    val previous =
+      requests.requestForVersion(
+        EditorBringIntoViewTarget.CurrentSelectionHead,
+        1L,
+        EditorBringIntoViewPolicy.CursorGuard,
+      )
+    val current =
+      requests.requestForVersion(pageRectsTarget, 2L, EditorBringIntoViewPolicy.ResultReveal)
 
     assertTrue(previous.presentation.isCompleted)
     assertSame(current, requests.activateForVersion(version = 2L))
@@ -77,8 +110,12 @@ class EditorBringIntoViewRequestsTest {
   @Test
   fun `late binding cannot replace a newer declaration`() {
     val requests = EditorBringIntoViewRequests()
-    val previous = requests.declare(EditorBringIntoViewTarget.CurrentSelectionHead)
-    val current = requests.declare(pageRectsTarget)
+    val previous =
+      requests.declare(
+        EditorBringIntoViewTarget.CurrentSelectionHead,
+        EditorBringIntoViewPolicy.CursorGuard,
+      )
+    val current = requests.declare(pageRectsTarget, EditorBringIntoViewPolicy.ResultReveal)
 
     assertFalse(requests.bind(previous, version = 1L))
     assertTrue(requests.bind(current, version = 2L))
@@ -88,7 +125,12 @@ class EditorBringIntoViewRequestsTest {
   @Test
   fun `exact page rect request becomes obsolete when its revision is skipped`() {
     val requests = EditorBringIntoViewRequests()
-    val request = requests.requestForVersion(pageRectsTarget, version = 2L)
+    val request =
+      requests.requestForVersion(
+        pageRectsTarget,
+        version = 2L,
+        policy = EditorBringIntoViewPolicy.ResultReveal,
+      )
 
     assertNull(requests.activateForVersion(version = 3L))
     assertFalse(request.presentation.isCompleted)
@@ -97,9 +139,51 @@ class EditorBringIntoViewRequestsTest {
   }
 
   @Test
+  fun `pointer selection request is exact and becomes obsolete when its revision is skipped`() {
+    val requests = EditorBringIntoViewRequests()
+    val request =
+      requests.requestForVersion(
+        EditorBringIntoViewTarget.CurrentSelectionHead,
+        version = 2L,
+        policy = EditorBringIntoViewPolicy.PointerCursorGuard,
+      )
+
+    assertNull(requests.activateForVersion(version = 1L))
+    assertSame(request, requests.activateForVersion(version = 2L))
+    assertNull(requests.activateForVersion(version = 3L))
+    requests.discardObsoleteForVersion(version = 3L)
+    assertTrue(request.presentation.isCompleted)
+  }
+
+  @Test
+  fun `new request supersedes an exact pointer selection reveal`() {
+    val requests = EditorBringIntoViewRequests()
+    val pointer =
+      requests.requestForVersion(
+        EditorBringIntoViewTarget.CurrentSelectionHead,
+        version = 2L,
+        policy = EditorBringIntoViewPolicy.PointerCursorGuard,
+      )
+    val current =
+      requests.requestForVersion(
+        EditorBringIntoViewTarget.CurrentSelectionHead,
+        version = 3L,
+        policy = EditorBringIntoViewPolicy.CursorGuard,
+      )
+
+    assertTrue(pointer.presentation.isCompleted)
+    assertSame(current, requests.activateForVersion(version = 3L))
+  }
+
+  @Test
   fun `matching presentation completes and clears the current reveal`() {
     val requests = EditorBringIntoViewRequests()
-    val request = requests.requestForVersion(EditorBringIntoViewTarget.CurrentSelectionHead, 1L)
+    val request =
+      requests.requestForVersion(
+        EditorBringIntoViewTarget.CurrentSelectionHead,
+        1L,
+        EditorBringIntoViewPolicy.CursorGuard,
+      )
 
     assertTrue(requests.markPresented(version = 1L, request = request))
     assertTrue(request.presentation.isCompleted)
@@ -111,14 +195,22 @@ class EditorBringIntoViewRequestsTest {
   fun `surface failure discards only a reveal eligible for the failed version`() {
     val requests = EditorBringIntoViewRequests()
     val previous =
-      requests.requestForVersion(EditorBringIntoViewTarget.CurrentSelectionHead, version = 1L)
+      requests.requestForVersion(
+        EditorBringIntoViewTarget.CurrentSelectionHead,
+        version = 1L,
+        policy = EditorBringIntoViewPolicy.CursorGuard,
+      )
 
     requests.discardFailedForVersion(version = 1L)
 
     assertTrue(previous.presentation.isCompleted)
 
     val current =
-      requests.requestForVersion(EditorBringIntoViewTarget.CurrentSelectionHead, version = 3L)
+      requests.requestForVersion(
+        EditorBringIntoViewTarget.CurrentSelectionHead,
+        version = 3L,
+        policy = EditorBringIntoViewPolicy.CursorGuard,
+      )
     requests.discardFailedForVersion(version = 2L)
 
     assertFalse(current.presentation.isCompleted)
@@ -128,7 +220,12 @@ class EditorBringIntoViewRequestsTest {
   @Test
   fun `cancel completes and clears the current reveal`() {
     val requests = EditorBringIntoViewRequests()
-    val request = requests.requestForVersion(EditorBringIntoViewTarget.CurrentSelectionHead, 1L)
+    val request =
+      requests.requestForVersion(
+        EditorBringIntoViewTarget.CurrentSelectionHead,
+        1L,
+        EditorBringIntoViewPolicy.CursorGuard,
+      )
 
     requests.cancel()
 

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorScrollResolverTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorScrollResolverTest.kt
@@ -2,6 +2,7 @@ package co.typie.editor.scroll
 
 import androidx.compose.ui.geometry.Size
 import co.typie.editor.EditorState
+import co.typie.editor.VerticalSpan
 import co.typie.editor.body.EditorDocumentLayoutSpec
 import co.typie.editor.ffi.Affinity
 import co.typie.editor.ffi.CursorMetrics
@@ -15,6 +16,7 @@ import co.typie.editor.runtime.EditorBoundsInContainer
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class EditorScrollResolverTest {
   @Test
@@ -37,10 +39,68 @@ class EditorScrollResolverTest {
       resolveEditorScrollIntent(
         frame = frame,
         target = EditorBringIntoViewTarget.CurrentSelectionHead,
+        policy = EditorBringIntoViewPolicy.CursorGuard,
         currentScroll = 200f,
       )
 
     assertScrollTo(intent, 360f)
+  }
+
+  @Test
+  fun `resolver returns no scroll when fitting cursor guard target clamps to current offset`() {
+    val frame =
+      frame(
+        state =
+          state(
+            cursor =
+              CursorMetrics(
+                pageIdx = 0,
+                caret = FfiRect(0f, 580f, 0f, 20f),
+                line = FfiRect(0f, 580f, 0f, 20f),
+              ),
+            pageSizes = listOf(PageSize(width = 300f, height = 620f)),
+          )
+      )
+
+    val intent =
+      resolveEditorScrollIntent(
+        frame = frame,
+        target = EditorBringIntoViewTarget.CurrentSelectionHead,
+        policy = EditorBringIntoViewPolicy.CursorGuard,
+        currentScroll = 0f,
+        maximumScrollY = 0f,
+      )
+
+    assertEquals(EditorScrollIntentResult.NoScroll, intent)
+  }
+
+  @Test
+  fun `resolver returns no scroll when typewriter target clamps to current offset`() {
+    val frame =
+      frame(
+        state =
+          state(
+            cursor =
+              CursorMetrics(
+                pageIdx = 0,
+                caret = FfiRect(0f, 580f, 0f, 20f),
+                line = FfiRect(0f, 580f, 0f, 20f),
+              ),
+            pageSizes = listOf(PageSize(width = 300f, height = 620f)),
+          ),
+        typewriterEnabled = true,
+      )
+
+    val intent =
+      resolveEditorScrollIntent(
+        frame = frame,
+        target = EditorBringIntoViewTarget.CurrentSelectionHead,
+        policy = EditorBringIntoViewPolicy.Typewriter,
+        currentScroll = 0f,
+        maximumScrollY = 0f,
+      )
+
+    assertEquals(EditorScrollIntentResult.NoScroll, intent)
   }
 
   @Test
@@ -65,6 +125,7 @@ class EditorScrollResolverTest {
       resolveEditorScrollIntent(
         frame = frame,
         target = EditorBringIntoViewTarget.CurrentSelectionHead,
+        policy = EditorBringIntoViewPolicy.CursorGuard,
         currentScroll = 200f,
       )
 
@@ -94,6 +155,7 @@ class EditorScrollResolverTest {
       resolveEditorScrollIntent(
         frame = frame,
         target = EditorBringIntoViewTarget.CurrentSelectionHead,
+        policy = EditorBringIntoViewPolicy.CursorGuard,
         currentScroll = 200f,
         contentOriginY = 0f,
       )
@@ -123,6 +185,7 @@ class EditorScrollResolverTest {
       resolveEditorScrollIntent(
         frame = frame,
         target = EditorBringIntoViewTarget.CurrentSelectionHead,
+        policy = EditorBringIntoViewPolicy.CursorGuard,
         currentScroll = 200f,
       )
 
@@ -151,6 +214,7 @@ class EditorScrollResolverTest {
       resolveEditorScrollIntent(
         frame = frame,
         target = EditorBringIntoViewTarget.CurrentSelectionHead,
+        policy = EditorBringIntoViewPolicy.CursorGuard,
         currentScroll = 0f,
       )
 
@@ -158,7 +222,7 @@ class EditorScrollResolverTest {
   }
 
   @Test
-  fun `selection head target resolves from selection endpoint instead of collapsed cursor line`() {
+  fun `typewriter follows the endpoint matching a keyboard-extended range head`() {
     val anchor = position(offset = 1)
     val head = position(offset = 8)
     val frame =
@@ -180,17 +244,248 @@ class EditorScrollResolverTest {
                 toPosition = head,
               ),
             pageSizes = listOf(PageSize(width = 300f, height = 620f)),
-          )
+          ),
+        typewriterEnabled = true,
       )
 
     val intent =
       resolveEditorScrollIntent(
         frame = frame,
         target = EditorBringIntoViewTarget.CurrentSelectionHead,
+        policy = EditorBringIntoViewPolicy.Typewriter,
         currentScroll = 200f,
       )
 
-    assertScrollTo(intent, 360f)
+    assertScrollTo(intent, 440f)
+  }
+
+  @Test
+  fun `typewriter mode follows a collapsed current selection caret`() {
+    val cursor =
+      CursorMetrics(
+        pageIdx = 0,
+        caret = FfiRect(0f, 500f, 0f, 20f),
+        line = FfiRect(0f, 500f, 0f, 20f),
+      )
+    val collapsedState =
+      state(cursor = cursor, pageSizes = listOf(PageSize(width = 300f, height = 900f)))
+    val frame = frame(state = collapsedState, typewriterEnabled = true)
+
+    assertScrollTo(
+      resolveEditorScrollIntent(
+        frame = frame,
+        target = EditorBringIntoViewTarget.CurrentSelectionHead,
+        policy = EditorBringIntoViewPolicy.Typewriter,
+        currentScroll = 0f,
+      ),
+      360f,
+    )
+  }
+
+  @Test
+  fun `candidate unit selection geometry drives typewriter reveal and padding`() {
+    val publishedState =
+      state(
+        cursor =
+          CursorMetrics(
+            pageIdx = 0,
+            caret = FfiRect(0f, 500f, 0f, 20f),
+            line = FfiRect(0f, 500f, 0f, 20f),
+          ),
+        pageSizes = listOf(PageSize(width = 300f, height = 900f)),
+      )
+    val publishedFrame = frame(state = publishedState, typewriterEnabled = true)
+
+    val anchor = position(offset = 0)
+    val head = position(offset = 1)
+    val unitSelectionState =
+      state(
+        cursor = null,
+        selection = Selection(anchor = anchor, head = head),
+        selectionEndpoints =
+          SelectionEndpoints(
+            from = PageRect(pageIdx = 0, rect = FfiRect(0f, 500f, 0f, 40f)),
+            to = PageRect(pageIdx = 0, rect = FfiRect(0f, 500f, 0f, 40f)),
+            fromPosition = anchor,
+            toPosition = head,
+          ),
+        pageSizes = listOf(PageSize(width = 300f, height = 900f)),
+      )
+    val unitSelectionFrame = publishedFrame.withState(unitSelectionState)
+
+    assertTrue(unitSelectionFrame.autoScrollPolicy.typewriterActive)
+    assertEquals(130f, unitSelectionFrame.autoScrollPolicy.bottomPadding)
+    assertScrollTo(
+      resolveEditorScrollIntent(
+        frame = unitSelectionFrame,
+        target = EditorBringIntoViewTarget.CurrentSelectionHead,
+        policy = EditorBringIntoViewPolicy.Typewriter,
+        currentScroll = 0f,
+      ),
+      370f,
+    )
+    assertEquals(
+      listOf(VerticalSpan(top = 370f, bottom = 670f)),
+      resolveInstantRevealPreparationViewports(
+        frame = unitSelectionFrame,
+        target = EditorBringIntoViewTarget.CurrentSelectionHead,
+        policy = EditorBringIntoViewPolicy.Typewriter,
+        currentScroll = 0f,
+        contentOriginY = 0f,
+        maximumScrollY = 600f,
+      ),
+    )
+  }
+
+  @Test
+  fun `typewriter mode does not apply to page rect targets`() {
+    val frame =
+      frame(
+        state =
+          state(
+            cursor =
+              CursorMetrics(
+                pageIdx = 0,
+                caret = FfiRect(0f, 500f, 0f, 20f),
+                line = FfiRect(0f, 500f, 0f, 20f),
+              ),
+            pageSizes = listOf(PageSize(width = 300f, height = 900f)),
+          ),
+        typewriterEnabled = true,
+      )
+
+    val target =
+      EditorBringIntoViewTarget.PageRects(
+        listOf(PageRect(pageIdx = 0, rect = FfiRect(0f, 500f, 0f, 20f)))
+      )
+
+    assertScrollTo(
+      resolveEditorScrollIntent(
+        frame = frame,
+        target = target,
+        policy = EditorBringIntoViewPolicy.Typewriter,
+        currentScroll = 0f,
+      ),
+      280f,
+    )
+    assertEquals(
+      listOf(VerticalSpan(top = 440f, bottom = 740f), VerticalSpan(top = 280f, bottom = 580f)),
+      resolveInstantRevealPreparationViewports(
+        frame = frame,
+        target = target,
+        policy = EditorBringIntoViewPolicy.Typewriter,
+        currentScroll = 0f,
+        contentOriginY = 0f,
+        maximumScrollY = 600f,
+      ),
+    )
+  }
+
+  @Test
+  fun `pointer policy applies the cursor guard to a compact selection head`() {
+    val frame =
+      frame(
+        state =
+          state(
+            cursor =
+              CursorMetrics(
+                pageIdx = 0,
+                caret = FfiRect(0f, 250f, 0f, 20f),
+                line = FfiRect(0f, 250f, 0f, 20f),
+              ),
+            pageSizes = listOf(PageSize(width = 300f, height = 900f)),
+          )
+      )
+
+    assertScrollTo(
+      resolveEditorScrollIntent(
+        frame = frame,
+        target = EditorBringIntoViewTarget.CurrentSelectionHead,
+        policy = EditorBringIntoViewPolicy.PointerCursorGuard,
+        currentScroll = 0f,
+      ),
+      30f,
+    )
+    assertTrue(
+      resolveInstantRevealPreparationViewports(
+          frame = frame,
+          target = EditorBringIntoViewTarget.CurrentSelectionHead,
+          policy = EditorBringIntoViewPolicy.PointerCursorGuard,
+          currentScroll = 0f,
+          contentOriginY = 0f,
+          maximumScrollY = 600f,
+        )
+        .contains(VerticalSpan(top = 30f, bottom = 330f))
+    )
+  }
+
+  @Test
+  fun `pointer policy keeps an oversized selection when one cursor margin is visible inside the guard`() {
+    val frame = frame(state = unitSelectionState(FfiRect(0f, 180f, 0f, 500f)))
+
+    assertEquals(
+      EditorScrollIntentResult.NoScroll,
+      resolveEditorScrollIntent(
+        frame = frame,
+        target = EditorBringIntoViewTarget.CurrentSelectionHead,
+        policy = EditorBringIntoViewPolicy.PointerCursorGuard,
+        currentScroll = 0f,
+      ),
+    )
+  }
+
+  @Test
+  fun `pointer policy reveals one cursor margin of an oversized selection entering from below`() {
+    val frame = frame(state = unitSelectionState(FfiRect(0f, 210f, 0f, 500f)))
+    val target = EditorBringIntoViewTarget.CurrentSelectionHead
+
+    assertScrollTo(
+      resolveEditorScrollIntent(
+        frame = frame,
+        target = target,
+        policy = EditorBringIntoViewPolicy.PointerCursorGuard,
+        currentScroll = 0f,
+      ),
+      30f,
+    )
+    assertTrue(
+      resolveInstantRevealPreparationViewports(
+          frame = frame,
+          target = target,
+          policy = EditorBringIntoViewPolicy.PointerCursorGuard,
+          currentScroll = 0f,
+          contentOriginY = 0f,
+          maximumScrollY = 600f,
+        )
+        .contains(VerticalSpan(top = 30f, bottom = 330f))
+    )
+  }
+
+  @Test
+  fun `pointer policy reveals one cursor margin of an oversized selection entering from above`() {
+    val frame = frame(state = unitSelectionState(FfiRect(0f, 0f, 0f, 500f)))
+    val target = EditorBringIntoViewTarget.CurrentSelectionHead
+
+    assertScrollTo(
+      resolveEditorScrollIntent(
+        frame = frame,
+        target = target,
+        policy = EditorBringIntoViewPolicy.PointerCursorGuard,
+        currentScroll = 410f,
+      ),
+      380f,
+    )
+    assertTrue(
+      resolveInstantRevealPreparationViewports(
+          frame = frame,
+          target = target,
+          policy = EditorBringIntoViewPolicy.PointerCursorGuard,
+          currentScroll = 410f,
+          contentOriginY = 0f,
+          maximumScrollY = 600f,
+        )
+        .contains(VerticalSpan(top = 380f, bottom = 680f))
+    )
   }
 
   @Test
@@ -215,6 +510,7 @@ class EditorScrollResolverTest {
       resolveEditorScrollIntent(
         frame = frame,
         target = EditorBringIntoViewTarget.CurrentSelectionHead,
+        policy = EditorBringIntoViewPolicy.CursorGuard,
         currentScroll = 200f,
       )
 
@@ -246,6 +542,35 @@ class EditorScrollResolverTest {
               PageRect(pageIdx = 1, rect = FfiRect(x = 0f, y = 20f, width = 40f, height = 20f)),
             )
           ),
+        policy = EditorBringIntoViewPolicy.ResultReveal,
+        currentScroll = 0f,
+      )
+
+    assertScrollTo(intent, 440f)
+  }
+
+  @Test
+  fun `page rects result reveal top-aligns an oversized target below the viewport`() {
+    val frame =
+      frame(
+        state =
+          state(
+            cursor = null,
+            selection = null,
+            pageSizes = listOf(PageSize(width = 300f, height = 1000f)),
+          )
+      )
+
+    val intent =
+      resolveEditorScrollIntent(
+        frame = frame,
+        target =
+          EditorBringIntoViewTarget.PageRects(
+            listOf(
+              PageRect(pageIdx = 0, rect = FfiRect(x = 0f, y = 500f, width = 40f, height = 400f))
+            )
+          ),
+        policy = EditorBringIntoViewPolicy.ResultReveal,
         currentScroll = 0f,
       )
 
@@ -333,6 +658,7 @@ class EditorScrollResolverTest {
     state: EditorState,
     layoutSpec: EditorDocumentLayoutSpec = EditorDocumentLayoutSpec.Continuous(maxWidth = 300f),
     density: Float = 1f,
+    typewriterEnabled: Boolean = false,
   ): EditorScrollFrame {
     val visibleArea = EditorVisibleArea(viewport = Size(width = 300f, height = 300f))
     return EditorScrollFrame(
@@ -340,10 +666,33 @@ class EditorScrollResolverTest {
       layoutSpec = layoutSpec,
       displayZoom = 1f,
       visibleArea = visibleArea,
-      autoScrollPolicy = resolveEditorAutoScrollPolicy(visibleArea = visibleArea),
+      autoScrollPolicy =
+        resolveEditorAutoScrollPolicy(
+          visibleArea = visibleArea,
+          typewriterEnabled = typewriterEnabled,
+          typewriterActive = typewriterEnabled,
+          targetLineHeight = 20f,
+        ),
       headerHeight = 0f,
       density = density,
       editorBounds = EditorBoundsInContainer(x = 0f, y = 0f, width = 300f, height = 1000f),
+    )
+  }
+
+  private fun unitSelectionState(rect: FfiRect): EditorState {
+    val anchor = position(offset = 0)
+    val head = position(offset = 1)
+    return state(
+      cursor = null,
+      selection = Selection(anchor = anchor, head = head),
+      selectionEndpoints =
+        SelectionEndpoints(
+          from = PageRect(pageIdx = 0, rect = rect),
+          to = PageRect(pageIdx = 0, rect = rect),
+          fromPosition = anchor,
+          toPosition = head,
+        ),
+      pageSizes = listOf(PageSize(width = 300f, height = 900f)),
     )
   }
 

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorUpdateWithBringIntoViewTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorUpdateWithBringIntoViewTest.kt
@@ -38,11 +38,15 @@ class EditorUpdateWithBringIntoViewTest {
       val updateDeferred = async {
         editor.updateWithBringIntoView(requests) {
           enqueue(Message.System(SystemEvent.Initialize))
-          bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+          bringIntoView(
+            EditorBringIntoViewTarget.CurrentSelectionHead,
+            policy = EditorBringIntoViewPolicy.CursorGuard,
+          )
         }
       }
       testScheduler.runCurrent()
       val request = assertNotNull(requests.activateForVersion(version = 1L))
+      assertEquals(EditorBringIntoViewPolicy.CursorGuard, request.policy)
       assertTrue(requests.markPresented(version = 1L, request = request))
       val update = assertNotNull(updateDeferred.await())
 
@@ -62,17 +66,19 @@ class EditorUpdateWithBringIntoViewTest {
         assertNotNull(
           editor.updateNowWithBringIntoView(requests) {
             enqueue(Message.System(SystemEvent.Initialize))
-            bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+            bringIntoView(
+              EditorBringIntoViewTarget.CurrentSelectionHead,
+              policy = EditorBringIntoViewPolicy.Typewriter,
+            )
           }
         )
 
       assertEquals(1L, update.revision)
       assertEquals(1L, update.snapshot.version)
       assertNull(requests.activateForVersion(version = 0L))
-      assertTrue(
-        requests.activateForVersion(version = 1L)?.target ==
-          EditorBringIntoViewTarget.CurrentSelectionHead
-      )
+      val request = assertNotNull(requests.activateForVersion(version = 1L))
+      assertTrue(request.target == EditorBringIntoViewTarget.CurrentSelectionHead)
+      assertEquals(EditorBringIntoViewPolicy.Typewriter, request.policy)
     }
 
   @Test
@@ -88,7 +94,10 @@ class EditorUpdateWithBringIntoViewTest {
           admit = { throw kotlinx.coroutines.CancellationException("not admitted") },
         ) {
           enqueue(Message.System(SystemEvent.Initialize))
-          bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+          bringIntoView(
+            EditorBringIntoViewTarget.CurrentSelectionHead,
+            policy = EditorBringIntoViewPolicy.CursorGuard,
+          )
         }
       }
 
@@ -106,7 +115,10 @@ class EditorUpdateWithBringIntoViewTest {
         launch(start = CoroutineStart.LAZY) {
           editor.updateWithBringIntoView(requests) {
             enqueue(Message.System(SystemEvent.Initialize))
-            bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+            bringIntoView(
+              EditorBringIntoViewTarget.CurrentSelectionHead,
+              policy = EditorBringIntoViewPolicy.CursorGuard,
+            )
           }
         }
       caller.start()
@@ -145,7 +157,10 @@ class EditorUpdateWithBringIntoViewTest {
       val first = async {
         editor.updateWithBringIntoView(requests) {
           enqueue(Message.System(SystemEvent.Initialize))
-          bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+          bringIntoView(
+            EditorBringIntoViewTarget.CurrentSelectionHead,
+            policy = EditorBringIntoViewPolicy.CursorGuard,
+          )
         }
       }
       testScheduler.runCurrent()
@@ -160,7 +175,10 @@ class EditorUpdateWithBringIntoViewTest {
       val second = async {
         editor.updateWithBringIntoView(requests) {
           enqueue(Message.System(SystemEvent.Initialize))
-          bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+          bringIntoView(
+            EditorBringIntoViewTarget.CurrentSelectionHead,
+            policy = EditorBringIntoViewPolicy.CursorGuard,
+          )
         }
       }
       testScheduler.runCurrent()
@@ -195,7 +213,10 @@ class EditorUpdateWithBringIntoViewTest {
       val first = async {
         editor.updateWithBringIntoView(requests) {
           enqueue(Message.System(SystemEvent.Initialize))
-          bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+          bringIntoView(
+            EditorBringIntoViewTarget.CurrentSelectionHead,
+            policy = EditorBringIntoViewPolicy.CursorGuard,
+          )
         }
       }
       testScheduler.runCurrent()

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/attachment/DefaultEditorAttachmentImporterTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/attachment/DefaultEditorAttachmentImporterTest.kt
@@ -24,6 +24,7 @@ import co.typie.editor.ffi.NodeOp
 import co.typie.editor.ffi.PlainNode
 import co.typie.editor.ffi.Rect
 import co.typie.editor.ffi.StateField
+import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.EditorBringIntoViewTarget
 import co.typie.editor.sync.createTestDocumentEditingSession
@@ -214,7 +215,10 @@ class DefaultEditorAttachmentImporterTest {
     assertTrue(state.images.uploads.containsKey(nodeId))
     assertFalse(released)
     assertEquals(
-      EditorBringIntoViewRequests.Request(EditorBringIntoViewTarget.CurrentSelectionHead),
+      EditorBringIntoViewRequests.Request(
+        target = EditorBringIntoViewTarget.CurrentSelectionHead,
+        policy = EditorBringIntoViewPolicy.Typewriter,
+      ),
       bringIntoViewRequests.activateForVersion(editor.appliedState.version),
     )
 
@@ -225,6 +229,10 @@ class DefaultEditorAttachmentImporterTest {
 
     assertEquals(listOf(1), callbackInvocations)
     assertTrue(released)
+    assertEquals(
+      EditorBringIntoViewPolicy.CursorGuard,
+      bringIntoViewRequests.activateForVersion(editor.appliedState.version)?.policy,
+    )
   }
 
   @Test

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/attachment/SessionEditorIncomingContentHandlerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/attachment/SessionEditorIncomingContentHandlerTest.kt
@@ -4,6 +4,7 @@ import co.typie.editor.Editor
 import co.typie.editor.FakeFfiEditor
 import co.typie.editor.ffi.ClipboardOp
 import co.typie.editor.ffi.Message
+import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.sync.createTestDocumentEditingSession
 import co.typie.platform.Clipboard
@@ -27,6 +28,7 @@ class SessionEditorIncomingContentHandlerTest {
     val fake = FakeFfiEditor()
     val editor = Editor(fake, this)
     val session = createTestDocumentEditingSession(editor, this)
+    val bringIntoViewRequests = EditorBringIntoViewRequests()
     val handler =
       SessionEditorIncomingContentHandler(
         importer =
@@ -34,7 +36,7 @@ class SessionEditorIncomingContentHandlerTest {
             importCalls += 1
             true
           },
-        bringIntoViewRequests = EditorBringIntoViewRequests(),
+        bringIntoViewRequests = bringIntoViewRequests,
         isSessionCurrent = { it === session },
         onAttachmentError = {},
       )
@@ -52,6 +54,10 @@ class SessionEditorIncomingContentHandlerTest {
       )
 
     assertTrue(handled)
+    assertEquals(
+      EditorBringIntoViewPolicy.Typewriter,
+      bringIntoViewRequests.activateForVersion(editor.appliedState.version)?.policy,
+    )
     assertEquals(0, importCalls)
     assertTrue(released)
     assertTrue(

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/EditorFrameSyncDesktopFixture.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/EditorFrameSyncDesktopFixture.kt
@@ -21,6 +21,7 @@ import co.typie.editor.ffi.SelectionOp
 import co.typie.editor.ffi.Viewport
 import co.typie.editor.runtime.EditorRuntime
 import co.typie.editor.runtime.EditorUiState
+import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.EditorBringIntoViewTarget
 import co.typie.editor.scroll.EditorScrollFrame
@@ -161,7 +162,10 @@ internal class FrameSyncFixture(
         assertNotNull(
           editor.updateNowWithBringIntoView(bringIntoViewRequests) {
             enqueue(Message.Key(KeyEvent(Key.Enter)))
-            bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+            bringIntoView(
+              EditorBringIntoViewTarget.CurrentSelectionHead,
+              policy = EditorBringIntoViewPolicy.Typewriter,
+            )
           }
         )
       test.waitUntil(timeoutMillis = 10_000) {
@@ -173,7 +177,10 @@ internal class FrameSyncFixture(
           assertNotNull(
             editor.updateNowWithBringIntoView(bringIntoViewRequests) {
               enqueue(Message.Key(KeyEvent(Key.Backspace)))
-              bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+              bringIntoView(
+                EditorBringIntoViewTarget.CurrentSelectionHead,
+                policy = EditorBringIntoViewPolicy.Typewriter,
+              )
             }
           )
         test.waitUntil(timeoutMillis = 10_000) {
@@ -197,7 +204,10 @@ internal class FrameSyncFixture(
       assertNotNull(
         editor.updateNowWithBringIntoView(bringIntoViewRequests) {
           repeat(LongDocumentParagraphCount) { enqueue(Message.Key(KeyEvent(Key.Enter))) }
-          bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+          bringIntoView(
+            EditorBringIntoViewTarget.CurrentSelectionHead,
+            policy = EditorBringIntoViewPolicy.Typewriter,
+          )
         }
       )
     test.waitUntil(timeoutMillis = 10_000) {
@@ -212,7 +222,10 @@ internal class FrameSyncFixture(
       assertNotNull(
         editor.updateNowWithBringIntoView(bringIntoViewRequests) {
           enqueue(Message.Selection(SelectionOp.SetAt(page = 0, x = PageMargin, y = PageMargin)))
-          bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+          bringIntoView(
+            EditorBringIntoViewTarget.CurrentSelectionHead,
+            policy = EditorBringIntoViewPolicy.CursorGuard,
+          )
         }
       )
     test.waitUntil(timeoutMillis = 10_000) {
@@ -249,7 +262,10 @@ internal class FrameSyncFixture(
       assertNotNull(
         editor.updateNowWithBringIntoView(bringIntoViewRequests) {
           enqueue(Message.Key(KeyEvent(Key.Enter)))
-          bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+          bringIntoView(
+            EditorBringIntoViewTarget.CurrentSelectionHead,
+            policy = EditorBringIntoViewPolicy.Typewriter,
+          )
         }
       )
     test.waitUntil(timeoutMillis = 10_000) {

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/EditorFrameSyncDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/EditorFrameSyncDesktopTest.kt
@@ -45,6 +45,7 @@ import co.typie.editor.interaction.LocalEditorInteractionScope
 import co.typie.editor.interaction.gestures.EditorSelectionHandleType
 import co.typie.editor.runtime.LocalEditorRuntime
 import co.typie.editor.runtime.LocalEditorUiState
+import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorBringIntoViewTarget
 import co.typie.editor.scroll.EditorScrollIntentResult
 import co.typie.editor.scroll.LocalEditorBringIntoViewRequests
@@ -283,7 +284,10 @@ class EditorFrameSyncDesktopTest {
         assertNotNull(
           fixture.editor.updateNowWithBringIntoView(fixture.bringIntoViewRequests) {
             enqueue(Message.Selection(SelectionOp.SetAt(page = 0, x = 0f, y = 0f)))
-            bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+            bringIntoView(
+              EditorBringIntoViewTarget.CurrentSelectionHead,
+              policy = EditorBringIntoViewPolicy.CursorGuard,
+            )
           }
         )
       waitUntil(timeoutMillis = 10_000) {
@@ -306,7 +310,10 @@ class EditorFrameSyncDesktopTest {
                 )
               )
             )
-            bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+            bringIntoView(
+              EditorBringIntoViewTarget.CurrentSelectionHead,
+              policy = EditorBringIntoViewPolicy.CursorGuard,
+            )
           }
         )
       waitUntil(timeoutMillis = 10_000) {
@@ -400,6 +407,7 @@ class EditorFrameSyncDesktopTest {
           resolveEditorScrollIntent(
             frame = fixture.scrollFrame(downState),
             target = EditorBringIntoViewTarget.CurrentSelectionHead,
+            policy = EditorBringIntoViewPolicy.Typewriter,
             currentScroll = beforeDown,
           )
             as? EditorScrollIntentResult.ScrollTo,
@@ -431,6 +439,7 @@ class EditorFrameSyncDesktopTest {
           resolveEditorScrollIntent(
             frame = fixture.scrollFrame(upState),
             target = EditorBringIntoViewTarget.CurrentSelectionHead,
+            policy = EditorBringIntoViewPolicy.Typewriter,
             currentScroll = beforeUp,
           )
             as? EditorScrollIntentResult.ScrollTo,
@@ -469,7 +478,10 @@ class EditorFrameSyncDesktopTest {
         assertNotNull(
           fixture.editor.updateNowWithBringIntoView(fixture.bringIntoViewRequests) {
             enqueue(Message.Selection(SelectionOp.SetFrozen(saved)))
-            bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+            bringIntoView(
+              EditorBringIntoViewTarget.CurrentSelectionHead,
+              policy = EditorBringIntoViewPolicy.CursorGuard,
+            )
           }
         )
       assertFalse(fixture.uiState.editorBoundsInContainer.isValid)
@@ -498,6 +510,7 @@ class EditorFrameSyncDesktopTest {
           resolveEditorScrollIntent(
             frame = fixture.scrollFrame(firstRestoredFrame.snapshot),
             target = EditorBringIntoViewTarget.CurrentSelectionHead,
+            policy = EditorBringIntoViewPolicy.CursorGuard,
             currentScroll = 0f,
           )
             as? EditorScrollIntentResult.ScrollTo
@@ -534,6 +547,7 @@ class EditorFrameSyncDesktopTest {
         resolveEditorScrollIntent(
           frame = fixture.scrollFrame(fixture.editor.publishedState),
           target = target,
+          policy = EditorBringIntoViewPolicy.CursorGuard,
           currentScroll = 0f,
         ),
         "TEST HARNESS: target must be visible in the stale 300dp viewport",
@@ -550,6 +564,7 @@ class EditorFrameSyncDesktopTest {
                   )
               ),
           target = target,
+          policy = EditorBringIntoViewPolicy.CursorGuard,
           currentScroll = 0f,
         )
           is EditorScrollIntentResult.ScrollTo,
@@ -561,6 +576,7 @@ class EditorFrameSyncDesktopTest {
         fixture.bringIntoViewRequests.requestForVersion(
           target = target,
           version = fixture.editor.appliedRevision,
+          policy = EditorBringIntoViewPolicy.CursorGuard,
         )
         fixture.editor.requestPublication()
       }
@@ -597,7 +613,10 @@ class EditorFrameSyncDesktopTest {
         assertNotNull(
           fixture.editor.updateNowWithBringIntoView(fixture.bringIntoViewRequests) {
             enqueue(Message.Selection(SelectionOp.SetFrozen(saved)))
-            bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+            bringIntoView(
+              EditorBringIntoViewTarget.CurrentSelectionHead,
+              policy = EditorBringIntoViewPolicy.CursorGuard,
+            )
           }
         )
       val expectedScroll =
@@ -605,6 +624,7 @@ class EditorFrameSyncDesktopTest {
           resolveEditorScrollIntent(
             frame = fixture.scrollFrame(restore.snapshot),
             target = EditorBringIntoViewTarget.CurrentSelectionHead,
+            policy = EditorBringIntoViewPolicy.CursorGuard,
             currentScroll = beforeScroll,
           )
             as? EditorScrollIntentResult.ScrollTo
@@ -699,7 +719,10 @@ class EditorFrameSyncDesktopTest {
         assertNotNull(
           fixture.editor.updateNowWithBringIntoView(fixture.bringIntoViewRequests) {
             enqueue(Message.Selection(SelectionOp.SetAt(page = 0, x = 0f, y = 0f)))
-            bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+            bringIntoView(
+              EditorBringIntoViewTarget.CurrentSelectionHead,
+              policy = EditorBringIntoViewPolicy.CursorGuard,
+            )
           }
         )
       waitUntil(timeoutMillis = 10_000) {
@@ -713,7 +736,10 @@ class EditorFrameSyncDesktopTest {
         assertNotNull(
           fixture.editor.updateNowWithBringIntoView(fixture.bringIntoViewRequests) {
             enqueue(Message.Selection(SelectionOp.SetFrozen(saved)))
-            bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+            bringIntoView(
+              EditorBringIntoViewTarget.CurrentSelectionHead,
+              policy = EditorBringIntoViewPolicy.CursorGuard,
+            )
           }
         )
       restoreRevision = restore.revision
@@ -722,6 +748,7 @@ class EditorFrameSyncDesktopTest {
           resolveEditorScrollIntent(
             frame = fixture.scrollFrame(restore.snapshot),
             target = EditorBringIntoViewTarget.CurrentSelectionHead,
+            policy = EditorBringIntoViewPolicy.CursorGuard,
             currentScroll = 0f,
           )
             as? EditorScrollIntentResult.ScrollTo
@@ -778,7 +805,10 @@ class EditorFrameSyncDesktopTest {
         fixture.scope.launch {
           fixture.editor.updateWithBringIntoView(fixture.bringIntoViewRequests) {
             enqueue(Message.Key(KeyEvent(Key.Enter)))
-            bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+            bringIntoView(
+              EditorBringIntoViewTarget.CurrentSelectionHead,
+              policy = EditorBringIntoViewPolicy.Typewriter,
+            )
           }
         }
       fixture.continuationScheduler.runCurrent()
@@ -824,6 +854,7 @@ class EditorFrameSyncDesktopTest {
           resolveEditorScrollIntent(
             frame = scrollFrame,
             target = EditorBringIntoViewTarget.CurrentSelectionHead,
+            policy = EditorBringIntoViewPolicy.Typewriter,
             currentScroll = beforeScroll,
           )
             as? EditorScrollIntentResult.ScrollTo,
@@ -852,7 +883,10 @@ class EditorFrameSyncDesktopTest {
           assertNotNull(
             fixture.editor.updateNowWithBringIntoView(fixture.bringIntoViewRequests) {
               enqueue(Message.Key(KeyEvent(Key.Backspace)))
-              bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+              bringIntoView(
+                EditorBringIntoViewTarget.CurrentSelectionHead,
+                policy = EditorBringIntoViewPolicy.Typewriter,
+              )
             }
           )
         assertEquals(
@@ -881,7 +915,10 @@ class EditorFrameSyncDesktopTest {
             assertNotNull(
               fixture.editor.updateNowWithBringIntoView(fixture.bringIntoViewRequests) {
                 enqueue(Message.Key(KeyEvent(Key.Enter)))
-                bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+                bringIntoView(
+                  EditorBringIntoViewTarget.CurrentSelectionHead,
+                  policy = EditorBringIntoViewPolicy.Typewriter,
+                )
               }
             )
           assertEquals(2, burstEnter.snapshot.pageSizes.size)
@@ -889,7 +926,10 @@ class EditorFrameSyncDesktopTest {
             assertNotNull(
               fixture.editor.updateNowWithBringIntoView(fixture.bringIntoViewRequests) {
                 enqueue(Message.Key(KeyEvent(Key.Backspace)))
-                bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+                bringIntoView(
+                  EditorBringIntoViewTarget.CurrentSelectionHead,
+                  policy = EditorBringIntoViewPolicy.Typewriter,
+                )
               }
             )
           assertEquals(1, burstBackspace.snapshot.pageSizes.size)
@@ -905,7 +945,10 @@ class EditorFrameSyncDesktopTest {
           assertNotNull(
             fixture.editor.updateNowWithBringIntoView(fixture.bringIntoViewRequests) {
               enqueue(Message.Key(KeyEvent(Key.Enter)))
-              bringIntoView(EditorBringIntoViewTarget.CurrentSelectionHead)
+              bringIntoView(
+                EditorBringIntoViewTarget.CurrentSelectionHead,
+                policy = EditorBringIntoViewPolicy.Typewriter,
+              )
             }
           )
         val growing = assertNotNull(fixture.editor.publishedBundle)

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/input/EditorInputEnabledDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/input/EditorInputEnabledDesktopTest.kt
@@ -36,6 +36,7 @@ import co.typie.editor.ffi.NavigationOp
 import co.typie.editor.ffi.Size as EditorSize
 import co.typie.editor.ffi.StateField
 import co.typie.editor.runtime.EditorUiState
+import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.LocalEditorBringIntoViewRequests
 import co.typie.editor.scroll.rememberEditorBringIntoViewRequests
@@ -199,6 +200,13 @@ class EditorInputEnabledDesktopTest {
     val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     val editor = Editor(fake, scope)
     val session = createTestDocumentEditingSession(editor, scope)
+    var observedRevealPolicy: EditorBringIntoViewPolicy? = null
+    lateinit var bringIntoViewRequests: EditorBringIntoViewRequests
+    bringIntoViewRequests = EditorBringIntoViewRequests {
+      bringIntoViewRequests.activateForVersion(Long.MAX_VALUE)?.let { request ->
+        observedRevealPolicy = request.policy
+      }
+    }
 
     try {
       editor.setImeSessionActive(true)
@@ -206,7 +214,6 @@ class EditorInputEnabledDesktopTest {
 
       setContent {
         val focusRequester = remember { FocusRequester() }
-        val bringIntoViewRequests = rememberEditorBringIntoViewRequests()
         Box(
           Modifier.size(200.dp)
             .testTag(InputTag)
@@ -247,8 +254,10 @@ class EditorInputEnabledDesktopTest {
         },
       )
 
+      bringIntoViewRequests.cancel()
       editor.refreshImeSnapshot()
       fake.enqueued.clear()
+      observedRevealPolicy = null
       onNodeWithTag(InputTag).performKeyInput {
         keyDown(Key.DirectionLeft)
         keyUp(Key.DirectionLeft)
@@ -256,11 +265,15 @@ class EditorInputEnabledDesktopTest {
       val moveLeft =
         Message.Navigation(NavigationOp.Move(Movement.Grapheme(Direction.Backward), extend = false))
       waitUntil(timeoutMillis = 5_000) { fake.enqueued.any { it == moveLeft } }
+      waitUntil(timeoutMillis = 5_000) {
+        observedRevealPolicy == EditorBringIntoViewPolicy.Typewriter
+      }
       assertEquals(
         listOf(Message.TextInput(listOf(FlatImeOp.CommitAsIs)), moveLeft),
         fake.enqueued.filter { it is Message.TextInput || it == moveLeft },
       )
 
+      bringIntoViewRequests.cancel()
       editor.refreshImeSnapshot()
       fake.enqueued.clear()
       onNodeWithTag(InputTag).performKeyInput {

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/interaction/EditorInteractionsDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/interaction/EditorInteractionsDesktopTest.kt
@@ -2052,7 +2052,7 @@ class EditorInteractionsDesktopTest {
 
     override fun performSelectionHaptic() = Unit
 
-    override fun requestCurrentSelectionHead(version: Long) = Unit
+    override fun requestPointerSelectionHead(version: Long) = Unit
   }
 
   private companion object {

--- a/apps/website/src/lib/editor-ffi/components/Input.svelte
+++ b/apps/website/src/lib/editor-ffi/components/Input.svelte
@@ -26,7 +26,7 @@
       enqueued = true;
     }
     if (enqueued) {
-      editor.scrollIntoView({ target: { type: 'current_selection_head' }, mode: 'typewriter' });
+      editor.scrollIntoView({ target: { type: 'current_selection_head' }, policy: 'typewriter' });
     }
   };
 

--- a/apps/website/src/lib/editor-ffi/editor-frame-sync.browser.test.ts
+++ b/apps/website/src/lib/editor-ffi/editor-frame-sync.browser.test.ts
@@ -476,7 +476,7 @@ describe('web editor frame synchronization', () => {
       const { editor } = await mountEditor(paginatedDocWithPageBreaks(3, { text: 'linked pixels', href }));
       const update = editor.updateNow((request) => {
         request.enqueue({ type: 'selection', op: { type: 'set_at', page: 2, x: PAGE_MARGIN, y: PAGE_MARGIN } });
-        editor.scrollIntoView({ target: { type: 'current_selection_head' }, behavior: 'instant' });
+        editor.scrollIntoView({ target: { type: 'current_selection_head' }, policy: 'cursor_guard' });
       });
       expect(update).not.toBeNull();
       if (!update) throw new Error('Expected the far-page reveal update');
@@ -512,7 +512,7 @@ describe('web editor frame synchronization', () => {
 
     editor.updateNow((request) => {
       request.enqueue({ type: 'selection', op: { type: 'set_at', page: 0, x: PAGE_MARGIN, y: PAGE_MARGIN } });
-      presentation = editor.scrollIntoView({ target: { type: 'current_selection_head' }, behavior: 'instant' });
+      presentation = editor.scrollIntoView({ target: { type: 'current_selection_head' }, policy: 'cursor_guard' });
     });
     editor.surfaceReplacementFailed(0);
 
@@ -536,7 +536,7 @@ describe('web editor frame synchronization', () => {
     let restorePresentation: Promise<void> | undefined;
     const restore = editor.updateNow((request) => {
       request.enqueue({ type: 'selection', op: { type: 'set_frozen', selection: saved } });
-      restorePresentation = editor.scrollIntoView({ target: { type: 'current_selection_head' } });
+      restorePresentation = editor.scrollIntoView({ target: { type: 'current_selection_head' }, policy: 'cursor_guard' });
     });
     expect(restore).not.toBeNull();
     if (!restore) throw new Error('Expected a restore update');
@@ -576,7 +576,7 @@ describe('web editor frame synchronization', () => {
 
     const farUpdate = editor.updateNow((request) => {
       request.enqueue({ type: 'selection', op: { type: 'set_at', page: pageCount - 1, x: PAGE_MARGIN, y: PAGE_MARGIN } });
-      editor.scrollIntoView({ target: { type: 'current_selection_head' }, behavior: 'instant' });
+      editor.scrollIntoView({ target: { type: 'current_selection_head' }, policy: 'cursor_guard' });
     });
     expect(farUpdate).not.toBeNull();
     if (!farUpdate) throw new Error('Expected the far-page selection update');
@@ -589,7 +589,7 @@ describe('web editor frame synchronization', () => {
 
     const resetUpdate = editor.updateNow((request) => {
       request.enqueue({ type: 'selection', op: { type: 'set_at', page: 0, x: PAGE_MARGIN, y: PAGE_MARGIN } });
-      editor.scrollIntoView({ target: { type: 'current_selection_head' }, behavior: 'instant' });
+      editor.scrollIntoView({ target: { type: 'current_selection_head' }, policy: 'cursor_guard' });
     });
     expect(resetUpdate).not.toBeNull();
     if (!resetUpdate) throw new Error('Expected the viewport reset update');
@@ -1086,7 +1086,7 @@ describe('web editor frame synchronization', () => {
 
     scrollRoot.scrollTop = 24;
     scrollRoot.dispatchEvent(new Event('scroll'));
-    editor.scrollIntoView({ target: { type: 'current_selection_head' }, mode: 'nearest', behavior: 'instant' });
+    editor.scrollIntoView({ target: { type: 'current_selection_head' }, policy: 'cursor_guard' });
     await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
 
     const endpoints = editor.selectionEndpoints();
@@ -1136,7 +1136,7 @@ describe('web editor frame synchronization', () => {
 
     const update = editor.updateNow((request) => {
       request.enqueue({ type: 'selection', op: { type: 'set_at', page: pageCount - 1, x: PAGE_MARGIN, y: 1_000_000 } });
-      editor.scrollIntoView({ target: { type: 'current_selection_head' }, behavior: 'instant' });
+      editor.scrollIntoView({ target: { type: 'current_selection_head' }, policy: 'cursor_guard' });
     });
     expect(update).not.toBeNull();
     if (!update) throw new Error('Expected the far-page reveal update');

--- a/apps/website/src/lib/editor-ffi/editor-host-failure.test.ts
+++ b/apps/website/src/lib/editor-ffi/editor-host-failure.test.ts
@@ -257,7 +257,7 @@ describe('Editor guarded core invocation', () => {
 
     editor.updateNow(() => {
       editor.enqueue({ type: 'history', op: { type: 'undo' } });
-      editor.scrollIntoView({ target: { type: 'current_selection_head' } });
+      editor.scrollIntoView({ target: { type: 'current_selection_head' }, policy: 'cursor_guard' });
     });
 
     expect(order).toEqual(['before-publish', 'replace']);
@@ -508,7 +508,7 @@ describe('Editor guarded core invocation', () => {
 
     const update = editor.updateNow(() => {
       editor.enqueue({ type: 'selection', op: { type: 'unset' } });
-      editor.scrollIntoView({ target: { type: 'current_selection_head' } });
+      editor.scrollIntoView({ target: { type: 'current_selection_head' }, policy: 'cursor_guard' });
     });
 
     expect(update).not.toBeNull();
@@ -522,7 +522,7 @@ describe('Editor guarded core invocation', () => {
 
     const update = editor.updateNow(() => {
       editor.enqueue({ type: 'history', op: { type: 'undo' } });
-      editor.scrollIntoView({ target: { type: 'current_selection_head' } });
+      editor.scrollIntoView({ target: { type: 'current_selection_head' }, policy: 'cursor_guard' });
     });
 
     expect(update).toBeNull();
@@ -706,7 +706,7 @@ describe('Editor guarded core invocation', () => {
     let presentation: Promise<void> | undefined;
     editor.updateNow(() => {
       editor.enqueue({ type: 'history', op: { type: 'undo' } });
-      presentation = editor.scrollIntoView({ target: { type: 'current_selection_head' } });
+      presentation = editor.scrollIntoView({ target: { type: 'current_selection_head' }, policy: 'cursor_guard' });
     });
     let settled = false;
     void presentation?.then(() => {

--- a/apps/website/src/lib/editor-ffi/editor-publication.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor-publication.svelte.ts
@@ -49,6 +49,7 @@ function reconcilePublication(
 ): void {
   if (editor.terminal) return;
 
+  scroll.discardObsoleteForRevision(editor.appliedSnapshot.revision);
   const preparation = resolveEditorSurfacePreparation(editor, scroll);
   if (!preparation) return;
   editor.requestSurfacePages(preparation.requiredPages);
@@ -135,15 +136,19 @@ function resolveEditorSurfacePreparation(
   const target = targetRects ? resolveTargetSpan(targetRects, pageSpans, zoom) : null;
   const preparationViewports =
     target && pendingRequest?.behavior === 'instant'
-      ? scroll.resolvePreparationViewports(pendingRequest, {
-          scrollTop,
-          clientHeight,
-          scrollHeight,
-          targetTop: target.targetTop,
-          targetBottom: target.targetBottom,
-        })
+      ? scroll.resolvePreparationViewports(
+          pendingRequest,
+          {
+            scrollTop,
+            clientHeight,
+            scrollHeight,
+            targetTop: target.targetTop,
+            targetBottom: target.targetBottom,
+          },
+          snapshot,
+        )
       : [];
-  const scrollIntent = resolveScrollIntent(pendingRequest, targetRects, target, scroll, {
+  const scrollIntent = resolveScrollIntent(pendingRequest, targetRects, target, snapshot, scroll, {
     scrollTop,
     clientHeight,
     scrollHeight,
@@ -181,6 +186,7 @@ function resolveScrollIntent(
   request: EditorBringIntoViewRequest | null,
   targetRects: ReturnType<NonNullable<EditorContext['scroll']>['resolveTargetRects']>,
   target: RevealTargetSpan | null,
+  snapshot: EditorSnapshot,
   scroll: NonNullable<EditorContext['scroll']>,
   metrics: Pick<ScrollContainerMetrics, 'scrollTop' | 'clientHeight' | 'scrollHeight'>,
 ): EditorScrollIntentResult | null {
@@ -188,7 +194,7 @@ function resolveScrollIntent(
   if (targetRects === null) return { type: 'no_scroll' };
   if (target === null) return { type: 'unresolved' };
 
-  const y = scroll.resolveScrollTop(request, { ...metrics, ...target });
+  const y = scroll.resolveScrollTop(request, { ...metrics, ...target }, snapshot);
   return y === null ? { type: 'no_scroll' } : { type: 'scroll_to', y };
 }
 

--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -927,7 +927,7 @@ export class Editor {
     if (idx === undefined) return;
     const match = this.#searchMatches[idx];
     if (!match) return;
-    this.scrollIntoView({ target: { type: 'tracked_item', id: match.id } });
+    this.scrollIntoView({ target: { type: 'tracked_item', id: match.id }, policy: 'result_reveal' });
   }
 
   #handleSearchReplaceResult(id: string, outcome: string): void {
@@ -1406,7 +1406,7 @@ export class Editor {
     if (this.readOnly || this.terminal) return;
     this.updateNow(() => {
       this.enqueue({ type: 'clipboard', op: { type: 'cut' } });
-      this.scrollIntoView({ target: { type: 'current_selection_head' }, mode: 'nearest' });
+      this.scrollIntoView({ target: { type: 'current_selection_head' }, policy: 'cursor_guard' });
     });
   }
 
@@ -1420,7 +1420,7 @@ export class Editor {
     if (this.readOnly || this.terminal) return;
     this.updateNow(() => {
       this.enqueue({ type: 'clipboard', op: { type: 'paste', html: undefined, text: result.text } });
-      this.scrollIntoView({ target: { type: 'current_selection_head' }, mode: 'typewriter' });
+      this.scrollIntoView({ target: { type: 'current_selection_head' }, policy: 'typewriter' });
     });
   }
 
@@ -2362,7 +2362,7 @@ export class Editor {
         this.activeSpellcheckErrorId = null;
         return;
       }
-      this.scrollIntoView({ target: { type: 'tracked_item', id } });
+      this.scrollIntoView({ target: { type: 'tracked_item', id }, policy: 'result_reveal' });
     }
   }
 
@@ -2539,7 +2539,7 @@ export class Editor {
     if (id !== null) {
       const ok = move(id, 'comment-active');
       if (ok) {
-        this.scrollIntoView({ target: { type: 'tracked_item', id } });
+        this.scrollIntoView({ target: { type: 'tracked_item', id }, policy: 'result_reveal' });
       } else {
         this.activeCommentId = null;
       }
@@ -2572,7 +2572,7 @@ export class Editor {
         this.activeAiFeedbackId = null;
         return;
       }
-      this.scrollIntoView({ target: { type: 'tracked_item', id } });
+      this.scrollIntoView({ target: { type: 'tracked_item', id }, policy: 'result_reveal' });
     }
   }
 

--- a/apps/website/src/lib/editor-ffi/handlers/clipboard.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/clipboard.ts
@@ -46,7 +46,7 @@ export const handleCut: EditorEventHandler<ImeTextInput, ClipboardEvent> = (edit
   e.preventDefault();
   editor.updateNow(() => {
     editor.enqueue({ type: 'clipboard', op: { type: 'cut' } });
-    editor.scrollIntoView({ target: { type: 'current_selection_head' }, mode: 'nearest' });
+    editor.scrollIntoView({ target: { type: 'current_selection_head' }, policy: 'cursor_guard' });
   });
 };
 
@@ -97,7 +97,7 @@ const readClipboardText = async (items: readonly ClipboardItem[]): Promise<{ htm
 };
 
 const scrollAfterPaste = (editor: Editor): void => {
-  editor.scrollIntoView({ target: { type: 'current_selection_head' }, mode: 'typewriter' });
+  editor.scrollIntoView({ target: { type: 'current_selection_head' }, policy: 'typewriter' });
 };
 
 const paste = (

--- a/apps/website/src/lib/editor-ffi/handlers/keyboard.test.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/keyboard.test.ts
@@ -45,7 +45,7 @@ describe('handleKeyDown', () => {
 
     expect(editor.updateNow).toHaveBeenCalledOnce();
     expect(messages).toEqual([{ type: 'key', event: { key: 'enter' } }]);
-    expect(editor.scrollIntoView).toHaveBeenCalledWith({ target: { type: 'current_selection_head' }, mode: 'typewriter' });
+    expect(editor.scrollIntoView).toHaveBeenCalledWith({ target: { type: 'current_selection_head' }, policy: 'typewriter' });
   });
 
   it('leaves composing navigation to the native post-composition keydown', () => {

--- a/apps/website/src/lib/editor-ffi/handlers/keyboard.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/keyboard.ts
@@ -24,7 +24,7 @@ const macOnly = () => isMac;
 
 const currentSelectionHeadTypewriterReveal = (): EditorScrollIntoViewOptions => ({
   target: { type: 'current_selection_head' },
-  mode: 'typewriter',
+  policy: 'typewriter',
 });
 
 const withCurrentSelectionHeadReveal = (bindings: KeyBinding[]): KeyBinding[] =>

--- a/apps/website/src/lib/editor-ffi/handlers/pointer.test.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/pointer.test.ts
@@ -157,7 +157,10 @@ describe('pointer native drag admission', () => {
 
     expect(editor.endNativeDragAdmission).toHaveBeenCalledWith({ restoreFocus: true });
     expect(editor.enqueue).toHaveBeenCalledWith({ type: 'selection', op: { type: 'set_at', page: 0, x: 10, y: 20 } });
-    expect(editor.scrollIntoView).toHaveBeenCalledWith({ target: { type: 'current_selection_head' }, mode: 'nearest' });
+    expect(editor.scrollIntoView).toHaveBeenCalledWith({
+      target: { type: 'current_selection_head' },
+      policy: 'pointer_cursor_guard',
+    });
     expect(editor.updateNow).toHaveBeenCalledTimes(1);
   });
 
@@ -224,7 +227,10 @@ describe('pointer native drag admission', () => {
     expect(target.setPointerCapture).toHaveBeenCalledWith(1);
     expect(target.releasePointerCapture).toHaveBeenCalledWith(1);
     expect(editor.enqueue).toHaveBeenCalledWith({ type: 'selection', op: { type: 'set_at', page: 0, x: 10, y: 20 } });
-    expect(editor.scrollIntoView).toHaveBeenCalledWith({ target: { type: 'current_selection_head' }, mode: 'nearest' });
+    expect(editor.scrollIntoView).toHaveBeenCalledWith({
+      target: { type: 'current_selection_head' },
+      policy: 'pointer_cursor_guard',
+    });
   });
 
   it('promotes a rapid third click inside the selected word to paragraph selection', () => {

--- a/apps/website/src/lib/editor-ffi/handlers/pointer.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/pointer.ts
@@ -117,7 +117,7 @@ export const handlePointerDown: EditorEventHandler<HTMLElement, PointerEvent> = 
       }
     });
     interactionSelection = update?.snapshot.selection;
-    editor.scrollIntoView({ target: { type: 'current_selection_head' }, mode: 'nearest' });
+    editor.scrollIntoView({ target: { type: 'current_selection_head' }, policy: 'pointer_cursor_guard' });
   }
   state.markPointerDown(e.pointerId, !nativeDragCandidate, { page, x, y }, count, modifiers, nativeDragCandidate, interactionSelection);
   if (!nativeDragCandidate) {
@@ -374,7 +374,7 @@ class PointerState {
           op: { type: 'set_at', page: session.down.page, x: session.down.x, y: session.down.y },
         }),
       );
-      editor.scrollIntoView({ target: { type: 'current_selection_head' }, mode: 'nearest' });
+      editor.scrollIntoView({ target: { type: 'current_selection_head' }, policy: 'pointer_cursor_guard' });
     }
     this.#edgeAutoScroll.stop();
     this.#session = null;

--- a/apps/website/src/lib/editor-ffi/required-surface-pages.test.ts
+++ b/apps/website/src/lib/editor-ffi/required-surface-pages.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { requiredSurfacePages } from './required-surface-pages';
-import { resolveInstantRevealPreparationViewports, resolveNearestScrollTop, resolveTypewriterScrollTop } from './scroll';
+import { resolveGuardedScrollTop, resolveInstantRevealPreparationViewports, resolveTypewriterScrollTop } from './scroll';
 import type { SurfacePageSpan, VerticalSpan } from './required-surface-pages';
 
 const pages = (...boundaries: number[]): SurfacePageSpan[] =>
@@ -161,11 +161,11 @@ describe('requiredSurfacePages', () => {
       visibleArea: { topInset: 10, bottomInset: 20 },
     };
     const preparation = resolveInstantRevealPreparationViewports({
-      mode: 'nearest',
+      mode: 'cursor_guard',
       scrollTop: 350,
       ...metrics,
     });
-    const exactDestinations = [0, 350, 800].map((scrollTop) => resolveNearestScrollTop({ scrollTop, ...metrics }) ?? scrollTop);
+    const exactDestinations = [0, 350, 800].map((scrollTop) => resolveGuardedScrollTop({ scrollTop, ...metrics }) ?? scrollTop);
 
     for (const scrollTop of exactDestinations) {
       expect(preparation).toContainEqual({ top: scrollTop, bottom: scrollTop + metrics.clientHeight });
@@ -180,19 +180,17 @@ describe('requiredSurfacePages', () => {
       targetBottom: 1100,
       visibleArea: { topInset: 20, bottomInset: 30 },
     };
-    const preparation = resolveInstantRevealPreparationViewports({ mode: 'nearest', scrollTop: 0, ...metrics });
-
     for (const scrollTop of [0, 600, 1500]) {
-      const destination = resolveNearestScrollTop({ scrollTop, ...metrics });
-      expect(destination).not.toBeNull();
-      expect(preparation).toContainEqual({ top: destination, bottom: Number(destination) + metrics.clientHeight });
+      const preparation = resolveInstantRevealPreparationViewports({ mode: 'cursor_guard', scrollTop, ...metrics });
+      const destination = resolveGuardedScrollTop({ scrollTop, ...metrics }) ?? scrollTop;
+      expect(preparation).toContainEqual({ top: destination, bottom: destination + metrics.clientHeight });
     }
   });
 
   it('instant preparation uses production clamp centered fallback and typewriter alignment', () => {
     expect(
       resolveInstantRevealPreparationViewports({
-        mode: 'nearest',
+        mode: 'cursor_guard',
         scrollTop: 200,
         clientHeight: 400,
         scrollHeight: 650,
@@ -210,9 +208,9 @@ describe('requiredSurfacePages', () => {
       targetBottom: 520,
       visibleArea: { topInset: 70, bottomInset: 70 },
     };
-    const centeredDestination = resolveNearestScrollTop(centeredMetrics);
+    const centeredDestination = resolveGuardedScrollTop(centeredMetrics);
     expect(centeredDestination).not.toBeNull();
-    expect(resolveInstantRevealPreparationViewports({ mode: 'nearest', ...centeredMetrics })).toEqual([
+    expect(resolveInstantRevealPreparationViewports({ mode: 'cursor_guard', ...centeredMetrics })).toEqual([
       { top: centeredDestination, bottom: Number(centeredDestination) + centeredMetrics.clientHeight },
     ]);
 
@@ -227,6 +225,36 @@ describe('requiredSurfacePages', () => {
     const typewriterDestination = resolveTypewriterScrollTop(typewriterMetrics);
     expect(resolveInstantRevealPreparationViewports({ mode: 'typewriter', ...typewriterMetrics })).toEqual([
       { top: typewriterDestination, bottom: Number(typewriterDestination) + typewriterMetrics.clientHeight },
+    ]);
+
+    const oversizedTypewriterMetrics = {
+      mode: 'typewriter' as const,
+      scrollTop: 0,
+      clientHeight: 400,
+      scrollHeight: 2000,
+      targetTop: 600,
+      targetBottom: 1100,
+      visibleArea: { topInset: 20, bottomInset: 30 },
+      position: 0.5,
+    };
+    expect(resolveTypewriterScrollTop(oversizedTypewriterMetrics)).toBe(790);
+    expect(resolveInstantRevealPreparationViewports(oversizedTypewriterMetrics)).toEqual([
+      { top: 0, bottom: 400 },
+      { top: 520, bottom: 920 },
+      { top: 790, bottom: 1190 },
+    ]);
+
+    const documentEdgeMetrics = {
+      ...oversizedTypewriterMetrics,
+      scrollTop: 800,
+      targetTop: 10,
+      targetBottom: 500,
+    };
+    expect(resolveTypewriterScrollTop(documentEdgeMetrics)).toBe(0);
+    expect(resolveInstantRevealPreparationViewports(documentEdgeMetrics)).toEqual([
+      { top: 800, bottom: 1200 },
+      { top: 0, bottom: 400 },
+      { top: 190, bottom: 590 },
     ]);
   });
 

--- a/apps/website/src/lib/editor-ffi/scroll-scope.test.ts
+++ b/apps/website/src/lib/editor-ffi/scroll-scope.test.ts
@@ -14,6 +14,22 @@ const trackedSnapshot = (id: string, rect: PageRect): EditorSnapshot =>
     rootAttrs: undefined,
   }) as EditorSnapshot;
 
+const selectionSnapshot = (collapsed: boolean, rect: PageRect): EditorSnapshot => {
+  const anchor = { node: 'text', offset: 0, affinity: 'downstream' as const };
+  const head = collapsed ? anchor : { ...anchor, offset: 1 };
+  return {
+    ...trackedSnapshot('unused', rect),
+    cursor: collapsed ? { page_idx: rect.page_idx, line: rect.rect } : undefined,
+    selection: { anchor, head },
+    selectionEndpoints: {
+      from: rect,
+      to: rect,
+      from_position: anchor,
+      to_position: head,
+    },
+  } as EditorSnapshot;
+};
+
 describe('EditorRequest', () => {
   it('replaces an existing before-publish registration and runs only the latest one', () => {
     const request = new EditorRequest();
@@ -50,7 +66,8 @@ describe('EditorRequest', () => {
   });
 });
 
-function setup(snapshot: EditorSnapshot) {
+function setup(snapshot: EditorSnapshot, typewriter?: { enabled: boolean; position: number | undefined }) {
+  const typewriterPreferences = typewriter ?? { enabled: false, position: undefined };
   const scrollTo = vi.fn();
   const requestPublication = vi.fn();
   const editor = {
@@ -82,18 +99,200 @@ function setup(snapshot: EditorSnapshot) {
     editor,
     requestPublication,
     scrollTo,
-    scope: new EditorScrollScope(editor, () => ({ enabled: false, position: undefined })),
+    scope: new EditorScrollScope(editor, () => typewriterPreferences),
   };
 }
 
 describe('EditorScrollScope', () => {
+  const revealMetrics = {
+    scrollTop: 0,
+    clientHeight: 400,
+    scrollHeight: 1200,
+    targetTop: 500,
+    targetBottom: 520,
+  };
+
+  it('uses typewriter reveal for a collapsed current selection caret', () => {
+    const rect = { page_idx: 0, rect: { x: 0, y: 500, width: 1, height: 20 } };
+    const snapshot = selectionSnapshot(true, rect);
+    const { scope } = setup(snapshot, { enabled: true, position: 0.5 });
+    const request = scope.declare({ target: { type: 'current_selection_head' }, policy: 'typewriter' });
+
+    expect(scope.resolveScrollTop(request, revealMetrics, snapshot)).toBe(310);
+  });
+
+  it('uses candidate unit-selection endpoint geometry for typewriter reveal and padding', () => {
+    const publishedRect = { page_idx: 0, rect: { x: 0, y: 500, width: 1, height: 20 } };
+    const candidateRect = { page_idx: 0, rect: { x: 0, y: 500, width: 1, height: 40 } };
+    const publishedSnapshot = selectionSnapshot(true, publishedRect);
+    const candidateSnapshot = selectionSnapshot(false, candidateRect);
+    const { scope } = setup(publishedSnapshot, { enabled: true, position: 0.5 });
+    const request = scope.declare({ target: { type: 'current_selection_head' }, policy: 'typewriter' });
+    const candidateMetrics = { ...revealMetrics, targetBottom: 540 };
+
+    expect(scope.resolveScrollTop(request, candidateMetrics, candidateSnapshot)).toBe(320);
+    expect(scope.resolvePreparationViewports(request, candidateMetrics, candidateSnapshot)).toEqual([{ top: 320, bottom: 720 }]);
+    expect(scope.bottomPaddingFor(candidateSnapshot)).toBe(160);
+  });
+
+  it('uses typewriter reveal at the endpoint matching a keyboard-extended range head', () => {
+    const headRect = { page_idx: 0, rect: { x: 0, y: 500, width: 1, height: 20 } };
+    const baseSnapshot = selectionSnapshot(false, headRect);
+    const fromRect = { page_idx: 0, rect: { x: 0, y: 20, width: 1, height: 20 } };
+    if (!baseSnapshot.selectionEndpoints) throw new Error('range snapshot must have selection endpoints');
+    const snapshot = {
+      ...baseSnapshot,
+      selectionEndpoints: { ...baseSnapshot.selectionEndpoints, from: fromRect },
+    } as EditorSnapshot;
+    const { scope } = setup(snapshot, { enabled: true, position: 0.5 });
+    const request = scope.declare({ target: { type: 'current_selection_head' }, policy: 'typewriter' });
+
+    expect(scope.resolveTargetRects(request.target, snapshot)).toEqual([headRect]);
+    expect(scope.resolveScrollTop(request, revealMetrics, snapshot)).toBe(310);
+  });
+
+  it('keeps an explicit cursor-guard current-selection-head request out of typewriter mode', () => {
+    const rect = { page_idx: 0, rect: { x: 0, y: 500, width: 1, height: 20 } };
+    const snapshot = selectionSnapshot(false, rect);
+    const { scope } = setup(snapshot, { enabled: true, position: 0.5 });
+    const request = scope.declare({ target: { type: 'current_selection_head' }, policy: 'cursor_guard' });
+
+    expect(scope.resolveScrollTop(request, revealMetrics, snapshot)).toBe(180);
+  });
+
+  it('falls back to cursor guard when typewriter is requested for a tracked item', () => {
+    const rect = { page_idx: 0, rect: { x: 0, y: 500, width: 1, height: 20 } };
+    const snapshot = selectionSnapshot(true, rect);
+    const { scope } = setup(snapshot, { enabled: true, position: 0.5 });
+    const request = scope.declare({ target: { type: 'tracked_item', id: 'unused' }, policy: 'typewriter' });
+
+    expect(scope.resolveScrollTop(request, revealMetrics, snapshot)).toBe(180);
+    expect(scope.resolvePreparationViewports(request, revealMetrics, snapshot)).toEqual([
+      { top: 440, bottom: 840 },
+      { top: 180, bottom: 580 },
+    ]);
+  });
+
+  it('top-aligns an oversized tracked result below the viewport', () => {
+    const snapshot = trackedSnapshot('target', {
+      page_idx: 0,
+      rect: { x: 0, y: 1000, width: 1, height: 500 },
+    });
+    const { scope } = setup(snapshot);
+    const request = scope.declare({ target: { type: 'tracked_item', id: 'target' }, policy: 'result_reveal' });
+
+    expect(
+      scope.resolveScrollTop(
+        request,
+        { scrollTop: 300, clientHeight: 400, scrollHeight: 2000, targetTop: 1000, targetBottom: 1500 },
+        snapshot,
+      ),
+    ).toBe(940);
+  });
+
+  it('derives smooth behavior for tracked result reveals', () => {
+    const snapshot = trackedSnapshot('target', {
+      page_idx: 0,
+      rect: { x: 0, y: 1000, width: 1, height: 500 },
+    });
+    const { scope } = setup(snapshot);
+
+    const request = scope.declare({
+      target: { type: 'tracked_item', id: 'target' },
+      policy: 'result_reveal',
+    });
+
+    expect(request.behavior).toBe('smooth');
+  });
+
+  it('applies the cursor guard to a compact pointer selection head', () => {
+    const rect = { page_idx: 0, rect: { x: 0, y: 350, width: 1, height: 20 } };
+    const snapshot = selectionSnapshot(true, rect);
+    const { scope } = setup(snapshot);
+    const request = scope.declare({
+      target: { type: 'current_selection_head' },
+      policy: 'pointer_cursor_guard',
+    });
+
+    expect(scope.resolveTargetRects(request.target, snapshot)).toEqual([rect]);
+    expect(
+      scope.resolveScrollTop(request, { scrollTop: 0, clientHeight: 400, scrollHeight: 1200, targetTop: 350, targetBottom: 370 }, snapshot),
+    ).toBe(30);
+    expect(
+      scope.resolvePreparationViewports(
+        request,
+        { scrollTop: 0, clientHeight: 400, scrollHeight: 1200, targetTop: 350, targetBottom: 370 },
+        snapshot,
+      ),
+    ).toContainEqual({ top: 30, bottom: 430 });
+  });
+
+  it('keeps an oversized pointer selection when one cursor margin is visible inside the guard', () => {
+    const snapshot = selectionSnapshot(false, { page_idx: 0, rect: { x: 0, y: 280, width: 1, height: 500 } });
+    const { scope } = setup(snapshot);
+    const request = scope.declare({
+      target: { type: 'current_selection_head' },
+      policy: 'pointer_cursor_guard',
+    });
+
+    expect(
+      scope.resolveScrollTop(request, { scrollTop: 0, clientHeight: 400, scrollHeight: 1200, targetTop: 280, targetBottom: 780 }, snapshot),
+    ).toBeNull();
+  });
+
+  it('reveals one cursor margin of an oversized pointer selection entering from below', () => {
+    const snapshot = selectionSnapshot(false, { page_idx: 0, rect: { x: 0, y: 310, width: 1, height: 500 } });
+    const { scope } = setup(snapshot);
+    const request = scope.declare({
+      target: { type: 'current_selection_head' },
+      policy: 'pointer_cursor_guard',
+    });
+    const metrics = { scrollTop: 0, clientHeight: 400, scrollHeight: 1200, targetTop: 310, targetBottom: 810 };
+
+    expect(scope.resolveScrollTop(request, metrics, snapshot)).toBe(30);
+    expect(scope.resolvePreparationViewports(request, metrics, snapshot)).toContainEqual({ top: 30, bottom: 430 });
+  });
+
+  it('reveals one cursor margin of an oversized pointer selection entering from above', () => {
+    const snapshot = selectionSnapshot(false, { page_idx: 0, rect: { x: 0, y: 0, width: 1, height: 500 } });
+    const { scope } = setup(snapshot);
+    const request = scope.declare({
+      target: { type: 'current_selection_head' },
+      policy: 'pointer_cursor_guard',
+    });
+    const metrics = { scrollTop: 410, clientHeight: 400, scrollHeight: 1200, targetTop: 0, targetBottom: 500 };
+
+    expect(scope.resolveScrollTop(request, metrics, snapshot)).toBe(380);
+    expect(scope.resolvePreparationViewports(request, metrics, snapshot)).toContainEqual({ top: 380, bottom: 780 });
+  });
+
+  it('treats pointer selection reveals as exact-revision requests and discards skipped revisions', async () => {
+    const snapshot = trackedSnapshot('target', {
+      page_idx: 0,
+      rect: { x: 0, y: 0, width: 1, height: 20 },
+    });
+    const { scope } = setup(snapshot);
+    const request = scope.declare({
+      target: { type: 'current_selection_head' },
+      policy: 'pointer_cursor_guard',
+    });
+    expect(scope.bind(request, 7)).toBe(true);
+
+    expect(scope.activateForRevision(6)).toBeNull();
+    expect(scope.activateForRevision(7)).toBe(request);
+    expect(scope.activateForRevision(8)).toBeNull();
+    scope.discardObsoleteForRevision(8);
+    await expect(request.presentation).resolves.toBeUndefined();
+    expect(scope.pendingRequest).toBeNull();
+  });
+
   it('keeps a declared reveal ineligible until the installing revision binds it', () => {
     const snapshot = trackedSnapshot('target', {
       page_idx: 0,
       rect: { x: 0, y: 900, width: 1, height: 20 },
     });
     const { scope } = setup(snapshot);
-    const request = scope.declare({ target: { type: 'tracked_item', id: 'target' }, mode: 'nearest' });
+    const request = scope.declare({ target: { type: 'tracked_item', id: 'target' }, policy: 'result_reveal' });
 
     expect(scope.activateForRevision(7)).toBeNull();
     expect(scope.bind(request, 7)).toBe(true);
@@ -109,7 +308,7 @@ describe('EditorScrollScope', () => {
     const { scope } = setup(snapshot);
     const admission = new EditorRequest();
 
-    scope.scrollIntoView({ target: { type: 'current_selection_head' }, mode: 'nearest' }, admission);
+    scope.scrollIntoView({ target: { type: 'current_selection_head' }, policy: 'cursor_guard' }, admission);
     const request = scope.pendingRequest;
     if (!request) throw new Error('Expected a pending reveal');
     expect(request.targetRevision).toBeNull();
@@ -125,7 +324,7 @@ describe('EditorScrollScope', () => {
     });
     const { scope } = setup(snapshot);
 
-    const presentation = scope.scrollIntoView({ target: { type: 'tracked_item', id: 'target' }, mode: 'nearest' });
+    const presentation = scope.scrollIntoView({ target: { type: 'tracked_item', id: 'target' }, policy: 'result_reveal' });
     const request = scope.pendingRequest;
     if (!request) throw new Error('Expected a pending reveal');
 
@@ -148,11 +347,11 @@ describe('EditorScrollScope', () => {
       rect: { x: 0, y: 900, width: 1, height: 20 },
     });
     const { scope } = setup(snapshot);
-    const tracked = scope.declare({ target: { type: 'tracked_item', id: 'target' }, mode: 'nearest' });
+    const tracked = scope.declare({ target: { type: 'tracked_item', id: 'target' }, policy: 'result_reveal' });
     expect(scope.bind(tracked, 7)).toBe(true);
     expect(scope.activateForRevision(8)).toBe(tracked);
 
-    const selection = scope.declare({ target: { type: 'current_selection_head' }, mode: 'nearest' });
+    const selection = scope.declare({ target: { type: 'current_selection_head' }, policy: 'cursor_guard' });
     expect(scope.bind(selection, 7)).toBe(true);
     expect(scope.activateForRevision(8)).toBe(selection);
   });
@@ -163,10 +362,13 @@ describe('EditorScrollScope', () => {
       rect: { x: 0, y: 900, width: 1, height: 20 },
     });
     const { scope } = setup(snapshot);
-    const old = scope.declare({ target: { type: 'tracked_item', id: 'old' }, mode: 'nearest' });
+    const old = scope.declare({
+      target: { type: 'current_selection_head' },
+      policy: 'pointer_cursor_guard',
+    });
     const oldPresentation = old.presentation;
 
-    scope.declare({ target: { type: 'tracked_item', id: 'new' }, mode: 'nearest' });
+    scope.declare({ target: { type: 'tracked_item', id: 'new' }, policy: 'result_reveal' });
 
     await expect(oldPresentation).resolves.toBeUndefined();
   });
@@ -177,7 +379,7 @@ describe('EditorScrollScope', () => {
       rect: { x: 0, y: 900, width: 1, height: 20 },
     });
     const { requestPublication, scope } = setup(snapshot);
-    const request = scope.declare({ target: { type: 'tracked_item', id: 'target' }, mode: 'nearest' });
+    const request = scope.declare({ target: { type: 'tracked_item', id: 'target' }, policy: 'result_reveal' });
     const presentation = request.presentation;
     requestPublication.mockClear();
 
@@ -195,9 +397,9 @@ describe('EditorScrollScope', () => {
     });
     const { requestPublication, scope } = setup(snapshot);
 
-    scope.scrollIntoView({ target: { type: 'tracked_item', id: 'old' }, mode: 'nearest' });
+    scope.scrollIntoView({ target: { type: 'tracked_item', id: 'old' }, policy: 'result_reveal' });
     const old = scope.pendingRequest;
-    scope.scrollIntoView({ target: { type: 'tracked_item', id: 'new' }, mode: 'nearest' });
+    scope.scrollIntoView({ target: { type: 'tracked_item', id: 'new' }, policy: 'result_reveal' });
 
     expect(scope.pendingRequest?.target).toEqual({ type: 'tracked_item', id: 'new' });
     expect(requestPublication).toHaveBeenCalledTimes(2);
@@ -211,9 +413,9 @@ describe('EditorScrollScope', () => {
     });
     const { requestPublication, scope, scrollTo } = setup(snapshot);
 
-    scope.scrollIntoView({ target: { type: 'tracked_item', id: 'old' }, mode: 'nearest' });
+    scope.scrollIntoView({ target: { type: 'tracked_item', id: 'old' }, policy: 'result_reveal' });
     const old = scope.pendingRequest;
-    scope.scrollIntoView({ target: { type: 'tracked_item', id: 'new' }, mode: 'nearest' });
+    scope.scrollIntoView({ target: { type: 'tracked_item', id: 'new' }, policy: 'result_reveal' });
     const current = scope.pendingRequest;
     if (!old || !current) throw new Error('Expected both scroll requests');
     requestPublication.mockClear();
@@ -245,7 +447,7 @@ describe('EditorScrollScope', () => {
     const { editor, scope, scrollTo } = setup(snapshot);
     editor.pageEls[1] = undefined;
 
-    scope.scrollIntoView({ target: { type: 'current_selection_head' }, mode: 'nearest' });
+    scope.scrollIntoView({ target: { type: 'current_selection_head' }, policy: 'cursor_guard' });
     const request = scope.pendingRequest;
     if (!request) throw new Error('Expected a scroll request');
 
@@ -262,8 +464,7 @@ describe('EditorScrollScope', () => {
     const { scope, scrollTo } = setup(snapshot);
     const presentation = scope.scrollIntoView({
       target: { type: 'tracked_item', id: 'target' },
-      mode: 'nearest',
-      behavior: 'instant',
+      policy: 'cursor_guard',
     });
     const request = scope.pendingRequest;
     if (!request) throw new Error('Expected a pending reveal');
@@ -297,7 +498,7 @@ describe('EditorScrollScope', () => {
     } as EditorSnapshot;
     const { scope, scrollTo } = setup(snapshot);
 
-    scope.scrollIntoView({ target: { type: 'current_selection_head' }, mode: 'nearest' });
+    scope.scrollIntoView({ target: { type: 'current_selection_head' }, policy: 'cursor_guard' });
     const request = scope.pendingRequest;
     if (!request) throw new Error('Expected a scroll request');
 
@@ -312,7 +513,7 @@ describe('EditorScrollScope', () => {
     });
     const { editor, scope, scrollTo } = setup(snapshot);
 
-    scope.scrollIntoView({ target: { type: 'tracked_item', id: 'target' }, mode: 'nearest' });
+    scope.scrollIntoView({ target: { type: 'tracked_item', id: 'target' }, policy: 'result_reveal' });
     const request = scope.pendingRequest;
     if (!request) throw new Error('Expected a scroll request');
 
@@ -334,7 +535,7 @@ describe('EditorScrollScope', () => {
     });
     const { scope, scrollTo } = setup(snapshot);
 
-    scope.scrollIntoView({ target: { type: 'tracked_item', id: 'missing' }, mode: 'nearest' });
+    scope.scrollIntoView({ target: { type: 'tracked_item', id: 'missing' }, policy: 'result_reveal' });
     const request = scope.pendingRequest;
     if (!request) throw new Error('Expected a scroll request');
     const presentation = request.presentation;

--- a/apps/website/src/lib/editor-ffi/scroll.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/scroll.svelte.ts
@@ -1,11 +1,11 @@
 import { getAppContext } from '@typie/ui/context';
 import { untrack } from 'svelte';
-import { CONTINUOUS_VIEW_PADDING } from './constants';
+import { CONTINUOUS_VIEW_PADDING, CURSOR_VISIBLE_MARGIN } from './constants';
 import { selectionHeadRect } from './geometry';
 import {
+  resolveGuardedScrollTop,
   resolveInstantRevealPreparationViewports,
   resolveKeepVisibleBottomPadding,
-  resolveNearestScrollTop,
   resolveTypewriterBottomPadding,
   resolveTypewriterScrollTop,
 } from './scroll';
@@ -15,14 +15,14 @@ import type { EditorRequest } from './editor-update';
 import type { VerticalSpan } from './required-surface-pages';
 import type { EditorVisibleArea, RevealTargetSpan, ScrollContainerMetrics } from './scroll';
 
-export type EditorScrollRevealMode = 'nearest' | 'typewriter';
+export type EditorScrollRevealPolicy = 'cursor_guard' | 'pointer_cursor_guard' | 'typewriter' | 'result_reveal';
+type ResolvedEditorScrollRevealPolicy = Exclude<EditorScrollRevealPolicy, 'pointer_cursor_guard'>;
 
 export type EditorScrollIntoViewTarget = { type: 'current_selection_head' } | { type: 'tracked_item'; id: string };
 
 export type EditorScrollIntoViewOptions = {
   target: EditorScrollIntoViewTarget;
-  mode?: EditorScrollRevealMode;
-  behavior?: ScrollBehavior;
+  policy: EditorScrollRevealPolicy;
 };
 
 export type EditorScrollIntentResult = { type: 'unresolved' } | { type: 'no_scroll' } | { type: 'scroll_to'; y: number };
@@ -32,7 +32,8 @@ type TypewriterPreferences = {
   position: number | undefined;
 };
 
-export type EditorBringIntoViewRequest = Required<EditorScrollIntoViewOptions> & {
+export type EditorBringIntoViewRequest = EditorScrollIntoViewOptions & {
+  behavior: ScrollBehavior;
   targetRevision: number | null;
   presentation: Promise<void>;
   completePresentation: () => void;
@@ -62,12 +63,12 @@ function sanitizeTypewriterPosition(position: number | undefined): number {
   return typeof position === 'number' && Number.isFinite(position) ? Math.max(0, Math.min(1, position)) : 0.5;
 }
 
-function createBringIntoViewRequest({ target, mode = 'nearest', behavior }: EditorScrollIntoViewOptions): EditorBringIntoViewRequest {
+function createBringIntoViewRequest({ target, policy }: EditorScrollIntoViewOptions): EditorBringIntoViewRequest {
   const { promise: presentation, resolve } = Promise.withResolvers<undefined>();
   return {
     target,
-    mode,
-    behavior: behavior ?? (target.type === 'tracked_item' ? 'smooth' : 'instant'),
+    policy,
+    behavior: policy === 'result_reveal' ? 'smooth' : 'instant',
     targetRevision: null,
     presentation,
     completePresentation: () => resolve(undefined),
@@ -189,7 +190,7 @@ export class EditorScrollScope {
     const request = createBringIntoViewRequest(options);
     this.#pendingRequest?.completePresentation();
     this.#pendingRequest = request;
-    this.#keepVisibleTarget = request.target;
+    this.#keepVisibleTarget = request.policy === 'pointer_cursor_guard' ? null : request.target;
     this.#editor.requestPublication();
     return request;
   }
@@ -204,7 +205,15 @@ export class EditorScrollScope {
   activateForRevision(revision: number): EditorBringIntoViewRequest | null {
     const request = this.#pendingRequest;
     if (!request || request.targetRevision === null) return null;
-    return revision >= request.targetRevision ? request : null;
+    const eligible = request.policy === 'pointer_cursor_guard' ? revision === request.targetRevision : revision >= request.targetRevision;
+    return eligible ? request : null;
+  }
+
+  discardObsoleteForRevision(revision: number): void {
+    const request = this.#pendingRequest;
+    if (request?.policy === 'pointer_cursor_guard' && request.targetRevision !== null && revision > request.targetRevision) {
+      this.discard(request);
+    }
   }
 
   discard(request: EditorBringIntoViewRequest): void {
@@ -232,28 +241,64 @@ export class EditorScrollScope {
     return true;
   }
 
-  resolveScrollTop(request: EditorBringIntoViewRequest, metrics: ScrollContainerMetrics & RevealTargetSpan): number | null {
-    const mode = request.mode === 'typewriter' && this.#typewriterPreferences().enabled ? 'typewriter' : 'nearest';
-    return mode === 'typewriter'
-      ? resolveTypewriterScrollTop({
+  resolveScrollTop(
+    request: EditorBringIntoViewRequest,
+    metrics: ScrollContainerMetrics & RevealTargetSpan,
+    snapshot: EditorSnapshot,
+  ): number | null {
+    const policy = this.#resolvePolicy(request, snapshot);
+    switch (policy) {
+      case 'typewriter': {
+        return resolveTypewriterScrollTop({
           ...metrics,
           visibleArea: this.visibleArea,
           position: sanitizeTypewriterPosition(this.#typewriterPreferences().position),
-        })
-      : resolveNearestScrollTop({ ...metrics, visibleArea: this.visibleArea });
+        });
+      }
+      case 'result_reveal': {
+        return resolveGuardedScrollTop({
+          ...metrics,
+          visibleArea: this.visibleArea,
+          oversizedAlignment: 'start',
+        });
+      }
+      case 'cursor_guard': {
+        return resolveGuardedScrollTop({
+          ...metrics,
+          visibleArea: this.visibleArea,
+          oversizedMinimumVisibleHeight: request.policy === 'pointer_cursor_guard' ? CURSOR_VISIBLE_MARGIN : undefined,
+        });
+      }
+    }
   }
 
-  resolvePreparationViewports(request: EditorBringIntoViewRequest, metrics: ScrollContainerMetrics & RevealTargetSpan): VerticalSpan[] {
-    const mode = request.mode === 'typewriter' && this.#typewriterPreferences().enabled ? 'typewriter' : 'nearest';
+  resolvePreparationViewports(
+    request: EditorBringIntoViewRequest,
+    metrics: ScrollContainerMetrics & RevealTargetSpan,
+    snapshot: EditorSnapshot,
+  ): VerticalSpan[] {
+    if (request.behavior !== 'instant') return [];
+    const policy = this.#resolvePolicy(request, snapshot);
     return resolveInstantRevealPreparationViewports({
       ...metrics,
-      mode,
+      mode: policy === 'typewriter' ? 'typewriter' : 'cursor_guard',
       visibleArea: this.visibleArea,
+      oversizedMinimumVisibleHeight: request.policy === 'pointer_cursor_guard' ? CURSOR_VISIBLE_MARGIN : undefined,
       position: sanitizeTypewriterPosition(this.#typewriterPreferences().position),
     });
   }
 
-  // eslint-disable-next-line unicorn/consistent-class-member-order -- public scroll contract is grouped before private padding details
+  // eslint-disable-next-line unicorn/consistent-class-member-order -- public scroll contract is grouped before private policy details
+  #resolvePolicy(request: EditorBringIntoViewRequest, snapshot: EditorSnapshot): ResolvedEditorScrollRevealPolicy {
+    if (request.policy === 'pointer_cursor_guard') return 'cursor_guard';
+    if (request.policy !== 'typewriter') return request.policy;
+    return request.target.type === 'current_selection_head' &&
+      this.#typewriterPreferences().enabled &&
+      this.resolveTargetRects(request.target, snapshot) !== null
+      ? 'typewriter'
+      : 'cursor_guard';
+  }
+
   #hasResolvedKeepVisibleTarget(snapshot: EditorSnapshot | undefined): boolean {
     const target = this.#keepVisibleTarget;
     return target !== null && this.resolveTargetRects(target, snapshot) !== null;
@@ -302,15 +347,12 @@ export class EditorScrollScope {
     });
   }
 
-  scrollIntoView(
-    { target, mode = 'nearest', behavior }: EditorScrollIntoViewOptions,
-    admission?: EditorRequest,
-  ): Promise<void> | undefined {
+  scrollIntoView({ target, policy }: EditorScrollIntoViewOptions, admission?: EditorRequest): Promise<void> | undefined {
     if (this.#destroyed) {
       return;
     }
 
-    const request = this.declare({ target, mode, behavior });
+    const request = this.declare({ target, policy });
     if (admission) {
       admission.beforePublish(
         (update) => {

--- a/apps/website/src/lib/editor-ffi/scroll.test.ts
+++ b/apps/website/src/lib/editor-ffi/scroll.test.ts
@@ -1,15 +1,15 @@
 import { describe, expect, it } from 'vitest';
 import {
+  resolveGuardedScrollTop,
   resolveKeepVisibleBottomPadding,
-  resolveNearestScrollTop,
   resolveTypewriterBottomPadding,
   resolveTypewriterScrollTop,
 } from './scroll';
 
-describe('resolveNearestScrollTop', () => {
+describe('resolveGuardedScrollTop', () => {
   it('keeps the target inside the guarded visible area with insets', () => {
     expect(
-      resolveNearestScrollTop({
+      resolveGuardedScrollTop({
         scrollTop: 100,
         clientHeight: 400,
         scrollHeight: 1000,
@@ -20,7 +20,7 @@ describe('resolveNearestScrollTop', () => {
     ).toBe(130);
 
     expect(
-      resolveNearestScrollTop({
+      resolveGuardedScrollTop({
         scrollTop: 100,
         clientHeight: 400,
         scrollHeight: 1000,
@@ -33,7 +33,7 @@ describe('resolveNearestScrollTop', () => {
 
   it('returns null when the target is already visible', () => {
     expect(
-      resolveNearestScrollTop({
+      resolveGuardedScrollTop({
         scrollTop: 100,
         clientHeight: 400,
         scrollHeight: 1000,
@@ -43,9 +43,9 @@ describe('resolveNearestScrollTop', () => {
     ).toBeNull();
   });
 
-  it('aligns an oversized target top to the guarded visible area', () => {
+  it('aligns an oversized target below the viewport bottom to the lower cursor guard', () => {
     expect(
-      resolveNearestScrollTop({
+      resolveGuardedScrollTop({
         scrollTop: 300,
         clientHeight: 400,
         scrollHeight: 2000,
@@ -53,7 +53,71 @@ describe('resolveNearestScrollTop', () => {
         targetBottom: 1500,
         visibleArea: { topInset: 10, bottomInset: 20 },
       }),
-    ).toBe(930);
+    ).toBe(1180);
+  });
+
+  it('does not scroll when an oversized target already covers the guarded visible area', () => {
+    expect(
+      resolveGuardedScrollTop({
+        scrollTop: 300,
+        clientHeight: 400,
+        scrollHeight: 2000,
+        targetTop: 250,
+        targetBottom: 800,
+        visibleArea: { topInset: 10, bottomInset: 20 },
+      }),
+    ).toBeNull();
+  });
+
+  it('does not scroll when an oversized target exactly meets either guard edge and covers the other', () => {
+    const metrics = {
+      scrollTop: 300,
+      clientHeight: 400,
+      scrollHeight: 2000,
+      visibleArea: { topInset: 10, bottomInset: 20 },
+    };
+
+    expect(resolveGuardedScrollTop({ ...metrics, targetTop: 370, targetBottom: 800 })).toBeNull();
+    expect(resolveGuardedScrollTop({ ...metrics, targetTop: 100, targetBottom: 620 })).toBeNull();
+  });
+
+  it('aligns an oversized target to the violated guard edge even within the old slack', () => {
+    expect(
+      resolveGuardedScrollTop({
+        scrollTop: 300,
+        clientHeight: 400,
+        scrollHeight: 2000,
+        targetTop: 390,
+        targetBottom: 900,
+        visibleArea: { topInset: 10, bottomInset: 20 },
+      }),
+    ).toBe(580);
+  });
+
+  it('clamps an oversized cursor reveal at the document edge', () => {
+    expect(
+      resolveGuardedScrollTop({
+        scrollTop: 10,
+        clientHeight: 400,
+        scrollHeight: 800,
+        targetTop: 0,
+        targetBottom: 251,
+        visibleArea: { topInset: 30, bottomInset: 0 },
+      }),
+    ).toBe(0);
+  });
+
+  it('aligns an oversized target above the viewport top to the upper cursor guard', () => {
+    expect(
+      resolveGuardedScrollTop({
+        scrollTop: 300,
+        clientHeight: 400,
+        scrollHeight: 2000,
+        targetTop: 0,
+        targetBottom: 400,
+        visibleArea: { topInset: 10, bottomInset: 20 },
+      }),
+    ).toBe(0);
   });
 });
 
@@ -83,6 +147,34 @@ describe('resolveTypewriterScrollTop', () => {
         position: 0.5,
       }),
     ).toBe(1500);
+  });
+
+  it('falls back to the lower cursor guard for an oversized target below the viewport', () => {
+    expect(
+      resolveTypewriterScrollTop({
+        scrollTop: 300,
+        clientHeight: 400,
+        scrollHeight: 2000,
+        targetTop: 1000,
+        targetBottom: 1500,
+        visibleArea: { topInset: 10, bottomInset: 20 },
+        position: 0.5,
+      }),
+    ).toBe(1180);
+  });
+
+  it('keeps the viewport when an oversized target spans both cursor guard edges', () => {
+    expect(
+      resolveTypewriterScrollTop({
+        scrollTop: 300,
+        clientHeight: 400,
+        scrollHeight: 2000,
+        targetTop: 250,
+        targetBottom: 800,
+        visibleArea: { topInset: 10, bottomInset: 20 },
+        position: 0.5,
+      }),
+    ).toBeNull();
   });
 });
 

--- a/apps/website/src/lib/editor-ffi/scroll.ts
+++ b/apps/website/src/lib/editor-ffi/scroll.ts
@@ -51,7 +51,7 @@ function uniqueClampedScrollTops(scrollTops: readonly number[], maximumScrollTop
   return result;
 }
 
-export function resolveNearestScrollTop({
+export function resolveGuardedScrollTop({
   scrollTop,
   clientHeight,
   scrollHeight,
@@ -59,10 +59,14 @@ export function resolveNearestScrollTop({
   targetBottom,
   visibleArea,
   margin = CURSOR_VISIBLE_MARGIN,
+  oversizedAlignment = 'cursor_guard',
+  oversizedMinimumVisibleHeight,
 }: ScrollContainerMetrics &
   RevealTargetSpan & {
     visibleArea?: EditorVisibleArea;
     margin?: number;
+    oversizedAlignment?: 'cursor_guard' | 'start';
+    oversizedMinimumVisibleHeight?: number;
   }): number | null {
   const area = normalizeVisibleArea(visibleArea);
   const safeMargin = Math.max(0, finiteOrZero(margin));
@@ -91,7 +95,30 @@ export function resolveNearestScrollTop({
   const targetHeight = Math.max(0, safeTargetBottom - safeTargetTop);
   const rangeHeight = rangeBottom - rangeTop;
   if (targetHeight > rangeHeight) {
-    nextTop = safeTargetTop - rangeTop;
+    if (oversizedAlignment === 'start') {
+      nextTop = safeTargetTop - rangeTop;
+    } else if (oversizedMinimumVisibleHeight === undefined) {
+      if (safeTargetTop - safeScrollTop <= rangeTop && safeTargetBottom - safeScrollTop >= rangeBottom) {
+        return null;
+      }
+      if (safeTargetBottom - safeScrollTop > rangeBottom) {
+        nextTop = safeTargetBottom - rangeBottom;
+      } else if (safeTargetTop - safeScrollTop < rangeTop) {
+        nextTop = safeTargetTop - rangeTop;
+      }
+    } else {
+      const targetTopInViewport = safeTargetTop - safeScrollTop;
+      const targetBottomInViewport = safeTargetBottom - safeScrollTop;
+      const minimumVisibleHeight = Math.min(rangeHeight, Math.max(0, finiteOrZero(oversizedMinimumVisibleHeight)));
+      const visibleHeight = Math.max(0, Math.min(targetBottomInViewport, rangeBottom) - Math.max(targetTopInViewport, rangeTop));
+      if (visibleHeight >= minimumVisibleHeight) return null;
+
+      if (targetTopInViewport > rangeTop) {
+        nextTop = safeTargetTop - (rangeBottom - minimumVisibleHeight);
+      } else if (targetBottomInViewport < rangeBottom) {
+        nextTop = safeTargetBottom - (rangeTop + minimumVisibleHeight);
+      }
+    }
   } else if (safeTargetBottom - safeScrollTop > rangeBottom) {
     nextTop = safeTargetBottom - rangeBottom;
   } else if (safeTargetTop - safeScrollTop < rangeTop) {
@@ -116,12 +143,14 @@ export function resolveInstantRevealPreparationViewports({
   visibleArea,
   margin = CURSOR_VISIBLE_MARGIN,
   position = 0.5,
+  oversizedMinimumVisibleHeight,
 }: ScrollContainerMetrics &
   RevealTargetSpan & {
-    mode: 'nearest' | 'typewriter';
+    mode: 'cursor_guard' | 'typewriter';
     visibleArea?: EditorVisibleArea;
     margin?: number;
     position?: number;
+    oversizedMinimumVisibleHeight?: number;
   }): VerticalSpan[] {
   const safeClientHeight = Math.max(0, finiteOrZero(clientHeight));
   if (safeClientHeight <= 0) return [];
@@ -133,7 +162,13 @@ export function resolveInstantRevealPreparationViewports({
   const maximumScrollTop = resolveMaxScrollTop({ clientHeight, scrollHeight });
   let destinations: number[];
 
-  if (mode === 'typewriter') {
+  const safeMargin = Math.max(0, finiteOrZero(margin));
+  const rangeTop = area.topInset + safeMargin;
+  const rangeBottom = safeClientHeight - area.bottomInset - safeMargin;
+  const targetHeight = Math.max(0, safeTargetBottom - safeTargetTop);
+  const useTypewriter = mode === 'typewriter' && targetHeight <= Math.max(0, rangeBottom - rangeTop);
+
+  if (useTypewriter) {
     const usableHeight = Math.max(0, safeClientHeight - area.topInset - area.bottomInset);
     if (usableHeight <= 0) return [];
     destinations = [
@@ -148,9 +183,6 @@ export function resolveInstantRevealPreparationViewports({
       }) ?? safeScrollTop,
     ];
   } else {
-    const safeMargin = Math.max(0, finiteOrZero(margin));
-    const rangeTop = area.topInset + safeMargin;
-    const rangeBottom = safeClientHeight - area.bottomInset - safeMargin;
     if (rangeBottom <= rangeTop) {
       const visibleTop = area.topInset;
       const visibleBottom = safeClientHeight - area.bottomInset;
@@ -166,11 +198,21 @@ export function resolveInstantRevealPreparationViewports({
       const targetTopInViewport = safeTargetTop - safeScrollTop;
       const targetBottomInViewport = safeTargetBottom - safeScrollTop;
       destinations = [];
-      if (targetHeight <= rangeBottom - rangeTop && targetTopInViewport >= rangeTop && targetBottomInViewport <= rangeBottom) {
-        destinations.push(safeScrollTop);
+      if (targetHeight > rangeBottom - rangeTop) {
+        if (oversizedMinimumVisibleHeight === undefined) {
+          destinations.push(safeScrollTop, safeTargetTop - rangeTop, safeTargetBottom - rangeBottom);
+        } else {
+          const minimumVisibleHeight = Math.min(rangeBottom - rangeTop, Math.max(0, finiteOrZero(oversizedMinimumVisibleHeight)));
+          destinations.push(
+            safeScrollTop,
+            safeTargetTop - (rangeBottom - minimumVisibleHeight),
+            safeTargetBottom - (rangeTop + minimumVisibleHeight),
+          );
+        }
+      } else {
+        if (targetTopInViewport >= rangeTop && targetBottomInViewport <= rangeBottom) destinations.push(safeScrollTop);
+        destinations.push(safeTargetTop - rangeTop, safeTargetBottom - rangeBottom);
       }
-      destinations.push(safeTargetTop - rangeTop);
-      if (targetHeight <= rangeBottom - rangeTop) destinations.push(safeTargetBottom - rangeBottom);
     }
   }
 
@@ -198,6 +240,17 @@ export function resolveTypewriterScrollTop({
   }
 
   const targetHeight = Math.max(0, finiteOrZero(targetBottom) - finiteOrZero(targetTop));
+  const guardedHeight = Math.max(0, usableHeight - CURSOR_VISIBLE_MARGIN * 2);
+  if (targetHeight > guardedHeight) {
+    return resolveGuardedScrollTop({
+      scrollTop,
+      clientHeight,
+      scrollHeight,
+      targetTop,
+      targetBottom,
+      visibleArea: area,
+    });
+  }
   const clampedPosition = clamp(finiteOrZero(position), 0, 1);
   const targetTopInViewport = area.topInset + Math.max(0, usableHeight - targetHeight) * clampedPosition;
   const clamped = clamp(finiteOrZero(targetTop) - targetTopInViewport, 0, resolveMaxScrollTop({ clientHeight, scrollHeight }));

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-comments/DocumentComments.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-comments/DocumentComments.svelte
@@ -223,7 +223,7 @@
     } else {
       const rect = selectionHeadRect(snapshot);
       activeAnchor = rect ? anchorFromPageRects([rect]) : null;
-      ctx.scroll?.scrollIntoView({ target: { type: 'current_selection_head' } });
+      ctx.scroll?.scrollIntoView({ target: { type: 'current_selection_head' }, policy: 'cursor_guard' });
     }
   }
 
@@ -255,7 +255,7 @@
     }
     activeThreadId = id;
     activeAnchor = anchor;
-    ctx.scroll?.scrollIntoView({ target: { type: 'tracked_item', id } });
+    ctx.scroll?.scrollIntoView({ target: { type: 'tracked_item', id }, policy: 'result_reveal' });
   }
 
   function takeFocusReturnSession(): FocusReturnSession | null {

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditor.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditor.svelte
@@ -913,7 +913,7 @@
                 selection: savedSelection,
               },
             });
-            presentation = editor.scrollIntoView({ target: { type: 'current_selection_head' } });
+            presentation = editor.scrollIntoView({ target: { type: 'current_selection_head' }, policy: 'cursor_guard' });
           });
           return presentation;
         } catch {


### PR DESCRIPTION
## 배경

기존 cursor reveal은 target이 cursor guard보다 크면 현재 노출 상태와 관계없이 target top을 top guard에 맞췄습니다. 이 때문에 큰 이미지처럼 oversized target이 이미 충분히 보이는 상태에서도 불필요한 scroll이 발생했습니다.

또한 KMP에서는 typewriter 설정이 전역 auto-scroll mode로 적용되어 pointer selection이나 result reveal도 typewriter 동작의 영향을 받을 수 있었습니다. 이번 변경에서는 reveal의 목적을 명시적인 policy로 분리하고 Web과 KMP에 같은 계산 규칙을 적용합니다.

## 변경된 policy

| Policy | 적용 시나리오 | Fitting target | Oversized target | Behavior |
| --- | --- | --- | --- | --- |
| `CursorGuard` | 일반적인 selection head reveal | cursor guard 안에 들어오는 nearest 위치로 이동 | 양쪽 guard를 모두 덮고 있으면 유지. 한쪽 guard만 벗어나면 해당 edge에 맞춤 | Instant |
| `PointerCursorGuard` | pointer로 selection 변경 | `CursorGuard`와 동일 | cursor guard 안에 `CursorVisibleMargin` 이상 보이면 유지. 부족한 경우 해당 높이만 reveal | Instant |
| `Typewriter` | keyboard 입력과 이동 | 설정된 typewriter position에 맞춤 | `CursorGuard`로 fallback | Instant |
| `ResultReveal` | comment, 맞춤법, 검색, AI feedback 등의 결과 | target 전체가 들어오는 nearest 위치로 이동 | target top을 top guard에 맞춤 | Smooth |

## Request 처리

- reveal request에서 `policy`를 필수로 지정하도록 변경했습니다.
- scroll `behavior`는 callsite에서 별도로 조합하지 않고 policy에서 결정합니다.
- pointer reveal은 selection이 만들어진 exact revision에서만 처리합니다.
  - 해당 revision을 건너뛰면 obsolete request를 discard합니다.
  - Web에서는 이후 publication까지 selection을 추적하는 keep-visible target으로 남기지 않습니다.
- 계산된 offset을 실제 scroll range로 clamp한 뒤 현재 위치와 같으면 `NoScroll`로 처리합니다.
- instant reveal을 위한 required surface page 계산에도 실제 reveal과 동일한 oversized policy를 적용합니다.
- Web과 KMP의 policy 구분과 scroll 계산을 동일하게 맞췄습니다.