### PR TITLE
줄바꿈으로 끝나는 텍스트 붙여넣기 오류 수정

### DIFF
--- a/crates/editor-commands/src/commands/insert_slice.rs
+++ b/crates/editor-commands/src/commands/insert_slice.rs
@@ -1065,6 +1065,38 @@ mod tests {
     }
 
     #[test]
+    fn insert_plain_text_ending_in_newline_places_caret_at_right_paragraph_start() {
+        let (initial, ..) = state! {
+            doc { root { target: paragraph { text("ab") } } }
+            selection: (target, 1)
+        };
+        let (actual, steps, ..) = transact!(initial, |tr| insert_slice(
+            &mut tr,
+            Slice::from_text("X\n"),
+            SliceProvenance::Plain
+        ));
+        let view = actual.view();
+        let paragraphs = view
+            .root()
+            .expect("root exists")
+            .child_blocks()
+            .map(|block| block.id())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            paragraphs
+                .iter()
+                .map(|id| view.node(*id).unwrap().inline_text())
+                .collect::<Vec<_>>(),
+            ["aX", "b"]
+        );
+        assert_eq!(
+            actual.selection,
+            Some(Selection::collapsed(Position::new(paragraphs[1], 0)))
+        );
+        assert_eq!(split_step_count(&steps), 1);
+    }
+
+    #[test]
     fn insert_paragraph_break_slice_at_paragraph_start_preserves_boundary() {
         let (initial, ..) = state! {
             doc { root { target: paragraph { text("x") } } }

--- a/crates/editor-commands/src/helpers/slice.rs
+++ b/crates/editor-commands/src/helpers/slice.rs
@@ -1840,6 +1840,17 @@ impl TextblockSplicePlan {
             });
         }
 
+        let last_output_node = nodes.len() - 1;
+        if self.final_caret_at_right_boundary {
+            // An empty open end authors a paragraph boundary but no inline unit.
+            // Bind the split right only as the caret endpoint; the inserted
+            // range still ends at the last authored output above.
+            nodes.push(SliceOutputNodeSpec {
+                source: SliceOutputSource::SplitRight,
+                node_type: self.textblock_type,
+            });
+        }
+
         let last_inserted_merged = self
             .inserted_blocks
             .len()
@@ -1863,7 +1874,7 @@ impl TextblockSplicePlan {
         } else {
             SliceOutputRelation::After
         };
-        let head_affinity = if self.merge_end {
+        let head_affinity = if self.merge_end && !self.final_caret_at_right_boundary {
             inline_output_end_affinity(&self.blocks.last()?.children)
         } else if !self.inserted_blocks.is_empty() {
             Affinity::Upstream
@@ -1881,6 +1892,14 @@ impl TextblockSplicePlan {
             },
             head_affinity,
         )?;
+        if self.final_caret_at_right_boundary {
+            output.caret = SliceOutputPositionSpec {
+                node: output.nodes.len() - 1,
+                relation: SliceOutputRelation::Start,
+                affinity: Affinity::Downstream,
+            };
+            output.head.node = last_output_node;
+        }
         if self.join_start
             && self.inserted_blocks.is_empty()
             && !self.merge_end
@@ -2033,8 +2052,8 @@ pub(crate) fn plan_textblock_splice_target(
     let unjoined_ends_with_page_break = inserted_blocks
         .last()
         .is_some_and(|fragment| paragraph_ends_with_page_break(fragment));
-    let final_caret_at_right_boundary =
-        split_emits && inserted_blocks.is_empty() && !join_start_emits && !merge_end_emits;
+    let final_caret_at_right_boundary = (merge_end && !merge_end_emits)
+        || (split_emits && inserted_blocks.is_empty() && !join_start_emits && !merge_end_emits);
     let insert_at = textblock_index + usize::from(has_left);
     let left = if has_left {
         Some(ExistingBlock {


### PR DESCRIPTION
- 문단 중간에 줄바꿈으로 끝나는 텍스트를 붙여넣으면 삽입 계획과 실행 결과의 커서 위치가 달라 문서 오류가 발생하던 문제를 수정했습니다.
- 분할된 오른쪽 문단을 최종 커서 위치로 추적하되 실제 삽입 범위에서는 제외했습니다.
- 줄바꿈으로 끝나는 일반 텍스트 붙여넣기 회귀 테스트를 추가했습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>