### PR TITLE
prism rail hit area 수정

### DIFF
--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismRail.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismRail.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-  import { css, cva } from '@typie/styled-system/css';
+  import { css, cva, cx } from '@typie/styled-system/css';
   import { getMarginContext } from './context.svelte.ts';
   import { GUTTER } from './margin-view.ts';
-  import { layoutRails, RAIL_CHIP_SIZE, RAIL_TEXT_GAP, RAIL_WIDTH, railLeft } from './rail-layout.ts';
+  import { layoutRailHitTargets, RAIL_CHIP_SIZE, RAIL_TEXT_GAP, RAIL_WIDTH, railLeft } from './rail-layout.ts';
   import type { RailSpan } from './rail-layout.ts';
 
   // 거터는 실제로 비어 있는 폭, gap은 본문과의 이격이다 — 둘 다 좁아진 만큼만 받는다.
@@ -11,14 +11,15 @@
   let { spans, gutter = GUTTER, gap = RAIL_TEXT_GAP }: Props = $props();
 
   const margin = getMarginContext();
-  const rails = $derived(layoutRails(spans, gutter, gap));
+  const rails = $derived(layoutRailHitTargets(spans, gutter, gap));
 
   const barRecipe = cva({
     base: {
       position: 'absolute',
       borderRadius: 'full',
+      pointerEvents: 'auto',
       cursor: 'pointer',
-      transition: '[background-color 0.25s cubic-bezier(0.2, 0, 0, 1), left 0.25s cubic-bezier(0.2, 0, 0, 1)]',
+      transition: '[background-color 0.2s cubic-bezier(0.2, 0, 0, 1), opacity 0.2s cubic-bezier(0.2, 0, 0, 1)]',
     },
     variants: {
       tone: {
@@ -28,11 +29,13 @@
       },
       active: { true: {}, false: {} },
     },
-    // 막대·레일 칩·카드 칩은 같은 지적의 세 표지다 — 상태마다 셋이 정확히 같은 색이어야 한다
     compoundVariants: [
-      { tone: 'open', active: true, css: { backgroundColor: 'review.issue.default' } },
-      { tone: 'closed', active: true, css: { backgroundColor: 'border.strong' } },
-      { tone: 'strength', active: true, css: { backgroundColor: 'review.strength.default' } },
+      { tone: 'open', active: false, css: { _groupHover: { backgroundColor: 'review.issue.default', opacity: '80' } } },
+      { tone: 'closed', active: false, css: { _groupHover: { backgroundColor: 'border.strong', opacity: '80' } } },
+      { tone: 'strength', active: false, css: { _groupHover: { backgroundColor: 'review.strength.default', opacity: '80' } } },
+      { tone: 'open', active: true, css: { backgroundColor: 'review.issue.default', opacity: '100' } },
+      { tone: 'closed', active: true, css: { backgroundColor: 'border.strong', opacity: '100' } },
+      { tone: 'strength', active: true, css: { backgroundColor: 'review.strength.default', opacity: '100' } },
     ],
   });
 
@@ -43,10 +46,15 @@
       alignItems: 'center',
       justifyContent: 'center',
       borderRadius: '5px',
+      borderWidth: '1px',
+      borderStyle: 'solid',
+      borderColor: 'transparent',
       fontSize: '10px',
       fontWeight: 'bold',
+      pointerEvents: 'auto',
       cursor: 'pointer',
-      transition: '[background-color 0.25s cubic-bezier(0.2, 0, 0, 1), color 0.25s cubic-bezier(0.2, 0, 0, 1)]',
+      transition:
+        '[background-color 0.2s cubic-bezier(0.2, 0, 0, 1), border-color 0.2s cubic-bezier(0.2, 0, 0, 1), color 0.2s cubic-bezier(0.2, 0, 0, 1)]',
     },
     variants: {
       tone: {
@@ -59,11 +67,21 @@
       },
       active: { true: {}, false: {} },
     },
-    // 활성 반전도 계열을 따른다 — 표기 전체가 회색조인 닫힌 지적에서 칩만 브랜드로 뒤집히면 어긋난다
     compoundVariants: [
-      { tone: 'open', active: true, css: { backgroundColor: 'review.issue.default', color: 'surface.default' } },
-      { tone: 'closed', active: true, css: { backgroundColor: 'border.strong', color: 'text.bright' } },
-      { tone: 'strength', active: true, css: { backgroundColor: 'review.strength.default', color: 'surface.default' } },
+      { tone: 'open', active: false, css: { _groupHover: { borderColor: 'review.issue.default' } } },
+      { tone: 'closed', active: false, css: { _groupHover: { borderColor: 'border.strong' } } },
+      { tone: 'strength', active: false, css: { _groupHover: { borderColor: 'review.strength.default' } } },
+      {
+        tone: 'open',
+        active: true,
+        css: { backgroundColor: 'review.issue.default', borderColor: 'review.issue.default', color: 'surface.default' },
+      },
+      { tone: 'closed', active: true, css: { backgroundColor: 'border.strong', borderColor: 'border.strong', color: 'text.bright' } },
+      {
+        tone: 'strength',
+        active: true,
+        css: { backgroundColor: 'review.strength.default', borderColor: 'review.strength.default', color: 'surface.default' },
+      },
     ],
   });
 
@@ -74,31 +92,57 @@
   };
 </script>
 
-<!-- 레일은 켜기 전용이다 — 재클릭은 해제가 아니라 그 자리로 다시 데려간다. -->
+<!-- 숫자와 막대의 최소 사각형이 한 버튼이다. 시각 요소는 모든 투명 클릭 면보다 위에 서서 직접 클릭을 먼저 받는다. -->
 {#each rails as rail (rail.id)}
   {@const active = margin.activeId === rail.itemId}
+  {@const barLeft = railLeft(rail.lane, gutter, gap)}
+  {@const visualPriority = rails.length + rail.hitPriority + 1}
   <button
-    style:top={`${rail.top}px`}
-    style:height={`${rail.height}px`}
-    style:left={`${railLeft(rail.lane, gutter, gap)}px`}
-    style:width={`${RAIL_WIDTH}px`}
-    class={css(barRecipe.raw({ tone: rail.tone, active }))}
+    style:top={`${rail.hitBox.top}px`}
+    style:height={`${rail.hitBox.bottom - rail.hitBox.top}px`}
+    style:left={`${rail.hitBox.left}px`}
+    style:width={`${rail.hitBox.right - rail.hitBox.left}px`}
+    class={cx(
+      'group',
+      css({
+        position: 'absolute',
+        padding: '0',
+        borderWidth: '0',
+        backgroundColor: 'transparent',
+        pointerEvents: 'none',
+        cursor: 'pointer',
+      }),
+    )}
     aria-label={labelOf(rail)}
     data-prism-margin-activator
-    onclick={() => margin.activate(rail.itemId)}
-    type="button"
-  ></button>
-  <button
-    style:top={`${rail.chipTop}px`}
-    style:left={`${rail.chipLeft}px`}
-    style:width={`${RAIL_CHIP_SIZE}px`}
-    style:height={`${RAIL_CHIP_SIZE}px`}
-    class={css(chipRecipe.raw({ tone: rail.tone, active }))}
-    aria-label={labelOf(rail)}
-    data-prism-margin-activator
+    data-selected={active ? '' : undefined}
     onclick={() => margin.activate(rail.itemId)}
     type="button"
   >
-    {rail.number}
+    <span
+      style:z-index={rail.hitPriority}
+      class={css({ position: 'absolute', inset: '0', pointerEvents: 'auto', cursor: 'pointer' })}
+      aria-hidden="true"
+    ></span>
+    <span
+      style:top={`${rail.top - rail.hitBox.top}px`}
+      style:height={`${rail.height}px`}
+      style:left={`${barLeft - rail.hitBox.left}px`}
+      style:width={`${RAIL_WIDTH}px`}
+      style:z-index={visualPriority}
+      class={css(barRecipe.raw({ tone: rail.tone, active }))}
+      aria-hidden="true"
+    ></span>
+    <span
+      style:top={`${rail.chipTop - rail.hitBox.top}px`}
+      style:left={`${rail.chipLeft - rail.hitBox.left}px`}
+      style:width={`${RAIL_CHIP_SIZE}px`}
+      style:height={`${RAIL_CHIP_SIZE}px`}
+      style:z-index={visualPriority}
+      class={css(chipRecipe.raw({ tone: rail.tone, active }))}
+      aria-hidden="true"
+    >
+      {rail.number}
+    </span>
   </button>
 {/each}

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/rail-layout.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/rail-layout.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { layoutRails, maxRailLanes, RAIL_CHIP_SIZE, RAIL_TEXT_GAP, RAIL_WIDTH, railLeft } from './rail-layout.ts';
+import { layoutRailHitTargets, layoutRails, maxRailLanes, RAIL_CHIP_SIZE, RAIL_TEXT_GAP, RAIL_WIDTH, railLeft } from './rail-layout.ts';
 import type { PlacedRail, RailSpan } from './rail-layout.ts';
 
 const span = (id: string, top: number, height: number): RailSpan => ({
@@ -99,5 +99,30 @@ describe('maxRailLanes', () => {
   it('셈이 0 이하로 떨어져도 한 레인은 남는다', () => {
     expect(maxRailLanes(64)).toBe(1);
     expect(maxRailLanes(0)).toBe(1);
+  });
+});
+
+describe('layoutRailHitTargets', () => {
+  it('숫자와 막대를 포함하는 가장 작은 사각형을 만든다', () => {
+    const [target] = layoutRailHitTargets([span('a:0', 10, 40)], 100);
+
+    expect(target.hitBox).toEqual({ left: 35, top: 10, right: 56, bottom: 50 });
+  });
+
+  it('같은 레인에서는 작은 클릭 범위에 더 높은 우선순위를 준다', () => {
+    const [large, small] = layoutRailHitTargets([span('large:0', 0, 80), span('small:0', 100, 20)], 100);
+
+    expect(small.lane).toBe(large.lane);
+    expect(small.hitPriority).toBeGreaterThan(large.hitPriority);
+  });
+
+  it('클릭 범위가 더 커도 바깥 레인에 놓인 것에 높은 우선순위를 준다', () => {
+    const [inner, outer] = layoutRailHitTargets([span('inner:0', 0, 20), span('outer:0', 5, 80)], 100);
+
+    expect(outer.lane).toBeGreaterThan(inner.lane);
+    expect((outer.hitBox.right - outer.hitBox.left) * (outer.hitBox.bottom - outer.hitBox.top)).toBeGreaterThan(
+      (inner.hitBox.right - inner.hitBox.left) * (inner.hitBox.bottom - inner.hitBox.top),
+    );
+    expect(outer.hitPriority).toBeGreaterThan(inner.hitPriority);
   });
 });

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/rail-layout.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/rail-layout.ts
@@ -11,6 +11,9 @@ export type RailSpan = {
 
 export type PlacedRail = RailSpan & { lane: number; chipTop: number; chipLeft: number };
 
+export type RailHitBox = { left: number; top: number; right: number; bottom: number };
+export type RailHitTarget = PlacedRail & { hitBox: RailHitBox; hitPriority: number };
+
 export const RAIL_WIDTH = 3;
 export const RAIL_CHIP_SIZE = 16;
 export const RAIL_TEXT_GAP = 44;
@@ -30,9 +33,7 @@ export const maxRailLanes = (gutter: number): number =>
 // gap이 줄어드는 구간(거터 < 47)에서는 어느 쪽 셈이든 결과가 1레인으로 같다.
 export const railLeft = (lane: number, gutter: number, gap = RAIL_TEXT_GAP): number => gutter - gap - RAIL_WIDTH - lane * RAIL_LANE_STEP;
 
-type Box = { left: number; top: number; right: number; bottom: number };
-
-const intersects = (a: Box, b: Box) => a.left < b.right && b.left < a.right && a.top < b.bottom && b.top < a.bottom;
+const intersects = (a: RailHitBox, b: RailHitBox) => a.left < b.right && b.left < a.right && a.top < b.bottom && b.top < a.bottom;
 
 export const layoutRails = (spans: readonly RailSpan[], gutter: number, gap = RAIL_TEXT_GAP): PlacedRail[] => {
   const lanes = maxRailLanes(gutter);
@@ -56,16 +57,16 @@ export const layoutRails = (spans: readonly RailSpan[], gutter: number, gap = RA
     rail.lane = lane;
   }
 
-  const bars: Box[] = rails.map((rail) => {
+  const bars: RailHitBox[] = rails.map((rail) => {
     const left = railLeft(rail.lane, gutter, gap);
     return { left, top: rail.top, right: left + RAIL_WIDTH, bottom: rail.top + rail.height };
   });
 
-  const chips: Box[] = [];
+  const chips: RailHitBox[] = [];
   for (const [index, rail] of rails.entries()) {
     const barX = railLeft(rail.lane, gutter, gap);
     const sides = [barX - RAIL_CHIP_SIZE - RAIL_CHIP_GAP, barX + RAIL_WIDTH + RAIL_CHIP_GAP];
-    let chosen: Box | null = null;
+    let chosen: RailHitBox | null = null;
 
     for (const left of sides) {
       if (left < 0) continue;
@@ -97,4 +98,25 @@ export const layoutRails = (spans: readonly RailSpan[], gutter: number, gap = RA
   }
 
   return rails;
+};
+
+export const layoutRailHitTargets = (spans: readonly RailSpan[], gutter: number, gap = RAIL_TEXT_GAP): RailHitTarget[] => {
+  const targets = layoutRails(spans, gutter, gap).map((rail) => {
+    const barLeft = railLeft(rail.lane, gutter, gap);
+    return {
+      ...rail,
+      hitBox: {
+        left: Math.min(barLeft, rail.chipLeft),
+        top: Math.min(rail.top, rail.chipTop),
+        right: Math.max(barLeft + RAIL_WIDTH, rail.chipLeft + RAIL_CHIP_SIZE),
+        bottom: Math.max(rail.top + rail.height, rail.chipTop + RAIL_CHIP_SIZE),
+      },
+    };
+  });
+  const area = (target: (typeof targets)[number]) =>
+    (target.hitBox.right - target.hitBox.left) * (target.hitBox.bottom - target.hitBox.top);
+  const ordered = targets.toSorted((a, b) => a.lane - b.lane || area(b) - area(a));
+  const priority = new Map(ordered.map((target, hitPriority) => [target, hitPriority]));
+
+  return targets.map((target) => ({ ...target, hitPriority: priority.get(target) ?? 0 }));
 };


### PR DESCRIPTION
- 숫자와 라인을 포함하는 wrapper 전체가 hit area
- hover 스타일 추가
- 클릭 영역이 겹치면 더 바깥쪽 lane 피드백을 우선
- 같은 lane에서는 클릭 영역이 더 작은 피드백을 우선

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>