### PR TITLE
앱 에디터에서 이미지와 파일 다운로드 지원

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/external/EditorExternalElementState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/external/EditorExternalElementState.kt
@@ -99,6 +99,7 @@ internal data class EditorFileAsset(
 internal data class EditorImageAsset(
   override val id: String,
   val url: String,
+  val originalUrl: String,
   val width: Int,
   val height: Int,
   val ratio: Double,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorExternalAssetMapper.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorExternalAssetMapper.kt
@@ -16,6 +16,7 @@ internal fun EditorExternalAsset_asset.toEditorExternalAsset(): EditorExternalAs
         EditorImageAsset(
           id = image.id,
           url = image.url,
+          originalUrl = image.originalUrl,
           width = image.width,
           height = image.height,
           ratio = image.ratio,
@@ -44,6 +45,7 @@ internal fun PersistBlobAsImage.toEditorImageAsset(): EditorImageAsset =
   EditorImageAsset(
     id = id,
     url = url,
+    originalUrl = originalUrl,
     width = width,
     height = height,
     ratio = ratio,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.graphql
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.graphql
@@ -69,6 +69,7 @@ fragment EditorExternalAsset_asset on DocumentAsset {
   ... on Image {
     id
     url
+    originalUrl
     width
     height
     ratio
@@ -127,6 +128,7 @@ mutation EditorScreen_PersistBlobAsImage_Mutation($input: PersistBlobAsImageInpu
   persistBlobAsImage(input: $input) {
     id
     url
+    originalUrl
     width
     height
     ratio

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/attachment/EditorAttachmentDownload.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/attachment/EditorAttachmentDownload.kt
@@ -1,0 +1,68 @@
+package co.typie.screen.editor.editor.attachment
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsBytes
+import io.ktor.http.ContentDisposition
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.decodeURLPart
+import io.ktor.http.fileExtensions
+
+internal data class DownloadedEditorAttachment(
+  val bytes: ByteArray,
+  val filename: String,
+  val mimeType: String,
+)
+
+internal suspend fun HttpClient.downloadEditorAttachment(
+  url: String,
+  fallbackFilename: String? = null,
+  defaultFilenameStem: String = "file",
+): DownloadedEditorAttachment {
+  val response = get(url)
+  val contentType =
+    response.headers[HttpHeaders.ContentType]?.let {
+      runCatching { ContentType.parse(it).withoutParameters() }.getOrNull()
+    } ?: ContentType.Application.OctetStream
+  val filename =
+    parseAttachmentFilename(response.headers[HttpHeaders.ContentDisposition])
+      ?: fallbackFilename?.trim()?.takeIf(String::isNotEmpty)
+      ?: defaultAttachmentFilename(defaultFilenameStem, contentType)
+
+  return DownloadedEditorAttachment(
+    bytes = response.bodyAsBytes(),
+    filename = filename,
+    mimeType = contentType.toString(),
+  )
+}
+
+internal fun parseAttachmentFilename(contentDisposition: String?): String? {
+  val parsed =
+    contentDisposition?.let { runCatching { ContentDisposition.parse(it) }.getOrNull() }
+      ?: return null
+
+  return parsed
+    .parameter(ContentDisposition.Parameters.FileNameAsterisk)
+    ?.decodeExtendedFilename()
+    ?.trim()
+    ?.takeIf(String::isNotEmpty)
+    ?: parsed.parameter(ContentDisposition.Parameters.FileName)?.trim()?.takeIf(String::isNotEmpty)
+}
+
+private fun String.decodeExtendedFilename(): String? {
+  val charsetEnd = indexOf('\'')
+  if (charsetEnd <= 0 || !substring(0, charsetEnd).equals("UTF-8", ignoreCase = true)) {
+    return null
+  }
+  val languageEnd = indexOf('\'', startIndex = charsetEnd + 1)
+  if (languageEnd < 0) return null
+
+  return runCatching { substring(languageEnd + 1).decodeURLPart() }.getOrNull()
+}
+
+private fun defaultAttachmentFilename(stem: String, contentType: ContentType): String {
+  val normalizedStem = stem.trim().ifEmpty { "file" }
+  val extension = contentType.fileExtensions().firstOrNull() ?: return normalizedStem
+  return "$normalizedStem.$extension"
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/FileToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/FileToolbar.kt
@@ -1,9 +1,11 @@
 package co.typie.screen.editor.editor.toolbar.contextual
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
 import co.typie.editor.DocumentEditingSession
@@ -13,12 +15,17 @@ import co.typie.editor.ffi.NodeOp
 import co.typie.editor.ffi.PlainNode
 import co.typie.editor.runtime.LocalEditorRuntime
 import co.typie.icons.Lucide
+import co.typie.network.Http
 import co.typie.platform.FilePickerResult
 import co.typie.platform.FilePickerSelectionMode
 import co.typie.platform.IncomingContentItem
+import co.typie.platform.Platform
+import co.typie.platform.PlatformModule
 import co.typie.platform.rememberFilePicker
+import co.typie.platform.rememberShareAnchor
 import co.typie.screen.editor.editor.attachment.EditorAttachmentDestination
 import co.typie.screen.editor.editor.attachment.LocalEditorAttachmentImporter
+import co.typie.screen.editor.editor.attachment.downloadEditorAttachment
 import co.typie.screen.editor.editor.toolbar.EditorToolbarButton
 import co.typie.screen.editor.editor.toolbar.EditorToolbarPage
 import co.typie.screen.editor.editor.toolbar.EditorToolbarPageKey
@@ -26,6 +33,7 @@ import co.typie.screen.editor.editor.toolbar.EditorToolbarPageScope
 import co.typie.screen.editor.editor.toolbar.EditorToolbarRow
 import co.typie.screen.editor.editor.toolbar.EditorToolbarSessionState
 import co.typie.ui.component.toast.LocalToast
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.launch
 
@@ -145,13 +153,17 @@ private fun EditorFileToolbar(
   pickFile: (nodeId: String) -> Unit,
   modifier: Modifier = Modifier,
 ) {
+  val toast = LocalToast.current
   val uriHandler = LocalUriHandler.current
+  val coroutineScope = rememberCoroutineScope()
+  val shareAnchor = rememberShareAnchor()
   val externalElementState = LocalEditorExternalElementState.current
   val fileState = externalElementState.files
   val fileId = file?.id
   val asset = fileId?.let(fileState.assets::get)
   val uploading = nodeId?.let { fileState.uploads.containsKey(it) } == true
   val hasFile = fileId != null || uploading
+  var downloadInProgress by remember(asset?.id) { mutableStateOf(false) }
 
   EditorToolbarRow(scope = scope, modifier = modifier) {
     if (!hasFile) {
@@ -165,7 +177,46 @@ private fun EditorFileToolbar(
       EditorToolbarButton(
         icon = Lucide.Download,
         contentDescription = "파일 다운로드",
-        onClick = { uriHandler.openUri(asset.url) },
+        enabled = !downloadInProgress,
+        modifier = shareAnchor.modifier,
+        onClick = {
+          if (PlatformModule.platform == Platform.Desktop) {
+            uriHandler.openUri(asset.url)
+          } else if (!downloadInProgress) {
+            downloadInProgress = true
+            coroutineScope.launch {
+              try {
+                val downloaded =
+                  try {
+                    Http.downloadEditorAttachment(url = asset.url, fallbackFilename = asset.name)
+                  } catch (error: CancellationException) {
+                    throw error
+                  } catch (_: Throwable) {
+                    toast.error("파일을 내려받을 수 없어요.")
+                    return@launch
+                  }
+                val shared =
+                  try {
+                    PlatformModule.share.share(
+                      bytes = downloaded.bytes,
+                      filename = downloaded.filename,
+                      mimeType = downloaded.mimeType,
+                      anchor = shareAnchor.value,
+                    )
+                  } catch (error: CancellationException) {
+                    throw error
+                  } catch (_: Throwable) {
+                    false
+                  }
+                if (!shared) {
+                  toast.error("파일을 내보낼 수 없어요.")
+                }
+              } finally {
+                downloadInProgress = false
+              }
+            }
+          }
+        },
       )
     }
     EditorToolbarButton(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/ImageToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/ImageToolbar.kt
@@ -1,10 +1,13 @@
 package co.typie.screen.editor.editor.toolbar.contextual
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
 import co.typie.editor.DocumentEditingSession
 import co.typie.editor.external.LocalEditorExternalElementState
 import co.typie.editor.ffi.Message
@@ -12,12 +15,17 @@ import co.typie.editor.ffi.NodeOp
 import co.typie.editor.ffi.PlainNode
 import co.typie.editor.runtime.LocalEditorRuntime
 import co.typie.icons.Lucide
+import co.typie.network.Http
 import co.typie.platform.FilePickerResult
 import co.typie.platform.FilePickerSelectionMode
 import co.typie.platform.IncomingContentItem
+import co.typie.platform.Platform
+import co.typie.platform.PlatformModule
 import co.typie.platform.rememberFilePicker
+import co.typie.platform.rememberShareAnchor
 import co.typie.screen.editor.editor.attachment.EditorAttachmentDestination
 import co.typie.screen.editor.editor.attachment.LocalEditorAttachmentImporter
+import co.typie.screen.editor.editor.attachment.downloadEditorAttachment
 import co.typie.screen.editor.editor.toolbar.EditorToolbarButton
 import co.typie.screen.editor.editor.toolbar.EditorToolbarPage
 import co.typie.screen.editor.editor.toolbar.EditorToolbarPageKey
@@ -26,6 +34,7 @@ import co.typie.screen.editor.editor.toolbar.EditorToolbarRow
 import co.typie.screen.editor.editor.toolbar.EditorToolbarSecondary
 import co.typie.screen.editor.editor.toolbar.EditorToolbarSessionState
 import co.typie.ui.component.toast.LocalToast
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.launch
 
@@ -145,12 +154,17 @@ private fun EditorImageToolbar(
   pickImage: (nodeId: String) -> Unit,
   modifier: Modifier = Modifier,
 ) {
+  val toast = LocalToast.current
+  val uriHandler = LocalUriHandler.current
+  val coroutineScope = rememberCoroutineScope()
+  val shareAnchor = rememberShareAnchor()
   val externalElementState = LocalEditorExternalElementState.current
   val imageState = externalElementState.images
   val imageId = image?.id
   val readyAsset = imageId?.let(imageState.assets::get)
   val uploading = nodeId?.let { imageState.uploads.containsKey(it) } == true
   val hasImage = imageId != null || uploading
+  var downloadInProgress by remember(readyAsset?.id) { mutableStateOf(false) }
 
   EditorToolbarRow(scope = scope, modifier = modifier) {
     if (!hasImage) {
@@ -168,6 +182,55 @@ private fun EditorImageToolbar(
         contentDescription = "이미지 폭 조정",
         selected = selected,
         onClick = { scope.toggleSecondaryToolbar(resizeSecondary) },
+      )
+    }
+    if (readyAsset != null) {
+      EditorToolbarButton(
+        icon = Lucide.Download,
+        contentDescription = "이미지 다운로드",
+        enabled = !downloadInProgress,
+        modifier = shareAnchor.modifier,
+        onClick = {
+          if (PlatformModule.platform == Platform.Desktop) {
+            uriHandler.openUri(readyAsset.originalUrl)
+          } else if (!downloadInProgress) {
+            downloadInProgress = true
+            coroutineScope.launch {
+              try {
+                val downloaded =
+                  try {
+                    Http.downloadEditorAttachment(
+                      url = readyAsset.originalUrl,
+                      defaultFilenameStem = "image",
+                    )
+                  } catch (error: CancellationException) {
+                    throw error
+                  } catch (_: Throwable) {
+                    toast.error("이미지를 내려받을 수 없어요.")
+                    return@launch
+                  }
+                val shared =
+                  try {
+                    PlatformModule.share.share(
+                      bytes = downloaded.bytes,
+                      filename = downloaded.filename,
+                      mimeType = downloaded.mimeType,
+                      anchor = shareAnchor.value,
+                    )
+                  } catch (error: CancellationException) {
+                    throw error
+                  } catch (_: Throwable) {
+                    false
+                  }
+                if (!shared) {
+                  toast.error("이미지를 내보낼 수 없어요.")
+                }
+              } finally {
+                downloadInProgress = false
+              }
+            }
+          }
+        },
       )
     }
     EditorToolbarButton(

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/EditorAssetHydratorTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/EditorAssetHydratorTest.kt
@@ -337,6 +337,7 @@ class EditorAssetHydratorTest {
     EditorImageAsset(
       id = id,
       url = "https://example.com/$id",
+      originalUrl = "https://example.com/original/$id",
       width = 100,
       height = 50,
       ratio = 2.0,

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/attachment/DefaultEditorAttachmentImporterTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/attachment/DefaultEditorAttachmentImporterTest.kt
@@ -343,6 +343,7 @@ class DefaultEditorAttachmentImporterTest {
               EditorImageAsset(
                 id = "asset-${file.filename.removeSuffix(".png")}",
                 url = "https://example.com/${file.filename}",
+                originalUrl = "https://example.com/original/${file.filename}",
                 width = 10,
                 height = 5,
                 ratio = 2.0,
@@ -440,6 +441,7 @@ class DefaultEditorAttachmentImporterTest {
               EditorImageAsset(
                 id = "asset-${file.filename.removeSuffix(".png")}",
                 url = "https://example.com/${file.filename}",
+                originalUrl = "https://example.com/original/${file.filename}",
                 width = 10,
                 height = 5,
                 ratio = 2.0,
@@ -1248,6 +1250,7 @@ class DefaultEditorAttachmentImporterTest {
       EditorImageAsset(
         id = "asset-image",
         url = "https://example.com/image.png",
+        originalUrl = "https://example.com/original/image.png",
         width = 10,
         height = 5,
         ratio = 2.0,

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/attachment/EditorAttachmentDownloadTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/attachment/EditorAttachmentDownloadTest.kt
@@ -1,0 +1,16 @@
+package co.typie.screen.editor.editor.attachment
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class EditorAttachmentDownloadTest {
+  @Test
+  fun `decodes the API utf8 filename`() {
+    assertEquals(
+      "타이피 이미지.svg",
+      parseAttachmentFilename(
+        "inline; filename*=UTF-8''%ED%83%80%EC%9D%B4%ED%94%BC%20%EC%9D%B4%EB%AF%B8%EC%A7%80.svg"
+      ),
+    )
+  }
+}

--- a/apps/mobile/compose/src/iosMain/kotlin/co/typie/platform/PlatformServiceModule.ios.kt
+++ b/apps/mobile/compose/src/iosMain/kotlin/co/typie/platform/PlatformServiceModule.ios.kt
@@ -110,40 +110,41 @@ internal class IOSClipboard : Clipboard {
     val snapshot =
       withContext(Dispatchers.Main) {
         runCatching {
-          val pasteboard = UIPasteboard.generalPasteboard
-          val html =
-            pasteboard
-              .valueForPasteboardType(UTI_HTML)
-              .asPasteboardString()
-              ?.takeIf(String::isNotEmpty)
-              ?: pasteboard
-                .dataForPasteboardType(UTI_HTML)
-                ?.decodeUtf8()
+            val pasteboard = UIPasteboard.generalPasteboard
+            val html =
+              pasteboard
+                .valueForPasteboardType(UTI_HTML)
+                .asPasteboardString()
                 ?.takeIf(String::isNotEmpty)
-          if (html != null) {
-            return@runCatching IOSPasteboardSnapshot(
-              html = html,
-              text = pasteboard.string,
-              items = emptyList(),
-              providers = emptyList(),
+                ?: pasteboard
+                  .dataForPasteboardType(UTI_HTML)
+                  ?.decodeUtf8()
+                  ?.takeIf(String::isNotEmpty)
+            if (html != null) {
+              return@runCatching IOSPasteboardSnapshot(
+                html = html,
+                text = pasteboard.string,
+                items = emptyList(),
+                providers = emptyList(),
+              )
+            }
+
+            val pasteboardItems =
+              pasteboard.items.mapNotNull { it as? Map<*, *> }.map { it.toMap() }
+            IOSPasteboardSnapshot(
+              html = null,
+              text =
+                pasteboardItems.firstNotNullOfOrNull { item ->
+                  item[UTI_PLAIN_TEXT].asPasteboardString()
+                } ?: pasteboard.string,
+              items = pasteboardItems,
+              providers =
+                pasteboard.itemProviders
+                  .filterIsInstance<NSItemProvider>()
+                  .takeIf { it.size == pasteboardItems.size }
+                  .orEmpty(),
             )
           }
-
-          val pasteboardItems = pasteboard.items.mapNotNull { it as? Map<*, *> }.map { it.toMap() }
-          IOSPasteboardSnapshot(
-            html = null,
-            text =
-              pasteboardItems.firstNotNullOfOrNull { item ->
-                item[UTI_PLAIN_TEXT].asPasteboardString()
-              } ?: pasteboard.string,
-            items = pasteboardItems,
-            providers =
-              pasteboard.itemProviders
-                .filterIsInstance<NSItemProvider>()
-                .takeIf { it.size == pasteboardItems.size }
-                .orEmpty(),
-          )
-        }
           .getOrNull()
       } ?: return null
 
@@ -499,47 +500,35 @@ internal class IOSShare : Share {
   ): Boolean =
     withContext(Dispatchers.Main) {
       runCatching {
-          val item: Any =
-            if (mimeType.startsWith("image/")) {
-              bytes.toUIImage()
-            } else {
-              val root = NSTemporaryDirectory() + "share/"
-              val directory = root + NSUUID().UUIDString + "/"
-              val directoryCreated =
-                NSFileManager.defaultManager.createDirectoryAtPath(
-                  path = directory,
-                  withIntermediateDirectories = true,
-                  attributes = null,
-                  error = null,
-                )
-              if (!directoryCreated) return@runCatching false
+          val root = NSTemporaryDirectory() + "share/"
+          val directory = root + NSUUID().UUIDString + "/"
+          val directoryCreated =
+            NSFileManager.defaultManager.createDirectoryAtPath(
+              path = directory,
+              withIntermediateDirectories = true,
+              attributes = null,
+              error = null,
+            )
+          if (!directoryCreated) return@runCatching false
 
-              sweepShareCache(root)
+          sweepShareCache(root)
 
-              val path = directory + sanitizeShareFilename(filename)
-              val written = bytes.toNSData().writeToFile(path, atomically = true)
-              if (!written) return@runCatching false
+          val path = directory + sanitizeShareFilename(filename)
+          val written = bytes.toNSData().writeToFile(path, atomically = true)
+          if (!written) return@runCatching false
 
-              NSURL.fileURLWithPath(path)
-            }
-
-          presentShareSheet(listOf(item), anchor)
-          true
+          presentShareSheet(listOf(NSURL.fileURLWithPath(path)), anchor)
         }
         .getOrDefault(false)
     }
 
   override suspend fun share(text: String, anchor: ShareAnchor?): Boolean =
     withContext(Dispatchers.Main) {
-      runCatching {
-          presentShareSheet(listOf(text), anchor)
-          true
-        }
-        .getOrDefault(false)
+      runCatching { presentShareSheet(listOf(text), anchor) }.getOrDefault(false)
     }
 
-  private fun presentShareSheet(items: List<Any>, anchor: ShareAnchor?) {
-    val controller = topViewController() ?: return
+  private fun presentShareSheet(items: List<Any>, anchor: ShareAnchor?): Boolean {
+    val controller = topViewController() ?: return false
     val sourceView = controller.view
     val activityVC = UIActivityViewController(activityItems = items, applicationActivities = null)
     activityVC.popoverPresentationController?.let { popover ->
@@ -559,6 +548,7 @@ internal class IOSShare : Share {
       }
     }
     controller.presentViewController(activityVC, animated = true, completion = null)
+    return true
   }
 
   private fun topViewController(): UIViewController? {


### PR DESCRIPTION
- 앱 이미지/파일 툴바에 다운로드 기능 추가
- 모바일에서는 원본 파일을 시스템 공유 시트로 전달하고 Desktop에서는 URL 열기 유지