### PR TITLE
프리즘 대화 하단 스크롤 추종 수정

### DIFF
--- a/apps/website/src/routes/website/(dashboard)/@prism/PrismTranscript.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@prism/PrismTranscript.svelte
@@ -118,6 +118,7 @@
   const late = $derived(nowTick - lastBeat >= LATE_MS);
 
   const MAX_FRAME_MS = 100;
+  const BOTTOM_FOLLOW_TOLERANCE_PX = 8;
 
   const reduceMotion = typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
   const newPaced = () => new PacedText({ instant: reduceMotion });
@@ -136,6 +137,11 @@
     }
 
     chase = true;
+  };
+
+  const resumeFollow = () => {
+    follow = true;
+    if (container) chaseBottom(container);
   };
 
   let live = $state<PacedText | null>(null);
@@ -229,8 +235,11 @@
       if (follow && container) {
         const target = container.scrollHeight - container.clientHeight;
         const gap = target - container.scrollTop;
-        if (gap > 0) container.scrollTop = gap < 1 ? target : container.scrollTop + gap * (1 - Math.exp(-dt / 120));
-        if (!active && gap < 1) chase = false;
+        if (gap > 0) {
+          const step = gap * (1 - Math.exp(-dt / 120));
+          container.scrollTop = gap < BOTTOM_FOLLOW_TOLERANCE_PX ? target : container.scrollTop + Math.max(1, step);
+        }
+        if (!active && gap < BOTTOM_FOLLOW_TOLERANCE_PX) chase = false;
       } else if (!active) {
         chase = false;
       }
@@ -286,7 +295,7 @@
   let prevPending: string | null = null;
 
   $effect.pre(() => {
-    if (pending !== null && prevPending === null) follow = true;
+    if (pending !== null && prevPending === null) resumeFollow();
     prevPending = pending;
   });
 
@@ -313,10 +322,10 @@
     }
 
     const gap = element.scrollHeight - element.scrollTop - element.clientHeight;
-    if (element.scrollTop < lastTop - 1 && gap >= 8) {
+    if (element.scrollTop < lastTop - 1 && gap >= BOTTOM_FOLLOW_TOLERANCE_PX) {
       follow = false;
-    } else if (gap < 8) {
-      follow = true;
+    } else if (!follow && gap < BOTTOM_FOLLOW_TOLERANCE_PX) {
+      resumeFollow();
     }
 
     lastTop = element.scrollTop;
@@ -337,7 +346,7 @@
     const scroller = container;
     if (!scroller || !content) return;
     const observer = new ResizeObserver(() => {
-      if (follow && !active) {
+      if (follow) {
         chaseBottom(scroller);
       }
       updateOverflow();
@@ -515,10 +524,7 @@
         _active: { transform: 'scale(0.97)' },
       })}
       aria-label="아래로"
-      onclick={() => {
-        follow = true;
-        container?.scrollTo({ top: container.scrollHeight, behavior: reduceMotion ? 'auto' : 'smooth' });
-      }}
+      onclick={resumeFollow}
       type="button"
       in:pop
       out:pop={{ out: true }}

--- a/apps/website/src/routes/website/(dashboard)/@prism/PrismTranscript.test-props.svelte.ts
+++ b/apps/website/src/routes/website/(dashboard)/@prism/PrismTranscript.test-props.svelte.ts
@@ -1,0 +1,9 @@
+class ReactiveProps<T extends object> {
+  value: T = $state() as T;
+
+  constructor(value: T) {
+    this.value = value;
+  }
+}
+
+export const reactiveProps = <T extends object>(props: T): T => new ReactiveProps(props).value;

--- a/apps/website/src/routes/website/(dashboard)/@prism/prism-transcript-scroll.browser.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/@prism/prism-transcript-scroll.browser.test.ts
@@ -1,0 +1,91 @@
+import '../../../../app.css';
+
+import { emptyTranscript } from '@typie/prism';
+import { mount, tick, unmount } from 'svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import PrismTranscript from './PrismTranscript.svelte';
+import { reactiveProps } from './PrismTranscript.test-props.svelte.ts';
+import type { Transcript, TranscriptMessage } from '@typie/prism';
+
+vi.mock('$env/dynamic/public', () => ({ env: {} }));
+
+const userMessage = (index: number): TranscriptMessage => ({
+  role: 'user',
+  key: `user-${index}`,
+  text: `message ${index} `.repeat(12),
+  at: index,
+  runSeq: null,
+});
+
+const transcriptWith = (messages: TranscriptMessage[]): Transcript => ({ ...emptyTranscript(), messages });
+const bottomGap = (element: HTMLElement) => element.scrollHeight - element.scrollTop - element.clientHeight;
+const nextFrame = () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+const waitForBottomGap = async (element: HTMLElement, maximum: number) => {
+  for (let frame = 0; frame < 120 && bottomGap(element) > maximum; frame++) await nextFrame();
+  expect(bottomGap(element)).toBeLessThanOrEqual(maximum);
+};
+
+let component: Record<string, unknown> | undefined;
+
+afterEach(async () => {
+  if (component) await unmount(component);
+  component = undefined;
+  document.body.replaceChildren();
+});
+
+describe('PRISM transcript bottom follow', () => {
+  it('chases the actual bottom whenever the go-to-bottom button is absent', async () => {
+    const messages = Array.from({ length: 30 }, (_, index) => userMessage(index));
+    const props = reactiveProps({
+      transcript: transcriptWith(messages),
+      loading: false,
+      pending: null as string | null,
+      sessionId: 'session-1' as string | null,
+      failedIds: new Set<string>(),
+      reconnecting: false,
+      policy: 'STANDARD' as const,
+      onResolve: vi.fn().mockResolvedValue(undefined),
+      onRetry: vi.fn(),
+    });
+    const target = document.createElement('div');
+    Object.assign(target.style, { display: 'flex', flexDirection: 'column', height: '320px', width: '360px' });
+    document.body.append(target);
+    component = mount(PrismTranscript, { target, props });
+
+    await tick();
+    const scroller = target.firstElementChild?.firstElementChild;
+    expect(scroller).toBeInstanceOf(HTMLElement);
+    if (!(scroller instanceof HTMLElement)) return;
+    await waitForBottomGap(scroller, 1);
+    expect(scroller.scrollHeight).toBeGreaterThan(scroller.clientHeight);
+
+    scroller.dispatchEvent(new Event('scroll'));
+    scroller.scrollTop = scroller.scrollHeight - scroller.clientHeight - 40;
+    scroller.dispatchEvent(new Event('scroll'));
+    await tick();
+    expect(target.querySelector('[aria-label="아래로"]')).not.toBeNull();
+
+    scroller.scrollTop = scroller.scrollHeight - scroller.clientHeight - 7;
+    scroller.dispatchEvent(new Event('scroll'));
+    await tick();
+    await vi.waitFor(() => expect(target.querySelector('[aria-label="아래로"]')).toBeNull());
+    await waitForBottomGap(scroller, 1);
+
+    const previousScrollHeight = scroller.scrollHeight;
+    props.transcript = transcriptWith([...messages, userMessage(messages.length)]);
+    await tick();
+    await vi.waitFor(() => expect(scroller.scrollHeight).toBeGreaterThan(previousScrollHeight));
+    await waitForBottomGap(scroller, 7);
+    expect(target.querySelector('[aria-label="아래로"]')).toBeNull();
+
+    scroller.scrollTop = scroller.scrollHeight - scroller.clientHeight - 40;
+    scroller.dispatchEvent(new Event('scroll'));
+    await tick();
+    const button = target.querySelector('[aria-label="아래로"]');
+    expect(button).toBeInstanceOf(HTMLButtonElement);
+    if (!(button instanceof HTMLButtonElement)) return;
+    button.click();
+    await waitForBottomGap(scroller, 1);
+    await vi.waitFor(() => expect(target.querySelector('[aria-label="아래로"]')).toBeNull());
+  });
+});


### PR DESCRIPTION
## 변경 사항

- 추종 재개 시 `follow` 상태만 바꾸지 않고 하단 추종 애니메이션도 함께 시작하도록 통합
- 대화 전송, 하단 근처 재진입, go-to-bottom 버튼 클릭이 동일한 추종 경로를 사용하도록 변경
- 추종 중에는 스트리밍 활성 여부와 관계없이 콘텐츠 크기 변경 시 하단 추종을 다시 시작
- 비례 이동량이 스크롤 좌표 반올림보다 작아져 멈추지 않도록 프레임당 최소 1px 이동 보장
- 기존 8px 하단 판정을 추종 완료와 스냅 기준에도 공통 적용
- 하단 이탈·재진입, 대화 추가, go-to-bottom 버튼 클릭을 검증하는 Chromium 브라우저 테스트 추가

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>