### PR TITLE
앱 검색 및 메인 탭 전환 시 포커스 처리 수정

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationSoftwareKeyboardInteraction.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationSoftwareKeyboardInteraction.kt
@@ -11,23 +11,39 @@ internal class NavigationSoftwareKeyboardInteraction(
   private val controller: SoftwareKeyboardPresentationController
 ) {
   private var session: SoftwareKeyboardPresentationSession? = null
+  private var hiddenProgressContinuationStart: Float? = null
 
   fun start() {
     if (session != null) return
+    hiddenProgressContinuationStart = null
     session = controller.acquire()
   }
 
   fun updateHiddenProgress(progress: Float) {
-    session?.updateHiddenProgress(progress)
+    val continuationStart = hiddenProgressContinuationStart
+    val effectiveProgress =
+      if (continuationStart == null) {
+        progress
+      } else {
+        continuationStart + (1f - continuationStart) * progress.coerceIn(0f, 1f)
+      }
+    session?.updateHiddenProgress(effectiveProgress)
+  }
+
+  fun continueFromHiddenProgress(progress: Float) {
+    if (session == null) return
+    hiddenProgressContinuationStart = progress.coerceIn(0f, 1f)
   }
 
   fun restore() {
+    hiddenProgressContinuationStart = null
     val activeSession = session ?: return
     session = null
     activeSession.finish(SoftwareKeyboardPresentationEndpoint.Shown)
   }
 
   suspend fun hideAndAwaitResolution(): SoftwareKeyboardInteractionResolution? {
+    hiddenProgressContinuationStart = null
     val activeSession = session ?: return null
     session = null
     val interactionId = activeSession.interactionId
@@ -40,6 +56,7 @@ internal class NavigationSoftwareKeyboardInteraction(
   }
 
   fun dispose() {
+    hiddenProgressContinuationStart = null
     session?.dispose()
     session = null
   }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationStack.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationStack.kt
@@ -207,6 +207,7 @@ fun NavigationStack(
   bottomBarState: BottomBarState? = null,
   modifier: Modifier = Modifier,
   foregroundInteractive: Boolean = true,
+  foregroundFocusEnabled: Boolean = foregroundInteractive,
   content: @Composable (Route) -> Unit,
 ) {
   val themeMode = AppTheme.themeMode
@@ -442,6 +443,9 @@ fun NavigationStack(
         val animatesSeparately = delayed || transitionStyle == RouteTransitionStyle.Fade
         if (animatesSeparately) {
           exitAnimation.cancelAndJoin()
+          if (transitionStyle == RouteTransitionStyle.Fade) {
+            softwareKeyboardInteraction.continueFromHiddenProgress(progress.value)
+          }
           if (!animateRemovalTo(target)) {
             return@coroutineScope performProgressiveRemoval(target)
           }
@@ -791,7 +795,7 @@ fun NavigationStack(
     Box(
       modifier
         .fillMaxSize()
-        .focusProperties { canFocus = foregroundInteractive }
+        .focusProperties { canFocus = foregroundFocusEnabled }
         .onSizeChanged {
           containerWidth = it.width.toFloat()
           containerHeight = it.height.toFloat()

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/home/search/SearchScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/home/search/SearchScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -64,6 +65,8 @@ fun SearchScreen() {
   val model = viewModel { SearchViewModel() }
   val scrollState = rememberScrollState()
   val placeholder = "${model.query.data.site.name.truncate(10)}에서 검색..."
+  val autoFocus = model.initialFocusRequestPending
+  SideEffect { if (autoFocus) model.consumeInitialFocusRequest() }
 
   ProvideTopBar()
 
@@ -80,6 +83,7 @@ fun SearchScreen() {
         placeholder = placeholder,
         onValueChange = { model.setKeyword(it) },
         onSubmit = { model.submitKeyword() },
+        autoFocus = autoFocus,
         modifier = Modifier.fillMaxWidth(),
       )
 
@@ -150,6 +154,7 @@ private fun SearchInputField(
   placeholder: String,
   onValueChange: (String) -> Unit,
   onSubmit: () -> Unit,
+  autoFocus: Boolean,
   modifier: Modifier = Modifier,
 ) {
   TextField(
@@ -159,7 +164,7 @@ private fun SearchInputField(
     modifier = modifier,
     labelPosition = LabelPosition.None,
     placeholder = placeholder,
-    autoFocus = true,
+    autoFocus = autoFocus,
     imeAction = ImeAction.Search,
     platformImeOptions = nativeTextInputPlatformImeOptions(),
     onImeAction = onSubmit,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/home/search/SearchViewModel.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/home/search/SearchViewModel.kt
@@ -19,6 +19,9 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 class SearchViewModel : ViewModel() {
+  internal var initialFocusRequestPending = true
+    private set
+
   var inputKeyword by mutableStateOf("")
     private set
 
@@ -43,6 +46,10 @@ class SearchViewModel : ViewModel() {
     ) {
       SearchScreen_Search_Query(siteId = Preference.siteId!!, query = activeKeyword)
     }
+
+  internal fun consumeInitialFocusRequest() {
+    initialFocusRequestPending = false
+  }
 
   fun setKeyword(keyword: String) {
     inputKeyword = keyword

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/shell/MainShell.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/shell/MainShell.kt
@@ -151,6 +151,7 @@ fun MainShell(content: @Composable (Route) -> Unit) {
           onSettledTab = { tab -> navState.currentTab = tab },
         ) { tab ->
           val foregroundInteractive = tab == settledTab && motion == null && drawerAtRest
+          val foregroundFocusEnabled = tab == settledTab && drawerAtRest
           NavigationStack(
             navigator = navigators[tab]!!,
             topBarState =
@@ -158,6 +159,7 @@ fun MainShell(content: @Composable (Route) -> Unit) {
             bottomBarState =
               if (tab == chromeTab) bottomBarState else backgroundBottomBarStates.getValue(tab),
             foregroundInteractive = foregroundInteractive,
+            foregroundFocusEnabled = foregroundFocusEnabled,
             content = content,
           )
         }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/shell/MainTabPager.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/shell/MainTabPager.kt
@@ -22,7 +22,11 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.Velocity
+import co.typie.platform.LocalSoftwareKeyboardPresentationController
+import co.typie.platform.SoftwareKeyboardPresentationEndpoint
+import co.typie.platform.SoftwareKeyboardPresentationSession
 import kotlin.math.abs
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -248,6 +252,8 @@ internal fun MainTabPager(
   content: @Composable (Tab) -> Unit,
 ) {
   val pagerState = state.pagerState
+  val focusManager = LocalFocusManager.current
+  val softwareKeyboardPresentationController = LocalSoftwareKeyboardPresentationController.current
   val isDirectDrag by pagerState.interactionSource.collectIsDraggedAsState()
   val latestGestureAdmissionAllowed by rememberUpdatedState(gestureAdmissionAllowed)
   val latestOnSettledTab by rememberUpdatedState(onSettledTab)
@@ -271,6 +277,41 @@ internal fun MainTabPager(
       .collect { (_, raw) ->
         state.reconcileRawPager(raw)?.let { settledTab -> latestOnSettledTab(settledTab) }
       }
+  }
+
+  LaunchedEffect(state, softwareKeyboardPresentationController, focusManager) {
+    var origin: Tab? = null
+    var keyboardSession: SoftwareKeyboardPresentationSession? = null
+
+    try {
+      snapshotFlow { Triple(state.motion, state.bodyPosition, state.settledTab) }
+        .collect { (motion, bodyPosition, settledTab) ->
+          if (motion != null) {
+            if (origin == null) {
+              origin = motion.origin
+              keyboardSession = softwareKeyboardPresentationController.acquire()
+            }
+            val activeOrigin = origin ?: return@collect
+            keyboardSession?.updateHiddenProgress(
+              abs(bodyPosition - activeOrigin.ordinal).coerceIn(0f, 1f)
+            )
+            return@collect
+          }
+
+          val activeOrigin = origin ?: return@collect
+          val activeKeyboardSession = keyboardSession
+          origin = null
+          keyboardSession = null
+          if (settledTab == activeOrigin) {
+            activeKeyboardSession?.finish(SoftwareKeyboardPresentationEndpoint.Shown)
+          } else {
+            activeKeyboardSession?.finish(SoftwareKeyboardPresentationEndpoint.Hidden)
+            focusManager.clearFocus(force = true)
+          }
+        }
+    } finally {
+      keyboardSession?.dispose()
+    }
   }
 
   LaunchedEffect(navigationLocked, state.motion?.origin, state.motion != null) {

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/navigation/NavigationSoftwareKeyboardInteractionTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/navigation/NavigationSoftwareKeyboardInteractionTest.kt
@@ -30,6 +30,33 @@ class NavigationSoftwareKeyboardInteractionTest {
   }
 
   @Test
+  fun separateVisualTransitionContinuesFromTheReleasedKeyboardProgress() {
+    val factory = RecordingDriverFactory()
+    val interaction =
+      NavigationSoftwareKeyboardInteraction(SoftwareKeyboardPresentationController(factory))
+
+    interaction.start()
+    interaction.updateHiddenProgress(0.8f)
+    interaction.continueFromHiddenProgress(0.8f)
+    interaction.updateHiddenProgress(0f)
+    interaction.updateHiddenProgress(0.5f)
+    interaction.updateHiddenProgress(1f)
+
+    val firstDriver = requireNotNull(factory.driver)
+    assertEquals(4, firstDriver.progress.size)
+    listOf(0.8f, 0.8f, 0.9f, 1f).zip(firstDriver.progress).forEach { (expected, actual) ->
+      assertEquals(expected, actual, absoluteTolerance = 0.0001f)
+    }
+
+    interaction.restore()
+    firstDriver.acceptEndpoint()
+    interaction.start()
+    interaction.updateHiddenProgress(0.25f)
+
+    assertEquals(listOf(0.25f), requireNotNull(factory.driver).progress)
+  }
+
+  @Test
   fun restoreRemovesOnlyNavigationContributionAndRevealsTheRemainingProgress() {
     val factory = RecordingDriverFactory()
     val controller = SoftwareKeyboardPresentationController(factory)

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/SoftwareKeyboardNavigationStackDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/SoftwareKeyboardNavigationStackDesktopTest.kt
@@ -44,6 +44,72 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalTestApi::class)
 class SoftwareKeyboardNavigationStackDesktopTest {
   @Test
+  fun committedSearchBackSwipeDoesNotRewindKeyboardProgressAfterRelease() = runComposeUiTest {
+    val navigator = Navigator(Route.Home)
+    val driver = ImmediateProgressDriver()
+    val controller = SoftwareKeyboardPresentationController { driver }
+    var activationDistancePx = 0f
+
+    setContent {
+      CompositionLocalProvider(
+        LocalAppColors provides LightColors,
+        LocalSoftwareKeyboardPresentationController provides controller,
+      ) {
+        activationDistancePx =
+          LocalViewConfiguration.current.touchSlop * NAVIGATION_POP_ACTIVATION_SLOP_MULTIPLIER
+        NavigationStackTestHost(
+          navigator = navigator,
+          topBarState = remember { TopBarState() },
+          modifier = Modifier.size(width = 320.dp, height = 640.dp),
+        ) { route ->
+          Box(
+            Modifier.fillMaxSize()
+              .testTag(if (route == Route.Search) SEARCH_ROUTE_TAG else HOME_ROUTE_TAG)
+          )
+        }
+        LaunchedEffect(Unit) { navigator.navigate(Route.Search) }
+      }
+    }
+    waitUntil { navigator.current == Route.Search && !navigator.isTransitioning }
+
+    val routeNode = onNodeWithTag(SEARCH_ROUTE_TAG)
+    mainClock.autoAdvance = false
+    try {
+      routeNode.performTouchInput {
+        down(Offset(x = 10f, y = center.y))
+        moveBy(Offset(x = activationDistancePx + 256f, y = 0f), delayMillis = 600L)
+      }
+      mainClock.advanceTimeByFrame()
+      mainClock.advanceTimeByFrame()
+      waitForIdle()
+
+      var observedProgressCount = driver.progress.size
+      var previousProgress = driver.progress.last()
+      assertTrue(previousProgress > 0.7f)
+
+      routeNode.performTouchInput { up() }
+      repeat(60) { frame ->
+        mainClock.advanceTimeByFrame()
+        waitForIdle()
+        driver.progress.drop(observedProgressCount).forEach { currentProgress ->
+          assertTrue(
+            currentProgress + PROGRESS_TOLERANCE >= previousProgress,
+            "Keyboard progress rewound from $previousProgress to $currentProgress after release at frame $frame",
+          )
+          previousProgress = currentProgress
+        }
+        observedProgressCount = driver.progress.size
+      }
+
+      assertEquals(Route.Home, navigator.current)
+      assertFalse(navigator.isTransitioning)
+      assertEquals(SoftwareKeyboardPresentationEndpoint.Hidden, driver.endpoint)
+    } finally {
+      mainClock.autoAdvance = true
+    }
+  }
+
+  @Test
   fun committedRouteRetainsItsOutgoingCompositionUntilHiddenResolves() = runComposeUiTest {
     val navigator = Navigator(Route.Home)
     val editorRoute = Route.Editor("software-keyboard-async-resolution")
@@ -312,6 +378,23 @@ class SoftwareKeyboardNavigationStackDesktopTest {
   }
 }
 
+private class ImmediateProgressDriver : SoftwareKeyboardPresentationDriver {
+  val progress = mutableListOf<Float>()
+  var endpoint: SoftwareKeyboardPresentationEndpoint? = null
+    private set
+
+  override fun updateHiddenProgress(progress: Float) {
+    this.progress += progress
+  }
+
+  override fun finish(endpoint: SoftwareKeyboardPresentationEndpoint, onAccepted: () -> Unit) {
+    this.endpoint = endpoint
+    onAccepted()
+  }
+
+  override fun dispose() = Unit
+}
+
 private class DeferredEndpointDriver : SoftwareKeyboardPresentationDriver {
   var endpoint: SoftwareKeyboardPresentationEndpoint? = null
     private set
@@ -339,9 +422,11 @@ private class KeyboardTestClient : TextInputClient {
 }
 
 private const val NAVIGATION_POP_ACTIVATION_SLOP_MULTIPLIER = 3f
+private const val PROGRESS_TOLERANCE = 0.0001f
 private val DESKTOP_IME_BOTTOM_OFFSET = 12.dp
 private const val GEOMETRY_TOLERANCE_PX = 1.5f
 private const val ROOT_TAG = "software-keyboard-navigation-root"
 private const val KEYBOARD_TAG = "software-keyboard-navigation-keyboard"
 private const val EDITOR_ROUTE_TAG = "software-keyboard-navigation-editor"
+private const val SEARCH_ROUTE_TAG = "software-keyboard-navigation-search"
 private const val HOME_ROUTE_TAG = "software-keyboard-navigation-home"

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/home/search/SearchScreenDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/home/search/SearchScreenDesktopTest.kt
@@ -1,0 +1,83 @@
+package co.typie.screen.home.search
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertIsNotFocused
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import co.typie.dev.ProvideDesktopDebugKeyboardPresentation
+import co.typie.ui.component.dialog.Dialog
+import co.typie.ui.component.dialog.LocalDialog
+import co.typie.ui.component.sheet.LocalSheet
+import co.typie.ui.component.sheet.Sheet
+import co.typie.ui.theme.LocalThemeMode
+import co.typie.ui.theme.ResolvedThemeMode
+import java.io.File
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class SearchScreenDesktopTest {
+  @Test
+  fun `search input autofocus is not repeated when the same route entry is reexposed`() =
+    runComposeUiTest {
+      configureEditorFfiLibrary()
+      val owner =
+        object : ViewModelStoreOwner {
+          override val viewModelStore = ViewModelStore()
+        }
+      var visible by mutableStateOf(true)
+
+      setContent {
+        val dialog = remember { Dialog() }
+        val sheet = remember { Sheet() }
+        ProvideDesktopDebugKeyboardPresentation {
+          CompositionLocalProvider(
+            LocalViewModelStoreOwner provides owner,
+            LocalThemeMode provides ResolvedThemeMode.Light,
+            LocalDialog provides dialog,
+            LocalSheet provides sheet,
+          ) {
+            if (visible) SearchScreen()
+          }
+        }
+      }
+      waitForIdle()
+
+      onNode(hasSetTextAction(), useUnmergedTree = true).assertIsFocused()
+
+      runOnIdle { visible = false }
+      waitForIdle()
+      runOnIdle { visible = true }
+      waitForIdle()
+
+      onNode(hasSetTextAction(), useUnmergedTree = true).assertIsNotFocused()
+      owner.viewModelStore.clear()
+    }
+
+  private fun configureEditorFfiLibrary() {
+    if (System.getProperty("jna.library.path") != null) return
+
+    val repository =
+      generateSequence(File(System.getProperty("user.dir"))) { it.parentFile }
+        .firstOrNull { File(it, "Cargo.toml").isFile } ?: error("Typie repository root not found")
+    val host =
+      when (System.getProperty("os.arch")) {
+        "aarch64" -> "aarch64-apple-darwin"
+        "x86_64" -> "x86_64-apple-darwin"
+        else -> error("Unsupported desktop test architecture: ${System.getProperty("os.arch")}")
+      }
+    val directory = File(repository, "target/$host/release-uniffi")
+    check(File(directory, "libeditor_ffi.dylib").isFile) {
+      "Desktop editor FFI is not built; run `just -f crates/editor-ffi/justfile desktop`"
+    }
+    System.setProperty("jna.library.path", directory.absolutePath)
+  }
+}

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/shell/MainShellAutofocusDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/shell/MainShellAutofocusDesktopTest.kt
@@ -4,14 +4,17 @@ import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.hasSetTextAction
@@ -42,6 +45,74 @@ import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalTestApi::class)
 class MainShellAutofocusDesktopTest {
+  @Test
+  fun `main tab motion retains source focus and rejects background focus until settle`() =
+    runComposeUiTest {
+      configureEditorFfiLibrary()
+      var selectTab: ((Tab) -> Unit)? = null
+      var currentTab = Tab.Home
+      var isBodyMoving = false
+      var sourceFocused = false
+      var backgroundFocusRequester: FocusRequester? = null
+
+      setContent {
+        val sheet = remember { Sheet() }
+        val dialog = remember { Dialog() }
+        CompositionLocalProvider(
+          LocalThemeMode provides ResolvedThemeMode.Light,
+          LocalSheet provides sheet,
+          LocalDialog provides dialog,
+        ) {
+          MainShell { route ->
+            val tabState = LocalTabState.current
+            SideEffect {
+              selectTab = tabState.onSelectTab
+              currentTab = tabState.currentTab
+              isBodyMoving = tabState.isBodyMoving
+            }
+
+            when (route) {
+              Route.Home -> {
+                val focusRequester = remember { FocusRequester() }
+                BasicTextField(
+                  value = "",
+                  onValueChange = {},
+                  modifier =
+                    Modifier.fillMaxSize().focusRequester(focusRequester).onFocusChanged {
+                      sourceFocused = it.isFocused
+                    },
+                )
+                LaunchedEffect(Unit) { focusRequester.requestFocus() }
+              }
+
+              Route.Space -> {
+                val focusRequester = remember { FocusRequester() }
+                SideEffect { backgroundFocusRequester = focusRequester }
+                Box(Modifier.fillMaxSize().focusRequester(focusRequester).focusable())
+              }
+
+              else -> Unit
+            }
+          }
+        }
+      }
+      waitUntil { sourceFocused && selectTab != null }
+
+      mainClock.autoAdvance = false
+      runOnIdle { requireNotNull(selectTab).invoke(Tab.Space) }
+      repeat(8) { mainClock.advanceTimeByFrame() }
+      runOnIdle {
+        assertTrue(isBodyMoving)
+        assertTrue(sourceFocused)
+        assertFalse(requireNotNull(backgroundFocusRequester).requestFocus())
+        assertTrue(sourceFocused)
+      }
+
+      mainClock.autoAdvance = true
+      waitUntil(timeoutMillis = 5_000L) { currentTab == Tab.Space && !isBodyMoving }
+      runOnIdle { assertFalse(sourceFocused) }
+    }
+
   @Test
   fun `feedback autofocus keeps the software keyboard visible inside main shell`() =
     assertNestedFormAutofocus(Route.Feedback)

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/shell/MainTabPagerDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/shell/MainTabPagerDesktopTest.kt
@@ -6,14 +6,20 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollDispatcher
@@ -30,8 +36,13 @@ import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
+import co.typie.platform.LocalSoftwareKeyboardPresentationController
+import co.typie.platform.SoftwareKeyboardPresentationController
+import co.typie.platform.SoftwareKeyboardPresentationDriver
+import co.typie.platform.SoftwareKeyboardPresentationEndpoint
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.CompletableDeferred
@@ -41,6 +52,112 @@ import kotlinx.coroutines.runBlocking
 
 @OptIn(ExperimentalTestApi::class)
 class MainTabPagerDesktopTest {
+  @Test
+  fun `committed tab swipe hides the keyboard and clears focus only after settle`() =
+    runComposeUiTest {
+      lateinit var state: MainTabState
+      val focusRequester = FocusRequester()
+      val keyboardDriver = RecordingMainTabKeyboardDriver()
+      val controller = SoftwareKeyboardPresentationController { keyboardDriver }
+      var inputFocused = false
+
+      setContent {
+        CompositionLocalProvider(LocalSoftwareKeyboardPresentationController provides controller) {
+          Box(Modifier.size(width = 320.dp, height = 640.dp)) {
+            MainTabPager(
+              state = rememberMainTabState().also { state = it },
+              gestureAdmissionAllowed = true,
+              modifier = Modifier.fillMaxSize().testTag(PagerTag),
+            ) {
+              Box(Modifier.fillMaxSize())
+            }
+            BasicTextField(
+              value = "",
+              onValueChange = {},
+              modifier =
+                Modifier.size(1.dp).focusRequester(focusRequester).onFocusChanged {
+                  inputFocused = it.isFocused
+                },
+            )
+            LaunchedEffect(Unit) { focusRequester.requestFocus() }
+          }
+        }
+      }
+      waitUntil { inputFocused }
+
+      onNodeWithTag(PagerTag).performTouchInput {
+        down(center)
+        repeat(10) { moveBy(Offset(x = -20f, y = 0f), delayMillis = 16L) }
+      }
+      waitUntil { state.motion?.source == MainTabMotionSource.DirectDrag }
+      runOnIdle {
+        assertTrue(inputFocused)
+        assertTrue(keyboardDriver.endpoints.isEmpty())
+        assertTrue(keyboardDriver.progress.any { it > 0f })
+        assertTrue(keyboardDriver.progress.all { it in 0f..1f })
+      }
+
+      onNodeWithTag(PagerTag).performTouchInput { up() }
+      waitUntil(timeoutMillis = 5_000L) { state.motion == null && state.settledTab == Tab.Space }
+
+      runOnIdle {
+        assertFalse(inputFocused)
+        assertEquals(listOf(SoftwareKeyboardPresentationEndpoint.Hidden), keyboardDriver.endpoints)
+      }
+    }
+
+  @Test
+  fun `cancelled tab swipe restores the keyboard without clearing focus`() = runComposeUiTest {
+    lateinit var state: MainTabState
+    val focusRequester = FocusRequester()
+    val keyboardDriver = RecordingMainTabKeyboardDriver()
+    val controller = SoftwareKeyboardPresentationController { keyboardDriver }
+    var inputFocused = false
+
+    setContent {
+      CompositionLocalProvider(LocalSoftwareKeyboardPresentationController provides controller) {
+        Box(Modifier.size(width = 320.dp, height = 640.dp)) {
+          MainTabPager(
+            state = rememberMainTabState().also { state = it },
+            gestureAdmissionAllowed = true,
+            modifier = Modifier.fillMaxSize().testTag(PagerTag),
+          ) {
+            Box(Modifier.fillMaxSize())
+          }
+          BasicTextField(
+            value = "",
+            onValueChange = {},
+            modifier =
+              Modifier.size(1.dp).focusRequester(focusRequester).onFocusChanged {
+                inputFocused = it.isFocused
+              },
+          )
+          LaunchedEffect(Unit) { focusRequester.requestFocus() }
+        }
+      }
+    }
+    waitUntil { inputFocused }
+
+    onNodeWithTag(PagerTag).performTouchInput {
+      down(center)
+      moveBy(Offset(x = -80f, y = 0f), delayMillis = 100L)
+    }
+    waitUntil { state.motion?.source == MainTabMotionSource.DirectDrag }
+    runOnIdle {
+      assertTrue(inputFocused)
+      assertTrue(keyboardDriver.endpoints.isEmpty())
+      assertTrue(keyboardDriver.progress.any { it > 0f })
+    }
+    onNodeWithTag(PagerTag).performTouchInput { up() }
+    waitUntil(timeoutMillis = 5_000L) { state.motion == null }
+
+    runOnIdle {
+      assertEquals(Tab.Home, state.settledTab)
+      assertTrue(inputFocused)
+      assertEquals(listOf(SoftwareKeyboardPresentationEndpoint.Shown), keyboardDriver.endpoints)
+    }
+  }
+
   @Test
   fun `idle pager composes only the visible body`() = runComposeUiTest {
     val composedTabs = mutableSetOf<Tab>()
@@ -416,4 +533,20 @@ class MainTabPagerDesktopTest {
     const val PagerTag = "main-tab-pager"
     val NoOpNestedScrollConnection = object : NestedScrollConnection {}
   }
+}
+
+private class RecordingMainTabKeyboardDriver : SoftwareKeyboardPresentationDriver {
+  val progress = mutableListOf<Float>()
+  val endpoints = mutableListOf<SoftwareKeyboardPresentationEndpoint>()
+
+  override fun updateHiddenProgress(progress: Float) {
+    this.progress += progress
+  }
+
+  override fun finish(endpoint: SoftwareKeyboardPresentationEndpoint, onAccepted: () -> Unit) {
+    endpoints += endpoint
+    onAccepted()
+  }
+
+  override fun dispose() = Unit
 }


### PR DESCRIPTION
- 검색 화면은 최초 진입에서만 autofocus하고 하위 route에서 돌아올 때는 다시 포커스하지 않도록 수정
- 메인 탭 swipe 중 source focus와 키보드 진행률을 유지하고 취소 시 복원
- 다른 탭 전환이 확정된 뒤에만 source focus를 해제하고 키보드를 숨기도록 변경
- Fade route의 back swipe release 뒤 키보드 진행률이 되감기지 않도록 수정