### PR TITLE
프리즘 리뷰 모드 전환 레이아웃 시프트 수정

### DIFF
--- a/apps/website/src/lib/editor-ffi/components/View.svelte
+++ b/apps/website/src/lib/editor-ffi/components/View.svelte
@@ -290,6 +290,7 @@
 >
   <div
     style:--page-gap={isPaginated ? `${pageGap}px` : undefined}
+    style:overflow-x={!useWindowScroll && contentAnimation ? 'clip' : undefined}
     class={css({
       display: 'flex',
       flexDirection: 'column',

--- a/apps/website/src/lib/editor-ffi/editor-host-failure.test.ts
+++ b/apps/website/src/lib/editor-ffi/editor-host-failure.test.ts
@@ -1281,14 +1281,40 @@ describe('Editor guarded core invocation', () => {
     editor.resizeViewportNow(320, 800, 1);
     expect(editor.appliedRevision).toBe(2);
     expect(editor.publishedRevision).toBe(1);
+    expect(editor.publishedViewport).toEqual({ width: 1, height: 1, scale_factor: 1 });
     expect(editor.isPublished(editor.appliedRevision, { requireFrame: true })).toBe(false);
 
     core.render_surface.mockReturnValue({ value: 2 });
     editor.invalidateSurface(0);
 
     expect(editor.publishedRevision).toBe(2);
+    expect(editor.publishedViewport).toEqual({ width: 320, height: 800, scale_factor: 1 });
     expect(editor.publishedSurfaceCanvas(0)).toBe(candidate);
     expect(editor.isPublished(editor.appliedRevision, { requireFrame: true })).toBe(true);
+
+    releaseHost();
+    editor.destroy();
+  });
+
+  it('publishes the immediately applied viewport with the retained frame', async () => {
+    const { editor, core } = await createEditor();
+    const releaseHost = editor.activateVisualHost();
+    const displayed = document.createElement('canvas');
+    editor.attachSurface(0, displayed, 100, 100);
+    core.render_surface.mockClear();
+    core.tick_through.mockImplementation((requestId) => ({
+      revision: { value: 2 },
+      events: [],
+      request_outcomes: [{ request_id: requestId, command_outcomes: [{ type: 'applied' }] }],
+    }));
+
+    editor.resizeViewportNow(320, 800, 1);
+
+    expect(core.render_surface).not.toHaveBeenCalled();
+    expect(editor.appliedRevision).toBe(2);
+    expect(editor.publishedRevision).toBe(2);
+    expect(editor.publishedViewport).toEqual({ width: 320, height: 800, scale_factor: 1 });
+    expect(editor.publishedSurfaceCanvas(0)).toBe(displayed);
 
     releaseHost();
     editor.destroy();

--- a/apps/website/src/lib/editor-ffi/editor-publication-preparation.test.ts
+++ b/apps/website/src/lib/editor-ffi/editor-publication-preparation.test.ts
@@ -5,6 +5,7 @@ import type { Editor, EditorSnapshot } from './editor.svelte';
 
 const snapshot = (overrides: Partial<EditorSnapshot>): EditorSnapshot => ({
   revision: 1,
+  viewport: { width: 600, height: 400, scale_factor: 1 },
   cursor: undefined,
   placeholder: undefined,
   selection: undefined,

--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -97,6 +97,7 @@ type PageSnapshot = Readonly<{
 
 export type EditorSnapshot = Readonly<{
   revision: number;
+  viewport: Viewport;
   cursor: CursorMetrics | undefined;
   placeholder: PlaceholderMetrics | undefined;
   selection: Selection | undefined;
@@ -351,6 +352,7 @@ export class Editor {
 
   #applied = $state.raw<EditorSnapshot>({
     revision: 0,
+    viewport: { width: 0, height: 0, scale_factor: 1 },
     cursor: undefined,
     placeholder: undefined,
     selection: undefined,
@@ -618,6 +620,7 @@ export class Editor {
 
       return {
         revision,
+        viewport: this.#appliedViewport,
         cursor: fields.has('cursor') ? core.cursor() : previous.cursor,
         placeholder: fields.has('placeholder') ? (core.placeholder() ?? undefined) : previous.placeholder,
         selection: fields.has('selection') || fields.has('doc') ? core.selection() : previous.selection,
@@ -1506,6 +1509,10 @@ export class Editor {
 
   get publishedRevision(): number | undefined {
     return this.published?.snapshot.revision;
+  }
+
+  get publishedViewport(): Viewport | undefined {
+    return this.published?.snapshot.viewport;
   }
 
   awaitPublishedRevision(revision: number, options?: { requireFrame?: boolean }): Promise<EditorPublicationResult> {

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismMarginLayer.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismMarginLayer.svelte
@@ -18,13 +18,10 @@
 
   type Mark = { itemId: string; ratio: number; tone: RailTone };
 
-  // 컨트롤러가 실제로 낸 오른쪽 자리. 회차를 갈아타는 동안에도 래치되어 유지되므로
-  // 컬럼의 렌더 조건을 여기서 읽으면 자리가 없는 프레임에 그리지도, 전환 중에 깜빡이지도 않는다
   type Props = {
-    insetRight: number;
     contentMotion?: { fromX: number; duration: number; easing: string };
   };
-  let { insetRight, contentMotion }: Props = $props();
+  let { contentMotion }: Props = $props();
 
   const ctx = getEditorContext();
   const margin = getMarginContext();
@@ -156,9 +153,11 @@
   const railGutter = $derived(Math.min(GUTTER, Math.max(0, bodyLeft)));
   const railGap = $derived(Math.min(RAIL_TEXT_GAP, Math.max(0, railGutter - RAIL_WIDTH)));
 
-  // 완전히 닫힌 첫 프레임에도 숨은 컬럼을 먼저 세운다. 카드가 배치를 마쳤다는 신호가
-  // 컨트롤러에 도착해야 그제야 inset/scale/fade가 함께 출발한다.
-  const columnPresent = $derived(insetRight > 0 || (margin.mode === 'column' && margin.ready && margin.presentationRoundId !== null));
+  // 완전히 닫힌 첫 프레임에도 숨은 컬럼을 먼저 세우고, 닫히는 동안은 진행률이 0이 될 때까지 붙잡는다.
+  // 카드가 배치를 마쳤다는 신호가 컨트롤러에 도착해야 그제야 inset/scale/fade가 함께 출발한다.
+  const columnPresent = $derived(
+    margin.presentationProgress > 0 || (margin.mode === 'column' && margin.ready && margin.presentationRoundId !== null),
+  );
   const presentation = $derived(lanePresentation(margin.presentationProgress));
   const presentationAnimating = $derived(margin.presentationProgress < 1);
 
@@ -206,12 +205,20 @@
   <!-- 이 레이어는 에디터의 포인터 표면(extensionAreaEl) 안에 산다 — 막지 않으면 레일·카드의 pointerdown이
        handlePointerDown까지 올라가 캐럿이 튀고 포인터 캡처가 잡혀 click이 버튼 대신 본문에 떨어진다.
        focusin은 editor.focus()로 답글 입력의 포커스를 뺏고, userSelect:none은 카드 글자 선택을 막는다.
+       닫히는 컬럼은 inset이 먼저 풀린 뒤 fade하므로, 가로 overflow는 여기서 잘라 스크롤 폭에 넣지 않는다.
        드롭은 막기만 하면 브라우저 기본 동작이 파일을 열어 버리므로, 여기서 삼켜 아무 일도 없게 만든다.
        팝오버는 스크롤러로 포탈되어 이 경로 밖이고, 여기서 막히는 것은 레일·룰러·컬럼이다.
        tabindex는 포커스 탐색을 여기서 멈추기 위한 것이다 — 없으면 클릭이 레이어를 지나쳐
        에디터 쪽 조상에 포커스를 앉히고, 그 focusin이 원고 입력을 도로 잡아채 카드 선택이 지워진다. -->
   <div
-    class={css({ position: 'absolute', inset: '0', pointerEvents: 'none', userSelect: 'text', WebkitUserSelect: 'text' })}
+    class={css({
+      position: 'absolute',
+      inset: '0',
+      overflowX: 'clip',
+      pointerEvents: 'none',
+      userSelect: 'text',
+      WebkitUserSelect: 'text',
+    })}
     draggable={false}
     onclick={(event) => event.stopPropagation()}
     oncontextmenu={(event) => event.stopPropagation()}

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditor.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditor.svelte
@@ -288,6 +288,7 @@
   const isOwner = $derived(query.data.me.id === entity?.user.id || query.data.me.role === 'ADMIN');
 
   let editorAreaWidth = $state(0);
+  const marginAvailable = $derived(Math.min(editorAreaWidth, ctx.editor?.publishedViewport?.width ?? 0));
 
   // 판이 아직 없으면 컬럼이 들어갈 수 있는지 판정할 수 없다 — 폭을 모르는 동안은 팝오버로 선다
   const marginBodyWidth = $derived.by(() => {
@@ -1022,7 +1023,7 @@
     <div class={flex({ flexDirection: 'column', flexGrow: '1', overflowX: 'auto' })}>
       <!-- 헤더의 리뷰 버튼도 여백 컨텍스트를 읽는다 — 헤더까지 감싼다 -->
       <PrismReviewMargin
-        available={editorAreaWidth}
+        available={marginAvailable}
         bodyWidth={marginBodyWidth}
         {documentId}
         entityId={entity?.id ?? null}
@@ -1446,7 +1447,7 @@
                               </div>
                             {/snippet}
                             <CommentPopover />
-                            <PrismMarginLayer contentMotion={insets.contentMotion} insetRight={insets.right} />
+                            <PrismMarginLayer contentMotion={insets.contentMotion} />
                           </EditorComponent>
                         </svelte:boundary>
                       {/key}

--- a/crates/editor-view/src/view.rs
+++ b/crates/editor-view/src/view.rs
@@ -993,6 +993,15 @@ impl View {
     pub fn resize(&mut self, viewport: Viewport, state: &State) -> bool {
         let old_fingerprint = self.fingerprint.clone();
         self.viewport = viewport;
+        let retained_layout_is_current = self.layout.is_some()
+            && self
+                .layout_state
+                .as_ref()
+                .is_some_and(|layout_state| Arc::ptr_eq(&layout_state.projected, &state.projected));
+        let (_, _, new_fingerprint) = self.build_pipeline(state);
+        if retained_layout_is_current && old_fingerprint.as_ref() == Some(&new_fingerprint) {
+            return false;
+        }
         self.compute(state);
         let changed = self.fingerprint.as_ref() != old_fingerprint.as_ref();
         if changed {
@@ -1242,6 +1251,31 @@ mod invalidation_tests {
             view.layout_state().and_then(|state| state.selection),
             selection_state.selection,
         );
+    }
+
+    #[test]
+    fn fingerprint_preserving_resize_keeps_page_fragments() {
+        let mut projected = ProjectedState::empty();
+        projected.commit();
+        let state = State::new(projected, None);
+        let mut view = make_view(800.0);
+
+        view.layout(&state);
+        assert!(view.fragment_for_page(0).is_some());
+        assert!(
+            view.layout.as_ref().unwrap().page_fragments[0]
+                .get()
+                .is_some()
+        );
+
+        assert!(!view.resize(Viewport::new(700.0, 700.0, 1.0), &state));
+
+        assert!(
+            view.layout.as_ref().unwrap().page_fragments[0]
+                .get()
+                .is_some()
+        );
+        assert_eq!(view.viewport(), &Viewport::new(700.0, 700.0, 1.0));
     }
 
     #[test]


### PR DESCRIPTION
## 변경 사항
PRISM 패널을 열고 닫을 때 리뷰 column과 popover 모드가 에디터 화면보다 먼저 전환되어 발생하던 레이아웃 튐과 버벅임을 개선했습니다.
- 에디터 viewport를 실제 frame과 함께 게시하고, 리뷰 모드 판단을 게시된 viewport 시점에 맞췄습니다.
- 레이아웃 fingerprint가 유지되는 resize에서는 기존 layout과 page fragment를 재사용합니다.
- 리뷰 column을 닫힘 fade가 끝날 때까지 유지해 기존 scale/fade 효과가 보존되도록 했습니다.
- 전환 중 일시적으로 생기는 가로 overflow가 스크롤바로 나타나지 않도록 제한했습니다.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>