### PR TITLE
인풋 포커스된 route를 pop할 때의 iOS 크래시 수정

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationStack.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationStack.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.ProvidedValue
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.movableContentOf
 import androidx.compose.runtime.mutableStateMapOf
@@ -71,6 +72,7 @@ import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.hazeSource
 import kotlin.math.abs
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.NonCancellable
@@ -221,6 +223,8 @@ fun NavigationStack(
   // compound key가 달라져 viewModel/rememberSaveable 키가 꼬인다.)
   val latestContent by rememberUpdatedState(content)
   val routeScenes = remember { mutableMapOf<Route, NavigationRouteScene>() }
+  var retainedRemovedRoutes by remember { mutableStateOf(emptyList<Route>()) }
+  var sceneApplyConfirmation by remember { mutableStateOf<CompletableDeferred<Unit>?>(null) }
   val routeSceneFor: (Route) -> NavigationRouteScene = { route ->
     routeScenes.getOrPut(route) {
       val owner =
@@ -267,11 +271,8 @@ fun NavigationStack(
       )
     }
 
-  // 백스택에서 제거된 라우트의 movable 캐시 정리
-  LaunchedEffect(Unit) {
-    snapshotFlow { navigator.stack.toSet() }
-      .collect { active -> routeScenes.keys.retainAll(active) }
-  }
+  val currentSceneApplyConfirmation = sceneApplyConfirmation
+  SideEffect { currentSceneApplyConfirmation?.complete(Unit) }
 
   val scope = rememberCoroutineScope()
   var containerWidth by remember { mutableStateOf(0f) }
@@ -325,6 +326,44 @@ fun NavigationStack(
     }
   }
 
+  suspend fun updateScenesAndAwaitApply(update: () -> Unit) {
+    val confirmation = CompletableDeferred<Unit>()
+    sceneApplyConfirmation = confirmation
+    update()
+    confirmation.await()
+  }
+
+  suspend fun settleAfterRemoval(removedRoutes: List<Route>) {
+    if (removedRoutes.isEmpty()) {
+      progress.snapTo(0f)
+      visibleRoute = navigator.current
+      behindRoute = null
+      animState = AnimState.Idle
+      return
+    }
+
+    // Moving the destination scene from behind to main while releasing the outgoing movable
+    // content in the same pager subcomposition can corrupt Compose Runtime's change list. First
+    // move both scenes to their settled slots, then release the outgoing scene in a separately
+    // applied composition.
+    // TODO: Re-test without this handoff after upgrading to a Compose Runtime that includes
+    // https://github.com/androidx/androidx/commit/215b08ffba30e9369e91460e1d726d646558e556.
+    // Remove it only after the focused pager regression test and the iOS keyboard repro both pass.
+    val presentedRemovedRoutes = removedRoutes.filter { it == visibleRoute || it.keepAlive }
+    updateScenesAndAwaitApply {
+      retainedRemovedRoutes = presentedRemovedRoutes
+      visibleRoute = navigator.current
+      behindRoute = null
+      animState = AnimState.Idle
+    }
+    updateScenesAndAwaitApply { retainedRemovedRoutes = emptyList() }
+    sceneApplyConfirmation = null
+
+    removedRoutes.forEach(routeScenes::remove)
+    navigator.clearViewModelStoresFor(removedRoutes)
+    clearRemovedRoutes(removedRoutes)
+  }
+
   suspend fun settleAtCurrentRoute(restoreKeyboard: Boolean = true) {
     progress.snapTo(0f)
     if (restoreKeyboard) softwareKeyboardInteraction.restore()
@@ -340,10 +379,7 @@ fun NavigationStack(
     } else {
       committedKeyboardHide.await()
     }
-    visibleRoute = navigator.current
-    behindRoute = null
-    animState = AnimState.Idle
-    clearRemovedRoutes(removedRoutes)
+    settleAfterRemoval(removedRoutes)
   }
 
   suspend fun animateRemovalTo(
@@ -616,8 +652,7 @@ fun NavigationStack(
                 // presentation failed; finish the exact prepared removal without another prompt.
                 val removedRoutes = navigator.performPopTo(targetRoute)
                 softwareKeyboardInteraction.hideAndAwaitResolution()
-                settleAtCurrentRoute(restoreKeyboard = false)
-                clearRemovedRoutes(removedRoutes)
+                settleAfterRemoval(removedRoutes)
                 navigator.consumePopRequest()
                 navigator.completeTransition()
               } else {
@@ -859,9 +894,9 @@ fun NavigationStack(
             }
           }
       ) {
-        navigator.stack.forEach { route ->
+        (navigator.stack + retainedRemovedRoutes).distinct().forEach { route ->
           if (route == mainRoute || route == behindRoute) return@forEach
-          if (!route.keepAlive) return@forEach
+          if (!route.keepAlive && route !in retainedRemovedRoutes) return@forEach
           Box(Modifier.fillMaxSize()) {
             presentRouteSurface(route, null, null)
             presentRouteForeground(route, null, null, Modifier.fillMaxSize())

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/Navigator.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/Navigator.kt
@@ -168,13 +168,16 @@ class Navigator(startRoute: Route) {
     val removedRoutes = mutableListOf<Route>()
     while (_stack.size > index + 1) {
       val removed = _stack.removeAt(_stack.lastIndex)
-      viewModelStores.remove(removed)?.clear()
       removedRoutes += removed
     }
     if (removedRoutes.isNotEmpty()) {
       lastOperation = NavOperation.Pop
     }
     return removedRoutes
+  }
+
+  internal fun clearViewModelStoresFor(routes: List<Route>) {
+    routes.forEach { route -> viewModelStores.remove(route)?.clear() }
   }
 
   suspend fun popTo(route: Route): NavigationResult {

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/shell/MainTabPagerDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/shell/MainTabPagerDesktopTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -36,12 +37,17 @@ import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
+import co.typie.navigation.NavigationStackTestHost
+import co.typie.navigation.Navigator
 import co.typie.platform.LocalSoftwareKeyboardPresentationController
 import co.typie.platform.SoftwareKeyboardPresentationController
 import co.typie.platform.SoftwareKeyboardPresentationDriver
 import co.typie.platform.SoftwareKeyboardPresentationEndpoint
+import co.typie.route.Route
+import co.typie.ui.component.topbar.TopBarState
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.CompletableDeferred
@@ -51,6 +57,72 @@ import kotlinx.coroutines.runBlocking
 
 @OptIn(ExperimentalTestApi::class)
 class MainTabPagerDesktopTest {
+  @Test
+  fun `focused nested route can pop to root inside the pager`() = runComposeUiTest {
+    val navigator = Navigator(listOf(Route.Home, Route.SpaceSettings))
+    val focusRequester = FocusRequester()
+    lateinit var pop: () -> Unit
+    var inputFocused = false
+    var outgoingAttached = false
+    var destinationAppliedWhileOutgoingAttached = false
+
+    setContent {
+      val scope = rememberCoroutineScope()
+      pop = { scope.launch { navigator.pop() } }
+      MainTabPager(
+        state = rememberMainTabState(),
+        gestureAdmissionAllowed = !navigator.canPop && !navigator.isTransitioning,
+        modifier = Modifier.size(width = 320.dp, height = 640.dp),
+      ) { tab ->
+        if (tab == Tab.Home) {
+          NavigationStackTestHost(
+            navigator = navigator,
+            topBarState = remember { TopBarState() },
+            modifier = Modifier.fillMaxSize(),
+          ) { route ->
+            if (route == Route.SpaceSettings) {
+              DisposableEffect(route) {
+                outgoingAttached = true
+                onDispose { outgoingAttached = false }
+              }
+              BasicTextField(
+                value = "",
+                onValueChange = {},
+                modifier =
+                  Modifier.fillMaxSize().focusRequester(focusRequester).onFocusChanged {
+                    inputFocused = it.isFocused
+                  },
+              )
+              LaunchedEffect(route) { focusRequester.requestFocus() }
+            } else {
+              SideEffect {
+                if (
+                  navigator.current == Route.Home && navigator.isTransitioning && outgoingAttached
+                ) {
+                  destinationAppliedWhileOutgoingAttached = true
+                }
+              }
+              Box(Modifier.fillMaxSize())
+            }
+          }
+        } else {
+          Box(Modifier.fillMaxSize())
+        }
+      }
+    }
+    waitUntil(timeoutMillis = 5_000L) {
+      navigator.current == Route.SpaceSettings && !navigator.isTransitioning
+    }
+    waitUntil { inputFocused }
+
+    runOnIdle { pop() }
+    waitUntil(timeoutMillis = 5_000L) {
+      navigator.current == Route.Home && !navigator.isTransitioning
+    }
+    assertTrue(destinationAppliedWhileOutgoingAttached)
+    assertFalse(outgoingAttached)
+  }
+
   @Test
   fun `committed tab swipe clears focus only after keyboard hide is accepted`() = runComposeUiTest {
     lateinit var state: MainTabState


### PR DESCRIPTION
Focused input이 있는 route를 pop할 때 destination scene 이동과 outgoing scene 해제가 같은 composition에서 일어나 Compose Runtime이 크래시할 수 있었습니다.  
(스페이스 설정 > 인풋 포커스 > 뒤로가기)

- outgoing scene을 다음 applied composition까지 유지
- scene 해제 후 ViewModelStore 정리
- focused input이 있는 pager route pop 회귀 테스트 추가
- 향후 Compose Runtime 업그레이드 시 workaround 제거를 재검증하도록 TODO 추가