### PR TITLE
웹 맞춤법 검사/코멘트 오버레이 타겟이 너무 클 때 뷰포트 가운데로 폴백

### DIFF
--- a/apps/website/src/lib/floating-centered-fallback.browser.test.ts
+++ b/apps/website/src/lib/floating-centered-fallback.browser.test.ts
@@ -1,0 +1,96 @@
+import { computePosition, flip, hide, inline, offset, shift } from '@floating-ui/dom';
+import { createCenterWhenReferenceDoesNotFitMiddleware } from '@typie/ui/actions';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const GAP = 6;
+const PADDING = 8;
+
+const mounted: HTMLElement[] = [];
+
+afterEach(() => {
+  for (const element of mounted) element.remove();
+  mounted.length = 0;
+});
+
+describe('createCenterWhenReferenceDoesNotFitMiddleware', () => {
+  it('centers from the complete multi-rect anchor after inline placement resets', async () => {
+    const popoverHeight = Math.floor(window.innerHeight / 3);
+    const floating = document.createElement('div');
+    Object.assign(floating.style, { position: 'absolute', width: '280px', height: `${popoverHeight}px` });
+    document.body.append(floating);
+    mounted.push(floating);
+
+    const edgeSpace = Math.floor(popoverHeight / 3);
+    const first = new DOMRect(100, edgeSpace, 100, 20);
+    const last = new DOMRect(100, window.innerHeight - edgeSpace - 20, 200, 20);
+    const reference = {
+      getBoundingClientRect: () => new DOMRect(100, first.top, 200, last.bottom - first.top),
+      getClientRects: () => [first, last],
+    };
+    const requiredSideSpace = popoverHeight + GAP;
+
+    expect(first.top - 8).toBeLessThan(requiredSideSpace);
+    expect(window.innerHeight - 8 - last.bottom).toBeLessThan(requiredSideSpace);
+    expect(last.top - 8).toBeGreaterThanOrEqual(requiredSideSpace);
+    const centeredFallback = createCenterWhenReferenceDoesNotFitMiddleware({ gap: GAP, overflow: { padding: PADDING } });
+
+    const position = await computePosition(reference, floating, {
+      placement: 'right-start',
+      middleware: [
+        offset(GAP),
+        centeredFallback.captureReferenceBounds,
+        inline(),
+        flip(),
+        shift({ padding: PADDING }),
+        centeredFallback.centerWhenNeitherSideFits,
+        hide(),
+      ],
+    });
+
+    expect(position.x).toBeCloseTo((window.innerWidth - 280) / 2);
+    expect(position.y).toBeCloseTo((window.innerHeight - popoverHeight) / 2);
+  });
+
+  it('centers within the configured clipping boundary', async () => {
+    const boundary = document.createElement('div');
+    Object.assign(boundary.style, {
+      position: 'fixed',
+      left: '40px',
+      top: '40px',
+      width: '300px',
+      height: '500px',
+      overflow: 'hidden',
+    });
+    document.body.append(boundary);
+    mounted.push(boundary);
+    const boundaryRect = boundary.getBoundingClientRect();
+
+    const floating = document.createElement('div');
+    Object.assign(floating.style, { position: 'absolute', width: '280px', height: '240px' });
+    document.body.append(floating);
+    mounted.push(floating);
+
+    const first = new DOMRect(100, 100, 100, 20);
+    const last = new DOMRect(100, 460, 200, 20);
+    const reference = {
+      getBoundingClientRect: () => new DOMRect(100, first.top, 200, last.bottom - first.top),
+      getClientRects: () => [first, last],
+    };
+    const centeredFallback = createCenterWhenReferenceDoesNotFitMiddleware({ gap: 4, overflow: { boundary, padding: PADDING } });
+    const position = await computePosition(reference, floating, {
+      placement: 'right-start',
+      middleware: [
+        offset(4),
+        centeredFallback.captureReferenceBounds,
+        inline(),
+        flip({ boundary, padding: PADDING }),
+        shift({ boundary, padding: PADDING }),
+        centeredFallback.centerWhenNeitherSideFits,
+        hide({ boundary }),
+      ],
+    });
+
+    expect(position.x).toBeCloseTo(boundaryRect.left + (boundaryRect.width - 280) / 2);
+    expect(position.y).toBeCloseTo(boundaryRect.top + (boundaryRect.height - 240) / 2);
+  });
+});

--- a/apps/website/src/lib/floating-centered-fallback.test.ts
+++ b/apps/website/src/lib/floating-centered-fallback.test.ts
@@ -1,0 +1,62 @@
+import { resolveFloatingCenteredFallback } from '@typie/ui/actions';
+import { describe, expect, it } from 'vitest';
+
+const popover = { width: 280, height: 240 };
+const viewport = { x: 8, y: 8, width: 984, height: 784 };
+
+describe('resolveFloatingCenteredFallback', () => {
+  it('keeps normal placement when only the space above fits', () => {
+    expect(
+      resolveFloatingCenteredFallback({
+        reference: { x: 100, y: 600, width: 200, height: 40 },
+        floating: popover,
+        clippingRect: viewport,
+        gap: 6,
+      }),
+    ).toBeNull();
+  });
+
+  it('keeps normal placement when only the space below fits', () => {
+    expect(
+      resolveFloatingCenteredFallback({
+        reference: { x: 100, y: 80, width: 200, height: 40 },
+        floating: popover,
+        clippingRect: viewport,
+        gap: 6,
+      }),
+    ).toBeNull();
+  });
+
+  it('does not override the existing below-first choice when both sides fit', () => {
+    expect(
+      resolveFloatingCenteredFallback({
+        reference: { x: 100, y: 350, width: 200, height: 40 },
+        floating: popover,
+        clippingRect: viewport,
+        gap: 6,
+      }),
+    ).toBeNull();
+  });
+
+  it('centers in the padded viewport when neither side fits', () => {
+    expect(
+      resolveFloatingCenteredFallback({
+        reference: { x: 100, y: 200, width: 200, height: 400 },
+        floating: popover,
+        clippingRect: viewport,
+        gap: 6,
+      }),
+    ).toEqual({ x: 360, y: 280 });
+  });
+
+  it('uses the provided padded viewport bounds for the centered fallback', () => {
+    expect(
+      resolveFloatingCenteredFallback({
+        reference: { x: 200, y: 180, width: 200, height: 340 },
+        floating: popover,
+        clippingRect: { x: 108, y: 48, width: 784, height: 604 },
+        gap: 6,
+      }),
+    ).toEqual({ x: 360, y: 230 });
+  });
+});

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-comments/CommentPopover.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-comments/CommentPopover.svelte
@@ -48,6 +48,7 @@
   const open = $derived(comments.composing || comments.activeThreadId !== null);
   const thread = $derived(threadFragment.data);
   const anchor = $derived(comments.activeAnchor);
+  const surface = $derived(editor?.scrollContainerEl);
   const virtualAnchor = $derived.by(() => {
     if (!editor || !anchor) return null;
     const snapshot = editor.published?.snapshot;
@@ -120,8 +121,8 @@
   });
 </script>
 
-{#if open && virtualAnchor}
-  <CommentPopoverCard onclickoutside={() => tryClose(comments.closeFromOutside)} reference={virtualAnchor}>
+{#if open && virtualAnchor && surface}
+  <CommentPopoverCard boundary={surface} onclickoutside={() => tryClose(comments.closeFromOutside)} reference={virtualAnchor}>
     {#if comments.composing}
       <CommentComposer
         autofocus

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-comments/CommentPopoverCard.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-comments/CommentPopoverCard.svelte
@@ -1,26 +1,55 @@
 <script lang="ts">
   import { flip, hide, inline, shift } from '@floating-ui/dom';
   import { css } from '@typie/styled-system/css';
-  import { createFloatingActions } from '@typie/ui/actions';
+  import { createCenterWhenReferenceDoesNotFitMiddleware, createFloatingActions } from '@typie/ui/actions';
   import { scale } from 'svelte/transition';
   import { getCommentContext } from './context.svelte';
   import type { ReferenceElement } from '@floating-ui/dom';
   import type { Snippet } from 'svelte';
 
   type Props = {
+    boundary: HTMLElement;
     reference: ReferenceElement;
     onclickoutside: () => void;
     children: Snippet;
   };
-  let { reference, onclickoutside, children }: Props = $props();
+  let { boundary, reference, onclickoutside, children }: Props = $props();
 
   const comments = getCommentContext();
   let element = $state<HTMLElement | null>(null);
 
+  const POPOVER_GAP = 6;
+  const VIEWPORT_PADDING = 8;
+  const centeredFallback = createCenterWhenReferenceDoesNotFitMiddleware({
+    gap: POPOVER_GAP,
+    overflow: () => ({ boundary, padding: VIEWPORT_PADDING }),
+  });
+
   const { anchor: referenceAction, floating } = createFloatingActions({
     placement: 'bottom-start',
-    offset: 6,
-    middleware: [inline(), flip(), shift({ padding: 8 }), hide()],
+    offset: POPOVER_GAP,
+    middleware: [
+      centeredFallback.captureReferenceBounds,
+      inline(),
+      flip({
+        get boundary() {
+          return boundary;
+        },
+        padding: VIEWPORT_PADDING,
+      }),
+      shift({
+        get boundary() {
+          return boundary;
+        },
+        padding: VIEWPORT_PADDING,
+      }),
+      centeredFallback.centerWhenNeitherSideFits,
+      hide({
+        get boundary() {
+          return boundary;
+        },
+      }),
+    ],
     onClickOutside: (event: Event) => {
       if (event.target instanceof HTMLElement && event.target.closest('[data-comment-panel-item]')) return;
       onclickoutside();
@@ -57,7 +86,7 @@
     comments.captureFocusReturn(event.relatedTarget);
   }}
   role="presentation"
-  use:floating
+  use:floating={{ appendTo: boundary }}
   transition:scale={{ start: 0.95, duration: 150 }}
 >
   {@render children()}

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/SpellcheckPopover.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/SpellcheckPopover.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import { hide, inline, shift, size } from '@floating-ui/dom';
+  import { flip, hide, inline, shift, size } from '@floating-ui/dom';
   import { flex } from '@typie/styled-system/patterns';
-  import { createFloatingActions } from '@typie/ui/actions';
+  import { createCenterWhenReferenceDoesNotFitMiddleware, createFloatingActions } from '@typie/ui/actions';
   import { Icon } from '@typie/ui/components';
   import { Toast } from '@typie/ui/notification';
   import ArrowRightIcon from '~icons/lucide/arrow-right';
@@ -26,12 +26,23 @@
   });
 
   const scroller = $derived(editor.scrollContainerEl);
+  const centeredFallback = createCenterWhenReferenceDoesNotFitMiddleware({
+    gap: 4,
+    overflow: () => ({ boundary: scroller ?? undefined, padding: 8 }),
+  });
 
   const { anchor, floating } = createFloatingActions({
     placement: 'top',
     offset: 4,
     middleware: [
+      centeredFallback.captureReferenceBounds,
       inline(),
+      flip({
+        get boundary() {
+          return scroller ?? undefined;
+        },
+        padding: 8,
+      }),
       shift({
         get boundary() {
           return scroller ?? undefined;
@@ -49,6 +60,7 @@
           });
         },
       }),
+      centeredFallback.centerWhenNeitherSideFits,
       hide({
         strategy: 'escaped',
         get boundary() {

--- a/packages/ui/src/actions/floating.svelte.ts
+++ b/packages/ui/src/actions/floating.svelte.ts
@@ -1,13 +1,103 @@
-import { arrow, autoUpdate, computePosition, flip, offset, shift } from '@floating-ui/dom';
+import { arrow, autoUpdate, computePosition, detectOverflow, flip, offset, shift } from '@floating-ui/dom';
 import { on } from 'svelte/events';
 import { match } from 'ts-pattern';
-import type { FloatingElement, Middleware, OffsetOptions, Placement, ReferenceElement } from '@floating-ui/dom';
+import type {
+  Derivable,
+  DetectOverflowOptions,
+  FloatingElement,
+  Middleware,
+  MiddlewareState,
+  OffsetOptions,
+  Placement,
+  Rect,
+  ReferenceElement,
+  SideObject,
+} from '@floating-ui/dom';
 import type { Action } from 'svelte/action';
 
 export type ReferenceAction = Action<ReferenceElement>;
 export type FloatingAction = Action<FloatingElement, { appendTo?: Element | null } | undefined>;
 export type ArrowAction = Action<HTMLElement>;
 export type UpdatePosition = () => Promise<void>;
+
+type PlacementRect = Pick<Rect, 'x' | 'y' | 'width' | 'height'>;
+type PlacementSize = Pick<Rect, 'width' | 'height'>;
+
+type CenteredFallbackInput = {
+  reference: PlacementRect;
+  floating: PlacementSize;
+  clippingRect: PlacementRect;
+  gap: number;
+};
+
+type CenterWhenReferenceDoesNotFitOptions = {
+  gap: number;
+  overflow?: DetectOverflowOptions | Derivable<DetectOverflowOptions>;
+};
+
+type CenterWhenReferenceDoesNotFitMiddleware = {
+  captureReferenceBounds: Middleware;
+  centerWhenNeitherSideFits: Middleware;
+};
+
+const REFERENCE_BOUNDS_MIDDLEWARE = 'referenceBoundsForCenteredFallback';
+
+export function resolveFloatingCenteredFallback({
+  reference,
+  floating,
+  clippingRect,
+  gap,
+}: CenteredFallbackInput): { x: number; y: number } | null {
+  const requiredSideSpace = floating.height + gap;
+  const fitsAbove = reference.y - clippingRect.y >= requiredSideSpace;
+  const fitsBelow = clippingRect.y + clippingRect.height - (reference.y + reference.height) >= requiredSideSpace;
+  if (fitsAbove || fitsBelow) return null;
+
+  return {
+    x: Math.max(clippingRect.x, clippingRect.x + (clippingRect.width - floating.width) / 2),
+    y: Math.max(clippingRect.y, clippingRect.y + (clippingRect.height - floating.height) / 2),
+  };
+}
+
+function clippingRectFromOverflow(state: MiddlewareState, overflow: SideObject): PlacementRect {
+  return {
+    x: state.x + overflow.left,
+    y: state.y + overflow.top,
+    width: state.rects.floating.width - overflow.left - overflow.right,
+    height: state.rects.floating.height - overflow.top - overflow.bottom,
+  };
+}
+
+export function createCenterWhenReferenceDoesNotFitMiddleware({
+  gap,
+  overflow: overflowOptions,
+}: CenterWhenReferenceDoesNotFitOptions): CenterWhenReferenceDoesNotFitMiddleware {
+  return {
+    captureReferenceBounds: {
+      name: REFERENCE_BOUNDS_MIDDLEWARE,
+      async fn({ elements, platform, strategy }) {
+        const rects = await platform.getElementRects({ reference: elements.reference, floating: elements.floating, strategy });
+        return { data: { reference: rects.reference } };
+      },
+    },
+    centerWhenNeitherSideFits: {
+      name: 'centerWhenReferenceDoesNotFit',
+      async fn(state) {
+        const reference = (state.middlewareData[REFERENCE_BOUNDS_MIDDLEWARE] as { reference?: PlacementRect } | undefined)?.reference;
+        if (!reference) return {};
+
+        const overflow = await detectOverflow(state, overflowOptions);
+        const position = resolveFloatingCenteredFallback({
+          reference,
+          floating: state.rects.floating,
+          clippingRect: clippingRectFromOverflow(state, overflow),
+          gap,
+        });
+        return position ?? {};
+      },
+    },
+  };
+}
 
 type CreateFloatingActionsOptions = {
   placement: Placement;


### PR DESCRIPTION
- 앱 context menu와 동일한 포지셔닝 정책을 사용
- 위나 아래에 배치할 수 없으면 뷰포트 가운데에 배치
- 코멘트 팝오버를 배치하는 바운더리를 툴바 제외한 에디터 영역으로 제한 (맞춤법 검사 오버레이는 이미 그렇게 되어있음)

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>