### PR TITLE
pending이 caret에, caret이 line height에 영향을 미치게 함

### DIFF
--- a/crates/editor-core/src/editor.rs
+++ b/crates/editor-core/src/editor.rs
@@ -35,22 +35,24 @@ use editor_state::undo::{RecordMerge, TransientState, UndoEntry, UndoHistory};
 
 fn normalize_pending_overlay(state: &State) -> Option<PendingOverlay> {
     let modifiers = state.pending_modifiers.clone();
-
     if modifiers.is_empty() {
         return None;
     }
     let selection = state.selection.as_ref()?;
-    let view = state.view();
-    let textblock = view
-        .node(selection.head.node)?
-        .ancestors()
-        .find(|n| n.spec().is_textblock())?;
-    let is_empty = textblock.children().next().is_none();
-    if !is_empty {
+    if !selection.is_collapsed() {
         return None;
     }
+    let view = state.view();
+    let node = view.node(selection.head.node)?;
+    let position = node
+        .ancestors()
+        .find(|ancestor| ancestor.spec().is_textblock())
+        .map_or(selection.head, |textblock| Position {
+            node: textblock.id(),
+            ..selection.head
+        });
     Some(PendingOverlay {
-        node_id: textblock.id(),
+        position,
         modifiers,
     })
 }
@@ -2597,8 +2599,8 @@ mod tests {
     }
 
     #[test]
-    fn normalize_non_empty_paragraph_returns_none() {
-        let (state, _p1) = state! {
+    fn normalize_non_empty_paragraph_returns_caret_overlay() {
+        let (state, p1) = state! {
             doc { root { p1: paragraph { text("hi") } } }
             selection: (p1, 0)
         };
@@ -2606,7 +2608,14 @@ mod tests {
             modifier: Modifier::Bold,
         }];
         let s = with_pending(state, pending);
-        assert!(normalize_pending_overlay(&s).is_none());
+        let overlay = normalize_pending_overlay(&s).expect("caret overlay");
+        assert_eq!(overlay.position, Position::new(p1, 0));
+        assert_eq!(
+            overlay.modifiers,
+            vec![PendingModifier::Set {
+                modifier: Modifier::Bold
+            }]
+        );
     }
 
     #[test]
@@ -2620,21 +2629,8 @@ mod tests {
         }];
         let s = with_pending(state, pending.clone());
         let ps = normalize_pending_overlay(&s).expect("Some");
-        assert_eq!(ps.node_id, p1);
+        assert_eq!(ps.position, Position::new(p1, 0));
         assert_eq!(ps.modifiers, pending);
-    }
-
-    #[test]
-    fn normalize_head_on_text_child_ascends_to_textblock() {
-        let (state, _p1) = state! {
-            doc { root { p1: paragraph { text("hi") } } }
-            selection: (p1, 0)
-        };
-        let pending: PendingModifiers = vec![PendingModifier::Set {
-            modifier: Modifier::Bold,
-        }];
-        let s = with_pending(state, pending);
-        assert!(normalize_pending_overlay(&s).is_none());
     }
 
     fn zombie_css() -> Vec<Changeset<EditOp>> {
@@ -4497,6 +4493,180 @@ mod tests {
     }
 
     #[test]
+    fn pending_font_size_affects_only_active_caret_metrics() {
+        let (initial, p1, p2) = state! {
+            doc { root {
+                p1: paragraph { text("a") }
+                p2: paragraph { text("b") [font_size(2400)] }
+            } }
+            selection: (p1, 1)
+            pending_modifiers: [font_size(3600)]
+        };
+        let mut editor = Editor::new_test(initial);
+        editor.apply(Message::System {
+            event: crate::message::SystemEvent::Initialize,
+        });
+
+        let active_caret = editor
+            .view()
+            .cursor_metrics(&editor.state, &Position::new(p1, 1))
+            .expect("active cursor metrics after pending font_size 36pt")
+            .caret;
+        let other_caret = editor
+            .view()
+            .cursor_metrics(&editor.state, &Position::new(p2, 1))
+            .expect("non-active cursor metrics at 24pt text")
+            .caret;
+
+        assert!(
+            active_caret.height > other_caret.height,
+            "36pt pending must affect only the active caret, not a queried 24pt position: active={}, other={}",
+            active_caret.height,
+            other_caret.height
+        );
+    }
+
+    #[test]
+    fn pending_font_size_expands_active_line_layout() {
+        let (initial, p1, p2) = state! {
+            doc { root {
+                p1: paragraph { text("a") }
+                p2: paragraph { text("b") }
+            } }
+            selection: (p1, 1)
+        };
+        let mut editor = Editor::new_test(initial);
+        editor.apply(Message::System {
+            event: crate::message::SystemEvent::Initialize,
+        });
+
+        let before_active = editor
+            .view()
+            .cursor_metrics(&editor.state, &Position::new(p1, 1))
+            .expect("active cursor before pending font size");
+        let before_next = editor
+            .view()
+            .cursor_metrics(&editor.state, &Position::new(p2, 0))
+            .expect("next paragraph cursor before pending font size");
+
+        editor.apply(Message::Modifier {
+            op: ModifierOp::Set {
+                modifier: Modifier::FontSize { value: 9600 },
+            },
+        });
+
+        let after_active = editor
+            .view()
+            .cursor_metrics(&editor.state, &Position::new(p1, 1))
+            .expect("active cursor after pending font size 96pt");
+        let after_next = editor
+            .view()
+            .cursor_metrics(&editor.state, &Position::new(p2, 0))
+            .expect("next paragraph cursor after pending font size");
+
+        assert!(
+            after_active.line.height >= after_active.caret.height,
+            "active line must contain the pending caret: line={}, caret={}",
+            after_active.line.height,
+            after_active.caret.height
+        );
+        assert!(
+            after_active.caret.y >= after_active.line.y
+                && after_active.caret.bottom() <= after_active.line.bottom(),
+            "pending caret must stay inside the active line: line={:?}, caret={:?}",
+            after_active.line,
+            after_active.caret
+        );
+        assert!(
+            after_active.line.height > before_active.line.height,
+            "active line must grow for the pending font size: before={}, after={}",
+            before_active.line.height,
+            after_active.line.height
+        );
+        assert!(
+            after_next.line.y > before_next.line.y,
+            "following content must move below the expanded active line: before={}, after={}",
+            before_next.line.y,
+            after_next.line.y
+        );
+    }
+
+    #[test]
+    fn non_empty_clear_all_updates_active_caret_metrics() {
+        let (initial, p1) = state! {
+            doc { root { p1: paragraph { text("a") [font_size(3600)] } } }
+            selection: (p1, 1)
+        };
+        let mut editor = Editor::new_test(initial);
+        editor.apply(Message::System {
+            event: crate::message::SystemEvent::Initialize,
+        });
+
+        let big_caret = editor
+            .view()
+            .cursor_metrics(&editor.state, &Position::new(p1, 1))
+            .expect("cursor metrics at the end of 36pt text")
+            .caret;
+
+        editor.apply(Message::Modifier {
+            op: ModifierOp::ClearAll,
+        });
+
+        let view = editor.state().view();
+        let leaf_state = view
+            .node(p1)
+            .and_then(|node| node.leaf_state_at(0))
+            .expect("existing text leaf after ClearAll");
+        assert_eq!(
+            leaf_state
+                .own
+                .get(&ModifierType::FontSize)
+                .map(|own| &own.value),
+            Some(&Modifier::FontSize { value: 3600 }),
+            "collapsed ClearAll must not change existing text"
+        );
+
+        let cleared_caret = editor
+            .view()
+            .cursor_metrics(&editor.state, &Position::new(p1, 1))
+            .expect("cursor metrics after ClearAll")
+            .caret;
+        assert!(
+            cleared_caret.height < big_caret.height,
+            "caret must return to the resolved default size after ClearAll: big={}, cleared={}",
+            big_caret.height,
+            cleared_caret.height
+        );
+    }
+
+    #[test]
+    fn non_empty_clear_all_publishes_cursor_state_field() {
+        let (initial, _p1) = state! {
+            doc { root { p1: paragraph { text("a") [font_size(3600)] } } }
+            selection: (p1, 1)
+        };
+        let mut editor = Editor::new_test(initial);
+        editor.apply(Message::System {
+            event: crate::message::SystemEvent::Initialize,
+        });
+
+        let events = editor.apply(Message::Modifier {
+            op: ModifierOp::ClearAll,
+        });
+
+        assert!(
+            events.iter().any(|event| {
+                matches!(
+                    event,
+                    EditorEvent::StateChanged { fields }
+                        if fields.contains(&StateField::Cursor)
+                )
+            }),
+            "pending-only ClearAll must tell hosts to re-query the cursor"
+        );
+    }
+
+    #[test]
     fn empty_paragraph_clear_all_modifiers_clears_carry_font_size() {
         let (initial, p1) = state! {
             doc { root { p1: paragraph carry([font_size(2400)]) {} } }
@@ -5590,6 +5760,48 @@ mod tests {
                 .cursor_metrics(st2, &st2.selection.expect("selection exists in test").head)
                 .is_some(),
             "normal caret still valid after leaving the gap (phantom space recovered)"
+        );
+    }
+
+    #[test]
+    fn gap_caret_pending_font_size_expands_line_and_publishes_cursor_state_field() {
+        let (initial, _root, _p1) = state! {
+            doc { root: root { image p1: paragraph { text("b") } } }
+            selection: (root, 0, <)
+        };
+        let mut editor = Editor::new_test(initial);
+        editor.apply(Message::System {
+            event: crate::message::SystemEvent::Initialize,
+        });
+
+        let events = editor.apply(Message::Modifier {
+            op: ModifierOp::Set {
+                modifier: Modifier::FontSize { value: 9600 },
+            },
+        });
+        let position = editor.state.selection.expect("gap selection").head;
+        let cursor = editor
+            .view()
+            .cursor_metrics(&editor.state, &position)
+            .expect("gap cursor metrics after pending font size");
+
+        assert!(
+            cursor.line.height >= cursor.caret.height
+                && cursor.caret.y >= cursor.line.y
+                && cursor.caret.bottom() <= cursor.line.bottom(),
+            "gap line must contain the pending caret: line={:?}, caret={:?}",
+            cursor.line,
+            cursor.caret,
+        );
+        assert!(
+            events.iter().any(|event| {
+                matches!(
+                    event,
+                    EditorEvent::StateChanged { fields }
+                        if fields.contains(&StateField::Cursor)
+                )
+            }),
+            "gap pending style change must tell hosts to re-query the cursor",
         );
     }
 

--- a/crates/editor-view/src/measure/container.rs
+++ b/crates/editor-view/src/measure/container.rs
@@ -8,7 +8,7 @@ use editor_model::{
 use editor_resource::Resource;
 
 use crate::measure::PageBreakPolicy;
-use crate::measure::text::measure::build_strut_only_line;
+use crate::measure::text::measure::{build_strut_only_line, expand_line_for_caret};
 use crate::measure::text::resolve::style_from_effective_modifiers;
 use crate::style::{BorderMode, BoxStyle, Direction};
 use editor_common::EdgeInsets;
@@ -65,12 +65,13 @@ fn make_gap_phantom_block(
     node: &NodeView,
     width: f32,
     index: usize,
+    ctx: &MeasureContext,
     resource: &mut Resource,
 ) -> (Arc<MeasuredNode>, f32) {
     let base_style =
         style_from_effective_modifiers(&node.effective().values().cloned().collect::<Vec<_>>());
     let indent = phantom_indent(node);
-    let line = build_strut_only_line(
+    let mut line = build_strut_only_line(
         node.id(),
         &base_style,
         width,
@@ -79,6 +80,11 @@ fn make_gap_phantom_block(
         index..index,
         resource,
     );
+    if let Some((position, expansion)) = ctx.pending_caret_for(&node.id())
+        && position.offset == index
+    {
+        line = expand_line_for_caret(&line, expansion);
+    }
     (
         Arc::new(MeasuredNode::from_line(width, line)),
         resolve_gap_after(node.effective()),
@@ -104,14 +110,16 @@ pub(crate) fn layout_vertical<'a>(
     let n_children = children.len();
     for (i, child) in children.into_iter().enumerate() {
         if gap_phantom_index == Some(i) {
-            blocks.push(make_gap_phantom_block(node, width, i, resource));
+            blocks.push(make_gap_phantom_block(node, width, i, ctx, resource));
         }
         let gap_after = resolve_gap_after(child_effective(node, i, &child));
         let m = measure_child(child, width, ctx, resource);
         blocks.push((m, gap_after));
     }
     if gap_phantom_index == Some(n_children) {
-        blocks.push(make_gap_phantom_block(node, width, n_children, resource));
+        blocks.push(make_gap_phantom_block(
+            node, width, n_children, ctx, resource,
+        ));
     }
 
     let mut result = Vec::with_capacity(blocks.len() * 2);

--- a/crates/editor-view/src/measure/context.rs
+++ b/crates/editor-view/src/measure/context.rs
@@ -1,4 +1,5 @@
-use crate::view_state::GapPhantom;
+use crate::measure::text::measure::LineStrutExpansion;
+use crate::view_state::{GapPhantom, PendingOverlay};
 use editor_crdt::Dot;
 use hashbrown::HashMap;
 
@@ -7,7 +8,8 @@ pub(crate) struct MeasureContext {
     pub fold_states: HashMap<Dot, bool>,
     pub external_heights: HashMap<Dot, f32>,
     pub gap_phantom: Option<GapPhantom>,
-    pub pending_overlay: Option<(Dot, editor_state::PendingModifiers)>,
+    pub pending_overlay: Option<PendingOverlay>,
+    pub pending_caret_expansion: Option<LineStrutExpansion>,
 }
 
 impl MeasureContext {
@@ -29,8 +31,19 @@ impl MeasureContext {
     pub fn pending_for(&self, node: &Dot) -> Option<&editor_state::PendingModifiers> {
         self.pending_overlay
             .as_ref()
-            .filter(|(id, _)| id == node)
-            .map(|(_, m)| m)
+            .filter(|overlay| &overlay.position.node == node)
+            .map(|overlay| &overlay.modifiers)
+    }
+
+    pub fn pending_caret_for(
+        &self,
+        node: &Dot,
+    ) -> Option<(&editor_state::Position, &LineStrutExpansion)> {
+        let overlay = self
+            .pending_overlay
+            .as_ref()
+            .filter(|overlay| &overlay.position.node == node)?;
+        Some((&overlay.position, self.pending_caret_expansion.as_ref()?))
     }
 }
 
@@ -42,10 +55,8 @@ pub(crate) fn measure_context(vs: &crate::view_state::ViewState) -> MeasureConte
             parent: gp.parent,
             index: gp.index,
         }),
-        pending_overlay: vs
-            .pending_overlay
-            .as_ref()
-            .map(|ps| (ps.node_id, ps.modifiers.clone())),
+        pending_overlay: vs.pending_overlay.clone(),
+        pending_caret_expansion: None,
     }
 }
 
@@ -109,7 +120,10 @@ mod tests {
             modifier: Modifier::Bold,
         }];
         let ctx = MeasureContext {
-            pending_overlay: Some((a, modifiers.clone())),
+            pending_overlay: Some(PendingOverlay {
+                position: editor_state::Position::new(a, 0),
+                modifiers: modifiers.clone(),
+            }),
             ..Default::default()
         };
         assert_eq!(ctx.pending_for(&a), Some(&modifiers));
@@ -131,7 +145,7 @@ mod tests {
             index: 1,
         });
         vs.pending_overlay = Some(PendingOverlay {
-            node_id: p1,
+            position: editor_state::Position::new(p1, 0),
             modifiers: modifiers.clone(),
         });
 
@@ -146,6 +160,12 @@ mod tests {
                 index: 1
             })
         );
-        assert_eq!(ctx.pending_overlay, Some((p1, modifiers)));
+        assert_eq!(
+            ctx.pending_overlay,
+            Some(PendingOverlay {
+                position: editor_state::Position::new(p1, 0),
+                modifiers,
+            })
+        );
     }
 }

--- a/crates/editor-view/src/measure/nodes/fold.rs
+++ b/crates/editor-view/src/measure/nodes/fold.rs
@@ -49,6 +49,7 @@ pub(crate) fn measure_fold_title(
         Alignment::Left,
         0.0,
         ctx.pending_for(&node.id()),
+        ctx.pending_caret_for(&node.id()),
         None,
         resource,
     );
@@ -186,6 +187,7 @@ mod tests {
     use crate::measure::context::MeasureContext;
     use crate::measure::text::measure::measure_paragraph;
     use crate::style::DecorationData;
+    use crate::view_state::PendingOverlay;
 
     use super::*;
     use crate::measure::types::MeasuredContent;
@@ -368,6 +370,7 @@ mod tests {
             inner_width,
             Alignment::Left,
             0.0,
+            None,
             None,
             None,
             &mut res,
@@ -636,7 +639,10 @@ mod tests {
             modifier: Modifier::FontSize { value: 9600 },
         }];
         let ctx_pending = MeasureContext {
-            pending_overlay: Some((title_id, big)),
+            pending_overlay: Some(PendingOverlay {
+                position: editor_state::Position::new(title_id, 0),
+                modifiers: big,
+            }),
             ..Default::default()
         };
         let h_pending =

--- a/crates/editor-view/src/measure/nodes/line_geometry.rs
+++ b/crates/editor-view/src/measure/nodes/line_geometry.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::measure::text::measure::MeasuredLine;
+use crate::measure::text::measure::{LineStrutExpansion, MeasuredLine};
 use crate::measure::types::{MeasuredBox, MeasuredContent, MeasuredNode};
 
 pub(crate) struct FirstLineInfo {
@@ -27,12 +27,6 @@ pub(crate) fn first_line_info(node: &MeasuredNode) -> Option<FirstLineInfo> {
         }
         _ => None,
     }
-}
-
-pub(crate) struct LineStrutExpansion {
-    pub ascent: f32,
-    pub descent: f32,
-    pub min_line_height: f32,
 }
 
 pub(crate) struct ExpandedFirstLine {
@@ -100,9 +94,8 @@ fn expand_line(
     expansion: &LineStrutExpansion,
 ) -> MeasuredNode {
     if line.is_phantom {
-        // The ONE deliberate H1 exception: the phantom wrapper is forced to
-        // zero height (matching old `line_geometry.rs:105`), so it bypasses
-        // `from_line` (which would copy `line.height` and pollute the SumTree).
+        // Phantom wrappers stay zero-height; `from_line` would copy the line's
+        // intrinsic height into the layout tree.
         return MeasuredNode {
             width,
             height: 0.0,
@@ -112,50 +105,10 @@ fn expand_line(
 
     let new_ascent = line.ascent.max(expansion.ascent);
     let new_descent = line.descent.max(expansion.descent);
-    let content_height = new_ascent + new_descent;
     let new_height = old_height.max(expansion.min_line_height);
-    let leading = new_height - content_height;
-    let new_baseline = leading / 2.0 + new_ascent;
-    let delta = new_baseline - line.baseline;
-
-    let mut glyph_runs = line.glyph_runs.clone();
-    if delta != 0.0 {
-        for run in &mut glyph_runs {
-            for g in &mut run.glyphs {
-                g.y += delta;
-            }
-        }
-    }
-    let mut ruby_annotations = line.ruby_annotations.clone();
-    if delta != 0.0 {
-        for ann in &mut ruby_annotations {
-            ann.baseline_y += delta;
-            for run in &mut ann.glyph_runs {
-                for g in &mut run.glyphs {
-                    g.y += delta;
-                }
-            }
-        }
-    }
-
     MeasuredNode::from_line(
         width,
-        MeasuredLine {
-            node: line.node,
-            height: new_height,
-            baseline: new_baseline,
-            ascent: new_ascent,
-            descent: new_descent,
-            cursor_ascent: line.cursor_ascent,
-            cursor_descent: line.cursor_descent,
-            glyph_runs,
-            ruby_annotations,
-            empty_caret_x: line.empty_caret_x,
-            offset_range: line.offset_range.clone(),
-            tab_gaps: line.tab_gaps.clone(),
-            is_phantom: line.is_phantom,
-            content_edge_x: line.content_edge_x,
-        },
+        line.with_vertical_metrics(new_ascent, new_descent, new_height),
     )
 }
 

--- a/crates/editor-view/src/measure/nodes/list_item.rs
+++ b/crates/editor-view/src/measure/nodes/list_item.rs
@@ -14,10 +14,11 @@ use crate::measure::text::strut::compute_strut;
 use crate::style::{Alignment, Decoration, DecorationData};
 
 use super::dispatch::measure_child;
-use super::line_geometry::{LineStrutExpansion, expand_first_line, first_line_info};
+use super::line_geometry::{expand_first_line, first_line_info};
 use crate::measure::Measurer;
 use crate::measure::container::layout_padded;
 use crate::measure::context::MeasureContext;
+use crate::measure::text::measure::LineStrutExpansion;
 use crate::measure::types::{MeasuredContent, MeasuredNode};
 
 const MARKER_RECT_MIN_RATIO: f32 = 1.25;

--- a/crates/editor-view/src/measure/nodes/paragraph.rs
+++ b/crates/editor-view/src/measure/nodes/paragraph.rs
@@ -63,6 +63,7 @@ pub(crate) fn measure_paragraph_block(
         align,
         indent,
         pending,
+        ctx.pending_caret_for(&node.id()),
         Some(&mut measurer.seg_cache),
         resource,
     );
@@ -114,6 +115,7 @@ mod tests {
     use editor_resource::Resource;
 
     use crate::measure::context::MeasureContext;
+    use crate::view_state::PendingOverlay;
 
     use super::*;
 
@@ -447,7 +449,10 @@ mod tests {
             modifier: Modifier::FontSize { value: 9600 },
         }];
         let ctx_pending = MeasureContext {
-            pending_overlay: Some((para_id, big)),
+            pending_overlay: Some(PendingOverlay {
+                position: editor_state::Position::new(para_id, 0),
+                modifiers: big,
+            }),
             ..Default::default()
         };
         let r_pending =
@@ -482,7 +487,10 @@ mod tests {
             modifier: Modifier::FontSize { value: 9600 },
         }];
         let ctx_pending = MeasureContext {
-            pending_overlay: Some((para_id, big)),
+            pending_overlay: Some(PendingOverlay {
+                position: editor_state::Position::new(para_id, 0),
+                modifiers: big,
+            }),
             ..Default::default()
         };
         let r_pending =

--- a/crates/editor-view/src/measure/text/measure.rs
+++ b/crates/editor-view/src/measure/text/measure.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use editor_crdt::Dot;
 use editor_model::{Alignment, ChildView, Modifier, NodeView};
 use editor_resource::Resource;
+use editor_state::{Affinity, Position};
 
 use crate::glyph_run::RubyAnnotation;
 
@@ -58,6 +59,92 @@ pub(crate) struct MeasuredLine {
     pub tab_gaps: Vec<TabGap>,
     pub is_phantom: bool,
     pub content_edge_x: Option<f32>,
+}
+
+impl MeasuredLine {
+    pub(crate) fn contains_position(&self, pos: &Position) -> bool {
+        if self.node != pos.node {
+            return false;
+        }
+        if let Some(range) = &self.offset_range
+            && pos.offset >= range.start
+            && pos.offset <= range.end
+        {
+            return true;
+        }
+        self.glyph_runs
+            .iter()
+            .any(|run| pos.offset >= run.offset_range.start && pos.offset <= run.offset_range.end)
+            || self
+                .tab_gaps
+                .iter()
+                .any(|gap| pos.offset >= gap.offset_index && pos.offset <= gap.offset_index + 1)
+    }
+
+    pub(crate) fn with_vertical_metrics(&self, ascent: f32, descent: f32, height: f32) -> Self {
+        let leading = height - (ascent + descent);
+        let baseline = leading / 2.0 + ascent;
+        let delta = baseline - self.baseline;
+
+        let mut line = self.clone();
+        line.height = height;
+        line.baseline = baseline;
+        line.ascent = ascent;
+        line.descent = descent;
+        if delta != 0.0 {
+            for run in &mut line.glyph_runs {
+                for glyph in &mut run.glyphs {
+                    glyph.y += delta;
+                }
+            }
+            for annotation in &mut line.ruby_annotations {
+                annotation.baseline_y += delta;
+                for run in &mut annotation.glyph_runs {
+                    for glyph in &mut run.glyphs {
+                        glyph.y += delta;
+                    }
+                }
+            }
+        }
+        line
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct LineStrutExpansion {
+    pub ascent: f32,
+    pub descent: f32,
+    pub min_line_height: f32,
+}
+
+pub(crate) fn expand_line_for_caret(
+    line: &MeasuredLine,
+    expansion: &LineStrutExpansion,
+) -> MeasuredLine {
+    let ascent = line.ascent.max(expansion.ascent);
+    let descent = line.descent.max(expansion.descent);
+    let height = line
+        .height
+        .max(expansion.min_line_height)
+        .max(ascent + descent);
+    line.with_vertical_metrics(ascent, descent, height)
+}
+
+fn expand_line_at_position(
+    lines: &mut [MeasuredLine],
+    position: &Position,
+    expansion: &LineStrutExpansion,
+) -> bool {
+    let matches = |line: &MeasuredLine| !line.is_phantom && line.contains_position(position);
+    let index = match position.affinity {
+        Affinity::Upstream => lines.iter().position(matches),
+        Affinity::Downstream => lines.iter().rposition(matches),
+    };
+    let Some(index) = index else {
+        return false;
+    };
+    lines[index] = expand_line_for_caret(&lines[index], expansion);
+    true
 }
 
 pub(crate) fn build_strut_only_line(
@@ -295,6 +382,7 @@ pub(crate) fn measure_paragraph(
     align: Alignment,
     indent: f32,
     pending: Option<&editor_state::PendingModifiers>,
+    pending_caret: Option<(&Position, &LineStrutExpansion)>,
     mut seg_cache: Option<&mut SegmentCache>,
     resource: &mut Resource,
 ) -> (Vec<MeasuredLine>, f32) {
@@ -391,6 +479,10 @@ pub(crate) fn measure_paragraph(
     }
     if let Some(cache) = seg_cache {
         cache.prune(node_id, segments.len());
+    }
+
+    if let Some((position, expansion)) = pending_caret {
+        expand_line_at_position(&mut lines, position, expansion);
     }
 
     let total_height: f32 = lines.iter().map(|l| l.height).sum();
@@ -495,7 +587,16 @@ mod tests {
         let view = DocView::new(&pd);
         let para = view.root().unwrap().child_blocks().next().unwrap();
         let mut res = Resource::new_test();
-        measure_paragraph(&para, width, Alignment::Left, 0.0, None, None, &mut res)
+        measure_paragraph(
+            &para,
+            width,
+            Alignment::Left,
+            0.0,
+            None,
+            None,
+            None,
+            &mut res,
+        )
     }
 
     fn glyph_runs(lines: &[MeasuredLine]) -> Vec<&GlyphRun> {
@@ -520,8 +621,17 @@ mod tests {
         let para = view.root().unwrap().child_blocks().next().unwrap();
         let mut res = Resource::new_test();
 
-        let uncached =
-            measure_paragraph(&para, 200.0, Alignment::Left, 0.0, None, None, &mut res).0;
+        let uncached = measure_paragraph(
+            &para,
+            200.0,
+            Alignment::Left,
+            0.0,
+            None,
+            None,
+            None,
+            &mut res,
+        )
+        .0;
 
         let mut cache = SegmentCache::default();
         // First pass populates the cache (all segments measured + stored relative).
@@ -530,6 +640,7 @@ mod tests {
             200.0,
             Alignment::Left,
             0.0,
+            None,
             None,
             Some(&mut cache),
             &mut res,
@@ -541,6 +652,7 @@ mod tests {
             200.0,
             Alignment::Left,
             0.0,
+            None,
             None,
             Some(&mut cache),
             &mut res,
@@ -591,6 +703,7 @@ mod tests {
             Alignment::Left,
             0.0,
             None,
+            None,
             Some(&mut cache),
             &mut res,
         );
@@ -605,6 +718,7 @@ mod tests {
             0.0,
             None,
             None,
+            None,
             &mut res,
         )
         .0;
@@ -613,6 +727,7 @@ mod tests {
             200.0,
             Alignment::Left,
             0.0,
+            None,
             None,
             Some(&mut cache),
             &mut res,
@@ -779,7 +894,16 @@ mod tests {
         let view = DocView::new(&pd);
         let para = view.root().unwrap().child_blocks().next().unwrap();
         let mut res = Resource::new_test();
-        measure_paragraph(&para, width, Alignment::Left, 0.0, pending, None, &mut res)
+        measure_paragraph(
+            &para,
+            width,
+            Alignment::Left,
+            0.0,
+            pending,
+            None,
+            None,
+            &mut res,
+        )
     }
 
     fn font_size_span(spans: SpanLog, op_seq: u64, target: Dot, value: u32) -> SpanLog {
@@ -1043,6 +1167,115 @@ mod tests {
         assert!(
             (h1 - h0).abs() < 0.01,
             "pending must not apply to a paragraph with Char leaves (h0={h0}, h1={h1})"
+        );
+    }
+
+    fn geometry_line(
+        n: u64,
+        height: f32,
+        ascent: f32,
+        descent: f32,
+        offset_range: Range<usize>,
+        is_phantom: bool,
+    ) -> MeasuredLine {
+        MeasuredLine {
+            node: Dot::new(1, n),
+            height,
+            baseline: ascent,
+            ascent,
+            descent,
+            cursor_ascent: ascent,
+            cursor_descent: descent,
+            glyph_runs: vec![],
+            ruby_annotations: vec![],
+            empty_caret_x: 0.0,
+            offset_range: Some(offset_range),
+            tab_gaps: vec![],
+            is_phantom,
+            content_edge_x: None,
+        }
+    }
+
+    #[test]
+    fn caret_expansion_skips_matching_trailing_phantom() {
+        let real = geometry_line(8, 10.0, 8.0, 2.0, 0..2, false);
+        let phantom = geometry_line(8, 0.0, 0.0, 0.0, 2..2, true);
+        let mut lines = vec![real, phantom];
+        let expansion = LineStrutExpansion {
+            ascent: 20.0,
+            descent: 5.0,
+            min_line_height: 25.0,
+        };
+
+        assert!(expand_line_at_position(
+            &mut lines,
+            &Position::new(Dot::new(1, 8), 2),
+            &expansion,
+        ));
+        assert_eq!(lines[0].height, 25.0, "the real line must expand");
+        assert_eq!(lines[1].height, 0.0, "the phantom must stay zero-height");
+    }
+
+    #[test]
+    fn caret_expansion_respects_soft_wrap_affinity() {
+        fn lines() -> Vec<MeasuredLine> {
+            vec![
+                geometry_line(9, 10.0, 8.0, 2.0, 0..1, false),
+                geometry_line(9, 10.0, 8.0, 2.0, 1..2, false),
+            ]
+        }
+
+        let expansion = LineStrutExpansion {
+            ascent: 20.0,
+            descent: 5.0,
+            min_line_height: 25.0,
+        };
+        let mut upstream = lines();
+        assert!(expand_line_at_position(
+            &mut upstream,
+            &Position {
+                node: Dot::new(1, 9),
+                offset: 1,
+                affinity: Affinity::Upstream,
+            },
+            &expansion,
+        ));
+        assert_eq!((upstream[0].height, upstream[1].height), (25.0, 10.0));
+
+        let mut downstream = lines();
+        assert!(expand_line_at_position(
+            &mut downstream,
+            &Position {
+                node: Dot::new(1, 9),
+                offset: 1,
+                affinity: Affinity::Downstream,
+            },
+            &expansion,
+        ));
+        assert_eq!((downstream[0].height, downstream[1].height), (10.0, 25.0));
+    }
+
+    #[test]
+    fn caret_expansion_contains_opposing_ascent_and_descent() {
+        let line = geometry_line(10, 20.0, 18.0, 2.0, 0..1, false);
+        let mut lines = vec![line];
+        let expansion = LineStrutExpansion {
+            ascent: 2.0,
+            descent: 18.0,
+            min_line_height: 20.0,
+        };
+
+        assert!(expand_line_at_position(
+            &mut lines,
+            &Position::new(Dot::new(1, 10), 0),
+            &expansion,
+        ));
+        assert!(
+            lines[0].height >= lines[0].ascent + lines[0].descent,
+            "caret expansion must contain the merged ascent and descent: height={}, ascent={}, descent={}",
+            lines[0].height,
+            lines[0].ascent,
+            lines[0].descent,
         );
     }
 }

--- a/crates/editor-view/src/query/layout_index.rs
+++ b/crates/editor-view/src/query/layout_index.rs
@@ -661,22 +661,7 @@ fn position_matches_node(node: &LayoutNode, pos: &Position) -> bool {
 }
 
 fn position_matches_line(line: &LayoutLine, pos: &Position) -> bool {
-    if line.node != pos.node {
-        return false;
-    }
-    if let Some(range) = &line.offset_range
-        && pos.offset >= range.start
-        && pos.offset <= range.end
-    {
-        return true;
-    }
-    line.glyph_runs
-        .iter()
-        .any(|run| pos.offset >= run.offset_range.start && pos.offset <= run.offset_range.end)
-        || line
-            .tab_gaps
-            .iter()
-            .any(|gap| pos.offset >= gap.offset_index && pos.offset <= gap.offset_index + 1)
+    line.contains_position(pos)
 }
 
 fn position_attaches_to_child(pos: &Position, parent: &Dot, index: usize) -> bool {

--- a/crates/editor-view/src/query/placeholder.rs
+++ b/crates/editor-view/src/query/placeholder.rs
@@ -35,8 +35,8 @@ pub(crate) fn placeholder_metrics(
     let nv = view.root()?.child_blocks().next()?;
     let elem_id = nv.id();
     let pending_modifiers = pending_overlay
-        .filter(|style| style.node_id == elem_id)
-        .map(|style| &style.modifiers);
+        .filter(|overlay| overlay.position.node == elem_id)
+        .map(|overlay| &overlay.modifiers);
     let modifiers = resolve_caret_modifiers(
         &state.projected,
         &Position::new(elem_id, 0),

--- a/crates/editor-view/src/view.rs
+++ b/crates/editor-view/src/view.rs
@@ -4,11 +4,17 @@ use editor_common::{EdgeInsets, Movement};
 use editor_crdt::Dot;
 use editor_model::{LayoutMode, Node, NodeView};
 use editor_resource::Resource;
-use editor_state::{LayoutDirty, Position, ResolvedSelection, Selection, StablePosition, State};
+use editor_state::{
+    LayoutDirty, Position, ResolvedSelection, Selection, StablePosition, State,
+    resolve_caret_modifiers,
+};
 
 use crate::measure::Measurer;
-use crate::measure::context::measure_context;
+use crate::measure::context::{MeasureContext, measure_context};
 use crate::measure::nodes::dispatch::content_remeasurement_target;
+use crate::measure::text::measure::LineStrutExpansion;
+use crate::measure::text::resolve::style_from_effective_modifiers;
+use crate::measure::text::strut::compute_strut;
 use crate::measure::types::MeasuredTree;
 use crate::page::LayoutPage;
 use crate::page_fragment::{PageFragmentTree, build_page_fragment_tree};
@@ -23,6 +29,29 @@ use crate::viewport::Viewport;
 
 const CONTINUOUS_MARGIN_X: f32 = 20.0;
 const CONTINUOUS_CONTENT_CAP: f32 = 1024.0;
+
+fn measure_context_with_pending_caret(
+    view_state: &ViewState,
+    state: &State,
+    resource: &mut Resource,
+) -> MeasureContext {
+    let mut context = measure_context(view_state);
+    context.pending_caret_expansion = view_state.pending_overlay.as_ref().and_then(|pending| {
+        let modifiers =
+            resolve_caret_modifiers(&state.projected, &pending.position, &pending.modifiers)
+                .into_values()
+                .collect::<Vec<_>>();
+        let style = style_from_effective_modifiers(&modifiers);
+        let strut = compute_strut(resource, &style)?;
+        Some(LineStrutExpansion {
+            ascent: strut.ascent,
+            descent: strut.descent,
+            min_line_height: (style.font_size * style.line_height)
+                .max(strut.ascent + strut.descent),
+        })
+    });
+    context
+}
 
 pub struct View {
     resource: Arc<Mutex<Resource>>,
@@ -81,8 +110,11 @@ impl View {
         let mut dirty = dirty;
         if pending_changed {
             for id in [
-                self.view_state.pending_overlay.as_ref().map(|p| p.node_id),
-                new_pending_overlay.as_ref().map(|p| p.node_id),
+                self.view_state
+                    .pending_overlay
+                    .as_ref()
+                    .map(|p| p.position.node),
+                new_pending_overlay.as_ref().map(|p| p.position.node),
             ]
             .into_iter()
             .flatten()
@@ -188,7 +220,10 @@ impl View {
         }
         let continuous = matches!(Self::doc_layout_mode(state), LayoutMode::Continuous { .. });
         let view = state.view();
-        let ctx = measure_context(&self.view_state);
+        let ctx = {
+            let mut resource = self.resource.lock().unwrap();
+            measure_context_with_pending_caret(&self.view_state, state, &mut resource)
+        };
 
         struct SpliceSeed {
             dot: Dot,
@@ -495,9 +530,9 @@ impl View {
             self.layout = None;
             return;
         };
-        let ctx = measure_context(&self.view_state);
         let measured = {
             let mut resource = self.resource.lock().unwrap();
+            let ctx = measure_context_with_pending_caret(&self.view_state, state, &mut resource);
             let root_arc = self
                 .measurer
                 .measure(&root, content_width, &ctx, &mut resource);
@@ -729,9 +764,22 @@ impl View {
         crate::query::navigation::position_at_preferred_x_in(&result.layout_index, &node, at_end, x)
     }
 
-    pub fn cursor_metrics(&self, _state: &State, pos: &Position) -> Option<CursorMetrics> {
+    pub fn cursor_metrics(&self, state: &State, pos: &Position) -> Option<CursorMetrics> {
         let result = self.layout.as_ref()?;
-        crate::query::cursor::cursor_metrics(&result.layout_index, pos, None)
+        let pending = state
+            .selection
+            .as_ref()
+            .filter(|selection| selection.is_collapsed() && selection.head == *pos)
+            .map_or(&[][..], |_| state.pending_modifiers.as_slice());
+        let modifiers = resolve_caret_modifiers(&state.projected, pos, pending)
+            .into_values()
+            .collect::<Vec<_>>();
+        let style = style_from_effective_modifiers(&modifiers);
+        let metrics_override = {
+            let mut resource = self.resource.lock().unwrap();
+            compute_strut(&mut resource, &style).map(|strut| (strut.ascent, strut.descent))
+        };
+        crate::query::cursor::cursor_metrics(&result.layout_index, pos, metrics_override)
     }
 
     pub fn placeholder_metrics(
@@ -1074,17 +1122,19 @@ impl View {
 mod invalidation_tests {
     use std::sync::{Arc, Mutex};
 
-    use editor_crdt::{Dot, ListOp};
+    use editor_crdt::{Dot, ListOp, OpGraph};
     use editor_model::{
         CalloutNodeAttr, CalloutVariant, EditOp, Modifier, ModifierAttrOp, NodeAttr, NodeAttrOp,
         NodeType, SeqItem, TableNodeAttr,
     };
     use editor_resource::Resource;
-    use editor_state::{LayoutDirty, Position, ProjectedState, Selection, State};
+    use editor_state::{LayoutDirty, PendingModifier, Position, ProjectedState, Selection, State};
 
     use super::View;
     use crate::measure::context::measure_context;
     use crate::measure::types::MeasuredNode;
+    use crate::paginate::types::LayoutContent;
+    use crate::view_state::PendingOverlay;
     use crate::viewport::Viewport;
 
     fn seq_block(pos: usize, node_type: NodeType, parents: Vec<Dot>) -> EditOp {
@@ -1120,6 +1170,19 @@ mod invalidation_tests {
         let mut resource = view.resource.lock().unwrap();
         view.measurer
             .measure(&nv, content_width, &ctx, &mut resource)
+    }
+
+    fn layout_with_pending_font_size(view: &mut View, state: &State, position: Position) {
+        view.layout(state);
+        assert!(view.reconcile(
+            state,
+            LayoutDirty::empty(),
+            Some(PendingOverlay {
+                position,
+                modifiers: state.pending_modifiers.clone(),
+            }),
+            None,
+        ));
     }
 
     #[test]
@@ -1452,6 +1515,167 @@ mod invalidation_tests {
                 "empty paragraph cache must be evicted and re-measured after root font-size change"
             );
         }
+    }
+
+    #[test]
+    fn pending_caret_expands_real_line_before_trailing_phantom() {
+        let mut graph = OpGraph::<EditOp>::with_actor(1);
+        let paragraph = graph
+            .add_mut(seq_block(0, NodeType::Paragraph, vec![Dot::ROOT]))
+            .unwrap()
+            .id;
+        graph.add_mut(seq_char(1, 'a')).unwrap();
+        graph.add_mut(seq_char(2, ' ')).unwrap();
+        graph.commit_mut();
+
+        let position = Position::new(paragraph, 2);
+        let mut state = State::new(
+            ProjectedState::from_graph(graph).unwrap(),
+            Some(Selection::collapsed(position)),
+        );
+        state.pending_modifiers = vec![PendingModifier::Set {
+            modifier: Modifier::FontSize { value: 9600 },
+        }];
+
+        let mut view = make_view(41.0);
+        layout_with_pending_font_size(&mut view, &state, position);
+
+        let cursor = view
+            .cursor_metrics(&state, &position)
+            .expect("paragraph-end cursor metrics");
+        assert!(
+            cursor.line.height >= cursor.caret.height
+                && cursor.caret.y >= cursor.line.y
+                && cursor.caret.bottom() <= cursor.line.bottom(),
+            "the real cursor line must contain the pending caret even when a trailing phantom exists: line={:?}, caret={:?}",
+            cursor.line,
+            cursor.caret,
+        );
+    }
+
+    #[test]
+    fn pending_caret_expands_list_marker_geometry_with_first_line() {
+        let mut graph = OpGraph::<EditOp>::with_actor(1);
+        let root = Dot::ROOT;
+        let list = graph
+            .add_mut(seq_block(0, NodeType::BulletList, vec![root]))
+            .unwrap()
+            .id;
+        let item = graph
+            .add_mut(seq_block(1, NodeType::ListItem, vec![root, list]))
+            .unwrap()
+            .id;
+        let paragraph = graph
+            .add_mut(seq_block(2, NodeType::Paragraph, vec![root, list, item]))
+            .unwrap()
+            .id;
+        graph.add_mut(seq_char(3, 'a')).unwrap();
+        graph
+            .add_mut(seq_block(4, NodeType::Paragraph, vec![root]))
+            .unwrap();
+        graph.commit_mut();
+
+        let position = Position::new(paragraph, 1);
+        let mut state = State::new(
+            ProjectedState::from_graph(graph).unwrap(),
+            Some(Selection::collapsed(position)),
+        );
+        state.pending_modifiers = vec![PendingModifier::Set {
+            modifier: Modifier::FontSize { value: 9600 },
+        }];
+
+        let mut view = make_view(800.0);
+        layout_with_pending_font_size(&mut view, &state, position);
+
+        let cursor = view
+            .cursor_metrics(&state, &position)
+            .expect("list-item cursor metrics");
+        let layout = view.layout.as_ref().expect("layout");
+        let item_entry = layout
+            .layout_index
+            .box_entry(&item)
+            .expect("list-item layout entry");
+        let LayoutContent::Box(item_box) = item_entry
+            .content(&layout.layout_index)
+            .expect("list-item layout node")
+        else {
+            panic!("list item must be a box");
+        };
+        let marker = item_box
+            .style
+            .decorations
+            .first()
+            .expect("list marker decoration");
+
+        assert!(
+            (marker.rect.height - cursor.line.height).abs() < 0.01,
+            "list marker geometry must use the final expanded first-line height: marker={}, line={}",
+            marker.rect.height,
+            cursor.line.height,
+        );
+    }
+
+    #[test]
+    fn pending_caret_expands_fold_icon_geometry_with_title_line() {
+        let mut graph = OpGraph::<EditOp>::with_actor(1);
+        let root = Dot::ROOT;
+        let fold = graph
+            .add_mut(seq_block(0, NodeType::Fold, vec![root]))
+            .unwrap()
+            .id;
+        let title = graph
+            .add_mut(seq_block(1, NodeType::FoldTitle, vec![root, fold]))
+            .unwrap()
+            .id;
+        graph.add_mut(seq_char(2, 'a')).unwrap();
+        graph
+            .add_mut(seq_block(3, NodeType::Paragraph, vec![root]))
+            .unwrap();
+        graph.commit_mut();
+
+        let position = Position::new(title, 1);
+        let mut state = State::new(
+            ProjectedState::from_graph(graph).unwrap(),
+            Some(Selection::collapsed(position)),
+        );
+        state.pending_modifiers = vec![PendingModifier::Set {
+            modifier: Modifier::FontSize { value: 9600 },
+        }];
+
+        let mut view = make_view(800.0);
+        layout_with_pending_font_size(&mut view, &state, position);
+
+        let cursor = view
+            .cursor_metrics(&state, &position)
+            .expect("fold-title cursor metrics");
+        let layout = view.layout.as_ref().expect("layout");
+        let title_entry = layout
+            .layout_index
+            .box_entry(&title)
+            .expect("fold-title layout entry");
+        let title_rect = layout
+            .layout_index
+            .page_rect(title_entry.rect)
+            .expect("fold title page rect")
+            .rect;
+        let LayoutContent::Box(title_box) = title_entry
+            .content(&layout.layout_index)
+            .expect("fold-title layout node")
+        else {
+            panic!("fold title must be a box");
+        };
+        let icon = title_box
+            .style
+            .decorations
+            .first()
+            .expect("fold icon decoration");
+        let icon_center = title_rect.y + icon.rect.y + icon.rect.height / 2.0;
+        let line_center = cursor.line.y + cursor.line.height / 2.0;
+
+        assert!(
+            (icon_center - line_center).abs() < 0.01,
+            "fold icon must be centered on the final expanded title line: icon_center={icon_center}, line_center={line_center}",
+        );
     }
 }
 

--- a/crates/editor-view/src/view_state.rs
+++ b/crates/editor-view/src/view_state.rs
@@ -1,11 +1,11 @@
 use editor_common::DecorationStyle;
 use editor_crdt::Dot;
-use editor_state::PendingModifiers;
+use editor_state::{PendingModifiers, Position};
 use hashbrown::HashMap;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct PendingOverlay {
-    pub node_id: Dot,
+    pub position: Position,
     pub modifiers: PendingModifiers,
 }
 
@@ -71,13 +71,13 @@ mod tests {
     fn pending_overlay_equality() {
         let n = Dot::new(1, 1);
         let a = PendingOverlay {
-            node_id: n,
+            position: Position::new(n, 0),
             modifiers: vec![PendingModifier::Set {
                 modifier: Modifier::Bold,
             }],
         };
         let b = PendingOverlay {
-            node_id: n,
+            position: Position::new(n, 0),
             modifiers: vec![PendingModifier::Set {
                 modifier: Modifier::Bold,
             }],


### PR DESCRIPTION
## 문제

큰 글자 뒤에서 서식을 지워도 caret 크기가 즉시 작아지지 않았습니다.

또한 작은 줄에서 pending font size를 크게 설정하면 caret만 커지고 줄 높이는 유지되어 앞뒤 줄을 침범했습니다. Root gap에서는 pending 서식 변경이 phantom line과 Cursor 갱신에 반영되지 않았습니다.

## 변경

- `PendingOverlay`가 node뿐 아니라 정확한 caret position을 보관하도록 변경했습니다.
- `resolve_caret_modifiers`로 계산한 최종 입력 스타일을 caret과 줄 측정의 공통 원천으로 사용합니다.
- pending caret이 놓인 실제 줄을 확장하고 soft-wrap affinity를 존중합니다.
- gap cursor의 phantom line에도 같은 caret 확장 규칙을 적용합니다.
- caret이 합쳐진 ascent와 descent를 항상 포함하도록 줄 높이를 보장합니다.
- 공통 baseline 재배치와 caret/list-marker별 줄 확장 정책을 분리했습니다.
- pending-only 변경도 host가 Cursor metrics를 다시 조회하도록 합니다.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>