### PR TITLE
프리즘 열린 문서 도구가 pane 복원을 대기

### DIFF
--- a/apps/website/src/lib/prism/open-documents.svelte.ts
+++ b/apps/website/src/lib/prism/open-documents.svelte.ts
@@ -15,24 +15,96 @@ export type OpenDocument = {
 const key: unique symbol = Symbol('OpenDocuments');
 
 export class OpenDocumentRegistry {
-  #entries = new SvelteMap<string, OpenDocument>();
+  #entries = new SvelteMap<string, OpenDocument | null>();
+  #expectedPaneIds: Set<string> | null = null;
+  // eslint-disable-next-line svelte/prefer-svelte-reactivity -- callbacks are notified imperatively when readiness changes
+  #readyWaiters = new Set<() => void>();
 
-  upsert(paneKey: string, doc: OpenDocument) {
-    this.#entries.set(paneKey, doc);
+  #accepts(paneId: string) {
+    return this.#expectedPaneIds === null || this.#expectedPaneIds.has(paneId);
   }
 
-  remove(paneKey: string) {
-    this.#entries.delete(paneKey);
+  #ready() {
+    return this.#expectedPaneIds !== null && [...this.#expectedPaneIds].every((paneId) => this.#entries.has(paneId));
+  }
+
+  #notifyReady() {
+    if (!this.#ready()) return;
+
+    for (const waiter of this.#readyWaiters) {
+      waiter();
+    }
+  }
+
+  setExpectedPanes(paneIds: readonly string[]) {
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity -- authoritative input is synchronized imperatively by the pane host
+    const next = new Set(paneIds);
+    this.#expectedPaneIds = next;
+
+    for (const paneId of this.#entries.keys()) {
+      if (!next.has(paneId)) {
+        this.#entries.delete(paneId);
+      }
+    }
+
+    this.#notifyReady();
+  }
+
+  invalidate() {
+    this.#expectedPaneIds = null;
+    this.#entries.clear();
+  }
+
+  expectPane(paneId: string) {
+    if (!this.#accepts(paneId)) return;
+    this.#entries.delete(paneId);
+  }
+
+  resolvePane(paneId: string) {
+    if (!this.#accepts(paneId)) return;
+    this.#entries.set(paneId, null);
+    this.#notifyReady();
+  }
+
+  upsert(paneId: string, doc: OpenDocument) {
+    if (!this.#accepts(paneId)) return;
+    this.#entries.set(paneId, doc);
+    this.#notifyReady();
   }
 
   snapshot(): { documents: OpenDocument[] } {
     // eslint-disable-next-line svelte/prefer-svelte-reactivity -- transient accumulator local to this call; never a render signal
     const byId = new Map<string, OpenDocument>();
     for (const doc of this.#entries.values()) {
+      if (doc === null) continue;
       const prev = byId.get(doc.documentId);
       byId.set(doc.documentId, prev ? { ...prev, active: prev.active || doc.active } : { ...doc });
     }
     return { documents: [...byId.values()].toSorted((a, b) => a.documentId.localeCompare(b.documentId)) };
+  }
+
+  snapshotWhenReady(timeoutMs = 2000): Promise<{ documents: OpenDocument[] }> {
+    if (this.#ready()) {
+      return Promise.resolve(this.snapshot());
+    }
+
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.#readyWaiters.delete(onReady);
+        reject(new Error(`Open documents are not ready after ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      const onReady = () => {
+        if (!this.#ready()) return;
+
+        clearTimeout(timeout);
+        this.#readyWaiters.delete(onReady);
+        resolve(this.snapshot());
+      };
+
+      this.#readyWaiters.add(onReady);
+      onReady();
+    });
   }
 }
 

--- a/apps/website/src/lib/prism/open-documents.test.ts
+++ b/apps/website/src/lib/prism/open-documents.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { OpenDocumentRegistry } from './open-documents.svelte.ts';
 
 describe('OpenDocumentRegistry', () => {
   it('페인별 등록을 문서 id로 합치고, 제거하면 빠진다', () => {
     const r = new OpenDocumentRegistry();
+    r.setExpectedPanes(['p1', 'p2', 'p3']);
     r.upsert('p1', {
       kind: 'document',
       documentId: 'D1',
@@ -58,8 +59,7 @@ describe('OpenDocumentRegistry', () => {
         },
       ],
     });
-    r.remove('p2');
-    r.remove('p3');
+    r.setExpectedPanes(['p1']);
     expect(r.snapshot()).toEqual({
       documents: [
         {
@@ -76,8 +76,9 @@ describe('OpenDocumentRegistry', () => {
     });
   });
 
-  it('같은 페인 키에 다시 등록하면 값이 대체되고, 제거 후 재등록해도 항목은 하나다', () => {
+  it('같은 페인을 다시 분류하면 값이 대체되고 항목은 하나다', () => {
     const r = new OpenDocumentRegistry();
+    r.setExpectedPanes(['p1']);
     r.upsert('p1', {
       kind: 'document',
       documentId: 'D1',
@@ -113,7 +114,7 @@ describe('OpenDocumentRegistry', () => {
       ],
     });
 
-    r.remove('p1');
+    r.expectPane('p1');
     r.upsert('p1', {
       kind: 'document',
       documentId: 'D2',
@@ -142,6 +143,7 @@ describe('OpenDocumentRegistry', () => {
 
   it('재등록 순서와 무관하게 문서 id 순으로 정렬한다', () => {
     const r = new OpenDocumentRegistry();
+    r.setExpectedPanes(['p1', 'p2']);
     r.upsert('p1', {
       kind: 'document',
       documentId: 'D1',
@@ -162,7 +164,7 @@ describe('OpenDocumentRegistry', () => {
       iconColor: 'gray',
       active: false,
     });
-    r.remove('p1');
+    r.expectPane('p1');
     r.upsert('p1', {
       kind: 'document',
       documentId: 'D1',
@@ -175,5 +177,132 @@ describe('OpenDocumentRegistry', () => {
     });
 
     expect(r.snapshot().documents.map((doc) => doc.documentId)).toEqual(['D1', 'D2']);
+  });
+
+  it('모든 엔티티 페인의 분류가 끝날 때까지 스냅샷을 기다린다', async () => {
+    const r = new OpenDocumentRegistry();
+    r.setExpectedPanes(['p1', 'p2']);
+
+    const pending = r.snapshotWhenReady();
+    r.upsert('p1', {
+      kind: 'document',
+      documentId: 'D1',
+      entityId: 'E1',
+      title: '가',
+      subtitle: null,
+      icon: 'file',
+      iconColor: 'gray',
+      active: true,
+    });
+
+    let settled = false;
+    void pending.then(() => (settled = true));
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    r.resolvePane('p2');
+    await expect(pending).resolves.toEqual({
+      documents: [
+        {
+          kind: 'document',
+          documentId: 'D1',
+          entityId: 'E1',
+          title: '가',
+          subtitle: null,
+          icon: 'file',
+          iconColor: 'gray',
+          active: true,
+        },
+      ],
+    });
+  });
+
+  it('동기화되지 않았거나 미분류 페인이 남으면 2초 뒤 거부한다', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const unsynchronized = new OpenDocumentRegistry();
+      const unsynchronizedResult = expect(unsynchronized.snapshotWhenReady()).rejects.toThrow();
+      await vi.advanceTimersByTimeAsync(2000);
+      await unsynchronizedResult;
+
+      const unresolved = new OpenDocumentRegistry();
+      unresolved.setExpectedPanes(['p1']);
+      const unresolvedResult = expect(unresolved.snapshotWhenReady()).rejects.toThrow();
+      await vi.advanceTimersByTimeAsync(2000);
+      await unresolvedResult;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('기다리던 페인이 예상 목록에서 빠지면 준비된 스냅샷을 반환한다', async () => {
+    const r = new OpenDocumentRegistry();
+    r.setExpectedPanes(['p1', 'p2']);
+    r.resolvePane('p1');
+
+    const pending = r.snapshotWhenReady();
+    r.setExpectedPanes(['p1']);
+
+    await expect(pending).resolves.toEqual({ documents: [] });
+  });
+
+  it('분류를 다시 시작한 페인은 재분류될 때까지 기다리고 이전 문서를 지운다', async () => {
+    const r = new OpenDocumentRegistry();
+    r.setExpectedPanes(['p1']);
+    r.upsert('p1', {
+      kind: 'document',
+      documentId: 'D1',
+      entityId: 'E1',
+      title: '가',
+      subtitle: null,
+      icon: 'file',
+      iconColor: 'gray',
+      active: true,
+    });
+    await expect(r.snapshotWhenReady()).resolves.toHaveProperty('documents.0.documentId', 'D1');
+
+    r.expectPane('p1');
+    const pending = r.snapshotWhenReady();
+    r.resolvePane('p1');
+
+    await expect(pending).resolves.toEqual({ documents: [] });
+  });
+
+  it('무효화 후에는 이전 문서를 버리고 새 페인 분류를 기다린다', async () => {
+    const r = new OpenDocumentRegistry();
+    r.setExpectedPanes(['p1']);
+    r.upsert('p1', {
+      kind: 'document',
+      documentId: 'D1',
+      entityId: 'E1',
+      title: '이전 문서',
+      subtitle: null,
+      icon: 'file',
+      iconColor: 'gray',
+      active: true,
+    });
+    await expect(r.snapshotWhenReady()).resolves.toHaveProperty('documents.0.documentId', 'D1');
+
+    r.invalidate();
+    const pending = r.snapshotWhenReady();
+    r.setExpectedPanes(['p1']);
+
+    let settled = false;
+    void pending.then(() => (settled = true));
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    r.upsert('p1', {
+      kind: 'document',
+      documentId: 'D2',
+      entityId: 'E2',
+      title: '복원된 문서',
+      subtitle: null,
+      icon: 'file',
+      iconColor: 'gray',
+      active: true,
+    });
+    await expect(pending).resolves.toHaveProperty('documents.0.documentId', 'D2');
   });
 });

--- a/apps/website/src/routes/website/(dashboard)/@prism/PrismPanel.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@prism/PrismPanel.svelte
@@ -281,25 +281,41 @@
     return { text: awaitingAnswer ? workflowCopy.waiting : workflowCopy.running, stop: workflowCopy.stop };
   });
 
-  const resolveTool = async (agentId: string, toolCallId: string, input: unknown) => {
-    const sessionId = chat.sessionId;
+  const resolveToolForSession = async (
+    sessionId: string | null,
+    transcriptAgentId: string | null,
+    agentId: string,
+    toolCallId: string,
+    input: unknown,
+  ) => {
     if (sessionId === null) {
       throw new Error('prism session is not ready');
     }
 
-    const root = agentId.length === 0 || agentId === chat.transcript.agentId;
+    const root = agentId.length === 0 || agentId === transcriptAgentId;
     await resolvePrismTool({ input: { sessionId, agentId: root ? undefined : agentId, toolCallId, input } });
+  };
+
+  const resolveTool = async (agentId: string, toolCallId: string, input: unknown) => {
+    await resolveToolForSession(chat.sessionId, chat.transcript.agentId, agentId, toolCallId, input);
   };
 
   const autoResolver = new AutoResolver({
     resolve: async (toolCallId) => {
+      const sessionId = chat.sessionId;
+      if (sessionId === null) {
+        return;
+      }
+
+      const transcriptAgentId = chat.transcript.agentId;
       const request = pendingRootRequests(chat.transcript).find((entry) => entry.toolCallId === toolCallId);
       const resolver = request === undefined ? undefined : clientResolvers[request.tool];
       if (request === undefined || resolver === undefined) {
         return;
       }
 
-      await resolveTool(request.agentId, toolCallId, resolver({ openDocuments }));
+      const input = await resolver({ openDocuments });
+      await resolveToolForSession(sessionId, transcriptAgentId, request.agentId, toolCallId, input);
     },
     settled: (err) => {
       const error = unwrapError(err);

--- a/apps/website/src/routes/website/(dashboard)/@prism/tools/index.ts
+++ b/apps/website/src/routes/website/(dashboard)/@prism/tools/index.ts
@@ -16,8 +16,8 @@ export type ClientResolverDeps = {
   openDocuments: OpenDocumentRegistry;
 };
 
-export const clientResolvers: Record<string, ((deps: ClientResolverDeps) => unknown) | undefined> = {
-  'list-open-documents': ({ openDocuments }) => openDocuments.snapshot(),
+export const clientResolvers: Record<string, ((deps: ClientResolverDeps) => unknown | Promise<unknown>) | undefined> = {
+  'list-open-documents': ({ openDocuments }) => openDocuments.snapshotWhenReady(),
 };
 
 export type { ActionBodyProps } from './action-cards.ts';

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/EntityPane.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/EntityPane.svelte
@@ -5,10 +5,12 @@
   import { center, flex } from '@typie/styled-system/patterns';
   import { Helmet, Icon } from '@typie/ui/components';
   import { getAppContext } from '@typie/ui/context';
+  import { onDestroy } from 'svelte';
   import { fade } from 'svelte/transition';
   import FileXIcon from '~icons/lucide/file-x';
   import XIcon from '~icons/lucide/x';
   import { fb } from '$lib/analytics';
+  import { getOpenDocuments } from '$lib/prism/open-documents.svelte';
   import { graphql } from '$mearie';
   import { resolveActiveTreeAncestorIds } from '../../@tree/entity-reveal.svelte';
   import DocumentV2 from '../v2/Document.svelte';
@@ -36,6 +38,8 @@
           id
           slug
           state
+          icon
+          iconColor
 
           ancestors {
             id
@@ -51,6 +55,8 @@
             ... on Document {
               id
               layoutMode
+              nullableTitle
+              subtitle
             }
           }
         }
@@ -81,11 +87,41 @@
 
   const app = getAppContext();
   const paneGroup = getPaneGroup();
+  const openDocuments = getOpenDocuments();
+
+  openDocuments.expectPane(pane.id);
+  onDestroy(() => openDocuments.expectPane(pane.id));
 
   const focused = $derived(pane.id === paneGroup.state.current.focusedPaneId);
   const entity = $derived(query.data?.entity);
   const documentLayoutMode = $derived(entity?.node.__typename === 'Document' ? entity.node.layoutMode : null);
   const documentId = $derived(entity?.node.__typename === 'Document' ? entity.node.id : null);
+
+  $effect(() => {
+    if (query.loading) {
+      openDocuments.expectPane(pane.id);
+      return;
+    }
+
+    if (!query.data) return;
+
+    const currentEntity = query.data.entity;
+    const node = currentEntity?.node;
+    if (currentEntity?.state === EntityState.ACTIVE && node?.__typename === 'Document') {
+      openDocuments.upsert(pane.id, {
+        kind: 'document',
+        documentId: node.id,
+        entityId: currentEntity.id,
+        title: node.nullableTitle ?? null,
+        subtitle: node.subtitle ?? null,
+        icon: currentEntity.icon,
+        iconColor: currentEntity.iconColor,
+        active: focused,
+      });
+    } else {
+      openDocuments.resolvePane(pane.id);
+    }
+  });
 
   $effect(() => {
     if (entity && entity.slug !== pane.slug) {

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/Panes.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/Panes.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import { css } from '@typie/styled-system/css';
   import { getAppContext } from '@typie/ui/context';
+  import { onDestroy } from 'svelte';
   import { fade } from 'svelte/transition';
+  import { getOpenDocuments } from '$lib/prism/open-documents.svelte';
   import { getPaneGroup } from './context.svelte';
   import EntityPane from './EntityPane.svelte';
   import { computeLayout } from './geometry';
@@ -17,6 +19,14 @@
 
   const app = getAppContext();
   const context = getPaneGroup();
+  const openDocuments = getOpenDocuments();
+
+  const syncOpenDocumentPanes = () => {
+    openDocuments.setExpectedPanes(context.panes.filter((pane) => pane.kind === 'entity').map((pane) => pane.id));
+  };
+
+  $effect.pre(syncOpenDocumentPanes);
+  onDestroy(() => openDocuments.invalidate());
 
   let rootRef = $state<HTMLDivElement>();
   let rootWidth = $state(0);

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/open-documents-panes-test-entity-pane.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/open-documents-panes-test-entity-pane.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import { getOpenDocuments } from '$lib/prism/open-documents.svelte';
+  import type { Pane } from './types';
+
+  type Props = {
+    pane: Extract<Pane, { kind: 'entity' }>;
+  };
+
+  let { pane }: Props = $props();
+
+  const openDocuments = getOpenDocuments();
+
+  openDocuments.expectPane(pane.id);
+  $effect(() => {
+    openDocuments.upsert(pane.id, {
+      kind: 'document',
+      documentId: pane.slug,
+      entityId: pane.slug,
+      title: pane.slug,
+      subtitle: null,
+      icon: 'file',
+      iconColor: 'gray',
+      active: true,
+    });
+  });
+</script>
+
+<div>{pane.slug}</div>

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/open-documents-panes-test-root.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/open-documents-panes-test-root.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import { setupOpenDocuments } from '$lib/prism/open-documents.svelte';
+  import { setupPaneGroup } from './context.svelte';
+  import Panes from './Panes.svelte';
+  import type { OpenDocumentRegistry } from '$lib/prism/open-documents.svelte';
+  import type { Pane } from './types';
+
+  type Props = {
+    onRegistry: (registry: OpenDocumentRegistry) => void;
+  };
+
+  let { onRegistry }: Props = $props();
+
+  const openDocuments = setupOpenDocuments();
+  const paneGroup = setupPaneGroup('open-documents-panes-test', {
+    userId: 'open-documents-panes-test',
+    navigate: () => {
+      // No navigation in this test host.
+    },
+    onSiteChange: () => {
+      // The test stays on one site.
+    },
+  });
+
+  const pane = (id: string, slug: string): Pane => ({ id, type: 'pane', kind: 'entity', slug });
+
+  paneGroup.state.current.root = pane('p1', 'D1');
+  paneGroup.state.current.focusedPaneId = 'p1';
+  onRegistry(openDocuments);
+
+  const root = $derived(paneGroup.state.current.root);
+
+  export function replacePane() {
+    paneGroup.state.current.root = pane('p2', 'D2');
+    paneGroup.state.current.focusedPaneId = 'p2';
+  }
+</script>
+
+{#if root}
+  <Panes {root} />
+{/if}

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/open-documents-panes.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/open-documents-panes.test.ts
@@ -1,0 +1,75 @@
+import { mount, tick, unmount } from 'svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import OpenDocumentsPanesTestRoot from './open-documents-panes-test-root.svelte';
+import type { OpenDocumentRegistry } from '$lib/prism/open-documents.svelte';
+
+const localStorageStub = vi.hoisted(() => {
+  const storage = new Map<string, string>();
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      get length() {
+        return storage.size;
+      },
+      clear: () => storage.clear(),
+      getItem: (key: string) => storage.get(key) ?? null,
+      key: (index: number) => [...storage.keys()][index] ?? null,
+      removeItem: (key: string) => storage.delete(key),
+      setItem: (key: string, value: string) => storage.set(key, value),
+    } satisfies Storage,
+  });
+  return storage;
+});
+
+vi.mock('@typie/ui/context', () => ({
+  getAppContext: () => ({ preference: { current: { zenModeEnabled: false } } }),
+}));
+
+vi.mock('./EntityPane.svelte', async () => {
+  const module = await import('./open-documents-panes-test-entity-pane.svelte');
+  return { default: module.default };
+});
+
+type TestRoot = {
+  replacePane: () => void;
+};
+
+beforeEach(() => {
+  localStorageStub.clear();
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe = vi.fn();
+      disconnect = vi.fn();
+    },
+  );
+  vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue(DOMRect.fromRect({ width: 800, height: 600 }));
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  document.body.replaceChildren();
+});
+
+describe('Panes open-document readiness', () => {
+  it('교체된 페인의 캐시된 문서를 첫 분류에서 받아들인다', async () => {
+    let registry: OpenDocumentRegistry | undefined;
+    const component = mount(OpenDocumentsPanesTestRoot, {
+      target: document.body,
+      props: { onRegistry: (value) => (registry = value) },
+    }) as TestRoot;
+
+    try {
+      await tick();
+      expect(registry?.snapshot().documents.map((document) => document.documentId)).toEqual(['D1']);
+
+      component.replacePane();
+      await tick();
+
+      expect(registry?.snapshot().documents.map((document) => document.documentId)).toEqual(['D2']);
+    } finally {
+      await unmount(component);
+    }
+  });
+});

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/Document.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/Document.svelte
@@ -2,9 +2,7 @@
   import { createFragment } from '@mearie/svelte';
   import { tick } from 'svelte';
   import { setupEditorContext } from '$lib/editor-ffi/editor.svelte';
-  import { getOpenDocuments } from '$lib/prism/open-documents.svelte';
   import { graphql } from '$mearie';
-  import { getPane } from '../@pane/context.svelte';
   import DocumentEditor from './DocumentEditor.svelte';
   import type { DocumentV2_query$key } from '$mearie';
 
@@ -24,19 +22,12 @@
         ...DocumentEditorV2_query
 
         entity(slug: $slug) {
-          id
-          slug
-          icon
-          iconColor
-
           node {
             __typename
 
             ... on Document {
               id
               title
-              nullableTitle
-              subtitle
               documentType: type
               createdAt
               updatedAt
@@ -85,33 +76,11 @@
 
   const ctx = setupEditorContext();
 
-  const openDocuments = getOpenDocuments();
-  const pane = getPane();
-
   const entity = $derived(query.data.entity);
   const documentId = $derived(entity?.node.__typename === 'Document' ? entity.node.id : null);
 
   $effect(() => {
     ctx.documentId = documentId;
-  });
-
-  $effect(() => {
-    const node = entity?.node;
-    if (!node || node.__typename !== 'Document') return;
-
-    const paneKey = `${pane.id}:${node.id}`;
-    openDocuments.upsert(paneKey, {
-      kind: 'document',
-      documentId: node.id,
-      entityId: entity.id,
-      title: node.nullableTitle ?? null,
-      subtitle: node.subtitle ?? null,
-      icon: entity.icon,
-      iconColor: entity.iconColor,
-      active: focused,
-    });
-
-    return () => openDocuments.remove(paneKey);
   });
 
   let mounted = $state(true);


### PR DESCRIPTION
## 문제

HMR이나 페인 교체 직후 프리즘의 열린 문서 조회가 엔티티 페인 복원보다 먼저 실행되면, 아직 분류되지 않은 페인을 누락한 채 빈 목록이나 부분적인 목록을 반환할 수 있었습니다.

## 변경 사항

- 열린 문서 레지스트리가 현재 엔티티 페인 목록과 각 페인의 분류 완료 여부를 함께 추적합니다.
- `list-open-documents`는 모든 페인이 분류될 때까지 최대 2초 기다리고, 준비되지 않으면 기존 자동 재시도 흐름을 사용합니다.
- 문서 등록을 `EntityPane`에서 처리해 문서가 아닌 엔티티도 분류 완료로 표시하고, 페인 교체나 HMR 중 이전 결과를 제거합니다.
- 대기 중 다른 프리즘 세션으로 전환해도 결과는 요청을 시작한 세션에 반환합니다.