### PR TITLE
안드로이드 nav pop swipe에 소프트웨어 키보드 연동

### DIFF
--- a/apps/mobile/compose/src/androidHostTest/kotlin/co/typie/platform/AndroidSoftwareKeyboardPresentationTest.kt
+++ b/apps/mobile/compose/src/androidHostTest/kotlin/co/typie/platform/AndroidSoftwareKeyboardPresentationTest.kt
@@ -1,0 +1,445 @@
+package co.typie.platform
+
+import androidx.core.graphics.Insets
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AndroidSoftwareKeyboardPresentationTest {
+  @Test
+  fun latestPendingProgressIsAppliedAcrossEveryInsetEdgeWhenControlBecomesReady() {
+    val driver =
+      AndroidSoftwareKeyboardPresentationDriver(
+        onInvalidated = {},
+        cancelControl = {},
+        hideIme = {},
+        isImeVisible = { true },
+      )
+    val control =
+      RecordingAndroidImeAnimationControl(
+        hiddenStateInsets = Insets.of(2, 4, 6, 8),
+        shownStateInsets = Insets.of(10, 20, 30, 40),
+        currentAlpha = 0.4f,
+      )
+
+    driver.updateHiddenProgress(0.25f)
+    driver.updateHiddenProgress(0.75f)
+    driver.onReady(control)
+
+    assertEquals(
+      listOf(AndroidImeFrame(Insets.of(4, 8, 12, 16), alpha = 0.4f, fraction = 0.25f)),
+      control.frames,
+    )
+  }
+
+  @Test
+  fun completedEndpointAnimationFinishesAtTheRequestedEndpointBeforeAcceptingIt() {
+    for ((endpoint, shown) in
+      listOf(
+        SoftwareKeyboardPresentationEndpoint.Shown to true,
+        SoftwareKeyboardPresentationEndpoint.Hidden to false,
+      )) {
+      val driver =
+        AndroidSoftwareKeyboardPresentationDriver(
+          onInvalidated = {},
+          cancelControl = {},
+          hideIme = {},
+          isImeVisible = { true },
+          endpointAnimator = ImmediateAndroidImeEndpointAnimator,
+        )
+      val control = RecordingAndroidImeAnimationControl()
+      var accepted = false
+      driver.onReady(control)
+
+      driver.finish(endpoint) {
+        assertEquals(listOf(shown), control.finishes)
+        accepted = true
+      }
+
+      assertTrue(accepted)
+    }
+  }
+
+  @Test
+  fun terminalRequestContinuesFromCurrentProgressBeforeFinishingControl() {
+    val endpointAnimator = ManualAndroidImeEndpointAnimator()
+    val driver =
+      AndroidSoftwareKeyboardPresentationDriver(
+        onInvalidated = {},
+        cancelControl = {},
+        hideIme = {},
+        isImeVisible = { true },
+        endpointAnimator = endpointAnimator,
+      )
+    val control =
+      RecordingAndroidImeAnimationControl(
+        hiddenStateInsets = Insets.NONE,
+        shownStateInsets = Insets.of(0, 0, 0, 100),
+      )
+    var accepted = false
+    driver.updateHiddenProgress(0.6f)
+    driver.onReady(control)
+
+    driver.finish(SoftwareKeyboardPresentationEndpoint.Hidden) { accepted = true }
+
+    assertEquals(0.6f, endpointAnimator.fromHiddenProgress)
+    assertEquals(1f, endpointAnimator.toHiddenProgress)
+    assertTrue(control.finishes.isEmpty())
+    assertFalse(accepted)
+
+    endpointAnimator.updateProgress(0.8f)
+
+    assertEquals(Insets.of(0, 0, 0, 20), control.frames.last().insets)
+    assertTrue(control.finishes.isEmpty())
+    assertFalse(accepted)
+
+    endpointAnimator.finish()
+
+    assertEquals(Insets.NONE, control.frames.last().insets)
+    assertEquals(listOf(false), control.finishes)
+    assertTrue(accepted)
+  }
+
+  @Test
+  fun terminalRequestBeforeReadinessAnimatesFromTheLatestProgressWhenControlArrives() {
+    for ((endpoint, shown) in
+      listOf(
+        SoftwareKeyboardPresentationEndpoint.Shown to true,
+        SoftwareKeyboardPresentationEndpoint.Hidden to false,
+      )) {
+      val endpointAnimator = ManualAndroidImeEndpointAnimator()
+      val driver =
+        AndroidSoftwareKeyboardPresentationDriver(
+          onInvalidated = {},
+          cancelControl = {},
+          hideIme = {},
+          isImeVisible = { true },
+          endpointAnimator = endpointAnimator,
+        )
+      val control = RecordingAndroidImeAnimationControl()
+      var accepted = false
+      driver.updateHiddenProgress(0.6f)
+
+      driver.finish(endpoint) { accepted = true }
+      driver.onReady(control)
+
+      assertEquals(0.6f, endpointAnimator.fromHiddenProgress)
+      assertEquals(if (shown) 0f else 1f, endpointAnimator.toHiddenProgress)
+      assertTrue(control.finishes.isEmpty())
+      assertFalse(accepted)
+
+      endpointAnimator.finish()
+
+      assertEquals(listOf(shown), control.finishes)
+      assertTrue(accepted)
+    }
+  }
+
+  @Test
+  fun cancellationBeforeReadinessInvalidatesOnceAndIgnoresLateReadiness() {
+    var invalidations = 0
+    val driver =
+      AndroidSoftwareKeyboardPresentationDriver(
+        onInvalidated = { invalidations += 1 },
+        cancelControl = {},
+        hideIme = {},
+        isImeVisible = { true },
+      )
+    val lateControl = RecordingAndroidImeAnimationControl()
+
+    driver.onCancelled()
+    driver.onCancelled()
+    driver.updateHiddenProgress(0.8f)
+    driver.onReady(lateControl)
+
+    assertEquals(1, invalidations)
+    assertTrue(lateControl.frames.isEmpty())
+    assertTrue(lateControl.finishes.isEmpty())
+  }
+
+  @Test
+  fun cancellationAfterHiddenRequestFallsBackToHideBeforeAcceptingIt() {
+    val events = mutableListOf<String>()
+    var invalidations = 0
+    val driver =
+      AndroidSoftwareKeyboardPresentationDriver(
+        onInvalidated = { invalidations += 1 },
+        cancelControl = {},
+        hideIme = { events += "hide" },
+        isImeVisible = { true },
+        endpointAnimator = ImmediateAndroidImeEndpointAnimator,
+      )
+
+    driver.finish(SoftwareKeyboardPresentationEndpoint.Hidden) { events += "accepted" }
+    driver.onCancelled()
+    driver.onCancelled()
+
+    assertEquals(listOf("hide", "accepted"), events)
+    assertEquals(0, invalidations)
+  }
+
+  @Test
+  fun cancellationAfterShownRequestIsAcceptedOnlyIfTheImeIsVisible() {
+    for (imeVisible in listOf(true, false)) {
+      var accepted = false
+      var invalidations = 0
+      val driver =
+        AndroidSoftwareKeyboardPresentationDriver(
+          onInvalidated = { invalidations += 1 },
+          cancelControl = {},
+          hideIme = {},
+          isImeVisible = { imeVisible },
+        )
+
+      driver.finish(SoftwareKeyboardPresentationEndpoint.Shown) { accepted = true }
+      driver.onCancelled()
+
+      assertEquals(imeVisible, accepted)
+      assertEquals(if (imeVisible) 0 else 1, invalidations)
+    }
+  }
+
+  @Test
+  fun synchronousCancellationDuringProgressCannotReviveTheDriver() {
+    var invalidations = 0
+    lateinit var driver: AndroidSoftwareKeyboardPresentationDriver
+    val control = RecordingAndroidImeAnimationControl()
+    driver =
+      AndroidSoftwareKeyboardPresentationDriver(
+        onInvalidated = { invalidations += 1 },
+        cancelControl = {},
+        hideIme = {},
+        isImeVisible = { true },
+      )
+    driver.onReady(control)
+    control.onSetInsetsAndAlpha = driver::onCancelled
+
+    driver.updateHiddenProgress(0.5f)
+    driver.updateHiddenProgress(0.75f)
+
+    assertEquals(1, invalidations)
+    assertEquals(2, control.frames.size)
+  }
+
+  @Test
+  fun synchronousCancellationDuringFinishAcceptsTheTerminalRequestOnce() {
+    val events = mutableListOf<String>()
+    lateinit var driver: AndroidSoftwareKeyboardPresentationDriver
+    val control = RecordingAndroidImeAnimationControl()
+    driver =
+      AndroidSoftwareKeyboardPresentationDriver(
+        onInvalidated = { events += "invalidated" },
+        cancelControl = {},
+        hideIme = { events += "hide" },
+        isImeVisible = { true },
+        endpointAnimator = ImmediateAndroidImeEndpointAnimator,
+      )
+    driver.onReady(control)
+    control.onFinish = {
+      events += "finish"
+      driver.onCancelled()
+    }
+
+    driver.finish(SoftwareKeyboardPresentationEndpoint.Hidden) { events += "accepted" }
+    driver.onCancelled()
+
+    assertEquals(listOf("finish", "hide", "accepted"), events)
+  }
+
+  @Test
+  fun disposalCancelsControlOnceAndMakesSynchronousAndLateCallbacksHarmless() {
+    var cancellations = 0
+    var invalidations = 0
+    lateinit var driver: AndroidSoftwareKeyboardPresentationDriver
+    val lateControl = RecordingAndroidImeAnimationControl().apply { isReady = false }
+    driver =
+      AndroidSoftwareKeyboardPresentationDriver(
+        onInvalidated = { invalidations += 1 },
+        cancelControl = {
+          cancellations += 1
+          driver.onCancelled()
+        },
+        hideIme = {},
+        isImeVisible = { true },
+      )
+
+    driver.dispose()
+    driver.dispose()
+    driver.onReady(lateControl)
+    driver.updateHiddenProgress(0.5f)
+
+    assertEquals(1, cancellations)
+    assertEquals(0, invalidations)
+    assertTrue(lateControl.frames.isEmpty())
+  }
+
+  @Test
+  fun successfulPlatformFinishAcceptsTheTerminalRequestOnce() {
+    var acceptances = 0
+    var invalidations = 0
+    lateinit var driver: AndroidSoftwareKeyboardPresentationDriver
+    val control = RecordingAndroidImeAnimationControl()
+    driver =
+      AndroidSoftwareKeyboardPresentationDriver(
+        onInvalidated = { invalidations += 1 },
+        cancelControl = {},
+        hideIme = {},
+        isImeVisible = { true },
+        endpointAnimator = ImmediateAndroidImeEndpointAnimator,
+      )
+    control.onFinish = driver::onFinished
+    driver.finish(SoftwareKeyboardPresentationEndpoint.Shown) { acceptances += 1 }
+
+    driver.onReady(control)
+    driver.onFinished()
+
+    assertEquals(1, acceptances)
+    assertEquals(0, invalidations)
+  }
+
+  @Test
+  fun unexpectedPlatformFinishInvalidatesTheActiveDriverOnce() {
+    var invalidations = 0
+    val driver =
+      AndroidSoftwareKeyboardPresentationDriver(
+        onInvalidated = { invalidations += 1 },
+        cancelControl = {},
+        hideIme = {},
+        isImeVisible = { true },
+      )
+
+    driver.onFinished()
+    driver.onFinished()
+
+    assertEquals(1, invalidations)
+  }
+
+  @Test
+  fun notReadyControlAfterHiddenRequestUsesTheCancellationFallback() {
+    val events = mutableListOf<String>()
+    val control = RecordingAndroidImeAnimationControl().apply { isReady = false }
+    val driver =
+      AndroidSoftwareKeyboardPresentationDriver(
+        onInvalidated = { events += "invalidated" },
+        cancelControl = {},
+        hideIme = { events += "hide" },
+        isImeVisible = { true },
+        endpointAnimator = ImmediateAndroidImeEndpointAnimator,
+      )
+    driver.finish(SoftwareKeyboardPresentationEndpoint.Hidden) { events += "accepted" }
+
+    driver.onReady(control)
+
+    assertEquals(listOf("hide", "accepted"), events)
+  }
+
+  @Test
+  fun failureApplyingPendingProgressInvalidatesWithoutEscapingTheReadinessCallback() {
+    var invalidations = 0
+    val control =
+      RecordingAndroidImeAnimationControl().apply {
+        onSetInsetsAndAlpha = { error("control was cancelled") }
+      }
+    val driver =
+      AndroidSoftwareKeyboardPresentationDriver(
+        onInvalidated = { invalidations += 1 },
+        cancelControl = {},
+        hideIme = {},
+        isImeVisible = { true },
+      )
+    driver.updateHiddenProgress(0.5f)
+
+    driver.onReady(control)
+    driver.updateHiddenProgress(0.75f)
+
+    assertEquals(1, invalidations)
+    assertEquals(1, control.frames.size)
+  }
+
+  @Test
+  fun failureFinishingAfterReadinessUsesTheRequestedEndpointFallback() {
+    val events = mutableListOf<String>()
+    val control = RecordingAndroidImeAnimationControl().apply { onFinish = { error("cancelled") } }
+    val driver =
+      AndroidSoftwareKeyboardPresentationDriver(
+        onInvalidated = { events += "invalidated" },
+        cancelControl = {},
+        hideIme = { events += "hide" },
+        isImeVisible = { true },
+        endpointAnimator = ImmediateAndroidImeEndpointAnimator,
+      )
+    driver.finish(SoftwareKeyboardPresentationEndpoint.Hidden) { events += "accepted" }
+
+    driver.onReady(control)
+
+    assertEquals(listOf("hide", "accepted"), events)
+  }
+}
+
+private data class AndroidImeFrame(val insets: Insets, val alpha: Float, val fraction: Float)
+
+private val ImmediateAndroidImeEndpointAnimator =
+  AndroidImeEndpointAnimator { _, toHiddenProgress, onProgress, onFinished ->
+    onProgress(toHiddenProgress)
+    onFinished()
+    AndroidImeEndpointAnimation {}
+  }
+
+private class ManualAndroidImeEndpointAnimator : AndroidImeEndpointAnimator {
+  var fromHiddenProgress: Float? = null
+    private set
+
+  var toHiddenProgress: Float? = null
+    private set
+
+  private var onProgress: ((Float) -> Unit)? = null
+  private var onFinished: (() -> Unit)? = null
+
+  override fun animate(
+    fromHiddenProgress: Float,
+    toHiddenProgress: Float,
+    onProgress: (Float) -> Unit,
+    onFinished: () -> Unit,
+  ): AndroidImeEndpointAnimation {
+    this.fromHiddenProgress = fromHiddenProgress
+    this.toHiddenProgress = toHiddenProgress
+    this.onProgress = onProgress
+    this.onFinished = onFinished
+    return AndroidImeEndpointAnimation {
+      this.onProgress = null
+      this.onFinished = null
+    }
+  }
+
+  fun updateProgress(hiddenProgress: Float) {
+    checkNotNull(onProgress).invoke(hiddenProgress)
+  }
+
+  fun finish() {
+    updateProgress(checkNotNull(toHiddenProgress))
+    checkNotNull(onFinished).invoke()
+  }
+}
+
+private class RecordingAndroidImeAnimationControl(
+  override val hiddenStateInsets: Insets = Insets.NONE,
+  override val shownStateInsets: Insets = Insets.NONE,
+  override val currentAlpha: Float = 1f,
+) : AndroidImeAnimationControl {
+  override var isReady: Boolean = true
+  var onSetInsetsAndAlpha: () -> Unit = {}
+  var onFinish: () -> Unit = {}
+  val frames = mutableListOf<AndroidImeFrame>()
+  val finishes = mutableListOf<Boolean>()
+
+  override fun setInsetsAndAlpha(insets: Insets, alpha: Float, fraction: Float) {
+    frames += AndroidImeFrame(insets, alpha, fraction)
+    onSetInsetsAndAlpha()
+  }
+
+  override fun finish(shown: Boolean) {
+    finishes += shown
+    onFinish()
+  }
+}

--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/platform/SoftwareKeyboardPresentation.android.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/platform/SoftwareKeyboardPresentation.android.kt
@@ -1,6 +1,289 @@
 package co.typie.platform
 
+import android.animation.Animator
+import android.animation.AnimatorListenerAdapter
+import android.animation.ValueAnimator
+import android.os.Build
+import android.os.CancellationSignal
+import android.view.View
+import android.view.animation.PathInterpolator
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalView
+import androidx.core.graphics.Insets
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsAnimationControlListenerCompat
+import androidx.core.view.WindowInsetsAnimationControllerCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
+import kotlin.math.roundToInt
+
+internal fun interface AndroidImeEndpointAnimation {
+  fun cancel()
+}
+
+internal fun interface AndroidImeEndpointAnimator {
+  fun animate(
+    fromHiddenProgress: Float,
+    toHiddenProgress: Float,
+    onProgress: (Float) -> Unit,
+    onFinished: () -> Unit,
+  ): AndroidImeEndpointAnimation
+}
+
+private object ValueAnimatorAndroidImeEndpointAnimator : AndroidImeEndpointAnimator {
+  override fun animate(
+    fromHiddenProgress: Float,
+    toHiddenProgress: Float,
+    onProgress: (Float) -> Unit,
+    onFinished: () -> Unit,
+  ): AndroidImeEndpointAnimation {
+    if (fromHiddenProgress == toHiddenProgress) {
+      onProgress(toHiddenProgress)
+      onFinished()
+      return AndroidImeEndpointAnimation {}
+    }
+
+    var cancelled = false
+    val animator =
+      ValueAnimator.ofFloat(fromHiddenProgress, toHiddenProgress).apply {
+        duration = AndroidImeEndpointAnimationDurationMillis
+        interpolator = PathInterpolator(0.4f, 0f, 0.2f, 1f)
+        addUpdateListener { onProgress(it.animatedValue as Float) }
+        addListener(
+          object : AnimatorListenerAdapter() {
+            override fun onAnimationCancel(animation: Animator) {
+              cancelled = true
+            }
+
+            override fun onAnimationEnd(animation: Animator) {
+              if (!cancelled) onFinished()
+            }
+          }
+        )
+        start()
+      }
+    return AndroidImeEndpointAnimation(animator::cancel)
+  }
+}
+
+internal interface AndroidImeAnimationControl {
+  val hiddenStateInsets: Insets
+  val shownStateInsets: Insets
+  val currentAlpha: Float
+  val isReady: Boolean
+
+  fun setInsetsAndAlpha(insets: Insets, alpha: Float, fraction: Float)
+
+  fun finish(shown: Boolean)
+}
+
+internal class AndroidSoftwareKeyboardPresentationDriver(
+  private val onInvalidated: () -> Unit,
+  private val cancelControl: () -> Unit,
+  private val hideIme: () -> Unit,
+  private val isImeVisible: () -> Boolean,
+  private val endpointAnimator: AndroidImeEndpointAnimator = ValueAnimatorAndroidImeEndpointAnimator,
+) : SoftwareKeyboardPresentationDriver {
+  private sealed interface Lifecycle {
+    class Pending(var hiddenProgress: Float) : Lifecycle
+
+    class Ready(val control: AndroidImeAnimationControl, var hiddenProgress: Float) : Lifecycle
+
+    class Terminal(
+      val endpoint: SoftwareKeyboardPresentationEndpoint,
+      val onAccepted: () -> Unit,
+      var hiddenProgress: Float,
+      var animation: AndroidImeEndpointAnimation? = null,
+    ) : Lifecycle
+
+    data object Closed : Lifecycle
+  }
+
+  private var lifecycle: Lifecycle = Lifecycle.Pending(hiddenProgress = 0f)
+
+  override fun updateHiddenProgress(progress: Float) {
+    val hiddenProgress = progress.coerceIn(0f, 1f)
+    when (val current = lifecycle) {
+      is Lifecycle.Pending -> current.hiddenProgress = hiddenProgress
+      is Lifecycle.Ready -> {
+        current.hiddenProgress = hiddenProgress
+        applyHiddenProgress(current)
+      }
+      is Lifecycle.Terminal,
+      Lifecycle.Closed -> Unit
+    }
+  }
+
+  override fun finish(endpoint: SoftwareKeyboardPresentationEndpoint, onAccepted: () -> Unit) {
+    when (val current = lifecycle) {
+      is Lifecycle.Pending ->
+        lifecycle = Lifecycle.Terminal(endpoint, onAccepted, current.hiddenProgress)
+      is Lifecycle.Ready -> {
+        val terminal = Lifecycle.Terminal(endpoint, onAccepted, current.hiddenProgress)
+        lifecycle = terminal
+        animateControlToEndpoint(control = current.control, terminal = terminal)
+      }
+      is Lifecycle.Terminal,
+      Lifecycle.Closed -> Unit
+    }
+  }
+
+  override fun dispose() {
+    val current = lifecycle
+    if (current == Lifecycle.Closed) return
+    lifecycle = Lifecycle.Closed
+    if (current is Lifecycle.Terminal) current.animation?.cancel()
+    cancelControl()
+  }
+
+  fun onCancelled() {
+    when (val current = lifecycle) {
+      is Lifecycle.Pending,
+      is Lifecycle.Ready -> {
+        lifecycle = Lifecycle.Closed
+        onInvalidated()
+      }
+      is Lifecycle.Terminal -> {
+        lifecycle = Lifecycle.Closed
+        current.animation?.cancel()
+        val accepted =
+          runCatching {
+              when (current.endpoint) {
+                SoftwareKeyboardPresentationEndpoint.Shown -> isImeVisible()
+                SoftwareKeyboardPresentationEndpoint.Hidden -> {
+                  hideIme()
+                  true
+                }
+              }
+            }
+            .getOrDefault(false)
+        if (accepted) current.onAccepted() else onInvalidated()
+      }
+      Lifecycle.Closed -> Unit
+    }
+  }
+
+  fun onReady(control: AndroidImeAnimationControl) {
+    when (val current = lifecycle) {
+      is Lifecycle.Pending -> {
+        if (!control.isReady) {
+          onCancelled()
+          return
+        }
+        val ready = Lifecycle.Ready(control = control, hiddenProgress = current.hiddenProgress)
+        lifecycle = ready
+        if (runCatching { applyHiddenProgress(ready) }.isFailure && lifecycle === ready) {
+          onCancelled()
+        }
+      }
+      is Lifecycle.Terminal -> {
+        if (!control.isReady) {
+          onCancelled()
+          return
+        }
+        if (
+          runCatching { animateControlToEndpoint(control = control, terminal = current) }
+            .isFailure && lifecycle === current
+        ) {
+          onCancelled()
+        }
+      }
+      is Lifecycle.Ready,
+      Lifecycle.Closed -> Unit
+    }
+  }
+
+  fun onFinished() {
+    when (val current = lifecycle) {
+      is Lifecycle.Pending,
+      is Lifecycle.Ready -> {
+        lifecycle = Lifecycle.Closed
+        onInvalidated()
+      }
+      is Lifecycle.Terminal -> {
+        current.animation?.cancel()
+        acceptTerminal(current)
+      }
+      Lifecycle.Closed -> Unit
+    }
+  }
+
+  private fun animateControlToEndpoint(
+    control: AndroidImeAnimationControl,
+    terminal: Lifecycle.Terminal,
+  ) {
+    val animation =
+      endpointAnimator.animate(
+        fromHiddenProgress = terminal.hiddenProgress,
+        toHiddenProgress = terminal.endpoint.hiddenProgress,
+        onProgress = { hiddenProgress ->
+          if (lifecycle !== terminal) return@animate
+          terminal.hiddenProgress = hiddenProgress
+          if (runCatching { applyHiddenProgress(control, hiddenProgress) }.isFailure) {
+            onCancelled()
+          }
+        },
+        onFinished = {
+          if (lifecycle !== terminal) return@animate
+          terminal.animation = null
+          if (
+            runCatching {
+                control.finish(
+                  shown = terminal.endpoint == SoftwareKeyboardPresentationEndpoint.Shown
+                )
+              }
+              .isFailure
+          ) {
+            onCancelled()
+          } else {
+            acceptTerminal(terminal)
+          }
+        },
+      )
+    if (lifecycle === terminal) {
+      terminal.animation = animation
+    } else {
+      animation.cancel()
+    }
+  }
+
+  private fun acceptTerminal(terminal: Lifecycle.Terminal) {
+    if (lifecycle !== terminal) return
+    lifecycle = Lifecycle.Closed
+    terminal.onAccepted()
+  }
+
+  private fun applyHiddenProgress(ready: Lifecycle.Ready) {
+    applyHiddenProgress(ready.control, ready.hiddenProgress)
+  }
+
+  private fun applyHiddenProgress(control: AndroidImeAnimationControl, hiddenProgress: Float) {
+    val shownFraction = 1f - hiddenProgress
+    val shown = control.shownStateInsets
+    val hidden = control.hiddenStateInsets
+    control.setInsetsAndAlpha(
+      insets =
+        Insets.of(
+          shown.left.interpolateTo(hidden.left, hiddenProgress),
+          shown.top.interpolateTo(hidden.top, hiddenProgress),
+          shown.right.interpolateTo(hidden.right, hiddenProgress),
+          shown.bottom.interpolateTo(hidden.bottom, hiddenProgress),
+        ),
+      alpha = control.currentAlpha,
+      fraction = shownFraction,
+    )
+  }
+
+  private fun Int.interpolateTo(target: Int, fraction: Float): Int =
+    (this + (target - this) * fraction).roundToInt()
+}
+
+private val SoftwareKeyboardPresentationEndpoint.hiddenProgress: Float
+  get() = if (this == SoftwareKeyboardPresentationEndpoint.Hidden) 1f else 0f
+
+private const val AndroidImeEndpointAnimationDurationMillis = 220L
 
 private val UnavailableSoftwareKeyboardPresentationDriverFactory =
   SoftwareKeyboardPresentationDriverFactory {
@@ -9,4 +292,96 @@ private val UnavailableSoftwareKeyboardPresentationDriverFactory =
 
 @Composable
 internal actual fun rememberSoftwareKeyboardPresentationDriverFactory():
-  SoftwareKeyboardPresentationDriverFactory = UnavailableSoftwareKeyboardPresentationDriverFactory
+  SoftwareKeyboardPresentationDriverFactory {
+  if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+    return UnavailableSoftwareKeyboardPresentationDriverFactory
+  }
+
+  val activity = activityContext()
+  val view = LocalView.current
+  return remember(activity, view) {
+    val insetsController = WindowCompat.getInsetsController(activity.window, view)
+    SoftwareKeyboardPresentationDriverFactory { onInvalidated ->
+      acquireAndroidSoftwareKeyboardPresentationDriver(
+        view = view,
+        insetsController = insetsController,
+        onInvalidated = onInvalidated,
+      )
+    }
+  }
+}
+
+private fun acquireAndroidSoftwareKeyboardPresentationDriver(
+  view: View,
+  insetsController: WindowInsetsControllerCompat,
+  onInvalidated: () -> Unit,
+): SoftwareKeyboardPresentationDriver? {
+  val imeType = WindowInsetsCompat.Type.ime()
+  if (
+    !view.isAttachedToWindow ||
+      !view.hasWindowFocus() ||
+      ViewCompat.getRootWindowInsets(view)?.isVisible(imeType) != true
+  ) {
+    return null
+  }
+
+  val cancellationSignal = CancellationSignal()
+  val driver =
+    AndroidSoftwareKeyboardPresentationDriver(
+      onInvalidated = onInvalidated,
+      cancelControl = cancellationSignal::cancel,
+      hideIme = { insetsController.hide(imeType) },
+      isImeVisible = { ViewCompat.getRootWindowInsets(view)?.isVisible(imeType) == true },
+    )
+  val listener =
+    object : WindowInsetsAnimationControlListenerCompat {
+      override fun onReady(controller: WindowInsetsAnimationControllerCompat, types: Int) {
+        if (types and imeType == 0) {
+          cancellationSignal.cancel()
+          driver.onCancelled()
+        } else {
+          driver.onReady(AndroidImeAnimationControlCompat(controller))
+        }
+      }
+
+      override fun onFinished(controller: WindowInsetsAnimationControllerCompat) {
+        driver.onFinished()
+      }
+
+      override fun onCancelled(controller: WindowInsetsAnimationControllerCompat?) {
+        driver.onCancelled()
+      }
+    }
+
+  try {
+    insetsController.controlWindowInsetsAnimation(imeType, -1L, null, cancellationSignal, listener)
+  } catch (throwable: Throwable) {
+    driver.dispose()
+    throw throwable
+  }
+  return driver
+}
+
+private class AndroidImeAnimationControlCompat(
+  private val controller: WindowInsetsAnimationControllerCompat
+) : AndroidImeAnimationControl {
+  override val hiddenStateInsets: Insets
+    get() = controller.hiddenStateInsets
+
+  override val shownStateInsets: Insets
+    get() = controller.shownStateInsets
+
+  override val currentAlpha: Float
+    get() = controller.currentAlpha
+
+  override val isReady: Boolean
+    get() = controller.isReady
+
+  override fun setInsetsAndAlpha(insets: Insets, alpha: Float, fraction: Float) {
+    controller.setInsetsAndAlpha(insets, alpha, fraction)
+  }
+
+  override fun finish(shown: Boolean) {
+    controller.finish(shown)
+  }
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationStack.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationStack.kt
@@ -507,7 +507,6 @@ fun NavigationStack(
     behindRoute = prev
     animState = AnimState.Dragging
     predictiveBackActive = true
-    softwareKeyboardInteraction.start()
     progress.snapTo(0f)
     return true
   }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -126,6 +126,7 @@ import co.typie.navigation.Nav
 import co.typie.navigation.NavigationResult
 import co.typie.navigation.PlatformBackHandler
 import co.typie.navigation.RouteRemovalDecision
+import co.typie.platform.LocalSoftwareKeyboardPresentationController
 import co.typie.platform.PlatformModule
 import co.typie.platform.connectivityService
 import co.typie.route.Route
@@ -256,6 +257,7 @@ internal fun openEditorAuxiliarySubPane(
 @Composable
 fun EditorScreen(entityId: String) {
   val nav = Nav.current
+  val softwareKeyboardPresentationController = LocalSoftwareKeyboardPresentationController.current
   val dialog = LocalDialog.current
   val sheet = LocalSheet.current
   val popoverOverlayState = LocalPopoverOverlayState.current
@@ -777,17 +779,21 @@ fun EditorScreen(entityId: String) {
   }
 
   val leaveInterceptor =
-    remember(activeEditor, editingSession, dialog, toast) {
+    remember(activeEditor, editingSession, dialog, toast, softwareKeyboardPresentationController) {
       activeEditor?.let { editor ->
         val session = editingSession?.takeIf { it.editor === editor } ?: return@remember null
         var restoreFocusAfterRollback = false
         EditorRouteLeaveInterceptor(
           finalizeInput = {
             restoreFocusAfterRollback = uiState.focused
-            runtime.blur()
-            uiState.updateFocus(false)
+            val retainPlatformFocus =
+              softwareKeyboardPresentationController.interactionState.unresolved
+            if (!retainPlatformFocus) {
+              runtime.blur()
+              uiState.updateFocus(false)
+            }
             editor.updateNow { enqueue(Message.System(SystemEvent.SetFocused(false))) }
-            runtime.deactivateScene()
+            if (!retainPlatformFocus) runtime.deactivateScene()
           },
           restoreInput = {
             val shouldRestoreFocus = restoreFocusAfterRollback
@@ -797,7 +803,9 @@ fun EditorScreen(entityId: String) {
                 nav.current == Route.Editor(entityId) &&
                 runtime.editor === editor
             ) {
-              runtime.focus()
+              if (runtime.focus()) {
+                editor.updateNow { enqueue(Message.System(SystemEvent.SetFocused(true))) }
+              }
             }
           },
           beginStop = session::beginStop,


### PR DESCRIPTION
Android에서도 앱 내부 전체 화면 swipe back 진행률에 맞춰 IME inset을 직접 제어하도록 presentation driver를 구현했습니다.

제스처 취소 시에는 키보드를 원래 위치로 복원하고, pop 확정 시에는 현재 inset에서 시작해 키보드가 끝까지 자연스럽게 내려가도록 했습니다. 시스템 predictive back은 기존 시스템 동작을 유지합니다.

에디터에서는 leave 준비가 진행 중인 IME 제어를 취소하지 않도록 플랫폼 focus 해제 시점을 조정했습니다. 편집 admission과 저장 준비는 pop 확정 즉시 시작하면서도, 키보드가 잠시 전체 크기로 점프하는 현상을 방지합니다.