### PR TITLE
하위 route pop 후 메인 탭과 drawer 스와이프가 복구되도록 함

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/Navigator.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/Navigator.kt
@@ -52,7 +52,7 @@ class Navigator(startRoute: Route) {
   val popRequested: Boolean
     get() = pendingPopTarget != null
 
-  private var transitionCompletion: CompletableDeferred<NavigationResult>? = null
+  private var transitionCompletion: CompletableDeferred<NavigationResult>? by mutableStateOf(null)
 
   val isTransitioning: Boolean
     get() = transitionCompletion?.isActive == true || removalLeaseActive

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/shell/MainTabPagerDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/shell/MainTabPagerDesktopTest.kt
@@ -58,9 +58,10 @@ import kotlinx.coroutines.runBlocking
 @OptIn(ExperimentalTestApi::class)
 class MainTabPagerDesktopTest {
   @Test
-  fun `focused nested route can pop to root inside the pager`() = runComposeUiTest {
+  fun `focused nested route pop restores pager gesture admission`() = runComposeUiTest {
     val navigator = Navigator(listOf(Route.Home, Route.SpaceSettings))
     val focusRequester = FocusRequester()
+    lateinit var mainTabState: MainTabState
     lateinit var pop: () -> Unit
     var inputFocused = false
     var outgoingAttached = false
@@ -70,9 +71,9 @@ class MainTabPagerDesktopTest {
       val scope = rememberCoroutineScope()
       pop = { scope.launch { navigator.pop() } }
       MainTabPager(
-        state = rememberMainTabState(),
+        state = rememberMainTabState().also { mainTabState = it },
         gestureAdmissionAllowed = !navigator.canPop && !navigator.isTransitioning,
-        modifier = Modifier.size(width = 320.dp, height = 640.dp),
+        modifier = Modifier.size(width = 320.dp, height = 640.dp).testTag(PagerTag),
       ) { tab ->
         if (tab == Tab.Home) {
           NavigationStackTestHost(
@@ -121,6 +122,14 @@ class MainTabPagerDesktopTest {
     }
     assertTrue(destinationAppliedWhileOutgoingAttached)
     assertFalse(outgoingAttached)
+
+    onNodeWithTag(PagerTag).performTouchInput {
+      down(center)
+      repeat(10) { moveBy(Offset(x = -20f, y = 0f), delayMillis = 16L) }
+      up()
+    }
+    waitUntil(timeoutMillis = 5_000L) { mainTabState.motion == null }
+    assertEquals(Tab.Space, mainTabState.settledTab)
   }
 
   @Test


### PR DESCRIPTION
스페이스 설정 같은 하위 route를 pop한 뒤 transition 종료가 Compose에 전파되지 않아, 메인 탭 pager와 drawer 스와이프가 비활성 상태로 남을 수 있었습니다.

- Navigator의 transition 상태를 Compose에서 관찰 가능하게 변경
- focused 하위 route pop 직후 메인 탭 스와이프가 복구되는 회귀 테스트 추가