### PR TITLE
프리즘 리뷰 컬럼 하단에서 스크롤이 떨리는 문제 수정

### DIFF
--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismCardColumn.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismCardColumn.svelte
@@ -424,7 +424,7 @@
       {emptyCopy}
     </p>
   {:else if anchored}
-    <div bind:this={columnEl} class={css({ position: 'relative', flexGrow: '1' })}>
+    <div bind:this={columnEl} class={css({ position: 'relative', flexGrow: '1', overflowY: 'clip' })}>
       <div style:opacity={presentation.opacity} class={css(edgeLineRecipe.raw({ edge: 'top' }))}>
         <button class={css(edgeRowRecipe.raw({ shown: hiddenAbove > 0 }))} onclick={() => jumpEdge('up')} type="button">
           <div class={css(edgeBlurRecipe.raw({ layer: 'outermost', shown: hiddenAbove > 0 }))}></div>


### PR DESCRIPTION
문서 bottom보다 리뷰 카드 bottom이 더 밑에 있을 때 맨 밑에서 overscroll하면 스크롤이 떨리는 버그를 해결함

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>