### PR TITLE
앱 에디터 헤더 포커스 시 동기적으로 selection unset

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -450,10 +450,6 @@ fun EditorScreen(entityId: String) {
       editorFocused = uiState.focused,
       bringIntoViewRequests = bringIntoViewRequests,
     )
-  fun clearBodySelectionForHeaderFocus() {
-    val activeEditor = runtime.editor ?: return
-    activeEditor.enqueue(Message.Selection(SelectionOp.Unset))
-  }
   suspend fun ensureEditorMutationSubscription(): Boolean {
     return SubscriptionService.gate(sheet = sheet, action = GatedAction.Generic)
   }
@@ -1841,11 +1837,11 @@ fun EditorScreen(entityId: String) {
               onTitleChange = model::updateTitleDraft,
               onSubtitleChange = model::updateSubtitleDraft,
               onTitleFocused = {
-                clearBodySelectionForHeaderFocus()
+                runtime.editor?.updateNow { enqueue(Message.Selection(SelectionOp.Unset)) }
                 entryState.markTitleFocused()
               },
               onSubtitleFocused = {
-                clearBodySelectionForHeaderFocus()
+                runtime.editor?.updateNow { enqueue(Message.Selection(SelectionOp.Unset)) }
                 entryState.markSubtitleFocused()
               },
               onHeightChanged = screenState::updateHeaderHeight,


### PR DESCRIPTION
뒤늦은 unset으로 인해 부분적으로 viewport anchor reconcile이 일어나는 현상을 막음

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>