### PR TITLE
#5147 workaround를 제거하고 compose 패치로 대체

### DIFF
--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/ext/PlatformImeOptions.android.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/ext/PlatformImeOptions.android.kt
@@ -1,5 +1,0 @@
-package co.typie.ext
-
-import androidx.compose.ui.text.input.PlatformImeOptions
-
-internal actual fun nativeTextInputPlatformImeOptions(): PlatformImeOptions? = null

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ext/PlatformImeOptions.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ext/PlatformImeOptions.kt
@@ -1,5 +1,0 @@
-package co.typie.ext
-
-import androidx.compose.ui.text.input.PlatformImeOptions
-
-internal expect fun nativeTextInputPlatformImeOptions(): PlatformImeOptions?

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/home/search/SearchScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/home/search/SearchScreen.kt
@@ -33,7 +33,6 @@ import co.typie.ext.InteractionScope
 import co.typie.ext.clickable
 import co.typie.ext.excludeBottom
 import co.typie.ext.imePadding
-import co.typie.ext.nativeTextInputPlatformImeOptions
 import co.typie.ext.pressScale
 import co.typie.ext.separated
 import co.typie.ext.truncate
@@ -166,7 +165,6 @@ private fun SearchInputField(
     placeholder = placeholder,
     autoFocus = autoFocus,
     imeAction = ImeAction.Search,
-    platformImeOptions = nativeTextInputPlatformImeOptions(),
     onImeAction = onSubmit,
     leadingIcon = {
       Icon(icon = Lucide.Search, modifier = Modifier.size(16.dp), tint = AppTheme.colors.textHint)

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/TextField.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/TextField.kt
@@ -52,7 +52,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
-import androidx.compose.ui.text.input.PlatformImeOptions
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
@@ -227,7 +226,6 @@ fun TextField(
   onBlur: (() -> Unit)? = null,
   keyboardType: KeyboardType = KeyboardType.Text,
   imeAction: ImeAction? = null,
-  platformImeOptions: PlatformImeOptions? = null,
   onImeAction: (() -> Unit)? = null,
   onTabAction: (() -> Unit)? = null,
   onShiftTabAction: (() -> Unit)? = null,
@@ -385,11 +383,7 @@ fun TextField(
         ),
       cursorBrush = SolidColor(AppTheme.colors.textDefault),
       keyboardOptions =
-        KeyboardOptions(
-          keyboardType = resolvedKeyboardType,
-          imeAction = resolvedImeAction,
-          platformImeOptions = platformImeOptions,
-        ),
+        KeyboardOptions(keyboardType = resolvedKeyboardType, imeAction = resolvedImeAction),
       keyboardActions =
         KeyboardActions(onNext = { onImeAction?.invoke() }, onDone = { onImeAction?.invoke() }),
       visualTransformation =

--- a/apps/mobile/compose/src/desktopMain/kotlin/co/typie/ext/PlatformImeOptions.desktop.kt
+++ b/apps/mobile/compose/src/desktopMain/kotlin/co/typie/ext/PlatformImeOptions.desktop.kt
@@ -1,5 +1,0 @@
-package co.typie.ext
-
-import androidx.compose.ui.text.input.PlatformImeOptions
-
-internal actual fun nativeTextInputPlatformImeOptions(): PlatformImeOptions? = null

--- a/apps/mobile/compose/src/iosMain/kotlin/co/typie/ext/PlatformImeOptions.ios.kt
+++ b/apps/mobile/compose/src/iosMain/kotlin/co/typie/ext/PlatformImeOptions.ios.kt
@@ -1,9 +1,0 @@
-package co.typie.ext
-
-import androidx.compose.ui.ExperimentalComposeUiApi
-import androidx.compose.ui.text.input.PlatformImeOptions
-
-@OptIn(ExperimentalComposeUiApi::class)
-internal actual fun nativeTextInputPlatformImeOptions(): PlatformImeOptions? = PlatformImeOptions {
-  usingNativeTextInput(true)
-}


### PR DESCRIPTION
[#5147](https://github.com/penxle/typie/pull/5147)에서 도입한 Search 전용 native text input workaround를 제거합니다. Compose 입력 view가 UIKit에 attach되기 전에 실제 입력 필드 geometry를 적용하도록 [upstream 패치](https://github.com/penxle/compose-patches/blob/e834c33d360e7298dd4a93a45d377c4d1bf13611/patches/ios-compose-text-input-initial-frame/ios-compose-text-input-initial-frame.patch)를 추가해, 기본 non-native 입력 경로에서도 검은 사각형이 나타나지 않도록 수정했습니다.