### PR TITLE
키보드 전환 중 하단 UI의 프레임 지연을 줄임

### DIFF
--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/ext/ImeInsets.android.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/ext/ImeInsets.android.kt
@@ -4,17 +4,16 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.imeAnimationTarget
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.dp
+import androidx.compose.runtime.remember
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
-internal actual fun rememberTrustedImeBottomInset() =
-  with(LocalDensity.current) {
-    val rawImeBottom = WindowInsets.ime.getBottom(this).toDp()
-    val animationTargetBottom = WindowInsets.imeAnimationTarget.getBottom(this).toDp()
-    trustedImeBottomInset(
-      rawImeBottom = rawImeBottom,
-      settledImeBottom = animationTargetBottom.takeIf { it > 0.dp },
-    )
+internal actual fun rememberTrustedImeInsets(): WindowInsets {
+  val rawImeInsets = WindowInsets.ime
+  val animationTargetInsets = WindowInsets.imeAnimationTarget
+  return remember(rawImeInsets, animationTargetInsets) {
+    trustedImeInsets(rawImeInsets) { density ->
+      animationTargetInsets.getBottom(density).takeIf { it > 0 }
+    }
   }
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ext/ImeInsets.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ext/ImeInsets.kt
@@ -1,9 +1,41 @@
 package co.typie.ext
 
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
 
-@Composable internal expect fun rememberTrustedImeBottomInset(): Dp
+@Composable internal expect fun rememberTrustedImeInsets(): WindowInsets
+
+@Composable
+internal fun rememberTrustedImeBottomInset(): Dp {
+  val density = LocalDensity.current
+  return with(density) { rememberTrustedImeInsets().getBottom(this).toDp() }
+}
+
+internal fun trustedImeInsets(
+  rawImeInsets: WindowInsets,
+  settledBottom: (Density) -> Int?,
+  presentationBottom: (Density) -> Int? = { null },
+): WindowInsets =
+  object : WindowInsets {
+    override fun getLeft(density: Density, layoutDirection: LayoutDirection) =
+      rawImeInsets.getLeft(density, layoutDirection)
+
+    override fun getTop(density: Density) = rawImeInsets.getTop(density)
+
+    override fun getRight(density: Density, layoutDirection: LayoutDirection) =
+      rawImeInsets.getRight(density, layoutDirection)
+
+    override fun getBottom(density: Density): Int {
+      val rawBottom = rawImeInsets.getBottom(density)
+      val settled = settledBottom(density)
+      val presentation = presentationBottom(density)
+      return presentation ?: if (settled != null && rawBottom > settled) settled else rawBottom
+    }
+  }
 
 internal fun trustedImeBottomInset(rawImeBottom: Dp, settledImeBottom: Dp?): Dp =
   if (settledImeBottom != null && rawImeBottom > settledImeBottom) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ext/WindowInsets.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ext/WindowInsets.kt
@@ -1,7 +1,9 @@
 package co.typie.ext
 
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
@@ -50,10 +52,16 @@ fun Modifier.navigationBarsPadding(): Modifier = windowInsetsPadding(WindowInset
 
 @Composable
 fun Modifier.navigationBarsOrImePadding(): Modifier {
-  val navigationBarsBottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
-  val imeBottom = rememberTrustedImeBottomInset()
-  return windowInsetsPadding(WindowInsets(bottom = maxOf(navigationBarsBottom, imeBottom)))
+  return navigationBarsOrImePadding(
+    navigationBars = WindowInsets.navigationBars,
+    ime = rememberTrustedImeInsets(),
+  )
 }
+
+internal fun Modifier.navigationBarsOrImePadding(
+  navigationBars: WindowInsets,
+  ime: WindowInsets,
+): Modifier = windowInsetsPadding(navigationBars.union(ime).only(WindowInsetsSides.Bottom))
 
 @Composable
 fun Modifier.safeDrawingHorizontalPadding(): Modifier {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationStack.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationStack.kt
@@ -1,6 +1,7 @@
 package co.typie.navigation
 
 import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.Spring.StiffnessMediumLow
 import androidx.compose.animation.core.spring
@@ -73,6 +74,7 @@ import dev.chrisbanes.haze.hazeSource
 import kotlin.math.abs
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.NonCancellable
@@ -88,6 +90,37 @@ private enum class AnimState {
   Pop,
   Dragging,
   PopGestureCommitted,
+}
+
+private class NavigationTransitionProgress(private val onProgress: (Float) -> Unit) {
+  private val animatable = Animatable(0f)
+  private var requestedValue = 0f
+
+  val value: Float
+    get() = animatable.value
+
+  suspend fun snapTo(targetValue: Float) {
+    requestedValue = targetValue
+    onProgress(targetValue)
+    animatable.snapTo(targetValue)
+  }
+
+  fun launchSnapTo(scope: CoroutineScope, targetValue: Float) {
+    requestedValue = targetValue
+    onProgress(targetValue)
+    scope.launch { animatable.snapTo(targetValue) }
+  }
+
+  fun launchDragBy(scope: CoroutineScope, delta: Float) {
+    launchSnapTo(scope, (requestedValue + delta).coerceIn(0f, 1f))
+  }
+
+  suspend fun animateTo(targetValue: Float, animationSpec: AnimationSpec<Float>) {
+    animatable.animateTo(targetValue, animationSpec) {
+      requestedValue = value
+      onProgress(value)
+    }
+  }
 }
 
 private class NavigationRouteScene(
@@ -285,16 +318,16 @@ fun NavigationStack(
   var behindRoute by remember { mutableStateOf<Route?>(null) }
   var transitionStyle by remember { mutableStateOf(RouteTransitionStyle.Slide) }
 
-  val progress = remember { Animatable(0f) }
   val softwareKeyboardPresentationController = LocalSoftwareKeyboardPresentationController.current
   val softwareKeyboardInteraction =
     remember(softwareKeyboardPresentationController) {
       NavigationSoftwareKeyboardInteraction(softwareKeyboardPresentationController)
     }
+  val progress =
+    remember(softwareKeyboardInteraction) {
+      NavigationTransitionProgress(softwareKeyboardInteraction::updateHiddenProgress)
+    }
   DisposableEffect(softwareKeyboardInteraction) { onDispose(softwareKeyboardInteraction::dispose) }
-  LaunchedEffect(softwareKeyboardInteraction) {
-    snapshotFlow { progress.value }.collect(softwareKeyboardInteraction::updateHiddenProgress)
-  }
   val topBarBackdropHazeState = remember { HazeState() }
   val topBarSampleRequests = remember { NavigationTopBarSampleRequests() }
   val topBarLuminanceCache =
@@ -533,7 +566,7 @@ fun NavigationStack(
     behindRoute = prev
     animState = AnimState.Dragging
     softwareKeyboardInteraction.start()
-    scope.launch { progress.snapTo(0f) }
+    progress.launchSnapTo(scope, 0f)
   }
 
   suspend fun startPredictiveBackDrag(): Boolean {
@@ -548,10 +581,7 @@ fun NavigationStack(
   }
 
   fun updatePopDrag(dragAmount: Float) {
-    scope.launch {
-      val newValue = (progress.value + dragAmount / containerWidth).coerceIn(0f, 1f)
-      progress.snapTo(newValue)
-    }
+    progress.launchDragBy(scope, dragAmount / containerWidth)
   }
 
   suspend fun commitPopDrag() {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarHost.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarHost.kt
@@ -2,8 +2,6 @@ package co.typie.screen.editor.editor.toolbar
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.MutableTransitionState
-import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -18,7 +16,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -41,6 +38,7 @@ import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorBringIntoViewTarget
 import co.typie.editor.scroll.LocalEditorBringIntoViewRequests
 import co.typie.editor.scroll.updateWithBringIntoView
+import co.typie.ext.rememberTrustedImeInsets
 import co.typie.graphql.fragment.EditorSettingsFontFamily_family
 import co.typie.screen.editor.editor.state.EditorInputEffect
 import co.typie.screen.editor.editor.toolbar.contextual.ImageResizeSecondaryToolbar
@@ -128,15 +126,14 @@ internal fun EditorToolbarHost(
   val bottomPanelHeight = panel?.height ?: inputState.lastBottomPanelHeight
   val bottomPanelContainerHeight = panel?.let { ToolbarBottomPanelGap + it.height } ?: 0.dp
   val lastBottomPanelContainerHeight = ToolbarBottomPanelGap + inputState.lastBottomPanelHeight
-  val bottomPanelAnimationTargetHeight =
-    if (panel != null) {
-      bottomPanelContainerHeight
-    } else if (restoringKeyboard) {
-      lastBottomPanelContainerHeight
-    } else {
-      0.dp
-    }
-  val bottomSpacerTargetHeight =
+  val bottomPanelLayoutHeight =
+    resolveEditorToolbarBottomPanelLayoutHeight(
+      activeBottomPanelContainerHeight = panel?.let { bottomPanelContainerHeight },
+      restoringKeyboard = restoringKeyboard,
+      panelTransitionIdle = bottomPanelTransition.isIdle,
+      lastBottomPanelContainerHeight = lastBottomPanelContainerHeight,
+    )
+  val bottomSpacerHeight =
     if (panel != null) {
       bottomPanelContainerHeight + environment.safeBottomInset
     } else {
@@ -159,13 +156,6 @@ internal fun EditorToolbarHost(
       environment = environment,
       imeVisible = imeVisible,
     )
-  val animatePanelHeight =
-    if (panel != null) {
-      panel.keyboardSpace == null
-    } else {
-      !restoringKeyboard
-    }
-
   fun syncToolbarScopedSurfaces(currentScope: EditorToolbarScope?) {
     sessionState.clearSecondaryToolbarIfInvalid(currentScope)
     val currentPanel = inputState.panel
@@ -188,57 +178,13 @@ internal fun EditorToolbarHost(
     }
   }
 
-  val previousImeVisible = remember { mutableStateOf(imeVisible) }
-  val imeAppearing = !previousImeVisible.value && imeVisible
-  val panelTransitionRunning =
-    bottomPanelTransition.currentState != bottomPanelTransition.targetState
-  val inputSpaceOwnsSpacer = activeBottomPanel == null && (imeVisible || !panelTransitionRunning)
-  val panelAnimationSpec =
-    when {
-      !animatePanelHeight -> snap()
-      panelTransitionRunning ->
-        tween<Dp>(
-          if (bottomPanelTransition.targetState) {
-            ToolbarBottomPanelVisibilityEnterMillis
-          } else {
-            ToolbarBottomPanelVisibilityExitMillis
-          }
-        )
-      else -> tween(ToolbarBottomPanelVisibilityEnterMillis)
-    }
-  val spacerAnimationSpec =
-    when {
-      imeAppearing -> snap()
-      inputSpaceOwnsSpacer -> snap()
-      !animatePanelHeight -> snap()
-      panelTransitionRunning ->
-        tween<Dp>(
-          if (bottomPanelTransition.targetState) {
-            ToolbarBottomPanelVisibilityEnterMillis
-          } else {
-            ToolbarBottomPanelVisibilityExitMillis
-          }
-        )
-      else -> tween(ToolbarBottomPanelVisibilityEnterMillis)
-    }
-  val bottomSpacerHeight by
-    animateDpAsState(
-      targetValue = bottomSpacerTargetHeight,
-      animationSpec = spacerAnimationSpec,
-      label = "EditorToolbarBottomSpacerHeight",
-    )
-  val bottomPanelLayoutHeight by
-    animateDpAsState(
-      targetValue = bottomPanelAnimationTargetHeight,
-      animationSpec = panelAnimationSpec,
-      label = "EditorToolbarBottomPanelLayoutHeight",
-    )
+  val inputSpaceOwnsPlacement =
+    editorToolbarInputSpaceOwnsPlacement(bottomPanelLayoutHeight = bottomPanelLayoutHeight)
   val bottomInset =
     (maxOf(bottomSpacerHeight, bottomPanelLayoutHeight + environment.safeBottomInset) -
         bottomPanelLayoutHeight)
       .coerceAtLeast(0.dp)
-
-  SideEffect { previousImeVisible.value = imeVisible }
+  val visualImeInsets = rememberTrustedImeInsets()
 
   fun sendEditorMessages(messages: List<Message>) {
     if (messages.isEmpty()) {
@@ -290,7 +236,16 @@ internal fun EditorToolbarHost(
     modifier =
       modifier
         .fillMaxWidth()
-        .offset { IntOffset(x = 0, y = -bottomInset.roundToPx()) }
+        .offset {
+          val visualBottomInset =
+            resolveEditorToolbarVisualBottomInset(
+              inputSpaceOwnsPlacement = inputSpaceOwnsPlacement,
+              visualImeBottom = visualImeInsets.getBottom(this),
+              safeBottomInset = environment.safeBottomInset.roundToPx(),
+              retainedBottomInset = bottomInset.roundToPx(),
+            )
+          IntOffset(x = 0, y = -visualBottomInset)
+        }
         .padding(
           start = ToolbarHorizontalPadding,
           end = ToolbarHorizontalPadding,
@@ -430,3 +385,31 @@ internal fun EditorToolbarHost(
     }
   }
 }
+
+internal fun resolveEditorToolbarVisualBottomInset(
+  inputSpaceOwnsPlacement: Boolean,
+  visualImeBottom: Int,
+  safeBottomInset: Int,
+  retainedBottomInset: Int,
+): Int =
+  if (inputSpaceOwnsPlacement) {
+    maxOf(visualImeBottom, safeBottomInset)
+  } else {
+    retainedBottomInset
+  }
+
+internal fun editorToolbarInputSpaceOwnsPlacement(bottomPanelLayoutHeight: Dp): Boolean =
+  bottomPanelLayoutHeight == 0.dp
+
+internal fun resolveEditorToolbarBottomPanelLayoutHeight(
+  activeBottomPanelContainerHeight: Dp?,
+  restoringKeyboard: Boolean,
+  panelTransitionIdle: Boolean,
+  lastBottomPanelContainerHeight: Dp,
+): Dp =
+  activeBottomPanelContainerHeight
+    ?: if (restoringKeyboard || !panelTransitionIdle) {
+      lastBottomPanelContainerHeight
+    } else {
+      0.dp
+    }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/ext/ImeInsetsTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/ext/ImeInsetsTest.kt
@@ -1,5 +1,8 @@
 package co.typie.ext
 
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -13,5 +16,66 @@ class ImeInsetsTest {
   @Test
   fun trustedInsetPreservesImeAnimationBeforeItReachesTarget() {
     assertEquals(120.dp, trustedImeBottomInset(rawImeBottom = 120.dp, settledImeBottom = 350.dp))
+  }
+
+  @Test
+  fun trustedWindowInsetsReadsLatestRawAndSettledValues() {
+    var rawBottom = 806
+    var settledBottom: Int? = 350
+    val insets =
+      trustedImeInsets(
+        rawImeInsets =
+          object : WindowInsets {
+            override fun getLeft(density: Density, layoutDirection: LayoutDirection) = 0
+
+            override fun getTop(density: Density) = 0
+
+            override fun getRight(density: Density, layoutDirection: LayoutDirection) = 0
+
+            override fun getBottom(density: Density) = rawBottom
+          },
+        settledBottom = { settledBottom },
+      )
+    val density = Density(1f)
+
+    assertEquals(350, insets.getBottom(density))
+
+    rawBottom = 120
+    assertEquals(120, insets.getBottom(density))
+
+    settledBottom = null
+    rawBottom = 280
+    assertEquals(280, insets.getBottom(density))
+  }
+
+  @Test
+  fun trustedWindowInsetsUsesPresentationBottomInBothDirections() {
+    var rawBottom = 120
+    var presentationBottom: Int? = 160
+    val insets =
+      trustedImeInsets(
+        rawImeInsets =
+          object : WindowInsets {
+            override fun getLeft(density: Density, layoutDirection: LayoutDirection) = 0
+
+            override fun getTop(density: Density) = 0
+
+            override fun getRight(density: Density, layoutDirection: LayoutDirection) = 0
+
+            override fun getBottom(density: Density) = rawBottom
+          },
+        settledBottom = { null },
+        presentationBottom = { presentationBottom },
+      )
+    val density = Density(1f)
+
+    assertEquals(160, insets.getBottom(density))
+
+    rawBottom = 200
+    presentationBottom = 80
+    assertEquals(80, insets.getBottom(density))
+
+    presentationBottom = 0
+    assertEquals(0, insets.getBottom(density))
   }
 }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarPlacementTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarPlacementTest.kt
@@ -1,0 +1,93 @@
+package co.typie.screen.editor.editor.toolbar
+
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ToolbarPlacementTest {
+  @Test
+  fun keyboardOwnedPlacementUsesTheLatestVisualInset() {
+    assertEquals(
+      280,
+      resolveEditorToolbarVisualBottomInset(
+        inputSpaceOwnsPlacement = true,
+        visualImeBottom = 280,
+        safeBottomInset = 46,
+        retainedBottomInset = 240,
+      ),
+    )
+  }
+
+  @Test
+  fun panelOwnedPlacementIgnoresTheKeyboardInset() {
+    assertEquals(
+      46,
+      resolveEditorToolbarVisualBottomInset(
+        inputSpaceOwnsPlacement = false,
+        visualImeBottom = 280,
+        safeBottomInset = 46,
+        retainedBottomInset = 46,
+      ),
+    )
+  }
+
+  @Test
+  fun keyboardRestoreKeepsPanelSpaceAsThePlacementOwner() {
+    assertFalse(editorToolbarInputSpaceOwnsPlacement(bottomPanelLayoutHeight = 188.dp))
+  }
+
+  @Test
+  fun liveInputOwnsPlacementAfterPanelSpaceIsReleased() {
+    assertTrue(editorToolbarInputSpaceOwnsPlacement(bottomPanelLayoutHeight = 0.dp))
+  }
+
+  @Test
+  fun exitingPanelRetainsPlacementOwnershipWhenTheKeyboardIsAlreadyVisible() {
+    val bottomPanelLayoutHeight =
+      resolveEditorToolbarBottomPanelLayoutHeight(
+        activeBottomPanelContainerHeight = null,
+        restoringKeyboard = false,
+        panelTransitionIdle = false,
+        lastBottomPanelContainerHeight = 188.dp,
+      )
+
+    assertFalse(editorToolbarInputSpaceOwnsPlacement(bottomPanelLayoutHeight))
+    assertEquals(
+      46,
+      resolveEditorToolbarVisualBottomInset(
+        inputSpaceOwnsPlacement = editorToolbarInputSpaceOwnsPlacement(bottomPanelLayoutHeight),
+        visualImeBottom = 280,
+        safeBottomInset = 46,
+        retainedBottomInset = 46,
+      ),
+    )
+  }
+
+  @Test
+  fun exitingPanelKeepsItsLayoutHeightUntilVisibilityTransitionCompletes() {
+    assertEquals(
+      188.dp,
+      resolveEditorToolbarBottomPanelLayoutHeight(
+        activeBottomPanelContainerHeight = null,
+        restoringKeyboard = false,
+        panelTransitionIdle = false,
+        lastBottomPanelContainerHeight = 188.dp,
+      ),
+    )
+  }
+
+  @Test
+  fun settledPanelExitReleasesItsLayoutHeightWithoutAnimation() {
+    assertEquals(
+      0.dp,
+      resolveEditorToolbarBottomPanelLayoutHeight(
+        activeBottomPanelContainerHeight = null,
+        restoringKeyboard = false,
+        panelTransitionIdle = true,
+        lastBottomPanelContainerHeight = 188.dp,
+      ),
+    )
+  }
+}

--- a/apps/mobile/compose/src/desktopMain/kotlin/co/typie/ext/ImeInsets.desktop.kt
+++ b/apps/mobile/compose/src/desktopMain/kotlin/co/typie/ext/ImeInsets.desktop.kt
@@ -2,8 +2,5 @@ package co.typie.ext
 
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalDensity
 
-@Composable
-internal actual fun rememberTrustedImeBottomInset() =
-  with(LocalDensity.current) { WindowInsets.ime.getBottom(this).toDp() }
+@Composable internal actual fun rememberTrustedImeInsets(): WindowInsets = WindowInsets.ime

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ext/WindowInsetsDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ext/WindowInsetsDesktopTest.kt
@@ -1,0 +1,65 @@
+package co.typie.ext
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+class WindowInsetsDesktopTest {
+  @Test
+  fun navigationBarsOrImePaddingReadsTheLatestInsetDuringLayout() = runComposeUiTest {
+    var bottomInsetPx by mutableIntStateOf(0)
+    var compositionCount = 0
+    val imeInsets =
+      object : WindowInsets {
+        override fun getLeft(density: Density, layoutDirection: LayoutDirection) = 30
+
+        override fun getTop(density: Density) = 0
+
+        override fun getRight(density: Density, layoutDirection: LayoutDirection) = 0
+
+        override fun getBottom(density: Density) = bottomInsetPx
+      }
+
+    setContent {
+      compositionCount += 1
+      Box(
+        Modifier.size(100.dp)
+          .navigationBarsOrImePadding(navigationBars = WindowInsets(0), ime = imeInsets)
+          .testTag(ContainerTag)
+      ) {
+        Box(Modifier.align(Alignment.BottomCenter).size(10.dp).testTag(ContentTag))
+      }
+    }
+
+    val containerBounds = onNodeWithTag(ContainerTag).fetchSemanticsNode().boundsInRoot
+    val initialBounds = onNodeWithTag(ContentTag).fetchSemanticsNode().boundsInRoot
+    runOnIdle { bottomInsetPx = 24 }
+    waitForIdle()
+
+    val updatedBounds = onNodeWithTag(ContentTag).fetchSemanticsNode().boundsInRoot
+    assertEquals(24f, initialBounds.bottom - updatedBounds.bottom, absoluteTolerance = 0.5f)
+    assertEquals(containerBounds.center.x, initialBounds.center.x, absoluteTolerance = 0.5f)
+    assertEquals(containerBounds.center.x, updatedBounds.center.x, absoluteTolerance = 0.5f)
+    assertEquals(1, compositionCount)
+  }
+
+  private companion object {
+    const val ContainerTag = "window-insets-container"
+    const val ContentTag = "window-insets-content"
+  }
+}

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/NavigationStackDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/NavigationStackDesktopTest.kt
@@ -91,6 +91,32 @@ class NavigationStackDesktopTest {
   }
 
   @Test
+  fun navigationForegroundCanMatchRouteHostBounds() = runComposeUiTest {
+    val navigator = Navigator(Route.Home)
+
+    setContent {
+      NavigationStackTestHost(
+        navigator = navigator,
+        topBarState = remember { TopBarState() },
+        modifier = Modifier.size(width = 320.dp, height = 640.dp),
+      ) { route ->
+        Box(Modifier.fillMaxSize().testTag("surface-$route"))
+        Box(Modifier.fillMaxSize().padding(horizontal = 12.dp)) {
+          NavigationForeground(matchHostBounds = true) {
+            Box(Modifier.fillMaxSize().testTag("foreground-$route"))
+          }
+        }
+      }
+    }
+    waitForIdle()
+
+    assertEquals(
+      onNodeWithTag("surface-${Route.Home}").fetchSemanticsNode().boundsInRoot,
+      onNodeWithTag("foreground-${Route.Home}").fetchSemanticsNode().boundsInRoot,
+    )
+  }
+
+  @Test
   fun navigationForegroundCanSharePointerInputWithRouteSurface() = runComposeUiTest {
     val navigator = Navigator(Route.Home)
     val editorRoute = Route.Editor("document-id")

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/SoftwareKeyboardNavigationStackDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/SoftwareKeyboardNavigationStackDesktopTest.kt
@@ -44,6 +44,51 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalTestApi::class)
 class SoftwareKeyboardNavigationStackDesktopTest {
   @Test
+  fun backSwipeDeliversKeyboardProgressBeforeTheNextPresentedFrame() = runComposeUiTest {
+    val navigator = Navigator(Route.Home)
+    val driver = ImmediateProgressDriver()
+    val controller = SoftwareKeyboardPresentationController { driver }
+    var activationDistancePx = 0f
+
+    setContent {
+      CompositionLocalProvider(
+        LocalAppColors provides LightColors,
+        LocalSoftwareKeyboardPresentationController provides controller,
+      ) {
+        activationDistancePx =
+          LocalViewConfiguration.current.touchSlop * NAVIGATION_POP_ACTIVATION_SLOP_MULTIPLIER
+        NavigationStackTestHost(
+          navigator = navigator,
+          topBarState = remember { TopBarState() },
+          modifier = Modifier.size(width = 320.dp, height = 640.dp),
+        ) { route ->
+          Box(
+            Modifier.fillMaxSize()
+              .testTag(if (route == Route.Search) SEARCH_ROUTE_TAG else HOME_ROUTE_TAG)
+          )
+        }
+        LaunchedEffect(Unit) { navigator.navigate(Route.Search) }
+      }
+    }
+    waitUntil { navigator.current == Route.Search && !navigator.isTransitioning }
+
+    mainClock.autoAdvance = false
+    try {
+      onNodeWithTag(SEARCH_ROUTE_TAG).performTouchInput {
+        down(Offset(x = 10f, y = center.y))
+        moveBy(Offset(x = activationDistancePx + 80f, y = 0f), delayMillis = 16L)
+      }
+
+      assertTrue(
+        driver.progress.lastOrNull()?.let { it > 0f } == true,
+        "Keyboard progress must be delivered before Compose presents the matching drag frame",
+      )
+    } finally {
+      mainClock.autoAdvance = true
+    }
+  }
+
+  @Test
   fun committedSearchBackSwipeDoesNotRewindKeyboardProgressAfterRelease() = runComposeUiTest {
     val navigator = Navigator(Route.Home)
     val driver = ImmediateProgressDriver()

--- a/apps/mobile/compose/src/iosMain/kotlin/co/typie/ext/ImeInsets.ios.kt
+++ b/apps/mobile/compose/src/iosMain/kotlin/co/typie/ext/ImeInsets.ios.kt
@@ -9,7 +9,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import platform.Foundation.NSNotification
@@ -23,17 +22,26 @@ import platform.UIKit.UIKeyboardWillHideNotification
 import swiftPMImport.co.typie.compose.EditorKeyboardBridge
 
 @Composable
-internal actual fun rememberTrustedImeBottomInset(): Dp {
-  val density = LocalDensity.current
-  val rawImeBottom = with(density) { WindowInsets.ime.getBottom(this).toDp() }
+internal actual fun rememberTrustedImeInsets(): WindowInsets {
+  val rawImeInsets = WindowInsets.ime
   var settledImeBottom by remember { mutableStateOf<Dp?>(null) }
+  var presentationImeBottom by remember { mutableStateOf<Dp?>(null) }
 
   DisposableEffect(Unit) {
     fun updateSettledImeBottom(notification: NSNotification?) {
-      settledImeBottom =
-        notification?.let(EditorKeyboardBridge::imeVisibleHeightWithNotification)?.dp?.takeIf {
-          it > 0.dp
+      val visibleHeight =
+        notification?.let(EditorKeyboardBridge::imeVisibleHeightWithNotification)?.dp ?: 0.dp
+      val isPresentationFrame =
+        notification != null &&
+          EditorKeyboardBridge.isSoftwareKeyboardPresentationFrameWithNotification(notification)
+      if (isPresentationFrame) {
+        presentationImeBottom = visibleHeight
+      } else {
+        if (presentationImeBottom != 0.dp || visibleHeight > 0.dp) {
+          presentationImeBottom = null
         }
+        settledImeBottom = visibleHeight.takeIf { it > 0.dp }
+      }
     }
 
     val center = NSNotificationCenter.defaultCenter
@@ -76,6 +84,7 @@ internal actual fun rememberTrustedImeBottomInset(): Dp {
         queue = NSOperationQueue.mainQueue,
       ) {
         settledImeBottom = null
+        presentationImeBottom = null
       }
 
     onDispose {
@@ -87,5 +96,13 @@ internal actual fun rememberTrustedImeBottomInset(): Dp {
     }
   }
 
-  return trustedImeBottomInset(rawImeBottom = rawImeBottom, settledImeBottom = settledImeBottom)
+  return remember(rawImeInsets) {
+    trustedImeInsets(
+      rawImeInsets = rawImeInsets,
+      settledBottom = { density -> settledImeBottom?.let { with(density) { it.roundToPx() } } },
+      presentationBottom = { density ->
+        presentationImeBottom?.let { with(density) { it.roundToPx() } }
+      },
+    )
+  }
 }

--- a/apps/mobile/ios/Bridge/Sources/Bridge/EditorKeyboardBridge.swift
+++ b/apps/mobile/ios/Bridge/Sources/Bridge/EditorKeyboardBridge.swift
@@ -59,6 +59,10 @@ import UIKit
     return keyboardVisibleHeight(from: keyboardFrame)
   }
 
+  public static func isSoftwareKeyboardPresentationFrame(notification: Notification) -> Bool {
+    notification.object is SoftwareKeyboardPresentationBridge
+  }
+
   private static func detectHardwareKeyboardModeFromUIKeyboardImpl() -> Bool? {
     guard let instance = activeKeyboard() else {
       return nil


### PR DESCRIPTION
키보드가 움직일 때 툴바와 하단 버튼이 이전 프레임의 inset을 사용해 간격이 흔들리는 문제를 줄입니다.

- IME inset을 composition에서 `Dp`로 고정하지 않고 layout 시점에 최신 `WindowInsets`로 읽도록 변경했습니다.
- iOS에서는 샘플링한 keyboard presentation frame을 우선 사용하고, Android에서는 IME animation target을 신뢰 경계로 유지합니다.
- 화면 스와이프 진행률을 키보드 presentation driver에 즉시 전달합니다.
- 에디터 툴바의 별도 위치 애니메이션을 제거하되, 바텀 패널의 fade/scale과 exit 공간은 유지합니다.
- 푸터와 저장 버튼은 navigation bar와 IME의 bottom inset만 layout 단계에서 적용합니다.

iOS의 duration 0 keyboard frame을 즉시 반영하는 Compose 패치에 의존합니다:
https://github.com/penxle/compose-patches/commit/e02e61471b52f4bc2f18d4dd8fb80f950b05407d


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>