### PR TITLE
reveal과 viewport anchor 개선

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorTapGesture.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorTapGesture.kt
@@ -525,6 +525,29 @@ private fun EditorTapGesture.dispatchReadingTap(
   doubleTapDrag: EditorDoubleTapDragSession,
   context: EditorGestureContext,
 ): Boolean {
+  if (clickCount == 1) {
+    if (!context.readOnly && !context.doubleTapToEditEnabled) {
+      return dispatchReadingActivation(
+        position = position,
+        inputModifiers = inputModifiers,
+        shouldOpenContextMenu = shouldOpenContextMenu,
+        doubleTapDrag = doubleTapDrag,
+        context = context,
+      )
+    }
+    return dispatchSelectionTap(
+      position = position,
+      clickCount = clickCount,
+      inputModifiers = inputModifiers,
+      shouldOpenContextMenu = shouldOpenContextMenu,
+      doubleTapDrag = doubleTapDrag,
+      context = context,
+      expectedEditing = false,
+      preserveExistingSelectionOnSingleTap = false,
+      beforeLaunch = {},
+    )
+  }
+
   val point =
     context.geometry.resolvePoint(positionInNode = position)
       ?: run {
@@ -552,48 +575,8 @@ private fun EditorTapGesture.dispatchReadingTap(
     }
     EditorInteractiveTapResult.None -> Unit
   }
-  if (clickCount != 1) {
-    clearTapHistory()
-    return false
-  }
-  if (!context.readOnly && !context.doubleTapToEditEnabled) {
-    return dispatchReadingActivation(
-      position = position,
-      inputModifiers = inputModifiers,
-      shouldOpenContextMenu = shouldOpenContextMenu,
-      doubleTapDrag = doubleTapDrag,
-      context = context,
-    )
-  }
-
-  val generation =
-    beginPendingPresentation(
-      editor = editor,
-      expectedEditing = false,
-      tapCount = clickCount,
-      showReadingHint = true,
-      context = context,
-    )
-  var appliedSnapshot: EditorState? = null
-  context.semantics.pointSelection.launchCursorMove(
-    editor = editor,
-    point = point,
-    onApplied = { snapshot -> appliedSnapshot = snapshot },
-    afterDispatch = { dispatched ->
-      val snapshot = appliedSnapshot
-      if (dispatched && snapshot != null) {
-        markPendingSelectionApplied(
-          generation = generation,
-          snapshot = snapshot,
-          showContextMenu = shouldOpenContextMenu && !snapshot.selection.isCollapsed(),
-          context = context,
-        )
-      } else {
-        cancelPendingPresentation(context = context)
-      }
-    },
-  )
-  return true
+  clearTapHistory()
+  return false
 }
 
 private fun EditorTapGesture.dispatchReadingActivation(
@@ -694,7 +677,7 @@ private fun EditorTapGesture.dispatchSelectionTap(
       editor = editor,
       expectedEditing = expectedEditing,
       tapCount = clickCount,
-      showReadingHint = false,
+      showReadingHint = !expectedEditing && clickCount == 1,
       context = context,
     )
   val wasFocused = context.isFocused
@@ -734,6 +717,9 @@ private fun EditorTapGesture.dispatchSelectionTap(
     appliedSnapshot = snapshot
     if (clickCount == 1) {
       when {
+        !expectedEditing -> {
+          showContextMenuAfterPublication = !snapshot.selection.isCollapsed()
+        }
         !snapshot.selection.isCollapsed() -> {
           if (!hitExistingSelectionAtTap) {
             showContextMenuAfterPublication = true

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorBringIntoViewRequests.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorBringIntoViewRequests.kt
@@ -5,7 +5,6 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
-import co.typie.editor.EditorState
 import kotlin.concurrent.atomics.AtomicLong
 import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
@@ -26,21 +25,6 @@ internal class EditorBringIntoViewRequests(private val requestPresentation: () -
 
   val pendingRequest: Request?
     get() = pending.load()
-
-  fun requestForState(
-    state: EditorState,
-    policy: EditorBringIntoViewPolicy,
-    behavior: EditorBringIntoViewBehavior = EditorBringIntoViewBehavior.Instant,
-    target: EditorState.() -> EditorBringIntoViewTarget?,
-  ): Boolean {
-    requestForVersion(
-      target = state.target() ?: return false,
-      version = state.version,
-      policy = policy,
-      behavior = behavior,
-    )
-    return true
-  }
 
   fun requestForVersion(
     target: EditorBringIntoViewTarget,
@@ -89,27 +73,7 @@ internal class EditorBringIntoViewRequests(private val requestPresentation: () -
     val request = pending.load() ?: return null
     val targetVersion =
       request.targetVersion.load().takeUnless { it == UNBOUND_VERSION } ?: return null
-    val eligible =
-      if (
-        request.target is EditorBringIntoViewTarget.PageRects ||
-          request.policy == EditorBringIntoViewPolicy.PointerCursorGuard
-      ) {
-        version == targetVersion
-      } else {
-        version >= targetVersion
-      }
-    return request.takeIf { eligible }
-  }
-
-  fun discardObsoleteForVersion(version: Long) {
-    val request = pending.load() ?: return
-    val targetVersion = request.targetVersion.load().takeUnless { it == UNBOUND_VERSION } ?: return
-    if (
-      (request.target is EditorBringIntoViewTarget.PageRects ||
-        request.policy == EditorBringIntoViewPolicy.PointerCursorGuard) && version > targetVersion
-    ) {
-      discard(request)
-    }
+    return request.takeIf { version >= targetVersion }
   }
 
   fun discardFailedForVersion(version: Long) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorScrollIntent.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorScrollIntent.kt
@@ -59,8 +59,6 @@ internal sealed interface EditorBringIntoViewTarget {
   data object CurrentSelectionHead : EditorBringIntoViewTarget
 
   data class TrackedItem(val id: String) : EditorBringIntoViewTarget
-
-  data class PageRects(val rects: List<PageRect>) : EditorBringIntoViewTarget
 }
 
 internal enum class EditorBringIntoViewPolicy {
@@ -357,7 +355,6 @@ private fun resolveBringIntoViewTargetPageRects(
       resolveCurrentSelectionHeadPageRect(state)?.let(::listOf)
     is EditorBringIntoViewTarget.TrackedItem ->
       state.trackedRanges.firstOrNull { it.id == target.id }?.rects?.takeIf { it.isNotEmpty() }
-    is EditorBringIntoViewTarget.PageRects -> target.rects.takeIf { it.isNotEmpty() }
   }
 
 private fun EditorScrollFrame.resolvePolicy(
@@ -371,9 +368,6 @@ private fun EditorScrollFrame.resolvePolicy(
     requestedPolicy == EditorBringIntoViewPolicy.Typewriter -> EditorBringIntoViewPolicy.CursorGuard
     else -> requestedPolicy
   }
-
-internal fun List<PageRect>.toPageRectsTarget(): EditorBringIntoViewTarget.PageRects? =
-  takeIf { it.isNotEmpty() }?.let(EditorBringIntoViewTarget::PageRects)
 
 private fun resolveCollapsedSelectionHeadPageRect(state: EditorState): PageRect? {
   val cursor = state.cursor ?: return null

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/viewport/EditorViewportAnchorState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/viewport/EditorViewportAnchorState.kt
@@ -44,6 +44,8 @@ internal class EditorViewportAnchorState {
     preferredSelection = null
   }
 
+  fun needsSelectionAdoption(identity: ViewportAnchor): Boolean = preferredSelection != identity
+
   fun consumeScrollChange(revision: Int): Boolean {
     val previous = observedScrollRevision
     observedScrollRevision = revision
@@ -80,6 +82,21 @@ internal class EditorViewportAnchorState {
     scrollY: Float,
   ) {
     attachActive(identity, geometry, scrollY)
+  }
+
+  fun adoptSelection(
+    identity: ViewportAnchor,
+    geometry: EditorViewportAnchorGeometry,
+    scrollY: Float,
+    visibleArea: EditorVisibleArea,
+    preserveActiveAnchor: Boolean,
+  ) {
+    if (!needsSelectionAdoption(identity)) return
+    val activate =
+      !preserveActiveAnchor &&
+        (active != null || canRetainAfterDirectScroll(geometry, scrollY, visibleArea))
+    preferredSelection = identity
+    if (activate) attachActive(identity, geometry, scrollY)
   }
 
   fun clearPreferredSelection() {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayout.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayout.kt
@@ -232,6 +232,10 @@ internal fun EditorScreenLayout(
   val viewConfiguration = LocalViewConfiguration.current
   val bringIntoViewRequests = LocalEditorBringIntoViewRequests.current
   val coroutineScope = rememberCoroutineScope()
+  val smoothScrollSession =
+    remember(coroutineScope, state.viewportState, bringIntoViewRequests) {
+      EditorSmoothScrollSession(coroutineScope, state.viewportState, bringIntoViewRequests)
+    }
   val smoothScrollEnabled =
     coroutineScope.coroutineContext[MotionDurationScale]
       ?.scaleFactor
@@ -242,9 +246,6 @@ internal fun EditorScreenLayout(
     bringIntoViewRequests.activateForVersion(it.version)
   }
   val viewportAnchorState = remember { EditorViewportAnchorState() }
-  if (appliedState != null && bringIntoViewRequest == null) {
-    SideEffect { bringIntoViewRequests.discardObsoleteForVersion(appliedState.version) }
-  }
   val surfacePreparation = editor?.let {
     resolveAnchoredEditorSurfacePreparation(
       editor = it,
@@ -254,6 +255,7 @@ internal fun EditorScreenLayout(
       anchorState = viewportAnchorState,
       publishedBundle = it.publishedBundle,
       smoothScrollEnabled = smoothScrollEnabled,
+      smoothRevealActive = smoothScrollSession.active,
     )
   }
   if (editor != null && surfacePreparation != null) {
@@ -267,10 +269,6 @@ internal fun EditorScreenLayout(
   val screenPointerSequence = remember { EditorScreenPointerSequence() }
   val viewportFlingBehavior = ScrollableDefaults.flingBehavior()
   val viewportAnchorPresentationRef = remember { EditorViewportAnchorPresentationRef() }
-  val smoothScrollSession =
-    remember(coroutineScope, state.viewportState, bringIntoViewRequests) {
-      EditorSmoothScrollSession(coroutineScope, state.viewportState, bringIntoViewRequests)
-    }
   var layoutBoundsInRoot by remember { mutableStateOf<Rect?>(null) }
   if (isCurrentNavigationRoute) {
     DisposableEffect(navigationPopNestedScroll, viewportScrollableState) {
@@ -391,6 +389,7 @@ internal fun EditorScreenLayout(
             anchorState = viewportAnchorState,
             publishedBundle = publishedBundle,
             smoothScrollEnabled = smoothScrollEnabled,
+            smoothRevealActive = smoothScrollSession.active,
           )
         } else {
           null
@@ -414,6 +413,7 @@ internal fun EditorScreenLayout(
                 anchorState = viewportAnchorState,
                 publishedBundle = publishedBundle,
                 smoothScrollEnabled = smoothScrollEnabled,
+                smoothRevealActive = smoothScrollSession.active,
               )
         if (!stillCurrent) return@let null
 
@@ -711,6 +711,7 @@ internal fun resolveAnchoredEditorSurfacePreparation(
   anchorState: EditorViewportAnchorState,
   publishedBundle: PublishedBundle?,
   smoothScrollEnabled: Boolean = true,
+  smoothRevealActive: Boolean = false,
 ): EditorSurfacePreparation? {
   val initial =
     resolveEditorSurfacePreparation(
@@ -730,6 +731,7 @@ internal fun resolveAnchoredEditorSurfacePreparation(
       currentScrollOffset = currentScrollOffset,
       maximumScrollY = initial.maximumScrollY,
       contentOriginY = initial.contentOriginY,
+      smoothRevealActive = smoothRevealActive,
     )
       as? EditorViewportAnchorPublication.Ready ?: return null
   if (anchorPublication.scrollY == currentScrollOffset.y) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorViewportAnchorReconciler.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorViewportAnchorReconciler.kt
@@ -34,67 +34,65 @@ internal fun reconcileViewportAnchorPublication(
   currentScrollOffset: Offset,
   maximumScrollY: Float,
   contentOriginY: Float,
+  smoothRevealActive: Boolean = false,
 ): EditorViewportAnchorPublication {
   val currentScrollY = currentScrollOffset.y
-  if (publishedBundle == null || publishedBundle.snapshot.version == candidateState.version) {
-    return EditorViewportAnchorPublication.Ready(
+  val candidateFrame = measuredScrollFrame.withState(candidateState)
+  val selectionCapture = editor.captureSelectionViewportAnchor(candidateState.version)
+  if (selectionCapture == null && candidateState.selection != null) {
+    return EditorViewportAnchorPublication.Withhold
+  }
+  if (selectionCapture != null && anchorState.needsSelectionAdoption(selectionCapture.identity)) {
+    val geometry =
+      selectionCapture.geometry.toEditorViewportAnchorGeometry(
+        frame = candidateFrame,
+        contentOriginY = contentOriginY,
+      ) ?: return EditorViewportAnchorPublication.Withhold
+    anchorState.adoptSelection(
+      identity = selectionCapture.identity,
+      geometry = geometry,
+      scrollY = currentScrollY,
+      visibleArea = candidateFrame.visibleArea,
+      preserveActiveAnchor = smoothRevealActive,
+    )
+  } else if (candidateState.selection == null && anchorState.preferredSelectionIdentity != null) {
+    if (!smoothRevealActive) {
+      val publishedState = publishedBundle?.snapshot ?: candidateState
+      val publishedFrame = candidateFrame.withState(publishedState)
+      attachViewportCenterAnchor(
+        editor = editor,
+        anchorState = anchorState,
+        revision = publishedState.version,
+        frame = publishedFrame,
+        scrollOffset = currentScrollOffset,
+        contentOriginY = resolveViewportAnchorContentOriginY(publishedFrame),
+      ) ?: return EditorViewportAnchorPublication.Withhold
+    }
+    anchorState.clearPreferredSelection()
+  }
+  val unanchoredPublication =
+    EditorViewportAnchorPublication.Ready(
       scrollY = currentScrollY.coerceIn(0f, maximumScrollY),
       geometry = null,
     )
+  if (publishedBundle == null || publishedBundle.snapshot.version == candidateState.version) {
+    return unanchoredPublication
   }
-  var identity =
-    anchorState.identity
-      ?: return EditorViewportAnchorPublication.Ready(
-        scrollY = currentScrollY.coerceIn(0f, maximumScrollY),
-        geometry = null,
-      )
-  val candidateFrame = measuredScrollFrame.withState(candidateState)
-
-  var resolution = editor.resolveViewportAnchor(candidateState.version, identity)
-  if (
-    resolution is ViewportAnchorResolution.Deleted ||
-      resolution is ViewportAnchorResolution.NotLaidOut
-  ) {
-    val publishedFrame = measuredScrollFrame.withState(publishedBundle.snapshot)
-    val publishedContentOriginY = resolveViewportAnchorContentOriginY(publishedFrame)
-    val centerPoint =
-      viewportCenterAnchorPoint(publishedFrame, currentScrollOffset, publishedContentOriginY)
-    val fallback = centerPoint?.let {
-      editor.captureViewportAnchorAt(publishedBundle.snapshot.version, it)
-    }
-    if (fallback == null) {
-      anchorState.clear()
-      return EditorViewportAnchorPublication.Ready(
-        scrollY = currentScrollY.coerceIn(0f, maximumScrollY),
-        geometry = null,
-      )
-    }
-    val oldGeometry =
-      fallback.geometry.toEditorViewportAnchorGeometry(
-        frame = publishedFrame,
-        contentOriginY = publishedContentOriginY,
-      )
-    if (oldGeometry == null) {
-      anchorState.clear()
-      return EditorViewportAnchorPublication.Ready(
-        scrollY = currentScrollY.coerceIn(0f, maximumScrollY),
-        geometry = null,
-      )
-    }
-    anchorState.attach(fallback.identity, oldGeometry, currentScrollY)
-    identity = fallback.identity
-    resolution = editor.resolveViewportAnchor(candidateState.version, identity)
-  }
+  val resolution =
+    resolveCandidateViewportAnchor(
+      editor = editor,
+      anchorState = anchorState,
+      publishedBundle = publishedBundle,
+      candidateFrame = candidateFrame,
+      currentScrollOffset = currentScrollOffset,
+    ) ?: return unanchoredPublication
 
   return when (resolution) {
     ViewportAnchorResolution.Unavailable -> EditorViewportAnchorPublication.Withhold
     ViewportAnchorResolution.Deleted,
     ViewportAnchorResolution.NotLaidOut -> {
       anchorState.clear()
-      EditorViewportAnchorPublication.Ready(
-        scrollY = currentScrollY.coerceIn(0f, maximumScrollY),
-        geometry = null,
-      )
+      unanchoredPublication
     }
     is ViewportAnchorResolution.Resolved -> {
       val geometry =
@@ -131,6 +129,44 @@ internal fun reconcileViewportAnchorPublication(
       )
     }
   }
+}
+
+private fun resolveCandidateViewportAnchor(
+  editor: Editor,
+  anchorState: EditorViewportAnchorState,
+  publishedBundle: PublishedBundle,
+  candidateFrame: EditorScrollFrame,
+  currentScrollOffset: Offset,
+): ViewportAnchorResolution? {
+  val identity = anchorState.identity ?: return null
+  val resolution = editor.resolveViewportAnchor(candidateFrame.state.version, identity)
+  if (
+    resolution !is ViewportAnchorResolution.Deleted &&
+      resolution !is ViewportAnchorResolution.NotLaidOut
+  ) {
+    return resolution
+  }
+
+  val publishedFrame = candidateFrame.withState(publishedBundle.snapshot)
+  val publishedContentOriginY = resolveViewportAnchorContentOriginY(publishedFrame)
+  val centerPoint =
+    viewportCenterAnchorPoint(publishedFrame, currentScrollOffset, publishedContentOriginY)
+  val fallback = centerPoint?.let {
+    editor.captureViewportAnchorAt(publishedBundle.snapshot.version, it)
+  }
+  val oldGeometry =
+    fallback
+      ?.geometry
+      ?.toEditorViewportAnchorGeometry(
+        frame = publishedFrame,
+        contentOriginY = publishedContentOriginY,
+      )
+  if (fallback == null || oldGeometry == null) {
+    anchorState.clear()
+    return null
+  }
+  anchorState.attach(fallback.identity, oldGeometry, currentScrollOffset.y)
+  return editor.resolveViewportAnchor(candidateFrame.state.version, fallback.identity)
 }
 
 internal fun reconcileViewportAnchorObservation(
@@ -181,12 +217,12 @@ internal fun reconcileViewportAnchorObservation(
         contentOriginY = contentOriginY,
       )
         ?: attachViewportCenterAnchor(
-          editor,
-          anchorState,
-          revision,
-          presentationFrame,
-          viewportState.scrollOffset,
-          contentOriginY,
+          editor = editor,
+          anchorState = anchorState,
+          revision = revision,
+          frame = presentationFrame,
+          scrollOffset = viewportState.scrollOffset,
+          contentOriginY = contentOriginY,
         )
     } else {
       null

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorReadingModeInteractionTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorReadingModeInteractionTest.kt
@@ -43,6 +43,19 @@ import kotlinx.coroutines.test.runTest
 @OptIn(ExperimentalCoroutinesApi::class)
 class EditorReadingModeInteractionTest {
   @Test
+  fun `reading single tap does not request pointer guard for the applied selection`() =
+    runTest(StandardTestDispatcher()) {
+      val fixture = fixture()
+      fixture.fake.publishSnapshot(fixture.editor)
+
+      fixture.controller.down(pointerId = 1L, nowMillis = 0L)
+      fixture.controller.up(pointerId = 1L, nowMillis = 40L)
+      runCurrent()
+
+      assertEquals(emptyList(), fixture.effects.pointerSelectionHeadVersions)
+    }
+
+  @Test
   fun `reading single tap waits through the consecutive tap window before hint`() =
     runTest(StandardTestDispatcher()) {
       val fixture = fixture()
@@ -292,7 +305,7 @@ class EditorReadingModeInteractionTest {
     }
 
   @Test
-  fun `reading activation ignores Shift and places a collapsed cursor`() =
+  fun `reading Shift tap extends selection before editing activation places a collapsed cursor`() =
     runTest(StandardTestDispatcher()) {
       val fixture = fixture()
       fixture.fake.publishSnapshot(fixture.editor)
@@ -314,7 +327,16 @@ class EditorReadingModeInteractionTest {
 
       assertEquals(
         listOf<Message>(
-          Message.Selection(SelectionOp.SetAt(page = 0, x = 10f, y = 20f)),
+          Message.Selection(
+            SelectionOp.ExtendTo(
+              anchor = FakeFfiEditor.EmptySelection.anchor,
+              headPage = 0,
+              headX = 10f,
+              headY = 20f,
+              baseSelection = null,
+              allowCollapse = true,
+            )
+          ),
           Message.Selection(SelectionOp.SetAt(page = 0, x = 10f, y = 20f)),
         ),
         fixture.fake.enqueued,
@@ -642,6 +664,7 @@ class EditorReadingModeInteractionTest {
     var editingRequestCount = 0
     var focusRequestCount = 0
     var softwareKeyboardRequestCount = 0
+    val pointerSelectionHeadVersions = mutableListOf<Long>()
     private var tapSequenceConfirmationJob: Job? = null
 
     override fun containsDocumentInteraction(positionInRoot: Offset): Boolean = true
@@ -711,7 +734,9 @@ class EditorReadingModeInteractionTest {
 
     override fun performSelectionHaptic() = Unit
 
-    override fun requestPointerSelectionHead(version: Long) = Unit
+    override fun requestPointerSelectionHead(version: Long) {
+      pointerSelectionHeadVersions += version
+    }
   }
 }
 

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorBringIntoViewRequestsTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorBringIntoViewRequestsTest.kt
@@ -1,8 +1,5 @@
 package co.typie.editor.scroll
 
-import co.typie.editor.EditorState
-import co.typie.editor.ffi.PageRect
-import co.typie.editor.ffi.Rect as FfiRect
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
@@ -10,39 +7,14 @@ import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class EditorBringIntoViewRequestsTest {
-  private val pageRectsTarget =
-    EditorBringIntoViewTarget.PageRects(
-      listOf(PageRect(pageIdx = 0, rect = FfiRect(x = 0f, y = 10f, width = 20f, height = 30f)))
-    )
-
-  @Test
-  fun `state-based request derives target and version from the same state`() {
-    val requests = EditorBringIntoViewRequests()
-    val state = EditorState.Initial.copy(version = 11L, selectionHitRects = pageRectsTarget.rects)
-
-    assertTrue(
-      requests.requestForState(
-        state,
-        policy = EditorBringIntoViewPolicy.Reveal,
-        behavior = EditorBringIntoViewBehavior.Smooth,
-      ) {
-        selectionHitRects.toPageRectsTarget()
-      }
-    )
-
-    assertNull(requests.activateForVersion(version = 10L))
-    val request = requests.activateForVersion(version = 11L)
-    assertTrue(request?.target == pageRectsTarget)
-    assertTrue(request?.policy == EditorBringIntoViewPolicy.Reveal)
-    assertTrue(request?.behavior == EditorBringIntoViewBehavior.Smooth)
-  }
+  private val trackedItemTarget = EditorBringIntoViewTarget.TrackedItem("comment-1")
 
   @Test
   fun `request behavior defaults to instant independently from reveal policy`() {
     val requests = EditorBringIntoViewRequests()
 
     requests.requestForVersion(
-      target = pageRectsTarget,
+      target = trackedItemTarget,
       version = 11L,
       policy = EditorBringIntoViewPolicy.Reveal,
     )
@@ -56,7 +28,7 @@ class EditorBringIntoViewRequestsTest {
     val requests = EditorBringIntoViewRequests()
 
     requests.requestForVersion(
-      target = pageRectsTarget,
+      target = trackedItemTarget,
       version = 11L,
       policy = EditorBringIntoViewPolicy.Reveal,
       behavior = EditorBringIntoViewBehavior.Smooth,
@@ -78,21 +50,6 @@ class EditorBringIntoViewRequestsTest {
     )
 
     assertTrue(wakes > 0)
-  }
-
-  @Test
-  fun `state-based request reports when state has no target`() {
-    val requests = EditorBringIntoViewRequests()
-
-    assertFalse(
-      requests.requestForState(
-        EditorState.Initial,
-        policy = EditorBringIntoViewPolicy.CursorGuard,
-      ) {
-        null
-      }
-    )
-    assertNull(requests.activateForVersion(version = EditorState.Initial.version))
   }
 
   @Test
@@ -120,8 +77,6 @@ class EditorBringIntoViewRequestsTest {
         policy = EditorBringIntoViewPolicy.Reveal,
       )
 
-    requests.discardObsoleteForVersion(version = 12L)
-
     assertSame(request, requests.activateForVersion(version = 12L))
     assertFalse(request.presentation.isCompleted)
   }
@@ -135,7 +90,8 @@ class EditorBringIntoViewRequestsTest {
         1L,
         EditorBringIntoViewPolicy.CursorGuard,
       )
-    val current = requests.requestForVersion(pageRectsTarget, 2L, EditorBringIntoViewPolicy.Reveal)
+    val current =
+      requests.requestForVersion(trackedItemTarget, 2L, EditorBringIntoViewPolicy.Reveal)
 
     assertTrue(previous.presentation.isCompleted)
     assertSame(current, requests.activateForVersion(version = 2L))
@@ -149,7 +105,7 @@ class EditorBringIntoViewRequestsTest {
         EditorBringIntoViewTarget.CurrentSelectionHead,
         EditorBringIntoViewPolicy.CursorGuard,
       )
-    val current = requests.declare(pageRectsTarget, EditorBringIntoViewPolicy.Reveal)
+    val current = requests.declare(trackedItemTarget, EditorBringIntoViewPolicy.Reveal)
 
     assertFalse(requests.bind(previous, version = 1L))
     assertTrue(requests.bind(current, version = 2L))
@@ -157,23 +113,7 @@ class EditorBringIntoViewRequestsTest {
   }
 
   @Test
-  fun `exact page rect request becomes obsolete when its revision is skipped`() {
-    val requests = EditorBringIntoViewRequests()
-    val request =
-      requests.requestForVersion(
-        pageRectsTarget,
-        version = 2L,
-        policy = EditorBringIntoViewPolicy.Reveal,
-      )
-
-    assertNull(requests.activateForVersion(version = 3L))
-    assertFalse(request.presentation.isCompleted)
-    requests.discardObsoleteForVersion(version = 3L)
-    assertTrue(request.presentation.isCompleted)
-  }
-
-  @Test
-  fun `pointer selection request is exact and becomes obsolete when its revision is skipped`() {
+  fun `pointer selection request remains eligible when a later revision provides geometry`() {
     val requests = EditorBringIntoViewRequests()
     val request =
       requests.requestForVersion(
@@ -184,13 +124,12 @@ class EditorBringIntoViewRequestsTest {
 
     assertNull(requests.activateForVersion(version = 1L))
     assertSame(request, requests.activateForVersion(version = 2L))
-    assertNull(requests.activateForVersion(version = 3L))
-    requests.discardObsoleteForVersion(version = 3L)
-    assertTrue(request.presentation.isCompleted)
+    assertSame(request, requests.activateForVersion(version = 3L))
+    assertFalse(request.presentation.isCompleted)
   }
 
   @Test
-  fun `new request supersedes an exact pointer selection reveal`() {
+  fun `new request supersedes a pending pointer selection reveal`() {
     val requests = EditorBringIntoViewRequests()
     val pointer =
       requests.requestForVersion(

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorScrollResolverTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorScrollResolverTest.kt
@@ -339,7 +339,8 @@ class EditorScrollResolverTest {
   }
 
   @Test
-  fun `typewriter mode does not apply to page rect targets`() {
+  fun `typewriter mode does not apply to tracked item targets`() {
+    val target = EditorBringIntoViewTarget.TrackedItem("comment-1")
     val frame =
       frame(
         state =
@@ -351,13 +352,9 @@ class EditorScrollResolverTest {
                 line = FfiRect(0f, 500f, 0f, 20f),
               ),
             pageSizes = listOf(PageSize(width = 300f, height = 900f)),
+            trackedRanges = listOf(trackedRange(id = target.id, y = 500f)),
           ),
         typewriterEnabled = true,
-      )
-
-    val target =
-      EditorBringIntoViewTarget.PageRects(
-        listOf(PageRect(pageIdx = 0, rect = FfiRect(0f, 500f, 0f, 20f)))
       )
 
     assertScrollTo(
@@ -519,7 +516,14 @@ class EditorScrollResolverTest {
   }
 
   @Test
-  fun `page rects target reveals the vertical union across pages`() {
+  fun `tracked item target reveals the vertical union across pages`() {
+    val target = EditorBringIntoViewTarget.TrackedItem("comment-1")
+    val rects =
+      listOf(
+        PageRect(pageIdx = 0, rect = FfiRect(x = 0f, y = 500f, width = 40f, height = 20f)),
+        PageRect(pageIdx = 0, rect = FfiRect(x = 0f, y = 580f, width = 40f, height = 20f)),
+        PageRect(pageIdx = 1, rect = FfiRect(x = 0f, y = 20f, width = 40f, height = 20f)),
+      )
     val frame =
       frame(
         state =
@@ -528,6 +532,7 @@ class EditorScrollResolverTest {
             selection = null,
             pageSizes =
               listOf(PageSize(width = 300f, height = 620f), PageSize(width = 300f, height = 620f)),
+            trackedRanges = listOf(trackedRange(id = target.id, rects = rects)),
           ),
         layoutSpec = paginatedLayout(),
       )
@@ -535,14 +540,7 @@ class EditorScrollResolverTest {
     val intent =
       resolveEditorScrollIntent(
         frame = frame,
-        target =
-          EditorBringIntoViewTarget.PageRects(
-            listOf(
-              PageRect(pageIdx = 0, rect = FfiRect(x = 0f, y = 500f, width = 40f, height = 20f)),
-              PageRect(pageIdx = 0, rect = FfiRect(x = 0f, y = 580f, width = 40f, height = 20f)),
-              PageRect(pageIdx = 1, rect = FfiRect(x = 0f, y = 20f, width = 40f, height = 20f)),
-            )
-          ),
+        target = target,
         policy = EditorBringIntoViewPolicy.Reveal,
         currentScroll = 0f,
       )
@@ -576,7 +574,8 @@ class EditorScrollResolverTest {
   }
 
   @Test
-  fun `page rects reveal top-aligns an oversized target below the viewport`() {
+  fun `tracked item reveal top-aligns an oversized target below the viewport`() {
+    val target = EditorBringIntoViewTarget.TrackedItem("comment-1")
     val frame =
       frame(
         state =
@@ -584,18 +583,26 @@ class EditorScrollResolverTest {
             cursor = null,
             selection = null,
             pageSizes = listOf(PageSize(width = 300f, height = 1000f)),
+            trackedRanges =
+              listOf(
+                trackedRange(
+                  id = target.id,
+                  rects =
+                    listOf(
+                      PageRect(
+                        pageIdx = 0,
+                        rect = FfiRect(x = 0f, y = 500f, width = 40f, height = 400f),
+                      )
+                    ),
+                )
+              ),
           )
       )
 
     val intent =
       resolveEditorScrollIntent(
         frame = frame,
-        target =
-          EditorBringIntoViewTarget.PageRects(
-            listOf(
-              PageRect(pageIdx = 0, rect = FfiRect(x = 0f, y = 500f, width = 40f, height = 400f))
-            )
-          ),
+        target = target,
         policy = EditorBringIntoViewPolicy.Reveal,
         currentScroll = 0f,
       )
@@ -631,7 +638,14 @@ class EditorScrollResolverTest {
   }
 
   @Test
-  fun `page rects target height resolves from the vertical union across pages`() {
+  fun `tracked item target height resolves from the vertical union across pages`() {
+    val target = EditorBringIntoViewTarget.TrackedItem("comment-1")
+    val rects =
+      listOf(
+        PageRect(pageIdx = 0, rect = FfiRect(x = 0f, y = 500f, width = 40f, height = 20f)),
+        PageRect(pageIdx = 0, rect = FfiRect(x = 0f, y = 580f, width = 40f, height = 20f)),
+        PageRect(pageIdx = 1, rect = FfiRect(x = 0f, y = 20f, width = 40f, height = 20f)),
+      )
     val height =
       resolveBringIntoViewTargetHeight(
         state =
@@ -640,16 +654,10 @@ class EditorScrollResolverTest {
             selection = null,
             pageSizes =
               listOf(PageSize(width = 300f, height = 620f), PageSize(width = 300f, height = 620f)),
+            trackedRanges = listOf(trackedRange(id = target.id, rects = rects)),
           ),
         layoutSpec = paginatedLayout(),
-        target =
-          EditorBringIntoViewTarget.PageRects(
-            listOf(
-              PageRect(pageIdx = 0, rect = FfiRect(x = 0f, y = 500f, width = 40f, height = 20f)),
-              PageRect(pageIdx = 0, rect = FfiRect(x = 0f, y = 580f, width = 40f, height = 20f)),
-              PageRect(pageIdx = 1, rect = FfiRect(x = 0f, y = 20f, width = 40f, height = 20f)),
-            )
-          ),
+        target = target,
         displayZoom = 1f,
       )
 
@@ -743,13 +751,16 @@ class EditorScrollResolverTest {
   }
 
   private fun trackedRange(id: String, y: Float): TrackedRange =
+    trackedRange(id = id, rects = listOf(PageRect(pageIdx = 0, rect = FfiRect(0f, y, 40f, 20f))))
+
+  private fun trackedRange(id: String, rects: List<PageRect>): TrackedRange =
     TrackedRange(
       id = id,
       group = "comment-active",
       anchor = position(offset = 0),
       head = position(offset = 1),
       metadata = "",
-      rects = listOf(PageRect(pageIdx = 0, rect = FfiRect(0f, y, 40f, 20f))),
+      rects = rects,
       text = "comment",
     )
 }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/viewport/EditorViewportAnchorStateTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/viewport/EditorViewportAnchorStateTest.kt
@@ -201,6 +201,33 @@ class EditorViewportAnchorStateTest {
     assertEquals(viewportIdentity, state.identity)
   }
 
+  @Test
+  fun `selection adoption compares stable anchor identity`() {
+    val state = EditorViewportAnchorState()
+    state.attachSelection(identity, geometry(pointY = 200f), scrollY = 100f)
+
+    assertFalse(state.needsSelectionAdoption(identity))
+    assertTrue(state.needsSelectionAdoption(viewportIdentity))
+  }
+
+  @Test
+  fun `preferred selection can change without replacing the active viewport anchor`() {
+    val state = EditorViewportAnchorState()
+    val visibleArea = EditorVisibleArea(viewport = Size(width = 300f, height = 300f))
+    state.attachViewport(viewportIdentity, geometry(pointY = 500f), scrollY = 350f)
+
+    state.adoptSelection(
+      identity = identity,
+      geometry = geometry(pointY = 200f),
+      scrollY = 350f,
+      visibleArea = visibleArea,
+      preserveActiveAnchor = true,
+    )
+
+    assertEquals(viewportIdentity, state.identity)
+    assertEquals(identity, state.preferredSelectionIdentity)
+  }
+
   private fun geometry(
     pointY: Float,
     top: Float? = null,

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/layout/EditorSurfacePreparationTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/layout/EditorSurfacePreparationTest.kt
@@ -9,6 +9,7 @@ import co.typie.editor.PublishedBundle
 import co.typie.editor.VerticalSpan
 import co.typie.editor.body.EditorDocumentLayoutSpec
 import co.typie.editor.ffi.Affinity
+import co.typie.editor.ffi.CapturedViewportAnchor
 import co.typie.editor.ffi.PageRect
 import co.typie.editor.ffi.Position
 import co.typie.editor.ffi.Rect
@@ -16,6 +17,7 @@ import co.typie.editor.ffi.ResolvedViewportAnchor
 import co.typie.editor.ffi.Selection
 import co.typie.editor.ffi.SelectionEndpoints
 import co.typie.editor.ffi.Size as PageSize
+import co.typie.editor.ffi.TrackedRange
 import co.typie.editor.ffi.ViewportAnchor
 import co.typie.editor.ffi.ViewportAnchorPoint
 import co.typie.editor.ffi.ViewportAnchorResolution
@@ -81,6 +83,16 @@ class EditorSurfacePreparationTest {
     val editor =
       Editor(
         FakeFfiEditor(
+          captureSelectionViewportAnchorProvider = {
+            CapturedViewportAnchor(
+              identity = identity,
+              geometry =
+                ResolvedViewportAnchor(
+                  point = ViewportAnchorPoint(pageIdx = 2, x = 0f, y = 250f),
+                  rect = measuredRect,
+                ),
+            )
+          },
           resolveViewportAnchorProvider = { _, _ ->
             ViewportAnchorResolution.Resolved(
               ResolvedViewportAnchor(
@@ -88,7 +100,7 @@ class EditorSurfacePreparationTest {
                 rect = measuredRect,
               )
             )
-          }
+          },
         ),
         this,
         StandardTestDispatcher(testScheduler),
@@ -149,13 +161,11 @@ class EditorSurfacePreparationTest {
         this,
         StandardTestDispatcher(testScheduler),
       )
-    val frame = frame()
+    val target = EditorBringIntoViewTarget.TrackedItem("comment-1")
+    val frame = frameWithTrackedItem(target.id)
     val request =
       EditorBringIntoViewRequests.Request(
-        target =
-          EditorBringIntoViewTarget.PageRects(
-            listOf(PageRect(pageIdx = 2, rect = Rect(x = 0f, y = 100f, width = 1f, height = 20f)))
-          ),
+        target = target,
         policy = EditorBringIntoViewPolicy.Reveal,
         behavior = EditorBringIntoViewBehavior.Instant,
       )
@@ -202,13 +212,11 @@ class EditorSurfacePreparationTest {
   @Test
   fun `disabled smooth motion prepares the destination like an instant reveal`() = runTest {
     val editor = Editor(FakeFfiEditor(), this, StandardTestDispatcher(testScheduler))
-    val frame = frame()
+    val target = EditorBringIntoViewTarget.TrackedItem("comment-1")
+    val frame = frameWithTrackedItem(target.id)
     val request =
       EditorBringIntoViewRequests.Request(
-        target =
-          EditorBringIntoViewTarget.PageRects(
-            listOf(PageRect(pageIdx = 2, rect = Rect(x = 0f, y = 100f, width = 1f, height = 20f)))
-          ),
+        target = target,
         policy = EditorBringIntoViewPolicy.Reveal,
         behavior = EditorBringIntoViewBehavior.Smooth,
       )
@@ -288,6 +296,32 @@ class EditorSurfacePreparationTest {
       headerHeight = 0f,
       density = 1f,
       editorBounds = EditorBoundsInContainer(x = 0f, y = 0f, width = 600f, height = 4_000f),
+    )
+  }
+
+  private fun frameWithTrackedItem(id: String): EditorScrollFrame {
+    val frame = frame()
+    val anchor = Position(node = "1:1", offset = 0, affinity = Affinity.Downstream)
+    val head = Position(node = "1:1", offset = 1, affinity = Affinity.Downstream)
+    return frame.copy(
+      state =
+        frame.state.copy(
+          trackedRanges =
+            listOf(
+              TrackedRange(
+                id = id,
+                group = "comment-active",
+                anchor = anchor,
+                head = head,
+                metadata = "",
+                rects =
+                  listOf(
+                    PageRect(pageIdx = 2, rect = Rect(x = 0f, y = 100f, width = 1f, height = 20f))
+                  ),
+                text = "comment",
+              )
+            )
+        )
     )
   }
 }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/layout/EditorViewportAnchorReconcilerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/layout/EditorViewportAnchorReconcilerTest.kt
@@ -6,11 +6,15 @@ import co.typie.editor.Editor
 import co.typie.editor.EditorState
 import co.typie.editor.FakeFfiEditor
 import co.typie.editor.PublishedBundle
+import co.typie.editor.VerticalSpan
 import co.typie.editor.body.EditorDocumentLayoutSpec
+import co.typie.editor.ffi.Affinity
 import co.typie.editor.ffi.CapturedViewportAnchor
 import co.typie.editor.ffi.PageRect
+import co.typie.editor.ffi.Position
 import co.typie.editor.ffi.Rect
 import co.typie.editor.ffi.ResolvedViewportAnchor
+import co.typie.editor.ffi.Selection
 import co.typie.editor.ffi.Size as PageSize
 import co.typie.editor.ffi.ViewportAnchor
 import co.typie.editor.ffi.ViewportAnchorPoint
@@ -20,8 +24,10 @@ import co.typie.editor.scroll.EditorBringIntoViewTarget
 import co.typie.editor.scroll.EditorScrollFrame
 import co.typie.editor.scroll.EditorVisibleArea
 import co.typie.editor.scroll.resolveEditorAutoScrollPolicy
+import co.typie.editor.viewport.EditorViewportAnchorGeometry
 import co.typie.editor.viewport.EditorViewportAnchorState
 import co.typie.editor.viewport.EditorViewportState
+import co.typie.editor.viewport.resolveViewportAnchorContentOriginY
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -31,6 +37,7 @@ import kotlinx.coroutines.test.runTest
 
 class EditorViewportAnchorReconcilerTest {
   private val selectionAnchor = ViewportAnchor.Node(node = "1:1", offsetX = 0f, offsetY = 0f)
+  private val movedSelectionAnchor = ViewportAnchor.Node(node = "1:2", offsetX = 0f, offsetY = 0f)
   private val viewportAnchor = ViewportAnchor.Node(node = "2:1", offsetX = 0f, offsetY = 0f)
 
   @Test
@@ -98,10 +105,7 @@ class EditorViewportAnchorReconcilerTest {
         visibleArea = visibleArea,
         mode = EditorViewportScrollReconcileMode.Enabled,
         smoothRevealActive = false,
-        handoffTarget =
-          EditorBringIntoViewTarget.PageRects(
-            listOf(PageRect(pageIdx = 0, rect = Rect(0f, 500f, 1f, 20f)))
-          ),
+        handoffTarget = EditorBringIntoViewTarget.TrackedItem("comment-1"),
         selectionRevealOrigin = null,
         contentOriginY = 0f,
       )
@@ -237,6 +241,251 @@ class EditorViewportAnchorReconcilerTest {
     assertTrue(viewportState.lastScrollWasAuto)
   }
 
+  @Test
+  fun `selection change attaches without scrolling then viewport shrink keeps it guarded`() =
+    runTest {
+      val visibleArea = visibleArea()
+      val occluded = visibleArea(bottomOcclusionInset = 100f)
+      val initialFrame =
+        frame(visibleArea).let { frame ->
+          frame.copy(
+            state =
+              frame.state.copy(
+                selection =
+                  Selection(
+                    anchor = Position("text", 0, Affinity.Downstream),
+                    head = Position("text", 0, Affinity.Downstream),
+                  )
+              )
+          )
+        }
+      val movedFrame =
+        initialFrame.copy(
+          state =
+            initialFrame.state.copy(
+              version = 2L,
+              selection =
+                Selection(
+                  anchor = Position("text", 1, Affinity.Downstream),
+                  head = Position("text", 1, Affinity.Downstream),
+                ),
+            )
+        )
+      val anchorState = EditorViewportAnchorState()
+      val viewportState = viewportState(scrollY = 100f)
+      var currentSelectionAnchor = selectionAnchor
+      val geometries =
+        mapOf(
+          selectionAnchor to selectionGeometry(200f),
+          movedSelectionAnchor to selectionGeometry(340f),
+          viewportAnchor to
+            ResolvedViewportAnchor(
+              point = ViewportAnchorPoint(pageIdx = 0, x = 0f, y = 500f),
+              rect = null,
+            ),
+        )
+      val editor =
+        Editor(
+          FakeFfiEditor(
+            captureSelectionViewportAnchorProvider = {
+              val geometry = geometries.getValue(currentSelectionAnchor)
+              CapturedViewportAnchor(identity = currentSelectionAnchor, geometry = geometry)
+            },
+            captureViewportAnchorAtProvider = { _, _ ->
+              CapturedViewportAnchor(
+                identity = viewportAnchor,
+                geometry = geometries.getValue(viewportAnchor),
+              )
+            },
+            resolveViewportAnchorProvider = { _, anchor ->
+              geometries[anchor]?.let(ViewportAnchorResolution::Resolved)
+                ?: ViewportAnchorResolution.Deleted
+            },
+          ),
+          this,
+          StandardTestDispatcher(testScheduler),
+        )
+
+      reconcile(editor, anchorState, initialFrame, viewportState, visibleArea)
+      currentSelectionAnchor = movedSelectionAnchor
+      val publication =
+        reconcileViewportAnchorPublication(
+          editor = editor,
+          anchorState = anchorState,
+          publishedBundle = PublishedBundle(snapshot = initialFrame.state, frames = emptyMap()),
+          candidateState = movedFrame.state,
+          measuredScrollFrame = movedFrame,
+          currentScrollOffset = viewportState.scrollOffset,
+          maximumScrollY = viewportState.maxScrollY,
+          contentOriginY = 0f,
+        )
+
+      assertEquals(movedSelectionAnchor, anchorState.identity)
+      assertEquals(movedSelectionAnchor, anchorState.preferredSelectionIdentity)
+      assertEquals(Offset(x = 0f, y = 100f), viewportState.scrollOffset)
+
+      (publication as EditorViewportAnchorPublication.Ready).geometry?.let { geometry ->
+        anchorState.acceptGeometry(geometry, viewportState.scrollOffset.y)
+      }
+      reconcile(editor, anchorState, movedFrame, viewportState, visibleArea)
+
+      reconcile(
+        editor,
+        anchorState,
+        movedFrame.copy(visibleArea = occluded),
+        viewportState,
+        occluded,
+      )
+
+      assertEquals(Offset(x = 0f, y = 210f), viewportState.scrollOffset)
+      assertTrue(viewportState.lastScrollWasAuto)
+    }
+
+  @Test
+  fun `initial selection outside the guard keeps the viewport center active`() = runTest {
+    val visibleArea = visibleArea()
+    val initialFrame =
+      frame(visibleArea).let { frame ->
+        frame.copy(
+          state =
+            frame.state.copy(
+              selection =
+                Selection(
+                  anchor = Position("text", 0, Affinity.Downstream),
+                  head = Position("text", 0, Affinity.Downstream),
+                )
+            )
+        )
+      }
+    val anchorState = EditorViewportAnchorState()
+    val viewportState = viewportState(scrollY = 100f)
+    val editor = editor(selectionY = 500f)
+
+    reconcileViewportAnchorPublication(
+      editor = editor,
+      anchorState = anchorState,
+      publishedBundle = null,
+      candidateState = initialFrame.state,
+      measuredScrollFrame = initialFrame,
+      currentScrollOffset = viewportState.scrollOffset,
+      maximumScrollY = viewportState.maxScrollY,
+      contentOriginY = 0f,
+    )
+    reconcile(editor, anchorState, initialFrame, viewportState, visibleArea)
+
+    assertEquals(viewportAnchor, anchorState.identity)
+    assertEquals(selectionAnchor, anchorState.preferredSelectionIdentity)
+    assertEquals(Offset(x = 0f, y = 100f), viewportState.scrollOffset)
+  }
+
+  @Test
+  fun `selection removal adopts the viewport center without scrolling`() = runTest {
+    val visibleArea = visibleArea()
+    val initialFrame =
+      frame(visibleArea).let { frame ->
+        frame.copy(
+          state =
+            frame.state.copy(
+              selection =
+                Selection(
+                  anchor = Position("text", 0, Affinity.Downstream),
+                  head = Position("text", 0, Affinity.Downstream),
+                )
+            )
+        )
+      }
+    val candidateFrame =
+      initialFrame.copy(state = initialFrame.state.copy(version = 2L, selection = null))
+    val anchorState =
+      EditorViewportAnchorState().apply {
+        attachSelection(selectionAnchor, anchorGeometry(200f), scrollY = 100f)
+      }
+    val editor =
+      Editor(
+        FakeFfiEditor(
+          captureViewportAnchorAtProvider = { _, _ ->
+            CapturedViewportAnchor(identity = viewportAnchor, geometry = selectionGeometry(500f))
+          },
+          resolveViewportAnchorProvider = { _, anchor ->
+            when (anchor) {
+              selectionAnchor -> ViewportAnchorResolution.Resolved(selectionGeometry(200f))
+              viewportAnchor -> ViewportAnchorResolution.Resolved(selectionGeometry(500f))
+              else -> ViewportAnchorResolution.Deleted
+            }
+          },
+        ),
+        this,
+        StandardTestDispatcher(testScheduler),
+      )
+
+    val publication =
+      reconcileViewportAnchorPublication(
+        editor = editor,
+        anchorState = anchorState,
+        publishedBundle = PublishedBundle(snapshot = initialFrame.state, frames = emptyMap()),
+        candidateState = candidateFrame.state,
+        measuredScrollFrame = candidateFrame,
+        currentScrollOffset = Offset(x = 0f, y = 100f),
+        maximumScrollY = 600f,
+        contentOriginY = resolveViewportAnchorContentOriginY(candidateFrame),
+      )
+
+    assertEquals(viewportAnchor, anchorState.identity)
+    assertEquals(null, anchorState.preferredSelectionIdentity)
+    assertEquals(100f, (publication as EditorViewportAnchorPublication.Ready).scrollY)
+  }
+
+  @Test
+  fun `unresolved candidate selection keeps the existing anchors and withholds publication`() =
+    runTest {
+      val visibleArea = visibleArea()
+      val initialFrame =
+        frame(visibleArea).let { frame ->
+          frame.copy(
+            state =
+              frame.state.copy(
+                selection =
+                  Selection(
+                    anchor = Position("text", 0, Affinity.Downstream),
+                    head = Position("text", 0, Affinity.Downstream),
+                  )
+              )
+          )
+        }
+      val candidateFrame = initialFrame.copy(state = initialFrame.state.copy(version = 2L))
+      val anchorState =
+        EditorViewportAnchorState().apply {
+          attachSelection(selectionAnchor, anchorGeometry(200f), scrollY = 100f)
+        }
+      val editor =
+        Editor(
+          FakeFfiEditor(
+            captureSelectionViewportAnchorProvider = { null },
+            resolveViewportAnchorProvider = { _, _ ->
+              ViewportAnchorResolution.Resolved(selectionGeometry(200f))
+            },
+          ),
+          this,
+          StandardTestDispatcher(testScheduler),
+        )
+
+      val publication =
+        reconcileViewportAnchorPublication(
+          editor = editor,
+          anchorState = anchorState,
+          publishedBundle = PublishedBundle(snapshot = initialFrame.state, frames = emptyMap()),
+          candidateState = candidateFrame.state,
+          measuredScrollFrame = candidateFrame,
+          currentScrollOffset = Offset(x = 0f, y = 100f),
+          maximumScrollY = 600f,
+          contentOriginY = 0f,
+        )
+
+      assertEquals(EditorViewportAnchorPublication.Withhold, publication)
+      assertEquals(selectionAnchor, anchorState.identity)
+      assertEquals(selectionAnchor, anchorState.preferredSelectionIdentity)
+    }
+
   private fun reconcile(
     editor: Editor,
     anchorState: EditorViewportAnchorState,
@@ -310,6 +559,18 @@ class EditorViewportAnchorReconcilerTest {
       StandardTestDispatcher(testScheduler),
     )
   }
+
+  private fun selectionGeometry(selectionY: Float): ResolvedViewportAnchor =
+    ResolvedViewportAnchor(
+      point = ViewportAnchorPoint(pageIdx = 0, x = 0f, y = selectionY),
+      rect = PageRect(pageIdx = 0, rect = Rect(0f, selectionY - 10f, 1f, 20f)),
+    )
+
+  private fun anchorGeometry(selectionY: Float): EditorViewportAnchorGeometry =
+    EditorViewportAnchorGeometry(
+      pointY = selectionY,
+      rect = VerticalSpan(top = selectionY - 10f, bottom = selectionY + 10f),
+    )
 
   private fun viewportState(scrollY: Float): EditorViewportState =
     EditorViewportState().apply {

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/EditorFrameSyncDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/EditorFrameSyncDesktopTest.kt
@@ -36,8 +36,6 @@ import co.typie.editor.ext.isCollapsed
 import co.typie.editor.ffi.Key
 import co.typie.editor.ffi.KeyEvent
 import co.typie.editor.ffi.Message
-import co.typie.editor.ffi.PageRect
-import co.typie.editor.ffi.Rect as FfiRect
 import co.typie.editor.ffi.SelectionOp
 import co.typie.editor.ffi.SelectionPointUnit
 import co.typie.editor.interaction.EditorInteractionScope
@@ -538,10 +536,17 @@ class EditorFrameSyncDesktopTest {
         fixture.editor.publishedBundle?.frames?.containsKey(0) == true
       }
 
-      val target =
-        EditorBringIntoViewTarget.PageRects(
-          listOf(PageRect(pageIdx = 0, rect = FfiRect(x = 0f, y = 100f, width = 1f, height = 10f)))
+      val cursorUpdate = runOnIdle {
+        assertNotNull(
+          fixture.editor.updateNow { repeat(2) { enqueue(Message.Key(KeyEvent(Key.Enter))) } }
         )
+      }
+      waitUntil(timeoutMillis = 10_000) {
+        (fixture.editor.publishedRevision ?: -1L) >= cursorUpdate.revision
+      }
+      waitForIdle()
+
+      val target = EditorBringIntoViewTarget.CurrentSelectionHead
       assertEquals(
         EditorScrollIntentResult.NoScroll,
         resolveEditorScrollIntent(

--- a/apps/website/src/lib/editor-ffi/editor-publication.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor-publication.svelte.ts
@@ -50,7 +50,6 @@ function reconcilePublication(
 ): void {
   if (editor.terminal) return;
 
-  scroll.discardObsoleteForRevision(editor.appliedSnapshot.revision);
   const anchorPublication = scroll.prepareViewportAnchorPublication(editor.appliedSnapshot);
   if (anchorPublication.type === 'unavailable') return;
   const preparation = resolveEditorSurfacePreparation(editor, scroll, anchorPublication.targetScrollTop ?? undefined);

--- a/apps/website/src/lib/editor-ffi/handlers/pointer.test.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/pointer.test.ts
@@ -233,6 +233,17 @@ describe('pointer native drag admission', () => {
     });
   });
 
+  it('updates a read-only mouse selection without requesting pointer guard reveal', () => {
+    const editor = createEditor({ readOnly: true });
+    const target = createPointerTarget({ captured: true });
+
+    handlePointerDown(editor, createPointerEvent({ target }));
+    handlePointerUp(editor, createPointerEvent({ target }));
+
+    expect(editor.enqueue).toHaveBeenCalledWith({ type: 'selection', op: { type: 'set_at', page: 0, x: 10, y: 20 } });
+    expect(editor.scrollIntoView).not.toHaveBeenCalled();
+  });
+
   it('promotes a rapid third click inside the selected word to paragraph selection', () => {
     const editor = createEditor();
     const target = createPointerTarget({ captured: true });

--- a/apps/website/src/lib/editor-ffi/handlers/pointer.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/pointer.ts
@@ -117,7 +117,9 @@ export const handlePointerDown: EditorEventHandler<HTMLElement, PointerEvent> = 
       }
     });
     interactionSelection = update?.snapshot.selection;
-    editor.scrollIntoView({ target: { type: 'current_selection_head' }, policy: 'pointer_cursor_guard' });
+    if (!editor.readOnly) {
+      editor.scrollIntoView({ target: { type: 'current_selection_head' }, policy: 'pointer_cursor_guard' });
+    }
   }
   state.markPointerDown(e.pointerId, !nativeDragCandidate, { page, x, y }, count, modifiers, nativeDragCandidate, interactionSelection);
   if (!nativeDragCandidate) {
@@ -374,7 +376,9 @@ class PointerState {
           op: { type: 'set_at', page: session.down.page, x: session.down.x, y: session.down.y },
         }),
       );
-      editor.scrollIntoView({ target: { type: 'current_selection_head' }, policy: 'pointer_cursor_guard' });
+      if (!editor.readOnly) {
+        editor.scrollIntoView({ target: { type: 'current_selection_head' }, policy: 'pointer_cursor_guard' });
+      }
     }
     this.#edgeAutoScroll.stop();
     this.#session = null;

--- a/apps/website/src/lib/editor-ffi/scroll-scope.test.ts
+++ b/apps/website/src/lib/editor-ffi/scroll-scope.test.ts
@@ -341,7 +341,7 @@ describe('EditorScrollScope', () => {
     expect(scope.resolvePreparationViewports(request, metrics, snapshot)).toContainEqual({ top: 380, bottom: 780 });
   });
 
-  it('treats pointer selection reveals as exact-revision requests and discards skipped revisions', async () => {
+  it('keeps pointer selection reveals eligible across later revisions', () => {
     const snapshot = trackedSnapshot('target', {
       page_idx: 0,
       rect: { x: 0, y: 0, width: 1, height: 20 },
@@ -355,10 +355,8 @@ describe('EditorScrollScope', () => {
 
     expect(scope.activateForRevision(6)).toBeNull();
     expect(scope.activateForRevision(7)).toBe(request);
-    expect(scope.activateForRevision(8)).toBeNull();
-    scope.discardObsoleteForRevision(8);
-    await expect(request.presentation).resolves.toBeUndefined();
-    expect(scope.pendingRequest).toBeNull();
+    expect(scope.activateForRevision(8)).toBe(request);
+    expect(scope.pendingRequest).toBe(request);
   });
 
   it('keeps a declared reveal ineligible until the installing revision binds it', () => {
@@ -738,6 +736,157 @@ describe('EditorScrollScope', () => {
     scope.applyViewportAnchorPublication(publication);
     expect(scrollTo).toHaveBeenCalledExactlyOnceWith({ top: 220, behavior: 'instant' });
     expect(scrollTop).toBe(220);
+  });
+
+  it('attaches a changed selection without scrolling then guards it after the viewport shrinks', () => {
+    const initial = selectionSnapshot(true, {
+      page_idx: 0,
+      rect: { x: 0, y: 90, width: 1, height: 20 },
+    });
+    const nextPosition = { node: 'text', offset: 1, affinity: 'downstream' as const };
+    const nextRect = { page_idx: 0, rect: { x: 0, y: 340, width: 1, height: 20 } };
+    const next = {
+      ...selectionSnapshot(true, nextRect),
+      revision: 2,
+      selection: { anchor: nextPosition, head: nextPosition },
+      selectionEndpoints: {
+        from: nextRect,
+        to: nextRect,
+        from_position: nextPosition,
+        to_position: nextPosition,
+      },
+    } as EditorSnapshot;
+    const { editor, getScrollTop, scope, scrollTo } = setup(initial);
+    const initialAnchor = { type: 'node' as const, node: 'selection-1', offset_x: 0, offset_y: 0 };
+    const nextAnchor = { type: 'node' as const, node: 'selection-2', offset_x: 0, offset_y: 0 };
+    const initialGeometry = {
+      point: { page_idx: 0, x: 0, y: 100 },
+      rect: { page_idx: 0, rect: { x: 0, y: 90, width: 1, height: 20 } },
+    };
+    const nextGeometry = {
+      point: { page_idx: 0, x: 0, y: 350 },
+      rect: nextRect,
+    };
+    let capture = { identity: initialAnchor, geometry: initialGeometry };
+    editor.captureSelectionViewportAnchor = vi.fn(() => capture);
+    editor.resolveViewportAnchor = vi.fn((_revision, identity) => ({
+      type: 'resolved' as const,
+      geometry: identity === initialAnchor ? initialGeometry : nextGeometry,
+    }));
+
+    expect(scope.prepareViewportAnchorPublication(initial).type).toBe('ready');
+    capture = { identity: nextAnchor, geometry: nextGeometry };
+    Object.assign(editor, {
+      published: { snapshot: next, frames: editor.published?.frames ?? new Map() },
+      publishedRevision: next.revision,
+    });
+
+    const publication = scope.prepareViewportAnchorPublication(next);
+    scope.applyViewportAnchorPublication(publication);
+
+    expect(scrollTo).not.toHaveBeenCalled();
+    expect(getScrollTop()).toBe(0);
+
+    scope.setVisibleArea({ topInset: 0, bottomInset: 100 });
+
+    expect(scrollTo).toHaveBeenCalledExactlyOnceWith({ top: 120, behavior: 'instant' });
+    expect(getScrollTop()).toBe(120);
+  });
+
+  it('keeps the viewport center active for an initial selection outside the guard', () => {
+    const initial = selectionSnapshot(true, {
+      page_idx: 0,
+      rect: { x: 0, y: 490, width: 1, height: 20 },
+    });
+    const { editor, scope } = setup(initial);
+    const selection = { type: 'node' as const, node: 'selection', offset_x: 0, offset_y: 0 };
+    const viewport = { type: 'node' as const, node: 'viewport', offset_x: 0, offset_y: 0 };
+    const selectionGeometry = {
+      point: { page_idx: 0, x: 0, y: 500 },
+      rect: { page_idx: 0, rect: { x: 0, y: 490, width: 1, height: 20 } },
+    };
+    const viewportGeometry = { point: { page_idx: 0, x: 0, y: 200 }, rect: undefined };
+    editor.captureSelectionViewportAnchor = vi.fn(() => ({ identity: selection, geometry: selectionGeometry }));
+    editor.captureViewportAnchorAt = vi.fn(() => ({ identity: viewport, geometry: viewportGeometry }));
+    editor.resolveViewportAnchor = vi.fn((_revision, identity) => ({
+      type: 'resolved' as const,
+      geometry: identity.node === selection.node ? selectionGeometry : viewportGeometry,
+    }));
+
+    expect(scope.prepareViewportAnchorPublication(initial)).toEqual({
+      type: 'ready',
+      geometry: { pointY: 200 },
+      targetScrollTop: 0,
+    });
+  });
+
+  it('adopts the viewport center without scrolling when selection is removed', () => {
+    const initial = selectionSnapshot(true, {
+      page_idx: 0,
+      rect: { x: 0, y: 90, width: 1, height: 20 },
+    });
+    const candidate = {
+      ...initial,
+      revision: 2,
+      cursor: undefined,
+      selection: undefined,
+      selectionEndpoints: undefined,
+    } as EditorSnapshot;
+    const { editor, scope, scrollTo } = setup(initial);
+    const selection = { type: 'node' as const, node: 'selection', offset_x: 0, offset_y: 0 };
+    const viewport = { type: 'node' as const, node: 'viewport', offset_x: 0, offset_y: 0 };
+    const selectionGeometry = {
+      point: { page_idx: 0, x: 0, y: 100 },
+      rect: { page_idx: 0, rect: { x: 0, y: 90, width: 1, height: 20 } },
+    };
+    const viewportGeometry = { point: { page_idx: 0, x: 0, y: 500 }, rect: undefined };
+    let capture: { identity: typeof selection; geometry: typeof selectionGeometry } | undefined = {
+      identity: selection,
+      geometry: selectionGeometry,
+    };
+    editor.captureSelectionViewportAnchor = vi.fn(() => capture);
+    editor.captureViewportAnchorAt = vi.fn(() => ({ identity: viewport, geometry: viewportGeometry }));
+    editor.resolveViewportAnchor = vi.fn((_revision, identity) => ({
+      type: 'resolved' as const,
+      geometry: identity.node === selection.node ? selectionGeometry : viewportGeometry,
+    }));
+
+    expect(scope.prepareViewportAnchorPublication(initial).type).toBe('ready');
+    capture = undefined;
+
+    expect(scope.prepareViewportAnchorPublication(candidate)).toEqual({
+      type: 'ready',
+      geometry: { pointY: 500 },
+      targetScrollTop: 0,
+    });
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+
+  it('keeps existing anchors and withholds publication while candidate selection geometry is unavailable', () => {
+    const initial = selectionSnapshot(true, {
+      page_idx: 0,
+      rect: { x: 0, y: 90, width: 1, height: 20 },
+    });
+    const candidate = { ...initial, revision: 2 } as EditorSnapshot;
+    const { editor, scope } = setup(initial);
+    const selection = { type: 'node' as const, node: 'selection', offset_x: 0, offset_y: 0 };
+    const geometry = {
+      point: { page_idx: 0, x: 0, y: 100 },
+      rect: { page_idx: 0, rect: { x: 0, y: 90, width: 1, height: 20 } },
+    };
+    let capture: { identity: typeof selection; geometry: typeof geometry } | undefined = { identity: selection, geometry };
+    editor.captureSelectionViewportAnchor = vi.fn(() => capture);
+    editor.resolveViewportAnchor = vi.fn(() => ({ type: 'resolved' as const, geometry }));
+
+    expect(scope.prepareViewportAnchorPublication(initial).type).toBe('ready');
+    capture = undefined;
+
+    expect(scope.prepareViewportAnchorPublication(candidate)).toEqual({ type: 'unavailable' });
+    capture = { identity: { ...selection }, geometry };
+    expect(scope.prepareViewportAnchorPublication(initial)).toMatchObject({
+      type: 'ready',
+      geometry: { pointY: 100 },
+    });
   });
 
   it('does not withhold a publication when a live anchor has no candidate geometry', () => {

--- a/apps/website/src/lib/editor-ffi/scroll.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/scroll.svelte.ts
@@ -11,7 +11,7 @@ import {
 } from './scroll';
 import { SmoothScrollMotion } from './smooth-scroll-motion';
 import { EditorViewportAnchorState, resolveViewportAnchorGeometry, viewportCenterAnchorPoint } from './viewport-anchor';
-import type { PageRect } from '@typie/editor-ffi/browser';
+import type { PageRect, ViewportAnchorResolution } from '@typie/editor-ffi/browser';
 import type { Editor, EditorContext, EditorSnapshot } from './editor.svelte';
 import type { EditorRequest } from './editor-update';
 import type { VerticalSpan } from './required-surface-pages';
@@ -246,15 +246,7 @@ export class EditorScrollScope {
   activateForRevision(revision: number): EditorBringIntoViewRequest | null {
     const request = this.#pendingRequest;
     if (!request || request.targetRevision === null) return null;
-    const eligible = request.policy === 'pointer_cursor_guard' ? revision === request.targetRevision : revision >= request.targetRevision;
-    return eligible ? request : null;
-  }
-
-  discardObsoleteForRevision(revision: number): void {
-    const request = this.#pendingRequest;
-    if (request?.policy === 'pointer_cursor_guard' && request.targetRevision !== null && revision > request.targetRevision) {
-      this.discard(request);
-    }
+    return revision >= request.targetRevision ? request : null;
   }
 
   discard(request: EditorBringIntoViewRequest): void {
@@ -286,6 +278,25 @@ export class EditorScrollScope {
   prepareViewportAnchorPublication(snapshot: EditorSnapshot): EditorViewportAnchorPublication {
     const viewport = this.#editor.scrollViewport;
     if (!viewport) return { type: 'ready', geometry: null, targetScrollTop: null };
+    const selectionCapture = this.#editor.captureSelectionViewportAnchor(snapshot.revision);
+    if (!selectionCapture && snapshot.selection) return { type: 'unavailable' };
+    if (selectionCapture && this.#viewportAnchor.needsSelectionAdoption(selectionCapture.identity)) {
+      const selectionMetrics = this.#viewportMetrics(snapshot, true);
+      if (!selectionMetrics) return { type: 'unavailable' };
+      const selectionGeometry = resolveViewportAnchorGeometry(selectionCapture.geometry, selectionMetrics.layout);
+      if (!selectionGeometry) return { type: 'unavailable' };
+      this.#viewportAnchor.adoptSelection(
+        selectionCapture.identity,
+        selectionGeometry,
+        selectionMetrics.scrollTop,
+        selectionMetrics.clientHeight,
+        this.visibleArea,
+        this.#smoothMotion !== null,
+      );
+    } else if (!snapshot.selection && this.#viewportAnchor.preferredSelectionIdentity) {
+      if (!this.#smoothMotion && !this.#attachViewportCenter()) return { type: 'unavailable' };
+      this.#viewportAnchor.clearPreferredSelection();
+    }
     if (this.#smoothMotion) this.#attachViewportCenter();
     else this.#ensureViewportAnchor();
 
@@ -298,20 +309,12 @@ export class EditorScrollScope {
       targetScrollTop: clampedScrollTop === metrics.scrollTop ? null : clampedScrollTop,
     });
 
-    const identity = this.#viewportAnchor.identity;
-    if (!identity) return fallbackPublication();
-    let resolution = this.#editor.resolveViewportAnchor(snapshot.revision, identity);
+    const resolution = this.#resolveCandidateViewportAnchor(snapshot);
+    if (!resolution) return fallbackPublication();
     if (resolution.type === 'unavailable') return { type: 'unavailable' };
     if (resolution.type === 'deleted' || resolution.type === 'not_laid_out') {
-      this.#attachViewportCenter();
-      const fallback = this.#viewportAnchor.identity;
-      if (!fallback) return fallbackPublication();
-      resolution = this.#editor.resolveViewportAnchor(snapshot.revision, fallback);
-      if (resolution.type === 'unavailable') return { type: 'unavailable' };
-      if (resolution.type === 'deleted' || resolution.type === 'not_laid_out') {
-        this.#viewportAnchor.clear();
-        return fallbackPublication();
-      }
+      this.#viewportAnchor.clear();
+      return fallbackPublication();
     }
 
     const geometry = resolveViewportAnchorGeometry(resolution.geometry, metrics.layout);
@@ -490,6 +493,17 @@ export class EditorScrollScope {
   }
 
   // eslint-disable-next-line unicorn/consistent-class-member-order -- public scroll contract is grouped before private policy details
+  #resolveCandidateViewportAnchor(snapshot: EditorSnapshot): ViewportAnchorResolution | null {
+    const identity = this.#viewportAnchor.identity;
+    if (!identity) return null;
+    const resolution = this.#editor.resolveViewportAnchor(snapshot.revision, identity);
+    if (resolution.type !== 'deleted' && resolution.type !== 'not_laid_out') return resolution;
+
+    this.#attachViewportCenter();
+    const fallback = this.#viewportAnchor.identity;
+    return fallback ? this.#editor.resolveViewportAnchor(snapshot.revision, fallback) : null;
+  }
+
   #resolvePolicy(
     request: Pick<EditorBringIntoViewRequest, 'target' | 'policy'>,
     snapshot: EditorSnapshot,
@@ -596,10 +610,10 @@ export class EditorScrollScope {
     this.#attachViewportCenter();
   }
 
-  #attachViewportCenter(): void {
+  #attachViewportCenter(): boolean {
     const snapshot = this.#editor.published?.snapshot;
     const metrics = this.#viewportMetrics(snapshot);
-    if (!snapshot || !metrics) return;
+    if (!snapshot || !metrics) return false;
     const viewportRect = this.#editor.scrollViewport?.getRect();
     const topInset = Math.max(0, this.visibleArea.topInset);
     const visibleHeight = Math.max(0, metrics.clientHeight - topInset - Math.max(0, this.visibleArea.bottomInset));
@@ -612,11 +626,13 @@ export class EditorScrollScope {
     const point = local
       ? { page_idx: local.page, x: local.x, y: local.y }
       : viewportCenterAnchorPoint(snapshot, metrics.layout, metrics.scrollTop, metrics.clientHeight, this.visibleArea);
-    if (!point) return;
+    if (!point) return false;
     const capture = this.#editor.captureViewportAnchorAt(snapshot.revision, point);
-    if (!capture) return;
+    if (!capture) return false;
     const geometry = resolveViewportAnchorGeometry(capture.geometry, metrics.layout);
-    if (geometry) this.#viewportAnchor.attachViewport(capture.identity, geometry, metrics.scrollTop);
+    if (!geometry) return false;
+    this.#viewportAnchor.attachViewport(capture.identity, geometry, metrics.scrollTop);
+    return true;
   }
 
   #selectionRevealOrigin(request: EditorBringIntoViewRequest, scrollTop: number | undefined): EditorViewportAnchorRevealOrigin | undefined {

--- a/apps/website/src/lib/editor-ffi/viewport-anchor.test.ts
+++ b/apps/website/src/lib/editor-ffi/viewport-anchor.test.ts
@@ -88,4 +88,22 @@ describe('EditorViewportAnchorState', () => {
     expect(state.tryReactivatePreferredSelection({ pointY: 200 }, 100, 300, visibleArea)).toBe(false);
     expect(state.identity).toBe(viewportIdentity);
   });
+
+  it('compares selection adoption by stable anchor identity', () => {
+    const state = new EditorViewportAnchorState();
+    state.attachSelection(identity, { pointY: 200 }, 100);
+
+    expect(state.needsSelectionAdoption({ ...identity })).toBe(false);
+    expect(state.needsSelectionAdoption(viewportIdentity)).toBe(true);
+  });
+
+  it('updates the preferred selection without replacing the active viewport anchor', () => {
+    const state = new EditorViewportAnchorState();
+    state.attachViewport(viewportIdentity, { pointY: 500 }, 350);
+
+    state.adoptSelection(identity, { pointY: 200 }, 350, 300, visibleArea, true);
+
+    expect(state.identity).toBe(viewportIdentity);
+    expect(state.preferredSelectionIdentity).toBe(identity);
+  });
 });

--- a/apps/website/src/lib/editor-ffi/viewport-anchor.ts
+++ b/apps/website/src/lib/editor-ffi/viewport-anchor.ts
@@ -1,4 +1,5 @@
 import { clamp } from '@typie/ui/utils';
+import stringify from 'fast-json-stable-stringify';
 import { CURSOR_VISIBLE_MARGIN } from './constants';
 import { resolveGuardedScrollTop } from './scroll';
 import type { ResolvedViewportAnchor, ViewportAnchor, ViewportAnchorPoint } from '@typie/editor-ffi/browser';
@@ -61,6 +62,10 @@ export class EditorViewportAnchorState {
     this.#preferredSelection = null;
   }
 
+  needsSelectionAdoption(identity: ViewportAnchor): boolean {
+    return this.#preferredSelection === null || stringify(this.#preferredSelection) !== stringify(identity);
+  }
+
   attach(identity: ViewportAnchor, geometry: EditorViewportAnchorGeometry, scrollTop: number): void {
     this.#attachActive(identity, geometry, scrollTop);
   }
@@ -77,6 +82,21 @@ export class EditorViewportAnchorState {
 
   attachViewport(identity: ViewportAnchor, geometry: EditorViewportAnchorGeometry, scrollTop: number): void {
     this.#attachActive(identity, geometry, scrollTop);
+  }
+
+  adoptSelection(
+    identity: ViewportAnchor,
+    geometry: EditorViewportAnchorGeometry,
+    scrollTop: number,
+    clientHeight: number,
+    visibleArea: EditorVisibleArea,
+    preserveActiveAnchor: boolean,
+  ): void {
+    if (!this.needsSelectionAdoption(identity)) return;
+    const activate =
+      !preserveActiveAnchor && (this.#active !== null || this.canRetainAfterDirectScroll(geometry, scrollTop, clientHeight, visibleArea));
+    this.#preferredSelection = identity;
+    if (activate) this.#attachActive(identity, geometry, scrollTop);
   }
 
   clearPreferredSelection(): void {


### PR DESCRIPTION
## 변경 사항

- 읽기 모드 탭에서는 selection만 적용하고 pointer cursor-guard reveal은 요청하지 않도록 했습니다.
- 읽기 모드에서도 Shift+탭으로 기존 selection을 확장할 수 있게 했습니다.
- pointer selection reveal이 target revision 이후에도 최신 selection geometry로 처리되도록 request lifecycle을 통일했습니다.
- selection 변경을 App/Web viewport-anchor publication에 포함했습니다.
  - selection 변경 자체로는 즉시 스크롤하지 않습니다.
  - viewport resize, 회전, 키보드/툴바 표시 시 cursor guard를 벗어난 경우에만 최소한으로 reconcile합니다.
  - selection 제거 시 현재 viewport center로 스크롤 위치 변화 없이 전환합니다.
  - smooth reveal 중에는 기존 active anchor를 유지합니다.
- App에만 남아 있던 snapshot geometry 기반 `PageRects` target을 제거하고 stable target인 `CurrentSelectionHead`와 `TrackedItem(id)`만 사용하도록 정리했습니다.

## UX 변화

읽기 모드에서 화면 가장자리나 cursor-guard padding을 탭해도 화면이 즉시 움직이지 않습니다.

이후 편집 모드로 전환되어 키보드와 툴바가 나타나거나, 화면 회전 및 resize로 visible area가 달라지면 현재 selection을 viewport anchor로 사용합니다. Selection이 cursor guard를 벗어나는 경우에만 필요한 만큼 스크롤합니다.

Pointer reveal 요청은 중간 publication revision이 추가되어도 사라지지 않으므로, 편집 전환 시 커서가 가려지거나 덜 올라오는 비결정적인 동작을 방지합니다.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>