### PR TITLE
tracked range reveal 시 접힌 폴드를 펼치도록 함

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorUpdateWithBringIntoView.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorUpdateWithBringIntoView.kt
@@ -5,6 +5,7 @@ import co.typie.editor.EditorRequestScope
 import co.typie.editor.EditorUpdate
 import co.typie.editor.beforePublish
 import co.typie.editor.ffi.Message
+import co.typie.editor.ffi.ViewOp
 
 internal interface EditorBringIntoViewUpdateScope : EditorRequestScope {
   fun bringIntoView(
@@ -92,3 +93,16 @@ internal suspend fun Editor.updateWithBringIntoView(
     ?.let { bringIntoViewRequests.awaitPresentation(it) }
   return update
 }
+
+internal suspend fun Editor.revealTrackedItem(
+  bringIntoViewRequests: EditorBringIntoViewRequests,
+  id: String,
+): EditorUpdate? =
+  updateWithBringIntoView(bringIntoViewRequests) {
+    enqueue(Message.View(ViewOp.ExpandFoldsForTrackedRange(id)))
+    bringIntoView(
+      target = EditorBringIntoViewTarget.TrackedItem(id),
+      policy = EditorBringIntoViewPolicy.Reveal,
+      behavior = EditorBringIntoViewBehavior.Smooth,
+    )
+  }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/aifeedback/EditorAiFeedbackSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/aifeedback/EditorAiFeedbackSession.kt
@@ -13,10 +13,8 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.viewmodel.compose.viewModel
 import co.typie.editor.Editor
 import co.typie.editor.EditorState
-import co.typie.editor.scroll.EditorBringIntoViewBehavior
-import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorBringIntoViewRequests
-import co.typie.editor.scroll.toPageRectsTarget
+import co.typie.editor.scroll.revealTrackedItem
 import co.typie.graphql.AiFeedback_LiteraryAnalysisDocumentStream_Subscription
 import co.typie.graphql.Apollo
 import co.typie.screen.editor.editor.selectTrackedRangeMember
@@ -73,16 +71,10 @@ internal fun rememberEditorAiFeedbackSession(
     bottomOcclusion = value.coerceAtLeast(0f)
   }
 
-  fun requestRangeIntoView(id: String?) {
+  suspend fun requestRangeIntoView(id: String?) {
     val activeEditor = editor ?: return
     if (id == null) return
-    bringIntoViewRequests.requestForState(
-      state = activeEditor.appliedState,
-      policy = EditorBringIntoViewPolicy.Reveal,
-      behavior = EditorBringIntoViewBehavior.Smooth,
-    ) {
-      trackedRanges.firstOrNull { it.id == id }?.rects?.toPageRectsTarget()
-    }
+    activeEditor.revealTrackedItem(bringIntoViewRequests, id)
   }
 
   suspend fun updateActiveRangeDecoration() {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/EditorFindReplaceSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/EditorFindReplaceSession.kt
@@ -14,9 +14,8 @@ import co.typie.editor.DocumentEditingSession
 import co.typie.editor.Editor
 import co.typie.editor.EditorState
 import co.typie.editor.ext.isCollapsed
-import co.typie.editor.scroll.EditorBringIntoViewBehavior
-import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorBringIntoViewRequests
+import co.typie.editor.scroll.revealTrackedItem
 import co.typie.storage.Preference
 import co.typie.ui.component.toast.LocalToast
 import co.typie.ui.component.toast.ToastType
@@ -383,17 +382,11 @@ private class FindReplaceSessionController {
     )
   }
 
-  private fun requestActiveRangeIntoView(
+  private suspend fun requestActiveRangeIntoView(
     editor: Editor,
     bringIntoViewRequests: EditorBringIntoViewRequests,
   ) {
-    bringIntoViewRequests.requestForState(
-      state = editor.appliedState,
-      policy = EditorBringIntoViewPolicy.Reveal,
-      behavior = EditorBringIntoViewBehavior.Smooth,
-    ) {
-      trackedRanges.searchMatchScrollTarget(activeMatchId())
-    }
+    activeMatchId()?.let { id -> editor.revealTrackedItem(bringIntoViewRequests, id) }
   }
 }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceEditorRanges.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceEditorRanges.kt
@@ -7,8 +7,6 @@ import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.Selection
 import co.typie.editor.ffi.TrackedRange
 import co.typie.editor.ffi.TrackedRangeOp
-import co.typie.editor.scroll.EditorBringIntoViewTarget
-import co.typie.editor.scroll.toPageRectsTarget
 
 internal const val SEARCH_MATCH_RANGE_GROUP = "search-match"
 internal const val ACTIVE_SEARCH_MATCH_RANGE_GROUP = "search-match-active"
@@ -158,8 +156,3 @@ internal suspend fun Editor.replaceAllFindReplaceRanges(
     }
     ?.commandOutcomes
     ?.none { it is CommandOutcome.Rejected } == true
-
-internal fun List<TrackedRange>.searchMatchScrollTarget(id: String?): EditorBringIntoViewTarget? {
-  if (id == null) return null
-  return searchMatchRanges().firstOrNull { it.id == id }?.rects?.toPageRectsTarget()
-}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/spellcheck/EditorSpellcheckSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/spellcheck/EditorSpellcheckSession.kt
@@ -17,11 +17,10 @@ import co.typie.editor.EditorState
 import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.Selection
 import co.typie.editor.ffi.SelectionOp
-import co.typie.editor.scroll.EditorBringIntoViewBehavior
 import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.EditorBringIntoViewTarget
-import co.typie.editor.scroll.toPageRectsTarget
+import co.typie.editor.scroll.revealTrackedItem
 import co.typie.editor.scroll.updateWithBringIntoView
 import co.typie.screen.editor.editor.selectTrackedRangeMember
 import co.typie.screen.editor.editor.state.EditorOverlayOcclusion
@@ -84,16 +83,10 @@ internal fun rememberEditorSpellcheckSession(
     bottomOcclusion = value.coerceAtLeast(0f)
   }
 
-  fun requestRangeIntoView(id: String?) {
+  suspend fun requestRangeIntoView(id: String?) {
     val activeEditor = editor ?: return
     if (id == null) return
-    bringIntoViewRequests.requestForState(
-      state = activeEditor.appliedState,
-      policy = EditorBringIntoViewPolicy.Reveal,
-      behavior = EditorBringIntoViewBehavior.Smooth,
-    ) {
-      trackedRanges.firstOrNull { it.id == id }?.rects?.toPageRectsTarget()
-    }
+    activeEditor.revealTrackedItem(bringIntoViewRequests, id)
   }
 
   suspend fun updateActiveRangeDecoration() {
@@ -150,7 +143,7 @@ internal fun rememberEditorSpellcheckSession(
         } else {
           updateCompactOverlayHeightForRange(activeModel.activeRangeId)
         }
-        requestRangeIntoView(activeModel.activeRangeId)
+        scope.launch { requestRangeIntoView(activeModel.activeRangeId) }
         if (results.isEmpty()) {
           toast.show(ToastType.Success, "맞춤법 오류가 없습니다.")
         }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/comments/EditorCommentsSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/comments/EditorCommentsSession.kt
@@ -15,10 +15,9 @@ import co.typie.editor.Editor
 import co.typie.editor.EditorState
 import co.typie.editor.ffi.StableSelection
 import co.typie.editor.ffi.TrackedRange
-import co.typie.editor.scroll.EditorBringIntoViewBehavior
-import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.EditorBringIntoViewTarget
+import co.typie.editor.scroll.revealTrackedItem
 import co.typie.screen.editor.editor.selectTrackedRangeMember
 import co.typie.ui.component.toast.LocalToast
 import co.typie.ui.component.toast.ToastType
@@ -204,13 +203,9 @@ internal fun rememberEditorCommentsSession(
       return@LaunchedEffect
     }
     if (editor == null) return@LaunchedEffect
-    bringIntoViewRequests.requestForVersion(
-      target = activeThreadScrollTarget,
-      version = editorState.version,
-      policy = EditorBringIntoViewPolicy.Reveal,
-      behavior = EditorBringIntoViewBehavior.Smooth,
-    )
-    lastRequestedActivationRevision = activeThreadActivationRevision
+    if (editor.revealTrackedItem(bringIntoViewRequests, activeThreadScrollTarget.id) != null) {
+      lastRequestedActivationRevision = activeThreadActivationRevision
+    }
   }
   LaunchedEffect(sheetActive, collapsedSelectionHead, collapsedCommentRange?.id) {
     if (
@@ -279,10 +274,8 @@ internal fun rememberEditorCommentsSession(
 
 internal fun List<TrackedRange>.commentThreadScrollTarget(
   threadId: String?
-): EditorBringIntoViewTarget? {
+): EditorBringIntoViewTarget.TrackedItem? {
   if (threadId == null) return null
-  return this.firstOrNull {
-      it.id == threadId && it.group == ACTIVE_COMMENT_RANGE_GROUP && it.rects.isNotEmpty()
-    }
+  return this.firstOrNull { it.id == threadId && it.group == ACTIVE_COMMENT_RANGE_GROUP }
     ?.let { EditorBringIntoViewTarget.TrackedItem(it.id) }
 }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorUpdateWithBringIntoViewTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorUpdateWithBringIntoViewTest.kt
@@ -10,6 +10,7 @@ import co.typie.editor.ffi.FrameKey
 import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.Size
 import co.typie.editor.ffi.SystemEvent
+import co.typie.editor.ffi.ViewOp
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -28,6 +29,26 @@ import kotlinx.coroutines.test.runTest
 
 class EditorUpdateWithBringIntoViewTest {
   private val dispatcher = StandardTestDispatcher()
+
+  @Test
+  fun `tracked item reveal expands folds and binds semantic target to the same version`() =
+    runTest(dispatcher) {
+      val requests = EditorBringIntoViewRequests()
+      val fake = FakeFfiEditor()
+      val editor = Editor(fake, this, dispatcher)
+
+      val update = assertNotNull(editor.revealTrackedItem(requests, id = "match-1"))
+
+      assertEquals(
+        listOf<Message>(Message.View(ViewOp.ExpandFoldsForTrackedRange(id = "match-1"))),
+        fake.enqueued,
+      )
+      assertEquals(1L, update.revision)
+      val request = assertNotNull(requests.activateForVersion(version = update.revision))
+      assertEquals(EditorBringIntoViewTarget.TrackedItem("match-1"), request.target)
+      assertEquals(EditorBringIntoViewPolicy.Reveal, request.policy)
+      assertEquals(EditorBringIntoViewBehavior.Smooth, request.behavior)
+    }
 
   @Test
   fun `update bringIntoView attaches to applied editor version`() =

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/subpane/comments/EditorCommentsSessionTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/subpane/comments/EditorCommentsSessionTest.kt
@@ -25,8 +25,9 @@ class EditorCommentsSessionTest {
       EditorBringIntoViewTarget.TrackedItem(activeRange.id),
       listOf(activeRange).commentThreadScrollTarget(activeRange.id),
     )
-    assertNull(
-      listOf(activeRange.copy(rects = emptyList())).commentThreadScrollTarget(activeRange.id)
+    assertEquals(
+      EditorBringIntoViewTarget.TrackedItem(activeRange.id),
+      listOf(activeRange.copy(rects = emptyList())).commentThreadScrollTarget(activeRange.id),
     )
   }
 

--- a/apps/website/src/lib/editor-ffi/editor-frame-sync.browser.test.ts
+++ b/apps/website/src/lib/editor-ffi/editor-frame-sync.browser.test.ts
@@ -160,6 +160,29 @@ function longDoc(): PlainDoc {
   };
 }
 
+function foldedTrackedRangeDoc(targetText: string): PlainDoc {
+  return {
+    root: entry(
+      { type: 'root', layout_mode: { type: 'continuous', max_width: PAGE_WIDTH } },
+      [
+        ...Array.from({ length: 12 }, (_, index) =>
+          entry({ type: 'paragraph' }, [entry({ type: 'text', text: `preceding paragraph ${index}` })]),
+        ),
+        entry({ type: 'fold' }, [
+          entry({ type: 'fold_title' }, [entry({ type: 'text', text: 'Collapsed section' })]),
+          entry({ type: 'fold_content' }, [entry({ type: 'paragraph' }, [entry({ type: 'text', text: targetText })])]),
+        ]),
+        entry({ type: 'paragraph' }),
+      ],
+      {
+        block_gap: { type: 'block_gap', value: 80 },
+        font_size: { type: 'font_size', value: 1000 },
+        line_height: { type: 'line_height', value: 150 },
+      } as never,
+    ),
+  };
+}
+
 function paginatedDocWithPageBreaks(pageCount: number, linkedLastPage?: { text: string; href: string }): PlainDoc {
   const pageHeight = 221;
   return {
@@ -568,6 +591,40 @@ function expectActualCanvas(editor: Editor, pageIndex: number, requirePaintedPix
 }
 
 describe('web editor frame synchronization', () => {
+  it.each([
+    { mode: 'editable', readOnly: false },
+    { mode: 'read-only', readOnly: true },
+  ])('expands a collapsed fold before revealing a tracked item in $mode mode', async ({ readOnly }) => {
+    const errorId = `folded-error-${crypto.randomUUID()}`;
+    const targetText = 'folded tracked target';
+    const { editor, scrollRoot } = await mountEditor(foldedTrackedRangeDoc(targetText), { readOnly });
+    const prose = editor.proseText();
+    const start = prose.indexOf(targetText);
+    expect(start).toBeGreaterThanOrEqual(0);
+    const selection = editor.proseToSelection(start, start + targetText.length);
+    expect(selection).toBeDefined();
+    if (!selection) throw new Error('Expected the folded prose target to resolve');
+
+    editor.setSpellcheckErrors([{ id: errorId, selection, context: targetText, corrections: [], explanation: '' }]);
+    await expect.poll(() => editor.appliedSnapshot.trackedRanges.some((range) => range.id === errorId)).toBe(true);
+    await waitForPresentation(editor);
+    expect(editor.trackedRangeForSnapshot(errorId, editor.appliedSnapshot)?.rects).toEqual([]);
+
+    editor.setActiveSpellcheckError(errorId);
+
+    await expect.poll(() => editor.trackedRangeForSnapshot(errorId, editor.appliedSnapshot)?.rects.length ?? 0).toBeGreaterThan(0);
+    await waitForPresentation(editor);
+    await vi.waitFor(() => {
+      const published = editor.published;
+      const range = published && editor.trackedRangeForSnapshot(errorId, published.snapshot);
+      const targetRect = range && pageRectsToClientRect(editor, range.rects);
+      const viewport = scrollRoot.getBoundingClientRect();
+      expect(targetRect).not.toBeNull();
+      expect(targetRect?.top).toBeGreaterThanOrEqual(viewport.top - COORDINATE_TOLERANCE_PX);
+      expect(targetRect?.bottom).toBeLessThanOrEqual(viewport.bottom + COORDINATE_TOLERANCE_PX);
+    });
+  });
+
   it('presents ordinary page overlays without waiting for IntersectionObserver delivery', async () => {
     vi.stubGlobal('IntersectionObserver', SilentIntersectionObserver);
     try {

--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -934,7 +934,7 @@ export class Editor {
     if (idx === undefined) return;
     const match = this.#searchMatches[idx];
     if (!match) return;
-    this.scrollIntoView({ target: { type: 'tracked_item', id: match.id }, policy: 'reveal', behavior: 'smooth' });
+    this.revealTrackedItem(match.id);
   }
 
   #handleSearchReplaceResult(id: string, outcome: string): void {
@@ -1558,6 +1558,15 @@ export class Editor {
 
   scrollIntoView(options: EditorScrollIntoViewOptions): Promise<void> | undefined {
     return this.#scrollIntoView?.(options, this.#admission);
+  }
+
+  revealTrackedItem(id: string): Promise<void> | undefined {
+    let presentation: Promise<void> | undefined;
+    void this.update((request) => {
+      request.enqueue({ type: 'view', op: { type: 'expand_folds_for_tracked_range', id } });
+      presentation = this.scrollIntoView({ target: { type: 'tracked_item', id }, policy: 'reveal', behavior: 'smooth' });
+    }).catch((err: unknown) => this.fail(err));
+    return presentation;
   }
 
   clientToLocal(clientX: number, clientY: number) {
@@ -2405,7 +2414,7 @@ export class Editor {
         this.activeSpellcheckErrorId = null;
         return;
       }
-      this.scrollIntoView({ target: { type: 'tracked_item', id }, policy: 'reveal', behavior: 'smooth' });
+      this.revealTrackedItem(id);
     }
   }
 
@@ -2582,7 +2591,7 @@ export class Editor {
     if (id !== null) {
       const ok = move(id, 'comment-active');
       if (ok) {
-        this.scrollIntoView({ target: { type: 'tracked_item', id }, policy: 'reveal', behavior: 'smooth' });
+        this.revealTrackedItem(id);
       } else {
         this.activeCommentId = null;
       }
@@ -2615,7 +2624,7 @@ export class Editor {
         this.activeAiFeedbackId = null;
         return;
       }
-      this.scrollIntoView({ target: { type: 'tracked_item', id }, policy: 'reveal', behavior: 'smooth' });
+      this.revealTrackedItem(id);
     }
   }
 

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-comments/DocumentComments.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-comments/DocumentComments.svelte
@@ -188,16 +188,7 @@
 
   const anchorFromPageRects = (rects: PageRect[]): CommentAnchor | null => (rects.length > 0 ? { type: 'page_rects', rects } : null);
 
-  const publishedTrackedRangeRects = (id: string): PageRect[] | null => {
-    const snapshot = editor?.published?.snapshot;
-    const range = snapshot ? editor?.trackedRangeForSnapshot(id, snapshot) : undefined;
-    return range && range.rects.length > 0 ? range.rects : null;
-  };
-
-  const anchorForThread = (id: string): CommentAnchor | null => {
-    const rects = publishedTrackedRangeRects(id);
-    return rects ? { type: 'tracked_item', id } : null;
-  };
+  const anchorForThread = (id: string): CommentAnchor | null => (isLocatable(id) ? { type: 'tracked_item', id } : null);
 
   function isLocatable(id: string): boolean {
     return editor?.isCommentLocatable(id) ?? false;
@@ -251,15 +242,10 @@
       return;
     }
     composing = false;
-    const rects = publishedTrackedRangeRects(id);
-    const anchor = rects ? ({ type: 'tracked_item', id } satisfies CommentAnchor) : null;
-    if (!anchor) {
-      Toast.error('원문에서 위치를 찾을 수 없는 코멘트예요');
-      return;
-    }
+    const wasActive = activeThreadId === id;
     activeThreadId = id;
-    activeAnchor = anchor;
-    ctx.scroll?.scrollIntoView({ target: { type: 'tracked_item', id }, policy: 'reveal', behavior: 'smooth' });
+    activeAnchor = { type: 'tracked_item', id };
+    if (wasActive) editor.revealTrackedItem(id);
   }
 
   function takeFocusReturnSession(): FocusReturnSession | null {

--- a/crates/editor-core/src/editor.rs
+++ b/crates/editor-core/src/editor.rs
@@ -1874,16 +1874,32 @@ impl Editor {
     pub(crate) fn toggle_fold(&mut self, id: Dot) -> bool {
         let did_change = self.view.toggle_fold(&self.state, id);
         if did_change {
-            self.push_event(EditorEvent::StateChanged {
-                fields: vec![
-                    StateField::Cursor,
-                    StateField::PageSizes,
-                    StateField::ExternalElements,
-                ],
-            });
-            self.invalidate_render();
+            self.fold_layout_changed();
         }
         did_change
+    }
+
+    pub(crate) fn expand_folds(&mut self, ids: impl IntoIterator<Item = Dot>) -> bool {
+        let did_change = self.view.expand_folds(&self.state, ids);
+        if did_change {
+            self.fold_layout_changed();
+        }
+        did_change
+    }
+
+    fn fold_layout_changed(&mut self) {
+        self.push_event(EditorEvent::StateChanged {
+            fields: vec![
+                StateField::Cursor,
+                StateField::PageSizes,
+                StateField::ExternalElements,
+                StateField::TableOverlays,
+                StateField::LinkRects,
+                StateField::TrackedRanges,
+                StateField::Placeholder,
+            ],
+        });
+        self.invalidate_render();
     }
 
     pub(crate) fn set_fold_expanded(&mut self, id: Dot, expanded: bool) -> bool {

--- a/crates/editor-core/src/handle/view.rs
+++ b/crates/editor-core/src/handle/view.rs
@@ -1,6 +1,6 @@
 use editor_crdt::Dot;
 use editor_model::{DocView, Node};
-use editor_state::{Position, Selection};
+use editor_state::{Position, Selection, StableResolveCtx};
 use editor_transaction::HistoryMeta;
 
 use crate::editor::Editor;
@@ -31,7 +31,44 @@ pub fn handle_view_op(editor: &mut Editor, op: ViewOp) -> Result<(), EditorError
             editor.toggle_fold(id);
             Ok(())
         }
+        ViewOp::ExpandFoldsForTrackedRange { id } => {
+            let folds = folds_containing_tracked_range(editor, &id);
+            editor.expand_folds(folds);
+            Ok(())
+        }
     }
+}
+
+fn folds_containing_tracked_range(editor: &Editor, id: &str) -> Vec<Dot> {
+    let Some(range) = editor.tracked_ranges().get(id) else {
+        return Vec::new();
+    };
+    if range.locate(editor.state()).is_none() {
+        return Vec::new();
+    }
+    let doc = editor.state().view();
+    let ctx = StableResolveCtx::from_live(&doc, editor.state().projected.seq_checkout());
+    let Some(selection) = range.selection.resolve(&ctx) else {
+        return Vec::new();
+    };
+    let mut folds = Vec::new();
+    for position in [selection.anchor, selection.head] {
+        let Some(node) = doc.node(position.node) else {
+            continue;
+        };
+        for ancestor in node.ancestors() {
+            if !matches!(ancestor.node(), Node::FoldContent(_)) {
+                continue;
+            }
+            let Some(fold) = ancestor.parent() else {
+                continue;
+            };
+            if matches!(fold.node(), Node::Fold(_)) && !folds.contains(&fold.id()) {
+                folds.push(fold.id());
+            }
+        }
+    }
+    folds
 }
 
 // Legacy parity: collapse hides fold-content, so a caret/anchor inside it is
@@ -97,6 +134,18 @@ mod tests {
         );
     }
 
+    fn add_tracked_range(editor: &mut Editor, id: &str, selection: Selection) {
+        editor.apply(Message::TrackedRange {
+            op: TrackedRangeOp::Add {
+                id: id.into(),
+                group: "test".into(),
+                selection,
+                metadata: String::new(),
+                invalidate_on_text_change: false,
+            },
+        });
+    }
+
     #[test]
     fn fold_defaults_to_collapsed_on_load() {
         let (initial, f1, ..) = state! {
@@ -114,6 +163,170 @@ mod tests {
         });
 
         assert!(!editor.fold_expanded(f1), "folds load collapsed by default");
+    }
+
+    #[test]
+    fn expand_folds_for_tracked_range_opens_containing_fold_content() {
+        let (initial, outer, _outer_title, inner, p1) = state! {
+            doc { root {
+                outer: fold {
+                    outer_title: fold_title { text("Outer") }
+                    fold_content {
+                        inner: fold {
+                            fold_title { text("Inner") }
+                            fold_content { p1: paragraph { text("Body") } }
+                        }
+                    }
+                }
+            } }
+            selection: (outer_title, 0)
+        };
+        let mut editor = Editor::new_test(initial);
+        editor.apply(Message::System {
+            event: SystemEvent::Initialize,
+        });
+        add_tracked_range(
+            &mut editor,
+            "range",
+            Selection::new(Position::new(p1, 0), Position::new(p1, 4)),
+        );
+        set_pending_format(&mut editor);
+        let selection_before = editor.state().selection;
+        let history_undos_before = editor.history_undos_len();
+        let history_redos_before = editor.history_redos_len();
+
+        let events = editor.apply(Message::View {
+            op: ViewOp::ExpandFoldsForTrackedRange { id: "range".into() },
+        });
+
+        assert!(editor.fold_expanded(outer));
+        assert!(editor.fold_expanded(inner));
+        assert_eq!(editor.state().selection, selection_before);
+        assert!(!editor.state().pending_modifiers.is_empty());
+        assert_eq!(editor.history_undos_len(), history_undos_before);
+        assert_eq!(editor.history_redos_len(), history_redos_before);
+        let expected_fields = [
+            StateField::Cursor,
+            StateField::PageSizes,
+            StateField::ExternalElements,
+            StateField::TableOverlays,
+            StateField::LinkRects,
+            StateField::TrackedRanges,
+        ];
+        assert!(events.iter().any(|event| matches!(
+            event,
+            EditorEvent::StateChanged { fields }
+                if expected_fields.iter().all(|field| fields.contains(field))
+        )));
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, EditorEvent::RenderInvalidated))
+        );
+
+        let repeated_events = editor.apply(Message::View {
+            op: ViewOp::ExpandFoldsForTrackedRange { id: "range".into() },
+        });
+        assert!(repeated_events.is_empty());
+        assert_eq!(editor.history_undos_len(), history_undos_before);
+        assert_eq!(editor.history_redos_len(), history_redos_before);
+    }
+
+    #[test]
+    fn expand_folds_for_tracked_range_opens_sibling_endpoint_folds_only() {
+        let (initial, first, _first_title, p1, second, p2, unrelated) = state! {
+            doc { root {
+                first: fold {
+                    first_title: fold_title { text("First") }
+                    fold_content { p1: paragraph { text("One") } }
+                }
+                second: fold {
+                    fold_title { text("Second") }
+                    fold_content { p2: paragraph { text("Two") } }
+                }
+                unrelated: fold {
+                    fold_title { text("Unrelated") }
+                    fold_content { paragraph { text("Other") } }
+                }
+            } }
+            selection: (first_title, 0)
+        };
+        let mut editor = Editor::new_test(initial);
+        editor.apply(Message::System {
+            event: SystemEvent::Initialize,
+        });
+        add_tracked_range(
+            &mut editor,
+            "spanning-range",
+            Selection::new(Position::new(p1, 0), Position::new(p2, 3)),
+        );
+
+        editor.apply(Message::View {
+            op: ViewOp::ExpandFoldsForTrackedRange {
+                id: "spanning-range".into(),
+            },
+        });
+
+        assert!(editor.fold_expanded(first));
+        assert!(editor.fold_expanded(second));
+        assert!(!editor.fold_expanded(unrelated));
+    }
+
+    #[test]
+    fn expand_folds_for_tracked_range_does_not_open_fold_for_title() {
+        let (initial, f1, ft1, ..) = state! {
+            doc { root {
+                f1: fold {
+                    ft1: fold_title { text("Title") }
+                    fold_content { paragraph { text("Body") } }
+                }
+            } }
+            selection: (ft1, 0)
+        };
+        let mut editor = Editor::new_test(initial);
+        editor.apply(Message::System {
+            event: SystemEvent::Initialize,
+        });
+        add_tracked_range(
+            &mut editor,
+            "title-range",
+            Selection::new(Position::new(ft1, 0), Position::new(ft1, 5)),
+        );
+
+        let events = editor.apply(Message::View {
+            op: ViewOp::ExpandFoldsForTrackedRange {
+                id: "title-range".into(),
+            },
+        });
+
+        assert!(!editor.fold_expanded(f1));
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn expand_folds_for_missing_tracked_range_is_noop() {
+        let (initial, f1, ..) = state! {
+            doc { root {
+                f1: fold {
+                    ft1: fold_title { text("Title") }
+                    fold_content { paragraph { text("Body") } }
+                }
+            } }
+            selection: (ft1, 0)
+        };
+        let mut editor = Editor::new_test(initial);
+        editor.apply(Message::System {
+            event: SystemEvent::Initialize,
+        });
+
+        let events = editor.apply(Message::View {
+            op: ViewOp::ExpandFoldsForTrackedRange {
+                id: "missing".into(),
+            },
+        });
+
+        assert!(!editor.fold_expanded(f1));
+        assert!(events.is_empty());
     }
 
     #[test]

--- a/crates/editor-core/src/message.rs
+++ b/crates/editor-core/src/message.rs
@@ -303,6 +303,7 @@ pub enum ListOp {
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ViewOp {
     ToggleFold { id: Dot },
+    ExpandFoldsForTrackedRange { id: String },
 }
 
 #[ffi]

--- a/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
@@ -734,7 +734,7 @@ export type Tri<T> = { type: "absent" } | { type: "uniform"; value: T } | { type
 
 export type UnderlineStyle = "solid" | "dashed" | "wavy";
 
-export type ViewOp = { type: "toggle_fold"; id: Dot };
+export type ViewOp = { type: "toggle_fold"; id: Dot } | { type: "expand_folds_for_tracked_range"; id: string };
 
 export type ViewportAnchor = { type: "position"; stable: StableSelection; original_node: Dot; geometry: ViewportAnchorPositionGeometry } | { type: "node"; node: Dot; offset_x: number; offset_y: number };
 

--- a/crates/editor-ffi/pkg/server/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/server/editor_ffi.d.ts
@@ -804,7 +804,7 @@ export type Tri<T> = { type: "absent" } | { type: "uniform"; value: T } | { type
 
 export type UnderlineStyle = "solid" | "dashed" | "wavy";
 
-export type ViewOp = { type: "toggle_fold"; id: Dot };
+export type ViewOp = { type: "toggle_fold"; id: Dot } | { type: "expand_folds_for_tracked_range"; id: string };
 
 export type ViewportAnchor = { type: "position"; stable: StableSelection; original_node: Dot; geometry: ViewportAnchorPositionGeometry } | { type: "node"; node: Dot; offset_x: number; offset_y: number };
 

--- a/crates/editor-view/src/view.rs
+++ b/crates/editor-view/src/view.rs
@@ -1057,6 +1057,34 @@ impl View {
         true
     }
 
+    pub fn expand_folds(&mut self, state: &State, nodes: impl IntoIterator<Item = Dot>) -> bool {
+        let mut changed = Vec::new();
+        {
+            let view = state.view();
+            for node in nodes {
+                if changed.contains(&node)
+                    || self.view_state.fold_expanded(node)
+                    || !view
+                        .node(node)
+                        .is_some_and(|node_view| matches!(node_view.node(), Node::Fold(_)))
+                {
+                    continue;
+                }
+                changed.push(node);
+            }
+        }
+        if changed.is_empty() {
+            return false;
+        }
+        for node in changed {
+            self.view_state.fold_states.insert(node, true);
+            self.evict_measure_for(state, node);
+        }
+        self.compute(state);
+        self.view_state.preferred_x = None;
+        true
+    }
+
     pub fn clear_preferred_x(&mut self) {
         self.view_state.preferred_x = None;
     }


### PR DESCRIPTION
- 활성 검색 결과, 코멘트, 맞춤법 오류, AI 피드백이 접힌 폴드 안에 있으면 reveal되지 않던 문제를 수정
- Core가 tracked range 양 끝점의 `FoldContent` ancestry를 기준으로 필요한 폴드만 찾아 한 번에 펼치고, layout과 관련 geometry를 함께 갱신
- Web/App은 폴드 확장과 `TrackedItem(id)` reveal을 같은 editor update에 묶어 기존 publication, smooth scroll, request lifecycle을 그대로 사용
- 코멘트 위치를 현재 rect가 아니라 `TrackedItem(id)`로 유지해, 펼치기 전 geometry가 비어 있어도 fold 확장 후 최신 위치를 찾도록 변경
- 편집/읽기 모드에서 동일하게 동작하며, reveal로 열린 폴드는 자동으로 다시 접지 않음

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>