### PR TITLE
갭 커서 첫 입력 누락 수정

### DIFF
--- a/crates/editor-core/src/editor.rs
+++ b/crates/editor-core/src/editor.rs
@@ -835,9 +835,18 @@ impl Editor {
             })?
             .to_flat();
         let (sel_start, sel_end) = (anchor_flat.min(head_flat), anchor_flat.max(head_flat));
+        // Text input materializes a gap before replaying IME ops, so the host
+        // must receive the gap's real offset instead of an adjacent text offset.
+        let collapsed_insertable =
+            sel_start == sel_end && is_flat_offset_insertable(&doc, sel_start);
+        let at_gap_cursor = !collapsed_insertable
+            && sel.is_collapsed()
+            && editor_state::gap_cursor_at(&sel.head, &doc).is_some();
         // ime() runs on every cursor move; the collapsed caret is the dominant
         // case, so avoid walking the same offset twice.
-        let (sel_start, sel_end) = if sel_start == sel_end {
+        let (sel_start, sel_end) = if collapsed_insertable || at_gap_cursor {
+            (sel_start, sel_end)
+        } else if sel_start == sel_end {
             let s = nearest_insertable_flat(&doc, doc_size, sel_start);
             (s, s)
         } else {
@@ -3609,6 +3618,95 @@ mod tests {
         assert_eq!(ctx.text, "\u{2028}hello world\u{2029}");
         assert_eq!(ctx.selection.start, 3);
         assert_eq!(ctx.selection.end, 9);
+    }
+
+    #[test]
+    fn input_context_preserves_leading_gap_cursor_offset() {
+        let (state, ..) = state! {
+            doc { r: root { image paragraph { text("b") } } }
+            selection: (r, 0, <)
+        };
+        let mut editor = Editor::new_test(state);
+
+        let ctx = editor.ime(usize::MAX, usize::MAX).unwrap().unwrap();
+
+        assert_eq!(ctx.selection.start, 0);
+        assert_eq!(ctx.selection.end, 0);
+    }
+
+    #[test]
+    fn input_context_preserves_between_monolithic_gap_cursor_offset() {
+        let (state, ..) = state! {
+            doc { r: root {
+                fold { fold_title { text("A") } fold_content { paragraph { text("x") } } }
+                fold { fold_title { text("B") } fold_content { paragraph { text("y") } } }
+                paragraph {}
+            } }
+            selection: (r, 1)
+        };
+        let mut editor = Editor::new_test(state);
+
+        let ctx = editor.ime(usize::MAX, usize::MAX).unwrap().unwrap();
+
+        assert_eq!(ctx.selection.start, 10);
+        assert_eq!(ctx.selection.end, 10);
+    }
+
+    #[test]
+    fn web_text_input_from_reported_leading_gap_materializes_and_inserts() {
+        let (state, ..) = state! {
+            doc { r: root { image paragraph { text("b") } } }
+            selection: (r, 0, <)
+        };
+        let mut editor = Editor::new_test(state);
+        let ctx = editor.ime(usize::MAX, usize::MAX).unwrap().unwrap();
+
+        editor.apply(Message::TextInput {
+            ops: vec![
+                FlatImeOp::SetSelection {
+                    start: ctx.selection.start,
+                    end: ctx.selection.end,
+                },
+                FlatImeOp::ReplaceSelection { text: "a".into() },
+            ],
+        });
+
+        let (expected, ..) = state! {
+            doc { root { p1: paragraph { text("a") } image paragraph { text("b") } } }
+            selection: (p1, 1)
+        };
+        editor_state::assert_state_eq!(editor.state(), &expected);
+        assert_eq!(editor.state().composition, None);
+    }
+
+    #[test]
+    fn web_composition_from_reported_leading_gap_materializes_and_composes() {
+        let (state, ..) = state! {
+            doc { r: root { image paragraph { text("b") } } }
+            selection: (r, 0, <)
+        };
+        let mut editor = Editor::new_test(state);
+        let ctx = editor.ime(usize::MAX, usize::MAX).unwrap().unwrap();
+
+        editor.apply(Message::TextInput {
+            ops: vec![
+                FlatImeOp::SetComposition {
+                    start: ctx.selection.start,
+                    end: ctx.selection.end,
+                },
+                FlatImeOp::Compose { text: "ㅎ".into() },
+            ],
+        });
+
+        let (expected, ..) = state! {
+            doc { root { p1: paragraph { text("ㅎ") } image paragraph { text("b") } } }
+            selection: (p1, 1)
+        };
+        editor_state::assert_state_eq!(editor.state(), &expected);
+        assert_eq!(
+            editor.state().composition,
+            Some(Composition { start: 1, end: 2 })
+        );
     }
 
     #[test]

--- a/crates/editor-core/src/handle/key.rs
+++ b/crates/editor-core/src/handle/key.rs
@@ -350,6 +350,23 @@ mod tests {
     }
 
     #[test]
+    fn enter_at_leading_gap_materializes_without_splitting() {
+        let (state, ..) = state! {
+            doc { r: root { image paragraph { text("b") } } }
+            selection: (r, 0, <)
+        };
+        let mut editor = Editor::new_test(state);
+
+        editor.apply(key(Key::Enter));
+
+        let (expected, ..) = state! {
+            doc { root { p1: paragraph {} image paragraph { text("b") } } }
+            selection: (p1, 0)
+        };
+        assert_state_eq!(editor.state(), &expected);
+    }
+
+    #[test]
     fn enter_in_empty_blockquote_after_image_before_text_paragraph() {
         let (state, ..) = state! {
             doc {


### PR DESCRIPTION
- `Editor::ime()`가 갭 커서를 인접 textblock 위치로 보정하지 않고 실제 flat offset을 전달하도록 수정했습니다.
- 웹에서 반환된 offset으로 첫 입력을 보내도 materialize된 문단의 caret으로 올바르게 remap되어, 첫 글자와 조합 입력이 누락되지 않습니다.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>