### PR TITLE
에디터 failure overlay를 pane 스크롤 영역에 맞춤

### DIFF
--- a/apps/website/src/lib/editor-ffi/components/ui/EditorFailureOverlay.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ui/EditorFailureOverlay.svelte
@@ -17,9 +17,12 @@
     id: string;
     actionLabel: string;
     onAction: () => void;
-  } & ({ contentPosition?: 'surface'; surfaceElement?: never } | { contentPosition: 'viewport'; surfaceElement: HTMLElement });
+  } & (
+    | { contentPosition?: 'surface'; surfaceElement?: never; minimumWidth?: never }
+    | { contentPosition: 'viewport'; surfaceElement: HTMLElement; minimumWidth?: number }
+  );
 
-  let { id, actionLabel, onAction, contentPosition = 'surface', surfaceElement }: Props = $props();
+  let { id, actionLabel, onAction, contentPosition = 'surface', surfaceElement, minimumWidth }: Props = $props();
 
   let overlayElement: HTMLElement | undefined = $state();
   let actionButton: HTMLElement | undefined = $state();
@@ -86,6 +89,7 @@
   style:left={visibleBounds ? `${visibleBounds.left}px` : undefined}
   style:width={visibleBounds ? `${visibleBounds.width}px` : undefined}
   style:height={visibleBounds ? `${visibleBounds.height}px` : undefined}
+  style:min-width={minimumWidth ? `${minimumWidth}px` : undefined}
   style:visibility={overlayVisible ? undefined : 'hidden'}
   style:pointer-events={overlayVisible ? undefined : 'none'}
   class={css({
@@ -122,27 +126,27 @@
           class={flex({
             flexDirection: 'column',
             alignItems: 'center',
-            gap: '20px',
+            gap: '14px',
             borderRadius: '12px',
-            padding: { base: '24px', lg: '48px' },
+            padding: { base: '24px', lg: '32px' },
             boxSizing: 'border-box',
             width: 'full',
             minWidth: '0',
-            maxWidth: '400px',
+            maxWidth: '340px',
             flexShrink: '0',
             marginY: 'auto',
             backgroundColor: 'surface.default',
             textAlign: 'center',
-            boxShadow: 'medium',
+            boxShadow: 'small',
             zIndex: '1',
             pointerEvents: 'auto',
           })}
           in:scale|global={{ start: 0.96, duration: 150 }}
         >
-          <Logo class={css({ height: '32px' })} />
-          <h2 id={titleId} class={css({ fontSize: '24px', fontWeight: 'extrabold' })}>앗! 문제가 발생했어요</h2>
+          <Logo class={css({ width: '24px', height: '24px' })} />
+          <h2 id={titleId} class={css({ fontSize: '20px', fontWeight: 'bold' })}>앗! 문제가 발생했어요</h2>
           <p id={messageId} class={css({ fontSize: '14px', color: 'text.faint' })}>잠시 후 다시 시도해주세요.</p>
-          <Button style={css.raw({ width: 'full' })} onclick={onAction} size="lg" bind:element={actionButton}>{actionLabel}</Button>
+          <Button onclick={onAction} size="md" bind:element={actionButton}>{actionLabel}</Button>
         </div>
       </div>
     </div>

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditor.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditor.svelte
@@ -27,7 +27,7 @@
   import StickyNoteIcon from '~icons/lucide/sticky-note';
   import XIcon from '~icons/lucide/x';
   import { Editor as EditorComponent, EditorFailureOverlay } from '$lib/editor-ffi/components';
-  import { CONTINUOUS_VIEW_PADDING, IS_MAC } from '$lib/editor-ffi/constants';
+  import { CONTINUOUS_MIN_WIDTH, CONTINUOUS_VIEW_PADDING, IS_MAC } from '$lib/editor-ffi/constants';
   import { browserScaleFactor, Editor, getEditorContext } from '$lib/editor-ffi/editor.svelte';
   import { createAssetHydrator } from '$lib/editor-ffi/handlers/asset-hydration';
   import { registerLinkContextMenu } from '$lib/editor-ffi/handlers/link';
@@ -1020,7 +1020,7 @@
   {/if}
 
   <div class={flex({ height: 'full', flex: '1', overflowX: 'auto' })}>
-    <div class={flex({ flexDirection: 'column', flexGrow: '1', overflowX: 'auto' })}>
+    <div class={flex({ position: 'relative', flexDirection: 'column', flexGrow: '1', overflowX: 'auto' })}>
       <!-- 헤더의 리뷰 버튼도 여백 컨텍스트를 읽는다 — 헤더까지 감싼다 -->
       <PrismReviewMargin
         available={marginAvailable}
@@ -1455,11 +1455,6 @@
                     {#if showFindReplace}
                       <DocumentFindReplace bind:this={findReplaceComponent} onclose={() => (showFindReplace = false)} />
                     {/if}
-                    {#if liveEditorFailed}
-                      <EditorFailureOverlay id={`document-editor-${pane.id}`} actionLabel="다시 불러오기" onAction={retryLiveEditor} />
-                    {:else if previewEditorRetry}
-                      <EditorFailureOverlay id={`document-preview-${pane.id}`} actionLabel="다시 불러오기" onAction={previewEditorRetry} />
-                    {/if}
                   </div>
                 </div>
 
@@ -1473,6 +1468,26 @@
               </DocumentComments>
             {/if}
           </div>
+
+          {#if liveEditorFailed && ctx.editorAreaEl}
+            <EditorFailureOverlay
+              id={`document-editor-${pane.id}`}
+              actionLabel="다시 불러오기"
+              contentPosition="viewport"
+              minimumWidth={CONTINUOUS_MIN_WIDTH + CONTINUOUS_VIEW_PADDING * 2}
+              onAction={retryLiveEditor}
+              surfaceElement={ctx.editorAreaEl}
+            />
+          {:else if previewEditorRetry && ctx.editorAreaEl}
+            <EditorFailureOverlay
+              id={`document-preview-${pane.id}`}
+              actionLabel="다시 불러오기"
+              contentPosition="viewport"
+              minimumWidth={CONTINUOUS_MIN_WIDTH + CONTINUOUS_VIEW_PADDING * 2}
+              onAction={previewEditorRetry}
+              surfaceElement={ctx.editorAreaEl}
+            />
+          {/if}
         {/snippet}
       </PrismReviewMargin>
 


### PR DESCRIPTION
- 에디터 failure card의 크기 및 스타일을 조정
- 좁은 pane에서도 card가 보이는 viewport 폭에 맞춰 축소되지 않고, pane의 스크롤 가능한 내부 공간을 기준으로 배치되도록 변경

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>