### PR TITLE
세컨더리 툴바 스와이프 닫기

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarControls.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarControls.kt
@@ -302,11 +302,11 @@ internal fun Modifier.emitPressInteractions(interactionSource: MutableInteractio
 
 @Composable
 internal fun Modifier.toolbarVerticalSwipeGestures(
-  onPointerSessionStart: () -> Unit,
-  onSwipeUp: () -> Unit,
+  onPointerSessionStart: () -> Unit = {},
+  onSwipeUp: () -> Unit = {},
   onSwipeDown: () -> Unit,
-  onSwipeDownProgress: (ToolbarDismissSwipeProgress) -> Unit,
-  onSwipeDownCancelled: () -> Unit,
+  onSwipeDownProgress: (ToolbarDismissSwipeProgress) -> Unit = {},
+  onSwipeDownCancelled: () -> Unit = {},
 ): Modifier {
   val latestOnPointerSessionStart = rememberUpdatedState(onPointerSessionStart)
   val latestOnSwipeUp = rememberUpdatedState(onSwipeUp)

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarPages.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarPages.kt
@@ -1,6 +1,5 @@
 package co.typie.screen.editor.editor.toolbar
 
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.animation.core.animateDpAsState
@@ -20,6 +19,8 @@ import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -44,6 +45,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.unit.IntOffset
@@ -158,10 +160,11 @@ internal fun EditorToolbarPages(
   val toolbarStackHeight by
     animateDpAsState(
       targetValue =
-        ToolbarStackHeight + if (secondaryToolbarInLayout) ToolbarSecondaryStackHeight else 0.dp,
+        ToolbarStackHeight + if (secondaryToolbarVisible) ToolbarSecondaryStackHeight else 0.dp,
       animationSpec = tween(ToolbarSecondaryVisibilityMillis),
       label = "EditorToolbarStackHeight",
     )
+  val secondaryToolbarSlotHeight = (toolbarStackHeight - ToolbarStackHeight).coerceAtLeast(0.dp)
   SideEffect { onSecondaryToolbarInLayoutChange(secondaryToolbarInLayout) }
   DisposableEffect(Unit) { onDispose { onSecondaryToolbarInLayoutChange(false) } }
   val bottomTouchPadding = if (includeBottomGapInTouchArea) ToolbarBottomPadding else 0.dp
@@ -176,20 +179,31 @@ internal fun EditorToolbarPages(
     val hardStopActivationEpsilonPx = with(density) { ToolbarHardStopActivationEpsilon.toPx() }
     val swipeVelocityThresholdPx = with(density) { ToolbarSwipeVelocityThreshold.toPx() }
     var outerEdgeDrag by remember { mutableStateOf(ToolbarOuterEdgeDrag()) }
-    var dismissSwipeProgress by remember { mutableStateOf<ToolbarDismissSwipeProgress?>(null) }
-    var dismissSwipeArmedProgress by remember { mutableStateOf(Animatable(0f)) }
-    val dismissSwipeArmedAnimationJob = remember { mutableStateOf<Job?>(null) }
-    val dismissSwipeFollowOffset =
-      dismissSwipeProgress?.distancePx?.times(ToolbarDismissSwipeFollowFraction) ?: 0f
-    val dismissSwipeDragOffset =
-      dismissSwipeFollowOffset +
-        (dismissSwipeArmedOffsetPx - dismissSwipeFollowOffset) * dismissSwipeArmedProgress.value
-    val dismissSwipeVisualOffset by
+    var primaryDismissSwipeProgress by remember {
+      mutableStateOf<ToolbarDismissSwipeProgress?>(null)
+    }
+    var primaryDismissSwipeArmedProgress by remember { mutableStateOf(Animatable(0f)) }
+    val primaryDismissSwipeArmedAnimationJob = remember { mutableStateOf<Job?>(null) }
+    val primaryDismissSwipeFollowOffset =
+      primaryDismissSwipeProgress?.distancePx?.times(ToolbarDismissSwipeFollowFraction) ?: 0f
+    val primaryDismissSwipeDragOffset =
+      primaryDismissSwipeFollowOffset +
+        (dismissSwipeArmedOffsetPx - primaryDismissSwipeFollowOffset) *
+          primaryDismissSwipeArmedProgress.value
+    val primaryDismissSwipeAnimatedOffset by
       animateFloatAsState(
-        targetValue = if (dismissSwipeProgress != null) dismissSwipeDragOffset else 0f,
-        animationSpec = if (dismissSwipeProgress != null) snap() else ToolbarOverscrollSpring,
-        label = "EditorToolbarDismissSwipeOffset",
+        targetValue =
+          if (primaryDismissSwipeProgress != null) primaryDismissSwipeDragOffset else 0f,
+        animationSpec =
+          if (primaryDismissSwipeProgress != null) snap() else ToolbarOverscrollSpring,
+        label = "EditorToolbarPrimaryDismissSwipeOffset",
       )
+    val primaryDismissSwipeVisualOffset =
+      if (primaryDismissSwipeProgress != null) {
+        primaryDismissSwipeDragOffset
+      } else {
+        primaryDismissSwipeAnimatedOffset
+      }
     val outerEdgeVisualOffset =
       animateFloatAsState(
         targetValue = if (pagerState.pointerScrollGestureActive) outerEdgeDrag.offset else 0f,
@@ -602,222 +616,265 @@ internal fun EditorToolbarPages(
         label = "editor-toolbar-indicator-alpha",
       )
 
-    if (pageCount > 1) {
-      EditorToolbarIndicatorPill(
-        pages = pages,
-        pageProgress = indicatorProgress,
-        animateBackground = pagerState.indicatorInteracting && !pagerState.indicatorDragging,
-        currentPageIndex = currentPageIndex,
-        modifier =
-          Modifier.align(Alignment.TopCenter)
-            .alpha(indicatorAlpha)
-            .then(
-              if (indicatorAlpha > 0.01f) {
-                Modifier.toolbarIndicatorGestures(
-                    pageCount = pageCount,
-                    currentPageIndex = currentPageIndex,
-                    onIndicatorProgress = { progress ->
-                      pagerState.indicatorDragProgress = progress
-                    },
-                    onIndicatorDraggingChange = { dragging ->
-                      pagerState.indicatorDragging = dragging
-                    },
-                    onPageSelected = { page -> navigateToPageIndex(page) },
-                    onInteractionActiveChange = { active ->
-                      pagerState.indicatorInteracting = active
-                      if (!active) {
-                        pagerState.indicatorDragProgress = null
-                        pagerState.indicatorDragging = false
-                      }
-                      pagerState.indicatorPulse++
-                    },
-                  )
-                  .preserveEditorFocusOnToolbarInteraction()
-              } else {
-                Modifier
-              }
-            ),
-      )
-    }
-
-    AnimatedVisibility(
-      visibleState = secondaryToolbarTransition,
-      enter =
-        fadeIn(
-          animationSpec =
-            tween(
-              durationMillis = ToolbarSecondaryVisibilityMillis,
-              delayMillis = ToolbarSecondaryVisibilityMillis,
-            )
-        ),
-      exit = fadeOut(animationSpec = tween(ToolbarSecondaryVisibilityMillis)),
+    Column(
       modifier =
         Modifier.align(Alignment.BottomCenter)
-          .padding(bottom = ToolbarHeight + ToolbarSecondaryGap + bottomTouchPadding)
-          .fillMaxWidth(),
+          .fillMaxWidth()
+          .height(toolbarStackHeight + bottomTouchPadding),
+      horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-      secondaryToolbar()
-    }
-
-    InteractionScope {
-      val toolbarInteractionSource =
-        LocalInteractionSource.current ?: remember { MutableInteractionSource() }
-      val toolbarSurfaceColor = AppTheme.colors.surfaceDefault
-      val toolbarPagerInputModifier =
-        Modifier.emitPressInteractions(toolbarInteractionSource)
-          .trackToolbarScrollGestureStart(
-            onStart = {
-              outerEdgeDrag = ToolbarOuterEdgeDrag(offset = outerEdgeVisualOffset.value)
-              pagerState.pointerScrollGestureActive = true
-              pagerState.scrollGestureStartPosition = pagerState.scrollPosition
-            },
-            onEnd = { pagerState.pointerScrollGestureActive = false },
-          )
-          .scrollable(
-            state = scrollableState,
-            orientation = Orientation.Horizontal,
-            enabled = pageDistance > 0f && pageCount > 1,
-            flingBehavior = flingBehavior,
-            interactionSource = toolbarInteractionSource,
-          )
-          .preserveEditorFocusOnToolbarInteraction()
       Box(
-        modifier =
-          Modifier.align(Alignment.BottomCenter)
-            .fillMaxWidth()
-            .height(ToolbarHeight + bottomTouchPadding)
-            .toolbarVerticalSwipeGestures(
-              onPointerSessionStart = {
-                dismissSwipeArmedAnimationJob.value?.cancel()
-                dismissSwipeArmedAnimationJob.value = null
-                dismissSwipeProgress = null
-                dismissSwipeArmedProgress = Animatable(0f)
-              },
-              onSwipeUp = {
-                if (pageCount > 1) {
-                  pagerState.indicatorPulse++
-                }
-              },
-              onSwipeDown = {
-                dismissSwipeProgress = null
-                onToolbarDismissRequest()
-              },
-              onSwipeDownProgress = { progress ->
-                val armedChanged = (dismissSwipeProgress?.armed == true) != progress.armed
-                dismissSwipeProgress = progress
-                if (armedChanged) {
-                  dismissSwipeArmedAnimationJob.value?.cancel()
-                  val armedProgress = dismissSwipeArmedProgress
-                  dismissSwipeArmedAnimationJob.value = scope.launch {
-                    armedProgress.animateTo(
-                      targetValue = if (progress.armed) 1f else 0f,
-                      animationSpec = ToolbarDismissSwipeThresholdSpring,
-                    )
-                  }
-                  if (progress.armed) {
-                    hapticFeedback.performHapticFeedback(
-                      HapticFeedbackType.GestureThresholdActivate
-                    )
-                  }
-                }
-              },
-              onSwipeDownCancelled = { dismissSwipeProgress = null },
-            )
+        modifier = Modifier.fillMaxWidth().height(ToolbarIndicatorHeight),
+        contentAlignment = Alignment.TopCenter,
       ) {
-        Box(
-          modifier =
-            Modifier.align(Alignment.TopCenter)
-              .fillMaxWidth()
-              .height(ToolbarHeight)
-              .graphicsLayer { translationY = dismissSwipeVisualOffset }
-              .shadow(AppTheme.shadows.sm, ToolbarCapsuleShape)
-              .pressScale(ToolbarCapsulePressedScale)
-              .clip(ToolbarCapsuleShape)
-              .hazeEffect(hazeState) {
-                blurEffect {
-                  backgroundColor = toolbarSurfaceColor
-                  blurRadius = ToolbarBackdropBlurRadius
-                }
-              }
-              .border(ToolbarBorderWidth, AppTheme.colors.borderEmphasis, ToolbarCapsuleShape)
-        ) {
-          EditorToolbarSurfaceBackground(shape = ToolbarCapsuleShape)
+        if (pageCount > 1) {
+          EditorToolbarIndicatorPill(
+            pages = pages,
+            pageProgress = indicatorProgress,
+            animateBackground = pagerState.indicatorInteracting && !pagerState.indicatorDragging,
+            currentPageIndex = currentPageIndex,
+            modifier =
+              Modifier.graphicsLayer { translationY = primaryDismissSwipeVisualOffset }
+                .alpha(indicatorAlpha)
+                .then(
+                  if (indicatorAlpha > 0.01f) {
+                    Modifier.toolbarIndicatorGestures(
+                        pageCount = pageCount,
+                        currentPageIndex = currentPageIndex,
+                        onIndicatorProgress = { progress ->
+                          pagerState.indicatorDragProgress = progress
+                        },
+                        onIndicatorDraggingChange = { dragging ->
+                          pagerState.indicatorDragging = dragging
+                        },
+                        onPageSelected = { page -> navigateToPageIndex(page) },
+                        onInteractionActiveChange = { active ->
+                          pagerState.indicatorInteracting = active
+                          if (!active) {
+                            pagerState.indicatorDragProgress = null
+                            pagerState.indicatorDragging = false
+                          }
+                          pagerState.indicatorPulse++
+                        },
+                      )
+                      .preserveEditorFocusOnToolbarInteraction()
+                  } else {
+                    Modifier
+                  }
+                ),
+          )
+        }
+      }
 
+      Spacer(Modifier.height(ToolbarIndicatorGap))
+
+      Box(
+        Modifier.fillMaxWidth().layout { measurable, constraints ->
+          val contentHeight = ToolbarSecondaryStackHeight.roundToPx()
+          val slotHeight = secondaryToolbarSlotHeight.roundToPx().coerceIn(0, contentHeight)
+          // Keep asynchronous content on final constraints while only the stack slot expands.
+          val placeable =
+            measurable.measure(
+              constraints.copy(minHeight = contentHeight, maxHeight = contentHeight)
+            )
+
+          layout(placeable.width, slotHeight) {
+            placeable.placeRelative(x = 0, y = slotHeight - contentHeight)
+          }
+        }
+      ) {
+        androidx.compose.animation.AnimatedVisibility(
+          visibleState = secondaryToolbarTransition,
+          enter =
+            fadeIn(
+              animationSpec =
+                tween(
+                  durationMillis = ToolbarSecondaryVisibilityMillis,
+                  delayMillis = ToolbarSecondaryVisibilityMillis,
+                )
+            ),
+          exit = fadeOut(animationSpec = tween(ToolbarSecondaryVisibilityMillis)),
+          modifier =
+            Modifier.align(Alignment.BottomCenter).offset(y = -ToolbarSecondaryGap).fillMaxWidth(),
+        ) {
           Box(
-            modifier = Modifier.matchParentSize().clipToBounds().then(toolbarPagerInputModifier)
+            modifier =
+              Modifier.fillMaxWidth()
+                .height(ToolbarSecondaryHeight)
+                .toolbarVerticalSwipeGestures(onSwipeDown = onSecondaryToolbarClear)
           ) {
             Box(
               modifier =
                 Modifier.fillMaxSize().graphicsLayer {
-                  translationX = pagerState.hardStopVisualOffset.value + outerEdgeVisualOffset.value
+                  translationY = primaryDismissSwipeVisualOffset
                 }
             ) {
-              pages.forEachIndexed { index, page ->
-                val pageScope =
-                  EditorToolbarPageScope(
-                    toolbarScope = page.toolbarScope,
-                    activeBottomPanel = activeBottomPanel,
-                    activeSecondaryToolbar = activeSecondaryToolbar,
-                    commandScope = commandScope,
-                    hasNextPage = index < lastPageIndex,
-                    navigateToPage = ::navigateToPage,
-                    onSecondaryToolbarToggle = onSecondaryToolbarToggle,
-                    clearSecondaryToolbar = onSecondaryToolbarClear,
-                    onBottomPanelToggle = onBottomPanelToggle,
-                    sendMessage = onEditorMessage,
-                    performToolAction = onToolAction,
-                  )
+              secondaryToolbar()
+            }
+          }
+        }
+      }
 
-                Box(
-                  modifier =
-                    Modifier.fillMaxSize().offset {
-                      val pageOffset = pageMetrics.pageOffsetFor(index, visualScrollPosition)
-                      IntOffset(x = pageOffset.roundToInt(), y = 0)
+      InteractionScope {
+        val toolbarInteractionSource =
+          LocalInteractionSource.current ?: remember { MutableInteractionSource() }
+        val toolbarSurfaceColor = AppTheme.colors.surfaceDefault
+        val toolbarPagerInputModifier =
+          Modifier.emitPressInteractions(toolbarInteractionSource)
+            .trackToolbarScrollGestureStart(
+              onStart = {
+                outerEdgeDrag = ToolbarOuterEdgeDrag(offset = outerEdgeVisualOffset.value)
+                pagerState.pointerScrollGestureActive = true
+                pagerState.scrollGestureStartPosition = pagerState.scrollPosition
+              },
+              onEnd = { pagerState.pointerScrollGestureActive = false },
+            )
+            .scrollable(
+              state = scrollableState,
+              orientation = Orientation.Horizontal,
+              enabled = pageDistance > 0f && pageCount > 1,
+              flingBehavior = flingBehavior,
+              interactionSource = toolbarInteractionSource,
+            )
+            .preserveEditorFocusOnToolbarInteraction()
+        Box(
+          modifier =
+            Modifier.fillMaxWidth()
+              .height(ToolbarHeight + bottomTouchPadding)
+              .toolbarVerticalSwipeGestures(
+                onPointerSessionStart = {
+                  primaryDismissSwipeArmedAnimationJob.value?.cancel()
+                  primaryDismissSwipeArmedAnimationJob.value = null
+                  primaryDismissSwipeProgress = null
+                  primaryDismissSwipeArmedProgress = Animatable(0f)
+                },
+                onSwipeUp = {
+                  if (pageCount > 1) {
+                    pagerState.indicatorPulse++
+                  }
+                },
+                onSwipeDown = {
+                  primaryDismissSwipeProgress = null
+                  onToolbarDismissRequest()
+                },
+                onSwipeDownProgress = { progress ->
+                  val armedChanged = (primaryDismissSwipeProgress?.armed == true) != progress.armed
+                  primaryDismissSwipeProgress = progress
+                  if (armedChanged) {
+                    primaryDismissSwipeArmedAnimationJob.value?.cancel()
+                    val armedProgress = primaryDismissSwipeArmedProgress
+                    primaryDismissSwipeArmedAnimationJob.value = scope.launch {
+                      armedProgress.animateTo(
+                        targetValue = if (progress.armed) 1f else 0f,
+                        animationSpec = ToolbarDismissSwipeThresholdSpring,
+                      )
                     }
-                ) {
-                  page.content(pageScope)
+                    if (progress.armed) {
+                      hapticFeedback.performHapticFeedback(
+                        HapticFeedbackType.GestureThresholdActivate
+                      )
+                    }
+                  }
+                },
+                onSwipeDownCancelled = { primaryDismissSwipeProgress = null },
+              )
+        ) {
+          Box(
+            modifier =
+              Modifier.align(Alignment.TopCenter)
+                .fillMaxWidth()
+                .height(ToolbarHeight)
+                .graphicsLayer { translationY = primaryDismissSwipeVisualOffset }
+                .shadow(AppTheme.shadows.sm, ToolbarCapsuleShape)
+                .pressScale(ToolbarCapsulePressedScale)
+                .clip(ToolbarCapsuleShape)
+                .hazeEffect(hazeState) {
+                  blurEffect {
+                    backgroundColor = toolbarSurfaceColor
+                    blurRadius = ToolbarBackdropBlurRadius
+                  }
+                }
+                .border(ToolbarBorderWidth, AppTheme.colors.borderEmphasis, ToolbarCapsuleShape)
+          ) {
+            EditorToolbarSurfaceBackground(shape = ToolbarCapsuleShape)
+
+            Box(
+              modifier = Modifier.matchParentSize().clipToBounds().then(toolbarPagerInputModifier)
+            ) {
+              Box(
+                modifier =
+                  Modifier.fillMaxSize().graphicsLayer {
+                    translationX =
+                      pagerState.hardStopVisualOffset.value + outerEdgeVisualOffset.value
+                  }
+              ) {
+                pages.forEachIndexed { index, page ->
+                  val pageScope =
+                    EditorToolbarPageScope(
+                      toolbarScope = page.toolbarScope,
+                      activeBottomPanel = activeBottomPanel,
+                      activeSecondaryToolbar = activeSecondaryToolbar,
+                      commandScope = commandScope,
+                      hasNextPage = index < lastPageIndex,
+                      navigateToPage = ::navigateToPage,
+                      onSecondaryToolbarToggle = onSecondaryToolbarToggle,
+                      clearSecondaryToolbar = onSecondaryToolbarClear,
+                      onBottomPanelToggle = onBottomPanelToggle,
+                      sendMessage = onEditorMessage,
+                      performToolAction = onToolAction,
+                    )
+
+                  Box(
+                    modifier =
+                      Modifier.fillMaxSize().offset {
+                        val pageOffset = pageMetrics.pageOffsetFor(index, visualScrollPosition)
+                        IntOffset(x = pageOffset.roundToInt(), y = 0)
+                      }
+                  ) {
+                    page.content(pageScope)
+                  }
                 }
               }
             }
+
+            InteractionScope {
+              EditorToolbarIconButton(
+                icon =
+                  when (fixedAction) {
+                    ToolbarFixedAction.ClosePanel -> Lucide.CircleX
+                    ToolbarFixedAction.HideToolbar -> Lucide.ChevronDown
+                    ToolbarFixedAction.DismissInput -> Lucide.KeyboardOff
+                  },
+                contentDescription =
+                  when (fixedAction) {
+                    ToolbarFixedAction.ClosePanel -> "하단 패널 닫기"
+                    ToolbarFixedAction.HideToolbar -> "툴바 숨기기"
+                    ToolbarFixedAction.DismissInput -> if (editorFocused) "에디터 포커스 해제" else "키보드 닫기"
+                  },
+                onClick = onKeyboardDismissRequest,
+                shape = ToolbarFixedActionShape,
+                fixedActionSurface = true,
+                inheritInteractionSource = true,
+                crossfadeIcon = true,
+                modifier =
+                  Modifier.align(Alignment.CenterEnd)
+                    .width(ToolbarFixedActionWidth)
+                    .fillMaxHeight()
+                    .padding(ToolbarFixedActionPadding)
+                    .pressScale(ToolbarFixedActionPressedScale),
+              )
+            }
           }
 
-          InteractionScope {
-            EditorToolbarIconButton(
-              icon =
-                when (fixedAction) {
-                  ToolbarFixedAction.ClosePanel -> Lucide.CircleX
-                  ToolbarFixedAction.HideToolbar -> Lucide.ChevronDown
-                  ToolbarFixedAction.DismissInput -> Lucide.KeyboardOff
-                },
-              contentDescription =
-                when (fixedAction) {
-                  ToolbarFixedAction.ClosePanel -> "하단 패널 닫기"
-                  ToolbarFixedAction.HideToolbar -> "툴바 숨기기"
-                  ToolbarFixedAction.DismissInput -> if (editorFocused) "에디터 포커스 해제" else "키보드 닫기"
-                },
-              onClick = onKeyboardDismissRequest,
-              shape = ToolbarFixedActionShape,
-              fixedActionSurface = true,
-              inheritInteractionSource = true,
-              crossfadeIcon = true,
+          if (includeBottomGapInTouchArea) {
+            Box(
               modifier =
-                Modifier.align(Alignment.CenterEnd)
-                  .width(ToolbarFixedActionWidth)
-                  .fillMaxHeight()
-                  .padding(ToolbarFixedActionPadding)
-                  .pressScale(ToolbarFixedActionPressedScale),
+                Modifier.align(Alignment.BottomCenter)
+                  .fillMaxWidth()
+                  .height(bottomTouchPadding)
+                  .then(toolbarPagerInputModifier)
             )
           }
-        }
-
-        if (includeBottomGapInTouchArea) {
-          Box(
-            modifier =
-              Modifier.align(Alignment.BottomCenter)
-                .fillMaxWidth()
-                .height(bottomTouchPadding)
-                .then(toolbarPagerInputModifier)
-          )
         }
       }
     }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/toolbar/EditorToolbarPagesDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/toolbar/EditorToolbarPagesDesktopTest.kt
@@ -1583,6 +1583,195 @@ class EditorToolbarPagesDesktopTest {
   }
 
   @Test
+  fun primaryDismissDragMovesVisibleToolbarStackTogether() = runComposeUiTest {
+    mainClock.autoAdvance = false
+    var density = 0f
+    setContent {
+      density = LocalDensity.current.density
+      ToolbarTestContent(textScrollState = rememberScrollState(), secondaryToolbarVisible = true)
+    }
+    mainClock.advanceTimeByFrame()
+    val initialPrimaryTop = pageTop(MainPageTag)
+    val initialSecondaryTop = pageTop(SecondaryToolbarTag)
+    val initialIndicatorTop = indicatorTop()
+
+    startToolbarVerticalDrag(37.dp)
+    mainClock.advanceTimeBy(500)
+
+    val expectedOffset = 16f * density
+    assertNear(
+      initialPrimaryTop + expectedOffset,
+      pageTop(MainPageTag),
+      "primary drag should move the primary toolbar",
+    )
+    assertNear(
+      initialSecondaryTop + expectedOffset,
+      pageTop(SecondaryToolbarTag),
+      "primary drag should move the secondary toolbar",
+    )
+    assertNear(
+      initialIndicatorTop + expectedOffset,
+      indicatorTop(),
+      "primary drag should move the indicator",
+    )
+
+    releaseToolbarVerticalDrag()
+    mainClock.autoAdvance = true
+    waitForIdle()
+  }
+
+  @Test
+  fun secondaryContentKeepsFinalHeightWhileStackSlotExpands() = runComposeUiTest {
+    mainClock.autoAdvance = false
+    lateinit var secondaryToolbarVisible: MutableState<Boolean>
+    var density = 0f
+    setContent {
+      secondaryToolbarVisible = remember { mutableStateOf(false) }
+      density = LocalDensity.current.density
+      ToolbarTestContent(
+        textScrollState = rememberScrollState(),
+        secondaryToolbarVisible = secondaryToolbarVisible.value,
+      )
+    }
+    mainClock.advanceTimeByFrame()
+
+    runOnIdle { secondaryToolbarVisible.value = true }
+    mainClock.advanceTimeByFrame()
+    mainClock.advanceTimeBy(ToolbarSecondaryVisibilityMillis.toLong() / 2)
+
+    val secondaryHeight =
+      onNodeWithTag(SecondaryToolbarTag).fetchSemanticsNode().boundsInRoot.height
+    assertNear(
+      ToolbarSecondaryHeight.value * density,
+      secondaryHeight,
+      "secondary content should be measured at its final height during stack expansion",
+    )
+
+    mainClock.autoAdvance = true
+    waitForIdle()
+  }
+
+  @Test
+  fun secondaryExitMovesIndicatorDuringTransition() = runComposeUiTest {
+    mainClock.autoAdvance = false
+    lateinit var secondaryToolbarVisible: MutableState<Boolean>
+    var density = 0f
+    setContent {
+      secondaryToolbarVisible = remember { mutableStateOf(true) }
+      density = LocalDensity.current.density
+      ToolbarTestContent(
+        textScrollState = rememberScrollState(),
+        secondaryToolbarVisible = secondaryToolbarVisible.value,
+        toolbarLayoutHeightOverride = ToolbarStackHeight + ToolbarSecondaryStackHeight,
+      )
+    }
+    mainClock.advanceTimeBy(ToolbarSecondaryVisibilityMillis.toLong() * 2)
+    val initialIndicatorTop = indicatorTop()
+
+    runOnIdle { secondaryToolbarVisible.value = false }
+    mainClock.advanceTimeByFrame()
+    mainClock.advanceTimeBy(ToolbarSecondaryVisibilityMillis.toLong() / 2)
+
+    val indicatorTopDuringExit = indicatorTop()
+    val finalIndicatorTop = initialIndicatorTop + ToolbarSecondaryStackHeight.value * density
+    assertTrue(
+      indicatorTopDuringExit > initialIndicatorTop + 2f,
+      "indicator should start moving down while the secondary toolbar exits",
+    )
+    assertTrue(
+      indicatorTopDuringExit < finalIndicatorTop - 2f,
+      "indicator should still be moving during the secondary toolbar exit",
+    )
+
+    mainClock.autoAdvance = true
+    waitForIdle()
+  }
+
+  @Test
+  fun secondaryDismissDragDoesNotMoveToolbarStack() = runComposeUiTest {
+    mainClock.autoAdvance = false
+    setContent {
+      ToolbarTestContent(textScrollState = rememberScrollState(), secondaryToolbarVisible = true)
+    }
+    mainClock.advanceTimeByFrame()
+    val initialPrimaryTop = pageTop(MainPageTag)
+    val initialSecondaryTop = pageTop(SecondaryToolbarTag)
+    val initialIndicatorTop = indicatorTop()
+
+    startSecondaryToolbarVerticalDrag(37.dp)
+    mainClock.advanceTimeBy(500)
+
+    assertNear(
+      initialPrimaryTop,
+      pageTop(MainPageTag),
+      "secondary drag should not move the primary toolbar",
+    )
+    assertNear(
+      initialSecondaryTop,
+      pageTop(SecondaryToolbarTag),
+      "secondary drag should not move the secondary toolbar",
+    )
+    assertNear(initialIndicatorTop, indicatorTop(), "secondary drag should not move the indicator")
+
+    releaseSecondaryToolbarVerticalDrag()
+    mainClock.autoAdvance = true
+    waitForIdle()
+  }
+
+  @Test
+  fun secondarySwipeDownClearsOnlySecondaryToolbar() = runComposeUiTest {
+    var secondaryClears = 0
+    var toolbarDismissals = 0
+    var keyboardDismissals = 0
+    val haptics = mutableListOf<HapticFeedbackType>()
+    val hapticFeedback =
+      object : HapticFeedback {
+        override fun performHapticFeedback(hapticFeedbackType: HapticFeedbackType) {
+          haptics += hapticFeedbackType
+        }
+      }
+    setContent {
+      ToolbarTestContent(
+        textScrollState = rememberScrollState(),
+        secondaryToolbarVisible = true,
+        onSecondaryToolbarClear = { secondaryClears++ },
+        onToolbarDismissRequest = { toolbarDismissals++ },
+        onKeyboardDismissRequest = { keyboardDismissals++ },
+        hapticFeedback = hapticFeedback,
+      )
+    }
+    waitForIdle()
+
+    swipeSecondaryToolbarDown(40.dp)
+
+    assertEquals(1, secondaryClears)
+    assertEquals(0, toolbarDismissals)
+    assertEquals(0, keyboardDismissals)
+    assertEquals(emptyList(), haptics)
+    assertNear(0f, pageLeft(MainPageTag), "primary toolbar should remain visible")
+  }
+
+  @Test
+  fun secondarySwipeDownBelowActivationThresholdDoesNotClearSecondaryToolbar() = runComposeUiTest {
+    var secondaryClears = 0
+    var toolbarDismissals = 0
+    setContent {
+      ToolbarTestContent(
+        textScrollState = rememberScrollState(),
+        secondaryToolbarVisible = true,
+        onSecondaryToolbarClear = { secondaryClears++ },
+        onToolbarDismissRequest = { toolbarDismissals++ },
+      )
+    }
+    waitForIdle()
+
+    swipeSecondaryToolbarDown(35.dp)
+
+    assertEquals(0, secondaryClears)
+    assertEquals(0, toolbarDismissals)
+  }
+
+  @Test
   fun swipeUpFromToolbarButtonRevealsIndicatorWithoutClickingButton() = runComposeUiTest {
     lateinit var pagerState: ToolbarPagerState
     var toolbarButtonClicks = 0
@@ -1940,6 +2129,30 @@ class EditorToolbarPagesDesktopTest {
     waitForIdle()
   }
 
+  private fun ComposeUiTest.startSecondaryToolbarVerticalDrag(distance: Dp) {
+    onNodeWithTag(SecondaryToolbarTag).performTouchInput {
+      down(center)
+      moveTo(center + Offset(x = 0f, y = distance.toPx()))
+    }
+    waitForIdle()
+  }
+
+  private fun ComposeUiTest.releaseSecondaryToolbarVerticalDrag() {
+    onNodeWithTag(SecondaryToolbarTag).performTouchInput { up() }
+    waitForIdle()
+  }
+
+  private fun ComposeUiTest.swipeSecondaryToolbarDown(distance: Dp) {
+    onNodeWithTag(SecondaryToolbarTag).performTouchInput {
+      swipe(
+        start = center,
+        end = center + Offset(x = 0f, y = distance.toPx()),
+        durationMillis = 120,
+      )
+    }
+    waitForIdle()
+  }
+
   private fun ComposeUiTest.tapToolbarIndicatorPage(pageIndex: Int, pageCount: Int) {
     onNodeWithTag(ToolbarTag).performTouchInput {
       val itemPx = ToolbarIndicatorItemSize.toPx()
@@ -2041,6 +2254,9 @@ class EditorToolbarPagesDesktopTest {
   private fun SemanticsNodeInteractionsProvider.pageTop(tag: String): Float =
     onNodeWithTag(tag).fetchSemanticsNode().boundsInRoot.top
 
+  private fun SemanticsNodeInteractionsProvider.indicatorTop(): Float =
+    onNodeWithContentDescription("메인 툴바").fetchSemanticsNode().boundsInRoot.top
+
   private fun assertNear(expected: Float, actual: Float, message: String) {
     assertTrue(abs(expected - actual) <= 2f, "$message. expected=$expected actual=$actual")
   }
@@ -2056,10 +2272,12 @@ class EditorToolbarPagesDesktopTest {
     textItemWidth: Dp = 80.dp,
     onToolbarDismissRequest: () -> Unit = {},
     onKeyboardDismissRequest: () -> Unit = {},
+    onSecondaryToolbarClear: () -> Unit = {},
     onMainButtonClick: () -> Unit = {},
     ancestorModifier: Modifier = Modifier,
     includeBottomGapInTouchArea: Boolean = false,
     secondaryToolbarVisible: Boolean = false,
+    toolbarLayoutHeightOverride: Dp? = null,
     hapticFeedback: HapticFeedback? = null,
   ) {
     val pages =
@@ -2072,9 +2290,10 @@ class EditorToolbarPagesDesktopTest {
     val commandScope = rememberCoroutineScope()
     val bottomTouchGapHeight = if (includeBottomGapInTouchArea) ToolbarBottomPadding else 0.dp
     val toolbarLayoutHeight =
-      ToolbarStackHeight +
-        bottomTouchGapHeight +
-        if (secondaryToolbarVisible) ToolbarSecondaryStackHeight else 0.dp
+      toolbarLayoutHeightOverride
+        ?: (ToolbarStackHeight +
+          bottomTouchGapHeight +
+          if (secondaryToolbarVisible) ToolbarSecondaryStackHeight else 0.dp)
     ToolbarTestTheme(hapticFeedback = hapticFeedback) {
       Box(ancestorModifier) {
         Box(Modifier.width(360.dp).height(toolbarLayoutHeight).testTag(ToolbarTag)) {
@@ -2092,6 +2311,7 @@ class EditorToolbarPagesDesktopTest {
               onKeyboardDismissRequest = onKeyboardDismissRequest,
               onToolbarDismissRequest = onToolbarDismissRequest,
               onBottomPanelToggle = { _, _ -> },
+              onSecondaryToolbarClear = onSecondaryToolbarClear,
               secondaryToolbarVisible = secondaryToolbarVisible,
               secondaryToolbar = {
                 Box(


### PR DESCRIPTION
## 변경 사항

- 세컨더리 툴바를 아래로 스와이프하면 닫히도록 합니다.
- 툴바 인디케이터, 선택적인 세컨더리 툴바, 프라이머리 툴바를 하나의 세로 스택으로 배치합니다.
- 프라이머리 툴바를 아래로 스와이프할 때 표시된 툴바와 인디케이터가 함께 이동하도록 합니다.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>