### PR TITLE
메인 탭 전환 시의 키보드/포커스 UX 개선

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteEditState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteEditState.kt
@@ -156,6 +156,10 @@ internal class NoteEditState(private val scope: CoroutineScope) {
   fun shouldAutoFocusContent(siteId: String, noteId: String): Boolean =
     activeFormFor(siteId = siteId, noteId = noteId)?.autoFocusContent == true
 
+  fun consumeAutoFocusContent(siteId: String, noteId: String) {
+    activeFormFor(siteId = siteId, noteId = noteId)?.consumeAutoFocusContent()
+  }
+
   fun cancelPendingSaves(siteId: String, noteId: String) {
     activeFormFor(siteId = siteId, noteId = noteId)?.cancelPendingSaves()
   }
@@ -189,11 +193,14 @@ internal enum class NoteSaveOutcome {
 private class ActiveNoteFormState(
   private val scope: CoroutineScope,
   note: NoteCard_note,
-  val autoFocusContent: Boolean,
+  autoFocusContent: Boolean,
   private val onSaveFailed: () -> Unit,
 ) {
   val noteId: String = note.id
   val siteId: String = note.site.id
+
+  var autoFocusContent by mutableStateOf(autoFocusContent)
+    private set
 
   var serverSnapshot by mutableStateOf(note)
     private set
@@ -227,6 +234,10 @@ private class ActiveNoteFormState(
         showSaving -> NoteSaveStatus.SAVING
         else -> NoteSaveStatus.NONE
       }
+
+  fun consumeAutoFocusContent() {
+    autoFocusContent = false
+  }
 
   val isContentDirty: Boolean
     get() = contentEdit.desired != null

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteList.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteList.kt
@@ -87,6 +87,12 @@ internal fun WithNoteEditPresentation(
 ) {
   val siteId = note.site.id
   val noteId = note.id
+  val autoFocusContent = editState.shouldAutoFocusContent(siteId = siteId, noteId = noteId)
+  SideEffect {
+    if (autoFocusContent) {
+      editState.consumeAutoFocusContent(siteId = siteId, noteId = noteId)
+    }
+  }
   content(
     NoteEditPresentation(
       note = editState.overlay(note),
@@ -97,7 +103,7 @@ internal fun WithNoteEditPresentation(
       saveStatus = editState.saveStatus(siteId = siteId, noteId = noteId),
       hasPendingColor = editState.hasPendingColor(siteId = siteId, noteId = noteId),
       isDirty = editState.isDirty(siteId = siteId, noteId = noteId),
-      autoFocusContent = editState.shouldAutoFocusContent(siteId = siteId, noteId = noteId),
+      autoFocusContent = autoFocusContent,
     )
   )
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/shell/MainShell.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/shell/MainShell.kt
@@ -151,7 +151,7 @@ fun MainShell(content: @Composable (Route) -> Unit) {
           onSettledTab = { tab -> navState.currentTab = tab },
         ) { tab ->
           val foregroundInteractive = tab == settledTab && motion == null && drawerAtRest
-          val foregroundFocusEnabled = tab == settledTab && drawerAtRest
+          val foregroundFocusEnabled = tab == mainTabState.focusEnabledTab && drawerAtRest
           NavigationStack(
             navigator = navigators[tab]!!,
             topBarState =

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/shell/MainTabPager.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/shell/MainTabPager.kt
@@ -31,6 +31,7 @@ import kotlin.math.abs
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 internal enum class MainTabMotionSource {
@@ -50,6 +51,9 @@ internal class MainTabState(initialTab: Tab, private val scope: CoroutineScope) 
   var motion by mutableStateOf<MainTabMotion?>(null)
     private set
 
+  var focusEnabledTab by mutableStateOf(initialTab)
+    private set
+
   val bodyPosition: Float
     get() =
       if (motion == null) {
@@ -65,6 +69,10 @@ internal class MainTabState(initialTab: Tab, private val scope: CoroutineScope) 
   private var activeMotionSessionId: Long? = null
   private var activeMotionObservedScroll = false
   private var returningToOrigin = false
+
+  fun enableFocusFor(tab: Tab) {
+    focusEnabledTab = tab
+  }
 
   fun selectTab(tab: Tab, beforeTransition: suspend () -> Unit = {}) {
     if (motion?.source == MainTabMotionSource.DirectDrag) return
@@ -305,8 +313,15 @@ internal fun MainTabPager(
           if (settledTab == activeOrigin) {
             activeKeyboardSession?.finish(SoftwareKeyboardPresentationEndpoint.Shown)
           } else {
-            activeKeyboardSession?.finish(SoftwareKeyboardPresentationEndpoint.Hidden)
+            activeKeyboardSession?.let { session ->
+              val interactionId = session.interactionId
+              session.updateHiddenProgress(1f)
+              session.finish(SoftwareKeyboardPresentationEndpoint.Hidden)
+              snapshotFlow { softwareKeyboardPresentationController.interactionState }
+                .first { it.activeInteractionId != interactionId }
+            }
             focusManager.clearFocus(force = true)
+            state.enableFocusFor(state.settledTab)
           }
         }
     } finally {

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/domain/note/NoteListDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/domain/note/NoteListDesktopTest.kt
@@ -43,10 +43,37 @@ import dev.chrisbanes.haze.blur.HazeBlurStyle
 import dev.chrisbanes.haze.blur.LocalHazeBlurStyle
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalTestApi::class)
 class NoteListDesktopTest {
+  @Test
+  fun newlyCreatedNoteAutofocusIsNotRepeatedAfterPresentationReturns() = runComposeUiTest {
+    val note = notesNote(id = "new")
+    var presentationVisible by mutableStateOf(true)
+    val observedAutofocus = mutableListOf<Boolean>()
+
+    setContent {
+      val scope = rememberCoroutineScope()
+      val editState = remember(scope) { NoteEditState(scope).also { it.openNew(note) } }
+
+      if (presentationVisible) {
+        WithNoteEditPresentation(note = note, editState = editState) { presentation ->
+          SideEffect { observedAutofocus += presentation.autoFocusContent }
+        }
+      }
+    }
+    waitUntil { observedAutofocus.any { it } }
+
+    runOnIdle { presentationVisible = false }
+    waitForIdle()
+    runOnIdle { presentationVisible = true }
+    waitForIdle()
+
+    assertFalse(observedAutofocus.last())
+  }
+
   @Test
   fun projectedNoteOrderDoesNotChangeThePhysicalListDuringDrag() = runComposeUiTest {
     val first = notesNote(id = "first", content = "first-content", order = "100")

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/shell/MainShellAutofocusDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/shell/MainShellAutofocusDesktopTest.kt
@@ -24,6 +24,10 @@ import co.typie.dev.DesktopDebugKeyboard
 import co.typie.navigation.LocalNavigationForegroundInteractive
 import co.typie.navigation.Nav
 import co.typie.navigation.Navigator
+import co.typie.platform.LocalSoftwareKeyboardPresentationController
+import co.typie.platform.SoftwareKeyboardPresentationController
+import co.typie.platform.SoftwareKeyboardPresentationDriver
+import co.typie.platform.SoftwareKeyboardPresentationEndpoint
 import co.typie.route.Route
 import co.typie.screen.more.feedback.FeedbackForm
 import co.typie.screen.settings.updateprofile.UpdateProfileForm
@@ -46,72 +50,83 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalTestApi::class)
 class MainShellAutofocusDesktopTest {
   @Test
-  fun `main tab motion retains source focus and rejects background focus until settle`() =
-    runComposeUiTest {
-      configureEditorFfiLibrary()
-      var selectTab: ((Tab) -> Unit)? = null
-      var currentTab = Tab.Home
-      var isBodyMoving = false
-      var sourceFocused = false
-      var backgroundFocusRequester: FocusRequester? = null
+  fun `main tab motion retains source focus until keyboard hide is accepted`() = runComposeUiTest {
+    configureEditorFfiLibrary()
+    val keyboardDriver = DeferredMainShellKeyboardDriver()
+    val keyboardController = SoftwareKeyboardPresentationController { keyboardDriver }
+    var selectTab: ((Tab) -> Unit)? = null
+    var currentTab = Tab.Home
+    var isBodyMoving = false
+    var sourceFocused = false
+    var backgroundFocusRequester: FocusRequester? = null
 
-      setContent {
-        val sheet = remember { Sheet() }
-        val dialog = remember { Dialog() }
-        CompositionLocalProvider(
-          LocalThemeMode provides ResolvedThemeMode.Light,
-          LocalSheet provides sheet,
-          LocalDialog provides dialog,
-        ) {
-          MainShell { route ->
-            val tabState = LocalTabState.current
-            SideEffect {
-              selectTab = tabState.onSelectTab
-              currentTab = tabState.currentTab
-              isBodyMoving = tabState.isBodyMoving
+    setContent {
+      val sheet = remember { Sheet() }
+      val dialog = remember { Dialog() }
+      CompositionLocalProvider(
+        LocalThemeMode provides ResolvedThemeMode.Light,
+        LocalSheet provides sheet,
+        LocalDialog provides dialog,
+        LocalSoftwareKeyboardPresentationController provides keyboardController,
+      ) {
+        MainShell { route ->
+          val tabState = LocalTabState.current
+          SideEffect {
+            selectTab = tabState.onSelectTab
+            currentTab = tabState.currentTab
+            isBodyMoving = tabState.isBodyMoving
+          }
+
+          when (route) {
+            Route.Home -> {
+              val focusRequester = remember { FocusRequester() }
+              BasicTextField(
+                value = "",
+                onValueChange = {},
+                modifier =
+                  Modifier.fillMaxSize().focusRequester(focusRequester).onFocusChanged {
+                    sourceFocused = it.isFocused
+                  },
+              )
+              LaunchedEffect(Unit) { focusRequester.requestFocus() }
             }
 
-            when (route) {
-              Route.Home -> {
-                val focusRequester = remember { FocusRequester() }
-                BasicTextField(
-                  value = "",
-                  onValueChange = {},
-                  modifier =
-                    Modifier.fillMaxSize().focusRequester(focusRequester).onFocusChanged {
-                      sourceFocused = it.isFocused
-                    },
-                )
-                LaunchedEffect(Unit) { focusRequester.requestFocus() }
-              }
-
-              Route.Space -> {
-                val focusRequester = remember { FocusRequester() }
-                SideEffect { backgroundFocusRequester = focusRequester }
-                Box(Modifier.fillMaxSize().focusRequester(focusRequester).focusable())
-              }
-
-              else -> Unit
+            Route.Space -> {
+              val focusRequester = remember { FocusRequester() }
+              SideEffect { backgroundFocusRequester = focusRequester }
+              Box(Modifier.fillMaxSize().focusRequester(focusRequester).focusable())
             }
+
+            else -> Unit
           }
         }
       }
-      waitUntil { sourceFocused && selectTab != null }
-
-      mainClock.autoAdvance = false
-      runOnIdle { requireNotNull(selectTab).invoke(Tab.Space) }
-      repeat(8) { mainClock.advanceTimeByFrame() }
-      runOnIdle {
-        assertTrue(isBodyMoving)
-        assertTrue(sourceFocused)
-        assertFalse(requireNotNull(backgroundFocusRequester).requestFocus())
-        assertTrue(sourceFocused)
-      }
-
-      mainClock.autoAdvance = true
-      waitUntil(timeoutMillis = 5_000L) { currentTab == Tab.Space && !isBodyMoving }
-      runOnIdle { assertFalse(sourceFocused) }
     }
+    waitUntil { sourceFocused && selectTab != null }
+
+    mainClock.autoAdvance = false
+    runOnIdle { requireNotNull(selectTab).invoke(Tab.Space) }
+    repeat(8) { mainClock.advanceTimeByFrame() }
+    runOnIdle {
+      assertTrue(isBodyMoving)
+      assertTrue(sourceFocused)
+      assertFalse(requireNotNull(backgroundFocusRequester).requestFocus())
+      assertTrue(sourceFocused)
+    }
+
+    mainClock.autoAdvance = true
+    waitUntil(timeoutMillis = 5_000L) { currentTab == Tab.Space && !isBodyMoving }
+    waitUntil { keyboardDriver.endpoints == listOf(SoftwareKeyboardPresentationEndpoint.Hidden) }
+    runOnIdle {
+      assertTrue(sourceFocused)
+      assertFalse(requireNotNull(backgroundFocusRequester).requestFocus())
+      assertEquals(1f, keyboardDriver.progress.last())
+    }
+
+    runOnIdle { keyboardDriver.acceptEndpoint() }
+    waitUntil { !sourceFocused }
+    runOnIdle { assertTrue(requireNotNull(backgroundFocusRequester).requestFocus()) }
+  }
 
   @Test
   fun `feedback autofocus keeps the software keyboard visible inside main shell`() =
@@ -289,4 +304,26 @@ class MainShellAutofocusDesktopTest {
   private companion object {
     const val KeyboardStabilityNanos = 250_000_000L
   }
+}
+
+private class DeferredMainShellKeyboardDriver : SoftwareKeyboardPresentationDriver {
+  val progress = mutableListOf<Float>()
+  val endpoints = mutableListOf<SoftwareKeyboardPresentationEndpoint>()
+  private var endpointAcceptance: (() -> Unit)? = null
+
+  override fun updateHiddenProgress(progress: Float) {
+    this.progress += progress
+  }
+
+  override fun finish(endpoint: SoftwareKeyboardPresentationEndpoint, onAccepted: () -> Unit) {
+    endpoints += endpoint
+    endpointAcceptance = onAccepted
+  }
+
+  fun acceptEndpoint() {
+    endpointAcceptance?.invoke()
+    endpointAcceptance = null
+  }
+
+  override fun dispose() = Unit
 }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/shell/MainTabPagerDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/shell/MainTabPagerDesktopTest.kt
@@ -42,7 +42,6 @@ import co.typie.platform.SoftwareKeyboardPresentationDriver
 import co.typie.platform.SoftwareKeyboardPresentationEndpoint
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.CompletableDeferred
@@ -53,58 +52,96 @@ import kotlinx.coroutines.runBlocking
 @OptIn(ExperimentalTestApi::class)
 class MainTabPagerDesktopTest {
   @Test
-  fun `committed tab swipe hides the keyboard and clears focus only after settle`() =
-    runComposeUiTest {
-      lateinit var state: MainTabState
-      val focusRequester = FocusRequester()
-      val keyboardDriver = RecordingMainTabKeyboardDriver()
-      val controller = SoftwareKeyboardPresentationController { keyboardDriver }
-      var inputFocused = false
+  fun `committed tab swipe clears focus only after keyboard hide is accepted`() = runComposeUiTest {
+    lateinit var state: MainTabState
+    val focusRequester = FocusRequester()
+    val keyboardDriver = DeferredMainTabKeyboardDriver()
+    val controller = SoftwareKeyboardPresentationController { keyboardDriver }
+    var inputFocused = false
 
-      setContent {
-        CompositionLocalProvider(LocalSoftwareKeyboardPresentationController provides controller) {
-          Box(Modifier.size(width = 320.dp, height = 640.dp)) {
-            MainTabPager(
-              state = rememberMainTabState().also { state = it },
-              gestureAdmissionAllowed = true,
-              modifier = Modifier.fillMaxSize().testTag(PagerTag),
-            ) {
-              Box(Modifier.fillMaxSize())
-            }
-            BasicTextField(
-              value = "",
-              onValueChange = {},
-              modifier =
-                Modifier.size(1.dp).focusRequester(focusRequester).onFocusChanged {
-                  inputFocused = it.isFocused
-                },
-            )
-            LaunchedEffect(Unit) { focusRequester.requestFocus() }
+    setContent {
+      CompositionLocalProvider(LocalSoftwareKeyboardPresentationController provides controller) {
+        Box(Modifier.size(width = 320.dp, height = 640.dp)) {
+          MainTabPager(
+            state = rememberMainTabState().also { state = it },
+            gestureAdmissionAllowed = true,
+            modifier = Modifier.fillMaxSize().testTag(PagerTag),
+          ) {
+            Box(Modifier.fillMaxSize())
           }
+          BasicTextField(
+            value = "",
+            onValueChange = {},
+            modifier =
+              Modifier.size(1.dp).focusRequester(focusRequester).onFocusChanged {
+                inputFocused = it.isFocused
+              },
+          )
+          LaunchedEffect(Unit) { focusRequester.requestFocus() }
         }
       }
-      waitUntil { inputFocused }
+    }
+    waitUntil { inputFocused }
 
-      onNodeWithTag(PagerTag).performTouchInput {
-        down(center)
-        repeat(10) { moveBy(Offset(x = -20f, y = 0f), delayMillis = 16L) }
-      }
-      waitUntil { state.motion?.source == MainTabMotionSource.DirectDrag }
-      runOnIdle {
-        assertTrue(inputFocused)
-        assertTrue(keyboardDriver.endpoints.isEmpty())
-        assertTrue(keyboardDriver.progress.any { it > 0f })
-        assertTrue(keyboardDriver.progress.all { it in 0f..1f })
-      }
+    onNodeWithTag(PagerTag).performTouchInput {
+      down(center)
+      repeat(10) { moveBy(Offset(x = -20f, y = 0f), delayMillis = 16L) }
+    }
+    waitUntil { state.motion?.source == MainTabMotionSource.DirectDrag }
+    runOnIdle {
+      assertTrue(inputFocused)
+      assertTrue(keyboardDriver.endpoints.isEmpty())
+      assertTrue(keyboardDriver.progress.any { it > 0f })
+      assertTrue(keyboardDriver.progress.all { it in 0f..1f })
+    }
 
-      onNodeWithTag(PagerTag).performTouchInput { up() }
-      waitUntil(timeoutMillis = 5_000L) { state.motion == null && state.settledTab == Tab.Space }
+    onNodeWithTag(PagerTag).performTouchInput { up() }
+    waitUntil(timeoutMillis = 5_000L) { state.motion == null && state.settledTab == Tab.Space }
+    waitUntil { keyboardDriver.endpoints == listOf(SoftwareKeyboardPresentationEndpoint.Hidden) }
 
-      runOnIdle {
-        assertFalse(inputFocused)
-        assertEquals(listOf(SoftwareKeyboardPresentationEndpoint.Hidden), keyboardDriver.endpoints)
+    runOnIdle {
+      assertTrue(inputFocused)
+      assertEquals(1f, keyboardDriver.progress.last())
+    }
+    runOnIdle { keyboardDriver.acceptEndpoint() }
+    waitUntil { !inputFocused }
+  }
+
+  @Test
+  fun `delayed keyboard hide enables focus for the latest settled tab`() = runComposeUiTest {
+    lateinit var state: MainTabState
+    val keyboardDriver = DeferredMainTabKeyboardDriver()
+    val controller = SoftwareKeyboardPresentationController { keyboardDriver }
+
+    setContent {
+      CompositionLocalProvider(LocalSoftwareKeyboardPresentationController provides controller) {
+        MainTabPager(
+          state = rememberMainTabState().also { state = it },
+          gestureAdmissionAllowed = true,
+          modifier = Modifier.size(width = 320.dp, height = 640.dp),
+        ) {
+          Box(Modifier.fillMaxSize())
+        }
       }
     }
+    waitForIdle()
+
+    runOnIdle { state.selectTab(Tab.Space) }
+    waitUntil(timeoutMillis = 5_000L) { state.motion == null && state.settledTab == Tab.Space }
+    waitUntil { keyboardDriver.endpoints == listOf(SoftwareKeyboardPresentationEndpoint.Hidden) }
+    runOnIdle { assertEquals(Tab.Home, state.focusEnabledTab) }
+
+    runOnIdle { state.selectTab(Tab.Notes) }
+    waitUntil(timeoutMillis = 5_000L) { state.motion == null && state.settledTab == Tab.Notes }
+    runOnIdle {
+      assertEquals(Tab.Home, state.focusEnabledTab)
+      assertEquals(listOf(SoftwareKeyboardPresentationEndpoint.Hidden), keyboardDriver.endpoints)
+    }
+
+    runOnIdle { keyboardDriver.acceptEndpoint() }
+    waitUntil { state.focusEnabledTab != Tab.Home }
+    runOnIdle { assertEquals(Tab.Notes, state.focusEnabledTab) }
+  }
 
   @Test
   fun `cancelled tab swipe restores the keyboard without clearing focus`() = runComposeUiTest {
@@ -546,6 +583,28 @@ private class RecordingMainTabKeyboardDriver : SoftwareKeyboardPresentationDrive
   override fun finish(endpoint: SoftwareKeyboardPresentationEndpoint, onAccepted: () -> Unit) {
     endpoints += endpoint
     onAccepted()
+  }
+
+  override fun dispose() = Unit
+}
+
+private class DeferredMainTabKeyboardDriver : SoftwareKeyboardPresentationDriver {
+  val progress = mutableListOf<Float>()
+  val endpoints = mutableListOf<SoftwareKeyboardPresentationEndpoint>()
+  private var endpointAcceptance: (() -> Unit)? = null
+
+  override fun updateHiddenProgress(progress: Float) {
+    this.progress += progress
+  }
+
+  override fun finish(endpoint: SoftwareKeyboardPresentationEndpoint, onAccepted: () -> Unit) {
+    endpoints += endpoint
+    endpointAcceptance = onAccepted
+  }
+
+  fun acceptEndpoint() {
+    endpointAcceptance?.invoke()
+    endpointAcceptance = null
   }
 
   override fun dispose() = Unit


### PR DESCRIPTION
변경사항

- 탭 전환 완료 시 키보드 진행률을 `1f`로 확정하고, Hidden 수락 이후에만 포커스를 해제합니다.
- 그동안 이전 탭의 기존 포커스만 유지하고 새 탭의 신규 포커스는 차단합니다.
- 새 노트 autofocus는 최초 presentation에서 소비해, Notes로 돌아올 때 키보드가 다시 뜨지 않습니다.

개선점

- 탭 전환으로 키보드를 닫을 때 간헐적으로 키보드가 full size로 보였다가 줄어드는 문제를 해결
- 포커스가 풀렸던 탭으로 되돌아가는 중에 다시 포커스가 되고 키보드가 뜨는 문제를 해결
- 그런데 그럴 때 전환이 완료되면 다시 포커스가 해제되고 키보드가 내려가는 문제를 해결