### PR TITLE
폴드 내부의 셀렉션 복원 무한 대기 디버그

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/entry/EditorEntryStateSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/entry/EditorEntryStateSession.kt
@@ -13,6 +13,7 @@ import co.typie.editor.Editor
 import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.SelectionOp
 import co.typie.editor.ffi.StableSelection
+import co.typie.editor.ffi.ViewOp
 import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.EditorBringIntoViewTarget
@@ -70,6 +71,7 @@ internal fun rememberEditorEntryStateSession(
 
     activeEditor.updateWithBringIntoView(bringIntoViewRequests) {
       enqueue(Message.Selection(SelectionOp.SetFrozen(selection = selection)))
+      enqueue(Message.View(ViewOp.ExpandFoldsForSelection))
       bringIntoView(
         EditorBringIntoViewTarget.CurrentSelectionHead,
         policy = EditorBringIntoViewPolicy.Reveal,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorViewportAnchorReconciler.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorViewportAnchorReconciler.kt
@@ -39,9 +39,6 @@ internal fun reconcileViewportAnchorPublication(
   val currentScrollY = currentScrollOffset.y
   val candidateFrame = measuredScrollFrame.withState(candidateState)
   val selectionCapture = editor.captureSelectionViewportAnchor(candidateState.version)
-  if (selectionCapture == null && candidateState.selection != null) {
-    return EditorViewportAnchorPublication.Withhold
-  }
   if (selectionCapture != null && anchorState.needsSelectionAdoption(selectionCapture.identity)) {
     val geometry =
       selectionCapture.geometry.toEditorViewportAnchorGeometry(

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/layout/EditorViewportAnchorReconcilerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/layout/EditorViewportAnchorReconcilerTest.kt
@@ -436,55 +436,54 @@ class EditorViewportAnchorReconcilerTest {
   }
 
   @Test
-  fun `unresolved candidate selection keeps the existing anchors and withholds publication`() =
-    runTest {
-      val visibleArea = visibleArea()
-      val initialFrame =
-        frame(visibleArea).let { frame ->
-          frame.copy(
-            state =
-              frame.state.copy(
-                selection =
-                  Selection(
-                    anchor = Position("text", 0, Affinity.Downstream),
-                    head = Position("text", 0, Affinity.Downstream),
-                  )
-              )
-          )
-        }
-      val candidateFrame = initialFrame.copy(state = initialFrame.state.copy(version = 2L))
-      val anchorState =
-        EditorViewportAnchorState().apply {
-          attachSelection(selectionAnchor, anchorGeometry(200f), scrollY = 100f)
-        }
-      val editor =
-        Editor(
-          FakeFfiEditor(
-            captureSelectionViewportAnchorProvider = { null },
-            resolveViewportAnchorProvider = { _, _ ->
-              ViewportAnchorResolution.Resolved(selectionGeometry(200f))
-            },
-          ),
-          this,
-          StandardTestDispatcher(testScheduler),
+  fun `unresolved candidate selection keeps the existing anchors and publishes`() = runTest {
+    val visibleArea = visibleArea()
+    val initialFrame =
+      frame(visibleArea).let { frame ->
+        frame.copy(
+          state =
+            frame.state.copy(
+              selection =
+                Selection(
+                  anchor = Position("text", 0, Affinity.Downstream),
+                  head = Position("text", 0, Affinity.Downstream),
+                )
+            )
         )
+      }
+    val candidateFrame = initialFrame.copy(state = initialFrame.state.copy(version = 2L))
+    val anchorState =
+      EditorViewportAnchorState().apply {
+        attachSelection(selectionAnchor, anchorGeometry(200f), scrollY = 100f)
+      }
+    val editor =
+      Editor(
+        FakeFfiEditor(
+          captureSelectionViewportAnchorProvider = { null },
+          resolveViewportAnchorProvider = { _, _ ->
+            ViewportAnchorResolution.Resolved(selectionGeometry(200f))
+          },
+        ),
+        this,
+        StandardTestDispatcher(testScheduler),
+      )
 
-      val publication =
-        reconcileViewportAnchorPublication(
-          editor = editor,
-          anchorState = anchorState,
-          publishedBundle = PublishedBundle(snapshot = initialFrame.state, frames = emptyMap()),
-          candidateState = candidateFrame.state,
-          measuredScrollFrame = candidateFrame,
-          currentScrollOffset = Offset(x = 0f, y = 100f),
-          maximumScrollY = 600f,
-          contentOriginY = 0f,
-        )
+    val publication =
+      reconcileViewportAnchorPublication(
+        editor = editor,
+        anchorState = anchorState,
+        publishedBundle = PublishedBundle(snapshot = initialFrame.state, frames = emptyMap()),
+        candidateState = candidateFrame.state,
+        measuredScrollFrame = candidateFrame,
+        currentScrollOffset = Offset(x = 0f, y = 100f),
+        maximumScrollY = 600f,
+        contentOriginY = 0f,
+      )
 
-      assertEquals(EditorViewportAnchorPublication.Withhold, publication)
-      assertEquals(selectionAnchor, anchorState.identity)
-      assertEquals(selectionAnchor, anchorState.preferredSelectionIdentity)
-    }
+    assertTrue(publication is EditorViewportAnchorPublication.Ready)
+    assertEquals(selectionAnchor, anchorState.identity)
+    assertEquals(selectionAnchor, anchorState.preferredSelectionIdentity)
+  }
 
   private fun reconcile(
     editor: Editor,

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/entry/EditorEntryStateSessionDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/entry/EditorEntryStateSessionDesktopTest.kt
@@ -6,13 +6,17 @@ import androidx.compose.ui.test.v2.runComposeUiTest
 import co.typie.editor.Editor
 import co.typie.editor.FakeFfiEditor
 import co.typie.editor.ffi.Affinity
+import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.Position
 import co.typie.editor.ffi.Selection
+import co.typie.editor.ffi.SelectionOp
 import co.typie.editor.ffi.StableSelection
+import co.typie.editor.ffi.ViewOp
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import java.io.File
 import java.util.UUID
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -63,6 +67,13 @@ class EditorEntryStateSessionDesktopTest {
       waitUntil { requests.activateForVersion(editor.appliedRevision) != null }
 
       assertFalse(requireNotNull(entry).presentationReady)
+      assertEquals(
+        listOf(
+          Message.Selection(SelectionOp.SetFrozen(selection = saved)),
+          Message.View(ViewOp.ExpandFoldsForSelection),
+        ),
+        fake.enqueued,
+      )
 
       runOnIdle {
         val request = requireNotNull(requests.activateForVersion(editor.appliedRevision))

--- a/apps/website/src/lib/editor-ffi/editor-frame-sync.browser.test.ts
+++ b/apps/website/src/lib/editor-ffi/editor-frame-sync.browser.test.ts
@@ -183,6 +183,22 @@ function foldedTrackedRangeDoc(targetText: string): PlainDoc {
   };
 }
 
+function nestedFoldedSelectionDoc(targetText: string): PlainDoc {
+  return {
+    root: entry({ type: 'root', layout_mode: { type: 'continuous', max_width: PAGE_WIDTH } }, [
+      entry({ type: 'fold' }, [
+        entry({ type: 'fold_title' }, [entry({ type: 'text', text: 'Outer fold' })]),
+        entry({ type: 'fold_content' }, [
+          entry({ type: 'fold' }, [
+            entry({ type: 'fold_title' }, [entry({ type: 'text', text: 'Inner fold' })]),
+            entry({ type: 'fold_content' }, [entry({ type: 'paragraph' }, [entry({ type: 'text', text: targetText })])]),
+          ]),
+        ]),
+      ]),
+    ]),
+  };
+}
+
 function paginatedDocWithPageBreaks(pageCount: number, linkedLastPage?: { text: string; href: string }): PlainDoc {
   const pageHeight = 221;
   return {
@@ -722,6 +738,39 @@ describe('web editor frame synchronization', () => {
     await expect(restorePresentation).resolves.toBeUndefined();
     expect(firstRestoredFrame?.scrollTop).toBeGreaterThan(0);
     expect(firstRestoredFrame?.selectionHeadVisible).toBe(true);
+  });
+
+  it('expands nested folds before presenting a restored selection', async () => {
+    const targetText = 'restored folded caret';
+    const { editor } = await mountEditor(nestedFoldedSelectionDoc(targetText));
+    const caretOffset = editor.proseText().indexOf(targetText) + targetText.length;
+    expect(caretOffset).toBeGreaterThan(targetText.length - 1);
+    const selection = editor.proseToSelection(caretOffset, caretOffset);
+    const saved = selection && editor.freezeSelection(selection);
+    expect(saved).toBeDefined();
+    if (!saved) throw new Error('Expected a restorable folded selection');
+
+    const hiddenRestore = editor.updateNow((request) => {
+      request.enqueue({ type: 'selection', op: { type: 'set_frozen', selection: saved } });
+    });
+    expect(hiddenRestore).not.toBeNull();
+    if (!hiddenRestore) throw new Error('Expected a hidden-selection restore update');
+    await waitForPresentation(editor, hiddenRestore.revision);
+    expect(editor.appliedSnapshot.selection).toBeDefined();
+    expect(selectionHeadRect(editor.appliedSnapshot)).toBeNull();
+
+    let restorePresentation: Promise<void> | undefined;
+    const restore = editor.updateNow((request) => {
+      request.enqueue({ type: 'selection', op: { type: 'set_frozen', selection: saved } });
+      request.enqueue({ type: 'view', op: { type: 'expand_folds_for_selection' } });
+      restorePresentation = editor.scrollIntoView({ target: { type: 'current_selection_head' }, policy: 'reveal' });
+    });
+    expect(restore).not.toBeNull();
+    if (!restore) throw new Error('Expected a folded restore update');
+
+    await expect.poll(() => selectionHeadRect(editor.appliedSnapshot)).not.toBeNull();
+    await expect(restorePresentation).resolves.toBeUndefined();
+    expect(editor.publishedRevision).toBeGreaterThanOrEqual(restore.revision);
   });
 
   it('smoothly reveals a spellcheck result after its page surface was virtualized', async () => {

--- a/apps/website/src/lib/editor-ffi/editor-publication-preparation.test.ts
+++ b/apps/website/src/lib/editor-ffi/editor-publication-preparation.test.ts
@@ -27,6 +27,50 @@ afterEach(() => {
 });
 
 describe('editor publication preparation', () => {
+  it('completes a current-selection reveal when the candidate has no selection geometry', async () => {
+    const position = { node: 'hidden', offset: 0, affinity: 'downstream' as const };
+    const candidate = snapshot({
+      selection: { anchor: position, head: position },
+      pageSizes: [{ width: 600, height: 1000 }],
+    });
+    const editor = {
+      destroyed: false,
+      appliedSnapshot: candidate,
+      appliedRevision: candidate.revision,
+      publishedRevision: candidate.revision,
+      published: { snapshot: candidate, frames: new Map([[0, {}]]) },
+      viewport: { height: 400 },
+      scaleFactor: 1,
+      displayZoom: 1,
+      activeSurfacePages: new Set<number>(),
+      extensionAreaEl: {
+        getBoundingClientRect: () => new DOMRect(0, 0, 600, 1000),
+      },
+      scrollViewport: {
+        getRect: () => new DOMRect(0, 0, 600, 400),
+        getScrollTop: () => 0,
+        getScrollHeight: () => 1000,
+        scrollTo: vi.fn(),
+      },
+      requestPublication: vi.fn(),
+      safeDisplayZoom: () => 1,
+      clientToLocal: vi.fn(() => null),
+      captureSelectionViewportAnchor: vi.fn(() => void 0),
+      captureViewportAnchorAt: vi.fn(() => void 0),
+    } as unknown as Editor;
+    const scroll = new EditorScrollScope(editor, () => ({ enabled: false, position: undefined }));
+    const presentation = scroll.scrollIntoView({ target: { type: 'current_selection_head' }, policy: 'reveal' });
+
+    expect(scroll.prepareViewportAnchorPublication(candidate).type).toBe('ready');
+    const preparation = resolveEditorSurfacePreparation(editor, scroll);
+    expect(preparation?.scrollIntent).toEqual({ type: 'no_scroll' });
+    const request = preparation?.pendingRequest;
+    expect(request).not.toBeNull();
+    if (!request || !preparation?.scrollIntent) throw new Error('Expected a pending no-scroll reveal');
+    expect(scroll.applyPending(request, candidate, preparation.scrollIntent)).toBe(true);
+    await expect(presentation).resolves.toBeUndefined();
+  });
+
   it('plans surfaces and reveal from the anchor-corrected candidate scroll', () => {
     const candidate = snapshot({
       revision: 1,

--- a/apps/website/src/lib/editor-ffi/scroll-scope.test.ts
+++ b/apps/website/src/lib/editor-ffi/scroll-scope.test.ts
@@ -862,7 +862,7 @@ describe('EditorScrollScope', () => {
     expect(scrollTo).not.toHaveBeenCalled();
   });
 
-  it('keeps existing anchors and withholds publication while candidate selection geometry is unavailable', () => {
+  it('keeps existing anchors and publishes while candidate selection geometry is unavailable', () => {
     const initial = selectionSnapshot(true, {
       page_idx: 0,
       rect: { x: 0, y: 90, width: 1, height: 20 },
@@ -881,7 +881,7 @@ describe('EditorScrollScope', () => {
     expect(scope.prepareViewportAnchorPublication(initial).type).toBe('ready');
     capture = undefined;
 
-    expect(scope.prepareViewportAnchorPublication(candidate)).toEqual({ type: 'unavailable' });
+    expect(scope.prepareViewportAnchorPublication(candidate).type).toBe('ready');
     capture = { identity: { ...selection }, geometry };
     expect(scope.prepareViewportAnchorPublication(initial)).toMatchObject({
       type: 'ready',

--- a/apps/website/src/lib/editor-ffi/scroll.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/scroll.svelte.ts
@@ -279,7 +279,6 @@ export class EditorScrollScope {
     const viewport = this.#editor.scrollViewport;
     if (!viewport) return { type: 'ready', geometry: null, targetScrollTop: null };
     const selectionCapture = this.#editor.captureSelectionViewportAnchor(snapshot.revision);
-    if (!selectionCapture && snapshot.selection) return { type: 'unavailable' };
     if (selectionCapture && this.#viewportAnchor.needsSelectionAdoption(selectionCapture.identity)) {
       const selectionMetrics = this.#viewportMetrics(snapshot, true);
       if (!selectionMetrics) return { type: 'unavailable' };

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditor.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditor.svelte
@@ -913,6 +913,7 @@
                 selection: savedSelection,
               },
             });
+            request.enqueue({ type: 'view', op: { type: 'expand_folds_for_selection' } });
             presentation = editor.scrollIntoView({ target: { type: 'current_selection_head' }, policy: 'reveal' });
           });
           return presentation;

--- a/crates/editor-core/src/handle/view.rs
+++ b/crates/editor-core/src/handle/view.rs
@@ -31,6 +31,15 @@ pub fn handle_view_op(editor: &mut Editor, op: ViewOp) -> Result<(), EditorError
             editor.toggle_fold(id);
             Ok(())
         }
+        ViewOp::ExpandFoldsForSelection => {
+            let folds = editor
+                .state()
+                .selection
+                .map(|selection| folds_containing_selection(&editor.state().view(), selection))
+                .unwrap_or_default();
+            editor.expand_folds(folds);
+            Ok(())
+        }
         ViewOp::ExpandFoldsForTrackedRange { id } => {
             let folds = folds_containing_tracked_range(editor, &id);
             editor.expand_folds(folds);
@@ -51,6 +60,10 @@ fn folds_containing_tracked_range(editor: &Editor, id: &str) -> Vec<Dot> {
     let Some(selection) = range.selection.resolve(&ctx) else {
         return Vec::new();
     };
+    folds_containing_selection(&doc, selection)
+}
+
+fn folds_containing_selection(doc: &DocView, selection: Selection) -> Vec<Dot> {
     let mut folds = Vec::new();
     for position in [selection.anchor, selection.head] {
         let Some(node) = doc.node(position.node) else {
@@ -163,6 +176,45 @@ mod tests {
         });
 
         assert!(!editor.fold_expanded(f1), "folds load collapsed by default");
+    }
+
+    #[test]
+    fn expand_folds_for_selection_opens_nested_folds_for_restored_selection() {
+        let (initial, outer, _outer_title, inner, p1) = state! {
+            doc { root {
+                outer: fold {
+                    outer_title: fold_title { text("Outer") }
+                    fold_content {
+                        inner: fold {
+                            fold_title { text("Inner") }
+                            fold_content { p1: paragraph { text("Body") } }
+                        }
+                    }
+                }
+            } }
+            selection: (outer_title, 0)
+        };
+        let target = Selection::collapsed(Position::new(p1, 2));
+        let frozen = editor_state::StableSelection::capture(&target, &initial.view());
+        let mut editor = Editor::new_test(initial);
+        editor.apply(Message::System {
+            event: SystemEvent::Initialize,
+        });
+        editor.apply(Message::Selection {
+            op: SelectionOp::SetFrozen { selection: frozen },
+        });
+
+        assert_eq!(editor.state().selection, Some(target));
+        assert!(!editor.fold_expanded(outer));
+        assert!(!editor.fold_expanded(inner));
+
+        editor.apply(Message::View {
+            op: ViewOp::ExpandFoldsForSelection,
+        });
+
+        assert!(editor.fold_expanded(outer));
+        assert!(editor.fold_expanded(inner));
+        assert_eq!(editor.state().selection, Some(target));
     }
 
     #[test]

--- a/crates/editor-core/src/message.rs
+++ b/crates/editor-core/src/message.rs
@@ -303,6 +303,7 @@ pub enum ListOp {
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ViewOp {
     ToggleFold { id: Dot },
+    ExpandFoldsForSelection,
     ExpandFoldsForTrackedRange { id: String },
 }
 

--- a/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
@@ -734,7 +734,7 @@ export type Tri<T> = { type: "absent" } | { type: "uniform"; value: T } | { type
 
 export type UnderlineStyle = "solid" | "dashed" | "wavy";
 
-export type ViewOp = { type: "toggle_fold"; id: Dot } | { type: "expand_folds_for_tracked_range"; id: string };
+export type ViewOp = { type: "toggle_fold"; id: Dot } | { type: "expand_folds_for_selection" } | { type: "expand_folds_for_tracked_range"; id: string };
 
 export type ViewportAnchor = { type: "position"; stable: StableSelection; original_node: Dot; geometry: ViewportAnchorPositionGeometry } | { type: "node"; node: Dot; offset_x: number; offset_y: number };
 

--- a/crates/editor-ffi/pkg/server/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/server/editor_ffi.d.ts
@@ -804,7 +804,7 @@ export type Tri<T> = { type: "absent" } | { type: "uniform"; value: T } | { type
 
 export type UnderlineStyle = "solid" | "dashed" | "wavy";
 
-export type ViewOp = { type: "toggle_fold"; id: Dot } | { type: "expand_folds_for_tracked_range"; id: string };
+export type ViewOp = { type: "toggle_fold"; id: Dot } | { type: "expand_folds_for_selection" } | { type: "expand_folds_for_tracked_range"; id: string };
 
 export type ViewportAnchor = { type: "position"; stable: StableSelection; original_node: Dot; geometry: ViewportAnchorPositionGeometry } | { type: "node"; node: Dot; offset_x: number; offset_y: number };
 


### PR DESCRIPTION
## 문제

저장된 `StableSelection`이 접힌 fold 내부를 가리키는 경우, `SetFrozen`은 live selection을 복원하지만 fold의 view state는 펼치지 않습니다.

이 상태에서는 `snapshot.selection`은 존재하지만 selection rect와 viewport anchor capture가 생성되지 않습니다. 기존 Web/App publication reconciler는 selection이 있는데 capture가 없으면 publication을 보류했습니다. 이후 geometry를 갱신할 사건이 없으면 `current_selection_head` reveal이 완료되지 않고, Web에서는 `handleEditorReady`가 `onReady`까지 도달하지 못했습니다.

## 수정

- 현재 selection의 anchor/head를 포함하는 fold를 펼치는 `ViewOp::ExpandFoldsForSelection`을 추가했습니다.
  - 기존 `ExpandFoldsForTrackedRange`의 fold ancestor 탐색을 공유합니다.
  - 중첩된 fold도 함께 펼칩니다.
- Web/App의 저장된 selection 복원 요청을 다음 순서로 변경했습니다.
  1. `SetFrozen`
  2. `ExpandFoldsForSelection`
  3. `current_selection_head` reveal
- selection viewport anchor capture가 없다는 이유만으로 publication을 보류하지 않도록 Web/App 동작을 맞췄습니다.
  - selection anchor 채택만 건너뛰고 기존 viewport anchor를 사용해 publication을 계속합니다.
  - selection rect가 없으면 reveal은 `no_scroll`로 완료됩니다.

## 테스트

- 중첩된 fold 내부의 frozen selection을 복원하면 모든 상위 fold가 펼쳐지는 Core 테스트
- selection은 있지만 geometry가 없는 revision도 publish되는 Web 브라우저 테스트
- geometry가 없는 `current_selection_head` reveal이 완료되는 Web 테스트
- 동일한 publication fallback과 복원 요청 순서를 검증하는 App 테스트

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>