### PR TITLE
route pop 취소 시 제거된 route 정리를 보장함

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationStack.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/navigation/NavigationStack.kt
@@ -359,6 +359,12 @@ fun NavigationStack(
     }
   }
 
+  fun releaseRemovedRouteResources(removedRoutes: List<Route>) {
+    removedRoutes.forEach(routeScenes::remove)
+    navigator.clearViewModelStoresFor(removedRoutes)
+    clearRemovedRoutes(removedRoutes)
+  }
+
   suspend fun updateScenesAndAwaitApply(update: () -> Unit) {
     val confirmation = CompletableDeferred<Unit>()
     sceneApplyConfirmation = confirmation
@@ -379,22 +385,22 @@ fun NavigationStack(
     // content in the same pager subcomposition can corrupt Compose Runtime's change list. First
     // move both scenes to their settled slots, then release the outgoing scene in a separately
     // applied composition.
-    // TODO: Re-test without this handoff after upgrading to a Compose Runtime that includes
-    // https://github.com/androidx/androidx/commit/215b08ffba30e9369e91460e1d726d646558e556.
-    // Remove it only after the focused pager regression test and the iOS keyboard repro both pass.
-    val presentedRemovedRoutes = removedRoutes.filter { it == visibleRoute || it.keepAlive }
-    updateScenesAndAwaitApply {
-      retainedRemovedRoutes = presentedRemovedRoutes
-      visibleRoute = navigator.current
-      behindRoute = null
-      animState = AnimState.Idle
+    // TODO: Re-test without this handoff after the next Compose Runtime upgrade. Remove it only
+    // after the focused pager regression test and the iOS keyboard repro both pass.
+    try {
+      val presentedRemovedRoutes = removedRoutes.filter { it == visibleRoute || it.keepAlive }
+      updateScenesAndAwaitApply {
+        retainedRemovedRoutes = presentedRemovedRoutes
+        visibleRoute = navigator.current
+        behindRoute = null
+        animState = AnimState.Idle
+      }
+      updateScenesAndAwaitApply { retainedRemovedRoutes = emptyList() }
+    } finally {
+      sceneApplyConfirmation = null
+      retainedRemovedRoutes = emptyList()
+      releaseRemovedRouteResources(removedRoutes)
     }
-    updateScenesAndAwaitApply { retainedRemovedRoutes = emptyList() }
-    sceneApplyConfirmation = null
-
-    removedRoutes.forEach(routeScenes::remove)
-    navigator.clearViewModelStoresFor(removedRoutes)
-    clearRemovedRoutes(removedRoutes)
   }
 
   suspend fun settleAtCurrentRoute(restoreKeyboard: Boolean = true) {
@@ -676,16 +682,32 @@ fun NavigationStack(
             navigator.consumePopRequest()
             navigator.completeTransition(result = result)
           } catch (e: Throwable) {
-            withContext(NonCancellable) {
-              if (navigator.peekRemovalPolicy() == RouteRemovalPolicy.BypassInterceptors) {
-                // Server deletion already succeeded. Do not strand the deleted document because
-                // presentation failed; finish the exact prepared removal without another prompt.
-                val removedRoutes = navigator.performPopTo(targetRoute)
-                softwareKeyboardInteraction.hideAndAwaitResolution()
-                settleAfterRemoval(removedRoutes)
+            if (navigator.peekRemovalPolicy() == RouteRemovalPolicy.BypassInterceptors) {
+              // Server deletion already succeeded. Do not strand the deleted document because
+              // presentation failed; finish the exact prepared removal without another prompt.
+              val removedRoutes = navigator.performPopTo(targetRoute)
+              var cancellation = e as? CancellationException
+              try {
+                // A cancelled effect is leaving composition, so no future SideEffect can confirm
+                // a scene handoff. The synchronous finally block below is sufficient in that case.
+                if (cancellation == null) {
+                  softwareKeyboardInteraction.hideAndAwaitResolution()
+                  settleAfterRemoval(removedRoutes)
+                }
+              } catch (rescueFailure: Throwable) {
+                if (rescueFailure is CancellationException) {
+                  cancellation = rescueFailure
+                } else if (rescueFailure !== e) {
+                  e.addSuppressed(rescueFailure)
+                }
+              } finally {
+                releaseRemovedRouteResources(removedRoutes)
                 navigator.consumePopRequest()
                 navigator.completeTransition()
-              } else {
+              }
+              cancellation?.let { throw it }
+            } else {
+              withContext(NonCancellable) {
                 val rollbackFailure =
                   try {
                     navigator.routeRemovals.rollbackActiveSegment()
@@ -708,8 +730,8 @@ fun NavigationStack(
                 navigator.consumePopRequest()
                 navigator.completeTransition(e)
               }
+              if (e is CancellationException) throw e
             }
-            if (e is CancellationException) throw e
           }
         }
       }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/shell/MainTabPagerDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/shell/MainTabPagerDesktopTest.kt
@@ -37,8 +37,12 @@ import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
+import co.typie.navigation.NavigationResult
 import co.typie.navigation.NavigationStackTestHost
 import co.typie.navigation.Navigator
+import co.typie.navigation.RouteRemovalDecision
+import co.typie.navigation.RouteRemovalInterceptor
+import co.typie.navigation.RouteRemovalPreparation
 import co.typie.platform.LocalSoftwareKeyboardPresentationController
 import co.typie.platform.SoftwareKeyboardPresentationController
 import co.typie.platform.SoftwareKeyboardPresentationDriver
@@ -48,6 +52,7 @@ import co.typie.ui.component.topbar.TopBarState
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotSame
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.CompletableDeferred
@@ -130,6 +135,133 @@ class MainTabPagerDesktopTest {
     }
     waitUntil(timeoutMillis = 5_000L) { mainTabState.motion == null }
     assertEquals(Tab.Space, mainTabState.settledTab)
+  }
+
+  @Test
+  fun `disposing navigation stack during scene handoff clears removed route store`() =
+    runComposeUiTest {
+      val navigator = Navigator(listOf(Route.Home, Route.SpaceSettings))
+      val removedRouteStore = navigator.viewModelStoreFor(Route.SpaceSettings)
+      lateinit var pop: () -> Unit
+      var showNavigationStack by mutableStateOf(true)
+      var outgoingAttached = false
+
+      setContent {
+        val scope = rememberCoroutineScope()
+        pop = { scope.launch { runCatching { navigator.pop() } } }
+        MainTabPager(
+          state = rememberMainTabState(),
+          gestureAdmissionAllowed = !navigator.canPop && !navigator.isTransitioning,
+          modifier = Modifier.size(width = 320.dp, height = 640.dp),
+        ) { tab ->
+          if (tab == Tab.Home && showNavigationStack) {
+            NavigationStackTestHost(
+              navigator = navigator,
+              topBarState = remember { TopBarState() },
+              modifier = Modifier.fillMaxSize(),
+            ) { route ->
+              if (route == Route.SpaceSettings) {
+                DisposableEffect(route) {
+                  outgoingAttached = true
+                  onDispose { outgoingAttached = false }
+                }
+              } else {
+                SideEffect {
+                  if (navigator.current == Route.Home && outgoingAttached) {
+                    showNavigationStack = false
+                  }
+                }
+              }
+              Box(Modifier.fillMaxSize())
+            }
+          } else {
+            Box(Modifier.fillMaxSize())
+          }
+        }
+      }
+      waitUntil { outgoingAttached }
+
+      runOnIdle { pop() }
+      waitUntil(timeoutMillis = 5_000L) { !showNavigationStack }
+      waitUntil(timeoutMillis = 5_000L) { !navigator.isTransitioning }
+
+      assertEquals(Route.Home, navigator.current)
+      assertNotSame(removedRouteStore, navigator.viewModelStoreFor(Route.SpaceSettings))
+    }
+
+  @Test
+  fun `disposing navigation stack during bypass removal completes transition`() = runComposeUiTest {
+    val editorRoute = Route.Editor("editor")
+    val documentRoute = Route.Document("document")
+    val navigator = Navigator(listOf(Route.Home, editorRoute, documentRoute))
+    lateinit var removeDocument: () -> Unit
+    var showNavigationStack by mutableStateOf(true)
+    var removalResult: Result<NavigationResult>? = null
+
+    navigator.routeRemovals.register(
+      editorRoute,
+      object : RouteRemovalInterceptor {
+        override suspend fun prepare(onDelayed: (suspend () -> Unit)?): RouteRemovalPreparation =
+          RouteRemovalPreparation.Ready
+
+        override suspend fun resolveDecision(): RouteRemovalDecision =
+          error("Ready removal must not require a decision")
+
+        override suspend fun rollback() = Unit
+      },
+    )
+
+    setContent {
+      val scope = rememberCoroutineScope()
+      removeDocument = {
+        scope.launch {
+          val prepared = checkNotNull(navigator.prepareAdjacentRemoval(documentRoute, editorRoute))
+          removalResult = runCatching { navigator.commitAdjacentRemoval(prepared) }
+        }
+      }
+      MainTabPager(
+        state = rememberMainTabState(),
+        gestureAdmissionAllowed = !navigator.canPop && !navigator.isTransitioning,
+        modifier = Modifier.size(width = 320.dp, height = 640.dp),
+      ) { tab ->
+        if (tab == Tab.Home && showNavigationStack) {
+          NavigationStackTestHost(
+            navigator = navigator,
+            topBarState = remember { TopBarState() },
+            modifier = Modifier.fillMaxSize(),
+          ) { route ->
+            Box(
+              Modifier.fillMaxSize()
+                .testTag(
+                  if (route == documentRoute) BypassOutgoingRouteTag else "bypass-background"
+                )
+            )
+          }
+        } else {
+          Box(Modifier.fillMaxSize())
+        }
+      }
+    }
+    val outgoingRoute = onNodeWithTag(BypassOutgoingRouteTag)
+    outgoingRoute.fetchSemanticsNode()
+
+    try {
+      mainClock.autoAdvance = false
+      runOnIdle { removeDocument() }
+      waitUntil(timeoutMillis = 5_000L) { navigator.popRequested }
+      mainClock.advanceTimeByFrame()
+      mainClock.advanceTimeBy(200L)
+      assertTrue(outgoingRoute.fetchSemanticsNode().boundsInRoot.top > 0f)
+      runOnIdle { showNavigationStack = false }
+      mainClock.advanceTimeByFrame()
+    } finally {
+      mainClock.autoAdvance = true
+    }
+    waitUntil(timeoutMillis = 5_000L) { !navigator.isTransitioning }
+    waitUntil(timeoutMillis = 5_000L) { removalResult != null }
+
+    assertEquals(Route.Home, navigator.current)
+    assertEquals(NavigationResult.ReachedTarget, removalResult?.getOrThrow())
   }
 
   @Test
@@ -646,6 +778,7 @@ class MainTabPagerDesktopTest {
   }
 
   private companion object {
+    const val BypassOutgoingRouteTag = "bypass-outgoing-route"
     const val ChromeTag = "main-tab-fixed-chrome"
     const val ChildPagerTag = "main-tab-child-pager"
     const val PagerTag = "main-tab-pager"


### PR DESCRIPTION
PR #5226 리뷰에서 지적된 cancellation 경로를 보완합니다.

- scene handoff가 취소돼도 removed route의 scene과 ViewModelStore 정리
- bypass removal 중 NavigationStack이 해제되면 composition 적용을 기다리지 않고 transition 완료
- 두 경로에 대한 회귀 테스트 추가

compose 패치를 시도했지만 결국 해결하지 못하고 기존 workaround에 덧붙였습니다..

관련 리뷰:
- https://github.com/penxle/typie/pull/5226#discussion_r3741669680
- https://github.com/penxle/typie/pull/5226#discussion_r3741669677

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>