### PR TITLE
es2025 iterator helpers 문법 제거

### DIFF
--- a/apps/website/src/lib/editor-ffi/editor-host-failure.test.ts
+++ b/apps/website/src/lib/editor-ffi/editor-host-failure.test.ts
@@ -425,6 +425,29 @@ describe('Editor guarded core invocation', () => {
     editor.destroy();
   });
 
+  it('accepts a publication when iterator helper methods are unavailable', async () => {
+    const { editor } = await createEditor(createCore(), false);
+    const releaseHost = editor.activateVisualHost();
+    const requiredPages = new Set([0]);
+    editor.requestSurfacePages(requiredPages);
+    editor.attachSurface(0, document.createElement('canvas'), 100, 100);
+    const bundle = editor.publishIfReady(requiredPages);
+    if (!bundle) throw new Error('Expected a publishable bundle');
+
+    const iteratorProto = Object.getPrototypeOf(Object.getPrototypeOf(new Map().keys())) as { some?: unknown };
+    const originalSome = iteratorProto.some;
+    delete iteratorProto.some;
+    try {
+      expect(editor.acceptPublication(bundle)).toBe(true);
+    } finally {
+      iteratorProto.some = originalSome;
+    }
+
+    editor.completePresentation(bundle);
+    releaseHost();
+    editor.destroy();
+  });
+
   it.each([
     [
       'request admission',

--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -1879,7 +1879,7 @@ export class Editor {
       !host ||
       this.#applied !== bundle.snapshot ||
       bundle.frames.size !== this.surfacePageRequirements.size ||
-      bundle.frames.keys().some((page) => !this.surfacePageRequirements.has(page))
+      [...bundle.frames.keys()].some((page) => !this.surfacePageRequirements.has(page))
     ) {
       return false;
     }

--- a/packages/lintconfig/eslint.js
+++ b/packages/lintconfig/eslint.js
@@ -89,6 +89,7 @@ export default defineConfig([
       'unicorn/prefer-global-this': 'off',
       'unicorn/prefer-https': 'off',
       'unicorn/prefer-includes-over-repeated-comparisons': 'off',
+      'unicorn/prefer-iterator-helpers': 'off',
       'unicorn/prefer-iterator-to-array': 'off',
       'unicorn/prefer-number-coercion': 'off',
       'unicorn/prefer-split-limit': 'off',


### PR DESCRIPTION
es2025 미지원 브라우저 (iOS 18.4 이하 등) 에서 에디터 로드가 안 되던 문제 수정

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>