### PR TITLE
Slice 삽입 후 커서와 삽입 범위 계산 일원화

### DIFF
--- a/crates/editor-commands/src/commands/insert_slice.rs
+++ b/crates/editor-commands/src/commands/insert_slice.rs
@@ -7,16 +7,16 @@ use editor_transaction::Transaction;
 use crate::CommandResult;
 use crate::commands::{apply_cell_fill_plan, apply_table_grid_plan};
 use crate::helpers::{
-    LinearJoinExecution, SliceInsertionTarget, SliceOutputPositionSpec, SliceOutputRelation,
+    LinearJoinExecution, SliceInsertionTarget, SliceOutputRelation,
     apply_cross_range_removal_without_join, apply_linear_deletion_plan, block_parent_and_index,
     install_planned_selection, materialize_planned_endpoint, materialize_planned_selection,
-    remap_linear_deletion_plan, split_block_wrapper_before_child,
+    remap_linear_deletion_plan, resolve_live_slice_output_dot, split_block_wrapper_before_child,
 };
 use crate::judgments::{
-    AppliedSliceInsertion, FitOutcome, JoinedReplacementPlan, LinearFinalSelection, LinearFitPlan,
-    LinearMutation, PlannedBoundaryInsertion, PlannedBranchInsertion, PlannedBranchNode,
-    PlannedBranchSplit, PlannedJoin, PlannedOutputKey, RangePlacement, SliceFitPlan,
-    SliceFitPlanKind, apply_slice_insertion_plan, fit_slice,
+    AppliedSliceInsertion, BoundSliceOutputPosition, FitOutcome, JoinedReplacementPlan,
+    LinearFinalSelection, LinearFitPlan, LinearMutation, PlannedBoundaryInsertion,
+    PlannedBranchInsertion, PlannedBranchNode, PlannedBranchSplit, PlannedJoin, PlannedOutputKey,
+    RangePlacement, SliceFitPlan, SliceFitPlanKind, apply_slice_insertion_plan, fit_slice,
 };
 use crate::types::SliceProvenance;
 
@@ -161,11 +161,8 @@ fn apply_linear_fit_plan(
                     ));
                 }
                 let left = apply_boundary_insertion(tr, left, provenance)?;
-                validate_applied_insertion(tr, &left)?;
                 let right = apply_boundary_insertion(tr, right, provenance)?;
-                validate_applied_insertion(tr, &right)?;
-                let middle = apply_branch_insertion(tr, middle, provenance)?;
-                validate_applied_insertion(tr, &middle)?;
+                apply_branch_insertion(tr, middle, provenance)?;
                 if applied_insertion
                     .replace(AppliedLinearInsertion::SeparatedOpenEdges { left, right })
                     .is_some()
@@ -209,20 +206,18 @@ fn apply_linear_fit_plan(
             })?;
             match applied {
                 AppliedLinearInsertion::Single(applied) => {
-                    let caret =
-                        resolve_planned_output_position(tr, &applied, applied.output.caret)?;
+                    let caret = resolve_bound_output_position(tr, &applied.caret)?;
                     let inserted = Selection::new(
-                        resolve_planned_output_position(tr, &applied, applied.output.anchor)?,
-                        resolve_planned_output_position(tr, &applied, applied.output.head)?,
+                        resolve_bound_output_position(tr, &applied.anchor)?,
+                        resolve_bound_output_position(tr, &applied.head)?,
                     );
-                    validate_observed_insertion_selection(tr, &applied, caret, inserted)?;
                     (caret, inserted)
                 }
                 AppliedLinearInsertion::SeparatedOpenEdges { left, right } => {
-                    let caret = resolve_planned_output_position(tr, &right, right.output.caret)?;
+                    let caret = resolve_bound_output_position(tr, &right.caret)?;
                     let inserted = Selection::new(
-                        resolve_planned_output_position(tr, &left, left.output.anchor)?,
-                        resolve_planned_output_position(tr, &right, right.output.head)?,
+                        resolve_bound_output_position(tr, &left.anchor)?,
+                        resolve_bound_output_position(tr, &right.head)?,
                     );
                     (caret, inserted)
                 }
@@ -312,82 +307,17 @@ fn resolve_final_position(
         })
 }
 
-fn validate_observed_insertion_selection(
+fn resolve_bound_output_position(
     tr: &Transaction,
-    applied: &AppliedSliceInsertion,
-    caret: Position,
-    inserted: Selection,
-) -> Result<(), crate::CommandError> {
-    validate_observed_selection(
-        tr,
-        caret,
-        inserted,
-        applied.observed_caret,
-        applied.observed_inserted,
-    )
-}
-
-fn validate_applied_insertion(
-    tr: &Transaction,
-    applied: &AppliedSliceInsertion,
-) -> Result<(), crate::CommandError> {
-    let caret = resolve_planned_output_position(tr, applied, applied.output.caret)?;
-    let inserted = Selection::new(
-        resolve_planned_output_position(tr, applied, applied.output.anchor)?,
-        resolve_planned_output_position(tr, applied, applied.output.head)?,
-    );
-    validate_observed_insertion_selection(tr, applied, caret, inserted)
-}
-
-fn validate_observed_selection(
-    tr: &Transaction,
-    caret: Position,
-    inserted: Selection,
-    observed_caret: Position,
-    observed_inserted: Selection,
-) -> Result<(), crate::CommandError> {
-    let view = tr.view();
-    let normalize = |selection: Selection| selection.normalize(&view).unwrap_or(selection);
-    let planned_caret = normalize(Selection::collapsed(caret));
-    let observed_caret = normalize(Selection::collapsed(resolve_final_position(
-        tr,
-        observed_caret,
-    )?));
-    if planned_caret != observed_caret {
-        return Err(crate::CommandError::Corrupted(format!(
-            "Slice executor produced a different caret than the planned output: planned={planned_caret:?}, observed={observed_caret:?}"
-        )));
-    }
-    let planned_inserted = normalize(inserted);
-    let observed_inserted = normalize(Selection::new(
-        resolve_final_position(tr, observed_inserted.anchor)?,
-        resolve_final_position(tr, observed_inserted.head)?,
-    ));
-    if planned_inserted != observed_inserted {
-        return Err(crate::CommandError::Corrupted(format!(
-            "Slice executor produced a different inserted range than the planned output: planned={planned_inserted:?}, observed={observed_inserted:?}"
-        )));
-    }
-    Ok(())
-}
-
-fn resolve_planned_output_position(
-    tr: &Transaction,
-    applied: &AppliedSliceInsertion,
-    planned: SliceOutputPositionSpec,
+    bound: &BoundSliceOutputPosition,
 ) -> Result<Position, crate::CommandError> {
-    let dot = applied.nodes.get(planned.node).copied().ok_or_else(|| {
-        crate::CommandError::Corrupted(
-            "Slice final selection referenced an unavailable planned output node".into(),
-        )
-    })?;
-    let dot = resolve_live_output_dot(tr, dot).ok_or_else(|| {
+    let view = tr.view();
+    let dot = resolve_live_slice_output_dot(&view, bound.dot).ok_or_else(|| {
         crate::CommandError::Corrupted(
             "Slice final selection output node no longer resolves".into(),
         )
     })?;
-    let view = tr.view();
-    let mut position = match planned.relation {
+    let mut position = match bound.relation {
         SliceOutputRelation::Before | SliceOutputRelation::After => {
             let (parent, index) = output_parent_and_index(&view, dot).ok_or_else(|| {
                 crate::CommandError::Corrupted(
@@ -396,7 +326,7 @@ fn resolve_planned_output_position(
             })?;
             Position::new(
                 parent,
-                index + usize::from(matches!(planned.relation, SliceOutputRelation::After)),
+                index + usize::from(matches!(bound.relation, SliceOutputRelation::After)),
             )
         }
         SliceOutputRelation::AfterTerminalPageBreak => {
@@ -458,19 +388,8 @@ fn resolve_planned_output_position(
             }
         }
     };
-    position.affinity = planned.affinity;
+    position.affinity = bound.affinity;
     Ok(position)
-}
-
-fn resolve_live_output_dot(tr: &Transaction, dot: editor_crdt::Dot) -> Option<editor_crdt::Dot> {
-    let view = tr.view();
-    if view.node(dot).is_some() || view.block_of(dot).is_some() {
-        return Some(dot);
-    }
-    let resolved = view.alias_classes().resolve_with(dot, |candidate| {
-        view.node(candidate).is_some() || view.block_of(candidate).is_some()
-    });
-    (view.node(resolved).is_some() || view.block_of(resolved).is_some()).then_some(resolved)
 }
 
 fn output_parent_and_index(
@@ -675,12 +594,12 @@ mod tests {
     use editor_crdt::{Dot, ListOp, sequence::Bias as SeqBias};
     use editor_macros::state;
     use editor_model::{
-        Alignment, ChildView, EditOp, Fragment, Modifier, NodeType, PlainBlockquoteNode,
-        PlainHorizontalRuleNode, PlainListItemNode, PlainNode, PlainOrderedListNode,
-        PlainPageBreakNode, PlainParagraphNode, PlainTextNode, SeqItem,
+        AliasOp, AliasRun, Alignment, ChildView, EditOp, Fragment, Modifier, NodeType,
+        PlainBlockquoteNode, PlainHorizontalRuleNode, PlainListItemNode, PlainNode,
+        PlainOrderedListNode, PlainPageBreakNode, PlainParagraphNode, PlainTextNode, SeqItem,
     };
     use editor_resource::Resource;
-    use editor_state::{Position, Selection, State};
+    use editor_state::{Affinity, Position, Selection, State};
     use editor_transaction::Step;
 
     use super::*;
@@ -742,6 +661,61 @@ mod tests {
             open_start: 1,
             open_end: 1,
         }
+    }
+
+    #[test]
+    fn bound_output_position_resolves_canonical_live_alias() {
+        let (initial, paragraph) = state! {
+            doc { root { paragraph: paragraph { text("abc") } } }
+            selection: (paragraph, 0)
+        };
+        let chars = initial
+            .view()
+            .node(paragraph)
+            .expect("paragraph")
+            .children()
+            .filter_map(|child| match child {
+                ChildView::Leaf(leaf) => Some(leaf.dot()),
+                ChildView::Block(_) => None,
+            })
+            .collect::<Vec<_>>();
+        let [raw, first_live, canonical_live] = chars.as_slice() else {
+            panic!("expected three inline leaves");
+        };
+
+        let mut deletion = Transaction::new(&initial);
+        deletion.remove_text(paragraph, 0, 1).unwrap();
+        let (mut state, ..) = deletion.commit();
+        for live in [first_live, canonical_live] {
+            state
+                .projected_mut()
+                .apply(EditOp::Alias(AliasOp {
+                    pairs: vec![AliasRun {
+                        old_start: *raw,
+                        len: 1,
+                        new_start: *live,
+                    }],
+                }))
+                .unwrap();
+        }
+
+        let tr = Transaction::new(&state);
+        assert_eq!(
+            resolve_bound_output_position(
+                &tr,
+                &BoundSliceOutputPosition {
+                    dot: *raw,
+                    relation: SliceOutputRelation::After,
+                    affinity: Affinity::Downstream,
+                },
+            )
+            .unwrap(),
+            Position {
+                node: paragraph,
+                offset: 2,
+                affinity: Affinity::Downstream,
+            }
+        );
     }
 
     #[test]
@@ -910,48 +884,6 @@ mod tests {
             steps.is_empty(),
             "the failed output resolution must be atomic"
         );
-    }
-
-    #[test]
-    fn fitted_insertion_rejects_a_corrupted_output_source_path_before_mutation() {
-        let (initial, _p) = state! {
-            doc { root { p: paragraph { text("abc") } } }
-            selection: (p, 1)
-        };
-        let FitOutcome::Plan(mut plan) = fit_slice(
-            &initial,
-            initial.selection.expect("selection"),
-            Slice::new(
-                vec![Fragment::leaf(PlainNode::Text(PlainTextNode {
-                    text: "X".into(),
-                }))],
-                0,
-                0,
-            ),
-        )
-        .unwrap() else {
-            panic!("inline insertion must fit");
-        };
-        let SliceFitPlanKind::Linear(LinearFitPlan {
-            mutation: LinearMutation::PointInsertion { insertion },
-            ..
-        }) = &mut plan.kind
-        else {
-            panic!("expected a point insertion plan");
-        };
-        let crate::judgments::SliceInsertionPlan::DirectInline { output, .. } = insertion else {
-            panic!("expected direct inline insertion");
-        };
-        output.nodes[0].source = crate::helpers::SliceOutputSource::InlineSlot { index: 99 };
-
-        let mut tr = Transaction::new(&initial);
-        assert!(
-            apply_fitted_slice(&mut tr, plan, SliceProvenance::Formatted).is_err(),
-            "a planned output key detached from its source slot must be rejected"
-        );
-        let (actual, steps, ..) = tr.commit();
-        assert_state_eq!(&actual, &initial);
-        assert!(steps.is_empty(), "the stale output plan must be atomic");
     }
 
     #[test]
@@ -2163,7 +2095,7 @@ mod tests {
 
     #[test]
     fn open_edges_are_inserted_before_a_middle_list_merges_their_containers() {
-        let (initial, _left, _right) = state! {
+        let (initial, left, right) = state! {
             doc { root {
                 ordered_list {
                     list_item { left: paragraph { text("AB") } }
@@ -2186,9 +2118,49 @@ mod tests {
             1,
         );
 
+        let FitOutcome::Plan(plan) =
+            fit_slice(&initial, initial.selection.expect("selection"), slice).unwrap()
+        else {
+            panic!("separated open edges must produce a fitted plan");
+        };
         let mut tr = Transaction::new(&initial);
-        assert!(insert_slice(&mut tr, slice, SliceProvenance::Formatted).unwrap());
+        let inserted = apply_fitted_slice(&mut tr, plan, SliceProvenance::Formatted).unwrap();
         let (actual, _, recorded, ..) = tr.commit();
+        let right_survivor = {
+            let view = actual.view();
+            view.alias_classes()
+                .members_of(right)
+                .into_iter()
+                .flatten()
+                .copied()
+                .find(|dot| view.node(*dot).is_some())
+                .expect("right alias must survive the list merge")
+        };
+
+        assert_ne!(right_survivor, right);
+        assert_eq!(
+            inserted,
+            Selection::new(
+                Position {
+                    node: left,
+                    offset: 1,
+                    affinity: Affinity::Upstream,
+                },
+                Position {
+                    node: right_survivor,
+                    offset: 1,
+                    affinity: Affinity::Upstream,
+                },
+            )
+        );
+        assert_eq!(
+            actual.selection,
+            Some(Selection::collapsed(Position {
+                node: right_survivor,
+                offset: 1,
+                affinity: Affinity::Downstream,
+            }))
+        );
 
         {
             let view = actual.view();

--- a/crates/editor-commands/src/commands/insert_slice_at.rs
+++ b/crates/editor-commands/src/commands/insert_slice_at.rs
@@ -183,18 +183,21 @@ mod tests {
         }
     }
 
-    fn open_bullet_list_slice(text: &str, open_start: u32, open_end: u32) -> Slice {
+    fn bullet_list_slice(texts: &[&str], open_start: u32, open_end: u32) -> Slice {
         Slice {
             content: vec![Fragment {
                 node: PlainNode::BulletList(PlainBulletListNode::default()),
                 modifiers: vec![],
                 carry: vec![],
-                children: vec![Fragment {
-                    node: PlainNode::ListItem(PlainListItemNode::default()),
-                    modifiers: vec![],
-                    carry: vec![],
-                    children: vec![paragraph_fragment(text)],
-                }],
+                children: texts
+                    .iter()
+                    .map(|text| Fragment {
+                        node: PlainNode::ListItem(PlainListItemNode::default()),
+                        modifiers: vec![],
+                        carry: vec![],
+                        children: vec![paragraph_fragment(text)],
+                    })
+                    .collect(),
             }],
             open_start,
             open_end,
@@ -535,6 +538,144 @@ mod tests {
     }
 
     #[test]
+    fn insert_slice_at_direct_inline_returns_inserted_range() {
+        let (initial, p1) = state! {
+            doc { root { p1: paragraph { text("ab") } } }
+            selection: none
+        };
+
+        let mut tr = Transaction::new(&initial);
+        let inserted = insert_slice_at(
+            &mut tr,
+            Position::new(p1, 1),
+            Slice::new(
+                vec![Fragment::leaf(PlainNode::Text(PlainTextNode {
+                    text: "X".into(),
+                }))],
+                0,
+                0,
+            ),
+            SliceProvenance::Plain,
+        )
+        .expect("insert succeeds")
+        .expect("slice inserted");
+        let (actual, ..) = tr.commit();
+
+        assert_eq!(actual.view().node(p1).unwrap().inline_text(), "aXb");
+        assert_eq!(
+            inserted,
+            Selection::new(
+                Position {
+                    node: p1,
+                    offset: 1,
+                    affinity: Affinity::Downstream,
+                },
+                Position {
+                    node: p1,
+                    offset: 2,
+                    affinity: Affinity::Downstream,
+                },
+            )
+        );
+    }
+
+    #[test]
+    fn insert_plain_text_ending_in_newline_returns_only_authored_text_range() {
+        let (initial, p1) = state! {
+            doc { root { p1: paragraph { text("ab") } } }
+            selection: none
+        };
+
+        let mut tr = Transaction::new(&initial);
+        let inserted = insert_slice_at(
+            &mut tr,
+            Position::new(p1, 1),
+            Slice::from_text("X\n"),
+            SliceProvenance::Plain,
+        )
+        .expect("insert succeeds")
+        .expect("slice inserted");
+        let (actual, ..) = tr.commit();
+
+        let view = actual.view();
+        let paragraphs = view
+            .root()
+            .expect("root exists")
+            .child_blocks()
+            .collect::<Vec<_>>();
+        assert_eq!(
+            paragraphs
+                .iter()
+                .map(|paragraph| paragraph.inline_text())
+                .collect::<Vec<_>>(),
+            ["aX", "b"]
+        );
+        assert_eq!(
+            inserted,
+            Selection::new(
+                Position {
+                    node: paragraphs[0].id(),
+                    offset: 1,
+                    affinity: Affinity::Upstream,
+                },
+                Position {
+                    node: paragraphs[0].id(),
+                    offset: 2,
+                    affinity: Affinity::Upstream,
+                },
+            )
+        );
+    }
+
+    #[test]
+    fn insert_newline_only_returns_the_authored_paragraph_boundary() {
+        let (initial, p1) = state! {
+            doc { root { p1: paragraph { text("ab") } } }
+            selection: none
+        };
+
+        let mut tr = Transaction::new(&initial);
+        let inserted = insert_slice_at(
+            &mut tr,
+            Position::new(p1, 1),
+            Slice::from_text("\n"),
+            SliceProvenance::Plain,
+        )
+        .expect("insert succeeds")
+        .expect("slice inserted");
+        let (actual, ..) = tr.commit();
+
+        let view = actual.view();
+        let paragraphs = view
+            .root()
+            .expect("root exists")
+            .child_blocks()
+            .collect::<Vec<_>>();
+        assert_eq!(
+            paragraphs
+                .iter()
+                .map(|paragraph| paragraph.inline_text())
+                .collect::<Vec<_>>(),
+            ["a", "b"]
+        );
+        assert_eq!(
+            inserted,
+            Selection::new(
+                Position {
+                    node: paragraphs[0].id(),
+                    offset: 1,
+                    affinity: Affinity::Upstream,
+                },
+                Position {
+                    node: paragraphs[1].id(),
+                    offset: 0,
+                    affinity: Affinity::Downstream,
+                },
+            )
+        );
+    }
+
+    #[test]
     fn insert_open_list_context_merges_items_at_list_boundary() {
         let (initial, list) = state! {
             doc { root {
@@ -551,11 +692,26 @@ mod tests {
         let inserted = insert_slice_at(
             &mut tr,
             Position::new(list, 1),
-            open_bullet_list_slice("B", 1, 1),
+            bullet_list_slice(&["B"], 1, 1),
             SliceProvenance::Formatted,
         )
-        .expect("command succeeds");
-        assert!(inserted.is_some());
+        .expect("command succeeds")
+        .expect("slice inserted");
+        assert_eq!(
+            inserted,
+            Selection::new(
+                Position {
+                    node: list,
+                    offset: 1,
+                    affinity: Affinity::Downstream,
+                },
+                Position {
+                    node: list,
+                    offset: 2,
+                    affinity: Affinity::Upstream,
+                },
+            )
+        );
         let (actual, ..) = tr.commit();
 
         let view = actual.view();
@@ -565,14 +721,126 @@ mod tests {
     }
 
     #[test]
-    fn closed_list_between_adjacent_lists_uses_the_planned_earlier_kind_merges() {
+    fn insert_slice_at_open_ancestor_splice_returns_inserted_range() {
+        let (initial, target) = state! {
+            doc { root {
+                blockquote { target: paragraph { text("ab") } }
+                paragraph {}
+            } }
+            selection: none
+        };
+        let slice = Slice {
+            content: vec![Fragment {
+                node: NodeType::Blockquote.into_node().to_plain(),
+                modifiers: vec![],
+                carry: vec![],
+                children: vec![paragraph_fragment("X")],
+            }],
+            open_start: 2,
+            open_end: 2,
+        };
+
+        let mut tr = Transaction::new(&initial);
+        let inserted = insert_slice_at(
+            &mut tr,
+            Position::new(target, 1),
+            slice,
+            SliceProvenance::Formatted,
+        )
+        .expect("insert succeeds")
+        .expect("slice inserted");
+        let (actual, ..) = tr.commit();
+
+        assert_eq!(actual.view().node(target).unwrap().inline_text(), "aXb");
+        assert_eq!(
+            inserted,
+            Selection::new(
+                Position {
+                    node: target,
+                    offset: 1,
+                    affinity: Affinity::Upstream,
+                },
+                Position {
+                    node: target,
+                    offset: 2,
+                    affinity: Affinity::Downstream,
+                },
+            )
+        );
+    }
+
+    #[test]
+    fn insert_slice_at_open_ancestor_splice_returns_multi_edge_range() {
+        let (initial, target) = state! {
+            doc { root {
+                blockquote { target: paragraph { text("xy") } }
+                paragraph {}
+            } }
+            selection: none
+        };
+        let slice = Slice {
+            content: vec![Fragment {
+                node: NodeType::Blockquote.into_node().to_plain(),
+                modifiers: vec![],
+                carry: vec![],
+                children: vec![paragraph_fragment("A"), paragraph_fragment("B")],
+            }],
+            open_start: 2,
+            open_end: 2,
+        };
+
+        let mut tr = Transaction::new(&initial);
+        let inserted = insert_slice_at(
+            &mut tr,
+            Position::new(target, 1),
+            slice,
+            SliceProvenance::Formatted,
+        )
+        .expect("insert succeeds")
+        .expect("slice inserted");
+        let (actual, ..) = tr.commit();
+        let view = actual.view();
+        let paragraphs = view
+            .node(target)
+            .expect("first paragraph remains")
+            .parent()
+            .expect("blockquote remains")
+            .child_blocks()
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            paragraphs
+                .iter()
+                .map(|paragraph| paragraph.inline_text())
+                .collect::<Vec<_>>(),
+            ["xA", "By"]
+        );
+        assert_eq!(
+            inserted,
+            Selection::new(
+                Position {
+                    node: paragraphs[0].id(),
+                    offset: 1,
+                    affinity: Affinity::Upstream,
+                },
+                Position {
+                    node: paragraphs[1].id(),
+                    offset: 1,
+                    affinity: Affinity::Downstream,
+                },
+            )
+        );
+    }
+
+    #[test]
+    fn multi_item_closed_list_between_adjacent_lists_returns_the_inserted_range() {
         let (initial, root, earlier) = state! {
             doc { root: root {
                 earlier: ordered_list {
                     list_item { paragraph { text("A") } }
                 }
                 bullet_list {
-                    list_item { paragraph { text("C") } }
+                    list_item { paragraph { text("D") } }
                 }
                 paragraph {}
             } }
@@ -583,7 +851,7 @@ mod tests {
         let inserted = insert_slice_at(
             &mut tr,
             Position::new(root, 1),
-            open_bullet_list_slice("B", 0, 0),
+            bullet_list_slice(&["B", "C"], 0, 0),
             SliceProvenance::Formatted,
         )
         .expect("command succeeds");
@@ -597,7 +865,7 @@ mod tests {
                 },
                 Position {
                     node: earlier,
-                    offset: 2,
+                    offset: 3,
                     affinity: Affinity::Upstream,
                 },
             ))
@@ -619,7 +887,7 @@ mod tests {
         assert_eq!(lists.len(), 1);
         assert_eq!(lists[0].id(), earlier);
         assert_eq!(lists[0].node_type(), NodeType::OrderedList);
-        assert_eq!(list_item_texts(&view, earlier), ["A", "B", "C"]);
+        assert_eq!(list_item_texts(&view, earlier), ["A", "B", "C", "D"]);
     }
 
     #[test]
@@ -638,7 +906,7 @@ mod tests {
         let inserted = insert_slice_at(
             &mut tr,
             Position::new(empty, 0),
-            open_bullet_list_slice("B", 0, 0),
+            bullet_list_slice(&["B"], 0, 0),
             SliceProvenance::Formatted,
         )
         .expect("command succeeds")
@@ -693,7 +961,7 @@ mod tests {
             insert_slice_at(
                 &mut tr,
                 Position::new(list, 1),
-                open_bullet_list_slice("B", 3, 0),
+                bullet_list_slice(&["B"], 3, 0),
                 SliceProvenance::Formatted,
             )
             .expect("command succeeds")
@@ -719,7 +987,7 @@ mod tests {
             insert_slice_at(
                 &mut tr,
                 Position::new(list, 1),
-                open_bullet_list_slice("B", 0, 3),
+                bullet_list_slice(&["B"], 0, 3),
                 SliceProvenance::Formatted,
             )
             .expect("command succeeds")

--- a/crates/editor-commands/src/helpers/slice.rs
+++ b/crates/editor-commands/src/helpers/slice.rs
@@ -4,14 +4,13 @@ use editor_model::{
     ChildView, DocView, Fragment, Modifier, NodeType, PlainNode, PlainParagraphNode, Schema,
     Subtree, content_placement,
 };
-use editor_state::{Affinity, Position, Selection, StableSelection, first_cursor_position};
+use editor_state::{Affinity, Position, Selection, first_cursor_position};
 use editor_transaction::{Transaction, fulfill, minimal_subtree};
 
 use super::{
     apply_inline_modifiers, child_node_type, consume_pending_modifiers, insert_hard_break_at_caret,
     insert_tab_at_caret, insert_text_at_caret, is_list_type, merge_adjacent_list_pair,
-    next_sibling, resolve_effective_modifiers, resolve_selection_after_adjacent_list_merge,
-    restore_selection_after_adjacent_list_merge,
+    next_sibling, resolve_effective_modifiers,
 };
 use crate::types::SliceProvenance;
 use crate::{CommandError, CommandResult};
@@ -341,7 +340,6 @@ pub(crate) struct OpenAncestorSplice {
     pub source: Fragment,
 }
 
-#[derive(Clone, PartialEq, Eq)]
 pub(crate) struct SliceInsertionOutputPlan {
     pub(crate) nodes: Vec<SliceOutputNodeSpec>,
     pub(crate) caret: SliceOutputPositionSpec,
@@ -349,13 +347,12 @@ pub(crate) struct SliceInsertionOutputPlan {
     pub(crate) head: SliceOutputPositionSpec,
 }
 
-#[derive(Clone, PartialEq, Eq)]
 pub(crate) struct SliceOutputNodeSpec {
     pub(crate) source: SliceOutputSource,
     pub(crate) node_type: NodeType,
 }
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SliceOutputSource {
     InlineSlot {
         index: usize,
@@ -366,24 +363,29 @@ pub(crate) enum SliceOutputSource {
     TextblockStartInline {
         index: usize,
     },
-    TextblockBlockPath {
+    TextblockBlock {
         block_index: usize,
-        child_path: Vec<usize>,
+    },
+    TextblockListItem {
+        block_index: usize,
+        child_index: usize,
     },
     TextblockEndInline {
         index: usize,
     },
-    BlockPath {
+    Block {
         block_index: usize,
-        child_path: Vec<usize>,
+    },
+    BlockListItem {
+        block_index: usize,
+        child_index: usize,
     },
     SplitLeft,
     SplitRight,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) struct SliceOutputPositionSpec {
-    pub(crate) node: usize,
+    pub(crate) source: SliceOutputSource,
     pub(crate) relation: SliceOutputRelation,
     pub(crate) affinity: Affinity,
 }
@@ -395,6 +397,15 @@ pub(crate) enum SliceOutputRelation {
     AfterTerminalPageBreak,
     Start,
     End,
+}
+
+pub(crate) fn resolve_live_slice_output_dot(view: &DocView, dot: Dot) -> Option<Dot> {
+    let is_live = |candidate| view.node(candidate).is_some() || view.block_of(candidate).is_some();
+    if is_live(dot) {
+        return Some(dot);
+    }
+    let resolved = view.alias_classes().resolve_with(dot, is_live);
+    is_live(resolved).then_some(resolved)
 }
 
 pub(crate) fn planned_inline_output(
@@ -532,21 +543,22 @@ fn output_plan_for_units(
     anchor_affinity: Affinity,
     head_affinity: Affinity,
 ) -> Option<SliceInsertionOutputPlan> {
-    let last = nodes.len().checked_sub(1)?;
+    let first = nodes.first()?.source;
+    let last = nodes.last()?.source;
     Some(SliceInsertionOutputPlan {
         nodes,
         caret: SliceOutputPositionSpec {
-            node: last,
+            source: last,
             relation: caret_relation,
             affinity: caret_affinity,
         },
         anchor: SliceOutputPositionSpec {
-            node: 0,
+            source: first,
             relation: SliceOutputRelation::Before,
             affinity: anchor_affinity,
         },
         head: SliceOutputPositionSpec {
-            node: last,
+            source: last,
             relation: SliceOutputRelation::After,
             affinity: head_affinity,
         },
@@ -579,30 +591,29 @@ fn planned_block_output_nodes(
 ) -> Vec<SliceOutputNodeSpec> {
     let mut output = Vec::new();
     for (block_index, block) in blocks.iter().enumerate() {
-        let source = |child_path| {
-            if textblock {
-                SliceOutputSource::TextblockBlockPath {
-                    block_index,
-                    child_path,
-                }
-            } else {
-                SliceOutputSource::BlockPath {
-                    block_index,
-                    child_path,
-                }
-            }
+        let source = |child_index| match (textblock, child_index) {
+            (true, None) => SliceOutputSource::TextblockBlock { block_index },
+            (true, Some(child_index)) => SliceOutputSource::TextblockListItem {
+                block_index,
+                child_index,
+            },
+            (false, None) => SliceOutputSource::Block { block_index },
+            (false, Some(child_index)) => SliceOutputSource::BlockListItem {
+                block_index,
+                child_index,
+            },
         };
         if inserted_member_is_merged(list_merges, block_index) && is_list_type(block.node.as_type())
         {
             output.extend(block.children.iter().enumerate().map(|(index, child)| {
                 SliceOutputNodeSpec {
-                    source: source(vec![index]),
+                    source: source(Some(index)),
                     node_type: child.node.as_type(),
                 }
             }));
         } else {
             output.push(SliceOutputNodeSpec {
-                source: source(Vec::new()),
+                source: source(None),
                 node_type: block.node.as_type(),
             });
         }
@@ -922,32 +933,43 @@ pub(crate) fn insert_content_as_inline_at_position(
     fragments: Vec<Fragment>,
     mode: &InlineMode,
 ) -> Result<Option<SliceInsertionExecution>, CommandError> {
-    if fragments.is_empty() {
+    let mut outputs = Vec::new();
+    if !append_inline_outputs_at_position(tr, position, &fragments, mode, &mut outputs, |index| {
+        SliceOutputSource::InlineSlot { index }
+    })? {
         return Ok(None);
     }
+    Ok(Some(SliceInsertionExecution {
+        outputs,
+        split_left: None,
+        split_right: None,
+    }))
+}
 
+fn append_inline_outputs_at_position(
+    tr: &mut Transaction,
+    position: Position,
+    fragments: &[Fragment],
+    mode: &InlineMode,
+    outputs: &mut Vec<SliceOutputBinding>,
+    source: impl FnMut(usize) -> SliceOutputSource,
+) -> Result<bool, CommandError> {
     tr.set_selection(Some(Selection::collapsed(position)))?;
     let start = tr
         .selection()
         .expect("selection preserved through mutations")
         .head;
-    let inserted = insert_inline_fragments(tr, &fragments, mode)?;
-    if !inserted {
-        return Ok(None);
+    if !insert_inline_fragments(tr, fragments, mode)? {
+        return Ok(false);
     }
     let mut end = tr
         .selection()
         .expect("selection preserved through mutations")
         .head;
+    append_output_bindings_between(tr, start, end, outputs, source)?;
     end.affinity = Affinity::Downstream;
     tr.set_selection(Some(Selection::collapsed(end)))?;
-    let units = output_units_between(tr, start, end)?;
-    Ok(Some(SliceInsertionExecution {
-        inserted: Selection::new(start, end),
-        units,
-        split_left: None,
-        split_right: None,
-    }))
+    Ok(true)
 }
 
 pub(crate) fn insert_blocks_in_textblock_at_position(
@@ -971,14 +993,9 @@ pub(crate) fn insert_open_ancestor_splice_at_position(
         return Ok(None);
     }
 
-    let start = Position {
-        node: *splice.destination.last().unwrap(),
-        offset: position.offset,
-        affinity: Affinity::Upstream,
-    };
     let left = splice.destination;
     let mut right = left.clone();
-    let mut output_units = Vec::new();
+    let mut outputs = Vec::new();
     tr.batch::<_, CommandError>(|tr| {
         let deepest = depth - 1;
         tr.split_node(left[deepest], position.offset)?;
@@ -995,7 +1012,6 @@ pub(crate) fn insert_open_ancestor_splice_at_position(
             }
         }
 
-        let mut inserted = InsertedRange::default();
         let source_children = &splice.source.children;
         match source_children.as_slice() {
             [] => {
@@ -1004,39 +1020,19 @@ pub(crate) fn insert_open_ancestor_splice_at_position(
                 ));
             }
             [only] => {
-                join_open_fragment_both(tr, &left[1..], &right[1..], only, mode, &mut inserted)?;
+                join_open_fragment_both(tr, &left[1..], &right[1..], only, mode, &mut outputs)?;
             }
             [first, middle @ .., last] => {
-                append_open_fragment(tr, &left[1..], first, mode, &mut inserted)?;
-                insert_fragments_after(tr, left[0], left[1], middle, mode, &mut inserted)?;
-                prepend_open_fragment(tr, &right[1..], last, mode, &mut inserted)?;
+                append_open_fragment(tr, &left[1..], first, mode, &mut outputs)?;
+                insert_fragments_after(tr, left[0], left[1], middle, mode, &mut outputs)?;
+                prepend_open_fragment(tr, &right[1..], last, mode, &mut outputs)?;
             }
         }
-
-        let mut end = inserted
-            .end
-            .clone()
-            .and_then(|endpoint| resolve_inserted_range_endpoint(tr, endpoint))
-            .ok_or_else(|| {
-                CommandError::Corrupted(
-                    "open-ancestor Slice plan produced no inserted endpoint".into(),
-                )
-            })?;
-        end.affinity = Affinity::Downstream;
-        output_units = inserted.units.clone();
-        tr.set_selection(Some(Selection::collapsed(end)))?;
         Ok(())
     })?;
 
-    let end = tr
-        .selection()
-        .map(|selection| selection.head)
-        .ok_or_else(|| {
-            CommandError::Corrupted("open-ancestor Slice plan produced no final caret".into())
-        })?;
     Ok(Some(SliceInsertionExecution {
-        inserted: Selection::new(start, end),
-        units: output_units,
+        outputs,
         split_left: None,
         split_right: None,
     }))
@@ -1293,7 +1289,7 @@ fn join_open_fragment_both(
     right: &[Dot],
     source: &Fragment,
     mode: &InlineMode,
-    inserted: &mut InsertedRange,
+    inserted: &mut Vec<SliceOutputBinding>,
 ) -> Result<(), CommandError> {
     let (&left_node, &right_node) = left
         .first()
@@ -1330,7 +1326,7 @@ fn append_open_fragment(
     destination: &[Dot],
     source: &Fragment,
     mode: &InlineMode,
-    inserted: &mut InsertedRange,
+    inserted: &mut Vec<SliceOutputBinding>,
 ) -> Result<(), CommandError> {
     let &node = destination
         .first()
@@ -1351,7 +1347,7 @@ fn prepend_open_fragment(
     destination: &[Dot],
     source: &Fragment,
     mode: &InlineMode,
-    inserted: &mut InsertedRange,
+    inserted: &mut Vec<SliceOutputBinding>,
 ) -> Result<(), CommandError> {
     let &node = destination
         .first()
@@ -1380,19 +1376,16 @@ fn insert_inline_at_edge(
     fragments: &[Fragment],
     at_start: bool,
     mode: &InlineMode,
-    inserted: &mut InsertedRange,
+    inserted: &mut Vec<SliceOutputBinding>,
 ) -> Result<(), CommandError> {
     let position = if at_start {
         position_at_start_of_block(tr, block)?
     } else {
         position_at_end_of_block(tr, block)?
     };
-    if let Some(execution) =
-        insert_content_as_inline_at_position(tr, position, fragments.to_vec(), mode)?
-    {
-        inserted.include_position_range(execution.inserted.anchor, execution.inserted.head);
-        inserted.units.extend(execution.units);
-    }
+    append_inline_outputs_at_position(tr, position, fragments, mode, inserted, |index| {
+        SliceOutputSource::OpenSpliceUnit { index }
+    })?;
     Ok(())
 }
 
@@ -1402,7 +1395,7 @@ fn insert_fragments_after(
     child: Dot,
     fragments: &[Fragment],
     mode: &InlineMode,
-    inserted: &mut InsertedRange,
+    inserted: &mut Vec<SliceOutputBinding>,
 ) -> Result<(), CommandError> {
     if fragments.is_empty() {
         return Ok(());
@@ -1427,7 +1420,7 @@ fn insert_fragments_before(
     child: Dot,
     fragments: &[Fragment],
     mode: &InlineMode,
-    inserted: &mut InsertedRange,
+    inserted: &mut Vec<SliceOutputBinding>,
 ) -> Result<(), CommandError> {
     if fragments.is_empty() {
         return Ok(());
@@ -1451,7 +1444,7 @@ fn insert_fragments_at_end(
     parent: Dot,
     fragments: &[Fragment],
     mode: &InlineMode,
-    inserted: &mut InsertedRange,
+    inserted: &mut Vec<SliceOutputBinding>,
 ) -> Result<(), CommandError> {
     if fragments.is_empty() {
         return Ok(());
@@ -1471,13 +1464,18 @@ fn insert_closed_fragments(
     index: usize,
     fragments: &[Fragment],
     mode: &InlineMode,
-    inserted: &mut InsertedRange,
+    inserted: &mut Vec<SliceOutputBinding>,
 ) -> Result<(), CommandError> {
     for (offset, fragment) in fragments.iter().enumerate() {
         let inserted_id =
             tr.insert_subtree(parent, index + offset, fragment.clone().into_subtree())?;
         if let Some(inserted_id) = inserted_id {
-            inserted.include_block(inserted_id);
+            inserted.push(SliceOutputBinding {
+                source: SliceOutputSource::OpenSpliceUnit {
+                    index: inserted.len(),
+                },
+                dot: inserted_id,
+            });
             paint_inserted_subtree(tr, inserted_id, mode)?;
         }
     }
@@ -1559,108 +1557,24 @@ pub(crate) fn is_insertable_inline_fragment(fragment: &Fragment) -> bool {
     }
 }
 
-#[derive(Clone)]
-enum InsertedRangeEndpoint {
-    Position(Position),
-    BeforeBlock(Dot),
-    AfterBlock(Dot),
+pub(crate) struct SliceOutputBinding {
+    pub(crate) source: SliceOutputSource,
+    pub(crate) dot: Dot,
 }
 
 pub(crate) struct SliceInsertionExecution {
-    pub(crate) inserted: Selection,
-    pub(crate) units: Vec<Dot>,
+    pub(crate) outputs: Vec<SliceOutputBinding>,
     pub(crate) split_left: Option<Dot>,
     pub(crate) split_right: Option<Dot>,
 }
 
-#[derive(Default)]
-struct InsertedRange {
-    start: Option<InsertedRangeEndpoint>,
-    end: Option<InsertedRangeEndpoint>,
-    blocks: Vec<Dot>,
-    units: Vec<Dot>,
-}
-
-impl InsertedRange {
-    fn prepend_position(&mut self, start: Position) {
-        self.start = Some(InsertedRangeEndpoint::Position(start));
-    }
-
-    fn include_position_range(&mut self, start: Position, end: Position) {
-        self.start
-            .get_or_insert(InsertedRangeEndpoint::Position(start));
-        self.end = Some(InsertedRangeEndpoint::Position(end));
-    }
-
-    fn include_block(&mut self, block_id: Dot) {
-        self.start
-            .get_or_insert(InsertedRangeEndpoint::BeforeBlock(block_id));
-        self.end = Some(InsertedRangeEndpoint::AfterBlock(block_id));
-        self.blocks.push(block_id);
-        self.units.push(block_id);
-    }
-
-    fn selection(&self, tr: &Transaction) -> Result<Option<Selection>, CommandError> {
-        let mut endpoints = Vec::new();
-        if let Some(start) = self.start.clone() {
-            endpoints.push(resolve_inserted_range_endpoint(tr, start).ok_or_else(|| {
-                CommandError::Corrupted("planned Slice start output no longer resolves".into())
-            })?);
-        }
-        if let Some(end) = self.end.clone() {
-            endpoints.push(resolve_inserted_range_endpoint(tr, end).ok_or_else(|| {
-                CommandError::Corrupted("planned Slice end output no longer resolves".into())
-            })?);
-        }
-        for block in &self.blocks {
-            endpoints.push(
-                resolve_inserted_range_endpoint(tr, InsertedRangeEndpoint::BeforeBlock(*block))
-                    .ok_or_else(|| {
-                        CommandError::Corrupted(
-                            "planned Slice block-start output no longer resolves".into(),
-                        )
-                    })?,
-            );
-            endpoints.push(
-                resolve_inserted_range_endpoint(tr, InsertedRangeEndpoint::AfterBlock(*block))
-                    .ok_or_else(|| {
-                        CommandError::Corrupted(
-                            "planned Slice block-end output no longer resolves".into(),
-                        )
-                    })?,
-            );
-        }
-
-        let view = tr.state().view();
-        let resolved = endpoints
-            .iter()
-            .map(|position| {
-                position.resolve(&view).ok_or_else(|| {
-                    CommandError::Corrupted(
-                        "planned Slice output position no longer resolves".into(),
-                    )
-                })
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        let Some(start) = resolved.iter().min().map(|position| position.position()) else {
-            return Ok(None);
-        };
-        let end = resolved
-            .iter()
-            .max()
-            .map(|position| position.position())
-            .ok_or_else(|| {
-                CommandError::Corrupted("planned Slice output range has no end".into())
-            })?;
-        Ok(Some(Selection::new(start, end)))
-    }
-}
-
-fn output_units_between(
+fn append_output_bindings_between(
     tr: &Transaction,
     start: Position,
     end: Position,
-) -> Result<Vec<Dot>, CommandError> {
+    outputs: &mut Vec<SliceOutputBinding>,
+    mut source: impl FnMut(usize) -> SliceOutputSource,
+) -> Result<(), CommandError> {
     if start.node != end.node || start.offset > end.offset {
         return Err(CommandError::Corrupted(
             "inline Slice output escaped its planned textblock".into(),
@@ -1670,21 +1584,30 @@ fn output_units_between(
     let node = view
         .node(start.node)
         .ok_or(CommandError::NodeNotFound(start.node))?;
-    let units = node
-        .children()
-        .skip(start.offset)
-        .take(end.offset - start.offset)
-        .map(|child| match child {
-            ChildView::Block(block) => block.id(),
-            ChildView::Leaf(leaf) => leaf.dot(),
-        })
-        .collect::<Vec<_>>();
-    if units.len() != end.offset - start.offset {
+    if end.offset > node.child_count() {
         return Err(CommandError::Corrupted(
             "inline Slice output produced a different child span".into(),
         ));
     }
-    Ok(units)
+    let expected_count = end.offset - start.offset;
+    let first_output_index = outputs.len();
+    outputs.reserve(expected_count);
+    for (index, child) in node
+        .children()
+        .skip(start.offset)
+        .take(expected_count)
+        .enumerate()
+    {
+        let dot = match child {
+            ChildView::Block(block) => block.id(),
+            ChildView::Leaf(leaf) => leaf.dot(),
+        };
+        outputs.push(SliceOutputBinding {
+            source: source(first_output_index + index),
+            dot,
+        });
+    }
+    Ok(())
 }
 
 /// Elem id at child slot `index` of `container` when it is an addressable block
@@ -1823,24 +1746,25 @@ impl TextblockSplicePlan {
                     },
                 ],
                 caret: SliceOutputPositionSpec {
-                    node: 1,
+                    source: SliceOutputSource::SplitRight,
                     relation: SliceOutputRelation::Start,
                     affinity: Affinity::Downstream,
                 },
                 anchor: SliceOutputPositionSpec {
-                    node: 0,
+                    source: SliceOutputSource::SplitLeft,
                     relation: SliceOutputRelation::End,
                     affinity: Affinity::Upstream,
                 },
                 head: SliceOutputPositionSpec {
-                    node: 1,
+                    source: SliceOutputSource::SplitRight,
                     relation: SliceOutputRelation::Start,
                     affinity: Affinity::Downstream,
                 },
             });
         }
 
-        let last_output_node = nodes.len() - 1;
+        let first_output = nodes.first()?.source;
+        let last_authored_output = nodes.last()?.source;
         if self.final_caret_at_right_boundary {
             // An empty open end authors a paragraph boundary but no inline unit.
             // Bind the split right only as the caret endpoint; the inserted
@@ -1881,26 +1805,20 @@ impl TextblockSplicePlan {
         } else {
             inline_output_end_affinity(&self.blocks.first()?.children)
         };
-        let mut output = output_plan_for_units(
-            nodes,
-            caret_relation,
-            Affinity::Downstream,
-            if self.join_start {
-                Affinity::Upstream
-            } else {
-                Affinity::Downstream
-            },
-            head_affinity,
-        )?;
-        if self.final_caret_at_right_boundary {
-            output.caret = SliceOutputPositionSpec {
-                node: output.nodes.len() - 1,
+        let caret = if self.final_caret_at_right_boundary {
+            SliceOutputPositionSpec {
+                source: SliceOutputSource::SplitRight,
                 relation: SliceOutputRelation::Start,
                 affinity: Affinity::Downstream,
-            };
-            output.head.node = last_output_node;
-        }
-        if self.join_start
+            }
+        } else {
+            SliceOutputPositionSpec {
+                source: last_authored_output,
+                relation: caret_relation,
+                affinity: Affinity::Downstream,
+            }
+        };
+        let head_relation = if self.join_start
             && self.inserted_blocks.is_empty()
             && !self.merge_end
             && self
@@ -1908,9 +1826,28 @@ impl TextblockSplicePlan {
                 .first()
                 .is_some_and(|block| paragraph_ends_with_page_break(block))
         {
-            output.head.relation = SliceOutputRelation::AfterTerminalPageBreak;
-        }
-        Some(output)
+            SliceOutputRelation::AfterTerminalPageBreak
+        } else {
+            SliceOutputRelation::After
+        };
+        Some(SliceInsertionOutputPlan {
+            nodes,
+            caret,
+            anchor: SliceOutputPositionSpec {
+                source: first_output,
+                relation: SliceOutputRelation::Before,
+                affinity: if self.join_start {
+                    Affinity::Upstream
+                } else {
+                    Affinity::Downstream
+                },
+            },
+            head: SliceOutputPositionSpec {
+                source: last_authored_output,
+                relation: head_relation,
+                affinity: head_affinity,
+            },
+        })
     }
 }
 
@@ -2166,9 +2103,7 @@ fn insert_blocks_in_textblock(
         tr.remove_subtree(textblock_id)?;
     }
 
-    let mut last_caret: Option<Position> = None;
-    let mut inserted_range = InsertedRange::default();
-    let mut terminal_page_break_start: Option<Position> = None;
+    let mut start_outputs = Vec::new();
 
     if plan.join_start {
         let left_id = left_id.expect("merge start requires left destination content");
@@ -2179,24 +2114,16 @@ fn insert_blocks_in_textblock(
             .is_some_and(|fragment| fragment.node.as_type() == NodeType::PageBreak)
             .then(|| &inline[..inline.len() - 1])
             .unwrap_or(&inline);
-        tr.set_selection(Some(Selection::collapsed(position_at_end_of_block(
-            tr, left_id,
-        )?)))?;
-        let start = tr
-            .selection()
-            .expect("selection preserved through mutations")
-            .head;
-        let inserted = insert_inline_fragments(tr, insertable_inline, mode)?;
+        let position = position_at_end_of_block(tr, left_id)?;
+        append_inline_outputs_at_position(
+            tr,
+            position,
+            insertable_inline,
+            mode,
+            &mut start_outputs,
+            |index| SliceOutputSource::TextblockStartInline { index },
+        )?;
         let inserted_page_break = insert_terminal_page_break_from_edge(tr, left_id, &inline)?;
-        let end = tr
-            .selection()
-            .expect("selection preserved through mutations")
-            .head;
-        if start.offset < end.offset {
-            inserted_range
-                .units
-                .extend(output_units_between(tr, start, end)?);
-        }
         if inserted_page_break {
             let page_break = tr
                 .view()
@@ -2213,19 +2140,18 @@ fn insert_blocks_in_textblock(
                         "planned terminal PageBreak output was not authored".into(),
                     )
                 })?;
-            inserted_range.units.push(page_break);
-            terminal_page_break_start = Some(start);
-            last_caret = Some(end);
-        } else if inserted {
-            inserted_range.include_position_range(start, end);
-            last_caret = Some(end);
+            start_outputs.push(SliceOutputBinding {
+                source: SliceOutputSource::TextblockStartInline {
+                    index: start_outputs.len(),
+                },
+                dot: page_break,
+            });
         }
     }
 
     if plan.merge_destinations {
         let left_id = left_id.expect("destination merge requires left content");
         tr.merge_node(left_id)?;
-        last_caret = tr.selection().map(|s| s.head);
     }
 
     let mut inserted_blocks = Vec::with_capacity(unjoined_count);
@@ -2240,42 +2166,26 @@ fn insert_blocks_in_textblock(
             tr.insert_subtree(container_id, block_index, fragment.clone().into_subtree())?
         {
             inserted_blocks.push(inserted_id);
-            inserted_range.include_block(inserted_id);
             if let Some(paint) = mode.plain_paint() {
                 paint_block_uniformly(tr, inserted_id, paint)?;
             }
-            // Block-level atoms have no inner caret. Their planned end slot is
-            // the boundary immediately after the authored atom.
-            last_caret = Some(position_at_end_of_block(tr, inserted_id).or_else(|_| {
-                resolve_inserted_range_endpoint(tr, InsertedRangeEndpoint::AfterBlock(inserted_id))
-                    .ok_or(CommandError::NodeNotFound(inserted_id))
-            })?);
         }
     }
 
+    let mut end_outputs = Vec::new();
     if plan.merge_end {
         let right_id = right_id.expect("merge end requires right destination content");
         let last = blocks.last().unwrap();
         let inline = last.children.to_vec();
-        tr.set_selection(Some(Selection::collapsed(position_at_start_of_block(
-            tr, right_id,
-        )?)))?;
-        let start = tr
-            .selection()
-            .expect("selection preserved through mutations")
-            .head;
-        let inserted = insert_inline_fragments(tr, &inline, mode)?;
-        let end = tr
-            .selection()
-            .expect("selection preserved through mutations")
-            .head;
-        if inserted {
-            inserted_range.include_position_range(start, end);
-            inserted_range
-                .units
-                .extend(output_units_between(tr, start, end)?);
-        }
-        last_caret = Some(end);
+        let position = position_at_start_of_block(tr, right_id)?;
+        append_inline_outputs_at_position(
+            tr,
+            position,
+            &inline,
+            mode,
+            &mut end_outputs,
+            |index| SliceOutputSource::TextblockEndInline { index },
+        )?;
         if let Some(paint) = mode.plain_paint() {
             tr.replace_carry(right_id, carry_from_paint(paint))?;
         }
@@ -2289,84 +2199,30 @@ fn insert_blocks_in_textblock(
     };
     tr.apply_steps(steps)?;
 
-    if !plan.merge_end && plan.unjoined_ends_with_page_break {
-        let following_id = block_child_id(tr, container_id, plan.insert_at + unjoined_count)
-            .ok_or_else(|| CommandError::Corrupted("PageBreak has no following block".into()))?;
-        last_caret = Some(position_at_start_of_block(tr, following_id)?);
-    }
-
-    if let Some(start) = terminal_page_break_start {
-        if inserted_range.end.is_some() {
-            inserted_range.prepend_position(start);
-        } else {
-            let following_id =
-                block_child_id(tr, container_id, plan.insert_at).ok_or_else(|| {
-                    CommandError::Corrupted("PageBreak has no following block".into())
-                })?;
-            let end = position_at_start_of_block(tr, following_id)?;
-            inserted_range.include_position_range(start, end);
-            last_caret = Some(end);
-        }
-    }
-
-    let mut final_pos = match (last_caret, plan.final_caret_at_right_boundary) {
-        (_, true) => position_at_start_of_block(
-            tr,
-            right_id.ok_or_else(|| {
-                CommandError::Corrupted(
-                    "planned textblock split lost its right caret boundary".into(),
-                )
-            })?,
-        )?,
-        (Some(position), false) => position,
-        (None, false) => {
-            return Err(CommandError::Corrupted(
-                "textblock Slice plan produced a different final caret".into(),
-            ));
-        }
-    };
-    final_pos.affinity = Affinity::Downstream;
-    let explicit_inserted_selection = inserted_range.selection(tr)?;
-    let split_boundary_selection =
-        if plan.has_left && plan.has_right && explicit_inserted_selection.is_none() {
-            match (left_id, right_id) {
-                (Some(left_id), Some(right_id)) => Some(Selection::new(
-                    position_at_end_of_block(tr, left_id)?,
-                    position_at_start_of_block(tr, right_id)?,
-                )),
-                _ => {
-                    return Err(CommandError::Corrupted(
-                        "planned textblock split lost a surviving boundary".into(),
-                    ));
-                }
-            }
-        } else {
-            None
-        };
-    let inserted_selection = explicit_inserted_selection
-        .or(split_boundary_selection)
-        .ok_or_else(|| {
-            CommandError::Corrupted("textblock Slice plan produced no inserted selection".into())
-        })?;
-    let output_units = expand_planned_list_output_units(
+    let mut outputs = start_outputs;
+    outputs.extend(block_output_bindings(
         tr,
-        &inserted_range.units,
         &inserted_blocks,
         &plan.list_merges,
-    )?;
-    tr.set_selection(Some(Selection::collapsed(final_pos)))?;
-    let inserted_selection = apply_planned_list_merges(
+        |block_index, child_index| match child_index {
+            Some(child_index) => SliceOutputSource::TextblockListItem {
+                block_index,
+                child_index,
+            },
+            None => SliceOutputSource::TextblockBlock { block_index },
+        },
+    )?);
+    outputs.extend(end_outputs);
+    apply_planned_list_merges(
         tr,
         container_id,
         plan.insert_at,
         &inserted_blocks,
         &plan.list_merges,
-        inserted_selection,
     )?;
 
     Ok(Some(SliceInsertionExecution {
-        inserted: inserted_selection,
-        units: output_units,
+        outputs,
         split_left: left_id,
         split_right: right_id,
     }))
@@ -2404,7 +2260,6 @@ pub(crate) fn insert_blocks_at_block_boundary(
     let container_id = position.node;
     let base_index = position.offset;
     let block_count = blocks.len();
-    let terminal_page_break = blocks.last().is_some_and(paragraph_ends_with_page_break);
     let mut inserted: Vec<Dot> = Vec::with_capacity(block_count);
     tr.batch(|tr| {
         // Normalization between the sequential inserts can synthesize scaffold
@@ -2463,7 +2318,7 @@ pub(crate) fn insert_blocks_at_block_boundary(
         .ok_or_else(|| {
             CommandError::Corrupted("planned block Slice end output no longer resolves".into())
         })?;
-    let span = last_inserted_index
+    last_inserted_index
         .checked_sub(first_inserted_index)
         .and_then(|distance| distance.checked_add(1))
         .filter(|span| *span == inserted.len())
@@ -2474,37 +2329,19 @@ pub(crate) fn insert_blocks_at_block_boundary(
         })?;
     let start_index = first_inserted_index;
 
-    let mut final_pos = if terminal_page_break {
-        let following =
-            block_child_id(tr, container_id, last_inserted_index + 1).ok_or_else(|| {
-                CommandError::Corrupted("planned PageBreak output has no following block".into())
-            })?;
-        position_at_start_of_block(tr, following)?
-    } else {
-        let last = *inserted
-            .last()
-            .ok_or_else(|| CommandError::Corrupted("planned block Slice output is empty".into()))?;
-        position_at_end_of_block(tr, last).or_else(|_| {
-            resolve_inserted_range_endpoint(tr, InsertedRangeEndpoint::AfterBlock(last))
-                .ok_or(CommandError::NodeNotFound(last))
-        })?
-    };
-    final_pos.affinity = Affinity::Downstream;
-    tr.set_selection(Some(Selection::collapsed(final_pos)))?;
-
-    let inserted_selection = selection_over_inserted_blocks(container_id, start_index, span);
-    let output_units = expand_planned_list_output_units(tr, &inserted, &inserted, &list_merges)?;
-    let inserted_selection = apply_planned_list_merges(
-        tr,
-        container_id,
-        start_index,
-        &inserted,
-        &list_merges,
-        inserted_selection,
-    )?;
+    let outputs =
+        block_output_bindings(tr, &inserted, &list_merges, |block_index, child_index| {
+            match child_index {
+                Some(child_index) => SliceOutputSource::BlockListItem {
+                    block_index,
+                    child_index,
+                },
+                None => SliceOutputSource::Block { block_index },
+            }
+        })?;
+    apply_planned_list_merges(tr, container_id, start_index, &inserted, &list_merges)?;
     Ok(Some(SliceInsertionExecution {
-        inserted: inserted_selection,
-        units: output_units,
+        outputs,
         split_left: None,
         split_right: None,
     }))
@@ -2516,8 +2353,7 @@ fn apply_planned_list_merges(
     start_index: usize,
     inserted: &[Dot],
     merges: &[PlannedListMerge],
-    mut inserted_selection: Selection,
-) -> Result<Selection, CommandError> {
+) -> Result<(), CommandError> {
     let left = start_index
         .checked_sub(1)
         .and_then(|index| block_child_id(tr, container_id, index));
@@ -2555,29 +2391,17 @@ fn apply_planned_list_merges(
             }
             (earlier_id, later_id)
         };
-        let selection = tr.selection();
-        let stable = selection.map(|selection| StableSelection::capture(&selection, &tr.view()));
-        let inserted_stable = StableSelection::capture(&inserted_selection, &tr.view());
-        let merged_lists = merge_adjacent_list_pair(tr, pair.0, pair.1)?;
-        if let Some((selection, stable)) = selection.zip(stable) {
-            restore_selection_after_adjacent_list_merge(tr, selection, stable, &merged_lists)?;
-        }
-        inserted_selection = resolve_selection_after_adjacent_list_merge(
-            tr,
-            inserted_selection,
-            inserted_stable,
-            &merged_lists,
-        )?;
+        merge_adjacent_list_pair(tr, pair.0, pair.1)?;
     }
-    Ok(inserted_selection)
+    Ok(())
 }
 
-fn expand_planned_list_output_units(
+fn block_output_bindings(
     tr: &Transaction,
-    units: &[Dot],
     inserted: &[Dot],
     merges: &[PlannedListMerge],
-) -> Result<Vec<Dot>, CommandError> {
+    mut source: impl FnMut(usize, Option<usize>) -> SliceOutputSource,
+) -> Result<Vec<SliceOutputBinding>, CommandError> {
     let mut merged_inserted = vec![false; inserted.len()];
     for planned in merges {
         for member in [planned.earlier, planned.later] {
@@ -2594,31 +2418,30 @@ fn expand_planned_list_output_units(
 
     let view = tr.view();
     let mut output = Vec::new();
-    for unit in units {
-        let Some(index) = inserted.iter().position(|inserted| inserted == unit) else {
-            output.push(*unit);
-            continue;
-        };
-        if !merged_inserted[index] {
-            output.push(*unit);
+    for (block_index, &unit) in inserted.iter().enumerate() {
+        if !merged_inserted[block_index] {
+            output.push(SliceOutputBinding {
+                source: source(block_index, None),
+                dot: unit,
+            });
             continue;
         }
-        let list = view.node(*unit).ok_or(CommandError::NodeNotFound(*unit))?;
+        let list = view.node(unit).ok_or(CommandError::NodeNotFound(unit))?;
         if !is_list_type(list.node_type()) {
             return Err(CommandError::Corrupted(
                 "planned list merge output is not a list".into(),
             ));
         }
-        let items = list
-            .child_blocks()
-            .map(|item| item.id())
-            .collect::<Vec<_>>();
-        if items.is_empty() {
+        let mut items = list.child_blocks().enumerate().peekable();
+        if items.peek().is_none() {
             return Err(CommandError::Corrupted(
                 "planned list merge output contains no list item".into(),
             ));
         }
-        output.extend(items);
+        output.extend(items.map(|(child_index, item)| SliceOutputBinding {
+            source: source(block_index, Some(child_index)),
+            dot: item.id(),
+        }));
     }
     Ok(output)
 }
@@ -2720,48 +2543,6 @@ fn open_fragments_for_parent(
             }
             candidates.extend(&last.children);
             open_end -= 1;
-        }
-    }
-}
-
-fn selection_over_inserted_blocks(
-    container_id: Dot,
-    start_index: usize,
-    block_count: usize,
-) -> Selection {
-    Selection::new(
-        Position {
-            node: container_id,
-            offset: start_index,
-            affinity: Affinity::Downstream,
-        },
-        Position {
-            node: container_id,
-            offset: start_index + block_count,
-            affinity: Affinity::Upstream,
-        },
-    )
-}
-
-fn resolve_inserted_range_endpoint(
-    tr: &Transaction,
-    endpoint: InsertedRangeEndpoint,
-) -> Option<Position> {
-    match endpoint {
-        InsertedRangeEndpoint::Position(position) => Some(position),
-        InsertedRangeEndpoint::BeforeBlock(ref id) | InsertedRangeEndpoint::AfterBlock(ref id) => {
-            let view = tr.state().view();
-            let (parent_id, index) = block_parent_and_index(&view, *id)?;
-            let (offset, affinity) = match endpoint {
-                InsertedRangeEndpoint::BeforeBlock(_) => (index, Affinity::Downstream),
-                InsertedRangeEndpoint::AfterBlock(_) => (index + 1, Affinity::Upstream),
-                InsertedRangeEndpoint::Position(_) => unreachable!(),
-            };
-            Some(Position {
-                node: parent_id,
-                offset,
-                affinity,
-            })
         }
     }
 }

--- a/crates/editor-commands/src/judgments/mod.rs
+++ b/crates/editor-commands/src/judgments/mod.rs
@@ -13,9 +13,9 @@ pub use slice::{FitOutcome, SliceFitPlan, fit_slice};
 pub(crate) use list::{lift_selected_list_items, sink_selected_list_items};
 pub(crate) use list_kind::{judge_lift_list_items_of_kind, judge_set_list_kind};
 pub(crate) use slice::{
-    AppliedSliceInsertion, CellFillPlan, JoinedReplacementPlan, LinearFinalSelection,
-    LinearFitPlan, LinearMutation, PlannedBoundaryInsertion, PlannedBranchInsertion,
-    PlannedBranchNode, PlannedBranchSplit, PlannedJoin, PlannedOutputKey, RangePlacement,
-    SliceFitPlanKind, SliceInsertionPlan, TableFinalSelection, TableGridPlan,
+    AppliedSliceInsertion, BoundSliceOutputPosition, CellFillPlan, JoinedReplacementPlan,
+    LinearFinalSelection, LinearFitPlan, LinearMutation, PlannedBoundaryInsertion,
+    PlannedBranchInsertion, PlannedBranchNode, PlannedBranchSplit, PlannedJoin, PlannedOutputKey,
+    RangePlacement, SliceFitPlanKind, SliceInsertionPlan, TableFinalSelection, TableGridPlan,
     apply_slice_insertion_plan,
 };

--- a/crates/editor-commands/src/judgments/slice.rs
+++ b/crates/editor-commands/src/judgments/slice.rs
@@ -1,21 +1,24 @@
 use editor_clipboard::Slice;
+use editor_crdt::Dot;
 use editor_model::{DocView, Fragment};
-use editor_state::{Position, Selection};
+use editor_state::{Affinity, Position};
 use editor_transaction::Transaction;
 
 use crate::CommandError;
 use crate::helpers::{
     ExistingBlock, HoistBoundaryStep, HoistInitialBoundary, HoistedBlockInsertionPlan,
     OpenAncestorSplice, SliceInsertionExecution, SliceInsertionOutputPlan, SliceInsertionTarget,
-    SliceInsertionTargetShape, SliceOutputSource, TextblockSplicePlan, block_boundary_fragments,
-    build_inline_mode, fit_slice_for_textblock_target_parent, fragments_are_inline,
-    fragments_fit_parent, inline_fragments_fit_target, insert_blocks_at_block_boundary,
+    SliceInsertionTargetShape, SliceOutputPositionSpec, SliceOutputRelation, SliceOutputSource,
+    TextblockSplicePlan, block_boundary_fragments, build_inline_mode,
+    fit_slice_for_textblock_target_parent, fragments_are_inline, fragments_fit_parent,
+    inline_fragments_fit_target, insert_blocks_at_block_boundary,
     insert_blocks_in_textblock_at_position, insert_content_as_inline_at_position,
     insert_hoisted_blocks_at_position, insert_open_ancestor_splice_at_position,
     is_insertable_inline_fragment, is_supported_inline_fragment, materialize_repair_position,
     open_ancestor_splice_for_target, open_ancestor_splice_is_complete_no_output,
     open_inline_content_for_target, plan_textblock_splice_target, planned_block_output,
-    planned_inline_output, planned_open_splice_output, top_level_fragments,
+    planned_inline_output, planned_open_splice_output, resolve_live_slice_output_dot,
+    top_level_fragments,
 };
 use crate::types::SliceProvenance;
 
@@ -33,32 +36,31 @@ pub(crate) use linear_fitter::{
 };
 pub(crate) use table_fitter::{CellFillPlan, TableFinalSelection, TableGridPlan};
 
-pub(crate) enum SliceInsertionPlan {
+pub(crate) struct SliceInsertionPlan {
+    kind: SliceInsertionKind,
+    output: SliceInsertionOutputPlan,
+}
+
+enum SliceInsertionKind {
     DirectInline {
         fragments: Vec<Fragment>,
-        output: SliceInsertionOutputPlan,
     },
     SpliceOpenAncestors {
         destination: Vec<editor_crdt::Dot>,
         source: Fragment,
-        output: SliceInsertionOutputPlan,
     },
     SpliceBlocks {
         plan: TextblockSplicePlan,
-        output: SliceInsertionOutputPlan,
     },
     HoistBlocks {
         plan: HoistedBlockInsertionPlan,
-        output: SliceInsertionOutputPlan,
     },
     OpenInline {
         fragments: Vec<Fragment>,
-        output: SliceInsertionOutputPlan,
     },
     BlockBoundary {
         blocks: Vec<Fragment>,
         list_merges: Vec<crate::helpers::PlannedListMerge>,
-        output: SliceInsertionOutputPlan,
     },
 }
 
@@ -124,7 +126,10 @@ fn try_place_slice_at_frontier(
                 && fragments.iter().any(is_insertable_inline_fragment)
             {
                 let output = planned_inline_output(&fragments, target.position().affinity)?;
-                return Some(SliceInsertionPlan::DirectInline { fragments, output });
+                return Some(SliceInsertionPlan {
+                    kind: SliceInsertionKind::DirectInline { fragments },
+                    output,
+                });
             }
         }
 
@@ -153,9 +158,11 @@ fn try_place_slice_at_frontier(
             }
             splice.source = fitted.pop().expect("cardinality checked");
             let output = planned_open_splice_output(&splice)?;
-            return Some(SliceInsertionPlan::SpliceOpenAncestors {
-                destination: splice.destination,
-                source: splice.source,
+            return Some(SliceInsertionPlan {
+                kind: SliceInsertionKind::SpliceOpenAncestors {
+                    destination: splice.destination,
+                    source: splice.source,
+                },
                 output,
             });
         }
@@ -203,11 +210,17 @@ fn try_place_slice_at_frontier(
             .and_then(|candidate| plan_textblock_splice_target(target, candidate))
         {
             let output = plan.planned_output()?;
-            return Some(SliceInsertionPlan::SpliceBlocks { plan, output });
+            return Some(SliceInsertionPlan {
+                kind: SliceInsertionKind::SpliceBlocks { plan },
+                output,
+            });
         }
         if let Some(plan) = plan_hoisted_block_insertion(target, &slice) {
             let output = planned_block_output(&plan.blocks, &plan.list_merges)?;
-            return Some(SliceInsertionPlan::HoistBlocks { plan, output });
+            return Some(SliceInsertionPlan {
+                kind: SliceInsertionKind::HoistBlocks { plan },
+                output,
+            });
         }
 
         let candidate = parent_fitted.as_ref().unwrap_or(&slice);
@@ -227,7 +240,10 @@ fn try_place_slice_at_frontier(
                 return None;
             }
             let output = planned_inline_output(&fragments, target.position().affinity)?;
-            return Some(SliceInsertionPlan::OpenInline { fragments, output });
+            return Some(SliceInsertionPlan {
+                kind: SliceInsertionKind::OpenInline { fragments },
+                output,
+            });
         }
         None
     } else {
@@ -268,9 +284,11 @@ fn try_place_slice_at_frontier(
             });
         let list_merges = crate::helpers::plan_adjacent_list_merges(left, &blocks, right)?;
         let output = planned_block_output(&blocks, &list_merges)?;
-        Some(SliceInsertionPlan::BlockBoundary {
-            blocks,
-            list_merges,
+        Some(SliceInsertionPlan {
+            kind: SliceInsertionKind::BlockBoundary {
+                blocks,
+                list_merges,
+            },
             output,
         })
     }
@@ -455,10 +473,16 @@ fn placement_is_complete_no_output(target: &SliceInsertionTarget, slice: &Slice)
 }
 
 pub(crate) struct AppliedSliceInsertion {
-    pub(crate) nodes: Vec<editor_crdt::Dot>,
-    pub(crate) output: SliceInsertionOutputPlan,
-    pub(crate) observed_caret: Position,
-    pub(crate) observed_inserted: Selection,
+    pub(crate) caret: BoundSliceOutputPosition,
+    pub(crate) anchor: BoundSliceOutputPosition,
+    pub(crate) head: BoundSliceOutputPosition,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct BoundSliceOutputPosition {
+    pub(crate) dot: Dot,
+    pub(crate) relation: SliceOutputRelation,
+    pub(crate) affinity: Affinity,
 }
 
 pub(crate) fn apply_slice_insertion_plan(
@@ -467,29 +491,18 @@ pub(crate) fn apply_slice_insertion_plan(
     plan: SliceInsertionPlan,
     provenance: SliceProvenance,
 ) -> Result<AppliedSliceInsertion, CommandError> {
-    let (output, execution) = match plan {
-        SliceInsertionPlan::DirectInline { fragments, output } => {
-            ensure_output_plan(
-                &output,
-                planned_inline_output(&fragments, position.affinity),
-            )?;
+    let SliceInsertionPlan { kind, output } = plan;
+    let execution = match kind {
+        SliceInsertionKind::DirectInline { fragments }
+        | SliceInsertionKind::OpenInline { fragments } => {
             let position = materialize_repair_position(tr, position)?;
             let mode = build_inline_mode(tr, &position, provenance)?;
-            let execution = insert_content_as_inline_at_position(tr, position, fragments, &mode)?;
-            (output, execution)
+            insert_content_as_inline_at_position(tr, position, fragments, &mode)?
         }
-        SliceInsertionPlan::SpliceOpenAncestors {
+        SliceInsertionKind::SpliceOpenAncestors {
             destination,
             source,
-            output,
         } => {
-            ensure_output_plan(
-                &output,
-                planned_open_splice_output(&OpenAncestorSplice {
-                    destination: destination.clone(),
-                    source: source.clone(),
-                }),
-            )?;
             let mut inserted = None;
             tr.batch::<_, CommandError>(|tr| {
                 let position = materialize_repair_position(tr, position)?;
@@ -505,10 +518,9 @@ pub(crate) fn apply_slice_insertion_plan(
                 )?;
                 Ok(())
             })?;
-            (output, inserted)
+            inserted
         }
-        SliceInsertionPlan::SpliceBlocks { plan, output } => {
-            ensure_output_plan(&output, plan.planned_output())?;
+        SliceInsertionKind::SpliceBlocks { plan } => {
             let mut inserted = None;
             tr.batch::<_, CommandError>(|tr| {
                 let position = materialize_repair_position(tr, position)?;
@@ -516,53 +528,23 @@ pub(crate) fn apply_slice_insertion_plan(
                 inserted = insert_blocks_in_textblock_at_position(tr, position, &plan, &mode)?;
                 Ok(())
             })?;
-            (output, inserted)
+            inserted
         }
-        SliceInsertionPlan::HoistBlocks { plan, output } => {
-            ensure_output_plan(
-                &output,
-                planned_block_output(&plan.blocks, &plan.list_merges),
-            )?;
-            let execution = insert_hoisted_blocks_at_position(tr, position, plan)?;
-            (output, execution)
+        SliceInsertionKind::HoistBlocks { plan } => {
+            insert_hoisted_blocks_at_position(tr, position, plan)?
         }
-        SliceInsertionPlan::OpenInline { fragments, output } => {
-            ensure_output_plan(
-                &output,
-                planned_inline_output(&fragments, position.affinity),
-            )?;
-            let position = materialize_repair_position(tr, position)?;
-            let mode = build_inline_mode(tr, &position, provenance)?;
-            let execution = insert_content_as_inline_at_position(tr, position, fragments, &mode)?;
-            (output, execution)
-        }
-        SliceInsertionPlan::BlockBoundary {
+        SliceInsertionKind::BlockBoundary {
             blocks,
             list_merges,
-            output,
         } => {
-            ensure_output_plan(&output, planned_block_output(&blocks, &list_merges))?;
             let position = materialize_repair_position(tr, position)?;
-            let execution = insert_blocks_at_block_boundary(tr, position, blocks, list_merges)?;
-            (output, execution)
+            insert_blocks_at_block_boundary(tr, position, blocks, list_merges)?
         }
     };
     let execution = execution.ok_or_else(|| {
-        CommandError::Corrupted("planned Slice insertion produced no inserted selection".into())
+        CommandError::Corrupted("planned Slice insertion produced no insertion output".into())
     })?;
     bind_planned_output_nodes(tr, &output, execution)
-}
-
-fn ensure_output_plan(
-    actual: &SliceInsertionOutputPlan,
-    expected: Option<SliceInsertionOutputPlan>,
-) -> Result<(), CommandError> {
-    if expected.as_ref() != Some(actual) {
-        return Err(CommandError::Corrupted(
-            "Slice insertion output no longer matches its planned source path".into(),
-        ));
-    }
-    Ok(())
 }
 
 fn bind_planned_output_nodes(
@@ -570,77 +552,100 @@ fn bind_planned_output_nodes(
     output: &SliceInsertionOutputPlan,
     execution: SliceInsertionExecution,
 ) -> Result<AppliedSliceInsertion, CommandError> {
-    let observed_caret = tr
-        .selection()
-        .filter(|selection| selection.is_collapsed())
-        .map(|selection| selection.head)
-        .ok_or_else(|| {
-            CommandError::Corrupted("planned Slice insertion produced no final caret".into())
-        })?;
-    let observed_inserted = execution.inserted;
-    let mut units = execution.units.into_iter();
-    let mut nodes = Vec::with_capacity(output.nodes.len());
+    let SliceInsertionExecution {
+        outputs,
+        split_left,
+        split_right,
+    } = execution;
+    let mut outputs = outputs.into_iter();
+    let mut caret = None;
+    let mut anchor = None;
+    let mut head = None;
     for spec in &output.nodes {
         let dot = match &spec.source {
-            SliceOutputSource::SplitLeft => execution.split_left,
-            SliceOutputSource::SplitRight => execution.split_right,
-            _ => units.next(),
+            SliceOutputSource::SplitLeft => split_left,
+            SliceOutputSource::SplitRight => split_right,
+            source => {
+                let output = outputs.next().ok_or_else(|| {
+                    CommandError::Corrupted(
+                        "planned Slice output node was not bound by its insertion action".into(),
+                    )
+                })?;
+                if &output.source != source {
+                    return Err(CommandError::Corrupted(
+                        "authored Slice output came from a different source path".into(),
+                    ));
+                }
+                Some(output.dot)
+            }
         }
         .ok_or_else(|| {
             CommandError::Corrupted(
                 "planned Slice output node was not bound by its insertion action".into(),
             )
         })?;
-        let (dot, actual_type) =
-            resolve_output_node(tr, dot).ok_or(CommandError::NodeNotFound(dot))?;
+        let actual_type =
+            resolve_output_node_type(tr, dot).ok_or(CommandError::NodeNotFound(dot))?;
         if actual_type != spec.node_type {
             return Err(CommandError::Corrupted(
                 "planned Slice output node has a different type".into(),
             ));
         }
-        nodes.push(dot);
+        bind_planned_output_position(&mut caret, &output.caret, &spec.source, dot)?;
+        bind_planned_output_position(&mut anchor, &output.anchor, &spec.source, dot)?;
+        bind_planned_output_position(&mut head, &output.head, &spec.source, dot)?;
     }
-    if units.next().is_some() {
+    if outputs.next().is_some() {
         return Err(CommandError::Corrupted(
             "Slice insertion authored an undeclared output node".into(),
         ));
     }
+    let require_bound = |position: Option<BoundSliceOutputPosition>| {
+        position.ok_or_else(|| {
+            CommandError::Corrupted(
+                "planned Slice endpoint was not bound by its insertion action".into(),
+            )
+        })
+    };
     Ok(AppliedSliceInsertion {
-        nodes,
-        output: output.clone(),
-        observed_caret,
-        observed_inserted,
+        caret: require_bound(caret)?,
+        anchor: require_bound(anchor)?,
+        head: require_bound(head)?,
     })
 }
 
-fn resolve_output_node(
+fn bind_planned_output_position(
+    bound: &mut Option<BoundSliceOutputPosition>,
+    planned: &SliceOutputPositionSpec,
+    source: &SliceOutputSource,
+    dot: Dot,
+) -> Result<(), CommandError> {
+    if source != &planned.source {
+        return Ok(());
+    }
+    if bound.is_some() {
+        return Err(CommandError::Corrupted(
+            "planned Slice endpoint was bound more than once".into(),
+        ));
+    }
+    *bound = Some(BoundSliceOutputPosition {
+        dot,
+        relation: planned.relation,
+        affinity: planned.affinity,
+    });
+    Ok(())
+}
+
+fn resolve_output_node_type(
     tr: &Transaction,
     dot: editor_crdt::Dot,
-) -> Option<(editor_crdt::Dot, editor_model::NodeType)> {
+) -> Option<editor_model::NodeType> {
     let view = tr.view();
-    if let Some(node) = view.node(dot) {
-        return Some((dot, node.node_type()));
-    }
-    let live = view
-        .alias_classes()
-        .members_of(dot)
-        .into_iter()
-        .flatten()
-        .copied()
-        .find(|member| view.node(*member).is_some() || view.block_of(*member).is_some())
-        .unwrap_or(dot);
+    let live = resolve_live_slice_output_dot(&view, dot)?;
     if let Some(node) = view.node(live) {
-        return Some((live, node.node_type()));
+        return Some(node.node_type());
     }
-    let parent = view.block_of(live)?;
-    let node_type = view
-        .node(parent)?
-        .children()
-        .find_map(|child| match child {
-            editor_model::ChildView::Leaf(leaf) if leaf.dot() == live => Some(leaf.node_type()),
-            _ => None,
-        })?;
-    Some((live, node_type))
+    view.leaf(live).map(|leaf| leaf.node_type())
 }
 
 #[cfg(test)]
@@ -648,10 +653,10 @@ mod tests {
     use editor_clipboard::Slice;
     use editor_macros::state;
     use editor_model::{
-        Fragment, PlainBulletListNode, PlainHorizontalRuleNode, PlainListItemNode, PlainNode,
-        PlainParagraphNode, PlainTextNode,
+        AliasOp, AliasRun, ChildView, EditOp, Fragment, PlainBulletListNode,
+        PlainHorizontalRuleNode, PlainListItemNode, PlainNode, PlainParagraphNode, PlainTextNode,
     };
-    use editor_state::{Affinity, Position};
+    use editor_state::{Affinity, Position, Selection};
 
     use super::*;
 
@@ -693,12 +698,106 @@ mod tests {
             FitOutcome::Plan(SliceFitPlan {
                 kind: SliceFitPlanKind::Linear(LinearFitPlan {
                     mutation: LinearMutation::PointInsertion {
-                        insertion: SliceInsertionPlan::DirectInline { .. },
+                        insertion: SliceInsertionPlan {
+                            kind: SliceInsertionKind::DirectInline { .. },
+                            ..
+                        },
                     },
                     ..
                 })
             })
         ));
+    }
+
+    #[test]
+    fn binding_rejects_reordered_same_type_inline_outputs() {
+        let (state, p1) = state! {
+            doc { root { p1: paragraph { text("ab") } } }
+            selection: (p1, 1)
+        };
+        let position = Position::new(p1, 1);
+        let fragments = text_slice("XY").content;
+        let output = planned_inline_output(&fragments, position.affinity).unwrap();
+        let mut tr = Transaction::new(&state);
+        let mode = build_inline_mode(&mut tr, &position, SliceProvenance::Formatted).unwrap();
+        let mut execution =
+            insert_content_as_inline_at_position(&mut tr, position, fragments, &mode)
+                .unwrap()
+                .unwrap();
+        execution.outputs.swap(0, 1);
+
+        assert!(matches!(
+            bind_planned_output_nodes(&tr, &output, execution),
+            Err(CommandError::Corrupted(_))
+        ));
+    }
+
+    #[test]
+    fn binding_preserves_raw_output_identity_until_final_resolution() {
+        let (initial, p1) = state! {
+            doc { root { p1: paragraph { text("abc") } } }
+            selection: (p1, 0)
+        };
+        let chars = initial
+            .view()
+            .node(p1)
+            .expect("paragraph")
+            .children()
+            .filter_map(|child| match child {
+                ChildView::Leaf(leaf) => Some(leaf.dot()),
+                ChildView::Block(_) => None,
+            })
+            .collect::<Vec<_>>();
+        let [raw, first_live, final_live] = chars.as_slice() else {
+            panic!("expected three inline leaves");
+        };
+
+        let mut deletion = Transaction::new(&initial);
+        deletion.remove_text(p1, 0, 1).unwrap();
+        let (mut state, ..) = deletion.commit();
+        for live in [first_live, final_live] {
+            state
+                .projected_mut()
+                .apply(EditOp::Alias(AliasOp {
+                    pairs: vec![AliasRun {
+                        old_start: *raw,
+                        len: 1,
+                        new_start: *live,
+                    }],
+                }))
+                .unwrap();
+        }
+
+        let tr = Transaction::new(&state);
+        let view = tr.view();
+        assert_eq!(
+            view.alias_classes().resolve_with(*raw, |candidate| {
+                view.node(candidate).is_some() || view.block_of(candidate).is_some()
+            }),
+            *final_live,
+            "the fixture must have more than one live alias"
+        );
+        let output = planned_inline_output(&text_slice("x").content, Affinity::Downstream)
+            .expect("one inline output");
+        let execution = SliceInsertionExecution {
+            outputs: vec![crate::helpers::SliceOutputBinding {
+                source: SliceOutputSource::InlineSlot { index: 0 },
+                dot: *raw,
+            }],
+            split_left: None,
+            split_right: None,
+        };
+
+        let applied = bind_planned_output_nodes(&tr, &output, execution).unwrap();
+        assert_eq!(applied.caret.dot, *raw);
+        assert_eq!(applied.anchor.dot, *raw);
+        assert_eq!(applied.head.dot, *raw);
+        for bound in [&applied.caret, &applied.anchor, &applied.head] {
+            assert_eq!(
+                resolve_live_slice_output_dot(&view, bound.dot),
+                Some(*final_live)
+            );
+        }
     }
 
     #[test]
@@ -763,7 +862,10 @@ mod tests {
                 | FitOutcome::Plan(SliceFitPlan {
                     kind: SliceFitPlanKind::Linear(LinearFitPlan {
                         mutation: LinearMutation::PointInsertion {
-                            insertion: SliceInsertionPlan::OpenInline { .. },
+                            insertion: SliceInsertionPlan {
+                                kind: SliceInsertionKind::OpenInline { .. },
+                                ..
+                            },
                         },
                         ..
                     })

--- a/crates/editor-commands/src/judgments/slice/linear_fitter.rs
+++ b/crates/editor-commands/src/judgments/slice/linear_fitter.rs
@@ -6,7 +6,8 @@ use editor_model::{ChildView, DocView, Fragment, content_placement};
 use editor_state::{Position, Selection};
 
 use super::{
-    PlacementOutcome, SliceInsertionPlan, place_slice_at_frontier, place_slice_at_position,
+    PlacementOutcome, SliceInsertionKind, SliceInsertionPlan, place_slice_at_frontier,
+    place_slice_at_position,
 };
 use crate::CommandError;
 use crate::helpers::{
@@ -288,9 +289,11 @@ impl<'a, 'doc> OriginalRangeFrontiers<'a, 'doc> {
             parent,
             splits,
             right_boundary,
-            insertion: SliceInsertionPlan::BlockBoundary {
-                blocks,
-                list_merges,
+            insertion: SliceInsertionPlan {
+                kind: SliceInsertionKind::BlockBoundary {
+                    blocks,
+                    list_merges,
+                },
                 output,
             },
         }))
@@ -485,8 +488,9 @@ fn fit_at_preserved_branch_boundary(
             };
             if block_boundary_fragments(slice, node.node_type()).is_some()
                 && can_split_from_lca_to(view, lca, candidate)
-                && let PlacementOutcome::Placed(SliceInsertionPlan::BlockBoundary {
-                    blocks, ..
+                && let PlacementOutcome::Placed(SliceInsertionPlan {
+                    kind: SliceInsertionKind::BlockBoundary { blocks, .. },
+                    ..
                 }) = place_slice_at_position(view, Position::new(candidate, 0), slice.clone())
             {
                 break (candidate, blocks);


### PR DESCRIPTION
- Slice planner와 executor가 최종 커서와 삽입 범위를 각각 계산하고 비교하던 중복을 제거했습니다.
- planner는 output source와 relation을 선언하고 executor는 실제 생성된 node와 split identity만 반환하도록 역할을 나눴습니다. Source 순서·개수·타입을 결합 단계에서 검증한 뒤, 모든 분할·병합·alias 적용이 끝난 graph에서 최종 selection을 한 번만 설정합니다.
- 인접 리스트 병합으로 삽입한 list wrapper가 사라지는 경우에는 삽입한 ListItem identity를 추적해 기존 item을 포함하지 않는 정확한 범위를 복원합니다.
- executor의 임시 selection·삽입 범위 계산과 복구 로직을 제거하고, inline/newline/open ancestor/list merge/alias 변경/rollback 회귀 테스트를 보강했습니다.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>