### PR TITLE
문서 변경 중에도 smooth scroll이 이어지게 함

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorBringIntoViewRequests.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorBringIntoViewRequests.kt
@@ -24,6 +24,9 @@ internal class EditorBringIntoViewRequests(private val requestPresentation: () -
 
   private val pending = AtomicReference<Request?>(null)
 
+  val pendingRequest: Request?
+    get() = pending.load()
+
   fun requestForState(
     state: EditorState,
     policy: EditorBringIntoViewPolicy,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorScrollIntent.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorScrollIntent.kt
@@ -58,6 +58,8 @@ internal fun EditorAutoScrollPolicy.resolveForState(
 internal sealed interface EditorBringIntoViewTarget {
   data object CurrentSelectionHead : EditorBringIntoViewTarget
 
+  data class TrackedItem(val id: String) : EditorBringIntoViewTarget
+
   data class PageRects(val rects: List<PageRect>) : EditorBringIntoViewTarget
 }
 
@@ -353,6 +355,8 @@ private fun resolveBringIntoViewTargetPageRects(
   when (target) {
     EditorBringIntoViewTarget.CurrentSelectionHead ->
       resolveCurrentSelectionHeadPageRect(state)?.let(::listOf)
+    is EditorBringIntoViewTarget.TrackedItem ->
+      state.trackedRanges.firstOrNull { it.id == target.id }?.rects?.takeIf { it.isNotEmpty() }
     is EditorBringIntoViewTarget.PageRects -> target.rects.takeIf { it.isNotEmpty() }
   }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/viewport/EditorSmoothScrollMotion.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/viewport/EditorSmoothScrollMotion.kt
@@ -1,0 +1,112 @@
+package co.typie.editor.viewport
+
+import kotlin.math.abs
+import kotlin.math.exp
+import kotlin.math.max
+import kotlin.math.sign
+import kotlin.math.sqrt
+
+internal class EditorSmoothScrollMotion
+private constructor(
+  private var position: Double,
+  private var target: Double,
+  viewportHeight: Double,
+) {
+  data class Snapshot(val position: Double, val velocity: Double, val target: Double)
+
+  private var velocity = 0.0
+  private var omega = responseRate(position, target, viewportHeight)
+  var finished = false
+    private set
+
+  init {
+    finishIfArrived()
+  }
+
+  fun advance(deltaSeconds: Double): Snapshot {
+    if (finished || !deltaSeconds.isFinite() || deltaSeconds <= 0.0) {
+      return snapshot()
+    }
+    val previousRemaining = target - position
+    val error = position - target
+    val b = velocity + omega * error
+    val decay = exp(-omega * deltaSeconds)
+    position = target + (error + b * deltaSeconds) * decay
+    velocity = (velocity - omega * b * deltaSeconds) * decay
+    if (previousRemaining * (target - position) < 0.0) {
+      finish()
+    } else {
+      finishIfArrived()
+    }
+    return snapshot()
+  }
+
+  fun retarget(target: Double, viewportHeight: Double) {
+    if (!target.isFinite()) return
+    this.target = target
+    if (abs(target - position) <= PositionThreshold) {
+      finish()
+      return
+    }
+    finished = false
+    val remaining = target - position
+    val towardVelocity = velocity * remaining.sign
+    omega =
+      max(responseRate(position, target, viewportHeight), max(0.0, towardVelocity) / abs(remaining))
+  }
+
+  fun translate(delta: Double) {
+    if (!delta.isFinite()) return
+    position += delta
+    target += delta
+  }
+
+  fun synchronizeBounds(actualPosition: Double, maximumScroll: Double, viewportHeight: Double) {
+    if (!actualPosition.isFinite() || !maximumScroll.isFinite()) return
+    val maximum = max(0.0, maximumScroll)
+    position = actualPosition.coerceIn(0.0, maximum)
+    target = target.coerceIn(0.0, maximum)
+    if ((position <= 0.0 && velocity < 0.0) || (position >= maximum && velocity > 0.0)) {
+      velocity = 0.0
+    }
+    retarget(target, viewportHeight)
+  }
+
+  fun cancel() {
+    target = position
+    finish()
+  }
+
+  fun snapshot(): Snapshot = Snapshot(position = position, velocity = velocity, target = target)
+
+  private fun finishIfArrived() {
+    if (abs(target - position) <= PositionThreshold && abs(velocity) <= VelocityThreshold) {
+      finish()
+    }
+  }
+
+  private fun finish() {
+    position = target
+    velocity = 0.0
+    finished = true
+  }
+
+  companion object {
+    private const val MinSettleSeconds = 0.18
+    private const val DistanceSettleSeconds = 0.11
+    private const val MaxSettleSeconds = 0.65
+    private const val OnePercentResponse = 6.64
+    private const val PositionThreshold = 0.5
+    private const val VelocityThreshold = 5.0
+
+    fun start(position: Double, target: Double, viewportHeight: Double): EditorSmoothScrollMotion =
+      EditorSmoothScrollMotion(position, target, viewportHeight)
+
+    private fun responseRate(position: Double, target: Double, viewportHeight: Double): Double {
+      val distance = abs(target - position) / max(1.0, viewportHeight)
+      val settleSeconds =
+        (MinSettleSeconds + DistanceSettleSeconds * sqrt(distance)).coerceAtMost(MaxSettleSeconds)
+      return OnePercentResponse / settleSeconds
+    }
+  }
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/viewport/EditorViewport.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/viewport/EditorViewport.kt
@@ -1,8 +1,5 @@
 package co.typie.editor.viewport
 
-import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.EaseOutCubic
-import androidx.compose.animation.core.tween
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
@@ -29,9 +26,6 @@ import kotlin.math.max
 
 private const val EditorViewportWheelPanScale = 10f
 private const val EditorViewportWheelZoomScale = 10f
-private const val EditorViewportSmoothScrollDurationMillis = 260
-private val EditorViewportSmoothScrollSpec =
-  tween<Float>(durationMillis = EditorViewportSmoothScrollDurationMillis, easing = EaseOutCubic)
 
 private class ViewportPositionHolder(initial: Offset) : ViewModel() {
   var position by mutableStateOf(initial)
@@ -171,21 +165,6 @@ internal class EditorViewportState(initialScrollOffset: Offset = Offset.Zero) {
       isAutoScroll = isAutoScroll,
       emitScrollEvent = true,
     )
-  }
-
-  suspend fun animateScrollToY(targetY: Float, isAutoScroll: Boolean = false) {
-    invalidateRetainedTransformScrollTargetAfterTransform()
-    pendingRestoredScrollOffset = null
-    val resolvedY = resolveScrollY(targetY)
-    if (scrollOffset.y == resolvedY) {
-      return
-    }
-
-    val animation = Animatable(scrollOffset.y)
-    animation.animateTo(resolvedY, EditorViewportSmoothScrollSpec) {
-      scrollToY(targetY = value, isAutoScroll = isAutoScroll)
-    }
-    scrollToY(targetY = resolvedY, isAutoScroll = isAutoScroll)
   }
 
   fun scrollTo(offset: Offset, isAutoScroll: Boolean = false) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayout.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayout.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.MotionDurationScale
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
@@ -92,12 +93,9 @@ import co.typie.screen.editor.editor.overlay.resolveEditorMagnifierPlacement
 import co.typie.screen.editor.editor.state.EditorScreenState
 import co.typie.ui.theme.LocalHazeState
 import dev.chrisbanes.haze.hazeSource
-import kotlin.coroutines.coroutineContext
-import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.roundToInt
 import kotlinx.coroutines.CoroutineStart
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
 private enum class EditorScreenLayoutSlot {
@@ -233,6 +231,12 @@ internal fun EditorScreenLayout(
   val platformIndirectScaleBridge = remember { EditorPlatformIndirectScaleBridge() }
   val viewConfiguration = LocalViewConfiguration.current
   val bringIntoViewRequests = LocalEditorBringIntoViewRequests.current
+  val coroutineScope = rememberCoroutineScope()
+  val smoothScrollEnabled =
+    coroutineScope.coroutineContext[MotionDurationScale]
+      ?.scaleFactor
+      ?.takeIf { it.isFinite() }
+      ?.let { it > 0f } ?: true
   val appliedState = editor?.appliedState
   val bringIntoViewRequest = appliedState?.let {
     bringIntoViewRequests.activateForVersion(it.version)
@@ -249,6 +253,7 @@ internal fun EditorScreenLayout(
       bringIntoViewRequest = bringIntoViewRequest,
       anchorState = viewportAnchorState,
       publishedBundle = it.publishedBundle,
+      smoothScrollEnabled = smoothScrollEnabled,
     )
   }
   if (editor != null && surfacePreparation != null) {
@@ -262,10 +267,10 @@ internal fun EditorScreenLayout(
   val screenPointerSequence = remember { EditorScreenPointerSequence() }
   val viewportFlingBehavior = ScrollableDefaults.flingBehavior()
   val viewportAnchorPresentationRef = remember { EditorViewportAnchorPresentationRef() }
-  val coroutineScope = rememberCoroutineScope()
-  var smoothScrollJob by remember { mutableStateOf<Job?>(null) }
-  var smoothScrollRequest by remember { mutableStateOf<EditorBringIntoViewRequests.Request?>(null) }
-  var smoothScrollTargetY by remember { mutableStateOf<Float?>(null) }
+  val smoothScrollSession =
+    remember(coroutineScope, state.viewportState, bringIntoViewRequests) {
+      EditorSmoothScrollSession(coroutineScope, state.viewportState, bringIntoViewRequests)
+    }
   var layoutBoundsInRoot by remember { mutableStateOf<Rect?>(null) }
   if (isCurrentNavigationRoute) {
     DisposableEffect(navigationPopNestedScroll, viewportScrollableState) {
@@ -286,11 +291,7 @@ internal fun EditorScreenLayout(
     state.viewportState.isDirectManipulationInProgress,
   ) {
     if (state.viewportState.isTransforming || state.viewportState.isDirectManipulationInProgress) {
-      smoothScrollJob?.cancel()
-      smoothScrollJob = null
-      smoothScrollTargetY = null
-      smoothScrollRequest?.let(bringIntoViewRequests::discard)
-      smoothScrollRequest = null
+      smoothScrollSession.stop()?.let(bringIntoViewRequests::discard)
     }
   }
   val magnifierPlacement = layoutBoundsInRoot?.let { bounds ->
@@ -389,6 +390,7 @@ internal fun EditorScreenLayout(
             bringIntoViewRequest = currentRequest,
             anchorState = viewportAnchorState,
             publishedBundle = publishedBundle,
+            smoothScrollEnabled = smoothScrollEnabled,
           )
         } else {
           null
@@ -411,6 +413,7 @@ internal fun EditorScreenLayout(
                 bringIntoViewRequest = latestRequest,
                 anchorState = viewportAnchorState,
                 publishedBundle = publishedBundle,
+                smoothScrollEnabled = smoothScrollEnabled,
               )
         if (!stillCurrent) return@let null
 
@@ -419,11 +422,13 @@ internal fun EditorScreenLayout(
           return@let null
         }
 
+        val previousScrollY = state.viewportState.scrollOffset.y
         state.viewportState.scrollToY(
           targetY = anchorPublication.scrollY,
           isAutoScroll = true,
           maximumScrollY = currentPreparation.maximumScrollY,
         )
+        smoothScrollSession.translate(state.viewportState.scrollOffset.y - previousScrollY)
         anchorPublication.geometry?.let { geometry ->
           viewportAnchorState.acceptGeometry(geometry, state.viewportState.scrollOffset.y)
         }
@@ -499,7 +504,7 @@ internal fun EditorScreenLayout(
                 bringIntoViewRequests.activateForVersion(scrollFrameVersion) === it
               }
               var placementScrollY = state.viewportState.scrollOffset.y
-              var handoffViewportAnchorToSelection = false
+              var viewportAnchorHandoffTarget: EditorBringIntoViewTarget? = null
               var handoffSelectionRevealOrigin: EditorViewportAnchorRevealOrigin? = null
               val scrollIntentResult = bringIntoViewRequest?.let { request ->
                 acceptedPreparation?.scrollIntent
@@ -523,12 +528,12 @@ internal fun EditorScreenLayout(
                     null -> Unit
                     EditorScrollIntentResult.Unresolved -> Unit
                     EditorScrollIntentResult.NoScroll -> {
-                      smoothScrollJob?.cancel()
-                      smoothScrollJob = null
-                      smoothScrollTargetY = null
-                      smoothScrollRequest = null
+                      if (!smoothScrollSession.finishIfNearTarget(bringIntoViewRequest)) {
+                        smoothScrollSession.stop()
+                      }
+                      placementScrollY = state.viewportState.scrollOffset.y
                       requestToMarkPresented = bringIntoViewRequest
-                      handoffViewportAnchorToSelection = true
+                      viewportAnchorHandoffTarget = bringIntoViewRequest.target
                       if (
                         bringIntoViewRequest.target ==
                           EditorBringIntoViewTarget.CurrentSelectionHead
@@ -542,13 +547,16 @@ internal fun EditorScreenLayout(
                       }
                     }
                     is EditorScrollIntentResult.ScrollTo -> {
-                      when (bringIntoViewRequest.behavior) {
+                      val effectiveBehavior =
+                        if (smoothScrollEnabled) {
+                          bringIntoViewRequest.behavior
+                        } else {
+                          EditorBringIntoViewBehavior.Instant
+                        }
+                      when (effectiveBehavior) {
                         EditorBringIntoViewBehavior.Instant -> {
                           val revealOriginScrollY = placementScrollY
-                          smoothScrollJob?.cancel()
-                          smoothScrollJob = null
-                          smoothScrollTargetY = null
-                          smoothScrollRequest = null
+                          smoothScrollSession.stop()
                           val maximumScrollY =
                             acceptedPreparation?.maximumScrollY ?: state.viewportState.maxScrollY
                           placementScrollY = scrollIntentResult.y.coerceIn(0f, maximumScrollY)
@@ -558,7 +566,7 @@ internal fun EditorScreenLayout(
                             maximumScrollY = maximumScrollY,
                           )
                           requestToMarkPresented = bringIntoViewRequest
-                          handoffViewportAnchorToSelection = true
+                          viewportAnchorHandoffTarget = bringIntoViewRequest.target
                           if (
                             bringIntoViewRequest.target ==
                               EditorBringIntoViewTarget.CurrentSelectionHead
@@ -573,15 +581,48 @@ internal fun EditorScreenLayout(
                         }
 
                         EditorBringIntoViewBehavior.Smooth -> {
-                          val targetY = scrollIntentResult.y
-                          val alreadyAnimating =
-                            smoothScrollRequest === bringIntoViewRequest &&
-                              smoothScrollJob?.isActive == true &&
-                              smoothScrollTargetY?.let { abs(it - targetY) <= 1f } == true
-                          if (!alreadyAnimating) {
-                            smoothScrollJob?.cancel()
-                            smoothScrollRequest = bringIntoViewRequest
-                            smoothScrollTargetY = targetY
+                          val maximumScrollY =
+                            acceptedPreparation?.maximumScrollY ?: state.viewportState.maxScrollY
+                          val smoothScrollUpdate =
+                            smoothScrollSession.retarget(
+                              request = bringIntoViewRequest,
+                              targetY = scrollIntentResult.y,
+                              viewportHeight = state.viewportState.viewportSize.height,
+                              maximumScrollY = maximumScrollY,
+                            ) { completedRequest ->
+                              val activePresentation = viewportAnchorPresentationRef.current
+                              if (
+                                activePresentation != null &&
+                                  activePresentation.bundle.snapshot !==
+                                    activePresentation.editor.appliedState
+                              ) {
+                                activePresentation.editor.requestPublication()
+                                false
+                              } else {
+                                if (
+                                  activePresentation != null &&
+                                    bringIntoViewRequests.markPresented(
+                                      version = activePresentation.bundle.snapshot.version,
+                                      request = completedRequest,
+                                    )
+                                ) {
+                                  attachSelectionViewportAnchor(
+                                    editor = activePresentation.editor,
+                                    anchorState = viewportAnchorState,
+                                    revision = activePresentation.bundle.snapshot.version,
+                                    frame = activePresentation.frame,
+                                    scrollY = state.viewportState.scrollOffset.y,
+                                    visibleArea = activePresentation.visibleArea,
+                                    requireGuard =
+                                      completedRequest.target !=
+                                        EditorBringIntoViewTarget.CurrentSelectionHead,
+                                    contentOriginY = activePresentation.contentOriginY,
+                                  )
+                                }
+                                true
+                              }
+                            }
+                          if (smoothScrollUpdate == EditorSmoothScrollUpdate.Changed) {
                             editor?.let { activeEditor ->
                               attachViewportCenterAnchor(
                                 editor = activeEditor,
@@ -592,42 +633,10 @@ internal fun EditorScreenLayout(
                                 contentOriginY = presentationContentOriginY,
                               )
                             }
-                            smoothScrollJob = coroutineScope.launch {
-                              var completed = false
-                              try {
-                                state.viewportState.animateScrollToY(
-                                  targetY = targetY,
-                                  isAutoScroll = true,
-                                )
-                                completed = true
-                              } finally {
-                                if (smoothScrollJob == coroutineContext[Job]) {
-                                  smoothScrollJob = null
-                                  smoothScrollTargetY = null
-                                  smoothScrollRequest = null
-                                  val activePresentation = viewportAnchorPresentationRef.current
-                                  if (
-                                    completed &&
-                                      activePresentation != null &&
-                                      bringIntoViewRequests.markPresented(
-                                        version = activePresentation.bundle.snapshot.version,
-                                        request = bringIntoViewRequest,
-                                      )
-                                  ) {
-                                    attachSelectionViewportAnchor(
-                                      editor = activePresentation.editor,
-                                      anchorState = viewportAnchorState,
-                                      revision = activePresentation.bundle.snapshot.version,
-                                      frame = activePresentation.frame,
-                                      scrollY = state.viewportState.scrollOffset.y,
-                                      visibleArea = activePresentation.visibleArea,
-                                      requireGuard = false,
-                                      contentOriginY = activePresentation.contentOriginY,
-                                    )
-                                  }
-                                }
-                              }
-                            }
+                          }
+                          if (smoothScrollUpdate == EditorSmoothScrollUpdate.Finished) {
+                            requestToMarkPresented = bringIntoViewRequest
+                            viewportAnchorHandoffTarget = bringIntoViewRequest.target
                           }
                         }
                       }
@@ -646,8 +655,8 @@ internal fun EditorScreenLayout(
                 viewportState = state.viewportState,
                 visibleArea = measuredVisibleArea,
                 mode = viewportScrollReconcileMode,
-                smoothRevealActive = smoothScrollJob != null,
-                handoffToSelection = handoffViewportAnchorToSelection,
+                smoothRevealActive = smoothScrollSession.active,
+                handoffTarget = viewportAnchorHandoffTarget,
                 selectionRevealOrigin = handoffSelectionRevealOrigin,
                 contentOriginY = presentationContentOriginY,
               )
@@ -701,6 +710,7 @@ internal fun resolveAnchoredEditorSurfacePreparation(
   bringIntoViewRequest: EditorBringIntoViewRequests.Request?,
   anchorState: EditorViewportAnchorState,
   publishedBundle: PublishedBundle?,
+  smoothScrollEnabled: Boolean = true,
 ): EditorSurfacePreparation? {
   val initial =
     resolveEditorSurfacePreparation(
@@ -708,6 +718,7 @@ internal fun resolveAnchoredEditorSurfacePreparation(
       scrollFrame = scrollFrame,
       currentScroll = currentScrollOffset.y,
       bringIntoViewRequest = bringIntoViewRequest,
+      smoothScrollEnabled = smoothScrollEnabled,
     ) ?: return null
   val anchorPublication =
     reconcileViewportAnchorPublication(
@@ -729,6 +740,7 @@ internal fun resolveAnchoredEditorSurfacePreparation(
       scrollFrame = scrollFrame,
       currentScroll = anchorPublication.scrollY,
       bringIntoViewRequest = bringIntoViewRequest,
+      smoothScrollEnabled = smoothScrollEnabled,
     )
     ?.copy(anchorPublication = anchorPublication)
 }
@@ -738,6 +750,7 @@ internal fun resolveEditorSurfacePreparation(
   scrollFrame: EditorScrollFrame,
   currentScroll: Float,
   bringIntoViewRequest: EditorBringIntoViewRequests.Request?,
+  smoothScrollEnabled: Boolean = true,
 ): EditorSurfacePreparation? {
   val state = scrollFrame.state
   val viewportHeight = scrollFrame.visibleArea.viewport.height
@@ -749,7 +762,7 @@ internal fun resolveEditorSurfacePreparation(
       displayZoom = scrollFrame.displayZoom,
     )
   val headerHeight = scrollFrame.headerHeight.takeIf(Float::isFinite) ?: 0f
-  val resolvedContentOrigin = resolveViewportAnchorContentOriginY(scrollFrame)
+  val resolvedContentOrigin = headerHeight + bodyGeometry.topSpacerHeight
   val pageSpans =
     state.pageSizes.mapIndexedNotNull { page, size ->
       val pageTop =
@@ -786,45 +799,38 @@ internal fun resolveEditorSurfacePreparation(
           pagesContentHeight +
           scrollFrame.autoScrollPolicy.bottomPadding,
       )
-  val currentViewport =
-    if (
-      currentScroll.isFinite() &&
-        currentScroll >= 0f &&
-        viewportHeight.isFinite() &&
-        viewportHeight > 0f
-    ) {
-      VerticalSpan(top = currentScroll, bottom = currentScroll + viewportHeight)
-    } else {
-      null
-    }
-  if (currentViewport == null) return null
+  if (!currentScroll.isFinite() || !viewportHeight.isFinite() || viewportHeight <= 0f) return null
   val maximumScrollY = (contentExtent - viewportHeight).coerceAtLeast(0f)
+  val planningScrollY = currentScroll.coerceIn(0f, maximumScrollY)
+  val currentViewport =
+    VerticalSpan(top = planningScrollY, bottom = planningScrollY + viewportHeight)
   val scrollIntent = bringIntoViewRequest?.let { request ->
     resolveEditorScrollIntent(
       frame = scrollFrame,
       target = request.target,
       policy = request.policy,
-      currentScroll = currentScroll,
+      currentScroll = planningScrollY,
       contentOriginY = resolvedContentOrigin,
       maximumScrollY = maximumScrollY,
     )
   }
+  val instantReveal =
+    bringIntoViewRequest != null &&
+      (bringIntoViewRequest.behavior == EditorBringIntoViewBehavior.Instant || !smoothScrollEnabled)
   val preparationViewports =
-    if (bringIntoViewRequest?.behavior == EditorBringIntoViewBehavior.Instant) {
+    if (instantReveal) {
       resolveInstantRevealPreparationViewports(
         frame = scrollFrame,
         target = bringIntoViewRequest.target,
         policy = bringIntoViewRequest.policy,
-        currentScroll = currentScroll,
+        currentScroll = planningScrollY,
         contentOriginY = resolvedContentOrigin,
         maximumScrollY = maximumScrollY,
       )
     } else {
       emptyList()
     }
-  val instantRevealUnresolved =
-    bringIntoViewRequest?.behavior == EditorBringIntoViewBehavior.Instant &&
-      scrollIntent == EditorScrollIntentResult.Unresolved
+  val instantRevealUnresolved = instantReveal && scrollIntent == EditorScrollIntentResult.Unresolved
   if (instantRevealUnresolved) return null
   val requiredPages =
     requiredSurfacePages(
@@ -835,7 +841,7 @@ internal fun resolveEditorSurfacePreparation(
     )
   val exactViewport =
     when {
-      bringIntoViewRequest?.behavior != EditorBringIntoViewBehavior.Instant -> currentViewport
+      !instantReveal -> currentViewport
       scrollIntent is EditorScrollIntentResult.ScrollTo -> {
         val top = scrollIntent.y.coerceIn(0f, maximumScrollY)
         VerticalSpan(top = top, bottom = top + viewportHeight)
@@ -850,7 +856,7 @@ internal fun resolveEditorSurfacePreparation(
       activePages = editor.activeSurfacePages,
     )
   }
-  if (bringIntoViewRequest?.behavior == EditorBringIntoViewBehavior.Instant) {
+  if (instantReveal) {
     check(exactPages != null && requiredPages.containsAll(exactPages)) {
       "Instant reveal destination requires unprepared surfaces: " +
         "required=$requiredPages destination=$exactPages"

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorSmoothScrollSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorSmoothScrollSession.kt
@@ -1,0 +1,205 @@
+package co.typie.screen.editor.editor.layout
+
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.MotionDurationScale
+import co.typie.editor.scroll.EditorBringIntoViewBehavior
+import co.typie.editor.scroll.EditorBringIntoViewRequests
+import co.typie.editor.viewport.EditorSmoothScrollMotion
+import co.typie.editor.viewport.EditorViewportState
+import kotlin.coroutines.coroutineContext
+import kotlin.math.abs
+import kotlin.math.sign
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+
+internal enum class EditorSmoothScrollUpdate {
+  Unchanged,
+  Changed,
+  Finished,
+}
+
+internal class EditorSmoothScrollSession(
+  private val coroutineScope: CoroutineScope,
+  private val viewportState: EditorViewportState,
+  private val bringIntoViewRequests: EditorBringIntoViewRequests,
+) {
+  private var job: Job? = null
+  private var requestLifecycleJob: Job? = null
+  private var request: EditorBringIntoViewRequests.Request? = null
+  private var motion: EditorSmoothScrollMotion? = null
+  private var acceptCompletion: ((EditorBringIntoViewRequests.Request) -> Boolean)? = null
+
+  val active: Boolean
+    get() = motion != null
+
+  private fun reconcilePendingRequest(request: EditorBringIntoViewRequests.Request?) {
+    if (motion == null || this.request === request) return
+    val retainMotion = request?.behavior == EditorBringIntoViewBehavior.Smooth
+    stop(clearMotion = !retainMotion)
+    if (retainMotion) observeRequest(request)
+  }
+
+  fun retarget(
+    request: EditorBringIntoViewRequests.Request,
+    targetY: Float,
+    viewportHeight: Float,
+    maximumScrollY: Float,
+    acceptCompletion: (EditorBringIntoViewRequests.Request) -> Boolean,
+  ): EditorSmoothScrollUpdate {
+    val position = viewportState.scrollOffset.y
+    val target = targetY.coerceIn(0f, maximumScrollY)
+    val previousMotion = motion
+    val previous = previousMotion?.snapshot()
+    if (
+      this.request === request && job?.isActive == true && previous?.target == target.toDouble()
+    ) {
+      this.acceptCompletion = acceptCompletion
+      return EditorSmoothScrollUpdate.Unchanged
+    }
+
+    val direction = (target - position).toDouble().sign
+    val previousDirection = previous?.let { (it.target - it.position).sign } ?: 0.0
+    motion =
+      if (
+        previousMotion == null ||
+          (this.request !== request &&
+            direction != 0.0 &&
+            previousDirection != 0.0 &&
+            direction != previousDirection)
+      ) {
+        EditorSmoothScrollMotion.start(
+          position = position.toDouble(),
+          target = target.toDouble(),
+          viewportHeight = viewportHeight.toDouble(),
+        )
+      } else {
+        previousMotion.apply {
+          synchronizeBounds(
+            actualPosition = position.toDouble(),
+            maximumScroll = maximumScrollY.toDouble(),
+            viewportHeight = viewportHeight.toDouble(),
+          )
+          retarget(target = target.toDouble(), viewportHeight = viewportHeight.toDouble())
+        }
+      }
+    observeRequest(request)
+    this.acceptCompletion = acceptCompletion
+
+    if (motion?.finished == true && job?.isActive != true) {
+      stop()
+      return EditorSmoothScrollUpdate.Finished
+    }
+    if (job?.isActive != true) {
+      job = coroutineScope.launch { run() }
+    }
+    return EditorSmoothScrollUpdate.Changed
+  }
+
+  fun translate(delta: Float) {
+    motion?.translate(delta.toDouble())
+  }
+
+  fun finishIfNearTarget(request: EditorBringIntoViewRequests.Request): Boolean {
+    val target = motion?.snapshot()?.target ?: return false
+    if (this.request !== request || abs(target - viewportState.scrollOffset.y) > 1.0) {
+      return false
+    }
+    viewportState.scrollToY(targetY = target.toFloat(), isAutoScroll = true)
+    stop()
+    return true
+  }
+
+  fun stop(clearMotion: Boolean = true): EditorBringIntoViewRequests.Request? {
+    val stoppedJob = job
+    val stoppedRequestLifecycleJob = requestLifecycleJob
+    val stoppedRequest = request
+    job = null
+    requestLifecycleJob = null
+    request = null
+    acceptCompletion = null
+    if (clearMotion) {
+      motion?.cancel()
+      motion = null
+    }
+    stoppedJob?.cancel()
+    stoppedRequestLifecycleJob?.cancel()
+    return stoppedRequest
+  }
+
+  private fun observeRequest(request: EditorBringIntoViewRequests.Request) {
+    if (this.request === request && requestLifecycleJob?.isActive == true) return
+    requestLifecycleJob?.cancel()
+    this.request = request
+    requestLifecycleJob = coroutineScope.launch {
+      bringIntoViewRequests.awaitPresentation(request)
+      if (requestLifecycleJob == coroutineContext[Job]) {
+        requestLifecycleJob = null
+      }
+      if (this@EditorSmoothScrollSession.request === request) {
+        reconcilePendingRequest(bringIntoViewRequests.pendingRequest)
+      }
+    }
+  }
+
+  private suspend fun run() {
+    var completed = false
+    try {
+      var previousFrameTime: Long? = null
+      while (true) {
+        val currentMotion = motion ?: return
+        if (currentMotion.finished) break
+        val frameTime = withFrameNanos { it }
+        val durationScale = motionDurationScale()
+        if (durationScale == 0.0) break
+        val previousTime = previousFrameTime
+        previousFrameTime = frameTime
+        if (previousTime == null) continue
+        val activeMotion = motion ?: return
+        if (activeMotion.finished) continue
+        val viewportHeight = viewportState.viewportSize.height
+        val maximumScrollY = viewportState.maxScrollY
+        val position = viewportState.scrollOffset.y
+        val snapshot = activeMotion.snapshot()
+        if (
+          abs(snapshot.position - position) > 1.0 ||
+            snapshot.target < 0.0 ||
+            snapshot.target > maximumScrollY.toDouble()
+        ) {
+          activeMotion.synchronizeBounds(
+            actualPosition = position.toDouble(),
+            maximumScroll = maximumScrollY.toDouble(),
+            viewportHeight = viewportHeight.toDouble(),
+          )
+        }
+        val next =
+          activeMotion.advance((frameTime - previousTime) / 1_000_000_000.0 / durationScale)
+        viewportState.scrollToY(targetY = next.position.toFloat(), isAutoScroll = true)
+      }
+      motion?.snapshot()?.target?.let { target ->
+        viewportState.scrollToY(targetY = target.toFloat(), isAutoScroll = true)
+      }
+      completed = true
+    } finally {
+      if (job == coroutineContext[Job]) {
+        val completedRequest = request
+        val completion = acceptCompletion
+        job = null
+        val retainMotion =
+          completed && completedRequest != null && completion?.invoke(completedRequest) == false
+        if (!retainMotion) {
+          requestLifecycleJob?.cancel()
+          requestLifecycleJob = null
+          request = null
+          motion = null
+          acceptCompletion = null
+        }
+      }
+    }
+  }
+
+  private suspend fun motionDurationScale(): Double {
+    val scale = coroutineContext[MotionDurationScale]?.scaleFactor ?: 1f
+    return scale.takeIf { it.isFinite() && it >= 0f }?.toDouble() ?: 1.0
+  }
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorViewportAnchorReconciler.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorViewportAnchorReconciler.kt
@@ -5,6 +5,7 @@ import co.typie.editor.Editor
 import co.typie.editor.EditorState
 import co.typie.editor.PublishedBundle
 import co.typie.editor.ffi.ViewportAnchorResolution
+import co.typie.editor.scroll.EditorBringIntoViewTarget
 import co.typie.editor.scroll.EditorScrollFrame
 import co.typie.editor.scroll.EditorScrollIntentResult
 import co.typie.editor.scroll.EditorVisibleArea
@@ -36,11 +37,17 @@ internal fun reconcileViewportAnchorPublication(
 ): EditorViewportAnchorPublication {
   val currentScrollY = currentScrollOffset.y
   if (publishedBundle == null || publishedBundle.snapshot.version == candidateState.version) {
-    return EditorViewportAnchorPublication.Ready(scrollY = currentScrollY, geometry = null)
+    return EditorViewportAnchorPublication.Ready(
+      scrollY = currentScrollY.coerceIn(0f, maximumScrollY),
+      geometry = null,
+    )
   }
   var identity =
     anchorState.identity
-      ?: return EditorViewportAnchorPublication.Ready(scrollY = currentScrollY, geometry = null)
+      ?: return EditorViewportAnchorPublication.Ready(
+        scrollY = currentScrollY.coerceIn(0f, maximumScrollY),
+        geometry = null,
+      )
   val candidateFrame = measuredScrollFrame.withState(candidateState)
 
   var resolution = editor.resolveViewportAnchor(candidateState.version, identity)
@@ -135,7 +142,7 @@ internal fun reconcileViewportAnchorObservation(
   visibleArea: EditorVisibleArea,
   mode: EditorViewportScrollReconcileMode,
   smoothRevealActive: Boolean,
-  handoffToSelection: Boolean,
+  handoffTarget: EditorBringIntoViewTarget?,
   selectionRevealOrigin: EditorViewportAnchorRevealOrigin?,
   contentOriginY: Float,
 ) {
@@ -150,7 +157,7 @@ internal fun reconcileViewportAnchorObservation(
   val revision = bundle.snapshot.version
   val presentationFrame = frame.withState(bundle.snapshot)
   var geometry =
-    if (handoffToSelection) {
+    if (handoffTarget != null) {
       attachSelectionViewportAnchor(
         editor = editor,
         anchorState = anchorState,
@@ -158,7 +165,7 @@ internal fun reconcileViewportAnchorObservation(
         frame = presentationFrame,
         scrollY = viewportState.scrollOffset.y,
         visibleArea = visibleArea,
-        requireGuard = false,
+        requireGuard = handoffTarget != EditorBringIntoViewTarget.CurrentSelectionHead,
         revealOrigin = selectionRevealOrigin,
         contentOriginY = contentOriginY,
       )
@@ -186,12 +193,15 @@ internal fun reconcileViewportAnchorObservation(
     }
 
   if (
-    scrollChanged && !handoffToSelection && !smoothRevealActive && !viewportState.lastScrollWasAuto
+    scrollChanged &&
+      handoffTarget == null &&
+      !smoothRevealActive &&
+      !viewportState.lastScrollWasAuto
   ) {
     anchorState.finishRevealConvergence()
   }
   if (smoothRevealActive) {
-    if (scrollChanged && !handoffToSelection) {
+    if (scrollChanged && handoffTarget == null) {
       attachViewportCenterAnchor(
         editor,
         anchorState,
@@ -214,7 +224,7 @@ internal fun reconcileViewportAnchorObservation(
         presentationFrame,
         contentOriginY,
       )
-  if (scrollChanged && !handoffToSelection) {
+  if (scrollChanged && handoffTarget == null) {
     val preferredSelectionGeometry =
       if (!viewportState.lastScrollWasAuto) {
         resolvePreferredSelectionViewportAnchorGeometry(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/comments/EditorCommentsSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/comments/EditorCommentsSession.kt
@@ -19,7 +19,6 @@ import co.typie.editor.scroll.EditorBringIntoViewBehavior
 import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.EditorBringIntoViewTarget
-import co.typie.editor.scroll.toPageRectsTarget
 import co.typie.screen.editor.editor.selectTrackedRangeMember
 import co.typie.ui.component.toast.LocalToast
 import co.typie.ui.component.toast.ToastType
@@ -204,12 +203,10 @@ internal fun rememberEditorCommentsSession(
     if (lastRequestedActivationRevision == activeThreadActivationRevision) {
       return@LaunchedEffect
     }
-    val activeEditor = editor ?: return@LaunchedEffect
-    val (snapshot, range) = activeEditor.trackedRangeSnapshot(threadId)
-    val target = listOfNotNull(range).commentThreadScrollTarget(threadId) ?: return@LaunchedEffect
+    if (editor == null) return@LaunchedEffect
     bringIntoViewRequests.requestForVersion(
-      target = target,
-      version = snapshot.version,
+      target = activeThreadScrollTarget,
+      version = editorState.version,
       policy = EditorBringIntoViewPolicy.Reveal,
       behavior = EditorBringIntoViewBehavior.Smooth,
     )
@@ -284,7 +281,8 @@ internal fun List<TrackedRange>.commentThreadScrollTarget(
   threadId: String?
 ): EditorBringIntoViewTarget? {
   if (threadId == null) return null
-  return this.firstOrNull { it.id == threadId && it.group == ACTIVE_COMMENT_RANGE_GROUP }
-    ?.rects
-    ?.toPageRectsTarget()
+  return this.firstOrNull {
+      it.id == threadId && it.group == ACTIVE_COMMENT_RANGE_GROUP && it.rects.isNotEmpty()
+    }
+    ?.let { EditorBringIntoViewTarget.TrackedItem(it.id) }
 }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorBringIntoViewRequestsTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorBringIntoViewRequestsTest.kt
@@ -111,6 +111,22 @@ class EditorBringIntoViewRequestsTest {
   }
 
   @Test
+  fun `tracked item request remains eligible when a later revision provides its geometry`() {
+    val requests = EditorBringIntoViewRequests()
+    val request =
+      requests.requestForVersion(
+        target = EditorBringIntoViewTarget.TrackedItem("comment-1"),
+        version = 11L,
+        policy = EditorBringIntoViewPolicy.Reveal,
+      )
+
+    requests.discardObsoleteForVersion(version = 12L)
+
+    assertSame(request, requests.activateForVersion(version = 12L))
+    assertFalse(request.presentation.isCompleted)
+  }
+
+  @Test
   fun `new declaration immediately supersedes the previous reveal`() {
     val requests = EditorBringIntoViewRequests()
     val previous =

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorScrollResolverTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorScrollResolverTest.kt
@@ -12,6 +12,7 @@ import co.typie.editor.ffi.Rect as FfiRect
 import co.typie.editor.ffi.Selection
 import co.typie.editor.ffi.SelectionEndpoints
 import co.typie.editor.ffi.Size as PageSize
+import co.typie.editor.ffi.TrackedRange
 import co.typie.editor.runtime.EditorBoundsInContainer
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -550,6 +551,31 @@ class EditorScrollResolverTest {
   }
 
   @Test
+  fun `tracked item target resolves geometry from the candidate state`() {
+    val target = EditorBringIntoViewTarget.TrackedItem("comment-1")
+    val frame =
+      frame(
+        state =
+          state(
+            cursor = null,
+            selection = null,
+            pageSizes = listOf(PageSize(width = 300f, height = 900f)),
+            trackedRanges = listOf(trackedRange(id = target.id, y = 500f)),
+          )
+      )
+
+    assertScrollTo(
+      resolveEditorScrollIntent(
+        frame = frame,
+        target = target,
+        policy = EditorBringIntoViewPolicy.Reveal,
+        currentScroll = 0f,
+      ),
+      280f,
+    )
+  }
+
+  @Test
   fun `page rects reveal top-aligns an oversized target below the viewport`() {
     val frame =
       frame(
@@ -641,6 +667,7 @@ class EditorScrollResolverTest {
     pageSizes: List<PageSize>,
     selection: Selection? = cursor?.let { collapsedSelection() },
     selectionEndpoints: SelectionEndpoints? = null,
+    trackedRanges: List<TrackedRange> = emptyList(),
   ): EditorState =
     EditorState(
       version = 1L,
@@ -652,6 +679,7 @@ class EditorScrollResolverTest {
       rootAttrs = null,
       rootModifiers = null,
       ime = null,
+      trackedRanges = trackedRanges,
     )
 
   private fun frame(
@@ -713,4 +741,15 @@ class EditorScrollResolverTest {
     val position = position(offset = 0)
     return Selection(anchor = position, head = position)
   }
+
+  private fun trackedRange(id: String, y: Float): TrackedRange =
+    TrackedRange(
+      id = id,
+      group = "comment-active",
+      anchor = position(offset = 0),
+      head = position(offset = 1),
+      metadata = "",
+      rects = listOf(PageRect(pageIdx = 0, rect = FfiRect(0f, y, 40f, 20f))),
+      text = "comment",
+    )
 }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/viewport/EditorSmoothScrollMotionTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/viewport/EditorSmoothScrollMotionTest.kt
@@ -1,0 +1,163 @@
+package co.typie.editor.viewport
+
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class EditorSmoothScrollMotionTest {
+  @Test
+  fun `translation preserves velocity and remaining distance`() {
+    val motion =
+      EditorSmoothScrollMotion.start(position = 100.0, target = 500.0, viewportHeight = 400.0)
+    motion.advance(1.0 / 60.0)
+    val before = motion.snapshot()
+
+    motion.translate(700.0)
+
+    val after = motion.snapshot()
+    assertEquals(before.position + 700.0, after.position, 1e-8)
+    assertEquals(before.target + 700.0, after.target, 1e-8)
+    assertEquals(before.velocity, after.velocity, 1e-8)
+    assertEquals(before.target - before.position, after.target - after.position, 1e-8)
+  }
+
+  @Test
+  fun `matching elapsed time is frame rate independent`() {
+    val at60Hz =
+      EditorSmoothScrollMotion.start(position = 0.0, target = 1600.0, viewportHeight = 400.0)
+    val at120Hz =
+      EditorSmoothScrollMotion.start(position = 0.0, target = 1600.0, viewportHeight = 400.0)
+
+    repeat(30) { at60Hz.advance(1.0 / 60.0) }
+    repeat(60) { at120Hz.advance(1.0 / 120.0) }
+
+    assertEquals(at60Hz.snapshot().position, at120Hz.snapshot().position, 1e-8)
+    assertEquals(at60Hz.snapshot().velocity, at120Hz.snapshot().velocity, 1e-8)
+  }
+
+  @Test
+  fun `matches the Web retarget and translation vector`() {
+    val motion =
+      EditorSmoothScrollMotion.start(position = 0.0, target = 1600.0, viewportHeight = 400.0)
+    motion.advance(0.05)
+    motion.advance(0.05)
+    motion.translate(700.0)
+    motion.retarget(target = 2100.0, viewportHeight = 400.0)
+    motion.advance(0.05)
+
+    assertEquals(1809.7452631440876, motion.snapshot().position, 0.01)
+    assertEquals(4556.356253653357, motion.snapshot().velocity, 0.1)
+    assertEquals(2100.0, motion.snapshot().target)
+  }
+
+  @Test
+  fun `farther destination takes longer and reaches a higher speed`() {
+    val short =
+      runToCompletion(
+        EditorSmoothScrollMotion.start(position = 0.0, target = 100.0, viewportHeight = 400.0)
+      )
+    val long =
+      runToCompletion(
+        EditorSmoothScrollMotion.start(position = 0.0, target = 1600.0, viewportHeight = 400.0)
+      )
+
+    assertTrue(long.elapsed > short.elapsed)
+    assertTrue(long.elapsed < short.elapsed * 4.0)
+    assertTrue(long.peakVelocity > short.peakVelocity)
+  }
+
+  @Test
+  fun `retarget preserves current position and velocity`() {
+    val motion =
+      EditorSmoothScrollMotion.start(position = 0.0, target = 800.0, viewportHeight = 400.0)
+    repeat(8) { motion.advance(1.0 / 60.0) }
+    val before = motion.snapshot()
+
+    motion.retarget(target = 1200.0, viewportHeight = 400.0)
+
+    assertEquals(before.position, motion.snapshot().position)
+    assertEquals(before.velocity, motion.snapshot().velocity)
+    assertEquals(1200.0, motion.snapshot().target)
+  }
+
+  @Test
+  fun `within-threshold retarget finishes despite remaining velocity`() {
+    val motion =
+      EditorSmoothScrollMotion.start(position = 0.0, target = 800.0, viewportHeight = 400.0)
+    repeat(8) { motion.advance(1.0 / 60.0) }
+    val target = motion.snapshot().position + 0.25
+
+    motion.retarget(target = target, viewportHeight = 400.0)
+
+    assertTrue(motion.finished)
+    assertEquals(
+      EditorSmoothScrollMotion.Snapshot(position = target, velocity = 0.0, target = target),
+      motion.snapshot(),
+    )
+  }
+
+  @Test
+  fun `high-speed closer retarget does not overshoot`() {
+    val motion =
+      EditorSmoothScrollMotion.start(position = 0.0, target = 1600.0, viewportHeight = 400.0)
+    repeat(12) { motion.advance(1.0 / 60.0) }
+    val before = motion.snapshot()
+    val target = before.position + 80.0
+
+    motion.retarget(target = target, viewportHeight = 400.0)
+    assertEquals(before.velocity, motion.snapshot().velocity)
+
+    while (!motion.finished) {
+      assertTrue(motion.advance(1.0 / 120.0).position <= target)
+    }
+    assertEquals(
+      EditorSmoothScrollMotion.Snapshot(position = target, velocity = 0.0, target = target),
+      motion.snapshot(),
+    )
+  }
+
+  @Test
+  fun `bound synchronization removes outward velocity and adopts host position`() {
+    val motion =
+      EditorSmoothScrollMotion.start(position = 0.0, target = 1600.0, viewportHeight = 400.0)
+    repeat(6) { motion.advance(1.0 / 60.0) }
+
+    motion.synchronizeBounds(actualPosition = 600.0, maximumScroll = 600.0, viewportHeight = 400.0)
+
+    assertTrue(motion.finished)
+    assertEquals(
+      EditorSmoothScrollMotion.Snapshot(position = 600.0, velocity = 0.0, target = 600.0),
+      motion.snapshot(),
+    )
+  }
+
+  @Test
+  fun `delayed frame catches up to the full elapsed time`() {
+    val delayed =
+      EditorSmoothScrollMotion.start(position = 0.0, target = 800.0, viewportHeight = 400.0)
+    val uninterrupted =
+      EditorSmoothScrollMotion.start(position = 0.0, target = 800.0, viewportHeight = 400.0)
+
+    delayed.advance(0.25)
+    repeat(15) { uninterrupted.advance(1.0 / 60.0) }
+
+    assertEquals(uninterrupted.snapshot().position, delayed.snapshot().position, 1e-8)
+    assertEquals(uninterrupted.snapshot().velocity, delayed.snapshot().velocity, 1e-8)
+  }
+
+  private fun runToCompletion(motion: EditorSmoothScrollMotion): RunResult {
+    var elapsed = 0.0
+    var peakVelocity = 0.0
+    while (!motion.finished && elapsed < 5.0) {
+      val state = motion.advance(1.0 / 120.0)
+      elapsed += 1.0 / 120.0
+      peakVelocity = max(peakVelocity, abs(state.velocity))
+    }
+    assertTrue(motion.finished)
+    return RunResult(elapsed = elapsed, peakVelocity = peakVelocity)
+  }
+
+  private data class RunResult(val elapsed: Double, val peakVelocity: Double)
+}

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/viewport/EditorViewportStateTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/viewport/EditorViewportStateTest.kt
@@ -6,7 +6,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import kotlinx.coroutines.test.runTest
 
 class EditorViewportStateTest {
   @Test
@@ -297,7 +296,7 @@ class EditorViewportStateTest {
   }
 
   @Test
-  fun `unchanged animated scroll intent invalidates retained zoom target`() = runTest {
+  fun `unchanged scroll intent invalidates retained zoom target`() {
     val state = EditorViewportState()
     state.updateMeasuredBounds(
       viewportSize = Size(width = 100f, height = 100f),
@@ -310,7 +309,7 @@ class EditorViewportStateTest {
     )
     state.endTransform()
 
-    state.animateScrollToY(targetY = 100f)
+    state.scrollToY(targetY = 100f)
     state.updateMeasuredBounds(
       viewportSize = Size(width = 100f, height = 100f),
       contentSize = Size(width = 400f, height = 400f),

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/layout/EditorSmoothScrollSessionTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/layout/EditorSmoothScrollSessionTest.kt
@@ -1,0 +1,253 @@
+package co.typie.screen.editor.editor.layout
+
+import androidx.compose.runtime.BroadcastFrameClock
+import androidx.compose.ui.MotionDurationScale
+import androidx.compose.ui.geometry.Size
+import co.typie.editor.scroll.EditorBringIntoViewBehavior
+import co.typie.editor.scroll.EditorBringIntoViewPolicy
+import co.typie.editor.scroll.EditorBringIntoViewRequests
+import co.typie.editor.scroll.EditorBringIntoViewTarget
+import co.typie.editor.viewport.EditorViewportState
+import kotlin.coroutines.coroutineContext
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class EditorSmoothScrollSessionTest {
+  @Test
+  fun `no-op near the active target finishes at the exact target`() =
+    runTest(StandardTestDispatcher()) {
+      val frameClock = BroadcastFrameClock()
+      val viewportState = viewportState()
+      val requests = EditorBringIntoViewRequests()
+      val session =
+        EditorSmoothScrollSession(
+          coroutineScope = CoroutineScope(coroutineContext + frameClock),
+          viewportState = viewportState,
+          bringIntoViewRequests = requests,
+        )
+      val request = smoothRequest(requests)
+
+      session.retarget(
+        request = request,
+        targetY = 580f,
+        viewportHeight = 400f,
+        maximumScrollY = 1600f,
+      ) {
+        true
+      }
+      viewportState.scrollToY(targetY = 579.25f, isAutoScroll = true)
+
+      assertTrue(session.finishIfNearTarget(request))
+      assertEquals(580f, viewportState.scrollOffset.y)
+      assertFalse(session.active)
+    }
+
+  @Test
+  fun `retains a finished motion when its presentation is stale and retargets it after reconciliation`() =
+    runTest(StandardTestDispatcher()) {
+      val frameClock = BroadcastFrameClock()
+      val viewportState = viewportState()
+      val requests = EditorBringIntoViewRequests()
+      val session =
+        EditorSmoothScrollSession(
+          coroutineScope = CoroutineScope(coroutineContext + frameClock),
+          viewportState = viewportState,
+          bringIntoViewRequests = requests,
+        )
+      val request = smoothRequest(requests)
+      var completionCount = 0
+
+      session.retarget(
+        request = request,
+        targetY = 580f,
+        viewportHeight = 400f,
+        maximumScrollY = 1600f,
+      ) {
+        completionCount += 1
+        false
+      }
+      var frameTimeNanos = pumpFrames(frameClock) { completionCount > 0 }
+
+      assertEquals(580f, viewportState.scrollOffset.y)
+      assertEquals(1, completionCount)
+      assertTrue(session.active)
+
+      viewportState.scrollToY(targetY = 780f, isAutoScroll = true)
+      session.translate(200f)
+      session.retarget(
+        request = request,
+        targetY = 980f,
+        viewportHeight = 400f,
+        maximumScrollY = 1600f,
+      ) {
+        completionCount += 1
+        true
+      }
+      frameTimeNanos = pumpFrames(frameClock, frameTimeNanos) { completionCount > 1 }
+
+      assertTrue(frameTimeNanos > 0L)
+      assertEquals(980f, viewportState.scrollOffset.y)
+      assertEquals(2, completionCount)
+      assertFalse(session.active)
+    }
+
+  @Test
+  fun `retained motion clears when its smooth replacement is discarded`() =
+    runTest(StandardTestDispatcher()) {
+      val frameClock = BroadcastFrameClock()
+      val viewportState = viewportState()
+      val requests = EditorBringIntoViewRequests()
+      val session =
+        EditorSmoothScrollSession(
+          coroutineScope = CoroutineScope(coroutineContext + frameClock),
+          viewportState = viewportState,
+          bringIntoViewRequests = requests,
+        )
+      val request = smoothRequest(requests)
+      var completed = false
+
+      session.retarget(
+        request = request,
+        targetY = 580f,
+        viewportHeight = 400f,
+        maximumScrollY = 1600f,
+      ) {
+        completed = true
+        false
+      }
+      pumpFrames(frameClock) { completed }
+      assertTrue(session.active)
+
+      val replacement =
+        requests.declare(
+          target = EditorBringIntoViewTarget.CurrentSelectionHead,
+          policy = EditorBringIntoViewPolicy.Reveal,
+          behavior = EditorBringIntoViewBehavior.Smooth,
+        )
+      runCurrent()
+      assertTrue(session.active)
+
+      requests.discard(replacement)
+      runCurrent()
+
+      assertFalse(session.active)
+    }
+
+  @Test
+  fun `running motion stops when its request is discarded`() =
+    runTest(StandardTestDispatcher()) {
+      val frameClock = BroadcastFrameClock()
+      val viewportState = viewportState()
+      val requests = EditorBringIntoViewRequests()
+      val session =
+        EditorSmoothScrollSession(
+          coroutineScope = CoroutineScope(coroutineContext + frameClock),
+          viewportState = viewportState,
+          bringIntoViewRequests = requests,
+        )
+      val request = smoothRequest(requests)
+
+      session.retarget(
+        request = request,
+        targetY = 800f,
+        viewportHeight = 400f,
+        maximumScrollY = 1600f,
+      ) {
+        true
+      }
+      requests.discard(request)
+      runCurrent()
+      val active = session.active
+      session.stop()
+
+      assertFalse(active)
+    }
+
+  @Test
+  fun `motion duration scale slows the custom animator`() =
+    runTest(StandardTestDispatcher()) {
+      val normalPosition = scrollPositionAfterFrames(durationScale = 1f)
+      val slowedPosition = scrollPositionAfterFrames(durationScale = 2f)
+
+      assertTrue(slowedPosition < normalPosition)
+    }
+
+  private suspend fun TestScope.scrollPositionAfterFrames(durationScale: Float): Float {
+    val frameClock = BroadcastFrameClock()
+    val scale = TestMotionDurationScale(durationScale)
+    val viewportState = viewportState()
+    val requests = EditorBringIntoViewRequests()
+    val session =
+      EditorSmoothScrollSession(
+        coroutineScope = CoroutineScope(coroutineContext + frameClock + scale),
+        viewportState = viewportState,
+        bringIntoViewRequests = requests,
+      )
+
+    session.retarget(
+      request = smoothRequest(requests),
+      targetY = 800f,
+      viewportHeight = 400f,
+      maximumScrollY = 1600f,
+    ) {
+      true
+    }
+
+    var frameTimeNanos = 0L
+    repeat(10) {
+      runCurrent()
+      frameTimeNanos += 16_000_000L
+      frameClock.sendFrame(frameTimeNanos)
+    }
+    runCurrent()
+    val position = viewportState.scrollOffset.y
+    session.stop()
+    runCurrent()
+    return position
+  }
+
+  private fun viewportState(): EditorViewportState =
+    EditorViewportState().apply {
+      updateMeasuredBounds(
+        viewportSize = Size(width = 600f, height = 400f),
+        contentSize = Size(width = 600f, height = 2000f),
+      )
+    }
+
+  private fun smoothRequest(
+    requests: EditorBringIntoViewRequests = EditorBringIntoViewRequests()
+  ): EditorBringIntoViewRequests.Request =
+    requests.requestForVersion(
+      target = EditorBringIntoViewTarget.CurrentSelectionHead,
+      version = 1L,
+      policy = EditorBringIntoViewPolicy.Reveal,
+      behavior = EditorBringIntoViewBehavior.Smooth,
+    )
+
+  private suspend fun TestScope.pumpFrames(
+    frameClock: BroadcastFrameClock,
+    initialFrameTimeNanos: Long = 0L,
+    done: () -> Boolean,
+  ): Long {
+    var frameTimeNanos = initialFrameTimeNanos
+    repeat(120) {
+      runCurrent()
+      if (done()) return frameTimeNanos
+      frameTimeNanos += 16_000_000L
+      frameClock.sendFrame(frameTimeNanos)
+    }
+    runCurrent()
+    return frameTimeNanos
+  }
+
+  private class TestMotionDurationScale(override val scaleFactor: Float) : MotionDurationScale
+}

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/layout/EditorSurfacePreparationTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/layout/EditorSurfacePreparationTest.kt
@@ -33,7 +33,9 @@ import co.typie.editor.viewport.EditorViewportAnchorRevealOrigin
 import co.typie.editor.viewport.EditorViewportAnchorState
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 
@@ -196,6 +198,74 @@ class EditorSurfacePreparationTest {
     assertEquals(measuredInitially?.scrollIntent, corrected?.scrollIntent)
     assertEquals(measuredInitially?.maximumScrollY, corrected?.maximumScrollY)
   }
+
+  @Test
+  fun `disabled smooth motion prepares the destination like an instant reveal`() = runTest {
+    val editor = Editor(FakeFfiEditor(), this, StandardTestDispatcher(testScheduler))
+    val frame = frame()
+    val request =
+      EditorBringIntoViewRequests.Request(
+        target =
+          EditorBringIntoViewTarget.PageRects(
+            listOf(PageRect(pageIdx = 2, rect = Rect(x = 0f, y = 100f, width = 1f, height = 20f)))
+          ),
+        policy = EditorBringIntoViewPolicy.Reveal,
+        behavior = EditorBringIntoViewBehavior.Smooth,
+      )
+
+    val animated =
+      resolveEditorSurfacePreparation(
+        editor = editor,
+        scrollFrame = frame,
+        currentScroll = 0f,
+        bringIntoViewRequest = request,
+        smoothScrollEnabled = true,
+      )
+    val reducedMotion =
+      resolveEditorSurfacePreparation(
+        editor = editor,
+        scrollFrame = frame,
+        currentScroll = 0f,
+        bringIntoViewRequest = request,
+        smoothScrollEnabled = false,
+      )
+
+    assertFalse(2 in animated!!.requiredPages)
+    assertTrue(2 in reducedMotion!!.requiredPages)
+  }
+
+  @Test
+  fun `surface planning clamps to a candidate document shorter than the current scroll`() =
+    runTest {
+      val editor = Editor(FakeFfiEditor(), this, StandardTestDispatcher(testScheduler))
+      val baseFrame = frame()
+      val candidateFrame =
+        baseFrame.copy(
+          state =
+            baseFrame.state.copy(
+              version = 2L,
+              pageSizes = listOf(PageSize(width = 600f, height = 1_000f)),
+            )
+        )
+
+      val preparation =
+        resolveAnchoredEditorSurfacePreparation(
+          editor = editor,
+          scrollFrame = candidateFrame,
+          currentScrollOffset = Offset(x = 0f, y = 90_000f),
+          bringIntoViewRequest = null,
+          anchorState = EditorViewportAnchorState(),
+          publishedBundle =
+            PublishedBundle(snapshot = baseFrame.state.copy(version = 1L), frames = emptyMap()),
+        )
+
+      val resolved = requireNotNull(preparation)
+      assertEquals(setOf(0), resolved.requiredPages)
+      assertEquals(
+        EditorViewportAnchorPublication.Ready(scrollY = resolved.maximumScrollY, geometry = null),
+        resolved.anchorPublication,
+      )
+    }
 
   private fun frame(): EditorScrollFrame {
     val visibleArea = EditorVisibleArea(viewport = Size(width = 600f, height = 400f))

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/layout/EditorViewportAnchorReconcilerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/layout/EditorViewportAnchorReconcilerTest.kt
@@ -16,6 +16,7 @@ import co.typie.editor.ffi.ViewportAnchor
 import co.typie.editor.ffi.ViewportAnchorPoint
 import co.typie.editor.ffi.ViewportAnchorResolution
 import co.typie.editor.runtime.EditorBoundsInContainer
+import co.typie.editor.scroll.EditorBringIntoViewTarget
 import co.typie.editor.scroll.EditorScrollFrame
 import co.typie.editor.scroll.EditorVisibleArea
 import co.typie.editor.scroll.resolveEditorAutoScrollPolicy
@@ -75,6 +76,38 @@ class EditorViewportAnchorReconcilerTest {
     assertEquals(viewportAnchor, anchorState.identity)
     assertEquals(Offset(x = 0f, y = 250f), viewportState.scrollOffset)
   }
+
+  @Test
+  fun `non-selection reveal keeps the viewport anchor when selection is outside the guard`() =
+    runTest {
+      val visibleArea = visibleArea()
+      val frame = frame(visibleArea)
+      val anchorState = EditorViewportAnchorState()
+      val viewportState = viewportState(scrollY = 350f)
+      val editor = editor(selectionY = 50f)
+
+      reconcile(editor, anchorState, frame, viewportState, visibleArea)
+      assertEquals(viewportAnchor, anchorState.identity)
+
+      reconcileViewportAnchorObservation(
+        editor = editor,
+        anchorState = anchorState,
+        bundle = PublishedBundle(snapshot = frame.state, frames = emptyMap()),
+        frame = frame,
+        viewportState = viewportState,
+        visibleArea = visibleArea,
+        mode = EditorViewportScrollReconcileMode.Enabled,
+        smoothRevealActive = false,
+        handoffTarget =
+          EditorBringIntoViewTarget.PageRects(
+            listOf(PageRect(pageIdx = 0, rect = Rect(0f, 500f, 1f, 20f)))
+          ),
+        selectionRevealOrigin = null,
+        contentOriginY = 0f,
+      )
+
+      assertEquals(viewportAnchor, anchorState.identity)
+    }
 
   @Test
   fun `scroll observed during transform is reconciled after the transform ends`() = runTest {
@@ -166,7 +199,7 @@ class EditorViewportAnchorReconcilerTest {
       visibleArea = visibleArea,
       mode = EditorViewportScrollReconcileMode.Enabled,
       smoothRevealActive = false,
-      handoffToSelection = false,
+      handoffTarget = null,
       selectionRevealOrigin = null,
       contentOriginY = 40f,
     )
@@ -180,7 +213,7 @@ class EditorViewportAnchorReconcilerTest {
       visibleArea = visibleArea,
       mode = EditorViewportScrollReconcileMode.Enabled,
       smoothRevealActive = false,
-      handoffToSelection = false,
+      handoffTarget = null,
       selectionRevealOrigin = null,
       contentOriginY = 40f,
     )
@@ -221,7 +254,7 @@ class EditorViewportAnchorReconcilerTest {
       visibleArea = visibleArea,
       mode = EditorViewportScrollReconcileMode.Enabled,
       smoothRevealActive = smoothRevealActive,
-      handoffToSelection = false,
+      handoffTarget = null,
       selectionRevealOrigin = null,
       contentOriginY = 0f,
     )

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/subpane/comments/EditorCommentsSessionTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/subpane/comments/EditorCommentsSessionTest.kt
@@ -5,7 +5,7 @@ import co.typie.editor.ffi.PageRect
 import co.typie.editor.ffi.Position
 import co.typie.editor.ffi.Rect
 import co.typie.editor.ffi.TrackedRange
-import co.typie.editor.scroll.toPageRectsTarget
+import co.typie.editor.scroll.EditorBringIntoViewTarget
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -22,8 +22,11 @@ class EditorCommentsSessionTest {
 
     assertNull(listOf(inactiveRange).commentThreadScrollTarget(inactiveRange.id))
     assertEquals(
-      rects.toPageRectsTarget(),
+      EditorBringIntoViewTarget.TrackedItem(activeRange.id),
       listOf(activeRange).commentThreadScrollTarget(activeRange.id),
+    )
+    assertNull(
+      listOf(activeRange.copy(rects = emptyList())).commentThreadScrollTarget(activeRange.id)
     )
   }
 

--- a/apps/website/src/lib/editor-ffi/components/View.svelte
+++ b/apps/website/src/lib/editor-ffi/components/View.svelte
@@ -238,7 +238,6 @@
         ctx.editor?.requestPublication();
       }
     : undefined}
-  onscrollend={useWindowScroll ? () => ctx.scroll?.settleSmoothReveal() : undefined}
   onwheel={useWindowScroll ? () => ctx.scroll?.cancel() : undefined}
 />
 
@@ -303,7 +302,6 @@
       ctx.scroll?.observeViewportScroll();
       ctx.editor?.requestPublication();
     }}
-    onscrollend={() => ctx.scroll?.settleSmoothReveal()}
     onwheel={() => ctx.scroll?.cancel()}
     bind:clientWidth
     bind:clientHeight

--- a/apps/website/src/lib/editor-ffi/editor-frame-sync-test-host.svelte
+++ b/apps/website/src/lib/editor-ffi/editor-frame-sync-test-host.svelte
@@ -103,7 +103,14 @@
   });
 </script>
 
-<svelte:window onscroll={useWindowScroll ? () => editor.requestPublication() : undefined} />
+<svelte:window
+  onscroll={useWindowScroll
+    ? () => {
+        ctx.scroll?.observeViewportScroll();
+        editor.requestPublication();
+      }
+    : undefined}
+/>
 
 {#snippet editorContent()}
   <div

--- a/apps/website/src/lib/editor-ffi/editor-frame-sync.browser.test.ts
+++ b/apps/website/src/lib/editor-ffi/editor-frame-sync.browser.test.ts
@@ -187,6 +187,34 @@ function paginatedDocWithPageBreaks(pageCount: number, linkedLastPage?: { text: 
   };
 }
 
+function paginatedDocWithLinkedPage(pageCount: number, linkedPage: number, text: string, href: string): PlainDoc {
+  const pageHeight = 221;
+  return {
+    root: entry(
+      {
+        type: 'root',
+        layout_mode: {
+          type: 'paginated',
+          page_width: PAGE_WIDTH,
+          page_height: pageHeight,
+          page_margin_top: PAGE_MARGIN,
+          page_margin_bottom: PAGE_MARGIN,
+          page_margin_left: PAGE_MARGIN,
+          page_margin_right: PAGE_MARGIN,
+        },
+      },
+      Array.from({ length: pageCount }, (_, page) => {
+        const children: PlainNodeEntry[] = [];
+        if (page === linkedPage) {
+          children.push(entry({ type: 'text', text }, [], { link: { type: 'link', href } } as never));
+        }
+        if (page < pageCount - 1) children.push(entry({ type: 'page_break' }));
+        return entry({ type: 'paragraph' }, children);
+      }),
+    ),
+  };
+}
+
 async function mountEditor(
   plain: PlainDoc,
   options: { readOnly?: boolean; typewriterEnabled?: boolean; withZoom?: boolean; displayZoom?: number } = {},
@@ -457,6 +485,77 @@ async function waitForPresentation(editor: Editor, revision = editor.appliedRevi
   await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
 }
 
+async function prepareTrackedItemSmoothReveal(pageCount: number, targetPage: number) {
+  const errorId = `smooth-target-${crypto.randomUUID()}`;
+  const text = 'tracked target';
+  const href = `https://example.com/${errorId}`;
+  const harness = await mountEditor(paginatedDocWithLinkedPage(pageCount, targetPage, text, href));
+  const { editor, scrollRoot } = harness;
+
+  const targetUpdate = editor.updateNow((request) => {
+    request.enqueue({ type: 'selection', op: { type: 'set_at', page: targetPage, x: PAGE_MARGIN, y: PAGE_MARGIN } });
+  });
+  expect(targetUpdate).not.toBeNull();
+  if (!targetUpdate) throw new Error('Expected the tracked-target selection update');
+  await waitForPresentation(editor, targetUpdate.revision);
+
+  const selection = editor.appliedSnapshot.selection;
+  const targetSelection = selection && editor.modifierSpanSelection(selection.head, 'link');
+  expect(targetSelection).toBeDefined();
+  if (!targetSelection) throw new Error('Expected the linked target selection');
+  editor.setSpellcheckErrors([{ id: errorId, selection: targetSelection, context: text, corrections: [], explanation: '' }]);
+  await expect.poll(() => editor.appliedSnapshot.trackedRanges.some((range) => range.id === errorId)).toBe(true);
+  await waitForPresentation(editor);
+
+  let startPresentation: Promise<void> | undefined;
+  const startUpdate = editor.updateNow((request) => {
+    request.enqueue({ type: 'selection', op: { type: 'set_at', page: pageCount - 1, x: PAGE_MARGIN, y: PAGE_MARGIN } });
+    startPresentation = editor.scrollIntoView({ target: { type: 'current_selection_head' }, policy: 'cursor_guard', behavior: 'instant' });
+  });
+  expect(startUpdate).not.toBeNull();
+  expect(startPresentation).toBeDefined();
+  if (!startUpdate || !startPresentation) throw new Error('Expected the smooth-reveal start-position presentation');
+  await startPresentation;
+  expect(scrollRoot.scrollTop).toBeGreaterThan(0);
+
+  const unrelatedSelectionUpdate = editor.updateNow((request) => {
+    request.enqueue({ type: 'selection', op: { type: 'set_at', page: targetPage + 10, x: PAGE_MARGIN, y: PAGE_MARGIN } });
+  });
+  expect(unrelatedSelectionUpdate).not.toBeNull();
+  if (!unrelatedSelectionUpdate) throw new Error('Expected the unrelated selection update');
+  await waitForPresentation(editor, unrelatedSelectionUpdate.revision);
+
+  const presentation = editor.scrollIntoView({ target: { type: 'tracked_item', id: errorId }, policy: 'reveal', behavior: 'smooth' });
+  expect(presentation).toBeDefined();
+  if (!presentation) throw new Error('Expected the smooth reveal presentation');
+  return { editor, errorId, presentation, scrollRoot };
+}
+
+function insertPagesBeforeTrackedTarget(editor: Editor, count = 1): number {
+  const selection = editor.appliedSnapshot.selection;
+  const savedSelection = selection && editor.freezeSelection(selection);
+  expect(savedSelection).toBeDefined();
+  if (!savedSelection) throw new Error('Expected a stable selection before the preceding page insertion');
+  const update = editor.updateNow((request) => {
+    request.enqueue({ type: 'selection', op: { type: 'set_at', page: 0, x: PAGE_MARGIN, y: PAGE_MARGIN } });
+    for (let index = 0; index < count; index += 1) {
+      request.enqueue({ type: 'insertion', op: { type: 'break', kind: 'page' } });
+    }
+    request.enqueue({ type: 'selection', op: { type: 'set_frozen', selection: savedSelection } });
+  });
+  expect(update).not.toBeNull();
+  if (!update) throw new Error('Expected the preceding page insertion');
+  return update.revision;
+}
+
+function trackedTargetScrollTop(editor: Editor, id: string): number | null {
+  const snapshot = editor.published?.snapshot;
+  const rect = snapshot && editor.trackedRangeForSnapshot(id, snapshot)?.rects[0];
+  if (!snapshot || !rect) return null;
+  const pageTop = snapshot.pageSizes.slice(0, rect.page_idx).reduce((sum, page) => sum + page.height + PAGE_GAP, 0);
+  return pageTop + rect.rect.y - CURSOR_VISIBLE_MARGIN;
+}
+
 function expectActualCanvas(editor: Editor, pageIndex: number, requirePaintedPixels = true) {
   const frame = editor.published?.frames.get(pageIndex);
   const canvas = document.querySelector<HTMLCanvasElement>(`canvas[data-page-canvas="${pageIndex}"]`);
@@ -631,6 +730,90 @@ describe('web editor frame synchronization', () => {
     }
     expect(revealed, 'the offscreen spellcheck result was not presented after its smooth reveal').toBe(true);
     expectActualCanvas(editor, pageCount - 1);
+  });
+
+  it('keeps an in-flight smooth reveal advancing while preceding page edits are published', async () => {
+    const { editor, errorId, presentation, scrollRoot } = await prepareTrackedItemSmoothReveal(32, 10);
+    let completed = false;
+    void presentation.then(() => {
+      completed = true;
+    });
+    const initialScrollTop = scrollRoot.scrollTop;
+    await expect.poll(() => Math.abs(scrollRoot.scrollTop - initialScrollTop)).toBeGreaterThan(0.25);
+    const initialTargetScrollTop = trackedTargetScrollTop(editor, errorId);
+    expect(initialTargetScrollTop).not.toBeNull();
+    if (initialTargetScrollTop === null) throw new Error('Expected initial tracked target geometry');
+    let previousDistance = scrollRoot.scrollTop - initialTargetScrollTop;
+    let consecutiveStationaryFrames = 0;
+    let maximumStationaryFrames = 0;
+    let insertedPages = 0;
+    const samples: {
+      frame: number;
+      capturedAtMs: number;
+      scrollTop: number;
+      targetScrollTop: number | null;
+      distance: number | null;
+      revision: number;
+    }[] = [];
+
+    for (let frame = 0; !completed && frame < 240; frame += 1) {
+      if (frame === 2) {
+        insertPagesBeforeTrackedTarget(editor, 20);
+        insertedPages = 20;
+      }
+      const capturedAtMs = await nextAnimationFrame();
+      const targetScrollTop = trackedTargetScrollTop(editor, errorId);
+      const currentScrollTop = scrollRoot.scrollTop;
+      const distance = targetScrollTop === null ? null : currentScrollTop - targetScrollTop;
+      samples.push({
+        frame,
+        capturedAtMs,
+        scrollTop: currentScrollTop,
+        targetScrollTop,
+        distance,
+        revision: editor.publishedRevision ?? -1,
+      });
+      if (distance !== null && distance > 20) {
+        consecutiveStationaryFrames = Math.abs(distance - previousDistance) <= 0.25 ? consecutiveStationaryFrames + 1 : 0;
+        maximumStationaryFrames = Math.max(maximumStationaryFrames, consecutiveStationaryFrames);
+        previousDistance = distance;
+      }
+    }
+
+    expect(insertedPages).toBe(20);
+    expect(completed, 'smooth reveal did not complete after preceding page edits').toBe(true);
+    expect(
+      maximumStationaryFrames,
+      `smooth reveal visibly stalled between animation frames: ${JSON.stringify(samples.slice(-20))}`,
+    ).toBeLessThanOrEqual(1);
+  });
+
+  it('converges to the final tracked geometry when preceding page edits arrive near completion', async () => {
+    const { editor, errorId, presentation, scrollRoot } = await prepareTrackedItemSmoothReveal(32, 10);
+    let completed = false;
+    void presentation.then(() => {
+      completed = true;
+    });
+    let insertedPages = false;
+
+    for (let frame = 0; !completed && frame < 240; frame += 1) {
+      await nextAnimationFrame();
+      const targetScrollTop = trackedTargetScrollTop(editor, errorId);
+      if (!insertedPages && targetScrollTop !== null && scrollRoot.scrollTop - targetScrollTop < scrollRoot.clientHeight) {
+        insertPagesBeforeTrackedTarget(editor, 20);
+        insertedPages = true;
+      }
+    }
+
+    expect(insertedPages, 'TEST HARNESS: preceding edits were not inserted near completion').toBe(true);
+    expect(completed, 'smooth reveal did not complete after the near-finish edits').toBe(true);
+
+    const finalEditRevision = insertPagesBeforeTrackedTarget(editor);
+    await waitForPresentation(editor, finalEditRevision);
+    const finalTargetScrollTop = trackedTargetScrollTop(editor, errorId);
+    expect(finalTargetScrollTop).not.toBeNull();
+    if (finalTargetScrollTop === null) throw new Error('Expected final tracked target geometry');
+    expect(scrollRoot.scrollTop).toBeCloseTo(finalTargetScrollTop, 0);
   });
 
   it('rejects a presentation without the cursor page native frame', () => {

--- a/apps/website/src/lib/editor-ffi/editor-publication-preparation.test.ts
+++ b/apps/website/src/lib/editor-ffi/editor-publication-preparation.test.ts
@@ -1,36 +1,62 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { resolveEditorSurfacePreparation } from './editor-publication.svelte';
 import { EditorScrollScope } from './scroll.svelte';
 import type { Editor, EditorSnapshot } from './editor.svelte';
 
+const snapshot = (overrides: Partial<EditorSnapshot>): EditorSnapshot => ({
+  revision: 1,
+  cursor: undefined,
+  placeholder: undefined,
+  selection: undefined,
+  selectionEndpoints: undefined,
+  lastHistoryTag: undefined,
+  pageSizes: [],
+  pageBackingSizes: [],
+  externalElements: [],
+  tableOverlays: [],
+  linkRects: [],
+  pageData: new Map(),
+  rootAttrs: undefined,
+  rootModifiers: [],
+  trackedRanges: [],
+  ...overrides,
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
 describe('editor publication preparation', () => {
   it('plans surfaces and reveal from the anchor-corrected candidate scroll', () => {
-    const snapshot = {
+    const candidate = snapshot({
       revision: 1,
       pageSizes: Array.from({ length: 4 }, () => ({ width: 600, height: 1000 })),
       trackedRanges: [
         {
           id: 'target',
+          group: 'comment',
+          anchor: { node: 'paragraph', offset: 0, affinity: 'downstream' },
+          head: { node: 'paragraph', offset: 0, affinity: 'downstream' },
+          metadata: '',
           rects: [{ page_idx: 0, rect: { x: 0, y: 100, width: 1, height: 20 } }],
+          text: '',
         },
       ],
-      selection: undefined,
-      selectionEndpoints: undefined,
-      cursor: undefined,
-      rootAttrs: undefined,
-    } as EditorSnapshot;
+    });
     let scrollTop = 100;
     const editor = {
       destroyed: false,
-      appliedSnapshot: snapshot,
-      appliedRevision: snapshot.revision,
-      publishedRevision: snapshot.revision,
-      published: { snapshot, frames: new Map([[0, {}]]) },
+      appliedSnapshot: candidate,
+      appliedRevision: candidate.revision,
+      publishedRevision: candidate.revision,
+      published: { snapshot: candidate, frames: new Map([[0, {}]]) },
       viewport: { height: 400 },
       scaleFactor: 1,
       displayZoom: 1,
       activeSurfacePages: new Set<number>(),
-      extensionAreaEl: null,
+      extensionAreaEl: {
+        getBoundingClientRect: () => new DOMRect(0, -100, 600, 4000),
+      },
       scrollViewport: {
         getRect: () => new DOMRect(0, 0, 600, 400),
         getScrollTop: () => scrollTop,
@@ -52,5 +78,129 @@ describe('editor publication preparation', () => {
 
     expect(preparation?.scrollIntent).toEqual({ type: 'scroll_to', y: 2040 });
     expect(preparation?.requiredPages).toEqual(new Set([1, 2]));
+  });
+
+  it('prepares destination surfaces when reduced motion turns a smooth reveal into an instant reveal', () => {
+    const candidate = snapshot({
+      pageSizes: Array.from({ length: 3 }, () => ({ width: 600, height: 1000 })),
+      trackedRanges: [
+        {
+          id: 'target',
+          group: 'comment',
+          anchor: { node: 'paragraph', offset: 0, affinity: 'downstream' },
+          head: { node: 'paragraph', offset: 0, affinity: 'downstream' },
+          metadata: '',
+          rects: [{ page_idx: 2, rect: { x: 0, y: 100, width: 1, height: 20 } }],
+          text: '',
+        },
+      ],
+    });
+    const editor = {
+      destroyed: false,
+      appliedSnapshot: candidate,
+      appliedRevision: candidate.revision,
+      publishedRevision: candidate.revision,
+      published: { snapshot: candidate, frames: new Map([[0, {}]]) },
+      viewport: { height: 400 },
+      scaleFactor: 1,
+      displayZoom: 1,
+      activeSurfacePages: new Set<number>(),
+      extensionAreaEl: {
+        getBoundingClientRect: () => new DOMRect(0, 0, 600, 3040),
+      },
+      scrollViewport: {
+        getRect: () => new DOMRect(0, 0, 600, 400),
+        getScrollTop: () => 0,
+        getScrollHeight: () => 3040,
+        scrollTo: vi.fn(),
+      },
+      requestPublication: vi.fn(),
+      safeDisplayZoom: () => 1,
+      trackedRangeForSnapshot: (id: string, snapshot: EditorSnapshot) => snapshot.trackedRanges.find((range) => range.id === id),
+    } as unknown as Editor;
+    const scroll = new EditorScrollScope(editor, () => ({ enabled: false, position: undefined }));
+    vi.stubGlobal('matchMedia', () => ({ matches: false }));
+    scroll.scrollIntoView({ target: { type: 'tracked_item', id: 'target' }, policy: 'reveal', behavior: 'smooth' });
+
+    const animated = resolveEditorSurfacePreparation(editor, scroll);
+
+    vi.stubGlobal('matchMedia', () => ({ matches: true }));
+    scroll.scrollIntoView({ target: { type: 'tracked_item', id: 'target' }, policy: 'reveal', behavior: 'smooth' });
+    const reducedMotion = resolveEditorSurfacePreparation(editor, scroll);
+
+    expect(animated?.requiredPages.has(2)).toBe(false);
+    expect(reducedMotion?.requiredPages.has(2)).toBe(true);
+  });
+
+  it('clamps surface planning to a candidate document that became shorter than the current scroll', () => {
+    const candidate = snapshot({
+      revision: 2,
+      pageSizes: [{ width: 600, height: 1000 }],
+    });
+    const scrollTop = 90_000;
+    const editor = {
+      destroyed: false,
+      appliedSnapshot: candidate,
+      appliedRevision: candidate.revision,
+      publishedRevision: 1,
+      published: undefined,
+      viewport: { height: 400 },
+      scaleFactor: 1,
+      displayZoom: 1,
+      activeSurfacePages: new Set([9]),
+      scrollRootEl: {} as HTMLElement,
+      extensionAreaEl: {
+        getBoundingClientRect: () => new DOMRect(0, -scrollTop, 600, 1000),
+      },
+      scrollViewport: {
+        getRect: () => new DOMRect(0, 0, 600, 400),
+        getScrollTop: () => scrollTop,
+        getScrollHeight: () => 100_000,
+        scrollTo: vi.fn(),
+      },
+      requestPublication: vi.fn(),
+      safeDisplayZoom: () => 1,
+    } as unknown as Editor;
+    const scroll = new EditorScrollScope(editor, () => ({ enabled: false, position: undefined }));
+
+    const preparation = resolveEditorSurfacePreparation(editor, scroll);
+
+    expect(preparation?.requiredPages).toEqual(new Set([0]));
+  });
+
+  it('keeps planning in the enclosing window scroll range beyond the editor document', () => {
+    const candidate = snapshot({
+      revision: 1,
+      pageSizes: [{ width: 600, height: 1000 }],
+    });
+    const scrollTop = 3000;
+    const editor = {
+      destroyed: false,
+      appliedSnapshot: candidate,
+      appliedRevision: candidate.revision,
+      publishedRevision: candidate.revision,
+      published: undefined,
+      viewport: { height: 400 },
+      scaleFactor: 1,
+      displayZoom: 1,
+      activeSurfacePages: new Set<number>(),
+      scrollRootEl: null,
+      extensionAreaEl: {
+        getBoundingClientRect: () => new DOMRect(0, -scrollTop, 600, 1000),
+      },
+      scrollViewport: {
+        getRect: () => new DOMRect(0, 0, 600, 400),
+        getScrollTop: () => scrollTop,
+        getScrollHeight: () => 4000,
+        scrollTo: vi.fn(),
+      },
+      requestPublication: vi.fn(),
+      safeDisplayZoom: () => 1,
+    } as unknown as Editor;
+    const scroll = new EditorScrollScope(editor, () => ({ enabled: false, position: undefined }));
+
+    const preparation = resolveEditorSurfacePreparation(editor, scroll);
+
+    expect(preparation?.requiredPages).toEqual(new Set());
   });
 });

--- a/apps/website/src/lib/editor-ffi/editor-publication.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor-publication.svelte.ts
@@ -2,6 +2,7 @@ import { flushSync, untrack } from 'svelte';
 import { PAGE_GAP } from './constants';
 import { pageRectsToRevealTargetSpan, resolvePageSpans } from './geometry';
 import { requiredSurfacePages } from './required-surface-pages';
+import { isInstantReveal } from './scroll.svelte';
 import { zoomDiffers } from './zoom';
 import type { EditorContext, EditorSnapshot, PublishedBundle } from './editor.svelte';
 import type { EditorSurfaceHost } from './editor-surface-host.svelte';
@@ -57,7 +58,7 @@ function reconcilePublication(
   editor.requestSurfacePages(preparation.requiredPages);
   surfaceHost.reconcile(preparation.requiredPages);
   surfaceHost.syncPublished();
-  if (preparation.pendingRequest?.behavior === 'instant' && preparation.scrollIntent?.type === 'unresolved') return;
+  if (isInstantReveal(preparation.pendingRequest) && preparation.scrollIntent?.type === 'unresolved') return;
 
   const bundle = editor.publishIfReady(preparation.requiredPages);
   if (!bundle) return;
@@ -74,7 +75,7 @@ function reconcilePublication(
     const finalPreparation = resolveEditorSurfacePreparation(editor, scroll, finalAnchorPublication.targetScrollTop ?? undefined);
     if (
       !finalPreparation ||
-      (finalPreparation.pendingRequest?.behavior === 'instant' && finalPreparation.scrollIntent?.type === 'unresolved') ||
+      (isInstantReveal(finalPreparation.pendingRequest) && finalPreparation.scrollIntent?.type === 'unresolved') ||
       finalPreparation.pendingRequest !== preparation.pendingRequest ||
       !samePages(finalPreparation.requiredPages, preparation.requiredPages)
     ) {
@@ -88,7 +89,7 @@ function reconcilePublication(
     surfaceHost.syncPublished(bundle);
     if (finalPreparation.pendingRequest && finalPreparation.scrollIntent) {
       const applied = scroll.applyPending(finalPreparation.pendingRequest, bundle.snapshot, finalPreparation.scrollIntent);
-      if (!applied && finalPreparation.pendingRequest.behavior === 'instant') {
+      if (!applied && isInstantReveal(finalPreparation.pendingRequest)) {
         editor.requestPublication();
         return;
       }
@@ -124,11 +125,12 @@ export function resolveEditorSurfacePreparation(
   const snapshot = editor.appliedSnapshot;
   const viewportRect = viewport.getRect();
   const clientHeight = viewportRect.bottom - viewportRect.top;
-  const scrollTop = currentScrollTop ?? viewport.getScrollTop();
+  const actualScrollTop = viewport.getScrollTop();
+  const scrollTop = currentScrollTop ?? actualScrollTop;
   if (!Number.isFinite(scrollTop) || scrollTop < 0 || !Number.isFinite(clientHeight) || clientHeight <= 0) return null;
 
   const zoom = displayZoom(snapshot, editor.displayZoom);
-  const origin = editor.extensionAreaEl ? editor.extensionAreaEl.getBoundingClientRect().top - viewportRect.top + scrollTop : 0;
+  const origin = editor.extensionAreaEl ? editor.extensionAreaEl.getBoundingClientRect().top - viewportRect.top + actualScrollTop : 0;
   const pageSpans = resolvePageSpans(snapshot.pageSizes, {
     origin,
     displayZoom: zoom,
@@ -138,17 +140,20 @@ export function resolveEditorSurfacePreparation(
   const bottomPadding = scroll.bottomPaddingFor(snapshot);
   const predictedExtent = pageSpans.at(-1)?.bottom ?? origin;
   const scrollHeight = Math.max(predictedExtent + bottomPadding, clientHeight);
-  const currentViewport = { top: scrollTop, bottom: scrollTop + clientHeight };
+  const maximumScrollTop = Math.max(0, scrollHeight - clientHeight);
+  const planningScrollTop = editor.scrollRootEl ? Math.max(0, Math.min(scrollTop, maximumScrollTop)) : scrollTop;
+  const currentViewport = { top: planningScrollTop, bottom: planningScrollTop + clientHeight };
 
   const pendingRequest = scroll.activateForRevision(snapshot.revision);
   const targetRects = pendingRequest ? scroll.resolveTargetRects(pendingRequest.target, snapshot) : null;
   const target = targetRects ? pageRectsToRevealTargetSpan(targetRects, pageSpans, zoom) : null;
+  const instantReveal = isInstantReveal(pendingRequest);
   const preparationViewports =
-    target && pendingRequest?.behavior === 'instant'
+    target && pendingRequest && instantReveal
       ? scroll.resolvePreparationViewports(
           pendingRequest,
           {
-            scrollTop,
+            scrollTop: planningScrollTop,
             clientHeight,
             scrollHeight,
             targetTop: target.targetTop,
@@ -158,7 +163,7 @@ export function resolveEditorSurfacePreparation(
         )
       : [];
   const scrollIntent = resolveScrollIntent(pendingRequest, targetRects, target, snapshot, scroll, {
-    scrollTop,
+    scrollTop: planningScrollTop,
     clientHeight,
     scrollHeight,
   });
@@ -168,7 +173,7 @@ export function resolveEditorSurfacePreparation(
     activePages: editor.activeSurfacePages,
     preparationViewports,
   });
-  if (pendingRequest?.behavior === 'instant') {
+  if (instantReveal) {
     const exactViewport =
       scrollIntent?.type === 'scroll_to' ? { top: scrollIntent.y, bottom: scrollIntent.y + clientHeight } : currentViewport;
     const exactPages = requiredSurfacePages({

--- a/apps/website/src/lib/editor-ffi/scroll-scope.test.ts
+++ b/apps/website/src/lib/editor-ffi/scroll-scope.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { EditorRequest, EditorUpdate } from './editor-update';
 import { EditorScrollScope } from './scroll.svelte';
 import type { PageRect } from '@typie/editor-ffi/browser';
@@ -72,6 +72,15 @@ describe('EditorRequest', () => {
 
 function setup(snapshot: EditorSnapshot, typewriter?: { enabled: boolean; position: number | undefined }) {
   const typewriterPreferences = typewriter ?? { enabled: false, position: undefined };
+  let animationTime = 0;
+  let nextAnimationFrameId = 1;
+  const animationFrames = new Map<number, FrameRequestCallback>();
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+    const id = nextAnimationFrameId++;
+    animationFrames.set(id, callback);
+    return id;
+  });
+  vi.stubGlobal('cancelAnimationFrame', (id: number) => animationFrames.delete(id));
   let scrollTop = 0;
   const scrollTo = vi.fn((options: ScrollToOptions) => {
     if (options.behavior === 'instant' && options.top !== undefined) scrollTop = options.top;
@@ -110,7 +119,15 @@ function setup(snapshot: EditorSnapshot, typewriter?: { enabled: boolean; positi
     requestPublication,
   } as unknown as Editor;
   return {
+    advanceAnimation: (milliseconds = 16) => {
+      animationTime += milliseconds;
+      const callbacks = [...animationFrames.values()];
+      animationFrames.clear();
+      for (const callback of callbacks) callback(animationTime);
+    },
+    animationFrameCount: () => animationFrames.size,
     editor,
+    getScrollTop: () => scrollTop,
     requestPublication,
     setScrollTop: (value: number) => {
       scrollTop = value;
@@ -119,6 +136,10 @@ function setup(snapshot: EditorSnapshot, typewriter?: { enabled: boolean; positi
     scope: new EditorScrollScope(editor, () => typewriterPreferences),
   };
 }
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe('EditorScrollScope', () => {
   const revealMetrics = {
@@ -238,6 +259,27 @@ describe('EditorScrollScope', () => {
     expect(request.behavior).toBe('smooth');
   });
 
+  it('applies a smooth request immediately when reduced motion is preferred', () => {
+    const snapshot = trackedSnapshot('target', {
+      page_idx: 0,
+      rect: { x: 0, y: 900, width: 1, height: 20 },
+    });
+    const { animationFrameCount, scope, scrollTo } = setup(snapshot);
+    vi.stubGlobal('matchMedia', () => ({ matches: true }));
+    const request = scope.declare({
+      target: { type: 'tracked_item', id: 'target' },
+      policy: 'reveal',
+      behavior: 'smooth',
+    });
+    scope.bind(request, snapshot.revision);
+
+    expect(scope.resolvePreparationViewports(request, revealMetrics, snapshot)).not.toEqual([]);
+    expect(scope.applyPending(request, snapshot, { type: 'scroll_to', y: 580 })).toBe(true);
+    expect(scrollTo).toHaveBeenCalledExactlyOnceWith({ top: 580, behavior: 'instant' });
+    expect(animationFrameCount()).toBe(0);
+    expect(scope.pendingRequest).toBeNull();
+  });
+
   it('applies the cursor guard to a compact pointer selection head', () => {
     const rect = { page_idx: 0, rect: { x: 0, y: 350, width: 1, height: 20 } };
     const snapshot = selectionSnapshot(true, rect);
@@ -355,7 +397,7 @@ describe('EditorScrollScope', () => {
       page_idx: 0,
       rect: { x: 0, y: 900, width: 1, height: 20 },
     });
-    const { scope, setScrollTop } = setup(snapshot);
+    const { advanceAnimation, animationFrameCount, scope } = setup(snapshot);
 
     const presentation = scope.scrollIntoView({
       target: { type: 'tracked_item', id: 'target' },
@@ -376,8 +418,7 @@ describe('EditorScrollScope', () => {
 
     expect(scope.applyPending(request, snapshot, { type: 'scroll_to', y: 580 })).toBe(true);
     expect(scope.pendingRequest).toBe(request);
-    setScrollTop(580);
-    scope.settleSmoothReveal();
+    for (let frame = 0; frame < 100 && animationFrameCount() > 0; frame++) advanceAnimation();
     await expect(presentation).resolves.toBeUndefined();
   });
 
@@ -448,22 +489,26 @@ describe('EditorScrollScope', () => {
     expect(requestPublication).toHaveBeenCalledOnce();
   });
 
-  it('interrupts the native smooth scroll when direct manipulation cancels its reveal', () => {
+  it('cancels the custom smooth scroll when direct manipulation takes control', () => {
     const snapshot = trackedSnapshot('target', {
       page_idx: 0,
       rect: { x: 0, y: 900, width: 1, height: 20 },
     });
-    const { scope, scrollTo, setScrollTop } = setup(snapshot);
+    const { advanceAnimation, animationFrameCount, scope, scrollTo } = setup(snapshot);
     scope.scrollIntoView({ target: { type: 'tracked_item', id: 'target' }, policy: 'reveal', behavior: 'smooth' });
     const request = scope.pendingRequest;
     if (!request) throw new Error('Expected a pending reveal');
     expect(scope.applyPending(request, snapshot, { type: 'scroll_to', y: 580 })).toBe(true);
 
-    setScrollTop(250);
+    advanceAnimation();
+    advanceAnimation();
+    const callsBeforeCancel = scrollTo.mock.calls.length;
     scope.cancel();
+    advanceAnimation();
 
-    expect(scrollTo).toHaveBeenNthCalledWith(1, { top: 580, behavior: 'smooth' });
-    expect(scrollTo).toHaveBeenNthCalledWith(2, { top: 250, behavior: 'instant' });
+    expect(animationFrameCount()).toBe(0);
+    expect(scrollTo).toHaveBeenCalledTimes(callsBeforeCancel);
+    expect(scrollTo.mock.calls.every(([options]) => options.behavior === 'instant')).toBe(true);
   });
 
   it('keeps the existing latest-request-wins reveal contract', () => {
@@ -487,7 +532,7 @@ describe('EditorScrollScope', () => {
       page_idx: 0,
       rect: { x: 0, y: 900, width: 1, height: 20 },
     });
-    const { requestPublication, scope, scrollTo, setScrollTop } = setup(snapshot);
+    const { advanceAnimation, animationFrameCount, requestPublication, scope, scrollTo } = setup(snapshot);
 
     scope.scrollIntoView({ target: { type: 'tracked_item', id: 'old' }, policy: 'reveal', behavior: 'smooth' });
     const old = scope.pendingRequest;
@@ -499,15 +544,38 @@ describe('EditorScrollScope', () => {
     expect(scope.applyPending(old, snapshot, { type: 'scroll_to', y: 100 })).toBe(false);
     expect(scope.applyPending(current, snapshot, { type: 'scroll_to', y: 580 })).toBe(true);
     expect(scope.applyPending(current, snapshot, { type: 'scroll_to', y: 580 })).toBe(true);
-    expect(scrollTo).toHaveBeenCalledExactlyOnceWith({ top: 580, behavior: 'smooth' });
+    expect(scrollTo).not.toHaveBeenCalled();
+    expect(animationFrameCount()).toBe(1);
     expect(scope.applyPending(current, snapshot, { type: 'scroll_to', y: 640 })).toBe(true);
-    expect(scrollTo).toHaveBeenNthCalledWith(2, { top: 640, behavior: 'smooth' });
     expect(scope.pendingRequest).toBe(current);
     expect(requestPublication).not.toHaveBeenCalled();
-    setScrollTop(640);
-    scope.settleSmoothReveal();
+    for (let frame = 0; frame < 100 && animationFrameCount() > 0; frame++) advanceAnimation();
+    expect(scrollTo).toHaveBeenLastCalledWith({ top: 640, behavior: 'instant' });
     expect(scope.pendingRequest).toBeNull();
     expect(requestPublication).toHaveBeenCalledOnce();
+  });
+
+  it('does not reshape an in-flight motion when the same target is published again', () => {
+    const snapshot = trackedSnapshot('target', {
+      page_idx: 0,
+      rect: { x: 0, y: 900, width: 1, height: 20 },
+    });
+    const run = (republish: boolean) => {
+      const { advanceAnimation, getScrollTop, scope } = setup(snapshot);
+      const request = scope.declare({
+        target: { type: 'tracked_item', id: 'target' },
+        policy: 'reveal',
+        behavior: 'smooth',
+      });
+      scope.bind(request, snapshot.revision);
+      scope.applyPending(request, snapshot, { type: 'scroll_to', y: 580 });
+      for (let frame = 0; frame < 8; frame++) advanceAnimation();
+      if (republish) scope.applyPending(request, snapshot, { type: 'scroll_to', y: 580 });
+      advanceAnimation();
+      return getScrollTop();
+    };
+
+    expect(run(true)).toBeCloseTo(run(false), 8);
   });
 
   it('applies a preverified instant destination without mounted page geometry', () => {
@@ -699,17 +767,62 @@ describe('EditorScrollScope', () => {
     });
   });
 
-  it('restarts an interrupted native smooth reveal and ignores settle before reaching the target', () => {
+  it('clamps an unanchored publication to the candidate scroll extent', () => {
+    const current = trackedSnapshot('target', {
+      page_idx: 1,
+      rect: { x: 0, y: 100, width: 1, height: 20 },
+    });
+    const candidate = {
+      ...current,
+      revision: 2,
+      pageSizes: [{ width: 600, height: 300 }],
+    } as EditorSnapshot;
+    const { editor, getScrollTop, scope, scrollTo, setScrollTop } = setup(current);
+    editor.scrollRootEl = {} as HTMLElement;
+    setScrollTop(800);
+
+    const publication = scope.prepareViewportAnchorPublication(candidate);
+
+    expect(publication).toEqual({ type: 'ready', geometry: null, targetScrollTop: 0 });
+    scope.applyViewportAnchorPublication(publication);
+    expect(scrollTo).toHaveBeenCalledExactlyOnceWith({ top: 0, behavior: 'instant' });
+    expect(getScrollTop()).toBe(0);
+  });
+
+  it('does not clamp an unanchored publication to the editor extent in a window scroller', () => {
+    const current = trackedSnapshot('target', {
+      page_idx: 1,
+      rect: { x: 0, y: 100, width: 1, height: 20 },
+    });
+    const candidate = {
+      ...current,
+      revision: 2,
+      pageSizes: [{ width: 600, height: 300 }],
+    } as EditorSnapshot;
+    const { editor, scope, setScrollTop } = setup(current);
+    editor.scrollRootEl = null;
+    setScrollTop(800);
+
+    expect(scope.prepareViewportAnchorPublication(candidate)).toEqual({
+      type: 'ready',
+      geometry: null,
+      targetScrollTop: null,
+    });
+  });
+
+  it('translates an in-flight smooth reveal across viewport-anchor reconciliation', () => {
     const snapshot = trackedSnapshot('target', {
       page_idx: 0,
       rect: { x: 0, y: 900, width: 1, height: 20 },
     });
-    const { scope, scrollTo, setScrollTop } = setup(snapshot);
+    const { advanceAnimation, animationFrameCount, scope, scrollTo } = setup(snapshot);
     scope.scrollIntoView({ target: { type: 'tracked_item', id: 'target' }, policy: 'reveal', behavior: 'smooth' });
     const request = scope.pendingRequest;
     if (!request) throw new Error('Expected a pending reveal');
 
     expect(scope.applyPending(request, snapshot, { type: 'scroll_to', y: 580 })).toBe(true);
+    advanceAnimation();
+    advanceAnimation();
     scope.applyViewportAnchorPublication({
       type: 'ready',
       geometry: { pointY: 320 },
@@ -717,18 +830,46 @@ describe('EditorScrollScope', () => {
     });
     expect(scope.applyPending(request, snapshot, { type: 'scroll_to', y: 580 })).toBe(true);
 
-    expect(scrollTo).toHaveBeenNthCalledWith(1, { top: 580, behavior: 'smooth' });
-    expect(scrollTo).toHaveBeenNthCalledWith(2, { top: 220, behavior: 'instant' });
-    expect(scrollTo).toHaveBeenNthCalledWith(3, { top: 580, behavior: 'smooth' });
-    scope.settleSmoothReveal();
-    expect(scope.pendingRequest).toBe(request);
-
-    setScrollTop(580);
-    scope.settleSmoothReveal();
+    expect(scrollTo).toHaveBeenCalledWith({ top: 220, behavior: 'instant' });
+    for (let frame = 0; frame < 100 && animationFrameCount() > 0; frame++) advanceAnimation();
+    expect(scrollTo).toHaveBeenLastCalledWith({ top: 580, behavior: 'instant' });
     expect(scope.pendingRequest).toBeNull();
   });
 
-  it('interrupts native smooth scrolling when a later publication resolves the reveal as no-op', () => {
+  it('keeps a smooth reveal pending until the latest applied geometry is published', async () => {
+    const snapshot = trackedSnapshot('target', {
+      page_idx: 0,
+      rect: { x: 0, y: 900, width: 1, height: 20 },
+    });
+    const { advanceAnimation, animationFrameCount, editor, requestPublication, scope, scrollTo } = setup(snapshot);
+    scope.scrollIntoView({ target: { type: 'tracked_item', id: 'target' }, policy: 'reveal', behavior: 'smooth' });
+    const request = scope.pendingRequest;
+    if (!request) throw new Error('Expected a pending reveal');
+    const presentation = request.presentation;
+
+    expect(scope.applyPending(request, snapshot, { type: 'scroll_to', y: 580 })).toBe(true);
+    const candidate = { ...snapshot, revision: 2 } as EditorSnapshot;
+    Object.assign(editor, { appliedSnapshot: candidate, appliedRevision: candidate.revision });
+
+    for (let frame = 0; frame < 100 && animationFrameCount() > 0; frame++) advanceAnimation();
+
+    expect(scrollTo).toHaveBeenLastCalledWith({ top: 580, behavior: 'instant' });
+    expect(scope.pendingRequest).toBe(request);
+    expect(requestPublication).toHaveBeenCalled();
+
+    Object.assign(editor, {
+      published: { snapshot: candidate, frames: editor.published?.frames ?? new Map() },
+      publishedRevision: candidate.revision,
+    });
+    expect(scope.applyPending(request, candidate, { type: 'scroll_to', y: 780 })).toBe(true);
+    for (let frame = 0; frame < 100 && animationFrameCount() > 0; frame++) advanceAnimation();
+
+    expect(scrollTo).toHaveBeenLastCalledWith({ top: 780, behavior: 'instant' });
+    expect(scope.pendingRequest).toBeNull();
+    await expect(presentation).resolves.toBeUndefined();
+  });
+
+  it('finishes an in-flight smooth reveal when a later publication resolves it as no-op', () => {
     const snapshot = trackedSnapshot('target', {
       page_idx: 0,
       rect: { x: 0, y: 900, width: 1, height: 20 },
@@ -746,9 +887,70 @@ describe('EditorScrollScope', () => {
     });
     expect(scope.applyPending(request, snapshot, { type: 'no_scroll' })).toBe(true);
 
-    expect(scrollTo).toHaveBeenNthCalledWith(1, { top: 580, behavior: 'smooth' });
-    expect(scrollTo).toHaveBeenNthCalledWith(2, { top: 220, behavior: 'instant' });
-    expect(scrollTo).toHaveBeenNthCalledWith(3, { top: 220, behavior: 'instant' });
+    expect(scrollTo).toHaveBeenCalledExactlyOnceWith({ top: 220, behavior: 'instant' });
+    expect(scope.pendingRequest).toBeNull();
+  });
+
+  it('keeps a non-selection reveal anchored near its destination after the visible area shrinks', () => {
+    const selectionRect = {
+      page_idx: 0,
+      rect: { x: 0, y: 90, width: 1, height: 20 },
+    };
+    const targetRect = {
+      page_idx: 0,
+      rect: { x: 0, y: 900, width: 1, height: 20 },
+    };
+    const snapshot = {
+      ...selectionSnapshot(true, selectionRect),
+      trackedRanges: [{ id: 'target', rects: [targetRect] }],
+    } as EditorSnapshot;
+    const { editor, getScrollTop, scope, scrollTo } = setup(snapshot);
+    const selection = { type: 'node' as const, node: 'selection', offset_x: 0, offset_y: 0 };
+    const viewport = { type: 'node' as const, node: 'viewport', offset_x: 0, offset_y: 0 };
+    const selectionGeometry = {
+      point: { page_idx: 0, x: 0, y: 100 },
+      rect: selectionRect,
+    };
+    const viewportGeometry = {
+      point: { page_idx: 0, x: 0, y: 700 },
+      rect: undefined,
+    };
+    editor.captureSelectionViewportAnchor = vi.fn(() => ({ identity: selection, geometry: selectionGeometry }));
+    editor.captureViewportAnchorAt = vi.fn(() => ({ identity: viewport, geometry: viewportGeometry }));
+    editor.resolveViewportAnchor = vi.fn((_revision, identity) => ({
+      type: 'resolved' as const,
+      geometry: identity === selection ? selectionGeometry : viewportGeometry,
+    }));
+
+    scope.scrollIntoView({ target: { type: 'tracked_item', id: 'target' }, policy: 'reveal' });
+    const request = scope.pendingRequest;
+    if (!request) throw new Error('Expected a scroll request');
+    expect(scope.applyPending(request, snapshot, { type: 'scroll_to', y: 580 })).toBe(true);
+    scrollTo.mockClear();
+
+    scope.visibleArea = { topInset: 0, bottomInset: 100 };
+    scope.reconcileViewportResize();
+
+    expect(scrollTo).not.toHaveBeenCalled();
+    expect(getScrollTop()).toBe(580);
+  });
+
+  it('snaps an in-flight smooth reveal to its target when a no-op publication is within scroll tolerance', () => {
+    const snapshot = trackedSnapshot('target', {
+      page_idx: 0,
+      rect: { x: 0, y: 900, width: 1, height: 20 },
+    });
+    const { scope, scrollTo, setScrollTop } = setup(snapshot);
+    scope.scrollIntoView({ target: { type: 'tracked_item', id: 'target' }, policy: 'reveal', behavior: 'smooth' });
+    const request = scope.pendingRequest;
+    if (!request) throw new Error('Expected a pending reveal');
+
+    expect(scope.applyPending(request, snapshot, { type: 'scroll_to', y: 580 })).toBe(true);
+    setScrollTop(579.25);
+    expect(scope.applyPending(request, snapshot, { type: 'no_scroll' })).toBe(true);
+
+    expect(scrollTo).toHaveBeenLastCalledWith({ top: 580, behavior: 'instant' });
+    expect(scope.pendingRequest).toBeNull();
   });
 
   it('starts a smooth reveal without requiring a frame for the target page', () => {
@@ -756,7 +958,7 @@ describe('EditorScrollScope', () => {
       page_idx: 1,
       rect: { x: 0, y: 100, width: 1, height: 20 },
     });
-    const { editor, scope, scrollTo, setScrollTop } = setup(snapshot);
+    const { advanceAnimation, animationFrameCount, editor, scope, scrollTo } = setup(snapshot);
 
     scope.scrollIntoView({ target: { type: 'tracked_item', id: 'target' }, policy: 'reveal', behavior: 'smooth' });
     const request = scope.pendingRequest;
@@ -770,9 +972,9 @@ describe('EditorScrollScope', () => {
 
     expect(scope.applyPending(request, snapshot, { type: 'scroll_to', y: 900 })).toBe(true);
     expect(scope.pendingRequest).toBe(request);
-    expect(scrollTo).toHaveBeenCalledExactlyOnceWith({ top: 900, behavior: 'smooth' });
-    setScrollTop(900);
-    scope.settleSmoothReveal();
+    expect(scrollTo).not.toHaveBeenCalled();
+    for (let frame = 0; frame < 100 && animationFrameCount() > 0; frame++) advanceAnimation();
+    expect(scrollTo).toHaveBeenLastCalledWith({ top: 800, behavior: 'instant' });
     expect(scope.pendingRequest).toBeNull();
   });
 

--- a/apps/website/src/lib/editor-ffi/scroll.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/scroll.svelte.ts
@@ -9,6 +9,7 @@ import {
   resolveTypewriterBottomPadding,
   resolveTypewriterScrollTop,
 } from './scroll';
+import { SmoothScrollMotion } from './smooth-scroll-motion';
 import { EditorViewportAnchorState, resolveViewportAnchorGeometry, viewportCenterAnchorPoint } from './viewport-anchor';
 import type { PageRect } from '@typie/editor-ffi/browser';
 import type { Editor, EditorContext, EditorSnapshot } from './editor.svelte';
@@ -70,6 +71,14 @@ function sanitizeTypewriterPosition(position: number | undefined): number {
   return typeof position === 'number' && Number.isFinite(position) ? Math.max(0, Math.min(1, position)) : 0.5;
 }
 
+function prefersReducedMotion(): boolean {
+  return globalThis.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
+}
+
+export function isInstantReveal(request: Pick<EditorBringIntoViewRequest, 'behavior'> | null): boolean {
+  return request !== null && (request.behavior === 'instant' || (request.behavior === 'smooth' && prefersReducedMotion()));
+}
+
 function createBringIntoViewRequest({ target, policy, behavior = 'instant' }: EditorScrollIntoViewOptions): EditorBringIntoViewRequest {
   const { promise: presentation, resolve } = Promise.withResolvers<undefined>();
   return {
@@ -125,8 +134,9 @@ export class EditorScrollScope {
   #destroyed = false;
   #expectedScrollTop: number | null = null;
   #smoothRequest: EditorBringIntoViewRequest | null = null;
-  #smoothTargetY: number | null = null;
-  #smoothSettleTimer: ReturnType<typeof setTimeout> | null = null;
+  #smoothMotion: SmoothScrollMotion | null = null;
+  #smoothAnimationFrame: number | null = null;
+  #smoothAnimationTime: number | null = null;
   readonly #editor: Editor;
   readonly #typewriterPreferences: () => TypewriterPreferences;
   readonly #viewportAnchor = new EditorViewportAnchorState();
@@ -186,31 +196,30 @@ export class EditorScrollScope {
         return false;
       }
       case 'no_scroll': {
+        const smoothTarget = this.#smoothRequest === request ? this.#smoothMotion?.snapshot().target : undefined;
+        const scrollTop = this.#editor.scrollViewport?.getScrollTop();
+        if (smoothTarget !== undefined && scrollTop !== undefined && Math.abs(smoothTarget - scrollTop) <= 1) {
+          this.#finishSmoothReveal();
+          return true;
+        }
         this.#interruptSmoothReveal();
         const revealOrigin = this.#selectionRevealOrigin(request, this.#editor.scrollViewport?.getScrollTop());
         const presented = this.markPresented(snapshot.revision, request);
-        if (presented) this.#attachSelectionOrCenter(false, revealOrigin);
+        if (presented) this.#attachSelectionOrCenter(request.target.type !== 'current_selection_head', revealOrigin);
         return presented;
       }
       case 'scroll_to': {
         const viewport = this.#editor.scrollViewport;
         if (!viewport) return false;
-        if (request.behavior === 'smooth') {
-          if (this.#smoothRequest === request && this.#smoothTargetY !== null && Math.abs(this.#smoothTargetY - result.y) <= 1) {
-            return true;
-          }
-          this.#smoothRequest = request;
-          this.#smoothTargetY = result.y;
-          this.#attachViewportCenter();
-          viewport.scrollTo({ top: result.y, behavior: request.behavior });
-          this.#scheduleSmoothSettle();
-          return true;
+        if (!isInstantReveal(request)) {
+          return this.#applySmoothReveal(request, snapshot, result.y);
         }
+        this.#interruptSmoothReveal();
         const revealOrigin = this.#selectionRevealOrigin(request, viewport.getScrollTop());
-        viewport.scrollTo({ top: result.y, behavior: request.behavior });
-        this.#expectedScrollTop = result.y;
+        viewport.scrollTo({ top: result.y, behavior: 'instant' });
+        this.#expectedScrollTop = viewport.getScrollTop();
         const presented = this.markPresented(snapshot.revision, request);
-        if (presented) this.#attachSelectionOrCenter(false, revealOrigin);
+        if (presented) this.#attachSelectionOrCenter(request.target.type !== 'current_selection_head', revealOrigin);
         return presented;
       }
     }
@@ -218,7 +227,8 @@ export class EditorScrollScope {
 
   declare(options: EditorScrollIntoViewOptions): EditorBringIntoViewRequest {
     const request = createBringIntoViewRequest(options);
-    this.#interruptSmoothReveal();
+    if (options.behavior === 'smooth' && this.#smoothMotion) this.#pauseSmoothReveal();
+    else this.#interruptSmoothReveal();
     this.#pendingRequest?.completePresentation();
     this.#pendingRequest = request;
     this.#keepVisibleTarget = request.policy === 'pointer_cursor_guard' ? null : request.target;
@@ -249,7 +259,7 @@ export class EditorScrollScope {
 
   discard(request: EditorBringIntoViewRequest): void {
     if (this.#pendingRequest !== request) return;
-    if (this.#smoothRequest === request) this.#interruptSmoothReveal();
+    this.#interruptSmoothReveal();
     this.#pendingRequest = null;
     request.completePresentation();
     this.#editor.requestPublication();
@@ -276,75 +286,93 @@ export class EditorScrollScope {
   prepareViewportAnchorPublication(snapshot: EditorSnapshot): EditorViewportAnchorPublication {
     const viewport = this.#editor.scrollViewport;
     if (!viewport) return { type: 'ready', geometry: null, targetScrollTop: null };
-    if (this.#smoothRequest) this.#attachViewportCenter();
+    if (this.#smoothMotion) this.#attachViewportCenter();
     else this.#ensureViewportAnchor();
 
+    const metrics = this.#viewportMetrics(snapshot, true);
+    if (!metrics) return { type: 'unavailable' };
+    const clampedScrollTop = Math.max(0, Math.min(metrics.scrollTop, metrics.maximumScrollTop));
+    const fallbackPublication = (): EditorViewportAnchorPublication => ({
+      type: 'ready',
+      geometry: null,
+      targetScrollTop: clampedScrollTop === metrics.scrollTop ? null : clampedScrollTop,
+    });
+
     const identity = this.#viewportAnchor.identity;
-    if (!identity) return { type: 'ready', geometry: null, targetScrollTop: null };
+    if (!identity) return fallbackPublication();
     let resolution = this.#editor.resolveViewportAnchor(snapshot.revision, identity);
     if (resolution.type === 'unavailable') return { type: 'unavailable' };
     if (resolution.type === 'deleted' || resolution.type === 'not_laid_out') {
       this.#attachViewportCenter();
       const fallback = this.#viewportAnchor.identity;
-      if (!fallback) return { type: 'ready', geometry: null, targetScrollTop: null };
+      if (!fallback) return fallbackPublication();
       resolution = this.#editor.resolveViewportAnchor(snapshot.revision, fallback);
       if (resolution.type === 'unavailable') return { type: 'unavailable' };
       if (resolution.type === 'deleted' || resolution.type === 'not_laid_out') {
         this.#viewportAnchor.clear();
-        return { type: 'ready', geometry: null, targetScrollTop: null };
+        return fallbackPublication();
       }
     }
 
-    const metrics = this.#viewportMetrics(snapshot);
-    if (!metrics) return { type: 'unavailable' };
     const geometry = resolveViewportAnchorGeometry(resolution.geometry, metrics.layout);
     if (!geometry) return { type: 'unavailable' };
+    const targetScrollTop = this.#viewportAnchor.publicationRevealScroll(
+      geometry,
+      metrics.scrollTop,
+      metrics.clientHeight,
+      metrics.scrollHeight,
+      this.visibleArea,
+      (origin) => {
+        const rects = this.resolveTargetRects(origin.target, snapshot);
+        const target = rects && pageRectsToRevealTargetSpan(rects, metrics.layout.pages, metrics.layout.zoom);
+        if (!target) return null;
+        return (
+          this.resolveScrollTop(
+            origin,
+            {
+              scrollTop: origin.scrollTop,
+              clientHeight: metrics.clientHeight,
+              scrollHeight: metrics.scrollHeight,
+              ...target,
+            },
+            snapshot,
+          ) ?? origin.scrollTop
+        );
+      },
+    );
     return {
       type: 'ready',
       geometry,
-      targetScrollTop: this.#viewportAnchor.publicationRevealScroll(
-        geometry,
-        metrics.scrollTop,
-        metrics.clientHeight,
-        metrics.scrollHeight,
-        this.visibleArea,
-        (origin) => {
-          const rects = this.resolveTargetRects(origin.target, snapshot);
-          const target = rects && pageRectsToRevealTargetSpan(rects, metrics.layout.pages, metrics.layout.zoom);
-          if (!target) return null;
-          return (
-            this.resolveScrollTop(
-              origin,
-              {
-                scrollTop: origin.scrollTop,
-                clientHeight: metrics.clientHeight,
-                scrollHeight: metrics.scrollHeight,
-                ...target,
-              },
-              snapshot,
-            ) ?? origin.scrollTop
-          );
-        },
-      ),
+      targetScrollTop,
     };
   }
 
   applyViewportAnchorPublication(publication: EditorViewportAnchorPublication): void {
     if (publication.type !== 'ready') return;
-    if (!publication.geometry || publication.targetScrollTop === null) {
-      this.#ensureViewportAnchor();
+    const viewport = this.#editor.scrollViewport;
+    if (publication.targetScrollTop === null) {
+      if (viewport && publication.geometry) {
+        this.#viewportAnchor.acceptGeometry(publication.geometry, viewport.getScrollTop());
+      } else {
+        this.#ensureViewportAnchor();
+      }
       return;
     }
-    const viewport = this.#editor.scrollViewport;
     if (!viewport) return;
     const viewportRect = viewport.getRect();
     const clientHeight = viewportRect.bottom - viewportRect.top;
     const maximumScrollTop = Math.max(0, viewport.getScrollHeight() - clientHeight);
     const target = Math.max(0, Math.min(publication.targetScrollTop, maximumScrollTop));
-    if (Math.abs(viewport.getScrollTop() - target) > 1) {
-      if (this.#smoothRequest) this.#smoothTargetY = null;
-      this.#expectedScrollTop = target;
+    const previousScrollTop = viewport.getScrollTop();
+    if (Math.abs(previousScrollTop - target) > 1) {
       viewport.scrollTo({ top: target, behavior: 'instant' });
+      const actualScrollTop = viewport.getScrollTop();
+      this.#expectedScrollTop = actualScrollTop;
+      this.#smoothMotion?.translate(actualScrollTop - previousScrollTop);
+    }
+    if (!publication.geometry) {
+      this.#ensureViewportAnchor();
+      return;
     }
     this.#viewportAnchor.acceptGeometry(publication.geometry, viewport.getScrollTop());
   }
@@ -358,11 +386,7 @@ export class EditorScrollScope {
       return;
     }
     this.#expectedScrollTop = null;
-    if (this.#smoothRequest) {
-      this.#attachViewportCenter();
-      this.#scheduleSmoothSettle();
-      return;
-    }
+    if (this.#smoothMotion) this.cancel();
     this.#viewportAnchor.finishRevealConvergence();
 
     const metrics = this.#viewportMetrics(this.#editor.published?.snapshot);
@@ -388,7 +412,14 @@ export class EditorScrollScope {
   }
 
   reconcileViewportResize(): void {
-    if (this.#smoothRequest) {
+    if (this.#smoothMotion) {
+      const viewport = this.#editor.scrollViewport;
+      const rect = viewport?.getRect();
+      const viewportHeight = rect ? rect.bottom - rect.top : 0;
+      if (viewportHeight > 0) {
+        const target = this.#smoothMotion.snapshot().target;
+        this.#smoothMotion.retarget(target, viewportHeight);
+      }
       this.#attachViewportCenter();
       return;
     }
@@ -409,18 +440,6 @@ export class EditorScrollScope {
     this.#expectedScrollTop = target;
     this.#editor.scrollViewport?.scrollTo({ top: target, behavior: 'instant' });
     this.#viewportAnchor.acceptGeometry(geometry, target);
-  }
-
-  settleSmoothReveal(): void {
-    const request = this.#smoothRequest;
-    if (!request) return;
-    const target = this.#smoothTargetY;
-    const scrollTop = this.#editor.scrollViewport?.getScrollTop();
-    if (target === null || scrollTop === undefined || Math.abs(scrollTop - target) > 1) return;
-    this.#clearSmoothReveal();
-    if (this.markPresented(this.#editor.publishedRevision ?? this.#editor.appliedRevision, request)) {
-      this.#attachSelectionOrCenter(false);
-    }
   }
 
   resolveScrollTop(
@@ -459,7 +478,7 @@ export class EditorScrollScope {
     metrics: ScrollContainerMetrics & RevealTargetSpan,
     snapshot: EditorSnapshot,
   ): VerticalSpan[] {
-    if (request.behavior !== 'instant') return [];
+    if (!isInstantReveal(request)) return [];
     const policy = this.#resolvePolicy(request, snapshot);
     return resolveInstantRevealPreparationViewports({
       ...metrics,
@@ -630,7 +649,10 @@ export class EditorScrollScope {
     return metrics ? resolveViewportAnchorGeometry(resolution.geometry, metrics.layout) : null;
   }
 
-  #viewportMetrics(snapshot: EditorSnapshot | undefined): {
+  #viewportMetrics(
+    snapshot: EditorSnapshot | undefined,
+    candidateExtent = false,
+  ): {
     layout: EditorViewportAnchorLayout;
     scrollTop: number;
     clientHeight: number;
@@ -654,7 +676,9 @@ export class EditorScrollScope {
       pageGap: snapshot.rootAttrs?.layout_mode.type === 'paginated' ? PAGE_GAP * zoom : 0,
     });
     const predictedExtent = pages.at(-1)?.bottom ?? origin;
-    const scrollHeight = Math.max(viewport.getScrollHeight(), predictedExtent + this.bottomPaddingFor(snapshot), clientHeight);
+    const candidateScrollHeight = Math.max(predictedExtent + this.bottomPaddingFor(snapshot), clientHeight);
+    const scrollHeight =
+      candidateExtent && this.#editor.scrollRootEl ? candidateScrollHeight : Math.max(viewport.getScrollHeight(), candidateScrollHeight);
     return {
       layout: { pages, zoom },
       scrollTop,
@@ -664,29 +688,116 @@ export class EditorScrollScope {
     };
   }
 
-  #scheduleSmoothSettle(): void {
-    if (this.#smoothSettleTimer !== null) clearTimeout(this.#smoothSettleTimer);
-    this.#smoothSettleTimer = setTimeout(() => this.settleSmoothReveal(), 120);
+  #applySmoothReveal(request: EditorBringIntoViewRequest, snapshot: EditorSnapshot, target: number): boolean {
+    const viewport = this.#editor.scrollViewport;
+    const metrics = this.#viewportMetrics(snapshot);
+    if (!viewport || !metrics) return false;
+    const clampedTarget = Math.max(0, Math.min(target, metrics.maximumScrollTop));
+    const previous = this.#smoothMotion?.snapshot();
+    const direction = Math.sign(clampedTarget - metrics.scrollTop);
+    const previousDirection = previous ? Math.sign(previous.target - previous.position) : 0;
+    if (this.#smoothRequest === request && previous?.target === clampedTarget) {
+      if (this.#smoothMotion?.finished) this.#finishSmoothReveal();
+      else this.#scheduleSmoothAnimationFrame();
+      return true;
+    }
+    if (
+      !this.#smoothMotion ||
+      (direction !== 0 && previousDirection !== 0 && direction !== previousDirection && this.#smoothRequest !== request)
+    ) {
+      this.#smoothMotion = SmoothScrollMotion.start({
+        position: metrics.scrollTop,
+        target: clampedTarget,
+        viewportHeight: metrics.clientHeight,
+      });
+    } else {
+      this.#smoothMotion.synchronizeBounds(metrics.scrollTop, metrics.maximumScrollTop, metrics.clientHeight);
+      this.#smoothMotion.retarget(clampedTarget, metrics.clientHeight);
+    }
+    this.#smoothRequest = request;
+    this.#attachViewportCenter();
+    if (this.#smoothMotion.finished) {
+      this.#finishSmoothReveal();
+    } else {
+      this.#scheduleSmoothAnimationFrame();
+    }
+    return true;
+  }
+
+  #scheduleSmoothAnimationFrame(): void {
+    if (this.#smoothAnimationFrame !== null) return;
+    this.#smoothAnimationFrame = requestAnimationFrame((time) => this.#advanceSmoothReveal(time));
+  }
+
+  #advanceSmoothReveal(time: number): void {
+    this.#smoothAnimationFrame = null;
+    const request = this.#smoothRequest;
+    const motion = this.#smoothMotion;
+    const viewport = this.#editor.scrollViewport;
+    if (!request || !motion || !viewport) return;
+    const previousTime = this.#smoothAnimationTime;
+    this.#smoothAnimationTime = time;
+    if (previousTime === null) {
+      this.#scheduleSmoothAnimationFrame();
+      return;
+    }
+
+    const rect = viewport.getRect();
+    const viewportHeight = rect.bottom - rect.top;
+    const maximumScrollTop = Math.max(0, viewport.getScrollHeight() - viewportHeight);
+    const current = viewport.getScrollTop();
+    const snapshot = motion.snapshot();
+    if (Math.abs(current - snapshot.position) > 1 || snapshot.target < 0 || snapshot.target > maximumScrollTop) {
+      motion.synchronizeBounds(current, maximumScrollTop, viewportHeight);
+    }
+    const next = motion.advance((time - previousTime) / 1000);
+    this.#expectedScrollTop = next.position;
+    viewport.scrollTo({ top: next.position, behavior: 'instant' });
+    const actual = viewport.getScrollTop();
+    if (Math.abs(actual - next.position) > 1) {
+      this.#expectedScrollTop = actual;
+      motion.synchronizeBounds(actual, maximumScrollTop, viewportHeight);
+    }
+    if (motion.finished) this.#finishSmoothReveal();
+    else this.#scheduleSmoothAnimationFrame();
+  }
+
+  #finishSmoothReveal(): void {
+    const request = this.#smoothRequest;
+    const motion = this.#smoothMotion;
+    const viewport = this.#editor.scrollViewport;
+    if (!request || !motion || !viewport) return;
+    const target = motion.snapshot().target;
+    if (Math.abs(viewport.getScrollTop() - target) > 0.5) {
+      viewport.scrollTo({ top: target, behavior: 'instant' });
+      this.#expectedScrollTop = viewport.getScrollTop();
+    }
+    const publicationCurrent = this.#editor.published?.snapshot === this.#editor.appliedSnapshot;
+    if (!publicationCurrent) {
+      this.#smoothAnimationTime = null;
+      this.#editor.requestPublication();
+      return;
+    }
+    this.#clearSmoothReveal();
+    if (this.markPresented(this.#editor.publishedRevision ?? this.#editor.appliedRevision, request)) {
+      this.#attachSelectionOrCenter(request.target.type !== 'current_selection_head');
+    }
+  }
+
+  #pauseSmoothReveal(): void {
+    if (this.#smoothAnimationFrame !== null) cancelAnimationFrame(this.#smoothAnimationFrame);
+    this.#smoothAnimationFrame = null;
+    this.#smoothAnimationTime = null;
+    this.#smoothRequest = null;
   }
 
   #clearSmoothReveal(): void {
-    if (this.#smoothSettleTimer !== null) clearTimeout(this.#smoothSettleTimer);
-    this.#smoothSettleTimer = null;
-    this.#smoothRequest = null;
-    this.#smoothTargetY = null;
+    this.#pauseSmoothReveal();
+    this.#smoothMotion = null;
   }
 
   #interruptSmoothReveal(): void {
-    if (!this.#smoothRequest) {
-      this.#clearSmoothReveal();
-      return;
-    }
-    const viewport = this.#editor.scrollViewport;
-    const scrollTop = viewport?.getScrollTop();
-    if (viewport && scrollTop !== undefined && Number.isFinite(scrollTop)) {
-      this.#expectedScrollTop = scrollTop;
-      viewport.scrollTo({ top: scrollTop, behavior: 'instant' });
-    }
+    this.#smoothMotion?.cancel();
     this.#clearSmoothReveal();
   }
 }

--- a/apps/website/src/lib/editor-ffi/smooth-scroll-motion.test.ts
+++ b/apps/website/src/lib/editor-ffi/smooth-scroll-motion.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import { SmoothScrollMotion } from './smooth-scroll-motion';
+
+describe('SmoothScrollMotion', () => {
+  it('translates the coordinate system without changing velocity or remaining distance', () => {
+    const motion = SmoothScrollMotion.start({ position: 100, target: 500, viewportHeight: 400 });
+    motion.advance(1 / 60);
+    const before = motion.snapshot();
+
+    motion.translate(700);
+
+    const after = motion.snapshot();
+    expect(after.position).toBeCloseTo(before.position + 700, 10);
+    expect(after.target).toBeCloseTo(before.target + 700, 10);
+    expect(after.velocity).toBeCloseTo(before.velocity, 10);
+    expect(after.target - after.position).toBeCloseTo(before.target - before.position, 10);
+  });
+
+  it('produces the same state for equal elapsed time across frame rates', () => {
+    const at60Hz = SmoothScrollMotion.start({ position: 0, target: 1600, viewportHeight: 400 });
+    const at120Hz = SmoothScrollMotion.start({ position: 0, target: 1600, viewportHeight: 400 });
+
+    repeat(30, () => at60Hz.advance(1 / 60));
+    repeat(60, () => at120Hz.advance(1 / 120));
+
+    expect(at60Hz.snapshot().position).toBeCloseTo(at120Hz.snapshot().position, 8);
+    expect(at60Hz.snapshot().velocity).toBeCloseTo(at120Hz.snapshot().velocity, 8);
+  });
+
+  it('matches the cross-host retarget and translation vector', () => {
+    const motion = SmoothScrollMotion.start({ position: 0, target: 1600, viewportHeight: 400 });
+    motion.advance(0.05);
+    motion.advance(0.05);
+    motion.translate(700);
+    motion.retarget(2100, 400);
+    motion.advance(0.05);
+
+    expect(motion.snapshot().position).toBeCloseTo(1809.7452631440876, 8);
+    expect(motion.snapshot().velocity).toBeCloseTo(4556.356253653357, 8);
+    expect(motion.snapshot().target).toBe(2100);
+  });
+
+  it('takes longer and reaches a higher speed for a farther destination', () => {
+    const short = runToCompletion(SmoothScrollMotion.start({ position: 0, target: 100, viewportHeight: 400 }));
+    const long = runToCompletion(SmoothScrollMotion.start({ position: 0, target: 1600, viewportHeight: 400 }));
+
+    expect(long.elapsed).toBeGreaterThan(short.elapsed);
+    expect(long.elapsed).toBeLessThan(short.elapsed * 4);
+    expect(long.peakVelocity).toBeGreaterThan(short.peakVelocity);
+  });
+
+  it('retargets without changing the current position or velocity', () => {
+    const motion = SmoothScrollMotion.start({ position: 0, target: 800, viewportHeight: 400 });
+    repeat(8, () => motion.advance(1 / 60));
+    const before = motion.snapshot();
+
+    motion.retarget(1200, 400);
+
+    expect(motion.snapshot().position).toBe(before.position);
+    expect(motion.snapshot().velocity).toBe(before.velocity);
+    expect(motion.snapshot().target).toBe(1200);
+  });
+
+  it('finishes at a target within the position threshold even with remaining velocity', () => {
+    const motion = SmoothScrollMotion.start({ position: 0, target: 800, viewportHeight: 400 });
+    repeat(8, () => motion.advance(1 / 60));
+    const current = motion.snapshot().position;
+
+    motion.retarget(current + 0.25, 400);
+
+    expect(motion.finished).toBe(true);
+    expect(motion.snapshot()).toEqual({ position: current + 0.25, velocity: 0, target: current + 0.25 });
+  });
+
+  it('preserves velocity while preventing a high-speed closer retarget from overshooting', () => {
+    const motion = SmoothScrollMotion.start({ position: 0, target: 1600, viewportHeight: 400 });
+    repeat(12, () => motion.advance(1 / 60));
+    const before = motion.snapshot();
+    const closerTarget = before.position + 80;
+
+    motion.retarget(closerTarget, 400);
+    expect(motion.snapshot().velocity).toBe(before.velocity);
+
+    while (!motion.finished) {
+      expect(motion.advance(1 / 120).position).toBeLessThanOrEqual(closerTarget);
+    }
+    expect(motion.snapshot()).toEqual({ position: closerTarget, velocity: 0, target: closerTarget });
+  });
+
+  it('synchronizes host-clamped bounds and removes only outward velocity', () => {
+    const motion = SmoothScrollMotion.start({ position: 0, target: 1600, viewportHeight: 400 });
+    repeat(6, () => motion.advance(1 / 60));
+
+    motion.synchronizeBounds(600, 600, 400);
+
+    expect(motion.snapshot()).toEqual({ position: 600, velocity: 0, target: 600 });
+    expect(motion.finished).toBe(true);
+  });
+
+  it('catches up to the full elapsed time after a delayed frame', () => {
+    const delayed = SmoothScrollMotion.start({ position: 0, target: 800, viewportHeight: 400 });
+    const uninterrupted = SmoothScrollMotion.start({ position: 0, target: 800, viewportHeight: 400 });
+
+    delayed.advance(0.25);
+    repeat(15, () => uninterrupted.advance(1 / 60));
+
+    expect(delayed.snapshot().position).toBeCloseTo(uninterrupted.snapshot().position, 8);
+    expect(delayed.snapshot().velocity).toBeCloseTo(uninterrupted.snapshot().velocity, 8);
+  });
+});
+
+function repeat(count: number, block: () => void): void {
+  for (let index = 0; index < count; index += 1) block();
+}
+
+function runToCompletion(motion: SmoothScrollMotion): { elapsed: number; peakVelocity: number } {
+  let elapsed = 0;
+  let peakVelocity = 0;
+  while (!motion.finished && elapsed < 5) {
+    const state = motion.advance(1 / 120);
+    elapsed += 1 / 120;
+    peakVelocity = Math.max(peakVelocity, Math.abs(state.velocity));
+  }
+  expect(motion.finished).toBe(true);
+  return { elapsed, peakVelocity };
+}

--- a/apps/website/src/lib/editor-ffi/smooth-scroll-motion.ts
+++ b/apps/website/src/lib/editor-ffi/smooth-scroll-motion.ts
@@ -1,0 +1,116 @@
+const MIN_SETTLE_SECONDS = 0.18;
+const DISTANCE_SETTLE_SECONDS = 0.11;
+const MAX_SETTLE_SECONDS = 0.65;
+const ONE_PERCENT_RESPONSE = 6.64;
+const POSITION_THRESHOLD = 0.5;
+const VELOCITY_THRESHOLD = 5;
+
+export type SmoothScrollMotionSnapshot = {
+  position: number;
+  velocity: number;
+  target: number;
+};
+
+type SmoothScrollMotionStart = {
+  position: number;
+  target: number;
+  viewportHeight: number;
+};
+
+export class SmoothScrollMotion {
+  static start({ position, target, viewportHeight }: SmoothScrollMotionStart): SmoothScrollMotion {
+    return new SmoothScrollMotion(position, target, viewportHeight);
+  }
+
+  #position: number;
+  #velocity = 0;
+  #target: number;
+  #omega: number;
+  #finished = false;
+
+  private constructor(position: number, target: number, viewportHeight: number) {
+    this.#position = position;
+    this.#target = target;
+    this.#omega = responseRate(position, target, viewportHeight);
+    this.#finishIfArrived();
+  }
+
+  #finishIfArrived(): void {
+    if (Math.abs(this.#target - this.#position) <= POSITION_THRESHOLD && Math.abs(this.#velocity) <= VELOCITY_THRESHOLD) {
+      this.#finish();
+    }
+  }
+
+  #finish(): void {
+    this.#position = this.#target;
+    this.#velocity = 0;
+    this.#finished = true;
+  }
+
+  get finished(): boolean {
+    return this.#finished;
+  }
+
+  advance(deltaSeconds: number): SmoothScrollMotionSnapshot {
+    if (this.#finished || !Number.isFinite(deltaSeconds) || deltaSeconds <= 0) {
+      return this.snapshot();
+    }
+    const previousRemaining = this.#target - this.#position;
+    const error = this.#position - this.#target;
+    const b = this.#velocity + this.#omega * error;
+    const decay = Math.exp(-this.#omega * deltaSeconds);
+    this.#position = this.#target + (error + b * deltaSeconds) * decay;
+    this.#velocity = (this.#velocity - this.#omega * b * deltaSeconds) * decay;
+    if (previousRemaining * (this.#target - this.#position) < 0) {
+      this.#finish();
+    } else {
+      this.#finishIfArrived();
+    }
+    return this.snapshot();
+  }
+
+  retarget(target: number, viewportHeight: number): void {
+    if (!Number.isFinite(target)) return;
+    this.#target = target;
+    if (Math.abs(this.#target - this.#position) <= POSITION_THRESHOLD) {
+      this.#finish();
+      return;
+    }
+    this.#finished = false;
+    const remaining = this.#target - this.#position;
+    const towardVelocity = this.#velocity * Math.sign(remaining);
+    this.#omega = Math.max(responseRate(this.#position, this.#target, viewportHeight), Math.max(0, towardVelocity) / Math.abs(remaining));
+  }
+
+  translate(delta: number): void {
+    if (!Number.isFinite(delta)) return;
+    this.#position += delta;
+    this.#target += delta;
+  }
+
+  synchronizeBounds(actualPosition: number, maximumScroll: number, viewportHeight: number): void {
+    if (!Number.isFinite(actualPosition) || !Number.isFinite(maximumScroll)) return;
+    const maximum = Math.max(0, maximumScroll);
+    this.#position = Math.max(0, Math.min(actualPosition, maximum));
+    this.#target = Math.max(0, Math.min(this.#target, maximum));
+    if ((this.#position <= 0 && this.#velocity < 0) || (this.#position >= maximum && this.#velocity > 0)) {
+      this.#velocity = 0;
+    }
+    this.retarget(this.#target, viewportHeight);
+  }
+
+  cancel(): void {
+    this.#target = this.#position;
+    this.#finish();
+  }
+
+  snapshot(): SmoothScrollMotionSnapshot {
+    return { position: this.#position, velocity: this.#velocity, target: this.#target };
+  }
+}
+
+function responseRate(position: number, target: number, viewportHeight: number): number {
+  const distance = Math.abs(target - position) / Math.max(1, viewportHeight);
+  const settleSeconds = Math.min(MAX_SETTLE_SECONDS, MIN_SETTLE_SECONDS + DISTANCE_SETTLE_SECONDS * Math.sqrt(distance));
+  return ONE_PERCENT_RESPONSE / settleSeconds;
+}


### PR DESCRIPTION
- Web/App smooth reveal을 동일한 거리 기반 custom animator로 구현
- layout/publication 변화 시 현재 속도를 유지하면서 목적지와 scroll bounds를 갱신
- request lifecycle과 viewport anchor를 연결해 취소·교체·완료 상태를 정확히 반영
- comment reveal은 tracked item의 최신 geometry를 사용하도록 변경
- remote edit, 페이지 추가, external height 갱신 중에도 스크롤이 중단되거나 잘못된 위치에서 끝나지 않도록 개선
- 문서 축소, window scroll, reduced motion과 non-selection reveal 경계 처리 보강

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>