### PR TITLE
iOS 입력 디버그

### DIFF
--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.android.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.android.kt
@@ -95,6 +95,8 @@ internal actual fun rememberEditorKeyboardState(
   )
 }
 
+internal actual fun endInputMethodComposition() = Unit
+
 private fun isExternalKeyboardAttached(): Boolean =
   InputDevice.getDeviceIds().any { deviceId ->
     val device = InputDevice.getDevice(deviceId)

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorImeCommandNormalizer.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorImeCommandNormalizer.kt
@@ -54,8 +54,14 @@ internal object EditorImeCommandNormalizer {
             messages += Message.Key(KeyEvent(Key.Enter))
           }
           if (segment.isNotEmpty() || index == 0) {
-            ops += FlatImeOp.Compose(segment)
-            ops += FlatImeOp.CommitAsIs
+            // commitText replaces an active preedit, but otherwise it is a committed
+            // selection replacement and must stay inside the native edit transaction.
+            if (hasActiveComposition) {
+              ops += FlatImeOp.Compose(segment)
+              ops += FlatImeOp.CommitAsIs
+            } else {
+              ops += FlatImeOp.ReplaceSelection(segment)
+            }
             hasActiveComposition = false
           }
         }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.kt
@@ -182,6 +182,8 @@ internal expect fun rememberEditorKeyboardState(
   isEditorInputSessionActive: () -> Boolean
 ): EditorKeyboardState
 
+internal expect fun endInputMethodComposition()
+
 internal fun isImeVisible(imeBottom: Dp, safeBottomInset: Dp): Boolean = imeBottom > safeBottomInset
 
 internal fun trustedImeBottomInset(rawImeBottom: Dp, keyboardState: EditorKeyboardState): Dp {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarHost.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarHost.kt
@@ -247,6 +247,10 @@ internal fun EditorToolbarHost(
 
     val session = runtime.session ?: return
     session.submit { editor, context ->
+      // The iOS Korean keyboard can retain composition state without exposing a marked range.
+      // End that native state before changing the editor; doing this after the toolbar update is
+      // too late because the keyboard has already associated the preceding text with the new style.
+      endInputMethodComposition()
       editor.scope.launch(context) {
         val update =
           editor.updateWithBringIntoView(bringIntoViewRequests) {

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/input/EditorImeCommandNormalizerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/input/EditorImeCommandNormalizerTest.kt
@@ -21,14 +21,11 @@ import kotlin.test.assertEquals
 
 class EditorImeCommandNormalizerTest {
   @Test
-  fun `commit text normalizes to composition replacement and commit`() {
+  fun `commit text without active preedit replaces selection`() {
     val messages =
       EditorImeCommandNormalizer.normalize(listOf(CommitTextCommand("a", 1)), ime = null)
 
-    assertEquals(
-      listOf(Message.TextInput(listOf(FlatImeOp.Compose("a"), FlatImeOp.CommitAsIs))),
-      messages,
-    )
+    assertEquals(listOf(Message.TextInput(listOf(FlatImeOp.ReplaceSelection("a")))), messages)
   }
 
   @Test
@@ -65,8 +62,7 @@ class EditorImeCommandNormalizerTest {
             FlatImeOp.Compose("안녕하세요"),
             FlatImeOp.CommitAsIs,
             FlatImeOp.ClearComposition,
-            FlatImeOp.Compose(" "),
-            FlatImeOp.CommitAsIs,
+            FlatImeOp.ReplaceSelection(" "),
           )
         )
       ),
@@ -89,9 +85,9 @@ class EditorImeCommandNormalizerTest {
 
     assertEquals(
       listOf(
-        Message.TextInput(listOf(FlatImeOp.Compose("foo"), FlatImeOp.CommitAsIs)),
+        Message.TextInput(listOf(FlatImeOp.ReplaceSelection("foo"))),
         Message.Key(KeyEvent(Key.Enter)),
-        Message.TextInput(listOf(FlatImeOp.Compose("bar"), FlatImeOp.CommitAsIs)),
+        Message.TextInput(listOf(FlatImeOp.ReplaceSelection("bar"))),
       ),
       messages,
     )
@@ -104,10 +100,10 @@ class EditorImeCommandNormalizerTest {
 
     assertEquals(
       listOf(
-        Message.TextInput(listOf(FlatImeOp.Compose("a"), FlatImeOp.CommitAsIs)),
+        Message.TextInput(listOf(FlatImeOp.ReplaceSelection("a"))),
         Message.Key(KeyEvent(Key.Enter)),
         Message.Key(KeyEvent(Key.Enter)),
-        Message.TextInput(listOf(FlatImeOp.Compose("b"), FlatImeOp.CommitAsIs)),
+        Message.TextInput(listOf(FlatImeOp.ReplaceSelection("b"))),
       ),
       messages,
     )
@@ -124,7 +120,7 @@ class EditorImeCommandNormalizerTest {
       listOf(
         Message.TextInput(listOf(FlatImeOp.Compose(""), FlatImeOp.CommitAsIs)),
         Message.Key(KeyEvent(Key.Enter)),
-        Message.TextInput(listOf(FlatImeOp.Compose("foo"), FlatImeOp.CommitAsIs)),
+        Message.TextInput(listOf(FlatImeOp.ReplaceSelection("foo"))),
       ),
       messages,
     )
@@ -159,11 +155,7 @@ class EditorImeCommandNormalizerTest {
       )
 
     assertEquals(
-      listOf(
-        Message.TextInput(
-          listOf(FlatImeOp.CommitAsIs, FlatImeOp.Compose(" "), FlatImeOp.CommitAsIs)
-        )
-      ),
+      listOf(Message.TextInput(listOf(FlatImeOp.CommitAsIs, FlatImeOp.ReplaceSelection(" ")))),
       messages,
     )
   }
@@ -244,12 +236,9 @@ class EditorImeCommandNormalizerTest {
         Message.TextInput(
           listOf(
             FlatImeOp.SetSelection(4563, 4565),
-            FlatImeOp.Compose(""),
-            FlatImeOp.CommitAsIs,
-            FlatImeOp.Compose("ㅎ"),
-            FlatImeOp.CommitAsIs,
-            FlatImeOp.Compose("아"),
-            FlatImeOp.CommitAsIs,
+            FlatImeOp.ReplaceSelection(""),
+            FlatImeOp.ReplaceSelection("ㅎ"),
+            FlatImeOp.ReplaceSelection("아"),
           )
         )
       ),
@@ -269,9 +258,7 @@ class EditorImeCommandNormalizerTest {
 
     assertEquals(
       listOf(
-        Message.TextInput(
-          listOf(FlatImeOp.SetSelection(11, 12), FlatImeOp.Compose("x"), FlatImeOp.CommitAsIs)
-        )
+        Message.TextInput(listOf(FlatImeOp.SetSelection(11, 12), FlatImeOp.ReplaceSelection("x")))
       ),
       messages,
     )
@@ -336,10 +323,7 @@ class EditorImeCommandNormalizerTest {
         ime = null,
       )
 
-    assertEquals(
-      listOf(Message.TextInput(listOf(FlatImeOp.Compose("x"), FlatImeOp.CommitAsIs))),
-      messages,
-    )
+    assertEquals(listOf(Message.TextInput(listOf(FlatImeOp.ReplaceSelection("x")))), messages)
   }
 
   @Test

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/input/RecordedInputEntrySerializationTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/input/RecordedInputEntrySerializationTest.kt
@@ -115,10 +115,7 @@ class RecordedInputEntrySerializationTest {
         imeBefore = null,
         imeAfter = null,
       )
-    assertEquals(
-      listOf(Message.TextInput(listOf(FlatImeOp.Compose("a"), FlatImeOp.CommitAsIs))),
-      entry.messages,
-    )
+    assertEquals(listOf(Message.TextInput(listOf(FlatImeOp.ReplaceSelection("a")))), entry.messages)
     assertEquals(listOf("CommitText(text=a, newCursorPosition=1)"), entry.commands)
   }
 }

--- a/apps/mobile/compose/src/desktopMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.desktop.kt
+++ b/apps/mobile/compose/src/desktopMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.desktop.kt
@@ -38,6 +38,8 @@ internal actual fun rememberEditorKeyboardState(
   )
 }
 
+internal actual fun endInputMethodComposition() = Unit
+
 internal fun resolveDesktopEditorKeyboardState(
   hardwareKeyboardConnected: Boolean,
   imeBottom: Dp,

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/input/EditorInputEnabledDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/input/EditorInputEnabledDesktopTest.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.unit.dp
 import co.typie.editor.Editor
 import co.typie.editor.FakeFfiEditor
 import co.typie.editor.ffi.Break
+import co.typie.editor.ffi.CommandOutcome
 import co.typie.editor.ffi.Direction
 import co.typie.editor.ffi.EditorEvent
 import co.typie.editor.ffi.FlatImeOp
@@ -196,7 +197,18 @@ class EditorInputEnabledDesktopTest {
   fun navigationAndShortcutsCommitCompositionBeforeDispatch() = runComposeUiTest {
     val composingIme =
       Ime(text = "한", windowStart = 0, selection = ImeRange(1, 1), composing = ImeRange(0, 1))
-    val fake = FakeFfiEditor(imeProvider = { _, _ -> composingIme })
+    var currentIme: Ime? = composingIme
+    val fake =
+      FakeFfiEditor(
+        onTick = { listOf(EditorEvent.StateChanged(listOf(StateField.Ime))) },
+        imeProvider = { _, _ -> currentIme },
+      )
+    fake.commandOutcomesProvider = { _, messages ->
+      if (messages.any { it == Message.TextInput(listOf(FlatImeOp.CommitAsIs)) }) {
+        currentIme = composingIme.copy(composing = null)
+      }
+      List(messages.size) { CommandOutcome.Applied }
+    }
     val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     val editor = Editor(fake, scope)
     val session = createTestDocumentEditingSession(editor, scope)
@@ -256,6 +268,7 @@ class EditorInputEnabledDesktopTest {
 
       bringIntoViewRequests.cancel()
       editor.refreshImeSnapshot()
+      currentIme = composingIme
       fake.enqueued.clear()
       observedRevealPolicy = null
       onNodeWithTag(InputTag).performKeyInput {
@@ -275,6 +288,7 @@ class EditorInputEnabledDesktopTest {
 
       bringIntoViewRequests.cancel()
       editor.refreshImeSnapshot()
+      currentIme = composingIme
       fake.enqueued.clear()
       onNodeWithTag(InputTag).performKeyInput {
         keyDown(Key.MetaLeft)

--- a/apps/mobile/compose/src/iosMain/kotlin/co/typie/editor/input/EditorInput.ios.kt
+++ b/apps/mobile/compose/src/iosMain/kotlin/co/typie/editor/input/EditorInput.ios.kt
@@ -160,7 +160,9 @@ internal actual suspend fun PlatformTextInputSessionScope.createEditorInputReque
           }
         }
       scope.block()
-      onEditCommand(commands)
+      if (commands.isNotEmpty()) {
+        onEditCommand(commands)
+      }
     }
   }
 }

--- a/apps/mobile/compose/src/iosMain/kotlin/co/typie/editor/input/EditorPlatformInputBridge.ios.kt
+++ b/apps/mobile/compose/src/iosMain/kotlin/co/typie/editor/input/EditorPlatformInputBridge.ios.kt
@@ -23,6 +23,7 @@ import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import swiftPMImport.co.typie.compose.EditorFloatingCursorBridge
+import swiftPMImport.co.typie.compose.EditorKeyboardBridge
 import swiftPMImport.co.typie.compose.EditorTextInputTraitsBridge
 
 internal actual class EditorPlatformInputBridge actual constructor() {
@@ -40,7 +41,9 @@ internal actual class EditorPlatformInputBridge actual constructor() {
 
   actual fun bindInputSession(session: PlatformTextInputSessionScope) = Unit
 
-  actual fun resetPlatformInputBeforeBindingDispatch() = Unit
+  actual fun resetPlatformInputBeforeBindingDispatch() {
+    EditorKeyboardBridge.endInputMethodComposition()
+  }
 
   actual fun onPreKeyEvent(
     event: KeyEvent,

--- a/apps/mobile/compose/src/iosMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.ios.kt
+++ b/apps/mobile/compose/src/iosMain/kotlin/co/typie/screen/editor/editor/toolbar/EditorKeyboardType.ios.kt
@@ -206,5 +206,9 @@ internal actual fun rememberEditorKeyboardState(
   )
 }
 
+internal actual fun endInputMethodComposition() {
+  EditorKeyboardBridge.endInputMethodComposition()
+}
+
 private fun isEditorHardwareKeyboardConnected(): Boolean =
   EditorKeyboardBridge.isInHardwareKeyboardMode()

--- a/apps/mobile/compose/src/iosTest/kotlin/co/typie/editor/input/EditorInputRequestIosTest.kt
+++ b/apps/mobile/compose/src/iosTest/kotlin/co/typie/editor/input/EditorInputRequestIosTest.kt
@@ -6,25 +6,78 @@ import androidx.compose.ui.platform.PlatformTextInputMethodRequest
 import androidx.compose.ui.platform.PlatformTextInputSessionScope
 import androidx.compose.ui.text.input.CommitTextCommand
 import androidx.compose.ui.text.input.EditCommand
+import androidx.compose.ui.text.input.SetSelectionCommand
+import androidx.compose.ui.text.input.TextEditingScope
+import androidx.compose.ui.text.input.TextFieldValue
 import co.typie.editor.Editor
 import co.typie.editor.FakeFfiEditor
+import co.typie.editor.ffi.Ime
+import co.typie.editor.ffi.ImeRange
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
 
 class EditorInputRequestIosTest {
   @Test
-  fun nativeEditBlockDispatchesEditCommands() {
+  fun requestExposesTheWholeImeWindowIncludingParagraphBoundaries() = runTest {
+    val before = ime(text = "\u2028문단1\u2029\u2028ㅎ\u2029", selection = 7)
+
+    val result = runNativeEdit(before) {}
+
+    assertEquals(before.toTextFieldValue(), result.value)
+  }
+
+  @Test
+  fun paragraphStartRewriteKeepsFullImeWindowCoordinates() = runTest {
+    val result =
+      runNativeEdit(before = ime(text = "\u2028문단1\u2029\u2028ㅎ\u2029", selection = 7)) {
+        setSelection(0, 1)
+        commitText("", 0)
+      }
+
+    assertEquals(
+      listOf(listOf(SetSelectionCommand(0, 1), CommitTextCommand("", 0))),
+      result.dispatched,
+    )
+  }
+
+  @Test
+  fun nativeEditBlockDispatchesEditCommandsInOrder() = runTest {
+    val result =
+      runNativeEdit(before = ime(text = "x", selection = 1)) {
+        setSelection(0, 0)
+        commitText("typed", 1)
+      }
+
+    val expected: List<List<EditCommand>> =
+      listOf(listOf(SetSelectionCommand(0, 0), CommitTextCommand("typed", 1)))
+    assertEquals(expected, result.dispatched)
+  }
+
+  private data class NativeEditResult(
+    val value: TextFieldValue,
+    val dispatched: List<List<EditCommand>>,
+  )
+
+  private suspend fun TestScope.runNativeEdit(
+    before: Ime,
+    block: TextEditingScope.() -> Unit,
+  ): NativeEditResult {
     val editorScope = CoroutineScope(EmptyCoroutineContext)
-    val editor = Editor(FakeFfiEditor(), editorScope)
+    val fake = FakeFfiEditor(imeProvider = { _, _ -> before })
+    val editor = Editor(fake, editorScope)
     val dispatched = mutableListOf<List<EditCommand>>()
     try {
+      editor.setImeSessionActive(true)
+      fake.applySnapshot(editor)
       val request =
-        kotlinx.coroutines.runBlocking {
-          TestTextInputSessionScope.createEditorInputRequest(
+        TestTextInputSessionScope(coroutineContext)
+          .createEditorInputRequest(
             editor = editor,
             bringIntoViewRequests = EditorBringIntoViewRequests(),
             onEditCommand = dispatched::add,
@@ -35,21 +88,27 @@ class EditorInputRequestIosTest {
             isSessionCurrent = { true },
             onIncomingContent = { false },
           )
-        }
 
-      request.editText { commitText("typed", 1) }
-
-      val expected: List<List<EditCommand>> = listOf(listOf(CommitTextCommand("typed", 1)))
-      assertEquals(expected, dispatched)
+      val value = request.value()
+      request.editText(block)
+      return NativeEditResult(value = value, dispatched = dispatched)
     } finally {
       editorScope.cancel()
     }
   }
+
+  private fun ime(text: String, selection: Int): Ime =
+    Ime(
+      text = text,
+      windowStart = 0,
+      selection = ImeRange(start = selection, end = selection),
+      composing = null,
+    )
 }
 
-private object TestTextInputSessionScope : PlatformTextInputSessionScope {
-  override val coroutineContext = EmptyCoroutineContext
-
+private class TestTextInputSessionScope(
+  override val coroutineContext: kotlin.coroutines.CoroutineContext = EmptyCoroutineContext
+) : PlatformTextInputSessionScope {
   override suspend fun startInputMethod(request: PlatformTextInputMethodRequest): Nothing =
     error("not used")
 }

--- a/apps/mobile/ios/Bridge/Sources/Bridge/EditorKeyboardBridge.swift
+++ b/apps/mobile/ios/Bridge/Sources/Bridge/EditorKeyboardBridge.swift
@@ -1,5 +1,6 @@
 import Foundation
 import GameController
+import ObjectiveC.runtime
 import UIKit
 
 @MainActor @objcMembers public final class EditorKeyboardBridge: NSObject {
@@ -9,6 +10,31 @@ import UIKit
     }
 
     return GCKeyboard.coalesced != nil
+  }
+
+  public static func endInputMethodComposition() -> Bool {
+    guard let keyboard = activeKeyboard() else {
+      return false
+    }
+
+    let selector = NSSelectorFromString("acceptAutocorrectionAndEndComposition")
+    guard
+      keyboard.responds(to: selector),
+      let method = class_getInstanceMethod(type(of: keyboard), selector),
+      method_getNumberOfArguments(method) == 2
+    else {
+      return false
+    }
+    let returnType = method_copyReturnType(method)
+    defer { free(returnType) }
+    guard String(cString: returnType) == "v" else {
+      return false
+    }
+
+    typealias VoidMethod = @convention(c) (AnyObject, Selector) -> Void
+    let function = unsafeBitCast(method_getImplementation(method), to: VoidMethod.self)
+    function(keyboard, selector)
+    return true
   }
 
   public static func isImeFrameVisible(notification: Notification) -> Bool {
@@ -34,12 +60,7 @@ import UIKit
   }
 
   private static func detectHardwareKeyboardModeFromUIKeyboardImpl() -> Bool? {
-    guard
-      let cls = NSClassFromString("UIKeyboardImpl") as? NSObject.Type,
-      let instance =
-        cls.perform(NSSelectorFromString("activeInstance"))?
-        .takeUnretainedValue() as? NSObject
-    else {
+    guard let instance = activeKeyboard() else {
       return nil
     }
 
@@ -52,6 +73,18 @@ import UIKit
     let methodImplementation = instance.method(for: selector)
     let function = unsafeBitCast(methodImplementation, to: BoolMethod.self)
     return function(instance, selector)
+  }
+
+  private static func activeKeyboard() -> NSObject? {
+    guard let cls = NSClassFromString("UIKeyboardImpl") as? NSObject.Type else {
+      return nil
+    }
+
+    let selector = NSSelectorFromString("activeInstance")
+    guard cls.responds(to: selector) else {
+      return nil
+    }
+    return cls.perform(selector)?.takeUnretainedValue() as? NSObject
   }
 
   private static func keyboardVisibleHeight(from keyboardFrame: CGRect) -> Double {

--- a/apps/mobile/settings.gradle.kts
+++ b/apps/mobile/settings.gradle.kts
@@ -8,6 +8,7 @@ val githubPackagesUser =
   providers.gradleProperty("gpr.user").orElse(providers.environmentVariable("GITHUB_ACTOR"))
 val githubPackagesToken =
   providers.gradleProperty("gpr.key").orElse(providers.environmentVariable("GITHUB_TOKEN"))
+val composePatchesRepository = providers.gradleProperty("composePatchesRepository").orNull
 
 pluginManagement {
   repositories {
@@ -27,13 +28,17 @@ dependencyResolutionManagement {
   repositories {
     exclusiveContent {
       forRepository {
-        maven("https://maven.pkg.github.com/penxle/compose-patches") {
-          name = "GitHubPackages"
-          // Local builds read these from ~/.gradle/gradle.properties; CI can provide the
-          // environment fallbacks above.
-          credentials {
-            username = githubPackagesUser.orNull
-            password = githubPackagesToken.orNull
+        if (composePatchesRepository != null) {
+          maven(composePatchesRepository) { name = "ComposePatchesLocal" }
+        } else {
+          maven("https://maven.pkg.github.com/penxle/compose-patches") {
+            name = "GitHubPackages"
+            // Local builds read these from ~/.gradle/gradle.properties; CI can provide the
+            // environment fallbacks above.
+            credentials {
+              username = githubPackagesUser.orNull
+              password = githubPackagesToken.orNull
+            }
           }
         }
       }

--- a/crates/editor-core/src/handle/text_input.rs
+++ b/crates/editor-core/src/handle/text_input.rs
@@ -843,6 +843,17 @@ fn flat_ime_ops_form_plain_backspace(editor: &Editor, ops: &[FlatImeOp]) -> bool
         .is_some_and(|prev| prev.to_flat() == change.replace_start)
 }
 
+fn flat_ime_ops_have_direct_backspace_shape(ops: &[FlatImeOp]) -> bool {
+    match ops {
+        [FlatImeOp::DeleteSurrounding { .. }] | [FlatImeOp::DeleteSurroundingUtf16 { .. }] => true,
+        [
+            FlatImeOp::SetSelection { .. },
+            FlatImeOp::ReplaceSelection { text },
+        ] => text.is_empty(),
+        _ => false,
+    }
+}
+
 pub fn handle_flat_ime_ops(editor: &mut Editor, ops: Vec<FlatImeOp>) -> Result<(), EditorError> {
     for segment in ops.split_inclusive(|op| matches!(op, FlatImeOp::CommitAsIs)) {
         handle_flat_ime_segment(editor, segment)?;
@@ -852,9 +863,11 @@ pub fn handle_flat_ime_ops(editor: &mut Editor, ops: Vec<FlatImeOp>) -> Result<(
 
 fn handle_flat_ime_segment(editor: &mut Editor, ops: &[FlatImeOp]) -> Result<(), EditorError> {
     let mut delete_paint = editor.ime_delete_paint.take();
+    let plain_backspace = flat_ime_ops_form_plain_backspace(editor, ops);
+    let standalone_backspace = plain_backspace && flat_ime_ops_have_direct_backspace_shape(ops);
 
     if matches!(editor.last_history_tag(), Some(HistoryTag::AutoReplacement))
-        && flat_ime_ops_form_plain_backspace(editor, ops)
+        && plain_backspace
         && editor.try_undo_auto_replacement()
     {
         if !editor.state().pending_modifiers.is_empty() {
@@ -978,7 +991,11 @@ fn handle_flat_ime_segment(editor: &mut Editor, ops: &[FlatImeOp]) -> Result<(),
 
         let sidecar_before = editor.composition_paint.clone();
 
-        let next_delete_paint = if !del.is_empty()
+        // A standalone backspace is a completed user action. Only retain the
+        // deleted paint when an IME rewrite batch temporarily removes text and
+        // may continue that rewrite in the next request.
+        let next_delete_paint = if !standalone_backspace
+            && !del.is_empty()
             && text_change.insert.is_empty()
             && !del.iter().any(|c| is_token(*c))
             && result.comp.is_none()
@@ -4551,7 +4568,7 @@ mod tests {
     }
 
     #[test]
-    fn ime_split_messages_delete_then_insert_preserves_deleted_paint() {
+    fn ime_separate_delete_and_insert_do_not_preserve_deleted_paint() {
         let (state, p1) = state! {
             doc { root { p1: paragraph { text("가") } } }
             selection: (p1, 1)
@@ -4572,7 +4589,36 @@ mod tests {
         editor.apply(Message::TextInput {
             ops: vec![FlatImeOp::ReplaceSelection { text: "아".into() }],
         });
-        assert_eq!(paint_at(&editor, p1, 1), vec![Modifier::Bold], "아 bold");
+        assert_eq!(paint_at(&editor, p1, 1), vec![], "아 unstyled");
+    }
+
+    #[test]
+    fn committed_backspace_does_not_carry_consumed_pending_paint_to_the_next_input() {
+        let (state, p1) = state! {
+            doc { root { p1: paragraph { text("..") } } }
+            selection: (p1, 2)
+            pending_modifiers: [bold]
+        };
+        let mut editor = Editor::new_test(state);
+
+        editor.apply(Message::TextInput {
+            ops: vec![FlatImeOp::ReplaceSelection { text: "하".into() }],
+        });
+        assert_eq!(paint_at(&editor, p1, 2), vec![Modifier::Bold]);
+        assert!(editor.state().pending_modifiers.is_empty());
+
+        editor.apply(Message::TextInput {
+            ops: vec![FlatImeOp::DeleteSurrounding {
+                before: 1,
+                after: 0,
+            }],
+        });
+        assert!(editor.state().pending_modifiers.is_empty());
+
+        editor.apply(Message::TextInput {
+            ops: vec![FlatImeOp::ReplaceSelection { text: "하".into() }],
+        });
+        assert_eq!(paint_at(&editor, p1, 2), vec![]);
     }
 
     #[test]
@@ -4622,7 +4668,7 @@ mod tests {
     }
 
     #[test]
-    fn ime_split_delete_paint_invalidated_by_intervening_message() {
+    fn ime_separate_delete_and_insert_remain_unstyled_with_intervening_message() {
         let (state, p1) = state! {
             doc { root { p1: paragraph { text("가") } } }
             selection: (p1, 1)
@@ -4838,7 +4884,7 @@ mod tests {
     }
 
     #[test]
-    fn ime_split_messages_recompose_sole_char_preserves_deleted_paint() {
+    fn ime_separate_delete_and_insert_of_sole_char_use_empty_paragraph_paint() {
         let (state, p1) = state! {
             doc { root { p1: paragraph {} } }
             selection: (p1, 0)


### PR DESCRIPTION
## 배경

Compose 1.12의 iOS 입력 경로에서 UIKit의 입력 상태와 앱의 편집 상태가 어긋나는 문제가 있었습니다.

이로 인해 한글 조합 중 서식이 되돌아가거나 문단 경계가 잘못 처리됐습니다. 텍스트 대치 후에는 키보드가 이전 문맥을 유지했고, 글자를 지운 뒤에도 삭제한 서식이 다음 입력에 남았습니다.

## 변경 사항

### Compose 패치

같은 turn에 발생한 UIKit 입력 callback을 하나의 edit transaction으로 묶습니다.

앱에서 텍스트 대치가 발생해 UIKit의 예상 결과와 달라지면 키보드의 입력 문맥도 새 결과로 동기화합니다.

### KMP 입력 어댑터

`commitText`의 의미를 조합 상태에 따라 구분했습니다.

- 조합 중이면 `Compose + CommitAsIs`
- 일반 입력이면 `ReplaceSelection`

문단 경계를 포함한 전체 IME 문맥을 유지하고, 빈 edit command는 엔진에 전달하지 않습니다.

### 엔진

독립적인 Backspace에서는 삭제한 글자의 서식을 다음 입력으로 넘기지 않습니다.

IME가 글자를 재조합하는 경우에만 삭제한 서식을 임시로 보존합니다.

### iOS 앱

iOS 기본 키보드는 조합 범위를 노출하지 않고 한글 조합을 유지할 수 있습니다.

서식 변경 전에 이 숨은 조합을 먼저 끝내도록 했습니다. 키보드 responder를 재생성하지 않으므로 키보드나 toolbar가 깜빡이지 않습니다.

사용하는 selector가 없거나 형태가 다르면 아무 작업도 하지 않습니다. Android와 Desktop에는 적용되지 않습니다.


## 개선되는 동작

- 서식 변경 후 한글을 조합해도 서식이 되돌아가지 않음
- 문단 시작점의 한글 입력이 이전 문단으로 합쳐지지 않음
- 텍스트 대치 후 키보드 문맥과 앱의 텍스트가 일치함
- 글자를 지우면 해당 글자에 사용한 pending modifier도 해제됨
- iOS 기본 키보드에서 `한 → 서식 변경 → 한` 입력이 새 조합으로 시작됨
- 플로팅 커서가 문단 경계를 넘을 수 있음

Slyder 키보드같은 서드파티 키보드가 자체적으로 유지하는 숨은 조합은 종료할 수 없어 `한 → 서식 변경 → 한` 시 `핞`이 되는 제한은 남아 있습니다.