### PR TITLE
프리즘 리뷰 하이라이트 수정

### DIFF
--- a/apps/website/src/lib/editor-ffi/editor-host-failure.test.ts
+++ b/apps/website/src/lib/editor-ffi/editor-host-failure.test.ts
@@ -1499,6 +1499,42 @@ describe('Editor guarded core invocation', () => {
     editor.destroy();
   });
 
+  it('retains freshly resolved tracked geometry for an older published snapshot', async () => {
+    const { editor, core } = await createEditor();
+    const stale = {
+      id: 'prism-issue:0',
+      anchor: { node: 'text', offset: 1, affinity: 'downstream' },
+      head: { node: 'text', offset: 4, affinity: 'downstream' },
+      rects: [{ page_idx: 0, rect: { x: 10, y: 20, width: 30, height: 10 } }],
+    } as TrackedRange;
+    const fresh = { ...stale, rects: [{ page_idx: 0, rect: { x: 10, y: 80, width: 30, height: 10 } }] };
+    core.tracked_ranges.mockReturnValueOnce([stale]).mockReturnValueOnce([fresh]);
+    core.tick
+      .mockReturnValueOnce({
+        revision: { value: 2 },
+        events: [{ type: 'state_changed', fields: ['tracked_ranges'] }],
+        request_outcomes: [],
+      })
+      .mockReturnValueOnce({
+        revision: { value: 3 },
+        events: [{ type: 'state_changed', fields: ['ime'] }],
+        request_outcomes: [],
+      });
+
+    editor.enqueue({ type: 'history', op: { type: 'undo' } });
+    frames.at(-1)?.(0);
+    const publishedCandidate = editor.appliedSnapshot;
+    expect(editor.freshTrackedRanges()).toEqual([fresh]);
+
+    editor.enqueue({ type: 'history', op: { type: 'undo' } });
+    frames.at(-1)?.(0);
+
+    expect(editor.appliedRevision).toBe(3);
+    expect(editor.trackedRangeForSnapshot(stale.id, publishedCandidate)).toEqual(fresh);
+
+    editor.destroy();
+  });
+
   it('does not make visual-host activation depend on the publication it installs', async () => {
     const { editor } = await createEditor();
     const tracked = createTrackedEffect(() => editor.activateVisualHost());

--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -417,11 +417,6 @@ export class Editor {
   #aiFeedbackDecorationsInstalled = false;
   #aiFeedbackMembershipIds: string[] | null = null;
 
-  #prismReviewDecorationsInstalled = false;
-  // eslint-disable-next-line svelte/prefer-svelte-reactivity
-  #prismReviewTones = new Map<string, 'issue' | 'strength'>();
-  #activePrismReviewIds: string[] = [];
-
   #commentDecorationsInstalled = false;
   // eslint-disable-next-line svelte/prefer-svelte-reactivity
   #registeredCommentIds = new Set<string>();
@@ -488,8 +483,6 @@ export class Editor {
 
   aiFeedbacks = $state<AiFeedback[]>([]);
   activeAiFeedbackId = $state<string | null>(null);
-
-  prismReviewRangeIds = $state<string[]>([]);
 
   activeCommentId = $state<string | null>(null);
   commentClickHandler: ((id: string) => void) | null = null;
@@ -1032,11 +1025,6 @@ export class Editor {
       this.spellcheckErrors = this.spellcheckErrors.filter((e) => !stale.has(e.id));
       if (this.activeSpellcheckErrorId !== null && stale.has(this.activeSpellcheckErrorId)) {
         this.activeSpellcheckErrorId = null;
-      }
-
-      if (this.prismReviewRangeIds.some((id) => stale.has(id))) {
-        this.prismReviewRangeIds = this.prismReviewRangeIds.filter((id) => !stale.has(id));
-        this.#activePrismReviewIds = this.#activePrismReviewIds.filter((id) => !stale.has(id));
       }
     });
 
@@ -2358,34 +2346,6 @@ export class Editor {
     });
   }
 
-  installPrismReviewDecorations(): void {
-    if (this.#prismReviewDecorationsInstalled) return;
-    this.#prismReviewDecorationsInstalled = true;
-
-    // 평시 그룹에는 데코레이션을 걸지 않는다 — 본문은 활성일 때만 물든다
-    this.enqueue({
-      type: 'tracked_range',
-      op: {
-        type: 'set_group_decoration',
-        group: 'prism-issue-active',
-        style: { background: 'ui.prism-issue-active', background_radius: 2, background_inset: 2, underline: undefined },
-        enabled: true,
-        z_index: 1,
-      },
-    });
-
-    this.enqueue({
-      type: 'tracked_range',
-      op: {
-        type: 'set_group_decoration',
-        group: 'prism-strength-active',
-        style: { background: 'ui.prism-strength-active', background_radius: 2, background_inset: 2, underline: undefined },
-        enabled: true,
-        z_index: 1,
-      },
-    });
-  }
-
   setSpellcheckErrors(
     items: {
       id: string;
@@ -2545,8 +2505,6 @@ export class Editor {
 
     this.clearPrismReviewRanges();
 
-    const installed: string[] = [];
-
     for (const item of items) {
       // 해소되지 않는 selection은 tick에서 터져 에디터를 종료시킨다.
       // freezeSelection이 그 판정(양 끝 resolve)을 큐를 거치지 않고 내주고, 그 결과가 곧 앵커다.
@@ -2571,12 +2529,7 @@ export class Editor {
         continue;
       }
       if (result.type === 'ignored') continue;
-
-      this.#prismReviewTones.set(item.id, item.tone);
-      installed.push(item.id);
     }
-
-    this.prismReviewRangeIds = installed;
   }
 
   // 스냅숏의 trackedRanges는 코어가 tracked_ranges 필드를 낼 때만 갈린다(materializeSnapshot) — 본문이
@@ -2586,35 +2539,20 @@ export class Editor {
     if (this.#freshRangesFor !== this.#applied) {
       this.#freshRanges = this.#invokeCore((core) => core.tracked_ranges());
       this.#freshRangesFor = this.#applied;
+      // 이 snapshot이 게시된 뒤 다음 판이 먼저 적용되어도, 호스트는 그 캔버스와 짝인 지금 좌표를 써야 한다.
+      // snapshot 사본에만 남은 stale id는 undefined로 고정해 옛 rect로 되돌아가지 않게 한다.
+      // eslint-disable-next-line svelte/prefer-svelte-reactivity -- immutable snapshot cache installed into a WeakMap
+      const resolved = new Map<string, TrackedRange | undefined>(this.#applied.trackedRanges.map((range) => [range.id, undefined]));
+      for (const range of this.#freshRanges) resolved.set(range.id, range);
+      this.#resolvedTrackedRanges.set(this.#applied, resolved);
     }
     return this.#freshRanges;
   }
 
-  setActivePrismReviewRanges(ids: readonly string[]): void {
-    const next = [...ids];
-    if (sameIds(this.#activePrismReviewIds, next)) return;
-
-    const move = (id: string, active: boolean): boolean => {
-      const tone = this.#prismReviewTones.get(id);
-      if (tone === undefined) return false;
-      if (this.#applied.trackedRanges.every((range) => range.id !== id)) return false;
-      const base = tone === 'issue' ? 'prism-issue' : 'prism-strength';
-      this.enqueue({ type: 'tracked_range', op: { type: 'set_group', id, group: active ? `${base}-active` : base } });
-      return true;
-    };
-
-    for (const id of this.#activePrismReviewIds) move(id, false);
-    // 앉지 못한 id를 활성으로 기록하면 sameIds가 다음 시도를 막는다
-    this.#activePrismReviewIds = next.filter((id) => move(id, true));
-  }
-
   clearPrismReviewRanges(): void {
-    for (const group of ['prism-issue', 'prism-issue-active', 'prism-strength', 'prism-strength-active']) {
+    for (const group of ['prism-issue', 'prism-strength']) {
       this.enqueue({ type: 'tracked_range', op: { type: 'clear_group', group } });
     }
-    this.#prismReviewTones.clear();
-    this.#activePrismReviewIds = [];
-    this.prismReviewRangeIds = [];
   }
 
   installCommentDecorations(): void {

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismCard.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismCard.svelte
@@ -129,8 +129,8 @@
     },
     variants: {
       tone: {
-        active: { borderColor: 'border.pink', backgroundColor: 'surface.default', boxShadow: 'medium' },
-        activeStrength: { borderColor: 'border.emerald', backgroundColor: 'surface.default', boxShadow: 'medium' },
+        active: { borderColor: 'review.issue.default', backgroundColor: 'surface.default', boxShadow: 'medium' },
+        activeStrength: { borderColor: 'review.strength.default', backgroundColor: 'surface.default', boxShadow: 'medium' },
         open: { borderColor: 'border.default', backgroundColor: 'surface.default', boxShadow: 'small' },
         settled: { borderColor: 'border.subtle', backgroundColor: 'surface.subtle' },
         settledActive: { borderColor: 'border.subtle', backgroundColor: 'surface.subtle' },
@@ -160,15 +160,18 @@
     },
     variants: {
       tone: {
-        open: { backgroundColor: 'accent.pink.subtle', color: 'text.pink' },
-        strength: { backgroundColor: 'accent.emerald.subtle', color: 'text.emerald' },
+        open: { backgroundColor: 'review.issue.subtle', color: 'review.issue.default' },
+        strength: {
+          backgroundColor: 'review.strength.subtle',
+          color: 'review.strength.default',
+        },
         settled: { backgroundColor: 'surface.muted', color: 'text.faint' },
       },
       active: { true: {}, false: {} },
     },
     compoundVariants: [
-      { tone: 'open', active: true, css: { backgroundColor: 'accent.pink.default', color: 'text.bright' } },
-      { tone: 'strength', active: true, css: { backgroundColor: 'accent.emerald.default', color: 'text.bright' } },
+      { tone: 'open', active: true, css: { backgroundColor: 'review.issue.default', color: 'surface.default' } },
+      { tone: 'strength', active: true, css: { backgroundColor: 'review.strength.default', color: 'surface.default' } },
       { tone: 'settled', active: true, css: { backgroundColor: 'border.strong', color: 'text.bright' } },
     ],
   });

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismOverviewRuler.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismOverviewRuler.svelte
@@ -50,9 +50,9 @@
     },
     variants: {
       tone: {
-        open: { backgroundColor: 'accent.pink.default' },
+        open: { backgroundColor: 'review.issue.default' },
         closed: { backgroundColor: 'border.strong' },
-        strength: { backgroundColor: 'accent.emerald.default' },
+        strength: { backgroundColor: 'review.strength.default' },
       },
       active: { true: { width: '10px', opacity: '100' }, false: { width: '6px', opacity: '55' } },
     },

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismRail.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismRail.svelte
@@ -22,17 +22,17 @@
     },
     variants: {
       tone: {
-        open: { backgroundColor: 'accent.pink.subtle' },
+        open: { backgroundColor: 'review.issue.subtle' },
         closed: { backgroundColor: 'surface.muted' },
-        strength: { backgroundColor: 'accent.emerald.subtle' },
+        strength: { backgroundColor: 'review.strength.subtle' },
       },
       active: { true: {}, false: {} },
     },
     // 막대·레일 칩·카드 칩은 같은 지적의 세 표지다 — 상태마다 셋이 정확히 같은 색이어야 한다
     compoundVariants: [
-      { tone: 'open', active: true, css: { backgroundColor: 'accent.pink.default' } },
+      { tone: 'open', active: true, css: { backgroundColor: 'review.issue.default' } },
       { tone: 'closed', active: true, css: { backgroundColor: 'border.strong' } },
-      { tone: 'strength', active: true, css: { backgroundColor: 'accent.emerald.default' } },
+      { tone: 'strength', active: true, css: { backgroundColor: 'review.strength.default' } },
     ],
   });
 
@@ -50,17 +50,20 @@
     },
     variants: {
       tone: {
-        open: { backgroundColor: 'accent.pink.subtle', color: 'text.pink' },
+        open: { backgroundColor: 'review.issue.subtle', color: 'review.issue.default' },
         closed: { backgroundColor: 'surface.muted', color: 'text.faint' },
-        strength: { backgroundColor: 'accent.emerald.subtle', color: 'text.emerald' },
+        strength: {
+          backgroundColor: 'review.strength.subtle',
+          color: 'review.strength.default',
+        },
       },
       active: { true: {}, false: {} },
     },
     // 활성 반전도 계열을 따른다 — 표기 전체가 회색조인 닫힌 지적에서 칩만 브랜드로 뒤집히면 어긋난다
     compoundVariants: [
-      { tone: 'open', active: true, css: { backgroundColor: 'accent.pink.default', color: 'text.bright' } },
+      { tone: 'open', active: true, css: { backgroundColor: 'review.issue.default', color: 'surface.default' } },
       { tone: 'closed', active: true, css: { backgroundColor: 'border.strong', color: 'text.bright' } },
-      { tone: 'strength', active: true, css: { backgroundColor: 'accent.emerald.default', color: 'text.bright' } },
+      { tone: 'strength', active: true, css: { backgroundColor: 'review.strength.default', color: 'surface.default' } },
     ],
   });
 

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismReviewHighlightLayer.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismReviewHighlightLayer.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import { token } from '@typie/styled-system/tokens';
+  import { untrack } from 'svelte';
+  import { getEditorContext } from '$lib/editor-ffi/editor.svelte';
+  import { getMarginContext } from './context.svelte.ts';
+  import PrismReviewHighlightRect from './PrismReviewHighlightRect.svelte';
+  import type { PageRect } from '@typie/editor-ffi/browser';
+
+  type HighlightRect = { rangeId: string; fragmentIndex: number; pageRect: PageRect };
+
+  const ctx = getEditorContext();
+  const editor = $derived(ctx.editor);
+  const margin = getMarginContext();
+  const highlight = $derived.by<{ kind: 'issue' | 'strength' | null; rects: HighlightRect[] }>(() => {
+    const activeId = margin.activeId;
+    const published = editor?.published;
+    if (activeId === null || !editor || !published) return { kind: null, rects: [] };
+
+    // items는 applied snapshot에도 반응하지만 rect는 published canvas와만 함께 바뀌어야 한다.
+    const active = untrack(() => margin.items.find((item) => item.id === activeId));
+    if (!active) return { kind: null, rects: [] };
+
+    const rects = active.rangeIds
+      .flatMap((rangeId) =>
+        (editor.trackedRangeForSnapshot(rangeId, published.snapshot)?.rects ?? []).map((pageRect, fragmentIndex) => ({
+          rangeId,
+          fragmentIndex,
+          pageRect,
+        })),
+      )
+      .filter(({ pageRect }) => published.frames.has(pageRect.page_idx));
+
+    return {
+      kind: active.kind,
+      rects,
+    };
+  });
+  const edge = $derived(token(highlight.kind === 'strength' ? 'colors.review.strength.default' : 'colors.review.issue.default'));
+  const fill = $derived(token(highlight.kind === 'strength' ? 'colors.review.strength.highlight' : 'colors.review.issue.highlight'));
+</script>
+
+{#if editor}
+  {#each highlight.rects as rect (`${rect.rangeId}:${rect.fragmentIndex}`)}
+    <PrismReviewHighlightRect {edge} {editor} {fill} kind={highlight.kind} rect={rect.pageRect} />
+  {/each}
+{/if}

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismReviewHighlightRect.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismReviewHighlightRect.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+  import { presentedPageElement } from '$lib/editor-ffi/geometry';
+  import type { PageRect } from '@typie/editor-ffi/browser';
+  import type { Editor } from '$lib/editor-ffi/editor.svelte';
+
+  type Props = {
+    editor: Editor;
+    edge: string;
+    fill: string;
+    kind: 'issue' | 'strength' | null;
+    rect: PageRect;
+  };
+
+  let { editor, edge, fill, kind, rect }: Props = $props();
+
+  const container = $derived(presentedPageElement(editor, rect.page_idx));
+  let element = $state<HTMLDivElement>();
+
+  $effect(() => {
+    if (container && element && element.parentElement !== container) container.append(element);
+  });
+</script>
+
+<div
+  bind:this={element}
+  style:--review-edge={edge}
+  style:--review-fill={fill}
+  style:left={`${rect.rect.x}px`}
+  style:top={`${rect.rect.y}px`}
+  style:width={`${rect.rect.width}px`}
+  style:height={`${rect.rect.height}px`}
+  class="prism-review-highlight"
+  data-prism-review-highlight={kind}
+></div>
+
+<style>
+  .prism-review-highlight {
+    position: absolute;
+    overflow: hidden;
+    border-radius: 3px;
+    pointer-events: none;
+  }
+
+  .prism-review-highlight::before,
+  .prism-review-highlight::after {
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    content: '';
+    pointer-events: none;
+  }
+
+  .prism-review-highlight::before {
+    color: var(--review-fill);
+    background: linear-gradient(
+      180deg,
+      color-mix(in oklch, currentColor 4%, transparent) 0%,
+      color-mix(in oklch, currentColor 4%, transparent) 52%,
+      color-mix(in oklch, currentColor 15%, transparent) 74%,
+      color-mix(in oklch, currentColor 36%, transparent) 100%
+    );
+    mix-blend-mode: color;
+  }
+
+  .prism-review-highlight::after {
+    color: var(--review-edge);
+    box-shadow: inset 0 -1px color-mix(in oklch, var(--review-edge) 72%, transparent);
+  }
+</style>

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismReviewMargin.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismReviewMargin.svelte
@@ -11,6 +11,7 @@
   import { TIER_OPTIONS } from '../../../@prism/review/tiers.ts';
   import { setupMarginContext } from './context.svelte.ts';
   import { COLUMN_GAP, COLUMN_WIDTH, describeThread, GUTTER, resolveMode } from './margin-view.ts';
+  import PrismReviewHighlightLayer from './PrismReviewHighlightLayer.svelte';
   import type { Selection } from '@typie/editor-ffi/browser';
   import type { Anchor } from '@typie/prism';
   import type { Snippet } from 'svelte';
@@ -368,7 +369,6 @@
       nextRaw.push({ ...spec.item, rangeIds: place.rangeIds });
     }
 
-    current.installPrismReviewDecorations();
     current.setPrismReviewRanges(installs);
     placed = next;
     raw = nextRaw;
@@ -433,13 +433,6 @@
     if (raw.every((item) => item.rangeIds.length > 0)) return;
     lostRetry = setTimeout(() => untrack(() => buildItems(new Set(), true)), LOST_RETRY_IDLE);
   };
-
-  $effect(() => {
-    const current = editor;
-    if (!current) return;
-    const active = items.find((item) => item.id === activeId);
-    current.setActivePrismReviewRanges(active?.rangeIds ?? []);
-  });
 
   // 닫는다고 목록에서 빠지지 않는다 — 이번 회차의 피드백은 닫혀도 회색으로 제자리에 남는다.
   // 다른 갈래로 옮겨 가는 것은 재리뷰 사영(회차 경계)에서만 일어나며, 그 축(bornRound)은 다음 스코프다.
@@ -723,3 +716,4 @@
 </script>
 
 {@render children(insets)}
+<PrismReviewHighlightLayer />

--- a/assets/theme.json
+++ b/assets/theme.json
@@ -38,9 +38,7 @@
     "ui.search-match": "#ffff80",
     "ui.search-match-active": "#ffd280",
     "ui.comment-highlight": "#ffe8b3",
-    "ui.comment-highlight-active": "#ffd98a",
-    "ui.prism-issue-active": "#ffd8ff",
-    "ui.prism-strength-active": "#caf8d3"
+    "ui.comment-highlight-active": "#ffd98a"
   },
   "darkShared": {
     "ui.accent.brand.default": "#505ca4",
@@ -61,9 +59,7 @@
     "ui.search-match": "#544a2e",
     "ui.search-match-active": "#a06828",
     "ui.comment-highlight": "#5c4a1f",
-    "ui.comment-highlight-active": "#6e5824",
-    "ui.prism-issue-active": "#643d60",
-    "ui.prism-strength-active": "#29583d"
+    "ui.comment-highlight-active": "#6e5824"
   },
   "variants": {
     "light-white": {

--- a/packages/styled-system/src/colors.ts
+++ b/packages/styled-system/src/colors.ts
@@ -77,32 +77,32 @@ export const colors = defineTokens.colors({
     '950': { value: 'oklch(0.287 0.060 166)' }, // #003424
   },
 
-  emerald: {
-    '50': { value: 'oklch(0.965 0.025 152)' }, // #e8f9eb
-    '100': { value: 'oklch(0.905 0.072 152)' }, // #bdeec8
-    '200': { value: 'oklch(0.855 0.116 152)' }, // #93e6aa
-    '300': { value: 'oklch(0.795 0.174 152)' }, // #50db82
-    '400': { value: 'oklch(0.700 0.166 152)' }, // #32bb68
-    '500': { value: 'oklch(0.620 0.147 152)' }, // #299e58
-    '600': { value: 'oklch(0.560 0.133 152)' }, // #228a4b
-    '700': { value: 'oklch(0.490 0.116 152)' }, // #1b723e
-    '800': { value: 'oklch(0.420 0.100 152)' }, // #135c30
-    '900': { value: 'oklch(0.360 0.085 152)' }, // #0e4926
-    '950': { value: 'oklch(0.250 0.060 152)' }, // #042912
+  jade: {
+    '50': { value: 'oklch(0.9860 0.0136 158.3)' }, // #f3fdf7
+    '100': { value: 'oklch(0.9652 0.0312 158.3)' }, // #e3faec
+    '200': { value: 'oklch(0.9109 0.0494 158.3)' }, // #c7ecd5
+    '300': { value: 'oklch(0.8301 0.0845 158.3)' }, // #98d9b3
+    '400': { value: 'oklch(0.7181 0.1202 158.3)' }, // #59bb87
+    '500': { value: 'oklch(0.5865 0.1040 160.3)' }, // #398f67
+    '600': { value: 'oklch(0.5067 0.0877 160.3)' }, // #2f7454
+    '700': { value: 'oklch(0.4473 0.0780 162.3)' }, // #246247
+    '800': { value: 'oklch(0.3990 0.0650 162.3)' }, // #21523d
+    '900': { value: 'oklch(0.3404 0.0507 164.3)' }, // #1c4031
+    '950': { value: 'oklch(0.2870 0.0390 164.3)' }, // #163125
   },
 
-  pink: {
-    '50': { value: 'oklch(0.965 0.025 330)' }, // #feeefc
-    '100': { value: 'oklch(0.905 0.072 330)' }, // #fccff7
-    '200': { value: 'oklch(0.855 0.116 330)' }, // #fbb4f4
-    '300': { value: 'oklch(0.795 0.174 330)' }, // #f98ff1
-    '400': { value: 'oklch(0.730 0.246 330)' }, // #f85def
-    '500': { value: 'oklch(0.665 0.273 330)' }, // #e832e0
-    '600': { value: 'oklch(0.600 0.246 330)' }, // #ca2bc4
-    '700': { value: 'oklch(0.530 0.218 330)' }, // #ab22a6
-    '800': { value: 'oklch(0.460 0.189 330)' }, // #8d1b88
-    '900': { value: 'oklch(0.395 0.162 330)' }, // #72146e
-    '950': { value: 'oklch(0.265 0.109 330)' }, // #40073e
+  violet: {
+    '50': { value: 'oklch(0.9700 0.0157 294.8)' }, // #f5f3ff
+    '100': { value: 'oklch(0.9377 0.0325 292.8)' }, // #ebe7ff
+    '200': { value: 'oklch(0.8868 0.0591 289.8)' }, // #d8d4ff
+    '300': { value: 'oklch(0.8129 0.0993 287.8)' }, // #beb8ff
+    '400': { value: 'oklch(0.7205 0.1522 285.8)' }, // #9d94ff
+    '500': { value: 'oklch(0.6096 0.1807 284.8)' }, // #7b6de9
+    '600': { value: 'oklch(0.5122 0.1807 282.8)' }, // #5d50c9
+    '700': { value: 'oklch(0.4256 0.1673 280.8)' }, // #4439a6
+    '800': { value: 'oklch(0.3607 0.1405 278.8)' }, // #312d84
+    '900': { value: 'oklch(0.2958 0.1097 276.8)' }, // #212262
+    '950': { value: 'oklch(0.2200 0.0776 274.8)' }, // #11153e
   },
 
   blue: {
@@ -194,32 +194,32 @@ export const colors = defineTokens.colors({
       '950': { value: 'oklch(0.19 0.041 162)' }, // #00190e
     },
 
-    emerald: {
-      '50': { value: 'oklch(0.83 0.090 152)' }, // #9bd9ab
-      '100': { value: 'oklch(0.76 0.130 152)' }, // #6bc987
-      '200': { value: 'oklch(0.68 0.160 152)' }, // #32b364
-      '300': { value: 'oklch(0.60 0.157 152)' }, // #049a4e
-      '400': { value: 'oklch(0.55 0.144 152)' }, // #028844
-      '500': { value: 'oklch(0.48 0.126 152)' }, // #017137
-      '600': { value: 'oklch(0.41 0.107 152)' }, // #025a2b
-      '700': { value: 'oklch(0.35 0.092 152)' }, // #004721
-      '800': { value: 'oklch(0.29 0.076 152)' }, // #003617
-      '900': { value: 'oklch(0.24 0.063 152)' }, // #00270f
-      '950': { value: 'oklch(0.19 0.050 152)' }, // #001a08
+    jade: {
+      '50': { value: 'oklch(0.8300 0.0724 161.0)' }, // #9ed6b8
+      '100': { value: 'oklch(0.7545 0.0987 161.0)' }, // #73c39b
+      '200': { value: 'oklch(0.6753 0.0981 161.0)' }, // #5aaa83
+      '300': { value: 'oklch(0.5961 0.0862 161.0)' }, // #4c8f6e
+      '400': { value: 'oklch(0.5465 0.0790 161.0)' }, // #427f61
+      '500': { value: 'oklch(0.4772 0.0691 161.0)' }, // #366950
+      '600': { value: 'oklch(0.4079 0.0586 161.0)' }, // #2a543f
+      '700': { value: 'oklch(0.3485 0.0500 161.0)' }, // #204232
+      '800': { value: 'oklch(0.2890 0.0415 161.0)' }, // #163124
+      '900': { value: 'oklch(0.2395 0.0342 161.0)' }, // #0f241a
+      '950': { value: 'oklch(0.1900 0.0270 161.0)' }, // #081810
     },
 
-    pink: {
-      '50': { value: 'oklch(0.83 0.080 330)' }, // #e6b5e0
-      '100': { value: 'oklch(0.76 0.120 330)' }, // #dc95d5
-      '200': { value: 'oklch(0.68 0.190 330)' }, // #d665cf
-      '300': { value: 'oklch(0.60 0.210 330)' }, // #c142ba
-      '400': { value: 'oklch(0.55 0.210 330)' }, // #b030aa
-      '500': { value: 'oklch(0.48 0.190 330)' }, // #94228f
-      '600': { value: 'oklch(0.41 0.170 330)' }, // #791475
-      '700': { value: 'oklch(0.35 0.150 330)' }, // #62095e
-      '800': { value: 'oklch(0.29 0.120 330)' }, // #490847
-      '900': { value: 'oklch(0.24 0.100 330)' }, // #370435
-      '950': { value: 'oklch(0.19 0.080 330)' }, // #260224
+    violet: {
+      '50': { value: 'oklch(0.8300 0.0903 288.9)' }, // #c5beff
+      '100': { value: 'oklch(0.7599 0.1304 287.9)' }, // #ada3ff
+      '200': { value: 'oklch(0.6799 0.1541 286.9)' }, // #9387f1
+      '300': { value: 'oklch(0.5999 0.1719 285.9)' }, // #7a6be0
+      '400': { value: 'oklch(0.5499 0.1837 284.9)' }, // #6b5ad6
+      '500': { value: 'oklch(0.4800 0.1837 283.9)' }, // #5744bf
+      '600': { value: 'oklch(0.4100 0.1719 282.9)' }, // #4332a2
+      '700': { value: 'oklch(0.3500 0.1482 281.9)' }, // #332684
+      '800': { value: 'oklch(0.2900 0.1244 280.9)' }, // #251b66
+      '900': { value: 'oklch(0.2400 0.1007 279.9)' }, // #19144d
+      '950': { value: 'oklch(0.1900 0.0770 278.9)' }, // #0e0c35
     },
 
     blue: {
@@ -370,8 +370,6 @@ export const semanticColors = defineSemanticTokens.colors({
   'text.success': { value: { base: '{colors.green.700}', _dark: '{colors.dark.green.100}' } },
   'text.link': { value: { base: '{colors.blue.600}', _dark: '{colors.dark.blue.200}' } },
   'text.brand': { value: { base: '{colors.brand.500}', _dark: '{colors.dark.brand.100}' } },
-  'text.emerald': { value: { base: '{colors.emerald.700}', _dark: '{colors.dark.emerald.100}' } },
-  'text.pink': { value: { base: '{colors.pink.700}', _dark: '{colors.dark.pink.100}' } },
 
   'surface.default': {
     value: {
@@ -530,12 +528,6 @@ export const semanticColors = defineSemanticTokens.colors({
   // 알파는 광량을 표면에 맡기고 색기만 얹는다
   'accent.brand.subtle': { value: { base: '{colors.brand.100}', _dark: '{colors.dark.brand.300/30}' } },
   // 전 패밀리 공통 3규칙(브랜드와 동일): 채움 램프는 다크에서 반전(400→300→200), subtle 면은 선명한 300톤의 30% 알파
-  'accent.emerald.default': { value: { base: '{colors.emerald.500}', _dark: '{colors.dark.emerald.400}' } },
-  'accent.emerald.subtle': { value: { base: '{colors.emerald.100}', _dark: '{colors.dark.emerald.300/30}' } },
-  'accent.pink.default': { value: { base: '{colors.pink.500}', _dark: '{colors.dark.pink.400}' } },
-  'accent.pink.hover': { value: { base: '{colors.pink.600}', _dark: '{colors.dark.pink.300}' } },
-  'accent.pink.active': { value: { base: '{colors.pink.700}', _dark: '{colors.dark.pink.200}' } },
-  'accent.pink.subtle': { value: { base: '{colors.pink.100}', _dark: '{colors.dark.pink.300/30}' } },
   'accent.info.default': { value: { base: '{colors.blue.500}', _dark: '{colors.dark.blue.400}' } },
   'accent.info.subtle': { value: { base: '{colors.blue.50}', _dark: '{colors.dark.blue.300/30}' } },
   'accent.danger.default': { value: { base: '{colors.red.600}', _dark: '{colors.dark.red.400}' } },
@@ -546,6 +538,27 @@ export const semanticColors = defineSemanticTokens.colors({
   'accent.warning.subtle': { value: { base: '{colors.amber.50}', _dark: '{colors.dark.amber.300/30}' } },
   'accent.success.default': { value: { base: '{colors.green.700}', _dark: '{colors.dark.green.400}' } },
   'accent.success.subtle': { value: { base: '{colors.green.50}', _dark: '{colors.dark.green.300/30}' } },
+
+  'review.issue.default': { value: { base: '{colors.violet.500}', _dark: '{colors.dark.violet.100}' } },
+  'review.issue.subtle': {
+    value: {
+      base: 'color-mix(in oklch, {colors.violet.500} 16%, transparent)',
+      _dark: 'color-mix(in oklch, {colors.dark.violet.100} 16%, transparent)',
+    },
+  },
+  'review.issue.highlight': {
+    value: { base: 'color-mix(in oklch, {colors.violet.500} 35%, transparent)', _dark: '{colors.dark.violet.100}' },
+  },
+  'review.strength.default': { value: { base: '{colors.jade.500}', _dark: '{colors.dark.jade.100}' } },
+  'review.strength.subtle': {
+    value: {
+      base: 'color-mix(in oklch, {colors.jade.500} 16%, transparent)',
+      _dark: 'color-mix(in oklch, {colors.dark.jade.100} 16%, transparent)',
+    },
+  },
+  'review.strength.highlight': {
+    value: { base: 'color-mix(in oklch, {colors.jade.500} 35%, transparent)', _dark: '{colors.dark.jade.100}' },
+  },
 
   'border.default': {
     value: {
@@ -612,8 +625,6 @@ export const semanticColors = defineSemanticTokens.colors({
   },
   'border.brand': { value: { base: '{colors.brand.600}', _dark: '{colors.dark.brand.400}' } },
   'border.danger': { value: { base: '{colors.red.600}', _dark: '{colors.dark.red.400}' } },
-  'border.emerald': { value: { base: '{colors.emerald.600}', _dark: '{colors.dark.emerald.400}' } },
-  'border.pink': { value: { base: '{colors.pink.600}', _dark: '{colors.dark.pink.400}' } },
 
   'shadow.default': { value: { base: '{colors.gray.950}', _dark: '{colors.dark.gray.950}' } },
 


### PR DESCRIPTION
## 변경 사항

- 활성 PRISM 리뷰 범위의 하이라이트를 에디터 엔진 decoration 대신 페이지 위에서 렌더링하도록 변경
- issue와 strength에 각각 violet, jade 컬러 스케일 및 `review.*` 시맨틱 토큰 도입
- 카드, 레일, overview ruler의 리뷰 색상을 새 토큰으로 통일
- 새로운 본문 하이라이트 스타일

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>