### PR TITLE
PrismActionCard가 mutation 성공만으로 busy 상태를 풀지 않도록 함

### DIFF
--- a/apps/website/src/routes/website/(dashboard)/@prism/tools/PrismActionCard.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@prism/tools/PrismActionCard.svelte
@@ -31,8 +31,9 @@
       await resolve({ approve });
     } catch (err) {
       const error = unwrapError(err);
-      if (!(error instanceof TypieError && error.code === 'prism_tool_settled')) sendFailed = true;
-    } finally {
+      if (error instanceof TypieError && error.code === 'prism_tool_settled') return;
+
+      sendFailed = true;
       busy = false;
     }
   };


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>