### PR TITLE
새로 생성한 엔티티를 트리에서 표시

### DIFF
--- a/apps/website/src/routes/website/(dashboard)/@context-menu/FolderMenu.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@context-menu/FolderMenu.svelte
@@ -30,6 +30,7 @@
   import { graphql } from '$mearie';
   import { getPaneGroup } from '../[slug]/@pane/context.svelte';
   import { SubscribeModal } from '../@subscription/subscribe-modal.svelte';
+  import { createEntityTreeRevealRequest, entityTreeRevealState } from '../@tree/entity-reveal.svelte';
   import { maxDepth } from '../@tree/utils';
   import EntityIconPicker from './EntityIconPicker.svelte';
   import { showPasteToast } from './paste-toast';
@@ -525,6 +526,8 @@
 
     mixpanel.track('create_child_document', { via });
     open();
+    const revealRequest = createEntityTreeRevealRequest(resp.createDocument.entity.id, [entity.id], false);
+    entityTreeRevealState.set(revealRequest);
     await goto(`/${resp.createDocument.entity.slug}`);
   }}
 >
@@ -552,7 +555,7 @@
 
       // NOTE: 메뉴 닫힘/포커스 복귀 사이클 이후 실행되도록 다음 tick으로 미룬다.
       await tick();
-      app.state.newFolderId = resp.createFolder.id;
+      entityTreeRevealState.set(createEntityTreeRevealRequest(resp.createFolder.entity.id, [entity.id], true));
     }}
   >
     하위 폴더 생성

--- a/apps/website/src/routes/website/(dashboard)/@context-menu/TreeRootMenu.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@context-menu/TreeRootMenu.svelte
@@ -10,6 +10,7 @@
   import { cache } from '$lib/graphql';
   import { graphql } from '$mearie';
   import { SubscribeModal } from '../@subscription/subscribe-modal.svelte';
+  import { createEntityTreeRevealRequest, entityTreeRevealState } from '../@tree/entity-reveal.svelte';
   import { showPasteToast } from './paste-toast';
 
   let { siteId, lastRootEntityOrder }: { siteId: string; lastRootEntityOrder: string | null } = $props();
@@ -248,6 +249,8 @@
 
     const resp = await createDocument({ input: { siteId, v2: true } });
     mixpanel.track('create_document', { via: 'tree_root_menu' });
+    const revealRequest = createEntityTreeRevealRequest(resp.createDocument.entity.id, [], false);
+    entityTreeRevealState.set(revealRequest);
     await goto(`/${resp.createDocument.entity.slug}`);
   }}
 >
@@ -263,7 +266,7 @@
 
     const resp = await createFolder({ input: { siteId, name: '새 폴더' } });
     mixpanel.track('create_folder', { via: 'tree_root_menu' });
-    app.state.newFolderId = resp.createFolder.id;
+    entityTreeRevealState.set(createEntityTreeRevealRequest(resp.createFolder.entity.id, [], true));
   }}
 >
   새 폴더 생성

--- a/apps/website/src/routes/website/(dashboard)/@tree/Document.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@tree/Document.svelte
@@ -9,6 +9,7 @@
   import { untrack } from 'svelte';
   import EllipsisIcon from '~icons/lucide/ellipsis';
   import FileIcon from '~icons/lucide/file';
+  import { navigating } from '$app/state';
   import { graphql } from '$mearie';
   import DocumentMenu from '../@context-menu/DocumentMenu.svelte';
   import EntityIcon from '../@context-menu/EntityIcon.svelte';
@@ -16,6 +17,7 @@
   import EntitySelectionIndicator from './@selection/EntitySelectionIndicator.svelte';
   import MultiEntitiesMenu from './@selection/MultiEntitiesMenu.svelte';
   import DocumentTooltip from './DocumentTooltip.svelte';
+  import { entityTreeRevealState, shouldConsumeDocumentRevealRequest } from './entity-reveal.svelte';
   import { getTreeContext } from './state.svelte';
   import type { DashboardLayout_EntityTree_Document_document$key } from '$mearie';
 
@@ -88,6 +90,15 @@
     if (active) {
       element?.scrollIntoView({ behavior: 'instant', block: 'nearest' });
     }
+  });
+
+  $effect(() => {
+    const request = entityTreeRevealState.current;
+    if (!request || !shouldConsumeDocumentRevealRequest(request, document.data.entity.id, active, navigating.to === null)) {
+      return;
+    }
+
+    entityTreeRevealState.consume(request);
   });
 </script>
 

--- a/apps/website/src/routes/website/(dashboard)/@tree/Folder.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@tree/Folder.svelte
@@ -19,6 +19,7 @@
   import EntitySelectionIndicator from './@selection/EntitySelectionIndicator.svelte';
   import MultiEntitiesMenu from './@selection/MultiEntitiesMenu.svelte';
   import Entity from './Entity.svelte';
+  import { entityTreeRevealState, shouldOpenEntityTreeFolder } from './entity-reveal.svelte';
   import FolderTooltip from './FolderTooltip.svelte';
   import { getTreeContext } from './state.svelte';
   import type { DashboardLayout_EntityTree_Folder_folder$key } from '$mearie';
@@ -187,22 +188,23 @@
     }
   });
 
+  $effect.pre(() => {
+    if (shouldOpenEntityTreeFolder(folder.data.entity.id)) {
+      open = true;
+    }
+  });
+
   $effect(() => {
-    if (app.state.newFolderId !== folder.data.id) {
+    const request = entityTreeRevealState.current;
+    if (request?.targetEntityId !== folder.data.entity.id) {
       return;
     }
 
-    editing = true;
-    app.state.newFolderId = undefined;
-
-    if (detailsEl) {
-      const rect = detailsEl.getBoundingClientRect();
-      const isInViewport = rect.top >= 0 && rect.bottom <= window.innerHeight;
-
-      if (!isInViewport) {
-        detailsEl.scrollIntoView({ behavior: 'instant', block: 'nearest' });
-      }
+    if (request.rename) {
+      editing = true;
     }
+    detailsEl?.scrollIntoView({ behavior: 'instant', block: 'nearest' });
+    entityTreeRevealState.consume(request);
   });
 </script>
 

--- a/apps/website/src/routes/website/(dashboard)/@tree/entity-reveal.svelte.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/@tree/entity-reveal.svelte.test.ts
@@ -1,0 +1,96 @@
+import { EntityState } from '@typie/lib/enums';
+import { tick } from 'svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  consumeEntityTreeRevealRequest,
+  createEntityTreeRevealRequest,
+  entityTreeRevealState,
+  resolveActiveTreeAncestorIds,
+  shouldConsumeDocumentRevealRequest,
+  shouldOpenEntityTreeFolder,
+} from './entity-reveal.svelte';
+
+let destroyEffect: (() => void) | undefined;
+
+afterEach(() => {
+  destroyEffect?.();
+  destroyEffect = undefined;
+  entityTreeRevealState.set(undefined);
+});
+
+describe('entity tree reveal', () => {
+  it('uses ancestors only while the focused entity belongs to the active tree', () => {
+    expect(resolveActiveTreeAncestorIds(EntityState.ACTIVE, ['A', 'B'])).toEqual(['A', 'B']);
+    expect(resolveActiveTreeAncestorIds(EntityState.DELETED, ['A', 'B'])).toEqual([]);
+  });
+
+  it('snapshots the target path and distinguishes ancestors from the target', () => {
+    const source = ['A', 'B'];
+    const request = createEntityTreeRevealRequest('NEW', source, true);
+
+    source.push('C');
+
+    expect(request).toEqual({ targetEntityId: 'NEW', ancestorFolderIds: ['A', 'B'], rename: true });
+    entityTreeRevealState.set(request);
+    expect(shouldOpenEntityTreeFolder('A')).toBe(true);
+    expect(shouldOpenEntityTreeFolder('NEW')).toBe(false);
+    entityTreeRevealState.set(undefined);
+    expect(shouldOpenEntityTreeFolder('A')).toBe(false);
+    expect(shouldConsumeDocumentRevealRequest(request, 'NEW', false, true)).toBe(false);
+    expect(shouldConsumeDocumentRevealRequest(request, 'NEW', true, false)).toBe(false);
+    expect(shouldConsumeDocumentRevealRequest(request, 'NEW', true, true)).toBe(true);
+    expect(shouldConsumeDocumentRevealRequest(request, 'OTHER', true, true)).toBe(false);
+  });
+
+  it('reopens a collapsed active folder only when the reveal path contains it', async () => {
+    let open = $state(false);
+    const active = true;
+
+    destroyEffect = $effect.root(() => {
+      $effect.pre(() => {
+        if (active) {
+          open = true;
+        }
+      });
+      $effect.pre(() => {
+        if (shouldOpenEntityTreeFolder('A')) {
+          open = true;
+        }
+      });
+    });
+
+    await tick();
+    expect(open).toBe(true);
+
+    open = false;
+    await tick();
+    entityTreeRevealState.set(createEntityTreeRevealRequest('NEW', ['B'], true));
+    await tick();
+    expect(open).toBe(false);
+
+    entityTreeRevealState.set(createEntityTreeRevealRequest('NEW', ['A'], true));
+    await tick();
+
+    expect(open).toBe(true);
+  });
+
+  it('does not let an older reveal effect consume a newer request', () => {
+    const handled = createEntityTreeRevealRequest('OLD', ['A'], false);
+    const newer = createEntityTreeRevealRequest('NEW', [], false);
+
+    expect(consumeEntityTreeRevealRequest(newer, handled)).toBe(newer);
+    expect(consumeEntityTreeRevealRequest(handled, handled)).toBeUndefined();
+
+    const newerForSameTarget = createEntityTreeRevealRequest('OLD', [], true);
+    entityTreeRevealState.set(newerForSameTarget);
+    const current = entityTreeRevealState.current;
+    expect(current).toEqual(newerForSameTarget);
+
+    entityTreeRevealState.consume(handled);
+    expect(entityTreeRevealState.current).toBe(current);
+
+    if (!current) throw new Error('expected a current reveal request');
+    entityTreeRevealState.consume(current);
+    expect(entityTreeRevealState.current).toBeUndefined();
+  });
+});

--- a/apps/website/src/routes/website/(dashboard)/@tree/entity-reveal.svelte.ts
+++ b/apps/website/src/routes/website/(dashboard)/@tree/entity-reveal.svelte.ts
@@ -1,0 +1,46 @@
+import { EntityState } from '@typie/lib/enums';
+
+export type EntityTreeRevealRequest = {
+  targetEntityId: string;
+  ancestorFolderIds: string[];
+  rename: boolean;
+};
+
+let current = $state<EntityTreeRevealRequest>();
+
+export const entityTreeRevealState = {
+  get current() {
+    return current;
+  },
+
+  set(request: EntityTreeRevealRequest | undefined) {
+    current = request;
+  },
+
+  consume(handled: EntityTreeRevealRequest) {
+    current = consumeEntityTreeRevealRequest(current, handled);
+  },
+};
+
+export const resolveActiveTreeAncestorIds = (state: EntityState, ancestorIds: string[]): string[] =>
+  state === EntityState.ACTIVE ? ancestorIds : [];
+
+export const createEntityTreeRevealRequest = (
+  targetEntityId: string,
+  ancestorFolderIds: string[],
+  rename: boolean,
+): EntityTreeRevealRequest => ({ targetEntityId, ancestorFolderIds: [...ancestorFolderIds], rename });
+
+export const shouldOpenEntityTreeFolder = (folderEntityId: string): boolean => current?.ancestorFolderIds.includes(folderEntityId) ?? false;
+
+export const shouldConsumeDocumentRevealRequest = (
+  request: EntityTreeRevealRequest | undefined,
+  documentEntityId: string,
+  active: boolean,
+  navigationIdle: boolean,
+): boolean => active && navigationIdle && request?.targetEntityId === documentEntityId;
+
+export const consumeEntityTreeRevealRequest = (
+  currentRequest: EntityTreeRevealRequest | undefined,
+  handled: EntityTreeRevealRequest,
+): EntityTreeRevealRequest | undefined => (currentRequest === handled ? undefined : currentRequest);

--- a/apps/website/src/routes/website/(dashboard)/Sidebar.svelte
+++ b/apps/website/src/routes/website/(dashboard)/Sidebar.svelte
@@ -23,6 +23,7 @@
   import PrismBadgeDot from './@prism/PrismBadgeDot.svelte';
   import { SubscribeModal } from './@subscription/subscribe-modal.svelte';
   import TrialWidget from './@subscription/TrialWidget.svelte';
+  import { createEntityTreeRevealRequest, entityTreeRevealState } from './@tree/entity-reveal.svelte';
   import EntityTree from './@tree/EntityTree.svelte';
   import FeedbackPopover from './FeedbackPopover.svelte';
   import Profile from './Profile.svelte';
@@ -618,6 +619,7 @@
               return;
             }
 
+            const ancestorFolderIds = [...app.state.ancestors];
             const { lowerOrder, upperOrder } = getAdjacentOrders();
             const resp = await createFolder({
               input: {
@@ -631,7 +633,7 @@
 
             mixpanel.track('create_folder', { via: 'tree' });
 
-            app.state.newFolderId = resp.createFolder.id;
+            entityTreeRevealState.set(createEntityTreeRevealRequest(resp.createFolder.entity.id, ancestorFolderIds, true));
           }}
           type="button"
           use:tooltip={{ message: '새 폴더 생성' }}
@@ -652,6 +654,7 @@
               return;
             }
 
+            const ancestorFolderIds = [...app.state.ancestors];
             const { lowerOrder, upperOrder } = getAdjacentOrders();
 
             const resp = await createDocument({
@@ -665,6 +668,8 @@
             });
 
             mixpanel.track('create_document', { via: 'tree' });
+            const revealRequest = createEntityTreeRevealRequest(resp.createDocument.entity.id, ancestorFolderIds, false);
+            entityTreeRevealState.set(revealRequest);
             await goto(`/${resp.createDocument.entity.slug}`);
           }}
           type="button"

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/EntityPane.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/EntityPane.svelte
@@ -10,6 +10,7 @@
   import XIcon from '~icons/lucide/x';
   import { fb } from '$lib/analytics';
   import { graphql } from '$mearie';
+  import { resolveActiveTreeAncestorIds } from '../../@tree/entity-reveal.svelte';
   import DocumentV2 from '../v2/Document.svelte';
   import CloseButton from './CloseButton.svelte';
   import { getPaneGroup, setupPane } from './context.svelte';
@@ -94,7 +95,10 @@
 
   $effect(() => {
     if (focused && entity) {
-      app.state.ancestors = entity.ancestors.map((ancestor) => ancestor.id);
+      app.state.ancestors = resolveActiveTreeAncestorIds(
+        entity.state,
+        entity.ancestors.map((ancestor) => ancestor.id),
+      );
     }
   });
 

--- a/packages/ui/src/context/app.svelte.ts
+++ b/packages/ui/src/context/app.svelte.ts
@@ -70,7 +70,6 @@ type AppState = {
     limit: { totalCharacterCount: number; totalBlobSize: string };
   };
 
-  newFolderId?: string;
   nextCurrentSiteId?: string;
 
   openMenuCount: number;


### PR DESCRIPTION
## 문제

새 문서나 폴더를 생성했을 때 상위 폴더가 닫혀 있으면 생성된 항목이 트리에서 보이지 않았습니다.

또한 삭제된 문서를 보고 있을 때도 해당 문서의 이전 상위 경로가 생성 위치로 사용되어, 새 항목이 예상하지 못한 폴더에 생성될 수 있었습니다.

## 변경 사항

- 삭제된 문서에서는 상위 폴더 경로를 생성 위치로 사용하지 않아 새 항목이 루트에 생성되도록 합니다.
- 엔티티 생성 시 대상과 상위 폴더 경로를 reveal 요청으로 전달합니다.
- 요청에 포함된 상위 폴더만 열고 생성된 항목을 스크롤 영역에 표시합니다.
- 사용자가 접어둔 다른 경로의 폴더는 reveal 요청으로 다시 열리지 않도록 합니다.
- 기존 폴더 전용 상태를 문서와 폴더가 함께 사용하는 reveal 상태로 교체합니다.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>