### PR TITLE
폴드 제목에 지원하지 않는 서식이 적용되지 않도록 함

### DIFF
--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarContextTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarContextTest.kt
@@ -563,7 +563,7 @@ class ToolbarContextTest {
       resolveEditorToolbarContext(
         editorState(
           selection = collapsedSelection(),
-          modifierState = modifierState(inlineText = true),
+          modifierState = modifierState(inlineText = false),
           blockState =
             blockState(
               ancestors =
@@ -576,10 +576,7 @@ class ToolbarContextTest {
         )
       )
 
-    assertEquals(
-      listOf(EditorToolbarPageKey.Main, EditorToolbarPageKey.Text, EditorToolbarPageKey.Fold),
-      context.pageKeys,
-    )
+    assertEquals(listOf(EditorToolbarPageKey.Main, EditorToolbarPageKey.Fold), context.pageKeys)
     assertEquals(null, context.autoTargetPageKey)
     assertEquals(null, context.autoTargetKey)
     assertEquals("fold", context.foldTargetId)

--- a/apps/website/src/lib/editor-ffi/components/toolbar/BottomToolbar.svelte
+++ b/apps/website/src/lib/editor-ffi/components/toolbar/BottomToolbar.svelte
@@ -70,6 +70,28 @@
     return { active: false, indeterminate: false };
   };
 
+  const textFormattingDisabled = $derived.by(() => {
+    const state = ctx.editor?.modifierState;
+    if (!state) return false;
+    return [
+      state.bold,
+      state.italic,
+      state.underline,
+      state.strikethrough,
+      state.font_size,
+      state.font_family,
+      state.font_weight,
+      state.text_color,
+      state.background_color,
+      state.letter_spacing,
+      state.link,
+      state.ruby,
+    ].every((tri) => tri.type === 'absent');
+  });
+
+  const alignmentDisabled = $derived(ctx.editor?.modifierState?.alignment?.type === 'absent');
+  const lineHeightDisabled = $derived(ctx.editor?.modifierState?.line_height?.type === 'absent');
+
   const currentTextColor = $derived(
     ctx.editor?.modifierState?.text_color?.type === 'uniform'
       ? ctx.editor.modifierState.text_color.value.value
@@ -188,6 +210,7 @@
   <div class={flex({ alignItems: 'center', gap: '4px' })}>
     <ToolbarDropdownButton
       chevron
+      disabled={textFormattingDisabled}
       label={isTextColorMixed ? '글씨 색: 여러 색' : '글씨 색'}
       onEscape={() => ctx.editor?.focus()}
       placement="bottom-start"
@@ -233,6 +256,7 @@
 
     <ToolbarDropdownButton
       chevron
+      disabled={textFormattingDisabled}
       label={isTextBackgroundColorMixed ? '배경색: 여러 색' : '배경색'}
       onEscape={() => ctx.editor?.focus()}
       placement="bottom-start"
@@ -282,9 +306,9 @@
       {/snippet}
     </ToolbarDropdownButton>
 
-    <ToolbarFontFamily {fontFamilies} onUploadClick={onFontUploadClick} />
-    <ToolbarFontWeight {fontFamilies} />
-    <ToolbarFontSize />
+    <ToolbarFontFamily disabled={textFormattingDisabled} {fontFamilies} onUploadClick={onFontUploadClick} />
+    <ToolbarFontWeight disabled={textFormattingDisabled} {fontFamilies} />
+    <ToolbarFontSize disabled={textFormattingDisabled} />
   </div>
 
   <VerticalDivider style={css.raw({ height: '12px' })} />
@@ -292,6 +316,7 @@
   <div class={flex({ alignItems: 'center', gap: '4px' })}>
     <ToolbarButton
       active={boldS.active}
+      disabled={textFormattingDisabled}
       icon={BoldIcon}
       keys={['Mod', 'B']}
       label="굵게"
@@ -301,6 +326,7 @@
 
     <ToolbarButton
       active={italicS.active}
+      disabled={textFormattingDisabled}
       icon={ItalicIcon}
       keys={['Mod', 'I']}
       label="기울임"
@@ -310,6 +336,7 @@
 
     <ToolbarButton
       active={strikethroughS.active}
+      disabled={textFormattingDisabled}
       icon={StrikethroughIcon}
       keys={['Mod', 'Shift', 'S']}
       label="취소선"
@@ -319,6 +346,7 @@
 
     <ToolbarButton
       active={underlineS.active}
+      disabled={textFormattingDisabled}
       icon={UnderlineIcon}
       keys={['Mod', 'U']}
       label="밑줄"
@@ -332,7 +360,7 @@
   <div class={flex({ alignItems: 'center', gap: '4px' })}>
     <ToolbarDropdownButton
       active={isLinkActive}
-      disabled={isLinkMixed || (isCollapsed && !isLinkActive)}
+      disabled={textFormattingDisabled || isLinkMixed || (isCollapsed && !isLinkActive)}
       label="링크"
       onEscape={() => ctx.editor?.focus()}
       onOpenChange={(opened) => {
@@ -353,7 +381,7 @@
 
     <ToolbarDropdownButton
       active={isRubyActive}
-      disabled={isRubyMixed || (isCollapsed && !isRubyActive)}
+      disabled={textFormattingDisabled || isRubyMixed || (isCollapsed && !isRubyActive)}
       label="루비"
       onEscape={() => ctx.editor?.focus()}
       onOpenChange={(opened) => {
@@ -383,7 +411,7 @@
   <VerticalDivider style={css.raw({ height: '12px' })} />
 
   <div class={flex({ alignItems: 'center', gap: '4px' })}>
-    <ToolbarDropdownButton label="문단 정렬" onEscape={() => ctx.editor?.focus()} size="small">
+    <ToolbarDropdownButton disabled={alignmentDisabled} label="문단 정렬" onEscape={() => ctx.editor?.focus()} size="small">
       {#snippet anchor()}
         <ToolbarIcon icon={values.textAlign.find((a) => a.value === currentTextAlign)?.icon ?? values.textAlign[0].icon} />
       {/snippet}
@@ -406,7 +434,7 @@
       {/snippet}
     </ToolbarDropdownButton>
 
-    <ToolbarDropdownButton label="문단 행간" onEscape={() => ctx.editor?.focus()} size="small">
+    <ToolbarDropdownButton disabled={lineHeightDisabled} label="문단 행간" onEscape={() => ctx.editor?.focus()} size="small">
       {#snippet anchor()}
         <ToolbarIcon icon={LineHeightIcon} />
       {/snippet}
@@ -429,7 +457,7 @@
       {/snippet}
     </ToolbarDropdownButton>
 
-    <ToolbarDropdownButton label="문단 자간" onEscape={() => ctx.editor?.focus()} size="small">
+    <ToolbarDropdownButton disabled={textFormattingDisabled} label="문단 자간" onEscape={() => ctx.editor?.focus()} size="small">
       {#snippet anchor()}
         <ToolbarIcon icon={LetterSpacingIcon} />
       {/snippet}
@@ -456,6 +484,7 @@
   <VerticalDivider style={css.raw({ height: '12px' })} />
 
   <ToolbarButton
+    disabled={textFormattingDisabled}
     icon={RemoveFormattingIcon}
     keys={['Mod', '\\']}
     label="서식 지우기"

--- a/apps/website/src/lib/editor-ffi/components/toolbar/ToolbarButton.svelte
+++ b/apps/website/src/lib/editor-ffi/components/toolbar/ToolbarButton.svelte
@@ -49,7 +49,7 @@
     {onpointerdown}
     type="button"
     use:tooltip={{
-      message: disabled ? '(준비중)' : undefined,
+      message: undefined,
       delay: 200,
       arrow: false,
     }}
@@ -84,7 +84,7 @@
     {onpointerdown}
     type="button"
     use:tooltip={{
-      message: disabled ? `${label} (준비중)` : label,
+      message: label,
       keys,
       delay: 200,
       arrow: false,
@@ -118,7 +118,7 @@
     {onpointerdown}
     type="button"
     use:tooltip={{
-      message: disabled ? `${label} (준비중)` : label,
+      message: label,
       keys,
       delay: 1000,
       arrow: false,

--- a/apps/website/src/lib/editor-ffi/components/toolbar/ToolbarDropdownButton.svelte
+++ b/apps/website/src/lib/editor-ffi/components/toolbar/ToolbarDropdownButton.svelte
@@ -62,6 +62,7 @@
   });
 
   const open = () => {
+    if (disabled) return;
     opened = true;
     onOpenChange?.(true);
   };
@@ -70,6 +71,10 @@
     opened = false;
     onOpenChange?.(false);
   };
+
+  $effect(() => {
+    if (disabled && opened) close();
+  });
 
   const handleEscape = () => {
     close();

--- a/apps/website/src/lib/editor-ffi/components/toolbar/ToolbarFontFamily.svelte
+++ b/apps/website/src/lib/editor-ffi/components/toolbar/ToolbarFontFamily.svelte
@@ -14,9 +14,10 @@
   type Props = {
     fontFamilies?: readonly FontFamily[];
     onUploadClick?: () => void;
+    disabled?: boolean;
   };
 
-  let { fontFamilies = [], onUploadClick }: Props = $props();
+  let { fontFamilies = [], onUploadClick, disabled = false }: Props = $props();
 
   const ctx = getEditorContext();
 
@@ -72,6 +73,7 @@
 
 <SearchableDropdown
   style={css.raw({ width: '120px' })}
+  {disabled}
   extraItems={onUploadClick
     ? [
         {

--- a/apps/website/src/lib/editor-ffi/components/toolbar/ToolbarFontSize.svelte
+++ b/apps/website/src/lib/editor-ffi/components/toolbar/ToolbarFontSize.svelte
@@ -9,6 +9,12 @@
   import { getEditorContext } from '$lib/editor-ffi/editor.svelte';
   import { values } from '$lib/editor-ffi/values';
 
+  type Props = {
+    disabled?: boolean;
+  };
+
+  let { disabled = false }: Props = $props();
+
   const ctx = getEditorContext();
 
   let anchorElement: HTMLDivElement | undefined = $state();
@@ -43,12 +49,17 @@
   });
 
   const open = () => {
+    if (disabled) return;
     opened = true;
   };
 
   const close = () => {
     opened = false;
   };
+
+  $effect(() => {
+    if (disabled) close();
+  });
 
   const handleFocus = () => {
     isFocused = true;
@@ -140,7 +151,7 @@
   };
 </script>
 
-<div class={css({ position: 'relative', width: '50px' })}>
+<div class={css({ position: 'relative', width: '50px', opacity: disabled ? '50' : '100', pointerEvents: disabled ? 'none' : 'auto' })}>
   <div
     bind:this={anchorElement}
     class={css({
@@ -172,6 +183,7 @@
         border: 'none',
         outline: 'none',
       })}
+      {disabled}
       onblur={handleBlur}
       onfocus={handleFocus}
       onkeydown={handleKeydown}
@@ -186,6 +198,7 @@
         pointerEvents: opened ? 'auto' : 'none',
         cursor: 'pointer',
       })}
+      {disabled}
       onclick={() => {
         applyFontSize(true);
         inputElement?.blur();

--- a/apps/website/src/lib/editor-ffi/components/toolbar/ToolbarFontWeight.svelte
+++ b/apps/website/src/lib/editor-ffi/components/toolbar/ToolbarFontWeight.svelte
@@ -13,9 +13,10 @@
 
   type Props = {
     fontFamilies?: readonly FontFamily[];
+    disabled?: boolean;
   };
 
-  let { fontFamilies = [] }: Props = $props();
+  let { fontFamilies = [], disabled = false }: Props = $props();
 
   const ctx = getEditorContext();
 
@@ -62,6 +63,7 @@
 
 <SearchableDropdown
   style={css.raw({ width: '100px' })}
+  {disabled}
   getLabel={(value) => fontWeightValueLabel(currentFontFamilyAndFonts.fonts, values.fontWeight, value)}
   items={weightItems}
   label="폰트 굵기"

--- a/crates/editor-commands/src/commands/clear_all_modifiers.rs
+++ b/crates/editor-commands/src/commands/clear_all_modifiers.rs
@@ -2,8 +2,9 @@ use std::collections::BTreeSet;
 
 use editor_crdt::Dot;
 use editor_model::{DocView, ModifierType};
-use editor_state::{PendingModifier, PendingModifiers};
+use editor_state::{PendingModifier, PendingModifiers, modifier_can_apply_to_inserted_text};
 use editor_transaction::Transaction;
+use strum::IntoEnumIterator;
 
 use crate::CommandResult;
 use crate::helpers::{clear_all_modifiers_range, companion_unset};
@@ -40,8 +41,12 @@ fn clear_all_modifiers_collapsed(tr: &mut Transaction) -> CommandResult {
         .expect("entry caller guaranteed selection")
         .head;
 
-    let (block_id, block_carry_types, own_types) = {
+    let (block_id, block_carry_types, own_types, applicable_types) = {
         let view = tr.view();
+        let applicable: BTreeSet<ModifierType> = ModifierType::iter()
+            .filter(|ty| ty.is_carry_kind())
+            .filter(|&ty| modifier_can_apply_to_inserted_text(&view, &pos, ty))
+            .collect();
         let block = view
             .node(pos.node)
             .and_then(|n| n.ancestors().find(|a| a.spec().is_textblock()));
@@ -49,10 +54,13 @@ fn clear_all_modifiers_collapsed(tr: &mut Transaction) -> CommandResult {
         let carry: Vec<_> = block
             .into_iter()
             .flat_map(|b| b.carry_modifiers().into_keys())
-            .filter(|t| t.is_carry_kind())
+            .filter(|ty| applicable.contains(ty))
             .collect();
-        let own = caret_own_text_types(&view, pos.node, pos.offset);
-        (id, carry, own)
+        let own: Vec<ModifierType> = caret_own_text_types(&view, pos.node, pos.offset)
+            .into_iter()
+            .filter(|ty| applicable.contains(ty))
+            .collect();
+        (id, carry, own, applicable)
     };
 
     let had_carry = !block_carry_types.is_empty();
@@ -66,6 +74,9 @@ fn clear_all_modifiers_collapsed(tr: &mut Transaction) -> CommandResult {
         own_types.into_iter().chain(block_carry_types).collect();
 
     for pm in tr.pending_modifiers() {
+        if !applicable_types.contains(&pm.as_type()) {
+            continue;
+        }
         match pm {
             PendingModifier::Set { modifier } if modifier.as_type().is_carry_kind() => {
                 types.insert(modifier.as_type());
@@ -347,6 +358,33 @@ mod tests {
             }
             selection: (p1, 2)
         };
+        transact_fail!(initial, |tr| clear_all_modifiers(&mut tr));
+    }
+
+    #[test]
+    fn collapsed_fold_title_with_unsupported_pending_is_noop() {
+        let (initial, ..) = state! {
+            doc { root { fold {
+                ft: fold_title { text("Title") }
+                fold_content { paragraph {} }
+            } } }
+            selection: (ft, 2)
+            pending_modifiers: [font_size(3600)]
+        };
+
+        transact_fail!(initial, |tr| clear_all_modifiers(&mut tr));
+    }
+
+    #[test]
+    fn fold_title_range_clear_all_is_noop() {
+        let (initial, ..) = state! {
+            doc { root { fold {
+                ft: fold_title { text("Title") }
+                fold_content { paragraph {} }
+            } } }
+            selection: (ft, 0) -> (ft, 5)
+        };
+
         transact_fail!(initial, |tr| clear_all_modifiers(&mut tr));
     }
 

--- a/crates/editor-commands/src/commands/edit_modifier.rs
+++ b/crates/editor-commands/src/commands/edit_modifier.rs
@@ -1,6 +1,8 @@
 use editor_crdt::Dot;
 use editor_model::{ChildView, DocView, Modifier, ModifierType};
-use editor_state::{PendingModifier, PendingModifiers, Position};
+use editor_state::{
+    PendingModifier, PendingModifiers, Position, modifier_can_apply_to_inserted_text,
+};
 use editor_transaction::Transaction;
 
 use crate::CommandResult;
@@ -85,6 +87,17 @@ fn edit_modifier_collapsed(
     modifier_type: ModifierType,
     modifier: Option<Modifier>,
 ) -> CommandResult {
+    let pos = tr
+        .selection()
+        .expect("entry caller guaranteed selection")
+        .head;
+    {
+        let view = tr.view();
+        if !modifier_can_apply_to_inserted_text(&view, &pos, modifier_type) {
+            return Ok(false);
+        }
+    }
+
     if !matches!(modifier_type, ModifierType::Link | ModifierType::Ruby) {
         let mut pending: PendingModifiers = tr
             .pending_modifiers()
@@ -99,11 +112,6 @@ fn edit_modifier_collapsed(
         tr.set_pending_modifiers(pending)?;
         return Ok(true);
     }
-
-    let pos: Position = tr
-        .selection()
-        .expect("entry caller guaranteed selection")
-        .head;
 
     let span = {
         let view = tr.view();
@@ -350,6 +358,46 @@ mod tests {
             pending_modifiers: [!background_color]
         };
         assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn collapsed_fold_title_edit_background_color_is_noop() {
+        let (initial, ..) = state! {
+            doc { root { fold {
+                ft: fold_title { text("Title") }
+                fold_content { paragraph {} }
+            } } }
+            selection: (ft, 2)
+        };
+
+        let (actual, ..) = transact_fail!(initial, |tr| edit_modifier(
+            &mut tr,
+            ModifierType::BackgroundColor,
+            Some(Modifier::BackgroundColor {
+                value: "red".to_string()
+            })
+        ));
+
+        assert!(actual.pending_modifiers.is_empty());
+    }
+
+    #[test]
+    fn fold_title_range_edit_background_color_is_noop() {
+        let (initial, ..) = state! {
+            doc { root { fold {
+                ft: fold_title { text("Title") }
+                fold_content { paragraph {} }
+            } } }
+            selection: (ft, 0) -> (ft, 5)
+        };
+
+        transact_fail!(initial, |tr| edit_modifier(
+            &mut tr,
+            ModifierType::BackgroundColor,
+            Some(Modifier::BackgroundColor {
+                value: "red".to_string()
+            })
+        ));
     }
 
     #[test]

--- a/crates/editor-commands/src/commands/insert_text.rs
+++ b/crates/editor-commands/src/commands/insert_text.rs
@@ -14,6 +14,8 @@ pub fn insert_text(tr: &mut Transaction, text: &str) -> CommandResult {
 #[cfg(test)]
 mod tests {
     use editor_macros::state;
+    use editor_model::Modifier;
+    use editor_transaction::Step;
 
     use super::*;
     use crate::CommandError;
@@ -134,6 +136,29 @@ mod tests {
             selection: (p1, 6, <)
         };
         assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn typing_in_fold_title_ignores_unsupported_pending() {
+        let (initial, ..) = state! {
+            doc { root { fold {
+                ft: fold_title { text("Title") }
+                fold_content { paragraph {} }
+            } } }
+            selection: (ft, 5)
+            pending_modifiers: [font_size(3600)]
+        };
+
+        let (actual, steps, ..) = transact!(initial, |tr| insert_text(&mut tr, "!"));
+
+        assert!(actual.pending_modifiers.is_empty());
+        assert!(!steps.iter().any(|record| matches!(
+            &record.step,
+            Step::AddSpanModifier {
+                modifier: Modifier::FontSize { value: 3600 },
+                ..
+            }
+        )));
     }
 
     #[test]

--- a/crates/editor-commands/src/commands/set_font_family.rs
+++ b/crates/editor-commands/src/commands/set_font_family.rs
@@ -2,7 +2,8 @@ use editor_common::Tri;
 use editor_model::{DEFAULT_FONT_WEIGHT, Modifier, ModifierType};
 use editor_resource::Resource;
 use editor_state::{
-    PendingModifier, PendingModifiers, caret_provided_and_override, resolve_modifier_state,
+    PendingModifier, PendingModifiers, caret_provided_and_override,
+    modifier_can_apply_to_inserted_text, resolve_modifier_state,
 };
 use editor_transaction::Transaction;
 
@@ -36,6 +37,15 @@ fn set_collapsed(
 ) -> CommandResult {
     let selection = tr.selection().expect("entry caller guaranteed selection");
     let pos = selection.head;
+
+    {
+        let view = tr.view();
+        view.node(pos.node)
+            .ok_or(CommandError::NodeNotFound(pos.node))?;
+        if !modifier_can_apply_to_inserted_text(&view, &pos, ModifierType::FontFamily) {
+            return Ok(false);
+        }
+    }
 
     let (provided_family, explicit_family, old_weight, old_bold, inherited_weight) = {
         let ms = resolve_modifier_state(&tr.state().projected, &selection, tr.pending_modifiers())
@@ -151,6 +161,44 @@ mod tests {
             .set_fonts(prepare_fonts(families))
             .expect("font families must change resources");
         Resource::from_snapshot(source.snapshot())
+    }
+
+    #[test]
+    fn collapsed_fold_title_set_font_family_is_noop() {
+        let resource = make_resource([("Other", vec![400, 700])]);
+        let (initial, ..) = state! {
+            doc { root { fold {
+                ft: fold_title { text("Title") }
+                fold_content { paragraph {} }
+            } } }
+            selection: (ft, 2)
+        };
+
+        let (actual, ..) = transact_fail!(initial, |tr| set_font_family(
+            &mut tr,
+            "Other".to_string(),
+            &resource
+        ));
+
+        assert!(actual.pending_modifiers.is_empty());
+    }
+
+    #[test]
+    fn fold_title_range_set_font_family_is_noop() {
+        let resource = make_resource([("Other", vec![400, 700])]);
+        let (initial, ..) = state! {
+            doc { root { fold {
+                ft: fold_title { text("Title") }
+                fold_content { paragraph {} }
+            } } }
+            selection: (ft, 0) -> (ft, 5)
+        };
+
+        transact_fail!(initial, |tr| set_font_family(
+            &mut tr,
+            "Other".to_string(),
+            &resource
+        ));
     }
 
     #[test]

--- a/crates/editor-commands/src/commands/set_modifier.rs
+++ b/crates/editor-commands/src/commands/set_modifier.rs
@@ -1,6 +1,9 @@
 use editor_crdt::Dot;
 use editor_model::Modifier;
-use editor_state::{PendingModifier, PendingModifiers, caret_provided_and_override};
+use editor_state::{
+    PendingModifier, PendingModifiers, caret_provided_and_override,
+    modifier_can_apply_to_inserted_text,
+};
 use editor_transaction::Transaction;
 
 use crate::helpers::{
@@ -49,6 +52,9 @@ fn set_modifier_collapsed_text(tr: &mut Transaction, modifier: &Modifier) -> Com
         let view = tr.view();
         view.node(pos.node)
             .ok_or(CommandError::NodeNotFound(pos.node))?;
+        if !modifier_can_apply_to_inserted_text(&view, &pos, modifier_type) {
+            return Ok(false);
+        }
         caret_provided_and_override(&tr.state().projected, pos.node, pos.offset, modifier_type)
     };
 
@@ -269,6 +275,40 @@ mod tests {
             pending_modifiers: [font_size(2400)]
         };
         assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn collapsed_fold_title_set_font_size_is_noop() {
+        let (initial, ..) = state! {
+            doc { root { fold {
+                ft: fold_title { text("Title") }
+                fold_content { paragraph {} }
+            } } }
+            selection: (ft, 2)
+        };
+
+        let (actual, ..) = transact_fail!(initial, |tr| set_modifier(
+            &mut tr,
+            Modifier::FontSize { value: 2400 }
+        ));
+
+        assert!(actual.pending_modifiers.is_empty());
+    }
+
+    #[test]
+    fn fold_title_range_set_font_size_is_noop() {
+        let (initial, ..) = state! {
+            doc { root { fold {
+                ft: fold_title { text("Title") }
+                fold_content { paragraph {} }
+            } } }
+            selection: (ft, 0) -> (ft, 5)
+        };
+
+        transact_fail!(initial, |tr| set_modifier(
+            &mut tr,
+            Modifier::FontSize { value: 2400 }
+        ));
     }
 
     #[test]

--- a/crates/editor-commands/src/commands/toggle_bold.rs
+++ b/crates/editor-commands/src/commands/toggle_bold.rs
@@ -1,8 +1,9 @@
 use editor_common::Tri;
 use editor_model::{DEFAULT_FONT_WEIGHT, Modifier, ModifierType};
 use editor_resource::{Resource, find_bold_target, find_unbold_target};
-use editor_state::resolve_modifier_state;
-use editor_state::{PendingModifier, PendingModifiers};
+use editor_state::{
+    PendingModifier, PendingModifiers, modifier_can_apply_to_inserted_text, resolve_modifier_state,
+};
 use editor_transaction::Transaction;
 
 use crate::helpers::{block_weight, toggle_bold_range};
@@ -23,6 +24,15 @@ pub fn toggle_bold(tr: &mut Transaction, resource: &Resource) -> CommandResult {
 fn toggle_bold_collapsed(tr: &mut Transaction, resource: &Resource) -> CommandResult {
     let selection = tr.selection().expect("entry caller guaranteed selection");
     let pos = selection.head;
+
+    {
+        let view = tr.view();
+        view.node(pos.node)
+            .ok_or(CommandError::NodeNotFound(pos.node))?;
+        if !modifier_can_apply_to_inserted_text(&view, &pos, ModifierType::Bold) {
+            return Ok(false);
+        }
+    }
 
     let (current_weight, font_family, is_bold, synthetic_bold, weight_bold) = {
         let ms = resolve_modifier_state(&tr.state().projected, &selection, tr.pending_modifiers())
@@ -167,6 +177,36 @@ mod tests {
         let mut tr = editor_transaction::Transaction::new(&initial);
         let result = toggle_bold(&mut tr, &resource);
         assert!(matches!(result, Ok(false)));
+    }
+
+    #[test]
+    fn collapsed_fold_title_toggle_bold_is_noop() {
+        let resource = make_resource([("Pretendard", vec![400, 700])]);
+        let (initial, ..) = state! {
+            doc { root { fold {
+                ft: fold_title { text("Title") }
+                fold_content { paragraph {} }
+            } } }
+            selection: (ft, 2)
+        };
+
+        let (actual, ..) = transact_fail!(initial, |tr| toggle_bold(&mut tr, &resource));
+
+        assert!(actual.pending_modifiers.is_empty());
+    }
+
+    #[test]
+    fn fold_title_range_toggle_bold_is_noop() {
+        let resource = make_resource([("Pretendard", vec![400, 700])]);
+        let (initial, ..) = state! {
+            doc { root { fold {
+                ft: fold_title { text("Title") }
+                fold_content { paragraph {} }
+            } } }
+            selection: (ft, 0) -> (ft, 5)
+        };
+
+        transact_fail!(initial, |tr| toggle_bold(&mut tr, &resource));
     }
 
     #[test]

--- a/crates/editor-commands/src/commands/toggle_modifier.rs
+++ b/crates/editor-commands/src/commands/toggle_modifier.rs
@@ -1,6 +1,7 @@
 use editor_model::{Modifier, ModifierType};
-use editor_state::resolve_modifier_state;
-use editor_state::{PendingModifier, PendingModifiers};
+use editor_state::{
+    PendingModifier, PendingModifiers, modifier_can_apply_to_inserted_text, resolve_modifier_state,
+};
 use editor_transaction::Transaction;
 
 use crate::helpers::{modifier_from_unit_type, range_has_modifier, toggle_modifier_range};
@@ -30,6 +31,9 @@ fn toggle_modifier_collapsed(
         let view = tr.view();
         view.node(pos.node)
             .ok_or(CommandError::NodeNotFound(pos.node))?;
+        if !modifier_can_apply_to_inserted_text(&view, &pos, modifier_type) {
+            return Ok(false);
+        }
     }
 
     let has_modifier = {
@@ -88,6 +92,35 @@ mod tests {
             pending_modifiers: [italic]
         };
         assert_state_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn collapsed_fold_title_toggle_italic_is_noop() {
+        let (initial, ..) = state! {
+            doc { root { fold {
+                ft: fold_title { text("Title") }
+                fold_content { paragraph {} }
+            } } }
+            selection: (ft, 2)
+        };
+
+        let (actual, ..) =
+            transact_fail!(initial, |tr| toggle_modifier(&mut tr, ModifierType::Italic));
+
+        assert!(actual.pending_modifiers.is_empty());
+    }
+
+    #[test]
+    fn fold_title_range_toggle_italic_is_noop() {
+        let (initial, ..) = state! {
+            doc { root { fold {
+                ft: fold_title { text("Title") }
+                fold_content { paragraph {} }
+            } } }
+            selection: (ft, 0) -> (ft, 5)
+        };
+
+        transact_fail!(initial, |tr| toggle_modifier(&mut tr, ModifierType::Italic));
     }
 
     #[test]

--- a/crates/editor-commands/src/helpers/insertion.rs
+++ b/crates/editor-commands/src/helpers/insertion.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use editor_common::StrExt;
 use editor_crdt::Dot;
@@ -6,7 +6,9 @@ use editor_model::{
     ChildView, Modifier, ModifierType, Node, NodeType, PlainHardBreakNode, PlainNode,
     PlainPageBreakNode, PlainTabNode, PlainTextNode, Subtree,
 };
-use editor_state::{Affinity, PendingModifiers, Position, Selection};
+use editor_state::{
+    Affinity, PendingModifiers, Position, Selection, modifier_applies_to_textblock_child,
+};
 use editor_transaction::{Step, Transaction};
 
 use crate::helpers::resolve_effective_modifiers;
@@ -156,23 +158,37 @@ fn apply_inline_modifiers_run(
     is_char: bool,
     desired: &[Modifier],
 ) -> Result<(), CommandError> {
-    let applicable = |ty: ModifierType| -> bool {
-        ty.is_text_applicable()
-            && (is_char || !matches!(ty, ModifierType::Link | ModifierType::Ruby))
-    };
-
-    let desired_map: BTreeMap<ModifierType, Modifier> = desired
-        .iter()
-        .filter(|m| applicable(m.as_type()))
-        .map(|m| (m.as_type(), m.clone()))
-        .collect();
-
-    let actual: BTreeMap<ModifierType, Modifier> = {
+    let (desired_map, actual, applicable_types) = {
         let view = tr.state().view();
-        match view.leaf_state_by_dot_slow(first) {
+        let Some(leaf) = view.leaf(first) else {
+            return Ok(());
+        };
+        let Some(host) = leaf.parent() else {
+            return Ok(());
+        };
+        let applies = |ty: ModifierType| {
+            modifier_applies_to_textblock_child(&view, host.id(), leaf.node_type(), ty)
+                && (is_char || !matches!(ty, ModifierType::Link | ModifierType::Ruby))
+        };
+        let desired_map: BTreeMap<ModifierType, Modifier> = desired
+            .iter()
+            .filter(|modifier| {
+                applies(modifier.as_type())
+                    && host.effective().get(&modifier.as_type()) != Some(*modifier)
+            })
+            .map(|modifier| (modifier.as_type(), modifier.clone()))
+            .collect();
+        let actual = match view.leaf_state_by_dot_slow(first) {
             Some(st) => st.own.iter().map(|(t, o)| (*t, o.value.clone())).collect(),
             None => BTreeMap::new(),
-        }
+        };
+        let applicable_types: BTreeSet<ModifierType> = desired_map
+            .keys()
+            .chain(actual.keys())
+            .copied()
+            .filter(|ty| applies(*ty))
+            .collect();
+        (desired_map, actual, applicable_types)
     };
 
     for (ty, m) in &desired_map {
@@ -181,7 +197,7 @@ fn apply_inline_modifiers_run(
         }
     }
     for (ty, m) in &actual {
-        if !desired_map.contains_key(ty) && ty.is_text_applicable() {
+        if !desired_map.contains_key(ty) && applicable_types.contains(ty) {
             tr.remove_span_modifier(first, last, m.clone())?;
         }
     }

--- a/crates/editor-commands/src/helpers/modifiers.rs
+++ b/crates/editor-commands/src/helpers/modifiers.rs
@@ -8,8 +8,9 @@ use editor_model::{
 };
 use editor_resource::{Resource, find_bold_target, find_unbold_target, match_weight};
 use editor_state::{
-    PendingModifiers, Position, ProjectedState, ResolvedSelection, Selection, apply_pending,
-    continuation_at, leaf_groups_in_range, leaf_spans_in_range, resolve_modifier_state_in_range,
+    LeafGroup, PendingModifiers, Position, ProjectedState, ResolvedSelection, Selection,
+    continuation_at, leaf_groups_in_range, modifier_applies_to_textblock_child,
+    resolve_caret_modifiers, resolve_modifier_state_in_range,
 };
 use editor_transaction::Transaction;
 use strum::IntoEnumIterator;
@@ -25,9 +26,9 @@ pub(crate) fn resolve_effective_modifiers(
     offset: usize,
     pending_modifiers: &PendingModifiers,
 ) -> Vec<Modifier> {
-    let mut out = continuation_at(state, block, offset);
-    apply_pending(&mut out, pending_modifiers);
-    out.into_values().collect()
+    resolve_caret_modifiers(state, &Position::new(block, offset), pending_modifiers)
+        .into_values()
+        .collect()
 }
 
 /// Inheritable modifiers provided by ancestors (self excluded), per type.
@@ -258,6 +259,73 @@ pub(crate) fn validate_edit(
     Ok(true)
 }
 
+fn leaf_group_applicability(
+    view: &DocView,
+    groups: &[LeafGroup<'_>],
+    modifier_type: ModifierType,
+) -> Vec<bool> {
+    let mut cache: hashbrown::HashMap<(Dot, NodeType), bool> = hashbrown::HashMap::new();
+    groups
+        .iter()
+        .map(|group| {
+            *cache
+                .entry((group.host, group.leaf_type))
+                .or_insert_with(|| {
+                    modifier_applies_to_textblock_child(
+                        view,
+                        group.host,
+                        group.leaf_type,
+                        modifier_type,
+                    )
+                })
+        })
+        .collect()
+}
+
+fn leaf_spans_for_applicability(
+    view: &DocView,
+    groups: &[LeafGroup<'_>],
+    applicability: &[bool],
+    is_cell_rect: bool,
+) -> Vec<(Dot, Dot)> {
+    debug_assert_eq!(groups.len(), applicability.len());
+    let mut spans = Vec::new();
+    let mut current: Option<(Option<Dot>, Dot, Dot)> = None;
+
+    for (group, applies) in groups.iter().zip(applicability) {
+        if !applies {
+            if let Some((_, first, last)) = current.take() {
+                spans.push((first, last));
+            }
+            continue;
+        }
+
+        let partition = is_cell_rect.then(|| {
+            view.node(group.host)
+                .and_then(|host| {
+                    host.ancestors()
+                        .find(|node| node.node_type() == NodeType::TableCell)
+                })
+                .map_or(group.host, |cell| cell.id())
+        });
+        match &mut current {
+            Some((current_partition, _, last)) if *current_partition == partition => {
+                *last = group.last;
+            }
+            _ => {
+                if let Some((_, first, last)) = current.take() {
+                    spans.push((first, last));
+                }
+                current = Some((partition, group.first, group.last));
+            }
+        }
+    }
+    if let Some((_, first, last)) = current {
+        spans.push((first, last));
+    }
+    spans
+}
+
 pub(crate) fn edit_modifier_range(
     tr: &mut Transaction,
     selection: Selection,
@@ -269,7 +337,14 @@ pub(crate) fn edit_modifier_range(
         let rs = selection
             .resolve(&view)
             .ok_or(CommandError::Corrupted("cannot resolve selection".into()))?;
-        let spans = leaf_spans_in_range(&rs);
+        let groups = leaf_groups_in_range(&rs);
+        let applicability = leaf_group_applicability(&view, &groups, modifier_type);
+        let spans = leaf_spans_for_applicability(
+            &view,
+            &groups,
+            &applicability,
+            rs.as_cell_rect().is_some(),
+        );
         let present = spans.first().and_then(|&(first, _)| {
             view.leaf_state_by_dot_slow(first)
                 .and_then(|st| st.eff.get(&modifier_type).cloned())
@@ -386,10 +461,14 @@ pub(crate) fn set_font_family_range(
                 .as_ref()
                 == Some(&family)
         };
+        let leaf_groups = leaf_groups_in_range(&rs);
+        let applicability = leaf_group_applicability(&view, &leaf_groups, ModifierType::FontFamily);
         let groups = coalesce_group_runs(
-            leaf_groups_in_range(&rs)
-                .into_iter()
-                .map(|g| {
+            leaf_groups
+                .iter()
+                .zip(&applicability)
+                .filter(|(_, applies)| **applies)
+                .map(|(g, _)| {
                     let all_leaf = view
                         .node(g.host)
                         .is_some_and(|n| n.leaf_child_count() == n.child_count());
@@ -520,10 +599,14 @@ pub(crate) fn set_modifier_range_text(
                 .as_ref()
                 == Some(modifier)
         };
+        let leaf_groups = leaf_groups_in_range(&rs);
+        let applicability = leaf_group_applicability(&view, &leaf_groups, modifier_type);
         let groups: Vec<(Dot, Dot, bool)> = coalesce_group_runs(
-            leaf_groups_in_range(&rs)
+            leaf_groups
                 .iter()
-                .map(|g| {
+                .zip(&applicability)
+                .filter(|(_, applies)| **applies)
+                .map(|(g, _)| {
                     let all_leaf = view
                         .node(g.host)
                         .is_some_and(|n| n.leaf_child_count() == n.child_count());
@@ -580,8 +663,8 @@ pub(crate) fn block_family(view: &DocView, elem: Dot) -> Option<String> {
     }
 }
 
-pub(crate) fn range_has_heavy_weight(rs: &ResolvedSelection) -> bool {
-    leaf_groups_in_range(rs).iter().any(|g| {
+fn groups_have_heavy_weight(groups: &[&LeafGroup<'_>]) -> bool {
+    groups.iter().any(|g| {
         matches!(
             g.effective.get(&ModifierType::FontWeight),
             Some(Modifier::FontWeight { value }) if *value >= 700
@@ -589,24 +672,20 @@ pub(crate) fn range_has_heavy_weight(rs: &ResolvedSelection) -> bool {
     })
 }
 
-fn leaf_uniform_font_weight(rs: &ResolvedSelection) -> Option<u16> {
-    let mut it = leaf_groups_in_range(rs)
-        .into_iter()
-        .map(|g| font_weight(g.effective));
+fn leaf_uniform_font_weight(groups: &[&LeafGroup<'_>]) -> Option<u16> {
+    let mut it = groups.iter().map(|g| font_weight(g.effective));
     let first = it.next()?;
     it.all(|w| w == first).then_some(first)
 }
 
-fn leaf_uniform_font_family(rs: &ResolvedSelection) -> Option<String> {
+fn leaf_uniform_font_family(groups: &[&LeafGroup<'_>]) -> Option<String> {
     let family = |effective: &BTreeMap<ModifierType, Modifier>| match effective
         .get(&ModifierType::FontFamily)
     {
         Some(Modifier::FontFamily { value }) => value.clone(),
         _ => DEFAULT_FONT_FAMILY.to_string(),
     };
-    let mut it = leaf_groups_in_range(rs)
-        .into_iter()
-        .map(|g| family(g.effective));
+    let mut it = groups.iter().map(|g| family(g.effective));
     let first = it.next()?;
     it.all(|f| f == first).then_some(first)
 }
@@ -647,7 +726,20 @@ pub(crate) fn toggle_bold_range(
         let rs = selection
             .resolve(&view)
             .ok_or(CommandError::Corrupted("cannot resolve selection".into()))?;
-        let spans = leaf_spans_in_range(&rs);
+        let groups = leaf_groups_in_range(&rs);
+        let applicability = leaf_group_applicability(&view, &groups, ModifierType::Bold);
+        let spans = leaf_spans_for_applicability(
+            &view,
+            &groups,
+            &applicability,
+            rs.as_cell_rect().is_some(),
+        );
+        let applicable_groups: Vec<&LeafGroup<'_>> = groups
+            .iter()
+            .zip(&applicability)
+            .filter(|(_, applies)| **applies)
+            .map(|(group, _)| group)
+            .collect();
         let end_touched: Vec<Dot> = end_touched_textblocks(&view, &rs)
             .into_iter()
             .filter(|&b| block_accepts_carry_kind(&view, b, ModifierType::Bold))
@@ -657,16 +749,15 @@ pub(crate) fn toggle_bold_range(
             Tri::Uniform { .. }
         );
         let leaf_ctx = (!spans.is_empty()).then(|| {
-            let from_block = rs.from().node();
+            let from_block = applicable_groups[0].host;
             let inherited_weight = block_weight(&view, from_block).unwrap_or(DEFAULT_FONT_WEIGHT);
-            let current_weight = leaf_uniform_font_weight(&rs).unwrap_or(inherited_weight);
-            let font_family = leaf_uniform_font_family(&rs).unwrap_or_else(|| {
+            let current_weight =
+                leaf_uniform_font_weight(&applicable_groups).unwrap_or(inherited_weight);
+            let font_family = leaf_uniform_font_family(&applicable_groups).unwrap_or_else(|| {
                 block_family(&view, from_block).unwrap_or_else(|| DEFAULT_FONT_FAMILY.to_string())
             });
-            let synthetic_bold = leaf_groups_in_range(&rs)
-                .iter()
-                .any(|g| has_bold(g.effective));
-            let weight_bold = range_has_heavy_weight(&rs);
+            let synthetic_bold = applicable_groups.iter().any(|g| has_bold(g.effective));
+            let weight_bold = groups_have_heavy_weight(&applicable_groups);
             (
                 current_weight,
                 font_family,
@@ -777,7 +868,14 @@ pub(crate) fn toggle_modifier_range(
         let rs = selection
             .resolve(&view)
             .ok_or(CommandError::Corrupted("cannot resolve selection".into()))?;
-        let spans = leaf_spans_in_range(&rs);
+        let groups = leaf_groups_in_range(&rs);
+        let applicability = leaf_group_applicability(&view, &groups, modifier_type);
+        let spans = leaf_spans_for_applicability(
+            &view,
+            &groups,
+            &applicability,
+            rs.as_cell_rect().is_some(),
+        );
         let all_have =
             range_has_modifier(&resolve_modifier_state_in_range(state, &rs), modifier_type);
         let end_touched: Vec<_> = end_touched_textblocks(&view, &rs)
@@ -808,16 +906,31 @@ pub(crate) fn toggle_modifier_range(
 }
 
 type CarryBlocksByKind = Vec<(ModifierType, Vec<Dot>)>;
+type TextSpansByKind = Vec<(ModifierType, Vec<(Dot, Dot)>)>;
 
 pub(crate) fn clear_all_modifiers_range(
     tr: &mut Transaction,
     selection: Selection,
 ) -> CommandResult {
-    let (spans, companion_by_kind): (Vec<(Dot, Dot)>, CarryBlocksByKind) = {
+    let (spans_by_kind, companion_by_kind): (TextSpansByKind, CarryBlocksByKind) = {
         let view = tr.view();
         let rs = selection
             .resolve(&view)
             .ok_or(CommandError::Corrupted("cannot resolve selection".into()))?;
+        let groups = leaf_groups_in_range(&rs);
+        let spans_by_kind = ModifierType::iter()
+            .filter(|ty| ty.is_text_applicable())
+            .map(|ty| {
+                let applicability = leaf_group_applicability(&view, &groups, ty);
+                let spans = leaf_spans_for_applicability(
+                    &view,
+                    &groups,
+                    &applicability,
+                    rs.as_cell_rect().is_some(),
+                );
+                (ty, spans)
+            })
+            .collect();
         let et = end_touched_textblocks(&view, &rs);
         let companion_by_kind = ModifierType::iter()
             .filter(|t| t.is_carry_kind())
@@ -830,12 +943,14 @@ pub(crate) fn clear_all_modifiers_range(
                 (ty, blocks)
             })
             .collect();
-        (leaf_spans_in_range(&rs), companion_by_kind)
+        (spans_by_kind, companion_by_kind)
     };
 
-    for &(first, last) in &spans {
-        for ty in ModifierType::iter().filter(|&t| t.is_text_applicable()) {
-            tr.remove_span_modifier(first, last, placeholder_modifier(ty))?;
+    let mut touched_any_span = false;
+    for (ty, spans) in &spans_by_kind {
+        touched_any_span |= !spans.is_empty();
+        for &(first, last) in spans {
+            tr.remove_span_modifier(first, last, placeholder_modifier(*ty))?;
         }
     }
 
@@ -845,7 +960,7 @@ pub(crate) fn clear_all_modifiers_range(
         companion_unset(tr, blocks, *ty)?;
     }
 
-    if spans.is_empty() && !touched_any_carry {
+    if !touched_any_span && !touched_any_carry {
         return Ok(false);
     }
     Ok(true)

--- a/crates/editor-core/src/editor.rs
+++ b/crates/editor-core/src/editor.rs
@@ -35,22 +35,24 @@ use editor_state::undo::{RecordMerge, TransientState, UndoEntry, UndoHistory};
 
 fn normalize_pending_overlay(state: &State) -> Option<PendingOverlay> {
     let modifiers = state.pending_modifiers.clone();
-
     if modifiers.is_empty() {
         return None;
     }
     let selection = state.selection.as_ref()?;
-    let view = state.view();
-    let textblock = view
-        .node(selection.head.node)?
-        .ancestors()
-        .find(|n| n.spec().is_textblock())?;
-    let is_empty = textblock.children().next().is_none();
-    if !is_empty {
+    if !selection.is_collapsed() {
         return None;
     }
+    let view = state.view();
+    let node = view.node(selection.head.node)?;
+    let position = node
+        .ancestors()
+        .find(|ancestor| ancestor.spec().is_textblock())
+        .map_or(selection.head, |textblock| Position {
+            node: textblock.id(),
+            ..selection.head
+        });
     Some(PendingOverlay {
-        node_id: textblock.id(),
+        position,
         modifiers,
     })
 }
@@ -2597,8 +2599,8 @@ mod tests {
     }
 
     #[test]
-    fn normalize_non_empty_paragraph_returns_none() {
-        let (state, _p1) = state! {
+    fn normalize_non_empty_paragraph_returns_caret_overlay() {
+        let (state, p1) = state! {
             doc { root { p1: paragraph { text("hi") } } }
             selection: (p1, 0)
         };
@@ -2606,7 +2608,14 @@ mod tests {
             modifier: Modifier::Bold,
         }];
         let s = with_pending(state, pending);
-        assert!(normalize_pending_overlay(&s).is_none());
+        let overlay = normalize_pending_overlay(&s).expect("caret overlay");
+        assert_eq!(overlay.position, Position::new(p1, 0));
+        assert_eq!(
+            overlay.modifiers,
+            vec![PendingModifier::Set {
+                modifier: Modifier::Bold
+            }]
+        );
     }
 
     #[test]
@@ -2620,21 +2629,8 @@ mod tests {
         }];
         let s = with_pending(state, pending.clone());
         let ps = normalize_pending_overlay(&s).expect("Some");
-        assert_eq!(ps.node_id, p1);
+        assert_eq!(ps.position, Position::new(p1, 0));
         assert_eq!(ps.modifiers, pending);
-    }
-
-    #[test]
-    fn normalize_head_on_text_child_ascends_to_textblock() {
-        let (state, _p1) = state! {
-            doc { root { p1: paragraph { text("hi") } } }
-            selection: (p1, 0)
-        };
-        let pending: PendingModifiers = vec![PendingModifier::Set {
-            modifier: Modifier::Bold,
-        }];
-        let s = with_pending(state, pending);
-        assert!(normalize_pending_overlay(&s).is_none());
     }
 
     fn zombie_css() -> Vec<Changeset<EditOp>> {
@@ -4497,6 +4493,180 @@ mod tests {
     }
 
     #[test]
+    fn pending_font_size_affects_only_active_caret_metrics() {
+        let (initial, p1, p2) = state! {
+            doc { root {
+                p1: paragraph { text("a") }
+                p2: paragraph { text("b") [font_size(2400)] }
+            } }
+            selection: (p1, 1)
+            pending_modifiers: [font_size(3600)]
+        };
+        let mut editor = Editor::new_test(initial);
+        editor.apply(Message::System {
+            event: crate::message::SystemEvent::Initialize,
+        });
+
+        let active_caret = editor
+            .view()
+            .cursor_metrics(&editor.state, &Position::new(p1, 1))
+            .expect("active cursor metrics after pending font_size 36pt")
+            .caret;
+        let other_caret = editor
+            .view()
+            .cursor_metrics(&editor.state, &Position::new(p2, 1))
+            .expect("non-active cursor metrics at 24pt text")
+            .caret;
+
+        assert!(
+            active_caret.height > other_caret.height,
+            "36pt pending must affect only the active caret, not a queried 24pt position: active={}, other={}",
+            active_caret.height,
+            other_caret.height
+        );
+    }
+
+    #[test]
+    fn pending_font_size_expands_active_line_layout() {
+        let (initial, p1, p2) = state! {
+            doc { root {
+                p1: paragraph { text("a") }
+                p2: paragraph { text("b") }
+            } }
+            selection: (p1, 1)
+        };
+        let mut editor = Editor::new_test(initial);
+        editor.apply(Message::System {
+            event: crate::message::SystemEvent::Initialize,
+        });
+
+        let before_active = editor
+            .view()
+            .cursor_metrics(&editor.state, &Position::new(p1, 1))
+            .expect("active cursor before pending font size");
+        let before_next = editor
+            .view()
+            .cursor_metrics(&editor.state, &Position::new(p2, 0))
+            .expect("next paragraph cursor before pending font size");
+
+        editor.apply(Message::Modifier {
+            op: ModifierOp::Set {
+                modifier: Modifier::FontSize { value: 9600 },
+            },
+        });
+
+        let after_active = editor
+            .view()
+            .cursor_metrics(&editor.state, &Position::new(p1, 1))
+            .expect("active cursor after pending font size 96pt");
+        let after_next = editor
+            .view()
+            .cursor_metrics(&editor.state, &Position::new(p2, 0))
+            .expect("next paragraph cursor after pending font size");
+
+        assert!(
+            after_active.line.height >= after_active.caret.height,
+            "active line must contain the pending caret: line={}, caret={}",
+            after_active.line.height,
+            after_active.caret.height
+        );
+        assert!(
+            after_active.caret.y >= after_active.line.y
+                && after_active.caret.bottom() <= after_active.line.bottom(),
+            "pending caret must stay inside the active line: line={:?}, caret={:?}",
+            after_active.line,
+            after_active.caret
+        );
+        assert!(
+            after_active.line.height > before_active.line.height,
+            "active line must grow for the pending font size: before={}, after={}",
+            before_active.line.height,
+            after_active.line.height
+        );
+        assert!(
+            after_next.line.y > before_next.line.y,
+            "following content must move below the expanded active line: before={}, after={}",
+            before_next.line.y,
+            after_next.line.y
+        );
+    }
+
+    #[test]
+    fn non_empty_clear_all_updates_active_caret_metrics() {
+        let (initial, p1) = state! {
+            doc { root { p1: paragraph { text("a") [font_size(3600)] } } }
+            selection: (p1, 1)
+        };
+        let mut editor = Editor::new_test(initial);
+        editor.apply(Message::System {
+            event: crate::message::SystemEvent::Initialize,
+        });
+
+        let big_caret = editor
+            .view()
+            .cursor_metrics(&editor.state, &Position::new(p1, 1))
+            .expect("cursor metrics at the end of 36pt text")
+            .caret;
+
+        editor.apply(Message::Modifier {
+            op: ModifierOp::ClearAll,
+        });
+
+        let view = editor.state().view();
+        let leaf_state = view
+            .node(p1)
+            .and_then(|node| node.leaf_state_at(0))
+            .expect("existing text leaf after ClearAll");
+        assert_eq!(
+            leaf_state
+                .own
+                .get(&ModifierType::FontSize)
+                .map(|own| &own.value),
+            Some(&Modifier::FontSize { value: 3600 }),
+            "collapsed ClearAll must not change existing text"
+        );
+
+        let cleared_caret = editor
+            .view()
+            .cursor_metrics(&editor.state, &Position::new(p1, 1))
+            .expect("cursor metrics after ClearAll")
+            .caret;
+        assert!(
+            cleared_caret.height < big_caret.height,
+            "caret must return to the resolved default size after ClearAll: big={}, cleared={}",
+            big_caret.height,
+            cleared_caret.height
+        );
+    }
+
+    #[test]
+    fn non_empty_clear_all_publishes_cursor_state_field() {
+        let (initial, _p1) = state! {
+            doc { root { p1: paragraph { text("a") [font_size(3600)] } } }
+            selection: (p1, 1)
+        };
+        let mut editor = Editor::new_test(initial);
+        editor.apply(Message::System {
+            event: crate::message::SystemEvent::Initialize,
+        });
+
+        let events = editor.apply(Message::Modifier {
+            op: ModifierOp::ClearAll,
+        });
+
+        assert!(
+            events.iter().any(|event| {
+                matches!(
+                    event,
+                    EditorEvent::StateChanged { fields }
+                        if fields.contains(&StateField::Cursor)
+                )
+            }),
+            "pending-only ClearAll must tell hosts to re-query the cursor"
+        );
+    }
+
+    #[test]
     fn empty_paragraph_clear_all_modifiers_clears_carry_font_size() {
         let (initial, p1) = state! {
             doc { root { p1: paragraph carry([font_size(2400)]) {} } }
@@ -5590,6 +5760,48 @@ mod tests {
                 .cursor_metrics(st2, &st2.selection.expect("selection exists in test").head)
                 .is_some(),
             "normal caret still valid after leaving the gap (phantom space recovered)"
+        );
+    }
+
+    #[test]
+    fn gap_caret_pending_font_size_expands_line_and_publishes_cursor_state_field() {
+        let (initial, _root, _p1) = state! {
+            doc { root: root { image p1: paragraph { text("b") } } }
+            selection: (root, 0, <)
+        };
+        let mut editor = Editor::new_test(initial);
+        editor.apply(Message::System {
+            event: crate::message::SystemEvent::Initialize,
+        });
+
+        let events = editor.apply(Message::Modifier {
+            op: ModifierOp::Set {
+                modifier: Modifier::FontSize { value: 9600 },
+            },
+        });
+        let position = editor.state.selection.expect("gap selection").head;
+        let cursor = editor
+            .view()
+            .cursor_metrics(&editor.state, &position)
+            .expect("gap cursor metrics after pending font size");
+
+        assert!(
+            cursor.line.height >= cursor.caret.height
+                && cursor.caret.y >= cursor.line.y
+                && cursor.caret.bottom() <= cursor.line.bottom(),
+            "gap line must contain the pending caret: line={:?}, caret={:?}",
+            cursor.line,
+            cursor.caret,
+        );
+        assert!(
+            events.iter().any(|event| {
+                matches!(
+                    event,
+                    EditorEvent::StateChanged { fields }
+                        if fields.contains(&StateField::Cursor)
+                )
+            }),
+            "gap pending style change must tell hosts to re-query the cursor",
         );
     }
 

--- a/crates/editor-state/src/carry.rs
+++ b/crates/editor-state/src/carry.rs
@@ -1,11 +1,10 @@
 use editor_crdt::Dot;
-use editor_model::{ChildView, DocView, ModifierType, NodeType, Schema};
+use editor_model::{ChildView, DocView, ModifierType, NodeType};
 
+use crate::modifier_resolution::modifier_target_matches_path;
 use crate::position::Position;
 use crate::selection::ResolvedSelection;
 use crate::traversal::{blocks_in_range, leaves_in_block_range};
-
-const CHARLIKE_SLOTS: [NodeType; 3] = [NodeType::Text, NodeType::Tab, NodeType::HardBreak];
 
 pub fn block_accepts_carry_kind(view: &DocView, block: Dot, ty: ModifierType) -> bool {
     let Some(node) = view.node(block) else {
@@ -14,14 +13,17 @@ pub fn block_accepts_carry_kind(view: &DocView, block: Dot, ty: ModifierType) ->
     if !node.spec().is_textblock() {
         return false;
     }
-    let mut base: Vec<NodeType> = node.ancestors().map(|a| a.node_type()).collect();
-    base.reverse();
-    let target = &Schema::modifier_spec(ty).target;
-    CHARLIKE_SLOTS.iter().any(|&slot| {
-        let mut path = base.clone();
-        path.push(slot);
-        target.matches(&path)
-    })
+    let mut path: Vec<NodeType> = node.ancestors().map(|a| a.node_type()).collect();
+    path.reverse();
+    for child_type in [NodeType::Text, NodeType::Tab, NodeType::HardBreak] {
+        path.push(child_type);
+        let applies = modifier_target_matches_path(&path, child_type, ty);
+        path.pop();
+        if applies {
+            return true;
+        }
+    }
+    false
 }
 
 pub fn end_touched_textblocks(view: &DocView, rs: &ResolvedSelection) -> Vec<Dot> {

--- a/crates/editor-state/src/lib.rs
+++ b/crates/editor-state/src/lib.rs
@@ -64,7 +64,10 @@ pub use flat::{flat_size_walk_probe, from_flat_walk_probe, to_flat_walk_probe};
 pub use gap_cursor::{GapCursor, as_gap_cursor, gap_cursor_at};
 pub use layout_dirty::LayoutDirty;
 pub use load_builder::BuildError;
-pub use modifier_resolution::{resolve_caret_modifiers, resolve_effective_modifiers_at};
+pub use modifier_resolution::{
+    modifier_applies_to_textblock_child, modifier_can_apply_to_inserted_text,
+    resolve_caret_modifiers, resolve_effective_modifiers_at,
+};
 pub use modifier_span::resolve_modifier_span_selection;
 pub use modifier_state::{resolve_modifier_state, resolve_modifier_state_in_range};
 pub use normalize::{

--- a/crates/editor-state/src/modifier_resolution.rs
+++ b/crates/editor-state/src/modifier_resolution.rs
@@ -3,14 +3,43 @@ use std::collections::BTreeMap;
 
 use editor_crdt::Dot;
 use editor_model::{
-    EffectiveSources, Modifier, ModifierType, NodeType, NodeView, Schema, resolve_effective,
+    DocView, EffectiveSources, Modifier, ModifierType, NodeType, NodeView, Schema,
+    resolve_effective,
 };
 
 use crate::Position;
-use crate::continuation::{apply_pending, continuation_at};
+use crate::continuation::continuation_at;
+use crate::gap_cursor::gap_cursor_at;
 use crate::pending_modifier::PendingModifier;
 use crate::projected_state::ProjectedState;
 use crate::state::State;
+
+pub(crate) fn modifier_target_matches_path(
+    path: &[NodeType],
+    target_type: NodeType,
+    ty: ModifierType,
+) -> bool {
+    let target = &Schema::modifier_spec(ty).target;
+    target.rightmost_node_types().contains(&target_type) && target.matches(path)
+}
+
+pub fn modifier_applies_to_textblock_child(
+    view: &DocView,
+    textblock: Dot,
+    child_type: NodeType,
+    ty: ModifierType,
+) -> bool {
+    let Some(host) = view
+        .node(textblock)
+        .filter(|node| node.spec().is_textblock())
+    else {
+        return false;
+    };
+    let mut path: Vec<NodeType> = host.ancestors().map(|node| node.node_type()).collect();
+    path.reverse();
+    path.push(child_type);
+    modifier_target_matches_path(&path, child_type, ty)
+}
 
 fn parents_path(host: &NodeView) -> Vec<(NodeType, Option<Dot>)> {
     let mut v: Vec<(NodeType, Option<Dot>)> = host
@@ -49,6 +78,52 @@ pub fn resolve_effective_modifiers_at(state: &State, pos: &Position) -> Vec<Modi
         .collect()
 }
 
+/// Whether a modifier can target text inserted at `pos`. A gap cursor is
+/// evaluated as its virtual paragraph.
+pub fn modifier_can_apply_to_inserted_text(
+    view: &DocView,
+    pos: &Position,
+    ty: ModifierType,
+) -> bool {
+    let Some(host) = view.node(pos.node) else {
+        return false;
+    };
+
+    if host.spec().is_textblock() {
+        return modifier_applies_to_textblock_child(view, host.id(), NodeType::Text, ty);
+    }
+
+    if gap_cursor_at(pos, view).is_none() {
+        return false;
+    }
+
+    let mut path: Vec<NodeType> = host.ancestors().map(|node| node.node_type()).collect();
+    path.reverse();
+    path.extend([NodeType::Paragraph, NodeType::Text]);
+    modifier_target_matches_path(&path, NodeType::Text, ty)
+}
+
+fn apply_pending_at_position(
+    out: &mut BTreeMap<ModifierType, Modifier>,
+    pending: &[PendingModifier],
+    view: &DocView,
+    pos: &Position,
+) {
+    for pending in pending {
+        if !modifier_can_apply_to_inserted_text(view, pos, pending.as_type()) {
+            continue;
+        }
+        match pending {
+            PendingModifier::Set { modifier } => {
+                out.insert(modifier.as_type(), modifier.clone());
+            }
+            PendingModifier::Unset { ty } => {
+                out.remove(ty);
+            }
+        }
+    }
+}
+
 /// Modifiers that would apply to text inserted at `pos`.
 pub fn resolve_caret_modifiers(
     state: &ProjectedState,
@@ -62,12 +137,12 @@ pub fn resolve_caret_modifiers(
 
     if !Schema::node_spec(host.node_type()).is_textblock() {
         let mut out = inherited_over(&parents_path(&host), state);
-        apply_pending(&mut out, pending);
+        apply_pending_at_position(&mut out, pending, &view, pos);
         return out;
     }
 
     let mut out = continuation_at(state, pos.node, pos.offset);
-    apply_pending(&mut out, pending);
+    apply_pending_at_position(&mut out, pending, &view, pos);
     for (ty, m) in inherited_over(&self_path(&host), state) {
         out.entry(ty).or_insert(m);
     }
@@ -430,6 +505,28 @@ mod tests {
             out.get(&ModifierType::FontWeight),
             Some(&Modifier::FontWeight { value: 500 }),
             "the FoldTitle implicit weight wins over the root record"
+        );
+    }
+
+    #[test]
+    fn foldtitle_ignores_unsupported_pending_but_keeps_implicit_style() {
+        let (state, title) = fold_title_state();
+        let out = resolve_caret_modifiers(
+            &state,
+            &Position::new(title, 0),
+            &[PendingModifier::Set {
+                modifier: Modifier::FontSize { value: 3600 },
+            }],
+        );
+
+        assert_ne!(
+            out.get(&ModifierType::FontSize),
+            Some(&Modifier::FontSize { value: 3600 })
+        );
+        assert_eq!(
+            out.get(&ModifierType::FontWeight),
+            Some(&Modifier::FontWeight { value: 500 }),
+            "fixed FoldTitle paint remains available to caret geometry"
         );
     }
 

--- a/crates/editor-state/src/modifier_state.rs
+++ b/crates/editor-state/src/modifier_state.rs
@@ -15,28 +15,15 @@ use crate::selection::ResolvedSelection;
 use crate::selection::Selection;
 use crate::traversal;
 
-fn modifier_for_caret_state(
-    caret: &BTreeMap<ModifierType, Modifier>,
-    textblock: &NodeView,
-    ty: ModifierType,
-) -> Option<Modifier> {
-    modifier_for_caret_map(
-        caret,
-        textblock.node_type(),
-        &textblock_type_path(textblock),
-        textblock.effective(),
-        ty,
-    )
-}
-
 fn modifier_for_caret_map(
     caret: &BTreeMap<ModifierType, Modifier>,
     block_type: NodeType,
     block_path: &[NodeType],
+    text_path: &[NodeType],
     block_effective: &BTreeMap<ModifierType, Modifier>,
     ty: ModifierType,
 ) -> Option<Modifier> {
-    if !modifier_applies_for(block_type, block_path, ty) {
+    if !modifier_applies_for(block_type, block_path, text_path, ty) {
         return None;
     }
     if let Some(modifier) = caret.get(&ty) {
@@ -51,16 +38,18 @@ fn modifier_for_caret_map(
     .or(Some(default))
 }
 
-fn modifier_applies_for(block_type: NodeType, block_path: &[NodeType], ty: ModifierType) -> bool {
+fn modifier_applies_for(
+    block_type: NodeType,
+    block_path: &[NodeType],
+    text_path: &[NodeType],
+    ty: ModifierType,
+) -> bool {
     let target = &Schema::modifier_spec(ty).target;
     let targets = target.rightmost_node_types();
     if targets.contains(&block_type) && target.matches(block_path) {
         return true;
     }
-    targets.contains(&NodeType::Text)
-        && Schema::node_spec(block_type)
-            .content
-            .matches(NodeType::Text)
+    targets.contains(&NodeType::Text) && target.matches(text_path)
 }
 
 fn virtual_paragraph_toolbar(
@@ -85,6 +74,8 @@ fn virtual_paragraph_toolbar(
 
     let mut para_path: Vec<NodeType> = container_path.iter().map(|(t, _)| *t).collect();
     para_path.push(NodeType::Paragraph);
+    let mut text_path = para_path.clone();
+    text_path.push(NodeType::Text);
 
     let empty_caret: BTreeMap<ModifierType, Modifier> = BTreeMap::new();
     let mut out = BTreeMap::new();
@@ -93,6 +84,7 @@ fn virtual_paragraph_toolbar(
             &empty_caret,
             NodeType::Paragraph,
             &para_path,
+            &text_path,
             &para_effective,
             ty,
         ) {
@@ -121,12 +113,19 @@ fn carry_virtual_leaves<'a>(
         let carry = state.carry_modifiers(b_dot);
         let block_type = b.node_type();
         let block_path = textblock_type_path(&b);
+        let mut text_path = block_path.clone();
+        text_path.push(NodeType::Text);
         let block_effective = b.effective();
         let mut eff = BTreeMap::new();
         for ty in ModifierType::iter().filter(|t| t.is_carry_kind()) {
-            if let Some(m) =
-                modifier_for_caret_map(&carry, block_type, &block_path, block_effective, ty)
-            {
+            if let Some(m) = modifier_for_caret_map(
+                &carry,
+                block_type,
+                &block_path,
+                &text_path,
+                block_effective,
+                ty,
+            ) {
                 eff.insert(ty, m);
             }
         }
@@ -381,9 +380,19 @@ pub fn resolve_modifier_state(
         let modifiers = if let Some(node) = view.node(sel.head.node)
             && Schema::node_spec(node.node_type()).is_textblock()
         {
+            let block_path = textblock_type_path(&node);
+            let mut text_path = block_path.clone();
+            text_path.push(NodeType::Text);
             let mut modifiers = BTreeMap::new();
             for ty in ModifierType::iter() {
-                if let Some(modifier) = modifier_for_caret_state(&caret, &node, ty) {
+                if let Some(modifier) = modifier_for_caret_map(
+                    &caret,
+                    node.node_type(),
+                    &block_path,
+                    &text_path,
+                    node.effective(),
+                    ty,
+                ) {
                     modifiers.insert(ty, modifier);
                 }
             }
@@ -880,17 +889,26 @@ mod tests {
     }
 
     #[test]
-    fn collapsed_fold_title_does_not_report_line_height_default() {
+    fn collapsed_fold_title_reports_text_formatting_as_unavailable() {
         let (state, title) = fold_title_state();
         let s = collapsed(title, 0);
         let ms = resolve_modifier_state(&state, &s, &[]).unwrap();
+
+        assert_eq!(ms.bold, Tri::Absent);
+        assert_eq!(ms.italic, Tri::Absent);
+        assert_eq!(ms.underline, Tri::Absent);
+        assert_eq!(ms.strikethrough, Tri::Absent);
+        assert_eq!(ms.font_size, Tri::Absent);
+        assert_eq!(ms.font_family, Tri::Absent);
+        assert_eq!(ms.font_weight, Tri::Absent);
+        assert_eq!(ms.text_color, Tri::Absent);
+        assert_eq!(ms.background_color, Tri::Absent);
+        assert_eq!(ms.letter_spacing, Tri::Absent);
+        assert_eq!(ms.link, Tri::Absent);
+        assert_eq!(ms.ruby, Tri::Absent);
         assert_eq!(ms.line_height, Tri::Absent);
-        assert_eq!(
-            ms.font_weight,
-            Tri::Uniform {
-                value: editor_model::FontWeightValue { value: 500 }
-            }
-        );
+        assert_eq!(ms.alignment, Tri::Absent);
+        assert_eq!(ms.effective_bold, Tri::Absent);
     }
 
     // §4.2: collapsed inherits — caret in para under root[font_size] → font_size Uniform

--- a/crates/editor-view/src/measure/container.rs
+++ b/crates/editor-view/src/measure/container.rs
@@ -8,7 +8,7 @@ use editor_model::{
 use editor_resource::Resource;
 
 use crate::measure::PageBreakPolicy;
-use crate::measure::text::measure::build_strut_only_line;
+use crate::measure::text::measure::{build_strut_only_line, expand_line_for_caret};
 use crate::measure::text::resolve::style_from_effective_modifiers;
 use crate::style::{BorderMode, BoxStyle, Direction};
 use editor_common::EdgeInsets;
@@ -65,12 +65,13 @@ fn make_gap_phantom_block(
     node: &NodeView,
     width: f32,
     index: usize,
+    ctx: &MeasureContext,
     resource: &mut Resource,
 ) -> (Arc<MeasuredNode>, f32) {
     let base_style =
         style_from_effective_modifiers(&node.effective().values().cloned().collect::<Vec<_>>());
     let indent = phantom_indent(node);
-    let line = build_strut_only_line(
+    let mut line = build_strut_only_line(
         node.id(),
         &base_style,
         width,
@@ -79,6 +80,11 @@ fn make_gap_phantom_block(
         index..index,
         resource,
     );
+    if let Some((position, expansion)) = ctx.pending_caret_for(&node.id())
+        && position.offset == index
+    {
+        line = expand_line_for_caret(&line, expansion);
+    }
     (
         Arc::new(MeasuredNode::from_line(width, line)),
         resolve_gap_after(node.effective()),
@@ -104,14 +110,16 @@ pub(crate) fn layout_vertical<'a>(
     let n_children = children.len();
     for (i, child) in children.into_iter().enumerate() {
         if gap_phantom_index == Some(i) {
-            blocks.push(make_gap_phantom_block(node, width, i, resource));
+            blocks.push(make_gap_phantom_block(node, width, i, ctx, resource));
         }
         let gap_after = resolve_gap_after(child_effective(node, i, &child));
         let m = measure_child(child, width, ctx, resource);
         blocks.push((m, gap_after));
     }
     if gap_phantom_index == Some(n_children) {
-        blocks.push(make_gap_phantom_block(node, width, n_children, resource));
+        blocks.push(make_gap_phantom_block(
+            node, width, n_children, ctx, resource,
+        ));
     }
 
     let mut result = Vec::with_capacity(blocks.len() * 2);

--- a/crates/editor-view/src/measure/context.rs
+++ b/crates/editor-view/src/measure/context.rs
@@ -1,4 +1,5 @@
-use crate::view_state::GapPhantom;
+use crate::measure::text::measure::LineStrutExpansion;
+use crate::view_state::{GapPhantom, PendingOverlay};
 use editor_crdt::Dot;
 use hashbrown::HashMap;
 
@@ -7,7 +8,8 @@ pub(crate) struct MeasureContext {
     pub fold_states: HashMap<Dot, bool>,
     pub external_heights: HashMap<Dot, f32>,
     pub gap_phantom: Option<GapPhantom>,
-    pub pending_overlay: Option<(Dot, editor_state::PendingModifiers)>,
+    pub pending_overlay: Option<PendingOverlay>,
+    pub pending_caret_expansion: Option<LineStrutExpansion>,
 }
 
 impl MeasureContext {
@@ -29,8 +31,19 @@ impl MeasureContext {
     pub fn pending_for(&self, node: &Dot) -> Option<&editor_state::PendingModifiers> {
         self.pending_overlay
             .as_ref()
-            .filter(|(id, _)| id == node)
-            .map(|(_, m)| m)
+            .filter(|overlay| &overlay.position.node == node)
+            .map(|overlay| &overlay.modifiers)
+    }
+
+    pub fn pending_caret_for(
+        &self,
+        node: &Dot,
+    ) -> Option<(&editor_state::Position, &LineStrutExpansion)> {
+        let overlay = self
+            .pending_overlay
+            .as_ref()
+            .filter(|overlay| &overlay.position.node == node)?;
+        Some((&overlay.position, self.pending_caret_expansion.as_ref()?))
     }
 }
 
@@ -42,10 +55,8 @@ pub(crate) fn measure_context(vs: &crate::view_state::ViewState) -> MeasureConte
             parent: gp.parent,
             index: gp.index,
         }),
-        pending_overlay: vs
-            .pending_overlay
-            .as_ref()
-            .map(|ps| (ps.node_id, ps.modifiers.clone())),
+        pending_overlay: vs.pending_overlay.clone(),
+        pending_caret_expansion: None,
     }
 }
 
@@ -109,7 +120,10 @@ mod tests {
             modifier: Modifier::Bold,
         }];
         let ctx = MeasureContext {
-            pending_overlay: Some((a, modifiers.clone())),
+            pending_overlay: Some(PendingOverlay {
+                position: editor_state::Position::new(a, 0),
+                modifiers: modifiers.clone(),
+            }),
             ..Default::default()
         };
         assert_eq!(ctx.pending_for(&a), Some(&modifiers));
@@ -131,7 +145,7 @@ mod tests {
             index: 1,
         });
         vs.pending_overlay = Some(PendingOverlay {
-            node_id: p1,
+            position: editor_state::Position::new(p1, 0),
             modifiers: modifiers.clone(),
         });
 
@@ -146,6 +160,12 @@ mod tests {
                 index: 1
             })
         );
-        assert_eq!(ctx.pending_overlay, Some((p1, modifiers)));
+        assert_eq!(
+            ctx.pending_overlay,
+            Some(PendingOverlay {
+                position: editor_state::Position::new(p1, 0),
+                modifiers,
+            })
+        );
     }
 }

--- a/crates/editor-view/src/measure/nodes/fold.rs
+++ b/crates/editor-view/src/measure/nodes/fold.rs
@@ -49,6 +49,7 @@ pub(crate) fn measure_fold_title(
         Alignment::Left,
         0.0,
         ctx.pending_for(&node.id()),
+        ctx.pending_caret_for(&node.id()),
         None,
         resource,
     );
@@ -186,6 +187,7 @@ mod tests {
     use crate::measure::context::MeasureContext;
     use crate::measure::text::measure::measure_paragraph;
     use crate::style::DecorationData;
+    use crate::view_state::PendingOverlay;
 
     use super::*;
     use crate::measure::types::MeasuredContent;
@@ -368,6 +370,7 @@ mod tests {
             inner_width,
             Alignment::Left,
             0.0,
+            None,
             None,
             None,
             &mut res,
@@ -636,7 +639,10 @@ mod tests {
             modifier: Modifier::FontSize { value: 9600 },
         }];
         let ctx_pending = MeasureContext {
-            pending_overlay: Some((title_id, big)),
+            pending_overlay: Some(PendingOverlay {
+                position: editor_state::Position::new(title_id, 0),
+                modifiers: big,
+            }),
             ..Default::default()
         };
         let h_pending =

--- a/crates/editor-view/src/measure/nodes/line_geometry.rs
+++ b/crates/editor-view/src/measure/nodes/line_geometry.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::measure::text::measure::MeasuredLine;
+use crate::measure::text::measure::{LineStrutExpansion, MeasuredLine};
 use crate::measure::types::{MeasuredBox, MeasuredContent, MeasuredNode};
 
 pub(crate) struct FirstLineInfo {
@@ -27,12 +27,6 @@ pub(crate) fn first_line_info(node: &MeasuredNode) -> Option<FirstLineInfo> {
         }
         _ => None,
     }
-}
-
-pub(crate) struct LineStrutExpansion {
-    pub ascent: f32,
-    pub descent: f32,
-    pub min_line_height: f32,
 }
 
 pub(crate) struct ExpandedFirstLine {
@@ -100,9 +94,8 @@ fn expand_line(
     expansion: &LineStrutExpansion,
 ) -> MeasuredNode {
     if line.is_phantom {
-        // The ONE deliberate H1 exception: the phantom wrapper is forced to
-        // zero height (matching old `line_geometry.rs:105`), so it bypasses
-        // `from_line` (which would copy `line.height` and pollute the SumTree).
+        // Phantom wrappers stay zero-height; `from_line` would copy the line's
+        // intrinsic height into the layout tree.
         return MeasuredNode {
             width,
             height: 0.0,
@@ -112,50 +105,10 @@ fn expand_line(
 
     let new_ascent = line.ascent.max(expansion.ascent);
     let new_descent = line.descent.max(expansion.descent);
-    let content_height = new_ascent + new_descent;
     let new_height = old_height.max(expansion.min_line_height);
-    let leading = new_height - content_height;
-    let new_baseline = leading / 2.0 + new_ascent;
-    let delta = new_baseline - line.baseline;
-
-    let mut glyph_runs = line.glyph_runs.clone();
-    if delta != 0.0 {
-        for run in &mut glyph_runs {
-            for g in &mut run.glyphs {
-                g.y += delta;
-            }
-        }
-    }
-    let mut ruby_annotations = line.ruby_annotations.clone();
-    if delta != 0.0 {
-        for ann in &mut ruby_annotations {
-            ann.baseline_y += delta;
-            for run in &mut ann.glyph_runs {
-                for g in &mut run.glyphs {
-                    g.y += delta;
-                }
-            }
-        }
-    }
-
     MeasuredNode::from_line(
         width,
-        MeasuredLine {
-            node: line.node,
-            height: new_height,
-            baseline: new_baseline,
-            ascent: new_ascent,
-            descent: new_descent,
-            cursor_ascent: line.cursor_ascent,
-            cursor_descent: line.cursor_descent,
-            glyph_runs,
-            ruby_annotations,
-            empty_caret_x: line.empty_caret_x,
-            offset_range: line.offset_range.clone(),
-            tab_gaps: line.tab_gaps.clone(),
-            is_phantom: line.is_phantom,
-            content_edge_x: line.content_edge_x,
-        },
+        line.with_vertical_metrics(new_ascent, new_descent, new_height),
     )
 }
 

--- a/crates/editor-view/src/measure/nodes/list_item.rs
+++ b/crates/editor-view/src/measure/nodes/list_item.rs
@@ -14,10 +14,11 @@ use crate::measure::text::strut::compute_strut;
 use crate::style::{Alignment, Decoration, DecorationData};
 
 use super::dispatch::measure_child;
-use super::line_geometry::{LineStrutExpansion, expand_first_line, first_line_info};
+use super::line_geometry::{expand_first_line, first_line_info};
 use crate::measure::Measurer;
 use crate::measure::container::layout_padded;
 use crate::measure::context::MeasureContext;
+use crate::measure::text::measure::LineStrutExpansion;
 use crate::measure::types::{MeasuredContent, MeasuredNode};
 
 const MARKER_RECT_MIN_RATIO: f32 = 1.25;

--- a/crates/editor-view/src/measure/nodes/paragraph.rs
+++ b/crates/editor-view/src/measure/nodes/paragraph.rs
@@ -63,6 +63,7 @@ pub(crate) fn measure_paragraph_block(
         align,
         indent,
         pending,
+        ctx.pending_caret_for(&node.id()),
         Some(&mut measurer.seg_cache),
         resource,
     );
@@ -114,6 +115,7 @@ mod tests {
     use editor_resource::Resource;
 
     use crate::measure::context::MeasureContext;
+    use crate::view_state::PendingOverlay;
 
     use super::*;
 
@@ -447,7 +449,10 @@ mod tests {
             modifier: Modifier::FontSize { value: 9600 },
         }];
         let ctx_pending = MeasureContext {
-            pending_overlay: Some((para_id, big)),
+            pending_overlay: Some(PendingOverlay {
+                position: editor_state::Position::new(para_id, 0),
+                modifiers: big,
+            }),
             ..Default::default()
         };
         let r_pending =
@@ -482,7 +487,10 @@ mod tests {
             modifier: Modifier::FontSize { value: 9600 },
         }];
         let ctx_pending = MeasureContext {
-            pending_overlay: Some((para_id, big)),
+            pending_overlay: Some(PendingOverlay {
+                position: editor_state::Position::new(para_id, 0),
+                modifiers: big,
+            }),
             ..Default::default()
         };
         let r_pending =

--- a/crates/editor-view/src/measure/text/measure.rs
+++ b/crates/editor-view/src/measure/text/measure.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use editor_crdt::Dot;
 use editor_model::{Alignment, ChildView, Modifier, NodeView};
 use editor_resource::Resource;
+use editor_state::{Affinity, Position};
 
 use crate::glyph_run::RubyAnnotation;
 
@@ -58,6 +59,92 @@ pub(crate) struct MeasuredLine {
     pub tab_gaps: Vec<TabGap>,
     pub is_phantom: bool,
     pub content_edge_x: Option<f32>,
+}
+
+impl MeasuredLine {
+    pub(crate) fn contains_position(&self, pos: &Position) -> bool {
+        if self.node != pos.node {
+            return false;
+        }
+        if let Some(range) = &self.offset_range
+            && pos.offset >= range.start
+            && pos.offset <= range.end
+        {
+            return true;
+        }
+        self.glyph_runs
+            .iter()
+            .any(|run| pos.offset >= run.offset_range.start && pos.offset <= run.offset_range.end)
+            || self
+                .tab_gaps
+                .iter()
+                .any(|gap| pos.offset >= gap.offset_index && pos.offset <= gap.offset_index + 1)
+    }
+
+    pub(crate) fn with_vertical_metrics(&self, ascent: f32, descent: f32, height: f32) -> Self {
+        let leading = height - (ascent + descent);
+        let baseline = leading / 2.0 + ascent;
+        let delta = baseline - self.baseline;
+
+        let mut line = self.clone();
+        line.height = height;
+        line.baseline = baseline;
+        line.ascent = ascent;
+        line.descent = descent;
+        if delta != 0.0 {
+            for run in &mut line.glyph_runs {
+                for glyph in &mut run.glyphs {
+                    glyph.y += delta;
+                }
+            }
+            for annotation in &mut line.ruby_annotations {
+                annotation.baseline_y += delta;
+                for run in &mut annotation.glyph_runs {
+                    for glyph in &mut run.glyphs {
+                        glyph.y += delta;
+                    }
+                }
+            }
+        }
+        line
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct LineStrutExpansion {
+    pub ascent: f32,
+    pub descent: f32,
+    pub min_line_height: f32,
+}
+
+pub(crate) fn expand_line_for_caret(
+    line: &MeasuredLine,
+    expansion: &LineStrutExpansion,
+) -> MeasuredLine {
+    let ascent = line.ascent.max(expansion.ascent);
+    let descent = line.descent.max(expansion.descent);
+    let height = line
+        .height
+        .max(expansion.min_line_height)
+        .max(ascent + descent);
+    line.with_vertical_metrics(ascent, descent, height)
+}
+
+fn expand_line_at_position(
+    lines: &mut [MeasuredLine],
+    position: &Position,
+    expansion: &LineStrutExpansion,
+) -> bool {
+    let matches = |line: &MeasuredLine| !line.is_phantom && line.contains_position(position);
+    let index = match position.affinity {
+        Affinity::Upstream => lines.iter().position(matches),
+        Affinity::Downstream => lines.iter().rposition(matches),
+    };
+    let Some(index) = index else {
+        return false;
+    };
+    lines[index] = expand_line_for_caret(&lines[index], expansion);
+    true
 }
 
 pub(crate) fn build_strut_only_line(
@@ -295,6 +382,7 @@ pub(crate) fn measure_paragraph(
     align: Alignment,
     indent: f32,
     pending: Option<&editor_state::PendingModifiers>,
+    pending_caret: Option<(&Position, &LineStrutExpansion)>,
     mut seg_cache: Option<&mut SegmentCache>,
     resource: &mut Resource,
 ) -> (Vec<MeasuredLine>, f32) {
@@ -391,6 +479,10 @@ pub(crate) fn measure_paragraph(
     }
     if let Some(cache) = seg_cache {
         cache.prune(node_id, segments.len());
+    }
+
+    if let Some((position, expansion)) = pending_caret {
+        expand_line_at_position(&mut lines, position, expansion);
     }
 
     let total_height: f32 = lines.iter().map(|l| l.height).sum();
@@ -495,7 +587,16 @@ mod tests {
         let view = DocView::new(&pd);
         let para = view.root().unwrap().child_blocks().next().unwrap();
         let mut res = Resource::new_test();
-        measure_paragraph(&para, width, Alignment::Left, 0.0, None, None, &mut res)
+        measure_paragraph(
+            &para,
+            width,
+            Alignment::Left,
+            0.0,
+            None,
+            None,
+            None,
+            &mut res,
+        )
     }
 
     fn glyph_runs(lines: &[MeasuredLine]) -> Vec<&GlyphRun> {
@@ -520,8 +621,17 @@ mod tests {
         let para = view.root().unwrap().child_blocks().next().unwrap();
         let mut res = Resource::new_test();
 
-        let uncached =
-            measure_paragraph(&para, 200.0, Alignment::Left, 0.0, None, None, &mut res).0;
+        let uncached = measure_paragraph(
+            &para,
+            200.0,
+            Alignment::Left,
+            0.0,
+            None,
+            None,
+            None,
+            &mut res,
+        )
+        .0;
 
         let mut cache = SegmentCache::default();
         // First pass populates the cache (all segments measured + stored relative).
@@ -530,6 +640,7 @@ mod tests {
             200.0,
             Alignment::Left,
             0.0,
+            None,
             None,
             Some(&mut cache),
             &mut res,
@@ -541,6 +652,7 @@ mod tests {
             200.0,
             Alignment::Left,
             0.0,
+            None,
             None,
             Some(&mut cache),
             &mut res,
@@ -591,6 +703,7 @@ mod tests {
             Alignment::Left,
             0.0,
             None,
+            None,
             Some(&mut cache),
             &mut res,
         );
@@ -605,6 +718,7 @@ mod tests {
             0.0,
             None,
             None,
+            None,
             &mut res,
         )
         .0;
@@ -613,6 +727,7 @@ mod tests {
             200.0,
             Alignment::Left,
             0.0,
+            None,
             None,
             Some(&mut cache),
             &mut res,
@@ -779,7 +894,16 @@ mod tests {
         let view = DocView::new(&pd);
         let para = view.root().unwrap().child_blocks().next().unwrap();
         let mut res = Resource::new_test();
-        measure_paragraph(&para, width, Alignment::Left, 0.0, pending, None, &mut res)
+        measure_paragraph(
+            &para,
+            width,
+            Alignment::Left,
+            0.0,
+            pending,
+            None,
+            None,
+            &mut res,
+        )
     }
 
     fn font_size_span(spans: SpanLog, op_seq: u64, target: Dot, value: u32) -> SpanLog {
@@ -1043,6 +1167,115 @@ mod tests {
         assert!(
             (h1 - h0).abs() < 0.01,
             "pending must not apply to a paragraph with Char leaves (h0={h0}, h1={h1})"
+        );
+    }
+
+    fn geometry_line(
+        n: u64,
+        height: f32,
+        ascent: f32,
+        descent: f32,
+        offset_range: Range<usize>,
+        is_phantom: bool,
+    ) -> MeasuredLine {
+        MeasuredLine {
+            node: Dot::new(1, n),
+            height,
+            baseline: ascent,
+            ascent,
+            descent,
+            cursor_ascent: ascent,
+            cursor_descent: descent,
+            glyph_runs: vec![],
+            ruby_annotations: vec![],
+            empty_caret_x: 0.0,
+            offset_range: Some(offset_range),
+            tab_gaps: vec![],
+            is_phantom,
+            content_edge_x: None,
+        }
+    }
+
+    #[test]
+    fn caret_expansion_skips_matching_trailing_phantom() {
+        let real = geometry_line(8, 10.0, 8.0, 2.0, 0..2, false);
+        let phantom = geometry_line(8, 0.0, 0.0, 0.0, 2..2, true);
+        let mut lines = vec![real, phantom];
+        let expansion = LineStrutExpansion {
+            ascent: 20.0,
+            descent: 5.0,
+            min_line_height: 25.0,
+        };
+
+        assert!(expand_line_at_position(
+            &mut lines,
+            &Position::new(Dot::new(1, 8), 2),
+            &expansion,
+        ));
+        assert_eq!(lines[0].height, 25.0, "the real line must expand");
+        assert_eq!(lines[1].height, 0.0, "the phantom must stay zero-height");
+    }
+
+    #[test]
+    fn caret_expansion_respects_soft_wrap_affinity() {
+        fn lines() -> Vec<MeasuredLine> {
+            vec![
+                geometry_line(9, 10.0, 8.0, 2.0, 0..1, false),
+                geometry_line(9, 10.0, 8.0, 2.0, 1..2, false),
+            ]
+        }
+
+        let expansion = LineStrutExpansion {
+            ascent: 20.0,
+            descent: 5.0,
+            min_line_height: 25.0,
+        };
+        let mut upstream = lines();
+        assert!(expand_line_at_position(
+            &mut upstream,
+            &Position {
+                node: Dot::new(1, 9),
+                offset: 1,
+                affinity: Affinity::Upstream,
+            },
+            &expansion,
+        ));
+        assert_eq!((upstream[0].height, upstream[1].height), (25.0, 10.0));
+
+        let mut downstream = lines();
+        assert!(expand_line_at_position(
+            &mut downstream,
+            &Position {
+                node: Dot::new(1, 9),
+                offset: 1,
+                affinity: Affinity::Downstream,
+            },
+            &expansion,
+        ));
+        assert_eq!((downstream[0].height, downstream[1].height), (10.0, 25.0));
+    }
+
+    #[test]
+    fn caret_expansion_contains_opposing_ascent_and_descent() {
+        let line = geometry_line(10, 20.0, 18.0, 2.0, 0..1, false);
+        let mut lines = vec![line];
+        let expansion = LineStrutExpansion {
+            ascent: 2.0,
+            descent: 18.0,
+            min_line_height: 20.0,
+        };
+
+        assert!(expand_line_at_position(
+            &mut lines,
+            &Position::new(Dot::new(1, 10), 0),
+            &expansion,
+        ));
+        assert!(
+            lines[0].height >= lines[0].ascent + lines[0].descent,
+            "caret expansion must contain the merged ascent and descent: height={}, ascent={}, descent={}",
+            lines[0].height,
+            lines[0].ascent,
+            lines[0].descent,
         );
     }
 }

--- a/crates/editor-view/src/query/layout_index.rs
+++ b/crates/editor-view/src/query/layout_index.rs
@@ -661,22 +661,7 @@ fn position_matches_node(node: &LayoutNode, pos: &Position) -> bool {
 }
 
 fn position_matches_line(line: &LayoutLine, pos: &Position) -> bool {
-    if line.node != pos.node {
-        return false;
-    }
-    if let Some(range) = &line.offset_range
-        && pos.offset >= range.start
-        && pos.offset <= range.end
-    {
-        return true;
-    }
-    line.glyph_runs
-        .iter()
-        .any(|run| pos.offset >= run.offset_range.start && pos.offset <= run.offset_range.end)
-        || line
-            .tab_gaps
-            .iter()
-            .any(|gap| pos.offset >= gap.offset_index && pos.offset <= gap.offset_index + 1)
+    line.contains_position(pos)
 }
 
 fn position_attaches_to_child(pos: &Position, parent: &Dot, index: usize) -> bool {

--- a/crates/editor-view/src/query/placeholder.rs
+++ b/crates/editor-view/src/query/placeholder.rs
@@ -35,8 +35,8 @@ pub(crate) fn placeholder_metrics(
     let nv = view.root()?.child_blocks().next()?;
     let elem_id = nv.id();
     let pending_modifiers = pending_overlay
-        .filter(|style| style.node_id == elem_id)
-        .map(|style| &style.modifiers);
+        .filter(|overlay| overlay.position.node == elem_id)
+        .map(|overlay| &overlay.modifiers);
     let modifiers = resolve_caret_modifiers(
         &state.projected,
         &Position::new(elem_id, 0),

--- a/crates/editor-view/src/view.rs
+++ b/crates/editor-view/src/view.rs
@@ -4,11 +4,17 @@ use editor_common::{EdgeInsets, Movement};
 use editor_crdt::Dot;
 use editor_model::{LayoutMode, Node, NodeView};
 use editor_resource::Resource;
-use editor_state::{LayoutDirty, Position, ResolvedSelection, Selection, StablePosition, State};
+use editor_state::{
+    LayoutDirty, Position, ResolvedSelection, Selection, StablePosition, State,
+    resolve_caret_modifiers,
+};
 
 use crate::measure::Measurer;
-use crate::measure::context::measure_context;
+use crate::measure::context::{MeasureContext, measure_context};
 use crate::measure::nodes::dispatch::content_remeasurement_target;
+use crate::measure::text::measure::LineStrutExpansion;
+use crate::measure::text::resolve::style_from_effective_modifiers;
+use crate::measure::text::strut::compute_strut;
 use crate::measure::types::MeasuredTree;
 use crate::page::LayoutPage;
 use crate::page_fragment::{PageFragmentTree, build_page_fragment_tree};
@@ -23,6 +29,29 @@ use crate::viewport::Viewport;
 
 const CONTINUOUS_MARGIN_X: f32 = 20.0;
 const CONTINUOUS_CONTENT_CAP: f32 = 1024.0;
+
+fn measure_context_with_pending_caret(
+    view_state: &ViewState,
+    state: &State,
+    resource: &mut Resource,
+) -> MeasureContext {
+    let mut context = measure_context(view_state);
+    context.pending_caret_expansion = view_state.pending_overlay.as_ref().and_then(|pending| {
+        let modifiers =
+            resolve_caret_modifiers(&state.projected, &pending.position, &pending.modifiers)
+                .into_values()
+                .collect::<Vec<_>>();
+        let style = style_from_effective_modifiers(&modifiers);
+        let strut = compute_strut(resource, &style)?;
+        Some(LineStrutExpansion {
+            ascent: strut.ascent,
+            descent: strut.descent,
+            min_line_height: (style.font_size * style.line_height)
+                .max(strut.ascent + strut.descent),
+        })
+    });
+    context
+}
 
 pub struct View {
     resource: Arc<Mutex<Resource>>,
@@ -81,8 +110,11 @@ impl View {
         let mut dirty = dirty;
         if pending_changed {
             for id in [
-                self.view_state.pending_overlay.as_ref().map(|p| p.node_id),
-                new_pending_overlay.as_ref().map(|p| p.node_id),
+                self.view_state
+                    .pending_overlay
+                    .as_ref()
+                    .map(|p| p.position.node),
+                new_pending_overlay.as_ref().map(|p| p.position.node),
             ]
             .into_iter()
             .flatten()
@@ -188,7 +220,10 @@ impl View {
         }
         let continuous = matches!(Self::doc_layout_mode(state), LayoutMode::Continuous { .. });
         let view = state.view();
-        let ctx = measure_context(&self.view_state);
+        let ctx = {
+            let mut resource = self.resource.lock().unwrap();
+            measure_context_with_pending_caret(&self.view_state, state, &mut resource)
+        };
 
         struct SpliceSeed {
             dot: Dot,
@@ -495,9 +530,9 @@ impl View {
             self.layout = None;
             return;
         };
-        let ctx = measure_context(&self.view_state);
         let measured = {
             let mut resource = self.resource.lock().unwrap();
+            let ctx = measure_context_with_pending_caret(&self.view_state, state, &mut resource);
             let root_arc = self
                 .measurer
                 .measure(&root, content_width, &ctx, &mut resource);
@@ -729,9 +764,22 @@ impl View {
         crate::query::navigation::position_at_preferred_x_in(&result.layout_index, &node, at_end, x)
     }
 
-    pub fn cursor_metrics(&self, _state: &State, pos: &Position) -> Option<CursorMetrics> {
+    pub fn cursor_metrics(&self, state: &State, pos: &Position) -> Option<CursorMetrics> {
         let result = self.layout.as_ref()?;
-        crate::query::cursor::cursor_metrics(&result.layout_index, pos, None)
+        let pending = state
+            .selection
+            .as_ref()
+            .filter(|selection| selection.is_collapsed() && selection.head == *pos)
+            .map_or(&[][..], |_| state.pending_modifiers.as_slice());
+        let modifiers = resolve_caret_modifiers(&state.projected, pos, pending)
+            .into_values()
+            .collect::<Vec<_>>();
+        let style = style_from_effective_modifiers(&modifiers);
+        let metrics_override = {
+            let mut resource = self.resource.lock().unwrap();
+            compute_strut(&mut resource, &style).map(|strut| (strut.ascent, strut.descent))
+        };
+        crate::query::cursor::cursor_metrics(&result.layout_index, pos, metrics_override)
     }
 
     pub fn placeholder_metrics(
@@ -1074,17 +1122,19 @@ impl View {
 mod invalidation_tests {
     use std::sync::{Arc, Mutex};
 
-    use editor_crdt::{Dot, ListOp};
+    use editor_crdt::{Dot, ListOp, OpGraph};
     use editor_model::{
         CalloutNodeAttr, CalloutVariant, EditOp, Modifier, ModifierAttrOp, NodeAttr, NodeAttrOp,
         NodeType, SeqItem, TableNodeAttr,
     };
     use editor_resource::Resource;
-    use editor_state::{LayoutDirty, Position, ProjectedState, Selection, State};
+    use editor_state::{LayoutDirty, PendingModifier, Position, ProjectedState, Selection, State};
 
     use super::View;
     use crate::measure::context::measure_context;
     use crate::measure::types::MeasuredNode;
+    use crate::paginate::types::LayoutContent;
+    use crate::view_state::PendingOverlay;
     use crate::viewport::Viewport;
 
     fn seq_block(pos: usize, node_type: NodeType, parents: Vec<Dot>) -> EditOp {
@@ -1120,6 +1170,19 @@ mod invalidation_tests {
         let mut resource = view.resource.lock().unwrap();
         view.measurer
             .measure(&nv, content_width, &ctx, &mut resource)
+    }
+
+    fn layout_with_pending_font_size(view: &mut View, state: &State, position: Position) {
+        view.layout(state);
+        assert!(view.reconcile(
+            state,
+            LayoutDirty::empty(),
+            Some(PendingOverlay {
+                position,
+                modifiers: state.pending_modifiers.clone(),
+            }),
+            None,
+        ));
     }
 
     #[test]
@@ -1452,6 +1515,167 @@ mod invalidation_tests {
                 "empty paragraph cache must be evicted and re-measured after root font-size change"
             );
         }
+    }
+
+    #[test]
+    fn pending_caret_expands_real_line_before_trailing_phantom() {
+        let mut graph = OpGraph::<EditOp>::with_actor(1);
+        let paragraph = graph
+            .add_mut(seq_block(0, NodeType::Paragraph, vec![Dot::ROOT]))
+            .unwrap()
+            .id;
+        graph.add_mut(seq_char(1, 'a')).unwrap();
+        graph.add_mut(seq_char(2, ' ')).unwrap();
+        graph.commit_mut();
+
+        let position = Position::new(paragraph, 2);
+        let mut state = State::new(
+            ProjectedState::from_graph(graph).unwrap(),
+            Some(Selection::collapsed(position)),
+        );
+        state.pending_modifiers = vec![PendingModifier::Set {
+            modifier: Modifier::FontSize { value: 9600 },
+        }];
+
+        let mut view = make_view(41.0);
+        layout_with_pending_font_size(&mut view, &state, position);
+
+        let cursor = view
+            .cursor_metrics(&state, &position)
+            .expect("paragraph-end cursor metrics");
+        assert!(
+            cursor.line.height >= cursor.caret.height
+                && cursor.caret.y >= cursor.line.y
+                && cursor.caret.bottom() <= cursor.line.bottom(),
+            "the real cursor line must contain the pending caret even when a trailing phantom exists: line={:?}, caret={:?}",
+            cursor.line,
+            cursor.caret,
+        );
+    }
+
+    #[test]
+    fn pending_caret_expands_list_marker_geometry_with_first_line() {
+        let mut graph = OpGraph::<EditOp>::with_actor(1);
+        let root = Dot::ROOT;
+        let list = graph
+            .add_mut(seq_block(0, NodeType::BulletList, vec![root]))
+            .unwrap()
+            .id;
+        let item = graph
+            .add_mut(seq_block(1, NodeType::ListItem, vec![root, list]))
+            .unwrap()
+            .id;
+        let paragraph = graph
+            .add_mut(seq_block(2, NodeType::Paragraph, vec![root, list, item]))
+            .unwrap()
+            .id;
+        graph.add_mut(seq_char(3, 'a')).unwrap();
+        graph
+            .add_mut(seq_block(4, NodeType::Paragraph, vec![root]))
+            .unwrap();
+        graph.commit_mut();
+
+        let position = Position::new(paragraph, 1);
+        let mut state = State::new(
+            ProjectedState::from_graph(graph).unwrap(),
+            Some(Selection::collapsed(position)),
+        );
+        state.pending_modifiers = vec![PendingModifier::Set {
+            modifier: Modifier::FontSize { value: 9600 },
+        }];
+
+        let mut view = make_view(800.0);
+        layout_with_pending_font_size(&mut view, &state, position);
+
+        let cursor = view
+            .cursor_metrics(&state, &position)
+            .expect("list-item cursor metrics");
+        let layout = view.layout.as_ref().expect("layout");
+        let item_entry = layout
+            .layout_index
+            .box_entry(&item)
+            .expect("list-item layout entry");
+        let LayoutContent::Box(item_box) = item_entry
+            .content(&layout.layout_index)
+            .expect("list-item layout node")
+        else {
+            panic!("list item must be a box");
+        };
+        let marker = item_box
+            .style
+            .decorations
+            .first()
+            .expect("list marker decoration");
+
+        assert!(
+            (marker.rect.height - cursor.line.height).abs() < 0.01,
+            "list marker geometry must use the final expanded first-line height: marker={}, line={}",
+            marker.rect.height,
+            cursor.line.height,
+        );
+    }
+
+    #[test]
+    fn pending_caret_expands_fold_icon_geometry_with_title_line() {
+        let mut graph = OpGraph::<EditOp>::with_actor(1);
+        let root = Dot::ROOT;
+        let fold = graph
+            .add_mut(seq_block(0, NodeType::Fold, vec![root]))
+            .unwrap()
+            .id;
+        let title = graph
+            .add_mut(seq_block(1, NodeType::FoldTitle, vec![root, fold]))
+            .unwrap()
+            .id;
+        graph.add_mut(seq_char(2, 'a')).unwrap();
+        graph
+            .add_mut(seq_block(3, NodeType::Paragraph, vec![root]))
+            .unwrap();
+        graph.commit_mut();
+
+        let position = Position::new(title, 1);
+        let mut state = State::new(
+            ProjectedState::from_graph(graph).unwrap(),
+            Some(Selection::collapsed(position)),
+        );
+        state.pending_modifiers = vec![PendingModifier::Set {
+            modifier: Modifier::FontSize { value: 9600 },
+        }];
+
+        let mut view = make_view(800.0);
+        layout_with_pending_font_size(&mut view, &state, position);
+
+        let cursor = view
+            .cursor_metrics(&state, &position)
+            .expect("fold-title cursor metrics");
+        let layout = view.layout.as_ref().expect("layout");
+        let title_entry = layout
+            .layout_index
+            .box_entry(&title)
+            .expect("fold-title layout entry");
+        let title_rect = layout
+            .layout_index
+            .page_rect(title_entry.rect)
+            .expect("fold title page rect")
+            .rect;
+        let LayoutContent::Box(title_box) = title_entry
+            .content(&layout.layout_index)
+            .expect("fold-title layout node")
+        else {
+            panic!("fold title must be a box");
+        };
+        let icon = title_box
+            .style
+            .decorations
+            .first()
+            .expect("fold icon decoration");
+        let icon_center = title_rect.y + icon.rect.y + icon.rect.height / 2.0;
+        let line_center = cursor.line.y + cursor.line.height / 2.0;
+
+        assert!(
+            (icon_center - line_center).abs() < 0.01,
+            "fold icon must be centered on the final expanded title line: icon_center={icon_center}, line_center={line_center}",
+        );
     }
 }
 

--- a/crates/editor-view/src/view_state.rs
+++ b/crates/editor-view/src/view_state.rs
@@ -1,11 +1,11 @@
 use editor_common::DecorationStyle;
 use editor_crdt::Dot;
-use editor_state::PendingModifiers;
+use editor_state::{PendingModifiers, Position};
 use hashbrown::HashMap;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct PendingOverlay {
-    pub node_id: Dot,
+    pub position: Position,
     pub modifiers: PendingModifiers,
 }
 
@@ -71,13 +71,13 @@ mod tests {
     fn pending_overlay_equality() {
         let n = Dot::new(1, 1);
         let a = PendingOverlay {
-            node_id: n,
+            position: Position::new(n, 0),
             modifiers: vec![PendingModifier::Set {
                 modifier: Modifier::Bold,
             }],
         };
         let b = PendingOverlay {
-            node_id: n,
+            position: Position::new(n, 0),
             modifiers: vec![PendingModifier::Set {
                 modifier: Modifier::Bold,
             }],

--- a/packages/ui/src/components/SearchableDropdown.svelte
+++ b/packages/ui/src/components/SearchableDropdown.svelte
@@ -94,6 +94,7 @@
   });
 
   const open = () => {
+    if (disabled) return;
     if (anchorElement) {
       anchorWidth = anchorElement.getBoundingClientRect().width;
     }
@@ -103,6 +104,10 @@
   const close = () => {
     opened = false;
   };
+
+  $effect(() => {
+    if (disabled) close();
+  });
 
   const handleFocus = () => {
     isFocused = true;
@@ -200,6 +205,7 @@
       alignItems: 'center',
       borderRadius: '4px',
       height: '24px',
+      opacity: disabled ? '50' : '100',
       _hover: {
         backgroundColor: 'surface.muted',
       },
@@ -245,6 +251,7 @@
       pointerEvents: opened ? 'auto' : 'none',
       cursor: 'pointer',
     })}
+    {disabled}
     onclick={() => {
       inputElement?.blur();
       close();


### PR DESCRIPTION
- #5240 이후로 폴드에서 pending modifier를 바꾸면 caret과 line height가 커지고 fold title이 크게 렌더링되는 문제가 생겼습니다.
- 폴드 제목에서는 글자 크기, 굵기, 색상 등의 텍스트 서식을 사용할 수 없도록 했습니다.
- 앱에서는 텍스트 툴바 페이지를 숨기고, 웹에서는 관련 컨트롤을 비활성화했습니다.
- 툴바뿐 아니라 단축키나 직접 입력을 통해서도 폴드 제목에 서식이 적용되지 않습니다.
- 비활성화된 컨트롤의 `(준비중)` 문구를 제거했습니다.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>