### PR TITLE
tracked range membership을 position이 아닌 selection 단위로 함

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Editor.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Editor.kt
@@ -1568,16 +1568,16 @@ internal constructor(
             previous.lastHistoryTag
           },
         trackedRanges = trackedRanges,
-        trackedRangesContainingSelectionHead =
-          if (selection != null && selection.anchor == selection.head) {
+        trackedRangesContainingSelection =
+          if (selection != null) {
             if (selectionChanged || changed(StateField.TrackedRanges) || documentChanged) {
               if (trackedRanges.isEmpty()) {
                 emptyList()
               } else {
-                inner.trackedRangesContainingPosition(selection.head, null)
+                inner.trackedRangesContainingSelection(selection, null)
               }
             } else {
-              previous.trackedRangesContainingSelectionHead
+              previous.trackedRangesContainingSelection
             }
           } else {
             emptyList()

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorState.kt
@@ -37,7 +37,7 @@ data class EditorState(
   val ime: Ime?,
   val lastHistoryTag: HistoryTag? = null,
   val trackedRanges: List<TrackedRange> = emptyList(),
-  val trackedRangesContainingSelectionHead: List<TrackedRangeEndpoints> = emptyList(),
+  val trackedRangesContainingSelection: List<TrackedRangeEndpoints> = emptyList(),
   val selectionHitRects: List<PageRect> = emptyList(),
   val cursorHitRects: List<PageRect> = emptyList(),
   val interactiveRegions: List<InteractiveRegion> = emptyList(),

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/aifeedback/EditorAiFeedbackSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/aifeedback/EditorAiFeedbackSession.kt
@@ -263,7 +263,7 @@ internal fun rememberEditorAiFeedbackSession(
     active,
     editorState.selection,
     editorState.trackedRanges,
-    editorState.trackedRangesContainingSelectionHead,
+    editorState.trackedRangesContainingSelection,
     model?.results,
   ) {
     val activeModel = model ?: return@LaunchedEffect
@@ -271,24 +271,18 @@ internal fun rememberEditorAiFeedbackSession(
       lastMembershipIdsMappedToAiFeedback = null
       return@LaunchedEffect
     }
-    val selection =
-      editorState.selection
-        ?: run {
-          lastMembershipIdsMappedToAiFeedback = null
-          return@LaunchedEffect
-        }
-    if (activeModel.results.isEmpty()) {
+    if (editorState.selection == null) {
       lastMembershipIdsMappedToAiFeedback = null
       return@LaunchedEffect
     }
-    if (selection.anchor != selection.head) {
+    if (activeModel.results.isEmpty()) {
       lastMembershipIdsMappedToAiFeedback = null
       return@LaunchedEffect
     }
 
     val resultIds = activeModel.results.mapTo(mutableSetOf()) { it.id }
     val membershipIds =
-      editorState.trackedRangesContainingSelectionHead.trackedRangeMembershipIds(
+      editorState.trackedRangesContainingSelection.trackedRangeMembershipIds(
         allowedGroups = AI_FEEDBACK_MEMBERSHIP_GROUPS,
         ownedIds = resultIds,
       )
@@ -296,7 +290,7 @@ internal fun rememberEditorAiFeedbackSession(
     lastMembershipIdsMappedToAiFeedback = membershipIds
 
     val rangeId =
-      editorState.trackedRangesContainingSelectionHead
+      editorState.trackedRangesContainingSelection
         .selectTrackedRangeMember(
           allowedGroups = AI_FEEDBACK_MEMBERSHIP_GROUPS,
           activeId = activeModel.activeRangeId,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/spellcheck/EditorSpellcheckSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/spellcheck/EditorSpellcheckSession.kt
@@ -226,7 +226,7 @@ internal fun rememberEditorSpellcheckSession(
     active,
     editorState.selection,
     editorState.trackedRanges,
-    editorState.trackedRangesContainingSelectionHead,
+    editorState.trackedRangesContainingSelection,
     model?.results,
   ) {
     val activeModel = model ?: return@LaunchedEffect
@@ -258,14 +258,10 @@ internal fun rememberEditorSpellcheckSession(
           lastMembershipIdsMappedToSpellcheck = null
           return@LaunchedEffect
         }
-    if (selection.anchor != selection.head) {
-      lastMembershipIdsMappedToSpellcheck = null
-      return@LaunchedEffect
-    }
 
     val resultIds = activeModel.results.mapTo(mutableSetOf()) { it.id }
     val membershipIds =
-      editorState.trackedRangesContainingSelectionHead.trackedRangeMembershipIds(
+      editorState.trackedRangesContainingSelection.trackedRangeMembershipIds(
         allowedGroups = SPELLCHECK_MEMBERSHIP_GROUPS,
         ownedIds = resultIds,
       )
@@ -278,7 +274,7 @@ internal fun rememberEditorSpellcheckSession(
     lastMembershipIdsMappedToSpellcheck = membershipIds
 
     val rangeId =
-      editorState.trackedRangesContainingSelectionHead
+      editorState.trackedRangesContainingSelection
         .selectTrackedRangeMember(
           allowedGroups = SPELLCHECK_MEMBERSHIP_GROUPS,
           activeId = activeModel.activeRangeId,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/comments/EditorCommentsSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/comments/EditorCommentsSession.kt
@@ -111,15 +111,15 @@ internal fun rememberEditorCommentsSession(
   val activeThreadId = model?.threadState?.activeThreadId
   val selection = editorState.selection
   val selectionCollapsed = selection == null || selection.anchor == selection.head
-  val collapsedCommentRange =
+  val selectedCommentRange =
     remember(
-      editorState.trackedRangesContainingSelectionHead,
-      selectionCollapsed,
+      editorState.trackedRangesContainingSelection,
+      selection,
       activeThreadId,
       openSelectionsById.keys,
     ) {
-      if (selection != null && selectionCollapsed) {
-        editorState.trackedRangesContainingSelectionHead.selectTrackedRangeMember(
+      if (selection != null) {
+        editorState.trackedRangesContainingSelection.selectTrackedRangeMember(
           allowedGroups = COMMENT_MEMBERSHIP_GROUPS,
           activeId = activeThreadId,
           ownedIds = openSelectionsById.keys,
@@ -128,10 +128,9 @@ internal fun rememberEditorCommentsSession(
         null
       }
     }
-  val collapsedSelectionHead = selection?.takeIf { selectionCollapsed }?.head
   val topBarCreateEnabled = model != null && selection != null && !selectionCollapsed
   val toolbarEnabled =
-    model != null && selection != null && (!selectionCollapsed || collapsedCommentRange != null)
+    model != null && selection != null && (!selectionCollapsed || selectedCommentRange != null)
 
   val trackedCommentRanges =
     remember(editorState.trackedRanges, sheetActive) {
@@ -207,18 +206,17 @@ internal fun rememberEditorCommentsSession(
       lastRequestedActivationRevision = activeThreadActivationRevision
     }
   }
-  LaunchedEffect(sheetActive, collapsedSelectionHead, collapsedCommentRange?.id) {
+  LaunchedEffect(sheetActive, selection, selectedCommentRange?.id) {
     if (
       !sheetActive ||
         selection == null ||
-        !selectionCollapsed ||
         inputFocused ||
         model?.threadState?.hasUnsavedInput == true
     ) {
       return@LaunchedEffect
     }
 
-    val threadId = collapsedCommentRange?.id ?: return@LaunchedEffect
+    val threadId = selectedCommentRange?.id ?: return@LaunchedEffect
     if (threadId != activeThreadId) {
       requestQueue.requestActiveThread(threadId)
     }
@@ -255,7 +253,7 @@ internal fun rememberEditorCommentsSession(
           }
         } else {
           openSheet()
-          collapsedCommentRange?.let { range -> requestQueue.requestActiveThread(range.id) }
+          selectedCommentRange?.let { range -> requestQueue.requestActiveThread(range.id) }
         }
       }
     },
@@ -263,8 +261,8 @@ internal fun rememberEditorCommentsSession(
       hideContextMenu()
       if (model != null) {
         openSheet()
-        if (selection != null && selectionCollapsed) {
-          collapsedCommentRange?.let { range -> requestQueue.requestActiveThread(range.id) }
+        if (selection != null) {
+          selectedCommentRange?.let { range -> requestQueue.requestActiveThread(range.id) }
         }
       }
     },

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorRequestTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorRequestTest.kt
@@ -11,6 +11,7 @@ import co.typie.editor.ffi.Position
 import co.typie.editor.ffi.ProseRangeInstallOutcome
 import co.typie.editor.ffi.ProseTrackedRangeRegistration
 import co.typie.editor.ffi.Rect
+import co.typie.editor.ffi.Selection
 import co.typie.editor.ffi.StateField
 import co.typie.editor.ffi.SystemEvent
 import co.typie.editor.ffi.TrackedRange
@@ -280,8 +281,13 @@ class EditorRequestTest {
     }
 
   @Test
-  fun snapshot_refreshes_membership_when_ranges_or_document_change_under_stationary_cursor() =
+  fun snapshot_refreshes_membership_when_ranges_or_document_change_under_stationary_selection() =
     runTest(dispatcher) {
+      val selection =
+        Selection(
+          anchor = Position(node = "text", offset = 1, affinity = Affinity.Downstream),
+          head = Position(node = "text", offset = 3, affinity = Affinity.Downstream),
+        )
       val range =
         TrackedRange(
           id = "comment-1",
@@ -310,30 +316,34 @@ class EditorRequestTest {
       val fake =
         FakeFfiEditor(
           onTick = { events.removeFirst() },
+          selectionProvider = { selection },
           trackedRangesProvider = { listOf(range) },
-          trackedRangesContainingPositionProvider = { _, _ -> listOf(rangeEndpoints) },
+          trackedRangesContainingSelectionProvider = { queriedSelection, _ ->
+            assertEquals(selection, queriedSelection)
+            listOf(rangeEndpoints)
+          },
         )
       val editor = Editor(fake, this, dispatcher)
 
       editor.update { enqueue(sampleMessage) }
 
       assertEquals(1, fake.trackedRangesCallCount)
-      assertEquals(1, fake.trackedRangesContainingPositionCallCount)
+      assertEquals(1, fake.trackedRangesContainingSelectionCallCount)
       assertEquals(listOf(range), editor.appliedState.trackedRanges)
-      assertEquals(listOf(rangeEndpoints), editor.appliedState.trackedRangesContainingSelectionHead)
+      assertEquals(listOf(rangeEndpoints), editor.appliedState.trackedRangesContainingSelection)
 
       editor.update { enqueue(sampleMessage) }
 
       assertEquals(1, fake.trackedRangesCallCount)
-      assertEquals(1, fake.trackedRangesContainingPositionCallCount)
+      assertEquals(1, fake.trackedRangesContainingSelectionCallCount)
       assertEquals(listOf(range), editor.appliedState.trackedRanges)
-      assertEquals(listOf(rangeEndpoints), editor.appliedState.trackedRangesContainingSelectionHead)
+      assertEquals(listOf(rangeEndpoints), editor.appliedState.trackedRangesContainingSelection)
 
       editor.update { enqueue(sampleMessage) }
 
       assertEquals(1, fake.trackedRangesCallCount)
-      assertEquals(2, fake.trackedRangesContainingPositionCallCount)
-      assertEquals(listOf(rangeEndpoints), editor.appliedState.trackedRangesContainingSelectionHead)
+      assertEquals(2, fake.trackedRangesContainingSelectionCallCount)
+      assertEquals(listOf(rangeEndpoints), editor.appliedState.trackedRangesContainingSelection)
     }
 
   @Test
@@ -348,8 +358,8 @@ class EditorRequestTest {
       editor.update { enqueue(sampleMessage) }
 
       assertEquals(1, fake.trackedRangesCallCount)
-      assertEquals(0, fake.trackedRangesContainingPositionCallCount)
-      assertEquals(emptyList(), editor.appliedState.trackedRangesContainingSelectionHead)
+      assertEquals(0, fake.trackedRangesContainingSelectionCallCount)
+      assertEquals(emptyList(), editor.appliedState.trackedRangesContainingSelection)
     }
 
   @Test

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/FakeFfiEditor.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/FakeFfiEditor.kt
@@ -108,7 +108,8 @@ internal class FakeFfiEditor(
   var copySelectionProvider: () -> ClipboardPayload? = { null },
   var selectionEndpointsProvider: () -> SelectionEndpoints? = { null },
   var trackedRangesProvider: (String?) -> List<TrackedRange> = { emptyList() },
-  var trackedRangesContainingPositionProvider: (Position, String?) -> List<TrackedRangeEndpoints> =
+  var trackedRangesContainingSelectionProvider:
+    (Selection, String?) -> List<TrackedRangeEndpoints> =
     { _, _ ->
       emptyList()
     },
@@ -165,7 +166,7 @@ internal class FakeFfiEditor(
   val resizeCalls = mutableListOf<SurfaceResizeCall>()
   val surfaceEvents = mutableListOf<String>()
   var trackedRangesCallCount: Int = 0
-  var trackedRangesContainingPositionCallCount: Int = 0
+  var trackedRangesContainingSelectionCallCount: Int = 0
   var placeholderCallCount: Int = 0
   val insertedTemplateFragments = mutableListOf<ByteArray>()
   val attached = mutableSetOf<Int>()
@@ -462,12 +463,12 @@ internal class FakeFfiEditor(
     return trackedRangesProvider(group)
   }
 
-  override fun trackedRangesContainingPosition(
-    position: Position,
+  override fun trackedRangesContainingSelection(
+    selection: Selection,
     group: String?,
   ): List<TrackedRangeEndpoints> {
-    trackedRangesContainingPositionCallCount += 1
-    return trackedRangesContainingPositionProvider(position, group)
+    trackedRangesContainingSelectionCallCount += 1
+    return trackedRangesContainingSelectionProvider(selection, group)
   }
 
   override fun exportPageVector(page: Int, scaleFactor: Double): ByteArray = ByteArray(0)

--- a/apps/website/src/lib/editor-ffi/comments.browser.test.ts
+++ b/apps/website/src/lib/editor-ffi/comments.browser.test.ts
@@ -1,6 +1,13 @@
+import '../../app.css';
+
+import { mount, tick, unmount } from 'svelte';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { userEvent } from 'vitest/browser';
 import { initWasm } from '$lib/wasm-ffi.svelte';
 import { Editor } from './editor.svelte';
+import EditorFrameSyncTestHost from './editor-frame-sync-test-host.svelte';
+import { handle } from './handlers';
+import { handleClick } from './handlers/pointer';
 import type { PlainDoc, PlainNode, PlainNodeEntry, StableSelection } from '@typie/editor-ffi/browser';
 
 const { captureException } = vi.hoisted(() => ({ captureException: vi.fn() }));
@@ -21,13 +28,23 @@ const doc: PlainDoc = {
   ]),
 };
 
+const imageDoc: PlainDoc = {
+  root: entry({ type: 'root', layout_mode: { type: 'continuous', max_width: 320 } }, [
+    entry({ type: 'image', id: 'asset', proportion: 100 }),
+  ]),
+};
+
 describe('frozen comment registration', () => {
+  let mounted: Record<string, unknown> | undefined;
   let editor: Editor | undefined;
 
-  afterEach(() => {
+  afterEach(async () => {
+    if (mounted) await unmount(mounted);
+    mounted = undefined;
     editor?.destroy();
     editor = undefined;
     captureException.mockReset();
+    document.body.replaceChildren();
   });
 
   it('rejects a malformed selection without failing the editor or blocking valid siblings', async () => {
@@ -46,5 +63,89 @@ describe('frozen comment registration', () => {
     expect(editor.terminal).toBe(false);
     expect(editor.registeredCommentIds()).toEqual(['valid']);
     expect(captureException).toHaveBeenCalledOnce();
+  });
+
+  it('finds a comment for the selected image atom at the clicked geometry', async () => {
+    await initWasm();
+    editor = await Editor.createFromDoc(imageDoc, { width: 320, height: 180, scale_factor: 1 });
+    const initialImage = editor.appliedSnapshot.externalElements[0];
+    if (!initialImage) throw new Error('Expected an image external element');
+
+    editor.setExternalElementHeight(initialImage.node, 120);
+    editor.updateNow((request) =>
+      request.enqueue({
+        type: 'selection',
+        op: {
+          type: 'set_at',
+          page: initialImage.page_idx,
+          x: initialImage.bounds.x + initialImage.bounds.width / 2,
+          y: initialImage.bounds.y + initialImage.bounds.height / 2,
+        },
+      }),
+    );
+    const selection = editor.appliedSnapshot.selection;
+    if (!selection) throw new Error('Expected the image selection');
+    expect(selection.anchor).not.toEqual(selection.head);
+
+    const frozen = editor.freezeSelection(selection);
+    if (!frozen) throw new Error('Expected a stable image selection');
+    editor.addFrozenComment('image-comment', frozen);
+    await vi.waitFor(() => expect(editor?.appliedSnapshot.trackedRanges.map(({ id }) => id)).toContain('image-comment'));
+
+    const image = editor.appliedSnapshot.externalElements[0];
+    if (!image) throw new Error('Expected the updated image external element');
+    expect(editor.commentIdAt(image.page_idx, image.bounds.x + image.bounds.width / 2, image.bounds.y + image.bounds.height / 2)).toBe(
+      'image-comment',
+    );
+  });
+
+  it('enlarges a read-only image without opening its comment', async () => {
+    await initWasm();
+    editor = await Editor.createFromDoc(imageDoc, { width: 320, height: 180, scale_factor: 1 });
+    editor.imageAssets.set('asset', {
+      id: 'asset',
+      url: 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"/>',
+      originalUrl: 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"/>',
+      width: 100,
+      height: 100,
+      placeholder: '',
+    });
+    editor.updateNow((request) => request.enqueue({ type: 'selection', op: { type: 'set_flat', start: 0, end: 1 } }));
+    const selection = editor.appliedSnapshot.selection;
+    if (!selection) throw new Error('Expected the image selection');
+    const frozen = editor.freezeSelection(selection);
+    if (!frozen) throw new Error('Expected a stable image selection');
+    editor.addFrozenComment('image-comment', frozen);
+    await vi.waitFor(() => expect(editor?.appliedSnapshot.trackedRanges.map(({ id }) => id)).toContain('image-comment'));
+    editor.updateNow((request) => request.enqueue({ type: 'selection', op: { type: 'set_flat', start: 1, end: 1 } }));
+
+    const commentClickHandler = vi.fn();
+    editor.commentClickHandler = commentClickHandler;
+    const parentClickHandler = vi.fn(handle(editor, handleClick));
+    const target = document.createElement('div');
+    document.body.append(target);
+    mounted = mount(EditorFrameSyncTestHost, {
+      target,
+      props: {
+        editor,
+        onclick: parentClickHandler,
+        readOnly: true,
+        userId: `image-comment-${crypto.randomUUID()}`,
+      },
+    });
+    await tick();
+
+    await vi.waitFor(() => expect(document.querySelector('[aria-label="이미지 확대 보기"]')).not.toBeNull());
+    const image = document.querySelector<HTMLElement>('[aria-label="이미지 확대 보기"]');
+    if (!image) throw new Error('Expected the read-only image');
+    await vi.waitFor(() => expect(editor?.appliedSnapshot.externalElements[0]?.bounds.height).toBeGreaterThan(1));
+    const rect = image.getBoundingClientRect();
+    expect(editor.readOnly).toBe(true);
+    expect(rect.width).toBeGreaterThan(0);
+    await userEvent.click(image);
+
+    expect(commentClickHandler).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(document.querySelector('[aria-label="닫기"]')).not.toBeNull());
+    expect(parentClickHandler).not.toHaveBeenCalled();
   });
 });

--- a/apps/website/src/lib/editor-ffi/components/ExternalImage.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ExternalImage.svelte
@@ -301,8 +301,11 @@
         style={css.raw({ width: 'full', borderRadius: '4px' }, !canEdit && { cursor: 'zoom-in' })}
         alt="본문 이미지"
         aria-label={canEdit ? undefined : '이미지 확대 보기'}
-        onclick={() => {
-          if (!canEdit) enlarged = true;
+        onclick={(event) => {
+          if (canEdit) return;
+
+          event.stopPropagation();
+          enlarged = true;
         }}
         onkeydown={(event) => {
           if (canEdit || !(event.key === 'Enter' || event.key === ' ')) {

--- a/apps/website/src/lib/editor-ffi/editor-frame-sync-test-host.svelte
+++ b/apps/website/src/lib/editor-ffi/editor-frame-sync-test-host.svelte
@@ -6,7 +6,7 @@
 </script>
 
 <script lang="ts">
-  import { setupAppContext } from '@typie/ui/context';
+  import { setupAppContext, setupThemeContext } from '@typie/ui/context';
   import { elementScrollViewport, windowScrollViewport } from '@typie/ui/utils';
   import { onDestroy, untrack } from 'svelte';
   import Caret from './components/Caret.svelte';
@@ -22,12 +22,14 @@
   import { setupEditorPublication } from './editor-publication.svelte';
   import { EditorSurfaceHost } from './editor-surface-host.svelte';
   import { setupEditorScroll } from './scroll.svelte';
+  import type { MouseEventHandler } from 'svelte/elements';
   import type { Editor } from './editor.svelte';
 
   type Props = {
     editor: Editor;
     onReady?: (harness: EditorFrameSyncTestHarness) => void;
     onPublishedReady?: () => void;
+    onclick?: MouseEventHandler<HTMLDivElement>;
     readOnly?: boolean;
     typewriterEnabled?: boolean;
     useWindowScroll?: boolean;
@@ -39,6 +41,7 @@
     editor,
     onReady,
     onPublishedReady,
+    onclick,
     readOnly = false,
     typewriterEnabled = false,
     useWindowScroll = false,
@@ -47,6 +50,7 @@
   }: Props = $props();
 
   const app = setupAppContext(userId);
+  setupThemeContext();
   app.preference.current = { ...app.preference.current, lineHighlightEnabled: true, typewriterEnabled };
 
   const ctx = setupEditorContext();
@@ -113,6 +117,8 @@
 />
 
 {#snippet editorContent()}
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div
     bind:this={extensionArea}
     style:padding-bottom={`${ctx.scroll?.bottomPadding ?? 0}px`}
@@ -122,6 +128,7 @@
       editor.extensionAreaEl = el;
     }}
     data-editor-extension-area
+    {onclick}
   >
     <EditorPages {editor} {surfaceHost} />
 

--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -664,14 +664,14 @@ export class Editor {
     }
 
     const hasMembershipConsumers = this.spellcheckErrors.length > 0 || this.aiFeedbacks.length > 0;
-    if (!hasMembershipConsumers || !snapshot.selection || !isSelectionCollapsed(snapshot.selection)) {
+    if (!hasMembershipConsumers || !snapshot.selection) {
       this.#spellcheckMembershipIds = null;
       this.#aiFeedbackMembershipIds = null;
     }
 
     if (hasMembershipConsumers) {
-      const membership = semanticMembershipForStateChange(fields, snapshot.selection, (position) =>
-        this.#invokeCore((core) => core.tracked_ranges_containing_position(position, null)),
+      const membership = semanticMembershipForStateChange(fields, snapshot.selection, (selection) =>
+        this.#invokeCore((core) => core.tracked_ranges_containing_selection(selection, null)),
       );
       if (membership !== undefined) {
         this.#syncActiveSpellcheckErrorFromMembership(membership);
@@ -2567,12 +2567,12 @@ export class Editor {
 
   commentIdAt(page: number, x: number, y: number): string | null {
     const selection = this.#applied.selection;
-    if (!selection || !isSelectionCollapsed(selection)) return null;
+    if (!selection) return null;
 
     return this.#invokeCore((core) => {
       // eslint-disable-next-line svelte/prefer-svelte-reactivity
       const geometryHitIds = new Set(core.tracked_ranges_at(page, x, y, null).map((hit) => hit.id));
-      const membership = core.tracked_ranges_containing_position(selection.head, null).filter((range) => geometryHitIds.has(range.id));
+      const membership = core.tracked_ranges_containing_selection(selection, null).filter((range) => geometryHitIds.has(range.id));
       return selectTrackedRangeMember(membership, COMMENT_MEMBERSHIP_GROUPS, this.activeCommentId, this.#registeredCommentIds)?.id ?? null;
     });
   }

--- a/apps/website/src/lib/editor-ffi/handlers/pointer.test.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/pointer.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   cancelPointerInteraction,
+  handleClick,
   handlePointerCaptureLost,
   handlePointerDown,
   handlePointerMove,
@@ -123,6 +124,8 @@ const createEditor = ({
       handlePointerCancel: vi.fn(),
     },
     updatePointerHover: vi.fn(),
+    commentClickHandler: vi.fn(),
+    commentIdAt: vi.fn(() => 'comment-1'),
   };
   return editor as unknown as Editor & {
     enqueue: ReturnType<typeof vi.fn>;
@@ -131,8 +134,21 @@ const createEditor = ({
     selectionHitTest: ReturnType<typeof vi.fn>;
     suspendToolbarSync: ReturnType<typeof vi.fn>;
     resumeToolbarSync: ReturnType<typeof vi.fn>;
+    commentClickHandler: ReturnType<typeof vi.fn>;
+    commentIdAt: ReturnType<typeof vi.fn>;
   };
 };
+
+describe('comment pointer activation', () => {
+  it('checks comment membership for a non-collapsed selection', () => {
+    const editor = createEditor({ isSelectionCollapsed: false, selection: rangeSelection, appliedSelection: rangeSelection });
+
+    handleClick(editor, createPointerEvent() as unknown as MouseEvent & { currentTarget: HTMLElement });
+
+    expect(editor.commentIdAt).toHaveBeenCalledWith(0, 10, 20);
+    expect(editor.commentClickHandler).toHaveBeenCalledWith('comment-1');
+  });
+});
 
 describe('pointer native drag admission', () => {
   it('admits native drag on a selected range without capturing pointer and collapses on click release', () => {

--- a/apps/website/src/lib/editor-ffi/handlers/pointer.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/pointer.ts
@@ -167,7 +167,6 @@ export const handlePointerUp: EditorEventHandler<HTMLElement, PointerEvent> = (e
 
 export const handleClick: EditorEventHandler<HTMLElement, MouseEvent> = (editor, e) => {
   if (e.button !== 0 || !editor.commentClickHandler) return;
-  if (!editor.isSelectionCollapsed) return;
 
   const local = editor.clientToLocal(e.clientX, e.clientY);
   if (!local) return;

--- a/apps/website/src/lib/editor-ffi/tracked-range-membership.test.ts
+++ b/apps/website/src/lib/editor-ffi/tracked-range-membership.test.ts
@@ -15,16 +15,30 @@ describe('tracked range membership', () => {
   it.each<StateField>(['selection', 'doc', 'tracked_ranges'])('%s change refreshes membership under a stationary cursor', (field) => {
     const query = vi.fn(() => [member('a', 'comment')]);
 
-    expect(semanticMembershipForStateChange(new Set([field]), collapsed(3), query)).toEqual([member('a', 'comment')]);
-    expect(query).toHaveBeenCalledWith(position(3));
+    const selection = collapsed(3);
+    expect(semanticMembershipForStateChange(new Set([field]), selection, query)).toEqual([member('a', 'comment')]);
+    expect(query).toHaveBeenCalledWith(selection);
   });
 
-  it('does not query for layout-only changes or non-collapsed selections', () => {
+  it('queries membership for non-collapsed selections', () => {
     const query = vi.fn(() => [member('a', 'comment')]);
     const expanded: Selection = { anchor: position(1), head: position(2) };
 
+    expect(semanticMembershipForStateChange(new Set<StateField>(['selection']), expanded, query)).toEqual([member('a', 'comment')]);
+    expect(query).toHaveBeenCalledWith(expanded);
+  });
+
+  it('does not query when the selection is unavailable', () => {
+    const query = vi.fn(() => [member('a', 'comment')]);
+
+    expect(semanticMembershipForStateChange(new Set<StateField>(['selection']), undefined, query)).toBeUndefined();
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('does not query for layout-only changes', () => {
+    const query = vi.fn(() => [member('a', 'comment')]);
+
     expect(semanticMembershipForStateChange(new Set<StateField>(['page_sizes', 'cursor']), collapsed(1), query)).toBeUndefined();
-    expect(semanticMembershipForStateChange(new Set<StateField>(['selection']), expanded, query)).toBeUndefined();
     expect(query).not.toHaveBeenCalled();
   });
 

--- a/apps/website/src/lib/editor-ffi/tracked-range-membership.ts
+++ b/apps/website/src/lib/editor-ffi/tracked-range-membership.ts
@@ -1,18 +1,16 @@
-import type { Position, Selection, StateField, TrackedRangeEndpoints } from '@typie/editor-ffi/browser';
+import type { Selection, StateField, TrackedRangeEndpoints } from '@typie/editor-ffi/browser';
 
-type MembershipQuery = (position: Position) => TrackedRangeEndpoints[];
+type MembershipQuery = (selection: Selection) => TrackedRangeEndpoints[];
 
-const samePosition = (a: Position, b: Position): boolean => a.node === b.node && a.offset === b.offset && a.affinity === b.affinity;
-
-/** 문서 의미가 바뀔 때만 collapsed cursor의 Core membership을 다시 읽는다. */
+/** 문서 의미가 바뀔 때만 현재 selection의 Core membership을 다시 읽는다. */
 export const semanticMembershipForStateChange = (
   fields: ReadonlySet<StateField>,
   selection: Selection | undefined,
   query: MembershipQuery,
 ): TrackedRangeEndpoints[] | undefined => {
   if (!fields.has('selection') && !fields.has('doc') && !fields.has('tracked_ranges')) return undefined;
-  if (!selection || !samePosition(selection.anchor, selection.head)) return undefined;
-  return query(selection.head);
+  if (!selection) return undefined;
+  return query(selection);
 };
 
 const featureMembers = (

--- a/crates/editor-core/src/editor.rs
+++ b/crates/editor-core/src/editor.rs
@@ -2,18 +2,20 @@ use editor_clipboard::Slice;
 use editor_commands::CommandError;
 use editor_common::{HistoryTag, Movement, time::Duration};
 use editor_crdt::{Changeset, CrdtError, Dot, Op};
-use editor_model::{EditOp, ModifierState, ModifierType, PlainDoc, PlainNode};
+use editor_model::{EditOp, ModifierState, ModifierType, NodeView, PlainDoc, PlainNode};
 use editor_renderer::{Mark, MarkData, RenderSink, Renderer, damage::IRect};
 #[cfg(any(test, feature = "test-utils"))]
 use editor_resource::ThemeVariant;
 use editor_resource::{CharacterCount, Resource, count_text};
 use editor_state::{
-    LayoutDirty, Position, ResolvedPosition, ResolvedPositionFlatExt, Selection, StableSelection,
-    State, closest_empty_paragraph_break_end_between, farther_endpoint, is_unit_node_selection,
+    CellRect, LayoutDirty, Position, ResolvedPosition, ResolvedPositionFlatExt, ResolvedSelection,
+    Selection, StableSelection, State, closest_empty_paragraph_break_end_between, farther_endpoint,
+    is_unit_node_selection,
 };
 use editor_transaction::{Effect, HistoryMeta, MergeKind, StepError, Transaction};
 use editor_view::{GapPhantom, PageRect, PendingOverlay, View, Viewport};
 use hashbrown::{HashMap, HashSet};
+use std::cell::OnceCell;
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 use strum::IntoEnumIterator;
@@ -55,6 +57,86 @@ fn normalize_pending_overlay(state: &State) -> Option<PendingOverlay> {
         position,
         modifiers,
     })
+}
+
+fn same_position_slot(a: &ResolvedPosition<'_>, b: &ResolvedPosition<'_>) -> bool {
+    a.node() == b.node() && a.offset() == b.offset()
+}
+
+fn cell_rect_contains_rect(outer: &CellRect<'_>, inner: &CellRect<'_>) -> bool {
+    outer.table_id() == inner.table_id()
+        && outer.rows().start() <= inner.rows().start()
+        && inner.rows().end() <= outer.rows().end()
+        && outer.cols().start() <= inner.cols().start()
+        && inner.cols().end() <= outer.cols().end()
+}
+
+fn cell_rect_contains_position(
+    rect: &CellRect<'_>,
+    outer: &ResolvedSelection<'_>,
+    inner: &ResolvedSelection<'_>,
+) -> bool {
+    let position = inner.head();
+    if same_position_slot(position, outer.anchor()) || same_position_slot(position, outer.head()) {
+        return true;
+    }
+
+    let Some(node) = inner.view().node(position.node()) else {
+        return false;
+    };
+    rect.covers(&node)
+}
+
+fn cell_rect_contains_flat_selection(
+    rect: &CellRect<'_>,
+    outer: &ResolvedSelection<'_>,
+    inner: &ResolvedSelection<'_>,
+) -> bool {
+    if inner.is_collapsed() {
+        return cell_rect_contains_position(rect, outer, inner);
+    }
+    let anchor_cell = editor_state::enclosing_table_cell(inner.view(), inner.anchor().node());
+    let head_cell = editor_state::enclosing_table_cell(inner.view(), inner.head().node());
+    let Some(cell_id) = anchor_cell.filter(|cell| Some(*cell) == head_cell) else {
+        return false;
+    };
+    let Some(cell) = inner.view().node(cell_id) else {
+        return false;
+    };
+    rect.covers(&cell)
+}
+
+fn resolved_selection_contains<'a>(
+    outer: &ResolvedSelection<'a>,
+    inner: &ResolvedSelection<'a>,
+    inner_rect: Option<&CellRect<'a>>,
+    inner_cells: &OnceCell<Vec<NodeView<'a>>>,
+) -> bool {
+    match (outer.as_cell_rect(), inner_rect) {
+        (Some(outer), Some(inner)) => cell_rect_contains_rect(&outer, inner),
+        (Some(rect), None) => cell_rect_contains_flat_selection(&rect, outer, inner),
+        (None, Some(rect)) => inner_cells
+            .get_or_init(|| rect.cells())
+            .iter()
+            .all(|cell| outer.contains_subtree(cell)),
+        (None, None) => {
+            let outer_start = outer.from().to_flat();
+            let outer_end = outer.to().to_flat();
+            let inner_start = inner.from().to_flat();
+            let inner_end = inner.to().to_flat();
+            outer_start < outer_end && outer_start <= inner_start && inner_end <= outer_end
+        }
+    }
+}
+
+fn resolved_selections_match(a: &ResolvedSelection<'_>, b: &ResolvedSelection<'_>) -> bool {
+    match (a.as_cell_rect(), b.as_cell_rect()) {
+        (Some(a), Some(b)) => cell_rect_contains_rect(&a, &b) && cell_rect_contains_rect(&b, &a),
+        (None, None) => {
+            a.from().to_flat() == b.from().to_flat() && a.to().to_flat() == b.to().to_flat()
+        }
+        _ => false,
+    }
 }
 
 fn normalize_gap_phantom(state: &State) -> Option<GapPhantom> {
@@ -719,25 +801,29 @@ impl Editor {
         scored.into_iter().map(|(_, _, hit)| hit).collect()
     }
 
-    /// Returns located tracked ranges whose closed interval contains `position`.
+    /// Returns located tracked ranges that fully contain `selection`.
     ///
-    /// Exact end matches come first so the preceding range wins at a shared
-    /// end/start boundary. Remaining ties are sorted by shortest range, then ID.
-    /// This membership policy is independent of the range's insertion affinity:
-    /// including the end cursor here does not make later text part of the range.
-    pub fn tracked_ranges_containing_position(
+    /// Collapsed selections keep the closed-boundary policy: exact end matches
+    /// come first so the preceding range wins at a shared end/start boundary.
+    /// Non-collapsed selections prefer an exact match. Remaining ties are sorted
+    /// by the tracked range's resolved document span, then ID. Cell rectangles
+    /// compare their selected cells rather than their flattened endpoint interval.
+    /// Endpoint membership remains independent of insertion affinity.
+    pub fn tracked_ranges_containing_selection(
         &self,
-        position: editor_state::Position,
+        selection: Selection,
         group: Option<&str>,
     ) -> Vec<&crate::tracked_range::TrackedRange> {
         use crate::tracked_range::TrackedRange;
-        use editor_state::ResolvedPositionFlatExt;
 
         let doc = self.state.view();
-        let Some(pos) = position.resolve(&doc) else {
+        let Some(query) = selection.resolve(&doc) else {
             return Vec::new();
         };
-        let pos = pos.to_flat();
+        let query_rect = query.as_cell_rect();
+        let query_cells = OnceCell::new();
+        let collapsed = query.is_collapsed();
+        let query_end = query.to().to_flat();
 
         let iter: Box<dyn Iterator<Item = &TrackedRange>> = match group {
             Some(g) => Box::new(self.tracked_ranges.iter_group(g)),
@@ -753,12 +839,15 @@ impl Editor {
                 continue;
             };
 
-            let anchor = resolved.anchor().to_flat();
-            let head = resolved.head().to_flat();
-            let start = anchor.min(head);
-            let end = anchor.max(head);
-            if start < end && start <= pos && pos <= end {
-                scored.push((end != pos, end - start, range));
+            if resolved_selection_contains(&resolved, &query, query_rect.as_ref(), &query_cells) {
+                let start = resolved.from().to_flat();
+                let end = resolved.to().to_flat();
+                let preferred = if collapsed {
+                    end == query_end
+                } else {
+                    resolved_selections_match(&resolved, &query)
+                };
+                scored.push((!preferred, end - start, range));
             }
         }
 

--- a/crates/editor-core/src/tests/tracked_range_position_lookup.rs
+++ b/crates/editor-core/src/tests/tracked_range_position_lookup.rs
@@ -18,7 +18,15 @@ fn add_msg(id: &str, group: &str, selection: Selection) -> Message {
 
 fn ids_at(editor: &Editor, position: Position, group: Option<&str>) -> Vec<String> {
     editor
-        .tracked_ranges_containing_position(position, group)
+        .tracked_ranges_containing_selection(Selection::collapsed(position), group)
+        .into_iter()
+        .map(|range| range.id.clone())
+        .collect()
+}
+
+fn ids_for_selection(editor: &Editor, selection: Selection, group: Option<&str>) -> Vec<String> {
+    editor
+        .tracked_ranges_containing_selection(selection, group)
         .into_iter()
         .map(|range| range.id.clone())
         .collect()
@@ -224,5 +232,150 @@ fn membership_uses_document_positions_across_paragraph_boundaries() {
     assert_eq!(
         ids_at(&editor, Position::new(p2, 2), Some("comment")),
         ["after"]
+    );
+}
+
+#[test]
+fn selection_membership_requires_full_containment_and_prefers_the_smallest_range() {
+    let (state, p1) = state! {
+        doc { root { p1: paragraph { text("abcdefghij") } } }
+        selection: (p1, 0)
+    };
+    let mut editor = Editor::new_test(state);
+    for (id, start, end) in [
+        ("outer", 0, 10),
+        ("inner", 2, 8),
+        ("exact", 3, 5),
+        ("partial", 4, 9),
+    ] {
+        editor.apply(add_msg(
+            id,
+            "comment",
+            Selection::new(Position::new(p1, start), Position::new(p1, end)),
+        ));
+    }
+
+    let selection = Selection::new(Position::new(p1, 3), Position::new(p1, 5));
+    assert_eq!(
+        ids_for_selection(&editor, selection, Some("comment")),
+        ["exact", "inner", "outer"]
+    );
+    assert_eq!(
+        ids_for_selection(
+            &editor,
+            Selection::new(Position::new(p1, 5), Position::new(p1, 3)),
+            Some("comment")
+        ),
+        ["exact", "inner", "outer"]
+    );
+    assert_eq!(
+        ids_for_selection(
+            &editor,
+            Selection::new(Position::new(p1, 1), Position::new(p1, 9)),
+            Some("comment")
+        ),
+        ["outer"]
+    );
+}
+
+#[test]
+fn selection_membership_includes_an_exact_image_atom_selection() {
+    let (state, _root) = state! {
+        doc { root: root { image } }
+        selection: (root, 0, >) -> (root, 1, <)
+    };
+    let selection = state.selection.unwrap();
+    let mut editor = Editor::new_test(state);
+    editor.apply(add_msg("image-comment", "comment", selection));
+
+    assert_eq!(
+        ids_for_selection(&editor, selection, Some("comment")),
+        ["image-comment"]
+    );
+}
+
+#[test]
+fn cell_rectangle_membership_uses_selected_cells_including_empty_cells() {
+    let (state, c00, p00, c01, c02, p02, c10, c11, c12) = state! {
+        doc { root { table {
+            table_row {
+                c00: table_cell { p00: paragraph {} }
+                c01: table_cell { paragraph {} }
+                c02: table_cell { p02: paragraph {} }
+            }
+            table_row {
+                c10: table_cell { paragraph {} }
+                c11: table_cell { paragraph {} }
+                c12: table_cell { paragraph {} }
+            }
+        } } }
+        selection: (p00, 0)
+    };
+    let view = state.view();
+    let outer = editor_state::cell_rect_selection(c00, c11, &view).expect("outer cell rectangle");
+    let inner = editor_state::cell_rect_selection(c00, c10, &view).expect("inner cell rectangle");
+    let overlap =
+        editor_state::cell_rect_selection(c01, c12, &view).expect("overlapping cell rectangle");
+    drop(view);
+
+    let mut editor = Editor::new_test(state);
+    editor.apply(add_msg("cells", "comment", outer));
+
+    assert_eq!(
+        ids_for_selection(&editor, inner, Some("comment")),
+        ["cells"]
+    );
+    assert!(
+        ids_for_selection(&editor, overlap, Some("comment")).is_empty(),
+        "a partial rectangle overlap is not membership"
+    );
+    assert_eq!(
+        ids_at(&editor, Position::new(p00, 0), Some("comment")),
+        ["cells"]
+    );
+    assert!(
+        ids_at(&editor, Position::new(p02, 0), Some("comment")).is_empty(),
+        "a caret in an unselected cell must not match the flattened rectangle interval"
+    );
+    assert_eq!(
+        ids_at(&editor, outer.anchor, Some("comment")),
+        ["cells"],
+        "cell rectangle boundaries remain inclusive"
+    );
+
+    let _ = (c02, c12);
+}
+
+#[test]
+fn selection_membership_handles_mixed_flat_and_cell_rectangle_shapes() {
+    let (state, root, c00, p00, c01) = state! {
+        doc { root: root { table {
+            table_row {
+                c00: table_cell { p00: paragraph { text("ab") } }
+                c01: table_cell { paragraph {} }
+            }
+        } } }
+        selection: (p00, 0)
+    };
+    let view = state.view();
+    let cells = editor_state::cell_rect_selection(c00, c01, &view).expect("cell rectangle");
+    drop(view);
+
+    let mut editor = Editor::new_test(state);
+    editor.apply(add_msg(
+        "table",
+        "flat",
+        Selection::new(Position::new(root, 0), Position::new(root, 1)),
+    ));
+    editor.apply(add_msg("cells", "cell", cells));
+
+    assert_eq!(ids_for_selection(&editor, cells, Some("flat")), ["table"]);
+    assert_eq!(
+        ids_for_selection(
+            &editor,
+            Selection::new(Position::new(p00, 0), Position::new(p00, 2)),
+            Some("cell")
+        ),
+        ["cells"]
     );
 }

--- a/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
@@ -835,7 +835,7 @@ declare class Editor {
     tracked_range(id: string): TrackedRange | undefined;
     tracked_ranges(group?: string | null): TrackedRange[];
     tracked_ranges_at(page: number, x: number, y: number, group?: string | null): TrackedRangeHit[];
-    tracked_ranges_containing_position(position: Position, group?: string | null): TrackedRangeEndpoints[];
+    tracked_ranges_containing_selection(selection: Selection, group?: string | null): TrackedRangeEndpoints[];
 }
 
 declare class EditorHost {

--- a/crates/editor-ffi/pkg/server/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/server/editor_ffi.d.ts
@@ -888,7 +888,7 @@ declare class Editor {
     tracked_range(id: string): TrackedRange | undefined;
     tracked_ranges(group?: string | null): TrackedRange[];
     tracked_ranges_at(page: number, x: number, y: number, group?: string | null): TrackedRangeHit[];
-    tracked_ranges_containing_position(position: Position, group?: string | null): TrackedRangeEndpoints[];
+    tracked_ranges_containing_selection(selection: Selection, group?: string | null): TrackedRangeEndpoints[];
 }
 
 declare class EditorHost {

--- a/crates/editor-ffi/src/editor.rs
+++ b/crates/editor-ffi/src/editor.rs
@@ -915,20 +915,20 @@ impl Editor {
         })
     }
 
-    pub fn tracked_ranges_containing_position(
+    pub fn tracked_ranges_containing_selection(
         &self,
-        position: Complex<editor_state::Position>,
+        selection: Complex<editor_state::Selection>,
         group: Option<String>,
     ) -> EditorResult<Vec<Complex<TrackedRangeEndpoints>>> {
         self.with_inner(|inner| {
-            let position = position.from_ffi()?;
+            let selection = selection.from_ffi()?;
             let state = inner.editor.state();
             let ranges = inner
                 .editor
-                .tracked_ranges_containing_position(position, group.as_deref());
+                .tracked_ranges_containing_selection(selection, group.as_deref());
             let result: Vec<TrackedRangeEndpoints> = ranges
                 .iter()
-                .filter_map(|r| public_tracked_range_endpoints(state, r))
+                .filter_map(|range| public_tracked_range_endpoints(state, range))
                 .collect();
             Ok(result.into_ffi()?)
         })
@@ -3292,7 +3292,7 @@ mod tests {
     }
 
     #[test]
-    fn ffi_tracked_ranges_containing_position_preserves_core_membership_order() {
+    fn ffi_tracked_ranges_containing_collapsed_selection_preserves_core_membership_order() {
         let (initial, p1) = state! {
             doc { root { p1: paragraph { text("abcde") } } }
             selection: (p1, 0)
@@ -3318,8 +3318,8 @@ mod tests {
         let _ = editor.tick().expect("tick");
 
         let matches = editor
-            .tracked_ranges_containing_position(
-                editor_state::Position::new(p1, 3),
+            .tracked_ranges_containing_selection(
+                editor_state::Selection::collapsed(editor_state::Position::new(p1, 3)),
                 Some("comment".into()),
             )
             .expect("ffi ok");
@@ -3330,6 +3330,39 @@ mod tests {
                 .collect::<Vec<_>>(),
             ["before", "after"],
             "FFI must preserve Core's exact-end-first membership order"
+        );
+    }
+
+    #[test]
+    fn ffi_tracked_ranges_containing_selection_includes_image_atom_selection() {
+        let (initial, _root) = state! {
+            doc { root: root { image } }
+            selection: (root, 0, >) -> (root, 1, <)
+        };
+        let selection = initial.selection.expect("image selection");
+        let editor = make_ffi_editor(initial);
+        editor
+            .enqueue_for_test(editor_core::Message::TrackedRange {
+                op: editor_core::TrackedRangeOp::Add {
+                    id: "image-comment".into(),
+                    group: "comment".into(),
+                    selection,
+                    metadata: String::new(),
+                    invalidate_on_text_change: false,
+                },
+            })
+            .expect("enqueue tracked-range add");
+        let _ = editor.tick().expect("tick");
+
+        let matches = editor
+            .tracked_ranges_containing_selection(selection, Some("comment".into()))
+            .expect("ffi ok");
+        assert_eq!(
+            matches
+                .iter()
+                .map(|range| range.id.as_str())
+                .collect::<Vec<_>>(),
+            ["image-comment"]
         );
     }
 


### PR DESCRIPTION
## 변경 사항

- membership 조회의 입력을 position에서 selection으로 확장했습니다.
- non-collapsed selection은 tracked range에 완전히 포함되는 경우에만 membership으로 판정합니다.
- 정확히 일치하는 범위를 우선하고, 이후 더 작은 범위와 ID 순으로 정렬합니다.
- collapsed selection의 기존 경계 포함 및 exact-end 우선 정책은 유지합니다.
- 셀 selection은 평탄화된 endpoint 구간이 아니라 실제 선택된 셀을 기준으로 비교합니다.
- Web과 App의 코멘트·맞춤법·AI 피드백 소비자를 selection 기반 API로 전환했습니다.
- 전환이 끝난 position 기반 Core/FFI API와 관련 바인딩을 제거했습니다.

## 바뀌는 유저 시나리오

- 이미지 atom과 텍스트 범위 같은 non-collapsed selection도 해당 tracked range를 찾을 수 있습니다.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>