### PR TITLE
HMR 시 WASM 런타임 정리

### DIFF
--- a/apps/website/src/lib/editor-ffi/registry.test.ts
+++ b/apps/website/src/lib/editor-ffi/registry.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { fanOutResourceUpdate, register, snapshot, unregister } from './registry';
+import { destroyAll, fanOutResourceUpdate, register, snapshot, unregister } from './registry';
 import type { ResourceUpdate } from '@typie/editor-ffi/browser';
 import type { Editor } from './editor.svelte';
 
@@ -27,5 +27,40 @@ describe('editor registry resource fan-out', () => {
     expect(first.receiveResourceUpdate).toHaveBeenCalledWith(update);
     expect(second.receiveResourceUpdate).toHaveBeenCalledWith(update);
     expect(update.free).toHaveBeenCalledTimes(1);
+  });
+
+  it('destroys every live editor from a stable snapshot', () => {
+    const first = { destroy: vi.fn() } as unknown as Editor;
+    const second = { destroy: vi.fn() } as unknown as Editor;
+    vi.mocked(first.destroy).mockImplementation(() => unregister(first));
+    vi.mocked(second.destroy).mockImplementation(() => unregister(second));
+    register(first);
+    register(second);
+
+    destroyAll();
+
+    expect(first.destroy).toHaveBeenCalledOnce();
+    expect(second.destroy).toHaveBeenCalledOnce();
+    expect(snapshot()).toEqual([]);
+  });
+
+  it('continues destroying editors after one fails', () => {
+    const error = new Error('destroy failed');
+    const first = { destroy: vi.fn() } as unknown as Editor;
+    const second = { destroy: vi.fn() } as unknown as Editor;
+    vi.mocked(first.destroy).mockImplementation(() => {
+      unregister(first);
+      throw error;
+    });
+    vi.mocked(second.destroy).mockImplementation(() => unregister(second));
+    vi.spyOn(console, 'error').mockImplementation(() => false);
+    register(first);
+    register(second);
+
+    destroyAll();
+
+    expect(first.destroy).toHaveBeenCalledOnce();
+    expect(second.destroy).toHaveBeenCalledOnce();
+    expect(console.error).toHaveBeenCalledWith('Failed to destroy an editor.', error);
   });
 });

--- a/apps/website/src/lib/editor-ffi/registry.ts
+++ b/apps/website/src/lib/editor-ffi/registry.ts
@@ -15,6 +15,16 @@ export function snapshot(): Editor[] {
   return [...editors];
 }
 
+export function destroyAll(): void {
+  for (const editor of snapshot()) {
+    try {
+      editor.destroy();
+    } catch (err) {
+      console.error('Failed to destroy an editor.', err);
+    }
+  }
+}
+
 export function fanOutResourceUpdate(update: ResourceUpdate | undefined): void {
   if (!update) return;
   try {

--- a/apps/website/src/lib/prism-ui/runtime-lifecycle.test.ts
+++ b/apps/website/src/lib/prism-ui/runtime-lifecycle.test.ts
@@ -1,0 +1,107 @@
+import { createPrismRuntime } from '@typie/prism-ui';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const observer = class {
+  disconnect = vi.fn();
+  observe = vi.fn();
+  unobserve = vi.fn();
+};
+
+const mediaQuery = {
+  addEventListener: vi.fn(),
+  matches: false,
+  removeEventListener: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.stubGlobal('IntersectionObserver', observer);
+  vi.stubGlobal('ResizeObserver', observer);
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn(() => mediaQuery),
+  );
+  vi.stubGlobal(
+    'requestAnimationFrame',
+    vi.fn(() => 1),
+  );
+  vi.stubGlobal('cancelAnimationFrame', vi.fn());
+  Object.defineProperty(navigator, 'gpu', { configurable: true, value: {} });
+  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(
+    () =>
+      ({
+        clearRect: vi.fn(),
+        fillRect: vi.fn(),
+        fillStyle: '',
+        getImageData: vi.fn(() => ({ data: new Uint8ClampedArray([255, 255, 255, 255]) })),
+      }) as never,
+  );
+});
+
+afterEach(() => {
+  Reflect.deleteProperty(navigator, 'gpu');
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  document.body.replaceChildren();
+});
+
+const createRuntimeFixture = () => {
+  const renderer = {
+    frameUniformByteLength: 656,
+    free: vi.fn(),
+    render: vi.fn(),
+    renderComputed: vi.fn(),
+    whenSubmittedWorkDone: vi.fn(() => Promise.resolve()),
+  };
+  const rendererRuntime = {
+    createRenderer: vi.fn(() => renderer),
+    free: vi.fn(),
+  };
+  const runtime = createPrismRuntime({
+    loadRenderer: async () => ({ PrismWebRuntime: { create: vi.fn(async () => rendererRuntime) } }) as never,
+  });
+  return { renderer, rendererRuntime, runtime };
+};
+
+describe('Prism runtime lifecycle', () => {
+  it('destroys every mount and frees the shared WASM runtime once', async () => {
+    const { renderer, rendererRuntime, runtime } = createRuntimeFixture();
+    const firstHost = document.createElement('div');
+    const secondHost = document.createElement('div');
+    document.body.append(firstHost, secondHost);
+    runtime.mountObject(firstHost, { target: 'prism' });
+    runtime.mountObject(secondHost, { target: 'icon' });
+    await vi.waitFor(() => expect(rendererRuntime.createRenderer).toHaveBeenCalledOnce());
+
+    runtime.destroy();
+    runtime.destroy();
+
+    await vi.waitFor(() => expect(rendererRuntime.free).toHaveBeenCalledOnce());
+    expect(renderer.free).toHaveBeenCalledOnce();
+    expect(firstHost.childElementCount).toBe(0);
+    expect(secondHost.childElementCount).toBe(0);
+    expect(() => runtime.mountObject(firstHost, { target: 'icon' })).toThrow('destroyed');
+  });
+
+  it('continues cleanup when one mount fails to destroy', async () => {
+    const { rendererRuntime, runtime } = createRuntimeFixture();
+    const firstHost = document.createElement('div');
+    const secondHost = document.createElement('div');
+    document.body.append(firstHost, secondHost);
+    const firstMount = runtime.mountObject(firstHost, { target: 'prism' });
+    runtime.mountObject(secondHost, { target: 'icon' });
+    await vi.waitFor(() => expect(rendererRuntime.createRenderer).toHaveBeenCalledOnce());
+    const error = new Error('mount cleanup failed');
+    const destroyFirstMount = firstMount.destroy.bind(firstMount);
+    firstMount.destroy = vi.fn(() => {
+      throw error;
+    });
+    vi.spyOn(console, 'error').mockImplementation(() => false);
+
+    expect(() => runtime.destroy()).not.toThrow();
+
+    await vi.waitFor(() => expect(rendererRuntime.free).toHaveBeenCalledOnce());
+    expect(secondHost.childElementCount).toBe(0);
+    expect(console.error).toHaveBeenCalledWith('Failed to destroy a Prism mount.', error);
+    destroyFirstMount();
+  });
+});

--- a/apps/website/src/lib/prism-ui/runtime.test.ts
+++ b/apps/website/src/lib/prism-ui/runtime.test.ts
@@ -3,10 +3,15 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 const mocks = vi.hoisted(() => {
   const PrismWebRuntime = { create: vi.fn() };
   return {
+    cleanup: undefined as (() => void) | undefined,
     compileStreaming: vi.fn(async () => ({ compiled: true })),
     createInstance: vi.fn(async () => ({ PrismWebRuntime })),
     fetch: vi.fn(async () => new Response()),
     PrismWebRuntime,
+    registerWasmHmrCleanup: vi.fn((_hot: unknown, cleanup: () => void) => {
+      mocks.cleanup = cleanup;
+    }),
+    runtime: { destroy: vi.fn() },
     runtimeOptions: undefined as { loadRenderer: () => Promise<unknown> } | undefined,
   };
 });
@@ -14,15 +19,18 @@ const mocks = vi.hoisted(() => {
 vi.mock('@typie/prism-ui', () => ({
   createPrismRuntime: (options: typeof mocks.runtimeOptions) => {
     mocks.runtimeOptions = options;
-    return {};
+    return mocks.runtime;
   },
 }));
 vi.mock('@typie/prism-ui-web/browser', () => ({ createInstance: mocks.createInstance }));
 vi.mock('@typie/prism-ui-web/browser/wasm?url', () => ({ default: '/prism-ui.wasm' }));
+vi.mock('$lib/wasm-hmr', () => ({ registerWasmHmrCleanup: mocks.registerWasmHmrCleanup }));
 
 describe('Typie Prism renderer loader', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
+    mocks.cleanup = undefined;
     vi.stubGlobal('fetch', mocks.fetch);
     vi.spyOn(WebAssembly, 'compileStreaming').mockImplementation(mocks.compileStreaming);
   });
@@ -40,5 +48,13 @@ describe('Typie Prism renderer loader', () => {
     expect(mocks.compileStreaming).toHaveBeenCalledOnce();
     expect(mocks.createInstance).toHaveBeenCalledWith({ compiled: true });
     expect(loaded).toMatchObject({ PrismWebRuntime: mocks.PrismWebRuntime });
+  });
+
+  test('destroys the Prism runtime when the WASM module is replaced', async () => {
+    await import('./runtime.ts');
+
+    mocks.cleanup?.();
+
+    expect(mocks.runtime.destroy).toHaveBeenCalledOnce();
   });
 });

--- a/apps/website/src/lib/prism-ui/runtime.ts
+++ b/apps/website/src/lib/prism-ui/runtime.ts
@@ -1,6 +1,7 @@
 import { createPrismRuntime } from '@typie/prism-ui';
 import { createInstance } from '@typie/prism-ui-web/browser';
 import wasmUrl from '@typie/prism-ui-web/browser/wasm?url';
+import { registerWasmHmrCleanup } from '$lib/wasm-hmr';
 
 export const prismRuntime = createPrismRuntime({
   loadRenderer: async () => {
@@ -11,3 +12,5 @@ export const prismRuntime = createPrismRuntime({
     };
   },
 });
+
+registerWasmHmrCleanup(import.meta.hot, () => prismRuntime.destroy());

--- a/apps/website/src/lib/wasm-ffi.svelte.test.ts
+++ b/apps/website/src/lib/wasm-ffi.svelte.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  cleanup: undefined as (() => void) | undefined,
+  createInstance: vi.fn(),
+  destroyAll: vi.fn(),
+  host: { free: vi.fn() },
+  registerWasmHmrCleanup: vi.fn((_hot: unknown, cleanup: () => void) => {
+    mocks.cleanup = cleanup;
+  }),
+}));
+
+vi.mock('@typie/editor-ffi/browser', () => ({ createInstance: mocks.createInstance }));
+vi.mock('@typie/editor-ffi/browser/icu.zst?url', () => ({ default: '/editor-icu.zst' }));
+vi.mock('@typie/editor-ffi/browser/wasm?url', () => ({ default: '/editor.wasm' }));
+vi.mock('$lib/editor-ffi/registry', () => ({ destroyAll: mocks.destroyAll }));
+vi.mock('$lib/wasm-hmr', () => ({ registerWasmHmrCleanup: mocks.registerWasmHmrCleanup }));
+
+const editorModule = () => ({ EditorHost: { create: vi.fn(() => mocks.host) } });
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  mocks.cleanup = undefined;
+  mocks.createInstance.mockResolvedValue(editorModule());
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => new Response(new Uint8Array([1, 2, 3]))),
+  );
+  vi.spyOn(WebAssembly, 'compileStreaming').mockResolvedValue({} as WebAssembly.Module);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('Editor WASM HMR lifecycle', () => {
+  it('destroys live editors before freeing the initialized host', async () => {
+    const { initWasm } = await import('./wasm-ffi.svelte');
+    await initWasm();
+
+    mocks.cleanup?.();
+
+    expect(mocks.destroyAll).toHaveBeenCalledOnce();
+    expect(mocks.host.free).toHaveBeenCalledOnce();
+    expect(mocks.destroyAll.mock.invocationCallOrder[0]).toBeLessThan(mocks.host.free.mock.invocationCallOrder[0] ?? 0);
+  });
+
+  it('frees a host that finishes initializing after HMR disposal', async () => {
+    const deferredInstance = Promise.withResolvers<ReturnType<typeof editorModule>>();
+    mocks.createInstance.mockImplementation(() => deferredInstance.promise);
+    const { initWasm } = await import('./wasm-ffi.svelte');
+    const initialization = initWasm();
+    await vi.waitFor(() => expect(mocks.createInstance).toHaveBeenCalledOnce());
+
+    mocks.cleanup?.();
+    deferredInstance.resolve(editorModule());
+
+    await expect(initialization).rejects.toThrow('initialization was canceled');
+    expect(mocks.destroyAll).toHaveBeenCalledOnce();
+    expect(mocks.host.free).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/website/src/lib/wasm-ffi.svelte.ts
+++ b/apps/website/src/lib/wasm-ffi.svelte.ts
@@ -1,11 +1,14 @@
 import { createInstance } from '@typie/editor-ffi/browser';
 import icuUrl from '@typie/editor-ffi/browser/icu.zst?url';
 import wasmUrl from '@typie/editor-ffi/browser/wasm?url';
+import { destroyAll } from '$lib/editor-ffi/registry';
+import { registerWasmHmrCleanup } from '$lib/wasm-hmr';
 import type { EditorHost } from '@typie/editor-ffi/browser';
 
 let host: EditorHost | undefined;
 let hostPromise: Promise<EditorHost> | undefined;
 let panicked = $state(false);
+let disposed = false;
 
 function wrapWithCrashDetection<T extends object>(target: T): T {
   return new Proxy(target, {
@@ -36,6 +39,8 @@ function wrapWithCrashDetection<T extends object>(target: T): T {
 }
 
 export function initWasm(): Promise<EditorHost> {
+  if (disposed) return Promise.reject(new Error('Editor WASM was disposed for HMR.'));
+
   return (hostPromise ??= (async () => {
     const [mod, icuData] = await Promise.all([
       WebAssembly.compileStreaming(fetch(wasmUrl)),
@@ -45,10 +50,27 @@ export function initWasm(): Promise<EditorHost> {
     ]);
 
     const { EditorHost } = await createInstance(mod);
-    host = wrapWithCrashDetection(EditorHost.create(icuData));
+    const createdHost = wrapWithCrashDetection(EditorHost.create(icuData));
+    if (disposed) {
+      createdHost.free();
+      throw new Error('Editor WASM initialization was canceled for HMR.');
+    }
+    host = createdHost;
     return host;
   })());
 }
+
+function disposeWasm(): void {
+  if (disposed) return;
+  disposed = true;
+  destroyAll();
+  const currentHost = host;
+  host = undefined;
+  hostPromise = undefined;
+  currentHost?.free();
+}
+
+registerWasmHmrCleanup(import.meta.hot, disposeWasm);
 
 export const wasm: EditorHost & { readonly panicked: boolean } = new Proxy({} as EditorHost & { readonly panicked: boolean }, {
   get(_, prop) {

--- a/apps/website/src/lib/wasm-hmr.test.ts
+++ b/apps/website/src/lib/wasm-hmr.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test, vi } from 'vitest';
+import { registerWasmHmrCleanup } from './wasm-hmr';
+
+describe('WASM HMR cleanup', () => {
+  test('cleans up when its module is replaced', () => {
+    let dispose: (() => void) | undefined;
+    const hot = {
+      dispose: vi.fn((callback: () => void) => {
+        dispose = callback;
+      }),
+    };
+    const cleanup = vi.fn();
+
+    registerWasmHmrCleanup(hot, cleanup);
+    dispose?.();
+
+    expect(cleanup).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/website/src/lib/wasm-hmr.ts
+++ b/apps/website/src/lib/wasm-hmr.ts
@@ -1,0 +1,7 @@
+type WasmHmrContext = {
+  dispose(callback: () => void): void;
+};
+
+export function registerWasmHmrCleanup(hot: WasmHmrContext | undefined, cleanup: () => void): void {
+  hot?.dispose(cleanup);
+}

--- a/packages/prism-ui/src/runtime.ts
+++ b/packages/prism-ui/src/runtime.ts
@@ -31,6 +31,7 @@ type PrismEdgeColor = string | readonly [number, number, number, number];
 
 type PrismWebRuntimeInstance = {
   createRenderer(canvas: HTMLCanvasElement, preferHdr: boolean): PrismWebRenderer;
+  free(): void;
 };
 
 type PrismRendererModule = {
@@ -85,6 +86,7 @@ export type MountedPrismSpinner = {
 };
 
 export type PrismRuntime = {
+  destroy(): void;
   mountObject(element: HTMLElement, options: PrismRuntimeObjectOptions): MountedPrismObject;
   mountSpinner(element: HTMLElement, options?: PrismRuntimeSpinnerOptions): MountedPrismSpinner;
 };
@@ -159,6 +161,8 @@ export function createPrismRuntime(options: PrismRuntimeOptions): PrismRuntime {
 
   let modulePromise: Promise<PrismRendererModule> | null = null;
   let rendererRuntimePromise: Promise<PrismWebRuntimeInstance> | null = null;
+  let runtimeDestroyed = false;
+  const mounts = new Set<MountedPrismObject | MountedPrismSpinner>();
 
   function loadModule(): Promise<PrismRendererModule> {
     modulePromise ??= Promise.try(options.loadRenderer);
@@ -179,6 +183,7 @@ export function createPrismRuntime(options: PrismRuntimeOptions): PrismRuntime {
   }
 
   function mountObject(element: HTMLElement, initialOptions: PrismRuntimeObjectOptions): MountedPrismObject {
+    if (runtimeDestroyed) throw new Error('Prism runtime is destroyed.');
     requireElement(element);
     requireTarget(initialOptions.target);
     const document = element.ownerDocument ?? globalThis.document;
@@ -885,10 +890,11 @@ export function createPrismRuntime(options: PrismRuntimeOptions): PrismRuntime {
       setTarget(initialOptions.target);
     }
 
-    return {
+    const mounted: MountedPrismObject = {
       destroy() {
         if (destroyed) return;
         destroyed = true;
+        mounts.delete(mounted);
         transitionGeneration += 1;
         if (frameId) cancelAnimationFrame(frameId);
         if (presentationFrameId) cancelAnimationFrame(presentationFrameId);
@@ -937,9 +943,12 @@ export function createPrismRuntime(options: PrismRuntimeOptions): PrismRuntime {
         return ensureController().then(() => readiness);
       },
     };
+    mounts.add(mounted);
+    return mounted;
   }
 
   function mountSpinner(element: HTMLElement, spinnerOptions: PrismRuntimeSpinnerOptions = {}): MountedPrismSpinner {
+    if (runtimeDestroyed) throw new Error('Prism runtime is destroyed.');
     requireElement(element);
     const document = element.ownerDocument ?? globalThis.document;
     const root = document.createElement('span');
@@ -1069,10 +1078,11 @@ export function createPrismRuntime(options: PrismRuntimeOptions): PrismRuntime {
     if (reducedMotion) void ensureAtlas();
     else void loadApng();
 
-    return {
+    const mounted: MountedPrismSpinner = {
       destroy() {
         if (destroyed) return;
         destroyed = true;
+        mounts.delete(mounted);
         apngLoadGeneration += 1;
         apngHdrPlayer.disconnect();
         atlasPlayer?.dispose();
@@ -1101,7 +1111,30 @@ export function createPrismRuntime(options: PrismRuntimeOptions): PrismRuntime {
         }
       },
     };
+    mounts.add(mounted);
+    return mounted;
   }
 
-  return { mountObject, mountSpinner };
+  function destroy(): void {
+    if (runtimeDestroyed) return;
+    runtimeDestroyed = true;
+    for (const mounted of mounts) {
+      try {
+        mounted.destroy();
+      } catch (err) {
+        console.error('Failed to destroy a Prism mount.', err);
+      } finally {
+        mounts.delete(mounted);
+      }
+    }
+
+    const runtimePromise = rendererRuntimePromise;
+    rendererRuntimePromise = null;
+    modulePromise = null;
+    if (runtimePromise) {
+      void runtimePromise.then((runtime) => runtime.free()).catch(() => null);
+    }
+  }
+
+  return { destroy, mountObject, mountSpinner };
 }


### PR DESCRIPTION
## 문제

개발 환경에서 HMR이 반복될 때 기존 Editor와 PRISM의 WASM 자원을 명시적으로 해제하는 경로가 없었습니다.

교체된 모듈의 Editor host, PRISM renderer와 runtime이 남으면 WASM 메모리가 누적되어 결국 메모리 부족이 발생할 수 있습니다.

## 변경 사항

- WASM을 사용하는 모듈이 교체될 때 cleanup을 실행합니다.
- 살아 있는 Editor를 모두 파괴한 뒤 `EditorHost`를 해제합니다.
- Editor WASM 초기화 도중 모듈이 교체되면, 늦게 생성된 host도 즉시 해제합니다.
- PRISM runtime이 생성한 object와 spinner mount를 추적하고 일괄 정리할 수 있게 합니다.
- PRISM mount를 모두 정리한 뒤 공유 WASM runtime을 해제합니다.
- 개별 자원 정리가 실패해도 나머지 cleanup은 계속 진행합니다.
- cleanup은 중복 호출되어도 한 번만 실행되도록 합니다.

프로덕션에서는 HMR 컨텍스트가 없으므로 이 cleanup 경로가 실행되지 않습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>