### PR TITLE
iOS에서 폰트 크기 모달 닫을 때 지체 없이 에디터로 포커스 복원

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorFocusReturnSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorFocusReturnSession.kt
@@ -87,18 +87,19 @@ internal class EditorFocusReturnSession(
 
   suspend fun restore() {
     val captured = state as? State.Captured ?: return
+    if (isRestorable(captured.context) && captured.context.editor.currentSelection() != null) {
+      state = State.Idle
+      captured.stableSelection.cancel()
+      focusBestEffort(captured.context)
+      return
+    }
+
     awaitFocusBoundary()
     if (state !== captured) return
 
     state = State.Idle
     if (!isRestorable(captured.context)) {
       captured.stableSelection.cancel()
-      return
-    }
-
-    if (captured.context.editor.currentSelection() != null) {
-      captured.stableSelection.cancel()
-      focusBestEffort(captured.context)
       return
     }
 

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/EditorFocusReturnSessionTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/EditorFocusReturnSessionTest.kt
@@ -107,8 +107,9 @@ class EditorFocusReturnSessionTest {
   }
 
   @Test
-  fun currentSelectionWinsWithoutWaitingForOrApplyingCapture() = runTest {
+  fun currentSelectionFocusesWithoutWaitingForRestoreBoundaryOrCapture() = runTest {
     val editor = testEditor(selection("eligible"))
+    val restoreBoundary = CompletableDeferred<Unit>()
     val freezeGate = CompletableDeferred<StableSelection?>()
     var applyRequests = 0
     var focusRequests = 0
@@ -118,16 +119,23 @@ class EditorFocusReturnSessionTest {
         freezeSelection = { _, _ -> freezeGate.await() },
         applySelection = { _, _ -> applyRequests += 1 },
         focusEditor = { focusRequests += 1 },
-        awaitFocusBoundary = {},
+        awaitFocusBoundary = restoreBoundary::await,
       )
 
     capture(session, editor)
     editor.setSelection(selection("current"))
-    session.restore()
+    val restore = launch { session.restore() }
+    runCurrent()
 
-    assertEquals(0, applyRequests)
-    assertEquals(1, focusRequests)
-    assertFalse(freezeGate.isCompleted)
+    try {
+      assertEquals(0, applyRequests)
+      assertEquals(1, focusRequests)
+      assertFalse(freezeGate.isCompleted)
+      assertTrue(restore.isCompleted)
+    } finally {
+      restoreBoundary.complete(Unit)
+      restore.join()
+    }
   }
 
   @Test


### PR DESCRIPTION
iOS에서 폰트 크기 입력 모달을 닫을 때, 에디터 selection이 그대로 남아 있다면 다음 프레임을 기다리지 않고 즉시 에디터로 포커스를 돌려주도록 변경했습니다.
모달과 에디터 사이에서 입력 세션이 잠시 끊기며 키보드와 툴바가 내려갔다 다시 올라오는 현상을 방지합니다. Selection을 복원해야 하는 기존 경로는 그대로 유지했습니다.
또한 현재 selection이 있는 경우 프레임 경계나 비동기 selection 캡처를 기다리지 않는지 회귀 테스트를 추가했습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>