### PR TITLE
3D 프리즘 토글 버튼

### DIFF
--- a/apps/website/src/icons/prism-off.svg
+++ b/apps/website/src/icons/prism-off.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path
+    d="M17.2348 22.4532L1.9291 17.7297 M1.9291 17.7297L6.92714 6.92714 M13.054804 13.054804L17.2348 22.4532 M15.0067 3.2528L19.897518 14.240664 M17.2348 22.4532L19.693356 19.693356 M8.836622 3.179768L15.0067 3.2528"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path d="M2 2l20 20" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/apps/website/src/routes/website/(dashboard)/@prism/PrismPanel.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@prism/PrismPanel.svelte
@@ -17,6 +17,8 @@
   import PencilIcon from '~icons/lucide/pencil';
   import PlusIcon from '~icons/lucide/plus';
   import TrashIcon from '~icons/lucide/trash-2';
+  import PrismIcon from '~icons/typie/prism';
+  import PrismOffIcon from '~icons/typie/prism-off';
   import { page } from '$app/state';
   import { cache, wsStatus } from '$lib/graphql';
   import { unwrapError } from '$lib/graphql/error';
@@ -356,6 +358,7 @@
   let indicatorPhase = $state<'answered' | 'failed' | 'hidden' | 'submitting' | 'welcome'>(
     selected.current === null ? 'welcome' : 'hidden',
   );
+  let prismObjectAvailable = $state(false);
   let indicatorSpinnerOwner = $state<'panel' | 'row'>('row');
   let indicatorWaitSeen = $state(false);
   const chipsVisible = $derived(emptySession && draft.length === 0);
@@ -372,6 +375,21 @@
     backgroundColor: 'surface.muted',
     transition: '[background-color 150ms ease]',
     _hover: { backgroundColor: 'interactive.hover' },
+  });
+  const prismToggleClass = css({
+    position: 'absolute',
+    top: '12px',
+    left: '12px',
+    zIndex: '2',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: '4px',
+    size: '24px',
+    color: 'text.faint',
+    transition: '[transform 160ms cubic-bezier(0.23, 1, 0.32, 1)]',
+    _supportHover: { color: 'text.subtle', backgroundColor: 'surface.muted' },
+    _active: { transform: 'scale(0.95)' },
   });
   let listOpen = $state(false);
   const listToggleLabel = $derived(listOpen ? '대화 목록 닫기' : '대화 목록 열기');
@@ -960,12 +978,29 @@
     {/if}
 
     <div class={flex({ position: 'relative', flexDirection: 'column', flexGrow: '1', minHeight: '0' })}>
+      {#if !chat.loading && emptySession && prismObjectAvailable}
+        {@const prismEnabled = app.preference.current.prismWelcomeObjectEnabled}
+        {@const prismToggleLabel = prismEnabled ? '3D 프리즘 끄기' : '3D 프리즘 켜기'}
+        <button
+          class={prismToggleClass}
+          aria-label="3D 프리즘"
+          aria-pressed={prismEnabled}
+          onclick={() => (app.preference.current.prismWelcomeObjectEnabled = !prismEnabled)}
+          type="button"
+          use:tooltip={{ message: prismToggleLabel }}
+        >
+          <Icon icon={prismEnabled ? PrismOffIcon : PrismIcon} size={16} />
+        </button>
+      {/if}
+
       {#if app.preference.current.prismPanelOpen && indicatorPhase !== 'hidden'}
         {#key chat.generation}
           <PrismPanelIndicator
             destination={indicatorDestination}
+            onPrismAvailabilityChange={(available) => (prismObjectAvailable = available)}
             onSpinnerOwnerChange={(owner) => (indicatorSpinnerOwner = owner)}
             phase={indicatorPhase}
+            prismEnabled={app.preference.current.prismWelcomeObjectEnabled}
             themeVariant={theme.currentThemeVariant}
             {welcomeAdmission}
           />

--- a/apps/website/src/routes/website/(dashboard)/@prism/PrismPanelIndicator.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@prism/PrismPanelIndicator.svelte
@@ -3,6 +3,7 @@
   import { PRISM_ICON_DURATION_SECONDS } from '@typie/prism-ui';
   import { token } from '@typie/styled-system/tokens';
   import { onDestroy, onMount, untrack } from 'svelte';
+  import PrismIcon from '~icons/typie/prism';
   import PrismObject from '$lib/prism-ui/PrismObject.svelte';
   import { createPrismIndicatorPath, samplePrismIndicatorPath } from './lib/prism-indicator-path.ts';
   import PrismPanelWelcomeMessage from './PrismPanelWelcomeMessage.svelte';
@@ -20,8 +21,10 @@
 
   type Props = {
     destination?: HTMLElement;
+    onPrismAvailabilityChange?: (available: boolean) => void;
     onSpinnerOwnerChange?: (owner: PrismSpinnerOwner) => void;
     phase: PrismIndicatorPhase;
+    prismEnabled?: boolean;
     reducedMotion?: boolean;
     themeVariant?: ThemeVariant;
     welcomeAdmission?: boolean;
@@ -31,8 +34,10 @@
 
   let {
     destination,
+    onPrismAvailabilityChange,
     onSpinnerOwnerChange,
     phase,
+    prismEnabled = true,
     reducedMotion = typeof window !== 'undefined' &&
       typeof window.matchMedia === 'function' &&
       window.matchMedia('(prefers-reduced-motion: reduce)').matches,
@@ -42,6 +47,7 @@
   let actor = $state<HTMLDivElement>();
   let actorMounted = $state(true);
   let actorVisible = $state(true);
+  let prismRendererMounted = $state(!reducedMotion);
   const edgeColor = $derived(themeVariant ? themeData.variants[themeVariant]['ui.border.default'] : undefined);
   let mode = $state<Mode>('idle');
   let path: PrismIndicatorPath | null = null;
@@ -67,8 +73,11 @@
   let admissionFrame = 0;
   let followerFrame = 0;
   let returnStartProgress = 0;
+  let prismAvailable: boolean | undefined;
   let spinnerOwner: PrismSpinnerOwner | undefined;
-  const showWelcomeMessage = $derived(phase === 'welcome' && (target === 'prism' || reducedMotion || snapshot.readiness === 'unavailable'));
+  const welcomeMessageEligible = $derived(!prismEnabled || target === 'prism' || reducedMotion || snapshot.readiness === 'unavailable');
+  let welcomeMessageAdmitted = $state(false);
+  const showWelcomeMessage = $derived(phase === 'welcome' && (welcomeMessageEligible || welcomeMessageAdmitted));
 
   const center = (element: HTMLElement): PrismIndicatorPoint => {
     const bounds = element.getBoundingClientRect();
@@ -79,6 +88,12 @@
     if (spinnerOwner === owner) return;
     spinnerOwner = owner;
     onSpinnerOwnerChange?.(owner);
+  };
+
+  const setPrismAvailable = (available: boolean) => {
+    if (prismAvailable === available) return;
+    prismAvailable = available;
+    onPrismAvailabilityChange?.(available);
   };
 
   const clearDwell = () => {
@@ -96,6 +111,7 @@
   const scheduleWelcomeMorph = () => {
     if (
       phase !== 'welcome' ||
+      !prismEnabled ||
       !welcomeAdmission ||
       mode !== 'idle' ||
       target !== 'icon' ||
@@ -111,6 +127,7 @@
       welcomeFrame = 0;
       if (
         phase !== 'welcome' ||
+        !prismEnabled ||
         !welcomeAdmission ||
         mode !== 'idle' ||
         target !== 'icon' ||
@@ -288,7 +305,7 @@
     clearDwell();
     if (mode !== 'idle' && mode !== 'candidate') return;
     if (mode === 'idle') {
-      if (reducedMotion || snapshot.readiness !== 'ready') {
+      if (!prismEnabled || reducedMotion || snapshot.readiness !== 'ready') {
         fallbackToRow();
         return;
       }
@@ -307,7 +324,7 @@
       actorVisible = true;
       if (actor) actor.style.transform = 'translate3d(0px, 0px, 0px)';
       targetDurationMs = undefined;
-      target = reducedMotion || snapshot.readiness === 'unavailable' ? 'icon' : 'prism';
+      target = !prismEnabled || reducedMotion || snapshot.readiness === 'unavailable' ? 'icon' : 'prism';
       return;
     }
 
@@ -341,9 +358,14 @@
 
   const handleSnapshot = (next: PrismRuntimeSnapshot) => {
     snapshot = next;
+    setPrismAvailable(!reducedMotion && next.readiness === 'ready');
     if (next.readiness === 'unavailable') {
       settleStaticPresentation();
+      prismRendererMounted = false;
       return;
+    }
+    if (!prismEnabled && next.readiness === 'ready' && next.owner === 'svg' && next.settledTarget === 'icon') {
+      prismRendererMounted = false;
     }
     scheduleWelcomeMorph();
     if (mode === 'morphing') {
@@ -388,6 +410,7 @@
 
   onDestroy(() => {
     destroyed = true;
+    setPrismAvailable(false);
     window.removeEventListener('load', observeLoadedBrowser);
     if (stabilityIdle !== 0) cancelIdleCallback(stabilityIdle);
     if (stabilityFrame !== 0) cancelAnimationFrame(stabilityFrame);
@@ -399,11 +422,34 @@
 
   $effect(() => {
     const useStaticPresentation = reducedMotion;
-    if (useStaticPresentation) untrack(settleStaticPresentation);
+    setPrismAvailable(!useStaticPresentation && snapshot.readiness === 'ready');
+    if (useStaticPresentation) {
+      prismRendererMounted = false;
+      untrack(settleStaticPresentation);
+    } else if (prismEnabled && snapshot.readiness !== 'unavailable') {
+      prismRendererMounted = true;
+    }
   });
 
   $effect(() => {
-    if (welcomeAdmission) untrack(scheduleWelcomeMorph);
+    if (phase !== 'welcome') welcomeMessageAdmitted = false;
+    else if (welcomeMessageEligible) welcomeMessageAdmitted = true;
+  });
+
+  $effect(() => {
+    const enabled = prismEnabled;
+    const admitted = welcomeAdmission;
+    untrack(() => {
+      if (!enabled) {
+        const alreadySettledAtIcon = target === 'icon' && snapshot.owner === 'svg' && snapshot.settledTarget === 'icon';
+        targetDurationMs = undefined;
+        target = 'icon';
+        if (alreadySettledAtIcon && snapshot.readiness !== 'loading') prismRendererMounted = false;
+      } else if (admitted) {
+        prismRendererMounted = true;
+        scheduleWelcomeMorph();
+      }
+    });
   });
 
   $effect(() => {
@@ -429,15 +475,19 @@
         class="actor"
         data-prism-indicator-actor
       >
-        <PrismObject
-          {edgeColor}
-          {interactive}
-          onStateChange={handleSnapshot}
-          preload={!reducedMotion}
-          {reducedMotion}
-          {target}
-          {targetDurationMs}
-        />
+        {#if prismRendererMounted}
+          <PrismObject
+            {edgeColor}
+            {interactive}
+            onStateChange={handleSnapshot}
+            preload={!reducedMotion}
+            {reducedMotion}
+            {target}
+            {targetDurationMs}
+          />
+        {:else}
+          <PrismIcon aria-hidden="true" data-prism-indicator-static-icon height="44" width="44" />
+        {/if}
       </div>
     {/if}
   </span>
@@ -445,7 +495,7 @@
 
 <PrismPanelWelcomeMessage
   delayMs={snapshot.readiness === 'unavailable' ? 0 : WELCOME_MESSAGE_DELAY_MS}
-  immediate={reducedMotion}
+  immediate={reducedMotion || !prismEnabled}
   visible={showWelcomeMessage}
 />
 

--- a/apps/website/src/routes/website/(dashboard)/@prism/prism-panel-indicator.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/@prism/prism-panel-indicator.test.ts
@@ -141,6 +141,56 @@ const setSourceRect = (target: HTMLElement) => {
 };
 
 describe('Prism panel indicator', () => {
+  test('reports whether the 3D prism renderer is actually available', async () => {
+    const target = document.createElement('div');
+    const availability: boolean[] = [];
+    const props = reactiveProps({
+      onPrismAvailabilityChange: (available: boolean) => {
+        availability.push(available);
+      },
+      phase: 'welcome' as const,
+    });
+    const component = mount(PrismPanelIndicator, { target, props });
+    try {
+      await tick();
+      expect(availability.at(-1)).toBe(false);
+
+      runtime.emit({ readiness: 'ready' });
+      await tick();
+      expect(availability.at(-1)).toBe(true);
+
+      runtime.emit({ readiness: 'unavailable' });
+      await tick();
+      expect(availability.at(-1)).toBe(false);
+      expect(runtime.mountObject).toHaveBeenCalledOnce();
+    } finally {
+      await unmount(component);
+    }
+  });
+
+  test('never reports the 3D prism as available with reduced motion', async () => {
+    const target = document.createElement('div');
+    const availability: boolean[] = [];
+    const props = reactiveProps({
+      onPrismAvailabilityChange: (available: boolean) => {
+        availability.push(available);
+      },
+      phase: 'welcome' as const,
+      reducedMotion: true,
+    });
+    const component = mount(PrismPanelIndicator, { target, props });
+    try {
+      await tick();
+      runtime.emit({ readiness: 'ready' });
+      await tick();
+
+      expect(availability.at(-1)).toBe(false);
+      expect(availability).not.toContain(true);
+    } finally {
+      await unmount(component);
+    }
+  });
+
   test('uses the theme-state edge color before the view-transition DOM catches up', async () => {
     const target = document.createElement('div');
     const previousTheme = document.documentElement.dataset.theme;
@@ -233,6 +283,124 @@ describe('Prism panel indicator', () => {
     }
   });
 
+  test('keeps the welcome prism static when the 3D object preference is disabled', async () => {
+    const target = document.createElement('div');
+    const availability: boolean[] = [];
+    const props = reactiveProps({
+      onPrismAvailabilityChange: (available: boolean) => {
+        availability.push(available);
+      },
+      phase: 'welcome' as const,
+      prismEnabled: false,
+    });
+    const component = mount(PrismPanelIndicator, { target, props });
+    try {
+      await tick();
+      await vi.advanceTimersByTimeAsync(700);
+      runtime.emit({ readiness: 'ready' });
+      stepIdleCallback();
+      stepAnimationFrame();
+      stepAnimationFrame();
+      stepAnimationFrame();
+      await tick();
+
+      expect(runtime.object.setTarget).not.toHaveBeenCalledWith('prism');
+      expect(availability.at(-1)).toBe(true);
+      expect(runtime.object.destroy).toHaveBeenCalledOnce();
+      expect(target.querySelector('[data-prism-indicator-static-icon]')).not.toBeNull();
+    } finally {
+      await unmount(component);
+    }
+  });
+
+  test('remounts the 3D renderer when the static welcome prism is enabled again', async () => {
+    const target = document.createElement('div');
+    const props = reactiveProps({ phase: 'welcome' as const, prismEnabled: false });
+    const component = mount(PrismPanelIndicator, { target, props });
+    try {
+      await tick();
+      runtime.emit({ readiness: 'ready' });
+      await tick();
+      expect(runtime.object.destroy).toHaveBeenCalledOnce();
+
+      props.prismEnabled = true;
+      await tick();
+
+      expect(runtime.mountObject).toHaveBeenCalledTimes(2);
+      expect(target.querySelector('[data-prism-indicator-static-icon]')).toBeNull();
+    } finally {
+      await unmount(component);
+    }
+  });
+
+  test('shows the welcome message immediately when the 3D object preference is disabled', async () => {
+    const target = document.createElement('div');
+    const props = reactiveProps({ phase: 'welcome' as const, prismEnabled: false });
+    const component = mount(PrismPanelIndicator, { target, props });
+    try {
+      await tick();
+
+      expect(target.querySelector('[data-prism-indicator-message]')).not.toBeNull();
+      expect(animate).not.toHaveBeenCalled();
+    } finally {
+      await unmount(component);
+    }
+  });
+
+  test('keeps an admitted welcome message visible while the 3D object preference is enabled', async () => {
+    const target = document.createElement('div');
+    const props = reactiveProps({ phase: 'welcome' as const, prismEnabled: false });
+    const component = mount(PrismPanelIndicator, { target, props });
+    try {
+      await tick();
+      expect(target.querySelector('[data-prism-indicator-message]')).not.toBeNull();
+
+      animate.mockClear();
+      props.prismEnabled = true;
+      await tick();
+
+      expect(target.querySelector('[data-prism-indicator-message]')).not.toBeNull();
+      expect(animate).not.toHaveBeenCalled();
+    } finally {
+      await unmount(component);
+    }
+  });
+
+  test('returns the welcome prism to the icon when the 3D object preference is disabled', async () => {
+    const target = document.createElement('div');
+    const props = reactiveProps({ phase: 'welcome' as const, prismEnabled: true });
+    const component = mount(PrismPanelIndicator, { target, props });
+    try {
+      await tick();
+      await vi.advanceTimersByTimeAsync(700);
+      runtime.emit({ readiness: 'ready' });
+      stepIdleCallback();
+      stepAnimationFrame();
+      stepAnimationFrame();
+      stepAnimationFrame();
+      await tick();
+      expect(runtime.object.setTarget).toHaveBeenCalledWith('prism');
+
+      runtime.object.setTarget.mockClear();
+      props.prismEnabled = false;
+      await tick();
+
+      expect(runtime.object.setTarget).toHaveBeenCalledWith('icon');
+      expect(runtime.object.destroy).not.toHaveBeenCalled();
+
+      runtime.emit({ journeyProgress: null, owner: 'svg', requestedTarget: 'icon', settledTarget: 'icon' });
+      await tick();
+
+      expect(runtime.object.destroy).toHaveBeenCalledOnce();
+      expect(target.querySelector('[data-prism-indicator-static-icon]')).not.toBeNull();
+      stepAnimationFrame();
+      await tick();
+      expect(runtime.object.setTarget).not.toHaveBeenCalledWith('prism');
+    } finally {
+      await unmount(component);
+    }
+  });
+
   test('reveals the welcome message only after the icon-to-prism morph starts and keeps it outside the moving actor', async () => {
     const random = vi.spyOn(Math, 'random').mockReturnValue(0);
     const target = document.createElement('div');
@@ -318,7 +486,8 @@ describe('Prism panel indicator', () => {
       await tick();
       setSourceRect(target);
       expect(runtime.object.whenReady).not.toHaveBeenCalled();
-      expect(runtime.object.setTarget).toHaveBeenCalledWith('icon');
+      expect(runtime.mountObject).not.toHaveBeenCalled();
+      expect(target.querySelector('[data-prism-indicator-static-icon]')).not.toBeNull();
 
       await vi.advanceTimersByTimeAsync(700);
       runtime.emit({ readiness: 'ready' });
@@ -337,6 +506,41 @@ describe('Prism panel indicator', () => {
       props.phase = 'failed';
       await tick();
       expect(target.querySelector<HTMLElement>('[data-prism-indicator-actor]')?.style.visibility).not.toBe('hidden');
+      expect(runtime.object.setTarget).not.toHaveBeenCalledWith('prism');
+    } finally {
+      await unmount(component);
+    }
+  });
+
+  test('hands submission directly to the row spinner when the 3D object preference is disabled', async () => {
+    const target = document.createElement('div');
+    const owners: string[] = [];
+    const props = reactiveProps({
+      destination: destination() as HTMLElement | undefined,
+      onSpinnerOwnerChange: (owner: string) => {
+        owners.push(owner);
+      },
+      phase: 'welcome' as 'failed' | 'submitting' | 'welcome',
+      prismEnabled: false,
+    });
+    const component = mount(PrismPanelIndicator, { target, props });
+    try {
+      await tick();
+      setSourceRect(target);
+      runtime.emit({ readiness: 'ready' });
+      await tick();
+
+      props.phase = 'submitting';
+      await tick();
+
+      expect(owners.at(-1)).toBe('row');
+      expect(target.querySelector<HTMLElement>('[data-prism-indicator-actor]')?.style.visibility).toBe('hidden');
+      expect(runtime.object.setTarget).not.toHaveBeenCalledWith('spinner', expect.anything());
+
+      runtime.object.setTarget.mockClear();
+      props.phase = 'failed';
+      await tick();
+
       expect(runtime.object.setTarget).not.toHaveBeenCalledWith('prism');
     } finally {
       await unmount(component);

--- a/packages/ui/src/context/app.svelte.ts
+++ b/packages/ui/src/context/app.svelte.ts
@@ -10,6 +10,7 @@ export type AppPreference = {
 
   prismPanelOpen: boolean;
   prismPanelWidth: number;
+  prismWelcomeObjectEnabled: boolean;
 
   defaultPrimaryToolbar: 'insert' | 'format';
 
@@ -144,6 +145,7 @@ export const setupAppContext = (userId: string) => {
 
       prismPanelOpen: false,
       prismPanelWidth: 420,
+      prismWelcomeObjectEnabled: true,
 
       defaultPrimaryToolbar: 'format',
 


### PR DESCRIPTION
## 변경 사항

- 새 PRISM 대화에서 중앙 3D 프리즘을 끄고 다시 켤 수 있는 토글을 추가했습니다.
- 선택한 표시 설정을 사용자별 로컬 preference로 저장합니다.
- reduced motion 환경이나 WebGPU 프리즘을 표시할 수 없는 환경에서는 토글을 노출하지 않습니다.
- 프리즘을 끄면 모핑을 마친 뒤 renderer와 canvas를 정리하며, 나머지 새 대화 UI는 그대로 유지합니다.
- Lucide 스타일의 `prism-off` 아이콘을 추가했습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>