### PR TITLE
툴팁 전환 애니메이션 안정화

### DIFF
--- a/apps/website/src/lib/tooltip-coordinator.svelte.test.ts
+++ b/apps/website/src/lib/tooltip-coordinator.svelte.test.ts
@@ -88,10 +88,21 @@ const advance = async (milliseconds: number) => {
   await settle();
 };
 
+const lastAnimation = (): Animation | undefined => vi.mocked(Element.prototype.animate).mock.results.at(-1)?.value as Animation | undefined;
+
 const finishLastAnimation = async () => {
-  const animation = vi.mocked(Element.prototype.animate).mock.results.at(-1)?.value as Animation | undefined;
+  const animation = lastAnimation();
   animation?.onfinish?.call(animation, {} as AnimationPlaybackEvent);
   await settle();
+};
+
+const finishAnimations = async () => {
+  const results = vi.mocked(Element.prototype.animate).mock.results;
+  for (const result of results) {
+    const animation = result.value as Animation | undefined;
+    animation?.onfinish?.call(animation, {} as AnimationPlaybackEvent);
+    await settle();
+  }
 };
 
 const expectTooltip = (text: string) => {
@@ -146,6 +157,7 @@ beforeEach(() => {
 
 afterEach(async () => {
   await unmountFixture();
+  await finishAnimations();
   await vi.runOnlyPendingTimersAsync();
   if (originalAnimateDescriptor) Object.defineProperty(Element.prototype, 'animate', originalAnimateDescriptor);
   else delete (Element.prototype as Partial<Element>).animate;
@@ -346,7 +358,7 @@ describe('tooltip skip delay and shared host', () => {
     expect(tooltipElement()).toBe(firstHost);
   });
 
-  it('closes at 80ms but opens a new host immediately from warm state', async () => {
+  it('returns from the outro and reuses its host when another trigger arrives', async () => {
     await mountFixture();
     const first = trigger('action-third');
     const second = trigger('action-second');
@@ -354,14 +366,35 @@ describe('tooltip skip delay and shared host', () => {
     enter(first);
     await settle();
     const firstHost = tooltipElement();
+    await finishLastAnimation();
+
     leave(first);
     await advance(80);
-    expect(tooltipElement()).toBeNull();
+    const outro = lastAnimation();
+    expect(outro).toBeDefined();
 
     enter(second);
     await settle();
     expectTooltip('Second tooltip');
-    expect(tooltipElement()).not.toBe(firstHost);
+    expect(tooltipElement()).toBe(firstHost);
+
+    await finishLastAnimation();
+    expect(tooltipElement()).toBe(firstHost);
+  });
+
+  it('runs the tooltip outro independently of its trigger parent unmount', async () => {
+    await mountFixture();
+    enter(trigger('action-third'));
+    await settle();
+    const host = tooltipElement();
+    await finishLastAnimation();
+
+    await unmountFixture();
+
+    expect(document.querySelector('[data-testid="tooltip-test-root"]')).toBeNull();
+    expect(tooltipElement()).toBe(host);
+    await finishLastAnimation();
+    expect(tooltipElement()).toBeNull();
   });
 
   it('opens immediately 299ms into the warm window', async () => {
@@ -373,6 +406,7 @@ describe('tooltip skip delay and shared host', () => {
     await settle();
     leave(first);
     await advance(80);
+    await finishLastAnimation();
     await advance(299);
     enter(second);
     await settle();
@@ -389,6 +423,7 @@ describe('tooltip skip delay and shared host', () => {
     await settle();
     leave(first);
     await advance(80);
+    await finishLastAnimation();
     await advance(300);
     enter(second);
 
@@ -482,6 +517,7 @@ describe('tooltip eligibility and persistent visibility', () => {
 
     props.firstMessage = null;
     await settle();
+    await finishLastAnimation();
     expect(tooltipElement()).toBeNull();
     enter(trigger('action-second'));
     await settle();
@@ -539,6 +575,7 @@ describe('tooltip eligibility and persistent visibility', () => {
     await settle();
     props.firstForce = undefined;
     await settle();
+    await finishLastAnimation();
     expect(tooltipElement()).toBeNull();
 
     enter(trigger('action-second'));
@@ -566,6 +603,7 @@ describe('tooltip click behavior', () => {
     await settle();
     first.click();
     await settle();
+    await finishLastAnimation();
 
     expect(tooltipElement()).toBeNull();
   });

--- a/apps/website/src/lib/tooltip-test-root.svelte
+++ b/apps/website/src/lib/tooltip-test-root.svelte
@@ -147,6 +147,30 @@
           Motion third
         </button>
         <button
+          class="motion-toolbar-anchor motion-toolbar-lock"
+          data-testid="motion-toolbar-lock"
+          type="button"
+          use:tooltip={{ message: '편집 잠금', delay: 0, placement: 'bottom' }}
+        >
+          Lock
+        </button>
+        <button
+          class="motion-toolbar-anchor motion-toolbar-zen"
+          data-testid="motion-toolbar-zen"
+          type="button"
+          use:tooltip={{ message: '집중 모드 켜기', keys: ['Mod', 'Shift', 'M'], delay: 0, placement: 'bottom' }}
+        >
+          Zen
+        </button>
+        <button
+          class="motion-toolbar-anchor motion-toolbar-close"
+          data-testid="motion-toolbar-close"
+          type="button"
+          use:tooltip={{ message: '창 닫기', delay: 0, placement: 'bottom' }}
+        >
+          Close
+        </button>
+        <button
           class="motion-anchor motion-anchor-side"
           data-testid="motion-side"
           type="button"
@@ -289,6 +313,25 @@
   .motion-prism-close {
     position: absolute;
     top: 56px;
+  }
+
+  .motion-toolbar-anchor {
+    position: fixed;
+    top: 80px;
+    width: 24px;
+    height: 24px;
+  }
+
+  .motion-toolbar-lock {
+    right: 56px;
+  }
+
+  .motion-toolbar-zen {
+    right: 32px;
+  }
+
+  .motion-toolbar-close {
+    right: 8px;
   }
 
   .motion-anchor-first {

--- a/apps/website/src/lib/tooltip.browser.test.ts
+++ b/apps/website/src/lib/tooltip.browser.test.ts
@@ -68,6 +68,10 @@ const waitForPositionedTooltip = async (text: string): Promise<HTMLElement> => {
 afterEach(async () => {
   if (component) await unmount(component);
   component = undefined;
+  for (const element of document.querySelectorAll<HTMLElement>('[data-tooltip-presence]')) {
+    for (const animation of element.getAnimations()) animation.finish();
+  }
+  await frames(1);
   vi.restoreAllMocks();
   document.body.replaceChildren();
 });
@@ -82,7 +86,6 @@ describe('shared tooltip anchor motion', () => {
     const host = await waitForPositionedTooltip('굵게');
     const surface = host.querySelector<HTMLElement>('[data-tooltip-surface]');
     const firstLeft = Number.parseFloat(host.style.left);
-    const firstWidth = surface?.getBoundingClientRect().width ?? 0;
 
     leave(first);
     enter(second);
@@ -103,23 +106,19 @@ describe('shared tooltip anchor motion', () => {
     expect(getComputedStyle(currentContent as HTMLElement).opacity).toBe('0');
     const outgoingAnimation = outgoingContent?.getAnimations()[0];
     const incomingAnimation = currentContent?.getAnimations()[0];
-    expect(outgoingAnimation?.effect?.getTiming().duration).toBe(120);
-    expect(incomingAnimation?.effect?.getTiming().duration).toBe(120);
-    expect((outgoingAnimation?.effect as KeyframeEffect | null)?.getKeyframes().map(({ opacity }) => opacity)).toEqual(['1', '0']);
-    expect((incomingAnimation?.effect as KeyframeEffect | null)?.getKeyframes().map(({ opacity }) => opacity)).toEqual(['0', '1']);
     const sizeAnimation = surface
       ?.getAnimations()
       .find((animation) => (animation.effect as KeyframeEffect | null)?.getKeyframes().some((frame) => frame.width !== undefined));
-    const sizeKeyframes = (sizeAnimation?.effect as KeyframeEffect | null)?.getKeyframes();
-    expect(sizeAnimation?.effect?.getTiming().duration).toBe(120);
-    expect(Math.abs(Number.parseFloat(String(sizeKeyframes?.[0]?.width)) - firstWidth)).toBeLessThanOrEqual(1);
-    expect(Number.parseFloat(String(sizeKeyframes?.at(-1)?.width))).toBeGreaterThan(firstWidth);
+    expect(outgoingAnimation).toBeDefined();
+    expect(incomingAnimation).toBeDefined();
+    expect(sizeAnimation).toBeDefined();
     expect(getComputedStyle(surface as HTMLElement).overflow).toBe('hidden');
     expect(Math.abs(Number.parseFloat(host.style.left) - firstLeft)).toBeLessThanOrEqual(160);
+    const midpoint = Number(sizeAnimation?.effect?.getTiming().duration ?? 0) / 2;
     for (const animation of [outgoingAnimation, incomingAnimation, sizeAnimation]) {
       if (!animation) continue;
       animation.pause();
-      animation.currentTime = 60;
+      animation.currentTime = midpoint;
     }
     await frames(1);
     expect(currentContent?.getBoundingClientRect().top).toBeCloseTo(outgoingContent?.getBoundingClientRect().top ?? 0, 1);
@@ -138,6 +137,112 @@ describe('shared tooltip anchor motion', () => {
     expect(tooltip()).toBe(host);
     expect(host.dataset.tooltipMotion).toBe('travel');
     await vi.waitFor(() => expect(host.dataset.tooltipMotion).toBe('idle'));
+  });
+
+  it('preserves the full outgoing layout when a width transition reverses midway', async () => {
+    await mountFixture();
+    const lock = trigger('motion-toolbar-lock');
+    const zen = trigger('motion-toolbar-zen');
+
+    enter(lock);
+    const host = await waitForPositionedTooltip('편집 잠금');
+    host.querySelector<HTMLElement>('[data-tooltip-presence]')?.getAnimations()[0]?.finish();
+    await frames(1);
+
+    leave(lock);
+    enter(zen);
+    await vi.waitFor(() => expect(host.dataset.tooltipMotion).toBe('travel'));
+    const firstSurface = host.querySelector<HTMLElement>('[data-tooltip-surface]');
+    const firstIncoming = host.querySelector<HTMLElement>('[data-tooltip-content="current"]');
+    const sizeAnimation = firstSurface
+      ?.getAnimations()
+      .find((animation) => (animation.effect as KeyframeEffect | null)?.getKeyframes().some((frame) => frame.width !== undefined));
+    const midpoint = Number(sizeAnimation?.effect?.getTiming().duration ?? 0) / 2;
+    for (const animation of [
+      ...host.getAnimations(),
+      ...(firstSurface?.getAnimations() ?? []),
+      ...(firstIncoming?.getAnimations() ?? []),
+    ]) {
+      animation.pause();
+      animation.currentTime = midpoint;
+    }
+    const fullZenWidth = Number.parseFloat(firstIncoming?.style.width ?? '');
+    expect(fullZenWidth).toBeGreaterThan(0);
+
+    leave(zen);
+    enter(lock);
+    await vi.waitFor(() => {
+      expect(host.querySelector<HTMLElement>('[data-tooltip-content="outgoing"]')?.textContent).toContain('집중 모드 켜기');
+      expect(host.querySelector<HTMLElement>('[data-tooltip-content="current"]')?.textContent).toContain('편집 잠금');
+    });
+
+    const outgoing = host.querySelector<HTMLElement>('[data-tooltip-content="outgoing"]');
+    const outgoingLabel = outgoing?.querySelector<HTMLElement>('span');
+    expect(outgoingLabel).not.toBeNull();
+    const fontSize = Number.parseFloat(getComputedStyle(outgoingLabel as HTMLElement).fontSize);
+    expect(outgoingLabel?.getBoundingClientRect().height).toBeLessThan(fontSize * 1.5);
+    expect(Number.parseFloat(outgoing?.style.width ?? '')).toBeCloseTo(fullZenWidth, 1);
+  });
+
+  it('preserves a stable wide tooltip layout during a single transition to a narrower target', async () => {
+    await mountFixture();
+    const zen = trigger('motion-toolbar-zen');
+    const lock = trigger('motion-toolbar-lock');
+
+    enter(zen);
+    const host = await waitForPositionedTooltip('집중 모드 켜기');
+    host.querySelector<HTMLElement>('[data-tooltip-presence]')?.getAnimations()[0]?.finish();
+    await frames(1);
+    const stableContent = host.querySelector<HTMLElement>('[data-tooltip-content="current"]');
+    const stableIntrinsicWidth = stableContent?.scrollWidth ?? 0;
+    expect(stableIntrinsicWidth).toBeGreaterThan(0);
+
+    leave(zen);
+    enter(lock);
+    await vi.waitFor(() => {
+      expect(host.querySelector<HTMLElement>('[data-tooltip-content="outgoing"]')?.textContent).toContain('집중 모드 켜기');
+    });
+
+    const outgoing = host.querySelector<HTMLElement>('[data-tooltip-content="outgoing"]');
+    const outgoingLabel = outgoing?.querySelector<HTMLElement>('span');
+    expect(outgoingLabel).not.toBeNull();
+    const fontSize = Number.parseFloat(getComputedStyle(outgoingLabel as HTMLElement).fontSize);
+    expect(outgoingLabel?.getBoundingClientRect().height).toBeLessThan(fontSize * 1.5);
+    expect(Number.parseFloat(outgoing?.style.width ?? '')).toBeGreaterThanOrEqual(stableIntrinsicWidth);
+  });
+
+  it('pins the arrow to the next anchor immediately while the shared shell travels underneath it', async () => {
+    await mountFixture();
+    const close = trigger('motion-toolbar-close');
+    const zen = trigger('motion-toolbar-zen');
+
+    enter(close);
+    const host = await waitForPositionedTooltip('창 닫기');
+    host.querySelector<HTMLElement>('[data-tooltip-presence]')?.getAnimations()[0]?.finish();
+    await frames(1);
+    const arrow = host.querySelector<HTMLElement>('[data-tooltip-surface]')?.nextElementSibling as HTMLElement | null;
+    expect(arrow).not.toBeNull();
+    const nextAnchorCenter = zen.getBoundingClientRect().left + zen.getBoundingClientRect().width / 2;
+
+    leave(close);
+    enter(zen);
+    await vi.waitFor(() => expect(host.dataset.tooltipMotion).toBe('travel'));
+    const travel = host
+      .getAnimations()
+      .find((animation) => (animation.effect as KeyframeEffect | null)?.getKeyframes().some((keyframe) => keyframe.left !== undefined));
+    expect(travel).toBeDefined();
+    const arrowMotion = arrow?.getAnimations()[0];
+    expect(arrowMotion).toBeDefined();
+    const duration = Number(travel?.effect?.getTiming().duration ?? 0);
+    for (const progress of [0, 0.5, 0.99]) {
+      for (const animation of [travel, arrowMotion]) {
+        animation?.pause();
+        if (animation) animation.currentTime = duration * progress;
+      }
+      await frames(1);
+      const arrowCenter = (arrow?.getBoundingClientRect().left ?? 0) + (arrow?.getBoundingClientRect().width ?? 0) / 2;
+      expect(arrowCenter).toBeCloseTo(nextAnchorCenter, 0);
+    }
   });
 
   it('crossfades without travelling to a far anchor', async () => {
@@ -221,6 +326,8 @@ describe('shared tooltip anchor motion', () => {
 
     enter(first);
     const host = await waitForPositionedTooltip('wraps onto');
+    host.querySelector<HTMLElement>('[data-tooltip-presence]')?.getAnimations()[0]?.finish();
+    await frames(1);
     const previousContent = host.querySelector<HTMLElement>('[data-tooltip-content="current"]')?.getBoundingClientRect();
     expect(previousContent).toBeDefined();
 
@@ -273,6 +380,46 @@ describe('shared tooltip anchor motion', () => {
         (animation.effect as KeyframeEffect | null)?.getKeyframes().some((keyframe) => keyframe.opacity !== undefined),
       );
     expect(rootOpacityAnimations).toHaveLength(0);
+  });
+
+  it('returns to fully visible without a snap when an outro interrupts the intro', async () => {
+    await mountFixture();
+    const first = trigger('motion-first');
+    const second = trigger('motion-second');
+
+    enter(first);
+    const host = await waitForPositionedTooltip('굵게');
+    const presence = host.querySelector<HTMLElement>('[data-tooltip-presence]');
+    const intro = presence?.getAnimations()[0];
+    expect(intro).toBeDefined();
+    if (!intro) throw new Error('Expected an intro animation');
+    intro.pause();
+    intro.currentTime = Number(intro.effect?.getTiming().duration ?? 0) / 2;
+    await frames(1);
+
+    leave(first);
+    await vi.waitFor(() => expect(presence?.getAnimations()[0]).not.toBe(intro));
+    const outro = presence?.getAnimations()[0];
+    expect(outro).toBeDefined();
+    if (!outro) throw new Error('Expected an outro animation');
+    outro.pause();
+    outro.currentTime = Number(outro.effect?.getTiming().duration ?? 0) / 2;
+    await frames(1);
+    const opacityBeforeReentry = Number.parseFloat(getComputedStyle(presence as HTMLElement).opacity);
+
+    enter(second);
+    const opacityAfterReentry = Number.parseFloat(getComputedStyle(presence as HTMLElement).opacity);
+    expect(opacityAfterReentry).toBeCloseTo(opacityBeforeReentry, 2);
+    await waitForTooltip('기울임');
+    const returnAnimation = presence?.getAnimations()[0];
+    expect(returnAnimation).toBeDefined();
+    if (!returnAnimation) throw new Error('Expected a return animation');
+
+    returnAnimation.pause();
+    const duration = Number(returnAnimation.effect?.getTiming().duration ?? 0);
+    returnAnimation.currentTime = returnAnimation.playbackRate < 0 ? 0 : duration;
+    await frames(1);
+    expect(getComputedStyle(presence as HTMLElement).opacity).toBe('1');
   });
 
   it('settles shared transitions immediately when reduced motion is requested', async () => {

--- a/packages/ui/src/actions/TooltipComponent.svelte
+++ b/packages/ui/src/actions/TooltipComponent.svelte
@@ -10,6 +10,7 @@
     outgoingPresentation?: TooltipPresentation;
     contentHidden: boolean;
     floating: Action<HTMLElement>;
+    presenceAction: Action<HTMLElement>;
     surfaceAction: Action<HTMLElement>;
     arrowAction: Action<HTMLElement>;
     contentAction: Action<HTMLElement>;
@@ -36,6 +37,7 @@
     outgoingPresentation,
     contentHidden,
     floating,
+    presenceAction,
     surfaceAction,
     arrowAction,
     contentAction,
@@ -92,56 +94,58 @@
   role="tooltip"
   use:floating
 >
-  <div
-    class={css(
-      {
-        position: 'relative',
-        overflow: 'hidden',
-        borderRadius: '4px',
-        boxSizing: 'border-box',
-        paddingX: '8px',
-        paddingY: '4px',
-        fontSize: '12px',
-        color: 'text.bright',
-        backgroundColor: 'surface.dark',
-        boxShadow: 'medium',
-      },
-      presentation.kind === 'wrapper' ? presentation.tooltipStyle : undefined,
-    )}
-    data-tooltip-surface
-    use:surfaceAction
-  >
-    <div class={css({ position: 'relative' })}>
-      <div
-        style:opacity={contentHidden ? 0 : undefined}
-        class={contentClass(presentation)}
-        data-tooltip-content="current"
-        use:contentAction
-      >
-        {@render renderPresentation(presentation)}
-      </div>
-
-      {#if outgoingPresentation}
-        <div
-          class={[css({ position: 'absolute', top: '0', left: '0' }), contentClass(outgoingPresentation)]}
-          aria-hidden="true"
-          data-tooltip-content="outgoing"
-          use:outgoingContentAction
-        >
-          {@render renderPresentation(outgoingPresentation)}
-        </div>
-      {/if}
-    </div>
-  </div>
-
-  {#if showArrow}
+  <div class={css({ position: 'relative' })} data-tooltip-presence use:presenceAction>
     <div
-      class={css({
-        borderTopLeftRadius: '2px',
-        size: '8px',
-        backgroundColor: 'surface.dark',
-      })}
-      use:arrowAction
-    ></div>
-  {/if}
+      class={css(
+        {
+          position: 'relative',
+          overflow: 'hidden',
+          borderRadius: '4px',
+          boxSizing: 'border-box',
+          paddingX: '8px',
+          paddingY: '4px',
+          fontSize: '12px',
+          color: 'text.bright',
+          backgroundColor: 'surface.dark',
+          boxShadow: 'medium',
+        },
+        presentation.kind === 'wrapper' ? presentation.tooltipStyle : undefined,
+      )}
+      data-tooltip-surface
+      use:surfaceAction
+    >
+      <div class={css({ position: 'relative' })}>
+        <div
+          style:opacity={contentHidden ? 0 : undefined}
+          class={contentClass(presentation)}
+          data-tooltip-content="current"
+          use:contentAction
+        >
+          {@render renderPresentation(presentation)}
+        </div>
+
+        {#if outgoingPresentation}
+          <div
+            class={[css({ position: 'absolute', top: '0', left: '0' }), contentClass(outgoingPresentation)]}
+            aria-hidden="true"
+            data-tooltip-content="outgoing"
+            use:outgoingContentAction
+          >
+            {@render renderPresentation(outgoingPresentation)}
+          </div>
+        {/if}
+      </div>
+    </div>
+
+    {#if showArrow}
+      <div
+        class={css({
+          borderTopLeftRadius: '2px',
+          size: '8px',
+          backgroundColor: 'surface.dark',
+        })}
+        use:arrowAction
+      ></div>
+    {/if}
+  </div>
 </div>

--- a/packages/ui/src/actions/tooltip-coordinator.svelte.ts
+++ b/packages/ui/src/actions/tooltip-coordinator.svelte.ts
@@ -48,6 +48,7 @@ type TooltipHostProps = {
   outgoingPresentation?: TooltipPresentation;
   contentHidden: boolean;
   floating: Action<HTMLElement>;
+  presenceAction: Action<HTMLElement>;
   surfaceAction: Action<HTMLElement>;
   arrowAction: Action<HTMLElement>;
   contentAction: Action<HTMLElement>;
@@ -83,9 +84,18 @@ type HostMotion =
   | { kind: 'crossfade-out'; animation: Animation; target: TriggerRecord }
   | { kind: 'crossfade-in'; animation: Animation; target: TriggerRecord };
 
+type PresenceMotion = { kind: 'idle' } | { kind: 'intro' | 'outro'; animation: Animation };
+
 type SizeSnapshot = {
   width: number;
   height: number;
+};
+
+type ContentTransitionGeometry = {
+  previousSurface: SizeSnapshot;
+  nextSurface: SizeSnapshot;
+  previousContent: SizeSnapshot;
+  nextContent: SizeSnapshot;
 };
 
 type CalculatedPosition = Awaited<ReturnType<typeof computePosition>>;
@@ -102,6 +112,9 @@ const reactiveProps = <T extends object>(value: T): T => new ReactiveProps(value
 
 const TOOLTIP_SKIP_DELAY_MS = 300;
 const TOOLTIP_LEAVE_GRACE_MS = 80;
+const TOOLTIP_INTRO_MS = 200;
+const TOOLTIP_OUTRO_MS = 100;
+const TOOLTIP_PRESENCE_SCALE = 0.9;
 const TOOLTIP_MAX_TRAVEL_PX = 160;
 const TOOLTIP_TRAVEL_MS = 120;
 const TOOLTIP_CONTENT_CROSSFADE_MS = 120;
@@ -152,8 +165,23 @@ const sameSurfaceStyle = (left: TooltipPresentation, right: TooltipPresentation)
 
 const captureSize = (element: HTMLElement | undefined): SizeSnapshot | undefined => {
   if (!element) return;
+  const style = element.ownerDocument.defaultView?.getComputedStyle(element);
   const rect = element.getBoundingClientRect();
-  return { width: rect.width || element.offsetWidth, height: rect.height || element.offsetHeight };
+  const width = Number.parseFloat(style?.width ?? '');
+  const height = Number.parseFloat(style?.height ?? '');
+  return {
+    width: Number.isFinite(width) && width > 0 ? width : rect.width || element.offsetWidth,
+    height: Number.isFinite(height) && height > 0 ? height : rect.height || element.offsetHeight,
+  };
+};
+
+const captureContentSize = (element: HTMLElement | undefined): SizeSnapshot | undefined => {
+  const size = captureSize(element);
+  if (!element || !size) return size;
+  return {
+    width: Math.max(size.width, element.scrollWidth),
+    height: Math.max(size.height, element.scrollHeight),
+  };
 };
 
 const setSize = (element: HTMLElement | undefined, size: SizeSnapshot | undefined): void => {
@@ -182,6 +210,7 @@ class TooltipCoordinator {
   #hostProps: TooltipHostProps | undefined;
   #rendered: RenderedTooltipSnapshot | undefined;
   #floatingElement: HTMLElement | undefined;
+  #presenceElement: HTMLElement | undefined;
   #surfaceElement: HTMLElement | undefined;
   #arrowElement: HTMLElement | undefined;
   #contentElement: HTMLElement | undefined;
@@ -189,7 +218,11 @@ class TooltipCoordinator {
   #cleanupAutoUpdate: (() => void) | undefined;
   #positionVersion = 0;
   #hostMotion: HostMotion = { kind: 'idle' };
+  #presenceMotion: PresenceMotion = { kind: 'idle' };
+  #introPending = false;
+  #closing = false;
   #sizeAnimation: Animation | undefined;
+  #arrowAnimation: Animation | undefined;
   #contentAnimations: Animation[] = [];
   #contentMotionToken = 0;
 
@@ -200,8 +233,19 @@ class TooltipCoordinator {
 
     return {
       destroy: () => {
-        if (this.#floatingElement === element) this.#floatingElement = undefined;
-        this.#stopPositioning();
+        if (this.#floatingElement === element) {
+          this.#floatingElement = undefined;
+          this.#stopPositioning();
+        }
+      },
+    };
+  };
+
+  readonly #presenceAction: Action<HTMLElement> = (element) => {
+    this.#presenceElement = element;
+    return {
+      destroy: () => {
+        if (this.#presenceElement === element) this.#presenceElement = undefined;
       },
     };
   };
@@ -259,6 +303,11 @@ class TooltipCoordinator {
       } else {
         this.#show(record);
       }
+      return;
+    }
+
+    if (this.#closing) {
+      this.#show(record);
       return;
     }
 
@@ -351,36 +400,45 @@ class TooltipCoordinator {
     this.#clearLeaveTimer();
     this.#clearWarmTimer();
     const previous = this.#active;
+    const reopening = this.#closing;
     this.#active = record;
 
-    if (!this.#component) {
-      const hostProps = reactiveProps<TooltipHostProps>({
-        presentation: record.description.presentation,
-        outgoingPresentation: undefined,
-        contentHidden: false,
-        floating: this.#floatingAction,
-        surfaceAction: this.#surfaceAction,
-        arrowAction: this.#arrowAction,
-        contentAction: this.#contentAction,
-        outgoingContentAction: this.#outgoingContentAction,
-        showArrow: record.description.arrow,
-        motion: 'idle',
-      });
-      this.#hostProps = hostProps;
-      this.#rendered = {
-        record,
-        presentation: record.description.presentation,
-        showArrow: record.description.arrow,
-      };
-      this.#component = mount(TooltipComponent, {
-        target: record.description.container,
-        props: hostProps,
-      }) as Record<string, unknown>;
-    } else if (previous && previous !== record) {
-      void this.#switchTarget(record);
-    } else {
-      this.#syncHost(record);
+    if (this.#component) {
+      if (reopening) this.#reopenPresence();
+      if ((previous && previous !== record) || (reopening && this.#rendered?.record !== record)) {
+        if (!reopening) this.#finishIntro();
+        void this.#switchTarget(record);
+      } else {
+        this.#syncHost(record);
+      }
+      return;
     }
+
+    this.#closing = false;
+    this.#introPending = true;
+    const hostProps = reactiveProps<TooltipHostProps>({
+      presentation: record.description.presentation,
+      outgoingPresentation: undefined,
+      contentHidden: false,
+      floating: this.#floatingAction,
+      presenceAction: this.#presenceAction,
+      surfaceAction: this.#surfaceAction,
+      arrowAction: this.#arrowAction,
+      contentAction: this.#contentAction,
+      outgoingContentAction: this.#outgoingContentAction,
+      showArrow: record.description.arrow,
+      motion: 'idle',
+    });
+    this.#hostProps = hostProps;
+    this.#rendered = {
+      record,
+      presentation: record.description.presentation,
+      showArrow: record.description.arrow,
+    };
+    this.#component = mount(TooltipComponent, {
+      target: record.description.container,
+      props: hostProps,
+    }) as Record<string, unknown>;
   }
 
   #syncHost(record: TriggerRecord): void {
@@ -420,17 +478,113 @@ class TooltipCoordinator {
   }
 
   #closeVisible(): void {
-    if (!this.#active && !this.#component) return;
+    if (this.#closing || (!this.#active && !this.#component)) return;
     this.#active = undefined;
+    this.#closing = true;
     this.#clearLeaveTimer();
     this.#stopPositioning();
     this.#cancelMotion();
     this.#clearContentTransition();
+    this.#restoreRenderedDescription();
+    if (!this.#component || !this.#presenceElement || this.#prefersReducedMotion()) {
+      this.#finishClose();
+      return;
+    }
+    this.#startOutro();
+  }
+
+  #startIntro(): void {
+    if (!this.#presenceElement || !this.#introPending) return;
+    this.#introPending = false;
+    if (this.#prefersReducedMotion()) return;
+
+    this.#animatePresenceIn('0', `scale(${TOOLTIP_PRESENCE_SCALE})`, TOOLTIP_INTRO_MS);
+  }
+
+  #animatePresenceIn(opacity: string, transform: string, duration: number): void {
+    const element = this.#presenceElement;
+    if (!element) return;
+    this.#cancelPresenceMotion();
+    const animation = element.animate(
+      [
+        { opacity, transform },
+        { opacity: 1, transform: 'scale(1)' },
+      ],
+      { duration, easing: 'cubic-bezier(0.2, 0, 0, 1)', fill: 'both' },
+    );
+    this.#trackPresenceMotion('intro', animation);
+  }
+
+  #startOutro(): void {
+    const element = this.#presenceElement;
+    if (!element) {
+      this.#finishClose();
+      return;
+    }
+
+    this.#introPending = false;
+    const style = element.ownerDocument.defaultView?.getComputedStyle(element);
+    const opacity = style?.opacity || '1';
+    const transform = !style?.transform || style.transform === 'none' ? 'scale(1)' : style.transform;
+    this.#cancelPresenceMotion();
+    const animation = element.animate(
+      [
+        { opacity, transform },
+        { opacity: 0, transform: `scale(${TOOLTIP_PRESENCE_SCALE})` },
+      ],
+      { duration: TOOLTIP_OUTRO_MS, easing: 'cubic-bezier(0.4, 0, 1, 1)', fill: 'both' },
+    );
+    this.#trackPresenceMotion('outro', animation);
+  }
+
+  #trackPresenceMotion(kind: 'intro' | 'outro', animation: Animation): void {
+    const motion: PresenceMotion = { kind, animation };
+    this.#presenceMotion = motion;
+    animation.onfinish = () => {
+      if (this.#presenceMotion !== motion) return;
+      if (this.#closing) this.#finishClose();
+      else this.#finishPresenceMotion(motion);
+    };
+  }
+
+  #reopenPresence(): void {
+    this.#closing = false;
+    if (this.#presenceMotion.kind !== 'outro') return;
+    const element = this.#presenceElement;
+    if (!element) return;
+    const style = element.ownerDocument.defaultView?.getComputedStyle(element);
+    const opacity = style?.opacity || '0';
+    const transform = !style?.transform || style.transform === 'none' ? `scale(${TOOLTIP_PRESENCE_SCALE})` : style.transform;
+    this.#introPending = false;
+    this.#animatePresenceIn(opacity, transform, TOOLTIP_OUTRO_MS);
+  }
+
+  #finishIntro(): void {
+    if (this.#presenceMotion.kind === 'intro') this.#finishPresenceMotion(this.#presenceMotion);
+  }
+
+  #finishPresenceMotion(motion: Exclude<PresenceMotion, { kind: 'idle' }>): void {
+    if (this.#presenceMotion !== motion) return;
+    motion.animation.cancel();
+    this.#presenceMotion = { kind: 'idle' };
+  }
+
+  #cancelPresenceMotion(): void {
+    if (this.#presenceMotion.kind !== 'idle') this.#presenceMotion.animation.cancel();
+    this.#presenceMotion = { kind: 'idle' };
+  }
+
+  #finishClose(): void {
+    if (!this.#closing) return;
+    this.#cancelPresenceMotion();
     const component = this.#component;
+    this.#closing = false;
+    this.#introPending = false;
     this.#component = undefined;
     this.#hostProps = undefined;
     this.#rendered = undefined;
     this.#floatingElement = undefined;
+    this.#presenceElement = undefined;
     this.#surfaceElement = undefined;
     this.#arrowElement = undefined;
     this.#contentElement = undefined;
@@ -467,7 +621,7 @@ class TooltipCoordinator {
   }
 
   #cleanupIfUnused(): void {
-    if (this.#records.size > 0 || this.#active || this.#pending || this.#warm) return;
+    if (this.#records.size > 0 || this.#active || this.#pending || this.#warm || this.#component) return;
     this.#clearPending();
     this.#clearLeaveTimer();
     this.#stopPositioning();
@@ -497,6 +651,7 @@ class TooltipCoordinator {
   async #switchTarget(record: TriggerRecord): Promise<void> {
     const previousPosition = this.#captureVisualPosition();
     const previousSurfaceSize = captureSize(this.#surfaceElement);
+    const previousContentSize = this.#captureRenderedContentSize();
     this.#stopPositioning();
     this.#cancelMotion(previousPosition, previousSurfaceSize);
     this.#clearContentTransition();
@@ -518,7 +673,6 @@ class TooltipCoordinator {
       return;
     }
 
-    const previousContentSize = captureSize(this.#contentElement);
     const contentMotionToken = this.#prepareContentCrossfade(record, previousPresentation);
     await tick();
     if (this.#active !== record) return;
@@ -529,7 +683,7 @@ class TooltipCoordinator {
     if (!result || this.#active !== record) return;
     const destination = snapshotPosition(record, result.x, result.y, result.placement);
     const nextSurfaceSize = captureSize(this.#surfaceElement);
-    const nextContentSize = captureSize(this.#contentElement);
+    const nextContentSize = captureContentSize(this.#contentElement);
     setSize(this.#contentElement, nextContentSize);
     setSize(this.#outgoingContentElement, previousContentSize);
 
@@ -539,8 +693,18 @@ class TooltipCoordinator {
     if (travels) {
       this.#presentHostDescription(record);
       this.#applyPosition(record, result);
-      this.#startContentCrossfade(record, contentMotionToken);
+      const contentGeometry =
+        previousSurfaceSize && nextSurfaceSize && previousContentSize && nextContentSize
+          ? {
+              previousSurface: previousSurfaceSize,
+              nextSurface: nextSurfaceSize,
+              previousContent: previousContentSize,
+              nextContent: nextContentSize,
+            }
+          : undefined;
+      this.#startContentCrossfade(record, contentMotionToken, contentGeometry);
       this.#startSizeTransition(previousSurfaceSize, nextSurfaceSize);
+      this.#pinArrowDuringTravel(previousPosition, destination);
       this.#startTravel(previousPosition, destination);
       this.#startTracking(record, false);
       return;
@@ -598,6 +762,12 @@ class TooltipCoordinator {
     return { ...position, x: Number.isFinite(x) ? x : position.x, y: Number.isFinite(y) ? y : position.y };
   }
 
+  #captureRenderedContentSize(): SizeSnapshot | undefined {
+    const element =
+      this.#hostProps?.outgoingPresentation === this.#rendered?.presentation ? this.#outgoingContentElement : this.#contentElement;
+    return captureContentSize(element);
+  }
+
   #startSizeTransition(previous: SizeSnapshot | undefined, next: SizeSnapshot | undefined): void {
     const surfaceElement = this.#surfaceElement;
     if (!surfaceElement || !previous || !next || (previous.width === next.width && previous.height === next.height)) {
@@ -618,6 +788,28 @@ class TooltipCoordinator {
       animation.cancel();
       this.#sizeAnimation = undefined;
       clearSize(this.#surfaceElement);
+    };
+  }
+
+  #pinArrowDuringTravel(previous: PositionSnapshot, destination: PositionSnapshot): void {
+    const element = this.#arrowElement;
+    if (!element) return;
+    const axis = destination.side === 'top' || destination.side === 'bottom' ? 'left' : 'top';
+    const value = Number.parseFloat(element.ownerDocument.defaultView?.getComputedStyle(element)[axis] ?? '');
+    if (!Number.isFinite(value)) return;
+    const travel = axis === 'left' ? destination.x - previous.x : destination.y - previous.y;
+    if (Math.abs(travel) < 0.5) return;
+    const keyframes =
+      axis === 'left' ? [{ left: `${value + travel}px` }, { left: `${value}px` }] : [{ top: `${value + travel}px` }, { top: `${value}px` }];
+    const animation = element.animate(keyframes, {
+      duration: TOOLTIP_TRAVEL_MS,
+      easing: 'cubic-bezier(0.2, 0, 0, 1)',
+    });
+    this.#arrowAnimation = animation;
+    animation.onfinish = () => {
+      if (this.#arrowAnimation !== animation) return;
+      animation.cancel();
+      this.#arrowAnimation = undefined;
     };
   }
 
@@ -644,7 +836,7 @@ class TooltipCoordinator {
     return token;
   }
 
-  #startContentCrossfade(record: TriggerRecord, token: number): void {
+  #startContentCrossfade(record: TriggerRecord, token: number, geometry: ContentTransitionGeometry | undefined): void {
     const outgoingContentElement = this.#outgoingContentElement;
     const contentElement = this.#contentElement;
     if (!outgoingContentElement || !contentElement || this.#active !== record || this.#contentMotionToken !== token) {
@@ -653,28 +845,59 @@ class TooltipCoordinator {
     }
     const outgoing = outgoingContentElement.animate([{ opacity: 1 }, { opacity: 0 }], {
       duration: TOOLTIP_CONTENT_CROSSFADE_MS,
-      easing: 'ease-out',
       fill: 'forwards',
     });
     const incoming = contentElement.animate([{ opacity: 0 }, { opacity: 1 }], {
       duration: TOOLTIP_CONTENT_CROSSFADE_MS,
-      easing: 'ease-out',
       fill: 'forwards',
     });
-    this.#contentAnimations = [outgoing, incoming];
-    incoming.onfinish = () => void this.#finishContentCrossfade(record, token, outgoing, incoming);
+    const outgoingPosition = geometry
+      ? this.#centerContentDuringResize(outgoingContentElement, geometry.previousContent, geometry.previousSurface, geometry.nextSurface)
+      : undefined;
+    const incomingPosition = geometry
+      ? this.#centerContentDuringResize(contentElement, geometry.nextContent, geometry.previousSurface, geometry.nextSurface)
+      : undefined;
+    this.#contentAnimations = [outgoing, incoming, outgoingPosition, incomingPosition].filter(
+      (animation): animation is Animation => animation !== undefined,
+    );
+    incoming.onfinish = () => void this.#finishContentCrossfade(record, token, incoming);
   }
 
-  async #finishContentCrossfade(record: TriggerRecord, token: number, outgoing: Animation, incoming: Animation): Promise<void> {
+  #centerContentDuringResize(
+    element: HTMLElement,
+    content: SizeSnapshot,
+    previousSurface: SizeSnapshot,
+    nextSurface: SizeSnapshot,
+  ): Animation | undefined {
+    const surfaceElement = this.#surfaceElement;
+    if (!surfaceElement) return;
+    const style = surfaceElement.ownerDocument.defaultView?.getComputedStyle(surfaceElement);
+    const horizontalPadding = Number.parseFloat(style?.paddingLeft ?? '') + Number.parseFloat(style?.paddingRight ?? '');
+    const verticalPadding = Number.parseFloat(style?.paddingTop ?? '') + Number.parseFloat(style?.paddingBottom ?? '');
+    if (!Number.isFinite(horizontalPadding) || !Number.isFinite(verticalPadding)) return;
+    const offset = (surface: SizeSnapshot) => ({
+      x: (surface.width - horizontalPadding - content.width) / 2,
+      y: (surface.height - verticalPadding - content.height) / 2,
+    });
+    const from = offset(previousSurface);
+    const to = offset(nextSurface);
+    if (Math.abs(from.x - to.x) < 0.5 && Math.abs(from.y - to.y) < 0.5) return;
+    return element.animate([{ transform: `translate(${from.x}px, ${from.y}px)` }, { transform: `translate(${to.x}px, ${to.y}px)` }], {
+      duration: TOOLTIP_TRAVEL_MS,
+      easing: 'cubic-bezier(0.2, 0, 0, 1)',
+    });
+  }
+
+  async #finishContentCrossfade(record: TriggerRecord, token: number, incoming: Animation): Promise<void> {
     if (this.#contentMotionToken !== token || !this.#contentAnimations.includes(incoming) || this.#active !== record) return;
+    const animations = this.#contentAnimations;
     if (this.#hostProps) {
       this.#hostProps.contentHidden = false;
       this.#hostProps.outgoingPresentation = undefined;
     }
     await tick();
     if (this.#contentMotionToken !== token || this.#active !== record) return;
-    outgoing.cancel();
-    incoming.cancel();
+    for (const animation of animations) animation.cancel();
     this.#contentAnimations = [];
     clearSize(this.#contentElement);
     clearSize(this.#outgoingContentElement);
@@ -727,6 +950,8 @@ class TooltipCoordinator {
     this.#setHostMotion({ kind: 'idle' });
     this.#sizeAnimation?.cancel();
     this.#sizeAnimation = undefined;
+    this.#arrowAnimation?.cancel();
+    this.#arrowAnimation = undefined;
     if (position && this.#floatingElement) {
       this.#floatingElement.style.left = `${position.x}px`;
       this.#floatingElement.style.top = `${position.y}px`;
@@ -806,6 +1031,7 @@ class TooltipCoordinator {
       visibility: 'visible',
     });
     if (this.#rendered?.record === record) this.#rendered.position = snapshotPosition(record, result.x, result.y, result.placement);
+    this.#startIntro();
 
     if (!arrowElement || !result.middlewareData.arrow) return;
     const side = resolvedSide(result.placement);


### PR DESCRIPTION
- 툴팁 intro/outro를 coordinator에서 관리하고, outro 중 다른 툴팁으로 이동하면 자연스럽게 전환을 되돌립니다.
- shared tooltip 전환 중 shell 크기와 내용을 함께 애니메이션하고, 콘텐츠를 중앙에 배치합니다.
- 콘텐츠 크기를 보존해 순간적인 줄바꿈을 방지하고, arrow를 새 앵커 위치에 고정합니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>