### PR TITLE
AI 설정 변환 시 프리즘 리뷰 확인 카드 상태 복구

### DIFF
--- a/apps/website/src/routes/website/(dashboard)/@preference/PrismTab.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@preference/PrismTab.svelte
@@ -83,18 +83,20 @@
     try {
       await updatePreferences(
         { input: { value: { aiOptIn: enabled } } },
-        {
-          metadata: {
-            cache: {
-              optimisticResponse: {
-                updatePreferences: {
-                  id: user.data.id,
-                  preferences: { ...user.data.preferences, aiOptIn: enabled },
+        enabled
+          ? undefined
+          : {
+              metadata: {
+                cache: {
+                  optimisticResponse: {
+                    updatePreferences: {
+                      id: user.data.id,
+                      preferences: { ...user.data.preferences, aiOptIn: enabled },
+                    },
+                  },
                 },
               },
             },
-          },
-        },
       );
       mixpanel.track('ai_opt_in', { enabled });
     } catch {

--- a/apps/website/src/routes/website/(dashboard)/@prism/PrismToolRequest.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@prism/PrismToolRequest.svelte
@@ -35,7 +35,7 @@
   {@const Card = card}
   <div use:tooltip={{ message: guarded ? unavailableMessage : null, placement: 'bottom', delay: 0, arrow: false }}>
     <div class={css({ '&[data-readonly=true]': { opacity: '70' } })} aria-disabled={guarded} data-readonly={guarded} inert={guarded}>
-      <Card {message} {open} resolve={(input) => resolve(message.agentId, message.toolCallId, input)} {sessionId} />
+      <Card disabled={guarded} {message} {open} resolve={(input) => resolve(message.agentId, message.toolCallId, input)} {sessionId} />
     </div>
   </div>
 {:else if failed}

--- a/apps/website/src/routes/website/(dashboard)/@prism/review/PrismReviewConfirmCard.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@prism/review/PrismReviewConfirmCard.svelte
@@ -24,7 +24,7 @@
   import type { ToolCardProps } from '../tools/index.ts';
   import type { LineageOption } from './lineage-view.ts';
 
-  let { message, sessionId, open, resolve }: ToolCardProps = $props();
+  let { message, sessionId, open, disabled, resolve }: ToolCardProps = $props();
 
   const openDocuments = getOpenDocuments();
   const documents = $derived(openDocuments.snapshot().documents);
@@ -162,7 +162,7 @@
 
   $effect(() => {
     const documentId = selected?.documentId ?? null;
-    if (!open || documentId === null) {
+    if (!open || disabled || documentId === null) {
       return;
     }
 

--- a/apps/website/src/routes/website/(dashboard)/@prism/tools/index.ts
+++ b/apps/website/src/routes/website/(dashboard)/@prism/tools/index.ts
@@ -9,6 +9,7 @@ export type ToolCardProps = {
   message: ToolRequestMessage;
   sessionId: string | null;
   open: boolean;
+  disabled: boolean;
   resolve: (input: unknown) => Promise<void>;
 };
 


### PR DESCRIPTION
- AI 비활성 상태에서는 리뷰 준비 요청을 실행하지 않도록 했습니다.
- AI 활성화 설정이 서버에 저장된 뒤 리뷰 준비를 시작하도록 했습니다.
- 재활성화 후 크레딧 요구량과 시작 버튼이 복구되지 않는 문제를 수정했습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>