### PR TITLE
앱 에디터 nav pop 확정 후 소프트웨어 키보드 다시 올라오지 않도록 함

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationSoftwareKeyboardInteraction.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationSoftwareKeyboardInteraction.kt
@@ -11,39 +11,23 @@ internal class NavigationSoftwareKeyboardInteraction(
   private val controller: SoftwareKeyboardPresentationController
 ) {
   private var session: SoftwareKeyboardPresentationSession? = null
-  private var hiddenProgressContinuationStart: Float? = null
 
   fun start() {
     if (session != null) return
-    hiddenProgressContinuationStart = null
     session = controller.acquire()
   }
 
   fun updateHiddenProgress(progress: Float) {
-    val continuationStart = hiddenProgressContinuationStart
-    val effectiveProgress =
-      if (continuationStart == null) {
-        progress
-      } else {
-        continuationStart + (1f - continuationStart) * progress.coerceIn(0f, 1f)
-      }
-    session?.updateHiddenProgress(effectiveProgress)
-  }
-
-  fun continueFromHiddenProgress(progress: Float) {
-    if (session == null) return
-    hiddenProgressContinuationStart = progress.coerceIn(0f, 1f)
+    session?.updateHiddenProgress(progress)
   }
 
   fun restore() {
-    hiddenProgressContinuationStart = null
     val activeSession = session ?: return
     session = null
     activeSession.finish(SoftwareKeyboardPresentationEndpoint.Shown)
   }
 
   suspend fun hideAndAwaitResolution(): SoftwareKeyboardInteractionResolution? {
-    hiddenProgressContinuationStart = null
     val activeSession = session ?: return null
     session = null
     val interactionId = activeSession.interactionId
@@ -56,7 +40,6 @@ internal class NavigationSoftwareKeyboardInteraction(
   }
 
   fun dispose() {
-    hiddenProgressContinuationStart = null
     session?.dispose()
     session = null
   }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationStack.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationStack.kt
@@ -72,6 +72,7 @@ import dev.chrisbanes.haze.hazeSource
 import kotlin.math.abs
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
@@ -324,24 +325,32 @@ fun NavigationStack(
     }
   }
 
-  suspend fun settleAtCurrentRoute() {
+  suspend fun settleAtCurrentRoute(restoreKeyboard: Boolean = true) {
     progress.snapTo(0f)
-    softwareKeyboardInteraction.restore()
+    if (restoreKeyboard) softwareKeyboardInteraction.restore()
     visibleRoute = navigator.current
     behindRoute = null
     animState = AnimState.Idle
   }
 
-  suspend fun commitRemovalTo(target: Route) {
+  suspend fun commitRemovalTo(target: Route, committedKeyboardHide: Deferred<Unit>? = null) {
     val removedRoutes = navigator.performPopTo(target)
-    softwareKeyboardInteraction.hideAndAwaitResolution()
+    if (committedKeyboardHide == null) {
+      softwareKeyboardInteraction.hideAndAwaitResolution()
+    } else {
+      committedKeyboardHide.await()
+    }
     visibleRoute = navigator.current
     behindRoute = null
     animState = AnimState.Idle
     clearRemovedRoutes(removedRoutes)
   }
 
-  suspend fun animateRemovalTo(target: Route, verifyPreparedSegment: Boolean = true): Boolean {
+  suspend fun animateRemovalTo(
+    target: Route,
+    verifyPreparedSegment: Boolean = true,
+    committedKeyboardHide: Deferred<Unit>? = null,
+  ): Boolean {
     val requiresTransition = target != navigator.current
     val continuesPopGesture =
       animState == AnimState.PopGestureCommitted &&
@@ -351,7 +360,7 @@ fun NavigationStack(
       if (animState == AnimState.PopGestureCommitted) {
         progress.animateTo(0f, spring(stiffness = StiffnessMediumLow))
       }
-      settleAtCurrentRoute()
+      settleAtCurrentRoute(restoreKeyboard = committedKeyboardHide == null)
     } else {
       transitionStyle = visibleRoute.transitionStyleTo(target)
       behindRoute = target
@@ -366,12 +375,12 @@ fun NavigationStack(
 
     if (verifyPreparedSegment && !navigator.routeRemovals.activeSegmentIsCurrent()) {
       navigator.routeRemovals.rollbackActiveSegment()
-      settleAtCurrentRoute()
+      settleAtCurrentRoute(restoreKeyboard = committedKeyboardHide == null)
       return false
     }
 
     if (!requiresTransition) return true
-    commitRemovalTo(target)
+    commitRemovalTo(target, committedKeyboardHide)
     return true
   }
 
@@ -408,11 +417,16 @@ fun NavigationStack(
       async(start = CoroutineStart.UNDISPATCHED) {
         progress.animateTo(1f, spring(stiffness = StiffnessMediumLow))
       }
+    val committedKeyboardHide =
+      async(start = CoroutineStart.UNDISPATCHED) {
+        softwareKeyboardInteraction.hideAndAwaitResolution()
+        Unit
+      }
 
     suspend fun settleGestureAtCurrentRoute() {
       exitAnimation.cancelAndJoin()
       progress.animateTo(0f, spring(stiffness = StiffnessMediumLow))
-      settleAtCurrentRoute()
+      settleAtCurrentRoute(restoreKeyboard = false)
     }
 
     suspend fun rollbackGestureAndRetry(): NavigationResult {
@@ -421,6 +435,7 @@ fun NavigationStack(
       } finally {
         settleGestureAtCurrentRoute()
       }
+      committedKeyboardHide.await()
       return performProgressiveRemoval(target)
     }
 
@@ -443,10 +458,8 @@ fun NavigationStack(
         val animatesSeparately = delayed || transitionStyle == RouteTransitionStyle.Fade
         if (animatesSeparately) {
           exitAnimation.cancelAndJoin()
-          if (transitionStyle == RouteTransitionStyle.Fade) {
-            softwareKeyboardInteraction.continueFromHiddenProgress(progress.value)
-          }
-          if (!animateRemovalTo(target)) {
+          if (!animateRemovalTo(target, committedKeyboardHide = committedKeyboardHide)) {
+            committedKeyboardHide.await()
             return@coroutineScope performProgressiveRemoval(target)
           }
         } else {
@@ -456,7 +469,7 @@ fun NavigationStack(
           return@coroutineScope rollbackGestureAndRetry()
         }
 
-        if (!animatesSeparately) commitRemovalTo(target)
+        if (!animatesSeparately) commitRemovalTo(target, committedKeyboardHide)
         navigator.routeRemovals.commitSegment()
         return@coroutineScope NavigationResult.ReachedTarget
       }
@@ -470,6 +483,7 @@ fun NavigationStack(
       navigator.routeRemovals.resolveBlockedRoute()?.let {
         return@coroutineScope it
       }
+      committedKeyboardHide.await()
       performProgressiveRemoval(target)
     } catch (throwable: Throwable) {
       withContext(NonCancellable) { settleGestureAtCurrentRoute() }
@@ -603,7 +617,7 @@ fun NavigationStack(
                 // presentation failed; finish the exact prepared removal without another prompt.
                 val removedRoutes = navigator.performPopTo(targetRoute)
                 softwareKeyboardInteraction.hideAndAwaitResolution()
-                settleAtCurrentRoute()
+                settleAtCurrentRoute(restoreKeyboard = false)
                 clearRemovedRoutes(removedRoutes)
                 navigator.consumePopRequest()
                 navigator.completeTransition()
@@ -617,7 +631,9 @@ fun NavigationStack(
                   }
                 val settleFailure =
                   try {
-                    settleAtCurrentRoute()
+                    settleAtCurrentRoute(
+                      restoreKeyboard = currentAnimState != AnimState.PopGestureCommitted
+                    )
                     null
                   } catch (throwable: Throwable) {
                     throwable

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/navigation/NavigationSoftwareKeyboardInteractionTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/navigation/NavigationSoftwareKeyboardInteractionTest.kt
@@ -30,33 +30,6 @@ class NavigationSoftwareKeyboardInteractionTest {
   }
 
   @Test
-  fun separateVisualTransitionContinuesFromTheReleasedKeyboardProgress() {
-    val factory = RecordingDriverFactory()
-    val interaction =
-      NavigationSoftwareKeyboardInteraction(SoftwareKeyboardPresentationController(factory))
-
-    interaction.start()
-    interaction.updateHiddenProgress(0.8f)
-    interaction.continueFromHiddenProgress(0.8f)
-    interaction.updateHiddenProgress(0f)
-    interaction.updateHiddenProgress(0.5f)
-    interaction.updateHiddenProgress(1f)
-
-    val firstDriver = requireNotNull(factory.driver)
-    assertEquals(4, firstDriver.progress.size)
-    listOf(0.8f, 0.8f, 0.9f, 1f).zip(firstDriver.progress).forEach { (expected, actual) ->
-      assertEquals(expected, actual, absoluteTolerance = 0.0001f)
-    }
-
-    interaction.restore()
-    firstDriver.acceptEndpoint()
-    interaction.start()
-    interaction.updateHiddenProgress(0.25f)
-
-    assertEquals(listOf(0.25f), requireNotNull(factory.driver).progress)
-  }
-
-  @Test
   fun restoreRemovesOnlyNavigationContributionAndRevealsTheRemainingProgress() {
     val factory = RecordingDriverFactory()
     val controller = SoftwareKeyboardPresentationController(factory)

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/SoftwareKeyboardNavigationStackDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/SoftwareKeyboardNavigationStackDesktopTest.kt
@@ -293,39 +293,6 @@ class SoftwareKeyboardNavigationStackDesktopTest {
             }
           },
         )
-      routeNode.performTouchInput {
-        down(Offset(x = 10f, y = center.y))
-        moveBy(Offset(x = activationDistancePx + 320f, y = 0f), delayMillis = 600L)
-      }
-      waitUntil {
-        onAllNodes(hasTestTag(KEYBOARD_TAG)).fetchSemanticsNodes().isEmpty() && imeBottomPx == 0f
-      }
-      assertTrue(keyboardPresentationController.interactionState.unresolved)
-      assertEquals(
-        SoftwareKeyboardInteractionResolution.Shown,
-        keyboardPresentationController.interactionState.lastResolution,
-      )
-
-      routeNode.performTouchInput { up() }
-      waitUntil {
-        rollbackCount == 1 &&
-          navigator.current == editorRoute &&
-          !navigator.isTransitioning &&
-          abs(
-            onNodeWithTag(KEYBOARD_TAG).fetchSemanticsNode().boundsInRoot.height -
-              fullKeyboardHeight
-          ) < GEOMETRY_TOLERANCE_PX
-      }
-
-      assertEquals(fullImeBottom, imeBottomPx, absoluteTolerance = GEOMETRY_TOLERANCE_PX)
-      assertTrue(DesktopDebugKeyboard.visible)
-      assertEquals(
-        SoftwareKeyboardInteractionResolution.Shown,
-        keyboardPresentationController.interactionState.lastResolution,
-      )
-      unregisterInterceptor.invoke()
-      unregisterInterceptor = null
-
       mainClock.autoAdvance = false
       routeNode.performTouchInput {
         down(Offset(x = 10f, y = center.y))
@@ -337,7 +304,70 @@ class SoftwareKeyboardNavigationStackDesktopTest {
 
       var previousKeyboardHeight =
         onNodeWithTag(KEYBOARD_TAG).fetchSemanticsNode().boundsInRoot.height
+      assertTrue(previousKeyboardHeight > GEOMETRY_TOLERANCE_PX)
+      assertTrue(keyboardPresentationController.interactionState.unresolved)
+      assertEquals(
+        SoftwareKeyboardInteractionResolution.Shown,
+        keyboardPresentationController.interactionState.lastResolution,
+      )
+
       routeNode.performTouchInput { up() }
+      waitForIdle()
+      assertEquals(
+        previousKeyboardHeight,
+        onNodeWithTag(KEYBOARD_TAG).fetchSemanticsNode().boundsInRoot.height,
+        absoluteTolerance = GEOMETRY_TOLERANCE_PX,
+      )
+      repeat(60) { frame ->
+        mainClock.advanceTimeByFrame()
+        waitForIdle()
+        val currentKeyboardHeight =
+          onAllNodes(hasTestTag(KEYBOARD_TAG))
+            .fetchSemanticsNodes()
+            .firstOrNull()
+            ?.boundsInRoot
+            ?.height ?: 0f
+        assertTrue(
+          currentKeyboardHeight <= previousKeyboardHeight + GEOMETRY_TOLERANCE_PX,
+          "Keyboard rose from $previousKeyboardHeight to $currentKeyboardHeight after committed release at frame $frame",
+        )
+        previousKeyboardHeight = currentKeyboardHeight
+      }
+
+      assertEquals(1, rollbackCount)
+      assertEquals(editorRoute, navigator.current)
+      assertFalse(navigator.isTransitioning)
+      onNodeWithTag(KEYBOARD_TAG).assertDoesNotExist()
+      assertEquals(0f, imeBottomPx)
+      assertFalse(DesktopDebugKeyboard.visible)
+      assertEquals(
+        SoftwareKeyboardInteractionResolution.Hidden,
+        keyboardPresentationController.interactionState.lastResolution,
+      )
+      unregisterInterceptor.invoke()
+      unregisterInterceptor = null
+
+      runOnIdle { DesktopDebugKeyboard.showKeyboard() }
+      repeat(20) {
+        mainClock.advanceTimeByFrame()
+        waitForIdle()
+      }
+      routeNode.performTouchInput {
+        down(Offset(x = 10f, y = center.y))
+        moveBy(Offset(x = activationDistancePx + 256f, y = 0f), delayMillis = 600L)
+      }
+      mainClock.advanceTimeByFrame()
+      mainClock.advanceTimeByFrame()
+      waitForIdle()
+
+      previousKeyboardHeight = onNodeWithTag(KEYBOARD_TAG).fetchSemanticsNode().boundsInRoot.height
+      routeNode.performTouchInput { up() }
+      waitForIdle()
+      assertEquals(
+        previousKeyboardHeight,
+        onNodeWithTag(KEYBOARD_TAG).fetchSemanticsNode().boundsInRoot.height,
+        absoluteTolerance = GEOMETRY_TOLERANCE_PX,
+      )
 
       repeat(60) { frame ->
         mainClock.advanceTimeByFrame()


### PR DESCRIPTION
- pop 확정 즉시 현재 IME inset에서 키보드 숨김 애니메이션 시작
- route 전환 및 저장 보호 처리와 별개로 키보드를 완전히 숨길 때까지 진행
- 저장 보호로 route가 되돌아와도 확정된 키보드 숨김은 취소하지 않도록 변경