### PR TITLE
문서 화면 진입 시 키보드 종료 동기화를 개선함

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -1315,6 +1315,7 @@ fun EditorScreen(entityId: String) {
                     var delivered = false
                     try {
                       DocumentCharacterCountSnapshots.put(entityId, activeEditor?.characterCounts())
+                      keyboardController?.hide()
                       screenState.prepareToLeaveEditorScene(
                         runtime = runtime,
                         uiState = uiState,

--- a/apps/mobile/compose/src/iosMain/kotlin/co/typie/ext/ImeInsets.ios.kt
+++ b/apps/mobile/compose/src/iosMain/kotlin/co/typie/ext/ImeInsets.ios.kt
@@ -76,6 +76,7 @@ internal actual fun rememberTrustedImeInsets(): WindowInsets {
         queue = NSOperationQueue.mainQueue,
       ) {
         settledImeBottom = null
+        presentationImeBottom = null
       }
     val didHideObserver =
       center.addObserverForName(

--- a/apps/mobile/compose/src/iosTest/kotlin/co/typie/ext/ImeInsetsIosTest.kt
+++ b/apps/mobile/compose/src/iosTest/kotlin/co/typie/ext/ImeInsetsIosTest.kt
@@ -1,0 +1,75 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+package co.typie.ext
+
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.runtime.AbstractApplier
+import androidx.compose.runtime.Composition
+import androidx.compose.runtime.Recomposer
+import androidx.compose.ui.unit.Density
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.cinterop.useContents
+import kotlinx.coroutines.test.runTest
+import platform.CoreGraphics.CGRectMake
+import platform.Foundation.NSNotificationCenter
+import platform.Foundation.NSValue
+import platform.UIKit.UIKeyboardFrameEndUserInfoKey
+import platform.UIKit.UIKeyboardWillChangeFrameNotification
+import platform.UIKit.UIKeyboardWillHideNotification
+import platform.UIKit.UIScreen
+import platform.UIKit.valueWithCGRect
+import swiftPMImport.co.typie.compose.SoftwareKeyboardPresentationBridge
+
+class ImeInsetsIosTest {
+  @Test
+  fun keyboardWillHideClearsPresentationFrameOverride() = runTest {
+    var insets: WindowInsets? = null
+    val composition = Composition(UnitApplier(), Recomposer(coroutineContext))
+    try {
+      composition.setContent { insets = rememberTrustedImeInsets() }
+
+      val (screenWidth, screenHeight) =
+        UIScreen.mainScreen.bounds.useContents { size.width to size.height }
+      val keyboardHeight = 200.0
+      val keyboardFrame =
+        CGRectMake(
+          x = 0.0,
+          y = screenHeight - keyboardHeight,
+          width = screenWidth,
+          height = keyboardHeight,
+        )
+      val center = NSNotificationCenter.defaultCenter
+      val bridge = SoftwareKeyboardPresentationBridge()
+      center.postNotificationName(
+        aName = UIKeyboardWillChangeFrameNotification,
+        `object` = bridge,
+        userInfo = mapOf(UIKeyboardFrameEndUserInfoKey to NSValue.valueWithCGRect(keyboardFrame)),
+      )
+
+      assertEquals(200, requireNotNull(insets).getBottom(Density(1f)))
+
+      center.postNotificationName(
+        aName = UIKeyboardWillHideNotification,
+        `object` = null,
+        userInfo = null,
+      )
+
+      assertEquals(0, requireNotNull(insets).getBottom(Density(1f)))
+    } finally {
+      composition.dispose()
+    }
+  }
+}
+
+private class UnitApplier : AbstractApplier<Unit>(Unit) {
+  override fun insertBottomUp(index: Int, instance: Unit) = Unit
+
+  override fun insertTopDown(index: Int, instance: Unit) = Unit
+
+  override fun move(from: Int, to: Int, count: Int) = Unit
+
+  override fun onClear() = Unit
+
+  override fun remove(index: Int, count: Int) = Unit
+}


### PR DESCRIPTION
에디터에서 DocumentScreen으로 이동할 때 키보드는 닫히는데 툴바가 제자리에 떠있는 것처럼 보이는 현상을 개선

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>