### PR TITLE
프리즘 리뷰 레일을 본문 쪽으로 정렬

### DIFF
--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismRail.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismRail.svelte
@@ -2,11 +2,11 @@
   import { css, cva, cx } from '@typie/styled-system/css';
   import { getMarginContext } from './context.svelte.ts';
   import { GUTTER } from './margin-view.ts';
-  import { layoutRailHitTargets, RAIL_CHIP_SIZE, RAIL_TEXT_GAP, RAIL_WIDTH, railLeft } from './rail-layout.ts';
+  import { layoutRailHitTargets, RAIL_CHIP_SIZE, RAIL_TEXT_GAP, RAIL_WIDTH } from './rail-layout.ts';
   import type { RailSpan } from './rail-layout.ts';
 
-  // 거터는 실제로 비어 있는 폭, gap은 본문과의 이격이다 — 둘 다 좁아진 만큼만 받는다.
-  // 공간이 모자랄 때 양보하는 것은 이격이지 막대가 아니다
+  // 거터는 rail이 사용할 수 있는 전체 폭이다. gap은 lane과 번호 칩의 상대 위치를 정할 때 오른쪽에 미리 남겨 두는 공간이다.
+  // layoutRails는 그 상대 위치를 유지한 채, 세로로 겹치는 묶음 전체를 본문에서 최소 간격만큼 떨어진 자리로 옮긴다.
   type Props = { spans: RailSpan[]; gutter?: number; gap?: number };
   let { spans, gutter = GUTTER, gap = RAIL_TEXT_GAP }: Props = $props();
 
@@ -95,7 +95,6 @@
 <!-- 숫자와 막대의 최소 사각형이 한 버튼이다. 시각 요소는 모든 투명 클릭 면보다 위에 서서 직접 클릭을 먼저 받는다. -->
 {#each rails as rail (rail.id)}
   {@const active = margin.activeId === rail.itemId}
-  {@const barLeft = railLeft(rail.lane, gutter, gap)}
   {@const visualPriority = rails.length + rail.hitPriority + 1}
   <button
     style:top={`${rail.hitBox.top}px`}
@@ -127,7 +126,7 @@
     <span
       style:top={`${rail.top - rail.hitBox.top}px`}
       style:height={`${rail.height}px`}
-      style:left={`${barLeft - rail.hitBox.left}px`}
+      style:left={`${rail.left - rail.hitBox.left}px`}
       style:width={`${RAIL_WIDTH}px`}
       style:z-index={visualPriority}
       class={css(barRecipe.raw({ tone: rail.tone, active }))}

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/rail-layout.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/rail-layout.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { layoutRailHitTargets, layoutRails, maxRailLanes, RAIL_CHIP_SIZE, RAIL_TEXT_GAP, RAIL_WIDTH, railLeft } from './rail-layout.ts';
+import { layoutRailHitTargets, layoutRails, maxRailLanes, RAIL_CHIP_SIZE, RAIL_TEXT_GAP, RAIL_WIDTH } from './rail-layout.ts';
 import type { PlacedRail, RailSpan } from './rail-layout.ts';
 
 const span = (id: string, top: number, height: number): RailSpan => ({
@@ -15,10 +15,12 @@ type Box = { left: number; top: number; right: number; bottom: number };
 
 const intersects = (a: Box, b: Box) => a.left < b.right && b.left < a.right && a.top < b.bottom && b.top < a.bottom;
 
-const barBox = (rail: PlacedRail, gutter: number): Box => {
-  const left = railLeft(rail.lane, gutter);
-  return { left, top: rail.top, right: left + RAIL_WIDTH, bottom: rail.top + rail.height };
-};
+const barBox = (rail: PlacedRail): Box => ({
+  left: rail.left,
+  top: rail.top,
+  right: rail.left + RAIL_WIDTH,
+  bottom: rail.top + rail.height,
+});
 
 const chipBox = (rail: PlacedRail): Box => ({
   left: rail.chipLeft,
@@ -65,8 +67,8 @@ describe('layoutRails', () => {
       first.chipTop < second.chipTop + RAIL_CHIP_SIZE &&
       second.chipTop < first.chipTop + RAIL_CHIP_SIZE;
     expect(overlaps).toBe(false);
-    expect(intersects(chipBox(first), barBox(second, 100))).toBe(false);
-    expect(intersects(chipBox(second), barBox(first, 100))).toBe(false);
+    expect(intersects(chipBox(first), barBox(second))).toBe(false);
+    expect(intersects(chipBox(second), barBox(first))).toBe(false);
   });
 
   // 소비자는 거터가 좁으면 이격을 그만큼 줄여 부른다 — 그때도 0번 레인은 컨테이너 안에 남아야 한다.
@@ -75,13 +77,12 @@ describe('layoutRails', () => {
     for (const gutter of [20, 30, 40, 47, 60, 100]) {
       const gap = Math.min(RAIL_TEXT_GAP, Math.max(0, gutter - RAIL_WIDTH));
       const [rail] = layoutRails([span('a:0', 0, 20)], gutter, gap);
-      const left = railLeft(0, gutter, gap);
       expect(rail.lane).toBe(0);
-      expect(left).toBeGreaterThanOrEqual(0);
+      expect(rail.left).toBeGreaterThanOrEqual(0);
       expect(rail.chipLeft).toBeGreaterThanOrEqual(0);
       // 칩은 layoutRails 안에서 배치되므로 이 단언이 gap이 실제로 흘러 들어갔는지를 잡는다 —
       // gap을 무시하면 막대를 음수에 두고 칩을 0에 얹어 둘이 겹친다
-      expect(intersects(chipBox(rail), { left, top: rail.top, right: left + RAIL_WIDTH, bottom: rail.top + rail.height })).toBe(false);
+      expect(intersects(chipBox(rail), barBox(rail))).toBe(false);
     }
   });
 });
@@ -103,10 +104,16 @@ describe('maxRailLanes', () => {
 });
 
 describe('layoutRailHitTargets', () => {
+  it('세로로 겹치지 않는 rail 덩어리는 각각 본문과 최소 간격을 두고 우측 정렬한다', () => {
+    const targets = layoutRailHitTargets([span('first:0', 0, 20), span('second:0', 40, 20)], 100);
+
+    expect(targets.map((target) => target.hitBox.right)).toEqual([84, 84]);
+  });
+
   it('숫자와 막대를 포함하는 가장 작은 사각형을 만든다', () => {
     const [target] = layoutRailHitTargets([span('a:0', 10, 40)], 100);
 
-    expect(target.hitBox).toEqual({ left: 35, top: 10, right: 56, bottom: 50 });
+    expect(target.hitBox).toEqual({ left: 63, top: 10, right: 84, bottom: 50 });
   });
 
   it('같은 레인에서는 작은 클릭 범위에 더 높은 우선순위를 준다', () => {

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/rail-layout.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/rail-layout.ts
@@ -9,7 +9,7 @@ export type RailSpan = {
   height: number;
 };
 
-export type PlacedRail = RailSpan & { lane: number; chipTop: number; chipLeft: number };
+export type PlacedRail = RailSpan & { lane: number; left: number; chipTop: number; chipLeft: number };
 
 export type RailHitBox = { left: number; top: number; right: number; bottom: number };
 export type RailHitTarget = PlacedRail & { hitBox: RailHitBox; hitPriority: number };
@@ -21,6 +21,7 @@ export const RAIL_TEXT_GAP = 44;
 const RAIL_LANE_STEP = 7;
 const RAIL_MIN_HEIGHT = 14;
 const RAIL_CHIP_GAP = 2;
+const RAIL_BODY_GAP = 16;
 const LANE_CLEARANCE = 6;
 
 // 레인 상한의 구속 조건은 막대가 아니라 왼쪽 칩 자리다 — 마지막 레인도 왼쪽 배치가 가능해야
@@ -28,8 +29,9 @@ const LANE_CLEARANCE = 6;
 export const maxRailLanes = (gutter: number): number =>
   Math.max(1, Math.floor((gutter - RAIL_TEXT_GAP - RAIL_WIDTH - RAIL_CHIP_SIZE - RAIL_CHIP_GAP) / RAIL_LANE_STEP) + 1);
 
-// 공간이 모자라면 양보하는 것은 막대가 아니라 본문과의 이격이다 — 거터가 좁을 때 gap을 줄여 부르면
-// 0번 레인이 컨테이너 왼쪽 밖으로 나가지 않는다. maxRailLanes는 gap을 받지 않아도 된다:
+// lane과 번호 칩의 상대 위치를 정할 때는 오른쪽에 gap만큼 빈 공간을 둔다. 거터가 좁을 때 gap을 줄여 부르면
+// 0번 레인이 컨테이너 왼쪽 밖으로 나가지 않는다. 이 좌표는 아래에서 rail 묶음 전체를 옮기기 전의 위치다.
+// maxRailLanes는 gap을 받지 않아도 된다:
 // gap이 줄어드는 구간(거터 < 47)에서는 어느 쪽 셈이든 결과가 1레인으로 같다.
 export const railLeft = (lane: number, gutter: number, gap = RAIL_TEXT_GAP): number => gutter - gap - RAIL_WIDTH - lane * RAIL_LANE_STEP;
 
@@ -38,7 +40,7 @@ const intersects = (a: RailHitBox, b: RailHitBox) => a.left < b.right && b.left 
 export const layoutRails = (spans: readonly RailSpan[], gutter: number, gap = RAIL_TEXT_GAP): PlacedRail[] => {
   const lanes = maxRailLanes(gutter);
   const rails: PlacedRail[] = spans
-    .map((span) => ({ ...span, height: Math.max(RAIL_MIN_HEIGHT, span.height), lane: 0, chipTop: span.top, chipLeft: 0 }))
+    .map((span) => ({ ...span, height: Math.max(RAIL_MIN_HEIGHT, span.height), lane: 0, left: 0, chipTop: span.top, chipLeft: 0 }))
     .toSorted((a, b) => a.top - b.top);
 
   const laneBottoms: number[] = [];
@@ -58,13 +60,13 @@ export const layoutRails = (spans: readonly RailSpan[], gutter: number, gap = RA
   }
 
   const bars: RailHitBox[] = rails.map((rail) => {
-    const left = railLeft(rail.lane, gutter, gap);
-    return { left, top: rail.top, right: left + RAIL_WIDTH, bottom: rail.top + rail.height };
+    rail.left = railLeft(rail.lane, gutter, gap);
+    return { left: rail.left, top: rail.top, right: rail.left + RAIL_WIDTH, bottom: rail.top + rail.height };
   });
 
   const chips: RailHitBox[] = [];
   for (const [index, rail] of rails.entries()) {
-    const barX = railLeft(rail.lane, gutter, gap);
+    const barX = rail.left;
     const sides = [barX - RAIL_CHIP_SIZE - RAIL_CHIP_GAP, barX + RAIL_WIDTH + RAIL_CHIP_GAP];
     let chosen: RailHitBox | null = null;
 
@@ -97,18 +99,41 @@ export const layoutRails = (spans: readonly RailSpan[], gutter: number, gap = RA
     rail.chipTop = chosen.top;
   }
 
+  // 막대와 번호 칩의 세로 범위가 겹치거나 연쇄적으로 이어지는 rail을 한 묶음으로 본다.
+  // 묶음 안의 lane과 칩 좌우 위치는 그대로 두고, 가장 오른쪽 요소가 본문에서 RAIL_BODY_GAP만큼 떨어지도록
+  // 모든 rail을 같은 거리만큼 옮긴다. 세로 범위가 겹치지 않는 묶음은 따로 옮겨도 새 교차가 생기지 않는다.
+  const groups: { bottom: number; rails: PlacedRail[] }[] = [];
+  for (const rail of rails) {
+    const top = Math.min(rail.top, rail.chipTop);
+    const bottom = Math.max(rail.top + rail.height, rail.chipTop + RAIL_CHIP_SIZE);
+    const group = groups.at(-1);
+    if (group === undefined || group.bottom <= top) groups.push({ bottom, rails: [rail] });
+    else {
+      group.bottom = Math.max(group.bottom, bottom);
+      group.rails.push(rail);
+    }
+  }
+
+  for (const group of groups) {
+    const right = Math.max(...group.rails.map((rail) => Math.max(rail.left + RAIL_WIDTH, rail.chipLeft + RAIL_CHIP_SIZE)));
+    const offset = Math.max(0, gutter - RAIL_BODY_GAP - right);
+    for (const rail of group.rails) {
+      rail.left += offset;
+      rail.chipLeft += offset;
+    }
+  }
+
   return rails;
 };
 
 export const layoutRailHitTargets = (spans: readonly RailSpan[], gutter: number, gap = RAIL_TEXT_GAP): RailHitTarget[] => {
   const targets = layoutRails(spans, gutter, gap).map((rail) => {
-    const barLeft = railLeft(rail.lane, gutter, gap);
     return {
       ...rail,
       hitBox: {
-        left: Math.min(barLeft, rail.chipLeft),
+        left: Math.min(rail.left, rail.chipLeft),
         top: Math.min(rail.top, rail.chipTop),
-        right: Math.max(barLeft + RAIL_WIDTH, rail.chipLeft + RAIL_CHIP_SIZE),
+        right: Math.max(rail.left + RAIL_WIDTH, rail.chipLeft + RAIL_CHIP_SIZE),
         bottom: Math.max(rail.top + rail.height, rail.chipTop + RAIL_CHIP_SIZE),
       },
     };


### PR DESCRIPTION
프리즘 리뷰 레일이 주변에 겹치는 레일이 없어도 거터의 고정 위치에 남아, 본문과 불필요하게 멀어지는 경우가 있었습니다.

레일과 번호 칩의 상대 배치는 유지하면서 세로로 겹치는 묶음별로 본문 쪽에 정렬합니다. 각 묶음은 본문과 16px 간격을 유지합니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>