### PR TITLE
프리즘 리뷰 열기/닫기 모션 개선

### DIFF
--- a/apps/website/src/lib/editor-ffi/components/Editor.svelte
+++ b/apps/website/src/lib/editor-ffi/components/Editor.svelte
@@ -13,6 +13,7 @@
     style?: SystemStyleObject;
     contentInsetLeft?: number;
     contentInsetRight?: number;
+    contentMotion?: { fromX: number; duration: number; easing: string };
     header?: Snippet;
     footer?: Snippet;
     children?: Snippet;
@@ -27,6 +28,7 @@
     style,
     contentInsetLeft = 0,
     contentInsetRight = 0,
+    contentMotion,
     header,
     footer,
     children,
@@ -50,6 +52,7 @@
     {active}
     {contentInsetLeft}
     {contentInsetRight}
+    {contentMotion}
     {document$key}
     {footer}
     {header}

--- a/apps/website/src/lib/editor-ffi/components/View.svelte
+++ b/apps/website/src/lib/editor-ffi/components/View.svelte
@@ -53,6 +53,8 @@
     /** 본문 좌우에 비워 둘 폭. 여백 레이어(프리즘 리뷰)가 레일·카드 컬럼을 놓는 자리다. */
     contentInsetLeft?: number;
     contentInsetRight?: number;
+    /** 최종 레이아웃으로 바뀐 본문을 이전 화면 위치에서 합성하는 일회성 모션. */
+    contentMotion?: { fromX: number; duration: number; easing: string };
     onReady?: () => void;
     header?: Snippet;
     footer?: Snippet;
@@ -67,6 +69,7 @@
     style,
     contentInsetLeft = 0,
     contentInsetRight = 0,
+    contentMotion,
     onReady,
     header,
     footer,
@@ -173,6 +176,11 @@
   const continuousMaxFrameWidth = $derived(
     layoutMode?.type === 'continuous' ? `${layoutMode.max_width + CONTINUOUS_VIEW_PADDING * 2}px` : undefined,
   );
+  const contentAnimation = $derived.by(() => {
+    if (!contentMotion || contentMotion.fromX === 0) return;
+    const name = contentMotion.fromX > 0 ? 'editor-content-from-right' : 'editor-content-from-left';
+    return `${name} ${contentMotion.duration}ms ${contentMotion.easing} both`;
+  });
   // 헤더 폴백(판 없음)에서도 인셋은 래퍼 패딩으로 들어간다 — 상한도 그만큼 넓어야 안쪽 트랙이 그대로 남는다
   const headerFallbackMaxWidth = $derived(
     layoutMode?.type === 'continuous'
@@ -330,6 +338,8 @@
   >
     {#if ctx.editor && header}
       <div
+        style:--editor-content-from-x={`${contentMotion?.fromX ?? 0}px`}
+        style:animation={contentAnimation}
         style:width={headerGeometry ? `${headerGeometry.trackWidth + contentInsetLeft + contentInsetRight}px` : '100%'}
         style:min-width={headerGeometry ? undefined : editorMinWidth}
         style:max-width={headerGeometry ? undefined : headerFallbackMaxWidth}
@@ -372,9 +382,6 @@
               flexGrow: '1',
               width: 'full',
               userSelect: 'none',
-              ...(isPaginated && {
-                rowGap: 'var(--page-gap)',
-              }),
             },
             ctx.editor.readOnly && {
               WebkitUserSelect: 'none',
@@ -413,15 +420,32 @@
           tabindex={0}
           use:touchPanLock={ctx.editor.gesture.panLockActive}
         >
-          <EditorPages editor={ctx.editor} {surfaceHost} />
+          <div
+            style:--editor-content-from-x={`${contentMotion?.fromX ?? 0}px`}
+            style:animation={contentAnimation}
+            class={css({
+              position: 'relative',
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              flexGrow: '1',
+              flexShrink: '0',
+              width: 'full',
+              ...(isPaginated && {
+                rowGap: 'var(--page-gap)',
+              }),
+            })}
+          >
+            <EditorPages editor={ctx.editor} {surfaceHost} />
 
-          <DocumentOverlayLayer />
+            <DocumentOverlayLayer />
 
-          <Caret />
+            <Caret />
 
-          <LineHighlight />
+            <LineHighlight />
 
-          <PlaceholderOverlay />
+            <PlaceholderOverlay />
+          </div>
 
           <ViewportOverlay>
             <Input />
@@ -461,3 +485,23 @@
     <Scrollbar />
   {/if}
 </div>
+
+<style>
+  @keyframes -global-editor-content-from-right {
+    from {
+      translate: var(--editor-content-from-x) 0;
+    }
+    to {
+      translate: 0 0;
+    }
+  }
+
+  @keyframes -global-editor-content-from-left {
+    from {
+      translate: var(--editor-content-from-x) 0;
+    }
+    to {
+      translate: 0 0;
+    }
+  }
+</style>

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismMarginLayer.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismMarginLayer.svelte
@@ -7,7 +7,7 @@
   import PrismReviewDetail from '../../../@prism/review/PrismReviewDetail.svelte';
   import { getMarginContext } from './context.svelte.ts';
   import { lanePresentation, targetColumnLeft } from './margin-motion.ts';
-  import { COLUMN_WIDTH, GUTTER } from './margin-view.ts';
+  import { COLUMN_GAP, COLUMN_WIDTH, GUTTER } from './margin-view.ts';
   import PrismCardColumn from './PrismCardColumn.svelte';
   import PrismCardPopover from './PrismCardPopover.svelte';
   import PrismOverviewRuler from './PrismOverviewRuler.svelte';
@@ -20,8 +20,11 @@
 
   // 컨트롤러가 실제로 낸 오른쪽 자리. 회차를 갈아타는 동안에도 래치되어 유지되므로
   // 컬럼의 렌더 조건을 여기서 읽으면 자리가 없는 프레임에 그리지도, 전환 중에 깜빡이지도 않는다
-  type Props = { insetRight: number };
-  let { insetRight }: Props = $props();
+  type Props = {
+    insetRight: number;
+    contentMotion?: { fromX: number; duration: number; easing: string };
+  };
+  let { insetRight, contentMotion }: Props = $props();
 
   const ctx = getEditorContext();
   const margin = getMarginContext();
@@ -31,11 +34,26 @@
   let marks = $state.raw<Mark[]>([]);
   let bodyLeft = $state(0);
   let columnLeft = $state(0);
+  const railAnimation = $derived.by(() => {
+    if (!contentMotion || contentMotion.fromX === 0) return;
+    const name = contentMotion.fromX > 0 ? 'editor-content-from-right' : 'editor-content-from-left';
+    return `${name} ${contentMotion.duration}ms ${contentMotion.easing} both`;
+  });
   // 확장 영역 위에 얹힌 헤더(제목·부제목) 블록의 높이 — 세그먼트를 그 높이에 세운다
   let headerHeight = $state(0);
 
   const toneOf = (item: MarginItem): RailTone =>
     item.kind === 'strength' ? 'strength' : item.thread?.state === 'CLOSED' ? 'closed' : 'open';
+
+  const layoutLeftWithin = (element: HTMLElement, ancestor: HTMLElement): number | null => {
+    let left = 0;
+    let current: HTMLElement | null = element;
+    while (current !== null && current !== ancestor) {
+      left += current.offsetLeft;
+      current = current.offsetParent instanceof HTMLElement ? current.offsetParent : null;
+    }
+    return current === ancestor ? left : null;
+  };
 
   // items는 적용 스냅숏마다 새로 지어지고 published도 프레임 교체마다 새 번들이다 — 신원으로 재측정을 걸면
   // 타이핑 한 번마다 rect를 읽어 강제 리플로우가 난다. 측정은 판 번호와 항목 집합이 실제로 바뀔 때만 돈다.
@@ -113,10 +131,15 @@
     if (pageEl && layout) {
       const inset = layout.type === 'paginated' ? layout.page_margin_left * zoom : CONTINUOUS_VIEW_PADDING;
       const pageRect = pageEl.getBoundingClientRect();
-      bodyLeft = pageRect.left - areaRect.left + inset;
-      // 확장 영역은 인셋을 제 padding으로 받고 페이지는 그 안에서 가운데 정렬된다 — 오른쪽 끝에 붙이면
-      // 창이 넓을수록 카드가 원고에서 멀어진다. 레일이 그렇듯 컬럼도 페이지에 붙어야 한다.
-      columnLeft = targetColumnLeft(pageRect.right - areaRect.left, margin.presentationProgress);
+      const pageLayoutLeft = layoutLeftWithin(pageEl, area);
+      if (pageLayoutLeft !== null) {
+        bodyLeft = pageLayoutLeft + inset;
+        // getBoundingClientRect에는 본문 합성 translate가 들어간다. 레일·컬럼은 움직이면 안 되므로 transform을
+        // 타지 않는 layout 좌표와 실제 DOM에 적용된 인셋으로 목표 위치를 구한다.
+        const rightInset = Number.parseFloat(area.style.paddingRight) || 0;
+        const layoutProgress = Math.max(0, Math.min(1, rightInset / (COLUMN_WIDTH + COLUMN_GAP)));
+        columnLeft = targetColumnLeft(pageLayoutLeft + pageRect.width, layoutProgress);
+      }
     }
   };
 
@@ -212,6 +235,8 @@
          빈 거터는 클릭을 본문에 넘긴다 — 막대·칩만 받는다. -->
     {#if margin.selectedRoundId !== null}
       <div
+        style:--editor-content-from-x={`${contentMotion?.fromX ?? 0}px`}
+        style:animation={railAnimation}
         style:left={`${bodyLeft - railGutter}px`}
         style:width={`${railGutter}px`}
         class={css({ position: 'absolute', top: '0', bottom: '0', '& > button': { pointerEvents: 'auto' } })}

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismReviewMargin.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismReviewMargin.svelte
@@ -9,10 +9,17 @@
   import { cache } from '$lib/graphql';
   import { takeMarginJump } from '$lib/prism/margin-jump.svelte';
   import { graphql } from '$mearie';
-  import { prismVisibilityEasing, reducedMotion } from '../../../@prism/lib/motion.ts';
+  import { PRISM_VISIBILITY_MOTION, prismVisibilityEasing, reducedMotion } from '../../../@prism/lib/motion.ts';
   import { TIER_OPTIONS } from '../../../@prism/review/tiers.ts';
   import { setupMarginContext } from './context.svelte.ts';
-  import { marginInsets, marginMotionDuration, marginMotionTarget, nextMarginReserved, resolvePresentedRoundId } from './margin-motion.ts';
+  import {
+    contentMotionOffset,
+    marginInsets,
+    marginMotionDuration,
+    marginMotionTarget,
+    nextMarginReserved,
+    resolvePresentedRoundId,
+  } from './margin-motion.ts';
   import { describeThread, resolveMode } from './margin-view.ts';
   import PrismReviewHighlightLayer from './PrismReviewHighlightLayer.svelte';
   import type { Selection } from '@typie/editor-ffi/browser';
@@ -36,6 +43,7 @@
         {
           left: number;
           right: number;
+          contentMotion?: { fromX: number; duration: number; easing: string };
         },
       ]
     >;
@@ -146,8 +154,9 @@
     );
   });
 
+  const reduceMotion = reducedMotion();
   const presentation = new Tween(0, {
-    duration: marginMotionDuration(reducedMotion()),
+    duration: marginMotionDuration(reduceMotion),
     easing: prismVisibilityEasing,
   });
   let presentationPrepared = $state(false);
@@ -155,8 +164,25 @@
   // 완전히 닫힌 컬럼만 첫 카드 배치가 끝났다는 신호를 받은 뒤 열림을 시작한다.
   const presentationAdmitted = $derived(presentationPrepared || presentation.current > 0);
   const presentationTarget = $derived(marginMotionTarget(mode, idle, reserved, presentationAdmitted));
+  const openInsets = marginInsets(1);
+  const contentShift = (openInsets.right - openInsets.left) / 2;
+  let contentMotion = $state<{ fromX: number; duration: number; easing: string }>();
+  // 목표가 바뀌는 순간의 진행률만 잡는다. Tween 매 프레임을 따라가면 CSS animation이 계속 다시 시작된다.
   $effect(() => {
-    presentation.target = presentationTarget;
+    const target = presentationTarget;
+    const progress = untrack(() => presentation.current);
+    contentMotion =
+      reduceMotion || progress === target
+        ? undefined
+        : {
+            fromX: contentMotionOffset(target, progress, contentShift),
+            duration: PRISM_VISIBILITY_MOTION.duration,
+            easing: PRISM_VISIBILITY_MOTION.easing,
+          };
+    presentation.target = target;
+  });
+  $effect(() => {
+    if (presentation.current === presentationTarget) contentMotion = undefined;
   });
 
   $effect(() => {
@@ -775,7 +801,7 @@
     react: (threadId, value) => guard(() => reactMutation({ input: { threadId, value } }), '처리하지 못했어요'),
   });
 
-  const insets = $derived(marginInsets(presentation.current));
+  const insets = $derived({ ...marginInsets(presentationTarget), contentMotion });
 
   onDestroy(() => {
     clearTimeout(lostRetry);

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/margin-motion.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/margin-motion.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  contentMotionOffset,
   lanePresentation,
   marginInsets,
   marginMotionDuration,
@@ -78,5 +79,19 @@ describe('targetColumnLeft', () => {
     expect(targetColumnLeft(closedPageRight, 0)).toBe(expected);
     expect(targetColumnLeft(closedPageRight + shift / 2, 0.5)).toBe(expected);
     expect(targetColumnLeft(closedPageRight + shift, 1)).toBe(expected);
+  });
+});
+
+describe('contentMotionOffset', () => {
+  it('전환 중 목표가 바뀌어도 현재 화면 위치를 이어 간다', () => {
+    const shift = 148;
+    const progress = 0.4;
+    const openingLayoutLeft = -shift;
+    const closingLayoutLeft = 0;
+
+    const openingVisualLeft = openingLayoutLeft + contentMotionOffset(1, progress, shift);
+    const closingVisualLeft = closingLayoutLeft + contentMotionOffset(0, progress, shift);
+
+    expect(openingVisualLeft).toBeCloseTo(closingVisualLeft);
   });
 });

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/margin-motion.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/margin-motion.ts
@@ -28,6 +28,8 @@ export const marginMotionTarget = (mode: MarginMode, idle: boolean, reserved: bo
 
 export const marginMotionDuration = (reduceMotion: boolean): number => (reduceMotion ? 0 : PRISM_VISIBILITY_MOTION.duration);
 
+export const contentMotionOffset = (target: 0 | 1, progress: number, shift: number): number => (target - clampProgress(progress)) * shift;
+
 export const targetColumnLeft = (pageRight: number, progress: number): number => {
   const remaining = 1 - clampProgress(progress);
   return pageRight + COLUMN_GAP + ((GUTTER - (COLUMN_WIDTH + COLUMN_GAP)) * remaining) / 2;

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditor.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditor.svelte
@@ -1336,6 +1336,7 @@
                             active={focused}
                             contentInsetLeft={insets.left}
                             contentInsetRight={insets.right}
+                            contentMotion={insets.contentMotion}
                             document$key={document}
                             onReady={handleEditorReady}
                           >
@@ -1445,7 +1446,7 @@
                               </div>
                             {/snippet}
                             <CommentPopover />
-                            <PrismMarginLayer insetRight={insets.right} />
+                            <PrismMarginLayer contentMotion={insets.contentMotion} insetRight={insets.right} />
                           </EditorComponent>
                         </svelte:boundary>
                       {/key}


### PR DESCRIPTION
## 변경 사항

프리즘 리뷰를 열고 닫을 때 매 프레임 본문 여백을 변경하던 방식을 없앴습니다.

최종 레이아웃은 한 번만 적용하고, 본문·헤더·레일의 이동은 CSS `translate`로 처리해 기존 전환 효과를 더 부드럽게 표시합니다.

## 확인

- 리뷰 열기 및 닫기
- 전환 중 빠른 방향 전환
- 본문과 레일의 이동 동기화

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>