### PR TITLE
Editor core failure를 terminal failure로 일관되게 처리

### DIFF
--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/input/EditorInputConnection.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/input/EditorInputConnection.kt
@@ -81,7 +81,7 @@ internal class EditorInputConnection(
     ImeEditBatch(isSessionCurrent) { messages ->
       val recorder = editor.inputRecorder
       val imeBefore = if (recorder == null) null else editor.appliedState.ime
-      val update = editor.runInputCallback {
+      val update = editor.runCallback {
         editor.updateNowWithBringIntoView(bringIntoViewRequests) {
           for (message in messages) {
             enqueue(message)

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Editor.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Editor.kt
@@ -51,6 +51,7 @@ import kotlin.concurrent.atomics.AtomicLong
 import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.reflect.KClass
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.PersistentMap
@@ -95,6 +96,20 @@ internal sealed interface TryEnqueueResult {
 
   data class Failed(val error: Throwable) : TryEnqueueResult
 }
+
+// Carries editor failure ownership explicitly across suspend boundaries. The payload also keeps
+// coroutine exception recovery from turning this control signal into an indistinguishable copy of
+// the underlying failure on JVM.
+internal class EditorFailureSignal(val failure: Throwable) :
+  RuntimeException(failure.message, failure)
+
+internal fun Throwable.unwrapEditorFailureSignal(): Throwable =
+  (this as? EditorFailureSignal)?.failure ?: this
+
+internal fun CoroutineScope.launchEditorEffect(
+  editor: Editor?,
+  block: suspend CoroutineScope.() -> Unit,
+): Job = editor?.launchEffect(coroutineScope = this, block = block) ?: launch(block = block)
 
 private class SurfacePage(
   var target: SurfaceTarget,
@@ -167,11 +182,14 @@ internal constructor(
   internal var imeNotificationsPaused: Boolean by mutableStateOf(false)
 
   val terminal: Boolean
-    get() = disposed.load() || failed.load()
+    get() = disposed.load() || failure.load() != null
+
+  internal val terminalFailure: Throwable?
+    get() = failure.load()
 
   private val mutex = PriorityMutex()
   private val disposed: AtomicBoolean = AtomicBoolean(false)
-  private val failed: AtomicBoolean = AtomicBoolean(false)
+  private val failure: AtomicReference<Throwable?> = AtomicReference(null)
   private val imeSessionActive: AtomicBoolean = AtomicBoolean(false)
   private val syncInProgress: AtomicBoolean = AtomicBoolean(false)
   private val localEdits = EditorLocalEditCoordinator()
@@ -201,7 +219,7 @@ internal constructor(
       scope = scope,
       dispatcher = dispatcher,
       disposed = disposed,
-      failed = failed,
+      failure = failure,
       notifyFailure = { error -> notifyFailure(error) },
     )
 
@@ -306,9 +324,22 @@ internal constructor(
         val accepted =
           withContext(dispatcher) {
             mutex.withLock {
-              ensureActive()
+              try {
+                ensureActive()
+              } catch (e: CancellationException) {
+                throw e
+              } catch (e: Throwable) {
+                throw claimEffectFailure(e)
+              }
               if (!admit()) return@withLock false
-              val requestId = inner.enqueueRequest(request.messages)
+              val requestId =
+                try {
+                  inner.enqueueRequest(request.messages)
+                } catch (e: CancellationException) {
+                  throw e
+                } catch (e: Throwable) {
+                  throw claimEffectFailure(e)
+                }
               registerPendingRequest(requestId = requestId, completion = receipt, request = request)
               admitted = true
               if (ownsLocalEdit) {
@@ -327,15 +358,15 @@ internal constructor(
         }
         receipt.await()
       } catch (e: CancellationException) {
-        if (!admitted) request.discard()
+        if (!admitted) request.discardAfterFailure(e)
         if (ownsLocalEdit && !admitted) localEdit.fail(e)
         throw e
       } catch (e: Throwable) {
-        if (!admitted) request.discard()
+        if (!admitted) request.discardAfterFailure(e)
         receipt.completeExceptionally(e)
         if (ownsLocalEdit && !admitted) localEdit.fail(e)
-        fail(e)
-        throw e
+        val admittedFailure = if (admitted) failure.load() else null
+        throw admittedFailure?.let(::EditorFailureSignal) ?: claimEffectFailure(e)
       }
     return update
   }
@@ -381,11 +412,11 @@ internal constructor(
             }
           }
         } catch (e: CancellationException) {
-          if (!admitted) request.discard()
+          if (!admitted) request.discardAfterFailure(e)
           localEdit.fail(e)
           throw e
         } catch (e: Throwable) {
-          if (!admitted) request.discard()
+          if (!admitted) request.discardAfterFailure(e)
           localEdit.fail(e)
           fail(e)
           throw e
@@ -404,7 +435,7 @@ internal constructor(
     try {
       request.block()
     } catch (error: Throwable) {
-      request.discard()
+      request.discardAfterFailure(error)
       throw error
     }
     return request
@@ -423,11 +454,11 @@ internal constructor(
   internal fun deactivateImeSession() {
     if (!imeSessionActive.load()) return
     try {
-      updateNow(admit = { appliedState.ime?.composing != null }) {
-        enqueue(Message.TextInput(listOf(FlatImeOp.CommitAsIs)))
+      runCallback {
+        updateNow(admit = { appliedState.ime?.composing != null }) {
+          enqueue(Message.TextInput(listOf(FlatImeOp.CommitAsIs)))
+        }
       }
-    } catch (error: Throwable) {
-      if (!terminal) throw error
     } finally {
       setImeSessionActive(false)
     }
@@ -436,15 +467,11 @@ internal constructor(
   // IME materialization is a Host read preference, not a core mutation. It keeps
   // the same applied revision instead of creating an empty barrier tick.
   internal suspend fun refreshImeSnapshot() {
-    withSuspendFailureNotification {
-      withContext(dispatcher) {
-        mutex.withLock {
-          if (terminal || !imeSessionActive.load()) return@withLock
-          val ime = inner.ime(IME_SNAPSHOT_WINDOW, IME_SNAPSHOT_WINDOW)
-          if (appliedState.ime != ime) {
-            appliedState = appliedState.copy(ime = ime)
-          }
-        }
+    invokeCore {
+      if (!imeSessionActive.load()) return@invokeCore
+      val ime = inner.ime(IME_SNAPSHOT_WINDOW, IME_SNAPSHOT_WINDOW)
+      if (appliedState.ime != ime) {
+        appliedState = appliedState.copy(ime = ime)
       }
     }
   }
@@ -462,6 +489,43 @@ internal constructor(
       return TryEnqueueResult.Failed(e)
     }
   }
+
+  internal inline fun <T> runCallback(block: () -> T): T? {
+    if (terminal) return null
+    return try {
+      block()
+    } catch (error: CancellationException) {
+      throw error
+    } catch (error: Throwable) {
+      // Synchronous UI callback boundaries contain only failures the editor has already claimed.
+      if (failure.load() !== error) throw error
+      null
+    }
+  }
+
+  internal suspend fun runEffect(block: suspend () -> Unit): Boolean {
+    if (terminal) return false
+    return try {
+      block()
+      !terminal
+    } catch (error: CancellationException) {
+      throw error
+    } catch (error: Throwable) {
+      val claimed = failure.load()
+      when {
+        claimed === error -> false
+        error is EditorFailureSignal && claimed === error.failure -> false
+        else -> throw error
+      }
+    }
+  }
+
+  internal fun launchEffect(
+    coroutineScope: CoroutineScope = scope,
+    context: CoroutineContext = EmptyCoroutineContext,
+    start: CoroutineStart = CoroutineStart.DEFAULT,
+    block: suspend CoroutineScope.() -> Unit,
+  ): Job = coroutineScope.launch(context, start) { runEffect { block() } }
 
   fun enqueue(message: Message) {
     val result = tryEnqueue { message }
@@ -482,30 +546,30 @@ internal constructor(
     }
   }
 
-  suspend fun freezeSelection(selection: Selection): StableSelection? =
-    readInner(defaultValue = { null }) { it.freezeSelection(selection) }
+  suspend fun freezeSelection(selection: Selection): StableSelection? = invokeCore {
+    inner.freezeSelection(selection)
+  }
 
-  suspend fun findMatches(query: String, matchWholeWord: Boolean): List<Selection> =
-    readInner(defaultValue = { emptyList() }) {
-      it.findMatches(query, SearchOptions(matchWholeWord = matchWholeWord))
-    }
+  suspend fun findMatches(query: String, matchWholeWord: Boolean): List<Selection> = invokeCore {
+    inner.findMatches(query, SearchOptions(matchWholeWord = matchWholeWord))
+  }
 
-  suspend fun proseText(): String = readInner(defaultValue = { "" }) { it.proseText() }
+  suspend fun proseText(): String = invokeCore { inner.proseText() }
 
-  suspend fun proseToSelection(start: Int, end: Int): Selection? =
-    readInner(defaultValue = { null }) { it.proseToSelection(start, end) }
+  suspend fun proseToSelection(start: Int, end: Int): Selection? = invokeCore {
+    inner.proseToSelection(start, end)
+  }
 
-  suspend fun proseTextAnnotated(): String =
-    readInner(defaultValue = { "" }) { it.proseTextAnnotated() }
+  suspend fun proseTextAnnotated(): String = invokeCore { inner.proseTextAnnotated() }
 
-  suspend fun proseToSelectionAnnotated(start: Int, end: Int): Selection? =
-    readInner(defaultValue = { null }) { it.proseToSelectionAnnotated(start, end) }
+  suspend fun proseToSelectionAnnotated(start: Int, end: Int): Selection? = invokeCore {
+    inner.proseToSelectionAnnotated(start, end)
+  }
 
-  suspend fun trackedRange(id: String): TrackedRange? =
-    readInner(defaultValue = { null }) { it.trackedRange(id) }
+  suspend fun trackedRange(id: String): TrackedRange? = invokeCore { inner.trackedRange(id) }
 
   internal suspend fun trackedRangeSnapshot(id: String): Pair<EditorState, TrackedRange?> =
-    readInner(defaultValue = { appliedState to null }) { inner ->
+    invokeCore {
       appliedState to inner.trackedRange(id)
     }
 
@@ -602,6 +666,7 @@ internal constructor(
     readSnapshot(version = tick.revision.value, events = tick.events)
 
     val events = publicEvents(tick.events)
+    val completedRequestIds = mutableListOf<Long>()
     val completions = mutableListOf<Pair<CompletableDeferred<EditorUpdate>, EditorUpdate>>()
     for (request in tick.requestOutcomes) {
       val pending = pendingRequests.load()[request.requestId.value] ?: continue
@@ -614,7 +679,7 @@ internal constructor(
           editor = this,
         )
       pending.request.runBeforePublish(update)
-      pendingRequests.updatePersistent { it.removing(request.requestId.value) }
+      completedRequestIds += request.requestId.value
       pending.completion?.let { completion -> completions += completion to update }
     }
     reconcileSurfaceTargets(
@@ -623,6 +688,9 @@ internal constructor(
     )
     startSurfaceRenders()
     publicationSourceChanged()
+    pendingRequests.updatePersistent { requests ->
+      completedRequestIds.fold(requests) { current, requestId -> current.removing(requestId) }
+    }
     completions.forEach { (completion, update) -> completion.complete(update) }
   }
 
@@ -713,7 +781,13 @@ internal constructor(
     val immediate =
       withContext(dispatcher) {
         mutex.withLock {
-          ensureActive()
+          try {
+            ensureActive()
+          } catch (e: CancellationException) {
+            throw e
+          } catch (e: Throwable) {
+            throw claimEffectFailure(e)
+          }
           val host = visualHost
           if (host == null) {
             NoHost
@@ -782,48 +856,54 @@ internal constructor(
     return PublishedBundle(snapshot = source.snapshot, frames = frames)
   }
 
-  internal fun acceptPublication(bundle: PublishedBundle): Boolean = runBlocking {
-    mutex.withPriorityLock(escalationMillis = 0) {
-      if (published === bundle && publishedHostToken === visualHost?.token) {
-        return@withPriorityLock true
-      }
-      val host = visualHost
-      if (host == null) return@withPriorityLock false
-      if (appliedState !== bundle.snapshot) return@withPriorityLock false
-      if (bundle.frames.size != surfacePageRequirements.size) return@withPriorityLock false
-      for (pageIndex in surfacePageRequirements) {
-        val finishedFrame = bundle.frames[pageIndex] ?: return@withPriorityLock false
-        val page = host.pages[pageIndex] ?: return@withPriorityLock false
-        if (
-          page.frame !== finishedFrame ||
-            !Publication.accepts(
-              proof = finishedFrame.proof,
-              target = page.target,
-              requiredRevision = page.requiredRevision,
-              available = page.available,
-            )
-        ) {
-          return@withPriorityLock false
+  internal fun acceptPublication(bundle: PublishedBundle): Boolean {
+    if (terminal) return false
+    return withFailureFallback(defaultValue = { false }) {
+      runBlocking {
+        mutex.withPriorityLock(escalationMillis = 0) {
+          if (terminal) return@withPriorityLock false
+          if (published === bundle && publishedHostToken === visualHost?.token) {
+            return@withPriorityLock true
+          }
+          val host = visualHost
+          if (host == null) return@withPriorityLock false
+          if (appliedState !== bundle.snapshot) return@withPriorityLock false
+          if (bundle.frames.size != surfacePageRequirements.size) return@withPriorityLock false
+          for (pageIndex in surfacePageRequirements) {
+            val finishedFrame = bundle.frames[pageIndex] ?: return@withPriorityLock false
+            val page = host.pages[pageIndex] ?: return@withPriorityLock false
+            if (
+              page.frame !== finishedFrame ||
+                !Publication.accepts(
+                  proof = finishedFrame.proof,
+                  target = page.target,
+                  requiredRevision = page.requiredRevision,
+                  available = page.available,
+                )
+            ) {
+              return@withPriorityLock false
+            }
+          }
+          val previousRevision = published?.snapshot?.version
+          val nextRevision = bundle.snapshot.version
+          if (
+            previousRevision != nextRevision &&
+              !inner.replaceViewportAnchorPresentation(Revision(nextRevision))
+          ) {
+            return@withPriorityLock false
+          }
+          for (pageIndex in surfacePageRequirements) {
+            val page = host.pages.getValue(pageIndex)
+            page.requiredRevision = null
+            page.failedRevision = null
+          }
+          published = bundle
+          publishedHostToken = host.token
+          refreshPublicationSource()
+          refreshRetainedFrames()
+          true
         }
       }
-      val previousRevision = published?.snapshot?.version
-      val nextRevision = bundle.snapshot.version
-      if (
-        previousRevision != nextRevision &&
-          !inner.replaceViewportAnchorPresentation(Revision(nextRevision))
-      ) {
-        return@withPriorityLock false
-      }
-      for (pageIndex in surfacePageRequirements) {
-        val page = host.pages.getValue(pageIndex)
-        page.requiredRevision = null
-        page.failedRevision = null
-      }
-      published = bundle
-      publishedHostToken = host.token
-      refreshPublicationSource()
-      refreshRetainedFrames()
-      true
     }
   }
 
@@ -831,31 +911,45 @@ internal constructor(
     completePublicationWaiters(bundle)
   }
 
-  internal fun captureSelectionViewportAnchor(revision: Long): CapturedViewportAnchor? =
-    runBlocking {
-      mutex.withPriorityLock(escalationMillis = 0) {
-        ensureActive()
-        inner.captureSelectionViewportAnchor(Revision(revision))
+  internal fun captureSelectionViewportAnchor(revision: Long): CapturedViewportAnchor? {
+    if (terminal) return null
+    return withFailureFallback(defaultValue = { null }) {
+      runBlocking {
+        mutex.withPriorityLock(escalationMillis = 0) {
+          if (terminal) return@withPriorityLock null
+          inner.captureSelectionViewportAnchor(Revision(revision))
+        }
       }
     }
+  }
 
   internal fun captureViewportAnchorAt(
     revision: Long,
     point: ViewportAnchorPoint,
-  ): CapturedViewportAnchor? = runBlocking {
-    mutex.withPriorityLock(escalationMillis = 0) {
-      ensureActive()
-      inner.captureViewportAnchorAt(Revision(revision), point)
+  ): CapturedViewportAnchor? {
+    if (terminal) return null
+    return withFailureFallback(defaultValue = { null }) {
+      runBlocking {
+        mutex.withPriorityLock(escalationMillis = 0) {
+          if (terminal) return@withPriorityLock null
+          inner.captureViewportAnchorAt(Revision(revision), point)
+        }
+      }
     }
   }
 
   internal fun resolveViewportAnchor(
     revision: Long,
     anchor: ViewportAnchor,
-  ): ViewportAnchorResolution = runBlocking {
-    mutex.withPriorityLock(escalationMillis = 0) {
-      ensureActive()
-      inner.resolveViewportAnchor(Revision(revision), anchor)
+  ): ViewportAnchorResolution {
+    if (terminal) return ViewportAnchorResolution.Unavailable
+    return withFailureFallback(defaultValue = { ViewportAnchorResolution.Unavailable }) {
+      runBlocking {
+        mutex.withPriorityLock(escalationMillis = 0) {
+          if (terminal) return@withPriorityLock ViewportAnchorResolution.Unavailable
+          inner.resolveViewportAnchor(Revision(revision), anchor)
+        }
+      }
     }
   }
 
@@ -1286,19 +1380,19 @@ internal constructor(
   }
 
   fun inspectState(options: InspectStateOptions? = null): String =
-    withFailureNotification(defaultValue = { "" }) {
+    withFailureFallback(defaultValue = { "" }) {
       ensureActive()
       inner.inspectState(options)
     }
 
   fun inspectStateAsMacro(): String =
-    withFailureNotification(defaultValue = { "" }) {
+    withFailureFallback(defaultValue = { "" }) {
       ensureActive()
       inner.inspectStateAsMacro()
     }
 
   fun inspectSelectionAsSliceMacro(): String? =
-    withFailureNotification(defaultValue = { null }) {
+    withFailureFallback(defaultValue = { null }) {
       ensureActive()
       inner.inspectSelectionAsSliceMacro()
     }
@@ -1324,7 +1418,7 @@ internal constructor(
     px >= x && px <= x + width && py >= y && py <= y + height
 
   suspend fun characterCounts(): CharacterCounts? =
-    withSuspendFailureNotification(defaultValue = { null }) {
+    withSuspendFailureFallback(defaultValue = { null }) {
       withContext(dispatcher) {
         mutex.withLock {
           if (terminal) {
@@ -1337,7 +1431,7 @@ internal constructor(
     }
 
   suspend fun copySelection(): ClipboardPayload? =
-    withSuspendFailureNotification(defaultValue = { null }) {
+    withSuspendFailureFallback(defaultValue = { null }) {
       withContext(dispatcher) {
         mutex.withLock {
           if (terminal) {
@@ -1387,19 +1481,17 @@ internal constructor(
     }
 
   internal suspend fun receiveRemoteChangeset(payload: ByteArray) {
-    withSuspendFailureNotification {
-      val events =
-        withContext(dispatcher) {
-          mutex.withLock {
-            ensureActive()
-            inner.receiveRemoteChangeset(payload)
-            val tick = inner.tick() ?: return@withLock emptyList()
-            install(tick)
-            publicEvents(tick.events)
-          }
-        }
-      emit(events)
+    val events = invokeCore {
+      inner.receiveRemoteChangeset(payload)
+      val tick = inner.tick() ?: return@invokeCore emptyList()
+      install(tick)
+      publicEvents(tick.events)
     }
+    emit(events)
+  }
+
+  internal suspend fun applyRemoteChangesets(payloads: Iterable<ByteArray>): Boolean = runEffect {
+    payloads.forEach { payload -> if (payload.isNotEmpty()) receiveRemoteChangeset(payload) }
   }
 
   suspend fun insertTemplateFragment(changesets: ByteArray): Boolean =
@@ -1594,7 +1686,7 @@ internal constructor(
     if (disposed.load()) {
       throw CancellationException("Editor disposed")
     }
-    check(!failed.load()) { "Editor failed" }
+    failure.load()?.let { throw it }
   }
 
   internal fun fail(error: Throwable) {
@@ -1602,7 +1694,7 @@ internal constructor(
       throw error
     }
     if (disposed.load()) return
-    if (!failed.compareAndSet(expectedValue = false, newValue = true)) return
+    if (!failure.compareAndSet(expectedValue = null, newValue = error)) return
 
     EditorRegistry.unregisterAsync(this)
     scope.launch(dispatcher + NonCancellable, start = CoroutineStart.UNDISPATCHED) {
@@ -1620,16 +1712,21 @@ internal constructor(
         refreshPublicationSource()
       }
       receipts.forEach { it.completeExceptionally(error) }
-      waiters.forEach { it.completion.completeExceptionally(error) }
+      waiters.forEach { it.completion.completeExceptionally(EditorFailureSignal(error)) }
       edits.forEach { it.fail(error) }
-      requests.forEach(CollectedEditorRequest::discard)
+      requests.forEach { it.discardAfterFailure(error) }
       onError(this@Editor, error)
     }
   }
 
   private fun notifyFailure(error: Throwable) = fail(error)
 
-  private fun <T> withFailureNotification(defaultValue: () -> T, block: () -> T): T =
+  private fun claimEffectFailure(error: Throwable): Throwable {
+    fail(error)
+    return if (failure.load() === error) EditorFailureSignal(error) else error
+  }
+
+  private fun <T> withFailureFallback(defaultValue: () -> T, block: () -> T): T =
     try {
       block()
     } catch (e: CancellationException) {
@@ -1639,45 +1736,21 @@ internal constructor(
       defaultValue()
     }
 
-  private suspend fun <T> readInner(
-    defaultValue: () -> T,
-    block: (co.typie.editor.ffi.Editor) -> T,
-  ): T =
-    withSuspendFailureNotification(defaultValue) {
-      withContext(dispatcher) {
-        mutex.withLock {
-          ensureActive()
-          block(inner)
-        }
-      }
-    }
-
   private suspend fun <T> invokeCore(block: () -> T): T =
-    try {
-      withContext(dispatcher) {
-        mutex.withLock {
+    withContext(dispatcher) {
+      mutex.withLock {
+        try {
           ensureActive()
           block()
+        } catch (e: CancellationException) {
+          throw e
+        } catch (e: Throwable) {
+          throw claimEffectFailure(e)
         }
       }
-    } catch (e: CancellationException) {
-      throw e
-    } catch (e: Throwable) {
-      fail(e)
-      throw e
     }
 
-  private suspend fun withSuspendFailureNotification(block: suspend () -> Unit) {
-    try {
-      block()
-    } catch (e: CancellationException) {
-      throw e
-    } catch (e: Throwable) {
-      notifyFailure(e)
-    }
-  }
-
-  private suspend fun <T> withSuspendFailureNotification(
+  private suspend fun <T> withSuspendFailureFallback(
     defaultValue: () -> T,
     block: suspend () -> T,
   ): T =
@@ -1770,7 +1843,16 @@ internal constructor(
               EditorRegistry.commitResourceUpdate {
                 PlatformModule.editorHost.setThemeVariant(themeVariant)
               }
-              checkNotNull(editor.update { enqueue(Message.System(SystemEvent.Initialize)) })
+              val update =
+                try {
+                  editor.update { enqueue(Message.System(SystemEvent.Initialize)) }
+                } catch (signal: EditorFailureSignal) {
+                  throw signal.failure
+                }
+              if (update == null) {
+                throw editor.failure.load()
+                  ?: IllegalStateException("Editor initialization was not applied")
+              }
               initialized.store(true)
             } finally {
               if (!initialized.load()) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorRequestScope.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorRequestScope.kt
@@ -29,7 +29,7 @@ internal class CollectedEditorRequest : EditorRequestScope {
     try {
       block?.invoke(update)
     } catch (error: Throwable) {
-      onDiscard?.invoke()
+      runCleanupPreservingFailure(error) { onDiscard?.invoke() }
       throw error
     }
   }
@@ -39,6 +39,19 @@ internal class CollectedEditorRequest : EditorRequestScope {
     beforePublish = null
     discardBeforePublish = null
     onDiscard?.invoke()
+  }
+
+  fun discardAfterFailure(error: Throwable) {
+    runCleanupPreservingFailure(error, ::discard)
+  }
+}
+
+private inline fun runCleanupPreservingFailure(error: Throwable, cleanup: () -> Unit) {
+  val failure = error.unwrapEditorFailureSignal()
+  try {
+    cleanup()
+  } catch (cleanupFailure: Throwable) {
+    if (cleanupFailure !== failure) failure.addSuppressed(cleanupFailure)
   }
 }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorUpdate.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorUpdate.kt
@@ -11,7 +11,15 @@ internal constructor(
   val commandOutcomes: List<CommandOutcome>,
   private val editor: Editor,
 ) {
-  suspend fun awaitPublished(): EditorPublicationResult = editor.awaitPublished(revision)
+  suspend fun awaitPublished(): EditorPublicationResult =
+    try {
+      awaitPublishedInEffect()
+    } catch (signal: EditorFailureSignal) {
+      throw signal.failure
+    }
+
+  internal suspend fun awaitPublishedInEffect(): EditorPublicationResult =
+    editor.awaitPublished(revision)
 }
 
 sealed interface EditorPublicationResult

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorView.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorView.kt
@@ -97,17 +97,20 @@ internal fun EditorView(
               PlatformModule.editorHost.setThemeVariant(target.themeVariant)
             }
           }
-          editor.update {
-            enqueue(
-              Message.System(
-                SystemEvent.Resize(
-                  width = target.width,
-                  height = target.height,
-                  scaleFactor = target.scaleFactor,
+          val resizeApplied = editor.runEffect {
+            editor.update {
+              enqueue(
+                Message.System(
+                  SystemEvent.Resize(
+                    width = target.width,
+                    height = target.height,
+                    scaleFactor = target.scaleFactor,
+                  )
                 )
               )
-            )
+            }
           }
+          if (!resizeApplied) return@LaunchedEffect
           if (shouldUpdateTheme) editorThemeVariant = target.themeVariant
           if (currentLoad !== load || load.isClosed) return@LaunchedEffect
           if (currentEnvironment != target) continue
@@ -168,7 +171,9 @@ internal fun EditorView(
         Modifier.focusRequester(editor.focusRequester)
           .onFocusChanged {
             uiState.updateFocus(it.isFocused)
-            editor.enqueue(Message.System(SystemEvent.SetFocused(it.isFocused)))
+            editor.runCallback {
+              editor.enqueue(Message.System(SystemEvent.SetFocused(it.isFocused)))
+            }
           }
           .editorInput(
             enabled = editorInputEnabled,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/SurfaceDriver.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/SurfaceDriver.kt
@@ -92,7 +92,7 @@ internal class SurfaceDriver(
   private val scope: CoroutineScope,
   private val dispatcher: CoroutineDispatcher,
   private val disposed: AtomicBoolean,
-  private val failed: AtomicBoolean,
+  private val failure: AtomicReference<Throwable?>,
   private val notifyFailure: (Throwable) -> Unit,
 ) {
   private val nextSessionId = AtomicLong(0L)
@@ -112,7 +112,7 @@ internal class SurfaceDriver(
   ): SurfaceSessionHandle {
     val session =
       SurfaceSessionHandle(editor = editor, id = nextSessionId.addAndFetch(1), page = page)
-    if (disposed.load() || failed.load()) return session
+    if (disposed.load() || failure.load() != null) return session
 
     sessions.updatePersistent { it.putting(page, session.id) }
     enqueue(AttachSurface(session, handle, configuration))
@@ -120,13 +120,13 @@ internal class SurfaceDriver(
   }
 
   fun resize(session: SurfaceSessionHandle, configuration: SurfaceConfiguration) {
-    if (!isCurrent(session) || disposed.load() || failed.load()) return
+    if (!isCurrent(session) || disposed.load() || failure.load() != null) return
     enqueue(ResizeSurface(session, configuration))
   }
 
   fun render(session: SurfaceSessionHandle, revision: Long, complete: (FrameKey?) -> Unit) {
     val command = RenderSurface(session, revision, complete)
-    if (!isCurrent(session) || disposed.load() || failed.load()) {
+    if (!isCurrent(session) || disposed.load() || failure.load() != null) {
       completeRender(command, null)
       return
     }
@@ -148,7 +148,7 @@ internal class SurfaceDriver(
   }
 
   private fun enqueue(command: SurfaceCommand): Boolean {
-    if ((disposed.load() || failed.load()) && command !is DetachSurface) return false
+    if ((disposed.load() || failure.load() != null) && command !is DetachSurface) return false
     commands.updatePersistent { it.adding(command) }
     schedule()
     return true
@@ -179,7 +179,7 @@ internal class SurfaceDriver(
   }
 
   private fun run(command: SurfaceCommand, attached: MutableMap<Int, Long>) {
-    if ((disposed.load() || failed.load()) && command !is DetachSurface) {
+    if ((disposed.load() || failure.load() != null) && command !is DetachSurface) {
       if (command is RenderSurface) completeRender(command, null)
       return
     }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/external/EditorExternalElementOverlay.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/external/EditorExternalElementOverlay.kt
@@ -87,7 +87,9 @@ private fun EditorExternalElement(element: ExternalElement, displayZoom: Float) 
           return@onSizeChanged
         }
         reportedHeight = height
-        editor.enqueue(Message.System(SystemEvent.SetExternalHeight(element.node, height)))
+        editor.runCallback {
+          editor.enqueue(Message.System(SystemEvent.SetExternalHeight(element.node, height)))
+        }
       }
   ) {
     context(renderScope) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorInput.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorInput.kt
@@ -96,16 +96,6 @@ internal expect suspend fun PlatformTextInputSessionScope.createEditorInputReque
 
 internal expect fun requiresEditorInputSessionRestartForSoftwareKeyboardSuppression(): Boolean
 
-internal inline fun <T> Editor.runInputCallback(block: () -> T): T? {
-  if (terminal) return null
-  return try {
-    block()
-  } catch (error: Throwable) {
-    if (!terminal) throw error
-    null
-  }
-}
-
 internal fun rebindImeResync(
   previous: (() -> Unit)?,
   target: Editor,
@@ -266,7 +256,7 @@ internal class EditorInputNode(
   ) {
     if (messages.isEmpty()) return
     submit { sessionEditor, context ->
-      sessionEditor.scope.launch(context) {
+      sessionEditor.launchEffect(context = context) {
         sessionEditor.updateWithBringIntoView(bringIntoViewRequests) {
           messages.forEach(::enqueue)
           bringIntoViewTarget?.let { target ->
@@ -302,14 +292,14 @@ internal class EditorInputNode(
         val completion = coalescer.submitOrdered {
           incomingContentHandler.handleClipboard(capturedSession, clipboard, action.mode)
         }
-        coroutineScope.launch { completion.await() }
+        editor.launchEffect(coroutineScope = coroutineScope) { completion.await() }
       }
       is EditorKeyBindingAction.Messages -> {
         if (action.coalescible) {
           submit { _, localEdit -> coalescer.submit(binding, clipboard, localEdit) }
         } else {
           val completion = coalescer.submit(binding, clipboard)
-          coroutineScope.launch { completion.await() }
+          editor.launchEffect(coroutineScope = coroutineScope) { completion.await() }
         }
       }
     }
@@ -343,7 +333,10 @@ internal class EditorInputNode(
         // actions are safe to resolve and register immediately; stateful or clipboard actions
         // resolve inside the ordered queue so their side effects cannot overtake paste.
         if (action.coalescible) {
-          coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+          editor.launchEffect(
+            coroutineScope = coroutineScope,
+            start = CoroutineStart.UNDISPATCHED,
+          ) {
             val messages = action.messages(editor, clipboard)
             platformInputBridge.dispatchAppOwnedKeyMessages(messages, preState) {
               var postState: EditorState? = null
@@ -369,7 +362,7 @@ internal class EditorInputNode(
               )
             }
           }
-          coroutineScope.launch { completion.await() }
+          editor.launchEffect(coroutineScope = coroutineScope) { completion.await() }
         }
       }
     }
@@ -396,7 +389,7 @@ internal class EditorInputNode(
   ): EditorState? {
     if (messages.isEmpty()) return null
     return editor
-      .runInputCallback {
+      .runCallback {
         editor.updateNowWithBringIntoView(bringIntoViewRequests) {
           messages.forEach(::enqueue)
           bringIntoViewTarget?.let { target ->
@@ -662,7 +655,7 @@ internal class EditorInputNode(
     registerTextInputClient(this, if (sessionEnabled) textInputClient else null)
     focusedJob =
       if (sessionEnabled) {
-        coroutineScope.launch {
+        editor.launchEffect(coroutineScope = coroutineScope) {
           val uninstallPlatformSessionEffects =
             platformInputBridge.installSessionEffects(
               cursor = ::presentedCursor,
@@ -732,8 +725,8 @@ internal class EditorInputNode(
                       false
                     } else {
                       val commandStartSession = session
-                      coroutineScope
-                        .launch {
+                      editor
+                        .launchEffect(coroutineScope = coroutineScope) {
                           incomingContentHandler.handleCandidates(commandStartSession, candidates)
                         }
                         .invokeOnCompletion { candidates.close() }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionScope.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionScope.kt
@@ -9,6 +9,7 @@ import co.typie.editor.interaction.gestures.EditorConsecutiveTapMaxIntervalMilli
 import co.typie.editor.interaction.gestures.EditorLongPressDispatchDelayMillis
 import co.typie.editor.interaction.gestures.EditorTapDispatchDelayMillis
 import co.typie.editor.interaction.semantics.EditorViewportZoomSemanticConfig
+import co.typie.editor.launchEditorEffect
 import co.typie.editor.runtime.EditorUiState
 import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorBringIntoViewRequests
@@ -135,7 +136,11 @@ internal class EditorInteractionScope(
   fun reset() {
     cancelTapDispatch()
     cancelLongPressDispatch()
-    controller.reset()
+    if (uiState == null) {
+      cancelTapSequenceConfirmation()
+    } else {
+      controller.reset()
+    }
     releaseScrollGestureLock()
     editor = null
     bringIntoViewRequests = null
@@ -299,7 +304,7 @@ internal class EditorInteractionScope(
   }
 
   override fun launchInteraction(block: suspend () -> Unit) {
-    coroutineScope.launch { block() }
+    coroutineScope.launchEditorEffect(editor) { block() }
   }
 
   override fun requestEditing(editor: Editor): Boolean = onRequestEditing?.invoke(editor) == true

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/semantics/EditorInteractiveHitSemantic.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/semantics/EditorInteractiveHitSemantic.kt
@@ -28,18 +28,22 @@ internal class EditorInteractiveHitSemantic {
         if (onText) {
           EditorInteractiveTapResult.None
         } else {
-          editor.enqueue(Message.View(ViewOp.ToggleFold(id = hit.id)))
-          EditorInteractiveTapResult.HandledViewAction
+          editor.runCallback {
+            editor.enqueue(Message.View(ViewOp.ToggleFold(id = hit.id)))
+            EditorInteractiveTapResult.HandledViewAction
+          } ?: EditorInteractiveTapResult.None
         }
       }
       is InteractiveHit.CalloutIcon -> {
         if (editing && !readOnly) {
-          editor.enqueue(
-            Message.Node(
-              NodeOp.SetAttrs(id = hit.id, attrs = PlainNode.Callout(variant = hit.nextVariant))
+          editor.runCallback {
+            editor.enqueue(
+              Message.Node(
+                NodeOp.SetAttrs(id = hit.id, attrs = PlainNode.Callout(variant = hit.nextVariant))
+              )
             )
-          )
-          EditorInteractiveTapResult.HandledViewAction
+            EditorInteractiveTapResult.HandledViewAction
+          } ?: EditorInteractiveTapResult.None
         } else {
           EditorInteractiveTapResult.BlockedMutation
         }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/semantics/EditorPointSelectionSemantic.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/semantics/EditorPointSelectionSemantic.kt
@@ -111,10 +111,12 @@ internal class EditorPointSelectionSemantic(private val effects: EditorInteracti
     )
 
   fun enqueueCursorMove(editor: Editor, point: PagePoint): Boolean {
-    editor.enqueue(
-      Message.Selection(SelectionOp.SetAt(page = point.page, x = point.x, y = point.y))
-    )
-    return true
+    return editor.runCallback {
+      editor.enqueue(
+        Message.Selection(SelectionOp.SetAt(page = point.page, x = point.x, y = point.y))
+      )
+      true
+    } ?: false
   }
 
   private suspend fun dispatchSelection(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/semantics/EditorSelectionHandleSemantic.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/semantics/EditorSelectionHandleSemantic.kt
@@ -22,7 +22,7 @@ internal class EditorSelectionHandleSemantic(
     val op =
       point.selectionHandleExtensionOp(anchor = anchor, baseSelection = baseSelection)
         ?: return null
-    editor.enqueue(Message.Selection(op))
+    editor.runCallback { editor.enqueue(Message.Selection(op)) } ?: return null
     return op
   }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/semantics/EditorTableColumnResizeSemantic.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/semantics/EditorTableColumnResizeSemantic.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import co.typie.editor.Editor
+import co.typie.editor.EditorSurfaceUnavailableException
 import co.typie.editor.EditorUpdate
 import co.typie.editor.ffi.CommandOutcome
 import co.typie.editor.ffi.Message
@@ -16,15 +17,11 @@ import co.typie.editor.interaction.EditorInteractionGeometry
 import co.typie.editor.interaction.EditorTableCellSelection
 import co.typie.editor.interaction.EditorTableCellSelectionHandleTouchTargetDp
 import co.typie.editor.interaction.resolveActiveTableCellSelection
-import kotlin.coroutines.coroutineContext
 import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.roundToInt
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.job
-import kotlinx.coroutines.launch
 
 private const val TableColumnResizeTouchWidthDp = 24f
 private const val TableColumnResizeMinColumnWidth = 40f
@@ -116,14 +113,7 @@ internal class EditorTableColumnResizeSemantic {
       return
     }
     draft = finished
-    val update =
-      try {
-        currentEditor.commitTableResize(finished)
-      } catch (error: Throwable) {
-        clear()
-        if (!currentEditor.terminal) throw error
-        return
-      }
+    val update = currentEditor.runCallback { currentEditor.commitTableResize(finished) }
     if (
       update == null || update.commandOutcomes.any { outcome -> outcome is CommandOutcome.Rejected }
     ) {
@@ -132,20 +122,19 @@ internal class EditorTableColumnResizeSemantic {
     }
 
     val waitJob =
-      currentEditor.scope.launch(start = CoroutineStart.LAZY) {
+      currentEditor.launchEffect(start = CoroutineStart.LAZY) {
         try {
-          update.awaitPublished()
-        } catch (e: CancellationException) {
-          throw e
-        } catch (_: Throwable) {
-          // The Editor already owns failure reporting; this job only owns the draft handoff.
-        } finally {
-          if (publicationWaitJob === coroutineContext.job) {
-            publicationWaitJob = null
-            clear()
-          }
+          update.awaitPublishedInEffect()
+        } catch (_: EditorSurfaceUnavailableException) {
+          // A replacement surface can publish a newer revision; this draft is no longer needed.
         }
       }
+    waitJob.invokeOnCompletion {
+      if (publicationWaitJob === waitJob) {
+        publicationWaitJob = null
+        clear()
+      }
+    }
     publicationWaitJob = waitJob
     waitJob.start()
   }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/preview/EditorPreview.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/preview/EditorPreview.kt
@@ -71,6 +71,7 @@ import co.typie.platform.PlatformModule
 import co.typie.ui.theme.AppTheme
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.hazeSource
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 
@@ -139,13 +140,15 @@ internal fun EditorPreview(
 
     // The settings preview is layout-first on purpose: the frame resizes immediately
     // and the previous text stays visible scaled until the re-render lands.
-    editor.updateNow {
-      if (editor.appliedState.rootAttrs?.layoutMode != layoutMode) {
-        enqueueRootLayoutMode(layoutMode)
+    editor.runEffect {
+      editor.updateNow {
+        if (editor.appliedState.rootAttrs?.layoutMode != layoutMode) {
+          enqueueRootLayoutMode(layoutMode)
+        }
+        changedModifiers.forEach { modifier -> enqueueRootModifier(modifier) }
+        enqueue(Message.Selection(SelectionOp.Unset))
+        enqueue(Message.System(SystemEvent.SetFocused(false)))
       }
-      changedModifiers.forEach { modifier -> enqueueRootModifier(modifier) }
-      enqueue(Message.Selection(SelectionOp.Unset))
-      enqueue(Message.System(SystemEvent.SetFocused(false)))
     }
   }
 
@@ -238,6 +241,7 @@ private fun EditorPreviewContent(
   val displayZoom = zoomController.displayZoom
   val renderZoom = zoomController.renderZoom
   val editor = runtime.editor
+  val failure = runtime.failure
 
   val requiredPages =
     if (editor != null) {
@@ -276,12 +280,14 @@ private fun EditorPreviewContent(
   LaunchedEffect(
     runtime,
     editor,
+    failure,
     sourceKey,
     viewportWidth,
     viewportHeight,
     density.density,
     themeVariant,
   ) {
+    if (failure != null) return@LaunchedEffect
     val viewport =
       Viewport(
         width = viewportWidth,
@@ -291,41 +297,50 @@ private fun EditorPreviewContent(
     val activeEditor = runtime.editor
     if (activeEditor == null) {
       val nextEditor =
-        when (source) {
-          is EditorPreviewSource.Graph ->
-            Editor.create(
-              graph = source.bytes,
-              viewport = viewport,
-              themeVariant = themeVariant,
-              scope = editorScope,
-              onError = { activeEditor, error -> runtime.fail(activeEditor, error) },
-            )
-          EditorPreviewSource.Generated ->
-            Editor.createFromDoc(
-              doc = doc,
-              viewport = viewport,
-              themeVariant = themeVariant,
-              scope = editorScope,
-              onError = { activeEditor, error -> runtime.fail(activeEditor, error) },
-            )
-          EditorPreviewSource.AttachedEditor -> return@LaunchedEffect
+        try {
+          when (source) {
+            is EditorPreviewSource.Graph ->
+              Editor.create(
+                graph = source.bytes,
+                viewport = viewport,
+                themeVariant = themeVariant,
+                scope = editorScope,
+                onError = { activeEditor, error -> runtime.fail(activeEditor, error) },
+              )
+            EditorPreviewSource.Generated ->
+              Editor.createFromDoc(
+                doc = doc,
+                viewport = viewport,
+                themeVariant = themeVariant,
+                scope = editorScope,
+                onError = { activeEditor, error -> runtime.fail(activeEditor, error) },
+              )
+            EditorPreviewSource.AttachedEditor -> return@LaunchedEffect
+          }
+        } catch (error: CancellationException) {
+          throw error
+        } catch (error: Throwable) {
+          runtime.fail(error)
+          return@LaunchedEffect
         }
       runtime.attach(nextEditor)
     } else {
       EditorRegistry.commitResourceUpdate {
         PlatformModule.editorHost.setThemeVariant(themeVariant)
       }
-      activeEditor.updateNow {
-        enqueue(
-          Message.System(
-            SystemEvent.Resize(
-              width = viewport.width,
-              height = viewport.height,
-              scaleFactor = viewport.scaleFactor,
+      activeEditor.runEffect {
+        activeEditor.updateNow {
+          enqueue(
+            Message.System(
+              SystemEvent.Resize(
+                width = viewport.width,
+                height = viewport.height,
+                scaleFactor = viewport.scaleFactor,
+              )
             )
           )
-        )
-        enqueue(Message.System(SystemEvent.SetFocused(false)))
+          enqueue(Message.System(SystemEvent.SetFocused(false)))
+        }
       }
     }
   }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/runtime/EditorRuntime.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/runtime/EditorRuntime.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.setValue
 import co.touchlab.kermit.Logger
 import co.typie.editor.DocumentEditingSession
 import co.typie.editor.Editor
+import co.typie.editor.unwrapEditorFailureSignal
 import io.sentry.kotlin.multiplatform.Sentry
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -94,44 +95,45 @@ class EditorRuntime(private val uiScope: CoroutineScope) {
   }
 
   fun fail(error: Throwable) {
-    if (error is CancellationException) {
-      throw error
-    }
-    uiScope.launch { setFailed(error) }
+    val failure = failureSource(error)
+    uiScope.launch { setFailed(failure) }
   }
 
   fun fail(editor: Editor, error: Throwable) {
-    if (error is CancellationException) {
-      throw error
-    }
+    val failure = failureSource(error)
     uiScope.launch {
       if (this@EditorRuntime.editor !== editor) {
         return@launch
       }
-      setFailed(error)
+      setFailed(failure)
     }
   }
 
   internal fun fail(session: DocumentEditingSession, error: Throwable) {
-    if (error is CancellationException) {
-      throw error
-    }
+    val failure = failureSource(error)
     uiScope.launch {
       if (this@EditorRuntime.session !== session) {
         return@launch
       }
-      setFailed(error)
+      setFailed(failure)
     }
   }
+
+  private fun failureSource(error: Throwable): Throwable =
+    error.unwrapEditorFailureSignal().also { failure ->
+      if (failure is CancellationException) throw failure
+    }
 
   private fun setFailed(error: Throwable) {
     if (failure != null) {
       return
     }
 
-    val detail = error.cause?.let { "$error; cause=$it" } ?: error.toString()
-    Logger.e(error) { "Editor failed: $detail" }
-    Sentry.captureException(error)
+    runCatching {
+      val detail = error.cause?.let { "$error; cause=$it" } ?: error.toString()
+      Logger.e(error) { "Editor failed: $detail" }
+    }
+    runCatching { Sentry.captureException(error) }
     failureState = Failure(error = error, editor = editor)
     clear()
   }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/surface/EditorSurfaceHost.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/surface/EditorSurfaceHost.kt
@@ -33,13 +33,10 @@ internal fun EditorSurfaceHost(
   val hostLifetime = remember(editor) { Any() }
   DisposableEffect(editor, hostLifetime) {
     val active =
-      try {
+      editor.runCallback {
         editor.activateVisualHost(hostLifetime, onPublicationFailure)
         true
-      } catch (error: Throwable) {
-        if (!editor.terminal) throw error
-        false
-      }
+      } ?: false
     onDispose {
       if (active) editor.deactivateVisualHost(hostLifetime)
       onDeactivate()

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/document/bodysettings/DocumentBodySettingsScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/document/bodysettings/DocumentBodySettingsScreen.kt
@@ -369,6 +369,11 @@ fun DocumentBodySettingsScreen(entityId: String) {
       }
     }
 
+    LaunchedEffect(previewRuntime.failure) {
+      previewRuntime.failure ?: return@LaunchedEffect
+      dialog.error(nav) { previewRuntime.clearFailure() }
+    }
+
     LaunchedEffect(load, document.id, channel) {
       val readyLoad = load ?: return@LaunchedEffect
       if (!settingsRuntime.canCreateEditor) return@LaunchedEffect
@@ -409,9 +414,9 @@ fun DocumentBodySettingsScreen(entityId: String) {
         lateinit var createdSession: DocumentEditingSession
         readyLoad.activate(
           apply = { event ->
-            for (bundle in event.bundles) {
-              if (bundle.isNotEmpty()) createdEditor.receiveRemoteChangeset(bundle)
-              bootstrapFailure.load()?.let { throw it }
+            if (!createdEditor.applyRemoteChangesets(event.bundles)) {
+              throw createdEditor.terminalFailure
+                ?: CancellationException("Editor disposed while applying remote changesets")
             }
           },
           startLive = { baseline ->
@@ -586,7 +591,7 @@ fun DocumentBodySettingsScreen(entityId: String) {
       if (!controlsEnabled) return
       val activeSession = settingsRuntime.session ?: return
       activeSession.submit { activeEditor, context ->
-        activeEditor.scope.launch(context) {
+        activeEditor.launchEffect(context = context) {
           model
             .applyAndRelayBodySettings(editor = activeEditor, block = block)
             .withDefaultExceptionHandler(toast)

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -228,6 +228,7 @@ import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
@@ -571,21 +572,26 @@ fun EditorScreen(entityId: String) {
           nav.current == Route.Editor(entityId) &&
           screenState.sceneInForeground
       }
-      val finalized =
+      var finalized = false
+      val completed =
         if (activeEditor == null) {
+          finalized = true
           true
         } else {
-          activeEditor
-            .update(admit = transitionCurrent) {
-              if (activeEditor.appliedState.ime?.composing != null) {
-                enqueue(Message.TextInput(listOf(FlatImeOp.CommitAsIs)))
-              }
-              enqueue(Message.System(SystemEvent.SetFocused(false)))
-            }
-            ?.commandOutcomes
-            ?.none { it is CommandOutcome.Rejected } == true
+          activeEditor.runEffect {
+            finalized =
+              activeEditor
+                .update(admit = transitionCurrent) {
+                  if (activeEditor.appliedState.ime?.composing != null) {
+                    enqueue(Message.TextInput(listOf(FlatImeOp.CommitAsIs)))
+                  }
+                  enqueue(Message.System(SystemEvent.SetFocused(false)))
+                }
+                ?.commandOutcomes
+                ?.none { it is CommandOutcome.Rejected } == true
+          }
         }
-      if (!finalized || !transitionCurrent()) return
+      if (!completed || !finalized || !transitionCurrent()) return
       model.flushDrafts()
 
       if (!transitionCurrent()) return
@@ -629,12 +635,12 @@ fun EditorScreen(entityId: String) {
   }
   LaunchedEffect(entityId, editor) {
     val activeEditor = editor ?: return@LaunchedEffect
-    EditorLocalChangesetBus.consume(entityId).forEach { activeEditor.receiveRemoteChangeset(it) }
+    activeEditor.applyRemoteChangesets(EditorLocalChangesetBus.consume(entityId))
   }
   LaunchedEffect(entityId, runtime) {
-    EditorLocalChangesetBus.notifications(entityId).collectLatest {
-      val activeEditor = runtime.editor ?: return@collectLatest
-      EditorLocalChangesetBus.consume(entityId).forEach { activeEditor.receiveRemoteChangeset(it) }
+    EditorLocalChangesetBus.notifications(entityId).collect {
+      val activeEditor = runtime.editor ?: return@collect
+      activeEditor.applyRemoteChangesets(EditorLocalChangesetBus.consume(entityId))
     }
   }
 
@@ -987,8 +993,9 @@ fun EditorScreen(entityId: String) {
         if (queued.isEmpty()) break
 
         for (event in queued) {
-          for (bundle in event.bundles) {
-            if (bundle.isNotEmpty()) readyEditor.receiveRemoteChangeset(bundle)
+          if (!readyEditor.applyRemoteChangesets(event.bundles)) {
+            readyEditor.terminalFailure?.let(runtime::fail)
+            return@LaunchedEffect
           }
           effectiveBaseline =
             effectiveBaseline.copy(
@@ -1549,16 +1556,20 @@ fun EditorScreen(entityId: String) {
           currentEditorReadOnly == expectedEditorReadOnly &&
           !currentDirectEditingEnabled
       }
-      val cleaned =
-        activeEditor
-          .update(admit = cleanupCurrent) {
-            if (activeEditor.appliedState.ime?.composing != null) {
-              enqueue(Message.TextInput(listOf(FlatImeOp.CommitAsIs)))
+      var cleaned = false
+      val cleanupCompleted = activeEditor.runEffect {
+        cleaned =
+          activeEditor
+            .update(admit = cleanupCurrent) {
+              if (activeEditor.appliedState.ime?.composing != null) {
+                enqueue(Message.TextInput(listOf(FlatImeOp.CommitAsIs)))
+              }
+              enqueue(Message.System(SystemEvent.SetFocused(false)))
             }
-            enqueue(Message.System(SystemEvent.SetFocused(false)))
-          }
-          ?.commandOutcomes
-          ?.none { it is CommandOutcome.Rejected } == true
+            ?.commandOutcomes
+            ?.none { it is CommandOutcome.Rejected } == true
+      }
+      if (!cleanupCompleted) return@LaunchedEffect
       if (!cleaned || !cleanupCurrent()) return@LaunchedEffect
       if (!uiState.focused) return@LaunchedEffect
       interactionScope.controller.cancel()
@@ -1801,7 +1812,7 @@ fun EditorScreen(entityId: String) {
         onMeasuredViewportSizeChange = { viewport ->
           val editor = runtime.editor
           if (editor != null && viewport.width > 0f && viewport.height > 0f) {
-            scope.launch {
+            editor.launchEffect(coroutineScope = scope) {
               editor.update {
                 enqueue(
                   Message.System(
@@ -1837,11 +1848,19 @@ fun EditorScreen(entityId: String) {
               onTitleChange = model::updateTitleDraft,
               onSubtitleChange = model::updateSubtitleDraft,
               onTitleFocused = {
-                runtime.editor?.updateNow { enqueue(Message.Selection(SelectionOp.Unset)) }
+                runtime.editor?.let { activeEditor ->
+                  activeEditor.runCallback {
+                    activeEditor.updateNow { enqueue(Message.Selection(SelectionOp.Unset)) }
+                  }
+                }
                 entryState.markTitleFocused()
               },
               onSubtitleFocused = {
-                runtime.editor?.updateNow { enqueue(Message.Selection(SelectionOp.Unset)) }
+                runtime.editor?.let { activeEditor ->
+                  activeEditor.runCallback {
+                    activeEditor.updateNow { enqueue(Message.Selection(SelectionOp.Unset)) }
+                  }
+                }
                 entryState.markSubtitleFocused()
               },
               onHeightChanged = screenState::updateHeaderHeight,
@@ -1953,7 +1972,7 @@ fun EditorScreen(entityId: String) {
                 onRepasteAsText = repasteAsText@{
                     if (!directEditingEnabled) return@repasteAsText
                     activeSession.submit { activeEditor, context ->
-                      activeEditor.scope.launch(context) {
+                      activeEditor.launchEffect(context = context) {
                         activeEditor.updateWithBringIntoView(bringIntoViewRequests) {
                           enqueue(Message.Clipboard(ClipboardOp.RepasteAsText))
                           bringIntoView(
@@ -2094,7 +2113,7 @@ internal fun enterDocumentStartFromHeader(
 ) {
   requestEditorFocus()
   val activeEditor = editor ?: return
-  scope.launch {
+  activeEditor.launchEffect(coroutineScope = scope) {
     activeEditor.update {
       enqueue(
         Message.Navigation(NavigationOp.Move(Movement.Document(Direction.Backward), extend = false))

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/aifeedback/AiFeedbackEditorRanges.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/aifeedback/AiFeedbackEditorRanges.kt
@@ -20,8 +20,10 @@ internal suspend fun Editor.installAiFeedbackDecorations() {
 }
 
 internal fun Editor.clearAiFeedbackRanges() {
-  enqueue(Message.TrackedRange(TrackedRangeOp.ClearGroup(group = AI_FEEDBACK_RANGE_GROUP)))
-  enqueue(Message.TrackedRange(TrackedRangeOp.ClearGroup(group = ACTIVE_AI_FEEDBACK_RANGE_GROUP)))
+  runCallback {
+    enqueue(Message.TrackedRange(TrackedRangeOp.ClearGroup(group = AI_FEEDBACK_RANGE_GROUP)))
+    enqueue(Message.TrackedRange(TrackedRangeOp.ClearGroup(group = ACTIVE_AI_FEEDBACK_RANGE_GROUP)))
+  }
 }
 
 internal suspend fun Editor.addAiFeedbackRange(item: AiFeedbackRangeRegistration) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/aifeedback/EditorAiFeedbackSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/aifeedback/EditorAiFeedbackSession.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.viewmodel.compose.viewModel
 import co.typie.editor.Editor
 import co.typie.editor.EditorState
+import co.typie.editor.launchEditorEffect
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.revealTrackedItem
 import co.typie.graphql.AiFeedback_LiteraryAnalysisDocumentStream_Subscription
@@ -104,93 +105,96 @@ internal fun rememberEditorAiFeedbackSession(
     val activeEditor = editor ?: return
 
     analysisJob?.cancel()
-    analysisJob = scope.launch {
-      val sourceText = activeEditor.proseTextAnnotated()
-      val analysisRunId = activeModel.prepareAnalysis(sourceText)
-      activeEditor.installAiFeedbackDecorations()
-      activeEditor.clearAiFeedbackRanges()
-      if (sourceText.trim().isBlank()) {
-        activeModel.complete()
-        setOverlayBottomOcclusion(0f)
-        toast.show(ToastType.Success, "피드백이 없습니다.")
-        return@launch
-      }
+    analysisJob =
+      activeEditor.launchEffect(coroutineScope = scope) {
+        val sourceText = activeEditor.proseTextAnnotated()
+        val analysisRunId = activeModel.prepareAnalysis(sourceText)
+        activeEditor.installAiFeedbackDecorations()
+        activeEditor.clearAiFeedbackRanges()
+        if (sourceText.trim().isBlank()) {
+          activeModel.complete()
+          setOverlayBottomOcclusion(0f)
+          toast.show(ToastType.Success, "피드백이 없습니다.")
+          return@launchEffect
+        }
 
-      try {
-        Apollo.subscription(
-            AiFeedback_LiteraryAnalysisDocumentStream_Subscription(
-              text = sourceText,
-              documentId = Optional.presentIfNotNull(documentId),
+        try {
+          Apollo.subscription(
+              AiFeedback_LiteraryAnalysisDocumentStream_Subscription(
+                text = sourceText,
+                documentId = Optional.presentIfNotNull(documentId),
+              )
             )
-          )
-          .toFlow()
-          .collect { response ->
-            if (!activeModel.isCurrentAnalysisRun(analysisRunId)) return@collect
-            if (activeModel.isPendingAnalysisStale(sourceText, activeEditor.proseTextAnnotated())) {
-              cancelAnalysisState(clearRanges = true)
-              if (activeModel.active) {
-                toast.show(ToastType.Success, "내용이 수정되어 분석이 취소됐어요.")
-              }
-              return@collect
-            }
-
-            val payload = response.data?.literaryAnalysisDocumentStreamV2 ?: return@collect
-            when (payload.type) {
-              "feedback" -> {
-                val raw = payload.feedback?.toRawAiFeedbackResult() ?: return@collect
-                if (activeModel.results.any { it.id == raw.id }) return@collect
-                val selection =
-                  activeEditor.proseToSelectionAnnotated(raw.start, raw.end) ?: return@collect
-                val wasEmpty = activeModel.results.isEmpty()
-                activeEditor.addAiFeedbackRange(
-                  AiFeedbackRangeRegistration(id = raw.id, selection = selection)
-                )
-                activeModel.appendResult(raw.toAiFeedbackResult())
-                updateCompactOverlayHeightForRange(activeModel.activeRangeId)
-                updateActiveRangeDecoration()
-                if (wasEmpty) {
-                  requestRangeIntoView(activeModel.activeRangeId)
-                }
-              }
-              "progress" -> {
-                activeModel.updateProgress(payload.progress?.toAiFeedbackProgress())
-              }
-              "complete" -> {
-                activeModel.complete()
-                val completedJob = analysisJob
-                analysisJob = null
-                completedJob?.cancel()
-                if (activeModel.results.isEmpty()) {
-                  setOverlayBottomOcclusion(0f)
-                  toast.show(ToastType.Success, "피드백이 없습니다.")
-                }
-              }
-              "error" -> {
-                activeModel.fail()
-                val failedJob = analysisJob
-                analysisJob = null
-                failedJob?.cancel()
+            .toFlow()
+            .collect { response ->
+              if (!activeModel.isCurrentAnalysisRun(analysisRunId)) return@collect
+              if (
+                activeModel.isPendingAnalysisStale(sourceText, activeEditor.proseTextAnnotated())
+              ) {
+                cancelAnalysisState(clearRanges = true)
                 if (activeModel.active) {
-                  toast.show(ToastType.Error, "분석에 실패했어요.")
+                  toast.show(ToastType.Success, "내용이 수정되어 분석이 취소됐어요.")
+                }
+                return@collect
+              }
+
+              val payload = response.data?.literaryAnalysisDocumentStreamV2 ?: return@collect
+              when (payload.type) {
+                "feedback" -> {
+                  val raw = payload.feedback?.toRawAiFeedbackResult() ?: return@collect
+                  if (activeModel.results.any { it.id == raw.id }) return@collect
+                  val selection =
+                    activeEditor.proseToSelectionAnnotated(raw.start, raw.end) ?: return@collect
+                  val wasEmpty = activeModel.results.isEmpty()
+                  activeEditor.addAiFeedbackRange(
+                    AiFeedbackRangeRegistration(id = raw.id, selection = selection)
+                  )
+                  activeModel.appendResult(raw.toAiFeedbackResult())
+                  updateCompactOverlayHeightForRange(activeModel.activeRangeId)
+                  updateActiveRangeDecoration()
+                  if (wasEmpty) {
+                    requestRangeIntoView(activeModel.activeRangeId)
+                  }
+                }
+                "progress" -> {
+                  activeModel.updateProgress(payload.progress?.toAiFeedbackProgress())
+                }
+                "complete" -> {
+                  activeModel.complete()
+                  val completedJob = analysisJob
+                  analysisJob = null
+                  completedJob?.cancel()
+                  if (activeModel.results.isEmpty()) {
+                    setOverlayBottomOcclusion(0f)
+                    toast.show(ToastType.Success, "피드백이 없습니다.")
+                  }
+                }
+                "error" -> {
+                  activeModel.fail()
+                  val failedJob = analysisJob
+                  analysisJob = null
+                  failedJob?.cancel()
+                  if (activeModel.active) {
+                    toast.show(ToastType.Error, "분석에 실패했어요.")
+                  }
                 }
               }
             }
+        } catch (e: CancellationException) {
+          throw e
+        } catch (e: Exception) {
+          if (activeModel.isCurrentAnalysisRun(analysisRunId)) {
+            activeModel.fail()
+            if (activeModel.active) {
+              toast.show(ToastType.Error, "분석에 실패했어요.")
+            }
           }
-      } catch (e: CancellationException) {
-        throw e
-      } catch (e: Exception) {
-        if (activeModel.isCurrentAnalysisRun(analysisRunId)) {
-          activeModel.fail()
-          if (activeModel.active) {
-            toast.show(ToastType.Error, "분석에 실패했어요.")
+        } finally {
+          if (analysisJob == coroutineContext[Job]) {
+            analysisJob = null
           }
-        }
-      } finally {
-        if (analysisJob == coroutineContext[Job]) {
-          analysisJob = null
         }
       }
-    }
   }
 
   fun close() {
@@ -226,7 +230,7 @@ internal fun rememberEditorAiFeedbackSession(
 
   LaunchedEffect(active, editor) {
     if (active) {
-      editor?.installAiFeedbackDecorations()
+      editor?.runEffect { editor.installAiFeedbackDecorations() }
     }
   }
 
@@ -235,10 +239,12 @@ internal fun rememberEditorAiFeedbackSession(
     val expectedText = activeModel.pendingAnalysisText ?: return@LaunchedEffect
     val activeEditor = editor ?: return@LaunchedEffect
     if (!active || !activeModel.loading) return@LaunchedEffect
-    if (activeEditor.proseTextAnnotated() == expectedText) return@LaunchedEffect
+    activeEditor.runEffect effect@{
+      if (activeEditor.proseTextAnnotated() == expectedText) return@effect
 
-    cancelAnalysisState(clearRanges = true)
-    toast.show(ToastType.Success, "내용이 수정되어 분석이 취소됐어요.")
+      cancelAnalysisState(clearRanges = true)
+      toast.show(ToastType.Success, "내용이 수정되어 분석이 취소됐어요.")
+    }
   }
 
   LaunchedEffect(active, editorState.trackedRanges, model?.results) {
@@ -246,17 +252,21 @@ internal fun rememberEditorAiFeedbackSession(
     val activeEditor = editor ?: return@LaunchedEffect
     if (!active || activeModel.results.isEmpty()) return@LaunchedEffect
 
-    val removedIds =
-      activeModel.cleanupMissingRanges(
-        liveIds =
-          activeEditor.appliedState.trackedRanges.aiFeedbackRanges().mapTo(mutableSetOf()) { it.id }
-      )
-    if (removedIds.isEmpty()) return@LaunchedEffect
+    activeEditor.runEffect effect@{
+      val removedIds =
+        activeModel.cleanupMissingRanges(
+          liveIds =
+            activeEditor.appliedState.trackedRanges.aiFeedbackRanges().mapTo(mutableSetOf()) {
+              it.id
+            }
+        )
+      if (removedIds.isEmpty()) return@effect
 
-    if (activeModel.results.isNotEmpty()) {
-      updateCompactOverlayHeightForRange(activeModel.activeRangeId)
+      if (activeModel.results.isNotEmpty()) {
+        updateCompactOverlayHeightForRange(activeModel.activeRangeId)
+      }
+      updateActiveRangeDecoration()
     }
-    updateActiveRangeDecoration()
   }
 
   LaunchedEffect(
@@ -267,6 +277,7 @@ internal fun rememberEditorAiFeedbackSession(
     model?.results,
   ) {
     val activeModel = model ?: return@LaunchedEffect
+    val activeEditor = editor ?: return@LaunchedEffect
     if (!active) {
       lastMembershipIdsMappedToAiFeedback = null
       return@LaunchedEffect
@@ -279,34 +290,35 @@ internal fun rememberEditorAiFeedbackSession(
       lastMembershipIdsMappedToAiFeedback = null
       return@LaunchedEffect
     }
-
-    val resultIds = activeModel.results.mapTo(mutableSetOf()) { it.id }
-    val membershipIds =
-      editorState.trackedRangesContainingSelection.trackedRangeMembershipIds(
-        allowedGroups = AI_FEEDBACK_MEMBERSHIP_GROUPS,
-        ownedIds = resultIds,
-      )
-    if (membershipIds == lastMembershipIdsMappedToAiFeedback) return@LaunchedEffect
-    lastMembershipIdsMappedToAiFeedback = membershipIds
-
-    val rangeId =
-      editorState.trackedRangesContainingSelection
-        .selectTrackedRangeMember(
+    activeEditor.runEffect effect@{
+      val resultIds = activeModel.results.mapTo(mutableSetOf()) { it.id }
+      val membershipIds =
+        editorState.trackedRangesContainingSelection.trackedRangeMembershipIds(
           allowedGroups = AI_FEEDBACK_MEMBERSHIP_GROUPS,
-          activeId = activeModel.activeRangeId,
           ownedIds = resultIds,
         )
-        ?.id
-    val previousActiveRangeId = activeModel.activeRangeId
-    if (rangeId == null) {
-      activeModel.activate(null)
-    } else {
-      activeModel.activate(rangeId)
-    }
-    updateCompactOverlayHeightForRange(activeModel.activeRangeId)
-    updateActiveRangeDecoration()
-    if (rangeId != null && rangeId != previousActiveRangeId) {
-      requestRangeIntoView(rangeId)
+      if (membershipIds == lastMembershipIdsMappedToAiFeedback) return@effect
+      lastMembershipIdsMappedToAiFeedback = membershipIds
+
+      val rangeId =
+        editorState.trackedRangesContainingSelection
+          .selectTrackedRangeMember(
+            allowedGroups = AI_FEEDBACK_MEMBERSHIP_GROUPS,
+            activeId = activeModel.activeRangeId,
+            ownedIds = resultIds,
+          )
+          ?.id
+      val previousActiveRangeId = activeModel.activeRangeId
+      if (rangeId == null) {
+        activeModel.activate(null)
+      } else {
+        activeModel.activate(rangeId)
+      }
+      updateCompactOverlayHeightForRange(activeModel.activeRangeId)
+      updateActiveRangeDecoration()
+      if (rangeId != null && rangeId != previousActiveRangeId) {
+        requestRangeIntoView(rangeId)
+      }
     }
   }
 
@@ -330,13 +342,13 @@ internal fun rememberEditorAiFeedbackSession(
           close()
           return@open
         }
-        scope.launch {
-          if (editor == null) return@launch
-          if (!ensureSubscription()) return@launch
-          if (!ensureAiOptIn()) return@launch
+        scope.launchEditorEffect(editor) {
+          if (editor == null) return@launchEditorEffect
+          if (!ensureSubscription()) return@launchEditorEffect
+          if (!ensureAiOptIn()) return@launchEditorEffect
           if (activeModel.active) {
             close()
-            return@launch
+            return@launchEditorEffect
           }
           occlusionReleaseJob?.cancel()
           occlusionReleaseJob = null
@@ -349,9 +361,9 @@ internal fun rememberEditorAiFeedbackSession(
     rerun = rerun@{
         val activeModel = model ?: return@rerun
         if (!activeModel.active || activeModel.loading) return@rerun
-        scope.launch {
-          if (!ensureSubscription()) return@launch
-          if (!activeModel.active || activeModel.loading) return@launch
+        scope.launchEditorEffect(editor) {
+          if (!ensureSubscription()) return@launchEditorEffect
+          if (!activeModel.active || activeModel.loading) return@launchEditorEffect
           activeModel.updateExpanded(false)
           runAnalysis()
         }
@@ -359,7 +371,7 @@ internal fun rememberEditorAiFeedbackSession(
     activateResult = { id ->
       model?.activate(id)
       updateCompactOverlayHeightForRange(model?.activeRangeId)
-      scope.launch {
+      scope.launchEditorEffect(editor) {
         updateActiveRangeDecoration()
         requestRangeIntoView(id)
       }
@@ -367,7 +379,7 @@ internal fun rememberEditorAiFeedbackSession(
     showCurrentResult = { id -> model?.setCurrent(id) },
     ignore = ignore@{ id ->
         val activeEditor = editor ?: return@ignore
-        scope.launch {
+        scope.launchEditorEffect(activeEditor) {
           activeEditor.removeAiFeedbackRange(id)
           val nextId = model?.remove(id, activateReplacement = true)
           if (nextId != null) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/attachment/EditorAttachmentImporter.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/attachment/EditorAttachmentImporter.kt
@@ -3,6 +3,7 @@
 package co.typie.screen.editor.editor.attachment
 
 import androidx.compose.runtime.compositionLocalOf
+import co.touchlab.kermit.Logger
 import co.typie.editor.DocumentEditingSession
 import co.typie.editor.Editor
 import co.typie.editor.external.EditorExternalAsset
@@ -207,31 +208,47 @@ internal class DefaultEditorAttachmentImporter(
           it.requestId == requestId
         }
       if (matches.isEmpty()) {
+        Logger.e { "Attachment placeholder request emitted no matching receipt: $requestId" }
         return emptyList()
       }
       if (matches.size != 1) {
-        val error =
-          IllegalStateException(
-            "Expected exactly one attachment placeholder result for $requestId, got ${matches.size}"
-          )
-        editor.fail(error)
-        throw error
+        return failPlaceholderReceiptInvariant(
+          editor,
+          "Attachment placeholder request emitted duplicate matching receipts: " +
+            "requestId=$requestId, receiptCount=${matches.size}",
+        )
       }
       val nodeIds = matches.single().nodeIds
       if (remaining.size != nodeIds.size) {
-        val error =
-          IllegalStateException(
-            "Expected ${remaining.size} attachment placeholders, got ${nodeIds.size}"
-          )
-        editor.fail(error)
-        throw error
+        return failPlaceholderReceiptInvariant(
+          editor,
+          "Attachment placeholder receipt count mismatch: " +
+            "expected=${remaining.size}, actual=${nodeIds.size}",
+        )
       }
       targets += nodeIds.zip(remaining)
     }
 
-    return targets.map { (nodeId, preparedItem) ->
+    val mapped = targets.map { (nodeId, preparedItem) ->
       Target(nodeId, preparedItem.item, preparedItem.pending)
     }
+    if (mapped.map(Target::nodeId).distinct().size != mapped.size) {
+      return failPlaceholderReceiptInvariant(
+        editor,
+        "Attachment placeholder receipt contains duplicate mapped node IDs",
+      )
+    }
+    if (mapped.any { target -> !isAvailablePlaceholder(editor, target.nodeId, target.item.kind) }) {
+      Logger.e { "Attachment placeholder receipt contains an unavailable target" }
+      return emptyList()
+    }
+    return mapped
+  }
+
+  private fun failPlaceholderReceiptInvariant(editor: Editor, message: String): List<Target> {
+    val error = IllegalStateException(message)
+    editor.fail(error)
+    return emptyList()
   }
 
   private suspend fun uploadTarget(
@@ -341,6 +358,7 @@ internal class DefaultEditorAttachmentImporter(
 
   private fun isCurrent(session: DocumentEditingSession, editor: Editor, target: Target): Boolean =
     isSessionCurrent(session) &&
+      !editor.terminal &&
       pendingMatches(target) &&
       isEmptyPlaceholder(editor, target.nodeId, target.item.kind)
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/entry/EditorEntryStateSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/entry/EditorEntryStateSession.kt
@@ -69,15 +69,17 @@ internal fun rememberEditorEntryStateSession(
     val activeEditor = editor ?: return@LaunchedEffect
     val selection = restoreSelection ?: return@LaunchedEffect
 
-    activeEditor.updateWithBringIntoView(bringIntoViewRequests) {
-      enqueue(Message.Selection(SelectionOp.SetFrozen(selection = selection)))
-      enqueue(Message.View(ViewOp.ExpandFoldsForSelection))
-      bringIntoView(
-        EditorBringIntoViewTarget.CurrentSelectionHead,
-        policy = EditorBringIntoViewPolicy.Reveal,
-      )
+    activeEditor.runEffect {
+      activeEditor.updateWithBringIntoView(bringIntoViewRequests) {
+        enqueue(Message.Selection(SelectionOp.SetFrozen(selection = selection)))
+        enqueue(Message.View(ViewOp.ExpandFoldsForSelection))
+        bringIntoView(
+          EditorBringIntoViewTarget.CurrentSelectionHead,
+          policy = EditorBringIntoViewPolicy.Reveal,
+        )
+      }
+      session.markPresentationReady()
     }
-    session.markPresentationReady()
   }
 
   LaunchedEffect(documentId, editor) {
@@ -94,7 +96,9 @@ internal fun rememberEditorEntryStateSession(
     snapshotFlow { currentEditorFocused.value to activeEditor.appliedState.selection }
       .collect { (focused, selection) ->
         if (focused && selection != null && selection != baselineSelection) {
-          controller.saveBodySelection(documentId = activeDocumentId, editor = activeEditor)
+          activeEditor.runEffect {
+            controller.saveBodySelection(documentId = activeDocumentId, editor = activeEditor)
+          }
         }
 
         if (focused || wasFocused) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/EditorFindReplaceSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/EditorFindReplaceSession.kt
@@ -14,11 +14,11 @@ import co.typie.editor.DocumentEditingSession
 import co.typie.editor.Editor
 import co.typie.editor.EditorState
 import co.typie.editor.ext.isCollapsed
+import co.typie.editor.launchEditorEffect
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.storage.Preference
 import co.typie.ui.component.toast.LocalToast
 import co.typie.ui.component.toast.ToastType
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -72,7 +72,7 @@ internal fun rememberEditorFindReplaceSession(
 
   LaunchedEffect(state.active, editor) {
     if (state.active) {
-      editor?.installFindReplaceDecorations()
+      editor?.runEffect { editor.installFindReplaceDecorations() }
     }
   }
 
@@ -83,11 +83,22 @@ internal fun rememberEditorFindReplaceSession(
     state.findText,
     matchWholeWord,
   ) {
-    state.runSearch(
-      editor = editor,
-      matchWholeWord = matchWholeWord,
-      bringIntoViewRequests = bringIntoViewRequests,
-    )
+    val activeEditor = editor
+    if (activeEditor == null) {
+      state.runSearch(
+        editor = null,
+        matchWholeWord = matchWholeWord,
+        bringIntoViewRequests = bringIntoViewRequests,
+      )
+    } else {
+      activeEditor.runEffect {
+        state.runSearch(
+          editor = activeEditor,
+          matchWholeWord = matchWholeWord,
+          bringIntoViewRequests = bringIntoViewRequests,
+        )
+      }
+    }
   }
 
   return EditorFindReplaceSession(
@@ -98,18 +109,18 @@ internal fun rememberEditorFindReplaceSession(
     matchCount = state.matches.size,
     activeMatchNumber = state.activeIndex?.let { it + 1 },
     searchInputFocusRequest = state.searchInputFocusRequest,
-    onOpen = { scope.launch { state.open(editor) } },
-    close = { scope.launch { state.close(editor) } },
+    onOpen = { scope.launchEditorEffect(editor) { state.open(editor) } },
+    close = { scope.launchEditorEffect(editor) { state.close(editor) } },
     updateFindText = state::updateFindText,
     updateReplaceText = state::updateReplaceText,
     updateMatchWholeWord = { enabled -> Preference.searchMatchWholeWord = enabled },
     findPrevious = {
-      scope.launch {
+      scope.launchEditorEffect(editor) {
         state.findBy(offset = -1, editor = editor, bringIntoViewRequests = bringIntoViewRequests)
       }
     },
     findNext = {
-      scope.launch {
+      scope.launchEditorEffect(editor) {
         state.findBy(offset = 1, editor = editor, bringIntoViewRequests = bringIntoViewRequests)
       }
     },
@@ -120,11 +131,13 @@ internal fun rememberEditorFindReplaceSession(
           return@replace
         }
         if (!state.canReplaceActive()) return@replace
-        scope.launch {
-          if (!ensureSubscription()) return@launch
-          if (!state.canReplaceActive() || !onEditingIntent(activeSession.editor)) return@launch
+        scope.launchEditorEffect(activeSession.editor) {
+          if (!ensureSubscription()) return@launchEditorEffect
+          if (!state.canReplaceActive() || !onEditingIntent(activeSession.editor)) {
+            return@launchEditorEffect
+          }
           activeSession.submit { activeEditor, context ->
-            activeEditor.scope.launch(context) {
+            activeEditor.launchEffect(context = context) {
               state.replaceActive(
                 editor = activeEditor,
                 admitMutation = { admitMutation(activeSession) },
@@ -141,11 +154,13 @@ internal fun rememberEditorFindReplaceSession(
           return@replaceAll
         }
         if (!state.canReplaceAll()) return@replaceAll
-        scope.launch {
-          if (!ensureSubscription()) return@launch
-          if (!state.canReplaceAll() || !onEditingIntent(activeSession.editor)) return@launch
+        scope.launchEditorEffect(activeSession.editor) {
+          if (!ensureSubscription()) return@launchEditorEffect
+          if (!state.canReplaceAll() || !onEditingIntent(activeSession.editor)) {
+            return@launchEditorEffect
+          }
           activeSession.submit { activeEditor, context ->
-            activeEditor.scope.launch(context) {
+            activeEditor.launchEffect(context = context) {
               state.replaceAllMatches(
                 editor = activeEditor,
                 admitMutation = { admitMutation(activeSession) },

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceEditorRanges.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceEditorRanges.kt
@@ -64,8 +64,12 @@ internal suspend fun Editor.installFindReplaceDecorations() {
 }
 
 internal fun Editor.clearFindReplaceRanges() {
-  enqueue(Message.TrackedRange(TrackedRangeOp.ClearGroup(group = SEARCH_MATCH_RANGE_GROUP)))
-  enqueue(Message.TrackedRange(TrackedRangeOp.ClearGroup(group = ACTIVE_SEARCH_MATCH_RANGE_GROUP)))
+  runCallback {
+    enqueue(Message.TrackedRange(TrackedRangeOp.ClearGroup(group = SEARCH_MATCH_RANGE_GROUP)))
+    enqueue(
+      Message.TrackedRange(TrackedRangeOp.ClearGroup(group = ACTIVE_SEARCH_MATCH_RANGE_GROUP))
+    )
+  }
 }
 
 internal suspend fun Editor.setFindReplaceRanges(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorContextMenuActions.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorContextMenuActions.kt
@@ -18,7 +18,6 @@ import co.typie.editor.scroll.updateWithBringIntoView
 import co.typie.platform.Clipboard
 import co.typie.platform.IncomingContentMode
 import co.typie.platform.PlatformModule
-import kotlinx.coroutines.launch
 
 internal data class EditorContextMenuActions(
   val showCopyCutActions: Boolean,
@@ -56,7 +55,7 @@ internal fun rememberEditorContextMenuActions(
   ) {
     val expandSelection =
       { unit: SelectionExpansionUnit, bringIntoViewTarget: EditorBringIntoViewTarget? ->
-        editor.scope.launch {
+        editor.launchEffect {
           val appliedState =
             if (bringIntoViewTarget == null) {
               editor.update { enqueue(Message.Selection(SelectionOp.Expand(unit))) }?.snapshot
@@ -78,13 +77,13 @@ internal fun rememberEditorContextMenuActions(
       showCopyCutActions = !selection.isCollapsed(),
       availableExpansionUnits = availableExpansionUnits,
       onCopy = {
-        editor.scope.launch {
+        editor.launchEffect {
           editor.copySelection()?.let { clipboard.copyRichText(html = it.html, text = it.text) }
         }
       },
       onCut = {
-        editor.scope.launch {
-          val payload = editor.copySelection() ?: return@launch
+        editor.launchEffect {
+          val payload = editor.copySelection() ?: return@launchEffect
           if (clipboard.copyRichText(html = payload.html, text = payload.text)) {
             editor.updateWithBringIntoView(bringIntoViewRequests) {
               enqueue(Message.Clipboard(ClipboardOp.Cut))
@@ -99,7 +98,7 @@ internal fun rememberEditorContextMenuActions(
       onPaste = {
         val session = runtime.session?.takeIf { it.editor === editor }
         if (session != null) {
-          editor.scope.launch {
+          editor.launchEffect {
             incomingContentHandler.handleClipboard(session, clipboard, IncomingContentMode.Rich)
           }
         }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorTableAxisSelectionOverlay.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorTableAxisSelectionOverlay.kt
@@ -262,7 +262,7 @@ internal data class EditorTableAxisSelectorOverlayPlacement(
 )
 
 private fun Editor.sendTableAxisOp(selector: EditorTableAxisSelector, op: TableOp) {
-  updateNow { enqueue(selector.tableMessage(op)) }
+  runCallback { updateNow { enqueue(selector.tableMessage(op)) } }
 }
 
 private fun EditorTableAxisSelector.tableMessage(op: TableOp): Message =

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/spellcheck/EditorSpellcheckSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/spellcheck/EditorSpellcheckSession.kt
@@ -17,6 +17,7 @@ import co.typie.editor.EditorState
 import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.Selection
 import co.typie.editor.ffi.SelectionOp
+import co.typie.editor.launchEditorEffect
 import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.EditorBringIntoViewTarget
@@ -143,7 +144,9 @@ internal fun rememberEditorSpellcheckSession(
         } else {
           updateCompactOverlayHeightForRange(activeModel.activeRangeId)
         }
-        scope.launch { requestRangeIntoView(activeModel.activeRangeId) }
+        activeEditor.launchEffect(coroutineScope = scope) {
+          requestRangeIntoView(activeModel.activeRangeId)
+        }
         if (results.isEmpty()) {
           toast.show(ToastType.Success, "맞춤법 오류가 없습니다.")
         }
@@ -159,7 +162,7 @@ internal fun rememberEditorSpellcheckSession(
 
   fun scheduleRangeClear(activeEditor: Editor?, activeModel: SpellcheckViewModel?) {
     if (activeEditor == null || activeModel == null) return
-    activeEditor.scope.launch {
+    activeEditor.launchEffect {
       activeEditor.clearSpellcheckRanges(admit = activeModel::hasNoActiveRun)
     }
   }
@@ -196,7 +199,7 @@ internal fun rememberEditorSpellcheckSession(
 
   LaunchedEffect(active, editor) {
     if (active) {
-      editor?.installSpellcheckDecorations()
+      editor?.runEffect { editor.installSpellcheckDecorations() }
     }
   }
 
@@ -205,20 +208,22 @@ internal fun rememberEditorSpellcheckSession(
     val pendingCheck = activeModel.pendingCheck ?: return@LaunchedEffect
     val activeEditor = editor ?: return@LaunchedEffect
     if (!active || !activeModel.loading) return@LaunchedEffect
-    if (activeEditor.proseText() == pendingCheck.sourceText) return@LaunchedEffect
+    activeEditor.runEffect effect@{
+      if (activeEditor.proseText() == pendingCheck.sourceText) return@effect
 
-    val run = pendingCheck.run
-    if (!activeModel.cancelCheck(run)) return@LaunchedEffect
-    try {
-      val cleared =
-        withContext(NonCancellable) {
-          activeEditor.clearSpellcheckRanges(admit = { activeModel.ownsCleanup(run) })
+      val run = pendingCheck.run
+      if (!activeModel.cancelCheck(run)) return@effect
+      try {
+        val cleared =
+          withContext(NonCancellable) {
+            activeEditor.clearSpellcheckRanges(admit = { activeModel.ownsCleanup(run) })
+          }
+        if (cleared && activeModel.ownsCleanup(run) && activeModel.active) {
+          toast.show(ToastType.Success, "내용이 수정되어 맞춤법 검사가 취소됐어요.")
         }
-      if (cleared && activeModel.ownsCleanup(run) && activeModel.active) {
-        toast.show(ToastType.Success, "내용이 수정되어 맞춤법 검사가 취소됐어요.")
+      } finally {
+        activeModel.finishCleanup(run)
       }
-    } finally {
-      activeModel.finishCleanup(run)
     }
   }
 
@@ -236,61 +241,62 @@ internal fun rememberEditorSpellcheckSession(
       return@LaunchedEffect
     }
 
-    val cleanup =
-      activeModel.cleanupStale(
-        activeEditor.appliedState.trackedRanges.spellcheckRanges().associate { it.id to it.text }
-      )
-    if (cleanup.isNotEmpty()) {
-      activeEditor.removeSpellcheckRanges(cleanup)
-      if (activeModel.results.isNotEmpty()) {
-        updateCompactOverlayHeightForRange(activeModel.activeRangeId)
-      }
-      updateActiveRangeDecoration()
-    }
-
-    if (!active || activeModel.results.isEmpty()) {
-      lastMembershipIdsMappedToSpellcheck = null
-      return@LaunchedEffect
-    }
-    val selection =
-      editorState.selection
-        ?: run {
-          lastMembershipIdsMappedToSpellcheck = null
-          return@LaunchedEffect
+    activeEditor.runEffect effect@{
+      val cleanup =
+        activeModel.cleanupStale(
+          activeEditor.appliedState.trackedRanges.spellcheckRanges().associate { it.id to it.text }
+        )
+      if (cleanup.isNotEmpty()) {
+        activeEditor.removeSpellcheckRanges(cleanup)
+        if (activeModel.results.isNotEmpty()) {
+          updateCompactOverlayHeightForRange(activeModel.activeRangeId)
         }
+        updateActiveRangeDecoration()
+      }
 
-    val resultIds = activeModel.results.mapTo(mutableSetOf()) { it.id }
-    val membershipIds =
-      editorState.trackedRangesContainingSelection.trackedRangeMembershipIds(
-        allowedGroups = SPELLCHECK_MEMBERSHIP_GROUPS,
-        ownedIds = resultIds,
-      )
-    if (selection == programmaticSelectionToSkip) {
-      programmaticSelectionToSkip = null
-      lastMembershipIdsMappedToSpellcheck = membershipIds
-      return@LaunchedEffect
-    }
-    if (membershipIds == lastMembershipIdsMappedToSpellcheck) return@LaunchedEffect
-    lastMembershipIdsMappedToSpellcheck = membershipIds
-
-    val rangeId =
-      editorState.trackedRangesContainingSelection
-        .selectTrackedRangeMember(
+      if (!active || activeModel.results.isEmpty()) {
+        lastMembershipIdsMappedToSpellcheck = null
+        return@effect
+      }
+      val selection =
+        editorState.selection
+          ?: run {
+            lastMembershipIdsMappedToSpellcheck = null
+            return@effect
+          }
+      val resultIds = activeModel.results.mapTo(mutableSetOf()) { it.id }
+      val membershipIds =
+        editorState.trackedRangesContainingSelection.trackedRangeMembershipIds(
           allowedGroups = SPELLCHECK_MEMBERSHIP_GROUPS,
-          activeId = activeModel.activeRangeId,
           ownedIds = resultIds,
         )
-        ?.id
-    val previousActiveRangeId = activeModel.activeRangeId
-    if (rangeId == null) {
-      activeModel.activate(null)
-    } else {
-      activeModel.activate(rangeId)
-    }
-    updateCompactOverlayHeightForRange(activeModel.activeRangeId)
-    updateActiveRangeDecoration()
-    if (rangeId != null && rangeId != previousActiveRangeId) {
-      requestRangeIntoView(rangeId)
+      if (selection == programmaticSelectionToSkip) {
+        programmaticSelectionToSkip = null
+        lastMembershipIdsMappedToSpellcheck = membershipIds
+        return@effect
+      }
+      if (membershipIds == lastMembershipIdsMappedToSpellcheck) return@effect
+      lastMembershipIdsMappedToSpellcheck = membershipIds
+
+      val rangeId =
+        editorState.trackedRangesContainingSelection
+          .selectTrackedRangeMember(
+            allowedGroups = SPELLCHECK_MEMBERSHIP_GROUPS,
+            activeId = activeModel.activeRangeId,
+            ownedIds = resultIds,
+          )
+          ?.id
+      val previousActiveRangeId = activeModel.activeRangeId
+      if (rangeId == null) {
+        activeModel.activate(null)
+      } else {
+        activeModel.activate(rangeId)
+      }
+      updateCompactOverlayHeightForRange(activeModel.activeRangeId)
+      updateActiveRangeDecoration()
+      if (rangeId != null && rangeId != previousActiveRangeId) {
+        requestRangeIntoView(rangeId)
+      }
     }
   }
 
@@ -314,12 +320,12 @@ internal fun rememberEditorSpellcheckSession(
           close()
           return@open
         }
-        scope.launch {
-          if (editor == null) return@launch
-          if (!ensureSubscription()) return@launch
+        scope.launchEditorEffect(editor) {
+          if (editor == null) return@launchEditorEffect
+          if (!ensureSubscription()) return@launchEditorEffect
           if (activeModel.active) {
             close()
-            return@launch
+            return@launchEditorEffect
           }
           occlusionReleaseJob?.cancel()
           occlusionReleaseJob = null
@@ -333,9 +339,9 @@ internal fun rememberEditorSpellcheckSession(
     rerun = rerun@{
         val activeModel = model ?: return@rerun
         if (!activeModel.active || activeModel.loading) return@rerun
-        scope.launch {
-          if (!ensureSubscription()) return@launch
-          if (!activeModel.active || activeModel.loading) return@launch
+        scope.launchEditorEffect(editor) {
+          if (!ensureSubscription()) return@launchEditorEffect
+          if (!activeModel.active || activeModel.loading) return@launchEditorEffect
           activeModel.updateExpanded(false)
           runCheck()
         }
@@ -343,7 +349,7 @@ internal fun rememberEditorSpellcheckSession(
     activateResult = { id ->
       model?.activate(id)
       updateCompactOverlayHeightForRange(model?.activeRangeId)
-      scope.launch {
+      scope.launchEditorEffect(editor) {
         updateActiveRangeDecoration()
         requestRangeIntoView(id)
       }
@@ -357,12 +363,12 @@ internal fun rememberEditorSpellcheckSession(
           return@applySuggestion
         }
 
-        scope.launch {
-          if (activeSession.editor.trackedRange(id) == null) return@launch
-          if (!ensureSubscription()) return@launch
-          if (!onEditingIntent(activeSession.editor)) return@launch
+        scope.launchEditorEffect(activeSession.editor) {
+          if (activeSession.editor.trackedRange(id) == null) return@launchEditorEffect
+          if (!ensureSubscription()) return@launchEditorEffect
+          if (!onEditingIntent(activeSession.editor)) return@launchEditorEffect
           activeSession.submit { activeEditor, context ->
-            activeEditor.scope.launch(context) {
+            activeEditor.launchEffect(context = context) {
               val replaced =
                 activeEditor.replaceSpellcheckRangeText(
                   id = id,
@@ -386,15 +392,15 @@ internal fun rememberEditorSpellcheckSession(
     directEdit = directEdit@{ id ->
         val activeSession = editingSession ?: return@directEdit
         val activeEditor = activeSession.editor
-        scope.launch {
-          val range = activeEditor.trackedRange(id) ?: return@launch
+        scope.launchEditorEffect(activeEditor) {
+          val range = activeEditor.trackedRange(id) ?: return@launchEditorEffect
           if (documentLocked) {
             toast.show(ToastType.Error, "잠긴 문서는 편집할 수 없어요.")
-            return@launch
+            return@launchEditorEffect
           }
 
-          if (!ensureSubscription()) return@launch
-          if (!onEditingIntent(activeEditor)) return@launch
+          if (!ensureSubscription()) return@launchEditorEffect
+          if (!onEditingIntent(activeEditor)) return@launchEditorEffect
           val update =
             activeEditor.updateWithBringIntoView(
               bringIntoViewRequests = bringIntoViewRequests,
@@ -410,7 +416,7 @@ internal fun rememberEditorSpellcheckSession(
                 policy = EditorBringIntoViewPolicy.CursorGuard,
               )
             }
-          if (update == null) return@launch
+          if (update == null) return@launchEditorEffect
           model?.activate(null)
           updateCompactOverlayHeightForRange(null)
           model?.updateExpanded(false)
@@ -422,7 +428,7 @@ internal fun rememberEditorSpellcheckSession(
       },
     ignore = ignore@{ id ->
         val activeEditor = editor ?: return@ignore
-        scope.launch {
+        scope.launchEditorEffect(activeEditor) {
           activeEditor.removeSpellcheckRange(id)
           val nextId = model?.remove(id, activateReplacement = true)
           if (nextId != null) {
@@ -438,7 +444,7 @@ internal fun rememberEditorSpellcheckSession(
         val ids =
           activeModel.results.filter { it.context == context }.mapTo(mutableSetOf()) { it.id }
         val activeEditor = editor ?: return@ignoreSame
-        scope.launch {
+        scope.launchEditorEffect(activeEditor) {
           activeEditor.removeSpellcheckRanges(ids)
           val nextId = activeModel.removeByContext(context, activateReplacement = true)
           if (nextId != null) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/state/EditorScreenState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/state/EditorScreenState.kt
@@ -42,7 +42,9 @@ internal class EditorScreenState internal constructor(val viewportState: EditorV
     sceneInForeground = isForeground
     if (!isForeground) {
       uiState.updateFocus(false)
-      runtime.editor?.enqueue(Message.System(SystemEvent.SetFocused(false)))
+      runtime.editor?.let { editor ->
+        editor.runCallback { editor.enqueue(Message.System(SystemEvent.SetFocused(false))) }
+      }
       runtime.deactivateScene()
     }
   }
@@ -53,7 +55,9 @@ internal class EditorScreenState internal constructor(val viewportState: EditorV
     flushDrafts: suspend () -> Unit,
   ) {
     uiState.updateFocus(false)
-    runtime.editor?.enqueue(Message.System(SystemEvent.SetFocused(false)))
+    runtime.editor?.let { editor ->
+      editor.runCallback { editor.enqueue(Message.System(SystemEvent.SetFocused(false))) }
+    }
     runtime.deactivateScene()
     flushDrafts()
     withFrameNanos {}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/EditorSubPaneHost.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/EditorSubPaneHost.kt
@@ -100,12 +100,8 @@ internal fun EditorSubPaneHost(
         onAction = tableAction@{ message ->
             if (!editorMutationEnabled) return@tableAction
             val currentEditor = editor ?: return@tableAction
-            try {
-              currentEditor.updateNow { enqueue(message) }
-            } catch (error: Throwable) {
-              if (!currentEditor.terminal) throw error
-              return@tableAction
-            }
+            currentEditor.runCallback { currentEditor.updateNow { enqueue(message) } }
+              ?: return@tableAction
             currentEditor.focus()
           },
         onDismissStarted = state::beginDismiss,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/comments/EditorCommentsSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/comments/EditorCommentsSession.kt
@@ -21,7 +21,6 @@ import co.typie.editor.scroll.revealTrackedItem
 import co.typie.screen.editor.editor.selectTrackedRangeMember
 import co.typie.ui.component.toast.LocalToast
 import co.typie.ui.component.toast.ToastType
-import kotlinx.coroutines.launch
 
 internal class EditorCommentsSession(
   val model: CommentsViewModel?,
@@ -106,7 +105,7 @@ internal fun rememberEditorCommentsSession(
   }
   val openSelectionsById = model?.openSelectionsById.orEmpty()
 
-  LaunchedEffect(editor) { editor?.installCommentDecorations() }
+  LaunchedEffect(editor) { editor?.runEffect { editor.installCommentDecorations() } }
 
   val activeThreadId = model?.threadState?.activeThreadId
   val selection = editorState.selection
@@ -184,13 +183,17 @@ internal fun rememberEditorCommentsSession(
 
   LaunchedEffect(editor, openSelectionsById, activeThreadId) {
     val activeEditor = editor ?: return@LaunchedEffect
-    activeEditor.syncCommentRanges(
-      selectionsById = openSelectionsById,
-      activeId = activeThreadId,
-      currentRanges = editorState.trackedRanges,
-    )
+    activeEditor.runEffect {
+      activeEditor.syncCommentRanges(
+        selectionsById = openSelectionsById,
+        activeId = activeThreadId,
+        currentRanges = editorState.trackedRanges,
+      )
+    }
   }
-  LaunchedEffect(editor, composeSelection) { editor?.setCommentComposeRange(composeSelection) }
+  LaunchedEffect(editor, composeSelection) {
+    editor?.runEffect { editor.setCommentComposeRange(composeSelection) }
+  }
   LaunchedEffect(editor, activeThreadId, activeThreadActivationRevision, activeThreadScrollTarget) {
     val threadId = activeThreadId
     if (threadId == null) {
@@ -201,9 +204,13 @@ internal fun rememberEditorCommentsSession(
     if (lastRequestedActivationRevision == activeThreadActivationRevision) {
       return@LaunchedEffect
     }
-    if (editor == null) return@LaunchedEffect
-    if (editor.revealTrackedItem(bringIntoViewRequests, activeThreadScrollTarget.id) != null) {
-      lastRequestedActivationRevision = activeThreadActivationRevision
+    val activeEditor = editor ?: return@LaunchedEffect
+    activeEditor.runEffect {
+      if (
+        activeEditor.revealTrackedItem(bringIntoViewRequests, activeThreadScrollTarget.id) != null
+      ) {
+        lastRequestedActivationRevision = activeThreadActivationRevision
+      }
     }
   }
   LaunchedEffect(sheetActive, selection, selectedCommentRange?.id) {
@@ -231,9 +238,13 @@ internal fun rememberEditorCommentsSession(
     threadLocationById = threadLocationById,
     composeLocation = composeLocation,
     virtualThreadGuardVisible = sheetActive && model?.threadState?.hasDirtyVirtualThread == true,
-    freezeCurrentSelection = {
-      editorState.selection?.let { currentSelection -> editor?.freezeSelection(currentSelection) }
-    },
+    freezeCurrentSelection = freezeCurrentSelection@{
+        val activeEditor = editor ?: return@freezeCurrentSelection null
+        val currentSelection = editorState.selection ?: return@freezeCurrentSelection null
+        var frozenSelection: StableSelection? = null
+        activeEditor.runEffect { frozenSelection = activeEditor.freezeSelection(currentSelection) }
+        frozenSelection
+      },
     ensureMutationSubscription = ensureMutationSubscription,
     onInputFocusChanged = { focused -> inputFocused = focused },
     requestFromTextToolbar = {
@@ -242,7 +253,7 @@ internal fun rememberEditorCommentsSession(
       val currentSelection = editorState.selection
       if (currentSelection != null && activeEditor != null) {
         if (currentSelection.anchor != currentSelection.head) {
-          scope.launch {
+          activeEditor.launchEffect(coroutineScope = scope) {
             val frozenSelection = activeEditor.freezeSelection(currentSelection)
             if (frozenSelection == null) {
               toast.show(ToastType.Error, "선택 영역에 코멘트를 달 수 없어요.")

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarHost.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarHost.kt
@@ -197,7 +197,7 @@ internal fun EditorToolbarHost(
       // End that native state before changing the editor; doing this after the toolbar update is
       // too late because the keyboard has already associated the preceding text with the new style.
       endInputMethodComposition()
-      editor.scope.launch(context) {
+      editor.launchEffect(context = context) {
         val update =
           editor.updateWithBringIntoView(bringIntoViewRequests) {
             if (editor.appliedState.ime?.composing != null) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/bottom/Nodes.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/bottom/Nodes.kt
@@ -62,7 +62,6 @@ import co.typie.ui.icon.Icon
 import co.typie.ui.icon.IconData
 import co.typie.ui.theme.AppShapes
 import co.typie.ui.theme.AppTheme
-import kotlinx.coroutines.launch
 
 @Composable
 internal fun BottomToolbarNodes(
@@ -108,7 +107,7 @@ internal fun BottomToolbarNodes(
             is EditorToolbarNodeInsertAction.SendMessage -> {
               val session = runtime.session ?: return@NodeInsertTile
               session.submit { currentEditor, context ->
-                currentEditor.scope.launch(context) {
+                currentEditor.launchEffect(context = context) {
                   currentEditor.updateWithBringIntoView(bringIntoViewRequests) {
                     enqueue(action.message)
                     bringIntoView(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/FileToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/FileToolbar.kt
@@ -106,8 +106,8 @@ internal fun rememberEditorFilePicker(
         }
       }
       var importStarted = false
-      scope
-        .launch(start = CoroutineStart.UNDISPATCHED) {
+      session.editor
+        .launchEffect(coroutineScope = scope, start = CoroutineStart.UNDISPATCHED) {
           importStarted = true
           importer.import(
             session = session,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/ImageResizeSecondaryToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/ImageResizeSecondaryToolbar.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import co.typie.editor.EditorSurfaceUnavailableException
 import co.typie.editor.external.EditorImageResizeDraft
 import co.typie.editor.external.IMAGE_MAX_PROPORTION
 import co.typie.editor.external.IMAGE_MIN_PROPORTION
@@ -41,13 +42,9 @@ import co.typie.screen.editor.editor.toolbar.ToolbarSecondaryContentStartInset
 import co.typie.ui.component.Slider
 import co.typie.ui.component.Text
 import co.typie.ui.theme.AppTheme
-import kotlin.coroutines.coroutineContext
 import kotlin.math.roundToInt
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.job
-import kotlinx.coroutines.launch
 
 private val ImageResizeToolbarItemGap = 8.dp
 private val ImageResizeToolbarEndPadding = 12.dp
@@ -176,21 +173,16 @@ internal fun ImageResizeSecondaryToolbar(
         boundsWidth = stableBoundsWidth,
         originalWidth = stableOriginalWidth,
       )
-    val update =
-      try {
-        editor.updateNow {
-          enqueue(
-            Message.Node(
-              NodeOp.SetAttr(id = nodeId, attr = NodeAttr.Image(ImageNodeAttr.Proportion(next)))
-            )
+    val update = editor.runCallback {
+      editor.updateNow {
+        enqueue(
+          Message.Node(
+            NodeOp.SetAttr(id = nodeId, attr = NodeAttr.Image(ImageNodeAttr.Proportion(next)))
           )
-          enqueue(Message.System(SystemEvent.SetExternalHeight(nodeId, finalHeight)))
-        }
-      } catch (error: Throwable) {
-        clearDraft()
-        if (!editor.terminal) throw error
-        return
+        )
+        enqueue(Message.System(SystemEvent.SetExternalHeight(nodeId, finalHeight)))
       }
+    }
     if (
       update == null || update.commandOutcomes.any { outcome -> outcome is CommandOutcome.Rejected }
     ) {
@@ -199,20 +191,19 @@ internal fun ImageResizeSecondaryToolbar(
     }
 
     val waitJob =
-      coroutineScope.launch(start = CoroutineStart.LAZY) {
+      editor.launchEffect(coroutineScope = coroutineScope, start = CoroutineStart.LAZY) {
         try {
-          update.awaitPublished()
-        } catch (e: CancellationException) {
-          throw e
-        } catch (_: Throwable) {
-          // The Editor already owns failure reporting; this job only owns the draft handoff.
-        } finally {
-          if (publicationWaitJob === coroutineContext.job) {
-            publicationWaitJob = null
-            clearDraft()
-          }
+          update.awaitPublishedInEffect()
+        } catch (_: EditorSurfaceUnavailableException) {
+          // A replacement surface can publish a newer revision; this draft is no longer needed.
         }
       }
+    waitJob.invokeOnCompletion {
+      if (publicationWaitJob === waitJob) {
+        publicationWaitJob = null
+        clearDraft()
+      }
+    }
     publicationWaitJob = waitJob
     waitJob.start()
   }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/ImageToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/contextual/ImageToolbar.kt
@@ -107,8 +107,8 @@ internal fun rememberEditorImagePicker(
         }
       }
       var importStarted = false
-      scope
-        .launch(start = CoroutineStart.UNDISPATCHED) {
+      session.editor
+        .launchEffect(coroutineScope = scope, start = CoroutineStart.UNDISPATCHED) {
           importStarted = true
           importer.import(
             session = session,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/presetsettings/PresetSettingsScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/settings/presetsettings/PresetSettingsScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
@@ -30,12 +31,14 @@ import co.typie.editor.runtime.EditorRuntime
 import co.typie.ext.imePadding
 import co.typie.ext.verticalScroll
 import co.typie.icons.Lucide
+import co.typie.navigation.Nav
 import co.typie.result.withDefaultExceptionHandler
 import co.typie.ui.component.Screen
 import co.typie.ui.component.Text
 import co.typie.ui.component.dialog.DialogResult
 import co.typie.ui.component.dialog.LocalDialog
 import co.typie.ui.component.dialog.confirm
+import co.typie.ui.component.dialog.error
 import co.typie.ui.component.editorsettings.EditorSettingsFontSection
 import co.typie.ui.component.editorsettings.EditorSettingsLayoutSection
 import co.typie.ui.component.editorsettings.EditorSettingsSectionDivider
@@ -55,6 +58,8 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun PresetSettingsScreen() {
+  val nav = Nav.current
+  val dialog = LocalDialog.current
   val model = viewModel { PresetSettingsViewModel() }
   val scope = rememberCoroutineScope()
   val scrollState = rememberScrollState()
@@ -110,6 +115,11 @@ fun PresetSettingsScreen() {
     val previewShape = RoundedCornerShape(bottomStart = AppShapes.xl, bottomEnd = AppShapes.xl)
     val style = model.preset.toEditorStyleSettings()
     val previewRuntime = remember { EditorRuntime(uiScope = scope) }
+
+    LaunchedEffect(previewRuntime.failure) {
+      previewRuntime.failure ?: return@LaunchedEffect
+      dialog.error(nav) { previewRuntime.clearFailure() }
+    }
 
     Box(
       modifier =

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorPublicationHostTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorPublicationHostTest.kt
@@ -14,6 +14,7 @@ import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
@@ -128,6 +129,68 @@ class EditorPublicationHostTest {
     }
 
   @Test
+  fun terminal_failure_is_contained_while_an_editor_effect_waits_for_publication() =
+    runTest(dispatcher) {
+      val failure = IllegalStateException("publication failed")
+      val reported = mutableListOf<Throwable>()
+      val editor =
+        Editor(
+          inner = FakeFfiEditor(),
+          scope = this,
+          dispatcher = dispatcher,
+          onError = { _, error -> reported += error },
+        )
+      editor.activateVisualHost(Any())
+
+      supervisorScope {
+        val effect =
+          async(start = CoroutineStart.UNDISPATCHED) {
+            editor.runEffect { editor.awaitPublished(revision = 1L) }
+          }
+        assertFalse(effect.isCompleted)
+
+        editor.fail(failure)
+        runCurrent()
+
+        assertTrue(effect.isCompleted)
+        assertFalse(effect.await())
+      }
+      assertSame(failure, reported.single())
+    }
+
+  @Test
+  fun terminal_failure_is_contained_before_an_editor_effect_starts_waiting_for_publication() =
+    runTest(dispatcher) {
+      val failure = IllegalStateException("publication failed")
+      val reported = mutableListOf<Throwable>()
+      val editor =
+        Editor(
+          inner = FakeFfiEditor(),
+          scope = this,
+          dispatcher = dispatcher,
+          onError = { _, error -> reported += error },
+        )
+      val started = CompletableDeferred<Unit>()
+      val proceed = CompletableDeferred<Unit>()
+
+      val effect =
+        async(start = CoroutineStart.UNDISPATCHED) {
+          editor.runEffect {
+            started.complete(Unit)
+            proceed.await()
+            editor.awaitPublished(revision = 1L)
+          }
+        }
+      started.await()
+      editor.fail(failure)
+      proceed.complete(Unit)
+      runCurrent()
+
+      assertFalse(effect.await())
+      assertSame(failure, reported.single())
+    }
+
+  @Test
   fun failedViewportAnchorPresentationReplacementLeavesTheCandidateReady() =
     runTest(dispatcher) {
       val replacementRevisions = mutableListOf<Long>()
@@ -161,6 +224,45 @@ class EditorPublicationHostTest {
       assertEquals(update.revision, editor.publishIfReady(setOf(0))?.snapshot?.version)
       assertEquals(0L, replacementRevisions.first())
       assertTrue(replacementRevisions.drop(1).all { it == update.revision })
+    }
+
+  @Test
+  fun viewportAnchorPresentationReplacementContainsNativeFailure() =
+    runTest(dispatcher) {
+      val failure = IllegalStateException("replacement failed")
+      var failReplacement = false
+      val reported = mutableListOf<Throwable>()
+      val fake =
+        FakeFfiEditor(
+          onTick = { listOf(EditorEvent.RenderInvalidated) },
+          pageSizesProvider = { listOf(Size(width = 100f, height = 100f)) },
+          replaceViewportAnchorPresentationProvider = { revision ->
+            if (failReplacement) throw failure
+            revision.value == 0L
+          },
+        )
+      val editor = Editor(fake, this, dispatcher, onError = { _, error -> reported += error })
+      editor.activateVisualHost(Any())
+      val session = editor.attachSurface(0, 10L, 100.0, 100.0, 1.0, wakeDelivery = {})
+      editor.requestSurfacePages(setOf(0))
+      advanceUntilIdle()
+      editor.deliverFrame(session, editorRevision = 0L, frameKey = 1L)
+      advanceUntilIdle()
+      assertTrue(editor.acceptPublication(requireNotNull(editor.publishIfReady(setOf(0)))))
+
+      val update = requireNotNull(editor.update { enqueue(message) })
+      advanceUntilIdle()
+      editor.deliverFrame(session, editorRevision = update.revision, frameKey = 2L)
+      advanceUntilIdle()
+      val candidate = requireNotNull(editor.publishIfReady(setOf(0)))
+      failReplacement = true
+
+      assertFalse(editor.acceptPublication(candidate))
+      advanceUntilIdle()
+
+      assertTrue(editor.terminal)
+      assertSame(failure, reported.single())
+      assertEquals(0L, editor.publishedRevision)
     }
 
   @Test

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorRequestTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorRequestTest.kt
@@ -23,6 +23,7 @@ import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
@@ -440,7 +441,9 @@ class EditorRequestTest {
 
       val thrown = assertFailsWith<RuntimeException> { editor.update { enqueue(sampleMessage) } }
 
-      assertEquals(boom.message, thrown.message)
+      // JVM coroutine stack-trace recovery may copy the exception while retaining the source as
+      // its cause; Kotlin/Native propagates the source directly.
+      assertSame(boom, thrown.cause ?: thrown)
       assertEquals(1, reported.size)
       assertTrue(reported.single() === boom)
       assertEquals(EditorState.Initial, editor.appliedState)
@@ -467,6 +470,128 @@ class EditorRequestTest {
       }
 
       assertEquals(listOf("discarded", "reported"), events)
+    }
+
+  @Test
+  fun update_reports_the_original_failure_when_discard_cleanup_throws() =
+    runTest(dispatcher) {
+      val failure = RuntimeException("tick failed")
+      val cleanupFailure = RuntimeException("discard failed")
+      val reported = mutableListOf<Throwable>()
+      val editor =
+        Editor(
+          inner = FakeFfiEditor(onTick = { throw failure }),
+          scope = this,
+          dispatcher = dispatcher,
+          onError = { _, error -> reported += error },
+        )
+
+      assertFailsWith<RuntimeException> {
+        editor.update {
+          beforePublish(block = {}, onDiscard = { throw cleanupFailure })
+          enqueue(sampleMessage)
+        }
+      }
+
+      assertSame(failure, reported.single())
+      assertSame(cleanupFailure, failure.suppressedExceptions.single())
+    }
+
+  @Test
+  fun updateNow_reports_the_admission_failure_when_discard_cleanup_throws() =
+    runTest(dispatcher) {
+      val failure = RuntimeException("admission failed")
+      val cleanupFailure = RuntimeException("discard failed")
+      val reported = mutableListOf<Throwable>()
+      val editor =
+        Editor(
+          inner = FakeFfiEditor(beforeEnqueueRequest = { throw failure }),
+          scope = this,
+          dispatcher = dispatcher,
+          onError = { _, error -> reported += error },
+        )
+
+      val thrown =
+        assertFailsWith<RuntimeException> {
+          editor.updateNow {
+            beforePublish(block = {}, onDiscard = { throw cleanupFailure })
+            enqueue(sampleMessage)
+          }
+        }
+
+      assertSame(failure, thrown)
+      assertTrue(editor.terminal)
+      assertSame(failure, reported.single())
+      assertSame(cleanupFailure, failure.suppressedExceptions.single())
+    }
+
+  @Test
+  fun updateNow_reports_the_beforePublish_failure_when_discard_cleanup_throws() =
+    runTest(dispatcher) {
+      val failure = RuntimeException("beforePublish failed")
+      val cleanupFailure = RuntimeException("discard failed")
+      val reported = mutableListOf<Throwable>()
+      val editor =
+        Editor(
+          inner = FakeFfiEditor(),
+          scope = this,
+          dispatcher = dispatcher,
+          onError = { _, error -> reported += error },
+        )
+
+      val thrown =
+        assertFailsWith<RuntimeException> {
+          editor.updateNow {
+            beforePublish(block = { throw failure }, onDiscard = { throw cleanupFailure })
+            enqueue(sampleMessage)
+          }
+        }
+
+      assertSame(failure, thrown)
+      assertTrue(editor.terminal)
+      assertSame(failure, reported.single())
+      assertSame(cleanupFailure, failure.suppressedExceptions.single())
+    }
+
+  @Test
+  fun beforePublish_failure_completes_every_request_from_the_same_tick() =
+    runTest(dispatcher) {
+      val failure = RuntimeException("beforePublish failed")
+      val reported = mutableListOf<Throwable>()
+      val editor =
+        Editor(
+          inner = FakeFfiEditor(),
+          scope = this,
+          dispatcher = dispatcher,
+          onError = { _, error -> reported += error },
+        )
+
+      val first =
+        async(start = CoroutineStart.UNDISPATCHED) {
+          runCatching {
+            editor.update {
+              beforePublish(block = {}, onDiscard = {})
+              enqueue(sampleMessage)
+            }
+          }
+        }
+      val second =
+        async(start = CoroutineStart.UNDISPATCHED) {
+          runCatching {
+            editor.update {
+              beforePublish(block = { throw failure }, onDiscard = {})
+              enqueue(sampleMessage)
+            }
+          }
+        }
+
+      dispatcher.scheduler.runCurrent()
+
+      assertTrue(first.isCompleted)
+      assertTrue(second.isCompleted)
+      assertTrue(first.await().isFailure)
+      assertTrue(second.await().isFailure)
+      assertSame(failure, reported.single())
     }
 
   @Test
@@ -603,7 +728,7 @@ class EditorRequestTest {
     }
 
   @Test
-  fun updateNow_reports_tick_exception_without_applying() =
+  fun updateNow_reports_and_propagates_tick_exception_without_applying() =
     runTest(dispatcher) {
       val boom = IllegalStateException("boom")
       val fake = FakeFfiEditor(onTick = { throw boom })
@@ -844,6 +969,25 @@ class EditorRequestTest {
       dispatcher.scheduler.advanceUntilIdle()
       assertEquals(1, fake.tickCount)
       assertEquals(listOf(sampleMessage), fake.enqueued)
+    }
+
+  @Test
+  fun enqueue_reports_and_propagates_native_admission_failure() =
+    runTest(dispatcher) {
+      val failure = IllegalStateException("admission failed")
+      val fake = FakeFfiEditor(beforeEnqueueRequest = { throw failure })
+      val reported = mutableListOf<Throwable>()
+      val editor = Editor(fake, this, dispatcher, onError = { _, error -> reported += error })
+
+      val thrown = assertFailsWith<IllegalStateException> { editor.enqueue(sampleMessage) }
+      dispatcher.scheduler.advanceUntilIdle()
+
+      assertTrue(thrown === failure)
+      assertTrue(editor.terminal)
+      assertEquals(1, reported.size)
+      assertTrue(reported.single() === failure)
+      assertEquals(emptyList(), fake.enqueued)
+      assertEquals(0, fake.tickCount)
     }
 
   @Test

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorTerminalViewportAnchorTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorTerminalViewportAnchorTest.kt
@@ -1,0 +1,120 @@
+package co.typie.editor
+
+import co.typie.editor.ffi.ViewportAnchor
+import co.typie.editor.ffi.ViewportAnchorPoint
+import co.typie.editor.ffi.ViewportAnchorResolution
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+
+class EditorTerminalViewportAnchorTest {
+  private val point = ViewportAnchorPoint(pageIdx = 0, x = 0f, y = 0f)
+  private val anchor = ViewportAnchor.Node(node = "1:1", offsetX = 0f, offsetY = 0f)
+
+  @Test
+  fun failed_editor_returns_unavailable_viewport_anchor_reads() = runTest {
+    var selectionCaptureCount = 0
+    var pointCaptureCount = 0
+    var resolutionCount = 0
+    val editor =
+      Editor(
+        FakeFfiEditor(
+          captureSelectionViewportAnchorProvider = {
+            selectionCaptureCount += 1
+            error("terminal editor must not capture the selection anchor")
+          },
+          captureViewportAnchorAtProvider = { _, _ ->
+            pointCaptureCount += 1
+            error("terminal editor must not capture a point anchor")
+          },
+          resolveViewportAnchorProvider = { _, _ ->
+            resolutionCount += 1
+            error("terminal editor must not resolve an anchor")
+          },
+        ),
+        this,
+        StandardTestDispatcher(testScheduler),
+      )
+    editor.fail(RuntimeException("boom"))
+
+    assertNull(editor.captureSelectionViewportAnchor(revision = 1L))
+    assertNull(
+      editor.captureViewportAnchorAt(
+        revision = 1L,
+        point = ViewportAnchorPoint(pageIdx = 0, x = 0f, y = 0f),
+      )
+    )
+    assertEquals(
+      ViewportAnchorResolution.Unavailable,
+      editor.resolveViewportAnchor(revision = 1L, anchor = anchor),
+    )
+    assertEquals(0, selectionCaptureCount)
+    assertEquals(0, pointCaptureCount)
+    assertEquals(0, resolutionCount)
+  }
+
+  @Test
+  fun selection_anchor_capture_contains_native_failure() = runTest {
+    val failure = IllegalStateException("selection capture failed")
+    val reported = mutableListOf<Throwable>()
+    val editor =
+      Editor(
+        inner = FakeFfiEditor(captureSelectionViewportAnchorProvider = { throw failure }),
+        scope = this,
+        dispatcher = StandardTestDispatcher(testScheduler),
+        onError = { _, error -> reported += error },
+      )
+
+    assertNull(editor.captureSelectionViewportAnchor(revision = 1L))
+    advanceUntilIdle()
+
+    assertTrue(editor.terminal)
+    assertSame(failure, reported.single())
+  }
+
+  @Test
+  fun point_anchor_capture_contains_native_failure() = runTest {
+    val failure = IllegalStateException("point capture failed")
+    val reported = mutableListOf<Throwable>()
+    val editor =
+      Editor(
+        inner = FakeFfiEditor(captureViewportAnchorAtProvider = { _, _ -> throw failure }),
+        scope = this,
+        dispatcher = StandardTestDispatcher(testScheduler),
+        onError = { _, error -> reported += error },
+      )
+
+    assertNull(editor.captureViewportAnchorAt(revision = 1L, point = point))
+    advanceUntilIdle()
+
+    assertTrue(editor.terminal)
+    assertSame(failure, reported.single())
+  }
+
+  @Test
+  fun anchor_resolution_contains_native_failure() = runTest {
+    val failure = IllegalStateException("anchor resolution failed")
+    val reported = mutableListOf<Throwable>()
+    val editor =
+      Editor(
+        inner = FakeFfiEditor(resolveViewportAnchorProvider = { _, _ -> throw failure }),
+        scope = this,
+        dispatcher = StandardTestDispatcher(testScheduler),
+        onError = { _, error -> reported += error },
+      )
+
+    assertEquals(
+      ViewportAnchorResolution.Unavailable,
+      editor.resolveViewportAnchor(revision = 1L, anchor = anchor),
+    )
+    advanceUntilIdle()
+
+    assertTrue(editor.terminal)
+    assertSame(failure, reported.single())
+  }
+}

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorUpdateTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorUpdateTest.kt
@@ -15,9 +15,11 @@ import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertSame
+import kotlin.test.assertTrue
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.async
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.buildJsonObject
@@ -109,6 +111,27 @@ class EditorUpdateTest {
     }
 
   @Test
+  fun frozenCommentNativeAdmissionFailureDoesNotFailEditor() =
+    runTest(dispatcher) {
+      val failure = IllegalStateException("admission failed")
+      val fake = FakeFfiEditor(beforeEnqueueRequest = { throw failure })
+      val reported = mutableListOf<Throwable>()
+      val editor = Editor(fake, this, dispatcher, onError = { _, error -> reported += error })
+      val selection = assertNotNull(fake.freezeSelection(FakeFfiEditor.EmptySelection))
+
+      editor.addFrozenComment(
+        id = "comment",
+        group = COMMENT_RANGE_GROUP,
+        selection = json.encodeToJsonElement(selection),
+      )
+      advanceUntilIdle()
+
+      assertFalse(editor.terminal)
+      assertEquals(emptyList(), reported)
+      assertEquals(emptyList(), fake.enqueued)
+    }
+
+  @Test
   fun tickThroughLeavesLaterResourceWorkQueued() {
     val fake = FakeFfiEditor()
     val requestId = fake.enqueueRequest(listOf(message))
@@ -152,7 +175,9 @@ class EditorUpdateTest {
       val withHost =
         async(start = CoroutineStart.UNDISPATCHED) { editor.update { enqueue(message) } }
       runCurrent()
-      val publication = requireNotNull(withHost.await()).awaitPublished()
+      val update = requireNotNull(withHost.await())
+      assertTrue(editor.acceptPublication(requireNotNull(editor.publishIfReady(emptySet()))))
+      val publication = update.awaitPublished()
 
       val published = assertIs<Published>(publication)
       assertEquals(2L, published.revision)

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/FakeFfiEditor.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/FakeFfiEditor.kt
@@ -106,6 +106,7 @@ internal class FakeFfiEditor(
       ViewportAnchorResolution.Unavailable
     },
   var copySelectionProvider: () -> ClipboardPayload? = { null },
+  var proseTextAnnotatedProvider: () -> String = { "" },
   var selectionEndpointsProvider: () -> SelectionEndpoints? = { null },
   var trackedRangesProvider: (String?) -> List<TrackedRange> = { emptyList() },
   var trackedRangesContainingSelectionProvider:
@@ -484,7 +485,7 @@ internal class FakeFfiEditor(
 
   override fun proseToSelection(start: Int, end: Int): Selection? = null
 
-  override fun proseTextAnnotated(): String = ""
+  override fun proseTextAnnotated(): String = proseTextAnnotatedProvider()
 
   override fun proseToSelectionAnnotated(start: Int, end: Int): Selection? = null
 

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/SurfaceDriverTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/SurfaceDriverTest.kt
@@ -3,6 +3,7 @@ package co.typie.editor
 import co.typie.editor.ffi.FrameKey
 import co.typie.editor.ffi.Revision
 import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -125,6 +126,29 @@ class SurfaceDriverTest {
     }
 
   @Test
+  fun failureRejectsNewSurfaceWorkButStillAllowsDetach() =
+    runTest(dispatcher) {
+      val fake = FakeFfiEditor()
+      val editor = Editor(fake, this, dispatcher)
+      val failure = AtomicReference<Throwable?>(null)
+      val driver = driver(fake, failure = failure)
+      val session = driver.attach(editor, page = 0, handle = 1L, configuration = configuration)
+      advanceUntilIdle()
+      val completions = mutableListOf<FrameKey?>()
+
+      failure.store(IllegalStateException("editor failed"))
+      driver.resize(session, SurfaceConfiguration(1.0, 1.0, 1.0))
+      driver.render(session, revision = 1L) { completions += it }
+      driver.detach(session)
+      advanceUntilIdle()
+
+      assertEquals(listOf<FrameKey?>(null), completions)
+      assertEquals(emptyList(), fake.resizeCalls)
+      assertEquals(emptyList(), fake.renderCalls)
+      assertEquals(listOf("attach:0:1", "detach:0"), fake.surfaceEvents)
+    }
+
+  @Test
   fun cancelledOwnerScopeStillCompletesDetachOnce() =
     runTest(dispatcher) {
       val fake = FakeFfiEditor()
@@ -171,6 +195,7 @@ class SurfaceDriverTest {
     fake: FakeFfiEditor,
     failures: MutableList<Throwable> = mutableListOf(),
     disposed: AtomicBoolean = AtomicBoolean(false),
+    failure: AtomicReference<Throwable?> = AtomicReference(null),
     scope: CoroutineScope = CoroutineScope(dispatcher),
   ): SurfaceDriver =
     SurfaceDriver(
@@ -178,7 +203,7 @@ class SurfaceDriverTest {
       scope = scope,
       dispatcher = dispatcher,
       disposed = disposed,
-      failed = AtomicBoolean(false),
+      failure = failure,
       notifyFailure = { failures += it },
     )
 }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/input/EditorInputCallbackTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/input/EditorInputCallbackTest.kt
@@ -10,19 +10,26 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 
 class EditorInputCallbackTest {
   private val message = Message.System(SystemEvent.Initialize)
 
   @Test
-  fun `input callback does not invoke the block after the editor is terminal`() = runTest {
+  fun `editor callback does not invoke the block after the editor is terminal`() = runTest {
     val editor = Editor(FakeFfiEditor(), this)
     var invoked = false
     editor.dispose()
 
     val result =
-      editor.runInputCallback<Unit> {
+      editor.runCallback<Unit> {
         invoked = true
         error("must not run")
       }
@@ -32,7 +39,7 @@ class EditorInputCallbackTest {
   }
 
   @Test
-  fun `input callback contains a failure already owned by the editor`() = runTest {
+  fun `editor callback contains a failure already owned by the editor`() = runTest {
     val failure = IllegalStateException("tick failed")
     val reported = mutableListOf<Throwable>()
     val editor =
@@ -42,7 +49,7 @@ class EditorInputCallbackTest {
         onError = { _, error -> reported += error },
       )
 
-    val result = editor.runInputCallback { editor.updateNow { enqueue(message) } }
+    val result = editor.runCallback { editor.updateNow { enqueue(message) } }
 
     assertNull(result)
     assertTrue(editor.terminal)
@@ -50,14 +57,239 @@ class EditorInputCallbackTest {
   }
 
   @Test
-  fun `input callback rethrows a nonterminal programming error`() = runTest {
+  fun `editor callback contains a direct enqueue failure after routing it to the editor`() =
+    runTest {
+      val failure = IllegalStateException("admission failed")
+      val reported = mutableListOf<Throwable>()
+      val editor =
+        Editor(
+          inner = FakeFfiEditor(beforeEnqueueRequest = { throw failure }),
+          scope = this,
+          onError = { _, error -> reported += error },
+        )
+
+      val result = editor.runCallback { editor.enqueue(message) }
+
+      assertNull(result)
+      assertTrue(editor.terminal)
+      assertSame(failure, reported.single())
+    }
+
+  @Test
+  fun `editor callback rethrows a nonterminal programming error`() = runTest {
     val failure = IllegalStateException("programming error")
     val editor = Editor(FakeFfiEditor(), this)
 
     val thrown =
-      assertFailsWith<IllegalStateException> { editor.runInputCallback<Unit> { throw failure } }
+      assertFailsWith<IllegalStateException> { editor.runCallback<Unit> { throw failure } }
 
     assertSame(failure, thrown)
+    assertFalse(editor.terminal)
+  }
+
+  @Test
+  fun `editor callback rethrows an unrelated error after the editor fails`() = runTest {
+    val editorFailure = IllegalStateException("editor failed")
+    val programmingError = IllegalArgumentException("programming error")
+    val editor = Editor(FakeFfiEditor(), this)
+
+    val thrown =
+      assertFailsWith<IllegalArgumentException> {
+        editor.runCallback<Unit> {
+          editor.fail(editorFailure)
+          throw programmingError
+        }
+      }
+
+    assertSame(programmingError, thrown)
+    assertTrue(editor.terminal)
+  }
+
+  @Test
+  fun `editor callback never contains cancellation`() = runTest {
+    val cancellation = CancellationException("cancelled")
+    val editor = Editor(FakeFfiEditor(), this)
+
+    val thrown =
+      assertFailsWith<CancellationException> { editor.runCallback<Unit> { throw cancellation } }
+
+    assertSame(cancellation, thrown)
+    assertFalse(editor.terminal)
+  }
+
+  @Test
+  fun `editor effect rethrows an unrelated error after the editor fails`() = runTest {
+    val editorFailure = IllegalStateException("editor failed")
+    val programmingError = IllegalArgumentException("programming error")
+    val editor = Editor(FakeFfiEditor(), this)
+
+    val thrown =
+      assertFailsWith<IllegalArgumentException> {
+        editor.runEffect {
+          editor.fail(editorFailure)
+          throw programmingError
+        }
+      }
+
+    assertSame(programmingError, thrown)
+    assertTrue(editor.terminal)
+  }
+
+  @Test
+  fun `editor effect reports incomplete when the editor becomes terminal without throwing`() =
+    runTest {
+      val failure = IllegalStateException("editor failed")
+      val editor = Editor(FakeFfiEditor(), this)
+
+      val completed = editor.runEffect { editor.fail(failure) }
+
+      assertFalse(completed)
+      assertTrue(editor.terminal)
+    }
+
+  @Test
+  fun `editor effect rethrows an unrelated wrapper around the editor failure`() = runTest {
+    val editorFailure = IllegalStateException("editor failed")
+    val wrapper = RuntimeException("programming error", editorFailure)
+    val editor = Editor(FakeFfiEditor(), this)
+
+    val thrown =
+      assertFailsWith<RuntimeException> {
+        editor.runEffect {
+          editor.fail(editorFailure)
+          throw wrapper
+        }
+      }
+
+    assertSame(wrapper, thrown)
+    assertTrue(editor.terminal)
+  }
+
+  @Test
+  fun `editor effect rethrows a lookalike wrapper around the editor failure`() = runTest {
+    val editorFailure = IllegalStateException("editor failed")
+    val wrapper = IllegalStateException("editor failed", editorFailure)
+    val editor = Editor(FakeFfiEditor(), this)
+
+    val thrown =
+      assertFailsWith<IllegalStateException> {
+        editor.runEffect {
+          editor.fail(editorFailure)
+          throw wrapper
+        }
+      }
+
+    assertSame(wrapper, thrown)
+    assertTrue(editor.terminal)
+  }
+
+  @Test
+  fun `editor effect stops when a business read fails`() = runTest {
+    val failure = IllegalStateException("prose read failed")
+    val reported = mutableListOf<Throwable>()
+    val editor =
+      Editor(
+        inner = FakeFfiEditor(proseTextAnnotatedProvider = { throw failure }),
+        scope = this,
+        dispatcher = StandardTestDispatcher(testScheduler),
+        onError = { _, error -> reported += error },
+      )
+    var continued = false
+
+    val completed = editor.runEffect {
+      editor.proseTextAnnotated()
+      continued = true
+    }
+
+    assertFalse(completed)
+    assertFalse(continued)
+    runCurrent()
+    assertSame(failure, reported.single())
+  }
+
+  @Test
+  fun `editor effect contains a terminal failure observed by a later business read`() = runTest {
+    val failure = IllegalStateException("editor failed")
+    val reported = mutableListOf<Throwable>()
+    val editor =
+      Editor(
+        inner = FakeFfiEditor(),
+        scope = this,
+        dispatcher = StandardTestDispatcher(testScheduler),
+        onError = { _, error -> reported += error },
+      )
+    val started = CompletableDeferred<Unit>()
+    val proceed = CompletableDeferred<Unit>()
+
+    val effect =
+      async(start = CoroutineStart.UNDISPATCHED) {
+        editor.runEffect {
+          started.complete(Unit)
+          proceed.await()
+          editor.proseTextAnnotated()
+        }
+      }
+    started.await()
+    editor.fail(failure)
+    proceed.complete(Unit)
+    runCurrent()
+
+    assertFalse(effect.await())
+    assertSame(failure, reported.single())
+  }
+
+  @Test
+  fun `editor effect contains a terminal failure observed before update admission`() = runTest {
+    val failure = IllegalStateException("editor failed")
+    val reported = mutableListOf<Throwable>()
+    val editor =
+      Editor(
+        inner = FakeFfiEditor(),
+        scope = this,
+        dispatcher = StandardTestDispatcher(testScheduler),
+        onError = { _, error -> reported += error },
+      )
+
+    val effect =
+      async(start = CoroutineStart.UNDISPATCHED) {
+        editor.runEffect { editor.update { enqueue(message) } }
+      }
+    editor.fail(failure)
+    runCurrent()
+
+    assertFalse(effect.await())
+    assertSame(failure, reported.single())
+  }
+
+  @Test
+  fun `editor effect contains its failure across nested deferred awaits`() = runTest {
+    val failure = IllegalStateException("nested update failed")
+    val reported = mutableListOf<Throwable>()
+    val editor =
+      Editor(
+        inner = FakeFfiEditor(beforeEnqueueRequest = { throw failure }),
+        scope = this,
+        dispatcher = StandardTestDispatcher(testScheduler),
+        onError = { _, error -> reported += error },
+      )
+
+    val completed = editor.runEffect {
+      coroutineScope { async { async { editor.update { enqueue(message) } }.await() }.await() }
+    }
+
+    assertFalse(completed)
+    runCurrent()
+    assertSame(failure, reported.single())
+  }
+
+  @Test
+  fun `editor effect never contains cancellation`() = runTest {
+    val cancellation = CancellationException("cancelled")
+    val editor = Editor(FakeFfiEditor(), this)
+
+    val thrown = assertFailsWith<CancellationException> { editor.runEffect { throw cancellation } }
+
+    assertSame(cancellation, thrown)
     assertFalse(editor.terminal)
   }
 }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionScopeTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionScopeTest.kt
@@ -28,6 +28,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -37,6 +38,31 @@ import kotlinx.coroutines.test.runTest
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class EditorInteractionScopeTest {
+  @Test
+  fun `interaction effect contains an editor-owned failure`() =
+    runTest(StandardTestDispatcher()) {
+      val failure = IllegalStateException("interaction failed")
+      val reported = mutableListOf<Throwable>()
+      val editor =
+        Editor(
+          inner = FakeFfiEditor(beforeEnqueueRequest = { throw failure }),
+          scope = this,
+          dispatcher = StandardTestDispatcher(testScheduler),
+          onError = { _, error -> reported += error },
+        )
+      val scope = EditorInteractionScope(coroutineScope = this)
+      updateScope(scope = scope, editor = editor, editing = { true })
+
+      scope.launchInteraction {
+        editor.update { enqueue(Message.Selection(SelectionOp.SetAt(page = 0, x = 0f, y = 0f))) }
+      }
+      advanceUntilIdle()
+
+      assertTrue(editor.terminal)
+      val reportedFailure = reported.single()
+      assertSame(failure, reportedFailure.cause ?: reportedFailure)
+    }
+
   @Test
   fun `geometry reads the bundle accepted after the latest scope update`() =
     runTest(StandardTestDispatcher()) {
@@ -235,6 +261,27 @@ class EditorInteractionScopeTest {
         )
       val editor =
         Editor(fake, this, StandardTestDispatcher(testScheduler)).also { fake.publishSnapshot(it) }
+      var frameKey: FrameKey? = null
+      val surface =
+        editor.attachSurface(
+          page = 0,
+          handle = 1L,
+          width = 400.0,
+          height = 700.0,
+          scaleFactor = 1.0,
+          wakeDelivery = { frameKey = it },
+        )
+      editor.requestSurfacePages(setOf(0))
+      advanceUntilIdle()
+      editor.deliverFrame(
+        session = surface,
+        bitmap = ImageBitmap(width = 400, height = 700),
+        pixelSize = IntSize(width = 400, height = 700),
+        editorRevision = editor.appliedState.version,
+        frameKey = assertNotNull(frameKey).value,
+      )
+      advanceUntilIdle()
+      assertTrue(editor.acceptPublication(assertNotNull(editor.publishIfReady(setOf(0)))))
       val uiState =
         EditorUiState().apply {
           updateInteractionSurfaceBounds(
@@ -280,6 +327,8 @@ class EditorInteractionScopeTest {
         position = Offset(10f, 20f),
       )
       advanceUntilIdle()
+      assertTrue(editor.acceptPublication(assertNotNull(editor.publishIfReady(setOf(0)))))
+      scope.onEditorStateChanged()
 
       assertTrue(editing)
       assertEquals(

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/semantics/EditorTableColumnResizeSemanticTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/semantics/EditorTableColumnResizeSemanticTest.kt
@@ -1,18 +1,29 @@
 package co.typie.editor.interaction.semantics
 
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.unit.IntSize
 import co.typie.editor.Editor
 import co.typie.editor.FakeFfiEditor
 import co.typie.editor.ffi.Alignment
+import co.typie.editor.ffi.EditorEvent
+import co.typie.editor.ffi.FrameKey
 import co.typie.editor.ffi.Rect as FfiRect
+import co.typie.editor.ffi.Size
 import co.typie.editor.ffi.TableBorderStyle
 import co.typie.editor.ffi.TableOverlay
 import co.typie.editor.ffi.TableOverlayColumn
 import kotlin.test.Test
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 
 class EditorTableColumnResizeSemanticTest {
@@ -54,6 +65,57 @@ class EditorTableColumnResizeSemanticTest {
 
     assertTrue(fake.enqueued.isEmpty())
   }
+
+  @Test
+  fun `unavailable surface clears the committed draft without escaping the interaction`() =
+    runTest {
+      val dispatcher = StandardTestDispatcher(testScheduler)
+      val uncaught = mutableListOf<Throwable>()
+      val editorScope =
+        CoroutineScope(
+          SupervisorJob() + dispatcher + CoroutineExceptionHandler { _, error -> uncaught += error }
+        )
+      val fake =
+        FakeFfiEditor(
+          onTick = { listOf(EditorEvent.RenderInvalidated) },
+          pageSizesProvider = { listOf(Size(width = 100f, height = 100f)) },
+        )
+      val editor = Editor(fake, editorScope, dispatcher)
+      val semantic = EditorTableColumnResizeSemantic()
+      var pendingFrameKey: FrameKey? = null
+
+      try {
+        editor.activateVisualHost(Any())
+        val session =
+          editor.attachSurface(0, 10L, 100.0, 100.0, 1.0) { frameKey -> pendingFrameKey = frameKey }
+        editor.requestSurfacePages(setOf(0))
+        advanceUntilIdle()
+        editor.deliverFrame(
+          session = session,
+          bitmap = ImageBitmap(width = 100, height = 100),
+          pixelSize = IntSize(width = 100, height = 100),
+          editorRevision = 0L,
+          frameKey = requireNotNull(pendingFrameKey).value,
+        )
+        advanceUntilIdle()
+        pendingFrameKey = null
+
+        semantic.press(editor, columnResizePlacement())
+        assertTrue(semantic.start())
+        semantic.update(5f)
+        semantic.end()
+        advanceUntilIdle()
+
+        editor.surfaceTargetUnavailable(session, requireNotNull(pendingFrameKey))
+        advanceUntilIdle()
+
+        assertTrue(uncaught.isEmpty())
+        assertFalse(editor.terminal)
+        assertNull(semantic.presentation.draft)
+      } finally {
+        editorScope.cancel()
+      }
+    }
 
   private fun columnResizePlacement(): EditorTableColumnResizePlacement {
     val overlay =

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/runtime/EditorRuntimeTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/runtime/EditorRuntimeTest.kt
@@ -2,6 +2,7 @@ package co.typie.editor.runtime
 
 import co.typie.editor.DocumentEditingSession
 import co.typie.editor.Editor
+import co.typie.editor.EditorFailureSignal
 import co.typie.editor.FakeFfiEditor
 import co.typie.editor.sync.createTestDocumentEditingSession
 import kotlin.test.Test
@@ -128,5 +129,16 @@ class EditorRuntimeTest {
 
     assertNull(runtime.failure)
     assertNull(runtime.failedEditor)
+  }
+
+  @Test
+  fun editorFailureSignalPublishesItsOriginalFailure() = runTest {
+    val runtime = EditorRuntime(uiScope = this)
+    val failure = IllegalStateException("fatal editor failure")
+
+    runtime.fail(EditorFailureSignal(failure))
+    runCurrent()
+
+    assertSame(failure, runtime.failure)
   }
 }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/sync/RemoteChangesetPipelineTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/sync/RemoteChangesetPipelineTest.kt
@@ -1,15 +1,20 @@
 package co.typie.editor.sync
 
+import co.typie.editor.Editor
+import co.typie.editor.FakeFfiEditor
 import co.typie.editor.sync.ws.SyncWsException
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runCurrent
@@ -227,6 +232,84 @@ class RemoteChangesetPipelineTest {
     assertContentEquals(enc(9), sink.confirmed.last())
     assertContentEquals(enc(4), sink.durable.last())
     pipeline.stop()
+  }
+
+  @Test
+  fun failedEditorApplyDoesNotAdvanceCursorOrHeads() = runTest {
+    val failure = IllegalStateException("remote apply failed")
+    val reported = mutableListOf<Throwable>()
+    val editor =
+      Editor(
+        inner = FakeFfiEditor(receiveRemoteChangesetProvider = { throw failure }),
+        scope = this,
+        dispatcher = StandardTestDispatcher(testScheduler),
+        onError = { _, error -> reported += error },
+      )
+    val transport = FakeTransport()
+    val sink = RecordingHeadsSink()
+    val pipeline =
+      RemoteChangesetPipeline(
+        editor = editor.asSyncEditor(),
+        headsSink = sink,
+        transport = transport,
+        initialSeq = "s1",
+        scope = CoroutineScope(coroutineContext),
+        onNeedsReload = {},
+      )
+    transport.pullResult =
+      PullResult(
+        changesets = listOf(enc(7)),
+        seq = "s2",
+        heads = enc(7),
+        durableHeads = enc(3),
+        needsReload = false,
+      )
+
+    pipeline.refetchFromServer()
+    runCurrent()
+
+    assertSame(failure, reported.single())
+    assertTrue(sink.confirmed.isEmpty())
+    assertTrue(sink.durable.isEmpty())
+
+    transport.pullResult =
+      PullResult(
+        changesets = emptyList(),
+        seq = "",
+        heads = enc(),
+        durableHeads = enc(),
+        needsReload = true,
+      )
+    pipeline.refetchFromServer()
+
+    assertEquals(listOf<String?>("s1", "s1"), transport.pullCalls)
+  }
+
+  @Test
+  fun editorBatchBoundaryContainsFailureAndStops() = runTest {
+    val failure = IllegalStateException("remote apply failed")
+    val reported = mutableListOf<Throwable>()
+    var attempts = 0
+    val editor =
+      Editor(
+        inner =
+          FakeFfiEditor(
+            receiveRemoteChangesetProvider = {
+              attempts += 1
+              throw failure
+            }
+          ),
+        scope = this,
+        dispatcher = StandardTestDispatcher(testScheduler),
+        onError = { _, error -> reported += error },
+      )
+
+    val completed = editor.applyRemoteChangesets(listOf(enc(1), enc(2)))
+    runCurrent()
+
+    assertFalse(completed)
+    assertEquals(1, attempts)
+    assertSame(failure, reported.single())
   }
 
   @Test

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/document/bodysettings/DocumentBodySettingsSyncTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/document/bodysettings/DocumentBodySettingsSyncTest.kt
@@ -29,7 +29,10 @@ import co.typie.ui.component.editorsettings.toEditorStyleSettings
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -157,6 +160,31 @@ class DocumentBodySettingsSyncTest {
 
     pipeline?.stop()
     editor.dispose()
+  }
+
+  @Test
+  fun failedBootstrapApplyDoesNotStartLiveOrAdvanceBaseline() = runTest {
+    val initialBaseline =
+      DocumentSyncBaseline(seq = "1-0", heads = byteArrayOf(1), durableHeads = byteArrayOf(1))
+    val load = DocumentBodySettingsLoad(graph = byteArrayOf(0), baseline = initialBaseline)
+    val failure = IllegalStateException("remote apply failed")
+    var started = false
+    assertTrue(load.queue(changesetsEvent(seq = "2-0", value = 2)))
+
+    val thrown =
+      assertFailsWith<IllegalStateException> {
+        load.activate(apply = { throw failure }, startLive = { started = true })
+      }
+
+    assertSame(failure, thrown)
+    assertFalse(started)
+
+    var recoveredBaseline: DocumentSyncBaseline? = null
+    load.activate(apply = {}, startLive = { recoveredBaseline = it })
+
+    assertEquals("1-0", recoveredBaseline?.seq)
+    assertContentEquals(byteArrayOf(1), recoveredBaseline?.heads)
+    assertContentEquals(byteArrayOf(1), recoveredBaseline?.durableHeads)
   }
 
   @Test

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/attachment/DefaultEditorAttachmentImporterTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/attachment/DefaultEditorAttachmentImporterTest.kt
@@ -33,7 +33,6 @@ import co.typie.platform.IncomingContentItem
 import co.typie.platform.PickedFile
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -808,6 +807,61 @@ class DefaultEditorAttachmentImporterTest {
   }
 
   @Test
+  fun editorFailureAfterUploadPreventsCacheAndCommitAndClearsOwnership() = runTest {
+    var released = false
+    val nodeId = "image-node"
+    lateinit var fake: FakeFfiEditor
+    fake =
+      FakeFfiEditor(
+        onTick = {
+          listOf(
+            EditorEvent.StateChanged(fields = listOf(StateField.ExternalElements)),
+            EditorEvent.AttachmentPlaceholdersInserted(
+              requestId = requestedPlaceholderId(fake),
+              nodeIds = listOf(nodeId),
+            ),
+          )
+        },
+        externalElementsProvider = { listOf(emptyImageElement(nodeId)) },
+      )
+    val editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
+    val session = createTestDocumentEditingSession(editor, this)
+    val state = EditorExternalElementState()
+    val importer =
+      DefaultEditorAttachmentImporter(
+        externalElementState = state,
+        bringIntoViewRequests = EditorBringIntoViewRequests(),
+        persistence =
+          object : EditorAttachmentPersistence by FakePersistence {
+            override suspend fun persistImage(file: PickedFile): EditorImageAsset {
+              editor.fail(IllegalStateException("editor failed"))
+              return FakePersistence.persistImage(file)
+            }
+          },
+        isSessionCurrent = { it === session },
+        backgroundScope = this,
+      )
+
+    val callbackInvocations = mutableListOf<Int>()
+    val accepted =
+      importer.import(
+        session = session,
+        items = listOf(imageItem { released = true }),
+        destination = EditorAttachmentDestination.CurrentSelection,
+        onCompleted = { importedCount -> callbackInvocations += importedCount },
+      )
+
+    assertTrue(accepted)
+    advanceUntilIdle()
+    assertTrue(editor.terminal)
+    assertEquals(listOf(0), callbackInvocations)
+    assertTrue(released)
+    assertNull(state.images.uploads[nodeId])
+    assertTrue(state.images.assets.isEmpty())
+    assertFalse(fake.enqueued.any { it is Message.Node })
+  }
+
+  @Test
   fun placeholderRemovedDuringUploadPreventsCommitAndClosesFile() = runTest {
     var placeholderExists = true
     var placeholderRequestHandled = false
@@ -964,18 +1018,117 @@ class DefaultEditorAttachmentImporterTest {
 
   @Test
   fun duplicatePlaceholderResultsFailEditorExactlyOnceAndCloseFiles() = runTest {
-    assertTerminalPlaceholderInvariant(
+    assertPlaceholderMappingRejected(
       itemCount = 1,
       nodeIdResults = listOf(listOf("first-node"), listOf("second-node")),
+      terminal = true,
     )
   }
 
   @Test
   fun placeholderCountMismatchFailsEditorExactlyOnceAndClosesFiles() = runTest {
-    assertTerminalPlaceholderInvariant(
+    assertPlaceholderMappingRejected(
       itemCount = 2,
       nodeIdResults = listOf(listOf("only-one-node")),
+      terminal = true,
     )
+  }
+
+  @Test
+  fun duplicatePlaceholderNodeIdsFailEditorExactlyOnceAndCloseFiles() = runTest {
+    assertPlaceholderMappingRejected(
+      itemCount = 2,
+      nodeIdResults = listOf(listOf("same-node", "same-node")),
+      terminal = true,
+    )
+  }
+
+  @Test
+  fun unavailablePlaceholderRejectsImportBeforePendingOrPersistence() = runTest {
+    assertPlaceholderMappingRejected(itemCount = 1, nodeIdResults = listOf(listOf("missing-node")))
+  }
+
+  @Test
+  fun wrongKindPlaceholderRejectsImportBeforePendingOrPersistence() = runTest {
+    val nodeId = "file-node"
+    assertPlaceholderMappingRejected(
+      itemCount = 1,
+      nodeIdResults = listOf(listOf(nodeId)),
+      externalElementsProvider = { listOf(emptyFileElement(nodeId)) },
+    )
+  }
+
+  @Test
+  fun receiptCannotReuseExistingPlaceholderForAnotherItem() = runTest {
+    val existingNodeId = "existing-node"
+    var releasedCount = 0
+    var persistenceCount = 0
+    val reported = mutableListOf<Throwable>()
+    lateinit var fake: FakeFfiEditor
+    fake =
+      FakeFfiEditor(
+        onTick = {
+          if (fake.placeholderRequests().isEmpty()) {
+            emptyList()
+          } else {
+            listOf(
+              EditorEvent.AttachmentPlaceholdersInserted(
+                requestId = requestedPlaceholderId(fake),
+                nodeIds = listOf(existingNodeId),
+              )
+            )
+          }
+        },
+        externalElementsProvider = { listOf(emptyImageElement(existingNodeId)) },
+      )
+    val editor =
+      Editor(
+        fake,
+        this,
+        StandardTestDispatcher(testScheduler),
+        onError = { _, error -> reported += error },
+      )
+    fake.applySnapshot(editor)
+    val session = createTestDocumentEditingSession(editor, this)
+    val state = EditorExternalElementState()
+    val importer =
+      DefaultEditorAttachmentImporter(
+        externalElementState = state,
+        bringIntoViewRequests = EditorBringIntoViewRequests(),
+        persistence =
+          object : EditorAttachmentPersistence by FakePersistence {
+            override suspend fun persistImage(file: PickedFile): EditorImageAsset {
+              persistenceCount += 1
+              return FakePersistence.persistImage(file)
+            }
+          },
+        isSessionCurrent = { it === session },
+        backgroundScope = this,
+      )
+    val callbackInvocations = mutableListOf<Int>()
+
+    val accepted =
+      importer.import(
+        session = session,
+        items =
+          List(2) { index -> imageItem(filename = "image-$index.png") { releasedCount += 1 } },
+        destination =
+          EditorAttachmentDestination.ExistingPlaceholder(
+            nodeId = existingNodeId,
+            expectedKind = IncomingContentItem.Kind.Image,
+          ),
+        onCompleted = { importedCount -> callbackInvocations += importedCount },
+      )
+    advanceUntilIdle()
+
+    assertFalse(accepted)
+    assertTrue(editor.terminal)
+    assertEquals(1, reported.size)
+    assertTrue(reported.single() is IllegalStateException)
+    assertTrue(state.images.uploads.isEmpty())
+    assertEquals(0, persistenceCount)
+    assertEquals(2, releasedCount)
+    assertEquals(listOf(0), callbackInvocations)
   }
 
   @Test
@@ -1118,9 +1271,11 @@ class DefaultEditorAttachmentImporterTest {
     }
   }
 
-  private suspend fun TestScope.assertTerminalPlaceholderInvariant(
+  private suspend fun TestScope.assertPlaceholderMappingRejected(
     itemCount: Int,
     nodeIdResults: List<List<String>>,
+    externalElementsProvider: () -> List<ExternalElement> = { emptyList() },
+    terminal: Boolean = false,
   ) {
     var releasedCount = 0
     var persistenceCount = 0
@@ -1132,14 +1287,16 @@ class DefaultEditorAttachmentImporterTest {
           if (fake.placeholderRequests().isEmpty()) {
             emptyList()
           } else {
-            nodeIdResults.map { nodeIds ->
-              EditorEvent.AttachmentPlaceholdersInserted(
-                requestId = requestedPlaceholderId(fake),
-                nodeIds = nodeIds,
-              )
-            }
+            listOf(EditorEvent.StateChanged(fields = listOf(StateField.ExternalElements))) +
+              nodeIdResults.map { nodeIds ->
+                EditorEvent.AttachmentPlaceholdersInserted(
+                  requestId = requestedPlaceholderId(fake),
+                  nodeIds = nodeIds,
+                )
+              }
           }
-        }
+        },
+        externalElementsProvider = externalElementsProvider,
       )
     val dispatcher = StandardTestDispatcher(testScheduler)
     val editorScope = CoroutineScope(SupervisorJob() + dispatcher)
@@ -1160,29 +1317,34 @@ class DefaultEditorAttachmentImporterTest {
         backgroundScope = this,
       )
 
-    lateinit var thrown: IllegalStateException
+    val callbackInvocations = mutableListOf<Int>()
     try {
-      thrown =
-        assertFailsWith<IllegalStateException> {
-          importer.import(
-            session = session,
-            items =
-              List(itemCount) { index ->
-                imageItem(filename = "image-$index.png") { releasedCount += 1 }
-              },
-            destination = EditorAttachmentDestination.CurrentSelection,
-            onCompleted = {},
-          )
-        }
+      val accepted =
+        importer.import(
+          session = session,
+          items =
+            List(itemCount) { index ->
+              imageItem(filename = "image-$index.png") { releasedCount += 1 }
+            },
+          destination = EditorAttachmentDestination.CurrentSelection,
+          onCompleted = { importedCount -> callbackInvocations += importedCount },
+        )
+      advanceUntilIdle()
+
+      assertFalse(accepted)
+      assertEquals(terminal, editor.terminal)
+      if (terminal) {
+        assertEquals(1, reported.size)
+        assertTrue(reported.single() is IllegalStateException)
+      } else {
+        assertTrue(reported.isEmpty())
+      }
+      assertEquals(0, persistenceCount)
+      assertEquals(itemCount, releasedCount)
+      assertEquals(listOf(0), callbackInvocations)
     } finally {
       editorScope.cancel()
     }
-
-    assertTrue(editor.terminal)
-    assertEquals(1, reported.size)
-    assertTrue(thrown === reported.single())
-    assertEquals(0, persistenceCount)
-    assertEquals(itemCount, releasedCount)
   }
 
   private fun requestedPlaceholderId(fake: FakeFfiEditor?): String {

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/state/EditorScreenStateTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/state/EditorScreenStateTest.kt
@@ -2,15 +2,22 @@ package co.typie.screen.editor.editor.state
 
 import androidx.compose.runtime.BroadcastFrameClock
 import androidx.compose.ui.geometry.Size
+import co.typie.editor.Editor
+import co.typie.editor.FakeFfiEditor
 import co.typie.editor.runtime.EditorRuntime
 import co.typie.editor.runtime.EditorUiState
 import co.typie.editor.viewport.EditorViewportState
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 
@@ -57,6 +64,32 @@ class EditorScreenStateTest {
   }
 
   @Test
+  fun `leaving the foreground contains an editor admission failure at the scene callback`() =
+    runTest {
+      val failure = IllegalStateException("admission failed")
+      val runtime = EditorRuntime(uiScope = this)
+      val editor =
+        Editor(
+          inner = FakeFfiEditor(beforeEnqueueRequest = { throw failure }),
+          scope = this,
+          dispatcher = StandardTestDispatcher(testScheduler),
+          onError = { activeEditor, error -> runtime.fail(activeEditor, error) },
+        )
+      runtime.attach(editor)
+      val state = EditorScreenState(viewportState = EditorViewportState())
+
+      state.updateSceneForeground(
+        isForeground = false,
+        runtime = runtime,
+        uiState = EditorUiState(),
+      )
+      advanceUntilIdle()
+
+      assertFalse(state.sceneInForeground)
+      assertSame(failure, runtime.failure)
+    }
+
+  @Test
   fun `prepareToLeaveEditorScene waits for header flush before returning`() = runTest {
     val state = EditorScreenState(viewportState = EditorViewportState())
     val runtime = EditorRuntime(uiScope = this)
@@ -87,4 +120,38 @@ class EditorScreenStateTest {
 
     leaveJob.join()
   }
+
+  @Test
+  fun `preparing to leave contains an editor admission failure and still flushes the header`() =
+    runTest {
+      val failure = IllegalStateException("admission failed")
+      val runtime = EditorRuntime(uiScope = this)
+      val editor =
+        Editor(
+          inner = FakeFfiEditor(beforeEnqueueRequest = { throw failure }),
+          scope = this,
+          dispatcher = StandardTestDispatcher(testScheduler),
+          onError = { activeEditor, error -> runtime.fail(activeEditor, error) },
+        )
+      runtime.attach(editor)
+      val state = EditorScreenState(viewportState = EditorViewportState())
+      val frameClock = BroadcastFrameClock()
+      var flushed = false
+
+      val leaveJob =
+        launch(frameClock) {
+          state.prepareToLeaveEditorScene(
+            runtime = runtime,
+            uiState = EditorUiState(),
+            flushDrafts = { flushed = true },
+          )
+        }
+      runCurrent()
+      frameClock.sendFrame(0L)
+      advanceUntilIdle()
+
+      assertTrue(flushed)
+      assertSame(failure, runtime.failure)
+      leaveJob.join()
+    }
 }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/EditorInitializationDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/EditorInitializationDesktopTest.kt
@@ -1,0 +1,54 @@
+package co.typie.editor
+
+import co.typie.editor.ffi.ThemeVariant
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class EditorInitializationDesktopTest {
+  @Test
+  fun createInitialized_propagates_the_original_initialize_failure() = runTest {
+    configureEditorFfiLibrary()
+    val failure = IllegalStateException("initialize failed")
+    val reported = mutableListOf<Throwable>()
+
+    val thrown =
+      assertFailsWith<IllegalStateException> {
+        Editor.createInitialized(
+          scope = this,
+          themeVariant = ThemeVariant.LightWhite,
+          dispatcher = UnconfinedTestDispatcher(testScheduler),
+          onError = { _, error -> reported += error },
+          createInner = { FakeFfiEditor(beforeEnqueueRequest = { throw failure }) },
+        )
+      }
+
+    assertSame(failure, thrown.cause ?: thrown)
+    assertTrue(reported.isEmpty())
+  }
+}
+
+private fun configureEditorFfiLibrary() {
+  if (System.getProperty("jna.library.path") != null) return
+
+  val repository =
+    generateSequence(File(System.getProperty("user.dir"))) { it.parentFile }
+      .firstOrNull { File(it, "Cargo.toml").isFile } ?: error("Typie repository root not found")
+  val host =
+    when (System.getProperty("os.arch")) {
+      "aarch64" -> "aarch64-apple-darwin"
+      "x86_64" -> "x86_64-apple-darwin"
+      else -> error("Unsupported desktop test architecture: ${System.getProperty("os.arch")}")
+    }
+  val directory = File(repository, "target/$host/release-uniffi")
+  check(File(directory, "libeditor_ffi.dylib").isFile) {
+    "Desktop editor FFI is not built; run `just -f crates/editor-ffi/justfile desktop`"
+  }
+  System.setProperty("jna.library.path", directory.absolutePath)
+}

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/input/EditorInputFailureDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/input/EditorInputFailureDesktopTest.kt
@@ -1,0 +1,82 @@
+package co.typie.editor.input
+
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.InterceptPlatformTextInput
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import co.typie.editor.Editor
+import co.typie.editor.FakeFfiEditor
+import co.typie.editor.runtime.EditorUiState
+import co.typie.editor.scroll.rememberEditorBringIntoViewRequests
+import co.typie.editor.sync.createTestDocumentEditingSession
+import co.typie.platform.NoopClipboard
+import co.typie.platform.Platform
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+
+@OptIn(ExperimentalTestApi::class)
+class EditorInputFailureDesktopTest {
+  @Test
+  fun `ime snapshot failure stops the actual platform input session`() = runComposeUiTest {
+    val failure = IllegalStateException("ime snapshot failed")
+    val reported = CompletableDeferred<Throwable>()
+    val fake = FakeFfiEditor(imeProvider = { _, _ -> throw failure })
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val editor = Editor(fake, scope, onError = { _, error -> reported.complete(error) })
+    val session = createTestDocumentEditingSession(editor, scope)
+    val focusRequester = FocusRequester()
+    var inputRequests = 0
+
+    try {
+      setContent {
+        InterceptPlatformTextInput(
+          interceptor = { request, nextHandler ->
+            inputRequests += 1
+            nextHandler.startInputMethod(request)
+          }
+        ) {
+          val bringIntoViewRequests = rememberEditorBringIntoViewRequests()
+          Box(
+            Modifier.size(200.dp)
+              .focusRequester(focusRequester)
+              .editorInput(
+                session = session,
+                uiState = EditorUiState(),
+                platform = Platform.Desktop,
+                bringIntoViewRequests = bringIntoViewRequests,
+                enabled = true,
+                suppressSoftwareKeyboard = false,
+                clipboard = NoopClipboard,
+              )
+              .focusable()
+          )
+        }
+      }
+      waitForIdle()
+      runOnIdle { assertTrue(focusRequester.requestFocus()) }
+      waitUntil(timeoutMillis = 5_000) { reported.isCompleted }
+
+      assertSame(failure, reported.await())
+      runOnIdle {
+        assertTrue(editor.terminal)
+        assertEquals(0, inputRequests)
+      }
+    } finally {
+      session.stop()
+      scope.cancel()
+    }
+  }
+}

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/preview/EditorPreviewDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/preview/EditorPreviewDesktopTest.kt
@@ -28,6 +28,8 @@ import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import kotlinx.coroutines.CoroutineScope
@@ -37,6 +39,52 @@ import kotlinx.coroutines.cancel
 
 @OptIn(ExperimentalTestApi::class)
 class EditorPreviewDesktopTest {
+  @Test
+  fun graphPreviewRoutesInitializationFailureToItsRuntime() = runComposeUiTest {
+    configureRenderBufferLibrary()
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+    val runtime = EditorRuntime(scope)
+    val liveEditor = Editor(FakeFfiEditor(), scope, Dispatchers.Unconfined)
+    val liveRuntime = EditorRuntime(scope).apply { attach(liveEditor) }
+
+    try {
+      setContent {
+        CompositionLocalProvider(
+          LocalDensity provides Density(1f),
+          LocalThemeMode provides ResolvedThemeMode.Light,
+        ) {
+          EditorPreview(
+            layoutMode = A4Layout,
+            runtime = runtime,
+            modifier = Modifier.size(100.dp),
+            shape = RoundedCornerShape(0.dp),
+            source = EditorPreviewSource.Graph(byteArrayOf(0)),
+          )
+        }
+      }
+
+      waitUntil(timeoutMillis = 10_000) { runtime.failure != null }
+
+      runOnIdle {
+        assertNotNull(runtime.failure)
+        assertNull(runtime.editor)
+        assertNull(liveRuntime.failure)
+        assertSame(liveEditor, liveRuntime.editor)
+      }
+
+      val firstFailure = runtime.failure
+      runOnIdle { runtime.clearFailure() }
+      waitUntil(timeoutMillis = 10_000) {
+        runtime.failure != null && runtime.failure !== firstFailure
+      }
+    } finally {
+      runtime.clear()
+      runtime.clearFailure()
+      liveRuntime.clear()
+      scope.cancel()
+    }
+  }
+
   @Test
   fun pageSizeAndBodySizeChangesPublishCoherentPreviewFrames() = runComposeUiTest {
     configureRenderBufferLibrary()

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceTopBarDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceTopBarDesktopTest.kt
@@ -102,14 +102,14 @@ class FindReplaceTopBarDesktopTest {
       waitForIdle()
 
       onNodeWithText("kr 뀨♡", useUnmergedTree = true).performTouchInput { click() }
-      waitForIdle()
+      waitUntil(timeoutMillis = 5_000L) { pendingFindText != null }
       runOnIdle {
         findText = checkNotNull(pendingFindText)
         pendingFindText = null
       }
       waitForIdle()
       onNodeWithText("kr 뀨♡", useUnmergedTree = true).performTouchInput { click() }
-      waitForIdle()
+      waitUntil(timeoutMillis = 5_000L) { pendingFindText == "아" }
 
       onNode(hasSetTextAction(), useUnmergedTree = true).assertTextEquals("아")
     } finally {

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/toolbar/contextual/ImageResizeSecondaryToolbarDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/toolbar/contextual/ImageResizeSecondaryToolbarDesktopTest.kt
@@ -1,0 +1,160 @@
+package co.typie.screen.editor.editor.toolbar.contextual
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import co.typie.editor.Editor
+import co.typie.editor.FakeFfiEditor
+import co.typie.editor.external.EditorExternalElementState
+import co.typie.editor.external.EditorImageAsset
+import co.typie.editor.external.LocalEditorExternalElementState
+import co.typie.editor.ffi.EditorEvent
+import co.typie.editor.ffi.ExternalElement
+import co.typie.editor.ffi.ExternalElementData
+import co.typie.editor.ffi.FrameKey
+import co.typie.editor.ffi.Rect
+import co.typie.editor.ffi.Size
+import co.typie.editor.ffi.StateField
+import co.typie.editor.runtime.EditorRuntime
+import co.typie.editor.runtime.LocalEditorRuntime
+import co.typie.ui.theme.LightAppShadows
+import co.typie.ui.theme.LightColors
+import co.typie.ui.theme.LocalAppColors
+import co.typie.ui.theme.LocalAppShadows
+import co.typie.ui.theme.LocalThemeMode
+import co.typie.ui.theme.ResolvedThemeMode
+import dev.chrisbanes.haze.blur.HazeBlurStyle
+import dev.chrisbanes.haze.blur.LocalHazeBlurStyle
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+
+@OptIn(ExperimentalTestApi::class)
+class ImageResizeSecondaryToolbarDesktopTest {
+  @Test
+  fun unavailableSurfaceClearsDraftWithoutFailingEditor() = runComposeUiTest {
+    val nodeId = "image-node"
+    val assetId = "image-asset"
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+    var frameKey: FrameKey? = null
+    val fake =
+      FakeFfiEditor(
+        pageSizesProvider = { listOf(Size(width = 400f, height = 700f)) },
+        externalElementsProvider = {
+          listOf(
+            ExternalElement(
+              pageIdx = 0,
+              node = nodeId,
+              bounds = Rect(x = 0f, y = 0f, width = 200f, height = 100f),
+              isSelected = true,
+              data = ExternalElementData.Image(id = assetId, proportion = 50),
+            )
+          )
+        },
+        onTick = {
+          listOf(
+            EditorEvent.StateChanged(listOf(StateField.ExternalElements)),
+            EditorEvent.RenderInvalidated,
+          )
+        },
+      )
+    val editor = Editor(fake, scope, Dispatchers.Unconfined)
+    val runtime = EditorRuntime(scope)
+    val externalState = EditorExternalElementState()
+
+    try {
+      val initialUpdate = fake.applySnapshot(editor)
+      editor.activateVisualHost(Any())
+      val surface =
+        editor.attachSurface(
+          page = 0,
+          handle = 1L,
+          width = 400.0,
+          height = 700.0,
+          scaleFactor = 1.0,
+          wakeDelivery = { frameKey = it },
+        )
+      editor.requestSurfacePages(setOf(0))
+      waitUntil { frameKey != null }
+      editor.deliverFrame(
+        session = surface,
+        bitmap = ImageBitmap(width = 400, height = 700),
+        pixelSize = IntSize(width = 400, height = 700),
+        editorRevision = initialUpdate.revision,
+        frameKey = assertNotNull(frameKey).value,
+      )
+      waitUntil { editor.publishIfReady(setOf(0)) != null }
+      assertTrue(editor.acceptPublication(assertNotNull(editor.publishIfReady(setOf(0)))))
+      runtime.attach(editor)
+      externalState.put(
+        EditorImageAsset(
+          id = assetId,
+          url = "https://example.com/image.png",
+          originalUrl = "https://example.com/original.png",
+          width = 400,
+          height = 200,
+          ratio = 2.0,
+          placeholder = null,
+        )
+      )
+
+      setContent {
+        CompositionLocalProvider(
+          LocalDensity provides Density(1f),
+          LocalAppColors provides LightColors,
+          LocalAppShadows provides LightAppShadows,
+          LocalThemeMode provides ResolvedThemeMode.Light,
+          LocalHazeBlurStyle provides
+            HazeBlurStyle(blurRadius = 20.dp, noiseFactor = 0f, colorEffects = listOf()),
+          LocalEditorRuntime provides runtime,
+          LocalEditorExternalElementState provides externalState,
+        ) {
+          ImageResizeSecondaryToolbar(
+            nodeId = nodeId,
+            onClose = {},
+            modifier = Modifier.testTag(ToolbarTag).size(width = 320.dp, height = 48.dp),
+          )
+        }
+      }
+      waitForIdle()
+      frameKey = null
+
+      onNodeWithTag(ToolbarTag).performMouseInput {
+        moveTo(Offset(x = 90f, y = center.y))
+        press()
+        moveTo(Offset(x = 180f, y = center.y))
+        release()
+      }
+
+      waitUntil { frameKey != null }
+      runOnIdle { assertNotNull(externalState.images.resizeDrafts[nodeId]) }
+      editor.surfaceTargetUnavailable(surface, assertNotNull(frameKey))
+      waitUntil { externalState.images.resizeDrafts[nodeId] == null }
+
+      runOnIdle { assertFalse(editor.terminal) }
+    } finally {
+      runtime.clear()
+      scope.cancel()
+    }
+  }
+
+  private companion object {
+    const val ToolbarTag = "image-resize-secondary-toolbar"
+  }
+}

--- a/apps/website/src/lib/editor-ffi/attachment-importer.test.ts
+++ b/apps/website/src/lib/editor-ffi/attachment-importer.test.ts
@@ -43,7 +43,9 @@ const external = (node: string, kind: AttachmentPlaceholderKind, id?: string) =>
 
 class FakeEditor {
   destroyed = false;
+  failed = false;
   readOnly = false;
+  failure: unknown = undefined;
   externalElements: ReturnType<typeof external>[] = [];
   inflightImages = new Map<string, InflightImage>();
   inflightFiles = new Map<string, InflightFile>();
@@ -52,6 +54,16 @@ class FakeEditor {
   focus = vi.fn();
   updateEventsImpl: () => EditorEvent[] = () => [];
   updateOutcomesImpl: () => CommandOutcome[] = () => [{ type: 'applied' }];
+
+  get terminal() {
+    return this.destroyed || this.failed;
+  }
+
+  fail(error: unknown): void {
+    if (this.terminal) return;
+    this.failure = error;
+    this.failed = true;
+  }
 
   get appliedSnapshot() {
     return { externalElements: this.externalElements };
@@ -183,14 +195,29 @@ describe('attachment receipt mapping', () => {
     });
   });
 
+  it('rejects no matching receipt without failing the editor', () => {
+    const { editor, importer } = createImporter();
+    const onFailure = vi.fn();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(vi.fn());
+    editor.updateEventsImpl = () => [receipt('unrelated-request', ['unrelated-node'])];
+
+    const accepted = importer.importAtSelection(
+      [
+        { file: file('a.png', 'image/png'), kind: 'image' },
+        { file: file('b.png', 'image/png'), kind: 'image' },
+      ],
+      { onFailure },
+    );
+
+    expect(accepted).toBe(false);
+    expect(editor.terminal).toBe(false);
+    expect(editor.inflightImages.size).toBe(0);
+    expect(upload.uploadImageFile).not.toHaveBeenCalled();
+    expect(onFailure).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledExactlyOnceWith(expect.stringContaining('no matching receipt'), expect.any(String));
+  });
+
   it.each([
-    [
-      'no matching receipt',
-      (editor: FakeEditor) => {
-        editor.updateEventsImpl = () => [receipt('unrelated-request', ['unrelated-node'])];
-      },
-      'no matching receipt',
-    ],
     [
       'duplicate matching receipts',
       (editor: FakeEditor) => {
@@ -214,10 +241,9 @@ describe('attachment receipt mapping', () => {
       },
       'duplicate node IDs',
     ],
-  ])('rejects %s without reserving or reporting an upload failure', (_name, configure, diagnostic) => {
+  ])('fails the editor on %s without reserving or reporting an upload failure', (_name, configure, diagnostic) => {
     const { editor, importer } = createImporter();
     const onFailure = vi.fn();
-    const consoleError = vi.spyOn(console, 'error').mockImplementation(vi.fn());
     configure(editor);
 
     const accepted = importer.importAtSelection(
@@ -229,11 +255,11 @@ describe('attachment receipt mapping', () => {
     );
 
     expect(accepted).toBe(false);
+    expect(editor.terminal).toBe(true);
+    expect(editor.failure).toEqual(expect.objectContaining({ message: expect.stringContaining(diagnostic) }));
     expect(editor.inflightImages.size).toBe(0);
     expect(upload.uploadImageFile).not.toHaveBeenCalled();
     expect(onFailure).not.toHaveBeenCalled();
-    expect(consoleError).toHaveBeenCalledOnce();
-    expect(consoleError.mock.calls[0]?.[0]).toEqual(expect.stringContaining(diagnostic));
   });
 
   it('rejects an exact placeholder request outcome even if a matching receipt is present', () => {
@@ -367,9 +393,27 @@ describe('attachment receipt mapping', () => {
     ).toEqual(['existing', 'tail-node']);
   });
 
-  it('rejects a drop receipt that places the reuse candidate anywhere except first', () => {
+  it('fails the editor when a receipt reuses the existing destination for another item', () => {
     const { editor, importer } = createImporter();
-    const consoleError = vi.spyOn(console, 'error').mockImplementation(vi.fn());
+    editor.externalElements.push(external('existing', 'image'));
+    installReceipt(editor, ['existing']);
+
+    const accepted = importer.importAtSelection(
+      [
+        { file: file('first.png', 'image/png'), kind: 'image' },
+        { file: file('second.png', 'image/png'), kind: 'image' },
+      ],
+      { existingNodeId: 'existing', onFailure: vi.fn() },
+    );
+
+    expect(accepted).toBe(false);
+    expect(editor.terminal).toBe(true);
+    expect(editor.failure).toEqual(expect.objectContaining({ message: expect.stringContaining('existing destination node ID') }));
+    expect(editor.inflightImages.size).toBe(0);
+  });
+
+  it('fails the editor when a drop receipt places the reuse candidate anywhere except first', () => {
+    const { editor, importer } = createImporter();
     editor.externalElements.push(external('candidate', 'image'));
     editor.updateEventsImpl = () => {
       const { requestId } = latestRequestFrom(editor);
@@ -386,9 +430,9 @@ describe('attachment receipt mapping', () => {
     );
 
     expect(accepted).toBe(false);
+    expect(editor.terminal).toBe(true);
+    expect(editor.failure).toEqual(expect.objectContaining({ message: expect.stringContaining('reuse candidate') }));
     expect(editor.inflightImages.size + editor.inflightFiles.size).toBe(0);
-    expect(consoleError).toHaveBeenCalledOnce();
-    expect(consoleError.mock.calls[0]?.[0]).toEqual(expect.stringContaining('reuse candidate'));
   });
 
   it.each([
@@ -576,6 +620,7 @@ describe('attachment target lifecycle', () => {
   it.each([
     ['editor replacement', (ctx: FakeContext) => (ctx.editor = new FakeEditor())],
     ['destroy', (_ctx: FakeContext, editor: FakeEditor) => (editor.destroyed = true)],
+    ['failure', (_ctx: FakeContext, editor: FakeEditor) => editor.fail(new Error('failed'))],
     ['read-only transition', (_ctx: FakeContext, editor: FakeEditor) => (editor.readOnly = true)],
     ['node deletion', (_ctx: FakeContext, editor: FakeEditor) => (editor.externalElements = [])],
     ['undo removal', (_ctx: FakeContext, editor: FakeEditor) => (editor.externalElements = [])],

--- a/apps/website/src/lib/editor-ffi/attachment-importer.ts
+++ b/apps/website/src/lib/editor-ffi/attachment-importer.ts
@@ -39,7 +39,7 @@ export class EditorAttachmentImporter {
   }
 
   #isEditorCurrent(editor: Editor): boolean {
-    return this.#ctx.editor === editor && !editor.destroyed && !editor.readOnly;
+    return this.#ctx.editor === editor && !editor.terminal && !editor.readOnly;
   }
 
   #isAvailable(editor: Editor, nodeId: string, kind: AttachmentPlaceholderKind): boolean {
@@ -53,6 +53,10 @@ export class EditorAttachmentImporter {
 
   #pendingMap(editor: Editor, kind: AttachmentPlaceholderKind): Editor['inflightImages'] | Editor['inflightFiles'] {
     return kind === 'image' ? editor.inflightImages : editor.inflightFiles;
+  }
+
+  #failReceiptInvariant(editor: Editor, message: string): void {
+    editor.fail(new Error(message));
   }
 
   #collectReceipt(editor: Editor, requestId: string, enqueue: () => void): string[] | undefined {
@@ -75,25 +79,25 @@ export class EditorAttachmentImporter {
       return undefined;
     }
     if (matches.length > 1) {
-      console.error('Attachment placeholder request emitted duplicate matching receipts.', {
-        requestId,
-        receiptCount: matches.length,
-      });
+      this.#failReceiptInvariant(
+        editor,
+        `Attachment placeholder request emitted duplicate matching receipts: requestId=${requestId}, receiptCount=${matches.length}`,
+      );
       return undefined;
     }
     return matches[0];
   }
 
-  #isExactMapping(nodeIds: readonly string[], expectedCount: number): boolean {
+  #isExactMapping(editor: Editor, nodeIds: readonly string[], expectedCount: number): boolean {
     if (nodeIds.length !== expectedCount) {
-      console.error('Attachment placeholder receipt count mismatch.', {
-        expectedCount,
-        actualCount: nodeIds.length,
-      });
+      this.#failReceiptInvariant(
+        editor,
+        `Attachment placeholder receipt count mismatch: expected=${expectedCount}, actual=${nodeIds.length}`,
+      );
       return false;
     }
     if (new Set(nodeIds).size !== expectedCount) {
-      console.error('Attachment placeholder receipt contains duplicate node IDs.', nodeIds);
+      this.#failReceiptInvariant(editor, 'Attachment placeholder receipt contains duplicate node IDs');
       return false;
     }
     return true;
@@ -279,12 +283,9 @@ export class EditorAttachmentImporter {
           },
         });
       });
-      if (!nodeIds || !this.#isExactMapping(nodeIds, tail.length)) return false;
+      if (!nodeIds || !this.#isExactMapping(editor, nodeIds, tail.length)) return false;
       if (existingNodeId !== undefined && nodeIds.includes(existingNodeId)) {
-        console.error('Attachment placeholder receipt contains the existing destination node ID.', {
-          existingNodeId,
-          nodeIds,
-        });
+        this.#failReceiptInvariant(editor, 'Attachment placeholder receipt contains the existing destination node ID');
         return false;
       }
       for (const [index, item] of tail.entries()) {
@@ -339,12 +340,9 @@ export class EditorAttachmentImporter {
         },
       });
     });
-    if (!nodeIds || !this.#isExactMapping(nodeIds, items.length)) return false;
+    if (!nodeIds || !this.#isExactMapping(editor, nodeIds, items.length)) return false;
     if (reuseCandidate && nodeIds.indexOf(reuseCandidate) > 0) {
-      console.error('Attachment placeholder receipt placed the reuse candidate after the first item.', {
-        reuseNodeId: reuseCandidate,
-        nodeIds,
-      });
+      this.#failReceiptInvariant(editor, 'Attachment placeholder receipt placed the reuse candidate after the first item');
       return false;
     }
 

--- a/apps/website/src/lib/editor-ffi/editor-host-failure.test.ts
+++ b/apps/website/src/lib/editor-ffi/editor-host-failure.test.ts
@@ -11,7 +11,9 @@ const wasmHarness = vi.hoisted(() => ({
   setThemeVariant: vi.fn(() => null),
 }));
 
-vi.mock('@sentry/sveltekit', () => ({ captureException: vi.fn() }));
+const sentryHarness = vi.hoisted(() => ({ captureException: vi.fn() }));
+
+vi.mock('@sentry/sveltekit', () => sentryHarness);
 
 vi.mock('$env/dynamic/public', () => ({ env: {} }));
 
@@ -184,6 +186,7 @@ describe('Editor guarded core invocation', () => {
     frames = [];
     wasmHarness.createEditor.mockReset();
     wasmHarness.setThemeVariant.mockReset().mockReturnValue(null);
+    sentryHarness.captureException.mockReset();
     vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
       frames.push((time) => {
         callback(time);
@@ -205,6 +208,31 @@ describe('Editor guarded core invocation', () => {
     await expect(Editor.createFromDoc({} as never, { width: 1, height: 1, scale_factor: 1 })).rejects.toBe(error);
 
     expect(core.free).toHaveBeenCalledTimes(1);
+    expect(snapshot()).toEqual([]);
+  });
+
+  it('reports the first terminal failure exactly once', async () => {
+    const { editor } = await createEditor();
+    const failure = new Error('terminal failure');
+
+    editor.fail(failure);
+    editor.fail(new Error('later failure'));
+
+    expect(sentryHarness.captureException).toHaveBeenCalledOnce();
+    expect(sentryHarness.captureException).toHaveBeenCalledWith(failure);
+  });
+
+  it('still contains the editor when terminal failure reporting throws', async () => {
+    const { editor, core } = await createEditor();
+    const failure = new Error('terminal failure');
+    sentryHarness.captureException.mockImplementationOnce(() => {
+      throw new Error('reporting failed');
+    });
+
+    editor.fail(failure);
+
+    expect(editor.failure).toBe(failure);
+    expect(core.free).toHaveBeenCalledOnce();
     expect(snapshot()).toEqual([]);
   });
 
@@ -271,6 +299,8 @@ describe('Editor guarded core invocation', () => {
   it('rejects an admitted async update when its before-publish callback fails', async () => {
     const { editor, core } = await createEditor();
     const error = new Error('before publish failed');
+    const cleanupFailure = new Error('before publish cleanup failed');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(vi.fn());
     core.tick.mockReturnValue({
       revision: { value: 2 },
       events: [],
@@ -279,15 +309,100 @@ describe('Editor guarded core invocation', () => {
 
     const update = editor.update((request) => {
       request.enqueue({ type: 'history', op: { type: 'undo' } });
-      request.beforePublish(() => {
-        throw error;
-      });
+      request.beforePublish(
+        () => {
+          throw error;
+        },
+        () => {
+          throw cleanupFailure;
+        },
+      );
     });
 
     frames.at(-1)?.(0);
 
     await expect(update).rejects.toBe(error);
     expect(editor.failure).toBe(error);
+    expect(consoleError).toHaveBeenCalledWith('Editor request cleanup failed:', cleanupFailure);
+  });
+
+  it('rejects every request from a tick when a later before-publish callback fails', async () => {
+    const { editor, core } = await createEditor();
+    const error = new Error('later before publish failed');
+    core.enqueue_request.mockReturnValueOnce({ value: 1 }).mockReturnValueOnce({ value: 2 });
+    core.tick.mockReturnValue({
+      revision: { value: 2 },
+      events: [],
+      request_outcomes: [
+        { request_id: { value: 1 }, command_outcomes: [{ type: 'applied' }] },
+        { request_id: { value: 2 }, command_outcomes: [{ type: 'applied' }] },
+      ],
+    });
+
+    const first = editor.update((request) => {
+      request.enqueue({ type: 'history', op: { type: 'undo' } });
+    });
+    const second = editor.update((request) => {
+      request.enqueue({ type: 'history', op: { type: 'undo' } });
+      request.beforePublish(() => {
+        throw error;
+      });
+    });
+    const assertions = Promise.all([expect(first).rejects.toBe(error), expect(second).rejects.toBe(error)]);
+
+    frames.at(-1)?.(0);
+
+    await assertions;
+    expect(editor.failure).toBe(error);
+  });
+
+  it('rejects a terminal receipt even when its discard hook fails', async () => {
+    const { editor } = await createEditor();
+    const failure = new Error('terminal failure');
+    const cleanupFailure = new Error('discard failed');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {
+      throw new Error('cleanup reporting failed');
+    });
+    const update = editor.update((request) => {
+      request.enqueue({ type: 'history', op: { type: 'undo' } });
+      request.beforePublish(vi.fn(), () => {
+        throw cleanupFailure;
+      });
+    });
+    const rejection = expect(update).rejects.toBe(failure);
+
+    editor.fail(failure);
+
+    await rejection;
+    expect(editor.failure).toBe(failure);
+    expect(consoleError).toHaveBeenCalledWith('Editor request cleanup failed:', cleanupFailure);
+  });
+
+  it('keeps an admitted receipt pending until surface reconciliation completes', async () => {
+    const { editor, core } = await createEditor();
+    const error = new Error('surface replacement failed');
+    const releaseHost = editor.activateVisualHost();
+    editor.attachSurface(0, document.createElement('canvas'), 100, 100, () => {
+      throw error;
+    });
+    core.page_sizes.mockReturnValue([{ width: 100, height: 120 }, ...DefaultPageSizes.slice(1)]);
+    core.page_backing_sizes.mockReturnValue([{ width: 100, height: 120 }, ...DefaultPageSizes.slice(1)]);
+    core.tick.mockReturnValue({
+      revision: { value: 2 },
+      events: [{ type: 'state_changed', fields: ['page_sizes'] }],
+      request_outcomes: [{ request_id: { value: 1 }, command_outcomes: [{ type: 'applied' }] }],
+    });
+
+    const update = editor.update((request) => {
+      request.enqueue({ type: 'history', op: { type: 'undo' } });
+    });
+    const rejection = expect(update).rejects.toBe(error);
+
+    frames.at(-1)?.(0);
+
+    await rejection;
+    expect(editor.failure).toBe(error);
+    releaseHost();
   });
 
   it('does not complete publication waiters until the accepted bundle is presented', async () => {

--- a/apps/website/src/lib/editor-ffi/editor-update.ts
+++ b/apps/website/src/lib/editor-ffi/editor-update.ts
@@ -35,7 +35,7 @@ export class EditorRequest {
     try {
       block?.(update);
     } catch (err) {
-      onDiscard?.();
+      runCleanupPreservingFailure(err, () => onDiscard?.());
       throw err;
     }
   }
@@ -47,6 +47,10 @@ export class EditorRequest {
     onDiscard?.();
   }
 
+  discardAfterFailure(error: unknown): void {
+    runCleanupPreservingFailure(error, () => this.discard());
+  }
+
   removeMessagesWhere(predicate: (message: Message) => boolean): boolean {
     const retained = this.#messages.filter((message) => !predicate(message));
     if (retained.length === this.#messages.length) return false;
@@ -56,6 +60,19 @@ export class EditorRequest {
 
   get empty(): boolean {
     return this.#messages.length === 0;
+  }
+}
+
+function runCleanupPreservingFailure(error: unknown, cleanup: () => void): void {
+  try {
+    cleanup();
+  } catch (err) {
+    if (err === error) return;
+    try {
+      console.error('Editor request cleanup failed:', err);
+    } catch {
+      // Cleanup reporting must not replace the original failure.
+    }
   }
 }
 

--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -702,6 +702,7 @@ export class Editor {
     this.#applied = this.#materializeSnapshot(result.revision.value, fields);
     const publicEvents = result.events.filter((event) => event.type !== 'state_changed' && event.type !== 'render_invalidated');
 
+    const completedReceiptIds: number[] = [];
     const completedReceipts: { receipt: UpdateReceipt; update: EditorUpdate }[] = [];
     for (const outcome of result.request_outcomes) {
       const receipt = this.#receipts.get(outcome.request_id.value);
@@ -710,7 +711,7 @@ export class Editor {
         this.#awaitPublished(result.revision.value, signal),
       );
       receipt.request.runBeforePublish(update);
-      this.#receipts.delete(outcome.request_id.value);
+      completedReceiptIds.push(outcome.request_id.value);
       completedReceipts.push({ receipt, update });
     }
 
@@ -732,6 +733,7 @@ export class Editor {
 
     for (const waiter of this.#appliedWaiters) waiter.resolve(result.revision.value);
     this.#appliedWaiters.clear();
+    for (const requestId of completedReceiptIds) this.#receipts.delete(requestId);
     for (const { receipt, update } of completedReceipts) {
       receipt.resolve(update);
     }
@@ -1125,7 +1127,7 @@ export class Editor {
     try {
       build(request);
     } catch (err) {
-      request.discard();
+      request.discardAfterFailure(err);
       throw err;
     } finally {
       this.#admission = undefined;
@@ -1714,7 +1716,7 @@ export class Editor {
       try {
         return this.#invokeCore((core) => core.enqueue_request([...request.messages]));
       } catch (err) {
-        request.discard();
+        request.discardAfterFailure(err);
         throw err;
       }
     })();
@@ -1762,7 +1764,7 @@ export class Editor {
       if (receiptFailure) throw receiptFailure.error;
       if (!update) throw new Error(`tickThrough omitted request outcome ${requestId.value}`);
     } catch (err) {
-      request?.discard();
+      request?.discardAfterFailure(err);
       if (admitted && !this.#creationActive) this.fail(err);
       throw err;
     } finally {
@@ -2020,17 +2022,18 @@ export class Editor {
     const reason = error ?? new Error('Editor operation failed');
     this.#failure = reason;
     this.#failed = true;
+    try {
+      Sentry.captureException(reason);
+    } catch {
+      // Telemetry must not interrupt terminal cleanup.
+    }
     // eslint-disable-next-line svelte/prefer-svelte-reactivity -- immutable empty snapshot
     this.surfacePageRequirements = new Set();
     this.#stopRuntime();
     unregister(this);
     for (const receipt of this.#receipts.values()) {
-      try {
-        receipt.request.discard();
-        receipt.reject(reason);
-      } catch {
-        // Failure cleanup must continue even if an internal receipt hook throws.
-      }
+      receipt.request.discardAfterFailure(reason);
+      receipt.reject(reason);
     }
     this.#receipts.clear();
     for (const waiter of this.#appliedWaiters) waiter.reject(reason);
@@ -2650,7 +2653,7 @@ export class Editor {
 
     const disposed = new Error('Editor is disposed');
     for (const receipt of this.#receipts.values()) {
-      receipt.request.discard();
+      receipt.request.discardAfterFailure(disposed);
       receipt.reject(disposed);
     }
     this.#receipts.clear();


### PR DESCRIPTION
## 배경

find/replace 등에서 Editor FFI 호출이 실패하면 failure modal로 전환되기 전에 예외가 Compose callback이나 coroutine 밖으로 빠져 앱이 종료될 수 있었습니다. 일부 경로는 실패를 빈 결과로 처리하거나 pending request와 publication waiter를 남길 수 있었고, Web과 KMP의 terminal failure semantics도 일치하지 않았습니다.

## 변경

- Editor가 최초 core/FFI failure를 보존하고 terminal 상태로 전환하도록 정리했습니다.
- business flow는 즉시 중단하되, 이미 claim된 failure만 framework callback과 effect 경계에서 처리해 앱 크래시를 방지했습니다.
- failure 시 pending request, publication waiter, local edit와 cleanup을 빠짐없이 종료하고 runtime 또는 preview failure modal로 연결했습니다.
- remote changeset, IME, surface, toolbar, find/replace, spellcheck, AI feedback 등 Editor callsite에 동일한 failure contract를 적용했습니다.
- Web도 failure reporting, receipt lifecycle, cleanup과 attachment invariant 처리를 같은 semantics로 맞췄습니다.
- 관련 lifecycle 및 race regression test를 보강했습니다.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>