### PR TITLE
프리즘 모핑 중 시각적 튐 수정

### DIFF
--- a/apps/website/src/routes/website/(dashboard)/@prism/PrismPanelIndicator.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@prism/PrismPanelIndicator.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
+  import themeData from '@typie/assets/theme.json' with { type: 'json' };
   import { PRISM_ICON_DURATION_SECONDS } from '@typie/prism-ui';
   import { token } from '@typie/styled-system/tokens';
-  import { onDestroy, onMount, tick, untrack } from 'svelte';
+  import { onDestroy, onMount, untrack } from 'svelte';
   import PrismObject from '$lib/prism-ui/PrismObject.svelte';
   import { createPrismIndicatorPath, samplePrismIndicatorPath } from './lib/prism-indicator-path.ts';
   import PrismPanelWelcomeMessage from './PrismPanelWelcomeMessage.svelte';
@@ -39,7 +40,7 @@
   let actor = $state<HTMLDivElement>();
   let actorMounted = $state(true);
   let actorVisible = $state(true);
-  let edgeColor = $state<string>();
+  const edgeColor = $derived(themeVariant ? themeData.variants[themeVariant]['ui.border.default'] : undefined);
   let mode = $state<Mode>('idle');
   let path: PrismIndicatorPath | null = null;
   let snapshot = $state<PrismRuntimeSnapshot>({
@@ -390,17 +391,6 @@
     clearDwell();
     cancelAdmission();
     stopFollowing();
-  });
-
-  $effect(() => {
-    const currentThemeVariant = themeVariant;
-    const currentActor = actor;
-    if (!currentActor) return;
-
-    void tick().then(() => {
-      if (destroyed || currentThemeVariant !== themeVariant || currentActor !== actor) return;
-      edgeColor = getComputedStyle(currentActor).color;
-    });
   });
 
   $effect(() => {

--- a/apps/website/src/routes/website/(dashboard)/@prism/prism-panel-indicator.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/@prism/prism-panel-indicator.test.ts
@@ -1,3 +1,4 @@
+import themeData from '@typie/assets/theme.json' with { type: 'json' };
 import { mount, tick, unmount } from 'svelte';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import PrismPanelIndicator from './PrismPanelIndicator.svelte';
@@ -140,27 +141,34 @@ const setSourceRect = (target: HTMLElement) => {
 };
 
 describe('Prism panel indicator', () => {
-  test('resamples the rendered edge color when the theme variant changes', async () => {
+  test('uses the theme-state edge color before the view-transition DOM catches up', async () => {
     const target = document.createElement('div');
-    let renderedColor = 'rgb(190, 190, 190)';
-    const computedStyle = vi
-      .spyOn(globalThis, 'getComputedStyle')
-      .mockImplementation(() => ({ color: renderedColor }) as CSSStyleDeclaration);
-    const props = reactiveProps({ phase: 'welcome' as const, themeVariant: 'light-white' as 'dark-black' | 'light-white' });
+    const previousTheme = document.documentElement.dataset.theme;
+    const previousLightVariant = document.documentElement.dataset.variantLight;
+    const previousDarkVariant = document.documentElement.dataset.variantDark;
+    document.documentElement.dataset.theme = 'dark';
+    document.documentElement.dataset.variantDark = 'black';
+    const darkColor = themeData.variants['dark-black']['ui.border.default'];
+    const lightColor = themeData.variants['light-white']['ui.border.default'];
+    const props = reactiveProps({ phase: 'welcome' as const, themeVariant: 'dark-black' as 'dark-black' | 'light-white' });
     const component = mount(PrismPanelIndicator, { target, props });
     try {
       await tick();
       await tick();
-      expect(runtime.object.update).toHaveBeenCalledWith(expect.objectContaining({ edgeColor: renderedColor }));
+      expect(runtime.object.update).toHaveBeenCalledWith(expect.objectContaining({ edgeColor: darkColor }));
 
       runtime.object.update.mockClear();
-      renderedColor = 'rgb(96, 96, 96)';
-      props.themeVariant = 'dark-black';
+      props.themeVariant = 'light-white';
       await tick();
       await tick();
-      expect(runtime.object.update).toHaveBeenCalledWith(expect.objectContaining({ edgeColor: renderedColor }));
+      expect(runtime.object.update).toHaveBeenCalledWith(expect.objectContaining({ edgeColor: lightColor }));
     } finally {
-      computedStyle.mockRestore();
+      if (previousTheme === undefined) delete document.documentElement.dataset.theme;
+      else document.documentElement.dataset.theme = previousTheme;
+      if (previousLightVariant === undefined) delete document.documentElement.dataset.variantLight;
+      else document.documentElement.dataset.variantLight = previousLightVariant;
+      if (previousDarkVariant === undefined) delete document.documentElement.dataset.variantDark;
+      else document.documentElement.dataset.variantDark = previousDarkVariant;
       await unmount(component);
     }
   });

--- a/packages/prism-ui/src/runtime.ts
+++ b/packages/prism-ui/src/runtime.ts
@@ -638,6 +638,7 @@ export function createPrismRuntime(options: PrismRuntimeOptions): PrismRuntime {
       controller.setIconMorphSample(null);
       if (targetProgress === 0) {
         controller.setActive(false);
+        resetPointerInteractionAppearance();
         settledTarget = 'icon';
       } else {
         controller.setRotationPhase(sample.phase);
@@ -673,6 +674,7 @@ export function createPrismRuntime(options: PrismRuntimeOptions): PrismRuntime {
       const first = samplePrismIconMorphTrajectory(trajectory, 0);
       const last = samplePrismIconMorphTrajectory(trajectory, 1);
       controller.setActive(true);
+      controller.setMorphPoseQuaternion(null);
       renderIconSample(first);
 
       if (action.instant) {
@@ -840,7 +842,10 @@ export function createPrismRuntime(options: PrismRuntimeOptions): PrismRuntime {
       const durationMs = targetDuration(requestOptions);
       if (destroyed || target === requestedTarget) return;
       stopPointerInteraction();
-      resetPointerInteractionAppearance();
+      // Keep the current light phase and interaction appearance until the
+      // WebGPU prism is fully hidden. Resetting them here makes the light jump
+      // before the prism-to-icon trajectory has even started.
+      if (target !== 'icon') resetPointerInteractionAppearance();
       requestedTarget = target;
       settledTarget = null;
       if (durationMs === null) {


### PR DESCRIPTION
## 변경 사항

- 아이콘 전환이 끝날 때까지 기존 자세와 광원 상태 유지
- 프리즘으로 돌아올 때 이전 포인터 인터랙션 자세 초기화
- 현재 테마 variant의 색상을 셰이더 아이콘 edge에 반영

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>