### PR TITLE
smooth reveal 종료 시 스크롤 흔들림 수정

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/EditorFindReplaceSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/EditorFindReplaceSession.kt
@@ -15,7 +15,6 @@ import co.typie.editor.Editor
 import co.typie.editor.EditorState
 import co.typie.editor.ext.isCollapsed
 import co.typie.editor.scroll.EditorBringIntoViewRequests
-import co.typie.editor.scroll.revealTrackedItem
 import co.typie.storage.Preference
 import co.typie.ui.component.toast.LocalToast
 import co.typie.ui.component.toast.ToastType
@@ -256,15 +255,21 @@ private class FindReplaceSessionController {
         previousIndex = previousIndex,
         searchInputChanged = searchInputChanged,
       )
+    val registrations = nextMatches.map {
+      FindReplaceRangeRegistration(id = it.id, selection = it.selection)
+    }
+    val activeId = nextActiveIndex?.let { nextMatches.getOrNull(it)?.id }
 
     matches = nextMatches
     activeIndex = nextActiveIndex
-    activeEditor.setFindReplaceRanges(
-      nextMatches.map { FindReplaceRangeRegistration(id = it.id, selection = it.selection) }
-    )
-    updateActiveRangeDecoration(activeEditor)
     if (searchInputChanged || force) {
-      requestActiveRangeIntoView(activeEditor, bringIntoViewRequests)
+      activeEditor.setFindReplaceRangesAndReveal(
+        items = registrations,
+        activeId = activeId,
+        bringIntoViewRequests = bringIntoViewRequests,
+      )
+    } else {
+      activeEditor.setFindReplaceRanges(items = registrations, activeId = activeId)
     }
   }
 
@@ -277,10 +282,12 @@ private class FindReplaceSessionController {
       if (matches.isEmpty()) return
       val currentIndex = activeIndex ?: 0
       activeIndex = (currentIndex + offset + matches.size) % matches.size
-      editor?.let {
-        updateActiveRangeDecoration(it)
-        requestActiveRangeIntoView(it, bringIntoViewRequests)
-      }
+      val activeId = activeMatchId() ?: return@withLock
+      editor?.setActiveFindReplaceRangeAndReveal(
+        activeId = activeId,
+        currentRanges = editor.appliedState.trackedRanges,
+        bringIntoViewRequests = bringIntoViewRequests,
+      )
     }
   }
 
@@ -374,20 +381,6 @@ private class FindReplaceSessionController {
       searchInputChanged || previousIndex == null -> 0
       else -> previousIndex.coerceIn(0, nextMatches.lastIndex)
     }
-
-  private suspend fun updateActiveRangeDecoration(editor: Editor) {
-    editor.setActiveFindReplaceRange(
-      activeId = activeMatchId(),
-      currentRanges = editor.appliedState.trackedRanges,
-    )
-  }
-
-  private suspend fun requestActiveRangeIntoView(
-    editor: Editor,
-    bringIntoViewRequests: EditorBringIntoViewRequests,
-  ) {
-    activeMatchId()?.let { id -> editor.revealTrackedItem(bringIntoViewRequests, id) }
-  }
 }
 
 private fun String.toSingleLineText(): String = replace('\r', ' ').replace('\n', ' ')

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceEditorRanges.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceEditorRanges.kt
@@ -1,12 +1,19 @@
 package co.typie.screen.editor.editor.findreplace
 
 import co.typie.editor.Editor
+import co.typie.editor.EditorRequestScope
 import co.typie.editor.ffi.CommandOutcome
 import co.typie.editor.ffi.DecorationStyle
 import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.Selection
 import co.typie.editor.ffi.TrackedRange
 import co.typie.editor.ffi.TrackedRangeOp
+import co.typie.editor.ffi.ViewOp
+import co.typie.editor.scroll.EditorBringIntoViewBehavior
+import co.typie.editor.scroll.EditorBringIntoViewPolicy
+import co.typie.editor.scroll.EditorBringIntoViewRequests
+import co.typie.editor.scroll.EditorBringIntoViewTarget
+import co.typie.editor.scroll.updateWithBringIntoView
 
 internal const val SEARCH_MATCH_RANGE_GROUP = "search-match"
 internal const val ACTIVE_SEARCH_MATCH_RANGE_GROUP = "search-match-active"
@@ -61,52 +68,92 @@ internal fun Editor.clearFindReplaceRanges() {
   enqueue(Message.TrackedRange(TrackedRangeOp.ClearGroup(group = ACTIVE_SEARCH_MATCH_RANGE_GROUP)))
 }
 
-internal suspend fun Editor.setFindReplaceRanges(items: List<FindReplaceRangeRegistration>) {
-  update {
-    enqueue(Message.TrackedRange(TrackedRangeOp.ClearGroup(group = SEARCH_MATCH_RANGE_GROUP)))
-    enqueue(
-      Message.TrackedRange(TrackedRangeOp.ClearGroup(group = ACTIVE_SEARCH_MATCH_RANGE_GROUP))
-    )
-    items.forEach { item ->
-      enqueue(
-        Message.TrackedRange(
-          TrackedRangeOp.Add(
-            id = item.id,
-            group = SEARCH_MATCH_RANGE_GROUP,
-            selection = item.selection,
-          )
-        )
+internal suspend fun Editor.setFindReplaceRanges(
+  items: List<FindReplaceRangeRegistration>,
+  activeId: String?,
+) {
+  update { enqueueFindReplaceRangeReplacement(items = items, activeId = activeId) }
+}
+
+internal suspend fun Editor.setFindReplaceRangesAndReveal(
+  items: List<FindReplaceRangeRegistration>,
+  activeId: String?,
+  bringIntoViewRequests: EditorBringIntoViewRequests,
+) {
+  updateWithBringIntoView(bringIntoViewRequests) {
+    enqueueFindReplaceRangeReplacement(items = items, activeId = activeId)
+    activeId?.let { id ->
+      enqueue(Message.View(ViewOp.ExpandFoldsForTrackedRange(id)))
+      bringIntoView(
+        target = EditorBringIntoViewTarget.TrackedItem(id),
+        policy = EditorBringIntoViewPolicy.Reveal,
+        behavior = EditorBringIntoViewBehavior.Smooth,
       )
     }
   }
 }
 
-internal suspend fun Editor.setActiveFindReplaceRange(
+internal suspend fun Editor.setActiveFindReplaceRangeAndReveal(
+  activeId: String,
+  currentRanges: List<TrackedRange>,
+  bringIntoViewRequests: EditorBringIntoViewRequests,
+) {
+  updateWithBringIntoView(bringIntoViewRequests) {
+    enqueueActiveFindReplaceRange(activeId = activeId, currentRanges = currentRanges)
+    enqueue(Message.View(ViewOp.ExpandFoldsForTrackedRange(activeId)))
+    bringIntoView(
+      target = EditorBringIntoViewTarget.TrackedItem(activeId),
+      policy = EditorBringIntoViewPolicy.Reveal,
+      behavior = EditorBringIntoViewBehavior.Smooth,
+    )
+  }
+}
+
+private fun EditorRequestScope.enqueueFindReplaceRangeReplacement(
+  items: List<FindReplaceRangeRegistration>,
   activeId: String?,
+) {
+  enqueue(Message.TrackedRange(TrackedRangeOp.ClearGroup(group = SEARCH_MATCH_RANGE_GROUP)))
+  enqueue(Message.TrackedRange(TrackedRangeOp.ClearGroup(group = ACTIVE_SEARCH_MATCH_RANGE_GROUP)))
+  items.forEach { item ->
+    enqueue(
+      Message.TrackedRange(
+        TrackedRangeOp.Add(
+          id = item.id,
+          group =
+            if (item.id == activeId) {
+              ACTIVE_SEARCH_MATCH_RANGE_GROUP
+            } else {
+              SEARCH_MATCH_RANGE_GROUP
+            },
+          selection = item.selection,
+        )
+      )
+    )
+  }
+}
+
+private fun EditorRequestScope.enqueueActiveFindReplaceRange(
+  activeId: String,
   currentRanges: List<TrackedRange>,
 ) {
   val searchRanges = currentRanges.searchMatchRanges()
-  update {
-    searchRanges
-      .filter { it.group == ACTIVE_SEARCH_MATCH_RANGE_GROUP && it.id != activeId }
-      .forEach { range ->
-        enqueue(
-          Message.TrackedRange(
-            TrackedRangeOp.SetGroup(id = range.id, group = SEARCH_MATCH_RANGE_GROUP)
-          )
-        )
-      }
-
-    if (
-      activeId != null &&
-        searchRanges.any { it.id == activeId && it.group != ACTIVE_SEARCH_MATCH_RANGE_GROUP }
-    ) {
+  searchRanges
+    .filter { it.group == ACTIVE_SEARCH_MATCH_RANGE_GROUP && it.id != activeId }
+    .forEach { range ->
       enqueue(
         Message.TrackedRange(
-          TrackedRangeOp.SetGroup(id = activeId, group = ACTIVE_SEARCH_MATCH_RANGE_GROUP)
+          TrackedRangeOp.SetGroup(id = range.id, group = SEARCH_MATCH_RANGE_GROUP)
         )
       )
     }
+
+  if (searchRanges.any { it.id == activeId && it.group != ACTIVE_SEARCH_MATCH_RANGE_GROUP }) {
+    enqueue(
+      Message.TrackedRange(
+        TrackedRangeOp.SetGroup(id = activeId, group = ACTIVE_SEARCH_MATCH_RANGE_GROUP)
+      )
+    )
   }
 }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorSmoothScrollSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorSmoothScrollSession.kt
@@ -102,10 +102,12 @@ internal class EditorSmoothScrollSession(
 
   fun finishIfNearTarget(request: EditorBringIntoViewRequests.Request): Boolean {
     val target = motion?.snapshot()?.target ?: return false
-    if (this.request !== request || abs(target - viewportState.scrollOffset.y) > 1.0) {
+    val current = viewportState.scrollOffset.y
+    val sameRequest = this.request === request
+    val nearTarget = abs(target - current) <= 1.0
+    if (!sameRequest || !nearTarget) {
       return false
     }
-    viewportState.scrollToY(targetY = target.toFloat(), isAutoScroll = true)
     stop()
     return true
   }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorViewportAnchorReconciler.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorViewportAnchorReconciler.kt
@@ -257,7 +257,9 @@ internal fun reconcileViewportAnchorObservation(
         presentationFrame,
         contentOriginY,
       )
-  if (scrollChanged && handoffTarget == null) {
+  if (scrollChanged && handoffTarget != null) {
+    geometry?.let { anchorState.acceptGeometry(it, viewportState.scrollOffset.y) }
+  } else if (scrollChanged) {
     val preferredSelectionGeometry =
       if (!viewportState.lastScrollWasAuto) {
         resolvePreferredSelectionViewportAnchorGeometry(

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceEditorRangesTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceEditorRangesTest.kt
@@ -1,0 +1,223 @@
+package co.typie.screen.editor.editor.findreplace
+
+import co.typie.editor.Editor
+import co.typie.editor.FakeFfiEditor
+import co.typie.editor.ffi.Affinity
+import co.typie.editor.ffi.Message
+import co.typie.editor.ffi.Position
+import co.typie.editor.ffi.Selection
+import co.typie.editor.ffi.TrackedRange
+import co.typie.editor.ffi.TrackedRangeOp
+import co.typie.editor.ffi.ViewOp
+import co.typie.editor.scroll.EditorBringIntoViewBehavior
+import co.typie.editor.scroll.EditorBringIntoViewPolicy
+import co.typie.editor.scroll.EditorBringIntoViewRequests
+import co.typie.editor.scroll.EditorBringIntoViewTarget
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+
+class FindReplaceEditorRangesTest {
+  private val dispatcher = StandardTestDispatcher()
+
+  @Test
+  fun `activating an existing range updates both groups and reveals in one editor revision`() =
+    runTest(dispatcher) {
+      val bringIntoViewRequests = EditorBringIntoViewRequests()
+      val fake = FakeFfiEditor()
+      val editor = Editor(fake, this, dispatcher)
+
+      editor.setActiveFindReplaceRangeAndReveal(
+        activeId = "match-2",
+        currentRanges =
+          listOf(
+            trackedRange(id = "match-1", group = ACTIVE_SEARCH_MATCH_RANGE_GROUP, start = 0),
+            trackedRange(id = "match-2", group = SEARCH_MATCH_RANGE_GROUP, start = 10),
+          ),
+        bringIntoViewRequests = bringIntoViewRequests,
+      )
+
+      assertSingleRequest(
+        fake,
+        listOf(
+          Message.TrackedRange(
+            TrackedRangeOp.SetGroup(id = "match-1", group = SEARCH_MATCH_RANGE_GROUP)
+          ),
+          Message.TrackedRange(
+            TrackedRangeOp.SetGroup(id = "match-2", group = ACTIVE_SEARCH_MATCH_RANGE_GROUP)
+          ),
+          Message.View(ViewOp.ExpandFoldsForTrackedRange(id = "match-2")),
+        ),
+      )
+      val appliedVersion = editor.appliedState.version
+      assertNull(bringIntoViewRequests.activateForVersion(version = appliedVersion - 1))
+      val reveal = assertNotNull(bringIntoViewRequests.activateForVersion(version = appliedVersion))
+      assertEquals(EditorBringIntoViewTarget.TrackedItem("match-2"), reveal.target)
+      assertEquals(EditorBringIntoViewPolicy.Reveal, reveal.policy)
+      assertEquals(EditorBringIntoViewBehavior.Smooth, reveal.behavior)
+    }
+
+  @Test
+  fun `replacing ranges with reveal installs final groups and expands the active range atomically`() =
+    runTest(dispatcher) {
+      val bringIntoViewRequests = EditorBringIntoViewRequests()
+      val fake = FakeFfiEditor()
+      val editor = Editor(fake, this, dispatcher)
+      val first = registration(id = "match-1", start = 0)
+      val second = registration(id = "match-2", start = 10)
+
+      editor.setFindReplaceRangesAndReveal(
+        items = listOf(first, second),
+        activeId = second.id,
+        bringIntoViewRequests = bringIntoViewRequests,
+      )
+
+      assertSingleRequest(
+        fake,
+        listOf(
+          Message.TrackedRange(TrackedRangeOp.ClearGroup(group = SEARCH_MATCH_RANGE_GROUP)),
+          Message.TrackedRange(TrackedRangeOp.ClearGroup(group = ACTIVE_SEARCH_MATCH_RANGE_GROUP)),
+          Message.TrackedRange(
+            TrackedRangeOp.Add(
+              id = first.id,
+              group = SEARCH_MATCH_RANGE_GROUP,
+              selection = first.selection,
+            )
+          ),
+          Message.TrackedRange(
+            TrackedRangeOp.Add(
+              id = second.id,
+              group = ACTIVE_SEARCH_MATCH_RANGE_GROUP,
+              selection = second.selection,
+            )
+          ),
+          Message.View(ViewOp.ExpandFoldsForTrackedRange(id = second.id)),
+        ),
+      )
+      val appliedVersion = editor.appliedState.version
+      assertNull(bringIntoViewRequests.activateForVersion(version = appliedVersion - 1))
+      val reveal = assertNotNull(bringIntoViewRequests.activateForVersion(version = appliedVersion))
+      assertEquals(EditorBringIntoViewTarget.TrackedItem(second.id), reveal.target)
+      assertEquals(EditorBringIntoViewPolicy.Reveal, reveal.policy)
+      assertEquals(EditorBringIntoViewBehavior.Smooth, reveal.behavior)
+    }
+
+  @Test
+  fun `refreshing ranges installs the active item directly without expanding folds`() =
+    runTest(dispatcher) {
+      val fake = FakeFfiEditor()
+      val editor = Editor(fake, this, dispatcher)
+      val first = registration(id = "match-1", start = 0)
+      val second = registration(id = "match-2", start = 10)
+
+      editor.setFindReplaceRanges(items = listOf(first, second), activeId = second.id)
+
+      assertSingleRequest(
+        fake,
+        listOf(
+          Message.TrackedRange(TrackedRangeOp.ClearGroup(group = SEARCH_MATCH_RANGE_GROUP)),
+          Message.TrackedRange(TrackedRangeOp.ClearGroup(group = ACTIVE_SEARCH_MATCH_RANGE_GROUP)),
+          Message.TrackedRange(
+            TrackedRangeOp.Add(
+              id = first.id,
+              group = SEARCH_MATCH_RANGE_GROUP,
+              selection = first.selection,
+            )
+          ),
+          Message.TrackedRange(
+            TrackedRangeOp.Add(
+              id = second.id,
+              group = ACTIVE_SEARCH_MATCH_RANGE_GROUP,
+              selection = second.selection,
+            )
+          ),
+        ),
+      )
+    }
+
+  @Test
+  fun `refreshing ranges without an active item installs every item in the normal group`() =
+    runTest(dispatcher) {
+      val fake = FakeFfiEditor()
+      val editor = Editor(fake, this, dispatcher)
+      val first = registration(id = "match-1", start = 0)
+      val second = registration(id = "match-2", start = 10)
+
+      editor.setFindReplaceRanges(items = listOf(first, second), activeId = null)
+
+      assertSingleRequest(
+        fake,
+        listOf(
+          Message.TrackedRange(TrackedRangeOp.ClearGroup(group = SEARCH_MATCH_RANGE_GROUP)),
+          Message.TrackedRange(TrackedRangeOp.ClearGroup(group = ACTIVE_SEARCH_MATCH_RANGE_GROUP)),
+          Message.TrackedRange(
+            TrackedRangeOp.Add(
+              id = first.id,
+              group = SEARCH_MATCH_RANGE_GROUP,
+              selection = first.selection,
+            )
+          ),
+          Message.TrackedRange(
+            TrackedRangeOp.Add(
+              id = second.id,
+              group = SEARCH_MATCH_RANGE_GROUP,
+              selection = second.selection,
+            )
+          ),
+        ),
+      )
+    }
+
+  @Test
+  fun `replacing empty ranges through the reveal path clears both groups without revealing`() =
+    runTest(dispatcher) {
+      val bringIntoViewRequests = EditorBringIntoViewRequests()
+      val fake = FakeFfiEditor()
+      val editor = Editor(fake, this, dispatcher)
+
+      editor.setFindReplaceRangesAndReveal(
+        items = emptyList(),
+        activeId = null,
+        bringIntoViewRequests = bringIntoViewRequests,
+      )
+
+      assertSingleRequest(
+        fake,
+        listOf(
+          Message.TrackedRange(TrackedRangeOp.ClearGroup(group = SEARCH_MATCH_RANGE_GROUP)),
+          Message.TrackedRange(TrackedRangeOp.ClearGroup(group = ACTIVE_SEARCH_MATCH_RANGE_GROUP)),
+        ),
+      )
+      assertNull(bringIntoViewRequests.activateForVersion(version = editor.appliedState.version))
+    }
+
+  private fun assertSingleRequest(fake: FakeFfiEditor, expected: List<Message>) {
+    assertEquals(1, fake.enqueuedRequests.size)
+    assertEquals(expected, fake.enqueuedRequests.single().messages)
+  }
+
+  private fun registration(id: String, start: Int): FindReplaceRangeRegistration =
+    FindReplaceRangeRegistration(id = id, selection = selection(start))
+
+  private fun trackedRange(id: String, group: String, start: Int): TrackedRange {
+    val selection = selection(start)
+    return TrackedRange(
+      id = id,
+      group = group,
+      anchor = selection.anchor,
+      head = selection.head,
+      metadata = "",
+      rects = emptyList(),
+      text = id,
+    )
+  }
+
+  private fun selection(start: Int): Selection =
+    Selection(
+      anchor = Position(node = "text", offset = start, affinity = Affinity.Downstream),
+      head = Position(node = "text", offset = start + 5, affinity = Affinity.Downstream),
+    )
+}

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/layout/EditorSmoothScrollSessionTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/layout/EditorSmoothScrollSessionTest.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.test.runTest
 @OptIn(ExperimentalCoroutinesApi::class)
 class EditorSmoothScrollSessionTest {
   @Test
-  fun `no-op near the active target finishes at the exact target`() =
+  fun `no-op near the active target finishes at the current position`() =
     runTest(StandardTestDispatcher()) {
       val frameClock = BroadcastFrameClock()
       val viewportState = viewportState()
@@ -47,7 +47,7 @@ class EditorSmoothScrollSessionTest {
       viewportState.scrollToY(targetY = 579.25f, isAutoScroll = true)
 
       assertTrue(session.finishIfNearTarget(request))
-      assertEquals(580f, viewportState.scrollOffset.y)
+      assertEquals(579.25f, viewportState.scrollOffset.y)
       assertFalse(session.active)
     }
 

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/layout/EditorViewportAnchorReconcilerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/layout/EditorViewportAnchorReconcilerTest.kt
@@ -114,6 +114,73 @@ class EditorViewportAnchorReconcilerTest {
     }
 
   @Test
+  fun `non-selection reveal handoff keeps the achieved scroll through the next publication`() =
+    runTest {
+      val visibleArea = visibleArea()
+      val initialFrame =
+        frame(visibleArea).let { frame ->
+          frame.copy(
+            state =
+              frame.state.copy(
+                selection =
+                  Selection(
+                    anchor = Position("text", 0, Affinity.Downstream),
+                    head = Position("text", 0, Affinity.Downstream),
+                  )
+              )
+          )
+        }
+      val candidateFrame = initialFrame.copy(state = initialFrame.state.copy(version = 2L))
+      val anchorState =
+        EditorViewportAnchorState().apply {
+          attachSelection(selectionAnchor, anchorGeometry(240f), scrollY = 100f)
+        }
+      val viewportState = viewportState(scrollY = 350f)
+      val editor = editor(selectionY = 200f)
+
+      attachViewportCenterAnchor(
+        editor = editor,
+        anchorState = anchorState,
+        revision = initialFrame.state.version,
+        frame = initialFrame,
+        scrollOffset = viewportState.scrollOffset,
+        contentOriginY = 0f,
+      )
+      anchorState.consumeScrollChange(viewportState.lastScrollRevision)
+      anchorState.consumeVisibleAreaChange(visibleArea)
+
+      viewportState.scrollToY(targetY = 349.75f, isAutoScroll = true)
+      reconcileViewportAnchorObservation(
+        editor = editor,
+        anchorState = anchorState,
+        bundle = PublishedBundle(snapshot = initialFrame.state, frames = emptyMap()),
+        frame = initialFrame,
+        viewportState = viewportState,
+        visibleArea = visibleArea,
+        mode = EditorViewportScrollReconcileMode.Enabled,
+        smoothRevealActive = false,
+        handoffTarget = EditorBringIntoViewTarget.TrackedItem("search-match:1"),
+        selectionRevealOrigin = null,
+        contentOriginY = 0f,
+      )
+
+      val publication =
+        reconcileViewportAnchorPublication(
+          editor = editor,
+          anchorState = anchorState,
+          publishedBundle = PublishedBundle(snapshot = initialFrame.state, frames = emptyMap()),
+          candidateState = candidateFrame.state,
+          measuredScrollFrame = candidateFrame,
+          currentScrollOffset = viewportState.scrollOffset,
+          maximumScrollY = viewportState.maxScrollY,
+          contentOriginY = 0f,
+        )
+          as EditorViewportAnchorPublication.Ready
+
+      assertEquals(349.75f, publication.scrollY)
+    }
+
+  @Test
   fun `scroll observed during transform is reconciled after the transform ends`() = runTest {
     val visibleArea = visibleArea()
     val frame = frame(visibleArea)

--- a/apps/website/src/lib/editor-ffi/editor-frame-sync.browser.test.ts
+++ b/apps/website/src/lib/editor-ffi/editor-frame-sync.browser.test.ts
@@ -894,7 +894,7 @@ describe('web editor frame synchronization', () => {
     ).toBeLessThanOrEqual(1);
   });
 
-  it('converges to the final tracked geometry when preceding page edits arrive near completion', async () => {
+  it('converges within scroll tolerance when preceding page edits arrive near completion', async () => {
     const { editor, errorId, presentation, scrollRoot } = await prepareTrackedItemSmoothReveal(32, 10);
     let completed = false;
     void presentation.then(() => {
@@ -919,7 +919,7 @@ describe('web editor frame synchronization', () => {
     const finalTargetScrollTop = trackedTargetScrollTop(editor, errorId);
     expect(finalTargetScrollTop).not.toBeNull();
     if (finalTargetScrollTop === null) throw new Error('Expected final tracked target geometry');
-    expect(scrollRoot.scrollTop).toBeCloseTo(finalTargetScrollTop, 0);
+    expect(Math.abs(scrollRoot.scrollTop - finalTargetScrollTop)).toBeLessThanOrEqual(1);
   });
 
   it('rejects a presentation without the cursor page native frame', () => {

--- a/apps/website/src/lib/editor-ffi/scroll-scope.test.ts
+++ b/apps/website/src/lib/editor-ffi/scroll-scope.test.ts
@@ -1084,12 +1084,12 @@ describe('EditorScrollScope', () => {
     expect(getScrollTop()).toBe(580);
   });
 
-  it('snaps an in-flight smooth reveal to its target when a no-op publication is within scroll tolerance', () => {
+  it('finishes an in-flight smooth reveal at its current position when a no-op publication is within scroll tolerance', () => {
     const snapshot = trackedSnapshot('target', {
       page_idx: 0,
       rect: { x: 0, y: 900, width: 1, height: 20 },
     });
-    const { scope, scrollTo, setScrollTop } = setup(snapshot);
+    const { getScrollTop, scope, scrollTo, setScrollTop } = setup(snapshot);
     scope.scrollIntoView({ target: { type: 'tracked_item', id: 'target' }, policy: 'reveal', behavior: 'smooth' });
     const request = scope.pendingRequest;
     if (!request) throw new Error('Expected a pending reveal');
@@ -1098,7 +1098,8 @@ describe('EditorScrollScope', () => {
     setScrollTop(579.25);
     expect(scope.applyPending(request, snapshot, { type: 'no_scroll' })).toBe(true);
 
-    expect(scrollTo).toHaveBeenLastCalledWith({ top: 580, behavior: 'instant' });
+    expect(getScrollTop()).toBe(579.25);
+    expect(scrollTo).not.toHaveBeenCalled();
     expect(scope.pendingRequest).toBeNull();
   });
 

--- a/apps/website/src/lib/editor-ffi/scroll.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/scroll.svelte.ts
@@ -196,12 +196,6 @@ export class EditorScrollScope {
         return false;
       }
       case 'no_scroll': {
-        const smoothTarget = this.#smoothRequest === request ? this.#smoothMotion?.snapshot().target : undefined;
-        const scrollTop = this.#editor.scrollViewport?.getScrollTop();
-        if (smoothTarget !== undefined && scrollTop !== undefined && Math.abs(smoothTarget - scrollTop) <= 1) {
-          this.#finishSmoothReveal();
-          return true;
-        }
         this.#interruptSmoothReveal();
         const revealOrigin = this.#selectionRevealOrigin(request, this.#editor.scrollViewport?.getScrollTop());
         const presented = this.markPresented(snapshot.revision, request);


### PR DESCRIPTION
## 문제

같은 줄에 여러 검색 결과가 있을 때 이전/다음으로 이동하면 smooth reveal이 끝나는 순간 스크롤이 짧게 왕복하는 현상이 있었습니다. (cursor guard padding 쪽에 reveal 대상이 딱 붙어있을 때)

App에서는 활성 검색 결과 변경과 reveal이 서로 다른 editor update로 처리되어 중간 publication이 만들어졌습니다. 또한 최신 layout이 목표점의 1px 이내에서 `NoScroll`을 반환해도 App/Web smooth-scroll session이 이전 목표 위치로 마지막 스냅을 수행했습니다.

App에서는 viewport anchor도 스냅 전 위치를 기준으로 유지되어 다음 publication에서 스크롤을 반대 방향으로 되돌릴 수 있었습니다.

## 수정

- App의 검색 결과 교체, 활성 그룹 지정, fold 확장, `TrackedItem` reveal을 하나의 editor update로 처리했습니다.
- 검색 결과 갱신 시 처음부터 최종 활성 그룹을 등록해 중간 publication을 제거했습니다.
- App/Web에서 `NoScroll`로 smooth reveal을 종료할 때 과거 목표점으로 스냅하지 않고 현재 도달 위치를 유지하도록 변경했습니다.
- App viewport anchor가 reveal handoff 시점의 실제 scroll 위치를 기준으로 이어지도록 했습니다.
- Web 브라우저 통합 테스트의 기대값을 production과 동일한 1px scroll tolerance로 맞췄습니다.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>