### PR TITLE
스크롤 reveal policy와 behavior 분리

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorAutoScrollPolicy.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorAutoScrollPolicy.kt
@@ -191,7 +191,7 @@ internal fun resolveKeepVisibleScrollOffset(
   )
 }
 
-internal fun resolveResultRevealScrollOffset(
+internal fun resolveRevealScrollOffset(
   currentScroll: Float,
   targetTopInContent: Float,
   targetBottomInContent: Float,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorBringIntoViewRequests.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorBringIntoViewRequests.kt
@@ -13,13 +13,11 @@ import kotlinx.coroutines.CompletableDeferred
 
 @OptIn(ExperimentalAtomicApi::class)
 internal class EditorBringIntoViewRequests(private val requestPresentation: () -> Unit = {}) {
-  data class Request(val target: EditorBringIntoViewTarget, val policy: EditorBringIntoViewPolicy) {
-    val behavior: EditorBringIntoViewBehavior =
-      if (policy == EditorBringIntoViewPolicy.ResultReveal) {
-        EditorBringIntoViewBehavior.Smooth
-      } else {
-        EditorBringIntoViewBehavior.Instant
-      }
+  data class Request(
+    val target: EditorBringIntoViewTarget,
+    val policy: EditorBringIntoViewPolicy,
+    val behavior: EditorBringIntoViewBehavior,
+  ) {
     internal val targetVersion = AtomicLong(UNBOUND_VERSION)
     internal val presentation = CompletableDeferred<Unit>()
   }
@@ -29,12 +27,14 @@ internal class EditorBringIntoViewRequests(private val requestPresentation: () -
   fun requestForState(
     state: EditorState,
     policy: EditorBringIntoViewPolicy,
+    behavior: EditorBringIntoViewBehavior = EditorBringIntoViewBehavior.Instant,
     target: EditorState.() -> EditorBringIntoViewTarget?,
   ): Boolean {
     requestForVersion(
       target = state.target() ?: return false,
       version = state.version,
       policy = policy,
+      behavior = behavior,
     )
     return true
   }
@@ -43,10 +43,16 @@ internal class EditorBringIntoViewRequests(private val requestPresentation: () -
     target: EditorBringIntoViewTarget,
     version: Long,
     policy: EditorBringIntoViewPolicy,
-  ): Request = declare(target = target, policy = policy).also { bind(it, version) }
+    behavior: EditorBringIntoViewBehavior = EditorBringIntoViewBehavior.Instant,
+  ): Request =
+    declare(target = target, policy = policy, behavior = behavior).also { bind(it, version) }
 
-  fun declare(target: EditorBringIntoViewTarget, policy: EditorBringIntoViewPolicy): Request {
-    val request = Request(target = target, policy = policy)
+  fun declare(
+    target: EditorBringIntoViewTarget,
+    policy: EditorBringIntoViewPolicy,
+    behavior: EditorBringIntoViewBehavior = EditorBringIntoViewBehavior.Instant,
+  ): Request {
+    val request = Request(target = target, policy = policy, behavior = behavior)
     pending.exchange(request)?.presentation?.complete(Unit)
     requestPresentation()
     return request

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorScrollIntent.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorScrollIntent.kt
@@ -65,7 +65,7 @@ internal enum class EditorBringIntoViewPolicy {
   CursorGuard,
   PointerCursorGuard,
   Typewriter,
-  ResultReveal,
+  Reveal,
 }
 
 internal sealed interface EditorScrollIntentResult {
@@ -226,7 +226,7 @@ internal fun resolveInstantRevealPreparationViewports(
 
       EditorBringIntoViewPolicy.CursorGuard,
       EditorBringIntoViewPolicy.PointerCursorGuard,
-      EditorBringIntoViewPolicy.ResultReveal -> {
+      EditorBringIntoViewPolicy.Reveal -> {
         val range = keepVisibleRange
         if (!range.isValid) {
           listOf(
@@ -422,8 +422,8 @@ private fun resolveBringIntoViewTargetOffset(
         maximumScrollY = maximumScrollY,
       )
 
-    EditorBringIntoViewPolicy.ResultReveal ->
-      resolveResultRevealScrollOffset(
+    EditorBringIntoViewPolicy.Reveal ->
+      resolveRevealScrollOffset(
         currentScroll = currentScroll,
         targetTopInContent = rect.top,
         targetBottomInContent = rect.bottom,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorUpdateWithBringIntoView.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorUpdateWithBringIntoView.kt
@@ -7,12 +7,17 @@ import co.typie.editor.beforePublish
 import co.typie.editor.ffi.Message
 
 internal interface EditorBringIntoViewUpdateScope : EditorRequestScope {
-  fun bringIntoView(target: EditorBringIntoViewTarget, policy: EditorBringIntoViewPolicy)
+  fun bringIntoView(
+    target: EditorBringIntoViewTarget,
+    policy: EditorBringIntoViewPolicy,
+    behavior: EditorBringIntoViewBehavior = EditorBringIntoViewBehavior.Instant,
+  )
 }
 
 private data class EditorBringIntoViewUpdate(
   val target: EditorBringIntoViewTarget,
   val policy: EditorBringIntoViewPolicy,
+  val behavior: EditorBringIntoViewBehavior,
 )
 
 private fun EditorRequestScope.applyBringIntoViewUpdate(
@@ -29,8 +34,10 @@ private fun EditorRequestScope.applyBringIntoViewUpdate(
       override fun bringIntoView(
         target: EditorBringIntoViewTarget,
         policy: EditorBringIntoViewPolicy,
+        behavior: EditorBringIntoViewBehavior,
       ) {
-        selectedUpdate = EditorBringIntoViewUpdate(target = target, policy = policy)
+        selectedUpdate =
+          EditorBringIntoViewUpdate(target = target, policy = policy, behavior = behavior)
       }
     }
   )
@@ -42,7 +49,12 @@ internal fun Editor.updateNowWithBringIntoView(
   block: EditorBringIntoViewUpdateScope.() -> Unit,
 ): EditorUpdate? = updateNow {
   applyBringIntoViewUpdate(block)?.let { reveal ->
-    val request = bringIntoViewRequests.declare(target = reveal.target, policy = reveal.policy)
+    val request =
+      bringIntoViewRequests.declare(
+        target = reveal.target,
+        policy = reveal.policy,
+        behavior = reveal.behavior,
+      )
     beforePublish(
       block = { applied -> bringIntoViewRequests.bind(request, applied.revision) },
       onDiscard = { bringIntoViewRequests.discard(request) },
@@ -60,7 +72,11 @@ internal suspend fun Editor.updateWithBringIntoView(
     update(admit = admit) {
       applyBringIntoViewUpdate(block)?.let { requested ->
         val request =
-          bringIntoViewRequests.declare(target = requested.target, policy = requested.policy)
+          bringIntoViewRequests.declare(
+            target = requested.target,
+            policy = requested.policy,
+            behavior = requested.behavior,
+          )
         reveal = request
         beforePublish(
           block = { applied -> bringIntoViewRequests.bind(request, applied.revision) },

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/aifeedback/EditorAiFeedbackSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/aifeedback/EditorAiFeedbackSession.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.viewmodel.compose.viewModel
 import co.typie.editor.Editor
 import co.typie.editor.EditorState
+import co.typie.editor.scroll.EditorBringIntoViewBehavior
 import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.toPageRectsTarget
@@ -77,7 +78,8 @@ internal fun rememberEditorAiFeedbackSession(
     if (id == null) return
     bringIntoViewRequests.requestForState(
       state = activeEditor.appliedState,
-      policy = EditorBringIntoViewPolicy.ResultReveal,
+      policy = EditorBringIntoViewPolicy.Reveal,
+      behavior = EditorBringIntoViewBehavior.Smooth,
     ) {
       trackedRanges.firstOrNull { it.id == id }?.rects?.toPageRectsTarget()
     }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/entry/EditorEntryStateSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/entry/EditorEntryStateSession.kt
@@ -72,7 +72,7 @@ internal fun rememberEditorEntryStateSession(
       enqueue(Message.Selection(SelectionOp.SetFrozen(selection = selection)))
       bringIntoView(
         EditorBringIntoViewTarget.CurrentSelectionHead,
-        policy = EditorBringIntoViewPolicy.CursorGuard,
+        policy = EditorBringIntoViewPolicy.Reveal,
       )
     }
     session.markPresentationReady()

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/EditorFindReplaceSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/EditorFindReplaceSession.kt
@@ -14,6 +14,7 @@ import co.typie.editor.DocumentEditingSession
 import co.typie.editor.Editor
 import co.typie.editor.EditorState
 import co.typie.editor.ext.isCollapsed
+import co.typie.editor.scroll.EditorBringIntoViewBehavior
 import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.storage.Preference
@@ -388,7 +389,8 @@ private class FindReplaceSessionController {
   ) {
     bringIntoViewRequests.requestForState(
       state = editor.appliedState,
-      policy = EditorBringIntoViewPolicy.ResultReveal,
+      policy = EditorBringIntoViewPolicy.Reveal,
+      behavior = EditorBringIntoViewBehavior.Smooth,
     ) {
       trackedRanges.searchMatchScrollTarget(activeMatchId())
     }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/spellcheck/EditorSpellcheckSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/spellcheck/EditorSpellcheckSession.kt
@@ -17,6 +17,7 @@ import co.typie.editor.EditorState
 import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.Selection
 import co.typie.editor.ffi.SelectionOp
+import co.typie.editor.scroll.EditorBringIntoViewBehavior
 import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.EditorBringIntoViewTarget
@@ -88,7 +89,8 @@ internal fun rememberEditorSpellcheckSession(
     if (id == null) return
     bringIntoViewRequests.requestForState(
       state = activeEditor.appliedState,
-      policy = EditorBringIntoViewPolicy.ResultReveal,
+      policy = EditorBringIntoViewPolicy.Reveal,
+      behavior = EditorBringIntoViewBehavior.Smooth,
     ) {
       trackedRanges.firstOrNull { it.id == id }?.rects?.toPageRectsTarget()
     }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/comments/EditorCommentsSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/comments/EditorCommentsSession.kt
@@ -15,6 +15,7 @@ import co.typie.editor.Editor
 import co.typie.editor.EditorState
 import co.typie.editor.ffi.StableSelection
 import co.typie.editor.ffi.TrackedRange
+import co.typie.editor.scroll.EditorBringIntoViewBehavior
 import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.EditorBringIntoViewTarget
@@ -209,7 +210,8 @@ internal fun rememberEditorCommentsSession(
     bringIntoViewRequests.requestForVersion(
       target = target,
       version = snapshot.version,
-      policy = EditorBringIntoViewPolicy.ResultReveal,
+      policy = EditorBringIntoViewPolicy.Reveal,
+      behavior = EditorBringIntoViewBehavior.Smooth,
     )
     lastRequestedActivationRevision = activeThreadActivationRevision
   }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorBringIntoViewRequestsTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorBringIntoViewRequestsTest.kt
@@ -21,7 +21,11 @@ class EditorBringIntoViewRequestsTest {
     val state = EditorState.Initial.copy(version = 11L, selectionHitRects = pageRectsTarget.rects)
 
     assertTrue(
-      requests.requestForState(state, policy = EditorBringIntoViewPolicy.ResultReveal) {
+      requests.requestForState(
+        state,
+        policy = EditorBringIntoViewPolicy.Reveal,
+        behavior = EditorBringIntoViewBehavior.Smooth,
+      ) {
         selectionHitRects.toPageRectsTarget()
       }
     )
@@ -29,18 +33,33 @@ class EditorBringIntoViewRequestsTest {
     assertNull(requests.activateForVersion(version = 10L))
     val request = requests.activateForVersion(version = 11L)
     assertTrue(request?.target == pageRectsTarget)
-    assertTrue(request?.policy == EditorBringIntoViewPolicy.ResultReveal)
+    assertTrue(request?.policy == EditorBringIntoViewPolicy.Reveal)
     assertTrue(request?.behavior == EditorBringIntoViewBehavior.Smooth)
   }
 
   @Test
-  fun `result reveal derives smooth behavior`() {
+  fun `request behavior defaults to instant independently from reveal policy`() {
     val requests = EditorBringIntoViewRequests()
 
     requests.requestForVersion(
       target = pageRectsTarget,
       version = 11L,
-      policy = EditorBringIntoViewPolicy.ResultReveal,
+      policy = EditorBringIntoViewPolicy.Reveal,
+    )
+
+    val request = requests.activateForVersion(version = 11L)
+    assertTrue(request?.behavior == EditorBringIntoViewBehavior.Instant)
+  }
+
+  @Test
+  fun `request accepts smooth behavior independently from reveal policy`() {
+    val requests = EditorBringIntoViewRequests()
+
+    requests.requestForVersion(
+      target = pageRectsTarget,
+      version = 11L,
+      policy = EditorBringIntoViewPolicy.Reveal,
+      behavior = EditorBringIntoViewBehavior.Smooth,
     )
 
     val request = requests.activateForVersion(version = 11L)
@@ -100,8 +119,7 @@ class EditorBringIntoViewRequestsTest {
         1L,
         EditorBringIntoViewPolicy.CursorGuard,
       )
-    val current =
-      requests.requestForVersion(pageRectsTarget, 2L, EditorBringIntoViewPolicy.ResultReveal)
+    val current = requests.requestForVersion(pageRectsTarget, 2L, EditorBringIntoViewPolicy.Reveal)
 
     assertTrue(previous.presentation.isCompleted)
     assertSame(current, requests.activateForVersion(version = 2L))
@@ -115,7 +133,7 @@ class EditorBringIntoViewRequestsTest {
         EditorBringIntoViewTarget.CurrentSelectionHead,
         EditorBringIntoViewPolicy.CursorGuard,
       )
-    val current = requests.declare(pageRectsTarget, EditorBringIntoViewPolicy.ResultReveal)
+    val current = requests.declare(pageRectsTarget, EditorBringIntoViewPolicy.Reveal)
 
     assertFalse(requests.bind(previous, version = 1L))
     assertTrue(requests.bind(current, version = 2L))
@@ -129,7 +147,7 @@ class EditorBringIntoViewRequestsTest {
       requests.requestForVersion(
         pageRectsTarget,
         version = 2L,
-        policy = EditorBringIntoViewPolicy.ResultReveal,
+        policy = EditorBringIntoViewPolicy.Reveal,
       )
 
     assertNull(requests.activateForVersion(version = 3L))

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorScrollResolverTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorScrollResolverTest.kt
@@ -542,7 +542,7 @@ class EditorScrollResolverTest {
               PageRect(pageIdx = 1, rect = FfiRect(x = 0f, y = 20f, width = 40f, height = 20f)),
             )
           ),
-        policy = EditorBringIntoViewPolicy.ResultReveal,
+        policy = EditorBringIntoViewPolicy.Reveal,
         currentScroll = 0f,
       )
 
@@ -550,7 +550,7 @@ class EditorScrollResolverTest {
   }
 
   @Test
-  fun `page rects result reveal top-aligns an oversized target below the viewport`() {
+  fun `page rects reveal top-aligns an oversized target below the viewport`() {
     val frame =
       frame(
         state =
@@ -570,7 +570,7 @@ class EditorScrollResolverTest {
               PageRect(pageIdx = 0, rect = FfiRect(x = 0f, y = 500f, width = 40f, height = 400f))
             )
           ),
-        policy = EditorBringIntoViewPolicy.ResultReveal,
+        policy = EditorBringIntoViewPolicy.Reveal,
         currentScroll = 0f,
       )
 

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorUpdateWithBringIntoViewTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorUpdateWithBringIntoViewTest.kt
@@ -69,6 +69,7 @@ class EditorUpdateWithBringIntoViewTest {
             bringIntoView(
               EditorBringIntoViewTarget.CurrentSelectionHead,
               policy = EditorBringIntoViewPolicy.Typewriter,
+              behavior = EditorBringIntoViewBehavior.Smooth,
             )
           }
         )
@@ -79,6 +80,7 @@ class EditorUpdateWithBringIntoViewTest {
       val request = assertNotNull(requests.activateForVersion(version = 1L))
       assertTrue(request.target == EditorBringIntoViewTarget.CurrentSelectionHead)
       assertEquals(EditorBringIntoViewPolicy.Typewriter, request.policy)
+      assertEquals(EditorBringIntoViewBehavior.Smooth, request.behavior)
     }
 
   @Test

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/attachment/DefaultEditorAttachmentImporterTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/attachment/DefaultEditorAttachmentImporterTest.kt
@@ -24,6 +24,7 @@ import co.typie.editor.ffi.NodeOp
 import co.typie.editor.ffi.PlainNode
 import co.typie.editor.ffi.Rect
 import co.typie.editor.ffi.StateField
+import co.typie.editor.scroll.EditorBringIntoViewBehavior
 import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.EditorBringIntoViewTarget
@@ -218,6 +219,7 @@ class DefaultEditorAttachmentImporterTest {
       EditorBringIntoViewRequests.Request(
         target = EditorBringIntoViewTarget.CurrentSelectionHead,
         policy = EditorBringIntoViewPolicy.Typewriter,
+        behavior = EditorBringIntoViewBehavior.Instant,
       ),
       bringIntoViewRequests.activateForVersion(editor.appliedState.version),
     )

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/layout/EditorSurfacePreparationTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/layout/EditorSurfacePreparationTest.kt
@@ -20,6 +20,7 @@ import co.typie.editor.ffi.ViewportAnchor
 import co.typie.editor.ffi.ViewportAnchorPoint
 import co.typie.editor.ffi.ViewportAnchorResolution
 import co.typie.editor.runtime.EditorBoundsInContainer
+import co.typie.editor.scroll.EditorBringIntoViewBehavior
 import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.EditorBringIntoViewTarget
@@ -60,7 +61,12 @@ class EditorSurfacePreparationTest {
     val measuredFrame = selectionFrame(version = 2L, rect = measuredRect)
     val target = EditorBringIntoViewTarget.CurrentSelectionHead
     val policy = EditorBringIntoViewPolicy.CursorGuard
-    val request = EditorBringIntoViewRequests.Request(target = target, policy = policy)
+    val request =
+      EditorBringIntoViewRequests.Request(
+        target = target,
+        policy = policy,
+        behavior = EditorBringIntoViewBehavior.Instant,
+      )
     val provisionalScroll =
       (resolveEditorSurfacePreparation(
             editor = Editor(FakeFfiEditor(), this, StandardTestDispatcher(testScheduler)),
@@ -148,7 +154,8 @@ class EditorSurfacePreparationTest {
           EditorBringIntoViewTarget.PageRects(
             listOf(PageRect(pageIdx = 2, rect = Rect(x = 0f, y = 100f, width = 1f, height = 20f)))
           ),
-        policy = EditorBringIntoViewPolicy.ResultReveal,
+        policy = EditorBringIntoViewPolicy.Reveal,
+        behavior = EditorBringIntoViewBehavior.Instant,
       )
 
     val uncorrected =

--- a/apps/website/src/lib/editor-ffi/editor-frame-sync.browser.test.ts
+++ b/apps/website/src/lib/editor-ffi/editor-frame-sync.browser.test.ts
@@ -536,7 +536,7 @@ describe('web editor frame synchronization', () => {
     let restorePresentation: Promise<void> | undefined;
     const restore = editor.updateNow((request) => {
       request.enqueue({ type: 'selection', op: { type: 'set_frozen', selection: saved } });
-      restorePresentation = editor.scrollIntoView({ target: { type: 'current_selection_head' }, policy: 'cursor_guard' });
+      restorePresentation = editor.scrollIntoView({ target: { type: 'current_selection_head' }, policy: 'reveal' });
     });
     expect(restore).not.toBeNull();
     if (!restore) throw new Error('Expected a restore update');

--- a/apps/website/src/lib/editor-ffi/editor-publication-preparation.test.ts
+++ b/apps/website/src/lib/editor-ffi/editor-publication-preparation.test.ts
@@ -47,7 +47,7 @@ describe('editor publication preparation', () => {
       },
     } as unknown as Editor;
     const scroll = new EditorScrollScope(editor, () => ({ enabled: false, position: undefined }));
-    scroll.scrollIntoView({ target: { type: 'tracked_item', id: 'target' }, policy: 'result_reveal' });
+    scroll.scrollIntoView({ target: { type: 'tracked_item', id: 'target' }, policy: 'reveal' });
     const preparation = resolveEditorSurfacePreparation(editor, scroll, 2100);
 
     expect(preparation?.scrollIntent).toEqual({ type: 'scroll_to', y: 2040 });

--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -934,7 +934,7 @@ export class Editor {
     if (idx === undefined) return;
     const match = this.#searchMatches[idx];
     if (!match) return;
-    this.scrollIntoView({ target: { type: 'tracked_item', id: match.id }, policy: 'result_reveal' });
+    this.scrollIntoView({ target: { type: 'tracked_item', id: match.id }, policy: 'reveal', behavior: 'smooth' });
   }
 
   #handleSearchReplaceResult(id: string, outcome: string): void {
@@ -2405,7 +2405,7 @@ export class Editor {
         this.activeSpellcheckErrorId = null;
         return;
       }
-      this.scrollIntoView({ target: { type: 'tracked_item', id }, policy: 'result_reveal' });
+      this.scrollIntoView({ target: { type: 'tracked_item', id }, policy: 'reveal', behavior: 'smooth' });
     }
   }
 
@@ -2582,7 +2582,7 @@ export class Editor {
     if (id !== null) {
       const ok = move(id, 'comment-active');
       if (ok) {
-        this.scrollIntoView({ target: { type: 'tracked_item', id }, policy: 'result_reveal' });
+        this.scrollIntoView({ target: { type: 'tracked_item', id }, policy: 'reveal', behavior: 'smooth' });
       } else {
         this.activeCommentId = null;
       }
@@ -2615,7 +2615,7 @@ export class Editor {
         this.activeAiFeedbackId = null;
         return;
       }
-      this.scrollIntoView({ target: { type: 'tracked_item', id }, policy: 'result_reveal' });
+      this.scrollIntoView({ target: { type: 'tracked_item', id }, policy: 'reveal', behavior: 'smooth' });
     }
   }
 

--- a/apps/website/src/lib/editor-ffi/scroll-scope.test.ts
+++ b/apps/website/src/lib/editor-ffi/scroll-scope.test.ts
@@ -196,7 +196,7 @@ describe('EditorScrollScope', () => {
       rect: { x: 0, y: 1000, width: 1, height: 500 },
     });
     const { scope } = setup(snapshot);
-    const request = scope.declare({ target: { type: 'tracked_item', id: 'target' }, policy: 'result_reveal' });
+    const request = scope.declare({ target: { type: 'tracked_item', id: 'target' }, policy: 'reveal' });
 
     expect(
       scope.resolveScrollTop(
@@ -207,7 +207,7 @@ describe('EditorScrollScope', () => {
     ).toBe(940);
   });
 
-  it('derives smooth behavior for tracked result reveals', () => {
+  it('defaults request behavior to instant independently from the reveal policy', () => {
     const snapshot = trackedSnapshot('target', {
       page_idx: 0,
       rect: { x: 0, y: 1000, width: 1, height: 500 },
@@ -216,7 +216,23 @@ describe('EditorScrollScope', () => {
 
     const request = scope.declare({
       target: { type: 'tracked_item', id: 'target' },
-      policy: 'result_reveal',
+      policy: 'reveal',
+    });
+
+    expect(request.behavior).toBe('instant');
+  });
+
+  it('accepts smooth behavior independently from the reveal policy', () => {
+    const snapshot = trackedSnapshot('target', {
+      page_idx: 0,
+      rect: { x: 0, y: 1000, width: 1, height: 500 },
+    });
+    const { scope } = setup(snapshot);
+
+    const request = scope.declare({
+      target: { type: 'tracked_item', id: 'target' },
+      policy: 'reveal',
+      behavior: 'smooth',
     });
 
     expect(request.behavior).toBe('smooth');
@@ -309,7 +325,7 @@ describe('EditorScrollScope', () => {
       rect: { x: 0, y: 900, width: 1, height: 20 },
     });
     const { scope } = setup(snapshot);
-    const request = scope.declare({ target: { type: 'tracked_item', id: 'target' }, policy: 'result_reveal' });
+    const request = scope.declare({ target: { type: 'tracked_item', id: 'target' }, policy: 'reveal' });
 
     expect(scope.activateForRevision(7)).toBeNull();
     expect(scope.bind(request, 7)).toBe(true);
@@ -341,7 +357,11 @@ describe('EditorScrollScope', () => {
     });
     const { scope, setScrollTop } = setup(snapshot);
 
-    const presentation = scope.scrollIntoView({ target: { type: 'tracked_item', id: 'target' }, policy: 'result_reveal' });
+    const presentation = scope.scrollIntoView({
+      target: { type: 'tracked_item', id: 'target' },
+      policy: 'reveal',
+      behavior: 'smooth',
+    });
     const request = scope.pendingRequest;
     if (!request) throw new Error('Expected a pending reveal');
 
@@ -367,7 +387,7 @@ describe('EditorScrollScope', () => {
       rect: { x: 0, y: 900, width: 1, height: 20 },
     });
     const { scope } = setup(snapshot);
-    const tracked = scope.declare({ target: { type: 'tracked_item', id: 'target' }, policy: 'result_reveal' });
+    const tracked = scope.declare({ target: { type: 'tracked_item', id: 'target' }, policy: 'reveal' });
     expect(scope.bind(tracked, 7)).toBe(true);
     expect(scope.activateForRevision(8)).toBe(tracked);
 
@@ -406,7 +426,7 @@ describe('EditorScrollScope', () => {
     });
     const oldPresentation = old.presentation;
 
-    scope.declare({ target: { type: 'tracked_item', id: 'new' }, policy: 'result_reveal' });
+    scope.declare({ target: { type: 'tracked_item', id: 'new' }, policy: 'reveal' });
 
     await expect(oldPresentation).resolves.toBeUndefined();
   });
@@ -417,7 +437,7 @@ describe('EditorScrollScope', () => {
       rect: { x: 0, y: 900, width: 1, height: 20 },
     });
     const { requestPublication, scope } = setup(snapshot);
-    const request = scope.declare({ target: { type: 'tracked_item', id: 'target' }, policy: 'result_reveal' });
+    const request = scope.declare({ target: { type: 'tracked_item', id: 'target' }, policy: 'reveal' });
     const presentation = request.presentation;
     requestPublication.mockClear();
 
@@ -434,7 +454,7 @@ describe('EditorScrollScope', () => {
       rect: { x: 0, y: 900, width: 1, height: 20 },
     });
     const { scope, scrollTo, setScrollTop } = setup(snapshot);
-    scope.scrollIntoView({ target: { type: 'tracked_item', id: 'target' }, policy: 'result_reveal' });
+    scope.scrollIntoView({ target: { type: 'tracked_item', id: 'target' }, policy: 'reveal', behavior: 'smooth' });
     const request = scope.pendingRequest;
     if (!request) throw new Error('Expected a pending reveal');
     expect(scope.applyPending(request, snapshot, { type: 'scroll_to', y: 580 })).toBe(true);
@@ -453,9 +473,9 @@ describe('EditorScrollScope', () => {
     });
     const { requestPublication, scope } = setup(snapshot);
 
-    scope.scrollIntoView({ target: { type: 'tracked_item', id: 'old' }, policy: 'result_reveal' });
+    scope.scrollIntoView({ target: { type: 'tracked_item', id: 'old' }, policy: 'reveal', behavior: 'smooth' });
     const old = scope.pendingRequest;
-    scope.scrollIntoView({ target: { type: 'tracked_item', id: 'new' }, policy: 'result_reveal' });
+    scope.scrollIntoView({ target: { type: 'tracked_item', id: 'new' }, policy: 'reveal', behavior: 'smooth' });
 
     expect(scope.pendingRequest?.target).toEqual({ type: 'tracked_item', id: 'new' });
     expect(requestPublication).toHaveBeenCalledTimes(2);
@@ -469,9 +489,9 @@ describe('EditorScrollScope', () => {
     });
     const { requestPublication, scope, scrollTo, setScrollTop } = setup(snapshot);
 
-    scope.scrollIntoView({ target: { type: 'tracked_item', id: 'old' }, policy: 'result_reveal' });
+    scope.scrollIntoView({ target: { type: 'tracked_item', id: 'old' }, policy: 'reveal', behavior: 'smooth' });
     const old = scope.pendingRequest;
-    scope.scrollIntoView({ target: { type: 'tracked_item', id: 'new' }, policy: 'result_reveal' });
+    scope.scrollIntoView({ target: { type: 'tracked_item', id: 'new' }, policy: 'reveal', behavior: 'smooth' });
     const current = scope.pendingRequest;
     if (!old || !current) throw new Error('Expected both scroll requests');
     requestPublication.mockClear();
@@ -685,7 +705,7 @@ describe('EditorScrollScope', () => {
       rect: { x: 0, y: 900, width: 1, height: 20 },
     });
     const { scope, scrollTo, setScrollTop } = setup(snapshot);
-    scope.scrollIntoView({ target: { type: 'tracked_item', id: 'target' }, policy: 'result_reveal' });
+    scope.scrollIntoView({ target: { type: 'tracked_item', id: 'target' }, policy: 'reveal', behavior: 'smooth' });
     const request = scope.pendingRequest;
     if (!request) throw new Error('Expected a pending reveal');
 
@@ -714,7 +734,7 @@ describe('EditorScrollScope', () => {
       rect: { x: 0, y: 900, width: 1, height: 20 },
     });
     const { scope, scrollTo } = setup(snapshot);
-    scope.scrollIntoView({ target: { type: 'tracked_item', id: 'target' }, policy: 'result_reveal' });
+    scope.scrollIntoView({ target: { type: 'tracked_item', id: 'target' }, policy: 'reveal', behavior: 'smooth' });
     const request = scope.pendingRequest;
     if (!request) throw new Error('Expected a pending reveal');
 
@@ -738,7 +758,7 @@ describe('EditorScrollScope', () => {
     });
     const { editor, scope, scrollTo, setScrollTop } = setup(snapshot);
 
-    scope.scrollIntoView({ target: { type: 'tracked_item', id: 'target' }, policy: 'result_reveal' });
+    scope.scrollIntoView({ target: { type: 'tracked_item', id: 'target' }, policy: 'reveal', behavior: 'smooth' });
     const request = scope.pendingRequest;
     if (!request) throw new Error('Expected a scroll request');
 
@@ -763,7 +783,7 @@ describe('EditorScrollScope', () => {
     });
     const { scope, scrollTo } = setup(snapshot);
 
-    scope.scrollIntoView({ target: { type: 'tracked_item', id: 'missing' }, policy: 'result_reveal' });
+    scope.scrollIntoView({ target: { type: 'tracked_item', id: 'missing' }, policy: 'reveal' });
     const request = scope.pendingRequest;
     if (!request) throw new Error('Expected a scroll request');
     const presentation = request.presentation;

--- a/apps/website/src/lib/editor-ffi/scroll.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/scroll.svelte.ts
@@ -17,14 +17,16 @@ import type { VerticalSpan } from './required-surface-pages';
 import type { EditorVisibleArea, RevealTargetSpan, ScrollContainerMetrics } from './scroll';
 import type { EditorViewportAnchorGeometry, EditorViewportAnchorLayout, EditorViewportAnchorRevealOrigin } from './viewport-anchor';
 
-export type EditorScrollRevealPolicy = 'cursor_guard' | 'pointer_cursor_guard' | 'typewriter' | 'result_reveal';
+export type EditorScrollRevealPolicy = 'cursor_guard' | 'pointer_cursor_guard' | 'typewriter' | 'reveal';
 type ResolvedEditorScrollRevealPolicy = Exclude<EditorScrollRevealPolicy, 'pointer_cursor_guard'>;
+export type EditorScrollBehavior = 'instant' | 'smooth';
 
 export type EditorScrollIntoViewTarget = { type: 'current_selection_head' } | { type: 'tracked_item'; id: string };
 
 export type EditorScrollIntoViewOptions = {
   target: EditorScrollIntoViewTarget;
   policy: EditorScrollRevealPolicy;
+  behavior?: EditorScrollBehavior;
 };
 
 export type EditorScrollIntentResult = { type: 'unresolved' } | { type: 'no_scroll' } | { type: 'scroll_to'; y: number };
@@ -38,7 +40,7 @@ type TypewriterPreferences = {
 };
 
 export type EditorBringIntoViewRequest = EditorScrollIntoViewOptions & {
-  behavior: ScrollBehavior;
+  behavior: EditorScrollBehavior;
   targetRevision: number | null;
   presentation: Promise<void>;
   completePresentation: () => void;
@@ -68,12 +70,12 @@ function sanitizeTypewriterPosition(position: number | undefined): number {
   return typeof position === 'number' && Number.isFinite(position) ? Math.max(0, Math.min(1, position)) : 0.5;
 }
 
-function createBringIntoViewRequest({ target, policy }: EditorScrollIntoViewOptions): EditorBringIntoViewRequest {
+function createBringIntoViewRequest({ target, policy, behavior = 'instant' }: EditorScrollIntoViewOptions): EditorBringIntoViewRequest {
   const { promise: presentation, resolve } = Promise.withResolvers<undefined>();
   return {
     target,
     policy,
-    behavior: policy === 'result_reveal' ? 'smooth' : 'instant',
+    behavior,
     targetRevision: null,
     presentation,
     completePresentation: () => resolve(undefined),
@@ -435,7 +437,7 @@ export class EditorScrollScope {
           position: sanitizeTypewriterPosition(this.#typewriterPreferences().position),
         });
       }
-      case 'result_reveal': {
+      case 'reveal': {
         return resolveGuardedScrollTop({
           ...metrics,
           visibleArea: this.visibleArea,
@@ -532,12 +534,12 @@ export class EditorScrollScope {
     });
   }
 
-  scrollIntoView({ target, policy }: EditorScrollIntoViewOptions, admission?: EditorRequest): Promise<void> | undefined {
+  scrollIntoView(options: EditorScrollIntoViewOptions, admission?: EditorRequest): Promise<void> | undefined {
     if (this.#destroyed) {
       return;
     }
 
-    const request = this.declare({ target, policy });
+    const request = this.declare(options);
     if (admission) {
       admission.beforePublish(
         (update) => {

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-comments/DocumentComments.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-comments/DocumentComments.svelte
@@ -259,7 +259,7 @@
     }
     activeThreadId = id;
     activeAnchor = anchor;
-    ctx.scroll?.scrollIntoView({ target: { type: 'tracked_item', id }, policy: 'result_reveal' });
+    ctx.scroll?.scrollIntoView({ target: { type: 'tracked_item', id }, policy: 'reveal', behavior: 'smooth' });
   }
 
   function takeFocusReturnSession(): FocusReturnSession | null {

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditor.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditor.svelte
@@ -913,7 +913,7 @@
                 selection: savedSelection,
               },
             });
-            presentation = editor.scrollIntoView({ target: { type: 'current_selection_head' }, policy: 'cursor_guard' });
+            presentation = editor.scrollIntoView({ target: { type: 'current_selection_head' }, policy: 'reveal' });
           });
           return presentation;
         } catch {


### PR DESCRIPTION
- 기존의 result_reveal 정책을 reveal로 rename
- policy와 behavior 분리: 기존에는 result_reveal일 때만 behavior가 smooth였으나 이제 behavior는 명시적으로 지정해야 하며 기본값은 instant임
- 문서 로드 시 스크롤 복원은 이제 reveal + instant임