### PR TITLE
문서 sync snapshot 이후 무한 리로드 수정

### DIFF
--- a/apps/api/src/sync/channel.test.ts
+++ b/apps/api/src/sync/channel.test.ts
@@ -8,7 +8,7 @@ const makeChannel = (deps: FakeSyncDeps, documentId = 'D1', clientId = 'c1', use
   return { sent, channel: new DocumentChannel({ deps, send, documentId, clientId, userId }) };
 };
 
-test('신규 attach: attach-ack → 청크 → snapshot-end(collectedSeq) → tail 순서', async () => {
+test('신규 attach: snapshot baseline보다 새 stream의 첫 seq가 커도 tail을 이어 보낸다', async () => {
   const deps = new FakeSyncDeps();
   deps.seedBundles('D1', [
     { id: 'B1', seq: 1, payload: Uint8Array.of(1, 1) },
@@ -16,6 +16,7 @@ test('신규 attach: attach-ack → 청크 → snapshot-end(collectedSeq) → ta
   ]);
   deps.collectedSeq.set('D1', '5-0');
   deps.seedStream('D1', [{ seq: '6-0', changeset: Uint8Array.of(6) }]);
+  deps.oldestRetained.set('D1', '6-0');
   deps.liveHeads.set('D1', Uint8Array.of(0xaa));
   deps.durableHeadsMap.set('D1', Uint8Array.of(0xdd));
 
@@ -36,6 +37,29 @@ test('신규 attach: attach-ack → 청크 → snapshot-end(collectedSeq) → ta
   assert.equal(tail.seq, '6-0');
   assert.deepEqual(tail.bundles, [Uint8Array.of(6)]);
   channel.stop();
+});
+
+test('snapshot 전송 중 collectedSeq가 전진했다면 잘린 tail을 reload한다', async () => {
+  const deps = new FakeSyncDeps();
+  deps.collectedSeq.set('D1', '5-0');
+  deps.seedBundles('D1', [{ id: 'B1', seq: 1, payload: Uint8Array.of(1) }]);
+  deps.seedStream('D1', [{ seq: '6-0', changeset: Uint8Array.of(6) }]);
+  deps.oldestRetained.set('D1', '6-0');
+  const originalRead = deps.readBundlesAfter;
+  deps.readBundlesAfter = async (documentId, afterSeq, limit) => {
+    const rows = await originalRead(documentId, afterSeq, limit);
+    deps.collectedSeq.set('D1', '6-0');
+    return rows;
+  };
+
+  const { sent, channel } = makeChannel(deps);
+  await channel.start();
+
+  assert.deepEqual(
+    sent.map((m) => m.t),
+    ['attach-ack', 'snapshot-chunk', 'snapshot-end', 'reload'],
+  );
+  assert.equal(channel.stopped, true);
 });
 
 test('collectedSeq는 bundle 행 읽기 전에 확정된다', async () => {

--- a/apps/api/src/sync/channel.ts
+++ b/apps/api/src/sync/channel.ts
@@ -122,7 +122,7 @@ export class DocumentChannel {
     if (this.stopped) return;
     const { heads, durableHeads } = await this.#readHeads();
     await this.#send({ t: 'snapshot-end', documentId: this.#documentId, seq: collectedSeq ?? '', heads, durableHeads });
-    await this.#sendTail(collectedSeq);
+    await this.#sendTail(collectedSeq, 'snapshot');
   }
 
   async #sendRowChunks(row: BundleRow, startOffset: number): Promise<void> {
@@ -164,10 +164,10 @@ export class DocumentChannel {
         return;
       }
     }
-    await this.#sendTail(cursor);
+    await this.#sendTail(cursor, 'resume');
   }
 
-  async #sendTail(sinceSeq: string | null): Promise<void> {
+  async #sendTail(sinceSeq: string | null, mode: 'snapshot' | 'resume'): Promise<void> {
     const reload = async (): Promise<void> => {
       await this.#send({ t: 'reload', documentId: this.#documentId });
       this.stop();
@@ -199,8 +199,14 @@ export class DocumentChannel {
     while (!done) {
       const page = await this.#deps.readStreamBatch(this.#documentId, cursor, TAIL_BATCH_ENTRIES);
       if (cursor !== null && (await this.#deps.isStreamTruncated(this.#documentId, cursor))) {
-        await reload();
-        return;
+        // A full snapshot already covers its captured durable frontier. If collect has not
+        // advanced, a newer first stream entry starts a fresh tail rather than proving a gap.
+        const snapshotBaselineStillCurrent =
+          mode === 'snapshot' && cursor === sinceSeq && (await this.#deps.getCollectedSeq(this.#documentId)) === sinceSeq;
+        if (!snapshotBaselineStillCurrent) {
+          await reload();
+          return;
+        }
       }
       if (page.length === 0) break;
       for (const entry of page) {


### PR DESCRIPTION
## 문제 시나리오

- 문서에 들어갔다가 back한 뒤 다시 진입하면 서버가 snapshot을 전송하고 이후 tail을 연결함
- 이미 반영된 이전 stream이 정리되고 새 Redis stream이 생성된 경우, 첫 tail seq가 snapshot 기준 seq보다 클 수 있음
- 이를 tail 유실로 잘못 판단해 reload를 요청했고, 재접속 후에도 같은 판단이 반복되면서 웹/앱 에디터가 무한 리로드됨

## 변경

- snapshot 기준점이 여전히 최신이면 새 stream의 첫 메시지를 정상적인 tail로 처리
- snapshot 전송 중 collect가 진행된 실제 tail 유실에는 기존 reload 안전장치 유지
- 정상적인 stream 재생성과 실제 tail 유실을 구분하는 회귀 테스트 추가