### PR TITLE
안드로이드 에디터 찾기 인풋에서 조합 깨지는 문제 수정

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ext/TextInputState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ext/TextInputState.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusState
 import androidx.compose.ui.text.TextRange
@@ -58,7 +59,9 @@ internal constructor(private val binding: TextInputBinding, initialValue: TextFi
   fun update(value: String, onValueChange: (String) -> Unit, onDismiss: () -> Unit) {
     currentOnValueChange = onValueChange
     currentOnDismiss = onDismiss
-    this.value = syncTextInputValue(currentValue = this.value, text = value)
+    this.value = Snapshot.withoutReadObservation {
+      syncTextInputValue(currentValue = this.value, text = value)
+    }
   }
 
   fun onValueChange(value: TextFieldValue) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -119,6 +119,7 @@ import co.typie.editor.sync.ws.replacementSnapshotInFlight
 import co.typie.editor.viewport.consumeEditorViewportTouchPan
 import co.typie.ext.LocalScrollGestureLockState
 import co.typie.ext.ime
+import co.typie.ext.rememberTextInputState
 import co.typie.graphql.QueryState
 import co.typie.navigation.LocalNavigationTopBarSampleRequester
 import co.typie.navigation.Nav
@@ -1244,11 +1245,17 @@ fun EditorScreen(entityId: String) {
 
     when {
       findReplace.active -> {
+        val findInputState =
+          rememberTextInputState(
+            value = findReplace.findText,
+            onValueChange = findReplace.updateFindText,
+            onDismiss = {},
+          )
         ProvideTopBar(
           backdropBlurEnabled = false,
           leading = { FindReplaceTopBarLeading(session = findReplace) },
           leadingKey = FindReplaceTopBarLeadingKey,
-          center = { FindReplaceTopBarCenter(session = findReplace) },
+          center = { FindReplaceTopBarCenter(session = findReplace, inputState = findInputState) },
           centerKey = FindReplaceTopBarCenterKey,
           centerAppearance = TopBarCenterAppearance.ThemeSurface,
           trailing = { FindReplaceTopBarTrailing(session = findReplace) },

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceTopBar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceTopBar.kt
@@ -30,7 +30,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import co.typie.ext.rememberTextInputState
+import co.typie.ext.TextInputState
 import co.typie.ext.textInputFocusable
 import co.typie.icons.Lucide
 import co.typie.ui.component.Text
@@ -58,14 +58,10 @@ internal fun FindReplaceTopBarLeading(session: EditorFindReplaceSession) {
 }
 
 @Composable
-internal fun FindReplaceTopBarCenter(session: EditorFindReplaceSession) {
-  val inputState =
-    rememberTextInputState(
-      value = session.findText,
-      onValueChange = session.updateFindText,
-      onDismiss = {},
-    )
-
+internal fun FindReplaceTopBarCenter(
+  session: EditorFindReplaceSession,
+  inputState: TextInputState,
+) {
   LaunchedEffect(session.active, session.searchInputFocusRequest) {
     if (session.active) {
       inputState.requestFocus()

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceTopBarDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceTopBarDesktopTest.kt
@@ -1,0 +1,126 @@
+package co.typie.screen.editor.editor.findreplace
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import co.typie.dev.DesktopDebugKeyboard
+import co.typie.dev.ProvideDesktopDebugKeyboardPresentation
+import co.typie.ext.rememberTextInputState
+import co.typie.navigation.LocalRoute
+import co.typie.route.Route
+import co.typie.ui.component.topbar.LocalTopBarState
+import co.typie.ui.component.topbar.ProvideTopBar
+import co.typie.ui.component.topbar.TopBar
+import co.typie.ui.component.topbar.TopBarCenterAppearance
+import co.typie.ui.component.topbar.TopBarState
+import co.typie.ui.theme.LightAppShadows
+import co.typie.ui.theme.LightColors
+import co.typie.ui.theme.LocalAppColors
+import co.typie.ui.theme.LocalAppShadows
+import co.typie.ui.theme.LocalThemeMode
+import co.typie.ui.theme.ResolvedThemeMode
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class FindReplaceTopBarDesktopTest {
+  @Test
+  fun `korean composition survives find session snapshot updates`() = runComposeUiTest {
+    val previousHardwareKeyboardConnected = DesktopDebugKeyboard.hardwareKeyboardConnected
+    var findText by mutableStateOf("")
+    var pendingFindText: String? = null
+
+    try {
+      runOnIdle {
+        DesktopDebugKeyboard.updateHardwareKeyboardConnected(false)
+        DesktopDebugKeyboard.hideKeyboardSurface()
+      }
+      setContent {
+        val topBarState = remember { TopBarState() }
+        val session =
+          EditorFindReplaceSession(
+            active = true,
+            findText = findText,
+            replaceText = "",
+            matchWholeWord = false,
+            matchCount = 0,
+            activeMatchNumber = null,
+            searchInputFocusRequest = 0,
+            onOpen = {},
+            close = {},
+            updateFindText = { pendingFindText = it },
+            updateReplaceText = {},
+            updateMatchWholeWord = {},
+            findPrevious = {},
+            findNext = {},
+            replace = {},
+            replaceAll = {},
+          )
+        val inputState =
+          rememberTextInputState(
+            value = session.findText,
+            onValueChange = session.updateFindText,
+            onDismiss = {},
+          )
+
+        CompositionLocalProvider(
+          LocalAppColors provides LightColors,
+          LocalAppShadows provides LightAppShadows,
+          LocalThemeMode provides ResolvedThemeMode.Light,
+          LocalRoute provides Route.Editor("document-id"),
+          LocalTopBarState provides topBarState,
+        ) {
+          ProvideDesktopDebugKeyboardPresentation {
+            Box(Modifier.size(width = 400.dp, height = 700.dp)) {
+              ProvideTopBar(
+                leading = null,
+                center = { FindReplaceTopBarCenter(session = session, inputState = inputState) },
+                centerKey = FindInputKey,
+                centerAppearance = TopBarCenterAppearance.ThemeSurface,
+                trailing = null,
+                scrollOffset = null,
+              )
+              TopBar(state = topBarState)
+              DesktopDebugKeyboard.Overlay(Modifier.fillMaxSize())
+            }
+          }
+        }
+      }
+      waitForIdle()
+
+      onNodeWithText("kr 뀨♡", useUnmergedTree = true).performTouchInput { click() }
+      waitForIdle()
+      runOnIdle {
+        findText = checkNotNull(pendingFindText)
+        pendingFindText = null
+      }
+      waitForIdle()
+      onNodeWithText("kr 뀨♡", useUnmergedTree = true).performTouchInput { click() }
+      waitForIdle()
+
+      onNode(hasSetTextAction(), useUnmergedTree = true).assertTextEquals("아")
+    } finally {
+      runOnIdle {
+        DesktopDebugKeyboard.updateHardwareKeyboardConnected(previousHardwareKeyboardConnected)
+        DesktopDebugKeyboard.hideKeyboardSurface()
+      }
+    }
+  }
+
+  private companion object {
+    val FindInputKey = Any()
+  }
+}


### PR DESCRIPTION
- 찾기 입력 상태를 에디터 화면에서 소유하고 top bar에서는 렌더링만 하도록 변경
- 세션 검색어 반영이 늦더라도 로컬 IME 조합 범위가 유지되도록 수정
- `ㅇ → 아` 한글 조합 회귀 테스트 추가