### PR TITLE
앱 nav pop swipe에 소프트웨어 키보드 연동하기 위한 기반 작업

### DIFF
--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/platform/SoftwareKeyboardPresentation.android.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/platform/SoftwareKeyboardPresentation.android.kt
@@ -1,0 +1,12 @@
+package co.typie.platform
+
+import androidx.compose.runtime.Composable
+
+private val UnavailableSoftwareKeyboardPresentationDriverFactory =
+  SoftwareKeyboardPresentationDriverFactory {
+    null
+  }
+
+@Composable
+internal actual fun rememberSoftwareKeyboardPresentationDriverFactory():
+  SoftwareKeyboardPresentationDriverFactory = UnavailableSoftwareKeyboardPresentationDriverFactory

--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.android.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.android.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import co.typie.platform.LocalSoftwareKeyboardPresentationController
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
@@ -29,6 +30,9 @@ internal actual fun rememberEditorKeyboardState(
   val configuration = LocalConfiguration.current
   val context = LocalContext.current
   val density = LocalDensity.current
+  val keyboardInteractionResolver = remember { EditorKeyboardInteractionResolver() }
+  val keyboardInteractionState =
+    LocalSoftwareKeyboardPresentationController.current.interactionState
   val imeBottom = WindowInsets.ime.getBottom(density)
   val imeAnimationSourceBottom = WindowInsets.imeAnimationSource.getBottom(density)
   val imeAnimationTargetBottom = WindowInsets.imeAnimationTarget.getBottom(density)
@@ -73,17 +77,21 @@ internal actual fun rememberEditorKeyboardState(
     externalKeyboardAttached = isExternalKeyboardAttached()
     onDispose { inputManager.unregisterInputDeviceListener(listener) }
   }
-  return EditorKeyboardState(
-    type =
-      if (hardwareKeyboardVisible) {
-        EditorKeyboardType.Hardware
-      } else {
-        EditorKeyboardType.Software
-      },
-    imeFrameVisible = imeBottom > 0 || imeAnimationTargetBottom > 0,
-    imeHideEventOwner = imeHideEventOwner,
-    presentation = presentation,
-    hardwareKeyboardAttached = hardwareKeyboardVisible || externalKeyboardAttached,
+  return keyboardInteractionResolver.resolve(
+    nativeState =
+      EditorKeyboardState(
+        type =
+          if (hardwareKeyboardVisible) {
+            EditorKeyboardType.Hardware
+          } else {
+            EditorKeyboardType.Software
+          },
+        imeFrameVisible = imeBottom > 0 || imeAnimationTargetBottom > 0,
+        imeHideEventOwner = imeHideEventOwner,
+        presentation = presentation,
+        hardwareKeyboardAttached = hardwareKeyboardVisible || externalKeyboardAttached,
+      ),
+    interactionState = keyboardInteractionState,
   )
 }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/App.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/App.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.Composable
 import co.typie.dev.SystemChrome
 import co.typie.ext.ScrollGestureLockScope
 import co.typie.network.Http
+import co.typie.platform.ProvideSoftwareKeyboardPresentation
 import co.typie.shell.RootShell
 import co.typie.ui.theme.AppTheme
 import coil3.ImageLoader
@@ -27,5 +28,7 @@ fun App() {
       .build()
   }
 
-  AppTheme { SystemChrome { ScrollGestureLockScope { RootShell() } } }
+  AppTheme {
+    ProvideSoftwareKeyboardPresentation { SystemChrome { ScrollGestureLockScope { RootShell() } } }
+  }
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationSoftwareKeyboardInteraction.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationSoftwareKeyboardInteraction.kt
@@ -1,0 +1,46 @@
+package co.typie.navigation
+
+import androidx.compose.runtime.snapshotFlow
+import co.typie.platform.SoftwareKeyboardInteractionResolution
+import co.typie.platform.SoftwareKeyboardPresentationController
+import co.typie.platform.SoftwareKeyboardPresentationEndpoint
+import co.typie.platform.SoftwareKeyboardPresentationSession
+import kotlinx.coroutines.flow.first
+
+internal class NavigationSoftwareKeyboardInteraction(
+  private val controller: SoftwareKeyboardPresentationController
+) {
+  private var session: SoftwareKeyboardPresentationSession? = null
+
+  fun start() {
+    if (session != null) return
+    session = controller.acquire()
+  }
+
+  fun updateHiddenProgress(progress: Float) {
+    session?.updateHiddenProgress(progress)
+  }
+
+  fun restore() {
+    val activeSession = session ?: return
+    session = null
+    activeSession.finish(SoftwareKeyboardPresentationEndpoint.Shown)
+  }
+
+  suspend fun hideAndAwaitResolution(): SoftwareKeyboardInteractionResolution? {
+    val activeSession = session ?: return null
+    session = null
+    val interactionId = activeSession.interactionId
+    activeSession.finish(SoftwareKeyboardPresentationEndpoint.Hidden)
+    val resolvedState =
+      snapshotFlow { controller.interactionState }.first { it.activeInteractionId != interactionId }
+    return resolvedState.lastResolution.takeIf {
+      resolvedState.lastResolvedInteractionId == interactionId
+    }
+  }
+
+  fun dispose() {
+    session?.dispose()
+    session = null
+  }
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationStack.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationStack.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.ProvidedValue
 import androidx.compose.runtime.getValue
@@ -49,6 +50,7 @@ import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import co.touchlab.kermit.Logger
 import co.typie.ext.pointerIgnore
+import co.typie.platform.LocalSoftwareKeyboardPresentationController
 import co.typie.platform.isTouchDragPointer
 import co.typie.route.Route
 import co.typie.route.RouteTransitionStyle
@@ -281,6 +283,15 @@ fun NavigationStack(
   var transitionStyle by remember { mutableStateOf(RouteTransitionStyle.Slide) }
 
   val progress = remember { Animatable(0f) }
+  val softwareKeyboardPresentationController = LocalSoftwareKeyboardPresentationController.current
+  val softwareKeyboardInteraction =
+    remember(softwareKeyboardPresentationController) {
+      NavigationSoftwareKeyboardInteraction(softwareKeyboardPresentationController)
+    }
+  DisposableEffect(softwareKeyboardInteraction) { onDispose(softwareKeyboardInteraction::dispose) }
+  LaunchedEffect(softwareKeyboardInteraction) {
+    snapshotFlow { progress.value }.collect(softwareKeyboardInteraction::updateHiddenProgress)
+  }
   val topBarBackdropHazeState = remember { HazeState() }
   val topBarSampleRequests = remember { NavigationTopBarSampleRequests() }
   val topBarLuminanceCache =
@@ -314,13 +325,15 @@ fun NavigationStack(
 
   suspend fun settleAtCurrentRoute() {
     progress.snapTo(0f)
+    softwareKeyboardInteraction.restore()
     visibleRoute = navigator.current
     behindRoute = null
     animState = AnimState.Idle
   }
 
-  fun commitRemovalTo(target: Route) {
+  suspend fun commitRemovalTo(target: Route) {
     val removedRoutes = navigator.performPopTo(target)
+    softwareKeyboardInteraction.hideAndAwaitResolution()
     visibleRoute = navigator.current
     behindRoute = null
     animState = AnimState.Idle
@@ -465,6 +478,7 @@ fun NavigationStack(
     transitionStyle = visibleRoute.transitionStyleTo(prev)
     behindRoute = prev
     animState = AnimState.Dragging
+    softwareKeyboardInteraction.start()
     scope.launch { progress.snapTo(0f) }
   }
 
@@ -475,6 +489,7 @@ fun NavigationStack(
     behindRoute = prev
     animState = AnimState.Dragging
     predictiveBackActive = true
+    softwareKeyboardInteraction.start()
     progress.snapTo(0f)
     return true
   }
@@ -520,8 +535,7 @@ fun NavigationStack(
         commitPopDrag()
       } else {
         progress.animateTo(0f, spring(stiffness = StiffnessMediumLow))
-        behindRoute = null
-        animState = AnimState.Idle
+        settleAtCurrentRoute()
       }
     }
   }
@@ -530,8 +544,7 @@ fun NavigationStack(
     if (animState != AnimState.Dragging) return
     scope.launch {
       progress.animateTo(0f, spring(stiffness = StiffnessMediumLow))
-      behindRoute = null
-      animState = AnimState.Idle
+      settleAtCurrentRoute()
     }
   }
 
@@ -585,6 +598,7 @@ fun NavigationStack(
                 // Server deletion already succeeded. Do not strand the deleted document because
                 // presentation failed; finish the exact prepared removal without another prompt.
                 val removedRoutes = navigator.performPopTo(targetRoute)
+                softwareKeyboardInteraction.hideAndAwaitResolution()
                 settleAtCurrentRoute()
                 clearRemovedRoutes(removedRoutes)
                 navigator.consumePopRequest()

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/platform/SoftwareKeyboardPresentation.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/platform/SoftwareKeyboardPresentation.kt
@@ -1,0 +1,285 @@
+package co.typie.platform
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
+
+internal enum class SoftwareKeyboardPresentationEndpoint {
+  Shown,
+  Hidden,
+}
+
+internal enum class SoftwareKeyboardInteractionResolution {
+  Shown,
+  Hidden,
+  Aborted,
+}
+
+internal data class SoftwareKeyboardInteractionState(
+  val activeInteractionId: Long? = null,
+  val hiddenProgress: Float = 0f,
+  val resolutionVersion: Long = 0L,
+  val lastResolvedInteractionId: Long? = null,
+  val lastResolution: SoftwareKeyboardInteractionResolution? = null,
+) {
+  val unresolved: Boolean
+    get() = activeInteractionId != null
+}
+
+internal interface SoftwareKeyboardPresentationDriver {
+  fun updateHiddenProgress(progress: Float)
+
+  fun finish(endpoint: SoftwareKeyboardPresentationEndpoint, onAccepted: () -> Unit)
+
+  fun dispose()
+}
+
+internal fun interface SoftwareKeyboardPresentationDriverFactory {
+  fun acquire(onInvalidated: () -> Unit): SoftwareKeyboardPresentationDriver?
+}
+
+internal class SoftwareKeyboardPresentationController(
+  private val driverFactory: SoftwareKeyboardPresentationDriverFactory
+) {
+  var interactionState by mutableStateOf(SoftwareKeyboardInteractionState())
+    private set
+
+  private var nextInteractionId = 0L
+  private var nextContributionId = 0L
+  private var acquisition: Acquisition? = null
+  private var activeInteraction: ActiveInteraction? = null
+
+  fun acquire(): SoftwareKeyboardPresentationSession? {
+    activeInteraction?.let { interaction ->
+      if (interaction.endpoint != null) return null
+      return addContribution(interaction)
+    }
+    if (acquisition != null) return null
+
+    val interactionId = ++nextInteractionId
+    val pendingAcquisition = Acquisition(interactionId)
+    acquisition = pendingAcquisition
+    interactionState =
+      interactionState.copy(activeInteractionId = interactionId, hiddenProgress = 0f)
+    val driverResult = runCatching { driverFactory.acquire { invalidate(interactionId) } }
+    acquisition = null
+    val driver = driverResult.getOrNull()
+
+    if (pendingAcquisition.invalidated || driverResult.isFailure) {
+      interactionState =
+        interactionState.resolved(
+          interactionId = interactionId,
+          resolution = SoftwareKeyboardInteractionResolution.Aborted,
+        )
+      if (driver != null) runCatching(driver::dispose)
+      return null
+    }
+    if (driver == null) {
+      interactionState = interactionState.copy(activeInteractionId = null, hiddenProgress = 0f)
+      return null
+    }
+
+    val interaction = ActiveInteraction(id = interactionId, driver = driver)
+    activeInteraction = interaction
+    return addContribution(interaction)
+  }
+
+  fun dispose() {
+    acquisition?.invalidated = true
+    activeInteraction?.let { abort(it.id) }
+  }
+
+  internal fun updateHiddenProgress(interactionId: Long, contributionId: Long, progress: Float) {
+    val interaction = activeContribution(interactionId, contributionId) ?: return
+    val clampedProgress = progress.coerceIn(0f, 1f)
+    val effectiveProgress =
+      interaction.contributions.maxOf { (id, currentProgress) ->
+        if (id == contributionId) clampedProgress else currentProgress
+      }
+    val updated =
+      runCatching { interaction.driver.updateHiddenProgress(effectiveProgress) }.isSuccess
+    if (!updated) {
+      abort(interactionId)
+      return
+    }
+    if (activeContribution(interactionId, contributionId) !== interaction) return
+    interaction.contributions[contributionId] = clampedProgress
+    interactionState = interactionState.copy(hiddenProgress = effectiveProgress)
+  }
+
+  internal fun finish(
+    interactionId: Long,
+    contributionId: Long,
+    endpoint: SoftwareKeyboardPresentationEndpoint,
+  ) {
+    val interaction = activeContribution(interactionId, contributionId) ?: return
+    if (
+      endpoint == SoftwareKeyboardPresentationEndpoint.Shown && interaction.contributions.size > 1
+    ) {
+      removeContribution(interaction, contributionId)
+      return
+    }
+
+    interaction.endpoint = endpoint
+    interaction.contributions.clear()
+    val requested =
+      runCatching {
+          interaction.driver.finish(endpoint) {
+            accept(interactionId = interactionId, endpoint = endpoint)
+          }
+        }
+        .isSuccess
+    if (!requested) abort(interactionId)
+  }
+
+  internal fun dispose(interactionId: Long, contributionId: Long) {
+    val interaction = activeContribution(interactionId, contributionId) ?: return
+    if (interaction.contributions.size > 1) {
+      removeContribution(interaction, contributionId)
+    } else {
+      abort(interactionId)
+    }
+  }
+
+  private fun accept(interactionId: Long, endpoint: SoftwareKeyboardPresentationEndpoint) {
+    val interaction =
+      activeInteraction?.takeIf { it.id == interactionId && it.endpoint == endpoint } ?: return
+    activeInteraction = null
+    interactionState =
+      interactionState.resolved(
+        interactionId = interaction.id,
+        resolution = endpoint.toResolution(),
+      )
+  }
+
+  private fun abort(interactionId: Long) {
+    val interaction = activeInteraction?.takeIf { it.id == interactionId } ?: return
+    activeInteraction = null
+    interactionState =
+      interactionState.resolved(
+        interactionId = interaction.id,
+        resolution = SoftwareKeyboardInteractionResolution.Aborted,
+      )
+    runCatching(interaction.driver::dispose)
+  }
+
+  private fun invalidate(interactionId: Long) {
+    val pendingAcquisition = acquisition
+    if (pendingAcquisition?.id == interactionId) {
+      pendingAcquisition.invalidated = true
+      return
+    }
+    abort(interactionId)
+  }
+
+  private fun addContribution(interaction: ActiveInteraction): SoftwareKeyboardPresentationSession {
+    val contributionId = ++nextContributionId
+    interaction.contributions[contributionId] = 0f
+    return SoftwareKeyboardPresentationSession(
+      interactionId = interaction.id,
+      contributionId = contributionId,
+      controller = this,
+    )
+  }
+
+  private fun activeContribution(interactionId: Long, contributionId: Long): ActiveInteraction? =
+    activeInteraction?.takeIf {
+      it.id == interactionId && it.endpoint == null && contributionId in it.contributions
+    }
+
+  private fun removeContribution(interaction: ActiveInteraction, contributionId: Long) {
+    val effectiveProgress =
+      interaction.contributions.asSequence().filter { it.key != contributionId }.maxOf { it.value }
+    val updated =
+      runCatching { interaction.driver.updateHiddenProgress(effectiveProgress) }.isSuccess
+    if (!updated) {
+      abort(interaction.id)
+      return
+    }
+    if (activeContribution(interaction.id, contributionId) !== interaction) return
+    interaction.contributions.remove(contributionId)
+    interactionState = interactionState.copy(hiddenProgress = effectiveProgress)
+  }
+
+  private fun SoftwareKeyboardInteractionState.resolved(
+    interactionId: Long,
+    resolution: SoftwareKeyboardInteractionResolution,
+  ): SoftwareKeyboardInteractionState =
+    copy(
+      activeInteractionId = null,
+      resolutionVersion = resolutionVersion + 1,
+      lastResolvedInteractionId = interactionId,
+      lastResolution = resolution,
+    )
+
+  private class Acquisition(val id: Long, var invalidated: Boolean = false)
+
+  private class ActiveInteraction(
+    val id: Long,
+    val driver: SoftwareKeyboardPresentationDriver,
+    val contributions: MutableMap<Long, Float> = linkedMapOf(),
+    var endpoint: SoftwareKeyboardPresentationEndpoint? = null,
+  )
+
+  companion object {
+    val unavailable =
+      SoftwareKeyboardPresentationController(SoftwareKeyboardPresentationDriverFactory { null })
+  }
+}
+
+internal class SoftwareKeyboardPresentationSession
+internal constructor(
+  val interactionId: Long,
+  private val contributionId: Long,
+  private val controller: SoftwareKeyboardPresentationController,
+) {
+  fun updateHiddenProgress(progress: Float) {
+    controller.updateHiddenProgress(
+      interactionId = interactionId,
+      contributionId = contributionId,
+      progress = progress,
+    )
+  }
+
+  fun finish(endpoint: SoftwareKeyboardPresentationEndpoint) {
+    controller.finish(
+      interactionId = interactionId,
+      contributionId = contributionId,
+      endpoint = endpoint,
+    )
+  }
+
+  fun dispose() {
+    controller.dispose(interactionId = interactionId, contributionId = contributionId)
+  }
+}
+
+private fun SoftwareKeyboardPresentationEndpoint.toResolution() =
+  when (this) {
+    SoftwareKeyboardPresentationEndpoint.Shown -> SoftwareKeyboardInteractionResolution.Shown
+    SoftwareKeyboardPresentationEndpoint.Hidden -> SoftwareKeyboardInteractionResolution.Hidden
+  }
+
+@Composable
+internal expect fun rememberSoftwareKeyboardPresentationDriverFactory():
+  SoftwareKeyboardPresentationDriverFactory
+
+internal val LocalSoftwareKeyboardPresentationController = staticCompositionLocalOf {
+  SoftwareKeyboardPresentationController.unavailable
+}
+
+@Composable
+internal fun ProvideSoftwareKeyboardPresentation(content: @Composable () -> Unit) {
+  val driverFactory = rememberSoftwareKeyboardPresentationDriverFactory()
+  val controller = remember(driverFactory) { SoftwareKeyboardPresentationController(driverFactory) }
+  DisposableEffect(controller) { onDispose(controller::dispose) }
+  CompositionLocalProvider(
+    LocalSoftwareKeyboardPresentationController provides controller,
+    content = content,
+  )
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.kt
@@ -4,6 +4,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import co.typie.ext.trustedImeBottomInset as trustedSettledImeBottomInset
+import co.typie.platform.SoftwareKeyboardInteractionResolution
+import co.typie.platform.SoftwareKeyboardInteractionState
 
 internal enum class EditorKeyboardType {
   Software,
@@ -80,6 +82,99 @@ internal class EditorImeHideOwnershipTracker {
       EditorKeyboardPresentation.Hiding,
       EditorKeyboardPresentation.Hidden -> beginHide()
     }
+}
+
+internal class EditorKeyboardInteractionResolver {
+  private var lastSemanticState: EditorKeyboardState? = null
+  private var retainedInteraction: RetainedKeyboardInteraction? = null
+  private var nativeHideVersionOffset = 0
+
+  fun resolve(
+    nativeState: EditorKeyboardState,
+    interactionState: SoftwareKeyboardInteractionState,
+  ): EditorKeyboardState {
+    val normalizedNativeState = nativeState.withNormalizedHideVersion()
+    val activeInteractionId = interactionState.activeInteractionId
+    if (activeInteractionId != null) {
+      if (retainedInteraction?.interactionId != activeInteractionId) {
+        lastSemanticState
+          ?.takeIf { it.presentation is EditorKeyboardPresentation.Shown }
+          ?.let {
+            retainedInteraction =
+              RetainedKeyboardInteraction(
+                interactionId = activeInteractionId,
+                resolutionVersion = interactionState.resolutionVersion,
+                semanticState = it,
+              )
+          }
+      }
+      return retainOrRecord(normalizedNativeState)
+    }
+
+    val retained = retainedInteraction
+    if (retained != null && interactionState.resolutionVersion > retained.resolutionVersion) {
+      return when (interactionState.lastResolution) {
+        SoftwareKeyboardInteractionResolution.Shown -> {
+          if (nativeState.presentation is EditorKeyboardPresentation.Shown) {
+            nativeHideVersionOffset =
+              (nativeState.imeHideEventVersion - retained.semanticState.imeHideEventVersion)
+                .coerceAtLeast(0)
+            retainedInteraction = null
+            record(
+              nativeState.copy(imeHideEventVersion = retained.semanticState.imeHideEventVersion)
+            )
+          } else {
+            retainOrRecord(normalizedNativeState)
+          }
+        }
+        SoftwareKeyboardInteractionResolution.Hidden -> {
+          if (
+            nativeState.presentation == EditorKeyboardPresentation.Hiding ||
+              nativeState.presentation == EditorKeyboardPresentation.Hidden
+          ) {
+            retainedInteraction = null
+            record(normalizedNativeState)
+          } else {
+            retainOrRecord(normalizedNativeState)
+          }
+        }
+        SoftwareKeyboardInteractionResolution.Aborted -> {
+          retainedInteraction = null
+          record(normalizedNativeState)
+        }
+        null -> retainOrRecord(normalizedNativeState)
+      }
+    }
+
+    return record(normalizedNativeState)
+  }
+
+  private fun retainOrRecord(nativeState: EditorKeyboardState): EditorKeyboardState =
+    record(retainedInteraction?.semanticState?.retainOver(nativeState) ?: nativeState)
+
+  private fun record(state: EditorKeyboardState): EditorKeyboardState {
+    lastSemanticState = state
+    return state
+  }
+
+  private fun EditorKeyboardState.withNormalizedHideVersion(): EditorKeyboardState =
+    copy(imeHideEventVersion = (imeHideEventVersion - nativeHideVersionOffset).coerceAtLeast(0))
+
+  private fun EditorKeyboardState.retainOver(
+    nativeState: EditorKeyboardState
+  ): EditorKeyboardState =
+    nativeState.copy(
+      imeFrameVisible = imeFrameVisible,
+      imeHideEventVersion = imeHideEventVersion,
+      imeHideEventOwner = imeHideEventOwner,
+      presentation = presentation,
+    )
+
+  private data class RetainedKeyboardInteraction(
+    val interactionId: Long,
+    val resolutionVersion: Long,
+    val semanticState: EditorKeyboardState,
+  )
 }
 
 @Composable

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/navigation/NavigationSoftwareKeyboardInteractionTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/navigation/NavigationSoftwareKeyboardInteractionTest.kt
@@ -1,0 +1,176 @@
+package co.typie.navigation
+
+import androidx.compose.runtime.snapshots.Snapshot
+import co.typie.platform.SoftwareKeyboardInteractionResolution
+import co.typie.platform.SoftwareKeyboardPresentationController
+import co.typie.platform.SoftwareKeyboardPresentationDriver
+import co.typie.platform.SoftwareKeyboardPresentationDriverFactory
+import co.typie.platform.SoftwareKeyboardPresentationEndpoint
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+
+class NavigationSoftwareKeyboardInteractionTest {
+  @Test
+  fun forwardsProgressOnlyWhileAnInteractionIsActive() {
+    val factory = RecordingDriverFactory()
+    val interaction =
+      NavigationSoftwareKeyboardInteraction(SoftwareKeyboardPresentationController(factory))
+
+    interaction.updateHiddenProgress(0.4f)
+    interaction.start()
+    interaction.updateHiddenProgress(0.4f)
+    interaction.updateHiddenProgress(0.7f)
+
+    assertEquals(listOf(0.4f, 0.7f), requireNotNull(factory.driver).progress)
+  }
+
+  @Test
+  fun restoreRemovesOnlyNavigationContributionAndRevealsTheRemainingProgress() {
+    val factory = RecordingDriverFactory()
+    val controller = SoftwareKeyboardPresentationController(factory)
+    val editorContribution = requireNotNull(controller.acquire())
+    editorContribution.updateHiddenProgress(0.4f)
+    val interaction = NavigationSoftwareKeyboardInteraction(controller)
+    interaction.start()
+    interaction.updateHiddenProgress(0.8f)
+
+    assertEquals(0.8f, controller.interactionState.hiddenProgress)
+
+    interaction.restore()
+
+    assertEquals(0.4f, controller.interactionState.hiddenProgress)
+    assertEquals(emptyList(), requireNotNull(factory.driver).endpoints)
+  }
+
+  @Test
+  fun hideWaitsForTheGlobalHiddenResolution() = runTest {
+    val factory = RecordingDriverFactory()
+    val controller = SoftwareKeyboardPresentationController(factory)
+    val interaction = NavigationSoftwareKeyboardInteraction(controller)
+    interaction.start()
+
+    val resolution =
+      async(start = CoroutineStart.UNDISPATCHED) { interaction.hideAndAwaitResolution() }
+
+    assertFalse(resolution.isCompleted)
+    requireNotNull(factory.driver).acceptEndpoint()
+    Snapshot.sendApplyNotifications()
+    assertEquals(SoftwareKeyboardInteractionResolution.Hidden, resolution.await())
+  }
+
+  @Test
+  fun hideWaitReleasesWhenThePlatformInteractionAborts() = runTest {
+    val factory = RecordingDriverFactory()
+    val controller = SoftwareKeyboardPresentationController(factory)
+    val interaction = NavigationSoftwareKeyboardInteraction(controller)
+    interaction.start()
+
+    val resolution =
+      async(start = CoroutineStart.UNDISPATCHED) { interaction.hideAndAwaitResolution() }
+
+    assertFalse(resolution.isCompleted)
+    requireNotNull(factory.invalidation).invoke()
+    Snapshot.sendApplyNotifications()
+    assertEquals(SoftwareKeyboardInteractionResolution.Aborted, resolution.await())
+  }
+
+  @Test
+  fun staleNavigationContributionDoesNotWaitForAnUnrelatedResolution() = runTest {
+    val factory = RecordingDriverFactory()
+    val controller = SoftwareKeyboardPresentationController(factory)
+    val interaction = NavigationSoftwareKeyboardInteraction(controller)
+    interaction.start()
+    requireNotNull(factory.invalidation).invoke()
+    val unrelated = requireNotNull(controller.acquire())
+    unrelated.finish(SoftwareKeyboardPresentationEndpoint.Hidden)
+    requireNotNull(factory.driver).acceptEndpoint()
+
+    assertEquals(null, withTimeout(100) { interaction.hideAndAwaitResolution() })
+  }
+
+  @Test
+  fun restoreResolvesToShown() {
+    val restoreFactory = RecordingDriverFactory()
+    val restoreInteraction =
+      NavigationSoftwareKeyboardInteraction(SoftwareKeyboardPresentationController(restoreFactory))
+    restoreInteraction.start()
+
+    restoreInteraction.restore()
+
+    assertEquals(
+      listOf(SoftwareKeyboardPresentationEndpoint.Shown),
+      requireNotNull(restoreFactory.driver).endpoints,
+    )
+  }
+
+  @Test
+  fun unresolvedContributionIsAbortedWhenTheOwnerIsDisposed() {
+    val factory = RecordingDriverFactory()
+    val interaction =
+      NavigationSoftwareKeyboardInteraction(SoftwareKeyboardPresentationController(factory))
+    interaction.start()
+
+    interaction.dispose()
+
+    assertEquals(1, requireNotNull(factory.driver).disposeCount)
+  }
+
+  @Test
+  fun unavailableControllerKeepsEveryOperationANoOp() = runTest {
+    val controller = SoftwareKeyboardPresentationController.unavailable
+    val interaction = NavigationSoftwareKeyboardInteraction(controller)
+
+    interaction.start()
+    interaction.updateHiddenProgress(0.5f)
+    interaction.restore()
+    interaction.hideAndAwaitResolution()
+    interaction.dispose()
+
+    assertEquals(null, controller.interactionState.activeInteractionId)
+  }
+}
+
+private class RecordingDriverFactory : SoftwareKeyboardPresentationDriverFactory {
+  var driver: RecordingDriver? = null
+    private set
+
+  var invalidation: (() -> Unit)? = null
+    private set
+
+  override fun acquire(onInvalidated: () -> Unit): SoftwareKeyboardPresentationDriver =
+    RecordingDriver().also {
+      driver = it
+      invalidation = onInvalidated
+    }
+}
+
+private class RecordingDriver : SoftwareKeyboardPresentationDriver {
+  val progress = mutableListOf<Float>()
+  val endpoints = mutableListOf<SoftwareKeyboardPresentationEndpoint>()
+  var disposeCount = 0
+    private set
+
+  private var endpointAcceptance: (() -> Unit)? = null
+
+  override fun updateHiddenProgress(progress: Float) {
+    this.progress += progress
+  }
+
+  override fun finish(endpoint: SoftwareKeyboardPresentationEndpoint, onAccepted: () -> Unit) {
+    endpoints += endpoint
+    endpointAcceptance = onAccepted
+  }
+
+  override fun dispose() {
+    disposeCount += 1
+  }
+
+  fun acceptEndpoint() {
+    endpointAcceptance?.invoke()
+  }
+}

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/platform/SoftwareKeyboardPresentationTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/platform/SoftwareKeyboardPresentationTest.kt
@@ -1,0 +1,435 @@
+package co.typie.platform
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SoftwareKeyboardPresentationTest {
+  @Test
+  fun unavailableFactoryCannotAcquire() {
+    val controller = SoftwareKeyboardPresentationController { null }
+
+    assertNull(controller.acquire())
+    assertEquals(SoftwareKeyboardInteractionState(), controller.interactionState)
+  }
+
+  @Test
+  fun onlyOnePlatformInteractionOwnsTheDriver() {
+    val factory = RecordingDriverFactory()
+    val controller = SoftwareKeyboardPresentationController(factory)
+
+    val first = controller.acquire()
+    val second = controller.acquire()
+
+    assertTrue(first != null)
+    assertTrue(second != null)
+    assertEquals(1, factory.acquireCount)
+    assertEquals(first.interactionId, controller.interactionState.activeInteractionId)
+  }
+
+  @Test
+  fun multipleContributionsShareOneDriverAndPublishTheirMaximumProgress() {
+    val factory = RecordingDriverFactory()
+    val controller = SoftwareKeyboardPresentationController(factory)
+    val first = requireNotNull(controller.acquire())
+    val second = requireNotNull(controller.acquire())
+    val driver = factory.drivers.single()
+
+    first.updateHiddenProgress(0.6f)
+    second.updateHiddenProgress(0.3f)
+
+    assertEquals(1, factory.acquireCount)
+    assertEquals(0.6f, controller.interactionState.hiddenProgress)
+    assertEquals(0.6f, driver.progress.last())
+
+    second.updateHiddenProgress(0.8f)
+
+    assertEquals(0.8f, controller.interactionState.hiddenProgress)
+    assertEquals(0.8f, driver.progress.last())
+  }
+
+  @Test
+  fun shownRemovesOnlyItsContributionUntilTheLastContributionFinishes() {
+    val factory = RecordingDriverFactory()
+    val controller = SoftwareKeyboardPresentationController(factory)
+    val first = requireNotNull(controller.acquire())
+    val second = requireNotNull(controller.acquire())
+    val driver = factory.drivers.single()
+    first.updateHiddenProgress(0.7f)
+    second.updateHiddenProgress(0.4f)
+
+    first.finish(SoftwareKeyboardPresentationEndpoint.Shown)
+
+    assertTrue(driver.endpoints.isEmpty())
+    assertTrue(controller.interactionState.unresolved)
+    assertEquals(0.4f, controller.interactionState.hiddenProgress)
+
+    second.finish(SoftwareKeyboardPresentationEndpoint.Shown)
+
+    assertEquals(listOf(SoftwareKeyboardPresentationEndpoint.Shown), driver.endpoints)
+    assertTrue(controller.interactionState.unresolved)
+    driver.acceptEndpoint()
+    assertEquals(
+      SoftwareKeyboardInteractionResolution.Shown,
+      controller.interactionState.lastResolution,
+    )
+  }
+
+  @Test
+  fun hiddenFinishWinsGloballyAndMakesEveryContributionStale() {
+    val factory = RecordingDriverFactory()
+    val controller = SoftwareKeyboardPresentationController(factory)
+    val first = requireNotNull(controller.acquire())
+    val second = requireNotNull(controller.acquire())
+    val driver = factory.drivers.single()
+
+    second.finish(SoftwareKeyboardPresentationEndpoint.Hidden)
+    first.updateHiddenProgress(0.9f)
+    first.finish(SoftwareKeyboardPresentationEndpoint.Shown)
+    first.dispose()
+
+    assertEquals(listOf(SoftwareKeyboardPresentationEndpoint.Hidden), driver.endpoints)
+    assertNull(controller.acquire())
+    driver.acceptEndpoint()
+    assertEquals(
+      SoftwareKeyboardInteractionResolution.Hidden,
+      controller.interactionState.lastResolution,
+    )
+  }
+
+  @Test
+  fun disposingAContributionFallsBackToTheRemainingProgressAndFinalDisposeAborts() {
+    val factory = RecordingDriverFactory()
+    val controller = SoftwareKeyboardPresentationController(factory)
+    val first = requireNotNull(controller.acquire())
+    val second = requireNotNull(controller.acquire())
+    val driver = factory.drivers.single()
+    first.updateHiddenProgress(0.8f)
+    second.updateHiddenProgress(0.3f)
+
+    first.dispose()
+
+    assertTrue(controller.interactionState.unresolved)
+    assertEquals(0.3f, controller.interactionState.hiddenProgress)
+    assertEquals(0, driver.disposeCount)
+
+    second.dispose()
+
+    assertFalse(controller.interactionState.unresolved)
+    assertEquals(1, driver.disposeCount)
+    assertEquals(
+      SoftwareKeyboardInteractionResolution.Aborted,
+      controller.interactionState.lastResolution,
+    )
+  }
+
+  @Test
+  fun progressIsClampedWithoutReacquiringTheDriver() {
+    val factory = RecordingDriverFactory()
+    val controller = SoftwareKeyboardPresentationController(factory)
+    val session = requireNotNull(controller.acquire())
+
+    session.updateHiddenProgress(-0.2f)
+    session.updateHiddenProgress(0.4f)
+    session.updateHiddenProgress(0.4f)
+    session.updateHiddenProgress(1.3f)
+
+    assertEquals(listOf(0f, 0.4f, 0.4f, 1f), factory.drivers.single().progress)
+    assertEquals(1f, controller.interactionState.hiddenProgress)
+    assertEquals(1, factory.acquireCount)
+  }
+
+  @Test
+  fun endpointRemainsUnresolvedUntilTheDriverAcceptsIt() {
+    val factory = RecordingDriverFactory()
+    val controller = SoftwareKeyboardPresentationController(factory)
+    val session = requireNotNull(controller.acquire())
+    val driver = factory.drivers.single()
+
+    session.finish(SoftwareKeyboardPresentationEndpoint.Hidden)
+    session.finish(SoftwareKeyboardPresentationEndpoint.Shown)
+    session.updateHiddenProgress(0.5f)
+
+    assertEquals(listOf(SoftwareKeyboardPresentationEndpoint.Hidden), driver.endpoints)
+    assertTrue(controller.interactionState.unresolved)
+    assertEquals(0L, controller.interactionState.resolutionVersion)
+    assertNull(controller.interactionState.lastResolution)
+    assertNull(controller.acquire())
+
+    driver.acceptEndpoint()
+
+    assertFalse(controller.interactionState.unresolved)
+    assertEquals(1L, controller.interactionState.resolutionVersion)
+    assertEquals(
+      SoftwareKeyboardInteractionResolution.Hidden,
+      controller.interactionState.lastResolution,
+    )
+    assertTrue(controller.acquire() != null)
+  }
+
+  @Test
+  fun shownEndpointPublishesShownOnlyAfterAcceptance() {
+    val factory = RecordingDriverFactory()
+    val controller = SoftwareKeyboardPresentationController(factory)
+    val session = requireNotNull(controller.acquire())
+    val driver = factory.drivers.single()
+
+    session.finish(SoftwareKeyboardPresentationEndpoint.Shown)
+    assertNull(controller.interactionState.lastResolution)
+
+    driver.acceptEndpoint()
+
+    assertEquals(
+      SoftwareKeyboardInteractionResolution.Shown,
+      controller.interactionState.lastResolution,
+    )
+    assertEquals(1L, controller.interactionState.resolutionVersion)
+  }
+
+  @Test
+  fun disposeAbortsOnceAndMakesTheStaleSessionHarmless() {
+    val factory = RecordingDriverFactory()
+    val controller = SoftwareKeyboardPresentationController(factory)
+    val session = requireNotNull(controller.acquire())
+    val driver = factory.drivers.single()
+
+    session.dispose()
+    session.dispose()
+    session.updateHiddenProgress(0.7f)
+    session.finish(SoftwareKeyboardPresentationEndpoint.Hidden)
+
+    assertEquals(1, driver.disposeCount)
+    assertTrue(driver.progress.isEmpty())
+    assertTrue(driver.endpoints.isEmpty())
+    assertEquals(
+      SoftwareKeyboardInteractionResolution.Aborted,
+      controller.interactionState.lastResolution,
+    )
+    assertEquals(1L, controller.interactionState.resolutionVersion)
+  }
+
+  @Test
+  fun lateCallbacksFromAnOldGenerationDoNotAffectTheCurrentSession() {
+    val factory = RecordingDriverFactory()
+    val controller = SoftwareKeyboardPresentationController(factory)
+    val firstSession = requireNotNull(controller.acquire())
+    val firstDriver = factory.drivers.single()
+    val firstInvalidation = factory.invalidations.single()
+
+    firstSession.finish(SoftwareKeyboardPresentationEndpoint.Hidden)
+    firstDriver.acceptEndpoint()
+    val secondSession = requireNotNull(controller.acquire())
+    val stateBeforeLateCallbacks = controller.interactionState
+
+    firstDriver.acceptEndpoint()
+    firstInvalidation()
+
+    assertEquals(secondSession.interactionId, controller.interactionState.activeInteractionId)
+    assertEquals(stateBeforeLateCallbacks, controller.interactionState)
+  }
+
+  @Test
+  fun matchingDriverInvalidationAbortsTheSession() {
+    val factory = RecordingDriverFactory()
+    val controller = SoftwareKeyboardPresentationController(factory)
+    requireNotNull(controller.acquire())
+
+    factory.invalidations.single()()
+
+    assertFalse(controller.interactionState.unresolved)
+    assertEquals(
+      SoftwareKeyboardInteractionResolution.Aborted,
+      controller.interactionState.lastResolution,
+    )
+    assertEquals(1L, controller.interactionState.resolutionVersion)
+  }
+
+  @Test
+  fun acquiringIsUnresolvedBeforeTheFactoryRunsAndRejectsSynchronousReentry() {
+    lateinit var controller: SoftwareKeyboardPresentationController
+    var stateDuringFactory = SoftwareKeyboardInteractionState()
+    var nestedSession: SoftwareKeyboardPresentationSession? = null
+    val driver = RecordingDriver()
+    controller = SoftwareKeyboardPresentationController { onInvalidated ->
+      stateDuringFactory = controller.interactionState
+      nestedSession = controller.acquire()
+      onInvalidated()
+      driver
+    }
+
+    assertNull(controller.acquire())
+
+    assertTrue(stateDuringFactory.unresolved)
+    assertNull(nestedSession)
+    assertEquals(1, driver.disposeCount)
+    assertEquals(
+      SoftwareKeyboardInteractionResolution.Aborted,
+      controller.interactionState.lastResolution,
+    )
+  }
+
+  @Test
+  fun disposingTheControllerDuringAcquisitionAbortsTheReturnedDriver() {
+    lateinit var controller: SoftwareKeyboardPresentationController
+    val driver = RecordingDriver()
+    controller = SoftwareKeyboardPresentationController {
+      controller.dispose()
+      driver
+    }
+
+    assertNull(controller.acquire())
+
+    assertEquals(1, driver.disposeCount)
+    assertEquals(
+      SoftwareKeyboardInteractionResolution.Aborted,
+      controller.interactionState.lastResolution,
+    )
+  }
+
+  @Test
+  fun synchronousInvalidationDuringUpdateCannotOverwriteAReentrantSession() {
+    lateinit var controller: SoftwareKeyboardPresentationController
+    lateinit var replacement: SoftwareKeyboardPresentationSession
+    var acquireCount = 0
+    controller = SoftwareKeyboardPresentationController { onInvalidated ->
+      acquireCount += 1
+      if (acquireCount == 1) {
+        InvalidatingUpdateDriver {
+          onInvalidated()
+          replacement = requireNotNull(controller.acquire())
+        }
+      } else {
+        RecordingDriver()
+      }
+    }
+    val original = requireNotNull(controller.acquire())
+
+    original.updateHiddenProgress(0.8f)
+
+    assertEquals(replacement.interactionId, controller.interactionState.activeInteractionId)
+    assertEquals(0f, controller.interactionState.hiddenProgress)
+  }
+
+  @Test
+  fun driverFailuresNeverEscapeAndAbortOnlyTheMatchingSession() {
+    val driver = ThrowingDriver()
+    val controller = SoftwareKeyboardPresentationController { driver }
+    val session = requireNotNull(controller.acquire())
+
+    session.updateHiddenProgress(0.5f)
+    session.finish(SoftwareKeyboardPresentationEndpoint.Hidden)
+    session.dispose()
+
+    assertFalse(controller.interactionState.unresolved)
+    assertEquals(
+      SoftwareKeyboardInteractionResolution.Aborted,
+      controller.interactionState.lastResolution,
+    )
+    assertEquals(1L, controller.interactionState.resolutionVersion)
+  }
+
+  @Test
+  fun factoryFailuresNeverEscape() {
+    val controller =
+      SoftwareKeyboardPresentationController(
+        SoftwareKeyboardPresentationDriverFactory { error("factory failure") }
+      )
+
+    assertNull(controller.acquire())
+    assertEquals(
+      SoftwareKeyboardInteractionResolution.Aborted,
+      controller.interactionState.lastResolution,
+    )
+    assertEquals(1L, controller.interactionState.resolutionVersion)
+  }
+
+  @Test
+  fun finishFailuresAbortTheMatchingInteraction() {
+    val controller = SoftwareKeyboardPresentationController { FinishThrowingDriver() }
+    val session = requireNotNull(controller.acquire())
+
+    session.finish(SoftwareKeyboardPresentationEndpoint.Hidden)
+
+    assertFalse(controller.interactionState.unresolved)
+    assertEquals(
+      SoftwareKeyboardInteractionResolution.Aborted,
+      controller.interactionState.lastResolution,
+    )
+  }
+}
+
+private class RecordingDriverFactory : SoftwareKeyboardPresentationDriverFactory {
+  val drivers = mutableListOf<RecordingDriver>()
+  val invalidations = mutableListOf<() -> Unit>()
+  var acquireCount = 0
+    private set
+
+  override fun acquire(onInvalidated: () -> Unit): SoftwareKeyboardPresentationDriver {
+    acquireCount += 1
+    invalidations += onInvalidated
+    return RecordingDriver().also(drivers::add)
+  }
+}
+
+private class RecordingDriver : SoftwareKeyboardPresentationDriver {
+  val progress = mutableListOf<Float>()
+  val endpoints = mutableListOf<SoftwareKeyboardPresentationEndpoint>()
+  var disposeCount = 0
+    private set
+
+  private var endpointAcceptance: (() -> Unit)? = null
+
+  override fun updateHiddenProgress(progress: Float) {
+    this.progress += progress
+  }
+
+  override fun finish(endpoint: SoftwareKeyboardPresentationEndpoint, onAccepted: () -> Unit) {
+    endpoints += endpoint
+    endpointAcceptance = onAccepted
+  }
+
+  override fun dispose() {
+    disposeCount += 1
+  }
+
+  fun acceptEndpoint() {
+    endpointAcceptance?.invoke()
+  }
+}
+
+private class ThrowingDriver : SoftwareKeyboardPresentationDriver {
+  override fun updateHiddenProgress(progress: Float) {
+    error("update failure")
+  }
+
+  override fun finish(endpoint: SoftwareKeyboardPresentationEndpoint, onAccepted: () -> Unit) {
+    error("finish failure")
+  }
+
+  override fun dispose() {
+    error("dispose failure")
+  }
+}
+
+private class InvalidatingUpdateDriver(private val onUpdate: () -> Unit) :
+  SoftwareKeyboardPresentationDriver {
+  override fun updateHiddenProgress(progress: Float) {
+    onUpdate()
+  }
+
+  override fun finish(endpoint: SoftwareKeyboardPresentationEndpoint, onAccepted: () -> Unit) = Unit
+
+  override fun dispose() = Unit
+}
+
+private class FinishThrowingDriver : SoftwareKeyboardPresentationDriver {
+  override fun updateHiddenProgress(progress: Float) = Unit
+
+  override fun finish(endpoint: SoftwareKeyboardPresentationEndpoint, onAccepted: () -> Unit) {
+    error("finish failure")
+  }
+
+  override fun dispose() = Unit
+}

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardTypeTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardTypeTest.kt
@@ -1,6 +1,9 @@
 package co.typie.screen.editor.editor.toolbar
 
 import androidx.compose.ui.unit.dp
+import co.typie.platform.SoftwareKeyboardInteractionResolution
+import co.typie.platform.SoftwareKeyboardInteractionState
+import co.typie.platform.SoftwareKeyboardPresentationController
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -181,4 +184,213 @@ class EditorKeyboardTypeTest {
       ),
     )
   }
+
+  @Test
+  fun active_keyboard_interaction_retains_the_last_shown_semantics() {
+    val resolver = EditorKeyboardInteractionResolver()
+    val shown = shownKeyboardState(version = 3, owner = EditorImeInputOwner.Editor)
+    resolver.resolve(shown, SoftwareKeyboardInteractionState())
+
+    val resolved =
+      resolver.resolve(
+        nativeState =
+          hiddenKeyboardState(
+            presentation = EditorKeyboardPresentation.Hiding,
+            version = 4,
+            owner = EditorImeInputOwner.Other,
+          ),
+        interactionState =
+          SoftwareKeyboardInteractionState(activeInteractionId = 1L, hiddenProgress = 1f),
+      )
+
+    assertEquals(EditorKeyboardPresentation.Shown(320.dp), resolved.presentation)
+    assertEquals(true, resolved.imeFrameVisible)
+    assertEquals(3, resolved.imeHideEventVersion)
+    assertEquals(EditorImeInputOwner.Editor, resolved.imeHideEventOwner)
+  }
+
+  @Test
+  fun acquiring_interaction_retains_shown_semantics_before_the_factory_runs() {
+    val resolver = EditorKeyboardInteractionResolver()
+    val shown = shownKeyboardState(version = 3, owner = EditorImeInputOwner.Editor)
+    resolver.resolve(shown, SoftwareKeyboardInteractionState())
+    lateinit var controller: SoftwareKeyboardPresentationController
+    var resolvedDuringAcquisition: EditorKeyboardState? = null
+    controller = SoftwareKeyboardPresentationController {
+      resolvedDuringAcquisition =
+        resolver.resolve(
+          nativeState =
+            hiddenKeyboardState(
+              presentation = EditorKeyboardPresentation.Hiding,
+              version = 4,
+              owner = EditorImeInputOwner.Other,
+            ),
+          interactionState = controller.interactionState,
+        )
+      null
+    }
+
+    assertNull(controller.acquire())
+
+    val resolved = requireNotNull(resolvedDuringAcquisition)
+    assertEquals(EditorKeyboardPresentation.Shown(320.dp), resolved.presentation)
+    assertEquals(3, resolved.imeHideEventVersion)
+    assertEquals(EditorImeInputOwner.Editor, resolved.imeHideEventOwner)
+  }
+
+  @Test
+  fun shown_resolution_discards_transient_native_hide_version() {
+    val resolver = EditorKeyboardInteractionResolver()
+    val shown = shownKeyboardState(version = 3)
+    resolver.resolve(shown, SoftwareKeyboardInteractionState())
+    resolver.resolve(
+      hiddenKeyboardState(presentation = EditorKeyboardPresentation.Hiding, version = 4),
+      SoftwareKeyboardInteractionState(activeInteractionId = 1L, hiddenProgress = 0.7f),
+    )
+
+    val stillRetained =
+      resolver.resolve(
+        hiddenKeyboardState(presentation = EditorKeyboardPresentation.Hidden, version = 4),
+        resolvedInteraction(SoftwareKeyboardInteractionResolution.Shown),
+      )
+    val settledShown =
+      resolver.resolve(
+        shownKeyboardState(version = 4),
+        resolvedInteraction(SoftwareKeyboardInteractionResolution.Shown),
+      )
+    val laterRealHide =
+      resolver.resolve(
+        hiddenKeyboardState(
+          presentation = EditorKeyboardPresentation.Hiding,
+          version = 5,
+          owner = EditorImeInputOwner.Editor,
+        ),
+        resolvedInteraction(SoftwareKeyboardInteractionResolution.Shown),
+      )
+
+    assertEquals(EditorKeyboardPresentation.Shown(320.dp), stillRetained.presentation)
+    assertEquals(3, stillRetained.imeHideEventVersion)
+    assertEquals(EditorKeyboardPresentation.Shown(320.dp), settledShown.presentation)
+    assertEquals(3, settledShown.imeHideEventVersion)
+    assertEquals(EditorKeyboardPresentation.Hiding, laterRealHide.presentation)
+    assertEquals(4, laterRealHide.imeHideEventVersion)
+  }
+
+  @Test
+  fun hidden_resolution_publishes_the_native_hide_once_it_reaches_the_endpoint() {
+    val resolver = EditorKeyboardInteractionResolver()
+    resolver.resolve(shownKeyboardState(version = 2), SoftwareKeyboardInteractionState())
+    resolver.resolve(
+      hiddenKeyboardState(presentation = EditorKeyboardPresentation.Hiding, version = 3),
+      SoftwareKeyboardInteractionState(activeInteractionId = 1L, hiddenProgress = 1f),
+    )
+
+    val resolved =
+      resolver.resolve(
+        hiddenKeyboardState(
+          presentation = EditorKeyboardPresentation.Hiding,
+          version = 3,
+          owner = EditorImeInputOwner.Editor,
+        ),
+        resolvedInteraction(SoftwareKeyboardInteractionResolution.Hidden),
+      )
+    val settled =
+      resolver.resolve(
+        hiddenKeyboardState(
+          presentation = EditorKeyboardPresentation.Hidden,
+          version = 3,
+          owner = EditorImeInputOwner.Editor,
+        ),
+        resolvedInteraction(SoftwareKeyboardInteractionResolution.Hidden),
+      )
+
+    assertEquals(EditorKeyboardPresentation.Hiding, resolved.presentation)
+    assertEquals(3, resolved.imeHideEventVersion)
+    assertEquals(EditorImeInputOwner.Editor, resolved.imeHideEventOwner)
+    assertEquals(EditorKeyboardPresentation.Hidden, settled.presentation)
+    assertEquals(3, settled.imeHideEventVersion)
+  }
+
+  @Test
+  fun aborted_interaction_releases_to_the_current_native_state() {
+    val resolver = EditorKeyboardInteractionResolver()
+    resolver.resolve(shownKeyboardState(version = 1), SoftwareKeyboardInteractionState())
+    resolver.resolve(
+      hiddenKeyboardState(presentation = EditorKeyboardPresentation.Hiding, version = 2),
+      SoftwareKeyboardInteractionState(activeInteractionId = 1L, hiddenProgress = 0.5f),
+    )
+    val nativeHidden =
+      hiddenKeyboardState(
+        presentation = EditorKeyboardPresentation.Hidden,
+        version = 2,
+        owner = EditorImeInputOwner.Other,
+      )
+
+    assertEquals(
+      nativeHidden,
+      resolver.resolve(
+        nativeState = nativeHidden,
+        interactionState = resolvedInteraction(SoftwareKeyboardInteractionResolution.Aborted),
+      ),
+    )
+  }
+
+  @Test
+  fun later_interaction_captures_a_fresh_shown_state() {
+    val resolver = EditorKeyboardInteractionResolver()
+    resolver.resolve(shownKeyboardState(version = 1), SoftwareKeyboardInteractionState())
+    resolver.resolve(
+      shownKeyboardState(version = 1),
+      SoftwareKeyboardInteractionState(activeInteractionId = 1L),
+    )
+    resolver.resolve(
+      shownKeyboardState(version = 1, settledImeBottom = 320.dp),
+      resolvedInteraction(SoftwareKeyboardInteractionResolution.Shown),
+    )
+
+    val freshShown = shownKeyboardState(version = 1, settledImeBottom = 360.dp)
+    resolver.resolve(freshShown, resolvedInteraction(SoftwareKeyboardInteractionResolution.Shown))
+    val retained =
+      resolver.resolve(
+        hiddenKeyboardState(presentation = EditorKeyboardPresentation.Hidden, version = 2),
+        SoftwareKeyboardInteractionState(
+          activeInteractionId = 2L,
+          hiddenProgress = 1f,
+          resolutionVersion = 1L,
+          lastResolution = SoftwareKeyboardInteractionResolution.Shown,
+        ),
+      )
+
+    assertEquals(EditorKeyboardPresentation.Shown(360.dp), retained.presentation)
+    assertEquals(1, retained.imeHideEventVersion)
+  }
 }
+
+private fun shownKeyboardState(
+  version: Int,
+  owner: EditorImeInputOwner? = null,
+  settledImeBottom: androidx.compose.ui.unit.Dp = 320.dp,
+) =
+  EditorKeyboardState(
+    type = EditorKeyboardType.Software,
+    imeFrameVisible = true,
+    imeHideEventVersion = version,
+    imeHideEventOwner = owner,
+    presentation = EditorKeyboardPresentation.Shown(settledImeBottom),
+  )
+
+private fun hiddenKeyboardState(
+  presentation: EditorKeyboardPresentation,
+  version: Int,
+  owner: EditorImeInputOwner? = null,
+) =
+  EditorKeyboardState(
+    type = EditorKeyboardType.Software,
+    imeFrameVisible = false,
+    imeHideEventVersion = version,
+    imeHideEventOwner = owner,
+    presentation = presentation,
+  )
+
+private fun resolvedInteraction(resolution: SoftwareKeyboardInteractionResolution) =
+  SoftwareKeyboardInteractionState(resolutionVersion = 1L, lastResolution = resolution)

--- a/apps/mobile/compose/src/desktopMain/kotlin/co/typie/dev/DesktopDebugKeyboard.kt
+++ b/apps/mobile/compose/src/desktopMain/kotlin/co/typie/dev/DesktopDebugKeyboard.kt
@@ -2,7 +2,8 @@ package co.typie.dev
 
 // cspell:ignore smol floof awoo
 
-import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.VectorConverter
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -27,6 +28,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
@@ -34,6 +36,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -49,6 +52,9 @@ import co.typie.ext.LocalInteractionSource
 import co.typie.ext.TextInputClient
 import co.typie.ext.TextInputKey
 import co.typie.ext.pressScale
+import co.typie.platform.LocalSoftwareKeyboardPresentationController
+import co.typie.platform.SoftwareKeyboardPresentationDriver
+import co.typie.platform.SoftwareKeyboardPresentationEndpoint
 import co.typie.ui.theme.AppShapes
 import co.typie.ui.theme.AppTheme
 import java.awt.Component
@@ -145,6 +151,18 @@ private val DesktopDebugKeyboardKoreanFixtures =
     listOf("ㅉ", "쪼", "쫀", "쫀ㄷ", "쫀드", "쫀득", "쫀득ㅈ", "쫀득제", "쫀득젤", "쫀득젤ㄹ", "쫀득젤리", "쫀득젤리♡"),
   )
 
+private val LocalDesktopDebugKeyboardPresentedHeight =
+  staticCompositionLocalOf<Dp> { error("ProvideDesktopDebugKeyboardPresentation is missing") }
+
+@Composable
+internal fun ProvideDesktopDebugKeyboardPresentation(content: @Composable () -> Unit) {
+  val presentedHeight = DesktopDebugKeyboard.rememberPresentedHeight()
+  CompositionLocalProvider(
+    LocalDesktopDebugKeyboardPresentedHeight provides presentedHeight,
+    content = content,
+  )
+}
+
 internal object DesktopDebugKeyboard {
   private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Swing)
   private val focusedOwners = linkedSetOf<Any>()
@@ -164,6 +182,9 @@ internal object DesktopDebugKeyboard {
   private var koreanFixtureBankIndex by mutableStateOf(0)
   private var koreanFixtureStepIndex by mutableStateOf(0)
   private var activeFixtureLanguage: Boolean? by mutableStateOf(null)
+  private var isPresentationFullyShown = false
+  private var presentationDriverToken: Any? = null
+  private var presentationDriverInvalidation: (() -> Unit)? = null
 
   var hardwareKeyboardConnected by mutableStateOf(false)
     private set
@@ -185,7 +206,7 @@ internal object DesktopDebugKeyboard {
         updateRecentClient(clients.getValue(owner))
       }
       if (focusGained && !hardwareKeyboardConnected) {
-        isVisible = true
+        setKeyboardSurfaceVisible(true)
       }
       return
     }
@@ -230,21 +251,21 @@ internal object DesktopDebugKeyboard {
 
   @Composable
   fun asWindowInsets(baseInsets: WindowInsets, bottomOffset: Dp = 0.dp): WindowInsets {
-    val animatedHeight = animatedHeight()
+    val presentedHeight = presentedHeight()
     return baseInsets.union(
-      WindowInsets(bottom = resolveDesktopDebugKeyboardInsetHeight(animatedHeight, bottomOffset))
+      WindowInsets(bottom = resolveDesktopDebugKeyboardInsetHeight(presentedHeight, bottomOffset))
     )
   }
 
   @Composable
   fun Overlay(modifier: Modifier = Modifier) {
-    val animatedHeight = animatedHeight()
-    if (animatedHeight <= 0.dp) return
+    val presentedHeight = presentedHeight()
+    if (presentedHeight <= 0.dp) return
 
     Box(
       modifier
         .fillMaxWidth()
-        .height(animatedHeight)
+        .height(presentedHeight)
         .pointerInput(Unit) {
           awaitEachGesture {
             awaitFirstDown(requireUnconsumed = false)
@@ -341,7 +362,7 @@ internal object DesktopDebugKeyboard {
   internal fun hideKeyboardSurface() {
     resetFixtureProgress()
     hideJob?.cancel()
-    isVisible = false
+    setKeyboardSurfaceVisible(false)
   }
 
   internal fun dismissInput() {
@@ -357,14 +378,14 @@ internal object DesktopDebugKeyboard {
     hideJob?.cancel()
     activeOwner = owner
     updateRecentClient(client)
-    isVisible = true
+    setKeyboardSurfaceVisible(true)
   }
 
   private fun beginPointerInteraction() {
     isPointerInteracting = true
     hideJob?.cancel()
     if (!hardwareKeyboardConnected) {
-      isVisible = true
+      setKeyboardSurfaceVisible(true)
     }
   }
 
@@ -535,7 +556,7 @@ internal object DesktopDebugKeyboard {
     val client = rememberedClient() ?: return
     hideJob?.cancel()
     if (!hardwareKeyboardConnected) {
-      isVisible = true
+      setKeyboardSurfaceVisible(true)
     }
     client.requestFocus()
     scope.launch {
@@ -551,19 +572,96 @@ internal object DesktopDebugKeyboard {
       if (!isPointerInteracting && focusedOwners.isEmpty()) {
         clearRecentClient()
         resetFixtureProgress()
-        isVisible = false
+        setKeyboardSurfaceVisible(false)
       }
     }
   }
 
   @Composable
-  private fun animatedHeight(): Dp {
-    val animatedHeight by
-      animateDpAsState(
-        targetValue = if (isVisible) height else 0.dp,
-        animationSpec = tween(durationMillis = DesktopDebugKeyboardAnimationDurationMillis),
-      )
-    return animatedHeight
+  internal fun rememberPresentedHeight(): Dp {
+    val interactionState = LocalSoftwareKeyboardPresentationController.current.interactionState
+    val heightAnimation = remember {
+      Animatable(initialValue = if (isVisible) height else 0.dp, typeConverter = Dp.VectorConverter)
+    }
+    LaunchedEffect(
+      isVisible,
+      height,
+      interactionState.activeInteractionId,
+      interactionState.hiddenProgress,
+    ) {
+      isPresentationFullyShown = false
+      if (interactionState.unresolved) {
+        heightAnimation.snapTo(height * (1f - interactionState.hiddenProgress))
+        isPresentationFullyShown = isVisible && interactionState.hiddenProgress == 0f
+      } else {
+        heightAnimation.animateTo(
+          targetValue = if (isVisible) height else 0.dp,
+          animationSpec = tween(durationMillis = DesktopDebugKeyboardAnimationDurationMillis),
+        )
+        isPresentationFullyShown = isVisible && heightAnimation.value == height
+      }
+    }
+    DisposableEffect(Unit) { onDispose { isPresentationFullyShown = false } }
+    return heightAnimation.value
+  }
+
+  internal fun acquirePresentationDriver(
+    onInvalidated: () -> Unit
+  ): SoftwareKeyboardPresentationDriver? {
+    if (!isPresentationReady() || !hasFocusedClient() || presentationDriverToken != null) {
+      return null
+    }
+
+    val token = Any()
+    presentationDriverToken = token
+    presentationDriverInvalidation = onInvalidated
+    return object : SoftwareKeyboardPresentationDriver {
+      override fun updateHiddenProgress(progress: Float) = Unit
+
+      override fun finish(endpoint: SoftwareKeyboardPresentationEndpoint, onAccepted: () -> Unit) {
+        if (presentationDriverToken !== token) return
+        presentationDriverToken = null
+        presentationDriverInvalidation = null
+        when (endpoint) {
+          SoftwareKeyboardPresentationEndpoint.Shown -> isVisible = true
+          SoftwareKeyboardPresentationEndpoint.Hidden -> {
+            resetFixtureProgress()
+            hideJob?.cancel()
+            isPresentationFullyShown = false
+            isVisible = false
+          }
+        }
+        onAccepted()
+      }
+
+      override fun dispose() {
+        if (presentationDriverToken !== token) return
+        presentationDriverToken = null
+        presentationDriverInvalidation = null
+      }
+    }
+  }
+
+  @Composable private fun presentedHeight(): Dp = LocalDesktopDebugKeyboardPresentedHeight.current
+
+  private fun setKeyboardSurfaceVisible(visible: Boolean) {
+    if (isVisible == visible) return
+    invalidatePresentationDriver()
+    isPresentationFullyShown = false
+    isVisible = visible
+  }
+
+  private fun hasFocusedClient(): Boolean = focusedOwners.any { clients.containsKey(it) }
+
+  private fun isPresentationReady(): Boolean =
+    isVisible && isPresentationFullyShown && !hardwareKeyboardConnected
+
+  private fun invalidatePresentationDriver() {
+    if (presentationDriverToken == null) return
+    val onInvalidated = presentationDriverInvalidation
+    presentationDriverToken = null
+    presentationDriverInvalidation = null
+    onInvalidated?.invoke()
   }
 
   @Composable

--- a/apps/mobile/compose/src/desktopMain/kotlin/co/typie/dev/SystemChrome.kt
+++ b/apps/mobile/compose/src/desktopMain/kotlin/co/typie/dev/SystemChrome.kt
@@ -88,73 +88,75 @@ actual fun SystemChrome(content: @Composable () -> Unit) {
     }
   }
 
-  CompositionLocalProvider(
-    LocalSoftwareKeyboardController provides keyboardController,
-    LocalNavigationStatusBarAppearanceController provides statusBarAppearanceController,
-  ) {
-    Box(Modifier.fillMaxSize()) {
-      // Content fills the full window so the Compose root lines up with the window
-      // origin, matching iOS/Android. The bezel is a decorative overlay drawn on top
-      // rather than a layout container, so positionInWindow works consistently.
-      Box(Modifier.fillMaxSize().clip(RoundedCornerShape(r + BezelThickness))) {
-        content()
-        DesktopDebugKeyboard.Overlay(
-          Modifier.align(Alignment.BottomStart)
-            .padding(start = BezelThickness, end = BezelThickness, bottom = BezelThickness)
-        )
-        StatusBar(
-          useLightForeground = statusBarAppearanceController.useLightForeground,
-          modifier =
-            Modifier.fillMaxWidth()
-              .align(Alignment.TopStart)
-              .padding(start = BezelThickness, top = BezelThickness, end = BezelThickness),
-        )
-        HomeIndicator(Modifier.align(Alignment.BottomCenter).padding(bottom = BezelThickness))
-      }
+  ProvideDesktopDebugKeyboardPresentation {
+    CompositionLocalProvider(
+      LocalSoftwareKeyboardController provides keyboardController,
+      LocalNavigationStatusBarAppearanceController provides statusBarAppearanceController,
+    ) {
+      Box(Modifier.fillMaxSize()) {
+        // Content fills the full window so the Compose root lines up with the window
+        // origin, matching iOS/Android. The bezel is a decorative overlay drawn on top
+        // rather than a layout container, so positionInWindow works consistently.
+        Box(Modifier.fillMaxSize().clip(RoundedCornerShape(r + BezelThickness))) {
+          content()
+          DesktopDebugKeyboard.Overlay(
+            Modifier.align(Alignment.BottomStart)
+              .padding(start = BezelThickness, end = BezelThickness, bottom = BezelThickness)
+          )
+          StatusBar(
+            useLightForeground = statusBarAppearanceController.useLightForeground,
+            modifier =
+              Modifier.fillMaxWidth()
+                .align(Alignment.TopStart)
+                .padding(start = BezelThickness, top = BezelThickness, end = BezelThickness),
+          )
+          HomeIndicator(Modifier.align(Alignment.BottomCenter).padding(bottom = BezelThickness))
+        }
 
-      // Bezel overlay: four concentric rounded rects filled outer→inner, then the
-      // screen area is cleared to reveal the content underneath. Requires an
-      // offscreen layer so BlendMode.Clear can punch a transparent hole.
-      Box(
-        Modifier.fillMaxSize()
-          .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen }
-          .drawBehind {
-            val rPx = r.toPx()
-            drawRoundRect(
-              color = BezelOuterHighlight,
-              cornerRadius = CornerRadius(rPx + 12.dp.toPx()),
-            )
-            val body = 1.5.dp.toPx()
-            drawRoundRect(
-              color = BezelBody,
-              topLeft = Offset(body, body),
-              size = Size(size.width - 2 * body, size.height - 2 * body),
-              cornerRadius = CornerRadius(rPx + 10.5.dp.toPx()),
-            )
-            val innerEdge = 10.5.dp.toPx()
-            drawRoundRect(
-              color = BezelInnerEdge,
-              topLeft = Offset(innerEdge, innerEdge),
-              size = Size(size.width - 2 * innerEdge, size.height - 2 * innerEdge),
-              cornerRadius = CornerRadius(rPx + 1.5.dp.toPx()),
-            )
-            val screenEdge = 11.5.dp.toPx()
-            drawRoundRect(
-              color = BezelScreenEdge,
-              topLeft = Offset(screenEdge, screenEdge),
-              size = Size(size.width - 2 * screenEdge, size.height - 2 * screenEdge),
-              cornerRadius = CornerRadius(rPx + 0.5.dp.toPx()),
-            )
-            val screen = BezelThickness.toPx()
-            drawRoundRect(
-              color = Color.Black,
-              topLeft = Offset(screen, screen),
-              size = Size(size.width - 2 * screen, size.height - 2 * screen),
-              cornerRadius = CornerRadius(rPx),
-              blendMode = BlendMode.Clear,
-            )
-          }
-      )
+        // Bezel overlay: four concentric rounded rects filled outer→inner, then the
+        // screen area is cleared to reveal the content underneath. Requires an
+        // offscreen layer so BlendMode.Clear can punch a transparent hole.
+        Box(
+          Modifier.fillMaxSize()
+            .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen }
+            .drawBehind {
+              val rPx = r.toPx()
+              drawRoundRect(
+                color = BezelOuterHighlight,
+                cornerRadius = CornerRadius(rPx + 12.dp.toPx()),
+              )
+              val body = 1.5.dp.toPx()
+              drawRoundRect(
+                color = BezelBody,
+                topLeft = Offset(body, body),
+                size = Size(size.width - 2 * body, size.height - 2 * body),
+                cornerRadius = CornerRadius(rPx + 10.5.dp.toPx()),
+              )
+              val innerEdge = 10.5.dp.toPx()
+              drawRoundRect(
+                color = BezelInnerEdge,
+                topLeft = Offset(innerEdge, innerEdge),
+                size = Size(size.width - 2 * innerEdge, size.height - 2 * innerEdge),
+                cornerRadius = CornerRadius(rPx + 1.5.dp.toPx()),
+              )
+              val screenEdge = 11.5.dp.toPx()
+              drawRoundRect(
+                color = BezelScreenEdge,
+                topLeft = Offset(screenEdge, screenEdge),
+                size = Size(size.width - 2 * screenEdge, size.height - 2 * screenEdge),
+                cornerRadius = CornerRadius(rPx + 0.5.dp.toPx()),
+              )
+              val screen = BezelThickness.toPx()
+              drawRoundRect(
+                color = Color.Black,
+                topLeft = Offset(screen, screen),
+                size = Size(size.width - 2 * screen, size.height - 2 * screen),
+                cornerRadius = CornerRadius(rPx),
+                blendMode = BlendMode.Clear,
+              )
+            }
+        )
+      }
     }
   }
 }

--- a/apps/mobile/compose/src/desktopMain/kotlin/co/typie/platform/SoftwareKeyboardPresentation.desktop.kt
+++ b/apps/mobile/compose/src/desktopMain/kotlin/co/typie/platform/SoftwareKeyboardPresentation.desktop.kt
@@ -1,0 +1,11 @@
+package co.typie.platform
+
+import androidx.compose.runtime.Composable
+import co.typie.dev.DesktopDebugKeyboard
+
+private val DesktopSoftwareKeyboardPresentationDriverFactory =
+  SoftwareKeyboardPresentationDriverFactory(DesktopDebugKeyboard::acquirePresentationDriver)
+
+@Composable
+internal actual fun rememberSoftwareKeyboardPresentationDriverFactory():
+  SoftwareKeyboardPresentationDriverFactory = DesktopSoftwareKeyboardPresentationDriverFactory

--- a/apps/mobile/compose/src/desktopMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.desktop.kt
+++ b/apps/mobile/compose/src/desktopMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.desktop.kt
@@ -8,12 +8,16 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import co.typie.dev.DesktopDebugKeyboard
 import co.typie.ext.ime
+import co.typie.platform.LocalSoftwareKeyboardPresentationController
 
 @Composable
 internal actual fun rememberEditorKeyboardState(
   isEditorInputSessionActive: () -> Boolean
 ): EditorKeyboardState {
   val density = LocalDensity.current
+  val keyboardInteractionResolver = remember { EditorKeyboardInteractionResolver() }
+  val keyboardInteractionState =
+    LocalSoftwareKeyboardPresentationController.current.interactionState
   val imeBottom = with(density) { WindowInsets.ime.getBottom(this).toDp() }
   val imeHideOwnershipTracker = remember { EditorImeHideOwnershipTracker() }
   val state =
@@ -21,12 +25,16 @@ internal actual fun rememberEditorKeyboardState(
       hardwareKeyboardConnected = DesktopDebugKeyboard.hardwareKeyboardConnected,
       imeBottom = imeBottom,
     )
-  return state.copy(
-    imeHideEventOwner =
-      imeHideOwnershipTracker.observe(
-        presentation = state.presentation,
-        editorInputSessionActive = isEditorInputSessionActive(),
-      )
+  return keyboardInteractionResolver.resolve(
+    nativeState =
+      state.copy(
+        imeHideEventOwner =
+          imeHideOwnershipTracker.observe(
+            presentation = state.presentation,
+            editorInputSessionActive = isEditorInputSessionActive(),
+          )
+      ),
+    interactionState = keyboardInteractionState,
   )
 }
 

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/dev/DesktopDebugKeyboardPresentationDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/dev/DesktopDebugKeyboardPresentationDesktopTest.kt
@@ -1,0 +1,525 @@
+package co.typie.dev
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import co.typie.ext.TextInputClient
+import co.typie.ext.ime
+import co.typie.platform.LocalSoftwareKeyboardPresentationController
+import co.typie.platform.ProvideSoftwareKeyboardPresentation
+import co.typie.platform.SoftwareKeyboardInteractionResolution
+import co.typie.platform.SoftwareKeyboardPresentationController
+import co.typie.platform.SoftwareKeyboardPresentationEndpoint
+import co.typie.ui.theme.LightColors
+import co.typie.ui.theme.LocalAppColors
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class DesktopDebugKeyboardPresentationDesktopTest {
+  @Test
+  fun ordinaryShowAndHideKeepTheSurfaceAndImeInsetTogether() = runComposeUiTest {
+    val owner = Any()
+    val client = RecordingTextInputClient()
+    val previousHardwareKeyboardConnected = DesktopDebugKeyboard.hardwareKeyboardConnected
+    var imeBottomPx = 0f
+    var shownHeightPx = 0f
+
+    try {
+      runOnIdle {
+        DesktopDebugKeyboard.updateHardwareKeyboardConnected(false)
+        DesktopDebugKeyboard.hideKeyboardSurface()
+        DesktopDebugKeyboard.registerClient(owner, client)
+      }
+      setContent {
+        CompositionLocalProvider(LocalAppColors provides LightColors) {
+          ProvideSoftwareKeyboardPresentation {
+            ProvideDesktopDebugKeyboardPresentation {
+              val density = LocalDensity.current
+              val imeBottom = WindowInsets.ime.getBottom(density).toFloat()
+              SideEffect {
+                imeBottomPx = imeBottom
+                shownHeightPx = with(density) { DesktopDebugKeyboard.height.toPx() }
+              }
+              Box(Modifier.size(width = 400.dp, height = 700.dp).testTag(ROOT_TAG)) {
+                DesktopDebugKeyboard.Overlay(
+                  Modifier.align(Alignment.BottomStart)
+                    .padding(bottom = DESKTOP_CHROME_BOTTOM_OFFSET)
+                    .testTag(KEYBOARD_TAG)
+                )
+              }
+            }
+          }
+        }
+      }
+
+      onNodeWithTag(KEYBOARD_TAG).assertDoesNotExist()
+      assertEquals(0f, imeBottomPx)
+
+      mainClock.autoAdvance = false
+      runOnIdle { DesktopDebugKeyboard.notifyFocusChanged(owner, isFocused = true) }
+      mainClock.advanceTimeBy(110L)
+      waitForIdle()
+
+      assertSurfaceMatchesImeInset(imeBottomPx)
+      val intermediateHeight = onNodeWithTag(KEYBOARD_TAG).fetchSemanticsNode().boundsInRoot.height
+      assertTrue(intermediateHeight in 1f..<shownHeightPx)
+
+      mainClock.advanceTimeBy(160L)
+      waitForIdle()
+
+      assertSurfaceMatchesImeInset(imeBottomPx)
+      assertEquals(
+        shownHeightPx,
+        onNodeWithTag(KEYBOARD_TAG).fetchSemanticsNode().boundsInRoot.height,
+        absoluteTolerance = POSITION_TOLERANCE_PX,
+      )
+
+      runOnIdle { DesktopDebugKeyboard.hideKeyboardSurface() }
+      mainClock.advanceTimeBy(110L)
+      waitForIdle()
+
+      assertSurfaceMatchesImeInset(imeBottomPx)
+      mainClock.advanceTimeBy(160L)
+      waitForIdle()
+
+      onNodeWithTag(KEYBOARD_TAG).assertDoesNotExist()
+      assertEquals(0f, imeBottomPx)
+    } finally {
+      mainClock.autoAdvance = true
+      runOnIdle {
+        DesktopDebugKeyboard.notifyFocusChanged(owner, isFocused = false)
+        DesktopDebugKeyboard.registerClient(owner, null)
+        DesktopDebugKeyboard.updateHardwareKeyboardConnected(previousHardwareKeyboardConnected)
+        DesktopDebugKeyboard.hideKeyboardSurface()
+      }
+    }
+  }
+
+  @Test
+  fun interactiveSessionCanStartOnlyAfterOrdinaryShowReachesItsEndpoint() = runComposeUiTest {
+    val owner = Any()
+    val client = RecordingTextInputClient()
+    val previousHardwareKeyboardConnected = DesktopDebugKeyboard.hardwareKeyboardConnected
+    lateinit var controller: SoftwareKeyboardPresentationController
+
+    try {
+      runOnIdle {
+        DesktopDebugKeyboard.updateHardwareKeyboardConnected(false)
+        DesktopDebugKeyboard.hideKeyboardSurface()
+        DesktopDebugKeyboard.registerClient(owner, client)
+      }
+      setContent {
+        ProvideSoftwareKeyboardPresentation {
+          ProvideDesktopDebugKeyboardPresentation {
+            val currentController = LocalSoftwareKeyboardPresentationController.current
+            SideEffect { controller = currentController }
+            Box(Modifier.fillMaxSize())
+          }
+        }
+      }
+      waitForIdle()
+
+      mainClock.autoAdvance = false
+      runOnIdle { DesktopDebugKeyboard.notifyFocusChanged(owner, isFocused = true) }
+      mainClock.advanceTimeBy(110L)
+      waitForIdle()
+
+      runOnIdle { assertNull(controller.acquire()) }
+
+      mainClock.advanceTimeBy(160L)
+      waitForIdle()
+
+      runOnIdle { requireNotNull(controller.acquire()).dispose() }
+    } finally {
+      mainClock.autoAdvance = true
+      runOnIdle {
+        DesktopDebugKeyboard.notifyFocusChanged(owner, isFocused = false)
+        DesktopDebugKeyboard.registerClient(owner, null)
+        DesktopDebugKeyboard.updateHardwareKeyboardConnected(previousHardwareKeyboardConnected)
+        DesktopDebugKeyboard.hideKeyboardSurface()
+      }
+    }
+  }
+
+  @Test
+  fun interactiveSessionRequiresACurrentFocusedClient() = runComposeUiTest {
+    val owner = Any()
+    val previousHardwareKeyboardConnected = DesktopDebugKeyboard.hardwareKeyboardConnected
+    lateinit var controller: SoftwareKeyboardPresentationController
+
+    try {
+      runOnIdle {
+        DesktopDebugKeyboard.updateHardwareKeyboardConnected(false)
+        DesktopDebugKeyboard.hideKeyboardSurface()
+        DesktopDebugKeyboard.notifyFocusChanged(owner, isFocused = true)
+      }
+      setContent {
+        ProvideSoftwareKeyboardPresentation {
+          ProvideDesktopDebugKeyboardPresentation {
+            val currentController = LocalSoftwareKeyboardPresentationController.current
+            SideEffect { controller = currentController }
+            Box(Modifier.fillMaxSize())
+          }
+        }
+      }
+      waitForIdle()
+
+      runOnIdle { assertNull(controller.acquire()) }
+    } finally {
+      runOnIdle {
+        DesktopDebugKeyboard.notifyFocusChanged(owner, isFocused = false)
+        DesktopDebugKeyboard.updateHardwareKeyboardConnected(previousHardwareKeyboardConnected)
+        DesktopDebugKeyboard.hideKeyboardSurface()
+      }
+    }
+  }
+
+  @Test
+  fun focusLossRevokesInteractiveAdmissionBeforeTheDelayedHide() = runComposeUiTest {
+    val owner = Any()
+    val client = RecordingTextInputClient()
+    val previousHardwareKeyboardConnected = DesktopDebugKeyboard.hardwareKeyboardConnected
+    lateinit var controller: SoftwareKeyboardPresentationController
+
+    try {
+      runOnIdle {
+        DesktopDebugKeyboard.updateHardwareKeyboardConnected(false)
+        DesktopDebugKeyboard.hideKeyboardSurface()
+        DesktopDebugKeyboard.registerClient(owner, client)
+        DesktopDebugKeyboard.notifyFocusChanged(owner, isFocused = true)
+      }
+      setContent {
+        ProvideSoftwareKeyboardPresentation {
+          ProvideDesktopDebugKeyboardPresentation {
+            val currentController = LocalSoftwareKeyboardPresentationController.current
+            SideEffect { controller = currentController }
+            Box(Modifier.fillMaxSize())
+          }
+        }
+      }
+      waitForIdle()
+
+      runOnIdle { DesktopDebugKeyboard.notifyFocusChanged(owner, isFocused = false) }
+
+      runOnIdle { assertNull(controller.acquire()) }
+    } finally {
+      runOnIdle {
+        DesktopDebugKeyboard.registerClient(owner, null)
+        DesktopDebugKeyboard.updateHardwareKeyboardConnected(previousHardwareKeyboardConnected)
+        DesktopDebugKeyboard.hideKeyboardSurface()
+      }
+    }
+  }
+
+  @Test
+  fun interactiveProgressUsesOneHeightAndRetainsInputUntilHiddenCompletion() = runComposeUiTest {
+    val owner = Any()
+    val client = RecordingTextInputClient()
+    val previousHardwareKeyboardConnected = DesktopDebugKeyboard.hardwareKeyboardConnected
+    lateinit var controller: SoftwareKeyboardPresentationController
+    var imeBottomPx = 0f
+    var shownHeightPx = 0f
+    var bottomOffsetPx = 0f
+
+    try {
+      runOnIdle {
+        DesktopDebugKeyboard.updateHardwareKeyboardConnected(false)
+        DesktopDebugKeyboard.hideKeyboardSurface()
+        DesktopDebugKeyboard.registerClient(owner, client)
+        DesktopDebugKeyboard.notifyFocusChanged(owner, isFocused = true)
+      }
+      setContent {
+        CompositionLocalProvider(LocalAppColors provides LightColors) {
+          ProvideSoftwareKeyboardPresentation {
+            ProvideDesktopDebugKeyboardPresentation {
+              val density = LocalDensity.current
+              val currentController = LocalSoftwareKeyboardPresentationController.current
+              val imeBottom = WindowInsets.ime.getBottom(density).toFloat()
+              SideEffect {
+                controller = currentController
+                imeBottomPx = imeBottom
+                shownHeightPx = with(density) { DesktopDebugKeyboard.height.toPx() }
+                bottomOffsetPx = with(density) { DESKTOP_CHROME_BOTTOM_OFFSET.toPx() }
+              }
+              Box(Modifier.size(width = 400.dp, height = 700.dp).testTag(ROOT_TAG)) {
+                DesktopDebugKeyboard.Overlay(
+                  Modifier.align(Alignment.BottomStart)
+                    .padding(bottom = DESKTOP_CHROME_BOTTOM_OFFSET)
+                    .testTag(KEYBOARD_TAG)
+                )
+              }
+            }
+          }
+        }
+      }
+      waitForIdle()
+      assertSurfaceMatchesImeInset(imeBottomPx)
+
+      mainClock.autoAdvance = false
+      val session = runOnIdle { requireNotNull(controller.acquire()) }
+      runOnIdle { session.updateHiddenProgress(0.5f) }
+      mainClock.advanceTimeByFrame()
+      mainClock.advanceTimeByFrame()
+      waitForIdle()
+
+      assertSurfaceMatchesImeInset(imeBottomPx)
+      assertEquals(
+        shownHeightPx * 0.5f + bottomOffsetPx,
+        imeBottomPx,
+        absoluteTolerance = POSITION_TOLERANCE_PX,
+      )
+
+      runOnIdle { session.updateHiddenProgress(1f) }
+      mainClock.advanceTimeByFrame()
+      mainClock.advanceTimeByFrame()
+      waitForIdle()
+
+      onNodeWithTag(KEYBOARD_TAG).assertDoesNotExist()
+      assertEquals(0f, imeBottomPx)
+      runOnIdle {
+        assertTrue(DesktopDebugKeyboard.visible)
+        assertTrue(controller.interactionState.unresolved)
+        assertNull(controller.interactionState.lastResolution)
+      }
+
+      runOnIdle { session.finish(SoftwareKeyboardPresentationEndpoint.Hidden) }
+      mainClock.advanceTimeByFrame()
+      waitForIdle()
+
+      onNodeWithTag(KEYBOARD_TAG).assertDoesNotExist()
+      assertEquals(0f, imeBottomPx)
+      runOnIdle {
+        assertFalse(DesktopDebugKeyboard.visible)
+        assertFalse(controller.interactionState.unresolved)
+        assertEquals(
+          SoftwareKeyboardInteractionResolution.Hidden,
+          controller.interactionState.lastResolution,
+        )
+        DesktopDebugKeyboard.showKeyboard()
+        assertTrue(DesktopDebugKeyboard.visible, "The focused registered client was released early")
+      }
+    } finally {
+      mainClock.autoAdvance = true
+      runOnIdle {
+        DesktopDebugKeyboard.notifyFocusChanged(owner, isFocused = false)
+        DesktopDebugKeyboard.registerClient(owner, null)
+        DesktopDebugKeyboard.updateHardwareKeyboardConnected(previousHardwareKeyboardConnected)
+        DesktopDebugKeyboard.hideKeyboardSurface()
+      }
+    }
+  }
+
+  @Test
+  fun committedHideContinuesDownwardAfterInputSessionEnds() = runComposeUiTest {
+    val owner = Any()
+    val client = RecordingTextInputClient()
+    val previousHardwareKeyboardConnected = DesktopDebugKeyboard.hardwareKeyboardConnected
+    lateinit var controller: SoftwareKeyboardPresentationController
+    var imeBottomPx = 0f
+
+    try {
+      runOnIdle {
+        DesktopDebugKeyboard.updateHardwareKeyboardConnected(false)
+        DesktopDebugKeyboard.hideKeyboardSurface()
+        DesktopDebugKeyboard.registerClient(owner, client)
+        DesktopDebugKeyboard.notifyFocusChanged(owner, isFocused = true)
+      }
+      setContent {
+        ProvideSoftwareKeyboardPresentation {
+          ProvideDesktopDebugKeyboardPresentation {
+            val density = LocalDensity.current
+            val currentController = LocalSoftwareKeyboardPresentationController.current
+            val imeBottom = WindowInsets.ime.getBottom(density).toFloat()
+            SideEffect {
+              controller = currentController
+              imeBottomPx = imeBottom
+            }
+            Box(Modifier.fillMaxSize())
+          }
+        }
+      }
+      waitForIdle()
+
+      mainClock.autoAdvance = false
+      val session = runOnIdle { requireNotNull(controller.acquire()) }
+      runOnIdle { session.updateHiddenProgress(0.8f) }
+      mainClock.advanceTimeByFrame()
+      mainClock.advanceTimeByFrame()
+      waitForIdle()
+      val insetBeforeCommittedHide = imeBottomPx
+
+      runOnIdle {
+        DesktopDebugKeyboard.notifyFocusChanged(owner, isFocused = false)
+        DesktopDebugKeyboard.registerClient(owner, null)
+        session.finish(SoftwareKeyboardPresentationEndpoint.Hidden)
+      }
+      mainClock.advanceTimeBy(60L)
+      waitForIdle()
+
+      assertTrue(
+        imeBottomPx <= insetBeforeCommittedHide + POSITION_TOLERANCE_PX,
+        "Committed hide must continue downward after the input session ends",
+      )
+
+      mainClock.advanceTimeBy(220L)
+      waitForIdle()
+
+      assertEquals(0f, imeBottomPx)
+      runOnIdle {
+        assertFalse(DesktopDebugKeyboard.visible)
+        assertEquals(
+          SoftwareKeyboardInteractionResolution.Hidden,
+          controller.interactionState.lastResolution,
+        )
+      }
+    } finally {
+      mainClock.autoAdvance = true
+      runOnIdle {
+        DesktopDebugKeyboard.notifyFocusChanged(owner, isFocused = false)
+        DesktopDebugKeyboard.registerClient(owner, null)
+        DesktopDebugKeyboard.updateHardwareKeyboardConnected(previousHardwareKeyboardConnected)
+        DesktopDebugKeyboard.hideKeyboardSurface()
+      }
+    }
+  }
+
+  @Test
+  fun shownCompletionHasNoGeometryJump() = runComposeUiTest {
+    val owner = Any()
+    val client = RecordingTextInputClient()
+    val previousHardwareKeyboardConnected = DesktopDebugKeyboard.hardwareKeyboardConnected
+    lateinit var controller: SoftwareKeyboardPresentationController
+    var imeBottomPx = 0f
+
+    try {
+      runOnIdle {
+        DesktopDebugKeyboard.updateHardwareKeyboardConnected(false)
+        DesktopDebugKeyboard.hideKeyboardSurface()
+        DesktopDebugKeyboard.registerClient(owner, client)
+        DesktopDebugKeyboard.notifyFocusChanged(owner, isFocused = true)
+      }
+      setContent {
+        CompositionLocalProvider(LocalAppColors provides LightColors) {
+          ProvideSoftwareKeyboardPresentation {
+            ProvideDesktopDebugKeyboardPresentation {
+              val density = LocalDensity.current
+              val currentController = LocalSoftwareKeyboardPresentationController.current
+              val imeBottom = WindowInsets.ime.getBottom(density).toFloat()
+              SideEffect {
+                controller = currentController
+                imeBottomPx = imeBottom
+              }
+              Box(Modifier.size(width = 400.dp, height = 700.dp).testTag(ROOT_TAG)) {
+                DesktopDebugKeyboard.Overlay(
+                  Modifier.align(Alignment.BottomStart)
+                    .padding(bottom = DESKTOP_CHROME_BOTTOM_OFFSET)
+                    .testTag(KEYBOARD_TAG)
+                )
+              }
+            }
+          }
+        }
+      }
+      waitForIdle()
+
+      mainClock.autoAdvance = false
+      val session = runOnIdle { requireNotNull(controller.acquire()) }
+      runOnIdle { session.updateHiddenProgress(0.6f) }
+      mainClock.advanceTimeByFrame()
+      mainClock.advanceTimeByFrame()
+      runOnIdle { session.updateHiddenProgress(0f) }
+      mainClock.advanceTimeByFrame()
+      mainClock.advanceTimeByFrame()
+      waitForIdle()
+      val beforeFinish = imeBottomPx
+
+      runOnIdle { session.finish(SoftwareKeyboardPresentationEndpoint.Shown) }
+      mainClock.advanceTimeByFrame()
+      waitForIdle()
+
+      assertEquals(beforeFinish, imeBottomPx, absoluteTolerance = POSITION_TOLERANCE_PX)
+      assertSurfaceMatchesImeInset(imeBottomPx)
+      runOnIdle {
+        assertEquals(
+          SoftwareKeyboardInteractionResolution.Shown,
+          controller.interactionState.lastResolution,
+        )
+      }
+    } finally {
+      mainClock.autoAdvance = true
+      runOnIdle {
+        DesktopDebugKeyboard.notifyFocusChanged(owner, isFocused = false)
+        DesktopDebugKeyboard.registerClient(owner, null)
+        DesktopDebugKeyboard.updateHardwareKeyboardConnected(previousHardwareKeyboardConnected)
+        DesktopDebugKeyboard.hideKeyboardSurface()
+      }
+    }
+  }
+
+  @Test
+  fun hiddenOrHardwareKeyboardCannotStartAnInteractiveSession() = runComposeUiTest {
+    val previousHardwareKeyboardConnected = DesktopDebugKeyboard.hardwareKeyboardConnected
+    lateinit var controller: SoftwareKeyboardPresentationController
+
+    try {
+      runOnIdle {
+        DesktopDebugKeyboard.updateHardwareKeyboardConnected(false)
+        DesktopDebugKeyboard.hideKeyboardSurface()
+      }
+      setContent {
+        ProvideSoftwareKeyboardPresentation {
+          ProvideDesktopDebugKeyboardPresentation {
+            val currentController = LocalSoftwareKeyboardPresentationController.current
+            SideEffect { controller = currentController }
+            Box(Modifier.fillMaxSize())
+          }
+        }
+      }
+      waitForIdle()
+
+      runOnIdle { assertNull(controller.acquire()) }
+      runOnIdle { DesktopDebugKeyboard.updateHardwareKeyboardConnected(true) }
+      runOnIdle { assertNull(controller.acquire()) }
+    } finally {
+      runOnIdle {
+        DesktopDebugKeyboard.updateHardwareKeyboardConnected(previousHardwareKeyboardConnected)
+        DesktopDebugKeyboard.hideKeyboardSurface()
+      }
+    }
+  }
+
+  private fun androidx.compose.ui.test.ComposeUiTest.assertSurfaceMatchesImeInset(
+    imeBottomPx: Float
+  ) {
+    val root = onNodeWithTag(ROOT_TAG).fetchSemanticsNode().boundsInRoot
+    val keyboard = onNodeWithTag(KEYBOARD_TAG).fetchSemanticsNode().boundsInRoot
+    assertEquals(root.bottom - keyboard.top, imeBottomPx, absoluteTolerance = POSITION_TOLERANCE_PX)
+  }
+}
+
+private class RecordingTextInputClient : TextInputClient {
+  override fun requestFocus() = Unit
+
+  override fun dismiss() = Unit
+}
+
+private val DESKTOP_CHROME_BOTTOM_OFFSET = 12.dp
+private const val POSITION_TOLERANCE_PX = 1.5f
+private const val ROOT_TAG = "desktop-keyboard-root"
+private const val KEYBOARD_TAG = "desktop-keyboard"

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/SoftwareKeyboardNavigationStackDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/SoftwareKeyboardNavigationStackDesktopTest.kt
@@ -1,0 +1,347 @@
+package co.typie.navigation
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalViewConfiguration
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import co.typie.dev.DesktopDebugKeyboard
+import co.typie.dev.ProvideDesktopDebugKeyboardPresentation
+import co.typie.ext.TextInputClient
+import co.typie.ext.ime
+import co.typie.platform.LocalSoftwareKeyboardPresentationController
+import co.typie.platform.ProvideSoftwareKeyboardPresentation
+import co.typie.platform.SoftwareKeyboardInteractionResolution
+import co.typie.platform.SoftwareKeyboardPresentationController
+import co.typie.platform.SoftwareKeyboardPresentationDriver
+import co.typie.platform.SoftwareKeyboardPresentationEndpoint
+import co.typie.route.Route
+import co.typie.ui.component.topbar.TopBarState
+import co.typie.ui.theme.LightColors
+import co.typie.ui.theme.LocalAppColors
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class SoftwareKeyboardNavigationStackDesktopTest {
+  @Test
+  fun committedRouteRetainsItsOutgoingCompositionUntilHiddenResolves() = runComposeUiTest {
+    val navigator = Navigator(Route.Home)
+    val editorRoute = Route.Editor("software-keyboard-async-resolution")
+    val driver = DeferredEndpointDriver()
+    val controller = SoftwareKeyboardPresentationController { driver }
+    var activationDistancePx = 0f
+    var editorAttached = false
+
+    setContent {
+      CompositionLocalProvider(
+        LocalAppColors provides LightColors,
+        LocalSoftwareKeyboardPresentationController provides controller,
+      ) {
+        activationDistancePx =
+          LocalViewConfiguration.current.touchSlop * NAVIGATION_POP_ACTIVATION_SLOP_MULTIPLIER
+        NavigationStackTestHost(
+          navigator = navigator,
+          topBarState = remember { TopBarState() },
+          modifier = Modifier.size(width = 320.dp, height = 640.dp),
+        ) { route ->
+          if (route == editorRoute) {
+            DisposableEffect(Unit) {
+              editorAttached = true
+              onDispose { editorAttached = false }
+            }
+          }
+          Box(
+            Modifier.fillMaxSize()
+              .testTag(if (route == editorRoute) EDITOR_ROUTE_TAG else HOME_ROUTE_TAG)
+          )
+        }
+        LaunchedEffect(Unit) { navigator.navigate(editorRoute) }
+      }
+    }
+    waitUntil { navigator.current == editorRoute && !navigator.isTransitioning }
+
+    onNodeWithTag(EDITOR_ROUTE_TAG).performTouchInput {
+      down(Offset(x = 10f, y = center.y))
+      moveBy(Offset(x = activationDistancePx + 320f, y = 0f), delayMillis = 600L)
+      up()
+    }
+    waitUntil {
+      navigator.current == Route.Home &&
+        driver.endpoint == SoftwareKeyboardPresentationEndpoint.Hidden
+    }
+
+    assertTrue(editorAttached)
+
+    runOnIdle { driver.acceptEndpoint() }
+    waitUntil { !navigator.isTransitioning && !editorAttached }
+  }
+
+  @Test
+  fun backSwipeRestoresTheKeyboardWhenCancelledAndHidesItWhenCommitted() = runComposeUiTest {
+    val owner = Any()
+    val client = KeyboardTestClient()
+    val navigator = Navigator(Route.Home)
+    val editorRoute = Route.Editor("software-keyboard-navigation")
+    val previousHardwareKeyboardConnected = DesktopDebugKeyboard.hardwareKeyboardConnected
+    lateinit var keyboardPresentationController: SoftwareKeyboardPresentationController
+    var activationDistancePx = 0f
+    var imeBottomPx = 0f
+    var imeBottomOffsetPx = 0f
+    var unregisterInterceptor: (() -> Unit)? = null
+    var rollbackCount = 0
+
+    try {
+      runOnIdle {
+        DesktopDebugKeyboard.updateHardwareKeyboardConnected(false)
+        DesktopDebugKeyboard.hideKeyboardSurface()
+        DesktopDebugKeyboard.registerClient(owner, client)
+        DesktopDebugKeyboard.notifyFocusChanged(owner, isFocused = true)
+      }
+      setContent {
+        CompositionLocalProvider(LocalAppColors provides LightColors) {
+          ProvideSoftwareKeyboardPresentation {
+            ProvideDesktopDebugKeyboardPresentation {
+              val density = LocalDensity.current
+              val currentKeyboardPresentationController =
+                LocalSoftwareKeyboardPresentationController.current
+              val imeBottom = WindowInsets.ime.getBottom(density).toFloat()
+              activationDistancePx =
+                LocalViewConfiguration.current.touchSlop * NAVIGATION_POP_ACTIVATION_SLOP_MULTIPLIER
+              SideEffect {
+                imeBottomPx = imeBottom
+                imeBottomOffsetPx = with(density) { DESKTOP_IME_BOTTOM_OFFSET.toPx() }
+                keyboardPresentationController = currentKeyboardPresentationController
+              }
+
+              Box(Modifier.size(width = 320.dp, height = 640.dp).testTag(ROOT_TAG)) {
+                NavigationStackTestHost(
+                  navigator = navigator,
+                  topBarState = remember { TopBarState() },
+                  modifier = Modifier.fillMaxSize(),
+                ) { route ->
+                  Box(
+                    Modifier.fillMaxSize()
+                      .testTag(if (route == editorRoute) EDITOR_ROUTE_TAG else HOME_ROUTE_TAG)
+                  )
+                }
+                DesktopDebugKeyboard.Overlay(
+                  Modifier.align(Alignment.BottomStart).testTag(KEYBOARD_TAG)
+                )
+              }
+            }
+          }
+        }
+        LaunchedEffect(Unit) { navigator.navigate(editorRoute) }
+      }
+      waitUntil { navigator.current == editorRoute && !navigator.isTransitioning }
+
+      val routeNode = onNodeWithTag(EDITOR_ROUTE_TAG)
+      val fullKeyboardHeight = onNodeWithTag(KEYBOARD_TAG).fetchSemanticsNode().boundsInRoot.height
+      val fullImeBottom = imeBottomPx
+
+      routeNode.performTouchInput {
+        down(Offset(x = 10f, y = center.y))
+        moveBy(Offset(x = activationDistancePx - 1f, y = 0f), delayMillis = 100L)
+      }
+      waitForIdle()
+
+      assertEquals(
+        fullKeyboardHeight,
+        onNodeWithTag(KEYBOARD_TAG).fetchSemanticsNode().boundsInRoot.height,
+        absoluteTolerance = GEOMETRY_TOLERANCE_PX,
+      )
+      assertEquals(fullImeBottom, imeBottomPx, absoluteTolerance = GEOMETRY_TOLERANCE_PX)
+
+      routeNode.performTouchInput { moveBy(Offset(x = 80f, y = 0f), delayMillis = 500L) }
+      waitUntil {
+        routeNode.fetchSemanticsNode().boundsInRoot.left > 1f &&
+          onNodeWithTag(KEYBOARD_TAG).fetchSemanticsNode().boundsInRoot.height <
+            fullKeyboardHeight - 1f
+      }
+
+      val routeProgress =
+        routeNode.fetchSemanticsNode().boundsInRoot.left /
+          onNodeWithTag(ROOT_TAG).fetchSemanticsNode().boundsInRoot.width
+      val interactiveKeyboardHeight =
+        onNodeWithTag(KEYBOARD_TAG).fetchSemanticsNode().boundsInRoot.height
+      assertEquals(
+        fullKeyboardHeight * (1f - routeProgress),
+        interactiveKeyboardHeight,
+        absoluteTolerance = GEOMETRY_TOLERANCE_PX,
+      )
+      assertEquals(
+        interactiveKeyboardHeight,
+        imeBottomPx - imeBottomOffsetPx,
+        absoluteTolerance = GEOMETRY_TOLERANCE_PX,
+      )
+
+      routeNode.performTouchInput { up() }
+      waitUntil {
+        navigator.current == editorRoute &&
+          !navigator.isTransitioning &&
+          abs(
+            onNodeWithTag(KEYBOARD_TAG).fetchSemanticsNode().boundsInRoot.height -
+              fullKeyboardHeight
+          ) < GEOMETRY_TOLERANCE_PX
+      }
+
+      assertEquals(fullImeBottom, imeBottomPx, absoluteTolerance = GEOMETRY_TOLERANCE_PX)
+      assertTrue(DesktopDebugKeyboard.visible)
+
+      unregisterInterceptor =
+        navigator.routeRemovals.register(
+          editorRoute,
+          object : RouteRemovalInterceptor {
+            override suspend fun prepare(
+              onDelayed: (suspend () -> Unit)?
+            ): RouteRemovalPreparation {
+              checkNotNull(onDelayed).invoke()
+              return RouteRemovalPreparation.NeedsDecision
+            }
+
+            override suspend fun resolveDecision(): RouteRemovalDecision =
+              RouteRemovalDecision.CancelRemoval
+
+            override suspend fun rollback() {
+              rollbackCount += 1
+            }
+          },
+        )
+      routeNode.performTouchInput {
+        down(Offset(x = 10f, y = center.y))
+        moveBy(Offset(x = activationDistancePx + 320f, y = 0f), delayMillis = 600L)
+      }
+      waitUntil {
+        onAllNodes(hasTestTag(KEYBOARD_TAG)).fetchSemanticsNodes().isEmpty() && imeBottomPx == 0f
+      }
+      assertTrue(keyboardPresentationController.interactionState.unresolved)
+      assertEquals(
+        SoftwareKeyboardInteractionResolution.Shown,
+        keyboardPresentationController.interactionState.lastResolution,
+      )
+
+      routeNode.performTouchInput { up() }
+      waitUntil {
+        rollbackCount == 1 &&
+          navigator.current == editorRoute &&
+          !navigator.isTransitioning &&
+          abs(
+            onNodeWithTag(KEYBOARD_TAG).fetchSemanticsNode().boundsInRoot.height -
+              fullKeyboardHeight
+          ) < GEOMETRY_TOLERANCE_PX
+      }
+
+      assertEquals(fullImeBottom, imeBottomPx, absoluteTolerance = GEOMETRY_TOLERANCE_PX)
+      assertTrue(DesktopDebugKeyboard.visible)
+      assertEquals(
+        SoftwareKeyboardInteractionResolution.Shown,
+        keyboardPresentationController.interactionState.lastResolution,
+      )
+      unregisterInterceptor.invoke()
+      unregisterInterceptor = null
+
+      mainClock.autoAdvance = false
+      routeNode.performTouchInput {
+        down(Offset(x = 10f, y = center.y))
+        moveBy(Offset(x = activationDistancePx + 256f, y = 0f), delayMillis = 600L)
+      }
+      mainClock.advanceTimeByFrame()
+      mainClock.advanceTimeByFrame()
+      waitForIdle()
+
+      var previousKeyboardHeight =
+        onNodeWithTag(KEYBOARD_TAG).fetchSemanticsNode().boundsInRoot.height
+      routeNode.performTouchInput { up() }
+
+      repeat(60) { frame ->
+        mainClock.advanceTimeByFrame()
+        waitForIdle()
+        val currentKeyboardHeight =
+          onAllNodes(hasTestTag(KEYBOARD_TAG))
+            .fetchSemanticsNodes()
+            .firstOrNull()
+            ?.boundsInRoot
+            ?.height ?: 0f
+        assertTrue(
+          currentKeyboardHeight <= previousKeyboardHeight + GEOMETRY_TOLERANCE_PX,
+          "Keyboard rose from $previousKeyboardHeight to $currentKeyboardHeight after release at frame $frame",
+        )
+        previousKeyboardHeight = currentKeyboardHeight
+      }
+
+      assertEquals(Route.Home, navigator.current)
+      assertFalse(navigator.isTransitioning)
+
+      onNodeWithTag(KEYBOARD_TAG).assertDoesNotExist()
+      assertEquals(0f, imeBottomPx)
+      assertFalse(DesktopDebugKeyboard.visible)
+      assertEquals(
+        SoftwareKeyboardInteractionResolution.Hidden,
+        keyboardPresentationController.interactionState.lastResolution,
+      )
+    } finally {
+      mainClock.autoAdvance = true
+      unregisterInterceptor?.invoke()
+      runOnIdle {
+        DesktopDebugKeyboard.notifyFocusChanged(owner, isFocused = false)
+        DesktopDebugKeyboard.registerClient(owner, null)
+        DesktopDebugKeyboard.updateHardwareKeyboardConnected(previousHardwareKeyboardConnected)
+        DesktopDebugKeyboard.hideKeyboardSurface()
+      }
+    }
+  }
+}
+
+private class DeferredEndpointDriver : SoftwareKeyboardPresentationDriver {
+  var endpoint: SoftwareKeyboardPresentationEndpoint? = null
+    private set
+
+  private var acceptance: (() -> Unit)? = null
+
+  override fun updateHiddenProgress(progress: Float) = Unit
+
+  override fun finish(endpoint: SoftwareKeyboardPresentationEndpoint, onAccepted: () -> Unit) {
+    this.endpoint = endpoint
+    acceptance = onAccepted
+  }
+
+  override fun dispose() = Unit
+
+  fun acceptEndpoint() {
+    acceptance?.invoke()
+  }
+}
+
+private class KeyboardTestClient : TextInputClient {
+  override fun requestFocus() = Unit
+
+  override fun dismiss() = Unit
+}
+
+private const val NAVIGATION_POP_ACTIVATION_SLOP_MULTIPLIER = 3f
+private val DESKTOP_IME_BOTTOM_OFFSET = 12.dp
+private const val GEOMETRY_TOLERANCE_PX = 1.5f
+private const val ROOT_TAG = "software-keyboard-navigation-root"
+private const val KEYBOARD_TAG = "software-keyboard-navigation-keyboard"
+private const val EDITOR_ROUTE_TAG = "software-keyboard-navigation-editor"
+private const val HOME_ROUTE_TAG = "software-keyboard-navigation-home"

--- a/apps/mobile/compose/src/iosMain/kotlin/co/typie/platform/SoftwareKeyboardPresentation.ios.kt
+++ b/apps/mobile/compose/src/iosMain/kotlin/co/typie/platform/SoftwareKeyboardPresentation.ios.kt
@@ -1,0 +1,12 @@
+package co.typie.platform
+
+import androidx.compose.runtime.Composable
+
+private val UnavailableSoftwareKeyboardPresentationDriverFactory =
+  SoftwareKeyboardPresentationDriverFactory {
+    null
+  }
+
+@Composable
+internal actual fun rememberSoftwareKeyboardPresentationDriverFactory():
+  SoftwareKeyboardPresentationDriverFactory = UnavailableSoftwareKeyboardPresentationDriverFactory

--- a/apps/mobile/compose/src/iosMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.ios.kt
+++ b/apps/mobile/compose/src/iosMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.ios.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.unit.dp
+import co.typie.platform.LocalSoftwareKeyboardPresentationController
 import platform.Foundation.NSNotificationCenter
 import platform.Foundation.NSOperationQueue
 import platform.GameController.GCKeyboardDidConnectNotification
@@ -29,6 +30,9 @@ internal actual fun rememberEditorKeyboardState(
 ): EditorKeyboardState {
   val editorInputSessionActive = isEditorInputSessionActive()
   val currentEditorInputSessionActive by rememberUpdatedState(editorInputSessionActive)
+  val keyboardInteractionResolver = remember { EditorKeyboardInteractionResolver() }
+  val keyboardInteractionState =
+    LocalSoftwareKeyboardPresentationController.current.interactionState
   val imeHideOwnershipTracker = remember { EditorImeHideOwnershipTracker() }
   var hardwareKeyboardMode by remember { mutableStateOf(isEditorHardwareKeyboardConnected()) }
   var imeFrameVisible by remember { mutableStateOf(false) }
@@ -184,17 +188,21 @@ internal actual fun rememberEditorKeyboardState(
     }
   }
 
-  return EditorKeyboardState(
-    type =
-      if (hardwareKeyboardMode) {
-        EditorKeyboardType.Hardware
-      } else {
-        EditorKeyboardType.Software
-      },
-    imeFrameVisible = imeFrameVisible,
-    imeHideEventVersion = imeHideEventVersion,
-    imeHideEventOwner = imeHideEventOwner,
-    presentation = presentation,
+  return keyboardInteractionResolver.resolve(
+    nativeState =
+      EditorKeyboardState(
+        type =
+          if (hardwareKeyboardMode) {
+            EditorKeyboardType.Hardware
+          } else {
+            EditorKeyboardType.Software
+          },
+        imeFrameVisible = imeFrameVisible,
+        imeHideEventVersion = imeHideEventVersion,
+        imeHideEventOwner = imeHideEventOwner,
+        presentation = presentation,
+      ),
+    interactionState = keyboardInteractionState,
   )
 }
 


### PR DESCRIPTION
- 소프트웨어 키보드 표시 진행률을 제어하는 공통 controller와 contribution session 추가
- 여러 contribution이 동시에 존재할 때 가장 작은 표시 inset을 사용하도록 진행률 합성
- `NavigationStack`의 일반 swipe back과 predictive back 진행률을 키보드 session에 연결
- 전환 취소, 오류 및 route 제거 rollback 시 키보드를 원래 위치로 복원
- route 제거가 성공한 뒤에만 semantic hide를 요청하고, driver가 결과를 확정할 때까지 outgoing route composition 유지
- interactive presentation 중 일시적인 native IME 상태 변화가 에디터의 키보드 의미 상태를 바꾸지 않도록 보존
- Desktop fake keyboard의 surface와 IME inset이 하나의 presented height를 사용하도록 통합
- source input session이 먼저 종료되어도 진행 중인 hide가 중단되거나 키보드가 되올라오지 않도록 처리
- Android와 iOS에는 공통 계약을 위한 platform 경계만 추가하고 실제 driver 구현은 후속 PR로 분리
- 공통 controller, 내비게이션 통합, 에디터 키보드 상태 및 Desktop geometry 회귀 테스트 추가