### PR TITLE
프리즘에서 스피너 전환 시 위치/크기 전환이 모핑보다 빨리 끝나게

### DIFF
--- a/apps/website/src/routes/website/(dashboard)/@prism/PrismPanelIndicator.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@prism/PrismPanelIndicator.svelte
@@ -10,7 +10,8 @@
   export type PrismIndicatorPhase = 'answered' | 'failed' | 'hidden' | 'submitting' | 'welcome';
   export type PrismSpinnerOwner = 'panel' | 'row';
 
-  const PRISM_TO_SPINNER_DURATION_MS = 3000;
+  const PRISM_TO_SPINNER_DURATION_MS = 2200;
+  const PRISM_TO_SPINNER_PRESENTATION_END_PROGRESS = 5 / 11;
 
   type Props = {
     destination?: HTMLElement;
@@ -172,6 +173,8 @@
     if (path) placeAt(samplePrismIndicatorPath(path, progress));
   };
 
+  const presentationProgress = (progress: number) => Math.min(progress / PRISM_TO_SPINNER_PRESENTATION_END_PROGRESS, 1);
+
   const fallbackToRow = () => {
     cancelAdmission();
     stopFollowing();
@@ -300,7 +303,7 @@
 
     if (mode === 'morphing') {
       const progress = Math.max(0, Math.min(1, snapshot.journeyProgress ?? 0));
-      startMorphReturn(progress === 0 ? undefined : PRISM_TO_SPINNER_DURATION_MS * progress, progress);
+      startMorphReturn(progress === 0 ? undefined : PRISM_TO_SPINNER_DURATION_MS * progress, presentationProgress(progress));
       return;
     }
     if (mode === 'arrived') {
@@ -343,14 +346,14 @@
           return;
         }
       }
-      placeAtProgress(progress);
+      placeAtProgress(presentationProgress(progress));
       if (progress === 1) arrive();
       return;
     }
 
     if (mode === 'returning') {
       const progress = next.settledTarget === 'prism' ? 1 : Math.max(0, Math.min(1, next.journeyProgress ?? 0));
-      placeAtProgress(returnStartProgress * (1 - progress));
+      placeAtProgress(returnStartProgress * (1 - presentationProgress(progress)));
       if (progress === 1) {
         placeAtProgress(0);
         mode = 'idle';

--- a/apps/website/src/routes/website/(dashboard)/@prism/lib/prism-indicator-path.ts
+++ b/apps/website/src/routes/website/(dashboard)/@prism/lib/prism-indicator-path.ts
@@ -9,7 +9,7 @@ export type PrismIndicatorPath = Readonly<{
   arcHeight: number;
 }>;
 
-const easeOutTravel = (progress: number) => Math.sin((progress * Math.PI) / 2);
+const easeOutTravel = (progress: number) => 1 - (1 - progress) ** 3;
 
 const requirePoint = (point: PrismIndicatorPoint) => {
   if (!Number.isFinite(point.x) || !Number.isFinite(point.y)) {

--- a/apps/website/src/routes/website/(dashboard)/@prism/prism-panel-indicator.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/@prism/prism-panel-indicator.test.ts
@@ -220,7 +220,7 @@ describe('Prism panel indicator', () => {
     }
   });
 
-  test('uses the 3000 ms morph progress as the single travel clock', async () => {
+  test('finishes screen travel before the 2200 ms morph settles', async () => {
     const target = document.createElement('div');
     const props = reactiveProps({
       destination: destination() as HTMLElement | undefined,
@@ -235,7 +235,7 @@ describe('Prism panel indicator', () => {
       await tick();
       stepAnimationFrame();
       await tick();
-      expect(runtime.object.setTarget).toHaveBeenCalledWith('spinner', { totalDurationMs: 3000 });
+      expect(runtime.object.setTarget).toHaveBeenCalledWith('spinner', { totalDurationMs: 2200 });
 
       const actor = target.querySelector<HTMLElement>('[data-prism-indicator-actor]');
       runtime.emit({ journeyProgress: 0.25, owner: 'webgpu', requestedTarget: 'spinner', settledTarget: null });
@@ -245,7 +245,7 @@ describe('Prism panel indicator', () => {
 
       runtime.emit({ journeyProgress: 0.75 });
       expect(actor?.style.transform).not.toBe(quarterTransform);
-      expect(actor?.style.transform).not.toBe('translate3d(-160px, -220px, 0px)');
+      expect(actor?.style.transform).toBe('translate3d(-160px, -220px, 0px)');
 
       runtime.emit({ journeyProgress: 1, owner: 'atlas', settledTarget: 'spinner' });
       expect(actor?.style.transform).toBe('translate3d(-160px, -220px, 0px)');
@@ -369,13 +369,13 @@ describe('Prism panel indicator', () => {
 
       props.phase = 'failed';
       await tick();
-      expect(runtime.object.setTarget).toHaveBeenCalledWith('prism', { totalDurationMs: 1200 });
+      expect(runtime.object.setTarget).toHaveBeenCalledWith('prism', { totalDurationMs: 880 });
 
       runtime.emit({ journeyProgress: 0, requestedTarget: 'prism' });
       expect(actor?.style.transform).toBe(departureTransform);
       runtime.emit({ journeyProgress: 0.5 });
       expect(actor?.style.transform).not.toBe(departureTransform);
-      expect(actor?.style.transform).not.toBe('translate3d(0px, 0px, 0px)');
+      expect(actor?.style.transform).toBe('translate3d(0px, 0px, 0px)');
       runtime.emit({ journeyProgress: 1, settledTarget: 'prism' });
       expect(actor?.style.transform).toBe('translate3d(0px, 0px, 0px)');
     } finally {
@@ -412,7 +412,7 @@ describe('Prism panel indicator', () => {
       runtime.emit({ journeyProgress: 0, requestedTarget: 'prism', settledTarget: null });
       runtime.emit({ journeyProgress: 0.5 });
       expect(actor?.style.transform).not.toBe('translate3d(-160px, -220px, 0px)');
-      expect(actor?.style.transform).not.toBe('translate3d(0px, 0px, 0px)');
+      expect(actor?.style.transform).toBe('translate3d(0px, 0px, 0px)');
       runtime.emit({ journeyProgress: 1, settledTarget: 'prism' });
       expect(actor?.style.transform).toBe('translate3d(0px, 0px, 0px)');
     } finally {
@@ -441,7 +441,7 @@ describe('Prism panel indicator', () => {
       expect(target.querySelector<HTMLElement>('[data-prism-indicator-actor]')?.style.visibility).toBe('hidden');
 
       runtime.emit({ readiness: 'ready' });
-      expect(runtime.object.setTarget).not.toHaveBeenCalledWith('spinner', { totalDurationMs: 3000 });
+      expect(runtime.object.setTarget).not.toHaveBeenCalledWith('spinner', { totalDurationMs: 2200 });
 
       props.phase = 'failed';
       await tick();

--- a/packages/prism-ui/src/internal/prism-spinner-morph.ts
+++ b/packages/prism-ui/src/internal/prism-spinner-morph.ts
@@ -8,6 +8,7 @@ export const PRISM_SPINNER_GEOMETRY_SWAP_PROGRESS = 0.72;
 export const PRISM_SPINNER_SILHOUETTE_PHASE_TURNS = 0.25;
 export const PRISM_SPINNER_CSS_SIZE = 18;
 const PRISM_SPINNER_SWAP_SCALE = 1.11118849;
+const PRISM_SPINNER_SIZE_COMPLETION_PROGRESS = 5 / 11;
 
 type Vector3 = readonly [number, number, number];
 type Triangle = readonly [number, number, number];
@@ -897,7 +898,8 @@ export type PrismSpinnerMorphChannels = {
 
 export function resolvePrismSpinnerSizeProgress(progress: number): number {
   const normalized = clamp(progress || 0);
-  return normalized ** 3;
+  const windowProgress = clamp(normalized / PRISM_SPINNER_SIZE_COMPLETION_PROGRESS);
+  return 1 - (1 - windowProgress) ** 3;
 }
 
 export function resolvePrismSpinnerMorphChannels(progress: number, prismSize: number, spinnerSize: number): PrismSpinnerMorphChannels {


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>