### PR TITLE
mearie monkey patch

### DIFF
--- a/apps/website/src/lib/graphql/mearie-cache-performance.test.ts
+++ b/apps/website/src/lib/graphql/mearie-cache-performance.test.ts
@@ -1,0 +1,124 @@
+import { applyPatchesImmutable, cacheExchange, createClient } from '@mearie/core';
+import { filter, map, pipe, subscribe } from '@mearie/core/stream';
+import { expect, test } from 'vitest';
+import type { Artifact, Exchange, OperationResult, SchemaMeta } from '@mearie/core';
+
+type Selection = Artifact['selections'][number];
+
+const FIELD_COUNT = 4000;
+const MAX_STRUCTURAL_UPDATE_MS = 100;
+
+const schema = {
+  entities: {
+    Child: { keyFields: ['id'] },
+    User: { keyFields: ['id'] },
+  },
+  inputs: {},
+  scalars: {},
+} satisfies SchemaMeta;
+
+const identitySelections = [
+  { kind: 'Field', name: '__typename', type: 'String' },
+  { kind: 'Field', name: 'id', type: 'ID' },
+] satisfies Selection[];
+
+const childrenSelection = {
+  kind: 'Field',
+  name: 'children',
+  type: 'Child',
+  array: true,
+  selections: identitySelections,
+} satisfies Selection;
+
+const observedArtifact = {
+  kind: 'query',
+  name: 'ObservedUser',
+  body: 'query ObservedUser { user { id } }',
+  selections: [
+    {
+      kind: 'Field',
+      name: 'user',
+      type: 'User',
+      selections: [
+        ...identitySelections,
+        childrenSelection,
+        ...Array.from({ length: FIELD_COUNT }, (_, index) => ({
+          kind: 'Field' as const,
+          name: `field${index}`,
+          type: 'String',
+        })),
+      ],
+    },
+  ],
+} satisfies Artifact<'query'>;
+
+const updateArtifact = {
+  kind: 'query',
+  name: 'UpdatedUser',
+  body: 'query UpdatedUser { user { id children { id } } }',
+  selections: [
+    {
+      kind: 'Field',
+      name: 'user',
+      type: 'User',
+      selections: [...identitySelections, childrenSelection],
+    },
+  ],
+} satisfies Artifact<'query'>;
+
+const observedUser = Object.fromEntries([
+  ['__typename', 'User'],
+  ['id', 'user-1'],
+  ['children', [{ __typename: 'Child', id: 'child-1' }]],
+  ...Array.from({ length: FIELD_COUNT }, (_, index) => [`field${index}`, `value-${index}`]),
+]);
+
+const responses: Record<string, unknown> = {
+  ObservedUser: { user: observedUser },
+  UpdatedUser: { user: { __typename: 'User', id: 'user-1', children: [{ __typename: 'Child', id: 'child-2' }] } },
+};
+
+const fixtureExchange: Exchange = () => ({
+  name: 'fixture',
+  io: (operations) =>
+    pipe(
+      operations,
+      filter((operation) => operation.variant === 'request'),
+      map((operation): OperationResult => ({
+        operation,
+        data: operation.variant === 'request' ? responses[operation.artifact.name] : undefined,
+      })),
+    ),
+});
+
+test('updates a structurally changed subscription without scanning unrelated cache cursors', async () => {
+  const client = createClient({ schema, exchanges: [cacheExchange(), fixtureExchange] });
+  const emissions: OperationResult[] = [];
+  const unsubscribe = pipe(
+    client.executeQuery(observedArtifact, {}),
+    subscribe({
+      next: (result) => {
+        emissions.push(result);
+      },
+    }),
+  );
+
+  try {
+    await expect.poll(() => emissions.at(-1)?.data).toBeDefined();
+    const initialData = emissions.at(-1)?.data;
+
+    const startedAt = performance.now();
+    await client.query(updateArtifact, {}, { fetchPolicy: 'network-only' });
+    const elapsedMs = performance.now() - startedAt;
+
+    expect(elapsedMs).toBeLessThan(MAX_STRUCTURAL_UPDATE_MS);
+    const patches = emissions.at(-1)?.metadata?.cache?.patches;
+    expect(patches).toBeDefined();
+    expect(applyPatchesImmutable(initialData, patches ?? [])).toMatchObject({
+      user: { children: [{ id: 'child-2' }] },
+    });
+  } finally {
+    unsubscribe();
+    client.dispose();
+  }
+});

--- a/patches/@mearie__core@0.8.1.patch
+++ b/patches/@mearie__core@0.8.1.patch
@@ -1,0 +1,98 @@
+diff --git a/dist/index.cjs b/dist/index.cjs
+index 6fedf56065632a992ed553618c1fdf2053716631..ff01a378ad057481427a71a49d7968446db789d0 100644
+--- a/dist/index.cjs
++++ b/dist/index.cjs
+@@ -700,6 +700,7 @@ const inlineFragmentMatches$1 = (selection, typename) => selection.kind === "Inl
+ */
+ var CursorRegistry = class {
+ 	#index = /* @__PURE__ */ new Map();
++	#dependencies = /* @__PURE__ */ new Map();
+ 	add(depKey, entry) {
+ 		let set = this.#index.get(depKey);
+ 		if (!set) {
+@@ -707,21 +708,21 @@ var CursorRegistry = class {
+ 			this.#index.set(depKey, set);
+ 		}
+ 		set.add(entry);
++		this.#dependencies.set(entry, depKey);
+ 	}
+ 	get(depKey) {
+ 		return this.#index.get(depKey);
+ 	}
+ 	remove(depKey, entry) {
+ 		const set = this.#index.get(depKey);
+-		if (set) {
+-			set.delete(entry);
+-			if (set.size === 0) this.#index.delete(depKey);
+-		}
++		if (!set?.delete(entry)) return;
++		this.#dependencies.delete(entry);
++		if (set.size === 0) this.#index.delete(depKey);
+ 	}
+ 	removeAll(cursors) {
+-		for (const [depKey, set] of this.#index) {
+-			for (const cursor of cursors) if (set.has(cursor)) set.delete(cursor);
+-			if (set.size === 0) this.#index.delete(depKey);
++		for (const cursor of cursors) {
++			const depKey = this.#dependencies.get(cursor);
++			if (depKey !== void 0) this.remove(depKey, cursor);
+ 		}
+ 	}
+ 	forEachByPrefix(prefix, callback) {
+@@ -729,6 +730,7 @@ var CursorRegistry = class {
+ 	}
+ 	clear() {
+ 		this.#index.clear();
++		this.#dependencies.clear();
+ 	}
+ };
+ const typenameFieldKey = makeFieldKey({
+diff --git a/dist/index.mjs b/dist/index.mjs
+index b4d905973d41d65990fe70e1e999185bbb69049c..be7331225ad1076348c46266150913b54e0a09b2 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -699,6 +699,7 @@ const inlineFragmentMatches$1 = (selection, typename) => selection.kind === "Inl
+ */
+ var CursorRegistry = class {
+ 	#index = /* @__PURE__ */ new Map();
++	#dependencies = /* @__PURE__ */ new Map();
+ 	add(depKey, entry) {
+ 		let set = this.#index.get(depKey);
+ 		if (!set) {
+@@ -706,21 +707,21 @@ var CursorRegistry = class {
+ 			this.#index.set(depKey, set);
+ 		}
+ 		set.add(entry);
++		this.#dependencies.set(entry, depKey);
+ 	}
+ 	get(depKey) {
+ 		return this.#index.get(depKey);
+ 	}
+ 	remove(depKey, entry) {
+ 		const set = this.#index.get(depKey);
+-		if (set) {
+-			set.delete(entry);
+-			if (set.size === 0) this.#index.delete(depKey);
+-		}
++		if (!set?.delete(entry)) return;
++		this.#dependencies.delete(entry);
++		if (set.size === 0) this.#index.delete(depKey);
+ 	}
+ 	removeAll(cursors) {
+-		for (const [depKey, set] of this.#index) {
+-			for (const cursor of cursors) if (set.has(cursor)) set.delete(cursor);
+-			if (set.size === 0) this.#index.delete(depKey);
++		for (const cursor of cursors) {
++			const depKey = this.#dependencies.get(cursor);
++			if (depKey !== void 0) this.remove(depKey, cursor);
+ 		}
+ 	}
+ 	forEachByPrefix(prefix, callback) {
+@@ -728,6 +729,7 @@ var CursorRegistry = class {
+ 	}
+ 	clear() {
+ 		this.#index.clear();
++		this.#dependencies.clear();
+ 	}
+ };
+ const typenameFieldKey = makeFieldKey({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,9 @@ settings:
 overrides:
   ioredis: ^5.11.1
 
+patchedDependencies:
+  '@mearie/core@0.8.1': cfb699f35b5b8753d3ccd535222bba55de7f71f523611369eac36a4b88c7c416
+
 importers:
 
   .:
@@ -553,7 +556,7 @@ importers:
         version: 1.2.5
       '@mearie/core':
         specifier: ^0.8.1
-        version: 0.8.1
+        version: 0.8.1(patch_hash=cfb699f35b5b8753d3ccd535222bba55de7f71f523611369eac36a4b88c7c416)
       '@mearie/svelte':
         specifier: ^0.5.1
         version: 0.5.1(svelte@5.56.8(@typescript-eslint/types@8.65.0))
@@ -11226,7 +11229,7 @@ snapshots:
       - jiti
       - magicast
 
-  '@mearie/core@0.8.1':
+  '@mearie/core@0.8.1(patch_hash=cfb699f35b5b8753d3ccd535222bba55de7f71f523611369eac36a4b88c7c416)':
     dependencies:
       '@mearie/shared': 0.5.0
 
@@ -11257,7 +11260,7 @@ snapshots:
 
   '@mearie/svelte@0.5.1(svelte@5.56.8(@typescript-eslint/types@8.65.0))':
     dependencies:
-      '@mearie/core': 0.8.1
+      '@mearie/core': 0.8.1(patch_hash=cfb699f35b5b8753d3ccd535222bba55de7f71f523611369eac36a4b88c7c416)
       svelte: 5.56.8(@typescript-eslint/types@8.65.0)
 
   '@mearie/vite@0.1.8(dotenv@17.4.2)(jiti@2.6.1)':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,3 +35,5 @@ minimumReleaseAgeExclude:
   - '@mearie/svelte@0.5.0 || 0.5.1'
   - '@mearie/vite@0.1.8'
   - mearie@0.1.8
+patchedDependencies:
+  '@mearie/core@0.8.1': patches/@mearie__core@0.8.1.patch


### PR DESCRIPTION
## 문제

`@mearie/core`의 `CursorRegistry.removeAll()`은 cursor를 제거할 때 전체 dependency index를 순회합니다.

큰 selection을 구독하는 상태에서 캐시 구조가 변경되면, 제거 대상과 관계없는 cache cursor까지 반복적으로 검사하면서 update latency가 크게 증가할 수 있습니다.

## 변경 사항

- `@mearie/core@0.8.1`에 pnpm patch를 적용했습니다.
- cursor에서 dependency key를 찾는 역방향 index를 추가했습니다.
- `removeAll()`이 전체 registry를 순회하지 않고 제거할 cursor를 직접 조회하도록 변경했습니다.
- `add()`, `remove()`, `clear()`에서 두 index가 함께 갱신되도록 했습니다.
- 4,000개의 관계없는 field가 존재하는 구독에서 구조적 cache update의 성능과 patch 결과를 검증하는 회귀 테스트를 추가했습니다.

## 검증

- mearie cache performance regression test 통과
- 구조 변경 후 생성된 cache patch가 새로운 child를 올바르게 반영하는지 확인

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>